### PR TITLE
[WIP] Port compute_diag third_shoc_moment

### DIFF
--- a/components/cam/src/physics/cam/bfb_math.inc
+++ b/components/cam/src/physics/cam/bfb_math.inc
@@ -14,6 +14,7 @@
 
 #define bfb_square(val) ((val)*(val))
 #define bfb_cube(val) ((val)*(val)*(val))
+#define bfb_quad(val) (bfb_square(bfb_square(val)))
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
 #  define bfb_pow(base, exp) cxx_pow(base, exp)

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1595,6 +1595,10 @@ subroutine compute_diag_third_shoc_moment(&
           wthv_sec_zi,&                       ! Input
           w3)                                 ! Output
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  use shoc_iso_f, only: compute_diag_third_shoc_moment_f
+#endif
+  
   implicit none
 ! INPUT VARIABLES
   ! number of SHOC columns
@@ -1642,6 +1646,19 @@ subroutine compute_diag_third_shoc_moment(&
   real(rtype) :: buoy_sgs2, bet2
   real(rtype) :: f0, f1, f2, f3, f4, f5
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  if (use_cxx) then
+    call compute_diag_third_shoc_moment_f(shcol,nlev,nlevi, &                 ! Input
+                                          w_sec,thl_sec, qw_sec, qwthl_sec,&  ! Input
+                                          wthl_sec, tke, dz_zt, dz_zi,&       ! Input
+                                          zt_grid,zi_grid, isotropy_zi,&      ! Input
+                                          brunt_zi,w_sec_zi,thetal_zi,&       ! Input
+                                          wthv_sec_zi,&                       ! Input
+                                          w3)                                 ! Output
+    return
+  endif
+#endif
+  
   ! set lower condition
   w3(:,nlevi) = 0._rtype
 
@@ -1787,7 +1804,6 @@ subroutine omega_terms_diag_third_shoc_moment(&
 
   !intent-out
   real(rtype), intent(out) :: omega0, omega1, omega2
-
 
   real(rtype), parameter :: a4=2.4_rtype/(3._rtype*c_diag_3rd_mom+5._rtype)
   real(rtype), parameter :: a5=0.6_rtype/(c_diag_3rd_mom*(3._rtype+5._rtype*c_diag_3rd_mom))

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1895,7 +1895,7 @@ subroutine clipping_diag_third_shoc_moments(&
 
       tsign = 1._rtype
       theterm = w_sec_zi(i,k)
-      cond = w3clip * bfb_sqrt(2._rtype * theterm**3)
+      cond = w3clip * bfb_sqrt(2._rtype * bfb_cube(theterm))
       if (w3(i,k) .lt. 0) tsign = -1._rtype
       if (tsign * w3(i,k) .gt. cond) w3(i,k) = tsign * cond
 

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1714,7 +1714,7 @@ subroutine fterms_input_for_diag_third_shoc_moment(&
   thedz2 = 1._rtype/(dz_zt+dz_zt_kc)
 
   iso       = isotropy_zi
-  isosqrd   = iso**2
+  isosqrd   = bfb_square(iso)
   buoy_sgs2 = isosqrd*brunt_zi
   bet2      = ggr/thetal_zi
 
@@ -1751,10 +1751,10 @@ subroutine f0_to_f5_diag_third_shoc_moment(&
   wsec_diff     = w_sec_kc    - w_sec
   tke_diff      = tke_kc      - tke
 
-  f0 = thedz2 * bet2**3 * iso**4 * wthl_sec * &
+  f0 = thedz2 * bfb_cube(bet2) * bfb_pow(iso,4._rtype) * wthl_sec * &
        thl_sec_diff
 
-  f1 = thedz2 * bet2**2 * iso**3 * (wthl_sec * &
+  f1 = thedz2 * bfb_square(bet2) * bfb_cube(iso) * (wthl_sec * &
        wthl_sec_diff + 0.5_rtype * &
        w_sec_zi*thl_sec_diff)
 
@@ -1788,6 +1788,7 @@ subroutine omega_terms_diag_third_shoc_moment(&
   !intent-out
   real(rtype), intent(out) :: omega0, omega1, omega2
 
+
   real(rtype), parameter :: a4=2.4_rtype/(3._rtype*c_diag_3rd_mom+5._rtype)
   real(rtype), parameter :: a5=0.6_rtype/(c_diag_3rd_mom*(3._rtype+5._rtype*c_diag_3rd_mom))
 
@@ -1812,10 +1813,13 @@ subroutine x_y_terms_diag_third_shoc_moment(&
   !intent-outs
   real(rtype), intent(out) :: x0, y0, x1, y1
 
-  real(rtype), parameter :: a0=(0.52_rtype*c_diag_3rd_mom**(-2))/(c_diag_3rd_mom-2._rtype)
-  real(rtype), parameter :: a1=0.87_rtype/(c_diag_3rd_mom**2)
-  real(rtype), parameter :: a2=0.5_rtype/c_diag_3rd_mom
-  real(rtype), parameter :: a3=0.6_rtype/(c_diag_3rd_mom*(c_diag_3rd_mom-2._rtype))
+  ! local variables
+  real(rtype) :: a0, a1, a2, a3
+
+  a0 = (0.52_rtype*bfb_pow(c_diag_3rd_mom,-2._rtype))/(c_diag_3rd_mom-2._rtype)
+  a1 = 0.87_rtype/bfb_square(c_diag_3rd_mom)
+  a2 = 0.5_rtype/c_diag_3rd_mom
+  a3 = 0.6_rtype/(c_diag_3rd_mom*(c_diag_3rd_mom-2._rtype))
 
   x0 = (a2 * buoy_sgs2 * (1._rtype - a3 * buoy_sgs2)) / &
        (1._rtype - (a1 + a3) * buoy_sgs2)
@@ -1891,7 +1895,7 @@ subroutine clipping_diag_third_shoc_moments(&
 
       tsign = 1._rtype
       theterm = w_sec_zi(i,k)
-      cond = w3clip * sqrt(2._rtype * theterm**3)
+      cond = w3clip * bfb_sqrt(2._rtype * theterm**3)
       if (w3(i,k) .lt. 0) tsign = -1._rtype
       if (tsign * w3(i,k) .gt. cond) w3(i,k) = tsign * cond
 

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1570,11 +1570,10 @@ subroutine diag_third_shoc_moments(&
   !Diagnose the third moment of the vertical-velocity
   call compute_diag_third_shoc_moment(&
           shcol,nlev,nlevi, &                 ! Input
-          w_sec,thl_sec, qw_sec, qwthl_sec,&  ! Input
+          w_sec,thl_sec,&                     ! Input
           wthl_sec, tke, dz_zt, dz_zi,&       ! Input
-          zt_grid,zi_grid, isotropy_zi,&      ! Input
+          isotropy_zi,&                       ! Input
           brunt_zi,w_sec_zi,thetal_zi,&       ! Input
-          wthv_sec_zi,&                       ! Input
           w3)                                 ! Output
 
   ! perform clipping to prevent unrealistically large values from occuring
@@ -1587,13 +1586,11 @@ subroutine diag_third_shoc_moments(&
 end subroutine diag_third_shoc_moments
 
 subroutine compute_diag_third_shoc_moment(&
-          shcol,nlev,nlevi, &                 ! Input
-          w_sec,thl_sec, qw_sec, qwthl_sec,&  ! Input
-          wthl_sec, tke, dz_zt, dz_zi,&       ! Input
-          zt_grid,zi_grid, isotropy_zi,&      ! Input
-          brunt_zi,w_sec_zi,thetal_zi,&       ! Input
-          wthv_sec_zi,&                       ! Input
-          w3)                                 ! Output
+          shcol, nlev, nlevi, w_sec, thl_sec, & ! Input
+          wthl_sec, tke, dz_zt, dz_zi, &        ! Input
+          isotropy_zi, brunt_zi,w_sec_zi, &     ! Input
+          thetal_zi, &                          ! Input
+          w3)                                   ! Output
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
   use shoc_iso_f, only: compute_diag_third_shoc_moment_f
@@ -1611,10 +1608,6 @@ subroutine compute_diag_third_shoc_moment(&
   real(rtype), intent(in) :: w_sec(shcol,nlev)
   ! second order liquid wat. potential temperature [K^2]
   real(rtype), intent(in) :: thl_sec(shcol,nlevi)
-  ! second order total water mixing ratio [kg2/kg2]
-  real(rtype), intent(in) :: qw_sec(shcol,nlevi)
-  ! covariance of temp and moisture [K kg/kg]
-  real(rtype), intent(in) :: qwthl_sec(shcol,nlevi)
   ! vertical flux of heat [K m/s]
   real(rtype), intent(in) :: wthl_sec(shcol,nlevi)
   ! turbulent kinetic energy [m2/s2]
@@ -1623,17 +1616,12 @@ subroutine compute_diag_third_shoc_moment(&
   real(rtype), intent(in) :: dz_zt(shcol,nlev)
   ! thickness centered on interface grid [m]
   real(rtype), intent(in) :: dz_zi(shcol,nlevi)
-  ! heights of thermodynamics points [m]
-  real(rtype), intent(in) :: zt_grid(shcol,nlev)
-  ! heights of interface points [m]
-  real(rtype), intent(in) :: zi_grid(shcol,nlevi)
 
   !Interpolated varaibles
   real(rtype), intent(in) :: isotropy_zi(shcol,nlevi)
   real(rtype), intent(in) :: brunt_zi(shcol,nlevi)
   real(rtype), intent(in) :: w_sec_zi(shcol,nlevi)
   real(rtype), intent(in) :: thetal_zi(shcol,nlevi)
-  real(rtype), intent(in) :: wthv_sec_zi(shcol,nlevi)
   ! third moment of vertical velocity
   real(rtype), intent(out) :: w3(shcol,nlevi)
 ! LOCAL VARIABLES
@@ -1648,12 +1636,10 @@ subroutine compute_diag_third_shoc_moment(&
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
   if (use_cxx) then
-    call compute_diag_third_shoc_moment_f(shcol,nlev,nlevi, &                 ! Input
-                                          w_sec,thl_sec, qw_sec, qwthl_sec,&  ! Input
-                                          wthl_sec, tke, dz_zt, dz_zi,&       ! Input
-                                          zt_grid,zi_grid, isotropy_zi,&      ! Input
-                                          brunt_zi,w_sec_zi,thetal_zi,&       ! Input
-                                          wthv_sec_zi,&                       ! Input
+    call compute_diag_third_shoc_moment_f(shcol,nlev,nlevi,w_sec,thl_sec, &   ! Input
+                                          wthl_sec, tke, dz_zt, dz_zi, &      ! Input
+                                          isotropy_zi,brunt_zi,w_sec_zi, &    ! Input
+                                          thetal_zi, &                        ! Input
                                           w3)                                 ! Output
     return
   endif

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1751,7 +1751,7 @@ subroutine f0_to_f5_diag_third_shoc_moment(&
   wsec_diff     = w_sec_kc    - w_sec
   tke_diff      = tke_kc      - tke
 
-  f0 = thedz2 * bfb_cube(bet2) * bfb_pow(iso,4._rtype) * wthl_sec * &
+  f0 = thedz2 * bfb_cube(bet2) * bfb_quad(iso) * wthl_sec * &
        thl_sec_diff
 
   f1 = thedz2 * bfb_square(bet2) * bfb_cube(iso) * (wthl_sec * &

--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -33,6 +33,7 @@ if (NOT CUDA_BUILD)
     shoc_update_host_dse.cpp
     shoc_calc_shoc_varorcovar.cpp
     shoc_calc_shoc_vertflux.cpp
+    shoc_compute_diag_third_shoc_moment.cpp
   )
 endif()
 

--- a/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment.cpp
+++ b/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment.cpp
@@ -1,0 +1,14 @@
+#include "shoc_compute_diag_third_shoc_moment_impl.hpp"
+#include "share/scream_types.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation using the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream

--- a/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
@@ -40,14 +40,6 @@ void Functions<S,D>
   w3(nlevi_pack-1)[last_pack_entry] = 0.0;
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
-    // Local variables
-    Spack
-      thedz, thedz2, iso, isosqrd, buoy_sgs2, bet2,
-      f0, f1, f2, f3, f4, f5,
-      omega0, omega1, omega2,
-      x0, x1, y0, y1,
-      aa0, aa1;
-
     // Constants
     const auto c_diag_3rd_mom = scream::shoc::Constants<Scalar>::c_diag_3rd_mom;
     const Scalar a0 = (sp(0.52)*std::pow(c_diag_3rd_mom,-2.0))/(c_diag_3rd_mom-2.0);
@@ -79,13 +71,13 @@ void Functions<S,D>
     ekat::pack::index_and_shift<-1>(s_tke, range_pack2, tke_k, tke_km1);
 
     // Compute inputs for computing f0 to f5 terms
-    thedz  = 1/dz_zi(k);
-    thedz2 = 1/(dz_zt_k+dz_zt_km1);
+    const auto thedz  = 1/dz_zi(k);
+    const auto thedz2 = 1/(dz_zt_k+dz_zt_km1);
 
-    iso       = isotropy_zi(k);
-    isosqrd   = ekat::pack::square(iso);
-    buoy_sgs2 = isosqrd*brunt_zi(k);
-    bet2      = C::gravit/thetal_zi(k);
+    const auto iso       = isotropy_zi(k);
+    const auto isosqrd   = ekat::pack::square(iso);
+    const auto buoy_sgs2 = isosqrd*brunt_zi(k);
+    const auto bet2      = C::gravit/thetal_zi(k);
 
     // Compute f0 to f5 terms
     const Spack thl_sec_diff = thl_sec_km1 - thl_sec_kp1;
@@ -93,27 +85,27 @@ void Functions<S,D>
     const Spack wsec_diff = w_sec_km1 - w_sec(k);
     const Spack tke_diff = tke_km1 - tke(k);
 
-    f0 = thedz2*ekat::pack::cube(bet2)*((iso*iso)*(iso*iso))*wthl_sec_k*thl_sec_diff;
-    f1 = thedz2*ekat::pack::square(bet2)*ekat::pack::cube(iso)*(wthl_sec_k*wthl_sec_diff+sp(0.5)*w_sec_zi(k)*thl_sec_diff);
-    f2 = thedz*bet2*isosqrd*wthl_sec_k*wsec_diff+2.0*thedz2*bet2*isosqrd*w_sec_zi(k)*wthl_sec_diff;
-    f3 = thedz2*bet2*isosqrd*w_sec_zi(k)*wthl_sec_diff+thedz*bet2*isosqrd*(wthl_sec_k*tke_diff);
-    f4 = thedz*iso*w_sec_zi(k)*(wsec_diff+tke_diff);
-    f5 = thedz*iso*w_sec_zi(k)*wsec_diff;
+    const auto f0 = thedz2*ekat::pack::cube(bet2)*((iso*iso)*(iso*iso))*wthl_sec_k*thl_sec_diff;
+    const auto f1 = thedz2*ekat::pack::square(bet2)*ekat::pack::cube(iso)*(wthl_sec_k*wthl_sec_diff+sp(0.5)*w_sec_zi(k)*thl_sec_diff);
+    const auto f2 = thedz*bet2*isosqrd*wthl_sec_k*wsec_diff+2.0*thedz2*bet2*isosqrd*w_sec_zi(k)*wthl_sec_diff;
+    const auto f3 = thedz2*bet2*isosqrd*w_sec_zi(k)*wthl_sec_diff+thedz*bet2*isosqrd*(wthl_sec_k*tke_diff);
+    const auto f4 = thedz*iso*w_sec_zi(k)*(wsec_diff+tke_diff);
+    const auto f5 = thedz*iso*w_sec_zi(k)*wsec_diff;
 
     // Compute omega terms
-    omega0 = a4/Spack(1.0-a5*buoy_sgs2);
-    omega1 = omega0/(2.0*c_diag_3rd_mom);
-    omega2 = omega1*f3+sp(5.0/4.0)*omega0*f4;
+    const auto omega0 = a4/Spack(1.0-a5*buoy_sgs2);
+    const auto omega1 = omega0/(2.0*c_diag_3rd_mom);
+    const auto omega2 = omega1*f3+sp(5.0/4.0)*omega0*f4;
 
     // Compute the x0, y0, x1, y1 terms
-    x0 = (a2*buoy_sgs2*(Spack(1.0)-a3*buoy_sgs2))/(Spack(1.0)-(a1+a3)*buoy_sgs2);
-    y0 = (2.0*a2*buoy_sgs2*x0)/(Spack(1.0)-a3*buoy_sgs2);
-    x1 = (a0*f0+a1*f1+a2*(Spack(1.0)-a3*buoy_sgs2)*f2)/(Spack(1.0)-(a1+a3)*buoy_sgs2);
-    y1 = (2.0*a2*(buoy_sgs2*x1+(a0/a1)*f0+f1))/(Spack(1.0)-a3*buoy_sgs2);
+    const auto x0 = (a2*buoy_sgs2*(Spack(1.0)-a3*buoy_sgs2))/(Spack(1.0)-(a1+a3)*buoy_sgs2);
+    const auto y0 = (2.0*a2*buoy_sgs2*x0)/(Spack(1.0)-a3*buoy_sgs2);
+    const auto x1 = (a0*f0+a1*f1+a2*(Spack(1.0)-a3*buoy_sgs2)*f2)/(Spack(1.0)-(a1+a3)*buoy_sgs2);
+    const auto y1 = (2.0*a2*(buoy_sgs2*x1+(a0/a1)*f0+f1))/(Spack(1.0)-a3*buoy_sgs2);
 
     // Compute the aa0, aa1 terms
-    aa0 = omega0*x0+omega1*y0;
-    aa1 = omega0*x1+omega1*y1+omega2;
+    const auto aa0 = omega0*x0+omega1*y0;
+    const auto aa1 = omega0*x1+omega1*y1+omega2;
 
     // Finally, compute the third moment of w
     w3(k).set(range_pack1 > 0 && range_pack1 < nlev,

--- a/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
@@ -25,8 +25,8 @@ void Functions<S,D>
   const uview_1d<const Spack>& thetal_zi,
   const uview_1d<Spack>& w3)
 {
-  const Int nlev_pack = ekat::pack::npack<Spack>(nlev);
-  const Int nlevi_pack = ekat::pack::npack<Spack>(nlevi);
+  const Int nlev_pack = ekat::npack<Spack>(nlev);
+  const Int nlevi_pack = ekat::npack<Spack>(nlevi);
 
   // Scalarize views for shifts
   const auto s_dz_zt = scalarize(dz_zt);
@@ -57,25 +57,25 @@ void Functions<S,D>
       w_sec_k,    w_sec_km1,
       tke_k,      tke_km1;
 
-    auto range_pack1 = ekat::pack::range<IntSmallPack>(k*Spack::n);
+    auto range_pack1 = ekat::range<IntSmallPack>(k*Spack::n);
     auto range_pack2 = range_pack1;
     // index for _km1 should never go below 0 and _kp1 should never go above nlevi
     range_pack2.set(range_pack1 < 1 || range_pack1 >= nlevi, 1);
 
-    ekat::pack::index_and_shift<-1>(s_dz_zt, range_pack2, dz_zt_k, dz_zt_km1);
-    ekat::pack::index_and_shift<-1>(s_wthl_sec, range_pack2, wthl_sec_k, wthl_sec_km1);
-    ekat::pack::index_and_shift<1> (s_wthl_sec, range_pack2, wthl_sec_k, wthl_sec_kp1);
-    ekat::pack::index_and_shift<-1>(s_thl_sec, range_pack2, thl_sec_k, thl_sec_km1);
-    ekat::pack::index_and_shift<1> (s_thl_sec, range_pack2, thl_sec_k, thl_sec_kp1);
-    ekat::pack::index_and_shift<-1>(s_w_sec, range_pack2, w_sec_k, w_sec_km1);
-    ekat::pack::index_and_shift<-1>(s_tke, range_pack2, tke_k, tke_km1);
+    ekat::index_and_shift<-1>(s_dz_zt, range_pack2, dz_zt_k, dz_zt_km1);
+    ekat::index_and_shift<-1>(s_wthl_sec, range_pack2, wthl_sec_k, wthl_sec_km1);
+    ekat::index_and_shift<1> (s_wthl_sec, range_pack2, wthl_sec_k, wthl_sec_kp1);
+    ekat::index_and_shift<-1>(s_thl_sec, range_pack2, thl_sec_k, thl_sec_km1);
+    ekat::index_and_shift<1> (s_thl_sec, range_pack2, thl_sec_k, thl_sec_kp1);
+    ekat::index_and_shift<-1>(s_w_sec, range_pack2, w_sec_k, w_sec_km1);
+    ekat::index_and_shift<-1>(s_tke, range_pack2, tke_k, tke_km1);
 
     // Compute inputs for computing f0 to f5 terms
     const auto thedz  = 1/dz_zi(k);
     const auto thedz2 = 1/(dz_zt_k+dz_zt_km1);
 
     const auto iso       = isotropy_zi(k);
-    const auto isosqrd   = ekat::pack::square(iso);
+    const auto isosqrd   = ekat::square(iso);
     const auto buoy_sgs2 = isosqrd*brunt_zi(k);
     const auto bet2      = C::gravit/thetal_zi(k);
 
@@ -85,8 +85,8 @@ void Functions<S,D>
     const Spack wsec_diff = w_sec_km1 - w_sec(k);
     const Spack tke_diff = tke_km1 - tke(k);
 
-    const auto f0 = thedz2*ekat::pack::cube(bet2)*((iso*iso)*(iso*iso))*wthl_sec_k*thl_sec_diff;
-    const auto f1 = thedz2*ekat::pack::square(bet2)*ekat::pack::cube(iso)*(wthl_sec_k*wthl_sec_diff+sp(0.5)*w_sec_zi(k)*thl_sec_diff);
+    const auto f0 = thedz2*ekat::cube(bet2)*((iso*iso)*(iso*iso))*wthl_sec_k*thl_sec_diff;
+    const auto f1 = thedz2*ekat::square(bet2)*ekat::cube(iso)*(wthl_sec_k*wthl_sec_diff+sp(0.5)*w_sec_zi(k)*thl_sec_diff);
     const auto f2 = thedz*bet2*isosqrd*wthl_sec_k*wsec_diff+2*thedz2*bet2*isosqrd*w_sec_zi(k)*wthl_sec_diff;
     const auto f3 = thedz2*bet2*isosqrd*w_sec_zi(k)*wthl_sec_diff+thedz*bet2*isosqrd*(wthl_sec_k*tke_diff);
     const auto f4 = thedz*iso*w_sec_zi(k)*(wsec_diff+tke_diff);

--- a/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
@@ -37,17 +37,17 @@ void Functions<S,D>
 
   // Set lower condition: w3(i,nlevi) = 0
   const Int last_pack_entry = (nlevi%Spack::n == 0 ? Spack::n-1 : nlevi%Spack::n-1);
-  w3(nlevi_pack-1)[last_pack_entry] = 0.0;
+  w3(nlevi_pack-1)[last_pack_entry] = 0;
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
     // Constants
     const auto c_diag_3rd_mom = scream::shoc::Constants<Scalar>::c_diag_3rd_mom;
-    const Scalar a0 = (sp(0.52)*std::pow(c_diag_3rd_mom,-2.0))/(c_diag_3rd_mom-2.0);
+    const Scalar a0 = (sp(0.52)*std::pow(c_diag_3rd_mom,-2))/(c_diag_3rd_mom-2);
     const Scalar a1 = sp(0.87)/(c_diag_3rd_mom*c_diag_3rd_mom);
     const Scalar a2 = sp(0.5)/c_diag_3rd_mom;
-    const Scalar a3 = sp(0.6)/(c_diag_3rd_mom*(c_diag_3rd_mom-2.0));
-    const Scalar a4 = sp(2.4)/(3.0*c_diag_3rd_mom+5.0);
-    const Scalar a5 = sp(0.6)/(c_diag_3rd_mom*(3.0+5.0*c_diag_3rd_mom));
+    const Scalar a3 = sp(0.6)/(c_diag_3rd_mom*(c_diag_3rd_mom-2));
+    const Scalar a4 = sp(2.4)/(3*c_diag_3rd_mom+5);
+    const Scalar a5 = sp(0.6)/(c_diag_3rd_mom*(3+5*c_diag_3rd_mom));
 
     // Calculate shifts
     Spack
@@ -87,21 +87,21 @@ void Functions<S,D>
 
     const auto f0 = thedz2*ekat::pack::cube(bet2)*((iso*iso)*(iso*iso))*wthl_sec_k*thl_sec_diff;
     const auto f1 = thedz2*ekat::pack::square(bet2)*ekat::pack::cube(iso)*(wthl_sec_k*wthl_sec_diff+sp(0.5)*w_sec_zi(k)*thl_sec_diff);
-    const auto f2 = thedz*bet2*isosqrd*wthl_sec_k*wsec_diff+2.0*thedz2*bet2*isosqrd*w_sec_zi(k)*wthl_sec_diff;
+    const auto f2 = thedz*bet2*isosqrd*wthl_sec_k*wsec_diff+2*thedz2*bet2*isosqrd*w_sec_zi(k)*wthl_sec_diff;
     const auto f3 = thedz2*bet2*isosqrd*w_sec_zi(k)*wthl_sec_diff+thedz*bet2*isosqrd*(wthl_sec_k*tke_diff);
     const auto f4 = thedz*iso*w_sec_zi(k)*(wsec_diff+tke_diff);
     const auto f5 = thedz*iso*w_sec_zi(k)*wsec_diff;
 
     // Compute omega terms
-    const auto omega0 = a4/Spack(1.0-a5*buoy_sgs2);
-    const auto omega1 = omega0/(2.0*c_diag_3rd_mom);
+    const auto omega0 = a4/Spack(1-a5*buoy_sgs2);
+    const auto omega1 = omega0/(2*c_diag_3rd_mom);
     const auto omega2 = omega1*f3+sp(5.0/4.0)*omega0*f4;
 
     // Compute the x0, y0, x1, y1 terms
-    const auto x0 = (a2*buoy_sgs2*(Spack(1.0)-a3*buoy_sgs2))/(Spack(1.0)-(a1+a3)*buoy_sgs2);
-    const auto y0 = (2.0*a2*buoy_sgs2*x0)/(Spack(1.0)-a3*buoy_sgs2);
-    const auto x1 = (a0*f0+a1*f1+a2*(Spack(1.0)-a3*buoy_sgs2)*f2)/(Spack(1.0)-(a1+a3)*buoy_sgs2);
-    const auto y1 = (2.0*a2*(buoy_sgs2*x1+(a0/a1)*f0+f1))/(Spack(1.0)-a3*buoy_sgs2);
+    const auto x0 = (a2*buoy_sgs2*(Spack(1)-a3*buoy_sgs2))/(Spack(1)-(a1+a3)*buoy_sgs2);
+    const auto y0 = (2*a2*buoy_sgs2*x0)/(Spack(1)-a3*buoy_sgs2);
+    const auto x1 = (a0*f0+a1*f1+a2*(Spack(1)-a3*buoy_sgs2)*f2)/(Spack(1)-(a1+a3)*buoy_sgs2);
+    const auto y1 = (2*a2*(buoy_sgs2*x1+(a0/a1)*f0+f1))/(Spack(1)-a3*buoy_sgs2);
 
     // Compute the aa0, aa1 terms
     const auto aa0 = omega0*x0+omega1*y0;
@@ -113,7 +113,7 @@ void Functions<S,D>
   });
 
   // Set upper condition: w3(i,0) = 0
-  w3(0)[0] = 0.0;
+  w3(0)[0] = 0;
 }
 
 } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_constants.hpp
+++ b/components/scream/src/physics/shoc/shoc_constants.hpp
@@ -11,10 +11,11 @@ namespace scream {
 template <typename Scalar>
 struct Constants
     {
-      static constexpr Scalar mintke     = 0.0004;  // Minimum TKE [m2/s2]
-      static constexpr Scalar maxtke     = 50.0;    // Maximum TKE [m2/s2]
-      static constexpr Scalar maxlen     = 20000.0; // Upper limit for mixing length [m]
-      static constexpr Scalar length_fac = 0.5;     // Mixing length scaling parameter
+      static constexpr Scalar mintke         = 0.0004;  // Minimum TKE [m2/s2]
+      static constexpr Scalar maxtke         = 50.0;    // Maximum TKE [m2/s2]
+      static constexpr Scalar maxlen         = 20000.0; // Upper limit for mixing length [m]
+      static constexpr Scalar length_fac     = 0.5;     // Mixing length scaling parameter
+      static constexpr Scalar c_diag_3rd_mom = 7.0;     // Coefficient for diag third moment parameters
     };
 
   } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -146,6 +146,7 @@ struct Functions
 # include "shoc_calc_shoc_vertflux_impl.hpp"
 # include "shoc_diag_second_moments_srf_impl.hpp"
 # include "shoc_diag_second_moments_ubycond_impl.hpp"
+# include "shoc_clipping_diag_third_shoc_moments_impl.hpp"
 # include "shoc_update_host_dse_impl.hpp"
 # include "shoc_pblintd_init_pot_impl.hpp"
 #endif

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -2,6 +2,7 @@
 #define SHOC_FUNCTIONS_HPP
 
 #include "physics/share/physics_constants.hpp"
+#include "physics/shoc/shoc_constants.hpp"
 
 #include "share/scream_types.hpp"
 
@@ -97,6 +98,24 @@ struct Functions
   static void shoc_diag_second_moments_ubycond(
     Scalar& thl_sec, Scalar& qw_sec, Scalar& wthl_sec, Scalar& wqw_sec,
     Scalar& qwthl_sec, Scalar& uw_sec, Scalar& vw_sec, Scalar& wtke_sec);
+
+  KOKKOS_FUNCTION
+  static void compute_diag_third_shoc_moment(
+    const MemberType& team,
+    const Int& nlev,
+    const Int& nlevi,
+    const uview_1d<const Spack>& w_sec,
+    const uview_1d<const Spack>& thl_sec,
+    const uview_1d<const Spack>& wthl_sec,
+    const uview_1d<const Spack>& tke,
+    const uview_1d<const Spack>& dz_zt,
+    const uview_1d<const Spack>& dz_zi,
+    const uview_1d<const Spack>& isotropy_zi,
+    const uview_1d<const Spack>& brunt_zi,
+    const uview_1d<const Spack>& w_sec_zi,
+    const uview_1d<const Spack>& thetal_zi,
+    const uview_1d<Spack>& w3);
+
 
   KOKKOS_FUNCTION
   static void update_host_dse(

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -146,12 +146,10 @@ void diag_third_shoc_moments_c(Int shoc, Int nlev, Int nlevi, Real *w_sec,
                                Real *zi_grid, Real *w3);
 
 void compute_diag_third_shoc_moment_c(Int shcol, Int nlev, Int nlevi, Real *w_sec,
-                                      Real *thl_sec, Real *qw_sec, Real *qwthl_sec,
-                                      Real *wthl_sec, Real *tke, Real *dz_zt, 
-                                      Real *dz_zi, Real *zt_grid, Real *zi_grid,
-                                      Real *isotropy_zi, Real *brunt_zi, 
-                                      Real *w_sec_zi, Real *thetal_zi, 
-                                      Real *wthv_sec_zi, Real *w3);
+                                      Real *thl_sec, Real *wthl_sec, Real *tke,
+                                      Real *dz_zt, Real *dz_zi, Real *isotropy_zi,
+                                      Real *brunt_zi,  Real *w_sec_zi, Real *thetal_zi,
+                                      Real *w3);
 
 void linear_interp_c(Real *x1, Real *x2, Real *y1, Real *y2, Int km1,
                      Int km2, Int ncol, Real minthresh);
@@ -487,10 +485,8 @@ void compute_diag_third_shoc_moment(SHOCCompThirdMomData &d) {
   shoc_init(d.nlev(), true);
   d.transpose<ekat::TransposeDirection::c2f>();
   compute_diag_third_shoc_moment_c(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,
-                                   d.qw_sec,d.qwthl_sec,d.wthl_sec,d.tke,d.dz_zt,
-                                   d.dz_zi,d.zt_grid,d.zi_grid,d.isotropy_zi,
-                                   d.brunt_zi,d.w_sec_zi,d.thetal_zi,d.wthv_sec_zi,
-                                   d.w3);
+                                   d.wthl_sec,d.tke,d.dz_zt,d.dz_zi,d.isotropy_zi,
+                                   d.brunt_zi,d.w_sec_zi,d.thetal_zi,d.w3);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 
@@ -794,19 +790,11 @@ void shoc_diag_second_moments_ubycond_f(Int shcol, Real* thl, Real* qw, Real* wt
 }
 
 void compute_diag_third_shoc_moment_f(Int shcol, Int nlev, Int nlevi, Real* w_sec,
-                                      Real* thl_sec, Real* qw_sec, Real* qwthl_sec,
-                                      Real* wthl_sec, Real* tke, Real* dz_zt,
-                                      Real* dz_zi, Real* zt_grid, Real* zi_grid,
-                                      Real* isotropy_zi, Real* brunt_zi, Real* w_sec_zi,
-                                      Real* thetal_zi, Real* wthv_sec_zi, Real* w3)
+                                      Real* thl_sec, Real* wthl_sec, Real* tke,
+                                      Real* dz_zt, Real* dz_zi, Real* isotropy_zi,
+                                      Real* brunt_zi, Real* w_sec_zi, Real* thetal_zi,
+                                      Real* w3)
 {
-  // These inputs are unused in the Fortran implementation
-  (void)qw_sec;
-  (void)qwthl_sec;
-  (void)zt_grid;
-  (void)zi_grid;
-  (void)wthv_sec_zi;
-
   using SHF = Functions<Real, DefaultDevice>;
 
   using Spack      = typename SHF::Spack;

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -733,6 +733,12 @@ void shoc_diag_second_moments_srf_f(Int shcol, Real* wthl, Real* uw, Real* vw,
                           Real* ustar2, Real* wstar);
 void shoc_diag_second_moments_ubycond_f(Int shcol, Real* thl, Real* qw, Real* wthl,
                           Real* wqw, Real* qwthl, Real* uw, Real* vw, Real* wtke);
+void compute_diag_third_shoc_moment_f(Int shcol, Int nlev, Int nlevi, Real* w_sec,
+                                      Real* thl_sec, Real* qw_sec, Real* qwthl_sec,
+                                      Real* wthl_sec, Real* tke, Real* dz_zt,
+                                      Real* dz_zi, Real* zt_grid, Real* zi_grid,
+                                      Real* isotropy_zi, Real* brunt_zi, Real* w_sec_zi,
+                                      Real* thetal_zi, Real* wthv_sec_zi, Real* w3);
 void update_host_dse_f(Int shcol, Int nlev, Real* thlm, Real* shoc_ql, Real* exner, Real* zt_grid,
                        Real* phis, Real* host_dse);
 void shoc_pblintd_init_pot_f(Int shcol, Int nlev, Real* thl, Real* ql, Real* q, Real* thv);

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -488,15 +488,15 @@ struct SHOCDiagThirdMomData : public PhysicsTestData {
 //Create data structure to hold data for compute_diag_third_shoc_moment
 struct SHOCCompThirdMomData : public PhysicsTestData {
   // Inputs
-  Real *w_sec, *thl_sec, *qw_sec, *qwthl_sec, *wthl_sec, *tke, *dz_zt;
-  Real *dz_zi, *zt_grid, *zi_grid, *isotropy_zi, *brunt_zi, *w_sec_zi;
-  Real *thetal_zi, *wthv_sec_zi;
+  Real *w_sec, *thl_sec, *wthl_sec, *tke, *dz_zt;
+  Real *dz_zi, *isotropy_zi, *brunt_zi, *w_sec_zi;
+  Real *thetal_zi;
 
   // Output
   Real *w3;
 
   SHOCCompThirdMomData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt, &zt_grid}, {&thl_sec, &wthl_sec, &qw_sec, &qwthl_sec, &zi_grid, &isotropy_zi, &dz_zi, &brunt_zi, &w_sec_zi, &thetal_zi, &wthv_sec_zi, &w3}) {}
+    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt}, {&thl_sec, &wthl_sec, &isotropy_zi, &dz_zi, &brunt_zi, &w_sec_zi, &thetal_zi, &w3}) {}
 
   SHOC_NO_SCALAR(SHOCCompThirdMomData, 3);
 };//SHOCCompThirdMomData
@@ -734,11 +734,10 @@ void shoc_diag_second_moments_srf_f(Int shcol, Real* wthl, Real* uw, Real* vw,
 void shoc_diag_second_moments_ubycond_f(Int shcol, Real* thl, Real* qw, Real* wthl,
                           Real* wqw, Real* qwthl, Real* uw, Real* vw, Real* wtke);
 void compute_diag_third_shoc_moment_f(Int shcol, Int nlev, Int nlevi, Real* w_sec,
-                                      Real* thl_sec, Real* qw_sec, Real* qwthl_sec,
-                                      Real* wthl_sec, Real* tke, Real* dz_zt,
-                                      Real* dz_zi, Real* zt_grid, Real* zi_grid,
-                                      Real* isotropy_zi, Real* brunt_zi, Real* w_sec_zi,
-                                      Real* thetal_zi, Real* wthv_sec_zi, Real* w3);
+                                      Real* thl_sec, Real* wthl_sec, Real* tke,
+                                      Real* dz_zt, Real* dz_zi, Real* isotropy_zi,
+                                      Real* brunt_zi, Real* w_sec_zi, Real* thetal_zi,
+                                      Real* w3);
 void update_host_dse_f(Int shcol, Int nlev, Real* thlm, Real* shoc_ql, Real* exner, Real* zt_grid,
                        Real* phis, Real* host_dse);
 void shoc_pblintd_init_pot_f(Int shcol, Int nlev, Real* thl, Real* ql, Real* q, Real* thv);

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -790,9 +790,9 @@ contains
  
   subroutine compute_diag_third_shoc_moment_c(&
                              shcol, nlev, nlevi, w_sec, thl_sec, &
-                             qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
-                             dz_zi, zt_grid, zi_grid, isotropy_zi, &
-                             brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
+                             wthl_sec, tke, dz_zt, &
+                             dz_zi, isotropy_zi, &
+                             brunt_zi, w_sec_zi, thetal_zi, &
                              w3) bind(C)
     use shoc, only: compute_diag_third_shoc_moment
 
@@ -801,27 +801,22 @@ contains
     integer(kind=c_int), intent(in), value :: nlevi
     real(kind=c_real), intent(in) :: w_sec(shcol,nlev)
     real(kind=c_real), intent(in) :: thl_sec(shcol,nlevi)
-    real(kind=c_real), intent(in) :: qw_sec(shcol,nlevi)
-    real(kind=c_real), intent(in) :: qwthl_sec(shcol,nlevi)
     real(kind=c_real), intent(in) :: wthl_sec(shcol,nlevi)
     real(kind=c_real), intent(in) :: tke(shcol,nlev)
     real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
     real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
-    real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
-    real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
     real(kind=c_real), intent(in) :: isotropy_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: brunt_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: thetal_zi(shcol,nlevi)
-    real(kind=c_real), intent(in) :: wthv_sec_zi(shcol,nlevi)
     
     real(kind=c_real), intent(out) :: w3(shcol,nlevi)
 
     call compute_diag_third_shoc_moment(&
                              shcol, nlev, nlevi, w_sec, thl_sec, &
-                             qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
-                             dz_zi, zt_grid, zi_grid, isotropy_zi, &
-                             brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
+                             wthl_sec, tke, dz_zt, &
+                             dz_zi, isotropy_zi, &
+                             brunt_zi, w_sec_zi, thetal_zi, &
                              w3)
 
   end subroutine compute_diag_third_shoc_moment_c			     

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -71,9 +71,9 @@ interface
  end subroutine shoc_diag_second_moments_ubycond_f
 
 subroutine compute_diag_third_shoc_moment_f(shcol, nlev, nlevi, w_sec, thl_sec, &
-                                            qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
-                                            dz_zi, zt_grid, zi_grid, isotropy_zi, &
-                                            brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
+                                            wthl_sec, tke, dz_zt, &
+                                            dz_zi, isotropy_zi, &
+                                            brunt_zi, w_sec_zi, thetal_zi, &
                                             w3) bind(C)
   use iso_c_binding
 
@@ -82,19 +82,14 @@ subroutine compute_diag_third_shoc_moment_f(shcol, nlev, nlevi, w_sec, thl_sec, 
   integer(kind=c_int), intent(in), value :: nlevi
   real(kind=c_real), intent(in) :: w_sec(shcol,nlev)
   real(kind=c_real), intent(in) :: thl_sec(shcol,nlevi)
-  real(kind=c_real), intent(in) :: qw_sec(shcol,nlevi)
-  real(kind=c_real), intent(in) :: qwthl_sec(shcol,nlevi)
   real(kind=c_real), intent(in) :: wthl_sec(shcol,nlevi)
   real(kind=c_real), intent(in) :: tke(shcol,nlev)
   real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
   real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
-  real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
-  real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
   real(kind=c_real), intent(in) :: isotropy_zi(shcol,nlevi)
   real(kind=c_real), intent(in) :: brunt_zi(shcol,nlevi)
   real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi)
   real(kind=c_real), intent(in) :: thetal_zi(shcol,nlevi)
-  real(kind=c_real), intent(in) :: wthv_sec_zi(shcol,nlevi)
 
   real(kind=c_real), intent(out) :: w3(shcol,nlevi)
 

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -70,6 +70,36 @@ interface
 
  end subroutine shoc_diag_second_moments_ubycond_f
 
+subroutine compute_diag_third_shoc_moment_f(shcol, nlev, nlevi, w_sec, thl_sec, &
+                                            qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
+                                            dz_zi, zt_grid, zi_grid, isotropy_zi, &
+                                            brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
+                                            w3) bind(C)
+  use iso_c_binding
+
+  integer(kind=c_int), intent(in), value :: shcol
+  integer(kind=c_int), intent(in), value :: nlev
+  integer(kind=c_int), intent(in), value :: nlevi
+  real(kind=c_real), intent(in) :: w_sec(shcol,nlev)
+  real(kind=c_real), intent(in) :: thl_sec(shcol,nlevi)
+  real(kind=c_real), intent(in) :: qw_sec(shcol,nlevi)
+  real(kind=c_real), intent(in) :: qwthl_sec(shcol,nlevi)
+  real(kind=c_real), intent(in) :: wthl_sec(shcol,nlevi)
+  real(kind=c_real), intent(in) :: tke(shcol,nlev)
+  real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
+  real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
+  real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
+  real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
+  real(kind=c_real), intent(in) :: isotropy_zi(shcol,nlevi)
+  real(kind=c_real), intent(in) :: brunt_zi(shcol,nlevi)
+  real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi)
+  real(kind=c_real), intent(in) :: thetal_zi(shcol,nlevi)
+  real(kind=c_real), intent(in) :: wthv_sec_zi(shcol,nlevi)
+
+  real(kind=c_real), intent(out) :: w3(shcol,nlevi)
+
+end subroutine compute_diag_third_shoc_moment_f
+
 subroutine update_host_dse_f(shcol, nlev, thlm, shoc_ql, exner, zt_grid, &
                              phis, host_dse) bind (C)
   use iso_c_binding

--- a/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
@@ -49,10 +49,6 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
     static constexpr Real w_sec_zi[nlevi] = {0.2, 0.3, 0.5, 0.4, 0.3, 0.1};
     // Define potential temperature second moment [K2]
     static constexpr Real thl_sec[nlevi] = {0.5, 0.9, 1.2, 0.8, 0.4, 0.3};
-    // Define second moment total water second moment [kg^2/kg^2]
-    static constexpr Real qw_sec[nlevi] = {1e-7, 3e-7, 2e-7, 1.4e-6, 5e-7, 4e-7};
-    // Define covarance of thetal and qw [K kg/kg]
-    static constexpr Real qwthl_sec[nlevi] = {1e-3, 3e-3, 2e-3, 1.4e-3, 5e-3, 4e-3};
     // Define vertical flux of temperature [K m/s]
     static constexpr Real wthl_sec[nlevi] = {0.003, -0.03, -0.04, -0.01, 0.01, 0.03};
     // Define the heights on the zi grid [m]
@@ -63,8 +59,6 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
     static constexpr Real brunt_zi[nlevi] = {4e-5, 3e-5, 3e-5, 2e-5, 2e-5, -1e-5};
     // Define the potential temperature on zi grid [K]
     static constexpr Real thetal_zi[nlevi] = {330, 325, 320, 310, 300, 301};
-    // Define the buoyancy flux on zi grid [K m/s]
-    static constexpr Real wthv_sec_zi[nlevi] = {0.002, 0.03, 0.04, 0.01, 0.02, 0.04};
     
     // Define TKE [m2/s2], compute from w_sec
     Real tke[nlev];
@@ -107,7 +101,6 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
 	
         SDS.w_sec[offset] = w_sec[n];
         SDS.dz_zt[offset] = dz_zt[n];
-        SDS.zt_grid[offset] = zt_grid[n];
         SDS.tke[offset] = tke[n];
 	
       }
@@ -117,17 +110,13 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
         const auto offset = n + s * nlevi;
 	
         SDS.dz_zi[offset] = dz_zi[n];
-        SDS.zi_grid[offset] = zi_grid[n];
         SDS.thl_sec[offset] = (s+1)*thl_sec[n];
-        SDS.qw_sec[offset] = (s+1)*qw_sec[n];
-        SDS.qwthl_sec[offset] = qwthl_sec[n];
         SDS.wthl_sec[offset] = wthl_sec[n];
 	
         SDS.w_sec_zi[offset] = w_sec_zi[n];
         SDS.isotropy_zi[offset] = isotropy_zi[n];
         SDS.brunt_zi[offset] = brunt_zi[n];
         SDS.thetal_zi[offset] = thetal_zi[n];
-        SDS.wthv_sec_zi[offset] = wthv_sec_zi[n];
 	
       }
     }      
@@ -141,7 +130,6 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
 	
         REQUIRE(SDS.w_sec[offset] >= 0);
         REQUIRE(SDS.dz_zt[offset] > 0);
-        REQUIRE(SDS.zt_grid[offset] > 0);
         REQUIRE(SDS.tke[offset] > 0);  
       }
       
@@ -149,9 +137,7 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
         const auto offset = n + s * nlevi;
 	
         REQUIRE(SDS.dz_zi[offset] >= 0);
-        REQUIRE(SDS.zi_grid[offset] >= 0);
         REQUIRE(SDS.thl_sec[offset] >= 0);
-        REQUIRE(SDS.qw_sec[offset] >= 0);
         REQUIRE(SDS.w_sec_zi[offset] >= 0);
         REQUIRE(SDS.isotropy_zi[offset] >= 0);
         REQUIRE(SDS.thetal_zi[offset] >= 0);
@@ -241,9 +227,9 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
       d.transpose<ekat::util::TransposeDirection::c2f>();
       // expects data in fortran layout
       compute_diag_third_shoc_moment_f(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,
-                                       d.qw_sec,d.qwthl_sec,d.wthl_sec,d.tke,d.dz_zt,
-                                       d.dz_zi,d.zt_grid,d.zi_grid,d.isotropy_zi,
-                                       d.brunt_zi,d.w_sec_zi,d.thetal_zi,d.wthv_sec_zi,
+                                       d.wthl_sec,d.tke,d.dz_zt,
+                                       d.dz_zi,d.isotropy_zi,
+                                       d.brunt_zi,d.w_sec_zi,d.thetal_zi,
                                        d.w3);
       d.transpose<ekat::util::TransposeDirection::f2c>();
     }

--- a/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
@@ -224,14 +224,14 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
 
     // Get data from cxx
     for (auto& d : SDS_cxx) {
-      d.transpose<ekat::util::TransposeDirection::c2f>();
+      d.transpose<ekat::TransposeDirection::c2f>();
       // expects data in fortran layout
       compute_diag_third_shoc_moment_f(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,
                                        d.wthl_sec,d.tke,d.dz_zt,
                                        d.dz_zi,d.isotropy_zi,
                                        d.brunt_zi,d.w_sec_zi,d.thetal_zi,
                                        d.w3);
-      d.transpose<ekat::util::TransposeDirection::f2c>();
+      d.transpose<ekat::TransposeDirection::f2c>();
     }
 
     // Verify BFB results, all data should be in C layout


### PR DESCRIPTION
Port `compute_diag_third_shoc_moment()`. This function depends on `fterms_input_for_diag_third_shoc_moment`, `f0_to_f5_diag_third_shoc_moment`, `omega_terms_diag_third_shoc_moment`, `x_y_terms_diag_third_shoc_moment`, `aa_terms_diag_third_shoc_moment`, `w3_diag_third_shoc_moment`, but all those functions are only called in `compute_diag_third_shoc_moment`, so I chose not to implement each of those functions in separate files. Let me know if people prefer separate implementations. 

If not, should I delete all the tests for the non-implemented function? Or at least delete the bfb portion of the tests? E.g. `shoc_fterm_input_third_moms_tests.cpp`.

This PR depends on https://github.com/E3SM-Project/scream/pull/599, but I imagine that PR will be merged much sooner. Also, I've labeled [WIP] till the testers are back up.