### PR TITLE
Add fast fail option to test-all-scream

### DIFF
--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -37,6 +37,8 @@ OR
 
     parser.add_argument("-s", "--submit", action="store_true", help="Submit results to dashboad, requires machine")
 
+    parser.add_argument("-f", "--fast-fail", action="store_true", help="Stop testing when the first failure is detected")
+
     default_baseline = "HEAD" if "JENKINS_HOME" in os.environ else "origin/master"
     parser.add_argument("-b", "--baseline", default=default_baseline,
                         help="What commit to use to generate baselines")

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -8,11 +8,12 @@ class TestAllScream(object):
 ###############################################################################
 
     ###########################################################################
-    def __init__(self, cxx, kokkos, submit, baseline, machine, custom_cmake_opts, tests):
+    def __init__(self, cxx, kokkos, submit, fast_fail, baseline, machine, custom_cmake_opts, tests):
     ###########################################################################
         self._cxx               = cxx
         self._kokkos            = kokkos
         self._submit            = submit
+        self._fast_fail         = fast_fail
         self._baseline          = baseline
         self._machine           = machine
         self._custom_cmake_opts = custom_cmake_opts
@@ -145,11 +146,13 @@ class TestAllScream(object):
             if not self._tests or "dbg" in self._tests:
                 success &= self.run_test([("CMAKE_BUILD_TYPE", "Debug")],
                                          [], "full_debug", git_head)
+                if not success and self._fast_fail: return success
 
             # A full debug single precision
             if not self._tests or "sp" in self._tests:
                 success &= self.run_test([("CMAKE_BUILD_TYPE", "Debug"), ("SCREAM_DOUBLE_PRECISION", "False")],
                                          [], "full_sp_debug", git_head)
+                if not success and self._fast_fail: return success
 
             # A full debug test with packsize=1 and FPE
             if not self._tests or "fpe" in self._tests:


### PR DESCRIPTION
@bartgol , since you asked for this, and it was very easy to do, I went ahead and added it.

That said, I would use this with a bit of caution. If a PR is not BFB, say it adds a round-off-level change, then test-all-scream will fail. If fast-fail is on, then the first test configuration will fail and terminate the testing, potentially hiding more serious failures in the single-precision or fpe runs.