### PR TITLE
Separate MemoryTraits mask from Unmanaged decorator.

### DIFF
--- a/components/scream/src/share/scream_kokkos_meta.hpp
+++ b/components/scream/src/share/scream_kokkos_meta.hpp
@@ -10,21 +10,29 @@ namespace ko {
 // app-specific array types here; rather, include only those things that one
 // could imagine could go into Kokkos itself.
 
+template <typename View>
+struct MemoryTraitsMask {
+  enum : unsigned int {
+    value = ((View::traits::memory_traits::RandomAccess ? Kokkos::RandomAccess : 0) |
+             (View::traits::memory_traits::Atomic ? Kokkos::Atomic : 0) |
+             (View::traits::memory_traits::Restrict ? Kokkos::Restrict : 0) |
+             (View::traits::memory_traits::Aligned ? Kokkos::Aligned : 0) |
+             (View::traits::memory_traits::Unmanaged ? Kokkos::Unmanaged : 0))
+      };
+};
+
 // Make the input View Unmanaged, whether or not it already is. One might
 // imagine that View::unmanaged_type would provide this.
 //   Use: Unmanged<ViewType>
 template <typename View>
-using Unmanaged = 
+using Unmanaged =
   // Provide a full View type specification, augmented with Unmanaged.
   Kokkos::View<typename View::traits::scalar_array_type,
                typename View::traits::array_layout,
                typename View::traits::device_type,
                Kokkos::MemoryTraits<
                  // All the current values...
-                 (View::traits::memory_traits::RandomAccess ? Kokkos::RandomAccess : 0) |
-                 (View::traits::memory_traits::Atomic ? Kokkos::Atomic : 0) |
-                 (View::traits::memory_traits::Restrict ? Kokkos::Restrict : 0) |
-                 (View::traits::memory_traits::Aligned ? Kokkos::Aligned : 0) |
+                 MemoryTraitsMask<View>::value |
                  // ... |ed with the one we want, whether or not it's
                  // already there.
                  Kokkos::Unmanaged> >;

--- a/components/scream/src/share/scream_kokkos_meta.hpp
+++ b/components/scream/src/share/scream_kokkos_meta.hpp
@@ -10,6 +10,8 @@ namespace ko {
 // app-specific array types here; rather, include only those things that one
 // could imagine could go into Kokkos itself.
 
+// Turn a View's MemoryTraits (traits::memory_traits) into the equivalent
+// unsigned int mask.
 template <typename View>
 struct MemoryTraitsMask {
   enum : unsigned int {

--- a/components/scream/src/share/tests/util_tests.cpp
+++ b/components/scream/src/share/tests/util_tests.cpp
@@ -59,6 +59,9 @@ TEST_CASE("Unmanaged", "scream::ko") {
     static_assert(CVUm::traits::memory_traits::Restrict, "Um");
     static_assert(CVUm::traits::memory_traits::Unmanaged, "Um");
 
+    // Another way to write CVUm;
+    typedef Unmanaged<V::const_type> CVUm_equiv;
+
     using Kokkos::Impl::ViewMapping;
     static_assert(ViewMapping<CVUm::traits, V::traits, void>::is_assignable,
                   "CVUm <- V");
@@ -66,8 +69,12 @@ TEST_CASE("Unmanaged", "scream::ko") {
                   "V </- CVUm");
     static_assert(ViewMapping<CVUm::traits, Unmanaged<V>::traits, void>::is_assignable,
                   "CVUm <- VUm");
+    static_assert(ViewMapping<CVUm_equiv::traits, Unmanaged<V>::traits, void>::is_assignable,
+                  "CVUm_equiv <- VUm");
     static_assert( ! ViewMapping<Unmanaged<V>::traits, CVUm::traits, void>::is_assignable,
                   "VUm </- CVUm");
+    static_assert( ! ViewMapping<Unmanaged<V>::traits, CVUm_equiv::traits, void>::is_assignable,
+                  "VUm </- CVUm_equiv");
     CVUm cv_um(v);
   }
 }


### PR DESCRIPTION
A design discussion with Luca yielded this improvement of the Unamanged
decorator. The impl detail of the MemoryTraits mask is separated from the impl
of Unmanaged. Thus, the impl detail of obtaining a mask can be used elsewhere,
if needed.