### PR TITLE
Update ftype and IMEX scheme for SCREAM compsets

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
@@ -95,8 +95,8 @@
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
 <tstep_type>10</tstep_type>
 
-<!-- Use se_ftype = 1 to improve dynamics/physics coupling -->
-<se_ftype>1</se_ftype>
+<!-- Dynamics/physics coupling; should be the default, but set to make sure -->
+<se_ftype>2</se_ftype>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
@@ -95,9 +95,6 @@
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
 <tstep_type>9</tstep_type>
 
-<!-- Dynamics/physics coupling; should be the default, but set to make sure -->
-<se_ftype>2</se_ftype>
-
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
 

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_hr.xml
@@ -93,7 +93,7 @@
 
 <!-- Settings related to the SCREAM NH dycore -->
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
-<tstep_type>10</tstep_type>
+<tstep_type>9</tstep_type>
 
 <!-- Dynamics/physics coupling; should be the default, but set to make sure -->
 <se_ftype>2</se_ftype>

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
@@ -96,6 +96,9 @@
 <iradsw hgrid="ne1024np4"> 4 </iradsw>
 <iradlw hgrid="ne1024np4"> 4 </iradlw>
 
+<!-- Settings related to the SCREAM NH dycore -->
+<theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
+
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
 

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
@@ -96,12 +96,6 @@
 <iradsw hgrid="ne1024np4"> 4 </iradsw>
 <iradlw hgrid="ne1024np4"> 4 </iradlw>
 
-<!-- Set IMEX scheme -->
-<tstep_type>5</tstep_type>
-
-<!-- Dynamics/physics coupling; should be the default, but set to make sure -->
-<se_ftype>2</se_ftype>
-
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
 

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
@@ -96,6 +96,9 @@
 <iradsw hgrid="ne1024np4"> 4 </iradsw>
 <iradlw hgrid="ne1024np4"> 4 </iradlw>
 
+<!-- Set IMEX scheme -->
+<tstep_type>5</tstep_type>
+
 <!-- Dynamics/physics coupling; should be the default, but set to make sure -->
 <se_ftype>2</se_ftype>
 

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
@@ -96,9 +96,6 @@
 <iradsw hgrid="ne1024np4"> 4 </iradsw>
 <iradlw hgrid="ne1024np4"> 4 </iradlw>
 
-<!-- Settings related to the SCREAM NH dycore -->
-<theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
-
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
 

--- a/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_scream_lr.xml
@@ -96,7 +96,7 @@
 <iradsw hgrid="ne1024np4"> 4 </iradsw>
 <iradlw hgrid="ne1024np4"> 4 </iradlw>
 
-<!-- Use se_ftype = 1 to improve dynamics/physics coupling -->
+<!-- Dynamics/physics coupling; should be the default, but set to make sure -->
 <se_ftype>2</se_ftype>
 
 <!-- Use the less sensitive advection scheme -->

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -168,7 +168,7 @@
 
 <!-- Settings related to the SCREAM NH dycore -->
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
-<tstep_type>10</tstep_type>
+<tstep_type>9</tstep_type>
 
 <!-- Dynamics/physics coupling; should be the default, but set to make sure -->
 <se_ftype>2</se_ftype>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -170,9 +170,6 @@
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
 <tstep_type>9</tstep_type>
 
-<!-- Dynamics/physics coupling; should be the default, but set to make sure -->
-<se_ftype>2</se_ftype>
-
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
 

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -179,10 +179,6 @@
 
 <!-- Settings related to the SCREAM NH dycore -->
 <theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
-<tstep_type>5</tstep_type>
-
-<!-- Dynamics/physics coupling; should be the default, but set to make sure -->
-<se_ftype>2</se_ftype>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -177,9 +177,6 @@
 <iradsw hgrid="ne1024np4"> 4 </iradsw>
 <iradlw hgrid="ne1024np4"> 4 </iradlw>
 
-<!-- Settings related to the SCREAM NH dycore -->
-<theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
-
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
 

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -179,6 +179,7 @@
 
 <!-- Settings related to the SCREAM NH dycore -->
 <theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
+<tstep_type>5</tstep_type>
 
 <!-- Dynamics/physics coupling; should be the default, but set to make sure -->
 <se_ftype>2</se_ftype>


### PR DESCRIPTION
Update the ftype and the IMEX scheme for SCREAM compsets. Use `ftype=2` for all SCREAM compsets (both HR and LR, this change only affects the F2000-SCREAM-LR compset), and use the `tstep_type=9` IMEX scheme for the HR compsets. These changes are in general non-BFB (in the E3SM integration testing sense, should not affect the unit tests at all), with the exception of the F2010-SCREAM-LR tests which are unaffected by this change (no change to `tstep_type`, and were already using `ftype=2`).

