### PR TITLE
Both Shoc and P3 now call Murphy Koop

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -56,6 +56,8 @@ module micro_p3
        lookup_table_1a_dum1_c, &
        p3_qc_autocon_expon, p3_qc_accret_expon
 
+   use wv_sat_scream, only:qv_sat
+
   ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
   use physics_share_f2c, only: cxx_pow, cxx_sqrt, cxx_cbrt, cxx_gamma, cxx_log, &
@@ -1514,180 +1516,6 @@ contains
     return
   END SUBROUTINE access_lookup_table_coll
 
-  !==========================================================================================!
-
-  real(rtype) function MurphyKoop_svp(t, i_type)
-
-    use scream_abortutils, only : endscreamrun
-
-    implicit none
-
-    !-------------------------------------------------------------------
-    ! Compute saturation vapor pressure (returned in units of pa)
-    ! Inputs:
-    ! "t", units [K]
-    !  i_type refers to saturation with respect to liquid (0) or ice (1)
-    !--------------------------------------------------------------------
-
-    !Murphy & Koop (2005)
-    real(rtype), intent(in) :: t
-    integer, intent(in)     :: i_type
-
-    !local vars
-    character(len=1000) :: err_msg
-    real(rtype)         :: logt, tmp
-
-    !parameters for ice saturation eqn
-    real(rtype), parameter :: ic(4)  =(/9.550426_rtype, 5723.265_rtype, 3.53068_rtype, &
-         0.00728332_rtype/)
-
-    !parameters for liq saturation eqn
-    real(rtype), parameter :: lq(10) = (/54.842763_rtype, 6763.22_rtype, 4.210_rtype, &
-         0.000367_rtype, 0.0415_rtype, 218.8_rtype, 53.878_rtype, 1331.22_rtype,       &
-         9.44523_rtype, 0.014025_rtype /)
-
-    logt = bfb_log(t)
-
-    if (i_type .eq. 1 .and. t .lt. zerodegc) then
-
-       !(good down to 110 K)
-       MurphyKoop_svp = bfb_exp(ic(1) - (ic(2) / t) + (ic(3) * logt) - (ic(4) * t))
-
-    elseif (i_type .eq. 0 .or. t .ge. zerodegc) then
-
-       ! (good for 123 < T < 332 K)
-       !For some reason, we cannot add line breaks if we use "bfb_exp", storing experssion in "tmp"
-       tmp = lq(1) - (lq(2) / t) - (lq(3) * logt) + (lq(4) * t) + &
-            (bfb_tanh(lq(5) * (t - lq(6))) * (lq(7) - (lq(8) / t) - &
-            (lq(9) * logt) + lq(10) * t))
-       MurphyKoop_svp = bfb_exp(tmp)
-    else
-
-       write(err_msg,*)'Error: Either MurphyKoop_svp i_type is not 0 or 1 or t=NaN. itype= ', &
-            i_type,' and temperature t=',t,' in file: ',__FILE__,' at line:',__LINE__
-       call endscreamrun(err_msg)
-    endif
-
-    return
-  end function MurphyKoop_svp
-
-  !_rtype
-  real(rtype) function polysvp1(t,i_type)
-
-    !-------------------------------------------
-    !  COMPUTE SATURATION VAPOR PRESSURE
-    !  POLYSVP1 RETURNED IN UNITS OF PA.
-    !  T IS INPUT IN UNITS OF K.
-    !  i_type REFERS TO SATURATION WITH RESPECT TO LIQUID (0) OR ICE (1)
-    !-------------------------------------------
-
-    use scream_abortutils, only : endscreamrun
-
-    use debug_info, only: report_error_info
-    implicit none
-
-    real(rtype), intent(in) :: t
-    integer, intent(in)     :: i_type
-
-    ! REPLACE GOFF-GRATCH WITH FASTER FORMULATION FROM FLATAU ET AL. 1992, TABLE 4 (RIGHT-HAND COLUMN)
-
-    !local variables
-    character(len=1000) :: err_msg
-
-    ! ice
-    real(rtype) a0i,a1i,a2i,a3i,a4i,a5i,a6i,a7i,a8i
-    data a0i,a1i,a2i,a3i,a4i,a5i,a6i,a7i,a8i /&
-         6.11147274_rtype,     0.503160820_rtype,     0.188439774e-1_rtype, &
-         0.420895665e-3_rtype, 0.615021634e-5_rtype,  0.602588177e-7_rtype, &
-         0.385852041e-9_rtype, 0.146898966e-11_rtype, 0.252751365e-14_rtype/
-
-    ! liquid
-    real(rtype) a0,a1,a2,a3,a4,a5,a6,a7,a8
-
-    ! V1.7
-    data a0,a1,a2,a3,a4,a5,a6,a7,a8 /&
-         6.11239921_rtype,      0.443987641_rtype,     0.142986287e-1_rtype, &
-         0.264847430e-3_rtype,  0.302950461e-5_rtype,  0.206739458e-7_rtype, &
-         0.640689451e-10_rtype,-0.952447341e-13_rtype,-0.976195544e-15_rtype/
-    real(rtype) dt
-
-    !-------------------------------------------
-
-    if (i_type.eq.1 .and. t.lt.zerodegc) then
-       ! ICE
-
-       !       Flatau formulation:
-       dt       = max(-80._rtype,t-273.15_rtype)
-       polysvp1 = a0i + dt*(a1i+dt*(a2i+dt*(a3i+dt*(a4i+dt*(a5i+dt*(a6i+dt*(a7i+       &
-            a8i*dt)))))))
-       polysvp1 = polysvp1*100._rtype
-
-       !       Goff-Gratch formulation:
-       !        POLYSVP1 = 10.**(-9.09718*(273.16/T-1.)-3.56654*                 &
-       !          log10(273.16/T)+0.876793*(1.-T/273.16)+                        &
-       !          log10(6.1071))*100.
-
-
-    elseif (i_type.eq.0 .or. t.ge.zerodegc) then
-       ! LIQUID
-
-       !       Flatau formulation:
-       dt       = max(-80._rtype,t-273.15_rtype)
-       polysvp1 = a0 + dt*(a1+dt*(a2+dt*(a3+dt*(a4+dt*(a5+dt*(a6+dt*(a7+a8*dt)))))))
-       polysvp1 = polysvp1*100._rtype
-
-       !       Goff-Gratch formulation:
-       !        POLYSVP1 = 10.**(-7.90298*(373.16/T-1.)+                         &
-       !             5.02808*log10(373.16/T)-                                    &
-       !             1.3816E-7*(10**(11.344*(1.-T/373.16))-1.)+                  &
-       !             8.1328E-3*(10**(-3.49149*(373.16/T-1.))-1.)+                &
-       !             log10(1013.246))*100.
-
-    !PMC added error checking
-    else
-
-       call report_error_info('Something went wrong', 'polysvp1')
-       write(err_msg,*)'** polysvp1 i_type must be 0 or 1 but is: ', &
-            i_type,' temperature is:',t,' in file: ',__FILE__, &
-            ' at line:',__LINE__
-       call endscreamrun(err_msg)
-    endif
-
-   return
-
-  end function polysvp1
-
-  subroutine check_temp(t, subname)
-    !Check if temprature values are in legit range
-    use scream_abortutils, only : endscreamrun
-    use ieee_arithmetic,   only : ieee_is_finite, ieee_is_nan
-
-    implicit none
-
-    real(rtype),      intent(in) :: t
-    character(len=*), intent(in) :: subname
-
-    character(len=1000) :: err_msg
-
-    if(t <= 0.0_rtype) then
-       write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is <= 0._r8 in file:',__FILE__, &
-            ' at line:',__LINE__
-       call endscreamrun(err_msg)
-    elseif(.not. ieee_is_finite(t)) then
-       write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is not finite in file:', &
-            __FILE__,' at line:',__LINE__
-       call endscreamrun(err_msg)
-    elseif(ieee_is_nan(t)) then
-       write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is NaN in file:',__FILE__, &
-             'at line:',__LINE__
-       call endscreamrun(err_msg)
-    endif
-
-    return
-  end subroutine check_temp
-
-  !------------------------------------------------------------------------------------------!
-
   !======================================================================================!
 
   subroutine find_lookupTable_indices_1a(dumi,dumjj,dumii,dumzz,dum1,dum4,dum5,dum6,      &
@@ -2041,38 +1869,6 @@ contains
 
   end subroutine impose_max_total_Ni
 
-
-  !===========================================================================================
-
-  real(rtype) function qv_sat(t_atm,p_atm,i_wrt)
-
-    !------------------------------------------------------------------------------------
-    ! Calls polysvp1 to obtain the saturation vapor pressure, and then computes
-    ! and returns the saturation mixing ratio, with respect to either liquid or ice,
-    ! depending on value of 'i_wrt'
-    !------------------------------------------------------------------------------------
-
-    implicit none
-
-    !Calling parameters:
-    real(rtype)    :: t_atm  !temperature [K]
-    real(rtype)    :: p_atm  !pressure    [Pa]
-    integer :: i_wrt  !index, 0 = w.r.t. liquid, 1 = w.r.t. ice
-
-    !Local variables:
-    real(rtype)            :: e_pres         !saturation vapor pressure [Pa]
-
-    !------------------
-    !Check if temprature is within legitimate range
-    call check_temp(t_atm, "qv_sat")
-
-    !e_pres = polysvp1(t_atm,i_wrt)
-    e_pres = MurphyKoop_svp(t_atm,i_wrt)
-    qv_sat = ep_2*e_pres/max(1.e-3_rtype,(p_atm-e_pres))
-
-    return
-
-  end function qv_sat
 
   !===========================================================================================
 

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -2464,6 +2464,7 @@ subroutine shoc_assumed_pdf_compute_qs(&
   Tl1_1,Tl1_2,pval,&   ! Input
   qs1,beta1,qs2,beta2) ! Ouput
 
+  use wv_sat_scream, only: MurphyKoop_svp
   implicit none
 
   ! intent-in
@@ -2478,6 +2479,7 @@ subroutine shoc_assumed_pdf_compute_qs(&
   real(rtype), intent(out) ::   beta2
 
   ! local vars
+  integer, parameter :: liquid = 0   ! liquid flag for MurphyKoop
   real(rtype) :: esval1_1
   real(rtype) :: esval1_2
   real(rtype) :: lstarn1
@@ -2486,7 +2488,7 @@ subroutine shoc_assumed_pdf_compute_qs(&
   esval1_1=0._rtype
   esval1_2=0._rtype
 
-  esval1_1=esatw_shoc(Tl1_1)*100._rtype
+  esval1_1=MurphyKoop_svp(Tl1_1, liquid)*100._rtype
   lstarn1=lcond
 
   qs1=0.622_rtype*esval1_1/max(esval1_1,pval-esval1_1)
@@ -2499,7 +2501,7 @@ subroutine shoc_assumed_pdf_compute_qs(&
     qs2=qs1
     beta2=beta1
   else
-    esval1_2=esatw_shoc(Tl1_2)*100._rtype
+    esval1_2=MurphyKoop_svp(Tl1_2, liquid)*100._rtype
     qs2=0.622_rtype*esval1_2/max(esval1_2,pval-esval1_2)
     beta2=(rgas/rv)*(lstarn2/(rgas*Tl1_2))*(lstarn2/(cp*Tl1_2))
   endif
@@ -4218,35 +4220,6 @@ subroutine linear_interp(x1,x2,y1,y2,km1,km2,ncol,minthresh)
     return
 
 end subroutine linear_interp
-
-!==============================================================
-!
-! Saturation vapor pressure and mixing ratio.
-! Based on Flatau et.al, (JAM, 1992:1507) - valid for T > -80C
-! sat. vapor over ice below -80C - used Murphy and Koop (2005)
-! For water below -80C simply assumed esw/esi = 2.
-! des/dT below -80C computed as a finite difference of es
-
-real(rtype) function esatw_shoc(t)
-   implicit none
-   real(rtype) t    ! temperature (K)
-   real(rtype) a0,a1,a2,a3,a4,a5,a6,a7,a8
-   data a0,a1,a2,a3,a4,a5,a6,a7,a8 /&
-        6.105851_rtype, 0.4440316_rtype, 0.1430341e-1_rtype, &
-        0.2641412e-3_rtype, 0.2995057e-5_rtype, 0.2031998e-7_rtype, &
-        0.6936113e-10_rtype, 0.2564861e-13_rtype,-0.3704404e-15_rtype/
-!         6.11239921, 0.443987641, 0.142986287e-1, &
-!       0.264847430e-3, 0.302950461e-5, 0.206739458e-7, &
-!       0.640689451e-10, -0.952447341e-13,-0.976195544e-15/
-   real(rtype) dt
-   dt = t-273.16_rtype
-   if(dt.gt.-80._rtype) then
-      esatw_shoc = a0 + dt*(a1+dt*(a2+dt*(a3+dt*(a4+dt*(a5+dt*(a6+dt*(a7+a8*dt)))))))
-   else
-      esatw_shoc = 2._rtype*0.01_rtype*exp(9.550426_rtype - 5723.265_rtype/t + 3.53068_rtype*Log(t) - 0.00728332_rtype*t)
-   end if
-end
-
 
 subroutine compute_brunt_shoc_length(nlev,nlevi,shcol,dz_zt,thv,thv_zi,brunt)
 

--- a/components/cam/src/physics/cam/wv_sat_scream.F90
+++ b/components/cam/src/physics/cam/wv_sat_scream.F90
@@ -13,11 +13,16 @@ module wv_sat_scream
   ! get real kind from utils
   use physics_utils,  only: rtype
   use micro_p3_utils, only: zerodegc
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  use physics_share_f2c, only: cxx_pow, cxx_sqrt, cxx_cbrt, cxx_gamma, cxx_log, &
+                                 cxx_log10, cxx_exp, cxx_tanh
+#endif
+
 
   implicit none
   private
 
-  public:: qv_sat
+  public:: qv_sat, MurphyKoop_svp
 
 contains
 
@@ -34,16 +39,12 @@ contains
     implicit none
 
     !Calling parameters:
-    real(rtype)    :: t_atm  !temperature [K]
-    real(rtype)    :: p_atm  !pressure    [Pa]
-    integer :: i_wrt  !index, 0 = w.r.t. liquid, 1 = w.r.t. ice
+    real(rtype), intent(in)    :: t_atm  !temperature [K]
+    real(rtype), intent(in)    :: p_atm  !pressure    [Pa]
+    integer, intent(in) :: i_wrt  !index, 0 = w.r.t. liquid, 1 = w.r.t. ice
 
     !Local variables:
     real(rtype)            :: e_pres         !saturation vapor pressure [Pa]
-
-    !------------------
-    !Check if temprature is within legitimate range
-    call check_temp(t_atm, "qv_sat")
 
     !e_pres = polysvp1(t_atm,i_wrt)
     e_pres = MurphyKoop_svp(t_atm,i_wrt)
@@ -86,6 +87,10 @@ contains
     real(rtype), parameter :: lq(10) = (/54.842763_rtype, 6763.22_rtype, 4.210_rtype, &
          0.000367_rtype, 0.0415_rtype, 218.8_rtype, 53.878_rtype, 1331.22_rtype,       &
          9.44523_rtype, 0.014025_rtype /)
+
+    !------------------
+    !Check if temprature is within legitimate range
+    call check_temp(t, "MurphyKoop_svp")
 
     logt = bfb_log(t)
 
@@ -153,6 +158,11 @@ contains
     real(rtype) dt
 
     !-------------------------------------------
+
+    !------------------
+    !Check if temprature is within legitimate range
+    call check_temp(t, "polysvp1")
+
 
     if (i_type.eq.1 .and. t.lt.zerodegc) then
        ! ICE

--- a/components/cam/src/physics/cam/wv_sat_scream.F90
+++ b/components/cam/src/physics/cam/wv_sat_scream.F90
@@ -1,0 +1,232 @@
+! Include bit-for-bit math macros.
+#include "bfb_math.inc"
+
+module wv_sat_scream
+
+  !------------------------------------------------------------------------------------
+  !This module has functions which scream uses for computing saturation vapor pressure
+  !of ice and liquid.
+  !Note: I just copied them over from micro_p3.F90 without any cleanup as this code
+  ! not be maintained on long term basis
+  !------------------------------------------------------------------------------------
+
+  ! get real kind from utils
+  use physics_utils,  only: rtype
+  use micro_p3_utils, only: zerodegc
+
+  implicit none
+  private
+
+  public:: qv_sat
+
+contains
+
+  !===========================================================================================
+  real(rtype) function qv_sat(t_atm,p_atm,i_wrt)
+
+    !------------------------------------------------------------------------------------
+    ! Calls polysvp1 to obtain the saturation vapor pressure, and then computes
+    ! and returns the saturation mixing ratio, with respect to either liquid or ice,
+    ! depending on value of 'i_wrt'
+    !------------------------------------------------------------------------------------
+
+    use micro_p3_utils, only: ep_2
+    implicit none
+
+    !Calling parameters:
+    real(rtype)    :: t_atm  !temperature [K]
+    real(rtype)    :: p_atm  !pressure    [Pa]
+    integer :: i_wrt  !index, 0 = w.r.t. liquid, 1 = w.r.t. ice
+
+    !Local variables:
+    real(rtype)            :: e_pres         !saturation vapor pressure [Pa]
+
+    !------------------
+    !Check if temprature is within legitimate range
+    call check_temp(t_atm, "qv_sat")
+
+    !e_pres = polysvp1(t_atm,i_wrt)
+    e_pres = MurphyKoop_svp(t_atm,i_wrt)
+    qv_sat = ep_2*e_pres/max(1.e-3_rtype,(p_atm-e_pres))
+
+    return
+
+  end function qv_sat
+  !===========================================================================================
+
+  !==========================================================================================!
+
+  real(rtype) function MurphyKoop_svp(t, i_type)
+
+    use scream_abortutils, only : endscreamrun
+
+    implicit none
+
+    !-------------------------------------------------------------------
+    ! Compute saturation vapor pressure (returned in units of pa)
+    ! Inputs:
+    ! "t", units [K]
+    !  i_type refers to saturation with respect to liquid (0) or ice (1)
+    ! Author: Balwinder Singh (algorithm from CAM routine)
+    !--------------------------------------------------------------------
+
+    !Murphy & Koop (2005)
+    real(rtype), intent(in) :: t
+    integer, intent(in)     :: i_type
+
+    !local vars
+    character(len=1000) :: err_msg
+    real(rtype)         :: logt, tmp
+
+    !parameters for ice saturation eqn
+    real(rtype), parameter :: ic(4)  =(/9.550426_rtype, 5723.265_rtype, 3.53068_rtype, &
+         0.00728332_rtype/)
+
+    !parameters for liq saturation eqn
+    real(rtype), parameter :: lq(10) = (/54.842763_rtype, 6763.22_rtype, 4.210_rtype, &
+         0.000367_rtype, 0.0415_rtype, 218.8_rtype, 53.878_rtype, 1331.22_rtype,       &
+         9.44523_rtype, 0.014025_rtype /)
+
+    logt = bfb_log(t)
+
+    if (i_type .eq. 1 .and. t .lt. zerodegc) then
+
+       !(good down to 110 K)
+       MurphyKoop_svp = bfb_exp(ic(1) - (ic(2) / t) + (ic(3) * logt) - (ic(4) * t))
+
+    elseif (i_type .eq. 0 .or. t .ge. zerodegc) then
+
+       ! (good for 123 < T < 332 K)
+       !For some reason, we cannot add line breaks if we use "bfb_exp", storing experssion in "tmp"
+       tmp = lq(1) - (lq(2) / t) - (lq(3) * logt) + (lq(4) * t) + &
+            (bfb_tanh(lq(5) * (t - lq(6))) * (lq(7) - (lq(8) / t) - &
+            (lq(9) * logt) + lq(10) * t))
+       MurphyKoop_svp = bfb_exp(tmp)
+    else
+
+       write(err_msg,*)'Error: Either MurphyKoop_svp i_type is not 0 or 1 or t=NaN. itype= ', &
+            i_type,' and temperature t=',t,' in file: ',__FILE__,' at line:',__LINE__
+       call endscreamrun(err_msg)
+    endif
+
+    return
+  end function MurphyKoop_svp
+
+  !_rtype
+  real(rtype) function polysvp1(t,i_type)
+
+    !-------------------------------------------
+    !  COMPUTE SATURATION VAPOR PRESSURE
+    !  POLYSVP1 RETURNED IN UNITS OF PA.
+    !  T IS INPUT IN UNITS OF K.
+    !  i_type REFERS TO SATURATION WITH RESPECT TO LIQUID (0) OR ICE (1)
+    !-------------------------------------------
+
+    use scream_abortutils, only : endscreamrun
+
+    use debug_info, only: report_error_info
+    implicit none
+
+    real(rtype), intent(in) :: t
+    integer, intent(in)     :: i_type
+
+    ! REPLACE GOFF-GRATCH WITH FASTER FORMULATION FROM FLATAU ET AL. 1992, TABLE 4 (RIGHT-HAND COLUMN)
+
+    !local variables
+    character(len=1000) :: err_msg
+
+    ! ice
+    real(rtype) a0i,a1i,a2i,a3i,a4i,a5i,a6i,a7i,a8i
+    data a0i,a1i,a2i,a3i,a4i,a5i,a6i,a7i,a8i /&
+         6.11147274_rtype,     0.503160820_rtype,     0.188439774e-1_rtype, &
+         0.420895665e-3_rtype, 0.615021634e-5_rtype,  0.602588177e-7_rtype, &
+         0.385852041e-9_rtype, 0.146898966e-11_rtype, 0.252751365e-14_rtype/
+
+    ! liquid
+    real(rtype) a0,a1,a2,a3,a4,a5,a6,a7,a8
+
+    ! V1.7
+    data a0,a1,a2,a3,a4,a5,a6,a7,a8 /&
+         6.11239921_rtype,      0.443987641_rtype,     0.142986287e-1_rtype, &
+         0.264847430e-3_rtype,  0.302950461e-5_rtype,  0.206739458e-7_rtype, &
+         0.640689451e-10_rtype,-0.952447341e-13_rtype,-0.976195544e-15_rtype/
+    real(rtype) dt
+
+    !-------------------------------------------
+
+    if (i_type.eq.1 .and. t.lt.zerodegc) then
+       ! ICE
+
+       !       Flatau formulation:
+       dt       = max(-80._rtype,t-273.15_rtype)
+       polysvp1 = a0i + dt*(a1i+dt*(a2i+dt*(a3i+dt*(a4i+dt*(a5i+dt*(a6i+dt*(a7i+       &
+            a8i*dt)))))))
+       polysvp1 = polysvp1*100._rtype
+
+       !       Goff-Gratch formulation:
+       !        POLYSVP1 = 10.**(-9.09718*(273.16/T-1.)-3.56654*                 &
+       !          log10(273.16/T)+0.876793*(1.-T/273.16)+                        &
+       !          log10(6.1071))*100.
+
+
+    elseif (i_type.eq.0 .or. t.ge.zerodegc) then
+       ! LIQUID
+
+       !       Flatau formulation:
+       dt       = max(-80._rtype,t-273.15_rtype)
+       polysvp1 = a0 + dt*(a1+dt*(a2+dt*(a3+dt*(a4+dt*(a5+dt*(a6+dt*(a7+a8*dt)))))))
+       polysvp1 = polysvp1*100._rtype
+
+       !       Goff-Gratch formulation:
+       !        POLYSVP1 = 10.**(-7.90298*(373.16/T-1.)+                         &
+       !             5.02808*log10(373.16/T)-                                    &
+       !             1.3816E-7*(10**(11.344*(1.-T/373.16))-1.)+                  &
+       !             8.1328E-3*(10**(-3.49149*(373.16/T-1.))-1.)+                &
+       !             log10(1013.246))*100.
+
+       !PMC added error checking
+    else
+
+       call report_error_info('Something went wrong', 'polysvp1')
+       write(err_msg,*)'** polysvp1 i_type must be 0 or 1 but is: ', &
+            i_type,' temperature is:',t,' in file: ',__FILE__, &
+            ' at line:',__LINE__
+       call endscreamrun(err_msg)
+    endif
+
+    return
+
+  end function polysvp1
+
+  subroutine check_temp(t, subname)
+    !Check if temprature values are in legit range
+    use scream_abortutils, only : endscreamrun
+    use ieee_arithmetic,   only : ieee_is_finite, ieee_is_nan
+
+    implicit none
+
+    real(rtype),      intent(in) :: t
+    character(len=*), intent(in) :: subname
+
+    character(len=1000) :: err_msg
+
+    if(t <= 0.0_rtype) then
+       write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is <= 0._r8 in file:',__FILE__, &
+            ' at line:',__LINE__
+       call endscreamrun(err_msg)
+    elseif(.not. ieee_is_finite(t)) then
+       write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is not finite in file:', &
+            __FILE__,' at line:',__LINE__
+       call endscreamrun(err_msg)
+    elseif(ieee_is_nan(t)) then
+       write(err_msg,*)'Error: Called from:',trim(adjustl(subname)),'; Temperature is:',t,' which is NaN in file:',__FILE__, &
+            'at line:',__LINE__
+       call endscreamrun(err_msg)
+    endif
+
+    return
+  end subroutine check_temp
+
+  !------------------------------------------------------------------------------------------!
+
+end module wv_sat_scream

--- a/components/scream/src/physics/p3/CMakeLists.txt
+++ b/components/scream/src/physics/p3/CMakeLists.txt
@@ -13,8 +13,6 @@ set(P3_SRCS
   micro_p3_iso_c.f90
   micro_p3_iso_f.f90
   ${SCREAM_BASE_DIR}/../cam/src/physics/cam/micro_p3.F90
-  ${SCREAM_BASE_DIR}/../cam/src/physics/cam/debug_info.F90
-  ${SCREAM_BASE_DIR}/../cam/src/physics/cam/micro_p3_utils.F90
   atmosphere_microphysics.cpp
   p3_inputs_initializer.cpp
   scream_p3_interface.F90

--- a/components/scream/src/physics/share/CMakeLists.txt
+++ b/components/scream/src/physics/share/CMakeLists.txt
@@ -13,6 +13,9 @@ set(PHYSICS_SHARE_SRCS
   physics_test_data.cpp
   ${SCREAM_BASE_DIR}/../cam/src/physics/cam/physics_utils.F90
   ${SCREAM_BASE_DIR}/../cam/src/physics/cam/scream_abortutils.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/cam/wv_sat_scream.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/cam/micro_p3_utils.F90
+  ${SCREAM_BASE_DIR}/../cam/src/physics/cam/debug_info.F90
 )
 
 # Add ETI source files if not on CUDA
@@ -31,4 +34,3 @@ target_link_libraries(physics_share scream_share ${SCREAM_TPL_LIBRARIES})
 if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)
 endif()
-

--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -80,14 +80,14 @@ struct Functions
   //  t is input in units of k.
   //  ice refers to saturation with respect to liquid (false) or ice (true)
   KOKKOS_FUNCTION
-  static Spack polysvp1(const Spack& t, const bool ice);
+  static Spack polysvp1(const Spack& t, const bool ice, const Smask& range_mask);
 
   //  compute saturation vapor pressure using Murphy and Koop(2005) formulation
   //  MurphyKoop_svp returned in units of pa.
   //  t is input in units of k.
   //  ice refers to saturation with respect to liquid (false) or ice (true)
   KOKKOS_FUNCTION
-  static Spack MurphyKoop_svp(const Spack& t, const bool ice);
+  static Spack MurphyKoop_svp(const Spack& t, const bool ice, const Smask& range_mask);
 
   // Calls a function to obtain the saturation vapor pressure, and then computes
   // and returns the saturation mixing ratio, with respect to either liquid or ice,

--- a/components/scream/src/physics/share/tests/physics_saturation_unit_tests.cpp
+++ b/components/scream/src/physics/share/tests/physics_saturation_unit_tests.cpp
@@ -89,15 +89,15 @@ struct UnitWrap::UnitTest<D>::TestSaturation
 
     //Get values from polysvp1 and qv_sat (qv_sat calls polysvp1 here) to test against "expected" values
     //--------------------------------------
-    const Spack sat_ice_fp  = physics::polysvp1(temps, true);
-    const Spack sat_liq_fp  = physics::polysvp1(temps, false);
+    const Spack sat_ice_fp  = physics::polysvp1(temps, true, Smask(true));
+    const Spack sat_liq_fp  = physics::polysvp1(temps, false, Smask(true));
     //last argument "0" of qv_sat function below forces qv_sat to call "polysvp1"
     const Spack mix_ice_fr = physics::qv_sat(temps, pres, true, Smask(true), physics::Polysvp1);
     const Spack mix_liq_fr = physics::qv_sat(temps, pres, false,Smask(true), physics::Polysvp1);
 
     //Get values from MurphyKoop_svp and qv_sat (qv_sat calls MurphyKoop_svp here) to test against "expected" values
-    const Spack sat_ice_mkp   = physics::MurphyKoop_svp(temps, true);
-    const Spack sat_liq_mkp   = physics::MurphyKoop_svp(temps, false);
+    const Spack sat_ice_mkp   = physics::MurphyKoop_svp(temps, true, Smask(true));
+    const Spack sat_liq_mkp   = physics::MurphyKoop_svp(temps, false, Smask(true));
     //last argument "1" of qv_sat function below forces qv_sat to call "MurphyKoop_svp"
     const Spack mix_ice_mkr  = physics::qv_sat(temps, pres, true,  Smask(true), physics::MurphyKoop);
     const Spack mix_liq_mkr  = physics::qv_sat(temps, pres, false, Smask(true), physics::MurphyKoop);


### PR DESCRIPTION
Following is the summary of changes to make SHOC call Murphy Koop(MK) water vapor saturation scheme:
1. Created a new F90 file and moved `qv_sat` calculations from P3 to this new file
2. Modified SHOC code so that it always calls MK and removed "esatw_shoc" function from SHOC
3. On C++ side, moved some F90 files in CMakeList.txt from P3 to Share folder (so that both SHOC and P3 can use these files)
4. Moved "check temperature" calls from qv_sat to MK and polysvp1 functions (both C++ and F90)
5. Fixed qv_sat unit test to add additional argument of mask