### PR TITLE
WIP build_scream.cmake needs to set build-type

### DIFF
--- a/components/cmake/build_scream.cmake
+++ b/components/cmake/build_scream.cmake
@@ -11,6 +11,13 @@ function(build_scream)
     # Grab CXX compiler from CIME
     include(${CASEROOT}/Macros.cmake)
 
+    # Set build type since scream manages its own flags
+    if (DEBUG)
+      set(CMAKE_BUILD_TYPE Debug)
+    else()
+      set(CMAKE_BUILD_TYPE Release)
+    endif()
+
     add_subdirectory("scream")
   endif()
 


### PR DESCRIPTION
The main CIME Cmake build system does not use build-types since
all the flags are being managed by Macros.cmake.

Scream, being semi-autonomous, does not use Macros.cmake and does
rely on build-type.

Setting to WIP because there's no point in autotesting this change.