### PR TITLE
Adjust micrphysics substeps for FSCREAM-HR compset on ne4 mesh.

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
@@ -66,6 +66,7 @@
 
 <!-- Macrophysics/microphysics coupling -->
 <cld_macmic_num_steps    > 6</cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne4np4"   > 24</cld_macmic_num_steps>
 
 <!-- SHOC timestep -->
 <shoc_timestep>20</shoc_timestep>


### PR DESCRIPTION
This commit addresses the current failures for the FSCREAM-HR
compset running the SMS_D testcase.

It effectively reduces the timestep for P3 microphysics by increasing
the number of substeps per physics timestep from 6 to 24.