### PR TITLE
fixed bug in P3 ice effective diameter needed by RRTMGP code

### DIFF
--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -1179,7 +1179,7 @@ end subroutine micro_p3_readnl
    !! Effective radius for cloud ice
    rei(:ncol,top_lev:) = rei(:ncol,top_lev:) * 1e6_rtype  ! Rescale rei to be in microns
    !! Effective diameter for cloud ice
-   dei(:ncol,top_lev:) = rei(:ncol,top_lev:) * rho_qi(:ncol,top_lev:)/rho_h2os * 2._rtype
+   dei(:ncol,top_lev:) = rei(:ncol,top_lev:) * 2._rtype
 
    !!
    !! Limiters for low cloud fraction


### PR DESCRIPTION
The PR addresses the bug @PeterCaldwell found on the calculation of the ice effective diameter in p3_interface. The multiplication by the density ratio has been removed. 