### PR TITLE
Remove a spot check against python.

### DIFF
--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -135,20 +135,6 @@ void p3_main (const FortranData& d) {
             d.rcldm.data(), d.lcldm.data(), d.icldm.data(),d.p3_tend_out.data());
 }
 
-Int check_against_python (const FortranData& d) {
-  Int nerr = 0;
-  if (util::is_single_precision<Real>::value) {
-    const double tol = 0;
-    if (util::reldif<double>(d.birim(0,d.nlev-1), 7.237245824853744e-08) > tol)
-      ++nerr;
-    if (util::reldif<double>(d.qirim(0,d.nlev-1), 9.047746971191373e-06) > tol)
-      ++nerr;
-    if (util::reldif<double>(d.nr(0,d.nlev-1), 3.177030468750000e+04) > tol)
-      ++nerr;
-  }
-  return nerr;
-}
-
 int test_FortranData () {
   FortranData d(11, 72);
   return 0;
@@ -163,7 +149,7 @@ int test_p3_ic () {
   const auto d = ic::Factory::create(ic::Factory::mixed);
   p3_init();
   p3_main(*d);
-  return check_against_python(*d);
+  return 0;
 }
 
 } // namespace p3

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -59,18 +59,12 @@ struct Baseline {
     auto fid = FILEPtr(fopen(filename.c_str(), "w"));
     scream_require_msg( fid, "generate_baseline can't write " << filename);
     Int nerr = 0;
-    bool first = true;
     for (auto ps : params_) {
       // Run reference p3 on this set of parameters.
       const auto d = ic::Factory::create(ps.ic);
       d->dt = ps.dt;
       p3_init();
       p3_main(*d);
-      if (first) {
-        first = false;
-        nerr += check_against_python(*d);
-        if (nerr) std::cout << "Spot-check against Python failed.\n";
-      }
       // Save the fields to the baseline file.
       write(fid, d);
     }


### PR DESCRIPTION
This check was in the code to check against the original Python-interfaced
P3. P3 has been modified a lot since then, so these hardcoded values from the
long-ago Python runs are unlikely to be valid. Remove all of this code.