### PR TITLE
For fortran consts, we always want double precision in the const

### DIFF
--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -48,7 +48,7 @@ module micro_p3_utils
     real(rtype),dimension(16), public :: dnu
 
     real(rtype), public, parameter :: mu_r_constant = 1.0_rtype
-    real(rtype), public, parameter :: lookup_table_1a_dum1_c =  4.135985029041767e+00 ! 1.0/(0.1*log10(261.7))
+    real(rtype), public, parameter :: lookup_table_1a_dum1_c =  4.135985029041767d+00 ! 1.0/(0.1*log10(261.7))
 
     real(rtype),public :: zerodegc  ! Temperature at zero degree celcius ~K
     real(rtype),public :: rainfrze  ! Contact and immersion freexing temp, -4C  ~K

--- a/components/scream/scripts/const-maker
+++ b/components/scream/scripts/const-maker
@@ -37,8 +37,13 @@ OR
 def const_maker(varname, expr):
 ###############################################################################
     val = eval(expr)
+
+    # Note: fortran sci-notation literals need a 'd' instead of 'e' to make
+    # them double-precision. The assignment to real(rtype) will truncate if
+    # necessary.
     print("Fortran:")
     print("real(rtype), public, parameter :: {} = {:22.15d} ! {}".format(varname, val, expr))
+
     print("C++:")
     print("static constexpr Scalar {} = {:22.15e}; // {}".format(varname, val, expr))
 

--- a/components/scream/scripts/const-maker
+++ b/components/scream/scripts/const-maker
@@ -38,7 +38,7 @@ def const_maker(varname, expr):
 ###############################################################################
     val = eval(expr)
     print("Fortran:")
-    print("real(rtype), public, parameter :: {} = {:22.15e} ! {}".format(varname, val, expr))
+    print("real(rtype), public, parameter :: {} = {:22.15d} ! {}".format(varname, val, expr))
     print("C++:")
     print("static constexpr Scalar {} = {:22.15e}; // {}".format(varname, val, expr))
 


### PR DESCRIPTION
The assignment will truncate it if needed.