### PR TITLE
Include <vector> in scream_session.cpp.

### DIFF
--- a/components/scream/ekat/src/ekat/scream_assert.hpp
+++ b/components/scream/ekat/src/ekat/scream_assert.hpp
@@ -63,7 +63,7 @@
 // As soon as we can use C++14, this macro can be removed, and you can simply use
 // `assert(check);` in the body of the constexpr function.
 #if defined(NDEBUG) || !defined(EKAT_CONSTEXPR_ASSERT)
-#define CONSTEXPR_ASSERT(CHECK) void(0)
+#define CONSTEXPR_ASSERT(CHECK) void(CHECK)
 #else
 namespace impl {
 struct assert_failure {

--- a/components/scream/ekat/src/ekat/scream_session.cpp
+++ b/components/scream/ekat/src/ekat/scream_session.cpp
@@ -3,6 +3,8 @@
 #include "ekat/scream_assert.hpp"
 #include "ekat/util/scream_arch.hpp"
 
+#include <vector>
+
 #ifdef SCREAM_FPE
 # include <xmmintrin.h>
 #endif


### PR DESCRIPTION
This PR fixes a bug which prevents scream from compiling on Compy. In particular, scream_session.cpp did not include vector which is required for compilation.