### PR TITLE
Add openmp header information to workspace_tests to fix intel compile.

### DIFF
--- a/components/scream/src/share/tests/workspace_tests.cpp
+++ b/components/scream/src/share/tests/workspace_tests.cpp
@@ -1,3 +1,7 @@
+#ifdef _OPENMP
+# include <omp.h>
+#endif
+
 #include <catch2/catch.hpp>
 
 #include "share/scream_workspace.hpp"


### PR DESCRIPTION
This PR fixes an issue when compiling C++ SCREAM where the command `omp_get_max_threads` couldn't be found in workspace_tests.cpp.