### PR TITLE
Flip SHOC in the vertical

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -392,10 +392,10 @@ subroutine shoc_grid( &
       dz_zt(i,k) = zi_grid(i,k) - zi_grid(i,k+1)
  
       ! define thickness of the interface grid points
-      if (k .eq. 1) then
+      if (k .eq. nlev) then
         dz_zi(i,k) = zt_grid(i,k)
       else
-        dz_zi(i,k) = zt_grid(i,k-1) - zt_grid(i,k)
+        dz_zi(i,k) = zt_grid(i,k) - zt_grid(i,k+1)
       endif
 
       ! Define the air density on the thermo grid

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -257,7 +257,7 @@ subroutine shoc_main ( &
          shcol,nlev,nlevi,&                   ! Input
 	 zt_grid,zi_grid,pdel,&               ! Input
          dz_zt,dz_zi,rho_zt)  		      ! Output
-  
+
   ! Update the turbulent length scale	 
   call shoc_length(&
          shcol,nlev,nlevi, tke,&              ! Input
@@ -275,7 +275,7 @@ subroutine shoc_main ( &
 	 uw_sfc,vw_sfc,&                      ! Input
 	 zt_grid,zi_grid,&                    ! Input
          tke,tk,tkh,&		              ! Input/Output
-	 isotropy)                            ! Output 
+	 isotropy)                            ! Output
   
   ! If implicit diffusion solver is used, 
   !  update SHOC prognostic variables here
@@ -336,7 +336,7 @@ subroutine shoc_main ( &
 	 wqw_sec,qwthl_sec,w3,pres,&          ! Input
 	 zt_grid,zi_grid,&                    ! Input
 	 shoc_cldfrac,shoc_ql,&               ! Output
-         wqls_sec,wthv_sec)                   ! Output	 
+         wqls_sec,wthv_sec)                   ! Output
 
   ! Check TKE to make sure values lie within acceptable 
   !  bounds after vertical advection, etc.
@@ -487,7 +487,7 @@ subroutine update_prognostics( &
   call linear_interp(zt_grid,zi_grid,rho_zt,rho_zi,nlev,nlevi,shcol,0._r8)
 
   do i=1,shcol
-    do k=1,nlev 
+    do k=1,nlev
       kb=k+1
 
       ! define air densities on various levels for mass weighted 
@@ -1209,7 +1209,7 @@ subroutine shoc_assumed_pdf(&
   call linear_interp(zi_grid,zt_grid,qwthl_sec,qwthl_sec_zt,nlevi,nlev,shcol,largeneg)
   call linear_interp(zi_grid,zt_grid,wqw_sec,wqw_sec_zt,nlevi,nlev,shcol,largeneg) !Alert
   call linear_interp(zi_grid,zt_grid,qw_sec,qw_sec_zt,nlevi,nlev,shcol,0._r8)  
-  call linear_interp(zi_grid,zt_grid,w_field,w_field_zt,nlevi,nlev,shcol,largeneg)  
+  call linear_interp(zi_grid,zt_grid,w_field,w_field_zt,nlevi,nlev,shcol,largeneg)
   
   do k=1,nlev
     do i=1,shcol
@@ -1479,7 +1479,7 @@ subroutine shoc_assumed_pdf(&
       wqls(i,k)=a*((w1_1-w_first)*ql1)+(1._r8-a)*((w1_2-w_first)*ql2)
       ! Compute the SGS buoyancy flux
       wthv_sec(i,k)=wthlsec+((1._r8-epsterm)/epsterm)*basetemp*wqwsec &
-        +((lcond/cp)*(basepres/pval)**(rgas/cp)-(1._r8/epsterm)*basetemp)*wqls(i,k)       
+        +((lcond/cp)*(basepres/pval)**(rgas/cp)-(1._r8/epsterm)*basetemp)*wqls(i,k)
      	
     enddo  ! end i loop here
   enddo	  ! end k loop here
@@ -1818,7 +1818,7 @@ subroutine shoc_length(&
     
       tkes=sqrt(tke(i,k))
       
-      if (brunt(i,k) .ge. 0) brunt2(i,k) = brunt(i,k) 
+      if (brunt(i,k) .ge. 0) brunt2(i,k) = brunt(i,k)
 
       shoc_mix(i,k)=min(maxlen,(2.8284_r8*sqrt(1._r8/((1._r8/(tscale*tkes*vonk*zt_grid(i,k))) &
         +(1._r8/(tscale*tkes*l_inf(i)))+0.01_r8*(brunt2(i,k)/tke(i,k)))))/0.3_r8)     

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -266,11 +266,6 @@ subroutine shoc_main ( &
 	 thetal,wthv_sec,thv,&                ! Input
 	 brunt,shoc_mix)  		      ! Output
 
-  write(*,*) 'BRUNT ', brunt
-  write(*,*) 'SHOCMIX ', shoc_mix
-  
-  write(*,*) 'TKEbeforeTKE ', tke
-
   ! Advance the SGS TKE equation	 
   call shoc_tke(&
          shcol,nlev,nlevi,dtime,&             ! Input
@@ -280,12 +275,7 @@ subroutine shoc_main ( &
 	 uw_sfc,vw_sfc,&                      ! Input
 	 zt_grid,zi_grid,&                    ! Input
          tke,tk,tkh,&		              ! Input/Output
-	 isotropy)                            ! Output
-	 
-  write(*,*) 'TKEafterTKE ', tke
-  write(*,*) 'TKEafterTKE ', tke
-  write(*,*) 'TKHafterTKE ', tkh
-  write(*,*) 'ISOTROPY ', isotropy  
+	 isotropy)                            ! Output 
   
   ! If implicit diffusion solver is used, 
   !  update SHOC prognostic variables here
@@ -298,9 +288,6 @@ subroutine shoc_main ( &
            thetal,qw,qtracers,tke,&           ! Input/Output
 	   u_wind,v_wind)                     ! Input/Output
   endif	 
-
-  write(*,*) 'TKEafterDIFF ', tke
-  write(*,*) 'TafterDIFF ', thetal
 
   ! Diagnose the second order moments, needed
   !  for the PDF closure
@@ -316,10 +303,6 @@ subroutine shoc_main ( &
 	 wthl_sec,wqw_sec,&                   ! Output
 	 qwthl_sec,uw_sec,vw_sec,wtke_sec,&   ! Output
 	 wtracer_sec)
-	 
-  write(*,*) 'wthl_sec ', wthl_sec
-  write(*,*) 'wqw_sec ', wqw_sec
-  write(*,*) 'uw_sec ', uw_sec
 
   ! Diagnose the third moment of vertical velocity, 
   !  needed for the PDF closure	 
@@ -331,8 +314,6 @@ subroutine shoc_main ( &
 	 dz_zt,dz_zi,&                        ! Input
 	 zt_grid,zi_grid,&                    ! Input
 	 w3)                                  ! Output
-	 
-  write(*,*) 'w3 ', w3
   
   ! Update thetal, qw, tracers, and wind components
   !   based on SGS mixing, if explicit scheme is used
@@ -355,12 +336,7 @@ subroutine shoc_main ( &
 	 wqw_sec,qwthl_sec,w3,pres,&          ! Input
 	 zt_grid,zi_grid,&                    ! Input
 	 shoc_cldfrac,shoc_ql,&               ! Output
-         wqls_sec,wthv_sec)                   ! Output
-	 
-  write(*,*) 'shoc_cldfrac ', shoc_cldfrac
-  write(*,*) 'shoc_ql ', shoc_ql
-  write(*,*) 'wqls_sec ', wqls_sec
-  write(*,*) 'wthv_sec ', wthv_sec	 
+         wqls_sec,wthv_sec)                   ! Output	 
 
   ! Check TKE to make sure values lie within acceptable 
   !  bounds after vertical advection, etc.
@@ -429,11 +405,7 @@ subroutine shoc_grid( &
   enddo ! end k loop (vertical loop)
   
   ! Set lower condition for dz_zi
-  dz_zi(:shcol,nlevi) = zt_grid(:shcol,nlev) 
- 
-  write(*,*) 'RHO_ZT ', rho_zt
-  write(*,*) 'PDEL ', pdel
-  write(*,*) 'DZ_ZT ', dz_zt  
+  dz_zi(:shcol,nlevi) = zt_grid(:shcol,nlev)  
   
   return
   
@@ -649,10 +621,6 @@ subroutine update_prognostics_implicit( &
   call linear_interp(zt_grid,zi_grid,tk,tk_zi,nlev,nlevi,shcol,0._r8)
   call linear_interp(zt_grid,zi_grid,rho_zt,rho_zi,nlev,nlevi,shcol,0._r8)
  
-  write(*,*) 'RHO_ZI ', rho_zi
-  write(*,*) 'DZ_ZI ', dz_zi
-  write(*,*) 'RHO_ZI ', rho_zt 
- 
   tmpi(:,1) = 0._r8
   ! Define the tmpi variable, which is really dt*(g*rho)**2/dp 
   !  at interfaces. Sub dp = g*rho*dz
@@ -682,7 +650,7 @@ subroutine update_prognostics_implicit( &
   enddo
 
   ! Apply the surface fluxes explicitly for temperature and moisture
-  thetal(:,nlev) = thetal(:,nlev) + dtime * (ggr * rho_zi(:,nlev) * rdp_zt(:,nlev)) * wthl_sfc(:)  
+  thetal(:,nlev) = thetal(:,nlev) + dtime * (ggr * rho_zi(:,nlevi) * rdp_zt(:,nlev)) * wthl_sfc(:)  
   qw(:,nlev) = qw(:,nlev) + dtime * (ggr * rho_zi(:,nlevi) * rdp_zt(:,nlev)) * wqw_sfc(:)
   tke(:,nlev) = tke(:,nlev) + dtime * (ggr * rho_zi(:,nlevi) * rdp_zt(:,nlev)) * wtke_flux(:)
 
@@ -836,8 +804,6 @@ subroutine diag_second_shoc_moments(&
   call linear_interp(zt_grid,zi_grid,tkh,tkh_zi,nlev,nlevi,shcol,0._r8)
   call linear_interp(zt_grid,zi_grid,tk,tk_zi,nlev,nlevi,shcol,0._r8)
   call linear_interp(zt_grid,zi_grid,shoc_mix,shoc_mix_zi,nlev,nlevi,shcol,0._r8)
- 
-  write(*,*) 'TKHzi ', tkh_zi
  
   ! Vertical velocity variance is assumed to be propotional
   !  to the TKE
@@ -1243,7 +1209,7 @@ subroutine shoc_assumed_pdf(&
   call linear_interp(zi_grid,zt_grid,qwthl_sec,qwthl_sec_zt,nlevi,nlev,shcol,largeneg)
   call linear_interp(zi_grid,zt_grid,wqw_sec,wqw_sec_zt,nlevi,nlev,shcol,largeneg) !Alert
   call linear_interp(zi_grid,zt_grid,qw_sec,qw_sec_zt,nlevi,nlev,shcol,0._r8)  
-  call linear_interp(zi_grid,zt_grid,w_field,w_field_zt,nlevi,nlev,shcol,largeneg)
+  call linear_interp(zi_grid,zt_grid,w_field,w_field_zt,nlevi,nlev,shcol,largeneg)  
   
   do k=1,nlev
     do i=1,shcol
@@ -1513,7 +1479,7 @@ subroutine shoc_assumed_pdf(&
       wqls(i,k)=a*((w1_1-w_first)*ql1)+(1._r8-a)*((w1_2-w_first)*ql2)
       ! Compute the SGS buoyancy flux
       wthv_sec(i,k)=wthlsec+((1._r8-epsterm)/epsterm)*basetemp*wqwsec &
-        +((lcond/cp)*(basepres/pval)**(rgas/cp)-(1._r8/epsterm)*basetemp)*wqls(i,k)  
+        +((lcond/cp)*(basepres/pval)**(rgas/cp)-(1._r8/epsterm)*basetemp)*wqls(i,k)       
      	
     enddo  ! end i loop here
   enddo	  ! end k loop here
@@ -1650,11 +1616,6 @@ subroutine shoc_tke(&
   !  thus zero out here
   shear_prod(:,1) = 0._r8
   shear_prod(:,nlevi) = 0._r8
-  
-  write(*,*) 'TK_ZI_intke ', tk_zi
-  write(*,*) 'SHEAR_PROD ', shear_prod
-  write(*,*) 'UWIND ', u_wind
-  write(*,*) 'VWIND ', v_wind
   
   ! Interpolate shear production from interface to thermo grid
   call linear_interp(zi_grid,zt_grid,shear_prod,shear_prod_zt,nlevi,nlev,shcol,largeneg)
@@ -2025,15 +1986,7 @@ subroutine vd_shoc_decomp( &
   do i=1,shcol
     denom(i,1) = 1._r8/ &
       (1._r8 + ca(i,1) - ca(i,1) * ze(i,2))
-  enddo
-  
-  write(*,*) 'CC ', cc
-  write(*,*) 'CA ', ca
-  write(*,*) 'denom ', denom
-  write(*,*) 'ze ', ze
-  write(*,*) 'kv_term ', kv_term
-  write(*,*) 'tmpi ', tmpi
-  write(*,*) 'rdp_zt ', rdp_zt  
+  enddo 
   
   return
   

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1592,7 +1592,7 @@ subroutine shoc_tke(&
 
   ! Compute shear production term, which is on interface levels
   ! This follows the methods of Bretheron and Park (2010)
-  do k=2,nlev
+  do k=1,nlev-1
     do i=1,shcol
     
       kb=k+1     

--- a/components/cam/src/physics/cam/shoc_intr.F90
+++ b/components/cam/src/physics/cam/shoc_intr.F90
@@ -530,19 +530,7 @@ end function shoc_implements_cnst
    real(r8) :: dtime                            ! SHOC time step                              [s]   
    real(r8) :: edsclr_in(pcols,pver,edsclr_dim)      ! Scalars to be diffused through SHOC         [units vary]   
    real(r8) :: edsclr_out(pcols,pver,edsclr_dim)
-   real(r8) :: tke_in(pcols,pver)
-   real(r8) :: thlm_in(pcols,pver)
-   real(r8) :: thv_in(pcols,pver)
-   real(r8) :: temp_in(pcols,pver)
-   real(r8) :: qv_in(pcols,pver)
    real(r8) :: rcm_in(pcols,pver)
-   real(r8) :: rvm_in(pcols,pver)
-   real(r8) :: rtm_in(pcols,pver)
-   real(r8) :: wthv_in(pcols,pver)
-   real(r8) :: pres_in(pcols,pver)
-   real(r8) :: um_in(pcols,pver)
-   real(r8) :: vm_in(pcols,pver)
-   real(r8) :: pdel_in(pcols,pver)
    real(r8) :: cloudfrac_shoc(pcols,pver)
    real(r8) :: rcm_shoc(pcols,pver)
    real(r8) :: newfice(pcols,pver)              ! fraction of ice in cloud at CLUBB start       [-]
@@ -553,7 +541,6 @@ end function shoc_implements_cnst
    real(r8) :: rvm(pcols,pver)
    real(r8) :: rtm(pcols,pver)
    real(r8) :: rcm(pcols,pver)
-!   real(r8) :: tke(pcols,pver)
    real(r8) :: ksrftms(pcols)                   ! Turbulent mountain stress surface drag        [kg/s/m2]
    real(r8) :: tautmsx(pcols)                   ! U component of turbulent mountain stress      [N/m2]
    real(r8) :: tautmsy(pcols)                   ! V component of turbulent mountain stress      [N/m2]
@@ -573,12 +560,6 @@ end function shoc_implements_cnst
    real(r8) :: wtke_sec_out(pcols,pverp), uw_sec_out(pcols,pverp)
    real(r8) :: vw_sec_out(pcols,pverp), w3_out(pcols,pverp)
    real(r8) :: wqls_out(pcols,pver), brunt_out(pcols,pver)
-   real(r8) :: shoc_mix(pcols,pver)
-   real(r8) :: w_sec(pcols,pver), thl_sec(pcols,pverp)
-   real(r8) :: qw_sec(pcols,pverp), qwthl_sec(pcols,pverp)
-   real(r8) :: wthl_sec(pcols,pverp), wqw_sec(pcols,pverp)
-   real(r8) :: wtke_sec(pcols,pverp), uw_sec(pcols,pverp)
-   real(r8) :: vw_sec(pcols,pverp), w3(pcols,pverp), wqls(pcols,pver), brunt(pcols,pver)
 
    real(r8) :: wthl_output(pcols,pverp)
    real(r8) :: wqw_output(pcols,pverp)
@@ -849,27 +830,7 @@ end function shoc_implements_cnst
        upwp_sfc(i) = upwp_sfc(i)-((ksrftms(i)*state1%u(i,pver))/rrho_i(i,pverp))
        vpwp_sfc(i) = vpwp_sfc(i)-((ksrftms(i)*state1%v(i,pver))/rrho_i(i,pverp))
      enddo 
-   endif           
-
-   ! Transfer to SHOC input arrays
-   do k=1,pver
-     do i=1,ncol
-       um_in(i,k)      = um(i,k)
-       vm_in(i,k)      = vm(i,k)   
-       rvm_in(i,k)     = rvm(i,k)
-       rcm_in(i,k)     = rcm(i,k)
-       rtm_in(i,k)     = rtm(i,k)
-       thlm_in(i,k)    = thlm(i,k)
-       thv_in(i,k)     = thv(i,k)
-       temp_in(i,k)    = state%t(i,k)
-       tke_in(i,k)     = tke(i,k)
-       wthv_in(i,k)    = wthv(i,k)
-       tkh_in(i,k)     = tkh(i,k)
-       tk_in(i,k)      = tk(i,k)
-       pdel_in(i,k)    = state1%pdel(i,k)
-       pres_in(i,k)    = state1%pmid(i,k)
-     enddo  
-   enddo   
+   endif             
    
    !  Do the same for tracers 
    icnt=0
@@ -892,14 +853,14 @@ end function shoc_implements_cnst
 
      call shoc_main( &
           ncol, pver, pverp, dtime, & ! Input
-	  host_dx_in(:ncol), host_dy_in(:ncol), thv_in(:ncol,:),rcm_in(:ncol,:),& ! Input
-          zt_g(:ncol,:), zi_g(:ncol,:), pres_in(:ncol,:), pdel_in(:ncol,:),& ! Input
+	  host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),rcm(:ncol,:),& ! Input
+          zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state1%pdel(:ncol,:pver),& ! Input
 	  wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
 	  wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
-	  tke_in(:ncol,:), thlm_in(:ncol,:), rtm_in(:ncol,:), & ! Input/Ouput
-	  um_in(:ncol,:), vm_in(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
-	  wthv_in(:ncol,:),tkh_in(:ncol,:),tk_in(:ncol,:), & ! Input/Output
-          cloudfrac_shoc(:ncol,:), rcm_shoc(:ncol,:), & ! Output
+	  tke(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
+	  um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
+	  wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), & ! Input/Output
+          cloud_frac(:ncol,:), rcm_shoc(:ncol,:), & ! Output
           shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
           w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)          
           wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
@@ -914,43 +875,14 @@ end function shoc_implements_cnst
    
    do k=1,pver
      do i=1,ncol 
-       um(i,k) = um_in(i,k)
-       vm(i,k) = vm_in(i,k)
-       thlm(i,k) = thlm_in(i,k)
-       rtm(i,k) = rtm_in(i,k)
+     
        rcm(i,k) = rcm_shoc(i,k)
-       cloud_frac(i,k) = min(cloudfrac_shoc(i,k),1._r8)
-       wthv(i,k) = wthv_in(i,k)
-       tke(i,k) = tke_in(i,k)
+       cloud_frac(i,k) = min(cloud_frac(i,k),1._r8)
        
        do ixind=1,edsclr_dim
          edsclr_out(i,k,ixind) = edsclr_in(i,k,ixind)
        enddo      
-
-       shoc_mix(i,k) = shoc_mix_out(i,k)
-       tk(i,k) = tk_in(i,k)
-       tkh(i,k) = tkh_in(i,k)
-       isotropy(i,k) = isotropy_out(i,k)
-       w_sec(i,k) = w_sec_out(i,k)
-       wqls(i,k) = wqls_out(i,k)
-       brunt(i,k) = brunt_out(i,k)
  
-     enddo
-   enddo
-
-   do k=1,pverp
-     do i=1,ncol
-
-       w3(i,k) = w3_out(i,k)
-       thl_sec(i,k) = thl_sec_out(i,k)
-       qw_sec(i,k) = qw_sec_out(i,k)
-       qwthl_sec(i,k) = qwthl_sec_out(i,k)
-       wthl_sec(i,k) = wthl_sec_out(i,k)
-       wqw_sec(i,k) = wqw_sec_out(i,k)
-       wtke_sec(i,k) = wtke_sec_out(i,k)
-       uw_sec(i,k) = uw_sec_out(i,k)
-       vw_sec(i,k) = vw_sec_out(i,k)
-
      enddo
    enddo
 
@@ -1243,37 +1175,37 @@ end function shoc_implements_cnst
 
     do k=1,pverp
       do i=1,ncol
-        wthl_output(i,k) = wthl_sec(i,k) * rrho_i(i,k) * cpair
-        wqw_output(i,k) = wqw_sec(i,k) * rrho_i(i,k) * latvap 
+        wthl_output(i,k) = wthl_sec_out(i,k) * rrho_i(i,k) * cpair
+        wqw_output(i,k) = wqw_sec_out(i,k) * rrho_i(i,k) * latvap 
       enddo
     enddo
 
     do k=1,pver
       do i=1,ncol
         wthv_output(i,k) = wthv(i,k) * rrho(i,k) * cpair
-        wql_output(i,k) = wqls(i,k) * rrho(i,k) * latvap 
+        wql_output(i,k) = wqls_out(i,k) * rrho(i,k) * latvap 
       enddo
     enddo
 
     call outfld('SHOC_TKE', tke, pcols, lchnk)
     call outfld('WTHV_SEC', wthv_output, pcols, lchnk)
-    call outfld('SHOC_MIX', shoc_mix, pcols, lchnk)
+    call outfld('SHOC_MIX', shoc_mix_out, pcols, lchnk)
     call outfld('TK', tk, pcols, lchnk)
     call outfld('TKH', tkh, pcols, lchnk)
-    call outfld('W_SEC', w_sec, pcols, lchnk)
-    call outfld('THL_SEC', thl_sec, pcols, lchnk)
-    call outfld('QW_SEC', qw_sec, pcols, lchnk)
-    call outfld('QWTHL_SEC', qwthl_sec, pcols, lchnk)
+    call outfld('W_SEC', w_sec_out, pcols, lchnk)
+    call outfld('THL_SEC', thl_sec_out, pcols, lchnk)
+    call outfld('QW_SEC', qw_sec_out, pcols, lchnk)
+    call outfld('QWTHL_SEC', qwthl_sec_out, pcols, lchnk)
     call outfld('WTHL_SEC', wthl_output, pcols, lchnk)
     call outfld('WQW_SEC', wqw_output, pcols, lchnk)
-    call outfld('WTKE_SEC', wtke_sec, pcols, lchnk)
-    call outfld('UW_SEC', uw_sec, pcols, lchnk)
-    call outfld('VW_SEC', vw_sec, pcols, lchnk)
-    call outfld('W3', w3, pcols, lchnk)
+    call outfld('WTKE_SEC', wtke_sec_out, pcols, lchnk)
+    call outfld('UW_SEC', uw_sec_out, pcols, lchnk)
+    call outfld('VW_SEC', vw_sec_out, pcols, lchnk)
+    call outfld('W3', w3_out, pcols, lchnk)
     call outfld('WQL_SEC',wql_output, pcols, lchnk)
-    call outfld('ISOTROPY',isotropy, pcols,lchnk)
+    call outfld('ISOTROPY',isotropy_out, pcols,lchnk)
     call outfld('CONCLD',concld,pcols,lchnk)
-    call outfld('BRUNT',brunt,pcols,lchnk)
+    call outfld('BRUNT',brunt_out,pcols,lchnk)
 
 #endif    
     return         

--- a/components/cam/src/physics/cam/shoc_intr.F90
+++ b/components/cam/src/physics/cam/shoc_intr.F90
@@ -834,10 +834,10 @@ end function shoc_implements_cnst
    do i=1,ncol
       !  Surface fluxes provided by host model
 
-      wpthlp_sfc(i) = cam_in%shf(i)/(cpair*rrho_i(i,1))       ! Sensible heat flux
-      wprtp_sfc(i)  = cam_in%cflx(i,1)/(rrho_i(i,1))      ! Latent heat flux
-      upwp_sfc(i)   = cam_in%wsx(i)/rrho_i(i,1)               ! Surface meridional momentum flux
-      vpwp_sfc(i)   = cam_in%wsy(i)/rrho_i(i,1)               ! Surface zonal momentum flux  
+      wpthlp_sfc(i) = cam_in%shf(i)/(cpair*rrho_i(i,pverp))       ! Sensible heat flux
+      wprtp_sfc(i)  = cam_in%cflx(i,1)/(rrho_i(i,pverp))      ! Latent heat flux
+      upwp_sfc(i)   = cam_in%wsx(i)/rrho_i(i,pverp)               ! Surface meridional momentum flux
+      vpwp_sfc(i)   = cam_in%wsy(i)/rrho_i(i,pverp)               ! Surface zonal momentum flux  
       wtracer_sfc(i,:) = 0._r8  ! in E3SM tracer fluxes are done elsewhere
    enddo   
       
@@ -846,8 +846,8 @@ end function shoc_implements_cnst
    ! ------------------------------------------------- !    
    if ( do_tms) then
      do i=1,ncol
-       upwp_sfc(i) = upwp_sfc(i)-((ksrftms(i)*state1%u(i,pver))/rrho_i(i,1))
-       vpwp_sfc(i) = vpwp_sfc(i)-((ksrftms(i)*state1%v(i,pver))/rrho_i(i,1))
+       upwp_sfc(i) = upwp_sfc(i)-((ksrftms(i)*state1%u(i,pver))/rrho_i(i,pverp))
+       vpwp_sfc(i) = vpwp_sfc(i)-((ksrftms(i)*state1%v(i,pver))/rrho_i(i,pverp))
      enddo 
    endif           
 

--- a/components/cam/src/physics/cam/shoc_intr.F90
+++ b/components/cam/src/physics/cam/shoc_intr.F90
@@ -812,18 +812,18 @@ end function shoc_implements_cnst
    enddo
    
    !  Define the SHOC thermodynamic grid (in units of m)
-   wm_zt(:,1) = 0._r8
+   wm_zt(:,pver) = 0._r8
    do k=1,pver
      do i=1,ncol
-       zt_g(i,k) = state1%zm(i,pver-k+1)-state1%zi(i,pver+1)
-       rrho(i,k)=(1._r8/gravit)*(state1%pdel(i,pver-k+1)/dz_g(i,pver-k+1))
-       wm_zt(i,k) = -1._r8*state1%omega(i,pver-k+1)/(rrho(i,k)*gravit)
+       zt_g(i,k) = state1%zm(i,k)-state1%zi(i,pver+1)
+       rrho(i,k)=(1._r8/gravit)*(state1%pdel(i,k)/dz_g(i,k))
+       wm_zt(i,k) = -1._r8*state1%omega(i,k)/(rrho(i,k)*gravit)
      enddo
    enddo
      
    do k=1,pverp
      do i=1,ncol
-       zi_g(i,k) = state1%zi(i,pverp-k+1)-state1%zi(i,pver+1)
+       zi_g(i,k) = state1%zi(i,k)-state1%zi(i,pver+1)
      enddo
    enddo
 
@@ -851,23 +851,23 @@ end function shoc_implements_cnst
      enddo 
    endif           
 
-   ! Need to flip arrays around for SHOC 
+   ! Transfer to SHOC input arrays
    do k=1,pver
      do i=1,ncol
-       um_in(i,k)      = um(i,pver-k+1)
-       vm_in(i,k)      = vm(i,pver-k+1)   
-       rvm_in(i,k)     = rvm(i,pver-k+1)
-       rcm_in(i,k)     = rcm(i,pver-k+1)
-       rtm_in(i,k)     = rtm(i,pver-k+1)
-       thlm_in(i,k)    = thlm(i,pver-k+1)
-       thv_in(i,k)     = thv(i,pver-k+1)
-       temp_in(i,k)    = state%t(i,pver-k+1)
-       tke_in(i,k)     = tke(i,pver-k+1)
-       wthv_in(i,k)    = wthv(i,pver-k+1)
-       tkh_in(i,k)     = tkh(i,pver-k+1)
-       tk_in(i,k)      = tk(i,pver-k+1)
-       pdel_in(i,k)    = state1%pdel(i,pver-k+1)
-       pres_in(i,k)    = state1%pmid(i,pver-k+1)
+       um_in(i,k)      = um(i,k)
+       vm_in(i,k)      = vm(i,k)   
+       rvm_in(i,k)     = rvm(i,k)
+       rcm_in(i,k)     = rcm(i,k)
+       rtm_in(i,k)     = rtm(i,k)
+       thlm_in(i,k)    = thlm(i,k)
+       thv_in(i,k)     = thv(i,k)
+       temp_in(i,k)    = state%t(i,k)
+       tke_in(i,k)     = tke(i,k)
+       wthv_in(i,k)    = wthv(i,k)
+       tkh_in(i,k)     = tkh(i,k)
+       tk_in(i,k)      = tk(i,k)
+       pdel_in(i,k)    = state1%pdel(i,k)
+       pres_in(i,k)    = state1%pmid(i,k)
      enddo  
    enddo   
    
@@ -878,7 +878,7 @@ end function shoc_implements_cnst
        icnt=icnt+1
        do k=1,pver
          do i=1,ncol
-           edsclr_in(i,k,icnt) = state1%q(i,pver-k+1,ixind)
+           edsclr_in(i,k,icnt) = state1%q(i,k,ixind)
          enddo
        enddo
      end if
@@ -910,30 +910,30 @@ end function shoc_implements_cnst
 
    enddo  ! end time loop
    
-   ! Arrays need to be "flipped" to E3SM grid
+   ! Transfer back to pbuf variables
    
    do k=1,pver
      do i=1,ncol 
-       um(i,k) = um_in(i,pver-k+1)
-       vm(i,k) = vm_in(i,pver-k+1)
-       thlm(i,k) = thlm_in(i,pver-k+1)
-       rtm(i,k) = rtm_in(i,pver-k+1)
-       rcm(i,k) = rcm_shoc(i,pver-k+1)
-       cloud_frac(i,k) = min(cloudfrac_shoc(i,pver-k+1),1._r8)
-       wthv(i,k) = wthv_in(i,pver-k+1)
-       tke(i,k) = tke_in(i,pver-k+1)
+       um(i,k) = um_in(i,k)
+       vm(i,k) = vm_in(i,k)
+       thlm(i,k) = thlm_in(i,k)
+       rtm(i,k) = rtm_in(i,k)
+       rcm(i,k) = rcm_shoc(i,k)
+       cloud_frac(i,k) = min(cloudfrac_shoc(i,k),1._r8)
+       wthv(i,k) = wthv_in(i,k)
+       tke(i,k) = tke_in(i,k)
        
        do ixind=1,edsclr_dim
-         edsclr_out(i,k,ixind) = edsclr_in(i,pver-k+1,ixind)
+         edsclr_out(i,k,ixind) = edsclr_in(i,k,ixind)
        enddo      
 
-       shoc_mix(i,k) = shoc_mix_out(i,pver-k+1)
-       tk(i,k) = tk_in(i,pver-k+1)
-       tkh(i,k) = tkh_in(i,pver-k+1)
-       isotropy(i,k) = isotropy_out(i,pver-k+1)
-       w_sec(i,k) = w_sec_out(i,pver-k+1)
-       wqls(i,k) = wqls_out(i,pver-k+1)
-       brunt(i,k) = brunt_out(i,pver-k+1)
+       shoc_mix(i,k) = shoc_mix_out(i,k)
+       tk(i,k) = tk_in(i,k)
+       tkh(i,k) = tkh_in(i,k)
+       isotropy(i,k) = isotropy_out(i,k)
+       w_sec(i,k) = w_sec_out(i,k)
+       wqls(i,k) = wqls_out(i,k)
+       brunt(i,k) = brunt_out(i,k)
  
      enddo
    enddo
@@ -941,15 +941,15 @@ end function shoc_implements_cnst
    do k=1,pverp
      do i=1,ncol
 
-       w3(i,k) = w3_out(i,pverp-k+1)
-       thl_sec(i,k) = thl_sec_out(i,pverp-k+1)
-       qw_sec(i,k) = qw_sec_out(i,pverp-k+1)
-       qwthl_sec(i,k) = qwthl_sec_out(i,pverp-k+1)
-       wthl_sec(i,k) = wthl_sec_out(i,pverp-k+1)
-       wqw_sec(i,k) = wqw_sec_out(i,pverp-k+1)
-       wtke_sec(i,k) = wtke_sec_out(i,pverp-k+1)
-       uw_sec(i,k) = uw_sec_out(i,pverp-k+1)
-       vw_sec(i,k) = vw_sec_out(i,pverp-k+1)
+       w3(i,k) = w3_out(i,k)
+       thl_sec(i,k) = thl_sec_out(i,k)
+       qw_sec(i,k) = qw_sec_out(i,k)
+       qwthl_sec(i,k) = qwthl_sec_out(i,k)
+       wthl_sec(i,k) = wthl_sec_out(i,k)
+       wqw_sec(i,k) = wqw_sec_out(i,k)
+       wtke_sec(i,k) = wtke_sec_out(i,k)
+       uw_sec(i,k) = uw_sec_out(i,k)
+       vw_sec(i,k) = vw_sec_out(i,k)
 
      enddo
    enddo
@@ -1243,15 +1243,15 @@ end function shoc_implements_cnst
 
     do k=1,pverp
       do i=1,ncol
-        wthl_output(i,k) = wthl_sec(i,k) * rrho_i(i,pverp-k+1) * cpair
-        wqw_output(i,k) = wqw_sec(i,k) * rrho_i(i,pverp-k+1) * latvap 
+        wthl_output(i,k) = wthl_sec(i,k) * rrho_i(i,k) * cpair
+        wqw_output(i,k) = wqw_sec(i,k) * rrho_i(i,k) * latvap 
       enddo
     enddo
 
     do k=1,pver
       do i=1,ncol
-        wthv_output(i,k) = wthv(i,k) * rrho(i,pver-k+1) * cpair
-        wql_output(i,k) = wqls(i,k) * rrho(i,pver-k+1) * latvap 
+        wthv_output(i,k) = wthv(i,k) * rrho(i,k) * cpair
+        wql_output(i,k) = wqls(i,k) * rrho(i,k) * latvap 
       enddo
     enddo
 


### PR DESCRIPTION
This PR flips SHOC in the vertical to make it consistent with SCREAM/E3SM.  Now SHOC’s top level is index k =1 and SHOC’s bottom level is k=nlev for variables on the mid-point grid and k=nlevi for variables on the interface grid.  

Note that this PR does not produce B4B answers, as I thought it would.  After careful investigation I determined this was due to roundoff error from the linear interpolation routine, in which the weight calculation indexes needed to be flipped around so that the same exact calculation would be performed.  I did not implement this in the PR because the liner interpolation routine is also called in the SHOC interface for eddy diffusivity values.  Had I flipped the linear interpolation routine we still would not be assured b4b results because the linear interp routine was called on E3SM grid on the original code, not the SHOC flipped grid, thus those answers would have been subject to roundoff as well.  

The resulting code was validated in several SCM cases and a short climate run using the FSCREAM-LR compset.  The differences in answers are very minor and not climate changing.  