### PR TITLE
Refactor handling of constant lookup_table_1a_dum1_c

### DIFF
--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -48,7 +48,7 @@ module micro_p3_utils
     real(rtype),dimension(16), public :: dnu
 
     real(rtype), public, parameter :: mu_r_constant = 1.0_rtype
-    real(rtype), public, parameter :: lookup_table_1a_dum1_c = 1.0_rtype/(0.1_rtype*log10(261.7_rtype))
+    real(rtype), public, parameter :: lookup_table_1a_dum1_c =  4.135985029041767e+00 ! 1.0/(0.1*log10(261.7))
 
     real(rtype),public :: zerodegc  ! Temperature at zero degree celcius ~K
     real(rtype),public :: rainfrze  ! Contact and immersion freexing temp, -4C  ~K

--- a/components/scream/scripts/const-maker
+++ b/components/scream/scripts/const-maker
@@ -1,0 +1,55 @@
+#! /usr/bin/env python
+
+"""
+Take a math expression not handled well by C++11 constexpr and produce a
+raw floating point value with provenance via code that can be pasted into
+fortran and C++.
+"""
+
+import argparse, sys, os
+from math import *
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n{0} <varname> '<expression>'
+OR
+{0} --help
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Get code for log10(3.)*2.0 \033[0m
+    > {0} myconst 'log10(3.)*2.0'
+""".format(os.path.basename(args[0])),
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("varname", help="The name of the variable")
+
+    parser.add_argument("expr", help="The expression to evaluate")
+
+    args = parser.parse_args(args[1:])
+
+    return args
+
+###############################################################################
+def const_maker(varname, expr):
+###############################################################################
+    val = eval(expr)
+    print("Fortran:")
+    print("real(rtype), public, parameter :: {} = {:22.15e} ! {}".format(varname, val, expr))
+    print("C++:")
+    print("static constexpr Scalar {} = {:22.15e}; // {}".format(varname, val, expr))
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    success = const_maker(**vars(parse_command_line(sys.argv, description)))
+
+    sys.exit(0 if success else 1)
+
+###############################################################################
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/components/scream/scripts/const-maker
+++ b/components/scream/scripts/const-maker
@@ -42,6 +42,8 @@ def const_maker(varname, expr):
     print("C++:")
     print("static constexpr Scalar {} = {:22.15e}; // {}".format(varname, val, expr))
 
+    return True
+
 ###############################################################################
 def _main_func(description):
 ###############################################################################

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -34,6 +34,7 @@ struct Functions
       coltabsize  = 2,  // number of ice-rain collection  quantities used from lookup table
     };
 
+    static constexpr ScalarT lookup_table_1a_dum1_c =  4.135985029041767e+00; // 1.0/(0.1*log10(261.7))
     static constexpr const char* p3_lookup_base = "p3_lookup_table_1.dat-v";
     static constexpr const char* p3_version = "2.8.2";
   };

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -240,6 +240,9 @@ struct Functions
 
 };
 
+template <typename ScalarT, typename DeviceT>
+constexpr ScalarT Functions<ScalarT, DeviceT>::P3C::lookup_table_1a_dum1_c;
+
 } // namespace p3
 } // namespace scream
 

--- a/components/scream/src/physics/p3/p3_functions_table_ice_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_table_ice_impl.hpp
@@ -93,7 +93,7 @@ void Functions<S,D>
 
   if (!qiti_gt_small.any()) return;
 
-  t.dum1 = (pack::log10(qitot/nitot)+18) * (sp(1.0)/(sp(0.1)*log10(sp(261.7)))) - 10; // For computational efficiency
+  t.dum1 = (pack::log10(qitot/nitot)+18) * P3C::lookup_table_1a_dum1_c - 10;
   t.dumi = IntSmallPack(t.dum1);
 
   // set limits (to make sure the calculated index doesn't exceed range of lookup table)

--- a/components/scream/src/physics/p3/p3_functions_table_ice_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_table_ice_impl.hpp
@@ -93,7 +93,8 @@ void Functions<S,D>
 
   if (!qiti_gt_small.any()) return;
 
-  t.dum1 = (pack::log10(qitot/nitot)+18) * P3C::lookup_table_1a_dum1_c - 10;
+  const auto lookup_table_1a_dum1_c = P3C::lookup_table_1a_dum1_c;
+  t.dum1 = (pack::log10(qitot/nitot)+18) * lookup_table_1a_dum1_c - 10;
   t.dumi = IntSmallPack(t.dum1);
 
   // set limits (to make sure the calculated index doesn't exceed range of lookup table)


### PR DESCRIPTION
Inconsistent support of constexpr across cxx compilers can make
it difficult to support constants that use std math functions
in their definitions. We introduce a new tool, const-maker, to
take these definitions and produce code for a raw value constant
in both fortran and C++.