### PR TITLE
Rename the namespaces. Also remove a clang-format 7 only option, and …

### DIFF
--- a/components/scream/.clang-format
+++ b/components/scream/.clang-format
@@ -9,7 +9,6 @@ ColumnLimit:       80
 Language:                    Cpp
 PointerAlignment:            Right
 DerivePointerAlignment:      false
-IndentPPDirectives:          true
 AlignConsecutiveAssignments: true
 AlignOperands:               true
 AlignTrailingComments:       true

--- a/components/scream/coupler/coupler.cpp
+++ b/components/scream/coupler/coupler.cpp
@@ -3,10 +3,7 @@
 namespace Scream {
 namespace Coupler {
 
-int coupler_stub()
-{
-  return 42;
-}
+int coupler_stub() { return 42; }
 
-} // namespace Coupler
-} // namespace Scream
+}  // namespace Coupler
+}  // namespace Scream

--- a/components/scream/coupler/coupler.hpp
+++ b/components/scream/coupler/coupler.hpp
@@ -6,7 +6,7 @@ namespace Coupler {
 
 int coupler_stub();
 
-} // namespace Coupler
-} // namespace Scream
+}  // namespace Coupler
+}  // namespace Scream
 
 #endif

--- a/components/scream/p3/p3.cpp
+++ b/components/scream/p3/p3.cpp
@@ -3,10 +3,7 @@
 namespace Scream {
 namespace P3 {
 
-int p3_stub()
-{
-  return 42;
-}
+int p3_stub() { return 42; }
 
-} // namespace P3
-} // namespace Scream
+}  // namespace P3
+}  // namespace Scream

--- a/components/scream/p3/p3.hpp
+++ b/components/scream/p3/p3.hpp
@@ -6,7 +6,7 @@ namespace P3 {
 
 int p3_stub();
 
-} // namespace P3
-} // namespace Scream
+}  // namespace P3
+}  // namespace Scream
 
 #endif

--- a/components/scream/rrtmgp/rrtmgp.cpp
+++ b/components/scream/rrtmgp/rrtmgp.cpp
@@ -1,12 +1,9 @@
 #include "rrtmgp.hpp"
 
 namespace Scream {
-namespace RRTMGP {
+namespace Rrtmgp {
 
-int rrtmgp_stub()
-{
-  return 42;
-}
+int rrtmgp_stub() { return 42; }
 
-} // namespace RRTMGP
-} // namespace Scream
+}  // namespace Rrtmgp
+}  // namespace Scream

--- a/components/scream/rrtmgp/rrtmgp.hpp
+++ b/components/scream/rrtmgp/rrtmgp.hpp
@@ -2,11 +2,11 @@
 #define SCREAM_RRTMGP_HPP
 
 namespace Scream {
-namespace RRTMGP {
+namespace Rrtmgp {
 
 int rrtmgp_stub();
 
-} // namespace RRTMGP
-} // namespace Scream
+}  // namespace Rrtmgp
+}  // namespace Scream
 
 #endif

--- a/components/scream/rrtmgp/tests/rrtmgp_tests.cpp
+++ b/components/scream/rrtmgp/tests/rrtmgp_tests.cpp
@@ -6,7 +6,7 @@
 namespace {
 
 TEST_CASE("Rrtmgp", "stub") {
-  int val = Scream::RRTMGP::rrtmgp_stub();
+  int val = Scream::Rrtmgp::rrtmgp_stub();
   REQUIRE(val == 42);
 }
 

--- a/components/scream/shoc/shoc.cpp
+++ b/components/scream/shoc/shoc.cpp
@@ -1,12 +1,9 @@
 #include "shoc.hpp"
 
 namespace Scream {
-namespace SHOC {
+namespace Shoc {
 
-int shoc_stub()
-{
-  return 42;
-}
+int shoc_stub() { return 42; }
 
-} // namespace SHOC
-} // namespace Scream
+}  // namespace Shoc
+}  // namespace Scream

--- a/components/scream/shoc/shoc.hpp
+++ b/components/scream/shoc/shoc.hpp
@@ -2,11 +2,11 @@
 #define SCREAM_SHOC_HPP
 
 namespace Scream {
-namespace SHOC {
+namespace Shoc {
 
 int shoc_stub();
 
-} // namespace SHOC
-} // namespace Scream
+}  // namespace Shoc
+}  // namespace Scream
 
 #endif

--- a/components/scream/shoc/tests/shoc_tests.cpp
+++ b/components/scream/shoc/tests/shoc_tests.cpp
@@ -6,7 +6,7 @@
 namespace {
 
 TEST_CASE("Shoc", "stub") {
-  int val = Scream::SHOC::shoc_stub();
+  int val = Scream::Shoc::shoc_stub();
   REQUIRE(val == 42);
 }
 


### PR DESCRIPTION
…run with clang-format 5.0.2