### PR TITLE
Adds a light weight utility to print simulation parameters

### DIFF
--- a/components/cam/src/physics/cam/debug_info.F90
+++ b/components/cam/src/physics/cam/debug_info.F90
@@ -13,6 +13,7 @@ module debug_info
 
   !Variables updated during the simulation
   integer :: macmiciter, chunk
+  !$OMP THREADPRIVATE(macmiciter,chunk )
 
   public:: &
        get_debug_chunk, &       !update chunk info from the simulation
@@ -50,20 +51,32 @@ contains
   subroutine report_error_info(cause, calling_func, icol, klev)
 
     !Reports simulation parameters
-
-    use cam_logfile,  only: iulog
-    use phys_grid,    only: get_rlat_p, get_rlon_p
-    use time_manager, only: get_nstep
-
+    use cam_abortutils, only: endrun
+    use cam_logfile,    only: iulog
+    use phys_grid,      only: get_rlat_p, get_rlon_p
+    use time_manager,   only: get_nstep
+    use physics_utils,  only: rtype
     implicit none
 
     integer, intent(in) :: icol !column(lat/lon) index
-    integer, intent(in) :: klev !vertical index
+    integer, optional, intent(in) :: klev !vertical index
     character(len=*), intent(in) :: cause, calling_func
 
     !local variables
-    write(iulog,*) 'Fail due to ',cause,' in ',calling_func, '.\n', &
-         'At lat,lon,k,macmic_it, timestep=',get_rlat_p(chunk,icol),get_rlon_p(chunk,icol),klev,macmiciter,get_nstep()
+    real(rtype), parameter::  radian2deg = 180.0_rtype/(4.0_rtype*atan(1.0_rtype)) !180/pi = 57.296
+
+    write(iulog,'(a)') '*****************************************************************'
+    write(iulog,'(a)')'Fail due to '//trim(adjustl(cause))//' in subroutine/function:'//trim(adjustl(calling_func))
+    write(iulog,'(a,f12.8,a,f12.8,a)')'Column location in degrees:(lat,lon) is:(',get_rlat_p(chunk,icol)*radian2deg,',', &
+         get_rlon_p(chunk,icol)*radian2deg,')'
+    write(iulog,'(a,i5)')'macmic_it is:', macmiciter
+    write(iulog,'(a,i5)')'timestep=',get_nstep()
+
+    if(present(klev)) then
+       write(iulog,'(a,i5)') 'K level is:', klev
+    endif
+
+    call endrun('Error occured in debug_info.F90')
 
   end subroutine report_error_info
 

--- a/components/cam/src/physics/cam/debug_info.F90
+++ b/components/cam/src/physics/cam/debug_info.F90
@@ -51,7 +51,6 @@ contains
   subroutine report_error_info(cause, calling_func, icol, klev)
 
     !Reports simulation parameters
-    use cam_abortutils, only: endrun
     use cam_logfile,    only: iulog
     use phys_grid,      only: get_rlat_p, get_rlon_p
     use time_manager,   only: get_nstep
@@ -75,8 +74,6 @@ contains
     if(present(klev)) then
        write(iulog,'(a,i5)') 'K level is:', klev
     endif
-
-    call endrun('Error occured in debug_info.F90')
 
   end subroutine report_error_info
 

--- a/components/cam/src/physics/cam/debug_info.F90
+++ b/components/cam/src/physics/cam/debug_info.F90
@@ -63,11 +63,17 @@ contains
   subroutine report_error_info(cause, calling_func, icol, klev, prnt_macmic)
 
     !Reports simulation parameters
-    use cam_logfile,    only: iulog
+
+    use micro_p3_utils, only: iulog_e3sm
+    use physics_utils,  only: rtype
+
+#ifdef SPMD
+    !Modules to use when SCREAM run with MPI under E3SM
+    use spmd_utils,     only: iam
     use phys_grid,      only: get_rlat_p, get_rlon_p
     use time_manager,   only: get_nstep
-    use physics_utils,  only: rtype
-    use spmd_utils,     only: iam
+#endif
+
     implicit none
 
     !intent-ins
@@ -80,6 +86,8 @@ contains
 
     !local variables
     real(rtype), parameter :: radian2deg = 180.0_rtype/(4.0_rtype*atan(1.0_rtype)) !180/pi = 57.296
+
+    integer                :: col_to_prnt, proc_num
     real(rtype)            :: lat, lon
     character(len=1000)    :: klevstr, macmicstr, icolstr
 
@@ -98,27 +106,37 @@ contains
     endif
 
     !update icolstr to add info about the column used and compute lat lon
+    lat = huge(1.0_rtype)
+    lon = huge(1.0_rtype)
     if(present(icol)) then
-       icolstr = '*NOTE*: Using user specified column index for computing lat-lons'
-       lat = get_rlat_p(chunk,icol)*radian2deg
-       lon = get_rlon_p(chunk,icol)*radian2deg
+       icolstr     = '*NOTE*: Using user specified column index for computing lat-lons'
+       col_to_prnt = icol
     else
        icolstr = '*NOTE*: Using auto updated column index from P3 for computing lat-lons'
-       lat = get_rlat_p(chunk,icol_p3)*radian2deg
-       lon = get_rlon_p(chunk,icol_p3)*radian2deg
+       col_to_prnt = icol_p3
     endif
 
+    !initialize proc_num to a negative value
+    proc_num = -1
+#ifdef SPMD
+    lat = get_rlat_p(chunk, col_to_prnt) * radian2deg
+    lon = get_rlon_p(chunk, col_to_prnt) * radian2deg
+    proc_num = iam
+#endif
+
     !print proc info in the message and issue only one write statement
-    write(iulog,'(a,/,a,i5,a,/,a,/,a,/,a,f12.8,a,f12.8,a,/,a,/,a,i5,/,a,/,a,i5,a,/,a)') &
+    write(iulog_e3sm,'(a,/,a,i5,a,/,a,/,a,/,a,f12.8,a,f12.8,a,/,a,/,a,i5,/,a,/,a,i5,a,/,a)') &
          '', &
-         '********************** Proc #', iam,' output *******************************************', &
+         '********************** Proc #', proc_num,' output *******************************************', &
          'Fail due to '//trim(adjustl(cause))//' in subroutine/function:'//trim(adjustl(calling_func)), &
+#ifdef SPMD
          trim(adjustl(icolstr)), &
          'Column location in degrees(lat,lon) is:(',lat,',',lon,')', &
          trim(adjustl(macmicstr)), &
          'timestep:',get_nstep(), &
+#endif
          trim(adjustl(klevstr)), &
-         '********************** Proc #', iam,' output Ends **************************************', &
+         '********************** Proc #', proc_num,' output Ends **************************************', &
          ''
   end subroutine report_error_info
 

--- a/components/cam/src/physics/cam/debug_info.F90
+++ b/components/cam/src/physics/cam/debug_info.F90
@@ -1,0 +1,71 @@
+module debug_info
+
+  !-------------------------------------------------------------
+  ! This is a light weight module to report parameters which
+  ! might be of interest in case of a simulation crash.
+  !
+  ! Author: Balwinder Singh
+  ! (Following suggestions from Peter Caldwell and Aaron Donahue)
+  !-------------------------------------------------------------
+
+  implicit none
+  private
+
+  !Variables updated during the simulation
+  integer :: macmiciter, chunk
+
+  public:: &
+       get_debug_chunk, &       !update chunk info from the simulation
+       get_debug_macmiciter, &  !update macro/microphysics iteration count
+       report_error_info        !report info on the current lat/lon and other simulation parameters
+
+contains
+
+  subroutine get_debug_chunk(chunk_in)
+
+    !Obtain chunk # from tphycbc
+
+    implicit none
+
+    integer :: chunk_in
+
+    chunk = chunk_in
+
+  end subroutine get_debug_chunk
+
+
+  subroutine get_debug_macmiciter(iter)
+
+    !Obtain iteration # of macro/microphysics sub-stepping iteration
+
+    implicit none
+
+    integer, intent(in) :: iter
+
+    macmiciter = iter
+
+  end subroutine get_debug_macmiciter
+
+
+  subroutine report_error_info(cause, calling_func, icol, klev)
+
+    !Reports simulation parameters
+
+    use cam_logfile,  only: iulog
+    use phys_grid,    only: get_rlat_p, get_rlon_p
+    use time_manager, only: get_nstep
+
+    implicit none
+
+    integer, intent(in) :: icol !column(lat/lon) index
+    integer, intent(in) :: klev !vertical index
+    character(len=*), intent(in) :: cause, calling_func
+
+    !local variables
+    write(iulog,*) 'Fail due to ',cause,' in ',calling_func, '.\n', &
+         'At lat,lon,k,macmic_it, timestep=',get_rlat_p(chunk,icol),get_rlon_p(chunk,icol),klev,macmiciter,get_nstep()
+
+  end subroutine report_error_info
+
+
+end module debug_info

--- a/components/cam/src/physics/cam/debug_info.F90
+++ b/components/cam/src/physics/cam/debug_info.F90
@@ -12,11 +12,12 @@ module debug_info
   private
 
   !Variables updated during the simulation
-  integer :: macmiciter, chunk
-  !$OMP THREADPRIVATE(macmiciter,chunk )
+  integer :: macmiciter, chunk, column_id
+  !$OMP THREADPRIVATE(macmiciter,chunk, column_id )
 
   public:: &
-       get_debug_chunk, &       !update chunk info from the simulation
+       get_debug_chunk,      &  !update chunk info from the simulation
+       get_debug_column_id,  &  !update column id
        get_debug_macmiciter, &  !update macro/microphysics iteration count
        report_error_info        !report info on the current lat/lon and other simulation parameters
 
@@ -28,12 +29,23 @@ contains
 
     implicit none
 
-    integer :: chunk_in
+    integer, intent(in) :: chunk_in
 
     chunk = chunk_in
 
   end subroutine get_debug_chunk
 
+  subroutine get_debug_column_id(col_in)
+
+    !Obtain column id from p3_main (micro_p3.F90)
+
+    implicit none
+
+    integer, intent(in) :: col_in
+
+    column_id = col_in
+
+  end subroutine get_debug_chunk
 
   subroutine get_debug_macmiciter(iter)
 
@@ -48,33 +60,51 @@ contains
   end subroutine get_debug_macmiciter
 
 
-  subroutine report_error_info(cause, calling_func, icol, klev)
+  subroutine report_error_info(cause, calling_func, icol, klev, prnt_macmic)
 
     !Reports simulation parameters
     use cam_logfile,    only: iulog
     use phys_grid,      only: get_rlat_p, get_rlon_p
     use time_manager,   only: get_nstep
     use physics_utils,  only: rtype
+    use spmd_utils,     only: iam
     implicit none
 
     integer, intent(in) :: icol !column(lat/lon) index
     integer, optional, intent(in) :: klev !vertical index
-    character(len=*), intent(in) :: cause, calling_func
+    logical, optional, intent(in) :: prnt_macmic !whether print macmiciter or not
+    character(len=*),  intent(in) :: cause, calling_func
 
     !local variables
-    real(rtype), parameter::  radian2deg = 180.0_rtype/(4.0_rtype*atan(1.0_rtype)) !180/pi = 57.296
+    real(rtype), parameter ::  radian2deg = 180.0_rtype/(4.0_rtype*atan(1.0_rtype)) !180/pi = 57.296
+    character(len=1000)    :: klevstr, macmicstr
 
-    write(iulog,'(a)') '*****************************************************************'
-    write(iulog,'(a)')'Fail due to '//trim(adjustl(cause))//' in subroutine/function:'//trim(adjustl(calling_func))
-    write(iulog,'(a,f12.8,a,f12.8,a)')'Column location in degrees:(lat,lon) is:(',get_rlat_p(chunk,icol)*radian2deg,',', &
-         get_rlon_p(chunk,icol)*radian2deg,')'
-    write(iulog,'(a,i5)')'macmic_it is:', macmiciter
-    write(iulog,'(a,i5)')'timestep=',get_nstep()
-
+    !check if klev is present or not and populate klevstr accordingly
     if(present(klev)) then
-       write(iulog,'(a,i5)') 'K level is:', klev
+       write(klevstr,*)'K level is:',klev
+    else
+       klevstr = 'K level not present'
     endif
 
+    !check if prnt_macmic is present or not and populate macmicstr accordingly
+    if(present(prnt_macmic) .and. prnt_macmic) then
+       write(macmicstr,*)'macmic_it is:', macmiciter
+    else
+       macmicstr = 'prnt_macmic is not present or prnt_macmic is False '
+    endif
+
+    !print proc info in the message and issue only one write statement
+    write(iulog,'(a,/,a,i5,a/,a,/,a,f12.8,a,f12.8,a,/,a,/,a,i5,/,a,/,a,i5,a,/,a)') &
+         '', &
+         '********************** Proc #', iam,' output *******************************************', &
+         'Fail due to '//trim(adjustl(cause))//' in subroutine/function:'//trim(adjustl(calling_func)), &
+         'Column location in degrees(lat,lon) is:(',get_rlat_p(chunk,icol)*radian2deg,',', &
+         get_rlon_p(chunk,icol)*radian2deg,')', &
+         trim(adjustl(macmicstr)), &
+         'timestep:',get_nstep(), &
+         trim(adjustl(klevstr)), &
+         '********************** Proc #', iam,' output Ends***************************************', &
+         ''
   end subroutine report_error_info
 
 

--- a/components/cam/src/physics/cam/debug_info.F90
+++ b/components/cam/src/physics/cam/debug_info.F90
@@ -12,8 +12,8 @@ module debug_info
   private
 
   !Variables updated during the simulation
-  integer :: macmiciter, chunk, column_id
-  !$OMP THREADPRIVATE(macmiciter,chunk, column_id )
+  integer :: macmiciter, chunk, icol_p3
+  !$OMP THREADPRIVATE(macmiciter,chunk, icol_p3 )
 
   public:: &
        get_debug_chunk,      &  !update chunk info from the simulation
@@ -43,9 +43,9 @@ contains
 
     integer, intent(in) :: col_in
 
-    column_id = col_in
+    icol_p3 = col_in
 
-  end subroutine get_debug_chunk
+  end subroutine get_debug_column_id
 
   subroutine get_debug_macmiciter(iter)
 
@@ -70,14 +70,18 @@ contains
     use spmd_utils,     only: iam
     implicit none
 
-    integer, intent(in) :: icol !column(lat/lon) index
-    integer, optional, intent(in) :: klev !vertical index
-    logical, optional, intent(in) :: prnt_macmic !whether print macmiciter or not
+    !intent-ins
     character(len=*),  intent(in) :: cause, calling_func
 
+    !intent-in and optional
+    integer, optional, intent(in) :: icol !column(lat/lon) index
+    integer, optional, intent(in) :: klev !vertical index
+    logical, optional, intent(in) :: prnt_macmic !whether print macmiciter or not
+
     !local variables
-    real(rtype), parameter ::  radian2deg = 180.0_rtype/(4.0_rtype*atan(1.0_rtype)) !180/pi = 57.296
-    character(len=1000)    :: klevstr, macmicstr
+    real(rtype), parameter :: radian2deg = 180.0_rtype/(4.0_rtype*atan(1.0_rtype)) !180/pi = 57.296
+    real(rtype)            :: lat, lon
+    character(len=1000)    :: klevstr, macmicstr, icolstr
 
     !check if klev is present or not and populate klevstr accordingly
     if(present(klev)) then
@@ -93,17 +97,28 @@ contains
        macmicstr = 'prnt_macmic is not present or prnt_macmic is False '
     endif
 
+    !update icolstr to add info about the column used and compute lat lon
+    if(present(icol)) then
+       icolstr = '*NOTE*: Using user specified column index for computing lat-lons'
+       lat = get_rlat_p(chunk,icol)*radian2deg
+       lon = get_rlon_p(chunk,icol)*radian2deg
+    else
+       icolstr = '*NOTE*: Using auto updated column index from P3 for computing lat-lons'
+       lat = get_rlat_p(chunk,icol_p3)*radian2deg
+       lon = get_rlon_p(chunk,icol_p3)*radian2deg
+    endif
+
     !print proc info in the message and issue only one write statement
-    write(iulog,'(a,/,a,i5,a/,a,/,a,f12.8,a,f12.8,a,/,a,/,a,i5,/,a,/,a,i5,a,/,a)') &
+    write(iulog,'(a,/,a,i5,a,/,a,/,a,/,a,f12.8,a,f12.8,a,/,a,/,a,i5,/,a,/,a,i5,a,/,a)') &
          '', &
          '********************** Proc #', iam,' output *******************************************', &
          'Fail due to '//trim(adjustl(cause))//' in subroutine/function:'//trim(adjustl(calling_func)), &
-         'Column location in degrees(lat,lon) is:(',get_rlat_p(chunk,icol)*radian2deg,',', &
-         get_rlon_p(chunk,icol)*radian2deg,')', &
+         trim(adjustl(icolstr)), &
+         'Column location in degrees(lat,lon) is:(',lat,',',lon,')', &
          trim(adjustl(macmicstr)), &
          'timestep:',get_nstep(), &
          trim(adjustl(klevstr)), &
-         '********************** Proc #', iam,' output Ends***************************************', &
+         '********************** Proc #', iam,' output Ends **************************************', &
          ''
   end subroutine report_error_info
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1126,6 +1126,7 @@ contains
     !                                                                                        !
     !----------------------------------------------------------------------------------------!
 
+    use debug_info, only: get_debug_column_id
     implicit none
 
     !----- Input/ouput arguments:  ----------------------------------------------------------!
@@ -1301,6 +1302,9 @@ contains
     !==
     !-----------------------------------------------------------------------------------!
     i_loop_main: do i = its,ite  ! main i-loop (around the entire scheme)
+
+       !update column in the debug_info module
+       call get_debug_column_id(i)
 
 !      if (debug_ON) call check_values(qv,T,i,it,debug_ABORT,100,col_location)
 
@@ -1579,6 +1583,7 @@ contains
 
     use scream_abortutils, only : endscreamrun
 
+    use debug_info, only: report_error_info
     implicit none
 
     real(rtype), intent(in) :: t
@@ -1641,6 +1646,7 @@ contains
     !PMC added error checking
     else
 
+       call report_error_info('Something went wrong', 'polysvp1')
        write(err_msg,*)'** polysvp1 i_type must be 0 or 1 but is: ', &
             i_type,' temperature is:',t,' in file: ',__FILE__,' at line:',__LINE__
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -39,8 +39,7 @@
 #include "bfb_math.inc"
 
 module micro_p3
-  use debug_info
-  use module_perturb
+
    ! get real kind from utils
    use physics_utils, only: rtype,rtype8,btype
 
@@ -1111,7 +1110,7 @@ contains
        diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,  &
        pratot,prctot,p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
-       vap_ice_exchange,col_location,lchnk)
+       vap_ice_exchange,col_location)
 
     !----------------------------------------------------------------------------------------!
     !                                                                                        !
@@ -1160,7 +1159,7 @@ contains
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: mu_c       ! Size distribution shape parameter for radiation
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: lamc       ! Size distribution slope parameter for radiation
 
-    integer, intent(in)                                  :: its,ite,lchnk    ! array bounds (horizontal)
+    integer, intent(in)                                  :: its,ite    ! array bounds (horizontal)
     integer, intent(in)                                  :: kts,kte    ! array bounds (vertical)
     integer, intent(in)                                  :: it         ! time step counter NOTE: starts at 1 for first time step
 
@@ -1302,8 +1301,6 @@ contains
     !==
     !-----------------------------------------------------------------------------------!
     i_loop_main: do i = its,ite  ! main i-loop (around the entire scheme)
-
-       if(icolprnt(lchnk) == i)call report_error_info('INFO SHOULD BE lat=-38.616147,lon=353.781153', 'p3_main', i, 72)
 
 !      if (debug_ON) call check_values(qv,T,i,it,debug_ABORT,100,col_location)
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -39,7 +39,8 @@
 #include "bfb_math.inc"
 
 module micro_p3
-
+  use debug_info
+  use module_perturb
    ! get real kind from utils
    use physics_utils, only: rtype,rtype8,btype
 
@@ -1110,7 +1111,7 @@ contains
        diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,  &
        pratot,prctot,p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
-       vap_ice_exchange,col_location)
+       vap_ice_exchange,col_location,lchnk)
 
     !----------------------------------------------------------------------------------------!
     !                                                                                        !
@@ -1159,7 +1160,7 @@ contains
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: mu_c       ! Size distribution shape parameter for radiation
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: lamc       ! Size distribution slope parameter for radiation
 
-    integer, intent(in)                                  :: its,ite    ! array bounds (horizontal)
+    integer, intent(in)                                  :: its,ite,lchnk    ! array bounds (horizontal)
     integer, intent(in)                                  :: kts,kte    ! array bounds (vertical)
     integer, intent(in)                                  :: it         ! time step counter NOTE: starts at 1 for first time step
 
@@ -1301,6 +1302,8 @@ contains
     !==
     !-----------------------------------------------------------------------------------!
     i_loop_main: do i = its,ite  ! main i-loop (around the entire scheme)
+
+       if(icolprnt(lchnk) == i)call report_error_info('INFO SHOULD BE lat=-38.616147,lon=353.781153', 'p3_main', i, 72)
 
 !      if (debug_ON) call check_values(qv,T,i,it,debug_ABORT,100,col_location)
 

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -1059,7 +1059,8 @@ end subroutine micro_p3_readnl
          liq_ice_exchange(its:ite,kts:kte),& ! OUT sum of liq-ice phase change tendenices   
          vap_liq_exchange(its:ite,kts:kte),& ! OUT sun of vap-liq phase change tendencies
          vap_ice_exchange(its:ite,kts:kte),& ! OUT sum of vap-ice phase change tendencies
-         col_location(its:ite,:3)          & ! IN column locations
+         col_location(its:ite,:3),          & ! IN column locations
+         lchnk &
          )
 
     p3_main_outputs(:,:,:) = -999._rtype

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -1059,8 +1059,7 @@ end subroutine micro_p3_readnl
          liq_ice_exchange(its:ite,kts:kte),& ! OUT sum of liq-ice phase change tendenices   
          vap_liq_exchange(its:ite,kts:kte),& ! OUT sun of vap-liq phase change tendencies
          vap_ice_exchange(its:ite,kts:kte),& ! OUT sum of vap-ice phase change tendencies
-         col_location(its:ite,:3),          & ! IN column locations
-         lchnk &
+         col_location(its:ite,:3)          & ! IN column locations
          )
 
     p3_main_outputs(:,:,:) = -999._rtype

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1921,6 +1921,7 @@ subroutine tphysbc (ztodt,               &
     use subcol_utils,    only: subcol_ptend_copy, is_subcol_on
     use phys_control,    only: use_qqflx_fixer, use_mass_borrower
     use nudging,         only: Nudge_Model,Nudge_Loc_PhysOut,nudging_calc_tend
+    use debug_info,      only: get_debug_chunk, get_debug_macmiciter
 
     implicit none
 
@@ -2110,6 +2111,8 @@ subroutine tphysbc (ztodt,               &
 
     lchnk = state%lchnk
     ncol  = state%ncol
+
+    call get_debug_chunk(lchnk)
 
     rtdt = 1._r8/ztodt
 
@@ -2476,6 +2479,8 @@ end if
        snow_pcw_macmic = 0._r8
 
        do macmic_it = 1, cld_macmic_num_steps
+
+          call get_debug_macmiciter(macmic_it)
 
         if (l_st_mac) then
 

--- a/components/scream/src/physics/p3/CMakeLists.txt
+++ b/components/scream/src/physics/p3/CMakeLists.txt
@@ -14,6 +14,7 @@ set(P3_SRCS
   micro_p3_iso_f.f90
   ${SCREAM_BASE_DIR}/../cam/src/physics/cam/scream_abortutils.F90
   ${SCREAM_BASE_DIR}/../cam/src/physics/cam/micro_p3.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/cam/debug_info.F90
   ${SCREAM_BASE_DIR}/../cam/src/physics/cam/micro_p3_utils.F90
   atmosphere_microphysics.cpp
   p3_inputs_initializer.cpp


### PR DESCRIPTION
This utility can be called from anywhere below the `tphysbc` level. 
A typical usage:
1. Add `use` statement : `use debug_info, only: report_error_info`
2. call `report_error_info` providing column number (Column number not required when calling within P3's column loop)
`call report_error_info(cause, calling_func, icol, klev, prnt_macmic)` ! last 3 arguments are optional
where,
`cause` is "reason for the failure"
`calling_func` is the "function/subroutine where the call originated"
[optional]`icol` is the column number
[optional]`klev` is the k level of the location
[optional]`prnt_macmiciter` is true if macmiciter needs to be printed

I have tested this code on Compy with and without threading and it worked fine.