### PR TITLE
change quartz back to broadwell

### DIFF
--- a/components/scream/cmake/machine-files/quartz.cmake
+++ b/components/scream/cmake/machine-files/quartz.cmake
@@ -3,6 +3,6 @@ set (EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/c
 include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
 
 # Enable Broadwell arch in Kokkos
-option(Kokkos_ARCH_SKX "" ON)
+option(Kokkos_ARCH_BDW "" ON)
 
 set(CMAKE_CXX_FLAGS "-w" CACHE STRING "")


### PR DESCRIPTION
Recent mods switched components/scream/cmake/machine-files/quartz.cmake from being BDW architecture to SKL, causing "illegal instruction" errors when scream tests were run.