### PR TITLE
Fix read/write routines to allow for # mpi rank > 1 in scorpio_interface

### DIFF
--- a/components/scream/src/mct_coupling/CMakeLists.txt
+++ b/components/scream/src/mct_coupling/CMakeLists.txt
@@ -49,7 +49,7 @@ set(ATM_SRC
   dead_mod.F90
   scream_scorpio_interface.F90
   scream_scorpio_interface.cpp
-  scream_scorpio_interface_iso_c.F90
+  scream_scorpio_interface_iso_c2f.F90
   ${SCREAM_BASE_DIR}/../cam/src/physics/cam/physics_utils.F90
 )
 

--- a/components/scream/src/mct_coupling/scream_scorpio_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface.cpp
@@ -12,15 +12,11 @@ using scream::Int;
 extern "C" {
 
 // Fortran routines to be called from C++
-  void register_infile_c(const std::string (&filename));
-  void grid_read_data_array_c_real_1d(const char*&& filename, const char*&& varname, const Int dim1_length, Real *hbuf);
-  void grid_read_data_array_c_real_2d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, Real *hbuf);
-  void grid_read_data_array_c_real_3d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, Real *hbuf);
-  void grid_read_data_array_c_real_4d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Int dim4_length, Real *hbuf);
-  void grid_read_data_array_c_int_1d(const char*&& filename, const char*&& varname, const Int dim1_length, Int *hbuf);
-  void grid_read_data_array_c_int_2d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, Int *hbuf);
-  void grid_read_data_array_c_int_3d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, Int *hbuf);
-  void grid_read_data_array_c_int_4d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Int dim4_length, Int *hbuf);
+  void register_infile_c(const char*&& filename);
+  void set_decomp_c(const char*&& filename);
+  void set_dof_c(const char*&& filename,const char*&& varname,const Int dof_len,const Int *x_dof);
+  void grid_read_data_array_c_real(const char*&& filename, const char*&& varname, const Int dim1_length, Real *hbuf);
+  void grid_read_data_array_c_int(const char*&& filename, const char*&& varname, const Int dim1_length, Int *hbuf);
 
   void grid_write_data_array_c_real_1d(const char*&& filename, const char*&& varname, const Int dim1_length, const Real* hbuf);
   void grid_write_data_array_c_real_2d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Real* hbuf);
@@ -34,9 +30,11 @@ extern "C" {
   void eam_pio_finalize_c();
   void register_outfile_c(const char*&& filename);
   void sync_outfile_c(const char*&& filename);
+  void eam_pio_closefile_c(const char*&& filename);
   void pio_update_time_c(const char*&& filename,const Real time);
   void register_dimension_c(const char*&& filename, const char*&& shortname, const char*&& longname, const int length);
   void register_variable_c(const char*&& filename,const char*&& shortname, const char*&& longname, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
+  void get_variable_c(const char*&& filename,const char*&& shortname, const char*&& longname, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
   void eam_pio_enddef_c(const char*&& filename);
 
 } // extern C
@@ -57,14 +55,29 @@ void register_outfile(const std::string& filename) {
   register_outfile_c(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
+void eam_pio_closefile(const std::string& filename) {
+
+  eam_pio_closefile_c(filename.c_str());
+}
+/* ----------------------------------------------------------------- */
 void register_infile(const std::string& filename) {
 
-  register_infile_c(filename);
+  register_infile_c(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
 void sync_outfile(const std::string& filename) {
 
   sync_outfile_c(filename.c_str());
+}
+/* ----------------------------------------------------------------- */
+void set_decomp(const std::string& filename) {
+
+  set_decomp_c(filename.c_str());
+}
+/* ----------------------------------------------------------------- */
+void set_dof(const std::string& filename, const std::string& varname, const Int dof_len, const Int* x_dof) {
+
+  set_dof_c(filename.c_str(),varname.c_str(),dof_len,x_dof);
 }
 /* ----------------------------------------------------------------- */
 void pio_update_time(const std::string& filename, const Real time) {
@@ -77,6 +90,11 @@ void register_dimension(const std::string &filename, const std::string& shortnam
   register_dimension_c(filename.c_str(), shortname.c_str(), longname.c_str(), length);
 }
 /* ----------------------------------------------------------------- */
+void get_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
+
+  get_variable_c(filename.c_str(), shortname.c_str(), longname.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
+}
+/* ----------------------------------------------------------------- */
 void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
 
   register_variable_c(filename.c_str(), shortname.c_str(), longname.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
@@ -86,54 +104,30 @@ void eam_pio_enddef(const std::string &filename) {
   eam_pio_enddef_c(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,1>& dim_length, Int *hbuf) {
+void grid_read_data_array(const std::string &filename, const std::string &varname, const Int& dim_length, Int *hbuf) {
 
-  grid_read_data_array_c_int_1d(filename.c_str(),varname.c_str(),dim_length[0],hbuf);
-
-};
-/* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,2>& dim_length, Int *hbuf) {
-
-  grid_read_data_array_c_int_2d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],hbuf);
+  grid_read_data_array_c_int(filename.c_str(),varname.c_str(),dim_length,hbuf);
 
 };
 /* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,3>& dim_length, Int *hbuf) {
+void grid_read_data_array(const std::string &filename, const std::string &varname, const Int& dim_length, Real *hbuf) {
 
-  grid_read_data_array_c_int_3d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],hbuf);
-
-};
-/* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,4>& dim_length, Int *hbuf) {
-
-  grid_read_data_array_c_int_4d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],dim_length[3],hbuf);
+  grid_read_data_array_c_real(filename.c_str(),varname.c_str(),dim_length,hbuf);
 
 };
 /* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,1>& dim_length, Real *hbuf) {
+void grid_write_data_array(const std::string &filename, const std::string &varname, const Int& dim_length, const Real* hbuf) {
 
-  grid_read_data_array_c_real_1d(filename.c_str(),varname.c_str(),dim_length[0],hbuf);
-
-};
-/* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,2>& dim_length, Real *hbuf) {
-
-  grid_read_data_array_c_real_2d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],hbuf);
+  grid_write_data_array_c_real_1d(filename.c_str(),varname.c_str(),dim_length,hbuf);
 
 };
 /* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,3>& dim_length, Real *hbuf) {
+void grid_write_data_array(const std::string &filename, const std::string &varname, const Int& dim_length, const Int* hbuf) {
 
-  grid_read_data_array_c_real_3d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],hbuf);
+  grid_write_data_array_c_int_1d(filename.c_str(),varname.c_str(),dim_length,hbuf);
 
 };
 /* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname, const  std::array<Int,4>& dim_length, Real *hbuf) {
-
-  grid_read_data_array_c_real_4d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],dim_length[3],hbuf);
-
-};
- /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, const Real* hbuf) {
 
   grid_write_data_array_c_real_1d(filename.c_str(),varname.c_str(),dim_length[0],hbuf);

--- a/components/scream/src/mct_coupling/scream_scorpio_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface.cpp
@@ -12,30 +12,30 @@ using scream::Int;
 extern "C" {
 
 // Fortran routines to be called from C++
-  void register_infile_c(const char*&& filename);
-  void set_decomp_c(const char*&& filename);
-  void set_dof_c(const char*&& filename,const char*&& varname,const Int dof_len,const Int *x_dof);
-  void grid_read_data_array_c_real(const char*&& filename, const char*&& varname, const Int dim1_length, Real *hbuf);
-  void grid_read_data_array_c_int(const char*&& filename, const char*&& varname, const Int dim1_length, Int *hbuf);
+  void register_infile_c2f(const char*&& filename);
+  void set_decomp_c2f(const char*&& filename);
+  void set_dof_c2f(const char*&& filename,const char*&& varname,const Int dof_len,const Int *x_dof);
+  void grid_read_data_array_c2f_real(const char*&& filename, const char*&& varname, const Int dim1_length, Real *hbuf);
+  void grid_read_data_array_c2f_int(const char*&& filename, const char*&& varname, const Int dim1_length, Int *hbuf);
 
-  void grid_write_data_array_c_real_1d(const char*&& filename, const char*&& varname, const Int dim1_length, const Real* hbuf);
-  void grid_write_data_array_c_real_2d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Real* hbuf);
-  void grid_write_data_array_c_real_3d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Real* hbuf);
-  void grid_write_data_array_c_real_4d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Int dim4_length, const Real* hbuf);
-  void grid_write_data_array_c_int_1d (const char*&& filename, const char*&& varname, const Int dim1_length, const Int* hbuf);
-  void grid_write_data_array_c_int_2d (const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int* hbuf);
-  void grid_write_data_array_c_int_3d (const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Int* hbuf);
-  void grid_write_data_array_c_int_4d (const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Int dim4_length, const Int* hbuf);
-  void eam_init_pio_subsystem_c(const int mpicom, const int compid, const bool local);
-  void eam_pio_finalize_c();
-  void register_outfile_c(const char*&& filename);
-  void sync_outfile_c(const char*&& filename);
-  void eam_pio_closefile_c(const char*&& filename);
-  void pio_update_time_c(const char*&& filename,const Real time);
-  void register_dimension_c(const char*&& filename, const char*&& shortname, const char*&& longname, const int length);
-  void register_variable_c(const char*&& filename,const char*&& shortname, const char*&& longname, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
-  void get_variable_c(const char*&& filename,const char*&& shortname, const char*&& longname, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
-  void eam_pio_enddef_c(const char*&& filename);
+  void grid_write_data_array_c2f_real_1d(const char*&& filename, const char*&& varname, const Int dim1_length, const Real* hbuf);
+  void grid_write_data_array_c2f_real_2d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Real* hbuf);
+  void grid_write_data_array_c2f_real_3d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Real* hbuf);
+  void grid_write_data_array_c2f_real_4d(const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Int dim4_length, const Real* hbuf);
+  void grid_write_data_array_c2f_int_1d (const char*&& filename, const char*&& varname, const Int dim1_length, const Int* hbuf);
+  void grid_write_data_array_c2f_int_2d (const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int* hbuf);
+  void grid_write_data_array_c2f_int_3d (const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Int* hbuf);
+  void grid_write_data_array_c2f_int_4d (const char*&& filename, const char*&& varname, const Int dim1_length, const Int dim2_length, const Int dim3_length, const Int dim4_length, const Int* hbuf);
+  void eam_init_pio_subsystem_c2f(const int mpicom, const int compid, const bool local);
+  void eam_pio_finalize_c2f();
+  void register_outfile_c2f(const char*&& filename);
+  void sync_outfile_c2f(const char*&& filename);
+  void eam_pio_closefile_c2f(const char*&& filename);
+  void pio_update_time_c2f(const char*&& filename,const Real time);
+  void register_dimension_c2f(const char*&& filename, const char*&& shortname, const char*&& longname, const int length);
+  void register_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
+  void get_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
+  void eam_pio_enddef_c2f(const char*&& filename);
 
 } // extern C
 
@@ -43,130 +43,130 @@ namespace scream {
 namespace scorpio {
 /* ----------------------------------------------------------------- */
 void eam_init_pio_subsystem(const int mpicom, const int compid, const bool local) {
-  eam_init_pio_subsystem_c(mpicom,compid,local);
+  eam_init_pio_subsystem_c2f(mpicom,compid,local);
 }
 /* ----------------------------------------------------------------- */
 void eam_pio_finalize() {
-  eam_pio_finalize_c();
+  eam_pio_finalize_c2f();
 }
 /* ----------------------------------------------------------------- */
 void register_outfile(const std::string& filename) {
 
-  register_outfile_c(filename.c_str());
+  register_outfile_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
 void eam_pio_closefile(const std::string& filename) {
 
-  eam_pio_closefile_c(filename.c_str());
+  eam_pio_closefile_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
 void register_infile(const std::string& filename) {
 
-  register_infile_c(filename.c_str());
+  register_infile_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
 void sync_outfile(const std::string& filename) {
 
-  sync_outfile_c(filename.c_str());
+  sync_outfile_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
 void set_decomp(const std::string& filename) {
 
-  set_decomp_c(filename.c_str());
+  set_decomp_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
 void set_dof(const std::string& filename, const std::string& varname, const Int dof_len, const Int* x_dof) {
 
-  set_dof_c(filename.c_str(),varname.c_str(),dof_len,x_dof);
+  set_dof_c2f(filename.c_str(),varname.c_str(),dof_len,x_dof);
 }
 /* ----------------------------------------------------------------- */
 void pio_update_time(const std::string& filename, const Real time) {
 
-  pio_update_time_c(filename.c_str(),time);
+  pio_update_time_c2f(filename.c_str(),time);
 }
 /* ----------------------------------------------------------------- */
 void register_dimension(const std::string &filename, const std::string& shortname, const std::string& longname, const int length) {
 
-  register_dimension_c(filename.c_str(), shortname.c_str(), longname.c_str(), length);
+  register_dimension_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), length);
 }
 /* ----------------------------------------------------------------- */
 void get_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
 
-  get_variable_c(filename.c_str(), shortname.c_str(), longname.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
+  get_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
 }
 /* ----------------------------------------------------------------- */
 void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
 
-  register_variable_c(filename.c_str(), shortname.c_str(), longname.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
+  register_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
 }
 /* ----------------------------------------------------------------- */
 void eam_pio_enddef(const std::string &filename) {
-  eam_pio_enddef_c(filename.c_str());
+  eam_pio_enddef_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
 void grid_read_data_array(const std::string &filename, const std::string &varname, const Int& dim_length, Int *hbuf) {
 
-  grid_read_data_array_c_int(filename.c_str(),varname.c_str(),dim_length,hbuf);
+  grid_read_data_array_c2f_int(filename.c_str(),varname.c_str(),dim_length,hbuf);
 
 };
 /* ----------------------------------------------------------------- */
 void grid_read_data_array(const std::string &filename, const std::string &varname, const Int& dim_length, Real *hbuf) {
 
-  grid_read_data_array_c_real(filename.c_str(),varname.c_str(),dim_length,hbuf);
+  grid_read_data_array_c2f_real(filename.c_str(),varname.c_str(),dim_length,hbuf);
 
 };
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const Int& dim_length, const Real* hbuf) {
 
-  grid_write_data_array_c_real_1d(filename.c_str(),varname.c_str(),dim_length,hbuf);
+  grid_write_data_array_c2f_real_1d(filename.c_str(),varname.c_str(),dim_length,hbuf);
 
 };
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const Int& dim_length, const Int* hbuf) {
 
-  grid_write_data_array_c_int_1d(filename.c_str(),varname.c_str(),dim_length,hbuf);
+  grid_write_data_array_c2f_int_1d(filename.c_str(),varname.c_str(),dim_length,hbuf);
 
 };
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, const Real* hbuf) {
 
-  grid_write_data_array_c_real_1d(filename.c_str(),varname.c_str(),dim_length[0],hbuf);
+  grid_write_data_array_c2f_real_1d(filename.c_str(),varname.c_str(),dim_length[0],hbuf);
 
 };
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,2>& dim_length, const Real* hbuf) {
 
-  grid_write_data_array_c_real_2d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],hbuf);
+  grid_write_data_array_c2f_real_2d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],hbuf);
 
 };
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,3>& dim_length, const Real* hbuf) {
 
-  grid_write_data_array_c_real_3d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],hbuf);
+  grid_write_data_array_c2f_real_3d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],hbuf);
 
 };
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,4>& dim_length, const Real* hbuf) {
 
-  grid_write_data_array_c_real_4d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],dim_length[3],hbuf);
+  grid_write_data_array_c2f_real_4d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],dim_length[3],hbuf);
 
 };
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, const Int* hbuf) {
 
-  grid_write_data_array_c_int_1d(filename.c_str(),varname.c_str(),dim_length[0],hbuf);
+  grid_write_data_array_c2f_int_1d(filename.c_str(),varname.c_str(),dim_length[0],hbuf);
 
 };
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,2>& dim_length, const Int* hbuf) {
 
-  grid_write_data_array_c_int_2d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],hbuf);
+  grid_write_data_array_c2f_int_2d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],hbuf);
 
 };
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,3>& dim_length, const Int* hbuf) {
 
-  grid_write_data_array_c_int_3d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],hbuf);
+  grid_write_data_array_c2f_int_3d(filename.c_str(),varname.c_str(),dim_length[0],dim_length[1],dim_length[2],hbuf);
 
 };
 /* ----------------------------------------------------------------- */

--- a/components/scream/src/mct_coupling/scream_scorpio_interface.hpp
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface.hpp
@@ -23,21 +23,23 @@ namespace scorpio {
 
   void eam_init_pio_subsystem(const int mpicom, const int compid, const bool local);
   void eam_pio_finalize();
+  void eam_pio_closefile(const std::string& filename);
   void register_outfile(const std::string& filename);
   void register_infile(const std::string& filename);
   void sync_outfile(const std::string& filename);
+  void set_decomp(const std::string& filename);
+  void set_dof(const std::string &filename, const std::string &varname, const Int dof_len, const Int* x_dof);
   void register_dimension(const std::string& filename,const std::string& shortname, const std::string& longname, const int length);
   void register_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
+  void get_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
   void eam_pio_enddef(const std::string &filename);
   void pio_update_time(const std::string &filename, const Real time);
-  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, Real* hbuf);
-  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,2>& dim_length, Real* hbuf);
-  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,3>& dim_length, Real* hbuf);
-  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,4>& dim_length, Real* hbuf);
-  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, Int* hbuf);
-  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,2>& dim_length, Int* hbuf);
-  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,3>& dim_length, Int* hbuf);
-  void grid_read_data_array(const std::string &filename, const std::string &varname, const std::array<Int,4>& dim_length, Int* hbuf);
+
+  void grid_read_data_array (const std::string &filename, const std::string &varname, const Int& dim_length, Real* hbuf);
+  void grid_read_data_array (const std::string &filename, const std::string &varname, const Int& dim_length, Int* hbuf);
+  void grid_write_data_array(const std::string &filename, const std::string &varname, const Int& dim_length, const Real* hbuf);
+  void grid_write_data_array(const std::string &filename, const std::string &varname, const Int& dim_length, const Int* hbuf);
+
   void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,1>& dim_length, const Real* hbuf);
   void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,2>& dim_length, const Real* hbuf);
   void grid_write_data_array(const std::string &filename, const std::string &varname, const std::array<Int,3>& dim_length, const Real* hbuf);

--- a/components/scream/src/mct_coupling/scream_scorpio_interface_iso_c.F90
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface_iso_c.F90
@@ -62,6 +62,41 @@ contains
 
   end subroutine sync_outfile_c
 !=====================================================================!
+  subroutine set_decomp_c(filename_in) bind(c)
+    use scream_scorpio_interface, only : set_decomp
+    type(c_ptr), intent(in) :: filename_in
+
+    character(len=256)       :: filename
+
+    call convert_c_string(filename_in,filename)
+    call set_decomp(trim(filename))
+  end subroutine set_decomp_c
+!=====================================================================!
+  subroutine set_dof_c(filename_in,varname_in,dof_len,dof_vec) bind(c)
+    use scream_scorpio_interface, only : set_dof
+    type(c_ptr), intent(in)                             :: filename_in
+    type(c_ptr), intent(in)                             :: varname_in
+    integer(kind=c_int), value, intent(in)              :: dof_len
+    integer(kind=c_int), intent(in), dimension(dof_len) :: dof_vec
+
+    character(len=256)       :: filename
+    character(len=256)       :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call set_dof(trim(filename),trim(varname),dof_len,dof_vec)
+  end subroutine set_dof_c
+!=====================================================================!
+  subroutine eam_pio_closefile_c(filename_in) bind(c)
+    use scream_scorpio_interface, only : eam_pio_closefile
+    type(c_ptr), intent(in) :: filename_in
+    character(len=256)      :: filename
+
+    call convert_c_string(filename_in,filename)
+    call eam_pio_closefile(trim(filename))
+
+  end subroutine eam_pio_closefile_c
+!=====================================================================!
   subroutine pio_update_time_c(filename_in,time) bind(c)
     use scream_scorpio_interface, only : eam_update_time
     type(c_ptr), intent(in) :: filename_in
@@ -73,6 +108,35 @@ contains
     call eam_update_time(trim(filename),time)
 
   end subroutine pio_update_time_c
+!=====================================================================!
+  subroutine get_variable_c(filename_in, shortname_in, longname_in, numdims, var_dimensions_in, dtype, pio_decomp_tag_in) bind(c)
+    use scream_scorpio_interface, only : get_variable
+    type(c_ptr), intent(in)                :: filename_in
+    type(c_ptr), intent(in)                :: shortname_in
+    type(c_ptr), intent(in)                :: longname_in
+    integer(kind=c_int), value, intent(in) :: numdims
+    type(c_ptr), intent(in)                :: var_dimensions_in(numdims)
+    integer(kind=c_int), value, intent(in) :: dtype
+    type(c_ptr), intent(in)                :: pio_decomp_tag_in
+    
+    character(len=256) :: filename
+    character(len=256) :: shortname
+    character(len=256) :: longname
+    character(len=256) :: var_dimensions(numdims)
+    character(len=256) :: pio_decomp_tag
+    integer            :: ii
+    
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(shortname_in,shortname)
+    call convert_c_string(longname_in,longname)
+    call convert_c_string(pio_decomp_tag_in,pio_decomp_tag)
+    do ii = 1,numdims
+      call convert_c_string(var_dimensions_in(ii), var_dimensions(ii))
+    end do
+   
+    call get_variable(filename,shortname,longname,numdims,var_dimensions,dtype,pio_decomp_tag)
+
+  end subroutine get_variable_c
 !=====================================================================!
   subroutine register_variable_c(filename_in, shortname_in, longname_in, numdims, var_dimensions_in, dtype, pio_decomp_tag_in) bind(c)
     use scream_scorpio_interface, only : register_variable
@@ -289,7 +353,7 @@ contains
 
   end subroutine grid_write_data_array_c_int_4d
 !=====================================================================!
-  subroutine grid_read_data_array_c_int_1d(filename_in,varname_in,dim1_length,hbuf_out) bind(c)
+  subroutine grid_read_data_array_c_int(filename_in,varname_in,dim1_length,hbuf_out) bind(c)
     use scream_scorpio_interface, only: grid_read_data_array
     use physics_utils, only: rtype
 
@@ -305,63 +369,9 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_read_data_array(filename,hbuf_out,varname)
 
-  end subroutine grid_read_data_array_c_int_1d
+  end subroutine grid_read_data_array_c_int
 !=====================================================================!
-  subroutine grid_read_data_array_c_int_2d(filename_in,varname_in,dim1_length,dim2_length,hbuf_out) bind(c)
-    use scream_scorpio_interface, only: grid_read_data_array
-    use physics_utils, only: rtype
-
-    type(c_ptr), intent(in)                :: filename_in
-    type(c_ptr), intent(in)                :: varname_in
-    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length
-    integer(kind=c_int), intent(out), dimension(dim1_length,dim2_length) :: hbuf_out
-
-    character(len=256) :: filename
-    character(len=256) :: varname
-
-    call convert_c_string(filename_in,filename)
-    call convert_c_string(varname_in,varname)
-    call grid_read_data_array(filename,hbuf_out,varname)
-
-  end subroutine grid_read_data_array_c_int_2d
-!=====================================================================!
-  subroutine grid_read_data_array_c_int_3d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,hbuf_out) bind(c)
-    use scream_scorpio_interface, only: grid_read_data_array
-    use physics_utils, only: rtype
-
-    type(c_ptr), intent(in)                :: filename_in
-    type(c_ptr), intent(in)                :: varname_in
-    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length,dim3_length
-    integer(kind=c_int), intent(out), dimension(dim1_length,dim2_length,dim3_length) :: hbuf_out
-
-    character(len=256) :: filename
-    character(len=256) :: varname
-
-    call convert_c_string(filename_in,filename)
-    call convert_c_string(varname_in,varname)
-    call grid_read_data_array(filename,hbuf_out,varname)
-
-  end subroutine grid_read_data_array_c_int_3d
-!=====================================================================!
-  subroutine grid_read_data_array_c_int_4d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,dim4_length,hbuf_out) bind(c)
-    use scream_scorpio_interface, only: grid_read_data_array
-    use physics_utils, only: rtype
-
-    type(c_ptr), intent(in)                :: filename_in
-    type(c_ptr), intent(in)                :: varname_in
-    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length,dim3_length,dim4_length
-    integer(kind=c_int), intent(out), dimension(dim1_length,dim2_length,dim3_length,dim4_length ) :: hbuf_out
-
-    character(len=256) :: filename
-    character(len=256) :: varname
-
-    call convert_c_string(filename_in,filename)
-    call convert_c_string(varname_in,varname)
-    call grid_read_data_array(filename,hbuf_out,varname)
-
-  end subroutine grid_read_data_array_c_int_4d
-!=====================================================================!
-  subroutine grid_read_data_array_c_real_1d(filename_in,varname_in,dim1_length,hbuf_out) bind(c)
+  subroutine grid_read_data_array_c_real(filename_in,varname_in,dim1_length,hbuf_out) bind(c)
     use scream_scorpio_interface, only: grid_read_data_array
     use physics_utils, only: rtype
 
@@ -377,60 +387,6 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_read_data_array(filename,hbuf_out,varname)
 
-  end subroutine grid_read_data_array_c_real_1d
-!=====================================================================!
-  subroutine grid_read_data_array_c_real_2d(filename_in,varname_in,dim1_length,dim2_length,hbuf_out) bind(c)
-    use scream_scorpio_interface, only: grid_read_data_array
-    use physics_utils, only: rtype
-
-    type(c_ptr), intent(in)                :: filename_in
-    type(c_ptr), intent(in)                :: varname_in
-    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length
-    real(kind=c_real), intent(out), dimension(dim1_length,dim2_length) :: hbuf_out
-
-    character(len=256) :: filename
-    character(len=256) :: varname
-
-    call convert_c_string(filename_in,filename)
-    call convert_c_string(varname_in,varname)
-    call grid_read_data_array(filename,hbuf_out,varname)
-
-  end subroutine grid_read_data_array_c_real_2d
-!=====================================================================!
-  subroutine grid_read_data_array_c_real_3d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,hbuf_out) bind(c)
-    use scream_scorpio_interface, only: grid_read_data_array
-    use physics_utils, only: rtype
-
-    type(c_ptr), intent(in)                :: filename_in
-    type(c_ptr), intent(in)                :: varname_in
-    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length,dim3_length
-    real(kind=c_real), intent(out), dimension(dim1_length,dim2_length,dim3_length) :: hbuf_out
-
-    character(len=256) :: filename
-    character(len=256) :: varname
-
-    call convert_c_string(filename_in,filename)
-    call convert_c_string(varname_in,varname)
-    call grid_read_data_array(filename,hbuf_out,varname)
-
-  end subroutine grid_read_data_array_c_real_3d
-!=====================================================================!
-  subroutine grid_read_data_array_c_real_4d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,dim4_length,hbuf_out) bind(c)
-    use scream_scorpio_interface, only: grid_read_data_array
-    use physics_utils, only: rtype
-
-    type(c_ptr), intent(in)                :: filename_in
-    type(c_ptr), intent(in)                :: varname_in
-    integer(kind=c_int), value, intent(in) :: dim1_length,dim2_length,dim3_length,dim4_length
-    real(kind=c_real), intent(out), dimension(dim1_length,dim2_length,dim3_length,dim4_length) :: hbuf_out
-
-    character(len=256) :: filename
-    character(len=256) :: varname
-
-    call convert_c_string(filename_in,filename)
-    call convert_c_string(varname_in,varname)
-    call grid_read_data_array(filename,hbuf_out,varname)
-
-  end subroutine grid_read_data_array_c_real_4d
+  end subroutine grid_read_data_array_c_real
 !=====================================================================!
 end module scream_scorpio_interface_iso_c

--- a/components/scream/src/mct_coupling/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/mct_coupling/scream_scorpio_interface_iso_c2f.F90
@@ -1,4 +1,4 @@
-module scream_scorpio_interface_iso_c
+module scream_scorpio_interface_iso_c2f
   use iso_c_binding
   implicit none
      
@@ -13,7 +13,7 @@ module scream_scorpio_interface_iso_c
 !
 contains
 !=====================================================================!
-  subroutine eam_init_pio_subsystem_c(mpicom,compid,local) bind(c)
+  subroutine eam_init_pio_subsystem_c2f(mpicom,compid,local) bind(c)
     use scream_scorpio_interface, only : eam_init_pio_subsystem
     use physics_utils, only: rtype
     integer(kind=c_int), value, intent(in) :: mpicom
@@ -21,15 +21,15 @@ contains
     logical(kind=c_bool),value, intent(in) :: local
 
     call eam_init_pio_subsystem(mpicom,compid,LOGICAL(local))
-  end subroutine eam_init_pio_subsystem_c
+  end subroutine eam_init_pio_subsystem_c2f
 !=====================================================================!
-  subroutine eam_pio_finalize_c() bind(c)
+  subroutine eam_pio_finalize_c2f() bind(c)
     use scream_scorpio_interface, only : eam_pio_finalize
 
     call eam_pio_finalize()
-  end subroutine eam_pio_finalize_c
+  end subroutine eam_pio_finalize_c2f
 !=====================================================================!
-  subroutine register_outfile_c(filename_in) bind(c)
+  subroutine register_outfile_c2f(filename_in) bind(c)
     use scream_scorpio_interface, only : register_outfile
     type(c_ptr), intent(in) :: filename_in
 
@@ -38,9 +38,9 @@ contains
     call convert_c_string(filename_in,filename)
     call register_outfile(trim(filename))
 
-  end subroutine register_outfile_c
+  end subroutine register_outfile_c2f
 !=====================================================================!
-  subroutine register_infile_c(filename_in) bind(c)
+  subroutine register_infile_c2f(filename_in) bind(c)
     use scream_scorpio_interface, only : register_infile
     type(c_ptr), intent(in) :: filename_in
 
@@ -49,9 +49,9 @@ contains
     call convert_c_string(filename_in,filename)
     call register_infile(trim(filename))
 
-  end subroutine register_infile_c
+  end subroutine register_infile_c2f
 !=====================================================================!
-  subroutine sync_outfile_c(filename_in) bind(c)
+  subroutine sync_outfile_c2f(filename_in) bind(c)
     use scream_scorpio_interface, only : eam_sync_piofile
     type(c_ptr), intent(in) :: filename_in
 
@@ -60,9 +60,9 @@ contains
     call convert_c_string(filename_in,filename)
     call eam_sync_piofile(trim(filename))
 
-  end subroutine sync_outfile_c
+  end subroutine sync_outfile_c2f
 !=====================================================================!
-  subroutine set_decomp_c(filename_in) bind(c)
+  subroutine set_decomp_c2f(filename_in) bind(c)
     use scream_scorpio_interface, only : set_decomp
     type(c_ptr), intent(in) :: filename_in
 
@@ -70,9 +70,9 @@ contains
 
     call convert_c_string(filename_in,filename)
     call set_decomp(trim(filename))
-  end subroutine set_decomp_c
+  end subroutine set_decomp_c2f
 !=====================================================================!
-  subroutine set_dof_c(filename_in,varname_in,dof_len,dof_vec) bind(c)
+  subroutine set_dof_c2f(filename_in,varname_in,dof_len,dof_vec) bind(c)
     use scream_scorpio_interface, only : set_dof
     type(c_ptr), intent(in)                             :: filename_in
     type(c_ptr), intent(in)                             :: varname_in
@@ -85,9 +85,9 @@ contains
     call convert_c_string(filename_in,filename)
     call convert_c_string(varname_in,varname)
     call set_dof(trim(filename),trim(varname),dof_len,dof_vec)
-  end subroutine set_dof_c
+  end subroutine set_dof_c2f
 !=====================================================================!
-  subroutine eam_pio_closefile_c(filename_in) bind(c)
+  subroutine eam_pio_closefile_c2f(filename_in) bind(c)
     use scream_scorpio_interface, only : eam_pio_closefile
     type(c_ptr), intent(in) :: filename_in
     character(len=256)      :: filename
@@ -95,9 +95,9 @@ contains
     call convert_c_string(filename_in,filename)
     call eam_pio_closefile(trim(filename))
 
-  end subroutine eam_pio_closefile_c
+  end subroutine eam_pio_closefile_c2f
 !=====================================================================!
-  subroutine pio_update_time_c(filename_in,time) bind(c)
+  subroutine pio_update_time_c2f(filename_in,time) bind(c)
     use scream_scorpio_interface, only : eam_update_time
     type(c_ptr), intent(in) :: filename_in
     real(kind=c_real), value, intent(in) :: time
@@ -107,9 +107,9 @@ contains
     call convert_c_string(filename_in,filename)
     call eam_update_time(trim(filename),time)
 
-  end subroutine pio_update_time_c
+  end subroutine pio_update_time_c2f
 !=====================================================================!
-  subroutine get_variable_c(filename_in, shortname_in, longname_in, numdims, var_dimensions_in, dtype, pio_decomp_tag_in) bind(c)
+  subroutine get_variable_c2f(filename_in, shortname_in, longname_in, numdims, var_dimensions_in, dtype, pio_decomp_tag_in) bind(c)
     use scream_scorpio_interface, only : get_variable
     type(c_ptr), intent(in)                :: filename_in
     type(c_ptr), intent(in)                :: shortname_in
@@ -136,9 +136,9 @@ contains
    
     call get_variable(filename,shortname,longname,numdims,var_dimensions,dtype,pio_decomp_tag)
 
-  end subroutine get_variable_c
+  end subroutine get_variable_c2f
 !=====================================================================!
-  subroutine register_variable_c(filename_in, shortname_in, longname_in, numdims, var_dimensions_in, dtype, pio_decomp_tag_in) bind(c)
+  subroutine register_variable_c2f(filename_in, shortname_in, longname_in, numdims, var_dimensions_in, dtype, pio_decomp_tag_in) bind(c)
     use scream_scorpio_interface, only : register_variable
     type(c_ptr), intent(in)                :: filename_in
     type(c_ptr), intent(in)                :: shortname_in
@@ -165,9 +165,9 @@ contains
    
     call register_variable(filename,shortname,longname,numdims,var_dimensions,dtype,pio_decomp_tag)
 
-  end subroutine register_variable_c
+  end subroutine register_variable_c2f
 !=====================================================================!
-  subroutine register_dimension_c(filename_in, shortname_in, longname_in, length) bind(c)
+  subroutine register_dimension_c2f(filename_in, shortname_in, longname_in, length) bind(c)
     use scream_scorpio_interface, only : register_dimension
     type(c_ptr), intent(in)                :: filename_in
     type(c_ptr), intent(in)                :: shortname_in
@@ -183,9 +183,9 @@ contains
     call convert_c_string(longname_in,longname)
     call register_dimension(filename,shortname,longname,length)
     
-  end subroutine register_dimension_c
+  end subroutine register_dimension_c2f
 !=====================================================================!
-  subroutine eam_pio_enddef_c(filename_in) bind(c)
+  subroutine eam_pio_enddef_c2f(filename_in) bind(c)
     use scream_scorpio_interface, only : eam_pio_enddef
     type(c_ptr), intent(in) :: filename_in
 
@@ -193,7 +193,7 @@ contains
 
     call convert_c_string(filename_in,filename)
     call eam_pio_enddef(filename)
-  end subroutine eam_pio_enddef_c
+  end subroutine eam_pio_enddef_c2f
 !=====================================================================!
   subroutine convert_c_string(c_string_ptr,f_string)
   ! Purpose: To convert a c_string pointer to the proper fortran string format.
@@ -209,7 +209,7 @@ contains
     return
   end subroutine convert_c_string
 !=====================================================================!
-  subroutine grid_write_data_array_c_real_1d(filename_in,varname_in,dim1_length,hbuf_in) bind(c)
+  subroutine grid_write_data_array_c2f_real_1d(filename_in,varname_in,dim1_length,hbuf_in) bind(c)
     use scream_scorpio_interface, only: grid_write_data_array
     use physics_utils, only: rtype
 
@@ -225,9 +225,9 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_write_data_array(filename,hbuf_in,varname)
 
-  end subroutine grid_write_data_array_c_real_1d
+  end subroutine grid_write_data_array_c2f_real_1d
 !=====================================================================!
-  subroutine grid_write_data_array_c_real_2d(filename_in,varname_in,dim1_length,dim2_length,hbuf_in) bind(c)
+  subroutine grid_write_data_array_c2f_real_2d(filename_in,varname_in,dim1_length,dim2_length,hbuf_in) bind(c)
     use scream_scorpio_interface, only: grid_write_data_array
     use physics_utils, only: rtype
 
@@ -243,9 +243,9 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_write_data_array(filename,hbuf_in,varname)
 
-  end subroutine grid_write_data_array_c_real_2d
+  end subroutine grid_write_data_array_c2f_real_2d
 !=====================================================================!
-  subroutine grid_write_data_array_c_real_3d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,hbuf_in) bind(c)
+  subroutine grid_write_data_array_c2f_real_3d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,hbuf_in) bind(c)
     use scream_scorpio_interface, only: grid_write_data_array
     use physics_utils, only: rtype
 
@@ -261,9 +261,9 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_write_data_array(filename,hbuf_in,varname)
 
-  end subroutine grid_write_data_array_c_real_3d
+  end subroutine grid_write_data_array_c2f_real_3d
 !=====================================================================!
-  subroutine grid_write_data_array_c_real_4d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,dim4_length,hbuf_in) bind(c)
+  subroutine grid_write_data_array_c2f_real_4d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,dim4_length,hbuf_in) bind(c)
     use scream_scorpio_interface, only: grid_write_data_array
     use physics_utils, only: rtype
 
@@ -279,9 +279,9 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_write_data_array(filename,hbuf_in,varname)
 
-  end subroutine grid_write_data_array_c_real_4d
+  end subroutine grid_write_data_array_c2f_real_4d
 !=====================================================================!
-  subroutine grid_write_data_array_c_int_1d(filename_in,varname_in,dim1_length,hbuf_in) bind(c)
+  subroutine grid_write_data_array_c2f_int_1d(filename_in,varname_in,dim1_length,hbuf_in) bind(c)
     use scream_scorpio_interface, only: grid_write_data_array
     use physics_utils, only: rtype
 
@@ -297,9 +297,9 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_write_data_array(filename,hbuf_in,varname)
 
-  end subroutine grid_write_data_array_c_int_1d
+  end subroutine grid_write_data_array_c2f_int_1d
 !=====================================================================!
-  subroutine grid_write_data_array_c_int_2d(filename_in,varname_in,dim1_length,dim2_length,hbuf_in) bind(c)
+  subroutine grid_write_data_array_c2f_int_2d(filename_in,varname_in,dim1_length,dim2_length,hbuf_in) bind(c)
     use scream_scorpio_interface, only: grid_write_data_array
     use physics_utils, only: rtype
 
@@ -315,9 +315,9 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_write_data_array(filename,hbuf_in,varname)
 
-  end subroutine grid_write_data_array_c_int_2d
+  end subroutine grid_write_data_array_c2f_int_2d
 !=====================================================================!
-  subroutine grid_write_data_array_c_int_3d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,hbuf_in) bind(c)
+  subroutine grid_write_data_array_c2f_int_3d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,hbuf_in) bind(c)
     use scream_scorpio_interface, only: grid_write_data_array
     use physics_utils, only: rtype
 
@@ -333,9 +333,9 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_write_data_array(filename,hbuf_in,varname)
 
-  end subroutine grid_write_data_array_c_int_3d
+  end subroutine grid_write_data_array_c2f_int_3d
 !=====================================================================!
-  subroutine grid_write_data_array_c_int_4d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,dim4_length,hbuf_in) bind(c)
+  subroutine grid_write_data_array_c2f_int_4d(filename_in,varname_in,dim1_length,dim2_length,dim3_length,dim4_length,hbuf_in) bind(c)
     use scream_scorpio_interface, only: grid_write_data_array
     use physics_utils, only: rtype
 
@@ -351,9 +351,9 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_write_data_array(filename,hbuf_in,varname)
 
-  end subroutine grid_write_data_array_c_int_4d
+  end subroutine grid_write_data_array_c2f_int_4d
 !=====================================================================!
-  subroutine grid_read_data_array_c_int(filename_in,varname_in,dim1_length,hbuf_out) bind(c)
+  subroutine grid_read_data_array_c2f_int(filename_in,varname_in,dim1_length,hbuf_out) bind(c)
     use scream_scorpio_interface, only: grid_read_data_array
     use physics_utils, only: rtype
 
@@ -369,9 +369,9 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_read_data_array(filename,hbuf_out,varname)
 
-  end subroutine grid_read_data_array_c_int
+  end subroutine grid_read_data_array_c2f_int
 !=====================================================================!
-  subroutine grid_read_data_array_c_real(filename_in,varname_in,dim1_length,hbuf_out) bind(c)
+  subroutine grid_read_data_array_c2f_real(filename_in,varname_in,dim1_length,hbuf_out) bind(c)
     use scream_scorpio_interface, only: grid_read_data_array
     use physics_utils, only: rtype
 
@@ -387,6 +387,6 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_read_data_array(filename,hbuf_out,varname)
 
-  end subroutine grid_read_data_array_c_real
+  end subroutine grid_read_data_array_c2f_real
 !=====================================================================!
-end module scream_scorpio_interface_iso_c
+end module scream_scorpio_interface_iso_c2f

--- a/components/scream/src/mct_coupling/tests/scorpio_tests.cpp
+++ b/components/scream/src/mct_coupling/tests/scorpio_tests.cpp
@@ -11,6 +11,9 @@
 
 namespace {
 
+Real x_i(const Int ii, const Int x_len);
+Real y_i(const Int ii, const Int y_len);
+Real z_i(const Int ii, const Int z_len);
 Real f_x(const Real x, const Real t); 
 Real f_y(const Real y, const Real t); 
 Real f_z(const Real z, const Real t); 
@@ -18,28 +21,42 @@ Int ind_x(const Int ii);
 Int ind_y(const Int jj);
 Int ind_z(const Int kk);
 Int ind_t(const Int tt);
+void get_dof(const std::size_t dimsize, const Int myrank, const Int numranks, Int &dof_len, Int &istart, Int &istop);
 
 TEST_CASE("scorpio_interface_output", "") {
-
+/* 
+ * A test to check that both output and input are behaving properly in the scream interface.
+ * The first step creates a new output file, generates data for writing output, and commits that data to the new output file.
+ * The second step opens the recently created output file, reads in all the available data, 
+ * and then compares the read in values with the expected values that should have been written out.
+ */
+  /* load namespaces needed for I/O and for data management */
   using namespace scream;
   using namespace scream::scorpio;
   using ekat::util::data;
 
-  // Create the set of SCORPIO output files and their respective
-  // dimensions and variables.
-  int compid=0;
-  MPI_Fint fcomm = MPI_Comm_c2f(MPI_COMM_WORLD);
+  int nerr = 0; // Set a record of the number of errors encountered.
+  /* Create the set of SCORPIO output files and their respective dimensions and variables. */
+  int compid=0;  // For CIME based builds this will be the integer ID assigned to the atm by the component coupler.  For testing we simply set to 0
+  Int myrank, numranks;
+  MPI_Fint fcomm = MPI_Comm_c2f(MPI_COMM_WORLD);  // MPI communicator group used for I/O.  In our simple test we use MPI_COMM_WORLD, however a sub
+  MPI_Comm_rank(MPI_COMM_WORLD, &myrank);  // Store rank and total number of ranks for determining which chunk of global array this rank is responsible for reading.
+  MPI_Comm_size(MPI_COMM_WORLD, &numranks);
   eam_init_pio_subsystem(fcomm,compid,true);   // Gather the initial PIO subsystem data creater by component coupler
-  // Register the set of output files:
-  std::string outfilename = "scorpio_output_test.nc";
-  register_outfile(outfilename);
-  // Register the set of dimensions per output file
+  /* Tell the scorpio interface module that we have a new output file to write to */
+  std::string outfilename = "scorpio_output_test.nc";  // For simplicity create a variable to store the name of the output file.  This will be used with most calls to make sure the every function is applying the action to the proper file (if multiple files are open)
+  register_outfile(outfilename);                       // Register this output file with the scorpio interface module
+  /* Set up the 4 spatial dimensions for this test and register them with the new output file */
   int xlen=10, ylen=5, zlen=2;
   register_dimension(outfilename,"x","horizontal distance",xlen);
   register_dimension(outfilename,"y","vertical distance",ylen);
   register_dimension(outfilename,"z","height",zlen);
-  register_dimension(outfilename,"time","time",0);
-  // Register the set of variables per output file
+  register_dimension(outfilename,"time","time",0);  // Note that time has an unknown length, setting the "length" to 0 tells the interface to set this dimension as having an unlimited length, thus allowing us to write as many timesnaps to file as we desire.
+  /* 
+   * Set up the list variables we wish to include in the output file
+   * Here we note that we are creating character arrays which use the named dimensions above.
+   * This is used when we register the variables to tell scorpio what dimensions each variable uses.
+   */
   const char* vec_time[] = {"time"};
   const char* vec_x[]    = {"x"};
   const char* vec_y[]    = {"y"};
@@ -47,20 +64,25 @@ TEST_CASE("scorpio_interface_output", "") {
   const char* vec_xt[]   = {"x","time"};
   const char* vec_xyt[]  = {"x","y","time"};
   const char* vec_xyzt[] = {"x","y","z","time"};
+  const char* vec_xy[]   = {"x","y"}; 
+  const char* vec_xyz[]  = {"x","y","z"};
  
-  register_variable(outfilename,"time","time",1,vec_time, PIO_REAL,"t");
+  register_variable(outfilename,"time","time",1,vec_time,  PIO_REAL,"t");
   register_variable(outfilename,"x","x-direction",1,vec_x, PIO_REAL,"x-real");
   register_variable(outfilename,"y","y-direction",1,vec_y, PIO_REAL,"y-real");
   register_variable(outfilename,"z","z-direction",1,vec_z, PIO_REAL,"z-real");
-  register_variable(outfilename,"data_1d","test value for 1d field",2,vec_xt, PIO_REAL,"xt-real");
-  register_variable(outfilename,"data_2d","test value for 2d field",3,vec_xyt, PIO_REAL,"xyt-real");
+  register_variable(outfilename,"data_1d","test value for 1d field",2,vec_xt,   PIO_REAL,"xt-real");
+  register_variable(outfilename,"data_2d","test value for 2d field",3,vec_xyt,  PIO_REAL,"xyt-real");
   register_variable(outfilename,"data_3d","test value for 3d field",4,vec_xyzt, PIO_REAL,"xyzt-real");
-  register_variable(outfilename,"index_1d","test value for 1d field",2,vec_xt, PIO_INT,"xt-int");
-  register_variable(outfilename,"index_2d","test value for 2d field",3,vec_xyt, PIO_INT,"xyt-int");
+  register_variable(outfilename,"index_1d","test value for 1d field",2,vec_xt,   PIO_INT,"xt-int");
+  register_variable(outfilename,"index_2d","test value for 2d field",3,vec_xyt,  PIO_INT,"xyt-int");
   register_variable(outfilename,"index_3d","test value for 3d field",4,vec_xyzt, PIO_INT,"xyzt-int");
-  // Finished with the initialization of variables in output file
-  eam_pio_enddef(outfilename);
-  // Create data to be written
+  /* 
+   * Construct the data to be written as output.  Note that here we take advantage of the ekat
+   * md_array utility for multi-dimension arrays.  It would also be acceptable to use the std::array,
+   * or other construct.  In the end, what is passed to scorpio is only the pointer to the beginning
+   * of the array of data.
+   */
   std::array<Real,10> x_data;
   std::array<Real, 5> y_data;
   std::array<Real, 2> z_data;
@@ -77,22 +99,111 @@ TEST_CASE("scorpio_interface_output", "") {
   ekat::util::md_array<Int, 5,10>     test_index_2d;
   ekat::util::md_array<Int, 2, 5,10>  test_index_3d;
   Real pi = 2*acos(0.0);
+  /* 
+   * Degrees of Freedom decomposition of input arrays, this information is used to tell
+   * PIO which global array indices the local MPI rank is responsible for.  Without it, we
+   * are not really doing PIO
+   */
+  // dof_* array record the total number of indices this rank is responsible for.
+  std::array<Int,1> dof_x;
+  std::array<Int,1> dof_y;
+  std::array<Int,1> dof_z;
+  std::array<Int,1> dof_test_1d;
+  std::array<Int,1> dof_test_2d;
+  std::array<Int,1> dof_test_3d;
+  // *start,*stop record the first and last index in the 1d flattened array that this rank
+  // is responsible for.
+  Int xstart,xstop;
+  Int ystart,ystop;
+  Int zstart,zstop;
+  Int test_1d_start,test_1d_stop;
+  Int test_2d_start,test_2d_stop;
+  Int test_3d_start,test_3d_stop;
+  /* 
+   * Setup PIO configuation for writing data.  This is a 3 step process:
+   * 1. Determine the number of indices, start and stop location for this rank.
+   * 2. Create a vector of the indices based on the info from step 1. 
+   *    We need to do this as a second step since we don't know the length of this vector ahead of time.
+   * 3. Assign the global indices to the dof vector.
+   */
+  // Time is special since it is a single value:
+  set_dof(outfilename,"time",0,0);
+  // start with x
+  get_dof(ekat::util::size(x_data), myrank, numranks, dof_x[0], xstart,xstop);
+  std::vector<Int> x_dof(dof_x[0]);
+  for (int ii=xstart,cnt=0;ii<=xstop;++ii,++cnt) {
+    x_dof[cnt] = ii+1;  // Add one to index since C++ starts at 0 and Fortran starts at 1
+  }
+  set_dof(outfilename,"x",dof_x[0],x_dof.data());
+  // next y
+  get_dof(ekat::util::size(y_data), myrank, numranks, dof_y[0], ystart,ystop);
+  std::vector<Int> y_dof(dof_y[0]);
+  for (int ii=ystart,cnt=0;ii<=ystop;++ii,++cnt) {
+    y_dof[cnt] = ii+1;
+  }
+  set_dof(outfilename,"y",dof_y[0],y_dof.data());
+  // next z
+  get_dof(ekat::util::size(z_data), myrank, numranks, dof_z[0], zstart,zstop);
+  std::vector<Int> z_dof(dof_z[0]);
+  for (int ii=zstart,cnt=0;ii<=zstop;++ii,++cnt) {
+    z_dof[cnt] = ii+1;
+  }
+  set_dof(outfilename,"z",dof_z[0],z_dof.data());
+  // now 1d, 2d and 3d data arrays.
+  get_dof(dimlen_1d[0], myrank, numranks, dof_test_1d[0], test_1d_start,test_1d_stop);
+  std::vector<Int> test1d_dof(dof_test_1d[0]);
+  for (int ii=test_1d_start,cnt=0;ii<=test_1d_stop;++ii,++cnt) {
+    test1d_dof[cnt] = ii+1;
+  }
+  set_dof(outfilename,"index_1d",dof_test_1d[0],test1d_dof.data());
+  set_dof(outfilename,"data_1d",dof_test_1d[0],test1d_dof.data());
 
+  get_dof(dimlen_2d[0]*dimlen_2d[1], myrank, numranks, dof_test_2d[0], test_2d_start,test_2d_stop);
+  std::vector<Int> test2d_dof(dof_test_2d[0]);
+  for (int ii=test_2d_start,cnt=0;ii<=test_2d_stop;++ii,++cnt) {
+    test2d_dof[cnt] = ii+1;
+  }
+  set_dof(outfilename,"index_2d",dof_test_2d[0],test2d_dof.data());
+  set_dof(outfilename,"data_2d",dof_test_2d[0],test2d_dof.data());
+
+  get_dof(dimlen_3d[0]*dimlen_3d[1]*dimlen_3d[2], myrank, numranks, dof_test_3d[0], test_3d_start,test_3d_stop);
+  std::vector<Int> test3d_dof(dof_test_3d[0]);
+  for (int ii=test_3d_start,cnt=0;ii<=test_3d_stop;++ii,++cnt) {
+    test3d_dof[cnt] = ii+1;
+  }
+  set_dof(outfilename,"index_3d",dof_test_3d[0],test3d_dof.data());
+  set_dof(outfilename,"data_3d",dof_test_3d[0],test3d_dof.data());
+  /* Set the x, y and z dimension values */
   for (decltype(x_data)::size_type ii=0;ii<x_data.size();ii++) {
-    x_data[ii] = 2.0*pi/x_data.size()*(ii+1);
+    x_data[ii] = x_i(ii,x_data.size()); 
   }
   for (int jj=0;jj<5;jj++) {
-    y_data[jj] = 4.0*pi/y_data.size()*(jj+1);
+    y_data[jj] = y_i(jj,y_data.size()); 
   }
   for (int kk=0;kk<2;kk++) {
-    z_data[kk] = 100*(kk+1);
+    z_data[kk] = z_i(kk,z_data.size()); 
   }
-  // Write dimension data and initial fields
-  grid_write_data_array(outfilename,"x",xdim,ekat::util::data(x_data));
-  grid_write_data_array(outfilename,"y",ydim,ekat::util::data(y_data));
-  grid_write_data_array(outfilename,"z",zdim,ekat::util::data(z_data));
-  sync_outfile(outfilename); 
-  // write multiple timesteps of data for comparison:
+  /* 
+   * When we are finished defining the set of dimensions and variables for the new output file
+   * we have to officially "end" the definition phase in scorpio.  After this step we can no longer
+   * add dimensions or variables to the file, or change their metadata.
+   * NOTE: We would normally also have to set_decomp (set the io-decomposition) for all variables.
+   * This is handled during the eam_pio_enddef call.  When reading variables (see below) we need to
+   * issue this command ourselves.
+   */
+  eam_pio_enddef(outfilename);
+  /* 
+   * Write these values to the file.  Note, "x", "y" and "z" are both
+   * dimensions and variables.  Here we are writing to the "variable"
+   * definition.  Dimensions in scorpio don't have vectors associated
+   * with them, they are labels with lengths used to define variables.
+   * So here we note, that you will most likely want to define all
+   * dimensions as variables as well.
+   */
+  grid_write_data_array(outfilename,"x",dof_x[0],ekat::util::data(x_data)+xstart);
+  grid_write_data_array(outfilename,"y",dof_y[0],ekat::util::data(y_data)+ystart);
+  grid_write_data_array(outfilename,"z",dof_z[0],ekat::util::data(z_data)+zstart);
+  /* To test multiple timelevels, generate unique data for multiple timesnaps, then write the data to file. */
   Real dt = 1.0;
   for (int tt=0;tt<3;tt++) {
     for (decltype(x_data)::size_type ii=0;ii<x_data.size();ii++) {
@@ -107,30 +218,153 @@ TEST_CASE("scorpio_interface_output", "") {
         } //kk
       } //jj
     } //ii
+    /* 
+     * Call pio_update_time to increase the number of timesnaps registered with this output file by 1.
+     * This is an essential step whenever pio is called for multiple timesnaps, otherwise the output will
+     * overwrite the current timesnap each time.
+     */
     pio_update_time(outfilename,tt*dt);
-    grid_write_data_array(outfilename,"index_1d",dimlen_1d,ekat::util::data(test_index_1d));
-    grid_write_data_array(outfilename,"index_2d",dimlen_2d,ekat::util::data(test_index_2d));
-    grid_write_data_array(outfilename,"index_3d",dimlen_3d,ekat::util::data(test_index_3d));
-    grid_write_data_array(outfilename,"data_1d",dimlen_1d,ekat::util::data(test_data_1d));
-    grid_write_data_array(outfilename,"data_2d",dimlen_2d,ekat::util::data(test_data_2d));
-    grid_write_data_array(outfilename,"data_3d",dimlen_3d,ekat::util::data(test_data_3d));
+    grid_write_data_array(outfilename,"index_1d",dof_test_1d[0],ekat::util::data(test_index_1d)+test_1d_start);
+    grid_write_data_array(outfilename,"index_2d",dof_test_2d[0],ekat::util::data(test_index_2d)+test_2d_start);
+    grid_write_data_array(outfilename,"index_3d",dof_test_3d[0],ekat::util::data(test_index_3d)+test_3d_start);
+    grid_write_data_array(outfilename,"data_1d", dof_test_1d[0],ekat::util::data(test_data_1d) +test_1d_start);
+    grid_write_data_array(outfilename,"data_2d", dof_test_2d[0],ekat::util::data(test_data_2d) +test_2d_start);
+    grid_write_data_array(outfilename,"data_3d", dof_test_3d[0],ekat::util::data(test_data_3d) +test_3d_start);
+    /* Call sync_outfile to ensure that all the fields are syncronized for this timesnap */
     sync_outfile(outfilename); 
   } //tt
+  /* Now close the output file and reopen it to check that the output is correct. */
+  eam_pio_closefile(outfilename);
 
+  /* ============================================================================================= */
+  /* ============================================================================================= */
+  /* ============================================================================================= */
+
+  /* Reopen the output file we just created to check both "input" and that the fields are correct. */
+  register_infile(outfilename);
+  /* Use "get_variable" to gather the important variable information for each variable we expect to
+   * load and test.  Note that we don't use "register_variable" since we are technically accessing a
+   * variable which should already exist in the file.
+   */
+  get_variable(outfilename,"time","time",1,vec_time, PIO_REAL,"t_in");
+  get_variable(outfilename,"x","x-direction",1,vec_x, PIO_REAL,"x-real_in");
+  get_variable(outfilename,"y","y-direction",1,vec_y, PIO_REAL,"y-real_in");
+  get_variable(outfilename,"z","z-direction",1,vec_z, PIO_REAL,"z-real_in");
+  get_variable(outfilename,"data_1d","test value for 1d field",1,vec_x, PIO_REAL,"x-real_in");
+  get_variable(outfilename,"data_2d","test value for 2d field",2,vec_xy, PIO_REAL,"xy-real_in");
+  get_variable(outfilename,"data_3d","test value for 3d field",3,vec_xyz, PIO_REAL,"xyz-real_in");
+  get_variable(outfilename,"index_1d","test value for 1d field",1,vec_x, PIO_INT,"x-int_in");
+  get_variable(outfilename,"index_2d","test value for 2d field",2,vec_xy, PIO_INT,"xy-int_in");
+  get_variable(outfilename,"index_3d","test value for 3d field",3,vec_xyz, PIO_INT,"xyz-int_in");
+  /* 
+   * Setup PIO configuation for reading data.  This is usually a 3 step process:
+   * 1. Determine the number of indices, start and stop location for this rank.
+   * 2. Create a vector of the indices based on the info from step 1. 
+   *    We need to do this as a second step since we don't know the length of this vector ahead of time.
+   * 3. Assign the global indices to the dof vector.
+   * We already did all of this setting things up for writing output, so here we just reuse the same dof vectors.
+   */
+  set_dof(outfilename,"time",0,0);
+  set_dof(outfilename,"x",dof_x[0],x_dof.data());
+  set_dof(outfilename,"y",dof_y[0],y_dof.data());
+  set_dof(outfilename,"z",dof_z[0],z_dof.data());
+  set_dof(outfilename,"index_1d",dof_test_1d[0],test1d_dof.data());
+  set_dof(outfilename,"data_1d",dof_test_1d[0],test1d_dof.data());
+  set_dof(outfilename,"index_2d",dof_test_2d[0],test2d_dof.data());
+  set_dof(outfilename,"data_2d",dof_test_2d[0],test2d_dof.data());
+  set_dof(outfilename,"index_3d",dof_test_3d[0],test3d_dof.data());
+  set_dof(outfilename,"data_3d",dof_test_3d[0],test3d_dof.data());
+  // Now that the variables have been gathered and the dof set for each one, set the iodesc decomposition from PIO.
+  set_decomp(outfilename);
+  /* Read input data for x, y and z, and compare with expected value.  Report mismatches as an error. */
+  grid_read_data_array(outfilename,"x",dof_x[0],ekat::util::data(x_data)+xstart);
+  grid_read_data_array(outfilename,"y",dof_y[0],ekat::util::data(y_data)+ystart);
+  grid_read_data_array(outfilename,"z",dof_z[0],ekat::util::data(z_data)+zstart);
+  nerr = 0;
+  for (Int ii=xstart;ii<=xstop;ii++) {
+    if (x_data[ii] != x_i(ii,x_data.size())) { ++nerr;}
+  }
+  REQUIRE(nerr==0);
+  nerr = 0;
+  for (Int jj=ystart;jj<=ystop;jj++) {
+    if (y_data[jj] != y_i(jj,y_data.size())) { ++nerr;}
+  }
+  REQUIRE(nerr==0);
+  nerr = 0;
+  for (Int kk=zstart;kk<=zstop;kk++) {
+    if (z_data[kk] != z_i(kk,z_data.size())) { ++nerr; std::printf("   - (%d) %f vs. %f\n",kk,z_data[kk],z_i(kk,z_data.size()));}
+  }
+  REQUIRE(nerr==0);
+  /* Now read and compare the field data for each of the timestep */
+  nerr = 0;
+  for (int tt=0;tt<3;tt++) {
+    pio_update_time(outfilename,-999.0);
+    grid_read_data_array(outfilename,"index_1d",dof_test_1d[0],ekat::util::data(test_index_1d)+test_1d_start);
+    grid_read_data_array(outfilename,"data_1d", dof_test_1d[0],ekat::util::data(test_data_1d) +test_1d_start);
+    nerr = 0;
+    for (int ii=0,ind=test_1d_start;ind<test_1d_stop;ii++,ind++) {
+      if (*(ekat::util::data(test_data_1d) + ind)  != f_x(x_data[ind],tt*dt)) {++nerr;}
+      if (*(ekat::util::data(test_index_1d) + ind) != ind_x(ind) + ind_t(tt))  {++nerr;}
+    }
+    REQUIRE(nerr==0);
+    nerr = 0;
+    grid_read_data_array(outfilename,"index_2d",dof_test_2d[0],ekat::util::data(test_index_2d)+test_2d_start);
+    grid_read_data_array(outfilename,"data_2d", dof_test_2d[0],ekat::util::data(test_data_2d) +test_2d_start);
+    for (int ind=test_2d_start;ind<=test_2d_stop;ind++) {
+      int jj = (int) ind / xdim[0]; 
+      int ii = ind - (jj*xdim[0]);
+      if (*(ekat::util::data(test_data_2d) + ind)  != f_x(x_data[ii],tt*dt)*f_y(y_data[jj],tt*dt)) {++nerr;}
+      if (*(ekat::util::data(test_index_2d) + ind) != ind_y(jj) + ind_x(ii) + ind_t(tt))  {++nerr;}
+    }
+    REQUIRE(nerr==0);
+    nerr = 0;
+    grid_read_data_array(outfilename,"index_3d",dof_test_3d[0],ekat::util::data(test_index_3d)+test_3d_start);
+    grid_read_data_array(outfilename,"data_3d", dof_test_3d[0],ekat::util::data(test_data_3d) +test_3d_start);
+    for (int ind=test_3d_start;ind<=test_3d_stop;ind++) {
+      int kk = (int) ind / (xdim[0]*ydim[0]);
+      int jj = (int) (ind - (kk*xdim[0]*ydim[0]))/xdim[0];
+      int ii = ind - (kk*xdim[0]*ydim[0] + jj*xdim[0]);
+      if (*(ekat::util::data(test_data_3d) + ind)  != f_x(x_data[ii],tt*dt)*f_y(y_data[jj],tt*dt) + f_z(z_data[kk],tt*dt)) {++nerr;}
+      if (*(ekat::util::data(test_index_3d) + ind) != ind_z(kk) + ind_y(jj) + ind_x(ii) + ind_t(tt))  {++nerr;}
+    }
+    REQUIRE(nerr==0);
+  } //tt
+  /* 
+   * Now that the test has finished, finalize PIO.  This also closes all files, so it is not neccessary to close the
+   * the file we used for testing input.  As we had done when testing the output above. 
+   */
   eam_pio_finalize();
+  /* 
+   * FINAL NOTE: The netCDF file created for the ouput phase of this test can be checked offline (using cprnc for example)
+   * against the baseline output file that is copied from /scream/data/ to the testing directory.  To test using cprnc issue
+   * the command:
+   *
+   *            cprnc scorpio_output_baseline.nc scorpio_output_test.nc
+   */
 } // TEST scorpio_interface_output
 /* ================================================================================================================ */
+/* 
+ * Test case focused entirely on the input interface.  The comments here would match the same as the comments for the
+ * test of input and output above.  This case is unique in that it checks the input values based on reading in a pre-
+ * written baseline netCDF file.
+ */
 TEST_CASE("scorpio_interface_input", "") {
 
   using namespace scream;
   using namespace scream::scorpio;
   using ekat::util::data;
 
+  Real pi = 2*acos(0.0);
+  Real dt = 1.0;
+  int nerr = 0;
   int compid=0;
+  Int myrank, numranks;
   MPI_Fint fcomm = MPI_Comm_c2f(MPI_COMM_WORLD);
+  MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+  MPI_Comm_size(MPI_COMM_WORLD, &numranks);
   eam_init_pio_subsystem(fcomm,compid,true);   // Gather the initial PIO subsystem data creater by component coupler
   // Register the set of output files:
-  std::string infilename = "scorpio_output_test.nc";
+  std::string infilename = "scorpio_output_baseline.nc";
   register_infile(infilename);
 
   const char* vec_time[] = {"time"};
@@ -140,75 +374,192 @@ TEST_CASE("scorpio_interface_input", "") {
   const char* vec_xy[]   = {"x","y"}; 
   const char* vec_xyz[]  = {"x","y","z"};
  
-  register_variable(infilename,"time","time",1,vec_time, PIO_REAL,"t");
-  register_variable(infilename,"x","x-direction",1,vec_x, PIO_REAL,"x-real");
-  register_variable(infilename,"y","y-direction",1,vec_y, PIO_REAL,"y-real");
-  register_variable(infilename,"z","z-direction",1,vec_z, PIO_REAL,"z-real");
-  register_variable(infilename,"data_1d","test value for 1d field",1,vec_x, PIO_REAL,"x-real");
-  register_variable(infilename,"data_2d","test value for 2d field",2,vec_xy, PIO_REAL,"xy-real");
-  register_variable(infilename,"data_3d","test value for 3d field",3,vec_xyz, PIO_REAL,"xyz-real");
-  register_variable(infilename,"index_1d","test value for 1d field",1,vec_x, PIO_INT,"x-int");
-  register_variable(infilename,"index_2d","test value for 2d field",2,vec_xy, PIO_INT,"xy-int");
-  register_variable(infilename,"index_3d","test value for 3d field",3,vec_xyz, PIO_INT,"xyz-int");
+  get_variable(infilename,"time","time",1,vec_time, PIO_REAL,"t");
+  get_variable(infilename,"x","x-direction",1,vec_x, PIO_REAL,"x-real");
+  get_variable(infilename,"y","y-direction",1,vec_y, PIO_REAL,"y-real");
+  get_variable(infilename,"z","z-direction",1,vec_z, PIO_REAL,"z-real");
+  get_variable(infilename,"data_1d","test value for 1d field",1,vec_x, PIO_REAL,"x-real");
+  get_variable(infilename,"data_2d","test value for 2d field",2,vec_xy, PIO_REAL,"xy-real");
+  get_variable(infilename,"data_3d","test value for 3d field",3,vec_xyz, PIO_REAL,"xyz-real");
+  get_variable(infilename,"index_1d","test value for 1d field",1,vec_x, PIO_INT,"x-int");
+  get_variable(infilename,"index_2d","test value for 2d field",2,vec_xy, PIO_INT,"xy-int");
+  get_variable(infilename,"index_3d","test value for 3d field",3,vec_xyz, PIO_INT,"xyz-int");
 
   // Create data to be written
-  std::array<Real,10> x_data;
-  std::array<Real, 5> y_data;
-  std::array<Real, 2> z_data;
   std::array<Int,1> xdim = {10};
   std::array<Int,1> ydim = {5};
   std::array<Int,1> zdim = {2};
   std::array<Int,1> dimlen_1d = {10};
   std::array<Int,2> dimlen_2d = {5,10};
   std::array<Int,3> dimlen_3d = {2,5,10};
+  // Data to be loaded from input file
+  std::array<Real,10> x_data;
+  std::array<Real, 5> y_data;
+  std::array<Real, 2> z_data;
   ekat::util::md_array<Real,10>       test_data_1d;
   ekat::util::md_array<Real, 5,10>    test_data_2d;
   ekat::util::md_array<Real, 2, 5,10> test_data_3d;
   ekat::util::md_array<Int,10>        test_index_1d;
   ekat::util::md_array<Int, 5,10>     test_index_2d;
   ekat::util::md_array<Int, 2, 5,10>  test_index_3d;
-  Real pi = 2*acos(0.0);
+  // Local arrays for BFB comparison
+  std::array<Real,10> comp_x;
+  std::array<Real, 5> comp_y;
+  std::array<Real, 2> comp_z;
+  ekat::util::md_array<Real,3,10>       comp_data_1d;
+  ekat::util::md_array<Real,3, 5,10>    comp_data_2d;
+  ekat::util::md_array<Real,3, 2, 5,10> comp_data_3d;
+  ekat::util::md_array<Int, 3,10>       comp_index_1d;
+  ekat::util::md_array<Int, 3, 5,10>    comp_index_2d;
+  ekat::util::md_array<Int, 3, 2, 5,10> comp_index_3d;
+  for (int tt=0;tt<3;tt++) {
+    for (decltype(comp_x)::size_type ii=0;ii<x_data.size();ii++) {
+      comp_x[ii] = 2.0*pi/comp_x.size()*(ii+1);
+      comp_data_1d[tt][ii] = 0.1 * cos(comp_x[ii]+tt*dt);
+      comp_index_1d[tt][ii] = ii + 10000*tt;
+      for (decltype(comp_y)::size_type jj=0;jj<5;jj++) {
+        comp_y[jj] = 4.0*pi/comp_y.size()*(jj+1);
+        comp_data_2d[tt][jj][ii] = 0.1 * cos(comp_x[ii]+tt*dt) * sin(comp_y[jj]+tt*dt);
+        comp_index_2d[tt][jj][ii] = ii + jj*100 + 10000*tt;
+        for (decltype(comp_z)::size_type kk=0;kk<2;kk++) {
+          comp_z[kk] = 100*(kk+1);
+          comp_data_3d[tt][kk][jj][ii] = 0.1 * cos(comp_x[ii]+tt*dt) * sin(comp_y[jj]+tt*dt) + comp_z[kk];
+          comp_index_3d[tt][kk][jj][ii] = ii + jj*100 + 1000*kk + 10000*tt;
+        } //comp_z
+      } //comp_y
+    } //comp_x
+  } //tt
 
-  grid_read_data_array(infilename,"x",xdim,ekat::util::data(x_data));
-  grid_read_data_array(infilename,"y",ydim,ekat::util::data(y_data));
-  grid_read_data_array(infilename,"z",zdim,ekat::util::data(z_data));
+  // Degrees of Freedom decomposition of input arrays
+  std::array<Int,1> dof_x;
+  std::array<Int,1> dof_y;
+  std::array<Int,1> dof_z;
+  std::array<Int,1> dof_test_1d;
+  std::array<Int,1> dof_test_2d;
+  std::array<Int,1> dof_test_3d;
+  Int xstart,xstop;
+  Int ystart,ystop;
+  Int zstart,zstop;
+  Int test_1d_start,test_1d_stop;
+  Int test_2d_start,test_2d_stop;
+  Int test_3d_start,test_3d_stop;
 
-  for (decltype(x_data)::size_type ii=0;ii<x_data.size();ii++) {
-    REQUIRE( x_data[ii] == 2.0*pi/x_data.size()*(ii+1) );
-  }
-  for (decltype(y_data)::size_type jj=0;jj<5;jj++) {
-    REQUIRE( y_data[jj] == 4.0*pi/y_data.size()*(jj+1) );
-  }
-  for (decltype(z_data)::size_type kk=0;kk<2;kk++) {
-    REQUIRE( z_data[kk] == 100*(kk+1) );
-  }
+  set_dof(infilename,"time",0,0);
 
-  Real dt = 1.0;
+  get_dof(ekat::util::size(x_data), myrank, numranks, dof_x[0], xstart,xstop);
+  std::vector<Int> x_dof(dof_x[0]);
+  for (int ii=xstart,cnt=0;ii<=xstop;++ii,++cnt) {
+    x_dof[cnt] = ii+1;
+  }
+  set_dof(infilename,"x",dof_x[0],x_dof.data());
+
+  get_dof(ekat::util::size(y_data), myrank, numranks, dof_y[0], ystart,ystop);
+  std::vector<Int> y_dof(dof_y[0]);
+  for (int ii=ystart,cnt=0;ii<=ystop;++ii,++cnt) {
+    y_dof[cnt] = ii+1;
+  }
+  set_dof(infilename,"y",dof_y[0],y_dof.data());
+
+  get_dof(ekat::util::size(z_data), myrank, numranks, dof_z[0], zstart,zstop);
+  std::vector<Int> z_dof(dof_z[0]);
+  for (int ii=zstart,cnt=0;ii<=zstop;++ii,++cnt) {
+    z_dof[cnt] = ii+1;
+  }
+  set_dof(infilename,"z",dof_z[0],z_dof.data());
+
+  get_dof(dimlen_1d[0], myrank, numranks, dof_test_1d[0], test_1d_start,test_1d_stop);
+  std::vector<Int> test1d_dof(dof_test_1d[0]);
+  for (int ii=test_1d_start,cnt=0;ii<=test_1d_stop;++ii,++cnt) {
+    test1d_dof[cnt] = ii+1;
+  }
+  set_dof(infilename,"index_1d",dof_test_1d[0],test1d_dof.data());
+  set_dof(infilename,"data_1d",dof_test_1d[0],test1d_dof.data());
+
+  get_dof(dimlen_2d[0]*dimlen_2d[1], myrank, numranks, dof_test_2d[0], test_2d_start,test_2d_stop);
+  std::vector<Int> test2d_dof(dof_test_2d[0]);
+  for (int ii=test_2d_start,cnt=0;ii<=test_2d_stop;++ii,++cnt) {
+    test2d_dof[cnt] = ii+1;
+  }
+  set_dof(infilename,"index_2d",dof_test_2d[0],test2d_dof.data());
+  set_dof(infilename,"data_2d",dof_test_2d[0],test2d_dof.data());
+
+  get_dof(dimlen_3d[0]*dimlen_3d[1]*dimlen_3d[2], myrank, numranks, dof_test_3d[0], test_3d_start,test_3d_stop);
+  std::vector<Int> test3d_dof(dof_test_3d[0]);
+  for (int ii=test_3d_start,cnt=0;ii<=test_3d_stop;++ii,++cnt) {
+    test3d_dof[cnt] = ii+1;
+  }
+  set_dof(infilename,"index_3d",dof_test_3d[0],test3d_dof.data());
+  set_dof(infilename,"data_3d",dof_test_3d[0],test3d_dof.data());
+
+  set_decomp(infilename);
+  // Read input data and compare
+  grid_read_data_array(infilename,"x",dof_x[0],ekat::util::data(x_data)+xstart);
+  grid_read_data_array(infilename,"y",dof_y[0],ekat::util::data(y_data)+ystart);
+  grid_read_data_array(infilename,"z",dof_z[0],ekat::util::data(z_data)+zstart);
+
+  for (Int ii=xstart;ii<=xstop;ii++) {
+    if (x_data[ii] != comp_x[ii]) { ++nerr;}
+  }
+  REQUIRE(nerr==0);
+  nerr = 0;
+  for (Int jj=ystart;jj<=ystop;jj++) {
+    if (y_data[jj] != comp_y[jj]) { ++nerr;}
+  }
+  REQUIRE(nerr==0);
+  nerr = 0;
+  for (Int kk=zstart;kk<=zstop;kk++) {
+    if (z_data[kk] != comp_z[kk]) { ++nerr;}
+  }
+  REQUIRE(nerr==0);
+  nerr = 0;
   for (int tt=0;tt<3;tt++) {
     pio_update_time(infilename,-999.0);
-    grid_read_data_array(infilename,"data_1d",dimlen_1d,ekat::util::data(test_data_1d));
-    grid_read_data_array(infilename,"data_2d",dimlen_2d,ekat::util::data(test_data_2d));
-    grid_read_data_array(infilename,"data_3d",dimlen_3d,ekat::util::data(test_data_3d));
-    grid_read_data_array(infilename,"index_1d",dimlen_1d,ekat::util::data(test_index_1d));
-    grid_read_data_array(infilename,"index_2d",dimlen_2d,ekat::util::data(test_index_2d));
-    grid_read_data_array(infilename,"index_3d",dimlen_3d,ekat::util::data(test_index_3d));
-    for (int ii=0;ii<x_data.size();ii++) {
-      REQUIRE(test_data_1d[ii] == f_x(x_data[ii],tt*dt));
-      REQUIRE(test_index_1d[ii]== ind_x(ii) + ind_t(tt));
-      for (int jj=0;jj<5;jj++) {
-        REQUIRE(test_index_2d[jj][ii] == ind_y(jj) + ind_x(ii) + ind_t(tt));
-        REQUIRE(test_data_2d[jj][ii] == (f_x(x_data[ii],tt*dt)*f_y(y_data[jj],tt*dt)));
-        for (int kk=0;kk<2;kk++) {
-          REQUIRE(test_index_3d[kk][jj][ii] == ind_z(kk) + ind_y(jj) + ind_x(ii) + ind_t(tt));
-          REQUIRE(test_data_3d[kk][jj][ii] ==((f_x(x_data[ii],tt*dt)*f_y(y_data[jj],tt*dt))+f_z(z_data[kk],tt*dt)));
-        } //kk
-      } //jj
-    } //ii
+    grid_read_data_array(infilename,"index_1d",dof_test_1d[0],ekat::util::data(test_index_1d)+test_1d_start);
+    grid_read_data_array(infilename,"index_2d",dof_test_2d[0],ekat::util::data(test_index_2d)+test_2d_start);
+    grid_read_data_array(infilename,"index_3d",dof_test_3d[0],ekat::util::data(test_index_3d)+test_3d_start);
+    grid_read_data_array(infilename,"data_1d", dof_test_1d[0],ekat::util::data(test_data_1d) +test_1d_start);
+    grid_read_data_array(infilename,"data_2d", dof_test_2d[0],ekat::util::data(test_data_2d) +test_2d_start);
+    grid_read_data_array(infilename,"data_3d", dof_test_3d[0],ekat::util::data(test_data_3d) +test_3d_start);
+    for (int ii=test_1d_start;ii<test_1d_stop;ii++) {
+      if (*(ekat::util::data(test_index_1d) + ii) != *(ekat::util::data(comp_index_1d[tt]) + ii)) {++nerr;}
+      if (*(ekat::util::data(test_data_1d) + ii)  != *(ekat::util::data(comp_data_1d[tt]) + ii))  {++nerr;}
+    }
+    REQUIRE(nerr==0);
+    nerr = 0;
+    for (int ii=test_2d_start;ii<test_2d_stop;ii++) {
+      if (*(ekat::util::data(test_index_2d) + ii) != *(ekat::util::data(comp_index_2d[tt]) + ii)) {++nerr;}
+      if (*(ekat::util::data(test_data_2d) + ii)  != *(ekat::util::data(comp_data_2d[tt]) + ii))  {++nerr;}
+    }
+    REQUIRE(nerr==0);
+    nerr = 0;
+    for (int ii=test_3d_start;ii<test_3d_stop;ii++) {
+      if (*(ekat::util::data(test_index_3d) + ii) != *(ekat::util::data(comp_index_3d[tt]) + ii)) {++nerr;}
+      if (*(ekat::util::data(test_data_3d) + ii)  != *(ekat::util::data(comp_data_3d[tt]) + ii))  {++nerr;}
+    }
+    REQUIRE(nerr==0);
   } //tt
+
   eam_pio_finalize();
 } // TEST scorpio_interface_input
 /* ================================================================================================================ */
 /*                                   Local functions to be used for tests:                                          */
+Real x_i(const Int ii, const Int x_len) {
+  Real x;
+  Real pi = 2*acos(0.0);
+  x = 2.0*pi/x_len*(ii+1);
+  return x;
+}
+Real y_i(const Int ii, const Int y_len) {
+  Real y;
+  Real pi = 2*acos(0.0);
+  y = 4.0*pi/y_len*(ii+1);
+  return y;
+}
+Real z_i(const Int ii, const Int z_len) {
+  Real z;
+  z = 100*(ii+1);
+  return z;
+}
 Real f_x(const Real x, const Real t) {
   Real f;
   f = 0.1 * cos(x+t);
@@ -235,6 +586,28 @@ Int ind_z(const Int kk) {
 }
 Int ind_t(const Int tt) {
   return 10000*tt;
+}
+
+void get_dof(const std::size_t dimsize, const Int myrank, const Int numranks, Int &dof_len, Int &istart, Int &istop) {
+
+  dof_len = dimsize/numranks;
+  Int extra_procs;
+  extra_procs = dimsize % numranks;
+  if (extra_procs>0) {
+    dof_len = dof_len+1;
+  }
+  istart = myrank*dof_len;
+  if (myrank == numranks-1) {
+    dof_len = std::max((Int) dimsize-istart,0);
+  }
+  istop = istart + dof_len-1;
+  // Final check that we don't have more ranks than total dof
+  if (istart >= dimsize) {
+    dof_len = 0;
+    istop = istart - 1;
+  }
+
+  return;
 }
 /* ================================================================================================================ */
 } //namespace

--- a/components/scream/src/mct_coupling/tests/scorpio_tests.cpp
+++ b/components/scream/src/mct_coupling/tests/scorpio_tests.cpp
@@ -280,34 +280,28 @@ TEST_CASE("scorpio_interface_output", "") {
   grid_read_data_array(outfilename,"x",dof_x[0],ekat::util::data(x_data)+xstart);
   grid_read_data_array(outfilename,"y",dof_y[0],ekat::util::data(y_data)+ystart);
   grid_read_data_array(outfilename,"z",dof_z[0],ekat::util::data(z_data)+zstart);
-  nerr = 0;
   for (Int ii=xstart;ii<=xstop;ii++) {
     if (x_data[ii] != x_i(ii,x_data.size())) { ++nerr;}
   }
   REQUIRE(nerr==0);
-  nerr = 0;
   for (Int jj=ystart;jj<=ystop;jj++) {
     if (y_data[jj] != y_i(jj,y_data.size())) { ++nerr;}
   }
   REQUIRE(nerr==0);
-  nerr = 0;
   for (Int kk=zstart;kk<=zstop;kk++) {
-    if (z_data[kk] != z_i(kk,z_data.size())) { ++nerr; std::printf("   - (%d) %f vs. %f\n",kk,z_data[kk],z_i(kk,z_data.size()));}
+    if (z_data[kk] != z_i(kk,z_data.size())) { ++nerr;} 
   }
   REQUIRE(nerr==0);
   /* Now read and compare the field data for each of the timestep */
-  nerr = 0;
   for (int tt=0;tt<3;tt++) {
     pio_update_time(outfilename,-999.0);
     grid_read_data_array(outfilename,"index_1d",dof_test_1d[0],ekat::util::data(test_index_1d)+test_1d_start);
     grid_read_data_array(outfilename,"data_1d", dof_test_1d[0],ekat::util::data(test_data_1d) +test_1d_start);
-    nerr = 0;
     for (int ii=0,ind=test_1d_start;ind<test_1d_stop;ii++,ind++) {
       if (*(ekat::util::data(test_data_1d) + ind)  != f_x(x_data[ind],tt*dt)) {++nerr;}
       if (*(ekat::util::data(test_index_1d) + ind) != ind_x(ind) + ind_t(tt))  {++nerr;}
     }
     REQUIRE(nerr==0);
-    nerr = 0;
     grid_read_data_array(outfilename,"index_2d",dof_test_2d[0],ekat::util::data(test_index_2d)+test_2d_start);
     grid_read_data_array(outfilename,"data_2d", dof_test_2d[0],ekat::util::data(test_data_2d) +test_2d_start);
     for (int ind=test_2d_start;ind<=test_2d_stop;ind++) {
@@ -317,7 +311,6 @@ TEST_CASE("scorpio_interface_output", "") {
       if (*(ekat::util::data(test_index_2d) + ind) != ind_y(jj) + ind_x(ii) + ind_t(tt))  {++nerr;}
     }
     REQUIRE(nerr==0);
-    nerr = 0;
     grid_read_data_array(outfilename,"index_3d",dof_test_3d[0],ekat::util::data(test_index_3d)+test_3d_start);
     grid_read_data_array(outfilename,"data_3d", dof_test_3d[0],ekat::util::data(test_data_3d) +test_3d_start);
     for (int ind=test_3d_start;ind<=test_3d_stop;ind++) {
@@ -501,17 +494,14 @@ TEST_CASE("scorpio_interface_input", "") {
     if (x_data[ii] != comp_x[ii]) { ++nerr;}
   }
   REQUIRE(nerr==0);
-  nerr = 0;
   for (Int jj=ystart;jj<=ystop;jj++) {
     if (y_data[jj] != comp_y[jj]) { ++nerr;}
   }
   REQUIRE(nerr==0);
-  nerr = 0;
   for (Int kk=zstart;kk<=zstop;kk++) {
     if (z_data[kk] != comp_z[kk]) { ++nerr;}
   }
   REQUIRE(nerr==0);
-  nerr = 0;
   for (int tt=0;tt<3;tt++) {
     pio_update_time(infilename,-999.0);
     grid_read_data_array(infilename,"index_1d",dof_test_1d[0],ekat::util::data(test_index_1d)+test_1d_start);
@@ -525,13 +515,11 @@ TEST_CASE("scorpio_interface_input", "") {
       if (*(ekat::util::data(test_data_1d) + ii)  != *(ekat::util::data(comp_data_1d[tt]) + ii))  {++nerr;}
     }
     REQUIRE(nerr==0);
-    nerr = 0;
     for (int ii=test_2d_start;ii<test_2d_stop;ii++) {
       if (*(ekat::util::data(test_index_2d) + ii) != *(ekat::util::data(comp_index_2d[tt]) + ii)) {++nerr;}
       if (*(ekat::util::data(test_data_2d) + ii)  != *(ekat::util::data(comp_data_2d[tt]) + ii))  {++nerr;}
     }
     REQUIRE(nerr==0);
-    nerr = 0;
     for (int ii=test_3d_start;ii<test_3d_stop;ii++) {
       if (*(ekat::util::data(test_index_3d) + ii) != *(ekat::util::data(comp_index_3d[tt]) + ii)) {++nerr;}
       if (*(ekat::util::data(test_data_3d) + ii)  != *(ekat::util::data(comp_data_3d[tt]) + ii))  {++nerr;}
@@ -588,10 +576,11 @@ Int ind_t(const Int tt) {
   return 10000*tt;
 }
 
-void get_dof(const std::size_t dimsize, const Int myrank, const Int numranks, Int &dof_len, Int &istart, Int &istop) {
+void get_dof(const std::size_t dimsize_in, const Int myrank, const Int numranks, Int &dof_len, Int &istart, Int &istop) {
 
+  Int extra_procs, dimsize;
+  dimsize = dimsize_in;
   dof_len = dimsize/numranks;
-  Int extra_procs;
   extra_procs = dimsize % numranks;
   if (extra_procs>0) {
     dof_len = dof_len+1;
@@ -600,13 +589,8 @@ void get_dof(const std::size_t dimsize, const Int myrank, const Int numranks, In
   if (myrank == numranks-1) {
     dof_len = std::max((Int) dimsize-istart,0);
   }
-  istop = istart + dof_len-1;
-  // Final check that we don't have more ranks than total dof
-  if (istart >= dimsize) {
-    dof_len = 0;
-    istop = istart - 1;
-  }
-
+  istop = std::min(istart + dof_len-1,dimsize-1);
+  dof_len = std::max(istop-istart + 1,0);
   return;
 }
 /* ================================================================================================================ */


### PR DESCRIPTION
This commit solves an issue which resulted from running the scorpio_interface
tests with the number of PIO ranks > 1.

The fix involves allows individual ranks to assign themselves a subset of the
total number of degree's of freedom (dof) for a given data array for I/O purposes.

In the case where # MPI ranks > total dof, excess mpi ranks should be assigned
0 degree's of freedom for I/O involving that variable.  See get_dof and set_dof
subroutines.  Note that PIO is ambivalent about the dimensions that make up the dof.
So a single column with multiple vertical levels can still be assigned multiple
PIO ranks for I/O.  This is an issue that arises when there are more PIO ranks than
there are absolute number of degrees of freedom for a specific variable.
A typical example would be "time" which has only one degree of freedom, so only one rank
needs to write this to output.
Another  example would be when writing a single dimension.  Like writing the hybrid 
vertical level coordinates (length = 72-128-?) with as many PIO ranks assigned as there
are columns, O(1000).  We only want a maximum of "vertical length" ranks writing to file.

The scorpio_interface unit tests have been updated reflecting this change.

Additionally, substantial comments have been included in the tests in order
to facilitate future users to understand each step that goes into I/O.

Changes that were requested for PR #451, but were not incorporated before that
PR was merged by the autotester have been made in this PR.