### PR TITLE
Clean up README.md file

### DIFF
--- a/components/scream/README.md
+++ b/components/scream/README.md
@@ -11,7 +11,7 @@ mkdir -p ${RUN_ROOT_DIR}/test/          #where scream is installed
                                         #and tests are run
 ```
 
-## Dependencies
+## Create dependencies
 Get Kokkos:
 ```
 cd ${KOKKOS_SRC_LOC}
@@ -36,7 +36,7 @@ make -j8 install
 ```
 For performance testing, other options should be used depending on architecture.
 
-## SCREAM
+## Build SCREAM
 Configure and build it:
 ```
 cd ${RUN_ROOT_DIR}/test
@@ -49,38 +49,39 @@ cmake \
 make -j8
 ```
 
-## Testing
-From a trusted SHA1, generate a baseline file:
+## Run tests
+After building SCREAM from a trusted SHA1 (such as master HEAD), generate
+a baseline file:
 ```
 cd ${RUN_ROOT_DIR}/test
 make baseline
 ```
-The generated baseline file is in `${RUN_ROOT_DIR}/test/p3/tests`.
+It is not necessary to know where the baseline file is, but if it is of
+interest, it is in the CMake-configurable `${SCREAM_TEST_DATA_DIR}`, which
+defaults to `data/` in the build directory.
 
-From any SHA1, run tests:
+Make your desired code modifications, then rebuild SCREAM from this new
+code. At this point you can run all tests with:
 ```
 cd ${RUN_ROOT_DIR}/test
 ctest -VV
 ```
-The test `ctest -R p3_regression` uses the baseline file to compare any new or
-altered implementations with the Fortran reference implementation's output in
-the baseline file.
+To just run the p3_regression test, for example, execute:
+```
+cd ${RUN_ROOT_DIR}/test
+ctest -R p3_regression
+```
 
-The intended use of the baseline capability is as follows:
+## p3_regression test details
 
-1. Run `make baseline` from a trusted commit, such as master HEAD.
-
-2. Develop code. If you're creating a new P3 implementation, add it to the
-function `Baseline::run_and_cmp` in
+p3_regression uses the baseline file to compare any new or altered
+implementations with the Fortran reference implementation's output in
+the baseline file. If you've created a new implementation (e.g. a
+Kokkos version of P3 or a version testing out a new performance paradigm),
+add the new implementation to the function `Baseline::run_and_cmp` in
 `${SCREAM_SRC_LOC}/scream/components/scream/p3/tests/p3_run_and_cmp.cpp`.
 
-3. The test `ctest -R p3_regression` will compare output against the baseline
-file.
-
-4. If the reference Fortran impl is changed such that output changes, carefully
+If the reference Fortran impl is changed such that output changes, carefully
 decide whether that is desired. If it is, then in your commit, tell everyone
 that a new baseline is needed.
 
-It is not important to know where the baseline file is, but if it is of
-interest, it is in the CMake-configurable `${SCREAM_TEST_DATA_DIR}`, which
-defaults to `data/` in the build directory.


### PR DESCRIPTION
Cleaned up the p3_regression test explanation in scream/components/scream/README.md. In particular, made Testing subsection names longer to describe themselves better and merged redundant list of steps at end of readme into the description of these steps above. 

Location of baseline files was described as being in 2 different places. I deleted mention of the location which I think is wrong.
