### PR TITLE
Warnings suppression

### DIFF
--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -85,8 +85,8 @@ module micro_p3_utils
 real(rtype), parameter :: dsph = 3._rtype
 
 ! Bounds for mean diameter for different constituents.
-real(rtype), parameter :: lam_bnd_rain(2) = 1._rtype/[500.e-6_rtype, 20.e-6_rtype]
-real(rtype), parameter :: lam_bnd_snow(2) = 1._rtype/[2000.e-6_rtype, 10.e-6_rtype]
+! real(rtype), parameter :: lam_bnd_rain(2) = 1._rtype/[500.e-6_rtype, 20.e-6_rtype]
+! real(rtype), parameter :: lam_bnd_snow(2) = 1._rtype/[2000.e-6_rtype, 10.e-6_rtype]
 
 ! Minimum average mass of particles.
 real(rtype), parameter :: min_mean_mass_liq = 1.e-20_rtype
@@ -118,8 +118,6 @@ real(rtype), parameter :: precip_limit  = 1.0E-2
     real(rtype), intent(in) :: pi
     integer, intent(in)     :: iulog
     logical(btype), intent(in)     :: masterproc
-
-    real(rtype) :: ice_lambda_bounds(2)
 
     ! logfile info
     iulog_e3sm      = iulog

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -8,6 +8,12 @@ else()
   set(CIME_BUILD TRUE)
 endif()
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+  # The new behavior for cmp0074 makes cmake use (rather than ignore)
+  # any <PackageName>_ROOT env/cmake variable previously set.
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 # Add the ./cmake folder to cmake path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/components/scream/src/physics/p3/scream_p3_interface.F90
+++ b/components/scream/src/physics/p3/scream_p3_interface.F90
@@ -70,7 +70,7 @@ contains
     real(kind=c_real), intent(inout) :: naai(pcols,pver)     ! ice nucleation number
     real(kind=c_real), intent(inout) :: npccn(pcols,pver)    ! liquid activation number tendency
 
-    character(len=100) :: case_title, tmp_c1, tmp_c2
+    character(len=100) :: case_title
 
     integer(kind=c_int) :: i, k
     logical(kind=c_bool) :: masterproc

--- a/components/scream/src/physics/shoc/scream_shoc_interface.F90
+++ b/components/scream/src/physics/shoc/scream_shoc_interface.F90
@@ -52,8 +52,7 @@ contains
     real(kind=c_real), intent(inout) :: q(pcols,pver,9) ! State array  kg/kg
     
     real(kind=r8) :: pref_mid(pcols,pver) ! pressure at midlevel hPa; r8 for now b/c shoc supports only r8 currently
-    integer(kind=c_int) :: its, ite, kts, kte, k
-    real(kind=c_real) :: karman
+    integer(kind=c_int) :: kts, kte, k
 
     kts     = 1
     kte     = pver


### PR DESCRIPTION
Suppress a config warning due to cmake policy 0074, as well as a handful of build warnings from f90 (unused vars).