### PR TITLE
Removes shoc python hardcoded comparison tests

### DIFF
--- a/components/scream/src/physics/shoc/shoc_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_f90.cpp
@@ -352,23 +352,6 @@ void gen_plot_script(const std::vector<std::shared_ptr<FortranData> >& data,
 
 } // end anonymous namespace
 
-Int check_against_python(const FortranData& d)
-{
-  Int nerr = 0;
-  if (util::is_double_precision<Real>::value) {
-    const double tol = 10 * std::numeric_limits<double>::epsilon();
-    if (util::reldif<double>(d.host_dse(0, 0), 359403.8686805374) > tol)
-      ++nerr;
-    if (util::reldif<double>(d.tke(0, 0), 0.0004) > tol)
-      ++nerr;
-    if (util::reldif<double>(d.thetal(0, 0), 310.0143540856747) > tol)
-      ++nerr;
-    if (std::abs(d.shoc_cldfrac(0, 0)) > tol)
-      ++nerr;
-  }
-  return nerr;
-}
-
 int test_shoc_ic (bool use_fortran, bool gen_plot_scripts) {
   Int nz = 160;
   shoc_init(nz, use_fortran);
@@ -403,8 +386,7 @@ int test_shoc_ic (bool use_fortran, bool gen_plot_scripts) {
     }
   }
 
-  // 5. Compare the results
-  return check_against_python(*d);
+  return 0;
 }
 
 } // namespace shoc


### PR DESCRIPTION
Hardwired tests were failing due to some recent NBFB changes to SHOC. These tests were added to facilitate python to C++ driver porting. This PR removes these hardwired tests.