### PR TITLE
Update SCREAM compsets to use CMIP6 2010 tunings

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -371,7 +371,7 @@ _TESTS = {
         "tests" : (
             "SMS_D.ne4pg2_ne4pg2.F2010-SCREAM-HR",
             "SMS_D.ne4pg2_ne4pg2.F2010-SCREAM-LR",
-            "SMS_D.ne4pg2_ne4pg2.FSCREAM-SA",
+            "SMS_D.ne4pg2_ne4pg2.F2000-SCREAM-SA",
             "ERS.ne4pg2_ne4pg2.F2010-SCREAM-HR",
             "ERS.ne4pg2_ne4pg2.F2010-SCREAM-LR",
             "ERP.ne4pg2_ne4pg2.F2010-SCREAM-HR.cam-double_memleak_tol",

--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -369,17 +369,17 @@ _TESTS = {
     "e3sm_scream" : {
         "time"  : "03:00:00",
         "tests" : (
-            "SMS_D.ne4pg2_ne4pg2.FSCREAM-HR",
-            "SMS_D.ne4pg2_ne4pg2.FSCREAM-LR",
+            "SMS_D.ne4pg2_ne4pg2.F2010-SCREAM-HR",
+            "SMS_D.ne4pg2_ne4pg2.F2010-SCREAM-LR",
             "SMS_D.ne4pg2_ne4pg2.FSCREAM-SA",
-            "ERS.ne4pg2_ne4pg2.FSCREAM-HR",
-            "ERS.ne4pg2_ne4pg2.FSCREAM-LR",
-            "ERP.ne4pg2_ne4pg2.FSCREAM-HR.cam-double_memleak_tol",
-            "ERP.ne4pg2_ne4pg2.FSCREAM-LR.cam-double_memleak_tol",
-            "REP.ne4pg2_ne4pg2.FSCREAM-HR",
-            "REP.ne4pg2_ne4pg2.FSCREAM-LR",
-            "PEM.ne4pg2_ne4pg2.FSCREAM-HR",
-            "PEM.ne4pg2_ne4pg2.FSCREAM-LR",
+            "ERS.ne4pg2_ne4pg2.F2010-SCREAM-HR",
+            "ERS.ne4pg2_ne4pg2.F2010-SCREAM-LR",
+            "ERP.ne4pg2_ne4pg2.F2010-SCREAM-HR.cam-double_memleak_tol",
+            "ERP.ne4pg2_ne4pg2.F2010-SCREAM-LR.cam-double_memleak_tol",
+            "REP.ne4pg2_ne4pg2.F2010-SCREAM-HR",
+            "REP.ne4pg2_ne4pg2.F2010-SCREAM-LR",
+            "PEM.ne4pg2_ne4pg2.F2010-SCREAM-HR",
+            "PEM.ne4pg2_ne4pg2.F2010-SCREAM-LR",
             )
     }
 }

--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -369,17 +369,17 @@ _TESTS = {
     "e3sm_scream" : {
         "time"  : "03:00:00",
         "tests" : (
-            "SMS_D.ne4_ne4.FSCREAM-HR",
-            "SMS_D.ne4_ne4.FSCREAM-LR",
-            "SMS_D.ne4_ne4.FSCREAM-SA",
-            "ERS.ne4_ne4.FSCREAM-HR",
-            "ERS.ne4_ne4.FSCREAM-LR",
-            "ERP.ne4_ne4.FSCREAM-HR.cam-double_memleak_tol",
-            "ERP.ne4_ne4.FSCREAM-LR.cam-double_memleak_tol",
-            "REP.ne4_ne4.FSCREAM-HR",
-            "REP.ne4_ne4.FSCREAM-LR",
-            "PEM.ne4_ne4.FSCREAM-HR",
-            "PEM.ne4_ne4.FSCREAM-LR",
+            "SMS_D.ne4pg2_ne4pg2.FSCREAM-HR",
+            "SMS_D.ne4pg2_ne4pg2.FSCREAM-LR",
+            "SMS_D.ne4pg2_ne4pg2.FSCREAM-SA",
+            "ERS.ne4pg2_ne4pg2.FSCREAM-HR",
+            "ERS.ne4pg2_ne4pg2.FSCREAM-LR",
+            "ERP.ne4pg2_ne4pg2.FSCREAM-HR.cam-double_memleak_tol",
+            "ERP.ne4pg2_ne4pg2.FSCREAM-LR.cam-double_memleak_tol",
+            "REP.ne4pg2_ne4pg2.FSCREAM-HR",
+            "REP.ne4pg2_ne4pg2.FSCREAM-LR",
+            "PEM.ne4pg2_ne4pg2.FSCREAM-HR",
+            "PEM.ne4pg2_ne4pg2.FSCREAM-LR",
             )
     }
 }

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
@@ -101,6 +101,9 @@
 <!-- For high-res, we use se_ftype = 1 to improve dynamics/physics coupling -->
 <se_ftype hgrid="ne1024np4">1</se_ftype>
 
+<!-- Use the less sensitive advection scheme -->
+<semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
+
 <!-- Turn off Gravity Waves -->
 <use_gw_front>.false.</use_gw_front>
 <use_gw_oro>.false.</use_gw_oro>

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
@@ -98,8 +98,8 @@
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
 <tstep_type>10</tstep_type>
 
-<!-- For high-res, we use se_ftype = 1 to improve dynamics/physics coupling -->
-<se_ftype hgrid="ne1024np4">1</se_ftype>
+<!-- Use se_ftype = 1 to improve dynamics/physics coupling -->
+<se_ftype>1</se_ftype>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
@@ -102,4 +102,7 @@
 <!-- For high-res, we use se_ftype = 1 to improve dynamics/physics coupling -->
 <se_ftype hgrid="ne1024np4">1</se_ftype>
 
+<!-- Use the less sensitive advection scheme -->
+<semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
+
 </namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
@@ -99,8 +99,8 @@
 <iradsw hgrid="ne1024np4"> 4 </iradsw>
 <iradlw hgrid="ne1024np4"> 4 </iradlw>
 
-<!-- For high-res, we use se_ftype = 1 to improve dynamics/physics coupling -->
-<se_ftype hgrid="ne1024np4">1</se_ftype>
+<!-- Use se_ftype = 1 to improve dynamics/physics coupling -->
+<se_ftype>1</se_ftype>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
@@ -34,7 +34,7 @@
 
 <!-- For comprehensive history -->
 <history_amwg>.true.</history_amwg>
-<history_aerosol>.true.</history_aerosol>
+<history_aerosol>.false.</history_aerosol>
 <history_aero_optics>.true.</history_aero_optics>
 
 <!-- File for BC dep in snow feature -->
@@ -100,7 +100,7 @@
 <iradlw hgrid="ne1024np4"> 4 </iradlw>
 
 <!-- Use se_ftype = 1 to improve dynamics/physics coupling -->
-<se_ftype>1</se_ftype>
+<se_ftype>2</se_ftype>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -27,14 +27,9 @@
 <use_hetfrz_classnuc    >.false.</use_hetfrz_classnuc>
 <use_preexisting_ice    >.false.</use_preexisting_ice>
 <hist_hetfrz_classnuc   >.false.</hist_hetfrz_classnuc>
-<micro_mg_dcs_tdep      >.true.</micro_mg_dcs_tdep>
-<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
 
 <!-- For Polar mods-->
 <sscav_tuning            >.true.</sscav_tuning>
-<convproc_do_aer         >.true.</convproc_do_aer>
-<convproc_do_gas         >.false.</convproc_do_gas>
-<convproc_method_activate>2</convproc_method_activate>
 <demott_ice_nuc          >.true.</demott_ice_nuc>
 <liqcf_fix               >.true.</liqcf_fix>
 <regen_fix               >.true.</regen_fix>
@@ -56,7 +51,6 @@
 <use_rad_dt_cosz>.true.</use_rad_dt_cosz>
 
 <!-- Tunable parameters for 72 layer model -->
-<ice_sed_ai>         500.0  </ice_sed_ai>
 <cldfrc_dp1>         0.045D0</cldfrc_dp1>
 <seasalt_emis_scale> 0.85   </seasalt_emis_scale>
 <dust_emis_fact      > 2.05D0    </dust_emis_fact>
@@ -69,24 +63,11 @@
 <n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
 <taubgnd                 >2.5D-3 </taubgnd>
 <raytau0                 >5.0D0</raytau0>
-<prc_coef1               >30500.0D0</prc_coef1>
-<prc_exp                 >3.19D0</prc_exp>
-<prc_exp1                >-1.2D0</prc_exp1>
-<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
 <nucleate_ice_subgrid    >1.2D0</nucleate_ice_subgrid>
-<cld_sed                 >1.0D0</cld_sed>
 <n_so4_monolayers_pcage  > 8.0D0     </n_so4_monolayers_pcage>
-<relvar_fix              > .true.    </relvar_fix>
 
 <!-- Parameters specific to deep convection (default off for HR compset) -->
-<deep_scheme             > off    </deep_scheme>
-<zmconv_c0_lnd           > 0.007  </zmconv_c0_lnd>
-<zmconv_c0_ocn           > 0.007  </zmconv_c0_ocn>
-<zmconv_dmpdz            >-0.7e-3 </zmconv_dmpdz>
-<zmconv_ke               > 5E-6   </zmconv_ke>
-<zmconv_tiedke_add       > 0.8D0  </zmconv_tiedke_add>
-<zmconv_cape_cin         > 1      </zmconv_cape_cin>
-<zmconv_mx_bot_lyr_adj   > 2      </zmconv_mx_bot_lyr_adj>
+<deep_scheme             > 'off'  </deep_scheme>
 
 <!-- Macrophysics/microphysics coupling -->
 <cld_macmic_num_steps    > 6 </cld_macmic_num_steps>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -187,8 +187,8 @@
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
 <tstep_type>10</tstep_type>
 
-<!-- Use se_ftype = 1 to improve dynamics/physics coupling -->
-<se_ftype>1</se_ftype>
+<!-- Dynamics/physics coupling; should be the default, but set to make sure -->
+<se_ftype>2</se_ftype>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -190,6 +190,9 @@
 <!-- For high-res, we use se_ftype = 1 to improve dynamics/physics coupling -->
 <se_ftype hgrid="ne1024np4">1</se_ftype>
 
+<!-- Use the less sensitive advection scheme -->
+<semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
+
 <!-- Turn off Gravity Waves -->
 <use_gw_front>.false.</use_gw_front>
 <use_gw_oro>.false.</use_gw_oro>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- TODO: enable COSP once we do an E3SM->SCREAM merge -->
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_2010control_input4MIPS_c20181017.nc</solar_data_file>
+<solar_data_ymd>20100101</solar_data_ymd>
+<solar_data_type>FIXED</solar_data_type>
+
+<!-- 2010 GHG values from CMIP6 input4MIPS -->
+<!-- <co2vmr>312.821e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in
+     cime/src/drivers/mct/cime_config/config_component_acme.xml -->
+<ch4vmr>1807.851e-9</ch4vmr>
+<n2ovmr>323.141e-9</n2ovmr>
+<f11vmr>768.7644e-12</f11vmr>
+<f12vmr>531.2820e-12</f12vmr>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>    CMIP_DOE-ACME_radiation_average_1850-2014_v3_c20171204.nc</prescribed_volcaero_file>
+<prescribed_volcaero_filetype>VOLC_CMIP6  </prescribed_volcaero_filetype>
+<prescribed_volcaero_type>    CYCLICAL    </prescribed_volcaero_type>
+<prescribed_volcaero_cycle_yr>1           </prescribed_volcaero_cycle_yr>
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc    >.false.</use_hetfrz_classnuc>
+<use_preexisting_ice    >.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc   >.false.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep      >.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning            >.true.</sscav_tuning>
+<convproc_do_aer         >.true.</convproc_do_aer>
+<convproc_do_gas         >.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc          >.true.</demott_ice_nuc>
+<liqcf_fix               >.true.</liqcf_fix>
+<regen_fix               >.true.</regen_fix>
+<resus_fix               >.true.</resus_fix>
+<mam_amicphys_optaa      >1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning    >.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+<ice_sed_ai>         500.0  </ice_sed_ai>
+<cldfrc_dp1>         0.045D0</cldfrc_dp1>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<dust_emis_fact      > 2.05D0    </dust_emis_fact>
+<seasalt_emis_scale  > 0.85      </seasalt_emis_scale>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<effgw_oro>          0.25    </effgw_oro>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<so4_sz_thresh_icenuc  > 0.05e-6   </so4_sz_thresh_icenuc>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<taubgnd                 >2.5D-3 </taubgnd>
+<raytau0                 >5.0D0</raytau0>
+<prc_coef1               >30500.0D0</prc_coef1>
+<prc_exp                 >3.19D0</prc_exp>
+<prc_exp1                >-1.2D0</prc_exp1>
+<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
+<nucleate_ice_subgrid    >1.2D0</nucleate_ice_subgrid>
+<cld_sed                 >1.0D0</cld_sed>
+<n_so4_monolayers_pcage  > 8.0D0     </n_so4_monolayers_pcage>
+<relvar_fix              > .true.    </relvar_fix>
+
+<!-- Parameters specific to deep convection (default off for HR compset) -->
+<deep_scheme             > off    </deep_scheme>
+<zmconv_c0_lnd           > 0.007  </zmconv_c0_lnd>
+<zmconv_c0_ocn           > 0.007  </zmconv_c0_ocn>
+<zmconv_dmpdz            >-0.7e-3 </zmconv_dmpdz>
+<zmconv_ke               > 5E-6   </zmconv_ke>
+<zmconv_tiedke_add       > 0.8D0  </zmconv_tiedke_add>
+<zmconv_cape_cin         > 1      </zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   > 2      </zmconv_mx_bot_lyr_adj>
+
+<!-- Macrophysics/microphysics coupling -->
+<cld_macmic_num_steps    > 6 </cld_macmic_num_steps>
+
+<!-- SHOC timestep -->
+<shoc_timestep> 20 </shoc_timestep>
+
+<!-- Energy fixer options -->
+<ieflx_opt  > 0     </ieflx_opt>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<ext_frc_type         >CYCLICAL</ext_frc_type>
+<ext_frc_cycle_yr     >2010</ext_frc_cycle_yr>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1x1_2010_clim_c20190821.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1x1_2010_clim_c20190821.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1x1_2010_clim_c20190821.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1x1_2010_clim_c20190821.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1x1_2010_clim_c20190821.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1x1_2010_clim_c20190821.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1x1_2010_clim_c20190821.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1x1_2010_clim_c20190821.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1x1_2010_clim_c20190821.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<srf_emis_type        >CYCLICAL</srf_emis_type>
+<srf_emis_cycle_yr    >2010</srf_emis_cycle_yr>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1x1_2010_clim_c20190821.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1x1_2010_clim_c20190821.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1x1_2010_clim_c20190821.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1x1_2010_clim_c20190821.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1x1_2010_clim_c20190821.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1x1_2010_clim_c20190821.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1x1_2010_clim_c20190821.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1x1_2010_clim_c20190821.nc </so4_a2_emis_file>
+
+<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<!-- NOTE: In order to set these, we would need to enable prognostic aerosol -->
+<!--tracer_cnst_type    >CYCLICAL</tracer_cnst_type-->
+<!--tracer_cnst_cycle_yr>2015</tracer_cnst_cycle_yr-->
+<!--tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file-->
+<!--tracer_cnst_filelist>''</tracer_cnst_filelist-->
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                    </mam_mom_cycle_yr>
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                  </mam_mom_datapath>
+<mam_mom_datatype  >'CYCLICAL'										                     </mam_mom_datatype>
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc' </mam_mom_filename> <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											                         </mam_mom_fixed_tod>
+<mam_mom_fixed_ymd >0											                         </mam_mom_fixed_ymd>
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'		 </mam_mom_specifier>
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
+<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
+<!-- sim_year used for CLM datasets and SST forcings -->
+<sim_year>2015</sim_year>
+
+<!-- Land datasets set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
+
+<!-- Prescribed aerosol options -->
+<use_hetfrz_classnuc>.false.</use_hetfrz_classnuc>
+<aerodep_flx_type>'CYCLICAL'</aerodep_flx_type>
+<aerodep_flx_datapath>atm/cam/chem/trop_mam/aero</aerodep_flx_datapath>
+<aerodep_flx_file nlev="72">mam4_0.9x1.2_L72_2000clim_c170323.nc</aerodep_flx_file>
+<aerodep_flx_file nlev="128">mam4_0.9x1.2_L128_2000clim_c191106.nc</aerodep_flx_file>
+<aerodep_flx_cycle_yr>01</aerodep_flx_cycle_yr>
+<prescribed_aero_type>'CYCLICAL'</prescribed_aero_type>
+<prescribed_aero_datapath>atm/cam/chem/trop_mam/aero</prescribed_aero_datapath>
+<prescribed_aero_file nlev="72">mam4_0.9x1.2_L72_2000clim_c170323.nc</prescribed_aero_file>
+<prescribed_aero_file nlev="128">mam4_0.9x1.2_L128_2000clim_c191106.nc</prescribed_aero_file>
+<prescribed_aero_cycle_yr>01</prescribed_aero_cycle_yr>
+
+<!-- Turn on temperature clipping for RRTMGP -->
+<rrtmgp_clip_temperatures> .true. </rrtmgp_clip_temperatures>
+
+<!-- Do radiation every five minutes for ne1024 -->
+<iradsw hgrid="ne1024np4"> 4 </iradsw>
+<iradlw hgrid="ne1024np4"> 4 </iradlw>
+
+<!-- Settings related to the SCREAM NH dycore -->
+<theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
+<tstep_type>10</tstep_type>
+
+<!-- For high-res, we use se_ftype = 1 to improve dynamics/physics coupling -->
+<se_ftype hgrid="ne1024np4">1</se_ftype>
+
+<!-- Turn off Gravity Waves -->
+<use_gw_front>.false.</use_gw_front>
+<use_gw_oro>.false.</use_gw_oro>
+<use_gw_convect>.false.</use_gw_convect>
+
+</namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -70,7 +70,7 @@
 <deep_scheme             > 'off'  </deep_scheme>
 
 <!-- Macrophysics/microphysics coupling -->
-<cld_macmic_num_steps    > 6 </cld_macmic_num_steps>
+<cld_macmic_num_steps    > 1 </cld_macmic_num_steps>
 
 <!-- SHOC timestep -->
 <shoc_timestep> 20 </shoc_timestep>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -187,8 +187,8 @@
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
 <tstep_type>10</tstep_type>
 
-<!-- For high-res, we use se_ftype = 1 to improve dynamics/physics coupling -->
-<se_ftype hgrid="ne1024np4">1</se_ftype>
+<!-- Use se_ftype = 1 to improve dynamics/physics coupling -->
+<se_ftype>1</se_ftype>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -41,7 +41,7 @@
 
 <!-- For comprehensive history -->
 <history_amwg>.true.</history_amwg>
-<history_aerosol>.true.</history_aerosol>
+<history_aerosol>.false.</history_aerosol>
 <history_aero_optics>.true.</history_aero_optics>
 
 <!-- File for BC dep in snow feature -->

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -70,7 +70,12 @@
 <deep_scheme             > 'off'  </deep_scheme>
 
 <!-- Macrophysics/microphysics coupling -->
-<cld_macmic_num_steps    > 1 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne4np4"   > 6 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne30np4"  > 6 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne120np4" > 3 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne256np4" > 3 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne512np4" > 1 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne1024np4"> 1 </cld_macmic_num_steps>
 
 <!-- SHOC timestep -->
 <shoc_timestep> 20 </shoc_timestep>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -80,7 +80,12 @@
 <zmconv_mx_bot_lyr_adj   > 2      </zmconv_mx_bot_lyr_adj>
 
 <!-- Macrophysics/microphysics coupling -->
-<cld_macmic_num_steps    > 6 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne4np4"   > 6 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne30np4"  > 6 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne120np4" > 3 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne256np4" > 3 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne512np4" > 1 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne1024np4"> 1 </cld_macmic_num_steps>
 
 <!-- SHOC timestep -->
 <!--shoc_timestep> 20 </shoc_timestep-->

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -191,6 +191,9 @@
 <!-- For high-res, we use se_ftype = 1 to improve dynamics/physics coupling -->
 <se_ftype hgrid="ne1024np4">1</se_ftype>
 
+<!-- Use the less sensitive advection scheme -->
+<semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
+
 <!-- Turn off Gravity Waves (only for HR) -->
 <!--use_gw_front>.false.</use_gw_front-->
 <!--use_gw_oro>.false.</use_gw_oro-->

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- TODO: enable COSP once we do an E3SM->SCREAM merge -->
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_2010control_input4MIPS_c20181017.nc</solar_data_file>
+<solar_data_ymd>20100101</solar_data_ymd>
+<solar_data_type>FIXED</solar_data_type>
+
+<!-- 2010 GHG values from CMIP6 input4MIPS -->
+<!-- <co2vmr>312.821e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in
+     cime/src/drivers/mct/cime_config/config_component_acme.xml -->
+<ch4vmr>1807.851e-9</ch4vmr>
+<n2ovmr>323.141e-9</n2ovmr>
+<f11vmr>768.7644e-12</f11vmr>
+<f12vmr>531.2820e-12</f12vmr>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>    CMIP_DOE-ACME_radiation_average_1850-2014_v3_c20171204.nc</prescribed_volcaero_file>
+<prescribed_volcaero_filetype>VOLC_CMIP6  </prescribed_volcaero_filetype>
+<prescribed_volcaero_type>    CYCLICAL    </prescribed_volcaero_type>
+<prescribed_volcaero_cycle_yr>1           </prescribed_volcaero_cycle_yr>
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc    >.false.</use_hetfrz_classnuc>
+<use_preexisting_ice    >.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc   >.false.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep      >.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning            >.true.</sscav_tuning>
+<convproc_do_aer         >.true.</convproc_do_aer>
+<convproc_do_gas         >.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc          >.true.</demott_ice_nuc>
+<liqcf_fix               >.true.</liqcf_fix>
+<regen_fix               >.true.</regen_fix>
+<resus_fix               >.true.</resus_fix>
+<mam_amicphys_optaa      >1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning    >.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+<ice_sed_ai>         500.0  </ice_sed_ai>
+<cldfrc_dp1>         0.045D0</cldfrc_dp1>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<dust_emis_fact      > 2.05D0    </dust_emis_fact>
+<seasalt_emis_scale  > 0.85      </seasalt_emis_scale>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<effgw_oro>          0.25    </effgw_oro>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<so4_sz_thresh_icenuc  > 0.05e-6   </so4_sz_thresh_icenuc>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<taubgnd                 >2.5D-3 </taubgnd>
+<raytau0                 >5.0D0</raytau0>
+<prc_coef1               >30500.0D0</prc_coef1>
+<prc_exp                 >3.19D0</prc_exp>
+<prc_exp1                >-1.2D0</prc_exp1>
+<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
+<nucleate_ice_subgrid    >1.2D0</nucleate_ice_subgrid>
+<cld_sed                 >1.0D0</cld_sed>
+<n_so4_monolayers_pcage  > 8.0D0     </n_so4_monolayers_pcage>
+<relvar_fix              > .true.    </relvar_fix>
+
+<!-- Parameters specific to deep convection (default off for HR compset) -->
+<deep_scheme             > zm     </deep_scheme>
+<zmconv_c0_lnd           > 0.007  </zmconv_c0_lnd>
+<zmconv_c0_ocn           > 0.007  </zmconv_c0_ocn>
+<zmconv_dmpdz            >-0.7e-3 </zmconv_dmpdz>
+<zmconv_ke               > 5E-6   </zmconv_ke>
+<zmconv_tiedke_add       > 0.8D0  </zmconv_tiedke_add>
+<zmconv_cape_cin         > 1      </zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   > 2      </zmconv_mx_bot_lyr_adj>
+
+<!-- Macrophysics/microphysics coupling -->
+<cld_macmic_num_steps    > 6 </cld_macmic_num_steps>
+
+<!-- SHOC timestep -->
+<!--shoc_timestep> 20 </shoc_timestep-->
+<shoc_timestep> 150.0D0 </shoc_timestep>
+
+<!-- Energy fixer options -->
+<ieflx_opt  > 0     </ieflx_opt>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<ext_frc_type         >CYCLICAL</ext_frc_type>
+<ext_frc_cycle_yr     >2010</ext_frc_cycle_yr>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1x1_2010_clim_c20190821.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1x1_2010_clim_c20190821.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1x1_2010_clim_c20190821.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1x1_2010_clim_c20190821.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1x1_2010_clim_c20190821.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1x1_2010_clim_c20190821.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1x1_2010_clim_c20190821.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1x1_2010_clim_c20190821.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1x1_2010_clim_c20190821.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<srf_emis_type        >CYCLICAL</srf_emis_type>
+<srf_emis_cycle_yr    >2010</srf_emis_cycle_yr>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1x1_2010_clim_c20190821.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1x1_2010_clim_c20190821.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1x1_2010_clim_c20190821.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1x1_2010_clim_c20190821.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1x1_2010_clim_c20190821.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1x1_2010_clim_c20190821.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1x1_2010_clim_c20190821.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1x1_2010_clim_c20190821.nc </so4_a2_emis_file>
+
+<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<!-- NOTE: In order to set these, we would need to enable prognostic aerosol -->
+<!--tracer_cnst_type    >CYCLICAL</tracer_cnst_type-->
+<!--tracer_cnst_cycle_yr>2015</tracer_cnst_cycle_yr-->
+<!--tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file-->
+<!--tracer_cnst_filelist>''</tracer_cnst_filelist-->
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                    </mam_mom_cycle_yr>
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                  </mam_mom_datapath>
+<mam_mom_datatype  >'CYCLICAL'										                     </mam_mom_datatype>
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc' </mam_mom_filename> <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											                         </mam_mom_fixed_tod>
+<mam_mom_fixed_ymd >0											                         </mam_mom_fixed_ymd>
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'		 </mam_mom_specifier>
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
+<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
+<!-- sim_year used for CLM datasets and SST forcings -->
+<sim_year>2015</sim_year>
+
+<!-- Land datasets set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
+
+<!-- Prescribed aerosol options -->
+<use_hetfrz_classnuc>.false.</use_hetfrz_classnuc>
+<aerodep_flx_type>'CYCLICAL'</aerodep_flx_type>
+<aerodep_flx_datapath>atm/cam/chem/trop_mam/aero</aerodep_flx_datapath>
+<aerodep_flx_file nlev="72">mam4_0.9x1.2_L72_2000clim_c170323.nc</aerodep_flx_file>
+<aerodep_flx_file nlev="128">mam4_0.9x1.2_L128_2000clim_c191106.nc</aerodep_flx_file>
+<aerodep_flx_cycle_yr>01</aerodep_flx_cycle_yr>
+<prescribed_aero_type>'CYCLICAL'</prescribed_aero_type>
+<prescribed_aero_datapath>atm/cam/chem/trop_mam/aero</prescribed_aero_datapath>
+<prescribed_aero_file nlev="72">mam4_0.9x1.2_L72_2000clim_c170323.nc</prescribed_aero_file>
+<prescribed_aero_file nlev="128">mam4_0.9x1.2_L128_2000clim_c191106.nc</prescribed_aero_file>
+<prescribed_aero_cycle_yr>01</prescribed_aero_cycle_yr>
+
+<!-- Turn on temperature clipping for RRTMGP -->
+<rrtmgp_clip_temperatures> .true. </rrtmgp_clip_temperatures>
+
+<!-- Do radiation every five minutes for ne1024 -->
+<iradsw hgrid="ne1024np4"> 4 </iradsw>
+<iradlw hgrid="ne1024np4"> 4 </iradlw>
+
+<!-- Settings related to the SCREAM NH dycore -->
+<theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
+<tstep_type>10</tstep_type>
+
+<!-- For high-res, we use se_ftype = 1 to improve dynamics/physics coupling -->
+<se_ftype hgrid="ne1024np4">1</se_ftype>
+
+<!-- Turn off Gravity Waves (only for HR) -->
+<!--use_gw_front>.false.</use_gw_front-->
+<!--use_gw_oro>.false.</use_gw_oro-->
+<!--use_gw_convect>.false.</use_gw_convect-->
+
+</namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -188,8 +188,8 @@
 <theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
 <tstep_type>10</tstep_type>
 
-<!-- For high-res, we use se_ftype = 1 to improve dynamics/physics coupling -->
-<se_ftype hgrid="ne1024np4">1</se_ftype>
+<!-- Use se_ftype = 1 to improve dynamics/physics coupling -->
+<se_ftype>1</se_ftype>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -185,7 +185,6 @@
 
 <!-- Settings related to the SCREAM NH dycore -->
 <theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
-<tstep_type>5</tstep_type>
 
 <!-- Dynamics/physics coupling; should be the default, but set to make sure -->
 <se_ftype>2</se_ftype>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -75,11 +75,10 @@
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
 <nucleate_ice_subgrid    >1.2D0</nucleate_ice_subgrid>
 <cld_sed                 >1.0D0</cld_sed>
-<n_so4_monolayers_pcage  > 8.0D0     </n_so4_monolayers_pcage>
 <relvar_fix              > .true.    </relvar_fix>
 
 <!-- Parameters specific to deep convection (default off for HR compset) -->
-<deep_scheme             > zm     </deep_scheme>
+<deep_scheme             > 'ZM'   </deep_scheme>
 <zmconv_c0_lnd           > 0.007  </zmconv_c0_lnd>
 <zmconv_c0_ocn           > 0.007  </zmconv_c0_ocn>
 <zmconv_dmpdz            >-0.7e-3 </zmconv_dmpdz>
@@ -186,7 +185,7 @@
 
 <!-- Settings related to the SCREAM NH dycore -->
 <theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
-<tstep_type>10</tstep_type>
+<tstep_type>5</tstep_type>
 
 <!-- Dynamics/physics coupling; should be the default, but set to make sure -->
 <se_ftype>2</se_ftype>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -188,8 +188,8 @@
 <theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
 <tstep_type>10</tstep_type>
 
-<!-- Use se_ftype = 1 to improve dynamics/physics coupling -->
-<se_ftype>1</se_ftype>
+<!-- Dynamics/physics coupling; should be the default, but set to make sure -->
+<se_ftype>2</se_ftype>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -27,8 +27,6 @@
 <use_hetfrz_classnuc    >.false.</use_hetfrz_classnuc>
 <use_preexisting_ice    >.false.</use_preexisting_ice>
 <hist_hetfrz_classnuc   >.false.</hist_hetfrz_classnuc>
-<micro_mg_dcs_tdep      >.true.</micro_mg_dcs_tdep>
-<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
 
 <!-- For Polar mods-->
 <sscav_tuning            >.true.</sscav_tuning>
@@ -56,11 +54,9 @@
 <use_rad_dt_cosz>.true.</use_rad_dt_cosz>
 
 <!-- Tunable parameters for 72 layer model -->
-<ice_sed_ai>         500.0  </ice_sed_ai>
 <cldfrc_dp1>         0.045D0</cldfrc_dp1>
 <seasalt_emis_scale> 0.85   </seasalt_emis_scale>
 <dust_emis_fact      > 2.05D0    </dust_emis_fact>
-<seasalt_emis_scale  > 0.85      </seasalt_emis_scale>
 <cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
 <effgw_oro>          0.25    </effgw_oro>
 <effgw_beres>        0.4    </effgw_beres>
@@ -69,13 +65,9 @@
 <n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
 <taubgnd                 >2.5D-3 </taubgnd>
 <raytau0                 >5.0D0</raytau0>
-<prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
 <nucleate_ice_subgrid    >1.2D0</nucleate_ice_subgrid>
-<cld_sed                 >1.0D0</cld_sed>
-<relvar_fix              > .true.    </relvar_fix>
 
 <!-- Parameters specific to deep convection (default off for HR compset) -->
 <deep_scheme             > 'ZM'   </deep_scheme>
@@ -191,10 +183,5 @@
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
-
-<!-- Turn off Gravity Waves (only for HR) -->
-<!--use_gw_front>.false.</use_gw_front-->
-<!--use_gw_oro>.false.</use_gw_oro-->
-<!--use_gw_convect>.false.</use_gw_convect-->
 
 </namelist_defaults>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -301,6 +301,8 @@
       <value compset="PIPD_CAM5"        >1850-PD_cam5</value>
       <value compset="2010_CAM5.*SCREAM-LR" >2010_scream_lr</value>
       <value compset="2010_CAM5.*SCREAM-HR" >2010_scream_hr</value>
+      <value compset="2000_CAM5.*SCREAM-LR" >2000_scream_lr</value>
+      <value compset="2000_CAM5.*SCREAM-HR" >2000_scream_hr</value>
       <!-- Aqua planet -->
       <value compset="_CAM5%AQUA"     >aquaplanet_EAMv1</value>
       <!-- Radiative-Convective Equilibrium (RCE) -->

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -31,7 +31,7 @@
     <valid_values>preqx,preqx_kokkos,preqx_acc,theta-l</valid_values>
     <default_value>preqx</default_value>
 	<values>
-	   <value compset="_CAM5%SCREAM-HR">theta-l</value>
+	   <value compset="_CAM5%SCREAM">theta-l</value>
 	</values>
     <group>build_component_cam</group>
     <file>env_build.xml</file>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -299,8 +299,8 @@
       <value compset="AR97_CAM[45]"     >scam_arm97</value>
       <value compset="SCAM_CAM5"        >scam_generic</value>
       <value compset="PIPD_CAM5"        >1850-PD_cam5</value>
-      <value compset="2000_CAM5.*SCREAM-LR" >2000_scream_lr</value>
-      <value compset="2000_CAM5.*SCREAM-HR" >2000_scream_hr</value>
+      <value compset="2010_CAM5.*SCREAM-LR" >2010_scream_lr</value>
+      <value compset="2010_CAM5.*SCREAM-HR" >2010_scream_hr</value>
       <!-- Aqua planet -->
       <value compset="_CAM5%AQUA"     >aquaplanet_EAMv1</value>
       <!-- Radiative-Convective Equilibrium (RCE) -->

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -575,6 +575,41 @@
         <value compset="AR9[57]_CAM">262.5</value>
       </values>
     </entry> 
+
+    <entry id="SSTICE_DATA_FILENAME">
+      <values>
+        <value compset="_CAM5%SCREAM-HR-DYAMOND1">$DIN_LOC_ROOT/atm/cam/sst/sst_ifs_2560x5136_20160725_20160916_c200505.nc</value>
+        <value compset="_CAM5%SCREAM-LR-DYAMOND1">$DIN_LOC_ROOT/atm/cam/sst/sst_ifs_2560x5136_20160725_20160916_c200505.nc</value>
+      </values>
+    </entry> 
+
+    <entry id="SSTICE_GRID_FILENAME">
+      <values>
+        <value compset="_CAM5%SCREAM-HR-DYAMOND1">$DIN_LOC_ROOT/ocn/docn7/domain.ocn.2560x5136.200505.nc</value>
+        <value compset="_CAM5%SCREAM-LR-DYAMOND1">$DIN_LOC_ROOT/ocn/docn7/domain.ocn.2560x5136.200505.nc</value>
+      </values>
+    </entry> 
+
+    <entry id="SSTICE_YEAR_ALIGN">
+      <values>
+        <value compset="_CAM5%SCREAM-HR-DYAMOND1">2016</value>
+        <value compset="_CAM5%SCREAM-HR-DYAMOND1">2016</value>
+      </values>
+    </entry> 
+
+    <entry id="SSTICE_YEAR_START">
+      <values>
+        <value compset="_CAM5%SCREAM-HR-DYAMOND1">2016</value>
+        <value compset="_CAM5%SCREAM-LR-DYAMOND1">2016</value>
+      </values>
+    </entry> 
+
+    <entry id="SSTICE_YEAR_END">
+      <values>
+        <value compset="_CAM5%SCREAM-HR-DYAMOND1">2016</value>
+        <value compset="_CAM5%SCREAM-LR-DYAMOND1">2016</value>
+      </values>
+    </entry> 
     
   </entries>
 

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -359,22 +359,22 @@
   
   <compset>
     <alias>FSCREAM-LR</alias>
-    <lname>2000_CAM5%SCREAM-LR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>2010_CAM5%SCREAM-LR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset> 
   
   <compset>
     <alias>FSCREAM-HR</alias>
-    <lname>2000_CAM5%SCREAM-HR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>2010_CAM5%SCREAM-HR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset> 
 
   <compset>
     <alias>FSCREAM-LR-DYAMOND1</alias>
-    <lname>2000_CAM5%SCREAM-LR-DYAMOND1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>2010_CAM5%SCREAM-LR-DYAMOND1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FSCREAM-HR-DYAMOND1</alias>
-    <lname>2000_CAM5%SCREAM-HR-DYAMOND1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>2010_CAM5%SCREAM-HR-DYAMOND1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <!-- *********************************** -->

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -357,24 +357,46 @@
   <!-- SCREAM compsets -->
   <!-- *********************************** -->  
   
+  <!-- SCREAM compsets with CMIP6 2010 forcings -->
   <compset>
-    <alias>FSCREAM-LR</alias>
+    <alias>F2010-SCREAM-LR</alias>
     <lname>2010_CAM5%SCREAM-LR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset> 
   
   <compset>
-    <alias>FSCREAM-HR</alias>
+    <alias>F2010-SCREAM-HR</alias>
     <lname>2010_CAM5%SCREAM-HR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset> 
 
   <compset>
-    <alias>FSCREAM-LR-DYAMOND1</alias>
+    <alias>F2010-SCREAM-LR-DYAMOND1</alias>
     <lname>2010_CAM5%SCREAM-LR-DYAMOND1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
-    <alias>FSCREAM-HR-DYAMOND1</alias>
+    <alias>F2010-SCREAM-HR-DYAMOND1</alias>
     <lname>2010_CAM5%SCREAM-HR-DYAMOND1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <!-- SCREAM compsets with old 2000 forcings -->
+  <compset>
+    <alias>F2000-SCREAM-LR</alias>
+    <lname>2000_CAM5%SCREAM-LR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset> 
+  
+  <compset>
+    <alias>F2000-SCREAM-HR</alias>
+    <lname>2000_CAM5%SCREAM-HR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset> 
+
+  <compset>
+    <alias>F2000-SCREAM-LR-DYAMOND1</alias>
+    <lname>2000_CAM5%SCREAM-LR-DYAMOND1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>F2000-SCREAM-HR-DYAMOND1</alias>
+    <lname>2000_CAM5%SCREAM-HR-DYAMOND1_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <!-- *********************************** -->

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -575,41 +575,6 @@
         <value compset="AR9[57]_CAM">262.5</value>
       </values>
     </entry> 
-
-    <entry id="SSTICE_DATA_FILENAME">
-      <values>
-        <value compset="_CAM5%SCREAM-HR-DYAMOND1">$DIN_LOC_ROOT/atm/cam/sst/sst_ifs_2560x5136_20160725_20160916_c200505.nc</value>
-        <value compset="_CAM5%SCREAM-LR-DYAMOND1">$DIN_LOC_ROOT/atm/cam/sst/sst_ifs_2560x5136_20160725_20160916_c200505.nc</value>
-      </values>
-    </entry> 
-
-    <entry id="SSTICE_GRID_FILENAME">
-      <values>
-        <value compset="_CAM5%SCREAM-HR-DYAMOND1">$DIN_LOC_ROOT/ocn/docn7/domain.ocn.2560x5136.200505.nc</value>
-        <value compset="_CAM5%SCREAM-LR-DYAMOND1">$DIN_LOC_ROOT/ocn/docn7/domain.ocn.2560x5136.200505.nc</value>
-      </values>
-    </entry> 
-
-    <entry id="SSTICE_YEAR_ALIGN">
-      <values>
-        <value compset="_CAM5%SCREAM-HR-DYAMOND1">2016</value>
-        <value compset="_CAM5%SCREAM-HR-DYAMOND1">2016</value>
-      </values>
-    </entry> 
-
-    <entry id="SSTICE_YEAR_START">
-      <values>
-        <value compset="_CAM5%SCREAM-HR-DYAMOND1">2016</value>
-        <value compset="_CAM5%SCREAM-LR-DYAMOND1">2016</value>
-      </values>
-    </entry> 
-
-    <entry id="SSTICE_YEAR_END">
-      <values>
-        <value compset="_CAM5%SCREAM-HR-DYAMOND1">2016</value>
-        <value compset="_CAM5%SCREAM-LR-DYAMOND1">2016</value>
-      </values>
-    </entry> 
     
   </entries>
 

--- a/components/scream/cime_config/config_compsets.xml
+++ b/components/scream/cime_config/config_compsets.xml
@@ -10,7 +10,7 @@
   <!-- E3SM C/G compsets -->
 
   <compset>
-    <alias>FSCREAM-SA</alias> <!-- SCREAM standalone -->
+    <alias>F2000-SCREAM-SA</alias> <!-- SCREAM standalone -->
     <lname>2000_SCREAM_SLND_SICE_SOCN_SROF_SGLC_SWAV</lname>
     <support_level>Experimental, under development</support_level>
   </compset>


### PR DESCRIPTION
Update SCREAM compsets to use the CMIP6 2010 settings rather than the older F2000 settings. Also update dynamics settings to use `se_ftype = 1` for all resolutions, and the less sensitive advection scheme by setting `semi_lagrange_cdr_alg = 3`.

[non-BFB]