### PR TITLE
Reintroduce PBUF variable in P3 needed for prognostic aerosols

### DIFF
--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -70,6 +70,7 @@ module micro_p3_interface
       prain_idx,          &
       nevapr_idx,         &
       dei_idx,            &
+      rate1_cw2pr_st_idx, &
       mu_idx,             &
       lambdac_idx,        &
       rei_idx,            &

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -194,7 +194,11 @@ end subroutine micro_p3_readnl
 
   subroutine micro_p3_register()
 
+  logical :: prog_modal_aero ! prognostic aerosols
+
   if (masterproc) write(iulog,'(A20)') ' P3 register start ...'
+
+  call phys_getopts( prog_modal_aero_out   = prog_modal_aero )
 
    ncnst = 0
     ! Register Microphysics Constituents 
@@ -243,6 +247,11 @@ end subroutine micro_p3_readnl
    call pbuf_add_field('QME',  'physpkg',dtype_r8,(/pcols,pver/), qme_idx)
    call pbuf_add_field('PRAIN','physpkg',dtype_r8,(/pcols,pver/), prain_idx)
    call pbuf_add_field('NEVAPR','physpkg',dtype_r8,(/pcols,pver/), nevapr_idx)
+
+   !! module aero_model
+   if (prog_modal_aero) then
+      call pbuf_add_field('RATE1_CW2PR_ST','physpkg',dtype_r8,(/pcols,pver/),rate1_cw2pr_st_idx)
+   endif
 
    !! module clubb_intr
    call pbuf_add_field('PRER_EVAP',  'global', dtype_r8,(/pcols,pver/), prer_evap_idx)


### PR DESCRIPTION
This commit reintroduces a variable to PBUF that is required when running with prognostic aerosols.  It shouldn't impact standard SCREAM simulations which don't use prognostic aerosols, but will allow certain SCM cases which do, to be run.

The PBUF variable was removed in a recent PR that cleaned up the P3 interface.