### PR TITLE
A series of small upgrades to automated testing scripts

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -117,6 +117,11 @@ set(SCREAM_MPI_ERRORS_ARE_FATAL TRUE CACHE BOOL "Whether MPI errors should abort
 set(SCREAM_MPIRUN_EXE ${DEFAULT_MPIRUN_EXE} CACHE STRING "The executable name for mpirun")
 set(SCREAM_LIB_ONLY ${DEFAULT_LIB_ONLY} CACHE BOOL "Only build libraries, no exes")
 
+# Assuming SCREAM_LIB_ONLY is FALSE (else, no exec is built at all), we provide the option
+# of building only baseline-related execs. By default, this option is off (menaing "build everything).
+# However, when generating baselines, this can be useful to reduce the amount of stuff compiled.
+set(SCREAM_BASELINES_ONLY FALSE CACHE BOOL "Whether building only baselines-related executables")
+
 ## Work out pack sizes.
 # Determine the master pack size.
 set(SCREAM_PACK_SIZE ${DEFAULT_PACK_SIZE} CACHE STRING

--- a/components/scream/scripts/jenkins/jenkins_common.sh
+++ b/components/scream/scripts/jenkins/jenkins_common.sh
@@ -27,7 +27,9 @@ if [ $skip_testing -eq 0 ]; then
       SUBMIT="" # We don't submit AT runs
   fi
 
-  BASELINES_DIR=/home/projects/e3sm/scream/pr-autotester/master-baselines/$SCREAM_MACHINE
+  # The special string "AUTO" makes test-all-scream look for a baseline dir in the machine_specs.py file.
+  # IF such dir is not found, then the default (ctest-build/baselines) is used
+  BASELINES_DIR=AUTO
 
   ./scream/components/scream/scripts/gather-all-data "./scripts/test-all-scream --baseline-dir $BASELINES_DIR /home/projects/\$compiler -p -i -m \$machine $SUBMIT" -l -m $SCREAM_MACHINE
 else

--- a/components/scream/scripts/jenkins/jenkins_common.sh
+++ b/components/scream/scripts/jenkins/jenkins_common.sh
@@ -27,7 +27,9 @@ if [ $skip_testing -eq 0 ]; then
       SUBMIT="" # We don't submit AT runs
   fi
 
-  ./scream/components/scream/scripts/gather-all-data "./scripts/test-all-scream \$compiler -p -i -m \$machine $SUBMIT" -l -m $SCREAM_MACHINE
+  BASELINES_DIR=/home/projects/e3sm/scream/pr-autotester/master-baselines/$SCREAM_MACHINE
+
+  ./scream/components/scream/scripts/gather-all-data "./scripts/test-all-scream --baseline-dir $BASELINES_DIR /home/projects/\$compiler -p -i -m \$machine $SUBMIT" -l -m $SCREAM_MACHINE
 else
   echo "Tests were skipped, since the Github label 'CI: Integrate Without Testing' was found.\n"
 fi

--- a/components/scream/scripts/jenkins/jenkins_common.sh
+++ b/components/scream/scripts/jenkins/jenkins_common.sh
@@ -31,7 +31,7 @@ if [ $skip_testing -eq 0 ]; then
   # IF such dir is not found, then the default (ctest-build/baselines) is used
   BASELINES_DIR=AUTO
 
-  ./scream/components/scream/scripts/gather-all-data "./scripts/test-all-scream --baseline-dir $BASELINES_DIR /home/projects/\$compiler -p -i -m \$machine $SUBMIT" -l -m $SCREAM_MACHINE
+  ./scream/components/scream/scripts/gather-all-data "./scripts/test-all-scream --baseline-dir $BASELINES_DIR \$compiler -p -i -m \$machine $SUBMIT" -l -m $SCREAM_MACHINE
 else
   echo "Tests were skipped, since the Github label 'CI: Integrate Without Testing' was found.\n"
 fi

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -1,9 +1,15 @@
-# MACHINE -> (env_setup, compiler, batch submit prefix, num host cores, num devices)
+# MACHINE -> (env_setup, compiler, batch submit prefix, num host cores, num devices, pre-existing baselines root dir)
 
 # Note: the numbef of host cores is used to parallelize compilation,
 #       while the number of devices is used to parallelize testing.
 #       On CPU machines, the two will usually coincide, while on GPU
 #       machines they are going to be different (compile on CPU, run on GPU).
+
+# Note: the pre-existing baselines root dir is used for integration testing only.
+#       It can be an empty string (""). If so, test-all-scream will use a default
+#       (ctest-build/baselines), and build baselines on the fly.
+#       This directory is interpreted as the directory where different builds
+#       subdirs are located (full_debug, full_sp_debug, debug_no_fpe).
 
 from utils import expect, get_cpu_core_count, run_cmd_no_fail
 import os
@@ -13,55 +19,65 @@ MACHINE_METADATA = {
                   "$(which mpicxx)",
                   "",
                   24,
-                  24),
+                  24,
+                  ""),
     "bowman"   : (["module purge", "module load openmpi/1.10.6/intel/17.2.174 git/2.8.2 cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-bowman/bin:$PATH"],
                   "$(which mpicxx)",
                   "srun",
                   68,
-                  68),
+                  68,
+                  "/home/projects/e3sm/scream/pr-autotester/master-baselines/bowman/"),
     "blake"    : (["module purge", "module load openmpi/2.1.5/intel/19.1.144 git/2.9.4 cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-blake/bin:$PATH"],
                   "$(which mpicxx)",
                   "srun",
                   48,
-                  48),
+                  48,
+                  "/home/projects/e3sm/scream/pr-autotester/master-baselines/blake/"),
     "waterman" : (["module purge", "module load devpack/latest/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88 git/2.10.1", "module switch cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-waterman/bin:$PATH"],
                   "$(which mpicxx)",
                   "bsub -I -q rhel7W",
                   80,
-                  4),
+                  4,
+                  ""),
     "white"    : (["module purge", "module load devpack/20181011/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88 git/2.10.1 cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-white/bin:$PATH"],
                   "$(which mpicxx)",
                   "bsub -I -q rhel7G",
                   64,
-                  4),
+                  4,
+                  "/home/projects/e3sm/scream/pr-autotester/master-baselines/white/"),
     "lassen" : (["module purge", "module load git gcc/7.3.1 cuda/10.1.243 cmake/3.14.5 spectrum-mpi netcdf/4.7.0 python/3.7.2", "export LLNL_USE_OMPI_VARS='y'"],
                   "$(which mpicxx)",
                   "bsub -Ip",
                   44,
-                  4),
+                  4,
+                  ""),
     "quartz" : (["module purge", "module load StdEnv cmake/3.14.5 mkl/2019.0 intel/19.0.4 netcdf-fortran/4.4.4 netcdf/4.4.1.1"],
                   "$(which mpicxx)",
                   "salloc --partition=pdebug",
                   36,
-                  36),
+                  36,
+                  ""),
     "syrah"  : (["module purge", "module load StdEnv cmake/3.14.5 mkl/2019.0 intel/19.0.4 netcdf-fortran/4.4.4 netcdf/4.4.1.1"],
                   "$(which mpicxx)",
                   "salloc --partition=pdebug",
                   16,
-                  16),
+                  16,
+                  ""),
     "summit" : (["module purge", "module load cmake/3.15.2 gcc/6.4.0 spectrum-mpi/10.3.0.1-20190611 cuda/10.1.168 python/3.6.6-anaconda3-5.3.0"],
                 "$(which mpicxx)",
                 "bsub -I -q batch -W 0:30 -P cli115 -nnodes 1",
                 44,
-                6),
+                6,
+                ""),
     "cori"   : (["eval $(../../cime/scripts/Tools/get_case_env)", "export OMP_NUM_THREADS=68"],
                 "$(which CC)",
                 "srun --time 02:00:00 --nodes=1 --constraint=knl,quad,cache --exclusive -q regular --account e3sm",
                 68,
-                68),
-    "generic-desktop" : (["source ~/.bashrc", "load gcc", "load netcdf"],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count()),
-    "generic-desktop-debug" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count()),
-    "generic-desktop-serial" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count()),
+                68,
+                ""),
+    "generic-desktop" : (["source ~/.bashrc", "load gcc", "load netcdf"],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
+    "generic-desktop-debug" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
+    "generic-desktop-serial" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
 }
 
 ###############################################################################
@@ -109,6 +125,18 @@ def get_mach_testing_resources (machine):
     expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
     return MACHINE_METADATA[machine][4]
+
+
+###############################################################################
+def get_mach_baseline_root_dir (machine,default_dir):
+###############################################################################
+
+    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+
+    if MACHINE_METADATA[machine][5]=="":
+        return default_dir
+    else:
+        return MACHINE_METADATA[machine][5]
 
 ###############################################################################
 def setup_mach_env (machine):

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -112,12 +112,14 @@ class TestAllScream(object):
                         self._baseline_ref = "origin/master"
             self._must_generate_baselines = True
 
-            self._baseline_dir = default_baselines_root_dir
+            self._baseline_dir = pathlib.Path(default_baselines_root_dir).resolve()
 
         else:
             # We treat the "AUTO" string as a request for automatic baseline dir.
             if self._baseline_dir == "AUTO":
                 self._baseline_dir = get_mach_baseline_root_dir(self._machine,default_baselines_root_dir)
+
+            self._baseline_dir = pathlib.Path(self._baseline_dir).resolve();
 
             # Make sure the baseline root directory exists
             expect(self._baseline_dir.is_dir(), "Baseline_dir {} is not a dir".format(self._baseline_dir))

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -343,6 +343,7 @@ class TestAllScream(object):
         test_dir = self.get_baseline_dir(test)
 
         cmake_config = self.generate_cmake_config(self._tests_cmake_args[test])
+        cmake_config += " -DSCREAM_BASELINES_ONLY=ON"
 
         print("===============================================================================")
         print("Generating baseline for test {} with config '{}'".format(self._test_full_names[test], cmake_config))

--- a/components/scream/src/control/tests/CMakeLists.txt
+++ b/components/scream/src/control/tests/CMakeLists.txt
@@ -1,18 +1,21 @@
-INCLUDE (ScreamUtils)
+# NOTE: if you have baseline-type tests, add the subdirectory OUTSIDE the following if statement
+if (NOT ${SCREAM_BASELINES_ONLY})
+  include (ScreamUtils)
 
-SET (num_mpi_ranks 1)
-SET (config_defines "")
+  set (num_mpi_ranks 1)
+  set (config_defines "")
 
-# Test control folder
-CreateUnitTest(ping_pong "ping_pong_test.cpp" "scream_control;scream_share" num_mpi_ranks config_defines LABELS "driver")
+  # Test control folder
+  CreateUnitTest(ping_pong "ping_pong_test.cpp" "scream_control;scream_share" num_mpi_ranks config_defines LABELS "driver")
 
-# Copy yaml input file to run directory
-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/ping_pong.yaml
-               ${CMAKE_CURRENT_BINARY_DIR}/ping_pong.yaml COPYONLY)
+  # Copy yaml input file to run directory
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ping_pong.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/ping_pong.yaml COPYONLY)
 
-# Unit test the ad
-CreateUnitTest(ad_ut "ad_tests.cpp" "scream_control;scream_share" num_mpi_ranks config_defines LABELS "driver")
+  # Unit test the ad
+  CreateUnitTest(ad_ut "ad_tests.cpp" "scream_control;scream_share" num_mpi_ranks config_defines LABELS "driver")
 
-# Copy yaml input file to run directory
-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/ad_tests.yaml
-               ${CMAKE_CURRENT_BINARY_DIR}/ad_tests.yaml COPYONLY)
+  # Copy yaml input file to run directory
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ad_tests.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/ad_tests.yaml COPYONLY)
+endif()

--- a/components/scream/src/dynamics/homme/tests/CMakeLists.txt
+++ b/components/scream/src/dynamics/homme/tests/CMakeLists.txt
@@ -1,17 +1,20 @@
-INCLUDE (ScreamUtils)
+# NOTE: if you have baseline-type tests, add the subdirectory OUTSIDE the following if statement
+if (NOT ${SCREAM_BASELINES_ONLY})
+  include (ScreamUtils)
 
-# Get or create the dynamics lib
-#                 HOMME_TARGET   NP PLEV QSIZE_D USE_PIO USE_ENERGY
-CreateDynamicsLib("preqx_kokkos"  4   72   4  FALSE   FALSE)
+  # Get or create the dynamics lib
+  #                 HOMME_TARGET   NP PLEV QSIZE_D USE_PIO USE_ENERGY
+  CreateDynamicsLib("preqx_kokkos"  4   72   4  FALSE   FALSE)
 
-SET (EXTRA_INCLUDE_DIRS ${HOMME_INCLUDE_DIRS})
-SET (EXTRA_CONFIG_DEFS
-     HAVE_CONFIG_H
-     HOMMEXX_CONFIG_IS_CMAKE
-)
+  set (EXTRA_INCLUDE_DIRS ${HOMME_INCLUDE_DIRS})
+  set (EXTRA_CONFIG_DEFS
+       HAVE_CONFIG_H
+       HOMMEXX_CONFIG_IS_CMAKE
+  )
 
-SET (NEED_LIBS ${dynLibName} scream_share pio timing ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
-SET (UNIT_TEST_EXTRA_LIBRARY_DIRS ${dynLibDir})
+  set (NEED_LIBS ${dynLibName} scream_share pio timing ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+  set (UNIT_TEST_EXTRA_LIBRARY_DIRS ${dynLibDir})
 
-# Test dynamics-physics fields remapping
-CreateUnitTest(homme_pd_remap "homme_pd_remap_tests.cpp" "${NEED_LIBS}" CONFIG_DEFS ${EXTRA_CONFIG_DEFS} INCLUDE_DIRS ${EXTRA_INCLUDE_DIRS})
+  # Test dynamics-physics fields remapping
+  CreateUnitTest(homme_pd_remap "homme_pd_remap_tests.cpp" "${NEED_LIBS}" CONFIG_DEFS ${EXTRA_CONFIG_DEFS} INCLUDE_DIRS ${EXTRA_INCLUDE_DIRS})
+endif()

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -35,7 +35,10 @@ set(P3_TESTS_SRCS
   p3_main_unit_tests.cpp
 )
 
-CreateUnitTest(p3_tests "${P3_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP p3_tests_ut_np1_omp1)
+# NOTE: tests inside this if statement won't be built in a baselines-only build
+if (NOT ${SCREAM_BASELINES_ONLY})
+  CreateUnitTest(p3_tests "${P3_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP p3_tests_ut_np1_omp1)
+endif()
 
 CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}" THREADS ${SCREAM_TEST_MAX_THREADS} EXE_ARGS "${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline" DEP p3_tests_ut_np1_omp1 OPTIONAL EXCLUDE_MAIN_CPP)
 

--- a/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
 include(ScreamUtils)
 
-CreateUnitTest(rrtmgp_tests rrtmgp_tests.cpp "rrtmgp;scream_share")
+# NOTE: tests inside this if statement won't be built in a baselines-only build
+if (NOT ${SCREAM_BASELINES_ONLY})
+  CreateUnitTest(rrtmgp_tests rrtmgp_tests.cpp "rrtmgp;scream_share")
+endif()

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -5,8 +5,11 @@ set(SHOC_TESTS_SRCS
     shoc_tests.cpp
     shoc_unit_tests.cpp)
 
-CreateUnitTest(shoc_tests "${SHOC_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP shoc_tests_ut_np1_omp1)
-# CreateUnitTest(shoc_stand_alone "shoc_stand_alone.cpp" "${NEED_LIBS}")
+# NOTE: tests inside this if statement won't be built in a baselines-only build
+if (NOT ${SCREAM_BASELINES_ONLY})
+  CreateUnitTest(shoc_tests "${SHOC_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP shoc_tests_ut_np1_omp1)
+  # CreateUnitTest(shoc_stand_alone "shoc_stand_alone.cpp" "${NEED_LIBS}")
+endif()
 
 CreateUnitTest(shoc_run_and_cmp "shoc_run_and_cmp.cpp" "${NEED_LIBS}" THREADS ${SCREAM_TEST_MAX_THREADS} EXE_ARGS "${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline" DEP shoc_tests_ut_np1_omp1 OPTIONAL EXCLUDE_MAIN_CPP)
 

--- a/components/scream/src/share/tests/CMakeLists.txt
+++ b/components/scream/src/share/tests/CMakeLists.txt
@@ -1,7 +1,10 @@
-include(ScreamUtils)
+# NOTE: tests inside this if statement won't be built in a baselines-only build
+if (NOT ${SCREAM_BASELINES_ONLY})
+  include(ScreamUtils)
 
-# Test fields
-CreateUnitTest(field "field_tests.cpp" scream_share)
+  # Test fields
+  CreateUnitTest(field "field_tests.cpp" scream_share)
 
-# Test atmosphere processes
-CreateUnitTest(atm_proc "atm_process_tests.cpp" scream_share)
+  # Test atmosphere processes
+  CreateUnitTest(atm_proc "atm_process_tests.cpp" scream_share)
+endif()

--- a/components/scream/tests/CMakeLists.txt
+++ b/components/scream/tests/CMakeLists.txt
@@ -1,8 +1,11 @@
-IF ("${SCREAM_DYNAMICS_DYCORE}" STREQUAL "HOMME")
-  add_subdirectory(scream_homme_dyn_ut_nlev72_qsize4)
-  add_subdirectory(scream_homme_dyn_p3)
-ENDIF()
+# NOTE: if you have baseline-type tests, add the subdirectory OUTSIDE the following if statement
+if (NOT ${SCREAM_BASELINES_ONLY})
+  if ("${SCREAM_DYNAMICS_DYCORE}" STREQUAL "HOMME")
+    add_subdirectory(scream_homme_dyn_ut_nlev72_qsize4)
+    add_subdirectory(scream_homme_dyn_p3)
+  endif()
 
-add_subdirectory(scream_p3)
-add_subdirectory(scream_p3_shoc)
-add_subdirectory(rrtmgp)
+  add_subdirectory(scream_p3)
+  add_subdirectory(scream_p3_shoc)
+  add_subdirectory(rrtmgp)
+endif()


### PR DESCRIPTION
Includes:

1) recycle existing baselines in jenkins jobs, unless they are missing or expired (meaning sha used to generate them does not match the sha of origin/master);
2) only build baseline executables when generating baselines;
3) always build baselines in a directory different from where the tests are built.