### PR TITLE
Removing useless sed for f90 config file

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -189,8 +189,6 @@ print_var(SCREAM_LIB_ONLY)
 add_definitions(-DSCREAM_CONFIG_IS_CMAKE)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/scream_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/src/scream_config.h)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/scream_config.f.in ${CMAKE_CURRENT_BINARY_DIR}/src/scream_config.f)
-# Run sed to change '/*...*/' comments into '!/*...*/'
-execute_process(COMMAND sed -i "s;^/;!/;g" ${CMAKE_CURRENT_BINARY_DIR}/src/scream_config.f)
 
 set(SCREAM_DYNAMICS_DYCORE "NONE" CACHE STRING "The name of the dycore to be used for dynamics. If NONE, then any code/test requiring dynamics is disabled.")
 string(TOUPPER "${SCREAM_DYNAMICS_DYCORE}" SCREAM_DYNAMICS_DYCORE)


### PR DESCRIPTION
The fortran config file is already different from the C one, in that it has comments with the `! blah` syntax, so no need to run sed.

Fixes #61.