### PR TITLE
SCREAM: Wiping CMakeCache.txt and CMakeFiles before running tests

### DIFF
--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -1,4 +1,4 @@
-from utils import run_cmd, check_minimum_python_version, get_current_head,     \
+from utils import run_cmd, run_cmd_no_fail, check_minimum_python_version, get_current_head,     \
     get_current_commit, get_current_branch, expect, is_repo_clean, cleanup_repo,  \
     get_common_ancestor, merge_git_ref, checkout_git_ref, print_last_commit
 
@@ -306,6 +306,11 @@ class TestAllScream(object):
         test_dir = self.get_test_dir(test)
         cmake_config = self.generate_cmake_config(self._tests_cmake_args[test], for_ctest=True)
         ctest_config = self.generate_ctest_config(cmake_config, [], test)
+
+        # This directory might have been used also to build the model to generate baselines.
+        # Although it's ok to build in the same dir, we MUST make sure to erase cmake's cache
+        # and internal files from the previous build (CMakeCache.txt and CMakeFiles folder)
+        run_cmd_no_fail("rm -rf CMake*", from_dir=test_dir)
 
         success = run_cmd(ctest_config, from_dir=test_dir, arg_stdout=None, arg_stderr=None, verbose=True, dry_run=self._dry_run)[0] == 0
 


### PR DESCRIPTION
This is important! If the baselines build and the branch build happen in
the same folder, we need to make sure we are not accidentally polluting
the branch build with cmake remnants from the baseline build.

This issue has been exposed by #378 , which kept failing only on GPU, despite tests passing when I manually did a configure-build-test, using a pre-existing baseline directory.

Medium-Short explanation: on 2/20/20 we decided to stop wiping out the bin dir where baselines are generated (maybe we wanted to save compilation time?). However, we SHOULD have still wiped cmake's cache (and maybe even config files). Instead we left them there. In our cmake logic, we reset some cache vars. When calling run_tests, this can cause  cmake to say something like

```
-- Configuring done
You have changed variables that require your cache to be deleted.
Configure will be re-run and you may have to reset some variables.
```
The big problem is that some variables are set not correctly in the second run. For instance, I see this:

```
-- ****************** Kokkos Settings ******************
-- Execution Spaces
--   Device Parallel: None
--     Host Parallel: None
--       Host Serial: Serial
--
-- Architectures:
--     None
--
-- Enabled options
--   KOKKOS_ENABLE_SERIAL
--   KOKKOS_ENABLE_LIBRT
--   KOKKOS_ENABLE_PROFILING
--   KOKKOS_ENABLE_DEPRECATED_CODE
```
NO CUDA ANYMORE!