### PR TITLE
SHOC refactor (PBL depth, energy calculation, substep)

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -2251,6 +2251,10 @@ subroutine shoc_energy_integrals(&
   integer :: i, k
   real(r8) :: rvm
   
+  se_int(:) = 0._r8
+  ke_int(:) = 0._r8
+  wv_int(:) = 0._r8
+  wl_int(:) = 0._r8
   do k=1,nlev
     do i=1,shcol
        rvm = rtm(i,k) - rcm(i,k) ! compute water vapor
@@ -2304,7 +2308,7 @@ subroutine update_host_temp(&
   do k=1,nlev
     do i=1,shcol
       temp = (thlm(i,k)+(lcond/cp)*shoc_ql(i,k))/exner(i,k)
-      host_temp(i,k) = cp*temp+ ggr*zt_grid(i,k)+phis(i)
+      host_temp(i,k) = cp*temp+ggr*zt_grid(i,k)+phis(i)
     enddo
   enddo
 
@@ -2364,7 +2368,7 @@ subroutine shoc_energy_fixer(&
   ! heights on interface grid [m] 
   real(r8), intent(in) :: zi_grid(shcol,nlev)    
   ! pressure on interface grid [Pa] 
-  real(r8), intent(in) :: pint(shcol,nlev)   
+  real(r8), intent(in) :: pint(shcol,nlevi)   
   ! density on midpoint grid [kg/m^3] 
   real(r8), intent(in) :: rho_zt(shcol,nlev) 
   !turbulent kinetic energy [m^2/s^2] 
@@ -2395,7 +2399,7 @@ subroutine shoc_energy_fixer(&
     lhf=wqw_sfc(i)*rho_zi(i,nlevi)
     te_a(i) = se_a(i) + ke_a(i) + (lcond+lice)*wv_a(i)+lice*wl_a(i)
     te_b(i) = se_b(i) + ke_b(i) + (lcond+lice)*wv_b(i)+lice*wl_b(i)
-    te_b(i) = te_b(i)+((shf+lhf)*(lcond+lice))*hdtime
+    te_b(i) = te_b(i)+(shf+(lhf)*(lcond+lice))*hdtime
   enddo    
   
   ! Limit the energy fixer to find highest layer where SHOC is active

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -317,9 +317,9 @@ subroutine shoc_main ( &
   ! conserves) and static energy (which E3SM conserves) are not exactly equal. 
   
   call shoc_energy_integrals(&
-         shcol,nlev,host_temp,pdel,&
-	 qw,shoc_ql,u_wind,v_wind,&
-	 se_b,ke_b,wv_b,wl_b)
+         shcol,nlev,host_temp,pdel,&            ! Input
+	 qw,shoc_ql,u_wind,v_wind,&             ! Input
+	 se_b,ke_b,wv_b,wl_b)                   ! Input/Output
 
   do t=1,nadv
 
@@ -431,19 +431,19 @@ subroutine shoc_main ( &
          shoc_ql,exner,zt_grid,phis,&          ! Input
 	 host_temp)	                       ! Output
   
-  call shoc_energy_integrals(&
-         shcol,nlev,host_temp,pdel,&
-	 qw,shoc_ql,u_wind,v_wind,&
-	 se_a,ke_a,wv_a,wl_a)
+  call shoc_energy_integrals(&                 ! Input
+         shcol,nlev,host_temp,pdel,&           ! Input
+	 qw,shoc_ql,u_wind,v_wind,&            ! Input
+	 se_a,ke_a,wv_a,wl_a)                  ! Output
 	 
   call shoc_energy_fixer(&
-         shcol,nlev,nlevi,dtime,nadv,&
-	 zt_grid,zi_grid,&
-         se_b,ke_b,wv_b,wl_b,&
-	 se_a,ke_a,wv_a,wl_a,&
-	 wthl_sfc,wqw_sfc,pdel,&
-	 rho_zt,tke,presi,&
-	 host_temp)
+         shcol,nlev,nlevi,dtime,nadv,&         ! Input
+	 zt_grid,zi_grid,&                     ! Input
+         se_b,ke_b,wv_b,wl_b,&                 ! Input
+	 se_a,ke_a,wv_a,wl_a,&                 ! Input
+	 wthl_sfc,wqw_sfc,pdel,&               ! Input
+	 rho_zt,tke,presi,&                    ! Input
+	 host_temp)                            ! Input/Output
     
   ! Remaining code is to diagnose certain quantities
   !  related to PBL.  No answer changing subroutines
@@ -2213,9 +2213,9 @@ end subroutine vd_shoc_solve
 !  with host model
 
 subroutine shoc_energy_integrals(&
-             shcol,nlev,host_temp,pdel,&
-	     rtm,rcm,u_wind,v_wind,&
-	     se_int,ke_int,wv_int,wl_int)
+             shcol,nlev,host_temp,pdel,&    ! Input
+	     rtm,rcm,u_wind,v_wind,&        ! Input
+	     se_int,ke_int,wv_int,wl_int)   ! Output
 
   implicit none
 
@@ -2320,13 +2320,13 @@ end subroutine update_host_temp
 ! Subroutine foe SHOC energy fixer with host model temp
 
 subroutine shoc_energy_fixer(&
-             shcol,nlev,nlevi,dtime,nadv,&
-	     zt_grid,zi_grid,& 
-             se_b,ke_b,wv_b,wl_b,&
-	     se_a,ke_a,wv_a,wl_a,&
-	     wthl_sfc,wqw_sfc,pdel,&
-	     rho_zt,tke,pint,&
-	     host_temp)
+             shcol,nlev,nlevi,dtime,nadv,&  ! Input
+	     zt_grid,zi_grid,&              ! Input
+             se_b,ke_b,wv_b,wl_b,&          ! Input
+	     se_a,ke_a,wv_a,wl_a,&          ! Input
+	     wthl_sfc,wqw_sfc,pdel,&        ! Input
+	     rho_zt,tke,pint,&              ! Input
+	     host_temp)                     ! Input/Output
 	     
   implicit none
 

--- a/components/cam/src/physics/cam/shoc_intr.F90
+++ b/components/cam/src/physics/cam/shoc_intr.F90
@@ -502,7 +502,6 @@ end function shoc_implements_cnst
    real(r8) :: edsclr_out(pcols,pver,edsclr_dim)
    real(r8) :: rcm_in(pcols,pver)
    real(r8) :: cloudfrac_shoc(pcols,pver)
-   real(r8) :: rcm_shoc(pcols,pver)
    real(r8) :: newfice(pcols,pver)              ! fraction of ice in cloud at CLUBB start       [-]
    real(r8) :: exner(pcols,pver)
    real(r8) :: thlm(pcols,pver)
@@ -797,35 +796,27 @@ end function shoc_implements_cnst
    ! Actually call SHOC                                !
    ! ------------------------------------------------- !   
 
-   do t=1,nadv
-
-     call shoc_main( &
-          ncol, pver, pverp, dtime, & ! Input
-	  host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),rcm(:ncol,:),& ! Input
-          zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state1%pdel(:ncol,:pver),& ! Input
-	  wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
-	  wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
-	  tke(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
-	  um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
-	  wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), & ! Input/Output
-          cloud_frac(:ncol,:), rcm_shoc(:ncol,:), & ! Output
-	  pblh(:ncol), & ! Output 
-          shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
-          w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)          
-          wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
-          uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
-          wqls_out(:ncol,:),brunt_out(:ncol,:)) ! Output (diagnostic)
-
-          rcm_in(:,:) = rcm_shoc(:,:)
-
-   enddo  ! end time loop
+   call shoc_main( &
+        ncol, pver, pverp, dtime, nadv, & ! Input
+	host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),& ! Input
+        zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state1%pdel(:ncol,:pver),& ! Input
+	wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
+	wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
+	tke(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
+	um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
+	wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), rcm(:ncol,:), & ! Input/Output
+        cloud_frac(:ncol,:), pblh(:ncol), & ! Output
+        shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
+        w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)   
+        wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
+        uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
+        wqls_out(:ncol,:),brunt_out(:ncol,:)) ! Output (diagnostic)
    
    ! Transfer back to pbuf variables
    
    do k=1,pver
      do i=1,ncol 
      
-       rcm(i,k) = rcm_shoc(i,k)
        cloud_frac(i,k) = min(cloud_frac(i,k),1._r8)
        
        do ixind=1,edsclr_dim

--- a/components/cam/src/physics/cam/shoc_intr.F90
+++ b/components/cam/src/physics/cam/shoc_intr.F90
@@ -520,6 +520,7 @@ end function shoc_implements_cnst
    real(r8) :: cloud_frac(pcols,pver)          ! CLUBB cloud fraction                          [fraction]
    real(r8) :: dlf2(pcols,pver)
    real(r8) :: isotropy(pcols,pver)
+   real(r8) :: host_temp(pcols,pver)
    real(r8) :: host_dx_in(pcols), host_dy_in(pcols)  
    real(r8) :: shoc_mix_out(pcols,pver), tk_in(pcols,pver), tkh_in(pcols,pver)
    real(r8) :: isotropy_out(pcols,pver)
@@ -756,6 +757,7 @@ end function shoc_implements_cnst
        zt_g(i,k) = state1%zm(i,k)-state1%zi(i,pver+1)
        rrho(i,k)=(1._r8/gravit)*(state1%pdel(i,k)/dz_g(i,k))
        wm_zt(i,k) = -1._r8*state1%omega(i,k)/(rrho(i,k)*gravit)
+       host_temp(i,k) = state1%s(i,k)
      enddo
    enddo
      
@@ -802,7 +804,8 @@ end function shoc_implements_cnst
         zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state1%pdel(:ncol,:pver),& ! Input
 	wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
 	wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
-	tke(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
+	exner(:ncol,:),state1%phis(:ncol), & ! Input
+	host_temp(:ncol,:), tke(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
 	um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
 	wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), rcm(:ncol,:), & ! Input/Output
         cloud_frac(:ncol,:), pblh(:ncol), & ! Output

--- a/components/cam/src/physics/cam/shoc_intr.F90
+++ b/components/cam/src/physics/cam/shoc_intr.F90
@@ -7,7 +7,7 @@ module shoc_intr
   !                                                                    !
   ! SHOC replaces the exisiting turbulence, shallow convection, and    !
   !   macrophysics in E3SM                                             !  
-  !                                                                    !  
+  !                                                                    !  p
   !                                                                    !
   !---------------------------Code history---------------------------- !
   ! Authors:  P. Bogenschutz                                           ! 
@@ -426,7 +426,7 @@ end function shoc_implements_cnst
  
     call shoc_init( &
           gravit, rair, rh2o, cpair, &
-	  latvap)   
+	  zvir, latvap, karman)   
     
     ! --------------- !
     ! End             !
@@ -861,6 +861,7 @@ end function shoc_implements_cnst
 	  um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
 	  wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), & ! Input/Output
           cloud_frac(:ncol,:), rcm_shoc(:ncol,:), & ! Output
+	  obklen(:ncol), & ! Output 
           shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
           w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)          
           wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
@@ -1148,13 +1149,13 @@ end function shoc_implements_cnst
     enddo
  
     ! diagnose surface friction and obukhov length (inputs to diagnose PBL depth)
-    do i=1,ncol
-      rrho(i,1) = (1._r8/gravit)*(state1%pdel(i,pver)/dz_g(i,pver))
-      call calc_ustar( state1%t(i,pver), state1%pmid(i,pver), cam_in%wsx(i), cam_in%wsy(i), &
-                       rrho(i,1), ustar2(i) )
-      call calc_obklen( th(i,pver), thv(i,pver), cam_in%cflx(i,1), cam_in%shf(i), rrho(i,1), ustar2(i), &
-                        kinheat(i), kinwat(i), kbfs(i), obklen(i) )  
-    enddo
+!    do i=1,ncol
+!      rrho(i,1) = (1._r8/gravit)*(state1%pdel(i,pver)/dz_g(i,pver))
+!      call calc_ustar( state1%t(i,pver), state1%pmid(i,pver), cam_in%wsx(i), cam_in%wsy(i), &
+!                       rrho(i,1), ustar2(i) )
+!      call calc_obklen( th(i,pver), thv(i,pver), cam_in%cflx(i,1), cam_in%shf(i), rrho(i,1), ustar2(i), &
+!                        kinheat(i), kinwat(i), kbfs(i), obklen(i) )  
+!    enddo
    
     dummy2(:) = 0._r8
     dummy3(:) = 0._r8
@@ -1162,10 +1163,11 @@ end function shoc_implements_cnst
     where (kbfs .eq. -0.0_r8) kbfs = 0.0_r8
 
     !  Compute PBL depth according to Holtslag-Boville Scheme
-    call pblintd(ncol, thv, state1%zm, state1%u, state1%v, &
-                ustar2, obklen, kbfs, pblh, dummy2, &
-                state1%zi, cloud_frac(:,1:pver), 1._r8-cam_in%landfrac, dummy3)  
+!    call pblintd(ncol, thv, state1%zm, state1%u, state1%v, &
+!                ustar2, obklen, kbfs, pblh, dummy2, &
+!                state1%zi, cloud_frac(:,1:pver), 1._r8-cam_in%landfrac, dummy3)  
 		
+!    write(*,*) 'PBLh ', pblh(:)		
     ! Assign the first pver levels of cloud_frac back to cld
     cld(:,1:pver) = cloud_frac(:,1:pver)	
 

--- a/components/cam/src/physics/cam/shoc_intr.F90
+++ b/components/cam/src/physics/cam/shoc_intr.F90
@@ -78,8 +78,7 @@ module shoc_intr
       shoc_liq_sh = 10.e-6, &
       shoc_ice_deep = 25.e-6, &
       shoc_ice_sh = 50.e-6  
-      
-  logical      :: do_tms    
+         
   logical      :: lq(pcnst)
   logical      :: lq2(pcnst)
  
@@ -122,7 +121,6 @@ module shoc_intr
     
     call phys_getopts( eddy_scheme_out                 = eddy_scheme, &
                        deep_scheme_out                 = deep_scheme, & 
-                       do_tms_out                      = do_tms,      &
                        history_budget_out              = history_budget, &
                        history_budget_histfile_num_out = history_budget_histfile_num, &
                        micro_do_icesupersat_out        = micro_do_icesupersat, &
@@ -347,27 +345,6 @@ end function shoc_implements_cnst
        lq(ixnumliq) = .false.
        edsclr_dim = edsclr_dim-1
     endif 
-
-    ! ----------------------------------------------------------------- !
-    ! Initialize turbulent mountain stress module                       !
-    ! ------------------------------------------------------------------!
-
-    if ( do_tms) then
-       call init_tms( r8, tms_orocnst, tms_z0fac, karman, gravit, rair, errstring)
-       call handle_errmsg(errstring, subname="init_tms")
-
-       call addfld( 'TAUTMSX' ,  horiz_only,  'A','N/m2',  'Zonal      turbulent mountain surface stress' )
-       call addfld( 'TAUTMSY' ,  horiz_only,  'A','N/m2',  'Meridional turbulent mountain surface stress' )
-       if (history_amwg) then
-          call add_default( 'TAUTMSX ', 1, ' ' )
-          call add_default( 'TAUTMSY ', 1, ' ' )
-       end if
-       if (masterproc) then
-          write(iulog,*)'Using turbulent mountain stress module'
-          write(iulog,*)'  tms_orocnst = ',tms_orocnst
-          write(iulog,*)'  tms_z0fac = ',tms_z0fac
-       end if
-    endif
 
     ! Add SHOC fields
     call addfld('SHOC_TKE', (/'lev'/), 'A', 'm2/s2', 'TKE')
@@ -758,18 +735,6 @@ end function shoc_implements_cnst
        wl_b(i) = wl_b(i) + state1%q(i,k,ixcldliq)*state1%pdel(i,k)/gravit
      enddo
    enddo
-   
-   ! ------------------------------------------------- !
-   ! Begin module to compute turbulent mountain stress !
-   ! ------------------------------------------------- !
-    if ( do_tms) then
-       call t_startf('compute_tms')
-       call compute_tms( pcols,        pver,      ncol,                   &
-                     state1%u,     state1%v,  state1%t,  state1%pmid, &
-                     state1%exner, state1%zm, sgh30,     ksrftms,     &
-                     tautmsx,      tautmsy,   cam_in%landfrac ) 
-       call t_stopf('compute_tms')
-    endif
     
    ! ------------------------------------------------- !
    ! End module to compute turbulent mountain stress   !
@@ -813,17 +778,7 @@ end function shoc_implements_cnst
       upwp_sfc(i)   = cam_in%wsx(i)/rrho_i(i,pverp)               ! Surface meridional momentum flux
       vpwp_sfc(i)   = cam_in%wsy(i)/rrho_i(i,pverp)               ! Surface zonal momentum flux  
       wtracer_sfc(i,:) = 0._r8  ! in E3SM tracer fluxes are done elsewhere
-   enddo   
-      
-   ! ------------------------------------------------- !
-   ! Apply TMS                                         !
-   ! ------------------------------------------------- !    
-   if ( do_tms) then
-     do i=1,ncol
-       upwp_sfc(i) = upwp_sfc(i)-((ksrftms(i)*state1%u(i,pver))/rrho_i(i,pverp))
-       vpwp_sfc(i) = vpwp_sfc(i)-((ksrftms(i)*state1%v(i,pver))/rrho_i(i,pverp))
-     enddo 
-   endif             
+   enddo               
    
    !  Do the same for tracers 
    icnt=0

--- a/components/cam/src/physics/cam/shoc_intr.F90
+++ b/components/cam/src/physics/cam/shoc_intr.F90
@@ -395,7 +395,7 @@ end function shoc_implements_cnst
  
     call shoc_init( &
           pver, gravit, rair, rh2o, cpair, &
-	  zvir, latvap, karman, &
+	  zvir, latvap, latice, karman, &
 	  pref_mid, nbot_shoc, ntop_shoc )   
     
     ! --------------- !
@@ -801,7 +801,7 @@ end function shoc_implements_cnst
    call shoc_main( &
         ncol, pver, pverp, dtime, nadv, & ! Input
 	host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),& ! Input
-        zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state1%pdel(:ncol,:pver),& ! Input
+        zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
 	wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
 	wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
 	exner(:ncol,:),state1%phis(:ncol), & ! Input

--- a/components/scream/src/physics/shoc/scream_shoc_interface.F90
+++ b/components/scream/src/physics/shoc/scream_shoc_interface.F90
@@ -39,6 +39,8 @@ module scream_shoc_interface_mod
   real(kind=c_real) :: cpliq  =    4188.00000000000
   real(kind=c_real) :: tmelt  =    273.150000000000
   real(kind=c_real) :: pi     =    3.14159265358979
+  real(kind=c_real) :: karman =    0.40000000000000
+  real(kind=c_real) :: zvir   =    0.60779307282415
 
 contains
 
@@ -48,13 +50,30 @@ contains
     use shoc,                   only: shoc_init,r8
  
     real(kind=c_real), intent(inout) :: q(pcols,pver,9) ! State array  kg/kg
+    
+    real(kind=c_real) :: pref_mid(pcols,pver)           ! pressure at midlevel hPa
+    integer(kind=c_int) :: its, ite, kts, kte
 
-    call shoc_init( &
+    kts     = 1
+    kte     = pver
+
+    do k = kte,kts,-1 
+      pref_mid(:,k)    = 1e3_rtype - (1e3_rtype-0.1)/real(pver)!state%pmid(:,:)
+    end do
+
+    call shoc_init(& 
+          integer(pver),&
           real(gravit,kind=r8),&
           real(rair,kind=r8),  &
           real(rh2o,kind=r8),  &
           real(cpair,kind=r8), &
-          real(latvap,kind=r8))   
+	  real(zvir,kind=r8),  &
+          real(latvap,kind=r8),&
+	  real(latice,kind=r8),&
+	  real(karman,kind=r8),&
+	  pref_mid,            &
+	  integer(kte),&
+	  integer(kts))   
 
     q(:,:,:) = 0.0_rtype
     q(:,:,1) = 1.0e-5_rtype!state%q(:,:,1)


### PR DESCRIPTION
This PR:
1) Moves the PBL depth diagnostic calculation into shoc.F90. 
2) Moves the energy fixer calculation from the SHOC interface to shoc.F90
3) Moves the SHOC substep loop from SHOC interface into shoc.F90

NOTE that this PR also removes all code in shoc_intr.F90 related to turbulent mountain stress (TMS).  do_tms always = .false. for E3SM/SCREAM runs.  This was legacy code from CAM5 days that got wrapped into shoc_intr.F90 when using clubb_intr.F90 as a template, thus is not needed.  

In addition, a bug where SHOC was not using the von karman constant consistent with the host model has also been fixed.  

This PR is not b4b (but non climate changing) because of step 1), where the PBL calculation was moved and due to order of operations this routine sees a slightly different state.  The von karman bug also contributes to this PR being non b4b.  Incremental implementations of steps 2) and 3) provided b4b answers with the last iteration, as expected.  