### PR TITLE
Port ice_melting: initial non-bfb F90 changes

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -35,9 +35,6 @@
 ! variables and outputs expected in E3SM.                                                  !
 !__________________________________________________________________________________________!
 
-#define bfb_square(val) ((val)*(val))
-#define bfb_cube(val) ((val)*(val)*(val))
-
 #ifdef SCREAM_CONFIG_IS_CMAKE
 #  define bfb_pow(base, exp) cxx_pow(base, exp)
 #  define bfb_cbrt(base) cxx_cbrt(base)
@@ -53,6 +50,10 @@
 #  define bfb_log10(val) log10(val)
 #  define bfb_exp(val) exp(val)
 #endif
+
+#define bfb_square(val) ((val)*(val))
+#define bfb_cube(val) ((val)*(val)*(val))
+#define bfb_sqrt(val) bfb_pow(val,0.5_rtype)
 
 module micro_p3
 
@@ -2285,9 +2286,8 @@ f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,    &
    if (qitot_incld .ge.qsmall .and. t.gt.zerodegc) then
       qsat0 = 0.622_rtype*e0/(pres-e0)
 
-      qimlt = ((f1pr05+f1pr14*sc**thrd*(rhofaci*rho/mu)**0.5_rtype)*((t-   &
+      qimlt = ((f1pr05+f1pr14*bfb_cbrt(sc)*bfb_sqrt(rhofaci*rho/mu)*((t-   &
       zerodegc)*kap-rho*xxlv*dv*(qsat0-qv))*2._rtype*pi/xlf)*nitot_incld
-
 
       qimlt = max(qimlt,0._rtype)
       nimlt = qimlt*(nitot_incld/qitot_incld)

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -30,10 +30,13 @@
 ! 1) Need to change the dz coordinate system in sedimentation to be consistent             !
 ! with E3SM's pressure based coordinate system, i.e. dp.                                   !
 ! 2) Move all physical constants into a micro_p3_util module and match them to             !
-! universal constants in E3SM for consistentcy.                                            !
+! universal constants in E3SM for consistency.                                            !
 ! 3) Need to include extra in/out values which correspond with microphysics PBUF           !
 ! variables and outputs expected in E3SM.                                                  !
 !__________________________________________________________________________________________!
+
+#define bfb_square(val) ((val)*(val))
+#define bfb_cube(val) ((val)*(val)*(val))
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
 #  define bfb_pow(base, exp) cxx_pow(base, exp)
@@ -42,6 +45,7 @@
 #  define bfb_log(val) cxx_log(val)
 #  define bfb_log10(val) cxx_log10(val)
 #  define bfb_exp(val) cxx_exp(val)
+#  define bfb_sqrt(val) bfb_pow(val,0.5_rtype)
 #else
 #  define bfb_pow(base, exp) (base)**exp
 #  define bfb_cbrt(base) (base)**thrd
@@ -49,11 +53,8 @@
 #  define bfb_log(val) log(val)
 #  define bfb_log10(val) log10(val)
 #  define bfb_exp(val) exp(val)
+#  define bfb_sqrt(val) sqrt(val)
 #endif
-
-#define bfb_square(val) ((val)*(val))
-#define bfb_cube(val) ((val)*(val)*(val))
-#define bfb_sqrt(val) bfb_pow(val,0.5_rtype)
 
 module micro_p3
 
@@ -2260,6 +2261,10 @@ f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,    &
    ! currently enhanced melting from collision is neglected
    ! include RH dependence
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    use micro_p3_iso_f, only: cxx_pow, cxx_cbrt
+#endif
+  
    implicit none
 
    real(rtype), intent(in) :: rho
@@ -2286,7 +2291,7 @@ f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,    &
    if (qitot_incld .ge.qsmall .and. t.gt.zerodegc) then
       qsat0 = 0.622_rtype*e0/(pres-e0)
 
-      qimlt = ((f1pr05+f1pr14*bfb_cbrt(sc)*bfb_sqrt(rhofaci*rho/mu)*((t-   &
+      qimlt = ((f1pr05+f1pr14*bfb_cbrt(sc)*bfb_sqrt(rhofaci*rho/mu))*((t-   &
       zerodegc)*kap-rho*xxlv*dv*(qsat0-qv))*2._rtype*pi/xlf)*nitot_incld
 
       qimlt = max(qimlt,0._rtype)

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -40,12 +40,12 @@
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
 #  define bfb_pow(base, exp) cxx_pow(base, exp)
+#  define bfb_sqrt(base) cxx_sqrt(base)
 #  define bfb_cbrt(base) cxx_cbrt(base)
 #  define bfb_gamma(val) cxx_gamma(val)
 #  define bfb_log(val) cxx_log(val)
 #  define bfb_log10(val) cxx_log10(val)
 #  define bfb_exp(val) cxx_exp(val)
-#  define bfb_sqrt(val) bfb_pow(val,0.5_rtype)
 #else
 #  define bfb_pow(base, exp) (base)**exp
 #  define bfb_cbrt(base) (base)**thrd
@@ -2262,7 +2262,7 @@ f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,    &
    ! include RH dependence
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
-    use micro_p3_iso_f, only: cxx_pow, cxx_cbrt
+    use micro_p3_iso_f, only: cxx_cbrt, cxx_sqrt
 #endif
   
    implicit none

--- a/components/scream/src/physics/p3/micro_p3_iso_f.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_f.f90
@@ -367,6 +367,16 @@ subroutine  update_prognostic_ice_f(qcheti,qccol,qcshd,nccol,ncheti,ncshdc,qrcol
     real(kind=c_real)               :: cxx_pow
   end function cxx_pow
 
+  function cxx_sqrt(base) bind(C)
+    use iso_c_binding
+
+    !arguments:
+    real(kind=c_real), value, intent(in)  :: base
+
+    ! return
+    real(kind=c_real)               :: cxx_sqrt
+  end function cxx_sqrt
+
   function cxx_cbrt(base) bind(C)
     use iso_c_binding
 

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -1784,6 +1784,7 @@ static Scalar wrap_name(Scalar input) {                 \
 }
 
   cuda_wrap_single_arg(cxx_gamma, std::tgamma)
+  cuda_wrap_single_arg(cxx_sqrt, std::sqrt)
   cuda_wrap_single_arg(cxx_cbrt, std::cbrt)
   cuda_wrap_single_arg(cxx_log, std::log)
   cuda_wrap_single_arg(cxx_log10, std::log10)
@@ -1816,6 +1817,15 @@ Real cxx_cbrt(Real input)
   return CudaWrap<Real, DefaultDevice>::cxx_cbrt(input);
 #else
   return std::cbrt(input);
+#endif
+}
+
+Real cxx_sqrt(Real input)
+{
+#ifdef KOKKOS_ENABLE_CUDA
+  return CudaWrap<Real, DefaultDevice>::cxx_sqrt(input);
+#else
+  return std::sqrt(input);
 #endif
 }
 

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -744,6 +744,7 @@ void ice_self_collection_f(Real rho, Real rhofaci, Real f1pr03, Real eii,
 extern "C" {
 
 Real cxx_pow(Real base, Real exp);
+Real cxx_sqrt(Real base);
 Real cxx_cbrt(Real base);
 Real cxx_gamma(Real input);
 Real cxx_log(Real input);


### PR DESCRIPTION
Just changing ice_melting subroutine in micro_p3.F90 in order to use BFB versions of functions when SCREAM_CONFIG_IS_CMAKE is true. 

In making this PR, I realize that it will be challenging for newbies to know when they've made the changes to the F90 code necessary for eventual BFB checking against the C++ version. Is the vision that experts will look over the code at this point and say based on theoretical understanding whether the changes are sufficient?

Also, I ran "ctest -R p3_run_and_cmp" to confirm the code runs (and it did), but the test issues a fail (as expected) since the whole point of this PR is to be non-bfb. It looks like the size of the errors is 1e-15 in all fields, so I guess I use that as proof that the changes are miniscule like we expect? Is this what other folks have been doing?