### PR TITLE
SHOC TKE to aerosol activation bug fix

### DIFF
--- a/components/cam/src/physics/cam/shoc_intr.F90
+++ b/components/cam/src/physics/cam/shoc_intr.F90
@@ -132,9 +132,9 @@ module shoc_intr
     call cnst_add('SHOC_TKE',0._r8,0._r8,0._r8,ixtke,longname='turbulent kinetic energy',cam_outfld=.false.)
   
     ! Fields that are not prognostic should be added to PBUF
-    call pbuf_add_field('WTHV', 'global', dtype_r8, (/pcols,pverp,dyn_time_lvls/), wthv_idx)
-    call pbuf_add_field('TKH', 'global', dtype_r8, (/pcols,pverp,dyn_time_lvls/), tkh_idx) 
-    call pbuf_add_field('TK', 'global', dtype_r8, (/pcols,pverp,dyn_time_lvls/), tk_idx) 
+    call pbuf_add_field('WTHV', 'global', dtype_r8, (/pcols,pver,dyn_time_lvls/), wthv_idx)
+    call pbuf_add_field('TKH', 'global', dtype_r8, (/pcols,pver,dyn_time_lvls/), tkh_idx) 
+    call pbuf_add_field('TK', 'global', dtype_r8, (/pcols,pver,dyn_time_lvls/), tk_idx) 
 
     call pbuf_add_field('pblh',       'global', dtype_r8, (/pcols/), pblh_idx)
     call pbuf_add_field('tke',        'global', dtype_r8, (/pcols, pverp/), tke_idx)


### PR DESCRIPTION
Aerosol activation requires TKE.  This is passed to that routine via the "tke" PBUF field.  Aerosol activation requires that TKE be on the pverp grid.  While the original code was passing TKE with pverp dimensions, there was never any interpolation being done from the mid point grid to the interface grid.  Thus, the surface index was always uninitialized.  Here I have created two arrays "tke_zt" (the TKE on the midpoint grid that SHOC uses and passes back to tracer state to be advected) and "tke_zi" (TKE on the interface grid that is stored in PBUF and passed to aerosol activation).  A linear interpolation routine call is added to interpolate tke_zt to tke_zi.  

In addition, I removed an unnecessary (originally intended) ghost point index from the wthv_sec, tkh, and tk fields.  These values were never being used, but modified for code clarity purposes.