### PR TITLE
Adds property test and boiler plate code for SHOC covariance/variance subroutine 

### DIFF
--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -124,6 +124,7 @@ void shoc_grid(Int nlev, SHOCGridData &d) {
   d.transpose<util::TransposeDirection::f2c>();
 }
 
+
 //Initialize data for calc_shoc_vertflux function
 SHOCVertfluxData::SHOCVertfluxData(Int shcol_, Int nlev_, Int nlevi_)
   : shcol(shcol_),
@@ -147,6 +148,7 @@ SHOCVertfluxData::SHOCVertfluxData(const SHOCVertfluxData &rhs)
   init_ptrs();
 }
 
+
 SHOCVertfluxData  &SHOCVertfluxData::operator=(const SHOCVertfluxData &rhs) {
   init_ptrs();
 
@@ -160,6 +162,7 @@ SHOCVertfluxData  &SHOCVertfluxData::operator=(const SHOCVertfluxData &rhs) {
 
   return *this;
 }
+
 
 void SHOCVertfluxData::init_ptrs() {
   Int offset         = 0;

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -23,6 +23,10 @@ void shoc_init_c(int nlev, Real gravit, Real rair, Real rh2o, Real cpair,
 
 void shoc_grid_c(int shcol, int nlev, int nlevi, Real *zt_grid, Real *zi_grid,
                  Real *pdel, Real *dz_zt, Real *dzi_zi, Real *rho_zt);
+		 
+void calc_shoc_varorcovar_c(Int shcol, Int nlev, Int nlevi,  Real tunefac,
+                            Real *isotropy_zi, Real *tkh_zi, Real *dz_zi,
+			    Real *invar1, Real *invar2, Real *varorcovar);		 
 }
 
 namespace scream {
@@ -114,6 +118,75 @@ void shoc_grid(Int nlev, SHOCGridData &d) {
   d.transpose<util::TransposeDirection::c2f>();
   shoc_grid_c(d.shcol, d.nlev, d.nlevi, d.zt_grid, d.zi_grid, d.pdel, d.dz_zt,
               d.dz_zi, d.rho_zt);
+  d.transpose<util::TransposeDirection::f2c>();
+}
+
+SHOCVarorcovarData::SHOCVarorcovarData(Int shcol_, Int nlev_, Int nlevi_, Real tunefac_)
+  : shcol(shcol_),
+    nlev(nlev_),
+    nlevi(nlevi_),
+    tunefac(tunefac_),
+    m_total(shcol_ * nlev_),
+    m_totali(shcol_ * nlevi_),
+    m_data(NUM_ARRAYS * m_total, 0),
+    m_datai(NUM_ARRAYS_i * m_totali, 0) {
+  init_ptrs();
+}
+
+SHOCVarorcovarData::SHOCVarorcovarData(const SHOCVarorcovarData &rhs)
+  : shcol(rhs.shcol),
+    nlev(rhs.nlev),
+    nlevi(rhs.nlevi),
+    tunefac(rhs.tunefac),
+    m_total(rhs.m_total),
+    m_totali(rhs.m_totali),
+    m_data(rhs.m_data),
+    m_datai(rhs.m_datai) {
+  init_ptrs();
+}
+
+
+SHOCVarorcovarData  &SHOCVarorcovarData::operator=(const SHOCVarorcovarData &rhs) {
+  init_ptrs();
+
+  shcol    = rhs.shcol;
+  nlev     = rhs.nlev;
+  nlevi    = rhs.nlevi;
+  tunefac  = rhs.tunefac;
+  m_total  = rhs.m_total;
+  m_totali = rhs.m_totali;
+  m_data   = rhs.m_data;
+  m_datai  = rhs.m_datai;  // Copy
+
+  return *this;
+}
+
+
+void SHOCVarorcovarData::init_ptrs() {
+  Int offset         = 0;
+  Real *data_begin   = m_data.data();
+  Real *data_begin_i = m_datai.data();
+
+  std::array<Real **, NUM_ARRAYS> ptrs     = {&invar1, &invar2};
+  std::array<Real **, NUM_ARRAYS_i> ptrs_i = {&tkh_zi, &dz_zi, &isotropy_zi, &varorcovar};
+
+  for(size_t i = 0; i < NUM_ARRAYS; ++i) {
+    *ptrs[i] = data_begin + offset;
+    offset += m_total;
+  }
+
+  offset = 0;
+  for(size_t i = 0; i < NUM_ARRAYS_i; ++i) {
+    *ptrs_i[i] = data_begin_i + offset;
+    offset += m_totali;
+  }
+}
+
+void calc_shoc_varorcovar(Int nlev, SHOCVarorcovarData &d) {
+  shoc_init(nlev, true);
+  d.transpose<util::TransposeDirection::c2f>();
+  calc_shoc_varorcovar_c(d.shcol, d.nlev, d.nlevi, d.tunefac, d.isotropy_zi, d.tkh_zi, 
+                         d.dz_zi, d.invar1, d.invar2, d.varorcovar);
   d.transpose<util::TransposeDirection::f2c>();
 }
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -65,6 +65,7 @@ struct SHOCGridData {
 // and density. 
 void shoc_grid(Int nlev, SHOCGridData &d);
 
+
 //Create data structure to hold data for calc_shoc_vertflux
 struct SHOCVertfluxData {
   static constexpr size_t NUM_ARRAYS   = 1; //# of arrays with values at cell centers (zt grid)

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -65,6 +65,49 @@ struct SHOCGridData {
 // and density. 
 void shoc_grid(Int nlev, SHOCGridData &d);
 
+struct SHOCVarorcovarData {
+  static constexpr size_t NUM_ARRAYS   = 2;
+  static constexpr size_t NUM_ARRAYS_i = 4;
+
+  // Inputs
+  Int   shcol, nlev, nlevi;
+  Real tunefac;
+  Real *tkh_zi, *dz_zi, *isotropy_zi, *invar1, *invar2;
+
+  // In/out
+  Real *varorcovar;
+
+  SHOCVarorcovarData(Int shcol_, Int nlev_, Int nlevi_, Real tunefac_);
+  SHOCVarorcovarData(const SHOCVarorcovarData &rhs);
+  SHOCVarorcovarData &operator=(const SHOCVarorcovarData &rhs);
+
+  void init_ptrs();
+
+  // Internals
+  Int m_shcol, m_nlev, m_nlevi, m_total, m_totali;
+  std::vector<Real> m_data;
+  std::vector<Real> m_datai;
+
+  template <util::TransposeDirection::Enum D>
+  void transpose() {
+    SHOCVarorcovarData d_trans(*this);
+
+    // Transpose on the zt grid
+    util::transpose<D>(invar1, d_trans.invar1, shcol, nlev);
+    util::transpose<D>(invar2, d_trans.invar2, shcol, nlev);
+
+    // Transpose on the zi grid
+    util::transpose<D>(tkh_zi, d_trans.tkh_zi, shcol, nlevi);
+    util::transpose<D>(dz_zi, d_trans.dz_zi, shcol, nlevi);
+    util::transpose<D>(isotropy_zi, d_trans.isotropy_zi, shcol, nlevi);
+    util::transpose<D>(varorcovar, d_trans.varorcovar, shcol, nlevi);
+
+    *this = std::move(d_trans);
+  }
+};//SHOCVarorcovarData
+
+void calc_shoc_varorcovar(Int nlev, SHOCVarorcovarData &d);
+
 }  // namespace shoc
 }  // namespace scream
 

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -114,5 +114,31 @@ contains
     call shoc_grid(shcol,nlev,nlevi,zt_grid,zi_grid,pdel,dz_zt,dz_zi,rho_zt)
 
   end subroutine shoc_grid_c
+  
+  subroutine calc_shoc_varorcovar_c(&
+       shcol,nlev,nlevi,tunefac,&                ! Input
+       isotropy_zi,tkh_zi,dz_zi,invar1,invar2,&  ! Input
+       varorcovar)bind (C)                       ! Input/Output 
+       
+      use shoc, only: calc_shoc_varorcovar
+
+      integer(kind=c_int), intent(in), value :: shcol
+      integer(kind=c_int), intent(in), value :: nlev
+      integer(kind=c_int), intent(in), value :: nlevi 
+      real(kind=c_real), intent(in), value :: tunefac
+      real(kind=c_real), intent(in) :: isotropy_zi(shcol,nlevi)
+      real(kind=c_real), intent(in) :: tkh_zi(shcol,nlevi)
+      real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
+      real(kind=c_real), intent(in) :: invar1(shcol,nlev)
+      real(kind=c_real), intent(in) :: invar2(shcol,nlev)
+	 
+      real(kind=c_real), intent(inout) :: varorcovar(shcol,nlevi)
+      
+      call calc_shoc_varorcovar(&
+           shcol,nlev,nlevi,tunefac,&               ! Input
+           isotropy_zi,tkh_zi,dz_zi,invar1,invar2,& ! Input
+           varorcovar)  
+	   
+  end subroutine calc_shoc_varorcovar_c      
 
 end module shoc_iso_c

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ SET (NEED_LIBS shoc physics_share scream_control scream_share)
 set(SHOC_TESTS_SRCS
     shoc_tests.cpp
     shoc_grid_tests.cpp
+    shoc_varorcovar_tests.cpp
     shoc_unit_tests.cpp)
 
 # NOTE: tests inside this if statement won't be built in a baselines-only build

--- a/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
@@ -1,0 +1,270 @@
+#include "catch2/catch.hpp"
+
+//#include "share/scream_types.hpp"
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+#include "ekat/scream_kokkos.hpp"
+#include "ekat/scream_pack.hpp"
+#include "ekat/scream_types.hpp"
+#include "ekat/util/scream_arch.hpp"
+#include "ekat/util/scream_kokkos_utils.hpp"
+#include "ekat/util/scream_utils.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "shoc_unit_tests_common.hpp"
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+TEST_CASE("shoc_varorcovar", "shoc") {
+  constexpr Int shcol    = 2;
+  constexpr Int nlev     = 4;
+  constexpr auto nlevi   = nlev + 1;
+   
+  //NOTE: This routine does not compute the (co)variance
+  // for boundary points.  Input Grid values that are never used
+  // are set to ZERO so as not to confuse the test data
+  // that is actually used (and is also an implicit test to be
+  // sure that operations are not done at the boundary).
+  // Output values at boundary set to something other than 
+  // zero to check that they are not modified.
+  
+  //IN: tunefac, isotropy_zi, tkh_zi, dz_zi, 
+  //IN: invar1, invar2
+  //OUT: varorcovar
+  
+  //********************************************
+  // TEST ONE
+  // Verify the variance calculation is valid  
+  
+  // Define data.  Some of this is recycled for tests two and three.
+    
+  // Define delta z on the nlevi grid [m]
+  Real dz_zi[nlevi] = {0.0, 100.0, 50.0, 20.0, 0.0};
+  // Eddy coefficients on the nlevi grid [m2s-1]
+  Real tkh_zi[nlevi] = {0.0, 10.0, 10.0, 10.0, 0.0};
+  // Return to isotropy timescale [s]
+  Real isotropy_zi[nlevi] = {0.0, 100.0, 100.0, 100.0, 0.0};
+  // Invar (in this example we use potential temperature) [K]
+  //   this variable should be on the nlev grid
+  Real invar_theta[nlev] = {320.0, 315.0, 315.0, 316.0};
+  // Initialize (co)variance on the nlevi grid, set boundaries
+  //   to large values to make sure they are not modified
+  Real varorcovar[nlevi] = {100., 0., 0., 0., 100.};
+  // Tuning factor
+  Real tunefac=1.0;  
+
+  // Initialzie data structure for bridgeing to F90
+  SHOCVarorcovarData SDS(shcol, nlev, nlevi, tunefac);
+
+  // Test that the inputs are reasonable.
+  REQUIRE(SDS.nlevi - SDS.nlev == 1);
+  REQUIRE(SDS.shcol > 0);
+  
+  // Fill in test data 
+  for(Int s = 0; s < SDS.shcol; ++s) {
+    // First on the nlev grid
+    for(Int n = 0; n < SDS.nlev; ++n) {
+      const auto offset = n + s * SDS.nlev;
+      
+      // Fill invar1 and invar2 with the SAME 
+      //  variable for this case to test the 
+      //  variance calculation of this function
+      SDS.invar1[offset] = invar_theta[n]; 
+      SDS.invar2[offset] = invar_theta[n];
+    }
+    
+    // Now for data on the nlevi grid
+    for(Int n = 0; n < SDS.nlevi; ++n) {
+      const auto offset = n + s * SDS.nlevi;
+      
+      SDS.tkh_zi[offset] = tkh_zi[n];
+      SDS.isotropy_zi[offset] = isotropy_zi[n];
+      SDS.dz_zi[offset] = dz_zi[n];
+      SDS.varorcovar[offset] = varorcovar[n];
+    }
+  }
+
+  // Check that the inputs make sense
+  
+  REQUIRE(SDS.tunefac > 0.0);
+  // Check to make sure that dz_zi, tkh_zi, and isotropy_zi
+  //  (outside of the boundaries) are greater than zero 
+  for(Int s = 0; s < SDS.shcol; ++s) {
+    // do NOT check boundaries!
+    for(Int n = 1; n < SDS.nlevi-1; ++n) {
+      const auto offset = n + s * SDS.nlevi;
+      REQUIRE(SDS.dz_zi[offset] > 0.0);
+      REQUIRE(SDS.tkh_zi[offset] > 0.0);
+      REQUIRE(SDS.isotropy_zi[offset] > 0.0);
+    }
+    // For this test make sure that invar1 = invar2
+    for(Int n = 0; n < SDS.nlev; ++n){
+      const auto offset = n + s * SDS.nlev;
+      REQUIRE(SDS.invar1[offset] == SDS.invar2[offset]);
+    }
+  }
+  
+  // Call the fortran implementation for variance
+  calc_shoc_varorcovar(nlev, SDS);
+  
+  // Check the results
+  for(Int s = 0; s < SDS.shcol; ++s) {   
+    for(Int n = 0; n < SDS.nlevi; ++n) {
+      const auto offset = n + s * SDS.nlevi;
+
+      // validate that the boundary points have NOT been modified      
+      if (n == 0 || n == nlevi){
+        REQUIRE(SDS.varorcovar[offset] == 100.0);
+      }
+      else{
+      
+      // Validate that all values are greater to 
+      //   or equal to zero 
+      
+        REQUIRE(SDS.varorcovar[offset] >= 0.0);
+      
+        // well mixed layer test
+        if ((invar_theta[n-1] - invar_theta[n]) == 0.0){
+          REQUIRE(SDS.varorcovar[offset] == 0.0);
+        }
+      }
+    } 
+  }
+
+  //********************************************
+  // TEST TWO
+  // Verify the Covariance calculation is valid
+  
+  // Now we check the covariance calculation
+  // Define an array to be total water [g/kg]
+  Real invar_qw[nlev] = {5.0, 10.0, 15.0, 20.0};
+  
+  // NOTE: all other inputs are reused from test one
+  
+  // convert to [kg/kg]
+  invar_qw[:] = invar_qw[:]/1000.0;
+
+  // Update invar2 to be total water
+  for(Int s = 0; s < SDS.shcol; ++s) {
+    // First on the nlev grid
+    for(Int n = 0; n < SDS.nlev; ++n) {
+      const auto offset = n + s * SDS.nlev;
+       
+      SDS.invar2[offset] = invar_qw[n];
+    }   
+  }
+  
+  // Check inputs
+  for(Int s = 0; s < SDS.shcol; ++s) {
+    // For this test make sure that invar1 is NOT
+    //  equal to invar2
+    for(Int n = 0; n < SDS.nlev; ++n){
+      const auto offset = n + s * SDS.nlev;
+      REQUIRE(SDS.invar1[offset] != SDS.invar2[offset]);
+    }
+  }   
+  
+  // Call the fortran implementation for covariance
+  calc_shoc_varorcovar(nlev, SDS);
+  
+  // Check the results
+  for(Int s = 0; s < SDS.shcol; ++s) {   
+    for(Int n = 0; n < SDS.nlevi; ++n) {
+      const auto offset = n + s * SDS.nlevi;
+
+      // validate that the boundary points 
+      //   have NOT been modified      
+      if (n == 0 || n == nlevi){
+        REQUIRE(SDS.varorcovar[offset] == 100.);
+      }
+      else{  
+      
+        // well mixed layer test
+        if ((invar_theta[n-1] - invar_theta[n]) == 0.0 ||
+	    (invar_qw[n-1] - invar_qw[n]) == 0.0){
+          REQUIRE(SDS.varorcovar[offset] == 0.0);
+        }
+	
+	// validate values are NEGATIVE if potential
+	//  temperature INCREASES with height and total water
+	//  DECREASES with height
+        if ((invar_theta[n-1] - invar_theta[n]) > 0.0 && 
+	    (invar_qw[n-1] - invar_qw[n]) < 0.0){
+          REQUIRE(SDS.varorcovar[offset] < 0.0);
+        }
+	
+	// validate values are POSITIVE if both 
+	//   potential temperature and total water 
+	//   DECREASE with height
+        if ((invar_theta[n-1] - invar_theta[n]) < 0.0 && 
+	    (invar_qw[n-1] - invar_qw[n]) < 0.0){
+          REQUIRE(SDS.varorcovar[offset] > 0.0);
+        }		
+	
+      }
+    } 
+  }
+  
+  //********************************************
+  // TEST THREE
+  // Verify that vertical differencing is done correctly  
+  
+  //  Assume that isotropy and tkh are constant with height
+  //  Assign values of potential temperature that are increasing
+  //  at a constant rate per GRID box.  Assign dz that INCREASES
+  //  with height and check that varorcovar DECREASES with height
+  
+  Real invar_th2[nlev] = {320.0, 315.0, 310.0, 305.0};
+  
+  // Update invar1 and invar2 to be identical
+  for(Int s = 0; s < SDS.shcol; ++s) {
+    // First on the nlev grid
+    for(Int n = 0; n < SDS.nlev; ++n) {
+      const auto offset = n + s * SDS.nlev;
+       
+      // Set both inputs to the same value 
+      SDS.invar1[offset] = invar_th2[n];
+      SDS.invar2[offset] = invar_th2[n];
+    }   
+  }  
+  
+  // Check the inputs
+  for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int n = 1; n < SDS.nlevi-1; ++n) {
+      const auto offset = n + s * SDS.nlevi;
+      // Validate that values of dz_zi are INCREASING with height
+      REQUIRE(SDS.dz_zi[offset]-SDS.dz_zi[offset+1] > 0.0); 
+    }
+    // For this test make sure that invar1 = invar2
+    for(Int n = 0; n < SDS.nlev; ++n){
+      const auto offset = n + s * SDS.nlev;
+      REQUIRE(SDS.invar1[offset] == SDS.invar2[offset]);
+    }
+  }  
+
+  // Call the fortran implementation for variance
+  calc_shoc_varorcovar(nlev, SDS);
+  
+  // Check the results
+  for(Int s = 0; s < SDS.shcol; ++s) {   
+    for(Int n = 1; n < SDS.nlev-1; ++n) {
+      const auto offset = n + s * SDS.nlevi;  
+
+      // Validate that values of varorcovar
+      //  are decreasing with height
+      REQUIRE(SDS.varorcovar[offset]-SDS.varorcovar[offset+1] < 0.0);        
+    
+    }
+  }
+
+}
+
+}  // namespace unit_test
+}  // namespace shoc
+}  // namespace scream

--- a/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
@@ -147,8 +147,10 @@ TEST_CASE("shoc_varorcovar", "shoc") {
   
   // NOTE: all other inputs are reused from test one
   
-  // convert to [kg/kg]
-  invar_qw[:] = invar_qw[:]/1000.0;
+  // convert total water to [kg/kg]
+  for (Int n = 0; n < SDS.nlev; ++n){
+    invar_qw[n] = invar_qw[n]/1000.;
+  }
 
   // Update invar2 to be total water
   for(Int s = 0; s < SDS.shcol; ++s) {


### PR DESCRIPTION
Adds property test and boilerplate code to call the function calc_shoc_varorcovar.  This is my first go around with this from top to bottom, though I heavily followed the implementation/precedent set by @pressel and @singhbalwinder. 

The property test tests calc_shoc_varcovar for the following properties:
1) Reasonable inputs
2) Computation of variance is valid and physical for a variety of conditions if input variables are the same
3) Computation of the covariance is valid and physics if the input variables are different
4) Vertical differencing