### PR TITLE
Cleanup diag second mom srf conversion a bit

### DIFF
--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -137,18 +137,25 @@ void SHOCDataBase::init_ptrs()
   }
 }
 
-void SHOCDataBase::randomize()
+void SHOCDataBase::randomize(const std::vector<std::pair<Real, Real> >& ranges,
+                             const std::vector<std::pair<Real, Real> >& ranges_i)
 {
   std::default_random_engine generator;
-  std::uniform_real_distribution<Real> data_dist(0.0, 1.0);
 
+  scream_assert_msg(ranges.size() <= m_ptrs.size(), "Provided more ranges than data items");
   for (size_t i = 0; i < m_ptrs.size(); ++i) {
+    std::uniform_real_distribution<Real> data_dist(i < ranges.size() ? ranges[i].first : 0.0,
+                                                   i < ranges.size() ? ranges[i].second : 1.0);
     for (size_t j = 0; j < m_total; ++j) {
       (*(m_ptrs[i]))[j] = data_dist(generator);
     }
   }
 
+  scream_assert_msg(ranges_i.size() <= m_ptrs_i.size(), "Provided more ranges than data items");
   for (size_t i = 0; i < m_ptrs_i.size(); ++i) {
+    std::uniform_real_distribution<Real> data_dist(i < ranges_i.size() ? ranges_i[i].first : 0.0,
+                                                   i < ranges_i.size() ? ranges_i[i].second : 1.0);
+
     for (size_t j = 0; j < m_totali; ++j) {
       (*(m_ptrs_i[i]))[j] = data_dist(generator);
     }

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -46,7 +46,8 @@ struct SHOCDataBase
     m_data = data;
   }
 
-  void randomize();
+  void randomize(const std::vector<std::pair<Real, Real> >& ranges = {},
+                 const std::vector<std::pair<Real, Real> >& ranges_i = {});
 
   Int total() const { return m_total; }
   Int totali() const { return m_totali; }
@@ -294,7 +295,7 @@ struct SHOCSecondMomentSrfData : public SHOCDataBase {
   SHOCDataBase(shcol_, 1, 1, {&wthl, &uw, &vw, &ustar2, &wstar}, {}) {}
   SHOCSecondMomentSrfData(const SHOCSecondMomentSrfData &rhs) : SHOCDataBase(rhs, {&wthl, &uw, &vw, &ustar2, &wstar}, {}) {}
   SHOCSecondMomentSrfData &operator=(const SHOCSecondMomentSrfData &rhs) { SHOCDataBase::operator=(rhs); return *this; }
-}; 
+};
 
 //
 // Glue functions to call fortran from from C++ with the Data struct
@@ -327,7 +328,7 @@ extern "C" {
 
 void calc_shoc_vertflux_f(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
 			  Real *dz_zi, Real *invar, Real *vertflux);
-void shoc_diag_second_moments_srf_f(Int shcol, Real* wthl, Real* uw, Real* vw, 
+void shoc_diag_second_moments_srf_f(Int shcol, Real* wthl, Real* uw, Real* vw,
                          Real* ustar2, Real* wstar);
 
 }

--- a/components/scream/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
@@ -33,11 +33,11 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
     // Tests for the SHOC function:
     //   compute_brunt_shoc_length
 
-    // Test for the Brunt Vaissalla frequency.  
+    // Test for the Brunt Vaissalla frequency.
     // Note that input temperature profiles are selected
     //  deliberately so that it includes a well mixed layer,
     //  an unstable layer, and a conditionally unstable layer
-    //  to test a range of conditions.  
+    //  to test a range of conditions.
 
     // Grid difference centered on thermo grid [m]
     static constexpr Real dz_zt[nlev] = {100.0, 75.0, 50.0, 25.0, 10.0};
@@ -57,9 +57,9 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
         const auto offset = n + s * SDS.nlev;
 
         SDS.dz_zt[offset] = dz_zt[n];
-        // For theta_v on thermo grid just take the vertical average 
+        // For theta_v on thermo grid just take the vertical average
         //  of thv_zi for this simple test.  Just used as a reference
-        //  in this subroutine.  
+        //  in this subroutine.
         SDS.thv[offset] = 0.5*(thv_zi[n]+thv_zi[n+1]);
       }
 
@@ -90,31 +90,31 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
     compute_brunt_shoc_length(SDS);
 
     // Check the results
-    for(Int s = 0; s < SDS.shcol; ++s) {   
+    for(Int s = 0; s < SDS.shcol; ++s) {
       for(Int n = 0; n < SDS.nlev; ++n) {
         const auto offset = n + s * SDS.nlev;
-      
+
         // Validate that brunt vaisalla frequency
         //  is the correct sign given atmospheric conditions
-      
+
         // well mixed layer
         if (thv_zi[n] - thv_zi[n+1] == 0.0){
           REQUIRE(SDS.brunt[offset] == 0.0);
         }
-        // unstable layer 
+        // unstable layer
         if (thv_zi[n] - thv_zi[n+1] < 0.0){
           REQUIRE(SDS.brunt[offset] < 0.0);
-        }  
+        }
         // stable layer
         if (thv_zi[n] - thv_zi[n+1] > 0.0){
           REQUIRE(SDS.brunt[offset] > 0.0);
         }
-      
-        // Validate that values fall within some 
-        //  reasonable bounds for this variable.  
+
+        // Validate that values fall within some
+        //  reasonable bounds for this variable.
         REQUIRE(SDS.brunt[offset < 1.0]);
         REQUIRE(SDS.brunt[offset > -1.0]);
-      
+
       }
     }
   }
@@ -126,18 +126,18 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
 }  // namespace scream
 
 namespace{
-  
+
 TEST_CASE("shoc_brunt_length_property", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCompBruntShocLength;
-  
+
   TestStruct::run_property();
 }
 
 TEST_CASE("shoc_brunt_length_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCompBruntShocLength;
-  
+
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_diag_second_mom_srf_test.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_second_mom_srf_test.cpp
@@ -28,19 +28,18 @@ struct UnitWrap::UnitTest<D>::TestSecondMomSrf {
 static void run_second_mom_srf_bfb()
 {
   SHOCSecondMomentSrfData mom_srf_data_f90[] = {
-    //               shcol
+    //                      shcol
     SHOCSecondMomentSrfData(36),
     SHOCSecondMomentSrfData(72),
     SHOCSecondMomentSrfData(128),
     SHOCSecondMomentSrfData(256),
   };
-    
+
   static constexpr Int num_runs = sizeof(mom_srf_data_f90) / sizeof(SHOCSecondMomentSrfData);
 
   for (Int i = 0; i < num_runs; ++i) {
-    mom_srf_data_f90[i].randomize();
+    mom_srf_data_f90[i].randomize({ {-1, 1} });
   }
-
 
   SHOCSecondMomentSrfData mom_srf_data_cxx[] = {
     SHOCSecondMomentSrfData(mom_srf_data_f90[0]),
@@ -51,15 +50,13 @@ static void run_second_mom_srf_bfb()
 
   for (Int i = 0; i < num_runs; ++i) {
     // expects data in C layout
-    shoc_diag_second_moments_srf(mom_srf_data_f90[i]);     
+    shoc_diag_second_moments_srf(mom_srf_data_f90[i]);
   }
-
 
   for (Int i = 0; i < num_runs; ++i) {
     SHOCSecondMomentSrfData& d = mom_srf_data_cxx[i];
     shoc_diag_second_moments_srf_f(d.shcol, d.wthl, d.uw, d.vw, d.ustar2, d.wstar);
   }
-
 
   for (Int i = 0; i < num_runs; ++i) {
     Int shcol = mom_srf_data_cxx[i].shcol;
@@ -72,18 +69,27 @@ static void run_second_mom_srf_bfb()
 
 static void run_second_mom_srf_phys()
 {
-    // TODO
-}
-};
-}
-}
+  // TODO
 }
 
+};
+
+} // namespace unit_test
+} // namespace shoc
+} // namespace scream
+
 namespace {
-TEST_CASE("shoc_second_moments_srf", "shoc") {
+
+TEST_CASE("shoc_second_moments_srf_property", "shoc") {
   using TRS = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestSecondMomSrf;
 
   TRS::run_second_mom_srf_phys();
+}
+
+TEST_CASE("shoc_second_moments_srf_bfb", "shoc") {
+  using TRS = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestSecondMomSrf;
+
   TRS::run_second_mom_srf_bfb();
 }
+
 }


### PR DESCRIPTION
We need negative numbers in the wthl input to fully exercise
the function. This means we needed a way to have customized ranges
of random values, not just 0..1, which is now supported in
SHOCDataBase::randomize().

Minor whitespace cleanup.

Have different names for property and bfb tests.