### PR TITLE
SHOC property test for upper level Length Scale function

### DIFF
--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -79,8 +79,8 @@ void calc_shoc_vertflux_c(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
 
 void shoc_length_c(Int shcol, Int nlev, Int nlevi, Real *tke, Real *host_dx,
                    Real *host_dy, Real *pblh, Real *zt_grid, Real *zi_grid,
-		   Real *dz_zt, Real *dz_zi, Real *thetal, Real *wthv_sec, 
-		   Real *thv, Real *brunt, Real *shoc_mix);
+                   Real *dz_zt, Real *dz_zi, Real *thetal, Real *wthv_sec,
+                   Real *thv, Real *brunt, Real *shoc_mix);
 
 void compute_brunt_shoc_length_c(Int nlev, Int nlevi, Int shcol ,Real *dz_zt,
                                  Real *thv, Real *thv_zi, Real *brunt);

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -279,12 +279,12 @@ void eddy_diffusivities(SHOCEddydiffData &d) {
 }
 
 void shoc_length(SHOCLengthData &d){
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  shoc_length_c(d.shcol,d.nlev,d.nlevi,d.tke,d.host_dx,d.host_dy,d.pblh,
-                d.zt_grid,d.zi_grid,d.dz_zt,d.dz_zi,d.thetal,d.wthv_sec,
-		d.thv,d.brunt,d.shoc_mix);
-  d.transpose<ekat::util::TransposeDirection::f2c>();		
+  shoc_length_c(d.shcol(),d.nlev(),d.nlevi(),d.tke,d.host_dx,d.host_dy,
+                d.pblh,d.zt_grid,d.zi_grid,d.dz_zt,d.dz_zi,d.thetal,
+		d.wthv_sec,d.thv,d.brunt,d.shoc_mix);
+  d.transpose<ekat::util::TransposeDirection::f2c>();	
 }
 
 void compute_brunt_shoc_length(SHOCBruntlengthData &d) {

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -333,7 +333,7 @@ void shoc_length(SHOCLengthData &d){
   d.transpose<ekat::util::TransposeDirection::c2f>();
   shoc_length_c(d.shcol(),d.nlev(),d.nlevi(),d.tke,d.host_dx,d.host_dy,
                 d.pblh,d.zt_grid,d.zi_grid,d.dz_zt,d.dz_zi,d.thetal,
-		d.wthv_sec,d.thv,d.brunt,d.shoc_mix);
+                d.wthv_sec,d.thv,d.brunt,d.shoc_mix);
   d.transpose<ekat::util::TransposeDirection::f2c>();	
 }
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -69,6 +69,11 @@ void eddy_diffusivities_c(Int nlev, Int shcol, Real *obklen, Real *pblh,
 void calc_shoc_vertflux_c(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
 			  Real *dz_zi, Real *invar, Real *vertflux);
 
+void shoc_length_c(Int shcol, Int nlev, Int nlevi, Real *tke, Real *host_dx,
+                   Real *host_dy, Real *pblh, Real *zt_grid, Real *zi_grid,
+		   Real *dz_zt, Real *dz_zi, Real *thetal, Real *wthv_sec, 
+		   Real *thv, Real *brunt, Real *shoc_mix);
+
 void compute_brunt_shoc_length_c(Int nlev, Int nlevi, Int shcol ,Real *dz_zt,
                                  Real *thv, Real *thv_zi, Real *brunt);
 
@@ -271,6 +276,15 @@ void eddy_diffusivities(SHOCEddydiffData &d) {
   eddy_diffusivities_c(d.nlev, d.shcol, d.obklen, d.pblh, d.zt_grid,
      d.shoc_mix, d.sterm_zt, d.isotropy, d.tke, d.tkh, d.tk);
   d.transpose<ekat::util::TransposeDirection::f2c>();
+}
+
+void shoc_length(SHOCLengthData &d){
+  shoc_init(d.nlev, true);
+  d.transpose<ekat::util::TransposeDirection::c2f>();
+  shoc_length_c(d.shcol,d.nlev,d.nlevi,d.tke,d.host_dx,d.host_dy,d.pblh,
+                d.zt_grid,d.zi_grid,d.dz_zt,d.dz_zi,d.thetal,d.wthv_sec,
+		d.thv,d.brunt,d.shoc_mix);
+  d.transpose<ekat::util::TransposeDirection::f2c>();		
 }
 
 void compute_brunt_shoc_length(SHOCBruntlengthData &d) {

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -233,6 +233,22 @@ struct SHOCVarorcovarData : public PhysicsTestData {
   PTD_ASSIGN_OP(SHOCVarorcovarData, 1, tunefac);
 };//SHOCVarorcovarData
 
+//Create data structure to hold data for shoc_length
+struct SHOCLengthData : public PhysicsTestData {
+  // Inputs
+  Real *tke, *host_dx, *host_dy, *pblh, *zt_grid, *zi_grid;
+  Real *dz_zt, *dz_zi, *wthv_sec, *thetal, *thv;
+
+  // Outputs
+  Real *brunt, *shoc_mix;
+
+  SHOCLengthData(Int shcol_, Int nlev_, Int nlevi_) :
+    PhysicsTestData(shcol_, nlev_, nlevi_, {&tke, &zt_grid, &dz_zt, &wthv_sec, &thetal, &thv, &brunt, &shoc_mix}, {&zi_grid, &dz_zi}, {&host_dx, &host_dy, &pblh}) {}
+
+  PTD_DATA_COPY_CTOR(SHOCLengthData, 3);
+  PTD_ASSIGN_OP(SHOCLengthData, 0)
+};//SHOCLengthData
+
 //Create data structure to hold data for compute_brunt_shoc_length
 struct SHOCBruntlengthData : public PhysicsTestData {
   // Inputs
@@ -507,6 +523,7 @@ void compute_shr_prod                               (SHOCTkeshearData &d);
 void isotropic_ts                                   (SHOCIsotropicData &d);
 void adv_sgs_tke                                    (SHOCAdvsgstkeData &d);
 void eddy_diffusivities                             (SHOCEddydiffData &d);
+void shoc_length                                    (SHOCLengthData &d);
 void compute_brunt_shoc_length                      (SHOCBruntlengthData &d);
 void compute_l_inf_shoc_length                      (SHOCInflengthData &d);
 void compute_conv_vel_shoc_length                   (SHOCConvvelData &d);

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -244,8 +244,7 @@ struct SHOCLengthData : public PhysicsTestData {
   SHOCLengthData(Int shcol_, Int nlev_, Int nlevi_) :
     PhysicsTestData(shcol_, nlev_, nlevi_, {&tke, &zt_grid, &dz_zt, &wthv_sec, &thetal, &thv, &brunt, &shoc_mix}, {&zi_grid, &dz_zi}, {&host_dx, &host_dy, &pblh}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCLengthData, 3);
-  PTD_ASSIGN_OP(SHOCLengthData, 0)
+  SHOC_NO_SCALAR(SHOCLengthData, 3);
 };//SHOCLengthData
 
 //Create data structure to hold data for compute_brunt_shoc_length

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -372,6 +372,21 @@ contains
     call calc_shoc_vertflux(shcol, nlev, nlevi, tkh_zi, dz_zi, invar, vertflux)
 
   end subroutine calc_shoc_vertflux_c
+  
+  subroutine shoc_length_c(shcol, nlev, nlevi, tke, host_dx, host_dy, pblh, &
+                zt_grid, zi_grid, dz_zt, dz_zi, thetal, wthv_sec, thv, &
+		brunt, shoc_mix) bind (C)
+    use shoc, only: shoc_length
+    
+    integer(kind=c_int), intent(in), value :: shcol
+    integer(kind=c_int), intent(in), value :: nlev
+    integer(kind=c_int), intent(in), value :: nlevi
+    real(kind=c_real), intent(in) :: tke(shcol,nlev)
+    real(kind=c_real), intent(in) :: host_dx(shcol)
+    real(kind=c_real), intent(in) :: host_dy(shcol)  
+    real(kind=c_real), intent(in) :: pblh(shcol)
+    real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
+    real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
 
   subroutine compute_brunt_shoc_length_c(nlev,nlevi,shcol,dz_zt,thv,thv_zi,brunt) bind (C)
     use shoc, only: compute_brunt_shoc_length

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -387,6 +387,20 @@ contains
     real(kind=c_real), intent(in) :: pblh(shcol)
     real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
     real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
+    real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
+    real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: wthv_sec(shcol,nlev)
+    real(kind=c_real), intent(in) :: thetal(shcol,nlev)
+    real(kind=c_real), intent(in) :: thv(shcol,nlev)
+    
+    real(kind=c_real), intent(out) :: brunt(shcol,nlev)
+    real(kind=c_real), intent(out) :: shoc_mix(shcol,nlev)
+    
+    call shoc_length(shcol, nlev, nlevi, tke, host_dx, host_dy, pblh, &
+                zt_grid, zi_grid, dz_zt, dz_zi, thetal, wthv_sec, thv, &
+		brunt, shoc_mix)
+		
+  end subroutine shoc_length_c
 
   subroutine compute_brunt_shoc_length_c(nlev,nlevi,shcol,dz_zt,thv,thv_zi,brunt) bind (C)
     use shoc, only: compute_brunt_shoc_length

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SHOC_TESTS_SRCS
     shoc_energy_total_fixer_tests.cpp
     shoc_energy_dse_fixer_tests.cpp
     shoc_energy_threshold_fixer_tests.cpp
+    shoc_length_tests.cpp
     shoc_brunt_length_tests.cpp
     shoc_l_inf_length_tests.cpp
     shoc_conv_vel_length_tests.cpp

--- a/components/scream/src/physics/shoc/tests/shoc_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_length_tests.cpp
@@ -1,0 +1,223 @@
+#include "catch2/catch.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestShocLength {
+
+  static void run_property()
+  {
+    static constexpr Int shcol    = 2;
+    static constexpr Int nlev     = 5;
+    static constexpr Int nlevi    = nlev+1;
+
+    // Tests for the upper level SHOC function:
+    //   shoc_length
+    
+    // TEST ONE
+    // Standard input and TKE test.  
+    // With reasonable inputs, verify outputs follow.  
+    // In addition, feed columns higher values of TKE and the length
+    // scale for these columns should be gradually larger, given all other
+    // inputs are equal.  
+
+    // PBL height [m]
+    static constexpr Real pblh = 1000.0;
+    // Define the host grid box size x-direction [m]
+    static constexpr Real host_dx = 3000; 
+    // Defin the host grid box size y-direction [m]
+    static constexpr Real host_dy = 5000; 
+    // Define the heights on the zt grid [m]
+    static constexpr Real zi_grid[nlevi] = {9000, 5000, 1500, 900, 500, 0};
+    // Virtual potential temperature on thermo grid [K]
+    static constexpr Real thv[nlev] = {315, 310, 305, 300, 295};    
+    // Buoyancy flux [K m/s]
+    static constexpr Real wthv_sec[nlev] = {0.02, 0.01, 0.04, 0.02, 0.05};   
+    // Turbulent kinetc energy [m2/s2]
+    static constexpr Real tke[nlev] = {0.1, 0.15, 0.2, 0.25, 0.3};
+    
+    // compute geometric grid mesh
+    const auto grid_mesh = sqrt(host_dx*host_dy);
+    
+    // Grid stuff to compute based on zi_grid
+    Real zt_grid[nlev];
+    Real dz_zt[nlev];
+    Real dz_zi[nlevi];
+    // Compute heights on midpoint grid 
+    for(Int n = 0; n < nlev; ++n) {
+      zt_grid[n] = 0.5*(zi_grid[n]+zi_grid[n+1]);
+      dz_zt[n] = zi_grid[n] - zi_grid[n+1];
+      if (n == 0){
+        dz_zi[n] = 0;
+      }
+      else{
+        dz_zi[n] = zt_grid[n-1] - zt_grid[n];
+      }
+    }
+    // set upper condition for dz_zi
+    dz_zi[nlevi-1] = zt_grid[nlev-1];
+
+    // Initialize data structure for bridging to F90
+    SHOCLengthData SDS(shcol, nlev, nlevi);
+    
+    // Load up input data
+    for(Int s = 0; s < SDS.shcol; ++s) {    
+      SDS.host_dx[s] = host_dx;
+      SDS.host_dy[s] = host_dy;
+      SDS.pblh[s] = pblh;
+      // Fill in test data on zt_grid.     
+      for(Int n = 0; n < SDS.nlev; ++n) {
+	const auto offset = n + s * SDS.nlev;
+	
+	// for subsequent columns, increase TKE
+	SDS.tke[offset] = (s+1)*tke[n];
+	
+	SDS.zt_grid[offset] = zt_grid[n];
+	SDS.thv[offset] = thv[n];
+	SDS.wthv_sec[offset] = wthv_sec[n];
+	SDS.dz_zt[offset] = dz_zt[n];	    
+      }
+      
+      // Fill in test data on zi_grid
+      for(Int n = 0; n < SDS.nlevi; ++n) {
+	const auto offset = n + s * SDS.nlevi;
+	
+	SDS.zi_grid[offset] = zi_grid[n];
+	SDS.dz_zi[offset] = dz_zi[n];
+      }   
+    }
+    
+    // Check input data
+    // for this test we need more than one column
+    REQUIRE(SDS.shcol > 1);
+    REQUIRE(SDS.nlevi == SDS.nlev+1);    
+    
+    for(Int s = 0; s < SDS.shcol; ++s) {     
+      for(Int n = 0; n < SDS.nlev; ++n) {
+	const auto offset = n + s * SDS.nlev;
+	
+	REQUIRE(SDS.zt_grid[offset] > 0);
+	REQUIRE(SDS.tke[offset] > 0);
+	REQUIRE(SDS.thv[offset] > 0);
+	REQUIRE(SDS.dz_zt[offset] > 0);
+	
+	// Make sure TKE is larger in next column over
+	if (s < SDS.shcol-1){
+	  // get offset for "neighboring" column
+	  const auto offsets = n + (s+1) * SDS.nlev;
+	  REQUIRE(SDS.tke[offsets] > SDS.tke[offset]);
+	}
+      }
+      
+      for(Int n = 0; n < SDS.nlev; ++n) {
+	const auto offset = n + s * SDS.nlev;
+	
+	REQUIRE(SDS.zi_grid[offset] >= 0);
+	REQUIRE(SDS.dz_zi[offset] >= 0);
+      }
+    }
+    
+    // Call the Fortran implementation 
+    shoc_length(SDS);
+
+    // Verify output
+    for(Int s = 0; s < SDS.shcol; ++s) {   
+      for(Int n = 0; n < SDS.nlev; ++n) { 
+        const auto offset = n + s * SDS.nlev;
+        // Require mixing length is greater than zero and is
+        //  less than geometric grid mesh length + 1 m
+        REQUIRE(SDS.shoc_mix[offset] > 0.0); 
+        REQUIRE(SDS.shoc_mix[offset] < 1.0+grid_mesh);
+	
+	// Be sure brunt vaisalla frequency is reasonable
+	REQUIRE(SDS.brunt[offset] < 1);
+	REQUIRE(SDS.brunt[offset] > -1);
+	
+	// Make sure length scale is larger when TKE is larger
+	if (s < SDS.shcol-1){
+	  // get offset for "neighboring" column
+	  const auto offsets = n + (s+1) * SDS.nlev;
+	  if (SDS.tke[offsets] > SDS.tke[offset]){
+	    REQUIRE(SDS.shoc_mix[offsets] > SDS.shoc_mix[offset]);
+	  }
+	  else{
+	    REQUIRE(SDS.shoc_mix[offsets] < SDS.shoc_mix[offset]);
+	  }
+	}	
+      }
+    }
+    
+    // TEST TWO
+    // Small grid mesh test.  Given a very small grid mesh, verify that
+    //  the length scale is confined to this value.  Input from first
+    //  test will be recycled into this one.
+     
+    // Define the host grid box size x-direction [m]
+    static constexpr Real host_dx_small = 3;
+    // Defin the host grid box size y-direction [m]
+    static constexpr Real host_dy_small = 5;
+    
+    // compute geometric grid mesh
+    const auto grid_mesh_small = sqrt(host_dx_small*host_dy_small);
+    
+    // Load new input
+    for(Int s = 0; s < SDS.shcol; ++s) {
+      SDS.host_dx[s] = host_dx_small;
+      SDS.host_dy[s] = host_dy_small;
+    }
+    
+    // call fortran implentation
+    shoc_length(SDS);
+    
+    // Verify output
+    for(Int s = 0; s < SDS.shcol; ++s) {   
+      for(Int n = 0; n < SDS.nlev; ++n) { 
+        const auto offset = n + s * SDS.nlev;
+        // Require mixing length is greater than zero and is
+        //  less than geometric grid mesh length + 1 m
+        REQUIRE(SDS.shoc_mix[offset] > 0.0); 
+        REQUIRE(SDS.shoc_mix[offset] < 1.0+grid_mesh_small);	
+      }
+    }
+
+  }
+
+};
+
+}  // namespace unit_test
+}  // namespace shoc
+}  // namespace scream
+
+namespace {
+
+TEST_CASE("shoc_length_property", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocLength;
+
+  TestStruct::run_property();
+}
+
+TEST_CASE("shoc_length_b4b", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocLength;
+
+}
+
+} // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -65,6 +65,7 @@ struct UnitWrap {
     struct TestShocIsotropicTs;
     struct TestShocShearProd;
     struct TestShocVarorCovar;
+    struct TestShocLength;
     struct TestCompBruntShocLength;
     struct TestCheckShocLength;
     struct TestCompShocConvTime;


### PR DESCRIPTION
Add property test for subroutine shoc_length, which serves as the upper level function for all of SHOC's length scale related routines.  