### PR TITLE
[WIP] Fix fsurdat defaults for SCREAM compsets

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -171,6 +171,7 @@
 <ncdata hgrid="ne1024np4" nlev="72"  ic_ymd="20160801">atm/cam/inic/homme/ifs_oper_T1279_2016080100_mod_subset_to_e3sm_ne1024np4_topoadj_L72.nc           </ncdata>
 <ncdata hgrid="ne512np4"  nlev="128" ic_ymd="20160801">atm/cam/inic/homme/ifs_oper_T1279_2016080100_mod_subset_to_e3sm_ne512np4_topoadj_L128_c20200115.nc </ncdata>
 <ncdata hgrid="ne512np4"  nlev="72"  ic_ymd="20160801">atm/cam/inic/homme/ifs_oper_T1279_2016080100_mod_subset_to_e3sm_ne512np4_topoadj_L72.nc            </ncdata>
+<ncdata hgrid="ne256np4"  nlev="128" ic_ymd="20160801">atm/cam/inic/homme/ifs_oper_T1279_2016080100_mod_subset_to_e3sm_ne256np4_topoadj_L128_c20200401.nc </ncdata>
 <ncdata hgrid="ne30np4"   nlev="128" ic_ymd="20160801">atm/cam/inic/homme/ifs_oper_T1279_2016080100_mod_subset_to_e3sm_ne30np4_topoadj_L128_c20200313.nc  </ncdata>
 <ncdata hgrid="ne30np4"   nlev="72"  ic_ymd="20160801">atm/cam/inic/homme/ifs_oper_T1279_2016080100_mod_subset_to_e3sm_ne30np4_topoadj_L72_c20200313.nc   </ncdata>
 <ncdata hgrid="ne4np4"    nlev="128" ic_ymd="20160801">atm/cam/inic/homme/ifs_oper_T1279_2016080100_mod_subset_to_e3sm_ne4np4_topoadj_L128_c20200313.nc   </ncdata>

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -269,6 +269,8 @@ lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr2000_c190620.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne240np4_simyr2000_c170821.nc</fsurdat>
 <fsurdat hgrid="r05"         sim_year="2000" >
 lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr2000_c190418.nc</fsurdat>
+<fsurdat hgrid="r0125"       sim_year="2000" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr2000_c190730.nc</fsurdat>
 
 <!-- Crop surface datasets -->
 <fsurdat hgrid="1.9x2.5"   sim_year="2000" use_crop=".true." >

--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -87,6 +87,8 @@
       <value compset="SSP585_CAM5%CMIP6_CLM45.*_BGC%B">2015-2100_SSP585_CMIP6bgc_transient</value> 
       <value compset="2010_CAM5%CMIP6-LR_CLM">2010_CMIP6LR_control</value>
       <value compset="2010_CAM5%CMIP6-HR_CLM">2010_CMIP6HR_control</value>
+      <value compset="2010_CAM5.*SCREAM-LR" >2010_CMIP6_control</value>
+      <value compset="2010_CAM5.*SCREAM-HR" >2010_CMIP6_control</value>
       <!-- superfast chemistry compsets (use CMIP6 land configuration)-->
       <value compset="1850_CAM5%AR5sf_CLM">1850_CMIP6_control</value>
       <value compset="20TR_CAM5%AR5sf_CLM">20thC_CMIP6_transient</value>


### PR DESCRIPTION
Make sure the fsurdat namelist variable for the land model (which specifies the land surface input data file) is set properly for SCREAM compsets using the r0125 land model. This was neglected for different reasons in the F2000 and F2010 SCREAM compsets. For F2000, it appears that somewhere along the way a default fsurdat stopped being specified for `sim_year=2000` and `hgrid=r0125`. For F2010, our compset definition failed to pick up the correct `2010_CMIP6_control` use case file for CLM. Fixes #489.