### PR TITLE
Add additional temperature debugging for RRTMGP

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -480,6 +480,9 @@
 <rrtmgp_coefficients_file_lw rad="rrtmgp">atm/cam/rad/rrtmgp_coefficients_lw_c181004.nc</rrtmgp_coefficients_file_lw>
 <rrtmgp_coefficients_file_sw rad="rrtmgp">atm/cam/rad/rrtmgp_coefficients_sw_c181004.nc</rrtmgp_coefficients_file_sw>
 
+<!-- flag for clipping temperatures -->
+<rrtmgp_clip_temperatures rad="rrtmgp">.false.</rrtmgp_clip_temperatures>
+
 <!-- CAM-RT absorptivity/emissivity lookup table -->
 <absems_data>atm/cam/rad/abs_ems_factors_fastvx.c030508.nc</absems_data>
 

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -4290,6 +4290,11 @@ File path for RRTMGP longwave gaseous absorption coefficients file.
 File path for RRTMGP shortwave gaseous absorption coefficients file.
 </entry>
 
+<entry id="rrtmgp_clip_temperatures" type="logical"
+       category="radiation" group="radiation_nl" valid_values="">
+Flag to determine whether temperatures should be clipped or limited when
+outside the range of the absorption coefficient look-up table values.
+</entry>
 <!-- Rayleigh Friction Parameterization -->
 
 <entry id="rayk0" type="integer" category="rayleigh_friction"

--- a/components/cam/src/physics/rrtmgp/assertions.F90
+++ b/components/cam/src/physics/rrtmgp/assertions.F90
@@ -7,7 +7,7 @@ module assertions
    private
 
    ! This module provides the following public routines
-   public :: assert_valid, assert_range, assert, check_range
+   public :: assert_valid, assert_range, assert
 
    ! Interface blocks to allow overloading procedures
    interface assert_valid
@@ -21,13 +21,6 @@ module assertions
                        assert_range_integer_1d, &
                        assert_range_integer_2d
    end interface
-
-   ! Procedure to check range, with extra arguments to get lat/lon location
-   ! where errors occur
-   interface check_range
-      module procedure check_range_2d, check_range_3d
-   end interface
-
 
 contains
 
@@ -197,56 +190,6 @@ contains
          call endrun('Assertion failed: ' // message)
       end if
    end subroutine
-   !-------------------------------------------------------------------------------
-
-   !-------------------------------------------------------------------------------
-   subroutine check_range_2d(state, v, vmin, vmax, vname)
-      use physconst, only: pi
-      use physics_types, only: physics_state
-      use cam_abortutils, only: endrun
-      type(physics_state), intent(in) :: state
-      real(r8), intent(in) :: v(:,:), vmin, vmax
-      character(len=*), intent(in) :: vname
-      real(r8) :: lat, lon
-      integer :: ix, iz
-      do iz = 1,size(v, 2)
-         do ix = 1,size(v, 1)
-            if (v(ix,iz) < vmin .or. v(ix,iz) > vmax) then
-               lat = state%lat(ix) * 180._r8 / pi
-               lon = state%lon(ix) * 180._r8 / pi
-               print *, 'Variable ' // trim(vname) // &
-                        ' out of range; value = ', v(ix,iz), &
-                        '; lat/lon = ', lat, lon
-               call endrun('check_range failed for ' // trim(vname))
-            end if
-         end do
-      end do
-   end subroutine check_range_2d
-   !-------------------------------------------------------------------------------
-   subroutine check_range_3d(state, v, vmin, vmax, vname)
-      use physconst, only: pi
-      use physics_types, only: physics_state
-      use cam_abortutils, only: endrun
-      type(physics_state), intent(in) :: state
-      real(r8), intent(in) :: v(:,:,:), vmin, vmax
-      character(len=*), intent(in) :: vname
-      real(r8) :: lat, lon
-      integer :: ix, iy, iz
-      do iz = 1,size(v, 3)
-         do iy = 1,size(v,2)
-            do ix = 1,size(v, 1)
-               if (v(ix,iy,iz) < vmin .or. v(ix,iy,iz) > vmax) then
-                  lat = state%lat(ix) * 180._r8 / pi
-                  lon = state%lon(ix) * 180._r8 / pi
-                  print *, 'Variable ' // trim(vname) // &
-                           ' out of range; value = ', v(ix,iy,iz), &
-                           '; lat/lon = ', lat, lon
-                  call endrun('check_range failed for ' // trim(vname))
-               end if
-            end do
-         end do
-      end do
-   end subroutine check_range_3d
    !-------------------------------------------------------------------------------
 
 end module assertions

--- a/components/cam/src/physics/rrtmgp/cloud_rad_props.F90
+++ b/components/cam/src/physics/rrtmgp/cloud_rad_props.F90
@@ -16,7 +16,6 @@ use interpolate_data, only: interp_type, lininterp_init, lininterp, &
 
 use cam_logfile,      only: iulog
 use cam_abortutils,   only: endrun
-use assertions,       only: check_range
 
 implicit none
 private
@@ -302,11 +301,6 @@ subroutine get_ice_optics_lw(state, pbuf, abs_od)
    ! the lookup tables.
    call pbuf_get_field(pbuf, i_iciwp, iciwpth)
    call pbuf_get_field(pbuf, i_dei,   dei)
-
-   ! DEBUG, check values
-   call check_range(state, iciwpth(1:state%ncol,:), 0._r8, huge(iciwpth), 'iciwpth')
-   call check_range(state, dei(1:state%ncol,:), 0._r8, huge(dei), 'dei')
-
    call interpolate_ice_optics_lw(state%ncol,iciwpth, dei, abs_od)
 
 end subroutine get_ice_optics_lw
@@ -370,11 +364,6 @@ subroutine get_liquid_optics_lw(state, pbuf, abs_od)
    call pbuf_get_field(pbuf, i_mu,      pgam)
    call pbuf_get_field(pbuf, i_iclwp,   iclwpth)
 
-   ! DEBUG, check values
-   call check_range(state, iclwpth(1:state%ncol,:), 0._r8, huge(iclwpth), 'iclwpth')
-   call check_range(state, lamc(1:state%ncol,:), 0._r8, huge(lamc), 'lamc')
-   call check_range(state, pgam(1:state%ncol,:), 0._r8, huge(pgam), 'pgam')
-
    do k = 1,pver
       do i = 1,ncol
          if(lamc(i,k) > 0._r8) then ! This seems to be the clue for no cloud from microphysics formulation
@@ -423,11 +412,6 @@ subroutine get_snow_optics_lw(state, pbuf, abs_od)
    ! different water path and effective diameter.
    call pbuf_get_field(pbuf, i_icswp, icswpth)
    call pbuf_get_field(pbuf, i_des,   des)
-
-   ! DEBUG, check values
-   call check_range(state, icswpth(1:state%ncol,:), 0._r8, huge(icswpth), 'icswpth')
-   call check_range(state, des(1:state%ncol,:), 0._r8, huge(des), 'des')
-
    call interpolate_ice_optics_lw(state%ncol,icswpth, des, abs_od)
 
 end subroutine get_snow_optics_lw

--- a/components/cam/src/physics/rrtmgp/cloud_rad_props.F90
+++ b/components/cam/src/physics/rrtmgp/cloud_rad_props.F90
@@ -16,6 +16,7 @@ use interpolate_data, only: interp_type, lininterp_init, lininterp, &
 
 use cam_logfile,      only: iulog
 use cam_abortutils,   only: endrun
+use assertions,       only: check_range
 
 implicit none
 private
@@ -302,6 +303,10 @@ subroutine get_ice_optics_lw(state, pbuf, abs_od)
    call pbuf_get_field(pbuf, i_iciwp, iciwpth)
    call pbuf_get_field(pbuf, i_dei,   dei)
 
+   ! DEBUG, check values
+   call check_range(state, iciwpth(1:state%ncol,:), 0._r8, huge(iciwpth), 'iciwpth')
+   call check_range(state, dei(1:state%ncol,:), 0._r8, huge(dei), 'dei')
+
    call interpolate_ice_optics_lw(state%ncol,iciwpth, dei, abs_od)
 
 end subroutine get_ice_optics_lw
@@ -365,6 +370,11 @@ subroutine get_liquid_optics_lw(state, pbuf, abs_od)
    call pbuf_get_field(pbuf, i_mu,      pgam)
    call pbuf_get_field(pbuf, i_iclwp,   iclwpth)
 
+   ! DEBUG, check values
+   call check_range(state, iclwpth(1:state%ncol,:), 0._r8, huge(iclwpth), 'iclwpth')
+   call check_range(state, lamc(1:state%ncol,:), 0._r8, huge(lamc), 'lamc')
+   call check_range(state, pgam(1:state%ncol,:), 0._r8, huge(pgam), 'pgam')
+
    do k = 1,pver
       do i = 1,ncol
          if(lamc(i,k) > 0._r8) then ! This seems to be the clue for no cloud from microphysics formulation
@@ -413,6 +423,10 @@ subroutine get_snow_optics_lw(state, pbuf, abs_od)
    ! different water path and effective diameter.
    call pbuf_get_field(pbuf, i_icswp, icswpth)
    call pbuf_get_field(pbuf, i_des,   des)
+
+   ! DEBUG, check values
+   call check_range(state, icswpth(1:state%ncol,:), 0._r8, huge(icswpth), 'icswpth')
+   call check_range(state, des(1:state%ncol,:), 0._r8, huge(des), 'des')
 
    call interpolate_ice_optics_lw(state%ncol,icswpth, des, abs_od)
 

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1386,8 +1386,8 @@ contains
       ! absorption coefficient look-up tables
       do iday = 1,nday
          icol = day_indices(iday)
-         lat(iday) = state%lat(icol) * pi / 180._r8
-         lon(iday) = state%lon(icol) * pi / 180._r8
+         lat(iday) = state%lat(icol) * 180._r8 / pi
+         lon(iday) = state%lon(icol) * 180._r8 / pi
       end do
       call t_startf('rrtmgp_check_temperatures')
       call check_range( &
@@ -1600,8 +1600,8 @@ contains
       ! values to min/max specified (depending on value of
       ! rrtmgp_clip_temperatures)
       do icol = 1,ncol
-         lat(icol) = state%lat(icol) * pi / 180._r8
-         lon(icol) = state%lon(icol) * pi / 180._r8
+         lat(icol) = state%lat(icol) * 180._r8 / pi
+         lon(icol) = state%lon(icol) * 180._r8 / pi
       end do
       call t_startf('rrtmgp_check_temperatures')
       call check_range( &

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -24,7 +24,7 @@ module radiation
    use mo_rte_kind, only: wp
 
    ! Use my assertion routines to perform sanity checks
-   use assertions, only: assert, assert_valid, assert_range
+   use assertions, only: assert, assert_valid, assert_range, check_range
 
    use radiation_state, only: ktop, kbot, nlev_rad
    use radiation_utils, only: compress_day_columns, expand_day_columns, &
@@ -1245,28 +1245,6 @@ contains
 
    end subroutine radiation_tend
 
-   subroutine check_range(state, v, vmin, vmax, vname)
-      use physconst, only: pi
-      use physics_types, only: physics_state
-      use cam_abortutils, only: endrun
-      type(physics_state), intent(in) :: state
-      real(r8), intent(in) :: v(:,:), vmin, vmax
-      character(len=*), intent(in) :: vname
-      real(r8) :: lat, lon
-      integer :: ix, iz
-      do iz = 1,size(v, 2)
-         do ix = 1,size(v, 1)
-            if (v(ix,iz) < vmin .or. v(ix,iz) > vmax) then
-               lat = state%lat(ix) * 180._r8 / pi
-               lon = state%lon(ix) * 180._r8 / pi
-               print *, 'Variable ' // trim(vname) // &
-                        ' out of range; value = ', v(ix,iz), &
-                        '; lat/lon = ', lat, lon
-               call endrun('check_range failed for ' // trim(vname))
-            end if
-         end do
-      end do
-   end subroutine check_range
 
    !----------------------------------------------------------------------------
 
@@ -1538,7 +1516,6 @@ contains
       use physics_types, only: physics_state
       use physics_buffer, only: physics_buffer_desc
       use camsrfexch, only: cam_in_t
-      use mo_rrtmgp_clr_all_sky, only: rte_lw
       use mo_fluxes_byband, only: ty_fluxes_byband
       use mo_optical_props, only: ty_optical_props_1scl
       use mo_gas_concentrations, only: ty_gas_concs
@@ -1590,7 +1567,9 @@ contains
                          pmid(1:ncol,1:nlev_rad), &
                          pint(1:ncol,1:nlev_rad+1))
        
+      ! DEBUG: check values
       call check_range(state, tmid(1:ncol,1:nlev_rad), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), 'tmid')
+      call check_range(state, tint(1:ncol,1:nlev_rad), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), 'tint')
 
       ! Set surface emissivity to 1 here. There is a note in the RRTMG
       ! implementation that this is treated in the land model, but the old
@@ -1632,6 +1611,10 @@ contains
             call t_startf('rad_aerosol_optics_lw')
             call set_aerosol_optics_lw(icall, state, pbuf, is_cmip6_volc, aerosol_optics_lw)
             call t_stopf('rad_aerosol_optics_lw')
+
+            ! DEBUG: check optical properties
+            call check_range(state, aerosol_optics_lw%tau, 0._r8, huge(aerosol_optics_lw%tau), 'aerosol_optics_lw%tau')
+            call check_range(state, cloud_optics_lw%tau  , 0._r8, huge(cloud_optics_lw%tau)  , 'cloud_optics_lw%tau'  )
 
             ! Do longwave radiative transfer calculations
             call t_startf('rad_calculations_lw')
@@ -2448,5 +2431,158 @@ end function string_in_list
 
    end subroutine expand_day_fluxes
 
+   ! --------------------------------------------------
+   !
+   ! Interfaces using clear (gas + aerosol) and all-sky categories, starting from
+   !   pressures, temperatures, and gas amounts for the gas contribution
+   !
+   ! --------------------------------------------------
+   function rte_lw(k_dist, gas_concs, p_lay, t_lay, p_lev,    &
+                      t_sfc, sfc_emis, cloud_props,           &
+                      allsky_fluxes, clrsky_fluxes,           &
+                      aer_props, col_dry, t_lev, inc_flux, n_gauss_angles) result(error_msg)
+
+     use mo_rte_kind,   only: wp
+     use mo_gas_optics, &
+                           only: ty_gas_optics
+     use mo_gas_concentrations, &
+                           only: ty_gas_concs
+     use mo_optical_props, only: ty_optical_props, &
+                                 ty_optical_props_arry, ty_optical_props_1scl, ty_optical_props_2str, ty_optical_props_nstr
+     use mo_source_functions, &
+                           only: ty_source_func_lw
+     use mo_fluxes,        only: ty_fluxes
+     use mo_rte_lw,        only: base_rte_lw => rte_lw
+
+     class(ty_gas_optics),              intent(in   ) :: k_dist       !< derived type with spectral information
+     type(ty_gas_concs),                intent(in   ) :: gas_concs    !< derived type encapsulating gas concentrations
+     real(wp), dimension(:,:),          intent(in   ) :: p_lay, t_lay !< pressure [Pa], temperature [K] at layer centers (ncol,nlay)
+     real(wp), dimension(:,:),          intent(in   ) :: p_lev        !< pressure at levels/interfaces [Pa] (ncol,nlay+1)
+     real(wp), dimension(:),            intent(in   ) :: t_sfc     !< surface temperature           [K]  (ncol)
+     real(wp), dimension(:,:),          intent(in   ) :: sfc_emis  !< emissivity at surface         []   (nband, ncol)
+     class(ty_optical_props_arry),      intent(in   ) :: cloud_props !< cloud optical properties (ncol,nlay,ngpt)
+     class(ty_fluxes),                  intent(inout) :: allsky_fluxes, clrsky_fluxes
+
+     ! Optional inputs
+     class(ty_optical_props_arry),  &
+               optional,       intent(in ) :: aer_props   !< aerosol optical properties
+     real(wp), dimension(:,:), &
+               optional,       intent(in ) :: col_dry !< Molecular number density (ncol, nlay)
+     real(wp), dimension(:,:), target, &
+               optional,       intent(in ) :: t_lev     !< temperature at levels [K] (ncol, nlay+1)
+     real(wp), dimension(:,:), target, &
+               optional,       intent(in ) :: inc_flux   !< incident flux at domain top [W/m2] (ncol, ngpts)
+     integer,  optional,       intent(in ) :: n_gauss_angles ! Number of angles used in Gaussian quadrature (no-scattering solution)
+     character(len=128)                    :: error_msg
+     ! --------------------------------
+     ! Local variables
+     !
+     class(ty_optical_props_arry), allocatable :: optical_props
+     type(ty_source_func_lw)                   :: sources
+
+     integer :: ncol, nlay, ngpt, nband, nstr
+     logical :: top_at_1
+     ! --------------------------------
+     ! Problem sizes
+     !
+     error_msg = ""
+
+     ncol  = size(p_lay, 1)
+     nlay  = size(p_lay, 2)
+     ngpt  = k_dist%get_ngpt()
+     nband = k_dist%get_nband()
+
+     top_at_1 = p_lay(1, 1) < p_lay(1, nlay)
+
+     ! ------------------------------------------------------------------------------------
+     !  Error checking
+     !
+     if(present(aer_props)) then
+       if(any([aer_props%get_ncol(), &
+               aer_props%get_nlay()] /= [ncol, nlay])) &
+         error_msg = "rrtmpg_lw: aerosol properties inconsistently sized"
+       if(.not. any(aer_props%get_ngpt() /= [ngpt, nband])) &
+         error_msg = "rrtmpg_lw: aerosol properties inconsistently sized"
+     end if
+
+     if(present(t_lev)) then
+       if(any([size(t_lev, 1), &
+               size(t_lev, 2)] /= [ncol, nlay+1])) &
+         error_msg = "rrtmpg_lw: t_lev inconsistently sized"
+     end if
+
+     if(present(inc_flux)) then
+       if(any([size(inc_flux, 1), &
+               size(inc_flux, 2)] /= [ncol, ngpt])) &
+         error_msg = "rrtmpg_lw: incident flux inconsistently sized"
+     end if
+     if(len_trim(error_msg) > 0) return
+
+     ! ------------------------------------------------------------------------------------
+     ! Optical properties arrays
+     !
+     select type(cloud_props)
+       class is (ty_optical_props_1scl) ! No scattering
+         allocate(ty_optical_props_1scl::optical_props)
+       class is (ty_optical_props_2str)
+         allocate(ty_optical_props_2str::optical_props)
+       class is (ty_optical_props_nstr)
+         allocate(ty_optical_props_nstr::optical_props)
+         nstr = size(cloud_props%tau,1)
+     end select
+
+     error_msg = optical_props%init(k_dist)
+     if(len_trim(error_msg) > 0) return
+     select type (optical_props)
+       class is (ty_optical_props_1scl) ! No scattering
+         error_msg = optical_props%alloc_1scl(ncol, nlay)
+       class is (ty_optical_props_2str)
+         error_msg = optical_props%alloc_2str(ncol, nlay)
+       class is (ty_optical_props_nstr)
+         error_msg = optical_props%alloc_nstr(nstr, ncol, nlay)
+     end select
+     if (error_msg /= '') return
+
+     !
+     ! Source function
+     !
+     error_msg = sources%init(k_dist)
+     error_msg = sources%alloc(ncol, nlay)
+     if (error_msg /= '') return
+     ! ------------------------------------------------------------------------------------
+     ! Clear skies
+     !
+     ! Gas optical depth -- pressure need to be expressed as Pa
+     !
+     error_msg = k_dist%gas_optics(p_lay, p_lev, t_lay, t_sfc, gas_concs, &
+                                   optical_props, sources,                &
+                                   col_dry, t_lev)
+     if (error_msg /= '') return
+     call assert_range(optical_props%tau, 0._wp, huge(optical_props%tau), 'rte_lw gas optical_props%tau')
+    
+     ! ----------------------------------------------------
+     ! Clear sky is gases + aerosols (if they're supplied)
+     !
+     if(present(aer_props)) error_msg = aer_props%increment(optical_props)
+     if(error_msg /= '') return
+     call assert_range(optical_props%tau, 0._wp, huge(optical_props%tau), 'rte_lw gas+aer optical_props%tau')
+
+     error_msg = base_rte_lw(optical_props, top_at_1, sources, &
+                             sfc_emis, clrsky_fluxes,          &
+                             inc_flux, n_gauss_angles)
+     if(error_msg /= '') return
+     ! ------------------------------------------------------------------------------------
+     ! All-sky fluxes = clear skies + clouds
+     !
+     error_msg = cloud_props%increment(optical_props)
+     if(error_msg /= '') return
+     call assert_range(optical_props%tau, 0._wp, huge(optical_props%tau), 'rte_lw gas+aer+cld optical_props%tau')
+
+     error_msg = base_rte_lw(optical_props, top_at_1, sources, &
+                             sfc_emis, allsky_fluxes,          &
+                             inc_flux, n_gauss_angles)
+
+     call sources%finalize()
+   end function rte_lw
 
 end module radiation

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -117,13 +117,12 @@ module radiation
    real(r8) :: dt_avg = 0.0_r8  
 
    ! k-distribution coefficients. These will be populated by reading from the
-   ! RRTMGP coefficients files, specified by coefficients_file_sw and
-   ! coefficients_file_lw in the radiation namelist. They exist as module data
-   ! because we only want to load those files once.
+   ! RRTMGP coefficients files, specified by rrtmgp_coefficients_file_sw and
+   ! rrtmgp_coefficients_file_lw in the radiation namelist. They exist as module
+   ! data because we only want to load those files once.
    type(ty_gas_optics_rrtmgp) :: k_dist_sw, k_dist_lw
 
-   ! k-distribution coefficients files to read from. These are set via namelist
-   ! variables.
+   ! k-distribution coefficients files to read from. Set via namelist.
    character(len=cl) :: rrtmgp_coefficients_file_sw, rrtmgp_coefficients_file_lw
 
    ! Should we clip temperatures when out of bounds of absorption coefficient

--- a/components/cam/src/physics/rrtmgp/radiation_utils.F90
+++ b/components/cam/src/physics/rrtmgp/radiation_utils.F90
@@ -288,52 +288,74 @@ contains
    end subroutine clip_values_2d
 
    !-------------------------------------------------------------------------------
-   subroutine check_range_2d(v, vmin, vmax, vname, lat, lon, abort_on_error)
+   subroutine check_range_2d(v, vmin, vmax, vname, lat, lon, abort_on_error, clip_values)
       use cam_abortutils, only: endrun
-      real(r8), intent(in) :: v(:,:), vmin, vmax
+      real(r8), intent(inout) :: v(:,:)
+      real(r8), intent(in) :: vmin, vmax
       character(len=*), intent(in) :: vname
       real(r8), intent(in) :: lat(:), lon(:)
-      logical, intent(in), optional :: abort_on_error
-      logical :: abort_on_error_local
+      logical, intent(in), optional :: abort_on_error, clip_values
+      logical :: abort_on_error_local, clip_values_local
       integer :: ix, iz
       if (present(abort_on_error)) then
          abort_on_error_local = abort_on_error
       else
          abort_on_error_local = .true.
       end if
+      if (present(clip_values)) then
+         clip_values_local = clip_values
+      else
+         clip_values_local = .false.
+      end if
       do iz = 1,size(v, 2)
          do ix = 1,size(v, 1)
             if (v(ix,iz) < vmin .or. v(ix,iz) > vmax) then
-               print *, 'Variable ' // trim(vname) // &
+               print *, 'WARNING: ' // trim(vname) // &
                         ' out of range; value = ', v(ix,iz), &
-                        '; lat/lon = ', lat(ix), lon(ix)
-               if (abort_on_error_local) call endrun('check_range failed for ' // trim(vname))
+                        '; lat, lon, lev = ', lat(ix), lon(ix), iz
+               if (clip_values_local) then
+                  if (v(ix,iz) < vmin) v(ix,iz) = vmin
+                  if (v(ix,iz) > vmax) v(ix,iz) = vmax
+               else if (abort_on_error_local) then
+                  call endrun('check_range failed for ' // trim(vname))
+               end if
             end if
          end do
       end do
    end subroutine check_range_2d
    !-------------------------------------------------------------------------------
-   subroutine check_range_3d(v, vmin, vmax, vname, lat, lon, abort_on_error)
+   subroutine check_range_3d(v, vmin, vmax, vname, lat, lon, abort_on_error, clip_values)
       use cam_abortutils, only: endrun
-      real(r8), intent(in) :: v(:,:,:), vmin, vmax
+      real(r8), intent(inout) :: v(:,:,:)
+      real(r8), intent(in) :: vmin, vmax
       character(len=*), intent(in) :: vname
       real(r8), intent(in) :: lat(:), lon(:)
-      logical, intent(in), optional :: abort_on_error
-      logical :: abort_on_error_local
+      logical, intent(in), optional :: abort_on_error, clip_values
+      logical :: abort_on_error_local, clip_values_local
       integer :: ix, iy, iz
       if (present(abort_on_error)) then
          abort_on_error_local = abort_on_error
       else
          abort_on_error_local = .true.
       end if
+      if (present(clip_values)) then
+         clip_values_local = clip_values
+      else
+         clip_values_local = .false.
+      end if
       do iz = 1,size(v, 3)
          do iy = 1,size(v,2)
             do ix = 1,size(v, 1)
                if (v(ix,iy,iz) < vmin .or. v(ix,iy,iz) > vmax) then
-                  print *, 'Variable ' // trim(vname) // &
+                  print *, 'WARNING: ' // trim(vname) // &
                            ' out of range; value = ', v(ix,iy,iz), &
-                           '; lat/lon = ', lat(ix), lon(ix)
-                  if (abort_on_error_local) call endrun('check_range failed for ' // trim(vname))
+                           '; lat, lon, lev = ', lat(ix), lon(ix), iz
+                  if (clip_values_local) then
+                     if (v(ix,iy,iz) < vmin) v(ix,iy,iz) = vmin
+                     if (v(ix,iy,iz) > vmax) v(ix,iy,iz) = vmax
+                  else if (abort_on_error_local) then
+                     call endrun('check_range failed for ' // trim(vname))
+                  end if
                end if
             end do
          end do

--- a/components/cam/src/physics/rrtmgp/radiation_utils.F90
+++ b/components/cam/src/physics/rrtmgp/radiation_utils.F90
@@ -288,30 +288,44 @@ contains
    end subroutine clip_values_2d
 
    !-------------------------------------------------------------------------------
-   subroutine check_range_2d(v, vmin, vmax, vname, lat, lon)
+   subroutine check_range_2d(v, vmin, vmax, vname, lat, lon, abort_on_error)
       use cam_abortutils, only: endrun
       real(r8), intent(in) :: v(:,:), vmin, vmax
       character(len=*), intent(in) :: vname
       real(r8), intent(in) :: lat(:), lon(:)
+      logical, intent(in), optional :: abort_on_error
+      logical :: abort_on_error_local
       integer :: ix, iz
+      if (present(abort_on_error)) then
+         abort_on_error_local = abort_on_error
+      else
+         abort_on_error_local = .true.
+      end if
       do iz = 1,size(v, 2)
          do ix = 1,size(v, 1)
             if (v(ix,iz) < vmin .or. v(ix,iz) > vmax) then
                print *, 'Variable ' // trim(vname) // &
                         ' out of range; value = ', v(ix,iz), &
                         '; lat/lon = ', lat(ix), lon(ix)
-               call endrun('check_range failed for ' // trim(vname))
+               if (abort_on_error_local) call endrun('check_range failed for ' // trim(vname))
             end if
          end do
       end do
    end subroutine check_range_2d
    !-------------------------------------------------------------------------------
-   subroutine check_range_3d(v, vmin, vmax, vname, lat, lon)
+   subroutine check_range_3d(v, vmin, vmax, vname, lat, lon, abort_on_error)
       use cam_abortutils, only: endrun
       real(r8), intent(in) :: v(:,:,:), vmin, vmax
       character(len=*), intent(in) :: vname
       real(r8), intent(in) :: lat(:), lon(:)
+      logical, intent(in), optional :: abort_on_error
+      logical :: abort_on_error_local
       integer :: ix, iy, iz
+      if (present(abort_on_error)) then
+         abort_on_error_local = abort_on_error
+      else
+         abort_on_error_local = .true.
+      end if
       do iz = 1,size(v, 3)
          do iy = 1,size(v,2)
             do ix = 1,size(v, 1)
@@ -319,7 +333,7 @@ contains
                   print *, 'Variable ' // trim(vname) // &
                            ' out of range; value = ', v(ix,iy,iz), &
                            '; lat/lon = ', lat(ix), lon(ix)
-                  call endrun('check_range failed for ' // trim(vname))
+                  if (abort_on_error_local) call endrun('check_range failed for ' // trim(vname))
                end if
             end do
          end do


### PR DESCRIPTION
Add check to make sure temperatures are within bounds of absorption coefficient look-up tables at a higher level in the RRTMGP call tree in order to provide information about where temperatures go out of bounds. Additionally, add an option (specified by namelist variable `rrtmgp_clip_temperatures`) to clip temperatures when they go out of bounds. With `rrtmgp_clip_temperatures = .false.` (the default), the model will abort when temperatures out of bounds are encountered. With `rrtmgp_clip_temperatures = .true.`, the model will issue a warning that temperatures have gone out of bounds, but clip the temperature input to RRTMGP and continue.