### PR TITLE
[WIP] Add more limiters on state and optics going into RRTMGP

### DIFF
--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -4199,11 +4199,6 @@ File path for RRTMGP longwave gaseous absorption coefficients file.
 File path for RRTMGP shortwave gaseous absorption coefficients file.
 </entry>
 
-<entry id="rrtmgp_clip_temperatures" type="logical"
-       category="radiation" group="radiation_nl" valid_values="">
-Flag to determine whether temperatures should be clipped or limited when
-outside the range of the absorption coefficient look-up table values.
-</entry>
 <!-- Rayleigh Friction Parameterization -->
 
 <entry id="rayk0" type="integer" category="rayleigh_friction"

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -197,7 +197,11 @@ contains
          combined_tau_ssa = cld_tau_ssa
          combined_tau_ssa_g = cld_tau_ssa_g
       end if
-
+     
+      ! Initialize outputs (in case column dimension > ncol)
+      tau_out = 0._r8
+      ssa_out = 0._r8
+      asm_out = 0._r8
       ! Copy to output arrays, converting to optical depth, single scattering
       ! albedo, and assymmetry parameter from the products that the CAM routines
       ! return. Make sure we do not try to divide by zero...
@@ -305,6 +309,7 @@ contains
       end if
 
       ! Set output optics
+      tau_out = 0._r8
       do iband = 1,nbnd
          tau_out(1:ncol,1:nlev,iband) = combined_tau(iband,1:ncol,1:nlev)
          liq_tau_out(1:ncol,1:nlev,iband) = liq_tau(iband,1:ncol,1:nlev)
@@ -539,6 +544,10 @@ contains
                             count(night_indices > 0), night_indices, is_cmip6_volc, &
                             tau, tau_w, tau_w_g, tau_w_f)
 
+      ! Initialize outputs (in case column dimension > ncol)
+      tau_out = 0._r8
+      ssa_out = 0._r8
+      asm_out = 0._r8
       ! Extract quantities from products
       do icol = 1,ncol
          ! Copy cloud optical depth over directly

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1362,27 +1362,27 @@ contains
                ! Check optical properties and clip if they go out of range
                call t_startf('rrtmgp_check_optics_sw')
                call check_range( &
-                  cld_tau_gpt_sw(1:ncol,1:nlev_rad,1:nswgpts), 0._r8, huge(cld_tau_gpt_sw), &
+                  cld_tau_gpt_sw(1:ncol,1:pver,1:nswgpts), 0._r8, huge(cld_tau_gpt_sw), &
                   trim(subroutine_name) // ' cld_tau_gpt_sw', lat, lon, clip_values=.true. &
                )
                call check_range( &
-                  cld_ssa_gpt_sw(1:ncol,1:nlev_rad,1:nswgpts), 0._r8, 1._r8, &
+                  cld_ssa_gpt_sw(1:ncol,1:pver,1:nswgpts), 0._r8, 1._r8, &
                   trim(subroutine_name) // ' cld_ssa_gpt_sw', lat, lon, clip_values=.true. &
                )
                call check_range( &
-                  cld_asm_gpt_sw(1:ncol,1:nlev_rad,1:nswgpts),-1._r8, 1._r8, &
+                  cld_asm_gpt_sw(1:ncol,1:pver,1:nswgpts),-1._r8, 1._r8, &
                   trim(subroutine_name) // ' cld_asm_gpt_sw', lat, lon, clip_values=.true. &
                )
                call check_range( &
-                  aer_tau_bnd_sw(1:ncol,1:nlev_rad,1:nswbands), 0._r8, huge(aer_tau_bnd_sw), &
+                  aer_tau_bnd_sw(1:ncol,1:pver,1:nswbands), 0._r8, huge(aer_tau_bnd_sw), &
                   trim(subroutine_name) // ' aer_tau_bnd_sw', lat, lon, clip_values=.true. &
                )
                call check_range( &
-                  aer_ssa_bnd_sw(1:ncol,1:nlev_rad,1:nswbands), 0._r8, 1._r8, &
+                  aer_ssa_bnd_sw(1:ncol,1:pver,1:nswbands), 0._r8, 1._r8, &
                   trim(subroutine_name) // ' aer_ssa_bnd_sw', lat, lon, clip_values=.true. &
                )
                call check_range( &
-                  aer_asm_bnd_sw(1:ncol,1:nlev_rad,1:nswbands),-1._r8, 1._r8, &
+                  aer_asm_bnd_sw(1:ncol,1:pver,1:nswbands),-1._r8, 1._r8, &
                   trim(subroutine_name) // ' aer_asm_bnd_sw', lat, lon, clip_values=.true. &
                )
                call t_stopf('rrtmgp_check_optics_sw')
@@ -1462,11 +1462,11 @@ contains
                ! Check optical properties and clip if they go out of range
                call t_startf('rrtmgp_check_optics_lw')
                call check_range( &
-                  cld_tau_gpt_lw(1:ncol,1:nlev_rad,1:nlwgpts), 0._r8, huge(cld_tau_gpt_lw), &
+                  cld_tau_gpt_lw(1:ncol,1:pver,1:nlwgpts), 0._r8, huge(cld_tau_gpt_lw), &
                   trim(subroutine_name) // ' cld_tau_gpt_lw', lat, lon, clip_values=.true. &
                )
                call check_range( &
-                  aer_tau_bnd_lw(1:ncol,1:nlev_rad,1:nlwbands), 0._r8, huge(aer_tau_bnd_lw), &
+                  aer_tau_bnd_lw(1:ncol,1:pver,1:nlwbands), 0._r8, huge(aer_tau_bnd_lw), &
                   trim(subroutine_name) // ' aer_tau_bnd_lw', lat, lon, clip_values=.true. &
                )
                call t_stopf('rrtmgp_check_optics_lw')

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1362,7 +1362,7 @@ contains
                ! Check optical properties and clip if they go out of range
                call t_startf('rrtmgp_check_optics_sw')
                call check_range( &
-                  cld_tau_gpt_sw(1:ncol,1:nlev_rad,1:nswgpts), 0._r8, huge(cld_tau_gpw_sw), &
+                  cld_tau_gpt_sw(1:ncol,1:nlev_rad,1:nswgpts), 0._r8, huge(cld_tau_gpt_sw), &
                   trim(subroutine_name) // ' cld_tau_gpt_sw', lat, lon, clip_values=.true. &
                )
                call check_range( &
@@ -1374,7 +1374,7 @@ contains
                   trim(subroutine_name) // ' cld_asm_gpt_sw', lat, lon, clip_values=.true. &
                )
                call check_range( &
-                  aer_tau_bnd_sw(1:ncol,1:nlev_rad,1:nswbands), 0._r8, huge(aer_tau_gpw_sw), &
+                  aer_tau_bnd_sw(1:ncol,1:nlev_rad,1:nswbands), 0._r8, huge(aer_tau_bnd_sw), &
                   trim(subroutine_name) // ' aer_tau_bnd_sw', lat, lon, clip_values=.true. &
                )
                call check_range( &
@@ -1462,11 +1462,11 @@ contains
                ! Check optical properties and clip if they go out of range
                call t_startf('rrtmgp_check_optics_lw')
                call check_range( &
-                  cld_tau_gpt_lw(1:ncol,1:nlev_rad,1:nlwgpts), 0._r8, huge(cld_tau_gpw_lw), &
+                  cld_tau_gpt_lw(1:ncol,1:nlev_rad,1:nlwgpts), 0._r8, huge(cld_tau_gpt_lw), &
                   trim(subroutine_name) // ' cld_tau_gpt_lw', lat, lon, clip_values=.true. &
                )
                call check_range( &
-                  aer_tau_bnd_lw(1:ncol,1:nlev_rad,1:nlwbands), 0._r8, huge(aer_tau_gpw_lw), &
+                  aer_tau_bnd_lw(1:ncol,1:nlev_rad,1:nlwbands), 0._r8, huge(aer_tau_bnd_lw), &
                   trim(subroutine_name) // ' aer_tau_bnd_lw', lat, lon, clip_values=.true. &
                )
                call t_stopf('rrtmgp_check_optics_lw')

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1359,6 +1359,34 @@ contains
                   aer_asm_bnd_sw = 0
                end if
 
+               ! Check optical properties and clip if they go out of range
+               call t_startf('rrtmgp_check_optics_sw')
+               call check_range( &
+                  cld_tau_gpt_sw(1:ncol,1:nlev_rad,1:nswgpts), 0._r8, huge(cld_tau_gpw_sw), &
+                  trim(subroutine_name) // ' cld_tau_gpt_sw', lat, lon, clip_values=.true. &
+               )
+               call check_range( &
+                  cld_ssa_gpt_sw(1:ncol,1:nlev_rad,1:nswgpts), 0._r8, 1._r8, &
+                  trim(subroutine_name) // ' cld_ssa_gpt_sw', lat, lon, clip_values=.true. &
+               )
+               call check_range( &
+                  cld_asm_gpt_sw(1:ncol,1:nlev_rad,1:nswgpts),-1._r8, 1._r8, &
+                  trim(subroutine_name) // ' cld_asm_gpt_sw', lat, lon, clip_values=.true. &
+               )
+               call check_range( &
+                  aer_tau_bnd_sw(1:ncol,1:nlev_rad,1:nswbands), 0._r8, huge(aer_tau_gpw_sw), &
+                  trim(subroutine_name) // ' aer_tau_bnd_sw', lat, lon, clip_values=.true. &
+               )
+               call check_range( &
+                  aer_ssa_bnd_sw(1:ncol,1:nlev_rad,1:nswbands), 0._r8, 1._r8, &
+                  trim(subroutine_name) // ' aer_ssa_bnd_sw', lat, lon, clip_values=.true. &
+               )
+               call check_range( &
+                  aer_asm_bnd_sw(1:ncol,1:nlev_rad,1:nswbands),-1._r8, 1._r8, &
+                  trim(subroutine_name) // ' aer_asm_bnd_sw', lat, lon, clip_values=.true. &
+               )
+               call t_stopf('rrtmgp_check_optics_sw')
+
                ! Call the shortwave radiation driver
                call radiation_driver_sw( &
                   ncol, active_gases, gas_vmr, &
@@ -1431,6 +1459,17 @@ contains
                else
                   aer_tau_bnd_lw = 0
                end if
+               ! Check optical properties and clip if they go out of range
+               call t_startf('rrtmgp_check_optics_lw')
+               call check_range( &
+                  cld_tau_gpt_lw(1:ncol,1:nlev_rad,1:nlwgpts), 0._r8, huge(cld_tau_gpw_lw), &
+                  trim(subroutine_name) // ' cld_tau_gpt_lw', lat, lon, clip_values=.true. &
+               )
+               call check_range( &
+                  aer_tau_bnd_lw(1:ncol,1:nlev_rad,1:nlwbands), 0._r8, huge(aer_tau_gpw_lw), &
+                  trim(subroutine_name) // ' aer_tau_bnd_lw', lat, lon, clip_values=.true. &
+               )
+               call t_stopf('rrtmgp_check_optics_lw')
                ! Call the longwave radiation driver to calculate fluxes and heating rates
                call radiation_driver_lw( &
                   ncol, active_gases, gas_vmr, &

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1227,11 +1227,11 @@ contains
             trim(subname) // ' tint' &
          ), fatal=.false.)
          call handle_error(clip_values( &
-            pmid(1:ncol,1:nlev_rad), k_dist_lw%get_pres_min(), k_dist_lw%get_pres_max(), &
+            pmid(1:ncol,1:nlev_rad), k_dist_lw%get_press_min(), k_dist_lw%get_press_max(), &
             trim(subname) // ' pmid' &
          ), fatal=.false.)
          call handle_error(clip_values( &
-            pint(1:ncol,1:nlev_rad+1), k_dist_lw%get_pres_min(), k_dist_lw%get_pres_max(), &
+            pint(1:ncol,1:nlev_rad+1), k_dist_lw%get_press_min(), k_dist_lw%get_press_max(), &
             trim(subname) // ' pint' &
          ), fatal=.false.)
          call t_stopf('rrtmgp_check_state')

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -14,11 +14,13 @@ module radiation
    use shr_kind_mod,     only: r8=>shr_kind_r8, cl=>shr_kind_cl
    use ppgrid,           only: pcols, pver, pverp, begchunk, endchunk
    use cam_abortutils,   only: endrun
+   use cam_history_support, only: add_hist_coord
    use scamMod,          only: scm_crm_mode, single_column, swrad_off
    use rad_constituents, only: N_DIAG
-   use radconstants,     only: &
-      set_sw_spectral_boundaries, set_lw_spectral_boundaries, check_wavenumber_bounds, &
-      get_band_index_sw, get_band_index_lw, test_get_band_index
+   use radconstants,     only: nswbands, nlwbands, &
+      get_band_index_sw, get_band_index_lw, test_get_band_index, &
+      set_sw_spectral_boundaries, set_lw_spectral_boundaries, &
+      get_sw_spectral_midpoints, get_lw_spectral_midpoints
 
    ! RRTMGP gas optics object to store coefficient information. This is imported
    ! here so that we can make the k_dist objects module data and only load them
@@ -31,7 +33,7 @@ module radiation
 
    use radiation_state, only: ktop, kbot, nlev_rad
    use radiation_utils, only: compress_day_columns, expand_day_columns, &
-                              check_range, handle_error
+                              handle_error
 
    implicit none
    private
@@ -129,33 +131,21 @@ module radiation
    real(r8) :: dt_avg = 0.0_r8  
 
    ! k-distribution coefficients. These will be populated by reading from the
-   ! RRTMGP coefficients files, specified by rrtmgp_coefficients_file_sw and
-   ! rrtmgp_coefficients_file_lw in the radiation namelist. They exist as module
-   ! data because we only want to load those files once.
+   ! RRTMGP coefficients files, specified by coefficients_file_sw and
+   ! coefficients_file_lw in the radiation namelist. They exist as module data
+   ! because we only want to load those files once.
    type(ty_gas_optics_rrtmgp) :: k_dist_sw, k_dist_lw
 
-   ! k-distribution coefficients files to read from. Set via namelist.
+   ! k-distribution coefficients files to read from. These are set via namelist
+   ! variables.
    character(len=cl) :: rrtmgp_coefficients_file_sw, rrtmgp_coefficients_file_lw
 
-   ! Should we clip temperatures when out of bounds of absorption coefficient
-   ! look-up table data?
-   logical :: rrtmgp_clip_temperatures = .false.
-
-   ! Number of shortwave and longwave bands in use by the RRTMGP radiation code.
-   ! This information will be stored in the k_dist_sw and k_dist_lw objects and may
-   ! be retrieved using the k_dist_sw%get_nband() and k_dist_lw%get_nband()
-   ! methods, but I think we need to save these as private module data so that we
-   ! can automatically allocate arrays later in subroutine headers, i.e.:
-   !
-   !     real(r8) :: cld_tau(pcols,pver,nswbands)
-   !
-   ! and so forth. Previously some of this existed in radconstants.F90, but I do
-   ! not think we need to use that.
-   ! EDIT: maybe these JUST below in radconstants.F90?
-   integer :: nswbands, nlwbands
-
-   ! Also, save number of g-points as private module data
+   ! Number of g-points in k-distribution (set based on absorption coefficient inputdata)
    integer :: nswgpts, nlwgpts
+
+   ! Band midpoints; these need to be module variables because of how cam_history works;
+   ! add_hist_coord sets up pointers to these, so they need to persist.
+   real(r8), target :: sw_band_midpoints(nswbands), lw_band_midpoints(nlwbands)
 
    ! Set name for this module (for purpose of writing output and log files)
    character(len=*), parameter :: module_name = 'radiation'
@@ -187,8 +177,8 @@ module radiation
    ! this mean?)
    integer, public, allocatable :: tot_chnk_till_this_prc(:,:,:)
 
-   ! indices to pbuf fields
-   integer :: cldfsnow_idx = 0 
+   ! Indices to pbuf fields
+   integer :: cldfsnow_idx = 0
 
    !============================================================================
 
@@ -222,7 +212,6 @@ contains
       ! Variables defined in namelist
       namelist /radiation_nl/ rrtmgp_coefficients_file_lw,     &
                               rrtmgp_coefficients_file_sw,     &
-                              rrtmgp_clip_temperatures   , &
                               iradsw, iradlw, irad_always,     &
                               use_rad_dt_cosz, spectralflux,   &
                               do_aerosol_rad, fixed_total_solar_irradiance
@@ -247,7 +236,6 @@ contains
       ! Broadcast namelist variables
       call mpibcast(rrtmgp_coefficients_file_lw, cl, mpi_character, mstrid, mpicom, ierr)
       call mpibcast(rrtmgp_coefficients_file_sw, cl, mpi_character, mstrid, mpicom, ierr)
-      call mpibcast(rrtmgp_clip_temperatures, 1, mpi_logical, mstrid, mpicom, ierr)
       call mpibcast(iradsw, 1, mpi_integer, mstrid, mpicom, ierr)
       call mpibcast(iradlw, 1, mpi_integer, mstrid, mpicom, ierr)
       call mpibcast(irad_always, 1, mpi_integer, mstrid, mpicom, ierr)
@@ -423,7 +411,6 @@ contains
    !-------------------------------------------------------------------------------
       use physics_buffer,     only: pbuf_get_index
       use cam_history,        only: addfld, horiz_only, add_default
-      use cam_history_support, only: add_hist_coord
       use constituents,       only: cnst_get_ind
       use phys_control,       only: phys_getopts
       use rad_constituents,   only: N_DIAG, rad_cnst_get_call_list, rad_cnst_get_info
@@ -461,7 +448,6 @@ contains
       integer :: history_budget_histfile_num ! output history file number for budget fields
       integer :: err
       integer :: dtime  ! time step
-
       logical :: use_MMF  ! SPCAM flag
 
       character(len=128) :: error_message
@@ -473,7 +459,6 @@ contains
       ! methods).
       type(ty_gas_concs) :: available_gases
 
-      real(r8), allocatable :: sw_band_midpoints(:), lw_band_midpoints(:)
       character(len=32) :: subname = 'radiation_init'
 
       !-----------------------------------------------------------------------
@@ -505,16 +490,15 @@ contains
       call rrtmgp_load_coefficients(k_dist_sw, rrtmgp_coefficients_file_sw, available_gases)
       call rrtmgp_load_coefficients(k_dist_lw, rrtmgp_coefficients_file_lw, available_gases)
 
-      ! Get number of bands used in shortwave and longwave and set module data
-      ! appropriately so that these sizes can be used to allocate array sizes.
-      nswbands = k_dist_sw%get_nband()
-      nlwbands = k_dist_lw%get_nband()
+      ! Make sure number of bands in absorption coefficient files matches what we expect
+      call assert(nswbands == k_dist_sw%get_nband(), 'nswbands does not match absorption coefficient data')
+      call assert(nlwbands == k_dist_lw%get_nband(), 'nlwbands does not match absorption coefficient data')
 
-      ! Likewise for g-points
+      ! Number of gpoints depend on inputdata, so initialize here
       nswgpts = k_dist_sw%get_ngpt()
       nlwgpts = k_dist_lw%get_ngpt()
 
-      ! Set values in radconstants
+      ! Set band intervals based on inputdata
       call set_sw_spectral_boundaries(k_dist_sw%get_band_lims_wavenumber())
       call set_lw_spectral_boundaries(k_dist_lw%get_band_lims_wavenumber())
 
@@ -527,7 +511,7 @@ contains
 
       ! Indices on radiation grid that correspond to top and bottom of the model
       ! grid...this is for cases where we want to add an extra layer above the
-      ! model top to deal with radiative heating above the model top...why???
+      ! model top to deal with radiative heating above the model top.
       ktop = nlev_rad - pver + 1
       kbot = nlev_rad
 
@@ -585,13 +569,10 @@ contains
       !
       
       ! Register new dimensions
-      allocate(sw_band_midpoints(nswbands), lw_band_midpoints(nlwbands))
-      sw_band_midpoints(:) = get_band_midpoints(nswbands, k_dist_sw)
-      lw_band_midpoints(:) = get_band_midpoints(nlwbands, k_dist_lw)
-      call assert(all(sw_band_midpoints > 0), subname // ': negative sw_band_midpoints')
-      call add_hist_coord('swband', nswbands, 'Shortwave band', 'wavelength', sw_band_midpoints)
-      call add_hist_coord('lwband', nlwbands, 'Longwave band', 'wavelength', lw_band_midpoints)
-      deallocate(sw_band_midpoints, lw_band_midpoints)
+      call get_sw_spectral_midpoints(sw_band_midpoints, 'cm-1')
+      call get_lw_spectral_midpoints(lw_band_midpoints, 'cm-1')
+      call add_hist_coord('swband', nswbands, 'Shortwave wavenumber', 'cm-1', sw_band_midpoints)
+      call add_hist_coord('lwband', nlwbands, 'Longwave wavenumber', 'cm-1', lw_band_midpoints)
 
       ! Shortwave radiation
       call addfld('TOT_CLD_VISTAU', (/ 'lev' /), 'A',   '1', &
@@ -1031,36 +1012,6 @@ contains
    end subroutine set_available_gases
 
 
-   ! Function to calculate band midpoints from kdist band limits
-   function get_band_midpoints(nbands, kdist) result(band_midpoints)
-      integer, intent(in) :: nbands
-      type(ty_gas_optics_rrtmgp), intent(in) :: kdist
-      real(r8) :: band_midpoints(nbands)
-      real(r8) :: band_limits(2,nbands)
-      integer :: i
-      character(len=32) :: subname = 'get_band_midpoints'
-
-      call assert(kdist%get_nband() == nbands, trim(subname) // ': kdist%get_nband() /= nbands')
-
-      band_limits = kdist%get_band_lims_wavelength()
-
-      call assert(size(band_limits, 1) == size(kdist%get_band_lims_wavelength(), 1), &
-                  subname // ': band_limits and kdist inconsistently sized')
-      call assert(size(band_limits, 2) == size(kdist%get_band_lims_wavelength(), 2), &
-                  subname // ': band_limits and kdist inconsistently sized')
-      call assert(size(band_limits, 2) == size(band_midpoints), &
-                  subname // ': band_limits and band_midpoints inconsistently sized')
-      call assert(all(band_limits > 0), subname // ': negative band limit wavelengths!')
-
-      band_midpoints(:) = 0._r8
-      do i = 1,nbands
-         band_midpoints(i) = (band_limits(1,i) + band_limits(2,i)) / 2._r8
-      end do
-      call assert(all(band_midpoints > 0), subname // ': negative band_midpoints!')
-
-   end function get_band_midpoints
-
-
    !===============================================================================
         
    !----------------------------------------------------------------------------
@@ -1106,7 +1057,6 @@ contains
                             get_cloud_optics_lw, sample_cloud_optics_lw, &
                             set_aerosol_optics_sw
       use aer_rad_props, only: aer_rad_props_lw
-      use physconst, only: pi
 
       ! For running CFMIP Observation Simulator Package (COSP)
       use cospsimulator_intr, only: docosp, cospsimulator_intr_run, cosp_nradsteps
@@ -1195,10 +1145,6 @@ contains
       ! Gas volume mixing ratios
       real(r8), dimension(size(active_gases),pcols,pver) :: gas_vmr
 
-      ! Latitude and longitude arrays for extra debugging information when
-      ! things go wrong
-      real(r8), dimension(pcols) :: lat, lon
-
       ! Needed for shortwave aerosol; TODO: remove this dependency
       integer :: nday, nnight     ! Number of daylight columns
       integer :: day_indices(pcols), night_indices(pcols)   ! Indicies of daylight coumns
@@ -1208,20 +1154,20 @@ contains
       logical :: conserve_energy = .true.
 
       ! Number of columns
-      integer :: ncol, icol
+      integer :: ncol
 
       ! For loops over diagnostic calls
       integer :: icall
       logical :: active_calls(0:N_DIAG)
 
       ! Everyone needs a name
-      character(*), parameter :: subroutine_name = 'radiation_tend'
+      character(*), parameter :: subname = 'radiation_tend'
 
       ! Radiative fluxes
       type(ty_fluxes_byband) :: fluxes_allsky, fluxes_clrsky
 
+      ! Zero-array for cloud properties if not diagnosed by microphysics
       real(r8), target, dimension(pcols,pver) :: zeros
-
 
       !----------------------------------------------------------------------
 
@@ -1243,7 +1189,7 @@ contains
       call pbuf_get_field(pbuf, pbuf_get_index('LAMBDAC'), lambdac)
       call pbuf_get_field(pbuf, pbuf_get_index('MU'), mu)
       ! May or may not have snow properties depending on microphysics
-      if (cldfsnow_idx > 0) then
+      if (do_snow_optics()) then
          call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), cldfsnow)
          call pbuf_get_field(pbuf, pbuf_get_index('ICSWP'), icswp)
          call pbuf_get_field(pbuf, pbuf_get_index('DES'), des)
@@ -1270,23 +1216,17 @@ contains
 
          ! Check temperatures to make sure they are within the bounds of the
          ! absorption coefficient look-up tables. If out of bounds, optionally clip
-         ! values to min/max specified (depending on value of
-         ! rrtmgp_clip_temperatures)
-         do icol = 1,ncol
-            lat(icol) = state%lat(icol) * 180._r8 / pi
-            lon(icol) = state%lon(icol) * 180._r8 / pi
-         end do
+         ! values to min/max specified
          call t_startf('rrtmgp_check_temperatures')
-         call check_range( &
+         call handle_error(clip_values( &
             tmid(1:ncol,1:nlev_rad), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
-            trim(subroutine_name) // ' tmid', lat, lon, clip_values=rrtmgp_clip_temperatures &
-         )
-         call check_range( &
+            trim(subname) // ' tmid' &
+         ), fatal=.false.)
+         call handle_error(clip_values( &
             tint(1:ncol,1:nlev_rad+1), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
-            trim(subroutine_name) // ' tint', lat, lon, clip_values=rrtmgp_clip_temperatures &
-         )
+            trim(subname) // ' tint' &
+         ), fatal=.false.)
          call t_stopf('rrtmgp_check_temperatures')
-
       end if
      
       ! Do shortwave stuff...
@@ -1314,6 +1254,9 @@ contains
 
          ! Do shortwave cloud optics calculations
          call t_startf('rad_cld_optics_sw')
+         cld_tau_gpt_sw = 0._r8
+         cld_ssa_gpt_sw = 0._r8
+         cld_asm_gpt_sw = 0._r8
          call get_cloud_optics_sw( &
             ncol, pver, nswbands, do_snow_optics(), cld, cldfsnow, iclwp, iciwp, icswp, &
             lambdac, mu, dei, des, rel, rei, &
@@ -1346,6 +1289,9 @@ contains
                ! Get aerosol optics
                if (do_aerosol_rad) then
                   call t_startf('rad_aer_optics_sw')
+                  aer_tau_bnd_sw = 0._r8
+                  aer_ssa_bnd_sw = 0._r8
+                  aer_asm_bnd_sw = 0._r8
                   call set_aerosol_optics_sw( &
                      icall, state, pbuf, &
                      night_indices(1:nnight), &
@@ -1359,33 +1305,13 @@ contains
                   aer_asm_bnd_sw = 0
                end if
 
-               ! Check optical properties and clip if they go out of range
-               call t_startf('rrtmgp_check_optics_sw')
-               call check_range( &
-                  cld_tau_gpt_sw(1:ncol,1:pver,1:nswgpts), 0._r8, huge(cld_tau_gpt_sw), &
-                  trim(subroutine_name) // ' cld_tau_gpt_sw', lat, lon, clip_values=.true. &
-               )
-               call check_range( &
-                  cld_ssa_gpt_sw(1:ncol,1:pver,1:nswgpts), 0._r8, 1._r8, &
-                  trim(subroutine_name) // ' cld_ssa_gpt_sw', lat, lon, clip_values=.true. &
-               )
-               call check_range( &
-                  cld_asm_gpt_sw(1:ncol,1:pver,1:nswgpts),-1._r8, 1._r8, &
-                  trim(subroutine_name) // ' cld_asm_gpt_sw', lat, lon, clip_values=.true. &
-               )
-               call check_range( &
-                  aer_tau_bnd_sw(1:ncol,1:pver,1:nswbands), 0._r8, huge(aer_tau_bnd_sw), &
-                  trim(subroutine_name) // ' aer_tau_bnd_sw', lat, lon, clip_values=.true. &
-               )
-               call check_range( &
-                  aer_ssa_bnd_sw(1:ncol,1:pver,1:nswbands), 0._r8, 1._r8, &
-                  trim(subroutine_name) // ' aer_ssa_bnd_sw', lat, lon, clip_values=.true. &
-               )
-               call check_range( &
-                  aer_asm_bnd_sw(1:ncol,1:pver,1:nswbands),-1._r8, 1._r8, &
-                  trim(subroutine_name) // ' aer_asm_bnd_sw', lat, lon, clip_values=.true. &
-               )
-               call t_stopf('rrtmgp_check_optics_sw')
+               ! Check (and possibly clip) values before passing to RRTMGP driver
+               call handle_error(clip_values(cld_tau_gpt_sw,  0._r8, huge(cld_tau_gpt_sw), trim(subname) // ' cld_tau_gpt_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(cld_ssa_gpt_sw,  0._r8,                1._r8, trim(subname) // ' cld_ssa_gpt_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(cld_asm_gpt_sw, -1._r8,                1._r8, trim(subname) // ' cld_asm_gpt_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_tau_bnd_sw,  0._r8, huge(aer_tau_bnd_sw), trim(subname) // ' aer_tau_bnd_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_ssa_bnd_sw,  0._r8,                1._r8, trim(subname) // ' aer_ssa_bnd_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_asm_bnd_sw, -1._r8,                1._r8, trim(subname) // ' aer_asm_bnd_sw', tolerance=1e-10_r8))
 
                ! Call the shortwave radiation driver
                call radiation_driver_sw( &
@@ -1430,6 +1356,7 @@ contains
          call initialize_rrtmgp_fluxes(ncol, nlev_rad+1, nlwbands, fluxes_clrsky)
 
          call t_startf('rad_cld_optics_lw')
+         cld_tau_gpt_lw = 0._r8
          call get_cloud_optics_lw( &
             ncol, pver, nlwbands, do_snow_optics(), cld, cldfsnow, iclwp, iciwp, icswp, &
             lambdac, mu, dei, des, rei, &
@@ -1454,22 +1381,17 @@ contains
                ! Get aerosol optics
                if (do_aerosol_rad) then
                   call t_startf('rad_aer_optics_lw')
+                  aer_tau_bnd_lw = 0._r8
                   call aer_rad_props_lw(is_cmip6_volc, icall, state, pbuf, aer_tau_bnd_lw)
                   call t_stopf('rad_aer_optics_lw')
                else
                   aer_tau_bnd_lw = 0
                end if
-               ! Check optical properties and clip if they go out of range
-               call t_startf('rrtmgp_check_optics_lw')
-               call check_range( &
-                  cld_tau_gpt_lw(1:ncol,1:pver,1:nlwgpts), 0._r8, huge(cld_tau_gpt_lw), &
-                  trim(subroutine_name) // ' cld_tau_gpt_lw', lat, lon, clip_values=.true. &
-               )
-               call check_range( &
-                  aer_tau_bnd_lw(1:ncol,1:pver,1:nlwbands), 0._r8, huge(aer_tau_bnd_lw), &
-                  trim(subroutine_name) // ' aer_tau_bnd_lw', lat, lon, clip_values=.true. &
-               )
-               call t_stopf('rrtmgp_check_optics_lw')
+
+               ! Check (and possibly clip) values before passing to RRTMGP driver
+               call handle_error(clip_values(cld_tau_gpt_lw,  0._r8, huge(cld_tau_gpt_lw), trim(subname) // ': cld_tau_gpt_lw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_tau_bnd_lw,  0._r8, huge(aer_tau_bnd_lw), trim(subname) // ': aer_tau_bnd_lw', tolerance=1e-10_r8))
+
                ! Call the longwave radiation driver to calculate fluxes and heating rates
                call radiation_driver_lw( &
                   ncol, active_gases, gas_vmr, &
@@ -1551,7 +1473,6 @@ contains
 
    end subroutine radiation_tend
 
-
    !----------------------------------------------------------------------------
 
    subroutine radiation_driver_sw(ncol, &
@@ -1566,7 +1487,7 @@ contains
       use mo_fluxes_byband, only: ty_fluxes_byband
       use mo_optical_props, only: ty_optical_props_2str
       use mo_gas_concentrations, only: ty_gas_concs
-      use radiation_utils, only: calculate_heating_rate, clip_values
+      use radiation_utils, only: calculate_heating_rate
       use cam_optics, only: get_cloud_optics_sw, sample_cloud_optics_sw, &
                             compress_optics_sw, set_aerosol_optics_sw
 
@@ -1615,7 +1536,7 @@ contains
       real(r8) :: tsi_scaling
 
       ! Loop indices
-      integer :: iband, iday, icol, igas
+      integer :: iband
 
       ! State fields that are passed into RRTMGP. Some of these may need to
       ! modified from what exist in the physics_state object, i.e. to clip
@@ -1624,6 +1545,7 @@ contains
       real(r8), dimension(ncol,nlev_rad+1) :: pint_day, tint_day
 
       real(r8), dimension(size(active_gases),ncol,pver) :: gas_vmr_day
+      integer :: igas, iday, icol
 
       ! Everybody needs a name
       character(*), parameter :: subroutine_name = 'radiation_driver_sw'
@@ -1858,7 +1780,7 @@ contains
       use mo_fluxes_byband, only: ty_fluxes_byband
       use mo_optical_props, only: ty_optical_props_1scl
       use mo_gas_concentrations, only: ty_gas_concs
-      use radiation_utils, only: calculate_heating_rate, clip_values
+      use radiation_utils, only: calculate_heating_rate
 
       ! Inputs
       integer, intent(in) :: ncol
@@ -1882,7 +1804,6 @@ contains
       type(ty_gas_concs) :: gas_concentrations
       type(ty_optical_props_1scl) :: aer_optics_lw
       type(ty_optical_props_1scl) :: cld_optics_lw
-
 
       ! Set surface emissivity to 1 here. There is a note in the RRTMG
       ! implementation that this is treated in the land model, but the old
@@ -2241,6 +2162,7 @@ contains
       ! Local namespace
       real(r8) :: wavenumber_limits(2,nswbands)
       integer :: ncol, iband
+      character(len=10) :: subname = 'set_albedo'
 
       ! Check dimension sizes of output arrays.
       ! albedo_dir and albedo_dif should have sizes nswbands,ncol, but ncol
@@ -2294,10 +2216,14 @@ contains
 
       ! Check values and clip if necessary (albedos should not be larger than 1)
       ! NOTE: this does actually issue warnings for albedos larger than 1, but this
-      ! was never checked for RRTMG, so albedos will probably be slight different
+      ! was never checked for RRTMG, so albedos will probably be slightly different
       ! than the implementation in RRTMG!
-      call clip_values(albedo_dir, 0._r8, 1._r8, varname='albedo_dir')
-      call clip_values(albedo_dif, 0._r8, 1._r8, varname='albedo_dif')
+      call handle_error(clip_values( &
+         albedo_dir, 0._r8, 1._r8, trim(subname) // ': albedo_dir', tolerance=0.01_r8) &
+      )
+      call handle_error(clip_values( &
+         albedo_dif, 0._r8, 1._r8, trim(subname) // ': albedo_dif', tolerance=0.01_r8) &
+      )
 
    end subroutine set_albedo
 

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1214,10 +1214,10 @@ contains
             pmid(1:ncol,1:nlev_rad), pint(1:ncol,1:nlev_rad+1) &
          )
 
-         ! Check temperatures to make sure they are within the bounds of the
-         ! absorption coefficient look-up tables. If out of bounds, optionally clip
+         ! Check state variables to make sure they are within the bounds of the
+         ! absorption coefficient look-up tables. If out of bounds, clip
          ! values to min/max specified
-         call t_startf('rrtmgp_check_temperatures')
+         call t_startf('rrtmgp_check_state')
          call handle_error(clip_values( &
             tmid(1:ncol,1:nlev_rad), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
             trim(subname) // ' tmid' &
@@ -1226,7 +1226,15 @@ contains
             tint(1:ncol,1:nlev_rad+1), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
             trim(subname) // ' tint' &
          ), fatal=.false.)
-         call t_stopf('rrtmgp_check_temperatures')
+         call handle_error(clip_values( &
+            pmid(1:ncol,1:nlev_rad), k_dist_lw%get_pres_min(), k_dist_lw%get_pres_max(), &
+            trim(subname) // ' pmid' &
+         ), fatal=.false.)
+         call handle_error(clip_values( &
+            pint(1:ncol,1:nlev_rad+1), k_dist_lw%get_pres_min(), k_dist_lw%get_pres_max(), &
+            trim(subname) // ' pint' &
+         ), fatal=.false.)
+         call t_stopf('rrtmgp_check_state')
       end if
      
       ! Do shortwave stuff...

--- a/components/cam/src/physics/rrtmgp/radiation_utils.F90
+++ b/components/cam/src/physics/rrtmgp/radiation_utils.F90
@@ -20,7 +20,7 @@ module radiation_utils
    end interface expand_day_columns
 
    interface clip_values
-      module procedure clip_values_1d, clip_values_2d
+      module procedure clip_values_1d, clip_values_2d, clip_values_3d
    end interface clip_values
 
    ! Procedure to check range, with extra arguments to print lat/lon location
@@ -28,6 +28,9 @@ module radiation_utils
    interface check_range
       module procedure check_range_2d, check_range_3d
    end interface
+
+   ! Max length for character strings
+   integer, parameter :: max_char_len = 512
 
    ! Name of this module for error messages
    character(len=*), parameter :: module_name = 'radiation_utils'
@@ -389,36 +392,30 @@ contains
       end do
    end subroutine check_range_3d
    !-------------------------------------------------------------------------------
-
-   !----------------------------------------------------------------------------
-
-   subroutine handle_error(error_message, stop_on_error)
+   subroutine handle_error(error_message, fatal)
       use cam_abortutils, only: endrun
-      use cam_logfile, only: iulog
       character(len=*), intent(in) :: error_message
-      logical, intent(in), optional :: stop_on_error
-      logical :: stop_on_error_local = .true.
+      logical, intent(in), optional :: fatal
+      logical :: fatal_local = .true.
 
       ! Allow passing of an optional flag to not stop the run if an error is
       ! encountered. This allows this subroutine to be used when inquiring if a
       ! variable exists without failing.
-      if (present(stop_on_error)) then
-         stop_on_error_local = stop_on_error
+      if (present(fatal)) then
+         fatal_local = fatal
       else
-         stop_on_error_local = .true.
+         fatal_local = .true.
       end if
 
       ! If we encounter an error, fail if we require success. Otherwise do
       ! nothing and return silently.
       if (len(trim(error_message)) > 0) then
-         if (stop_on_error_local) then
-            call endrun(module_name // ': ' // error_message)
+         if (fatal_local) then
+            call endrun(trim(error_message))
          else
-            write(iulog,*) 'WARNING: ', error_message
+            print *, trim(error_message)
          end if
       end if
    end subroutine handle_error
-
    !----------------------------------------------------------------------------
-
 end module radiation_utils

--- a/components/cam/src/physics/rrtmgp/radiation_utils.F90
+++ b/components/cam/src/physics/rrtmgp/radiation_utils.F90
@@ -174,89 +174,38 @@ contains
 
    !----------------------------------------------------------------------------
 
-   subroutine clip_values_1d(x, min_x, max_x, varname, warn)
+   ! Routines to clip array values if they are outside of an expected range,
+   ! defined by min_x and max_x. Allow passing a varname argument, which will be
+   ! appended to warning message and tolerance argument that sets a maximum
+   ! tolerance above which a warning or error will be thrown. That is, these 
+   ! routines will *always* clip values outside expected range and allow the 
+   ! simulation to continue, but a warning will be issued if the values fall 
+   ! outside the expected range plus the tolerance. In other words, no warning 
+   ! is issued when clipping values outside the valid range plus/minus the 
+   ! tolerance.
+   function clip_values_1d(x, min_x, max_x, varname, tolerance) result(error_message)
       real(r8), intent(inout) :: x(:)
       real(r8), intent(in) :: min_x
       real(r8), intent(in) :: max_x
-      character(len=*), intent(in), optional :: varname
-      logical, intent(in), optional :: warn
+      character(len=*), intent(in) :: varname
+      real(r8), intent(in), optional :: tolerance
+      real(r8) :: tolerance_local
+      character(max_char_len) :: error_message
 
-      logical :: warn_local
-
-      warn_local = .false.
-      if (present(warn)) then
-         warn_local = warn
-      end if
-
-      ! Look for values less than threshold
-      if (any(x < min_x)) then
-         ! Raise warning?
-         if (warn_local) then
-            if (present(varname)) then
-               print *, module_name // ' warning: ', &
-                        count(x < min_x), ' values are below threshold for variable ', &
-                        trim(varname), '; min = ', minval(x)
-            else
-               print *, module_name // ' warning: ', &
-                        count(x < min_x), ' values are below threshold; min = ', minval(x)
-            end if
-         end if
-
-         ! Clip values
-         where (x < min_x)
-            x = min_x
-         endwhere
-      end if
-
-      ! Look for values greater than threshold 
-      if (any(x > max_x)) then 
-         ! Raise warning?
-         if (warn_local) then
-            if (present(varname)) then
-               print *, module_name // ' warning: ', &
-                        count(x > max_x), ' values are above threshold for variable ', &
-                        trim(varname), '; max = ', maxval(x)
-            else
-               print *, module_name // ' warning: ', &
-                        count(x > max_x), ' values are above threshold; max = ', maxval(x)
-            end if
-         end if
-
-         ! Clip values
-         where (x > max_x)
-            x = max_x
-         end where
-      end if
-   end subroutine clip_values_1d
-
-   subroutine clip_values_2d(x, min_x, max_x, varname, warn)
-      real(r8), intent(inout) :: x(:,:)
-      real(r8), intent(in) :: min_x
-      real(r8), intent(in) :: max_x
-      character(len=*), intent(in), optional :: varname
-      logical, intent(in), optional :: warn
-
-      logical :: warn_local
-
-      warn_local = .false.
-      if (present(warn)) then
-         warn_local = warn
+      error_message = ''
+      tolerance_local = 0._r8
+      if (present(tolerance)) then
+         tolerance_local = tolerance
       end if
 
       ! look for values less than threshold
       if (any(x < min_x)) then
-         ! Raise warning?
-         if (warn_local) then
-            if (present(varname)) then
-               print *, module_name // ' warning: ', &
-                        count(x < min_x), ' values are below threshold for variable ', &
-                        trim(varname), '; min = ', minval(x)
-            else
-               print *, module_name // ' warning: ', &
-                        count(x < min_x), ' values are below threshold; min = ', minval(x)
-            end if
+         ! Raise warning? Only if outside tolerance
+         if (any(x < (min_x - tolerance_local))) then
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
+                     count(x < (min_x - tolerance_local)), ' values below threshold ', &
+                     '; min = ', minval(x)
          end if
-
          ! Clip values
          where (x < min_x)
             x = min_x
@@ -264,27 +213,107 @@ contains
       end if
 
       ! Look for values greater than threshold
-      if (any(x > max_x)) then 
-         ! Raise warning?
-         if (warn_local) then
-            if (present(varname)) then
-               print *, module_name // ' warning: ', &
-                        count(x > max_x), ' values are above threshold for variable ', &
-                        trim(varname), '; max = ', maxval(x)
-            else
-               print *, module_name // ' warning: ', &
-                        count(x > max_x), ' values are above threshold; max = ', maxval(x)
-            end if
+      if (any(x > max_x)) then
+         ! Raise warning? Only if outside tolerance
+         if (any(x > (max_x + tolerance_local))) then
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
+                     count(x > (max_x + tolerance_local)), ' values above threshold ', &
+                     '; max = ', maxval(x)
          end if
-
          ! Clip values
          where (x > max_x)
             x = max_x
          end where
       end if
+   end function clip_values_1d
+   !-------------------------------------------------------------------------------
+   function clip_values_2d(x, min_x, max_x, varname, tolerance) result(error_message)
+      real(r8), intent(inout) :: x(:,:)
+      real(r8), intent(in) :: min_x
+      real(r8), intent(in) :: max_x
+      character(len=*), intent(in) :: varname
+      real(r8), intent(in), optional :: tolerance
+      real(r8) :: tolerance_local
+      character(max_char_len) :: error_message
 
-   end subroutine clip_values_2d
+      error_message = ''
+      tolerance_local = 0._r8
+      if (present(tolerance)) then
+         tolerance_local = tolerance
+      end if
 
+      ! look for values less than threshold
+      if (any(x < min_x)) then
+         ! Raise warning? Only if outside tolerance
+         if (any(x < (min_x - tolerance_local))) then
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
+                     count(x < (min_x - tolerance_local)), ' values below threshold ', &
+                     '; min = ', minval(x)
+         end if
+         ! Clip values
+         where (x < min_x)
+            x = min_x
+         endwhere
+      end if
+
+      ! Look for values greater than threshold
+      if (any(x > max_x)) then
+         ! Raise warning? Only if outside tolerance
+         if (any(x > (max_x + tolerance_local))) then
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
+                     count(x > (max_x + tolerance_local)), ' values above threshold ', &
+                     '; max = ', maxval(x)
+         end if
+         ! Clip values
+         where (x > max_x)
+            x = max_x
+         end where
+      end if
+   end function clip_values_2d
+   !-------------------------------------------------------------------------------
+   function clip_values_3d(x, min_x, max_x, varname, tolerance) result(error_message)
+      real(r8), intent(inout) :: x(:,:,:)
+      real(r8), intent(in) :: min_x
+      real(r8), intent(in) :: max_x
+      character(len=*), intent(in) :: varname
+      real(r8), intent(in), optional :: tolerance
+      real(r8) :: tolerance_local
+      character(max_char_len) :: error_message
+
+      error_message = ''
+      tolerance_local = 0._r8
+      if (present(tolerance)) then
+         tolerance_local = tolerance
+      end if
+
+      ! look for values less than threshold
+      if (any(x < min_x)) then
+         ! Raise warning? Only if outside tolerance
+         if (any(x < (min_x - tolerance_local))) then
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
+                     count(x < (min_x - tolerance_local)), ' values below threshold ', &
+                     '; min = ', minval(x)
+         end if
+         ! Clip values
+         where (x < min_x)
+            x = min_x
+         endwhere
+      end if
+
+      ! Look for values greater than threshold
+      if (any(x > max_x)) then
+         ! Raise warning? Only if outside tolerance
+         if (any(x > (max_x + tolerance_local))) then
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
+                     count(x > (max_x + tolerance_local)), ' values above threshold ', &
+                     '; max = ', maxval(x)
+         end if
+         ! Clip values
+         where (x > max_x)
+            x = max_x
+         end where
+      end if
+   end function clip_values_3d
    !-------------------------------------------------------------------------------
    subroutine check_range_2d(v, vmin, vmax, vname, lat, lon, abort_on_error, clip_values)
       use cam_abortutils, only: endrun


### PR DESCRIPTION
Add more limiters on state variables (temperature and pressure) and cloud and aerosol optical properties going into RRTMGP so that we can prevent RRTMGP from throwing fatal errors when these values go slightly out of range (like if single scatter albedo is 1.00001 instead of [0,1]), or when we know temperature might go out of bounds of the absorption coefficient lookup tables but we want to continue the simulation anyways (i.e., the infamous tlay error). This also brings the upstream E3SM-specific radiation driver source code (i.e., radiation.F90, radiation_utils.F90, radconstants.F90) into agreement with SCREAM.