### PR TITLE
Driver init ops mods

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -92,9 +92,9 @@ if (SCREAM_POSSIBLY_NO_PACK)
 endif ()
 set (SCREAM_POSSIBLY_NO_PACK_SIZE ${DEFAULT_POSSIBLY_NO_PACK_SIZE})
 # Checks on pack sizes relative to the master one:
-check_pack_size(${SCREAM_PACK_SIZE}, ${SCREAM_SMALL_PACK_SIZE}, "small pack")
+check_pack_size(${SCREAM_PACK_SIZE} ${SCREAM_SMALL_PACK_SIZE} "small pack")
 # This one is an internal check, as the user cannot set SCREAM_POSSIBLY_NO_PACK_SIZE now.
-check_pack_size(${SCREAM_PACK_SIZE}, ${SCREAM_POSSIBLY_NO_PACK_SIZE}, "possibly no pack")
+check_pack_size(${SCREAM_PACK_SIZE} ${SCREAM_POSSIBLY_NO_PACK_SIZE} "possibly no pack")
 
 ## Now we have pack sizes. Proceed with other config options that depend on
 ## these.

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -22,7 +22,11 @@ void AtmosphereDriver::initialize (const Comm& atm_comm, const ParameterList& pa
   const std::string& gm_type = gm_params.get<std::string>("Type");
   m_grids_manager.reset(GridsManagerFactory::instance().create(gm_type,m_atm_comm,gm_params));
 
-  // Let the processes register their fields in the repo
+  // Initialize the processes
+  m_atm_process_group->set_grid(m_grids_manager);
+
+  // By now, the processes should have fully built the ids of their
+  // required/computed fields. Let them register them in the repo
   m_device_field_repo.registration_begins();
   m_atm_process_group->register_fields(m_device_field_repo);
   m_device_field_repo.registration_ends();
@@ -30,7 +34,7 @@ void AtmosphereDriver::initialize (const Comm& atm_comm, const ParameterList& pa
   // TODO: this is a good place where we can insert a DAG analysis, to make sure all
   //       processes have their dependency met.
 
-  // Set all the fields in the processes needing them (before, they only had headers)
+  // Set all the fields in the processes needing them (before, they only had ids)
   // Input fields will be handed to the processes as const
   const auto& inputs  = m_atm_process_group->get_required_fields();
   const auto& outputs = m_atm_process_group->get_computed_fields();
@@ -43,7 +47,7 @@ void AtmosphereDriver::initialize (const Comm& atm_comm, const ParameterList& pa
   }
 
   // Initialize the processes
-  m_atm_process_group->initialize(m_grids_manager);
+  m_atm_process_group->initialize();
 }
 
 void AtmosphereDriver::run ( /* inputs ? */ ) {

--- a/components/scream/src/control/surface_coupling.cpp
+++ b/components/scream/src/control/surface_coupling.cpp
@@ -9,7 +9,11 @@ SurfaceCoupling (const Comm& comm, const ParameterList& /*params*/)
   // Grab what you need from the parameter list
 }
 
-void SurfaceCoupling::initialize (const std::shared_ptr<const GridsManager> /* grids_manager */) {
+void SurfaceCoupling::set_grid (const std::shared_ptr<const GridsManager> /* grids_manager */) {
+  // Get the grid from the grids manager.
+}
+
+void SurfaceCoupling::initialize () {
   // Initialize the FieldRepository (FR) for host fields
   // (i.e., fields that are I/O w.r.t the coupler)
 }

--- a/components/scream/src/control/surface_coupling.hpp
+++ b/components/scream/src/control/surface_coupling.hpp
@@ -32,9 +32,12 @@ public:
   // The communicator associated with this atm process
   const Comm& get_comm () const { return m_comm; }
 
+  // Get the grid from the grids manager
+  void set_grid (const std::shared_ptr<const GridsManager> grids_manager);
+
   // The initialization method should prepare all stuff needed to import/export from/to
   // f90 structures.
-  void initialize (const std::shared_ptr<const GridsManager> grids_manager);
+  void initialize ();
 
   // The run method is responsible for exporting atm states to the e3sm coupler, and
   // import surface states from the e3sm coupler.

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -43,8 +43,11 @@ public:
   // The communicator used by the dynamics
   const Comm& get_comm () const { return m_dynamics_comm; }
 
+  // Set the grid
+  void set_grid (const std::shared_ptr<const GridsManager> grids_manager);
+
   // These are the three main interfaces:
-  void initialize (const std::shared_ptr<const GridsManager> grids_manager);
+  void initialize ();
   void run        (/* what inputs? */);
   void finalize   (/* what inputs? */);
 
@@ -57,14 +60,9 @@ public:
 
 protected:
 
-  // Setting the field in the atmosphere process
-  void set_required_field_impl (const Field<const Real, device_type>& f) {
-    m_dyn_fields_in.emplace(f.get_header().get_identifier().name(),f);
-  }
-
-  void set_computed_field_impl (const Field<Real, device_type>& f) {
-    m_dyn_fields_out.emplace(f.get_header().get_identifier().name(),f);
-  }
+  // Setting the fields in the atmosphere process
+  void set_required_field_impl (const Field<const Real, device_type>& f);
+  void set_computed_field_impl (const Field<      Real, device_type>& f);
 
   std::set<FieldIdentifier> m_required_fields;
   std::set<FieldIdentifier> m_computed_fields;

--- a/components/scream/src/share/atmosphere_process.hpp
+++ b/components/scream/src/share/atmosphere_process.hpp
@@ -50,6 +50,11 @@ public:
   // The communicator associated with this atm process
   virtual const Comm& get_comm () const = 0;
 
+  // Give the grids manager to the process, so it can grab its grid
+  // IMPORTANT: the process is *expected* to have valid field ids for
+  //            required/computed fields once this method returns
+  virtual void set_grid (const std::shared_ptr<const GridsManager> grids_manager) = 0;
+
   // These are the three main interfaces:
   //   - the initialize method sets up all the stuff the process needs to run,
   //     including arrays/views, parameters, and precomputed stuff.
@@ -63,13 +68,14 @@ public:
   // run method can (and usually will) be called multiple times.
   // We should put asserts to verify that the process has been init-ed, when
   // run/finalize is called.
-  virtual void initialize (const std::shared_ptr<const GridsManager> grids_manager) = 0;
+  virtual void initialize () = 0;
   virtual void run        (/* what inputs? */) = 0;
   virtual void finalize   (/* what inputs? */) = 0;
 
   // These methods set fields in the atm process. Fields live on device and they are all 1d.
   // If the process *needs* to store the field as n-dimensional field, use the
   // template function 'get_reshaped_view' (see field.hpp for details).
+  // Note: this method will be called *after* set_grid, but *before* initialize
   void set_required_field (const Field<const Real, device_type>& f) {
     error::runtime_check(requires(f.get_header().get_identifier()),
                          "Error! This atmosphere process does not require this field. "

--- a/components/scream/src/share/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atmosphere_process_group.cpp
@@ -41,14 +41,6 @@ AtmosphereProcessGroup (const Comm& comm, const ParameterList& params)
     for (const auto& name : m_atm_processes.back()->get_required_grids()) {
       m_required_grids.insert(name);
     }
-
-    // Add inputs/outputs to the list of inputs/outputs of this group
-    for (const auto& id : m_atm_processes[i]->get_required_fields()) {
-      m_required_fields.insert(id);
-    }
-    for (const auto& id : m_atm_processes[i]->get_computed_fields()) {
-      m_computed_fields.insert(id);
-    }
   }
 
   if (params.get<std::string>("Schedule Type") == "Sequential") {
@@ -62,10 +54,25 @@ AtmosphereProcessGroup (const Comm& comm, const ParameterList& params)
   error::runtime_check(m_group_schedule_type==GroupScheduleType::Sequential, "Error! Parallel schedule not yet implemented.\n");
 }
 
-void AtmosphereProcessGroup::initialize (const std::shared_ptr<const GridsManager> grids_manager) {
+void AtmosphereProcessGroup::set_grid (const std::shared_ptr<const GridsManager> grids_manager) {
+
+  for (int i=0; i<m_group_size; ++i) {
+    m_atm_processes[i]->set_grid(grids_manager);
+
+    // Add inputs/outputs to the list of inputs/outputs of this group
+    for (const auto& id : m_atm_processes[i]->get_required_fields()) {
+      m_required_fields.insert(id);
+    }
+    for (const auto& id : m_atm_processes[i]->get_computed_fields()) {
+      m_computed_fields.insert(id);
+    }
+  }
+}
+
+void AtmosphereProcessGroup::initialize () {
   // Now that we have the comm for the processes in the group, we can initialize them
   for (int i=0; i<m_group_size; ++i) {
-    m_atm_processes[i]->initialize(grids_manager);
+    m_atm_processes[i]->initialize();
   }
 }
 

--- a/components/scream/src/share/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atmosphere_process_group.hpp
@@ -47,10 +47,15 @@ public:
   // The communicator associated with this atm process
   const Comm& get_comm () const { return m_comm; }
 
+  // Grab the proper grid from the grids manager
+  void set_grid (const std::shared_ptr<const GridsManager> grids_manager);
+
   // The initialization, run, and finalization methods
-  void initialize (const std::shared_ptr<const GridsManager> grids_manager);
+  void initialize ();
   void run        (/* what inputs? */);
   void finalize   (/* what inputs? */);
+
+  void final_setup ();
 
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real, device_type>& field_repo) const;

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -30,10 +30,14 @@ public:
   // The communicator associated with this atm process
   const Comm& get_comm () const { return m_comm; }
 
+  void set_grid (const std::shared_ptr<const GridsManager> /* grids_manager */) {
+    // Do nothing
+  }
+
   // The initialization method should prepare all stuff needed to import/export from/to
   // f90 structures.
-  void initialize (const std::shared_ptr<const GridsManager> grids_manager) {
-    (void) grids_manager;
+  void initialize () {
+    // Do nothing
   }
 
   // The run method is responsible for exporting atm states to the e3sm coupler, and


### PR DESCRIPTION
This PR changes slightly how the driver creates/initializes the processes. In particular, this is what happened before:

1. create all processes
2. make all processes register required/computed fields in the repo
3. create all fields, and set them in the processes
4. call initialize on the fields

Step 1 was supposed to create valid field ids for all required/computed fields in the process. However, this was not possible in general, since that would require information on the grid (namely, the number of columns), which was only passed to the process during the initialize call.

This went undetected while working with HommeDynamics (HD) only, since that's a very special case: Homme is in charge of creating the grids, so the constructor of HD already had all the info that it needed to create the field ids. This is no longer true for other processes.
Moving the call to initialize between step 1 and 2 seemed appealing, but it would be problematic for the HD process: in fact, HD aims to replace the pointers of some key views in Hommexx's Elements structure with pointers coming from the fields registered in the repo. However, this has to be done *before* Homme is fully inited, since at that point the Elements structure is _copied_ into the C++ functors, and any subsequent change in the Elements' views' pointers would not be reflected in the functors.

Long story short, the order of the function calls was good. The only thing to change was that the processes need somehow to get the grid specs before they start registering fields in the repo. This is solved by adding a `set_grid` method, which the driver calls after construction, but before asking to register fields in the repo.

Finally, this PR also fixes a warning in the main CMakeLists.txt file, due to syntax supported in cmake 3.10 but not  in cmake 3.13.