### PR TITLE
Add explicit cxx and f90 versions of the p3_run_and_cmp test

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -219,6 +219,7 @@ set (SCREAM_F90_MODULES ${CMAKE_CURRENT_BINARY_DIR}/modules)
 file(MAKE_DIRECTORY ${SCREAM_TEST_DATA_DIR})
 
 add_custom_target(baseline)
+add_custom_target(baseline_cxx)
 
 add_subdirectory(src)
 if (NOT SCREAM_LIB_ONLY)

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -35,13 +35,20 @@ set(P3_TESTS_SRCS
 
 CreateUnitTest(p3_tests "${P3_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP p3_tests_ut_np1_omp1)
 
-CreateUnitTest(p3_run_and_cmp "p3_run_and_cmp.cpp" "${NEED_LIBS}" THREADS ${SCREAM_TEST_MAX_THREADS} EXE_ARGS "${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline" DEP p3_tests_ut_np1_omp1 OPTIONAL EXCLUDE_MAIN_CPP)
+CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}" THREADS ${SCREAM_TEST_MAX_THREADS} EXE_ARGS "${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline" DEP p3_tests_ut_np1_omp1 OPTIONAL EXCLUDE_MAIN_CPP)
+
+CreateUnitTest(p3_run_and_cmp_f90 "p3_run_and_cmp.cpp" "${NEED_LIBS}" THREADS ${SCREAM_TEST_MAX_THREADS} EXE_ARGS "-f ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline" DEP p3_tests_ut_np1_omp1 OPTIONAL EXCLUDE_MAIN_CPP)
 
 # By default, baselines should be created using all fortran
-add_custom_target(p3_baseline
-  COMMAND $<TARGET_FILE:p3_run_and_cmp> -f -g ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline)
+add_custom_target(p3_baseline_f90
+  COMMAND ${CMAKE_COMMAND} -E env OMP_NUM_THREADS=${SCREAM_TEST_MAX_THREADS} $<TARGET_FILE:p3_run_and_cmp_f90> -f -g ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline)
 
-add_dependencies(baseline p3_baseline)
+add_custom_target(p3_baseline_cxx
+  COMMAND ${CMAKE_COMMAND} -E env OMP_NUM_THREADS=${SCREAM_TEST_MAX_THREADS} $<TARGET_FILE:p3_run_and_cmp_cxx> -g ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline)
+
+add_dependencies(baseline p3_baseline_f90)
+
+add_dependencies(baseline_cxx p3_baseline_cxx)
 
 configure_file(${SCREAM_DATA_DIR}/p3_lookup_table_1.dat-v4 data/p3_lookup_table_1.dat-v4 COPYONLY)
 


### PR DESCRIPTION
Also, be sure to limit baseline generation to max threads.

Also, make it easy to generate baselines with cxx if you want.