### PR TITLE
Fix `get_cloud_dsd2` warning in P3

### DIFF
--- a/components/scream/cmake/ScreamUtils.cmake
+++ b/components/scream/cmake/ScreamUtils.cmake
@@ -30,10 +30,6 @@ function(CreateUnitTest target_name target_srcs scream_libs)
   set (test_libs "${scream_libs}")
   list(APPEND test_libs "${SCREAM_TPL_LIBRARIES}")
 
-  if ("${target_name}" MATCHES "field")
-    message ("field libs: ${test_libs}")
-  endif()
-
   if (NOT CreateUnitTest_MPI_RANKS)
     set (CreateUnitTest_MPI_RANKS 1)
   endif ()

--- a/components/scream/src/physics/p3/p3_dsd2_impl.hpp
+++ b/components/scream/src/physics/p3/p3_dsd2_impl.hpp
@@ -12,6 +12,7 @@ namespace p3 {
  */
 
 template <typename S, typename D>
+KOKKOS_FUNCTION
 void Functions<S,D>::
 get_cloud_dsd2(
   const Spack& qc, Spack& nc, Spack& mu_c, const Spack& rho, Spack& nu,

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -500,7 +500,7 @@ struct Functions
     const Smask& context = Smask(true) );
 
   // TODO: comment
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   static void get_cloud_dsd2(
     const Spack& qc, Spack& nc, Spack& mu_c, const Spack& rho, Spack& nu,
     const view_dnu_table& dnu, Spack& lamc, Spack& cdist, Spack& cdist1, const Spack& cld_frac_l,


### PR DESCRIPTION
Micro PR to fix a longstanding warning.