### PR TITLE
Adding a macro to create unit tests.

### DIFF
--- a/components/scream/cmake/ScreamMacros.cmake
+++ b/components/scream/cmake/ScreamMacros.cmake
@@ -1,0 +1,31 @@
+# This macro takes the following arguments:
+#    - target_name: the name of the executable
+#    - target_srcs: a list of src files for the executable
+#      Note: no need to include catch_main; this macro will add it
+#    - scream_libs: a list of scream libraries needed by the executable
+#    - config_defines: a list of additional defines for the compiler
+#    - num_mpi_ranks: the number of mpi ranks for the test
+#    - config_defines: specific define directives to be passed to the compiler
+
+MACRO(CreateUnitTest target_name target_srcs scream_libs num_mpi_ranks config_defines)
+  # Set link directories (must be done BEFORE add_executable is called)
+  link_directories(${SCREAM_TPL_LIBRARY_DIRS})
+
+  # Create the executable
+  add_executable (${target_name} ${${target_name}_SRCS} ${SCREAM_SRC_DIR}/share/util/scream_catch_main.cpp)
+
+  # Set all target properties
+  target_link_libraries(${target_name} ${scream_libs} ${SCREAM_TPL_LIBRARIES})
+  target_include_directories(${target_name} PUBLIC ${SCREAM_INCLUDE_DIRS} ${CATCH_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+  set_target_properties(${target_name} PROPERTIES LINK_FLAGS "${SCREAM_LINK_FLAGS}")
+  set_target_properties(${target_name} PROPERTIES Fortran_MODULE_DIRECTORY ${SCREAM_F90_MODULES})
+  set_target_properties(${target_name} PROPERTIES COMPILE_DEFINITIONS "${config_defines}")
+
+  # Create the test
+  IF (${num_mpi_ranks} GREATER 1)
+    ADD_TEST(${target_name}_ut mpiexec -np ${num_mpi_ranks} ${SCREAM_MPI_EXTRA_ARGS} ${target_name})
+  ELSE()
+    ADD_TEST(${target_name}_ut ${target_name})
+  ENDIF()
+
+ENDMACRO(CreateUnitTest)

--- a/components/scream/cmake/ScreamUtils.cmake
+++ b/components/scream/cmake/ScreamUtils.cmake
@@ -1,4 +1,4 @@
-# This macro takes the following arguments:
+# This function takes the following arguments:
 #    - target_name: the name of the executable
 #    - target_srcs: a list of src files for the executable
 #      Note: no need to include catch_main; this macro will add it
@@ -7,7 +7,7 @@
 #    - num_mpi_ranks: the number of mpi ranks for the test
 #    - config_defines: specific define directives to be passed to the compiler
 
-MACRO(CreateUnitTest target_name target_srcs scream_libs num_mpi_ranks config_defines)
+FUNCTION(CreateUnitTest target_name target_srcs scream_libs num_mpi_ranks config_defines)
   # Set link directories (must be done BEFORE add_executable is called)
   link_directories(${SCREAM_TPL_LIBRARY_DIRS})
 
@@ -28,4 +28,4 @@ MACRO(CreateUnitTest target_name target_srcs scream_libs num_mpi_ranks config_de
     ADD_TEST(${target_name}_ut ${target_name})
   ENDIF()
 
-ENDMACRO(CreateUnitTest)
+ENDFUNCTION(CreateUnitTest)

--- a/components/scream/src/share/tests/CMakeLists.txt
+++ b/components/scream/src/share/tests/CMakeLists.txt
@@ -1,18 +1,13 @@
-link_directories(${SCREAM_LIBRARY_DIRS} ${SCREAM_TPL_LIBRARY_DIRS})
-add_executable(util_unittest_f90 unit_test.f90)
-add_executable(util_tests
-  util_tests.cpp
-  ../util/scream_catch_main.cpp)
-add_executable(pack_tests
-  pack_tests.cpp
-  ../util/scream_catch_main.cpp)
-foreach (exe util_tests pack_tests util_unittest_f90)
-  target_link_libraries(${exe} scream_share ${SCREAM_TPL_LIBRARIES})
-  target_include_directories(${exe} PUBLIC ${SCREAM_INCLUDE_DIRS} ${CATCH_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
-  set_target_properties(${exe} PROPERTIES
-    LINK_FLAGS "${SCREAM_LINK_FLAGS}"
-    Fortran_MODULE_DIRECTORY ${SCREAM_F90_MODULES})
-  add_test(run_${exe} ${exe})
-endforeach ()
+INCLUDE (ScreamMacros)
 
+SET (num_mpi_ranks 1)
+SET (config_defines "")
 
+# Test utilities (f90)
+CreateUnitTest(util_f90 util_test.f90 scream_share num_mpi_ranks config_defines)
+
+# Test utilities (c++)
+CreateUnitTest(util_cxx util_tests.cpp scream_share num_mpi_ranks config_defines)
+
+# Test packs
+CreateUnitTest(packs pack_tests.cpp scream_share num_mpi_ranks config_defines)

--- a/components/scream/src/share/tests/CMakeLists.txt
+++ b/components/scream/src/share/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-INCLUDE (ScreamMacros)
+INCLUDE (ScreamUtils)
 
 SET (num_mpi_ranks 1)
 SET (config_defines "")


### PR DESCRIPTION
This mini PR introduces a macro for unit tests creation. Avoid code duplication and potential errors by putting all the cmake logic in a single place, for all tests.

So far, I only used it in the share tests.