### PR TITLE
Add log_predictNc = false case to p3_run_and_cmp.

### DIFF
--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -33,7 +33,7 @@ namespace p3 {
 FortranData::FortranData (Int ncol_, Int nlev_)
   : ncol(ncol_), nlev(nlev_)
 {
-
+  log_predictNc = true;
   dt = -1; // model time step, s; set to invalid -1
   it = 1;  // seems essentially unused
   // In/out
@@ -137,7 +137,7 @@ void p3_main (const FortranData& d) {
             d.prt_sol.data(), 1, d.ncol, 1, d.nlev, d.diag_ze.data(),
             d.diag_effc.data(), d.diag_effi.data(), d.diag_vmi.data(),
             d.diag_di.data(), d.diag_rhoi.data(),
-            d.log_predictnc,
+            d.log_predictNc,
             d.pdel.data(), d.exner.data(), d.cmeiout.data(), d.prain.data(),
             d.nevapr.data(), d.prer_evap.data(),
             d.rflx.data(), d.sflx.data(),

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -22,8 +22,7 @@ struct FortranData {
   using Array2 = Kokkos::View<Scalar**, Layout, ExeSpace>;
   using Array3 = Kokkos::View<Scalar***, Layout, ExeSpace>;
 
-  static constexpr bool log_predictnc = true;
-
+  bool log_predictNc;
   const Int ncol, nlev;
 
   // In

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -52,8 +52,9 @@ Int compare (const std::string& label, const double& tol,
 
 struct Baseline {
   Baseline () {
-    params_.push_back({ic::Factory::mixed, 1800, 1});
-    params_.push_back({ic::Factory::mixed, 1800, 2});
+    for (const bool log_predictNc : {true, false})
+      for (const int it : {1, 2})
+        params_.push_back({ic::Factory::mixed, 1800, it, log_predictNc});
   }
 
   Int generate_baseline (const std::string& filename) {
@@ -101,11 +102,13 @@ private:
     ic::Factory::IC ic;
     Real dt;
     Int it;
+    bool log_predictNc;
   };
 
   static void set_params (const ParamSet& ps, FortranData& d) {
     d.dt = ps.dt;
     d.it = ps.it;
+    d.log_predictNc = ps.log_predictNc;
   }
 
   std::vector<ParamSet> params_;


### PR DESCRIPTION
This adds more regression output. If I remove the new stuff, there is no diff with master baseline. With the new tests, current baseline cmp will fail b/c the files don't have the same fields. So this is non-BFB overall, but BFB for the part currently in master already.