### PR TITLE
[WIP] Creates a simple IO interface for reading/writing netCDF files. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
     - libopenmpi-dev
     - openmpi-bin
     - python3
-    - netcdf
+    - libnetcdf-dev
 
 git:
   submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
     - libopenmpi-dev
     - openmpi-bin
     - python3
+    - netcdf
 
 git:
   submodules: false

--- a/components/homme/CMakeLists.txt
+++ b/components/homme/CMakeLists.txt
@@ -292,8 +292,8 @@ SET (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/utils/cime/src/externals/pio
 #
 #set search paths for PIO's findNetCDF
 # HOMME machine files set NETCDF_DIR, PNETCDF_DIR which we copy
-# to variables used by PIO.  Newer machine files sould direclty set
-# necessyar PIO variables:
+# to variables used by PIO.  Newer machine files sould directly set
+# neccessary PIO variables:
 #
 ADD_DEFINITIONS(-D_NO_MPI_RSEND)
 

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.3)
 cmake_policy(SET CMP0057 NEW)
 
 project(SCREAM CXX Fortran)
+enable_language(C)
 set (CMAKE_CXX_STANDARD 11)
 
 # Print the sha of the last commit (useful to double check which version was tested on CDash)
@@ -19,6 +20,9 @@ SET (SCREAM_DATA_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/data)
 
 # Add the ./cmake folder to cmake path
 SET (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+# NetCDF
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cime//src/externals/pio2/cmake")
+FIND_PACKAGE(NetCDF COMPONENTS C)
 
 # Shortcut function, to print a variable
 function (print_var var)

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -22,7 +22,6 @@ SET (SCREAM_DATA_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/data)
 SET (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # NetCDF
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cime//src/externals/pio2/cmake")
-FIND_PACKAGE(NetCDF COMPONENTS C)
 
 # Shortcut function, to print a variable
 function (print_var var)

--- a/components/scream/cmake/SetCompilerFlags.cmake
+++ b/components/scream/cmake/SetCompilerFlags.cmake
@@ -231,7 +231,9 @@ endif()
 ##############################################################################
 # NetCDF
 ##############################################################################
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${NetCDF_C_INCLUDE_DIRS} -L${NetCDF_C_LIBRARIES} -lnetcdf")
+FIND_PACKAGE(NetCDF COMPONENTS C)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${NetCDF_C_INCLUDE_DIRS} -lnetcdf")
+set(CMAKE_CXX_LINKER_FLAGS "${CMAKE_CXX_LINKER_FLAGS} -L${NetCDF_C_LIBRARIES}")
 
 
 ##############################################################################

--- a/components/scream/cmake/SetCompilerFlags.cmake
+++ b/components/scream/cmake/SetCompilerFlags.cmake
@@ -228,6 +228,11 @@ if (${openmp_str_pos} GREATER -1)
     message(FATAL_ERROR "Unable to find OpenMP")
   endif()
 endif()
+##############################################################################
+# NetCDF
+##############################################################################
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${NetCDF_C_INCLUDE_DIRS} -L${NetCDF_C_LIBRARIES} -lnetcdf")
+
 
 ##############################################################################
 # Intel Phi (MIC) specific flags - only supporting the Intel compiler

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -140,8 +140,9 @@ private:
   /*----------------------------------------------------------------------*/
   // Simple io routines:
   int  open_nc_file(const std::string filename, const std::string runtype, const std::string mode) {
-      const int ndims = 4;
-      std::string dimnames[] = {"column","level","ilevel","fields"};
+      std::string dimnames_list[] = {"column","level","ilevel","fields"};
+      const int ndims = sizeof(dimnames_list)/sizeof(dimnames_list[0]);
+      std::vector<std::string> dimnames;
       std::string nc_filename = "";
       nc_filename.append(filename.c_str());
       nc_filename.append("_");
@@ -149,6 +150,7 @@ private:
       nc_filename.append(".nc");
       int dimrng[] = {ic_ncol,72,73,49};
       int ncid = -999;
+      for (int i=0;i<ndims;i++) {dimnames.push_back(dimnames_list[i]);}
       if (mode == "write") {
         ncid = init_output1(nc_filename, ndims, dimnames, dimrng);
       } else if (mode == "read") {
@@ -159,19 +161,22 @@ private:
   }
   static void reg_fields_nc (const Int ncid, const FortranData::Ptr& d) {
     FortranDataIterator fdi(d);
-    std::string dimnames[] = {"column","level","ilevel","fields"};
+    std::string dimnames_list[] = {"column","level","ilevel","fields"};
+    const int ndims = sizeof(dimnames_list)/sizeof(dimnames_list[0]);
+    std::vector<std::string> dimnames;
     std::string units="unitless";
+    for (int i=0;i<ndims;i++) {dimnames.push_back(dimnames_list[i]);}
     for (Int i = 0, n = fdi.nfield(); i < n; ++i) {
       const auto& f = fdi.getfield(i);
       if ( (f.extent[1]==72) && (f.extent[2]>1) ) {
-        dimnames[1] = "level";
-        dimnames[2] = "fields";
+        dimnames.at(1) = "level";
+        dimnames.at(2) = "fields";
         regfield(ncid,f.name,NC_REAL,3,dimnames,units);
       } else if (f.extent[1]==72) {
-        dimnames[1] = "level";
+        dimnames.at(1) = "level";
         regfield(ncid,f.name,NC_REAL,2,dimnames,units);
       } else if (f.extent[1]==73) {
-        dimnames[1] = "ilevel";
+        dimnames.at(1) = "ilevel";
         regfield(ncid,f.name,NC_REAL,2,dimnames,units);
       } else {
         regfield(ncid,f.name,NC_REAL,1,dimnames,units);

--- a/components/scream/src/share/CMakeLists.txt
+++ b/components/scream/src/share/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SHARE_SRC
   util/time_stamp.cpp
   util/scream_tridiag_bfb.cpp
   util/scream_tridiag_bfb_mod.F90
+  simpleio/simple_io_mod.cpp
 )
 
 # So far this is pointless, since we are not installing the library
@@ -51,6 +52,7 @@ set(SHARE_HEADERS
   util/scream_lin_interp.hpp
   util/time_stamp.hpp
   scream_workspace.hpp
+  simpleio/simple_io_mod.hpp
 )
 
 add_library(scream_share ${SHARE_SRC})

--- a/components/scream/src/share/simpleio/simple_io_mod.cpp
+++ b/components/scream/src/share/simpleio/simple_io_mod.cpp
@@ -1,0 +1,150 @@
+#include "simple_io_mod.hpp"
+
+#include "share/scream_assert.hpp"
+#include "share/util/scream_utils.hpp"
+#include <netcdf.h>
+
+using scream::Real;
+using scream::Int;
+
+namespace scream {
+namespace simpleio {
+
+/* ----------------------------------------------------------------- */
+void convert_string_to_char(std::string str_in,char str_out[str_in.size()+1]) {
+
+  str_in.copy(str_out,str_in.size()+1);
+  str_out[str_in.size()] = '\0';
+
+}
+/* ----------------------------------------------------------------- */
+int init_input(std::string filename) {
+
+
+  int nc_err, ncid;
+  char filename_in[filename.size()+1];
+
+  convert_string_to_char(filename,filename_in);
+  nc_err = nc_open(filename_in, NC_NOWRITE, &ncid);
+  scream_require_msg(nc_err==0,"NC Create Error! \n");
+
+  return ncid;
+}
+/* ----------------------------------------------------------------- */
+int init_output1(std::string filename, int ndims, std::string (&dimnames)[ndims],
+    int* dimrng)
+{
+
+  int nc_err, ncid;
+  int dimids[ndims];
+
+  char filename_in[filename.size()+1];
+  convert_string_to_char(filename,filename_in);
+  nc_err = nc_create(filename_in, NC_CLOBBER, &ncid);
+  scream_require_msg(nc_err==0,"NC Create Error! \n");
+
+  char dimname_in[256];
+  for (int i=0;i<ndims;i++) {
+    convert_string_to_char(dimnames[i],dimname_in);
+    nc_err = nc_def_dim(ncid,dimname_in, dimrng[i], &dimids[i]);
+    scream_require_msg(nc_err==0,"NC Define Dim Error! \n");
+  }
+
+  return ncid;
+
+}
+/* ----------------------------------------------------------------- */
+void init_output2(int ncid)
+{
+
+  int nc_err = nc_enddef(ncid);
+  scream_require_msg(nc_err==0,"NC Error! Finish NC metadata \n");
+
+}
+/* ----------------------------------------------------------------- */
+void regfield(int ncid,std::string field_name,int field_type,int ndim,std::string (&field_dim)[ndim],std::string units)
+{
+
+  char field_in[field_name.size()+1];
+  char dimname[256];
+  char units_in[256];
+  int dimids[ndim];
+  int varid;
+  int nc_err;
+
+  // Extract dimension id dependent on the dimension names
+  for (int ii=0;ii<ndim;ii++) {
+    convert_string_to_char(field_dim[ii],dimname);
+    nc_err = nc_inq_dimid(ncid,dimname,&dimids[ii]);
+    scream_require_msg(nc_err==0,"NC Get dimid Error! \n");
+  }
+ 
+  // Register the field 
+  convert_string_to_char(field_name,field_in);
+  nc_err = nc_def_var(ncid,field_in,field_type,ndim,dimids,&varid);
+  scream_require_msg(nc_err==0,"NC Var Create Error! \n");
+
+  // Add the units attribute
+  convert_string_to_char(units,units_in);
+  nc_err = nc_put_att(ncid,varid,"units",NC_CHAR,units.size()+1,units_in);
+  scream_require_msg(nc_err==0,"NC Var Units Error! \n");
+}
+/* ----------------------------------------------------------------- */
+void field_io(int ncid,std::string field_name, double &data, int time_dim, const std::string flag)
+{
+  char fieldname[256];
+  int varid;
+  int nc_err;
+  int ndims;
+
+  convert_string_to_char(field_name,fieldname);
+
+  nc_err = nc_inq_varid(ncid,fieldname,&varid);
+  scream_require_msg(nc_err==0,"NC Var Inq ID Error! \n");
+  nc_err = nc_inq_varndims(ncid,varid,&ndims);
+  size_t start[ndims];
+  size_t count[ndims];
+  int dimids[ndims];
+  nc_err = nc_inq_vardimid(ncid,varid,dimids);
+  for (int ii=0;ii<ndims;ii++) {
+    nc_err = nc_inq_dimlen(ncid,dimids[ii],&count[ii]);
+    start[ii] = 0;
+  }
+  if (time_dim >= 0) {
+    count[0] = 1;
+    start[0] = time_dim;
+  }
+
+  if (flag=="read") {
+    nc_err = nc_get_vara(ncid,varid, start, count, &data);
+    scream_require_msg(nc_err==0,"NC Write Data Error! \n");
+  } else if (flag=="write") {  
+    nc_err = nc_put_vara(ncid,varid, start, count, &data);
+    scream_require_msg(nc_err==0,"NC Write Data Error! \n");
+  } else {
+    scream_require_msg(0==1,"Error in IO, incorrect flag: " << flag);
+  }
+
+}
+/* ----------------------------------------------------------------- */
+void writefield(int ncid,std::string field_name, double &data, int time_dim)
+{
+  field_io(ncid, field_name, data, time_dim, "write");
+}
+/* ----------------------------------------------------------------- */
+void readfield(int ncid,std::string field_name, double &data, int time_dim)
+{
+  field_io(ncid, field_name, data, time_dim, "read");
+}
+/* ----------------------------------------------------------------- */
+void finalize_io(int ncid)
+{
+
+  int nc_err = nc_close(ncid);
+  scream_require_msg(nc_err==0,"NC Error! Close NC file \n");
+
+}
+
+
+} // namespace simpleio
+} // namespace scream

--- a/components/scream/src/share/simpleio/simple_io_mod.cpp
+++ b/components/scream/src/share/simpleio/simple_io_mod.cpp
@@ -11,7 +11,7 @@ namespace scream {
 namespace simpleio {
 
 /* ----------------------------------------------------------------- */
-void convert_string_to_char(std::string str_in,char str_out[str_in.size()+1]) {
+void convert_string_to_char(std::string str_in,char* str_out) {
 
   str_in.copy(str_out,str_in.size()+1);
   str_out[str_in.size()] = '\0';
@@ -31,7 +31,7 @@ int init_input(std::string filename) {
   return ncid;
 }
 /* ----------------------------------------------------------------- */
-int init_output1(std::string filename, int ndims, std::string (&dimnames)[ndims],
+int init_output1(std::string filename, int ndims, std::vector<std::string> &dimnames,
     int* dimrng)
 {
 
@@ -45,7 +45,7 @@ int init_output1(std::string filename, int ndims, std::string (&dimnames)[ndims]
 
   char dimname_in[256];
   for (int i=0;i<ndims;i++) {
-    convert_string_to_char(dimnames[i],dimname_in);
+    convert_string_to_char(dimnames.at(i),dimname_in);
     nc_err = nc_def_dim(ncid,dimname_in, dimrng[i], &dimids[i]);
     scream_require_msg(nc_err==0,"NC Define Dim Error! \n");
   }
@@ -62,7 +62,7 @@ void init_output2(int ncid)
 
 }
 /* ----------------------------------------------------------------- */
-void regfield(int ncid,std::string field_name,int field_type,int ndim,std::string (&field_dim)[ndim],std::string units)
+void regfield(int ncid,std::string field_name,int field_type,int ndim,std::vector<std::string> &field_dim,std::string units)
 {
 
   char field_in[field_name.size()+1];
@@ -74,7 +74,7 @@ void regfield(int ncid,std::string field_name,int field_type,int ndim,std::strin
 
   // Extract dimension id dependent on the dimension names
   for (int ii=0;ii<ndim;ii++) {
-    convert_string_to_char(field_dim[ii],dimname);
+    convert_string_to_char(field_dim.at(ii),dimname);
     nc_err = nc_inq_dimid(ncid,dimname,&dimids[ii]);
     scream_require_msg(nc_err==0,"NC Get dimid Error! \n");
   }
@@ -90,7 +90,7 @@ void regfield(int ncid,std::string field_name,int field_type,int ndim,std::strin
   scream_require_msg(nc_err==0,"NC Var Units Error! \n");
 }
 /* ----------------------------------------------------------------- */
-void field_io(int ncid,std::string field_name, double &data, int time_dim, const std::string flag)
+void field_io(int ncid,std::string field_name, scream::Real &data, int time_dim, const std::string flag)
 {
   char fieldname[256];
   int varid;
@@ -127,12 +127,12 @@ void field_io(int ncid,std::string field_name, double &data, int time_dim, const
 
 }
 /* ----------------------------------------------------------------- */
-void writefield(int ncid,std::string field_name, double &data, int time_dim)
+void writefield(int ncid,std::string field_name, scream::Real &data, int time_dim)
 {
   field_io(ncid, field_name, data, time_dim, "write");
 }
 /* ----------------------------------------------------------------- */
-void readfield(int ncid,std::string field_name, double &data, int time_dim)
+void readfield(int ncid,std::string field_name, scream::Real &data, int time_dim)
 {
   field_io(ncid, field_name, data, time_dim, "read");
 }

--- a/components/scream/src/share/simpleio/simple_io_mod.hpp
+++ b/components/scream/src/share/simpleio/simple_io_mod.hpp
@@ -1,0 +1,39 @@
+#ifndef SIMPLE_IO_MOD_HPP
+#define SIMPLE_IO_MOD_HPP
+
+#include "share/util/scream_utils.hpp"
+#include "share/scream_types.hpp"
+#include <netcdf.h>
+
+namespace scream {
+namespace simpleio {
+
+#ifdef SCREAM_DOUBLE_PRECISION
+const int NC_REAL = NC_DOUBLE;
+#else
+  int NC_REAL = NC_FLOAT;
+#endif
+
+// TODO overload functions so that nc_field is one of the only inputs needed.
+struct nc_field {
+  std::string fieldname;  // Field Name
+  int ftype;              // Data type for field
+  std::string units;      // Field Units
+  int ndims;              // Dimensionality of field
+  std::string dimensions[10]; // List of dimension names  //TODO: find a better way to do this.  Currently we assume that no field will have more than 10 dimensions.
+};
+
+// Set of netcdf wrappers
+int init_output1(std::string filename, int ndims, std::string (&dimnames)[ndims], int* dimrng);
+void init_output2(int ncid);
+void regfield(int ncid,std::string field_name,int field_type,int ndim,std::string (&field_dim)[ndim],std::string units);
+void writefield(int ncid,std::string field_name, double &data, int time_dim);
+void readfield(int ncid,std::string field_name, double &data, int time_dim);
+int init_input(std::string filename);
+
+void finalize_io(int ncid);
+
+} // namespace simpleio
+} // namespace scream
+
+#endif

--- a/components/scream/src/share/simpleio/simple_io_mod.hpp
+++ b/components/scream/src/share/simpleio/simple_io_mod.hpp
@@ -11,7 +11,7 @@ namespace simpleio {
 #ifdef SCREAM_DOUBLE_PRECISION
 const int NC_REAL = NC_DOUBLE;
 #else
-  int NC_REAL = NC_FLOAT;
+const int NC_REAL = NC_FLOAT;
 #endif
 
 // TODO overload functions so that nc_field is one of the only inputs needed.
@@ -20,15 +20,17 @@ struct nc_field {
   int ftype;              // Data type for field
   std::string units;      // Field Units
   int ndims;              // Dimensionality of field
-  std::string dimensions[10]; // List of dimension names  //TODO: find a better way to do this.  Currently we assume that no field will have more than 10 dimensions.
+  std::vector<std::string> dimensions; // List of dimension names  
 };
 
 // Set of netcdf wrappers
-int init_output1(std::string filename, int ndims, std::string (&dimnames)[ndims], int* dimrng);
+using scream::Real;
+using scream::Int;
+int init_output1(std::string filename, int ndims, std::vector<std::string> &dimnames, int* dimrng);
 void init_output2(int ncid);
-void regfield(int ncid,std::string field_name,int field_type,int ndim,std::string (&field_dim)[ndim],std::string units);
-void writefield(int ncid,std::string field_name, double &data, int time_dim);
-void readfield(int ncid,std::string field_name, double &data, int time_dim);
+void regfield(int ncid,std::string field_name,int field_type,int ndim,std::vector<std::string> &field_dim,std::string units);
+void writefield(int ncid,std::string field_name, Real &data, int time_dim);
+void readfield(int ncid,std::string field_name, Real &data, int time_dim);
 int init_input(std::string filename);
 
 void finalize_io(int ncid);

--- a/components/scream/src/share/tests/CMakeLists.txt
+++ b/components/scream/src/share/tests/CMakeLists.txt
@@ -32,3 +32,6 @@ CreateUnitTest(tridiag "tridiag_tests.cpp;tridiag_tests_correctness.cpp;tridiag_
 
 # Test units framework
 CreateUnitTest(units "units.cpp" scream_share)
+
+# Test utilities (simple_io)
+CreateUnitTest(simple_io "simple_io_tests.cpp" scream_share)

--- a/components/scream/src/share/tests/simple_io_tests.cpp
+++ b/components/scream/src/share/tests/simple_io_tests.cpp
@@ -1,0 +1,137 @@
+#include <catch2/catch.hpp>
+
+#include "share/scream_config.hpp"
+#include "share/scream_pack.hpp"
+#include "share/util/scream_utils.hpp"
+#include "share/simpleio/simple_io_mod.hpp"
+
+
+namespace {
+
+TEST_CASE("simple_io_mod", "test_simple_io") {
+
+  SECTION("Test Output") {
+/* ====================================================================
+ * Create sample output for simple_io test 
+ *
+ * Open netCDF output file and add all meta-data, including
+ * All dimensions for any output field
+ * Register all output fields
+ * ==================================================================== */
+  std::string filename = "pres_temp_4D.nc";
+  std::string dimnames[] = {"time","longitude","latitude","level"};
+  const int ndims = sizeof(dimnames)/sizeof(dimnames[0]);
+  int dimrng[] = {0,12,6,2};
+  int ncid = scream::simpleio::init_output1(filename, ndims, dimnames, dimrng);
+
+  // Construct an array of fields
+  scream::simpleio::nc_field *myfields = new scream::simpleio::nc_field[4];
+  /* Latitude */
+  myfields[0].fieldname = "latitude";
+  myfields[0].ftype = scream::simpleio::NC_REAL;
+  myfields[0].units = std::string("Degrees North");
+  myfields[0].ndims = 1;
+  myfields[0].dimensions[0] = {dimnames[2]}; 
+  /* Longitude */
+  myfields[1].fieldname = "longitude";
+  myfields[1].ftype = scream::simpleio::NC_REAL;
+  myfields[1].units = "Degrees East";
+  myfields[1].ndims = 1;
+  myfields[1].dimensions[0] = {dimnames[1]}; 
+  /* Pressure */
+  myfields[2].fieldname = "pressure";
+  myfields[2].ftype = scream::simpleio::NC_REAL;
+  myfields[2].units = "hPa";
+  myfields[2].ndims = 4;
+  for (int ii=0;ii<4;ii++) {myfields[2].dimensions[ii] = dimnames[ii];} 
+  /* Temperature */
+  myfields[3].fieldname = "temperature";
+  myfields[3].ftype = scream::simpleio::NC_REAL;
+  myfields[3].units = "K";
+  myfields[3].ndims = 4;
+  for (int ii=0;ii<4;ii++) {myfields[3].dimensions[ii] = dimnames[ii];} 
+  /* Register Fields */
+  for ( int ii=0;ii<4;ii++ ) {
+    scream::simpleio::regfield(ncid,myfields[ii].fieldname,myfields[ii].ftype,myfields[ii].ndims,myfields[ii].dimensions,myfields[ii].units);
+  }
+  scream::simpleio::init_output2(ncid);
+
+  // Now write some data
+/* ====================================================================
+ * Create sample output for simple_io test 
+ * ==================================================================== */
+  // Create sample output:
+  double lats[6]={0,0,0,0,0,0};
+  double lons[12];
+  double pres[12][6][2], temp[12][6][2];
+  for (int n=0; n<6; n++) {
+    lats[n] = 25.0 + (n) * 5.0;
+  }
+  for (int n=0; n<12; n++) {
+    lons[n] = -125.0 + (n) * 5.0;
+  }
+  for (int k=0; k<2;k++) {
+    for (int i=0; i<6; i++) {
+      for (int j=0; j<12; j++) {
+        pres[j][i][k] = j*100.+i*10.+k;
+        temp[j][i][k] = j+i+k;
+      }
+    }
+  }
+
+/* ====================================================================
+ * Write sample output to netCDF output file.
+ * ==================================================================== */
+  scream::simpleio::writefield(ncid,myfields[0].fieldname,lats[0],-1);
+  scream::simpleio::writefield(ncid,myfields[1].fieldname,lons[0],-1);
+  scream::simpleio::writefield(ncid,myfields[2].fieldname,pres[0][0][0],0);
+  scream::simpleio::writefield(ncid,myfields[3].fieldname,temp[0][0][0],0);
+  scream::simpleio::writefield(ncid,myfields[2].fieldname,pres[0][0][0],1);
+  scream::simpleio::writefield(ncid,myfields[3].fieldname,temp[0][0][0],1);
+
+
+/* ====================================================================
+ * Finished with test, close netCDF file
+ * ==================================================================== */
+  scream::simpleio::finalize_io(ncid);
+  delete [] myfields;
+  }
+
+ /* ==================================================================== */
+  SECTION("Test Input") {
+
+  // Open the test file
+  std::string filename = "pres_temp_4D.nc";
+  int ncid_in;
+
+  ncid_in = scream::simpleio::init_input(filename);
+  std::string fieldname;
+
+  fieldname  = "latitude";
+  double lat[6];
+  scream::simpleio::readfield(ncid_in,fieldname,lat[0],-1);
+  std::cout << "LAT READ\n";
+  for (double n : lat){
+    std::cout << n << "\n";
+  }
+//
+  fieldname = "pressure";
+  double pres[12][6][2];
+  scream::simpleio::readfield(ncid_in,fieldname,pres[0][0][0],0);
+  std::cout << "PRES READ\n";
+  for (int k=0;k<2;k++) {
+    for (int j=0;j<6;j++) {
+      for (int i=0;i<12;i++) {
+        std::cout << pres[i][j][k] << "\t";
+      }
+      std::cout << "\n";
+    }
+    std::cout << "\n";
+  }
+  std::cout << "\n";
+
+  scream::simpleio::finalize_io(ncid_in);
+  } // Test Input
+
+} // TEST_CASE
+} // empty namespace

--- a/components/scream/src/share/tests/simple_io_tests.cpp
+++ b/components/scream/src/share/tests/simple_io_tests.cpp
@@ -19,9 +19,13 @@ TEST_CASE("simple_io_mod", "test_simple_io") {
  * Register all output fields
  * ==================================================================== */
   std::string filename = "pres_temp_4D.nc";
-  std::string dimnames[] = {"time","longitude","latitude","level"};
-  const int ndims = sizeof(dimnames)/sizeof(dimnames[0]);
+  std::string dimnames_list[] = {"time","longitude","latitude","level"};
+  std::vector<std::string> dimnames;
+  const int ndims = sizeof(dimnames_list)/sizeof(dimnames_list[0]);
   int dimrng[] = {0,12,6,2};
+  // Build dimnames vector of strings
+  for (int i=0;i<ndims;i++) { dimnames.push_back(dimnames_list[i]); }
+
   int ncid = scream::simpleio::init_output1(filename, ndims, dimnames, dimrng);
 
   // Construct an array of fields
@@ -31,25 +35,25 @@ TEST_CASE("simple_io_mod", "test_simple_io") {
   myfields[0].ftype = scream::simpleio::NC_REAL;
   myfields[0].units = std::string("Degrees North");
   myfields[0].ndims = 1;
-  myfields[0].dimensions[0] = {dimnames[2]}; 
+  myfields[0].dimensions.push_back(dimnames.at(2)); 
   /* Longitude */
   myfields[1].fieldname = "longitude";
   myfields[1].ftype = scream::simpleio::NC_REAL;
   myfields[1].units = "Degrees East";
   myfields[1].ndims = 1;
-  myfields[1].dimensions[0] = {dimnames[1]}; 
+  myfields[1].dimensions.push_back(dimnames.at(1)); 
   /* Pressure */
   myfields[2].fieldname = "pressure";
   myfields[2].ftype = scream::simpleio::NC_REAL;
   myfields[2].units = "hPa";
   myfields[2].ndims = 4;
-  for (int ii=0;ii<4;ii++) {myfields[2].dimensions[ii] = dimnames[ii];} 
+  for (int ii=0;ii<4;ii++) {myfields[2].dimensions.push_back(dimnames.at(ii));} 
   /* Temperature */
   myfields[3].fieldname = "temperature";
   myfields[3].ftype = scream::simpleio::NC_REAL;
   myfields[3].units = "K";
   myfields[3].ndims = 4;
-  for (int ii=0;ii<4;ii++) {myfields[3].dimensions[ii] = dimnames[ii];} 
+  for (int ii=0;ii<4;ii++) {myfields[3].dimensions.push_back(dimnames.at(ii));} 
   /* Register Fields */
   for ( int ii=0;ii<4;ii++ ) {
     scream::simpleio::regfield(ncid,myfields[ii].fieldname,myfields[ii].ftype,myfields[ii].ndims,myfields[ii].dimensions,myfields[ii].units);
@@ -61,9 +65,9 @@ TEST_CASE("simple_io_mod", "test_simple_io") {
  * Create sample output for simple_io test 
  * ==================================================================== */
   // Create sample output:
-  double lats[6]={0,0,0,0,0,0};
-  double lons[12];
-  double pres[12][6][2], temp[12][6][2];
+  scream::Real lats[6]={0,0,0,0,0,0};
+  scream::Real lons[12];
+  scream::Real pres[12][6][2], temp[12][6][2];
   for (int n=0; n<6; n++) {
     lats[n] = 25.0 + (n) * 5.0;
   }
@@ -108,15 +112,15 @@ TEST_CASE("simple_io_mod", "test_simple_io") {
   std::string fieldname;
 
   fieldname  = "latitude";
-  double lat[6];
+  scream::Real lat[6];
   scream::simpleio::readfield(ncid_in,fieldname,lat[0],-1);
   std::cout << "LAT READ\n";
-  for (double n : lat){
+  for (scream::Real n : lat){
     std::cout << n << "\n";
   }
 //
   fieldname = "pressure";
-  double pres[12][6][2];
+  scream::Real pres[12][6][2];
   scream::simpleio::readfield(ncid_in,fieldname,pres[0][0][0],0);
   std::cout << "PRES READ\n";
   for (int k=0;k<2;k++) {


### PR DESCRIPTION
As a demonstration of the new interface the "p3_run_and_cmp"
test has been changed to use netCDF for writing baselines and
for later comparison against the baseline. The files produced
are also able to be compared using cprnc, however, automatic
use of cprnc has not been integrated in yet.

All new files are wrappers for the baseline netCDF-C commands to
make it easier to use and be more in line with the syntax and types
of variables we use in SCREAM.