### PR TITLE
Made sure outputs are always set for calc_rime_density.

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -2518,7 +2518,7 @@ f1pr02,acn,lamc, mu_c,qc_incld,qccol,    &
          ! use mass-weighted mean size
          D_c = (mu_c+4._rtype)/lamc
          V_impact  = abs(vtrmi1-Vt_qc)
-         Ri        = -(0.5e+6_rtype*D_c)*V_impact*iTc
+         Ri        = -0.5e+6_rtype * D_c * V_impact * iTc
          !               Ri        = max(1.,min(Ri,8.))
          Ri        = max(1._rtype,min(Ri,12._rtype))
          if (Ri.le.8.) then
@@ -2530,9 +2530,11 @@ f1pr02,acn,lamc, mu_c,qc_incld,qccol,    &
             ! in rime density up to wet growth
             rhorime_c  = 611._rtype+72.25_rtype*(Ri-8._rtype)
          endif
-
+      else
+         rhorime_c = 400._rtype
       endif    !if qc>qsmall
    else
+      vtrmi1 = 0._rtype ! no velocity if no ice
       rhorime_c = 400._rtype
    endif ! qi > qsmall and T < 273.15
 


### PR DESCRIPTION
Also removed a set of unnecessary parens from an expression that caused
us some confusion.

Discovered these issues while debugging #260