### PR TITLE
Helping out a picky C++ compiler with initializing an array.

### DIFF
--- a/components/scream/src/share/util/rational_constant.hpp
+++ b/components/scream/src/share/util/rational_constant.hpp
@@ -70,7 +70,6 @@ public:
     // Nothing to do here
   }
   constexpr RationalConstant (const RationalConstant&) = default;
-  RationalConstant& operator= (const RationalConstant&) = default;
 
   constexpr RationalConstant operator- () const {
     return RationalConstant(-m_num,m_den,m_fmt);

--- a/components/scream/src/share/util/scaling_factor.hpp
+++ b/components/scream/src/share/util/scaling_factor.hpp
@@ -31,7 +31,6 @@ struct ScalingFactor {
   }
 
   constexpr ScalingFactor (const ScalingFactor&) = default;
-  ScalingFactor& operator= (const ScalingFactor&) = default;
 
   static constexpr ScalingFactor one () { return ScalingFactor(1); }
   static constexpr ScalingFactor zero () { return ScalingFactor(0); }

--- a/components/scream/src/share/util/units.hpp
+++ b/components/scream/src/share/util/units.hpp
@@ -76,7 +76,6 @@ public:
   }
 
   Units (const Units&) = default;
-  Units& operator= (const Units&) = default;
 
   static Units nondimensional () {
     return Units(RationalConstant::one());

--- a/components/scream/src/share/util/units.hpp
+++ b/components/scream/src/share/util/units.hpp
@@ -51,7 +51,9 @@ public:
   // Construct a non-dimensional quantity
   Units (const ScalingFactor& scaling)
    : m_scaling {scaling}
-   , m_units{0,0,0,0,0,0,0}
+   , m_units{RationalConstant(0), RationalConstant(0), RationalConstant(0),
+             RationalConstant(0), RationalConstant(0), RationalConstant(0),
+             RationalConstant(0)}
    , m_exp_format (Format::Rat)
   {
     m_string = to_string(*this);


### PR DESCRIPTION
A C++ compiler I'm using (looks like GNU 9.2.1) has decided to be picky. I think what's going on is it's having trouble distinguishing an array initialization (of zeros) from default initialization for that array.

Fixes #269 