### PR TITLE
Add macro to set number of vertical levels

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -110,6 +110,7 @@ set(DEFAULT_LIB_ONLY FALSE)
 if (CIME_BUILD)
   set(DEFAULT_LIB_ONLY TRUE)
 endif()
+set(DEFAULT_NUM_VERTICAL_LEV 72)
 
 set(SCREAM_MIMIC_GPU ${DEFAULT_MIMIC_GPU} CACHE BOOL "Mimic GPU to correctness-test inter-column parallelism on non-GPU platform")
 set(SCREAM_PACK_CHECK_BOUNDS FALSE CACHE BOOL "If defined, scream::pack objects check indices against bounds")
@@ -122,6 +123,11 @@ set(SCREAM_LIB_ONLY ${DEFAULT_LIB_ONLY} CACHE BOOL "Only build libraries, no exe
 # of building only baseline-related execs. By default, this option is off (menaing "build everything).
 # However, when generating baselines, this can be useful to reduce the amount of stuff compiled.
 set(SCREAM_BASELINES_ONLY FALSE CACHE BOOL "Whether building only baselines-related executables")
+
+# Set number of vertical levels
+set(SCREAM_NUM_VERTICAL_LEV ${DEFAULT_NUM_VERTICAL_LEV} CACHE STRING
+    "The number of levels used in the vertical grid."
+)
 
 ## Work out pack sizes.
 # Determine the master pack size.
@@ -203,6 +209,7 @@ print_var(CUDA_BUILD)
 print_var(SCREAM_DOUBLE_PRECISION)
 print_var(SCREAM_MIMIC_GPU)
 print_var(SCREAM_FPE)
+print_var(SCREAM_NUM_VERTICAL_LEV)
 print_var(SCREAM_PACK_SIZE)
 print_var(SCREAM_SMALL_PACK_SIZE)
 print_var(SCREAM_POSSIBLY_NO_PACK_SIZE)

--- a/components/scream/cime_config/config_component.xml
+++ b/components/scream/cime_config/config_component.xml
@@ -27,7 +27,7 @@
     <valid_values></valid_values>
     <default_value></default_value>
     <values modifier='additive'>
-      <value compset="_SCREAM">SCREAM_NP 4 SCREAM_NUM_LEV 128 SCREAM_NUM_TRACERS 10</value>
+      <value compset="_SCREAM">SCREAM_NP 4 SCREAM_NUM_VERTICAL_LEV 128 SCREAM_NUM_TRACERS 10</value>
     </values>
     <group>build_component_scream</group>
     <file>env_build.xml</file>

--- a/components/scream/src/mct_coupling/CMakeLists.txt
+++ b/components/scream/src/mct_coupling/CMakeLists.txt
@@ -19,7 +19,6 @@ if ("${SCREAM_DYNAMICS_DYCORE}" STREQUAL "HOMME")
   # We set them to a default, but each compset should set its values anyways.
   set (SCREAM_DYN_TARGET none CACHE STRING "The name of the desired Homme target.")
   set (SCREAM_NP 4 CACHE STRING "The number of Gauss points per element.")
-  set (SCREAM_NUM_VERTICAL_LEV FALSE CACHE STRING "The number of vertical levels.")
   set (SCREAM_NUM_TRACERS 4 CACHE STRING "The max number of tracers.")
   set (SCREAM_USE_PIO FALSE CACHE STRING "Whether Homme can use PIO.")
   set (SCREAM_USE_ENERGY FALSE CACHE STRING "Whether Homme has extra energy checks.")

--- a/components/scream/src/mct_coupling/CMakeLists.txt
+++ b/components/scream/src/mct_coupling/CMakeLists.txt
@@ -19,13 +19,13 @@ if ("${SCREAM_DYNAMICS_DYCORE}" STREQUAL "HOMME")
   # We set them to a default, but each compset should set its values anyways.
   set (SCREAM_DYN_TARGET none CACHE STRING "The name of the desired Homme target.")
   set (SCREAM_NP 4 CACHE STRING "The number of Gauss points per element.")
-  set (SCREAM_NUM_LEV FALSE CACHE STRING "The number of vertical levels.")
+  set (SCREAM_NUM_VERTICAL_LEV FALSE CACHE STRING "The number of vertical levels.")
   set (SCREAM_NUM_TRACERS 4 CACHE STRING "The max number of tracers.")
   set (SCREAM_USE_PIO FALSE CACHE STRING "Whether Homme can use PIO.")
   set (SCREAM_USE_ENERGY FALSE CACHE STRING "Whether Homme has extra energy checks.")
 
   add_definitions(-DHOMME_WITHOUT_PIOLIBRARY)
-  CreateDynamicsLib (${SCREAM_DYN_TARGET} ${SCREAM_NP} ${SCREAM_NUM_LEV} ${SCREAM_NUM_TRACERS} ${SCREAM_USE_PIO} ${SCREAM_USE_ENERGY})
+  CreateDynamicsLib (${SCREAM_DYN_TARGET} ${SCREAM_NP} ${SCREAM_NUM_VERTICAL_LEV} ${SCREAM_NUM_TRACERS} ${SCREAM_USE_PIO} ${SCREAM_USE_ENERGY})
 
   target_include_directories (
     ${dynLibName}

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -37,7 +37,7 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   auto Q = kg/kg;
   Q.set_string("kg/kg");
 
-  constexpr int NVL = 72;  /* TODO THIS NEEDS TO BE CHANGED TO A CONFIGURABLE */
+  constexpr int NVL = SCREAM_NUM_VERTICAL_LEV;
   constexpr int QSZ =  35;  /* TODO THIS NEEDS TO BE CHANGED TO A CONFIGURABLE */
 
   const auto& grid_name = m_p3_params.get<std::string>("Grid");

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -24,7 +24,7 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   auto Q = kg/kg;
   Q.set_string("kg/kg");
 
-  constexpr int NVL = 72;  /* TODO THIS NEEDS TO BE CHANGED TO A CONFIGURABLE */
+  constexpr int NVL = SCREAM_NUM_VERTICAL_LEV;
   constexpr int QSZ =  35;  /* TODO THIS NEEDS TO BE CHANGED TO A CONFIGURABLE */
 
   auto grid = grids_manager->get_grid("Physics");

--- a/components/scream/src/scream_config.h.in
+++ b/components/scream/src/scream_config.h.in
@@ -19,6 +19,9 @@
 // The number of scalars in a possibly-no-pack. Use this packsize when a routine does better with pksize=1 on some architectures (SKX).
 #cmakedefine SCREAM_POSSIBLY_NO_PACK_SIZE ${SCREAM_POSSIBLY_NO_PACK_SIZE}
 
+// How many levels to use for the vertical grid
+#cmakedefine SCREAM_NUM_VERTICAL_LEV ${SCREAM_NUM_VERTICAL_LEV}
+
 // Whether MPI errors should abort
 #cmakedefine SCREAM_MPI_ERRORS_ARE_FATAL
 


### PR DESCRIPTION
Add a macro (`SCREAM_NUM_VERTICAL_LEV`) to specify the number of vertical levels. This is set in scream_config.h.in, and is configurable via cmake (set by default to 72 in components/scream/CMakeLists.txt). This removes the hard-coded value of 72 from the microphysics and macrophysics codes.

[B4B]