### PR TITLE
Fix for bfb_pow macro in P3

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -43,8 +43,8 @@
 #  define bfb_log10(val) cxx_log10(val)
 #  define bfb_exp(val) cxx_exp(val)
 #else
-#  define bfb_pow(base, exp) base**exp
-#  define bfb_cbrt(base) base**thrd
+#  define bfb_pow(base, exp) (base)**exp
+#  define bfb_cbrt(base) (base)**thrd
 #  define bfb_gamma(val) gamma(val)
 #  define bfb_log(val) log(val)
 #  define bfb_log10(val) log10(val)


### PR DESCRIPTION
Because bfb_pow is a macro, we need parentheses around the input
argument for cases when an expression is passed to the macro.