### PR TITLE
SHOC second moment refactor cleanup

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -944,10 +944,10 @@ subroutine diag_second_shoc_moments_lbycond(&
   ! Purpose of this subroutine is to diagnose the lower
   !  boundary condition for the second order moments needed 
   !  for the SHOC parameterization.  
-  ! The thermodymnamic, tracer, and momentum fluxes are set to the 
-  !  surface fluxes for the host model, while the thermodynamic
-  !  variances and covariances are computed according to that
-  !  of Andre et al. 1978.  
+  ! The thermodymnamic, tracer, and momentum fluxes are set 
+  !  to the surface fluxes for the host model, while the
+  !  thermodynamic variances and covariances are computed
+  !  according to that of Andre et al. 1978.  
 
   implicit none
 
@@ -1083,7 +1083,7 @@ subroutine diag_second_shoc_moments(&
          thl_sec,qw_sec,wthl_sec,wqw_sec,&      ! Input/Output
          qwthl_sec, uw_sec, vw_sec, wtke_sec, & ! Input/Output
          wtracer_sec,&                          ! Input/Output
-	 w_sec)                                 ! Output
+         w_sec)                                 ! Output
 	 
   ! Purpose of this subroutine is to diagnose the second
   !  order moments needed for the SHOC parameterization.
@@ -1133,23 +1133,23 @@ subroutine diag_second_shoc_moments(&
   
 ! INPUT/OUTPUT VARIABLES  
   ! second order liquid wat. potential temp. [K^2]
-  real(rtype), intent(out) :: thl_sec(shcol,nlevi)
+  real(rtype), intent(inout) :: thl_sec(shcol,nlevi)
   ! second order total water mixing rat. [kg^2/kg^2]
-  real(rtype), intent(out) :: qw_sec(shcol,nlevi)
+  real(rtype), intent(inout) :: qw_sec(shcol,nlevi)
   ! covariance of temp and moisture [K kg/kg]
-  real(rtype), intent(out) :: qwthl_sec(shcol,nlevi)
+  real(rtype), intent(inout) :: qwthl_sec(shcol,nlevi)
   ! vertical flux of heat [K m/s]
-  real(rtype), intent(out) :: wthl_sec(shcol,nlevi)
+  real(rtype), intent(inout) :: wthl_sec(shcol,nlevi)
   ! vertical flux of total water [kg/kg m/s]
-  real(rtype), intent(out) :: wqw_sec(shcol,nlevi)
+  real(rtype), intent(inout) :: wqw_sec(shcol,nlevi)
   ! vertical flux of zonal wind [m2/s2]
-  real(rtype), intent(out) :: uw_sec(shcol,nlevi)
+  real(rtype), intent(inout) :: uw_sec(shcol,nlevi)
   ! vertical flux of meridional wind [m2/s2]
-  real(rtype), intent(out) :: vw_sec(shcol,nlevi)
+  real(rtype), intent(inout) :: vw_sec(shcol,nlevi)
   ! vertical flux of tke [m3/s3]
-  real(rtype), intent(out) :: wtke_sec(shcol,nlevi)
+  real(rtype), intent(inout) :: wtke_sec(shcol,nlevi)
   ! vertical flux of tracer [varies m/s]
-  real(rtype), intent(out) :: wtracer_sec(shcol,nlevi,num_tracer)
+  real(rtype), intent(inout) :: wtracer_sec(shcol,nlevi,num_tracer)
 
 ! OUTPUT VARIABLES
   ! second order vertical velocity [m2/s2]
@@ -1231,10 +1231,13 @@ subroutine diag_second_shoc_moments_ubycond(&
          wtracer_sec)                           ! Input/Output
 	 
   ! Purpose of this subroutine is to diagnose the upper
-  !  boundary condition for the second order moments needed 
-  !  for the SHOC parameterization.  Currently set all to zero 	 
+  !  boundary condition for the second order moments 
+  !  needed for the SHOC parameterization.  Currently
+  !  set all to zero. 	 
 	 
   implicit none
+  
+  ! INPUT VARIABLES
   ! number of SHOC columns
   integer, intent(in) :: shcol
   ! number of interface levels
@@ -1242,7 +1245,7 @@ subroutine diag_second_shoc_moments_ubycond(&
   ! number of tracers
   integer, intent(in) :: num_tracer
 
-  ! OUTPUT VARIABLES
+  ! INPUT/OUTPUT VARIABLES
   ! second order liquid wat. potential temp. [K^2]
   real(rtype), intent(inout) :: thl_sec(shcol,nlevi)
   ! second order total water mixing rat. [kg^2/kg^2]

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -403,38 +403,40 @@ subroutine shoc_main ( &
          u_wind,v_wind)                     ! Input/Output
     endif
 
-    ! Diagnose the second order moments, needed
-    !  for the PDF closure
-    call diag_second_shoc_moments(&
+    ! Diagnose the second order moments, 
+    !  calculate surface boundary conditions
+    call diag_second_shoc_moments_lbycond(&
        shcol,nlev,nlevi,&                   ! Input
        num_qtracers,thetal,qw,&             ! Input
-       u_wind,v_wind,qtracers,tke,&         ! Input
+       u_wind,v_wind,qtracers,&             ! Input
        isotropy,tkh,tk,&                    ! Input
        dz_zi,zt_grid,zi_grid,&              ! Input
        wthl_sfc,wqw_sfc,uw_sfc,vw_sfc,&     ! Input
        wtracer_sfc,shoc_mix,&               ! Input
-       w_sec,thl_sec,qw_sec,&               ! Output
-       wthl_sec,wqw_sec,&                   ! Output
+       thl_sec,qw_sec,wthl_sec,wqw_sec,&    ! Output
        qwthl_sec,uw_sec,vw_sec,wtke_sec,&   ! Output
-       wtracer_sec)
+       wtracer_sec)                         ! Output
 
-    call calc_second_shock_moments(&
-         shcol,nlev,nlevi, &                    ! Input
-         num_qtracers,thetal,qw, &              ! Input
-         u_wind,v_wind,qtracers,tke, &          ! Input
-         isotropy,tkh,tk,&                      ! Input
-         dz_zi,zt_grid,zi_grid,shoc_mix, &      ! Input
-         w_sec, thl_sec, qw_sec,&               ! Output
-         wthl_sec,wqw_sec,&                     ! Output
-         qwthl_sec, uw_sec, vw_sec, wtke_sec, & ! Output
-         wtracer_sec)                           ! Output
+    ! Diagnose the second order moments
+    call diag_second_shoc_moments(&
+       shcol,nlev,nlevi, &                    ! Input
+       num_qtracers,thetal,qw, &              ! Input
+       u_wind,v_wind,qtracers,tke, &          ! Input
+       isotropy,tkh,tk,&                      ! Input
+       dz_zi,zt_grid,zi_grid,shoc_mix, &      ! Input
+       thl_sec, qw_sec,wthl_sec,wqw_sec,&     ! Input/Output
+       qwthl_sec, uw_sec, vw_sec, wtke_sec, & ! Input/Output
+       wtracer_sec,&                          ! Input/Output
+       w_sec)                                 ! Output
 
-    call apply_second_shoc_moments_bdycond(&
-         shcol,nlevi,num_qtracers, &            ! Input
-         thl_sec, qw_sec,&                      ! InOutput
-         wthl_sec,wqw_sec,&                     ! InOutput
-         qwthl_sec, uw_sec, vw_sec, wtke_sec, & ! InOutput
-         wtracer_sec)       
+    ! Diagnose the second order moments,
+    !  calculate the upper boundary conditions
+    call diag_second_shoc_moments_ubycond(&
+       shcol,nlevi,num_qtracers, &            ! Input
+       thl_sec, qw_sec,&                      ! Input/Output
+       wthl_sec,wqw_sec,&                     ! Input/Output
+       qwthl_sec, uw_sec, vw_sec, wtke_sec, & ! Input/Output
+       wtracer_sec)                           ! Input/Output
 
     ! Diagnose the third moment of vertical velocity,
     !  needed for the PDF closure
@@ -924,27 +926,28 @@ subroutine update_prognostics_implicit( &
 end subroutine update_prognostics_implicit
 
 !==============================================================
-! SHOC Diagnose the second order moments
+! SHOC Diagnose the second order moments, 
+!  lower boundary conditions
 
-subroutine diag_second_shoc_moments(&
+subroutine diag_second_shoc_moments_lbycond(&
          shcol,nlev,nlevi, &                    ! Input
          num_tracer,thetal,qw, &                ! Input
-         u_wind,v_wind,tracer,tke, &            ! Input
+         u_wind,v_wind,tracer, &                ! Input
          isotropy,tkh,tk,&                      ! Input
          dz_zi,zt_grid,zi_grid,&                ! Input
          wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, &   ! Input
          wtracer_sfc,shoc_mix, &                ! Input
-         w_sec, thl_sec, qw_sec,&               ! Output
-         wthl_sec,wqw_sec,&                     ! Output
+         thl_sec,qw_sec,wthl_sec,wqw_sec,&      ! Output
          qwthl_sec, uw_sec, vw_sec, wtke_sec, & ! Output
          wtracer_sec)                           ! Output
 
-  ! Purpose of this subroutine is to diagnose the second
-  !  order moments needed for the SHOC parameterization.
-  !  Namely these are variances of thetal, qw, and vertical
-  !  velocity.  In addition the vertical fluxes of thetal, qw,
-  !  u, v, TKE, and tracers are computed here as well as the
-  !  correlation of qw and thetal.
+  ! Purpose of this subroutine is to diagnose the lower
+  !  boundary condition for the second order moments needed 
+  !  for the SHOC parameterization.  
+  ! The thermodymnamic, tracer, and momentum fluxes are set to the 
+  !  surface fluxes for the host model, while the thermodynamic
+  !  variances and covariances are computed according to that
+  !  of Andre et al. 1978.  
 
   implicit none
 
@@ -966,8 +969,6 @@ subroutine diag_second_shoc_moments(&
   real(rtype), intent(in) :: u_wind(shcol,nlev)
   ! meridional wind component [m/s]
   real(rtype), intent(in) :: v_wind(shcol,nlev)
-  ! turbulent kinetic energy [m2/s2]
-  real(rtype), intent(in) :: tke(shcol,nlev)
   ! return to isotropy timescale [s]
   real(rtype), intent(in) :: isotropy(shcol,nlev)
   ! eddy coefficient for heat [m2/s]
@@ -997,8 +998,6 @@ subroutine diag_second_shoc_moments(&
   real(rtype), intent(in) :: shoc_mix(shcol,nlev)
 
 ! OUTPUT VARIABLES
-  ! second order vertical velocity [m2/s2]
-  real(rtype), intent(out) :: w_sec(shcol,nlev)
   ! second order liquid wat. potential temp. [K^2]
   real(rtype), intent(out) :: thl_sec(shcol,nlevi)
   ! second order total water mixing rat. [kg^2/kg^2]
@@ -1040,10 +1039,6 @@ subroutine diag_second_shoc_moments(&
   call linear_interp(zt_grid,zi_grid,tk,tk_zi,nlev,nlevi,shcol,0._rtype)
   call linear_interp(zt_grid,zi_grid,shoc_mix,shoc_mix_zi,nlev,nlevi,shcol,minlen)
 
-  ! Vertical velocity variance is assumed to be propotional
-  !  to the TKE
-  w_sec = w2tune*(2._rtype/3._rtype)*tke
-
   ! apply the surface conditions to diagnose turbulent
   !  moments at the surface
   do i=1,shcol
@@ -1077,19 +1072,29 @@ subroutine diag_second_shoc_moments(&
 
   enddo ! end i loop (column loop)
   return
-end subroutine diag_second_shoc_moments
+end subroutine diag_second_shoc_moments_lbycond
 
-subroutine calc_second_shock_moments(&
+subroutine diag_second_shoc_moments(&
          shcol,nlev,nlevi, &                    ! Input
          num_tracer,thetal,qw, &                ! Input
          u_wind,v_wind,tracer,tke, &            ! Input
          isotropy,tkh,tk,&                      ! Input
          dz_zi,zt_grid,zi_grid,shoc_mix, &      ! Input
-         w_sec, thl_sec, qw_sec,&               ! Output
-         wthl_sec,wqw_sec,&                     ! Output
-         qwthl_sec, uw_sec, vw_sec, wtke_sec, & ! Output
-         wtracer_sec)                           ! Output
+         thl_sec,qw_sec,wthl_sec,wqw_sec,&      ! Input/Output
+         qwthl_sec, uw_sec, vw_sec, wtke_sec, & ! Input/Output
+         wtracer_sec,&                          ! Input/Output
+	 w_sec)                                 ! Output
+	 
+  ! Purpose of this subroutine is to diagnose the second
+  !  order moments needed for the SHOC parameterization.
+  !  Namely these are variances of thetal, qw, and vertical
+  !  velocity.  In addition the vertical fluxes of thetal, qw,
+  !  u, v, TKE, and tracers are computed here as well as the
+  !  correlation of qw and thetal.	 
+	 
   implicit none
+
+! INPUT VARIABLES
   ! number of SHOC columns
   integer, intent(in) :: shcol
   ! number of midpoint levels
@@ -1125,10 +1130,8 @@ subroutine calc_second_shock_moments(&
   real(rtype), intent(in) :: dz_zi(shcol,nlevi)
   ! Mixing length [m]
   real(rtype), intent(in) :: shoc_mix(shcol,nlev)
-
-! OUTPUT VARIABLES
-  ! second order vertical velocity [m2/s2]
-  real(rtype), intent(out) :: w_sec(shcol,nlev)
+  
+! INPUT/OUTPUT VARIABLES  
   ! second order liquid wat. potential temp. [K^2]
   real(rtype), intent(out) :: thl_sec(shcol,nlevi)
   ! second order total water mixing rat. [kg^2/kg^2]
@@ -1147,6 +1150,10 @@ subroutine calc_second_shock_moments(&
   real(rtype), intent(out) :: wtke_sec(shcol,nlevi)
   ! vertical flux of tracer [varies m/s]
   real(rtype), intent(out) :: wtracer_sec(shcol,nlevi,num_tracer)
+
+! OUTPUT VARIABLES
+  ! second order vertical velocity [m2/s2]
+  real(rtype), intent(out) :: w_sec(shcol,nlev)
 
   ! LOCAL VARIABLES
   integer :: kb, kt, k, i, p
@@ -1214,14 +1221,19 @@ subroutine calc_second_shock_moments(&
     enddo ! end i loop (column loop)
   enddo  ! end k loop (vertical loop)
   return
-end subroutine calc_second_shock_moments
+end subroutine diag_second_shoc_moments
 
-subroutine apply_second_shoc_moments_bdycond(&
+subroutine diag_second_shoc_moments_ubycond(&
          shcol,nlevi,num_tracer, &              ! Input
-         thl_sec, qw_sec,&                      ! InOutput
-         wthl_sec,wqw_sec,&                     ! InOutput
-         qwthl_sec, uw_sec, vw_sec, wtke_sec, & ! InOutput
-         wtracer_sec)                           ! InOutput
+         thl_sec, qw_sec,&                      ! Input/Output
+         wthl_sec,wqw_sec,&                     ! Input/Output
+         qwthl_sec, uw_sec, vw_sec, wtke_sec, & ! Input/Output
+         wtracer_sec)                           ! Input/Output
+	 
+  ! Purpose of this subroutine is to diagnose the upper
+  !  boundary condition for the second order moments needed 
+  !  for the SHOC parameterization.  Currently set all to zero 	 
+	 
   implicit none
   ! number of SHOC columns
   integer, intent(in) :: shcol
@@ -1267,7 +1279,7 @@ subroutine apply_second_shoc_moments_bdycond(&
     qwthl_sec(i,1) = 0._rtype
   enddo ! end i loop (column loop)
   return
-end subroutine apply_second_shoc_moments_bdycond
+end subroutine diag_second_shoc_moments_ubycond
 
 !==============================================================
 ! SHOC Diagnose the third order moment of vertical velocity


### PR DESCRIPTION
This PR serves as a clean up for the refactor of the SHOC second order moments PR #374 .  Specifically:

1) Comments are updated to describe what each routine does.
2) The name of each routine is updated to be more consistent/descriptive (i.e. lower boundary condition and upper boundary condition routines).
3) Remove the duplicative computation of w_sec in the lower boundary condition routine.  
4) Fixes intent in/inout/out issues to make them more consistent.  