### PR TITLE
Add include of std::vector.

### DIFF
--- a/components/scream/ekat/src/ekat/scream_pack_kokkos.hpp
+++ b/components/scream/ekat/src/ekat/scream_pack_kokkos.hpp
@@ -5,6 +5,8 @@
 #include "scream_kokkos_meta.hpp"
 #include "ekat_config.h"
 
+#include <vector>
+
 namespace scream {
 namespace pack {
 


### PR DESCRIPTION
This PR includes std::vector in scream_pack_kokkos.hpp.  Without this inclusion SCREAM would not compile on Compy. 