### PR TITLE
SHOC property tests for upper level energy checker function

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -3651,7 +3651,7 @@ subroutine shoc_energy_threshold_fixer(&
   real(rtype), intent(in) :: te_b(shcol)
 
 
-  ! INPUT VARIABLES
+  ! OUTPUT VARIABLES
   real(rtype), intent(out) :: se_dis(shcol)
   integer, intent(out) :: shoctop(shcol)
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -26,6 +26,13 @@ void shoc_grid_c(int shcol, int nlev, int nlevi, Real *zt_grid, Real *zi_grid,
 void update_host_dse_c(Int shcol, Int nlev, Real *thlm, Real *shoc_ql,
                        Real *exner, Real *zt_grid, Real *phis, Real *host_dse);
 
+void shoc_energy_fixer_c(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv,
+                         Real *zt_grid, Real *zi_grid, Real *se_b, Real *ke_b,
+                         Real *wv_b, Real *wl_b, Real *se_a, Real *ke_a, 
+                         Real *wv_a, Real *wl_a, Real *wthl_sfc, Real *wqw_sfc,
+                         Real *pdel, Real *rho_zt, Real *tke, Real *pint, 
+                         Real *host_dse);
+
 void shoc_energy_integrals_c(Int shcol, Int nlev, Real *host_dse, Real *pdel,
                              Real *rtm, Real *rcm, Real *u_wind, Real *v_wind,
                              Real *se_int, Real *ke_int, Real *wv_int, Real *wl_int);
@@ -219,6 +226,17 @@ void update_host_dse(SHOCEnergydseData &d) {
   d.transpose<ekat::util::TransposeDirection::c2f>();
   update_host_dse_c(d.shcol(), d.nlev(), d.thlm, d.shoc_ql, d.exner,
                     d.zt_grid, d.phis, d.host_dse);
+  d.transpose<ekat::util::TransposeDirection::f2c>();
+}
+
+void shoc_energy_fixer(SHOCEnergyfixerData &d){
+  shoc_init(d.nlev(), true);
+  d.transpose<ekat::util::TransposeDirection::c2f>();
+  shoc_energy_fixer_c(d.shcol(), d.nlev(), d.nlevi(), d.dtime, d.nadv,
+                      d.zt_grid, d.zi_grid, d.se_b, d.ke_b, d.wv_b,
+                      d.wl_b, d.se_a, d.ke_a, d.wv_a, d.wl_a, d.wthl_sfc,
+                      d.wqw_sfc, d.pdel, d.rho_zt, d.tke, d.pint,
+                      d.host_dse);
   d.transpose<ekat::util::TransposeDirection::f2c>();
 }
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -166,6 +166,25 @@ struct SHOCEnergydseData : public PhysicsTestData {
   SHOC_NO_SCALAR(SHOCEnergydseData, 2);
 };//SHOCEnergydseData
 
+//create data structure for shoc_energy_fixer
+struct SHOCEnergyfixerData : public PhysicsTestData {
+  // Inputs
+  Int nadv;
+  Real dtime;
+  Real *zt_grid, *zi_grid, *se_b, *wv_b, *pint;
+  Real *se_a, *ke_b, *wl_b, *ke_a, *tke, *pdel;
+  Real *wv_a, *wl_a, *wthl_sfc, *wqw_sfc, *rho_zt;
+
+  // Output
+  Real *host_dse;
+
+  //functions to initialize data
+  SHOCEnergyfixerData(Int shcol_, Int nlev_, Int nlevi_, Real dtime_, Real nadv_) :
+    PhysicsTestData(shcol_, nlev_, nlevi_, {&host_dse, &zt_grid, &pdel, &rho_zt, &tke}, {&zi_grid, &pint}, {&se_b, &ke_b, &wv_b, &wl_b, &se_a, &ke_a, &wv_a, &wl_a, &wthl_sfc, &wqw_sfc}), nadv(nadv_), dtime(dtime_) {}
+
+  SHOC_SCALARS(SHOCEnergyfixerData, 3, 2, dtime, nadv);
+};//SHOCEnergyfixerData
+
 //create data structure for shoc_energy_integrals
 struct SHOCEnergyintData : public PhysicsTestData {
   // Inputs
@@ -593,6 +612,7 @@ struct SHOCSecondMomentUbycondData : public PhysicsTestData {
 
 void shoc_grid                                      (SHOCGridData &d);
 void update_host_dse                                (SHOCEnergydseData &d);
+void shoc_energy_fixer                              (SHOCEnergyfixerData &d);
 void shoc_energy_integrals                          (SHOCEnergyintData &d);
 void shoc_energy_total_fixer                        (SHOCEnergytotData &d);
 void shoc_energy_threshold_fixer                    (SHOCEnergythreshfixerData &d);

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -331,6 +331,8 @@ contains
                            wl_b, se_a, ke_a, wv_a, wl_a, wthl_sfc, &
                            wqw_sfc, pdel, rho_zt, tke, pint, &
                            host_dse)
+                           
+    write(*,*) 'DSE ', host_dse                      
 				 
   end subroutine shoc_energy_fixer_c
 

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -331,9 +331,7 @@ contains
                            wl_b, se_a, ke_a, wv_a, wl_a, wthl_sfc, &
                            wqw_sfc, pdel, rho_zt, tke, pint, &
                            host_dse)
-                           
-    write(*,*) 'DSE ', host_dse                      
-				 
+
   end subroutine shoc_energy_fixer_c
 
   subroutine shoc_energy_integrals_c(shcol, nlev, host_dse, pdel,&

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -294,6 +294,45 @@ contains
                            phis, host_dse)
 
   end subroutine update_host_dse_c
+  
+  subroutine shoc_energy_fixer_c(shcol, nlev, nlevi, dtime, nadv, &
+                                 zt_grid, zi_grid, se_b, ke_b, wv_b, &
+                                 wl_b, se_a, ke_a, wv_a, wl_a, wthl_sfc, &
+                                 wqw_sfc, pdel, rho_zt, tke, pint, &
+                                 host_dse) bind (C)
+    use shoc, only: shoc_energy_fixer
+
+    integer(kind=c_int), intent(in), value :: shcol
+    integer(kind=c_int), intent(in), value :: nlev
+    integer(kind=c_int), intent(in), value :: nlevi
+    real(kind=c_real), intent(in), value :: dtime
+    integer(kind=c_int), intent(in), value :: nadv
+    real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
+    real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
+    real(kind=c_real), intent(in) :: se_b(shcol)
+    real(kind=c_real), intent(in) :: ke_b(shcol)
+    real(kind=c_real), intent(in) :: wv_b(shcol)
+    real(kind=c_real), intent(in) :: wl_b(shcol)
+    real(kind=c_real), intent(in) :: se_a(shcol)
+    real(kind=c_real), intent(in) :: ke_a(shcol)
+    real(kind=c_real), intent(in) :: wv_a(shcol)
+    real(kind=c_real), intent(in) :: wl_a(shcol)
+    real(kind=c_real), intent(in) :: wthl_sfc(shcol)
+    real(kind=c_real), intent(in) :: wqw_sfc(shcol)
+    real(kind=c_real), intent(in) :: pdel(shcol,nlev)
+    real(kind=c_real), intent(in) :: rho_zt(shcol,nlev)
+    real(kind=c_real), intent(in) :: tke(shcol,nlev)
+    real(kind=c_real), intent(in) :: pint(shcol,nlevi)
+    
+    real(kind=c_real), intent(inout) :: host_dse(shcol,nlev)
+    
+    call shoc_energy_fixer(shcol, nlev, nlevi, dtime, nadv, &
+                           zt_grid, zi_grid, se_b, ke_b, wv_b, &
+                           wl_b, se_a, ke_a, wv_a, wl_a, wthl_sfc, &
+                           wqw_sfc, pdel, rho_zt, tke, pint, &
+                           host_dse)
+				 
+  end subroutine shoc_energy_fixer_c
 
   subroutine shoc_energy_integrals_c(shcol, nlev, host_dse, pdel,&
                                      rtm, rcm, u_wind, v_wind,&

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SHOC_TESTS_SRCS
     shoc_grid_tests.cpp
     shoc_vertflux_tests.cpp
     shoc_varorcovar_tests.cpp
+    shoc_energy_fixer_tests.cpp
     shoc_energy_update_dse_tests.cpp
     shoc_energy_integral_tests.cpp
     shoc_energy_total_fixer_tests.cpp

--- a/components/scream/src/physics/shoc/tests/shoc_energy_dse_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_dse_fixer_tests.cpp
@@ -25,6 +25,8 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyDseFixer {
 
   static void run_property()
   {
+    static constexpr Real gravit  = scream::physics::Constants<Real>::gravit;
+    static constexpr Real Cpair   = scream::physics::Constants<Real>::Cpair;    
     static constexpr Int shcol    = 6;
     static constexpr Int nlev     = 5;
 
@@ -36,8 +38,8 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyDseFixer {
     //  verify that given a positive value of energy imbalance that
     //  columns with a higher SHOC top were subject to more energy removal.
 
-    // Host model dry static energy [K]
-    static constexpr Real host_dse_input[nlev] = {350.0, 325.0, 315.0, 310.0, 300.0};
+    // Host model dry static energy [J kg-1]
+    static constexpr Real host_dse_input[nlev] = {350e3, 325e3, 315e3, 310e3, 300e3};
 
     // Energy disbalance.  For this test we assume all columns have
     //  the same disbalance magnitude.

--- a/components/scream/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
@@ -5,6 +5,7 @@
 #include "physics/shoc/shoc_functions.hpp"
 #include "physics/shoc/shoc_functions_f90.hpp"
 #include "physics/share/physics_constants.hpp"
+#include "physics/shoc/shoc_constants.hpp"
 #include "share/scream_types.hpp"
 
 #include "ekat/ekat_pack.hpp"
@@ -27,27 +28,28 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
   {
     static constexpr Real gravit  = scream::physics::Constants<Real>::gravit;
     static constexpr Real Cpair   = scream::physics::Constants<Real>::Cpair;
+    static constexpr Real mintke  = scream::shoc::Constants<Real>::mintke;
     static constexpr Int shcol    = 3;
     static constexpr Int nlev     = 5;
     static constexpr auto nlevi   = nlev + 1;
 
     // Tests for the SHOC function
     //     shoc_energy_fixer
-    
+
     // TESTs ONE through THREE
-    // No energy change and surface flux test.  
+    // No energy change and surface flux test.
     //  In one column, given inputs where the energy has not changed
     //  from timestep to timestep, verify that the host model dry static
-    //  energy also has not changed. 
-    
-    // In second column, give positive surface fluxes, 
-    //  all other information being the same.  Verify that energy was added 
+    //  energy also has not changed.
+
+    // In second column, give positive surface fluxes,
+    //  all other information being the same.  Verify that energy was added
     //  in to the system and verify that energy was added into the system AND
     //  verify that energy was only adjust at the levels where TKE is greater
     //  than zero.
-    
-    // In third column, give negative surface fluxes and verify energy 
-    //  was removed from the system.  
+
+    // In third column, give negative surface fluxes and verify energy
+    //  was removed from the system.
 
     // Timestep [s]
     static constexpr Real dtime = 300;
@@ -60,7 +62,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
     // Host model temperture [K]
     static constexpr Real host_temp_input[nlev] = {250, 275, 285, 290, 300};
     // Define TKE inputs
-    static constexpr Real tke[nlev] = {0.0004, 0.0004, 0.3, 0.4, 0.1};
+    static constexpr Real tke[nlev] = {mintke, mintke, 0.3, 0.4, 0.1};
    //  Pressure at interface [Pa]
     static constexpr Real pint[nlevi] = {50000, 60000, 70000, 80000, 90000, 100000};
     // Define integrated static energy, kinetic energy, water vapor,
@@ -85,7 +87,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
     // Want exactly three columns for this case
     REQUIRE(shcol == 3);
     REQUIRE(nlevi == nlev+1);
-    
+
     // compute host model dry static energy
     for(Int n = 0; n < nlev; ++n) {
       zt_grid[n] = 0.5*(zi_grid[n]+zi_grid[n+1]);
@@ -119,7 +121,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
         SDS.tke[offset] = tke[n];
         SDS.host_dse[offset] = host_dse_input[n];
       }
-      
+
       // Fill in test data on zi_grid.
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
@@ -161,18 +163,18 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
     shoc_energy_fixer(SDS);
 
     // Check test
-    // Verify that the dry static energy has not changed if surface 
+    // Verify that the dry static energy has not changed if surface
     //  fluxes are zero, else verify host_dse has increased
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
         const auto offset = n + s * nlev;
-        
+
         // If TKE is at minimum threshold then make sure that
         //  host_dse has not been modified
-        if (SDS.tke[offset] == 0.0004){
+        if (SDS.tke[offset] == mintke){
           REQUIRE(SDS.host_dse[offset] == host_dse_input[n]);
-        }         
-        else{        
+        }
+        else{
           if (SDS.wthl_sfc[s] == 0){
             REQUIRE(SDS.wqw_sfc[s] == 0); // verify input
             REQUIRE(SDS.host_dse[offset] == host_dse_input[n]);
@@ -184,20 +186,20 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
           else {
             REQUIRE(SDS.wqw_sfc[s] > 0);
             REQUIRE(SDS.host_dse[offset] > host_dse_input[n]);
-          }  
+          }
         }
 
       }
     }
-    
+
     // TEST FOUR
     // Energy loss, gain test.
     // Now set surface fluxes to zero and set all *_a scalar arrays
     //  to be less/more than the *_b arrays.  This will signify that SHOC
     //  lost/gained energy during integration and thus host_dse should be
     //  INCREASED/DECREASED at all levels where TKE is sufficient
-        
-    // Define by how much each energy integral array will 
+
+    // Define by how much each energy integral array will
     //  be perturbed
     static constexpr Real se_gainloss = 2;
     static constexpr Real ke_gainloss = 1;
@@ -207,9 +209,9 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
     // For this test set to zero
     static constexpr Real wthl_sfc_gainloss = 0;
     static constexpr Real wqw_sfc_gainloss = 0;
-    
+
     // Load up the data
-    // This will alternate between a positive and negative 
+    // This will alternate between a positive and negative
     Real gainloss_fac[shcol];
     // Initialize value
     gainloss_fac[0] = 1;
@@ -222,18 +224,18 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
       SDS.se_a[s] = se+gainloss_fac[s]*se_gainloss;
       SDS.ke_a[s] = ke+gainloss_fac[s]*ke_gainloss;
       SDS.wv_a[s] = wv+gainloss_fac[s]*wv_gainloss;
-      SDS.wl_a[s] = wl+gainloss_fac[s]*wl_gainloss;      
-      
-      // Alternate between positive and negative loss, 
+      SDS.wl_a[s] = wl+gainloss_fac[s]*wl_gainloss;
+
+      // Alternate between positive and negative loss,
       //  change sign for next column
       if (s < shcol-1){
         gainloss_fac[s+1] = gainloss_fac[s]*-1;
       }
     }
-    
+
     // Call the fortran implementation
     shoc_energy_fixer(SDS);
-    
+
     // Verify the result
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
@@ -241,10 +243,10 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
 
         // If TKE is at minimum threshold then make sure that
         //  host_dse has not been modified
-        if (SDS.tke[offset] == 0.0004){     
+        if (SDS.tke[offset] == mintke){
           REQUIRE(SDS.host_dse[offset] == host_dse_input[n]);
-        }         
-        else{       
+        }
+        else{
           // If the system gained energy, make sure that host_dse
           //  has decreased to compensate for this
           if (gainloss_fac[s] > 0){
@@ -253,9 +255,9 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
           // Else, the vice versa of above
           else{
             REQUIRE(SDS.host_dse[offset] > host_dse_input[n]);
-          }    
+          }
         }
-        
+
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
@@ -173,8 +173,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
         
           REQUIRE(SDS.host_dse[offset] == host_dse_input[n]);
           
-        }
-          
+        }         
         else{
         
           if (SDS.wthl_sfc[s] == 0){
@@ -250,8 +249,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
         
           REQUIRE(SDS.host_dse[offset] == host_dse_input[n]);
           
-        } 
-        
+        }         
         else{
         
           // If the system gained energy, make sure that host_dse
@@ -264,7 +262,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
             REQUIRE(SDS.host_dse[offset] > host_dse_input[n]);
           }    
         }
-
+        
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
@@ -170,12 +170,9 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
         // If TKE is at minimum threshold then make sure that
         //  host_dse has not been modified
         if (SDS.tke[offset] == 0.0004){
-        
           REQUIRE(SDS.host_dse[offset] == host_dse_input[n]);
-          
         }         
-        else{
-        
+        else{        
           if (SDS.wthl_sfc[s] == 0){
             REQUIRE(SDS.wqw_sfc[s] == 0); // verify input
             REQUIRE(SDS.host_dse[offset] == host_dse_input[n]);
@@ -187,8 +184,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
           else {
             REQUIRE(SDS.wqw_sfc[s] > 0);
             REQUIRE(SDS.host_dse[offset] > host_dse_input[n]);
-          }
-        
+          }  
         }
 
       }
@@ -245,13 +241,10 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
 
         // If TKE is at minimum threshold then make sure that
         //  host_dse has not been modified
-        if (SDS.tke[offset] == 0.0004){
-        
+        if (SDS.tke[offset] == 0.0004){     
           REQUIRE(SDS.host_dse[offset] == host_dse_input[n]);
-          
         }         
-        else{
-        
+        else{       
           // If the system gained energy, make sure that host_dse
           //  has decreased to compensate for this
           if (gainloss_fac[s] > 0){

--- a/components/scream/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
@@ -40,8 +40,8 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
     //   or moisture result in zero integral outputs.  If the
     //   column is positive then verify that wl_int >= wv_int
 
-    // Define host model dry static energy [K]
-    static constexpr Real host_dse[nlev] = {350.0, 325.0, 315.0, 310.0, 300.0};
+    // Define host model dry static energy [J kg-1]
+    static constexpr Real host_dse[nlev] = {350e3, 325e3, 315e3, 310e3, 300e3};
     // Defin the pressure difference [hPa] (converted to Pa later)
     static constexpr Real pdel[nlev]={100.0, 75.0, 50.0, 25.0, 10.0};
     // Define zonal wind on nlev grid [m/s]

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -54,8 +54,9 @@ struct UnitWrap {
     // Put struct decls here
     struct TestCalcShocVertflux;
     struct TestShocUpdateDse;
-    struct TestShocEnergyInt;
     struct TestShocEnergyFixer;
+    struct TestShocEnergyInt;
+    struct TestShocTotEnergyFixer;
     struct TestShocEnergyDseFixer;
     struct TestShocEnergyThreshFixer;
     struct TestShocEddyDiff;


### PR DESCRIPTION
Adds property test for the upper level check energy function.  

In addition, this PR:
- Fixes issue where a couple property tests (shoc_energy_integral_tests.cpp and shoc_energy_dse_fixer_tests.cpp) did not have correct inputs (as uncovered through making this test).
- Corrects an inconsistent comment issue in shoc.F90
- Renames the unit test for shoc_energy_total_fixer_tests.cpp to be a bit more descriptive (because that name was more appropriately used for this upper level test).