### PR TITLE
SHOC bug fix for Murphy/Koop implementation (and unrelated property test fix)

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -2491,7 +2491,7 @@ subroutine shoc_assumed_pdf_compute_qs(&
   esval1_1=0._rtype
   esval1_2=0._rtype
 
-  esval1_1=MurphyKoop_svp(Tl1_1, liquid)*100._rtype
+  esval1_1=MurphyKoop_svp(Tl1_1, liquid)
   lstarn1=lcond
 
   qs1=0.622_rtype*esval1_1/max(esval1_1,pval-esval1_1)
@@ -2504,7 +2504,7 @@ subroutine shoc_assumed_pdf_compute_qs(&
     qs2=qs1
     beta2=beta1
   else
-    esval1_2=MurphyKoop_svp(Tl1_2, liquid)*100._rtype
+    esval1_2=MurphyKoop_svp(Tl1_2, liquid)
     qs2=0.622_rtype*esval1_2/max(esval1_2,pval-esval1_2)
     beta2=(rgas/rv)*(lstarn2/(rgas*Tl1_2))*(lstarn2/(cp*Tl1_2))
   endif

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_compute_liqflux_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_compute_liqflux_tests.cpp
@@ -42,6 +42,8 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompLiqFlux {
     static constexpr Real ql1 = 0;
     // Define vertical velocity of second gaussian
     static constexpr Real w1_2 = -1;
+    // Define grid mean vertical velocity [m/s]
+    static constexpr Real w_first = 0;
 
     // Initialize data structure for bridging to F90
     SHOCPDFcompliqfluxData SDS;
@@ -52,6 +54,7 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompLiqFlux {
     SDS.ql1 = ql1;
     SDS.w1_2 = w1_2;
     SDS.ql2 = ql1;
+    SDS.w_first = w_first;
 
     // Verify there is no liquid water in inputs
     REQUIRE(SDS.ql1 == 0);
@@ -73,15 +76,20 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompLiqFlux {
     static constexpr Real w1_1_conv = 3;
     // Define liquid water loading gaussian one
     static constexpr Real ql1_conv = 0.004;
+    // Define liquid water loading gaussian two
+    static constexpr Real ql2_conv = 0;
     // Define vertical velocity of second gaussian
     static constexpr Real w1_2_conv = -0.1;
+    // Define grid mean vertical velocity [m/s]
+    static constexpr Real w_first_conv = 0.1;
 
     // Load input data
     SDS.a = a_conv;
     SDS.w1_1 = w1_1_conv;
     SDS.ql1 = ql1_conv;
     SDS.w1_2 = w1_2_conv;
-    SDS.ql2 = ql1_conv;
+    SDS.ql2 = ql2_conv;
+    SDS.w_first = w_first_conv;
 
     // Verify input data is as we expect for convective conditions
     REQUIRE(SDS.a < 0.5);
@@ -109,6 +117,8 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompLiqFlux {
     static constexpr Real w1_2_neg = -2.0;
     // Define liquid water loading gaussian two
     static constexpr Real ql2_neg = 0.004;
+    // Define grid mean vertical velocity [m/s]
+    static constexpr Real w_first_neg = -0.1;
 
     // Load input data
     SDS.a = a_neg;
@@ -116,6 +126,7 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompLiqFlux {
     SDS.ql1 = ql1_neg;
     SDS.w1_2 = w1_2_neg;
     SDS.ql2 = ql2_neg;
+    SDS.w_first = w_first_neg;
 
     // Verify input data is as we expect for convective conditions
     REQUIRE(SDS.a > 0.5);


### PR DESCRIPTION
This PR address two unrelated SHOC issues reported and closes #600 

1) With the implementation of Murphy Koop in PR #588 the 100 factor unit conversion is no longer needed since Murphy Koop returns in units of [Pa], unlike the old Flatau implementation.  This bug was uncovered by a failing SHOC property test.

2) It was also reported that the liquid water flux property test was failing when use with valgrind.  This was due to the grid mean vertical velocity not being initialized in any of the tests.  This has been fixed.