### PR TITLE
Remove polysvp+inexact conversion to qsat in favor of qv_sat calls

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -68,8 +68,6 @@ module micro_p3
 
   ! protected items should be treated as private for everyone except tests
 
-  real(rtype),protected :: e0
-
   real(rtype), protected, dimension(densize,rimsize,isize,tabsize) :: itab   !ice lookup table values
 
   !ice lookup table values for ice-rain collision/collection
@@ -134,12 +132,6 @@ contains
     !------------------------------------------------------------------------------------------!
 
     lookup_file_1 = trim(lookup_file_dir)//'/'//'p3_lookup_table_1.dat-v'//trim(version_p3)
-
-    !------------------------------------------------------------------------------------------!
-
-    ! saturation pressure at T = 0 C
-    e0    = polysvp1(zerodegc,0)
-
 
     !------------------------------------------------------------------------------------------!
     ! read in ice microphysics table
@@ -2336,8 +2328,8 @@ f1pr05,f1pr14,xxlv,xlf,dv,sc,mu,kap,qv,qitot_incld,nitot_incld,    &
 #endif
 
    if (qitot_incld .ge.qsmall .and. t.gt.zerodegc) then
-      qsat0 = 0.622_rtype*e0/(pres-e0)
-
+      qsat0 = qv_sat( zerodegc,pres,0 )
+      
       qimlt = ((f1pr05+f1pr14*bfb_cbrt(sc)*bfb_sqrt(rhofaci*rho/mu))*((t-   &
       zerodegc)*kap-rho*xxlv*dv*(qsat0-qv))*2._rtype*pi/xlf)*nitot_incld
 
@@ -2400,7 +2392,7 @@ qv,qc_incld,qitot_incld,nitot_incld,qr_incld,    &
 #endif
 
    if (qitot_incld.ge.qsmall .and. qc_incld+qr_incld.ge.1.e-6_rtype .and. t.lt.zerodegc) then
-      qsat0  = 0.622_rtype*e0/(pres-e0)
+      qsat0=qv_sat( zerodegc,pres,0 )
 
       qwgrth = ((f1pr05 + f1pr14*bfb_cbrt(sc)*bfb_sqrt(rhofaci*rho/mu))*       &
       2._rtype*pi*(rho*xxlv*dv*(qsat0-qv)-(t-zerodegc)*           &

--- a/components/scream/src/physics/p3/p3_functions_ice_cldliq_wet_growth_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_ice_cldliq_wet_growth_impl.hpp
@@ -32,14 +32,13 @@ void Functions<S,D>
    const auto any_if_col = any_if && qccol_qrcol_ge_small;
 
    const Spack zerodeg{tmelt};
-   const Spack e0 = polysvp1(zerodeg, zero);
    Spack qsat0{0.};
    Spack dum{0.};
    Spack dum1{0.};
 
    if (any_if.any()) {
-      qsat0 = sp(0.622)*e0/(pres-e0);
-
+     qsat0 = qv_sat( zerodeg,pres,0 );
+     
       qwgrth.set(any_if,
                 ((f1pr05+f1pr14*pack::cbrt(sc)*sqrt(rhofaci*rho/mu))*
                 twopi*(rho*xxlv*dv*(qsat0-qv)-(temp-tmelt)*kap)/

--- a/components/scream/src/physics/p3/p3_functions_ice_melting_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_ice_melting_impl.hpp
@@ -30,12 +30,8 @@ void Functions<S,D>
 
   if (has_melt_qi.any()){
 
-    //PMC qv_sat from math_impl.hpp seems to match hardcoded formula from F90 I'm swapping in C++ ver.
     //    Note that qsat0 should be with respect to liquid. Confirmed F90 code did this.
-
-    //const auto qsat0 = qv_sat(Spack(Tmelt), pres, false); //last false means NOT saturation w/ respect to ice.
-    const auto e0 = polysvp1(Spack(Tmelt), 0);
-    const auto qsat0 = 0.622 *e0/(pres-e0);
+    const auto qsat0 = qv_sat(Spack(Tmelt), pres, false); //last false means NOT saturation w/ respect to ice.
 
     qimlt.set(has_melt_qi, ( (f1pr05+f1pr14*pack::cbrt(sc)*pack::sqrt(rhofaci*rho/mu))
 			     *((t-Tmelt)*kap-rho*xxlv*dv*(qsat0-qv))


### PR DESCRIPTION
micro_p3.F90 computes saturation vapor pressure e0=polysvp1( zerodegc, pres, not_ice) because it is used 2x to compute saturation mixing ratio in the sprawl of F90 code. It used 0.622 instead of the more exact formula used by qv_sat() to convert to saturation mixing ratio and e0 ended up being computed 2x anyways in our C++ code because the places that used e0 ended up getting split into different functions. Thus it makes sense to skip polysvp1 going forward and just use the qv_sat function directly.

I tried to do this a few weeks ago via #331 but lost my nerve to integrate when p3_run_and_cmp differences were bigger than expected. This PR tries again and also gets relatively big differences for p3_run_and_cmp. This time I was very methodical in my changes, however, so I can say with confidence that the changes are entirely caused by switching 0.622 to ep_2 (which is a constant very close to 0.622). Further, the changes come almost entirely from ice_melting - the other affected funtion (ice_cldliq_wet_growth) had only O(1e-15) impact from this change. Looking over ice_melting, I'm not sure why it would be so sensitive except it involves a threshold to keep melt rate positive. Thus I'm confident this change is ok.