### PR TITLE
Scream: allow non-clean repo if baseline ref is HEAD

### DIFF
--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -7,7 +7,7 @@ gold standard to determine if the code is working or not on the current platform
 Run from $scream-repo/components/scream
 """
 
-from utils import expect, check_minimum_python_version, is_repo_clean
+from utils import expect, check_minimum_python_version
 check_minimum_python_version(3, 4)
 
 import argparse, sys, os
@@ -65,7 +65,6 @@ OR
     args = parser.parse_args(args[1:])
 
     expect(os.getcwd().endswith("components/scream"), "Run from $scream_repo/components/scream")
-    expect(is_repo_clean(), "Repo must be clean before running")
     if not args.kokkos:
         expect(args.machine, "If no external kokkos provided, must provide machine name for internal kokkos build")
     if args.submit:

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -56,6 +56,8 @@ OR
 
     parser.add_argument("--no-tests", action="store_true", help="Only build baselines, skip testing phase")
 
+    parser.add_argument("--keep-tree", action="store_true", help="Allow to keep the current work tree when testing against HEAD (only valid with `-b HEAD`)")
+
     parser.add_argument("-c", "--custom-cmake-opts", action="append", default=[],
                         help="Extra custom options to pass to cmake. Can use multiple times for multiple cmake options. The -D is added for you")
 

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -7,7 +7,7 @@ gold standard to determine if the code is working or not on the current platform
 Run from $scream-repo/components/scream
 """
 
-from utils import expect, check_minimum_python_version
+from utils import expect, check_minimum_python_version, is_repo_clean
 check_minimum_python_version(3, 4)
 
 import argparse, sys, os
@@ -80,6 +80,10 @@ def _main_func(description):
     success = tas.test_all_scream()
 
     print("OVERALL STATUS: {}".format("PASS" if success else "FAIL"))
+    if not is_repo_clean():
+        print("WARNING! You have uncommitted changes in your repo.",
+              "         The PASS/FAIL status may depend on these changes",
+              "         so if you want to keep them, don't forget to create a commit.",sep="\n")
     sys.exit(0 if success else 1)
 
 ###############################################################################

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -1,4 +1,4 @@
-from utils import run_cmd, check_minimum_python_version, get_current_head, run_cmd_no_fail, get_current_commit, expect
+from utils import run_cmd, check_minimum_python_version, get_current_head, run_cmd_no_fail, get_current_commit, expect, is_repo_clean
 check_minimum_python_version(3, 4)
 
 import os, shutil
@@ -172,6 +172,7 @@ class TestAllScream(object):
         print("Generating baselines for ref {}".format(git_baseline_head))
 
         if git_baseline_head != "HEAD":
+            expect(is_repo_clean(), "If baseline commit is not HEAD, then the repo must be clean before running")
             run_cmd_no_fail("git checkout {}".format(git_baseline_head))
             print("  Switched to {} ({})".format(git_baseline_head, get_current_commit()))
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -9,7 +9,7 @@ class TestAllScream(object):
 ###############################################################################
 
     ###########################################################################
-    def __init__(self, cxx, kokkos, submit, parallel, fast_fail, baseline_ref, baseline_dir, machine, no_tests, custom_cmake_opts, tests):
+    def __init__(self, cxx, kokkos, submit, parallel, fast_fail, baseline_ref, baseline_dir, machine, no_tests, keep_tree, custom_cmake_opts, tests):
     ###########################################################################
 
         self._cxx               = cxx
@@ -20,6 +20,7 @@ class TestAllScream(object):
         self._baseline_ref      = baseline_ref
         self._machine           = machine
         self._perform_tests     = not no_tests
+        self._keep_tree         = keep_tree
         self._baseline_dir      = baseline_dir
         self._custom_cmake_opts = custom_cmake_opts
         self._tests             = tests
@@ -70,6 +71,12 @@ class TestAllScream(object):
             # In case we have more tests than cores (unlikely)
             if self._proc_count == 0:
                 self._proc_count = 1
+
+        if self._keep_tree:
+            if self._baseline_dir=="NONE":
+                # Make sure the baseline ref is HEAD
+                expect(self._baseline_ref=="HEAD","The option --keep-tree is only available when testing against pre-built baselines (--baseline-dir) or HEAD (-b HEAD)")
+                
 
     ###############################################################################
     def generate_cmake_config(self, extra_configs, for_ctest=False):
@@ -171,7 +178,7 @@ class TestAllScream(object):
     ###############################################################################
         print("Generating baselines for ref {}".format(git_baseline_head))
 
-        if git_baseline_head != "HEAD":
+        if git_baseline_head != "HEAD" and not self._keep_tree:
             expect(is_repo_clean(), "If baseline commit is not HEAD, then the repo must be clean before running")
             run_cmd_no_fail("git checkout {}".format(git_baseline_head))
             print("  Switched to {} ({})".format(git_baseline_head, get_current_commit()))
@@ -194,7 +201,7 @@ class TestAllScream(object):
                     print('Generation of baselines for build {} failed'.format(self._test_full_names[test]))
                     return False
 
-        if git_baseline_head != "HEAD":
+        if git_baseline_head != "HEAD" and not self._keep_tree:
             run_cmd_no_fail("git checkout {}".format(git_head))
             print("  Switched back to {} ({})".format(git_head, get_current_commit()))
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -76,6 +76,8 @@ class TestAllScream(object):
             if self._baseline_dir=="NONE":
                 # Make sure the baseline ref is HEAD
                 expect(self._baseline_ref=="HEAD","The option --keep-tree is only available when testing against pre-built baselines (--baseline-dir) or HEAD (-b HEAD)")
+        else:
+            expect(is_repo_clean(),"Repo must be clean before running. If testing against HEAD or pre-built baselines, you can pass `--keep-tree` to allow non-clean repo.")
                 
 
     ###############################################################################
@@ -178,7 +180,7 @@ class TestAllScream(object):
     ###############################################################################
         print("Generating baselines for ref {}".format(git_baseline_head))
 
-        if git_baseline_head != "HEAD" and not self._keep_tree:
+        if git_baseline_head != "HEAD":
             expect(is_repo_clean(), "If baseline commit is not HEAD, then the repo must be clean before running")
             run_cmd_no_fail("git checkout {}".format(git_baseline_head))
             print("  Switched to {} ({})".format(git_baseline_head, get_current_commit()))
@@ -201,7 +203,7 @@ class TestAllScream(object):
                     print('Generation of baselines for build {} failed'.format(self._test_full_names[test]))
                     return False
 
-        if git_baseline_head != "HEAD" and not self._keep_tree:
+        if git_baseline_head != "HEAD":
             run_cmd_no_fail("git checkout {}".format(git_head))
             print("  Switched back to {} ({})".format(git_head, get_current_commit()))
 


### PR DESCRIPTION
This should speed up testing for users who manually run test-all-scream with minor increments. After all, if baseline ref is HEAD, test-all-scream does not switch branches.