### PR TITLE
Minor mods to test-all-scream

### DIFF
--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -83,7 +83,7 @@ class TestAllScream(object):
                     self._baseline_ref = "HEAD"
                 elif self._integration_test:
                     self._baseline_ref = "origin/master"
-                    merge_git_ref(git_ref="origin/master")
+                    merge_git_ref(git_ref="origin/master",verbose=True)
                 else:
                     self._baseline_ref = get_common_ancestor("origin/master")
                     # Prefer a symbolic ref if possible
@@ -99,7 +99,7 @@ class TestAllScream(object):
                 expect(test_baseline_dir.is_dir(), "Missing baseline {}".format(test_baseline_dir))
 
             if self._integration_test:
-                merge_git_ref(git_ref="origin/master")
+                merge_git_ref(git_ref="origin/master",verbose=True)
 
         # Deduce how many resources per test
         proc_count = 4

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -71,7 +71,7 @@ class TestAllScream(object):
         if self._submit:
             expect(self._machine, "If dashboard submit request, must provide machine name")
 
-        print_last_commit(git_ref="HEAD")
+        print_last_commit(git_ref=self._original_branch)
 
         # Compute baseline info
         expect(not (self._baseline_ref and self._baseline_dir),

--- a/components/scream/scripts/utils.py
+++ b/components/scream/scripts/utils.py
@@ -291,28 +291,13 @@ def get_current_branch(repo=None):
 ###############################################################################
     """
     Return the name of the current branch for a repository
-
-    >>> if "GIT_BRANCH" in os.environ:
-    ...     get_current_branch() is not None
-    ... else:
-    ...     os.environ["GIT_BRANCH"] = "foo"
-    ...     get_current_branch() == "foo"
-    True
+    If in detached HEAD state, returns None
     """
-    if ("GIT_BRANCH" in os.environ):
-        # This approach works better for Jenkins jobs because the Jenkins
-        # git plugin does not use local tracking branches, it just checks out
-        # to a commit
-        branch = os.environ["GIT_BRANCH"]
-        if (branch.startswith("origin/")):
-            branch = branch.replace("origin/", "", 1)
-        return branch
-    else:
-        stat, output, _ = run_cmd("git symbolic-ref HEAD", from_dir=repo)
-        if (stat != 0):
-            return None
-        else:
-            return output.replace("refs/heads/", "")
+
+    stat, output, err = run_cmd("git rev-parse --abbrev-ref HEAD", from_dir=repo)
+    expect (stat==0, "Error! The command 'git rev-parse --abbrev-ref HEAD' failed with error: {}".format(err))
+
+    return None if output=="HEAD" else output
 
 ###############################################################################
 def get_current_commit(short=False, repo=None, tag=False, commit=None):

--- a/components/scream/scripts/utils.py
+++ b/components/scream/scripts/utils.py
@@ -363,6 +363,15 @@ def merge_git_ref(git_ref, repo=None, verbose=False):
     """
     Merge given git ref into the current branch, and updates submodules
     """
+
+    # Even thoguh it can allow some extra corner cases (dirty repo, but ahead of git_ref),
+    # this check is mostly for debugging purposes, as it will inform that no merge occurred
+    out = get_common_ancestor(git_ref)
+    if out==get_current_commit(commit=git_ref):
+        if verbose:
+            print ("Merge of '{}' not necessary. Current HEAD is already ahead.".format(git_ref))
+        return
+
     expect(is_repo_clean(repo=repo), "Cannot merge ref '{}'. The repo is not clean.".format(git_ref))
     run_cmd_no_fail("git merge {} -m 'Automatic merge of {}'".format(git_ref,git_ref), from_dir=repo)
     update_submodules(repo=repo)

--- a/components/scream/scripts/utils.py
+++ b/components/scream/scripts/utils.py
@@ -358,7 +358,7 @@ def update_submodules(repo=None):
     run_cmd_no_fail("git submodule update --init --recursive", from_dir=repo)
 
 ###############################################################################
-def merge_git_ref(git_ref, repo=None):
+def merge_git_ref(git_ref, repo=None, verbose=False):
 ###############################################################################
     """
     Merge given git ref into the current branch, and updates submodules
@@ -367,6 +367,9 @@ def merge_git_ref(git_ref, repo=None):
     run_cmd_no_fail("git merge {} -m 'Automatic merge of {}'".format(git_ref,git_ref), from_dir=repo)
     update_submodules(repo=repo)
     expect(is_repo_clean(repo=repo), "Something went wrong while performing the merge of '{}'".format(git_ref))
+    if verbose:
+        print ("merged {} successfully merged.".format(git_ref))
+        print_last_commit()
 
 ###############################################################################
 def print_last_commit(git_ref=None, repo=None):


### PR DESCRIPTION
Mainly, avoid relying on GIT_BRANCH on jenkins. If in detached HEAD state, better avoid thinking that a branch exists. This may be ok with recent git versions, but it can generates errors with old git versions.

Namely, doing `git checkout branch_name` when branch_name only exists on a remote, may not work with some old git versions, and generate an error because branch_name is not a valid ref.