### PR TITLE
Non-BFB portion of rain_immersion_freezing p3 conversion.

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -2565,6 +2565,9 @@ subroutine rain_immersion_freezing(t,    &
 lamr, mu_r, cdistr, qr_incld,    &
 qrheti, nrheti)
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+   use micro_p3_iso_f, only: cxx_log, cxx_gamma, cxx_exp
+#endif
    !............................................................
    ! immersion freezing of rain
    ! for future: get rid of log statements below for rain freezing
@@ -2584,10 +2587,8 @@ qrheti, nrheti)
 
    if (qr_incld.ge.qsmall .and. t.le.rainfrze) then
 
-      Q_nuc = cons6*exp(log(cdistr)+log(gamma(7._rtype+mu_r))-6._rtype*log(lamr))* &
-      exp(aimm*(zerodegc-t))
-      N_nuc = cons5*exp(log(cdistr)+log(gamma(mu_r+4._rtype))-3._rtype*log(lamr))* &
-      exp(aimm*(zerodegc-t))
+      Q_nuc = cons6*bfb_exp(bfb_log(cdistr) + bfb_log(bfb_gamma(7._rtype+mu_r)) - 6._rtype*bfb_log(lamr))*bfb_exp(aimm*(zerodegc-t))
+      N_nuc = cons5*bfb_exp(bfb_log(cdistr) + bfb_log(bfb_gamma(mu_r+4._rtype)) - 3._rtype*bfb_log(lamr))*bfb_exp(aimm*(zerodegc-t))
 
       qrheti = Q_nuc
       nrheti = N_nuc


### PR DESCRIPTION
This is a non-BFB prelude to the conversion of the `rain_immersion_freezing` subroutine. It replaces calls to some Fortran math functions (`exp`, `log`, `gamma`) with C++ equivalents in preparation for a Kokkos/C++ replacement.