### PR TITLE
test-all-scream: quality of life improvements

### DIFF
--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -70,6 +70,13 @@ OR
     parser.add_argument("-i", "--integration-test", action="store_true", default="JENKINS_HOME" in os.environ,
                         help="Merge origin/master into this branch before testing.")
 
+    parser.add_argument("-r", "--root-dir",
+                        help="The root directory of the scream src you want to test. "
+                        "Default will be the scream src containing this script.")
+
+    parser.add_argument("-d", "--dry-run", action="store_true",
+                        help="Do a dry run, commands will be printed but not executed")
+
     return parser.parse_args(args[1:])
 
 ###############################################################################

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -1,10 +1,10 @@
-from utils import run_cmd, check_minimum_python_version, run_cmd_no_fail, get_current_head,     \
-                  get_current_commit, get_current_branch, expect, is_repo_clean, cleanup_repo,  \
-                  get_common_ancestor, merge_git_ref, checkout_git_ref, print_last_commit
+from utils import run_cmd, check_minimum_python_version, get_current_head,     \
+    get_current_commit, get_current_branch, expect, is_repo_clean, cleanup_repo,  \
+    get_common_ancestor, merge_git_ref, checkout_git_ref, print_last_commit
 
 check_minimum_python_version(3, 4)
 
-import os, shutil
+import os, shutil, pathlib
 import concurrent.futures as threading3
 
 ###############################################################################
@@ -14,7 +14,7 @@ class TestAllScream(object):
     ###########################################################################
     def __init__(self, cxx, kokkos=None, submit=False, parallel=False, fast_fail=False, baseline_ref=None,
                  baseline_dir=None, machine=None, no_tests=False, keep_tree=False, custom_cmake_opts=(), tests=(),
-                 integration_test="JENKINS_HOME" in os.environ):
+                 integration_test="JENKINS_HOME" in os.environ, root_dir=None, dry_run=False):
     ###########################################################################
 
         self._cxx               = cxx
@@ -29,10 +29,9 @@ class TestAllScream(object):
         self._baseline_dir      = baseline_dir
         self._custom_cmake_opts = custom_cmake_opts
         self._tests             = tests
-        self._src_dir           = os.getcwd()
+        self._root_dir          = root_dir
         self._integration_test  = integration_test
-        self._original_branch   = get_current_branch()
-        self._original_commit   = get_current_commit()
+        self._dry_run           = dry_run
 
         self._tests_cmake_args = {"dbg" : [("CMAKE_BUILD_TYPE", "Debug")],
                                   "sp"  : [("CMAKE_BUILD_TYPE", "Debug"),
@@ -53,7 +52,20 @@ class TestAllScream(object):
                        "Requested test '{}' is not supported by test-all-scream, please choose from: {}".\
                            format(t, ", ".join(self._test_full_names.keys())))
 
-        expect(self._src_dir.endswith("components/scream"), "Run from $scream_repo/components/scream")
+        # Compute root dir
+        if not self._root_dir:
+            self._root_dir = pathlib.Path(__file__).resolve().parent.parent
+        else:
+            self._root_dir = pathlib.Path(self._root_dir).resolve()
+            expect(self._root_dir.is_dir() and self._root_dir.parts()[-2:] == ('scream', 'components'),
+                   "Bad root-dir '{}', should be: $scream_repo/components/scream".format(self._root_dir))
+
+        os.chdir(str(self._root_dir)) # needed, or else every git command will need repo=root_dir
+        expect(get_current_commit(), "Root dir: {}, does not appear to be a git repo".format(self._root_dir))
+
+        self._original_branch = get_current_branch()
+        self._original_commit = get_current_commit()
+
         if not self._kokkos:
             expect(self._machine, "If no kokkos provided, must provide machine name for internal kokkos build")
         if self._submit:
@@ -80,11 +92,14 @@ class TestAllScream(object):
 
                 print("Using baseline commit {}".format(self._baseline_ref))
         else:
+            self._baseline_dir = pathlib.Path(self._baseline_dir).resolve()
+            expect(self._baseline_dir.is_dir(), "Baseline_dir {} is not a dir".format(self._baseline_dir))
+            for test in self._tests:
+                test_baseline_dir = self.get_preexisting_baseline(test)
+                expect(test_baseline_dir.is_dir(), "Missing baseline {}".format(test_baseline_dir))
+
             if self._integration_test:
                 merge_git_ref(git_ref="origin/master")
-
-            print("NOTE: baselines for each build type BT must be in '{}/BT/data'. We don't check this, "
-                  "but there will be errors if the baselines are not found.".format(self._baseline_dir))
 
         # Deduce how many resources per test
         proc_count = 4
@@ -120,7 +135,7 @@ class TestAllScream(object):
                 if self._tests.index(test)<remainder:
                     self._proc_count[test] = proc_count + 1
 
-                print ("test {} has {} procs".format(test,self._proc_count[test]))
+                print("test {} has {} procs".format(test,self._proc_count[test]))
 
         if self._keep_tree:
             expect(not is_repo_clean(), "Makes no sense to use --keep-tree when repo is clean")
@@ -139,12 +154,29 @@ class TestAllScream(object):
                    "you can pass `--keep-tree` to allow non-clean repo.")
 
     ###############################################################################
+    def get_test_dir(self, test):
+    ###############################################################################
+        return pathlib.Path(self._root_dir, "ctest-build", self._test_full_names[test])
+
+    ###############################################################################
+    def get_preexisting_baseline(self, test):
+    ###############################################################################
+        expect(self._baseline_dir is not None, "Cannot supply preexisting baseline without baseline dir")
+        return pathlib.Path(self._baseline_dir, self._test_full_names[test], "data")
+
+    ###############################################################################
+    def get_machine_file(self):
+    ###############################################################################
+        expect(self._machine is not None, "Cannot get machine file without machine")
+        return pathlib.Path(self._root_dir, "cmake", "machine-files", "{}.cmake".format(self._machine))
+
+    ###############################################################################
     def generate_cmake_config(self, extra_configs, for_ctest=False):
     ###############################################################################
         if self._kokkos:
             kokkos_cmake = "-DKokkos_DIR={}".format(self._kokkos)
         else:
-            kokkos_cmake = "-C {}/cmake/machine-files/{}.cmake".format(self._src_dir, self._machine)
+            kokkos_cmake = "-C {}".format(self.get_machine_file())
 
         result = "{}-DCMAKE_CXX_COMPILER={} {}".format("" if for_ctest else "cmake ", self._cxx, kokkos_cmake)
         for key, value in extra_configs:
@@ -180,7 +212,7 @@ class TestAllScream(object):
         result += "CTEST_PARALLEL_LEVEL={} ctest -V --output-on-failure ".format(self._proc_count[test])
 
         if self._baseline_dir is not None:
-            cmake_config += " -DSCREAM_TEST_DATA_DIR={}/{}/data".format(self._baseline_dir,name)
+            cmake_config += " -DSCREAM_TEST_DATA_DIR={}".format(self.get_preexisting_baseline(test))
 
         if not self._submit:
             result += "-DNO_SUBMIT=True "
@@ -189,7 +221,7 @@ class TestAllScream(object):
             result += "-D{}={} ".format(key, value)
 
         result += "-DBUILD_NAME_MOD={} ".format(name)
-        result += '-S {}/cmake/ctest_script.cmake -DCMAKE_COMMAND="{}" '.format(self._src_dir, cmake_config)
+        result += '-S {}/cmake/ctest_script.cmake -DCMAKE_COMMAND="{}" '.format(self._root_dir, cmake_config)
 
         # Ctest can only competently manage test pinning across a single instance of ctest. For
         # multiple concurrent instances of ctest, we have to help it.
@@ -202,17 +234,18 @@ class TestAllScream(object):
     ###############################################################################
     def generate_baselines(self, test):
     ###############################################################################
-        name = self._test_full_names[test]
-        test_dir = "ctest-build/{}".format(name)
+        test_dir = self.get_test_dir(test)
 
         cmake_config = self.generate_cmake_config(self._tests_cmake_args[test])
 
-        print("Generating baseline for build type {} with config '{}'".format(name, cmake_config))
+        print("===============================================================================")
+        print("Generating baseline for test {} with config '{}'".format(self._test_full_names[test], cmake_config))
+        print("===============================================================================")
 
         # We cannot just crash if we fail to generate baselines, since we would
         # not get a dashboard report if we did that. Instead, just ensure there is
         # no baseline file to compare against if there's a problem.
-        stat, _, err = run_cmd("{} {}".format(cmake_config, self._src_dir), from_dir=test_dir, verbose=True)
+        stat, _, err = run_cmd("{} {}".format(cmake_config, self._root_dir), from_dir=test_dir, verbose=True, dry_run=self._dry_run)
         if stat!= 0:
             print ("WARNING: Failed to configure baselines:\n{}".format(err))
             return False
@@ -222,7 +255,7 @@ class TestAllScream(object):
             start, end = self.get_taskset_id(test)
             cmd = "taskset -c {}-{} sh -c '{}'".format(start,end,cmd)
 
-        stat, _, err = run_cmd(cmd, from_dir=test_dir, verbose=True)
+        stat, _, err = run_cmd(cmd, from_dir=test_dir, verbose=True, dry_run=self._dry_run)
 
         if stat != 0:
             print("WARNING: Failed to create baselines:\n{}".format(err))
@@ -233,11 +266,11 @@ class TestAllScream(object):
     ###############################################################################
     def generate_all_baselines(self):
     ###############################################################################
-        git_head_commit     = get_current_commit()
-        git_head_ref        = get_current_head()
-        git_baseline_commit = get_current_commit(commit=self._baseline_ref)
+        git_head_ref = get_current_head()
 
+        print("###############################################################################")
         print("Generating baselines for ref {}".format(self._baseline_ref))
+        print("###############################################################################")
 
         checkout_git_ref(self._baseline_ref, verbose=True)
 
@@ -264,21 +297,27 @@ class TestAllScream(object):
     ###############################################################################
     def run_test(self, test):
     ###############################################################################
-        name = self._test_full_names[test]
         git_head = get_current_head()
-        print("Testing '{}' for build type '{}'".format(git_head,name))
 
-        test_dir = "ctest-build/{}".format(name)
+        print("===============================================================================")
+        print("Testing '{}' for test '{}'".format(git_head, self._test_full_names[test]))
+        print("===============================================================================")
+
+        test_dir = self.get_test_dir(test)
         cmake_config = self.generate_cmake_config(self._tests_cmake_args[test], for_ctest=True)
         ctest_config = self.generate_ctest_config(cmake_config, [], test)
 
-        success = run_cmd(ctest_config, from_dir=test_dir, arg_stdout=None, arg_stderr=None, verbose=True)[0] == 0
+        success = run_cmd(ctest_config, from_dir=test_dir, arg_stdout=None, arg_stderr=None, verbose=True, dry_run=self._dry_run)[0] == 0
 
         return success
 
     ###############################################################################
     def run_all_tests(self):
     ###############################################################################
+        print("###############################################################################")
+        print("Running tests!")
+        print("###############################################################################")
+
         success = True
         tests_success = {
             test : False
@@ -301,10 +340,11 @@ class TestAllScream(object):
 
         for t,s in tests_success.items():
             if not s:
-                name = self._test_full_names[t]
-                print("Build type {} failed. Here's a list of failed tests:".format(name))
-                out = run_cmd("cat ctest-build/{}/Testing/Temporary/LastTestsFailed*".format(name))[1]
-                print(out)
+                print("Build type {} failed. Here's a list of failed tests:".format(self._test_full_names[t]))
+                test_dir = self.get_test_dir(t)
+                test_results_dir = pathlib.Path(test_dir, "Testing", "Temporary")
+                for result in test_results_dir.glob("LastTestsFailed*"):
+                    print(result.read_text())
 
         return success
 
@@ -315,15 +355,13 @@ class TestAllScream(object):
         try:
             # First, create build directories (one per test)
             for test in self._tests:
-                # Get this test's build dir name and cmake args
-                full_name = self._test_full_names[test]
-                test_dir = "./ctest-build/{}".format(full_name)
+                test_dir = self.get_test_dir(test)
 
                 # Create this test's build dir
-                if os.path.exists(test_dir):
-                    shutil.rmtree(test_dir)
+                if test_dir.exists():
+                    shutil.rmtree(str(test_dir))
 
-                os.makedirs(test_dir)
+                test_dir.mkdir(parents=True)
 
             if self._baseline_dir is None:
                 # Second, generate baselines
@@ -344,6 +382,5 @@ class TestAllScream(object):
             if not self._keep_tree:
                 # Cleanup the repo if needed
                 cleanup_repo(self._original_branch, self._original_commit)
-
 
         return success

--- a/components/scream/scripts/utils.py
+++ b/components/scream/scripts/utils.py
@@ -22,7 +22,7 @@ def expect(condition, error_msg, exc_type=SystemExit, error_prefix="ERROR:"):
         raise exc_type(msg)
 
 ###############################################################################
-def run_cmd(cmd, input_str=None, from_dir=None, verbose=None,
+def run_cmd(cmd, input_str=None, from_dir=None, verbose=None, dry_run=False,
             arg_stdout=subprocess.PIPE, arg_stderr=subprocess.PIPE, env=None, combine_output=False):
 ###############################################################################
     """
@@ -32,9 +32,13 @@ def run_cmd(cmd, input_str=None, from_dir=None, verbose=None,
     True
     """
     arg_stderr = subprocess.STDOUT if combine_output else arg_stderr
+    from_dir = str(from_dir) if from_dir else from_dir
 
     if verbose:
         print("RUN: {}\nFROM: {}".format(cmd, os.getcwd() if from_dir is None else from_dir))
+
+    if dry_run:
+        return 0, "", ""
 
     if (input_str is not None):
         stdin = subprocess.PIPE
@@ -86,7 +90,8 @@ def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
     >>> run_cmd_no_fail('echo THE ERROR >&2', combine_output=True) == 'THE ERROR'
     True
     """
-    stat, output, errput = run_cmd(cmd, input_str, from_dir, verbose, arg_stdout, arg_stderr, env, combine_output)
+    stat, output, errput = run_cmd(cmd, input_str=input_str, from_dir=from_dir, verbose=verbose,
+                                   arg_stdout=arg_stdout, arg_stderr=arg_stderr, env=env, combine_output=combine_output)
     if stat != 0:
         # If command produced no errput, put output in the exception since we
         # have nothing else to go on.
@@ -362,7 +367,7 @@ def update_submodules(repo=None):
     """
     Updates submodules
     """
-    run_cmd_no_fail("git submodule update --init --recursive",from_dir=repo)
+    run_cmd_no_fail("git submodule update --init --recursive", from_dir=repo)
 
 ###############################################################################
 def merge_git_ref(git_ref, repo=None):
@@ -371,7 +376,7 @@ def merge_git_ref(git_ref, repo=None):
     Merge given git ref into the current branch, and updates submodules
     """
     expect(is_repo_clean(), "Cannot merge ref '{}'. The repo is not clean.".format(git_ref))
-    run_cmd_no_fail("git merge {} -m 'Automatic merge of {}'".format(git_ref,git_ref),from_dir=repo)
+    run_cmd_no_fail("git merge {} -m 'Automatic merge of {}'".format(git_ref,git_ref), from_dir=repo)
     update_submodules(repo)
     expect(is_repo_clean(), "Something went wrong while performing the merge of '{}'".format(git_ref))
 
@@ -383,8 +388,7 @@ def print_last_commit(git_ref=None, repo=None):
     """
     git_ref = get_current_head(repo) if git_ref is None else git_ref
     last_commit = run_cmd_no_fail("git log {} -1 --oneline".format(git_ref))
-    print("   Last commit on ref '{}':".format(git_ref))
-    print("     {}".format(last_commit))
+    print("Last commit on ref '{}': {}".format(git_ref, last_commit))
 
 ###############################################################################
 def checkout_git_ref(git_ref, verbose=False, repo=None):
@@ -402,7 +406,7 @@ def checkout_git_ref(git_ref, verbose=False, repo=None):
         expect(is_repo_clean(), "Something went wrong when checking out git ref '{}'".format(git_ref))
 
         if verbose:
-            print("  Switched to '{}' ({})".format(git_ref,git_commit))
+            print("Switched to '{}' ({})".format(git_ref,git_commit))
             print_last_commit(git_ref=git_ref)
 
 ###############################################################################


### PR DESCRIPTION
Interface:
1. Be more more flexible re where test-all-scream can be run from
2. Allow test-all-scream to test other scream repos than where it lives
3. Add dry-run
4. Improve output formatting with rows of # denoting major events and rows of = denoting per-test events.

Implementation:
1. Use python3's wonderful pathlib library for managing paths
2. Clean up some pylint warnings and errors
3. Improve encapsulation of key concepts such as asking for test directory
4. Better error checking if user specifies pre-existing baseline dir