### PR TITLE
Fixes precision issue with running the SCM

### DIFF
--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -1,19 +1,17 @@
 module micro_p3_utils
 
-#ifdef CAM
-    use shr_kind_mod,   only: rtype=>shr_kind_r8, itype=>shr_kind_i8
-#else
+#ifdef SCREAM_CONFIG_IS_CMAKE
     use iso_c_binding, only: c_double, c_float
+#else
+    use shr_kind_mod,   only: rtype=>shr_kind_r8, itype=>shr_kind_i8
 #endif
 
     implicit none
     private
     save
 
-#ifndef CAM
 #ifdef SCREAM_CONFIG_IS_CMAKE
 #include "scream_config.f"
-#endif
 
 #ifdef SCREAM_DOUBLE_PRECISION
   integer,parameter,public :: rtype = c_double ! 8 byte real, compatible with c type double


### PR DESCRIPTION
Fixes an issue where SCM runs don't use the CAM compiler flag.  Thus
there would be issues with the precision type in p3 vs. those of the
rest of the CAM model.

All baseline tests have passed.