### PR TITLE
Write P3 microphysics tendencies to output file

### DIFF
--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -742,6 +742,46 @@ end subroutine micro_p3_readnl
 !      call addfld('QCRAT', (/ 'lev' /), 'A', 'fraction', 'Qc Limiter: Fraction of qc tendency applied')
 !   end if
 
+   ! Record of microphysics tendencies
+   ! warm-phase process rates
+   call addfld('P3_qrcon',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for rain condensation   (Not in paper?)')
+   call addfld('P3_qcacc',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for cloud droplet accretion by rain')
+   call addfld('P3_qcaut',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for cloud droplet autoconversion to rain')
+   call addfld('P3_ncacc',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in cloud droplet number from accretion by rain')
+   call addfld('P3_ncautc', (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in cloud droplet number from autoconversion')
+   call addfld('P3_ncslf',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in cloud droplet number from self-collection  (Not in paper?)')
+   call addfld('P3_nrslf',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in rain number from self-collection  (Not in paper?)')
+   call addfld('P3_ncnuc',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in cloud droplet number from activation of CCN')
+   call addfld('P3_qccon',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for cloud droplet condensation')
+   call addfld('P3_qcnuc',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for activation of cloud droplets from CCN')
+   call addfld('P3_qrevp',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for rain evaporation')
+   call addfld('P3_qcevp',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for cloud droplet evaporation')
+   call addfld('P3_nrevp',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in rain number from evaporation')
+   call addfld('P3_ncautr', (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in rain number from autoconversion of cloud water')
+   ! ice-phase process rates
+   call addfld('P3_qccol',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for collection of cloud water by ice')
+   call addfld('P3_qwgrth', (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for wet growth rate')
+   call addfld('P3_qidep',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for vapor deposition')
+   call addfld('P3_qrcol',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for collection rain mass by ice')
+   call addfld('P3_qinuc',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for deposition/condensation freezing nuc')
+   call addfld('P3_nccol',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in cloud droplet number from collection by ice')
+   call addfld('P3_nrcol',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in rain number from collection by ice')
+   call addfld('P3_ninuc',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in ice number from deposition/cond-freezing nucleation')
+   call addfld('P3_qisub',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for sublimation of ice')
+   call addfld('P3_qimlt',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for melting of ice')
+   call addfld('P3_nimlt',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for melting of ice')
+   call addfld('P3_nisub',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in ice number from sublimation')
+   call addfld('P3_nislf',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in ice number from collection within a category (Not in paper?)')
+   call addfld('P3_qcheti', (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for immersion freezing droplets')
+   call addfld('P3_qrheti', (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for immersion freezing rain')
+   call addfld('P3_ncheti', (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for immersion freezing droplets')
+   call addfld('P3_nrheti', (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for immersion freezing rain')
+   call addfld('P3_nrshdr', (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for source for rain number from collision of rain/ice above freezing and shedding')
+   call addfld('P3_qcshd',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for source for rain mass due to cloud water/ice collision above freezing and shedding or wet growth and shedding')
+   call addfld('P3_qcmul',  (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for change in q, ice multiplication from rime-splitnering of cloud water (not included in the paper)')
+   call addfld('P3_ncshdc', (/ 'lev' /), 'A', 'kg/kg/s', 'P3 Tendency for source for rain number due to cloud water/ice collision above freezing  and shedding (combined with NRSHD in the paper)')
+
+
    ! determine the add_default fields
    call phys_getopts(history_amwg_out           = history_amwg         , &
                      history_verbose_out        = history_verbose      , &
@@ -775,6 +815,45 @@ end subroutine micro_p3_readnl
       call add_default ('CLOUDFRAC_LIQ_MICRO', 1, ' ')
       call add_default ('CLOUDFRAC_ICE_MICRO', 1, ' ')
       call add_default ('CLOUDFRAC_RAIN_MICRO', 1, ' ')
+      ! Microphysics tendencies !TODO, AaronDonahue, would like to make this a
+      ! namelist option instead of hardcoded as default output
+      ! warm-phase process rates
+      call add_default('P3_qrcon',  1, ' ')
+      call add_default('P3_qcacc',  1, ' ')
+      call add_default('P3_qcaut',  1, ' ')
+      call add_default('P3_ncacc',  1, ' ')
+      call add_default('P3_ncautc', 1, ' ')
+      call add_default('P3_ncslf',  1, ' ')
+      call add_default('P3_nrslf',  1, ' ')
+      call add_default('P3_ncnuc',  1, ' ')
+      call add_default('P3_qccon',  1, ' ')
+      call add_default('P3_qcnuc',  1, ' ')
+      call add_default('P3_qrevp',  1, ' ')
+      call add_default('P3_qcevp',  1, ' ')
+      call add_default('P3_nrevp',  1, ' ')
+      call add_default('P3_ncautr', 1, ' ')
+      ! ice-phase process rates
+      call add_default('P3_qccol',  1, ' ')
+      call add_default('P3_qwgrth', 1, ' ')
+      call add_default('P3_qidep',  1, ' ')
+      call add_default('P3_qrcol',  1, ' ')
+      call add_default('P3_qinuc',  1, ' ')
+      call add_default('P3_nccol',  1, ' ')
+      call add_default('P3_nrcol',  1, ' ')
+      call add_default('P3_ninuc',  1, ' ')
+      call add_default('P3_qisub',  1, ' ')
+      call add_default('P3_qimlt',  1, ' ')
+      call add_default('P3_nimlt',  1, ' ')
+      call add_default('P3_nisub',  1, ' ')
+      call add_default('P3_nislf',  1, ' ')
+      call add_default('P3_qcheti', 1, ' ')
+      call add_default('P3_qrheti', 1, ' ')
+      call add_default('P3_ncheti', 1, ' ')
+      call add_default('P3_nrheti', 1, ' ')
+      call add_default('P3_nrshdr', 1, ' ')
+      call add_default('P3_qcshd',  1, ' ')
+      call add_default('P3_qcmul',  1, ' ')
+      call add_default('P3_ncshdc', 1, ' ')
    end if
 
   end subroutine micro_p3_init
@@ -837,6 +916,7 @@ end subroutine micro_p3_readnl
     real(rtype) :: rcldm(pcols,pver)      !rain cloud fraction
     real(rtype) :: lcldm(pcols,pver)      !liquid cloud fraction
     real(rtype) :: icldm(pcols,pver)      !ice cloud fraction
+    real(rtype) :: tend_out(pcols,pver,35) !microphysical tendencies
 
     ! PBUF Variables
     real(rtype), pointer :: ast(:,:)      ! Relative humidity cloud fraction
@@ -1214,7 +1294,8 @@ end subroutine micro_p3_readnl
          sflx(its:ite,kts:kte+1),     & ! OUT grid-box average ice/snow flux (kgm^-2 s^-1) pverp
          rcldm(its:ite,kts:kte),      & ! OUT rain cloud fraction
          lcldm(its:ite,kts:kte),      & ! OUT liquid cloud fraction
-         icldm(its:ite,kts:kte)       & ! OUT ice cloud fraction
+         icldm(its:ite,kts:kte),      & ! OUT ice cloud fraction
+         tend_out(its:ite,kts:kte,:)  & ! OUT p3 microphysics tendencies
          )
 
     ! UPDATE TH AND QV OLD FOR NEXT P3 STEP
@@ -1554,6 +1635,45 @@ end subroutine micro_p3_readnl
 !   call outfld('FREQS',       freqs,       psetcols, lchnk, avg_subcol_field=use_subcol_microp)
 !   call outfld('ANSNOW',      nsout2,      psetcols, lchnk, avg_subcol_field=use_subcol_microp)
 !   call outfld('AQSNOW',      qsout2,      psetcols, lchnk, avg_subcol_field=use_subcol_microp)
+
+   ! Write p3 tendencies as output 
+   ! warm-phase process rates
+   call outfld('P3_qrcon',  tend_out(:,:, 1), pcols, lchnk) 
+   call outfld('P3_qcacc',  tend_out(:,:, 2), pcols, lchnk) 
+   call outfld('P3_qcaut',  tend_out(:,:, 3), pcols, lchnk) 
+   call outfld('P3_ncacc',  tend_out(:,:, 4), pcols, lchnk) 
+   call outfld('P3_ncautc', tend_out(:,:, 5), pcols, lchnk) 
+   call outfld('P3_ncslf',  tend_out(:,:, 6), pcols, lchnk) 
+   call outfld('P3_nrslf',  tend_out(:,:, 7), pcols, lchnk) 
+   call outfld('P3_ncnuc',  tend_out(:,:, 8), pcols, lchnk) 
+   call outfld('P3_qccon',  tend_out(:,:, 9), pcols, lchnk) 
+   call outfld('P3_qcnuc',  tend_out(:,:,10), pcols, lchnk) 
+   call outfld('P3_qrevp',  tend_out(:,:,11), pcols, lchnk) 
+   call outfld('P3_qcevp',  tend_out(:,:,12), pcols, lchnk) 
+   call outfld('P3_nrevp',  tend_out(:,:,13), pcols, lchnk) 
+   call outfld('P3_ncautr', tend_out(:,:,14), pcols, lchnk) 
+   ! ice-phase process rate
+   call outfld('P3_qccol',  tend_out(:,:,15), pcols, lchnk) 
+   call outfld('P3_qwgrth', tend_out(:,:,16), pcols, lchnk) 
+   call outfld('P3_qidep',  tend_out(:,:,17), pcols, lchnk) 
+   call outfld('P3_qrcol',  tend_out(:,:,18), pcols, lchnk) 
+   call outfld('P3_qinuc',  tend_out(:,:,19), pcols, lchnk) 
+   call outfld('P3_nccol',  tend_out(:,:,20), pcols, lchnk) 
+   call outfld('P3_nrcol',  tend_out(:,:,21), pcols, lchnk) 
+   call outfld('P3_ninuc',  tend_out(:,:,22), pcols, lchnk) 
+   call outfld('P3_qisub',  tend_out(:,:,23), pcols, lchnk) 
+   call outfld('P3_qimlt',  tend_out(:,:,24), pcols, lchnk) 
+   call outfld('P3_nimlt',  tend_out(:,:,25), pcols, lchnk) 
+   call outfld('P3_nisub',  tend_out(:,:,26), pcols, lchnk) 
+   call outfld('P3_nislf',  tend_out(:,:,27), pcols, lchnk) 
+   call outfld('P3_qcheti', tend_out(:,:,28), pcols, lchnk) 
+   call outfld('P3_qrheti', tend_out(:,:,29), pcols, lchnk) 
+   call outfld('P3_ncheti', tend_out(:,:,30), pcols, lchnk) 
+   call outfld('P3_nrheti', tend_out(:,:,31), pcols, lchnk) 
+   call outfld('P3_nrshdr', tend_out(:,:,32), pcols, lchnk) 
+   call outfld('P3_qcshd',  tend_out(:,:,33), pcols, lchnk) 
+   call outfld('P3_qcmul',  tend_out(:,:,34), pcols, lchnk) 
+   call outfld('P3_ncshdc', tend_out(:,:,35), pcols, lchnk) 
     
     !call outfld('P3_QCAUT',   qcaut,  pcols, lchnk)
 

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -81,7 +81,7 @@ contains
   subroutine p3_main_c(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
        pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
        diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc_in, &
-       pdel,exner,ast,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm) bind(C)
+       pdel,exner,ast,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out) bind(C)
     use micro_p3, only : p3_main
 
     real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, ssat, qv, th, th_old, qv_old
@@ -104,6 +104,7 @@ contains
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte+1)    :: sflx
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: ast
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: icldm, lcldm, rcldm
+    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte,35)   :: p3_tend_out
 
     logical :: log_predictNc
 
@@ -112,7 +113,7 @@ contains
     call p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
          pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
          diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
-         pdel,exner,ast,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm)
+         pdel,exner,ast,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out)
   end subroutine p3_main_c
 
    

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -23,7 +23,7 @@ extern "C" {
                  Real* pdel, Real* exner, Real* ast, Real* cmeiout, Real* prain,
                  Real* nevapr, Real* prer_evap,
                  Real* rflx, Real* sflx, // 1 extra column size
-                 Real* rcldm, Real* lcldm, Real* icldm);
+                 Real* rcldm, Real* lcldm, Real* icldm, Real* p3_tend_out);
 }
 
 namespace scream {
@@ -72,6 +72,7 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   rcldm = Array2("Rain cloud fraction", ncol, nlev);
   lcldm = Array2("Liquid cloud fraction", ncol, nlev);
   icldm = Array2("Ice cloud fraction", ncol, nlev);
+  p3_tend_out = Array3("Microphysics Tendencies", ncol, nlev, 35);
 }
 
 FortranDataIterator::FortranDataIterator (const FortranData::Ptr& d) {
@@ -95,7 +96,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(pdel); fdipb(exner); fdipb(ast); fdipb(cmeiout); fdipb(prain);
   fdipb(nevapr); fdipb(prer_evap);
   fdipb(rflx); fdipb(sflx);
-  fdipb(rcldm); fdipb(lcldm); fdipb(icldm);
+  fdipb(rcldm); fdipb(lcldm); fdipb(icldm), fdipb(p3_tend_out);
 #undef fdipb
 }
 
@@ -132,7 +133,7 @@ void p3_main (const FortranData& d) {
             d.pdel.data(), d.exner.data(), d.ast.data(), d.cmeiout.data(), d.prain.data(),
             d.nevapr.data(), d.prer_evap.data(),
             d.rflx.data(), d.sflx.data(),
-            d.rcldm.data(), d.lcldm.data(), d.icldm.data());
+            d.rcldm.data(), d.lcldm.data(), d.icldm.data(),d.p3_tend_out.data());
 }
 
 Int check_against_python (const FortranData& d) {

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -96,7 +96,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(pdel); fdipb(exner); fdipb(ast); fdipb(cmeiout); fdipb(prain);
   fdipb(nevapr); fdipb(prer_evap);
   fdipb(rflx); fdipb(sflx);
-  fdipb(rcldm); fdipb(lcldm); fdipb(icldm), fdipb(p3_tend_out);
+  fdipb(rcldm); fdipb(lcldm); fdipb(icldm); fdipb(p3_tend_out);
 #undef fdipb
 }
 

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -20,6 +20,7 @@ struct FortranData {
 
   using Array1 = Kokkos::View<Scalar*, Layout, ExeSpace>;
   using Array2 = Kokkos::View<Scalar**, Layout, ExeSpace>;
+  using Array3 = Kokkos::View<Scalar***, Layout, ExeSpace>;
 
   static constexpr bool log_predictnc = true;
 
@@ -32,6 +33,7 @@ struct FortranData {
   // Out
   Array1 prt_liq, prt_sol;
   Array2 diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, diag_rhoi, cmeiout, prain, nevapr, prer_evap, rflx, sflx, rcldm, lcldm, icldm;
+  Array3 p3_tend_out;
 
   FortranData(Int ncol, Int nlev);
 };

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 35);
+  REQUIRE(fdi.nfield() == 36);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);


### PR DESCRIPTION
This commit will include the microphysical tendencies as output
in the default output file when using the P3 microphysics
parameterization.

This will provide a tool for understanding what physics are impacting
the solution and should assist in understanding the solutions and
debugging.