### PR TITLE
Add scream-mct interface

### DIFF
--- a/components/scream/src/interface/ScreamContext.hpp
+++ b/components/scream/src/interface/ScreamContext.hpp
@@ -1,0 +1,68 @@
+#ifndef SCREAM_CONTEXT_HPP
+#define SCREAM_CONTEXT_HPP
+
+#include "share/util/scream_std_any.hpp"
+#include <map>
+#include <typeindex>
+
+namespace scream
+{
+
+class ScreamContext
+{
+public:
+
+  static ScreamContext& singleton() {
+    static ScreamContext c;
+    return c;
+  }
+
+  template<typename T,typename... Args>
+  T& create (Args... args) {
+    auto key = getKey<T>();
+    scream_require_msg(m_objects.find(key)==m_objects.end(),
+                       "Error! Object with key '" + key.name() + "' was already created in the scream context.\n");
+
+    auto it = m_objects.emplace(key,args...);
+
+    scream_require_msg(it.second, "Error! Something went wrong while creating object with key '" + key.name() + "'.\n");
+    return *it.first;
+
+  }
+
+  template<typename T>
+  const T& get () const {
+    auto key = getKey<T>();
+    scream_require_msg(m_objects.find(key)!=m_objects.end(),
+                       "Error! Object with key '" + key.name() + "' not found in the scream context.\n");
+    return m_objects.at(key);
+  }
+
+  template<typename T>
+  T& getNonConst () const {
+    auto key = getKey<T>();
+    scream_require_msg(m_objects.find(key)!=m_objects.end(),
+                       "Error! Object with key '" + key.name() + "' not found in the scream context.\n");
+    return m_objects.at(key);
+  }
+
+  void clean_up () {
+    m_objects.clear();
+  }
+
+private:
+
+  using key_type = std::type_index;
+
+  ScreamContext () = default;
+
+  // Rely on typeid to get a unique name for each type
+  template<typename T>
+  static key_type getKey() { return std::type_index(typeid(T)); }
+
+  std::map<key_type,util::any>  m_objects;
+};
+
+} // namespace scream
+
+#endif // SCREAM_CONTEXT_HPP

--- a/components/scream/src/interface/atm_comp_mct.F90
+++ b/components/scream/src/interface/atm_comp_mct.F90
@@ -1,5 +1,11 @@
 module atm_comp_mct
 
+  ! These are used across the module, so we issue a single use clause here
+  use mct_mod,         only: mct_aVect
+  use ESMF_ClockMod,   only: ESMF_Clock
+  use seq_cdata_mod,   only: seq_cdata
+  use seq_timemgr_mod, only: seq_timemgr_EClockGetData
+
   implicit none
 
 !--------------------------------------------------------------------------
@@ -15,9 +21,20 @@ contains
 !================================================================================
 
   subroutine atm_init_mct( EClock, cdata_a, x2a_a, a2x_a, NLFilename )
-    use ESM_ClockMod,  only: EClock
-    use seq_cdata_mod, only: seq_cdata
-    use mct_mod,       only: mct_aVect
+    use SHR_KIND_mod, only: SHR_KIND_IN
+    !
+    ! F90<->CXX interfaces
+    !
+    interface
+      subroutine scream_init (f_comm,start_ymd,start_tod) bind(c)
+        use iso_c_binding, only: c_int
+        integer (kind=SHR_KIND_IN) :: start_tod, start_ymd
+        !
+        ! Arguments
+        !
+        integer(kind=c_int), intent(in) :: f_comm
+      end subroutine scream_init
+    end interface
     !
     ! Arguments
     !
@@ -26,17 +43,40 @@ contains
     type(mct_aVect), intent(inout)              :: x2a_a
     type(mct_aVect), intent(inout)              :: a2x_a   
     character(len=*), optional,   intent(IN)    :: NLFilename ! Namelist filename
+    !
+    ! Locals
+    !
+    integer :: f_mpicomm
+    integer (kind=SHR_KIND_IN) :: start_tod, start_ymd
 
     print *, "Hello world, from scream initialization function"
 
+    ! Unpack data stored in cdata_a
+    call seq_cdata_setptrs(cdata_a,mpicom=f_mpicomm)
+
+    ! Get the time clock data
+    ! TODO: what does scream need to init its time stamps?
+    call seq_timemgr_EClockGetData(EClock, start_ymd=start_ymd, start_tod=start_tod)
+
+    ! Init scream
+    call scream_init (f_mpicomm,start_ymd,start_tod)
  end subroutine atm_init_mct
 
 !================================================================================
 
  subroutine atm_run_mct( EClock, cdata_a, x2a_a, a2x_a)
-    use ESM_ClockMod,  only: EClock
-    use seq_cdata_mod, only: seq_cdata
-    use mct_mod,       only: mct_aVect
+    !
+    ! F90<->CXX interfaces
+    !
+    interface
+      subroutine scream_run (dt) bind(c)
+        use iso_c_binding, only: c_double
+        !
+        ! Arguments
+        !
+        integer(kind=c_double), intent(in) :: dt
+      end subroutine scream_run
+    end interface
     !
     ! Arguments
     !
@@ -46,15 +86,21 @@ contains
     type(mct_aVect)             ,intent(inout) :: a2x_a
 
     print *, "Hello world, from scream run function"
+
+    call scream_run(dt)
     
   end subroutine atm_run_mct
 
 !================================================================================
 
   subroutine atm_final_mct( EClock, cdata_a, x2a_a, a2x_a)
-    use ESM_ClockMod,  only: EClock
-    use seq_cdata_mod, only: seq_cdata
-    use mct_mod,       only: mct_aVect
+    !
+    ! F90<->CXX interfaces
+    !
+    interface
+      subroutine scream_finalize () bind(c)
+      end subroutine scream_finalize
+    end interface
     !
     ! Arguments
     !
@@ -64,6 +110,8 @@ contains
     type(mct_aVect)             ,intent(inout) :: a2x_a
 
     print *, "Hello world, from scream finalization function"
+
+    call scream_finalize()
 
   end subroutine atm_final_mct
 

--- a/components/scream/src/interface/atm_comp_mct.F90
+++ b/components/scream/src/interface/atm_comp_mct.F90
@@ -1,0 +1,70 @@
+module atm_comp_mct
+
+  implicit none
+
+!--------------------------------------------------------------------------
+! Public interfaces
+!--------------------------------------------------------------------------
+
+  public :: atm_init_mct
+  public :: atm_run_mct
+  public :: atm_final_mct
+
+contains
+
+!================================================================================
+
+  subroutine atm_init_mct( EClock, cdata_a, x2a_a, a2x_a, NLFilename )
+    use ESM_ClockMod,  only: EClock
+    use seq_cdata_mod, only: seq_cdata
+    use mct_mod,       only: mct_aVect
+    !
+    ! Arguments
+    !
+    type(ESMF_Clock),intent(inout)              :: EClock
+    type(seq_cdata), intent(inout)              :: cdata_a
+    type(mct_aVect), intent(inout)              :: x2a_a
+    type(mct_aVect), intent(inout)              :: a2x_a   
+    character(len=*), optional,   intent(IN)    :: NLFilename ! Namelist filename
+
+    print *, "Hello world, from scream initialization function"
+
+ end subroutine atm_init_mct
+
+!================================================================================
+
+ subroutine atm_run_mct( EClock, cdata_a, x2a_a, a2x_a)
+    use ESM_ClockMod,  only: EClock
+    use seq_cdata_mod, only: seq_cdata
+    use mct_mod,       only: mct_aVect
+    !
+    ! Arguments
+    !
+    type(ESMF_Clock)            ,intent(inout) :: EClock
+    type(seq_cdata)             ,intent(inout) :: cdata_a
+    type(mct_aVect)             ,intent(inout) :: x2a_a
+    type(mct_aVect)             ,intent(inout) :: a2x_a
+
+    print *, "Hello world, from scream run function"
+    
+  end subroutine atm_run_mct
+
+!================================================================================
+
+  subroutine atm_final_mct( EClock, cdata_a, x2a_a, a2x_a)
+    use ESM_ClockMod,  only: EClock
+    use seq_cdata_mod, only: seq_cdata
+    use mct_mod,       only: mct_aVect
+    !
+    ! Arguments
+    !
+    type(ESMF_Clock)            ,intent(inout) :: EClock
+    type(seq_cdata)             ,intent(inout) :: cdata_a
+    type(mct_aVect)             ,intent(inout) :: x2a_a
+    type(mct_aVect)             ,intent(inout) :: a2x_a
+
+    print *, "Hello world, from scream finalization function"
+
+  end subroutine atm_final_mct
+
+end module atm_comp_mct

--- a/components/scream/src/interface/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/interface/scream_cxx_f90_interface.cpp
@@ -1,0 +1,57 @@
+#include "interface/ScreamContext.hpp"
+#include "control/atmosphere_driver.hpp"
+#include "share/mpi/scream_comm.hpp"
+#include "share/parameter_list.hpp"
+
+extern "C"
+{
+
+void scream_init (const MPI_Fint& f_comm, const int& start_ymd, const int& start_tod) {
+  // // Get the context
+  // auto& c = scream::ScreamContext::singleton();
+
+  // // Create the C MPI_Comm from the Fortran one
+  // MPI_Comm mpi_comm_c = MPI_Comm_f2c(f_comm);
+  // auto& comm = c.create<scream::Comm>(mpi_comm_c);
+
+  // // Fill the params, somehow
+  // scream::ParameterList ad_params;
+
+  // // Init the initial time, somehow
+  // // You probably need more than yymmdd to init the time stamp
+  // // E.g: you have to formalize switches for leap/nonleap years
+  // scream::util::TimeStamp t0;
+
+  // // Create the bare ad, then init it
+  // // TODO: uncomment once you have valid inputs. I fear AD may crash with no inputs.
+  // auto& ad = c.create<scream::control::AtmosphereDriver>();
+  // ad.initialize(comm, ad_params, t0);
+
+  (void) start_ymd;
+  (void) start_tod;
+  (void) f_comm;
+}
+
+void scream_run (const double& dt) {
+  // TODO: uncomment once you have valid inputs. I fear AD may crash with no inputs.
+
+  // // Get the context
+  // auto& c = scream::ScreamContext::singleton();
+
+  // // Get the AD, and run it
+  // auto& ad = c.getNonConst<scream::control::AtmosphereDriver>();
+  // ad.run(dt);
+  (void) dt;
+}
+
+void scream_finalize (/* args ? */) {
+  // TODO: uncomment once you have valid inputs. I fear AD may crash with no inputs.
+  // // Get the context
+  // auto& c = scream::ScreamContext::singleton();
+
+  // // Get the AD, and finalize it
+  // auto& ad = c.getNonConst<scream::control::AtmosphereDriver>();
+  // ad.finalize();
+}
+
+} // extern "C"


### PR DESCRIPTION
Adds stub files (for now) for hooking up scream to mct.

Even if the hooks (init/run/final) are mostly empty, it will allow to see if scream can build within e3sm. In time, the body of those subroutines will grow, as we hook up scream and the AD infrastructure.

I _believe_ this file (with the init/run/final subroutines) is all the interface mct expects from scream.