### PR TITLE
This commit will add the FSCREAM-SA compset to the nightly tests

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -371,6 +371,7 @@ _TESTS = {
         "tests" : (
             "SMS_D.ne4_ne4.FSCREAM-HR",
             "SMS_D.ne4_ne4.FSCREAM-LR",
+            "SMS_D.ne4_ne4.FSCREAM-SA",
             "ERS.ne4_ne4.FSCREAM-HR",
             "ERS.ne4_ne4.FSCREAM-LR",
             "ERP.ne4_ne4.FSCREAM-HR.cam-double_memleak_tol",


### PR DESCRIPTION
FSCREAM-SA is the stand-alone version of scream run within the E3SM
component suite.  Adding in a smoke test for FSCREAM-SA will allow us
to test that any new changes doesn't impact our ability to run SCREAM
use a CIME build.

[BFB]