### PR TITLE
Travis Continuous Integration with Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,13 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-6
+    - clang-3.9
     - lcov
 
-git:
-  submodules: false
+compiler:
+- g++-6
+# Note that when using clang for C++, gfortran will still be used for compilation
+- clang++
 
 branches:
   only:
@@ -23,6 +26,9 @@ branches:
 cache:
   directories:
   - kokkos
+
+git:
+  submodules: false
 
 before_script:
 - if [[ ! -d ${PWD}/kokkos/.git ]]; then rm -rf ${PWD}/kokkos; git clone http://github.com/kokkos/kokkos; fi
@@ -36,7 +42,11 @@ before_script:
 - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ln -s $(which g++-6) g++; export PATH="${PWD}:${PATH}"; fi
 
 script:
-- cmake -D CMAKE_BUILD_TYPE=Debug -D CMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage" -D KOKKOS_DIR=${PWD}/kokkos/install components/scream
+# In case we build the C++ with clang, we can't use address sanitizer in the fortran due to different libraries
+- fflags="-Wall"
+- if [[ "${CXX}" == "g++" ]]; then fflags="${fflags} -fsanitize=address"; fi
+# Note that these flags are gcc and clang specific
+- cmake -D CMAKE_CXX_COMPILER=${CXX} -D CMAKE_Fortran_COMPILER="gfortran" -D CMAKE_BUILD_TYPE=Debug -D CMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage -fsanitize=address -Wall" -D CMAKE_Fortran_FLAGS=${fflags} -D KOKKOS_DIR=${PWD}/kokkos/install components/scream
 - make -j 2
 - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - g++-6
+    - g++-7
     - clang-3.9
     - lcov
 
@@ -39,7 +39,7 @@ before_script:
 - cmake -D CMAKE_INSTALL_PREFIX=${PWD}/install -D CMAKE_BUILD_TYPE=Debug -D KOKKOS_ENABLE_DEBUG=ON -D KOKKOS_ENABLE_AGGRESSIVE_VECTORIZATION=OFF -D KOKKOS_ENABLE_OPENMP=OFF -D KOKKOS_ENABLE_PROFILING=OFF -D KOKKOS_ENABLE_SERIAL=ON -D KOKKOS_ENABLE_DEPRECATED_CODE=OFF ./
 - make -j 2 install
 - cd ..
-- if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ln -s $(which g++-6) g++; export PATH="${PWD}:${PATH}"; fi
+- if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ln -s $(which g++-7) g++; export PATH="${PWD}:${PATH}"; fi
 
 script:
 # In case we build the C++ with clang, we can't use address sanitizer in the fortran due to different libraries

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CMAKE_BUILD_TYPE RELEASE CACHE STRING "Select build type.")
 
 set(CATCH_INCL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extern/catch2/include)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 enable_testing()
 
 add_subdirectory(coupler)

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -5,9 +5,11 @@ include(CTest)
 
 set(CMAKE_BUILD_TYPE RELEASE CACHE STRING "Select build type.")
 
-set(CATCH_INCL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extern/catch2/include)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+include(CompilerFlags)
+
+set(CATCH_INCL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extern/catch2/include)
 
 enable_testing()
 

--- a/components/scream/cmake/CompilerFlags.cmake
+++ b/components/scream/cmake/CompilerFlags.cmake
@@ -1,0 +1,8 @@
+
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-std=c++11" CXX11_SUPPORTED)
+if(${CXX11_SUPPORTED})
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+else()
+  message(FATAL_ERROR, "The C++ compiler does not support C++11")
+endif()


### PR DESCRIPTION
Enables continuous integration testing with clang, and with address sanitizer.