### PR TITLE
Remove error capturing from core ctest script

### DIFF
--- a/components/scream/cmake/ctest_script.cmake
+++ b/components/scream/cmake/ctest_script.cmake
@@ -18,22 +18,13 @@ set(CTEST_CONFIGURE_COMMAND "${CMAKE_COMMAND} ${CTEST_SOURCE_DIRECTORY}")
 
 ctest_start(${dashboard_model} TRACK ${dashboard_track})
 
-ctest_configure(CAPTURE_CMAKE_ERROR configure_ctest_error RETURN_VALUE configure_error)
-message("configure error       = ${configure_error}")
-message("configure ctest error = ${configure_ctest_error}")
-
-ctest_build(CAPTURE_CMAKE_ERROR build_ctest_error RETURN_VALUE build_error FLAGS "-j8")
-message("build error           = ${build_error}")
-message("build ctest error     = ${build_ctest_error}")
+ctest_configure()
+ctest_build(FLAGS "-j8")
 
 if (NOT BUILD_ONLY)
-  ctest_test(PARALLEL_LEVEL ${PARALLEL_LEVEL} CAPTURE_CMAKE_ERROR test_ctest_error RETURN_VALUE test_error)
-  message("test error            = ${test_error}")
-  message("test ctest error      = ${test_ctest_error}")
+  ctest_test(PARALLEL_LEVEL ${PARALLEL_LEVEL})
 endif()
 
 if (NOT NO_SUBMIT)
-  ctest_submit(RETRY_COUNT 10 RETRY_DELAY 60 CAPTURE_CMAKE_ERROR submit_ctest_error RETURN_VALUE submit_error)
-  message("submit error            = ${submit_error}")
-  message("submit ctest error      = ${submit_ctest_error}")
+  ctest_submit(RETRY_COUNT 10 RETRY_DELAY 60)
 endif()

--- a/components/scream/cmake/ctest_script.cmake
+++ b/components/scream/cmake/ctest_script.cmake
@@ -22,9 +22,16 @@ ctest_configure()
 ctest_build(FLAGS "-j8")
 
 if (NOT BUILD_ONLY)
-  ctest_test(PARALLEL_LEVEL ${PARALLEL_LEVEL})
+  ctest_test(RETURN_VALUE TEST_RESULTS PARALLEL_LEVEL ${PARALLEL_LEVEL})
+  if (NOT TEST_RESULTS EQUAL 0)
+    set(TEST_FAILS True)
+  endif()
 endif()
 
 if (NOT NO_SUBMIT)
   ctest_submit(RETRY_COUNT 10 RETRY_DELAY 60)
+endif()
+
+if (TEST_FAILS)
+  message(FATAL_ERROR "Test had fails")
 endif()


### PR DESCRIPTION
It was preventing a non-zero return code when things failed.