### PR TITLE
cam/buildnml: Fix potential race condition when copying scream data

### DIFF
--- a/components/cam/cime_config/buildnml
+++ b/components/cam/cime_config/buildnml
@@ -212,7 +212,21 @@ def buildnml(case, caseroot, compname):
         with SharedArea():
             scream_data_dir = os.path.join(case.get_value("SRCROOT"), "components/scream/data")
             for item in os.listdir(scream_data_dir):
-                safe_copy(os.path.join(scream_data_dir, item), os.path.join(din_loc_root, "atm/cam/physprops"))
+                tgt_dir  = os.path.join(din_loc_root, "atm/cam/physprops")
+                tgt_path = os.path.join(tgt_dir, item)
+                if not os.path.isdir(tgt_dir):
+                    try:
+                        os.makedirs(tgt_dir)
+                    except OSError:
+                        pass # lost the race
+
+                try:
+                    fd = os.open(tgt_path, os.O_CREAT | os.O_EXCL)
+                    # If we get to this line, we won the race
+                    os.close(fd)
+                    safe_copy(os.path.join(scream_data_dir, item), tgt_path)
+                except OSError:
+                    pass # lost the race
 
 ###############################################################################
 def _main_func():


### PR DESCRIPTION
The input data dir is shared among all cases so we need to be careful
to handle races when copying scream data into it.

Marking as WIP since there's no reason to run this through the AT.