### PR TITLE
SCREAM: fixes in qv_sat function

### DIFF
--- a/components/scream/src/physics/p3/p3_ice_cldliq_wet_growth_impl.hpp
+++ b/components/scream/src/physics/p3/p3_ice_cldliq_wet_growth_impl.hpp
@@ -43,7 +43,7 @@ void Functions<S,D>
   Spack dum1{0.};
 
   if (any_if.any()) {
-    qsat0 = physics::qv_sat( zerodeg,pres,0 );
+    qsat0 = physics::qv_sat( zerodeg,pres, false );
 
     qwgrth.set(any_if,
                ((f1pr05+f1pr14*pack::cbrt(sc)*sqrt(rhofaci*rho/mu))*

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -152,8 +152,8 @@ void Functions<S,D>
 
     rho(k)     = pdel(k)/dzq(k) / g;
     inv_rho(k) = 1 / rho(k);
-    qvs(k)     = physics::qv_sat(t(k), pres(k), 0);
-    qvi(k)     = physics::qv_sat(t(k), pres(k), 1);
+    qvs(k)     = physics::qv_sat(t(k), pres(k), false);
+    qvi(k)     = physics::qv_sat(t(k), pres(k), true);
 
     supi(k) = qv(k) / qvi(k) - 1;
 

--- a/components/scream/src/physics/share/CMakeLists.txt
+++ b/components/scream/src/physics/share/CMakeLists.txt
@@ -16,7 +16,7 @@ set(PHYSICS_SHARE_SRCS
 
 # Add ETI source files if not on CUDA
 if (NOT CUDA_BUILD)
-  list(APPEND P3_SRCS
+  list(APPEND PHYSICS_SHARE_SRCS
   physics_saturation.cpp)
 endif()
 

--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -22,6 +22,8 @@ template <typename ScalarT, typename DeviceT>
 struct Functions
 {
 
+  enum SaturationFcn { Polysvp1 = 0, MurphyKoop = 1};
+
   //
   // ------- Types --------
   //
@@ -89,7 +91,7 @@ struct Functions
   // and returns the saturation mixing ratio, with respect to either liquid or ice,
   // depending on value of 'ice'
   KOKKOS_FUNCTION
-  static Spack qv_sat(const Spack& t_atm, const Spack& p_atm, const bool ice, const int& func_idx = 1);
+  static Spack qv_sat(const Spack& t_atm, const Spack& p_atm, const bool ice, const SaturationFcn func_idx = MurphyKoop);
 };
 
 } // namespace physics

--- a/components/scream/src/physics/share/physics_saturation.cpp
+++ b/components/scream/src/physics/share/physics_saturation.cpp
@@ -1,4 +1,4 @@
-#include "p3_functions_math_impl.hpp"
+#include "physics_saturation_impl.hpp"
 #include "ekat/scream_types.hpp"
 
 namespace scream {

--- a/components/scream/src/physics/share/physics_saturation_impl.hpp
+++ b/components/scream/src/physics/share/physics_saturation_impl.hpp
@@ -96,24 +96,24 @@ Functions<S,D>::polysvp1(const Spack& t, const bool ice)
 template <typename S, typename D>
 KOKKOS_FUNCTION
 typename Functions<S,D>::Spack
-Functions<S,D>::qv_sat(const Spack& t_atm, const Spack& p_atm, const bool ice, const int& func_idx)
+Functions<S,D>::qv_sat(const Spack& t_atm, const Spack& p_atm, const bool ice, const SaturationFcn func_idx)
 {
-  //func_idx is an optional argument to decide which scheme is to be called for saturation vapor pressure
-  //Currently default is set to "MurphyKoop_svp"
-  //func_idx = 0 --> polysvp1 (Flatau et al. 1992)
-  //func_idx = 1 --> MurphyKoop_svp (Murphy, D. M., and T. Koop 2005)
+  // func_idx is an optional argument to decide which scheme is to be called for saturation vapor pressure
+  // Currently default is set to "MurphyKoop_svp"
+  // func_idx = Polysvp1 (=0) --> polysvp1 (Flatau et al. 1992)
+  // func_idx = MurphyKoop (=1) --> MurphyKoop_svp (Murphy, D. M., and T. Koop 2005)
 
   Spack e_pres; // saturation vapor pressure [Pa]
 
   switch (func_idx){
-    case 0:
+    case Polysvp1:
       e_pres = polysvp1(t_atm, ice);
       break;
-    case 1:
+    case MurphyKoop:
       e_pres = MurphyKoop_svp(t_atm, ice);
       break;
     default:
-      scream::error::runtime_abort("Error: Invalid func_idx supplied to qv_sat:"+ func_idx );
+      scream_kerror_msg("Error! Invalid func_idx supplied to qv_sat.");
     }
 
   const auto ep_2 = C::ep_2;

--- a/components/scream/src/physics/share/tests/physics_saturation_unit_tests.cpp
+++ b/components/scream/src/physics/share/tests/physics_saturation_unit_tests.cpp
@@ -93,15 +93,15 @@ struct UnitWrap::UnitTest<D>::TestSaturation
     Spack sat_ice_fp  = physics::polysvp1(temps, true);
     Spack sat_liq_fp  = physics::polysvp1(temps, false);
     //last argument "0" of qv_sat function below forces qv_sat to call "polysvp1"
-    Spack mix_ice_fr = physics::qv_sat(temps, pres, true, 0);
-    Spack mix_liq_fr = physics::qv_sat(temps, pres, false,0);
+    Spack mix_ice_fr = physics::qv_sat(temps, pres, true, physics::Polysvp1);
+    Spack mix_liq_fr = physics::qv_sat(temps, pres, false,physics::Polysvp1);
 
     //Get values from MurphyKoop_svp and qv_sat (qv_sat calls MurphyKoop_svp here) to test against "expected" values
     Spack sat_ice_mkp   = physics::MurphyKoop_svp(temps, true);
     Spack sat_liq_mkp   = physics::MurphyKoop_svp(temps, false);
     //last argument "1" of qv_sat function below forces qv_sat to call "MurphyKoop_svp"
-    Spack mix_ice_mkr  = physics::qv_sat(temps, pres, true, 1);
-    Spack mix_liq_mkr  = physics::qv_sat(temps, pres, false,1);
+    Spack mix_ice_mkr  = physics::qv_sat(temps, pres, true, physics::MurphyKoop);
+    Spack mix_liq_mkr  = physics::qv_sat(temps, pres, false,physics::MurphyKoop);
 
     //Set error tolerances
     //--------------------------------------


### PR DESCRIPTION
- fixing ETI logic in cmake and in the cpp file
- fixing compilation error on GPU
- changed integer switch into an enum for verbosity (you can still use an int though).