### PR TITLE
Aaron/p3 rad fix

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -325,7 +325,7 @@ contains
        pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
        diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,  &
-       pratot,prctot,p3_tend_out)
+       pratot,prctot,p3_tend_out,mu_c,lamc)
 
     !----------------------------------------------------------------------------------------!
     !                                                                                        !
@@ -373,7 +373,9 @@ contains
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_effi  ! effective radius, ice            m
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_vmi   ! mass-weighted fall speed of ice  m s-1
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_di    ! mean diameter of ice             m
-    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_rhoi  ! bulk density of ice              kg m-1
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_rhoi  ! bulk density of ice              kg m-3
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: mu_c       ! Size distribution shape parameter for radiation
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: lamc       ! Size distribution slope parameter for radiation
 
     integer, intent(in)                                  :: its,ite    ! array bounds (horizontal)
     integer, intent(in)                                  :: kts,kte    ! array bounds (vertical)
@@ -408,10 +410,8 @@ contains
 
     ! 2D size distribution and fallspeed parameters:
 
-    real(rtype), dimension(its:ite,kts:kte) :: lamc
     real(rtype), dimension(its:ite,kts:kte) :: lamr
     real(rtype), dimension(its:ite,kts:kte) :: logn0r
-    real(rtype), dimension(its:ite,kts:kte) :: mu_c
 
     real(rtype), dimension(its:ite,kts:kte) :: nu
     real(rtype), dimension(its:ite,kts:kte) :: cdist

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1738,14 +1738,14 @@ contains
           p3_tend_out(i,k,34) = 0._rtype  ! used to be qcmul, but that has been removed.  Kept at 0.0 as placeholder.
           p3_tend_out(i,k,35) = ncshdc    ! source for rain number due to cloud water/ice collision above freezing  and shedding (combined with NRSHD in the paper) 
           ! measure microphysics processes tendency output
-          p3_tend_out(i,k,42) = qc(i,k)    - p3_tend_out(i,k,42) ! Liq. microphysics tendency, measure 
-          p3_tend_out(i,k,43) = nc(i,k)    - p3_tend_out(i,k,43) ! Liq. # microphysics tendency, measure 
-          p3_tend_out(i,k,44) = qr(i,k)    - p3_tend_out(i,k,44) ! Rain microphysics tendency, measure 
-          p3_tend_out(i,k,45) = nr(i,k)    - p3_tend_out(i,k,45) ! Rain # microphysics tendency, measure 
-          p3_tend_out(i,k,46) = qitot(i,k) - p3_tend_out(i,k,46) ! Ice  microphysics tendency, measure 
-          p3_tend_out(i,k,47) = nitot(i,k) - p3_tend_out(i,k,47) ! Ice  # microphysics tendency, measure 
-          p3_tend_out(i,k,48) = qv(i,k)    - p3_tend_out(i,k,48) ! Vapor  microphysics tendency, measure 
-          p3_tend_out(i,k,49) = th(i,k)    - p3_tend_out(i,k,49) ! Pot. Temp. microphysics tendency, measure 
+          p3_tend_out(i,k,42) = ( qc(i,k)    - p3_tend_out(i,k,42) ) * odt ! Liq. microphysics tendency, measure 
+          p3_tend_out(i,k,43) = ( nc(i,k)    - p3_tend_out(i,k,43) ) * odt ! Liq. # microphysics tendency, measure 
+          p3_tend_out(i,k,44) = ( qr(i,k)    - p3_tend_out(i,k,44) ) * odt ! Rain microphysics tendency, measure 
+          p3_tend_out(i,k,45) = ( nr(i,k)    - p3_tend_out(i,k,45) ) * odt ! Rain # microphysics tendency, measure 
+          p3_tend_out(i,k,46) = ( qitot(i,k) - p3_tend_out(i,k,46) ) * odt ! Ice  microphysics tendency, measure 
+          p3_tend_out(i,k,47) = ( nitot(i,k) - p3_tend_out(i,k,47) ) * odt ! Ice  # microphysics tendency, measure 
+          p3_tend_out(i,k,48) = ( qv(i,k)    - p3_tend_out(i,k,48) ) * odt ! Vapor  microphysics tendency, measure 
+          p3_tend_out(i,k,49) = ( th(i,k)    - p3_tend_out(i,k,49) ) * odt ! Pot. Temp. microphysics tendency, measure 
           ! Outputs associated with aerocom comparison:
           pratot(i,k) = qcacc ! cloud drop accretion by rain
           prctot(i,k) = qcaut ! cloud drop autoconversion to rain 
@@ -1929,8 +1929,8 @@ contains
           prt_liq(i) = prt_accum*inv_rhow*odt  !note, contribution from rain is added below
 
        endif qc_present
-       p3_tend_out(i,:,36) = qc(i,:) - p3_tend_out(i,:,36) ! Liq. sedimentation tendency, measure
-       p3_tend_out(i,:,37) = nc(i,:) - p3_tend_out(i,:,37) ! Liq. # sedimentation tendency, measure
+       p3_tend_out(i,:,36) = ( qc(i,:) - p3_tend_out(i,:,36) ) * odt ! Liq. sedimentation tendency, measure
+       p3_tend_out(i,:,37) = ( nc(i,:) - p3_tend_out(i,:,37) ) * odt ! Liq. # sedimentation tendency, measure
 
 
        !------------------------------------------------------------------------------------------!
@@ -2063,8 +2063,8 @@ contains
           prt_liq(i) = prt_liq(i) + prt_accum*inv_rhow*odt
 
        endif qr_present
-       p3_tend_out(i,:,38) = qr(i,:) - p3_tend_out(i,:,38) ! Rain sedimentation tendency, measure
-       p3_tend_out(i,:,39) = nr(i,:) - p3_tend_out(i,:,39) ! Rain # sedimentation tendency, measure
+       p3_tend_out(i,:,38) = ( qr(i,:) - p3_tend_out(i,:,38) ) * odt ! Rain sedimentation tendency, measure
+       p3_tend_out(i,:,39) = ( nr(i,:) - p3_tend_out(i,:,39) ) * odt ! Rain # sedimentation tendency, measure
 
 
        !------------------------------------------------------------------------------------------!
@@ -2198,8 +2198,8 @@ contains
           prt_sol(i) = prt_sol(i) + prt_accum*inv_rhow*odt
 
        endif qi_present
-       p3_tend_out(i,:,40) = qitot(i,:) - p3_tend_out(i,:,40) ! Ice sedimentation tendency, measure
-       p3_tend_out(i,:,41) = nitot(i,:) - p3_tend_out(i,:,41) ! Ice # sedimentation tendency, measure
+       p3_tend_out(i,:,40) = ( qitot(i,:) - p3_tend_out(i,:,40) ) * odt ! Ice sedimentation tendency, measure
+       p3_tend_out(i,:,41) = ( nitot(i,:) - p3_tend_out(i,:,41) ) * odt ! Ice # sedimentation tendency, measure
 
        !------------------------------------------------------------------------------------------!
 

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -480,8 +480,8 @@ end subroutine micro_p3_readnl
    call addfld ('FREQI', (/ 'lev' /), 'A', 'fraction', 'Fractional occurrence of ice'                             )
 
    ! Average cloud top particle size and number (liq, ice) and frequency
-   call addfld ('REL', (/ 'lev' /), 'A', 'micron', 'MG REL stratiform cloud effective radius liquid')
-   call addfld ('REI', (/ 'lev' /), 'A', 'micron', 'MG REI stratiform cloud effective radius ice')
+   call addfld ('REL', (/ 'lev' /), 'A', 'micron', 'REL stratiform cloud effective radius liquid')
+   call addfld ('REI', (/ 'lev' /), 'A', 'micron', 'REI stratiform cloud effective radius ice')
 
 !!== KZ_DCS
    call addfld ('DCST',(/ 'lev' /), 'A','m','dcs')

--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -23,8 +23,8 @@ module micro_p3_utils
     public :: rtype
 #endif
 
-    public :: get_latent_heat, micro_p3_utils_init, size_dist_param_liq, &
-              size_dist_param_basic,avg_diameter, rising_factorial, calculate_incloud_mixingratios
+    public :: get_latent_heat, micro_p3_utils_init, &
+              avg_diameter, calculate_incloud_mixingratios
 
     integer, public :: iulog_e3sm
     logical, public :: masterproc_e3sm
@@ -68,36 +68,8 @@ module micro_p3_utils
     integer, public,parameter :: iparam = 3
 
     real(rtype), parameter, public :: mincld=0.0001_rtype
-    real(rtype), parameter, public :: rhosn = 250._rtype  ! bulk density snow
-    real(rtype), parameter, public :: rhoi = 500._rtype   ! bulk density ice
     real(rtype), parameter, public :: rhows = 917._rtype  ! bulk density water solid
 
-
-public :: MicroHydrometeorProps
-
-type :: MicroHydrometeorProps
-   ! Density (kg/m^3)
-   real(rtype) :: rho
-   ! Information for size calculations.
-   ! Basic calculation of mean size is:
-   !     lambda = (shape_coef*nic/qic)^(1/eff_dim)
-   ! Then lambda is constrained by bounds.
-   real(rtype) :: eff_dim
-   real(rtype) :: shape_coef
-   real(rtype) :: lambda_bounds(2)
-   ! Minimum average particle mass (kg).
-   ! Limit is applied at the beginning of the size distribution calculations.
-   real(rtype) :: min_mean_mass
-end type MicroHydrometeorProps
-
-interface MicroHydrometeorProps
-   module procedure NewMicroHydrometeorProps
-end interface
-
-type(MicroHydrometeorProps), public :: micro_liq_props
-type(MicroHydrometeorProps), public :: micro_ice_props
-type(MicroHydrometeorProps), public :: micro_rain_props
-type(MicroHydrometeorProps), public :: micro_snow_props
 
 ! particle mass-diameter relationship
 ! currently we assume spherical particles for cloud ice/snow
@@ -117,20 +89,6 @@ real(rtype), parameter :: min_mean_mass_ice = 1.e-20_rtype
 REAL(rtype), PARAMETER :: cldm_min   = 1.e-20_rtype !! threshold min value for cloud fraction
 real(rtype), parameter :: incloud_limit = 5.1E-3
 real(rtype), parameter :: precip_limit  = 1.0E-2
-!=========================================================
-! Utilities that are cheaper if the compiler knows that
-! some argument is an integer.
-!=========================================================
-
-interface rising_factorial
-   module procedure rising_factorial_rtype
-   module procedure rising_factorial_integer
-end interface rising_factorial
-
-interface var_coef
-   module procedure var_coef_rtype
-   module procedure var_coef_integer
-end interface var_coef
 
     contains
 !__________________________________________________________________________________________!
@@ -263,20 +221,6 @@ end interface var_coef
     clbfact_dep = 1._rtype
     clbfact_sub = 1._rtype
 
-    ! Don't specify lambda bounds for cloud liquid, as they are determined by
-    ! pgam dynamically.
-    micro_liq_props = MicroHydrometeorProps(rhow, dsph, &
-         min_mean_mass=min_mean_mass_liq)
-  
-    ! Mean ice diameter can not grow bigger than twice the autoconversion
-    ! threshold for snow.
-    ice_lambda_bounds = 1._rtype/[2._rtype*400.e-6_rtype, 10.e-6_rtype] !! dcs 400.e-6
-    micro_ice_props = MicroHydrometeorProps(rhoi, dsph, &
-         ice_lambda_bounds, min_mean_mass_ice)
-  
-    micro_rain_props = MicroHydrometeorProps(rhow, dsph, lam_bnd_rain)
-    micro_snow_props = MicroHydrometeorProps(rhosn, dsph, lam_bnd_snow)
-    
     return
     end subroutine micro_p3_utils_init
 !__________________________________________________________________________________________!
@@ -364,108 +308,6 @@ end interface var_coef
 !__________________________________________________________________________________________!
 !                                                                                          !
 !__________________________________________________________________________________________!
-! get cloud droplet size distribution parameters
-elemental subroutine size_dist_param_liq(props, qcic, ncic, rho, pgam, lamc)
-  type(MicroHydrometeorProps), intent(in) :: props
-  real(rtype), intent(in) :: qcic
-  real(rtype), intent(inout) :: ncic
-  real(rtype), intent(in) :: rho
-
-  real(rtype), intent(out) :: pgam
-  real(rtype), intent(out) :: lamc
-
-  type(MicroHydrometeorProps) :: props_loc
-
-  if (qcic > qsmall) then
-
-     ! Local copy of properties that can be modified.
-     ! (Elemental routines that operate on arrays can't modify scalar
-     ! arguments.)
-     props_loc = props
-
-     ! Get pgam from fit to observations of martin et al. 1994
-#if ! defined(CLUBB_BFB_S2) && ! defined(CLUBB_BFB_ALL)
-     pgam = 0.0005714_rtype*(ncic/1.e6_rtype*rho) + 0.2714_rtype
-     pgam = 1._rtype/(pgam**2) - 1._rtype
-     pgam = max(pgam, 2._rtype)
-     pgam = min(pgam, 15._rtype)
-
-     ! Set coefficient for use in size_dist_param_basic.
-     props_loc%shape_coef = pi_e3sm * props_loc%rho / 6._rtype * &
-          rising_factorial(pgam+1._rtype, props_loc%eff_dim)
-#else
-     pgam = 0.0005714_rtype*1.e-6_rtype*ncic*rho + 0.2714_rtype
-     pgam = 1._rtype/(pgam**2) - 1._rtype
-     pgam = max(pgam, 2._rtype)
-
-     ! Set coefficient for use in size_dist_param_basic.
-     ! The 3D case is so common and optimizable that we specialize it:
-     if (props_loc%eff_dim == 3._rtype) then
-        props_loc%shape_coef = pi_e3sm / 6._rtype * props_loc%rho * &
-             rising_factorial(pgam+1._rtype, 3)
-     else
-        props_loc%shape_coef = pi_e3sm / 6._rtype * props_loc%rho * &
-             rising_factorial(pgam+1._rtype, props_loc%eff_dim)
-     end if
-#endif
-
-     ! Limit to between 2 and 50 microns mean size.
-     props_loc%lambda_bounds = (pgam+1._rtype)*1._rtype/[50.e-6_rtype, 2.e-6_rtype]
-
-     call size_dist_param_basic(props_loc, qcic, ncic, lamc)
-
-  else
-     ! pgam not calculated in this case, so set it to a value likely to
-     ! cause an error if it is accidentally used
-     ! (gamma function undefined for negative integers)
-     pgam = -100._rtype
-     lamc = 0._rtype
-  end if
-
-end subroutine size_dist_param_liq
-!__________________________________________________________________________________________!
-!                                                                                          !
-!__________________________________________________________________________________________!
-! Basic routine for getting size distribution parameters.
-elemental subroutine size_dist_param_basic(props, qic, nic, lam, n0)
-  type(MicroHydrometeorProps), intent(in) :: props
-  real(rtype), intent(in) :: qic
-  real(rtype), intent(inout) :: nic
-
-  real(rtype), intent(out) :: lam
-  real(rtype), intent(out), optional :: n0
-
-  if (qic > qsmall) then
-
-     ! add upper limit to in-cloud number concentration to prevent
-     ! numerical error
-     if (limiter_is_on(props%min_mean_mass)) then
-        nic = min(nic, qic / props%min_mean_mass)
-     end if
-
-     ! lambda = (c n/q)^(1/d)
-     lam = (props%shape_coef * nic/qic)**(1._rtype/props%eff_dim)
-
-     ! check for slope
-     ! adjust vars
-     if (lam < props%lambda_bounds(1)) then
-        lam = props%lambda_bounds(1)
-        nic = lam**(props%eff_dim) * qic/props%shape_coef
-     else if (lam > props%lambda_bounds(2)) then
-        lam = props%lambda_bounds(2)
-        nic = lam**(props%eff_dim) * qic/props%shape_coef
-     end if
-
-  else
-     lam = 0._rtype
-  end if
-
-  if (present(n0)) n0 = nic * lam
-
-end subroutine size_dist_param_basic
-!__________________________________________________________________________________________!
-!                                                                                          !
-!__________________________________________________________________________________________!
 
 real(rtype) elemental function avg_diameter(q, n, rho_air, rho_sub)
   ! Finds the average diameter of particles given their density, and
@@ -479,108 +321,6 @@ real(rtype) elemental function avg_diameter(q, n, rho_air, rho_sub)
   avg_diameter = (pi_e3sm * rho_sub * n/(q*rho_air))**(-1._rtype/3._rtype)
 
 end function avg_diameter
-!__________________________________________________________________________________________!
-!                                                                                          !
-!__________________________________________________________________________________________!
-! Constructor for a constituent property object.
-function NewMicroHydrometeorProps(rho, eff_dim, lambda_bounds, min_mean_mass) &
-     result(res)
-  real(rtype), intent(in) :: rho, eff_dim
-  real(rtype), intent(in), optional :: lambda_bounds(2), min_mean_mass
-  type(MicroHydrometeorProps) :: res
-
-  res%rho = rho
-  res%eff_dim = eff_dim
-  if (present(lambda_bounds)) then
-     res%lambda_bounds = lambda_bounds
-  else
-     res%lambda_bounds = no_limiter()
-  end if
-  if (present(min_mean_mass)) then
-     res%min_mean_mass = min_mean_mass
-  else
-     res%min_mean_mass = no_limiter()
-  end if
-
-  res%shape_coef = rho*pi_e3sm*gamma(eff_dim+1._rtype)/6._rtype
-
-end function NewMicroHydrometeorProps
-!__________________________________________________________________________________________!
-!                                                                                          !
-!__________________________________________________________________________________________!
-!========================================================================
-!UTILITIES
-!========================================================================
-
-pure function no_limiter()
-  real(rtype) :: no_limiter
-
-  no_limiter = transfer(limiter_off, no_limiter)
-
-end function no_limiter
-
-pure function limiter_is_on(lim)
-  real(rtype), intent(in) :: lim
-  logical :: limiter_is_on
-
-  limiter_is_on = transfer(lim, limiter_off) /= limiter_off
-
-end function limiter_is_on
-!========================================================================
-!FORMULAS
-!========================================================================
-
-! Use gamma function to implement rising factorial extended to the reals.
-pure function rising_factorial_rtype(x, n) result(res)
-  real(rtype), intent(in) :: x, n
-  real(rtype) :: res
-
-  res = gamma(x+n)/gamma(x)
-
-end function rising_factorial_rtype
-
-! Rising factorial can be performed much cheaper if n is a small integer.
-pure function rising_factorial_integer(x, n) result(res)
-  real(rtype), intent(in) :: x
-  integer, intent(in) :: n
-  real(rtype) :: res
-
-  integer :: i
-  real(rtype) :: factor
-
-  res = 1._rtype
-  factor = x
-
-  do i = 1, n
-     res = res * factor
-     factor = factor + 1._rtype
-  end do
-
-end function rising_factorial_integer
-
-elemental function var_coef_rtype(relvar, a) result(res)
-  ! Finds a coefficient for process rates based on the relative variance
-  ! of cloud water.
-  real(rtype), intent(in) :: relvar
-  real(rtype), intent(in) :: a
-  real(rtype) :: res
-
-  res = rising_factorial(relvar, a) / relvar**a
-
-end function var_coef_rtype
-
-elemental function var_coef_integer(relvar, a) result(res)
-  ! Finds a coefficient for process rates based on the relative variance
-  ! of cloud water.
-  real(rtype), intent(in) :: relvar
-  integer, intent(in) :: a
-  real(rtype) :: res
-
-  res = rising_factorial(relvar, a) / relvar**a
-
-end function var_coef_integer
-
-
 
 
 end module micro_p3_utils

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -83,7 +83,7 @@ contains
        pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
        diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc_in, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm, &
-       pratot,prctot,p3_tend_out) bind(C)
+       pratot,prctot,p3_tend_out,mu_c,lamc) bind(C)
     use micro_p3, only : p3_main
 
     real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, ssat, qv, th, th_old, qv_old
@@ -108,6 +108,7 @@ contains
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: icldm, lcldm, rcldm
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: pratot,prctot
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte,49)   :: p3_tend_out
+    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: mu_c,lamc
 
     logical :: log_predictNc
 
@@ -117,7 +118,7 @@ contains
          pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
          diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
          pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm, &
-         pratot,prctot,p3_tend_out)
+         pratot,prctot,p3_tend_out,mu_c,lamc)
   end subroutine p3_main_c
 
    

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -24,7 +24,7 @@ extern "C" {
                  Real* nevapr, Real* prer_evap,
                  Real* rflx, Real* sflx, // 1 extra column size
                  Real* rcldm, Real* lcldm, Real* icldm, Real* pratot, Real* prctot, 
-                 Real* p3_tend_out);
+                 Real* p3_tend_out, Real* mu_c, Real* lamc);
 }
 
 namespace scream {
@@ -77,6 +77,8 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   pratot = Array2("Cloud drop accretion by rain", ncol, nlev);
   prctot = Array2("Cloud drop autoconversion to rain", ncol, nlev);
   p3_tend_out = Array3("Microphysics Tendencies", ncol, nlev, 49);
+  mu_c = Array2("Size distribution shape paramter", ncol, nlev);
+  lamc = Array2("Size distribution slope paramter", ncol, nlev);
 }
 
 FortranDataIterator::FortranDataIterator (const FortranData::Ptr& d) {
@@ -102,6 +104,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(rflx); fdipb(sflx);
   fdipb(rcldm); fdipb(lcldm); fdipb(icldm); 
   fdipb(pratot); fdipb(prctot); fdipb(p3_tend_out);
+  fdipb(mu_c); fdipb(lamc);
 #undef fdipb
 }
 
@@ -139,7 +142,7 @@ void p3_main (const FortranData& d) {
             d.nevapr.data(), d.prer_evap.data(),
             d.rflx.data(), d.sflx.data(),
             d.rcldm.data(), d.lcldm.data(), d.icldm.data(),d.pratot.data(),d.prctot.data(),
-            d.p3_tend_out.data());
+            d.p3_tend_out.data(),d.mu_c.data(),d.lamc.data());
 }
 
 int test_FortranData () {

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -35,6 +35,7 @@ struct FortranData {
   Array2 diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, diag_rhoi, cmeiout, prain, nevapr, prer_evap, rflx, sflx, rcldm, lcldm, icldm;
   Array2 pratot, prctot;
   Array3 p3_tend_out;
+  Array2 mu_c, lamc;
 
   FortranData(Int ncol, Int nlev);
 };

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 39);
+  REQUIRE(fdi.nfield() == 41);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);


### PR DESCRIPTION
    Bugfix for variables passed from P3 microphysics to radiation scheme.
    
    This commit fixes an issue where the values passed from the P3-microphysics
    scheme to the radiation scheme were inconsistent with P3.  This commit:
    
    1) Removes a number of subroutines taken from MG microphysics that are
    no longer needed/used.
    2) Uses the effective radius for liquid (rel) and ice (rei) as determined inside P3,
    instead of taking values that are calculated based on MG subroutines.
    3) Furthermore, the bulk density of ice used to calculate the effective diameter
    of ice (dei) is taken from P3 instead of being a fixed constant.

Below are two year annual climatologies for,

top)       this PR
center)  MG microphysics
bottom) w/ P3 after PR #82

![image](https://user-images.githubusercontent.com/11351562/57941380-9eb19d80-7883-11e9-967e-4bf74f91eed5.png)

![image](https://user-images.githubusercontent.com/11351562/57941399-b12bd700-7883-11e9-9d7e-6064fcb99a43.png)

![image](https://user-images.githubusercontent.com/11351562/57941441-d1f42c80-7883-11e9-96d5-f432c7726260.png)

