### PR TITLE
Include a call to finalize scream session for SCORPIO error handling

### DIFF
--- a/components/scream/ekat/src/ekat/scream_session.cpp
+++ b/components/scream/ekat/src/ekat/scream_session.cpp
@@ -68,9 +68,10 @@ void initialize_scream_session (int argc, char **argv) {
   Kokkos::initialize(argc, argv);
   std::cout << util::config_string() << "\n";
 }
-
+extern "C" {
 void finalize_scream_session () {
   Kokkos::finalize();
 }
+} // extern "C"
 
 } // namespace scream

--- a/components/scream/ekat/src/ekat/scream_session.hpp
+++ b/components/scream/ekat/src/ekat/scream_session.hpp
@@ -5,8 +5,9 @@ namespace scream {
 
 void initialize_scream_session();
 void initialize_scream_session(int argc, char **argv);
+extern "C" {
 void finalize_scream_session();
-
+} // extern "C"
 } // namespace scream
 
 #endif // SCREAM_SESSION_HPP

--- a/components/scream/src/mct_coupling/scream_scorpio_interface.F90
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface.F90
@@ -567,8 +567,14 @@ contains
 !=====================================================================!
   ! Handle any errors that crop up
   subroutine errorHandle(errMsg, retVal)
-
+    use iso_c_binding
     implicit none
+
+    interface
+      subroutine finalize_scream_session() bind(C)
+        ! No inputs or anything, just interface to C code.
+      end subroutine finalize_scream_session
+    end interface
 
     character(len=*),  intent(in)    :: errMsg
     integer,           intent(in)    :: retVal
@@ -584,6 +590,7 @@ contains
         curr => curr%next
       end do
       ! Kill run
+      call finalize_scream_session()
       call mpi_abort(pio_mpicom,0,retVal)
     end if
 


### PR DESCRIPTION
This commit includes a call to finalize the scream session for the
error handling code within the SCORPIO interface.  This was, if an
error is encountered the Kokkos session will be finalized before
MPI abort is called.

[BFB]