### PR TITLE
A small upgrade to the catch-based testing system

### DIFF
--- a/components/scream/src/share/util/scream_catch_main.cpp
+++ b/components/scream/src/share/util/scream_catch_main.cpp
@@ -3,6 +3,8 @@
 #include "catch2/catch.hpp"
 
 #include "share/scream_session.hpp"
+#include "share/scream_assert.hpp"
+#include "share/util/scream_test_utils.hpp"
 #include <mpi.h>
 
 int main (int argc, char **argv) {
@@ -13,8 +15,37 @@ int main (int argc, char **argv) {
   // Initialize scream;
   scream::initialize_scream_session(argc, argv);
 
+  auto const readCommaSeparaterParams = [] (const std::string& cmd_line_arg) {
+    if (cmd_line_arg=="") {
+      return;
+    }
+    auto& ts = scream::util::TestSession::get();
+
+    std::stringstream input(cmd_line_arg);
+    std::string option;
+    while (getline(input,option,',')) {
+      // Split option according to key=val
+      auto pos = option.find('=');
+      scream_require_msg(pos!=std::string::npos, "Error! Badly formatted command line options.\n");
+      std::string key = option.substr(0,pos);
+      std::string val = option.substr(pos+1);
+      scream_require_msg(key!="", "Error! Empty key found in the list of command line options.\n");
+      scream_require_msg(val!="", "Error! Empty value for key '" + key + "'.\n");
+      ts.params[key] = val;
+    }
+  };
+  Catch::Session catch_session;
+  auto cli = catch_session.cli();
+  cli |= Catch::clara::Opt(readCommaSeparaterParams, "key1=val1[,key2=val2[,...]]")
+             ["--scream-test-params"]
+             ("list of parameters to forward to the test");
+  catch_session.cli(cli);
+
+  scream_require_msg(catch_session.applyCommandLine(argc,argv)==0,
+                     "Error! Something went wrong while parsing command line.\n");
+
   // Run tests
-  int num_failed = Catch::Session().run(argc, argv);
+  int num_failed = catch_session.run(argc, argv);
 
   // Finalize scream
   scream::finalize_scream_session();

--- a/components/scream/src/share/util/scream_test_utils.hpp
+++ b/components/scream/src/share/util/scream_test_utils.hpp
@@ -10,6 +10,17 @@
 namespace scream {
 namespace util {
 
+struct TestSession {
+  static TestSession& get () {
+    static TestSession s;
+    return s;
+  }
+
+  std::map<std::string,std::string> params;
+private:
+  TestSession() = default;
+};
+
 template <typename rngAlg, typename PDF>
 void genRandArray(int *const x, int length, rngAlg &engine, PDF &&pdf) {
   for (int i = 0; i < length; ++i) {


### PR DESCRIPTION
It is now possible to use the `--scream-test-params <key=var,...>`
syntax to pass one or more options to the particular test. It is up to
the individual test whether that option is valid and/or used. A test
is free to ignore the options altogether. All the pairs key-value are
stored as string, so if the test needs, say, an int, it must convert
the string to an int.

Example usage: my_test --scream-test-params ne=2,qsize=4,moist=false
