### PR TITLE
gather-all-data: quality of life improvements

### DIFF
--- a/components/scream/scripts/gather-all-data
+++ b/components/scream/scripts/gather-all-data
@@ -13,12 +13,19 @@ had good luck using face.sandia.gov as my launch machine.
 
 It is expected that your current repo is clean and that your current commit
 is the one you want to test.
+
+If doing remote testing, it is expected that a usable repo exists on the
+target machine at location $HOME/scream-perf-$machine (unless you provide
+a different root via the --root-dir argument.
+
+A number of options support automatic magic strings. See the help for individual
+options to see which magic strings are supported.
 """
 
 from utils import expect, check_minimum_python_version, get_current_commit
 check_minimum_python_version(3, 5)
 
-import argparse, sys, os
+import argparse, sys, pathlib
 
 from gather_all_data import GatherAllData, MACHINE_METADATA
 
@@ -38,29 +45,42 @@ OR
     > {0} './scripts/test-all-scream $compiler -m $machine' -l -m $machine
 
     \033[1;32m# Do correctness testing for scream-docs micro apps \033[0m
-    > {0} './test-all $compiler $kokkos' -d
+    > {0} './test-all $compiler $kokkos' -o
 
     \033[1;32m# Do a scaling performance test for lin-interp on blake \033[0m
-    > {0} '$scream/scripts/perf-analysis ncol:8000 km1:128 km2:256 minthresh:0.001 repeat:10 --kokkos=$kokkos --test=lin-interp/li_ref --test=lin-interp/li_kokkos --test=lin-interp/li_vect -s ncol:2:128000' -m blake -d
-""".format(os.path.basename(args[0])),
+    > {0} '$scream/scripts/perf-analysis ncol:8000 km1:128 km2:256 minthresh:0.001 repeat:10 --kokkos=$kokkos --test=lin-interp/li_ref --test=lin-interp/li_kokkos --test=lin-interp/li_vect -s ncol:2:128000' -m blake -o
+""".format(pathlib.Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    parser.add_argument("run", help="What to run on the machine, cwd will be either scream-perf-$machine/components/scream or scream-docs-perf-$machine/micro-apps depending on if --scream-docs was provided")
+    parser.add_argument("run", help="What to run on the machine, cwd for the command will be root-dir. "
+                        "Supported magic strings: $compiler $kokkos $machine $scream_docs $scream")
 
-    default_commit = get_current_commit(short=True)
-    parser.add_argument("-c", "--commit", default=default_commit, help="Commit to test. Default is current HEAD.")
+    parser.add_argument("-c", "--commit", help="Commit to test. Default is current HEAD.")
 
     parser.add_argument("-m", "--machine", dest="machines", action="append", choices=MACHINE_METADATA.keys(),
                         help="Select which machines to run on, default is all")
 
-    parser.add_argument("-d", "--scream-docs", action="store_true", help="Test scream-docs instead of scream.")
+    parser.add_argument("-o", "--scream-docs", action="store_true", help="Test scream-docs instead of scream.")
 
     parser.add_argument("-l", "--local", action="store_true",
-                        help="Run tests on local machine. Assumes ./scream and ./scream-docs")
+                        help="Run tests on local machine, only using this script to manage env and batch submission.")
 
-    parser.add_argument("-k", "--kokkos", help="Use to select specific kokkos installation. Can refer to this in run cmd with $kokkos")
+    parser.add_argument("-k", "--kokkos", help="Use to select specific kokkos installation. "
+                        "Default will be scream-repo/externals/kokkos. "
+                        "Supported magic strings: $machine $compiler")
+
+    parser.add_argument("-r", "--root-dir",
+                        help="The root directory of the scream src you want to test. "
+                        "Default will be the scream src containing this script for local testing or "
+                        "$HOME/scream-perf-$machine/components/scream for remote testing or "
+                        "$HOME/scream-docs-perf-$machine/micro-apps for remote testing of scream-docs. "
+                        "References to $machine in this option will be automatically replaced with the machine name. "
+                        "Supported magic strings: $machine")
+
+    parser.add_argument("-d", "--dry-run", action="store_true",
+                        help="Do a dry run, commands will be printed but not executed")
 
     args = parser.parse_args(args[1:])
 
@@ -70,14 +90,36 @@ OR
     expect(not (args.local and len(args.machines) > 1),
            "Cannot run on multiple machines if local")
 
-    if args.local:
-        expect(os.path.isdir("scream"), "Expected to see ./scream")
-        if args.scream_docs:
-            expect(os.path.isdir("scream-docs"), "Expected to see ./scream-docs")
+    # Compute root!
+    script_home = pathlib.Path(__file__).resolve().parent.parent
+    if not args.root_dir:
+        if args.local:
+            if args.scream_docs:
+                args.root_dir = pathlib.Path().resolve() # cwd
+                expect(args.root_dir.name == "micro-apps",
+                       "Please do local scream-docs gathers from $scream-docs-repo/micro-apps")
+            else:
+                args.root_dir = script_home
+        else:
+            if args.scream_docs:
+                args.root_dir = pathlib.Path("~/scream-docs-perf-$machine/micro-apps")
+            else:
+                args.root_dir = pathlib.Path("~/scream-perf-$machine/components/scream")
 
-    if not args.commit:
-        expect(args.local, "Could not determine commit")
-        args.commit = get_current_commit(short=True, repo="./scream") if not args.scream_docs else get_current_commit(short=True, repo="./scream-docs")
+    else:
+        if args.local:
+            args.root_dir = pathlib.Path(args.root_dir).resolve()
+        else:
+            args.root_dir = pathlib.Path(args.root_dir)
+
+    # If doing remote testing, set remote repos to commit matching local commit
+    if not args.commit and not args.local:
+        if args.scream_docs:
+            args.commit = get_current_commit(short=True)
+            expect(args.commit, "Must be able to probe scream-docs commit. "
+                   "Please run from a scream-docs repo or provide --commit=<COMMIT>")
+        else:
+            args.commit = get_current_commit(short=True, repo=str(script_home))
 
     return args
 

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -98,7 +98,7 @@ class GatherAllData(object):
         # a scream-docs test.
         setup = ""
         if (not self._local and self._scream_docs):
-            setup = "cd {} && git fetch && git reset --hard origin/master && git submodule update --init && "\
+            setup = "cd {} && git fetch && git reset --hard origin/master && git submodule update --init --recursive && "\
                 .format(scream_repo)
 
         extra_env = ""
@@ -106,7 +106,7 @@ class GatherAllData(object):
         if not is_cuda_machine:
             extra_env = "OMP_PROC_BIND=spread "
 
-        repo_setup = "true" if (self._local) else "git fetch && git checkout {} && git submodule update --init".format(self._commit)
+        repo_setup = "true" if (self._local) else "git fetch && git checkout {} && git submodule update --init --recursive".format(self._commit)
 
         cmd = "{}cd {} && {} && {} && {}{} {}".format(setup, repo, env_setup_str, repo_setup, extra_env, batch, local_cmd)
 

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -1,6 +1,6 @@
 from utils import run_cmd_no_fail
 
-import os
+import os, pathlib
 import concurrent.futures as threading3
 
 # MACHINE -> (env_setup, compiler, batch submit prefix)
@@ -42,7 +42,7 @@ class GatherAllData(object):
 ###############################################################################
 
     ###########################################################################
-    def __init__(self, run, commit, machines, scream_docs, local, kokkos):
+    def __init__(self, run, commit, machines, scream_docs, local, kokkos, root_dir, dry_run):
     ###########################################################################
         self._run         = run
         self._commit      = commit
@@ -50,6 +50,8 @@ class GatherAllData(object):
         self._scream_docs = scream_docs
         self._local       = local
         self._kokkos      = kokkos
+        self._root_dir    = root_dir
+        self._dry_run     = dry_run
 
     ###########################################################################
     def formulate_command(self, machine):
@@ -57,30 +59,40 @@ class GatherAllData(object):
         env_setup, compiler, batch = MACHINE_METADATA[machine]
         env_setup_str = " && ".join(env_setup)
 
+        root_dir = pathlib.Path(str(self._root_dir).replace("$machine", machine))
+
         # Compute locations of key repos
         if self._local:
-            scream_docs_repo = os.path.abspath("./scream-docs/micro-apps")
-            scream_repo      = os.path.abspath("./scream/components/scream")
+            if self._scream_docs:
+                scream_docs_repo = root_dir
+                scream_repo      = pathlib.Path(__file__).resolve().parent.parent
+            else:
+                scream_docs_repo = None
+                scream_repo      = root_dir
         else:
-            scream_docs_repo = "~/scream-docs-perf-{}/micro-apps".format(machine)
-            scream_repo      = "~/scream-perf-{}/components/scream".format(machine)
+            if self._scream_docs:
+                scream_docs_repo = root_dir
+                scream_repo      = pathlib.Path("~/scream-perf-{}/components/scream".format(machine))
+            else:
+                scream_docs_repo = None
+                scream_repo      = root_dir
 
         repo = scream_docs_repo if self._scream_docs else scream_repo
 
-        # Need to know kokkos location in order to set up OMPI_CXX
+        # Compute kokkos location
         if self._kokkos:
-            kokkos_loc = self._kokkos.replace("$machine", machine).replace("$compiler", compiler)
+            kokkos_loc = pathlib.Path(self._kokkos.replace("$machine", machine).replace("$compiler", compiler))
         else:
-            kokkos_loc = os.path.join(os.path.dirname(os.path.dirname(scream_repo)), "externals", "kokkos")
+            kokkos_loc = pathlib.Path(scream_repo.parent.parent, "externals", "kokkos")
 
         local_cmd = self._run
         # Do magic replacements here
         local_cmd = local_cmd.\
             replace("$compiler", compiler).\
-            replace("$kokkos", kokkos_loc).\
+            replace("$kokkos", str(kokkos_loc)).\
             replace("$machine", machine).\
-            replace("$scream_docs", scream_docs_repo).\
-            replace("$scream", scream_repo)
+            replace("$scream_docs", str(scream_docs_repo)).\
+            replace("$scream", str(scream_repo))
 
         # Scream-docs tests may depend on scream's Kokkos and scripts, so update scream repo too if we're doing
         # a scream-docs test.
@@ -91,9 +103,7 @@ class GatherAllData(object):
 
         extra_env = ""
         is_cuda_machine = "cuda" in env_setup_str
-        if is_cuda_machine and "OMPI_CXX" not in env_setup_str:
-            extra_env = "OMPI_CXX={}/bin/nvcc_wrapper ".format(kokkos_loc)
-        else:
+        if not is_cuda_machine:
             extra_env = "OMP_PROC_BIND=spread "
 
         repo_setup = "true" if (self._local) else "git fetch && git checkout {} && git submodule update --init".format(self._commit)
@@ -109,11 +119,11 @@ class GatherAllData(object):
         print("Starting analysis on {} with cmd: {}".format(machine, cmd))
 
         if self._local:
-            run_cmd_no_fail(cmd, arg_stdout=None, arg_stderr=None, verbose=True, exc_type=RuntimeError)
+            run_cmd_no_fail(cmd, arg_stdout=None, arg_stderr=None, verbose=True, dry_run=self._dry_run, exc_type=RuntimeError)
         else:
             try:
                 ssh_cmd = "ssh -o StrictHostKeyChecking=no {} '{}'".format(machine, cmd)
-                output = run_cmd_no_fail(ssh_cmd, exc_type=RuntimeError, combine_output=True)
+                output = run_cmd_no_fail(ssh_cmd, dry_run=self._dry_run, exc_type=RuntimeError, combine_output=True)
             except RuntimeError as e:
                 output = str(e)
                 raise

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -10,7 +10,7 @@ Run from $scream-repo/components/scream
 from utils import check_minimum_python_version
 check_minimum_python_version(3, 4)
 
-import argparse, sys, os
+import argparse, sys, os, pathlib
 
 from test_all_scream import TestAllScream
 
@@ -30,7 +30,7 @@ OR
     \033[1;32m# Run all tests on current machine with custom flags\033[0m
     > cd $scream_repo/components/scream
     > ./scripts/test-all-scream $(which mpicxx) -m melvin -c "CMAKE_CXX_FLAGS=-O1 -O2"
-""".format(os.path.basename(args[0])),
+""".format(pathlib.Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )

--- a/components/scream/scripts/utils.py
+++ b/components/scream/scripts/utils.py
@@ -71,7 +71,7 @@ def run_cmd(cmd, input_str=None, from_dir=None, verbose=None, dry_run=False,
     return stat, output, errput
 
 ###############################################################################
-def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
+def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None, dry_run=False,
                     arg_stdout=subprocess.PIPE, arg_stderr=subprocess.PIPE, env=None, combine_output=False, exc_type=SystemExit):
 ###############################################################################
     """
@@ -90,7 +90,7 @@ def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
     >>> run_cmd_no_fail('echo THE ERROR >&2', combine_output=True) == 'THE ERROR'
     True
     """
-    stat, output, errput = run_cmd(cmd, input_str=input_str, from_dir=from_dir, verbose=verbose,
+    stat, output, errput = run_cmd(cmd, input_str=input_str, from_dir=from_dir, verbose=verbose, dry_run=dry_run,
                                    arg_stdout=arg_stdout, arg_stderr=arg_stderr, env=env, combine_output=combine_output)
     if stat != 0:
         # If command produced no errput, put output in the exception since we
@@ -330,7 +330,7 @@ def get_current_commit(short=False, repo=None, tag=False, commit=None):
         rc, output, err = run_cmd("git rev-parse {} {}".format("--short" if short else "", commit), from_dir=repo)
 
     if rc != 0:
-        print("Warning: getting current commit {} failed with error: {}".format(tag, commit, err))
+        print("Warning: getting current commit {} failed with error: {}".format(commit, err))
 
     return output if rc == 0 else None
 
@@ -415,7 +415,7 @@ def get_git_toplevel_dir(repo=None):
     """
     Get repo toplevel directory
     """
-    return run_cmd_no_fail("git rev-parse --show-toplevel")
+    return run_cmd_no_fail("git rev-parse --show-toplevel", from_dir=repo)
 
 ###############################################################################
 def cleanup_repo(orig_branch, orig_commit, repo=None):
@@ -423,18 +423,18 @@ def cleanup_repo(orig_branch, orig_commit, repo=None):
     """
     Discards all unstaged changes, as well as untracked files
     """
-    curr_commit = get_current_commit()
+    curr_commit = get_current_commit(repo=repo)
 
     # Is this a pointless check? Maybe.
-    if not is_repo_clean():
+    if not is_repo_clean(repo=repo):
         # Discard any modifications to the repo (either tracked or untracked),
         # but keep the ctest-build directory
-        run_cmd_no_fail("git clean -df --exclude=ctest-build")
-        toplevel_dir = get_git_toplevel_dir()
-        run_cmd_no_fail("git checkout -- {}".format(toplevel_dir))
+        run_cmd_no_fail("git clean -df --exclude=ctest-build", from_dir=repo)
+        toplevel_dir = get_git_toplevel_dir(repo=repo)
+        run_cmd_no_fail("git checkout -- {}".format(toplevel_dir), from_dir=repo)
 
-    checkout_git_ref(orig_branch)
+    checkout_git_ref(orig_branch, repo=repo)
 
     # Is this also a pointless check?
     if curr_commit != orig_commit:
-        run_cmd_no_fail("git reset --hard {}".format(orig_commit))
+        run_cmd_no_fail("git reset --hard {}".format(orig_commit), from_dir=repo)


### PR DESCRIPTION
1. Improved documentation
2. Use pathlib to manage paths instead of os.path, as was done in test-all-scream
3. Added --root-dir and --dry-run args, as was done in test-all-scream
4. Let OMPI_CXX be managed by CMake
5. Fix some mistakes in utils
6. Allow much more flexibility re where gather-all-data can be run from