### PR TITLE
Some fixes/upgrades to test-all-scream

### DIFF
--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -55,6 +55,10 @@ class TestAllScream(object):
         if self._submit:
             expect(self._machine, "If dashboard submit request, must provide machine name")
 
+        last_commit = run_cmd_no_fail("git log -1 --oneline")
+        print("   Last commit on tested branch:")
+        print("     {}".format(last_commit))
+
         # Compute baseline info
         expect(not (self._baseline_ref and self._baseline_dir),
                "Makes no sense to specify a baseline generation commit if using pre-existing baselines ")
@@ -224,6 +228,11 @@ class TestAllScream(object):
             expect(is_repo_clean(), "If we need to change HEAD, then the repo must be clean before running")
             run_cmd_no_fail("git checkout {}".format(self._baseline_ref))
             print("  Switched to {} ({})".format(self._baseline_ref, git_baseline_commit))
+            last_commit = run_cmd_no_fail("git log -1 --oneline")
+            print("   Last commit on baseline ref:")
+            print("     {}".format(last_commit))
+            # Re-update submodules, just in case baselines and branch have different submodules
+            run_cmd_no_fail("git submodule update --init --recursive")
 
         success = True
         num_workers = len(self._tests) if self._parallel else 1
@@ -244,6 +253,11 @@ class TestAllScream(object):
         if need_checkout:
             run_cmd_no_fail("git checkout {}".format(git_head_ref))
             print("  Switched back to {} ({})".format(git_head_ref, git_head_commit))
+            last_commit = run_cmd_no_fail("git log -1 --oneline")
+            print("   Last commit on tested branch:")
+            print("     {}".format(last_commit))
+            # Re-update submodules, just in case baselines and branch have different submodules
+            run_cmd_no_fail("git submodule update --init --recursive")
 
         return success
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -66,7 +66,7 @@ class TestAllScream(object):
                 elif self._integration_test:
                     self._baseline_ref = "origin/master"
                     if get_current_commit() != get_current_commit(commit="origin/master"):
-                        run_cmd_no_fail("git merge origin/master", arg_stdout=None, arg_stderr=None, verbose=True)
+                        run_cmd_no_fail("git merge origin/master -m 'Autotester master merge commit'", arg_stdout=None, arg_stderr=None, verbose=True)
                 else:
                     self._baseline_ref = get_common_ancestor("origin/master")
                     # Prefer a symbolic ref if possible

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -79,6 +79,12 @@ class TestAllScream(object):
 
                 print("Using baseline commit {}".format(self._baseline_ref))
         else:
+            if self._integration_test:
+                if get_current_commit() != get_current_commit(commit="origin/master"):
+                    run_cmd_no_fail("git merge origin/master -m 'Autotester master merge commit'", arg_stdout=None, arg_stderr=None, verbose=True)
+                    # Re-update submodules, just in case master had some new stuff
+                    run_cmd_no_fail("git submodule update --init --recursive")
+
             print("NOTE: baselines for each build type BT must be in '{}/BT/data'. We don't check this, "
                   "but there will be errors if the baselines are not found.".format(self._baseline_dir))
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -69,8 +69,7 @@ class TestAllScream(object):
                     self._baseline_ref = "HEAD"
                 elif self._integration_test:
                     self._baseline_ref = "origin/master"
-                    if get_current_commit() != get_current_commit(commit="origin/master"):
-                        merge_git_ref(git_ref="origin/master")
+                    merge_git_ref(git_ref="origin/master")
                 else:
                     self._baseline_ref = get_common_ancestor("origin/master")
                     # Prefer a symbolic ref if possible
@@ -224,14 +223,9 @@ class TestAllScream(object):
         git_head_ref        = get_current_head()
         git_baseline_commit = get_current_commit(commit=self._baseline_ref)
 
-        need_checkout = git_baseline_commit != git_head_commit
-
         print("Generating baselines for ref {}".format(self._baseline_ref))
 
-        if need_checkout:
-            expect(is_repo_clean(), "If we need to change HEAD, then the repo must be clean before running")
-
-            checkout_git_ref(git_ref=self._baseline_ref,verbose=True)
+        checkout_git_ref(git_ref=self._baseline_ref,verbose=True)
 
         success = True
         num_workers = len(self._tests) if self._parallel else 1
@@ -249,8 +243,7 @@ class TestAllScream(object):
                     print('Generation of baselines for build {} failed'.format(self._test_full_names[test]))
                     return False
 
-        if need_checkout:
-            checkout_git_ref(git_ref=git_head_ref,verbose=True)
+        checkout_git_ref(git_ref=git_head_ref,verbose=True)
 
         return success
 

--- a/components/scream/scripts/utils.py
+++ b/components/scream/scripts/utils.py
@@ -358,7 +358,7 @@ def update_submodules(repo=None):
     """
     Updates submodules
     """
-    run_cmd("git submodule update --init --recursive",from_dir=repo)
+    run_cmd_no_fail("git submodule update --init --recursive",from_dir=repo)
 
 ###############################################################################
 def merge_git_ref(git_ref, repo=None):
@@ -366,7 +366,7 @@ def merge_git_ref(git_ref, repo=None):
     """
     Merge given git ref into the current branch, and updates submodules
     """
-    run_cmd("git merge {} -m 'Automatic merge of {}'".format(git_ref,git_ref),from_dir=repo)
+    run_cmd_no_fail("git merge {} -m 'Automatic merge of {}'".format(git_ref,git_ref),from_dir=repo)
     update_submodules(repo)
     expect(is_repo_clean(), "Something went wrong while performing the merge of '{}'".format(git_ref))
 
@@ -387,11 +387,14 @@ def checkout_git_ref(git_ref, verbose=False, repo=None):
     """
     Checks out 'branch_ref', and updates submodules
     """
-    run_cmd_no_fail("git checkout {}".format(git_ref),from_dir=repo)
-    update_submodules(repo)
-    git_commit = get_current_commit()
-    expect(is_repo_clean(), "Something went wrong when checking out git ref '{}'".format(git_ref))
-    if verbose:
-        print("  Switched to '{}' ({})".format(git_ref,git_commit))
-        print_last_commit(git_ref=git_ref)
+    if get_current_commit() != get_current_commit(commit=git_ref):
+        expect(is_repo_clean(), "If we need to change HEAD, then the repo must be clean before running")
+
+        run_cmd_no_fail("git checkout {}".format(git_ref),from_dir=repo)
+        update_submodules(repo)
+        git_commit = get_current_commit()
+        expect(is_repo_clean(), "Something went wrong when checking out git ref '{}'".format(git_ref))
+        if verbose:
+            print("  Switched to '{}' ({})".format(git_ref,git_commit))
+            print_last_commit(git_ref=git_ref)
 

--- a/components/scream/scripts/utils.py
+++ b/components/scream/scripts/utils.py
@@ -351,3 +351,47 @@ def get_common_ancestor(other_head, head="HEAD", repo=None):
     """
     rc, output, _ = run_cmd("git merge-base {} {}".format(other_head, head), from_dir=repo)
     return output if rc == 0 else None
+
+###############################################################################
+def update_submodules(repo=None):
+###############################################################################
+    """
+    Updates submodules
+    """
+    run_cmd("git submodule update --init --recursive",from_dir=repo)
+
+###############################################################################
+def merge_git_ref(git_ref, repo=None):
+###############################################################################
+    """
+    Merge given git ref into the current branch, and updates submodules
+    """
+    run_cmd("git merge {} -m 'Automatic merge of {}'".format(git_ref,git_ref),from_dir=repo)
+    update_submodules(repo)
+    expect(is_repo_clean(), "Something went wrong while performing the merge of '{}'".format(git_ref))
+
+###############################################################################
+def print_last_commit(git_ref=None, repo=None):
+###############################################################################
+    """
+    Prints a one-liner of the last commit
+    """
+    git_ref = get_current_head(repo) if git_ref is None else git_ref
+    last_commit = run_cmd_no_fail("git log {} -1 --oneline".format(git_ref))
+    print("   Last commit on ref '{}':".format(git_ref))
+    print("     {}".format(last_commit))
+
+###############################################################################
+def checkout_git_ref(git_ref, verbose=False, repo=None):
+###############################################################################
+    """
+    Checks out 'branch_ref', and updates submodules
+    """
+    run_cmd_no_fail("git checkout {}".format(git_ref),from_dir=repo)
+    update_submodules(repo)
+    git_commit = get_current_commit()
+    expect(is_repo_clean(), "Something went wrong when checking out git ref '{}'".format(git_ref))
+    if verbose:
+        print("  Switched to '{}' ({})".format(git_ref,git_commit))
+        print_last_commit(git_ref=git_ref)
+


### PR DESCRIPTION
These are:

1. when merging origin/master, add a message to the git command, to prevent merge failures due to lack of confirmation of commit when running in a script
2. when switching branches, update the submodules, to make sure the repo is clean and ready for testing. In particular, if we had to merge origin/master in the branch, the submodules needs to be updated, in case new submodules were added in master
3. printing a one-liner of the last commit at the beginning, and after switching branches (if we do), to increase verbosity in case of debugging
4. allowing integration testing when testing against a baseline dir. This may be useful soon, when the testing will become heavier and more costly.