### PR TITLE
Remove EAM dependencies from standalone P3

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -37,9 +37,10 @@
 
 module micro_p3
 
-   use cam_logfile,    only: iulog
-   use shr_kind_mod,   only: r8=>shr_kind_r8
-   use spmd_utils,     only: masterproc
+#ifdef CAM
+   use shr_kind_mod,   only: rtype=>shr_kind_r8
+#endif
+
    ! physical and mathematical constants
    use micro_p3_utils, only: rhosur,rhosui,ar,br,f1r,f2r,ecr,rhow,kr,kc,bimm,aimm,rin,mi0,nccnst,  &
        eci,eri,bcn,cpw,cons1,cons2,cons3,cons4,cons5,cons6,cons7,         &
@@ -49,10 +50,15 @@ module micro_p3
        rho_rimeMax,inv_rho_rimeMax,max_total_Ni,dbrk,nmltratio,clbfact_sub,  &
        clbfact_dep,iparam, isize, densize, rimsize, rcollsize, tabsize, colltabsize, &
        get_latent_heat, get_precip_fraction, zerodegc, pi=>pi_e3sm, dnu, &
-       micro_p3_utils_init, rainfrze, icenuct, homogfrze
+       micro_p3_utils_init, rainfrze, icenuct, homogfrze, iulog=>iulog_e3sm, &
+       masterproc=>masterproc_e3sm
 
   implicit none
   save
+
+#ifndef CAM
+  integer,parameter :: rtype = selected_real_kind(12) ! 8 byte real
+#endif
 
   public  :: p3_init,p3_main
 
@@ -60,18 +66,18 @@ module micro_p3
        find_lookupTable_indices_3,get_cloud_dsd2,        &
        get_rain_dsd2,calc_bulkRhoRime,impose_max_total_Ni,check_values,qv_sat
 
-  real(r8),private :: e0
+  real(rtype),private :: e0
 
-  real(r8), private, dimension(densize,rimsize,isize,tabsize) :: itab   !ice lookup table values
+  real(rtype), private, dimension(densize,rimsize,isize,tabsize) :: itab   !ice lookup table values
 
   !ice lookup table values for ice-rain collision/collection
   double precision, private, dimension(densize,rimsize,isize,rcollsize,colltabsize)    :: itabcoll
 
   ! lookup table values for rain shape parameter mu_r
-  real(r8), private, dimension(150) :: mu_r_table
+  real(rtype), private, dimension(150) :: mu_r_table
 
   ! lookup table values for rain number- and mass-weighted fallspeeds and ventilation parameters
-  real(r8), private, dimension(300,10) :: vn_table,vm_table,revap_table
+  real(rtype), private, dimension(300,10) :: vn_table,vm_table,revap_table
 
 contains
 
@@ -93,7 +99,6 @@ contains
     if (masterproc) write(iulog,*) ''
     if (masterproc) write(iulog,*) ' P3 microphysics: v',version_p3
 
-    call micro_p3_utils_init()
     call p3_init_a(lookup_file_dir)
     call p3_init_b()
 
@@ -109,7 +114,7 @@ contains
     character(len=16), parameter :: version_p3  = '2.8.2'          !version number of P3 package
     character(len=1024)          :: lookup_file_1                  !lookup table, main
     integer                      :: i,j,ii,jj
-    real(r8)                         :: dum
+    real(rtype)                         :: dum
     integer                      :: dumi
 
     !------------------------------------------------------------------------------------------!
@@ -162,8 +167,8 @@ contains
 
   subroutine p3_get_tables(mu_r_user, revap_user, vn_user, vm_user)
     ! This can be called instead of p3_init_b.
-    real(r8), dimension(150), intent(out) :: mu_r_user
-    real(r8), dimension(300,10), intent(out) :: vn_user, vm_user, revap_user
+    real(rtype), dimension(150), intent(out) :: mu_r_user
+    real(rtype), dimension(300,10), intent(out) :: vn_user, vm_user, revap_user
     mu_r_user(:) = mu_r_table(:)
     revap_user(:,:) = revap_table(:,:)
     vn_user(:,:) = vn_table(:,:)
@@ -172,8 +177,8 @@ contains
 
   subroutine p3_set_tables(mu_r_user, revap_user, vn_user, vm_user)
     ! This can be called instead of p3_init_b.
-    real(r8), dimension(150), intent(in) :: mu_r_user
-    real(r8), dimension(300,10), intent(in) :: vn_user, vm_user, revap_user
+    real(rtype), dimension(150), intent(in) :: mu_r_user
+    real(rtype), dimension(300,10), intent(in) :: vn_user, vm_user, revap_user
     mu_r_table(:) = mu_r_user(:)
     revap_table(:,:) = revap_user(:,:)
     vn_table(:,:) = vn_user(:,:)
@@ -183,7 +188,7 @@ contains
   SUBROUTINE p3_init_b()
     implicit none
     integer                      :: i,ii,jj,kk
-    real(r8)                         :: lamr,mu_r,lamold,dum,initlamr,dm,dum1,dum2,dum3,dum4,dum5,  &
+    real(rtype)                         :: lamr,mu_r,lamold,dum,initlamr,dm,dum1,dum2,dum3,dum4,dum5,  &
          dd,amg,vt,dia
 
     !------------------------------------------------------------------------------------------!
@@ -327,33 +332,33 @@ contains
 
     !----- Input/ouput arguments:  ----------------------------------------------------------!
 
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: qc         ! cloud, mass mixing ratio         kg kg-1
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: qc         ! cloud, mass mixing ratio         kg kg-1
     ! note: Nc may be specified or predicted (set by log_predictNc)
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: nc         ! cloud, number mixing ratio       #  kg-1
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: qr         ! rain, mass mixing ratio          kg kg-1
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: nr         ! rain, number mixing ratio        #  kg-1
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: qitot      ! ice, total mass mixing ratio     kg kg-1
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: qirim      ! ice, rime mass mixing ratio      kg kg-1
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: nitot      ! ice, total number mixing ratio   #  kg-1
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: birim      ! ice, rime volume mixing ratio    m3 kg-1
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: ssat       ! supersaturation (i.e., qv-qvs)   kg kg-1
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: nc         ! cloud, number mixing ratio       #  kg-1
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: qr         ! rain, mass mixing ratio          kg kg-1
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: nr         ! rain, number mixing ratio        #  kg-1
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: qitot      ! ice, total mass mixing ratio     kg kg-1
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: qirim      ! ice, rime mass mixing ratio      kg kg-1
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: nitot      ! ice, total number mixing ratio   #  kg-1
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: birim      ! ice, rime volume mixing ratio    m3 kg-1
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: ssat       ! supersaturation (i.e., qv-qvs)   kg kg-1
 
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: qv         ! water vapor mixing ratio         kg kg-1
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: th         ! potential temperature            K
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: th_old     ! beginning of time step value of theta K
-    real(r8), intent(inout), dimension(its:ite,kts:kte)      :: qv_old     ! beginning of time step value of qv    kg kg-1
-    real(r8), intent(in),    dimension(its:ite,kts:kte)      :: pres       ! pressure                         Pa
-    real(r8), intent(in),    dimension(its:ite,kts:kte)      :: dzq        ! vertical grid spacing            m
-    real(r8), intent(in)                                     :: dt         ! model time step                  s
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: qv         ! water vapor mixing ratio         kg kg-1
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: th         ! potential temperature            K
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: th_old     ! beginning of time step value of theta K
+    real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: qv_old     ! beginning of time step value of qv    kg kg-1
+    real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: pres       ! pressure                         Pa
+    real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: dzq        ! vertical grid spacing            m
+    real(rtype), intent(in)                                     :: dt         ! model time step                  s
 
-    real(r8), intent(out),   dimension(its:ite)              :: prt_liq    ! precipitation rate, liquid       m s-1
-    real(r8), intent(out),   dimension(its:ite)              :: prt_sol    ! precipitation rate, solid        m s-1
-    real(r8), intent(out),   dimension(its:ite,kts:kte)      :: diag_ze    ! equivalent reflectivity          dBZ
-    real(r8), intent(out),   dimension(its:ite,kts:kte)      :: diag_effc  ! effective radius, cloud          m
-    real(r8), intent(out),   dimension(its:ite,kts:kte)      :: diag_effi  ! effective radius, ice            m
-    real(r8), intent(out),   dimension(its:ite,kts:kte)      :: diag_vmi   ! mass-weighted fall speed of ice  m s-1
-    real(r8), intent(out),   dimension(its:ite,kts:kte)      :: diag_di    ! mean diameter of ice             m
-    real(r8), intent(out),   dimension(its:ite,kts:kte)      :: diag_rhoi  ! bulk density of ice              kg m-1
+    real(rtype), intent(out),   dimension(its:ite)              :: prt_liq    ! precipitation rate, liquid       m s-1
+    real(rtype), intent(out),   dimension(its:ite)              :: prt_sol    ! precipitation rate, solid        m s-1
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_ze    ! equivalent reflectivity          dBZ
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_effc  ! effective radius, cloud          m
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_effi  ! effective radius, ice            m
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_vmi   ! mass-weighted fall speed of ice  m s-1
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_di    ! mean diameter of ice             m
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_rhoi  ! bulk density of ice              kg m-1
 
     integer, intent(in)                                  :: its,ite    ! array bounds (horizontal)
     integer, intent(in)                                  :: kts,kte    ! array bounds (vertical)
@@ -361,115 +366,115 @@ contains
 
     logical, intent(in)                                  :: log_predictNc ! .T. (.F.) for prediction (specification) of Nc
 
-    real(r8), intent(in),    dimension(its:ite,kts:kte)      :: pdel       ! pressure thickness               Pa
-    real(r8), intent(in),    dimension(its:ite,kts:kte)      :: exner      ! Exner expression
+    real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: pdel       ! pressure thickness               Pa
+    real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: exner      ! Exner expression
 
     ! OUTPUT for PBUF variables used by other parameterizations
-    real(r8), intent(out),   dimension(its:ite,kts:kte)      :: cmeiout    ! qitend due to deposition/sublimation
-    real(r8), intent(out),   dimension(its:ite,kts:kte)      :: prain      ! Total precipitation (rain + snow)
-    real(r8), intent(out),   dimension(its:ite,kts:kte)      :: nevapr     ! evaporation of total precipitation (rain + snow)
-    real(r8), intent(out),   dimension(its:ite,kts:kte)      :: prer_evap  ! evaporation of rain
-    real(r8), intent(out),   dimension(its:ite,kts:kte+1)    :: rflx       ! grid-box average rain flux (kg m^-2 s^-1) pverp
-    real(r8), intent(out),   dimension(its:ite,kts:kte+1)    :: sflx       ! grid-box average ice/snow flux (kg m^-2 s^-1) pverp
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: cmeiout    ! qitend due to deposition/sublimation
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: prain      ! Total precipitation (rain + snow)
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: nevapr     ! evaporation of total precipitation (rain + snow)
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: prer_evap  ! evaporation of rain
+    real(rtype), intent(out),   dimension(its:ite,kts:kte+1)    :: rflx       ! grid-box average rain flux (kg m^-2 s^-1) pverp
+    real(rtype), intent(out),   dimension(its:ite,kts:kte+1)    :: sflx       ! grid-box average ice/snow flux (kg m^-2 s^-1) pverp
     ! INPUT needed for PBUF variables used by other parameterizations
-    real(r8), intent(in),    dimension(its:ite,kts:kte)      :: ast        ! relative humidity cloud fraction
+    real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: ast        ! relative humidity cloud fraction
 
-    real(r8), intent(out),   dimension(its:ite,kts:kte)      :: icldm, lcldm, rcldm ! Ice, Liquid and Rain cloud fraction
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: icldm, lcldm, rcldm ! Ice, Liquid and Rain cloud fraction
     !----- Local variables and parameters:  -------------------------------------------------!
 
-    real(r8), dimension(its:ite,kts:kte) :: mu_r  ! shape parameter of rain
-    real(r8), dimension(its:ite,kts:kte) :: t     ! temperature at the beginning of the microhpysics step [K]
-    real(r8), dimension(its:ite,kts:kte) :: t_old ! temperature at the beginning of the model time step [K]
+    real(rtype), dimension(its:ite,kts:kte) :: mu_r  ! shape parameter of rain
+    real(rtype), dimension(its:ite,kts:kte) :: t     ! temperature at the beginning of the microhpysics step [K]
+    real(rtype), dimension(its:ite,kts:kte) :: t_old ! temperature at the beginning of the model time step [K]
 
     ! 2D size distribution and fallspeed parameters:
 
-    real(r8), dimension(its:ite,kts:kte) :: lamc
-    real(r8), dimension(its:ite,kts:kte) :: lamr
-    real(r8), dimension(its:ite,kts:kte) :: logn0r
-    real(r8), dimension(its:ite,kts:kte) :: mu_c
-    !real(r8), dimension(its:ite,kts:kte) :: diag_effr   (currently not used)
-    real(r8), dimension(its:ite,kts:kte) :: nu
-    real(r8), dimension(its:ite,kts:kte) :: cdist
-    real(r8), dimension(its:ite,kts:kte) :: cdist1
-    real(r8), dimension(its:ite,kts:kte) :: cdistr
-    real(r8), dimension(its:ite,kts:kte) :: Vt_qc
+    real(rtype), dimension(its:ite,kts:kte) :: lamc
+    real(rtype), dimension(its:ite,kts:kte) :: lamr
+    real(rtype), dimension(its:ite,kts:kte) :: logn0r
+    real(rtype), dimension(its:ite,kts:kte) :: mu_c
+    !real(rtype), dimension(its:ite,kts:kte) :: diag_effr   (currently not used)
+    real(rtype), dimension(its:ite,kts:kte) :: nu
+    real(rtype), dimension(its:ite,kts:kte) :: cdist
+    real(rtype), dimension(its:ite,kts:kte) :: cdist1
+    real(rtype), dimension(its:ite,kts:kte) :: cdistr
+    real(rtype), dimension(its:ite,kts:kte) :: Vt_qc
 
     ! liquid-phase microphysical process rates:
     !  (all Q process rates in kg kg-1 s-1)
     !  (all N process rates in # kg-1)
 
-    real(r8) :: qrcon   ! rain condensation   (Not in paper?)
-    real(r8) :: qcacc   ! cloud droplet accretion by rain
-    real(r8) :: qcaut   ! cloud droplet autoconversion to rain
-    real(r8) :: ncacc   ! change in cloud droplet number from accretion by rain
-    real(r8) :: ncautc  ! change in cloud droplet number from autoconversion
-    real(r8) :: ncslf   ! change in cloud droplet number from self-collection  (Not in paper?)
-    real(r8) :: nrslf   ! change in rain number from self-collection  (Not in paper?)
-    real(r8) :: ncnuc   ! change in cloud droplet number from activation of CCN
-    real(r8) :: qccon   ! cloud droplet condensation
-    real(r8) :: qcnuc   ! activation of cloud droplets from CCN
-    real(r8) :: qrevp   ! rain evaporation
-    real(r8) :: qcevp   ! cloud droplet evaporation
-    real(r8) :: nrevp   ! change in rain number from evaporation
-    real(r8) :: ncautr  ! change in rain number from autoconversion of cloud water
+    real(rtype) :: qrcon   ! rain condensation   (Not in paper?)
+    real(rtype) :: qcacc   ! cloud droplet accretion by rain
+    real(rtype) :: qcaut   ! cloud droplet autoconversion to rain
+    real(rtype) :: ncacc   ! change in cloud droplet number from accretion by rain
+    real(rtype) :: ncautc  ! change in cloud droplet number from autoconversion
+    real(rtype) :: ncslf   ! change in cloud droplet number from self-collection  (Not in paper?)
+    real(rtype) :: nrslf   ! change in rain number from self-collection  (Not in paper?)
+    real(rtype) :: ncnuc   ! change in cloud droplet number from activation of CCN
+    real(rtype) :: qccon   ! cloud droplet condensation
+    real(rtype) :: qcnuc   ! activation of cloud droplets from CCN
+    real(rtype) :: qrevp   ! rain evaporation
+    real(rtype) :: qcevp   ! cloud droplet evaporation
+    real(rtype) :: nrevp   ! change in rain number from evaporation
+    real(rtype) :: ncautr  ! change in rain number from autoconversion of cloud water
 
     ! ice-phase microphysical process rates:
     !  (all Q process rates in kg kg-1 s-1)
     !  (all N process rates in # kg-1)
 
-    real(r8) :: qccol     ! collection of cloud water by ice
-    real(r8) :: qwgrth    ! wet growth rate
-    real(r8) :: qidep     ! vapor deposition
-    real(r8) :: qrcol     ! collection rain mass by ice
-    real(r8) :: qinuc     ! deposition/condensation freezing nuc
-    real(r8) :: nccol     ! change in cloud droplet number from collection by ice
-    real(r8) :: nrcol     ! change in rain number from collection by ice
-    real(r8) :: ninuc     ! change in ice number from deposition/cond-freezing nucleation
-    real(r8) :: qisub     ! sublimation of ice
-    real(r8) :: qimlt     ! melting of ice
-    real(r8) :: nimlt     ! melting of ice
-    real(r8) :: nisub     ! change in ice number from sublimation
-    real(r8) :: nislf     ! change in ice number from collection within a category (Not in paper?)
-    real(r8) :: qcheti    ! immersion freezing droplets
-    real(r8) :: qrheti    ! immersion freezing rain
-    real(r8) :: ncheti    ! immersion freezing droplets
-    real(r8) :: nrheti    ! immersion freezing rain
-    real(r8) :: nrshdr    ! source for rain number from collision of rain/ice above freezing and shedding
-    real(r8) :: qcshd     ! source for rain mass due to cloud water/ice collision above freezing and shedding or wet growth and shedding
-    real(r8) :: qcmul     ! change in q, ice multiplication from rime-splitnering of cloud water (not included in the paper)
-    real(r8) :: rhorime_c ! density of rime (from cloud)
-    real(r8) :: ncshdc    ! source for rain number due to cloud water/ice collision above freezing  and shedding (combined with NRSHD in the paper)
+    real(rtype) :: qccol     ! collection of cloud water by ice
+    real(rtype) :: qwgrth    ! wet growth rate
+    real(rtype) :: qidep     ! vapor deposition
+    real(rtype) :: qrcol     ! collection rain mass by ice
+    real(rtype) :: qinuc     ! deposition/condensation freezing nuc
+    real(rtype) :: nccol     ! change in cloud droplet number from collection by ice
+    real(rtype) :: nrcol     ! change in rain number from collection by ice
+    real(rtype) :: ninuc     ! change in ice number from deposition/cond-freezing nucleation
+    real(rtype) :: qisub     ! sublimation of ice
+    real(rtype) :: qimlt     ! melting of ice
+    real(rtype) :: nimlt     ! melting of ice
+    real(rtype) :: nisub     ! change in ice number from sublimation
+    real(rtype) :: nislf     ! change in ice number from collection within a category (Not in paper?)
+    real(rtype) :: qcheti    ! immersion freezing droplets
+    real(rtype) :: qrheti    ! immersion freezing rain
+    real(rtype) :: ncheti    ! immersion freezing droplets
+    real(rtype) :: nrheti    ! immersion freezing rain
+    real(rtype) :: nrshdr    ! source for rain number from collision of rain/ice above freezing and shedding
+    real(rtype) :: qcshd     ! source for rain mass due to cloud water/ice collision above freezing and shedding or wet growth and shedding
+    real(rtype) :: qcmul     ! change in q, ice multiplication from rime-splitnering of cloud water (not included in the paper)
+    real(rtype) :: rhorime_c ! density of rime (from cloud)
+    real(rtype) :: ncshdc    ! source for rain number due to cloud water/ice collision above freezing  and shedding (combined with NRSHD in the paper)
 
     ! AaronDonahue, The following microphysical processes are not currently used
     ! in the code so they have been deleted pending future improvements.
-!    real(r8) :: nchetc    ! contact freezing droplets
-!    real(r8) :: nimul     ! change in Ni, ice multiplication from rime-splintering (not included in the paper)
-!    real(r8) :: nrhetc    ! contact freezing rain
-!    real(r8) :: qchetc    ! contact freezing droplets
-!    real(r8) :: qrhetc    ! contact freezing rain
-!    real(r8) :: qrmul     ! change in q, ice multiplication from rime-splitnering of rain (not included in the paper)
+!    real(rtype) :: nchetc    ! contact freezing droplets
+!    real(rtype) :: nimul     ! change in Ni, ice multiplication from rime-splintering (not included in the paper)
+!    real(rtype) :: nrhetc    ! contact freezing rain
+!    real(rtype) :: qchetc    ! contact freezing droplets
+!    real(rtype) :: qrhetc    ! contact freezing rain
+!    real(rtype) :: qrmul     ! change in q, ice multiplication from rime-splitnering of rain (not included in the paper)
 
     logical   :: log_wetgrowth
 
-    real(r8) :: Eii_fact,epsi
-    real(r8) :: eii ! temperature dependent aggregation efficiency
+    real(rtype) :: Eii_fact,epsi
+    real(rtype) :: eii ! temperature dependent aggregation efficiency
 
-    real(r8), dimension(its:ite,kts:kte) :: diam_ice
+    real(rtype), dimension(its:ite,kts:kte) :: diam_ice
     ! AaronDonahue Added for extra output
-    real(r8), dimension(its:ite,kts:kte) :: cldm
-    real(r8)                             :: mincld
+    real(rtype), dimension(its:ite,kts:kte) :: cldm
+    real(rtype)                             :: mincld
     CHARACTER(len=16) :: precip_frac_method = 'max_overlap'
     ! AaronDonahue -end
 
-    real(r8), dimension(its:ite,kts:kte)      :: inv_dzq,inv_rho,ze_ice,ze_rain,prec,rho,       &
+    real(rtype), dimension(its:ite,kts:kte)      :: inv_dzq,inv_rho,ze_ice,ze_rain,prec,rho,       &
          rhofacr,rhofaci,acn,xxls,xxlv,xlf,qvs,qvi,sup,supi,vtrmi1,       &
          tmparr1,inv_exner
 
-    real(r8), dimension(kts:kte) ::  V_qr,V_qit,V_nit,V_nr,V_qc,V_nc,flux_qit,        &
+    real(rtype), dimension(kts:kte) ::  V_qr,V_qit,V_nit,V_nr,V_qc,V_nc,flux_qit,        &
          flux_qx,flux_nx,                     &
          flux_nit,flux_qir,flux_bir
 
-    real(r8)    :: lammax,lammin,mu,dv,sc,dqsdt,ab,kap,epsr,epsc,xx,aaa,epsilon,sigvl,epsi_tot, &
+    real(rtype)    :: lammax,lammin,mu,dv,sc,dqsdt,ab,kap,epsr,epsc,xx,aaa,epsilon,sigvl,epsi_tot, &
          aact,sm1,sm2,uu1,uu2,dum,dum1,dum2,    &
          dumqv,dumqvs,dums,ratio,qsat0,dum3,dum4,dum5,dum6,rdumii, &
          rdumjj,dqsidt,abi,dumqvi,rhop,v_impact,ri,iTc,D_c,tmp1,  &
@@ -492,24 +497,24 @@ contains
 
     ! quantities related to process rates/parameters, interpolated from lookup tables:
 
-    real(r8)    :: f1pr01   ! number-weighted fallspeed
-    real(r8)    :: f1pr02   ! mass-weighted fallspeed
-    real(r8)    :: f1pr03   ! ice collection within a category
-    real(r8)    :: f1pr04   ! collection of cloud water by ice
-    real(r8)    :: f1pr05   ! melting
-    real(r8)    :: f1pr06   ! effective radius
-    real(r8)    :: f1pr07   ! collection of rain number by ice
-    real(r8)    :: f1pr08   ! collection of rain mass by ice
-    real(r8)    :: f1pr09   ! minimum ice number (lambda limiter)
-    real(r8)    :: f1pr10   ! maximum ice number (lambda limiter)
-!    real(r8)    :: f1pr11   ! not used
-!    real(r8)    :: f1pr12   ! not used
-    real(r8)    :: f1pr13   ! reflectivity
-    real(r8)    :: f1pr14   ! melting (ventilation term)
-    real(r8)    :: f1pr15   ! mass-weighted mean diameter
-    real(r8)    :: f1pr16   ! mass-weighted mean particle density
-!    real(r8)    :: f1pr17   ! ice-ice category collection change in number (not used)
-!    real(r8)    :: f1pr18   ! ice-ice category collection change in mass (not used)
+    real(rtype)    :: f1pr01   ! number-weighted fallspeed
+    real(rtype)    :: f1pr02   ! mass-weighted fallspeed
+    real(rtype)    :: f1pr03   ! ice collection within a category
+    real(rtype)    :: f1pr04   ! collection of cloud water by ice
+    real(rtype)    :: f1pr05   ! melting
+    real(rtype)    :: f1pr06   ! effective radius
+    real(rtype)    :: f1pr07   ! collection of rain number by ice
+    real(rtype)    :: f1pr08   ! collection of rain mass by ice
+    real(rtype)    :: f1pr09   ! minimum ice number (lambda limiter)
+    real(rtype)    :: f1pr10   ! maximum ice number (lambda limiter)
+!    real(rtype)    :: f1pr11   ! not used
+!    real(rtype)    :: f1pr12   ! not used
+    real(rtype)    :: f1pr13   ! reflectivity
+    real(rtype)    :: f1pr14   ! melting (ventilation term)
+    real(rtype)    :: f1pr15   ! mass-weighted mean diameter
+    real(rtype)    :: f1pr16   ! mass-weighted mean particle density
+!    real(rtype)    :: f1pr17   ! ice-ice category collection change in number (not used)
+!    real(rtype)    :: f1pr18   ! ice-ice category collection change in mass (not used)
 
     !--These will be added as namelist parameters in the future
     logical, parameter :: debug_ON     = .false.  !.true. to switch on debugging checks/traps throughout code
@@ -2286,7 +2291,7 @@ contains
 
     implicit none
 
-    real(r8)    :: dum1,dum4,dum5,proc,iproc1,gproc1,tmp1,tmp2
+    real(rtype)    :: dum1,dum4,dum5,proc,iproc1,gproc1,tmp1,tmp2
     integer :: dumjj,dumii,dumi,index
 
     ! get value at current density index
@@ -2328,7 +2333,7 @@ contains
 
     implicit none
 
-    real(r8)    :: dum1,dum3,dum4,dum5,proc,dproc1,dproc2,iproc1,gproc1,tmp1,tmp2
+    real(rtype)    :: dum1,dum3,dum4,dum5,proc,dproc1,dproc2,iproc1,gproc1,tmp1,tmp2
     integer :: dumjj,dumii,dumj,dumi,index
 
 
@@ -2394,7 +2399,7 @@ contains
 
   !==========================================================================================!
 
-  real(r8) function polysvp1(T,i_type)
+  real(rtype) function polysvp1(T,i_type)
 
     !-------------------------------------------
     !  COMPUTE SATURATION VAPOR PRESSURE
@@ -2405,27 +2410,27 @@ contains
 
     implicit none
 
-    real(r8)    :: T
+    real(rtype)    :: T
     integer :: i_type
 
     ! REPLACE GOFF-GRATCH WITH FASTER FORMULATION FROM FLATAU ET AL. 1992, TABLE 4 (RIGHT-HAND COLUMN)
 
     ! ice
-    real(r8) a0i,a1i,a2i,a3i,a4i,a5i,a6i,a7i,a8i
+    real(rtype) a0i,a1i,a2i,a3i,a4i,a5i,a6i,a7i,a8i
     data a0i,a1i,a2i,a3i,a4i,a5i,a6i,a7i,a8i /&
          6.11147274, 0.503160820, 0.188439774e-1, &
          0.420895665e-3, 0.615021634e-5,0.602588177e-7, &
          0.385852041e-9, 0.146898966e-11, 0.252751365e-14/
 
     ! liquid
-    real(r8) a0,a1,a2,a3,a4,a5,a6,a7,a8
+    real(rtype) a0,a1,a2,a3,a4,a5,a6,a7,a8
 
     ! V1.7
     data a0,a1,a2,a3,a4,a5,a6,a7,a8 /&
          6.11239921, 0.443987641, 0.142986287e-1, &
          0.264847430e-3, 0.302950461e-5, 0.206739458e-7, &
          0.640689451e-10,-0.952447341e-13,-0.976195544e-15/
-    real(r8) dt
+    real(rtype) dt
 
     !-------------------------------------------
 
@@ -2488,9 +2493,9 @@ contains
 
     ! arguments:
     integer, intent(out) :: dumi,dumjj,dumii,dumzz
-    real(r8),    intent(out) :: dum1,dum4,dum5,dum6
+    real(rtype),    intent(out) :: dum1,dum4,dum5,dum6
     integer, intent(in)  :: isize,rimsize,densize
-    real(r8),    intent(in)  :: qitot,nitot,qirim,rhop
+    real(rtype),    intent(in)  :: qitot,nitot,qirim,rhop
 
     !------------------------------------------------------------------------------------------!
 
@@ -2547,13 +2552,13 @@ contains
 
     ! arguments:
     integer, intent(out) :: dumj
-    real(r8),    intent(out) :: dum3
+    real(rtype),    intent(out) :: dum3
     integer, intent(in)  :: rcollsize
-    real(r8),    intent(in)  :: qr,nr
+    real(rtype),    intent(in)  :: qr,nr
 
     ! local variables:
-    real(r8)                 :: dumlr
-    real(r8)                 :: real_rcollsize
+    real(rtype)                 :: dumlr
+    real(rtype)                 :: real_rcollsize
 
     !------------------------------------------------------------------------------------------!
     real_rcollsize = real(rcollsize)
@@ -2589,8 +2594,8 @@ contains
 
     ! arguments:
     integer, intent(out) :: dumii,dumjj
-    real(r8),    intent(out) :: dum1,rdumii,rdumjj,inv_dum3
-    real(r8),    intent(in)  :: mu_r,lamr
+    real(rtype),    intent(out) :: dum1,rdumii,rdumjj,inv_dum3
+    real(rtype),    intent(in)  :: mu_r,lamr
 
     !------------------------------------------------------------------------------------------!
 
@@ -2631,13 +2636,13 @@ contains
     implicit none
 
     !arguments:
-    real(r8), dimension(:), intent(in)  :: dnu
-    real(r8),     intent(in)            :: qc,rho
-    real(r8),     intent(inout)         :: nc
-    real(r8),     intent(out)           :: mu_c,nu,lamc,cdist,cdist1
+    real(rtype), dimension(:), intent(in)  :: dnu
+    real(rtype),     intent(in)            :: qc,rho
+    real(rtype),     intent(inout)         :: nc
+    real(rtype),     intent(out)           :: mu_c,nu,lamc,cdist,cdist1
 
     !local variables
-    real(r8)                            :: lammin,lammax
+    real(rtype)                            :: lammin,lammax
     integer                         :: dumi
 
     !--------------------------------------------------------------------------
@@ -2694,14 +2699,14 @@ contains
     implicit none
 
     !arguments:
-    real(r8), dimension(:), intent(in)  :: mu_r_table
-    real(r8),     intent(in)            :: qr
-    real(r8),     intent(inout)         :: nr
-    real(r8),     intent(out)           :: rdumii,lamr,mu_r,cdistr,logn0r
+    real(rtype), dimension(:), intent(in)  :: mu_r_table
+    real(rtype),     intent(in)            :: qr
+    real(rtype),     intent(inout)         :: nr
+    real(rtype),     intent(out)           :: rdumii,lamr,mu_r,cdistr,logn0r
     integer,  intent(out)           :: dumii
 
     !local variables:
-    real(r8)                            :: inv_dum,lammax,lammin
+    real(rtype)                            :: inv_dum,lammax,lammin
 
     !--------------------------------------------------------------------------
 
@@ -2768,9 +2773,9 @@ contains
     implicit none
 
     !arguments:
-    real(r8), intent(in)    :: qi_tot
-    real(r8), intent(inout) :: qi_rim,bi_rim
-    real(r8), intent(out)   :: rho_rime
+    real(rtype), intent(in)    :: qi_tot
+    real(rtype), intent(inout) :: qi_rim,bi_rim
+    real(rtype), intent(out)   :: rho_rime
 
     !--------------------------------------------------------------------------
 
@@ -2819,11 +2824,11 @@ contains
     implicit none
 
     !arguments:
-    real(r8), intent(inout)               :: nitot_local      !PMC - scalar now that nCat deleted.
-    real(r8), intent(in)                  :: max_total_Ni,inv_rho_local
+    real(rtype), intent(inout)               :: nitot_local      !PMC - scalar now that nCat deleted.
+    real(rtype), intent(in)                  :: max_total_Ni,inv_rho_local
 
     !local variables:
-    real(r8)                              :: dum
+    real(rtype)                              :: dum
 
     if (nitot_local.ge.1.e-20) then
        dum = max_total_Ni*inv_rho_local/nitot_local
@@ -2835,7 +2840,7 @@ contains
 
   !===========================================================================================
 
-  real(r8) function qv_sat(t_atm,p_atm,i_wrt)
+  real(rtype) function qv_sat(t_atm,p_atm,i_wrt)
 
     !------------------------------------------------------------------------------------
     ! Calls polysvp1 to obtain the saturation vapor pressure, and then computes
@@ -2846,12 +2851,12 @@ contains
     implicit none
 
     !Calling parameters:
-    real(r8)    :: t_atm  !temperature [K]
-    real(r8)    :: p_atm  !pressure    [Pa]
+    real(rtype)    :: t_atm  !temperature [K]
+    real(rtype)    :: p_atm  !pressure    [Pa]
     integer :: i_wrt  !index, 0 = w.r.t. liquid, 1 = w.r.t. ice
 
     !Local variables:
-    real(r8)            :: e_pres         !saturation vapor pressure [Pa]
+    real(rtype)            :: e_pres         !saturation vapor pressure [Pa]
 
     !------------------
 
@@ -2884,18 +2889,18 @@ contains
     implicit none
 
     !Calling parameters:
-    real(r8), dimension(:,:),   intent(in) :: Qv,T
+    real(rtype), dimension(:,:),   intent(in) :: Qv,T
     integer,                intent(in) :: source_ind,i,timestepcount
     logical,                intent(in) :: force_abort         !.TRUE. = forces abort if value violation is detected
 
     !Local variables:
-    real(r8), parameter :: T_low  = 173.
-    real(r8), parameter :: T_high = 323.
-    real(r8), parameter :: Q_high = 40.e-3
-    real(r8), parameter :: N_high = 1.e+20
-    real(r8), parameter :: B_high = Q_high*1.e-3
-    real(r8), parameter :: x_high = 1.e+30
-    real(r8), parameter :: x_low  = 0.
+    real(rtype), parameter :: T_low  = 173.
+    real(rtype), parameter :: T_high = 323.
+    real(rtype), parameter :: Q_high = 40.e-3
+    real(rtype), parameter :: N_high = 1.e+20
+    real(rtype), parameter :: B_high = Q_high*1.e-3
+    real(rtype), parameter :: x_high = 1.e+30
+    real(rtype), parameter :: x_low  = 0.
     integer         :: k,nk
     logical         :: trap,badvalue_found
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -462,7 +462,6 @@ contains
     real(rtype), dimension(its:ite,kts:kte) :: diam_ice
     ! AaronDonahue Added for extra output
     real(rtype), dimension(its:ite,kts:kte) :: cldm
-    real(rtype)                             :: mincld
     CHARACTER(len=16) :: precip_frac_method = 'max_overlap'
     ! AaronDonahue -end
 

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -10,7 +10,7 @@ module micro_p3_interface
   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  use shr_kind_mod,   only: r8=>shr_kind_r8
+  use shr_kind_mod,   only: rtype=>shr_kind_r8
   use ppgrid,         only: pcols,pver,pverp
 
 !comment: I think Kai added handle_errmsg. It would be better to 
@@ -20,7 +20,7 @@ module micro_p3_interface
   use physics_types,  only: physics_state, &
                             physics_ptend, &
                             physics_ptend_init
-  use physconst,      only: mwdry, cpair, mwh2o, gravit, rair, &
+  use physconst,      only: mwdry, cpair, mwh2o, gravit, rair, cpliq, pi, &
                             rh2o, latvap, latice, tmelt, rhoh2o, rairv 
   use constituents,   only: cnst_add, pcnst, sflxnam, apcnst, bpcnst, pcnst,&
                             cnst_name, cnst_get_ind,cnst_longname
@@ -139,14 +139,14 @@ module micro_p3_interface
 
 
 
-   real(r8) :: &
-      micro_mg_accre_enhan_fac = huge(1.0_r8), & !Accretion enhancement factor from namelist
-      prc_coef1_in             = huge(1.0_r8), &
-      prc_exp_in               = huge(1.0_r8), &
-      prc_exp1_in              = huge(1.0_r8), &
-      cld_sed_in               = huge(1.0_r8), & !scale fac for cloud sedimentation velocity
-      nccons                   = huge(1.0_r8), &
-      nicons                   = huge(1.0_r8)
+   real(rtype) :: &
+      micro_mg_accre_enhan_fac = huge(1.0_rtype), & !Accretion enhancement factor from namelist
+      prc_coef1_in             = huge(1.0_rtype), &
+      prc_exp_in               = huge(1.0_rtype), &
+      prc_exp1_in              = huge(1.0_rtype), &
+      cld_sed_in               = huge(1.0_rtype), & !scale fac for cloud sedimentation velocity
+      nccons                   = huge(1.0_rtype), &
+      nicons                   = huge(1.0_rtype)
 
    integer :: ncnst
 
@@ -155,15 +155,15 @@ module micro_p3_interface
   !assigned at the beginning of each step from the value at the end 
   !of the step before.
 
-  real(r8) :: th(pcols,pver)
-  real(r8) :: qv(pcols,pver)
+  real(rtype) :: th(pcols,pver)
+  real(rtype) :: qv(pcols,pver)
 
   character(len=8), parameter :: &      ! Constituent names
      cnst_names(8) = (/'CLDLIQ', 'CLDICE','NUMLIQ','NUMICE', &
                      'RAINQM', 'CLDRIM','NUMRAI','BVRIM'/)
 
-  real(r8) :: &             
-     ice_sed_ai = 700.0_r8      ! Fall speed parameter for cloud ice
+  real(rtype) :: &             
+     ice_sed_ai = 700.0_rtype      ! Fall speed parameter for cloud ice
 
   contains
 !===============================================================================
@@ -183,7 +183,7 @@ subroutine micro_p3_readnl(nlfile)
   logical :: micro_do_nccons    = .false.! micro_do_nccons = .true, MG does NOT predict numliq 
   logical :: micro_do_nicons    = .false.! micro_do_nicons = .true.,MG does NOT predict numice
   integer :: micro_mg_num_steps = 1      ! Number of substepping iterations done by MG (1.5 only for now).
-  real(r8) :: micro_nccons, micro_nicons
+  real(rtype) :: micro_nccons, micro_nicons
 
   ! Local variables
   integer :: unitn, ierr
@@ -277,40 +277,40 @@ end subroutine micro_p3_readnl
     ! (i.e. members of state%q) and save indices.
     ! TODO make sure the cnst_names match what we think they are here.
     !================
-   call cnst_add(cnst_names(1), mwdry, cpair, 0._r8, ixcldliq, &
+   call cnst_add(cnst_names(1), mwdry, cpair, 0._rtype, ixcldliq, &
          longname='Grid box averaged cloud liquid amount', &
          is_convtran1=.true.)
    ncnst = ncnst + 1
-   call cnst_add(cnst_names(2), mwdry, cpair, 0._r8, ixcldice, &
+   call cnst_add(cnst_names(2), mwdry, cpair, 0._rtype, ixcldice, &
          longname='Grid box averaged cloud ice amount', &
          is_convtran1=.true.)
    ncnst = ncnst + 1
-   call cnst_add(cnst_names(3), mwh2o, cpair, 0._r8, ixnumliq, &
+   call cnst_add(cnst_names(3), mwh2o, cpair, 0._rtype, ixnumliq, &
          longname='Grid box averaged cloud liquid number', &
          is_convtran1=.true.)
    ncnst = ncnst + 1
-   call cnst_add(cnst_names(4), mwh2o, cpair, 0._r8, ixnumice, &
+   call cnst_add(cnst_names(4), mwh2o, cpair, 0._rtype, ixnumice, &
          longname='Grid box averaged cloud ice number', &
          is_convtran1=.true.)
    ncnst = ncnst + 1
-   call cnst_add(cnst_names(5), mwh2o, cpair, 0._r8, ixrain, &
+   call cnst_add(cnst_names(5), mwh2o, cpair, 0._rtype, ixrain, &
          longname='Grid box averaged rain amount', &
          is_convtran1=.true.)
    ncnst = ncnst + 1
-   call cnst_add(cnst_names(6), mwh2o, cpair, 0._r8, ixcldrim, &
+   call cnst_add(cnst_names(6), mwh2o, cpair, 0._rtype, ixcldrim, &
          longname='Grid box averaged riming amount', &
          is_convtran1=.true.)
    ncnst = ncnst + 1
-   call cnst_add(cnst_names(7), mwh2o, cpair, 0._r8, ixnumrain, &
+   call cnst_add(cnst_names(7), mwh2o, cpair, 0._rtype, ixnumrain, &
          longname='Grid box averaged rain number', &
          is_convtran1=.true.)
    ncnst = ncnst + 1
-   call cnst_add(cnst_names(8), mwh2o, cpair, 0._r8, ixrimvol, &
+   call cnst_add(cnst_names(8), mwh2o, cpair, 0._rtype, ixrimvol, &
          longname='Grid box averaged riming volume', &
          is_convtran1=.true.)
    ncnst = ncnst + 1
 !+++ Aaron
-!    call cnst_add(cnst_names(8), mwh2o, cpair, 0._r8, ixqirim, &
+!    call cnst_add(cnst_names(8), mwh2o, cpair, 0._rtype, ixqirim, &
 !         longname='Grid box averaged riming ???', &
 !         is_convtran1=.true.)  ! TODO what is this?
 !--- Aaron
@@ -441,10 +441,10 @@ end subroutine micro_p3_readnl
     ! not read from the initial file.
 
     character(len=*), intent(in) :: name     ! constituent name
-    real(r8), intent(out) :: q(:,:)   ! mass mixing ratio (gcol, plev)
+    real(rtype), intent(out) :: q(:,:)   ! mass mixing ratio (gcol, plev)
     integer,  intent(in)  :: gcid(:)  ! global column id
 
-    if (micro_p3_implements_cnst(name)) q = 0.0_r8
+    if (micro_p3_implements_cnst(name)) q = 0.0_rtype
 
   end subroutine micro_p3_init_cnst
 
@@ -469,7 +469,8 @@ end subroutine micro_p3_readnl
     ! =============
     call phys_getopts(p3_lookup_dir_out = p3_lookup_dir)
 
-    call micro_p3_utils_init()
+    call micro_p3_utils_init(cpair,rair,rh2o,rhoh2o,mwh2o,mwdry,gravit,latvap,latice, &
+             cpliq,tmelt,pi,iulog,masterproc)
 
     ! CALL P3 INIT:
     !==============
@@ -512,38 +513,38 @@ end subroutine micro_p3_readnl
     if (is_first_step()) then
 
 
-       call pbuf_set_field(pbuf2d, p3_qv_idx, 0._r8)
-       call pbuf_set_field(pbuf2d, p3_th_idx, 0._r8)
+       call pbuf_set_field(pbuf2d, p3_qv_idx, 0._rtype)
+       call pbuf_set_field(pbuf2d, p3_th_idx, 0._rtype)
 
-       call pbuf_set_field(pbuf2d, cldo_idx,   0._r8)
-       call pbuf_set_field(pbuf2d, cc_t_idx,   0._r8)
-       call pbuf_set_field(pbuf2d, cc_qv_idx,  0._r8)
-       call pbuf_set_field(pbuf2d, cc_ql_idx,  0._r8)
-       call pbuf_set_field(pbuf2d, cc_qi_idx,  0._r8)
-       call pbuf_set_field(pbuf2d, cc_nl_idx,  0._r8)
-       call pbuf_set_field(pbuf2d, cc_ni_idx,  0._r8)
-       call pbuf_set_field(pbuf2d, cc_qlst_idx,0._r8)
-       call pbuf_set_field(pbuf2d, acprecl_idx,   0._r8)
-       call pbuf_set_field(pbuf2d, acgcme_idx, 0._r8)
+       call pbuf_set_field(pbuf2d, cldo_idx,   0._rtype)
+       call pbuf_set_field(pbuf2d, cc_t_idx,   0._rtype)
+       call pbuf_set_field(pbuf2d, cc_qv_idx,  0._rtype)
+       call pbuf_set_field(pbuf2d, cc_ql_idx,  0._rtype)
+       call pbuf_set_field(pbuf2d, cc_qi_idx,  0._rtype)
+       call pbuf_set_field(pbuf2d, cc_nl_idx,  0._rtype)
+       call pbuf_set_field(pbuf2d, cc_ni_idx,  0._rtype)
+       call pbuf_set_field(pbuf2d, cc_qlst_idx,0._rtype)
+       call pbuf_set_field(pbuf2d, acprecl_idx,   0._rtype)
+       call pbuf_set_field(pbuf2d, acgcme_idx, 0._rtype)
        call pbuf_set_field(pbuf2d, acnum_idx,  0)
-       call pbuf_set_field(pbuf2d, relvar_idx, 2._r8)
+       call pbuf_set_field(pbuf2d, relvar_idx, 2._rtype)
        call pbuf_set_field(pbuf2d, accre_enhan_idx, micro_mg_accre_enhan_fac)
-       call pbuf_set_field(pbuf2d, prer_evap_idx,  0._r8)
+       call pbuf_set_field(pbuf2d, prer_evap_idx,  0._rtype)
  
        !! not used 
-       if (qrain_idx > 0)   call pbuf_set_field(pbuf2d, qrain_idx, 0._r8)
-       if (nrain_idx > 0)   call pbuf_set_field(pbuf2d, nrain_idx, 0._r8)
+       if (qrain_idx > 0)   call pbuf_set_field(pbuf2d, qrain_idx, 0._rtype)
+       if (nrain_idx > 0)   call pbuf_set_field(pbuf2d, nrain_idx, 0._rtype)
 
        ! If sub-columns turned on, need to set the sub-column fields as well
        if (use_subcol_microp) then
-          call pbuf_set_field(pbuf2d, cldo_idx,   0._r8, col_type=col_type_subcol)
-          call pbuf_set_field(pbuf2d, cc_t_idx,   0._r8, col_type=col_type_subcol)
-          call pbuf_set_field(pbuf2d, cc_qv_idx,  0._r8, col_type=col_type_subcol)
-          call pbuf_set_field(pbuf2d, cc_ql_idx,  0._r8, col_type=col_type_subcol)
-          call pbuf_set_field(pbuf2d, cc_qi_idx,  0._r8, col_type=col_type_subcol)
-          call pbuf_set_field(pbuf2d, cc_nl_idx,  0._r8, col_type=col_type_subcol)
-          call pbuf_set_field(pbuf2d, cc_ni_idx,  0._r8, col_type=col_type_subcol)
-          call pbuf_set_field(pbuf2d, cc_qlst_idx,0._r8, col_type=col_type_subcol)
+          call pbuf_set_field(pbuf2d, cldo_idx,   0._rtype, col_type=col_type_subcol)
+          call pbuf_set_field(pbuf2d, cc_t_idx,   0._rtype, col_type=col_type_subcol)
+          call pbuf_set_field(pbuf2d, cc_qv_idx,  0._rtype, col_type=col_type_subcol)
+          call pbuf_set_field(pbuf2d, cc_ql_idx,  0._rtype, col_type=col_type_subcol)
+          call pbuf_set_field(pbuf2d, cc_qi_idx,  0._rtype, col_type=col_type_subcol)
+          call pbuf_set_field(pbuf2d, cc_nl_idx,  0._rtype, col_type=col_type_subcol)
+          call pbuf_set_field(pbuf2d, cc_ni_idx,  0._rtype, col_type=col_type_subcol)
+          call pbuf_set_field(pbuf2d, cc_qlst_idx,0._rtype, col_type=col_type_subcol)
        end if
 
     end if
@@ -655,7 +656,7 @@ end subroutine micro_p3_readnl
    ! NOTE -- only 'I' should be used for sub-column fields as subc-columns could shift from time-step to time-step
 !   if (use_subcol_microp) then
 !      call addfld('FICE_SCOL', (/'psubcols','lev     '/), 'I', 'fraction', &
-!           'Sub-column fractional ice content within cloud', flag_xyfill=.true., fill_value=1.e30_r8)
+!           'Sub-column fractional ice content within cloud', flag_xyfill=.true., fill_value=1.e30_rtype)
 !   end if
 
    ! Averaging for cloud particle number and size
@@ -800,136 +801,136 @@ end subroutine micro_p3_readnl
     !INPUT/OUTPUT VARIABLES
     type(physics_state),         intent(in)    :: state
     type(physics_ptend),         intent(out)   :: ptend
-    real(r8),                    intent(in)    :: dtime
+    real(rtype),                    intent(in)    :: dtime
     type(physics_buffer_desc),   pointer       :: pbuf(:)
     logical :: lq(pcnst)   !list of what constituents to update
 
     !INTERNAL VARIABLES
-    real(r8), pointer :: th_old(:,:)     !potential temperature from last step   K
-    real(r8), pointer :: qv_old(:,:)     !water vapor from last step             kg/kg
-    real(r8) :: ssat(pcols,pver)       !supersaturated mixing ratio            kg/kg
-    real(r8) :: dzq(pcols,pver)        !geometric layer thickness              m
-    real(r8) :: cldliq(pcols,pver)     !cloud liquid water mixing ratio        kg/kg
-    real(r8) :: numliq(pcols,pver)     !cloud liquid water drop concentraiton  #/kg
-    real(r8) :: rain(pcols,pver)       !rain water mixing ratio                kg/kg
-    real(r8) :: numrain(pcols,pver)    !rain water number concentration        #/kg
-    real(r8) :: qv(pcols,pver)         !water vapor mixing ratio               kg/kg
-    real(r8) :: ice(pcols,pver)        !total ice water mixing ratio           kg/kg
-    real(r8) :: qirim(pcols,pver)      !rime ice mixing ratio                  kg/kg
-    real(r8) :: numice(pcols,pver)     !total ice crystal number concentration #/kg
-    real(r8) :: rimvol(pcols,pver)     !rime volume mixing ratio               m3/kg
-    real(r8) :: temp(pcols,pver)       !potential temperature                  K
-    real(r8) :: rim(pcols,pver)        !rime mixing ratio                      kg/kg
-    real(r8) :: prt_liq(pcols)         !precipitation rate, liquid             m s-1
-    real(r8) :: prt_sol(pcols)         !precipitation rate, solid              m s-1
-    real(r8) :: diag_ze(pcols,pver)    !equivalent reflectivity                dBZ
-    real(r8) :: diag_effc(pcols,pver)  !effective radius, cloud                m
-    real(r8) :: diag_effi(pcols,pver)  !effective radius, ice                  m
-    real(r8) :: diag_vmi(pcols,pver)   !mass-weighted fall speed of ice        m s-1
-    real(r8) :: diag_di(pcols,pver)    !mean diameter of ice                   m
-    real(r8) :: diag_rhoi(pcols,pver)  !bulk density of ice                    kg m-1
-    real(r8) :: pres(pcols,pver)       !pressure at midlevel                   hPa
-    real(r8) :: cmeiout(pcols,pver)
-    real(r8) :: rflx(pcols,pver+1)     !grid-box average rain flux (kg m^-2s^-1) pverp
-    real(r8) :: sflx(pcols,pver+1)     !grid-box average ice/snow flux (kg m^-2s^-1) pverp
-    real(r8) :: exner(pcols,pver)      !exner formula for converting between potential and normal temp
-    real(r8) :: rcldm(pcols,pver)      !rain cloud fraction
-    real(r8) :: lcldm(pcols,pver)      !liquid cloud fraction
-    real(r8) :: icldm(pcols,pver)      !ice cloud fraction
+    real(rtype), pointer :: th_old(:,:)     !potential temperature from last step   K
+    real(rtype), pointer :: qv_old(:,:)     !water vapor from last step             kg/kg
+    real(rtype) :: ssat(pcols,pver)       !supersaturated mixing ratio            kg/kg
+    real(rtype) :: dzq(pcols,pver)        !geometric layer thickness              m
+    real(rtype) :: cldliq(pcols,pver)     !cloud liquid water mixing ratio        kg/kg
+    real(rtype) :: numliq(pcols,pver)     !cloud liquid water drop concentraiton  #/kg
+    real(rtype) :: rain(pcols,pver)       !rain water mixing ratio                kg/kg
+    real(rtype) :: numrain(pcols,pver)    !rain water number concentration        #/kg
+    real(rtype) :: qv(pcols,pver)         !water vapor mixing ratio               kg/kg
+    real(rtype) :: ice(pcols,pver)        !total ice water mixing ratio           kg/kg
+    real(rtype) :: qirim(pcols,pver)      !rime ice mixing ratio                  kg/kg
+    real(rtype) :: numice(pcols,pver)     !total ice crystal number concentration #/kg
+    real(rtype) :: rimvol(pcols,pver)     !rime volume mixing ratio               m3/kg
+    real(rtype) :: temp(pcols,pver)       !potential temperature                  K
+    real(rtype) :: rim(pcols,pver)        !rime mixing ratio                      kg/kg
+    real(rtype) :: prt_liq(pcols)         !precipitation rate, liquid             m s-1
+    real(rtype) :: prt_sol(pcols)         !precipitation rate, solid              m s-1
+    real(rtype) :: diag_ze(pcols,pver)    !equivalent reflectivity                dBZ
+    real(rtype) :: diag_effc(pcols,pver)  !effective radius, cloud                m
+    real(rtype) :: diag_effi(pcols,pver)  !effective radius, ice                  m
+    real(rtype) :: diag_vmi(pcols,pver)   !mass-weighted fall speed of ice        m s-1
+    real(rtype) :: diag_di(pcols,pver)    !mean diameter of ice                   m
+    real(rtype) :: diag_rhoi(pcols,pver)  !bulk density of ice                    kg m-1
+    real(rtype) :: pres(pcols,pver)       !pressure at midlevel                   hPa
+    real(rtype) :: cmeiout(pcols,pver)
+    real(rtype) :: rflx(pcols,pver+1)     !grid-box average rain flux (kg m^-2s^-1) pverp
+    real(rtype) :: sflx(pcols,pver+1)     !grid-box average ice/snow flux (kg m^-2s^-1) pverp
+    real(rtype) :: exner(pcols,pver)      !exner formula for converting between potential and normal temp
+    real(rtype) :: rcldm(pcols,pver)      !rain cloud fraction
+    real(rtype) :: lcldm(pcols,pver)      !liquid cloud fraction
+    real(rtype) :: icldm(pcols,pver)      !ice cloud fraction
 
     ! PBUF Variables
-    real(r8), pointer :: ast(:,:)      ! Relative humidity cloud fraction
-    real(r8), pointer :: cld(:,:)          ! Total cloud fraction
-    real(r8), pointer :: concld(:,:)       ! Convective cloud fraction
-    real(r8), pointer :: naai(:,:)      ! ice nucleation number
-    real(r8), pointer :: naai_hom(:,:)  ! ice nucleation number (homogeneous)
-    real(r8), pointer :: npccn(:,:)     ! liquid activation number tendency
-    real(r8), pointer :: rndst(:,:,:)
-    real(r8), pointer :: nacon(:,:,:)
-    real(r8), pointer :: cmeliq(:,:)
+    real(rtype), pointer :: ast(:,:)      ! Relative humidity cloud fraction
+    real(rtype), pointer :: cld(:,:)          ! Total cloud fraction
+    real(rtype), pointer :: concld(:,:)       ! Convective cloud fraction
+    real(rtype), pointer :: naai(:,:)      ! ice nucleation number
+    real(rtype), pointer :: naai_hom(:,:)  ! ice nucleation number (homogeneous)
+    real(rtype), pointer :: npccn(:,:)     ! liquid activation number tendency
+    real(rtype), pointer :: rndst(:,:,:)
+    real(rtype), pointer :: nacon(:,:,:)
+    real(rtype), pointer :: cmeliq(:,:)
     !! variables for heterogeneous freezing
-    real(r8), pointer :: frzimm(:,:)
-    real(r8), pointer :: frzcnt(:,:)
-    real(r8), pointer :: frzdep(:,:)
+    real(rtype), pointer :: frzimm(:,:)
+    real(rtype), pointer :: frzcnt(:,:)
+    real(rtype), pointer :: frzdep(:,:)
     !!
-    real(r8), pointer :: prec_str(:)          ! [Total] Sfc flux of precip from stratiform [ m/s ]
-    real(r8), pointer :: prec_sed(:)          ! Surface flux of total cloud water from sedimentation
-    real(r8), pointer :: prec_pcw(:)          ! Sfc flux of precip from microphysics [ m/s ]
-    real(r8), pointer :: snow_str(:)          ! [Total] Sfc flux of snow from stratiform   [ m/s ]
-    real(r8), pointer :: snow_pcw(:)          ! Sfc flux of snow from microphysics [ m/s ]
-    real(r8), pointer :: snow_sed(:)          ! Surface flux of cloud ice from sedimentation
-    real(r8), pointer :: relvar(:,:)       ! relative variance of cloud water
-    real(r8), pointer :: accre_enhan(:,:)  ! optional accretion enhancement for experimentation
-    real(r8), pointer :: cldo(:,:)         ! Old cloud fraction
-    real(r8), pointer :: prer_evap(:,:)    ! precipitation evaporation rate 
+    real(rtype), pointer :: prec_str(:)          ! [Total] Sfc flux of precip from stratiform [ m/s ]
+    real(rtype), pointer :: prec_sed(:)          ! Surface flux of total cloud water from sedimentation
+    real(rtype), pointer :: prec_pcw(:)          ! Sfc flux of precip from microphysics [ m/s ]
+    real(rtype), pointer :: snow_str(:)          ! [Total] Sfc flux of snow from stratiform   [ m/s ]
+    real(rtype), pointer :: snow_pcw(:)          ! Sfc flux of snow from microphysics [ m/s ]
+    real(rtype), pointer :: snow_sed(:)          ! Surface flux of cloud ice from sedimentation
+    real(rtype), pointer :: relvar(:,:)       ! relative variance of cloud water
+    real(rtype), pointer :: accre_enhan(:,:)  ! optional accretion enhancement for experimentation
+    real(rtype), pointer :: cldo(:,:)         ! Old cloud fraction
+    real(rtype), pointer :: prer_evap(:,:)    ! precipitation evaporation rate 
     !! wetdep 
-    real(r8), pointer :: qme(:,:)
-    real(r8), pointer :: prain(:,:)        ! Total precipitation (rain + snow)
-    real(r8), pointer :: nevapr(:,:)       ! Evaporation of total precipitation (rain + snow)
+    real(rtype), pointer :: qme(:,:)
+    real(rtype), pointer :: prain(:,:)        ! Total precipitation (rain + snow)
+    real(rtype), pointer :: nevapr(:,:)       ! Evaporation of total precipitation (rain + snow)
     !! COSP simulator
-    real(r8), pointer :: rel(:,:)          ! Liquid effective drop radius (microns)
-    real(r8), pointer :: rei(:,:)          ! Ice effective drop size (microns)
-    real(r8), pointer :: flxprc(:,:)     ! P3 grid-box mean flux_large_scale_cloud_rain+snow at interfaces (kg/m2/s)
-    real(r8), pointer :: flxsnw(:,:)     ! P3 grid-box mean flux_large_scale_cloud_snow at interfaces (kg/m2/s)
-    real(r8), pointer :: reffrain(:,:)   ! P3 diagnostic rain effective radius (um)
-    real(r8), pointer :: reffsnow(:,:)   ! P3 diagnostic snow effective radius (um)
-    real(r8), pointer :: cvreffliq(:,:)    ! convective cloud liquid effective radius (um)
-    real(r8), pointer :: cvreffice(:,:)    ! convective cloud ice effective radius (um)
+    real(rtype), pointer :: rel(:,:)          ! Liquid effective drop radius (microns)
+    real(rtype), pointer :: rei(:,:)          ! Ice effective drop size (microns)
+    real(rtype), pointer :: flxprc(:,:)     ! P3 grid-box mean flux_large_scale_cloud_rain+snow at interfaces (kg/m2/s)
+    real(rtype), pointer :: flxsnw(:,:)     ! P3 grid-box mean flux_large_scale_cloud_snow at interfaces (kg/m2/s)
+    real(rtype), pointer :: reffrain(:,:)   ! P3 diagnostic rain effective radius (um)
+    real(rtype), pointer :: reffsnow(:,:)   ! P3 diagnostic snow effective radius (um)
+    real(rtype), pointer :: cvreffliq(:,:)    ! convective cloud liquid effective radius (um)
+    real(rtype), pointer :: cvreffice(:,:)    ! convective cloud ice effective radius (um)
 
-    real(r8), pointer :: iciwpst(:,:)      ! Stratiform in-cloud ice water path for radiation
-    real(r8), pointer :: iclwpst(:,:)      ! Stratiform in-cloud liquid water path for radiation
+    real(rtype), pointer :: iciwpst(:,:)      ! Stratiform in-cloud ice water path for radiation
+    real(rtype), pointer :: iclwpst(:,:)      ! Stratiform in-cloud liquid water path for radiation
     !! radiation 
-    real(r8), pointer :: dei(:,:)          ! Ice effective diameter (um)
-    real(r8), pointer :: mu(:,:)           ! Size distribution shape parameter for radiation
-    real(r8), pointer :: lambdac(:,:)      ! Size distribution slope parameter for radiation
+    real(rtype), pointer :: dei(:,:)          ! Ice effective diameter (um)
+    real(rtype), pointer :: mu(:,:)           ! Size distribution shape parameter for radiation
+    real(rtype), pointer :: lambdac(:,:)      ! Size distribution slope parameter for radiation
     !! Park-Macro
-    real(r8), pointer :: cc_t(:,:)
-    real(r8), pointer :: cc_qv(:,:)
-    real(r8), pointer :: cc_ql(:,:)
-    real(r8), pointer :: cc_qi(:,:)
-    real(r8), pointer :: cc_nl(:,:)
-    real(r8), pointer :: cc_ni(:,:)
-    real(r8), pointer :: cc_qlst(:,:)
+    real(rtype), pointer :: cc_t(:,:)
+    real(rtype), pointer :: cc_qv(:,:)
+    real(rtype), pointer :: cc_ql(:,:)
+    real(rtype), pointer :: cc_qi(:,:)
+    real(rtype), pointer :: cc_nl(:,:)
+    real(rtype), pointer :: cc_ni(:,:)
+    real(rtype), pointer :: cc_qlst(:,:)
     !!
-    real(r8), pointer, dimension(:) :: acprecl ! accumulated precip across timesteps
-    real(r8), pointer, dimension(:) :: acgcme  ! accumulated condensation across timesteps
+    real(rtype), pointer, dimension(:) :: acprecl ! accumulated precip across timesteps
+    real(rtype), pointer, dimension(:) :: acgcme  ! accumulated condensation across timesteps
     integer,  pointer, dimension(:) :: acnum   ! counter for # timesteps accumulated
     ! DONE PBUF
 
     ! Derived Variables
-    real(r8) :: tgliqwp(pcols)   ! column liquid
-    real(r8) :: tgcmeliq(pcols)  ! column condensation rate (units)
-    real(r8) :: pe(pcols)        ! precip efficiency for output
-    real(r8) :: pefrac(pcols)    ! fraction of time precip efficiency is written out
-    real(r8) :: tpr(pcols)       ! average accumulated precipitation rate in pe calculation
-    real(r8) :: icimrst(pcols,pver) ! stratus ice mixing ratio - on grid
-    real(r8) :: icwmrst(pcols,pver) ! stratus water mixing ratio - on grid
-    real(r8) :: rho(pcols,pver)
-    real(r8) :: icecldf(state%psetcols,pver) ! Ice cloud fraction
-    real(r8) :: liqcldf(state%psetcols,pver) ! Liquid cloud fraction (combined into cloud)
-    real(r8) :: ncic(pcols,pver)
-    real(r8) :: niic(pcols,pver)
-    real(r8) :: rel_fn(pcols,pver)    ! Ice effective drop size at fixed number (indirect effect) (microns) - on grid
-    real(r8) :: nc(pcols,pver)
-    real(r8) :: drout2(pcols,pver)
-    real(r8) :: reff_rain(pcols,pver)
+    real(rtype) :: tgliqwp(pcols)   ! column liquid
+    real(rtype) :: tgcmeliq(pcols)  ! column condensation rate (units)
+    real(rtype) :: pe(pcols)        ! precip efficiency for output
+    real(rtype) :: pefrac(pcols)    ! fraction of time precip efficiency is written out
+    real(rtype) :: tpr(pcols)       ! average accumulated precipitation rate in pe calculation
+    real(rtype) :: icimrst(pcols,pver) ! stratus ice mixing ratio - on grid
+    real(rtype) :: icwmrst(pcols,pver) ! stratus water mixing ratio - on grid
+    real(rtype) :: rho(pcols,pver)
+    real(rtype) :: icecldf(state%psetcols,pver) ! Ice cloud fraction
+    real(rtype) :: liqcldf(state%psetcols,pver) ! Liquid cloud fraction (combined into cloud)
+    real(rtype) :: ncic(pcols,pver)
+    real(rtype) :: niic(pcols,pver)
+    real(rtype) :: rel_fn(pcols,pver)    ! Ice effective drop size at fixed number (indirect effect) (microns) - on grid
+    real(rtype) :: nc(pcols,pver)
+    real(rtype) :: drout2(pcols,pver)
+    real(rtype) :: reff_rain(pcols,pver)
 
     ! Variables used for microphysics output
-    real(r8) :: aqrain(pcols,pver)
-    real(r8) :: anrain(pcols,pver)
-    real(r8) :: nfice(pcols,pver)
-    real(r8) :: efcout(pcols,pver)      
-    real(r8) :: efiout(pcols,pver)      
-    real(r8) :: ncout(pcols,pver)      
-    real(r8) :: niout(pcols,pver)      
-    real(r8) :: freqr(pcols,pver)      
-    real(r8) :: freql(pcols,pver)      
-    real(r8) :: freqi(pcols,pver)      
-    real(r8) :: cdnumc(pcols)      
-    real(r8) :: icwmrst_out(pcols,pver) 
-    real(r8) :: icimrst_out(pcols,pver) 
-    real(r8) :: icinc(pcols,pver) 
-    real(r8) :: icwnc(pcols,pver) 
+    real(rtype) :: aqrain(pcols,pver)
+    real(rtype) :: anrain(pcols,pver)
+    real(rtype) :: nfice(pcols,pver)
+    real(rtype) :: efcout(pcols,pver)      
+    real(rtype) :: efiout(pcols,pver)      
+    real(rtype) :: ncout(pcols,pver)      
+    real(rtype) :: niout(pcols,pver)      
+    real(rtype) :: freqr(pcols,pver)      
+    real(rtype) :: freql(pcols,pver)      
+    real(rtype) :: freqi(pcols,pver)      
+    real(rtype) :: cdnumc(pcols)      
+    real(rtype) :: icwmrst_out(pcols,pver) 
+    real(rtype) :: icimrst_out(pcols,pver) 
+    real(rtype) :: icinc(pcols,pver) 
+    real(rtype) :: icwnc(pcols,pver) 
 
  
     integer :: it                      !timestep counter                       -
@@ -945,12 +946,12 @@ end subroutine micro_p3_readnl
     integer :: ngrdcol
 
     ! For rrtmg optics. specified distribution.
-    real(r8), parameter :: dcon   = 25.e-6_r8         ! Convective size distribution effective radius (um)
-    real(r8), parameter :: mucon  = 5.3_r8            ! Convective size distribution shape parameter
-    real(r8), parameter :: deicon = 50._r8            ! Convective ice effective diameter (um)
+    real(rtype), parameter :: dcon   = 25.e-6_rtype         ! Convective size distribution effective radius (um)
+    real(rtype), parameter :: mucon  = 5.3_rtype            ! Convective size distribution shape parameter
+    real(rtype), parameter :: deicon = 50._rtype            ! Convective ice effective diameter (um)
 
     ! For potential temperature conversion
-    real(r8) :: rd, cp, inv_cp
+    real(rtype) :: rd, cp, inv_cp
 
     psetcols = state%psetcols
     lchnk = state%lchnk
@@ -1084,7 +1085,7 @@ end subroutine micro_p3_readnl
     !              Return true on first step of initial run only.
     do icol = 1,ncol
        do k = 1,pver
-          exner(icol,k) = 1._r8/((state%pmid(icol,k)*1.e-5)**(rd*inv_cp))
+          exner(icol,k) = 1._rtype/((state%pmid(icol,k)*1.e-5)**(rd*inv_cp))
           if ( is_first_step() ) then
              th_old(icol,k)=state%t(icol,k)*exner(icol,k) !/(state%pmid(icol,k)*1.e-5)**(rd*inv_cp)
              qv_old(icol,k)=state%q(icol,k,1)
@@ -1129,7 +1130,7 @@ end subroutine micro_p3_readnl
     !(as we will set it initially), ssat is overwritten rather than used by p3.
     !Thus it shouldn't matter what ssat is, so we give it -999.
 
-    ssat(:,:) = -999._r8
+    ssat(:,:) = -999._rtype
 
     ! HANDLE TIMESTEP COUNTER
     !==============
@@ -1232,7 +1233,7 @@ end subroutine micro_p3_readnl
     !they are assigned here. The comments below are a step in that direction.
 
     !cloud_rad_props needs ice effective diameter, which Kai calculates as below:
-    !   dei = rei*diag_rhopo(i,k,iice)/rhows*2._r8
+    !   dei = rei*diag_rhopo(i,k,iice)/rhows*2._rtype
     !where rhopo is bulk ice density from table lookup (taken from f1pr16, but not 
     !done in my ver yet) and rhows=917.0 is a constant parameter.
 
@@ -1247,15 +1248,15 @@ end subroutine micro_p3_readnl
        do k = 1,pver
           temp(icol,k) = th(icol,k)/exner(icol,k) !*(state%pmid(icol,k)*1.e-5)**(rd*inv_cp) !convert theta to 
           ptend%s(icol,k)           = cpair*(temp(icol,k) - state%t(icol,k))/dtime ! changed cpair to 1005
-          ptend%q(icol,k,1)         = (max(0._r8,qv(icol,k)     ) - state%q(icol,k,1) )/dtime
-          ptend%q(icol,k,ixcldliq)  = (max(0._r8,cldliq(icol,k) ) - state%q(icol,k,ixcldliq) )/dtime
-          ptend%q(icol,k,ixnumliq)  = (max(0._r8,numliq(icol,k) ) - state%q(icol,k,ixnumliq) )/dtime
-          ptend%q(icol,k,ixrain)    = (max(0._r8,rain(icol,k)   ) - state%q(icol,k,ixrain) )/dtime
-          ptend%q(icol,k,ixnumrain) = (max(0._r8,numrain(icol,k)) - state%q(icol,k,ixnumrain) )/dtime
-          ptend%q(icol,k,ixcldice)  = (max(0._r8,ice(icol,k)    ) - state%q(icol,k,ixcldice) )/dtime
-          ptend%q(icol,k,ixnumice)  = (max(0._r8,numice(icol,k) ) - state%q(icol,k,ixnumice) )/dtime
-          ptend%q(icol,k,ixcldrim)  = (max(0._r8,rim(icol,k)    ) - state%q(icol,k,ixcldrim) )/dtime
-          ptend%q(icol,k,ixrimvol)  = (max(0._r8,rimvol(icol,k) ) - state%q(icol,k,ixrimvol) )/dtime
+          ptend%q(icol,k,1)         = (max(0._rtype,qv(icol,k)     ) - state%q(icol,k,1) )/dtime
+          ptend%q(icol,k,ixcldliq)  = (max(0._rtype,cldliq(icol,k) ) - state%q(icol,k,ixcldliq) )/dtime
+          ptend%q(icol,k,ixnumliq)  = (max(0._rtype,numliq(icol,k) ) - state%q(icol,k,ixnumliq) )/dtime
+          ptend%q(icol,k,ixrain)    = (max(0._rtype,rain(icol,k)   ) - state%q(icol,k,ixrain) )/dtime
+          ptend%q(icol,k,ixnumrain) = (max(0._rtype,numrain(icol,k)) - state%q(icol,k,ixnumrain) )/dtime
+          ptend%q(icol,k,ixcldice)  = (max(0._rtype,ice(icol,k)    ) - state%q(icol,k,ixcldice) )/dtime
+          ptend%q(icol,k,ixnumice)  = (max(0._rtype,numice(icol,k) ) - state%q(icol,k,ixnumice) )/dtime
+          ptend%q(icol,k,ixcldrim)  = (max(0._rtype,rim(icol,k)    ) - state%q(icol,k,ixcldrim) )/dtime
+          ptend%q(icol,k,ixrimvol)  = (max(0._rtype,rimvol(icol,k) ) - state%q(icol,k,ixrimvol) )/dtime
 
        end do
     end do
@@ -1268,11 +1269,11 @@ end subroutine micro_p3_readnl
     ! Do not subscript by ncol here, because in physpkg we divide the whole
     ! array and need to avoid an FPE due to uninitialized data.
     prec_pcw = prt_liq + prt_sol
-    prec_sed = 0._r8
+    prec_sed = 0._rtype
     prec_str = prec_pcw + prec_sed
 
     snow_pcw = prt_sol
-    snow_sed = 0._r8
+    snow_sed = 0._rtype
     snow_str = snow_pcw + snow_sed
       
    !icecldf(:ncol,top_lev:pver) = ast(:ncol,top_lev:pver)
@@ -1283,37 +1284,37 @@ end subroutine micro_p3_readnl
    ! Note that 'iclwp, iciwp' are used for radiation computation. !
    ! ------------------------------------------------------------ !
       
-   icinc = 0._r8
-   icwnc = 0._r8
-   iciwpst = 0._r8
-   iclwpst = 0._r8
+   icinc = 0._rtype
+   icwnc = 0._rtype
+   iciwpst = 0._rtype
+   iclwpst = 0._rtype
       
    do k = top_lev, pver
       do icol = 1, ncol
          ! Limits for in-cloud mixing ratios consistent with P3 microphysics
          ! in-cloud mixing ratio maximum limit of 0.005 kg/kg
-         icimrst(icol,k)   = min( state%q(icol,k,ixcldice) / max(mincld,icldm(icol,k)),0.005_r8 )
-         icwmrst(icol,k)   = min( state%q(icol,k,ixcldliq) / max(mincld,lcldm(icol,k)),0.005_r8 )
+         icimrst(icol,k)   = min( state%q(icol,k,ixcldice) / max(mincld,icldm(icol,k)),0.005_rtype )
+         icwmrst(icol,k)   = min( state%q(icol,k,ixcldliq) / max(mincld,lcldm(icol,k)),0.005_rtype )
          icinc(icol,k)     = state%q(icol,k,ixnumice) / max(mincld,icldm(icol,k)) * &
-              state%pmid(icol,k) / (287.15_r8*state%t(icol,k))
+              state%pmid(icol,k) / (287.15_rtype*state%t(icol,k))
          icwnc(icol,k)     = state%q(icol,k,ixnumliq) / max(mincld,lcldm(icol,k)) * &
-              state%pmid(icol,k) / (287.15_r8*state%t(icol,k))
+              state%pmid(icol,k) / (287.15_rtype*state%t(icol,k))
          ! Calculate micro_p3_acme cloud water paths in each layer
          ! Note: uses stratiform cloud fraction!
-         iciwpst(icol,k)   = min(state%q(icol,k,ixcldice)/max(mincld,ast(icol,k)),0.005_r8) * state%pdel(icol,k) / gravit
-         iclwpst(icol,k)   = min(state%q(icol,k,ixcldliq)/max(mincld,ast(icol,k)),0.005_r8) * state%pdel(icol,k) / gravit
+         iciwpst(icol,k)   = min(state%q(icol,k,ixcldice)/max(mincld,ast(icol,k)),0.005_rtype) * state%pdel(icol,k) / gravit
+         iclwpst(icol,k)   = min(state%q(icol,k,ixcldliq)/max(mincld,ast(icol,k)),0.005_rtype) * state%pdel(icol,k) / gravit
       end do                    
    end do
   
    ! array must be zeroed beyond trop_cloud_top_pre otherwise undefined values will be used in cosp.
-   flxprc(:ncol,1:top_lev) = 0.0_r8
-   flxsnw(:ncol,1:top_lev) = 0.0_r8
+   flxprc(:ncol,1:top_lev) = 0.0_rtype
+   flxsnw(:ncol,1:top_lev) = 0.0_rtype
 
    flxprc(:ncol,top_lev:pverp) = rflx(:ncol,top_lev:pverp) + sflx(:ncol,top_lev:pverp) ! need output from p3
    flxsnw(:ncol,top_lev:pverp) = sflx(:ncol,top_lev:pverp) ! need output from p3
 
-   cvreffliq(:ncol,top_lev:pver) = 9.0_r8
-   cvreffice(:ncol,top_lev:pver) = 37.0_r8
+   cvreffliq(:ncol,top_lev:pver) = 9.0_rtype
+   cvreffice(:ncol,top_lev:pver) = 37.0_rtype
 
     !note s=cp*T has units J/kg
 
@@ -1337,11 +1338,11 @@ end subroutine micro_p3_readnl
    !! Effective radius for cloud liquid, fixed number.
    !!
    
-   mu = 0._r8
-   lambdac = 0._r8
-   rel_fn = 10._r8
+   mu = 0._rtype
+   lambdac = 0._rtype
+   rel_fn = 10._rtype
 
-   ncic = 1.e8_r8
+   ncic = 1.e8_rtype
 
    !! size distribution 
    
@@ -1355,8 +1356,8 @@ end subroutine micro_p3_readnl
 
    where (icwmrst(:ngrdcol,top_lev:) > qsmall)
       rel_fn(:ngrdcol,top_lev:) = &
-                    (mu(:ngrdcol,top_lev:) + 3._r8)/ &
-                    lambdac(:ngrdcol,top_lev:)/2._r8 * 1.e6_r8
+                    (mu(:ngrdcol,top_lev:) + 3._rtype)/ &
+                    lambdac(:ngrdcol,top_lev:)/2._rtype * 1.e6_rtype
    end where
 
    !!
@@ -1364,9 +1365,9 @@ end subroutine micro_p3_readnl
    !! mu and lambdac.
    !!
    
-   mu = 0._r8
-   lambdac = 0._r8
-   rel = 10._r8
+   mu = 0._rtype
+   lambdac = 0._rtype
+   rel = 10._rtype
 
    !!
    !! Calculate ncic on the grid
@@ -1385,27 +1386,27 @@ end subroutine micro_p3_readnl
 
    where (icwmrst(:ngrdcol,top_lev:) >= qsmall)
       rel(:ngrdcol,top_lev:) = &
-           (mu(:ngrdcol,top_lev:) + 3._r8) / &
-           lambdac(:ngrdcol,top_lev:)/2._r8 * 1.e6_r8
+           (mu(:ngrdcol,top_lev:) + 3._rtype) / &
+           lambdac(:ngrdcol,top_lev:)/2._rtype * 1.e6_rtype
    elsewhere
       ! Deal with the fact that size_dist_param_liq sets mu to -100
       ! wherever there is no cloud.
-      mu(:ngrdcol,top_lev:) = 0._r8
+      mu(:ngrdcol,top_lev:) = 0._rtype
    end where
 
    !!
    !! Rain/Snow effective diameter
    !!
    
-   drout2    = 0._r8
-   reff_rain = 0._r8
-   aqrain    = 0._r8
-   anrain    = 0._r8
-   freqr     = 0._r8
+   drout2    = 0._rtype
+   reff_rain = 0._rtype
+   aqrain    = 0._rtype
+   anrain    = 0._rtype
+   freqr     = 0._rtype
 
       ! Prognostic precipitation
 
-      where (rain(:ngrdcol,top_lev:) >= 1.e-7_r8)
+      where (rain(:ngrdcol,top_lev:) >= 1.e-7_rtype)
          drout2(:ngrdcol,top_lev:) = avg_diameter( &
               rain(:ngrdcol,top_lev:), &
               numrain(:ngrdcol,top_lev:) * rho(:ngrdcol,top_lev:), &
@@ -1415,7 +1416,7 @@ end subroutine micro_p3_readnl
          anrain = numrain * rcldm
          freqr = rcldm
          reff_rain(:ngrdcol,top_lev:) = drout2(:ngrdcol,top_lev:) * &
-              1.5_r8 * 1.e6_r8
+              1.5_rtype * 1.e6_rtype
       end where
 
 
@@ -1423,7 +1424,7 @@ end subroutine micro_p3_readnl
    !! Effective radius and diameter for cloud ice
    !!
    
-   rei = 25._r8
+   rei = 25._rtype
 
    niic(:ngrdcol,top_lev:) = numice(:ngrdcol,top_lev:) / &
         max(mincld,icldm(:ngrdcol,top_lev:))
@@ -1436,12 +1437,12 @@ end subroutine micro_p3_readnl
 
    where (icimrst(:ngrdcol,top_lev:) >= qsmall)
       rei(:ngrdcol,top_lev:) = &
-         1.5_r8/rei(:ngrdcol,top_lev:) * 1.e6_r8
+         1.5_rtype/rei(:ngrdcol,top_lev:) * 1.e6_rtype
    elsewhere
-      rei(:ngrdcol,top_lev:) = 25._r8
+      rei(:ngrdcol,top_lev:) = 25._rtype
    end where
 
-   dei = rei * rhoi/rhows * 2._r8
+   dei = rei * rhoi/rhows * 2._rtype
 
    !!
    !! Limiters for low cloud fraction
@@ -1449,9 +1450,9 @@ end subroutine micro_p3_readnl
    
    do k = top_lev, pver
       do icol = 1, ngrdcol
-         if ( ast(icol,k) < 1.e-4_r8 ) then
+         if ( ast(icol,k) < 1.e-4_rtype ) then
             mu(icol,k) = mucon
-            lambdac(icol,k) = (mucon + 1._r8)/dcon
+            lambdac(icol,k) = (mucon + 1._rtype)/dcon
             dei(icol,k) = deicon
          end if
       end do
@@ -1460,7 +1461,7 @@ end subroutine micro_p3_readnl
    reffrain(:,:) = 0.d0
    reffsnow(:,:) = 0.d0
    reffrain(:ngrdcol,top_lev:pver) = reff_rain(:ngrdcol,top_lev:pver)
-   reffsnow(:ngrdcol,top_lev:pver) = 1000._r8 !! dummy value 
+   reffsnow(:ngrdcol,top_lev:pver) = 1000._rtype !! dummy value 
 
    ! ------------------------------------- !
    ! Precipitation efficiency Calculation  !
@@ -1470,13 +1471,13 @@ end subroutine micro_p3_readnl
    ! Liquid water path
 
    ! Compute liquid water paths, and column condensation
-   tgliqwp(:ngrdcol) = 0._r8
-   tgcmeliq(:ngrdcol) = 0._r8
+   tgliqwp(:ngrdcol) = 0._rtype
+   tgcmeliq(:ngrdcol) = 0._rtype
    do k = top_lev, pver
       do icol = 1, ngrdcol
          tgliqwp(icol)  = tgliqwp(icol) + iclwpst(icol,k)*cld(icol,k)
 
-         if (cmeliq(icol,k) > 1.e-12_r8) then
+         if (cmeliq(icol,k) > 1.e-12_rtype) then
             !convert cmeliq to right units:  kgh2o/kgair/s  *  kgair/m2  / kgh2o/m3  = m/s
             tgcmeliq(icol) = tgcmeliq(icol) + cmeliq(icol,k) * &
                  (state%pdel(icol,k) / gravit) / rhoh2o
@@ -1485,24 +1486,24 @@ end subroutine micro_p3_readnl
    end do
 
    ! Averaging for new output fields
-   efcout      = 0._r8
-   efiout      = 0._r8
-   ncout       = 0._r8
-   niout       = 0._r8
-   freql       = 0._r8
-   freqi       = 0._r8
-   cdnumc      = 0._r8
-   icwmrst_out = 0._r8
-   icimrst_out = 0._r8
-   nfice       = 0._r8
+   efcout      = 0._rtype
+   efiout      = 0._rtype
+   ncout       = 0._rtype
+   niout       = 0._rtype
+   freql       = 0._rtype
+   freqi       = 0._rtype
+   cdnumc      = 0._rtype
+   icwmrst_out = 0._rtype
+   icimrst_out = 0._rtype
+   nfice       = 0._rtype
 
    ! FICE
    do k = top_lev, pver
       do icol = 1, ngrdcol
       if (ice(icol,k).gt.qsmall .and. (rain(icol,k)+ice(icol,k)+cldliq(icol,k)).gt.qsmall) then
-         nfice(icol,k)=min(ice(icol,k)/(rain(icol,k)+ice(icol,k)+cldliq(icol,k)),1._r8)
+         nfice(icol,k)=min(ice(icol,k)/(rain(icol,k)+ice(icol,k)+cldliq(icol,k)),1._rtype)
       else
-         nfice(icol,k)=0._r8
+         nfice(icol,k)=0._rtype
       end if
       end do
    end do
@@ -1512,13 +1513,13 @@ end subroutine micro_p3_readnl
         state%pdel(:ngrdcol,top_lev:pver)/gravit, dim=2)
    do k = top_lev, pver
       do icol = 1, ngrdcol
-         if ( lcldm(icol,k) > 0.01_r8 .and. icwmrst(icol,k) > 5.e-5_r8 ) then
+         if ( lcldm(icol,k) > 0.01_rtype .and. icwmrst(icol,k) > 5.e-5_rtype ) then
             efcout(icol,k) = rel(icol,k) * lcldm(icol,k)
             ncout(icol,k)  = icwnc(icol,k) * lcldm(icol,k)
             freql(icol,k)  = lcldm(icol,k)
             icwmrst_out(icol,k) = icwmrst(icol,k)
          end if
-         if ( icldm(icol,k) > 0.01_r8 .and. icimrst(icol,k) > 1.e-6_r8 ) then
+         if ( icldm(icol,k) > 0.01_rtype .and. icimrst(icol,k) > 1.e-6_rtype ) then
             efiout(icol,k) = rei(icol,k) * icldm(icol,k)
             niout(icol,k)  = icinc(icol,k) * icldm(icol,k)
             freqi(icol,k)  = icldm(icol,k)

--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -135,8 +135,8 @@ end interface var_coef
     real(rtype), intent(in) :: cpliq
     real(rtype), intent(in) :: tmelt
     real(rtype), intent(in) :: pi
-    integer(itype), intent(in) :: iulog
-    logical, intent(in)  :: masterproc
+    integer, intent(in)     :: iulog
+    logical, intent(in)     :: masterproc
 
     real(rtype) :: ice_lambda_bounds(2)
 

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -77,8 +77,8 @@ contains
        end if
     end if
 
-    call micro_p3_utils_init(cpair,rair,rh2o,rhoh2o,mwh2o,mwdry,gravit,latvap,latice, &
-                   cpliq,tmelt,pi,iulog,masterproc)
+    call micro_p3_utils_init(Cpair,Rair,RH2O,RhoH2O,MWH2O,MWDry,gravit,LatVap,LatIce, &
+                   CpLiq,Tmelt,Pi,iulog,masterproc)
   end subroutine p3_init_c
 
   subroutine p3_main_c(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
@@ -123,23 +123,23 @@ contains
                  MWH2O, MWdry, gravit, LatVap, LatIce,        &
                  CpLiq, Tmelt, Pi, iulog, masterproc) bind(C)
 
-    real(kind=c_real), intent(in) :: cpair
-    real(kind=c_real), intent(in) :: rair
-    real(kind=c_real), intent(in) :: rh2o
-    real(kind=c_real), intent(in) :: rhoh2o
-    real(kind=c_real), intent(in) :: mwh2o
-    real(kind=c_real), intent(in) :: mwdry
+    real(kind=c_real), intent(in) :: Cpair
+    real(kind=c_real), intent(in) :: Rair
+    real(kind=c_real), intent(in) :: RH2O
+    real(kind=c_real), intent(in) :: RhoH2O
+    real(kind=c_real), intent(in) :: MWH2O
+    real(kind=c_real), intent(in) :: MWdry
     real(kind=c_real), intent(in) :: gravit
-    real(kind=c_real), intent(in) :: latvap
-    real(kind=c_real), intent(in) :: latice
-    real(kind=c_real), intent(in) :: cpliq
-    real(kind=c_real), intent(in) :: tmelt
-    real(kind=c_real), intent(in) :: pi
+    real(kind=c_real), intent(in) :: LatVap
+    real(kind=c_real), intent(in) :: LatIce
+    real(kind=c_real), intent(in) :: CpLiq
+    real(kind=c_real), intent(in) :: Tmelt
+    real(kind=c_real), intent(in) :: Pi
     integer(kind=c_int),value, intent(in) :: iulog
     logical(kind=c_bool), value, intent(in)  :: masterproc
 
-    call micro_p3_utils_init(cpair,rair,rh2o,rhoh2o,mwh2o,mwdry,gravit,latvap,latice, &
-                   cpliq,tmelt,pi,iulog,masterproc)
+    call micro_p3_utils_init(Cpair,Rair,RH2O,RhoH2O,MWH2O,MWdry,gravit,LatVap,LatIce, &
+                   CpLiq,Tmelt,Pi,iulog,masterproc)
   end subroutine micro_p3_utils_init_c
 
 end module micro_p3_iso_c

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -116,4 +116,29 @@ contains
          diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
          pdel,exner,ast,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm)
   end subroutine p3_main_c
+
+   
+  subroutine micro_p3_utils_init_c(Cpair, Rair, RH2O, RhoH2O, &
+                 MWH2O, MWdry, gravit, LatVap, LatIce,        &
+                 CpLiq, Tmelt, Pi, iulog, masterproc) bind(C)
+
+    real(kind=c_real), intent(in) :: cpair
+    real(kind=c_real), intent(in) :: rair
+    real(kind=c_real), intent(in) :: rh2o
+    real(kind=c_real), intent(in) :: rhoh2o
+    real(kind=c_real), intent(in) :: mwh2o
+    real(kind=c_real), intent(in) :: mwdry
+    real(kind=c_real), intent(in) :: gravit
+    real(kind=c_real), intent(in) :: latvap
+    real(kind=c_real), intent(in) :: latice
+    real(kind=c_real), intent(in) :: cpliq
+    real(kind=c_real), intent(in) :: tmelt
+    real(kind=c_real), intent(in) :: pi
+    integer(kind=c_int),value, intent(in) :: iulog
+    logical(kind=c_bool), value, intent(in)  :: masterproc
+
+    call micro_p3_utils_init(cpair,rair,rh2o,rhoh2o,mwh2o,mwdry,gravit,latvap,latice, &
+                   cpliq,tmelt,pi,iulog,masterproc)
+  end subroutine micro_p3_utils_init_c
+
 end module micro_p3_iso_c

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -77,8 +77,6 @@ contains
        end if
     end if
 
-    call micro_p3_utils_init(Cpair,Rair,RH2O,RhoH2O,MWH2O,MWDry,gravit,LatVap,LatIce, &
-                   CpLiq,Tmelt,Pi,iulog,masterproc)
   end subroutine p3_init_c
 
   subroutine p3_main_c(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
@@ -123,19 +121,19 @@ contains
                  MWH2O, MWdry, gravit, LatVap, LatIce,        &
                  CpLiq, Tmelt, Pi, iulog, masterproc) bind(C)
 
-    real(kind=c_real), intent(in) :: Cpair
-    real(kind=c_real), intent(in) :: Rair
-    real(kind=c_real), intent(in) :: RH2O
-    real(kind=c_real), intent(in) :: RhoH2O
-    real(kind=c_real), intent(in) :: MWH2O
-    real(kind=c_real), intent(in) :: MWdry
-    real(kind=c_real), intent(in) :: gravit
-    real(kind=c_real), intent(in) :: LatVap
-    real(kind=c_real), intent(in) :: LatIce
-    real(kind=c_real), intent(in) :: CpLiq
-    real(kind=c_real), intent(in) :: Tmelt
-    real(kind=c_real), intent(in) :: Pi
-    integer(kind=c_int),value, intent(in) :: iulog
+    real(kind=c_real), value, intent(in) :: Cpair
+    real(kind=c_real), value, intent(in) :: Rair
+    real(kind=c_real), value, intent(in) :: RH2O
+    real(kind=c_real), value, intent(in) :: RhoH2O
+    real(kind=c_real), value, intent(in) :: MWH2O
+    real(kind=c_real), value, intent(in) :: MWdry
+    real(kind=c_real), value, intent(in) :: gravit
+    real(kind=c_real), value, intent(in) :: LatVap
+    real(kind=c_real), value, intent(in) :: LatIce
+    real(kind=c_real), value, intent(in) :: CpLiq
+    real(kind=c_real), value, intent(in) :: Tmelt
+    real(kind=c_real), value, intent(in) :: Pi
+    integer(kind=c_int), value, intent(in) :: iulog
     logical(kind=c_bool), value, intent(in)  :: masterproc
 
     call micro_p3_utils_init(Cpair,Rair,RH2O,RhoH2O,MWH2O,MWdry,gravit,LatVap,LatIce, &

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -77,7 +77,6 @@ contains
        end if
     end if
 
-    call micro_p3_utils_init()
   end subroutine p3_init_c
 
   subroutine p3_main_c(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -77,6 +77,8 @@ contains
        end if
     end if
 
+    call micro_p3_utils_init(cpair,rair,rh2o,rhoh2o,mwh2o,mwdry,gravit,latvap,latice, &
+                   cpliq,tmelt,pi,iulog,masterproc)
   end subroutine p3_init_c
 
   subroutine p3_main_c(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -118,7 +118,7 @@ contains
    
   subroutine micro_p3_utils_init_c(Cpair, Rair, RH2O, RhoH2O, &
                  MWH2O, MWdry, gravit, LatVap, LatIce,        &
-                 CpLiq, Tmelt, Pi, iulog, masterproc) bind(C)
+                 CpLiq, Tmelt, Pi, iulog_in, masterproc_in) bind(C)
 
     use micro_p3_utils, only: micro_p3_utils_init
     real(kind=c_real), value, intent(in) :: Cpair
@@ -133,11 +133,17 @@ contains
     real(kind=c_real), value, intent(in) :: CpLiq
     real(kind=c_real), value, intent(in) :: Tmelt
     real(kind=c_real), value, intent(in) :: Pi
-    integer(kind=c_int), value, intent(in) :: iulog
-    logical(kind=c_bool), value, intent(in)  :: masterproc
+    integer(kind=c_int), value, intent(in) :: iulog_in
+    logical(kind=c_bool), value, intent(in)  :: masterproc_in
+
+    logical :: masterproc
+    integer :: iulog
+
+    masterproc = masterproc_in
+    iulog = iulog_in
 
     call micro_p3_utils_init(Cpair,Rair,RH2O,RhoH2O,MWH2O,MWdry,gravit,LatVap,LatIce, &
-                   CpLiq,Tmelt,Pi,iulog,masterproc)
+                   CpLiq,Tmelt,Pi,98,masterproc)
   end subroutine micro_p3_utils_init_c
 
 end module micro_p3_iso_c

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -23,7 +23,6 @@ contains
   subroutine p3_init_c(lookup_file_dir_c, info) bind(c)
     use array_io_mod
     use micro_p3, only: p3_init_a, p3_init_b, p3_set_tables, p3_get_tables
-    use micro_p3_utils, only: micro_p3_utils_init
 
     type(c_ptr), intent(in) :: lookup_file_dir_c
     integer(kind=c_int), intent(out) :: info
@@ -121,6 +120,7 @@ contains
                  MWH2O, MWdry, gravit, LatVap, LatIce,        &
                  CpLiq, Tmelt, Pi, iulog, masterproc) bind(C)
 
+    use micro_p3_utils, only: micro_p3_utils_init
     real(kind=c_real), value, intent(in) :: Cpair
     real(kind=c_real), value, intent(in) :: Rair
     real(kind=c_real), value, intent(in) :: RH2O

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -133,7 +133,7 @@ contains
     real(kind=c_real), value, intent(in) :: CpLiq
     real(kind=c_real), value, intent(in) :: Tmelt
     real(kind=c_real), value, intent(in) :: Pi
-    integer(kind=c_int), value, intent(in) :: iulog_in
+    integer(kind=c_int), value, intent(in)   :: iulog_in
     logical(kind=c_bool), value, intent(in)  :: masterproc_in
 
     logical :: masterproc
@@ -143,7 +143,7 @@ contains
     iulog = iulog_in
 
     call micro_p3_utils_init(Cpair,Rair,RH2O,RhoH2O,MWH2O,MWdry,gravit,LatVap,LatIce, &
-                   CpLiq,Tmelt,Pi,98,masterproc)
+                   CpLiq,Tmelt,Pi,iulog,masterproc)
   end subroutine micro_p3_utils_init_c
 
 end module micro_p3_iso_c

--- a/components/scream/src/physics/p3/p3_constants.hpp
+++ b/components/scream/src/physics/p3/p3_constants.hpp
@@ -27,7 +27,7 @@ struct Constants
   static constexpr Scalar CpLiq       = 4188.0;
   static constexpr Scalar Tmelt       = 273.15;
   static constexpr Scalar Pi          = 3.14159265;
-  static constexpr int    iulog       = 98;
+  static constexpr long long int    iulog       = 98;
   static constexpr bool   masterproc  = true;
   static constexpr Scalar RHOW     = RhoH2O;
   static constexpr Scalar INV_RHOW = 1.0/RHOW;

--- a/components/scream/src/physics/p3/p3_constants.hpp
+++ b/components/scream/src/physics/p3/p3_constants.hpp
@@ -15,11 +15,24 @@ namespace p3 {
 template <typename Scalar>
 struct Constants
 {
-  static constexpr Scalar RHOW     = 997.0;
+  static constexpr Scalar Cpair       = 1004.64;
+  static constexpr Scalar Rair        = 287.042;
+  static constexpr Scalar RH2O        = 461.505;
+  static constexpr Scalar RhoH2O      = 1000.0;
+  static constexpr Scalar MWH2O       = 18.016;
+  static constexpr Scalar MWdry       = 28.966;
+  static constexpr Scalar gravit      = 9.80616;
+  static constexpr Scalar LatVap      = 2501000.0;
+  static constexpr Scalar LatIce      = 333700.0;
+  static constexpr Scalar CpLiq       = 4188.0;
+  static constexpr Scalar Tmelt       = 273.15;
+  static constexpr Scalar Pi          = 3.14159265;
+  static constexpr int    iulog       = 98;
+  static constexpr bool   masterproc  = true;
+  static constexpr Scalar RHOW     = RhoH2O;
   static constexpr Scalar INV_RHOW = 1.0/RHOW;
   static constexpr Scalar THIRD    = 1.0/3.0;
   static constexpr Scalar SXTH     = 1.0/6.0;
-  static constexpr Scalar PI       = 3.14159265;
   static constexpr Scalar PIOV6    = PI*SXTH;
   static constexpr Scalar CONS1    = PIOV6*RHOW;
   static constexpr Scalar QSMALL   = 1.e-14;
@@ -27,7 +40,7 @@ struct Constants
   static constexpr Scalar P0       = 100000.0;        // reference pressure, Pa
   static constexpr Scalar RD       = 287.15;          // gas constant for dry air, J/kg/K
   static constexpr Scalar RHOSUR   = P0/(RD*273.15);
-  static constexpr Scalar CP       = 1005.0;          // heat constant of air at constant pressure, J/kg
+  static constexpr Scalar CP       = Cpair;          // heat constant of air at constant pressure, J/kg
   static constexpr Scalar INV_CP   = 1.0/CP;
 };
 

--- a/components/scream/src/physics/p3/p3_constants.hpp
+++ b/components/scream/src/physics/p3/p3_constants.hpp
@@ -33,7 +33,7 @@ struct Constants
   static constexpr Scalar INV_RHOW = 1.0/RHOW;
   static constexpr Scalar THIRD    = 1.0/3.0;
   static constexpr Scalar SXTH     = 1.0/6.0;
-  static constexpr Scalar PIOV6    = PI*SXTH;
+  static constexpr Scalar PIOV6    = Pi*SXTH;
   static constexpr Scalar CONS1    = PIOV6*RHOW;
   static constexpr Scalar QSMALL   = 1.e-14;
   static constexpr Scalar NSMALL   = 1.e-16;

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -7,6 +7,9 @@
 using scream::Real;
 using scream::Int;
 extern "C" {
+  void micro_p3_utils_init_c(Real Cpair, Real Rair, Real RH2O, Real RhoH2O, 
+                 Real MWH2O, Real MWdry, Real gravit, Real LatVap, Real LatIce, 
+                 Real CpLiq, Real Tmelt, Real Pi, Int iulog, bool masterproc)
   void p3_init_c(const char** lookup_file_dir, int* info);
   void p3_main_c(Real* qc, Real* nc, Real* qr, Real* nr, Real* th_old, Real* th,
                  Real* qv_old, Real* qv, Real dt, Real* qitot, Real* qirim,
@@ -99,6 +102,12 @@ const FortranDataIterator::RawArray&
 FortranDataIterator::getfield (Int i) const {
   scream_assert(i >= 0 || i < nfield());
   return fields_[i];
+}
+
+void micro_p3_utils_init (const FortranData& d) {
+  micro_p3_utils_init_c(d.Cpair, d.Rair, d.RH2O, d.RhoH2O, 
+                 d.MWH2O, d.MWdry, d.gravit, d.LatVap, d.LatIce, 
+                 d.CpLiq, d.Tmelt, d.Pi, d.iulog, d.masterproc)
 }
 
 void p3_init () {

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -1,4 +1,5 @@
 #include "p3_f90.hpp"
+#include "p3_constants.hpp"
 #include "p3_ic_cases.hpp"
 
 #include "share/scream_assert.hpp"
@@ -9,7 +10,7 @@ using scream::Int;
 extern "C" {
   void micro_p3_utils_init_c(Real Cpair, Real Rair, Real RH2O, Real RhoH2O, 
                  Real MWH2O, Real MWdry, Real gravit, Real LatVap, Real LatIce, 
-                 Real CpLiq, Real Tmelt, Real Pi, Int iulog, bool masterproc)
+                 Real CpLiq, Real Tmelt, Real Pi, Int iulog, bool masterproc);
   void p3_init_c(const char** lookup_file_dir, int* info);
   void p3_main_c(Real* qc, Real* nc, Real* qr, Real* nr, Real* th_old, Real* th,
                  Real* qv_old, Real* qv, Real dt, Real* qitot, Real* qirim,
@@ -105,9 +106,10 @@ FortranDataIterator::getfield (Int i) const {
 }
 
 void micro_p3_utils_init (const FortranData& d) {
-  micro_p3_utils_init_c(d.Cpair, d.Rair, d.RH2O, d.RhoH2O, 
-                 d.MWH2O, d.MWdry, d.gravit, d.LatVap, d.LatIce, 
-                 d.CpLiq, d.Tmelt, d.Pi, d.iulog, d.masterproc)
+  using c = Constants<double>;
+  micro_p3_utils_init_c(c::Cpair, c::Rair, c::RH2O, c::RhoH2O, 
+                 c::MWH2O, c::MWdry, c::gravit, c::LatVap, c::LatIce, 
+                 c::CpLiq, c::Tmelt, c::Pi, c::iulog, c::masterproc);
 }
 
 void p3_init () {


### PR DESCRIPTION
This commit removes all dependencies on EAM modules for the
standalone p3 modules; micro_p3.F90 and micro_p3_utils.F90.

The only dependency that is retained is for the designation of real
and integer precision (r8 and i8) which is taken from CIME in EAM.
A compile time directive is used to determine if running in standalone
mode or in EAM.  If in EAM then the CIME defintion is used for consistency.

In addition, the real type and integer type variables have been changed
from r8 and i8 to rtype and itype respectively.  This is to make the
variable names more general and remove the implied implementation (8-byte real)
that the old names have.