### PR TITLE
fix to initialize cloud fraction for PBL height call

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -181,8 +181,9 @@ subroutine shoc_main ( &
      exner,phis, &                        ! Input
      host_dse, tke, thetal, qw, &         ! Input/Output
      u_wind, v_wind,qtracers,&            ! Input/Output
-     wthv_sec,tkh,tk,shoc_ql,&            ! Input/Output
-     shoc_cldfrac,pblh,&                  ! Output
+     wthv_sec,tkh,tk,&                    ! Input/Output
+     shoc_cldfrac,shoc_ql,&               ! Input/Output
+     pblh,&                               ! Output
      shoc_mix, isotropy,&                 ! Output (diagnostic)
      w_sec, thl_sec, qw_sec, qwthl_sec,&  ! Output (diagnostic)
      wthl_sec, wqw_sec, wtke_sec,&        ! Output (diagnostic)
@@ -261,13 +262,13 @@ subroutine shoc_main ( &
   real(rtype), intent(inout) :: tk(shcol,nlev)
   ! eddy coefficent for heat [m2/s]
   real(rtype), intent(inout) :: tkh(shcol,nlev)
+  ! Cloud fraction [-]
+  real(rtype), intent(inout) :: shoc_cldfrac(shcol,nlev)  
   ! cloud liquid mixing ratio [kg/kg]
   real(rtype), intent(inout) :: shoc_ql(shcol,nlev)
 
   ! OUTPUT VARIABLES
 
-  ! Cloud fraction [-]
-  real(rtype), intent(out) :: shoc_cldfrac(shcol,nlev)
   ! planetary boundary layer depth [m]
   real(rtype), intent(out) :: pblh(shcol)
 
@@ -1963,7 +1964,7 @@ subroutine shoc_length(&
   !   the planetary boundary layer
   conv_vel(:)=0._rtype
 
-  do k=nlev-1,1,-1
+  do k=nlev,1,-1
     do i=1,shcol
       if (zt_grid(i,k) .lt. pblh(i)) then
         conv_vel(i) = conv_vel(i)+2.5_rtype*dz_zt(i,k)*(ggr/thv(i,k))*wthv_sec(i,k)

--- a/components/cam/src/physics/cam/shoc_intr.F90
+++ b/components/cam/src/physics/cam/shoc_intr.F90
@@ -318,6 +318,7 @@ end function shoc_implements_cnst
       call pbuf_set_field(pbuf2d, fice_idx, 0.0_r8)
       call pbuf_set_field(pbuf2d, tke_idx, tke_tol)
       call pbuf_set_field(pbuf2d, alst_idx, 0.0_r8)
+      call pbuf_set_field(pbuf2d, aist_idx, 0.0_r8)
       
       call pbuf_set_field(pbuf2d, vmag_gust_idx,    1.0_r8)
       

--- a/components/cam/src/physics/cam/shoc_intr.F90
+++ b/components/cam/src/physics/cam/shoc_intr.F90
@@ -317,6 +317,7 @@ end function shoc_implements_cnst
       call pbuf_set_field(pbuf2d, tk_idx, 0.0_r8) 
       call pbuf_set_field(pbuf2d, fice_idx, 0.0_r8)
       call pbuf_set_field(pbuf2d, tke_idx, tke_tol)
+      call pbuf_set_field(pbuf2d, alst_idx, 0.0_r8)
       
       call pbuf_set_field(pbuf2d, vmag_gust_idx,    1.0_r8)
       
@@ -721,6 +722,10 @@ end function shoc_implements_cnst
        thv(i,k) = state1%t(i,k)*exner(i,k)*(1.0_r8+zvir*state1%q(i,k,ixq)-state1%q(i,k,ixcldliq)) 
  
        tke_zt(i,k) = max(tke_tol,state1%q(i,k,ixtke))
+       
+       ! Cloud fraction needs to be initialized for first 
+       !  PBL height calculation call
+       cloud_frac(i,k) = alst(i,k) 
      
      enddo
    enddo         
@@ -792,8 +797,9 @@ end function shoc_implements_cnst
 	exner(:ncol,:),state1%phis(:ncol), & ! Input
 	shoc_s(:ncol,:), tke_zt(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
 	um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
-	wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), rcm(:ncol,:), & ! Input/Output
-        cloud_frac(:ncol,:), pblh(:ncol), & ! Output
+	wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), & ! Input/Output
+	cloud_frac(:ncol,:), rcm(:ncol,:), & ! Input/Output
+        pblh(:ncol), & ! Output
         shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
         w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)   
         wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)


### PR DESCRIPTION
The PBL height is a needed input for the length scale calculation in SHOC.  An input for the PBL height routine is the cloud fraction, which was not being initialized properly for the first SHOC timestep loop since cloud fraction is diagnosed at the end of SHOC.  Thus, before shoc_main is called, the SHOC cloud fraction is initialized with the alst (stratiform liquid cloud fraction from previous timestep) field.  In addition, the PBUF alst field is initialized to zero at model initialization.  This fix ameliorates the ERP.ne4_ne4.FSCREAM-HR.cori-knl_intel COMPARE fail (SMS_D.ne4_ne4.FSCREAM-HR.cori-knl_intel still fails, however).

Unrelated to this fix, another bug was found where the convective velocity scale (in shoc_length) was being computed by integrating from the second lowest midpoint layer to PBL height.  There is no reason why it should not be integrated from the lowest midpoint layer, so this was fixed.