### PR TITLE
Remove vap_cld_exchange from system

### DIFF
--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -104,7 +104,7 @@ contains
        diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm, &
        pratot,prctot,p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
-       vap_ice_exchange, vap_cld_exchange) bind(C)
+       vap_ice_exchange) bind(C)
     use micro_p3, only : p3_main
 
     real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, qv, th
@@ -134,7 +134,6 @@ contains
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: liq_ice_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_liq_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_ice_exchange
-    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_cld_exchange
 
     real(kind=c_real), dimension(its:ite,3) :: col_location
     integer :: i

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -28,7 +28,7 @@ extern "C" {
                  Real* rflx, Real* sflx, // 1 extra column size
                  Real* rcldm, Real* lcldm, Real* icldm, Real* pratot, Real* prctot,
                  Real* p3_tend_out, Real* mu_c, Real* lamc, Real* liq_ice_exchange,
-                 Real* vap_liq_exchange, Real* vap_ice_exchange, Real* vap_cld_exchange);
+                 Real* vap_liq_exchange, Real* vap_ice_exchange);
 }
 
 namespace scream {
@@ -84,7 +84,6 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   liq_ice_exchange = Array2("sum of liq-ice phase change tendenices", ncol, nlev);
   vap_liq_exchange = Array2("sum of vap-liq phase change tendenices", ncol, nlev);
   vap_ice_exchange = Array2("sum of vap-ice phase change tendenices", ncol, nlev);
-  vap_cld_exchange = Array2("sum of vap-cld phase change tendenices", ncol, nlev);
 }
 
 FortranDataIterator::FortranDataIterator (const FortranData::Ptr& d) {
@@ -100,7 +99,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
         d_->name.data(),                                                \
         d_->name.size()})
   fdipb(qv); fdipb(th); fdipb(pres);
-  fdipb(dzq); fdipb(ncnuc); fdipb(naai); fdipb(qc_relvar); fdipb(qc); 
+  fdipb(dzq); fdipb(ncnuc); fdipb(naai); fdipb(qc_relvar); fdipb(qc);
   fdipb(nc); fdipb(qr); fdipb(nr); fdipb(qitot); fdipb(nitot);
   fdipb(qirim); fdipb(birim); fdipb(prt_liq); fdipb(prt_sol);
   fdipb(diag_ze); fdipb(diag_effc); fdipb(diag_effi);
@@ -110,7 +109,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(rcldm); fdipb(lcldm); fdipb(icldm);
   fdipb(pratot); fdipb(prctot);
   fdipb(mu_c); fdipb(lamc); fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
-  fdipb(vap_ice_exchange); fdipb(vap_cld_exchange);
+  fdipb(vap_ice_exchange);;
 #undef fdipb
 }
 
@@ -155,7 +154,7 @@ void p3_main (const FortranData& d) {
             d.rflx.data(), d.sflx.data(),
             d.rcldm.data(), d.lcldm.data(), d.icldm.data(),d.pratot.data(),d.prctot.data(),
             d.p3_tend_out.data(),d.mu_c.data(),d.lamc.data(),d.liq_ice_exchange.data(),
-            d.vap_liq_exchange.data(),d.vap_ice_exchange.data(),d.vap_cld_exchange.data());
+            d.vap_liq_exchange.data(),d.vap_ice_exchange.data());
 }
 
 int test_FortranData () {

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -35,7 +35,7 @@ struct FortranData {
   Array2 pratot, prctot;
   Array3 p3_tend_out;
   Array2 mu_c, lamc;
-  Array2 liq_ice_exchange,vap_liq_exchange,vap_ice_exchange,vap_cld_exchange;
+  Array2 liq_ice_exchange,vap_liq_exchange,vap_ice_exchange;
 
   FortranData(Int ncol, Int nlev);
 };

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -736,7 +736,6 @@ struct Functions
     const uview_1d<Spack>& oprain,
     const uview_1d<Spack>& onevapr,
     const uview_1d<Spack>& oprer_evap,
-    const uview_1d<Spack>& ovap_cld_exchange,
     const uview_1d<Spack>& ovap_liq_exchange,
     const uview_1d<Spack>& ovap_ice_exchange,
     const uview_1d<Spack>& oliq_ice_exchange,
@@ -812,7 +811,6 @@ struct Functions
     const uview_1d<Spack>& oprain,
     const uview_1d<Spack>& onevapr,
     const uview_1d<Spack>& oprer_evap,
-    const uview_1d<Spack>& ovap_cld_exchange,
     const uview_1d<Spack>& ovap_liq_exchange,
     const uview_1d<Spack>& ovap_ice_exchange,
     const uview_1d<Spack>& oliq_ice_exchange,
@@ -883,8 +881,7 @@ struct Functions
     const view_2d<Spack>& prctot,           // autoconversion of cloud to rain
     const view_2d<Spack>& liq_ice_exchange, // sum of liq-ice phase change tendencies
     const view_2d<Spack>& vap_liq_exchange, // sum of vap-liq phase change tendencies
-    const view_2d<Spack>& vap_ice_exchange, // sum of vap-ice phase change tendencies
-    const view_2d<Spack>& vap_cld_exchange); // sum of vap-cld phase change tendencies
+    const view_2d<Spack>& vap_ice_exchange);// sum of vap-ice phase change tendencies
 };
 
 template <typename ScalarT, typename DeviceT>

--- a/components/scream/src/physics/p3/p3_functions_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_functions_main_impl.hpp
@@ -318,7 +318,6 @@ void Functions<S,D>
   const uview_1d<Spack>& oprain,
   const uview_1d<Spack>& onevapr,
   const uview_1d<Spack>& oprer_evap,
-  const uview_1d<Spack>& ovap_cld_exchange,
   const uview_1d<Spack>& ovap_liq_exchange,
   const uview_1d<Spack>& ovap_ice_exchange,
   const uview_1d<Spack>& oliq_ice_exchange,
@@ -682,7 +681,6 @@ void Functions<S,D>
     ovap_ice_exchange(k).set(not_skip_all, qidep - qisub + qinuc);
     ovap_liq_exchange(k).set(not_skip_all, -qrevp + qcnuc);
     oliq_ice_exchange(k).set(not_skip_all, qcheti + qrheti - qimlt + qiberg + qccol + qrcol);
-    ovap_cld_exchange(k).set(not_skip_all, qcnuc);
 
     // clipping for small hydrometeor values
     const auto qc_small    = oqc(k) < qsmall    && not_skip_all;
@@ -808,7 +806,6 @@ void Functions<S,D>
   const uview_1d<Spack>& oprain,
   const uview_1d<Spack>& onevapr,
   const uview_1d<Spack>& oprer_evap,
-  const uview_1d<Spack>& ovap_cld_exchange,
   const uview_1d<Spack>& ovap_liq_exchange,
   const uview_1d<Spack>& ovap_ice_exchange,
   const uview_1d<Spack>& oliq_ice_exchange,
@@ -852,7 +849,6 @@ void Functions<S,D>
       oqv(k)              .set(qc_small, oqv(k)+oqc(k));
       oth(k)              .set(qc_small, oth(k)-oexner(k)*oqc(k)*oxxlv(k)*inv_cp);
       ovap_liq_exchange(k).set(qc_small, ovap_liq_exchange(k) - oqc(k));
-      ovap_cld_exchange(k).set(qc_small, ovap_cld_exchange(k) - oqc(k));
       oqc(k)              .set(qc_small, 0);
       onc(k)              .set(qc_small, 0);
     }
@@ -1001,8 +997,7 @@ void Functions<S,D>
   const view_2d<Spack>& prctot,           // autoconversion of cloud to rain
   const view_2d<Spack>& liq_ice_exchange, // sum of liq-ice phase change tendenices
   const view_2d<Spack>& vap_liq_exchange, // sum of vap-liq phase change tendenices
-  const view_2d<Spack>& vap_ice_exchange, // sum of vap-ice phase change tendenices
-  const view_2d<Spack>& vap_cld_exchange) // sum of vap-cld phase change tendenices
+  const view_2d<Spack>& vap_ice_exchange) // sum of vap-ice phase change tendenices
 {
   using ExeSpace = typename KT::ExeSpace;
 
@@ -1131,7 +1126,6 @@ void Functions<S,D>
     const auto oliq_ice_exchange = util::subview(liq_ice_exchange, i);
     const auto ovap_liq_exchange = util::subview(vap_liq_exchange, i);
     const auto ovap_ice_exchange = util::subview(vap_ice_exchange, i);
-    const auto ovap_cld_exchange = util::subview(vap_cld_exchange, i);
     const auto oxxlv             = util::subview(xxlv, i);
     const auto oxxls             = util::subview(xxls, i);
     const auto oxlf              = util::subview(xlf, i);
@@ -1168,7 +1162,7 @@ void Functions<S,D>
       team, nk_pack, log_predictNc, dt, odt,
       dnu, itab, itabcol, revap_table,
       opres, opdel, odzq, oncnuc, oexner, inv_exner, inv_lcldm, inv_icldm, inv_rcldm, onaai, oqc_relvar, oicldm, olcldm, orcldm,
-      t, rho, inv_rho, qvs, qvi, sup, supi, rhofacr, rhofaci, acn, oqv, oth, oqc, onc, oqr, onr, oqitot, onitot, oqirim, obirim, oxxlv, oxxls, oxlf, qc_incld, qr_incld, qitot_incld, qirim_incld, nc_incld, nr_incld, nitot_incld, birim_incld, omu_c, nu, olamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, ocmeiout, oprain, onevapr, oprer_evap, ovap_cld_exchange, ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange, opratot, oprctot,
+      t, rho, inv_rho, qvs, qvi, sup, supi, rhofacr, rhofaci, acn, oqv, oth, oqc, onc, oqr, onr, oqitot, onitot, oqirim, obirim, oxxlv, oxxls, oxlf, qc_incld, qr_incld, qitot_incld, qirim_incld, nc_incld, nr_incld, nitot_incld, birim_incld, omu_c, nu, olamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, ocmeiout, oprain, onevapr, oprer_evap, ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange, opratot, oprctot,
       log_hydrometeorsPresent);
 
     //NOTE: At this point, it is possible to have negative (but small) nc, nr, nitot.  This is not
@@ -1221,7 +1215,7 @@ void Functions<S,D>
       team, nk_pack, log_predictNc, dt, odt,
       dnu, itab, itabcol, revap_table,
       opres, opdel, odzq, oncnuc, oexner, inv_exner, inv_lcldm, inv_icldm, inv_rcldm, onaai, oicldm, olcldm, orcldm,
-      t, rho, inv_rho, qvs, qvi, sup, supi, rhofacr, rhofaci, acn, oqv, oth, oqc, onc, oqr, onr, oqitot, onitot, oqirim, obirim, oxxlv, oxxls, oxlf, qc_incld, qr_incld, qitot_incld, qirim_incld, nc_incld, nr_incld, nitot_incld, birim_incld, omu_c, nu, olamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, ocmeiout, oprain, onevapr, oprer_evap, ovap_cld_exchange, ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange, opratot, oprctot, ze_rain, ze_ice, odiag_vmi, odiag_effi, odiag_di, odiag_rhoi, odiag_ze, tmparr1);
+      t, rho, inv_rho, qvs, qvi, sup, supi, rhofacr, rhofaci, acn, oqv, oth, oqc, onc, oqr, onr, oqitot, onitot, oqirim, obirim, oxxlv, oxxls, oxlf, qc_incld, qr_incld, qitot_incld, qirim_incld, nc_incld, nr_incld, nitot_incld, birim_incld, omu_c, nu, olamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, ocmeiout, oprain, onevapr, oprer_evap, ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange, opratot, oprctot, ze_rain, ze_ice, odiag_vmi, odiag_effi, odiag_di, odiag_rhoi, odiag_ze, tmparr1);
 
     //
     // merge ice categories with similar properties

--- a/components/scream/src/physics/p3/scream_p3_interface.F90
+++ b/components/scream/src/physics/p3/scream_p3_interface.F90
@@ -158,7 +158,6 @@ contains
     real(kind=c_real) :: liq_ice_exchange(pcols,pver) ! sum of liq-ice phase change tendenices
     real(kind=c_real) :: vap_liq_exchange(pcols,pver) ! sum of vap-liq phase change tendenices
     real(kind=c_real) :: vap_ice_exchange(pcols,pver) ! sum of vap-ice phase change tendenices
-    real(kind=c_real) :: vap_cld_exchange(pcols,pver) ! sum of vap-cld phase change tendenices
     real(kind=c_real) :: qc_relvar(pcols,pver)        ! 1/(var(qc)/mean(qc)**2) for P3 subgrid qc.
     real(kind=c_real) :: inv_cp
 

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 42);
+  REQUIRE(fdi.nfield() == 41);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);


### PR DESCRIPTION
Previous PR removed it from micro_p3.F90, but did not remove it
from scream/src.