### PR TITLE
Fast DIRK solver: Fix DEBUG=true run.

### DIFF
--- a/components/homme/src/theta-l/imex_mod.F90
+++ b/components/homme/src/theta-l/imex_mod.F90
@@ -644,7 +644,7 @@ contains
 
     ! Compare y and b
     relerr = maxval(abs(y - b), 3)/maxval(abs(b), 3)
-    if (hybrid%masterthread .and. maxval(relerr) > 1e3*epsilon(1.0_real_kind)) then
+    if (hybrid%masterthread .and. maxval(relerr) > 1e5*epsilon(1.0_real_kind)) then
        write(iulog,*) 'FAIL test_tridiag_solver', maxval(relerr)
     end if
   end subroutine test_tridiag_solver

--- a/components/homme/src/theta-l/imex_mod.F90
+++ b/components/homme/src/theta-l/imex_mod.F90
@@ -528,9 +528,9 @@ contains
           if (k.eq.1) then
             norminfJ0(i,j) = max(norminfJ0(i,j),(abs(JacD(i,j,k))+abs(JacU(i,j,k))))
           elseif (k.eq.nlev) then
-            norminfJ0(i,j) = max(norminfJ0(i,j),(abs(JacL(k-1,i,j))+abs(JacD(i,j,k))))
+            norminfJ0(i,j) = max(norminfJ0(i,j),(abs(JacL(i,j,k-1))+abs(JacD(i,j,k))))
           else
-            norminfJ0(i,j) = max(norminfJ0(i,j),(abs(JacL(k-1,i,j))+abs(JacD(i,j,k))+ &
+            norminfJ0(i,j) = max(norminfJ0(i,j),(abs(JacL(i,j,k-1))+abs(JacD(i,j,k))+ &
               abs(JacU(i,j,k))))
           end if
       end do


### PR DESCRIPTION
The IMEX unit test had the wrong index order in two spots, caught in the DEBUG=true build on cori-knl.