### PR TITLE
Added isnan overload for packs, plus couple of fixes for testing

### DIFF
--- a/components/scream/ekat/src/ekat/scream_pack.hpp
+++ b/components/scream/ekat/src/ekat/scream_pack.hpp
@@ -485,6 +485,17 @@ scream_mask_gen_bin_op_all(<=)
 scream_mask_gen_bin_op_all(>)
 scream_mask_gen_bin_op_all(<)
 
+template <typename PackType> KOKKOS_INLINE_FUNCTION
+OnlyPackReturn<PackType, Mask<PackType::n>>
+isnan (const PackType& p) {
+  Mask<PackType::n> m;
+  vector_simd for (int i = 0; i < PackType::n; ++i) {
+    m.set(i, util::isnan(p[i]));
+  }
+  return m;
+}
+
+
 template <typename PackType>
 KOKKOS_INLINE_FUNCTION
 OnlyPackReturn<PackType,Int> npack(const Int& nscalar) {

--- a/components/scream/ekat/src/ekat/scream_pack.hpp
+++ b/components/scream/ekat/src/ekat/scream_pack.hpp
@@ -490,7 +490,7 @@ OnlyPackReturn<PackType, Mask<PackType::n>>
 isnan (const PackType& p) {
   Mask<PackType::n> m;
   vector_simd for (int i = 0; i < PackType::n; ++i) {
-    m.set(i, util::isnan(p[i]));
+    m.set(i, util::is_nan(p[i]));
   }
   return m;
 }

--- a/components/scream/ekat/src/ekat/util/scream_utils.hpp
+++ b/components/scream/ekat/src/ekat/util/scream_utils.hpp
@@ -59,6 +59,7 @@ const T& max (const T& a, const T& b) { return a > b ? a : b; }
 KOKKOS_INLINE_FUNCTION bool isfinite (const Real& a) {
   return a == a && a != INFINITY && a != -INFINITY;
 }
+
 template <typename T> KOKKOS_INLINE_FUNCTION
 const T* max_element (const T* const begin, const T* const end) {
   const T* me = begin;
@@ -101,6 +102,15 @@ using std::strlen;
 using std::strcpy;
 using std::strcmp;
 #endif
+
+KOKKOS_INLINE_FUNCTION
+bool isnan (const Real& a) {
+#ifdef __CUDA_ARCH__
+  return isnan(a);
+#else
+  return std::isnan(a);
+#endif
+}
 
 template <typename Integer> KOKKOS_INLINE_FUNCTION
 void set_min_max (const Integer& lim0, const Integer& lim1,

--- a/components/scream/ekat/src/ekat/util/scream_utils.hpp
+++ b/components/scream/ekat/src/ekat/util/scream_utils.hpp
@@ -104,7 +104,7 @@ using std::strcmp;
 #endif
 
 KOKKOS_INLINE_FUNCTION
-bool isnan (const Real& a) {
+bool is_nan (const Real& a) {
 #ifdef __CUDA_ARCH__
   return isnan(a);
 #else

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -82,9 +82,9 @@ MACHINE_METADATA = {
                   40,
                   ""),
 
-    "generic-desktop" : (["source ~/.bashrc", "load gcc", "load netcdf"],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
-    "generic-desktop-debug" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
-    "generic-desktop-serial" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
+    "linux-generic" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
+    "linux-generic-debug" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
+    "linux-generic-serial" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
 }
 
 ###############################################################################

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -154,11 +154,11 @@ class TestAllScream(object):
         #   Deduce how many testing resources per test   #
         ##################################################
 
-        if ctest_parallel_level > 0:
-            ctest_max_jobs = ctest_parallel_level
+        if int(ctest_parallel_level) > 0:
+            ctest_max_jobs = int(ctest_parallel_level)
             print("Note: honoring requested value for ctest parallel level: {}".format(ctest_max_jobs))
         else:
-            ctest_max_jobs = get_mach_testing_resources(self._machine)
+            ctest_max_jobs = int(get_mach_testing_resources(self._machine))
             print("Note: no value passed for --ctest-parallel-level. Using the default for this machine: {}".format(ctest_max_jobs))
 
         self._testing_res_count = {"dbg" : ctest_max_jobs,
@@ -166,11 +166,11 @@ class TestAllScream(object):
                                    "fpe" : ctest_max_jobs}
 
         # Deduce how many compilation resources per test
-        if make_parallel_level > 0:
-            make_max_jobs = make_parallel_level
+        if int(make_parallel_level) > 0:
+            make_max_jobs = int(make_parallel_level)
             print("Note: honoring requested value for make parallel level: {}".format(make_max_jobs))
         else:
-            make_max_jobs = get_mach_compilation_resources(self._machine)
+            make_max_jobs = int(get_mach_compilation_resources(self._machine))
             print("Note: no value passed for --make-parallel-level. Using the default for this machine: {}".format(make_max_jobs))
 
         self._compile_res_count = {"dbg" : make_max_jobs,

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -412,8 +412,9 @@ class TestAllScream(object):
                     print('Generation of baselines for build {} failed'.format(self._test_full_names[test]))
                     return False
 
-        # Store the sha used for baselines generation
-        run_cmd_no_fail("echo '{}' > {}".format(get_current_commit(commit=self._baseline_ref),self._baseline_sha_file))
+        if success:
+            # Store the sha used for baselines generation
+            run_cmd_no_fail("echo '{}' > {}".format(get_current_commit(commit=self._baseline_ref),self._baseline_sha_file))
 
         checkout_git_ref(git_head_ref, verbose=True)
 


### PR DESCRIPTION
One can now do

```
pack::Pack<T,N> p;
...
auto m = pack::isnan(p);
```
and m will be a `Mask` storing whether each individual entry of `p` is a NaN. The function works on both host and device. Notice that this function may or may not be necessary: packs overload the `!=` operator, so one could do 
```
auto m = (p!=p);
```
This seems to work, but I am not 100% confident all compilers will perform the comparison when optimization flags are on. A compiler could very well decide to throw away the comparison and return false, since every possible number except nan compares equal to itself. I suspect the compiler would _not_ throw away the comparison, since `p` is not of built-in type, but the isnan utility simply removes every doubt, since it relies on `std::isnan` on host and Cuda's `isnan` on device.

Additionally, I discovered a couple of bugs in the testing system:
- when trying to store the sha of our baselines for future use, we should only store the sha if _all_ baselines are _successfully_ generated (otherwise we might have wrong/missing baselines). Before this PR, we were simply storing the baselines sha no matter what.
- the machine_specs.py file still contained `generic-desktop` instead of `linux-generic` (the name we recently switched our mach files to, for compatibility with cime). So specifying either `-m generic-desktop` or `-m linux-generic` would cause an error (either mach file not found or machine not found in the python dictionary. catch22).
- the entries for `generic-desktop` contained env setup commands for my laptop, for some reason. I must have done the mod to locally test that machine_specs.py was working, and then forgot to remove the mods, and ended up committing them. This PR cleans up that too.