### PR TITLE
Adding a Units framework, to be used in the Field structure stack.

### DIFF
--- a/components/scream/src/scream_config.h.in
+++ b/components/scream/src/scream_config.h.in
@@ -22,6 +22,9 @@
 // Whether MPI errors should abort
 #cmakedefine SCREAM_MPI_ERRORS_ARE_FATAL
 
+// Whether we allow use of CONSTEXPR_ASSERT macro
+#cmakedefine SCREAM_CONSTEXPR_ASSERT
+
 // Mimic GPU to correctness-test inter-column parallelism on non-GPU platform
 #cmakedefine SCREAM_MIMIC_GPU
 

--- a/components/scream/src/share/scream_assert.hpp
+++ b/components/scream/src/share/scream_assert.hpp
@@ -3,7 +3,9 @@
 
 #include <sstream>
 #include <exception>
+#include <assert.h>
 #include <stdexcept>  // For std::logic_error
+#include "scream_config.h"
 
 /*
  * Asserts and error checking for Scream.
@@ -48,6 +50,30 @@
 #define scream_krequire(condition)          impl_kthrow(condition, "")
 #define scream_require_msg(condition, msg)  impl_throw(condition, msg, std::logic_error)
 #define scream_krequire_msg(condition, msg) impl_kthrow(condition, msg)
+
+// Macros to do asserts inside constexpr functions
+// This is not necessary with C++14, where constexpr functions are "regular"
+// functions (they just can be evaluated at compile time). But in C++11 you can only have
+// 'return blah;' in a constexpr function, and user-defined constexpr constructors must
+// have an empty body (only initializer list syntax allowed).
+// NOTE: doing `return assert(check), blah;` seems the right solution, but it seems
+//       older versions of gcc may not like this option even if check evaluates to true.
+// As soon as we can use C++14, this macro can be removed, and you can simply use
+// `assert(check);` in the body of the constexpr function.
+#if defined(NDEBUG) || !defined(SCREAM_CONSTEXPR_ASSERT)
+#define CONSTEXPR_ASSERT(CHECK) void(0)
+#else
+namespace impl {
+struct assert_failure {
+  explicit assert_failure(const char *sz)
+  {
+    std::fprintf(stderr, "Assertion failure: %s\n", sz);
+  }
+};
+}
+#define CONSTEXPR_ASSERT(CHECK) \
+    ( (CHECK) ? void(0) : throw impl::assert_failure(#CHECK), void(0) )
+#endif
 
 namespace scream {
 namespace error {

--- a/components/scream/src/share/tests/CMakeLists.txt
+++ b/components/scream/src/share/tests/CMakeLists.txt
@@ -29,3 +29,6 @@ CreateUnitTest(upper_bound "upper_bound_test.cpp" scream_share)
 
 # Test tridiag solvers
 CreateUnitTest(tridiag "tridiag_tests.cpp;tridiag_tests_correctness.cpp;tridiag_tests_performance.cpp" scream_share THREADS ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_MAX_THREADS} 1 OPTIONAL EXCLUDE_MAIN_CPP)
+
+# Test units framework
+CreateUnitTest(units "units.cpp" scream_share)

--- a/components/scream/src/share/tests/units.cpp
+++ b/components/scream/src/share/tests/units.cpp
@@ -13,6 +13,7 @@ TEST_CASE("units_framework", "") {
     constexpr RationalConstant half(1,2);
     constexpr RationalConstant one(1);
     constexpr RationalConstant two(2,1);
+    const RationalConstant zero(0);
 
     // Verify operations
     REQUIRE(half*two == one);
@@ -20,18 +21,22 @@ TEST_CASE("units_framework", "") {
     REQUIRE(one/two == half);
     REQUIRE(half*half == quarter);
     REQUIRE(pow(half,2)==quarter);
-    REQUIRE_THROWS(RationalConstant(1,0));
-    REQUIRE_THROWS(RationalConstant(0,0));
-    REQUIRE_THROWS(pow(0*one,0));
+#ifdef SCREAM_CONSTEXPR_ASSERT
+    REQUIRE_THROWS(one/zero);
+    REQUIRE_THROWS(pow(zero,zero));
+#endif
   }
 
-  SECTION ("rational_constant") {
+  SECTION ("scaling_factor") {
     constexpr RationalConstant one = RationalConstant::one();
     constexpr RationalConstant third = 1/(3*one);
     constexpr RationalConstant four_thirds = 4*third;
     constexpr RationalConstant three_halves = 3/(2*one);
     constexpr RationalConstant two = 2*one;
     constexpr ScalingFactor root2 (2,{1,2});
+
+    // I need a runtime number for runtime checks
+    const RationalConstant three(3);
 
     // Verify operations
     REQUIRE( root2*root2 == two );
@@ -41,15 +46,21 @@ TEST_CASE("units_framework", "") {
     // Verify printing
     REQUIRE(to_string(root2)=="2^1/2");
     REQUIRE(to_string(root2,Format::Float)=="2^0.5");
+
+#ifdef SCREAM_CONSTEXPR_ASSERT
+    REQUIRE_THROWS(sqrt(-three));
+#endif
   }
 
   SECTION ("units") {
     constexpr RationalConstant one = RationalConstant::one();
-    constexpr auto km = kilo*m;
-    constexpr auto kPa = kilo*Pa;
+    const auto km = kilo*m;
+    const auto kPa = kilo*Pa;
 
     Units nondim (ScalingFactor(1));
     Units milliJ = milli*N*m;
+    Units mix_ratio = kg/kg;
+    mix_ratio.set_string("kg/kg");
 
     // Verify operations
     REQUIRE (milliJ == kPa*pow(m,3)/mega);
@@ -59,5 +70,10 @@ TEST_CASE("units_framework", "") {
     // Verify printing
     REQUIRE (to_string(nondim)=="1");
     REQUIRE (to_string(milliJ.set_exp_format(Format::Rat))=="0.001 m^2 s^-2 kg");
+
+    // Verify changing the string works and does not affect the to_string function
+    REQUIRE (mix_ratio==nondim);
+    REQUIRE (to_string(mix_ratio)=="1");
+    REQUIRE (mix_ratio.get_string()=="kg/kg");
   }
 }

--- a/components/scream/src/share/tests/units.cpp
+++ b/components/scream/src/share/tests/units.cpp
@@ -1,0 +1,63 @@
+#include <catch2/catch.hpp>
+
+#include "share/util/units.hpp"
+
+#include <iostream>
+
+TEST_CASE("units_framework", "") {
+  using namespace scream;
+  using namespace scream::units;
+
+  SECTION ("rational_constant") {
+    constexpr RationalConstant quarter(1,4);
+    constexpr RationalConstant half(1,2);
+    constexpr RationalConstant one(1);
+    constexpr RationalConstant two(2,1);
+
+    // Verify operations
+    REQUIRE(half*two == one);
+    REQUIRE(half+half == one);
+    REQUIRE(one/two == half);
+    REQUIRE(half*half == quarter);
+    REQUIRE(pow(half,2)==quarter);
+    REQUIRE_THROWS(RationalConstant(1,0));
+    REQUIRE_THROWS(RationalConstant(0,0));
+    REQUIRE_THROWS(pow(0*one,0));
+  }
+
+  SECTION ("rational_constant") {
+    constexpr RationalConstant one = RationalConstant::one();
+    constexpr RationalConstant third = 1/(3*one);
+    constexpr RationalConstant four_thirds = 4*third;
+    constexpr RationalConstant three_halves = 3/(2*one);
+    constexpr RationalConstant two = 2*one;
+    constexpr ScalingFactor root2 (2,{1,2});
+
+    // Verify operations
+    REQUIRE( root2*root2 == two );
+    REQUIRE( sqrt(two) == root2 );
+    REQUIRE( pow(three_halves,2)*pow(four_thirds,3) == 16*one/3);
+
+    // Verify printing
+    REQUIRE(to_string(root2)=="2^1/2");
+    REQUIRE(to_string(root2,Format::Float)=="2^0.5");
+  }
+
+  SECTION ("units") {
+    constexpr RationalConstant one = RationalConstant::one();
+    constexpr auto km = kilo*m;
+    constexpr auto kPa = kilo*Pa;
+
+    Units nondim (ScalingFactor(1));
+    Units milliJ = milli*N*m;
+
+    // Verify operations
+    REQUIRE (milliJ == kPa*pow(m,3)/mega);
+    REQUIRE (m/s*day/km == Units(one*86400/1000));
+    REQUIRE (pow(sqrt(m),2)==m);
+
+    // Verify printing
+    REQUIRE (to_string(nondim)=="1");
+    REQUIRE (to_string(milliJ.set_exp_format(Format::Rat))=="0.001 m^2 s^-2 kg");
+  }
+}

--- a/components/scream/src/share/util/rational_constant.hpp
+++ b/components/scream/src/share/util/rational_constant.hpp
@@ -1,0 +1,195 @@
+#ifndef SCREAM_RATIONAL_CONSTANT_HPP
+#define SCREAM_RATIONAL_CONSTANT_HPP
+
+#include <stdexcept>
+#include <sstream>
+
+#include "share/scream_assert.hpp"
+
+namespace scream
+{
+
+namespace util
+{
+
+enum class Format {
+  Float,
+  Rat,
+  Auto
+};
+
+inline constexpr Format operator&& (const Format fmt1, const Format fmt2) {
+  return fmt1==Format::Rat || fmt2==Format::Rat ? Format::Rat
+                    : (fmt1==Format::Auto ? fmt2 : fmt1);
+}
+
+constexpr long abs (const long a) {
+  return a>=0 ? a : -a;
+}
+
+constexpr long gcd (const long a, const long b) {
+  return b==0
+          ? a
+          : gcd(b, a % b);
+}
+
+// Elementary representation of a rational number
+// Note: we do not allow construction from a double (even if
+//       the double is a simple fraction, like 1.5), since
+//       its implementation (with correct checks and safeguards)
+//       would probably require too much effort, especially
+//       considered the scope of the usage of this class
+
+class RationalConstant {
+public:
+
+  // No default
+  RationalConstant () = delete;
+
+  // No construction from double
+  RationalConstant (const double x) = delete;
+
+  // Construction from long, means long/1
+  template<typename IntType>
+  constexpr RationalConstant (const IntType n,
+                              typename std::enable_if<std::is_integral<IntType>::value,Format>::type fmt = Format::Float)
+   : RationalConstant (n,1,fmt)
+  {
+    // Nothing to do here
+  }
+
+  template<typename IntType1, typename IntType2>
+  constexpr RationalConstant (const IntType1 n, const IntType2 d,
+                              typename std::enable_if<std::is_integral<IntType1>::value &&
+                                                      std::is_integral<IntType1>::value,Format>::type fmt = Format::Float)
+   : m_num(fix_num(n,d))
+   , m_den(fix_den(n,d))
+   , m_fmt(fmt)
+  {
+    // Nothing to do here
+  }
+  constexpr RationalConstant (const RationalConstant&) = default;
+  RationalConstant& operator= (const RationalConstant&) = default;
+
+  constexpr long long num () const { return m_num; }
+  constexpr long long den () const { return m_den; }
+
+  const RationalConstant& set_format (const Format fmt) {
+    m_fmt = fmt;
+    return *this;
+  }
+
+  constexpr Format get_format () const { return m_fmt; }
+
+  static constexpr RationalConstant one () { return RationalConstant(1); }
+  static constexpr RationalConstant zero () { return RationalConstant(0); }
+
+private:
+
+  // These two are used to help reduce a/b to lowest terms
+  static constexpr long long fix_num(const long long n, const long long d) {
+    return n==0
+            ? (d==0 ? throw std::logic_error("Error! 0/0 encountered.\n") : n)
+            : n / gcd(abs(n),abs(d));
+  }
+
+  static constexpr long long fix_den(const long long n, const long long d) {
+    return d<0
+            ? fix_den(n,-d)
+            : (d!=0
+                ? d / gcd(abs(n),abs(d))
+                : throw std::logic_error("Null denominator"));
+  }
+
+  const long long m_num;
+  const long long m_den;
+  Format m_fmt;
+};
+
+constexpr bool operator== (const RationalConstant& lhs, const RationalConstant& rhs) {
+  // Cross multiply, in case somehow (should not be possible, unless
+  // someone changed the implementation) someone managed to get lhs and/or
+  // rhs to not be already reduced to lower terms
+  return lhs.num()*rhs.den()==lhs.den()*rhs.num();
+}
+
+constexpr bool operator!= (const RationalConstant& lhs, const RationalConstant& rhs) {
+  return !(lhs==rhs);
+}
+
+constexpr RationalConstant operator+ (const RationalConstant& lhs, const RationalConstant& rhs) {
+  return RationalConstant (lhs.num()*rhs.den() + lhs.den()*rhs.num(),
+                           lhs.den()*rhs.den(),
+                           lhs.get_format()&&rhs.get_format());
+}
+
+constexpr RationalConstant operator- (const RationalConstant& lhs, const RationalConstant& rhs) {
+  return RationalConstant (lhs.num()*rhs.den() - lhs.den()*rhs.num(),
+                           lhs.den()*rhs.den(),
+                           lhs.get_format()&&rhs.get_format());
+}
+
+constexpr RationalConstant operator* (const RationalConstant& lhs, const RationalConstant& rhs) {
+  return RationalConstant (lhs.num()*rhs.num(),
+                           lhs.den()*rhs.den(),
+                           lhs.get_format()&&rhs.get_format());
+}
+
+constexpr RationalConstant operator/ (const RationalConstant& lhs, const RationalConstant& rhs) {
+  return RationalConstant (lhs.num()*rhs.den(),
+                           lhs.den()*rhs.num(),
+                           lhs.get_format()&&rhs.get_format());
+}
+
+constexpr long long pow_zero (const long long base) {
+  return base==0 ? throw std::logic_error("Error! Cannot compute 0^0!\n") : 1;
+}
+
+// WARNING! If exp>>1, this generates a huge recursion. Use carefully!!
+template<typename IntType>
+inline constexpr RationalConstant pow (const typename std::enable_if<std::is_integral<IntType>::value,RationalConstant>::type& x, const IntType p) {
+  // Three main cases:
+  //  - p<0: compute the -p power of 1/x
+  //  - p=0: base case, return 1 if x!=0, throw if x==0
+  //  - recursion step: x^p = x * x^{p-1}
+  return p<0 ? pow(1/x,-p)
+             : (p==0 ? RationalConstant(pow_zero(x.num()),pow_zero(x.den()))
+                     : ( (p&1)!=0 ? x*pow(x*x,p>>1) : pow(x*x,p>>1)));
+}
+
+inline std::string to_string (const RationalConstant& rat, const Format fmt = Format::Auto) {
+  // Note: using std::to_string(double) causes insertion of trailing zeros,
+  //       and the insertion of decimal part for integers.
+  //       E.g., to_string(1.0/2) leads to 0.5000000
+  std::stringstream ss;
+  switch (fmt) {
+    case Format::Float:
+      ss << static_cast<double>(rat.num())/rat.den();
+      break;
+    case Format::Rat:
+      ss << rat.num();
+      if (rat.den()!=1) {
+        ss << "/" << rat.den();
+      }
+      break;
+    case Format::Auto:
+      scream_require_msg(rat.get_format()!=Format::Auto, "Error! No format specified in the rational constant.\n");
+      ss << to_string(rat,rat.get_format());
+      break;
+    default:
+      scream_require_msg(false,"Error! Unrecognized format for printing RationalConstant.\n");
+      
+  }
+  return ss.str();
+}
+
+inline std::ostream& operator<< (std::ostream& out, const RationalConstant& rat) {
+  out << to_string(rat);
+  return out;
+}
+
+} // namespace util
+
+} // namespace scream
+
+#endif // SCREAM_RATIONAL_CONSTANT_HPP

--- a/components/scream/src/share/util/scaling_factor.hpp
+++ b/components/scream/src/share/util/scaling_factor.hpp
@@ -22,13 +22,27 @@ struct ScalingFactor {
   }
   constexpr ScalingFactor (const RationalConstant& b,
                            const RationalConstant& e)
-   : base(b)
-   , exp (e)
+   : base(check_and_adjust(b,e,true))
+   , exp (check_and_adjust(b,e,false))
   {
     // Nothing to do here
   }
+
   constexpr ScalingFactor (const ScalingFactor&) = default;
   ScalingFactor& operator= (const ScalingFactor&) = default;
+
+private:
+
+  static constexpr RationalConstant
+  check_and_adjust (const RationalConstant& b,
+                    const RationalConstant& e,
+                    const bool return_base) {
+    // Check that we are not doing 0^0 or taking even roots of negative numbers.
+    // If all good, adjust base and exp for x^0 case, and return what was requested.
+    return CONSTEXPR_ASSERT( !(b==RationalConstant::zero() && e==RationalConstant::zero()) ),
+           CONSTEXPR_ASSERT( !(b.num()<0 && e.den()%2==0) ),
+           e==RationalConstant::zero() ? RationalConstant::one(): (return_base ? b : e);
+  }
 };
 
 constexpr bool operator== (const ScalingFactor& lhs, const ScalingFactor& rhs) {
@@ -127,6 +141,11 @@ namespace prefixes {
 constexpr ScalingFactor nano  = ScalingFactor(10,-9);
 constexpr ScalingFactor micro = ScalingFactor(10,-6);
 constexpr ScalingFactor milli = ScalingFactor(10,-3);
+constexpr ScalingFactor centi = ScalingFactor(10,-2);
+constexpr ScalingFactor deci  = ScalingFactor(10,-1);
+
+constexpr ScalingFactor deca  = ScalingFactor(10, 1);
+constexpr ScalingFactor hecto = ScalingFactor(10, 2);
 constexpr ScalingFactor kilo  = ScalingFactor(10, 3);
 constexpr ScalingFactor mega  = ScalingFactor(10, 6);
 constexpr ScalingFactor giga  = ScalingFactor(10, 9);

--- a/components/scream/src/share/util/scaling_factor.hpp
+++ b/components/scream/src/share/util/scaling_factor.hpp
@@ -1,0 +1,139 @@
+#ifndef SCREAM_SCALING_FACTOR_HPP
+#define SCREAM_SCALING_FACTOR_HPP
+
+#include <iostream>
+#include "share/util/rational_constant.hpp"
+
+namespace scream
+{
+
+namespace util
+{
+
+struct ScalingFactor {
+  const RationalConstant base;
+  const RationalConstant exp;
+
+  ScalingFactor () = delete;
+  constexpr ScalingFactor (const RationalConstant& s)
+   : ScalingFactor(s,1)
+  {
+    // Nothing to do here
+  }
+  constexpr ScalingFactor (const RationalConstant& b,
+                           const RationalConstant& e)
+   : base(b)
+   , exp (e)
+  {
+    // Nothing to do here
+  }
+  constexpr ScalingFactor (const ScalingFactor&) = default;
+  ScalingFactor& operator= (const ScalingFactor&) = default;
+};
+
+constexpr bool operator== (const ScalingFactor& lhs, const ScalingFactor& rhs) {
+  // Recall that, with all terms being integers,
+  //    (a/b)^(c/d)==(x/y)^(w/z)
+  // is equivalent to
+  //    (a/b)^(cz) == (x/w)^(wd)
+  return pow(lhs.base,lhs.exp.num()*rhs.exp.den())==pow(rhs.base,rhs.exp.num()*lhs.exp.den());
+}
+
+constexpr bool operator== (const ScalingFactor& lhs, const RationalConstant& rhs) {
+  return lhs==ScalingFactor(rhs);
+}
+
+constexpr bool operator== (const RationalConstant& lhs, const ScalingFactor& rhs) {
+  return ScalingFactor(lhs)==rhs;
+}
+
+constexpr bool operator!= (const ScalingFactor& lhs, const ScalingFactor& rhs) {
+  return !(lhs==rhs);
+}
+
+constexpr ScalingFactor operator* (const ScalingFactor& lhs, const ScalingFactor& rhs) {
+  // If base or exp are the same, we can use powers properties,
+  // otherwise, recall that, with all terms being integers,
+  //    (a/b)^(c/d) * (x/y)^(w/z)
+  // is equivalent to
+  //    ((a/b)^(cz) * (x/w)^(wd)) ^ (1/dz)
+// auto l = pow(lhs.base,lhs.exp.num()*rhs.exp.den());
+// std::cout << "l = " << l.set_format(Rat) << "\n";
+  return lhs.base==rhs.base 
+            ? ScalingFactor(lhs.base,lhs.exp+rhs.exp)
+            : (lhs.exp==rhs.exp
+                ? ScalingFactor(lhs.base*rhs.base,lhs.exp)
+                : ScalingFactor( pow(lhs.base,lhs.exp.num()*rhs.exp.den()) * pow(rhs.base,rhs.exp.num()*lhs.exp.den()),
+                                 RationalConstant(1,lhs.exp.den()*rhs.exp.den())));
+}
+
+constexpr ScalingFactor operator* (const RationalConstant& lhs, const ScalingFactor& rhs) {
+  return rhs*ScalingFactor(lhs);
+}
+
+constexpr ScalingFactor operator* (const ScalingFactor& lhs, const RationalConstant& rhs) {
+  return lhs*ScalingFactor(rhs);
+}
+
+constexpr ScalingFactor operator/ (const ScalingFactor& lhs, const ScalingFactor& rhs) {
+  // If base or exp are the same, we can use powers properties,
+  // otherwise, recall that, with all terms being integers,
+  //    (a/b)^(c/d) / (x/y)^(w/z)
+  // is equivalent to
+  //    ((a/b)^(cz) / (x/w)^(wd)) ^ (1/dz)
+  return lhs.base==rhs.base 
+            ? ScalingFactor(lhs.base,lhs.exp-rhs.exp)
+            : (lhs.exp==rhs.exp
+                ? ScalingFactor(lhs.base/rhs.base,lhs.exp)
+                : ScalingFactor( pow(lhs.base,lhs.exp.num()*rhs.exp.den()) / pow(rhs.base,rhs.exp.num()*lhs.exp.den()),
+                                 RationalConstant(1,lhs.exp.den()*rhs.exp.den())));
+}
+
+constexpr ScalingFactor operator/ (const ScalingFactor& lhs, const RationalConstant& rhs) {
+  return lhs/ScalingFactor(rhs);
+}
+
+constexpr ScalingFactor operator/ (const RationalConstant& lhs, const ScalingFactor& rhs) {
+  return ScalingFactor(lhs)/rhs;
+}
+
+constexpr ScalingFactor pow (const ScalingFactor& x, const int p) {
+  return ScalingFactor(x.base,x.exp*p);
+}
+
+constexpr ScalingFactor pow (const ScalingFactor& x, const RationalConstant& y) {
+  return ScalingFactor(x.base,x.exp*y);
+}
+
+constexpr ScalingFactor sqrt (const ScalingFactor& x) {
+  return ScalingFactor(x.base,x.exp/2);
+}
+
+inline std::string to_string(const ScalingFactor& x, const Format exp_fmt = Format::Rat) {
+  std::string s = to_string(x.base);
+  if (x.exp!=RationalConstant::one()) {
+    s +=  "^" + to_string(x.exp,exp_fmt);
+  }
+  return s;
+}
+
+inline std::ostream& operator<< (std::ostream& out, const ScalingFactor& s) {
+  out << to_string(s);
+  return out;
+}
+
+
+namespace prefixes {
+constexpr ScalingFactor nano  = ScalingFactor(10,-9);
+constexpr ScalingFactor micro = ScalingFactor(10,-6);
+constexpr ScalingFactor milli = ScalingFactor(10,-3);
+constexpr ScalingFactor kilo  = ScalingFactor(10, 3);
+constexpr ScalingFactor mega  = ScalingFactor(10, 6);
+constexpr ScalingFactor giga  = ScalingFactor(10, 9);
+} // namespace prefixes
+
+} // namespace util
+
+} // namespace scream
+
+#endif // SCREAM_SCALING_FACTOR_HPP

--- a/components/scream/src/share/util/units.hpp
+++ b/components/scream/src/share/util/units.hpp
@@ -4,8 +4,6 @@
 #include "share/util/rational_constant.hpp"
 #include "share/util/scaling_factor.hpp"
 
-#include <sstream>
-
 namespace scream
 {
 
@@ -42,50 +40,64 @@ public:
   constexpr Units () = delete;
 
   // Construct a non-dimensional quantity
-  constexpr Units (const ScalingFactor& scaling)
+  Units (const ScalingFactor& scaling)
    : m_scaling {scaling}
    , m_units{0,0,0,0,0,0,0}
    , m_exp_format (Format::Rat)
   {
-    // Nothing to do here
+    m_string = to_string(*this);
   }
 
   // Construct a general quantity
-  constexpr Units (const RationalConstant& lengthExp,
-                   const RationalConstant& timeExp,
-                   const RationalConstant& massExp,
-                   const RationalConstant& temperatureExp,
-                   const RationalConstant& currentExp,
-                   const RationalConstant& amountExp,
-                   const RationalConstant& luminousIntensityExp,
-                   const ScalingFactor& scalingFactor = RationalConstant::one())
+  Units (const RationalConstant& lengthExp,
+         const RationalConstant& timeExp,
+         const RationalConstant& massExp,
+         const RationalConstant& temperatureExp,
+         const RationalConstant& currentExp,
+         const RationalConstant& amountExp,
+         const RationalConstant& luminousIntensityExp,
+         const ScalingFactor& scalingFactor = RationalConstant::one())
    : m_scaling {scalingFactor.base,scalingFactor.exp}
    , m_units {lengthExp,timeExp,massExp,temperatureExp,currentExp,amountExp,luminousIntensityExp}
    , m_exp_format (Format::Rat)
   {
-    // Nothing to do here
+    m_string = to_string(*this);
   }
 
-  constexpr Units (const Units&) = default;
+  Units (const Units&) = default;
   Units& operator= (const Units&) = default;
 
   const Units& set_exp_format (const Format fmt) {
+    // Note: this will NOT change the stored string.
+    //       It is only used by the to_string function.
     m_exp_format = fmt;
+
     return *this;
+  }
+
+  void set_string (const std::string& str) {
+    m_string = str;
+  }
+  const std::string& get_string () const {
+    return m_string;
   }
 
 private:
 
-  friend constexpr bool operator==(const Units&,const Units&);
+  void reset_string (const std::string& str) {
+    m_string = str;
+  }
 
-  friend constexpr Units operator*(const Units&,const Units&);
-  friend constexpr Units operator*(const ScalingFactor&,const Units&);
-  friend constexpr Units operator/(const Units&,const Units&);
-  friend constexpr Units operator/(const Units&,const ScalingFactor&);
-  friend constexpr Units operator/(const ScalingFactor&,const Units&);
-  friend constexpr Units pow(const Units&,const RationalConstant&);
-  friend constexpr Units sqrt(const Units&);
-  friend constexpr Units root(const Units&,const int);
+  friend bool operator==(const Units&,const Units&);
+
+  friend Units operator*(const Units&,const Units&);
+  friend Units operator*(const ScalingFactor&,const Units&);
+  friend Units operator/(const Units&,const Units&);
+  friend Units operator/(const Units&,const ScalingFactor&);
+  friend Units operator/(const ScalingFactor&,const Units&);
+  friend Units pow(const Units&,const RationalConstant&);
+  friend Units sqrt(const Units&);
+  friend Units root(const Units&,const int);
 
   friend std::string to_string(const Units&);
 
@@ -93,6 +105,8 @@ private:
   const RationalConstant  m_units[7];
 
   Format                  m_exp_format;
+
+  std::string             m_string;
 };
 
 // === Operators/functions overload === //
@@ -103,7 +117,7 @@ private:
 
 // --- Comparison --- //
 
-constexpr bool operator==(const Units& lhs, const Units& rhs) {
+bool operator==(const Units& lhs, const Units& rhs) {
   return lhs.m_scaling==rhs.m_scaling &&
          lhs.m_units[0]==rhs.m_units[0] &&
          lhs.m_units[1]==rhs.m_units[1] &&
@@ -114,12 +128,12 @@ constexpr bool operator==(const Units& lhs, const Units& rhs) {
          lhs.m_units[6]==rhs.m_units[6];
 }
 
-constexpr bool operator!=(const Units& lhs, const Units& rhs) {
+bool operator!=(const Units& lhs, const Units& rhs) {
   return !(lhs==rhs);
 }
 
 // --- Multiplicaiton --- //
-constexpr Units operator*(const Units& lhs, const Units& rhs) {
+Units operator*(const Units& lhs, const Units& rhs) {
   return Units(lhs.m_units[0]+rhs.m_units[0],
                lhs.m_units[1]+rhs.m_units[1],
                lhs.m_units[2]+rhs.m_units[2],
@@ -129,7 +143,7 @@ constexpr Units operator*(const Units& lhs, const Units& rhs) {
                lhs.m_units[6]+rhs.m_units[6],
                lhs.m_scaling*rhs.m_scaling);
 }
-constexpr Units operator*(const ScalingFactor& lhs, const Units& rhs) {
+Units operator*(const ScalingFactor& lhs, const Units& rhs) {
   return Units(rhs.m_units[0],
                rhs.m_units[1],
                rhs.m_units[2],
@@ -139,18 +153,18 @@ constexpr Units operator*(const ScalingFactor& lhs, const Units& rhs) {
                rhs.m_units[6],
                lhs*rhs.m_scaling);
 }
-constexpr Units operator*(const Units& lhs, const ScalingFactor& rhs) {
+Units operator*(const Units& lhs, const ScalingFactor& rhs) {
   return rhs*lhs;
 }
-constexpr Units operator*(const RationalConstant& lhs, const Units& rhs) {
+Units operator*(const RationalConstant& lhs, const Units& rhs) {
   return ScalingFactor(lhs)*rhs;
 }
-constexpr Units operator*(const Units& lhs, const RationalConstant& rhs) {
+Units operator*(const Units& lhs, const RationalConstant& rhs) {
   return lhs*ScalingFactor(rhs);
 }
 
 // --- Division --- //
-constexpr Units operator/(const Units& lhs, const Units& rhs) {
+Units operator/(const Units& lhs, const Units& rhs) {
   return Units(lhs.m_units[0]-rhs.m_units[0],
                lhs.m_units[1]-rhs.m_units[1],
                lhs.m_units[2]-rhs.m_units[2],
@@ -160,7 +174,7 @@ constexpr Units operator/(const Units& lhs, const Units& rhs) {
                lhs.m_units[6]-rhs.m_units[6],
                lhs.m_scaling/rhs.m_scaling);
 }
-constexpr Units operator/(const Units& lhs, const ScalingFactor& rhs) {
+Units operator/(const Units& lhs, const ScalingFactor& rhs) {
   return Units(lhs.m_units[0],
                lhs.m_units[1],
                lhs.m_units[2],
@@ -170,7 +184,7 @@ constexpr Units operator/(const Units& lhs, const ScalingFactor& rhs) {
                lhs.m_units[6],
                lhs.m_scaling/rhs);
 }
-constexpr Units operator/(const ScalingFactor& lhs, const Units& rhs) {
+Units operator/(const ScalingFactor& lhs, const Units& rhs) {
   return Units(1-rhs.m_units[0],
                1-rhs.m_units[1],
                1-rhs.m_units[2],
@@ -180,16 +194,16 @@ constexpr Units operator/(const ScalingFactor& lhs, const Units& rhs) {
                1-rhs.m_units[6],
                lhs/rhs.m_scaling);
 }
-constexpr Units operator/(const RationalConstant& lhs, const Units& rhs) {
+Units operator/(const RationalConstant& lhs, const Units& rhs) {
   return ScalingFactor(lhs)/rhs;
 }
-constexpr Units operator/(const Units& lhs, const RationalConstant& rhs) {
+Units operator/(const Units& lhs, const RationalConstant& rhs) {
   return lhs/ScalingFactor(rhs);
 }
 
 // --- Powers and roots --- //
 
-constexpr Units pow(const Units& x, const RationalConstant& p) {
+Units pow(const Units& x, const RationalConstant& p) {
   return Units(x.m_units[0]*p,
                x.m_units[1]*p,
                x.m_units[2]*p,
@@ -200,7 +214,7 @@ constexpr Units pow(const Units& x, const RationalConstant& p) {
                pow(x.m_scaling,p));
 }
 
-constexpr Units sqrt(const Units& x) {
+Units sqrt(const Units& x) {
   return Units(x.m_units[0] / 2,
                x.m_units[1] / 2,
                x.m_units[2] / 2,
@@ -226,7 +240,7 @@ inline std::string to_string(const Units& x) {
     }
   }
 
-  // Prepend the scaling only if not one or dimensionless unit
+  // Prepend the scaling only if it's not one, or if this is a dimensionless unit
   if (x.m_scaling!=RationalConstant::one() || num_non_trivial==0) {
     s = to_string(x.m_scaling,x.m_exp_format) + s;
   }
@@ -247,38 +261,38 @@ inline std::ostream& operator<< (std::ostream& out, const Units& x) {
 
 // === FUNDAMENTAL === //
 
-constexpr Units m   = Units(1,0,0,0,0,0,0);
-constexpr Units s   = Units(0,1,0,0,0,0,0);
-constexpr Units kg  = Units(0,0,1,0,0,0,0);
-constexpr Units K   = Units(0,0,0,1,0,0,0);
-constexpr Units A   = Units(0,0,0,0,1,0,0);
-constexpr Units mol = Units(0,0,0,0,0,1,0);
-constexpr Units cd  = Units(0,0,0,0,0,0,1);
+const Units m   = Units(1,0,0,0,0,0,0);
+const Units s   = Units(0,1,0,0,0,0,0);
+const Units kg  = Units(0,0,1,0,0,0,0);
+const Units K   = Units(0,0,0,1,0,0,0);
+const Units A   = Units(0,0,0,0,1,0,0);
+const Units mol = Units(0,0,0,0,0,1,0);
+const Units cd  = Units(0,0,0,0,0,0,1);
 
 // === DERIVED === //
 
 // Thermomechanics
-constexpr auto day  = 86400*s;      // day          (time)
-constexpr auto year = 365*day;      // year         (time)
-constexpr auto g    = milli*kg;     // gram         (mass)
-constexpr auto N    = kg*m/(s*s);   // newton       (force)
-constexpr auto dyn  = N/(10000);    // dyne         (force)
-constexpr auto Pa   = N/(m*m);      // pascal       (pressure)
-constexpr auto bar  = 10000*Pa;     // bar          (pressure)
-constexpr auto atm  = 101325*Pa;    // atmosphere   (pressure)
-constexpr auto J    = N*m;          // joule        (energy)
-constexpr auto W    = J/s;          // watt         (power)
+const Units day  = 86400*s;      // day          (time)
+const Units year = 365*day;      // year         (time)
+const Units g    = milli*kg;     // gram         (mass)
+const Units N    = kg*m/(s*s);   // newton       (force)
+const Units dyn  = N/(10000);    // dyne         (force)
+const Units Pa   = N/(m*m);      // pascal       (pressure)
+const Units bar  = 10000*Pa;     // bar          (pressure)
+const Units atm  = 101325*Pa;    // atmosphere   (pressure)
+const Units J    = N*m;          // joule        (energy)
+const Units W    = J/s;          // watt         (power)
 
 // Electro-magnetism
-constexpr auto C    = A*s;          // coulomb      (charge)
-constexpr auto V    = J/C;          // volt         (voltage)
-constexpr auto T    = N/(A*m);      // tesla        (magnetic field)
-constexpr auto F    = C/V;          // farad        (capacitance)
-constexpr auto Wb   = V*s;          // weber        (magnetic flux)
-constexpr auto H    = Wb/A;         // henri        (inductance)
-constexpr auto Sv   = J/kg;         // sievert      (radiation dose)
-constexpr auto rem  = Sv/100;       // rem          (radiation dose)
-constexpr auto Hz   = 1/s;          // hertz        (frequency)
+const Units C    = A*s;          // coulomb      (charge)
+const Units V    = J/C;          // volt         (voltage)
+const Units T    = N/(A*m);      // tesla        (magnetic field)
+const Units F    = C/V;          // farad        (capacitance)
+const Units Wb   = V*s;          // weber        (magnetic flux)
+const Units H    = Wb/A;         // henri        (inductance)
+const Units Sv   = J/kg;         // sievert      (radiation dose)
+const Units rem  = Sv/100;       // rem          (radiation dose)
+const Units Hz   = 1/s;          // hertz        (frequency)
 
 } // namespace units
 

--- a/components/scream/src/share/util/units.hpp
+++ b/components/scream/src/share/util/units.hpp
@@ -1,0 +1,287 @@
+#ifndef SCREAM_UNITS_HPP
+#define SCREAM_UNITS_HPP
+
+#include "share/util/rational_constant.hpp"
+#include "share/util/scaling_factor.hpp"
+
+#include <sstream>
+
+namespace scream
+{
+
+namespace units
+{
+
+// In the units namespace, it's ok to use some stuff from the util namespace
+using util::RationalConstant;
+using util::ScalingFactor;
+using util::Format;
+using namespace util::prefixes;
+
+constexpr int NUM_BASIC_UNITS = 7;
+constexpr const char* BASIC_UNITS_SYMBOLS[7] = {"m", "s", "kg", "K", "A", "mol", "cd"};
+
+/*
+ *  Units: a class to store physical units in terms of fundamental ones
+ *  
+ *  Units is morally storing 8 numbers:
+ *   - a scaling factor
+ *   - the exponents of the 7 base units
+ *  So if a quantity has units kPa, it will store
+ *  
+ *    - a scaling factor of 1000
+ *    - the exponents [ -1, -2, 1, 0, 0, 0, 0 ]
+ *  
+ *  since kPa = 1000 kg m^-1 s ^-2.
+ */
+
+class Units {
+public:
+
+  // No default
+  constexpr Units () = delete;
+
+  // Construct a non-dimensional quantity
+  constexpr Units (const ScalingFactor& scaling)
+   : m_scaling {scaling}
+   , m_units{0,0,0,0,0,0,0}
+   , m_exp_format (Format::Rat)
+  {
+    // Nothing to do here
+  }
+
+  // Construct a general quantity
+  constexpr Units (const RationalConstant& lengthExp,
+                   const RationalConstant& timeExp,
+                   const RationalConstant& massExp,
+                   const RationalConstant& temperatureExp,
+                   const RationalConstant& currentExp,
+                   const RationalConstant& amountExp,
+                   const RationalConstant& luminousIntensityExp,
+                   const ScalingFactor& scalingFactor = RationalConstant::one())
+   : m_scaling {scalingFactor.base,scalingFactor.exp}
+   , m_units {lengthExp,timeExp,massExp,temperatureExp,currentExp,amountExp,luminousIntensityExp}
+   , m_exp_format (Format::Rat)
+  {
+    // Nothing to do here
+  }
+
+  constexpr Units (const Units&) = default;
+  Units& operator= (const Units&) = default;
+
+  const Units& set_exp_format (const Format fmt) {
+    m_exp_format = fmt;
+    return *this;
+  }
+
+private:
+
+  friend constexpr bool operator==(const Units&,const Units&);
+
+  friend constexpr Units operator*(const Units&,const Units&);
+  friend constexpr Units operator*(const ScalingFactor&,const Units&);
+  friend constexpr Units operator/(const Units&,const Units&);
+  friend constexpr Units operator/(const Units&,const ScalingFactor&);
+  friend constexpr Units operator/(const ScalingFactor&,const Units&);
+  friend constexpr Units pow(const Units&,const RationalConstant&);
+  friend constexpr Units sqrt(const Units&);
+  friend constexpr Units root(const Units&,const int);
+
+  friend std::string to_string(const Units&);
+
+  const ScalingFactor     m_scaling;
+  const RationalConstant  m_units[7];
+
+  Format                  m_exp_format;
+};
+
+// === Operators/functions overload === //
+//
+// Recall: the first RationalConstant is a factor, while the remaining seven
+//         are only exponents. So in u1*u2, multiply the factor, and
+//         add the exponents
+
+// --- Comparison --- //
+
+constexpr bool operator==(const Units& lhs, const Units& rhs) {
+  return lhs.m_scaling==rhs.m_scaling &&
+         lhs.m_units[0]==rhs.m_units[0] &&
+         lhs.m_units[1]==rhs.m_units[1] &&
+         lhs.m_units[2]==rhs.m_units[2] &&
+         lhs.m_units[3]==rhs.m_units[3] &&
+         lhs.m_units[4]==rhs.m_units[4] &&
+         lhs.m_units[5]==rhs.m_units[5] &&
+         lhs.m_units[6]==rhs.m_units[6];
+}
+
+constexpr bool operator!=(const Units& lhs, const Units& rhs) {
+  return !(lhs==rhs);
+}
+
+// --- Multiplicaiton --- //
+constexpr Units operator*(const Units& lhs, const Units& rhs) {
+  return Units(lhs.m_units[0]+rhs.m_units[0],
+               lhs.m_units[1]+rhs.m_units[1],
+               lhs.m_units[2]+rhs.m_units[2],
+               lhs.m_units[3]+rhs.m_units[3],
+               lhs.m_units[4]+rhs.m_units[4],
+               lhs.m_units[5]+rhs.m_units[5],
+               lhs.m_units[6]+rhs.m_units[6],
+               lhs.m_scaling*rhs.m_scaling);
+}
+constexpr Units operator*(const ScalingFactor& lhs, const Units& rhs) {
+  return Units(rhs.m_units[0],
+               rhs.m_units[1],
+               rhs.m_units[2],
+               rhs.m_units[3],
+               rhs.m_units[4],
+               rhs.m_units[5],
+               rhs.m_units[6],
+               lhs*rhs.m_scaling);
+}
+constexpr Units operator*(const Units& lhs, const ScalingFactor& rhs) {
+  return rhs*lhs;
+}
+constexpr Units operator*(const RationalConstant& lhs, const Units& rhs) {
+  return ScalingFactor(lhs)*rhs;
+}
+constexpr Units operator*(const Units& lhs, const RationalConstant& rhs) {
+  return lhs*ScalingFactor(rhs);
+}
+
+// --- Division --- //
+constexpr Units operator/(const Units& lhs, const Units& rhs) {
+  return Units(lhs.m_units[0]-rhs.m_units[0],
+               lhs.m_units[1]-rhs.m_units[1],
+               lhs.m_units[2]-rhs.m_units[2],
+               lhs.m_units[3]-rhs.m_units[3],
+               lhs.m_units[4]-rhs.m_units[4],
+               lhs.m_units[5]-rhs.m_units[5],
+               lhs.m_units[6]-rhs.m_units[6],
+               lhs.m_scaling/rhs.m_scaling);
+}
+constexpr Units operator/(const Units& lhs, const ScalingFactor& rhs) {
+  return Units(lhs.m_units[0],
+               lhs.m_units[1],
+               lhs.m_units[2],
+               lhs.m_units[3],
+               lhs.m_units[4],
+               lhs.m_units[5],
+               lhs.m_units[6],
+               lhs.m_scaling/rhs);
+}
+constexpr Units operator/(const ScalingFactor& lhs, const Units& rhs) {
+  return Units(1-rhs.m_units[0],
+               1-rhs.m_units[1],
+               1-rhs.m_units[2],
+               1-rhs.m_units[3],
+               1-rhs.m_units[4],
+               1-rhs.m_units[5],
+               1-rhs.m_units[6],
+               lhs/rhs.m_scaling);
+}
+constexpr Units operator/(const RationalConstant& lhs, const Units& rhs) {
+  return ScalingFactor(lhs)/rhs;
+}
+constexpr Units operator/(const Units& lhs, const RationalConstant& rhs) {
+  return lhs/ScalingFactor(rhs);
+}
+
+// --- Powers and roots --- //
+
+constexpr Units pow(const Units& x, const RationalConstant& p) {
+  return Units(x.m_units[0]*p,
+               x.m_units[1]*p,
+               x.m_units[2]*p,
+               x.m_units[3]*p,
+               x.m_units[4]*p,
+               x.m_units[5]*p,
+               x.m_units[6]*p,
+               pow(x.m_scaling,p));
+}
+
+constexpr Units sqrt(const Units& x) {
+  return Units(x.m_units[0] / 2,
+               x.m_units[1] / 2,
+               x.m_units[2] / 2,
+               x.m_units[3] / 2,
+               x.m_units[4] / 2,
+               x.m_units[5] / 2,
+               x.m_units[6] / 2,
+               pow(x.m_scaling,RationalConstant(1,2)));
+}
+
+inline std::string to_string(const Units& x) {
+  std::string s;
+  int num_non_trivial = 0;
+  for (int i=0; i<NUM_BASIC_UNITS; ++i) {
+    if (x.m_units[i].num()==0) {
+      continue;
+    }
+    ++num_non_trivial;
+    s += " ";
+    s += BASIC_UNITS_SYMBOLS[i];
+    if (x.m_units[i]!=RationalConstant::one()) {
+      s += "^" + to_string(x.m_units[i],x.m_exp_format);
+    }
+  }
+
+  // Prepend the scaling only if not one or dimensionless unit
+  if (x.m_scaling!=RationalConstant::one() || num_non_trivial==0) {
+    s = to_string(x.m_scaling,x.m_exp_format) + s;
+  }
+  return s;
+}
+
+inline std::ostream& operator<< (std::ostream& out, const Units& x) {
+  out << to_string(x);
+  return out;
+}
+
+// ================== SHORT NAMES FOR COMMON PHYSICAL UNITS =============== //
+
+// Note to developers:
+// I added the 'most common' units. I avoided 'Siemes', since
+// the symbol is 'S', which is way too close to 's' (seconds).
+// TODO: should we add 'common' scaled ones, such as km=kilo*m?
+
+// === FUNDAMENTAL === //
+
+constexpr Units m   = Units(1,0,0,0,0,0,0);
+constexpr Units s   = Units(0,1,0,0,0,0,0);
+constexpr Units kg  = Units(0,0,1,0,0,0,0);
+constexpr Units K   = Units(0,0,0,1,0,0,0);
+constexpr Units A   = Units(0,0,0,0,1,0,0);
+constexpr Units mol = Units(0,0,0,0,0,1,0);
+constexpr Units cd  = Units(0,0,0,0,0,0,1);
+
+// === DERIVED === //
+
+// Thermomechanics
+constexpr auto day  = 86400*s;      // day          (time)
+constexpr auto year = 365*day;      // year         (time)
+constexpr auto g    = milli*kg;     // gram         (mass)
+constexpr auto N    = kg*m/(s*s);   // newton       (force)
+constexpr auto dyn  = N/(10000);    // dyne         (force)
+constexpr auto Pa   = N/(m*m);      // pascal       (pressure)
+constexpr auto bar  = 10000*Pa;     // bar          (pressure)
+constexpr auto atm  = 101325*Pa;    // atmosphere   (pressure)
+constexpr auto J    = N*m;          // joule        (energy)
+constexpr auto W    = J/s;          // watt         (power)
+
+// Electro-magnetism
+constexpr auto C    = A*s;          // coulomb      (charge)
+constexpr auto V    = J/C;          // volt         (voltage)
+constexpr auto T    = N/(A*m);      // tesla        (magnetic field)
+constexpr auto F    = C/V;          // farad        (capacitance)
+constexpr auto Wb   = V*s;          // weber        (magnetic flux)
+constexpr auto H    = Wb/A;         // henri        (inductance)
+constexpr auto Sv   = J/kg;         // sievert      (radiation dose)
+constexpr auto rem  = Sv/100;       // rem          (radiation dose)
+constexpr auto Hz   = 1/s;          // hertz        (frequency)
+
+} // namespace units
+
+} // namespace scream
+
+#endif // SCREAM_UNITS_HPP


### PR DESCRIPTION
This framework mimics part of boost::units, namely the 'unit' structure, without bringing in the quantity infrastructure. It is a much more simple implementation than boost's. In particular, not having to support quantities (i.e., attaching the units to the type of scalars), we do not need a template-based implementation, and we can do away with just storing the conversion to fundamental units in the class object (rather than in its type).

Since we don't template on units, we can now store a `Units` object inside the fields metadata (we could not do this with `boost::units`, where we would be forced to store only a conversion of units to string).

The implementation is quite simple, and the unit tests try to cover most of it.

I provided some constexpr objects representing fundamental and derived units, as well as some prefixes. Composite ones can be easily created from these. For instance, units for density or viscosity can be easily declared like this

```
constexpr auto kPa = kilo*Pa;   // for clarity; we could just replace kPa below with kilo*Pa or 1000*Pa.
constexpr auto my_density_units = kg/pow(m/1000,3); // kilograms per cubic millimiter
constexpr auto my_visc_units = kPa*s;                          // kilopascals seconds
```

Note: the idea is to later set units inside a `FieldIdentifier` with something like this:

```
constexpr auto MPa = mega*Pa;
viscosity_fid.set_units (MPa*s);
```