### PR TITLE
Adds shoc_constants file

### DIFF
--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SHOC_HEADERS
   shoc.hpp
   atmosphere_macrophysics.hpp
   scream_shoc_interface.hpp
+  shoc_constants.hpp
 )
 
 # Add ETI source files if not on CUDA

--- a/components/scream/src/physics/shoc/shoc_constants.hpp
+++ b/components/scream/src/physics/shoc/shoc_constants.hpp
@@ -1,0 +1,23 @@
+#ifndef SHOC_CONSTANTS_HPP
+#define SHOC_CONSTANTS_HPP
+
+namespace scream {
+  namespace shoc {
+
+    /*
+     * Mathematical constants used by shoc.
+     */
+
+template <typename Scalar>
+struct Constants
+    {
+      static constexpr Scalar mintke     = 0.0004;  // Minimum TKE [m2/s2]
+      static constexpr Scalar maxtke     = 50.0;    // Maximum TKE [m2/s2]
+      static constexpr Scalar maxlen     = 20000.0; // Upper limit for mixing length [m]
+      static constexpr Scalar length_fac = 0.5;     // Mixing length scaling parameter
+    };
+
+  } // namespace shoc
+} // namespace scream
+
+#endif


### PR DESCRIPTION
A new file for storing shoc specific constants has been added so that future PRs have a place to store constants. Right now, there are at least 3 PRs which try to add this file. All those PRs will have to resolve the conflict. Let me know if you need help with that.