### PR TITLE
Converted cldliq_immersion_freezing subroutine to C++/Kokkos

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -2533,7 +2533,7 @@ subroutine cldliq_immersion_freezing(t,lamc,mu_c,cdist1,qc_incld,    &
            qcheti,ncheti)
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
-   use micro_p3_iso_f, only: cxx_pow, cxx_gamma, cxx_exp
+   use micro_p3_iso_f, only: cldliq_immersion_freezing_f, cxx_pow, cxx_gamma, cxx_exp
 #endif
    !............................................................
    ! contact and immersion freezing droplets

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -2533,7 +2533,7 @@ subroutine cldliq_immersion_freezing(t,lamc,mu_c,cdist1,qc_incld,    &
            qcheti,ncheti)
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
-   use micro_p3_iso_f, only: cxx_gamma, cxx_exp
+   use micro_p3_iso_f, only: cxx_pow, cxx_gamma, cxx_exp
 #endif
    !............................................................
    ! contact and immersion freezing droplets
@@ -2551,11 +2551,16 @@ subroutine cldliq_immersion_freezing(t,lamc,mu_c,cdist1,qc_incld,    &
 
    real(rtype) :: dum, Q_nuc, N_nuc
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+   if (use_cxx) then
+      call cldliq_immersion_freezing_f(t,lamc,mu_c,cdist1,qc_incld,qcheti,ncheti)
+      return
+   endif
+#endif
    if (qc_incld.ge.qsmall .and. t.le.rainfrze) then
       ! for future: calculate gamma(mu_c+4) in one place since its used multiple times  !AaronDonahue, TODO
-      dum   = (1._rtype/lamc)**3
-      Q_nuc = cons6*cdist1*bfb_gamma(7._rtype+mu_c)*bfb_exp(aimm*(zerodegc-t))*dum**2
-      N_nuc = cons5*cdist1*bfb_gamma(mu_c+4._rtype)*bfb_exp(aimm*(zerodegc-t))*dum
+      Q_nuc = cons6*cdist1*bfb_gamma(7._rtype+mu_c)*bfb_exp(aimm*(zerodegc-t))*bfb_pow(lamc, -6.0)
+      N_nuc = cons5*cdist1*bfb_gamma(mu_c+4._rtype)*bfb_exp(aimm*(zerodegc-t))*bfb_pow(lamc, -3.0)
       qcheti = Q_nuc
       ncheti = N_nuc
    endif

--- a/components/scream/src/physics/p3/CMakeLists.txt
+++ b/components/scream/src/physics/p3/CMakeLists.txt
@@ -35,6 +35,7 @@ if (NOT CUDA_BUILD)
     p3_functions_autoconversion.cpp
     p3_functions_conservation.cpp
     p3_functions_cloud_rain_acc.cpp
+    p3_functions_cldliq_imm_freezing.cpp
     p3_functions_droplet_self_coll.cpp
     p3_functions_update_prognostics.cpp
     p3_functions_impose_max_total_Ni.cpp)

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -295,7 +295,7 @@ contains
 
   subroutine cldliq_immersion_freezing_c(t,lamc,mu_c,cdist1,qc_incld,qcheti,ncheti) bind(C)
 
-      use micro_p3, only: droplet_self_collection
+      use micro_p3, only: cldliq_immersion_freezing
       real(kind=c_real), value, intent(in) :: t, lamc, mu_c, cdist1, qc_incld
       real(kind=c_real), intent(out) :: qcheti, ncheti
 

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -293,6 +293,15 @@ contains
     call get_rain_dsd2(qr,nr,mu_r,lamr,cdistr,logn0r,rcldm)
   end subroutine get_rain_dsd2_c
 
+  subroutine cldliq_immersion_freezing_c(t,lamc,mu_c,cdist1,qc_incld,qcheti,ncheti) bind(C)
+
+      use micro_p3, only: droplet_self_collection
+      real(kind=c_real), value, intent(in) :: t, lamc, mu_c, cdist1, qc_incld
+      real(kind=c_real), intent(out) :: qcheti, ncheti
+
+      call cldliq_immersion_freezing(t, lamc, mu_c, cdist1, qc_incld, qcheti, ncheti)
+  end subroutine cldliq_immersion_freezing_c
+
   subroutine droplet_self_collection_c(rho,inv_rho,qc_incld,mu_c,nu,ncautc,ncslf) bind(C)
 
       use micro_p3, only: droplet_self_collection

--- a/components/scream/src/physics/p3/micro_p3_iso_f.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_f.f90
@@ -92,6 +92,14 @@ interface
     real(kind=c_real), intent(out)       :: lamr,mu_r,cdistr,logn0r
   end subroutine get_rain_dsd2_f
 
+  subroutine cldliq_immersion_freezing_f(t,lamc,mu_c,cdist1,qc_incld,qcheti,ncheti) bind(C)
+    use iso_c_binding
+
+    !arguments:
+    real(kind=c_real), value, intent(in) :: t, lamc, mu_c, cdist1, qc_incld
+    real(kind=c_real), intent(out) :: qcheti, ncheti
+  end subroutine cldliq_immersion_freezing_f
+
   subroutine droplet_self_collection_f(rho,inv_rho,qc_incld,mu_c,nu,ncautc,ncslf) bind(C)
     use iso_c_binding
 

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -379,6 +379,12 @@ struct Functions
     const Smask& qr_gt_small, const Spack& qr, Spack& nr, Spack& mu_r,
     Spack& lamr, Spack& cdistr, Spack& logn0r, const Spack& rcldm);
 
+  // Computes contact and immersion freezing droplets
+  KOKKOS_FUNCTION
+  static void cldliq_immersion_freezing(const Spack& t, const Spack& lamc,
+    const Spack& mu_c, const Spack& cdist1, const Spack& qc_incld,
+    Spack& qcheti, Spack& ncheti);
+
   // Computes droplet self collection
   KOKKOS_FUNCTION
   static void droplet_self_collection(const Spack& rho, const Spack& inv_rho,
@@ -490,6 +496,7 @@ void init_tables_from_f90_c(Real* vn_table_data, Real* vm_table_data, Real* mu_t
 # include "p3_functions_conservation_impl.hpp"
 # include "p3_functions_autoconversion_impl.hpp"
 # include "p3_functions_impose_max_total_Ni_impl.hpp"
+# include "p3_functions_cldliq_imm_freezing_impl.hpp"
 # include "p3_functions_droplet_self_coll_impl.hpp"
 # include "p3_functions_cloud_sed_impl.hpp"
 # include "p3_functions_cloud_rain_acc_impl.hpp"

--- a/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing.cpp
+++ b/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing.cpp
@@ -1,0 +1,15 @@
+#include "p3_functions_cldliq_imm_freezing_impl.hpp"
+#include "share/scream_types.hpp"
+
+namespace scream {
+namespace p3 {
+
+/*
+ * Explicit instantiation for doing p3 conservation functions on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace p3
+} // namespace scream

--- a/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing_impl.hpp
@@ -30,11 +30,10 @@ void Functions<S,D>
   if (qc_not_small_and_t_freezing.any()) {
     Spack expAimmDt, inv_lamc3;
     expAimmDt.set(qc_not_small_and_t_freezing, exp(AIMM * (ZeroDegC-t)));
-    inv_lamc3.set(qc_not_small_and_t_freezing,
-                  (sp(1.0)/lamc) * (sp(1.0)/lamc) * (sp(1.0)/lamc));
+    inv_lamc3.set(qc_not_small_and_t_freezing, cube(1/lamc));
     qcheti.set(qc_not_small_and_t_freezing,
                CONS6 * cdist1 * tgamma(sp(7.0)+mu_c) * expAimmDt *
-               (inv_lamc3 * inv_lamc3));
+               square(inv_lamc3));
     ncheti.set(qc_not_small_and_t_freezing,
                CONS5 * cdist1 * tgamma(sp(4.0)+mu_c) * expAimmDt * inv_lamc3);
   }

--- a/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing_impl.hpp
@@ -1,0 +1,44 @@
+#ifndef P3_FUNCTIONS_CLDLIQ_IMM_FREEZING_IMPL_HPP
+#define P3_FUNCTIONS_CLDLIQ_IMM_FREEZING_IMPL_HPP
+
+#include "p3_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace p3 {
+
+/*
+ * Implementation of p3 contact and immersion freezing droplets function.
+ * Clients should NOT #include this file, but include p3_functions.hpp instead.
+ */
+
+template <typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>
+::cldliq_immersion_freezing(const Spack& t, const Spack& lamc,
+                            const Spack& mu_c, const Spack& cdist1,
+                            const Spack& qc_incld, Spack& qcheti, Spack& ncheti)
+{
+  constexpr Scalar qsmall = C::QSMALL;
+  constexpr Scalar RainFrze = C::RainFrze;
+  constexpr Scalar ZeroDegC = C::ZeroDegC;
+  constexpr Scalar CONS5 = C::CONS5;
+  constexpr Scalar CONS6 = C::CONS6;
+
+  const auto qc_not_small_and_t_freezing = (qc_incld >= qsmall) &&
+                                           (t <= RainFrze);
+  if (qc_not_small_and_t_freezing.any()) {
+    qcheti.set(qc_not_small_and_t_freezing,
+               CONS6 * cdist1 *
+               tgamma(sp(7.0)+mu_c) * exp(AIMM * (ZeroDegC-t)) *
+               pow(lamc, sp(-6.0)));
+    ncheti.set(qc_not_small_and_t_freezing,
+               CONS5 * cdist1 *
+               tgamma(sp(4.0)+mu_c) * exp(AIMM * (ZeroDegC-t)) *
+               pow(lamc, sp(-3.0)));
+  }
+}
+
+} // namespace p3
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing_impl.hpp
@@ -19,6 +19,7 @@ void Functions<S,D>
                             const Spack& qc_incld, Spack& qcheti, Spack& ncheti)
 {
   constexpr Scalar qsmall = C::QSMALL;
+  constexpr Scalar AIMM = C::AIMM;
   constexpr Scalar RainFrze = C::RainFrze;
   constexpr Scalar ZeroDegC = C::ZeroDegC;
   constexpr Scalar CONS5 = C::CONS5;

--- a/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing_impl.hpp
@@ -27,14 +27,15 @@ void Functions<S,D>
   const auto qc_not_small_and_t_freezing = (qc_incld >= qsmall) &&
                                            (t <= RainFrze);
   if (qc_not_small_and_t_freezing.any()) {
+    Spack expAimmDt, lamc_inv, lamc_inv3;
+    expAimmDt.set(qc_not_small_and_t_freezing, exp(AIMM * (ZeroDegC-t)));
+    lamc_inv.set(qc_not_small_and_t_freezing, sp(1.0)/lamc);
+    lamc_inv3.set(qc_not_small_and_t_freezing, lamc_inv*lamc_inv*lamc_inv);
     qcheti.set(qc_not_small_and_t_freezing,
-               CONS6 * cdist1 *
-               tgamma(sp(7.0)+mu_c) * exp(AIMM * (ZeroDegC-t)) *
-               pow(lamc, sp(-6.0)));
+               CONS6 * cdist1 * tgamma(sp(7.0)+mu_c) * expAimmDt *
+               lamc_inv3 * lamc_inv);
     ncheti.set(qc_not_small_and_t_freezing,
-               CONS5 * cdist1 *
-               tgamma(sp(4.0)+mu_c) * exp(AIMM * (ZeroDegC-t)) *
-               pow(lamc, sp(-3.0)));
+               CONS5 * cdist1 * tgamma(sp(4.0)+mu_c) * expAimmDt * lamc_inv3);
   }
 }
 

--- a/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_cldliq_imm_freezing_impl.hpp
@@ -28,15 +28,15 @@ void Functions<S,D>
   const auto qc_not_small_and_t_freezing = (qc_incld >= qsmall) &&
                                            (t <= RainFrze);
   if (qc_not_small_and_t_freezing.any()) {
-    Spack expAimmDt, lamc_inv, lamc_inv3;
+    Spack expAimmDt, inv_lamc3;
     expAimmDt.set(qc_not_small_and_t_freezing, exp(AIMM * (ZeroDegC-t)));
-    lamc_inv.set(qc_not_small_and_t_freezing, sp(1.0)/lamc);
-    lamc_inv3.set(qc_not_small_and_t_freezing, lamc_inv*lamc_inv*lamc_inv);
+    inv_lamc3.set(qc_not_small_and_t_freezing,
+                  (sp(1.0)/lamc) * (sp(1.0)/lamc) * (sp(1.0)/lamc));
     qcheti.set(qc_not_small_and_t_freezing,
                CONS6 * cdist1 * tgamma(sp(7.0)+mu_c) * expAimmDt *
-               lamc_inv3 * lamc_inv);
+               (inv_lamc3 * inv_lamc3));
     ncheti.set(qc_not_small_and_t_freezing,
-               CONS5 * cdist1 * tgamma(sp(4.0)+mu_c) * expAimmDt * lamc_inv3);
+               CONS5 * cdist1 * tgamma(sp(4.0)+mu_c) * expAimmDt * inv_lamc3);
   }
 }
 

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -191,7 +191,7 @@ void access_lookup_table_coll(AccessLookupTableCollData& d)
                              d.lid.dum1, d.lidb.dum3, d.lid.dum4, d.lid.dum5, &d.proc);
 }
 
-void cldliq_immersion_freezing(CldLiqImmersionFreezingData& d)
+void cldliq_immersion_freezing(CldliqImmersionFreezingData& d)
 {
   p3_init(true);
   cldliq_immersion_freezing_c(d.t, d.lamc, d.mu_c, d.cdist1, d.qc_incld,

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -211,6 +211,24 @@ extern "C"{
 }
 ///////////////////////////////////////////////////////////////////////////////
 
+struct CldLiqImmersionFreezingData
+{
+  // inputs
+  Real t, lamc, mu_c, cdist1, qc_incld;
+
+  // output
+  Real qcheti, ncheti;
+};
+
+void cldliq_immersion_freezing(CldLiqImmersionFreezingData& d);
+extern "C"{
+
+  void cldliq_immersion_freezing_f(Real t, Real lamc, Real mu_c,
+    Real cdist1, Real qc_incld, Real* qcheti, Real* ncheti);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 struct DropletSelfCollectionData
 {
   // inputs

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -211,7 +211,7 @@ extern "C"{
 }
 ///////////////////////////////////////////////////////////////////////////////
 
-struct CldLiqImmersionFreezingData
+struct CldliqImmersionFreezingData
 {
   // inputs
   Real t, lamc, mu_c, cdist1, qc_incld;
@@ -220,7 +220,7 @@ struct CldLiqImmersionFreezingData
   Real qcheti, ncheti;
 };
 
-void cldliq_immersion_freezing(CldLiqImmersionFreezingData& d);
+void cldliq_immersion_freezing(CldliqImmersionFreezingData& d);
 extern "C"{
   void cldliq_immersion_freezing_f(Real t, Real lamc, Real mu_c,
     Real cdist1, Real qc_incld, Real* qcheti, Real* ncheti);

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(P3_TESTS_SRCS
   p3_table3_unit_tests.cpp
   p3_find_unit_tests.cpp
   p3_upwind_unit_tests.cpp
+  p3_cldliq_imm_freezing_unit_tests.cpp
   p3_rain_imm_freezing_unit_tests.cpp
   p3_droplet_self_coll_unit_tests.cpp
   p3_cloud_sed_unit_tests.cpp

--- a/components/scream/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -1,0 +1,136 @@
+#include "catch2/catch.hpp"
+
+#include "share/scream_types.hpp"
+#include "share/util/scream_utils.hpp"
+#include "share/scream_kokkos.hpp"
+#include "share/scream_pack.hpp"
+#include "physics/p3/p3_functions.hpp"
+#include "physics/p3/p3_functions_f90.hpp"
+#include "share/util/scream_kokkos_utils.hpp"
+
+#include "p3_unit_tests_common.hpp"
+
+#include <thread>
+#include <array>
+#include <algorithm>
+#include <random>
+
+namespace scream {
+namespace p3 {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing {
+
+static void run_phys()
+{
+  // TODO
+}
+
+static void run_bfb()
+{
+  static constexpr Int max_pack_size = 16;
+  REQUIRE(Spack::n <= max_pack_size);
+
+  // This is the threshold for whether the qc and qr cloud mixing ratios are
+  // large enough to affect the warm-phase process rates qcacc and ncacc.
+  constexpr Scalar qsmall = C::QSMALL;
+
+  constexpr Scalar t_freezing = 0.9 * C::RainFrze,
+                   t_not_freezing = 2.0 * C::RainFrze;
+  constexpr Scalar qc_incld_small = 0.9 * qsmall;
+  constexpr Scalar qc_incld_not_small = 2.0 * qsmall;
+  constexpr Scalar lamc1 = 0.1, lamc2 = 0.2, lamc3 = 0.3, lamc4 = 0.4;
+  constexpr Scalar mu_c1 = 0.2, mu_c2 = 0.4, mu_c3 = 0.6, mu_c4 = 0.8;
+  constexpr Scalar cdist11 = 0.25, cdist12 = 0.5, cdist13 = 0.75, cdist14 = 1.0;
+
+  CldliqImmersionFreezingData cldliq_imm_freezing_data[max_pack_size] = {
+    // t, lamc, mu_c, cdist1, qc_incld
+    {t_not_freezing, lamc1, mu_c1, cdist11, qc_incld_small},
+    {t_not_freezing, lamc2, mu_c2, cdist12, qc_incld_small},
+    {t_not_freezing, lamc3, mu_c3, cdist13, qc_incld_small},
+    {t_not_freezing, lamc4, mu_c4, cdist14, qc_incld_small},
+
+    {t_not_freezing, lamc1, mu_c1, cdist11, qc_incld_not_small},
+    {t_not_freezing, lamc2, mu_c2, cdist12, qc_incld_not_small},
+    {t_not_freezing, lamc3, mu_c3, cdist13, qc_incld_not_small},
+    {t_not_freezing, lamc4, mu_c4, cdist14, qc_incld_not_small},
+
+    {t_freezing, lamc1, mu_c1, cdist11, qc_incld_small},
+    {t_freezing, lamc2, mu_c2, cdist12, qc_incld_small},
+    {t_freezing, lamc3, mu_c3, cdist13, qc_incld_small},
+    {t_freezing, lamc4, mu_c4, cdist14, qc_incld_small},
+
+    {t_freezing, lamc1, mu_c1, cdist11, qc_incld_not_small},
+    {t_freezing, lamc2, mu_c2, cdist12, qc_incld_not_small},
+    {t_freezing, lamc3, mu_c3, cdist13, qc_incld_not_small},
+    {t_freezing, lamc4, mu_c4, cdist14, qc_incld_not_small}
+  };
+
+  // Sync to device
+  view_1d<CldliqImmersionFreezingData> device_data("cldliq_imm_freezing", Spack::n);
+  const auto host_data = Kokkos::create_mirror_view(device_data);
+  std::copy(&cldliq_imm_freezing_data[0], &cldliq_imm_freezing_data[0] + Spack::n,
+            host_data.data());
+  Kokkos::deep_copy(device_data, host_data);
+
+  // Run the Fortran subroutine.
+  for (Int i = 0; i < Spack::n; ++i) {
+    cldliq_immersion_freezing(cldliq_imm_freezing_data[i]);
+  }
+
+  // Run the lookup from a kernel and copy results back to host
+  Kokkos::parallel_for(1, KOKKOS_LAMBDA(const Int&) {
+    // Init pack inputs
+    Spack t, lamc, mu_c, cdist1, qc_incld;
+    for (Int s = 0; s < Spack::n; ++s) {
+      t[s]        = device_data(s).t;
+      lamc[s]     = device_data(s).lamc;
+      mu_c[s]     = device_data(s).mu_c;
+      cdist1[s]   = device_data(s).cdist1;
+      qc_incld[s] = device_data(s).qc_incld;
+    }
+
+    Spack qcheti{0.0};
+    Spack ncheti{0.0};
+
+    Functions::cldliq_immersion_freezing(t, lamc, mu_c, cdist1, qc_incld,
+                                         qcheti, ncheti);
+
+    // Copy results back into views
+    for (Int s = 0; s < Spack::n; ++s) {
+      device_data(s).qcheti  = qcheti[s];
+      device_data(s).ncheti  = ncheti[s];
+    }
+  });
+
+  // Sync back to host.
+  Kokkos::deep_copy(host_data, device_data);
+
+  // Validate results.
+  for (Int s = 0; s < Spack::n; ++s) {
+    REQUIRE(cldliq_imm_freezing_data[s].qcheti == host_data[s].qcheti);
+    REQUIRE(cldliq_imm_freezing_data[s].ncheti == host_data[s].ncheti);
+  }
+
+}
+
+};
+
+}
+}
+}
+
+namespace {
+
+TEST_CASE("p3_cldliq_immersion_freezing", "[p3_functions]")
+{
+  using TRIF = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCldliqImmersionFreezing;
+
+  TRIF::run_phys();
+  TRIF::run_bfb();
+
+  scream::p3::P3GlobalForFortran::deinit();
+}
+
+} // namespace

--- a/components/scream/src/physics/p3/tests/p3_unit_tests_common.hpp
+++ b/components/scream/src/physics/p3/tests/p3_unit_tests_common.hpp
@@ -67,6 +67,7 @@ struct UnitWrap {
     struct TestDsd2;
     struct TestP3Conservation;
     struct TestP3CloudWaterAutoconversion;
+    struct TestCldliqImmersionFreezing;
     struct TestRainImmersionFreezing;
     struct TestDropletSelfCollection;
     struct TestCloudSed;

--- a/components/scream/src/share/scream_pack.hpp
+++ b/components/scream/src/share/scream_pack.hpp
@@ -397,6 +397,24 @@ OnlyPack<PackType> pow (const PackType& a, const PackType& b) {
 
 template <typename PackType>
 KOKKOS_INLINE_FUNCTION
+OnlyPack<PackType> square (const PackType& a) {
+  PackType s;
+  vector_simd for (int i = 0; i < PackType::n; ++i)
+    s[i] = a[i] * a[i];
+  return s;
+}
+
+template <typename PackType>
+KOKKOS_INLINE_FUNCTION
+OnlyPack<PackType> cube (const PackType& a) {
+  PackType s;
+  vector_simd for (int i = 0; i < PackType::n; ++i)
+    s[i] = a[i] * a[i] * a[i];
+  return s;
+}
+
+template <typename PackType>
+KOKKOS_INLINE_FUNCTION
 OnlyPack<PackType> shift_right (const PackType& pm1, const PackType& p) {
   PackType s;
   s[0] = pm1[PackType::n-1];

--- a/components/scream/src/share/tests/pack_tests.cpp
+++ b/components/scream/src/share/tests/pack_tests.cpp
@@ -7,6 +7,14 @@
 
 namespace {
 
+double square(double x) {
+  return x * x;
+}
+
+double cube(double x) {
+  return x * x * x;
+}
+
 template <int PACKN>
 struct TestMask {
   typedef scream::pack::Mask<PACKN> Mask;
@@ -269,6 +277,9 @@ struct TestPack {
     test_pack_gen_unary_stdfn(log10);
     test_pack_gen_unary_stdfn(tgamma);
     test_pack_gen_unary_stdfn(sqrt);
+
+    test_pack_gen_unary_fn(square, square);
+    test_pack_gen_unary_fn(cube, cube);
 
     test_mask_gen_bin_op_all(==);
     test_mask_gen_bin_op_all(!=);


### PR DESCRIPTION
Here's the BFB portion of the `cldliq_immersion_freezing` conversion. As you can imagine, the parenthesis we discussed in the non-BFB PR require some care in the C++ version as well.

I'm not able to test this on Cori at the moment, since they're changing the project's account name, so I figured I'll let the AT test it on White.