### PR TITLE
Add dummy RRTMGP standalone test

### DIFF
--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Add RRTMGP source files. Right now, this builds the Fortran source for RRTMGP.
+# Once the C++ port of RRTMGP is complete we should switch over to that.
 set(RRTMGP_SRCS
   rrtmgp.cpp
   ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rrtmgp/kernels/mo_gas_optics_kernels.F90

--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -1,6 +1,28 @@
-
 set(RRTMGP_SRCS
   rrtmgp.cpp
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rrtmgp/kernels/mo_gas_optics_kernels.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rrtmgp/mo_gas_concentrations.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rrtmgp/mo_gas_optics.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rrtmgp/mo_gas_optics_rrtmgp.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rrtmgp/mo_rrtmgp_constants.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rrtmgp/mo_rrtmgp_util_reorder.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rrtmgp/mo_rrtmgp_util_string.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rte/mo_fluxes.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rte/mo_optical_props.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rte/mo_rte_kind.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rte/mo_rte_lw.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rte/mo_rte_sw.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rte/mo_rte_util_array.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rte/mo_source_functions.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rte/kernels/mo_fluxes_broadband_kernels.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rte/kernels/mo_optical_props_kernels.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rte/kernels/mo_rte_solver_kernels.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/extensions/mo_fluxes_byband.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/extensions/mo_fluxes_byband_kernels.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/extensions/mo_fluxes_bygpoint.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/extensions/mo_heating_rates.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/extensions/mo_rrtmgp_clr_all_sky.F90
 )
 
 set(RRTMGP_HEADERS

--- a/components/scream/src/physics/rrtmgp/rrtmgp.cpp
+++ b/components/scream/src/physics/rrtmgp/rrtmgp.cpp
@@ -1,9 +1,9 @@
 #include "rrtmgp.hpp"
 
 namespace scream {
-namespace rrtmgp {
+    namespace rrtmgp {
 
-int rrtmgp_stub() { return 42; }
+        int rrtmgp_stub() { return 42; }
 
-}  // namespace rrtmgp
+    }  // namespace rrtmgp
 }  // namespace scream

--- a/components/scream/src/physics/rrtmgp/rrtmgp.hpp
+++ b/components/scream/src/physics/rrtmgp/rrtmgp.hpp
@@ -2,11 +2,11 @@
 #define SCREAM_RRTMGP_HPP
 
 namespace scream {
-namespace rrtmgp {
+    namespace rrtmgp {
 
-int rrtmgp_stub();
+        int rrtmgp_stub();
 
-}  // namespace rrtmgp
+    }  // namespace rrtmgp
 }  // namespace scream
 
 #endif

--- a/components/scream/tests/CMakeLists.txt
+++ b/components/scream/tests/CMakeLists.txt
@@ -5,3 +5,4 @@ ENDIF()
 
 add_subdirectory(scream_p3)
 add_subdirectory(scream_p3_shoc)
+add_subdirectory(rrtmgp)

--- a/components/scream/tests/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/rrtmgp/CMakeLists.txt
@@ -1,14 +1,12 @@
 INCLUDE (ScreamUtils)
 
-#SET (p3Lib p3)
-#SET (NEED_LIBS ${p3Lib} scream_control scream_share)
-#SET (rrtmgpLib rrtmgp)
+# Required libraries
 SET (NEED_LIBS rrtmgp scream_control scream_share)
 
 # Test atmosphere processes
 CreateUnitTest(rrtmgp_stand_alone "rrtmgp_stand_alone.cpp" "${NEED_LIBS}")
 
-# Copy lookup tables to local data directory
+# Copy RRTMGP absorption coefficient lookup tables to local data directory
 FILE (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
 CONFIGURE_FILE(${SCREAM_DATA_DIR}/rrtmgp-data-sw-g224-2018-12-04.nc
                ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)

--- a/components/scream/tests/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/rrtmgp/CMakeLists.txt
@@ -8,7 +8,7 @@ CreateUnitTest(rrtmgp_stand_alone "rrtmgp_stand_alone.cpp" "${NEED_LIBS}")
 
 # Copy RRTMGP absorption coefficient lookup tables to local data directory
 FILE (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
-CONFIGURE_FILE(${SCREAM_DATA_DIR}/rrtmgp-data-sw-g224-2018-12-04.nc
+CONFIGURE_FILE(${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
                ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
-CONFIGURE_FILE(${SCREAM_DATA_DIR}/rrtmgp-data-lw-g256-2018-12-04.nc
+CONFIGURE_FILE(${SCREAM_BASE_DIR}/../cam/src/physics/rrtmgp/external/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
                ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)

--- a/components/scream/tests/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/rrtmgp/CMakeLists.txt
@@ -1,0 +1,16 @@
+INCLUDE (ScreamUtils)
+
+#SET (p3Lib p3)
+#SET (NEED_LIBS ${p3Lib} scream_control scream_share)
+#SET (rrtmgpLib rrtmgp)
+SET (NEED_LIBS rrtmgp scream_control scream_share)
+
+# Test atmosphere processes
+CreateUnitTest(rrtmgp_stand_alone "rrtmgp_stand_alone.cpp" "${NEED_LIBS}")
+
+# Copy lookup tables to local data directory
+FILE (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
+CONFIGURE_FILE(${SCREAM_DATA_DIR}/rrtmgp-data-sw-g224-2018-12-04.nc
+               ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
+CONFIGURE_FILE(${SCREAM_DATA_DIR}/rrtmgp-data-lw-g256-2018-12-04.nc
+               ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)

--- a/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
+++ b/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
@@ -1,0 +1,28 @@
+#include <catch2/catch.hpp>
+#include "share/atmosphere_process.hpp"
+#include "share/scream_pack.hpp"
+#include "share/grid/user_provided_grids_manager.hpp"
+#include "share/grid/se_grid.hpp"
+#include "control/atmosphere_driver.hpp"
+
+// #include "physics/rrtmgp/atmosphere_microphysics.hpp"
+// #include "physics/rrtmgp/scream_rrtmgp_interface.hpp"
+// #include "physics/rrtmgp/rrtmgp_functions_f90.hpp"
+
+namespace scream {
+    // === A dummy physics grids for this test === //
+    class DummyPhysicsGrid : public SEGrid {
+        public: DummyPhysicsGrid (const int num_cols) : SEGrid("Physics",GridType::SE_NodeBased,num_cols) {
+            // Nothing to do here
+        }
+        ~DummyPhysicsGrid () = default;
+    };
+
+    TEST_CASE("rrtmgp_stand_alone", "") {
+        using namespace scream;
+        using namespace scream::control;
+
+        // If we got here, we were able to run RRTMGP
+        REQUIRE(true);
+    }
+}

--- a/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
+++ b/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
@@ -5,6 +5,12 @@
 #include "share/grid/se_grid.hpp"
 #include "control/atmosphere_driver.hpp"
 
+/*
+ * This will eventually contain a standalone test for the RRTMGP driver 
+ * As of now, it is just a shell that at least requires RRTMGP to be built
+ * with the SCREAM build and test system. 
+ */
+
 // #include "physics/rrtmgp/atmosphere_microphysics.hpp"
 // #include "physics/rrtmgp/scream_rrtmgp_interface.hpp"
 // #include "physics/rrtmgp/rrtmgp_functions_f90.hpp"
@@ -18,11 +24,14 @@ namespace scream {
         ~DummyPhysicsGrid () = default;
     };
 
+    // Add the RRTMGP stand-alone driver test
     TEST_CASE("rrtmgp_stand_alone", "") {
         using namespace scream;
         using namespace scream::control;
 
-        // If we got here, we were able to run RRTMGP
+        // Do something interesting here...
+
+        // If we got here, we were able to run the above code
         REQUIRE(true);
     }
 }


### PR DESCRIPTION
Add a dummy RRTMGP standalone test to get SCREAM to build the RRTMGP source. This will be a starting point for adding the RRTMGP radiation interface to SCREAM, to interface with the AD.