### PR TITLE
SCREAM: make test-all-scream side-effect-free

### DIFF
--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -327,14 +327,16 @@ class TestAllScream(object):
                 if not success:
                     print ("Error(s) occurred during test phase")
 
+        except:
+            # Re-throw whatever the exception was
+            # Note: why do we catch it then, you may ask? Because we need to run
+            #       the finally block before the exception is pushed up the stack.
+            raise
+
+        finally:
             if not self._keep_tree:
                 # Cleanup the repo if needed
-                cleanup_repo(self._original_head, self._original_commit)
+                cleanup_repo(self._original_branch, self._original_commit)
 
-        except:
-            if not self._keep_tree:
-                # Cleanup the repo if needed, then re-throw whatever the exception was
-                cleanup_repo(self._original_head, self._original_commit)
-            raise
 
         return success

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -333,18 +333,13 @@ class TestAllScream(object):
                 success = self.generate_all_baselines()
                 if not success:
                     print ("Error(s) occurred during baselines generation phase")
+                    return False
 
             if self._perform_tests:
                 # Finally, run the tests
                 success &= self.run_all_tests()
                 if not success:
                     print ("Error(s) occurred during test phase")
-
-        except:
-            # Re-throw whatever the exception was
-            # Note: why do we catch it then, you may ask? Because we need to run
-            #       the finally block before the exception is pushed up the stack.
-            raise
 
         finally:
             if not self._keep_tree:

--- a/components/scream/scripts/utils.py
+++ b/components/scream/scripts/utils.py
@@ -367,7 +367,7 @@ def merge_git_ref(git_ref, repo=None):
     Merge given git ref into the current branch, and updates submodules
     """
     expect(is_repo_clean(), "Cannot merge ref '{}'. The repo is not clean.".format(git_ref))
-    stat = run_cmd("git merge {} -m 'Automatic merge of {}'".format(git_ref,git_ref),from_dir=repo)
+    run_cmd_no_fail("git merge {} -m 'Automatic merge of {}'".format(git_ref,git_ref),from_dir=repo)
     update_submodules(repo)
     expect(is_repo_clean(), "Something went wrong while performing the merge of '{}'".format(git_ref))
 
@@ -405,8 +405,7 @@ def get_git_toplevel_dir(repo=None):
     """
     Get repo toplevel directory
     """
-    stat, dirname = run_cmd_no_fail("git rev-parse --show-toplevel")
-    return dirname
+    return run_cmd_no_fail("git rev-parse --show-toplevel")
 
 ###############################################################################
 def cleanup_repo(orig_branch, orig_commit, repo=None):


### PR DESCRIPTION
This PR makes sure the repo is returned to its original state at the end of test-all-scream execution.

This is only useful if any of the following apply:

- user tests against a baseline ref other than HEAD, and something goes wrong while switching branches, or during the baselines generation
- user does an integration test. If successful, and the branch is not ahead of master, the repo will contain a merge commit. If something goes wrong during the merge, the repo may not be clean.

This mod should not affect a normal development cycle (in particular, it has no effect when running with `--keep-tree` option).