### PR TITLE
Remove baseline gen from ctest script

### DIFF
--- a/components/scream/cmake/ctest_script.cmake
+++ b/components/scream/cmake/ctest_script.cmake
@@ -27,8 +27,6 @@ message("build error           = ${build_error}")
 message("build ctest error     = ${build_ctest_error}")
 
 if (NOT BUILD_ONLY)
-  execute_process(COMMAND make baseline WORKING_DIRECTORY "${CTEST_BINARY_DIRECTORY}")
-
   ctest_test(PARALLEL_LEVEL ${PARALLEL_LEVEL} CAPTURE_CMAKE_ERROR test_ctest_error RETURN_VALUE test_error)
   message("test error            = ${test_error}")
   message("test ctest error      = ${test_ctest_error}")


### PR DESCRIPTION
After some evaluation, I determined that it is not practical to generate the baselines with the ctest_script itself. There's too much complexity involved with changing the state of the current repo. Instead, test-all-scream from our scream-docs repo will be used to generate the baselines.