### PR TITLE
Add release_many_contiguous to Workspace

### DIFF
--- a/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cloud_sed_impl.hpp
@@ -36,7 +36,7 @@ void Functions<S,D>
 {
   // Get temporary workspaces needed for the cloud-sed calculation
   uview_1d<Spack> V_qc, V_nc, flux_qx, flux_nx;
-  workspace.template take_many<4>(
+  workspace.template take_many_contiguous_unsafe<4>(
     {"V_qc", "V_nc", "flux_qx", "flux_nx"},
     {&V_qc, &V_nc, &flux_qx, &flux_nx});
 
@@ -127,10 +127,8 @@ void Functions<S,D>
       nc_tend(pk) = (nc(pk) - nc_tend(pk)) * odt; // Liq. # sedimentation tendency, measure
   });
 
-  workspace.release(V_qc);
-  workspace.release(V_nc);
-  workspace.release(flux_qx);
-  workspace.release(flux_nx);
+  workspace.template release_many_contiguous<4>(
+    {&V_qc, &V_nc, &flux_qx, &flux_nx});
 }
 
 } // namespace p3

--- a/components/scream/src/share/scream_workspace.hpp
+++ b/components/scream/src/share/scream_workspace.hpp
@@ -129,6 +129,11 @@ class WorkspaceManager
     void release(const View& space, std::enable_if<View::rank == 1>* = 0) const
     { release_impl<typename View::value_type>(space); }
 
+    // Release several contiguous sub-blocks.
+    template <size_t N, typename S=T>
+    KOKKOS_INLINE_FUNCTION
+    void release_many_contiguous(const view_1d_ptr_array<S, N>& ptrs) const;
+
 #ifndef NDEBUG
     // Get the name of a sub-block
     template <typename View>
@@ -197,8 +202,8 @@ class WorkspaceManager
 
     const WorkspaceManager& m_parent;
     const MemberType& m_team;
-    const int m_ws_idx;
-    int& m_next_slot;
+    const int m_ws_idx; // Workspace idx for m_team
+    int& m_next_slot; // the next free ws slot to allocate
   }; // class Workspace
 
 #ifndef KOKKOS_ENABLE_CUDA

--- a/components/scream/src/share/tests/workspace_tests.cpp
+++ b/components/scream/src/share/tests/workspace_tests.cpp
@@ -152,15 +152,19 @@ static void unittest_workspace()
 
       team.team_barrier();
 
-      if (r % 4 == 2) {
-        // let take_and_reset do the reset
-      }
-      else if (r % 2 == 0) {
+      if (r % 4 == 0) {
         ws.reset();
       }
-      else {
+      else if (r % 4 == 1) {
+        Kokkos::Array<ko::Unmanaged<view_1d<int> >*, num_ws> ptrs = { {&wssub[0], &wssub[1], &wssub[2], &wssub[3]} };
+        ws.release_many_contiguous(ptrs);
+      }
+      else if (r % 4 == 2) {
+        // let take_and_reset next loop do the reset
+      }
+      else { // % 4 == 3
         for (int w = num_ws - 1; w >= 0; --w) {
-          ws.release(wssub[w]);
+          ws.release(wssub[w]); // release individually
         }
       }
 


### PR DESCRIPTION
Makes it faster and less cumbersome to release several workspaces.

Cloud-sed (and all future conversions) should use take_many_contig and release_many_contig.