### PR TITLE
get summit working

### DIFF
--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -31,7 +31,7 @@ MACHINE_METADATA = {
                   "salloc --partition=pdebug"),
     "summit" : (["module purge", "module load cmake/3.15.2 gcc/6.4.0 spectrum-mpi/10.3.0.1-20190611 cuda/10.1.168 python/3.6.6-anaconda3-5.3.0"],
                 "$(which mpicxx)",
-                "bsub -I -q batch -W 0:10 -P cli115 -nnodes 1"),
+                "bsub -I -q batch -W 0:30 -P cli115 -nnodes 1"),
 }
 
 ###############################################################################

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -29,6 +29,9 @@ MACHINE_METADATA = {
     "syrah"  : (["module purge", "module load StdEnv cmake/3.14.5 mkl/2019.0 intel/19.0.4 netcdf-fortran/4.4.4 netcdf/4.4.1.1"],
                   "$(which mpicxx)",
                   "salloc --partition=pdebug"),
+    "summit" : (["module purge", "module load cmake/3.15.2 gcc/6.4.0 spectrum-mpi/10.3.0.1-20190611 cuda/10.1.168 python/3.6.6-anaconda3-5.3.0"],
+                "$(which mpicxx)",
+                "bsub -I -q batch -W 0:10 -P cli115 -nnodes 1"),
 }
 
 ###############################################################################

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -102,33 +102,17 @@ class TestAllScream(object):
         return baseline_files, datas
 
     ###############################################################################
-    def safe_remove_all(self):
-    ###############################################################################
-        import time
-        rm_stat = 1
-        while rm_stat != 0:
-            time.sleep(1)
-            rm_stat = run_cmd("/bin/rm -rf *")[0]
-            if rm_stat != 0:
-                remaining_files = run_cmd_no_fail("find . -type f")
-                processes = run_cmd_no_fail("ps -u acmetest")
-                lsof_out = run_cmd_no_fail("lsof -u acmetest")
-                print("Lsof out:\n{}\n\n".format(lsof_out))
-                print("Had trouble removing: {}".format(remaining_files))
-                print("Active processes: {}".format(processes))
-
-    ###############################################################################
     def run_test(self, extra_cmake_configs, extra_ctest_configs, build_name, git_head):
     ###############################################################################
         cmake_config = self.generate_cmake_config(extra_cmake_configs)
 
         # Clean out whatever might have been left in the build area from
-        # previous tests
-        self.safe_remove_all()
+        # previous tests. This command can sometimes fail due to .nfs files
+        run_cmd("/bin/rm -rf *")
 
         if ("BUILD_ONLY", "True") not in extra_ctest_configs:
             filepaths, datas = self.generate_baselines(cmake_config, git_head)
-            self.safe_remove_all() # Clean out baseline build
+            run_cmd("/bin/rm -rf *") # Clean out baseline build
             for filepath, data in zip(filepaths, datas):
                 if not os.path.isdir(os.path.dirname(filepath)):
                     os.makedirs(os.path.dirname(filepath))

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -110,6 +110,7 @@ class TestAllScream(object):
             if rm_stat != 0:
                 remaining_files = run_cmd_no_fail("find . -type f")
                 processes = run_cmd_no_fail("ps -u acmetest")
+                lsof_out = run_cmd_no_fail("lsof {}".format(" ".join(remaining_files.splitlines())))
                 print("Had trouble removing: {}".format(remaining_files))
                 print("Active processes: {}".format(processes))
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -1,7 +1,7 @@
 from utils import run_cmd, check_minimum_python_version, get_current_head, run_cmd_no_fail, get_current_commit
 check_minimum_python_version(3, 4)
 
-import os, shutil
+import os, shutil, time
 
 ###############################################################################
 class TestAllScream(object):
@@ -104,6 +104,9 @@ class TestAllScream(object):
     ###############################################################################
     def run_test(self, extra_cmake_configs, extra_ctest_configs, build_name, git_head):
     ###############################################################################
+        # Wait a few seconds between tests
+        time.sleep(5)
+
         cmake_config = self.generate_cmake_config(extra_cmake_configs)
 
         # Clean out whatever might have been left in the build area from

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -109,7 +109,9 @@ class TestAllScream(object):
             rm_stat = run_cmd("/bin/rm -rf *")[0]
             if rm_stat != 0:
                 remaining_files = run_cmd_no_fail("find . -type f")
+                processes = run_cmd_no_fail("ps -u acmetest")
                 print("Had trouble removing: {}".format(remaining_files))
+                print("Active processes: {}".format(processes))
 
     ###############################################################################
     def run_test(self, extra_cmake_configs, extra_ctest_configs, build_name, git_head):

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -102,7 +102,7 @@ class TestAllScream(object):
         return baseline_files, datas
 
     ###############################################################################
-    def safe_remove_all():
+    def safe_remove_all(self):
     ###############################################################################
         rm_stat = 1
         while rm_stat != 0:
@@ -111,7 +111,6 @@ class TestAllScream(object):
                 remaining_files = run_cmd_no_fail("find . -type f")
                 print("Had trouble removing: {}".format(remaining_files))
 
-
     ###############################################################################
     def run_test(self, extra_cmake_configs, extra_ctest_configs, build_name, git_head):
     ###############################################################################
@@ -119,11 +118,11 @@ class TestAllScream(object):
 
         # Clean out whatever might have been left in the build area from
         # previous tests
-        safe_remove_all()
+        self.safe_remove_all()
 
         if ("BUILD_ONLY", "True") not in extra_ctest_configs:
             filepaths, datas = self.generate_baselines(cmake_config, git_head)
-            safe_remove_all() # Clean out baseline build
+            self.safe_remove_all() # Clean out baseline build
             for filepath, data in zip(filepaths, datas):
                 if not os.path.isdir(os.path.dirname(filepath)):
                     os.makedirs(os.path.dirname(filepath))

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -1,7 +1,7 @@
 from utils import run_cmd, check_minimum_python_version, get_current_head, run_cmd_no_fail, get_current_commit
 check_minimum_python_version(3, 4)
 
-import os, shutil, time
+import os, shutil
 
 ###############################################################################
 class TestAllScream(object):
@@ -102,20 +102,28 @@ class TestAllScream(object):
         return baseline_files, datas
 
     ###############################################################################
+    def safe_remove_all():
+    ###############################################################################
+        rm_stat = 1
+        while rm_stat != 0:
+            rm_stat = run_cmd("/bin/rm -rf *")[0]
+            if rm_stat != 0:
+                remaining_files = run_cmd_no_fail("find . -type f")
+                print("Had trouble removing: {}".format(remaining_files))
+
+
+    ###############################################################################
     def run_test(self, extra_cmake_configs, extra_ctest_configs, build_name, git_head):
     ###############################################################################
-        # Wait a few seconds between tests
-        time.sleep(5)
-
         cmake_config = self.generate_cmake_config(extra_cmake_configs)
 
         # Clean out whatever might have been left in the build area from
         # previous tests
-        run_cmd_no_fail("/bin/rm -rf *")
+        safe_remove_all()
 
         if ("BUILD_ONLY", "True") not in extra_ctest_configs:
             filepaths, datas = self.generate_baselines(cmake_config, git_head)
-            run_cmd_no_fail("/bin/rm -rf *") # Clean out baseline build
+            safe_remove_all() # Clean out baseline build
             for filepath, data in zip(filepaths, datas):
                 if not os.path.isdir(os.path.dirname(filepath)):
                     os.makedirs(os.path.dirname(filepath))

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -104,13 +104,16 @@ class TestAllScream(object):
     ###############################################################################
     def safe_remove_all(self):
     ###############################################################################
+        import time
         rm_stat = 1
         while rm_stat != 0:
+            time.sleep(1)
             rm_stat = run_cmd("/bin/rm -rf *")[0]
             if rm_stat != 0:
                 remaining_files = run_cmd_no_fail("find . -type f")
                 processes = run_cmd_no_fail("ps -u acmetest")
                 lsof_out = run_cmd_no_fail("lsof -u acmetest")
+                print("Lsof out:\n{}\n\n".format(lsof_out))
                 print("Had trouble removing: {}".format(remaining_files))
                 print("Active processes: {}".format(processes))
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -110,7 +110,7 @@ class TestAllScream(object):
             if rm_stat != 0:
                 remaining_files = run_cmd_no_fail("find . -type f")
                 processes = run_cmd_no_fail("ps -u acmetest")
-                lsof_out = run_cmd_no_fail("lsof {}".format(" ".join(remaining_files.splitlines())))
+                lsof_out = run_cmd_no_fail("lsof -u acmetest")
                 print("Had trouble removing: {}".format(remaining_files))
                 print("Active processes: {}".format(processes))
 


### PR DESCRIPTION
Sorry for the hold up. There was some kind of bad interaction between cmake and summit's NFS file system that significantly delayed this PR. I eventually decided that it's harmless enough to ignore and to move on.

This now works for me:
```
./scream/components/scream/scripts/gather-all-data './scripts/test-all-scream $compiler -m $machine' -l -m summit
```

This implies that test_all_scream will work assuming the environment stuff I added to gather_all_data is loaded and OMPI_CXX is set.