### PR TITLE
[WIP] use bfb functions in shoc.F90

### DIFF
--- a/components/cam/src/physics/cam/bfb_math.inc
+++ b/components/cam/src/physics/cam/bfb_math.inc
@@ -14,6 +14,7 @@
 
 #define bfb_square(val) ((val)*(val))
 #define bfb_cube(val) ((val)*(val)*(val))
+#define bfb_quad(val) (bfb_square(bfb_square(val)))
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
 #  define bfb_pow(base, exp) cxx_pow(base, exp)

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1895,7 +1895,7 @@ subroutine clipping_diag_third_shoc_moments(&
 
       tsign = 1._rtype
       theterm = w_sec_zi(i,k)
-      cond = w3clip * bfb_sqrt(2._rtype * theterm**3)
+      cond = w3clip * bfb_sqrt(2._rtype * bfb_cube(theterm))
       if (w3(i,k) .lt. 0) tsign = -1._rtype
       if (tsign * w3(i,k) .gt. cond) w3(i,k) = tsign * cond
 

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1714,7 +1714,7 @@ subroutine fterms_input_for_diag_third_shoc_moment(&
   thedz2 = 1._rtype/(dz_zt+dz_zt_kc)
 
   iso       = isotropy_zi
-  isosqrd   = iso**2
+  isosqrd   = bfb_square(iso)
   buoy_sgs2 = isosqrd*brunt_zi
   bet2      = ggr/thetal_zi
 
@@ -1751,10 +1751,10 @@ subroutine f0_to_f5_diag_third_shoc_moment(&
   wsec_diff     = w_sec_kc    - w_sec
   tke_diff      = tke_kc      - tke
 
-  f0 = thedz2 * bet2**3 * iso**4 * wthl_sec * &
+  f0 = thedz2 * bfb_cube(bet2) * bfb_pow(iso,4._rtype) * wthl_sec * &
        thl_sec_diff
 
-  f1 = thedz2 * bet2**2 * iso**3 * (wthl_sec * &
+  f1 = thedz2 * bfb_square(bet2) * bfb_cube(iso) * (wthl_sec * &
        wthl_sec_diff + 0.5_rtype * &
        w_sec_zi*thl_sec_diff)
 
@@ -1788,6 +1788,7 @@ subroutine omega_terms_diag_third_shoc_moment(&
   !intent-out
   real(rtype), intent(out) :: omega0, omega1, omega2
 
+
   real(rtype), parameter :: a4=2.4_rtype/(3._rtype*c_diag_3rd_mom+5._rtype)
   real(rtype), parameter :: a5=0.6_rtype/(c_diag_3rd_mom*(3._rtype+5._rtype*c_diag_3rd_mom))
 
@@ -1812,10 +1813,13 @@ subroutine x_y_terms_diag_third_shoc_moment(&
   !intent-outs
   real(rtype), intent(out) :: x0, y0, x1, y1
 
-  real(rtype), parameter :: a0=(0.52_rtype*c_diag_3rd_mom**(-2))/(c_diag_3rd_mom-2._rtype)
-  real(rtype), parameter :: a1=0.87_rtype/(c_diag_3rd_mom**2)
-  real(rtype), parameter :: a2=0.5_rtype/c_diag_3rd_mom
-  real(rtype), parameter :: a3=0.6_rtype/(c_diag_3rd_mom*(c_diag_3rd_mom-2._rtype))
+  ! local variables
+  real(rtype) :: a0, a1, a2, a3
+
+  a0 = (0.52_rtype*bfb_pow(c_diag_3rd_mom,-2._rtype))/(c_diag_3rd_mom-2._rtype)
+  a1 = 0.87_rtype/bfb_square(c_diag_3rd_mom)
+  a2 = 0.5_rtype/c_diag_3rd_mom
+  a3 = 0.6_rtype/(c_diag_3rd_mom*(c_diag_3rd_mom-2._rtype))
 
   x0 = (a2 * buoy_sgs2 * (1._rtype - a3 * buoy_sgs2)) / &
        (1._rtype - (a1 + a3) * buoy_sgs2)
@@ -1891,7 +1895,7 @@ subroutine clipping_diag_third_shoc_moments(&
 
       tsign = 1._rtype
       theterm = w_sec_zi(i,k)
-      cond = w3clip * sqrt(2._rtype * theterm**3)
+      cond = w3clip * bfb_sqrt(2._rtype * theterm**3)
       if (w3(i,k) .lt. 0) tsign = -1._rtype
       if (tsign * w3(i,k) .gt. cond) w3(i,k) = tsign * cond
 

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1751,7 +1751,7 @@ subroutine f0_to_f5_diag_third_shoc_moment(&
   wsec_diff     = w_sec_kc    - w_sec
   tke_diff      = tke_kc      - tke
 
-  f0 = thedz2 * bfb_cube(bet2) * bfb_pow(iso,4._rtype) * wthl_sec * &
+  f0 = thedz2 * bfb_cube(bet2) * bfb_quad(iso) * wthl_sec * &
        thl_sec_diff
 
   f1 = thedz2 * bfb_square(bet2) * bfb_cube(iso) * (wthl_sec * &


### PR DESCRIPTION
After this, I'm creating a PR for porting `compute_diag_third_shoc_moment` and I need to change some subroutines in shoc.F90 to use bfb_*() functions.