### PR TITLE
Another upgrade/update to testing pattern

### DIFF
--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -499,7 +499,7 @@ struct CalcUpwindData : public PhysicsTestData
   PTD_DATA_COPY_CTOR(CalcUpwindData, 7);
   PTD_ASSIGN_OP(CalcUpwindData, 7, kts, kte, kdir, kbot, k_qxtop, num_arrays, dt_sub);
 
-  Int nk() const { return shcol; }
+  Int nk() const { return dim1; }
 
   void convert_to_ptr_arr(std::vector<Real*>& mem_space, Real**& fluxes_, Real**& vs_, Real**& qnx_);
 };
@@ -561,7 +561,7 @@ struct CloudSedData : public PhysicsTestData
   PTD_DATA_COPY_CTOR(CloudSedData, 9);
   PTD_ASSIGN_OP(CloudSedData, 9, kts, kte, ktop, kbot, kdir, dt, inv_dt, do_predict_nc, precip_liq_surf);
 
-  Int nk() const { return shcol; }
+  Int nk() const { return dim1; }
 };
 void cloud_sedimentation(CloudSedData& d);
 
@@ -596,7 +596,7 @@ struct IceSedData : public PhysicsTestData
   PTD_DATA_COPY_CTOR(IceSedData, 8);
   PTD_ASSIGN_OP(IceSedData, 8, kts, kte, ktop, kbot, kdir, dt, inv_dt, precip_ice_surf);
 
-  Int nk() const { return shcol; }
+  Int nk() const { return dim1; }
 };
 
 void ice_sedimentation(IceSedData& d);
@@ -634,7 +634,7 @@ struct RainSedData : public PhysicsTestData
   PTD_DATA_COPY_CTOR(RainSedData, 8);
   PTD_ASSIGN_OP(RainSedData, 8, kts, kte, ktop, kbot, kdir, dt, inv_dt, precip_liq_surf);
 
-  Int nk() const { return shcol; }
+  Int nk() const { return dim1; }
 };
 
 void rain_sedimentation(RainSedData& d);
@@ -688,12 +688,7 @@ struct HomogeneousFreezingData : public PhysicsTestData
   PTD_DATA_COPY_CTOR(HomogeneousFreezingData, 5);
   PTD_ASSIGN_OP(HomogeneousFreezingData, 5, kts, kte, ktop, kbot, kdir);
 
-  Int nk() const { return m_nk; }
-
- private:
-  // Internals
-  Int m_nk;
-
+  Int nk() const { return dim1; }
 };
 void homogeneous_freezing(HomogeneousFreezingData& d);
 
@@ -1007,7 +1002,7 @@ struct CheckValuesData : public PhysicsTestData
   PTD_DATA_COPY_CTOR(CheckValuesData, 5);
   PTD_ASSIGN_OP(CheckValuesData, 5, kts, kte, timestepcount, source_ind, force_abort);
 
-  Int nk() const { return shcol; }
+  Int nk() const { return dim1; }
 };
 void check_values(CheckValuesData& d);
 
@@ -1059,7 +1054,7 @@ struct P3MainPart1Data : public PhysicsTestData
   PTD_DATA_COPY_CTOR(P3MainPart1Data, 7);
   PTD_ASSIGN_OP(P3MainPart1Data, 7, kts, kte, kbot, ktop, kdir, do_predict_nc, dt);
 
-  Int nk() const { return shcol; }
+  Int nk() const { return dim1; }
 };
 
 void p3_main_part1(P3MainPart1Data& d);
@@ -1105,7 +1100,7 @@ struct P3MainPart2Data : public PhysicsTestData
   PTD_DATA_COPY_CTOR(P3MainPart2Data, 7);
   PTD_ASSIGN_OP(P3MainPart2Data, 9, kts, kte, kbot, ktop, kdir, do_predict_nc, dt, inv_dt, is_hydromet_present);
 
-  Int nk() const { return shcol; }
+  Int nk() const { return dim1; }
 };
 
 void p3_main_part2(P3MainPart2Data& d);
@@ -1145,7 +1140,7 @@ struct P3MainPart3Data : public PhysicsTestData
   PTD_DATA_COPY_CTOR(P3MainPart3Data, 5);
   PTD_ASSIGN_OP(P3MainPart3Data, 5, kts, kte, kbot, ktop, kdir);
 
-  Int nk() const { return shcol; }
+  Int nk() const { return dim1; }
 };
 
 void p3_main_part3(P3MainPart3Data& d);

--- a/components/scream/src/physics/p3/tests/p3_get_latent_heat_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_get_latent_heat_unit_tests.cpp
@@ -48,9 +48,9 @@ struct UnitWrap::UnitTest<D>::TestLatentHeat {
       LatentHeatData& d = latent_cxx[i];
       get_latent_heat_f(d.its, d.ite, d.kts, d.kte, d.v, d.s, d.f);
 
-      REQUIRE(h.total() == d.total());
+      REQUIRE(h.total1x2() == d.total1x2());
 
-      for (Int j = 0; j < h.total(); ++j) {
+      for (Int j = 0; j < h.total1x2(); ++j) {
         REQUIRE(d.v[j] == h.v[j]);
         REQUIRE(d.s[j] == h.s[j]);
         REQUIRE(d.f[j] == h.f[j]);

--- a/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -384,7 +384,7 @@ static void run_bfb_p3_main()
   }
 
   for (Int i = 0; i < num_runs; ++i) {
-    const auto tot = isds_fortran[i].total();
+    const auto tot = isds_fortran[i].total1x2();
     const auto& df90 = isds_fortran[i];
     const auto& dcxx = isds_fortran[i];
     for (Int t = 0; t < tot; ++t) {

--- a/components/scream/src/physics/share/physics_test_data.cpp
+++ b/components/scream/src/physics/share/physics_test_data.cpp
@@ -8,36 +8,36 @@
 
 namespace scream {
 
-PhysicsTestData::PhysicsTestData(Int shcol_, const std::vector<Real**>& ptrs_c, const std::vector<Int**>& idx_c) :
-  PhysicsTestData(shcol_, 0, 0, {}, {}, ptrs_c, idx_c)
+PhysicsTestData::PhysicsTestData(Int dim1_, const std::vector<Real**>& ptrs_c, const std::vector<Int**>& idx_c) :
+  PhysicsTestData(dim1_, 0, 0, {}, {}, ptrs_c, idx_c)
 {}
 
-PhysicsTestData::PhysicsTestData(Int shcol_, Int nlev_, const std::vector<Real**>& ptrs, const std::vector<Real**>& ptrs_c, const std::vector<Int**>& idx_c) :
-  PhysicsTestData(shcol_, nlev_, 0, ptrs, {}, ptrs_c, idx_c) {}
+PhysicsTestData::PhysicsTestData(Int dim1_, Int dim2_, const std::vector<Real**>& ptrs, const std::vector<Real**>& ptrs_c, const std::vector<Int**>& idx_c) :
+  PhysicsTestData(dim1_, dim2_, 0, ptrs, {}, ptrs_c, idx_c) {}
 
-PhysicsTestData::PhysicsTestData(Int shcol_, Int nlev_, Int nlevi_,
+PhysicsTestData::PhysicsTestData(Int dim1_, Int dim2_, Int dim3_,
                                  const std::vector<Real**>& ptrs, const std::vector<Real**>& ptrs_i,
                                  const std::vector<Real**>& ptrs_c, const std::vector<Int**>& idx_c) :
-  shcol(shcol_),
-  nlev(nlev_),
-  nlevi(nlevi_),
-  m_total(shcol_ * nlev_),
-  m_totali(shcol_ * nlevi_),
+  dim1(dim1_),
+  dim2(dim2_),
+  dim3(dim3_),
+  m_total(dim1_ * dim2_),
+  m_totali(dim1_ * dim3_),
   m_ptrs(ptrs),
   m_ptrs_i(ptrs_i),
   m_ptrs_c(ptrs_c),
   m_indices_c(idx_c),
-  m_data(m_ptrs.size() * m_total + m_ptrs_i.size() * m_totali + m_ptrs_c.size() * shcol, 0),
-  m_idx_data(idx_c.size() * shcol, 0)
+  m_data(m_ptrs.size() * m_total + m_ptrs_i.size() * m_totali + m_ptrs_c.size() * dim1, 0),
+  m_idx_data(idx_c.size() * dim1, 0)
 {
   init_ptrs();
 }
 
 PhysicsTestData& PhysicsTestData::assignment_impl(const PhysicsTestData& rhs)
 {
-  shcol      = rhs.shcol;
-  nlev       = rhs.nlev;
-  nlevi      = rhs.nlevi;
+  dim1       = rhs.dim1;
+  dim2       = rhs.dim2;
+  dim3       = rhs.dim3;
   m_total    = rhs.m_total;
   m_totali   = rhs.m_totali;
   m_data     = rhs.m_data;      // Copy
@@ -65,11 +65,11 @@ void PhysicsTestData::init_ptrs()
 
   for (size_t i = 0; i < m_ptrs_c.size(); ++i) {
     *(m_ptrs_c[i]) = data_begin + offset;
-    offset += shcol;
+    offset += dim1;
   }
 
   for (size_t i = 0; i < m_indices_c.size(); ++i) {
-    *(m_indices_c[i]) = m_idx_data.data() + shcol*i;
+    *(m_indices_c[i]) = m_idx_data.data() + dim1*i;
   }
 }
 
@@ -82,7 +82,7 @@ void PhysicsTestData::randomize(const std::vector<std::pair<void*, std::pair<Rea
 
   range_type ranges_copy(ranges);
 
-  for (auto& item : { PT{&m_ptrs, m_total} , PT{&m_ptrs_i, m_totali}, PT{&m_ptrs_c, shcol} }) {
+  for (auto& item : { PT{&m_ptrs, m_total} , PT{&m_ptrs_i, m_totali}, PT{&m_ptrs_c, dim1} }) {
     auto& ptrs = *item.first;
     const Int num_per = item.second;
     for (Real** ptr : ptrs) {
@@ -117,7 +117,7 @@ void PhysicsTestData::randomize(const std::vector<std::pair<void*, std::pair<Rea
       }
     }
     std::uniform_int_distribution<Int> data_dist(random_range.first, random_range.second);
-    for (Int i = 0; i < shcol; ++i) {
+    for (Int i = 0; i < dim1; ++i) {
       (*ptr)[i] = data_dist(generator);
     }
   }

--- a/components/scream/src/physics/share/physics_test_data.hpp
+++ b/components/scream/src/physics/share/physics_test_data.hpp
@@ -29,13 +29,13 @@ struct SHOCGridData : public PhysicsTestData {
   // In/out
   Real *dz_zt, *dz_zi, *rho_zt;
 
-  SHOCGridData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData(shcol_, nlev_, nlevi_,
-      {&zt_grid, &dz_zt, &pdel, &rho_zt},  // list of (shcol x nlev) members
-      {&zi_grid, &dz_zi}) {}               // list of (shcol x nlevi) members
+  SHOCGridData(Int dim1_, Int dim2_, Int dim3_) :
+    PhysicsTestData(dim1_, dim2_, dim3_,
+      {&zt_grid, &dz_zt, &pdel, &rho_zt},  // list of (dim1 x dim2) members
+      {&zi_grid, &dz_zi}) {}               // list of (dim1 x dim3) members
 
-  PTD_DATA_COPY_CTOR(SHOCGridData, 3); // 3 => number of arguments constructor expects
-  PTD_ASSIGN_OP(SHOCGridData, 0); // 0 => number of scalars
+  PTD_STD_DEF(SHOCGridData, 3, 0); // 3 => number of dimensions (1-3), 0 => number of scalars (0-10)
+  // If you have scalars, you'll have to add names after the count
 };
 */
 
@@ -53,8 +53,10 @@ struct SHOCGridData : public PhysicsTestData {
 #define PTD_ZEROES9 PTD_ZEROES8, 0
 #define PTD_ZEROES10 PTD_ZEROES9, 0
 
+#define PTD_ZEROES(a) PTD_ZEROES##a
+
 #define PTD_DATA_COPY_CTOR(name, num_args) \
-  name(const name& rhs) : name(PTD_ZEROES##num_args) { *this = rhs; }
+  name(const name& rhs) : name(PTD_ZEROES(num_args)) { *this = rhs; }
 
 #define  PTD_ASS0(                                ) ((void) (0))
 #define  PTD_ASS1(a                               )                                           a = rhs.a
@@ -72,25 +74,69 @@ struct SHOCGridData : public PhysicsTestData {
 #define PTD_ASSIGN_OP(name, num_scalars, ...)                                  \
   name& operator=(const name& rhs) { PTD_ASS##num_scalars(__VA_ARGS__); assignment_impl(rhs); return *this; }
 
+#define PTD_DIM_RENAME1(ndim1)                                              Int ndim1() const { return dim1; }
+#define PTD_DIM_RENAME2(ndim1, ndim2)        PTD_DIM_RENAME1(ndim1);        Int ndim2() const { return dim2; }
+#define PTD_DIM_RENAME3(ndim1, ndim2, ndim3) PTD_DIM_RENAME2(ndim1, ndim2); Int ndim3() const { return dim3; }
+
+#define PTD_DIM_RENAME(num_args, ...)           \
+  PTD_DIM_RENAME##num_args(__VA_ARGS__)
+
+#define PTD_ADD_1_0 1
+#define PTD_ADD_1_1 2
+#define PTD_ADD_1_2 3
+#define PTD_ADD_1_3 4
+#define PTD_ADD_1_4 5
+#define PTD_ADD_1_5 6
+#define PTD_ADD_1_6 7
+#define PTD_ADD_1_7 8
+#define PTD_ADD_1_8 9
+#define PTD_ADD_1_9 10
+
+#define PTD_ADD_2_0 2
+#define PTD_ADD_2_1 3
+#define PTD_ADD_2_2 4
+#define PTD_ADD_2_3 5
+#define PTD_ADD_2_4 6
+#define PTD_ADD_2_5 7
+#define PTD_ADD_2_6 8
+#define PTD_ADD_2_7 9
+#define PTD_ADD_2_8 10
+#define PTD_ADD_2_9 11
+
+#define PTD_ADD_3_0 3
+#define PTD_ADD_3_1 4
+#define PTD_ADD_3_2 5
+#define PTD_ADD_3_3 6
+#define PTD_ADD_3_4 7
+#define PTD_ADD_3_5 8
+#define PTD_ADD_3_6 9
+#define PTD_ADD_3_7 10
+#define PTD_ADD_3_8 11
+#define PTD_ADD_3_9 12
+
+#define PTD_STD_DEF(name, dim, num_scalars, ...)        \
+  PTD_DATA_COPY_CTOR(name, PTD_ADD_##dim##_##num_scalars);  \
+  PTD_ASSIGN_OP(name, num_scalars, __VA_ARGS__)
+
 namespace scream {
 
 // Base class for common test data setup
 struct PhysicsTestData
 {
-  Int shcol, nlev, nlevi;
+  Int dim1, dim2, dim3;
 
-  PhysicsTestData(Int shcol_,
-                  const std::vector<Real**>& ptrs_c,     // [shcol]
-                  const std::vector<Int**>& idx_c = {}); // [shcol] (optional)
+  PhysicsTestData(Int dim1_,
+                  const std::vector<Real**>& ptrs_c,     // [dim1]
+                  const std::vector<Int**>& idx_c = {}); // [dim1] (optional)
 
-  PhysicsTestData(Int shcol_, Int nlev_,
-                  const std::vector<Real**>& ptrs,        // [shcol x nlev]
-                  const std::vector<Real**>& ptrs_c = {}, // [shcol] (optional)
-                  const std::vector<Int**>& idx_c = {});  // [shcol] (optional)
+  PhysicsTestData(Int dim1_, Int dim2_,
+                  const std::vector<Real**>& ptrs,        // [dim1 x dim2]
+                  const std::vector<Real**>& ptrs_c = {}, // [dim1] (optional)
+                  const std::vector<Int**>& idx_c = {});  // [dim1] (optional)
 
-  PhysicsTestData(Int shcol_, Int nlev_, Int nlevi_,
-                  const std::vector<Real**>& ptrs,        // [schol x nlev]
-                  const std::vector<Real**>& ptrs_i,      // [schol x nlevi]
+  PhysicsTestData(Int dim1_, Int dim2_, Int dim3_,
+                  const std::vector<Real**>& ptrs,        // [schol x dim2]
+                  const std::vector<Real**>& ptrs_i,      // [schol x dim3]
                   const std::vector<Real**>& ptrs_c = {}, // [schol] (optional)
                   const std::vector<Int**>& idx_c = {});  // [schol] (optional)
 
@@ -106,12 +152,12 @@ struct PhysicsTestData
 
     // Transpose on the zt grid
     for (size_t i = 0; i < m_ptrs.size(); ++i) {
-      ekat::util::transpose<D>(*(m_ptrs[i]), data.data() + (m_total*i) , shcol, nlev);
+      ekat::util::transpose<D>(*(m_ptrs[i]), data.data() + (m_total*i) , dim1, dim2);
     }
 
     // Transpose on the zi grid
     for (size_t i = 0; i < m_ptrs_i.size(); ++i) {
-      ekat::util::transpose<D>(*(m_ptrs_i[i]), data.data() + (m_ptrs.size()*m_total) + (m_totali*i), shcol, nlevi);
+      ekat::util::transpose<D>(*(m_ptrs_i[i]), data.data() + (m_ptrs.size()*m_total) + (m_totali*i), dim1, dim3);
     }
 
     // Copy the column only grid
@@ -134,8 +180,8 @@ struct PhysicsTestData
   // d.randomize({ {d.wthl, {-1, 1}} });
   void randomize(const std::vector<std::pair<void*, std::pair<Real, Real> > >& ranges = {});
 
-  Int total() const { return m_total; }
-  Int totali() const { return m_totali; }
+  Int total1x2() const { return m_total; }
+  Int total1x3() const { return m_totali; }
 
  protected:
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -165,42 +165,42 @@ namespace shoc {
 //
 
 void calc_shoc_varorcovar(SHOCVarorcovarData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  calc_shoc_varorcovar_c(d.shcol, d.nlev, d.nlevi, d.tunefac, d.isotropy_zi, d.tkh_zi,
+  calc_shoc_varorcovar_c(d.shcol(), d.nlev(), d.nlevi(), d.tunefac, d.isotropy_zi, d.tkh_zi,
                          d.dz_zi, d.invar1, d.invar2, d.varorcovar);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void shoc_grid(SHOCGridData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  shoc_grid_c(d.shcol, d.nlev, d.nlevi, d.zt_grid, d.zi_grid, d.pdel, d.dz_zt,
+  shoc_grid_c(d.shcol(), d.nlev(), d.nlevi(), d.zt_grid, d.zi_grid, d.pdel, d.dz_zt,
               d.dz_zi, d.rho_zt);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void update_host_dse(SHOCEnergydseData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  update_host_dse_c(d.shcol, d.nlev, d.thlm, d.shoc_ql, d.exner,
+  update_host_dse_c(d.shcol(), d.nlev(), d.thlm, d.shoc_ql, d.exner,
                     d.zt_grid, d.phis, d.host_dse);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void shoc_energy_integrals(SHOCEnergyintData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  shoc_energy_integrals_c(d.shcol, d.nlev, d.host_dse, d.pdel,
+  shoc_energy_integrals_c(d.shcol(), d.nlev(), d.host_dse, d.pdel,
                           d.rtm, d.rcm, d.u_wind, d.v_wind,
                           d.se_int, d.ke_int, d.wv_int, d.wl_int);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void shoc_energy_total_fixer(SHOCEnergytotData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  shoc_energy_total_fixer_c(d.shcol, d.nlev, d.nlevi, d.dtime, d.nadv,
+  shoc_energy_total_fixer_c(d.shcol(), d.nlev(), d.nlevi(), d.dtime, d.nadv,
                             d.zt_grid, d.zi_grid,
                             d.se_b, d.ke_b, d.wv_b, d.wl_b,
                             d.se_a, d.ke_a, d.wv_a, d.wl_a,
@@ -210,126 +210,126 @@ void shoc_energy_total_fixer(SHOCEnergytotData &d) {
 }
 
 void shoc_energy_threshold_fixer(SHOCEnergythreshfixerData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  shoc_energy_threshold_fixer_c(d.shcol, d.nlev, d.nlevi,
+  shoc_energy_threshold_fixer_c(d.shcol(), d.nlev(), d.nlevi(),
                           d.pint, d.tke, d.te_a, d.te_b,
 			  d.se_dis, d.shoctop);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void shoc_energy_dse_fixer(SHOCEnergydsefixerData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  shoc_energy_dse_fixer_c(d.shcol, d.nlev,
+  shoc_energy_dse_fixer_c(d.shcol(), d.nlev(),
                           d.se_dis, d.shoctop, d.host_dse);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void calc_shoc_vertflux(SHOCVertfluxData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  calc_shoc_vertflux_c(d.shcol, d.nlev, d.nlevi, d.tkh_zi, d.dz_zi, d.invar,
+  calc_shoc_vertflux_c(d.shcol(), d.nlev(), d.nlevi(), d.tkh_zi, d.dz_zi, d.invar,
 		       d.vertflux);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void integ_column_stability(SHOCColstabData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  integ_column_stability_c(d.nlev, d.shcol, d.dz_zt, d.pres, d.brunt, d.brunt_int);
+  integ_column_stability_c(d.nlev(), d.shcol(), d.dz_zt, d.pres, d.brunt, d.brunt_int);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void compute_shr_prod(SHOCTkeshearData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  compute_shr_prod_c(d.nlevi, d.nlev, d.shcol, d.dz_zi, d.u_wind,
+  compute_shr_prod_c(d.nlevi(), d.nlev(), d.shcol(), d.dz_zi, d.u_wind,
                        d.v_wind, d.sterm);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void isotropic_ts(SHOCIsotropicData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  isotropic_ts_c(d.nlev, d.shcol, d.brunt_int, d.tke, d.a_diss,
+  isotropic_ts_c(d.nlev(), d.shcol(), d.brunt_int, d.tke, d.a_diss,
                  d.brunt, d.isotropy);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void adv_sgs_tke(SHOCAdvsgstkeData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  adv_sgs_tke_c(d.nlev, d.shcol, d.dtime, d.shoc_mix, d.wthv_sec,
+  adv_sgs_tke_c(d.nlev(), d.shcol(), d.dtime, d.shoc_mix, d.wthv_sec,
                 d.sterm_zt, d.tk, d.tke, d.a_diss);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void eddy_diffusivities(SHOCEddydiffData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  eddy_diffusivities_c(d.nlev, d.shcol, d.obklen, d.pblh, d.zt_grid,
+  eddy_diffusivities_c(d.nlev(), d.shcol(), d.obklen, d.pblh, d.zt_grid,
      d.shoc_mix, d.sterm_zt, d.isotropy, d.tke, d.tkh, d.tk);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void compute_brunt_shoc_length(SHOCBruntlengthData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  compute_brunt_shoc_length_c(d.nlev,d.nlevi,d.shcol,d.dz_zt,d.thv,d.thv_zi,d.brunt);
+  compute_brunt_shoc_length_c(d.nlev(),d.nlevi(),d.shcol(),d.dz_zt,d.thv,d.thv_zi,d.brunt);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void compute_l_inf_shoc_length(SHOCInflengthData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  compute_l_inf_shoc_length_c(d.nlev,d.shcol,d.zt_grid,d.dz_zt,d.tke,d.l_inf);
+  compute_l_inf_shoc_length_c(d.nlev(),d.shcol(),d.zt_grid,d.dz_zt,d.tke,d.l_inf);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void compute_conv_vel_shoc_length(SHOCConvvelData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  compute_conv_vel_shoc_length_c(d.nlev,d.shcol,d.pblh,d.zt_grid,
+  compute_conv_vel_shoc_length_c(d.nlev(),d.shcol(),d.pblh,d.zt_grid,
                                  d.dz_zt,d.thv,d.wthv_sec,d.conv_vel);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void compute_conv_time_shoc_length(SHOCConvtimeData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(42, true); // fake nlev
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  compute_conv_time_shoc_length_c(d.shcol,d.pblh,d.conv_vel,d.tscale);
+  compute_conv_time_shoc_length_c(d.shcol(),d.pblh,d.conv_vel,d.tscale);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void compute_shoc_mix_shoc_length(SHOCMixlengthData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  compute_shoc_mix_shoc_length_c(d.nlev,d.shcol,d.tke,d.brunt,d.tscale,
+  compute_shoc_mix_shoc_length_c(d.nlev(),d.shcol(),d.tke,d.brunt,d.tscale,
                                  d.zt_grid,d.l_inf,d.shoc_mix);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void check_length_scale_shoc_length(SHOCMixcheckData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  check_length_scale_shoc_length_c(d.nlev,d.shcol,d.host_dx,d.host_dy,d.shoc_mix);
+  check_length_scale_shoc_length_c(d.nlev(),d.shcol(),d.host_dx,d.host_dy,d.shoc_mix);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d)
 {
-  shoc_init(d.nlev, true);
+  shoc_init(42, true); // fake nlev
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  shoc_diag_second_moments_srf_c(d.shcol, d.wthl, d.uw, d.vw, d.ustar2, d.wstar);
+  shoc_diag_second_moments_srf_c(d.shcol(), d.wthl, d.uw, d.vw, d.ustar2, d.wstar);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
 void linear_interp(SHOCLinearintData& d)
 {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  linear_interp_c(d.x1,d.x2,d.y1,d.y2,d.nlev,d.nlevi,d.shcol,d.minthresh);
+  linear_interp_c(d.x1,d.x2,d.y1,d.y2,d.nlev(),d.nlevi(),d.shcol(),d.minthresh);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
@@ -425,9 +425,9 @@ void shoc_assumed_pdf_compute_buoyancy_flux(SHOCPDFcompbuoyfluxData &d)
 
 void shoc_diag_second_moments_ubycond(SHOCSecondMomentUbycondData& d)
 {
-  shoc_init(d.nlev, true);
+  shoc_init(42, true); // Fake nlev
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  shoc_diag_second_moments_ubycond_c(d.shcol, d.thl, d.qw, d.wthl, d.wqw, d.qwthl, d.uw, d.vw, d.wtke);
+  shoc_diag_second_moments_ubycond_c(d.shcol(), d.thl, d.qw, d.wthl, d.wqw, d.qwthl, d.uw, d.vw, d.wtke);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -14,6 +14,18 @@
 // Bridge functions to call fortran version of shoc functions from C++
 //
 
+#define SHOC_DIM_RENAME1 PTD_DIM_RENAME(1, shcol)
+#define SHOC_DIM_RENAME2 PTD_DIM_RENAME(2, shcol, nlev)
+#define SHOC_DIM_RENAME3 PTD_DIM_RENAME(3, shcol, nlev, nlevi)
+
+#define SHOC_NO_SCALAR(name, dim) \
+  PTD_STD_DEF(name, dim, 0);                      \
+  SHOC_DIM_RENAME##dim
+
+#define SHOC_SCALARS(name, dim, num_scalars, ...)       \
+  PTD_STD_DEF(name, dim, num_scalars, __VA_ARGS__);     \
+  SHOC_DIM_RENAME##dim
+
 namespace scream {
 namespace shoc {
 
@@ -28,8 +40,7 @@ struct SHOCGridData : public PhysicsTestData {
   SHOCGridData(Int shcol_, Int nlev_, Int nlevi_) :
     PhysicsTestData(shcol_, nlev_, nlevi_, {&zt_grid, &dz_zt, &pdel, &rho_zt}, {&zi_grid, &dz_zi}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCGridData, 3);
-  PTD_ASSIGN_OP(SHOCGridData, 0);
+  SHOC_NO_SCALAR(SHOCGridData, 3);
 };
 
 //Create data structure to hold data for integ_column_stability
@@ -43,8 +54,7 @@ struct SHOCColstabData : public PhysicsTestData {
   SHOCColstabData(Int shcol_, Int nlev_) :
     PhysicsTestData(shcol_, nlev_, {&dz_zt, &pres, &brunt}, {&brunt_int}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCColstabData, 2);
-  PTD_ASSIGN_OP(SHOCColstabData, 0);
+  SHOC_NO_SCALAR(SHOCColstabData, 2);
 };//SHOCColstabData
 
 //Create data structure to hold data for compute_shr_prod
@@ -59,8 +69,7 @@ struct SHOCTkeshearData : public PhysicsTestData {
   SHOCTkeshearData(Int shcol_, Int nlev_, Int nlevi_) :
     PhysicsTestData(shcol_, nlev_, nlevi_, {&u_wind, &v_wind}, {&dz_zi, &sterm}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCTkeshearData, 3);
-  PTD_ASSIGN_OP(SHOCTkeshearData, 0);
+  SHOC_NO_SCALAR(SHOCTkeshearData, 3);
 };//SHOCTkeshearData
 
 //Create data structure to hold data for isotropic_ts
@@ -75,8 +84,7 @@ struct SHOCIsotropicData : public PhysicsTestData {
   SHOCIsotropicData(Int shcol_, Int nlev_) :
     PhysicsTestData(shcol_, nlev_, {&tke, &a_diss, &brunt, &isotropy}, {&brunt_int}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCIsotropicData, 2);
-  PTD_ASSIGN_OP(SHOCIsotropicData, 0);
+  SHOC_NO_SCALAR(SHOCIsotropicData, 2);
 };//SHOCIsotropicData
 
 //Create data structure to hold data for adv_sgs_tke
@@ -95,8 +103,7 @@ struct SHOCAdvsgstkeData : public PhysicsTestData {
   SHOCAdvsgstkeData(Int shcol_, Int nlev_, Real dtime_) :
     PhysicsTestData(shcol_, nlev_, {&shoc_mix, &wthv_sec, &sterm_zt, &tk, &tke, &a_diss}), dtime(dtime_) {}
 
-  PTD_DATA_COPY_CTOR(SHOCAdvsgstkeData, 3);
-  PTD_ASSIGN_OP(SHOCAdvsgstkeData, 1, dtime);
+  SHOC_SCALARS(SHOCAdvsgstkeData, 2, 1, dtime);
 };//SHOCAdvsgstkeData
 
 //Create data structure to hold data for eddy_diffusivities
@@ -112,8 +119,7 @@ struct SHOCEddydiffData : public PhysicsTestData {
   SHOCEddydiffData(Int shcol_, Int nlev_) :
     PhysicsTestData(shcol_, nlev_, {&zt_grid, &shoc_mix, &isotropy, &tke, &tk, &tkh, &sterm_zt}, {&obklen, &pblh}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCEddydiffData, 2);
-  PTD_ASSIGN_OP(SHOCEddydiffData, 0);
+  SHOC_NO_SCALAR(SHOCEddydiffData, 2);
 };//SHOCEddydiffData
 
 
@@ -129,8 +135,7 @@ struct SHOCEnergydseData : public PhysicsTestData {
   SHOCEnergydseData(Int shcol_, Int nlev_) :
     PhysicsTestData(shcol_, nlev_, {&thlm, &shoc_ql, &exner, &zt_grid, &host_dse}, {&phis}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCEnergydseData, 2);
-  PTD_ASSIGN_OP(SHOCEnergydseData, 0);
+  SHOC_NO_SCALAR(SHOCEnergydseData, 2);
 };//SHOCEnergydseData
 
 //create data structure for shoc_energy_integrals
@@ -145,8 +150,7 @@ struct SHOCEnergyintData : public PhysicsTestData {
   SHOCEnergyintData(Int shcol_, Int nlev_) :
     PhysicsTestData(shcol_, nlev_, {&host_dse, &pdel, &rtm, &rcm, &u_wind, &v_wind}, {&se_int, &ke_int, &wv_int, &wl_int}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCEnergyintData, 2);
-  PTD_ASSIGN_OP(SHOCEnergyintData, 0);
+  SHOC_NO_SCALAR(SHOCEnergyintData, 2);
 };//SHOCEnergyintData
 
 //Create data structure for shoc_energy_total_fixer
@@ -164,8 +168,7 @@ struct SHOCEnergytotData : public PhysicsTestData {
   SHOCEnergytotData(Int shcol_, Int nlev_, Int nlevi_, Real dtime_, Int nadv_) :
     PhysicsTestData(shcol_, nlev_, nlevi_, {&zt_grid, &rho_zt}, {&zi_grid}, {&se_b, &ke_b, &wv_b, &wl_b, &se_a, &ke_a, &wv_a, &wl_a, &wthl_sfc, &wqw_sfc, &te_a, &te_b}), nadv(nadv_), dtime(dtime_) {}
 
-  PTD_DATA_COPY_CTOR(SHOCEnergytotData, 5);
-  PTD_ASSIGN_OP(SHOCEnergytotData, 2, dtime, nadv);
+  SHOC_SCALARS(SHOCEnergytotData, 3, 2, dtime, nadv);
 };//SHOCEnergytotData
 
 //create data structure for shoc_energy_threshold_fixer
@@ -181,8 +184,7 @@ struct SHOCEnergythreshfixerData : public PhysicsTestData {
   SHOCEnergythreshfixerData(Int shcol_, Int nlev_, Int nlevi_) :
     PhysicsTestData(shcol_, nlev_, nlevi_, {&tke}, {&pint}, {&se_dis, &te_a, &te_b}, {&shoctop}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCEnergythreshfixerData, 3);
-  PTD_ASSIGN_OP(SHOCEnergythreshfixerData, 0);
+  SHOC_NO_SCALAR(SHOCEnergythreshfixerData, 3);
 };//SHOCEnergythreshfixerData
 
 //create data structure for shoc_energy_dse_fixer
@@ -198,8 +200,7 @@ struct SHOCEnergydsefixerData : public PhysicsTestData {
   SHOCEnergydsefixerData(Int shcol_, Int nlev_) :
     PhysicsTestData(shcol_, nlev_, {&host_dse}, {&se_dis}, {&shoctop}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCEnergydsefixerData, 2);
-  PTD_ASSIGN_OP(SHOCEnergydsefixerData, 0);
+  SHOC_NO_SCALAR(SHOCEnergydsefixerData, 2);
 };//SHOCEnergydsefixerData
 
 //Create data structure to hold data for calc_shoc_vertflux
@@ -213,8 +214,7 @@ struct SHOCVertfluxData : public PhysicsTestData {
   SHOCVertfluxData(Int shcol_, Int nlev_, Int nlevi_) :
     PhysicsTestData(shcol_, nlev_, nlevi_, {&invar}, {&tkh_zi, &dz_zi, &vertflux}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCVertfluxData, 3);
-  PTD_ASSIGN_OP(SHOCVertfluxData, 0);
+  SHOC_NO_SCALAR(SHOCVertfluxData, 3);
 }; //SHOCVertfluxData
 
 //Create data structure to hold data for calc_shoc_varorcovar
@@ -229,8 +229,7 @@ struct SHOCVarorcovarData : public PhysicsTestData {
   SHOCVarorcovarData(Int shcol_, Int nlev_, Int nlevi_, Real tunefac_) :
     PhysicsTestData(shcol_, nlev_, nlevi_, {&invar1, &invar2}, {&tkh_zi, &dz_zi, &isotropy_zi, &varorcovar}), tunefac(tunefac_) {}
 
-  PTD_DATA_COPY_CTOR(SHOCVarorcovarData, 4);
-  PTD_ASSIGN_OP(SHOCVarorcovarData, 1, tunefac);
+  SHOC_SCALARS(SHOCVarorcovarData, 3, 1, tunefac);
 };//SHOCVarorcovarData
 
 //Create data structure to hold data for compute_brunt_shoc_length
@@ -244,8 +243,7 @@ struct SHOCBruntlengthData : public PhysicsTestData {
   SHOCBruntlengthData(Int shcol_, Int nlev_, Int nlevi_) :
     PhysicsTestData(shcol_, nlev_, nlevi_, {&dz_zt, &thv, &brunt}, {&thv_zi}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCBruntlengthData, 3);
-  PTD_ASSIGN_OP(SHOCBruntlengthData, 0)
+  SHOC_NO_SCALAR(SHOCBruntlengthData, 3);
 };//SHOCBruntlengthData
 
 //Create data structure to hold data for compute_l_inf_shoc_length
@@ -259,8 +257,7 @@ struct SHOCInflengthData : public PhysicsTestData {
   SHOCInflengthData(Int shcol_, Int nlev_) :
     PhysicsTestData(shcol_, nlev_, {&zt_grid, &dz_zt, &tke}, {&l_inf}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCInflengthData, 2);
-  PTD_ASSIGN_OP(SHOCInflengthData, 0);
+  SHOC_NO_SCALAR(SHOCInflengthData, 2);
 };//SHOCInflengthData
 
 //Create data structure to hold data for compute_vel_shoc_length
@@ -274,8 +271,7 @@ struct SHOCConvvelData : public PhysicsTestData {
   SHOCConvvelData(Int shcol_, Int nlev_) :
     PhysicsTestData(shcol_, nlev_, {&zt_grid, &dz_zt, &thv, &wthv_sec}, {&conv_vel, &pblh}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCConvvelData, 2);
-  PTD_ASSIGN_OP(SHOCConvvelData, 0);
+  SHOC_NO_SCALAR(SHOCConvvelData, 2);
 };//SHOCConvvelData
 
 //Create data structure to hold data for compute_conv_time_shoc_length
@@ -289,8 +285,7 @@ struct SHOCConvtimeData : public PhysicsTestData {
   SHOCConvtimeData(Int shcol_) :
     PhysicsTestData(shcol_, {&conv_vel, &pblh, &tscale}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCConvtimeData, 1);
-  PTD_ASSIGN_OP(SHOCConvtimeData, 0);
+  SHOC_NO_SCALAR(SHOCConvtimeData, 1);
 };//SHOCConvtimeData
 
 //Create data structure to hold data for compute_shoc_mix_shoc_length
@@ -304,8 +299,7 @@ struct SHOCMixlengthData : public PhysicsTestData {
   SHOCMixlengthData(Int shcol_, Int nlev_) :
     PhysicsTestData(shcol_, nlev_, {&tke, &brunt, &zt_grid, &shoc_mix}, {&l_inf, &tscale}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCMixlengthData, 2);
-  PTD_ASSIGN_OP(SHOCMixlengthData, 0);
+  SHOC_NO_SCALAR(SHOCMixlengthData, 2);
 };//SHOCMixlengthData
 
 //Create data structure to hold data for check_length_scale_shoc_length
@@ -319,8 +313,7 @@ struct SHOCMixcheckData : public PhysicsTestData {
   SHOCMixcheckData(Int shcol_, Int nlev_) :
     PhysicsTestData(shcol_, nlev_, {&shoc_mix}, {&host_dx, &host_dy}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCMixcheckData, 2);
-  PTD_ASSIGN_OP(SHOCMixcheckData, 0);
+  SHOC_NO_SCALAR(SHOCMixcheckData, 2);
 };//SHOCMixcheckData
 
 struct SHOCSecondMomentSrfData : public PhysicsTestData {
@@ -333,8 +326,7 @@ struct SHOCSecondMomentSrfData : public PhysicsTestData {
   SHOCSecondMomentSrfData(Int shcol_) :
     PhysicsTestData(shcol_, {&wthl, &uw, &vw, &ustar2, &wstar}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCSecondMomentSrfData, 1);
-  PTD_ASSIGN_OP(SHOCSecondMomentSrfData, 0);
+  SHOC_NO_SCALAR(SHOCSecondMomentSrfData, 1);
 };
 
 //Create data structure to hold data for linear_interp
@@ -349,8 +341,7 @@ struct SHOCLinearintData : public PhysicsTestData {
   SHOCLinearintData(Int shcol_, Int nlev_, Int nlevi_, Real minthresh_) :
     PhysicsTestData(shcol_, nlev_, nlevi_, {&x1, &y1}, {&x2, &y2}), minthresh(minthresh_) {}
 
-  PTD_DATA_COPY_CTOR(SHOCLinearintData, 4);
-  PTD_ASSIGN_OP(SHOCLinearintData, 1, minthresh);
+  SHOC_SCALARS(SHOCLinearintData, 3, 1, minthresh);
 };//SHOCLinearintData
 
 //Create data structure to hold data for shoc_assumed_pdf_tilda_to_real
@@ -482,8 +473,7 @@ struct SHOCSecondMomentUbycondData : public PhysicsTestData {
   SHOCSecondMomentUbycondData(Int shcol_) :
     PhysicsTestData(shcol_, {&thl, &qw, &wthl, &wqw, &qwthl, &uw, &vw, &wtke}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCSecondMomentUbycondData, 1);
-  PTD_ASSIGN_OP(SHOCSecondMomentUbycondData, 0);
+  SHOC_NO_SCALAR(SHOCSecondMomentUbycondData, 1);
 };
 
 //

--- a/components/scream/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
@@ -47,13 +47,14 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
     SHOCBruntlengthData SDS(shcol, nlev, nlevi);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.nlevi - SDS.nlev == 1);
-    REQUIRE(SDS.shcol > 0);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev && SDS.nlevi() == nlevi) );
+    REQUIRE(nlevi - nlev == 1);
+    REQUIRE(shcol > 0);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-        const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+        const auto offset = n + s * nlev;
 
         SDS.dz_zt[offset] = dz_zt[n];
         // For theta_v on thermo grid just take the vertical average
@@ -63,8 +64,8 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
       }
 
       // Fill in test data on zi_grid.
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-        const auto offset   = n + s * SDS.nlevi;
+      for(Int n = 0; n < nlevi; ++n) {
+        const auto offset   = n + s * nlevi;
         SDS.thv_zi[offset] = thv_zi[n];
       }
     }
@@ -72,15 +73,15 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
     // Check that the inputs make sense
 
     // Be sure that relevant variables are greater than zero
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev - 1; ++n) {
-        const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev - 1; ++n) {
+        const auto offset = n + s * nlev;
         REQUIRE(SDS.dz_zt[offset] > 0.0);
         REQUIRE(SDS.thv[offset] > 0.0);
       }
 
-      for(Int n = 0; n < SDS.nlevi - 1; ++n) {
-        const auto offset = n + s * SDS.nlevi;
+      for(Int n = 0; n < nlevi - 1; ++n) {
+        const auto offset = n + s * nlevi;
         REQUIRE(SDS.thv_zi[offset] > 0.0);
       }
     }
@@ -89,9 +90,9 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
     compute_brunt_shoc_length(SDS);
 
     // Check the results
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-        const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+        const auto offset = n + s * nlev;
 
         // Validate that brunt vaisalla frequency
         //  is the correct sign given atmospheric conditions
@@ -113,11 +114,14 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
         //  reasonable bounds for this variable.
         REQUIRE(SDS.brunt[offset < 1.0]);
         REQUIRE(SDS.brunt[offset > -1.0]);
-
       }
     }
   }
 
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -137,6 +141,7 @@ TEST_CASE("shoc_brunt_length_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCompBruntShocLength;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_check_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_check_length_tests.cpp
@@ -29,16 +29,16 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength {
 
     // Tests for the SHOC function:
     //   check_length_scale_shoc_length
-  
+
     // Test this simple function.  Feed the routine values of
     //  mixing length that are zero and much larger than the
     //  host grid box size to make sure that the function
-    //  corrects these erroneous values.  
-  
+    //  corrects these erroneous values.
+
     // Define the host grid box size x-direction [m]
-    static constexpr Real host_dx = 3000.0; 
+    static constexpr Real host_dx = 3000.0;
     // Defin the host grid box size y-direction [m]
-    static constexpr Real host_dy = 5000.0; 
+    static constexpr Real host_dy = 5000.0;
     // Define mixing length [m]
     //   In profile include values of zero and very large values
     Real shoc_mix[nlev] = {50000.0, 4000.0, 2000.0, 0.0, 500.0};
@@ -47,17 +47,18 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength {
     SHOCMixcheckData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.shcol > 0);
-  
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev) );
+    REQUIRE(shcol > 0);
+
     // compute geometric grid mesh
     const auto grid_mesh = sqrt(host_dx*host_dy);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       SDS.host_dx[s] = host_dx;
       SDS.host_dy[s] = host_dy;
-      for(Int n = 0; n < SDS.nlev; ++n) {
-        const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+        const auto offset = n + s * nlev;
 
         SDS.shoc_mix[offset] = shoc_mix[n];
       }
@@ -66,7 +67,7 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength {
     // Check that the inputs make sense
 
     // Be sure that relevant variables are greater than zero
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.host_dx[s] > 0.0);
       REQUIRE(SDS.host_dy[s] > 0.0);
     }
@@ -75,17 +76,21 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength {
     check_length_scale_shoc_length(SDS);
 
     // Check the results
-    for(Int s = 0; s < SDS.shcol; ++s) {   
-      for(Int n = 0; n < SDS.nlev; ++n) {
-        const auto offset = n + s * SDS.nlev;   
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+        const auto offset = n + s * nlev;
         // Require mixing length is greater than zero and is
         //  less than geometric grid mesh length + 1 m
-        REQUIRE(SDS.shoc_mix[offset] > 0.0); 
-        REQUIRE(SDS.shoc_mix[offset] < 1.0+grid_mesh); 
-      }   
+        REQUIRE(SDS.shoc_mix[offset] > 0.0);
+        REQUIRE(SDS.shoc_mix[offset] < 1.0+grid_mesh);
+      }
     }
   }
 
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -97,14 +102,15 @@ namespace{
 TEST_CASE("shoc_check_length_property", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCheckShocLength;
-  
+
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_check_length_b4b", "shoc")
+TEST_CASE("shoc_check_length_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCheckShocLength;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_conv_time_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_conv_time_length_tests.cpp
@@ -47,17 +47,18 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
     SHOCConvtimeData SDS(shcol);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.shcol > 0);
+    REQUIRE(SDS.shcol() == shcol);
+    REQUIRE(shcol > 0);
 
     // Fill in test data, all one dimensional
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       SDS.pblh[s] = pblh[s];
       SDS.conv_vel[s] = conv_vel[s];
     }
 
     // Check that the inputs make sense
 
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.pblh[s] > 0.0);
     }
 
@@ -66,7 +67,7 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
 
     // Check the results
     // Make sure that timescale is positive always
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.tscale[s] > 0.0);
     }
 
@@ -84,14 +85,14 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
     static constexpr Real conv_vel_cons1[shcol] = {10.0, 3.5, 0.1, 100.0, 0.4};
 
     // Fill in test data, all one dimensional
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       SDS.pblh[s] = pblh_cons1[s];
       SDS.conv_vel[s] = conv_vel_cons1[s];
     }
 
     // Check that the inputs make sense
 
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.pblh[s] > 0.0);
       // For this test all values of conv_vel must be positive
       REQUIRE(SDS.conv_vel[s] > 0.0);
@@ -103,7 +104,7 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
     // Verify Results
     // Make sure that if conv_vel is smaller than in a neighboring
     //  column, that the tscale is larger
-    for (Int s = 0; s < SDS.shcol-1; ++s){
+    for (Int s = 0; s < shcol-1; ++s){
       if (SDS.tscale[s] > SDS.tscale[s+1]){
 	REQUIRE(SDS.conv_vel[s] < SDS.conv_vel[s+1]);
       }
@@ -123,14 +124,14 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
     static constexpr Real conv_vel_cons2[shcol] = {0.5, 0.5, 0.5, 0.5, 0.5};
 
     // Fill in test data, all one dimensional
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       SDS.pblh[s] = pblh_cons2[s];
       SDS.conv_vel[s] = conv_vel_cons2[s];
     }
 
     // Check that the inputs make sense
 
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.pblh[s] > 0.0);
       // For this test all values of conv_vel must be positive
       REQUIRE(SDS.conv_vel[s] > 0.0);
@@ -142,13 +143,17 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
     // Verify Results
     // Make sure that if tscale is larger than in a
     //  neighboring column, that the PBL depth is larger
-    for (Int s = 0; s < SDS.shcol-1; ++s){
+    for (Int s = 0; s < shcol-1; ++s){
       if (SDS.tscale[s] > SDS.tscale[s+1]){
 	REQUIRE(SDS.pblh[s] > SDS.pblh[s+1]);
       }
     }
   }
 
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -164,10 +169,11 @@ TEST_CASE("shoc_conv_time_length_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_conv_time_length_b4b", "shoc")
+TEST_CASE("shoc_conv_time_length_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCompShocConvTime;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_conv_vel_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_conv_vel_length_tests.cpp
@@ -56,13 +56,14 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
     SHOCConvvelData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.shcol > 0);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev) );
+    REQUIRE(shcol > 0);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       SDS.pblh[s] = pblh;
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.dz_zt[offset] = dz_zt[n];
 	SDS.zt_grid[offset] = zt_grid[n];
@@ -73,9 +74,9 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
 
     // Check that the inputs make sense
 
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	// Be sure that relevant variables are greater than zero
 	REQUIRE(SDS.dz_zt[offset] > 0.0);
 	REQUIRE(SDS.thv[offset] > 0.0);
@@ -94,7 +95,7 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
 
     // Check the results
     // Make sure that conv_vel is negative
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.conv_vel[s] < 0.0);
     }
 
@@ -111,9 +112,9 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
     static constexpr Real wthv_sec_sym[nlev] = {0.04, 0.02, 0.00, -0.02, -0.04};
 
     // Fill in new test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.dz_zt[offset] = dz_zt_sym[n];
 	SDS.thv[offset] = thv_sym[n];
@@ -123,10 +124,10 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
 
     // Check that the inputs make sense
 
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       Real wthv_sum = 0.0;
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	// Be sure that relevant variables are greater than zero
 	REQUIRE(SDS.dz_zt[offset] > 0.0);
 	REQUIRE(SDS.thv[offset] > 0.0);
@@ -141,9 +142,14 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
 
     // Check the results
     // Make sure that conv_vel is zero
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.conv_vel[s] == approx_zero);
     }
+  }
+
+  static void run_bfb()
+  {
+    // TODO
   }
 
 };
@@ -161,10 +167,11 @@ TEST_CASE("shoc_conv_vel_length_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_conv_vel_length_b4b", "shoc")
+TEST_CASE("shoc_conv_vel_length_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCompShocConvVel;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_diag_second_mom_ubycond_test.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_second_mom_ubycond_test.cpp
@@ -55,12 +55,12 @@ static void run_second_mom_ubycond_bfb()
   }
 
   for (auto& d : uby_cxx) {
-    shoc_diag_second_moments_ubycond_f(d.shcol, d.thl, d.qw, d.qwthl, d.wthl, d.wqw, d.uw, d.vw, d.wtke);
+    shoc_diag_second_moments_ubycond_f(d.shcol(), d.thl, d.qw, d.qwthl, d.wthl, d.wqw, d.uw, d.vw, d.wtke);
   }
 
 
   for (Int i = 0; i < num_runs; ++i) {
-    Int shcol = uby_cxx[i].shcol;
+    Int shcol = uby_cxx[i].shcol();
     for (Int k = 0; k < shcol; ++k) {
       REQUIRE(uby_fortran[i].thl[k]      == uby_cxx[i].thl[k]);
       REQUIRE(uby_fortran[i].qw[k]       == uby_cxx[i].qw[k]);

--- a/components/scream/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
@@ -61,15 +61,16 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     SHOCEddydiffData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.shcol > 0);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev) );
+    REQUIRE(shcol > 0);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // Column only input
       SDS.pblh[s] = pblh;
       SDS.obklen[s] = obklen_reg[s];
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.tke[offset] = tke_reg;
 	SDS.zt_grid[offset] = zt_grid;
@@ -80,12 +81,12 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     }
 
     // Check that the inputs make sense
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.pblh[s] > 0.0);
       // Make sure point we are testing is within PBL
       REQUIRE(SDS.zt_grid[s] < SDS.pblh[s]);
-      for (Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+      for (Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	// Should be greater than zero
 	REQUIRE(SDS.tke[offset] > 0.0);
 	REQUIRE(SDS.zt_grid[offset] > 0.0);
@@ -99,11 +100,11 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     eddy_diffusivities(SDS);
 
     // Check to make sure the answers in the columns are different
-    for(Int s = 0; s < SDS.shcol-1; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol-1; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * SDS.nlev;
+	const auto offsets = n + (s+1) * nlev;
 	REQUIRE(SDS.tk[offset] != SDS.tk[offsets]);
 	REQUIRE(SDS.tkh[offset] != SDS.tkh[offsets]);
       }
@@ -129,17 +130,17 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     // Verify that input mixing length and shear term
     //   are increasing in each column for this
     //   test to be valid
-    for(Int s = 0; s < SDS.shcol-1; ++s) {
+    for(Int s = 0; s < shcol-1; ++s) {
       REQUIRE(shoc_mix_stab[s+1] > shoc_mix_stab[s]);
       REQUIRE(sterm_zt_stab[s+1] > sterm_zt_stab[s]);
     }
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // Column only input
       SDS.obklen[s] = obklen_stab[s];
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.tke[offset] = tke_stab;
 	SDS.shoc_mix[offset] = shoc_mix_stab[s];
@@ -149,11 +150,11 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     }
 
     // Check that the inputs make sense
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // Make sure we are testing stable boundary layer
       REQUIRE(SDS.obklen[s] > 0.0);
-      for (Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+      for (Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	// Should be greater than zero
 	REQUIRE(SDS.tke[offset] > 0.0);
 	REQUIRE(SDS.shoc_mix[offset] > 0.0);
@@ -167,11 +168,11 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
 
     // Check to make sure the answers in the columns are larger
     //   when the length scale and shear term are larger
-    for(Int s = 0; s < SDS.shcol-1; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol-1; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * SDS.nlev;
+	const auto offsets = n + (s+1) * nlev;
 	if (SDS.shoc_mix[offset] < SDS.shoc_mix[offsets] &
             SDS.sterm_zt[offset] < SDS.sterm_zt[offsets]){
           REQUIRE(SDS.tk[offset] < SDS.tkh[offsets]);
@@ -199,17 +200,17 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     // Verify that input isotropy and tke
     //   are increasing in each column for this
     //   test to be valid
-    for(Int s = 0; s < SDS.shcol-1; ++s) {
+    for(Int s = 0; s < shcol-1; ++s) {
       REQUIRE(isotropy_ustab[s+1] > isotropy_ustab[s]);
       REQUIRE(tke_ustab[s+1] > tke_ustab[s]);
     }
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // Column only input
       SDS.obklen[s] = obklen_ustab[s];
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.tke[offset] = tke_ustab[s];
 	SDS.shoc_mix[offset] = shoc_mix_ustab;
@@ -219,11 +220,11 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     }
 
     // Check that the inputs make sense
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // Make sure we are testing unstable boundary layer
       REQUIRE(SDS.obklen[s] < 0.0);
-      for (Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+      for (Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	// Should be greater than zero
 	REQUIRE(SDS.tke[offset] > 0.0);
 	REQUIRE(SDS.shoc_mix[offset] > 0.0);
@@ -237,11 +238,11 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
 
     // Check to make sure the diffusivities are smaller
     //  in the columns where isotropy and tke are smaller
-    for(Int s = 0; s < SDS.shcol-1; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol-1; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * SDS.nlev;
+	const auto offsets = n + (s+1) * nlev;
 	if (SDS.tke[offset] < SDS.tke[offsets] &
             SDS.isotropy[offset] < SDS.isotropy[offsets]){
           REQUIRE(SDS.tk[offset] < SDS.tk[offsets]);
@@ -251,6 +252,10 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     }
   }
 
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -266,10 +271,11 @@ TEST_CASE("shoc_tke_eddy_diffusivities_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_tke_eddy_diffusivities_b4b", "shoc")
+TEST_CASE("shoc_tke_eddy_diffusivities_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocEddyDiff;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
@@ -27,18 +27,17 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
   {
     static constexpr Int shcol    = 2;
     static constexpr Int nlev     = 5;
-    static constexpr auto nlevi   = nlev + 1;
 
     // Tests for the SHOC function
     //     shoc_energy_integrals
 
     // FIRST TEST and SECOND TEST
-    //   FIRST: kinetic energy test.  Given at least two columns with 
+    //   FIRST: kinetic energy test.  Given at least two columns with
     //   identical inputs but with increasing winds in each column
-    //   verify that the column with stronger winds results 
-    //   in a higher kinetic energy test.  
+    //   verify that the column with stronger winds results
+    //   in a higher kinetic energy test.
     //   SECOND: vapor test.  verify that columns with no vapor
-    //   or moisture result in zero integral outputs.  If the 
+    //   or moisture result in zero integral outputs.  If the
     //   column is positive then verify that wl_int >= wv_int
 
     // Define host model dry static energy [K]
@@ -59,18 +58,19 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
 
     // Test that the inputs are reasonable.
     // for this test we need exactly two columns
-    REQUIRE(SDS.shcol == 2);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev) );
+    REQUIRE(shcol == 2);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	// Add one degree K in the second column
 	SDS.host_dse[offset] = s+host_dse[n];
 
 	// convert to [kg/kg]
-	// Force the first column of cloud liquid 
+	// Force the first column of cloud liquid
 	//   to be zero!
 	SDS.rcm[offset] = s*rcm[n]/1000.0;
 	SDS.rtm[offset] = rtm[n]/1000.0;
@@ -86,9 +86,9 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
 
     // Check that the inputs make sense
 
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for (Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for (Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 
 	REQUIRE(SDS.host_dse[offset] > 0.0);
 	REQUIRE(SDS.rcm[offset] >= 0.0);
@@ -97,13 +97,13 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
 	// make sure the two columns are different and
 	//  as expected for the relevant variables
 	if (s == 0){
-          const auto offsets = n + (s+1) * SDS.nlev;
+          const auto offsets = n + (s+1) * nlev;
 
           REQUIRE(abs(SDS.u_wind[offsets]) > abs(SDS.u_wind[offset]));
           REQUIRE(abs(SDS.v_wind[offsets]) > abs(SDS.v_wind[offset]));
           REQUIRE(SDS.rcm[offset] == 0.0);
           REQUIRE(SDS.rcm[offsets] > SDS.rcm[offset]);
-	}      
+	}
       }
     }
 
@@ -126,7 +126,11 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
       }
     }
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -142,10 +146,11 @@ TEST_CASE("shoc_energy_integrals_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_energy_integrals_b4b", "shoc")
+TEST_CASE("shoc_energy_integrals_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocEnergyInt;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
@@ -27,15 +27,14 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
   {
     static constexpr Int shcol    = 2;
     static constexpr Int nlev     = 5;
-    static constexpr auto nlevi   = nlev + 1;
 
     // Tests for the SHOC function
     //     update_host_dse
 
     // FIRST TEST and SECOND TEST
-    //  1) Verify that DSE increases with height and 2) verify that 
+    //  1) Verify that DSE increases with height and 2) verify that
     //   points that contain cloud condensate result in a larger
-    //   dse if all other inputs are equal.  
+    //   dse if all other inputs are equal.
 
     // Liquid water potential temperature [K]
     static constexpr Real thlm[nlev] = {350.0, 325.0, 315.0, 310.0, 300.0};
@@ -53,20 +52,21 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
 
     // Test that the inputs are reasonable.
     // for this test we need exactly two columns
-    REQUIRE(SDS.shcol == 2);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev) );
+    REQUIRE(shcol == 2);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       SDS.phis[s] = phis;
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.thlm[offset] = thlm[n];
 	SDS.zt_grid[offset] = zt_grid[n];
 	SDS.exner[offset] = exner[n];
 
 	// convert to [kg/kg]
-	// Force the first column of cloud liquid 
+	// Force the first column of cloud liquid
 	//   to be zero!
 	SDS.shoc_ql[offset] = s*shoc_ql[n]/1000.0;
 
@@ -75,10 +75,10 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
 
     // Check that the inputs make sense
 
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.phis[s] >= 0.0);
-      for (Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+      for (Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 
 	REQUIRE(SDS.thlm[offset] > 0.0);
 	REQUIRE(SDS.shoc_ql[offset] >= 0.0);
@@ -88,17 +88,17 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
 	// make sure the two columns are different and
 	//  as expected for the relevant variables
 	if (s == 0){
-          const auto offsets = n + (s+1) * SDS.nlev;
+          const auto offsets = n + (s+1) * nlev;
 
           REQUIRE(SDS.shoc_ql[offset] == 0.0);
           REQUIRE(SDS.shoc_ql[offsets] > SDS.shoc_ql[offset]);
-	}    
+	}
 
 	// Check that heights and thlm increase upward
 	if (n < nlev-1){
           REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0.0);
 	  REQUIRE(SDS.thlm[offset + 1] - SDS.thlm[offset] < 0.0);
-	}  
+	}
 
       }
     }
@@ -107,24 +107,29 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
     update_host_dse(SDS);
 
     // Check test
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	// Verify dse is reasonable
 	REQUIRE(SDS.host_dse[offset] > 0.0);
 
 	// Verify that dse increases with height upward
 	if (n < nlev-1){
           REQUIRE(SDS.host_dse[offset + 1] - SDS.host_dse[offset] < 0.0);
-	} 
+	}
 
 	// Verify that dse is greater in points with condensate loading
 	if (s == 0){
-          const auto offsets = n + (s+1) * SDS.nlev;
+          const auto offsets = n + (s+1) * nlev;
 	  REQUIRE(SDS.host_dse[offsets] > SDS.host_dse[offset]);
-	}       
+	}
       }
     }
+  }
+
+  static void run_bfb()
+  {
+    // TODO
   }
 
 };
@@ -142,10 +147,11 @@ TEST_CASE("shoc_energy_host_dse_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_energy_host_dse_b4b", "shoc")
+TEST_CASE("shoc_energy_host_dse_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocUpdateDse;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_grid_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_grid_tests.cpp
@@ -42,21 +42,22 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
     SHOCGridData SDS(shcol, nlev, nlevi);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.nlevi - SDS.nlev == 1);
-    REQUIRE(SDS.shcol > 0);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev && SDS.nlevi()) );
+    REQUIRE(nlevi - nlev == 1);
+    REQUIRE(shcol > 0);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.zt_grid[offset] = zt_pts[n];
 	SDS.pdel[offset]    = density_zt[n] * gravit * (zi_pts[n]-zi_pts[n+1]);
       }
 
       // Fill in test data on zi_grid.
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-	const auto offset   = n + s * SDS.nlevi;
+      for(Int n = 0; n < nlevi; ++n) {
+	const auto offset   = n + s * nlevi;
 	SDS.zi_grid[offset] = zi_pts[n];
       }
     }
@@ -64,15 +65,15 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
     // Check that the inputs make sense
 
     // Check that zt decreases upward
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev - 1; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev - 1; ++n) {
+	const auto offset = n + s * nlev;
 	REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0.0);
       }
 
       // Check that zi decreases upward
-      for(Int n = 0; n < SDS.nlevi - 1; ++n) {
-	const auto offset = n + s * SDS.nlevi;
+      for(Int n = 0; n < nlevi - 1; ++n) {
+	const auto offset = n + s * nlevi;
 	REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0.0);
       }
     }
@@ -83,8 +84,8 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
     // First check that dz is correct
     for(Int s = 0; s < shcol; ++s) {
       Real zt_sum = 0;
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	REQUIRE(SDS.dz_zt[offset] > 0);
 	REQUIRE(SDS.dz_zt[offset] == zi_pts[n] - zi_pts[n+1]);
 	zt_sum += SDS.dz_zt[offset];
@@ -94,26 +95,26 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
     }
 
     for(Int s = 0; s < shcol; ++s) {
-      const auto s_offset = s * SDS.nlevi;
+      const auto s_offset = s * nlevi;
       REQUIRE(SDS.dz_zi[s_offset] == 0);
-      REQUIRE(SDS.dz_zi[s_offset + SDS.nlevi - 1] == zt_pts[nlev-1]);
+      REQUIRE(SDS.dz_zi[s_offset + nlevi - 1] == zt_pts[nlev-1]);
 
       Real zi_sum = 0;
-      for(Int n = 1; n < SDS.nlevi - 1; ++n) {
-	const auto offset = n + s * SDS.nlevi;
+      for(Int n = 1; n < nlevi - 1; ++n) {
+	const auto offset = n + s * nlevi;
 	REQUIRE(SDS.dz_zi[offset] > 0.0);
 	REQUIRE(SDS.dz_zi[offset] == zt_pts[n-1] - zt_pts[n]);
 	zi_sum += SDS.dz_zi[offset];
       }
       // Check that the sum of dz_zi is equal to the largest zt
-      zi_sum += SDS.dz_zi[SDS.nlevi - 1];
+      zi_sum += SDS.dz_zi[nlevi - 1];
       REQUIRE(zi_sum == SDS.zt_grid[0]);
     }
 
     // Now check density
     for(Int s = 0; s < shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	// check that the density is consistent with the hydrostatic approximation
 	REQUIRE(abs(SDS.rho_zt[offset] - density_zt[n]) <= std::numeric_limits<Real>::epsilon());
@@ -124,7 +125,11 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
       }
     }
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -140,10 +145,11 @@ TEST_CASE("shoc_grid_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_grid_b4b", "shoc")
+TEST_CASE("shoc_grid_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocGrid;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_grid_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_grid_tests.cpp
@@ -42,7 +42,7 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
     SHOCGridData SDS(shcol, nlev, nlevi);
 
     // Test that the inputs are reasonable.
-    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev && SDS.nlevi()) );
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev && SDS.nlevi() == nlevi) );
     REQUIRE(nlevi - nlev == 1);
     REQUIRE(shcol > 0);
 

--- a/components/scream/src/physics/shoc/tests/shoc_linearinterp_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_linearinterp_tests.cpp
@@ -28,17 +28,17 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
     static constexpr Int shcol    = 2;
     static constexpr Int km1     = 5;
     static constexpr auto km2   = km1 + 1;
-    
-    // TEST ONE 
+
+    // TEST ONE
     // Test interpolation going from midpoint grid to interface grid.  Note that
-    //  in this case the nlev grid is denoted by variable km1 and the nlevi 
+    //  in this case the nlev grid is denoted by variable km1 and the nlevi
     //  grid is represented by variable km2.  This is because the linear
     //  interp routine can interpolate from midpoint to interface grid or
-    //  vice versa so notation should be flexible.   
-    
+    //  vice versa so notation should be flexible.
+
     // Note that in this test we are testing TWO profils.  The first column
     //  will be loaded up with potential temperature values while the second
-    //  column will be loaded up with meridional wind values.  
+    //  column will be loaded up with meridional wind values.
 
     // Define the interface height grid [m]
     static constexpr Real zi_grid[km2] = {12500., 7500., 3000., 750., 250.0, 0.};
@@ -49,20 +49,21 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
     static constexpr Real u_wind_zt[km1] = {-2.0, -0.5, 0.0, 5.0, 2.0};
     // Define minimum threshold for this experiment, since we are
     //  dealing with negative winds in a column then set to a large
-    //  negative value since we do not want to clip.  
+    //  negative value since we do not want to clip.
     static constexpr Real minthresh = -99999.0;
 
     // Initialzie data structure for bridgeing to F90
     SHOCLinearintData SDS(shcol, km1, km2, minthresh);
 
     // For this test we need exactly two columns
-    REQUIRE(SDS.shcol == 2);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == km1 && SDS.nlevi() == km2 && SDS.minthresh == minthresh) );
+    REQUIRE(shcol == 2);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < km1; ++n) {
 	const auto offset = n + s * km1;
-        
+
 	// For zt grid heights compute as midpoint
 	//  between interface heights
 	SDS.x1[offset] = 0.5*(zi_grid[n]+zi_grid[n+1]);
@@ -84,7 +85,7 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
     // Check that the inputs make sense
 
     // Check that zt decreases upward
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < km1 - 1; ++n) {
 	const auto offset = n + s * km1;
 	REQUIRE(SDS.x1[offset + 1] - SDS.x1[offset] < 0.0);
@@ -99,20 +100,20 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
 
     // Call the fortran implementation
     linear_interp(SDS);
-    
+
     // First check that all output temperatures are greater than zero
 
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < km1; ++n) {
 	const auto offset = n + s * km1;
 	const auto offseti = n + s * km2;
-	
+
 	// check boundary points
 	// First upper boundary
 	if (n == 0){
 	  const auto uppergradient = SDS.y1[offset] - SDS.y1[offset+1];
 	  if (uppergradient > 0.0){
-	    // if upper gradient is positive then make sure that 
+	    // if upper gradient is positive then make sure that
 	    //  the temperature of the highest nlevi layer is greater
 	    //  than the tempature of the highest nlev layer
 	    REQUIRE(SDS.y2[offseti] > SDS.y1[offset]);
@@ -124,12 +125,12 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
 	    REQUIRE(SDS.y2[offseti] == SDS.y2[offseti]);
 	  }
 	}
-	
+
         // Now the lower boundary
 	else if (n == km1-1){
 	  const auto lowergradient = SDS.y1[offset-1] - SDS.y1[offset];
 	  if (lowergradient > 0.0){
-	    // if lower gradient is positive then make sure that 
+	    // if lower gradient is positive then make sure that
 	    //  the temperature of the lowest nlevi layer is lower
 	    //  than the tempature of the lowest nlev layer
 	    REQUIRE(SDS.y2[offseti+1] < SDS.y1[offset]);
@@ -141,23 +142,23 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
 	    REQUIRE(SDS.y2[offseti+1] == SDS.y2[offset]);
 	  }
 	}
-	
+
 	// Now make sure all points are bounded as expected
 	else{
 	  const auto gradient = SDS.y1[offset-1] - SDS.y1[offset];
 	  if (gradient == 0.0){
 	    REQUIRE(SDS.y2[offseti] == SDS.y1[offset]);
-	  } 
+	  }
 	  else if (gradient > 0.0){
 	    REQUIRE(SDS.y2[offseti] < SDS.y1[offset-1]);
 	    REQUIRE(SDS.y2[offseti] > SDS.y1[offset]);
 	  }
 	  else {
 	    REQUIRE(SDS.y2[offseti] > SDS.y1[offset-1]);
-	    REQUIRE(SDS.y2[offseti] < SDS.y1[offset]);	    
+	    REQUIRE(SDS.y2[offseti] < SDS.y1[offset]);
 	  }
 	}
-		
+
       }
     }
 
@@ -167,13 +168,13 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
     // Initialzie data structure for bridgeing to F90
     // NOTE that km2 and km1 grid must be switched here.
     // Must initialize a new data structure since km1 and km2 are swapped.
-    SHOCLinearintData SDS2(shcol, km2, km1, minthresh); 
+    SHOCLinearintData SDS2(shcol, km2, km1, minthresh);
 
     // Fill in test data on zi_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < km2; ++n) {
 	const auto offset = n + s * km2;
-        
+
 	// Load up stuff on interface grid.  Here we
 	//  are going to use information from the last test
 	//  to initialize our grid
@@ -181,19 +182,19 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
 	SDS2.y1[offset] = SDS.y2[offset];
       }
 
-      // Load up stuff on midpoint grid, use output from 
-      //  the last test here.  
+      // Load up stuff on midpoint grid, use output from
+      //  the last test here.
       for(Int n = 0; n < km1; ++n) {
 	const auto offset   = n + s * km1;
 	SDS2.x2[offset] = SDS.x1[offset];
       }
     }
-    
+
     linear_interp(SDS2);
-    
+
     // Check the result, make sure output is bounded correctly
-   
-    for(Int s = 0; s < SDS2.shcol; ++s) {
+
+    for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < km1; ++n) {
 	const auto offset = n + s * km1;
 	const auto offseti = n + s * km2;
@@ -203,20 +204,24 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
 
         if (gradient == 0.0){
 	  REQUIRE(SDS2.y2[offset] == SDS2.y1[offseti]);
-	} 
+	}
 	else if (gradient > 0.0){
 	  REQUIRE(SDS2.y2[offset] > SDS2.y1[offseti+1]);
 	  REQUIRE(SDS2.y2[offset] < SDS2.y1[offseti]);
 	}
 	else {
 	  REQUIRE(SDS2.y2[offset] < SDS2.y1[offseti+1]);
-	  REQUIRE(SDS2.y2[offset] > SDS2.y1[offseti]);	    
+	  REQUIRE(SDS2.y2[offset] > SDS2.y1[offseti]);
 	}
       }
     }
-        
+
   }
-  
+
+  static void run_bfb()
+  {
+
+  }
 };
 
 }  // namespace unit_test
@@ -232,10 +237,11 @@ TEST_CASE("shoc_linear_interp_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_linear_interp_b4b", "shoc")
+TEST_CASE("shoc_linear_interp_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocLinearInt;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_mix_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_mix_length_tests.cpp
@@ -30,19 +30,19 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
     // Tests for the SHOC function:
     //   compute_shoc_mix_shoc_length
 
-    // Multi column test will verify that 1) mixing length increases 
-    // with height given brunt vaisalla frequency and 
+    // Multi column test will verify that 1) mixing length increases
+    // with height given brunt vaisalla frequency and
     // TKE are constant with height and 2) Columns with larger
     // TKE values produce a larger length scale value
 
     // Define TKE [m2/s2] that will be used for each column
-    static constexpr Real tke_cons = 0.1;  
+    static constexpr Real tke_cons = 0.1;
     // Define the brunt vasailla frequency [s-1]
     static constexpr Real brunt_cons = 0.001;
     // Define the assymptoic length [m]
     static constexpr Real l_inf = 100.0;
     // Define the overturning timescale [s]
-    static constexpr Real tscale = 300.0; 
+    static constexpr Real tscale = 300.0;
     // Define the heights on the zt grid [m]
     static constexpr Real zt_grid[nlev] = {5000.0, 3000.0, 2000.0, 1000.0, 500.0};
 
@@ -51,16 +51,17 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
 
     // Test that the inputs are reasonable.
     // For this test shcol MUST be at least 2
-    REQUIRE(SDS.shcol > 1);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev) );
+    REQUIRE(shcol > 1);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       SDS.l_inf[s] = l_inf;
       SDS.tscale[s] = tscale;
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
-	// for the subsequent columns, increase 
+	// for the subsequent columns, increase
 	//  the amount of TKE
 	SDS.tke[offset] = (1.0+s)*tke_cons;
 	SDS.brunt[offset] = brunt_cons;
@@ -71,52 +72,55 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
     // Check that the inputs make sense
 
     // Be sure that relevant variables are greater than zero
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.l_inf[s] > 0.0);
       REQUIRE(SDS.tscale[s] > 0.0);
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	REQUIRE(SDS.tke[offset] > 0.0);
 	REQUIRE(SDS.zt_grid[offset] > 0.0);
 	if (s < shcol-1){
           // Verify that tke is larger column by column
-          const auto offsets = n + (s+1) * SDS.nlev;
+          const auto offsets = n + (s+1) * nlev;
           REQUIRE(SDS.tke[offset] < SDS.tke[offsets]);
 	}
       }
 
       // Check that zt increases upward
-      for(Int n = 0; n < SDS.nlev - 1; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev - 1; ++n) {
+	const auto offset = n + s * nlev;
 	REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0.0);
-      }        
+      }
     }
 
     // Call the fortran implementation
     compute_shoc_mix_shoc_length(SDS);
 
     // Check the results
-    for(Int s = 0; s < SDS.shcol; ++s) {   
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;   
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	// Validate shoc_mix greater than zero everywhere
-	REQUIRE(SDS.shoc_mix[offset] > 0.0);  
+	REQUIRE(SDS.shoc_mix[offset] > 0.0);
 	if (s < shcol-1){
           // Verify that mixing length increases column by column
-          const auto offsets = n + (s+1) * SDS.nlev;
+          const auto offsets = n + (s+1) * nlev;
           REQUIRE(SDS.shoc_mix[offset] < SDS.shoc_mix[offsets]);
-	}   
+	}
       }
 
       // Check that mixing length increases upward
-      for(Int n = 0; n < SDS.nlev - 1; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev - 1; ++n) {
+	const auto offset = n + s * nlev;
 	REQUIRE(SDS.shoc_mix[offset + 1] - SDS.shoc_mix[offset] < 0.0);
       }
-
     }
   }
 
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -132,10 +136,11 @@ TEST_CASE("shoc_mix_length_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_mix_length_b4b", "shoc")
+TEST_CASE("shoc_mix_length_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCompShocMixLength;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_compute_buoyflux_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_compute_buoyflux_tests.cpp
@@ -24,15 +24,14 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompBuoyFlux {
 
   static void run_property()
   {
-  
     static constexpr Real epsterm  = scream::physics::Constants<Real>::ep_2;
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_compute_buoyancy_flux
 
     // TEST ONE
-    // Dry atmostphere test.  If the atmosphere has no moisture, then 
+    // Dry atmostphere test.  If the atmosphere has no moisture, then
     //  verify that wthvsec = wthlsec
-    
+
     // Input data
     // Define the heat flux [K m/s]
     static constexpr Real wthlsec = 0.02;
@@ -42,71 +41,74 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompBuoyFlux {
     static constexpr Real wqls_dry = 0;
     // Define the input pressure [Pa]
     static constexpr Real pval = 85000;
-    
+
     // Initialize data structure for bridging to F90
     SHOCPDFcompbuoyfluxData SDS;
-    
+
     // Load input data
     SDS.wthlsec = wthlsec;
     SDS.wqwsec = wqwsec_dry;
     SDS.wqls = wqls_dry;
     SDS.pval = pval;
     SDS.epsterm = epsterm;
-    
+
     // Call the fortran implementation
     shoc_assumed_pdf_compute_buoyancy_flux(SDS);
-    
+
     // Check the result
     // Verify that buoyancy flux is equal to heat flux
     REQUIRE(SDS.wthv_sec == SDS.wthlsec);
-    
+
     // TEST TWO
     // Positive in cloud buoyancy test
     // Given two tests and inputs that are identical but one test
     //  with positive liquid water flux and the other with zero liquid
     //  water flux, verify that buoyancy flux is greater when cloud is
-    //  present and in updrafts.  
-    
+    //  present and in updrafts.
+
     // Some inputs will be recycled from previous test
-    
+
     // Define the latent heat flux [kg/kg m/s]
     static constexpr Real wqwsec_cloud = 0.004;
-    
+
     // Load the data
     SDS.wqwsec = wqwsec_cloud;
-    
+
     // For this test verify that liquid water flux is zero
     REQUIRE(SDS.wqls == 0);
-    
+
     // Call the fortran implementation
     shoc_assumed_pdf_compute_buoyancy_flux(SDS);
-    
+
     // Save the result
     Real wthv_sec_nocloud = SDS.wthv_sec;
-    
+
     // Define the liquid water flux [kg/kg m/s]
-    static constexpr Real wqls_cloud = 0.0004;    
-    
+    static constexpr Real wqls_cloud = 0.0004;
+
     SDS.wqls = wqls_cloud;
-    
+
     // For this test be sure that liquid water flux is positive
     REQUIRE(SDS.wqls > 0);
-    
+
     // Call the fortran implementation
     shoc_assumed_pdf_compute_buoyancy_flux(SDS);
-    
+
     // Make sure that this buoyancy flux is greater than the buoyancy
-    //   flux with no incloud updraft 
+    //   flux with no incloud updraft
     REQUIRE(SDS.wthv_sec > wthv_sec_nocloud);
-    
+
     // Also do some consistency checks.  Such as buoyancy flux
     //  should be greater (in this case) than the heat flux and
     //  the liquid water flux
     REQUIRE(SDS.wthv_sec > SDS.wthlsec);
     REQUIRE(SDS.wthv_sec > SDS.wqls);
-
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -122,10 +124,11 @@ TEST_CASE("shoc_pdf_compute_buoyflux_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_compute_buoyflux_b4b", "shoc")
+TEST_CASE("shoc_pdf_compute_buoyflux_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfCompBuoyFlux;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_compute_cloudvar_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_compute_cloudvar_tests.cpp
@@ -24,15 +24,14 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompCldVar {
 
   static void run_property()
   {
-  
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_compute_cloud_liquid_variance
 
     // TEST ONE
-    // standard deviation test.  Given two tests with identical inputs, 
+    // standard deviation test.  Given two tests with identical inputs,
     //  but one where s1 and s2 are larger, verify that SGS cloud water
     //  variance is larger
-    
+
     // Define gaussian fraction [-]
     static constexpr Real a = 0.3;
     // Define s1
@@ -46,26 +45,26 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompCldVar {
     // Define cloud liquid water for gaussian two [kg/kg]
     static constexpr Real ql2 = 0.001;
     // define cloud fraction for gaussian one [-]
-    static constexpr Real C2 = 0.1; 
+    static constexpr Real C2 = 0.1;
     // define grid mean shoc_ql [kg/kg]
     static constexpr Real shoc_ql = 0.005;
-    
+
     // Now define standard deviations of the gaussians.
     //    Here we define two sets for the different tests
     static constexpr Real std_s1_small = 0.01;
     static constexpr Real std_s2_small = 0.001;
-    
+
     // Define larger quantities for the second part of the test
     static constexpr Real std_s1_large = 0.02;
-    static constexpr Real std_s2_large = 0.002; 
-    
+    static constexpr Real std_s2_large = 0.002;
+
     // Verify these are in fact larger
     REQUIRE(std_s1_large > std_s1_small);
     REQUIRE(std_s2_large > std_s2_small);
-        
+
     // Initialize data structure for bridging to F90
     SHOCPDFcompcloudvarData SDS;
-    
+
     // load the data for the first part of the test
     SDS.a = a;
     SDS.s1 = s1;
@@ -75,10 +74,10 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompCldVar {
     SDS.ql2 = ql2;
     SDS.C2 = C2;
     SDS.shoc_ql = shoc_ql;
-    
+
     SDS.std_s1 = std_s1_small;
     SDS.std_s2 = std_s2_small;
-    
+
     // Verify inputs
     REQUIRE(SDS.a > 0);
     REQUIRE(SDS.a < 1);
@@ -90,61 +89,64 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompCldVar {
     REQUIRE(SDS.ql2 >= 0);
     REQUIRE(SDS.shoc_ql >= 0);
     REQUIRE(SDS.std_s1 >= 0);
-    REQUIRE(SDS.std_s2 >= 0);    
-    
+    REQUIRE(SDS.std_s2 >= 0);
+
     // Call the fortran implementation
     shoc_assumed_pdf_compute_cloud_liquid_variance(SDS);
-    
+
     // Save the result for the first part of the test
     Real shoc_ql2_small = SDS.shoc_ql2;
-    
-    // Now load the data needed for the second part of the test 
+
+    // Now load the data needed for the second part of the test
     SDS.std_s1 = std_s1_large;
     SDS.std_s2 = std_s2_large;
-    
+
     // Call the fortran implementation
     shoc_assumed_pdf_compute_cloud_liquid_variance(SDS);
-    
+
     // Verify that the liquid water variance is larger when the standard
     //   deviations of s are larger
-    
+
     REQUIRE(SDS.shoc_ql2 > shoc_ql2_small);
-    
+
     // TEST TWO
-    // Grid mean ql test.  Given identical inputs with the exception of 
+    // Grid mean ql test.  Given identical inputs with the exception of
     //  that in one set of inputs the grid mean of cloud water is larger, verify
     //  that shoc_ql2 is small in this case
-    
+
     // For inputs we will recycle the inputs from the last test used.
-    //  The exception being the grid mean cloud water 
-    
+    //  The exception being the grid mean cloud water
+
     static constexpr Real shoc_ql_small = 0.005;
-    static constexpr Real shoc_ql_large = 0.006;    
+    static constexpr Real shoc_ql_large = 0.006;
 
     // Verify that values are expected
-    REQUIRE(shoc_ql_large > shoc_ql_small); 
-    
+    REQUIRE(shoc_ql_large > shoc_ql_small);
+
     // Load input data
     SDS.shoc_ql = shoc_ql_small;
-    
+
     // Call the fortran implementation
     shoc_assumed_pdf_compute_cloud_liquid_variance(SDS);
-    
+
     // save the output for this test
     shoc_ql2_small = SDS.shoc_ql2;
-    
+
     // Load data for second part of this test
     SDS.shoc_ql = shoc_ql_large;
-    
+
     // Call the fortran implementation
     shoc_assumed_pdf_compute_cloud_liquid_variance(SDS);
-    
+
     // Check the result.  The cloud water variance should be SMALLER
     //  if the grid mean is larger for this case
-    REQUIRE(SDS.shoc_ql2 < shoc_ql2_small);    
-
+    REQUIRE(SDS.shoc_ql2 < shoc_ql2_small);
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -160,10 +162,11 @@ TEST_CASE("shoc_pdf_compute_cldvar_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_compute_cldvar_b4b", "shoc")
+TEST_CASE("shoc_pdf_compute_cldvar_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfCompCldVar;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_compute_liqflux_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_compute_liqflux_tests.cpp
@@ -24,17 +24,16 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompLiqFlux {
 
   static void run_property()
   {
-  
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_compute_liquid_water_flux
 
     // TEST ONE
     // Dry test.  Verify that wqls is zero if there is no
     //  liquid water loading.
-    
+
     // Input data (note that many of these inputs will be used
     //  for test two as well)
-    
+
     // Define the gaussian fraction [-]
     static constexpr Real a = 0.5;
     // Define vertical velocity of first gaussian
@@ -43,33 +42,31 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompLiqFlux {
     static constexpr Real ql1 = 0;
     // Define vertical velocity of second gaussian
     static constexpr Real w1_2 = -1;
-    // Define liquid water loading gaussian two
-    static constexpr Real ql2 = 0;
-  
+
     // Initialize data structure for bridging to F90
     SHOCPDFcompliqfluxData SDS;
-    
+
     // Load input data
     SDS.a = a;
     SDS.w1_1 = w1_1;
     SDS.ql1 = ql1;
     SDS.w1_2 = w1_2;
     SDS.ql2 = ql1;
-    
+
     // Verify there is no liquid water in inputs
     REQUIRE(SDS.ql1 == 0);
     REQUIRE(SDS.ql2 == 0);
-    
+
     // Call the fortran implementation
     shoc_assumed_pdf_compute_liquid_water_flux(SDS);
-    
+
     // Verify that liquid water flux is zero
     REQUIRE(SDS.wqls == 0);
-    
+
     // TEST TWO
     // Convective test.  Given inputs representative of convective
     //  conditions, verify that liquid water flux is greater than zero.
-    
+
      // Define the gaussian fraction [-]
     static constexpr Real a_conv = 0.1;
     // Define vertical velocity of first gaussian
@@ -78,32 +75,30 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompLiqFlux {
     static constexpr Real ql1_conv = 0.004;
     // Define vertical velocity of second gaussian
     static constexpr Real w1_2_conv = -0.1;
-    // Define liquid water loading gaussian two
-    static constexpr Real ql2_conv = 0; 
-    
+
     // Load input data
     SDS.a = a_conv;
     SDS.w1_1 = w1_1_conv;
     SDS.ql1 = ql1_conv;
     SDS.w1_2 = w1_2_conv;
-    SDS.ql2 = ql1_conv;  
-    
+    SDS.ql2 = ql1_conv;
+
     // Verify input data is as we expect for convective conditions
     REQUIRE(SDS.a < 0.5);
     REQUIRE(SDS.w1_1 > 0);
     REQUIRE(SDS.w1_2 < 0);
-    
+
     // Call the fortran implementation
     shoc_assumed_pdf_compute_liquid_water_flux(SDS);
-    
+
     // Verify the result.  Liquid water flux should be positive
     REQUIRE(SDS.wqls > 0);
-    
+
     // TEST THREE
     // negatively skewed test.  Given conditions indicative of negative
     //  skewness, with condensate in both gaussians, verify that liquid
     //  water flux is negative
-    
+
      // Define the gaussian fraction [-]
     static constexpr Real a_neg = 0.7;
     // Define vertical velocity of first gaussian
@@ -113,29 +108,32 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompLiqFlux {
     // Define vertical velocity of second gaussian
     static constexpr Real w1_2_neg = -2.0;
     // Define liquid water loading gaussian two
-    static constexpr Real ql2_neg = 0.004; 
-    
+    static constexpr Real ql2_neg = 0.004;
+
     // Load input data
     SDS.a = a_neg;
     SDS.w1_1 = w1_1_neg;
     SDS.ql1 = ql1_neg;
     SDS.w1_2 = w1_2_neg;
-    SDS.ql2 = ql2_neg;  
-    
+    SDS.ql2 = ql2_neg;
+
     // Verify input data is as we expect for convective conditions
     REQUIRE(SDS.a > 0.5);
     REQUIRE(SDS.w1_1 > 0);
     REQUIRE(SDS.w1_2 < 0);
     REQUIRE(SDS.ql1 == SDS.ql2);
-    
+
     // Call the fortran implementation
     shoc_assumed_pdf_compute_liquid_water_flux(SDS);
-    
+
     // Verify the result.  Liquid water flux should be positive
     REQUIRE(SDS.wqls < 0);
-        
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -151,10 +149,11 @@ TEST_CASE("shoc_pdf_compute_liqflux_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_compute_liqflux_b4b", "shoc")
+TEST_CASE("shoc_pdf_compute_liqflux_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfCompLiqFlux;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_compute_qs_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_compute_qs_tests.cpp
@@ -24,93 +24,96 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeQs {
 
   static void run_property()
   {
-  
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_compute_qs
 
     // TEST ONE
     // Zero Skewness tests.  Given inputs where Temperatures for
     //  the two gaussians are the same, verify that outputs are the same
-    
+
     // Define temperature of Gaussian 1 [K]
     static constexpr Real Tl1_1_eq = 290.0;
     // Define temperature of Gaussian 2 [K]
     static constexpr Real Tl1_2_eq = Tl1_1_eq;
     // Define pressure value [Pa]
     static constexpr Real pval_eq = 85000.0;
-    
+
     // Initialize data structure for bridging to F90
     SHOCPDFcompqsData SDS;
-    
+
     // Fill in input data
     SDS.Tl1_1 = Tl1_1_eq;
     SDS.Tl1_2 = Tl1_2_eq;
     SDS.pval = pval_eq;
-    
+
     // Check the inputs
     REQUIRE(SDS.Tl1_1 == SDS.Tl1_2);
     REQUIRE(SDS.pval > 0);
-    
-    // Call the fortran implementation 
+
+    // Call the fortran implementation
     shoc_assumed_pdf_compute_qs(SDS);
-    
+
     // Check the result
     REQUIRE(SDS.beta1 == SDS.beta2);
     REQUIRE(SDS.qs1 == SDS.qs2);
-    
+
     // TEST TWO
     // Pressure test.  Use the data from the last test and modify
     //  the pressure level to be lower and verify that qs1 is lower.
-    
+
     static constexpr Real pval_high = 100000.0;
-    
+
     // Save the result from last test
     Real qs1_test1 = SDS.qs1;
-    
+
     // Load new input
     SDS.pval = pval_high;
-    
+
     // Verify new pressure is greater than last test
     REQUIRE(SDS.pval > pval_eq);
-    
-    // Call the fortran implementation 
+
+    // Call the fortran implementation
     shoc_assumed_pdf_compute_qs(SDS);
-    
+
     // Check the result
-    REQUIRE(SDS.qs1 < qs1_test1);  
-    
+    REQUIRE(SDS.qs1 < qs1_test1);
+
     // TEST THREE
     // Skewed test.  using pressre input from last test, but using
     //  a skewed temperature distribution.  Verify that the gaussian
     //  with lower input temperature also has lower qs value
-    
+
     // Define temperature of Gaussian 1 [K]
     static constexpr Real Tl1_1_skew = 290;
     // Define temperature of Gaussian 2 [K]
-    static constexpr Real Tl1_2_skew = 300;      
-    
+    static constexpr Real Tl1_2_skew = 300;
+
     // Load new input
     SDS.Tl1_1 = Tl1_1_skew;
     SDS.Tl1_2 = Tl1_2_skew;
-    
+
     // Verify Gaussians are not equal
     REQUIRE(SDS.Tl1_1 != SDS.Tl1_2);
-    
-    // Call the fortran implementation 
-    shoc_assumed_pdf_compute_qs(SDS);  
-    
+
+    // Call the fortran implementation
+    shoc_assumed_pdf_compute_qs(SDS);
+
     // Check the result
     if (SDS.Tl1_1 < SDS.Tl1_2){
       REQUIRE(SDS.qs1 < SDS.qs2);
       REQUIRE(SDS.beta1 > SDS.beta2);
-    }  
+    }
     else{
       REQUIRE(SDS.qs1 > SDS.qs2);
       REQUIRE(SDS.beta1 < SDS.beta2);
     }
 
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -126,10 +129,11 @@ TEST_CASE("shoc_pdf_compute_qs_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_compute_qs_b4b", "shoc")
+TEST_CASE("shoc_pdf_compute_qs_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfComputeQs;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_compute_s_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_compute_s_tests.cpp
@@ -24,14 +24,13 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeS {
 
   static void run_property()
   {
-  
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_compute_s
 
     // TEST ONE
-    // Saturation test.  Given inputs that should produce saturation, 
+    // Saturation test.  Given inputs that should produce saturation,
     //  verify this condition is met.
-    
+
     // define Gaussian total water [kg/kg]
     static constexpr Real qw1 = 0.020;
     // define qs for gaussian 1 [kg/kg]
@@ -45,11 +44,11 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeS {
     // define total water variance for gaussian 1 [kg^2/kg^2]
     static constexpr Real qw2 = 1e-5;
     // define correlation between total water and temperature
-    static constexpr Real r_qwthl = 0.5; 
-    
+    static constexpr Real r_qwthl = 0.5;
+
     // Initialize data structure for bridging to F90
     SHOCPDFcompsData SDS;
-    
+
     // fill in data
     SDS.qw1 = qw1;
     SDS.qs1 = qs1;
@@ -60,57 +59,57 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeS {
     SDS.sqrtthl2 = sqrt(thl2);
     SDS.sqrtqw2 = sqrt(qw2);
     SDS.r_qwthl = r_qwthl;
-    
-    // Call the fortran implementation 
+
+    // Call the fortran implementation
     shoc_assumed_pdf_compute_s(SDS);
-    
+
     // Verify saturation has occurred
     REQUIRE(SDS.s > 0);
     REQUIRE(SDS.std_s > 0);
     REQUIRE(SDS.qn > 0);
     REQUIRE(SDS.C > 0);
-    
-    // TEST TWO 
-    // Variance test.  Given the same inputs as the previous test, but 
+
+    // TEST TWO
+    // Variance test.  Given the same inputs as the previous test, but
     //  with the variances doubled, verify that s is the same as the previous
-    //  test (because this does not depend on variance), but that std_s and 
+    //  test (because this does not depend on variance), but that std_s and
     //  qn have INCREASES but C has DECREASED.
-    
+
     // Save output from previous test
-    
+
     Real s_test1 = SDS.s;
     Real std_s_test1 = SDS.std_s;
     Real qn_test1 = SDS.qn;
     Real C_test1 = SDS.C;
-    
+
     // Fill in new values for variance, double the values
     //  uses in the previous test
-    
+
     // define temperature variance for gaussian 1 [K^2]
     static constexpr Real thl2_doub = 2*thl2;
     // define total water variance for gaussian 1 [kg^2/kg^2]
-    static constexpr Real qw2_doub = 2*qw2;   
-    
+    static constexpr Real qw2_doub = 2*qw2;
+
     REQUIRE(thl2_doub > thl2);
     REQUIRE(qw2_doub > qw2);
-    
+
     SDS.thl2 = thl2_doub;
     SDS.qw2 = qw2_doub;
     SDS.sqrtthl2 = sqrt(thl2_doub);
     SDS.sqrtqw2 = sqrt(qw2_doub);
-    
-    // Call the fortran implementation 
+
+    // Call the fortran implementation
     shoc_assumed_pdf_compute_s(SDS);
-    
+
     // check the result
     REQUIRE(SDS.s == s_test1);
     REQUIRE(SDS.std_s > std_s_test1);
     REQUIRE(SDS.qn > qn_test1);
-    REQUIRE(SDS.C < C_test1);    
-    
+    REQUIRE(SDS.C < C_test1);
+
     //TEST THREE
-    //Unsaturated test.  Given input with unsaturated conditions, verify 
-    // that the output is as expected.  
+    //Unsaturated test.  Given input with unsaturated conditions, verify
+    // that the output is as expected.
     static constexpr Real qw1_unsat = 0.016;
     // define qs for gaussian 1 [kg/kg]
     static constexpr Real qs1_unsat = 0.018;
@@ -118,7 +117,7 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeS {
     static constexpr Real thl2_unsat = 0;
     // define total water variance for gaussian 1 [kg^2/kg^2]
     static constexpr Real qw2_unsat = 0;
-    
+
     // load data
     SDS.qw1 = qw1_unsat;
     SDS.qs1 = qs1_unsat;
@@ -126,21 +125,24 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeS {
     SDS.qw2 = qw2_unsat;
     SDS.sqrtthl2 = sqrt(thl2_unsat);
     SDS.sqrtqw2 = sqrt(qw2_unsat);
-    
+
     // Check data
     REQUIRE(SDS.qw1 < SDS.qs1);
-    
-    // Call the fortran implementation 
+
+    // Call the fortran implementation
     shoc_assumed_pdf_compute_s(SDS);
-    
+
     // Verify output
     REQUIRE(SDS.s < 0);
     REQUIRE(SDS.C == 0);
     REQUIRE(SDS.qn == 0);
-    REQUIRE(SDS.std_s == 0);    
-
+    REQUIRE(SDS.std_s == 0);
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -156,10 +158,11 @@ TEST_CASE("shoc_pdf_compute_s_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_compute_s_b4b", "shoc")
+TEST_CASE("shoc_pdf_compute_s_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfComputeS;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_compute_sgsliq_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_compute_sgsliq_tests.cpp
@@ -24,15 +24,14 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeSgsLiq {
 
   static void run_property()
   {
-  
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_compute_sgs_liquid
 
     // TEST ONE
-    // Symmetric test.  For conditions of zero skewness, verify that 
-    //  that the SGS cloud condensate is equal to that of the two 
-    //  Gaussians.  
-    
+    // Symmetric test.  For conditions of zero skewness, verify that
+    //  that the SGS cloud condensate is equal to that of the two
+    //  Gaussians.
+
     // Define the gaussian fraction
     static constexpr Real a = 0.5;
     // Define the liquid water mixing ratio, gaussian 1 [kg/kg]
@@ -40,89 +39,89 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeSgsLiq {
     // Define the liquid water mixing ratio, gaussian 2 [kg/kg]
     // for this test, set equal to the first
     static constexpr Real ql2 = ql1;
-  
+
     // Initialize data structure for bridging to F90
     SHOCPDFcompsgsliqData SDS;
-    
+
     // Fill in the data
     SDS.a = a;
     SDS.ql1 = ql1;
     SDS.ql2 = ql2;
-    
+
     // Check the inputs
-    // For this test should be symmetric 
+    // For this test should be symmetric
     REQUIRE(SDS.a == 0.5);
     REQUIRE(SDS.ql1 == SDS.ql2);
-    
-    // Call the fortran implementation 
+
+    // Call the fortran implementation
     shoc_assumed_pdf_compute_sgs_liquid(SDS);
-    
+
     // Check the result
     REQUIRE(SDS.shoc_ql == SDS.ql1);
-    
-    // TEST TWO 
+
+    // TEST TWO
     // Negative test.  Assume that this routine is wrongly fed negative values
     //  of ql1 and ql2.  Verify that the result is zero.
-    
+
     // Define the gaussian fraction
     static constexpr Real a_neg = 0.2;
     // Define the liquid water mixing ratio, gaussian 1 [kg/kg]
     static constexpr Real ql1_neg = -0.02;
     // Define the liquid water mixing ratio, gaussian 2 [kg/kg]
     static constexpr Real ql2_neg =-0.01;
-    
+
     // Fill in the data
     SDS.a = a_neg;
     SDS.ql1 = ql1_neg;
     SDS.ql2 = ql2_neg;
-    
+
     // Check the inputs
     REQUIRE(SDS.a > 0);
     REQUIRE(SDS.a < 1);
-    
+
     // For this test we want mixing ratios to be negative
     REQUIRE(SDS.ql1 < 0);
     REQUIRE(SDS.ql2 < 0);
 
-    // Call the fortran implementation 
+    // Call the fortran implementation
     shoc_assumed_pdf_compute_sgs_liquid(SDS);
-    
+
     // Check the result.  Make sure mixing ratio is zero
     REQUIRE(SDS.shoc_ql == 0);
-    
+
     // TEST THREE
     // Positively skewed test. For test with positive skewness, verify that
     //  the resulting SGS cloud water lies between the two input values, given
-    //  a dry downdraft.  
-    
-    // Define the gaussian fraction
-    static constexpr Real a_skew = 0.1;
+    //  a dry downdraft.
+
     // Define the liquid water mixing ratio, gaussian 1 [kg/kg]
     static constexpr Real ql1_skew = 0.02;
     // Define the liquid water mixing ratio, gaussian 2 [kg/kg]
     static constexpr Real ql2_skew =0;
-    
+
     // Fill in the data
     SDS.a = a_neg;
     SDS.ql1 = ql1_skew;
     SDS.ql2 = ql2_skew;
-    
+
     // Check the data
     REQUIRE (SDS.a < 0.5);
     REQUIRE (SDS.ql1 > 0);
     REQUIRE (SDS.ql2 == 0);
 
-    // Call the fortran implementation 
+    // Call the fortran implementation
     shoc_assumed_pdf_compute_sgs_liquid(SDS);
-    
-    // Check the result.  Make sure SDS value is between the lower and 
+
+    // Check the result.  Make sure SDS value is between the lower and
     //  upper bound of the Gaussians
     REQUIRE(SDS.shoc_ql > SDS.ql2);
     REQUIRE(SDS.shoc_ql < SDS.ql1);
-     
-
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -138,10 +137,11 @@ TEST_CASE("shoc_pdf_compute_sgsliq_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_compute_sgsliq_b4b", "shoc")
+TEST_CASE("shoc_pdf_compute_sgsliq_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfComputeSgsLiq;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_computetemp_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_computetemp_tests.cpp
@@ -24,16 +24,15 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeTemp {
 
   static void run_property()
   {
-  
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_compute_temperature
 
     // TEST ONE
     // Keep liquid water potential temperature constant and
     //  decrease pressure by 10000 Pa each iteration.  Verify
-    //  that the liquid water temperature behaves as expected 
+    //  that the liquid water temperature behaves as expected
     //  (i.e. temperature decreases with decreasing pressure and
-    //  value is as expected relative to base pressure).  
+    //  value is as expected relative to base pressure).
 
     // Input liquid water potential temperature [K]
     static constexpr Real thl1 = 305;
@@ -41,42 +40,42 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeTemp {
     static constexpr Real basepres = 100000;
     // Input value of pval [Pa]
     Real pval = 110000;
-    
+
     // Decrease base pres by a certain amount each test
     static constexpr Real presincr = -10000;
-    
+
     Real Tl1_save;
-    
+
     // Initialize data structure for bridging to F90
     SHOCPDFcomptempData SDS;
-    
+
     // Fill in data
     SDS.thl1 = thl1;
     SDS.basepres = basepres;
     SDS.pval = pval;
-    
+
     Int num_tests = SDS.pval/abs(presincr);
-    
+
     REQUIRE(num_tests > 1);
     REQUIRE(presincr < 0);
-    // Make sure our starting pressure is greater than 
+    // Make sure our starting pressure is greater than
     //  basepres just so we test a range
     REQUIRE(SDS.pval > SDS.basepres);
-    
+
     for (Int s = 0; s < num_tests; ++s){
-      
+
       // make sure base pres is greater than zero
-      REQUIRE(basepres > 0);    
+      REQUIRE(basepres > 0);
 
       // Call the fortran implementation
-      shoc_assumed_pdf_compute_temperature(SDS);   
-      
-      // Check the result   
+      shoc_assumed_pdf_compute_temperature(SDS);
+
+      // Check the result
       // If pressure is greater than basepressure then
       //  make sure that temperature is greater than thetal
       if (SDS.pval > SDS.basepres){
         REQUIRE(SDS.Tl1 > SDS.thl1);
-      } 
+      }
       // otherwise temperature should be less than thetal
       else if(SDS.pval < SDS.basepres){
         REQUIRE(SDS.Tl1 < SDS.thl1);
@@ -86,24 +85,27 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeTemp {
       else
       {
         REQUIRE(SDS.Tl1 == SDS.thl1);
-      } 
-      
+      }
+
       // Make sure temperature are decreasing
       if (s > 0){
         REQUIRE(SDS.Tl1 < Tl1_save);
       }
-      
+
       // Save result to make sure that temperatures
       //  are decreasing as pressure decreases
-      Tl1_save = SDS.Tl1; 
-      
+      Tl1_save = SDS.Tl1;
+
       // Decrease pressure value
       SDS.pval = SDS.pval+presincr;
-     
-    }
 
+    }
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -119,10 +121,11 @@ TEST_CASE("shoc_pdf_computetemp_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_computetemp_b4b", "shoc")
+TEST_CASE("shoc_pdf_computetemp_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfComputeTemp;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_inplume_corr_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_inplume_corr_tests.cpp
@@ -24,10 +24,9 @@ struct UnitWrap::UnitTest<D>::TestShocInPlumeCorr {
 
   static void run_property()
   {
-  
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_inplume_correlations
-    
+
     // Test One
     // Zero correlation test.  Test conditions that should always
     //  yield a zero correlation
@@ -35,7 +34,7 @@ struct UnitWrap::UnitTest<D>::TestShocInPlumeCorr {
     // standard deviation moisture gaussian 1 [kg/kg]
     static constexpr Real sqrtqw2_1_zero = 0;
     // standard deviation moisture gaussian 2 [kg/kg]
-    static constexpr Real sqrtqw2_2_zero = 0;    
+    static constexpr Real sqrtqw2_2_zero = 0;
     // standard deviation temperature gaussian 1 [K]
     static constexpr Real sqrtthl2_1_zero = 0;
     // standard deviation moisture gaussian 2 [K]
@@ -56,10 +55,10 @@ struct UnitWrap::UnitTest<D>::TestShocInPlumeCorr {
     static constexpr Real thl1_2_zero = 289;
     // Define gaussian fraction [-]
     static constexpr Real a_zero = 0.2;
-    
+
     // Initialize data structure for bridging to F90
     SHOCPDFinplumeData SDS;
-    
+
     // Fill in test data
     SDS.sqrtqw2_1 = sqrtqw2_1_zero;
     SDS.sqrtqw2_2 = sqrtqw2_2_zero;
@@ -72,64 +71,67 @@ struct UnitWrap::UnitTest<D>::TestShocInPlumeCorr {
     SDS.thl_first = thl_first_zero;
     SDS.thl1_1 = thl1_1_zero;
     SDS.thl1_2 = thl1_2_zero;
-    SDS.a = a_zero; 
-    
-    // Call Fortran implementation 
-    shoc_assumed_pdf_inplume_correlations(SDS); 
-    
+    SDS.a = a_zero;
+
+    // Call Fortran implementation
+    shoc_assumed_pdf_inplume_correlations(SDS);
+
     // Check the result
     // Verify that correlation is zero
-    REQUIRE(SDS.r_qwthl_1 == 0.0);  
-    
-    // Test Two 
+    REQUIRE(SDS.r_qwthl_1 == 0.0);
+
+    // Test Two
     // Test conditions that should always yield a positive result
     // Note: some output is recycled
-    
+
     // standard deviation moisture gaussian 1 [kg/kg]
     static constexpr Real sqrtqw2_1_pos = 3e-4;
     // standard deviation moisture gaussian 2 [kg/kg]
-    static constexpr Real sqrtqw2_2_pos = 1e-4;    
+    static constexpr Real sqrtqw2_2_pos = 1e-4;
     // standard deviation temperature gaussian 1 [K]
     static constexpr Real sqrtthl2_1_pos = 0.7;
     // standard deviation moisture gaussian 2 [K]
     static constexpr Real sqrtthl2_2_pos = 0.2;
     // covariance of temperature and moisture [kg/kg K]
-    static constexpr Real qwthlsec_pos = 1.e-5; 
-    
+    static constexpr Real qwthlsec_pos = 1.e-5;
+
     // Fill in test data
     SDS.sqrtqw2_1 = sqrtqw2_1_pos;
     SDS.sqrtqw2_2 = sqrtqw2_2_pos;
     SDS.sqrtthl2_1 = sqrtthl2_1_pos;
     SDS.sqrtthl2_2 = sqrtthl2_2_pos;
     SDS.qwthlsec = qwthlsec_pos;
-    
-    // Call Fortran implementation 
-    shoc_assumed_pdf_inplume_correlations(SDS); 
-    
+
+    // Call Fortran implementation
+    shoc_assumed_pdf_inplume_correlations(SDS);
+
     // Check the result
     // Verify correlation is positive and not greater than one
     REQUIRE(SDS.r_qwthl_1 > 0);
     REQUIRE(SDS.r_qwthl_1 <= 1);
-    
+
     // Test Three
     // Test conditions that should always yield a negative result
-    
+
     // covariance of temperature and moisture [kg/kg K]
     static constexpr Real qwthlsec_neg = -1.e-5;
-    
+
     // Fill in test data
     SDS.qwthlsec = qwthlsec_neg;
-    
+
     // Call Fortran implementation
     shoc_assumed_pdf_inplume_correlations(SDS);
-    
+
     // Check the result
     // Verify correlation is negative and not less than negative one
     REQUIRE(SDS.r_qwthl_1 < 0);
-    REQUIRE(SDS.r_qwthl_1 >= -1);   
-      
+    REQUIRE(SDS.r_qwthl_1 >= -1);
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -145,10 +147,11 @@ TEST_CASE("shoc_pdf_inplume_corr_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_inplume_corr_b4b", "shoc")
+TEST_CASE("shoc_pdf_inplume_corr_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocInPlumeCorr;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_qw_parameters_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_qw_parameters_tests.cpp
@@ -24,19 +24,18 @@ struct UnitWrap::UnitTest<D>::TestShocQwParameters {
 
   static void run_property()
   {
-  
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_qw_parameters
 
     // TEST ONE
-    // run the test two times given identical inputs, except 
-    // one test where wqwsec is larger.  Verify that differece in 
+    // run the test two times given identical inputs, except
+    // one test where wqwsec is larger.  Verify that differece in
     // gaussians is also larger
 
     // Define the flux of total water [kg/kg m/s] small value
     static constexpr Real wqwsec_small = 0.0001;
     // Define the flux of total water [kg/kg m/s] large value
-    static constexpr Real wqwsec_large = 0.0005;    
+    static constexpr Real wqwsec_large = 0.0005;
     // Define the standard deviation of vertical velocity [m/s]
     static constexpr Real sqrtw2_test1 = 0.5;
     // Define the variance of total water [kg^2/kg^2]
@@ -51,16 +50,16 @@ struct UnitWrap::UnitTest<D>::TestShocQwParameters {
     static constexpr Real Skew_w_test1 = 1;
     // Define fraction of first gaussian
     static constexpr Real a_test1 = 0.2;
-    
+
     // conversion factor from kg/kg to g/kg
     static constexpr Real qvconv=1000;
-    
+
     // Be sure this value is actually larger
     REQUIRE(wqwsec_large > wqwsec_small);
-    
+
     // Initialize data structure for bridging to F90
     SHOCPDFqwparamData SDS;
-    
+
     // Fill the test data
     SDS.wqwsec = wqwsec_small;
     SDS.sqrtw2 = sqrtw2_test1;
@@ -71,12 +70,12 @@ struct UnitWrap::UnitTest<D>::TestShocQwParameters {
     SDS.w1_2 = w1_2_test1;
     SDS.Skew_w = Skew_w_test1;
     SDS.a = a_test1;
-    
+
     // Verify input is physical
     REQUIRE(SDS.sqrtw2 >= 0);
     REQUIRE(SDS.sqrtqt >= 0);
     REQUIRE(SDS.qw_first > 0);
-    
+
     // Make sure vertical velocity data is consistent
     REQUIRE(SDS.w1_1 > 0);
     REQUIRE(SDS.w1_2 < 0);
@@ -86,66 +85,69 @@ struct UnitWrap::UnitTest<D>::TestShocQwParameters {
     }
     else if (SDS.Skew_w < 0){
       REQUIRE(abs(SDS.w1_1) < abs(SDS.w1_2));
-      REQUIRE(SDS.a > 0.5);    
+      REQUIRE(SDS.a > 0.5);
     }
     else if (SDS.Skew_w == 0){
       REQUIRE(abs(SDS.w1_1) == abs(SDS.w1_2));
       REQUIRE(SDS.a == 0);
     }
-    
-    // Call Fortran implementation 
-    shoc_assumed_pdf_qw_parameters(SDS); 
-    
+
+    // Call Fortran implementation
+    shoc_assumed_pdf_qw_parameters(SDS);
+
     // Save absolute difference between the two gaussian moistures
     Real qwgaus_diff_result1 = abs(qvconv*SDS.qw1_2 - qvconv*SDS.qw1_1);
-    
+
     // Now laod up value for the large wqwsec test
     SDS.wqwsec = wqwsec_large;
 
-    // Call Fortran implementation 
+    // Call Fortran implementation
     shoc_assumed_pdf_qw_parameters(SDS);
-    
+
     // Save absolute difference between the two gaussian temps
-    Real qwgaus_diff_result2 = abs(qvconv*SDS.qw1_2 - qvconv*SDS.qw1_1); 
-    
+    Real qwgaus_diff_result2 = abs(qvconv*SDS.qw1_2 - qvconv*SDS.qw1_1);
+
     // Now check the result
-    REQUIRE(qwgaus_diff_result2 > qwgaus_diff_result1);       
-    
+    REQUIRE(qwgaus_diff_result2 > qwgaus_diff_result1);
+
     // TEST TWO
     // Run the test two times given idential inputs, except one test
     //  where qwsec is larger.  Verify that qw2_1 and qw2_2 are larger
 
     // Define the variance of total water [kg^2/kg^2] small
-    static constexpr Real qwsec_small = 1e-4;      
+    static constexpr Real qwsec_small = 1e-4;
     // Define the variance of total water [kg^2/kg^2] large
-    static constexpr Real qwsec_large = 2e-4;  
-    
+    static constexpr Real qwsec_large = 2e-4;
+
     REQUIRE(qwsec_large > qwsec_small);
-    
-    // Fill in test data 
+
+    // Fill in test data
     SDS.qwsec = qwsec_small;
     SDS.sqrtqt = sqrt(qwsec_small);
-    
+
     // Call the Fortran implementaiton
     shoc_assumed_pdf_qw_parameters(SDS);
-    
-    // Save the result to compare with next test 
+
+    // Save the result to compare with next test
     Real qw2_1_result1 = SDS.qw2_1;
     Real qw2_2_result1 = SDS.qw2_2;
-    
-    // Now load up input, with larger variances   
+
+    // Now load up input, with larger variances
     SDS.qwsec = qwsec_large;
-    SDS.sqrtqt = sqrt(qwsec_large);        
-      
-    // Call the fortran implementation  
+    SDS.sqrtqt = sqrt(qwsec_large);
+
+    // Call the fortran implementation
     shoc_assumed_pdf_qw_parameters(SDS);
-    
+
     // Now check the result
     REQUIRE(SDS.qw2_1 > qw2_1_result1);
     REQUIRE(SDS.qw2_2 > qw2_2_result1);
-      
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -161,10 +163,11 @@ TEST_CASE("shoc_pdf_qw_parameters_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_qw_parameters_b4b", "shoc")
+TEST_CASE("shoc_pdf_qw_parameters_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocQwParameters;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_thl_parameters_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_thl_parameters_tests.cpp
@@ -24,13 +24,12 @@ struct UnitWrap::UnitTest<D>::TestShocThlParameters {
 
   static void run_property()
   {
-  
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_thl_parameters
 
     // TEST ONE
-    // run the test two times given identical inputs, except 
-    // one test where thlsec is larger.  Verify that thl2_1 and 
+    // run the test two times given identical inputs, except
+    // one test where thlsec is larger.  Verify that thl2_1 and
     // th2_2 are larger
 
     // Define the flux of thetal [K m/s]
@@ -51,15 +50,15 @@ struct UnitWrap::UnitTest<D>::TestShocThlParameters {
     static constexpr Real Skew_w_test1 = 3;
     // Define fraction of first gaussian
     static constexpr Real a_test1 = 0.2;
-    // Define logical 
-    static constexpr bool dothetal_skew = false; 
-    
+    // Define logical
+    static constexpr bool dothetal_skew = false;
+
     // Be sure this value is actually larger
     REQUIRE(thlsec_large > thlsec_small);
-    
+
     // Initialize data structure for bridging to F90
     SHOCPDFthlparamData SDS;
-    
+
     // Fill the test data
     SDS.wthlsec = wthlsec_test1;
     SDS.sqrtw2 = sqrtw2_test1;
@@ -71,12 +70,12 @@ struct UnitWrap::UnitTest<D>::TestShocThlParameters {
     SDS.Skew_w = Skew_w_test1;
     SDS.a = a_test1;
     SDS.dothetal_skew = dothetal_skew;
-    
+
     // Verify input is physical
     REQUIRE(SDS.sqrtw2 >= 0);
     REQUIRE(SDS.sqrtthl >= 0);
     REQUIRE(SDS.thl_first > 0);
-    
+
     // Make sure vertical velocity data is consistent
     REQUIRE(SDS.w1_1 > 0);
     REQUIRE(SDS.w1_2 < 0);
@@ -86,7 +85,7 @@ struct UnitWrap::UnitTest<D>::TestShocThlParameters {
     }
     else if (SDS.Skew_w < 0){
       REQUIRE(abs(SDS.w1_1) < abs(SDS.w1_2));
-      REQUIRE(SDS.a > 0.5);    
+      REQUIRE(SDS.a > 0.5);
     }
     else if (SDS.Skew_w == 0){
       REQUIRE(abs(SDS.w1_1) == abs(SDS.w1_2));
@@ -95,63 +94,66 @@ struct UnitWrap::UnitTest<D>::TestShocThlParameters {
 
     // Call the fortran implementation
     shoc_assumed_pdf_thl_parameters(SDS);
-    
+
     // Save some results to compare with next test
     // save the gaussian temperature variances
     Real thl2_1_result1 = SDS.thl2_1;
     Real thl2_2_result1 = SDS.thl2_2;
-    
+
     // Now load up input data with a larger temperature standard deviation
     SDS.thlsec = thlsec_large;
-    SDS.sqrtthl = sqrt(thlsec_large); 
+    SDS.sqrtthl = sqrt(thlsec_large);
 
-    // Call the fortran implementation again 
-    shoc_assumed_pdf_thl_parameters(SDS);    
-    
+    // Call the fortran implementation again
+    shoc_assumed_pdf_thl_parameters(SDS);
+
     // Save some results to compare with the old test
     // save the gaussian temperature variances
     Real thl2_1_result2 = SDS.thl2_1;
-    Real thl2_2_result2 = SDS.thl2_2;    
-    
+    Real thl2_2_result2 = SDS.thl2_2;
+
     // Now check the result
     REQUIRE(thl2_1_result2 > thl2_1_result1);
     REQUIRE(thl2_2_result2 > thl2_2_result1);
-    
+
     // TEST TWO
-    // For a case with identical input except wthlsec, verify that 
+    // For a case with identical input except wthlsec, verify that
     // the case with higher wthlsec has larger |thl1_2-thl1_1|
-    
+
     // Define the flux of thetal [K m/s], small value
     static constexpr Real wthlsec_small = 0.02;
     // Define the large value
     static constexpr Real wthlsec_large = 0.05;
-    
+
     REQUIRE(wthlsec_large > wthlsec_small);
-    
+
     //load the value for the small test, all other inputs
     //  will be recycled from last test
     SDS.wthlsec = wthlsec_small;
-    
-    // Call Fortran implementation 
-    shoc_assumed_pdf_thl_parameters(SDS); 
-    
+
+    // Call Fortran implementation
+    shoc_assumed_pdf_thl_parameters(SDS);
+
     // Save absolute difference between the two gaussian temps
     Real thlgaus_diff_result1 = abs(SDS.thl1_2 - SDS.thl1_1);
-    
+
     // Now laod up value for the large wthlsec test
     SDS.wthlsec = wthlsec_large;
 
-    // Call Fortran implementation 
+    // Call Fortran implementation
     shoc_assumed_pdf_thl_parameters(SDS);
-    
+
     // Save absolute difference between the two gaussian temps
-    Real thlgaus_diff_result2 = abs(SDS.thl1_2 - SDS.thl1_1); 
-    
+    Real thlgaus_diff_result2 = abs(SDS.thl1_2 - SDS.thl1_1);
+
     // Now check the result
-    REQUIRE(thlgaus_diff_result2 > thlgaus_diff_result1);       
-      
+    REQUIRE(thlgaus_diff_result2 > thlgaus_diff_result1);
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -167,10 +169,11 @@ TEST_CASE("shoc_pdf_thl_parameters_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_thl_parameters_b4b", "shoc")
+TEST_CASE("shoc_pdf_thl_parameters_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocThlParameters;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_tildatoreal_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_tildatoreal_tests.cpp
@@ -24,12 +24,11 @@ struct UnitWrap::UnitTest<D>::TestShocPdfTildatoReal {
 
   static void run_property()
   {
-  
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_tilda_to_real
 
     // TEST ONE
-    // If variance of vertical velocity is zero then 
+    // If variance of vertical velocity is zero then
     //  verify that vertical velocity is equal grid mean
 
     // Define the grid mean vertical velocity [m/s]
@@ -38,10 +37,10 @@ struct UnitWrap::UnitTest<D>::TestShocPdfTildatoReal {
     static constexpr Real sqrtw2 = 0;
     // Define the normalized input of vertical velocity
     Real w1 = 0.1;
-    
+
     // Initialize data structure for bridging to F90
     SHOCPDFtildaData SDS;
-    
+
     // Fill the test data
     SDS.w_first = w_first;
     SDS.sqrtw2 = sqrtw2;
@@ -50,14 +49,14 @@ struct UnitWrap::UnitTest<D>::TestShocPdfTildatoReal {
     // Call the fortran implementation
     shoc_assumed_pdf_tilda_to_real(SDS);
 
-    // Check the test, verify that vertical velocity is equal 
+    // Check the test, verify that vertical velocity is equal
     //  to the grid mean value
-    
+
     REQUIRE(SDS.w1 == SDS.w_first);
-    
+
     // TEST TWO
     // Given a series of tests with increasing values of standard
-    //  deviation, verify that the gaussian value of w1 also 
+    //  deviation, verify that the gaussian value of w1 also
     //  is gradually increasing
 
     // Use value from test one
@@ -68,36 +67,39 @@ struct UnitWrap::UnitTest<D>::TestShocPdfTildatoReal {
     static constexpr Real incr = 0.1;
     // Define number of tests we want to do
     static constexpr Int num_tests = 10;
-    
+
     // Require at least two tests
     REQUIRE(num_tests >= 2);
-    
+
     // Initialize to a large neg value
     Real w1_previous = -999;
-    
+
     for (Int s = 0; s < num_tests; ++s){
-      // must initialize w1 at every test, 
+      // must initialize w1 at every test,
       //  since it is input/output
       SDS.w1 = w1;
       // increase value of sqrtw2 at every test
       SDS.sqrtw2 = SDS.sqrtw2 + incr;
-      
+
       REQUIRE(SDS.sqrtw2 >= 0.0);
-      
+
       // Call the fortran implementation
       shoc_assumed_pdf_tilda_to_real(SDS);
 
-      // Make sure test value is greater than 
+      // Make sure test value is greater than
       //  previous iteration
       REQUIRE(SDS.w1 > w1_previous);
-      
+
       // Save the result of this sample
       w1_previous = SDS.w1;
-      
-    }
 
+    }
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -113,10 +115,11 @@ TEST_CASE("shoc_pdf_tildatoreal_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_tildatoreal_b4b", "shoc")
+TEST_CASE("shoc_pdf_tildatoreal_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfTildatoReal;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_vv_parameters_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_vv_parameters_tests.cpp
@@ -24,14 +24,13 @@ struct UnitWrap::UnitTest<D>::TestShocVVParameters {
 
   static void run_property()
   {
-  
     // Property tests for the SHOC function
     //  shoc_assumed_pdf_vv_parameters
 
     // TEST ONE
-    // Given a symmetric distribution, verify that gaussian fractions 
+    // Given a symmetric distribution, verify that gaussian fractions
     //  are equal and that the two gaussians have identical vertical
-    //  velocities (but opposite sign). 
+    //  velocities (but opposite sign).
 
     // Define the grid mean vertical velocity [m/s]
     static constexpr Real w_first_sym = 1;
@@ -39,97 +38,100 @@ struct UnitWrap::UnitTest<D>::TestShocVVParameters {
     static constexpr Real w_sec_sym = 1;
     // Define the third moment of vertical velocity [m3/s3]
     static constexpr Real w3var_sym = 0;
-    
+
     // Initialize data structure for bridging to F90
     SHOCPDFvvparamData SDS;
-    
+
     // Fill the test data
     SDS.w_first = w_first_sym;
     SDS.w_sec = w_sec_sym;
     SDS.w3var = w3var_sym;
-    
+
     // Verify input is physical
     REQUIRE(SDS.w_sec >= 0);
 
     // Call the fortran implementation
     shoc_assumed_pdf_vv_parameters(SDS);
-    
+
     // Check the results
-    
+
     // Verify that gaussian fractions are equal
     REQUIRE(SDS.a == 0.5);
-    // Verify that guassian vertical velocities are 
+    // Verify that guassian vertical velocities are
     //   identical but opposite sign
     REQUIRE(SDS.w1_1 == -1.0*SDS.w1_2);
-    
+
     // TEST TWO
     // Given highly positive skewed distribution, verify that the gaussian
     //  fractions and vertical velocities are as expected
-    
+
     // Define the grid mean vertical velocity [m/s]
     static constexpr Real w_first_skew = 0;
     // Define the standard deviation of vertical velocity [m2/s2]
     static constexpr Real w_sec_skew = 1;
     // Define the third moment of vertical velocity [m3/s3]
-    static constexpr Real w3var_skew = 5;    
+    static constexpr Real w3var_skew = 5;
 
     // Fill the test data
     SDS.w_first = w_first_skew;
     SDS.w_sec = w_sec_skew;
     SDS.w3var = w3var_skew;
-    
-    // Verify input is physicsl 
+
+    // Verify input is physicsl
     REQUIRE(SDS.w_sec >= 0);
     // For this test we want w_first to be zero exactly
     REQUIRE(SDS.w_first == 0);
-    // For this test we want w3 to be positive 
+    // For this test we want w3 to be positive
     REQUIRE(SDS.w3var > 0);
-    
+
     // Call the fortran implementation
     shoc_assumed_pdf_vv_parameters(SDS);
-    
+
     // Verify that first gaussian is less than half
     REQUIRE(SDS.a < 0.5);
-    
+
     // Verify that first gaussian absolute value is larger
-    //  than second gaussian 
-    REQUIRE(abs(SDS.w1_1) > abs(SDS.w1_2)); 
-    
+    //  than second gaussian
+    REQUIRE(abs(SDS.w1_1) > abs(SDS.w1_2));
+
     // TEST THREE
     // Given highly negative skewed distribution, verify that the gaussian
     //  fractions and vertical velocities are as expected
-    
+
     // Define the grid mean vertical velocity [m/s]
     static constexpr Real w_first_neg = 0;
     // Define the standard deviation of vertical velocity [m2/s2]
     static constexpr Real w_sec_neg = 1;
     // Define the third moment of vertical velocity [m3/s3]
-    static constexpr Real w3var_neg = -5;    
+    static constexpr Real w3var_neg = -5;
 
     // Fill the test data
     SDS.w_first = w_first_neg;
     SDS.w_sec = w_sec_neg;
     SDS.w3var = w3var_neg;
-    
-    // Verify input is physicsl 
+
+    // Verify input is physicsl
     REQUIRE(SDS.w_sec >= 0);
     // For this test we want w_first to be zero exactly
     REQUIRE(SDS.w_first == 0);
     // For this test we want w3 to be negative
     REQUIRE(SDS.w3var < 0);
-    
+
     // Call the fortran implementation
     shoc_assumed_pdf_vv_parameters(SDS);
-    
+
     // Verify that first gaussian is greater than half
     REQUIRE(SDS.a > 0.5);
-    
+
     // Verify that second gaussian absolute value is larger
-    //  than first gaussian 
-    REQUIRE(abs(SDS.w1_1) < abs(SDS.w1_2));   
-    
+    //  than first gaussian
+    REQUIRE(abs(SDS.w1_1) < abs(SDS.w1_2));
   }
-  
+
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -145,10 +147,11 @@ TEST_CASE("shoc_pdf_vv_parameters_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_vv_parameters_b4b", "shoc")
+TEST_CASE("shoc_pdf_vv_parameters_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocVVParameters;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_tke_adv_sgs_tke_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_adv_sgs_tke_tests.cpp
@@ -60,12 +60,13 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
     SHOCAdvsgstkeData SDS(shcol, nlev, dtime);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.shcol > 0);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev && SDS.dtime == dtime) );
+    REQUIRE(shcol > 0);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.shoc_mix[offset] = shoc_mix_gr[s];
 	SDS.wthv_sec[offset] = wthv_sec_gr[s];
@@ -75,9 +76,9 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
     }
 
     // Check that the inputs make sense
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for (Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for (Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	// time step, mixing length, TKE values,
 	// shear terms should all be greater than zero
 	REQUIRE(SDS.dtime > 0.0);
@@ -92,9 +93,9 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
 
     // Check to make sure that there has been
     //  TKE growth
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	if (s == 0){
           // Growth check
@@ -122,9 +123,9 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
     Real tke_init_diss= 0.1;
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.shoc_mix[offset] = shoc_mix_diss[s];
 	SDS.wthv_sec[offset] = wthv_sec_diss;
@@ -134,9 +135,9 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
     }
 
     // Check that the inputs make sense
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for (Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for (Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	// time step, mixing length, TKE values,
 	// shear terms should all be greater than zero
 	REQUIRE(SDS.dtime > 0.0);
@@ -152,11 +153,11 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
     // Check to make sure that the column with
     //  the smallest length scale has larger
     //  dissipation rate
-    for(Int s = 0; s < SDS.shcol-1; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol-1; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * SDS.nlev;
+	const auto offsets = n + (s+1) * nlev;
 	if(SDS.shoc_mix[offset] > SDS.shoc_mix[offsets]){
           REQUIRE(SDS.a_diss[offset] < SDS.a_diss[offsets]);
 	}
@@ -167,6 +168,10 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
     }
   }
 
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -182,10 +187,11 @@ TEST_CASE("shoc_tke_adv_sgs_tke_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_tke_adv_sgs_tke_b4b", "shoc")
+TEST_CASE("shoc_tke_adv_sgs_tke_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocAdvSgsTke;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
@@ -53,12 +53,13 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
     SHOCColstabData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.shcol > 0);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev) );
+    REQUIRE(shcol > 0);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.dz_zt[offset] = dz_zt[n];
 	SDS.pres[offset] = pres[n];
@@ -67,9 +68,9 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
     }
 
     // Check that the inputs make sense
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for (Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for (Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	// Should be greater than zero
 	REQUIRE(SDS.dz_zt[offset] > 0.0);
 	// Make sure all pressure levels are in the
@@ -95,16 +96,16 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
     static constexpr Real brunt_neg[nlev] = {-0.3, -0.4, -0.1, -10.0, -0.5};
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	SDS.brunt[offset] = brunt_neg[n];
       }
     }
 
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for (Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for (Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	// All points should be less than zero
 	REQUIRE(SDS.brunt[offset] < 0.0);
       }
@@ -120,6 +121,10 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
     }
   }
 
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -135,10 +140,11 @@ TEST_CASE("shoc_tke_column_stab_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_tke_column_stab_b4b", "shoc")
+TEST_CASE("shoc_tke_column_stab_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocIntColStab;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
@@ -53,14 +53,15 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
     SHOCIsotropicData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.shcol > 0);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev) );
+    REQUIRE(shcol > 0);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // Column only input
       SDS.brunt_int[s] = brunt_int_st;
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.tke[offset] = tke_st;
 	SDS.a_diss[offset] = diss_st;
@@ -69,9 +70,9 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
     }
 
     // Check that the inputs make sense
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for (Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for (Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	// Should be greater than zero
 	REQUIRE(SDS.tke[offset] > 0.0);
 	REQUIRE(SDS.a_diss[offset] > 0.0);
@@ -83,11 +84,11 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
 
     // Check to make sure that column with positive
     //  brunt vaisalla frequency is smaller
-    for(Int s = 0; s < SDS.shcol-1; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol-1; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * SDS.nlev;
+	const auto offsets = n + (s+1) * nlev;
 	if(SDS.brunt[offset] < 0.0 & SDS.brunt[offsets] > 0.0){
           REQUIRE(SDS.isotropy[offset] > SDS.isotropy[offsets]);
 	}
@@ -112,10 +113,10 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
     static constexpr Real brunt_diss = 0.004;
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       SDS.brunt_int[s] = brunt_int_diss;
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.tke[offset] = tke_diss;
 	SDS.a_diss[offset] = diss_diss[s];
@@ -124,9 +125,9 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
     }
 
     // Check that the inputs make sense
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for (Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for (Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	// Should be greater than zero
 	REQUIRE(SDS.tke[offset] > 0.0);
 	REQUIRE(SDS.a_diss[offset] > 0.0);
@@ -138,11 +139,11 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
 
     // Check to make sure that column with positive
     //  brunt vaisalla frequency is smaller
-    for(Int s = 0; s < SDS.shcol-1; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol-1; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * SDS.nlev;
+	const auto offsets = n + (s+1) * nlev;
 	if(SDS.a_diss[offset] < SDS.a_diss[offsets]){
           REQUIRE(SDS.isotropy[offset] > SDS.isotropy[offsets]);
 	}
@@ -151,6 +152,11 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
 	}
       }
     }
+  }
+
+  static void run_bfb()
+  {
+    // TODO
   }
 
 };
@@ -168,10 +174,11 @@ TEST_CASE("shoc_tke_isotropic_ts_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_tke_isotropic_ts_b4b", "shoc")
+TEST_CASE("shoc_tke_isotropic_ts_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocIsotropicTs;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
@@ -53,30 +53,31 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
     SHOCTkeshearData SDS(shcol, nlev, nlevi);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.nlevi - SDS.nlev == 1);
-    REQUIRE(SDS.shcol > 0);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev && SDS.nlevi() == nlevi) );
+    REQUIRE(nlevi - nlev == 1);
+    REQUIRE(shcol > 0);
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.u_wind[offset] = u_wind_shr[n];
 	SDS.v_wind[offset] = v_wind_shr[n];
       }
 
       // Fill in test data on zi_grid.
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-	const auto offset   = n + s * SDS.nlevi;
+      for(Int n = 0; n < nlevi; ++n) {
+	const auto offset   = n + s * nlevi;
 	SDS.dz_zi[offset] = dz_zi[n];
       }
     }
 
     // Check that the inputs make sense
 
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for (Int n = 0; n < SDS.nlevi; ++n){
-	const auto offset = n + s * SDS.nlevi;
+    for(Int s = 0; s < shcol; ++s) {
+      for (Int n = 0; n < nlevi; ++n){
+	const auto offset = n + s * nlevi;
 	// Make sure top level dz_zi value is zero
 	if (n == 0){
           REQUIRE(SDS.dz_zi[offset] == 0.0);
@@ -96,8 +97,8 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
       // First check that sterm is ALWAYS greater than
       //  zero for non boundary points, but exactly zero
       //  for boundary points.
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-	const auto offset = n + s * SDS.nlevi;
+      for(Int n = 0; n < nlevi; ++n) {
+	const auto offset = n + s * nlevi;
 	if (n == 0 || n == nlevi-1){
           // Boundary point check
           REQUIRE(SDS.sterm[offset] == 0.0);
@@ -109,8 +110,8 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
       // Now validate that shear term is ALWAYS
       //  decreasing with height for these inputs, keeping
       //  in mind to exclude boundary points, which should be zero
-      for(Int n = 1; n < SDS.nlevi-2; ++n){
-	const auto offset = n + s * SDS.nlevi;
+      for(Int n = 1; n < nlevi-2; ++n){
+	const auto offset = n + s * nlevi;
 	REQUIRE(SDS.sterm[offset]-SDS.sterm[offset+1] < 0.0);
       }
     }
@@ -126,9 +127,9 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
     static constexpr Real v_wind_cons[nlev] = {-5.0, -5.0, -5.0, -5.0, -5.0};
 
     // Fill in test data on zt_grid.
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.u_wind[offset] = u_wind_cons[n];
 	SDS.v_wind[offset] = v_wind_cons[n];
@@ -141,13 +142,17 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
     // Check test
     // Verify that shear term is zero everywhere
     for(Int s = 0; s < shcol; ++s) {
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-	const auto offset = n + s * SDS.nlevi;
+      for(Int n = 0; n < nlevi; ++n) {
+	const auto offset = n + s * nlevi;
 	REQUIRE(SDS.sterm[offset] == 0.0);
       }
     }
   }
 
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -163,10 +168,11 @@ TEST_CASE("shoc_tke_shr_prod_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_tke_shr_prod_b4b", "shoc")
+TEST_CASE("shoc_tke_shr_prod_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocShearProd;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
@@ -67,14 +67,15 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     SHOCVarorcovarData SDS(shcol, nlev, nlevi, tunefac);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.nlevi - SDS.nlev == 1);
-    REQUIRE(SDS.shcol > 0);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev && SDS.nlevi() && SDS.tunefac == tunefac) );
+    REQUIRE(nlevi - nlev == 1);
+    REQUIRE(shcol > 0);
 
     // Fill in test data
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // First on the nlev grid
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	// Fill invar1 and invar2 with the SAME
 	//  variable for this case to test the
@@ -84,8 +85,8 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
       }
 
       // Now for data on the nlevi grid
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-	const auto offset = n + s * SDS.nlevi;
+      for(Int n = 0; n < nlevi; ++n) {
+	const auto offset = n + s * nlevi;
 
 	SDS.tkh_zi[offset] = tkh_zi[n];
 	SDS.isotropy_zi[offset] = isotropy_zi[n];
@@ -99,17 +100,17 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     REQUIRE(SDS.tunefac > 0.0);
     // Check to make sure that dz_zi, tkh_zi, and isotropy_zi
     //  (outside of the boundaries) are greater than zero
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // do NOT check boundaries!
-      for(Int n = 1; n < SDS.nlevi-1; ++n) {
-	const auto offset = n + s * SDS.nlevi;
+      for(Int n = 1; n < nlevi-1; ++n) {
+	const auto offset = n + s * nlevi;
 	REQUIRE(SDS.dz_zi[offset] > 0.0);
 	REQUIRE(SDS.tkh_zi[offset] > 0.0);
 	REQUIRE(SDS.isotropy_zi[offset] > 0.0);
       }
       // For this test make sure that invar1 = invar2
-      for(Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	REQUIRE(SDS.invar1[offset] == SDS.invar2[offset]);
       }
     }
@@ -118,9 +119,9 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     calc_shoc_varorcovar(SDS);
 
     // Check the results
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-	const auto offset = n + s * SDS.nlevi;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlevi; ++n) {
+	const auto offset = n + s * nlevi;
 
 	// validate that the boundary points have NOT been modified
 	if (n == 0 || n == nlevi){
@@ -152,26 +153,26 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     // NOTE: all other inputs are reused from test one
 
     // convert total water to [kg/kg]
-    for (Int n = 0; n < SDS.nlev; ++n){
+    for (Int n = 0; n < nlev; ++n){
       invar_qw[n] = invar_qw[n]/1000.;
     }
 
     // Update invar2 to be total water
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // First on the nlev grid
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	SDS.invar2[offset] = invar_qw[n];
       }
     }
 
     // Check inputs
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // For this test make sure that invar1 is NOT
       //  equal to invar2
-      for(Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	REQUIRE(SDS.invar1[offset] != SDS.invar2[offset]);
       }
     }
@@ -180,9 +181,9 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     calc_shoc_varorcovar(SDS);
 
     // Check the results
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-	const auto offset = n + s * SDS.nlevi;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlevi; ++n) {
+	const auto offset = n + s * nlevi;
 
 	// validate that the boundary points
 	//   have NOT been modified
@@ -229,10 +230,10 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     static constexpr Real invar_th2[nlev] = {320.0, 315.0, 310.0, 305.0};
 
     // Update invar1 and invar2 to be identical
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // First on the nlev grid
-      for(Int n = 0; n < SDS.nlev; ++n) {
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
 
 	// Set both inputs to the same value
 	SDS.invar1[offset] = invar_th2[n];
@@ -241,15 +242,15 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     }
 
     // Check the inputs
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 1; n < SDS.nlevi-1; ++n) {
-	const auto offset = n + s * SDS.nlevi;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 1; n < nlevi-1; ++n) {
+	const auto offset = n + s * nlevi;
 	// Validate that values of dz_zi are INCREASING with height
 	REQUIRE(SDS.dz_zi[offset]-SDS.dz_zi[offset+1] > 0.0);
       }
       // For this test make sure that invar1 = invar2
-      for(Int n = 0; n < SDS.nlev; ++n){
-	const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n){
+	const auto offset = n + s * nlev;
 	REQUIRE(SDS.invar1[offset] == SDS.invar2[offset]);
       }
     }
@@ -258,9 +259,9 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     calc_shoc_varorcovar(SDS);
 
     // Check the results
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 1; n < SDS.nlev-1; ++n) {
-	const auto offset = n + s * SDS.nlevi;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 1; n < nlev-1; ++n) {
+	const auto offset = n + s * nlevi;
 
 	// Validate that values of varorcovar
 	//  are decreasing with height
@@ -270,6 +271,10 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     }
   }
 
+  static void run_bfb()
+  {
+    // TODO
+  }
 };
 
 }  // namespace unit_test
@@ -285,10 +290,11 @@ TEST_CASE("shoc_varorcovar_property", "shoc")
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_varorcovar_b4b", "shoc")
+TEST_CASE("shoc_varorcovar_bfb", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocVarorCovar;
 
+  TestStruct::run_bfb();
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_vertflux_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_vertflux_tests.cpp
@@ -55,21 +55,22 @@ struct UnitWrap::UnitTest<D>::TestCalcShocVertflux {
     SHOCVertfluxData SDS(shcol, nlev, nlevi);
 
     // Test that the inputs are reasonable.
-    REQUIRE(SDS.nlevi - SDS.nlev == 1);
-    REQUIRE(SDS.shcol > 0);
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev && SDS.nlevi() == nlevi) );
+    REQUIRE(nlevi - nlev == 1);
+    REQUIRE(shcol > 0);
 
     // Fill in test data
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // First on the nlev grid
-      for(Int n = 0; n < SDS.nlev; ++n) {
-        const auto offset = n + s * SDS.nlev;
+      for(Int n = 0; n < nlev; ++n) {
+        const auto offset = n + s * nlev;
 
         SDS.invar[offset] = invar[n];
       }
 
       // Now for data on the nlevi grid
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-        const auto offset = n + s * SDS.nlevi;
+      for(Int n = 0; n < nlevi; ++n) {
+        const auto offset = n + s * nlevi;
 
         SDS.tkh_zi[offset] = tkh_zi[n];
         SDS.dz_zi[offset] = dz_zi[n];
@@ -81,10 +82,10 @@ struct UnitWrap::UnitTest<D>::TestCalcShocVertflux {
 
     // Check to make sure that dz_zi are tkh_zi
     //  (outside of the boundaries) are greater than zero
-    for(Int s = 0; s < SDS.shcol; ++s) {
+    for(Int s = 0; s < shcol; ++s) {
       // do NOT check boundaries!
-      for(Int n = 1; n < SDS.nlevi-1; ++n) {
-        const auto offset = n + s * SDS.nlevi;
+      for(Int n = 1; n < nlevi-1; ++n) {
+        const auto offset = n + s * nlevi;
         REQUIRE(SDS.dz_zi[offset] > 0);
         REQUIRE(SDS.tkh_zi[offset] > 0);
       }
@@ -94,9 +95,9 @@ struct UnitWrap::UnitTest<D>::TestCalcShocVertflux {
     calc_shoc_vertflux(SDS);
 
     // Check the results
-    for(Int s = 0; s < SDS.shcol; ++s) {
-      for(Int n = 0; n < SDS.nlevi; ++n) {
-        const auto offset = n + s * SDS.nlevi;
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlevi; ++n) {
+        const auto offset = n + s * nlevi;
 
         // validate that the boundary points
         //   have NOT been modified
@@ -127,7 +128,6 @@ struct UnitWrap::UnitTest<D>::TestCalcShocVertflux {
 
   static void run_bfb()
   {
-#if 0
     SHOCVertfluxData SDS_f90[] = {
       //               shcol, nlev, nlevi
       SHOCVertfluxData(10, 71, 72),
@@ -164,7 +164,7 @@ struct UnitWrap::UnitTest<D>::TestCalcShocVertflux {
     for (auto& d : SDS_cxx) {
       d.transpose<ekat::util::TransposeDirection::c2f>();
       // expects data in fortran layout
-      calc_shoc_vertflux_f(d.shcol, d.nlev, d.nlevi, d.tkh_zi, d.dz_zi, d.invar, d.vertflux);
+      calc_shoc_vertflux_f(d.shcol(), d.nlev(), d.nlevi(), d.tkh_zi, d.dz_zi, d.invar, d.vertflux);
       d.transpose<ekat::util::TransposeDirection::f2c>();
     }
 
@@ -172,11 +172,10 @@ struct UnitWrap::UnitTest<D>::TestCalcShocVertflux {
     for (Int i = 0; i < num_runs; ++i) {
       SHOCVertfluxData& d_f90 = SDS_f90[i];
       SHOCVertfluxData& d_cxx = SDS_cxx[i];
-      for (Int k = 0; k < d_f90.totali(); ++k) {
+      for (Int k = 0; k < d_f90.total1x3(); ++k) {
         REQUIRE(d_f90.vertflux[k] == d_cxx.vertflux[k]);
       }
     }
-#endif
   }
 
 };


### PR DESCRIPTION
1) Allow flexible dimension renaming
2) Have generic, not SHOC-specific, dimension names in the PhysicsTestData base class
3) Add PTD_STD_DEF macro to reduce even more code duplication
4) Fix lots of warnings in shoc tests

Fixes #549 