### PR TITLE
porting diag_second_moments_ubycond

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -991,7 +991,7 @@ subroutine diag_second_shoc_moments(&
   ! Diagnose the second order moments,
   !  calculate the upper boundary conditions
   call diag_second_moments_ubycond(&
-     shcol,num_tracer, &                    ! Input
+     shcol,                              &  ! Input
      thl_sec(:shcol,1), qw_sec(:shcol,1),&  ! Output
      wthl_sec(:shcol,1),wqw_sec(:shcol,1),& ! Output
      qwthl_sec(:shcol,1), uw_sec(:shcol,1),&! Output
@@ -1417,7 +1417,7 @@ subroutine calc_shoc_vertflux(&
 end subroutine calc_shoc_vertflux
 
 subroutine diag_second_moments_ubycond(&
-         shcol,num_tracer, &                    ! Input
+         shcol, &                               ! Input
          thl_sec, qw_sec,&                      ! Output
          wthl_sec,wqw_sec,&                     ! Output
          qwthl_sec, uw_sec, vw_sec, wtke_sec)   ! Output
@@ -1427,13 +1427,14 @@ subroutine diag_second_moments_ubycond(&
   !  needed for the SHOC parameterization.  Currently
   !  set all to zero.
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    use shoc_iso_f, only: shoc_diag_second_moments_ubycond_f
+#endif
   implicit none
 
   ! INPUT VARIABLES
   ! number of SHOC columns
   integer, intent(in) :: shcol
-  ! number of tracers
-  integer, intent(in) :: num_tracer
 
   ! OUTPUT VARIABLES
   ! second order liquid wat. potential temp. [K^2]
@@ -1455,6 +1456,17 @@ subroutine diag_second_moments_ubycond(&
 
   ! LOCAL VARIABLES
   integer :: i
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+   if (use_cxx) then
+       call shoc_diag_second_moments_ubycond_f(&
+                             shcol, &                    ! Input
+                             thl_sec, qw_sec,&                      ! Output
+                             wthl_sec,wqw_sec,&                     ! Output
+                             qwthl_sec, uw_sec, vw_sec, wtke_sec)   ! Output
+      return
+   endif
+#endif
 
   ! apply the upper boundary condition
   do i=1,shcol

--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SHOC_SRCS
   atmosphere_macrophysics.cpp
   scream_shoc_interface.F90
   shoc_diag_second_moments_srf.cpp
+  shoc_diag_second_moments_ubycond.cpp
 )
 
 set(SHOC_HEADERS

--- a/components/scream/src/physics/shoc/shoc_diag_second_moments_ubycond.cpp
+++ b/components/scream/src/physics/shoc/shoc_diag_second_moments_ubycond.cpp
@@ -1,0 +1,15 @@
+#include "shoc_diag_second_moments_ubycond_impl.hpp"
+#include "share/scream_types.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ *  * Explicit instantiation for using the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream
+

--- a/components/scream/src/physics/shoc/shoc_diag_second_moments_ubycond_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_second_moments_ubycond_impl.hpp
@@ -1,0 +1,37 @@
+#ifndef SHOC_DIAG_SECOND_MOMENTS_UBYCOND_IMPL_HPP
+#define SHOC_DIAG_SECOND_MOMENTS_UBYCOND_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+#include "physics_functions.hpp" // also for ETI not on GPUs
+
+namespace scream {
+namespace shoc {
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>
+::shoc_diag_second_moments_ubycond(
+    Scalar& thl_sec, Scalar& qw_sec, Scalar& wthl_sec, Scalar& wqw_sec,
+    Scalar& qwthl_sec, Scalar& uw_sec, Scalar& vw_sec, Scalar& wtke_sec)
+{
+  // Purpose of this subroutine is to diagnose the upper
+  //  boundary condition for the second order moments
+  //  needed for the SHOC parameterization.  Currently
+  //  set all to zero.
+
+ const auto zero = C::ZERO;
+
+ wthl_sec  = zero;
+ wqw_sec   = zero;
+ uw_sec    = zero;
+ vw_sec    = zero;
+ wtke_sec  = zero;
+ thl_sec   = zero;
+ qw_sec    = zero;
+ qwthl_sec = zero;
+
+}
+
+} // namespace shoc
+} // namespace scream
+#endif

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -81,6 +81,11 @@ struct Functions
     const Scalar& wthl_sfc, const Scalar& uw_sfc, const Scalar& vw_sfc,
     Scalar& ustar2, Scalar& wstar);
 
+  KOKKOS_FUNCTION
+  static void shoc_diag_second_moments_ubycond(
+    Scalar& thl_sec, Scalar& qw_sec, Scalar& wthl_sec, Scalar& wqw_sec,
+    Scalar& qwthl_sec, Scalar& uw_sec, Scalar& vw_sec, Scalar& wtke_sec);
+
 }; // struct Functions
 
 } // namespace shoc
@@ -91,6 +96,7 @@ struct Functions
 #ifdef KOKKOS_ENABLE_CUDA
 # include "shoc_calc_shoc_vertflux_impl.hpp"
 # include "shoc_diag_second_moments_srf_impl.hpp"
+# include "shoc_diag_second_moments_ubycond_impl.hpp"
 #endif
 
 #endif

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -95,6 +95,9 @@ void shoc_diag_second_moments_srf_c(Int shcol, Real* wthl, Real* uw, Real* vw,
 void linear_interp_c(Real *x1, Real *x2, Real *y1, Real *y2, Int km1,
                      Int km2, Int ncol, Real minthresh);			   
 
+void shoc_diag_second_moments_ubycond_c(Int shcol, Real* thl, Real* qw, Real* wthl,
+                                       Real* wqw, Real* qwthl, Real* uw, Real* vw,
+                                       Real* wtke);
 }
 
 namespace scream {
@@ -407,6 +410,14 @@ void linear_interp(SHOCLinearintData& d)
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
+void shoc_diag_second_moments_ubycond(SHOCSecondMomentUbycondData& d)
+{
+  shoc_init(d.nlev, true);
+  d.transpose<ekat::util::TransposeDirection::c2f>();
+  shoc_diag_second_moments_ubycond_c(d.shcol, d.thl, d.qw, d.wthl, d.wqw, d.qwthl, d.uw, d.vw, d.wtke);
+  d.transpose<ekat::util::TransposeDirection::f2c>();
+}
+
 //
 // _f function definitions. These expect data in C layout
 //
@@ -494,6 +505,54 @@ void shoc_diag_second_moments_srf_f(Int shcol, Real* wthl, Real* uw, Real* vw, R
   Kokkos::Array<view_1d, 2> out_views = {ustar2_d, wstar_d};
   ekat::pack::device_to_host({ustar2, wstar}, shcol, out_views);
 }
+
+void shoc_diag_second_moments_ubycond_f(Int shcol, Real* thl, Real* qw, Real* wthl, Real* wqw, Real* qwthl, Real* uw, Real* vw,
+      Real* wtke)
+{
+  using SHOC       = Functions<Real, DefaultDevice>;
+  using Spack      = typename SHOC::Spack;
+  using Scalar     = typename SHOC::Scalar;
+  using Pack1      = typename ekat::pack::Pack<Real, 1>;
+  using view_1d    = typename SHOC::view_1d<Pack1>;
+
+  view_1d thl_d  ("thl"  ,shcol),
+          qw_d   ("qw"   ,shcol),
+          qwthl_d("qwthl",shcol),
+          wthl_d ("wthl" ,shcol),
+          wqw_d  ("wqw"  ,shcol),
+          uw_d   ("uw"   ,shcol),
+          vw_d   ("vw"   ,shcol),
+          wtke_d ("wtke" ,shcol);
+
+  Kokkos::parallel_for("parallel_moments_ubycond", shcol, KOKKOS_LAMBDA (const int& i) {
+
+    Scalar thl_s{0.};
+    Scalar qw_s{0.};
+    Scalar wthl_s{0.};
+    Scalar wqw_s{0.};
+    Scalar qwthl_s{0.};
+    Scalar uw_s{0.};
+    Scalar vw_s{0.};
+    Scalar wtke_s{0.};
+
+    SHOC::shoc_diag_second_moments_ubycond(thl_s, qw_s, wthl_s, wqw_s, qwthl_s, uw_s, vw_s, wtke_s);
+
+    thl_d(i)[0]   = thl_s;
+    qw_d(i)[0]    = qw_s;
+    wthl_d(i)[0]  = wthl_s;
+    wqw_d(i)[0]   = wqw_s;
+    qwthl_d(i)[0] = qwthl_s;
+    uw_d(i)[0]    = uw_s;
+    vw_d(i)[0]    = vw_s;
+    wtke_d(i)[0]  = wtke_s;
+
+  });
+
+  Kokkos::Array<view_1d, 8> host_views = {thl_d, qw_d, qwthl_d, wthl_d, wqw_d, uw_d, vw_d, wtke_d};
+
+  ekat::pack::device_to_host({thl, qw, qwthl, wthl, wqw, uw, vw, wtke}, shcol, host_views);
+}
+
 
 } // namespace shoc
 } // namespace scream

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -415,6 +415,17 @@ struct SHOCLinearintData : public SHOCDataBase {
   { SHOCDataBase::operator=(rhs); minthresh = rhs.minthresh; return *this; }
 };//SHOCLinearintData
 
+struct SHOCSecondMomentUbycondData : public SHOCDataBase {
+  // Outputs
+  Real *thl, *qw, *wthl, *wqw, *qwthl, *uw, *vw, *wtke;
+
+  SHOCSecondMomentUbycondData(Int shcol_) :
+     SHOCDataBase(shcol_, 1, 0, {&thl, &qw, &wthl, &wqw, &qwthl, &uw, &vw, &wtke}, {}, {}) {}
+  SHOCSecondMomentUbycondData(const SHOCSecondMomentUbycondData &rhs) :
+     SHOCDataBase(rhs, {&thl, &qw, &wthl, &wqw, &qwthl, &uw, &vw, &wtke}, {}, {}) {}
+  SHOCSecondMomentUbycondData &operator=(const SHOCSecondMomentUbycondData &rhs) { SHOCDataBase::operator=(rhs); return *this; }
+};
+
 //
 // Glue functions to call fortran from from C++ with the Data struct
 //
@@ -444,6 +455,7 @@ void compute_shoc_mix_shoc_length(SHOCMixlengthData &d);
 void check_length_scale_shoc_length(SHOCMixcheckData &d);
 void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d);
 void linear_interp(SHOCLinearintData &d);
+void shoc_diag_second_moments_ubycond(SHOCSecondMomentUbycondData& d);
 
 //
 // _f functions decls
@@ -453,7 +465,9 @@ extern "C" {
 void calc_shoc_vertflux_f(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
 			  Real *dz_zi, Real *invar, Real *vertflux);
 void shoc_diag_second_moments_srf_f(Int shcol, Real* wthl, Real* uw, Real* vw,
-                         Real* ustar2, Real* wstar);
+                          Real* ustar2, Real* wstar);
+void shoc_diag_second_moments_ubycond_f(Int shcol, Real* thl, Real* qw, Real* wthl,
+                          Real* wqw, Real* qwthl, Real* uw, Real* vw, Real* wtke);
 
 }
 

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -497,4 +497,14 @@ contains
 
   end subroutine linear_interp_c  
 
+ subroutine shoc_diag_second_moments_ubycond_c(shcol, thl, qw, wthl, wqw, qwthl, uw, vw, wtke) bind(C)
+   use shoc, only: diag_second_moments_ubycond
+
+   ! argmens
+   integer(kind=c_int), value, intent(in) :: shcol
+   real(kind=c_real), intent(out)  :: thl(shcol), qw(shcol), qwthl(shcol),wthl(shcol),wqw(shcol), uw(shcol), vw(shcol), wtke(shcol)
+
+   call diag_second_moments_ubycond(shcol, thl, qw, wthl, wqw, qwthl, uw, vw, wtke)
+ end subroutine shoc_diag_second_moments_ubycond_c
+
 end module shoc_iso_c

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -43,6 +43,16 @@ interface
 
  end subroutine shoc_diag_second_moments_srf_f
 
+ subroutine shoc_diag_second_moments_ubycond_f(shcol, thl, qw, wthl, wqw, qwthl, uw, vw, wtke) bind(C)
+   use iso_c_binding
+
+   ! argmens
+   integer(kind=c_int), value, intent(in) :: shcol
+   real(kind=c_real), intent(out)  :: thl(shcol), qw(shcol), qwthl(shcol),wthl(shcol),wqw(shcol), &
+        uw(shcol), vw(shcol), wtke(shcol)
+
+ end subroutine shoc_diag_second_moments_ubycond_f
+
 end interface
 
 end module shoc_iso_f

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SHOC_TESTS_SRCS
     shoc_eddy_diffusivities_tests.cpp
     shoc_diag_second_mom_srf_test.cpp
     shoc_linearinterp_tests.cpp
+    shoc_diag_second_mom_ubycond_test.cpp
     shoc_unit_tests.cpp)
 
 # NOTE: tests inside this if statement won't be built in a baselines-only build

--- a/components/scream/src/physics/shoc/tests/shoc_diag_second_mom_ubycond_test.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_second_mom_ubycond_test.cpp
@@ -1,0 +1,90 @@
+#include "catch2/catch.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+//#include "share/scream_types.hpp"
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestSecondMomUbycond {
+
+static void run_second_mom_ubycond_bfb()
+{
+  SHOCSecondMomentUbycondData uby_fortran[] = {
+    // shcol 
+    SHOCSecondMomentUbycondData(128),
+    SHOCSecondMomentUbycondData(128),
+    SHOCSecondMomentUbycondData(128),
+    SHOCSecondMomentUbycondData(128),
+  };
+
+  static constexpr Int num_runs = sizeof(uby_fortran) / sizeof(SHOCSecondMomentUbycondData);
+
+  // Create copies of data for use by cxx. Needs to happen before fortran calls so that
+  // inout data is in original state
+  SHOCSecondMomentUbycondData uby_cxx[num_runs] = {
+    SHOCSecondMomentUbycondData(uby_fortran[0]),
+    SHOCSecondMomentUbycondData(uby_fortran[1]),
+    SHOCSecondMomentUbycondData(uby_fortran[2]),
+    SHOCSecondMomentUbycondData(uby_fortran[3]),
+  };
+
+  // Get data from fortran
+  for (Int i = 0; i < num_runs; ++i) {
+    shoc_diag_second_moments_ubycond(uby_fortran[i]);
+  }
+
+  for (Int i = 0; i < num_runs; ++i) {
+    SHOCSecondMomentUbycondData& d = uby_cxx[i];
+    shoc_diag_second_moments_ubycond_f(d.shcol, d.thl, d.qw, d.qwthl, d.wthl, d.wqw, d.uw, d.vw, d.wtke);
+  }
+
+
+  for (Int i = 0; i < num_runs; ++i) {
+    Int shcol = uby_cxx[i].shcol;
+    for (Int k = 0; k < shcol; ++k) {
+      REQUIRE(uby_fortran[i].thl[k]      == uby_cxx[i].thl[k]);
+      REQUIRE(uby_fortran[i].qw[k]       == uby_cxx[i].qw[k]);
+      REQUIRE(uby_fortran[i].qwthl[k]    == uby_cxx[i].qwthl[k]);
+      REQUIRE(uby_fortran[i].wthl[k]     == uby_cxx[i].wthl[k]);
+      REQUIRE(uby_fortran[i].wqw[k]      == uby_cxx[i].wqw[k]);
+      REQUIRE(uby_fortran[i].uw[k]       == uby_cxx[i].uw[k]);
+      REQUIRE(uby_fortran[i].vw[k]       == uby_cxx[i].vw[k]);
+      REQUIRE(uby_fortran[i].wtke[k]     == uby_cxx[i].wtke[k]);
+    }
+  }
+}
+
+static void run_second_mom_ubycond_phys()
+{
+    // TODO
+}
+};
+
+}
+}
+}
+
+namespace {
+TEST_CASE("second_mom_uby", "shoc") {
+  using TRS = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestSecondMomUbycond;
+  TRS::run_second_mom_ubycond_phys();
+  TRS::run_second_mom_ubycond_bfb();
+}
+}

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -73,6 +73,7 @@ struct UnitWrap {
     struct TestCompShocMixLength;
     struct TestSecondMomSrf;
     struct TestShocLinearInt;
+    struct TestSecondMomUbycond;
   };
 
 };


### PR DESCRIPTION
porting diag_second_moments_ubycond, redo the porting with the latest master branch, and removing the tracer in both c++/fortran code

BFB