### PR TITLE
Fix for variable mu_c which is not properly initialized.

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -604,6 +604,9 @@ contains
     inv_icldm = 1.0_rtype/icldm
     inv_lcldm = 1.0_rtype/lcldm
     inv_rcldm = 1.0_rtype/rcldm
+
+    mu_c = 0.0_rtype
+    lamc = 0.0_rtype
     ! AaronDonahue added exner term to replace all instances of th(i,k)/t(i,k), since th(i,k) is updated but t(i,k) is not, and this was
     ! causing energy conservation errors.
     inv_exner = 1._rtype/exner        !inverse of Exner expression, used when converting potential temp to temp

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -1118,9 +1118,9 @@ end subroutine micro_p3_readnl
     kte     = pver
     pres    = state%pmid(:,:)
     ! Initialize the raidation dependent variables.
-    mu      = mucon
-    lambdac = (mucon + 1._rtype)/dcon
-    dei     = deicon
+    mu      = 0.0_rtype !mucon
+    lambdac = 0.0_rtype !(mucon + 1._rtype)/dcon
+    dei     = 50.0_rtype !deicon
     ! Determine the cloud fraction and precip cover
     icldm(:,:) = 1.0_rtype
     lcldm(:,:) = 1.0_rtype


### PR DESCRIPTION
This fix should address diffs that we were seeing between the C++
and Fortran implementation of P3, since the C++ version does in fact
initialize mu_c properly.