### PR TITLE
The AtmosphereProcess abstract class now maintains a timestamp.

### DIFF
--- a/components/scream/src/control/tests/dummy_atm_proc.hpp
+++ b/components/scream/src/control/tests/dummy_atm_proc.hpp
@@ -67,11 +67,10 @@ public:
     m_output_fids.emplace(out_name,layout,ekat::units::m,m_grid->name());
   }
 
-  void initialize (const util::TimeStamp& t0) {
-    m_time_stamp = t0;
+  void initialize_ (const util::TimeStamp& t0) {
   }
 
-  void run (const Real dt) {
+  void run_ (const Real dt) {
     auto in = m_input.get_view();
     auto out = m_output.get_view();
     auto iter = m_iter % 4;
@@ -89,12 +88,13 @@ public:
     Kokkos::fence();
 
     ++m_iter;
-    m_time_stamp += dt;
-    m_output.get_header().get_tracking().update_time_stamp(m_time_stamp);
+    auto ts = timestamp();
+    ts += dt;
+    m_output.get_header().get_tracking().update_time_stamp(ts);
   }
 
   // Clean up
-  void finalize ( ) {}
+  void finalize_ ( ) {}
 
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real, device_type>& field_repo) const {
@@ -118,8 +118,6 @@ protected:
   }
 
   int m_iter;
-
-  util::TimeStamp           m_time_stamp;
 
   std::set<FieldIdentifier> m_input_fids;
   std::set<FieldIdentifier> m_output_fids;

--- a/components/scream/src/control/tests/dummy_atm_proc.hpp
+++ b/components/scream/src/control/tests/dummy_atm_proc.hpp
@@ -67,10 +67,10 @@ public:
     m_output_fids.emplace(out_name,layout,ekat::units::m,m_grid->name());
   }
 
-  void initialize_ (const util::TimeStamp& t0) {
+  void initialize_impl (const util::TimeStamp& t0) {
   }
 
-  void run_ (const Real dt) {
+  void run_impl (const Real dt) {
     auto in = m_input.get_view();
     auto out = m_output.get_view();
     auto iter = m_iter % 4;
@@ -94,7 +94,7 @@ public:
   }
 
   // Clean up
-  void finalize_ ( ) {}
+  void finalize_impl ( ) {}
 
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real, device_type>& field_repo) const {

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -72,7 +72,7 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
 }
 
 // =========================================================================================
-void P3Microphysics::initialize (const util::TimeStamp& t0)
+void P3Microphysics::initialize_ (const util::TimeStamp& t0)
 {
   m_current_ts = t0;
 
@@ -123,7 +123,7 @@ void P3Microphysics::initialize (const util::TimeStamp& t0)
 }
 
 // =========================================================================================
-void P3Microphysics::run (const Real dt)
+void P3Microphysics::run_ (const Real dt)
 {
   // std::array<const char*, num_views> view_names = {"q", "FQ", "T", "zi", "pmid", "dpres", "ast", "ni_activated", "nc_nuceat_tend"};
 
@@ -145,14 +145,18 @@ void P3Microphysics::run (const Real dt)
   for (auto& it : m_p3_fields_out) {
     Kokkos::deep_copy(it.second.get_view(),m_p3_host_views_out.at(it.first));
   }
-  m_current_ts += dt;
-  m_p3_fields_out.at("q").get_header().get_tracking().update_time_stamp(m_current_ts);
-  m_p3_fields_out.at("FQ").get_header().get_tracking().update_time_stamp(m_current_ts);
-  m_p3_fields_out.at("T").get_header().get_tracking().update_time_stamp(m_current_ts);
+
+  // Get a copy of the current timestamp (at the beginning of the step) and
+  // advance it, updating the p3 fields.
+  auto ts = timestamp();
+  ts += dt;
+  m_p3_fields_out.at("q").get_header().get_tracking().update_time_stamp(ts);
+  m_p3_fields_out.at("FQ").get_header().get_tracking().update_time_stamp(ts);
+  m_p3_fields_out.at("T").get_header().get_tracking().update_time_stamp(ts);
 }
 
 // =========================================================================================
-void P3Microphysics::finalize()
+void P3Microphysics::finalize_()
 {
   p3_finalize_f90 ();
 }

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -72,7 +72,7 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
 }
 
 // =========================================================================================
-void P3Microphysics::initialize_ (const util::TimeStamp& t0)
+void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
 {
   m_current_ts = t0;
 
@@ -96,7 +96,7 @@ void P3Microphysics::initialize_ (const util::TimeStamp& t0)
   const strvec& allowed_to_init = m_p3_params.get<strvec>("Initializable Inputs",strvec(0));
   const bool can_init_all = m_p3_params.get<bool>("Can Initialize All Inputs", false);
   const bool init_all_or_none = m_p3_params.get<bool>("Must Init All Inputs Or None", true);
-  
+
   const strvec& initable = can_init_all ? p3_inputs : allowed_to_init;
   if (initable.size()>0) {
     bool all_inited = true, all_uninited = true;
@@ -123,7 +123,7 @@ void P3Microphysics::initialize_ (const util::TimeStamp& t0)
 }
 
 // =========================================================================================
-void P3Microphysics::run_ (const Real dt)
+void P3Microphysics::run_impl (const Real dt)
 {
   // std::array<const char*, num_views> view_names = {"q", "FQ", "T", "zi", "pmid", "dpres", "ast", "ni_activated", "nc_nuceat_tend"};
 
@@ -156,7 +156,7 @@ void P3Microphysics::run_ (const Real dt)
 }
 
 // =========================================================================================
-void P3Microphysics::finalize_()
+void P3Microphysics::finalize_impl()
 {
   p3_finalize_f90 ();
 }

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -56,9 +56,9 @@ public:
 protected:
 
   // The three main overrides for the subcomponent
-  void initialize_ (const util::TimeStamp& t0);
-  void run_        (const Real dt);
-  void finalize_   ();
+  void initialize_impl (const util::TimeStamp& t0);
+  void run_impl        (const Real dt);
+  void finalize_impl   ();
 
   // Setting the fields in the atmospheric process
   void set_required_field_impl (const Field<const Real, device_type>& f);

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -46,11 +46,6 @@ public:
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
-  // The three main interfaces for the subcomponent
-  void initialize (const util::TimeStamp& t0);
-  void run        (const Real dt);
-  void finalize   ();
-
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real, device_type>& field_repo) const;
 
@@ -59,6 +54,11 @@ public:
   const std::set<FieldIdentifier>& get_computed_fields () const { return m_computed_fields; }
 
 protected:
+
+  // The three main overrides for the subcomponent
+  void initialize_ (const util::TimeStamp& t0);
+  void run_        (const Real dt);
+  void finalize_   ();
 
   // Setting the fields in the atmospheric process
   void set_required_field_impl (const Field<const Real, device_type>& f);

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -14,12 +14,12 @@ namespace scream {
 
     }  // RRTMGPRadiation::set_grids
 
-    void RRTMGPRadiation::initialize(const util::TimeStamp& t0) {
+    void RRTMGPRadiation::initialize_(const util::TimeStamp& t0) {
         // Call RRTMGP initialize routine
         //rrtmgp_initialize()
     }
-    void RRTMGPRadiation::run       (const Real dt) {}
-    void RRTMGPRadiation::finalize  () {}
+    void RRTMGPRadiation::run_      (const Real dt) {}
+    void RRTMGPRadiation::finalize_  () {}
 
     // Register all required and computed field in the field repository
     void RRTMGPRadiation::register_fields(FieldRepository<Real, device_type>& field_repo) const {

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -14,12 +14,12 @@ namespace scream {
 
     }  // RRTMGPRadiation::set_grids
 
-    void RRTMGPRadiation::initialize_(const util::TimeStamp& t0) {
+    void RRTMGPRadiation::initialize_impl(const util::TimeStamp& t0) {
         // Call RRTMGP initialize routine
         //rrtmgp_initialize()
     }
-    void RRTMGPRadiation::run_      (const Real dt) {}
-    void RRTMGPRadiation::finalize_  () {}
+    void RRTMGPRadiation::run_impl      (const Real dt) {}
+    void RRTMGPRadiation::finalize_impl  () {}
 
     // Register all required and computed field in the field repository
     void RRTMGPRadiation::register_fields(FieldRepository<Real, device_type>& field_repo) const {

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -38,11 +38,6 @@ namespace scream {
             // Set the grid
             void set_grids (const std::shared_ptr<const GridsManager> grid_manager);
 
-            // The three main interfaces for the subcomponent
-            void initialize (const util::TimeStamp& t0);
-            void run        (const Real dt);
-            void finalize   ();
-
             // Register all fields in the given repo
             void register_fields (FieldRepository<Real, device_type>& field_repo) const;
 
@@ -51,6 +46,11 @@ namespace scream {
             const std::set<FieldIdentifier>& get_computed_fields () const { return m_computed_fields; }
 
         protected:
+            // The three main interfaces for the subcomponent
+            void initialize_ (const util::TimeStamp& t0);
+            void run_        (const Real dt);
+            void finalize_   ();
+
             // Set fields in the atmosphere process
             void set_required_field_impl (const Field<const Real, device_type>& f);
             void set_computed_field_impl (const Field<      Real, device_type>& f);

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -47,9 +47,9 @@ namespace scream {
 
         protected:
             // The three main interfaces for the subcomponent
-            void initialize_ (const util::TimeStamp& t0);
-            void run_        (const Real dt);
-            void finalize_   ();
+            void initialize_impl (const util::TimeStamp& t0);
+            void run_impl        (const Real dt);
+            void finalize_impl   ();
 
             // Set fields in the atmosphere process
             void set_required_field_impl (const Field<const Real, device_type>& f);

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -50,7 +50,7 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
 }
 // =========================================================================================
-void SHOCMacrophysics::initialize_ (const util::TimeStamp& t0)
+void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
 {
   // TODO: create the host mirrors once.
   auto q_dev = m_shoc_fields_out.at("q").get_view();
@@ -64,7 +64,7 @@ void SHOCMacrophysics::initialize_ (const util::TimeStamp& t0)
 }
 
 // =========================================================================================
-void SHOCMacrophysics::run_ (const Real dt)
+void SHOCMacrophysics::run_impl (const Real dt)
 {
   // TODO: create the host mirrors once.
   auto q_dev   = m_shoc_fields_out.at("q").get_view();
@@ -88,7 +88,7 @@ void SHOCMacrophysics::run_ (const Real dt)
   m_shoc_fields_out.at("FQ").get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void SHOCMacrophysics::finalize_()
+void SHOCMacrophysics::finalize_impl()
 {
   shoc_finalize_f90 ();
 }

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -50,10 +50,8 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
 }
 // =========================================================================================
-void SHOCMacrophysics::initialize (const util::TimeStamp& t0)
+void SHOCMacrophysics::initialize_ (const util::TimeStamp& t0)
 {
-  m_current_ts = t0;
-
   // TODO: create the host mirrors once.
   auto q_dev = m_shoc_fields_out.at("q").get_view();
   auto q_host = Kokkos::create_mirror_view(q_dev);
@@ -66,7 +64,7 @@ void SHOCMacrophysics::initialize (const util::TimeStamp& t0)
 }
 
 // =========================================================================================
-void SHOCMacrophysics::run (const Real dt)
+void SHOCMacrophysics::run_ (const Real dt)
 {
   // TODO: create the host mirrors once.
   auto q_dev   = m_shoc_fields_out.at("q").get_view();
@@ -83,12 +81,14 @@ void SHOCMacrophysics::run (const Real dt)
   Kokkos::deep_copy(q_dev,q_host);
   Kokkos::deep_copy(fq_dev,fq_host);
 
-  m_current_ts += dt;
-  m_shoc_fields_out.at("q").get_header().get_tracking().update_time_stamp(m_current_ts);
-  m_shoc_fields_out.at("FQ").get_header().get_tracking().update_time_stamp(m_current_ts);
+  // Get the beginning-of-step timestamp and advance it to update our fields.
+  auto ts = timestamp();
+  ts += dt;
+  m_shoc_fields_out.at("q").get_header().get_tracking().update_time_stamp(ts);
+  m_shoc_fields_out.at("FQ").get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void SHOCMacrophysics::finalize()
+void SHOCMacrophysics::finalize_()
 {
   shoc_finalize_f90 ();
 }

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -56,9 +56,9 @@ public:
 protected:
 
   // The three main interfaces for the subcomponent
-  void initialize_ (const util::TimeStamp& t0);
-  void run_        (const Real dt);
-  void finalize_   ();
+  void initialize_impl (const util::TimeStamp& t0);
+  void run_impl        (const Real dt);
+  void finalize_impl   ();
 
   // Setting the fields in the atmospheric process
   void set_required_field_impl (const Field<const Real, device_type>& f);

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -46,11 +46,6 @@ public:
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
-  // The three main interfaces for the subcomponent
-  void initialize (const util::TimeStamp& t0);
-  void run        (const Real dt);
-  void finalize   ();
-
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real, device_type>& field_repo) const;
 
@@ -59,6 +54,11 @@ public:
   const std::set<FieldIdentifier>& get_computed_fields () const { return m_computed_fields; }
 
 protected:
+
+  // The three main interfaces for the subcomponent
+  void initialize_ (const util::TimeStamp& t0);
+  void run_        (const Real dt);
+  void finalize_   ();
 
   // Setting the fields in the atmospheric process
   void set_required_field_impl (const Field<const Real, device_type>& f);
@@ -70,7 +70,6 @@ protected:
   std::map<std::string,const_field_type>  m_shoc_fields_in;
   std::map<std::string,field_type>        m_shoc_fields_out;
 
-  util::TimeStamp   m_current_ts;
   ekat::Comm              m_shoc_comm;
 
 }; // class SHOCMacrophysics

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -81,7 +81,7 @@ public:
   //     that no other process is currently inside a call to 'run'.
   //   - the finalize method makes sure, if necessary, that all resources are freed.
   // NOTE: You don't override these methods. Override the protected methods
-  // NOTE: initialize_, run_, and finalize_ instead.
+  // NOTE: initialize_impl, run_impl, and finalize_impl instead.
   // The initialize/finalize method should be called just once per simulation (should
   // we enforce that? It depends on what resources we init/free, and how), while the
   // run method can (and usually will) be called multiple times.
@@ -89,15 +89,15 @@ public:
   // run/finalize is called.
   void initialize (const TimeStamp& t0) {
     t_ = t0;
-    initialize_(t_);
+    initialize_impl(t_);
   }
   void run        (const Real dt) {
     // Call the subclass's run method and update it afterward.
-    run_(dt);
+    run_impl(dt);
     t_ += dt;
   }
   void finalize   (/* what inputs? */) {
-    finalize_(/* what inputs? */);
+    finalize_impl(/* what inputs? */);
   }
 
   // These methods set fields in the atm process. Fields live on device and they are all 1d.
@@ -137,14 +137,14 @@ public:
 protected:
 
   // Override this method to initialize your subclass.
-  virtual void initialize_(const TimeStamp& t0) = 0;
+  virtual void initialize_impl(const TimeStamp& t0) = 0;
 
   // Override this method to define how your subclass runs forward one step
   // (of size dt). This method is called before the timestamp is updated.
-  virtual void run_(const Real dt) = 0;
+  virtual void run_impl(const Real dt) = 0;
 
   // Override this method to finalize your subclass.
-  virtual void finalize_(/* what inputs? */) = 0;
+  virtual void finalize_impl(/* what inputs? */) = 0;
 
   // This provides access to this process's timestamp.
   const TimeStamp& timestamp() const {

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -80,14 +80,25 @@ public:
   //     be running at the same time, or whether each process can assume
   //     that no other process is currently inside a call to 'run'.
   //   - the finalize method makes sure, if necessary, that all resources are freed.
+  // NOTE: You don't override these methods. Override the protected methods
+  // NOTE: initialize_, run_, and finalize_ instead.
   // The initialize/finalize method should be called just once per simulation (should
   // we enforce that? It depends on what resources we init/free, and how), while the
   // run method can (and usually will) be called multiple times.
   // We should put asserts to verify that the process has been init-ed, when
   // run/finalize is called.
-  virtual void initialize (const TimeStamp& t0) = 0;
-  virtual void run        (const Real dt) = 0;
-  virtual void finalize   (/* what inputs? */) = 0;
+  void initialize (const TimeStamp& t0) {
+    t_ = t0;
+    initialize_(t_);
+  }
+  void run        (const Real dt) {
+    // Call the subclass's run method and update it afterward.
+    run_(dt);
+    t_ += dt;
+  }
+  void finalize   (/* what inputs? */) {
+    finalize_(/* what inputs? */);
+  }
 
   // These methods set fields in the atm process. Fields live on device and they are all 1d.
   // If the process *needs* to store the field as n-dimensional field, use the
@@ -125,6 +136,21 @@ public:
 
 protected:
 
+  // Override this method to initialize your subclass.
+  virtual void initialize_(const TimeStamp& t0) = 0;
+
+  // Override this method to define how your subclass runs forward one step
+  // (of size dt). This method is called before the timestamp is updated.
+  virtual void run_(const Real dt) = 0;
+
+  // Override this method to finalize your subclass.
+  virtual void finalize_(/* what inputs? */) = 0;
+
+  // This provides access to this process's timestamp.
+  const TimeStamp& timestamp() const {
+    return t_;
+  }
+
   void add_me_as_provider (const Field<Real, device_type>& f) {
     f.get_header_ptr()->get_tracking().add_provider(weak_from_this());
   }
@@ -135,6 +161,12 @@ protected:
 
   virtual void set_required_field_impl (const Field<const Real, device_type>& f) = 0;
   virtual void set_computed_field_impl (const Field<      Real, device_type>& f) = 0;
+
+private:
+
+  // This process's copy of the timestamp, which is set on initialization and
+  // updated during stepping.
+  TimeStamp t_;
 };
 
 // A short name for the factory for atmosphere processes

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -209,7 +209,7 @@ void AtmosphereProcessGroup::set_grids (const std::shared_ptr<const GridsManager
   }
 }
 
-void AtmosphereProcessGroup::initialize_ (const TimeStamp& t0) {
+void AtmosphereProcessGroup::initialize_impl (const TimeStamp& t0) {
   // Now that we have the comm for the processes in the group, we can initialize them
   for (int i=0; i<m_group_size; ++i) {
     m_atm_processes[i]->initialize(t0);
@@ -264,7 +264,7 @@ setup_remappers (const FieldRepository<Real, device_type>& field_repo) {
   }
 }
 
-void AtmosphereProcessGroup::run_ (const Real dt) {
+void AtmosphereProcessGroup::run_impl (const Real dt) {
   if (m_group_schedule_type==ScheduleType::Sequential) {
     run_sequential(dt);
   } else {
@@ -365,7 +365,7 @@ void AtmosphereProcessGroup::run_parallel (const Real /* dt */) {
   EKAT_REQUIRE_MSG (false,"Error! Parallel splitting not yet implemented.\n");
 }
 
-void AtmosphereProcessGroup::finalize_ (/* what inputs? */) {
+void AtmosphereProcessGroup::finalize_impl (/* what inputs? */) {
   for (auto atm_proc : m_atm_processes) {
     atm_proc->finalize(/* what inputs? */);
   }

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -209,12 +209,11 @@ void AtmosphereProcessGroup::set_grids (const std::shared_ptr<const GridsManager
   }
 }
 
-void AtmosphereProcessGroup::initialize (const TimeStamp& t0) {
+void AtmosphereProcessGroup::initialize_ (const TimeStamp& t0) {
   // Now that we have the comm for the processes in the group, we can initialize them
   for (int i=0; i<m_group_size; ++i) {
     m_atm_processes[i]->initialize(t0);
   }
-  m_current_ts = t0;
 }
 
 void AtmosphereProcessGroup::
@@ -265,7 +264,7 @@ setup_remappers (const FieldRepository<Real, device_type>& field_repo) {
   }
 }
 
-void AtmosphereProcessGroup::run (const Real dt) {
+void AtmosphereProcessGroup::run_ (const Real dt) {
   if (m_group_schedule_type==ScheduleType::Sequential) {
     run_sequential(dt);
   } else {
@@ -274,20 +273,23 @@ void AtmosphereProcessGroup::run (const Real dt) {
 }
 
 void AtmosphereProcessGroup::run_sequential (const Real dt) {
-  m_current_ts += dt;
+  // Get the timestamp at the beginning of the step and advance it.
+  auto ts = timestamp();
+  ts += dt;
+
   for (int iproc=0; iproc<m_group_size; ++iproc) {
     // Reamp the inputs of this process
     const auto& inputs_remappers = m_inputs_remappers[iproc];
     for (const auto& it : inputs_remappers) {
       const auto& remapper = it.second;
       remapper->remap(true);
-      for (int ifield=0; ifield<remapper->get_num_fields(); ++ifield) {  
+      for (int ifield=0; ifield<remapper->get_num_fields(); ++ifield) {
         const auto& f = remapper->get_tgt_field(ifield);
-        f.get_header_ptr()->get_tracking().update_time_stamp(m_current_ts);
+        f.get_header_ptr()->get_tracking().update_time_stamp(ts);
 #ifdef SCREAM_DEBUG
         // Update the remapped field in the bkp repo
         auto bkp_f = m_bkp_field_repo->get_field(f.get_header().get_identifier());
-        bkp_f.get_header_ptr()->get_tracking().update_time_stamp(m_current_ts);
+        bkp_f.get_header_ptr()->get_tracking().update_time_stamp(ts);
         auto src = f.get_view();
         auto dst = bkp_f.get_view();
         Kokkos::deep_copy(dst,src);
@@ -314,7 +316,7 @@ void AtmosphereProcessGroup::run_sequential (const Real dt) {
                inputs_remappers.at(gn)->has_tgt_field(fid))) {
             // For fields that changed, make sure the time stamp has been updated
             const auto& ts = f.second.get_header().get_tracking().get_time_stamp();
-            EKAT_REQUIRE_MSG(field_is_unchanged || ts==m_current_ts,
+            EKAT_REQUIRE_MSG(field_is_unchanged || ts==timestamp(),
                                "Error! Process '" + atm_proc->name() + "' updated field '" +
                                 fid.get_id_string() + "', but it did not update its time stamp.\n");
           } else {
@@ -345,11 +347,11 @@ void AtmosphereProcessGroup::run_sequential (const Real dt) {
       remapper->remap(true);
       for (int ifield=0; ifield<remapper->get_num_fields(); ++ifield) {
         const auto& f = remapper->get_tgt_field(ifield);
-        f.get_header_ptr()->get_tracking().update_time_stamp(m_current_ts);
+        f.get_header_ptr()->get_tracking().update_time_stamp(ts);
 #ifdef SCREAM_DEBUG
         // Update the remapped field in the bkp repo
         auto bkp_f = m_bkp_field_repo->get_field(f.get_header().get_identifier());
-        bkp_f.get_header_ptr()->get_tracking().update_time_stamp(m_current_ts);
+        bkp_f.get_header_ptr()->get_tracking().update_time_stamp(ts);
         auto src = f.get_view();
         auto dst = bkp_f.get_view();
         Kokkos::deep_copy(dst,src);
@@ -363,7 +365,7 @@ void AtmosphereProcessGroup::run_parallel (const Real /* dt */) {
   EKAT_REQUIRE_MSG (false,"Error! Parallel splitting not yet implemented.\n");
 }
 
-void AtmosphereProcessGroup::finalize (/* what inputs? */) {
+void AtmosphereProcessGroup::finalize_ (/* what inputs? */) {
   for (auto atm_proc : m_atm_processes) {
     atm_proc->finalize(/* what inputs? */);
   }

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -87,9 +87,9 @@ public:
 protected:
 
   // The initialization, run, and finalization methods
-  void initialize_ (const TimeStamp& t0);
-  void run_        (const Real dt);
-  void finalize_   (/* what inputs? */);
+  void initialize_impl (const TimeStamp& t0);
+  void run_impl        (const Real dt);
+  void finalize_impl   (/* what inputs? */);
 
   void run_sequential (const Real dt);
   void run_parallel   (const Real dt);

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -49,11 +49,6 @@ public:
   // Grab the proper grid from the grids manager
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
-  // The initialization, run, and finalization methods
-  void initialize (const TimeStamp& t0);
-  void run        (const Real dt);
-  void finalize   (/* what inputs? */);
-
   void final_setup ();
 
   // Register all fields in the given repo
@@ -90,6 +85,11 @@ public:
   void set_internal_field (const Field<Real, device_type>& f);
 
 protected:
+
+  // The initialization, run, and finalization methods
+  void initialize_ (const TimeStamp& t0);
+  void run_        (const Real dt);
+  void finalize_   (/* what inputs? */);
 
   void run_sequential (const Real dt);
   void run_parallel   (const Real dt);
@@ -159,8 +159,6 @@ protected:
   const FieldRepository<Real, device_type>*   m_bkp_field_repo;
 
 #endif
-
-  TimeStamp                                   m_current_ts;
 };
 
 } // namespace scream

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -40,17 +40,6 @@ public:
   // The communicator associated with this atm process
   const ekat::Comm& get_comm () const { return m_comm; }
 
-  // The initialization method should prepare all stuff needed to import/export from/to
-  // f90 structures.
-  void initialize (const util::TimeStamp& /* t0 */ ) {}
-
-  // The run method is responsible for exporting atm states to the e3sm coupler, and
-  // import surface states from the e3sm coupler.
-  void run (const Real /* dt */) {}
-
-  // Clean up
-  void finalize ( /* inputs */ ) {}
-
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real, device_type>& /* field_repo */) const {}
 
@@ -59,6 +48,17 @@ public:
   const std::set<FieldIdentifier>&  get_computed_fields () const { return m_fids_out; }
 
 protected:
+
+  // The initialization method should prepare all stuff needed to import/export from/to
+  // f90 structures.
+  void initialize_ (const util::TimeStamp& /* t0 */ ) {}
+
+  // The run method is responsible for exporting atm states to the e3sm coupler, and
+  // import surface states from the e3sm coupler.
+  void run_ (const Real /* dt */) {}
+
+  // Clean up
+  void finalize_ ( /* inputs */ ) {}
 
   // Setting the field in the atmosphere process
   void set_required_field_impl (const Field<const Real, device_type>& /* f */) {}

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -51,14 +51,14 @@ protected:
 
   // The initialization method should prepare all stuff needed to import/export from/to
   // f90 structures.
-  void initialize_ (const util::TimeStamp& /* t0 */ ) {}
+  void initialize_impl (const util::TimeStamp& /* t0 */ ) {}
 
   // The run method is responsible for exporting atm states to the e3sm coupler, and
   // import surface states from the e3sm coupler.
-  void run_ (const Real /* dt */) {}
+  void run_impl (const Real /* dt */) {}
 
   // Clean up
-  void finalize_ ( /* inputs */ ) {}
+  void finalize_impl ( /* inputs */ ) {}
 
   // Setting the field in the atmosphere process
   void set_required_field_impl (const Field<const Real, device_type>& /* f */) {}

--- a/components/scream/src/share/util/scream_time_stamp.hpp
+++ b/components/scream/src/share/util/scream_time_stamp.hpp
@@ -6,9 +6,7 @@
 namespace scream {
 namespace util {
 
-// Micro-struct, to hold a time stamp
-// Note: this is NOT to store the current OS time, but rather
-//       the time of the simulation.
+// Micro-struct, to hold a simulation time stamp
 class TimeStamp {
 public:
 
@@ -31,7 +29,7 @@ public:
 
   TimeStamp& operator= (const TimeStamp&) = default;
 
-  // This methods will check that time shifts forward
+  // This method checks that time shifts forward (i.e. that seconds is positive)
   TimeStamp& operator+= (const double seconds);
 
 protected:


### PR DESCRIPTION
This change implements a commonly-used C++ pattern in which we override
protected methods (initialize_, run_, finalize_) that are wrapped by
public methods (initialize, run, finalize) that do the timestamp
arithmetic (and whatever else needs doing).

Closes #585