### PR TITLE
Disable the build of the stand-alone scorpio test during CIME build.

### DIFF
--- a/components/scream/src/mct_coupling/CMakeLists.txt
+++ b/components/scream/src/mct_coupling/CMakeLists.txt
@@ -92,6 +92,6 @@ set_target_properties(atm PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR
 # Link libraries
 target_link_libraries(atm PRIVATE ${SCREAM_LIBS} ${SCREAM_CIME_LIBS})
 
-#if (NOT SCREAM_LIB_ONLY)
-add_subdirectory(tests)
-#endif()
+if (NOT SCREAM_LIB_ONLY)
+  add_subdirectory(tests)
+endif()


### PR DESCRIPTION
This commit disables the building of the scorpio stand-alone test
when scream is built using CIME, as is the case with the F2000-SCREAM-SA
test.

Solves an issue with the Cori-KNL nightly tests where the SCREAM-SA test
was failing during the build step due to an error linking libraries for
the scorpio stand-alone test.  Note that we don't use this test in the
nightly testing so it isn't necessary.

Addresses, but does not fully fix issue #432.  Further work on a stand-alone build of scorpio within scream will be needed.

[BFB]