### PR TITLE
p3_run_and_cmp wasn't returning non-0 when it should have been. Fix.

### DIFF
--- a/components/scream/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/p3/tests/p3_run_and_cmp.cpp
@@ -91,7 +91,7 @@ struct Baseline {
         p3_main(*d);
         ne = compare("ref", tol, d_ref, d);
         if (ne) std::cout << "Ref impl failed.\n";
-        nerr += nerr;
+        nerr += ne;
       }
     }
     return nerr;


### PR DESCRIPTION
Thanks for the catch, @PeterCaldwell 