### PR TITLE
Kylepressel/aerosol activation

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -304,7 +304,7 @@ contains
   !==========================================================================================!
 
   SUBROUTINE p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
-       pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
+       pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
        diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out)
 
@@ -343,6 +343,8 @@ contains
     real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: qv_old     ! beginning of time step value of qv    kg kg-1
     real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: pres       ! pressure                         Pa
     real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: dzq        ! vertical grid spacing            m
+    real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: npccn      ! IN ccn activated number tendency kg-1 s-1
+    real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: naai       ! IN actived ice nuclei concentration  1/kg
     real(rtype), intent(in)                                     :: dt         ! model time step                  s
 
     real(rtype), intent(out),   dimension(its:ite)              :: prt_liq    ! precipitation rate, liquid       m s-1
@@ -1260,21 +1262,31 @@ contains
           ! allow ice nucleation if < -15 C and > 5% ice supersaturation
           ! use CELL-AVERAGE values, freezing of vapor
 
-          if (t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
+         if(.not. log_predictNc) then 
+            if ( t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
 
-             !        dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)
-             dum = 0.005*exp(0.304*(zerodegc-t(i,k)))*1000.*inv_rho(i,k)   !Cooper (1986)
-             dum = min(dum,100.e3*inv_rho(i,k))
-             N_nuc = max(0.,(dum-nitot(i,k))*odt)
+               !        dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)
+               dum = 0.005*exp(0.304*(zerodegc-t(i,k)))*1000.*inv_rho(i,k)   !Cooper (1986)
+               dum = min(dum,100.e3*inv_rho(i,k))
+               N_nuc = max(0.,(dum-nitot(i,k))*odt)
 
-             if (N_nuc.ge.1.e-20) then
-                Q_nuc = max(0.,(dum-nitot(i,k))*mi0*odt)
-                qinuc = Q_nuc
-                ninuc = N_nuc
-             endif
+               if (N_nuc.ge.1.e-20) then
+                  Q_nuc = max(0.,(dum-nitot(i,k))*mi0*odt)
+                  qinuc = Q_nuc
+                  ninuc = N_nuc
+               endif
 
-          endif
+            endif
+         endif 
 
+
+         if(log_predictNc) then 
+         !desposition/condencation nucleation predicted by aerosol scheme 
+            if  ( t(i,k) .lt. 258.15 .and. supi(i,k).ge.0.05) then
+               ninuc = max(0., (naai(i,k) - nitot(i,k))*odt)
+               qinuc = ninuc * mi0
+            endif
+         endif 
 
           !.................................................................
           ! droplet activation
@@ -1283,47 +1295,48 @@ contains
           ! note that this is also applied at the first time step
           ! this is not applied at the first time step, since saturation adjustment is applied at the first step
 
-          if (.not.(log_predictNc).and.sup(i,k).gt.1.e-6.and.it.gt.1) then
-             dum   = nccnst*inv_rho(i,k)*cons7-qc_incld(i,k)
-             dum   = max(0.,dum)
-             dumqvs = qv_sat(t(i,k),pres(i,k),0)
-             dqsdt = xxlv(i,k)*dumqvs/(rv*t(i,k)*t(i,k))
-             ab    = 1. + dqsdt*xxlv(i,k)*inv_cp
-             dum   = min(dum,(qv(i,k)-dumqvs)/ab)  ! limit overdepletion of supersaturation
-             qcnuc = dum*odt
-          endif
-
           if (log_predictNc) then
 
-             ! for predicted Nc, calculate activation explicitly from supersaturation
-             ! note that this is also applied at the first time step
-             ! note that this is also applied at the first time step
+            ! for predicted Nc, calculate activation explicitly from supersaturation
+            ! note that this is also applied at the first time step
+            ! note that this is also applied at the first time step
 
-             if (sup(i,k).gt.1.e-6) then
-                dum1  = 1./bact**0.5
-                sigvl = 0.0761 - 1.55e-4*(t(i,k)-zerodegc)
-                aact  = 2.*mw/(rhow*rr*t(i,k))*sigvl
-                sm1   = 2.*dum1*(aact*thrd*inv_rm1)**1.5
-                sm2   = 2.*dum1*(aact*thrd*inv_rm2)**1.5
-                uu1   = 2.*log(sm1/sup(i,k))/(4.242*log(sig1))
-                uu2   = 2.*log(sm2/sup(i,k))/(4.242*log(sig2))
-                dum1  = nanew1*0.5*(1.-erf(uu1)) ! activated number in kg-1 mode 1
-                dum2  = nanew2*0.5*(1.-erf(uu2)) ! activated number in kg-1 mode 2
-                ! make sure this value is not greater than total number of aerosol
-                dum2  = min((nanew1+nanew2),dum1+dum2)
-                dum2  = (dum2-nc_incld(i,k))*odt
-                dum2  = max(0.,dum2)
-                ncnuc = dum2
-                ! don't include mass increase from droplet activation during first time step
-                ! since this is already accounted for by saturation adjustment below
-                if (it.eq.1) then
-                   qcnuc = 0.
-                else
-                   qcnuc = ncnuc*cons7
-                endif
-             endif
+            if (sup(i,k).gt.1.e-6) then
+               ! code removed below by K. Pressel 2/19 to allow for activation of droplets 
+               ! by the aerosol scheme 
+               !dum1  = 1./bact**0.5
+               !sigvl = 0.0761 - 1.55e-4*(t(i,k)-zerodegc)
+               !aact  = 2.*mw/(rhow*rr*t(i,k))*sigvl
+               !sm1   = 2.*dum1*(aact*thrd*inv_rm1)**1.5
+               !sm2   = 2.*dum1*(aact*thrd*inv_rm2)**1.5
+               !uu1   = 2.*log(sm1/sup(i,k))/(4.242*log(sig1))
+               !uu2   = 2.*log(sm2/sup(i,k))/(4.242*log(sig2))
+               !dum1  = nanew1*0.5*(1.-erf(uu1)) ! activated number in kg-1 mode 1
+               !dum2  = nanew2*0.5*(1.-erf(uu2)) ! activated number in kg-1 mode 2
+               !! make sure this value is not greater than total number of aerosol
+               !dum2  = min((nanew1+nanew2),dum1+dum2)
+               !dum2  = (dum2-nc(i,k))*odt
+               !dum2  = max(0.,dum2)
+               !ncnuc = dum2
+               ! don't include mass increase from droplet activation during first time step
+               ! since this is already accounted for by saturation adjustment below
+               ncnuc = npccn(i,k)
+               if (it.eq.1) then
+                  qcnuc = 0.
+               else
+                  qcnuc = ncnuc*cons7
+               endif
+            endif
 
-          endif
+         else if (sup(i,k).gt.1.e-6.and.it.gt.1) then
+            dum   = nccnst*inv_rho(i,k)*cons7-qc(i,k)
+            dum   = max(0.,dum)
+            dumqvs = qv_sat(t(i,k),pres(i,k),0)
+            dqsdt = xxlv(i,k)*dumqvs/(rv*t(i,k)*t(i,k))
+            ab    = 1. + dqsdt*xxlv(i,k)*inv_cp
+            dum   = min(dum,(qv(i,k)-dumqvs)/ab)  ! limit overdepletion of supersaturation
+            qcnuc = dum*odt
+         endif
 
           !................................................................
           ! saturation adjustment to get initial cloud water

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1261,65 +1261,30 @@ contains
           ! allow ice nucleation if < -15 C and > 5% ice supersaturation
           ! use CELL-AVERAGE values, freezing of vapor
 
-<<<<<<< HEAD
          if ( t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
             if(.not. log_predictNc) then 
                ! dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)
                dum = 0.005*exp(0.304*(zerodegc-t(i,k)))*1000.*inv_rho(i,k)   !Cooper (1986)
                dum = min(dum,100.e3*inv_rho(i,k))
                N_nuc = max(0.,(dum-nitot(i,k))*odt)
-=======
-         if(.not. log_predictNc) then 
-            if ( t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
-
-               !        dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)
-               dum = 0.005*exp(0.304*(zerodegc-t(i,k)))*1000.*inv_rho(i,k)   !Cooper (1986)
-               dum = min(dum,100.e3*inv_rho(i,k))
-               N_nuc = max(0.,(dum-nitot(i,k))*odt)
-
->>>>>>> 9e1f98c83923e74f85a340750e0b74fb8b31c830
                if (N_nuc.ge.1.e-20) then
                   Q_nuc = max(0.,(dum-nitot(i,k))*mi0*odt)
                   qinuc = Q_nuc
                   ninuc = N_nuc
                endif
-<<<<<<< HEAD
             else 
             ! Ice nucleation predicted by aerosol scheme 
                ninuc = max(0., (naai(i,k) - nitot(i,k))*odt)
                qinuc = ninuc * mi0
             endif 
-=======
-
-            endif
-         endif 
-
-
-         if(log_predictNc) then 
-         ! Ice nucleation predicted by aerosol scheme 
-            if  ( t(i,k) .lt. 258.15 .and. supi(i,k).ge.0.05) then
-               ninuc = max(0., (naai(i,k) - nitot(i,k))*odt)
-               qinuc = ninuc * mi0
-            endif
->>>>>>> 9e1f98c83923e74f85a340750e0b74fb8b31c830
          endif 
 
           !.................................................................
           ! droplet activation
 
-<<<<<<< HEAD
           if (log_predictNc) then
             ! for predicted Nc, use activation predicted by aerosol scheme
             ! note that this is also applied at the first time step
-=======
-
-
-          if (log_predictNc) then
-
-            ! for predicted Nc, use activation predicted by aerosol scheme
-            ! note that this is also applied at the first time step
-
->>>>>>> 9e1f98c83923e74f85a340750e0b74fb8b31c830
             if (sup(i,k).gt.1.e-6) then
                ! code removed below by K. Pressel 2/19 to allow for activation of droplets 
                ! by the aerosol scheme 
@@ -1347,10 +1312,6 @@ contains
                   qcnuc = ncnuc*cons7
                endif
             endif
-<<<<<<< HEAD
-=======
-
->>>>>>> 9e1f98c83923e74f85a340750e0b74fb8b31c830
          else if (sup(i,k).gt.1.e-6.and.it.gt.1) then
            ! for specified Nc, make sure droplets are present if conditions are supersaturated
            ! this is not applied at the first time step, since saturation adjustment is applied at the first step

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1291,14 +1291,11 @@ contains
           !.................................................................
           ! droplet activation
 
-          ! for specified Nc, make sure droplets are present if conditions are supersaturated
-          ! note that this is also applied at the first time step
-          ! this is not applied at the first time step, since saturation adjustment is applied at the first step
+
 
           if (log_predictNc) then
 
-            ! for predicted Nc, calculate activation explicitly from supersaturation
-            ! note that this is also applied at the first time step
+            ! for predicted Nc, use activation predicted by aerosol scheme
             ! note that this is also applied at the first time step
 
             if (sup(i,k).gt.1.e-6) then
@@ -1324,11 +1321,14 @@ contains
                if (it.eq.1) then
                   qcnuc = 0.
                else
+                  !TODO Limit qcnuc so that conditions never become sub-saturated 
                   qcnuc = ncnuc*cons7
                endif
             endif
 
          else if (sup(i,k).gt.1.e-6.and.it.gt.1) then
+           ! for specified Nc, make sure droplets are present if conditions are supersaturated
+           ! this is not applied at the first time step, since saturation adjustment is applied at the first step
             dum   = nccnst*inv_rho(i,k)*cons7-qc(i,k)
             dum   = max(0.,dum)
             dumqvs = qv_sat(t(i,k),pres(i,k),0)

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1261,30 +1261,65 @@ contains
           ! allow ice nucleation if < -15 C and > 5% ice supersaturation
           ! use CELL-AVERAGE values, freezing of vapor
 
+<<<<<<< HEAD
          if ( t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
             if(.not. log_predictNc) then 
                ! dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)
                dum = 0.005*exp(0.304*(zerodegc-t(i,k)))*1000.*inv_rho(i,k)   !Cooper (1986)
                dum = min(dum,100.e3*inv_rho(i,k))
                N_nuc = max(0.,(dum-nitot(i,k))*odt)
+=======
+         if(.not. log_predictNc) then 
+            if ( t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
+
+               !        dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)
+               dum = 0.005*exp(0.304*(zerodegc-t(i,k)))*1000.*inv_rho(i,k)   !Cooper (1986)
+               dum = min(dum,100.e3*inv_rho(i,k))
+               N_nuc = max(0.,(dum-nitot(i,k))*odt)
+
+>>>>>>> 9e1f98c83923e74f85a340750e0b74fb8b31c830
                if (N_nuc.ge.1.e-20) then
                   Q_nuc = max(0.,(dum-nitot(i,k))*mi0*odt)
                   qinuc = Q_nuc
                   ninuc = N_nuc
                endif
+<<<<<<< HEAD
             else 
             ! Ice nucleation predicted by aerosol scheme 
                ninuc = max(0., (naai(i,k) - nitot(i,k))*odt)
                qinuc = ninuc * mi0
             endif 
+=======
+
+            endif
+         endif 
+
+
+         if(log_predictNc) then 
+         ! Ice nucleation predicted by aerosol scheme 
+            if  ( t(i,k) .lt. 258.15 .and. supi(i,k).ge.0.05) then
+               ninuc = max(0., (naai(i,k) - nitot(i,k))*odt)
+               qinuc = ninuc * mi0
+            endif
+>>>>>>> 9e1f98c83923e74f85a340750e0b74fb8b31c830
          endif 
 
           !.................................................................
           ! droplet activation
 
+<<<<<<< HEAD
           if (log_predictNc) then
             ! for predicted Nc, use activation predicted by aerosol scheme
             ! note that this is also applied at the first time step
+=======
+
+
+          if (log_predictNc) then
+
+            ! for predicted Nc, use activation predicted by aerosol scheme
+            ! note that this is also applied at the first time step
+
+>>>>>>> 9e1f98c83923e74f85a340750e0b74fb8b31c830
             if (sup(i,k).gt.1.e-6) then
                ! code removed below by K. Pressel 2/19 to allow for activation of droplets 
                ! by the aerosol scheme 
@@ -1312,6 +1347,10 @@ contains
                   qcnuc = ncnuc*cons7
                endif
             endif
+<<<<<<< HEAD
+=======
+
+>>>>>>> 9e1f98c83923e74f85a340750e0b74fb8b31c830
          else if (sup(i,k).gt.1.e-6.and.it.gt.1) then
            ! for specified Nc, make sure droplets are present if conditions are supersaturated
            ! this is not applied at the first time step, since saturation adjustment is applied at the first step

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1281,7 +1281,7 @@ contains
 
 
          if(log_predictNc) then 
-         !desposition/condencation nucleation predicted by aerosol scheme 
+         ! Ice nucleation predicted by aerosol scheme 
             if  ( t(i,k) .lt. 258.15 .and. supi(i,k).ge.0.05) then
                ninuc = max(0., (naai(i,k) - nitot(i,k))*odt)
                qinuc = ninuc * mi0

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1256,48 +1256,35 @@ contains
 
 444       continue
 
-
           !................................................................
           ! deposition/condensation-freezing nucleation
           ! allow ice nucleation if < -15 C and > 5% ice supersaturation
           ! use CELL-AVERAGE values, freezing of vapor
 
-         if(.not. log_predictNc) then 
-            if ( t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
-
-               !        dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)
+         if ( t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
+            if(.not. log_predictNc) then 
+               ! dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)
                dum = 0.005*exp(0.304*(zerodegc-t(i,k)))*1000.*inv_rho(i,k)   !Cooper (1986)
                dum = min(dum,100.e3*inv_rho(i,k))
                N_nuc = max(0.,(dum-nitot(i,k))*odt)
-
                if (N_nuc.ge.1.e-20) then
                   Q_nuc = max(0.,(dum-nitot(i,k))*mi0*odt)
                   qinuc = Q_nuc
                   ninuc = N_nuc
                endif
-
-            endif
-         endif 
-
-
-         if(log_predictNc) then 
-         ! Ice nucleation predicted by aerosol scheme 
-            if  ( t(i,k) .lt. 258.15 .and. supi(i,k).ge.0.05) then
+            else 
+            ! Ice nucleation predicted by aerosol scheme 
                ninuc = max(0., (naai(i,k) - nitot(i,k))*odt)
                qinuc = ninuc * mi0
-            endif
+            endif 
          endif 
 
           !.................................................................
           ! droplet activation
 
-
-
           if (log_predictNc) then
-
             ! for predicted Nc, use activation predicted by aerosol scheme
             ! note that this is also applied at the first time step
-
             if (sup(i,k).gt.1.e-6) then
                ! code removed below by K. Pressel 2/19 to allow for activation of droplets 
                ! by the aerosol scheme 
@@ -1325,7 +1312,6 @@ contains
                   qcnuc = ncnuc*cons7
                endif
             endif
-
          else if (sup(i,k).gt.1.e-6.and.it.gt.1) then
            ! for specified Nc, make sure droplets are present if conditions are supersaturated
            ! this is not applied at the first time step, since saturation adjustment is applied at the first step

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -1242,8 +1242,10 @@ end subroutine micro_p3_readnl
 
     ! HANDLE AEROSOL ACTIVATION
     !==============
-    !saving this for later... use prescribed Nd for now.
-    log_predictNc = .false.
+    ! TODO: Make log_predictNc a namelist option currently default values is set to .true.
+    ! which means that droplet and ice particle activation is predicted by the aerosol 
+    ! scheme. 
+    log_predictNc = .true.
 
     ! GET "OLD" VALUES
     !==============
@@ -1364,6 +1366,8 @@ end subroutine micro_p3_readnl
          ssat(its:ite,kts:kte),       & ! INOUT  supersaturation (i.e., qv-qvs)   kg kg-1
          pres(its:ite,kts:kte),       & ! IN     pressure at cell midpoints       Pa
          dzq(its:ite,kts:kte),        & ! IN     vertical grid spacing            m
+         npccn(its:ite,kts:kte),      & ! IN ccn activation number tendency kg-1 s-1
+         naai(its:ite,kts:kte),       & ! IN activated ice nuclei concentration kg-1
          it,                          & ! IN     time step counter NOTE: starts at 1 for first time step
          prt_liq(its:ite),            & ! OUT    surface liquid precip rate       m s-1
          prt_sol(its:ite),            & ! OUT    surface frozen precip rate       m s-1

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -1242,7 +1242,7 @@ end subroutine micro_p3_readnl
 
     ! HANDLE AEROSOL ACTIVATION
     !==============
-    ! TODO: Make log_predictNc a namelist option currently default values is set to .true.
+    ! TODO: Make log_predictNc a namelist option currently default value is set to .true.
     ! which means that droplet and ice particle activation is predicted by the aerosol 
     ! scheme. 
     log_predictNc = .true.

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -79,7 +79,7 @@ contains
   end subroutine p3_init_c
 
   subroutine p3_main_c(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
-       pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
+       pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
        diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc_in, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out) bind(C)
     use micro_p3, only : p3_main
@@ -87,6 +87,7 @@ contains
     real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, ssat, qv, th, th_old, qv_old
     real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qitot, qirim, nitot, birim
     real(kind=c_real), intent(in), dimension(its:ite,kts:kte) :: pres, dzq
+    real(kind=c_real), intent(in), dimension(its:ite,kts:kte) :: npccn,naai
     real(kind=c_real), value, intent(in) :: dt
     real(kind=c_real), intent(out), dimension(its:ite) :: prt_liq, prt_sol
     real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_ze, diag_effc
@@ -110,7 +111,7 @@ contains
     log_predictNc = log_predictNc_in
 
     call p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
-         pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
+         pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
          diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
          pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out)
   end subroutine p3_main_c

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -15,7 +15,7 @@ extern "C" {
   void p3_main_c(Real* qc, Real* nc, Real* qr, Real* nr, Real* th_old, Real* th,
                  Real* qv_old, Real* qv, Real dt, Real* qitot, Real* qirim,
                  Real* nitot, Real* birim, Real* ssat, Real* pres,
-                 Real* dzq, Int it, Real* prt_liq, Real* prt_sol, Int its,
+                 Real* dzq, Real* npccn, Real* naai, Int it, Real* prt_liq, Real* prt_sol, Int its,
                  Int ite, Int kts, Int kte, Real* diag_ze,
                  Real* diag_effc, Real* diag_effi, Real* diag_vmi,
                  Real* diag_di, Real* diag_rhoi,
@@ -51,6 +51,8 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   th_old = Array2("theta at beginning of timestep, K", ncol, nlev);
   pres = Array2("pressure, Pa", ncol, nlev);
   dzq = Array2("vertical grid spacing, m", ncol, nlev);
+  npccn = Array2("ccn activated number tendency, kg-1 s-1", ncol, nlev);
+  naai = Array2("activated nuclei concentration, kg-1", ncol, nlev);
   pdel = Array2("pressure thickness, Pa", ncol, nlev);
   exner = Array2("Exner expression", ncol, nlev);
   // Out
@@ -87,7 +89,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
         d_->name.data(),                                                \
         d_->name.size()})
   fdipb(qv); fdipb(th); fdipb(qv_old); fdipb(th_old); fdipb(pres);
-  fdipb(dzq); fdipb(qc); fdipb(nc); fdipb(qr); fdipb(nr);
+  fdipb(dzq); fdipb(npccn); fdipb(naai); fdipb(qc); fdipb(nc); fdipb(qr); fdipb(nr);
   fdipb(ssat); fdipb(qitot); fdipb(nitot);
   fdipb(qirim); fdipb(birim); fdipb(prt_liq); fdipb(prt_sol);
   fdipb(diag_ze); fdipb(diag_effc); fdipb(diag_effi);
@@ -124,7 +126,7 @@ void p3_main (const FortranData& d) {
   p3_main_c(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(), d.th_old.data(),
             d.th.data(), d.qv_old.data(), d.qv.data(), d.dt, d.qitot.data(),
             d.qirim.data(), d.nitot.data(), d.birim.data(), d.ssat.data(),
-            d.pres.data(), d.dzq.data(), d.it, d.prt_liq.data(),
+            d.pres.data(), d.dzq.data(), d.npccn.data(), d.naai.data(), d.it, d.prt_liq.data(),
             d.prt_sol.data(), 1, d.ncol, 1, d.nlev, d.diag_ze.data(),
             d.diag_effc.data(), d.diag_effi.data(), d.diag_vmi.data(),
             d.diag_di.data(), d.diag_rhoi.data(),

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -29,7 +29,7 @@ struct FortranData {
   // In
   Real dt;
   Int it;
-  Array2 qv, th, qv_old, th_old, pres, dzq, qc, nc, qr, nr, ssat, qitot, nitot, qirim, birim, pdel, exner;
+  Array2 qv, th, qv_old, th_old, pres, dzq, npccn, naai, qc, nc, qr, nr, ssat, qitot, nitot, qirim, birim, pdel, exner, ast;
   // Out
   Array1 prt_liq, prt_sol;
   Array2 diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, diag_rhoi, cmeiout, prain, nevapr, prer_evap, rflx, sflx, rcldm, lcldm, icldm;

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -67,7 +67,7 @@ struct Baseline {
       p3_init();
       p3_main(*d);
       if (first) {
-        first = false; 
+        first = false;
         nerr += check_against_python(*d);
         if (nerr) std::cout << "Spot-check against Python failed.\n";
       }
@@ -105,7 +105,7 @@ private:
     ic::Factory::IC ic;
     Real dt;
   };
-  
+
   std::vector<ParamSet> params_;
 
   static void write (const FILEPtr& fid, const FortranData::Ptr& d) {
@@ -114,7 +114,7 @@ private:
       const auto& f = fdi.getfield(i);
       util::write(&f.dim, 1, fid);
       util::write(f.extent, f.dim, fid);
-      util::write(f.data, f.size, fid);    
+      util::write(f.data, f.size, fid);
     }
   }
 
@@ -154,7 +154,7 @@ int main (int argc, char** argv) {
       "Options:\n"
       "  -g        Generate baseline file.\n"
       "  -t <tol>  Tolerance for relative error.\n";
-    return -1;
+    return 1;
   }
 
   bool generate = false;
@@ -180,8 +180,8 @@ int main (int argc, char** argv) {
     } else {
       printf("Comparing with %s at tol %1.1e\n", baseline_fn.c_str(), tol);
       nerr += bln.run_and_cmp(baseline_fn, tol);
-    }    
+    }
   } scream::finalize_scream_session();
 
-  return nerr;
+  return nerr != 0 ? 1 : 0;
 }

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 35);
+  REQUIRE(fdi.nfield() == 37);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);

--- a/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
@@ -1,12 +1,3 @@
+INCLUDE (ScreamUtils)
 
-set(RRTMGP_TEST_SRCS
-  rrtmgp_tests.cpp
-)
-
-add_executable(rrtmgp_tests ${RRTMGP_TEST_SRCS})
-
-target_include_directories(rrtmgp_tests PUBLIC ${SCREAM_INCLUDE_DIRS} ${CATCH_INCLUDE_DIR})
-
-target_link_libraries(rrtmgp_tests rrtmgp)
-
-add_test(run_rrtmgp_tests rrtmgp_tests)
+CreateUnitTest(rrtmgp_tests rrtmgp_tests.cpp "rrtmgp;scream_share")

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
@@ -1,5 +1,3 @@
-#define CATCH_CONFIG_MAIN
-
 #include "catch2/catch.hpp"
 #include "physics/rrtmgp/rrtmgp.hpp"
 

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -1,12 +1,3 @@
+INCLUDE (ScreamUtils)
 
-set(SHOC_TEST_SRCS
-  shoc_tests.cpp
-)
-
-add_executable(shoc_tests ${SHOC_TEST_SRCS})
-
-target_include_directories(shoc_tests PUBLIC ${SCREAM_INCLUDE_DIRS} ${CATCH_INCLUDE_DIR})
-
-target_link_libraries(shoc_tests shoc)
-
-add_test(run_shoc_tests shoc_tests)
+CreateUnitTest(shoc_tests shoc_tests.cpp "shoc;scream_share")

--- a/components/scream/src/physics/shoc/tests/shoc_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tests.cpp
@@ -1,5 +1,3 @@
-#define CATCH_CONFIG_MAIN
-
 #include "catch2/catch.hpp"
 #include "physics/shoc/shoc.hpp"
 

--- a/components/scream/src/share/util/scream_catch_main.cpp
+++ b/components/scream/src/share/util/scream_catch_main.cpp
@@ -14,7 +14,7 @@ int main (int argc, char **argv) {
   scream::initialize_scream_session(argc, argv);
 
   // Run tests
-  int result = Catch::Session().run(argc, argv);
+  int num_failed = Catch::Session().run(argc, argv);
 
   // Finalize scream
   scream::finalize_scream_session();
@@ -23,5 +23,5 @@ int main (int argc, char **argv) {
   MPI_Finalize();
 
   // Return test result
-  return result;
+  return num_failed != 0 ? 1 : 0;
 }


### PR DESCRIPTION
This PR adds a new feature to the Fortran implementation of P3 microphysics. In particular, it allows the number of aerosol particles that are activated to form cloud liquid droplets and ice particles, as  predicted by the aerosol scheme, to be included as source terms to the cloud and ice number concentrations that are prognosed as part of P3 microphysics. This feature is turned on by default.
 
The implementation of the feature amounts to adding two source terms to the right hand sides of the prognostic equations for _nitot_ and _nc_ that depend on _naii_ and _npccn_, respectively. Both naii and npccn are predicted by the aerosol scheme. 
 
These modifications to the source code are a non-BFB change.
