### PR TITLE
Property tests for SHOC third moment lowest level functions

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1635,7 +1635,7 @@ subroutine compute_diag_third_shoc_moment(&
   real(rtype) :: X0, Y0, X1, Y1, AA0, AA1
   real(rtype) :: zvar, x5var, iso, thedz, thedz2
   real(rtype) :: theterm, tsign
-  real(rtype) :: isosqrt
+  real(rtype) :: isosqrd
   real(rtype) :: buoy_sgs2, bet2
   real(rtype) :: f0, f1, f2, f3, f4, f5
 
@@ -1652,11 +1652,11 @@ subroutine compute_diag_third_shoc_moment(&
         call fterms_input_for_diag_third_shoc_moment(&
 	     dz_zi(i,k), dz_zt(i,k), dz_zt(i,kc), &               ! Input
              isotropy_zi(i,k), brunt_zi(i,k), thetal_zi(i,k), &   ! Input
-             thedz, thedz2, iso, isosqrt, buoy_sgs2, bet2)        ! Output
+             thedz, thedz2, iso, isosqrd, buoy_sgs2, bet2)        ! Output
 
         !Compute f0 to f5 terms
         call f0_to_f5_diag_third_shoc_moment(&
-	     thedz, thedz2, bet2, iso, isosqrt, &                 ! Input
+	     thedz, thedz2, bet2, iso, isosqrd, &                 ! Input
 	     wthl_sec (i,k), wthl_sec(i,kc), wthl_sec(i,kb), &    ! Input
 	     thl_sec(i,k), thl_sec(i,kc), thl_sec(i,kb), &        ! Input
              w_sec(i,k), w_sec(i,kc), w_sec_zi(i,k), &            ! Input
@@ -1693,7 +1693,7 @@ end subroutine compute_diag_third_shoc_moment
 subroutine fterms_input_for_diag_third_shoc_moment(&
      dz_zi, dz_zt, dz_zt_kc, &                      ! Input
      isotropy_zi, brunt_zi, thetal_zi, &            ! Input
-     thedz, thedz2, iso, isosqrt, buoy_sgs2, bet2)  ! Output
+     thedz, thedz2, iso, isosqrd, buoy_sgs2, bet2)  ! Output
 
   !Compute inputs for computing f0 to f5 terms
 
@@ -1704,22 +1704,22 @@ subroutine fterms_input_for_diag_third_shoc_moment(&
   real(rtype), intent(in) :: isotropy_zi, brunt_zi, thetal_zi
 
   !intent-outs
-  real(rtype), intent(out) :: thedz, thedz2, iso, isosqrt
+  real(rtype), intent(out) :: thedz, thedz2, iso, isosqrd
   real(rtype), intent(out) :: buoy_sgs2, bet2
 
   thedz  = 1._rtype/dz_zi
   thedz2 = 1._rtype/(dz_zt+dz_zt_kc)
 
   iso       = isotropy_zi
-  isosqrt   = iso**2
-  buoy_sgs2 = isosqrt*brunt_zi
+  isosqrd   = iso**2
+  buoy_sgs2 = isosqrd*brunt_zi
   bet2      = ggr/thetal_zi
 
   return
 end subroutine fterms_input_for_diag_third_shoc_moment
 
 subroutine f0_to_f5_diag_third_shoc_moment(&
-     thedz, thedz2, bet2, iso, isosqrt, &    ! Input
+     thedz, thedz2, bet2, iso, isosqrd, &    ! Input
      wthl_sec, wthl_sec_kc, wthl_sec_kb, &   ! Input
      thl_sec, thl_sec_kc, thl_sec_kb, &      ! Input
      w_sec, w_sec_kc,w_sec_zi, &             ! Input
@@ -1731,7 +1731,7 @@ subroutine f0_to_f5_diag_third_shoc_moment(&
   implicit none
 
   !intent-ins
-  real(rtype), intent(in) :: thedz, thedz2, bet2, iso, isosqrt
+  real(rtype), intent(in) :: thedz, thedz2, bet2, iso, isosqrd
   real(rtype), intent(in) :: wthl_sec, wthl_sec_kc, wthl_sec_kb
   real(rtype), intent(in) :: thl_sec, thl_sec_kc, thl_sec_kb
   real(rtype), intent(in) :: w_sec, w_sec_kc, w_sec_zi, tke, tke_kc
@@ -1755,13 +1755,13 @@ subroutine f0_to_f5_diag_third_shoc_moment(&
        wthl_sec_diff + 0.5_rtype * &
        w_sec_zi*thl_sec_diff)
 
-  f2 = thedz * bet2 * isosqrt * wthl_sec * &
+  f2 = thedz * bet2 * isosqrd * wthl_sec * &
        wsec_diff+ 2._rtype * thedz2 * bet2 * &
-       isosqrt * w_sec_zi * wthl_sec_diff
+       isosqrd * w_sec_zi * wthl_sec_diff
 
-  f3 = thedz2 * bet2 * isosqrt * w_sec_zi * &
+  f3 = thedz2 * bet2 * isosqrd * w_sec_zi * &
        wthl_sec_diff + thedz * &
-       bet2 * isosqrt * (wthl_sec * tke_diff)
+       bet2 * isosqrd * (wthl_sec * tke_diff)
 
   f4 = thedz * iso * w_sec_zi * (wsec_diff + &
        tke_diff)

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1865,7 +1865,7 @@ end function w3_diag_third_shoc_moment
 
 subroutine clipping_diag_third_shoc_moments(&
            nlevi,shcol,w_sec_zi,& ! Input
-	   w3)                    ! Output
+	   w3)                    ! Input/Output
 
   ! perform clipping to prevent unrealistically large values from occuring
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -111,8 +111,10 @@ void x_y_terms_diag_third_shoc_moment_c(Real buoy_sgs2, Real f0, Real f1, Real f
 				    
 void aa_terms_diag_third_shoc_moment_c(Real omega0, Real omega1, Real omega2, 
                                     Real x0, Real x1, Real y0, Real y1, 
-				    Real *aa0, Real *aa1);			   
-				   			    				    
+				    Real *aa0, Real *aa1);
+				    
+void w3_diag_third_shoc_moment_c(Real aa0, Real aa1, Real x0, 
+                                    Real x1, Real f5, Real *w3);				    		   				   			    				    
 void shoc_diag_second_moments_srf_c(Int shcol, Real* wthl, Real* uw, Real* vw,
                                    Real* ustar2, Real* wstar);
 				   
@@ -459,6 +461,11 @@ void x_y_terms_diag_third_shoc_moment(SHOCXYdiagthirdmomsData &d){
   shoc_init(1, true);
   x_y_terms_diag_third_shoc_moment_c(d.buoy_sgs2,d.f0,d.f1,d.f2,
                                      &d.x0,&d.y0,&d.x1,&d.y1);
+}
+
+void w3_diag_third_shoc_moment(SHOCW3diagthirdmomsData &d){
+  shoc_init(1, true);
+  w3_diag_third_shoc_moment_c(d.aa0,d.aa1,d.x0,d.x1,d.f5,&d.w3);
 }
 
 void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d)

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -344,9 +344,9 @@ void check_length_scale_shoc_length(SHOCMixcheckData &d) {
 }
 
 void clipping_diag_third_shoc_moments(SHOCClipthirdmomsData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  clipping_diag_third_shoc_moments_c(d.nlevi,d.shcol,d.w_sec_zi,d.w3);
+  clipping_diag_third_shoc_moments_c(d.nlevi(),d.shcol(),d.w_sec_zi,d.w3);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -88,6 +88,9 @@ void compute_shoc_mix_shoc_length_c(Int nlev, Int shcol, Real *tke, Real* brunt,
 
 void check_length_scale_shoc_length_c(Int nlev, Int shcol, Real *host_dx,
                                     Real *host_dy, Real *shoc_mix);
+				    
+void clipping_diag_third_shoc_moments_c(Int nlevi, Int shcol, Real *w_sec_zi,
+                                    Real *w3);				    
 
 void shoc_diag_second_moments_srf_c(Int shcol, Real* wthl, Real* uw, Real* vw,
                                    Real* ustar2, Real* wstar);
@@ -391,6 +394,13 @@ void check_length_scale_shoc_length(SHOCMixcheckData &d) {
   shoc_init(d.nlev, true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
   check_length_scale_shoc_length_c(d.nlev,d.shcol,d.host_dx,d.host_dy,d.shoc_mix);
+  d.transpose<ekat::util::TransposeDirection::f2c>();
+}
+
+void clipping_diag_third_shoc_moments(SHOCClipthirdmomsData &d) {
+  shoc_init(d.nlev, true);
+  d.transpose<ekat::util::TransposeDirection::c2f>();
+  clipping_diag_third_shoc_moments_c(d.nlevi,d.shcol,d.w_sec_zi,d.w3);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -344,7 +344,7 @@ void check_length_scale_shoc_length(SHOCMixcheckData &d) {
 }
 
 void clipping_diag_third_shoc_moments(SHOCClipthirdmomsData &d) {
-  shoc_init(d.nlev(), true);
+  shoc_init(d.nlevi()-1, true); // nlev = nlevi - 1
   d.transpose<ekat::util::TransposeDirection::c2f>();
   clipping_diag_third_shoc_moments_c(d.nlevi(),d.shcol(),d.w_sec_zi,d.w3);
   d.transpose<ekat::util::TransposeDirection::f2c>();

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -90,8 +90,29 @@ void check_length_scale_shoc_length_c(Int nlev, Int shcol, Real *host_dx,
                                     Real *host_dy, Real *shoc_mix);
 				    
 void clipping_diag_third_shoc_moments_c(Int nlevi, Int shcol, Real *w_sec_zi,
-                                    Real *w3);				    
-
+                                    Real *w3);	
+				    
+void fterms_input_for_diag_third_shoc_moment_c(Real dz_zi, Real dz_zt, Real dz_zt_kc,
+                                    Real isotropy_zi, Real brunt_zi, Real thetal_zi,
+                                    Real *thedz, Real *thedz2, Real *iso, 
+                                    Real *isosqrt, Real *buoy_sgs2, Real *bet2);				    			
+void f0_to_f5_diag_third_shoc_moment_c(Real thedz, Real thedz2, Real bet2, Real iso, 
+                                    Real isosqrt, Real wthl_sec, Real wthl_sec_kc, 
+				    Real wthl_sec_kb, Real thl_sec, Real thl_sec_kc, 
+				    Real thl_sec_kb, Real w_sec, Real w_sec_kc, Real w_sec_zi,
+                                    Real tke, Real tke_kc, Real *f0, Real *f1, 
+                                    Real *f2, Real *f3, Real *f4, Real *f5);
+				    
+void omega_terms_diag_third_shoc_moment_c(Real buoy_sgs2, Real f3, Real f4,
+                                    Real *omega0, Real *omega1, Real *omega2);
+				    
+void x_y_terms_diag_third_shoc_moment_c(Real buoy_sgs2, Real f0, Real f1, Real f2, 
+                                    Real *x0, Real *y0, Real *x1, Real *y1);
+				    
+void aa_terms_diag_third_shoc_moment_c(Real omega0, Real omega1, Real omega2, 
+                                    Real x0, Real x1, Real y0, Real y1, 
+				    Real *aa0, Real *aa1);			   
+				   			    				    
 void shoc_diag_second_moments_srf_c(Int shcol, Real* wthl, Real* uw, Real* vw,
                                    Real* ustar2, Real* wstar);
 				   
@@ -402,6 +423,42 @@ void clipping_diag_third_shoc_moments(SHOCClipthirdmomsData &d) {
   d.transpose<ekat::util::TransposeDirection::c2f>();
   clipping_diag_third_shoc_moments_c(d.nlevi,d.shcol,d.w_sec_zi,d.w3);
   d.transpose<ekat::util::TransposeDirection::f2c>();
+}
+
+void aa_terms_diag_third_shoc_moment(SHOCAAdiagthirdmomsData &d){
+  shoc_init(1, true);
+  aa_terms_diag_third_shoc_moment_c(d.omega0,d.omega1,d.omega2,d.x0,d.x1,d.y0,d.y1,
+                                    &d.aa0,&d.aa1);
+}
+
+void fterms_input_for_diag_third_shoc_moment(SHOCFterminputthirdmomsData &d){
+  shoc_init(1, true);
+  fterms_input_for_diag_third_shoc_moment_c(d.dz_zi,d.dz_zt,d.dz_zt_kc,
+                                     d.isotropy_zi,d.brunt_zi,d.thetal_zi,
+				     &d.thedz,&d.thedz2,&d.iso,
+				     &d.isosqrt,&d.buoy_sgs2,&d.bet2);
+}
+
+void f0_to_f5_diag_third_shoc_moment(SHOCFtermdiagthirdmomsData &d){
+  shoc_init(1, true);
+  f0_to_f5_diag_third_shoc_moment_c(d.thedz,d.thedz2,d.bet2,d.iso,d.isosqrt,
+                                    d.wthl_sec,d.wthl_sec_kc,d.wthl_sec_kb,
+                                    d.thl_sec,d.thl_sec_kc,d.thl_sec_kb,
+                                    d.w_sec,d.w_sec_kc,d.w_sec_zi,
+                                    d.tke,d.tke_kc,
+                                    &d.f0,&d.f1,&d.f2,&d.f3,&d.f4,&d.f5);
+}
+
+void omega_terms_diag_third_shoc_moment(SHOCOmegadiagthirdmomsData &d){
+  shoc_init(1, true);
+  omega_terms_diag_third_shoc_moment_c(d.buoy_sgs2,d.f3,d.f4,
+                                       &d.omega0,&d.omega1,&d.omega2);
+}
+
+void x_y_terms_diag_third_shoc_moment(SHOCXYdiagthirdmomsData &d){
+  shoc_init(1, true);
+  x_y_terms_diag_third_shoc_moment_c(d.buoy_sgs2,d.f0,d.f1,d.f2,
+                                     &d.x0,&d.y0,&d.x1,&d.y1);
 }
 
 void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d)

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -95,9 +95,9 @@ void clipping_diag_third_shoc_moments_c(Int nlevi, Int shcol, Real *w_sec_zi,
 void fterms_input_for_diag_third_shoc_moment_c(Real dz_zi, Real dz_zt, Real dz_zt_kc,
                                     Real isotropy_zi, Real brunt_zi, Real thetal_zi,
                                     Real *thedz, Real *thedz2, Real *iso, 
-                                    Real *isosqrt, Real *buoy_sgs2, Real *bet2);				    			
+                                    Real *isosqrd, Real *buoy_sgs2, Real *bet2);				    			
 void f0_to_f5_diag_third_shoc_moment_c(Real thedz, Real thedz2, Real bet2, Real iso, 
-                                    Real isosqrt, Real wthl_sec, Real wthl_sec_kc, 
+                                    Real isosqrd, Real wthl_sec, Real wthl_sec_kc, 
 				    Real wthl_sec_kb, Real thl_sec, Real thl_sec_kc, 
 				    Real thl_sec_kb, Real w_sec, Real w_sec_kc, Real w_sec_zi,
                                     Real tke, Real tke_kc, Real *f0, Real *f1, 
@@ -436,12 +436,12 @@ void fterms_input_for_diag_third_shoc_moment(SHOCFterminputthirdmomsData &d){
   fterms_input_for_diag_third_shoc_moment_c(d.dz_zi,d.dz_zt,d.dz_zt_kc,
                                      d.isotropy_zi,d.brunt_zi,d.thetal_zi,
 				     &d.thedz,&d.thedz2,&d.iso,
-				     &d.isosqrt,&d.buoy_sgs2,&d.bet2);
+				     &d.isosqrd,&d.buoy_sgs2,&d.bet2);
 }
 
 void f0_to_f5_diag_third_shoc_moment(SHOCFtermdiagthirdmomsData &d){
   shoc_init(1, true);
-  f0_to_f5_diag_third_shoc_moment_c(d.thedz,d.thedz2,d.bet2,d.iso,d.isosqrt,
+  f0_to_f5_diag_third_shoc_moment_c(d.thedz,d.thedz2,d.bet2,d.iso,d.isosqrd,
                                     d.wthl_sec,d.wthl_sec_kc,d.wthl_sec_kb,
                                     d.thl_sec,d.thl_sec_kc,d.thl_sec_kb,
                                     d.w_sec,d.w_sec_kc,d.w_sec_zi,

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -327,7 +327,8 @@ struct SHOCClipthirdmomsData : public PhysicsTestData {
   SHOCClipthirdmomsData(Int shcol_, Int nlevi_) :
     PhysicsTestData(shcol_, nlevi_,{&w_sec_zi, &w3}){}
 
-  SHOC_NO_SCALAR(SHOCClipthirdmomsData, 2);
+  PTD_STD_DEF(SHOCClipthirdmomsData, 2, 0);
+  PTD_DIM_RENAME(2, shcol, nlevi);
 
 };//SHOCClipthirdmomsData
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -324,11 +324,10 @@ struct SHOCClipthirdmomsData : public PhysicsTestData {
   // In/out
   Real *w3;
 
-  SHOCClipthirdmomsData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData(shcol_, nlev_, nlevi_,{},{&w_sec_zi, &w3}){}
+  SHOCClipthirdmomsData(Int shcol_, Int nlevi_) :
+    PhysicsTestData(shcol_, nlevi_,{&w_sec_zi, &w3}){}
 
-  PTD_DATA_COPY_CTOR(SHOCClipthirdmomsData, 3);
-  PTD_ASSIGN_OP(SHOCClipthirdmomsData, 0);
+  SHOC_NO_SCALAR(SHOCClipthirdmomsData, 2);
 
 };//SHOCClipthirdmomsData
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -385,6 +385,22 @@ struct SHOCMixcheckData : public SHOCDataBase {
   { SHOCDataBase::operator=(rhs); return *this; }
 };//SHOCMixcheckData
 
+//Create data structure to hold data for clipping_diag_third_shoc_moments
+struct SHOCClipthirdmomsData : public SHOCDataBase {
+  // Inputs
+  Real *w_sec_zi;
+
+  // In/out
+  Real *w3;
+
+  SHOCClipthirdmomsData(Int shcol_, Int nlevi_) :
+    SHOCDataBase(shcol_, 0, nlevi_, {}, {&w_sec_zi, &w3}, {}) {}
+  SHOCClipthirdmomsData(const SHOCClipthirdmomsData &rhs) :
+    SHOCDataBase(rhs, {}, {&w_sec_zi, &w3}, {}) {}
+  SHOCClipthirdmomsData &operator=(const SHOCClipthirdmomsData &rhs)
+  { SHOCDataBase::operator=(rhs); return *this; }
+};//SHOCClipthirdmomsData
+
 struct SHOCSecondMomentSrfData : public SHOCDataBase {
   // Inputs
   Real *wthl, *uw, *vw;
@@ -453,6 +469,7 @@ void compute_conv_vel_shoc_length(SHOCConvvelData &d);
 void compute_conv_time_shoc_length(SHOCConvtimeData &d);
 void compute_shoc_mix_shoc_length(SHOCMixlengthData &d);
 void check_length_scale_shoc_length(SHOCMixcheckData &d);
+void clipping_diag_third_shoc_moments(SHOCClipthirdmomsData &d);
 void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d);
 void linear_interp(SHOCLinearintData &d);
 void shoc_diag_second_moments_ubycond(SHOCSecondMomentUbycondData& d);

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -401,6 +401,58 @@ struct SHOCClipthirdmomsData : public SHOCDataBase {
   { SHOCDataBase::operator=(rhs); return *this; }
 };//SHOCClipthirdmomsData
 
+struct SHOCAAdiagthirdmomsData
+{
+  // inputs
+  Real omega0, omega1, omega2, x0, x1, y0, y1;
+  
+  // outputs
+  Real aa0, aa1;
+
+};
+
+struct SHOCFtermdiagthirdmomsData
+{
+  // inputs
+  Real thedz, thedz2, bet2, iso, isosqrt, wthl_sec, wthl_sec_kc;
+  Real wthl_sec_kb, thl_sec, thl_sec_kc, thl_sec_kb, w_sec;
+  Real w_sec_kc, w_sec_zi, tke, tke_kc;
+  
+  // outputs
+  Real f0, f1, f2, f3, f4, f5;
+
+};
+
+struct SHOCOmegadiagthirdmomsData
+{
+  // inputs
+  Real buoy_sgs2, f3, f4;
+  
+  // outputs
+  Real omega0, omega1, omega2;
+
+};
+
+struct SHOCXYdiagthirdmomsData
+{
+  // inputs
+  Real buoy_sgs2, f0, f1, f2;
+  
+  // outputs
+  Real x0, y0, x1, y1;
+
+};
+
+struct SHOCFterminputthirdmomsData
+{
+  // inputs
+  Real dz_zi, dz_zt, dz_zt_kc, isotropy_zi, brunt_zi, thetal_zi;
+  
+  // outputs
+  Real thedz, thedz2, iso, isosqrt, buoy_sgs2, bet2;
+
+};
+
 struct SHOCSecondMomentSrfData : public SHOCDataBase {
   // Inputs
   Real *wthl, *uw, *vw;
@@ -473,6 +525,11 @@ void clipping_diag_third_shoc_moments(SHOCClipthirdmomsData &d);
 void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d);
 void linear_interp(SHOCLinearintData &d);
 void shoc_diag_second_moments_ubycond(SHOCSecondMomentUbycondData& d);
+void fterms_input_for_diag_third_shoc_moment(SHOCFterminputthirdmomsData &d);
+void aa_terms_diag_third_shoc_moment(SHOCAAdiagthirdmomsData &d);
+void f0_to_f5_diag_third_shoc_moment(SHOCFtermdiagthirdmomsData &d);
+void omega_terms_diag_third_shoc_moment(SHOCOmegadiagthirdmomsData &d);
+void x_y_terms_diag_third_shoc_moment(SHOCXYdiagthirdmomsData &d);
 
 //
 // _f functions decls

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -414,7 +414,7 @@ struct SHOCAAdiagthirdmomsData
 struct SHOCFtermdiagthirdmomsData
 {
   // inputs
-  Real thedz, thedz2, bet2, iso, isosqrt, wthl_sec, wthl_sec_kc;
+  Real thedz, thedz2, bet2, iso, isosqrd, wthl_sec, wthl_sec_kc;
   Real wthl_sec_kb, thl_sec, thl_sec_kc, thl_sec_kb, w_sec;
   Real w_sec_kc, w_sec_zi, tke, tke_kc;
   
@@ -449,7 +449,7 @@ struct SHOCFterminputthirdmomsData
   Real dz_zi, dz_zt, dz_zt_kc, isotropy_zi, brunt_zi, thetal_zi;
   
   // outputs
-  Real thedz, thedz2, iso, isosqrt, buoy_sgs2, bet2;
+  Real thedz, thedz2, iso, isosqrd, buoy_sgs2, bet2;
 
 };
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -443,6 +443,16 @@ struct SHOCXYdiagthirdmomsData
 
 };
 
+struct SHOCW3diagthirdmomsData
+{
+  // inputs
+  Real aa0, aa1, x0, x1, f5;
+  
+  // outputs
+  Real w3;
+
+};
+
 struct SHOCFterminputthirdmomsData
 {
   // inputs
@@ -521,15 +531,16 @@ void compute_conv_vel_shoc_length(SHOCConvvelData &d);
 void compute_conv_time_shoc_length(SHOCConvtimeData &d);
 void compute_shoc_mix_shoc_length(SHOCMixlengthData &d);
 void check_length_scale_shoc_length(SHOCMixcheckData &d);
-void clipping_diag_third_shoc_moments(SHOCClipthirdmomsData &d);
-void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d);
-void linear_interp(SHOCLinearintData &d);
-void shoc_diag_second_moments_ubycond(SHOCSecondMomentUbycondData& d);
 void fterms_input_for_diag_third_shoc_moment(SHOCFterminputthirdmomsData &d);
 void aa_terms_diag_third_shoc_moment(SHOCAAdiagthirdmomsData &d);
 void f0_to_f5_diag_third_shoc_moment(SHOCFtermdiagthirdmomsData &d);
 void omega_terms_diag_third_shoc_moment(SHOCOmegadiagthirdmomsData &d);
 void x_y_terms_diag_third_shoc_moment(SHOCXYdiagthirdmomsData &d);
+void w3_diag_third_shoc_moment(SHOCW3diagthirdmomsData &d);
+void clipping_diag_third_shoc_moments(SHOCClipthirdmomsData &d);
+void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d);
+void linear_interp(SHOCLinearintData &d);
+void shoc_diag_second_moments_ubycond(SHOCSecondMomentUbycondData& d);
 
 //
 // _f functions decls

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -467,7 +467,20 @@ contains
 
     call check_length_scale_shoc_length(nlev,shcol,host_dx,host_dy,shoc_mix)
 
-  end subroutine check_length_scale_shoc_length_c         
+  end subroutine check_length_scale_shoc_length_c
+  
+  subroutine clipping_diag_third_shoc_moments_c(nlevi,shcol,w_sec_zi,w3) bind (C)
+    use shoc, only: clipping_diag_third_shoc_moments
+
+    integer(kind=c_int), intent(in), value :: nlevi
+    integer(kind=c_int), intent(in), value :: shcol
+    real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi) 
+
+    real(kind=c_real), intent(inout) :: w3(shcol,nlevi)
+
+    call clipping_diag_third_shoc_moments(nlevi,shcol,w_sec_zi,w3)
+
+  end subroutine clipping_diag_third_shoc_moments_c
 
   subroutine shoc_diag_second_moments_srf_c(shcol, wthl, uw, vw, ustar2, wstar) bind(C)
    use shoc, only: diag_second_moments_srf

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -485,7 +485,7 @@ contains
   subroutine fterms_input_for_diag_third_shoc_moment_c(&
                          dz_zi, dz_zt, dz_zt_kc, &
                          isotropy_zi, brunt_zi, thetal_zi, &
-                         thedz, thedz2, iso, isosqrt, buoy_sgs2, bet2) bind (C)
+                         thedz, thedz2, iso, isosqrd, buoy_sgs2, bet2) bind (C)
     use shoc, only: fterms_input_for_diag_third_shoc_moment
 
     real(kind=c_real), intent(in), value :: dz_zi
@@ -498,18 +498,18 @@ contains
     real(kind=c_real), intent(out) :: thedz
     real(kind=c_real), intent(out) :: thedz2
     real(kind=c_real), intent(out) :: iso
-    real(kind=c_real), intent(out) :: isosqrt
+    real(kind=c_real), intent(out) :: isosqrd
     real(kind=c_real), intent(out) :: buoy_sgs2
     real(kind=c_real), intent(out) :: bet2
 
     call fterms_input_for_diag_third_shoc_moment(dz_zi, dz_zt, dz_zt_kc, &
                          isotropy_zi, brunt_zi, thetal_zi, &
-                         thedz, thedz2, iso, isosqrt, buoy_sgs2, bet2)
+                         thedz, thedz2, iso, isosqrd, buoy_sgs2, bet2)
 
   end subroutine fterms_input_for_diag_third_shoc_moment_c
   
   subroutine f0_to_f5_diag_third_shoc_moment_c(&
-                          thedz, thedz2, bet2, iso, isosqrt, &
+                          thedz, thedz2, bet2, iso, isosqrd, &
                           wthl_sec, wthl_sec_kc, wthl_sec_kb, &
                           thl_sec, thl_sec_kc, thl_sec_kb, & 
                           w_sec, w_sec_kc,w_sec_zi, &
@@ -521,7 +521,7 @@ contains
     real(kind=c_real), intent(in), value :: thedz2
     real(kind=c_real), intent(in), value :: bet2
     real(kind=c_real), intent(in), value :: iso
-    real(kind=c_real), intent(in), value :: isosqrt
+    real(kind=c_real), intent(in), value :: isosqrd
     real(kind=c_real), intent(in), value :: wthl_sec
     real(kind=c_real), intent(in), value :: wthl_sec_kc
     real(kind=c_real), intent(in), value :: wthl_sec_kb
@@ -542,7 +542,7 @@ contains
     real(kind=c_real), intent(out) :: f5
 
     call f0_to_f5_diag_third_shoc_moment(&
-                          thedz, thedz2, bet2, iso, isosqrt, &
+                          thedz, thedz2, bet2, iso, isosqrd, &
                           wthl_sec, wthl_sec_kc, wthl_sec_kb, &
                           thl_sec, thl_sec_kc, thl_sec_kb, & 
                           w_sec, w_sec_kc,w_sec_zi, &

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -481,6 +481,139 @@ contains
     call clipping_diag_third_shoc_moments(nlevi,shcol,w_sec_zi,w3)
 
   end subroutine clipping_diag_third_shoc_moments_c
+  
+  subroutine fterms_input_for_diag_third_shoc_moment_c(&
+                         dz_zi, dz_zt, dz_zt_kc, &
+                         isotropy_zi, brunt_zi, thetal_zi, &
+                         thedz, thedz2, iso, isosqrt, buoy_sgs2, bet2) bind (C)
+    use shoc, only: fterms_input_for_diag_third_shoc_moment
+
+    real(kind=c_real), intent(in), value :: dz_zi
+    real(kind=c_real), intent(in), value :: dz_zt
+    real(kind=c_real), intent(in), value :: dz_zt_kc
+    real(kind=c_real), intent(in), value :: isotropy_zi
+    real(kind=c_real), intent(in), value :: brunt_zi
+    real(kind=c_real), intent(in), value :: thetal_zi
+
+    real(kind=c_real), intent(out) :: thedz
+    real(kind=c_real), intent(out) :: thedz2
+    real(kind=c_real), intent(out) :: iso
+    real(kind=c_real), intent(out) :: isosqrt
+    real(kind=c_real), intent(out) :: buoy_sgs2
+    real(kind=c_real), intent(out) :: bet2
+
+    call fterms_input_for_diag_third_shoc_moment(dz_zi, dz_zt, dz_zt_kc, &
+                         isotropy_zi, brunt_zi, thetal_zi, &
+                         thedz, thedz2, iso, isosqrt, buoy_sgs2, bet2)
+
+  end subroutine fterms_input_for_diag_third_shoc_moment_c
+  
+  subroutine f0_to_f5_diag_third_shoc_moment_c(&
+                          thedz, thedz2, bet2, iso, isosqrt, &
+                          wthl_sec, wthl_sec_kc, wthl_sec_kb, &
+                          thl_sec, thl_sec_kc, thl_sec_kb, & 
+                          w_sec, w_sec_kc,w_sec_zi, &
+                          tke, tke_kc, &
+                          f0, f1, f2, f3, f4, f5) bind (C)
+    use shoc, only: f0_to_f5_diag_third_shoc_moment
+
+    real(kind=c_real), intent(in), value :: thedz
+    real(kind=c_real), intent(in), value :: thedz2
+    real(kind=c_real), intent(in), value :: bet2
+    real(kind=c_real), intent(in), value :: iso
+    real(kind=c_real), intent(in), value :: isosqrt
+    real(kind=c_real), intent(in), value :: wthl_sec
+    real(kind=c_real), intent(in), value :: wthl_sec_kc
+    real(kind=c_real), intent(in), value :: wthl_sec_kb
+    real(kind=c_real), intent(in), value :: thl_sec
+    real(kind=c_real), intent(in), value :: thl_sec_kc
+    real(kind=c_real), intent(in), value :: thl_sec_kb
+    real(kind=c_real), intent(in), value :: w_sec
+    real(kind=c_real), intent(in), value :: w_sec_kc
+    real(kind=c_real), intent(in), value :: w_sec_zi
+    real(kind=c_real), intent(in), value :: tke
+    real(kind=c_real), intent(in), value :: tke_kc
+
+    real(kind=c_real), intent(out) :: f0
+    real(kind=c_real), intent(out) :: f1
+    real(kind=c_real), intent(out) :: f2
+    real(kind=c_real), intent(out) :: f3
+    real(kind=c_real), intent(out) :: f4
+    real(kind=c_real), intent(out) :: f5
+
+    call f0_to_f5_diag_third_shoc_moment(&
+                          thedz, thedz2, bet2, iso, isosqrt, &
+                          wthl_sec, wthl_sec_kc, wthl_sec_kb, &
+                          thl_sec, thl_sec_kc, thl_sec_kb, & 
+                          w_sec, w_sec_kc,w_sec_zi, &
+                          tke, tke_kc, &
+                          f0, f1, f2, f3, f4, f5)
+
+  end subroutine f0_to_f5_diag_third_shoc_moment_c
+  
+  subroutine omega_terms_diag_third_shoc_moment_c(&
+                          buoy_sgs2, f3, f4,&
+			  omega0, omega1, omega2) bind (C)
+    use shoc, only: omega_terms_diag_third_shoc_moment
+
+    real(kind=c_real), intent(in), value :: buoy_sgs2
+    real(kind=c_real), intent(in), value :: f3
+    real(kind=c_real), intent(in), value :: f4
+
+    real(kind=c_real), intent(out) :: omega0
+    real(kind=c_real), intent(out) :: omega1
+    real(kind=c_real), intent(out) :: omega2
+
+    call omega_terms_diag_third_shoc_moment(&
+                          buoy_sgs2, f3, f4, &
+			  omega0, omega1, omega2)
+
+  end subroutine omega_terms_diag_third_shoc_moment_c 
+  
+  subroutine x_y_terms_diag_third_shoc_moment_c(&
+                          buoy_sgs2, f0, f1, f2,&
+			  x0, y0, x1, y1) bind (C)
+    use shoc, only: x_y_terms_diag_third_shoc_moment
+
+    real(kind=c_real), intent(in), value :: buoy_sgs2
+    real(kind=c_real), intent(in), value :: f0
+    real(kind=c_real), intent(in), value :: f1
+    real(kind=c_real), intent(in), value :: f2
+
+    real(kind=c_real), intent(out) :: x0
+    real(kind=c_real), intent(out) :: y0
+    real(kind=c_real), intent(out) :: x1
+    real(kind=c_real), intent(out) :: y1
+
+    call x_y_terms_diag_third_shoc_moment(&
+                          buoy_sgs2, f0, f1, f2,&
+			  x0, y0, x1, y1)
+
+  end subroutine x_y_terms_diag_third_shoc_moment_c 
+  
+  subroutine aa_terms_diag_third_shoc_moment_c(&
+                          omega0, omega1, omega2,&
+			  x0, x1, y0, y1, &
+			  aa0, aa1) bind (C)
+    use shoc, only: aa_terms_diag_third_shoc_moment
+
+    real(kind=c_real), intent(in), value :: omega0
+    real(kind=c_real), intent(in), value :: omega1
+    real(kind=c_real), intent(in), value :: omega2
+    real(kind=c_real), intent(in), value :: x0
+    real(kind=c_real), intent(in), value :: x1
+    real(kind=c_real), intent(in), value :: y0
+    real(kind=c_real), intent(in), value :: y1
+
+    real(kind=c_real), intent(out) :: aa0
+    real(kind=c_real), intent(out) :: aa1
+
+    call aa_terms_diag_third_shoc_moment(&
+                          omega0, omega1, omega2,&
+			  x0, x1, y0, y1, &
+			  aa0, aa1)
+
+  end subroutine aa_terms_diag_third_shoc_moment_c        
 
   subroutine shoc_diag_second_moments_srf_c(shcol, wthl, uw, vw, ustar2, wstar) bind(C)
    use shoc, only: diag_second_moments_srf

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -551,6 +551,21 @@ contains
 
   end subroutine f0_to_f5_diag_third_shoc_moment_c
   
+  subroutine w3_diag_third_shoc_moment_c(aa0, aa1, x0, x1, f5, w3) bind (c)
+    use shoc, only: w3_diag_third_shoc_moment
+    
+    real(kind=c_real), intent(in), value :: aa0
+    real(kind=c_real), intent(in), value :: aa1
+    real(kind=c_real), intent(in), value :: x0
+    real(kind=c_real), intent(in), value :: x1
+    real(kind=c_real), intent(in), value :: f5
+    
+    real(kind=c_real), intent(out) :: w3
+
+    w3 = w3_diag_third_shoc_moment(aa0, aa1, x0, x1, f5)
+    
+  end subroutine w3_diag_third_shoc_moment_c
+  
   subroutine omega_terms_diag_third_shoc_moment_c(&
                           buoy_sgs2, f3, f4,&
 			  omega0, omega1, omega2) bind (C)

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SHOC_TESTS_SRCS
     shoc_check_length_tests.cpp
     shoc_conv_time_length_tests.cpp
     shoc_mix_length_tests.cpp
+    shoc_clip_third_moms_tests.cpp
     shoc_tke_column_stab_tests.cpp
     shoc_tke_shr_prod_tests.cpp
     shoc_tke_isotropic_ts_tests.cpp

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -17,6 +17,8 @@ set(SHOC_TESTS_SRCS
     shoc_check_length_tests.cpp
     shoc_conv_time_length_tests.cpp
     shoc_mix_length_tests.cpp
+    shoc_fterm_input_third_moms_tests.cpp
+    shoc_fterm_diag_third_moms_tests.cpp
     shoc_clip_third_moms_tests.cpp
     shoc_tke_column_stab_tests.cpp
     shoc_tke_shr_prod_tests.cpp

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SHOC_TESTS_SRCS
     shoc_omega_diag_third_moms_tests.cpp
     shoc_xy_diag_third_moms_tests.cpp
     shoc_aa_diag_third_moms_tests.cpp
+    shoc_w3_diag_third_moms_tests.cpp
     shoc_clip_third_moms_tests.cpp
     shoc_tke_column_stab_tests.cpp
     shoc_tke_shr_prod_tests.cpp

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -19,6 +19,9 @@ set(SHOC_TESTS_SRCS
     shoc_mix_length_tests.cpp
     shoc_fterm_input_third_moms_tests.cpp
     shoc_fterm_diag_third_moms_tests.cpp
+    shoc_omega_diag_third_moms_tests.cpp
+    shoc_xy_diag_third_moms_tests.cpp
+    shoc_aa_diag_third_moms_tests.cpp
     shoc_clip_third_moms_tests.cpp
     shoc_tke_column_stab_tests.cpp
     shoc_tke_shr_prod_tests.cpp

--- a/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
@@ -99,7 +99,7 @@ TEST_CASE("shoc_aa_diag_third_moms_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_aa_diag_third_moms_b4b", "shoc")
+TEST_CASE("shoc_aa_diag_third_moms_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestAAdiagThirdMoms;
 

--- a/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
@@ -27,17 +27,55 @@ struct UnitWrap::UnitTest<D>::TestAAdiagThirdMoms {
 
     // Tests for the SHOC function:
     //   aa_terms_diag_third_shoc_moment
+    
+    // Run test two times.  One where 0 parameters stay the same
+    //  and the other where 1 parameters vary.  Verify that the aa0
+    //  term remains constant between the two tests.  
   
-    //  Test to be sure that very high values of w3
-    //    are reduced but still the same sign   
-  
+    // omega0 term
+    constexpr static Real omega0 = 7.54e-2;
+    // omega1 term
+    constexpr static Real omega1 = 5.37e-3;
+    // omega2 term
+    constexpr static Real omega2 = 0.54;
+    // x0 term
+    constexpr static Real x0 = -4.31;
+    // y0 term
+    constexpr static Real y0 = 22.72;
+    // x1 term
+    constexpr static Real x1_test1a = 41.05;
+    // y1 term
+    constexpr static Real y1_test1a = 375.69;            
 
     // Initialize data structure for bridging to F90
     SHOCAAdiagthirdmomsData SDS;
 
+    // Load up the data
+    SDS.omega0 = omega0;
+    SDS.x0 = x0;
+    SDS.y0 = y0;
+    SDS.omega1 = omega1;
+    SDS.x1 = x1_test1a;
+    SDS.y1 = y1_test1a;
+    SDS.omega2 = omega2;
+      
+    // Call the fortran implementation    
+    aa_terms_diag_third_shoc_moment(SDS);  
+    
+    // Save the output
+    Real aa0_test1a = SDS.aa0;
+    Real aa1_test1a = SDS.aa1;
+    
+    // Load up data where only the 1 terms have varies
+    SDS.x1 = 0.3*x1_test1a;
+    SDS.y1 = 0.3*y1_test1a;   
     
     // Call the fortran implementation    
-    aa_terms_diag_third_shoc_moment(SDS);    
+    aa_terms_diag_third_shoc_moment(SDS); 
+    
+    // Check the result
+    REQUIRE(SDS.aa0 == aa0_test1a);
+    REQUIRE(SDS.aa1 < aa1_test1a);       
     
   }
 

--- a/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
@@ -103,6 +103,8 @@ TEST_CASE("shoc_aa_diag_third_moms_b4b", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestAAdiagThirdMoms;
 
+  TestStruct::run_bfb();
+
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
@@ -1,0 +1,65 @@
+#include "catch2/catch.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestAAdiagThirdMoms {
+
+  static void run_property()
+  {
+
+    // Tests for the SHOC function:
+    //   aa_terms_diag_third_shoc_moment
+  
+    //  Test to be sure that very high values of w3
+    //    are reduced but still the same sign   
+  
+
+    // Initialize data structure for bridging to F90
+    SHOCAAdiagthirdmomsData SDS;
+
+    
+    // Call the fortran implementation    
+    aa_terms_diag_third_shoc_moment(SDS);    
+    
+  }
+
+};
+
+}  // namespace unit_test
+}  // namespace shoc
+}  // namespace scream
+
+namespace{
+
+TEST_CASE("shoc_aa_diag_third_moms_property", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestAAdiagThirdMoms;
+  
+  TestStruct::run_property();
+}
+
+TEST_CASE("shoc_aa_diag_third_moms_b4b", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestAAdiagThirdMoms;
+
+}
+
+} // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
@@ -78,6 +78,11 @@ struct UnitWrap::UnitTest<D>::TestAAdiagThirdMoms {
     REQUIRE(SDS.aa1 < aa1_test1a);       
     
   }
+  
+  static void run_bfb()
+  {
+    // TODO
+  }  
 
 };
 

--- a/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
@@ -102,6 +102,11 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
     }    
     
   }
+  
+  static void run_bfb()
+  {
+    // TODO
+  }  
 
 };
 

--- a/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
@@ -123,7 +123,7 @@ TEST_CASE("shoc_clip_third_moms_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_clip_third_moms_b4b", "shoc")
+TEST_CASE("shoc_clip_third_moms_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestClipThirdMoms;
 

--- a/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
@@ -127,6 +127,7 @@ TEST_CASE("shoc_clip_third_moms_b4b", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestClipThirdMoms;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
@@ -1,0 +1,127 @@
+#include "catch2/catch.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
+
+  static void run_property()
+  {
+    static constexpr Int shcol    = 2;
+    static constexpr Int nlevi     = 5;
+
+    // Tests for the SHOC function:
+    //   clipping_diag_third_shoc_moments
+  
+    //  Test to be sure that very high values of w3
+    //    are reduced but still the same sign   
+  
+    // Define the second moment of vertical velocity
+    static constexpr Real w_sec_zi[nlevi] = {0.3, 0.4, 0.5, 0.4, 0.1}; 
+    // Define the third moment of vertical velocity
+    static constexpr Real w3_in[nlevi] = {0.2, 99999, -99999, 0.2, 0.05}; 
+    
+    // Define a local logical
+    bool w3_large;
+
+    // Initialize data structure for bridgeing to F90
+    SHOCClipthirdmomsData SDS(shcol, nlevi);
+
+    // Test that the inputs are reasonable.
+    REQUIRE(SDS.shcol > 0);
+    REQUIRE(SDS.nlevi > 1);
+    
+    // load up the input data
+    // Fill in test data on zt_grid.
+    for(Int s = 0; s < SDS.shcol; ++s) {
+      for(Int n = 0; n < SDS.nlevi; ++n) {
+        const auto offset = n + s * SDS.nlevi;
+
+        SDS.w_sec_zi[offset] = w_sec_zi[n];
+	SDS.w3[offset] = w3_in[n];
+      }
+    }
+    
+    // Verify the data
+    // For this particular test wen want to be sure that
+    //   the input has relatively small values of w2 (let's say
+    //   all smaller than 1, which is reasonable) and let's 
+    //   be sure that w3 has some very large unreasonable values
+    for(Int s = 0; s < SDS.shcol; ++s) {
+      // Initialize conditional to make sure there are
+      //   large values of w3 in input
+      w3_large = false;
+      for(Int n = 0; n < SDS.nlevi; ++n) {
+        const auto offset = n + s * SDS.nlevi;
+
+        REQUIRE(SDS.w_sec_zi[offset] <= 1);
+	if (abs(SDS.w3[offset]) > 1000){
+	  w3_large = true;
+	}
+        SDS.w_sec_zi[offset] = w_sec_zi[n];
+	SDS.w3[offset] = w3_in[n];
+      }
+      REQUIRE(w3_large == true);
+    }
+    
+    // Call the fortran implementation    
+    clipping_diag_third_shoc_moments(SDS);
+    
+    // Check the result
+    // For large values of w3, verify that the result has been 
+    //  reduced and is of the same sign
+    for(Int s = 0; s < SDS.shcol; ++s) {
+      for(Int n = 0; n < SDS.nlevi; ++n) {
+        const auto offset = n + s * SDS.nlevi;
+	
+	if (abs(w3_in[n]) > 1000){
+	  REQUIRE(abs(SDS.w3[offset]) < abs(w3_in[n]));
+	  if (w3_in[n] < 0){
+	    REQUIRE(SDS.w3[offset] < 0);
+	  }
+	} 
+	
+      }
+    }    
+    
+  }
+
+};
+
+}  // namespace unit_test
+}  // namespace shoc
+}  // namespace scream
+
+namespace{
+
+TEST_CASE("shoc_clip_third_moms_property", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestClipThirdMoms;
+  
+  TestStruct::run_property();
+}
+
+TEST_CASE("shoc_clip_third_moms_b4b", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestClipThirdMoms;
+
+}
+
+} // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
@@ -26,7 +26,6 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
   {
     static constexpr Int shcol    = 2;
     static constexpr Int nlevi    = 5;
-    static constexpr Int nlev     = nlevi-1;
 
     // Tests for the SHOC function:
     //   clipping_diag_third_shoc_moments
@@ -42,18 +41,18 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
     // Define a local logical
     bool w3_large;
 
-    // Initialize data structure for bridgeing to F90
-    SHOCClipthirdmomsData SDS(shcol, nlev, nlevi);
+    // Initialize data structure for bridging to F90
+    SHOCClipthirdmomsData SDS(shcol, nlevi);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.shcol > 0);
-    REQUIRE(SDS.nlevi > 1);
+    REQUIRE(SDS.shcol() > 0);
+    REQUIRE(SDS.nlevi() > 1);
     
     // load up the input data
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-        const auto offset = n + s * SDS.nlevi;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlevi; ++n) {
+        const auto offset = n + s * nlevi;
 
         SDS.w_sec_zi[offset] = w_sec_zi[n];
 	SDS.w3[offset] = w3_in[n];
@@ -65,12 +64,12 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
     //   the input has relatively small values of w2 (let's say
     //   all smaller than 1, which is reasonable) and let's 
     //   be sure that w3 has some very large unreasonable values
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // Initialize conditional to make sure there are
       //   large values of w3 in input
       w3_large = false;
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-        const auto offset = n + s * SDS.nlevi;
+      for(Int n = 0; n < nlevi; ++n) {
+        const auto offset = n + s * nlevi;
 
         REQUIRE(SDS.w_sec_zi[offset] <= 1);
 	if (abs(SDS.w3[offset]) > 1000){
@@ -88,9 +87,9 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
     // Check the result
     // For large values of w3, verify that the result has been 
     //  reduced and is of the same sign
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-        const auto offset = n + s * SDS.nlevi;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlevi; ++n) {
+        const auto offset = n + s * nlevi;
 	
 	if (abs(w3_in[n]) > 1000){
 	  REQUIRE(abs(SDS.w3[offset]) < abs(w3_in[n]));

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
@@ -169,7 +169,7 @@ TEST_CASE("shoc_fterm_diag_third_moms_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_fterm_diag_third_moms_b4b", "shoc")
+TEST_CASE("shoc_fterm_diag_third_moms_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestFtermdiagThirdMoms;
 

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
@@ -173,6 +173,7 @@ TEST_CASE("shoc_fterm_diag_third_moms_b4b", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestFtermdiagThirdMoms;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
@@ -1,0 +1,65 @@
+#include "catch2/catch.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestFtermdiagThirdMoms {
+
+  static void run_property()
+  {
+
+    // Tests for the SHOC function:
+    //   f0_to_f5_diag_third_shoc_moment
+  
+    //  Test to be sure that very high values of w3
+    //    are reduced but still the same sign   
+  
+
+    // Initialize data structure for bridging to F90
+    SHOCFtermdiagthirdmomsData SDS;
+
+    
+    // Call the fortran implementation    
+    f0_to_f5_diag_third_shoc_moment(SDS);    
+    
+  }
+
+};
+
+}  // namespace unit_test
+}  // namespace shoc
+}  // namespace scream
+
+namespace{
+
+TEST_CASE("shoc_fterm_diag_third_moms_property", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestFtermdiagThirdMoms;
+  
+  TestStruct::run_property();
+}
+
+TEST_CASE("shoc_fterm_diag_third_moms_b4b", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestFtermdiagThirdMoms;
+
+}
+
+} // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
@@ -28,16 +28,124 @@ struct UnitWrap::UnitTest<D>::TestFtermdiagThirdMoms {
     // Tests for the SHOC function:
     //   f0_to_f5_diag_third_shoc_moment
   
-    //  Test to be sure that very high values of w3
-    //    are reduced but still the same sign   
+    // TEST ONE
+    // Zero test.  Given no gradients, verify that relevant
+    //  terms are zero. 
+    
+    // 1/grid spacing [m-1]
+    constexpr static Real thedz = 0.1;
+    // 1/grid spacing for two grids [m-1]
+    constexpr static Real thedz2 = 0.05;
+    // bet2 term (ggr/thetal)
+    constexpr static Real bet2 = 0.0327;
+    // return to isotropy timescale [s]
+    constexpr static Real iso = 1000;
+    // liquid water flux [K m/s]
+    constexpr static Real wthl_sec_zero = 0.01;
+    // thetal variance [K^2]
+    constexpr static Real thl_sec_zero = 2;
+    // vertical velocity variance [m2/s2]
+    constexpr static Real w_sec_zero = 0.4;
+    // TKE [m2/s2]
+    constexpr static Real tke_zero = 0.5;
   
-
     // Initialize data structure for bridging to F90
     SHOCFtermdiagthirdmomsData SDS;
-
+    
+    // Fill in data
+    SDS.thedz = thedz;
+    SDS.thedz2 = thedz2;
+    SDS.bet2 = bet2;
+    SDS.iso = iso;
+    SDS.isosqrd = iso*iso;
+    // for the following moments, feed each level
+    //  the same value for this test
+    SDS.wthl_sec = wthl_sec_zero;
+    SDS.wthl_sec_kc = wthl_sec_zero;
+    SDS.wthl_sec_kb = wthl_sec_zero;
+    SDS.thl_sec = thl_sec_zero;
+    SDS.thl_sec_kc = thl_sec_zero;
+    SDS.thl_sec_kb = thl_sec_zero;
+    SDS.w_sec = w_sec_zero;
+    SDS.w_sec_kc = w_sec_zero;
+    SDS.w_sec_zi = w_sec_zero;
+    SDS.tke = tke_zero;
+    SDS.tke_kc = tke_zero;
+    
+    // Be sure inputs are as we expect
+    REQUIRE(SDS.thedz > 0);
+    REQUIRE(SDS.thedz2 > 0);
+    REQUIRE(SDS.wthl_sec_kc == SDS.wthl_sec_kb);
+    REQUIRE(SDS.thl_sec_kc == SDS.thl_sec_kb);
+    REQUIRE(SDS.w_sec_kc == SDS.w_sec); 
+    REQUIRE(SDS.tke_kc == SDS.tke);          
     
     // Call the fortran implementation    
     f0_to_f5_diag_third_shoc_moment(SDS);    
+    
+    // Check result, make sure all outputs are zero
+    REQUIRE(SDS.f0 == 0);
+    REQUIRE(SDS.f1 == 0);
+    REQUIRE(SDS.f2 == 0);
+    REQUIRE(SDS.f3 == 0);
+    REQUIRE(SDS.f4 == 0);
+    REQUIRE(SDS.f5 == 0);
+    
+    // TEST TWO 
+    // Positive gradient test.  Feed the function values of the second 
+    //  moments with positive gradients.  All fterms should have positive values
+
+    // liquid water flux [K m/s]
+    constexpr static Real wthl_sec = 0.01;
+    // liquid water flux [K m/s] above
+    constexpr static Real wthl_sec_kc = 0.02;
+    // liquid water flux [K m/s] below
+    constexpr static Real wthl_sec_kb = 0.00;        
+    // thetal variance [K^2]
+    constexpr static Real thl_sec = 2;
+    // thetal variance [K^2] above
+    constexpr static Real thl_sec_kc = 2.5;
+    // thetal variance [K^2]
+    constexpr static Real thl_sec_kb = 1.7;    
+    // vertical velocity variance [m2/s2]
+    constexpr static Real w_sec = 0.4;
+    // vertical velocity variance [m2/s2] above
+    constexpr static Real w_sec_kc = 0.5;    
+    // TKE [m2/s2]
+    constexpr static Real tke = 0.5;
+    // TKE [m2/s2] above
+    constexpr static Real tke_kc = 0.55;    
+    
+    // Feed in data
+    SDS.wthl_sec = wthl_sec;
+    SDS.wthl_sec_kc = wthl_sec_kc;
+    SDS.wthl_sec_kb = wthl_sec_kb;
+    SDS.thl_sec = thl_sec;
+    SDS.thl_sec_kc = thl_sec_kc;
+    SDS.thl_sec_kb = thl_sec_kb;
+    SDS.w_sec = w_sec;
+    SDS.w_sec_kc = w_sec_kc;
+    SDS.w_sec_zi = w_sec;
+    SDS.tke = tke;
+    SDS.tke_kc = tke_kc;
+    
+    // Verify input is what we want for this test
+    REQUIRE(wthl_sec > 0);
+    REQUIRE(wthl_sec_kc > wthl_sec_kb);
+    REQUIRE(thl_sec_kc > thl_sec_kb);
+    REQUIRE(w_sec_kc > w_sec); 
+    REQUIRE(tke_kc > tke);   
+    
+    // Call the fortran implementation    
+    f0_to_f5_diag_third_shoc_moment(SDS);    
+
+    // Check result, make sure all outputs are zero
+    REQUIRE(SDS.f0 > 0);
+    REQUIRE(SDS.f1 > 0);
+    REQUIRE(SDS.f2 > 0);
+    REQUIRE(SDS.f3 > 0);
+    REQUIRE(SDS.f4 > 0);
+    REQUIRE(SDS.f5 > 0);
     
   }
 

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
@@ -148,6 +148,11 @@ struct UnitWrap::UnitTest<D>::TestFtermdiagThirdMoms {
     REQUIRE(SDS.f5 > 0);
     
   }
+  
+  static void run_bfb()
+  {
+    // TODO
+  }  
 
 };
 

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
@@ -81,6 +81,11 @@ struct UnitWrap::UnitTest<D>::TestFtermInputThirdMoms {
     }
     
   }
+  
+  static void run_bfb()
+  {
+    // TODO
+  }  
 
 };
 

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
@@ -102,7 +102,7 @@ TEST_CASE("shoc_fterm_input_third_moms_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_fterm_input_third_moms_b4b", "shoc")
+TEST_CASE("shoc_fterm_input_third_moms_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestFtermInputThirdMoms;
 

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
@@ -1,0 +1,65 @@
+#include "catch2/catch.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestFtermInputThirdMoms {
+
+  static void run_property()
+  {
+
+    // Tests for the SHOC function:
+    //   fterms_input_for_diag_third_shoc_moment
+  
+    //  Test to be sure that very high values of w3
+    //    are reduced but still the same sign   
+  
+
+    // Initialize data structure for bridging to F90
+    SHOCFterminputthirdmomsData SDS;
+
+    
+    // Call the fortran implementation    
+    fterms_input_for_diag_third_shoc_moment(SDS);    
+    
+  }
+
+};
+
+}  // namespace unit_test
+}  // namespace shoc
+}  // namespace scream
+
+namespace{
+
+TEST_CASE("shoc_fterm_input_third_moms_property", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestFtermInputThirdMoms;
+  
+  TestStruct::run_property();
+}
+
+TEST_CASE("shoc_fterm_input_third_moms_b4b", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestFtermInputThirdMoms;
+
+}
+
+} // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
@@ -106,6 +106,7 @@ TEST_CASE("shoc_fterm_input_third_moms_b4b", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestFtermInputThirdMoms;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
@@ -28,16 +28,57 @@ struct UnitWrap::UnitTest<D>::TestFtermInputThirdMoms {
     // Tests for the SHOC function:
     //   fterms_input_for_diag_third_shoc_moment
   
-    //  Test to be sure that very high values of w3
-    //    are reduced but still the same sign   
-  
-
+    // TEST
+    // Given inputs, verify that output is reasonable  
+    
+    // grid spacing on interface grid [m]
+    constexpr static Real dz_zi = 100;
+    // grid spacing on midpoint grid [m]
+    constexpr static Real dz_zt = 80;
+    // grid spacing on adjacent midpoint grid [m]
+    constexpr static Real dz_zt_kc = 120;
+    // Return to isotropic timescale [s]
+    constexpr static Real isotropy_zi = 1000;
+    // Brunt vaisalla frequency [s] 
+    constexpr static Real brunt_zi = -0.05;
+    // Potential temperature on interface grid [K]
+    constexpr static Real thetal_zi = 300;
+    
     // Initialize data structure for bridging to F90
     SHOCFterminputthirdmomsData SDS;
-
+    
+    SDS.dz_zi = dz_zi;
+    SDS.dz_zt = dz_zt;
+    SDS.dz_zt_kc = dz_zt_kc;
+    SDS.isotropy_zi = isotropy_zi;
+    SDS.brunt_zi = brunt_zi;
+    SDS.thetal_zi = thetal_zi;
+    
+    // Check that input is physical 
+    REQUIRE(SDS.dz_zi > 0);
+    REQUIRE(SDS.dz_zt > 0);
+    REQUIRE(SDS.dz_zt_kc > 0);
+    REQUIRE(SDS.isotropy_zi > 0);
+    REQUIRE(SDS.thetal_zi > 0);
     
     // Call the fortran implementation    
-    fterms_input_for_diag_third_shoc_moment(SDS);    
+    fterms_input_for_diag_third_shoc_moment(SDS);  
+    
+    // Verify the result
+    
+    // Check that thedz2 is smaller than thedz.
+    REQUIRE(SDS.thedz2 < SDS.thedz);
+    
+    // Check that bet2 is smaller than thetal
+    REQUIRE(SDS.bet2 < SDS.thetal_zi);
+    
+    // Be sure that iso and isosqrd relationships hold
+    if (SDS.isotropy_zi > 1){
+      REQUIRE(SDS.isosqrd > SDS.iso);
+    }  
+    else{
+      REQUIRE(SDS.isosqrd < SDS.iso);
+    }
     
   }
 

--- a/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
@@ -100,6 +100,7 @@ TEST_CASE("shoc_omega_diag_third_moms_b4b", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestOmegadiagThirdMoms;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
@@ -1,0 +1,65 @@
+#include "catch2/catch.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestOmegadiagThirdMoms {
+
+  static void run_property()
+  {
+
+    // Tests for the SHOC function:
+    //   omega_terms_diag_third_shoc_moment
+  
+    //  Test to be sure that very high values of w3
+    //    are reduced but still the same sign   
+  
+
+    // Initialize data structure for bridging to F90
+    SHOCOmegadiagthirdmomsData SDS;
+
+    
+    // Call the fortran implementation    
+    omega_terms_diag_third_shoc_moment(SDS);    
+    
+  }
+
+};
+
+}  // namespace unit_test
+}  // namespace shoc
+}  // namespace scream
+
+namespace{
+
+TEST_CASE("shoc_omega_diag_third_moms_property", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestOmegadiagThirdMoms;
+  
+  TestStruct::run_property();
+}
+
+TEST_CASE("shoc_omega_diag_third_moms_b4b", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestOmegadiagThirdMoms;
+
+}
+
+} // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
@@ -96,7 +96,7 @@ TEST_CASE("shoc_omega_diag_third_moms_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_omega_diag_third_moms_b4b", "shoc")
+TEST_CASE("shoc_omega_diag_third_moms_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestOmegadiagThirdMoms;
 

--- a/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
@@ -28,16 +28,51 @@ struct UnitWrap::UnitTest<D>::TestOmegadiagThirdMoms {
     // Tests for the SHOC function:
     //   omega_terms_diag_third_shoc_moment
   
-    //  Test to be sure that very high values of w3
-    //    are reduced but still the same sign   
+    // TEST ONE
+    // Call the function twice, with two different sets of terms.  
+    //  In the second test the fterms should be larger.  Verify 
+    //  that the omega0 and omega1 terms are the same, but that the
+    //  omega2 term has increased.  
   
-
+    // buoyancy term (isotropy squared * brunt vaisalla frequency)
+    constexpr static Real buoy_sgs2 = -100;
+    // f3 term
+    constexpr static Real f3_test1a = 14;
+    // f4 term
+    constexpr static Real f4_test1a = 5;
+  
     // Initialize data structure for bridging to F90
     SHOCOmegadiagthirdmomsData SDS;
-
+    
+    // Load up the data
+    SDS.buoy_sgs2 = buoy_sgs2;
+    SDS.f3 = f3_test1a;
+    SDS.f4 = f4_test1a;
     
     // Call the fortran implementation    
     omega_terms_diag_third_shoc_moment(SDS);    
+    
+    // Save test results
+    Real omega0_test1a = SDS.omega0;
+    Real omega1_test1a = SDS.omega1;
+    Real omega2_test1a = SDS.omega2;
+    
+    // Now load up data for second part of test
+    // Feed in LARGER values
+    SDS.f3 = 2*f3_test1a;
+    SDS.f4 = 2*f4_test1a;    
+    
+    // Call the fortran implementation    
+    omega_terms_diag_third_shoc_moment(SDS);
+    
+    // Now check the result
+    
+    // omega0 and omega1 should NOT have changed
+    REQUIRE(SDS.omega0 == omega0_test1a);
+    REQUIRE(SDS.omega1 == omega1_test1a);
+    
+    // omega2 should have increased
+    REQUIRE(SDS.omega2 > omega2_test1a);    
     
   }
 

--- a/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
@@ -75,6 +75,11 @@ struct UnitWrap::UnitTest<D>::TestOmegadiagThirdMoms {
     REQUIRE(SDS.omega2 > omega2_test1a);    
     
   }
+  
+  static void run_bfb()
+  {
+    // TODO
+  }  
 
 };
 

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -68,6 +68,12 @@ struct UnitWrap {
     struct TestCompBruntShocLength;
     struct TestCheckShocLength;
     struct TestClipThirdMoms;
+    struct TestAAdiagThirdMoms;
+    struct TestFtermInputThirdMoms;
+    struct TestFtermdiagThirdMoms;
+    struct TestOmegadiagThirdMoms;
+    struct TestW3diagThirdMoms;
+    struct TestXYdiagThirdMoms;
     struct TestCompShocConvTime;
     struct TestCompShocConvVel;
     struct TestLInfShocLength;

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -69,6 +69,7 @@ struct UnitWrap {
     struct TestCheckShocLength;
     struct TestClipThirdMoms;
     struct TestAAdiagThirdMoms;
+    struct TestW3diagThirdMoms;
     struct TestFtermInputThirdMoms;
     struct TestFtermdiagThirdMoms;
     struct TestOmegadiagThirdMoms;

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -67,6 +67,7 @@ struct UnitWrap {
     struct TestShocVarorCovar;
     struct TestCompBruntShocLength;
     struct TestCheckShocLength;
+    struct TestClipThirdMoms;
     struct TestCompShocConvTime;
     struct TestCompShocConvVel;
     struct TestLInfShocLength;

--- a/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
@@ -119,7 +119,7 @@ TEST_CASE("shoc_w3_diag_third_moms_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_w3_diag_third_moms_b4b", "shoc")
+TEST_CASE("shoc_w3_diag_third_moms_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestW3diagThirdMoms;
 

--- a/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
@@ -1,0 +1,65 @@
+#include "catch2/catch.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestW3diagThirdMoms {
+
+  static void run_property()
+  {
+
+    // Tests for the SHOC function:
+    //   w3_diag_third_shoc_moment
+  
+    //  Test to be sure that very high values of w3
+    //    are reduced but still the same sign   
+  
+
+    // Initialize data structure for bridging to F90
+    SHOCW3diagthirdmomsData SDS;
+
+    
+    // Call the fortran implementation    
+    w3_diag_third_shoc_moment(SDS);    
+    
+  }
+
+};
+
+}  // namespace unit_test
+}  // namespace shoc
+}  // namespace scream
+
+namespace{
+
+TEST_CASE("shoc_w3_diag_third_moms_property", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestW3diagThirdMoms;
+  
+  TestStruct::run_property();
+}
+
+TEST_CASE("shoc_w3_diag_third_moms_b4b", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestW3diagThirdMoms;
+
+}
+
+} // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
@@ -123,6 +123,7 @@ TEST_CASE("shoc_w3_diag_third_moms_b4b", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestW3diagThirdMoms;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
@@ -98,6 +98,11 @@ struct UnitWrap::UnitTest<D>::TestW3diagThirdMoms {
     
     
   }
+  
+  static void run_bfb()
+  {
+    // TODO
+  }  
 
 };
 

--- a/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
@@ -26,18 +26,76 @@ struct UnitWrap::UnitTest<D>::TestW3diagThirdMoms {
   {
 
     // Tests for the SHOC function:
-    //   w3_diag_third_shoc_moment
+    //   w3_diag_third_shoc_moment 
+    
+    // TEST ONE
+    // Do series of tests to make sure output is as expected
   
-    //  Test to be sure that very high values of w3
-    //    are reduced but still the same sign   
-  
+    // aa0 term
+    constexpr static Real aa0_test1 = -0.2;
+    // aa1 term
+    constexpr static Real aa1_test1 = 5.65;
+    // x0 term
+    constexpr static Real x0_test1 = -4.31;
+    // y0 term
+    constexpr static Real x1_test1 = 41.05;    
+    // f5 term
+    constexpr static Real f5_test1 = 4;        
 
     // Initialize data structure for bridging to F90
     SHOCW3diagthirdmomsData SDS;
 
+    // Load up the data
+    SDS.aa0 = aa0_test1;
+    SDS.aa1 = aa1_test1;
+    SDS.x0 = x0_test1;
+    SDS.x1 = x1_test1;
+    SDS.f5 = f5_test1;
+      
+    // Call the fortran implementation    
+    w3_diag_third_shoc_moment(SDS);      
+
+    // Verify result is negative
+    REQUIRE(SDS.w3 < 0);
+ 
+    // save output
+    Real w3_test1 = SDS.w3;
+
+    // TEST TWO
+    // Modify parameters to decrease w3
+    // decrease this term
+    constexpr static Real aa1_test2 = 2.65;    
+    
+    SDS.aa1 = aa1_test2;
     
     // Call the fortran implementation    
-    w3_diag_third_shoc_moment(SDS);    
+    w3_diag_third_shoc_moment(SDS);      
+     
+    // Verify result has decreased
+    REQUIRE(SDS.w3 < SDS.aa1);
+    
+    // Save result
+    Real w3_test2 = SDS.w3;
+    
+    // TEST THREE
+    // Modify parameters to get positive result
+    // x0 term
+    constexpr static Real x0_test3 = -4.31;
+    // y0 term
+    constexpr static Real x1_test3 = -41.05;    
+    // f5 term
+    constexpr static Real f5_test3 = -4;
+    
+    SDS.x0 = x0_test3;
+    SDS.x1 = x1_test3;
+    SDS.f5 = f5_test3; 
+    
+    // Call the fortran implementation    
+    w3_diag_third_shoc_moment(SDS);
+    
+    // Verify the result is positive
+    REQUIRE(SDS.w3 > 0);       
+    
     
   }
 

--- a/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
@@ -106,6 +106,7 @@ TEST_CASE("shoc_xy_diag_third_moms_b4b", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestXYdiagThirdMoms;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
@@ -102,7 +102,7 @@ TEST_CASE("shoc_xy_diag_third_moms_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_xy_diag_third_moms_b4b", "shoc")
+TEST_CASE("shoc_xy_diag_third_moms_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestXYdiagThirdMoms;
 

--- a/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
@@ -1,0 +1,65 @@
+#include "catch2/catch.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestXYdiagThirdMoms {
+
+  static void run_property()
+  {
+
+    // Tests for the SHOC function:
+    //   x_y_terms_diag_third_shoc_moment
+  
+    //  Test to be sure that very high values of w3
+    //    are reduced but still the same sign   
+  
+
+    // Initialize data structure for bridging to F90
+    SHOCXYdiagthirdmomsData SDS;
+
+    
+    // Call the fortran implementation    
+    x_y_terms_diag_third_shoc_moment(SDS);    
+    
+  }
+
+};
+
+}  // namespace unit_test
+}  // namespace shoc
+}  // namespace scream
+
+namespace{
+
+TEST_CASE("shoc_xy_diag_third_moms_property", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestXYdiagThirdMoms;
+  
+  TestStruct::run_property();
+}
+
+TEST_CASE("shoc_xy_diag_third_moms_b4b", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestXYdiagThirdMoms;
+
+}
+
+} // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
@@ -28,16 +28,57 @@ struct UnitWrap::UnitTest<D>::TestXYdiagThirdMoms {
     // Tests for the SHOC function:
     //   x_y_terms_diag_third_shoc_moment
   
-    //  Test to be sure that very high values of w3
-    //    are reduced but still the same sign   
-  
+    // TEST ONE
+    // Call the function twice, with two different sets of terms.  
+    //  In the second test the fterms should be larger.  Verify 
+    //  that the x0 and y0 terms are the same, but that the
+    //  x1 and y1 terms have increased. 
+    
+    // buoyancy term (isotropy squared * brunt vaisalla frequency)
+    constexpr static Real buoy_sgs2 = -100;
+    // f0 term
+    constexpr static Real f0_test1a = 13000;
+    // f3 term
+    constexpr static Real f1_test1a = 8500;
+    // f4 term
+    constexpr static Real f2_test1a = 30;    
 
     // Initialize data structure for bridging to F90
     SHOCXYdiagthirdmomsData SDS;
-
+    
+    // Load up the data
+    SDS.buoy_sgs2 = buoy_sgs2;
+    SDS.f0 = f0_test1a;
+    SDS.f1 = f1_test1a;
+    SDS.f2 = f2_test1a;    
     
     // Call the fortran implementation    
-    x_y_terms_diag_third_shoc_moment(SDS);    
+    x_y_terms_diag_third_shoc_moment(SDS);
+    
+    // Save test results
+    Real x0_test1a = SDS.x0;
+    Real y0_test1a = SDS.y0;
+    Real x1_test1a = SDS.x1; 
+    Real y1_test1a = SDS.y1;
+    
+    // Now load up data for second part of test
+    // Feed in LARGER values
+    SDS.f0 = 1.2*f0_test1a;
+    SDS.f1 = 1.2*f1_test1a;
+    SDS.f2 = 1.2*f2_test1a;         
+
+    // Call the fortran implementation    
+    x_y_terms_diag_third_shoc_moment(SDS);
+    
+    // Now check the result
+    
+    // x0 and y0 terms should NOT have changed
+    REQUIRE(SDS.x0 == x0_test1a);
+    REQUIRE(SDS.y0 == y0_test1a);  
+    
+    // x1 and y1 terms should have increased
+    REQUIRE(SDS.x1 > x1_test1a);
+    REQUIRE(SDS.y1 > y1_test1a);      
     
   }
 

--- a/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
@@ -81,6 +81,11 @@ struct UnitWrap::UnitTest<D>::TestXYdiagThirdMoms {
     REQUIRE(SDS.y1 > y1_test1a);      
     
   }
+  
+  static void run_bfb()
+  {
+    // TODO
+  }  
 
 };
 


### PR DESCRIPTION
Adds property tests for SHOC's third moment lowest level functions.

Note that this PR also renames the variable "isosqrt" (which implied square root of isotropy term) to "isosqrd" (which correctly implies isotropy term squared) in the shoc.F90 file.  