### PR TITLE
Remove nonstandard/more approximate qsat calls in favor of qv_sat function

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -82,7 +82,7 @@ module micro_p3
 
   ! protected items should be treated as private for everyone except tests
 
-  real(rtype),protected :: e0
+  !real(rtype),protected :: e0 !PMC del622
 
   real(rtype), protected, dimension(densize,rimsize,isize,tabsize) :: itab   !ice lookup table values
 
@@ -152,8 +152,8 @@ contains
     !------------------------------------------------------------------------------------------!
 
     ! saturation pressure at T = 0 C
-    e0    = polysvp1(zerodegc,0)
-
+    !e0    = polysvp1(zerodegc,0)
+    !PMC del622
 
     !------------------------------------------------------------------------------------------!
     ! read in ice microphysics table
@@ -2296,7 +2296,8 @@ f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,    &
 #endif
    
    if (qitot_incld .ge.qsmall .and. t.gt.zerodegc) then
-      qsat0 = 0.622_rtype*e0/(pres-e0)
+      !qsat0 = 0.622_rtype*e0/(pres-e0) !PMC del622
+      qsat0 = qv_sat(zerodegc,pres,0)
       
       qimlt = ((f1pr05+f1pr14*bfb_cbrt(sc)*bfb_sqrt(rhofaci*rho/mu))*((t-   &
       zerodegc)*kap-rho*xxlv*dv*(qsat0-qv))*2._rtype*pi/xlf)*nitot_incld
@@ -2360,8 +2361,10 @@ qv,qc_incld,qitot_incld,nitot_incld,qr_incld,    &
 #endif
 
    if (qitot_incld.ge.qsmall .and. qc_incld+qr_incld.ge.1.e-6_rtype .and. t.lt.zerodegc) then
-      qsat0  = 0.622_rtype*e0/(pres-e0)
+      !qsat0  = 0.622_rtype*e0/(pres-e0) !PMC del622
+      qsat0 = qv_sat(zerodegc,pres,0)
 
+      
       qwgrth = ((f1pr05 + f1pr14*bfb_cbrt(sc)*bfb_sqrt(rhofaci*rho/mu))*       &
       2._rtype*pi*(rho*xxlv*dv*(qsat0-qv)-(t-zerodegc)*           &
       kap)/(xlf+cpw*(t-zerodegc)))*nitot_incld

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -82,8 +82,6 @@ module micro_p3
 
   ! protected items should be treated as private for everyone except tests
 
-  !real(rtype),protected :: e0 !PMC del622
-
   real(rtype), protected, dimension(densize,rimsize,isize,tabsize) :: itab   !ice lookup table values
 
   !ice lookup table values for ice-rain collision/collection
@@ -148,12 +146,6 @@ contains
     !------------------------------------------------------------------------------------------!
 
     lookup_file_1 = trim(lookup_file_dir)//'/'//'p3_lookup_table_1.dat-v'//trim(version_p3)
-
-    !------------------------------------------------------------------------------------------!
-
-    ! saturation pressure at T = 0 C
-    !e0    = polysvp1(zerodegc,0)
-    !PMC del622
 
     !------------------------------------------------------------------------------------------!
     ! read in ice microphysics table
@@ -2296,7 +2288,6 @@ f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,    &
 #endif
    
    if (qitot_incld .ge.qsmall .and. t.gt.zerodegc) then
-      !qsat0 = 0.622_rtype*e0/(pres-e0) !PMC del622
       qsat0 = qv_sat(zerodegc,pres,0)
       
       qimlt = ((f1pr05+f1pr14*bfb_cbrt(sc)*bfb_sqrt(rhofaci*rho/mu))*((t-   &
@@ -2361,7 +2352,6 @@ qv,qc_incld,qitot_incld,nitot_incld,qr_incld,    &
 #endif
 
    if (qitot_incld.ge.qsmall .and. qc_incld+qr_incld.ge.1.e-6_rtype .and. t.lt.zerodegc) then
-      !qsat0  = 0.622_rtype*e0/(pres-e0) !PMC del622
       qsat0 = qv_sat(zerodegc,pres,0)
 
       

--- a/components/scream/src/physics/p3/p3_constants.hpp
+++ b/components/scream/src/physics/p3/p3_constants.hpp
@@ -25,7 +25,7 @@ struct Constants
   static constexpr Scalar RhoH2O      = 1000.0;
   static constexpr Scalar MWH2O       = 18.016;
   static constexpr Scalar MWdry       = 28.966;
-  static constexpr Scalar ep_2        = MWH2O/MWdry;  // ratio of molecular mass of water to the molecular mass of dry air !0.622
+  static constexpr Scalar ep_2        = MWH2O/MWdry;  // ratio of molecular mass of water to the molecular mass of dry air =~0.622
   static constexpr Scalar gravit      = 9.80616;
   static constexpr Scalar LatVap      = 2501000.0;
   static constexpr Scalar LatIce      = 333700.0;

--- a/components/scream/src/physics/p3/p3_functions_ice_cldliq_wet_growth_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_ice_cldliq_wet_growth_impl.hpp
@@ -32,7 +32,7 @@ void Functions<S,D>
    const auto any_if_col = any_if && qccol_qrcol_ge_small;
 
    const Spack zerodeg{tmelt};
-   const Spack e0 = polysvp1(zerodeg, zero);
+   //const Spack e0 = polysvp1(zerodeg, zero); //PMC del622
    Spack qsat0{0.};
    Spack dum{0.};
    Spack dum1{0.};

--- a/components/scream/src/physics/p3/p3_functions_ice_cldliq_wet_growth_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_ice_cldliq_wet_growth_impl.hpp
@@ -38,8 +38,10 @@ void Functions<S,D>
    Spack dum1{0.};
 
    if (any_if.any()) {
-      qsat0 = sp(0.622)*e0/(pres-e0);
-  
+      //qsat0 = sp(0.622)*e0/(pres-e0);
+      //PMC del622
+      qsat0=qv_sat(zerodeg,pres,0);
+     
       qwgrth.set(any_if,
                 ((f1pr05+f1pr14*pack::cbrt(sc)*sqrt(rhofaci*rho/mu))*
                 twopi*(rho*xxlv*dv*(qsat0-qv)-(temp-tmelt)*kap)/

--- a/components/scream/src/physics/p3/p3_functions_ice_cldliq_wet_growth_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_ice_cldliq_wet_growth_impl.hpp
@@ -32,14 +32,11 @@ void Functions<S,D>
    const auto any_if_col = any_if && qccol_qrcol_ge_small;
 
    const Spack zerodeg{tmelt};
-   //const Spack e0 = polysvp1(zerodeg, zero); //PMC del622
    Spack qsat0{0.};
    Spack dum{0.};
    Spack dum1{0.};
 
    if (any_if.any()) {
-      //qsat0 = sp(0.622)*e0/(pres-e0);
-      //PMC del622
       qsat0=qv_sat(zerodeg,pres,0);
      
       qwgrth.set(any_if,

--- a/components/scream/src/physics/p3/p3_functions_ice_melting_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_ice_melting_impl.hpp
@@ -24,7 +24,8 @@ void Functions<S,D>
   const auto Pi = C::Pi;
   const auto QSMALL = C::QSMALL;
   const auto Tmelt = C::Tmelt;
-  
+  const Spack zerodeg{Tmelt};
+
   //Find cells above freezing AND which have ice
   const auto has_melt_qi = (qitot_incld >= QSMALL ) && (t > Tmelt);
 
@@ -34,9 +35,11 @@ void Functions<S,D>
     //    Note that qsat0 should be with respect to liquid. Confirmed F90 code did this.
 
     //const auto qsat0 = qv_sat(Spack(Tmelt), pres, false); //last false means NOT saturation w/ respect to ice.
-    const auto e0 = polysvp1(Spack(Tmelt), 0);
-    const auto qsat0 = 0.622 *e0/(pres-e0);
-
+    //const auto e0 = polysvp1(Spack(Tmelt), 0);
+    //const auto qsat0 = 0.622 *e0/(pres-e0);
+    //PMC del622
+    auto qsat0 = qv_sat(zerodeg,pres,0);
+    
     qimlt.set(has_melt_qi, ( (f1pr05+f1pr14*pack::cbrt(sc)*pack::sqrt(rhofaci*rho/mu))
 			     *((t-Tmelt)*kap-rho*xxlv*dv*(qsat0-qv))
 			     *sp(2.0)* Pi /xlf)*nitot_incld );

--- a/components/scream/src/physics/p3/p3_functions_ice_melting_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_ice_melting_impl.hpp
@@ -30,14 +30,7 @@ void Functions<S,D>
   const auto has_melt_qi = (qitot_incld >= QSMALL ) && (t > Tmelt);
 
   if (has_melt_qi.any()){
-
-    //PMC qv_sat from math_impl.hpp seems to match hardcoded formula from F90 I'm swapping in C++ ver.
-    //    Note that qsat0 should be with respect to liquid. Confirmed F90 code did this.
-
-    //const auto qsat0 = qv_sat(Spack(Tmelt), pres, false); //last false means NOT saturation w/ respect to ice.
-    //const auto e0 = polysvp1(Spack(Tmelt), 0);
-    //const auto qsat0 = 0.622 *e0/(pres-e0);
-    //PMC del622
+    
     auto qsat0 = qv_sat(zerodeg,pres,0);
     
     qimlt.set(has_melt_qi, ( (f1pr05+f1pr14*pack::cbrt(sc)*pack::sqrt(rhofaci*rho/mu))


### PR DESCRIPTION
Ice_melting and wet_growth processes computed qv saturation at T=0 C via a 2 step process where saturation vapor pressure at T=0 C was computed once at the module level and converted within ice melting and wet growth functions to get the saturation mixing ratio. This saved 1 expensive calculation of saturation vapor pressure (involving exponentials) but increased complexity and (because conversion to mixing ratio used a crude approximation of a constant) was less accurate. This PR simply switches to qv_sat usage in these functions. 

Because I changed *both* the F90 and the C++ with this PR, all of our small unit tests (in particular those for ice melting and wet growth) should still pass. Because gather-all-data tests p3_run_and_cmp using master as a baseline, we expect it to fail with roundoff-level (rather than huge) differences. That's what I saw when I ran this test on quartz (CPU) and lassen (GPU; though lassen timed out on the last of 3 configs it was testing). 