### PR TITLE
Kylepressel/activation

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -678,7 +678,9 @@ contains
 
 
          !Activaiton of cloud droplets 
-          nc(i,k) = nc(i,k) + npccn(i,k) * dt
+          if (log_predictNc) then 
+             nc(i,k) = nc(i,k) + npccn(i,k) * dt
+          endif 
 
           call calculate_incloud_mixingratios(qc(i,k),qr(i,k),qitot(i,k),qirim(i,k),nc(i,k),nr(i,k),nitot(i,k),birim(i,k), &
                   inv_lcldm(i,k),inv_icldm(i,k),inv_rcldm(i,k), &

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1268,27 +1268,6 @@ contains
           ! allow ice nucleation if < -15 C and > 5% ice supersaturation
           ! use CELL-AVERAGE values, freezing of vapor
 
-          if (t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
-
-             !        dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)
-             dum = 0.005*exp(0.304*(zerodegc-t(i,k)))*1000.*inv_rho(i,k)   !Cooper (1986)
-             dum = min(dum,100.e3*inv_rho(i,k))
-             N_nuc = max(0.,(dum-nitot(i,k))*odt)
-
-             if (N_nuc.ge.1.e-20) then
-                Q_nuc = max(0.,(dum-nitot(i,k))*mi0*odt)
-                qinuc = Q_nuc
-                ninuc = N_nuc
-             endif
-
-          endif
-
-
-          !................................................................
-          ! deposition/condensation-freezing nucleation
-          ! allow ice nucleation if < -15 C and > 5% ice supersaturation
-          ! use CELL-AVERAGE values, freezing of vapor
-
           if ( t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
             if(.not. log_predictNc) then 
                ! dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -304,9 +304,9 @@ contains
   !==========================================================================================!
 
   SUBROUTINE p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
-       pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
-       diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
-       pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out)
+   pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
+   diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
+   pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out)
 
     !----------------------------------------------------------------------------------------!
     !                                                                                        !
@@ -343,6 +343,8 @@ contains
     real(rtype), intent(inout), dimension(its:ite,kts:kte)      :: qv_old     ! beginning of time step value of qv    kg kg-1
     real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: pres       ! pressure                         Pa
     real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: dzq        ! vertical grid spacing            m
+    real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: npccn      ! IN ccn activated number tendency kg-1 s-1
+    real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: naai       ! IN actived ice nuclei concentration  1/kg
     real(rtype), intent(in)                                     :: dt         ! model time step                  s
 
     real(rtype), intent(out),   dimension(its:ite)              :: prt_liq    ! precipitation rate, liquid       m s-1
@@ -673,6 +675,10 @@ contains
              qirim(i,k) = 0.
              birim(i,k) = 0.
           endif
+
+
+         !Activaiton of cloud droplets 
+          nc(i,k) = nc(i,k) + npccn(i,k) * dt
 
           call calculate_incloud_mixingratios(qc(i,k),qr(i,k),qitot(i,k),qirim(i,k),nc(i,k),nr(i,k),nitot(i,k),birim(i,k), &
                   inv_lcldm(i,k),inv_icldm(i,k),inv_rcldm(i,k), &
@@ -1276,54 +1282,73 @@ contains
           endif
 
 
+          !................................................................
+          ! deposition/condensation-freezing nucleation
+          ! allow ice nucleation if < -15 C and > 5% ice supersaturation
+          ! use CELL-AVERAGE values, freezing of vapor
+
+          if ( t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
+            if(.not. log_predictNc) then 
+               ! dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)
+               dum = 0.005*exp(0.304*(zerodegc-t(i,k)))*1000.*inv_rho(i,k)   !Cooper (1986)
+               dum = min(dum,100.e3*inv_rho(i,k))
+               N_nuc = max(0.,(dum-nitot(i,k))*odt)
+               if (N_nuc.ge.1.e-20) then
+                  Q_nuc = max(0.,(dum-nitot(i,k))*mi0*odt)
+                  qinuc = Q_nuc
+                  ninuc = N_nuc
+               endif
+            else 
+            ! Ice nucleation predicted by aerosol scheme 
+               ninuc = max(0., (naai(i,k) - nitot(i,k))*odt)
+               qinuc = ninuc * mi0
+            endif 
+         endif 
+
           !.................................................................
           ! droplet activation
 
-          ! for specified Nc, make sure droplets are present if conditions are supersaturated
-          ! note that this is also applied at the first time step
-          ! this is not applied at the first time step, since saturation adjustment is applied at the first step
-
-          if (.not.(log_predictNc).and.sup(i,k).gt.1.e-6.and.it.gt.1) then
-             dum   = nccnst*inv_rho(i,k)*cons7-qc_incld(i,k)
-             dum   = max(0.,dum)
-             dumqvs = qv_sat(t(i,k),pres(i,k),0)
-             dqsdt = xxlv(i,k)*dumqvs/(rv*t(i,k)*t(i,k))
-             ab    = 1. + dqsdt*xxlv(i,k)*inv_cp
-             dum   = min(dum,(qv(i,k)-dumqvs)/ab)  ! limit overdepletion of supersaturation
-             qcnuc = dum*odt
-          endif
-
           if (log_predictNc) then
-
-             ! for predicted Nc, calculate activation explicitly from supersaturation
-             ! note that this is also applied at the first time step
-             ! note that this is also applied at the first time step
-
-             if (sup(i,k).gt.1.e-6) then
-                dum1  = 1./bact**0.5
-                sigvl = 0.0761 - 1.55e-4*(t(i,k)-zerodegc)
-                aact  = 2.*mw/(rhow*rr*t(i,k))*sigvl
-                sm1   = 2.*dum1*(aact*thrd*inv_rm1)**1.5
-                sm2   = 2.*dum1*(aact*thrd*inv_rm2)**1.5
-                uu1   = 2.*log(sm1/sup(i,k))/(4.242*log(sig1))
-                uu2   = 2.*log(sm2/sup(i,k))/(4.242*log(sig2))
-                dum1  = nanew1*0.5*(1.-erf(uu1)) ! activated number in kg-1 mode 1
-                dum2  = nanew2*0.5*(1.-erf(uu2)) ! activated number in kg-1 mode 2
-                ! make sure this value is not greater than total number of aerosol
-                dum2  = min((nanew1+nanew2),dum1+dum2)
-                dum2  = (dum2-nc_incld(i,k))*odt
-                dum2  = max(0.,dum2)
-                ncnuc = dum2
-                ! don't include mass increase from droplet activation during first time step
-                ! since this is already accounted for by saturation adjustment below
-                if (it.eq.1) then
-                   qcnuc = 0.
-                else
-                   qcnuc = ncnuc*cons7
-                endif
-             endif
-
-          endif
+            ! for predicted Nc, use activation predicted by aerosol scheme
+            ! note that this is also applied at the first time step
+            if (sup(i,k).gt.1.e-6) then
+               ! code removed below by K. Pressel 2/19 to allow for activation of droplets 
+               ! by the aerosol scheme 
+               !dum1  = 1./bact**0.5
+               !sigvl = 0.0761 - 1.55e-4*(t(i,k)-zerodegc)
+               !aact  = 2.*mw/(rhow*rr*t(i,k))*sigvl
+               !sm1   = 2.*dum1*(aact*thrd*inv_rm1)**1.5
+               !sm2   = 2.*dum1*(aact*thrd*inv_rm2)**1.5
+               !uu1   = 2.*log(sm1/sup(i,k))/(4.242*log(sig1))
+               !uu2   = 2.*log(sm2/sup(i,k))/(4.242*log(sig2))
+               !dum1  = nanew1*0.5*(1.-erf(uu1)) ! activated number in kg-1 mode 1
+               !dum2  = nanew2*0.5*(1.-erf(uu2)) ! activated number in kg-1 mode 2
+               !! make sure this value is not greater than total number of aerosol
+               !dum2  = min((nanew1+nanew2),dum1+dum2)
+               !dum2  = (dum2-nc(i,k))*odt
+               !dum2  = max(0.,dum2)
+               !ncnuc = dum2
+               ! don't include mass increase from droplet activation during first time step
+               ! since this is already accounted for by saturation adjustment below
+               ncnuc = npccn(i,k)
+               if (it.eq.1) then
+                  qcnuc = 0.
+               else
+                  !TODO Limit qcnuc so that conditions never become sub-saturated 
+                  qcnuc = ncnuc*cons7
+               endif
+            endif
+         else if (sup(i,k).gt.1.e-6.and.it.gt.1) then
+           ! for specified Nc, make sure droplets are present if conditions are supersaturated
+           ! this is not applied at the first time step, since saturation adjustment is applied at the first step
+            dum   = nccnst*inv_rho(i,k)*cons7-qc(i,k)
+            dum   = max(0.,dum)
+            dumqvs = qv_sat(t(i,k),pres(i,k),0)
+            dqsdt = xxlv(i,k)*dumqvs/(rv*t(i,k)*t(i,k))
+            ab    = 1. + dqsdt*xxlv(i,k)*inv_cp
+            dum   = min(dum,(qv(i,k)-dumqvs)/ab)  ! limit overdepletion of supersaturation
+            qcnuc = dum*odt
+         endif
 
           !................................................................
           ! saturation adjustment to get initial cloud water
@@ -1651,7 +1676,7 @@ contains
           qr(i,k) = qr(i,k) + (qcacc+qcaut+qrcon-qrevp)*dt
 
           if (log_predictNc) then
-             nc(i,k) = nc(i,k) + (-ncacc-ncautc+ncslf+ncnuc)*dt
+             nc(i,k) = nc(i,k) + (-ncacc-ncautc+ncslf)*dt
           else
              nc(i,k) = nccnst*inv_rho(i,k)
           endif

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -1243,7 +1243,7 @@ end subroutine micro_p3_readnl
     ! HANDLE AEROSOL ACTIVATION
     !==============
     !saving this for later... use prescribed Nd for now.
-    log_predictNc = .false.
+    log_predictNc = .true.
 
     ! GET "OLD" VALUES
     !==============
@@ -1364,6 +1364,8 @@ end subroutine micro_p3_readnl
          ssat(its:ite,kts:kte),       & ! INOUT  supersaturation (i.e., qv-qvs)   kg kg-1
          pres(its:ite,kts:kte),       & ! IN     pressure at cell midpoints       Pa
          dzq(its:ite,kts:kte),        & ! IN     vertical grid spacing            m
+         npccn(its:ite,kts:kte),      & ! IN ccn activation number tendency kg-1 s-1
+         naai(its:ite,kts:kte),       & ! IN activated ice nuclei concentration kg-1
          it,                          & ! IN     time step counter NOTE: starts at 1 for first time step
          prt_liq(its:ite),            & ! OUT    surface liquid precip rate       m s-1
          prt_sol(its:ite),            & ! OUT    surface frozen precip rate       m s-1

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -79,7 +79,7 @@ contains
   end subroutine p3_init_c
 
   subroutine p3_main_c(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
-       pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
+       pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
        diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc_in, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out) bind(C)
     use micro_p3, only : p3_main
@@ -87,6 +87,7 @@ contains
     real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, ssat, qv, th, th_old, qv_old
     real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qitot, qirim, nitot, birim
     real(kind=c_real), intent(in), dimension(its:ite,kts:kte) :: pres, dzq
+    real(kind=c_real), intent(in), dimension(its:ite,kts:kte) :: npccn,naai
     real(kind=c_real), value, intent(in) :: dt
     real(kind=c_real), intent(out), dimension(its:ite) :: prt_liq, prt_sol
     real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_ze, diag_effc
@@ -110,7 +111,7 @@ contains
     log_predictNc = log_predictNc_in
 
     call p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
-         pres,dzq,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
+         pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
          diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
          pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out)
   end subroutine p3_main_c

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -15,7 +15,7 @@ extern "C" {
   void p3_main_c(Real* qc, Real* nc, Real* qr, Real* nr, Real* th_old, Real* th,
                  Real* qv_old, Real* qv, Real dt, Real* qitot, Real* qirim,
                  Real* nitot, Real* birim, Real* ssat, Real* pres,
-                 Real* dzq, Int it, Real* prt_liq, Real* prt_sol, Int its,
+                 Real* dzq, Real* npccn, Real* naai, Int it, Real* prt_liq, Real* prt_sol, Int its,
                  Int ite, Int kts, Int kte, Real* diag_ze,
                  Real* diag_effc, Real* diag_effi, Real* diag_vmi,
                  Real* diag_di, Real* diag_rhoi,
@@ -51,6 +51,8 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   th_old = Array2("theta at beginning of timestep, K", ncol, nlev);
   pres = Array2("pressure, Pa", ncol, nlev);
   dzq = Array2("vertical grid spacing, m", ncol, nlev);
+  npccn = Array2("ccn activated number tendency, kg-1 s-1", ncol, nlev);
+  naai = Array2("activated nuclei concentration, kg-1", ncol, nlev);
   pdel = Array2("pressure thickness, Pa", ncol, nlev);
   exner = Array2("Exner expression", ncol, nlev);
   // Out
@@ -87,7 +89,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
         d_->name.data(),                                                \
         d_->name.size()})
   fdipb(qv); fdipb(th); fdipb(qv_old); fdipb(th_old); fdipb(pres);
-  fdipb(dzq); fdipb(qc); fdipb(nc); fdipb(qr); fdipb(nr);
+  fdipb(dzq); fdipb(npccn); fdipb(naai); fdipb(qc); fdipb(nc); fdipb(qr); fdipb(nr);
   fdipb(ssat); fdipb(qitot); fdipb(nitot);
   fdipb(qirim); fdipb(birim); fdipb(prt_liq); fdipb(prt_sol);
   fdipb(diag_ze); fdipb(diag_effc); fdipb(diag_effi);
@@ -124,7 +126,7 @@ void p3_main (const FortranData& d) {
   p3_main_c(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(), d.th_old.data(),
             d.th.data(), d.qv_old.data(), d.qv.data(), d.dt, d.qitot.data(),
             d.qirim.data(), d.nitot.data(), d.birim.data(), d.ssat.data(),
-            d.pres.data(), d.dzq.data(), d.it, d.prt_liq.data(),
+            d.pres.data(), d.dzq.data(), d.npccn.data(), d.naai.data(), d.it, d.prt_liq.data(),
             d.prt_sol.data(), 1, d.ncol, 1, d.nlev, d.diag_ze.data(),
             d.diag_effc.data(), d.diag_effi.data(), d.diag_vmi.data(),
             d.diag_di.data(), d.diag_rhoi.data(),

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -29,7 +29,7 @@ struct FortranData {
   // In
   Real dt;
   Int it;
-  Array2 qv, th, qv_old, th_old, pres, dzq, qc, nc, qr, nr, ssat, qitot, nitot, qirim, birim, pdel, exner;
+  Array2 qv, th, qv_old, th_old, pres, dzq, npccn, naai, qc, nc, qr, nr, ssat, qitot, nitot, qirim, birim, pdel, exner;
   // Out
   Array1 prt_liq, prt_sol;
   Array2 diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, diag_rhoi, cmeiout, prain, nevapr, prer_evap, rflx, sflx, rcldm, lcldm, icldm;

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 35);
+  REQUIRE(fdi.nfield() == 37);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);


### PR DESCRIPTION
This is a replacement PR for the aerosol activation. 

This PR adds a new feature to the Fortran implementation of P3 microphysics. In particular, it allows the number of aerosol particles that are activated to form cloud liquid droplets and ice particles, as predicted by the aerosol scheme, to be included as source terms to the cloud and ice number concentrations that are prognosed as part of P3 microphysics. This feature is turned on by default.

The implementation of the feature amounts to adding two source terms to the right hand sides of the prognostic equations for nitot and nc that depend on naii and npccn, respectively. Both naii and npccn are predicted by the aerosol scheme.

These modifications to the source code are a non-BFB change.