### PR TITLE
Enforce type=int for integer inputs of test-all-scream

### DIFF
--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -80,10 +80,10 @@ OR
     parser.add_argument("-d", "--dry-run", action="store_true",
                         help="Do a dry run, commands will be printed but not executed")
 
-    parser.add_argument("--make-parallel-level", action="store", default=0,
+    parser.add_argument("--make-parallel-level", action="store", type=int, default=0,
         help="Max number of jobs to be created during compilation. If not provided, use default for given machine.")
 
-    parser.add_argument("--ctest-parallel-level", action="store", default=0,
+    parser.add_argument("--ctest-parallel-level", action="store", type=int, default=0,
         help="Force to use this value for CTEST_PARALLEL_LEVEL. If not provided, use default for given machine.")
 
     return parser.parse_args(args[1:])

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -154,11 +154,11 @@ class TestAllScream(object):
         #   Deduce how many testing resources per test   #
         ##################################################
 
-        if int(ctest_parallel_level) > 0:
-            ctest_max_jobs = int(ctest_parallel_level)
+        if ctest_parallel_level > 0:
+            ctest_max_jobs = ctest_parallel_level
             print("Note: honoring requested value for ctest parallel level: {}".format(ctest_max_jobs))
         else:
-            ctest_max_jobs = int(get_mach_testing_resources(self._machine))
+            ctest_max_jobs = get_mach_testing_resources(self._machine)
             print("Note: no value passed for --ctest-parallel-level. Using the default for this machine: {}".format(ctest_max_jobs))
 
         self._testing_res_count = {"dbg" : ctest_max_jobs,
@@ -166,11 +166,11 @@ class TestAllScream(object):
                                    "fpe" : ctest_max_jobs}
 
         # Deduce how many compilation resources per test
-        if int(make_parallel_level) > 0:
-            make_max_jobs = int(make_parallel_level)
+        if make_parallel_level > 0:
+            make_max_jobs = make_parallel_level
             print("Note: honoring requested value for make parallel level: {}".format(make_max_jobs))
         else:
-            make_max_jobs = int(get_mach_compilation_resources(self._machine))
+            make_max_jobs = get_mach_compilation_resources(self._machine)
             print("Note: no value passed for --make-parallel-level. Using the default for this machine: {}".format(make_max_jobs))
 
         self._compile_res_count = {"dbg" : make_max_jobs,


### PR DESCRIPTION
Not only this avoids ugly casts later inside the testing scripts, but it also allows to catch bad inputs provided by the user.