### PR TITLE
Update the P3 debug warnings

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -360,7 +360,7 @@ contains
        diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,  &
        pratot,prctot,p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
-       vap_ice_exchange,vap_cld_exchange)
+       vap_ice_exchange,vap_cld_exchange,col_location)
 
     !----------------------------------------------------------------------------------------!
     !                                                                                        !
@@ -438,6 +438,7 @@ contains
     ! so that they can be written as ouput.  NOTE TO C++ PORT: This variable is entirely optional and doesn't need to be
     ! included in the port to C++, or can be changed if desired.
     real(rtype), intent(out),   dimension(its:ite,kts:kte,49)   :: p3_tend_out ! micro physics tendencies
+    real(rtype), intent(in),    dimension(its:ite,2)            :: col_location
     !----- Local variables and parameters:  -------------------------------------------------!
 
     real(rtype), dimension(its:ite,kts:kte) :: mu_r  ! shape parameter of rain
@@ -553,7 +554,7 @@ contains
 
 
     !--These will be added as namelist parameters in the future
-    logical(btype), parameter :: debug_ON     = .false.  !.true. to switch on debugging checks/traps throughout code
+    logical(btype), parameter :: debug_ON     = .true.  !.true. to switch on debugging checks/traps throughout code  TODO: Turn this back off as default once the tlay error is found.
     logical(btype), parameter :: debug_ABORT  = .false.  !.true. will result in forced abort in s/r 'check_values'
 
     !-----------------------------------------------------------------------------------!
@@ -618,7 +619,7 @@ contains
     !-----------------------------------------------------------------------------------!
     i_loop_main: do i = its,ite  ! main i-loop (around the entire scheme)
 
-       if (debug_ON) call check_values(qv,T,i,it,debug_ABORT,100)
+       if (debug_ON) call check_values(qv,T,i,it,debug_ABORT,100,col_location)
 
 
        log_hydrometeorsPresent = .false.
@@ -714,7 +715,7 @@ contains
 
        if (debug_ON) then
           tmparr1(i,:) = th(i,:)*inv_exner(i,:)!(pres(i,:)*1.e-5)**(rd*inv_cp)
-          call check_values(qv,tmparr1,i,it,debug_ABORT,200)
+          call check_values(qv,tmparr1,i,it,debug_ABORT,200,col_location)
 
        endif
 
@@ -1132,7 +1133,7 @@ contains
 
        if (debug_ON) then
           tmparr1(i,:) = th(i,:)*inv_exner(i,:)!(pres(i,:)*1.e-5)**(rd*inv_cp)
-          call check_values(qv,tmparr1,i,it,debug_ABORT,300)
+          call check_values(qv,tmparr1,i,it,debug_ABORT,300,col_location)
        endif
 
        if (.not. log_hydrometeorsPresent) goto 333
@@ -1289,7 +1290,7 @@ contains
 
        enddo k_loop_final_diagnostics
 
-       !   if (debug_ON) call check_values(qv,Ti,it,debug_ABORT,800)
+       !   if (debug_ON) call check_values(qv,Ti,it,debug_ABORT,800,col_location)
 
        !..............................................
        ! merge ice categories with similar properties
@@ -1305,7 +1306,7 @@ contains
 
        if (debug_ON) then
           tmparr1(i,:) = th(i,:)*inv_exner(i,:)!(pres(i,:)*1.e-5)**(rd*inv_cp)
-          call check_values(qv,tmparr1,i,it,debug_ABORT,900)
+          call check_values(qv,tmparr1,i,it,debug_ABORT,900,col_location)
        endif
 
        !.....................................................
@@ -1977,7 +1978,7 @@ contains
 
   !===========================================================================================
 
-  subroutine check_values(Qv,T,i,timestepcount,force_abort,source_ind)
+  subroutine check_values(Qv,T,i,timestepcount,force_abort,source_ind,col_loc)
 
     !------------------------------------------------------------------------------------
     ! Checks current values of prognotic variables for reasonable values and
@@ -1998,7 +1999,7 @@ contains
     implicit none
 
     !Calling parameters:
-    real(rtype), dimension(:,:),   intent(in) :: Qv,T
+    real(rtype), dimension(:,:),   intent(in) :: Qv,T,col_loc
     integer,                intent(in) :: source_ind,i,timestepcount
     logical(btype),                intent(in) :: force_abort         !.TRUE. = forces abort if value violation is detected
 
@@ -2021,14 +2022,13 @@ contains
 
        ! check unrealistic values or NANs for T and Qv
        if (.not.(T(i,k)>T_low .and. T(i,k)<T_high)) then
-          write(6,'(a41,4i5,1e15.6)') '** WARNING IN P3_MAIN -- src,i,k,step,T: ',      &
-               source_ind,i,k,timestepcount,T(i,k)
+          write(iulog,'(a60,i5,a2,i8,a2,f8.4,a2,f8.4,a2,i4,a2,i8,a2,e16.8)') &
+             '** WARNING IN P3_MAIN -- src, gcol, lon, lat, lvl, tstep, T:',source_ind,', ',int(col_loc(i,1)),', ',col_loc(i,2),', ',col_loc(i,3),', ',k,', ',timestepcount,', ',T(i,k)
           trap = .true.
        endif
        if (.not.(Qv(i,k)>=0. .and. Qv(i,k)<Q_high)) then
-          write(6,'(a42,4i5,1e15.6)') '** WARNING IN P3_MAIN -- src,i,k,step,Qv: ',     &
-               source_ind,i,k,timestepcount,Qv(i,k)
-
+          write(iulog,'(a60,i5,a2,i8,a2,f8.4,a2,f8.4,a2,i4,a2,i8,a2,e16.8)') &
+             '** WARNING IN P3_MAIN -- src, gcol, lon, lat, lvl, tstep, Qv:',source_ind,', ',int(col_loc(i,1)),', ',col_loc(i,2),', ',col_loc(i,3),', ',k,', ',timestepcount,', ',Qv(i,k)
           !trap = .true.  !note, tentatively no trap, since Qv could be negative passed in to mp
        endif
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -438,7 +438,7 @@ contains
     ! so that they can be written as ouput.  NOTE TO C++ PORT: This variable is entirely optional and doesn't need to be
     ! included in the port to C++, or can be changed if desired.
     real(rtype), intent(out),   dimension(its:ite,kts:kte,49)   :: p3_tend_out ! micro physics tendencies
-    real(rtype), intent(in),    dimension(its:ite,2)            :: col_location
+    real(rtype), intent(in),    dimension(its:ite,3)            :: col_location
     !----- Local variables and parameters:  -------------------------------------------------!
 
     real(rtype), dimension(its:ite,kts:kte) :: mu_r  ! shape parameter of rain

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -134,12 +134,18 @@ contains
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_ice_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_cld_exchange
 
+    real(kind=c_real), dimension(its:ite,3) :: col_location
+    integer :: i,k
+    do i = its,ite
+      col_location(i,:) = real(i)
+    end do
+
     call p3_main(qc,nc,qr,nr,th,qv,dt,qitot,qirim,nitot,birim,   &
          pres,dzq,npccn,naai,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
          diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
          pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm, &
          pratot,prctot,p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
-         vap_ice_exchange, vap_cld_exchange)
+         vap_ice_exchange, vap_cld_exchange,col_location)
   end subroutine p3_main_c
 
   subroutine p3_use_cxx_c(arg_use_cxx) bind(C)

--- a/components/scream/src/physics/p3/scream_p3_interface.F90
+++ b/components/scream/src/physics/p3/scream_p3_interface.F90
@@ -171,7 +171,9 @@ contains
     real(kind=c_real) :: vap_ice_exchange(pcols,pver) ! sum of vap-ice phase change tendenices
     real(kind=c_real) :: vap_cld_exchange(pcols,pver) ! sum of vap-cld phase change tendenices
 
-    real(kind=c_real) :: inv_cp 
+    real(kind=c_real) :: inv_cp
+
+    real(kind=c_real) :: col_location(pcols,3) 
 
     ! For rrtmg optics. specified distribution.
     real(kind=c_real), parameter :: dcon   = 25.e-6_rtype      ! Convective size distribution effective radius (um)
@@ -227,6 +229,7 @@ contains
         qirim(:,k)   = q(i,k,8) !1.0e-8_rtype!state%q(:,:,ixcldrim) !Aaron, changed ixqirim to ixcldrim to match Kai's code
         rimvol(:,k)  = q(i,k,9) !1.0e4_rtype!state%q(:,:,ixrimvol)
       end do
+      col_location(i,:) = real(i)
     end do 
 
 !    do k = kte,kts,-1 
@@ -307,7 +310,8 @@ contains
          liq_ice_exchange(its:ite,kts:kte),& ! OUT sum of liq-ice phase change tendenices   
          vap_liq_exchange(its:ite,kts:kte),& ! OUT sun of vap-liq phase change tendencies
          vap_ice_exchange(its:ite,kts:kte),& ! OUT sum of vap-ice phase change tendencies
-         vap_cld_exchange(its:ite,kts:kte) & ! OUT sum of vap-cld phase change tendencies
+         vap_cld_exchange(its:ite,kts:kte),& ! OUT sum of vap-cld phase change tendencies
+         col_location(its:ite,3)           & ! IN location of columns
          )
     do i = its,ite
       do k = kts,kte


### PR DESCRIPTION
Update the P3 debug warnings to include actual column location information, and timestep of occurrence.

Note, this is not equivalent to an error that occurs with a debug build.  There is a hardcoded "debug" bool in P3 that will either print or suppress warnings.  

[BFB]