### PR TITLE
Non-b4b F90 changes for rain self collection.

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -2854,6 +2854,7 @@ subroutine rain_self_collection(rho,qr_incld,nr_incld,    &
       ! note there should be a factor of 6^(1/3), but we
       ! want to keep breakup threshold consistent so 'dum'
       ! is expressed in terms of lambda rather than mass-mean D
+      
       dum2 = bfb_cbrt(qr_incld/(pi*rhow*nr_incld))
       if (dum2.lt.dum1) then
          dum = 1._rtype

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -2831,6 +2831,10 @@ subroutine rain_self_collection(rho,qr_incld,nr_incld,    &
    ! self-collection and breakup of rain
    ! (breakup following modified Verlinde and Cotton scheme)
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+   use micro_p3_iso_f, only: cxx_cbrt, cxx_exp
+#endif
+
    implicit none
 
    real(rtype), intent(in) :: rho
@@ -2850,12 +2854,11 @@ subroutine rain_self_collection(rho,qr_incld,nr_incld,    &
       ! note there should be a factor of 6^(1/3), but we
       ! want to keep breakup threshold consistent so 'dum'
       ! is expressed in terms of lambda rather than mass-mean D
-
-      dum2 = (qr_incld/(pi*rhow*nr_incld))**thrd
+      dum2 = bfb_cbrt(qr_incld/(pi*rhow*nr_incld))
       if (dum2.lt.dum1) then
          dum = 1._rtype
       else if (dum2.ge.dum1) then
-         dum = 2._rtype-exp(2300._rtype*(dum2-dum1))
+         dum = 2._rtype-bfb_exp(2300._rtype*(dum2-dum1))
       endif
 
       if (iparam.eq.1) then


### PR DESCRIPTION
This PR introduces non-b4b changes to the micro_p3.f90 source code that are required for the port of the rain self collection subroutine to C++.