### PR TITLE
Fix scream buildnml to allow keeping existing files

### DIFF
--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -32,7 +32,10 @@ def buildnml(case, caseroot, compname):
             os.mkdir(target)
 
         for item in os.listdir(src):
-            safe_copy(os.path.join(src, item), target)
+            # Do not overwrite existing files because that would remove any
+            # local mods made by the user.
+            if not os.path.exists(os.path.join(target, item)):
+                safe_copy(os.path.join(src, item), target)
 
 ###############################################################################
 def _main_func():


### PR DESCRIPTION
buildnml is called frequently during case control (setup, build, submit
all call it), so there was no way for the previous implementation to allow
for user case local changes to files setup by buildnml, like scream_input.yaml.

This PR changes scream's buildnml to not copy over existing files.

Fixes #506 