### PR TITLE
Fix for unset isotropy term for stable PBL

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1931,7 +1931,6 @@ subroutine shoc_tke(&
   real(rtype) :: lambda_low,lambda_high,lambda_slope, brunt_low
   real(rtype) :: brunt_int(shcol), z_over_L
   real(rtype) :: zL_crit_val, pbl_trans
-  logical :: do_stable
   integer i,j,k,kc,kb,kt
 
   lambda_low=0.001_rtype
@@ -2048,9 +2047,8 @@ subroutine shoc_tke(&
         tkh(i,k)=Ckh_s*(shoc_mix(i,k)**2)*sqrt(sterm_zt(i,k))
         tk(i,k)=Ckm_s*(shoc_mix(i,k)**2)*sqrt(sterm_zt(i,k))
       else
-	! Default definition of eddy diffusivity  
+        ! Default definition of eddy diffusivity for heat and momentum  
       
-        ! Define the eddy coefficients for heat and momentum
         tkh(i,k)=Ckh*isotropy(i,k)*tke(i,k)
         tk(i,k)=Ckm*isotropy(i,k)*tke(i,k)
       endif


### PR DESCRIPTION
Fix where the isotropy term was not being computed when the criteria for stable PBL is met.  While the isotropy term is not needed for the diffusivity terms for the stable PBL, this term is needed in other parts of the SHOC code and should be updated regardless.  

Answers are not b4b for global runs and SCM runs where the stable PBL is present (i.e. ARM97, GABLS) but differences are scientifically indistinguishable in these instances.  Answers are b4b for SCM cases where the stable boundary layer is not present (i.e. BOMEX, DYCOMS, etc.).

Also note that another bug was found where tk_zi was still present in the code and not being set (though never used in any calculation).   