### PR TITLE
SHOC property tests for mid and upper level functions for Third Moments

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -423,9 +423,8 @@ subroutine shoc_main ( &
        shcol,nlev,nlevi,&                   ! Input
        w_sec,thl_sec,qw_sec,qwthl_sec,&     ! Input
        wthl_sec,isotropy,brunt,&            ! Input
-       thetal,tke,wthv_sec,shoc_mix,&       ! Input
-       dz_zt,dz_zi,&                        ! Input
-       zt_grid,zi_grid,&                    ! Input
+       thetal,tke,wthv_sec,&                ! Input
+       dz_zt,dz_zi,zt_grid,zi_grid,&        ! Input
        w3)                                  ! Output
 
     ! Call the PDF to close on SGS cloud and turbulence
@@ -1490,9 +1489,8 @@ subroutine diag_third_shoc_moments(&
           shcol,nlev,nlevi, &                 ! Input
           w_sec, thl_sec, qw_sec, qwthl_sec,& ! Input
           wthl_sec, isotropy, brunt,&         ! Input
-          thetal,tke,wthv_sec,shoc_mix,&      ! Input
-          dz_zt, dz_zi,&                      ! Input
-          zt_grid,zi_grid,&                   ! Input
+          thetal,tke,wthv_sec,&               ! Input
+          dz_zt, dz_zi, zt_grid, zi_grid,&    ! Input
           w3)                                 ! Output
 
   ! Purpose of this subroutine is to diagnose the third
@@ -1530,8 +1528,6 @@ subroutine diag_third_shoc_moments(&
   real(rtype), intent(in) :: tke(shcol,nlev)
   ! buoyancy flux [K m/s]
   real(rtype), intent(in) :: wthv_sec(shcol,nlev)
-  ! mixing length [m]
-  real(rtype), intent(in) :: shoc_mix(shcol,nlev)
   ! thickness centered on thermodynamic grid [m]
   real(rtype), intent(in) :: dz_zt(shcol,nlev)
   ! thickness centered on interface grid [m]
@@ -1551,7 +1547,6 @@ subroutine diag_third_shoc_moments(&
   real(rtype) :: brunt_zi(shcol,nlevi)
   real(rtype) :: thetal_zi(shcol,nlevi)
   real(rtype) :: wthv_sec_zi(shcol,nlevi)
-  real(rtype) :: shoc_mix_zi(shcol,nlevi)
 
   ! Interpolate variables onto the interface levels
   call linear_interp(zt_grid,zi_grid,isotropy,isotropy_zi,nlev,nlevi,shcol,0._rtype)
@@ -1559,7 +1554,6 @@ subroutine diag_third_shoc_moments(&
   call linear_interp(zt_grid,zi_grid,w_sec,w_sec_zi,nlev,nlevi,shcol,(2._rtype/3._rtype)*mintke)
   call linear_interp(zt_grid,zi_grid,thetal,thetal_zi,nlev,nlevi,shcol,0._rtype)
   call linear_interp(zt_grid,zi_grid,wthv_sec,wthv_sec_zi,nlev,nlevi,shcol,largeneg)
-  call linear_interp(zt_grid,zi_grid,shoc_mix,shoc_mix_zi,nlev,nlevi,shcol,minlen)
 
   !Diagnose the third moment of the vertical-velocity
   call compute_diag_third_shoc_moment(&
@@ -1568,10 +1562,8 @@ subroutine diag_third_shoc_moments(&
           wthl_sec, tke, dz_zt, dz_zi,&       ! Input
           zt_grid,zi_grid, isotropy_zi,&      ! Input
           brunt_zi,w_sec_zi,thetal_zi,&       ! Input
-          wthv_sec_zi,shoc_mix_zi,&           ! Input
+          wthv_sec_zi,&                       ! Input
           w3)                                 ! Output
-
-
 
   ! perform clipping to prevent unrealistically large values from occuring
   call clipping_diag_third_shoc_moments(&
@@ -1588,7 +1580,7 @@ subroutine compute_diag_third_shoc_moment(&
           wthl_sec, tke, dz_zt, dz_zi,&       ! Input
           zt_grid,zi_grid, isotropy_zi,&      ! Input
           brunt_zi,w_sec_zi,thetal_zi,&       ! Input
-          wthv_sec_zi,shoc_mix_zi,&           ! Input
+          wthv_sec_zi,&                       ! Input
           w3)                                 ! Output
 
   implicit none
@@ -1626,7 +1618,6 @@ subroutine compute_diag_third_shoc_moment(&
   real(rtype), intent(in) :: w_sec_zi(shcol,nlevi)
   real(rtype), intent(in) :: thetal_zi(shcol,nlevi)
   real(rtype), intent(in) :: wthv_sec_zi(shcol,nlevi)
-  real(rtype), intent(in) :: shoc_mix_zi(shcol,nlevi)
   ! third moment of vertical velocity
   real(rtype), intent(out) :: w3(shcol,nlevi)
 ! LOCAL VARIABLES

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -92,6 +92,14 @@ void check_length_scale_shoc_length_c(Int nlev, Int shcol, Real *host_dx,
 void shoc_diag_second_moments_srf_c(Int shcol, Real* wthl, Real* uw, Real* vw,
                                    Real* ustar2, Real* wstar);
 
+void compute_diag_third_shoc_moment_c(Int shcol, Int nlev, Int nlevi, Real *w_sec,
+                                      Real *thl_sec, Real *qw_sec, Real *qwthl_sec,
+				      Real *wthl_sec, Real *tke, Real *dz_zt, 
+				      Real *dz_zi, Real *zt_grid, Real *zi_grid,
+				      Real *isotropy_zi, Real *brunt_zi, Real *w_sec_zi,
+				      Real *thetal_zi, Real *wthv_sec_zi, 
+				      Real *shoc_mix_zi, Real *w3);
+
 void linear_interp_c(Real *x1, Real *x2, Real *y1, Real *y2, Int km1,
                      Int km2, Int ncol, Real minthresh);
 void shoc_assumed_pdf_tilda_to_real_c(Real w_first, Real sqrtw2, Real* w1);
@@ -324,6 +332,17 @@ void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d)
   shoc_diag_second_moments_srf_c(d.shcol, d.wthl, d.uw, d.vw, d.ustar2, d.wstar);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
+
+void compute_diag_third_shoc_moment(SHOCCompThirdMomData &d) {
+  shoc_init(d.nlev, true);
+  d.transpose<ekat::util::TransposeDirection::c2f>();
+  compute_diag_third_shoc_moment_c(d.shcol,d.nlev,d.nlevi,d.w_sec,d.thl_sec,d.qw_sec,
+                                   d.qwthl_sec,d.wthl_sec,d.tke,d.dz_zt,d.dz_zi,
+				   d.zt_grid,d.zi_grid,d.isotropy_zi,d.brunt_zi,
+				   d.w_sec_zi,d.thetal_zi,d.wthv_sec_zi,
+				   d.shoc_mix_zi,d.w3);
+  d.transpose<ekat::util::TransposeDirection::f2c>();
+} 
 
 void linear_interp(SHOCLinearintData& d)
 {

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -99,6 +99,12 @@ void compute_diag_third_shoc_moment_c(Int shcol, Int nlev, Int nlevi, Real *w_se
 				      Real *isotropy_zi, Real *brunt_zi, Real *w_sec_zi,
 				      Real *thetal_zi, Real *wthv_sec_zi, 
 				      Real *shoc_mix_zi, Real *w3);
+				      
+void diag_third_shoc_moments_c(Int shoc, Int nlev, Int nlevi, Real *w_sec, 
+                               Real *thl_sec, Real *isotropy, Real *brunt,
+			       Real *thetal, Real *tke, Real *wthv_sec,
+			       Real *shoc_mix, Real *dz_zt, Real *dz_zi,
+			       Real *zt_grid, Real *zi_grid);
 
 void linear_interp_c(Real *x1, Real *x2, Real *y1, Real *y2, Int km1,
                      Int km2, Int ncol, Real minthresh);
@@ -341,6 +347,16 @@ void compute_diag_third_shoc_moment(SHOCCompThirdMomData &d) {
 				   d.dz_zi,d.zt_grid,d.zi_grid,d.isotropy_zi,
 				   d.brunt_zi,d.w_sec_zi,d.thetal_zi,d.wthv_sec_zi,
 				   d.shoc_mix_zi,d.w3);
+  d.transpose<ekat::util::TransposeDirection::f2c>();
+}
+
+void diag_third_shoc_moments(SHOCDiagThirdMomData &d) {
+  shoc_init(d.nlev(), true);
+  d.transpose<ekat::util::TransposeDirection::c2f>();
+  diag_third_shoc_moments_c(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,d.qw_sec,
+                            d.qwthl_sec,d.wthl_sec,d.isotropy,d.brunt,d.thetal,d.tke,
+			    d.wthv_sec,d.shoc_mix,d.dz_zt,d.dz_zi,d.zt_grid,d.zi_grid,
+			    d.w3);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 } 
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -334,12 +334,12 @@ void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d)
 }
 
 void compute_diag_third_shoc_moment(SHOCCompThirdMomData &d) {
-  shoc_init(d.nlev, true);
+  shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
-  compute_diag_third_shoc_moment_c(d.shcol,d.nlev,d.nlevi,d.w_sec,d.thl_sec,d.qw_sec,
-                                   d.qwthl_sec,d.wthl_sec,d.tke,d.dz_zt,d.dz_zi,
-				   d.zt_grid,d.zi_grid,d.isotropy_zi,d.brunt_zi,
-				   d.w_sec_zi,d.thetal_zi,d.wthv_sec_zi,
+  compute_diag_third_shoc_moment_c(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,
+                                   d.qw_sec,d.qwthl_sec,d.wthl_sec,d.tke,d.dz_zt,
+				   d.dz_zi,d.zt_grid,d.zi_grid,d.isotropy_zi,
+				   d.brunt_zi,d.w_sec_zi,d.thetal_zi,d.wthv_sec_zi,
 				   d.shoc_mix_zi,d.w3);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 } 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -345,7 +345,7 @@ void diag_third_shoc_moments(SHOCDiagThirdMomData &d) {
   d.transpose<ekat::util::TransposeDirection::c2f>();
   diag_third_shoc_moments_c(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,d.qw_sec,
                             d.qwthl_sec,d.wthl_sec,d.isotropy,d.brunt,d.thetal,
-			    d.tke,d.wthv_sec,d.dz_zt,d.dz_zi,d.zt_grid,d.zi_grid,
+                            d.tke,d.wthv_sec,d.dz_zt,d.dz_zi,d.zt_grid,d.zi_grid,
                             d.w3);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -92,19 +92,20 @@ void check_length_scale_shoc_length_c(Int nlev, Int shcol, Real *host_dx,
 void shoc_diag_second_moments_srf_c(Int shcol, Real* wthl, Real* uw, Real* vw,
                                    Real* ustar2, Real* wstar);
 
+void diag_third_shoc_moments_c(Int shoc, Int nlev, Int nlevi, Real *w_sec, 
+                               Real *thl_sec, Real *qw_sec, Real *qwthl_sec,
+			       Real *wthl_sec, Real *isotropy, Real *brunt,
+			       Real *thetal, Real *tke, Real *wthv_sec,
+			       Real *dz_zt, Real *dz_zi, Real *zt_grid,
+			       Real *zi_grid, Real *w3);
+
 void compute_diag_third_shoc_moment_c(Int shcol, Int nlev, Int nlevi, Real *w_sec,
                                       Real *thl_sec, Real *qw_sec, Real *qwthl_sec,
 				      Real *wthl_sec, Real *tke, Real *dz_zt, 
 				      Real *dz_zi, Real *zt_grid, Real *zi_grid,
 				      Real *isotropy_zi, Real *brunt_zi, Real *w_sec_zi,
 				      Real *thetal_zi, Real *wthv_sec_zi, 
-				      Real *shoc_mix_zi, Real *w3);
-				      
-void diag_third_shoc_moments_c(Int shoc, Int nlev, Int nlevi, Real *w_sec, 
-                               Real *thl_sec, Real *isotropy, Real *brunt,
-			       Real *thetal, Real *tke, Real *wthv_sec,
-			       Real *shoc_mix, Real *dz_zt, Real *dz_zi,
-			       Real *zt_grid, Real *zi_grid);
+				      Real *w3);
 
 void linear_interp_c(Real *x1, Real *x2, Real *y1, Real *y2, Int km1,
                      Int km2, Int ncol, Real minthresh);
@@ -339,6 +340,15 @@ void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d)
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
+void diag_third_shoc_moments(SHOCDiagThirdMomData &d) {
+  shoc_init(d.nlev(), true);
+  d.transpose<ekat::util::TransposeDirection::c2f>();
+  diag_third_shoc_moments_c(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,d.qw_sec,
+                            d.qwthl_sec,d.wthl_sec,d.isotropy,d.brunt,d.thetal,d.tke,
+			    d.wthv_sec,d.dz_zt,d.dz_zi,d.zt_grid,d.zi_grid,d.w3);
+  d.transpose<ekat::util::TransposeDirection::f2c>();
+}
+
 void compute_diag_third_shoc_moment(SHOCCompThirdMomData &d) {
   shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
@@ -346,19 +356,9 @@ void compute_diag_third_shoc_moment(SHOCCompThirdMomData &d) {
                                    d.qw_sec,d.qwthl_sec,d.wthl_sec,d.tke,d.dz_zt,
 				   d.dz_zi,d.zt_grid,d.zi_grid,d.isotropy_zi,
 				   d.brunt_zi,d.w_sec_zi,d.thetal_zi,d.wthv_sec_zi,
-				   d.shoc_mix_zi,d.w3);
+				   d.w3);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
-
-void diag_third_shoc_moments(SHOCDiagThirdMomData &d) {
-  shoc_init(d.nlev(), true);
-  d.transpose<ekat::util::TransposeDirection::c2f>();
-  diag_third_shoc_moments_c(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,d.qw_sec,
-                            d.qwthl_sec,d.wthl_sec,d.isotropy,d.brunt,d.thetal,d.tke,
-			    d.wthv_sec,d.shoc_mix,d.dz_zt,d.dz_zi,d.zt_grid,d.zi_grid,
-			    d.w3);
-  d.transpose<ekat::util::TransposeDirection::f2c>();
-} 
 
 void linear_interp(SHOCLinearintData& d)
 {

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -94,18 +94,18 @@ void shoc_diag_second_moments_srf_c(Int shcol, Real* wthl, Real* uw, Real* vw,
 
 void diag_third_shoc_moments_c(Int shoc, Int nlev, Int nlevi, Real *w_sec, 
                                Real *thl_sec, Real *qw_sec, Real *qwthl_sec,
-			       Real *wthl_sec, Real *isotropy, Real *brunt,
-			       Real *thetal, Real *tke, Real *wthv_sec,
-			       Real *dz_zt, Real *dz_zi, Real *zt_grid,
-			       Real *zi_grid, Real *w3);
+                               Real *wthl_sec, Real *isotropy, Real *brunt,
+                               Real *thetal, Real *tke, Real *wthv_sec,
+                               Real *dz_zt, Real *dz_zi, Real *zt_grid,
+                               Real *zi_grid, Real *w3);
 
 void compute_diag_third_shoc_moment_c(Int shcol, Int nlev, Int nlevi, Real *w_sec,
                                       Real *thl_sec, Real *qw_sec, Real *qwthl_sec,
-				      Real *wthl_sec, Real *tke, Real *dz_zt, 
-				      Real *dz_zi, Real *zt_grid, Real *zi_grid,
-				      Real *isotropy_zi, Real *brunt_zi, Real *w_sec_zi,
-				      Real *thetal_zi, Real *wthv_sec_zi, 
-				      Real *w3);
+                                      Real *wthl_sec, Real *tke, Real *dz_zt, 
+                                      Real *dz_zi, Real *zt_grid, Real *zi_grid,
+                                      Real *isotropy_zi, Real *brunt_zi, 
+                                      Real *w_sec_zi, Real *thetal_zi, 
+                                      Real *wthv_sec_zi, Real *w3);
 
 void linear_interp_c(Real *x1, Real *x2, Real *y1, Real *y2, Int km1,
                      Int km2, Int ncol, Real minthresh);
@@ -344,8 +344,9 @@ void diag_third_shoc_moments(SHOCDiagThirdMomData &d) {
   shoc_init(d.nlev(), true);
   d.transpose<ekat::util::TransposeDirection::c2f>();
   diag_third_shoc_moments_c(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,d.qw_sec,
-                            d.qwthl_sec,d.wthl_sec,d.isotropy,d.brunt,d.thetal,d.tke,
-			    d.wthv_sec,d.dz_zt,d.dz_zi,d.zt_grid,d.zi_grid,d.w3);
+                            d.qwthl_sec,d.wthl_sec,d.isotropy,d.brunt,d.thetal,
+			    d.tke,d.wthv_sec,d.dz_zt,d.dz_zi,d.zt_grid,d.zi_grid,
+                            d.w3);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 
@@ -354,9 +355,9 @@ void compute_diag_third_shoc_moment(SHOCCompThirdMomData &d) {
   d.transpose<ekat::util::TransposeDirection::c2f>();
   compute_diag_third_shoc_moment_c(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,
                                    d.qw_sec,d.qwthl_sec,d.wthl_sec,d.tke,d.dz_zt,
-				   d.dz_zi,d.zt_grid,d.zi_grid,d.isotropy_zi,
-				   d.brunt_zi,d.w_sec_zi,d.thetal_zi,d.wthv_sec_zi,
-				   d.w3);
+                                   d.dz_zi,d.zt_grid,d.zi_grid,d.isotropy_zi,
+                                   d.brunt_zi,d.w_sec_zi,d.thetal_zi,d.wthv_sec_zi,
+                                   d.w3);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -342,8 +342,7 @@ struct SHOCCompThirdMomData : public PhysicsTestData {
   SHOCCompThirdMomData(Int shcol_, Int nlev_, Int nlevi_) :
     PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt, &zt_grid}, {&thl_sec, &wthl_sec, &qw_sec, &qwthl_sec, &zi_grid, &isotropy_zi, &dz_zi, &brunt_zi, &w_sec_zi, &thetal_zi, &wthv_sec_zi, &shoc_mix_zi}) {}
 
-  PTD_DATA_COPY_CTOR(SHOCCompThirdMomData, 3);
-  PTD_ASSIGN_OP(SHOCCompThirdMomData, 0);
+  SHOC_NO_SCALAR(SHOCCompThirdMomData, 3);
 };//SHOCCompThirdMomData
 
 //Create data structure to hold data for linear_interp

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -340,7 +340,7 @@ struct SHOCCompThirdMomData : public PhysicsTestData {
   Real *w3;
 
   SHOCCompThirdMomData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt, &zt_grid}, {&thl_sec, &wthl_sec, &qw_sec, &qwthl_sec, &zi_grid, &isotropy_zi, &dz_zi, &brunt_zi, &w_sec_zi, &thetal_zi, &wthv_sec_zi, &shoc_mix_zi}) {}
+    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt, &zt_grid}, {&thl_sec, &wthl_sec, &qw_sec, &qwthl_sec, &zi_grid, &isotropy_zi, &dz_zi, &brunt_zi, &w_sec_zi, &thetal_zi, &wthv_sec_zi, &shoc_mix_zi, &w3}) {}
 
   SHOC_NO_SCALAR(SHOCCompThirdMomData, 3);
 };//SHOCCompThirdMomData

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -329,18 +329,34 @@ struct SHOCSecondMomentSrfData : public PhysicsTestData {
   SHOC_NO_SCALAR(SHOCSecondMomentSrfData, 1);
 };
 
+//Create data structure to hold data for diag_third_shoc_moments
+struct SHOCDiagThirdMomData : public PhysicsTestData {
+  // Inputs
+  Real *w_sec, *thl_sec, *qw_sec, *qwthl_sec, *wthl_sec, *tke;
+  Real *dz_zt, *dz_zi, *zt_grid, *zi_grid, *isotropy, *brunt;
+  Real *thetal, *wthv_sec;
+
+  // Output
+  Real *w3;
+
+  SHOCDiagThirdMomData(Int shcol_, Int nlev_, Int nlevi_) :
+    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt, &zt_grid, &brunt, &thetal, &wthv_sec, &isotropy}, {&thl_sec, &wthl_sec, &qw_sec, &qwthl_sec, &zi_grid, &dz_zi, &w3}) {}
+
+  SHOC_NO_SCALAR(SHOCDiagThirdMomData, 3);
+};//SHOCDiagThirdMomData
+
 //Create data structure to hold data for compute_diag_third_shoc_moment
 struct SHOCCompThirdMomData : public PhysicsTestData {
   // Inputs
   Real *w_sec, *thl_sec, *qw_sec, *qwthl_sec, *wthl_sec, *tke, *dz_zt;
   Real *dz_zi, *zt_grid, *zi_grid, *isotropy_zi, *brunt_zi, *w_sec_zi;
-  Real *thetal_zi, *wthv_sec_zi, *shoc_mix_zi;
+  Real *thetal_zi, *wthv_sec_zi;
 
   // Output
   Real *w3;
 
   SHOCCompThirdMomData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt, &zt_grid}, {&thl_sec, &wthl_sec, &qw_sec, &qwthl_sec, &zi_grid, &isotropy_zi, &dz_zi, &brunt_zi, &w_sec_zi, &thetal_zi, &wthv_sec_zi, &shoc_mix_zi, &w3}) {}
+    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt, &zt_grid}, {&thl_sec, &wthl_sec, &qw_sec, &qwthl_sec, &zi_grid, &isotropy_zi, &dz_zi, &brunt_zi, &w_sec_zi, &thetal_zi, &wthv_sec_zi, &w3}) {}
 
   SHOC_NO_SCALAR(SHOCCompThirdMomData, 3);
 };//SHOCCompThirdMomData
@@ -520,6 +536,7 @@ void compute_conv_time_shoc_length                  (SHOCConvtimeData &d);
 void compute_shoc_mix_shoc_length                   (SHOCMixlengthData &d);
 void check_length_scale_shoc_length                 (SHOCMixcheckData &d);
 void shoc_diag_second_moments_srf                   (SHOCSecondMomentSrfData& d);
+void diag_third_shoc_moments                        (SHOCDiagThirdMomData &d);
 void compute_diag_third_shoc_moment                 (SHOCCompThirdMomData &d);
 void linear_interp                                  (SHOCLinearintData &d);
 void shoc_assumed_pdf_tilda_to_real                 (SHOCPDFtildaData &d);

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -337,6 +337,23 @@ struct SHOCSecondMomentSrfData : public PhysicsTestData {
   PTD_ASSIGN_OP(SHOCSecondMomentSrfData, 0);
 };
 
+//Create data structure to hold data for compute_diag_third_shoc_moment
+struct SHOCCompThirdMomData : public PhysicsTestData {
+  // Inputs
+  Real *w_sec, *thl_sec, *qw_sec, *qwthl_sec, *wthl_sec, *tke, *dz_zt;
+  Real *dz_zi, *zt_grid, *zi_grid, *isotropy_zi, *brunt_zi, *w_sec_zi;
+  Real *thetal_zi, *wthv_sec_zi, *shoc_mix_zi;
+
+  // Output
+  Real *w3;
+
+  SHOCCompThirdMomData(Int shcol_, Int nlev_, Int nlevi_) :
+    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt, &zt_grid}, {&thl_sec, &wthl_sec, &qw_sec, &qwthl_sec, &zi_grid, &isotropy_zi, &dz_zi, &brunt_zi, &w_sec_zi, &thetal_zi, &wthv_sec_zi, &shoc_mix_zi}) {}
+
+  PTD_DATA_COPY_CTOR(SHOCCompThirdMomData, 3);
+  PTD_ASSIGN_OP(SHOCCompThirdMomData, 0);
+};//SHOCCompThirdMomData
+
 //Create data structure to hold data for linear_interp
 struct SHOCLinearintData : public PhysicsTestData {
   // Inputs
@@ -514,6 +531,7 @@ void compute_conv_time_shoc_length                  (SHOCConvtimeData &d);
 void compute_shoc_mix_shoc_length                   (SHOCMixlengthData &d);
 void check_length_scale_shoc_length                 (SHOCMixcheckData &d);
 void shoc_diag_second_moments_srf                   (SHOCSecondMomentSrfData& d);
+void compute_diag_third_shoc_moment                 (SHOCCompThirdMomData &d);
 void linear_interp                                  (SHOCLinearintData &d);
 void shoc_assumed_pdf_tilda_to_real                 (SHOCPDFtildaData &d);
 void shoc_assumed_pdf_vv_parameters                 (SHOCPDFvvparamData &d);

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -510,9 +510,7 @@ contains
     call diag_third_shoc_moments(&
                      shcol, nlev, nlevi, w_sec, thl_sec, qw_sec, &
                      qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
-                     tke, wthv_sec, dz_zt, dz_zi, zt_grid, zi_grid, w3) 
-		     
-    write(*,*) 'w3_diag ', w3		         
+                     tke, wthv_sec, dz_zt, dz_zi, zt_grid, zi_grid, w3)
 			     
   end subroutine diag_third_shoc_moments_c
  
@@ -551,8 +549,6 @@ contains
                              dz_zi, zt_grid, zi_grid, isotropy_zi, &
                              brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
                              w3)
-			     
-    write(*,*) 'w3_comp ', w3
 
   end subroutine compute_diag_third_shoc_moment_c			     
  

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -516,6 +516,8 @@ contains
                              dz_zi, zt_grid, zi_grid, isotropy_zi, &
                              brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
                              shoc_mix_zi, w3)
+			     
+    write(*,*) 'w3 ', w3
 
   end subroutine compute_diag_third_shoc_moment_c
  

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -483,9 +483,9 @@ contains
   subroutine compute_diag_third_shoc_moment_c(&
                              shcol, nlev, nlevi, w_sec, thl_sec, &
                              qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
-		             dz_zi, zt_grid, zi_grid, isotropy_zi, &
-		             brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
-		             shoc_mix_zi, w3) bind(C)
+                             dz_zi, zt_grid, zi_grid, isotropy_zi, &
+                             brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
+                             shoc_mix_zi, w3) bind(C)
     use shoc, only: compute_diag_third_shoc_moment
 
     integer(kind=c_int), intent(in), value :: shcol
@@ -513,9 +513,9 @@ contains
     call compute_diag_third_shoc_moment(&
                              shcol, nlev, nlevi, w_sec, thl_sec, &
                              qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
-		             dz_zi, zt_grid, zi_grid, isotropy_zi, &
-		             brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
-		             shoc_mix_zi, w3)
+                             dz_zi, zt_grid, zi_grid, isotropy_zi, &
+                             brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
+                             shoc_mix_zi, w3)
 
   end subroutine compute_diag_third_shoc_moment_c
  

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -480,6 +480,45 @@ contains
    call diag_second_moments_srf(shcol, wthl, uw, vw, ustar2, wstar)
  end subroutine shoc_diag_second_moments_srf_c
  
+  subroutine compute_diag_third_shoc_moment_c(&
+                             shcol, nlev, nlevi, w_sec, thl_sec, &
+                             qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
+		             dz_zi, zt_grid, zi_grid, isotropy_zi, &
+		             brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
+		             shoc_mix_zi, w3) bind(C)
+    use shoc, only: compute_diag_third_shoc_moment
+
+    integer(kind=c_int), intent(in), value :: shcol
+    integer(kind=c_int), intent(in), value :: nlev
+    integer(kind=c_int), intent(in), value :: nlevi
+    real(kind=c_real), intent(in) :: w_sec(shcol,nlev)
+    real(kind=c_real), intent(in) :: thl_sec(shcol,nlevi)
+    real(kind=c_real), intent(in) :: qw_sec(shcol,nlevi)
+    real(kind=c_real), intent(in) :: qwthl_sec(shcol,nlevi)
+    real(kind=c_real), intent(in) :: wthl_sec(shcol,nlevi)
+    real(kind=c_real), intent(in) :: tke(shcol,nlev)
+    real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
+    real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
+    real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
+    real(kind=c_real), intent(in) :: isotropy_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: brunt_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: thetal_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: wthv_sec_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: shoc_mix_zi(shcol,nlevi)
+    
+    real(kind=c_real), intent(out) :: w3(shcol,nlevi)
+
+    call compute_diag_third_shoc_moment(&
+                             shcol, nlev, nlevi, w_sec, thl_sec, &
+                             qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
+		             dz_zi, zt_grid, zi_grid, isotropy_zi, &
+		             brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
+		             shoc_mix_zi, w3)
+
+  end subroutine compute_diag_third_shoc_moment_c
+ 
   subroutine linear_interp_c(x1,x2,y1,y2,km1,km2,ncol,minthresh) bind (C)
     use shoc, only: linear_interp
 

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -479,13 +479,49 @@ contains
 
    call diag_second_moments_srf(shcol, wthl, uw, vw, ustar2, wstar)
  end subroutine shoc_diag_second_moments_srf_c
+
+  subroutine diag_third_shoc_moments_c(&
+                             shcol, nlev, nlevi, w_sec, thl_sec, qw_sec, &
+			     qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
+			     tke, wthv_sec, dz_zt, dz_zi, &
+			     zt_grid, zi_grid, w3) bind(C)
+  use shoc, only: diag_third_shoc_moments
+  
+    integer(kind=c_int), intent(in), value :: shcol
+    integer(kind=c_int), intent(in), value :: nlev
+    integer(kind=c_int), intent(in), value :: nlevi
+    real(kind=c_real), intent(in) :: w_sec(shcol,nlev)
+    real(kind=c_real), intent(in) :: thl_sec(shcol,nlevi)
+    real(kind=c_real), intent(in) :: qw_sec(shcol,nlevi)
+    real(kind=c_real), intent(in) :: qwthl_sec(shcol,nlevi)
+    real(kind=c_real), intent(in) :: wthl_sec(shcol,nlevi)
+    real(kind=c_real), intent(in) :: isotropy(shcol,nlev)
+    real(kind=c_real), intent(in) :: brunt(shcol,nlev)
+    real(kind=c_real), intent(in) :: thetal(shcol,nlev)
+    real(kind=c_real), intent(in) :: tke(shcol,nlev)
+    real(kind=c_real), intent(in) :: wthv_sec(shcol,nlev)
+    real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
+    real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
+    real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
+    
+    real(kind=c_real), intent(out) :: w3(shcol,nlevi)
+    
+    call diag_third_shoc_moments(&
+                     shcol, nlev, nlevi, w_sec, thl_sec, qw_sec, &
+                     qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
+                     tke, wthv_sec, dz_zt, dz_zi, zt_grid, zi_grid, w3) 
+		     
+    write(*,*) 'w3_diag ', w3		         
+			     
+  end subroutine diag_third_shoc_moments_c
  
   subroutine compute_diag_third_shoc_moment_c(&
                              shcol, nlev, nlevi, w_sec, thl_sec, &
                              qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
                              dz_zi, zt_grid, zi_grid, isotropy_zi, &
                              brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
-                             shoc_mix_zi, w3) bind(C)
+                             w3) bind(C)
     use shoc, only: compute_diag_third_shoc_moment
 
     integer(kind=c_int), intent(in), value :: shcol
@@ -506,7 +542,6 @@ contains
     real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: thetal_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: wthv_sec_zi(shcol,nlevi)
-    real(kind=c_real), intent(in) :: shoc_mix_zi(shcol,nlevi)
     
     real(kind=c_real), intent(out) :: w3(shcol,nlevi)
 
@@ -515,42 +550,11 @@ contains
                              qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
                              dz_zi, zt_grid, zi_grid, isotropy_zi, &
                              brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
-                             shoc_mix_zi, w3)
+                             w3)
 			     
-    write(*,*) 'w3 ', w3
+    write(*,*) 'w3_comp ', w3
 
-  end subroutine compute_diag_third_shoc_moment_c
-  
-  subroutine diag_third_shoc_moments_c(&
-                             shcol, nlev, nlevi, w_sec, thl_sec, qw_sec, &
-			     qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
-			     tke, wthv_sec, shoc_mix, dz_zt, dz_zi, &
-			     zt_grid, zi_grid, w3) bind(C)
-  use shoc, only: diag_third_shoc_moments
-  
-    integer(kind=c_int), intent(in), value :: shcol
-    integer(kind=c_int), intent(in), value :: nlev
-    integer(kind=c_int), intent(in), value :: nlevi
-    real(kind=c_real), intent(in) :: w_sec(shcol,nlev)
-    real(kind=c_real), intent(in) :: thl_sec(shcol,nlevi)
-    real(kind=c_real), intent(in) :: isotropy(shcol,nlev)
-    real(kind=c_real), intent(in) :: brunt(shcol,nlev)
-    real(kind=c_real), intent(in) :: thetal(shcol,nlev)
-    real(kind=c_real), intent(in) :: tke(shcol,nlev)
-    real(kind=c_real), intent(in) :: wthv_sec(shcol,nlev)
-    real(kind=c_real), intent(in) :: shoc_mix(shcol,nlev)
-    real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
-    real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
-    real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
-    real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
-    
-    call diag_third_shoc_moments_c(&
-                     shcol, nlev, nlevi, w_sec, thl_sec, qw_sec, &
-                     qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
-                     tke, wthv_sec, shoc_mix, dz_zt, dz_zi, &
-                     zt_grid, zi_grid, w3)     
-			     
-  end subroutine diag_third_shoc_moments_c			     
+  end subroutine compute_diag_third_shoc_moment_c			     
  
   subroutine linear_interp_c(x1,x2,y1,y2,km1,km2,ncol,minthresh) bind (C)
     use shoc, only: linear_interp

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -520,6 +520,37 @@ contains
     write(*,*) 'w3 ', w3
 
   end subroutine compute_diag_third_shoc_moment_c
+  
+  subroutine diag_third_shoc_moments_c(&
+                             shcol, nlev, nlevi, w_sec, thl_sec, qw_sec, &
+			     qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
+			     tke, wthv_sec, shoc_mix, dz_zt, dz_zi, &
+			     zt_grid, zi_grid, w3) bind(C)
+  use shoc, only: diag_third_shoc_moments
+  
+    integer(kind=c_int), intent(in), value :: shcol
+    integer(kind=c_int), intent(in), value :: nlev
+    integer(kind=c_int), intent(in), value :: nlevi
+    real(kind=c_real), intent(in) :: w_sec(shcol,nlev)
+    real(kind=c_real), intent(in) :: thl_sec(shcol,nlevi)
+    real(kind=c_real), intent(in) :: isotropy(shcol,nlev)
+    real(kind=c_real), intent(in) :: brunt(shcol,nlev)
+    real(kind=c_real), intent(in) :: thetal(shcol,nlev)
+    real(kind=c_real), intent(in) :: tke(shcol,nlev)
+    real(kind=c_real), intent(in) :: wthv_sec(shcol,nlev)
+    real(kind=c_real), intent(in) :: shoc_mix(shcol,nlev)
+    real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
+    real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
+    real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
+    
+    call diag_third_shoc_moments_c(&
+                     shcol, nlev, nlevi, w_sec, thl_sec, qw_sec, &
+                     qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
+                     tke, wthv_sec, shoc_mix, dz_zt, dz_zi, &
+                     zt_grid, zi_grid, w3)     
+			     
+  end subroutine diag_third_shoc_moments_c			     
  
   subroutine linear_interp_c(x1,x2,y1,y2,km1,km2,ncol,minthresh) bind (C)
     use shoc, only: linear_interp

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -482,9 +482,9 @@ contains
 
   subroutine diag_third_shoc_moments_c(&
                              shcol, nlev, nlevi, w_sec, thl_sec, qw_sec, &
-			     qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
-			     tke, wthv_sec, dz_zt, dz_zi, &
-			     zt_grid, zi_grid, w3) bind(C)
+                             qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
+                             tke, wthv_sec, dz_zt, dz_zi, &
+                             zt_grid, zi_grid, w3) bind(C)
   use shoc, only: diag_third_shoc_moments
   
     integer(kind=c_int), intent(in), value :: shcol

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SHOC_TESTS_SRCS
     shoc_tke_adv_sgs_tke_tests.cpp
     shoc_eddy_diffusivities_tests.cpp
     shoc_diag_second_mom_srf_test.cpp
+    shoc_compute_diag_third_tests.cpp
     shoc_linearinterp_tests.cpp
     shoc_pdf_tildatoreal_tests.cpp
     shoc_pdf_vv_parameters_tests.cpp

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SHOC_TESTS_SRCS
     shoc_tke_adv_sgs_tke_tests.cpp
     shoc_eddy_diffusivities_tests.cpp
     shoc_diag_second_mom_srf_test.cpp
+    shoc_diag_third_tests.cpp
     shoc_compute_diag_third_tests.cpp
     shoc_linearinterp_tests.cpp
     shoc_pdf_tildatoreal_tests.cpp

--- a/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
@@ -140,21 +140,21 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
         const auto offset = n + s * nlev;
 	
         REQUIRE(SDS.w_sec[offset] >= 0);
-	REQUIRE(SDS.dz_zt[offset] > 0);
-	REQUIRE(SDS.zt_grid[offset] > 0);
-	REQUIRE(SDS.tke[offset] > 0);  
+        REQUIRE(SDS.dz_zt[offset] > 0);
+        REQUIRE(SDS.zt_grid[offset] > 0);
+        REQUIRE(SDS.tke[offset] > 0);  
       }
       
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
 	
-	REQUIRE(SDS.dz_zi[offset] >= 0);
-	REQUIRE(SDS.zi_grid[offset] >= 0);
-	REQUIRE(SDS.thl_sec[offset] >= 0);
-	REQUIRE(SDS.qw_sec[offset] >= 0);
-	REQUIRE(SDS.w_sec_zi[offset] >= 0);
-	REQUIRE(SDS.isotropy_zi[offset] >= 0);
-	REQUIRE(SDS.thetal_zi[offset] >= 0);
+        REQUIRE(SDS.dz_zi[offset] >= 0);
+        REQUIRE(SDS.zi_grid[offset] >= 0);
+        REQUIRE(SDS.thl_sec[offset] >= 0);
+        REQUIRE(SDS.qw_sec[offset] >= 0);
+        REQUIRE(SDS.w_sec_zi[offset] >= 0);
+        REQUIRE(SDS.isotropy_zi[offset] >= 0);
+        REQUIRE(SDS.thetal_zi[offset] >= 0);
 	
       }    
       
@@ -178,10 +178,10 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
 	
 	// Given this profile, values should fall within
 	//  reasonable bounds
-	REQUIRE(abs(SDS.w3[offset]) < 10);
+        REQUIRE(abs(SDS.w3[offset]) < 10);
 	
 	if (n == 0 || n == nlevi-1){
-	  REQUIRE(SDS.w3[n] == 0);
+          REQUIRE(SDS.w3[n] == 0);
 	}
 	
 	if (SDS.w3[offset] > 0){
@@ -191,7 +191,7 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
 	// Verify points increase in magnitude as 
 	//  scalar variances increase
 	if (s < shcol-1 && n != 0 && n != nlevi-1){ 
-	  REQUIRE(std::abs(SDS.w3[offsets]) > std::abs(SDS.w3[offset]));
+          REQUIRE(std::abs(SDS.w3[offsets]) > std::abs(SDS.w3[offset]));
 	}
 	    
       }

--- a/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
@@ -184,13 +184,13 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
           REQUIRE(SDS.w3[n] == 0);
         }
 	
-	       if (SDS.w3[offset] > 0){
-	         is_skew = true;
-	       }
+        if (SDS.w3[offset] > 0){
+          is_skew = true;
+        }
 	
-	       // Verify points increase in magnitude as 
-	       //  scalar variances increase
-	       if (s < shcol-1 && n != 0 && n != nlevi-1){ 
+        // Verify points increase in magnitude as 
+        //  scalar variances increase
+        if (s < shcol-1 && n != 0 && n != nlevi-1){ 
           REQUIRE(std::abs(SDS.w3[offsets]) > std::abs(SDS.w3[offset]));
         }
 	    

--- a/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
@@ -31,6 +31,8 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
     // Tests for the SHOC function:
     //   compute_diag_third_shoc_moment
     
+    // Mid-level function for w3
+    
     // convective boundary layer test
     //  Feed in profiles that are representative of a convective boundary
     //  layer and verify that results are as expected i.e. boundary points

--- a/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
@@ -1,0 +1,184 @@
+#include "catch2/catch.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
+
+  static void run_property()
+  {
+    static constexpr Int shcol    = 1;
+    static constexpr Int nlev     = 5;
+    static constexpr Int nlevi    = nlev+1;
+
+    // Tests for the SHOC function:
+    //   compute_diag_third_shoc_moment
+
+    // Define vertical velocity second moment [m2/s2]
+    static constexpr Real w_sec_zi[nlevi] = {0.2, 0.3, 0.5, 0.4, 0.3, 0.1};
+    // Define potential temperature second moment [K2]
+    static constexpr Real thl_sec[nlevi] = {0.5, 0.9, 1.2, 0.8, 0.4, 0.3};
+    // Define second moment total water second moment [kg^2/kg^2]
+    static constexpr Real qw_sec[nlevi] = {0.1e-6, 0.3e-6, 1.4e-6, 0.5e-6, 0.4e-6};
+    // Define covarance of thetal and qw [K kg/kg]
+    static constexpr Real qwthl_sec[nlevi] = {1e-3, 3e-3, 1.4e-3, 5e-3, 4e-3};
+    // Define vertical flux of temperature [K m/s]
+    static constexpr Real wthl_sec[nlevi] = {0.003, -0.03, -0.04, -0.01, 0.01, 0.03};
+    // Define the heights on the zi grid [m]
+//    static constexpr Real zi_grid[nlevi] = {9000, 5000, 1500, 900, 500, 0};
+    static constexpr Real zi_grid[nlevi] = {900, 500, 150, 90, 50, 0};
+    // Define the return to isotropy timescale [s]
+    static constexpr Real isotropy_zi[nlevi] = {2000, 3000, 5000, 2000, 1000, 500};
+    // Define the brunt vaisalla frequency
+    static constexpr Real brunt_zi[nlevi] = {4e-5, 3e-5, 2e-5, 2e-5, -1e-5};
+    // Define the potential temperature on zi grid [K]
+    static constexpr Real thetal_zi[nlevi] = {330, 325, 320, 310, 300, 301};
+    // Define the buoyancy flux on zi grid [K m/s]
+    static constexpr Real wthv_sec_zi[nlevi] = {0.002, 0.03, 0.04, 0.01, 0.02, 0.04};
+    // Define the length scale on the zi grid [m]
+    static constexpr Real shoc_mix_zi[nlevi] = {600, 750, 1500, 1200, 750, 20};
+    
+    // Define TKE [m2/s2], compute from w_sec
+    Real tke[nlev];
+
+    // Grid stuff to compute based on zi_grid
+    Real zt_grid[nlev];
+    Real dz_zt[nlev];
+    Real dz_zi[nlevi];
+    Real w_sec[nlev];
+    // Compute heights on midpoint grid
+    for(Int n = 0; n < nlev; ++n) {
+      zt_grid[n] = 0.5*(zi_grid[n]+zi_grid[n+1]);
+      w_sec[n] = 0.5*(w_sec_zi[n]+w_sec_zi[n+1]);
+      tke[n] = 1.5*w_sec[n];
+      dz_zt[n] = zi_grid[n] - zi_grid[n+1];
+      if (n == 0){
+        dz_zi[n] = 0;
+      }
+      else{
+        dz_zi[n] = zt_grid[n-1] - zt_grid[n];
+      }
+    }
+    // set upper condition for dz_zi
+    dz_zi[nlevi-1] = zt_grid[nlev-1];
+
+    // Initialize data structure for bridging to F90
+    SHOCCompThirdMomData SDS(shcol, nlev, nlevi);
+
+    // Test that the inputs are reasonable.
+    // For this test shcol MUST be at least 2
+    REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev && SDS.nlevi() == nlevi) );
+    REQUIRE(SDS.nlevi() == SDS.nlev()+1);
+    
+    // Load up the new data
+    for(Int s = 0; s < shcol; ++s) { 
+      // Fill in test data on zt_grid.     
+      for(Int n = 0; n < nlev; ++n) {
+        const auto offset = n + s * nlev;
+	
+	SDS.w_sec[offset] = w_sec[n];
+	SDS.dz_zt[offset] = dz_zt[n];
+	SDS.zt_grid[offset] = zt_grid[n];
+	SDS.tke[offset] = tke[n];
+	
+      }
+
+      // Fill in test data on zi_grid.     
+      for(Int n = 0; n < nlevi; ++n) {
+        const auto offset = n + s * nlevi;
+	
+	SDS.dz_zi[offset] = dz_zi[n];
+	SDS.zi_grid[offset] = zi_grid[n];
+	SDS.thl_sec[offset] = thl_sec[n];
+	SDS.qw_sec[offset] = qw_sec[n];
+	SDS.qwthl_sec[offset] = qwthl_sec[n];
+	SDS.wthl_sec[offset] = wthl_sec[n];
+	
+	SDS.w_sec_zi[offset] = w_sec_zi[n];
+	SDS.isotropy_zi[offset] = isotropy_zi[n];
+	SDS.brunt_zi[offset] = brunt_zi[n];
+	SDS.thetal_zi[offset] = thetal_zi[n];
+	SDS.wthv_sec_zi[offset] = wthv_sec_zi[n];
+	SDS.shoc_mix_zi[offset] = shoc_mix_zi[n];
+	
+      }
+    }      
+
+    // Check that the inputs make sense
+    // Load up the new data
+    for(Int s = 0; s < shcol; ++s) { 
+      // Fill in test data on zt_grid.    
+      for(Int n = 0; n < nlev; ++n) {
+        const auto offset = n + s * nlev;
+	
+        REQUIRE(SDS.w_sec[offset] >= 0);
+	REQUIRE(SDS.dz_zt[offset] > 0);
+	REQUIRE(SDS.zt_grid[offset] > 0);
+//	REQUIRE(SDS.tke[offset] > 0);  
+      }
+      
+      for(Int n = 0; n < nlevi; ++n) {
+        const auto offset = n + s * nlevi;
+	
+	REQUIRE(SDS.dz_zi[offset] >= 0);
+	REQUIRE(SDS.zi_grid[offset] >= 0);
+	REQUIRE(SDS.thl_sec[offset] >= 0);
+	REQUIRE(SDS.qw_sec[offset] >= 0);
+	REQUIRE(SDS.w_sec_zi[offset] >= 0);
+	REQUIRE(SDS.isotropy_zi[offset] >= 0);
+	REQUIRE(SDS.thetal_zi[offset] >= 0);
+	REQUIRE(SDS.shoc_mix_zi[offset] >= 0);
+	
+      }    
+      
+    }
+
+    // Call the fortran implementation
+    compute_diag_third_shoc_moment(SDS);
+
+  }
+
+  static void run_bfb()
+  {
+    // TODO
+  }
+};
+
+}  // namespace unit_test
+}  // namespace shoc
+}  // namespace scream
+
+namespace {
+
+TEST_CASE("shoc_comp_diag_third_property", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocCompDiagThird;
+
+  TestStruct::run_property();
+}
+
+TEST_CASE("shoc_comp_diag_third_bfb", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocCompDiagThird;
+
+  TestStruct::run_bfb();
+}
+
+} // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
@@ -105,10 +105,10 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
       for(Int n = 0; n < nlev; ++n) {
         const auto offset = n + s * nlev;
 	
-	SDS.w_sec[offset] = w_sec[n];
-	SDS.dz_zt[offset] = dz_zt[n];
-	SDS.zt_grid[offset] = zt_grid[n];
-	SDS.tke[offset] = tke[n];
+        SDS.w_sec[offset] = w_sec[n];
+        SDS.dz_zt[offset] = dz_zt[n];
+        SDS.zt_grid[offset] = zt_grid[n];
+        SDS.tke[offset] = tke[n];
 	
       }
 
@@ -116,18 +116,18 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
 	
-	SDS.dz_zi[offset] = dz_zi[n];
-	SDS.zi_grid[offset] = zi_grid[n];
-	SDS.thl_sec[offset] = (s+1)*thl_sec[n];
-	SDS.qw_sec[offset] = (s+1)*qw_sec[n];
-	SDS.qwthl_sec[offset] = qwthl_sec[n];
-	SDS.wthl_sec[offset] = wthl_sec[n];
+        SDS.dz_zi[offset] = dz_zi[n];
+        SDS.zi_grid[offset] = zi_grid[n];
+        SDS.thl_sec[offset] = (s+1)*thl_sec[n];
+        SDS.qw_sec[offset] = (s+1)*qw_sec[n];
+        SDS.qwthl_sec[offset] = qwthl_sec[n];
+        SDS.wthl_sec[offset] = wthl_sec[n];
 	
-	SDS.w_sec_zi[offset] = w_sec_zi[n];
-	SDS.isotropy_zi[offset] = isotropy_zi[n];
-	SDS.brunt_zi[offset] = brunt_zi[n];
-	SDS.thetal_zi[offset] = thetal_zi[n];
-	SDS.wthv_sec_zi[offset] = wthv_sec_zi[n];
+        SDS.w_sec_zi[offset] = w_sec_zi[n];
+        SDS.isotropy_zi[offset] = isotropy_zi[n];
+        SDS.brunt_zi[offset] = brunt_zi[n];
+        SDS.thetal_zi[offset] = thetal_zi[n];
+        SDS.wthv_sec_zi[offset] = wthv_sec_zi[n];
 	
       }
     }      
@@ -173,26 +173,26 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
       is_skew = false; // Initialize
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
-	//offset for "neighboring" column
-	const auto offsets = n + (s+1) * nlevi;
+        //offset for "neighboring" column
+        const auto offsets = n + (s+1) * nlevi;
 	
-	// Given this profile, values should fall within
-	//  reasonable bounds
+        // Given this profile, values should fall within
+        //  reasonable bounds
         REQUIRE(abs(SDS.w3[offset]) < 10);
 	
-	if (n == 0 || n == nlevi-1){
+        if (n == 0 || n == nlevi-1){
           REQUIRE(SDS.w3[n] == 0);
-	}
+        }
 	
-	if (SDS.w3[offset] > 0){
-	  is_skew = true;
-	}
+	       if (SDS.w3[offset] > 0){
+	         is_skew = true;
+	       }
 	
-	// Verify points increase in magnitude as 
-	//  scalar variances increase
-	if (s < shcol-1 && n != 0 && n != nlevi-1){ 
+	       // Verify points increase in magnitude as 
+	       //  scalar variances increase
+	       if (s < shcol-1 && n != 0 && n != nlevi-1){ 
           REQUIRE(std::abs(SDS.w3[offsets]) > std::abs(SDS.w3[offset]));
-	}
+        }
 	    
       }
       // Verify each column has at least one positive vertical

--- a/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
@@ -20,31 +20,19 @@ namespace shoc {
 namespace unit_test {
 
 template <typename D>
-struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
+struct UnitWrap::UnitTest<D>::TestShocDiagThird {
 
   static void run_property()
   {
-    static constexpr Int shcol    = 2;
+    static constexpr Int shcol    = 1;
     static constexpr Int nlev     = 5;
     static constexpr Int nlevi    = nlev+1;
 
     // Tests for the SHOC function:
-    //   compute_diag_third_shoc_moment
-    
-    // convective boundary layer test
-    //  Feed in profiles that are representative of a convective boundary
-    //  layer and verify that results are as expected i.e. boundary points
-    //  are good and there is at least one point that has a positive w3 value.
-    //  In addition, the profiles being fed in below are completely reasonable
-    //  so will also verify that w3 falls within some reasonable bounds.
-    
-    // IN ADDITION will feed subsequent columns values with increasing
-    //  scalar fluxes.  The w3 term is proportional to these, thus we need to 
-    //  verify that as the scalar fluxes increase that the absolute value of
-    //  w3 increases, given all other inputs are the same.
+    //   diag_third_shoc_moments
 
     // Define vertical velocity second moment [m2/s2]
-    static constexpr Real w_sec_zi[nlevi] = {0.2, 0.3, 0.5, 0.4, 0.3, 0.1};
+    static constexpr Real w_sec[nlev] = {0.2, 0.3, 0.5, 0.3, 0.1};
     // Define potential temperature second moment [K2]
     static constexpr Real thl_sec[nlevi] = {0.5, 0.9, 1.2, 0.8, 0.4, 0.3};
     // Define second moment total water second moment [kg^2/kg^2]
@@ -56,13 +44,13 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
     // Define the heights on the zi grid [m]
     static constexpr Real zi_grid[nlevi] = {9000, 5000, 1500, 900, 500, 0};
     // Define the return to isotropy timescale [s]
-    static constexpr Real isotropy_zi[nlevi] = {2000, 3000, 5000, 2000, 1000, 500};
+    static constexpr Real isotropy[nlev] = {1000, 2000, 4000, 1000, 500};
     // Define the brunt vaisalla frequency
-    static constexpr Real brunt_zi[nlevi] = {4e-5, 3e-5, 3e-5, 2e-5, 2e-5, -1e-5};
+    static constexpr Real brunt[nlev] = {4e-5, 3e-5, 2e-5, 2e-5, -1e-5};
     // Define the potential temperature on zi grid [K]
-    static constexpr Real thetal_zi[nlevi] = {330, 325, 320, 310, 300, 301};
+    static constexpr Real thetal[nlev] = {330, 320, 310, 300, 305};
     // Define the buoyancy flux on zi grid [K m/s]
-    static constexpr Real wthv_sec_zi[nlevi] = {0.002, 0.03, 0.04, 0.01, 0.02, 0.04};
+    static constexpr Real wthv_sec[nlev] = {0.002, 0.03, 0.04, 0.02, 0.04};
     
     // Define TKE [m2/s2], compute from w_sec
     Real tke[nlev];
@@ -71,11 +59,9 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
     Real zt_grid[nlev];
     Real dz_zt[nlev];
     Real dz_zi[nlevi];
-    Real w_sec[nlev];
     // Compute heights on midpoint grid
     for(Int n = 0; n < nlev; ++n) {
       zt_grid[n] = 0.5*(zi_grid[n]+zi_grid[n+1]);
-      w_sec[n] = 0.5*(w_sec_zi[n]+w_sec_zi[n+1]);
       tke[n] = 1.5*w_sec[n];
       dz_zt[n] = zi_grid[n] - zi_grid[n+1];
       if (n == 0){
@@ -89,13 +75,12 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
     dz_zi[nlevi-1] = zt_grid[nlev-1];
 
     // Initialize data structure for bridging to F90
-    SHOCCompThirdMomData SDS(shcol, nlev, nlevi);
+    SHOCDiagThirdMomData SDS(shcol, nlev, nlevi);
 
     // Test that the inputs are reasonable.
     // For this test shcol MUST be at least 2
     REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev && SDS.nlevi() == nlevi) );
     REQUIRE(SDS.nlevi() == SDS.nlev()+1);
-    REQUIRE(shcol > 1);
     
     // Load up the new data
     for(Int s = 0; s < shcol; ++s) { 
@@ -116,16 +101,15 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
 	
 	SDS.dz_zi[offset] = dz_zi[n];
 	SDS.zi_grid[offset] = zi_grid[n];
-	SDS.thl_sec[offset] = (s+1)*thl_sec[n];
-	SDS.qw_sec[offset] = (s+1)*qw_sec[n];
+	SDS.thl_sec[offset] = thl_sec[n];
+	SDS.qw_sec[offset] = qw_sec[n];
 	SDS.qwthl_sec[offset] = qwthl_sec[n];
 	SDS.wthl_sec[offset] = wthl_sec[n];
 	
-	SDS.w_sec_zi[offset] = w_sec_zi[n];
-	SDS.isotropy_zi[offset] = isotropy_zi[n];
-	SDS.brunt_zi[offset] = brunt_zi[n];
-	SDS.thetal_zi[offset] = thetal_zi[n];
-	SDS.wthv_sec_zi[offset] = wthv_sec_zi[n];
+	SDS.isotropy[offset] = isotropy[n];
+	SDS.brunt[offset] = brunt[n];
+	SDS.thetal[offset] = thetal[n];
+	SDS.wthv_sec[offset] = wthv_sec[n];
 	
       }
     }      
@@ -150,53 +134,15 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
 	REQUIRE(SDS.zi_grid[offset] >= 0);
 	REQUIRE(SDS.thl_sec[offset] >= 0);
 	REQUIRE(SDS.qw_sec[offset] >= 0);
-	REQUIRE(SDS.w_sec_zi[offset] >= 0);
-	REQUIRE(SDS.isotropy_zi[offset] >= 0);
-	REQUIRE(SDS.thetal_zi[offset] >= 0);
+	REQUIRE(SDS.isotropy[offset] >= 0);
+	REQUIRE(SDS.thetal[offset] >= 0);
 	
       }    
       
     }
 
     // Call the fortran implementation
-    compute_diag_third_shoc_moment(SDS);
-    
-    // Check the result
-    
-    // Check to make sure there is at least one
-    //  positive w3 value for convective boundary layer
-    bool is_skew;
-    // Verify that boundary points are zero
-    for(Int s = 0; s < shcol; ++s) { 
-      is_skew = false; // Initialize
-      for(Int n = 0; n < nlevi; ++n) {
-        const auto offset = n + s * nlevi;
-	//offset for "neighboring" column
-	const auto offsets = n + (s+1) * nlevi;
-	
-	// Given this profile, values should fall within
-	//  reasonable bounds
-	REQUIRE(abs(SDS.w3[offset]) < 10);
-	
-	if (n == 0 || n == nlevi-1){
-	  REQUIRE(SDS.w3[n] == 0);
-	}
-	
-	if (SDS.w3[offset] > 0){
-	  is_skew = true;
-	}
-	
-	// Verify points increase in magnitude as 
-	//  scalar variances increase
-	if (s < shcol-1 && n != 0 && n != nlevi-1){ 
-	  REQUIRE(std::abs(SDS.w3[offsets]) > std::abs(SDS.w3[offset]));
-	}
-	    
-      }
-      // Verify each column has at least one positive vertical
-      //   velocity skewness value
-      REQUIRE(is_skew == true);
-    }    
+    diag_third_shoc_moments(SDS);
 
   }
 
@@ -212,16 +158,16 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
 
 namespace {
 
-TEST_CASE("shoc_comp_diag_third_property", "shoc")
+TEST_CASE("shoc_diag_third_property", "shoc")
 {
-  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocCompDiagThird;
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocDiagThird;
 
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_comp_diag_third_bfb", "shoc")
+TEST_CASE("shoc_diag_third_bfb", "shoc")
 {
-  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocCompDiagThird;
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocDiagThird;
 
   TestStruct::run_bfb();
 }

--- a/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
@@ -132,7 +132,7 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
         const auto offset = n + s * nlev;
 	
         REQUIRE(SDS.w_sec[offset] >= 0);
-	       // for this test make sure w_sec <= 1
+        // for this test make sure w_sec <= 1
         REQUIRE(SDS.w_sec[offset] <= 1);
 	
         REQUIRE(SDS.dz_zt[offset] > 0);
@@ -166,12 +166,12 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
 
-	       // For this test make sure w3 has been clipped.
-	       //  Given input w2, this should be less than 1
+        // For this test make sure w3 has been clipped.
+        //  Given input w2, this should be less than 1
         REQUIRE(abs(SDS.w3[offset]) < 1);
 	
         if (SDS.w3[offset] > 0){
-	         is_skew = true;
+          is_skew = true;
         }	
 	
       }
@@ -184,7 +184,7 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
 	
-	       w3_test1[offset] = SDS.w3[offset];
+        w3_test1[offset] = SDS.w3[offset];
       }
     }
     
@@ -209,7 +209,7 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
         const auto offset = n + s * nlevi;
         if (n != 0 && n != nlevi-1){
           REQUIRE(std::abs(SDS.w3[offset]) > std::abs(w3_test1[offset]));
-	       }
+        }
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
@@ -98,10 +98,10 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
       for(Int n = 0; n < nlev; ++n) {
         const auto offset = n + s * nlev;
 	
-	SDS.w_sec[offset] = w_sec[n];
-	SDS.dz_zt[offset] = dz_zt[n];
-	SDS.zt_grid[offset] = zt_grid[n];
-	SDS.tke[offset] = tke[n];
+        SDS.w_sec[offset] = w_sec[n];
+        SDS.dz_zt[offset] = dz_zt[n];
+        SDS.zt_grid[offset] = zt_grid[n];
+        SDS.tke[offset] = tke[n];
 	
         SDS.isotropy[offset] = isotropy[n];
         SDS.brunt[offset] = brunt[n];
@@ -114,12 +114,12 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
 	
-	SDS.dz_zi[offset] = dz_zi[n];
-	SDS.zi_grid[offset] = zi_grid[n];
-	SDS.thl_sec[offset] = thl_sec[n];
-	SDS.qw_sec[offset] = qw_sec[n];
-	SDS.qwthl_sec[offset] = qwthl_sec[n];
-	SDS.wthl_sec[offset] = wthl_sec[n];
+        SDS.dz_zi[offset] = dz_zi[n];
+        SDS.zi_grid[offset] = zi_grid[n];
+        SDS.thl_sec[offset] = thl_sec[n];
+        SDS.qw_sec[offset] = qw_sec[n];
+        SDS.qwthl_sec[offset] = qwthl_sec[n];
+        SDS.wthl_sec[offset] = wthl_sec[n];
 	
       }
     }      
@@ -132,7 +132,7 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
         const auto offset = n + s * nlev;
 	
         REQUIRE(SDS.w_sec[offset] >= 0);
-	// for this test make sure w_sec <= 1
+	       // for this test make sure w_sec <= 1
         REQUIRE(SDS.w_sec[offset] <= 1);
 	
         REQUIRE(SDS.dz_zt[offset] > 0);
@@ -166,13 +166,13 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
 
-	// For this test make sure w3 has been clipped.
-	//  Given input w2, this should be less than 1
+	       // For this test make sure w3 has been clipped.
+	       //  Given input w2, this should be less than 1
         REQUIRE(abs(SDS.w3[offset]) < 1);
 	
-	if (SDS.w3[offset] > 0){
-	  is_skew = true;
-	}	
+        if (SDS.w3[offset] > 0){
+	         is_skew = true;
+        }	
 	
       }
       REQUIRE(is_skew == true);
@@ -184,7 +184,7 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
 	
-	w3_test1[offset] = SDS.w3[offset];
+	       w3_test1[offset] = SDS.w3[offset];
       }
     }
     
@@ -193,9 +193,9 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
 	
-	SDS.w_sec[offset] = 10*w_sec[n];
-	// update new TKE value
-	SDS.tke[offset] = 1.5*SDS.w_sec[offset];
+        SDS.w_sec[offset] = 10*w_sec[n];
+        // update new TKE value
+        SDS.tke[offset] = 1.5*SDS.w_sec[offset];
       }
     }
     
@@ -207,9 +207,9 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
     for(Int s = 0; s < shcol; ++s) { 
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
-	if (n != 0 && n != nlevi-1){
+        if (n != 0 && n != nlevi-1){
           REQUIRE(std::abs(SDS.w3[offset]) > std::abs(w3_test1[offset]));
-	}
+	       }
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
@@ -133,11 +133,11 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
 	
         REQUIRE(SDS.w_sec[offset] >= 0);
 	// for this test make sure w_sec <= 1
-	REQUIRE(SDS.w_sec[offset] <= 1);
+        REQUIRE(SDS.w_sec[offset] <= 1);
 	
-	REQUIRE(SDS.dz_zt[offset] > 0);
-	REQUIRE(SDS.zt_grid[offset] > 0);
-	REQUIRE(SDS.tke[offset] > 0);
+        REQUIRE(SDS.dz_zt[offset] > 0);
+        REQUIRE(SDS.zt_grid[offset] > 0);
+        REQUIRE(SDS.tke[offset] > 0);
         REQUIRE(SDS.isotropy[offset] >= 0);
         REQUIRE(SDS.thetal[offset] >= 0);
       }
@@ -145,10 +145,10 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
 	
-	REQUIRE(SDS.dz_zi[offset] >= 0);
-	REQUIRE(SDS.zi_grid[offset] >= 0);
-	REQUIRE(SDS.thl_sec[offset] >= 0);
-	REQUIRE(SDS.qw_sec[offset] >= 0);
+        REQUIRE(SDS.dz_zi[offset] >= 0);
+        REQUIRE(SDS.zi_grid[offset] >= 0);
+        REQUIRE(SDS.thl_sec[offset] >= 0);
+        REQUIRE(SDS.qw_sec[offset] >= 0);
 	
       }    
       
@@ -168,7 +168,7 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
 
 	// For this test make sure w3 has been clipped.
 	//  Given input w2, this should be less than 1
-	REQUIRE(abs(SDS.w3[offset]) < 1);
+        REQUIRE(abs(SDS.w3[offset]) < 1);
 	
 	if (SDS.w3[offset] > 0){
 	  is_skew = true;

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -73,6 +73,7 @@ struct UnitWrap {
     struct TestCompShocMixLength;
     struct TestSecondMomSrf;
     struct TestShocCompDiagThird;
+    struct TestShocDiagThird;
     struct TestShocLinearInt;
     struct TestShocPdfTildatoReal;
     struct TestShocVVParameters;

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -72,6 +72,7 @@ struct UnitWrap {
     struct TestLInfShocLength;
     struct TestCompShocMixLength;
     struct TestSecondMomSrf;
+    struct TestShocCompDiagThird;
     struct TestShocLinearInt;
     struct TestShocPdfTildatoReal;
     struct TestShocVVParameters;


### PR DESCRIPTION
Adds property tests for mid level function compute_diag_third_shoc_moments and upper level function diag_third_shoc_moments.  

Note that it was discovered that variable "shoc_mix" was being fed into the third moment routines but was never used.  Thus, this PR also eliminates unnecessarily passing this variable.  