### PR TITLE
Enable checks for snow in radiation

### DIFF
--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -438,9 +438,13 @@ contains
 
       ! Get cloud and snow fractions, and combine
       call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cloud_fraction)
-      call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), snow_fraction)
-      combined_cloud_fraction(1:ncol,1:pver) = max(cloud_fraction(1:ncol,1:pver), &
-                                                   snow_fraction(1:ncol,1:pver))
+      if (snow_exists()) then
+         call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), snow_fraction)
+         combined_cloud_fraction(1:ncol,1:pver) = max(cloud_fraction(1:ncol,1:pver), &
+                                                      snow_fraction(1:ncol,1:pver))
+      else
+         combined_cloud_fraction(1:ncol,1:pver) = cloud_fraction(1:ncol,1:pver)
+      end if
 
       ! Do MCICA sampling of optics here. This will map bands to gpoints,
       ! while doing stochastic sampling of cloud state
@@ -569,11 +573,13 @@ contains
 
       ! Get cloud and snow fractions, and combine
       call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cloud_fraction)
-      call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), snow_fraction)
-
-      ! Combine cloud and snow fractions for MCICA sampling
-      combined_cloud_fraction(1:ncol,1:pver) = max(cloud_fraction(1:ncol,1:pver), &
-                                                   snow_fraction(1:ncol,1:pver))
+      if (snow_exists()) then
+         call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), snow_fraction)
+         combined_cloud_fraction(1:ncol,1:pver) = max(cloud_fraction(1:ncol,1:pver), &
+                                                      snow_fraction(1:ncol,1:pver))
+      else
+         combined_cloud_fraction(1:ncol,1:pver) = cloud_fraction(1:ncol,1:pver)
+      end if
 
       ! Do MCICA sampling of optics here. This will map bands to gpoints,
       ! while doing stochastic sampling of cloud state

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -104,12 +104,6 @@ contains
       real(r8), pointer :: iciwp(:,:), dei(:,:)
       real(r8), pointer :: cloud_fraction(:,:), snow_fraction(:,:)
 
-      ! Flag to see if we should be doing snow optics. To set this, we can look for
-      ! the "snow cloud fraction" on the physics buffer, and if found then set this
-      ! to .true.
-      logical :: do_snow_optics = .true.
-      integer :: err
-
       integer :: ncol, iband
 
       ! Initialize
@@ -147,60 +141,48 @@ contains
       call assert_range(liquid_tau(1:nswbands,1:ncol,1:pver), 0._r8, 1e20_r8, &
                         'get_cloud_optics_sw: liquid_tau')
 
-      ! Should we do snow optics? Check for existence of "cldfsnow" variable
-      ! NOTE: turned off for now...we need to figure out how to adjust the cloud
-      ! fraction seen by the mcica sampling as well when we are doing snow optics.
-      ! The thing to do then is probably to set this at the module level.
-      !call pbuf_get_index(pbuf, 'CLDFSNOW', err=err)
-      !if (err > 0) then
-      !   do_snow_optics = .true.
-      !else
-      !   do_snow_optics = .false.
-      !end if
-
-      ! Get snow cloud optics
-      if (do_snow_optics) then
-         ! Doing snow optics; call procedure to get these from CAM state and pbuf
-         call get_snow_optics_sw(state, pbuf, &
-                                 snow_tau, snow_tau_ssa, &
-                                 snow_tau_ssa_g, snow_tau_ssa_f)
-      else
-         ! We are not doing snow optics, so set these to zero so we can still use 
-         ! the arrays without additional logic
-         snow_tau(:,:,:) = 0.0
-         snow_tau_ssa(:,:,:) = 0.0
-         snow_tau_ssa_g(:,:,:) = 0.0
-         snow_tau_ssa_f(:,:,:) = 0.0
-      end if
-
-      ! Get cloud and snow fractions. This is used to weight the contribution to
-      ! the total lw absorption by the fraction of the column that contains
-      ! cloud vs snow. TODO: is this the right thing to do here?
-      call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cloud_fraction)
-      call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), snow_fraction)
-
       ! Combine all cloud optics from CAM routines
       cloud_tau = ice_tau + liquid_tau
       cloud_tau_ssa = ice_tau_ssa + liquid_tau_ssa
       cloud_tau_ssa_g = ice_tau_ssa_g + liquid_tau_ssa_g
-      call combine_properties( &
-         nswbands, ncol, pver, &
-         cloud_fraction(1:ncol,1:pver), cloud_tau(1:nswbands,1:ncol,1:pver), &
-         snow_fraction(1:ncol,1:pver), snow_tau(1:nswbands,1:ncol,1:pver), &
-         combined_tau(1:nswbands,1:ncol,1:pver) &
-      )
-      call combine_properties( &
-         nswbands, ncol, pver, &
-         cloud_fraction(1:ncol,1:pver), cloud_tau_ssa(1:nswbands,1:ncol,1:pver), &
-         snow_fraction(1:ncol,1:pver), snow_tau_ssa(1:nswbands,1:ncol,1:pver), &
-         combined_tau_ssa(1:nswbands,1:ncol,1:pver) &
-      )
-      call combine_properties( &
-         nswbands, ncol, pver, &
-         cloud_fraction(1:ncol,1:pver), cloud_tau_ssa_g(1:nswbands,1:ncol,1:pver), &
-         snow_fraction(1:ncol,1:pver), snow_tau_ssa_g(1:nswbands,1:ncol,1:pver), &
-         combined_tau_ssa_g(1:nswbands,1:ncol,1:pver) &
-      )
+
+      ! Merge in snow cloud optics
+      if (snow_exists()) then
+         ! Get cloud and snow fractions. This is used to weight the contribution to
+         ! the total lw absorption by the fraction of the column that contains
+         ! cloud vs snow. TODO: is this the right thing to do here?
+         call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cloud_fraction)
+         call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), snow_fraction)
+
+         ! Get snow optics from CAM routines
+         call get_snow_optics_sw(state, pbuf, &
+                                 snow_tau, snow_tau_ssa, &
+                                 snow_tau_ssa_g, snow_tau_ssa_f)
+
+         ! Merge snow and cloud optics, weighting by cloud and snow fractions
+         call combine_properties( &
+            nswbands, ncol, pver, &
+            cloud_fraction(1:ncol,1:pver), cloud_tau(1:nswbands,1:ncol,1:pver), &
+            snow_fraction(1:ncol,1:pver), snow_tau(1:nswbands,1:ncol,1:pver), &
+            combined_tau(1:nswbands,1:ncol,1:pver) &
+         )
+         call combine_properties( &
+            nswbands, ncol, pver, &
+            cloud_fraction(1:ncol,1:pver), cloud_tau_ssa(1:nswbands,1:ncol,1:pver), &
+            snow_fraction(1:ncol,1:pver), snow_tau_ssa(1:nswbands,1:ncol,1:pver), &
+            combined_tau_ssa(1:nswbands,1:ncol,1:pver) &
+         )
+         call combine_properties( &
+            nswbands, ncol, pver, &
+            cloud_fraction(1:ncol,1:pver), cloud_tau_ssa_g(1:nswbands,1:ncol,1:pver), &
+            snow_fraction(1:ncol,1:pver), snow_tau_ssa_g(1:nswbands,1:ncol,1:pver), &
+            combined_tau_ssa_g(1:nswbands,1:ncol,1:pver) &
+         )
+      else
+         combined_tau(:,:,:) = cloud_tau(:,:,:)
+         combined_tau_ssa(:,:,:) = cloud_tau_ssa(:,:,:)
+         combined_tau_ssa_g(:,:,:) = cloud_tau_ssa_g(:,:,:)
+      end if
       
       ! Copy to output arrays, converting to optical depth, single scattering
       ! albedo, and assymmetry parameter from the products that the CAM routines
@@ -274,22 +256,30 @@ contains
       ! Get liquid optics
       call get_liquid_optics_lw(state, pbuf, liq_tau)
 
-      ! Get snow optics?
-      call get_snow_optics_lw(state, pbuf, snow_tau)
-
-      ! Get cloud and snow fractions. This is used to weight the contribution to
-      ! the total lw absorption by the fraction of the column that contains
-      ! cloud vs snow. TODO: is this the right thing to do here?
-      call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cloud_fraction)
-      call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), snow_fraction)
-
       ! Combined cloud optics
       cloud_tau = liq_tau + ice_tau
-      call combine_properties(nlwbands, ncol, pver, &
-         cloud_fraction(1:ncol,1:pver), cloud_tau(1:nlwbands,1:ncol,1:pver), &
-         snow_fraction(1:ncol,1:pver), snow_tau(1:nlwbands,1:ncol,1:pver), &
-         combined_tau(1:nlwbands,1:ncol,1:pver) &
-      )
+
+      if (snow_exists()) then
+
+         ! Get snow optics?
+         call get_snow_optics_lw(state, pbuf, snow_tau)
+
+         ! Get cloud and snow fractions. This is used to weight the contribution to
+         ! the total lw absorption by the fraction of the column that contains
+         ! cloud vs snow. TODO: is this the right thing to do here?
+         call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cloud_fraction)
+         call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), snow_fraction)
+
+         ! Merge snow and cloud optics, weighting by snow and cloud fractions
+         call combine_properties(nlwbands, ncol, pver, &
+            cloud_fraction(1:ncol,1:pver), cloud_tau(1:nlwbands,1:ncol,1:pver), &
+            snow_fraction(1:ncol,1:pver), snow_tau(1:nlwbands,1:ncol,1:pver), &
+            combined_tau(1:nlwbands,1:ncol,1:pver) &
+         )
+
+      else
+         combined_tau(:,:,:) = cloud_tau(:,:,:)
+      end if
 
       ! Set optics_out
       do iband = 1,nlwbands
@@ -857,5 +847,26 @@ contains
    end subroutine output_cloud_optics_lw
 
    !----------------------------------------------------------------------------
+
+   ! Provide a logical function to determine whether or not we should do snow
+   ! optics. Depends on pbuf because we need to query the presence of snow
+   ! fields on the physics buffer
+   logical function snow_exists()
+
+      use physics_buffer, only: pbuf_get_index
+      integer :: idx, err
+
+      ! Should we do snow optics? Check for existence of "cldfsnow" variable
+      ! The thing to do then is probably to set this at the module level.
+      idx = pbuf_get_index('CLDFSNOW', errcode=err)
+      if (err > 0) then
+         snow_exists = .true.
+      else
+         snow_exists = .false.
+      end if
+
+      return
+
+   end function snow_exists
 
 end module cam_optics

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -863,7 +863,6 @@ contains
       integer :: idx, err
 
       ! Should we do snow optics? Check for existence of "cldfsnow" variable
-      ! The thing to do then is probably to set this at the module level.
       idx = pbuf_get_index('CLDFSNOW', errcode=err)
       if (err > 0) then
          snow_exists = .true.


### PR DESCRIPTION
Enable checks to see if "snow" variables exist in the physics buffer before trying to use them in cloud optics calculations. Snow is an important quantity in MG2 microphysics, and thus the existing radiative transfer interface includes code to include their radiative effects when calculating radiative fluxes and heating rates. However, snow is not treated separately in the P3 microphysics scheme, so it does not make sense to try to "fake" the radiative effects from a non-existent hydrometeor category. Thus, we do not require the snow variables to exist on the physics buffer, and only try to calculate snow optical properties if they do exist. This is BFB for MG2 configurations, and will now run when P3 is enabled as well. To validate that answers are BFB, compare baselines against any test using the `cam-rrtmgp` user-mods. E.g., `SMS_Ld1_P16x1.ne4_ne4.FC5AV1C-L.cori-knl_intel.cam-rrtmgp` (note that the RRTMGP implementation is not yet thread-safe, so you must specify `NTHRDS=1` when using RRTMGP).