### PR TITLE
Removes F2000-SCREAM-SA from list of nightly test suites.

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -374,7 +374,6 @@ _TESTS = {
         "tests" : (
             "SMS_D.ne4pg2_ne4pg2.F2010-SCREAM-HR",
             "SMS_D.ne4pg2_ne4pg2.F2010-SCREAM-LR",
-            "SMS_D_P96.ne4_ne4.F2000-SCREAM-SA",
             "ERS.ne4pg2_ne4pg2.F2010-SCREAM-HR",
             "ERS.ne4pg2_ne4pg2.F2010-SCREAM-LR",
             "ERP.ne4pg2_ne4pg2.F2010-SCREAM-HR.cam-double_memleak_tol",


### PR DESCRIPTION
Consistent failures of this test on during the Cori-KNL
nightly tests has become a distraction.  After discussion, it has
been determined that the configuration of the SCREAM-SA test is
not consistent with the component coupler and thus failures could
be attributable to the inproper usage rather than a bug in the code.

This commit will suspend application of the F2000-SCREAM-SA nightly
test until we transition to a fully active ATM model from the
perspective of the component coupler.

[BFB]