### PR TITLE
Kylepres/p3 iso c bugfix

### DIFF
--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -79,14 +79,14 @@ contains
 
   end subroutine p3_init_c
 
-  subroutine p3_main_c(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
+  subroutine p3_main_c(qc,nc,qr,nr,th,qv,dt,qitot,qirim,nitot,birim,   &
        pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
        diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc_in, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm, &
        pratot,prctot,p3_tend_out,mu_c,lamc) bind(C)
     use micro_p3, only : p3_main
 
-    real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, ssat, qv, th, th_old, qv_old
+    real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, qv, th
     real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qitot, qirim, nitot, birim
     real(kind=c_real), intent(in), dimension(its:ite,kts:kte) :: pres, dzq
     real(kind=c_real), intent(in), dimension(its:ite,kts:kte) :: npccn,naai
@@ -114,7 +114,7 @@ contains
 
     log_predictNc = log_predictNc_in
 
-    call p3_main(qc,nc,qr,nr,th_old,th,qv_old,qv,dt,qitot,qirim,nitot,birim,ssat,   &
+    call p3_main(qc,nc,qr,nr,th,qv,dt,qitot,qirim,nitot,birim,   &
          pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
          diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
          pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm, &

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -12,9 +12,9 @@ extern "C" {
                  Real MWH2O, Real MWdry, Real gravit, Real LatVap, Real LatIce, 
                  Real CpLiq, Real Tmelt, Real Pi, Int iulog, bool masterproc);
   void p3_init_c(const char** lookup_file_dir, int* info);
-  void p3_main_c(Real* qc, Real* nc, Real* qr, Real* nr, Real* th_old, Real* th,
-                 Real* qv_old, Real* qv, Real dt, Real* qitot, Real* qirim,
-                 Real* nitot, Real* birim, Real* ssat, Real* pres,
+  void p3_main_c(Real* qc, Real* nc, Real* qr, Real* nr, Real* th,
+                 Real* qv, Real dt, Real* qitot, Real* qirim,
+                 Real* nitot, Real* birim, Real* pres,
                  Real* dzq, Real* npccn, Real* naai, Int it, Real* prt_liq, Real* prt_sol, Int its,
                  Int ite, Int kts, Int kte, Real* diag_ze,
                  Real* diag_effc, Real* diag_effi, Real* diag_vmi,
@@ -45,11 +45,8 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   nitot = Array2("total ice number, #/kg", ncol, nlev);
   qirim = Array2("rime ice mass mixing ratio, kg/kg", ncol, nlev);
   birim = Array2("rime ice volume mixing ratio, m3/kg", ncol, nlev);
-  ssat = Array2("supersaturation (qv - qs), kg/kg", ncol, nlev);
   qv = Array2("water vapor mixing ratio, kg/kg", ncol, nlev);
   th = Array2("potential temperature, K", ncol, nlev);
-  qv_old = Array2("qv at beginning of timestep, kg/kg", ncol, nlev);
-  th_old = Array2("theta at beginning of timestep, K", ncol, nlev);
   pres = Array2("pressure, Pa", ncol, nlev);
   dzq = Array2("vertical grid spacing, m", ncol, nlev);
   npccn = Array2("ccn activated number tendency, kg-1 s-1", ncol, nlev);
@@ -93,9 +90,9 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
         {d_->name.extent_int(0), d_->name.extent_int(1), d_->name.extent_int(2)}, \
         d_->name.data(),                                                \
         d_->name.size()})
-  fdipb(qv); fdipb(th); fdipb(qv_old); fdipb(th_old); fdipb(pres);
+  fdipb(qv); fdipb(th); fdipb(pres);
   fdipb(dzq); fdipb(npccn); fdipb(naai); fdipb(qc); fdipb(nc); fdipb(qr); fdipb(nr);
-  fdipb(ssat); fdipb(qitot); fdipb(nitot);
+  fdipb(qitot); fdipb(nitot);
   fdipb(qirim); fdipb(birim); fdipb(prt_liq); fdipb(prt_sol);
   fdipb(diag_ze); fdipb(diag_effc); fdipb(diag_effi);
   fdipb(diag_vmi); fdipb(diag_di); fdipb(diag_rhoi);
@@ -130,9 +127,9 @@ void p3_init () {
 }
 
 void p3_main (const FortranData& d) {
-  p3_main_c(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(), d.th_old.data(),
-            d.th.data(), d.qv_old.data(), d.qv.data(), d.dt, d.qitot.data(),
-            d.qirim.data(), d.nitot.data(), d.birim.data(), d.ssat.data(),
+  p3_main_c(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(),
+            d.th.data(), d.qv.data(), d.dt, d.qitot.data(),
+            d.qirim.data(), d.nitot.data(), d.birim.data(),
             d.pres.data(), d.dzq.data(), d.npccn.data(), d.naai.data(), d.it, d.prt_liq.data(),
             d.prt_sol.data(), 1, d.ncol, 1, d.nlev, d.diag_ze.data(),
             d.diag_effc.data(), d.diag_effi.data(), d.diag_vmi.data(),

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -28,7 +28,7 @@ struct FortranData {
   // In
   Real dt;
   Int it;
-  Array2 qv, th, qv_old, th_old, pres, dzq, npccn, naai, qc, nc, qr, nr, ssat, qitot, nitot, qirim, birim, pdel, exner;
+  Array2 qv, th, pres, dzq, npccn, naai, qc, nc, qr, nr,  qitot, nitot, qirim, birim, pdel, exner;
   // Out
   Array1 prt_liq, prt_sol;
   Array2 diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, diag_rhoi, cmeiout, prain, nevapr, prer_evap, rflx, sflx, rcldm, lcldm, icldm;

--- a/components/scream/src/physics/p3/p3_ic_cases.cpp
+++ b/components/scream/src/physics/p3/p3_ic_cases.cpp
@@ -82,10 +82,6 @@ FortranData::Ptr make_mixed () {
   // deposition/condensation-freezing needs t<258.15 and >5% supersat.
   d.qv(0,33) = 1e-4;
 
-  // only now that qv is finalized can we define old values of it.
-  for (k = 0; k < nk; ++k) d.th_old(0,k) = d.th(0,k);
-  for (k = 0; k < nk; ++k) d.qv_old(0,k) = d.qv(0,k);
-
   // input variables.
   d.dt = 1800;
 

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 41);
+  REQUIRE(fdi.nfield() == 38);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);


### PR DESCRIPTION
This PR fixes bugs that entered master with PR #112. The bugs occurred because calls to p3_main in the C++ stand alone app were not updated to reflect changes in the arguments to the p3_main subroutine. The bug fixes do not touch p3_main and are limited to the standalone app, and are thus B4B. 