### PR TITLE
port clipping_diag_third_shoc_moments

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1872,6 +1872,10 @@ subroutine clipping_diag_third_shoc_moments(&
            nlevi,shcol,w_sec_zi,& ! Input
 	   w3)                    ! Input/Output
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    use shoc_iso_f, only: clipping_diag_third_shoc_moments_f
+#endif
+
   ! perform clipping to prevent unrealistically large values from occuring
 
   implicit none
@@ -1887,6 +1891,14 @@ subroutine clipping_diag_third_shoc_moments(&
   real(rtype) :: theterm
 
   integer k, i
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+   if (use_cxx) then
+      call clipping_diag_third_shoc_moments_f(nlevi,shcol,w_sec_zi, & ! Input
+                                              w3)                     ! Input/Output
+      return
+   endif
+#endif
 
   do k=1, nlevi
     do i=1, shcol

--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -36,6 +36,7 @@ if (NOT CUDA_BUILD)
     shoc_calc_shoc_vertflux.cpp
     shoc_linear_interp.cpp
     shoc_compute_shoc_mix_shoc_length.cpp
+    shoc_clipping_diag_third_shoc_moments.cpp
   ) # SHOC ETI SRCS
 endif()
 

--- a/components/scream/src/physics/shoc/shoc_clipping_diag_third_shoc_moments.cpp
+++ b/components/scream/src/physics/shoc/shoc_clipping_diag_third_shoc_moments.cpp
@@ -1,0 +1,14 @@
+#include "shoc_clipping_diag_third_shoc_moments_impl.hpp"
+#include "share/scream_types.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation using the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream

--- a/components/scream/src/physics/shoc/shoc_clipping_diag_third_shoc_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_clipping_diag_third_shoc_moments_impl.hpp
@@ -1,0 +1,35 @@
+#ifndef SHOC_CLIPPING_DIAG_THIRD_SHOC_MOMENTS_IMPL_HPP
+#define SHOC_CLIPPING_DIAG_THIRD_SHOC_MOMENTS_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace shoc {
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>
+::clipping_diag_third_shoc_moments(
+  const MemberType& team,
+  const Int& nlevi,
+  const uview_1d<const Spack>& w_sec_zi,
+  const uview_1d<Spack>& w3)
+{
+  const Int nlevi_pack = ekat::npack<Spack>(nlevi);
+
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlevi_pack), [&] (const Int& k) {
+    const auto w3clip = scream::shoc::Constants<Scalar>::w3clip;
+    Spack tsign(1);
+
+    const auto theterm = w_sec_zi(k);
+    const auto cond    = w3clip*ekat::sqrt(2*ekat::cube(theterm));
+
+    tsign.set(w3(k)<0, -1);
+    w3(k).set(tsign*w3(k) > cond, tsign*cond);
+  });
+}
+
+} // namespace shoc
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/shoc/shoc_constants.hpp
+++ b/components/scream/src/physics/shoc/shoc_constants.hpp
@@ -15,6 +15,7 @@ struct Constants
       static constexpr Scalar maxtke     = 50.0;    // Maximum TKE [m2/s2]
       static constexpr Scalar maxlen     = 20000.0; // Upper limit for mixing length [m]
       static constexpr Scalar length_fac = 0.5;     // Mixing length scaling parameter
+      static constexpr Scalar w3clip     = 1.2;     // Third moment of vertical velocity
     };
 
   } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -136,6 +136,14 @@ struct Functions
 
   KOKKOS_FUNCTION
   static void linear_interp(const uview_1d<const Spack>& x1, const uview_1d<const Spack>& x2, const uview_1d<const Spack>& y1, const uview_1d<Spack>& y2, const Int& km1, const Int& km2, const Int& ncol, const Spack& minthresh);
+
+  KOKKOS_FUNCTION
+   static void clipping_diag_third_shoc_moments(
+     const MemberType& team,
+     const Int& nlevi,
+     const uview_1d<const Spack>& w_sec_zi,
+     const uview_1d<Spack>& w3);
+
 }; // struct Functions
 
 } // namespace shoc
@@ -153,6 +161,7 @@ struct Functions
 # include "shoc_compute_shoc_mix_shoc_length_impl.hpp"
 # include "shoc_check_tke_impl.hpp"
 # include "shoc_linear_interp_impl.hpp"
+# include "shoc_clipping_diag_third_shoc_moments_impl.hpp"
 #endif // KOKKOS_ENABLE_CUDA
 
 #endif

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -1031,5 +1031,44 @@ void linear_interp_f(Real* x1, Real* x2, Real* y1, Real* y2, Int km1, Int km2, I
   // TODO
 }
 
+void clipping_diag_third_shoc_moments_f(Int nlevi, Int shcol, Real *w_sec_zi,
+                                        Real *w3)
+{
+  using SHF = Functions<Real, DefaultDevice>;
+
+  using Spack      = typename SHF::Spack;
+  using view_2d    = typename SHF::view_2d<Spack>;
+  using KT         = typename SHF::KT;
+  using ExeSpace   = typename KT::ExeSpace;
+  using MemberType = typename SHF::MemberType;
+
+  Kokkos::Array<view_2d, 2> temp_d;
+  Kokkos::Array<size_t, 2> dim1_sizes     = {shcol, shcol};
+  Kokkos::Array<size_t, 2> dim2_sizes     = {nlevi, nlevi};
+  Kokkos::Array<const Real*, 2> ptr_array = {w_sec_zi, w3};
+
+  // Sync to device
+  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+
+  view_2d
+    w_sec_zi_d(temp_d[0]),
+    w3_d      (temp_d[1]);
+
+  const Int nk_pack = ekat::npack<Spack>(nlevi);
+  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+    const Int i = team.league_rank();
+
+    const auto w_sec_zi_s = ekat::subview(w_sec_zi_d, i);
+    const auto w3_s       = ekat::subview(w3_d, i);
+
+    SHF::clipping_diag_third_shoc_moments(team, nlevi, w_sec_zi_s, w3_s);
+  });
+
+  // Sync back to host
+  Kokkos::Array<view_2d, 1> inout_views = {w3_d};
+  ekat::device_to_host<int,1>({w3}, {shcol}, {nlevi}, inout_views, true);
+}
+
 } // namespace shoc
 } // namespace scream

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -813,6 +813,8 @@ void compute_shoc_mix_shoc_length_f(Int nlev, Int shcol, Real* tke, Real* brunt,
                                     Real* tscale, Real* zt_grid, Real* l_inf, Real* shoc_mix);
 void check_tke_f(Int shcol, Int nlev, Real* tke);
 void linear_interp_f(Real* x1, Real* x2, Real* y1, Real* y2, Int km1, Int km2, Int ncol, Real minthresh);
+void clipping_diag_third_shoc_moments_f(Int nlevi, Int shcol, Real *w_sec_zi,
+                                        Real *w3);
 
 } // end _f function decls
 

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -132,6 +132,17 @@ interface
     real(kind=c_real) , value, intent(in) :: minthresh
   end subroutine linear_interp_f
 
+subroutine clipping_diag_third_shoc_moments_f(nlevi,shcol,w_sec_zi,w3) bind (C)
+  use iso_c_binding
+
+  integer(kind=c_int), intent(in), value :: nlevi
+  integer(kind=c_int), intent(in), value :: shcol
+  real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi)
+
+  real(kind=c_real), intent(inout) :: w3(shcol,nlevi)
+
+end subroutine clipping_diag_third_shoc_moments_f
+
 end interface
 
 end module shoc_iso_f


### PR DESCRIPTION
Port clipping_diag_third_shoc_moments to C++. Relies on bfb changes from https://github.com/E3SM-Project/scream/pull/613.

This pull request was already reviewed here: https://github.com/E3SM-Project/scream/pull/605. I decided to switch to non-forked branches so the tester could run without approval, otherwise same code. 