### PR TITLE
Convert cloud sedimentation

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3341,7 +3341,7 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
    qc, nc, nc_incld,mu_c,lamc,prt_liq,qc_tend,nc_tend)
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
-    use micro_p3_iso_f, only: cloud_sedimentation_f
+    use micro_p3_iso_f, only: cloud_sedimentation_f, cxx_gamma
 #endif
 
    implicit none
@@ -3444,9 +3444,9 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
                   lamc(k),tmp1,tmp2,lcldm(k))
 
                   nc(k) = nc_incld(k)*lcldm(k)
-                  dum = 1._rtype/lamc(k)**bcn
-                  V_qc(k) = acn(k)*gamma(4._rtype+bcn+mu_c(k))*dum/(gamma(mu_c(k)+4._rtype))
-                  V_nc(k) = acn(k)*gamma(1._rtype+bcn+mu_c(k))*dum/(gamma(mu_c(k)+1._rtype))
+                  dum = 1._rtype / (lamc(k)*lamc(k))
+                  V_qc(k) = acn(k)*bfb_gamma(4._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+4._rtype))
+                  V_nc(k) = acn(k)*bfb_gamma(1._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+1._rtype))
 
                endif qc_notsmall_c2
                Co_max = max(Co_max, V_qc(k)*dt_left*inv_dzq(k))
@@ -3467,8 +3467,8 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
                   call get_cloud_dsd2(qc_incld(k),nc_incld(k),mu_c(k),rho(k),nu,dnu,   &
                   lamc(k),tmp1,tmp2,lcldm(k))
                   nc(k) = nc_incld(k)*lcldm(k)
-                  dum = 1._rtype/lamc(k)**bcn
-                  V_qc(k) = acn(k)*gamma(4._rtype+bcn+mu_c(k))*dum/(gamma(mu_c(k)+4._rtype))
+                  dum = 1._rtype / (lamc(k)*lamc(k))
+                  V_qc(k) = acn(k)*bfb_gamma(4._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+4._rtype))
                endif qc_notsmall_c1
 
                Co_max = max(Co_max, V_qc(k)*dt_left*inv_dzq(k))

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3341,7 +3341,7 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
    qc, nc, nc_incld,mu_c,lamc,prt_liq,qc_tend,nc_tend)
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
-    use micro_p3_iso_f, only: cloud_sedimentation_f, cxx_gamma
+    use micro_p3_iso_f, only: cloud_sedimentation_f, cxx_gamma, cxx_pow
 #endif
 
    implicit none
@@ -3444,7 +3444,7 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
                        lamc(k),tmp1,tmp2,lcldm(k))
 
                   nc(k) = nc_incld(k)*lcldm(k)
-                  dum = 1._rtype / (lamc(k)*lamc(k))
+                  dum = 1._rtype / bfb_pow(lamc(k), bcn)
                   V_qc(k) = acn(k)*bfb_gamma(4._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+4._rtype))
                   V_nc(k) = acn(k)*bfb_gamma(1._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+1._rtype))
 
@@ -3467,7 +3467,7 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
                   call get_cloud_dsd2(qc_incld(k),nc_incld(k),mu_c(k),rho(k),nu,dnu,   &
                        lamc(k),tmp1,tmp2,lcldm(k))
                   nc(k) = nc_incld(k)*lcldm(k)
-                  dum = 1._rtype / (lamc(k)*lamc(k))
+                  dum = 1._rtype / bfb_pow(lamc(k), bcn)
                   V_qc(k) = acn(k)*bfb_gamma(4._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+4._rtype))
                endif qc_notsmall_c1
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -54,7 +54,7 @@
 module micro_p3
 
    ! get real kind from utils
-   use micro_p3_utils, only: rtype,rtype8
+   use micro_p3_utils, only: rtype,rtype8,btype
 
    ! physical and mathematical constants
    use micro_p3_utils, only: rhosur,rhosui,ar,br,f1r,f2r,rhow,kr,kc,aimm,mi0,nccnst,  &
@@ -3340,6 +3340,10 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
    dt,odt,dnu,log_predictNc, &
    qc, nc, nc_incld,mu_c,lamc,prt_liq,qc_tend,nc_tend)
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    use micro_p3_iso_f, only: cloud_sedimentation_f
+#endif
+
    implicit none
    integer, intent(in) :: kts, kte
    integer, intent(in) :: ktop, kbot, kdir
@@ -3382,6 +3386,19 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
    real(rtype), dimension(kts:kte), target :: flux_nx
 
    real(rtype) :: tmp1, tmp2, dum
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+   logical(btype) :: log_predictNc_c
+
+   log_predictNc_c = log_predictNc
+   if (use_cxx) then
+      call cloud_sedimentation_f(kts,kte,ktop,kbot,kdir,   &
+           qc_incld,rho,inv_rho,lcldm,acn,inv_dzq,&
+           dt,odt,log_predictNc_c, &
+           qc, nc, nc_incld,mu_c,lamc,prt_liq,qc_tend,nc_tend)
+      return
+   endif
+#endif
 
    k_qxtop = kbot
    log_qxpresent = .false.

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3441,7 +3441,7 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
                qc_notsmall_c2: if (qc_incld(k)>qsmall) then
                   !-- compute Vq, Vn
                   call get_cloud_dsd2(qc_incld(k),nc_incld(k),mu_c(k),rho(k),nu,dnu,   &
-                  lamc(k),tmp1,tmp2,lcldm(k))
+                       lamc(k),tmp1,tmp2,lcldm(k))
 
                   nc(k) = nc_incld(k)*lcldm(k)
                   dum = 1._rtype / (lamc(k)*lamc(k))
@@ -3465,7 +3465,7 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
             kloop_sedi_c1: do k = k_qxtop,k_qxbot,-kdir
                qc_notsmall_c1: if (qc_incld(k)>qsmall) then
                   call get_cloud_dsd2(qc_incld(k),nc_incld(k),mu_c(k),rho(k),nu,dnu,   &
-                  lamc(k),tmp1,tmp2,lcldm(k))
+                       lamc(k),tmp1,tmp2,lcldm(k))
                   nc(k) = nc_incld(k)*lcldm(k)
                   dum = 1._rtype / (lamc(k)*lamc(k))
                   V_qc(k) = acn(k)*bfb_gamma(4._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+4._rtype))

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -413,7 +413,7 @@ contains
     integer, intent(in)                                  :: kts,kte    ! array bounds (vertical)
     integer, intent(in)                                  :: it         ! time step counter NOTE: starts at 1 for first time step
 
-    logical, intent(in)                                  :: log_predictNc ! .T. (.F.) for prediction (specification) of Nc
+    logical(btype), intent(in)                           :: log_predictNc ! .T. (.F.) for prediction (specification) of Nc
 
     real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: pdel       ! pressure thickness               Pa
     real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: exner      ! Exner expression
@@ -502,7 +502,7 @@ contains
     real(rtype) :: ncshdc    ! source for rain number due to cloud water/ice collision above freezing  and shedding (combined with NRSHD in the paper)
     real(rtype) :: qiberg    ! Bergeron process
 
-    logical   :: log_wetgrowth
+    logical(btype) :: log_wetgrowth
 
     real(rtype) :: epsi
     real(rtype) :: eii ! temperature dependent aggregation efficiency
@@ -528,7 +528,7 @@ contains
     integer :: dumi,i,k,dumj,dumii,dumjj,dumzz,      &
          ktop,kbot,kdir
 
-    logical :: log_nucleationPossible,log_hydrometeorsPresent,     &
+    logical(btype) :: log_nucleationPossible,log_hydrometeorsPresent,     &
          log_exitlevel
 
 
@@ -553,8 +553,8 @@ contains
 
 
     !--These will be added as namelist parameters in the future
-    logical, parameter :: debug_ON     = .false.  !.true. to switch on debugging checks/traps throughout code
-    logical, parameter :: debug_ABORT  = .false.  !.true. will result in forced abort in s/r 'check_values'
+    logical(btype), parameter :: debug_ON     = .false.  !.true. to switch on debugging checks/traps throughout code
+    logical(btype), parameter :: debug_ABORT  = .false.  !.true. will result in forced abort in s/r 'check_values'
 
     !-----------------------------------------------------------------------------------!
     !  End of variables/parameters declarations
@@ -1988,7 +1988,7 @@ contains
     !Calling parameters:
     real(rtype), dimension(:,:),   intent(in) :: Qv,T
     integer,                intent(in) :: source_ind,i,timestepcount
-    logical,                intent(in) :: force_abort         !.TRUE. = forces abort if value violation is detected
+    logical(btype),                intent(in) :: force_abort         !.TRUE. = forces abort if value violation is detected
 
     !Local variables:
     real(rtype), parameter :: T_low  = 173._rtype
@@ -1999,7 +1999,7 @@ contains
     real(rtype), parameter :: x_high = 1.e+30_rtype
     real(rtype), parameter :: x_low  = 0._rtype
     integer         :: k,nk
-    logical         :: trap,badvalue_found
+    logical(btype)         :: trap,badvalue_found
 
     nk   = size(Qv,dim=2)
 
@@ -2266,7 +2266,7 @@ qv,qc_incld,qitot_incld,nitot_incld,qr_incld,    &
    real(rtype), intent(in) :: nitot_incld
    real(rtype), intent(in) :: qr_incld
 
-   logical, intent(inout) :: log_wetgrowth
+   logical(btype), intent(inout) :: log_wetgrowth
    real(rtype), intent(inout) :: qrcol
    real(rtype), intent(inout) :: qccol
    real(rtype), intent(inout) :: qwgrth
@@ -2560,7 +2560,7 @@ subroutine ice_nucleation(t,inv_rho,nitot,naai,supi,odt,log_predictNc,    &
    real(rtype), intent(in) :: naai
    real(rtype), intent(in) :: supi
    real(rtype), intent(in) :: odt
-   logical, intent(in) :: log_predictNc
+   logical(btype), intent(in) :: log_predictNc
 
    real(rtype), intent(inout) :: qinuc
    real(rtype), intent(inout) :: ninuc
@@ -2603,7 +2603,7 @@ real(rtype), intent(in) :: sup
 real(rtype), intent(in) :: xxlv
 real(rtype), intent(in) :: npccn
 
-logical, intent(in) :: log_predictNc
+logical(btype), intent(in) :: log_predictNc
 real(rtype), intent(in)  :: odt
 integer, intent(in) :: it
 
@@ -3048,8 +3048,8 @@ subroutine update_prognostic_ice(qcheti,qccol,qcshd,    &
    real(rtype), intent(in) :: xlf
    real(rtype), intent(in) :: xxls
 
-   logical, intent(in) :: log_predictNc
-   logical, intent(in) :: log_wetgrowth
+   logical(btype), intent(in) :: log_predictNc
+   logical(btype), intent(in) :: log_wetgrowth
    real(rtype), intent(in) :: dt
    real(rtype), intent(in) :: nmltratio
    real(rtype), intent(in) :: rhorime_c
@@ -3144,7 +3144,7 @@ subroutine update_prognostic_liquid(qcacc,ncacc,qcaut,ncautc,qcnuc,ncautr,ncslf,
    real(rtype), intent(in) :: nrslf
 
 
-   logical, intent(in) :: log_predictNc
+   logical(btype), intent(in) :: log_predictNc
    real(rtype), intent(in) :: inv_rho
    real(rtype), intent(in) :: exner
    real(rtype), intent(in) :: xxlv
@@ -3357,7 +3357,7 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
    real(rtype), intent(in) :: dt
    real(rtype), intent(in) :: odt
    real(rtype), dimension(:), intent(in) :: dnu
-   logical, intent(in) :: log_predictNc
+   logical(btype), intent(in) :: log_predictNc
 
    real(rtype), intent(inout), dimension(kts:kte), target :: qc
    real(rtype), intent(inout), dimension(kts:kte), target :: nc
@@ -3368,7 +3368,7 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
    real(rtype), intent(inout), dimension(kts:kte) :: qc_tend
    real(rtype), intent(inout), dimension(kts:kte) :: nc_tend
 
-   logical :: log_qxpresent
+   logical(btype) :: log_qxpresent
    integer :: k
    integer :: k_qxtop, k_qxbot, k_temp
    integer :: tmpint1
@@ -3388,13 +3388,10 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
    real(rtype) :: tmp1, tmp2, dum
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
-   logical(btype) :: log_predictNc_c
-
-   log_predictNc_c = log_predictNc
    if (use_cxx) then
       call cloud_sedimentation_f(kts,kte,ktop,kbot,kdir,   &
            qc_incld,rho,inv_rho,lcldm,acn,inv_dzq,&
-           dt,odt,log_predictNc_c, &
+           dt,odt,log_predictNc, &
            qc, nc, nc_incld,mu_c,lamc,prt_liq,qc_tend,nc_tend)
       return
    endif
@@ -3520,7 +3517,7 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,   &
    real(rtype), intent(inout), dimension(kts:kte) :: qr_tend
    real(rtype), intent(inout), dimension(kts:kte) :: nr_tend
 
-   logical :: log_qxpresent
+   logical(btype) :: log_qxpresent
    integer :: k
    integer :: k_qxtop, k_qxbot, k_temp
    integer, parameter :: num_arrays = 2
@@ -3689,7 +3686,7 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
    real(rtype), intent(inout), dimension(kts:kte) :: qi_tend
    real(rtype), intent(inout), dimension(kts:kte) :: ni_tend
 
-   logical :: log_qxpresent
+   logical(btype) :: log_qxpresent
    integer :: k
    integer :: k_qxtop, k_qxbot, k_temp
    integer :: tmpint1

--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -21,8 +21,11 @@ module micro_p3_utils
 #  else
   integer,parameter,public :: rtype = c_float ! 4 byte real, compatible with c type float
 #  endif
+
   integer,parameter :: itype = selected_int_kind (13) ! 8 byte integer
+
 #else
+  integer,parameter,public :: btype = kind(.true.) ! native logical
   public :: rtype
   integer,parameter,public :: rtype8 = selected_real_kind(15, 307) ! 8 byte real, compatible with c type double
 #endif
@@ -31,7 +34,7 @@ module micro_p3_utils
               avg_diameter, calculate_incloud_mixingratios
 
     integer, public :: iulog_e3sm
-    logical, public :: masterproc_e3sm
+    logical(btype), public :: masterproc_e3sm
 
     ! Signaling NaN bit pattern that represents a limiter that's turned off.
     integer(itype), parameter :: limiter_off = int(Z'7FF1111111111111', itype)
@@ -114,7 +117,7 @@ real(rtype), parameter :: precip_limit  = 1.0E-2
     real(rtype), intent(in) :: tmelt
     real(rtype), intent(in) :: pi
     integer, intent(in)     :: iulog
-    logical, intent(in)     :: masterproc
+    logical(btype), intent(in)     :: masterproc
 
     real(rtype) :: ice_lambda_bounds(2)
 

--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -1,29 +1,30 @@
 module micro_p3_utils
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
-    use iso_c_binding, only: c_double, c_float
+  use iso_c_binding, only: c_double, c_float, c_bool
 #else
-    use shr_kind_mod,   only: rtype=>shr_kind_r8, itype=>shr_kind_i8
+  use shr_kind_mod,   only: rtype=>shr_kind_r8, itype=>shr_kind_i8
 #endif
 
-    implicit none
-    private
-    save
+  implicit none
+  private
+  save
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
 #include "scream_config.f"
 
   integer,parameter,public :: rtype8 = c_double ! 8 byte real, compatible with c type double
+  integer,parameter,public :: btype  = c_bool ! boolean type, compatible with c
 
-#ifdef SCREAM_DOUBLE_PRECISION
+#  ifdef SCREAM_DOUBLE_PRECISION
   integer,parameter,public :: rtype = c_double ! 8 byte real, compatible with c type double
-#else
+#  else
   integer,parameter,public :: rtype = c_float ! 4 byte real, compatible with c type float
-#endif
+#  endif
   integer,parameter :: itype = selected_int_kind (13) ! 8 byte integer
 #else
-    public :: rtype
-    integer,parameter,public :: rtype8 = selected_real_kind(15, 307) ! 8 byte real, compatible with c type double
+  public :: rtype
+  integer,parameter,public :: rtype8 = selected_real_kind(15, 307) ! 8 byte real, compatible with c type double
 #endif
 
     public :: get_latent_heat, micro_p3_utils_init, &

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -67,6 +67,7 @@ def _main_func(description):
 
     success = tas.test_all_scream()
 
+    print("OVERALL STATUS: {}".format("PASS" if success else "FAIL"))
     sys.exit(0 if success else 1)
 
 ###############################################################################

--- a/components/scream/src/physics/p3/CMakeLists.txt
+++ b/components/scream/src/physics/p3/CMakeLists.txt
@@ -24,24 +24,13 @@ list(APPEND P3_SRCS ${share_sources})
 if (NOT CUDA_BUILD)
   list(APPEND P3_SRCS
     p3_functions_upwind.cpp
+    p3_functions_cloud_sed.cpp
     p3_functions_table3.cpp
     p3_functions_table_ice.cpp
     p3_functions_dsd2.cpp
     p3_functions_find.cpp
     p3_functions_math.cpp)
 endif()
-
-set(P3_HEADERS
-  p3_f90.hpp
-  p3_ic_cases.hpp
-  p3_constants.hpp
-  p3_functions_upwind_impl.hpp
-  p3_functions_table3_impl.hpp
-  p3_functions.hpp
-  p3_functions_find_impl.hpp
-  atmosphere_microphysics.hpp
-  scream_p3_interface.hpp
-)
 
 # link_directories(${SCREAM_TPL_LIBRARY_DIRS} ${SCREAM_LIBRARY_DIRS})
 add_library(p3 ${P3_SRCS})

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -293,5 +293,44 @@ contains
 
   end subroutine generalized_sedimentation_c
 
+  subroutine cloud_sedimentation_c(kts,kte,ktop,kbot,kdir,   &
+       qc_incld,rho,inv_rho,lcldm,acn,inv_dzq,&
+       dt,odt,log_predictNc, &
+       qc, nc, nc_incld,mu_c,lamc,prt_liq,qc_tend,nc_tend) bind(C)
+    use micro_p3, only: cloud_sedimentation, dnu
+
+    ! arguments
+    integer(kind=c_int), value, intent(in) :: kts, kte, ktop, kbot, kdir
+
+    real(kind=c_real), intent(in), dimension(kts:kte) :: qc_incld
+    real(kind=c_real), intent(in), dimension(kts:kte) :: rho
+    real(kind=c_real), intent(in), dimension(kts:kte) :: inv_rho
+    real(kind=c_real), intent(in), dimension(kts:kte) :: lcldm
+    real(kind=c_real), intent(in), dimension(kts:kte) :: acn
+    real(kind=c_real), intent(in), dimension(kts:kte) :: inv_dzq
+
+    real(kind=c_real),    value, intent(in) :: dt
+    real(kind=c_real),    value, intent(in) :: odt
+    logical(kind=c_bool), value, intent(in) :: log_predictNc
+
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: qc
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: nc
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: nc_incld
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: mu_c
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: lamc
+    real(kind=c_real), intent(inout) :: prt_liq
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: qc_tend
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: nc_tend
+
+    logical :: log_predictNc_f
+
+    log_predictNc_f = log_predictNc
+
+    call cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
+         qc_incld,rho,inv_rho,lcldm,acn,inv_dzq,&
+         dt,odt,dnu,log_predictNc_f, &
+         qc, nc, nc_incld,mu_c,lamc,prt_liq,qc_tend,nc_tend)
+
+  end subroutine cloud_sedimentation_c
 
 end module micro_p3_iso_c

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -84,7 +84,7 @@ contains
 
   subroutine p3_main_c(qc,nc,qr,nr,th,qv,dt,qitot,qirim,nitot,birim,   &
        pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
-       diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc_in, &
+       diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm, &
        pratot,prctot,p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
        vap_ice_exchange, vap_cld_exchange) bind(C)
@@ -99,7 +99,7 @@ contains
     real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_ze, diag_effc
     real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_effi, diag_vmi, diag_di, diag_rhoi
     integer(kind=c_int), value, intent(in) :: its,ite, kts,kte, it
-    logical(kind=c_bool), value, intent(in) :: log_predictNc_in
+    logical(kind=c_bool), value, intent(in) :: log_predictNc
 
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: pdel
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: exner
@@ -117,10 +117,6 @@ contains
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_liq_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_ice_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_cld_exchange
-
-    logical :: log_predictNc
-
-    log_predictNc = log_predictNc_in
 
     call p3_main(qc,nc,qr,nr,th,qv,dt,qitot,qirim,nitot,birim,   &
          pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
@@ -140,7 +136,7 @@ contains
 
   subroutine micro_p3_utils_init_c(Cpair, Rair, RH2O, RhoH2O, &
                  MWH2O, MWdry, gravit, LatVap, LatIce,        &
-                 CpLiq, Tmelt, Pi, iulog_in, masterproc_in) bind(C)
+                 CpLiq, Tmelt, Pi, iulog_in, masterproc) bind(C)
 
     use micro_p3_utils, only: micro_p3_utils_init
     real(kind=c_real), value, intent(in) :: Cpair
@@ -156,12 +152,9 @@ contains
     real(kind=c_real), value, intent(in) :: Tmelt
     real(kind=c_real), value, intent(in) :: Pi
     integer(kind=c_int), value, intent(in)   :: iulog_in
-    logical(kind=c_bool), value, intent(in)  :: masterproc_in
+    logical(kind=c_bool), value, intent(in)  :: masterproc
 
-    logical :: masterproc
     integer :: iulog
-
-    masterproc = masterproc_in
     iulog = iulog_in
 
     call micro_p3_utils_init(Cpair,Rair,RH2O,RhoH2O,MWH2O,MWdry,gravit,LatVap,LatIce, &
@@ -322,13 +315,9 @@ contains
     real(kind=c_real), intent(inout), dimension(kts:kte) :: qc_tend
     real(kind=c_real), intent(inout), dimension(kts:kte) :: nc_tend
 
-    logical :: log_predictNc_f
-
-    log_predictNc_f = log_predictNc
-
     call cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
          qc_incld,rho,inv_rho,lcldm,acn,inv_dzq,&
-         dt,odt,dnu,log_predictNc_f, &
+         dt,odt,dnu,log_predictNc, &
          qc, nc, nc_incld,mu_c,lamc,prt_liq,qc_tend,nc_tend)
 
   end subroutine cloud_sedimentation_c

--- a/components/scream/src/physics/p3/micro_p3_iso_f.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_f.f90
@@ -89,6 +89,36 @@ interface
     type(c_ptr), intent(in), dimension(num_arrays) :: vs, fluxes, qnx
   end subroutine generalized_sedimentation_f
 
+  subroutine cloud_sedimentation_f(kts,kte,ktop,kbot,kdir,   &
+       qc_incld,rho,inv_rho,lcldm,acn,inv_dzq,&
+       dt,odt,log_predictNc, &
+       qc, nc, nc_incld,mu_c,lamc,prt_liq,qc_tend,nc_tend) bind(C)
+
+    use iso_c_binding
+
+    integer(kind=c_int), value, intent(in) :: kts, kte, ktop, kbot, kdir
+
+    real(kind=c_real), intent(in), dimension(kts:kte) :: qc_incld
+    real(kind=c_real), intent(in), dimension(kts:kte) :: rho
+    real(kind=c_real), intent(in), dimension(kts:kte) :: inv_rho
+    real(kind=c_real), intent(in), dimension(kts:kte) :: lcldm
+    real(kind=c_real), intent(in), dimension(kts:kte) :: acn
+    real(kind=c_real), intent(in), dimension(kts:kte) :: inv_dzq
+
+    real(kind=c_real),    value, intent(in) :: dt
+    real(kind=c_real),    value, intent(in) :: odt
+    logical(kind=c_bool), value, intent(in) :: log_predictNc
+
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: qc
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: nc
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: nc_incld
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: mu_c
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: lamc
+    real(kind=c_real), intent(inout) :: prt_liq
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: qc_tend
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: nc_tend
+  end subroutine cloud_sedimentation_f
+
   !
   ! These are some routine math operations that are not BFB between
   ! fortran and C++ on all platforms, so fortran will need to use

--- a/components/scream/src/physics/p3/p3_constants.hpp
+++ b/components/scream/src/physics/p3/p3_constants.hpp
@@ -10,6 +10,9 @@ namespace p3 {
 
 /*
  * Mathematical constants used by p3.
+ *
+ * Note that a potential optimization could be to change the type of
+ * Scalar constants that have integer values to int.
  */
 
 template <typename Scalar>

--- a/components/scream/src/physics/p3/p3_constants.hpp
+++ b/components/scream/src/physics/p3/p3_constants.hpp
@@ -46,6 +46,7 @@ struct Constants
   static constexpr Scalar Tol         = util::is_single_precision<Real>::value ? 2e-5 : 1e-14;
   static constexpr Scalar mu_r_const  = 1.0;
   static constexpr Scalar dt_left_tol = 1.e-4;
+  static constexpr Scalar bcn         = 2.;
 };
 
 template <typename Scalar>

--- a/components/scream/src/physics/p3/p3_constants.hpp
+++ b/components/scream/src/physics/p3/p3_constants.hpp
@@ -45,6 +45,7 @@ struct Constants
   static constexpr Scalar INV_CP      = 1.0/CP;
   static constexpr Scalar Tol         = util::is_single_precision<Real>::value ? 2e-5 : 1e-14;
   static constexpr Scalar mu_r_const  = 1.0;
+  static constexpr Scalar dt_left_tol = 1.e-4;
 };
 
 template <typename Scalar>

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -290,6 +290,7 @@ struct Functions
   static Spack qv_sat(const Spack& t_atm, const Spack& p_atm, const bool ice);
 
   // TODO: comment
+  template <bool zero_out=true>
   KOKKOS_INLINE_FUNCTION
   static void get_cloud_dsd2(
     const Smask& qc_gt_small, const Spack& qc, Spack& nc, Spack& mu_c, const Spack& rho, Spack& nu,

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -3,6 +3,7 @@
 
 #include "share/scream_types.hpp"
 #include "share/scream_pack_kokkos.hpp"
+#include "share/scream_workspace.hpp"
 #include "p3_constants.hpp"
 
 namespace scream {
@@ -87,6 +88,8 @@ struct Functions
   using uview_1d = typename ko::template Unmanaged<view_1d<S> >;
 
   using MemberType = typename KT::MemberType;
+
+  using Workspace = typename WorkspaceManager<Spack, Device>::Workspace;
 
   // -- Table3 --
 
@@ -242,7 +245,9 @@ struct Functions
     const uview_1d<const Spack>& lcldm,
     const uview_1d<const Spack>& acn,
     const uview_1d<const Spack>& inv_dzq,
+    const view_dnu_table& dnu,
     const MemberType& team,
+    const Workspace& workspace,
     const Int& nk, const Int& ktop, const Int& kbot, const Int& kdir, const Scalar& dt, const Scalar& odt, const bool& log_predictNc,
     const uview_1d<Spack>& qc,
     const uview_1d<Spack>& nc,
@@ -288,7 +293,7 @@ struct Functions
   KOKKOS_INLINE_FUNCTION
   static void get_cloud_dsd2(
     const Smask& qc_gt_small, const Spack& qc, Spack& nc, Spack& mu_c, const Spack& rho, Spack& nu,
-    const view_1d<const Scalar>& dnu, Spack& lamc, Spack& cdist, Spack& cdist1, const Spack& lcldm);
+    const view_dnu_table& dnu, Spack& lamc, Spack& cdist, Spack& cdist1, const Spack& lcldm);
 
   // Computes and returns rain size distribution parameters
   KOKKOS_INLINE_FUNCTION

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -233,6 +233,26 @@ struct Functions
     const view_1d_ptr_array<Spack, nfield>& Vs, // (behaviorally const)
     const view_1d_ptr_array<Spack, nfield>& rs);
 
+  // Cloud sedimentation
+  KOKKOS_FUNCTION
+  static void cloud_sedimentation(
+    const uview_1d<const Spack>& qc_incld,
+    const uview_1d<const Spack>& rho,
+    const uview_1d<const Spack>& inv_rho,
+    const uview_1d<const Spack>& lcldm,
+    const uview_1d<const Spack>& acn,
+    const uview_1d<const Spack>& inv_dzq,
+    const MemberType& team,
+    const Int& nk, const Int& ktop, const Int& kbot, const Int& kdir, const Scalar& dt, const Scalar& odt, const bool& log_predictNc,
+    const uview_1d<Spack>& qc,
+    const uview_1d<Spack>& nc,
+    const uview_1d<Spack>& nc_incld,
+    const uview_1d<Spack>& mu_c,
+    const uview_1d<Spack>& lamc,
+    const uview_1d<Spack>& qc_tend,
+    const uview_1d<Spack>& nc_tend,
+    Scalar& prt_liq);
+
   // -- Find layers
 
   // Find the bottom and top of the mixing ratio, e.g., qr. It's worth casing
@@ -293,6 +313,7 @@ constexpr ScalarT Functions<ScalarT, DeviceT>::P3C::lookup_table_1a_dum1_c;
 # include "p3_functions_dsd2_impl.hpp"
 # include "p3_functions_upwind_impl.hpp"
 # include "p3_functions_find_impl.hpp"
+# include "p3_functions_cloud_sed_impl.hpp"
 #endif
 
 #endif

--- a/components/scream/src/physics/p3/p3_functions_cloud_sed.cpp
+++ b/components/scream/src/physics/p3/p3_functions_cloud_sed.cpp
@@ -1,0 +1,15 @@
+#include "p3_functions_cloud_sed_impl.hpp"
+#include "share/scream_types.hpp"
+
+namespace scream {
+namespace p3 {
+
+/*
+ * Explicit instatiation for doing p3 cloud sedimentation on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace p3
+} // namespace scream

--- a/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
@@ -52,15 +52,16 @@ void Functions<S,D>
 
   // find top, determine qxpresent
   const auto sqc = scalarize(qc);
+  constexpr Scalar qsmall = C::QSMALL;
   bool log_qxpresent;
-  const Int k_qxtop = find_top(team, sqc, C::QSMALL, kbot, ktop, kdir, log_qxpresent);
+  const Int k_qxtop = find_top(team, sqc, qsmall, kbot, ktop, kdir, log_qxpresent);
 
   if (log_qxpresent) {
     Scalar dt_left = dt;    // time remaining for sedi over full model (mp) time step
     Scalar prt_accum = 0.0; // precip rate for individual category
 
     // find bottom
-    Int k_qxbot = find_bottom(team, sqc, C::QSMALL, kbot, k_qxtop, kdir, log_qxpresent);
+    Int k_qxbot = find_bottom(team, sqc, qsmall, kbot, k_qxtop, kdir, log_qxpresent);
 
     while (dt_left > 1.e-4) {
       Scalar Co_max = 0.0;
@@ -81,7 +82,7 @@ void Functions<S,D>
       Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(team, kmax-kmin+1), [&] (int pk_, Scalar& lmax) {
           const int pk = kmin + pk_;
-          auto qc_gt_small = (qc_incld(pk) > C::QSMALL);
+          auto qc_gt_small = (qc_incld(pk) > qsmall);
           if (qc_gt_small.any()) {
             // compute Vq, Vn
             Spack nu, cdist, cdist1, dum;

--- a/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
@@ -1,0 +1,41 @@
+#ifndef P3_FUNCTIONS_CLOUD_SED_IMPL_HPP
+#define P3_FUNCTIONS_CLOUD_SED_IMPL_HPP
+
+#include "p3_functions.hpp"
+
+namespace scream {
+namespace p3 {
+
+/*
+ * Implementation of p3 cloud sedimentation function. Clients should NOT #include
+ * this file, #include p3_functions.hpp instead.
+ */
+
+template <typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>
+::cloud_sedimentation(
+    const uview_1d<const Spack>& qc_incld,
+    const uview_1d<const Spack>& rho,
+    const uview_1d<const Spack>& inv_rho,
+    const uview_1d<const Spack>& lcldm,
+    const uview_1d<const Spack>& acn,
+    const uview_1d<const Spack>& inv_dzq,
+    const MemberType& team,
+    const Int& nk, const Int& ktop, const Int& kbot, const Int& kdir, const Scalar& dt, const Scalar& odt, const bool& log_predictNc,
+    const uview_1d<Spack>& qc,
+    const uview_1d<Spack>& nc,
+    const uview_1d<Spack>& nc_incld,
+    const uview_1d<Spack>& mu_c,
+    const uview_1d<Spack>& lamc,
+    const uview_1d<Spack>& qc_tend,
+    const uview_1d<Spack>& nc_tend,
+    Scalar& prt_liq)
+{
+  // TODO
+}
+
+} // namespace p3
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
@@ -63,7 +63,7 @@ void Functions<S,D>
     // find bottom
     Int k_qxbot = find_bottom(team, sqc, qsmall, kbot, k_qxtop, kdir, log_qxpresent);
 
-    while (dt_left > 1.e-4) {
+    while (dt_left > C::dt_left_tol) {
       Scalar Co_max = 0.0;
       Int kmin, kmax;
       const Int kmin_scalar = ( kdir == 1 ? k_qxbot : k_qxtop);

--- a/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
@@ -21,7 +21,9 @@ void Functions<S,D>
     const uview_1d<const Spack>& lcldm,
     const uview_1d<const Spack>& acn,
     const uview_1d<const Spack>& inv_dzq,
+    const view_dnu_table& dnu,
     const MemberType& team,
+    const Workspace& workspace,
     const Int& nk, const Int& ktop, const Int& kbot, const Int& kdir, const Scalar& dt, const Scalar& odt, const bool& log_predictNc,
     const uview_1d<Spack>& qc,
     const uview_1d<Spack>& nc,
@@ -32,7 +34,88 @@ void Functions<S,D>
     const uview_1d<Spack>& nc_tend,
     Scalar& prt_liq)
 {
-  // TODO
+  // Get temporary workspaces needed for the cloud-sed calculation
+  uview_1d<Spack> V_qc, V_nc, flux_qx, flux_nx;
+  workspace.template take_many<4>(
+    {"V_qc", "V_nc", "flux_qx", "flux_nx"},
+    {&V_qc, &V_nc, &flux_qx, &flux_nx});
+
+  view_1d_ptr_array<Spack, 2>
+    fluxes_ptr = {&flux_qx, &flux_nx},
+    vs_ptr     = {&V_qc, &V_nc},
+    qnr_ptr    = {&qc, &nc};
+
+  // find top, determine qxpresent
+  const auto sqc = scalarize(qc);
+  bool log_qxpresent;
+  const Int k_qxtop = find_top(team, sqc, C::QSMALL, kbot, ktop, kdir, log_qxpresent);
+
+  if (log_qxpresent) {
+    Scalar dt_left = dt;    // time remaining for sedi over full model (mp) time step
+    Scalar prt_accum = 0.0; // precip rate for individual category
+
+    // find bottom
+    Int k_qxbot = find_bottom(team, sqc, C::QSMALL, kbot, k_qxtop, kdir, log_qxpresent);
+
+    while (dt_left > 1.e-4) {
+      Scalar Co_max = 0.0;
+      Int kmin, kmax;
+
+      Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(team, V_qc.extent(0)), [&] (Int k) {
+          V_qc(k) = 0;
+          if (log_predictNc) {
+            V_nc(k) = 0;
+          }
+      });
+      team.team_barrier();
+
+      // Convert top/bot to pack indices
+      util::set_min_max(k_qxbot, k_qxtop, kmin, kmax, Spack::n);
+
+      Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(team, kmax-kmin+1), [&] (int pk_, Scalar& lmax) {
+          const int pk = kmin + pk_;
+          auto qc_gt_small = (qc_incld(pk) > C::QSMALL);
+          if (qc_gt_small.any()) {
+            // compute Vq, Vn
+
+            Spack nu, cdist, cdist1, dum;
+            get_cloud_dsd2(qc_gt_small, qc(pk), nc(pk), mu_c(pk), rho(pk), nu, dnu, lamc(pk), cdist, cdist1, lcldm(pk));
+            nc(pk).set(qc_gt_small, nc_incld(pk)*lcldm(pk));
+            dum = 1 / pack::pow(lamc(pk), 2); // bcn = 2
+            V_qc(pk).set(qc_gt_small, acn(pk)*pack::tgamma(4 + 2 + mu_c(pk)) * dum / (pack::tgamma(mu_c(pk)+4)));
+            if (log_predictNc) {
+              V_nc(pk).set(qc_gt_small, acn(pk)*pack::tgamma(1 + 2 + mu_c(pk)) * dum / (pack::tgamma(mu_c(pk)+1)));
+            }
+
+            const auto Co_max_local = max(qc_gt_small, -1,
+                                          V_qc(pk) * dt_left * inv_dzq(pk));
+            if (Co_max_local > lmax)
+              lmax = Co_max_local;
+          }
+      }, Kokkos::Max<Scalar>(Co_max));
+      team.team_barrier();
+
+      generalized_sedimentation<2>(rho, inv_rho, inv_dzq, team, nk, k_qxtop, k_qxbot, kbot, kdir, Co_max, dt_left, prt_accum, fluxes_ptr, vs_ptr, qnr_ptr);
+
+      Kokkos::single(
+        Kokkos::PerTeam(team), [&] () {
+          prt_liq += prt_accum * C::INV_RHOW * odt;
+      });
+    }
+  }
+
+  Kokkos::parallel_for(
+    Kokkos::TeamThreadRange(team, qc_tend.extent(0)), [&] (int pk) {
+      qc_tend(pk) = (qc(pk) - qc_tend(pk)) * odt; // Liq. sedimentation tendency, measure
+      nc_tend(pk) = (nc(pk) - nc_tend(pk)) * odt; // Liq. # sedimentation tendency, measure
+  });
+
+  workspace.release(V_qc);
+  workspace.release(V_nc);
+  workspace.release(flux_qx);
+  workspace.release(flux_nx);
 }
 
 } // namespace p3

--- a/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
@@ -86,7 +86,7 @@ void Functions<S,D>
           const int pk = kmin + pk_;
           const auto range_pack = scream::pack::range<IntSmallPack>(pk*Spack::n);
           const auto range_mask = range_pack >= kmin_scalar && range_pack <= kmax_scalar;
-          auto qc_gt_small = range_mask && qc_incld(pk) > C::QSMALL;
+          auto qc_gt_small = range_mask && qc_incld(pk) > qsmall;
           if (qc_gt_small.any()) {
             // compute Vq, Vn
             Spack nu, cdist, cdist1, dum;

--- a/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
@@ -45,6 +45,11 @@ void Functions<S,D>
     vs_ptr     = {&V_qc, &V_nc},
     qnr_ptr    = {&qc, &nc};
 
+  view_1d_ptr_array<Spack, 1>
+    flux_ptr = {&flux_qx},
+    v_ptr     = {&V_qc},
+    qr_ptr    = {&qc};
+
   // find top, determine qxpresent
   const auto sqc = scalarize(qc);
   bool log_qxpresent;
@@ -96,7 +101,12 @@ void Functions<S,D>
       }, Kokkos::Max<Scalar>(Co_max));
       team.team_barrier();
 
-      generalized_sedimentation<2>(rho, inv_rho, inv_dzq, team, nk, k_qxtop, k_qxbot, kbot, kdir, Co_max, dt_left, prt_accum, fluxes_ptr, vs_ptr, qnr_ptr);
+      if (log_predictNc) {
+        generalized_sedimentation<2>(rho, inv_rho, inv_dzq, team, nk, k_qxtop, k_qxbot, kbot, kdir, Co_max, dt_left, prt_accum, fluxes_ptr, vs_ptr, qnr_ptr);
+      }
+      else {
+        generalized_sedimentation<1>(rho, inv_rho, inv_dzq, team, nk, k_qxtop, k_qxbot, kbot, kdir, Co_max, dt_left, prt_accum, flux_ptr, v_ptr, qr_ptr);
+      }
     }
 
     Kokkos::single(

--- a/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
@@ -79,11 +79,10 @@ void Functions<S,D>
           auto qc_gt_small = (qc_incld(pk) > C::QSMALL);
           if (qc_gt_small.any()) {
             // compute Vq, Vn
-
             Spack nu, cdist, cdist1, dum;
-            get_cloud_dsd2(qc_gt_small, qc(pk), nc(pk), mu_c(pk), rho(pk), nu, dnu, lamc(pk), cdist, cdist1, lcldm(pk));
+            get_cloud_dsd2(qc_gt_small, qc_incld(pk), nc_incld(pk), mu_c(pk), rho(pk), nu, dnu, lamc(pk), cdist, cdist1, lcldm(pk));
             nc(pk).set(qc_gt_small, nc_incld(pk)*lcldm(pk));
-            dum = 1 / pack::pow(lamc(pk), 2); // bcn = 2
+            dum = 1 / (lamc(pk)*lamc(pk)); // bcn = 2
             V_qc(pk).set(qc_gt_small, acn(pk)*pack::tgamma(4 + 2 + mu_c(pk)) * dum / (pack::tgamma(mu_c(pk)+4)));
             if (log_predictNc) {
               V_nc(pk).set(qc_gt_small, acn(pk)*pack::tgamma(1 + 2 + mu_c(pk)) * dum / (pack::tgamma(mu_c(pk)+1)));
@@ -98,12 +97,12 @@ void Functions<S,D>
       team.team_barrier();
 
       generalized_sedimentation<2>(rho, inv_rho, inv_dzq, team, nk, k_qxtop, k_qxbot, kbot, kdir, Co_max, dt_left, prt_accum, fluxes_ptr, vs_ptr, qnr_ptr);
-
-      Kokkos::single(
-        Kokkos::PerTeam(team), [&] () {
-          prt_liq += prt_accum * C::INV_RHOW * odt;
-      });
     }
+
+    Kokkos::single(
+      Kokkos::PerTeam(team), [&] () {
+        prt_liq = prt_accum * C::INV_RHOW * odt;
+      });
   }
 
   Kokkos::parallel_for(

--- a/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
@@ -85,7 +85,7 @@ void Functions<S,D>
           if (qc_gt_small.any()) {
             // compute Vq, Vn
             Spack nu, cdist, cdist1, dum;
-            get_cloud_dsd2(qc_gt_small, qc_incld(pk), nc_incld(pk), mu_c(pk), rho(pk), nu, dnu, lamc(pk), cdist, cdist1, lcldm(pk));
+            get_cloud_dsd2<false>(qc_gt_small, qc_incld(pk), nc_incld(pk), mu_c(pk), rho(pk), nu, dnu, lamc(pk), cdist, cdist1, lcldm(pk));
             nc(pk).set(qc_gt_small, nc_incld(pk)*lcldm(pk));
             dum = 1 / (lamc(pk)*lamc(pk)); // bcn = 2
             V_qc(pk).set(qc_gt_small, acn(pk)*pack::tgamma(4 + 2 + mu_c(pk)) * dum / (pack::tgamma(mu_c(pk)+4)));

--- a/components/scream/src/physics/p3/p3_functions_dsd2.cpp
+++ b/components/scream/src/physics/p3/p3_functions_dsd2.cpp
@@ -9,6 +9,15 @@ namespace p3 {
  * default device.
  */
 
+#define ETI_CLOUD_DSD2(zero_out)                                        \
+template void Functions<Real,DefaultDevice>                             \
+  ::get_cloud_dsd2<zero_out>(                                           \
+    const Smask& qc_gt_small,const Spack& qc, Spack& nc, Spack& mu_c, const Spack& rho, Spack& nu, \
+    const view_dnu_table& dnu, Spack& lamc, Spack& cdist, Spack& cdist1, const Spack& lcldm);
+ETI_CLOUD_DSD2(true)
+ETI_CLOUD_DSD2(false)
+#undef ETI_CLOUD_DSD2
+
 template struct Functions<Real,DefaultDevice>;
 
 } // namespace p3

--- a/components/scream/src/physics/p3/p3_functions_dsd2_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_dsd2_impl.hpp
@@ -15,15 +15,18 @@ namespace p3 {
  */
 
 template <typename S, typename D>
+template <bool zero_out>
 void Functions<S,D>::
 get_cloud_dsd2(const Smask& qc_gt_small, const Spack& qc, Spack& nc, Spack& mu_c, const Spack& rho, Spack& nu,
                const view_dnu_table& dnu, Spack& lamc, Spack& cdist, Spack& cdist1, const Spack& lcldm)
 {
-  lamc =   0;
-  cdist =  0;
-  cdist1 = 0;
-  nu     = 0;
-  mu_c   = 0;
+  if (zero_out) {
+    lamc =   0;
+    cdist =  0;
+    cdist1 = 0;
+    nu     = 0;
+    mu_c   = 0;
+  }
 
   if (qc_gt_small.any()) {
     constexpr Scalar nsmall = C::NSMALL;

--- a/components/scream/src/physics/p3/p3_functions_dsd2_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_dsd2_impl.hpp
@@ -17,7 +17,7 @@ namespace p3 {
 template <typename S, typename D>
 void Functions<S,D>::
 get_cloud_dsd2(const Smask& qc_gt_small, const Spack& qc, Spack& nc, Spack& mu_c, const Spack& rho, Spack& nu,
-               const view_1d<const Scalar>& dnu, Spack& lamc, Spack& cdist, Spack& cdist1, const Spack& lcldm)
+               const view_dnu_table& dnu, Spack& lamc, Spack& cdist, Spack& cdist1, const Spack& lcldm)
 {
   lamc =   0;
   cdist =  0;

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -412,7 +412,7 @@ void get_cloud_dsd2_f(Real qc_, Real* nc_, Real* mu_c_, Real rho_, Real* nu_, Re
   auto t_h = Kokkos::create_mirror_view(t_d);
 
   Real local_nc = *nc_;
-  auto dnu = P3GlobalForFortran::dnu();
+  const auto dnu = P3GlobalForFortran::dnu();
   Kokkos::parallel_for(1, KOKKOS_LAMBDA(const Int&) {
     typename P3F::Spack qc(qc_), nc(local_nc), rho(rho_), lcldm(lcldm_);
     typename P3F::Spack mu_c, nu, lamc, cdist, cdist1;
@@ -678,7 +678,7 @@ void cloud_sedimentation_f(
   const Int nk = (kte - kts) + 1;
 
   // Set up views
-  auto dnu = P3GlobalForFortran::dnu();
+  const auto dnu = P3GlobalForFortran::dnu();
 
   Kokkos::Array<view_1d, 13> temp_d;
 
@@ -732,7 +732,6 @@ void cloud_sedimentation_f(
   // Sync back to host
   Kokkos::Array<view_1d, 7> inout_views = {qc_d, nc_d, nc_incld_d, mu_c_d, lamc_d, qc_tend_d, nc_tend_d};
   pack::device_to_host({qc, nc, nc_incld, mu_c, lamc, qc_tend, nc_tend}, nk, inout_views);
-
 }
 
 // Cuda implementations of std math routines are not necessarily BFB

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -41,6 +41,11 @@ void calc_first_order_upwind_step_c(Int kts, Int kte, Int kdir, Int kbot, Int k_
 void generalized_sedimentation_c(Int kts, Int kte, Int kdir, Int k_qxtop, Int* k_qxbot, Int kbot, Real Co_max,
                                  Real* dt_left, Real* prt_accum, Real* inv_dzq, Real* inv_rho, Real* rho,
                                  Int num_arrays, Real** vs, Real** fluxes, Real** qnx);
+void cloud_sedimentation_c(
+  Int kts, Int kte, Int ktop, Int kbot, Int kdir,
+  Real* qc_incld, Real* rho, Real* inv_rho, Real* lcldm, Real* acn, Real* inv_dzq,
+  Real dt, Real odt, bool log_predictNc,
+  Real* qc, Real* nc, Real* nc_incld, Real* mu_c, Real* lamc, Real* prt_liq, Real* qc_tend, Real* nc_tend);
 
 }
 
@@ -188,13 +193,24 @@ GenSedData::GenSedData(
   Co_max(Co_max_), k_qxbot(k_qxbot_), dt_left(dt_left_), prt_accum(prt_accum_)
 { }
 
-
 void generalized_sedimentation(GenSedData& d)
 {
   p3_init(true);
   generalized_sedimentation_c(d.kts, d.kte, d.kdir, d.k_qxtop, &d.k_qxbot, d.kbot, d.Co_max,
                               &d.dt_left, &d.prt_accum, d.inv_dzq, d.inv_rho, d.rho,
                               d.num_arrays, d.vs, d.fluxes, d.qnx);
+}
+
+// TODO
+CloudSedData::CloudSedData() {}
+
+void cloud_sedimentation(CloudSedData& d)
+{
+  p3_init(true);
+  cloud_sedimentation_f(d.kts, d.kte, d.ktop, d.kbot, d.kdir,
+                        d.qc_incld, d.rho, d.inv_rho, d.lcldm, d.acn, d.inv_dzq,
+                        d.dt, d.odt, d.log_predictNc,
+                        d.qc, d.nc, d.nc_incld, d.mu_c, d.lamc, &d.prt_liq, d.qc_tend, d.nc_tend);
 }
 
 std::shared_ptr<P3GlobalForFortran::Views> P3GlobalForFortran::s_views;
@@ -574,6 +590,15 @@ void generalized_sedimentation_f(
   else {
     scream_require_msg(false, "Unsupported num arrays in bridge calc_first_order_upwind_step_f: " << num_arrays);
   }
+}
+
+void cloud_sedimentation_f(
+  Int kts, Int kte, Int ktop, Int kbot, Int kdir,
+  Real* qc_incld, Real* rho, Real* inv_rho, Real* lcldm, Real* acn, Real* inv_dzq,
+  Real dt, Real odt, bool log_predictNc,
+  Real* qc, Real* nc, Real* nc_incld, Real* mu_c, Real* lamc, Real* prt_liq, Real* qc_tend, Real* nc_tend)
+{
+  // TODO
 }
 
 // Cuda implementations of std math routines are not necessarily BFB

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -267,7 +267,7 @@ CloudSedData::CloudSedData(const CloudSedData& rhs) :
 void cloud_sedimentation(CloudSedData& d)
 {
   p3_init(true);
-  cloud_sedimentation_f(d.kts, d.kte, d.ktop, d.kbot, d.kdir,
+  cloud_sedimentation_c(d.kts, d.kte, d.ktop, d.kbot, d.kdir,
                         d.qc_incld, d.rho, d.inv_rho, d.lcldm, d.acn, d.inv_dzq,
                         d.dt, d.odt, d.log_predictNc,
                         d.qc, d.nc, d.nc_incld, d.mu_c, d.lamc, &d.prt_liq, d.qc_tend, d.nc_tend);

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -259,7 +259,30 @@ struct CloudSedData
   Real *qc, *nc, *nc_incld, *mu_c, *lamc, *qc_tend, *nc_tend;
   Real prt_liq;
 
-  CloudSedData();
+  CloudSedData(Int kts_, Int kte_, Int ktop_, Int kbot_, Int kdir_,
+               Real dt_, Real odt_, bool log_predictNc_, Real prt_liq,
+               std::pair<Real, Real> qc_incld_range,
+               std::pair<Real, Real> rho_range,
+               std::pair<Real, Real> lcldm_range,
+               std::pair<Real, Real> acn_range,
+               std::pair<Real, Real> inv_dzq_range,
+               std::pair<Real, Real> qc_range,
+               std::pair<Real, Real> nc_range,
+               std::pair<Real, Real> nc_incld_range,
+               std::pair<Real, Real> mu_c_range,
+               std::pair<Real, Real> lamc_range,
+               std::pair<Real, Real> qc_tend_range,
+               std::pair<Real, Real> nc_tend_range);
+
+  // deep copy
+  CloudSedData(const CloudSedData& rhs);
+
+  Int nk() const { return m_nk; }
+
+ private:
+  // Internals
+  Int m_nk;
+  std::vector<Real> m_data;
 };
 void cloud_sedimentation(CloudSedData& d);
 

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -247,6 +247,32 @@ void generalized_sedimentation_f(Int kts, Int kte, Int kdir, Int k_qxtop, Int *k
 
 }
 
+struct CloudSedData
+{
+  // Inputs
+  Int kts, kte, ktop, kbot, kdir;
+  Real *qc_incld, *rho, *inv_rho, *lcldm, *acn, *inv_dzq;
+  Real dt, odt;
+  bool log_predictNc;
+
+  // In/out
+  Real *qc, *nc, *nc_incld, *mu_c, *lamc, *qc_tend, *nc_tend;
+  Real prt_liq;
+
+  CloudSedData();
+};
+void cloud_sedimentation(CloudSedData& d);
+
+extern "C" {
+
+void cloud_sedimentation_f(
+  Int kts, Int kte, Int ktop, Int kbot, Int kdir,
+  Real* qc_incld, Real* rho, Real* inv_rho, Real* lcldm, Real* acn, Real* inv_dzq,
+  Real dt, Real odt, bool log_predictNc,
+  Real* qc, Real* nc, Real* nc_incld, Real* mu_c, Real* lamc, Real* prt_liq, Real* qc_tend, Real* nc_tend);
+
+}
+
 extern "C" {
 
 Real cxx_pow(Real base, Real exp);

--- a/components/scream/src/physics/p3/scream_p3_interface.F90
+++ b/components/scream/src/physics/p3/scream_p3_interface.F90
@@ -62,6 +62,7 @@ contains
     character(len=100) :: case_title
 
     integer(kind=c_int) :: i, k
+    logical(kind=c_bool) :: masterproc
 
     ! READ inputs from SCM for p3-stand-alone:
     q(:,:,:) = 0.0_rtype
@@ -93,9 +94,9 @@ contains
 !    q(:,:,7) = 1.0e5_rtype!state%q(:,:,ixnumrain)
 !    q(:,:,8) = 1.0e-8_rtype!state%q(:,:,ixcldrim) !Aaron, changed ixqirim to ixcldrim to match Kai's code
 !    q(:,:,9) = 1.0e4_rtype!state%q(:,:,ixrimvol)
-     
+    masterproc = .false.
     call micro_p3_utils_init(cpair,rair,rh2o,rhoh2o,mwh2o,mwdry,gravit,latvap,latice, &
-             cpliq,tmelt,pi,0,.false.)
+             cpliq,tmelt,pi,0,masterproc)
     call p3_init(micro_p3_lookup_dir,micro_p3_tableversion)
 
 
@@ -175,7 +176,7 @@ contains
     integer :: i
 
     integer(kind=c_int) :: it, its, ite, kts, kte
-    logical :: log_predictNc = .true.
+    logical(kind=c_bool) :: log_predictNc = .true.
     character(len=16) :: precip_frac_method = 'max_overlap'  ! AaronDonahue, Hard-coded for now, should be fixed in the future
 
     real(kind=c_real) :: qtest

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(P3_TESTS_SRCS
   p3_table3_unit_tests.cpp
   p3_find_unit_tests.cpp
   p3_upwind_unit_tests.cpp
+  p3_cloud_sed_unit_tests.cpp
   p3_dsd2_unit_tests.cpp
 )
 CreateUnitTest(p3_tests "${P3_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP p3_tests_ut_np1_omp1)

--- a/components/scream/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
@@ -29,7 +29,64 @@ static void run_phys()
 
 static void run_bfb()
 {
-  // TODO
+  CloudSedData csds_fortran[] = {
+    //         kts, kte, ktop, kbot, kdir, dt, odt, log_predictNc, prt_liq,
+    CloudSedData(1,  72,   36,   72,   -1, 0.0, 0.0,        false,     0.0,
+                 std::make_pair(5.100E-03, 9.952E-07), // qc_incld_range
+                 std::make_pair(4.056E-03, 1.153E+00), // rho_range
+                 std::make_pair(0.9, 1.1),             // lcldm_range
+                 std::make_pair(2.959E+07, 5.348E+07), // acn_range
+                 std::make_pair(2.863E-05, 8.141E-03), // inv_dzq_range
+                 std::make_pair(7.701E-16, 2.119E-04), // qc_range
+                 std::make_pair(7.701E-16, 2.119E-04), // nc_range
+                 std::make_pair(9.952E+05, 1.734E+08), // nc_incld_range
+                 std::make_pair(5.722E+00, 1.253E+01), // mu_c_range
+                 std::make_pair(3.381E+05, 2.519E+06), // lamc_range
+                 std::make_pair(9.952E-07, 9.982E-07), // qc_tend_range
+                 std::make_pair(9.952E+05, 1.743E+08)),// nc_tend_range
+  };
+
+  static constexpr Int num_runs = sizeof(csds_fortran) / sizeof(GenSedData);
+
+  // Create copies of data for use by cxx. Needs to happen before fortran calls so that
+  // inout data is in original state
+  CloudSedData csds_cxx[num_runs] = {
+    CloudSedData(csds_fortran[0]),
+    // CloudSedData(csds_fortran[1]),
+    // CloudSedData(csds_fortran[2]),
+    // CloudSedData(csds_fortran[3]),
+  };
+
+  // Get data from fortran
+  for (Int i = 0; i < num_runs; ++i) {
+    cloud_sedimentation(csds_fortran[i]);
+  }
+
+  // Get data from cxx
+  for (Int i = 0; i < num_runs; ++i) {
+    CloudSedData& d = csds_cxx[num_runs];
+    cloud_sedimentation_f(d.kts, d.kte, d.ktop, d.kbot, d.kdir,
+                          d.qc_incld, d.rho, d.inv_rho, d.lcldm, d.acn, d.inv_dzq,
+                          d.dt, d.odt, d.log_predictNc,
+                          d.qc, d.nc, d.nc_incld, d.mu_c, d.lamc, &d.prt_liq, d.qc_tend, d.nc_tend);
+  }
+
+  for (Int i = 0; i < num_runs; ++i) {
+    // Due to pack issues, we must restrict checks to the active k space
+    Int start = std::min(csds_fortran[i].kbot, csds_fortran[i].ktop) - 1; // 0-based indx
+    Int end   = std::max(csds_fortran[i].kbot, csds_fortran[i].ktop);     // 0-based indx
+    for (Int k = start; k < end; ++k) {
+      REQUIRE(csds_fortran[i].qc[k]       == csds_cxx[i].qc[k]);
+      REQUIRE(csds_fortran[i].nc[k]       == csds_cxx[i].nc[k]);
+      REQUIRE(csds_fortran[i].nc_incld[k] == csds_cxx[i].nc_incld[k]);
+      REQUIRE(csds_fortran[i].mu_c[k]     == csds_cxx[i].mu_c[k]);
+      REQUIRE(csds_fortran[i].lamc[k]     == csds_cxx[i].lamc[k]);
+      REQUIRE(csds_fortran[i].qc_tend[k]  == csds_cxx[i].qc_tend[k]);
+      REQUIRE(csds_fortran[i].nc_tend[k]  == csds_cxx[i].nc_tend[k]);
+    }
+    REQUIRE(csds_fortran[i].prt_liq == csds_cxx[i].prt_liq);
+  }
+
 }
 
 };

--- a/components/scream/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
@@ -1,0 +1,50 @@
+#include "catch2/catch.hpp"
+
+#include "share/scream_types.hpp"
+#include "share/util/scream_utils.hpp"
+#include "share/scream_kokkos.hpp"
+#include "share/scream_pack.hpp"
+#include "physics/p3/p3_functions.hpp"
+#include "physics/p3/p3_functions_f90.hpp"
+#include "share/util/scream_kokkos_utils.hpp"
+
+#include "p3_unit_tests_common.hpp"
+
+#include <thread>
+#include <array>
+#include <algorithm>
+#include <random>
+
+namespace scream {
+namespace p3 {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestCloudSed {
+
+static void run_phys()
+{
+  // TODO
+}
+
+static void run_bfb()
+{
+}
+
+};
+
+}
+}
+}
+
+namespace {
+
+TEST_CASE("p3_cloud_sed", "[p3_functions]")
+{
+  using TCS = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCloudSed;
+
+  TCS::run_phys();
+  TCS::run_bfb();
+}
+
+} // namespace

--- a/components/scream/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
@@ -29,6 +29,7 @@ static void run_phys()
 
 static void run_bfb()
 {
+  // TODO
 }
 
 };

--- a/components/scream/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
@@ -31,7 +31,67 @@ static void run_bfb()
 {
   CloudSedData csds_fortran[] = {
     //         kts, kte, ktop, kbot, kdir,        dt,       odt, log_predictNc, prt_liq,
-    CloudSedData(1,  72,   36,   72,   -1, 1.800E+03, 5.556E-04,         false,     0.0,
+    CloudSedData(1,  72,   27,   72,   -1, 1.800E+03, 5.556E-04,         false,     0.0,
+                 std::make_pair(5.100E-03, 9.952E-07), // qc_incld_range
+                 std::make_pair(4.056E-03, 1.153E+00), // rho_range
+                 std::make_pair(0.9, 1.1),             // lcldm_range
+                 std::make_pair(2.959E+07, 5.348E+07), // acn_range
+                 std::make_pair(2.863E-05, 8.141E-03), // inv_dzq_range
+                 std::make_pair(7.701E-16, 2.119E-04), // qc_range
+                 std::make_pair(7.701E-16, 2.119E-04), // nc_range
+                 std::make_pair(9.952E+05, 1.734E+08), // nc_incld_range
+                 std::make_pair(5.722E+00, 1.253E+01), // mu_c_range
+                 std::make_pair(3.381E+05, 2.519E+06), // lamc_range
+                 std::make_pair(9.952E-07, 9.982E-07), // qc_tend_range
+                 std::make_pair(9.952E+05, 1.743E+08)),// nc_tend_range
+
+    //         kts, kte, ktop, kbot, kdir,        dt,       odt, log_predictNc, prt_liq,
+    CloudSedData(1,  72,  72,   27,     1, 1.800E+03, 5.556E-04,         false,     0.0,
+                 std::make_pair(5.100E-03, 9.952E-07), // qc_incld_range
+                 std::make_pair(4.056E-03, 1.153E+00), // rho_range
+                 std::make_pair(0.9, 1.1),             // lcldm_range
+                 std::make_pair(2.959E+07, 5.348E+07), // acn_range
+                 std::make_pair(2.863E-05, 8.141E-03), // inv_dzq_range
+                 std::make_pair(7.701E-16, 2.119E-04), // qc_range
+                 std::make_pair(7.701E-16, 2.119E-04), // nc_range
+                 std::make_pair(9.952E+05, 1.734E+08), // nc_incld_range
+                 std::make_pair(5.722E+00, 1.253E+01), // mu_c_range
+                 std::make_pair(3.381E+05, 2.519E+06), // lamc_range
+                 std::make_pair(9.952E-07, 9.982E-07), // qc_tend_range
+                 std::make_pair(9.952E+05, 1.743E+08)),// nc_tend_range
+
+    //         kts, kte, ktop, kbot, kdir,        dt,       odt, log_predictNc, prt_liq,
+    CloudSedData(1,  72,   27,   72,   -1, 1.800E+03, 5.556E-04,          true,     0.0,
+                 std::make_pair(5.100E-03, 9.952E-07), // qc_incld_range
+                 std::make_pair(4.056E-03, 1.153E+00), // rho_range
+                 std::make_pair(0.9, 1.1),             // lcldm_range
+                 std::make_pair(2.959E+07, 5.348E+07), // acn_range
+                 std::make_pair(2.863E-05, 8.141E-03), // inv_dzq_range
+                 std::make_pair(7.701E-16, 2.119E-04), // qc_range
+                 std::make_pair(7.701E-16, 2.119E-04), // nc_range
+                 std::make_pair(9.952E+05, 1.734E+08), // nc_incld_range
+                 std::make_pair(5.722E+00, 1.253E+01), // mu_c_range
+                 std::make_pair(3.381E+05, 2.519E+06), // lamc_range
+                 std::make_pair(9.952E-07, 9.982E-07), // qc_tend_range
+                 std::make_pair(9.952E+05, 1.743E+08)),// nc_tend_range
+
+    //         kts, kte, ktop, kbot, kdir,        dt,       odt, log_predictNc, prt_liq,
+    CloudSedData(1,  72,  72,   27,     1, 1.800E+03, 5.556E-04,          true,     0.0,
+                 std::make_pair(5.100E-03, 9.952E-07), // qc_incld_range
+                 std::make_pair(4.056E-03, 1.153E+00), // rho_range
+                 std::make_pair(0.9, 1.1),             // lcldm_range
+                 std::make_pair(2.959E+07, 5.348E+07), // acn_range
+                 std::make_pair(2.863E-05, 8.141E-03), // inv_dzq_range
+                 std::make_pair(7.701E-16, 2.119E-04), // qc_range
+                 std::make_pair(7.701E-16, 2.119E-04), // nc_range
+                 std::make_pair(9.952E+05, 1.734E+08), // nc_incld_range
+                 std::make_pair(5.722E+00, 1.253E+01), // mu_c_range
+                 std::make_pair(3.381E+05, 2.519E+06), // lamc_range
+                 std::make_pair(9.952E-07, 9.982E-07), // qc_tend_range
+                 std::make_pair(9.952E+05, 1.743E+08)),// nc_tend_range
+
+    //         kts, kte, ktop, kbot, kdir,        dt,       odt, log_predictNc, prt_liq,
+    CloudSedData(1,  72,  27,   27,    -1, 1.800E+03, 5.556E-04,          true,     0.0,
                  std::make_pair(5.100E-03, 9.952E-07), // qc_incld_range
                  std::make_pair(4.056E-03, 1.153E+00), // rho_range
                  std::make_pair(0.9, 1.1),             // lcldm_range
@@ -52,9 +112,10 @@ static void run_bfb()
   // inout data is in original state
   CloudSedData csds_cxx[num_runs] = {
     CloudSedData(csds_fortran[0]),
-    // CloudSedData(csds_fortran[1]),
-    // CloudSedData(csds_fortran[2]),
-    // CloudSedData(csds_fortran[3]),
+    CloudSedData(csds_fortran[1]),
+    CloudSedData(csds_fortran[2]),
+    CloudSedData(csds_fortran[3]),
+    CloudSedData(csds_fortran[4]),
   };
 
   // Get data from fortran

--- a/components/scream/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
@@ -30,8 +30,8 @@ static void run_phys()
 static void run_bfb()
 {
   CloudSedData csds_fortran[] = {
-    //         kts, kte, ktop, kbot, kdir, dt, odt, log_predictNc, prt_liq,
-    CloudSedData(1,  72,   36,   72,   -1, 0.0, 0.0,        false,     0.0,
+    //         kts, kte, ktop, kbot, kdir,        dt,       odt, log_predictNc, prt_liq,
+    CloudSedData(1,  72,   36,   72,   -1, 1.800E+03, 5.556E-04,         false,     0.0,
                  std::make_pair(5.100E-03, 9.952E-07), // qc_incld_range
                  std::make_pair(4.056E-03, 1.153E+00), // rho_range
                  std::make_pair(0.9, 1.1),             // lcldm_range
@@ -64,7 +64,7 @@ static void run_bfb()
 
   // Get data from cxx
   for (Int i = 0; i < num_runs; ++i) {
-    CloudSedData& d = csds_cxx[num_runs];
+    CloudSedData& d = csds_cxx[i];
     cloud_sedimentation_f(d.kts, d.kte, d.ktop, d.kbot, d.kdir,
                           d.qc_incld, d.rho, d.inv_rho, d.lcldm, d.acn, d.inv_dzq,
                           d.dt, d.odt, d.log_predictNc,
@@ -103,6 +103,8 @@ TEST_CASE("p3_cloud_sed", "[p3_functions]")
 
   TCS::run_phys();
   TCS::run_bfb();
+
+  scream::p3::P3GlobalForFortran::deinit();
 }
 
 } // namespace

--- a/components/scream/src/physics/p3/tests/p3_unit_tests_common.hpp
+++ b/components/scream/src/physics/p3/tests/p3_unit_tests_common.hpp
@@ -65,6 +65,7 @@ struct UnitWrap {
     struct TestGenSed;
     struct TestP3Func;
     struct TestDsd2;
+    struct TestCloudSed;
   };
 
 };


### PR DESCRIPTION
Also,

* Adds new C-compatible logical type to micro_p3 (modeled after rtype).
* Contains some round-off level changes to micro_p3:cloud_sedimentation necessary for BFB results with CXX


