### PR TITLE
Testing: separating compilation and testing parallel levels

### DIFF
--- a/components/scream/scripts/gather-all-data
+++ b/components/scream/scripts/gather-all-data
@@ -27,7 +27,7 @@ check_minimum_python_version(3, 5)
 
 import argparse, sys, pathlib
 
-from gather_all_data import GatherAllData, MACHINE_METADATA
+from gather_all_data import GatherAllData
 from machines_specs import MACHINE_METADATA
 
 ###############################################################################

--- a/components/scream/scripts/gather-all-data
+++ b/components/scream/scripts/gather-all-data
@@ -28,6 +28,7 @@ check_minimum_python_version(3, 5)
 import argparse, sys, pathlib
 
 from gather_all_data import GatherAllData, MACHINE_METADATA
+from machines_specs import MACHINE_METADATA
 
 ###############################################################################
 def parse_command_line(args, description):

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -2,7 +2,7 @@ from utils import run_cmd_no_fail
 
 import os, pathlib
 import concurrent.futures as threading3
-from machine_specs import get_mach_env_setup_command, get_mach_cxx_compiler, get_mach_batch_command, get_mach_testing_resources
+from machines_specs import get_mach_env_setup_command, get_mach_cxx_compiler, get_mach_batch_command, get_mach_testing_resources
 
 ###############################################################################
 class GatherAllData(object):

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -27,7 +27,7 @@ class GatherAllData(object):
         compiler  = get_mach_cxx_compiler(machine)
         batch     = get_mach_batch_command(machine)
 
-        env_setup_str = " && ".join(env_setup) + "CTEST_PARALLEL_LEVEL={}".format(get_mach_testing_resources(machine))
+        env_setup_str = " && ".join(env_setup) + " CTEST_PARALLEL_LEVEL={}".format(get_mach_testing_resources(machine))
 
         root_dir = pathlib.Path(str(self._root_dir).replace("$machine", machine))
 

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -2,7 +2,7 @@ from utils import run_cmd_no_fail
 
 import os, pathlib
 import concurrent.futures as threading3
-from machine_specs import get_mach_env, get_mach_cxx_compiler, get_mach_batch_command, get_mach_testing_resources
+from machine_specs import get_mach_env_setup_command, get_mach_cxx_compiler, get_mach_batch_command, get_mach_testing_resources
 
 ###############################################################################
 class GatherAllData(object):
@@ -23,7 +23,7 @@ class GatherAllData(object):
     ###########################################################################
     def formulate_command(self, machine):
     ###########################################################################
-        env_setup = get_mach_env(machine)
+        env_setup = get_mach_env_setup_command(machine)
         compiler  = get_mach_cxx_compiler(machine)
         batch     = get_mach_batch_command(machine)
 

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -2,40 +2,7 @@ from utils import run_cmd_no_fail
 
 import os, pathlib
 import concurrent.futures as threading3
-
-# MACHINE -> (env_setup, compiler, batch submit prefix)
-MACHINE_METADATA = {
-    "melvin"   : (["module purge", "module load sems-env", "module load sems-gcc/7.3.0 sems-openmpi/1.10.1 sems-gcc/7.3.0 sems-git/2.10.1 sems-cmake/3.12.2 sems-python/3.5.2", "export CTEST_PARALLEL_LEVEL=24"],
-                  "$(which mpicxx)",
-                  ""),
-    "bowman"   : (["module purge", "module load openmpi/1.10.6/intel/17.2.174 git/2.8.2 cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-bowman/bin:$PATH", "export CTEST_PARALLEL_LEVEL=68"],
-                  "$(which mpicxx)",
-                  "srun"),
-    "blake"    : (["module purge", "module load openmpi/2.1.5/intel/19.1.144 git/2.9.4 cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-blake/bin:$PATH", "export CTEST_PARALLEL_LEVEL=48"],
-                  "$(which mpicxx)",
-                  "srun"),
-    "waterman" : (["module purge", "module load devpack/latest/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88 git/2.10.1", "module switch cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-waterman/bin:$PATH"],
-                  "$(which mpicxx)",
-                  "bsub -I -q rhel7W"),
-    "white"    : (["module purge", "module load devpack/20181011/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88 git/2.10.1 cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-white/bin:$PATH"],
-                  "$(which mpicxx)",
-                  "bsub -I -q rhel7G"),
-    "lassen" : (["module purge", "module load git gcc/7.3.1 cuda/10.1.243 cmake/3.14.5 spectrum-mpi netcdf/4.7.0 python/3.7.2", "export LLNL_USE_OMPI_VARS='y'"],
-                  "$(which mpicxx)",
-                  "bsub -Ip"),
-    "quartz" : (["module purge", "module load StdEnv cmake/3.14.5 mkl/2019.0 intel/19.0.4 netcdf-fortran/4.4.4 netcdf/4.4.1.1"],
-                  "$(which mpicxx)",
-                  "salloc --partition=pdebug"),
-    "syrah"  : (["module purge", "module load StdEnv cmake/3.14.5 mkl/2019.0 intel/19.0.4 netcdf-fortran/4.4.4 netcdf/4.4.1.1"],
-                  "$(which mpicxx)",
-                  "salloc --partition=pdebug"),
-    "summit" : (["module purge", "module load cmake/3.15.2 gcc/6.4.0 spectrum-mpi/10.3.0.1-20190611 cuda/10.1.168 python/3.6.6-anaconda3-5.3.0"],
-                "$(which mpicxx)",
-                "bsub -I -q batch -W 0:30 -P cli115 -nnodes 1"),
-    "cori"   : (["eval $(../../cime/scripts/Tools/get_case_env)", "export CTEST_PARALLEL_LEVEL=68", "export OMP_NUM_THREADS=68"],
-                "$(which CC)",
-                "srun --time 02:00:00 --nodes=1 --constraint=knl,quad,cache --exclusive -q regular --account e3sm"),
-}
+from machine_specs import get_mach_env, get_mach_cxx_compiler, get_mach_batch_command, get_mach_testing_resources
 
 ###############################################################################
 class GatherAllData(object):
@@ -56,8 +23,11 @@ class GatherAllData(object):
     ###########################################################################
     def formulate_command(self, machine):
     ###########################################################################
-        env_setup, compiler, batch = MACHINE_METADATA[machine]
-        env_setup_str = " && ".join(env_setup)
+        env_setup = get_mach_env(machine)
+        compiler  = get_mach_cxx_compiler(machine)
+        batch     = get_mach_batch_command(machine)
+
+        env_setup_str = " && ".join(env_setup) + "CTEST_PARALLEL_LEVEL={}".format(get_mach_testing_resources(machine))
 
         root_dir = pathlib.Path(str(self._root_dir).replace("$machine", machine))
 

--- a/components/scream/scripts/jenkins/jenkins_common.sh
+++ b/components/scream/scripts/jenkins/jenkins_common.sh
@@ -27,7 +27,8 @@ if [ $skip_testing -eq 0 ]; then
       SUBMIT="" # We don't submit AT runs
   fi
 
-  ./scream/components/scream/scripts/gather-all-data "./scripts/test-all-scream \$compiler -p -i -m \$machine $SUBMIT" -l -m $SCREAM_MACHINE
+  cd scream/components/scream
+  ./scripts/test-all-scream -p -i -m $SCREAM_MACHINE mpicxx
 else
   echo "Tests were skipped, since the Github label 'CI: Integrate Without Testing' was found.\n"
 fi

--- a/components/scream/scripts/jenkins/jenkins_common.sh
+++ b/components/scream/scripts/jenkins/jenkins_common.sh
@@ -27,8 +27,7 @@ if [ $skip_testing -eq 0 ]; then
       SUBMIT="" # We don't submit AT runs
   fi
 
-  cd scream/components/scream
-  ./scripts/test-all-scream -p -i -m $SCREAM_MACHINE mpicxx
+  ./scream/components/scream/scripts/gather-all-data "./scripts/test-all-scream \$compiler -p -i -m \$machine $SUBMIT" -l -m $SCREAM_MACHINE
 else
   echo "Tests were skipped, since the Github label 'CI: Integrate Without Testing' was found.\n"
 fi

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -1,0 +1,110 @@
+# MACHINE -> (env_setup, compiler, batch submit prefix, num host cores, num devices)
+
+# Note: the numbef of host cores is used to parallelize compilation,
+#       while the number of devices is used to parallelize testing.
+#       On CPU machines, the two will usually coincide, while on GPU
+#       machines they are going to be different (compile on CPU, run on GPU).
+
+from utils import expect, get_cpu_core_count
+
+MACHINE_METADATA = {
+    "melvin"   : (["module purge", "module load sems-env", "module load sems-gcc/7.3.0 sems-openmpi/1.10.1 sems-gcc/7.3.0 sems-git/2.10.1 sems-cmake/3.12.2 sems-python/3.5.2"],
+                  "$(which mpicxx)",
+                  "",
+                  24,
+                  24),
+    "bowman"   : (["module purge", "module load openmpi/1.10.6/intel/17.2.174 git/2.8.2 cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-bowman/bin:$PATH"],
+                  "$(which mpicxx)",
+                  "srun",
+                  68,
+                  68),
+    "blake"    : (["module purge", "module load openmpi/2.1.5/intel/19.1.144 git/2.9.4 cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-blake/bin:$PATH"],
+                  "$(which mpicxx)",
+                  "srun",
+                  48,
+                  48),
+    "waterman" : (["module purge", "module load devpack/latest/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88 git/2.10.1", "module switch cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-waterman/bin:$PATH"],
+                  "$(which mpicxx)",
+                  "bsub -I -q rhel7W",
+                  80,
+                  4),
+    "white"    : (["module purge", "module load devpack/20181011/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88 git/2.10.1 cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-white/bin:$PATH"],
+                  "$(which mpicxx)",
+                  "bsub -I -q rhel7G",
+                  64,
+                  4),
+    "lassen" : (["module purge", "module load git gcc/7.3.1 cuda/10.1.243 cmake/3.14.5 spectrum-mpi netcdf/4.7.0 python/3.7.2", "export LLNL_USE_OMPI_VARS='y'"],
+                  "$(which mpicxx)",
+                  "bsub -Ip",
+                  44,
+                  4),
+    "quartz" : (["module purge", "module load StdEnv cmake/3.14.5 mkl/2019.0 intel/19.0.4 netcdf-fortran/4.4.4 netcdf/4.4.1.1"],
+                  "$(which mpicxx)",
+                  "salloc --partition=pdebug",
+                  36,
+                  36),
+    "syrah"  : (["module purge", "module load StdEnv cmake/3.14.5 mkl/2019.0 intel/19.0.4 netcdf-fortran/4.4.4 netcdf/4.4.1.1"],
+                  "$(which mpicxx)",
+                  "salloc --partition=pdebug",
+                  16,
+                  16),
+    "summit" : (["module purge", "module load cmake/3.15.2 gcc/6.4.0 spectrum-mpi/10.3.0.1-20190611 cuda/10.1.168 python/3.6.6-anaconda3-5.3.0"],
+                "$(which mpicxx)",
+                "bsub -I -q batch -W 0:30 -P cli115 -nnodes 1",
+                44,
+                6),
+    "cori"   : (["eval $(../../cime/scripts/Tools/get_case_env)", "export OMP_NUM_THREADS=68"],
+                "$(which CC)",
+                "srun --time 02:00:00 --nodes=1 --constraint=knl,quad,cache --exclusive -q regular --account e3sm",
+                68,
+                68),
+    "generic-desktop" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count()),
+    "generic-desktop-debug" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count()),
+    "generic-desktop-serial" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count()),
+}
+
+###############################################################################
+def is_machine_supported (machine):
+###############################################################################
+
+    return machine in MACHINE_METADATA.keys()
+
+###############################################################################
+def get_mach_env (machine):
+###############################################################################
+
+    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+
+    return MACHINE_METADATA[machine][0]
+
+###############################################################################
+def get_mach_cxx_compiler (machine):
+###############################################################################
+
+    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+
+    return MACHINE_METADATA[machine][1]
+
+###############################################################################
+def get_mach_batch_command (machine):
+###############################################################################
+
+    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+
+    return MACHINE_METADATA[machine][2]
+
+###############################################################################
+def get_mach_compilation_resources (machine):
+###############################################################################
+
+    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+
+    return MACHINE_METADATA[machine][3]
+
+###############################################################################
+def get_mach_testing_resources (machine):
+###############################################################################
+
+    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+
+    return MACHINE_METADATA[machine][4]

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -64,6 +64,9 @@ OR
     parser.add_argument("-c", "--custom-cmake-opts", action="append", default=[],
         help="Extra custom options to pass to cmake. Can use multiple times for multiple cmake options. The -D is added for you")
 
+    parser.add_argument("-e", "--custom-env-vars", action="append", default=[],
+        help="Extra custom environment variables to be used. These will override (if applicable) whatever was found in machine_specs. Each -e flag supports a single env var, so to pass multiple env var, do -e ""KEY1=VALUE1"" -e ""KEY2=VALUE2"" ")
+
     parser.add_argument("-t", "--test", dest="tests", action="append", default=[],
         help="Only run specific test configurations, choices='dbg' (debug), 'sp' (single-prec), 'fpe' (floating-point exceptions)")
 

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -77,6 +77,12 @@ OR
     parser.add_argument("-d", "--dry-run", action="store_true",
                         help="Do a dry run, commands will be printed but not executed")
 
+    parser.add_argument("--make-parallel-level", action="store", default=0,
+        help="Max number of jobs to be created during compilation. If not provided, use default for given machine.")
+
+    parser.add_argument("--ctest-parallel-level", action="store", default=0,
+        help="Force to use this value for CTEST_PARALLEL_LEVEL. If not provided, use default for given machine.")
+
     return parser.parse_args(args[1:])
 
 ###############################################################################

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -8,6 +8,7 @@ check_minimum_python_version(3, 4)
 
 import os, shutil, pathlib
 import concurrent.futures as threading3
+import itertools
 
 ###############################################################################
 class TestAllScream(object):
@@ -211,9 +212,14 @@ class TestAllScream(object):
     ###############################################################################
     def get_taskset_id(self, test):
     ###############################################################################
-        myid = self._tests.index(test)
-        start = myid * self._compile_res_count[test]
-        end   = (myid+1) * self._compile_res_count[test] - 1
+        # Note: we need to loop through the whole list, since the compile_res_count
+        #       might not be the same for all test.
+
+        it = itertools.takewhile(lambda name: name!=test, self._tests)
+        offset = sum(self._compile_res_count[prevs] for prevs in it)
+
+        start = offset
+        end   = offset + self._compile_res_count[test] - 1
 
         return start, end
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -2,7 +2,7 @@ from utils import run_cmd, run_cmd_no_fail, check_minimum_python_version, get_cu
     get_current_commit, get_current_branch, expect, is_repo_clean, cleanup_repo,  \
     get_common_ancestor, merge_git_ref, checkout_git_ref, print_last_commit
 
-from machines_specs import get_mach_compilation_resources, get_mach_testing_resources
+from machines_specs import get_mach_compilation_resources, get_mach_testing_resources, setup_mach_env
 
 check_minimum_python_version(3, 4)
 
@@ -16,7 +16,8 @@ class TestAllScream(object):
 
     ###########################################################################
     def __init__(self, cxx, kokkos=None, submit=False, parallel=False, fast_fail=False, baseline_ref=None,
-                 baseline_dir=None, machine=None, no_tests=False, keep_tree=False, custom_cmake_opts=(), tests=(),
+                 baseline_dir=None, machine=None, no_tests=False, keep_tree=False,
+                 custom_cmake_opts=(), custom_env_vars=(), tests=(),
                  integration_test="JENKINS_HOME" in os.environ, root_dir=None, dry_run=False,
                  make_parallel_level=0, ctest_parallel_level=0):
     ###########################################################################
@@ -32,6 +33,7 @@ class TestAllScream(object):
         self._keep_tree         = keep_tree
         self._baseline_dir      = baseline_dir
         self._custom_cmake_opts = custom_cmake_opts
+        self._custom_env_vars   = custom_env_vars
         self._tests             = tests
         self._root_dir          = root_dir
         self._integration_test  = integration_test
@@ -378,6 +380,15 @@ class TestAllScream(object):
     ###############################################################################
     def test_all_scream(self):
     ###############################################################################
+
+        # Setup the env on this machine
+        setup_mach_env(self._machine)
+
+        # Add any override the user may have requested
+        for env_var in self._custom_env_vars:
+            key,val = env_var.split("=",2)
+            os.environ.update( { key : val } )
+
         success = True
         try:
             # First, create build directories (one per test)

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -272,7 +272,7 @@ class TestAllScream(object):
             print ("WARNING: Failed to configure baselines:\n{}".format(err))
             return False
 
-        cmd = "make -j{} && make baseline".format(self._compile_res_count[test])
+        cmd = "make -j{} && make -j{} baseline".format(self._compile_res_count[test],self._compile_res_count[test])
         if self._parallel:
             start, end = self.get_taskset_id(test)
             cmd = "taskset -c {}-{} sh -c '{}'".format(start,end,cmd)

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -2,6 +2,8 @@ from utils import run_cmd, run_cmd_no_fail, check_minimum_python_version, get_cu
     get_current_commit, get_current_branch, expect, is_repo_clean, cleanup_repo,  \
     get_common_ancestor, merge_git_ref, checkout_git_ref, print_last_commit
 
+from machines_specs import get_mach_compilation_resources, get_mach_testing_resources
+
 check_minimum_python_version(3, 4)
 
 import os, shutil, pathlib
@@ -14,7 +16,8 @@ class TestAllScream(object):
     ###########################################################################
     def __init__(self, cxx, kokkos=None, submit=False, parallel=False, fast_fail=False, baseline_ref=None,
                  baseline_dir=None, machine=None, no_tests=False, keep_tree=False, custom_cmake_opts=(), tests=(),
-                 integration_test="JENKINS_HOME" in os.environ, root_dir=None, dry_run=False):
+                 integration_test="JENKINS_HOME" in os.environ, root_dir=None, dry_run=False,
+                 make_parallel_level=0, ctest_parallel_level=0):
     ###########################################################################
 
         self._cxx               = cxx
@@ -101,41 +104,54 @@ class TestAllScream(object):
             if self._integration_test:
                 merge_git_ref(git_ref="origin/master",verbose=True)
 
-        # Deduce how many resources per test
-        proc_count = 4
+        # Deduce how many testing resources per test
+        if ctest_parallel_level > 0:
+            ctest_max_jobs = ctest_parallel_level
+            print("Note: honoring requested value for ctest parallel level: {}".format(ctest_max_jobs))
+        else:
+            ctest_max_jobs = get_mach_testing_resources(self._machine)
+            print("Note: no value passed for --ctest-parallel-level. Using the default for this machine: {}".format(ctest_max_jobs))
 
-        proc_set = False
-        if "CTEST_PARALLEL_LEVEL" in os.environ:
-            try:
-                proc_count = int(os.environ["CTEST_PARALLEL_LEVEL"])
-                proc_set = True
-            except ValueError:
-                pass
+        self._testing_res_count = {"dbg" : ctest_max_jobs,
+                                   "sp"  : ctest_max_jobs,
+                                   "fpe" : ctest_max_jobs}
 
-        if not proc_set:
-            print("WARNING: env var CTEST_PARALLEL_LEVEL unset, defaulting to {} which probably underutilizes your machine".\
-                      format(proc_count))
+        # Deduce how many compilation resources per test
+        if make_parallel_level > 0:
+            make_max_jobs = make_parallel_level
+            print("Note: honoring requested value for make parallel level: {}".format(make_max_jobs))
+        else:
+            make_max_jobs = get_mach_compilation_resources(self._machine)
+            print("Note: no value passed for --make-parallel-level. Using the default for this machine: {}".format(make_max_jobs))
 
-        self._proc_count = {"dbg" : proc_count,
-                            "sp"  : proc_count,
-                            "fpe" : proc_count}
+        self._compile_res_count = {"dbg" : make_max_jobs,
+                                   "sp"  : make_max_jobs,
+                                   "fpe" : make_max_jobs}
 
         if self._parallel:
             # We need to be aware that other builds may be running too.
             # (Do not oversubscribe the machine)
-            remainder = proc_count % len(self._tests)
-            proc_count = proc_count // len(self._tests)
+            make_remainder = make_max_jobs % len(self._tests)
+            make_count     = make_max_jobs // len(self._tests)
+            ctest_remainder = ctest_max_jobs % len(self._tests)
+            ctest_count     = ctest_max_jobs // len(self._tests)
 
             # In case we have more tests than cores (unlikely)
-            if proc_count == 0:
-                proc_count = 1
+            if make_count == 0:
+                make_count = 1
+            if ctest_count == 0:
+                ctest_count = 1
 
             for test in self._tests:
-                self._proc_count[test] = proc_count
-                if self._tests.index(test)<remainder:
-                    self._proc_count[test] = proc_count + 1
+                self._compile_res_count[test] = make_count
+                if self._tests.index(test)<make_remainder:
+                    self._compile_res_count[test] = make_count + 1
 
-                print("test {} has {} procs".format(test,self._proc_count[test]))
+                self._testing_res_count[test] = ctest_count
+                if self._tests.index(test)<ctest_remainder:
+                    self._testing_res_count[test] = ctest_count + 1
+
+                print("test {} can use {} jobs to compile, and {} jobs for testing".format(test,self._compile_res_count[test],self._testing_res_count[test]))
 
         if self._keep_tree:
             expect(not is_repo_clean(silent=True), "Makes no sense to use --keep-tree when repo is clean")
@@ -196,8 +212,8 @@ class TestAllScream(object):
     def get_taskset_id(self, test):
     ###############################################################################
         myid = self._tests.index(test)
-        start = myid * self._proc_count[test]
-        end   = (myid+1) * self._proc_count[test] - 1
+        start = myid * self._compile_res_count[test]
+        end   = (myid+1) * self._compile_res_count[test] - 1
 
         return start, end
 
@@ -209,7 +225,7 @@ class TestAllScream(object):
         if self._submit:
             result += "CIME_MACHINE={} ".format(self._machine)
 
-        result += "CTEST_PARALLEL_LEVEL={} ctest -V --output-on-failure ".format(self._proc_count[test])
+        result += "CTEST_PARALLEL_LEVEL={} ctest -V --output-on-failure ".format(self._testing_res_count[test])
 
         if self._baseline_dir is not None:
             cmake_config += " -DSCREAM_TEST_DATA_DIR={}".format(self.get_preexisting_baseline(test))
@@ -250,7 +266,7 @@ class TestAllScream(object):
             print ("WARNING: Failed to configure baselines:\n{}".format(err))
             return False
 
-        cmd = "make -j{} && make baseline".format(self._proc_count[test])
+        cmd = "make -j{} && make baseline".format(self._compile_res_count[test])
         if self._parallel:
             start, end = self.get_taskset_id(test)
             cmd = "taskset -c {}-{} sh -c '{}'".format(start,end,cmd)

--- a/components/scream/scripts/utils.py
+++ b/components/scream/scripts/utils.py
@@ -438,3 +438,12 @@ def cleanup_repo(orig_branch, orig_commit, repo=None):
     # Is this also a pointless check?
     if curr_commit != orig_commit:
         run_cmd_no_fail("git reset --hard {}".format(orig_commit), from_dir=repo)
+
+###############################################################################
+def get_cpu_core_count ():
+###############################################################################
+    """
+    Get the number of CPU processors available on the current node
+    """
+
+    return int(run_cmd_no_fail("cat /proc/cpuinfo | grep processor | wc -l"))


### PR DESCRIPTION
The two are separate. We want to use host CPU cores for compilation, while we want to use the node devices for testing. The two might coincide (on CPU machines), but are different on GPU machines. And with drastically different numbers. On white, for instance, we have 4 gpus on the node, but there are 128 hw threads available.

1) extract MACHINE_METADATA into its own module. Provide getter functions.
2) Make gather_all_data use the new module.
3) Add util that finds how many processors are on the current machine.
4) Add entries to mach dictionary, for generic-desktop (and its variants).
   No env/batch specified, and compilation/testing resources default to
   the number of processors on the machine.
5) Add flags to test-all-scream, to specify max jobs for compilation and
   testing phase. If not provided, get them from the MACH dictionary.

This addition to the MACH metadata also opens the door for effectively using multiple GPUs during testing. That's for another PR though, since it'd require some CMake mods too (see [here](https://cmake.org/cmake/help/latest/prop_test/RESOURCE_GROUPS.html) and [here](https://cmake.org/cmake/help/latest/manual/ctest.1.html#ctest-resource-allocation))