### PR TITLE
SHOC bug fix, dimensions of zi_grid corrected in length scale routine

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -3114,7 +3114,7 @@ subroutine shoc_length(&
   ! heights on midpoint grid [m]
   real(rtype), intent(in) :: zt_grid(shcol,nlev)
   ! heights on interface grid [m]
-  real(rtype), intent(in) :: zi_grid(shcol,nlev)
+  real(rtype), intent(in) :: zi_grid(shcol,nlevi)
   ! dz on midpoint grid [m]
   real(rtype), intent(in) :: dz_zt(shcol,nlev)
   ! dz on interface grid [m]


### PR DESCRIPTION
Dimensions of zi_grid are corrected from (shcol,nlev) to (shcol,nlevi) in the upper level shoc_length routine.  This is a b4b fix on LC and Cori, presumably because the nlevi value of zi_grid is always zero in SCREAM and these compilers likely using zero when accessing this index, and thus expected to be a B4B PR