### PR TITLE
WIP if scream is atm comp, do not build sharedlib kokkos

### DIFF
--- a/cime/scripts/lib/CIME/build.py
+++ b/cime/scripts/lib/CIME/build.py
@@ -62,7 +62,9 @@ def xml_to_make_variable(case, varname, cmake=False):
 def uses_kokkos(case):
 ###############################################################################
     cam_target = case.get_value("CAM_TARGET")
-    return get_model() == "e3sm" and cam_target in ("preqx_kokkos", "theta-l")
+    atm_comp   = case.get_value("COMP_ATM")
+
+    return get_model() == "e3sm" and (cam_target in ("preqx_kokkos", "theta-l") and atm_comp != "scream")
 
 ###############################################################################
 def _build_model(build_threaded, exeroot, incroot, complist,


### PR DESCRIPTION
we want to use the kokkos from scream, not sharedlibs

WIP only because there's no point in autotesting this change.