### PR TITLE
Make run_and_cmp output more intuitive

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -2993,7 +2993,7 @@ subroutine compute_shr_prod(nlevi, nlev, shcol, dz_zi, u_wind, v_wind, sterm)
         sterm(i,k) = u_grad**2+v_grad**2
      enddo
   enddo
-  
+
   ! Set lower and upper boundary for shear production
   ! Note that the lower bound for shear production has already
   ! been taken into account for the TKE boundary condition,

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -2990,8 +2990,7 @@ subroutine compute_shr_prod(nlevi, nlev, shcol, dz_zi, u_wind, v_wind, sterm)
         ! calculate vertical gradient of u&v wind
         u_grad = grid_dz*(u_wind(i,km1)-u_wind(i,k))
         v_grad = grid_dz*(v_wind(i,km1)-v_wind(i,k))
-        !sterm(i,k) = u_grad**2+v_grad**2 !standard approach
-        sterm(i,k) = u_grad*u_grad+v_grad*v_grad + 1.e-16_rtype !makes roundoff level change
+        sterm(i,k) = u_grad**2+v_grad**2
      enddo
   enddo
   

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -2990,10 +2990,11 @@ subroutine compute_shr_prod(nlevi, nlev, shcol, dz_zi, u_wind, v_wind, sterm)
         ! calculate vertical gradient of u&v wind
         u_grad = grid_dz*(u_wind(i,km1)-u_wind(i,k))
         v_grad = grid_dz*(v_wind(i,km1)-v_wind(i,k))
-        sterm(i,k) = u_grad**2+v_grad**2
+        !sterm(i,k) = u_grad**2+v_grad**2 !standard approach
+        sterm(i,k) = u_grad*u_grad+v_grad*v_grad + 1.e-16_rtype !makes roundoff level change
      enddo
   enddo
-
+  
   ! Set lower and upper boundary for shear production
   ! Note that the lower bound for shear production has already
   ! been taken into account for the TKE boundary condition,

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -15,10 +15,30 @@ using namespace scream;
 using namespace scream::util;
 using namespace scream::p3;
 
+  /* p3_run_and_cmp can be run in 2 modes. First, generate_baseline 
+   * runs the baseline (aka reference, probably git master) version of 
+   * the code and saves its output as a raw binary file. Then run_and_cmp
+   * runs the new/experimental version of the code and compares it against
+   * the baseline data you've saved to file. Both baseline and cmp modes
+   * start from an initial condition in ../p3_ic_cases.cpp. By default, 
+   * tests are run with log_PredictNc=true and false and also for 1 step or
+   * 6 steps. This creates a total of 4 different cases. When 6 steps are run,
+   * output for each step is considered separately. 
+   */
+
+
+/* Given a column of data for variable "label" from the reference run 
+ * (probably master) and from your new exploratory run, loop over all 
+ * heights and confirm whether or not the relative difference between  
+ * runs is within tolerance "tol". If not, print debug info. Here, "a"
+ * is the value from the reference run and "b" is from the new run.
+ */  
 template <typename Scalar>
 static Int compare (const std::string& label, const Scalar* a,
                     const Scalar* b, const Int& n, const Real& tol) {
-  Int nerr = 0;
+
+  Int nerr1 = 0;
+  Int nerr2 = 0;
   Real den = 0;
   for (Int i = 0; i < n; ++i)
     den = std::max(den, std::abs(a[i]));
@@ -26,23 +46,38 @@ static Int compare (const std::string& label, const Scalar* a,
   for (Int i = 0; i < n; ++i) {
     if (std::isnan(a[i]) || std::isinf(a[i]) ||
         std::isnan(b[i]) || std::isinf(b[i])) {
-      ++nerr;
+      ++nerr1;
       continue;
     }
+    
     const auto num = std::abs(a[i] - b[i]);
     if (num > tol*den) {
-      ++nerr;
+      ++nerr2;
       worst = std::max(worst, num);
     }
   }
-  if (nerr)
-    std::cout << label << " nerr " << nerr << " worst " << (worst/den)
-              << " with denominator " << den << "\n";
-  return nerr;
+
+  if (nerr1) {
+    std::cout << label << " has " << nerr1 << " infs + nans.\n";
+
+  }
+  
+  if (nerr2) {
+    std::cout << label << " > tol " << nerr2 << " times. Max rel diff= " << (worst/den)
+	      << " normalized by ref impl val=" << den << ".\n";
+
+  }
+  
+  return nerr1 + nerr2;
 }
 
-Int compare (const std::string& label, const double& tol,
+ /* When called with the below 3 args, compare loops over all variables 
+  * and calls the above version of "compare" to check for and report 
+  * large discrepancies.
+  */
+ Int compare (const double& tol,
              const FortranData::Ptr& ref, const FortranData::Ptr& d) {
+ 
   Int nerr = 0;
   FortranDataIterator refi(ref), di(d);
   scream_assert(refi.nfield() == di.nfield());
@@ -50,8 +85,7 @@ Int compare (const std::string& label, const double& tol,
     const auto& fr = refi.getfield(i);
     const auto& fd = di.getfield(i);
     scream_assert(fr.size == fd.size);
-    nerr += compare(label + std::string(" ") + fr.name,
-                    fr.data, fd.data, fr.size, tol);
+    nerr += compare(fr.name, fr.data, fd.data, fr.size, tol);
   }
   return nerr;
 }
@@ -59,7 +93,8 @@ Int compare (const std::string& label, const double& tol,
 struct Baseline {
   Baseline () {
     for (const bool log_predictNc : {true, false})
-      for (const int it : {1, 6})
+      for (const int it : {1, 6})   // # of steps to run is either 1 or 6.
+	//                 initial condit,     dt,  nsteps, prescribe or predict nc
         params_.push_back({ic::Factory::mixed, 300, it, log_predictNc});
   }
 
@@ -98,10 +133,10 @@ struct Baseline {
         set_params(ps, *d);
         p3_init();
         for (int it=0; it<ps.it; it++) {
-          std::cout << "--- checking case # " << case_num << ", it = " << it+1 << "/" << ps.it << " ---\n" << std::flush;
+          std::cout << "--- checking case # " << case_num << ", timestep # " << it+1 << " of " << ps.it << " ---\n" << std::flush;
           read(fid, d_ref);
           p3_main(*d, use_fortran);
-          ne = compare("ref", tol, d_ref, d);
+          ne = compare(tol, d_ref, d);
           if (ne) std::cout << "Ref impl failed.\n";
           nerr += ne;
         }

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -93,9 +93,8 @@ static Int compare (const std::string& label, const Scalar* a,
 struct Baseline {
   Baseline () {
     for (const bool log_predictNc : {true, false})
-      for (const int it : {1, 6})   // # of steps to run is either 1 or 6.
-	//                 initial condit,     dt,  nsteps, prescribe or predict nc
-        params_.push_back({ic::Factory::mixed, 300, it, log_predictNc});
+      //                 initial condit,     dt,  nsteps, prescribe or predict nc
+      params_.push_back({ic::Factory::mixed, 300, 6, log_predictNc});
   }
 
   Int generate_baseline (const std::string& filename, bool use_fortran) {

--- a/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
@@ -15,10 +15,30 @@ using namespace scream;
 using namespace scream::util;
 using namespace scream::shoc;
 
+  /* shoc_run_and_cmp can be run in 2 modes. First, generate_baseline 
+   * runs the baseline (aka reference, probably git master) version of 
+   * the code and saves its output as a raw binary file. Then run_and_cmp
+   * runs the new/experimental version of the code and compares it against
+   * the baseline data you've saved to file. Both baseline and cmp modes
+   * start from an initial condition in ../shoc_ic_cases.cpp. Each call to 
+   * shoc_main loops through nadv=15 steps. On top of this, shoc_main is 
+   * called iteratively num_iters=10 steps, performing checks and potentially
+   * writing output each time. This means that shoc_run_and_cmp is really 
+   * a single 150-step shoc run.
+   */
+  
 template <typename Scalar>
 static Int compare (const std::string& label, const Scalar* a,
                     const Scalar* b, const Int& n, const Real& tol) {
-  Int nerr = 0;
+  /* Given a column of data for variable "label" from the reference run 
+   * (probably master) and from your new exploratory run, loop over all 
+   * heights and confirm whether or not the relative difference between  
+   * runs is within tolerance "tol". If not, print debug info. Here, "a"
+   * is the value from the reference run and "b" is from the new run.
+   */
+
+  Int nerr1 = 0;
+  Int nerr2 = 0;
   Real den = 0;
   for (Int i = 0; i < n; ++i)
     den = std::max(den, std::abs(a[i]));
@@ -26,24 +46,38 @@ static Int compare (const std::string& label, const Scalar* a,
   for (Int i = 0; i < n; ++i) {
     if (std::isnan(a[i]) || std::isinf(a[i]) ||
         std::isnan(b[i]) || std::isinf(b[i])) {
-      ++nerr;
+      ++nerr1;
       continue;
     }
+    
     const auto num = std::abs(a[i] - b[i]);
     if (num > tol*den) {
-      ++nerr;
+      ++nerr2;
       worst = std::max(worst, num);
     }
   }
-  if (nerr) {
-    std::cout << label << " nerr " << nerr << " worst " << (worst/den)
-              << " with denominator " << den << "\n";
+
+  if (nerr1) {
+    std::cout << label << " has " << nerr1 << " infs + nans.\n";
+
   }
-  return nerr;
+  
+  if (nerr2) {
+    std::cout << label << " > tol " << nerr2 << " times. Max rel diff= " << (worst/den)
+	      << " normalized by ref impl val=" << den << ".\n";
+
+  }
+  
+  return nerr1 + nerr2;
 }
 
 Int compare (const std::string& label, const double& tol,
              const FortranData::Ptr& ref, const FortranData::Ptr& d) {
+  /* When called with the above 4 args, compare loops over all variables 
+   * and calls the above version of "compare" to check for and report 
+   * large discrepancies.
+   */
+  
   Int nerr = 0;
   FortranDataIterator refi(ref), di(d);
   scream_assert(refi.nfield() == di.nfield());
@@ -51,8 +85,7 @@ Int compare (const std::string& label, const double& tol,
     const auto& fr = refi.getfield(i);
     const auto& fd = di.getfield(i);
     scream_assert(fr.size == fd.size);
-    nerr += compare(label + std::string(" ") + fr.name,
-                    fr.data, fd.data, fr.size, tol);
+    nerr += compare(fr.name, fr.data, fd.data, fr.size, tol);
   }
   return nerr;
 }
@@ -101,8 +134,8 @@ struct Baseline {
         set_params(ps, *d);
         shoc_init(ps.nlev, use_fortran);
         for (int it = 0; it < num_iters; it++) {
-          std::cout << "--- checking case # " << case_num << ", it = " << it+1
-                    << "/" << num_iters << " ---\n" << std::flush;
+          std::cout << "--- checking case # " << case_num << ", timestep = " << (it+1)*ps.nadv
+                     << " ---\n" << std::flush;
           read(fid, d_ref);
           shoc_main(*d);
           ne = compare("ref", tol, d_ref, d);

--- a/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
@@ -21,21 +21,22 @@ using namespace scream::shoc;
    * runs the new/experimental version of the code and compares it against
    * the baseline data you've saved to file. Both baseline and cmp modes
    * start from an initial condition in ../shoc_ic_cases.cpp. Each call to 
-   * shoc_main loops through nadv=15 steps. On top of this, shoc_main is 
-   * called iteratively num_iters=10 steps, performing checks and potentially
-   * writing output each time. This means that shoc_run_and_cmp is really 
-   * a single 150-step shoc run.
+   * shoc_main loops through nadv=15 steps with dt=5 min. On top of this, 
+   * shoc_main is called iteratively num_iters=10 steps, performing checks 
+   * and potentiallywriting output each time. This means that shoc_run_and_cmp 
+   * is really a single 150-step shoc run.
    */
   
+
+/* Given a column of data for variable "label" from the reference run 
+ * (probably master) and from your new exploratory run, loop over all 
+ * heights and confirm whether or not the relative difference between  
+ * runs is within tolerance "tol". If not, print debug info. Here, "a"
+ * is the value from the reference run and "b" is from the new run.
+ */
 template <typename Scalar>
 static Int compare (const std::string& label, const Scalar* a,
                     const Scalar* b, const Int& n, const Real& tol) {
-  /* Given a column of data for variable "label" from the reference run 
-   * (probably master) and from your new exploratory run, loop over all 
-   * heights and confirm whether or not the relative difference between  
-   * runs is within tolerance "tol". If not, print debug info. Here, "a"
-   * is the value from the reference run and "b" is from the new run.
-   */
 
   Int nerr1 = 0;
   Int nerr2 = 0;
@@ -71,12 +72,12 @@ static Int compare (const std::string& label, const Scalar* a,
   return nerr1 + nerr2;
 }
 
-Int compare (const std::string& label, const double& tol,
+ /* When called with the below 3 args, compare loops over all variables 
+  * and calls the above version of "compare" to check for and report 
+  * large discrepancies.
+  */
+ Int compare (const double& tol,
              const FortranData::Ptr& ref, const FortranData::Ptr& d) {
-  /* When called with the above 4 args, compare loops over all variables 
-   * and calls the above version of "compare" to check for and report 
-   * large discrepancies.
-   */
   
   Int nerr = 0;
   FortranDataIterator refi(ref), di(d);
@@ -134,11 +135,11 @@ struct Baseline {
         set_params(ps, *d);
         shoc_init(ps.nlev, use_fortran);
         for (int it = 0; it < num_iters; it++) {
-          std::cout << "--- checking case # " << case_num << ", timestep = " << (it+1)*ps.nadv
+          std::cout << "--- checking case # " << case_num << ", timestep # = " << (it+1)*ps.nadv
                      << " ---\n" << std::flush;
           read(fid, d_ref);
           shoc_main(*d);
-          ne = compare("ref", tol, d_ref, d);
+          ne = compare(tol, d_ref, d);
           if (ne) std::cout << "Ref impl failed.\n";
           nerr += ne;
         }


### PR DESCRIPTION
I just dug through shoc_run_and_cmp because I was surprised to see infs in its output. It took me a while to grok what it was doing so I added comments. I also changed its output to be more intuitive. Below is an example of what the new output looks like:

```
: --- checking case # 1, timestep = 150 ---
94: host_dse > tol 572 times. Max rel diff= 0.0894023 normalized by ref impl val=360733.
94: tke > tol 336 times. Max rel diff= 4.71632e-07 normalized by ref impl val=0.0309735.
94: thetal > tol 562 times. Max rel diff= 1.4753e-10 normalized by ref impl val=311.421.
94: qw > tol 572 times. Max rel diff= 9.55217e-09 normalized by ref impl val=0.0165071.
94: u_wind > tol 574 times. Max rel diff= 1.93644e-08 normalized by ref impl val=8.5547.
```
 Are folks happy with the new version? If so, I'll make similar changes to p3_run_and_cmp.