### PR TITLE
Deleted default constructor for FieldHeader class.

### DIFF
--- a/components/scream/src/share/field/field_header.hpp
+++ b/components/scream/src/share/field/field_header.hpp
@@ -25,7 +25,6 @@ public:
   using extra_data_type = std::map<std::string,util::any>;
 
   // Constructor(s)
-  FieldHeader () = default;
   FieldHeader (const FieldHeader&) = default;
   explicit FieldHeader (const identifier_type& id);
 


### PR DESCRIPTION
This was being deleted by the compiler anyway, so this commit just
removes distracting warnings, in the interest of avoiding a culture
where we ignore C++ compiler warnings. (That path leads to the Dark
Side.)