### PR TITLE
Autoconversion test refactor and clean-up.

### DIFF
--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(P3_TESTS_SRCS
   p3_ice_collection_unit_tests.cpp
   p3_rain_sed_unit_tests.cpp
   p3_dsd2_unit_tests.cpp
+  p3_autoconversion_tests.cpp
 )
 CreateUnitTest(p3_tests "${P3_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP p3_tests_ut_np1_omp1)
 

--- a/components/scream/src/physics/p3/tests/p3_autoconversion_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_autoconversion_tests.cpp
@@ -1,0 +1,151 @@
+#include "catch2/catch.hpp"
+
+#include "share/scream_types.hpp"
+#include "share/util/scream_utils.hpp"
+#include "share/scream_kokkos.hpp"
+#include "share/scream_pack.hpp"
+#include "physics/p3/p3_functions.hpp"
+#include "physics/p3/p3_functions_f90.hpp"
+#include "share/util/scream_kokkos_utils.hpp"
+
+#include "p3_unit_tests_common.hpp"
+
+#include <thread>
+#include <array>
+#include <algorithm>
+#include <random>
+#include <iomanip>      // std::setprecision
+
+namespace scream {
+namespace p3 {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestP3CloudWaterAutoconversion
+{
+
+static void  cloud_water_autoconversion_unit_bfb_tests(){
+
+  static constexpr Int max_pack_size = 16;
+  REQUIRE(Spack::n <= max_pack_size);
+
+  CloudWaterAutoconversionData cwadc[max_pack_size] = {
+    // rho, qc_incld, nc_incld
+    {9.703E-01, 5.100E-03, 2.061E+08},
+    {1.006E+00,  5.100E-03, 1.988E+08},
+    {1.139E+00 },
+    {1.151E+00,  1.000E-06, 1.737E+08},
+
+    {9.703E-01, 5.100E-03, 2.061E+08},
+    {1.006E+00,  5.100E-03, 1.988E+08},
+    {1.139E+00 },
+    {1.151E+00,  1.000E-06, 1.737E+08},
+
+    {9.703E-01, 5.100E-03, 2.061E+08},
+    {1.006E+00,  5.100E-03, 1.988E+08},
+    {1.139E+00 },
+    {1.151E+00,  1.000E-06, 1.737E+08},
+
+    {9.703E-01, 5.100E-03, 2.061E+08},
+    {1.006E+00,  5.100E-03, 1.988E+08},
+    {1.139E+00 },
+    {1.151E+00,  1.000E-06, 1.737E+08},
+  };
+
+  // Sync to device
+  view_1d<CloudWaterAutoconversionData> cwadc_device("cwadc", Spack::n);
+  auto cwadc_host = Kokkos::create_mirror_view(cwadc_device);
+
+  // This copy only copies the input variables.
+  std::copy(&cwadc[0], &cwadc[0] + Spack::n, cwadc_host.data());
+  Kokkos::deep_copy(cwadc_device, cwadc_host);
+
+  // Get data from fortran
+  for (Int i = 0; i < Spack::n; ++i) {
+    cloud_water_autoconversion(cwadc[i]);
+  }
+
+    // Run the lookup from a kernel and copy results back to host
+  Kokkos::parallel_for(RangePolicy(0, 1), KOKKOS_LAMBDA(const Int& i) {
+    // Init pack inputs
+    Spack rho, inv_rho, qc_incld, nc_incld, qr_incld, mu_c, nu, qcaut, ncautc, ncautr;
+    for (Int s = 0; s < Spack::n; ++s) {
+      rho[s] = cwadc_device(s).rho;
+      qc_incld[s] = cwadc_device(s).qc_incld;
+      nc_incld[s] = cwadc_device(s).nc_incld;
+      qcaut[s] = cwadc_device(s).qcaut;
+      ncautc[s] = cwadc_device(s).ncautc;
+      ncautr[s] = cwadc_device(s).ncautr;
+    }
+
+    Functions::cloud_water_autoconversion(rho, qc_incld, nc_incld,
+      qcaut, ncautc, ncautr);
+    // Copy results back into views
+    for (Int s = 0; s < Spack::n; ++s) {
+      cwadc_device(s).rho = rho[s];
+      cwadc_device(s).qc_incld = qc_incld[s];
+      cwadc_device(s).nc_incld = nc_incld[s];
+      cwadc_device(s).qcaut = qcaut[s];
+      cwadc_device(s).ncautc = ncautc[s];
+      cwadc_device(s).ncautr = ncautr[s];
+    }
+
+  });
+
+    // Sync back to host
+    Kokkos::deep_copy(cwadc_host, cwadc_device);
+
+    // Validate results
+    for (Int s = 0; s < Spack::n; ++s) {
+       REQUIRE(cwadc[s].rho == cwadc_host(s).rho);
+       REQUIRE(cwadc[s].qc_incld == cwadc_host(s).qc_incld);
+       REQUIRE(cwadc[s].nc_incld == cwadc_host(s).nc_incld);
+       REQUIRE(cwadc[s].qcaut == cwadc_host(s).qcaut);
+       REQUIRE(cwadc[s].ncautc == cwadc_host(s).ncautc);
+       REQUIRE(cwadc[s].ncautr == cwadc_host(s).ncautr);
+     }
+}
+
+  static void run_bfb(){
+    cloud_water_autoconversion_unit_bfb_tests();
+  }
+
+  KOKKOS_FUNCTION  static void autoconversion_is_positive(const Int &i, Int &errors){
+
+    const Spack rho(1.0);
+    Spack qc_incld, nc_incld(1e7), qcaut(0.0), ncautc(0.0), ncautr(0.0);
+    for(int si=0; si<Spack::n; ++si){
+        qc_incld[si] = 1e-6 * i * Spack::n + si;
+      }
+        Functions::cloud_water_autoconversion(rho, qc_incld, nc_incld, qcaut, ncautc, ncautr);
+        if((qcaut < 0.0).any()){errors++;}
+    }
+
+  static void run_physics(){
+
+    int nerr = 0;
+
+    Kokkos::parallel_reduce("TestAutoConversionPositive", 1000, KOKKOS_LAMBDA(const Int& i,  Int& errors) {
+      autoconversion_is_positive(i, errors);
+    }, nerr);
+
+    Kokkos::fence();
+    REQUIRE(nerr == 0);
+
+  }
+
+}; //  TestP3CloudWaterAutoconversion
+
+} // namespace unit_test
+} // namespace p3
+} // namespace scream
+
+namespace{
+
+TEST_CASE("p3_cloud_water_autoconversion_test", "[p3_cloud_water_autoconversion_test]"){
+  scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3CloudWaterAutoconversion::run_physics();
+  scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3CloudWaterAutoconversion::run_bfb();
+}
+
+} // namespace
+

--- a/components/scream/src/physics/p3/tests/p3_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_unit_tests.cpp
@@ -550,121 +550,6 @@ static void cloud_water_conservation_tests_device(){
 
 };
 
-template <typename D>
-struct UnitWrap::UnitTest<D>::TestP3CloudWaterAutoconversion
-{
-
-static void  cloud_water_autoconversion_unit_bfb_tests(){
-
-  static constexpr Int max_pack_size = 16;
-  REQUIRE(Spack::n <= max_pack_size);
-
-  CloudWaterAutoconversionData cwadc[max_pack_size] = {
-    { 0.97026902585098274, 5.1000000000000004e-3, 206128398.07453227},
-    { 1.0061301158991891,  5.1000000000000004e-3, 198781446.69316244},
-    { 1.1393248270523915 },
-    { 1.1512545299884895,  9.9999999999999995e-7, 173723529.23727444},
-
-    { 0.97026902585098274, 5.1000000000000004e-3, 206128398.07453227},
-    { 1.0061301158991891,  5.1000000000000004e-3, 198781446.69316244},
-    { 1.1393248270523915 },
-    { 1.1512545299884895,  9.9999999999999995e-7, 173723529.23727444},
-
-    { 0.97026902585098274, 5.1000000000000004e-3, 206128398.07453227},
-    { 1.0061301158991891,  5.1000000000000004e-3, 198781446.69316244},
-    { 1.1393248270523915 },
-    { 1.1512545299884895,  9.9999999999999995e-7, 173723529.23727444},
-
-    { 0.97026902585098274, 5.1000000000000004e-3, 206128398.07453227},
-    { 1.0061301158991891,  5.1000000000000004e-3, 198781446.69316244},
-    { 1.1393248270523915 },
-    { 1.1512545299884895,  9.9999999999999995e-7, 173723529.23727444},
-  };
-
-  // Sync to device
-  view_1d<CloudWaterAutoconversionData> cwadc_device("cwadc", Spack::n);
-  auto cwadc_host = Kokkos::create_mirror_view(cwadc_device);
-
-  // This copy only copies the input variables.
-  std::copy(&cwadc[0], &cwadc[0] + Spack::n, cwadc_host.data());
-  Kokkos::deep_copy(cwadc_device, cwadc_host);
-
-  // Get data from fortran
-  for (Int i = 0; i < Spack::n; ++i) {
-    cloud_water_autoconversion(cwadc[i]);
-  }
-
-    // Run the lookup from a kernel and copy results back to host
-  Kokkos::parallel_for(RangePolicy(0, 1), KOKKOS_LAMBDA(const Int& i) {
-    // Init pack inputs
-    Spack rho, inv_rho, qc_incld, nc_incld, qr_incld, mu_c, nu, qcaut, ncautc, ncautr;
-    for (Int s = 0; s < Spack::n; ++s) {
-      rho[s] = cwadc_device(s).rho;
-      qc_incld[s] = cwadc_device(s).qc_incld;
-      nc_incld[s] = cwadc_device(s).nc_incld;
-      qcaut[s] = cwadc_device(s).qcaut;
-      ncautc[s] = cwadc_device(s).ncautc;
-      ncautr[s] = cwadc_device(s).ncautr;
-    }
-
-    Functions::cloud_water_autoconversion(rho, qc_incld, nc_incld,
-      qcaut, ncautc, ncautr);
-    // Copy results back into views
-    for (Int s = 0; s < Spack::n; ++s) {
-      cwadc_device(s).rho = rho[s];
-      cwadc_device(s).qc_incld = qc_incld[s];
-      cwadc_device(s).nc_incld = nc_incld[s];
-      cwadc_device(s).qcaut = qcaut[s];
-      cwadc_device(s).ncautc = ncautc[s];
-      cwadc_device(s).ncautr = ncautr[s];
-    }
-
-  });
-
-    // Sync back to host
-    Kokkos::deep_copy(cwadc_host, cwadc_device);
-
-    // Validate results
-    for (Int s = 0; s < Spack::n; ++s) {
-       REQUIRE(cwadc[s].rho == cwadc_host(s).rho);
-       REQUIRE(cwadc[s].qc_incld == cwadc_host(s).qc_incld);
-       REQUIRE(cwadc[s].nc_incld == cwadc_host(s).nc_incld);
-       REQUIRE(cwadc[s].qcaut == cwadc_host(s).qcaut);
-       REQUIRE(cwadc[s].ncautc == cwadc_host(s).ncautc);
-       REQUIRE(cwadc[s].ncautr == cwadc_host(s).ncautr);
-     }
-}
-
-  static void run_bfb(){
-    cloud_water_autoconversion_unit_bfb_tests();
-  }
-
-  KOKKOS_FUNCTION  static void autoconversion_is_positive(const Int &i, Int &errors){
-
-    const Spack rho(1.0);
-    Spack qc_incld, nc_incld(1e7), qcaut(0.0), ncautc(0.0), ncautr(0.0);
-    for(int si=0; si<Spack::n; ++si){
-        qc_incld[si] = 1e-6 * i * Spack::n + si;
-      }
-        Functions::cloud_water_autoconversion(rho, qc_incld, nc_incld, qcaut, ncautc, ncautr);
-        if((qcaut < 0.0).any()){errors++;}
-    }
-
-  static void run_physics(){
-
-    int nerr = 0;
-
-    Kokkos::parallel_reduce("TestAutoConversionPositive", 1000, KOKKOS_LAMBDA(const Int& i,  Int& errors) {
-      autoconversion_is_positive(i, errors);
-    }, nerr);
-
-    Kokkos::fence();
-    REQUIRE(nerr == 0);
-
-  }
-
-}; //  TestP3CloudWaterAutoconversion
-
   template <typename D>
   struct UnitWrap::UnitTest<D>::TestP3UpdatePrognosticIce
   {
@@ -1015,11 +900,6 @@ TEST_CASE("p3_functions", "[p3_functions]")
 TEST_CASE("p3_conservation_test", "[p3_conservation_test]"){
   scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3Conservation::run();
   scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3Conservation::run_bfb(); 
-}
-
-TEST_CASE("p3_cloud_water_autoconversion_test", "[p3_cloud_water_autoconversion_test]"){
-  scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3CloudWaterAutoconversion::run_physics();
-  scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3CloudWaterAutoconversion::run_bfb();
 }
 
 TEST_CASE("p3_update_prognostic_ice_test", "[p3_update_prognostic_ice_test]"){


### PR DESCRIPTION
Move autoconversion tests into their own source file and do a bit of code clean-up.