### PR TITLE
Fixed bug caused by use of uninitialized f1pr07 in rain collection.

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -2958,23 +2958,25 @@ contains
    real(rtype), intent(out) :: qrcol 
    real(rtype), intent(out) :: nrcol 
 
-   if (qitot_incld.ge.qsmall .and. qr_incld.ge.qsmall .and. t.le.zerodegc) then
-      ! note: f1pr08 and logn0r are already calculated as log_10
-      qrcol = 10._rtype**(f1pr08+logn0r)*rho*rhofaci*eri*nitot_incld
-      nrcol = 10._rtype**(f1pr07+logn0r)*rho*rhofaci*eri*nitot_incld
-   else if (t .ge. zerodegc) then
-      ! rain number sink due to collection
-      ! for T > 273.15, assume collected rain number is shed as
-      ! 1 mm drops
-      ! note that melting of ice number is scaled to the loss
-      ! rate of ice mass due to melting
-      ! collection of rain above freezing does not impact total rain mass
-      nrcol  = 10._rtype**(f1pr07 + logn0r)*rho*rhofaci*eri*nitot_incld     
-      ! for now neglect shedding of ice collecting rain above freezing, since snow is
-      ! not expected to shed in these conditions (though more hevaily rimed ice would be
-      ! expected to lead to shedding)
-   end if 
-
+   if (qitot_incld.ge.qsmall .and. qr_incld.ge.qsmall) then 
+      if (t.le.zerodegc) then
+         ! note: f1pr08 and logn0r are already calculated as log_10
+         qrcol = 10._rtype**(f1pr08+logn0r)*rho*rhofaci*eri*nitot_incld
+         nrcol = 10._rtype**(f1pr07+logn0r)*rho*rhofaci*eri*nitot_incld
+      else if (t .gt. zerodegc) then
+         ! rain number sink due to collection
+         ! for T > 273.15, assume collected rain number is shed as
+         ! 1 mm drops
+         ! note that melting of ice number is scaled to the loss
+         ! rate of ice mass due to melting
+         ! collection of rain above freezing does not impact total rain mass
+         nrcol  = 10._rtype**(f1pr07 + logn0r)*rho*rhofaci*eri*nitot_incld     
+         ! for now neglect shedding of ice collecting rain above freezing, since snow is
+         ! not expected to shed in these conditions (though more hevaily rimed ice would be
+         ! expected to lead to shedding)      
+      endif 
+   endif 
+   
   end subroutine ice_rain_collection
 
   subroutine ice_self_collection(rho,rhofaci,    &


### PR DESCRIPTION
This PR fixes a bug in the rain collection source term that led to use of an uninitialized value of f1pr07 which resulted in NaNs. The bug was introduced during the reordering of p3_main into subroutines and was undetected during regression testing.  The bug was caught during the nightly build which used the cmake option SCREAM_FPE=ON. 