### PR TITLE
non-BFB porting relaxation_timescale to cpp

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -2375,6 +2375,9 @@ epsi,epsi_tot)
    !-----------------------------
    ! calcualte total inverse ice relaxation timescale combined for all ice categories
    ! note 'f1pr' values are normalized, so we need to multiply by N
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    use micro_p3_iso_f, only: ice_relaxation_timescale_f, cxx_cbrt, cxx_sqrt
+#endif
 
    implicit none
 
@@ -2393,6 +2396,14 @@ epsi,epsi_tot)
    real(rtype), intent(out) :: epsi
    real(rtype), intent(inout) :: epsi_tot
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    if (use_cxx) then
+      call ice_relaxation_timescale_f(rho,t,rhofaci,     &
+                                      f1pr05,f1pr14,dv,mu,sc,qitot_incld,nitot_incld, &
+                                      epsi,epsi_tot)
+       return
+    endif
+#endif
 
 
    if (qitot_incld.ge.qsmall .and. t.lt.zerodegc) then

--- a/components/scream/src/physics/p3/CMakeLists.txt
+++ b/components/scream/src/physics/p3/CMakeLists.txt
@@ -39,7 +39,8 @@ if (NOT CUDA_BUILD)
     p3_functions_rain_imm_freezing.cpp
     p3_functions_droplet_self_coll.cpp
     p3_functions_update_prognostics.cpp
-    p3_functions_impose_max_total_Ni.cpp)
+    p3_functions_impose_max_total_Ni.cpp
+    p3_functions_ice_relaxation_timescale.cpp)
 endif()
 
 # link_directories(${SCREAM_TPL_LIBRARY_DIRS} ${SCREAM_LIBRARY_DIRS})

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -620,4 +620,19 @@ subroutine  update_prognostic_ice_c(qcheti,qccol,qcshd,nccol,ncheti,ncshdc,qrcol
 
   end subroutine update_prognostic_liquid_c
 
+ subroutine ice_relaxation_timescale_c(rho, temp, rhofaci, f1pr05, f1pr14,   &
+                                       dv, mu, sc, qitot_incld, nitot_incld, &
+                                       epsi, epsi_tot) bind(C)
+   use micro_p3, only: calc_ice_relaxation_timescale
+
+   ! arguments
+   real(kind=c_real), value, intent(in) :: rho, temp, rhofaci, f1pr05, f1pr14, &
+                                           dv, mu, sc, qitot_incld, nitot_incld
+   real(kind=c_real), intent(out) :: epsi, epsi_tot
+
+   call calc_ice_relaxation_timescale(rho, temp, rhofaci, f1pr05, f1pr14,   &
+                                      dv, mu, sc, qitot_incld, nitot_incld, &
+                                      epsi, epsi_tot)
+ end subroutine ice_relaxation_timescale_c
+
 end module micro_p3_iso_c

--- a/components/scream/src/physics/p3/micro_p3_iso_f.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_f.f90
@@ -350,6 +350,17 @@ subroutine  update_prognostic_ice_f(qcheti,qccol,qcshd,nccol,ncheti,ncshdc,qrcol
 
   end subroutine update_prognostic_liquid_f
 
+  subroutine ice_relaxation_timescale_f(rho, temp, rhofaci, f1pr05, f1pr14,   &
+                                        dv, mu, sc, qitot_incld, nitot_incld, &
+                                        epsi, epsi_tot) bind(C)
+    use iso_c_binding
+
+    ! arguments
+    real(kind=c_real), value, intent(in) :: rho, temp, rhofaci, f1pr05, f1pr14, &
+                                           dv, mu, sc, qitot_incld, nitot_incld
+    real(kind=c_real), intent(out) :: epsi, epsi_tot
+  end subroutine ice_relaxation_timescale_f
+
   !
   ! These are some routine math operations that are not BFB between
   ! fortran and C++ on all platforms, so fortran will need to use

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -475,7 +475,12 @@ struct Functions
     const bool log_predictNc, const Spack& inv_rho, const Spack& exner, const Spack& xxlv,
     const Scalar dt, Spack& th, Spack& qv, Spack& qc, Spack& nc, Spack& qr, Spack& nr);
 
-
+  // ice_relaxation timescale
+  KOKKOS_FUNCTION
+  static void ice_relaxation_timescale(const Spack& rho, const Spack& temp, const Spack& rhofaci, const Spack& f1pr05,
+                                       const Spack& f1pr14, const Spack& dv, const Spack& mu, const Spack& sc,
+                                       const Spack& qitot_incld, const Spack& nitot_incld,
+                                       Spack& epsi, Spack& epsi_tot);
 };
 
 template <typename ScalarT, typename DeviceT>
@@ -511,6 +516,7 @@ void init_tables_from_f90_c(Real* vn_table_data, Real* vm_table_data, Real* mu_t
 # include "p3_functions_rain_imm_freezing_impl.hpp"
 # include "p3_functions_update_prognostics_impl.hpp"
 # include "p3_functions_ice_collection_impl.hpp"
+# include "p3_functions_ice_relaxation_timescale_impl.hpp"
 #endif
 
 #endif

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -120,6 +120,10 @@ void ice_rain_collection_c(Real rho, Real temp, Real rhofaci, Real logn0r, Real 
 
 void ice_self_collection_c(Real rho, Real rhofaci, Real f1pr03, Real eii,
                            Real qirim_incld, Real qitot_incld, Real nitot_incld, Real* nislf);
+
+void ice_relaxation_timescale_c(Real rho, Real temp, Real rhofaci, Real f1pr05, Real f1pr14,
+                                Real dv, Real mu, Real sc, Real qitot_incld, Real nitot_incld,
+                                Real* epsi, Real* epsi_tot);
 }
 
 namespace scream {
@@ -286,6 +290,13 @@ void ice_self_collection(IceSelfCollectionData& d)
                         &d.nislf);
 }
 
+void ice_relaxation_timescale(IceRelaxationData& d)
+{
+  p3_init(true);
+  ice_relaxation_timescale_c(d.rho, d.temp, d.rhofaci, d.f1pr05, d.f1pr14,
+                             d.dv, d.mu, d.sc, d.qitot_incld, d.nitot_incld,
+                             &d.epsi, &d.epsi_tot);
+}
 
   void  update_prognostic_ice(P3UpdatePrognosticIceData& d){
     p3_init(true);
@@ -1905,6 +1916,40 @@ void ice_water_conservation_f(Real qitot_, Real qidep_, Real qinuc_, Real qiberg
     *qimlt_ = qimlt[0];
 
 }
+
+
+void ice_relaxation_timescale_f(Real rho_, Real temp_, Real rhofaci_, Real f1pr05_, Real f1pr14_,
+                                Real dv_, Real mu_, Real sc_, Real qitot_incld_, Real nitot_incld_,
+                                Real* epsi_, Real* epsi_tot_)
+{
+  using P3F  = Functions<Real, DefaultDevice>;
+
+  using Spack   = typename P3F::Spack;
+  using view_1d = typename P3F::view_1d<Real>;
+
+  view_1d t_d("t_d", 2);
+  const auto t_h = Kokkos::create_mirror_view(t_d);
+
+  Kokkos::parallel_for(1, KOKKOS_LAMBDA(const Int&) {
+
+    Spack rho{rho_}, temp{temp_}, rhofaci{rhofaci_}, f1pr05{f1pr05_}, f1pr14{f1pr14_}, dv{dv_},
+          mu{mu_}, sc{sc_}, qitot_incld{qitot_incld_}, nitot_incld{nitot_incld_};
+
+    Spack epsi{0.0}, epsi_tot{0.0};
+
+    P3F::ice_relaxation_timescale(rho, temp, rhofaci, f1pr05, f1pr14, dv, mu, sc, qitot_incld, nitot_incld,
+                                  epsi, epsi_tot);
+
+    t_d(0) = epsi[0];
+    t_d(0) = epsi_tot[0];
+  });
+
+  Kokkos::deep_copy(t_h, t_d);
+
+  *epsi_      = t_h(0);
+  *epsi_tot_  = t_h(1);
+}
+
 
 } // namespace p3
 } // namespace scream

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -737,6 +737,23 @@ void ice_self_collection_f(Real rho, Real rhofaci, Real f1pr03, Real eii,
 
 }
 
+struct IceRelaxationData
+{
+  // Inputs
+  Real rho, temp, rhofaci, f1pr05, f1pr14, dv, mu, sc, qitot_incld, nitot_incld;
+
+  // Outputs
+  Real epsi, epsi_tot;
+};
+void ice_relaxation_timescale(IceRelaxationData& d);
+
+extern "C" {
+ void ice_relaxation_timescale_f(Real rho, Real temp, Real rhofaci, Real f1pr05, Real f1pr14,
+                                 Real dv, Real mu, Real sc, Real qitot_incld, Real nitot_incld,
+                                 Real* epsi, Real* epsi_tot);
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////
 // BFB math stuff
 ///////////////////////////////////////////////////////////////////////////////

--- a/components/scream/src/physics/p3/p3_functions_ice_relaxation_timescale.cpp
+++ b/components/scream/src/physics/p3/p3_functions_ice_relaxation_timescale.cpp
@@ -1,0 +1,15 @@
+#include "p3_functions_ice_relaxation_timescale_impl.hpp"
+#include "share/scream_types.hpp"
+
+namespace scream {
+namespace p3 {
+
+/*
+ * Explicit instantiation for doing p3 conservation functions on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace p3
+} // namespace scream

--- a/components/scream/src/physics/p3/p3_functions_ice_relaxation_timescale_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_ice_relaxation_timescale_impl.hpp
@@ -1,0 +1,47 @@
+#ifndef P3_FUNCTIONS_ICE_RELAXATION_TIMESCALE_IMPL_HPP
+#define P3_FUNCTIONS_ICE_RELAXATION_TIMESCALE_IMPL_HPP
+
+#include "p3_functions.hpp" // for ETI only but harmless for GPU
+#include "p3_functions_math_impl.hpp"
+
+namespace scream {
+namespace p3 {
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>
+::ice_relaxation_timescale(const Spack& rho, const Spack& temp, const Spack& rhofaci, const Spack& f1pr05,
+                           const Spack& f1pr14, const Spack& dv, const Spack& mu, const Spack& sc, 
+                           const Spack& qitot_incld, const Spack& nitot_incld,
+                           Spack& epsi, Spack& epsi_tot)
+{
+   constexpr Scalar qsmall = C::QSMALL;
+   constexpr Scalar tmelt = C::Tmelt;
+   constexpr Scalar zero = C::ZERO;
+   constexpr Scalar pi = C::Pi;
+
+   const auto t_is_negative = temp < tmelt;
+   const auto qitot_incld_ge_small = qitot_incld >= qsmall;
+
+   const auto any_if = qitot_incld_ge_small && t_is_negative;
+
+   /*!-----------------------------
+    * calcualte total inverse ice relaxation timescale combined for all ice categories
+    * note 'f1pr' values are normalized, so we need to multiply by N
+    */
+   epsi.set(any_if,
+            ((f1pr05+f1pr14*pack::cbrt(sc)*pack::pow((rhofaci*rho/mu), 0.5))*
+            sp(2.0)*pi*rho*dv)*nitot_incld);
+
+   epsi_tot.set(any_if,
+                epsi_tot+epsi);
+
+   epsi.set(!any_if,
+             zero);
+
+}
+
+} // namespace p3
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(P3_TESTS_SRCS
   p3_rain_sed_unit_tests.cpp
   p3_dsd2_unit_tests.cpp
   p3_autoconversion_unit_tests.cpp
+  p3_ice_relaxation_timescale_unit_tests.cpp
 )
 CreateUnitTest(p3_tests "${P3_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP p3_tests_ut_np1_omp1)
 

--- a/components/scream/src/physics/p3/tests/p3_ice_relaxation_timescale_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_ice_relaxation_timescale_unit_tests.cpp
@@ -1,0 +1,125 @@
+#include "catch2/catch.hpp"
+
+#include "share/scream_types.hpp"
+#include "share/util/scream_utils.hpp"
+#include "share/scream_kokkos.hpp"
+#include "share/scream_pack.hpp"
+#include "physics/p3/p3_functions.hpp"
+#include "physics/p3/p3_functions_f90.hpp"
+#include "share/util/scream_kokkos_utils.hpp"
+
+#include "p3_unit_tests_common.hpp"
+
+#include <thread>
+#include <array>
+#include <algorithm>
+#include <random>
+#include <iomanip>      // std::setprecision
+
+namespace scream {
+namespace p3 {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestIceRelaxationTimescale {
+
+  static void run_ice_relaxation_timescale_bfb()
+  {
+    using KTH = KokkosTypes<HostDevice>;
+
+    static constexpr Int max_pack_size = 16;
+    REQUIRE(Spack::n <= max_pack_size);
+
+    IceRelaxationData self[max_pack_size] = {
+
+     // rho,     temp,    rhofaci,   f1pr05,    f1pr14,     dv,       mu,          sc,      qitot_incld, nitot_incld, epsi,epsi_tot
+      {4.056E-03, 1.021E+01, 8.852E-01, 0.174E+00, 0.021E+00, 1.221E-14, 5.100E-03, 9.558E-04, 1.234E-03, 9.952E+03},
+      {6.852E-02, 2.022E+01, 8.852E-01, 0.374E+00, 0.042E+00, 1.221E-13, 4.100E-03, 9.558E-04, 2.670E-03, 9.952E+03},
+      {8.852E-02, 3.086E+01, 8.900E-01, 0.123E+00, 0.081E+00, 1.221E-12, 3.100E-03, 9.558E-04, 3.451E-03, 9.952E+03},
+      {1.902E-01, 5.078E+01, 9.900E-01, 0.123E+00, 0.101E+00, 1.221E-11, 2.100E-03, 9.558E-04, 4.135E-03, 9.952E+03},
+
+      {2.201E-01, 1.300E+02, 0.100E+01, 0.174E+00, 0.112E+00, 1.221E-10, 1.100E-03, 2.558E-05, 5.672E-03, 9.952E+04},
+      {3.502E-01, 2.409E+02, 0.100E+01, 0.374E+00, 0.140E+00, 1.221E-09, 8.100E-04, 2.558E-05, 6.432E-03, 9.952E+04},
+      {4.852E-01, 3.490E+02, 0.100E+01, 0.123E+00, 0.210E+00, 1.221E-08, 4.100E-04, 2.558E-05, 7.412E-03, 9.952E+04},
+      {5.852E-01, 4.690E+02, 0.100E+01, 0.123E+00, 0.321E+00, 1.221E-07, 2.100E-04, 2.558E-05, 8.021E-03, 9.952E+04},
+
+      {6.852E-01, 5.021E+02, 0.950E+00, 0.150E+00, 0.432E+00, 1.221E-06, 9.952E-05, 4.596E-05, 9.834E-03, 1.734E+04},
+      {7.852E-01, 6.213E+02, 0.950E+00, 0.374E+00, 0.543E+00, 1.221E-05, 4.952E-05, 4.596E-05, 1.213E-02, 1.734E+04},
+      {8.852E-01, 7.012E+02, 0.950E+00, 0.123E+00, 0.671E+00, 1.221E-04, 1.952E-05, 4.596E-05, 1.346E-02, 1.734E+04},
+      {9.852E-01, 8.123E+02, 0.950E+00, 0.123E+00, 0.982E+00, 1.221E-03, 9.952E-06, 4.596E-05, 3.589E-02, 1.734E+04},
+
+      {1.002E+01, 9.321E+02, 1.069E+00, 0.174E+00, 1.201E+00, 1.221E-02, 6.952E-06, 6.596E-05, 6.982E-02, 1.734E+04},
+      {1.152E+01, 1.023E+03, 1.069E+00, 0.374E+00, 1.678E+00, 1.221E-02, 3.952E-06, 6.596E-05, 9.234E-02, 1.734E+04},
+      {1.252E+01, 2.012E+03, 1.069E+00, 0.123E+00, 2.312E+00, 1.221E-02, 1.952E-06, 6.596E-05, 2.345E-01, 1.734E+04},
+      {1.352E+01, 3.210E+03, 1.069E+00, 0.123E+00, 3.456E+00, 1.221E-02, 9.952E-07, 6.596E-05, 4.532E-01, 1.734E+04}     
+    };
+    // Get data from fortran
+    for (Int i = 0; i < Spack::n; ++i) {
+      ice_relaxation_timescale(self[i]);
+     }
+    
+    // Sync to device
+    KTH::view_1d<IceRelaxationData> self_host("self_host", Spack::n);
+    view_1d<IceRelaxationData> self_device("self_host", Spack::n);
+    std::copy(&self[0], &self[0] + Spack::n, self_host.data());
+    Kokkos::deep_copy(self_device, self_host);
+   
+    // Run the lookup from a kernel and copy results back to host
+    Kokkos::parallel_for(RangePolicy(0, 1), KOKKOS_LAMBDA(const Int& i) {
+    // Init pack inputs
+    Spack rho, temp, rhofaci, f1pr05, f1pr14, dv, mu, sc, qitot_incld, nitot_incld;
+
+      for (Int s = 0; s < Spack::n; ++s) {
+        rho[s]         = self_device(s).rho;
+        temp[s]        = self_device(s).temp;
+        rhofaci[s]     = self_device(s).rhofaci;
+        f1pr05[s]      = self_device(s).f1pr05;
+        f1pr14[s]      = self_device(s).f1pr14;
+        dv[s]          = self_device(s).dv;
+        mu[s]          = self_device(s).mu;
+        sc[s]          = self_device(s).sc;
+        qitot_incld[s] = self_device(s).qitot_incld;
+        nitot_incld[s] = self_device(s).nitot_incld;
+      }
+
+      Spack epsi{0.0};
+      Spack epsi_tot{0.0};
+      Functions::ice_relaxation_timescale(rho, temp, rhofaci, f1pr05, f1pr14, dv, mu, sc, qitot_incld, nitot_incld,
+                                          epsi, epsi_tot); 
+   
+      for (Int s = 0; s < Spack::n; ++s) {
+        self_device(s).epsi     = epsi[s];
+        self_device(s).epsi_tot = epsi_tot[s];
+      }
+    });
+
+    Kokkos::deep_copy(self_host, self_device);
+
+    for (Int s = 0; s < Spack::n; ++s) {
+      REQUIRE(self[s].epsi     == self_host(s).epsi);
+      REQUIRE(self[s].epsi_tot == self_host(s).epsi_tot);
+    }
+  }
+
+
+  static void run_ice_relaxation_timescale_phys()
+  {
+    // TODO
+  }
+};
+
+}
+}
+}
+
+namespace {
+
+TEST_CASE("p3_ice_relaxation_timescale", "[p3_functions]")
+{
+  using TD = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceRelaxationTimescale;
+
+  TD::run_ice_relaxation_timescale_phys();
+  TD::run_ice_relaxation_timescale_bfb();
+}
+
+}

--- a/components/scream/src/physics/p3/tests/p3_unit_tests_common.hpp
+++ b/components/scream/src/physics/p3/tests/p3_unit_tests_common.hpp
@@ -78,6 +78,7 @@ struct UnitWrap {
     struct TestIceCollection;
     struct TestP3UpdatePrognosticLiq;
     struct TestP3FunctionsImposeMaxTotalNi;
+    struct TestIceRelaxationTimescale;
   };
 
 };


### PR DESCRIPTION
This is non-BFB porting of the relaxation_timescale to cpp

No changes are made at micro_p3.F90 in order to do BFB comparison.

non-BFB