### PR TITLE
Delete saturation test against Clausius-Clapeyron

### DIFF
--- a/components/scream/src/physics/p3/p3_functions_math_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_math_impl.hpp
@@ -63,47 +63,6 @@ Functions<S,D>::qv_sat(const Spack& t_atm, const Spack& p_atm, const bool ice)
   return ep_2 * e_pres / pack::max(p_atm-e_pres, sp(1.e-3));
 }
 
-template <typename S, typename D>
-KOKKOS_FUNCTION
-typename Functions<S,D>::Spack
-Functions<S,D>::qvsat_exact(const Spack& t_atm, const Spack& p_atm, const bool ice)
-{
-  // Compute saturation mixing ratio qs analytically. 
-  // Derivation: Clausius Clapeyron says dqs/dT = L*qs/(Rv*T**2.).
-  // Taking the integral between some T0 and a particular T yields:
-  // qs(T) = qs(T0)*exp{-L/Rv*(1/T - 1/T0)}.
-  // Note that pressure dependency comes from qs(T0), which can
-  // be computed by using an experimentally-determined value for saturation 
-  // vapor pressure (es_T0) at 273.15 K and converting to qs using
-  // the exact formula qs(p) = es_T0/(pres - es_T0).
-
-  const auto tmelt = C::Tmelt;
-  const auto RV = C::RV;
-  const auto LatVap = C::LatVap;
-  const auto LatIce = C::LatIce;
-  const auto ep_2 = C::ep_2;
-  
-  Spack result;
-  Spack es_T0; //saturation vapor pressure at T=tmelt
-  Spack L; //latent heat of vaporization from liquid or ice
-
-  Smask ice_mask = (t_atm < tmelt) && ice;
-  Smask liq_mask = !ice_mask;
-
-  es_T0.set(ice_mask, sp(611.147274) );
-  es_T0.set(liq_mask, sp(611.239921) );
-
-  L.set(ice_mask, LatVap+LatIce );
-  L.set(liq_mask,LatVap);
-
-  Spack qs_T0 = ep_2 * es_T0 / pack::max(p_atm-es_T0, sp(1.e-3));
-  return qs_T0*pack::exp( -L/RV*(1/t_atm - 1/tmelt) );
-
-} // end qvsat_exact
-
-
-
-
 } // namespace p3
 } // namespace scream
 


### PR DESCRIPTION
In a previous PR, I added a test that checked whether the saturation mixing ratios our code was giving us were close to the analytic values we get from the Clausius-Clapeyron equation. Agreement was worse than I expected (only 4 decimal points or so), but I included the test anyways with a loose tolerance. I now understand that the Clausius-Clapeyron version may be analytic, but it neglects temperature dependence of latent heat of vaporization and fusion as well as surface tension and other non-ideal effects. Thus testing against Clausius-Clapeyron isn't very precise. Passing the more stringent testing against offline-calculated values from the same method as used online already provides the protection that Clausius-Clapeyron testing would provide. Thus I'm removing that Clausius-Clapeyron test.

Note that fiddling with this test was originally part of #347 , which I'm breaking into pieces because I can't figure out why that PR was failing AT on all machines but passing on both CPU and GPU LLNL machines.