### PR TITLE
Bugfix: fall speed uses incld quantities which aren't updated during sedimentation

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3363,7 +3363,7 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
                   call get_cloud_dsd2(qc_incld(k),nc_incld(k),mu_c(k),rho(k),nu,dnu,   &
                        lamc(k),tmp1,tmp2,lcldm(k))
 
-                  nc(k) = nc_incld(k)*lcldm(k)
+                  !nc(k) = nc_incld(k)*lcldm(k) !Again, nc is already updated by gen_sed and isn't used below, so why do this? and if so why not also qc?
                   dum = 1._rtype / bfb_pow(lamc(k), bcn)
                   V_qc(k) = acn(k)*bfb_gamma(4._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+4._rtype))
                   V_nc(k) = acn(k)*bfb_gamma(1._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+1._rtype))
@@ -3374,6 +3374,10 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
             enddo kloop_sedi_c2
 
             call generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_max, dt_left, prt_accum, inv_dzq, inv_rho, rho, num_arrays, vs, fluxes, qnr)
+
+            !Update _incld values with end-of-step cell-ave values
+            qc_incld(:) = qc(:)/lcldm(:)
+            nc_incld(:) = nc(:)/lcldm(:)
 
          enddo substep_sedi_c2
       else
@@ -3386,7 +3390,7 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
                qc_notsmall_c1: if (qc_incld(k)>qsmall) then
                   call get_cloud_dsd2(qc_incld(k),nc_incld(k),mu_c(k),rho(k),nu,dnu,   &
                        lamc(k),tmp1,tmp2,lcldm(k))
-                  nc(k) = nc_incld(k)*lcldm(k)
+                  !nc(k) = nc_incld(k)*lcldm(k) !Again, nc is already getting updated by gen_sed, so why do here? and if so why not also qc?
                   dum = 1._rtype / bfb_pow(lamc(k), bcn)
                   V_qc(k) = acn(k)*bfb_gamma(4._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+4._rtype))
                endif qc_notsmall_c1
@@ -3396,6 +3400,10 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
 
             call generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_max, dt_left, prt_accum, inv_dzq, inv_rho, rho, 1, vs, fluxes, qnr)
 
+            !Update _incld values with end-of-step cell-ave values
+            qc_incld(:) = qc(:)/lcldm(:)
+            nc_incld(:) = nc(:)/lcldm(:)
+            
          enddo substep_sedi_c1
 
       endif two_moment
@@ -3511,6 +3519,10 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,   &
             rflx(k+1) = rflx(k+1) + flux_qx(k) ! AaronDonahue
          enddo
 
+         !Update _incld values with end-of-step cell-ave values
+         qr_incld(:) = qr(:)/rcldm(:)
+         nr_incld(:) = nr(:)/rcldm(:)
+         
       enddo substep_sedi_r
 
       prt_liq = prt_liq + prt_accum*inv_rhow*odt
@@ -3543,7 +3555,10 @@ subroutine compute_rain_fall_velocity(qr_incld, rcldm, rhofacr, nr, nr_incld, mu
 
    call find_lookupTable_indices_3(dumii,dumjj,dum1,rdumii,rdumjj,inv_dum3,mu_r,lamr)
 
-   nr = nr_incld*rcldm
+   !nr is not used elsewhere in this function. Here, the updated value from generalized_sed
+   !is getting overwritten with the incld value which wasn't getting updated until this PR.
+   !And why is nr getting updated but not qr? Should delete nr from this function entirely.
+   !nr = nr_incld*rcldm 
 
    !mass-weighted fall speed:
 
@@ -3698,6 +3713,12 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
 
          call generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_max, dt_left, prt_accum, inv_dzq, inv_rho, rho, num_arrays, vs, fluxes, qnr)
 
+         !update _incld variables
+         qitot_incld(:) = qi(:)/icldm(:)
+         nitot_incld(:) = ni(:)/icldm(:)
+         qirim_incld(:) = qirirm(:)/icldm(:)
+         birim_incld(:) = birim(:)/icldm(:)
+         
       enddo substep_sedi_i
 
       prt_sol = prt_sol + prt_accum*inv_rhow*odt

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3280,7 +3280,6 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
    integer, intent(in) :: kts, kte
    integer, intent(in) :: ktop, kbot, kdir
 
-   real(rtype), intent(in), dimension(kts:kte) :: qc_incld
    real(rtype), intent(in), dimension(kts:kte) :: rho
    real(rtype), intent(in), dimension(kts:kte) :: inv_rho
    real(rtype), intent(in), dimension(kts:kte) :: lcldm
@@ -3293,6 +3292,7 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
 
    real(rtype), intent(inout), dimension(kts:kte), target :: qc
    real(rtype), intent(inout), dimension(kts:kte), target :: nc
+   real(rtype), intent(inout), dimension(kts:kte) :: qc_incld
    real(rtype), intent(inout), dimension(kts:kte) :: nc_incld
    real(rtype), intent(inout), dimension(kts:kte) :: mu_c
    real(rtype), intent(inout), dimension(kts:kte) :: lamc
@@ -3376,6 +3376,8 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
             call generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_max, dt_left, prt_accum, inv_dzq, inv_rho, rho, num_arrays, vs, fluxes, qnr)
 
             !Update _incld values with end-of-step cell-ave values
+            !Note that lcldm is set in interface to have min of mincld=1e-4
+            !so dividing by it is fine.
             qc_incld(:) = qc(:)/lcldm(:)
             nc_incld(:) = nc(:)/lcldm(:)
 
@@ -3401,6 +3403,8 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
             call generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_max, dt_left, prt_accum, inv_dzq, inv_rho, rho, 1, vs, fluxes, qnr)
 
             !Update _incld values with end-of-step cell-ave values
+            !Note that lcldm is set in interface to have min of mincld=1e-4
+            !so dividing by it is fine.
             qc_incld(:) = qc(:)/lcldm(:)
             nc_incld(:) = nc(:)/lcldm(:)
             
@@ -3426,7 +3430,6 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,   &
    integer, intent(in) :: kts, kte
    integer, intent(in) :: ktop, kbot, kdir
 
-   real(rtype), intent(in), dimension(kts:kte) :: qr_incld
 
    real(rtype), intent(in), dimension(kts:kte) :: rho
    real(rtype), intent(in), dimension(kts:kte) :: inv_rho
@@ -3438,6 +3441,7 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,   &
 
    real(rtype), intent(inout), target, dimension(kts:kte) :: qr
    real(rtype), intent(inout), target, dimension(kts:kte) :: nr
+   real(rtype), intent(inout), dimension(kts:kte) :: qr_incld
    real(rtype), intent(inout), dimension(kts:kte) :: nr_incld
    real(rtype), intent(inout), dimension(kts:kte) :: mu_r
    real(rtype), intent(inout), dimension(kts:kte) :: lamr
@@ -3520,6 +3524,8 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,   &
          enddo
 
          !Update _incld values with end-of-step cell-ave values
+         !Note that rcldm is set in interface to have min of mincld=1e-4
+         !so dividing by it is fine.
          qr_incld(:) = qr(:)/rcldm(:)
          nr_incld(:) = nr(:)/rcldm(:)
          
@@ -3714,9 +3720,11 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
          call generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_max, dt_left, prt_accum, inv_dzq, inv_rho, rho, num_arrays, vs, fluxes, qnr)
 
          !update _incld variables
-         qitot_incld(:) = qi(:)/icldm(:)
-         nitot_incld(:) = ni(:)/icldm(:)
-         qirim_incld(:) = qirirm(:)/icldm(:)
+         !Note that icldm is set in interface to have min of mincld=1e-4
+         !so dividing by it is fine.
+         qitot_incld(:) = qitot(:)/icldm(:)
+         nitot_incld(:) = nitot(:)/icldm(:)
+         qirim_incld(:) = qirim(:)/icldm(:)
          birim_incld(:) = birim(:)/icldm(:)
          
       enddo substep_sedi_i

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -445,7 +445,6 @@ end subroutine prevent_ice_overdepletion_c
     ! arguments
     integer(kind=c_int), value, intent(in) :: kts, kte, ktop, kbot, kdir
 
-    real(kind=c_real), intent(in), dimension(kts:kte) :: qc_incld
     real(kind=c_real), intent(in), dimension(kts:kte) :: rho
     real(kind=c_real), intent(in), dimension(kts:kte) :: inv_rho
     real(kind=c_real), intent(in), dimension(kts:kte) :: lcldm
@@ -458,6 +457,7 @@ end subroutine prevent_ice_overdepletion_c
 
     real(kind=c_real), intent(inout), dimension(kts:kte) :: qc
     real(kind=c_real), intent(inout), dimension(kts:kte) :: nc
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: qc_incld
     real(kind=c_real), intent(inout), dimension(kts:kte) :: nc_incld
     real(kind=c_real), intent(inout), dimension(kts:kte) :: mu_c
     real(kind=c_real), intent(inout), dimension(kts:kte) :: lamc
@@ -513,8 +513,6 @@ end subroutine prevent_ice_overdepletion_c
 
     integer(kind=c_int), value, intent(in) :: kts, kte, ktop, kbot, kdir
 
-    real(kind=c_real), intent(in), dimension(kts:kte) :: qr_incld
-
     real(kind=c_real), intent(in), dimension(kts:kte) :: rho
     real(kind=c_real), intent(in), dimension(kts:kte) :: inv_rho
     real(kind=c_real), intent(in), dimension(kts:kte) :: rhofacr
@@ -524,6 +522,7 @@ end subroutine prevent_ice_overdepletion_c
 
     real(kind=c_real), intent(inout), target, dimension(kts:kte) :: qr
     real(kind=c_real), intent(inout), target, dimension(kts:kte) :: nr
+    real(kind=c_real), intent(inout), dimension(kts:kte) :: qr_incld
     real(kind=c_real), intent(inout), dimension(kts:kte) :: nr_incld
     real(kind=c_real), intent(inout), dimension(kts:kte) :: mu_r
     real(kind=c_real), intent(inout), dimension(kts:kte) :: lamr

--- a/components/scream/src/physics/p3/p3_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_cloud_sed_impl.hpp
@@ -15,7 +15,7 @@ template <typename S, typename D>
 KOKKOS_FUNCTION
 void Functions<S,D>
 ::cloud_sedimentation(
-    const uview_1d<const Spack>& qc_incld,
+    const uview_1d<Spack>& qc_incld,
     const uview_1d<const Spack>& rho,
     const uview_1d<const Spack>& inv_rho,
     const uview_1d<const Spack>& lcldm,
@@ -92,8 +92,11 @@ void Functions<S,D>
             // compute Vq, Vn
             Spack nu, cdist, cdist1, dum;
             get_cloud_dsd2(qc_incld(pk), nc_incld(pk), mu_c(pk), rho(pk), nu, dnu, lamc(pk), cdist, cdist1, lcldm(pk), qc_gt_small);
-            nc(pk).set(qc_gt_small, nc_incld(pk)*lcldm(pk));
-            dum = 1 / (pack::pow(lamc(pk), bcn));
+
+	    //Doesn't make sense to do this here
+            //nc(pk).set(qc_gt_small, nc_incld(pk)*lcldm(pk));
+
+	    dum = 1 / (pack::pow(lamc(pk), bcn));
             V_qc(pk).set(qc_gt_small, acn(pk)*pack::tgamma(4 + bcn + mu_c(pk)) * dum / (pack::tgamma(mu_c(pk)+4)));
             if (log_predictNc) {
               V_nc(pk).set(qc_gt_small, acn(pk)*pack::tgamma(1 + bcn + mu_c(pk)) * dum / (pack::tgamma(mu_c(pk)+1)));
@@ -113,7 +116,16 @@ void Functions<S,D>
       else {
         generalized_sedimentation<1>(rho, inv_rho, inv_dzq, team, nk, k_qxtop, k_qxbot, kbot, kdir, Co_max, dt_left, prt_accum, flux_ptr, v_ptr, qr_ptr);
       }
-    }
+
+      //Update _incld values with end-of-step cell-ave values
+      //No prob w/ div by rcldm because set to min of 1e-4 in interface.
+      Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(team, qc.extent(0)), [&] (int pk) {
+	  qc_incld(pk)=qc(pk)/lcldm(pk);
+	  nc_incld(pk)=nc(pk)/lcldm(pk);
+	});
+      
+    } //end CFL substep loop
 
     Kokkos::single(
       Kokkos::PerTeam(team), [&] () {

--- a/components/scream/src/physics/p3/p3_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_cloud_sed_impl.hpp
@@ -118,7 +118,7 @@ void Functions<S,D>
       }
 
       //Update _incld values with end-of-step cell-ave values
-      //No prob w/ div by rcldm because set to min of 1e-4 in interface.
+      //No prob w/ div by lcldm because set to min of 1e-4 in interface.
       Kokkos::parallel_for(
         Kokkos::TeamThreadRange(team, qc.extent(0)), [&] (int pk) {
 	  qc_incld(pk)=qc(pk)/lcldm(pk);

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -271,7 +271,7 @@ struct Functions
   // Cloud sedimentation
   KOKKOS_FUNCTION
   static void cloud_sedimentation(
-    const uview_1d<const Spack>& qc_incld,
+    const uview_1d<Spack>& qc_incld,
     const uview_1d<const Spack>& rho,
     const uview_1d<const Spack>& inv_rho,
     const uview_1d<const Spack>& lcldm,
@@ -299,7 +299,7 @@ struct Functions
     const uview_1d<const Spack>& rhofacr,
     const uview_1d<const Spack>& rcldm,
     const uview_1d<const Spack>& inv_dzq,
-    const uview_1d<const Spack>& qr_incld,
+    const uview_1d<Spack>& qr_incld,
     const MemberType& team,
     const Workspace& workspace,
     const view_2d_table& vn_table, const view_2d_table& vm_table,


### PR DESCRIPTION
rain, ice, and cloud sedimentation computes fall speeds every CFL-required substep, but does so using _incld variables. But only cell-ave values are advected downward and updated each CFL substep. As a result, precip collects in the lowest level with non-zero mass in the first CFL substep. This PR just adds X_incld = X/cldfrac updates at the end of each CFL substep. 

Thanks to @ambrad for identifying the problem!