### PR TITLE
porting calc_shoc_varorcovar

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1308,6 +1308,10 @@ subroutine calc_shoc_varorcovar(&
   !  (depending on if invar1 is the same as invar2)
   !  for a given set of inputs
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    use shoc_iso_f, only: calc_shoc_varorcovar_f
+#endif
+
   implicit none
 
 ! INPUT VARIABLES
@@ -1338,6 +1342,14 @@ subroutine calc_shoc_varorcovar(&
   integer :: i, k, kt
   real(rtype) :: sm, grid_dz2
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+   if (use_cxx) then
+      call calc_shoc_varorcovar_f(shcol,nlev,nlevi,tunefac,isotropy_zi,tkh_zi,dz_zi,invar1,invar2,&  ! Input
+           varorcovar)                              ! Input/Output)
+      return
+   endif
+#endif
+   
   do k=2,nlev
 
     kt=k-1 ! define upper grid point indicee

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1355,7 +1355,7 @@ subroutine calc_shoc_varorcovar(&
     kt=k-1 ! define upper grid point indicee
     do i=1,shcol
 
-      grid_dz2=(1._rtype/dz_zi(i,k))**2 ! vertical grid diff squared
+      grid_dz2=bfb_square(1._rtype/dz_zi(i,k)) ! vertical grid diff squared
       sm=isotropy_zi(i,k)*tkh_zi(i,k) ! coefficient for variances
 
       ! Compute the variance or covariance

--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SHOC_HEADERS
 # Add ETI source files if not on CUDA
 if (NOT CUDA_BUILD)
   list(APPEND SHOC_SRCS
+    shoc_calc_shoc_varorcovar.cpp
     shoc_calc_shoc_vertflux.cpp
   )
 endif()

--- a/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar.cpp
+++ b/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar.cpp
@@ -5,8 +5,7 @@ namespace scream {
 namespace shoc {
 
 /*
- * Explicit instantiation for doing variance or covariance on Reals 
- * using the default device.
+ * Explicit instantiation using the default device.
  */
 
 template struct Functions<Real,DefaultDevice>;

--- a/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar.cpp
+++ b/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar.cpp
@@ -1,0 +1,15 @@
+#include "shoc_calc_shoc_varorcovar_impl.hpp"
+#include "share/scream_types.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation for doing variance or covariance on Reals 
+ * using the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream

--- a/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar_impl.hpp
@@ -26,18 +26,18 @@ void Functions<S,D>
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
     // Calculate shift
-    Spack up_grid1, grid1, up_grid2, grid2;
+    Spack invar1_s, invar1_sm1, invar2_s, invar2_sm1;
     auto range_pack1 = ekat::pack::range<IntSmallPack>(k*Spack::n);
     auto range_pack2 = range_pack1;
     range_pack2.set(range_pack1 < 1, 1); // don't want the shift to go below zero. we mask out that result anyway
-    ekat::pack::index_and_shift<-1>(sinvar1, range_pack2, grid1, up_grid1);
-    ekat::pack::index_and_shift<-1>(sinvar2, range_pack2, grid2, up_grid2);
+    ekat::pack::index_and_shift<-1>(sinvar1, range_pack2, invar1_s, invar1_sm1);
+    ekat::pack::index_and_shift<-1>(sinvar2, range_pack2, invar2_s, invar2_sm1);
 
     const Spack grid_dz = 1 / dz_zi(k);
     const Spack grid_dz2 = ekat::pack::square(grid_dz); // vertical grid diff squared
 
     // Compute the variance or covariance
-    varorcovar(k).set(range_pack1 > 0 && range_pack1 < nlev, tunefac*isotropy_zi(k)*tkh_zi(k)*grid_dz2*(up_grid1 - grid1)*(up_grid2 - grid2));
+    varorcovar(k).set(range_pack1 > 0 && range_pack1 < nlev, tunefac*isotropy_zi(k)*tkh_zi(k)*grid_dz2*(invar1_sm1 - invar1_s)*(invar2_sm1 - invar2_s));
   });
 }
 

--- a/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar_impl.hpp
@@ -1,0 +1,47 @@
+#ifndef SHOC_CALC_SHOC_VARORCOVAR_IMPL_HPP
+#define SHOC_CALC_SHOC_VARORCOVAR_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace shoc {
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>
+::calc_shoc_varorcovar(
+  const MemberType&            team,
+  const Int&                   nlev, 
+  const Scalar& tunefac,
+  const uview_1d<const Spack>& isotropy_zi, 
+  const uview_1d<const Spack>& tkh_zi,
+  const uview_1d<const Spack>& dz_zi,
+  const uview_1d<const Spack>& invar1, 
+  const uview_1d<const Spack>& invar2, 
+  const uview_1d<Spack>&       varorcovar)
+{
+  const Int nlev_pack = ekat::pack::npack<Spack>(nlev);
+  const auto sinvar1 = scalarize(invar1);
+  const auto sinvar2 = scalarize(invar2);
+
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+    // Calculate shift
+    Spack up_grid1, grid1, up_grid2, grid2;
+    auto range_pack1 = ekat::pack::range<IntSmallPack>(k*Spack::n);
+    auto range_pack2 = range_pack1;
+    range_pack2.set(range_pack1 < 1, 1); // don't want the shift to go below zero. we mask out that result anyway
+    ekat::pack::index_and_shift<-1>(sinvar1, range_pack2, grid1, up_grid1);
+    ekat::pack::index_and_shift<-1>(sinvar2, range_pack2, grid2, up_grid2);
+
+    const Spack grid_dz = 1 / dz_zi(k);
+    const Spack grid_dz2 = ekat::pack::square(grid_dz); // vertical grid diff squared
+
+    // Compute the variance or covariance
+    varorcovar(k).set(range_pack1 > 0 && range_pack1 < nlev, tunefac*isotropy_zi(k)*tkh_zi(k)*grid_dz2*(up_grid1 - grid1)*(up_grid2 - grid2));
+  });
+}
+
+} // namespace shoc
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar_impl.hpp
@@ -37,7 +37,7 @@ void Functions<S,D>
     const Spack grid_dz2 = ekat::pack::square(grid_dz); // vertical grid diff squared
 
     // Compute the variance or covariance
-    varorcovar(k).set(range_pack1 > 0 && range_pack1 < nlev, tunefac*isotropy_zi(k)*tkh_zi(k)*grid_dz2*(invar1_sm1 - invar1_s)*(invar2_sm1 - invar2_s));
+    varorcovar(k).set(range_pack1 > 0 && range_pack1 < nlev, tunefac*(isotropy_zi(k)*tkh_zi(k))*grid_dz2*(invar1_sm1 - invar1_s)*(invar2_sm1 - invar2_s));
   });
 }
 

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -68,6 +68,18 @@ struct Functions
   // --------- Functions ---------
   //
   KOKKOS_FUNCTION
+  static void calc_shoc_varorcovar(
+    const MemberType&            team,
+    const Int&                   nlev, 
+    const Scalar&                tunefac,
+    const uview_1d<const Spack>& isotropy_zi, 
+    const uview_1d<const Spack>& tkh_zi,
+    const uview_1d<const Spack>& dz_zi,
+    const uview_1d<const Spack>& invar1, 
+    const uview_1d<const Spack>& invar2, 
+    const uview_1d<Spack>&       varorcovar);
+
+  KOKKOS_FUNCTION
   static void calc_shoc_vertflux(
     const MemberType& team,
     const Int& nlev,
@@ -94,6 +106,7 @@ struct Functions
 // If a GPU build, make all code available to the translation unit; otherwise,
 // ETI is used.
 #ifdef KOKKOS_ENABLE_CUDA
+# include "shoc_calc_shoc_varorcovar_impl.hpp"
 # include "shoc_calc_shoc_vertflux_impl.hpp"
 # include "shoc_diag_second_moments_srf_impl.hpp"
 # include "shoc_diag_second_moments_ubycond_impl.hpp"

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -422,6 +422,57 @@ void shoc_diag_second_moments_ubycond(SHOCSecondMomentUbycondData& d)
 // _f function definitions. These expect data in C layout
 //
 
+void calc_shoc_varorcovar_f(Int shcol, Int nlev, Int nlevi, Real tunefac,
+                            Real *isotropy_zi, Real *tkh_zi, Real *dz_zi,
+                            Real *invar1, Real *invar2, Real *varorcovar)
+{
+  using SHF = Functions<Real, DefaultDevice>;
+
+  using Spack      = typename SHF::Spack;
+  using view_2d    = typename SHF::view_2d<Spack>;
+  using KT         = typename SHF::KT;
+  using ExeSpace   = typename KT::ExeSpace;
+  using MemberType = typename SHF::MemberType;
+
+  static constexpr Int num_arrays = 6;
+
+  Kokkos::Array<view_2d, num_arrays> temp_d;
+  Kokkos::Array<size_t, num_arrays> dim1_sizes     = {shcol,       shcol,  shcol, shcol,  shcol,  shcol};
+  Kokkos::Array<size_t, num_arrays> dim2_sizes     = {nlevi,       nlevi,  nlevi, nlev,   nlev,   nlevi};
+  Kokkos::Array<const Real*, num_arrays> ptr_array = {isotropy_zi, tkh_zi, dz_zi, invar1, invar2, varorcovar};
+
+  // Sync to device
+  ekat::pack::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+
+  view_2d
+    isotropy_zi_d  (temp_d[0]),
+    tkh_zi_d    (temp_d[1]),
+    dz_zi_d     (temp_d[2]),
+    invar1_d    (temp_d[3]),
+    invar2_d    (temp_d[4]),
+    varorcovar_d(temp_d[5]);
+
+  const Int nk_pack = ekat::pack::npack<Spack>(nlev);
+  const auto policy = ekat::util::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+    const Int i = team.league_rank();
+
+    const auto oisotropy_zi_d = ekat::util::subview(isotropy_zi_d, i);
+    const auto otkh_zi_d      = ekat::util::subview(tkh_zi_d, i);
+    const auto odz_zi_d       = ekat::util::subview(dz_zi_d, i);
+    const auto oinvar1_d      = ekat::util::subview(invar1_d, i);
+    const auto oinvar2_d      = ekat::util::subview(invar2_d, i);
+    const auto ovarorcovar_d  = ekat::util::subview(varorcovar_d, i);
+
+    SHF::calc_shoc_varorcovar(team, nlev, tunefac, oisotropy_zi_d, otkh_zi_d, odz_zi_d,
+                              oinvar1_d, oinvar2_d, ovarorcovar_d);
+  });
+
+  // Sync back to host
+  Kokkos::Array<view_2d, 1> inout_views = {varorcovar_d};
+  ekat::pack::device_to_host({varorcovar}, {shcol}, {nlevi}, inout_views, true);
+}
+
 void calc_shoc_vertflux_f(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
 			  Real *dz_zi, Real *invar, Real *vertflux)
 {

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -462,6 +462,9 @@ void shoc_diag_second_moments_ubycond(SHOCSecondMomentUbycondData& d);
 //
 extern "C" {
 
+void calc_shoc_varorcovar_f(Int shcol, Int nlev, Int nlevi, Real tunefac,
+                            Real *isotropy_zi, Real *tkh_zi, Real *dz_zi,
+                            Real *invar1, Real *invar2, Real *varorcovar);
 void calc_shoc_vertflux_f(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
 			  Real *dz_zi, Real *invar, Real *vertflux);
 void shoc_diag_second_moments_srf_f(Int shcol, Real* wthl, Real* uw, Real* vw,

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -21,7 +21,7 @@ interface
     integer(kind=c_int), intent(in), value :: shcol
     integer(kind=c_int), intent(in), value :: nlev
     integer(kind=c_int), intent(in), value :: nlevi
-    real(kind=c_real), intent(in) :: tunefac
+    real(kind=c_real), intent(in), value :: tunefac
     real(kind=c_real), intent(in) :: isotropy_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: tkh_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -15,6 +15,23 @@ module shoc_iso_f
 
 interface
 
+  subroutine calc_shoc_varorcovar_f(shcol, nlev, nlevi, tunefac, isotropy_zi, tkh_zi, dz_zi, invar1, invar2, varorcovar) bind (C)
+    use iso_c_binding
+
+    integer(kind=c_int), intent(in), value :: shcol
+    integer(kind=c_int), intent(in), value :: nlev
+    integer(kind=c_int), intent(in), value :: nlevi
+    real(kind=c_real), intent(in) :: tunefac
+    real(kind=c_real), intent(in) :: isotropy_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: tkh_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: invar1(shcol,nlev)
+    real(kind=c_real), intent(in) :: invar2(shcol,nlev)
+
+    real(kind=c_real), intent(inout) :: varorcovar(shcol,nlevi)
+
+  end subroutine calc_shoc_varorcovar_f
+  
   subroutine calc_shoc_vertflux_f(shcol, nlev, nlevi, tkh_zi, dz_zi, invar, vertflux) bind (C)
     use iso_c_binding
 

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -64,7 +64,7 @@ struct UnitWrap {
     struct TestShocIntColStab;
     struct TestShocIsotropicTs;
     struct TestShocShearProd;
-    struct TestShocVarorCovar;
+    struct TestShocVarorcovar;
     struct TestCompBruntShocLength;
     struct TestCheckShocLength;
     struct TestCompShocConvTime;

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -64,7 +64,7 @@ struct UnitWrap {
     struct TestShocIntColStab;
     struct TestShocIsotropicTs;
     struct TestShocShearProd;
-    struct TestShocVarorcovar;
+    struct TestShocVarorCovar;
     struct TestCompBruntShocLength;
     struct TestCheckShocLength;
     struct TestCompShocConvTime;

--- a/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
@@ -22,7 +22,7 @@ namespace shoc {
 namespace unit_test {
 
 template <typename D>
-struct UnitWrap::UnitTest<D>::TestShocVarorcovar {
+struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
 
   static void run_property()
   {
@@ -309,7 +309,7 @@ static void run_bfb()
     for (auto& d : SDS_cxx) {
       d.transpose<ekat::util::TransposeDirection::c2f>();
       // expects data in fortran layout
-      calc_shoc_varorcovar_f(d.shcol, d.nlev, d.nlevi,
+      calc_shoc_varorcovar_f(d.shcol(), d.nlev(), d.nlevi(),
                              d.tunefac, d.isotropy_zi,
                              d.tkh_zi, d.dz_zi,
                              d.invar1, d.invar2, d.varorcovar);
@@ -320,7 +320,7 @@ static void run_bfb()
     for (Int i = 0; i < num_runs; ++i) {
       SHOCVarorcovarData& d_f90 = SDS_f90[i];
       SHOCVarorcovarData& d_cxx = SDS_cxx[i];
-      for (Int k = 0; k < d_f90.totali(); ++k) {
+      for (Int k = 0; k < d_f90.total1x3(); ++k) {
         REQUIRE(d_f90.varorcovar[k] == d_cxx.varorcovar[k]);
       }
     }
@@ -335,7 +335,7 @@ namespace {
 
 TEST_CASE("shoc_varorcovar_property", "shoc")
 {
-  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocVarorcovar;
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocVarorCovar;
 
   TestStruct::run_property();
 }

--- a/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
@@ -278,7 +278,7 @@ static void run_bfb()
       SHOCVarorcovarData(10, 71, 72, 1),
       SHOCVarorcovarData(10, 12, 13, 1),
       SHOCVarorcovarData(7,  16, 17, 1),
-      SHOCVarorcovarData(2, 7, 8, 1),
+      SHOCVarorcovarData(2, 7, 8, 0.005),
     };
 
     static constexpr Int num_runs = sizeof(SDS_f90) / sizeof(SHOCVarorcovarData);


### PR DESCRIPTION
Implements the `calc_shoc_varorcovar` fortran subroutine in C++ and adds a bfb test to existing property test. 

I followed the structure of the `calc_shoc_vertflux`  subroutine (implemented in https://github.com/E3SM-Project/scream/pull/499) almost identically since the functions are so similar. Basically reusing the same bfb test.