### PR TITLE
SHOC fix to prevent raising negative value to fraction power

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1855,7 +1855,8 @@ subroutine shoc_length(&
         ! Look for cloud base in this column
 	if (cldin(i,k) .gt. cldthresh .and. cldin(i,k+1) .le. cldthresh) then 
 	  ku=k
-	  conv_var=conv_vel(i,k)**(1._r8/3._r8)
+	  conv_var=max(0._r8,conv_vel(i,k))
+	  conv_var=conv_var**(1._r8/3._r8)
 	endif
 	
 	! Compute the mixing length for the layer just determined

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1835,6 +1835,15 @@ subroutine shoc_length(&
       conv_vel(i,k) = conv_vel(i,k-1)+2.5_r8*dz_zt(i,k)*(ggr/thv(i,k))*wthv_sec(i,k)
     enddo ! end i loop (column loop)
   enddo ! end k loop (vertical loop)
+  
+  ! computed quantity above is wstar3
+  ! clip, to avoid negative values and take the cubed 
+  !   root to get the convective velocity scale
+  do k=1,nlev
+    do i=1,shcol
+      conv_vel(i,k) = max(0._r8,conv_vel(i,k))**(1._r8/3._r8) 
+    enddo
+  enddo
  
   if (doclouddef) then
  
@@ -1855,8 +1864,7 @@ subroutine shoc_length(&
         ! Look for cloud base in this column
 	if (cldin(i,k) .gt. cldthresh .and. cldin(i,k+1) .le. cldthresh) then 
 	  ku=k
-	  conv_var=max(0._r8,conv_vel(i,k))
-	  conv_var=conv_var**(1._r8/3._r8)
+	  conv_var=conv_vel(i,k)
 	endif
 	
 	! Compute the mixing length for the layer just determined


### PR DESCRIPTION
This PR prevents SHOC from taking the cubed root of the convective velocity scale if it is less than zero.  This was causing restart tests to fail on Cori with specific compilers.  Note that I verified that this code actually produces bit for bit results (in both SCM and global runs) with master because this convective velocity scale (conv_var) was/is only ever used (see line 1865 in shoc.F90) if it was greater than zero.  