### PR TITLE
[WIP]Replaced STOP with endrun calls and some minor fixes

### DIFF
--- a/components/scream/src/share/util/scream_utils.hpp
+++ b/components/scream/src/share/util/scream_utils.hpp
@@ -135,7 +135,7 @@ void transpose(const Scalar* sv, Scalar* dv, Int ni, Int nk) {
         dv[ni*k + i] = sv[nk*i + k];
       else
         dv[nk*i + k] = sv[ni*k + i];
-};
+}
 
 namespace check_overloads
 {


### PR DESCRIPTION
STOP Fortran calls can result in hangs if the program is run using MPI. E3SM's `endrun` utility calls `MPI_ABORT`, which provides a clean way to exit a program, where all MPI processes are aborted at once.
Other changes included in this PR:
1. Minor cleanup of a function
2. Error messages are added to endrun calls as args
3. A "semicolon" is removed to get rid of compiler warnings.