### PR TITLE
Aarondonahue/scorpio integration interface phase2 input

### DIFF
--- a/components/scream/src/mct_coupling/scream_scorpio_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface.cpp
@@ -12,6 +12,9 @@ using scream::Int;
 extern "C" {
 
 // Fortran routines to be called from C++
+  void register_infile_c(const std::string (&filename));
+  void grid_read_data_array_c_real_1d(const std::string &filename, const std::string &varname, const Int dim1_length, Real *hbuf);
+
   void grid_write_data_array_c_real_1d(const char*&& filename, const char*&& varname, const Int dim1_length, const Real* hbuf);
   void grid_write_data_array_c_real_2d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Real* hbuf);
   void grid_write_data_array_c_real_3d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Real* hbuf);
@@ -47,6 +50,11 @@ void register_outfile(const std::string& filename) {
   register_outfile_c(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
+void register_infile(const std::string& filename) {
+
+  register_infile_c(filename);
+}
+/* ----------------------------------------------------------------- */
 void sync_outfile(const std::string& filename) {
 
   sync_outfile_c(filename.c_str());
@@ -71,9 +79,15 @@ void eam_pio_enddef(const std::string &filename) {
   eam_pio_enddef_c(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
+void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,1>& dim_length, Real *hbuf) {
+
+  grid_read_data_array_c_real_1d(filename,varname,dim_length[0],hbuf);
+
+};
+ /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, const Real* hbuf) {
 
-  grid_write_data_array_c_real_1d(filename.c_str(),varname.c_str(),dim_length[1],hbuf);
+  grid_write_data_array_c_real_1d(filename.c_str(),varname.c_str(),dim_length[0],hbuf);
 
 };
 /* ----------------------------------------------------------------- */
@@ -97,7 +111,7 @@ void grid_write_data_array(const std::string &filename, const std::string &varna
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, const Int* hbuf) {
 
-  grid_write_data_array_c_int_1d(filename.c_str(),varname.c_str(),dim_length[1],hbuf);
+  grid_write_data_array_c_int_1d(filename.c_str(),varname.c_str(),dim_length[0],hbuf);
 
 };
 /* ----------------------------------------------------------------- */

--- a/components/scream/src/mct_coupling/scream_scorpio_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface.cpp
@@ -13,7 +13,14 @@ extern "C" {
 
 // Fortran routines to be called from C++
   void register_infile_c(const std::string (&filename));
-  void grid_read_data_array_c_real_1d(const std::string &filename, const std::string &varname, const Int dim1_length, Real *hbuf);
+  void grid_read_data_array_c_real_1d(const char*&& filename, const char*&& varname, const Int dim1_length, Real *hbuf);
+  void grid_read_data_array_c_real_2d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, Real *hbuf);
+  void grid_read_data_array_c_real_3d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, Real *hbuf);
+  void grid_read_data_array_c_real_4d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Int dim4_length, Real *hbuf);
+  void grid_read_data_array_c_int_1d(const char*&& filename, const char*&& varname, const Int dim1_length, Int *hbuf);
+  void grid_read_data_array_c_int_2d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, Int *hbuf);
+  void grid_read_data_array_c_int_3d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, Int *hbuf);
+  void grid_read_data_array_c_int_4d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Int dim4_length, Int *hbuf);
 
   void grid_write_data_array_c_real_1d(const char*&& filename, const char*&& varname, const Int dim1_length, const Real* hbuf);
   void grid_write_data_array_c_real_2d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Real* hbuf);
@@ -79,9 +86,51 @@ void eam_pio_enddef(const std::string &filename) {
   eam_pio_enddef_c(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
+void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,1>& dim_length, Int *hbuf) {
+
+  grid_read_data_array_c_int_1d(filename.c_str(),varname.c_str(),dim_length[0],hbuf);
+
+};
+/* ----------------------------------------------------------------- */
+void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,2>& dim_length, Int *hbuf) {
+
+  grid_read_data_array_c_int_2d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],hbuf);
+
+};
+/* ----------------------------------------------------------------- */
+void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,3>& dim_length, Int *hbuf) {
+
+  grid_read_data_array_c_int_3d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],hbuf);
+
+};
+/* ----------------------------------------------------------------- */
+void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,4>& dim_length, Int *hbuf) {
+
+  grid_read_data_array_c_int_4d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],dim_length[3],hbuf);
+
+};
+/* ----------------------------------------------------------------- */
 void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,1>& dim_length, Real *hbuf) {
 
-  grid_read_data_array_c_real_1d(filename,varname,dim_length[0],hbuf);
+  grid_read_data_array_c_real_1d(filename.c_str(),varname.c_str(),dim_length[0],hbuf);
+
+};
+/* ----------------------------------------------------------------- */
+void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,2>& dim_length, Real *hbuf) {
+
+  grid_read_data_array_c_real_2d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],hbuf);
+
+};
+/* ----------------------------------------------------------------- */
+void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,3>& dim_length, Real *hbuf) {
+
+  grid_read_data_array_c_real_3d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],hbuf);
+
+};
+/* ----------------------------------------------------------------- */
+void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,4>& dim_length, Real *hbuf) {
+
+  grid_read_data_array_c_real_4d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],dim_length[3],hbuf);
 
 };
  /* ----------------------------------------------------------------- */

--- a/components/scream/src/mct_coupling/scream_scorpio_interface.hpp
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface.hpp
@@ -24,11 +24,13 @@ namespace scorpio {
   void eam_init_pio_subsystem(const int mpicom, const int compid, const bool local);
   void eam_pio_finalize();
   void register_outfile(const std::string& filename);
+  void register_infile(const std::string& filename);
   void sync_outfile(const std::string& filename);
   void register_dimension(const std::string& filename,const std::string& shortname, const std::string& longname, const int length);
   void register_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
   void eam_pio_enddef(const std::string &filename);
   void pio_update_time(const std::string &filename, const Real time);
+  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, Real* hbuf);
   void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, const Real* hbuf);
   void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,2>& dim_length, const Real* hbuf);
   void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,3>& dim_length, const Real* hbuf);

--- a/components/scream/src/mct_coupling/scream_scorpio_interface.hpp
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface.hpp
@@ -31,6 +31,13 @@ namespace scorpio {
   void eam_pio_enddef(const std::string &filename);
   void pio_update_time(const std::string &filename, const Real time);
   void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, Real* hbuf);
+  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,2>& dim_length, Real* hbuf);
+  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,3>& dim_length, Real* hbuf);
+  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,4>& dim_length, Real* hbuf);
+  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, Int* hbuf);
+  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,2>& dim_length, Int* hbuf);
+  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,3>& dim_length, Int* hbuf);
+  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,4>& dim_length, Int* hbuf);
   void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, const Real* hbuf);
   void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,2>& dim_length, const Real* hbuf);
   void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,3>& dim_length, const Real* hbuf);

--- a/components/scream/src/mct_coupling/scream_scorpio_interface_iso_c.F90
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface_iso_c.F90
@@ -289,6 +289,78 @@ contains
 
   end subroutine grid_write_data_array_c_int_4d
 !=====================================================================!
+  subroutine grid_read_data_array_c_int_1d(filename_in,varname_in,dim1_length,hbuf_out) bind(c)
+    use scream_scorpio_interface, only: grid_read_data_array
+    use physics_utils, only: rtype
+
+    type(c_ptr), intent(in)                :: filename_in
+    type(c_ptr), intent(in)                :: varname_in
+    integer(kind=c_int), value, intent(in) :: dim1_length
+    integer(kind=c_int), intent(out), dimension(dim1_length) :: hbuf_out
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_read_data_array(filename,hbuf_out,varname)
+
+  end subroutine grid_read_data_array_c_int_1d
+!=====================================================================!
+  subroutine grid_read_data_array_c_int_2d(filename_in,varname_in,dim1_length,dim2_length,hbuf_out) bind(c)
+    use scream_scorpio_interface, only: grid_read_data_array
+    use physics_utils, only: rtype
+
+    type(c_ptr), intent(in)                :: filename_in
+    type(c_ptr), intent(in)                :: varname_in
+    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length
+    integer(kind=c_int), intent(out), dimension(dim1_length,dim2_length) :: hbuf_out
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_read_data_array(filename,hbuf_out,varname)
+
+  end subroutine grid_read_data_array_c_int_2d
+!=====================================================================!
+  subroutine grid_read_data_array_c_int_3d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,hbuf_out) bind(c)
+    use scream_scorpio_interface, only: grid_read_data_array
+    use physics_utils, only: rtype
+
+    type(c_ptr), intent(in)                :: filename_in
+    type(c_ptr), intent(in)                :: varname_in
+    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length,dim3_length
+    integer(kind=c_int), intent(out), dimension(dim1_length,dim2_length,dim3_length) :: hbuf_out
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_read_data_array(filename,hbuf_out,varname)
+
+  end subroutine grid_read_data_array_c_int_3d
+!=====================================================================!
+  subroutine grid_read_data_array_c_int_4d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,dim4_length,hbuf_out) bind(c)
+    use scream_scorpio_interface, only: grid_read_data_array
+    use physics_utils, only: rtype
+
+    type(c_ptr), intent(in)                :: filename_in
+    type(c_ptr), intent(in)                :: varname_in
+    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length,dim3_length,dim4_length
+    integer(kind=c_int), intent(out), dimension(dim1_length,dim2_length,dim3_length,dim4_length ) :: hbuf_out
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_read_data_array(filename,hbuf_out,varname)
+
+  end subroutine grid_read_data_array_c_int_4d
+!=====================================================================!
   subroutine grid_read_data_array_c_real_1d(filename_in,varname_in,dim1_length,hbuf_out) bind(c)
     use scream_scorpio_interface, only: grid_read_data_array
     use physics_utils, only: rtype
@@ -306,5 +378,59 @@ contains
     call grid_read_data_array(filename,hbuf_out,varname)
 
   end subroutine grid_read_data_array_c_real_1d
+!=====================================================================!
+  subroutine grid_read_data_array_c_real_2d(filename_in,varname_in,dim1_length,dim2_length,hbuf_out) bind(c)
+    use scream_scorpio_interface, only: grid_read_data_array
+    use physics_utils, only: rtype
+
+    type(c_ptr), intent(in)                :: filename_in
+    type(c_ptr), intent(in)                :: varname_in
+    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length
+    real(kind=c_real), intent(out), dimension(dim1_length,dim2_length) :: hbuf_out
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_read_data_array(filename,hbuf_out,varname)
+
+  end subroutine grid_read_data_array_c_real_2d
+!=====================================================================!
+  subroutine grid_read_data_array_c_real_3d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,hbuf_out) bind(c)
+    use scream_scorpio_interface, only: grid_read_data_array
+    use physics_utils, only: rtype
+
+    type(c_ptr), intent(in)                :: filename_in
+    type(c_ptr), intent(in)                :: varname_in
+    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length,dim3_length
+    real(kind=c_real), intent(out), dimension(dim1_length,dim2_length,dim3_length) :: hbuf_out
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_read_data_array(filename,hbuf_out,varname)
+
+  end subroutine grid_read_data_array_c_real_3d
+!=====================================================================!
+  subroutine grid_read_data_array_c_real_4d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,dim4_length,hbuf_out) bind(c)
+    use scream_scorpio_interface, only: grid_read_data_array
+    use physics_utils, only: rtype
+
+    type(c_ptr), intent(in)                :: filename_in
+    type(c_ptr), intent(in)                :: varname_in
+    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length,dim3_length,dim4_length
+    real(kind=c_real), intent(out), dimension(dim1_length,dim2_length,dim3_length,dim4_length) :: hbuf_out
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_read_data_array(filename,hbuf_out,varname)
+
+  end subroutine grid_read_data_array_c_real_4d
 !=====================================================================!
 end module scream_scorpio_interface_iso_c

--- a/components/scream/src/mct_coupling/scream_scorpio_interface_iso_c.F90
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface_iso_c.F90
@@ -40,6 +40,17 @@ contains
 
   end subroutine register_outfile_c
 !=====================================================================!
+  subroutine register_infile_c(filename_in) bind(c)
+    use scream_scorpio_interface, only : register_infile
+    type(c_ptr), intent(in) :: filename_in
+
+    character(len=256)       :: filename
+
+    call convert_c_string(filename_in,filename)
+    call register_infile(trim(filename))
+
+  end subroutine register_infile_c
+!=====================================================================!
   subroutine sync_outfile_c(filename_in) bind(c)
     use scream_scorpio_interface, only : eam_sync_piofile
     type(c_ptr), intent(in) :: filename_in
@@ -277,5 +288,23 @@ contains
     call grid_write_data_array(filename,hbuf_in,varname)
 
   end subroutine grid_write_data_array_c_int_4d
+!=====================================================================!
+  subroutine grid_read_data_array_c_real_1d(filename_in,varname_in,dim1_length,hbuf_out) bind(c)
+    use scream_scorpio_interface, only: grid_read_data_array
+    use physics_utils, only: rtype
 
+    type(c_ptr), intent(in)                :: filename_in
+    type(c_ptr), intent(in)                :: varname_in
+    integer(kind=c_int), value, intent(in) :: dim1_length
+    real(kind=c_real), intent(out), dimension(dim1_length) :: hbuf_out
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_read_data_array(filename,hbuf_out,varname)
+
+  end subroutine grid_read_data_array_c_real_1d
+!=====================================================================!
 end module scream_scorpio_interface_iso_c

--- a/components/scream/src/mct_coupling/tests/CMakeLists.txt
+++ b/components/scream/src/mct_coupling/tests/CMakeLists.txt
@@ -19,15 +19,12 @@ set (SCREAM_INCLUDE
      ${SCREAM_TPL_INCLUDE_DIRS}
      ${CSM_SHARE}
 )
-message("ASD")
-message("${ARRAY_SCORPIO_SRCS}")
-message("${SCREAM_LIBS}")
-message("${SCREAM_INCLUDE}")
 # Test atmosphere processes
 EkatCreateUnitTest(scorpio_interface "${ARRAY_SCORPIO_SRCS}" 
   LIBS ${SCREAM_LIBS} csm_share
   LIBS_DIRS ${SCREAM_INCLUDE} ${CSM_SHARE}
   INCLUDE_DIRS ${SCREAM_INCLUDE}
+  THREADS 1 4
 )
 
 configure_file(${SCREAM_DATA_DIR}/scorpio_output_baseline.nc scorpio_output_baseline.nc COPYONLY)

--- a/components/scream/src/mct_coupling/tests/scorpio_tests.cpp
+++ b/components/scream/src/mct_coupling/tests/scorpio_tests.cpp
@@ -173,15 +173,14 @@ TEST_CASE("scorpio_interface_input", "") {
   grid_read_data_array(infilename,"y",ydim,ekat::util::data(y_data));
   grid_read_data_array(infilename,"z",zdim,ekat::util::data(z_data));
 
-  int nerr = 0;
   for (decltype(x_data)::size_type ii=0;ii<x_data.size();ii++) {
-    if ( std::abs(x_data[ii] - 2.0*pi/x_data.size()*(ii+1)) > 0.0 ) {nerr++;}
+    REQUIRE( x_data[ii] == 2.0*pi/x_data.size()*(ii+1) );
   }
   for (decltype(y_data)::size_type jj=0;jj<5;jj++) {
-    if ( std::abs(y_data[jj] - 4.0*pi/y_data.size()*(jj+1)) > 0.0 ) {nerr++;}
+    REQUIRE( y_data[jj] == 4.0*pi/y_data.size()*(jj+1) );
   }
   for (decltype(z_data)::size_type kk=0;kk<2;kk++) {
-    if ( std::abs(z_data[kk] - 100*(kk+1)) > 0.0 ) {nerr++;}
+    REQUIRE( z_data[kk] == 100*(kk+1) );
   }
 
   Real dt = 1.0;


### PR DESCRIPTION
    Extension of the scream-scorpio interface to include input.
    
    This commit extends the framework already in place for accessing
    scorpio output routines to now include access to scorpio input routines.
    
    The set of unit tests is increased by one, thus a file is created and
    has output written to it in test #1.
    
    Test #2 opens that file and reads all fields in as input, testing against
    the expected field values.
    
    The testing has also been extended to include up to 4 threads.
    
    [BFB]