### PR TITLE
Introduce structs to high-level P3 interface

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1060,10 +1060,10 @@ contains
   !==========================================================================================!
 
   SUBROUTINE p3_main(qc,nc,qr,nr,th,qv,dt,qitot,qirim,nitot,birim,   &
-       pres,dzq,ncnuc,naai,qc_relvar,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
-       diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
+       pres,dzq,ncnuc,naai,qc_relvar,it,prt_liq,prt_sol,its,ite,kts,kte,diag_effc,     &
+       diag_effi,diag_rhoi,log_predictNc, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,  &
-       pratot,prctot,p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
+       p3_tend_out,mu_c,liq_ice_exchange,vap_liq_exchange, &
        vap_ice_exchange,col_location)
 
     !----------------------------------------------------------------------------------------!
@@ -1105,14 +1105,10 @@ contains
 
     real(rtype), intent(out),   dimension(its:ite)              :: prt_liq    ! precipitation rate, liquid       m s-1
     real(rtype), intent(out),   dimension(its:ite)              :: prt_sol    ! precipitation rate, solid        m s-1
-    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_ze    ! equivalent reflectivity          dBZ
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_effc  ! effective radius, cloud          m
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_effi  ! effective radius, ice            m
-    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_vmi   ! mass-weighted fall speed of ice  m s-1
-    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_di    ! mean diameter of ice             m
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_rhoi  ! bulk density of ice              kg m-3
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: mu_c       ! Size distribution shape parameter for radiation
-    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: lamc       ! Size distribution slope parameter for radiation
 
     integer, intent(in)                                  :: its,ite    ! array bounds (horizontal)
     integer, intent(in)                                  :: kts,kte    ! array bounds (vertical)
@@ -1130,8 +1126,6 @@ contains
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: prer_evap  ! evaporation of rain
     real(rtype), intent(out),   dimension(its:ite,kts:kte+1)    :: rflx       ! grid-box average rain flux (kg m^-2 s^-1) pverp
     real(rtype), intent(out),   dimension(its:ite,kts:kte+1)    :: sflx       ! grid-box average ice/snow flux (kg m^-2 s^-1) pverp
-    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: pratot     ! accretion of cloud by rain
-    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: prctot     ! autoconversion of cloud to rain
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: liq_ice_exchange ! sum of liq-ice phase change tendenices
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: vap_liq_exchange ! sum of vap-liq phase change tendenices
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: vap_ice_exchange ! sum of vap-ice phase change tendenices
@@ -1148,6 +1142,14 @@ contains
     !
     !----- Local variables and parameters:  -------------------------------------------------!
     !
+
+    ! These outputs are no longer provided by p3_main.
+    real(rtype), dimension(its:ite,kts:kte) :: diag_ze  ! equivalent reflectivity          dBZ
+    real(rtype), dimension(its:ite,kts:kte) :: diag_vmi ! mass-weighted fall speed of ice  m s-1
+    real(rtype), dimension(its:ite,kts:kte) :: diag_di  ! mean diameter of ice             m
+    real(rtype), dimension(its:ite,kts:kte) :: lamc     ! Size distribution slope parameter for radiation
+    real(rtype), dimension(its:ite,kts:kte) :: pratot   ! accretion of cloud by rain
+    real(rtype), dimension(its:ite,kts:kte) :: prctot   ! autoconversion of cloud to rain
 
     real(rtype), dimension(its:ite,kts:kte) :: mu_r  ! shape parameter of rain
     real(rtype), dimension(its:ite,kts:kte) :: t     ! temperature at the beginning of the microhpysics step [K]

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1063,7 +1063,7 @@ contains
        pres,dzq,ncnuc,naai,qc_relvar,it,prt_liq,prt_sol,its,ite,kts,kte,diag_effc,     &
        diag_effi,diag_rhoi,log_predictNc, &
        pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm,  &
-       p3_tend_out,mu_c,liq_ice_exchange,vap_liq_exchange, &
+       p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
        vap_ice_exchange,col_location)
 
     !----------------------------------------------------------------------------------------!
@@ -1109,6 +1109,7 @@ contains
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_effi  ! effective radius, ice            m
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_rhoi  ! bulk density of ice              kg m-3
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: mu_c       ! Size distribution shape parameter for radiation
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: lamc       ! Size distribution slope parameter for radiation
 
     integer, intent(in)                                  :: its,ite    ! array bounds (horizontal)
     integer, intent(in)                                  :: kts,kte    ! array bounds (vertical)
@@ -1147,7 +1148,6 @@ contains
     real(rtype), dimension(its:ite,kts:kte) :: diag_ze  ! equivalent reflectivity          dBZ
     real(rtype), dimension(its:ite,kts:kte) :: diag_vmi ! mass-weighted fall speed of ice  m s-1
     real(rtype), dimension(its:ite,kts:kte) :: diag_di  ! mean diameter of ice             m
-    real(rtype), dimension(its:ite,kts:kte) :: lamc     ! Size distribution slope parameter for radiation
     real(rtype), dimension(its:ite,kts:kte) :: pratot   ! accretion of cloud by rain
     real(rtype), dimension(its:ite,kts:kte) :: prctot   ! autoconversion of cloud to rain
 

--- a/components/scream/ekat/src/ekat/util/scream_arch.cpp
+++ b/components/scream/ekat/src/ekat/util/scream_arch.cpp
@@ -31,7 +31,7 @@ std::string active_avx_string () {
 std::string config_string () {
   std::stringstream ss;
   ss << "ExecSpace name: " << DefaultDevice::execution_space::name() << "\n";
-//  ss << "ExecSpace initialized: " << (DefaultDevice::execution_space::impl_is_initialized() ? "yes" : "no") << "\n";
+  ss << "ExecSpace initialized: " << (DefaultDevice::execution_space::impl_is_initialized() ? "yes" : "no") << "\n";
   ss << "sizeof(Real) " << sizeof(Real)
      << " avx " << active_avx_string()
      // << " packsize " << SCREAM_PACK_SIZE

--- a/components/scream/ekat/src/ekat/util/scream_arch.cpp
+++ b/components/scream/ekat/src/ekat/util/scream_arch.cpp
@@ -31,7 +31,7 @@ std::string active_avx_string () {
 std::string config_string () {
   std::stringstream ss;
   ss << "ExecSpace name: " << DefaultDevice::execution_space::name() << "\n";
-  ss << "ExecSpace initialized: " << (DefaultDevice::execution_space::impl_is_initialized() ? "yes" : "no") << "\n";
+//  ss << "ExecSpace initialized: " << (DefaultDevice::execution_space::impl_is_initialized() ? "yes" : "no") << "\n";
   ss << "sizeof(Real) " << sizeof(Real)
      << " avx " << active_avx_string()
      // << " packsize " << SCREAM_PACK_SIZE

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -100,11 +100,10 @@ contains
   end subroutine p3_init_c
 
   subroutine p3_main_c(qc,nc,qr,nr,th,qv,dt,qitot,qirim,nitot,birim,   &
-       pres,dzq,ncnuc,naai,qc_relvar,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
-       diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
-       pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm, &
-       pratot,prctot,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
-       vap_ice_exchange) bind(C)
+       pres,dzq,ncnuc,naai,qc_relvar,it,prt_liq,prt_sol,its,ite,kts,kte,diag_effc,     &
+       diag_effi,diag_rhoi,log_predictNc, pdel,exner,cmeiout,prain,nevapr, &
+       prer_evap,rflx,sflx,rcldm,lcldm,icldm,mu_c,liq_ice_exchange, &
+       vap_liq_exchange, vap_ice_exchange) bind(C)
     use micro_p3, only : p3_main
 
     real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, qv, th
@@ -114,8 +113,8 @@ contains
     real(kind=c_real), intent(in), dimension(its:ite,kts:kte) :: qc_relvar
     real(kind=c_real), value, intent(in) :: dt
     real(kind=c_real), intent(out), dimension(its:ite) :: prt_liq, prt_sol
-    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_ze, diag_effc
-    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_effi, diag_vmi, diag_di, diag_rhoi
+    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_effc
+    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_effi, diag_rhoi
     integer(kind=c_int), value, intent(in) :: its,ite, kts,kte, it
     logical(kind=c_bool), value, intent(in) :: log_predictNc
 
@@ -128,14 +127,12 @@ contains
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte+1)    :: rflx
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte+1)    :: sflx
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: icldm, lcldm, rcldm
-    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: pratot,prctot
-    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: mu_c,lamc
+    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: mu_c
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: liq_ice_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_liq_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_ice_exchange
 
     real(kind=c_real), dimension(its:ite,kts:kte,49)   :: p3_tend_out
-
     real(kind=c_real), dimension(its:ite,3) :: col_location
     integer :: i
     do i = its,ite
@@ -143,11 +140,10 @@ contains
     end do
 
     call p3_main(qc,nc,qr,nr,th,qv,dt,qitot,qirim,nitot,birim,   &
-         pres,dzq,ncnuc,naai,qc_relvar,it,prt_liq,prt_sol,its,ite,kts,kte,diag_ze,diag_effc,     &
-         diag_effi,diag_vmi,diag_di,diag_rhoi,log_predictNc, &
-         pdel,exner,cmeiout,prain,nevapr,prer_evap,rflx,sflx,rcldm,lcldm,icldm, &
-         pratot,prctot,p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
-         vap_ice_exchange, col_location)
+         pres,dzq,ncnuc,naai,qc_relvar,it,prt_liq,prt_sol,its,ite,kts,kte,diag_effc, &
+         diag_effi,diag_rhoi,log_predictNc,pdel,exner,cmeiout,prain,nevapr, &
+         prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out,mu_c,liq_ice_exchange,&
+         vap_liq_exchange, vap_ice_exchange, col_location)
   end subroutine p3_main_c
 
   subroutine micro_p3_utils_init_c(Cpair, Rair, RH2O, RhoH2O, &

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -102,7 +102,7 @@ contains
   subroutine p3_main_c(qc,nc,qr,nr,th,qv,dt,qitot,qirim,nitot,birim,   &
        pres,dzq,ncnuc,naai,qc_relvar,it,prt_liq,prt_sol,its,ite,kts,kte,diag_effc,     &
        diag_effi,diag_rhoi,log_predictNc, pdel,exner,cmeiout,prain,nevapr, &
-       prer_evap,rflx,sflx,rcldm,lcldm,icldm,mu_c,liq_ice_exchange, &
+       prer_evap,rflx,sflx,rcldm,lcldm,icldm,mu_c,lamc,liq_ice_exchange, &
        vap_liq_exchange, vap_ice_exchange) bind(C)
     use micro_p3, only : p3_main
 
@@ -127,7 +127,7 @@ contains
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte+1)    :: rflx
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte+1)    :: sflx
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: icldm, lcldm, rcldm
-    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: mu_c
+    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: mu_c, lamc
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: liq_ice_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_liq_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_ice_exchange
@@ -142,7 +142,7 @@ contains
     call p3_main(qc,nc,qr,nr,th,qv,dt,qitot,qirim,nitot,birim,   &
          pres,dzq,ncnuc,naai,qc_relvar,it,prt_liq,prt_sol,its,ite,kts,kte,diag_effc, &
          diag_effi,diag_rhoi,log_predictNc,pdel,exner,cmeiout,prain,nevapr, &
-         prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out,mu_c,liq_ice_exchange,&
+         prer_evap,rflx,sflx,rcldm,lcldm,icldm,p3_tend_out,mu_c,lamc,liq_ice_exchange,&
          vap_liq_exchange, vap_ice_exchange, col_location)
   end subroutine p3_main_c
 

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -22,7 +22,7 @@ extern "C" {
                  Real* diag_rhoi, bool log_predictNc, Real* pdel, Real* exner,
                  Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap,
                  Real* rflx, Real* sflx, // 1 extra column size
-                 Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c,
+                 Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c, Real* lamc,
                  Real* liq_ice_exchange, Real* vap_liq_exchange,
                  Real* vap_ice_exchange);
 }
@@ -69,8 +69,8 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   rcldm = Array2("Rain cloud fraction", ncol, nlev);
   lcldm = Array2("Liquid cloud fraction", ncol, nlev);
   icldm = Array2("Ice cloud fraction", ncol, nlev);
-  mu_c = Array2("Cloud size distribution shape paramter", ncol, nlev);
-  mu_r = Array2("Rain size distribution shape paramter", ncol, nlev);
+  mu_c = Array2("Size distribution shape paramter", ncol, nlev);
+  lamc = Array2("Size distribution slope paramter", ncol, nlev);
   liq_ice_exchange = Array2("sum of liq-ice phase change tendenices", ncol, nlev);
   vap_liq_exchange = Array2("sum of vap-liq phase change tendenices", ncol, nlev);
   vap_ice_exchange = Array2("sum of vap-ice phase change tendenices", ncol, nlev);
@@ -96,7 +96,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(pdel); fdipb(exner); fdipb(cmeiout); fdipb(prain);
   fdipb(nevapr); fdipb(prer_evap); fdipb(rflx); fdipb(sflx);
   fdipb(rcldm); fdipb(lcldm); fdipb(icldm);
-  fdipb(mu_c); fdipb(mu_r), fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
+  fdipb(mu_c); fdipb(lamc), fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
   fdipb(vap_ice_exchange);;
 #undef fdipb
 }
@@ -137,8 +137,7 @@ void p3_main (const FortranData& d, bool use_fortran) {
               d.log_predictNc, d.pdel.data(), d.exner.data(), d.cmeiout.data(),
               d.prain.data(), d.nevapr.data(), d.prer_evap.data(),
               d.rflx.data(), d.sflx.data(), d.rcldm.data(), d.lcldm.data(),
-              d.icldm.data(), d.mu_c.data(),
-              // TODO: We don't currently get mu_r from Fortran.
+              d.icldm.data(), d.mu_c.data(), d.lamc.data(),
               d.liq_ice_exchange.data(),
               d.vap_liq_exchange.data(),d.vap_ice_exchange.data());
   }
@@ -152,7 +151,7 @@ void p3_main (const FortranData& d, bool use_fortran) {
               d.pdel.data(), d.exner.data(), d.cmeiout.data(), d.prain.data(),
               d.nevapr.data(), d.prer_evap.data(), d.rflx.data(), d.sflx.data(),
               d.rcldm.data(), d.lcldm.data(), d.icldm.data(), d.mu_c.data(),
-              d.mu_r.data(), d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),
+              d.lamc.data(), d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),
               d.vap_ice_exchange.data());
   }
 }

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -17,17 +17,14 @@ extern "C" {
                  Real* qv, Real dt, Real* qitot, Real* qirim,
                  Real* nitot, Real* birim, Real* pres,
                  Real* dzq, Real* ncnuc, Real* naai, Real* qc_relvar,
-		 Int it, Real* prt_liq, Real* prt_sol, Int its,
-                 Int ite, Int kts, Int kte, Real* diag_ze,
-                 Real* diag_effc, Real* diag_effi, Real* diag_vmi,
-                 Real* diag_di, Real* diag_rhoi,
-                 bool log_predictNc,
-                 Real* pdel, Real* exner, Real* cmeiout, Real* prain,
-                 Real* nevapr, Real* prer_evap,
+                 Int it, Real* prt_liq, Real* prt_sol, Int its,
+                 Int ite, Int kts, Int kte, Real* diag_effc, Real* diag_effi,
+                 Real* diag_rhoi, bool log_predictNc, Real* pdel, Real* exner,
+                 Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap,
                  Real* rflx, Real* sflx, // 1 extra column size
-                 Real* rcldm, Real* lcldm, Real* icldm, Real* pratot, Real* prctot,
-                 Real* mu_c, Real* lamc, Real* liq_ice_exchange,
-                 Real* vap_liq_exchange, Real* vap_ice_exchange);
+                 Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c,
+                 Real* liq_ice_exchange, Real* vap_liq_exchange,
+                 Real* vap_ice_exchange);
 }
 
 namespace scream {
@@ -60,11 +57,8 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   // Out
   prt_liq = Array1("precipitation rate, liquid  m/s", ncol);
   prt_sol = Array1("precipitation rate, solid   m/s", ncol);
-  diag_ze = Array2("equivalent reflectivity, dBZ", ncol, nlev);
   diag_effc = Array2("effective radius, cloud, m", ncol, nlev);
   diag_effi = Array2("effective radius, ice, m", ncol, nlev);
-  diag_vmi = Array2("mass-weighted fall speed of ice, m/s", ncol, nlev);
-  diag_di = Array2("mean diameter of ice, m", ncol, nlev);
   diag_rhoi = Array2("bulk density of ice, kg/m", ncol, nlev);
   cmeiout = Array2("qitend due to deposition/sublimation ", ncol, nlev);
   prain = Array2("Total precipitation (rain + snow)", ncol, nlev);
@@ -75,10 +69,7 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   rcldm = Array2("Rain cloud fraction", ncol, nlev);
   lcldm = Array2("Liquid cloud fraction", ncol, nlev);
   icldm = Array2("Ice cloud fraction", ncol, nlev);
-  pratot = Array2("Cloud drop accretion by rain", ncol, nlev);
-  prctot = Array2("Cloud drop autoconversion to rain", ncol, nlev);
   mu_c = Array2("Size distribution shape paramter", ncol, nlev);
-  lamc = Array2("Size distribution slope paramter", ncol, nlev);
   liq_ice_exchange = Array2("sum of liq-ice phase change tendenices", ncol, nlev);
   vap_liq_exchange = Array2("sum of vap-liq phase change tendenices", ncol, nlev);
   vap_ice_exchange = Array2("sum of vap-ice phase change tendenices", ncol, nlev);
@@ -100,13 +91,11 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(dzq); fdipb(ncnuc); fdipb(naai); fdipb(qc_relvar); fdipb(qc);
   fdipb(nc); fdipb(qr); fdipb(nr); fdipb(qitot); fdipb(nitot);
   fdipb(qirim); fdipb(birim); fdipb(prt_liq); fdipb(prt_sol);
-  fdipb(diag_ze); fdipb(diag_effc); fdipb(diag_effi);
-  fdipb(diag_vmi); fdipb(diag_di); fdipb(diag_rhoi);
+  fdipb(diag_effc); fdipb(diag_effi); fdipb(diag_rhoi);
   fdipb(pdel); fdipb(exner); fdipb(cmeiout); fdipb(prain);
   fdipb(nevapr); fdipb(prer_evap); fdipb(rflx); fdipb(sflx);
   fdipb(rcldm); fdipb(lcldm); fdipb(icldm);
-  fdipb(pratot); fdipb(prctot);
-  fdipb(mu_c); fdipb(lamc); fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
+  fdipb(mu_c); fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
   fdipb(vap_ice_exchange);;
 #undef fdipb
 }
@@ -142,34 +131,26 @@ void p3_main (const FortranData& d, bool use_fortran) {
               d.th.data(), d.qv.data(), d.dt, d.qitot.data(),
               d.qirim.data(), d.nitot.data(), d.birim.data(),
               d.pres.data(), d.dzq.data(), d.ncnuc.data(), d.naai.data(), d.qc_relvar.data(),
-              d.it, d.prt_liq.data(),
-              d.prt_sol.data(), 1, d.ncol, 1, d.nlev, d.diag_ze.data(),
-              d.diag_effc.data(), d.diag_effi.data(), d.diag_vmi.data(),
-              d.diag_di.data(), d.diag_rhoi.data(),
-              d.log_predictNc,
-              d.pdel.data(), d.exner.data(), d.cmeiout.data(), d.prain.data(),
-              d.nevapr.data(), d.prer_evap.data(),
-              d.rflx.data(), d.sflx.data(),
-              d.rcldm.data(), d.lcldm.data(), d.icldm.data(),d.pratot.data(),d.prctot.data(),
-              d.mu_c.data(),d.lamc.data(),d.liq_ice_exchange.data(),
+              d.it, d.prt_liq.data(), d.prt_sol.data(), 1, d.ncol, 1, d.nlev,
+              d.diag_effc.data(), d.diag_effi.data(), d.diag_rhoi.data(),
+              d.log_predictNc, d.pdel.data(), d.exner.data(), d.cmeiout.data(),
+              d.prain.data(), d.nevapr.data(), d.prer_evap.data(),
+              d.rflx.data(), d.sflx.data(), d.rcldm.data(), d.lcldm.data(),
+              d.icldm.data(), d.mu_c.data(), d.liq_ice_exchange.data(),
               d.vap_liq_exchange.data(),d.vap_ice_exchange.data());
   }
   else {
-    p3_main_f(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(),
-              d.th.data(), d.qv.data(), d.dt, d.qitot.data(),
-              d.qirim.data(), d.nitot.data(), d.birim.data(),
-              d.pres.data(), d.dzq.data(), d.ncnuc.data(), d.naai.data(), d.qc_relvar.data(),
-              d.it, d.prt_liq.data(),
-              d.prt_sol.data(), 1, d.ncol, 1, d.nlev, d.diag_ze.data(),
-              d.diag_effc.data(), d.diag_effi.data(), d.diag_vmi.data(),
-              d.diag_di.data(), d.diag_rhoi.data(),
-              d.log_predictNc,
+    p3_main_f(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(), d.th.data(),
+              d.qv.data(), d.dt, d.qitot.data(), d.qirim.data(), d.nitot.data(),
+              d.birim.data(), d.pres.data(), d.dzq.data(), d.ncnuc.data(),
+              d.naai.data(), d.qc_relvar.data(), d.it, d.prt_liq.data(),
+              d.prt_sol.data(), 1, d.ncol, 1, d.nlev, d.diag_effc.data(),
+              d.diag_effi.data(), d.diag_rhoi.data(), d.log_predictNc,
               d.pdel.data(), d.exner.data(), d.cmeiout.data(), d.prain.data(),
-              d.nevapr.data(), d.prer_evap.data(),
-              d.rflx.data(), d.sflx.data(),
-              d.rcldm.data(), d.lcldm.data(), d.icldm.data(),d.pratot.data(),d.prctot.data(),
-              d.mu_c.data(),d.lamc.data(),d.liq_ice_exchange.data(),
-              d.vap_liq_exchange.data(),d.vap_ice_exchange.data());
+              d.nevapr.data(), d.prer_evap.data(), d.rflx.data(), d.sflx.data(),
+              d.rcldm.data(), d.lcldm.data(), d.icldm.data(), d.mu_c.data(),
+              d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),
+              d.vap_ice_exchange.data());
   }
 }
 

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -69,7 +69,8 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   rcldm = Array2("Rain cloud fraction", ncol, nlev);
   lcldm = Array2("Liquid cloud fraction", ncol, nlev);
   icldm = Array2("Ice cloud fraction", ncol, nlev);
-  mu_c = Array2("Size distribution shape paramter", ncol, nlev);
+  mu_c = Array2("Cloud size distribution shape paramter", ncol, nlev);
+  mu_r = Array2("Rain size distribution shape paramter", ncol, nlev);
   liq_ice_exchange = Array2("sum of liq-ice phase change tendenices", ncol, nlev);
   vap_liq_exchange = Array2("sum of vap-liq phase change tendenices", ncol, nlev);
   vap_ice_exchange = Array2("sum of vap-ice phase change tendenices", ncol, nlev);
@@ -95,7 +96,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(pdel); fdipb(exner); fdipb(cmeiout); fdipb(prain);
   fdipb(nevapr); fdipb(prer_evap); fdipb(rflx); fdipb(sflx);
   fdipb(rcldm); fdipb(lcldm); fdipb(icldm);
-  fdipb(mu_c); fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
+  fdipb(mu_c); fdipb(mu_r), fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
   fdipb(vap_ice_exchange);;
 #undef fdipb
 }
@@ -136,7 +137,9 @@ void p3_main (const FortranData& d, bool use_fortran) {
               d.log_predictNc, d.pdel.data(), d.exner.data(), d.cmeiout.data(),
               d.prain.data(), d.nevapr.data(), d.prer_evap.data(),
               d.rflx.data(), d.sflx.data(), d.rcldm.data(), d.lcldm.data(),
-              d.icldm.data(), d.mu_c.data(), d.liq_ice_exchange.data(),
+              d.icldm.data(), d.mu_c.data(),
+              // TODO: We don't currently get mu_r from Fortran.
+              d.liq_ice_exchange.data(),
               d.vap_liq_exchange.data(),d.vap_ice_exchange.data());
   }
   else {
@@ -149,7 +152,7 @@ void p3_main (const FortranData& d, bool use_fortran) {
               d.pdel.data(), d.exner.data(), d.cmeiout.data(), d.prain.data(),
               d.nevapr.data(), d.prer_evap.data(), d.rflx.data(), d.sflx.data(),
               d.rcldm.data(), d.lcldm.data(), d.icldm.data(), d.mu_c.data(),
-              d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),
+              d.mu_r.data(), d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),
               d.vap_ice_exchange.data());
   }
 }

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -31,10 +31,10 @@ struct FortranData {
     nitot, qirim, birim, pdel, exner;
   // Out
   Array1 prt_liq, prt_sol;
-  Array2 diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, diag_rhoi, cmeiout, prain, nevapr, prer_evap, rflx, sflx, rcldm, lcldm, icldm;
-  Array2 pratot, prctot;
+  Array2 diag_effc, diag_effi, diag_rhoi, cmeiout, prain, nevapr, prer_evap,
+         rflx, sflx, rcldm, lcldm, icldm;
   Array3 p3_tend_out;
-  Array2 mu_c, lamc;
+  Array2 mu_c;
   Array2 liq_ice_exchange,vap_liq_exchange,vap_ice_exchange;
 
   FortranData(Int ncol, Int nlev);

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -34,7 +34,7 @@ struct FortranData {
   Array2 diag_effc, diag_effi, diag_rhoi, cmeiout, prain, nevapr, prer_evap,
          rflx, sflx, rcldm, lcldm, icldm;
   Array3 p3_tend_out;
-  Array2 mu_c;
+  Array2 mu_c, mu_r;
   Array2 liq_ice_exchange,vap_liq_exchange,vap_ice_exchange;
 
   FortranData(Int ncol, Int nlev);

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -34,7 +34,7 @@ struct FortranData {
   Array2 diag_effc, diag_effi, diag_rhoi, cmeiout, prain, nevapr, prer_evap,
          rflx, sflx, rcldm, lcldm, icldm;
   Array3 p3_tend_out;
-  Array2 mu_c, mu_r;
+  Array2 mu_c, lamc;
   Array2 liq_ice_exchange,vap_liq_exchange,vap_ice_exchange;
 
   FortranData(Int ncol, Int nlev);

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -741,6 +741,7 @@ struct Functions
     const uview_1d<const Spack>& exner,
     const uview_1d<const Spack>& th,
     const uview_1d<const Spack>& dzq,
+    const uview_1d<Spack>& diag_ze,
     const uview_1d<Spack>& ze_ice,
     const uview_1d<Spack>& ze_rain,
     const uview_1d<Spack>& diag_effc,
@@ -861,6 +862,7 @@ struct Functions
     const uview_1d<Spack>& birim_incld,
     const uview_1d<Spack>& omu_c,
     const uview_1d<Spack>& nu,
+    const uview_1d<Spack>& lamc,
     const uview_1d<Spack>& cdist,
     const uview_1d<Spack>& cdist1,
     const uview_1d<Spack>& cdistr,
@@ -874,6 +876,8 @@ struct Functions
     const uview_1d<Spack>& vap_liq_exchange,
     const uview_1d<Spack>& vap_ice_exchange,
     const uview_1d<Spack>& liq_ice_exchange,
+    const uview_1d<Spack>& pratot,
+    const uview_1d<Spack>& prctot,
     bool& log_hydrometeorsPresent);
 
   KOKKOS_FUNCTION
@@ -902,13 +906,17 @@ struct Functions
     const uview_1d<Spack>& xxls,
     const uview_1d<Spack>& mu_c,
     const uview_1d<Spack>& nu,
+    const uview_1d<Spack>& lamc,
     const uview_1d<Spack>& mu_r,
     const uview_1d<Spack>& lamr,
     const uview_1d<Spack>& vap_liq_exchange,
     const uview_1d<Spack>& ze_rain,
     const uview_1d<Spack>& ze_ice,
+    const uview_1d<Spack>& diag_vmi,
     const uview_1d<Spack>& diag_effi,
+    const uview_1d<Spack>& diag_di,
     const uview_1d<Spack>& diag_rhoi,
+    const uview_1d<Spack>& diag_ze,
     const uview_1d<Spack>& diag_effc);
 
   static void p3_main(

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -144,8 +144,8 @@ struct Functions
   struct P3DiagnosticOutputs {
     // Size distribution shape parameter for radiation
     view_2d<Spack> mu_c;
-    // Size distribution shape parameter for rain
-    view_2d<Spack> mu_r;
+    // Size distribution slope parameter for radiation
+    view_2d<Spack> lamc;
     // qitend due to deposition/sublimation
     view_2d<Spack> cmeiout;
     // Precipitation rate, liquid [m s-1]
@@ -755,7 +755,7 @@ struct Functions
     const uview_1d<Spack>& inv_dzq,
     Scalar& prt_liq,
     Scalar& prt_sol,
-    view_1d_ptr_array<Spack, 35>& zero_init);
+    view_1d_ptr_array<Spack, 36>& zero_init);
 
   KOKKOS_FUNCTION
   static void p3_main_part1(
@@ -860,7 +860,7 @@ struct Functions
     const uview_1d<Spack>& nr_incld,
     const uview_1d<Spack>& nitot_incld,
     const uview_1d<Spack>& birim_incld,
-    const uview_1d<Spack>& omu_c,
+    const uview_1d<Spack>& mu_c,
     const uview_1d<Spack>& nu,
     const uview_1d<Spack>& lamc,
     const uview_1d<Spack>& cdist,

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -92,6 +92,115 @@ struct Functions
 
   using Workspace = typename WorkspaceManager<Spack, Device>::Workspace;
 
+  // This struct stores prognostic variables evolved by P3.
+  struct P3PrognosticState {
+    // Cloud mass mixing ratio [kg kg-1]
+    view_2d<Spack> qc;
+    // Cloud number mixing ratio [# kg-1]
+    view_2d<Spack> nc;
+    // Rain mass mixing ratio [kg kg-1]
+    view_2d<Spack> qr;
+    // Rain number mixing ratio [# kg-1]
+    view_2d<Spack> nr;
+    // Ice total mass mixing ratio [kg kg-1]
+    view_2d<Spack> qitot;
+    // Ice rime mass mixing ratio [kg kg-1]
+    view_2d<Spack> qirim;
+    // Ice total number mixing ratio [# kg-1]
+    view_2d<Spack> nitot;
+    // Ice rime volume mixing ratio [m3 kg-1]
+    view_2d<Spack> birim;
+    // Water vapor mixing ratio [kg kg-1]
+    view_2d<Spack> qv;
+    // Potential temperature [K]
+    view_2d<Spack> th;
+  };
+
+  // This struct stores diagnostic variables used by P3.
+  struct P3DiagnosticInputs {
+    // CCN activated number tendency [kg-1 s-1]
+    view_2d<const Spack> ncnuc;
+    // Activated ice nuclei concentration [1/kg]
+    view_2d<const Spack> naai;
+    // Assumed SGS 1/(var(qc)/mean(qc)) [kg2/kg2]
+    view_2d<const Spack> qc_relvar;
+    // Ice cloud fraction
+    view_2d<const Spack> icldm;
+    // Liquid cloud fraction
+    view_2d<const Spack> lcldm;
+    // Rain cloud fraction
+    view_2d<const Spack> rcldm;
+    // Pressure [Pa]
+    view_2d<const Spack> pres;
+    // Vertical grid spacing [m]
+    view_2d<const Spack> dzq;
+    // Pressure thickness [Pa]
+    view_2d<const Spack> pdel;
+    // Exner expression
+    view_2d<const Spack> exner;
+  };
+
+  // This struct stores diagnostic outputs computed by P3.
+  struct P3DiagnosticOutputs {
+    // Size distribution shape parameter for radiation
+    view_2d<Spack> mu_c;
+    // Size distribution shape parameter for rain
+    view_2d<Spack> mu_r;
+    // qitend due to deposition/sublimation
+    view_2d<Spack> cmeiout;
+    // Precipitation rate, liquid [m s-1]
+    view_1d<Scalar> prt_liq;
+    // Precipitation rate, solid [m s-1]
+    view_1d<Scalar> prt_sol;
+    // Effective cloud radius [m]
+    view_2d<Spack> diag_effc;
+    // Effective ice radius [m]
+    view_2d<Spack> diag_effi;
+    // Bulk density of ice [kg m-3]
+    view_2d<Spack> diag_rhoi;
+    // Total precipitation (rain + snow)
+    view_2d<Spack> prain;
+    // Evaporation of total precipitation (rain + snow)
+    view_2d<Spack> nevapr;
+    // Evaporation of rain
+    view_2d<Spack> prer_evap;
+    // Grid-box average rain flux [kg m^-2 s^-1] pverp
+    view_2d<Spack> rflx;
+    // Grid-box average ice/snow flux [kg m^-2 s^-1] pverp
+    view_2d<Spack> sflx;
+  };
+
+  // This struct stores time stepping and grid-index-related information.
+  struct P3Infrastructure {
+    // Model time step [s]
+    Real dt;
+    // Time step counter (1-based)
+    Int it;
+    // Lower bound for horizontal column indices.
+    Int its;
+    // Upper bound for horizontal column indices.
+    Int ite;
+    // Lower bound for vertical level indices.
+    Int kts;
+    // Upper bound for vertical level indices.
+    Int kte;
+    // Set to true to have P3 predict Nc, false to have Nc specified.
+    bool predictNc;
+    // Coordinates of columns, ni x 3
+    view_2d<const Scalar> col_location;
+  };
+
+  // This struct stores tendencies computed by P3 and used by other
+  // parameterizations.
+  struct P3HistoryOnly {
+    // Sum of liq-ice phase change tendencies
+    view_2d<Spack> liq_ice_exchange;
+    // Sum of vap-liq phase change tendencies
+    view_2d<Spack> vap_liq_exchange;
+    // Sum of vap-ice phase change tendencies
+    view_2d<Spack> vap_ice_exchange;
+  };
+
   // -- Table3 --
 
   struct Table3 {
@@ -632,7 +741,6 @@ struct Functions
     const uview_1d<const Spack>& exner,
     const uview_1d<const Spack>& th,
     const uview_1d<const Spack>& dzq,
-    const uview_1d<Spack>& diag_ze,
     const uview_1d<Spack>& ze_ice,
     const uview_1d<Spack>& ze_rain,
     const uview_1d<Spack>& diag_effc,
@@ -646,7 +754,7 @@ struct Functions
     const uview_1d<Spack>& inv_dzq,
     Scalar& prt_liq,
     Scalar& prt_sol,
-    view_1d_ptr_array<Spack, 40>& zero_init);
+    view_1d_ptr_array<Spack, 35>& zero_init);
 
   KOKKOS_FUNCTION
   static void p3_main_pre_main_loop(
@@ -753,7 +861,6 @@ struct Functions
     const uview_1d<Spack>& birim_incld,
     const uview_1d<Spack>& omu_c,
     const uview_1d<Spack>& nu,
-    const uview_1d<Spack>& olamc,
     const uview_1d<Spack>& cdist,
     const uview_1d<Spack>& cdist1,
     const uview_1d<Spack>& cdistr,
@@ -767,8 +874,6 @@ struct Functions
     const uview_1d<Spack>& vap_liq_exchange,
     const uview_1d<Spack>& vap_ice_exchange,
     const uview_1d<Spack>& liq_ice_exchange,
-    const uview_1d<Spack>& pratot,
-    const uview_1d<Spack>& prctot,
     bool& log_hydrometeorsPresent);
 
   KOKKOS_FUNCTION
@@ -797,76 +902,23 @@ struct Functions
     const uview_1d<Spack>& xxls,
     const uview_1d<Spack>& mu_c,
     const uview_1d<Spack>& nu,
-    const uview_1d<Spack>& lamc,
     const uview_1d<Spack>& mu_r,
     const uview_1d<Spack>& lamr,
     const uview_1d<Spack>& vap_liq_exchange,
     const uview_1d<Spack>& ze_rain,
     const uview_1d<Spack>& ze_ice,
-    const uview_1d<Spack>& diag_vmi,
     const uview_1d<Spack>& diag_effi,
-    const uview_1d<Spack>& diag_di,
     const uview_1d<Spack>& diag_rhoi,
-    const uview_1d<Spack>& diag_ze,
     const uview_1d<Spack>& diag_effc);
 
   static void p3_main(
-    // inputs
-    const view_2d<const Spack>& pres,          // pressure                             Pa
-    const view_2d<const Spack>& dzq,           // vertical grid spacing                m
-    const view_2d<const Spack>& ncnuc,         // IN ccn activated number tendency     kg-1 s-1
-    const view_2d<const Spack>& naai,          // IN actived ice nuclei concentration  1/kg
-    const view_2d<const Spack>& qc_relvar,     // assumed SGS 1/(var(qc)/mean(qc))     kg2/kg2
-    const Real&                 dt,            // model time step                      s
-    const Int&                  ni,            // num columns
-    const Int&                  nk,            // column size
-    const Int&                  it,            // time step counter NOTE: starts at 1 for first time step
-    const bool&                 log_predictNc, // .T. (.F.) for prediction (specification) of Nc
-    const view_2d<const Spack>& pdel,          // pressure thickness                   Pa
-    const view_2d<const Spack>& exner,         // Exner expression
-
-    // inputs needed for PBUF variables used by other parameterizations
-    const view_2d<const Spack>& icldm,         // ice cloud fraction
-    const view_2d<const Spack>& lcldm,         // liquid cloud fraction
-    const view_2d<const Spack>& rcldm,         // rain cloud fraction
-    const view_2d<const Scalar>& col_location, // ni x 3
-
-    // input/output  arguments
-    const view_2d<Spack>& qc,    // cloud, mass mixing ratio         kg kg-1
-    const view_2d<Spack>& nc,    // cloud, number mixing ratio       #  kg-1
-    const view_2d<Spack>& qr,    // rain, mass mixing ratio          kg kg-1
-    const view_2d<Spack>& nr,    // rain, number mixing ratio        #  kg-1
-    const view_2d<Spack>& qitot, // ice, total mass mixing ratio     kg kg-1
-    const view_2d<Spack>& qirim, // ice, rime mass mixing ratio      kg kg-1
-    const view_2d<Spack>& nitot, // ice, total number mixing ratio   #  kg-1
-    const view_2d<Spack>& birim, // ice, rime volume mixing ratio    m3 kg-1
-    const view_2d<Spack>& qv,    // water vapor mixing ratio         kg kg-1
-    const view_2d<Spack>& th,    // potential temperature            K
-
-    // output arguments
-    const view_1d<Scalar>& prt_liq,  // precipitation rate, liquid       m s-1
-    const view_1d<Scalar>& prt_sol,  // precipitation rate, solid        m s-1
-    const view_2d<Spack>& diag_ze,   // equivalent reflectivity          dBZ
-    const view_2d<Spack>& diag_effc, // effective radius, cloud          m
-    const view_2d<Spack>& diag_effi, // effective radius, ice            m
-    const view_2d<Spack>& diag_vmi,  // mass-weighted fall speed of ice  m s-1
-    const view_2d<Spack>& diag_di,   // mean diameter of ice             m
-    const view_2d<Spack>& diag_rhoi, // bulk density of ice              kg m-3
-    const view_2d<Spack>& mu_c,      // Size distribution shape parameter for radiation
-    const view_2d<Spack>& lamc,      // Size distribution slope parameter for radiation
-
-    // outputs for PBUF variables used by other parameterizations
-    const view_2d<Spack>& cmeiout,          // qitend due to deposition/sublimation
-    const view_2d<Spack>& prain,            // Total precipitation (rain + snow)
-    const view_2d<Spack>& nevapr,           // evaporation of total precipitation (rain + snow)
-    const view_2d<Spack>& prer_evap,        // evaporation of rain
-    const view_2d<Spack>& rflx,             // grid-box average rain flux (kg m^-2 s^-1) pverp
-    const view_2d<Spack>& sflx,             // grid-box average ice/snow flux (kg m^-2 s^-1) pverp
-    const view_2d<Spack>& pratot,           // accretion of cloud by rain
-    const view_2d<Spack>& prctot,           // autoconversion of cloud to rain
-    const view_2d<Spack>& liq_ice_exchange, // sum of liq-ice phase change tendencies
-    const view_2d<Spack>& vap_liq_exchange, // sum of vap-liq phase change tendencies
-    const view_2d<Spack>& vap_ice_exchange);// sum of vap-ice phase change tendencies
+    const P3PrognosticState& prognostic_state,
+    const P3DiagnosticInputs& diagnostic_inputs,
+    const P3DiagnosticOutputs& diagnostic_outputs,
+    const P3Infrastructure& infrastructure,
+    const P3HistoryOnly& history_only,
+    Int ni, // number of columns
+    Int nk); // number of vertical cells per column
 };
 
 template <typename ScalarT, typename DeviceT>

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3307,28 +3307,35 @@ void p3_main_part2_f(
 
     P3F::p3_main_part2(
       team, nk_pack, log_predictNc, dt, odt, dnu, itab, itabcol, revap_table,
-      pres_d, pdel_d, dzq_d, ncnuc_d, exner_d, inv_exner_d, inv_lcldm_d, inv_icldm_d, inv_rcldm_d, naai_d, qc_relvar_d, icldm_d, lcldm_d, rcldm_d,
+      pres_d, pdel_d, dzq_d, ncnuc_d, exner_d, inv_exner_d, inv_lcldm_d,
+      inv_icldm_d, inv_rcldm_d, naai_d, qc_relvar_d, icldm_d, lcldm_d, rcldm_d,
       t_d, rho_d, inv_rho_d, qvs_d, qvi_d, supi_d, rhofacr_d, rhofaci_d, acn_d,
-      qv_d, th_d, qc_d, nc_d, qr_d, nr_d, qitot_d, nitot_d, qirim_d, birim_d, xxlv_d, xxls_d, xlf_d, qc_incld_d, qr_incld_d,
-      qitot_incld_d, qirim_incld_d, nc_incld_d, nr_incld_d, nitot_incld_d, birim_incld_d, mu_c_d, nu_d, lamc_d, cdist_d, cdist1_d,
-      cdistr_d, mu_r_d, lamr_d, logn0r_d, cmeiout_d, prain_d, nevapr_d, prer_evap_d, vap_liq_exchange_d,
+      qv_d, th_d, qc_d, nc_d, qr_d, nr_d, qitot_d, nitot_d, qirim_d, birim_d,
+      xxlv_d, xxls_d, xlf_d, qc_incld_d, qr_incld_d, qitot_incld_d,
+      qirim_incld_d, nc_incld_d, nr_incld_d, nitot_incld_d, birim_incld_d,
+      mu_c_d, nu_d, lamc_d, cdist_d, cdist1_d, cdistr_d, mu_r_d, lamr_d,
+      logn0r_d, cmeiout_d, prain_d, nevapr_d, prer_evap_d, vap_liq_exchange_d,
       vap_ice_exchange_d, liq_ice_exchange_d, pratot_d, prctot_d, bools_d(0));
   });
 
   // Sync back to host
   Kokkos::Array<view_1d, 48> inout_views = {
     t_d, rho_d, inv_rho_d, qvs_d, qvi_d, supi_d, rhofacr_d, rhofaci_d, acn_d,
-    qv_d, th_d, qc_d, nc_d, qr_d, nr_d, qitot_d, nitot_d, qirim_d, birim_d, xxlv_d, xxls_d, xlf_d, qc_incld_d, qr_incld_d,
-    qitot_incld_d, qirim_incld_d, nc_incld_d, nr_incld_d, nitot_incld_d, birim_incld_d, mu_c_d, nu_d, lamc_d, cdist_d, cdist1_d,
-    cdistr_d, mu_r_d, lamr_d, logn0r_d, cmeiout_d, prain_d, nevapr_d, prer_evap_d, vap_liq_exchange_d,
-    vap_ice_exchange_d, liq_ice_exchange_d, pratot_d, prctot_d
+    qv_d, th_d, qc_d, nc_d, qr_d, nr_d, qitot_d, nitot_d, qirim_d, birim_d,
+    xxlv_d, xxls_d, xlf_d, qc_incld_d, qr_incld_d, qitot_incld_d, qirim_incld_d,
+    nc_incld_d, nr_incld_d, nitot_incld_d, birim_incld_d, mu_c_d, nu_d, lamc_d,
+    cdist_d, cdist1_d, cdistr_d, mu_r_d, lamr_d, logn0r_d, cmeiout_d, prain_d,
+    nevapr_d, prer_evap_d, vap_liq_exchange_d, vap_ice_exchange_d,
+    liq_ice_exchange_d, pratot_d, prctot_d
   };
 
-  pack::device_to_host({t, rho, inv_rho, qvs, qvi, supi, rhofacr, rhofaci, acn,
-        qv, th, qc, nc, qr, nr, qitot, nitot, qirim, birim, xxlv, xxls, xlf, qc_incld, qr_incld,
-        qitot_incld, qirim_incld, nc_incld, nr_incld, nitot_incld, birim_incld, mu_c, nu, lamc, cdist, cdist1,
-        cdistr, mu_r, lamr, logn0r, cmeiout, prain, nevapr, prer_evap, vap_liq_exchange,
-        vap_ice_exchange, liq_ice_exchange, pratot, prctot},
+  pack::device_to_host({
+      t, rho, inv_rho, qvs, qvi, supi, rhofacr, rhofaci, acn, qv, th, qc, nc,
+      qr, nr, qitot, nitot, qirim, birim, xxlv, xxls, xlf, qc_incld, qr_incld,
+      qitot_incld, qirim_incld, nc_incld, nr_incld, nitot_incld, birim_incld,
+      mu_c, nu, lamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, cmeiout, prain,
+      nevapr, prer_evap, vap_liq_exchange, vap_ice_exchange, liq_ice_exchange,
+      pratot, prctot},
     nk, inout_views);
 
   const auto bools_h = Kokkos::create_mirror_view(bools_d);
@@ -3340,9 +3347,12 @@ void p3_main_part2_f(
 void p3_main_part3_f(
   Int kts, Int kte, Int kbot, Int ktop, Int kdir,
   Real* exner, Real* lcldm, Real* rcldm,
-  Real* rho, Real* inv_rho, Real* rhofaci, Real* qv, Real* th, Real* qc, Real* nc, Real* qr, Real* nr, Real* qitot, Real* nitot, Real* qirim, Real* birim, Real* xxlv, Real* xxls,
-  Real* mu_c, Real* nu, Real* lamc, Real* mu_r, Real* lamr, Real* vap_liq_exchange,
-  Real*  ze_rain, Real* ze_ice, Real* diag_vmi, Real* diag_effi, Real* diag_di, Real* diag_rhoi, Real* diag_ze, Real* diag_effc)
+  Real* rho, Real* inv_rho, Real* rhofaci, Real* qv, Real* th, Real* qc,
+  Real* nc, Real* qr, Real* nr, Real* qitot, Real* nitot, Real* qirim,
+  Real* birim, Real* xxlv, Real* xxls, Real* mu_c, Real* nu, Real* lamc,
+  Real* mu_r, Real* lamr, Real* vap_liq_exchange, Real* ze_rain, Real* ze_ice,
+  Real* diag_vmi, Real* diag_effi, Real* diag_di, Real* diag_rhoi,
+  Real* diag_ze, Real* diag_effc)
 {
   using P3F  = Functions<Real, DefaultDevice>;
 
@@ -3367,13 +3377,10 @@ void p3_main_part3_f(
   Kokkos::Array<view_1d, P3MainPart3Data::NUM_ARRAYS> temp_d;
 
   pack::host_to_device({
-      exner, lcldm, rcldm,
-      rho, inv_rho, rhofaci,
-      qv, th, qc, nc, qr, nr, qitot, nitot, qirim, birim, xxlv, xxls,
-      mu_c, nu, lamc, mu_r,
-      lamr, vap_liq_exchange,
-      ze_rain, ze_ice, diag_vmi, diag_effi, diag_di, diag_rhoi, diag_ze, diag_effc
-    },
+      exner, lcldm, rcldm, rho, inv_rho, rhofaci, qv, th, qc,
+      nc, qr, nr, qitot, nitot, qirim, birim, xxlv, xxls, mu_c, nu, lamc, mu_r,
+      lamr, vap_liq_exchange, ze_rain, ze_ice, diag_vmi, diag_effi, diag_di,
+      diag_rhoi, diag_ze, diag_effc},
     nk, temp_d);
 
   view_1d
@@ -3428,15 +3435,16 @@ void p3_main_part3_f(
 
   // Sync back to host
   Kokkos::Array<view_1d, 29> inout_views = {
-    rho_d, inv_rho_d, rhofaci_d, qv_d, th_d, qc_d, nc_d, qr_d, nr_d, qitot_d, nitot_d, qirim_d, birim_d, xxlv_d, xxls_d,
-    mu_c_d, nu_d, lamc_d, mu_r_d, lamr_d, vap_liq_exchange_d,
-    ze_rain_d, ze_ice_d, diag_vmi_d, diag_effi_d, diag_di_d, diag_rhoi_d, diag_ze_d, diag_effc_d
+    rho_d, inv_rho_d, rhofaci_d, qv_d, th_d, qc_d, nc_d, qr_d, nr_d, qitot_d,
+    nitot_d, qirim_d, birim_d, xxlv_d, xxls_d, mu_c_d, nu_d, lamc_d, mu_r_d,
+    lamr_d, vap_liq_exchange_d, ze_rain_d, ze_ice_d, diag_vmi_d, diag_effi_d,
+    diag_di_d, diag_rhoi_d, diag_ze_d, diag_effc_d
   };
 
   pack::device_to_host({
-      rho, inv_rho, rhofaci, qv, th, qc, nc, qr, nr, qitot, nitot, qirim, birim, xxlv, xxls,
-      mu_c, nu, lamc, mu_r, lamr, vap_liq_exchange,
-      ze_rain, ze_ice, diag_vmi, diag_effi, diag_di, diag_rhoi, diag_ze, diag_effc
+      rho, inv_rho, rhofaci, qv, th, qc, nc, qr, nr, qitot, nitot, qirim, birim,
+      xxlv, xxls, mu_c, nu, lamc, mu_r, lamr, vap_liq_exchange, ze_rain, ze_ice,
+      diag_vmi, diag_effi, diag_di, diag_rhoi, diag_ze, diag_effc
     },
     nk, inout_views);
 }
@@ -3586,10 +3594,10 @@ void p3_main_f(
   for (size_t i = 0; i < P3MainData::NUM_ARRAYS - 10; ++i) dim2_sizes_out[i] = nk;
 
 
-  dim2_sizes_out[21] = nk+1; // rflx
-  dim2_sizes_out[22] = nk+1; // sflx
-  dim1_sizes_out[23] = 1; dim2_sizes_out[23] = ni; // prt_liq
-  dim1_sizes_out[24] = 1; dim2_sizes_out[24] = ni; // prt_sol
+  dim2_sizes_out[22] = nk+1; // rflx
+  dim2_sizes_out[23] = nk+1; // sflx
+  dim1_sizes_out[24] = 1; dim2_sizes_out[24] = ni; // prt_liq
+  dim1_sizes_out[25] = 1; dim2_sizes_out[25] = ni; // prt_sol
 
   pack::device_to_host({
       qc, nc, qr, nr, qitot, qirim, nitot, birim, qv, th, diag_effc, diag_effi,

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -219,7 +219,7 @@ void p3_main_c(
   Real* prt_sol, Int its, Int ite, Int kts, Int kte, Real* diag_effc,
   Real* diag_effi, Real* diag_rhoi, bool log_predictNc, Real* pdel, Real* exner,
   Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap, Real* rflx,
-  Real* sflx, Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c,
+  Real* sflx, Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c, Real* lamc,
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange);
 
 }
@@ -1169,7 +1169,7 @@ P3MainData::P3MainData(
   std::array<Real**, NUM_ARRAYS> ptrs = {
     &pres, &dzq, &ncnuc, &naai, &pdel, &exner, &icldm, &lcldm, &rcldm,
     &qc_relvar, &qc, &nc, &qr, &nr, &qitot, &qirim, &nitot, &birim, &qv, &th,
-    &diag_effc, &diag_effi, &diag_rhoi, &mu_c, &mu_r, &cmeiout, &prain, &nevapr,
+    &diag_effc, &diag_effi, &diag_rhoi, &mu_c, &lamc, &cmeiout, &prain, &nevapr,
     &prer_evap, &liq_ice_exchange, &vap_liq_exchange, &vap_ice_exchange, &rflx,
     &sflx, &prt_liq, &prt_sol
   };
@@ -1188,7 +1188,7 @@ P3MainData::P3MainData(const P3MainData& rhs) :
   std::array<Real**, NUM_ARRAYS> ptrs = {
     &pres, &dzq, &ncnuc, &naai, &pdel, &exner, &icldm, &lcldm, &rcldm,
     &qc_relvar, &qc, &nc, &qr, &nr, &qitot, &qirim, &nitot, &birim, &qv, &th,
-    &diag_effc, &diag_effi, &diag_rhoi, &mu_c, &mu_r, &cmeiout, &prain, &nevapr,
+    &diag_effc, &diag_effi, &diag_rhoi, &mu_c, &lamc, &cmeiout, &prain, &nevapr,
     &prer_evap, &liq_ice_exchange, &vap_liq_exchange, &vap_ice_exchange, &rflx,
     &sflx, &prt_liq, &prt_sol
   };
@@ -1208,7 +1208,7 @@ void p3_main(P3MainData& d)
     d.birim, d.pres, d.dzq, d.ncnuc, d.naai, d.qc_relvar, d.it, d.prt_liq,
     d.prt_sol, d.its, d.ite, d.kts, d.kte, d.diag_effc, d.diag_effi,
     d.diag_rhoi, d.log_predictNc, d.pdel, d.exner, d.cmeiout, d.prain, d.nevapr,
-    d.prer_evap, d.rflx, d.sflx, d.rcldm, d.lcldm, d.icldm, d.mu_c,
+    d.prer_evap, d.rflx, d.sflx, d.rcldm, d.lcldm, d.icldm, d.mu_c, d.lamc,
     d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange);
   d.transpose<util::TransposeDirection::f2c>();
 }
@@ -3448,7 +3448,7 @@ void p3_main_f(
   Real* prt_sol, Int its, Int ite, Int kts, Int kte, Real* diag_effc,
   Real* diag_effi, Real* diag_rhoi, bool log_predictNc, Real* pdel, Real* exner,
   Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap, Real* rflx,
-  Real* sflx, Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c, Real* mu_r,
+  Real* sflx, Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c, Real* lamc,
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange)
 {
   using P3F  = Functions<Real, DefaultDevice>;
@@ -3478,7 +3478,7 @@ void p3_main_f(
   Kokkos::Array<const Real*, P3MainData::NUM_ARRAYS> ptr_array = {
     pres, dzq, ncnuc, naai, pdel, exner, icldm, lcldm, rcldm, qc_relvar,
     qc, nc, qr, nr, qitot, qirim, nitot, birim, qv, th, diag_effc, diag_effi,
-    diag_rhoi, mu_c, mu_r, cmeiout, prain, nevapr, prer_evap, liq_ice_exchange,
+    diag_rhoi, mu_c, lamc, cmeiout, prain, nevapr, prer_evap, liq_ice_exchange,
     vap_liq_exchange, vap_ice_exchange, rflx, sflx, prt_liq, prt_sol
   };
 
@@ -3525,7 +3525,7 @@ void p3_main_f(
     diag_effi_d        (temp_d[counter++]),
     diag_rhoi_d        (temp_d[counter++]),
     mu_c_d             (temp_d[counter++]),
-    mu_r_d             (temp_d[counter++]),
+    lamc_d             (temp_d[counter++]),
     cmeiout_d          (temp_d[counter++]),
     prain_d            (temp_d[counter++]),
     nevapr_d           (temp_d[counter++]),
@@ -3557,7 +3557,7 @@ void p3_main_f(
   P3F::P3DiagnosticInputs diag_inputs{ncnuc_d, naai_d, qc_relvar_d, icldm_d,
                                       lcldm_d, rcldm_d, pres_d, dzq_d, pdel_d,
                                       exner_d};
-  P3F::P3DiagnosticOutputs diag_outputs{mu_c_d, mu_r_d, cmeiout_d, prt_liq_d,
+  P3F::P3DiagnosticOutputs diag_outputs{mu_c_d, lamc_d, cmeiout_d, prt_liq_d,
                                         prt_sol_d, diag_effc_d, diag_effi_d,
                                         diag_rhoi_d, prain_d, nevapr_d,
                                         prer_evap_d, rflx_d, sflx_d};
@@ -3576,7 +3576,7 @@ void p3_main_f(
   // Sync back to host
   Kokkos::Array<view_2d, P3MainData::NUM_ARRAYS - 10> inout_views = {
     qc_d, nc_d, qr_d, nr_d, qitot_d, qirim_d, nitot_d, birim_d, qv_d, th_d,
-    diag_effc_d, diag_effi_d, diag_rhoi_d, mu_c_d, mu_r_d, cmeiout_d, prain_d,
+    diag_effc_d, diag_effi_d, diag_rhoi_d, mu_c_d, lamc_d, cmeiout_d, prain_d,
     nevapr_d, prer_evap_d, liq_ice_exchange_d, vap_liq_exchange_d,
     vap_ice_exchange_d, rflx_d, sflx_d, prt_liq_temp_d, prt_sol_temp_d
   };
@@ -3593,7 +3593,7 @@ void p3_main_f(
 
   pack::device_to_host({
       qc, nc, qr, nr, qitot, qirim, nitot, birim, qv, th, diag_effc, diag_effi,
-      diag_rhoi, mu_c, mu_r, cmeiout, prain, nevapr, prer_evap, liq_ice_exchange,
+      diag_rhoi, mu_c, lamc, cmeiout, prain, nevapr, prer_evap, liq_ice_exchange,
       vap_liq_exchange, vap_ice_exchange, rflx, sflx, prt_liq, prt_sol
     },
     dim1_sizes_out, dim2_sizes_out, inout_views, true);

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -213,12 +213,14 @@ void p3_main_post_main_loop_c(
   Real*  ze_rain, Real* ze_ice, Real* diag_vmi, Real* diag_effi, Real* diag_di, Real* diag_rhoi, Real* diag_ze, Real* diag_effc);
 
 void p3_main_c(
-  Real* qc, Real* nc, Real* qr, Real* nr, Real* th, Real* qv, Real dt, Real* qitot, Real* qirim, Real* nitot, Real* birim,
-  Real* pres, Real* dzq, Real* ncnuc, Real* naai, Real* qc_relvar, Int it, Real* prt_liq, Real* prt_sol, Int its, Int ite, Int kts, Int kte, Real* diag_ze, Real* diag_effc,
-  Real* diag_effi, Real* diag_vmi, Real* diag_di, Real* diag_rhoi, bool log_predictNc,
-  Real* pdel, Real* exner, Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap, Real* rflx, Real* sflx, Real* rcldm, Real* lcldm, Real* icldm,
-  Real* pratot, Real* prctot, Real* mu_c, Real* lamc, Real* liq_ice_exchange, Real* vap_liq_exchange,
-  Real* vap_ice_exchange);
+  Real* qc, Real* nc, Real* qr, Real* nr, Real* th, Real* qv, Real dt,
+  Real* qitot, Real* qirim, Real* nitot, Real* birim, Real* pres, Real* dzq,
+  Real* ncnuc, Real* naai, Real* qc_relvar, Int it, Real* prt_liq,
+  Real* prt_sol, Int its, Int ite, Int kts, Int kte, Real* diag_effc,
+  Real* diag_effi, Real* diag_rhoi, bool log_predictNc, Real* pdel, Real* exner,
+  Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap, Real* rflx,
+  Real* sflx, Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c,
+  Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange);
 
 }
 
@@ -1165,9 +1167,11 @@ P3MainData::P3MainData(
   m_data( NUM_ARRAYS * m_nt, 0.0)
 {
   std::array<Real**, NUM_ARRAYS> ptrs = {
-    &pres, &dzq, &ncnuc, &naai, &pdel, &exner, &icldm, &lcldm, &rcldm, &qc_relvar,
-    &qc, &nc, &qr, &nr, &qitot, &qirim, &nitot, &birim, &qv, &th,
-    &diag_ze, &diag_effc, &diag_effi, &diag_vmi, &diag_di, &diag_rhoi, &mu_c, &lamc, &cmeiout, &prain, &nevapr, &prer_evap, &pratot, &prctot, &liq_ice_exchange, &vap_liq_exchange, &vap_ice_exchange, &rflx, &sflx, &prt_liq, &prt_sol
+    &pres, &dzq, &ncnuc, &naai, &pdel, &exner, &icldm, &lcldm, &rcldm,
+    &qc_relvar, &qc, &nc, &qr, &nr, &qitot, &qirim, &nitot, &birim, &qv, &th,
+    &diag_effc, &diag_effi, &diag_rhoi, &mu_c, &cmeiout, &prain, &nevapr,
+    &prer_evap, &liq_ice_exchange, &vap_liq_exchange, &vap_ice_exchange, &rflx,
+    &sflx
   };
 
   gen_random_data(ranges, ptrs, m_data.data(), m_nt);
@@ -1182,9 +1186,11 @@ P3MainData::P3MainData(const P3MainData& rhs) :
   Real* data_begin = m_data.data();
 
   std::array<Real**, NUM_ARRAYS> ptrs = {
-    &pres, &dzq, &ncnuc, &naai, &pdel, &exner, &icldm, &lcldm, &rcldm, &qc_relvar,
-    &qc, &nc, &qr, &nr, &qitot, &qirim, &nitot, &birim, &qv, &th,
-    &diag_ze, &diag_effc, &diag_effi, &diag_vmi, &diag_di, &diag_rhoi, &mu_c, &lamc, &cmeiout, &prain, &nevapr, &prer_evap, &pratot, &prctot, &liq_ice_exchange, &vap_liq_exchange, &vap_ice_exchange, &rflx, &sflx, &prt_liq, &prt_sol
+    &pres, &dzq, &ncnuc, &naai, &pdel, &exner, &icldm, &lcldm, &rcldm,
+    &qc_relvar, &qc, &nc, &qr, &nr, &qitot, &qirim, &nitot, &birim, &qv, &th,
+    &diag_effc, &diag_effi, &diag_rhoi, &mu_c, &cmeiout, &prain, &nevapr,
+    &prer_evap, &liq_ice_exchange, &vap_liq_exchange, &vap_ice_exchange, &rflx,
+    &sflx
   };
 
   for (size_t i = 0; i < NUM_ARRAYS; ++i) {
@@ -1198,12 +1204,12 @@ void p3_main(P3MainData& d)
   p3_init();
   d.transpose<util::TransposeDirection::c2f>();
   p3_main_c(
-    d.qc, d.nc, d.qr, d.nr, d.th, d.qv, d.dt, d.qitot, d.qirim, d.nitot, d.birim,
-    d.pres, d.dzq, d.ncnuc, d.naai, d.qc_relvar, d.it, d.prt_liq, d.prt_sol, d.its, d.ite, d.kts, d.kte, d.diag_ze, d.diag_effc,
-    d.diag_effi, d.diag_vmi, d.diag_di, d.diag_rhoi, d.log_predictNc,
-    d.pdel, d.exner, d.cmeiout, d.prain, d.nevapr, d.prer_evap, d.rflx, d.sflx, d.rcldm, d.lcldm, d.icldm,
-    d.pratot, d.prctot, d.mu_c, d.lamc, d.liq_ice_exchange, d.vap_liq_exchange,
-    d.vap_ice_exchange);
+    d.qc, d.nc, d.qr, d.nr, d.th, d.qv, d.dt, d.qitot, d.qirim, d.nitot,
+    d.birim, d.pres, d.dzq, d.ncnuc, d.naai, d.qc_relvar, d.it, d.prt_liq,
+    d.prt_sol, d.its, d.ite, d.kts, d.kte, d.diag_effc, d.diag_effi,
+    d.diag_rhoi, d.log_predictNc, d.pdel, d.exner, d.cmeiout, d.prain, d.nevapr,
+    d.prer_evap, d.rflx, d.sflx, d.rcldm, d.lcldm, d.icldm, d.mu_c,
+    d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange);
   d.transpose<util::TransposeDirection::f2c>();
 }
 
@@ -3304,9 +3310,9 @@ void p3_main_main_loop_f(
       pres_d, pdel_d, dzq_d, ncnuc_d, exner_d, inv_exner_d, inv_lcldm_d, inv_icldm_d, inv_rcldm_d, naai_d, qc_relvar_d, icldm_d, lcldm_d, rcldm_d,
       t_d, rho_d, inv_rho_d, qvs_d, qvi_d, supi_d, rhofacr_d, rhofaci_d, acn_d,
       qv_d, th_d, qc_d, nc_d, qr_d, nr_d, qitot_d, nitot_d, qirim_d, birim_d, xxlv_d, xxls_d, xlf_d, qc_incld_d, qr_incld_d,
-      qitot_incld_d, qirim_incld_d, nc_incld_d, nr_incld_d, nitot_incld_d, birim_incld_d, mu_c_d, nu_d, cdist_d, cdist1_d,
+      qitot_incld_d, qirim_incld_d, nc_incld_d, nr_incld_d, nitot_incld_d, birim_incld_d, mu_c_d, nu_d, lamc_d, cdist_d, cdist1_d,
       cdistr_d, mu_r_d, lamr_d, logn0r_d, cmeiout_d, prain_d, nevapr_d, prer_evap_d, vap_liq_exchange_d,
-      vap_ice_exchange_d, liq_ice_exchange_d, bools_d(0));
+      vap_ice_exchange_d, liq_ice_exchange_d, pratot_d, prctot_d, bools_d(0));
   });
 
   // Sync back to host
@@ -3414,9 +3420,10 @@ void p3_main_post_main_loop_f(
                                 exner_d, lcldm_d, rcldm_d, rho_d, inv_rho_d,
                                 rhofaci_d, qv_d, th_d, qc_d, nc_d, qr_d, nr_d,
                                 qitot_d, nitot_d, qirim_d, birim_d, xxlv_d,
-                                xxls_d, mu_c_d, nu_d, mu_r_d, lamr_d,
+                                xxls_d, mu_c_d, nu_d, lamc_d, mu_r_d, lamr_d,
                                 vap_liq_exchange_d, ze_rain_d, ze_ice_d,
-                                diag_effi_d, diag_rhoi_d, diag_effc_d);
+                                diag_vmi_d, diag_effi_d, diag_di_d, diag_rhoi_d,
+                                diag_ze_d, diag_effc_d);
   });
 
   // Sync back to host
@@ -3435,11 +3442,14 @@ void p3_main_post_main_loop_f(
 }
 
 void p3_main_f(
-  Real* qc, Real* nc, Real* qr, Real* nr, Real* th, Real* qv, Real dt, Real* qitot, Real* qirim, Real* nitot, Real* birim,
-  Real* pres, Real* dzq, Real* ncnuc, Real* naai, Real* qc_relvar, Int it, Real* prt_liq, Real* prt_sol, Int its, Int ite, Int kts, Int kte, Real* diag_ze, Real* diag_effc,
-  Real* diag_effi, Real* diag_vmi, Real* diag_di, Real* diag_rhoi, bool log_predictNc,
-  Real* pdel, Real* exner, Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap, Real* rflx, Real* sflx, Real* rcldm, Real* lcldm, Real* icldm,
-  Real* pratot, Real* prctot, Real* mu_c, Real* lamc, Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange)
+  Real* qc, Real* nc, Real* qr, Real* nr, Real* th, Real* qv, Real dt,
+  Real* qitot, Real* qirim, Real* nitot, Real* birim, Real* pres, Real* dzq,
+  Real* ncnuc, Real* naai, Real* qc_relvar, Int it, Real* prt_liq,
+  Real* prt_sol, Int its, Int ite, Int kts, Int kte, Real* diag_effc,
+  Real* diag_effi, Real* diag_rhoi, bool log_predictNc, Real* pdel, Real* exner,
+  Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap, Real* rflx,
+  Real* sflx, Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c,
+  Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange)
 {
   using P3F  = Functions<Real, DefaultDevice>;
 
@@ -3467,8 +3477,9 @@ void p3_main_f(
   Kokkos::Array<size_t,  P3MainData::NUM_ARRAYS> dim2_sizes;
   Kokkos::Array<const Real*, P3MainData::NUM_ARRAYS> ptr_array = {
     pres, dzq, ncnuc, naai, pdel, exner, icldm, lcldm, rcldm, qc_relvar,
-    qc, nc, qr, nr, qitot, qirim, nitot, birim, qv, th,
-    diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, diag_rhoi, mu_c, lamc, cmeiout, prain, nevapr, prer_evap, pratot, prctot, liq_ice_exchange, vap_liq_exchange, vap_ice_exchange, rflx, sflx, prt_liq, prt_sol
+    qc, nc, qr, nr, qitot, qirim, nitot, birim, qv, th, diag_effc, diag_effi,
+    diag_rhoi, mu_c, cmeiout, prain, nevapr, prer_evap, liq_ice_exchange,
+    vap_liq_exchange, vap_ice_exchange, rflx, sflx, prt_liq, prt_sol
   };
 
   for (size_t i = 0; i < P3MainData::NUM_ARRAYS; ++i) dim1_sizes[i] = ni;
@@ -3571,7 +3582,9 @@ void p3_main_f(
   // Sync back to host
   Kokkos::Array<view_2d, P3MainData::NUM_ARRAYS - 10> inout_views = {
     qc_d, nc_d, qr_d, nr_d, qitot_d, qirim_d, nitot_d, birim_d, qv_d, th_d,
-    diag_ze_d, diag_effc_d, diag_effi_d, diag_vmi_d, diag_di_d, diag_rhoi_d, mu_c_d, lamc_d, cmeiout_d, prain_d, nevapr_d, prer_evap_d, pratot_d, prctot_d, liq_ice_exchange_d, vap_liq_exchange_d, vap_ice_exchange_d, rflx_d, sflx_d, prt_liq_temp_d, prt_sol_temp_d
+    diag_effc_d, diag_effi_d, diag_rhoi_d, mu_c_d, cmeiout_d, prain_d, nevapr_d,
+    prer_evap_d, liq_ice_exchange_d, vap_liq_exchange_d, vap_ice_exchange_d,
+    rflx_d, sflx_d, prt_liq_temp_d, prt_sol_temp_d
   };
   Kokkos::Array<size_t,  P3MainData::NUM_ARRAYS - 10> dim1_sizes_out;
   Kokkos::Array<size_t,  P3MainData::NUM_ARRAYS - 10> dim2_sizes_out;
@@ -3585,8 +3598,9 @@ void p3_main_f(
   dim1_sizes_out[30] = 1; dim2_sizes_out[30] = ni; // prt_sol
 
   pack::device_to_host({
-      qc, nc, qr, nr, qitot, qirim, nitot, birim, qv, th,
-      diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, diag_rhoi, mu_c, lamc, cmeiout, prain, nevapr, prer_evap, pratot, prctot, liq_ice_exchange, vap_liq_exchange, vap_ice_exchange, rflx, sflx, prt_liq, prt_sol
+      qc, nc, qr, nr, qitot, qirim, nitot, birim, qv, th, diag_effc, diag_effi,
+      diag_rhoi, mu_c, cmeiout, prain, nevapr, prer_evap, liq_ice_exchange,
+      vap_liq_exchange, vap_ice_exchange, rflx, sflx, prt_liq, prt_sol
     },
     dim1_sizes_out, dim2_sizes_out, inout_views, true);
 }

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3470,7 +3470,7 @@ void p3_main_f(
 
   const Int ni    = (ite - its) + 1;
   const Int nk    = (kte - kts) + 1;
-return;
+
   // Set up views, pretend all views are input views for the sake of initializing kokkos views
   Kokkos::Array<view_2d, P3MainData::NUM_ARRAYS> temp_d;
   Kokkos::Array<size_t,  P3MainData::NUM_ARRAYS> dim1_sizes;

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3485,10 +3485,10 @@ void p3_main_f(
   for (size_t i = 0; i < P3MainData::NUM_ARRAYS; ++i) dim1_sizes[i] = ni;
   for (size_t i = 0; i < P3MainData::NUM_ARRAYS; ++i) dim2_sizes[i] = nk;
 
-  dim2_sizes[31] = nk+1; // rflx
-  dim2_sizes[32] = nk+1; // sflx
-  dim1_sizes[33] = 1; dim2_sizes[33] = ni; // prt_liq
-  dim1_sizes[34] = 1; dim2_sizes[34] = ni; // prt_sol
+  dim2_sizes[32] = nk+1; // rflx
+  dim2_sizes[33] = nk+1; // sflx
+  dim1_sizes[34] = 1; dim2_sizes[34] = ni; // prt_liq
+  dim1_sizes[35] = 1; dim2_sizes[35] = ni; // prt_sol
 
   // Initialize outputs to avoid uninitialized read warnings in memory checkers
   for (size_t i = P3MainData::NUM_INPUT_ARRAYS; i < P3MainData::NUM_ARRAYS; ++i) {

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -1171,7 +1171,7 @@ P3MainData::P3MainData(
     &qc_relvar, &qc, &nc, &qr, &nr, &qitot, &qirim, &nitot, &birim, &qv, &th,
     &diag_effc, &diag_effi, &diag_rhoi, &mu_c, &cmeiout, &prain, &nevapr,
     &prer_evap, &liq_ice_exchange, &vap_liq_exchange, &vap_ice_exchange, &rflx,
-    &sflx
+    &sflx, &prt_liq, &prt_sol
   };
 
   gen_random_data(ranges, ptrs, m_data.data(), m_nt);
@@ -1190,7 +1190,7 @@ P3MainData::P3MainData(const P3MainData& rhs) :
     &qc_relvar, &qc, &nc, &qr, &nr, &qitot, &qirim, &nitot, &birim, &qv, &th,
     &diag_effc, &diag_effi, &diag_rhoi, &mu_c, &cmeiout, &prain, &nevapr,
     &prer_evap, &liq_ice_exchange, &vap_liq_exchange, &vap_ice_exchange, &rflx,
-    &sflx
+    &sflx, &prt_liq, &prt_sol
   };
 
   for (size_t i = 0; i < NUM_ARRAYS; ++i) {

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -1234,7 +1234,7 @@ struct P3MainData
   Real* qc, *nc, *qr, *nr, *qitot, *qirim, *nitot, *birim, *qv, *th;
 
   // Out
-  Real *diag_effc, *diag_effi, *diag_rhoi, *mu_c, *mu_r, *cmeiout, *prain, *nevapr,
+  Real *diag_effc, *diag_effi, *diag_rhoi, *mu_c, *lamc, *cmeiout, *prain, *nevapr,
        *prer_evap, *liq_ice_exchange, *vap_liq_exchange, *vap_ice_exchange,
        *rflx, *sflx, *prt_liq, *prt_sol;
 
@@ -1270,7 +1270,7 @@ struct P3MainData
     util::transpose<D>(diag_effi, d_trans.diag_effi, m_ni, m_nk);
     util::transpose<D>(diag_rhoi, d_trans.diag_rhoi, m_ni, m_nk);
     util::transpose<D>(mu_c, d_trans.mu_c, m_ni, m_nk);
-    util::transpose<D>(mu_r, d_trans.mu_r, m_ni, m_nk);
+    util::transpose<D>(lamc, d_trans.lamc, m_ni, m_nk);
     util::transpose<D>(cmeiout, d_trans.cmeiout, m_ni, m_nk);
     util::transpose<D>(prain, d_trans.prain, m_ni, m_nk);
     util::transpose<D>(nevapr, d_trans.nevapr, m_ni, m_nk);
@@ -1308,7 +1308,7 @@ void p3_main_f(
   Real* prt_sol, Int its, Int ite, Int kts, Int kte, Real* diag_effc,
   Real* diag_effi, Real* diag_rhoi, bool log_predictNc, Real* pdel, Real* exner,
   Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap, Real* rflx,
-  Real* sflx, Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c, Real* mu_r,
+  Real* sflx, Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c, Real* lamc,
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange);
 }
 

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -1221,7 +1221,7 @@ void p3_main_post_main_loop_f(
 
 struct P3MainData
 {
-  static constexpr size_t NUM_ARRAYS = 41;
+  static constexpr size_t NUM_ARRAYS = 35;
   static constexpr size_t NUM_INPUT_ARRAYS = 20;
 
   // Inputs
@@ -1234,7 +1234,9 @@ struct P3MainData
   Real* qc, *nc, *qr, *nr, *qitot, *qirim, *nitot, *birim, *qv, *th;
 
   // Out
-  Real* diag_ze, *diag_effc, *diag_effi, *diag_vmi, *diag_di, *diag_rhoi, *mu_c, *lamc, *cmeiout, *prain, *nevapr, *prer_evap, *pratot, *prctot, *liq_ice_exchange, *vap_liq_exchange, *vap_ice_exchange, *rflx, *sflx, *prt_liq, *prt_sol;
+  Real *diag_effc, *diag_effi, *diag_rhoi, *mu_c, *cmeiout, *prain, *nevapr,
+       *prer_evap, *liq_ice_exchange, *vap_liq_exchange, *vap_ice_exchange,
+       *rflx, *sflx, *prt_liq, *prt_sol;
 
   P3MainData(Int its_, Int ite_, Int kts_, Int kte_, Int it_, Real dt_, bool log_predictNc_,
              const std::array< std::pair<Real, Real>, NUM_INPUT_ARRAYS >& ranges);
@@ -1264,20 +1266,14 @@ struct P3MainData
     util::transpose<D>(birim, d_trans.birim, m_ni, m_nk);
     util::transpose<D>(qv, d_trans.qv, m_ni, m_nk);
     util::transpose<D>(th, d_trans.th, m_ni, m_nk);
-    util::transpose<D>(diag_ze, d_trans.diag_ze, m_ni, m_nk);
     util::transpose<D>(diag_effc, d_trans.diag_effc, m_ni, m_nk);
     util::transpose<D>(diag_effi, d_trans.diag_effi, m_ni, m_nk);
-    util::transpose<D>(diag_vmi, d_trans.diag_vmi, m_ni, m_nk);
-    util::transpose<D>(diag_di, d_trans.diag_di, m_ni, m_nk);
     util::transpose<D>(diag_rhoi, d_trans.diag_rhoi, m_ni, m_nk);
     util::transpose<D>(mu_c, d_trans.mu_c, m_ni, m_nk);
-    util::transpose<D>(lamc, d_trans.lamc, m_ni, m_nk);
     util::transpose<D>(cmeiout, d_trans.cmeiout, m_ni, m_nk);
     util::transpose<D>(prain, d_trans.prain, m_ni, m_nk);
     util::transpose<D>(nevapr, d_trans.nevapr, m_ni, m_nk);
     util::transpose<D>(prer_evap, d_trans.prer_evap, m_ni, m_nk);
-    util::transpose<D>(pratot, d_trans.pratot, m_ni, m_nk);
-    util::transpose<D>(prctot, d_trans.prctot, m_ni, m_nk);
     util::transpose<D>(liq_ice_exchange, d_trans.liq_ice_exchange, m_ni, m_nk);
     util::transpose<D>(vap_liq_exchange, d_trans.vap_liq_exchange, m_ni, m_nk);
     util::transpose<D>(vap_ice_exchange, d_trans.vap_ice_exchange, m_ni, m_nk);
@@ -1305,11 +1301,14 @@ void p3_main(P3MainData& d);
 extern "C" {
 
 void p3_main_f(
-  Real* qc, Real* nc, Real* qr, Real* nr, Real* th, Real* qv, Real dt, Real* qitot, Real* qirim, Real* nitot, Real* birim,
-  Real* pres, Real* dzq, Real* ncnuc, Real* naai, Real* qc_relvar, Int it, Real* prt_liq, Real* prt_sol, Int its, Int ite, Int kts, Int kte, Real* diag_ze, Real* diag_effc,
-  Real* diag_effi, Real* diag_vmi, Real* diag_di, Real* diag_rhoi, bool log_predictNc,
-  Real* pdel, Real* exner, Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap, Real* rflx, Real* sflx, Real* rcldm, Real* lcldm, Real* icldm,
-  Real* pratot, Real* prctot, Real* mu_c, Real* lamc, Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange);
+  Real* qc, Real* nc, Real* qr, Real* nr, Real* th, Real* qv, Real dt,
+  Real* qitot, Real* qirim, Real* nitot, Real* birim, Real* pres, Real* dzq,
+  Real* ncnuc, Real* naai, Real* qc_relvar, Int it, Real* prt_liq,
+  Real* prt_sol, Int its, Int ite, Int kts, Int kte, Real* diag_effc,
+  Real* diag_effi, Real* diag_rhoi, bool log_predictNc, Real* pdel, Real* exner,
+  Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap, Real* rflx,
+  Real* sflx, Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c,
+  Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -1221,7 +1221,7 @@ void p3_main_post_main_loop_f(
 
 struct P3MainData
 {
-  static constexpr size_t NUM_ARRAYS = 35;
+  static constexpr size_t NUM_ARRAYS = 36;
   static constexpr size_t NUM_INPUT_ARRAYS = 20;
 
   // Inputs
@@ -1234,7 +1234,7 @@ struct P3MainData
   Real* qc, *nc, *qr, *nr, *qitot, *qirim, *nitot, *birim, *qv, *th;
 
   // Out
-  Real *diag_effc, *diag_effi, *diag_rhoi, *mu_c, *cmeiout, *prain, *nevapr,
+  Real *diag_effc, *diag_effi, *diag_rhoi, *mu_c, *mu_r, *cmeiout, *prain, *nevapr,
        *prer_evap, *liq_ice_exchange, *vap_liq_exchange, *vap_ice_exchange,
        *rflx, *sflx, *prt_liq, *prt_sol;
 
@@ -1270,6 +1270,7 @@ struct P3MainData
     util::transpose<D>(diag_effi, d_trans.diag_effi, m_ni, m_nk);
     util::transpose<D>(diag_rhoi, d_trans.diag_rhoi, m_ni, m_nk);
     util::transpose<D>(mu_c, d_trans.mu_c, m_ni, m_nk);
+    util::transpose<D>(mu_r, d_trans.mu_r, m_ni, m_nk);
     util::transpose<D>(cmeiout, d_trans.cmeiout, m_ni, m_nk);
     util::transpose<D>(prain, d_trans.prain, m_ni, m_nk);
     util::transpose<D>(nevapr, d_trans.nevapr, m_ni, m_nk);
@@ -1307,7 +1308,7 @@ void p3_main_f(
   Real* prt_sol, Int its, Int ite, Int kts, Int kte, Real* diag_effc,
   Real* diag_effi, Real* diag_rhoi, bool log_predictNc, Real* pdel, Real* exner,
   Real* cmeiout, Real* prain, Real* nevapr, Real* prer_evap, Real* rflx,
-  Real* sflx, Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c,
+  Real* sflx, Real* rcldm, Real* lcldm, Real* icldm, Real* mu_c, Real* mu_r,
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange);
 }
 

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -681,6 +681,10 @@ void Functions<S,D>
       hydrometeorsPresent = true;
     }
 
+    // Outputs associated with aerocom comparison:
+    pratot(k).set(not_skip_all, qcacc); // cloud drop accretion by rain
+    prctot(k).set(not_skip_all, qcaut); // cloud drop autoconversion to rain
+
     impose_max_total_Ni(nitot(k), max_total_Ni, inv_rho(k), not_skip_all);
 
     // Recalculate in-cloud values for sedimentation
@@ -818,7 +822,9 @@ void Functions<S,D>
       birim(k).set(qirim_small, 0);
 
       // note that reflectivity from lookup table is normalized, so we need to multiply by N
+      diag_vmi(k) .set(qi_gt_small, f1pr02 * rhofaci(k));
       diag_effi(k).set(qi_gt_small, f1pr06); // units are in m
+      diag_di(k)  .set(qi_gt_small, f1pr15);
       diag_rhoi(k).set(qi_gt_small, f1pr16);
 
       // note factor of air density below is to convert from m^6/kg to m^6/m^3
@@ -831,7 +837,11 @@ void Functions<S,D>
       nitot(k)  .set(qi_small, 0);
       qirim(k)  .set(qi_small, 0);
       birim(k)  .set(qi_small, 0);
+      diag_di(k).set(qi_small, 0);
     }
+
+    // sum ze components and convert to dBZ
+    diag_ze(k) = 10 * pack::log10((ze_rain(k) + ze_ice(k))*sp(1.e18));
 
     // if qr is very small then set Nr to 0 (needs to be done here after call
     // to ice lookup table because a minimum Nr of nsmall will be set otherwise even if qr=0)

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -39,7 +39,7 @@ void Functions<S,D>
   const uview_1d<Spack>& inv_dzq,
   Scalar& prt_liq,
   Scalar& prt_sol,
-  view_1d_ptr_array<Spack, 35>& zero_init)
+  view_1d_ptr_array<Spack, 36>& zero_init)
 {
   prt_liq = 0;
   prt_sol = 0;
@@ -909,7 +909,7 @@ void Functions<S,D>
       t,      // temperature at the beginning of the microhpysics step [K]
 
       // 2D size distribution and fallspeed parameters
-      lamr, lamc, logn0r, nu, cdist, cdist1, cdistr,
+      lamr, logn0r, nu, cdist, cdist1, cdistr,
 
       // Variables needed for in-cloud calculations
       inv_icldm, inv_lcldm, inv_rcldm, // Inverse cloud fractions (1/cld)
@@ -924,9 +924,9 @@ void Functions<S,D>
       // p3_tend_out, may not need these
       qtend_ignore, ntend_ignore;
 
-    workspace.template take_many_and_reset<42>(
+    workspace.template take_many_and_reset<41>(
       {
-        "mu_r", "t", "lamr", "lamc", "logn0r", "nu", "cdist", "cdist1", "cdistr",
+        "mu_r", "t", "lamr", "logn0r", "nu", "cdist", "cdist1", "cdistr",
         "inv_icldm", "inv_lcldm", "inv_rcldm", "qc_incld", "qr_incld", "qitot_incld", "qirim_incld",
         "nc_incld", "nr_incld", "nitot_incld", "birim_incld",
         "inv_dzq", "inv_rho", "ze_ice", "ze_rain", "prec", "rho",
@@ -935,7 +935,7 @@ void Functions<S,D>
         "pratot", "prctot", "qtend_ignore", "ntend_ignore"
       },
       {
-        &mu_r, &t, &lamr, &lamc, &logn0r, &nu, &cdist, &cdist1, &cdistr,
+        &mu_r, &t, &lamr, &logn0r, &nu, &cdist, &cdist1, &cdistr,
         &inv_icldm, &inv_lcldm, &inv_rcldm, &qc_incld, &qr_incld, &qitot_incld, &qirim_incld,
         &nc_incld, &nr_incld, &nitot_incld, &birim_incld,
         &inv_dzq, &inv_rho, &ze_ice, &ze_rain, &prec, &rho,
@@ -971,6 +971,7 @@ void Functions<S,D>
     const auto odiag_effi        = util::subview(diagnostic_outputs.diag_effi, i);
     const auto odiag_rhoi        = util::subview(diagnostic_outputs.diag_rhoi, i);
     const auto omu_c             = util::subview(diagnostic_outputs.mu_c, i);
+    const auto olamc             = util::subview(diagnostic_outputs.lamc, i);
     const auto ocmeiout          = util::subview(diagnostic_outputs.cmeiout, i);
     const auto oprain            = util::subview(diagnostic_outputs.prain, i);
     const auto onevapr           = util::subview(diagnostic_outputs.nevapr, i);
@@ -988,13 +989,13 @@ void Functions<S,D>
     bool &nucleationPossible  = bools(i, 0);
     bool &hydrometeorsPresent = bools(i, 1);
 
-    view_1d_ptr_array<Spack, 35> zero_init = {
+    view_1d_ptr_array<Spack, 36> zero_init = {
       &mu_r, &lamr, &logn0r, &nu, &cdist, &cdist1, &cdistr,
       &qc_incld, &qr_incld, &qitot_incld, &qirim_incld,
       &nc_incld, &nr_incld, &nitot_incld, &birim_incld,
       &inv_rho, &prec, &rho, &rhofacr, &rhofaci, &acn, &qvs, &qvi, &sup, &supi,
       &tmparr1, &qtend_ignore, &ntend_ignore,
-      &omu_c, &odiag_rhoi, &ocmeiout, &oprain, &onevapr, &orflx, &osflx
+      &omu_c, &olamc, &odiag_rhoi, &ocmeiout, &oprain, &onevapr, &orflx, &osflx
     };
 
     // initialize
@@ -1026,7 +1027,7 @@ void Functions<S,D>
       olcldm, orcldm, t, rho, inv_rho, qvs, qvi, supi, rhofacr, rhofaci, acn,
       oqv, oth, oqc, onc, oqr, onr, oqitot, onitot, oqirim, obirim, oxxlv,
       oxxls, oxlf, qc_incld, qr_incld, qitot_incld, qirim_incld, nc_incld,
-      nr_incld, nitot_incld, birim_incld, omu_c, nu, lamc, cdist, cdist1, cdistr,
+      nr_incld, nitot_incld, birim_incld, omu_c, nu, olamc, cdist, cdist1, cdistr,
       mu_r, lamr, logn0r, ocmeiout, oprain, onevapr, oprer_evap,
       ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange,
       pratot, prctot, hydrometeorsPresent);
@@ -1049,7 +1050,7 @@ void Functions<S,D>
     cloud_sedimentation(
       qc_incld, rho, inv_rho, olcldm, acn, inv_dzq, dnu, team, workspace,
       nk, ktop, kbot, kdir, infrastructure.dt, odt, infrastructure.predictNc,
-      oqc, onc, nc_incld, omu_c, lamc, qtend_ignore, ntend_ignore,
+      oqc, onc, nc_incld, omu_c, olamc, qtend_ignore, ntend_ignore,
       diagnostic_outputs.prt_liq(i));
 
     // Rain sedimentation:  (adaptive substepping)
@@ -1078,7 +1079,7 @@ void Functions<S,D>
     p3_main_part3(
       team, nk_pack, dnu, itab, oexner, olcldm, orcldm,
       rho, inv_rho, rhofaci, oqv, oth, oqc, onc, oqr, onr, oqitot, onitot,
-      oqirim, obirim, oxxlv, oxxls, omu_c, nu, lamc, mu_r, lamr,
+      oqirim, obirim, oxxlv, oxxls, omu_c, nu, olamc, mu_r, lamr,
       ovap_liq_exchange, ze_rain, ze_ice, diag_vmi, odiag_effi, diag_di,
       odiag_rhoi, diag_ze, odiag_effc);
 

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -940,7 +940,8 @@ void Functions<S,D>
         &nc_incld, &nr_incld, &nitot_incld, &birim_incld,
         &inv_dzq, &inv_rho, &ze_ice, &ze_rain, &prec, &rho,
         &rhofacr, &rhofaci, &acn, &qvs, &qvi, &sup, &supi,
-        &tmparr1, &inv_exner, &qtend_ignore, &ntend_ignore,
+        &tmparr1, &inv_exner, &diag_ze, &diag_vmi, &diag_di, &lamc,
+        &pratot, &prctot, &qtend_ignore, &ntend_ignore,
       });
 
     // Get single-column subviews of all inputs, shouldn't need any i-indexing

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -926,12 +926,12 @@ void Functions<S,D>
 
     workspace.template take_many_and_reset<42>(
       {
-        "mu_r", "t", "lamr", "logn0r", "nu", "cdist", "cdist1", "cdistr",
+        "mu_r", "t", "lamr", "lamc", "logn0r", "nu", "cdist", "cdist1", "cdistr",
         "inv_icldm", "inv_lcldm", "inv_rcldm", "qc_incld", "qr_incld", "qitot_incld", "qirim_incld",
         "nc_incld", "nr_incld", "nitot_incld", "birim_incld",
         "inv_dzq", "inv_rho", "ze_ice", "ze_rain", "prec", "rho",
         "rhofacr", "rhofaci", "acn", "qvs", "qvi", "sup", "supi",
-        "tmparr1", "inv_exner", "diag_ze", "diag_vmi", "diag_di", "lamc",
+        "tmparr1", "inv_exner", "diag_ze", "diag_vmi", "diag_di",
         "pratot", "prctot", "qtend_ignore", "ntend_ignore"
       },
       {
@@ -1004,7 +1004,6 @@ void Functions<S,D>
       ze_ice, ze_rain, odiag_effc, odiag_effi, inv_icldm, inv_lcldm,
       inv_rcldm, inv_exner, t, oqv, inv_dzq,
       diagnostic_outputs.prt_liq(i), diagnostic_outputs.prt_sol(i), zero_init);
-
     p3_main_part1(
       team, nk, infrastructure.predictNc, infrastructure.dt,
       opres, opdel, odzq, oncnuc, oexner, inv_exner, inv_lcldm, inv_icldm,

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -870,7 +870,7 @@ void Functions<S,D>
   const Int nk_pack = scream::pack::npack<Spack>(nk);
   const auto policy = util::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ni, nk_pack);
 
-  WorkspaceManager<Spack, Device> workspace_mgr(nk_pack, 42, policy);
+  WorkspaceManager<Spack, Device> workspace_mgr(nk_pack, 47, policy);
 
   // load constants into local vars
   const     Scalar odt          = 1 / infrastructure.dt;

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -935,13 +935,13 @@ void Functions<S,D>
         "pratot", "prctot", "qtend_ignore", "ntend_ignore"
       },
       {
-        &mu_r, &t, &lamr, &logn0r, &nu, &cdist, &cdist1, &cdistr,
+        &mu_r, &t, &lamr, &lamc, &logn0r, &nu, &cdist, &cdist1, &cdistr,
         &inv_icldm, &inv_lcldm, &inv_rcldm, &qc_incld, &qr_incld, &qitot_incld, &qirim_incld,
         &nc_incld, &nr_incld, &nitot_incld, &birim_incld,
         &inv_dzq, &inv_rho, &ze_ice, &ze_rain, &prec, &rho,
         &rhofacr, &rhofaci, &acn, &qvs, &qvi, &sup, &supi,
-        &tmparr1, &inv_exner, &diag_ze, &diag_vmi, &diag_di, &lamc,
-        &pratot, &prctot, &qtend_ignore, &ntend_ignore,
+        &tmparr1, &inv_exner, &diag_ze, &diag_vmi, &diag_di,
+        &pratot, &prctot, &qtend_ignore, &ntend_ignore
       });
 
     // Get single-column subviews of all inputs, shouldn't need any i-indexing

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -25,7 +25,6 @@ void Functions<S,D>
   const uview_1d<const Spack>& exner,
   const uview_1d<const Spack>& th,
   const uview_1d<const Spack>& dzq,
-  const uview_1d<Spack>& diag_ze,
   const uview_1d<Spack>& ze_ice,
   const uview_1d<Spack>& ze_rain,
   const uview_1d<Spack>& diag_effc,
@@ -39,7 +38,7 @@ void Functions<S,D>
   const uview_1d<Spack>& inv_dzq,
   Scalar& prt_liq,
   Scalar& prt_sol,
-  view_1d_ptr_array<Spack, 40>& zero_init)
+  view_1d_ptr_array<Spack, 35>& zero_init)
 {
   prt_liq = 0;
   prt_sol = 0;
@@ -47,7 +46,6 @@ void Functions<S,D>
   Kokkos::parallel_for(
     Kokkos::TeamThreadRange(team, nk_pack), [&] (Int k) {
 
-    diag_ze(k)      = -99;
     ze_ice(k)       = 1.e-22;
     ze_rain(k)      = 1.e-22;
     diag_effc(k)    = 10.e-6;
@@ -73,7 +71,7 @@ void Functions<S,D>
 ::p3_main_pre_main_loop(
   const MemberType& team,
   const Int& nk,
-  const bool& log_predictNc,
+  const bool& predictNc,
   const Scalar& dt,
   const uview_1d<const Spack>& pres,
   const uview_1d<const Spack>& pdel,
@@ -114,8 +112,8 @@ void Functions<S,D>
   const uview_1d<Spack>& nr_incld,
   const uview_1d<Spack>& nitot_incld,
   const uview_1d<Spack>& birim_incld,
-  bool& log_nucleationPossible,
-  bool& log_hydrometeorsPresent)
+  bool& nucleationPossible,
+  bool& hydrometeorsPresent)
 {
   // Get access to saturation functions
   using physics = scream::physics::Functions<Scalar, Device>;
@@ -130,8 +128,8 @@ void Functions<S,D>
   constexpr Scalar qsmall       = C::QSMALL;
   constexpr Scalar inv_cp       = C::INV_CP;
 
-  log_nucleationPossible = false;
-  log_hydrometeorsPresent = false;
+  nucleationPossible = false;
+  hydrometeorsPresent = false;
   team.team_barrier();
 
   const Int nk_pack = scream::pack::npack<Spack>(nk);
@@ -163,7 +161,7 @@ void Functions<S,D>
     acn(k)     = g * rhow / (18 * dum); // 'a' parameter for droplet fallspeed (Stokes' law)
 
     if ( (t(k) < zerodegc && supi(k) >= -0.05).any() ) {
-      log_nucleationPossible = true;
+      nucleationPossible = true;
     }
 
     // apply mass clipping if dry and mass is sufficiently small
@@ -175,11 +173,11 @@ void Functions<S,D>
     qc(k).set(drymass, 0);
     nc(k).set(drymass, 0);
     if ( not_drymass.any() ) {
-      log_hydrometeorsPresent = true; // updated further down
+      hydrometeorsPresent = true; // updated further down
       // Apply droplet activation here (before other microphysical processes) for consistency with qc increase by saturation
       // adjustment already applied in macrophysics. If prescribed drop number is used, this is also a good place to
       // prescribe that value
-      if (!log_predictNc) {
+      if (!predictNc) {
          nc(k).set(not_drymass, nccnst*inv_rho(k));
       } else {
          nc(k).set(not_drymass, pack::max(nc(k) + ncnuc(k) * dt, 0.0));
@@ -193,7 +191,7 @@ void Functions<S,D>
     qr(k).set(drymass, 0);
     nr(k).set(drymass, 0);
     if ( not_drymass.any() ) {
-      log_hydrometeorsPresent = true; // updated further down
+      hydrometeorsPresent = true; // updated further down
     }
 
     drymass = (qitot(k) < qsmall || (qitot(k) < 1.e-8 && supi(k) < -0.1));
@@ -205,7 +203,7 @@ void Functions<S,D>
     qirim(k).set(drymass, 0);
     birim(k).set(drymass, 0);
     if ( not_drymass.any() ) {
-      log_hydrometeorsPresent = true; // final update
+      hydrometeorsPresent = true; // final update
     }
 
     drymass = (qitot(k) >= qsmall && qitot(k) < 1.e-8 && t(k) >= zerodegc);
@@ -232,7 +230,7 @@ void Functions<S,D>
 ::p3_main_main_loop(
   const MemberType& team,
   const Int& nk_pack,
-  const bool& log_predictNc,
+  const bool& predictNc,
   const Scalar& dt,
   const Scalar& odt,
   const view_dnu_table& dnu,
@@ -285,7 +283,6 @@ void Functions<S,D>
   const uview_1d<Spack>& birim_incld,
   const uview_1d<Spack>& mu_c,
   const uview_1d<Spack>& nu,
-  const uview_1d<Spack>& lamc,
   const uview_1d<Spack>& cdist,
   const uview_1d<Spack>& cdist1,
   const uview_1d<Spack>& cdistr,
@@ -299,9 +296,7 @@ void Functions<S,D>
   const uview_1d<Spack>& vap_liq_exchange,
   const uview_1d<Spack>& vap_ice_exchange,
   const uview_1d<Spack>& liq_ice_exchange,
-  const uview_1d<Spack>& pratot,
-  const uview_1d<Spack>& prctot,
-  bool& log_hydrometeorsPresent)
+  bool& hydrometeorsPresent)
 {
   constexpr Scalar qsmall       = C::QSMALL;
   constexpr Scalar nsmall       = C::NSMALL;
@@ -313,7 +308,7 @@ void Functions<S,D>
   constexpr Scalar inv_cp       = C::INV_CP;
 
   team.team_barrier();
-  log_hydrometeorsPresent = false;
+  hydrometeorsPresent = false;
   team.team_barrier();
 
   Kokkos::parallel_for(
@@ -401,7 +396,7 @@ void Functions<S,D>
       epsc(0),        // TODO(doc)
       epsi_tot (0);   // inverse supersaturation relaxation timescale for combined ice categories
 
-    Smask log_wetgrowth(false);
+    Smask wetgrowth(false);
 
     // skip micro process calculations except nucleation/acvtivation if there no hydrometeors are present
     const auto skip_micro = skip_all || !(qc_incld(k) >= qsmall || qr_incld(k) >= qsmall || qitot_incld(k) >= qsmall);
@@ -413,7 +408,9 @@ void Functions<S,D>
         t(k), pres(k), rho(k), xxlv(k), xxls(k), qvs(k), qvi(k),
         mu, dv, sc, dqsdt, dqsidt, ab, abi, kap, eii, not_skip_micro);
 
-      get_cloud_dsd2(qc_incld(k), nc_incld(k), mu_c(k), rho(k), nu(k), dnu, lamc(k), cdist(k), cdist1(k), lcldm(k), not_skip_micro);
+      Spack lamc;
+      get_cloud_dsd2(qc_incld(k), nc_incld(k), mu_c(k), rho(k), nu(k), dnu,
+                     lamc, cdist(k), cdist1(k), lcldm(k), not_skip_micro);
       nc(k).set(not_skip_micro, nc_incld(k) * lcldm(k));
 
       get_rain_dsd2(qr_incld(k), nr_incld(k), mu_r(k), lamr(k), cdistr(k), logn0r(k), rcldm(k), not_skip_micro);
@@ -491,7 +488,7 @@ void Functions<S,D>
       // calculate wet growth
       ice_cldliq_wet_growth(
         rho(k), t(k), pres(k), rhofaci(k), f1pr05, f1pr14, xxlv(k), xlf(k), dv, kap, mu, sc, qv(k), qc_incld(k), qitot_incld(k), nitot_incld(k), qr_incld(k),
-        log_wetgrowth, qrcol, qccol, qwgrth, nrshdr, qcshd, not_skip_micro);
+        wetgrowth, qrcol, qccol, qwgrth, nrshdr, qcshd, not_skip_micro);
 
       // calcualte total inverse ice relaxation timescale combined for all ice categories
       // note 'f1pr' values are normalized, so we need to multiply by N
@@ -501,12 +498,12 @@ void Functions<S,D>
 
       // calculate rime density
       calc_rime_density(
-        t(k), rhofaci(k), f1pr02, acn(k), lamc(k), mu_c(k), qc_incld(k), qccol,
+        t(k), rhofaci(k), f1pr02, acn(k), lamc, mu_c(k), qc_incld(k), qccol,
         vtrmi1, rhorime_c, not_skip_micro);
 
       // contact and immersion freezing droplets
       cldliq_immersion_freezing(
-	t(k), lamc(k), mu_c(k), cdist1(k), qc_incld(k), qc_relvar(k),
+        t(k), lamc, mu_c(k), cdist1(k), qc_incld(k), qc_relvar(k),
         qcheti, ncheti, not_skip_micro);
 
       // for future: get rid of log statements below for rain freezing
@@ -539,7 +536,7 @@ void Functions<S,D>
 
     // deposition/condensation-freezing nucleation
     ice_nucleation(
-      t(k), inv_rho(k), nitot(k), naai(k), supi(k), odt, log_predictNc,
+      t(k), inv_rho(k), nitot(k), naai(k), supi(k), odt, predictNc,
       qinuc, ninuc, not_skip_all);
 
     // cloud water autoconversion
@@ -621,13 +618,17 @@ void Functions<S,D>
 
     //-- ice-phase dependent processes:
     update_prognostic_ice(
-      qcheti, qccol, qcshd, nccol, ncheti, ncshdc, qrcol, nrcol,  qrheti, nrheti, nrshdr, qimlt, nimlt, qisub, qidep, qinuc, ninuc, nislf, nisub, qiberg, exner(k), xxls(k), xlf(k), log_predictNc, log_wetgrowth, dt, nmltratio, rhorime_c,
-      th(k), qv(k), qitot(k), nitot(k), qirim(k), birim(k), qc(k), nc(k), qr(k), nr(k), not_skip_all);
+      qcheti, qccol, qcshd, nccol, ncheti, ncshdc, qrcol, nrcol,  qrheti,
+      nrheti, nrshdr, qimlt, nimlt, qisub, qidep, qinuc, ninuc, nislf, nisub,
+      qiberg, exner(k), xxls(k), xlf(k), predictNc, wetgrowth, dt, nmltratio,
+      rhorime_c, th(k), qv(k), qitot(k), nitot(k), qirim(k), birim(k), qc(k),
+      nc(k), qr(k), nr(k), not_skip_all);
 
     //-- warm-phase only processes:
     update_prognostic_liquid(
-      qcacc, ncacc, qcaut, ncautc, ncautr, ncslf, qrevp, nrevp, nrslf, log_predictNc, inv_rho(k), exner(k), xxlv(k), dt,
-      th(k), qv(k), qc(k), nc(k), qr(k), nr(k), not_skip_all);
+      qcacc, ncacc, qcaut, ncautc, ncautr, ncslf, qrevp, nrevp, nrslf,
+      predictNc, inv_rho(k), exner(k), xxlv(k), dt, th(k), qv(k), qc(k), nc(k),
+      qr(k), nr(k), not_skip_all);
 
     // AaronDonahue - Add extra variables needed from microphysics by E3SM:
     cmeiout(k)         .set(not_skip_all, qidep - qisub + qinuc);
@@ -653,7 +654,7 @@ void Functions<S,D>
     nc(k).set(qc_small, 0);
 
     if (qc_not_small.any()) {
-      log_hydrometeorsPresent = true;
+      hydrometeorsPresent = true;
     }
 
     qv(k).set(qr_small, qv(k) + qr(k));
@@ -662,7 +663,7 @@ void Functions<S,D>
     nr(k).set(qr_small, 0);
 
     if (qr_not_small.any()) {
-      log_hydrometeorsPresent = true;
+      hydrometeorsPresent = true;
     }
 
     qv(k).set(qitot_small, qv(k) + qitot(k));
@@ -673,14 +674,10 @@ void Functions<S,D>
     birim(k).set(qitot_small, 0);
 
     if (qitot_not_small.any()) {
-      log_hydrometeorsPresent = true;
+      hydrometeorsPresent = true;
     }
 
     impose_max_total_Ni(nitot(k), max_total_Ni, inv_rho(k), not_skip_all);
-
-    // Outputs associated with aerocom comparison:
-    pratot(k).set(not_skip_all, qcacc); // cloud drop accretion by rain
-    prctot(k).set(not_skip_all, qcaut); // cloud drop autoconversion to rain
 
     // Recalculate in-cloud values for sedimentation
     calculate_incloud_mixingratios(
@@ -718,17 +715,13 @@ void Functions<S,D>
   const uview_1d<Spack>& xxls,
   const uview_1d<Spack>& mu_c,
   const uview_1d<Spack>& nu,
-  const uview_1d<Spack>& lamc,
   const uview_1d<Spack>& mu_r,
   const uview_1d<Spack>& lamr,
   const uview_1d<Spack>& vap_liq_exchange,
   const uview_1d<Spack>& ze_rain,
   const uview_1d<Spack>& ze_ice,
-  const uview_1d<Spack>& diag_vmi,
   const uview_1d<Spack>& diag_effi,
-  const uview_1d<Spack>& diag_di,
   const uview_1d<Spack>& diag_rhoi,
-  const uview_1d<Spack>& diag_ze,
   const uview_1d<Spack>& diag_effc)
 {
   constexpr Scalar qsmall       = C::QSMALL;
@@ -754,9 +747,10 @@ void Functions<S,D>
     {
       const auto qc_gt_small = qc(k) >= qsmall;
       const auto qc_small    = !qc_gt_small;
-      get_cloud_dsd2(qc(k), nc(k), mu_c(k), rho(k), nu(k), dnu, lamc(k), ignore1, ignore2, lcldm(k), qc_gt_small);
+      Spack lamc;
+      get_cloud_dsd2(qc(k), nc(k), mu_c(k), rho(k), nu(k), dnu, lamc, ignore1, ignore2, lcldm(k), qc_gt_small);
 
-      diag_effc(k)       .set(qc_gt_small, sp(0.5) * (mu_c(k) + 3) / lamc(k));
+      diag_effc(k)       .set(qc_gt_small, sp(0.5) * (mu_c(k) + 3) / lamc);
       qv(k)              .set(qc_small, qv(k)+qc(k));
       th(k)              .set(qc_small, th(k)-exner(k)*qc(k)*xxlv(k)*inv_cp);
       vap_liq_exchange(k).set(qc_small, vap_liq_exchange(k) - qc(k));
@@ -817,9 +811,7 @@ void Functions<S,D>
       birim(k).set(qirim_small, 0);
 
       // note that reflectivity from lookup table is normalized, so we need to multiply by N
-      diag_vmi(k) .set(qi_gt_small, f1pr02 * rhofaci(k));
       diag_effi(k).set(qi_gt_small, f1pr06); // units are in m
-      diag_di(k)  .set(qi_gt_small, f1pr15);
       diag_rhoi(k).set(qi_gt_small, f1pr16);
 
       // note factor of air density below is to convert from m^6/kg to m^6/m^3
@@ -832,11 +824,7 @@ void Functions<S,D>
       nitot(k)  .set(qi_small, 0);
       qirim(k)  .set(qi_small, 0);
       birim(k)  .set(qi_small, 0);
-      diag_di(k).set(qi_small, 0);
     }
-
-    // sum ze components and convert to dBZ
-    diag_ze(k) = 10 * pack::log10((ze_rain(k) + ze_ice(k))*sp(1.e18));
 
     // if qr is very small then set Nr to 0 (needs to be done here after call
     // to ice lookup table because a minimum Nr of nsmall will be set otherwise even if qr=0)
@@ -848,62 +836,13 @@ void Functions<S,D>
 template <typename S, typename D>
 void Functions<S,D>
 ::p3_main(
-  // inputs
-  const view_2d<const Spack>& pres,          // pressure                             Pa
-  const view_2d<const Spack>& dzq,           // vertical grid spacing                m
-  const view_2d<const Spack>& ncnuc,         // IN ccn activated number tendency     kg-1 s-1
-  const view_2d<const Spack>& naai,          // IN actived ice nuclei concentration  1/kg
-  const view_2d<const Spack>& qc_relvar,     // Assumed SGS 1/(var(qc)/mean(qc))     kg2/kg2
-  const Real&                 dt,            // model time step                      s
-  const Int&                  ni,            // num columns
-  const Int&                  nk,            // column size
-  const Int&                  it,            // time step counter NOTE: starts at 1 for first time step
-  const bool&                 log_predictNc, // .T. (.F.) for prediction (specification) of Nc
-  const view_2d<const Spack>& pdel,          // pressure thickness                   Pa
-  const view_2d<const Spack>& exner,         // Exner expression
-
-  // inputs needed for PBUF variables used by other parameterizations
-  const view_2d<const Spack>& icldm,         // ice cloud fraction
-  const view_2d<const Spack>& lcldm,         // liquid cloud fraction
-  const view_2d<const Spack>& rcldm,         // rain cloud fraction
-  const view_2d<const Scalar>& col_location, // ni x 3
-
-  // input/output  arguments
-  const view_2d<Spack>& qc,    // cloud, mass mixing ratio         kg kg-1
-  const view_2d<Spack>& nc,    // cloud, number mixing ratio       #  kg-1
-  const view_2d<Spack>& qr,    // rain, mass mixing ratio          kg kg-1
-  const view_2d<Spack>& nr,    // rain, number mixing ratio        #  kg-1
-  const view_2d<Spack>& qitot, // ice, total mass mixing ratio     kg kg-1
-  const view_2d<Spack>& qirim, // ice, rime mass mixing ratio      kg kg-1
-  const view_2d<Spack>& nitot, // ice, total number mixing ratio   #  kg-1
-  const view_2d<Spack>& birim, // ice, rime volume mixing ratio    m3 kg-1
-  const view_2d<Spack>& qv,    // water vapor mixing ratio         kg kg-1
-  const view_2d<Spack>& th,    // potential temperature            K
-
-  // output arguments
-  const view_1d<Scalar>& prt_liq,  // precipitation rate, liquid       m s-1
-  const view_1d<Scalar>& prt_sol,  // precipitation rate, solid        m s-1
-  const view_2d<Spack>& diag_ze,   // equivalent reflectivity          dBZ
-  const view_2d<Spack>& diag_effc, // effective radius, cloud          m
-  const view_2d<Spack>& diag_effi, // effective radius, ice            m
-  const view_2d<Spack>& diag_vmi,  // mass-weighted fall speed of ice  m s-1
-  const view_2d<Spack>& diag_di,   // mean diameter of ice             m
-  const view_2d<Spack>& diag_rhoi, // bulk density of ice              kg m-3
-  const view_2d<Spack>& mu_c,      // Size distribution shape parameter for radiation
-  const view_2d<Spack>& lamc,      // Size distribution slope parameter for radiation
-
-  // outputs for PBUF variables used by other parameterizations
-  const view_2d<Spack>& cmeiout,          // qitend due to deposition/sublimation
-  const view_2d<Spack>& prain,            // Total precipitation (rain + snow)
-  const view_2d<Spack>& nevapr,           // evaporation of total precipitation (rain + snow)
-  const view_2d<Spack>& prer_evap,        // evaporation of rain
-  const view_2d<Spack>& rflx,             // grid-box average rain flux (kg m^-2 s^-1) pverp
-  const view_2d<Spack>& sflx,             // grid-box average ice/snow flux (kg m^-2 s^-1) pverp
-  const view_2d<Spack>& pratot,           // accretion of cloud by rain
-  const view_2d<Spack>& prctot,           // autoconversion of cloud to rain
-  const view_2d<Spack>& liq_ice_exchange, // sum of liq-ice phase change tendenices
-  const view_2d<Spack>& vap_liq_exchange, // sum of vap-liq phase change tendenices
-  const view_2d<Spack>& vap_ice_exchange) // sum of vap-ice phase change tendenices
+  const P3PrognosticState& prognostic_state,
+  const P3DiagnosticInputs& diagnostic_inputs,
+  const P3DiagnosticOutputs& diagnostic_outputs,
+  const P3Infrastructure& infrastructure,
+  const P3HistoryOnly& history_only,
+  Int ni,
+  Int nk)
 {
   using ExeSpace = typename KT::ExeSpace;
 
@@ -917,7 +856,7 @@ void Functions<S,D>
   WorkspaceManager<Spack, Device> workspace_mgr(nk_pack, 42, policy);
 
   // load constants into local vars
-  const     Scalar odt          = 1 / dt;
+  const     Scalar odt          = 1 / infrastructure.dt;
   constexpr Int    kdir         = -1;
   const     Int    ktop         = kdir == -1 ? 0    : nk-1;
   const     Int    kbot         = kdir == -1 ? nk-1 : 0;
@@ -953,7 +892,7 @@ void Functions<S,D>
       t,      // temperature at the beginning of the microhpysics step [K]
 
       // 2D size distribution and fallspeed parameters
-      lamr, logn0r, nu, cdist, cdist1, cdistr,
+      lamr, lamc, logn0r, nu, cdist, cdist1, cdistr,
 
       // Variables needed for in-cloud calculations
       inv_icldm, inv_lcldm, inv_rcldm, // Inverse cloud fractions (1/cld)
@@ -988,96 +927,97 @@ void Functions<S,D>
 
     // Get single-column subviews of all inputs, shouldn't need any i-indexing
     // after this.
-    const auto opres             = util::subview(pres, i);
-    const auto odzq              = util::subview(dzq, i);
-    const auto oncnuc            = util::subview(ncnuc, i);
-    const auto onaai             = util::subview(naai, i);
-    const auto oqc_relvar        = util::subview(qc_relvar, i);
-    const auto opdel             = util::subview(pdel, i);
-    const auto oexner            = util::subview(exner, i);
-    const auto oicldm            = util::subview(icldm, i);
-    const auto olcldm            = util::subview(lcldm, i);
-    const auto orcldm            = util::subview(rcldm, i);
-    const auto ocol_location     = util::subview(col_location, i);
-    const auto oqc               = util::subview(qc, i);
-    const auto onc               = util::subview(nc, i);
-    const auto oqr               = util::subview(qr, i);
-    const auto onr               = util::subview(nr, i);
-    const auto oqitot            = util::subview(qitot, i);
-    const auto oqirim            = util::subview(qirim, i);
-    const auto onitot            = util::subview(nitot, i);
-    const auto obirim            = util::subview(birim, i);
-    const auto oqv               = util::subview(qv, i);
-    const auto oth               = util::subview(th, i);
-    const auto odiag_ze          = util::subview(diag_ze, i);
-    const auto odiag_effc        = util::subview(diag_effc, i);
-    const auto odiag_effi        = util::subview(diag_effi, i);
-    const auto odiag_vmi         = util::subview(diag_vmi, i);
-    const auto odiag_di          = util::subview(diag_di, i);
-    const auto odiag_rhoi        = util::subview(diag_rhoi, i);
-    const auto omu_c             = util::subview(mu_c, i);
-    const auto olamc             = util::subview(lamc, i);
-    const auto ocmeiout          = util::subview(cmeiout, i);
-    const auto oprain            = util::subview(prain, i);
-    const auto onevapr           = util::subview(nevapr, i);
-    const auto oprer_evap        = util::subview(prer_evap, i);
-    const auto orflx             = util::subview(rflx, i);
-    const auto osflx             = util::subview(sflx, i);
-    const auto opratot           = util::subview(pratot, i);
-    const auto oprctot           = util::subview(prctot, i);
-    const auto oliq_ice_exchange = util::subview(liq_ice_exchange, i);
-    const auto ovap_liq_exchange = util::subview(vap_liq_exchange, i);
-    const auto ovap_ice_exchange = util::subview(vap_ice_exchange, i);
+    const auto opres             = util::subview(diagnostic_inputs.pres, i);
+    const auto odzq              = util::subview(diagnostic_inputs.dzq, i);
+    const auto oncnuc            = util::subview(diagnostic_inputs.ncnuc, i);
+    const auto onaai             = util::subview(diagnostic_inputs.naai, i);
+    const auto oqc_relvar        = util::subview(diagnostic_inputs.qc_relvar, i);
+    const auto opdel             = util::subview(diagnostic_inputs.pdel, i);
+    const auto oexner            = util::subview(diagnostic_inputs.exner, i);
+    const auto oicldm            = util::subview(diagnostic_inputs.icldm, i);
+    const auto olcldm            = util::subview(diagnostic_inputs.lcldm, i);
+    const auto orcldm            = util::subview(diagnostic_inputs.rcldm, i);
+    const auto ocol_location     = util::subview(infrastructure.col_location, i);
+    const auto oqc               = util::subview(prognostic_state.qc, i);
+    const auto onc               = util::subview(prognostic_state.nc, i);
+    const auto oqr               = util::subview(prognostic_state.qr, i);
+    const auto onr               = util::subview(prognostic_state.nr, i);
+    const auto oqitot            = util::subview(prognostic_state.qitot, i);
+    const auto oqirim            = util::subview(prognostic_state.qirim, i);
+    const auto onitot            = util::subview(prognostic_state.nitot, i);
+    const auto obirim            = util::subview(prognostic_state.birim, i);
+    const auto oqv               = util::subview(prognostic_state.qv, i);
+    const auto oth               = util::subview(prognostic_state.th, i);
+    const auto odiag_effc        = util::subview(diagnostic_outputs.diag_effc, i);
+    const auto odiag_effi        = util::subview(diagnostic_outputs.diag_effi, i);
+    const auto odiag_rhoi        = util::subview(diagnostic_outputs.diag_rhoi, i);
+    const auto omu_c             = util::subview(diagnostic_outputs.mu_c, i);
+    const auto ocmeiout          = util::subview(diagnostic_outputs.cmeiout, i);
+    const auto oprain            = util::subview(diagnostic_outputs.prain, i);
+    const auto onevapr           = util::subview(diagnostic_outputs.nevapr, i);
+    const auto oprer_evap        = util::subview(diagnostic_outputs.prer_evap, i);
+    const auto orflx             = util::subview(diagnostic_outputs.rflx, i);
+    const auto osflx             = util::subview(diagnostic_outputs.sflx, i);
+    const auto oliq_ice_exchange = util::subview(history_only.liq_ice_exchange, i);
+    const auto ovap_liq_exchange = util::subview(history_only.vap_liq_exchange, i);
+    const auto ovap_ice_exchange = util::subview(history_only.vap_ice_exchange, i);
     const auto oxxlv             = util::subview(xxlv, i);
     const auto oxxls             = util::subview(xxls, i);
     const auto oxlf              = util::subview(xlf, i);
 
     // Need to watch out for race conditions with these shared variables
-    bool &log_nucleationPossible  = bools(i, 0);
-    bool &log_hydrometeorsPresent = bools(i, 1);
+    bool &nucleationPossible  = bools(i, 0);
+    bool &hydrometeorsPresent = bools(i, 1);
 
-    view_1d_ptr_array<Spack, 40> zero_init = {
+    view_1d_ptr_array<Spack, 35> zero_init = {
       &mu_r, &lamr, &logn0r, &nu, &cdist, &cdist1, &cdistr,
       &qc_incld, &qr_incld, &qitot_incld, &qirim_incld,
       &nc_incld, &nr_incld, &nitot_incld, &birim_incld,
-      &inv_rho, &prec, &rho,
-      &rhofacr, &rhofaci, &acn, &qvs, &qvi, &sup, &supi,
+      &inv_rho, &prec, &rho, &rhofacr, &rhofaci, &acn, &qvs, &qvi, &sup, &supi,
       &tmparr1, &qtend_ignore, &ntend_ignore,
-      &opratot, &oprctot, &omu_c, &olamc, &odiag_vmi, &odiag_di, &odiag_rhoi, &ocmeiout, &oprain, &onevapr, &orflx, &osflx
+      &omu_c, &odiag_rhoi, &ocmeiout, &oprain, &onevapr, &orflx, &osflx
     };
 
     // initialize
     p3_main_init(
       team, nk_pack,
       oicldm, olcldm, orcldm, oexner, oth, odzq,
-      odiag_ze, ze_ice, ze_rain, odiag_effc, odiag_effi, inv_icldm, inv_lcldm, inv_rcldm, inv_exner, t, oqv, inv_dzq,
-      prt_liq(i), prt_sol(i), zero_init);
+      ze_ice, ze_rain, odiag_effc, odiag_effi, inv_icldm, inv_lcldm,
+      inv_rcldm, inv_exner, t, oqv, inv_dzq,
+      diagnostic_outputs.prt_liq(i), diagnostic_outputs.prt_sol(i), zero_init);
 
     p3_main_pre_main_loop(
-      team, nk, log_predictNc, dt,
-      opres, opdel, odzq, oncnuc, oexner, inv_exner, inv_lcldm, inv_icldm, inv_rcldm, oxxlv, oxxls, oxlf,
-      t, rho, inv_rho, qvs, qvi, supi, rhofacr, rhofaci, acn, oqv, oth, oqc, onc, oqr, onr, oqitot, onitot, oqirim, obirim, qc_incld, qr_incld, qitot_incld, qirim_incld, nc_incld, nr_incld, nitot_incld, birim_incld,
-      log_nucleationPossible, log_hydrometeorsPresent);
+      team, nk, infrastructure.predictNc, infrastructure.dt,
+      opres, opdel, odzq, oncnuc, oexner, inv_exner, inv_lcldm, inv_icldm,
+      inv_rcldm, oxxlv, oxxls, oxlf, t, rho, inv_rho, qvs, qvi, supi, rhofacr,
+      rhofaci, acn, oqv, oth, oqc, onc, oqr, onr, oqitot, onitot, oqirim,
+      obirim, qc_incld, qr_incld, qitot_incld, qirim_incld, nc_incld, nr_incld,
+      nitot_incld, birim_incld, nucleationPossible, hydrometeorsPresent);
 
     // There might not be any work to do for this team
-    if (!(log_nucleationPossible || log_hydrometeorsPresent)) {
+    if (!(nucleationPossible || hydrometeorsPresent)) {
       return; // this is how you do a "continue" in a kokkos lambda
     }
 
     // ------------------------------------------------------------------------------------------
     // main k-loop (for processes):
     p3_main_main_loop(
-      team, nk_pack, log_predictNc, dt, odt,
-      dnu, itab, itabcol, revap_table,
-      opres, opdel, odzq, oncnuc, oexner, inv_exner, inv_lcldm, inv_icldm, inv_rcldm, onaai, oqc_relvar, oicldm, olcldm, orcldm,
-      t, rho, inv_rho, qvs, qvi, supi, rhofacr, rhofaci, acn, oqv, oth, oqc, onc, oqr, onr, oqitot, onitot, oqirim, obirim, oxxlv, oxxls, oxlf, qc_incld, qr_incld, qitot_incld, qirim_incld, nc_incld, nr_incld, nitot_incld, birim_incld, omu_c, nu, olamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, ocmeiout, oprain, onevapr, oprer_evap, ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange, opratot, oprctot,
-      log_hydrometeorsPresent);
+      team, nk_pack, infrastructure.predictNc, infrastructure.dt, odt,
+      dnu, itab, itabcol, revap_table, opres, opdel, odzq, oncnuc, oexner,
+      inv_exner, inv_lcldm, inv_icldm, inv_rcldm, onaai, oqc_relvar, oicldm,
+      olcldm, orcldm, t, rho, inv_rho, qvs, qvi, supi, rhofacr, rhofaci, acn,
+      oqv, oth, oqc, onc, oqr, onr, oqitot, onitot, oqirim, obirim, oxxlv,
+      oxxls, oxlf, qc_incld, qr_incld, qitot_incld, qirim_incld, nc_incld,
+      nr_incld, nitot_incld, birim_incld, omu_c, nu, cdist, cdist1, cdistr,
+      mu_r, lamr, logn0r, ocmeiout, oprain, onevapr, oprer_evap,
+      ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange,
+      hydrometeorsPresent);
 
     //NOTE: At this point, it is possible to have negative (but small) nc, nr, nitot.  This is not
     //      a problem; those values get clipped to zero in the sedimentation section (if necessary).
     //      (This is not done above simply for efficiency purposes.)
 
-    if (!log_hydrometeorsPresent) return;
+    if (!hydrometeorsPresent) return;
 
     // -----------------------------------------------------------------------------------------
     // End of main microphysical processes section
@@ -1090,34 +1030,38 @@ void Functions<S,D>
 
     cloud_sedimentation(
       qc_incld, rho, inv_rho, olcldm, acn, inv_dzq, dnu, team, workspace,
-      nk, ktop, kbot, kdir, dt, odt, log_predictNc,
-      oqc, onc, nc_incld, omu_c, olamc, qtend_ignore, ntend_ignore, prt_liq(i));
+      nk, ktop, kbot, kdir, infrastructure.dt, odt, infrastructure.predictNc,
+      oqc, onc, nc_incld, omu_c, lamc, qtend_ignore, ntend_ignore,
+      diagnostic_outputs.prt_liq(i));
 
     // Rain sedimentation:  (adaptive substepping)
     rain_sedimentation(
-      rho, inv_rho, rhofacr, orcldm, inv_dzq, qr_incld, team, workspace, vn_table, vm_table,
-      nk, ktop, kbot, kdir, dt, odt,
-      oqr, onr, nr_incld, mu_r, lamr, orflx, qtend_ignore, ntend_ignore, prt_liq(i));
+      rho, inv_rho, rhofacr, orcldm, inv_dzq, qr_incld, team, workspace,
+      vn_table, vm_table, nk, ktop, kbot, kdir, infrastructure.dt, odt, oqr,
+      onr, nr_incld, mu_r, lamr, orflx, qtend_ignore, ntend_ignore,
+      diagnostic_outputs.prt_liq(i));
 
     // Ice sedimentation:  (adaptive substepping)
     ice_sedimentation(
-      rho, inv_rho, rhofaci, oicldm, inv_dzq, team, workspace,
-      nk, ktop, kbot, kdir, dt, odt,
-      oqitot, qitot_incld, onitot, nitot_incld, oqirim, qirim_incld, obirim, birim_incld, qtend_ignore, ntend_ignore, itab, prt_sol(i));
+      rho, inv_rho, rhofaci, oicldm, inv_dzq, team, workspace, nk, ktop, kbot,
+      kdir, infrastructure.dt, odt, oqitot, qitot_incld, onitot, nitot_incld,
+      oqirim, qirim_incld, obirim, birim_incld, qtend_ignore, ntend_ignore,
+      itab, diagnostic_outputs.prt_sol(i));
 
     // homogeneous freezing of cloud and rain
     homogeneous_freezing(
-      t, oexner, oxlf, team, nk, ktop, kbot, kdir,
-      oqc, onc, oqr, onr, oqitot, onitot, oqirim, obirim, oth);
+      t, oexner, oxlf, team, nk, ktop, kbot, kdir, oqc, onc, oqr, onr, oqitot,
+      onitot, oqirim, obirim, oth);
 
     //
     // final checks to ensure consistency of mass/number
     // and compute diagnostic fields for output
     //
     p3_main_post_main_loop(
-      team, nk_pack, dnu, itab,
-      oexner, olcldm, orcldm,
-      rho, inv_rho, rhofaci, oqv, oth, oqc, onc, oqr, onr, oqitot, onitot, oqirim, obirim, oxxlv, oxxls, omu_c, nu, olamc, mu_r, lamr, ovap_liq_exchange, ze_rain, ze_ice, odiag_vmi, odiag_effi, odiag_di, odiag_rhoi, odiag_ze, odiag_effc);
+      team, nk_pack, dnu, itab, oexner, olcldm, orcldm,
+      rho, inv_rho, rhofaci, oqv, oth, oqc, onc, oqr, onr, oqitot, onitot,
+      oqirim, obirim, oxxlv, oxxls, omu_c, nu, mu_r, lamr, ovap_liq_exchange,
+      ze_rain, ze_ice, odiag_effi, odiag_rhoi, odiag_effc);
 
     //
     // merge ice categories with similar properties
@@ -1133,7 +1077,8 @@ void Functions<S,D>
         tmparr1(k) = oth(k) * inv_exner(k);
     });
 
-    check_values(oqv, tmparr1, ktop, kbot, it, debug_ABORT, 900, team, ocol_location);
+    check_values(oqv, tmparr1, ktop, kbot, infrastructure.it, debug_ABORT, 900,
+                 team, ocol_location);
 #endif
   });
 }

--- a/components/scream/src/physics/p3/scream_p3_interface.F90
+++ b/components/scream/src/physics/p3/scream_p3_interface.F90
@@ -276,11 +276,8 @@ contains
          ite,                         & ! IN     horizontal index upper bound     -
          kts,                         & ! IN     vertical index lower bound       -
          kte,                         & ! IN     vertical index upper bound       -
-         diag_ze(its:ite,kts:kte),    & ! OUT    equivalent reflectivity          dBZ  UNUSED?
          rel(its:ite,kts:kte),        & ! OUT    effective radius, cloud          m
          rei(its:ite,kts:kte),        & ! OUT    effective radius, ice            m
-         diag_vmi(its:ite,kts:kte),   & ! OUT    mass-weighted fall speed of ice  m s-1
-         diag_di(its:ite,kts:kte),    & ! OUT    mean diameter of ice             m
          diag_rhoi(its:ite,kts:kte),  & ! OUT    bulk density of ice              kg m-3
          log_predictNc,               & ! IN     .true.=prognostic Nc, .false.=specified Nc
          ! AaronDonahue new stuff
@@ -295,11 +292,8 @@ contains
          rcldm(its:ite,kts:kte),      & ! IN rain cloud fraction
          lcldm(its:ite,kts:kte),      & ! IN liquid cloud fraction
          icldm(its:ite,kts:kte),      & ! IN ice cloud fraction
-         pratot(its:ite,kts:kte),     & ! OUT accretion of cloud by rain
-         prctot(its:ite,kts:kte),     & ! OUT autoconversion of cloud by rain
          tend_out(its:ite,kts:kte,:), & ! OUT p3 microphysics tendencies
          mu(its:ite,kts:kte),         & ! OUT Size distribution shape parameter for radiation
-         lambdac(its:ite,kts:kte),    & ! OUT Size distribution slope parameter for radiation
          liq_ice_exchange(its:ite,kts:kte),& ! OUT sum of liq-ice phase change tendenices
          vap_liq_exchange(its:ite,kts:kte),& ! OUT sun of vap-liq phase change tendencies
          vap_ice_exchange(its:ite,kts:kte),& ! OUT sum of vap-ice phase change tendencies

--- a/components/scream/src/physics/p3/scream_p3_interface.F90
+++ b/components/scream/src/physics/p3/scream_p3_interface.F90
@@ -294,6 +294,7 @@ contains
          icldm(its:ite,kts:kte),      & ! IN ice cloud fraction
          tend_out(its:ite,kts:kte,:), & ! OUT p3 microphysics tendencies
          mu(its:ite,kts:kte),         & ! OUT Size distribution shape parameter for radiation
+         lambdac(its:ite,kts:kte),     & ! OUT Size distribution slope parameter for radiation
          liq_ice_exchange(its:ite,kts:kte),& ! OUT sum of liq-ice phase change tendenices
          vap_liq_exchange(its:ite,kts:kte),& ! OUT sun of vap-liq phase change tendencies
          vap_ice_exchange(its:ite,kts:kte),& ! OUT sum of vap-ice phase change tendencies

--- a/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -505,7 +505,7 @@ static void run_bfb_p3_main()
       d.prt_sol, d.its, d.ite, d.kts, d.kte, d.diag_effc, d.diag_effi,
       d.diag_rhoi, d.log_predictNc, d.pdel, d.exner, d.cmeiout, d.prain,
       d.nevapr, d.prer_evap, d.rflx, d.sflx, d.rcldm, d.lcldm, d.icldm, d.mu_c,
-      d.mu_r, d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange);
+      d.lamc, d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange);
     d.transpose<util::TransposeDirection::f2c>();
   }
 
@@ -525,6 +525,7 @@ static void run_bfb_p3_main()
       REQUIRE(isds_fortran[i].diag_effi[t]        == isds_cxx[i].diag_effi[t]);
       REQUIRE(isds_fortran[i].diag_rhoi[t]        == isds_cxx[i].diag_rhoi[t]);
       REQUIRE(isds_fortran[i].mu_c[t]             == isds_cxx[i].mu_c[t]);
+      REQUIRE(isds_fortran[i].lamc[t]             == isds_cxx[i].lamc[t]);
       REQUIRE(isds_fortran[i].cmeiout[t]          == isds_cxx[i].cmeiout[t]);
       REQUIRE(isds_fortran[i].prain[t]            == isds_cxx[i].prain[t]);
       REQUIRE(isds_fortran[i].nevapr[t]           == isds_cxx[i].nevapr[t]);

--- a/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -500,11 +500,12 @@ static void run_bfb_p3_main()
     P3MainData& d = isds_cxx[i];
     d.transpose<util::TransposeDirection::c2f>();
     p3_main_f(
-      d.qc, d.nc, d.qr, d.nr, d.th, d.qv, d.dt, d.qitot, d.qirim, d.nitot, d.birim,
-      d.pres, d.dzq, d.ncnuc, d.naai, d.qc_relvar, d.it, d.prt_liq, d.prt_sol, d.its, d.ite, d.kts, d.kte, d.diag_ze, d.diag_effc,
-      d.diag_effi, d.diag_vmi, d.diag_di, d.diag_rhoi, d.log_predictNc,
-      d.pdel, d.exner, d.cmeiout, d.prain, d.nevapr, d.prer_evap, d.rflx, d.sflx, d.rcldm, d.lcldm, d.icldm,
-      d.pratot, d.prctot, d.mu_c, d.lamc, d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange);
+      d.qc, d.nc, d.qr, d.nr, d.th, d.qv, d.dt, d.qitot, d.qirim, d.nitot,
+      d.birim, d.pres, d.dzq, d.ncnuc, d.naai, d.qc_relvar, d.it, d.prt_liq,
+      d.prt_sol, d.its, d.ite, d.kts, d.kte, d.diag_effc, d.diag_effi,
+      d.diag_rhoi, d.log_predictNc, d.pdel, d.exner, d.cmeiout, d.prain,
+      d.nevapr, d.prer_evap, d.rflx, d.sflx, d.rcldm, d.lcldm, d.icldm, d.mu_c,
+      d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange);
     d.transpose<util::TransposeDirection::f2c>();
   }
 
@@ -520,20 +521,14 @@ static void run_bfb_p3_main()
       REQUIRE(isds_fortran[i].birim[t]            == isds_cxx[i].birim[t]);
       REQUIRE(isds_fortran[i].qv[t]               == isds_cxx[i].qv[t]);
       REQUIRE(isds_fortran[i].th[t]               == isds_cxx[i].th[t]);
-      REQUIRE(isds_fortran[i].diag_ze[t]          == isds_cxx[i].diag_ze[t]);
       REQUIRE(isds_fortran[i].diag_effc[t]        == isds_cxx[i].diag_effc[t]);
       REQUIRE(isds_fortran[i].diag_effi[t]        == isds_cxx[i].diag_effi[t]);
-      REQUIRE(isds_fortran[i].diag_vmi[t]         == isds_cxx[i].diag_vmi[t]);
-      REQUIRE(isds_fortran[i].diag_di[t]          == isds_cxx[i].diag_di[t]);
       REQUIRE(isds_fortran[i].diag_rhoi[t]        == isds_cxx[i].diag_rhoi[t]);
       REQUIRE(isds_fortran[i].mu_c[t]             == isds_cxx[i].mu_c[t]);
-      REQUIRE(isds_fortran[i].lamc[t]             == isds_cxx[i].lamc[t]);
       REQUIRE(isds_fortran[i].cmeiout[t]          == isds_cxx[i].cmeiout[t]);
       REQUIRE(isds_fortran[i].prain[t]            == isds_cxx[i].prain[t]);
       REQUIRE(isds_fortran[i].nevapr[t]           == isds_cxx[i].nevapr[t]);
       REQUIRE(isds_fortran[i].prer_evap[t]        == isds_cxx[i].prer_evap[t]);
-      REQUIRE(isds_fortran[i].pratot[t]           == isds_cxx[i].pratot[t]);
-      REQUIRE(isds_fortran[i].prctot[t]           == isds_cxx[i].prctot[t]);
       REQUIRE(isds_fortran[i].liq_ice_exchange[t] == isds_cxx[i].liq_ice_exchange[t]);
       REQUIRE(isds_fortran[i].vap_liq_exchange[t] == isds_cxx[i].vap_liq_exchange[t]);
       REQUIRE(isds_fortran[i].vap_ice_exchange[t] == isds_cxx[i].vap_ice_exchange[t]);

--- a/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -505,7 +505,7 @@ static void run_bfb_p3_main()
       d.prt_sol, d.its, d.ite, d.kts, d.kte, d.diag_effc, d.diag_effi,
       d.diag_rhoi, d.log_predictNc, d.pdel, d.exner, d.cmeiout, d.prain,
       d.nevapr, d.prer_evap, d.rflx, d.sflx, d.rcldm, d.lcldm, d.icldm, d.mu_c,
-      d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange);
+      d.mu_r, d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange);
     d.transpose<util::TransposeDirection::f2c>();
   }
 

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 35);
+  REQUIRE(fdi.nfield() == 36);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 41);
+  REQUIRE(fdi.nfield() == 35);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);


### PR DESCRIPTION
Here's the refactor that changes P3 to use structs. I have to say: it takes a lot of concentration to work in this environment. Maybe we could make it easier with more comments or some more tooling to help us perform memory-related operations. As it is, it can be fairly challenging to alter an interface once we've ported it.

+ P3 structs have been introduced in p3_functions.hpp as defined in #465 .
+ `p3_main` now accepts these structs as arguments. We still have `ni` and `nk` as separate integer parameters.
+ The Fortran bridge functions still all use separate variables, including `p3_main_f`, which Fortran calls to access our C++ implementation.
+ I've removed the `diag_ze`,  `diag_vmi`, `diag_di`, `pratot`, and `prctot` parameters from `p3_main`, both on the C++ and Fortran side. However, the lower-level functions still use these.
+ I've removed the `log_` prefix from boolean variables, since (a) it's no longer 1977 and variable names don't need to indicate types, and (b) these variables are related neither to logarithms nor logging. 

The `atmosphere_microphysics.*` code uses the F90 interface, so I haven't made any changes to it.

Closes #465 
