### PR TITLE
bugfix^2: update nc and nr after get_dsd2

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3450,7 +3450,11 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
                   call get_cloud_dsd2(qc_incld(k),nc_incld(k),mu_c(k),rho(k),nu,dnu,   &
                        lamc(k),tmp1,tmp2,lcldm(k))
 
-                  !nc(k) = nc_incld(k)*lcldm(k) !Again, nc is already updated by gen_sed and isn't used below, so why do this? and if so why not also qc?
+                  !get_cloud_dsd2 keeps the drop-size distribution within reasonable
+                  !bounds by modifying nc_incld. The next line maintains consistency
+                  !between nc_incld and nc
+                  nc(k) = nc_incld(k)*lcldm(k)
+                  
                   dum = 1._rtype / bfb_pow(lamc(k), bcn)
                   V_qc(k) = acn(k)*bfb_gamma(4._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+4._rtype))
                   V_nc(k) = acn(k)*bfb_gamma(1._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+1._rtype))
@@ -3479,7 +3483,12 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
                qc_notsmall_c1: if (qc_incld(k)>qsmall) then
                   call get_cloud_dsd2(qc_incld(k),nc_incld(k),mu_c(k),rho(k),nu,dnu,   &
                        lamc(k),tmp1,tmp2,lcldm(k))
-                  !nc(k) = nc_incld(k)*lcldm(k) !Again, nc is already getting updated by gen_sed, so why do here? and if so why not also qc?
+                  
+                  !get_cloud_dsd2 keeps the drop-size distribution within reasonable
+                  !bounds by modifying nc_incld. The next line maintains consistency
+                  !between nc_incld and nc
+                  nc(k) = nc_incld(k)*lcldm(k)
+                  
                   dum = 1._rtype / bfb_pow(lamc(k), bcn)
                   V_qc(k) = acn(k)*bfb_gamma(4._rtype+bcn+mu_c(k))*dum/(bfb_gamma(mu_c(k)+4._rtype))
                endif qc_notsmall_c1
@@ -3648,10 +3657,10 @@ subroutine compute_rain_fall_velocity(qr_incld, rcldm, rhofacr, nr, nr_incld, mu
 
    call find_lookupTable_indices_3(dumii,dumjj,dum1,rdumii,rdumjj,inv_dum3,mu_r,lamr)
 
-   !nr is not used elsewhere in this function. Here, the updated value from generalized_sed
-   !is getting overwritten with the incld value which wasn't getting updated until this PR.
-   !And why is nr getting updated but not qr? Should delete nr from this function entirely.
-   !nr = nr_incld*rcldm 
+   !get_rain_dsd2 keeps the drop-size distribution within reasonable
+   !bounds by modifying nr_incld. The next line maintains consistency
+   !between nr_incld and nr
+   nr = nr_incld*rcldm 
 
    !mass-weighted fall speed:
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3602,8 +3602,13 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,   &
 
             qr_notsmall_r1: if (qr_incld(k)>qsmall) then
 
-               call compute_rain_fall_velocity(qr_incld(k), rcldm(k), rhofacr(k), nr(k), nr_incld(k), &
+               call compute_rain_fall_velocity(qr_incld(k), rcldm(k), rhofacr(k), nr_incld(k), &
                     mu_r(k), lamr(k), V_qr(k), V_nr(k))
+
+               !in compute_rain_fall_velocity, get_rain_dsd2 keeps the drop-size
+               !distribution within reasonable bounds by modifying nr_incld. 
+               !The next line maintains consistency between nr_incld and nr.
+               nr = nr_incld*rcldm 
 
             endif qr_notsmall_r1
 
@@ -3636,12 +3641,11 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,   &
 
 end subroutine rain_sedimentation
 
-subroutine compute_rain_fall_velocity(qr_incld, rcldm, rhofacr, nr, nr_incld, mu_r, lamr, V_qr, V_nr)
+subroutine compute_rain_fall_velocity(qr_incld, rcldm, rhofacr, nr_incld, mu_r, lamr, V_qr, V_nr)
 
    real(rtype), intent(in) :: qr_incld
    real(rtype), intent(in) :: rcldm
    real(rtype), intent(in) :: rhofacr
-   real(rtype), intent(inout) :: nr
    real(rtype), intent(inout) :: nr_incld
    real(rtype), intent(out) :: mu_r
    real(rtype), intent(out) :: lamr
@@ -3656,11 +3660,6 @@ subroutine compute_rain_fall_velocity(qr_incld, rcldm, rhofacr, nr, nr_incld, mu
    call get_rain_dsd2(qr_incld,nr_incld,mu_r,lamr,tmp1,tmp2,rcldm)
 
    call find_lookupTable_indices_3(dumii,dumjj,dum1,rdumii,rdumjj,inv_dum3,mu_r,lamr)
-
-   !get_rain_dsd2 keeps the drop-size distribution within reasonable
-   !bounds by modifying nr_incld. The next line maintains consistency
-   !between nr_incld and nr
-   nr = nr_incld*rcldm 
 
    !mass-weighted fall speed:
 

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -573,15 +573,15 @@ end subroutine prevent_ice_overdepletion_c
          qc,nc,qr,nr,qitot,nitot,qirim,birim,th)
   end subroutine homogeneous_freezing_c
 
-  subroutine compute_rain_fall_velocity_c(qr_incld, rcldm, rhofacr, nr, nr_incld, mu_r, lamr, V_qr, V_nr) bind(C)
+  subroutine compute_rain_fall_velocity_c(qr_incld, rcldm, rhofacr, nr_incld, mu_r, lamr, V_qr, V_nr) bind(C)
     use micro_p3, only: compute_rain_fall_velocity
 
     ! arguments:
     real(kind=c_real), value, intent(in) :: qr_incld, rcldm, rhofacr
-    real(kind=c_real), intent(inout) :: nr, nr_incld
+    real(kind=c_real), intent(inout) :: nr_incld
     real(kind=c_real), intent(out) :: mu_r, lamr, V_qr, V_nr
 
-    call compute_rain_fall_velocity(qr_incld, rcldm, rhofacr, nr, nr_incld, mu_r, lamr, V_qr, V_nr)
+    call compute_rain_fall_velocity(qr_incld, rcldm, rhofacr, nr_incld, mu_r, lamr, V_qr, V_nr)
   end subroutine compute_rain_fall_velocity_c
 
 subroutine  update_prognostic_ice_c(qcheti,qccol,qcshd,nccol,ncheti,ncshdc,qrcol,nrcol,qrheti,nrheti,nrshdr, &

--- a/components/scream/src/physics/p3/p3_cloud_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_cloud_sed_impl.hpp
@@ -93,8 +93,10 @@ void Functions<S,D>
             Spack nu, cdist, cdist1, dum;
             get_cloud_dsd2(qc_incld(pk), nc_incld(pk), mu_c(pk), rho(pk), nu, dnu, lamc(pk), cdist, cdist1, lcldm(pk), qc_gt_small);
 
-	    //Doesn't make sense to do this here
-            //nc(pk).set(qc_gt_small, nc_incld(pk)*lcldm(pk));
+	    //get_cloud_dsd2 keeps the drop-size distribution within reasonable
+	    //bounds by modifying nc_incld. The next line maintains consistency
+	    //between nc_incld and nc
+            nc(pk).set(qc_gt_small, nc_incld(pk)*lcldm(pk));
 
 	    dum = 1 / (pack::pow(lamc(pk), bcn));
             V_qc(pk).set(qc_gt_small, acn(pk)*pack::tgamma(4 + bcn + mu_c(pk)) * dum / (pack::tgamma(mu_c(pk)+4)));

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -471,7 +471,7 @@ struct Functions
   KOKKOS_FUNCTION
   static void compute_rain_fall_velocity(
     const view_2d_table& vn_table, const view_2d_table& vm_table,
-    const Spack& qr_incld, const Spack& rcldm, const Spack& rhofacr, Spack& nr,
+    const Spack& qr_incld, const Spack& rcldm, const Spack& rhofacr, 
     Spack& nr_incld, Spack& mu_r, Spack& lamr, Spack& V_qr, Spack& V_nr,
     const Smask& context = Smask(true));
 

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -142,7 +142,7 @@ void ice_deposition_sublimation_c(
   Real abi, Real qv, Real* qidep, Real* qisub, Real* nisub, Real* qiberg);
 
 void compute_rain_fall_velocity_c(Real qr_incld, Real rcldm, Real rhofacr,
-                                  Real* nr, Real* nr_incld, Real* mu_r, Real* lamr, Real* V_qr, Real* V_nr);
+                                  Real* nr_incld, Real* mu_r, Real* lamr, Real* V_qr, Real* V_nr);
 
 void ice_cldliq_collection_c(Real rho, Real temp, Real rhofaci, Real f1pr04,
                              Real qitot_incld,Real qc_incld, Real nitot_incld, Real nc_incld,
@@ -963,7 +963,7 @@ void compute_rain_fall_velocity(ComputeRainFallVelocityData& d)
 {
   p3_init();
   compute_rain_fall_velocity_c(d.qr_incld, d.rcldm, d.rhofacr,
-                               &d.nr, &d.nr_incld, &d.mu_r, &d.lamr, &d.V_qr, &d.V_nr);
+                               &d.nr_incld, &d.mu_r, &d.lamr, &d.V_qr, &d.V_nr);
 }
 
 P3MainPart1Data::P3MainPart1Data(
@@ -2502,40 +2502,38 @@ void homogeneous_freezing_f(
 }
 
 void compute_rain_fall_velocity_f(Real qr_incld_, Real rcldm_, Real rhofacr_,
-                                  Real* nr_, Real* nr_incld_, Real* mu_r_, Real* lamr_, Real* V_qr_, Real* V_nr_)
+                                  Real* nr_incld_, Real* mu_r_, Real* lamr_, Real* V_qr_, Real* V_nr_)
 {
   using P3F  = Functions<Real, DefaultDevice>;
 
   using Spack   = typename P3F::Spack;
   using view_1d = typename P3F::view_1d<Real>;
 
-  Real local_nr = *nr_, local_nr_incld = *nr_incld_;
-  view_1d t_d("t_d", 6);
+  Real local_nr_incld = *nr_incld_;
+  view_1d t_d("t_d", 5);
   const auto t_h = Kokkos::create_mirror_view(t_d);
 
   const auto vn_table = P3GlobalForFortran::vn_table();
   const auto vm_table = P3GlobalForFortran::vm_table();
   Kokkos::parallel_for(1, KOKKOS_LAMBDA(const Int&) {
-    Spack qr_incld(qr_incld_), rcldm(rcldm_), rhofacr(rhofacr_), nr(local_nr), nr_incld(local_nr_incld),
+    Spack qr_incld(qr_incld_), rcldm(rcldm_), rhofacr(rhofacr_), nr_incld(local_nr_incld),
       mu_r, lamr, V_qr, V_nr;
 
     P3F::compute_rain_fall_velocity(vn_table, vm_table,
-                                    qr_incld, rcldm, rhofacr, nr, nr_incld, mu_r, lamr, V_qr, V_nr);
-    t_d(0) = nr[0];
-    t_d(1) = nr_incld[0];
-    t_d(2) = mu_r[0];
-    t_d(3) = lamr[0];
-    t_d(4) = V_qr[0];
-    t_d(5) = V_nr[0];
+                                    qr_incld, rcldm, rhofacr, nr_incld, mu_r, lamr, V_qr, V_nr);
+    t_d(0) = nr_incld[0];
+    t_d(1) = mu_r[0];
+    t_d(2) = lamr[0];
+    t_d(3) = V_qr[0];
+    t_d(4) = V_nr[0];
   });
   Kokkos::deep_copy(t_h, t_d);
 
-  *nr_       = t_h(0);
-  *nr_incld_ = t_h(1);
-  *mu_r_     = t_h(2);
-  *lamr_     = t_h(3);
-  *V_qr_     = t_h(4);
-  *V_nr_     = t_h(5);
+  *nr_incld_ = t_h(0);
+  *mu_r_     = t_h(1);
+  *lamr_     = t_h(2);
+  *V_qr_     = t_h(3);
+  *V_nr_     = t_h(4);
 }
 
 void ice_cldliq_collection_f(Real rho_, Real temp_, Real rhofaci_, Real f1pr04_,

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -740,7 +740,7 @@ struct ComputeRainFallVelocityData
   Real qr_incld, rcldm, rhofacr;
 
   // In/out
-  Real nr, nr_incld;
+  Real nr_incld;
 
   // Outputs
   Real mu_r, lamr, V_qr, V_nr;
@@ -750,7 +750,7 @@ void compute_rain_fall_velocity(ComputeRainFallVelocityData& d);
 extern "C" {
 
 void compute_rain_fall_velocity_f(Real qr_incld, Real rcldm, Real rhofacr,
-                                  Real* nr, Real* nr_incld, Real* mu_r, Real* lamr, Real* V_qr, Real* V_nr);
+                                  Real* nr_incld, Real* mu_r, Real* lamr, Real* V_qr, Real* V_nr);
 
 }
 ///////////////////////////////////////////////////////////////////////////////

--- a/components/scream/src/physics/p3/p3_rain_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_rain_sed_impl.hpp
@@ -24,8 +24,10 @@ void Functions<S,D>
   Spack tmp1, tmp2; //ignore
   get_rain_dsd2(qr_incld, nr_incld, mu_r, lamr, tmp1, tmp2, rcldm, context);
 
-  //PMC - nr isn't used in this fn and is already updated in generalized_sed.
-  //nr.set(context, nr_incld*rcldm);
+  //get_rain_dsd2 keeps the drop-size distribution within reasonable
+  //bounds by modifying nr_incld. The next line maintains consistency
+  //between nr_incld and nr
+  nr.set(context, nr_incld*rcldm);
 
   if (context.any()) {
     lookup(mu_r, lamr, table, context);

--- a/components/scream/src/physics/p3/p3_rain_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_rain_sed_impl.hpp
@@ -16,18 +16,13 @@ KOKKOS_FUNCTION
 void Functions<S,D>
 ::compute_rain_fall_velocity(
   const view_2d_table& vn_table, const view_2d_table& vm_table,
-  const Spack& qr_incld, const Spack& rcldm, const Spack& rhofacr, Spack& nr,
+  const Spack& qr_incld, const Spack& rcldm, const Spack& rhofacr,
   Spack& nr_incld, Spack& mu_r, Spack& lamr, Spack& V_qr, Spack& V_nr,
   const Smask& context)
 {
   Table3 table;
   Spack tmp1, tmp2; //ignore
   get_rain_dsd2(qr_incld, nr_incld, mu_r, lamr, tmp1, tmp2, rcldm, context);
-
-  //get_rain_dsd2 keeps the drop-size distribution within reasonable
-  //bounds by modifying nr_incld. The next line maintains consistency
-  //between nr_incld and nr
-  nr.set(context, nr_incld*rcldm);
 
   if (context.any()) {
     lookup(mu_r, lamr, table, context);
@@ -115,7 +110,14 @@ void Functions<S,D>
         if (qr_gt_small.any()) {
           compute_rain_fall_velocity(vn_table, vm_table,
                                      qr_incld(pk), rcldm(pk), rhofacr(pk),
-                                     nr(pk), nr_incld(pk), mu_r(pk), lamr(pk), V_qr(pk), V_nr(pk), qr_gt_small);
+                                     nr_incld(pk), mu_r(pk), lamr(pk),
+				     V_qr(pk), V_nr(pk), qr_gt_small);
+	  
+	  //in compute_rain_fall_velocity, get_rain_dsd2 keeps the drop-size
+	  //distribution within reasonable bounds by modifying nr_incld.
+	  //The next line maintains consistency between nr_incld and nr
+	  nr(pk).set(qr_gt_small, nr_incld(pk)*rcldm(pk));
+
         }
         const auto Co_max_local = max(qr_gt_small, -1,
                                       V_qr(pk) * dt_left * inv_dzq(pk));


### PR DESCRIPTION
In my previous bugfix, I commented out lines defining nc and nr from their incld values because I didn't realize that get_*_dsd2 was modifying them if the drop size distribution fell outside normal limits. This PR re-adds those lines. I don't expect this to have a big impact on model behavior.