### PR TITLE
Bugfix for hard-coded p3 table lookup version.

### DIFF
--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -23,6 +23,7 @@ module micro_p3_utils
   integer,parameter :: itype = selected_int_kind (13) ! 8 byte integer
 #else
     public :: rtype
+    integer,parameter,public :: rtype8 = selected_real_kind(15, 307) ! 8 byte real, compatible with c type double
 #endif
 
     public :: get_latent_heat, micro_p3_utils_init, &

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -38,7 +38,7 @@ contains
     character(kind=c_char, len=128) :: mu_r_filename, revap_filename, vn_filename, vm_filename
     integer :: len
     logical :: ok
-    character(len=16) :: p3_version="2.8.2"
+    character(len=16) :: p3_version="4"  ! TODO: Change to be dependent on table version and path specified in p3_functions.hpp
 
     call c_f_pointer(lookup_file_dir_c, lookup_file_dir)
     len = index(lookup_file_dir, C_NULL_CHAR) - 1

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -36,7 +36,7 @@ struct Functions
 
     static constexpr ScalarT lookup_table_1a_dum1_c =  4.135985029041767e+00; // 1.0/(0.1*log10(261.7))
     static constexpr const char* p3_lookup_base = "p3_lookup_table_1.dat-v";
-    static constexpr const char* p3_version = "2.8.2";
+    static constexpr const char* p3_version = "4"; // TODO: Change this so that the table version and table path is a runtime option.
   };
 
   //

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -19,6 +19,6 @@ add_custom_target(p3_baseline
 
 add_dependencies(baseline p3_baseline)
 
-configure_file(${SCREAM_DATA_DIR}/p3_lookup_table_1.dat-v2.8.2 p3_lookup_table_1.dat-v2.8.2 COPYONLY)
+configure_file(${SCREAM_DATA_DIR}/p3_lookup_table_1.dat-v4 p3_lookup_table_1.dat-v4 COPYONLY)
 
 


### PR DESCRIPTION
This PR fixes an issue where the hard-coded p3 table version was set to version 2.8.2, which doesn't reflect the recent change to v4 of the table.

Additionally there was a bug associated with the new rtype8 variable from p3_utils that wasn't defined if the build type was not SCREAM.  This broke the standard E3SM build.

TODO comments have been added addressing the desire to eventually make the lookup table a runtime option instead of hard-coded.