### PR TITLE
Strip further unused options from micro_p3.F90

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -446,8 +446,8 @@ contains
 
   SUBROUTINE p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
        pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
-       diag_effi,diag_vmi,diag_di,diag_rhoi,n_diag_2d,diag_2d,n_diag_3d,       &
-       diag_3d,log_predictNc,typeDiags_ON,prt_drzl,prt_rain,prt_crys,    &
+       diag_effi,diag_vmi,diag_di,diag_rhoi,       &
+       log_predictNc,typeDiags_ON,prt_drzl,prt_rain,prt_crys,    &
        prt_snow,prt_grpl,prt_pell,prt_hail,prt_sndp)
 
     !----------------------------------------------------------------------------------------!
@@ -496,14 +496,9 @@ contains
     real, intent(out),   dimension(its:ite,kts:kte)      :: diag_di    ! mean diameter of ice             m
     real, intent(out),   dimension(its:ite,kts:kte)      :: diag_rhoi  ! bulk density of ice              kg m-1
 
-    real, intent(out),   dimension(its:ite,n_diag_2d)         :: diag_2d  ! user-defined 2D diagnostic fields
-    real, intent(out),   dimension(its:ite,kts:kte,n_diag_3d) :: diag_3d  ! user-defined 3D diagnostic fields
-
     integer, intent(in)                                  :: its,ite    ! array bounds (horizontal)
     integer, intent(in)                                  :: kts,kte    ! array bounds (vertical)
     integer, intent(in)                                  :: it         ! time step counter NOTE: starts at 1 for first time step
-    integer, intent(in)                                  :: n_diag_2d  ! number of 2D diagnostic fields
-    integer, intent(in)                                  :: n_diag_3d  ! number of 3D diagnostic fields
 
     logical, intent(in)                                  :: log_predictNc ! .T. (.F.) for prediction (specification) of Nc
     logical, intent(in)                                  :: typeDiags_ON  !for diagnostic hydrometeor/precip rate types
@@ -660,25 +655,6 @@ contains
     !  End of variables/parameters declarations
     !-----------------------------------------------------------------------------------!
 
-    !-----------------------------------------------------------------------------------!
-    ! Note, the array 'diag_3d(ni,nk,n_diag_3d)' provides a placeholder to output 3D diagnostic fields.
-    ! The entire array array is inialized to zero (below).  Code can be added to store desired fields
-    ! by simply adding the appropriate assignment statements.  For example, if one wishs to output the
-    ! rain condensation and evaporation rates, simply add assignments in the appropriate locations.
-    !  e.g.:
-    !
-    !   diag_3d(i,k,1) = qrcon
-    !   diag_3d(i,k,2) = qrevp
-    !
-    ! The fields will automatically be passed to the driving model.  In GEM, these arrays can be
-    ! output by adding 'SS01' and 'SS02' to the model output list.
-    !
-    ! Similarly, 'diag_2d(ni,n_diag_2d) is a placeholder to output 2D diagnostic fields.
-    !  e.g.:
-    !
-    !   diag_2d(i,1) = maxval(qr(i,:))  !column-maximum qr
-    !-----------------------------------------------------------------------------------!
-
     ! direction of vertical leveling:
     !PMC got rid of 'model' option so we could just replace ktop with kts everywhere...
     ktop = kts        !k of top level
@@ -714,8 +690,6 @@ contains
     diag_vmi  = 0.
     diag_di   = 0.
     diag_rhoi = 0.
-    diag_2d   = 0.
-    diag_3d   = 0.
     rhorime_c = 400.
 
     tmparr1 = (pres*1.e-5)**(rd*inv_cp)

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -446,9 +446,7 @@ contains
 
   SUBROUTINE p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
        pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
-       diag_effi,diag_vmi,diag_di,diag_rhoi,       &
-       log_predictNc,typeDiags_ON,prt_drzl,prt_rain,prt_crys,    &
-       prt_snow,prt_grpl,prt_pell,prt_hail,prt_sndp)
+       diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc)
 
     !----------------------------------------------------------------------------------------!
     !                                                                                        !
@@ -501,16 +499,6 @@ contains
     integer, intent(in)                                  :: it         ! time step counter NOTE: starts at 1 for first time step
 
     logical, intent(in)                                  :: log_predictNc ! .T. (.F.) for prediction (specification) of Nc
-    logical, intent(in)                                  :: typeDiags_ON  !for diagnostic hydrometeor/precip rate types
-
-    real, intent(out), dimension(its:ite), optional      :: prt_drzl      ! precip rate, drizzle          m s-1
-    real, intent(out), dimension(its:ite), optional      :: prt_rain      ! precip rate, rain             m s-1
-    real, intent(out), dimension(its:ite), optional      :: prt_crys      ! precip rate, ice cystals      m s-1
-    real, intent(out), dimension(its:ite), optional      :: prt_snow      ! precip rate, snow             m s-1
-    real, intent(out), dimension(its:ite), optional      :: prt_grpl      ! precip rate, graupel           m s-1
-    real, intent(out), dimension(its:ite), optional      :: prt_pell      ! precip rate, ice pellets       m s-1
-    real, intent(out), dimension(its:ite), optional      :: prt_hail      ! precip rate, hail              m s-1
-    real, intent(out), dimension(its:ite), optional      :: prt_sndp      ! precip rate, unmelted snow     m s-1
 
     !----- Local variables and parameters:  -------------------------------------------------!
 
@@ -639,13 +627,6 @@ contains
     real    :: f1pr16   ! mass-weighted mean particle density
 !    real    :: f1pr17   ! ice-ice category collection change in number (not used)
 !    real    :: f1pr18   ! ice-ice category collection change in mass (not used)
-
-    ! quantities related to diagnostic hydrometeor/precipitation types
-    real,    parameter                       :: freq3DtypeDiag     = 60.     !frequency (min) for full-column diagnostics
-    real,    parameter                       :: thres_raindrop     = 100.e-6 !size threshold for drizzle vs. rain
-    real,    dimension(its:ite,kts:kte)      :: Q_drizzle,Q_rain
-    real,    dimension(its:ite,kts:kte) :: Q_crystals,Q_ursnow,Q_lrsnow,Q_grpl,Q_pellets,Q_hail
-    integer                                  :: ktop_typeDiag
 
     !--These will be added as namelist parameters in the future
     logical, parameter :: debug_ON     = .false.  !.true. to switch on debugging checks/traps throughout code
@@ -2368,152 +2349,7 @@ contains
     enddo i_loop_main
 
     !PMC deleted "if WRF" stuff
-
-    !...........................................................................................
-    ! Compute diagnostic hydrometeor types for output as 3D fields and
-    ! for partitioning into corresponding surface precipitation rates.
-
-    compute_type_diags: if (typeDiags_ON) then
-
-       if (.not.(present(prt_drzl).and.present(prt_rain).and.present(prt_crys).and. &
-            present(prt_snow).and.present(prt_grpl).and.present(prt_pell).and. &
-            present(prt_hail).and.present(prt_sndp))) then
-          print*,'***  ABORT IN P3_MAIN ***'
-          print*,'*  typeDiags_ON = .true. but prt_drzl, etc. are not passed into P3_MAIN'
-          print*,'*************************'
-          stop
-       endif
-       prt_drzl = 0.
-       prt_rain = 0.
-       prt_crys = 0.
-       prt_snow = 0.
-       prt_grpl = 0.
-       prt_pell = 0.
-       prt_hail = 0.
-       prt_sndp = 0.
-
-       if (freq3DtypeDiag>0. .and. mod(it*dt,freq3DtypeDiag*60.)==0.) then
-          !diagnose hydrometeor types for full columns
-          ktop_typeDiag = ktop
-       else
-          !diagnose hydrometeor types at bottom level only (for specific precip rates)
-          ktop_typeDiag = kbot
-       endif
-
-       i_loop_typediag: do i = its,ite
-
-          !-- rain vs. drizzle:
-          k_loop_typdiag_1: do k = kbot,ktop_typeDiag,kdir
-
-             Q_drizzle(i,k) = 0.
-             Q_rain(i,k)    = 0.
-             !note:  theese can be broken down further (outside of microphysics) into
-             !       liquid rain (drizzle) vs. freezing rain (drizzle) based on sfc temp.
-             if (qr(i,k)>qsmall .and. nr(i,k)>nsmall) then
-                tmp1 = (qr(i,k)/(pi*rhow*nr(i,k)))**thrd   !mean-mass diameter
-                if (tmp1 < thres_raindrop) then
-                   Q_drizzle(i,k) = qr(i,k)
-                else
-                   Q_rain(i,k)    = qr(i,k)
-                endif
-             endif
-
-          enddo k_loop_typdiag_1
-
-          if (Q_drizzle(i,kbot) > 0.) then
-             prt_drzl(i) = prt_liq(i)
-          elseif (Q_rain(i,kbot) > 0.) then
-             prt_rain(i) = prt_liq(i)
-          endif
-          !--- optimized version above above IF block (does not work on all FORTRAN compilers)
-          !        tmp1 = -(Q_drizzle(i,kbot) > 0.)  !note: tmp1=1.0 if Q_drizzle>0., else tmp1=0.0
-          !        tmp2 = -(Q_rain(i,kbot)    > 0.)
-          !        prt_drzl(i) = prt_liq(i)*tmp1  !precip rate of drizzle
-          !        prt_rain(i) = prt_liq(i)*tmp2  !precip rate of rain
-          !===
-
-          !-- ice-phase:
-
-          k_loop_typdiag_2: do k = kbot,ktop_typeDiag,kdir
-
-             Q_crystals(i,k) = 0.
-             Q_ursnow(i,k)   = 0.
-             Q_lrsnow(i,k)   = 0.
-             Q_grpl(i,k)     = 0.
-             Q_pellets(i,k)  = 0.
-             Q_hail(i,k)     = 0.
-
-             if (qitot(i,k)>qsmall) then
-                tmp1 = qirim(i,k)/qitot(i,k)   !rime mass fraction
-                if (tmp1<0.1) then
-                   !zero or trace rime:
-                   if (diag_di(i,k)<150.e-6) then
-                      Q_crystals(i,k) = qitot(i,k)
-                   else
-                      Q_ursnow(i,k) = qitot(i,k)
-                   endif
-                elseif (tmp1>=0.1 .and. tmp1<0.25) then
-                   !lightly rimed:
-                   Q_lrsnow(i,k) = qitot(i,k)
-                elseif (tmp1>=0.25 .and. tmp1<=1.) then
-                   !moderate-to-heavily rimed:
-                   if (diag_rhoi(i,k)<700.) then
-                      Q_grpl(i,k) = qitot(i,k)
-                   else
-                      if (diag_di(i,k)<1.e-3) then
-                         Q_pellets(i,k) = qitot(i,k)
-                      else
-                         Q_hail(i,k) = qitot(i,k)
-                      endif
-                   endif
-                else
-                   print*, 'STOP -- unrealistic rime fraction: ',tmp1
-                   stop
-                endif
-             endif !qitot>0
-
-          enddo k_loop_typdiag_2
-
-          !diagnostics for sfc precipitation rates: (liquid-equivalent volume flux, m s-1)
-          !  note: these are summed for all ice categories
-          if (Q_crystals(i,kbot) > 0.)    then
-             prt_crys(i) = prt_crys(i) + prt_sol(i)    !precip rate of small crystals
-          elseif (Q_ursnow(i,kbot) > 0.)  then
-             prt_snow(i) = prt_snow(i) + prt_sol(i)    !precip rate of unrimed + lightly rimed snow
-          elseif (Q_lrsnow(i,kbot) > 0.)  then
-             prt_snow(i) = prt_snow(i) + prt_sol(i)    !precip rate of unrimed + lightly rimed snow
-          elseif (Q_grpl(i,kbot) > 0.)    then
-             prt_grpl(i) = prt_grpl(i) + prt_sol(i)    !precip rate of graupel
-          elseif (Q_pellets(i,kbot) > 0.) then
-             prt_pell(i) = prt_pell(i) + prt_sol(i)    !precip rate of ice pellets
-          elseif (Q_hail(i,kbot) > 0.)    then
-             prt_hail(i) = prt_hail(i) + prt_sol(i)    !precip rate of hail
-          endif
-
-          !precip rate of unmelted total "snow":
-          !  For now, an instananeous solid-to-liquid ratio (tmp1) is assumed and is multiplied
-          !  by the total liquid-equivalent precip rates of snow (small crystals + lightly-rime + ..)
-          !  Later, this can be computed explicitly as the volume flux of unmelted ice.
-          tmp1 = 1000./max(1., 5.*diag_rhoi(i,kbot))
-          prt_sndp(i) = prt_sndp(i) + tmp1*(prt_crys(i) + prt_snow(i) + prt_grpl(i))
-
-       enddo i_loop_typediag
-
-       !- for output of 3D fields of diagnostic hydrometeor type (for iice = 1)
-       !     if (ktop_typeDiag == ktop) then
-       !        diag_3d(:,:,1) = Q_drizzle(:,:)
-       !        diag_3d(:,:,2) = Q_rain(:,:)
-       !        diag_3d(:,:,3) = Q_crystals(:,:)
-       !        diag_3d(:,:,4) = Q_ursnow(:,:)
-       !        diag_3d(:,:,5) = Q_lrsnow(:,:)
-       !        diag_3d(:,:,6) = Q_grpl(:,:)
-       !        diag_3d(:,:,7) = Q_pellets(:,:)
-       !        diag_3d(:,:,8) = Q_hail(:,:)
-       !     endif
-       !=
-
-    endif compute_type_diags
-
+    !PMC deleted typeDiags optional output stuff
 
     !=== (end of section for diagnostic hydrometeor/precip types)
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -447,7 +447,7 @@ contains
   SUBROUTINE p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
        pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
        diag_effi,diag_vmi,diag_di,diag_rhoi,n_diag_2d,diag_2d,n_diag_3d,       &
-       diag_3d,log_predictNc,typeDiags_ON,model,prt_drzl,prt_rain,prt_crys,    &
+       diag_3d,log_predictNc,typeDiags_ON,prt_drzl,prt_rain,prt_crys,    &
        prt_snow,prt_grpl,prt_pell,prt_hail,prt_sndp)
 
     !----------------------------------------------------------------------------------------!
@@ -507,7 +507,6 @@ contains
 
     logical, intent(in)                                  :: log_predictNc ! .T. (.F.) for prediction (specification) of Nc
     logical, intent(in)                                  :: typeDiags_ON  !for diagnostic hydrometeor/precip rate types
-    character(len=*), intent(in)                         :: model         !driving model
 
     real, intent(out), dimension(its:ite), optional      :: prt_drzl      ! precip rate, drizzle          m s-1
     real, intent(out), dimension(its:ite), optional      :: prt_rain      ! precip rate, rain             m s-1
@@ -681,15 +680,10 @@ contains
     !-----------------------------------------------------------------------------------!
 
     ! direction of vertical leveling:
-    if (trim(model)=='GEM' .or. trim(model)=='KIN1D') then
-       ktop = kts        !k of top level
-       kbot = kte        !k of bottom level
-       kdir = -1         !(k: 1=top, nk=bottom)
-    else
-       ktop = kte        !k of top level
-       kbot = kts        !k of bottom level
-       kdir = 1          !(k: 1=bottom, nk=top)
-    endif
+    !PMC got rid of 'model' option so we could just replace ktop with kts everywhere...
+    ktop = kts        !k of top level
+    kbot = kte        !k of bottom level
+    kdir = -1         !(k: 1=top, nk=bottom)
 
     !PMC deleted 'threshold size difference' calculation for multicategory here
 

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -79,7 +79,7 @@ contains
   subroutine p3_main_c(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
        pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
        diag_effi,diag_vmi,diag_di,diag_rhoi,n_diag_2d,diag_2d,n_diag_3d,       &
-       diag_3d,log_predictNc_in,typeDiags_ON_in,model_in,prt_drzl,prt_rain,prt_crys,    &
+       diag_3d,log_predictNc_in,typeDiags_ON_in,prt_drzl,prt_rain,prt_crys,    &
        prt_snow,prt_grpl,prt_pell,prt_hail,prt_sndp) bind(C)
     use micro_p3, only : p3_main
 
@@ -94,21 +94,13 @@ contains
     real(kind=c_real), intent(out), dimension(its:ite,kts:kte,n_diag_3d) :: diag_3d
     integer(kind=c_int), value, intent(in) :: its,ite, kts,kte, it, n_diag_2d, n_diag_3d
     logical(kind=c_bool), value, intent(in) :: log_predictNc_in, typeDiags_ON_in
-    type(c_ptr), intent(in) :: model_in
     real(kind=c_real), intent(out), dimension(its:ite), optional :: &
          prt_drzl, prt_rain, prt_crys, prt_snow, prt_grpl, prt_pell, prt_hail, prt_sndp
 
-    character(len=64), pointer :: model
     logical :: log_predictNc, typeDiags_ON
-    integer :: len
 
     log_predictNc = log_predictNc_in
     typeDiags_ON = typeDiags_ON_in
-
-!PMC deleted model from function call... should delete everywhere now.
-    
-    call c_f_pointer(model_in, model)
-    len = index(model, C_NULL_CHAR) - 1
 
     call p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
          pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -78,8 +78,8 @@ contains
 
   subroutine p3_main_c(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
        pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
-       diag_effi,diag_vmi,diag_di,diag_rhoi,n_diag_2d,diag_2d,n_diag_3d,       &
-       diag_3d,log_predictNc_in,typeDiags_ON_in,prt_drzl,prt_rain,prt_crys,    &
+       diag_effi,diag_vmi,diag_di,diag_rhoi,       &
+       log_predictNc_in,typeDiags_ON_in,prt_drzl,prt_rain,prt_crys,    &
        prt_snow,prt_grpl,prt_pell,prt_hail,prt_sndp) bind(C)
     use micro_p3, only : p3_main
 
@@ -90,9 +90,7 @@ contains
     real(kind=c_real), intent(out), dimension(its:ite) :: prt_liq, prt_sol
     real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_ze, diag_effc
     real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_effi, diag_vmi, diag_di, diag_rhoi
-    real(kind=c_real), intent(out), dimension(its:ite,n_diag_2d) :: diag_2d
-    real(kind=c_real), intent(out), dimension(its:ite,kts:kte,n_diag_3d) :: diag_3d
-    integer(kind=c_int), value, intent(in) :: its,ite, kts,kte, it, n_diag_2d, n_diag_3d
+    integer(kind=c_int), value, intent(in) :: its,ite, kts,kte, it
     logical(kind=c_bool), value, intent(in) :: log_predictNc_in, typeDiags_ON_in
     real(kind=c_real), intent(out), dimension(its:ite), optional :: &
          prt_drzl, prt_rain, prt_crys, prt_snow, prt_grpl, prt_pell, prt_hail, prt_sndp
@@ -104,8 +102,8 @@ contains
 
     call p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
          pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
-         diag_effi,diag_vmi,diag_di,diag_rhoi,n_diag_2d,diag_2d,n_diag_3d,       &
-         diag_3d,log_predictNc,typeDiags_ON,prt_drzl,prt_rain,prt_crys,    &
+         diag_effi,diag_vmi,diag_di,diag_rhoi,       &
+         log_predictNc,typeDiags_ON,prt_drzl,prt_rain,prt_crys,    &
          prt_snow,prt_grpl,prt_pell,prt_hail,prt_sndp)
   end subroutine p3_main_c
 end module micro_p3_iso_c

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -78,9 +78,7 @@ contains
 
   subroutine p3_main_c(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
        pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
-       diag_effi,diag_vmi,diag_di,diag_rhoi,       &
-       log_predictNc_in,typeDiags_ON_in,prt_drzl,prt_rain,prt_crys,    &
-       prt_snow,prt_grpl,prt_pell,prt_hail,prt_sndp) bind(C)
+       diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc_in) bind(C)
     use micro_p3, only : p3_main
 
     real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, ssat, qv, th, th_old, qv_old
@@ -91,19 +89,14 @@ contains
     real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_ze, diag_effc
     real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_effi, diag_vmi, diag_di, diag_rhoi
     integer(kind=c_int), value, intent(in) :: its,ite, kts,kte, it
-    logical(kind=c_bool), value, intent(in) :: log_predictNc_in, typeDiags_ON_in
-    real(kind=c_real), intent(out), dimension(its:ite), optional :: &
-         prt_drzl, prt_rain, prt_crys, prt_snow, prt_grpl, prt_pell, prt_hail, prt_sndp
+    logical(kind=c_bool), value, intent(in) :: log_predictNc_in
 
-    logical :: log_predictNc, typeDiags_ON
+    logical :: log_predictNc
 
     log_predictNc = log_predictNc_in
-    typeDiags_ON = typeDiags_ON_in
 
     call p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
          pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
-         diag_effi,diag_vmi,diag_di,diag_rhoi,       &
-         log_predictNc,typeDiags_ON,prt_drzl,prt_rain,prt_crys,    &
-         prt_snow,prt_grpl,prt_pell,prt_hail,prt_sndp)
+         diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc)
   end subroutine p3_main_c
 end module micro_p3_iso_c

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -105,13 +105,15 @@ contains
     log_predictNc = log_predictNc_in
     typeDiags_ON = typeDiags_ON_in
 
+!PMC deleted model from function call... should delete everywhere now.
+    
     call c_f_pointer(model_in, model)
     len = index(model, C_NULL_CHAR) - 1
 
     call p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
          pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
          diag_effi,diag_vmi,diag_di,diag_rhoi,n_diag_2d,diag_2d,n_diag_3d,       &
-         diag_3d,log_predictNc,typeDiags_ON,model(1:len),prt_drzl,prt_rain,prt_crys,    &
+         diag_3d,log_predictNc,typeDiags_ON,prt_drzl,prt_rain,prt_crys,    &
          prt_snow,prt_grpl,prt_pell,prt_hail,prt_sndp)
   end subroutine p3_main_c
 end module micro_p3_iso_c

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -62,7 +62,6 @@ FortranDataIterator::FortranDataIterator (const FortranData::Ptr& d) {
 
 void FortranDataIterator::init (const FortranData::Ptr& dp) {
   d_ = dp;
-  fields_.reserve(23);
 #define fdipb(name)                                                     \
   fields_.push_back({#name,                                             \
         2,                                                              \

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -18,7 +18,7 @@ extern "C" {
                  Real* diag_effc, Real* diag_effi, Real* diag_vmi,
                  Real* diag_di, Real* diag_rhoi, Int n_diag_2d, Real* diag_2d,
                  Int n_diag_3d, Real* diag_3d, bool log_predictNc,
-                 bool typeDiags_ON, const char** model, Real* prt_drzl,
+                 bool typeDiags_ON, Real* prt_drzl,
                  Real* prt_rain, Real* prt_crys, Real* prt_snow, Real* prt_grpl,
                  Real* prt_pell, Real* prt_hail, Real* prt_sndp);
 }
@@ -108,7 +108,6 @@ void p3_init () {
 }
 
 void p3_main (const FortranData& d) {
-  static const char* model = "GEM";
   p3_main_c(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(), d.th_old.data(),
             d.th.data(), d.qv_old.data(), d.qv.data(), d.dt, d.qitot.data(),
             d.qirim.data(), d.nitot.data(), d.birim.data(), d.ssat.data(),
@@ -117,7 +116,7 @@ void p3_main (const FortranData& d) {
             d.diag_effc.data(), d.diag_effi.data(), d.diag_vmi.data(),
             d.diag_di.data(), d.diag_rhoi.data(), d.diag_2d.extent_int(1),
             d.diag_2d.data(), d.diag_3d.extent_int(2), d.diag_3d.data(),
-            d.log_predictnc, d.typediags_on, &model, d.prt_drzl.data(),
+            d.log_predictnc, d.typediags_on, d.prt_drzl.data(),
             d.prt_rain.data(), d.prt_crys.data(), d. prt_snow.data(),
             d.prt_grpl.data(), d.prt_pell.data(), d.prt_hail.data(),
             d.prt_sndp.data());

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -16,8 +16,8 @@ extern "C" {
                  Real* dzq, Int it, Real* prt_liq, Real* prt_sol, Int its,
                  Int ite, Int kts, Int kte, Real* diag_ze,
                  Real* diag_effc, Real* diag_effi, Real* diag_vmi,
-                 Real* diag_di, Real* diag_rhoi, Int n_diag_2d, Real* diag_2d,
-                 Int n_diag_3d, Real* diag_3d, bool log_predictNc,
+                 Real* diag_di, Real* diag_rhoi, 
+                 bool log_predictNc,
                  bool typeDiags_ON, Real* prt_drzl,
                  Real* prt_rain, Real* prt_crys, Real* prt_snow, Real* prt_grpl,
                  Real* prt_pell, Real* prt_hail, Real* prt_sndp);
@@ -29,7 +29,6 @@ namespace p3 {
 FortranData::FortranData (Int ncol_, Int nlev_)
   : ncol(ncol_), nlev(nlev_)
 {
-  const Int n_diag_2d = 1, n_diag_3d = 1;
 
   dt = -1; // model time step, s; set to invalid -1
   it = 1;  // seems essentially unused
@@ -62,12 +61,10 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   prt_sndp = Array1("precip rate, unmelted snow m/s", ncol);
   diag_ze = Array2("equivalent reflectivity, dBZ", ncol, nlev);
   diag_effc = Array2("effective radius, cloud, m", ncol, nlev);
-  diag_2d = Array2("user-defined 2D diagnostic fields", ncol, n_diag_2d);
   diag_effi = Array2("effective radius, ice, m", ncol, nlev);
   diag_vmi = Array2("mass-weighted fall speed of ice, m/s", ncol, nlev);
   diag_di = Array2("mean diameter of ice, m", ncol, nlev);
   diag_rhoi = Array2("bulk density of ice, kg/m", ncol, nlev);
-  diag_3d = Array3("user-defined 3D diagnostic fields", ncol, nlev, n_diag_3d);
 }
 
 FortranDataIterator::FortranDataIterator (const FortranData::Ptr& d) {
@@ -89,8 +86,8 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(qirim); fdipb(birim); fdipb(prt_liq); fdipb(prt_sol);
   fdipb(prt_drzl); fdipb(prt_rain); fdipb(prt_crys); fdipb(prt_snow);
   fdipb(prt_grpl); fdipb(prt_pell); fdipb(prt_hail); fdipb(prt_sndp);
-  fdipb(diag_ze); fdipb(diag_effc); fdipb(diag_2d); fdipb(diag_effi);
-  fdipb(diag_vmi); fdipb(diag_di); fdipb(diag_rhoi); fdipb(diag_3d);
+  fdipb(diag_ze); fdipb(diag_effc); fdipb(diag_effi);
+  fdipb(diag_vmi); fdipb(diag_di); fdipb(diag_rhoi);
 #undef fdipb
 }
 
@@ -114,8 +111,7 @@ void p3_main (const FortranData& d) {
             d.pres.data(), d.dzq.data(), d.it, d.prt_liq.data(),
             d.prt_sol.data(), 1, d.ncol, 1, d.nlev, d.diag_ze.data(),
             d.diag_effc.data(), d.diag_effi.data(), d.diag_vmi.data(),
-            d.diag_di.data(), d.diag_rhoi.data(), d.diag_2d.extent_int(1),
-            d.diag_2d.data(), d.diag_3d.extent_int(2), d.diag_3d.data(),
+            d.diag_di.data(), d.diag_rhoi.data(),
             d.log_predictnc, d.typediags_on, d.prt_drzl.data(),
             d.prt_rain.data(), d.prt_crys.data(), d. prt_snow.data(),
             d.prt_grpl.data(), d.prt_pell.data(), d.prt_hail.data(),

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -17,10 +17,7 @@ extern "C" {
                  Int ite, Int kts, Int kte, Real* diag_ze,
                  Real* diag_effc, Real* diag_effi, Real* diag_vmi,
                  Real* diag_di, Real* diag_rhoi, 
-                 bool log_predictNc,
-                 bool typeDiags_ON, Real* prt_drzl,
-                 Real* prt_rain, Real* prt_crys, Real* prt_snow, Real* prt_grpl,
-                 Real* prt_pell, Real* prt_hail, Real* prt_sndp);
+                 bool log_predictNc);
 }
 
 namespace scream {
@@ -51,14 +48,6 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   // Out
   prt_liq = Array1("precipitation rate, liquid  m/s", ncol);
   prt_sol = Array1("precipitation rate, solid   m/s", ncol);
-  prt_drzl = Array1("precip rate, drizzle       m/s", ncol);
-  prt_rain = Array1("precip rate, rain          m/s", ncol);
-  prt_crys = Array1("precip rate, ice cystals   m/s", ncol);
-  prt_snow = Array1("precip rate, snow          m/s", ncol);
-  prt_grpl = Array1("precip rate, graupel       m/s", ncol);
-  prt_pell = Array1("precip rate, ice pellets   m/s", ncol);
-  prt_hail = Array1("precip rate, hail          m/s", ncol);
-  prt_sndp = Array1("precip rate, unmelted snow m/s", ncol);
   diag_ze = Array2("equivalent reflectivity, dBZ", ncol, nlev);
   diag_effc = Array2("effective radius, cloud, m", ncol, nlev);
   diag_effi = Array2("effective radius, ice, m", ncol, nlev);
@@ -73,7 +62,7 @@ FortranDataIterator::FortranDataIterator (const FortranData::Ptr& d) {
 
 void FortranDataIterator::init (const FortranData::Ptr& dp) {
   d_ = dp;
-  fields_.reserve(33);
+  fields_.reserve(23);
 #define fdipb(name)                                                     \
   fields_.push_back({#name,                                             \
         2,                                                              \
@@ -84,8 +73,6 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(dzq); fdipb(qc); fdipb(nc); fdipb(qr); fdipb(nr);
   fdipb(ssat); fdipb(qitot); fdipb(nitot);
   fdipb(qirim); fdipb(birim); fdipb(prt_liq); fdipb(prt_sol);
-  fdipb(prt_drzl); fdipb(prt_rain); fdipb(prt_crys); fdipb(prt_snow);
-  fdipb(prt_grpl); fdipb(prt_pell); fdipb(prt_hail); fdipb(prt_sndp);
   fdipb(diag_ze); fdipb(diag_effc); fdipb(diag_effi);
   fdipb(diag_vmi); fdipb(diag_di); fdipb(diag_rhoi);
 #undef fdipb
@@ -112,10 +99,7 @@ void p3_main (const FortranData& d) {
             d.prt_sol.data(), 1, d.ncol, 1, d.nlev, d.diag_ze.data(),
             d.diag_effc.data(), d.diag_effi.data(), d.diag_vmi.data(),
             d.diag_di.data(), d.diag_rhoi.data(),
-            d.log_predictnc, d.typediags_on, d.prt_drzl.data(),
-            d.prt_rain.data(), d.prt_crys.data(), d. prt_snow.data(),
-            d.prt_grpl.data(), d.prt_pell.data(), d.prt_hail.data(),
-            d.prt_sndp.data());
+            d.log_predictnc);
 }
 
 Int check_against_python (const FortranData& d) {

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -21,7 +21,7 @@ struct FortranData {
   using Array1 = Kokkos::View<Scalar*, Layout, ExeSpace>;
   using Array2 = Kokkos::View<Scalar**, Layout, ExeSpace>;
 
-  static constexpr bool log_predictnc = true, typediags_on = true;
+  static constexpr bool log_predictnc = true;
 
   const Int ncol, nlev;
 
@@ -30,7 +30,7 @@ struct FortranData {
   Int it;
   Array2 qv, th, qv_old, th_old, pres, dzq, qc, nc, qr, nr, ssat, qitot, nitot, qirim, birim;
   // Out
-  Array1 prt_liq, prt_sol, prt_drzl, prt_rain, prt_crys, prt_snow, prt_grpl, prt_pell, prt_hail, prt_sndp;
+  Array1 prt_liq, prt_sol;
   Array2 diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, diag_rhoi;
   
   FortranData(Int ncol, Int nlev);

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -20,7 +20,6 @@ struct FortranData {
 
   using Array1 = Kokkos::View<Scalar*, Layout, ExeSpace>;
   using Array2 = Kokkos::View<Scalar**, Layout, ExeSpace>;
-  using Array3 = Kokkos::View<Scalar***, Layout, ExeSpace>;
 
   static constexpr bool log_predictnc = true, typediags_on = true;
 
@@ -32,8 +31,7 @@ struct FortranData {
   Array2 qv, th, qv_old, th_old, pres, dzq, qc, nc, qr, nr, ssat, qitot, nitot, qirim, birim;
   // Out
   Array1 prt_liq, prt_sol, prt_drzl, prt_rain, prt_crys, prt_snow, prt_grpl, prt_pell, prt_hail, prt_sndp;
-  Array2 diag_ze, diag_effc, diag_2d, diag_effi, diag_vmi, diag_di, diag_rhoi;
-  Array3 diag_3d;
+  Array2 diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, diag_rhoi;
   
   FortranData(Int ncol, Int nlev);
 };

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 33);
+  REQUIRE(fdi.nfield() == 31);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 31);
+  REQUIRE(fdi.nfield() == 23);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);


### PR DESCRIPTION
Hardcoded vertical index=1 is top-of-atmosphere in order to get rid of 'model' input variable. Removed optional outputs for precipitation species and user-defined stuff: we can re-add them in a more E3SM-centric way later if we need to.