### PR TITLE
simple fix to workspace tests to remove any dependency on openMP.

### DIFF
--- a/components/scream/src/share/tests/workspace_tests.cpp
+++ b/components/scream/src/share/tests/workspace_tests.cpp
@@ -171,7 +171,7 @@ static void unittest_workspace()
 #ifdef WS_EXPENSIVE_TEST
     if (true)
 #else
-    if ( ExeSpace::concurrency() ) // the test below is expensive, we don't want all threads sweeps to run it
+    if ( ExeSpace::concurrency() == 2 ) // the test below is expensive, we don't want all threads sweeps to run it
 #endif
     {
       // Test weird take/release permutations.

--- a/components/scream/src/share/tests/workspace_tests.cpp
+++ b/components/scream/src/share/tests/workspace_tests.cpp
@@ -1,7 +1,3 @@
-#ifdef _OPENMP
-# include <omp.h>
-#endif
-
 #include <catch2/catch.hpp>
 
 #include "share/scream_workspace.hpp"
@@ -175,7 +171,7 @@ static void unittest_workspace()
 #ifdef WS_EXPENSIVE_TEST
     if (true)
 #else
-    if (omp_get_max_threads() == 2) // the test below is expensive, we don't want all threads sweeps to run it
+    if ( ExeSpace::concurrency() ) // the test below is expensive, we don't want all threads sweeps to run it
 #endif
     {
       // Test weird take/release permutations.


### PR DESCRIPTION
This commit removes the dependency on openMP, allowing the user
to still build in serial.