### PR TITLE
Kylepressel/p3 subroutines

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -924,7 +924,7 @@ contains
 
           !............................................................
           ! calculate wet growth
-          call calc_wet_growth(rho(i,k),t(i,k),pres(i,k),rhofaci(i,k),&
+          call ice_cldliq_wet_growth(rho(i,k),t(i,k),pres(i,k),rhofaci(i,k),&
           f1pr05,f1pr14,xxlv(i,k),xlf(i,k),dv,kap,mu,sc,&
           qv(i,k),qc_incld(i,k),qitot_incld(i,k),nitot_incld(i,k),qr_incld(i,k),log_wetgrowth,&
                qrcol,qccol,qwgrth,nrshdr,qcshd)
@@ -3051,7 +3051,7 @@ f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,    &
 end subroutine ice_melting
 
 
-subroutine calc_wet_growth(rho,t,pres,rhofaci,    &
+subroutine ice_cldliq_wet_growth(rho,t,pres,rhofaci,    &
 f1pr05,f1pr14,xxlv,xlf,dv,kap,mu,sc,    &
 qv,qc_incld,qitot_incld,nitot_incld,qr_incld,    &
            log_wetgrowth,qrcol,qccol,qwgrth,nrshdr,qcshd)
@@ -3113,7 +3113,7 @@ qv,qc_incld,qitot_incld,nitot_incld,qr_incld,    &
 
 
 
-end subroutine calc_wet_growth 
+end subroutine ice_cldliq_wet_growth 
 
 
 subroutine ice_relaxation_timescale(rho,t,rhofaci,     &

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -924,7 +924,7 @@ contains
 
           !............................................................
           ! calculate wet growth
-          call wet_growth(rho(i,k),t(i,k),pres(i,k),rhofaci(i,k),&
+          call calc_wet_growth(rho(i,k),t(i,k),pres(i,k),rhofaci(i,k),&
           f1pr05,f1pr14,xxlv(i,k),xlf(i,k),dv,kap,mu,sc,&
           qv(i,k),qc_incld(i,k),qitot_incld(i,k),nitot_incld(i,k),qr_incld(i,k),log_wetgrowth,&
                qrcol,qccol,qwgrth,nrshdr,qcshd)
@@ -3051,7 +3051,7 @@ f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,    &
 end subroutine ice_melting
 
 
-subroutine wet_growth(rho,t,pres,rhofaci,    &
+subroutine calc_wet_growth(rho,t,pres,rhofaci,    &
 f1pr05,f1pr14,xxlv,xlf,dv,kap,mu,sc,    &
 qv,qc_incld,qitot_incld,nitot_incld,qr_incld,    &
            log_wetgrowth,qrcol,qccol,qwgrth,nrshdr,qcshd)
@@ -3113,7 +3113,7 @@ qv,qc_incld,qitot_incld,nitot_incld,qr_incld,    &
 
 
 
-end subroutine wet_growth 
+end subroutine calc_wet_growth 
 
 
 subroutine ice_relaxation_timescale(rho,t,rhofaci,     &

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -58,8 +58,13 @@ module micro_p3
   public  :: p3_init,p3_main
 
   private :: polysvp1,find_lookupTable_indices_1a,find_lookupTable_indices_1b, &
-       find_lookupTable_indices_3,get_cloud_dsd2,        &
-       get_rain_dsd2,calc_bulkRhoRime,impose_max_total_Ni,check_values,qv_sat
+       find_lookupTable_indices_3,get_cloud_dsd2, &
+       get_rain_dsd2,calc_bulkRhoRime,impose_max_total_Ni,check_values,qv_sat, & 
+       ice_cldliq_collection, ice_rain_collection, ice_self_collection, & 
+       ice_melting, ice_cldliq_wet_growth, calc_ice_relaxation_timescale, & 
+       calc_rime_density, cldliq_immersion_freezing, rain_immersion_freezing
+
+
 
   real(rtype),private :: e0
 
@@ -895,7 +900,7 @@ contains
 
           !.......................
           ! collection of droplets
-          call ice_cld_liquid_collection(rho(i,k),t(i,k),rhofaci(i,k),&
+          call ice_cldliq_collection(rho(i,k),t(i,k),rhofaci(i,k),&
           f1pr04,qitot_incld(i,k),qc_incld(i,k),nitot_incld(i,k),nc_incld(i,k),&
                qccol,nccol,qcshd,ncshdc)
 
@@ -932,7 +937,7 @@ contains
           !-----------------------------
           ! calcualte total inverse ice relaxation timescale combined for all ice categories
           ! note 'f1pr' values are normalized, so we need to multiply by N
-          call ice_relaxation_timescale(rho(i,k),t(i,k),rhofaci(i,k),&
+          call calc_ice_relaxation_timescale(rho(i,k),t(i,k),rhofaci(i,k),&
           f1pr05,f1pr14,dv,mu,sc,qitot_incld(i,k),nitot_incld(i,k),&
                epsi,epsi_tot)
 
@@ -944,14 +949,14 @@ contains
 
           !............................................................
           ! contact and immersion freezing droplets
-          call cld_liq_immersion_freezing(t(i,k),&
+          call cldliq_immersion_freezing(t(i,k),&
           lamc(i,k),mu_c(i,k),cdist1(i,k),qc_incld(i,k),&
                qcheti,ncheti)
 
           !............................................................
           ! immersion freezing of rain
           ! for future: get rid of log statements below for rain freezing
-          call cld_rain_immersion_freezing(t(i,k),&
+          call rain_immersion_freezing(t(i,k),&
           lamr(i,k),mu_r(i,k),cdistr(i,k),qr_incld(i,k),&
                qrheti,nrheti)
 
@@ -2873,7 +2878,7 @@ contains
 
   end subroutine check_values
 
-  subroutine ice_cld_liquid_collection(rho,t,rhofaci,    &
+  subroutine ice_cldliq_collection(rho,t,rhofaci,    &
   f1pr04,qitot_incld,qc_incld,nitot_incld,nc_incld,    &
              qccol,nccol,qcshd,ncshdc)
    
@@ -2918,7 +2923,7 @@ contains
       end if 
    end if 
 
-  end subroutine ice_cld_liquid_collection
+  end subroutine ice_cldliq_collection
 
 
   subroutine ice_rain_collection(rho,t,rhofaci,    &
@@ -3116,7 +3121,7 @@ qv,qc_incld,qitot_incld,nitot_incld,qr_incld,    &
 end subroutine ice_cldliq_wet_growth 
 
 
-subroutine ice_relaxation_timescale(rho,t,rhofaci,     &
+subroutine calc_ice_relaxation_timescale(rho,t,rhofaci,     &
 f1pr05,f1pr14,dv,mu,sc,qitot_incld,nitot_incld,    &
 epsi,epsi_tot)
 
@@ -3152,7 +3157,7 @@ epsi,epsi_tot)
    endif 
 
 
-end subroutine ice_relaxation_timescale
+end subroutine calc_ice_relaxation_timescale
 
 
 subroutine calc_rime_density(t,rhofaci,    &
@@ -3227,7 +3232,7 @@ f1pr02,acn,lamc, mu_c,qc_incld,qccol,    &
    endif ! qi > qsmall and T < 273.15
 end subroutine calc_rime_density
 
-subroutine cld_liq_immersion_freezing(t,lamc,mu_c,cdist1,qc_incld,    &
+subroutine cldliq_immersion_freezing(t,lamc,mu_c,cdist1,qc_incld,    &
            qcheti,ncheti)
 
    !............................................................
@@ -3255,9 +3260,9 @@ subroutine cld_liq_immersion_freezing(t,lamc,mu_c,cdist1,qc_incld,    &
       ncheti = N_nuc
    endif 
 
-end subroutine cld_liq_immersion_freezing
+end subroutine cldliq_immersion_freezing
 
-subroutine cld_rain_immersion_freezing(t,    &
+subroutine rain_immersion_freezing(t,    &
 lamr, mu_r, cdistr, qr_incld,    &
 qrheti, nrheti)
 
@@ -3291,6 +3296,6 @@ qrheti, nrheti)
    endif 
 
 
-end subroutine cld_rain_immersion_freezing 
+end subroutine rain_immersion_freezing 
 
 end module micro_p3

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -938,7 +938,7 @@ contains
 
           !.........................
           ! calculate rime density
-          call rime_density(t(i,k),rhofaci(i,k),&
+          call calc_rime_density(t(i,k),rhofaci(i,k),&
           f1pr02,acn(i,k),lamc(i,k),mu_c(i,k),qc_incld(i,k),qccol,&
           vtrmi1,rhorime_c)
 
@@ -3155,7 +3155,7 @@ epsi,epsi_tot)
 end subroutine ice_relaxation_timescale
 
 
-subroutine rime_density(t,rhofaci,    &
+subroutine calc_rime_density(t,rhofaci,    &
 f1pr02,acn,lamc, mu_c,qc_incld,qccol,    &
            vtrmi1,rhorime_c) 
    
@@ -3225,7 +3225,7 @@ f1pr02,acn,lamc, mu_c,qc_incld,qccol,    &
    else 
       rhorime_c = 400._rtype 
    endif ! qi > qsmall and T < 273.15
-end subroutine rime_density
+end subroutine calc_rime_density
 
 subroutine cld_liq_immersion_freezing(t,lamc,mu_c,cdist1,qc_incld,    &
            qcheti,ncheti)

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3132,15 +3132,13 @@ subroutine ice_melting(rho, t, pres, rhofaci, f1pr05, f1pr14, xxlv, xlf, dv, sc,
    real(rtype), intent(out) :: nimlt
 
    real(rtype) :: qsat0
-   real(rtype), parameter :: dum = 0.0_rtype 
 
    if (qitot_incld .ge.qsmall .and. t.gt.zerodegc) then
       qsat0 = 0.622_rtype*e0/(pres-e0)
 
 
       qimlt = ((f1pr05+f1pr14*sc**thrd*(rhofaci*rho/mu)**0.5_rtype)*((t-   &
-      zerodegc)*kap-rho*xxlv*dv*(qsat0-qv))*2._rtype*pi/xlf+     &
-      dum)*nitot_incld
+      zerodegc)*kap-rho*xxlv*dv*(qsat0-qv))*2._rtype*pi/xlf)*nitot_incld
 
 
       qimlt = max(qimlt,0.)

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -926,34 +926,7 @@ contains
          call wet_growth(rho(i,k), t(i,k), pres(i,k), rhofaci(i,k), f1pr05, f1pr14, xxlv(i,k), xlf(i,k), & 
          dv, kap, mu, sc, qv(i,k), qc_incld(i,k), qitot_incld(i,k), nitot_incld(i,k), qr_incld(i,k), log_wetgrowth, &
          qrcol, qccol, qwgrth, nrshdr, qcshd)
-
-          ! similar to Musil (1970), JAS
-          ! note 'f1pr' values are normalized, so we need to multiply by N
-
-          !if (qitot_incld(i,k).ge.qsmall .and. qc_incld(i,k)+qr_incld(i,k).ge.1.e-6_rtype .and. t(i,k).lt.zerodegc) then
-
-          !   qsat0  = 0.622_rtype*e0/(pres(i,k)-e0)
-          !   qwgrth = ((f1pr05 + f1pr14*sc**thrd*(rhofaci(i,k)*rho(i,k)/mu)**0.5_rtype)*       &
-          !        2._rtype*pi*(rho(i,k)*xxlv(i,k)*dv*(qsat0-qv(i,k))-(t(i,k)-zerodegc)*           &
-          !        kap)/(xlf(i,k)+cpw*(t(i,k)-zerodegc)))*nitot_incld(i,k)
-          !   qwgrth = max(qwgrth,0._rtype)
-             !calculate shedding for wet growth
-          !   dum    = max(0._rtype,(qccol+qrcol)-qwgrth)
-          !   if (dum.ge.1.e-10_rtype) then
-          !      nrshdr = nrshdr + dum*1.923e+6_rtype   ! 1/5.2e-7, 5.2e-7 is the mass of a 1 mm raindrop
-          !      if ((qccol+qrcol).ge.1.e-10_rtype) then
-          !         dum1  = 1._rtype/(qccol+qrcol)
-          !         qcshd = qcshd + dum*qccol*dum1
-          !         qccol = qccol - dum*qccol*dum1
-          !         qrcol = qrcol - dum*qrcol*dum1
-          !      endif
-                ! densify due to wet growth
-          !      log_wetgrowth = .true.
-          !   endif
-
-          !  endif
-
-
+         
           !-----------------------------
           ! calcualte total inverse ice relaxation timescale combined for all ice categories
           ! note 'f1pr' values are normalized, so we need to multiply by N

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -916,8 +916,8 @@ contains
          ! self-collection of ice 
          call ice_self_collection(rho(i,k), rhofaci(i,k), f1pr03, eii, Eii_fact, qitot_incld(i,k), nitot_incld(i,k), nislf)
 
-          !............................................................
-          ! melting
+         !............................................................
+         ! melting
          call ice_melting(rho(i,k), t(i,k), pres(i,k), rhofaci(i,k), f1pr05, f1pr14, xxlv(i,k), xlf(i,k), & 
                            dv, sc, mu, kap, qv(i,k), qitot_incld(i,k), nitot_incld(i,k), qimlt, nimlt)
 
@@ -930,13 +930,8 @@ contains
           !-----------------------------
           ! calcualte total inverse ice relaxation timescale combined for all ice categories
           ! note 'f1pr' values are normalized, so we need to multiply by N
-          if (qitot_incld(i,k).ge.qsmall .and. t(i,k).lt.zerodegc) then
-             epsi = ((f1pr05+f1pr14*sc**thrd*(rhofaci(i,k)*rho(i,k)/mu)**0.5_rtype)*2._rtype*pi* &
-                  rho(i,k)*dv)*nitot_incld(i,k)
-             epsi_tot   = epsi_tot + epsi
-          else
-             epsi = 0._rtype
-          endif
+          call ice_relaxation(rho(i,k), t(i,k), rhofaci(i,k), f1pr05, f1pr14, dv, mu, sc, qitot_incld(i,k), nitot_incld(i,k), &
+           epsi, epsi_tot)
 
 
           !.........................
@@ -3189,6 +3184,42 @@ subroutine wet_growth(rho, t, pres, rhofaci, f1pr05, f1pr14, xxlv, xlf, &
 
 
 end subroutine wet_growth 
+
+
+subroutine ice_relaxation(rho, t, rhofaci, f1pr05, f1pr14, dv, mu, sc, qitot_incld, nitot_incld, epsi, epsi_tot)
+
+   !-----------------------------
+   ! calcualte total inverse ice relaxation timescale combined for all ice categories
+   ! note 'f1pr' values are normalized, so we need to multiply by N
+
+   implicit none 
+
+
+   real(rtype), intent(in) :: rho 
+   real(rtype), intent(in) :: t 
+   real(rtype), intent(in) :: rhofaci 
+   real(rtype), intent(in) :: f1pr05 
+   real(rtype), intent(in) :: f1pr14
+   real(rtype), intent(in) :: dv 
+   real(rtype), intent(in) :: mu 
+   real(rtype), intent(in) :: sc 
+   real(rtype), intent(in) :: qitot_incld 
+   real(rtype), intent(in) :: nitot_incld 
+
+   real(rtype), intent(out) :: epsi
+   real(rtype), intent(out) :: epsi_tot 
+
+   if (qitot_incld.ge.qsmall .and. t.lt.zerodegc) then
+      epsi = ((f1pr05+f1pr14*sc**thrd*(rhofaci*rho/mu)**0.5_rtype)*2._rtype*pi* &
+      rho*dv)*nitot_incld
+      epsi_tot   = epsi_tot + epsi
+   else
+      epsi = 0._rtype
+   endif 
+
+
+end subroutine ice_relaxation
+
 
 
 end module micro_p3

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -901,11 +901,15 @@ contains
 
           !.......................
           ! collection of droplets
-          call ice_droplet_collection(rho(i,k), t(i,k), rhofaci(i,k), f1pr04, qitot_incld(i,k), qc_incld(i,k),nitot_incld(i,k), nc_incld(i,k), qccol, nccol, qcshd, ncshdc)
+          call ice_droplet_collection(rho(i,k),t(i,k),rhofaci(i,k),&
+          f1pr04,qitot_incld(i,k),qc_incld(i,k),nitot_incld(i,k),nc_incld(i,k),&
+               qccol,nccol,qcshd,ncshdc)
 
           !....................
           ! collection of rain
-          call ice_drop_collection(rho(i,k), t(i,k), rhofaci(i,k), logn0r(i,k), f1pr07, f1pr08, qitot_incld(i,k), nitot_incld(i,k), qr_incld(i,k), qrcol, nrcol)
+          call ice_drop_collection(rho(i,k),t(i,k),rhofaci(i,k),&
+          logn0r(i,k),f1pr07,f1pr08,qitot_incld(i,k),nitot_incld(i,k),qr_incld(i,k),&
+               qrcol,nrcol)
           !...................................
           ! collection between ice categories
 
@@ -913,37 +917,49 @@ contains
 
           !.............................................
           ! self-collection of ice 
-          call ice_self_collection(rho(i,k), rhofaci(i,k), f1pr03, eii, Eii_fact, qitot_incld(i,k), nitot_incld(i,k), nislf)
+          call ice_self_collection(rho(i,k),rhofaci(i,k),&
+          f1pr03,eii,Eii_fact,qitot_incld(i,k),nitot_incld(i,k),&
+               nislf)
 
           !............................................................
           ! melting
-          call ice_melting(rho(i,k), t(i,k), pres(i,k), rhofaci(i,k), f1pr05, f1pr14, xxlv(i,k), xlf(i,k), & 
-            dv, sc, mu, kap, qv(i,k), qitot_incld(i,k), nitot_incld(i,k), qimlt, nimlt)
+          call ice_melting(rho(i,k),t(i,k),pres(i,k),rhofaci(i,k),&
+          f1pr05,f1pr14,xxlv(i,k),xlf(i,k),dv,sc,mu,kap,&
+          qv(i,k),qitot_incld(i,k),nitot_incld(i,k),&
+               qimlt,nimlt)
 
           !............................................................
           ! calculate wet growth
-          call wet_growth(rho(i,k), t(i,k), pres(i,k), rhofaci(i,k), f1pr05, f1pr14, xxlv(i,k), xlf(i,k), & 
-          dv, kap, mu, sc, qv(i,k), qc_incld(i,k), qitot_incld(i,k), nitot_incld(i,k), qr_incld(i,k), log_wetgrowth, &
-          qrcol, qccol, qwgrth, nrshdr, qcshd)
+          call wet_growth(rho(i,k),t(i,k),pres(i,k),rhofaci(i,k),&
+          f1pr05,f1pr14,xxlv(i,k),xlf(i,k),dv,kap,mu,sc,&
+          qv(i,k),qc_incld(i,k),qitot_incld(i,k),nitot_incld(i,k),qr_incld(i,k),log_wetgrowth,&
+               qrcol,qccol,qwgrth,nrshdr,qcshd)
          
           !-----------------------------
           ! calcualte total inverse ice relaxation timescale combined for all ice categories
           ! note 'f1pr' values are normalized, so we need to multiply by N
-          call ice_relaxation(rho(i,k), t(i,k), rhofaci(i,k), f1pr05, f1pr14, dv, mu, sc, qitot_incld(i,k), nitot_incld(i,k), &
-          epsi, epsi_tot)
+          call ice_relaxation(rho(i,k),t(i,k),rhofaci(i,k),&
+          f1pr05,f1pr14,dv,mu,sc,qitot_incld(i,k),nitot_incld(i,k),&
+               epsi,epsi_tot)
 
           !.........................
           ! calculate rime density
-          call rime_density(t(i,k), rhofaci(i,k), f1pr02, acn(i,k), lamc(i,k), mu_c(i,k), qc_incld(i,k), qccol, vtrmi1, rhorime_c)
+          call rime_density(t(i,k),rhofaci(i,k),&
+          f1pr02,acn(i,k),lamc(i,k),mu_c(i,k),qc_incld(i,k),qccol,&
+          vtrmi1,rhorime_c)
 
           !............................................................
           ! contact and immersion freezing droplets
-          call droplet_freezing(t(i,k), lamc(i,k), mu_c(i,k), cdist1(i,k), qc_incld(i,k), qcheti, ncheti)
+          call droplet_freezing(t(i,k),&
+          lamc(i,k),mu_c(i,k),cdist1(i,k),qc_incld(i,k),&
+               qcheti,ncheti)
 
           !............................................................
           ! immersion freezing of rain
           ! for future: get rid of log statements below for rain freezing
-          call rain_immersion_freezing(t(i,k), lamr(i,k), mu_r(i,k), cdistr(i,k), qr_incld(i,k), qrheti, nrheti)
+          call rain_immersion_freezing(t(i,k),&
+          lamr(i,k),mu_r(i,k),cdistr(i,k),qr_incld(i,k),&
+               qrheti,nrheti)
 
           !......................................
           ! rime splintering (Hallet-Mossop 1974)
@@ -2890,7 +2906,9 @@ contains
 
   end subroutine check_values
 
-  subroutine ice_droplet_collection(rho, t, rhofaci, f1pr04, qitot_incld, qc_incld, nitot_incld, nc_incld, qccol, nccol, qcshd, ncshdc)
+  subroutine ice_droplet_collection(rho,t,rhofaci,&
+  f1pr04,qitot_incld,qc_incld,nitot_incld,nc_incld,&
+             qccol,nccol,qcshd,ncshdc)
    
    !.......................
    ! collection of droplets
@@ -2936,7 +2954,9 @@ contains
   end subroutine ice_droplet_collection
 
 
-  subroutine ice_drop_collection(rho, t, rhofaci, logn0r, f1pr07, f1pr08, qitot_incld, nitot_incld, qr_incld, qrcol, nrcol)
+  subroutine ice_drop_collection(rho,t,rhofaci,&
+  logn0r,f1pr07,f1pr08,qitot_incld,nitot_incld,qr_incld,&
+  qrcol, nrcol)
    
    !....................
    ! collection of rain
@@ -2985,7 +3005,9 @@ contains
 
   end subroutine ice_drop_collection
 
-  subroutine ice_self_collection(rho, rhofaci, f1pr03, eii, Eii_fact, qitot_incld, nitot_incld, nislf)
+  subroutine ice_self_collection(rho,rhofaci,&
+  f1pr03,eii,Eii_fact,qitot_incld,nitot_incld,&
+             nislf)
 
    ! self-collection of ice 
 
@@ -3014,7 +3036,9 @@ contains
 end subroutine ice_self_collection
 
 
-subroutine ice_melting(rho, t, pres, rhofaci, f1pr05, f1pr14, xxlv, xlf, dv, sc, mu, kap, qv, qitot_incld, nitot_incld, qimlt, nimlt)
+subroutine ice_melting(rho,t,pres,rhofaci,&
+f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,&
+           qimlt,nimlt)
    ! melting
    ! need to add back accelerated melting due to collection of ice mass by rain (pracsw1)
    ! note 'f1pr' values are normalized, so we need to multiply by N
@@ -3060,10 +3084,10 @@ subroutine ice_melting(rho, t, pres, rhofaci, f1pr05, f1pr14, xxlv, xlf, dv, sc,
 end subroutine ice_melting
 
 
-subroutine wet_growth(rho, t, pres, rhofaci, f1pr05, f1pr14, xxlv, xlf, &
-                      dv, kap, mu, sc, qv, qc_incld, qitot_incld, nitot_incld, qr_incld, &
-                      log_wetgrowth, &
-                      qrcol, qccol, qwgrth, nrshdr, qcshd)
+subroutine wet_growth(rho,t,pres,rhofaci,&
+f1pr05,f1pr14,xxlv,xlf,dv,kap,mu,sc,&
+qv,qc_incld,qitot_incld,nitot_incld,qr_incld,&
+           log_wetgrowth,qrcol,qccol,qwgrth,nrshdr,qcshd)
 
    implicit none 
 
@@ -3125,7 +3149,9 @@ subroutine wet_growth(rho, t, pres, rhofaci, f1pr05, f1pr14, xxlv, xlf, &
 end subroutine wet_growth 
 
 
-subroutine ice_relaxation(rho, t, rhofaci, f1pr05, f1pr14, dv, mu, sc, qitot_incld, nitot_incld, epsi, epsi_tot)
+subroutine ice_relaxation(rho,t,rhofaci,&
+f1pr05,f1pr14,dv,mu,sc,qitot_incld,nitot_incld,&
+epsi,epsi_tot)
 
    !-----------------------------
    ! calcualte total inverse ice relaxation timescale combined for all ice categories
@@ -3162,7 +3188,9 @@ subroutine ice_relaxation(rho, t, rhofaci, f1pr05, f1pr14, dv, mu, sc, qitot_inc
 end subroutine ice_relaxation
 
 
-subroutine rime_density(t, rhofaci, f1pr02, acn, lamc,  mu_c, qc_incld, qccol, vtrmi1, rhorime_c) 
+subroutine rime_density(t,rhofaci,&
+f1pr02,acn,lamc, mu_c,qc_incld,qccol,&
+           vtrmi1,rhorime_c) 
    
    !.........................
    ! calculate rime density
@@ -3232,7 +3260,8 @@ subroutine rime_density(t, rhofaci, f1pr02, acn, lamc,  mu_c, qc_incld, qccol, v
    endif ! qi > qsmall and T < 273.15
 end subroutine rime_density
 
-subroutine droplet_freezing(t, lamc, mu_c, cdist1, qc_incld, qcheti, ncheti)
+subroutine droplet_freezing(t,lamc,mu_c,cdist1,qc_incld,&
+           qcheti,ncheti)
 
    !............................................................
    ! contact and immersion freezing droplets
@@ -3261,7 +3290,9 @@ subroutine droplet_freezing(t, lamc, mu_c, cdist1, qc_incld, qcheti, ncheti)
 
 end subroutine droplet_freezing 
 
-subroutine rain_immersion_freezing(t, lamr, mu_r, cdistr, qr_incld, qrheti, nrheti)
+subroutine rain_immersion_freezing(t,&
+lamr, mu_r, cdistr, qr_incld,&
+qrheti, nrheti)
 
    !............................................................
    ! immersion freezing of rain

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -2889,8 +2889,8 @@ contains
 
   end subroutine check_values
 
-  subroutine ice_droplet_collection(rho,t,rhofaci,&
-  f1pr04,qitot_incld,qc_incld,nitot_incld,nc_incld,&
+  subroutine ice_droplet_collection(rho,t,rhofaci,    &
+  f1pr04,qitot_incld,qc_incld,nitot_incld,nc_incld,    &
              qccol,nccol,qcshd,ncshdc)
    
    !.......................
@@ -2937,8 +2937,8 @@ contains
   end subroutine ice_droplet_collection
 
 
-  subroutine ice_drop_collection(rho,t,rhofaci,&
-  logn0r,f1pr07,f1pr08,qitot_incld,nitot_incld,qr_incld,&
+  subroutine ice_drop_collection(rho,t,rhofaci,    &
+  logn0r,f1pr07,f1pr08,qitot_incld,nitot_incld,qr_incld,    &
   qrcol, nrcol)
    
    !....................
@@ -2988,8 +2988,8 @@ contains
 
   end subroutine ice_drop_collection
 
-  subroutine ice_self_collection(rho,rhofaci,&
-  f1pr03,eii,Eii_fact,qitot_incld,nitot_incld,&
+  subroutine ice_self_collection(rho,rhofaci,    &
+  f1pr03,eii,Eii_fact,qitot_incld,nitot_incld,    &
              nislf)
 
    ! self-collection of ice 
@@ -3019,8 +3019,8 @@ contains
 end subroutine ice_self_collection
 
 
-subroutine ice_melting(rho,t,pres,rhofaci,&
-f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,&
+subroutine ice_melting(rho,t,pres,rhofaci,    &
+f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,    &
            qimlt,nimlt)
    ! melting
    ! need to add back accelerated melting due to collection of ice mass by rain (pracsw1)
@@ -3067,9 +3067,9 @@ f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,&
 end subroutine ice_melting
 
 
-subroutine wet_growth(rho,t,pres,rhofaci,&
-f1pr05,f1pr14,xxlv,xlf,dv,kap,mu,sc,&
-qv,qc_incld,qitot_incld,nitot_incld,qr_incld,&
+subroutine wet_growth(rho,t,pres,rhofaci,    &
+f1pr05,f1pr14,xxlv,xlf,dv,kap,mu,sc,    &
+qv,qc_incld,qitot_incld,nitot_incld,qr_incld,    &
            log_wetgrowth,qrcol,qccol,qwgrth,nrshdr,qcshd)
 
    implicit none 
@@ -3132,8 +3132,8 @@ qv,qc_incld,qitot_incld,nitot_incld,qr_incld,&
 end subroutine wet_growth 
 
 
-subroutine ice_relaxation(rho,t,rhofaci,&
-f1pr05,f1pr14,dv,mu,sc,qitot_incld,nitot_incld,&
+subroutine ice_relaxation(rho,t,rhofaci,     &
+f1pr05,f1pr14,dv,mu,sc,qitot_incld,nitot_incld,    &
 epsi,epsi_tot)
 
    !-----------------------------
@@ -3171,8 +3171,8 @@ epsi,epsi_tot)
 end subroutine ice_relaxation
 
 
-subroutine rime_density(t,rhofaci,&
-f1pr02,acn,lamc, mu_c,qc_incld,qccol,&
+subroutine rime_density(t,rhofaci,    &
+f1pr02,acn,lamc, mu_c,qc_incld,qccol,    &
            vtrmi1,rhorime_c) 
    
    !.........................
@@ -3243,7 +3243,7 @@ f1pr02,acn,lamc, mu_c,qc_incld,qccol,&
    endif ! qi > qsmall and T < 273.15
 end subroutine rime_density
 
-subroutine droplet_freezing(t,lamc,mu_c,cdist1,qc_incld,&
+subroutine droplet_freezing(t,lamc,mu_c,cdist1,qc_incld,    &
            qcheti,ncheti)
 
    !............................................................
@@ -3273,8 +3273,8 @@ subroutine droplet_freezing(t,lamc,mu_c,cdist1,qc_incld,&
 
 end subroutine droplet_freezing 
 
-subroutine rain_immersion_freezing(t,&
-lamr, mu_r, cdistr, qr_incld,&
+subroutine rain_immersion_freezing(t,    &
+lamr, mu_r, cdistr, qr_incld,    &
 qrheti, nrheti)
 
    !............................................................

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -197,7 +197,7 @@ contains
   SUBROUTINE p3_init_b()
     implicit none
     integer                      :: i,ii,jj,kk
-    real(rtype)                         :: lamr,mu_r,lamold,dum,initlamr,dm,dum1,dum2,dum3,dum4,dum5,  &
+    real(rtype)                         :: lamr,mu_r,dm,dum1,dum2,dum3,dum4,dum5,  &
          dd,amg,vt,dia
 
     !------------------------------------------------------------------------------------------!
@@ -484,14 +484,14 @@ contains
 
     real(rtype)    :: lammax,lammin,mu,dv,sc,dqsdt,ab,kap,epsr,epsc,xx,aaa,epsilon,epsi_tot, &
          dum,dum1,dum2,    &
-         dumqv,dumqvs,dums,ratio,qsat0,dum3,dum4,dum5,dum6,rdumii, &
-         rdumjj,dqsidt,abi,dumqvi,rhop,V_impact,ri,iTc,D_c,tmp1,  &
+         dumqv,dumqvs,dums,ratio,dum3,dum4,dum5,dum6,rdumii, &
+         rdumjj,dqsidt,abi,dumqvi,rhop,tmp1,  &
          tmp2,inv_dum3,odt,oxx,oabi,     &
          fluxdiv_qit,fluxdiv_nit,fluxdiv_qir,fluxdiv_bir,prt_accum, &
          fluxdiv_qx,fluxdiv_nx,Co_max,dt_sub,      &
          Q_nuc,N_nuc,         &
          deltaD_init,dumt,qcon_satadj,qdep_satadj,sources,sinks,    &
-         timeScaleFactor,dt_left, vtrmi1, Vt_qc
+         timeScaleFactor,dt_left, vtrmi1
 
 
     integer :: dumi,i,k,dumj,dumii,dumjj,dumzz,      &
@@ -817,7 +817,7 @@ contains
                lammin,lammax,cdist(i,k),cdist1(i,k),lcldm(i,k))
           nc(i,k) = nc_incld(i,k)*lcldm(i,k)
 
-          call get_rain_dsd2(qr_incld(i,k),nr_incld(i,k),mu_r(i,k),rdumii,dumii,lamr(i,k),mu_r_table,   &
+          call get_rain_dsd2(qr_incld(i,k),nr_incld(i,k),mu_r(i,k),lamr(i,k),   &
                cdistr(i,k),logn0r(i,k),rcldm(i,k))
           nr(i,k) = nr_incld(i,k)*rcldm(i,k)
 
@@ -1813,8 +1813,8 @@ contains
 
                    !Compute Vq, Vn:
                    nr(i,k)  = max(nr(i,k),nsmall)
-                   call get_rain_dsd2(qr_incld(i,k),nr_incld(i,k),mu_r(i,k),rdumii,dumii,lamr(i,k),     &
-                        mu_r_table,tmp1,tmp2,rcldm(i,k))
+                   call get_rain_dsd2(qr_incld(i,k),nr_incld(i,k),mu_r(i,k),lamr(i,k),     &
+                        tmp1,tmp2,rcldm(i,k))
                    call find_lookupTable_indices_3(dumii,dumjj,dum1,rdumii,rdumjj,inv_dum3, &
                         mu_r(i,k),lamr(i,k))
                    nr(i,k) = nr_incld(i,k)*rcldm(i,k)
@@ -2105,7 +2105,7 @@ contains
           ! rain:
           if (qr(i,k).ge.qsmall) then
 
-             call get_rain_dsd2(qr(i,k),nr(i,k),mu_r(i,k),rdumii,dumii,lamr(i,k),mu_r_table,   &
+             call get_rain_dsd2(qr(i,k),nr(i,k),mu_r(i,k),lamr(i,k),   &
                   !                        cdistr(i,k),logn0r(i,k))
                   tmp1,tmp2,rcldm(i,k))
 
@@ -2644,18 +2644,16 @@ contains
 
 
   !===========================================================================================
-  subroutine get_rain_dsd2(qr,nr,mu_r,rdumii,dumii,lamr,mu_r_table,cdistr,logn0r,rcldm)
+  subroutine get_rain_dsd2(qr,nr,mu_r,lamr,cdistr,logn0r,rcldm)
 
     ! Computes and returns rain size distribution parameters
 
     implicit none
 
     !arguments:
-    real(rtype), dimension(:), intent(in)  :: mu_r_table
     real(rtype),     intent(in)            :: qr,rcldm
     real(rtype),     intent(inout)         :: nr
-    real(rtype),     intent(out)           :: rdumii,lamr,mu_r,cdistr,logn0r
-    integer,  intent(out)           :: dumii
+    real(rtype),     intent(out)           :: lamr,mu_r,cdistr,logn0r
 
     !local variables:
     real(rtype)                            :: inv_dum,lammax,lammin

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -902,7 +902,7 @@ contains
 
           !.......................
           ! collection of droplets
-          call droplet_collection(rho(i,k), t(i,k), rhofaci(i,k), f1pr04, qitot_incld(i,k),  qc_incld(i,k),nitot_incld(i,k), nc_incld(i,k), qccol, nccol, qcshd, ncshdc)
+          call ice_droplet_collection(rho(i,k), t(i,k), rhofaci(i,k), f1pr04, qitot_incld(i,k),  qc_incld(i,k),nitot_incld(i,k), nc_incld(i,k), qccol, nccol, qcshd, ncshdc)
 
           !....................
           ! collection of rain

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -893,37 +893,28 @@ contains
 
           endif   ! qitot > qsmall
 
-          !----------------------------------------------------------------------
-          ! Begin calculations of microphysical processes
+         !----------------------------------------------------------------------
+         ! Begin calculations of microphysical processes
 
-          !......................................................................
-          ! ice processes
-          !......................................................................
+         !......................................................................
+         ! ice processes
+         !......................................................................
 
-          !.......................
-          ! collection of droplets
-          call ice_droplet_collection(rho(i,k), t(i,k), rhofaci(i,k), f1pr04, qitot_incld(i,k), qc_incld(i,k),nitot_incld(i,k), nc_incld(i,k), qccol, nccol, qcshd, ncshdc)
+         !.......................
+         ! collection of droplets
+         call ice_droplet_collection(rho(i,k), t(i,k), rhofaci(i,k), f1pr04, qitot_incld(i,k), qc_incld(i,k),nitot_incld(i,k), nc_incld(i,k), qccol, nccol, qcshd, ncshdc)
 
-          !....................
-          ! collection of rain
-          call ice_drop_collection(rho(i,k), t(i,k), rhofaci(i,k), logn0r(i,k), f1pr07, f1pr08, qitot_incld(i,k), nitot_incld(i,k), qr_incld(i,k), qrcol, nrcol)
-          !...................................
-          ! collection between ice categories
+         !....................
+         ! collection of rain
+         call ice_drop_collection(rho(i,k), t(i,k), rhofaci(i,k), logn0r(i,k), f1pr07, f1pr08, qitot_incld(i,k), nitot_incld(i,k), qr_incld(i,k), qrcol, nrcol)
+         !...................................
+         ! collection between ice categories
 
-          !PMC nCat deleted lots of stuff here.
+         !PMC nCat deleted lots of stuff here.
 
-          !.............................................
-          ! self-collection of ice (in a given category)
-
-          ! here we multiply rates by collection efficiency, air density,
-          ! and air density correction factor since these are not included
-          ! in the lookup table calculations
-          ! note 'f1pr' values are normalized, so we need to multiply by N
-
-          if (qitot_incld(i,k).ge.qsmall) then
-             nislf = f1pr03*rho(i,k)*eii*Eii_fact*rhofaci(i,k)*nitot_incld(i,k)
-          endif
-
+         !.............................................
+         ! self-collection of ice 
+         call ice_self_collection(rho(i,k), rhofaci(i,k), f1pr03, eii, Eii_fact, qitot_incld(i,k), nitot_incld(i,k), nislf)
 
           !............................................................
           ! melting
@@ -3098,8 +3089,38 @@ contains
       ! expected to lead to shedding)
    end if 
 
-
-
   end subroutine ice_drop_collection
+
+  subroutine ice_self_collection(rho, rhofaci, f1pr03, eii, Eii_fact, qitot_incld, nitot_incld, nislf)
+
+   ! self-collection of ice 
+
+   ! here we multiply rates by collection efficiency, air density,
+   ! and air density correction factor since these are not included
+   ! in the lookup table calculations
+   ! note 'f1pr' values are normalized, so we need to multiply by N
+
+   implicit none 
+
+   real(rtype), intent(in) :: rho 
+   real(rtype), intent(in) :: rhofaci
+   real(rtype), intent(in) :: f1pr03  
+   real(rtype), intent(in) :: eii 
+   real(rtype), intent(in) :: Eii_fact 
+   real(rtype), intent(in) :: qitot_incld
+   real(rtype), intent(in) :: nitot_incld
+
+   real(rtype), intent(out) :: nislf 
+
+   if (qitot_incld.ge.qsmall) then
+      if (qitot_incld.ge.qsmall) then
+         nislf = f1pr03*rho*eii*Eii_fact*rhofaci*nitot_incld
+      endif
+   endif
+
+
+end subroutine ice_self_collection
+
+
 
 end module micro_p3

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -943,16 +943,7 @@ contains
           !............................................................
           ! immersion freezing of rain
           ! for future: get rid of log statements below for rain freezing
-
-          if (qr_incld(i,k).ge.qsmall.and.t(i,k).le.rainfrze) then
-             Q_nuc = cons6*exp(log(cdistr(i,k))+log(gamma(7._rtype+mu_r(i,k)))-6._rtype*log(lamr(i,k)))* &
-                  exp(aimm*(zerodegc-T(i,k)))
-             N_nuc = cons5*exp(log(cdistr(i,k))+log(gamma(mu_r(i,k)+4._rtype))-3._rtype*log(lamr(i,k)))* &
-                  exp(aimm*(zerodegc-T(i,k)))
-             qrheti = Q_nuc
-             nrheti = N_nuc
-          endif
-
+          call rain_immersion_freezing(t(i,k), lamr(i,k), mu_r(i,k), cdistr(i,k), qr_incld(i,k), qrheti, nrheti)
 
           !......................................
           ! rime splintering (Hallet-Mossop 1974)
@@ -3270,5 +3261,38 @@ subroutine droplet_freezing(t, lamc, mu_c, cdist1, qc_incld, qcheti, ncheti)
 
 end subroutine droplet_freezing 
 
+subroutine rain_immersion_freezing(t, lamr, mu_r, cdistr, qr_incld, qrheti, nrheti)
+
+   !............................................................
+   ! immersion freezing of rain
+   ! for future: get rid of log statements below for rain freezing
+
+   implicit none 
+   
+   real(rtype), intent(in) :: t 
+   real(rtype), intent(in) :: mu_r 
+   real(rtype), intent(in) :: lamr 
+   real(rtype), intent(in) :: cdistr 
+   real(rtype), intent(in) :: qr_incld
+
+   real(rtype), intent(out) :: qrheti 
+   real(rtype), intent(out) :: nrheti 
+
+   real(rtype) :: Q_nuc, N_nuc 
+
+   if (qr_incld.ge.qsmall .and. t.le.rainfrze) then
+
+      Q_nuc = cons6*exp(log(cdistr)+log(gamma(7._rtype+mu_r))-6._rtype*log(lamr))* &
+      exp(aimm*(zerodegc-t))
+      N_nuc = cons5*exp(log(cdistr)+log(gamma(mu_r+4._rtype))-3._rtype*log(lamr))* &
+      exp(aimm*(zerodegc-t))
+
+      qrheti = Q_nuc 
+      nrheti = N_nuc 
+
+   endif 
+
+
+end subroutine rain_immersion_freezing 
 
 end module micro_p3


### PR DESCRIPTION
This PR is the first of several that will be made to break up p3_main into a collection of subroutines. 

The PR attempts to break ice microphysical processes into either individual subroutines or subroutines that group like processes. The changes are BFB. I would appreciate reviewers to provide input on naming conventions for the new subroutines as well as on adopting coding standards for these subroutines. 

