### PR TITLE
[WIP] Replace rain evaporation scheme with modified WRF-P3 version

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3455,6 +3455,15 @@ dt,qr2qv_evap_tend,nr_evap_tend)
    real(rtype) :: cld_frac, eps_eff, tau_eff, tau_r, ssat_r, A_c, sup_r
    real(rtype) :: equilib_evap_tend, tscale_weight, instant_evap_tend
 
+   !qv_prev and t_prev are initialized as -12 in micro_p3_init
+   ! check whether qv_prev and t_prev are less than -10 and if so, set as qv and t
+   if (qv_prev < -10._rtype) then
+      qv_prev=qv
+   end if
+   if (t_prev < -10._rtype) then
+      t_prev=t
+   end if
+
    !Initialize variables
    qr2qv_evap_tend = 0.0_rtype
    nr_evap_tend = 0.0_rtype

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3272,83 +3272,83 @@ qidep,qi2qv_sublim_tend,ni_sublim_tend,qiberg)
 end subroutine ice_deposition_sublimation
 
 !---Terai/Schpund version below!!!
-!!$subroutine evaporate_precip(qr_incld,qc_incld,nr_incld,qi_incld, &
-!!$cld_frac_l,cld_frac_r,qv,qv_old,qv_sat_l,qv_sat_i, &
-!!$ab,abi,epsr,epsi_tot,t,t_old,latent_heat_sublim,dqsdt,inv_dt, &
-!!$dt,qr2qv_evap_tend,nr_evap_tend)
-!!$
-!!$   implicit none
-!!$
-!!$   real(rtype), intent(in)  :: qr_incld
-!!$   real(rtype), intent(in)  :: qc_incld
-!!$   real(rtype), intent(in)  :: nr_incld
-!!$   real(rtype), intent(in)  :: qi_incld
-!!$   real(rtype), intent(in)  :: cld_frac_l
-!!$   real(rtype), intent(in)  :: cld_frac_r
-!!$   real(rtype), intent(in)  :: qv_sat_l,qv_sat_i
-!!$   real(rtype), intent(in)  :: ab,abi
-!!$   real(rtype), intent(in)  :: epsr,epsi_tot
-!!$   real(rtype), intent(in)  :: qv,qv_old
-!!$   real(rtype), intent(in)  :: t,t_old,latent_heat_sublim,dqsdt,inv_dt,dt
-!!$   real(rtype), intent(inout) :: qr2qv_evap_tend
-!!$   real(rtype), intent(inout) :: nr_evap_tend
-!!$   real(rtype) :: cld, xx, ssat_r, SPF, hlp_w, inv_xx, qrcon, inv_abi, aaa, sup_r 
-!!$
-!!$   ! +++++++++++++++++++++++++++++++++++++++++++++++ JS:
-!!$   ! Local stuff (generalize when done):
-!!$
-!!$   if (qc_incld + qi_incld < 1.e-6_rtype) then
-!!$         cld = 0._rtype
-!!$   else
-!!$         cld = cld_frac_l
-!!$   end if
-!!$
-!!$   ! Only calculate if there is some rain fraction > cloud fraction
-!!$   qr2qv_evap_tend = 0.0_rtype
-!!$   nr_evap_tend = 0.0_rtype
-!!$   if (cld_frac_r > cld) then
-!!$
-!!$      ssat_r = qv - qv_sat_l
-!!$      sup_r = qv / qv_sat_l - 1.0_rtype
-!!$      SPF = 1.0_rtype   
-!!$
-!!$      if (t < 273.15_rtype) then
-!!$         inv_abi = 1.0_rtype/abi
-!!$         xx   = epsr + epsi_tot*(1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi
-!!$      else
-!!$         xx   = epsr
-!!$      endif
-!!$
-!!$      ! hlp_qv_sat_i = qv_sat_i   !no modification due to latent heating
-!!$      hlp_w = -cp/g*(t - t_old)*inv_dt
-!!$
-!!$      if (t < 273.15_rtype) then
-!!$         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)-(qv_sat_l - qv_sat_i)*     &
-!!$               (1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi*epsi_tot
-!!$      else
-!!$         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)
-!!$      endif
-!!$
-!!$      xx  = max(1.e-20_rtype,xx)   ! set lower bound on xx to prevent division by zero
-!!$      inv_xx = 1.0_rtype/xx
-!!$
-!!$      qrcon = 0.0  !condensation rate, so rain evaporation will be < 0
-!!$      if (qr_incld > qsmall) qrcon = (aaa*epsr*inv_xx + (ssat_r*SPF-aaa*inv_xx)*inv_dt*epsr*inv_xx*(1.0_rtype-dexp(-dble(xx*dt))))/ab
-!!$
-!!$      if (sup_r < -0.001_rtype .and. qr_incld < 1.e-12_rtype)  qrcon = -qr_incld*inv_dt
-!!$
-!!$      if (qrcon < 0.0_rtype) then
-!!$         qrcon = max(qrcon,(qv-qv_sat_l)*inv_dt/ab) ! Do not allow qrcon*dt from exceeding saturation deficit
-!!$         qr2qv_evap_tend = -qrcon*(cld_frac_r-cld)/cld_frac_r !qr2qv_evap_tend occurs where there's rain but no cloud and scale by rain fraction
-!!$         nr_evap_tend = qr2qv_evap_tend*(nr_incld/qr_incld)
-!!$         qrcon = 0.0_rtype
-!!$      endif
-!!$
-!!$   endif
-!!$
-!!$   return
-!!$
-!!$end subroutine evaporate_precip
+subroutine evaporate_precip_old(qr_incld,qc_incld,nr_incld,qi_incld, &
+cld_frac_l,cld_frac_r,qv,qv_old,qv_sat_l,qv_sat_i, &
+ab,abi,epsr,epsi_tot,t,t_old,latent_heat_sublim,dqsdt,inv_dt, &
+dt,qr2qv_evap_tend,nr_evap_tend)
+
+   implicit none
+
+   real(rtype), intent(in)  :: qr_incld
+   real(rtype), intent(in)  :: qc_incld
+   real(rtype), intent(in)  :: nr_incld
+   real(rtype), intent(in)  :: qi_incld
+   real(rtype), intent(in)  :: cld_frac_l
+   real(rtype), intent(in)  :: cld_frac_r
+   real(rtype), intent(in)  :: qv_sat_l,qv_sat_i
+   real(rtype), intent(in)  :: ab,abi
+   real(rtype), intent(in)  :: epsr,epsi_tot
+   real(rtype), intent(in)  :: qv,qv_old
+   real(rtype), intent(in)  :: t,t_old,latent_heat_sublim,dqsdt,inv_dt,dt
+   real(rtype), intent(inout) :: qr2qv_evap_tend
+   real(rtype), intent(inout) :: nr_evap_tend
+   real(rtype) :: cld, xx, ssat_r, SPF, hlp_w, inv_xx, qrcon, inv_abi, aaa, sup_r 
+
+   ! +++++++++++++++++++++++++++++++++++++++++++++++ JS:
+   ! Local stuff (generalize when done):
+
+   if (qc_incld + qi_incld < 1.e-6_rtype) then
+         cld = 0._rtype
+   else
+         cld = cld_frac_l
+   end if
+
+   ! Only calculate if there is some rain fraction > cloud fraction
+   qr2qv_evap_tend = 0.0_rtype
+   nr_evap_tend = 0.0_rtype
+   if (cld_frac_r > cld) then
+
+      ssat_r = qv - qv_sat_l
+      sup_r = qv / qv_sat_l - 1.0_rtype
+      SPF = 1.0_rtype   
+
+      if (t < 273.15_rtype) then
+         inv_abi = 1.0_rtype/abi
+         xx   = epsr + epsi_tot*(1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi
+      else
+         xx   = epsr
+      endif
+
+      ! hlp_qv_sat_i = qv_sat_i   !no modification due to latent heating
+      hlp_w = -cp/g*(t - t_old)*inv_dt
+
+      if (t < 273.15_rtype) then
+         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)-(qv_sat_l - qv_sat_i)*     &
+               (1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi*epsi_tot
+      else
+         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)
+      endif
+
+      xx  = max(1.e-20_rtype,xx)   ! set lower bound on xx to prevent division by zero
+      inv_xx = 1.0_rtype/xx
+
+      qrcon = 0.0  !condensation rate, so rain evaporation will be < 0
+      if (qr_incld > qsmall) qrcon = (aaa*epsr*inv_xx + (ssat_r*SPF-aaa*inv_xx)*inv_dt*epsr*inv_xx*(1.0_rtype-dexp(-dble(xx*dt))))/ab
+
+      if (sup_r < -0.001_rtype .and. qr_incld < 1.e-12_rtype)  qrcon = -qr_incld*inv_dt
+
+      if (qrcon < 0.0_rtype) then
+         qrcon = max(qrcon,(qv-qv_sat_l)*inv_dt/ab) ! Do not allow qrcon*dt from exceeding saturation deficit
+         qr2qv_evap_tend = -qrcon*(cld_frac_r-cld)/cld_frac_r !qr2qv_evap_tend occurs where there's rain but no cloud and scale by rain fraction
+         nr_evap_tend = qr2qv_evap_tend*(nr_incld/qr_incld)
+         qrcon = 0.0_rtype
+      endif
+
+   endif
+
+   return
+
+end subroutine evaporate_precip_old
 
 !+++PMC Ver below!!!
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3288,8 +3288,8 @@ dt,qr2qv_evap_tend,nr_evap_tend)
    real(rtype), intent(in)  :: qv_sat_l,qv_sat_i
    real(rtype), intent(in)  :: ab,abi
    real(rtype), intent(in)  :: epsr,epsi_tot
-   real(rtype), intent(in)  :: qv,qv_old
-   real(rtype), intent(in)  :: t,t_old,latent_heat_sublim,dqsdt,inv_dt,dt
+   real(rtype), intent(in)  :: qv,qv_prev
+   real(rtype), intent(in)  :: t,t_prev,latent_heat_sublim,dqsdt,inv_dt,dt
    real(rtype), intent(inout) :: qr2qv_evap_tend
    real(rtype), intent(inout) :: nr_evap_tend
    real(rtype) :: cld, xx, ssat_r, SPF, hlp_w, inv_xx, qrcon, inv_abi, aaa, sup_r 
@@ -3320,13 +3320,13 @@ dt,qr2qv_evap_tend,nr_evap_tend)
       endif
 
       ! hlp_qv_sat_i = qv_sat_i   !no modification due to latent heating
-      hlp_w = -cp/g*(t - t_old)*inv_dt
+      hlp_w = -cp/g*(t - t_prev)*inv_dt
 
       if (t < 273.15_rtype) then
-         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)-(qv_sat_l - qv_sat_i)*     &
+         aaa = (qv - qv_prev)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)-(qv_sat_l - qv_sat_i)*     &
                (1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi*epsi_tot
       else
-         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)
+         aaa = (qv - qv_prev)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)
       endif
 
       xx  = max(1.e-20_rtype,xx)   ! set lower bound on xx to prevent division by zero

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1576,7 +1576,10 @@ contains
     else
 
        write(err_msg,*)'Error: Either MurphyKoop_svp i_type is not 0 or 1 or t=NaN. itype= ', &
-            i_type,' and temperature t=',t,' in file: ',__FILE__,' at line:',__LINE__
+            i_type,' and temperature t=',t ,' in file: ',&
+            __FILE__,&
+            ' at line:',&
+            __LINE__
        call endscreamrun(err_msg)
     endif
 
@@ -1660,7 +1663,8 @@ contains
 
        call report_error_info('Something went wrong', 'polysvp1')
        write(err_msg,*)'** polysvp1 i_type must be 0 or 1 but is: ', &
-            i_type,' temperature is:',t,' in file: ',__FILE__, &
+            i_type,' temperature is:',t,' in file: ',&
+            __FILE__, &
             ' at line:',__LINE__
        call endscreamrun(err_msg)
     endif
@@ -1672,7 +1676,7 @@ contains
   subroutine check_temp(t, subname)
     !Check if temprature values are in legit range
     use scream_abortutils, only : endscreamrun
-    use ieee_arithmetic,   only : ieee_is_finite, ieee_is_nan
+    !use ieee_arithmetic,   only : ieee_is_finite, ieee_is_nan
 
     implicit none
 
@@ -1682,17 +1686,18 @@ contains
     character(len=1000) :: err_msg
 
     if(t <= 0.0_rtype) then
-       write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is <= 0._r8 in file:',__FILE__, &
+       write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is <= 0._r8 in file:',&
+            __FILE__, &
             ' at line:',__LINE__
        call endscreamrun(err_msg)
-    elseif(.not. ieee_is_finite(t)) then
-       write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is not finite in file:', &
-            __FILE__,' at line:',__LINE__
-       call endscreamrun(err_msg)
-    elseif(ieee_is_nan(t)) then
-       write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is NaN in file:',__FILE__, &
-             'at line:',__LINE__
-       call endscreamrun(err_msg)
+    !elseif(.not. ieee_is_finite(t)) then
+    !   write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is not finite in file:', &
+    !        __FILE__,' at line:',__LINE__
+    !   call endscreamrun(err_msg)
+    !elseif(ieee_is_nan(t)) then
+    !   write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is NaN in file:',__FILE__, &
+    !         'at line:',__LINE__
+    !   call endscreamrun(err_msg)
     endif
 
     return
@@ -2157,7 +2162,9 @@ contains
        print*
        if (source_ind/=100) then
           write(err_msg,*)'Source_ind should be 100, source_ind is:', &
-               source_ind,' in file:',__FILE__,' at line:',__LINE__
+               source_ind,' in file:',&
+               __FILE__,&
+               ' at line:',__LINE__
           call endscreamrun(err_msg)
        endif
     endif
@@ -2892,8 +2899,9 @@ end subroutine cloud_water_autoconversion
 
 subroutine back_to_cell_average(cld_frac_l,cld_frac_r,cld_frac_i,                         &
    qc2qr_accret_tend,qr2qv_evap_tend,qc2qr_autoconv_tend,                                                      &
-   nc_accret_tend,nc_selfcollect_tend,nc2nr_autoconv_tend,nr_selfcollect_tend,nr_evap_tend,ncautr,qi2qv_sublim_tend,nr_ice_shed_tend,qc2qi_hetero_freeze_tend,              &
-   qrcol,qc2qr_ice_shed_tend,qi2qr_melt_tend,qccol,qr2qi_immers_freeze_tend,ni2nr_melt_tend,nc_collect_tend,ncshdc,nc2ni_immers_freeze_tend,nr_collect_tend,ni_selfcollect_tend,   &
+   nc_accret_tend,nc_selfcollect_tend,nc2nr_autoconv_tend,nr_selfcollect_tend,nr_evap_tend,ncautr,qi2qv_sublim_tend, &
+   nr_ice_shed_tend,qc2qi_hetero_freeze_tend, qrcol,qc2qr_ice_shed_tend,qi2qr_melt_tend,qccol,qr2qi_immers_freeze_tend, &
+   ni2nr_melt_tend,nc_collect_tend,ncshdc,nc2ni_immers_freeze_tend,nr_collect_tend,ni_selfcollect_tend,   &
    qidep,nr2ni_immers_freeze_tend,ni_sublim_tend,qinuc,ni_nucleat_tend,qiberg)
 
    ! Here we map the microphysics tendency rates back to CELL-AVERAGE quantities for updating
@@ -2906,8 +2914,10 @@ subroutine back_to_cell_average(cld_frac_l,cld_frac_r,cld_frac_i,               
    real(rtype), intent(in) :: cld_frac_r
    real(rtype), intent(in) :: cld_frac_i
 
-   real(rtype), intent(inout) :: qc2qr_accret_tend, qr2qv_evap_tend, qc2qr_autoconv_tend, nc_accret_tend, nc_selfcollect_tend, nc2nr_autoconv_tend, nr_selfcollect_tend, nr_evap_tend, ncautr
-   real(rtype), intent(inout) :: qi2qv_sublim_tend, nr_ice_shed_tend, qc2qi_hetero_freeze_tend, qrcol, qc2qr_ice_shed_tend, qi2qr_melt_tend, qccol, qr2qi_immers_freeze_tend, ni2nr_melt_tend, &
+   real(rtype), intent(inout) :: qc2qr_accret_tend, qr2qv_evap_tend, qc2qr_autoconv_tend, nc_accret_tend, &
+        nc_selfcollect_tend, nc2nr_autoconv_tend, nr_selfcollect_tend, nr_evap_tend, ncautr
+   real(rtype), intent(inout) :: qi2qv_sublim_tend, nr_ice_shed_tend, qc2qi_hetero_freeze_tend, qrcol, qc2qr_ice_shed_tend, &
+        qi2qr_melt_tend, qccol, qr2qi_immers_freeze_tend, ni2nr_melt_tend, &
         nc_collect_tend, ncshdc, nc2ni_immers_freeze_tend, nr_collect_tend, ni_selfcollect_tend, qidep
    real(rtype), intent(inout) :: nr2ni_immers_freeze_tend, ni_sublim_tend, qinuc, ni_nucleat_tend, qiberg
 
@@ -2993,7 +3003,8 @@ subroutine cloud_water_conservation(qc,dt,    &
    implicit none
 
    real(rtype), intent(in) :: qc, dt
-   real(rtype), intent(inout) :: qc2qr_autoconv_tend, qc2qr_accret_tend, qccol, qc2qi_hetero_freeze_tend, qc2qr_ice_shed_tend, qiberg, qi2qv_sublim_tend, qidep
+   real(rtype), intent(inout) :: qc2qr_autoconv_tend, qc2qr_accret_tend, qccol, qc2qi_hetero_freeze_tend, qc2qr_ice_shed_tend, &
+   qiberg, qi2qv_sublim_tend, qidep
    real(rtype) :: sinks, ratio
 
    sinks   = (qc2qr_autoconv_tend+qc2qr_accret_tend+qccol+qc2qi_hetero_freeze_tend+qc2qr_ice_shed_tend+qiberg)*dt
@@ -3143,7 +3154,8 @@ subroutine update_prognostic_ice(qc2qi_hetero_freeze_tend,qccol,qc2qr_ice_shed_t
    bm = bm + (qrcol*inv_rho_rimeMax+qccol/rho_qm_cloud+(qr2qi_immers_freeze_tend+ &
         qc2qi_hetero_freeze_tend)*inv_rho_rimeMax)*dt
 
-   ni = ni + (ni_nucleat_tend-ni2nr_melt_tend-ni_sublim_tend-ni_selfcollect_tend+nr2ni_immers_freeze_tend+nc2ni_immers_freeze_tend)*dt
+   ni = ni + (ni_nucleat_tend-ni2nr_melt_tend-ni_sublim_tend-ni_selfcollect_tend &
+        +nr2ni_immers_freeze_tend+nc2ni_immers_freeze_tend)*dt
 
    !PMC nCat deleted interactions_loop
 
@@ -3173,8 +3185,8 @@ subroutine update_prognostic_ice(qc2qi_hetero_freeze_tend,qccol,qc2qr_ice_shed_t
        qc2qi_hetero_freeze_tend+qr2qi_immers_freeze_tend-qi2qr_melt_tend+qiberg)* xlf*inv_cp)*dt
 end subroutine update_prognostic_ice
 
-subroutine update_prognostic_liquid(qc2qr_accret_tend,nc_accret_tend,qc2qr_autoconv_tend,nc2nr_autoconv_tend,ncautr,nc_selfcollect_tend,    &
-    qr2qv_evap_tend,nr_evap_tend,nr_selfcollect_tend,                                                        &
+subroutine update_prognostic_liquid(qc2qr_accret_tend,nc_accret_tend,qc2qr_autoconv_tend,nc2nr_autoconv_tend, &
+     ncautr,nc_selfcollect_tend, qr2qv_evap_tend,nr_evap_tend,nr_selfcollect_tend,         &
     do_predict_nc,inv_rho,exner,latent_heat_vapor,dt,                                      &
     th,qv,qc,nc,qr,nr)
 
@@ -3341,7 +3353,8 @@ dt,qr2qv_evap_tend,nr_evap_tend)
       inv_xx = 1.0_rtype/xx
 
       qrcon = 0.0  !condensation rate, so rain evaporation will be < 0
-      if (qr_incld > qsmall) qrcon = (aaa*epsr*inv_xx + (ssat_r*SPF-aaa*inv_xx)*inv_dt*epsr*inv_xx*(1.0_rtype-dexp(-dble(xx*dt))))/ab
+      if (qr_incld > qsmall) qrcon = (aaa*epsr*inv_xx + (ssat_r*SPF-aaa*inv_xx)*inv_dt*epsr*inv_xx &
+           *(1.0_rtype-dexp(-dble(xx*dt))))/ab
 
       if (sup_r < -0.001_rtype .and. qr_incld < 1.e-12_rtype)  qrcon = -qr_incld*inv_dt
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3454,14 +3454,20 @@ dt,qr2qv_evap_tend,nr_evap_tend)
    real(rtype), intent(inout) :: nr_evap_tend
    real(rtype) :: cld_frac, eps_eff, tau_eff, tau_r, ssat_r, A_c, sup_r
    real(rtype) :: equilib_evap_tend, tscale_weight, instant_evap_tend
+   real(rtype) :: qv_prev_int, t_prev_int
 
-   !qv_prev and t_prev are initialized as -12 in micro_p3_init
+   ! qv_prev_int and t_prev_int are local variables for qv_prev and t_prev
+   ! qv_prev and t_prev are initialized as -12 in micro_p3_init
    ! check whether qv_prev and t_prev are less than -10 and if so, set as qv and t
    if (qv_prev < -10._rtype) then
-      qv_prev=qv
+      qv_prev_int=qv
+   else
+      qv_prev_int=qv_prev
    end if
    if (t_prev < -10._rtype) then
-      t_prev=t
+      t_prev_int=t
+   else
+      t_prev_int=t_prev
    end if
 
    !Initialize variables
@@ -3510,10 +3516,10 @@ dt,qr2qv_evap_tend,nr_evap_tend)
       !Compute the constant source/sink term A_c for analytic integration. See Eq C4 in
       !Morrison+Milbrandt 2015 https://doi.org/10.1175/JAS-D-14-0065.1
       if (t < 273.15_rtype) then
-         A_c = (qv - qv_prev)*inv_dt - dqsdt*(t-t_prev)*inv_dt - (qv_sat_l - qv_sat_i)* &
+         A_c = (qv - qv_prev_int)*inv_dt - dqsdt*(t-t_prev_int)*inv_dt - (qv_sat_l - qv_sat_i)* &
                (1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)/abi*epsi_tot
       else
-         A_c = (qv - qv_prev)*inv_dt - dqsdt*(t-t_prev)*inv_dt
+         A_c = (qv - qv_prev_int)*inv_dt - dqsdt*(t-t_prev_int)*inv_dt
       endif
       
       !Now compute evap rate

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3292,123 +3292,132 @@ qidep,qi2qv_sublim_tend,ni_sublim_tend,qiberg)
 end subroutine ice_deposition_sublimation
 
 !---Terai/Schpund version below!!!
-subroutine evaporate_precip_old(qr_incld,qc_incld,nr_incld,qi_incld, &
-cld_frac_l,cld_frac_r,qv,qv_old,qv_sat_l,qv_sat_i, &
-ab,abi,epsr,epsi_tot,t,t_old,latent_heat_sublim,dqsdt,inv_dt, &
-dt,qr2qv_evap_tend,nr_evap_tend)
-
-   implicit none
-
-   real(rtype), intent(in)  :: qr_incld
-   real(rtype), intent(in)  :: qc_incld
-   real(rtype), intent(in)  :: nr_incld
-   real(rtype), intent(in)  :: qi_incld
-   real(rtype), intent(in)  :: cld_frac_l
-   real(rtype), intent(in)  :: cld_frac_r
-   real(rtype), intent(in)  :: qv_sat_l,qv_sat_i
-   real(rtype), intent(in)  :: ab,abi
-   real(rtype), intent(in)  :: epsr,epsi_tot
-   real(rtype), intent(in)  :: qv,qv_old
-   real(rtype), intent(in)  :: t,t_old,latent_heat_sublim,dqsdt,inv_dt,dt
-   real(rtype), intent(inout) :: qr2qv_evap_tend
-   real(rtype), intent(inout) :: nr_evap_tend
-   real(rtype) :: cld, xx, ssat_r, SPF, hlp_w, inv_xx, qrcon, inv_abi, aaa, sup_r 
-
-   ! +++++++++++++++++++++++++++++++++++++++++++++++ JS:
-   ! Local stuff (generalize when done):
-
-   if (qc_incld + qi_incld < 1.e-6_rtype) then
-         cld = 0._rtype
-   else
-         cld = cld_frac_l
-   end if
-
-   ! Only calculate if there is some rain fraction > cloud fraction
-   qr2qv_evap_tend = 0.0_rtype
-   nr_evap_tend = 0.0_rtype
-   if (cld_frac_r > cld) then
-
-      ssat_r = qv - qv_sat_l
-      sup_r = qv / qv_sat_l - 1.0_rtype
-      SPF = 1.0_rtype   
-
-      if (t < 273.15_rtype) then
-         inv_abi = 1.0_rtype/abi
-         xx   = epsr + epsi_tot*(1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi
-      else
-         xx   = epsr
-      endif
-
-      ! hlp_qv_sat_i = qv_sat_i   !no modification due to latent heating
-      hlp_w = -cp/g*(t - t_old)*inv_dt
-
-      if (t < 273.15_rtype) then
-         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)-(qv_sat_l - qv_sat_i)*     &
-               (1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi*epsi_tot
-      else
-         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)
-      endif
-
-      xx  = max(1.e-20_rtype,xx)   ! set lower bound on xx to prevent division by zero
-      inv_xx = 1.0_rtype/xx
-
-      qrcon = 0.0  !condensation rate, so rain evaporation will be < 0
-      if (qr_incld > qsmall) qrcon = (aaa*epsr*inv_xx + (ssat_r*SPF-aaa*inv_xx)*inv_dt*epsr*inv_xx &
-           *(1.0_rtype-dexp(-dble(xx*dt))))/ab
-
-      if (sup_r < -0.001_rtype .and. qr_incld < 1.e-12_rtype)  qrcon = -qr_incld*inv_dt
-
-      if (qrcon < 0.0_rtype) then
-         qrcon = max(qrcon,(qv-qv_sat_l)*inv_dt/ab) ! Do not allow qrcon*dt from exceeding saturation deficit
-         qr2qv_evap_tend = -qrcon*(cld_frac_r-cld)/cld_frac_r !qr2qv_evap_tend occurs where there's rain but no cloud and scale by rain fraction
-         nr_evap_tend = qr2qv_evap_tend*(nr_incld/qr_incld)
-         qrcon = 0.0_rtype
-      endif
-
-   endif
-
-   return
-
-end subroutine evaporate_precip_old
+!!$subroutine evaporate_precip_old(qr_incld,qc_incld,nr_incld,qi_incld, &
+!!$cld_frac_l,cld_frac_r,qv,qv_old,qv_sat_l,qv_sat_i, &
+!!$ab,abi,epsr,epsi_tot,t,t_old,latent_heat_sublim,dqsdt,inv_dt, &
+!!$dt,qr2qv_evap_tend,nr_evap_tend)
+!!$
+!!$   implicit none
+!!$
+!!$   real(rtype), intent(in)  :: qr_incld
+!!$   real(rtype), intent(in)  :: qc_incld
+!!$   real(rtype), intent(in)  :: nr_incld
+!!$   real(rtype), intent(in)  :: qi_incld
+!!$   real(rtype), intent(in)  :: cld_frac_l
+!!$   real(rtype), intent(in)  :: cld_frac_r
+!!$   real(rtype), intent(in)  :: qv_sat_l,qv_sat_i
+!!$   real(rtype), intent(in)  :: ab,abi
+!!$   real(rtype), intent(in)  :: epsr,epsi_tot
+!!$   real(rtype), intent(in)  :: qv,qv_old
+!!$   real(rtype), intent(in)  :: t,t_old,latent_heat_sublim,dqsdt,inv_dt,dt
+!!$   real(rtype), intent(inout) :: qr2qv_evap_tend
+!!$   real(rtype), intent(inout) :: nr_evap_tend
+!!$   real(rtype) :: cld, xx, ssat_r, SPF, hlp_w, inv_xx, qrcon, inv_abi, aaa, sup_r 
+!!$
+!!$   ! +++++++++++++++++++++++++++++++++++++++++++++++ JS:
+!!$   ! Local stuff (generalize when done):
+!!$
+!!$   if (qc_incld + qi_incld < 1.e-6_rtype) then
+!!$      cld = 0._rtype
+!!$   else
+!!$         cld = cld_frac_l
+!!$   end if
+!!$
+!!$   ! Only calculate if there is some rain fraction > cloud fraction
+!!$   qr2qv_evap_tend = 0.0_rtype
+!!$   nr_evap_tend = 0.0_rtype
+!!$   if (cld_frac_r > cld) then
+!!$      
+!!$      ssat_r = qv - qv_sat_l
+!!$      sup_r = qv / qv_sat_l - 1.0_rtype
+!!$      SPF = 1.0_rtype   
+!!$
+!!$      if (t < 273.15_rtype) then
+!!$         inv_abi = 1.0_rtype/abi
+!!$         xx   = epsr + epsi_tot*(1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi
+!!$      else
+!!$         xx   = epsr
+!!$      endif
+!!$      
+!!$      ! hlp_qv_sat_i = qv_sat_i   !no modification due to latent heating
+!!$      hlp_w = -cp/g*(t - t_old)*inv_dt
+!!$
+!!$      if (t < 273.15_rtype) then
+!!$         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)-(qv_sat_l - qv_sat_i)*     &
+!!$               (1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi*epsi_tot
+!!$      else
+!!$         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)
+!!$      endif
+!!$      
+!!$      xx  = max(1.e-20_rtype,xx)   ! set lower bound on xx to prevent division by zero
+!!$      inv_xx = 1.0_rtype/xx
+!!$
+!!$      qrcon = 0.0  !condensation rate, so rain evaporation will be < 0
+!!$      if (qr_incld > qsmall) qrcon = (aaa*epsr*inv_xx + (ssat_r*SPF-aaa*inv_xx)*inv_dt*epsr*inv_xx &
+!!$           *(1.0_rtype-dexp(-dble(xx*dt))))/ab
+!!$      
+!!$      if (sup_r < -0.001_rtype .and. qr_incld < 1.e-12_rtype)  qrcon = -qr_incld*inv_dt
+!!$
+!!$      if (qrcon < 0.0_rtype) then
+!!$         qrcon = max(qrcon,(qv-qv_sat_l)*inv_dt/ab) ! Do not allow qrcon*dt from exceeding saturation deficit
+!!$         qr2qv_evap_tend = -qrcon*(cld_frac_r-cld)/cld_frac_r !qr2qv_evap_tend occurs where there's rain but no cloud and scale by rain fraction
+!!$         nr_evap_tend = qr2qv_evap_tend*(nr_incld/qr_incld)
+!!$         qrcon = 0.0_rtype
+!!$      endif
+!!$      
+!!$   endif
+!!$   
+!!$   return
+!!$
+!!$end subroutine evaporate_precip_old
 
 !+++PMC Ver below!!!
 
-real(rtype) function rain_evap_tscale_weight(dt_over_tau)
+subroutine rain_evap_tscale_weight(dt_over_tau,weight)
   !Returns weighting between 0 and 1 for how much of the instantaneous
   !evaporation rate and how much of the equilibrium evaporation rate to
   !blend to get the timestep-average rain evaporation rate
 
   real(rtype), intent(in) :: dt_over_tau  !microphysics timestep divided by effective evap timescale
+  real(rtype), intent(out) :: weight
   
-  rain_evap_tscale_weight=(1._rtype - exp(-dt_over_tau) )/dt_over_tau
+  weight=(1._rtype - exp(-dt_over_tau) )/dt_over_tau
 
   return
-end function rain_evap_tscale_weight
+end subroutine rain_evap_tscale_weight
 
-real(rtype) function rain_evap_equilib_tend(A_c,ab,tau_eff,tau_r)
+subroutine rain_evap_equilib_tend(A_c,ab,tau_eff,tau_r, tend)
   !In equilibrium, the total evaporation must balance the tendency A_c from
   !all other processes. The rain evaporation is the fraction (1/tau_r)/(1/tau_eff)
   !of the total tendency and ab corrects for saturation changes due to evaporative
   !cooling.
 
   real(rtype), intent(in) :: A_c, ab, tau_eff, tau_r
+  real(rtype), intent(out) :: tend
 
-  rain_evap_equilib_tend = A_c/ab*tau_eff/tau_r
+  !sign convention: Negative A_c causes a supersaturation deficit which needs to be removed
+  !by evaporation (which is signed positive when active) to maintain equilibrium. Thus need
+  !a negative sign here since other terms are always positive.
+  tend = -A_c/ab*tau_eff/tau_r
 
   return
-end function rain_evap_equilib_tend
+end subroutine rain_evap_equilib_tend
 
-real(rtype) function rain_evap_instant_tend(ssat_r, ab, tau_r)
+subroutine rain_evap_instant_tend(ssat_r, ab, tau_r,tend)
   !The instantaneous rain evap tendency is just the absolute supersaturation
   !ssat_r divided by the supersaturation removal timescale for rain tau_r
   !corrected for the effect of evaporative cooling on saturation ab.
 
   real(rtype), intent(in) :: ssat_r, ab, tau_r
+  real(rtype), intent(out) :: tend
 
-  rain_evap_instant_tend = -ssat_r/(ab*tau_r)
+  !sign convention: ssat_r must be <0 for evap, other terms are always positive,
+  !and we want evap rate positive... so put a minus sign in front.
+  
+  tend = -ssat_r/(ab*tau_r)
 
   return
-end function rain_evap_instant_tend
+end subroutine rain_evap_instant_tend
 
 
 subroutine evaporate_precip(qr_incld,qc_incld,nr_incld,qi_incld, &
@@ -3443,7 +3452,7 @@ dt,qr2qv_evap_tend,nr_evap_tend)
    real(rtype), intent(in)  :: t,t_prev,latent_heat_sublim,dqsdt,inv_dt,dt
    real(rtype), intent(inout) :: qr2qv_evap_tend
    real(rtype), intent(inout) :: nr_evap_tend
-   real(rtype) :: cld_frac, eps_eff, tau_eff, tau_r, ssat_r, inv_abi, A_c, sup_r
+   real(rtype) :: cld_frac, eps_eff, tau_eff, tau_r, ssat_r, A_c, sup_r
    real(rtype) :: equilib_evap_tend, tscale_weight, instant_evap_tend
 
    !Initialize variables
@@ -3456,7 +3465,7 @@ dt,qr2qv_evap_tend,nr_evap_tend)
    !because micro lacks the info to reliably reconstruct macrophys
    !subgrid variability
    ssat_r = qv - qv_sat_l !absolute supersaturation
-
+   
    !Cloud fraction in clear-sky conditions has been set to mincld
    !to avoid divide-by-zero problems. Because rain evap only happens
    !in rainy portions outside cloud, setting clear-sky cloud fraction
@@ -3469,6 +3478,8 @@ dt,qr2qv_evap_tend,nr_evap_tend)
    end if
 
    !Only evaporate in the rainy area outside cloud when subsaturated
+   !Note: ignoring case where cell initially supersaturated but other processes would make
+   !it subsaturated within 1 timestep.
    if (cld_frac_r > cld_frac .and. ssat_r<0._rtype) then
       
       !Compute total effective inverse saturation removal timescale eps_eff
@@ -3478,12 +3489,11 @@ dt,qr2qv_evap_tend,nr_evap_tend)
       !it from being relative to ice to liquid instead. See Eq C3 of Morrison+Milbrandt 2015
       !https://doi.org/10.1175/JAS-D-14-0065.1
       if (t < 273.15_rtype) then
-         inv_abi = 1.0_rtype/abi !accounts for condensational heating changing qv_sat
-         eps_eff   = epsr + epsi_tot*(1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi
+         eps_eff   = epsr + epsi_tot*(1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)/abi
       else
          eps_eff   = epsr
       endif
-
+      
       !Set lower bound on eps_eff to prevent division by zero
       eps_eff  = max(1.e-20_rtype,eps_eff)   
       tau_eff = 1.0_rtype/eps_eff
@@ -3492,11 +3502,11 @@ dt,qr2qv_evap_tend,nr_evap_tend)
       !Morrison+Milbrandt 2015 https://doi.org/10.1175/JAS-D-14-0065.1
       if (t < 273.15_rtype) then
          A_c = (qv - qv_prev)*inv_dt - dqsdt*(t-t_prev)*inv_dt - (qv_sat_l - qv_sat_i)* &
-               (1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi*epsi_tot
+               (1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)/abi*epsi_tot
       else
          A_c = (qv - qv_prev)*inv_dt - dqsdt*(t-t_prev)*inv_dt
       endif
-
+      
       !Now compute evap rate
       
       !If no rain to evap, set tend to 0
@@ -3504,30 +3514,30 @@ dt,qr2qv_evap_tend,nr_evap_tend)
       !beginning of this function so this is a bit redundant 
       if (qr_incld < qsmall ) then
          qr2qv_evap_tend = 0._rtype
-         
+
       !If there's negligible qr and conditions are subsaturated, evaporate all qr
       elseif (qr_incld < 1e-12_rtype .and. qv/qv_sat_l < 0.999_rtype) then
          qr2qv_evap_tend = qr_incld*inv_dt
-
+         
       !If sizable qr, compute tend. 
       else
          !Timestep-averaged evap can be written as the weighted average of instantaneous 
          !and equilibrium evap rates with weighting tscale_weight. L'Hospital's rule 
          !shows tscale_weight is 1 in the limit of small dt. It approaches 0 as dt
          !gets big.
-         tscale_weight = rain_evap_tscale_weight(dt/tau_eff)
+         call rain_evap_tscale_weight(dt/tau_eff,tscale_weight)
 
          !in limit of very long timescales, evap must balance A_c.
          !(1/tau_r)/(1/tau_eff) is the fraction of this total tendency assigned to rain
          !Will be >0 if A_c>0: increased supersat from other procs must be balanced by
          !evaporation to stay in equilibrium.
-         equilib_evap_tend = rain_evap_equilib_tend(A_c,ab,tau_eff,tau_r)
+         call  rain_evap_equilib_tend(A_c,ab,tau_eff,tau_r,equilib_evap_tend)
 
          !in limit of short timesteps, evap can be calculated from ssat_r at the
          !beginning of the timestep
          !ssat_r<0 when evap occurs and evap_tend is positive when evaporating, so added
          !neg in front
-         instant_evap_tend = rain_evap_instant_tend(ssat_r, ab, tau_r)
+         call  rain_evap_instant_tend(ssat_r, ab, tau_r, instant_evap_tend)
          
          qr2qv_evap_tend = instant_evap_tend*tscale_weight &
               + equilib_evap_tend*(1-tscale_weight)
@@ -3547,7 +3557,7 @@ dt,qr2qv_evap_tend,nr_evap_tend)
       nr_evap_tend = qr2qv_evap_tend*(nr_incld/qr_incld)
 
    end if !cld_frac_r>cldfrac and ssat_r<0
-
+   
    return
 
 end subroutine evaporate_precip

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3376,7 +3376,7 @@ dt,qr2qv_evap_tend,nr_evap_tend)
          !and equilibrium evap rates with weighting tscale_weight. L'Hospital's rule 
          !shows tscale_weight is 1 in the limit of small dt. It approaches 0 as dt
          !gets big.
-         tscale_weight = tau_eff*inv_dt*(1._rtype - exp(dt*eps_eff) )
+         tscale_weight = tau_eff*inv_dt*(1._rtype - exp(-dt*eps_eff) )
 
          !in limit of very long timescales, evap must balance A_c.
          !(1/tau_r)/(1/tau_eff) is the fraction of this total tendency assigned to rain

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -341,8 +341,10 @@ contains
   !==========================================================================================!
 
   SUBROUTINE p3_main_part1(kts, kte, kbot, ktop, kdir, do_predict_nc, dt, &
-       pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, latent_heat_vapor, latent_heat_sublim, xlf, &
-       t, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, qv, th, qc, nc, qr, nr, &
+       pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l, inv_cld_frac_i, &
+       inv_cld_frac_r, latent_heat_vapor, latent_heat_sublim, xlf, &
+       t, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, qv, th, &
+       qc, nc, qr, nr, &
        qi, ni, qm, bm, qc_incld, qr_incld, qi_incld, qm_incld, &
        nc_incld, nr_incld, ni_incld, bm_incld, is_nucleat_possible, is_hydromet_present)
 
@@ -468,13 +470,13 @@ contains
     logical(btype), intent(in) :: do_predict_nc
     real(rtype), intent(in) :: dt, inv_dt
 
-    real(rtype), intent(in), dimension(kts:kte) :: pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l, inv_cld_frac_i,   &
-         inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r, qv_prev, t_prev
+    real(rtype), intent(in), dimension(kts:kte) :: pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l,  &
+         inv_cld_frac_i, inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r, qv_prev, t_prev
 
-    real(rtype), intent(inout), dimension(kts:kte) :: t, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn,        &
-         qv, th, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, xlf, qc_incld, qr_incld,                    &
+    real(rtype), intent(inout), dimension(kts:kte) :: t, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, &
+         qv, th, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, xlf, qc_incld, qr_incld,                 &
          qi_incld, qm_incld, nc_incld, nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1,      &
-         cdistr, mu_r, lamr, logn0r, cmeiout, precip_total_tend, nevapr, qr_evap_tend, vap_liq_exchange,                            &
+         cdistr, mu_r, lamr, logn0r, cmeiout, precip_total_tend, nevapr, qr_evap_tend, vap_liq_exchange,                         &
          vap_ice_exchange, liq_ice_exchange, pratot, prctot
 
     real(rtype), intent(inout), dimension(kts:kte,49) :: p3_tend_out ! micro physics tendencies
@@ -773,9 +775,11 @@ contains
 
       ! Here we map the microphysics tendency rates back to CELL-AVERAGE quantities for updating
       ! cell-average quantities.
-      call back_to_cell_average(cld_frac_l(k), cld_frac_r(k), cld_frac_i(k), qc2qr_accret_tend, qr2qv_evap_tend, qc2qr_autoconv_tend,&
-           nc_accret_tend, nc_selfcollect_tend, nc2nr_autoconv_tend, nr_selfcollect_tend, nr_evap_tend, ncautr, qi2qv_sublim_tend, nr_ice_shed_tend, qc2qi_hetero_freeze_tend,&
-           qrcol, qc2qr_ice_shed_tend, qi2qr_melt_tend, qccol, qr2qi_immers_freeze_tend, ni2nr_melt_tend, nc_collect_tend, ncshdc, nc2ni_immers_freeze_tend, nr_collect_tend, ni_selfcollect_tend,&
+      call back_to_cell_average(cld_frac_l(k),cld_frac_r(k),cld_frac_i(k), qc2qr_accret_tend, qr2qv_evap_tend, qc2qr_autoconv_tend,&
+           nc_accret_tend, nc_selfcollect_tend, nc2nr_autoconv_tend, nr_selfcollect_tend, nr_evap_tend, ncautr, &
+           qi2qv_sublim_tend, nr_ice_shed_tend, qc2qi_hetero_freeze_tend,&
+           qrcol, qc2qr_ice_shed_tend, qi2qr_melt_tend, qccol, qr2qi_immers_freeze_tend, ni2nr_melt_tend, nc_collect_tend, &
+      ncshdc, nc2ni_immers_freeze_tend, nr_collect_tend, ni_selfcollect_tend,&
            qidep, nr2ni_immers_freeze_tend, ni_sublim_tend, qinuc, ni_nucleat_tend, qiberg)
 
       !.................................................................
@@ -807,13 +811,16 @@ contains
       !          cannot possibly overdeplete qv
 
       ! cloud
-      call cloud_water_conservation(qc(k), dt, qc2qr_autoconv_tend, qc2qr_accret_tend, qccol, qc2qi_hetero_freeze_tend, qc2qr_ice_shed_tend, qiberg, qi2qv_sublim_tend, qidep)
+      call cloud_water_conservation(qc(k), dt, qc2qr_autoconv_tend, qc2qr_accret_tend, qccol, qc2qi_hetero_freeze_tend, &
+           qc2qr_ice_shed_tend, qiberg, qi2qv_sublim_tend, qidep)
 
       ! rain
-      call rain_water_conservation(qr(k), qc2qr_autoconv_tend, qc2qr_accret_tend, qi2qr_melt_tend, qc2qr_ice_shed_tend, dt, qr2qv_evap_tend, qrcol, qr2qi_immers_freeze_tend)
+      call rain_water_conservation(qr(k), qc2qr_autoconv_tend, qc2qr_accret_tend, qi2qr_melt_tend, qc2qr_ice_shed_tend, dt, &
+           qr2qv_evap_tend, qrcol, qr2qi_immers_freeze_tend)
 
       ! ice
-      call ice_water_conservation(qi(k), qidep, qinuc, qiberg, qrcol, qccol, qr2qi_immers_freeze_tend, qc2qi_hetero_freeze_tend, dt, qi2qv_sublim_tend, qi2qr_melt_tend)
+      call ice_water_conservation(qi(k), qidep, qinuc, qiberg, qrcol, qccol, qr2qi_immers_freeze_tend, qc2qi_hetero_freeze_tend, &
+           dt, qi2qv_sublim_tend, qi2qr_melt_tend)
 
       !---------------------------------------------------------------------------------
       ! update prognostic microphysics and thermodynamics variables
@@ -823,14 +830,14 @@ contains
       call update_prognostic_ice(qc2qi_hetero_freeze_tend, qccol, qc2qr_ice_shed_tend, &
            nc_collect_tend, nc2ni_immers_freeze_tend, ncshdc, &
            qrcol, nr_collect_tend,  qr2qi_immers_freeze_tend, nr2ni_immers_freeze_tend, nr_ice_shed_tend, &
-           qi2qr_melt_tend, ni2nr_melt_tend, qi2qv_sublim_tend, qidep, qinuc, ni_nucleat_tend, ni_selfcollect_tend, ni_sublim_tend, qiberg, &
-           exner(k), latent_heat_sublim(k), xlf(k), &
+           qi2qr_melt_tend, ni2nr_melt_tend, qi2qv_sublim_tend, qidep, qinuc, ni_nucleat_tend, ni_selfcollect_tend, &
+           ni_sublim_tend, qiberg, exner(k), latent_heat_sublim(k), xlf(k), &
            do_predict_nc, log_wetgrowth, dt, nmltratio, rho_qm_cloud, &
            th(k), qv(k), qi(k), ni(k), qm(k), bm(k), qc(k), nc(k), qr(k), nr(k) )
 
       !-- warm-phase only processes:
-      call update_prognostic_liquid(qc2qr_accret_tend, nc_accret_tend, qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, nc_selfcollect_tend,  &
-           qr2qv_evap_tend, nr_evap_tend, nr_selfcollect_tend,                                                  &
+      call update_prognostic_liquid(qc2qr_accret_tend, nc_accret_tend, qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, &
+           nc_selfcollect_tend, qr2qv_evap_tend, nr_evap_tend, nr_selfcollect_tend,           &
            do_predict_nc, inv_rho(k), exner(k), latent_heat_vapor(k), dt,                     &
            th(k), qv(k), qc(k), nc(k), qr(k), nr(k))
 
@@ -1065,8 +1072,8 @@ contains
   SUBROUTINE p3_main(qc,nc,qr,nr,th,qv,dt,qi,qm,ni,bm,   &
        pres,dz,nc_nuceat_tend,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_effc,     &
        diag_effi,rho_qi,do_predict_nc, &
-       dpres,exner,cmeiout,precip_total_tend,nevapr,qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,  &
-       p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
+       dpres,exner,cmeiout,precip_total_tend,nevapr,qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r, &
+       cld_frac_l,cld_frac_i, p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
        vap_ice_exchange,qv_prev,t_prev,col_location)
 
     !----------------------------------------------------------------------------------------!
@@ -1273,8 +1280,8 @@ contains
 
        call p3_main_part1(kts, kte, kbot, ktop, kdir, do_predict_nc, dt, &
             pres(i,:), dpres(i,:), dz(i,:), nc_nuceat_tend(i,:), exner(i,:), inv_exner(i,:), &
-            inv_cld_frac_l(i,:), inv_cld_frac_i(i,:), inv_cld_frac_r(i,:), latent_heat_vapor(i,:), latent_heat_sublim(i,:), xlf(i,:), &
-            t(i,:), rho(i,:), inv_rho(i,:), qv_sat_l(i,:), qv_sat_i(i,:), qv_supersat_i(i,:), rhofacr(i,:), &
+            inv_cld_frac_l(i,:), inv_cld_frac_i(i,:), inv_cld_frac_r(i,:), latent_heat_vapor(i,:), latent_heat_sublim(i,:), &
+            xlf(i,:), t(i,:), rho(i,:), inv_rho(i,:), qv_sat_l(i,:), qv_sat_i(i,:), qv_supersat_i(i,:), rhofacr(i,:), &
             rhofaci(i,:), acn(i,:), qv(i,:), th(i,:), qc(i,:), nc(i,:), qr(i,:), nr(i,:), &
             qi(i,:), ni(i,:), qm(i,:), bm(i,:), qc_incld(i,:), qr_incld(i,:), &
             qi_incld(i,:), qm_incld(i,:), nc_incld(i,:), nr_incld(i,:), &
@@ -1346,7 +1353,8 @@ contains
 
        call rain_sedimentation(kts,kte,ktop,kbot,kdir, &
          qr_incld(i,:),rho(i,:),inv_rho(i,:),rhofacr(i,:),cld_frac_r(i,:),inv_dz(i,:),dt,inv_dt, &
-         qr(i,:),nr(i,:),nr_incld(i,:),mu_r(i,:),lamr(i,:),precip_liq_surf(i),precip_liq_flux(i,:),p3_tend_out(i,:,38),p3_tend_out(i,:,39))
+         qr(i,:),nr(i,:),nr_incld(i,:),mu_r(i,:),lamr(i,:),precip_liq_surf(i),precip_liq_flux(i,:),p3_tend_out(i,:,38), &
+         p3_tend_out(i,:,39))
 
        !------------------------------------------------------------------------------------------!
        ! Ice sedimentation:  (adaptive substepping)

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3271,7 +3271,86 @@ qidep,qi2qv_sublim_tend,ni_sublim_tend,qiberg)
 
 end subroutine ice_deposition_sublimation
 
+!---Terai/Schpund version below!!!
+!!$subroutine evaporate_precip(qr_incld,qc_incld,nr_incld,qi_incld, &
+!!$cld_frac_l,cld_frac_r,qv,qv_old,qv_sat_l,qv_sat_i, &
+!!$ab,abi,epsr,epsi_tot,t,t_old,latent_heat_sublim,dqsdt,inv_dt, &
+!!$dt,qr2qv_evap_tend,nr_evap_tend)
+!!$
+!!$   implicit none
+!!$
+!!$   real(rtype), intent(in)  :: qr_incld
+!!$   real(rtype), intent(in)  :: qc_incld
+!!$   real(rtype), intent(in)  :: nr_incld
+!!$   real(rtype), intent(in)  :: qi_incld
+!!$   real(rtype), intent(in)  :: cld_frac_l
+!!$   real(rtype), intent(in)  :: cld_frac_r
+!!$   real(rtype), intent(in)  :: qv_sat_l,qv_sat_i
+!!$   real(rtype), intent(in)  :: ab,abi
+!!$   real(rtype), intent(in)  :: epsr,epsi_tot
+!!$   real(rtype), intent(in)  :: qv,qv_old
+!!$   real(rtype), intent(in)  :: t,t_old,latent_heat_sublim,dqsdt,inv_dt,dt
+!!$   real(rtype), intent(inout) :: qr2qv_evap_tend
+!!$   real(rtype), intent(inout) :: nr_evap_tend
+!!$   real(rtype) :: cld, xx, ssat_r, SPF, hlp_w, inv_xx, qrcon, inv_abi, aaa, sup_r 
+!!$
+!!$   ! +++++++++++++++++++++++++++++++++++++++++++++++ JS:
+!!$   ! Local stuff (generalize when done):
+!!$
+!!$   if (qc_incld + qi_incld < 1.e-6_rtype) then
+!!$         cld = 0._rtype
+!!$   else
+!!$         cld = cld_frac_l
+!!$   end if
+!!$
+!!$   ! Only calculate if there is some rain fraction > cloud fraction
+!!$   qr2qv_evap_tend = 0.0_rtype
+!!$   nr_evap_tend = 0.0_rtype
+!!$   if (cld_frac_r > cld) then
+!!$
+!!$      ssat_r = qv - qv_sat_l
+!!$      sup_r = qv / qv_sat_l - 1.0_rtype
+!!$      SPF = 1.0_rtype   
+!!$
+!!$      if (t < 273.15_rtype) then
+!!$         inv_abi = 1.0_rtype/abi
+!!$         xx   = epsr + epsi_tot*(1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi
+!!$      else
+!!$         xx   = epsr
+!!$      endif
+!!$
+!!$      ! hlp_qv_sat_i = qv_sat_i   !no modification due to latent heating
+!!$      hlp_w = -cp/g*(t - t_old)*inv_dt
+!!$
+!!$      if (t < 273.15_rtype) then
+!!$         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)-(qv_sat_l - qv_sat_i)*     &
+!!$               (1.0_rtype + latent_heat_sublim*inv_cp*dqsdt)*inv_abi*epsi_tot
+!!$      else
+!!$         aaa = (qv - qv_old)*inv_dt - dqsdt*(-hlp_w*g*inv_cp)
+!!$      endif
+!!$
+!!$      xx  = max(1.e-20_rtype,xx)   ! set lower bound on xx to prevent division by zero
+!!$      inv_xx = 1.0_rtype/xx
+!!$
+!!$      qrcon = 0.0  !condensation rate, so rain evaporation will be < 0
+!!$      if (qr_incld > qsmall) qrcon = (aaa*epsr*inv_xx + (ssat_r*SPF-aaa*inv_xx)*inv_dt*epsr*inv_xx*(1.0_rtype-dexp(-dble(xx*dt))))/ab
+!!$
+!!$      if (sup_r < -0.001_rtype .and. qr_incld < 1.e-12_rtype)  qrcon = -qr_incld*inv_dt
+!!$
+!!$      if (qrcon < 0.0_rtype) then
+!!$         qrcon = max(qrcon,(qv-qv_sat_l)*inv_dt/ab) ! Do not allow qrcon*dt from exceeding saturation deficit
+!!$         qr2qv_evap_tend = -qrcon*(cld_frac_r-cld)/cld_frac_r !qr2qv_evap_tend occurs where there's rain but no cloud and scale by rain fraction
+!!$         nr_evap_tend = qr2qv_evap_tend*(nr_incld/qr_incld)
+!!$         qrcon = 0.0_rtype
+!!$      endif
+!!$
+!!$   endif
+!!$
+!!$   return
+!!$
+!!$end subroutine evaporate_precip
 
+!+++PMC Ver below!!!
 subroutine evaporate_precip(qr_incld,qc_incld,nr_incld,qi_incld, &
 cld_frac_l,cld_frac_r,qv,qv_prev,qv_sat_l,qv_sat_i, &
 ab,abi,epsr,epsi_tot,t,t_prev,latent_heat_sublim,dqsdt,inv_dt, &

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -85,6 +85,8 @@ module micro_p3_interface
       qr_evap_tend_idx,      &
       cmeliq_idx,         &
       relvar_idx,         &
+      qv_prev_idx,        &
+      t_prev_idx,         &
       accre_enhan_idx     
 
 ! Physics buffer indices for fields registered by other modules
@@ -280,6 +282,9 @@ end subroutine micro_p3_readnl
    call pbuf_add_field('RELVAR',     'global',dtype_r8,(/pcols,pver/),   relvar_idx)
    call pbuf_add_field('ACCRE_ENHAN','global',dtype_r8,(/pcols,pver/), accre_enhan_idx)
 
+   call pbuf_add_field('QV_PREV',     'global',dtype_r8,(/pcols,pver/), qv_prev_idx)
+   call pbuf_add_field('T_PREV',      'global',dtype_r8,(/pcols,pver/), t_prev_idx)
+
    if (masterproc) write(iulog,'(A20)') '    P3 register finished'
   end subroutine micro_p3_register
 
@@ -362,6 +367,8 @@ end subroutine micro_p3_readnl
        call pbuf_set_field(pbuf2d, relvar_idx, 2._rtype)
        call pbuf_set_field(pbuf2d, accre_enhan_idx, micro_mg_accre_enhan_fac)
        call pbuf_set_field(pbuf2d, qr_evap_tend_idx,  0._rtype)
+       call pbuf_set_field(pbuf2d, qv_prev_idx,  0._rtype)
+       call pbuf_set_field(pbuf2d, t_prev_idx,  0._rtype)
  
     end if
 
@@ -766,7 +773,9 @@ end subroutine micro_p3_readnl
     real(rtype), pointer :: snow_sed(:)    ! Surface flux of cloud ice from sedimentation
     real(rtype), pointer :: relvar(:,:)    ! cloud liquid relative variance [-]
     real(rtype), pointer :: cldo(:,:)      ! Old cloud fraction
-    real(rtype), pointer :: qr_evap_tend(:,:) ! precipitation evaporation rate 
+    real(rtype), pointer :: qr_evap_tend(:,:) ! precipitation evaporation rate
+    real(rtype), pointer :: qv_prev(:,:)   ! qv from previous p3_main call
+    real(rtype), pointer :: t_prev(:,:)    ! t from previous p3_main call
     !! wetdep 
     real(rtype), pointer :: qme(:,:)
     real(rtype), pointer :: precip_total_tend(:,:)        ! Total precipitation (rain + snow)
@@ -856,6 +865,8 @@ end subroutine micro_p3_readnl
     ! All internal PBUF variables
     ! INPUTS
     call pbuf_get_field(pbuf,      relvar_idx,    relvar                                                   )
+    call pbuf_get_field(pbuf,      t_prev_idx,    t_prev                                                   )
+    call pbuf_get_field(pbuf,     qv_prev_idx,    qv_prev                                                  )
     ! OUTPUTS
     call pbuf_get_field(pbuf,        cldo_idx,      cldo, start=(/1,1,itim_old/), kount=(/psetcols,pver,1/))
     call pbuf_get_field(pbuf,         qme_idx,       qme                                                   )
@@ -1054,6 +1065,8 @@ end subroutine micro_p3_readnl
          liq_ice_exchange(its:ite,kts:kte),& ! OUT sum of liq-ice phase change tendenices   
          vap_liq_exchange(its:ite,kts:kte),& ! OUT sun of vap-liq phase change tendencies
          vap_ice_exchange(its:ite,kts:kte),& ! OUT sum of vap-ice phase change tendencies
+         qv_prev(its:ite,kts:kte),         & ! IN  qv at end of prev p3_main call   kg kg-1
+         t_prev(its:ite,kts:kte),          & ! IN  t at end of prev p3_main call    K
          col_location(its:ite,:3)          & ! IN column locations
          )
 
@@ -1114,6 +1127,10 @@ end subroutine micro_p3_readnl
     ptend%q(:ncol,:pver,ixnumice)  = ( max(0._rtype,numice(:ncol,:pver) ) - state%q(:ncol,:pver,ixnumice)  )/dtime
     ptend%q(:ncol,:pver,ixcldrim)  = ( max(0._rtype,qm(:ncol,:pver)  ) - state%q(:ncol,:pver,ixcldrim)  )/dtime
     ptend%q(:ncol,:pver,ixrimvol)  = ( max(0._rtype,rimvol(:ncol,:pver) ) - state%q(:ncol,:pver,ixrimvol)  )/dtime
+
+    ! Update t_prev and qv_prev to be used by evap_precip
+    t_prev(:ncol,:pver) = temp(:ncol,:pver)
+    qv_prev(:ncol,:pver) = qv(:ncol,:pver)
 
     call t_stopf('micro_p3_tend_loop')
     call t_startf('micro_p3_tend_finish')

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -367,8 +367,8 @@ end subroutine micro_p3_readnl
        call pbuf_set_field(pbuf2d, relvar_idx, 2._rtype)
        call pbuf_set_field(pbuf2d, accre_enhan_idx, micro_mg_accre_enhan_fac)
        call pbuf_set_field(pbuf2d, qr_evap_tend_idx,  0._rtype)
-       call pbuf_set_field(pbuf2d, qv_prev_idx,  0._rtype)
-       call pbuf_set_field(pbuf2d, t_prev_idx,  0._rtype)
+       call pbuf_set_field(pbuf2d, qv_prev_idx,  -12._rtype)
+       call pbuf_set_field(pbuf2d, t_prev_idx,  -12._rtype)
  
     end if
 

--- a/components/scream/src/physics/p3/CMakeLists.txt
+++ b/components/scream/src/physics/p3/CMakeLists.txt
@@ -47,7 +47,7 @@ if (NOT CUDA_BUILD)
     p3_rain_imm_freezing.cpp
     p3_droplet_self_coll.cpp
     p3_update_prognostics.cpp
-    p3_evaporate_sublimate_precip.cpp
+    p3_evaporate_precip.cpp
     p3_impose_max_total_Ni.cpp
     p3_calc_liq_relaxation_timescale.cpp
     p3_ice_relaxation_timescale.cpp

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -68,6 +68,8 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   m_computed_fields.emplace("FQ", tracers_layout,      Q, grid_name);
   m_computed_fields.emplace("T",  scalar3d_layout_mid, K, grid_name);
   m_computed_fields.emplace("q",  vector3d_layout_mid, Q, grid_name);
+  m_computed_fields.emplace("T_prev_p3",  scalar3d_layout_mid, K, grid_name);
+  m_computed_fields.emplace("q_prev_p3",  vector3d_layout_mid, Q, grid_name);
 }
 
 // =========================================================================================
@@ -90,7 +92,7 @@ void P3Microphysics::initialize (const util::TimeStamp& t0)
   //  - initable fields may not need initialization (e.g., some other atm proc that
   //    appears earlier in the atm dag might provide them).
 
-  std::vector<std::string> p3_inputs = {"q","T","FQ","ast","ni_activated","nc_nuceat_tend","pmid","dp","zi"};
+  std::vector<std::string> p3_inputs = {"q","T","FQ","ast","ni_activated","nc_nuceat_tend","pmid","dp","zi","qv_prev_p3","T_prev_p3"};
   using strvec = std::vector<std::string>;
   const strvec& allowed_to_init = m_p3_params.get<strvec>("Initializable Inputs",strvec(0));
   const bool can_init_all = m_p3_params.get<bool>("Can Initialize All Inputs", false);
@@ -138,7 +140,7 @@ void P3Microphysics::run (const Real dt)
   }
 
   // Call f90 routine
-  p3_main_f90 (dt, m_raw_ptrs_in["zi"], m_raw_ptrs_in["pmid"], m_raw_ptrs_in["dp"], m_raw_ptrs_in["ast"], m_raw_ptrs_in["ni_activated"], m_raw_ptrs_in["nc_nuceat_tend"], m_raw_ptrs_out["q"], m_raw_ptrs_out["FQ"], m_raw_ptrs_out["T"]);
+  p3_main_f90 (dt, m_raw_ptrs_in["zi"], m_raw_ptrs_in["pmid"], m_raw_ptrs_in["dp"], m_raw_ptrs_in["ast"], m_raw_ptrs_in["ni_activated"], m_raw_ptrs_in["nc_nuceat_tend"], m_raw_ptrs_out["q"], m_raw_ptrs_out["FQ"], m_raw_ptrs_out["T"], m_raw_ptrs_out["qv_prev_p3"], m_raw_ptrs_out["T_prev_p3"]);
 
   // Copy outputs back to device
   for (auto& it : m_p3_fields_out) {

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -654,16 +654,19 @@ subroutine  update_prognostic_ice_c(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
   end subroutine ice_self_collection_c
 
   subroutine evaporate_precip_c(qr_incld, qc_incld, nr_incld, qi_incld, cld_frac_l, &
-       cld_frac_r, qv_sat_l, ab, epsr, qv, qr2qv_evap_tend, nr_evap_tend) bind(C)
+       cld_frac_r, qv, qv_prev, qv_sat_l, qv_sat_i, ab, abi, epsr, epsi_tot, t, &
+       t_prev, latent_heat_sublim, dqsdt, inv_dt, dt, qr2qv_evap_tend, nr_evap_tend) bind(C)
     use micro_p3, only: evaporate_precip
 
     ! arguments
     real(kind=c_real), value, intent(in) :: qr_incld, qc_incld, nr_incld, qi_incld, cld_frac_l, &
-        cld_frac_r, qv_sat_l, ab, epsr, qv
+        cld_frac_r, qv_sat_l, ab, epsr, qv, qv_prev, t, t_prev, qv_sat_i, abi, epsi_tot, latent_heat_sublim, &
+        dqsdt, inv_dt, dt
     real(kind=c_real), intent(out) :: qr2qv_evap_tend, nr_evap_tend
 
     call evaporate_precip(qr_incld, qc_incld, nr_incld, qi_incld, cld_frac_l, &
-       cld_frac_r, qv_sat_l, ab, epsr, qv, qr2qv_evap_tend, nr_evap_tend)
+       cld_frac_r, qv, qv_prev, qv_sat_l, qv_sat_i, ab, abi, epsr, epsi_tot, t, &
+       t_prev, latent_heat_sublim, dqsdt, inv_dt, dt, qr2qv_evap_tend, nr_evap_tend)
   end subroutine evaporate_precip_c
 
   subroutine  update_prognostic_liquid_c(qc2qr_accret_tend, nc_accret_tend, qc2qr_autoconv_tend,nc2nr_autoconv_tend, ncautr, nc_selfcollect_tend, &
@@ -853,7 +856,7 @@ subroutine  update_prognostic_ice_c(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
 
  subroutine p3_main_part2_c(kts, kte, kbot, ktop, kdir, do_predict_nc, dt, inv_dt, &
        pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r,&
-       t, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, qv, th, qc, nc, qr, nr, qi, ni, &
+       qv_prev, t_prev, t, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, qv, th, qc, nc, qr, nr, qi, ni, &
        qm, bm, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, qc_incld, qr_incld, qi_incld, qm_incld, nc_incld, nr_incld, &
        ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, cmeiout, precip_total_tend, &
        nevapr, qr_evap_tend, vap_liq_exchange, vap_ice_exchange, liq_ice_exchange, pratot, &
@@ -867,7 +870,7 @@ subroutine  update_prognostic_ice_c(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
    real(kind=c_real), value, intent(in) :: dt, inv_dt
 
    real(kind=c_real), intent(in), dimension(kts:kte) :: pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l, inv_cld_frac_i, &
-        inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r
+        inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r, qv_prev, t_prev
 
    real(kind=c_real), intent(inout), dimension(kts:kte) :: t, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, &
         qv, th, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, qc_incld, qr_incld, &
@@ -882,7 +885,7 @@ subroutine  update_prognostic_ice_c(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
 
    call p3_main_part2(kts, kte, kbot, ktop, kdir, do_predict_nc, dt, inv_dt, &
         pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r,&
-        t, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, qv, th, qc, nc, qr, nr, qi, ni, &
+        qv_prev, t_prev, t, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, qv, th, qc, nc, qr, nr, qi, ni, &
         qm, bm, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, qc_incld, qr_incld, qi_incld, qm_incld, nc_incld, nr_incld, &
         ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, cmeiout, precip_total_tend, &
         nevapr, qr_evap_tend, vap_liq_exchange, vap_ice_exchange, liq_ice_exchange, pratot, &

--- a/components/scream/src/physics/p3/micro_p3_iso_c.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_c.f90
@@ -131,8 +131,8 @@ contains
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: liq_ice_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_liq_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_ice_exchange
-    real(kind=c_real), intent(in),   dimension(its:ite,kts:kte)      :: qv_prev
-    real(kind=c_real), intent(in),   dimension(its:ite,kts:kte)      :: t_prev
+    real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: qv_prev
+    real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: t_prev
 
     real(kind=c_real), dimension(its:ite,kts:kte,49)   :: p3_tend_out
     real(kind=c_real), dimension(its:ite,3) :: col_location
@@ -145,7 +145,7 @@ contains
          pres,dz,nc_nuceat_tend,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_effc, &
          diag_effi,rho_qi,do_predict_nc,dpres,exner,cmeiout,precip_total_tend,nevapr, &
          qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,p3_tend_out,mu_c,lamc,liq_ice_exchange,&
-         vap_liq_exchange, vap_ice_exchange, qv_prev,T_prev,col_location)
+         vap_liq_exchange, vap_ice_exchange,qv_prev,t_prev,col_location)
   end subroutine p3_main_c
 
   subroutine micro_p3_utils_init_c(Cpair, Rair, RH2O, RHO_H2O, &

--- a/components/scream/src/physics/p3/micro_p3_iso_f.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_f.f90
@@ -401,13 +401,13 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
     real(kind=c_real), intent(out) :: ni_selfcollect_tend
   end subroutine ice_self_collection_f
 
-  subroutine evaporate_precip_f(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv_sat_l, ab, &
-       epsr, qv, qr2qv_evap_tend, nr_evap_tend) bind(C)
+  subroutine evaporate_precip_f(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv, qv_prev, qv_sat_l, qv_sat_i, &
+       ab, abi, epsr, epsi_tot, t, t_prev, latent_heat_sublim, dqsdt, inv_dt, dt, qr2qv_evap_tend, nr_evap_tend) bind(C)
     use iso_c_binding
 
     ! arguments:
     real(kind=c_real), value, intent(in) :: qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv_sat_l, ab, &
-         epsr, qv
+         epsr, qv, qv_prev, t, t_prev, latent_heat_sublim, dqsdt, inv_dt, dt, abi, epsi_tot, qv_sat_i
     real(kind=c_real), intent(out) :: qr2qv_evap_tend, nr_evap_tend
 
   end subroutine evaporate_precip_f
@@ -553,7 +553,7 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
 
  subroutine p3_main_part2_f(kts, kte, kbot, ktop, kdir, do_predict_nc, dt, inv_dt, &
        pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r,&
-       t, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, qv, th, qc, nc, qr, nr, qi, ni, &
+       qv_prev, t_prev, t, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, qv, th, qc, nc, qr, nr, qi, ni, &
        qm, bm, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, qc_incld, qr_incld, qi_incld, qm_incld, nc_incld, nr_incld, &
        ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, cmeiout, precip_total_tend, &
        nevapr, qr_evap_tend, vap_liq_exchange, vap_ice_exchange, liq_ice_exchange, pratot, &
@@ -573,7 +573,7 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
         qv, th, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, qc_incld, qr_incld, &
         qi_incld, qm_incld, nc_incld, nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, &
         cdistr, mu_r, lamr, logn0r, cmeiout, precip_total_tend, nevapr, qr_evap_tend, vap_liq_exchange, &
-        vap_ice_exchange, liq_ice_exchange, pratot, prctot
+        vap_ice_exchange, liq_ice_exchange, pratot, prctot, qv_prev, t_prev
 
    logical(kind=c_bool), intent(out) :: is_hydromet_present
 
@@ -603,14 +603,14 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
       pres,dz,nc_nuceat_tend,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_ze,diag_effc,     &
       diag_effi,diag_vmi,diag_di,rho_qi,do_predict_nc, &
       dpres,exner,cmeiout,precip_total_tend,nevapr,qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,  &
-      pratot,prctot,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, vap_ice_exchange) bind(C)
+      pratot,prctot,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, vap_ice_exchange,qv_prev,t_prev) bind(C)
 
    use iso_c_binding
 
    ! args
    
    integer(kind=c_int), value, intent(in)  :: its, ite, kts, kte, it
-   real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, qi, qm, ni, bm, qv, th
+   real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, qi, qm, ni, bm, qv, th, qv_prev, t_prev
    real(kind=c_real), intent(in),  dimension(its:ite,kts:kte) :: pres, dz, nc_nuceat_tend, ni_activated, dpres, exner, cld_frac_i, cld_frac_l, cld_frac_r, inv_qc_relvar
    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, rho_qi, mu_c, &
         lamc, cmeiout, precip_total_tend, nevapr, qr_evap_tend, pratot, prctot, liq_ice_exchange, vap_liq_exchange, vap_ice_exchange

--- a/components/scream/src/physics/p3/micro_p3_iso_f.f90
+++ b/components/scream/src/physics/p3/micro_p3_iso_f.f90
@@ -401,7 +401,7 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
     real(kind=c_real), intent(out) :: ni_selfcollect_tend
   end subroutine ice_self_collection_f
 
-  subroutine evaporate_sublimate_precip_f(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv_sat_l, ab, &
+  subroutine evaporate_precip_f(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv_sat_l, ab, &
        epsr, qv, qr2qv_evap_tend, nr_evap_tend) bind(C)
     use iso_c_binding
 
@@ -410,7 +410,7 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
          epsr, qv
     real(kind=c_real), intent(out) :: qr2qv_evap_tend, nr_evap_tend
 
-  end subroutine evaporate_sublimate_precip_f
+  end subroutine evaporate_precip_f
 
   subroutine update_prognostic_liquid_f(qc2qr_accret_tend, nc_accret_tend, qc2qr_autoconv_tend,nc2nr_autoconv_tend, ncautr, nc_selfcollect_tend, &
        qr2qv_evap_tend, nr_evap_tend, nr_selfcollect_tend, do_predict_nc, inv_rho, exner, latent_heat_vapor, dt, th, qv, qc, nc, qr, nr) bind(C)
@@ -608,7 +608,8 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
    use iso_c_binding
 
    ! args
-
+   
+   integer(kind=c_int), value, intent(in)  :: its, ite, kts, kte, it
    real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, qi, qm, ni, bm, qv, th
    real(kind=c_real), intent(in),  dimension(its:ite,kts:kte) :: pres, dz, nc_nuceat_tend, ni_activated, dpres, exner, cld_frac_i, cld_frac_l, cld_frac_r, inv_qc_relvar
    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_ze, diag_effc, diag_effi, diag_vmi, diag_di, rho_qi, mu_c, &
@@ -616,7 +617,6 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
    real(kind=c_real), intent(out), dimension(its:ite,kts:kte+1) :: precip_liq_flux, precip_ice_flux
    real(kind=c_real), intent(out), dimension(its:ite) :: precip_liq_surf, precip_ice_surf
 
-   integer(kind=c_int), value, intent(in)  :: its, ite, kts, kte, it
    logical(kind=c_bool), value, intent(in) :: do_predict_nc
    real(kind=c_real), value, intent(in)    :: dt
 

--- a/components/scream/src/physics/p3/p3_evaporate_precip.cpp
+++ b/components/scream/src/physics/p3/p3_evaporate_precip.cpp
@@ -1,4 +1,4 @@
-#include "p3_evaporate_sublimate_precip_impl.hpp"
+#include "p3_evaporate_precip_impl.hpp"
 #include "ekat/scream_types.hpp"
 
 namespace scream {

--- a/components/scream/src/physics/p3/p3_evaporate_precip_impl.hpp
+++ b/components/scream/src/physics/p3/p3_evaporate_precip_impl.hpp
@@ -12,8 +12,11 @@ KOKKOS_FUNCTION
 void Functions<S,D>
 ::evaporate_precip(
   const Spack& qr_incld, const Spack& qc_incld, const Spack& nr_incld, const Spack& qi_incld,
-  const Spack& cld_frac_l, const Spack& cld_frac_r, const Spack& qv_sat_l, const Spack& ab, const Spack& epsr,
-  const Spack& qv, Spack& qr2qv_evap_tend, Spack& nr_evap_tend,
+  const Spack& cld_frac_l, const Spack& cld_frac_r, const Spack& qv, const Spack& qv_prev,
+  const Spack& qv_sat_l, const Spack& qv_sat_i, const Spack& ab, const Spack& abi, 
+  const Spack& epsr, const Spack& epsi_tot, const Spack& t, const Spack& t_prev,
+  const Spack& latent_heat_sublim, const Spack& dqsdt, const Scalar& inv_dt, const Scalar& dt,
+  Spack& qr2qv_evap_tend, Spack& nr_evap_tend,
   const Smask& context)
 {
   /* It is assumed that macrophysics handles condensation/evaporation of qc and

--- a/components/scream/src/physics/p3/p3_evaporate_precip_impl.hpp
+++ b/components/scream/src/physics/p3/p3_evaporate_precip_impl.hpp
@@ -1,5 +1,5 @@
-#ifndef P3_EVAPORATE_SUBLIMATE_PRECIP_IMPL_HPP
-#define P3_EVAPORATE_SUBLIMATE_PRECIP_IMPL_HPP
+#ifndef P3_EVAPORATE_PRECIP_IMPL_HPP
+#define P3_EVAPORATE_PRECIP_IMPL_HPP
 
 #include "p3_functions.hpp"
 #include "physics_constants.hpp"
@@ -10,7 +10,7 @@ namespace p3 {
 template<typename S, typename D>
 KOKKOS_FUNCTION
 void Functions<S,D>
-::evaporate_sublimate_precip(
+::evaporate_precip(
   const Spack& qr_incld, const Spack& qc_incld, const Spack& nr_incld, const Spack& qi_incld,
   const Spack& cld_frac_l, const Spack& cld_frac_r, const Spack& qv_sat_l, const Spack& ab, const Spack& epsr,
   const Spack& qv, Spack& qr2qv_evap_tend, Spack& nr_evap_tend,

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -24,7 +24,7 @@ extern "C" {
                  Real* precip_liq_flux, Real* precip_ice_flux, // 1 extra column size
                  Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, Real* mu_c, Real* lamc,
                  Real* liq_ice_exchange, Real* vap_liq_exchange,
-                 Real* vap_ice_exchange);
+                 Real* vap_ice_exchange, Real* qv_prev, Real* t_prev);
 }
 
 namespace scream {
@@ -47,6 +47,8 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   bm             = Array2("rime ice volume mixing ratio, m3/kg", ncol, nlev);
   qv             = Array2("water vapor mixing ratio, kg/kg", ncol, nlev);
   th             = Array2("potential temperature, K", ncol, nlev);
+  qv_prev        = Array2("previous water vapor mixing ratio, kg/kg", ncol, nlev);
+  t_prev         = Array2("previous temperature, K", ncol, nlev);
   pres           = Array2("pressure, Pa", ncol, nlev);
   dz             = Array2("vertical grid spacing, m", ncol, nlev);
   nc_nuceat_tend = Array2("ccn activated number tendency, kg-1 s-1", ncol, nlev);
@@ -97,7 +99,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(nevapr); fdipb(qr_evap_tend); fdipb(precip_liq_flux); fdipb(precip_ice_flux);
   fdipb(cld_frac_r); fdipb(cld_frac_l); fdipb(cld_frac_i);
   fdipb(mu_c); fdipb(lamc), fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
-  fdipb(vap_ice_exchange);;
+  fdipb(vap_ice_exchange); fdipb(qv_prev); fdipb(t_prev);;
 #undef fdipb
 }
 
@@ -139,7 +141,7 @@ void p3_main (const FortranData& d, bool use_fortran) {
               d.precip_liq_flux.data(), d.precip_ice_flux.data(), d.cld_frac_r.data(), d.cld_frac_l.data(),
               d.cld_frac_i.data(), d.mu_c.data(), d.lamc.data(),
               d.liq_ice_exchange.data(),
-              d.vap_liq_exchange.data(),d.vap_ice_exchange.data());
+              d.vap_liq_exchange.data(),d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data());
   }
   else {
     p3_main_f(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(), d.th.data(),
@@ -152,7 +154,7 @@ void p3_main (const FortranData& d, bool use_fortran) {
               d.nevapr.data(), d.qr_evap_tend.data(), d.precip_liq_flux.data(), d.precip_ice_flux.data(),
               d.cld_frac_r.data(), d.cld_frac_l.data(), d.cld_frac_i.data(), d.mu_c.data(),
               d.lamc.data(), d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),
-              d.vap_ice_exchange.data());
+              d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data());
   }
 }
 

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -28,7 +28,7 @@ struct FortranData {
   Real dt;
   Int it;
   Array2 qv, th, pres, dz, nc_nuceat_tend, ni_activated, inv_qc_relvar, qc, nc, qr, nr,  qi,
-    ni, qm, bm, dpres, exner, qv_prev, T_prev;
+    ni, qm, bm, dpres, exner, qv_prev, t_prev;
   // Out
   Array1 precip_liq_surf, precip_ice_surf;
   Array2 diag_effc, diag_effi, rho_qi, cmeiout, precip_total_tend, nevapr, qr_evap_tend,

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -28,7 +28,7 @@ struct FortranData {
   Real dt;
   Int it;
   Array2 qv, th, pres, dz, nc_nuceat_tend, ni_activated, inv_qc_relvar, qc, nc, qr, nr,  qi,
-    ni, qm, bm, dpres, exner;
+    ni, qm, bm, dpres, exner, qv_prev, t_prev;
   // Out
   Array1 precip_liq_surf, precip_ice_surf;
   Array2 diag_effc, diag_effi, rho_qi, cmeiout, precip_total_tend, nevapr, qr_evap_tend,

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -28,7 +28,7 @@ struct FortranData {
   Real dt;
   Int it;
   Array2 qv, th, pres, dz, nc_nuceat_tend, ni_activated, inv_qc_relvar, qc, nc, qr, nr,  qi,
-    ni, qm, bm, dpres, exner, qv_prev, t_prev;
+    ni, qm, bm, dpres, exner, qv_prev, T_prev;
   // Out
   Array1 precip_liq_surf, precip_ice_surf;
   Array2 diag_effc, diag_effi, rho_qi, cmeiout, precip_total_tend, nevapr, qr_evap_tend,

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -642,7 +642,7 @@ struct Functions
 
   // TODO (comments)
   KOKKOS_FUNCTION
-  static void evaporate_sublimate_precip(const Spack& qr_incld, const Spack& qc_incld,
+  static void evaporate_precip(const Spack& qr_incld, const Spack& qc_incld,
 					 const Spack& nr_incld, const Spack& qi_incld,
 					 const Spack& cld_frac_l, const Spack& cld_frac_r,
 					 const Spack& qv_sat_l, const Spack& ab, const Spack& epsr,
@@ -970,7 +970,7 @@ void init_tables_from_f90_c(Real* vn_table_data, Real* vm_table_data,
 # include "p3_rain_sed_impl.hpp"
 # include "p3_rain_imm_freezing_impl.hpp"
 # include "p3_get_time_space_phys_variables_impl.hpp"
-# include "p3_evaporate_sublimate_precip_impl.hpp"
+# include "p3_evaporate_precip_impl.hpp"
 # include "p3_update_prognostics_impl.hpp"
 # include "p3_ice_collection_impl.hpp"
 # include "p3_ice_deposition_sublimation_impl.hpp"

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -112,8 +112,10 @@ struct Functions
     view_2d<Spack> bm;
     // Water vapor mixing ratio [kg kg-1]
     view_2d<Spack> qv;
+    view_2d<Spack> qv_prev;
     // Potential temperature [K]
     view_2d<Spack> th;
+    view_2d<Spack> t_prev;
   };
 
   // This struct stores diagnostic variables used by P3.
@@ -644,9 +646,13 @@ struct Functions
   KOKKOS_FUNCTION
   static void evaporate_precip(const Spack& qr_incld, const Spack& qc_incld,
 					 const Spack& nr_incld, const Spack& qi_incld,
-					 const Spack& cld_frac_l, const Spack& cld_frac_r,
-					 const Spack& qv_sat_l, const Spack& ab, const Spack& epsr,
-					 const Spack& qv, Spack& qr2qv_evap_tend, Spack& nr_evap_tend,
+					 const Spack& cld_frac_l, const Spack& cld_frac_r, 
+					 const Spack& qv, const Spack& qv_prev,
+					 const Spack& qv_sat_l, const Spack& qv_sat_i, const Spack& ab, const Spack& abi,
+					 const Spack& epsr, const Spack& epsi_tot,
+					 const Spack& t, const Spack& t_prev,
+					 const Spack& latent_heat_sublim, const Spack& dqsdt, const Scalar& inv_dt, const Scalar& dt,
+					 Spack& qr2qv_evap_tend, Spack& nr_evap_tend,
                                          const Smask& context = Smask(true));
 
   //get number and mass tendencies due to melting ice
@@ -757,6 +763,8 @@ struct Functions
     const uview_1d<Spack>& t,
     const uview_1d<Spack>& qv,
     const uview_1d<Spack>& inv_dz,
+    const uview_1d<Spack>& t_prev,
+    const uview_1d<Spack>& qv_prev,
     Scalar& precip_liq_surf,
     Scalar& precip_ice_surf,
     view_1d_ptr_array<Spack, 36>& zero_init);
@@ -834,6 +842,8 @@ struct Functions
     const uview_1d<const Spack>& cld_frac_i,
     const uview_1d<const Spack>& cld_frac_l,
     const uview_1d<const Spack>& cld_frac_r,
+    const uview_1d<Spack>& q_prev,
+    const uview_1d<Spack>& t_prev,
     const uview_1d<Spack>& t,
     const uview_1d<Spack>& rho,
     const uview_1d<Spack>& inv_rho,

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -206,7 +206,7 @@ void p3_main_part2_c(
   Int kts, Int kte, Int kbot, Int ktop, Int kdir, bool do_predict_nc, Real dt, Real inv_dt,
   Real* pres, Real* dpres, Real* dz, Real* nc_nuceat_tend, Real* exner, Real* inv_exner, Real* inv_cld_frac_l, Real* inv_cld_frac_i, 
   Real* inv_cld_frac_r, Real* ni_activated, Real* inv_qc_relvar, Real* cld_frac_i, Real* cld_frac_l, Real* cld_frac_r,
-  Real* t, Real* rho, Real* inv_rho, Real* qv_sat_l, Real* qv_sat_i, Real* qv_supersat_i, Real* rhofacr, Real* rhofaci, Real* acn, 
+  Real* qv_prev, Real* t_prev, Real* t, Real* rho, Real* inv_rho, Real* qv_sat_l, Real* qv_sat_i, Real* qv_supersat_i, Real* rhofacr, Real* rhofaci, Real* acn, 
   Real* qv, Real* th, Real* qc, Real* nc, Real* qr, Real* nr, Real* qi, Real* ni,
   Real* qm, Real* bm, Real* latent_heat_vapor, Real* latent_heat_sublim, Real* latent_heat_fusion, Real* qc_incld, 
   Real* qr_incld, Real* qi_incld, Real* qm_incld, Real* nc_incld, Real* nr_incld,
@@ -231,7 +231,7 @@ void p3_main_c(
   Real* diag_effi, Real* rho_qi, bool do_predict_nc, Real* dpres, Real* exner,
   Real* cmeiout, Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend, Real* precip_liq_flux,
   Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, Real* mu_c, Real* lamc,
-  Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange);
+  Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev);
 
 }
 
@@ -1052,7 +1052,7 @@ P3MainPart2Data::P3MainPart2Data(
   m_data( NUM_ARRAYS * m_nk, 0.0)
 {
   std::array<Real**, NUM_ARRAYS> ptrs = {
-    &pres, &dpres, &dz, &nc_nuceat_tend, &exner, &inv_exner, &inv_cld_frac_l, &inv_cld_frac_i, &inv_cld_frac_r, &ni_activated, &inv_qc_relvar, &cld_frac_i, &cld_frac_l, &cld_frac_r,
+    &pres, &dpres, &dz, &nc_nuceat_tend, &exner, &inv_exner, &inv_cld_frac_l, &inv_cld_frac_i, &inv_cld_frac_r, &ni_activated, &inv_qc_relvar, &cld_frac_i, &cld_frac_l, &cld_frac_r, &qv_prev, &t_prev,
     &t, &rho, &inv_rho, &qv_sat_l, &qv_sat_i, &qv_supersat_i, &rhofacr, &rhofaci, &acn,
     &qv, &th, &qc, &nc, &qr, &nr, &qi, &ni, &qm, &bm, &latent_heat_vapor, &latent_heat_sublim, &latent_heat_fusion, &qc_incld, &qr_incld,
     &qi_incld, &qm_incld, &nc_incld, &nr_incld, &ni_incld, &bm_incld, &mu_c, &nu, &lamc, &cdist, &cdist1,
@@ -1082,7 +1082,7 @@ P3MainPart2Data::P3MainPart2Data(const P3MainPart2Data& rhs) :
   Real* data_begin = m_data.data();
 
   std::array<Real**, NUM_ARRAYS> ptrs = {
-    &pres, &dpres, &dz, &nc_nuceat_tend, &exner, &inv_exner, &inv_cld_frac_l, &inv_cld_frac_i, &inv_cld_frac_r, &ni_activated, &inv_qc_relvar, &cld_frac_i, &cld_frac_l, &cld_frac_r,
+    &pres, &dpres, &dz, &nc_nuceat_tend, &exner, &inv_exner, &inv_cld_frac_l, &inv_cld_frac_i, &inv_cld_frac_r, &ni_activated, &inv_qc_relvar, &cld_frac_i, &cld_frac_l, &cld_frac_r, &qv_prev, &t_prev,
     &t, &rho, &inv_rho, &qv_sat_l, &qv_sat_i, &qv_supersat_i, &rhofacr, &rhofaci, &acn,
     &qv, &th, &qc, &nc, &qr, &nr, &qi, &ni, &qm, &bm, &latent_heat_vapor, &latent_heat_sublim, &latent_heat_fusion, &qc_incld, &qr_incld,
     &qi_incld, &qm_incld, &nc_incld, &nr_incld, &ni_incld, &bm_incld, &mu_c, &nu, &lamc, &cdist, &cdist1,
@@ -1102,7 +1102,7 @@ void p3_main_part2(P3MainPart2Data& d)
   p3_main_part2_c(
     d.kts, d.kte, d.kbot, d.ktop, d.kdir, d.do_predict_nc, d.dt, d.inv_dt,
     d.pres, d.dpres, d.dz, d.nc_nuceat_tend, d.exner, d.inv_exner, d.inv_cld_frac_l, d.inv_cld_frac_i, d.inv_cld_frac_r, d.ni_activated, d.inv_qc_relvar, d.cld_frac_i, d.cld_frac_l, d.cld_frac_r,
-    d.t, d.rho, d.inv_rho, d.qv_sat_l, d.qv_sat_i, d.qv_supersat_i, d.rhofacr, d.rhofaci, d.acn, d.qv, d.th, d.qc, d.nc, d.qr, d.nr, d.qi, d.ni,
+    d.qv_prev,d.t_prev,d.t, d.rho, d.inv_rho, d.qv_sat_l, d.qv_sat_i, d.qv_supersat_i, d.rhofacr, d.rhofaci, d.acn, d.qv, d.th, d.qc, d.nc, d.qr, d.nr, d.qi, d.ni,
     d.qm, d.bm, d.latent_heat_vapor, d.latent_heat_sublim, d.latent_heat_fusion, d.qc_incld, d.qr_incld, d.qi_incld, d.qm_incld, d.nc_incld, d.nr_incld,
     d.ni_incld, d.bm_incld, d.mu_c, d.nu, d.lamc, d.cdist, d.cdist1, d.cdistr, d.mu_r, d.lamr, d.logn0r, d.cmeiout, d.precip_total_tend,
     d.nevapr, d.qr_evap_tend, d.vap_liq_exchange, d.vap_ice_exchange, d.liq_ice_exchange, d.pratot,
@@ -1184,7 +1184,7 @@ P3MainData::P3MainData(
     &inv_qc_relvar, &qc, &nc, &qr, &nr, &qi, &qm, &ni, &bm, &qv, &th,
     &diag_effc, &diag_effi, &rho_qi, &mu_c, &lamc, &cmeiout, &precip_total_tend, &nevapr,
     &qr_evap_tend, &liq_ice_exchange, &vap_liq_exchange, &vap_ice_exchange, &precip_liq_flux,
-    &precip_ice_flux, &precip_liq_surf, &precip_ice_surf
+    &precip_ice_flux, &precip_liq_surf, &precip_ice_surf, &qv_prev, &t_prev
   };
 
   gen_random_data(ranges, ptrs, m_data.data(), m_nt);
@@ -1203,7 +1203,7 @@ P3MainData::P3MainData(const P3MainData& rhs) :
     &inv_qc_relvar, &qc, &nc, &qr, &nr, &qi, &qm, &ni, &bm, &qv, &th,
     &diag_effc, &diag_effi, &rho_qi, &mu_c, &lamc, &cmeiout, &precip_total_tend, &nevapr,
     &qr_evap_tend, &liq_ice_exchange, &vap_liq_exchange, &vap_ice_exchange, &precip_liq_flux,
-    &precip_ice_flux, &precip_liq_surf, &precip_ice_surf
+    &precip_ice_flux, &precip_liq_surf, &precip_ice_surf, &qv_prev, &t_prev
   };
 
   for (size_t i = 0; i < NUM_ARRAYS; ++i) {
@@ -1222,7 +1222,7 @@ void p3_main(P3MainData& d)
     d.precip_ice_surf, d.its, d.ite, d.kts, d.kte, d.diag_effc, d.diag_effi,
     d.rho_qi, d.do_predict_nc, d.dpres, d.exner, d.cmeiout, d.precip_total_tend, d.nevapr,
     d.qr_evap_tend, d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i, d.mu_c, d.lamc,
-    d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange);
+    d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange,d.qv_prev,d.t_prev);
   d.transpose<util::TransposeDirection::f2c>();
 }
 
@@ -1527,7 +1527,9 @@ void update_prognostic_ice_f( Real qc2qi_hetero_freeze_tend_, Real qc2qi_collect
 }
 
 void evaporate_precip_f(Real qr_incld_, Real qc_incld_, Real nr_incld_, Real qi_incld_, Real cld_frac_l_,
-				  Real cld_frac_r_, Real qv_sat_l_, Real ab_, Real epsr_, Real qv_,
+				  Real cld_frac_r_, Real qv_, Real qv_prev_, Real qv_sat_l_, Real qv_sat_i_, 
+				  Real ab_, Real abi_, Real epsr_, Real epsi_tot_, Real t_, Real t_prev_,
+				  Real latent_heat_sublim_, Real dqsdt_, Real inv_dt, Real dt,
 				  Real* qr2qv_evap_tend_, Real* nr_evap_tend_)
 {
   using P3F = Functions<Real, DefaultDevice>;
@@ -1540,12 +1542,14 @@ void evaporate_precip_f(Real qr_incld_, Real qc_incld_, Real nr_incld_, Real qi_
 
   Kokkos::parallel_for(1, KOKKOS_LAMBDA(const Int&) {
       typename P3F::Spack qr_incld(qr_incld_), qc_incld(qc_incld_), nr_incld(nr_incld_), qi_incld(qi_incld_),
-	cld_frac_l(cld_frac_l_), cld_frac_r(cld_frac_r_), qv_sat_l(qv_sat_l_), ab(ab_), epsr(epsr_), qv(qv_);
+	cld_frac_l(cld_frac_l_), cld_frac_r(cld_frac_r_), qv(qv_), qv_prev(qv_prev_), qv_sat_l(qv_sat_l_), qv_sat_i(qv_sat_i_),
+        ab(ab_), abi(abi_), epsr(epsr_), epsi_tot(epsi_tot_), t(t_), t_prev(t_prev_), latent_heat_sublim(latent_heat_sublim_),
+        dqsdt(dqsdt_);
 
       typename P3F::Spack qr2qv_evap_tend(local_qr2qv_evap_tend), nr_evap_tend(local_nr_evap_tend);
 
-      P3F::evaporate_precip(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv_sat_l, ab,
-      epsr, qv, qr2qv_evap_tend, nr_evap_tend);
+      P3F::evaporate_precip(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv, qv_prev, qv_sat_l, qv_sat_i,
+      ab, abi, epsr, epsi_tot, t, t_prev, latent_heat_sublim, dqsdt, inv_dt, dt, qr2qv_evap_tend, nr_evap_tend);
 
       t_d(0) = qr2qv_evap_tend[0];
       t_d(1) = nr_evap_tend[0];
@@ -3212,7 +3216,7 @@ void p3_main_part2_f(
   Int kts, Int kte, Int kbot, Int ktop, Int kdir, bool do_predict_nc, Real dt, Real inv_dt,
   Real* pres, Real* dpres, Real* dz, Real* nc_nuceat_tend, Real* exner, Real* inv_exner, Real* inv_cld_frac_l, Real* inv_cld_frac_i, 
   Real* inv_cld_frac_r, Real* ni_activated, Real* inv_qc_relvar, Real* cld_frac_i, Real* cld_frac_l, Real* cld_frac_r,
-  Real* t, Real* rho, Real* inv_rho, Real* qv_sat_l, Real* qv_sat_i, Real* qv_supersat_i, Real* rhofacr, Real* rhofaci, 
+  Real* qv_prev, Real* t_prev, Real* t, Real* rho, Real* inv_rho, Real* qv_sat_l, Real* qv_sat_i, Real* qv_supersat_i, Real* rhofacr, Real* rhofaci, 
   Real* acn, Real* qv, Real* th, Real* qc, Real* nc, Real* qr, Real* nr, Real* qi, Real* ni,
   Real* qm, Real* bm, Real* latent_heat_vapor, Real* latent_heat_sublim, Real* latent_heat_fusion, Real* qc_incld, Real* qr_incld, Real* qi_incld, Real* qm_incld, Real* nc_incld, Real* nr_incld,
   Real* ni_incld, Real* bm_incld, Real* mu_c, Real* nu, Real* lamc, Real* cdist, Real* cdist1, Real* cdistr, Real* mu_r, Real* lamr, Real* logn0r, Real* cmeiout, Real* precip_total_tend,
@@ -3247,7 +3251,7 @@ void p3_main_part2_f(
         qv, th, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, qc_incld, qr_incld,
         qi_incld, qm_incld, nc_incld, nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1,
         cdistr, mu_r, lamr, logn0r, cmeiout, precip_total_tend, nevapr, qr_evap_tend, vap_liq_exchange,
-        vap_ice_exchange, liq_ice_exchange, pratot, prctot
+        vap_ice_exchange, liq_ice_exchange, pratot, prctot, qv_prev, t_prev
         },
     nk, temp_d);
 
@@ -3313,7 +3317,9 @@ void p3_main_part2_f(
     vap_ice_exchange_d  (temp_d[58]),
     liq_ice_exchange_d  (temp_d[59]),
     pratot_d            (temp_d[60]),
-    prctot_d            (temp_d[61]);
+    prctot_d            (temp_d[61]),
+    qv_prev_d           (temp_d[62]),
+    t_prev_d            (temp_d[63]);
 
   // Call core function from kernel
   const auto dnu         = P3GlobalForFortran::dnu();
@@ -3328,7 +3334,7 @@ void p3_main_part2_f(
       team, nk_pack, do_predict_nc, dt, inv_dt, dnu, itab, itabcol, revap_table,
       pres_d, dpres_d, dz_d, nc_nuceat_tend_d, exner_d, inv_exner_d, inv_cld_frac_l_d,
       inv_cld_frac_i_d, inv_cld_frac_r_d, ni_activated_d, inv_qc_relvar_d, cld_frac_i_d, cld_frac_l_d, cld_frac_r_d,
-      t_d, rho_d, inv_rho_d, qv_sat_l_d, qv_sat_i_d, qv_supersat_i_d, rhofacr_d, rhofaci_d, acn_d,
+      qv_prev_d, t_prev_d, t_d, rho_d, inv_rho_d, qv_sat_l_d, qv_sat_i_d, qv_supersat_i_d, rhofacr_d, rhofaci_d, acn_d,
       qv_d, th_d, qc_d, nc_d, qr_d, nr_d, qi_d, ni_d, qm_d, bm_d,
       latent_heat_vapor_d, latent_heat_sublim_d, latent_heat_fusion_d, qc_incld_d, qr_incld_d, qi_incld_d,
       qm_incld_d, nc_incld_d, nr_incld_d, ni_incld_d, bm_incld_d,
@@ -3476,7 +3482,7 @@ void p3_main_f(
   Real* diag_effi, Real* rho_qi, bool do_predict_nc, Real* dpres, Real* exner,
   Real* cmeiout, Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend, Real* precip_liq_flux,
   Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, Real* mu_c, Real* lamc,
-  Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange)
+  Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev)
 {
   using P3F  = Functions<Real, DefaultDevice>;
 
@@ -3504,7 +3510,7 @@ void p3_main_f(
   Kokkos::Array<size_t,  P3MainData::NUM_ARRAYS> dim2_sizes;
   Kokkos::Array<const Real*, P3MainData::NUM_ARRAYS> ptr_array = {
     pres, dz, nc_nuceat_tend, ni_activated, dpres, exner, cld_frac_i, cld_frac_l, cld_frac_r, inv_qc_relvar,
-    qc, nc, qr, nr, qi, qm, ni, bm, qv, th, diag_effc, diag_effi,
+    qc, nc, qr, nr, qi, qm, ni, bm, qv, th, qv_prev, t_prev, diag_effc, diag_effi,
     rho_qi, mu_c, lamc, cmeiout, precip_total_tend, nevapr, qr_evap_tend, liq_ice_exchange,
     vap_liq_exchange, vap_ice_exchange, precip_liq_flux, precip_ice_flux, precip_liq_surf, precip_ice_surf
   };
@@ -3548,6 +3554,8 @@ void p3_main_f(
     bm_d                   (temp_d[counter++]),
     qv_d                   (temp_d[counter++]),
     th_d                   (temp_d[counter++]),
+    qv_prev_d              (temp_d[counter++]),
+    t_prev_d               (temp_d[counter++]),
     diag_effc_d            (temp_d[counter++]),
     diag_effi_d            (temp_d[counter++]),
     rho_qi_d               (temp_d[counter++]),
@@ -3580,7 +3588,7 @@ void p3_main_f(
 
   // Pack our data into structs and ship it off to p3_main.
   P3F::P3PrognosticState prog_state{qc_d, nc_d, qr_d, nr_d, qi_d, qm_d,
-                                    ni_d, bm_d, qv_d, th_d};
+                                    ni_d, bm_d, qv_d, th_d, qv_prev_d, t_prev_d};
   P3F::P3DiagnosticInputs diag_inputs{nc_nuceat_tend_d, ni_activated_d, inv_qc_relvar_d, cld_frac_i_d,
                                       cld_frac_l_d, cld_frac_r_d, pres_d, dz_d, dpres_d,
                                       exner_d};

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -663,7 +663,7 @@ void update_prognostic_ice(P3UpdatePrognosticIceData& d){
                           &d.bm,         &d.qc,    &d.nc,    &d.qr, &d.nr);
 }
 
-void evaporate_precip(EvapSublimatePrecipData& d)
+void evaporate_precip(EvapPrecipData& d)
 {
   p3_init();
   evaporate_precip_c(d.qr_incld, d.qc_incld, d.nr_incld, d.qi_incld,

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -131,7 +131,7 @@ void  update_prognostic_ice_c(
   Real rho_qm_cloud, Real* th, Real* qv, Real* qi, Real* ni, Real* qm,
   Real* bm, Real* qc, Real* nc, Real* qr, Real* nr);
 
-void evaporate_sublimate_precip_c(Real qr_incld, Real qc_incld, Real nr_incld, Real qi_incld, Real cld_frac_l,
+void evaporate_precip_c(Real qr_incld, Real qc_incld, Real nr_incld, Real qi_incld, Real cld_frac_l,
   Real cld_frac_r, Real qv_sat_l, Real ab, Real epsr, Real qv, Real* qr2qv_evap_tend, Real* nr_evap_tend);
 
 void update_prognostic_liquid_c(
@@ -661,10 +661,10 @@ void update_prognostic_ice(P3UpdatePrognosticIceData& d){
                           &d.bm,         &d.qc,    &d.nc,    &d.qr, &d.nr);
 }
 
-void evaporate_sublimate_precip(EvapSublimatePrecipData& d)
+void evaporate_precip(EvapSublimatePrecipData& d)
 {
   p3_init();
-  evaporate_sublimate_precip_c(d.qr_incld, d.qc_incld, d.nr_incld, d.qi_incld,
+  evaporate_precip_c(d.qr_incld, d.qc_incld, d.nr_incld, d.qi_incld,
 			       d.cld_frac_l, d.cld_frac_r, d.qv_sat_l, d.ab, d.epsr, d.qv,
 			       &d.qr2qv_evap_tend, &d.nr_evap_tend);
 }
@@ -1523,7 +1523,7 @@ void update_prognostic_ice_f( Real qc2qi_hetero_freeze_tend_, Real qc2qi_collect
   *nr_    = t_h(9);
 }
 
-void evaporate_sublimate_precip_f(Real qr_incld_, Real qc_incld_, Real nr_incld_, Real qi_incld_, Real cld_frac_l_,
+void evaporate_precip_f(Real qr_incld_, Real qc_incld_, Real nr_incld_, Real qi_incld_, Real cld_frac_l_,
 				  Real cld_frac_r_, Real qv_sat_l_, Real ab_, Real epsr_, Real qv_,
 				  Real* qr2qv_evap_tend_, Real* nr_evap_tend_)
 {
@@ -1541,7 +1541,7 @@ void evaporate_sublimate_precip_f(Real qr_incld_, Real qc_incld_, Real nr_incld_
 
       typename P3F::Spack qr2qv_evap_tend(local_qr2qv_evap_tend), nr_evap_tend(local_nr_evap_tend);
 
-      P3F::evaporate_sublimate_precip(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv_sat_l, ab,
+      P3F::evaporate_precip(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv_sat_l, ab,
       epsr, qv, qr2qv_evap_tend, nr_evap_tend);
 
       t_d(0) = qr2qv_evap_tend[0];

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -132,7 +132,9 @@ void  update_prognostic_ice_c(
   Real* bm, Real* qc, Real* nc, Real* qr, Real* nr);
 
 void evaporate_precip_c(Real qr_incld, Real qc_incld, Real nr_incld, Real qi_incld, Real cld_frac_l,
-  Real cld_frac_r, Real qv_sat_l, Real ab, Real epsr, Real qv, Real* qr2qv_evap_tend, Real* nr_evap_tend);
+  Real cld_frac_r, Real qv, Real qv_prev, Real qv_sat_l, Real qv_sat_i, Real ab, Real abi, Real epsr, 
+  Real epsi_tot, Real t, Real t_prev, Real latent_heat_sublim, Real dqsdt, Real inv_dt, Real dt, 
+  Real* qr2qv_evap_tend, Real* nr_evap_tend);
 
 void update_prognostic_liquid_c(
   Real qc2qr_accret_tend, Real nc_accret_tend, Real qc2qr_autoconv_tend, Real nc2nr_autoconv_tend, Real ncautr,
@@ -665,7 +667,8 @@ void evaporate_precip(EvapSublimatePrecipData& d)
 {
   p3_init();
   evaporate_precip_c(d.qr_incld, d.qc_incld, d.nr_incld, d.qi_incld,
-			       d.cld_frac_l, d.cld_frac_r, d.qv_sat_l, d.ab, d.epsr, d.qv,
+			       d.cld_frac_l, d.cld_frac_r, d.qv, d.qv_prev, d.qv_sat_l, d.qv_sat_i, d.ab, d.abi,
+                               d.epsr, d.epsi_tot, d.t, d.t_prev, d.latent_heat_sublim, d.dqsdt, d.inv_dt, d.dt,
 			       &d.qr2qv_evap_tend, &d.nr_evap_tend);
 }
 

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -802,7 +802,7 @@ Real* qi, Real* ni, Real* qm, Real* bm, Real* qc, Real* nc, Real* qr, Real* nr);
 
 ///////////////////////////////////////////////////////////////////////////////
 
-struct EvapSublimatePrecipData
+struct EvapPrecipData
 {
   // Inputs
   Real qr_incld, qc_incld, nr_incld, qi_incld, cld_frac_l, cld_frac_r, qv_sat_l, ab, epsr, qv, qv_prev, t_prev, qv_sat_i, latent_heat_sublim, inv_dt, dt, abi, t, dqsdt, epsi_tot;
@@ -811,7 +811,7 @@ struct EvapSublimatePrecipData
   Real qr2qv_evap_tend, nr_evap_tend;
 };
 
-void evaporate_precip(EvapSublimatePrecipData& d);
+void evaporate_precip(EvapPrecipData& d);
 
 extern "C"{
 

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -805,7 +805,7 @@ Real* qi, Real* ni, Real* qm, Real* bm, Real* qc, Real* nc, Real* qr, Real* nr);
 struct EvapSublimatePrecipData
 {
   // Inputs
-  Real qr_incld, qc_incld, nr_incld, qi_incld, cld_frac_l, cld_frac_r, qv_sat_l, ab, epsr, qv;
+  Real qr_incld, qc_incld, nr_incld, qi_incld, cld_frac_l, cld_frac_r, qv_sat_l, ab, epsr, qv, qv_prev, t_prev, qv_sat_i, latent_heat_sublim, inv_dt, dt, abi, t, dqsdt, epsi_tot;
 
   //Outs
   Real qr2qv_evap_tend, nr_evap_tend;

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -811,11 +811,11 @@ struct EvapSublimatePrecipData
   Real qr2qv_evap_tend, nr_evap_tend;
 };
 
-void evaporate_sublimate_precip(EvapSublimatePrecipData& d);
+void evaporate_precip(EvapSublimatePrecipData& d);
 
 extern "C"{
 
-void evaporate_sublimate_precip_f( Real qr_incld, Real qc_incld, Real nr_incld, Real qi_incld,
+void evaporate_precip_f( Real qr_incld, Real qc_incld, Real nr_incld, Real qi_incld,
 Real cld_frac_l, Real cld_frac_r, Real qv_sat_l, Real ab, Real epsr, Real qv, Real* qr2qv_evap_tend, Real* nr_evap_tend);
 }
 

--- a/components/scream/src/physics/p3/p3_ic_cases.cpp
+++ b/components/scream/src/physics/p3/p3_ic_cases.cpp
@@ -42,6 +42,8 @@ FortranData::Ptr make_mixed (const Int ncol) {
     for (k = 0; k < nk; ++k) {
       const auto tmp = -5e-4 + 1e-3/double(nk)*k;
       d.qv(i,k) = tmp > 0 ? tmp : 0;
+      const auto tmp_p = -4.9e-4 + 1e-3/double(nk)*k;
+      d.qv_prev(i,k) = tmp_p > 0 ? tmp_p : 0;
     }
     // make layer with qc saturated.
     for (k = 0; k < 15; ++k) d.qv(i,nk-20+k) = 5e-3;
@@ -68,6 +70,8 @@ FortranData::Ptr make_mixed (const Int ncol) {
     for (k = 0; k < nk; ++k) {
       T(k) = 150 + 150/double(nk)*k;
       if (i > 0) T(k) += ((i % 3) - 0.5)/double(nk)*k;
+      d.T_prev(i,k) = 145 + 150/double(nk)*k;
+      if (i > 0) d.T_prev(i,k) += ((i % 3) - 0.5)/double(nk)*k;
       d.th(i,k) = T(k)*std::pow(Real(consts::P0/d.pres(i,k)), Real(consts::RD/consts::CP));
     }
 

--- a/components/scream/src/physics/p3/p3_ic_cases.cpp
+++ b/components/scream/src/physics/p3/p3_ic_cases.cpp
@@ -47,6 +47,7 @@ FortranData::Ptr make_mixed (const Int ncol) {
     }
     // make layer with qc saturated.
     for (k = 0; k < 15; ++k) d.qv(i,nk-20+k) = 5e-3;
+    for (k = 0; k < 15; ++k) d.qv_prev(i,nk-20+k) = 4.9e-3;
 
     // pres is actually an input variable, but needed here to compute theta.
     for (k = 0; k < nk; ++k) d.pres(i,k) = 100 + 1e5/double(nk)*k;
@@ -70,8 +71,8 @@ FortranData::Ptr make_mixed (const Int ncol) {
     for (k = 0; k < nk; ++k) {
       T(k) = 150 + 150/double(nk)*k;
       if (i > 0) T(k) += ((i % 3) - 0.5)/double(nk)*k;
-      d.T_prev(i,k) = 145 + 150/double(nk)*k;
-      if (i > 0) d.T_prev(i,k) += ((i % 3) - 0.5)/double(nk)*k;
+      d.t_prev(i,k) = 145 + 150/double(nk)*k;
+      if (i > 0) d.t_prev(i,k) += ((i % 3) - 0.5)/double(nk)*k;
       d.th(i,k) = T(k)*std::pow(Real(consts::P0/d.pres(i,k)), Real(consts::RD/consts::CP));
     }
 
@@ -79,6 +80,7 @@ FortranData::Ptr make_mixed (const Int ncol) {
     // needed for code coverage.
     d.qi(i,nk-1) = 1e-9;
     d.qv(i,nk-1) = 5e-2; // also needs to be supersaturated to avoid getting set
+    d.qv_prev(i,nk-1) = 4.9e-2; // also needs to be supersaturated to avoid getting set
     // to 0 earlier.
 
     // make lowest-level qc and qr>0 to trigger surface rain and drizzle
@@ -92,9 +94,11 @@ FortranData::Ptr make_mixed (const Int ncol) {
     // make qc>0 and qr>0 where T<233.15 to test homogeneous freezing.
     d.qc(i,35) = 1e-7;
     d.qv(i,35) = 1e-6;
+    d.qv_prev(i,35) = 0.9e-6;
 
     // deposition/condensation-freezing needs t<258.15 and >5% supersat.
     d.qv(i,33) = 1e-4;
+    d.qv_prev(i,33) = 0.9e-4;
 
     // input variables.
     d.dt = 1800;

--- a/components/scream/src/physics/p3/p3_inputs_initializer.cpp
+++ b/components/scream/src/physics/p3/p3_inputs_initializer.cpp
@@ -28,6 +28,8 @@ void P3InputsInitializer::initialize_fields ()
   count += m_fields.count("pmid");
   count += m_fields.count("dp");
   count += m_fields.count("zi");
+  count += m_fields.count("qv_prev_p3");
+  count += m_fields.count("t_prev_p3");
 
   if (count==0) {
     return;
@@ -48,6 +50,8 @@ void P3InputsInitializer::initialize_fields ()
   auto d_pmid  = m_fields.at("pmid").get_view();
   auto d_dpres  = m_fields.at("dp").get_view();
   auto d_zi    = m_fields.at("zi").get_view();
+  auto d_qv_prev_p3 = m_fields.at("qv_prev_p3").get_view();
+  auto d_T_prev_p3 = m_fields.at("T_prev_p3").get_view();
 
   // Create host mirrors
   auto h_q     = Kokkos::create_mirror_view(d_q);
@@ -58,6 +62,8 @@ void P3InputsInitializer::initialize_fields ()
   auto h_pmid  = Kokkos::create_mirror_view(d_pmid);
   auto h_dpres  = Kokkos::create_mirror_view(d_dpres);
   auto h_zi    = Kokkos::create_mirror_view(d_zi);
+  auto h_qv_prev_p3    = Kokkos::create_mirror_view(d_qv_prev_p3);
+  auto h_T_prev_p3    = Kokkos::create_mirror_view(d_T_prev_p3);
 
   // Get host mirros' raw pointers
   auto q     = h_q.data();
@@ -68,9 +74,11 @@ void P3InputsInitializer::initialize_fields ()
   auto pmid  = h_pmid.data();
   auto dpres  = h_dpres.data();
   auto zi    = h_zi.data();
+  auto qv_prev_p3 = h_qv_prev_p3.data();
+  auto T_prev_p3  = h_T_prev_p3.data();
 
   // Call f90 routine
-  p3_standalone_init_f90 (q, T, zi, pmid, dpres, ast, ni_activated, nc_nuceat_tend);
+  p3_standalone_init_f90 (q, T, zi, pmid, dpres, ast, ni_activated, nc_nuceat_tend, qv_prev_p3, T_prev_p3);
 
   // Deep copy back to device
   Kokkos::deep_copy(d_q,h_q);
@@ -81,6 +89,8 @@ void P3InputsInitializer::initialize_fields ()
   Kokkos::deep_copy(d_pmid,h_pmid);
   Kokkos::deep_copy(d_dpres,h_dpres);
   Kokkos::deep_copy(d_zi,h_zi);
+  Kokkos::deep_copy(d_qv_prev_p3,h_qv_prev_p3);
+  Kokkos::deep_copy(d_T_prev_p3,h_T_prev_p3);
 
   // If we are in charge of init-ing FQ as well, init it to 0.
   if (m_fields.count("FQ")==1) {

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -534,7 +534,7 @@ void Functions<S,D>
         revap_table, rho(k), f1r, f2r, dv, mu, sc, mu_r(k), lamr(k), cdistr(k), cdist(k), qr_incld(k), qc_incld(k),
         epsr, epsc, not_skip_micro);
 
-      evaporate_sublimate_precip(
+      evaporate_precip(
         qr_incld(k), qc_incld(k), nr_incld(k), qi_incld(k), cld_frac_l(k), cld_frac_r(k), qv_sat_l(k), ab, epsr, qv(k),
         qr2qv_evap_tend, nr_evap_tend, not_skip_micro);
 

--- a/components/scream/src/physics/p3/scream_p3_interface.F90
+++ b/components/scream/src/physics/p3/scream_p3_interface.F90
@@ -57,7 +57,7 @@ contains
 
   end subroutine p3_init_f90
   !====================================================================!
-  subroutine p3_standalone_init_f90 (q,T,zi,pmid,dpres,ast,ni_activated,nc_nuceat_tend) bind(c)
+  subroutine p3_standalone_init_f90 (q,T,zi,pmid,dpres,ast,ni_activated,nc_nuceat_tend,qv_prev,T_prev) bind(c)
     use micro_p3,       only: p3_init
     use micro_p3_utils, only: micro_p3_utils_init
 
@@ -69,6 +69,8 @@ contains
     real(kind=c_real), intent(inout) :: ast(pcols,pver)      !
     real(kind=c_real), intent(inout) :: ni_activated(pcols,pver)     ! ice nucleation number
     real(kind=c_real), intent(inout) :: nc_nuceat_tend(pcols,pver)    ! liquid activation number tendency
+    real(kind=c_real), intent(inout) :: qv_prev(pcols,pver)  ! State array  kg/kg Pa
+    real(kind=c_real), intent(inout) :: T_prev(pcols,pver)        !
 
     character(len=100) :: case_title
 
@@ -94,6 +96,8 @@ contains
       read(981,'(E16.8)') zi(i,nlev+1)
     end do
     close(981)
+    qv_prev(:,:) = q(:,:,1)
+    T_prev(:,:)  = T(:,:)
 
     masterproc = .false.
     call micro_p3_utils_init(cpair,rair,rh2o,rhoh2o,mwh2o,mwdry,gravit,latvap,latice, &
@@ -101,7 +105,7 @@ contains
     print *, 'P3-Standalone-Init Finished'
   end subroutine p3_standalone_init_f90
   !====================================================================!
-  subroutine p3_main_f90 (dtime,zi,pmid,dpres,ast,ni_activated,nc_nuceat_tend,q,FQ,T) bind(c)
+  subroutine p3_main_f90 (dtime,zi,pmid,dpres,ast,ni_activated,nc_nuceat_tend,q,FQ,T,qv_prev,T_prev) bind(c)
     use micro_p3,       only: p3_main
 
 !    real, intent(in) :: q(pcols,pver,9) ! Tracer mass concentrations from SCREAM      kg/kg
@@ -115,6 +119,8 @@ contains
     real(kind=c_real), intent(in)    :: ast(pcols,pver)     ! cloud fraction
     real(kind=c_real), intent(in)    :: ni_activated(pcols,pver)    ! ice nucleation number
     real(kind=c_real), intent(in)    :: nc_nuceat_tend(pcols,pver)   ! liquid activation number tendency
+    real(kind=c_real), intent(inout) :: qv_prev(pcols,pver)   ! water vapor mass concentration from previous micro step - used for rain_evap
+    real(kind=c_real), intent(inout) :: T_prev(pcols,pver)    ! temperature from previous micro step - used for rain_evap
     !INTERNAL VARIABLES
     real(kind=c_real) :: th(pcols,pver)         !potential temperature  K
     real(kind=c_real) :: dz(pcols,pver)        !geometric layer thickness              m
@@ -127,13 +133,9 @@ contains
     real(kind=c_real) :: qm(pcols,pver)      !rime ice mixing ratio                  kg/kg
     real(kind=c_real) :: numice(pcols,pver)     !total ice crystal number concentration #/kg
     real(kind=c_real) :: rimvol(pcols,pver)     !rime volume mixing ratio               m3/kg
-    ! real(kind=c_real) :: temp(pcols,pver)       !potential temperature                  K
-    ! real(kind=c_real) :: rim(pcols,pver)        !rime mixing ratio                      kg/kg
     real(kind=c_real) :: precip_liq_surf(pcols)         !precipitation rate, liquid             m s-1
     real(kind=c_real) :: precip_ice_surf(pcols)         !precipitation rate, solid              m s-1
     real(kind=c_real) :: diag_ze(pcols,pver)    !equivalent reflectivity                dBZ
-    ! real(kind=c_real) :: diag_effc(pcols,pver)  !effective radius, cloud                m
-    ! real(kind=c_real) :: diag_effi(pcols,pver)  !effective radius, ice                  m
     real(kind=c_real) :: diag_vmi(pcols,pver)   !mass-weighted fall speed of ice        m s-1
     real(kind=c_real) :: diag_di(pcols,pver)    !mean diameter of ice                   m
     real(kind=c_real) :: rho_qi(pcols,pver)  !bulk density of ice                    kg m-1
@@ -298,6 +300,8 @@ contains
          liq_ice_exchange(its:ite,kts:kte),& ! OUT sum of liq-ice phase change tendenices
          vap_liq_exchange(its:ite,kts:kte),& ! OUT sun of vap-liq phase change tendencies
          vap_ice_exchange(its:ite,kts:kte),& ! OUT sum of vap-ice phase change tendencies
+         qv_prev(its:ite,kts:kte),         & ! IN water vapor mixing ratio from previous microphysics step
+         T_prev(its:ite,kts:kte),          & ! IN temperature from previous microphysics step
          col_location(its:ite,3)           & ! IN location of columns
          )
     do i = its,ite
@@ -315,6 +319,8 @@ contains
         q(i,k,7) = numrain(i,k)
         q(i,k,8) = qm(i,k)
         q(i,k,9) = rimvol(i,k)
+        qv_prev(i,k) = qv(i,k)
+        T_prev(i,k)  = th(i,k)/exner(icol,k)
       end do
     end do
 

--- a/components/scream/src/physics/p3/scream_p3_interface.hpp
+++ b/components/scream/src/physics/p3/scream_p3_interface.hpp
@@ -13,12 +13,12 @@ extern "C"
 // Fortran routines to be called from C
 void p3_init_f90 ();
 void p3_standalone_init_f90 (Real* q, Real* T, Real* zi, Real* pmid, Real* dpres,
-                             Real* ast, Real* ni_activated, Real* nc_nuceat_tend );
+                             Real* ast, Real* ni_activated, Real* nc_nuceat_tend, Real* qv_prev, Real* T_prev );
 void p3_main_f90 (const Real& dtime,
                   const Real* zi, const Real* pmid,
                   const Real* dpres, const Real* ast,
                   const Real* ni_activated, const Real* nc_nuceat_tend,
-                  Real* q, Real* FQ, Real* T);
+                  Real* q, Real* FQ, Real* T, Real* qv_prev, Real* T_prev);
 void p3_finalize_f90 ();
 
 } // extern "C"

--- a/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -194,6 +194,8 @@ static void run_bfb_p3_main_part2()
     std::make_pair(0, 1), // cld_frac_i
     std::make_pair(0, 1), // cld_frac_l
     std::make_pair(0, 1), // cld_frac_r
+    std::make_pair(0, 1), // qv_prev
+    std::make_pair(zerodegc - 10, zerodegc + 10), // t_prev
     std::make_pair(zerodegc - 10, zerodegc + 10), // t
     std::make_pair(0, 1), // rho
     std::make_pair(0, 1), // inv_rho
@@ -275,7 +277,7 @@ static void run_bfb_p3_main_part2()
       d.kts, d.kte, d.kbot, d.ktop, d.kdir, d.do_predict_nc, d.dt, d.inv_dt,
       d.pres, d.dpres, d.dz, d.nc_nuceat_tend, d.exner, d.inv_exner, d.inv_cld_frac_l, d.inv_cld_frac_i, 
       d.inv_cld_frac_r, d.ni_activated, d.inv_qc_relvar, d.cld_frac_i, d.cld_frac_l, d.cld_frac_r,
-      d.t, d.rho, d.inv_rho, d.qv_sat_l, d.qv_sat_i, d.qv_supersat_i, d.rhofacr, d.rhofaci, d.acn, d.qv, d.th, d.qc, d.nc, d.qr, d.nr, d.qi, d.ni,
+      d.qv_prev, d.t_prev, d.t, d.rho, d.inv_rho, d.qv_sat_l, d.qv_sat_i, d.qv_supersat_i, d.rhofacr, d.rhofaci, d.acn, d.qv, d.th, d.qc, d.nc, d.qr, d.nr, d.qi, d.ni,
       d.qm, d.bm, d.latent_heat_vapor, d.latent_heat_sublim, d.latent_heat_fusion, d.qc_incld, d.qr_incld, d.qi_incld, d.qm_incld, d.nc_incld, d.nr_incld,
       d.ni_incld, d.bm_incld, d.mu_c, d.nu, d.lamc, d.cdist, d.cdist1, d.cdistr, d.mu_r, d.lamr, d.logn0r, d.cmeiout, d.precip_total_tend,
       d.nevapr, d.qr_evap_tend, d.vap_liq_exchange, d.vap_ice_exchange, d.liq_ice_exchange, d.pratot,
@@ -297,6 +299,8 @@ static void run_bfb_p3_main_part2()
       REQUIRE(isds_fortran[i].acn[k]                == isds_cxx[i].acn[k]);
       REQUIRE(isds_fortran[i].qv[k]                 == isds_cxx[i].qv[k]);
       REQUIRE(isds_fortran[i].th[k]                 == isds_cxx[i].th[k]);
+      REQUIRE(isds_fortran[i].qv_prev[k]            == isds_cxx[i].qv_prev[k]);
+      REQUIRE(isds_fortran[i].t_prev[k]             == isds_cxx[i].t_prev[k]);
       REQUIRE(isds_fortran[i].qc[k]                 == isds_cxx[i].qc[k]);
       REQUIRE(isds_fortran[i].nc[k]                 == isds_cxx[i].nc[k]);
       REQUIRE(isds_fortran[i].qr[k]                 == isds_cxx[i].qr[k]);
@@ -453,6 +457,7 @@ static void run_bfb_p3_main_part3()
 static void run_bfb_p3_main()
 {
   constexpr Scalar qsmall     = C::QSMALL;
+  constexpr Scalar zerodegc   = C::ZeroDegC;
 
   const std::array< std::pair<Real, Real>, P3MainData::NUM_INPUT_ARRAYS > ranges = {
     std::make_pair(1.00000000E+02 , 9.87111111E+04), // pres
@@ -475,6 +480,8 @@ static void run_bfb_p3_main()
     std::make_pair(0              , 1.00000000E-02), // bm
     std::make_pair(0              , 5.00000000E-02), // qv
     std::make_pair(6.72653866E+02 , 1.07954335E+03), // th
+    std::make_pair(0              , 4.90000000E-02), // qv_prev
+    std::make_pair(zerodegc - 9, zerodegc + 9),      // t_prev
   };
 
   P3MainData isds_fortran[] = {
@@ -507,7 +514,7 @@ static void run_bfb_p3_main()
       d.precip_ice_surf, d.its, d.ite, d.kts, d.kte, d.diag_effc, d.diag_effi,
       d.rho_qi, d.do_predict_nc, d.dpres, d.exner, d.cmeiout, d.precip_total_tend,
       d.nevapr, d.qr_evap_tend, d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i, d.mu_c,
-      d.lamc, d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange);
+      d.lamc, d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange,d.qv_prev,d.t_prev);
     d.transpose<util::TransposeDirection::f2c>();
   }
 
@@ -523,6 +530,8 @@ static void run_bfb_p3_main()
       REQUIRE(isds_fortran[i].bm[t]                == isds_cxx[i].bm[t]);
       REQUIRE(isds_fortran[i].qv[t]                == isds_cxx[i].qv[t]);
       REQUIRE(isds_fortran[i].th[t]                == isds_cxx[i].th[t]);
+      REQUIRE(isds_fortran[i].qv_prev[t]           == isds_cxx[i].qv_prev[t]);
+      REQUIRE(isds_fortran[i].t_prev[t]            == isds_cxx[i].t_prev[t]);
       REQUIRE(isds_fortran[i].diag_effc[t]         == isds_cxx[i].diag_effc[t]);
       REQUIRE(isds_fortran[i].diag_effi[t]         == isds_cxx[i].diag_effi[t]);
       REQUIRE(isds_fortran[i].rho_qi[t]            == isds_cxx[i].rho_qi[t]);

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 36);
+  REQUIRE(fdi.nfield() == 38);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);

--- a/components/scream/src/physics/p3/tests/p3_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_unit_tests.cpp
@@ -813,7 +813,7 @@ struct UnitWrap::UnitTest<D>::TestGetTimeSpacePhysVariables
 template <typename D>
 struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
 {
-  static void evaporate_sublimate_precip_unit_bfb_tests(){
+  static void evaporate_precip_unit_bfb_tests(){
 
     //fortran generated data is input to the following
     //This subroutine has 12 args, only 10 are supplied here for invoking it as last 2 are intent-outs
@@ -846,7 +846,7 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
 
     // Get data from fortran
     for (Int i = 0; i < max_pack_size; ++i) {
-      evaporate_sublimate_precip(espd[i]);
+      evaporate_precip(espd[i]);
     }
 
     // Run the lookup from a kernel and copy results back to host
@@ -871,7 +871,7 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
         nr_evap_tend[s]       = espd_device(vs).nr_evap_tend;
       }
 
-      Functions::evaporate_sublimate_precip(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv_sat_l, ab,
+      Functions::evaporate_precip(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv_sat_l, ab,
                                             epsr, qv, qr2qv_evap_tend, nr_evap_tend);
 
       // Copy results back into views
@@ -902,7 +902,7 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
   }
 
   static void run_bfb(){
-    evaporate_sublimate_precip_unit_bfb_tests();
+    evaporate_precip_unit_bfb_tests();
   }
 
 }; //TestEvapSublPrecip
@@ -1282,7 +1282,7 @@ TEST_CASE("p3_update_prognostic_liquid_test", "[p3_unit_tests]"){
   scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3UpdatePrognosticLiq::run_bfb();
 }
 
-TEST_CASE("p3_evaporate_sublimate_precip_test", "[p3_unit_tests]"){
+TEST_CASE("p3_evaporate_precip_test", "[p3_unit_tests]"){
   scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestEvapSublPrecip::run_bfb();
 }
 

--- a/components/scream/src/physics/p3/tests/p3_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_unit_tests.cpp
@@ -817,7 +817,7 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
 
     //fortran generated data is input to the following
     //This subroutine has 12 args, only 10 are supplied here for invoking it as last 2 are intent-outs
-    EvapSublimatePrecipData espd[max_pack_size] = {
+    EvapPrecipData espd[max_pack_size] = {
       {1.0010E-06,1.0000E-06,6.3726E+05,0.0000E+00,1.0000E+00,1.0000E+00,2.0321E-02,4.0889E+00,1.0080E-03,5.0000E-02},
       {5.2632E-07,0.0000E+00,3.3506E+05,0.0000E+00,1.0000E+00,1.0000E+00,1.8120E-02,3.7933E+00,5.2700E-04,4.7222E-04},
       {1.0526E-06,0.0000E+00,6.7013E+05,0.0000E+00,1.0000E+00,1.0000E+00,1.6134E-02,3.5224E+00,1.0480E-03,4.5833E-04},
@@ -837,7 +837,7 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
     };
 
     // Sync to device
-    view_1d<EvapSublimatePrecipData> espd_device("espd", max_pack_size);
+    view_1d<EvapPrecipData> espd_device("espd", max_pack_size);
     auto espd_host = Kokkos::create_mirror_view(espd_device);
 
     // This copy only copies the input variables.

--- a/components/scream/src/physics/p3/tests/p3_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_unit_tests.cpp
@@ -816,24 +816,27 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
   static void evaporate_precip_unit_bfb_tests(){
 
     //fortran generated data is input to the following
-    //This subroutine has 12 args, only 10 are supplied here for invoking it as last 2 are intent-outs
+    //This subroutine has 22 args, only 20 are supplied here for invoking it as last 2 are intent-outs
     EvapPrecipData espd[max_pack_size] = {
-      {1.0010E-06,1.0000E-06,6.3726E+05,0.0000E+00,1.0000E+00,1.0000E+00,2.0321E-02,4.0889E+00,1.0080E-03,5.0000E-02},
-      {5.2632E-07,0.0000E+00,3.3506E+05,0.0000E+00,1.0000E+00,1.0000E+00,1.8120E-02,3.7933E+00,5.2700E-04,4.7222E-04},
-      {1.0526E-06,0.0000E+00,6.7013E+05,0.0000E+00,1.0000E+00,1.0000E+00,1.6134E-02,3.5224E+00,1.0480E-03,4.5833E-04},
-      {1.5789E-06,0.0000E+00,1.0000E+06,0.0000E+00,1.0000E+00,1.0000E+00,1.4342E-02,3.2745E+00,1.5575E-03,4.4444E-04},
-      {2.1053E-06,0.0000E+00,1.0000E+06,0.0000E+00,1.0000E+00,1.0000E+00,1.2729E-02,3.0478E+00,1.7094E-03,4.3056E-04},
-      {9.3221E-07,9.8393E-07,5.9346E+05,0.0000E+00,1.0000E+00,1.0000E+00,2.0948E-02,4.1736E+00,9.3997E-04,5.0000E-02},
-      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,9.9759E-03,2.6520E+00,6.7694E-02,5.0000E-03},
-      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,8.8076E-03,2.4801E+00,6.7248E-02,5.0000E-03},
-      {5.8084E-05,0.0000E+00,8.6199E+05,0.0000E+00,1.0000E+00,1.0000E+00,1.3928E-02,3.2192E+00,5.3678E-03,4.3266E-04},
-      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,6.8265E-03,2.1817E+00,6.6348E-02,5.0000E-03},
-      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,5.9921E-03,2.0529E+00,6.5893E-02,5.0000E-03},
-      {0.0000E+00,0.0000E+00,1.0000E-16,1.1762E-03,1.0000E+00,1.0000E+00,4.6974E-03,1.8502E+00,0.0000E+00,4.6667E-03},
-      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,4.5879E-03,1.8310E+00,6.4975E-02,5.0000E-03},
-      {9.3232E-07,9.8402E-07,5.9353E+05,0.0000E+00,1.0000E+00,1.0000E+00,2.2254E-02,4.3493E+00,9.4247E-04,5.0000E-02},
-      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,3.4821E-03,1.6504E+00,6.4044E-02,5.0000E-03},
-      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,3.0231E-03,1.5735E+00,6.3574E-02,5.0000E-03},
+      // AaronDonahue - I put in some dummy values for the test but I'm not sure they are good representations.  Someone should check
+      // these.  We can delete the following line before merging.  But it does help guide the initial condition setup.
+      // qr          qc          nr        qi        cld_l     cld_r      qv          qv_prev      qv_sat_l    qv_sat_i     ab         abi          epsr   epsi_tot    t      t_prev  latent_sub    dqsdt  inv_dt    dt
+      {1.0010E-06,1.0000E-06,6.3726E+05,0.0000E+00,1.0000E+00,1.0000E+00,5.0000E-02,0.9*5.0000E-02,2.0321E-02,2.0321E-02,4.0889E+00,4.0889E+00,1.0080E-03,1.0080E-03,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {5.2632E-07,0.0000E+00,3.3506E+05,0.0000E+00,1.0000E+00,1.0000E+00,4.7222E-04,0.9*4.7222E-04,1.8120E-02,1.8120E-02,3.7933E+00,3.7933E+00,5.2700E-04,5.2700E-04,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {1.0526E-06,0.0000E+00,6.7013E+05,0.0000E+00,1.0000E+00,1.0000E+00,4.5833E-04,0.9*4.5833E-04,1.6134E-02,1.6134E-02,3.5224E+00,3.5224E+00,1.0480E-03,1.0480E-03,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {1.5789E-06,0.0000E+00,1.0000E+06,0.0000E+00,1.0000E+00,1.0000E+00,4.4444E-04,0.9*4.4444E-04,1.4342E-02,1.4342E-02,3.2745E+00,3.2745E+00,1.5575E-03,1.5575E-03,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {2.1053E-06,0.0000E+00,1.0000E+06,0.0000E+00,1.0000E+00,1.0000E+00,4.3056E-04,0.9*4.3056E-04,1.2729E-02,1.2729E-02,3.0478E+00,3.0478E+00,1.7094E-03,1.7094E-03,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {9.3221E-07,9.8393E-07,5.9346E+05,0.0000E+00,1.0000E+00,1.0000E+00,5.0000E-02,0.9*5.0000E-02,2.0948E-02,2.0948E-02,4.1736E+00,4.1736E+00,9.3997E-04,9.3997E-04,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,5.0000E-03,0.9*5.0000E-03,9.9759E-03,9.9759E-03,2.6520E+00,2.6520E+00,6.7694E-02,6.7694E-02,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,5.0000E-03,0.9*5.0000E-03,8.8076E-03,8.8076E-03,2.4801E+00,2.4801E+00,6.7248E-02,6.7248E-02,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {5.8084E-05,0.0000E+00,8.6199E+05,0.0000E+00,1.0000E+00,1.0000E+00,4.3266E-04,0.9*4.3266E-04,1.3928E-02,1.3928E-02,3.2192E+00,3.2192E+00,5.3678E-03,5.3678E-03,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,5.0000E-03,0.9*5.0000E-03,6.8265E-03,6.8265E-03,2.1817E+00,2.1817E+00,6.6348E-02,6.6348E-02,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,5.0000E-03,0.9*5.0000E-03,5.9921E-03,5.9921E-03,2.0529E+00,2.0529E+00,6.5893E-02,6.5893E-02,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {0.0000E+00,0.0000E+00,1.0000E-16,1.1762E-03,1.0000E+00,1.0000E+00,4.6667E-03,0.9*4.6667E-03,4.6974E-03,4.6974E-03,1.8502E+00,1.8502E+00,0.0000E+00,0.0000E+00,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,5.0000E-03,0.9*5.0000E-03,4.5879E-03,4.5879E-03,1.8310E+00,1.8310E+00,6.4975E-02,6.4975E-02,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {9.3232E-07,9.8402E-07,5.9353E+05,0.0000E+00,1.0000E+00,1.0000E+00,5.0000E-02,0.9*5.0000E-02,2.2254E-02,2.2254E-02,4.3493E+00,4.3493E+00,9.4247E-04,9.4247E-04,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,5.0000E-03,0.9*5.0000E-03,3.4821E-03,3.4821E-03,1.6504E+00,1.6504E+00,6.4044E-02,6.4044E-02,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
+      {1.0000E-02,5.1000E-03,1.0000E+06,5.1000E-03,1.0000E+00,1.0000E+00,5.0000E-03,0.9*5.0000E-03,3.0231E-03,3.0231E-03,1.5735E+00,1.5735E+00,6.3574E-02,6.3574E-02,313e+00,314e+00,2834700E+00,7.908E-01,3.3E-03,300E+00},
     };
 
     // Sync to device
@@ -853,8 +856,15 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
     Kokkos::parallel_for(RangePolicy(0, num_test_itrs), KOKKOS_LAMBDA(const Int& i) {
       const Int offset = i * Spack::n;
 
+      Scalar dt;
+      Scalar inv_dt;
+
+      // variables with single values assigned outside of the for loop
+      dt            = espd_device(0).dt;
+      inv_dt        = espd_device(0).inv_dt;
       // Init pack inputs
-      Spack qr_incld, qc_incld, nr_incld, qi_incld, cld_frac_l, cld_frac_r, qv_sat_l, ab, epsr, qv, qr2qv_evap_tend, nr_evap_tend;
+      Spack qr_incld, qc_incld, nr_incld, qi_incld, cld_frac_l, cld_frac_r, qv, qv_prev, qv_sat_l, qv_sat_i, 
+          ab, abi, epsr, epsi_tot, t, t_prev, latent_heat_sublim, dqsdt, qr2qv_evap_tend, nr_evap_tend;
 
       for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {
         qr_incld[s]    = espd_device(vs).qr_incld;
@@ -863,18 +873,29 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
         qi_incld[s] = espd_device(vs).qi_incld;
         cld_frac_l[s]       = espd_device(vs).cld_frac_l;
         cld_frac_r[s]       = espd_device(vs).cld_frac_r;
-        qv_sat_l[s]         = espd_device(vs).qv_sat_l;
-        ab[s]          = espd_device(vs).ab;
-        epsr[s]        = espd_device(vs).epsr;
         qv[s]          = espd_device(vs).qv;
+        qv_prev[s]     = espd_device(vs).qv_prev;
+        qv_sat_l[s]         = espd_device(vs).qv_sat_l;
+        qv_sat_i[s]         = espd_device(vs).qv_sat_i;
+        ab[s]          = espd_device(vs).ab;
+        abi[s]         = espd_device(vs).abi;
+        epsr[s]        = espd_device(vs).epsr;
+        epsi_tot[s]    = espd_device(vs).epsi_tot;
+        t[s]           = espd_device(vs).t;
+        t_prev[s]      = espd_device(vs).t_prev;
+        latent_heat_sublim[s] = espd_device(vs).latent_heat_sublim;
+        dqsdt[s]       = espd_device(vs).dqsdt;
         qr2qv_evap_tend[s]       = espd_device(vs).qr2qv_evap_tend;
         nr_evap_tend[s]       = espd_device(vs).nr_evap_tend;
       }
 
-      Functions::evaporate_precip(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv_sat_l, ab,
-                                            epsr, qv, qr2qv_evap_tend, nr_evap_tend);
+      Functions::evaporate_precip(qr_incld, qc_incld, nr_incld, qi_incld,  cld_frac_l, cld_frac_r, qv, qv_prev, qv_sat_l, qv_sat_i, 
+                                            ab, abi, epsr, epsi_tot, t, t_prev, latent_heat_sublim, dqsdt, inv_dt, dt, 
+                                            qr2qv_evap_tend, nr_evap_tend);
 
       // Copy results back into views
+      espd_device(0).dt            = dt;
+      espd_device(0).inv_dt        = inv_dt;
       for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {
         espd_device(vs).qr_incld    = qr_incld[s];
         espd_device(vs).qc_incld    = qc_incld[s];
@@ -882,10 +903,18 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
         espd_device(vs).qi_incld = qi_incld[s];
         espd_device(vs).cld_frac_l       = cld_frac_l[s];
         espd_device(vs).cld_frac_r       = cld_frac_r[s];
-        espd_device(vs).qv_sat_l         = qv_sat_l[s];
-        espd_device(vs).ab          = ab[s];
-        espd_device(vs).epsr        = epsr[s];
         espd_device(vs).qv          = qv[s];
+        espd_device(vs).qv_prev     = qv_prev[s];
+        espd_device(vs).qv_sat_l         = qv_sat_l[s];
+        espd_device(vs).qv_sat_i         = qv_sat_i[s];
+        espd_device(vs).ab          = ab[s];
+        espd_device(vs).abi          = abi[s];
+        espd_device(vs).epsr        = epsr[s];
+        espd_device(vs).epsi_tot    = epsi_tot[s];
+        espd_device(vs).t           = t[s];
+        espd_device(vs).t_prev      = t_prev[s];
+        espd_device(vs).latent_heat_sublim = latent_heat_sublim[s];
+        espd_device(vs).dqsdt        = dqsdt[s];
         espd_device(vs).qr2qv_evap_tend       = qr2qv_evap_tend[s];
         espd_device(vs).nr_evap_tend       = nr_evap_tend[s];
       }


### PR DESCRIPTION
The current rain evaporation scheme produces very large evaporation rates when the time-step of the model is on the order of hundreds of seconds, causing the model to crash. Replacing the rain evaporation scheme makes the model more stable by limiting the amount of rain evaporation that occurs. 
There are three distinct changes from the original rain evaporation:
* using grid box-mean qv instead of qclr to calculate the saturation deficit. 
* using a semi-analytic formulation that takes into account adjustments to qv to rain evaporation within the p3 time step. 
* taking into account temperature and qv tendencies outside of p3 to balance the rain evaporation in setting the saturation. 

The main differences compared to the WRF-P3 version are 
* the exclusion of epsc in the calculating the timescale of evaporation and 
* limiting evaporation to only occur in non-cloudy, rainy portions of the grid box and not all rainy portions. 