### PR TITLE
Fix precision to be compatible with E3SM build

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -37,11 +37,8 @@
 
 module micro_p3
 
-#ifdef CAM
-    use shr_kind_mod,   only: rtype=>shr_kind_r8, itype=>shr_kind_i8
-#else
-    use iso_c_binding, only: c_double, c_float
-#endif
+   ! get real kind from utils
+   use micro_p3_utils, only: rtype
 
    ! physical and mathematical constants
    use micro_p3_utils, only: rhosur,rhosui,ar,br,f1r,f2r,ecr,rhow,kr,kc,bimm,aimm,rin,mi0,nccnst,  &
@@ -57,19 +54,6 @@ module micro_p3
 
   implicit none
   save
-
-#ifndef CAM
-#ifdef SCREAM_CONFIG_IS_CMAKE
-#include "scream_config.f"
-#endif
-
-#ifdef SCREAM_DOUBLE_PRECISION
-  integer,parameter,public :: rtype = c_double ! 8 byte real, compatible with cype double
-#else
-  integer,parameter,public :: rtype = c_float ! 4 byte real, compatible with cype float
-#endif
-  integer,parameter :: itype = selected_int_kind (13) ! 8 byte integer
-#endif
 
   public  :: p3_init,p3_main
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -37,8 +37,11 @@
 
 module micro_p3
 
-   ! get real kind from utils
-   use micro_p3_utils, only: rtype
+#ifdef CAM
+    use shr_kind_mod,   only: rtype=>shr_kind_r8, itype=>shr_kind_i8
+#else
+    use iso_c_binding, only: c_double, c_float
+#endif
 
    ! physical and mathematical constants
    use micro_p3_utils, only: rhosur,rhosui,ar,br,f1r,f2r,ecr,rhow,kr,kc,bimm,aimm,rin,mi0,nccnst,  &
@@ -54,6 +57,19 @@ module micro_p3
 
   implicit none
   save
+
+#ifndef CAM
+#ifdef SCREAM_CONFIG_IS_CMAKE
+#include "scream_config.f"
+#endif
+
+#ifdef SCREAM_DOUBLE_PRECISION
+  integer,parameter,public :: rtype = c_double ! 8 byte real, compatible with cype double
+#else
+  integer,parameter,public :: rtype = c_float ! 4 byte real, compatible with cype float
+#endif
+  integer,parameter :: itype = selected_int_kind (13) ! 8 byte integer
+#endif
 
   public  :: p3_init,p3_main
 

--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -21,10 +21,12 @@ module micro_p3_utils
   integer,parameter,public :: rtype = c_float ! 4 byte real, compatible with c type float
 #endif
   integer,parameter :: itype = selected_int_kind (13) ! 8 byte integer
+#else
+    public :: rtype
 #endif
 
     public :: get_latent_heat, get_precip_fraction, micro_p3_utils_init, size_dist_param_liq, &
-              size_dist_param_basic,avg_diameter, rising_factorial, rtype
+              size_dist_param_basic,avg_diameter, rising_factorial
 
     integer, public :: iulog_e3sm
     logical, public :: masterproc_e3sm

--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -24,7 +24,7 @@ module micro_p3_utils
 #endif
 
     public :: get_latent_heat, get_precip_fraction, micro_p3_utils_init, size_dist_param_liq, &
-              size_dist_param_basic,avg_diameter, rising_factorial
+              size_dist_param_basic,avg_diameter, rising_factorial, rtype
 
     integer, public :: iulog_e3sm
     logical, public :: masterproc_e3sm


### PR DESCRIPTION
This commit fixes an issue that cropped up from PR #50 which broke
the E3SM build because precision (rtype) wasn't made a public variable
in micro_p3_utils

All tests PASS in baseline comparison test,
"100% tests passed, 0 tests failed out of 57"