### PR TITLE
Fix a bug in P3 microphysics which still relied on the variable `it`

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -932,7 +932,7 @@ contains
           !.................................................................
           ! droplet activation
           call droplet_activation(t(i,k),pres(i,k),qv(i,k),qc(i,k),inv_rho(i,k),&
-             sup(i,k),xxlv(i,k),npccn(i,k),log_predictNc,odt,it,&
+             sup(i,k),xxlv(i,k),npccn(i,k),log_predictNc,odt,&
              qcnuc,ncnuc)
 
           !................
@@ -2597,7 +2597,7 @@ subroutine ice_nucleation(t,inv_rho,nitot,naai,supi,odt,log_predictNc,    &
 end subroutine
 
 
-subroutine droplet_activation(t,pres,qv,qc,inv_rho,sup,xxlv,npccn,log_predictNc,odt,it,    &
+subroutine droplet_activation(t,pres,qv,qc,inv_rho,sup,xxlv,npccn,log_predictNc,odt,    &
    qcnuc,ncnuc)
 
 
@@ -2614,7 +2614,6 @@ real(rtype), intent(in) :: npccn
 
 logical(btype), intent(in) :: log_predictNc
 real(rtype), intent(in)  :: odt
-integer, intent(in) :: it
 
 real(rtype), intent(inout) :: qcnuc
 real(rtype), intent(inout) :: ncnuc
@@ -2629,14 +2628,10 @@ real(rtype) :: dum, dumqvs, dqsdt, ab
       ! note that this is also applied at the first time step
       if (sup.gt.1.e-6) then
          ncnuc = npccn
-         if (it.eq.1) then
-            qcnuc = 0._rtype
-         else
-            !TODO Limit qcnuc so that conditions never become sub-saturated
-            qcnuc = ncnuc*cons7
-         endif
+         !TODO Limit qcnuc so that conditions never become sub-saturated
+         qcnuc = ncnuc*cons7
       endif
-   else if (sup.gt.1.e-6.and.it.gt.1) then
+   else if (sup.gt.1.e-6) then
      ! for specified Nc, make sure droplets are present if conditions are supersaturated
      ! this is not applied at the first time step, since saturation adjustment is applied at the first step
       dum   = nccnst*inv_rho*cons7-qc

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -801,6 +801,7 @@ end subroutine micro_p3_readnl
   !================================================================================================
   subroutine micro_p3_tend(state, ptend, dtime, pbuf)
 
+    use time_manager,   only: get_nstep
     use cam_history,    only: outfld
     use physics_buffer, only: pbuf_col_type_index
     use micro_p3,       only: p3_main
@@ -1088,12 +1089,7 @@ end subroutine micro_p3_readnl
     !yet. E3SM has a handy function for deciding if this is the first step, so 
     !we hack "it" with "is_first_step()" for now. Eventually, we should replace
     !"it" with a logical.
-
-    if (is_first_step()) then
-       it=1
-    else
-       it=999 !integer
-    end if
+    it = get_nstep()
 
     ! MAKE LOCAL COPIES OF VARS MODIFIED BY P3
     !==============


### PR DESCRIPTION
P3 still had one location where nstep (var=it) was used to determine 
if an action would be done.

This logic was originally in P3 because P3 handled the saturation
adjustment and had to take different actions depending on whether
or not it was the first step (it=1) or any other step (it>1).

In scream we removed the saturation adjustment from p3 so this is
no longer a distinction that is needed.

Should be BFB, but presumably could see a slight change to the first
step.  And of course any subsequent step because of the propagation
of that difference.