### PR TITLE
port compute_diag_third_shoc_moment

### DIFF
--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -36,6 +36,7 @@ if (NOT CUDA_BUILD)
     shoc_calc_shoc_vertflux.cpp
     shoc_linear_interp.cpp
     shoc_compute_shoc_mix_shoc_length.cpp
+    shoc_compute_diag_third_shoc_moment.cpp
   ) # SHOC ETI SRCS
 endif()
 

--- a/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment.cpp
+++ b/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment.cpp
@@ -1,0 +1,14 @@
+#include "shoc_compute_diag_third_shoc_moment_impl.hpp"
+#include "share/scream_types.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation using the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream

--- a/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
@@ -1,0 +1,124 @@
+#ifndef SHOC_COMPUTE_DIAG_THIRD_SHOC_MOMENT_IMPL_HPP
+#define SHOC_COMPUTE_DIAG_THIRD_SHOC_MOMENT_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace shoc {
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>
+::compute_diag_third_shoc_moment(
+  const MemberType& team,
+  const Int& nlev,
+  const Int& nlevi,
+  const uview_1d<const Spack>& w_sec,
+  const uview_1d<const Spack>& thl_sec,
+  const uview_1d<const Spack>& wthl_sec,
+  const uview_1d<const Spack>& tke,
+  const uview_1d<const Spack>& dz_zt,
+  const uview_1d<const Spack>& dz_zi,
+  const uview_1d<const Spack>& isotropy_zi,
+  const uview_1d<const Spack>& brunt_zi,
+  const uview_1d<const Spack>& w_sec_zi,
+  const uview_1d<const Spack>& thetal_zi,
+  const uview_1d<Spack>& w3)
+{
+  const auto ggr = C::gravit;
+
+  const Int nlev_pack = ekat::npack<Spack>(nlev);
+  const Int nlevi_pack = ekat::npack<Spack>(nlevi);
+
+  // Scalarize views for shifts
+  const auto s_dz_zt = scalarize(dz_zt);
+  const auto s_wthl_sec = scalarize(wthl_sec);
+  const auto s_thl_sec = scalarize(thl_sec);
+  const auto s_w_sec = scalarize(w_sec);
+  const auto s_tke = scalarize(tke);
+
+  // Set lower condition: w3(i,nlevi) = 0
+  const Int last_pack_entry = (nlevi%Spack::n == 0 ? Spack::n-1 : nlevi%Spack::n-1);
+  w3(nlevi_pack-1)[last_pack_entry] = 0;
+
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+    // Constants
+    const auto c_diag_3rd_mom = scream::shoc::Constants<Scalar>::c_diag_3rd_mom;
+    const Scalar a0 = (sp(0.52)*(1/(c_diag_3rd_mom*c_diag_3rd_mom)))/(c_diag_3rd_mom-2);
+    const Scalar a1 = sp(0.87)/(c_diag_3rd_mom*c_diag_3rd_mom);
+    const Scalar a2 = sp(0.5)/c_diag_3rd_mom;
+    const Scalar a3 = sp(0.6)/(c_diag_3rd_mom*(c_diag_3rd_mom-2));
+    const Scalar a4 = sp(2.4)/(3*c_diag_3rd_mom+5);
+    const Scalar a5 = sp(0.6)/(c_diag_3rd_mom*(3+5*c_diag_3rd_mom));
+
+    // Calculate shifts
+    Spack
+      dz_zt_k,    dz_zt_km1,
+      wthl_sec_k, wthl_sec_km1, wthl_sec_kp1,
+      thl_sec_k,  thl_sec_km1,  thl_sec_kp1,
+      w_sec_k,    w_sec_km1,
+      tke_k,      tke_km1;
+
+    auto range_pack1 = ekat::range<IntSmallPack>(k*Spack::n);
+    auto range_pack2 = range_pack1;
+    // index for _km1 should never go below 0 and _kp1 should never go above nlevi
+    range_pack2.set(range_pack1 < 1 || range_pack1 >= nlevi, 1);
+
+    ekat::index_and_shift<-1>(s_dz_zt, range_pack2, dz_zt_k, dz_zt_km1);
+    ekat::index_and_shift<-1>(s_wthl_sec, range_pack2, wthl_sec_k, wthl_sec_km1);
+    ekat::index_and_shift<1> (s_wthl_sec, range_pack2, wthl_sec_k, wthl_sec_kp1);
+    ekat::index_and_shift<-1>(s_thl_sec, range_pack2, thl_sec_k, thl_sec_km1);
+    ekat::index_and_shift<1> (s_thl_sec, range_pack2, thl_sec_k, thl_sec_kp1);
+    ekat::index_and_shift<-1>(s_w_sec, range_pack2, w_sec_k, w_sec_km1);
+    ekat::index_and_shift<-1>(s_tke, range_pack2, tke_k, tke_km1);
+
+    // Compute inputs for computing f0 to f5 terms
+    const auto thedz  = 1/dz_zi(k);
+    const auto thedz2 = 1/(dz_zt_k+dz_zt_km1);
+
+    const auto iso       = isotropy_zi(k);
+    const auto isosqrd   = ekat::square(iso);
+    const auto buoy_sgs2 = isosqrd*brunt_zi(k);
+    const auto bet2      = ggr/thetal_zi(k);
+
+    // Compute f0 to f5 terms
+    const Spack thl_sec_diff = thl_sec_km1 - thl_sec_kp1;
+    const Spack wthl_sec_diff = wthl_sec_km1 - wthl_sec_kp1;
+    const Spack wsec_diff = w_sec_km1 - w_sec(k);
+    const Spack tke_diff = tke_km1 - tke(k);
+
+    const auto f0 = thedz2*ekat::cube(bet2)*((iso*iso)*(iso*iso))*wthl_sec_k*thl_sec_diff;
+    const auto f1 = thedz2*ekat::square(bet2)*ekat::cube(iso)*(wthl_sec_k*wthl_sec_diff+sp(0.5)*w_sec_zi(k)*thl_sec_diff);
+    const auto f2 = thedz*bet2*isosqrd*wthl_sec_k*wsec_diff+2*thedz2*bet2*isosqrd*w_sec_zi(k)*wthl_sec_diff;
+    const auto f3 = thedz2*bet2*isosqrd*w_sec_zi(k)*wthl_sec_diff+thedz*bet2*isosqrd*(wthl_sec_k*tke_diff);
+    const auto f4 = thedz*iso*w_sec_zi(k)*(wsec_diff+tke_diff);
+    const auto f5 = thedz*iso*w_sec_zi(k)*wsec_diff;
+
+    // Compute omega terms
+    const auto omega0 = a4/Spack(1-a5*buoy_sgs2);
+    const auto omega1 = omega0/(2*c_diag_3rd_mom);
+    const auto omega2 = omega1*f3+sp(5.0/4.0)*omega0*f4;
+
+    // Compute the x0, y0, x1, y1 terms
+    const auto x0 = (a2*buoy_sgs2*(Spack(1)-a3*buoy_sgs2))/(Spack(1)-(a1+a3)*buoy_sgs2);
+    const auto y0 = (2*a2*buoy_sgs2*x0)/(Spack(1)-a3*buoy_sgs2);
+    const auto x1 = (a0*f0+a1*f1+a2*(Spack(1)-a3*buoy_sgs2)*f2)/(Spack(1)-(a1+a3)*buoy_sgs2);
+    const auto y1 = (2*a2*(buoy_sgs2*x1+(a0/a1)*f0+f1))/(Spack(1)-a3*buoy_sgs2);
+
+    // Compute the aa0, aa1 terms
+    const auto aa0 = omega0*x0+omega1*y0;
+    const auto aa1 = omega0*x1+omega1*y1+omega2;
+
+    // Finally, compute the third moment of w
+    w3(k).set(range_pack1 > 0 && range_pack1 < nlev,
+              (aa1-sp(1.2)*x1-sp(1.5)*f5)/(Spack(c_diag_3rd_mom)-sp(1.2)*x0+aa0));
+  });
+
+  // Set upper condition: w3(i,0) = 0
+  w3(0)[0] = 0;
+}
+
+} // namespace shoc
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/shoc/shoc_constants.hpp
+++ b/components/scream/src/physics/shoc/shoc_constants.hpp
@@ -11,10 +11,11 @@ namespace scream {
 template <typename Scalar>
 struct Constants
     {
-      static constexpr Scalar mintke     = 0.0004;  // Minimum TKE [m2/s2]
-      static constexpr Scalar maxtke     = 50.0;    // Maximum TKE [m2/s2]
-      static constexpr Scalar maxlen     = 20000.0; // Upper limit for mixing length [m]
-      static constexpr Scalar length_fac = 0.5;     // Mixing length scaling parameter
+      static constexpr Scalar mintke         = 0.0004;  // Minimum TKE [m2/s2]
+      static constexpr Scalar maxtke         = 50.0;    // Maximum TKE [m2/s2]
+      static constexpr Scalar maxlen         = 20000.0; // Upper limit for mixing length [m]
+      static constexpr Scalar length_fac     = 0.5;     // Mixing length scaling parameter
+      static constexpr Scalar c_diag_3rd_mom = 7.0;     // Coefficient for diag third moment parameters
     };
 
   } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -112,6 +112,23 @@ struct Functions
     const uview_1d<Spack>& host_dse);
 
   KOKKOS_FUNCTION
+  static void compute_diag_third_shoc_moment(
+    const MemberType& team,
+    const Int& nlev,
+    const Int& nlevi,
+    const uview_1d<const Spack>& w_sec,
+    const uview_1d<const Spack>& thl_sec,
+    const uview_1d<const Spack>& wthl_sec,
+    const uview_1d<const Spack>& tke,
+    const uview_1d<const Spack>& dz_zt,
+    const uview_1d<const Spack>& dz_zi,
+    const uview_1d<const Spack>& isotropy_zi,
+    const uview_1d<const Spack>& brunt_zi,
+    const uview_1d<const Spack>& w_sec_zi,
+    const uview_1d<const Spack>& thetal_zi,
+    const uview_1d<Spack>& w3);
+
+  KOKKOS_FUNCTION
   static void shoc_pblintd_init_pot(
     const MemberType& team, const Int& nlev,
     const view_1d<const Spack>& thl, const view_1d<const Spack>& ql, const view_1d<const Spack>& q,
@@ -149,6 +166,7 @@ struct Functions
 # include "shoc_diag_second_moments_srf_impl.hpp"
 # include "shoc_diag_second_moments_ubycond_impl.hpp"
 # include "shoc_update_host_dse_impl.hpp"
+# include "shoc_compute_diag_third_shoc_moment_impl.hpp"
 # include "shoc_pblintd_init_pot_impl.hpp"
 # include "shoc_compute_shoc_mix_shoc_length_impl.hpp"
 # include "shoc_check_tke_impl.hpp"

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -162,12 +162,10 @@ void diag_third_shoc_moments_c(Int shoc, Int nlev, Int nlevi, Real *w_sec,
                                Real *zi_grid, Real *w3);
 
 void compute_diag_third_shoc_moment_c(Int shcol, Int nlev, Int nlevi, Real *w_sec,
-                                      Real *thl_sec, Real *qw_sec, Real *qwthl_sec,
-                                      Real *wthl_sec, Real *tke, Real *dz_zt,
-                                      Real *dz_zi, Real *zt_grid, Real *zi_grid,
-                                      Real *isotropy_zi, Real *brunt_zi,
-                                      Real *w_sec_zi, Real *thetal_zi,
-                                      Real *wthv_sec_zi, Real *w3);
+                                      Real *thl_sec, Real *wthl_sec, Real *tke,
+                                      Real *dz_zt, Real *dz_zi, Real *isotropy_zi,
+                                      Real *brunt_zi, Real *w_sec_zi, Real *thetal_zi,
+                                      Real *w3);
 
 void linear_interp_c(Real* x1, Real* x2, Real* y1, Real* y2, Int km1, Int km2, Int ncol, Real minthresh);
 void shoc_assumed_pdf_tilda_to_real_c(Real w_first, Real sqrtw2, Real* w1);
@@ -539,10 +537,8 @@ void compute_diag_third_shoc_moment(SHOCCompThirdMomData &d) {
   shoc_init(d.nlev(), true);
   d.transpose<ekat::TransposeDirection::c2f>();
   compute_diag_third_shoc_moment_c(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,
-                                   d.qw_sec,d.qwthl_sec,d.wthl_sec,d.tke,d.dz_zt,
-                                   d.dz_zi,d.zt_grid,d.zi_grid,d.isotropy_zi,
-                                   d.brunt_zi,d.w_sec_zi,d.thetal_zi,d.wthv_sec_zi,
-                                   d.w3);
+                                   d.wthl_sec,d.tke,d.dz_zt,d.dz_zi,d.isotropy_zi,
+                                   d.brunt_zi,d.w_sec_zi,d.thetal_zi,d.w3);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 
@@ -898,6 +894,83 @@ void update_host_dse_f(Int shcol, Int nlev, Real* thlm, Real* shoc_ql, Real* exn
   // Sync back to host
   Kokkos::Array<view_2d, 1> inout_views = {host_dse_d};
   ekat::device_to_host<int,1>({host_dse}, {shcol}, {nlev}, inout_views, true);
+}
+
+void compute_diag_third_shoc_moment_f(Int shcol, Int nlev, Int nlevi, Real* w_sec,
+                                      Real* thl_sec, Real* wthl_sec, Real* tke,
+                                      Real* dz_zt, Real* dz_zi, Real* isotropy_zi,
+                                      Real* brunt_zi, Real* w_sec_zi, Real* thetal_zi,
+                                      Real* w3)
+{
+  using SHF = Functions<Real, DefaultDevice>;
+
+  using Spack      = typename SHF::Spack;
+  using view_2d    = typename SHF::view_2d<Spack>;
+  using KT         = typename SHF::KT;
+  using ExeSpace   = typename KT::ExeSpace;
+  using MemberType = typename SHF::MemberType;
+
+  Kokkos::Array<view_2d, 11> temp_d;
+  Kokkos::Array<size_t, 11> dim1_sizes     = {shcol,       shcol,
+                                              shcol,       shcol,
+                                              shcol,       shcol,
+                                              shcol,       shcol,
+                                              shcol,       shcol,
+                                              shcol};
+  Kokkos::Array<size_t, 11> dim2_sizes     = {nlev,        nlevi,
+                                              nlevi,       nlev,
+                                              nlev,        nlevi,
+                                              nlevi,       nlevi,
+                                              nlevi,       nlevi,
+                                              nlevi};
+  Kokkos::Array<const Real*, 11> ptr_array = {w_sec,       thl_sec,
+                                              wthl_sec,    tke,
+                                              dz_zt,       dz_zi,
+                                              isotropy_zi, brunt_zi,
+                                              w_sec_zi,    thetal_zi,
+                                              w3};
+
+  // Sync to device
+  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+
+  view_2d
+    w_sec_d      (temp_d[0]),
+    thl_sec_d    (temp_d[1]),
+    wthl_sec_d   (temp_d[2]),
+    tke_d        (temp_d[3]),
+    dz_zt_d      (temp_d[4]),
+    dz_zi_d      (temp_d[5]),
+    isotropy_zi_d(temp_d[6]),
+    brunt_zi_d   (temp_d[7]),
+    w_sec_zi_d   (temp_d[8]),
+    thetal_zi_d  (temp_d[9]),
+    w3_d         (temp_d[10]);
+
+  const Int nk_pack = ekat::npack<Spack>(nlev);
+  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+    const Int i = team.league_rank();
+
+    const auto w_sec_s       = ekat::subview(w_sec_d, i);
+    const auto thl_sec_s     = ekat::subview(thl_sec_d, i);
+    const auto wthl_sec_s    = ekat::subview(wthl_sec_d, i);
+    const auto tke_s         = ekat::subview(tke_d, i);
+    const auto dz_zt_s       = ekat::subview(dz_zt_d, i);
+    const auto dz_zi_s       = ekat::subview(dz_zi_d, i);
+    const auto isotropy_zi_s = ekat::subview(isotropy_zi_d, i);
+    const auto brunt_zi_s    = ekat::subview(brunt_zi_d, i);
+    const auto w_sec_zi_s    = ekat::subview(w_sec_zi_d, i);
+    const auto thetal_zi_s   = ekat::subview(thetal_zi_d, i);
+    const auto w3_s          = ekat::subview(w3_d, i);
+
+    SHF::compute_diag_third_shoc_moment(team, nlev, nlevi, w_sec_s, thl_sec_s,
+                                        wthl_sec_s, tke_s, dz_zt_s, dz_zi_s, isotropy_zi_s,
+                                        brunt_zi_s, w_sec_zi_s, thetal_zi_s, w3_s);
+  });
+
+  // Sync back to host
+  Kokkos::Array<view_2d, 1> inout_views = {w3_d};
+  ekat::device_to_host<int,1>({w3}, {shcol}, {nlevi}, inout_views, true);
 }
 
 void shoc_pblintd_init_pot_f(Int shcol, Int nlev, Real *thl, Real* ql, Real* q,

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -567,15 +567,15 @@ struct SHOCDiagThirdMomData : public PhysicsTestData {
 //Create data structure to hold data for compute_diag_third_shoc_moment
 struct SHOCCompThirdMomData : public PhysicsTestData {
   // Inputs
-  Real *w_sec, *thl_sec, *qw_sec, *qwthl_sec, *wthl_sec, *tke, *dz_zt;
-  Real *dz_zi, *zt_grid, *zi_grid, *isotropy_zi, *brunt_zi, *w_sec_zi;
-  Real *thetal_zi, *wthv_sec_zi;
+  Real *w_sec, *thl_sec, *wthl_sec, *tke, *dz_zt;
+  Real *dz_zi, *isotropy_zi, *brunt_zi, *w_sec_zi;
+  Real *thetal_zi;
 
   // Output
   Real *w3;
 
   SHOCCompThirdMomData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt, &zt_grid}, {&thl_sec, &wthl_sec, &qw_sec, &qwthl_sec, &zi_grid, &isotropy_zi, &dz_zi, &brunt_zi, &w_sec_zi, &thetal_zi, &wthv_sec_zi, &w3}) {}
+    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt}, {&thl_sec, &wthl_sec, &isotropy_zi, &dz_zi, &brunt_zi, &w_sec_zi, &thetal_zi, &w3}) {}
 
   SHOC_NO_SCALAR(SHOCCompThirdMomData, 3);
 };//SHOCCompThirdMomData
@@ -808,6 +808,11 @@ void shoc_diag_second_moments_ubycond_f(Int shcol, Real* thl, Real* qw, Real* wt
                           Real* wqw, Real* qwthl, Real* uw, Real* vw, Real* wtke);
 void update_host_dse_f(Int shcol, Int nlev, Real* thlm, Real* shoc_ql, Real* exner, Real* zt_grid,
                        Real* phis, Real* host_dse);
+void compute_diag_third_shoc_moment_f(Int shcol, Int nlev, Int nlevi, Real* w_sec,
+                                      Real* thl_sec, Real* wthl_sec, Real* tke,
+                                      Real* dz_zt, Real* dz_zi, Real* isotropy_zi,
+                                      Real* brunt_zi, Real* w_sec_zi, Real* thetal_zi,
+                                      Real* w3);
 void shoc_pblintd_init_pot_f(Int shcol, Int nlev, Real* thl, Real* ql, Real* q, Real* thv);
 void compute_shoc_mix_shoc_length_f(Int nlev, Int shcol, Real* tke, Real* brunt,
                                     Real* tscale, Real* zt_grid, Real* l_inf, Real* shoc_mix);

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -870,10 +870,8 @@ contains
  
   subroutine compute_diag_third_shoc_moment_c(&
                              shcol, nlev, nlevi, w_sec, thl_sec, &
-                             qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
-                             dz_zi, zt_grid, zi_grid, isotropy_zi, &
-                             brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
-                             w3) bind(C)
+                             wthl_sec, tke, dz_zt, dz_zi, isotropy_zi, &
+                             brunt_zi, w_sec_zi, thetal_zi, w3) bind(C)
     use shoc, only: compute_diag_third_shoc_moment
 
     integer(kind=c_int), intent(in), value :: shcol
@@ -881,27 +879,22 @@ contains
     integer(kind=c_int), intent(in), value :: nlevi
     real(kind=c_real), intent(in) :: w_sec(shcol,nlev)
     real(kind=c_real), intent(in) :: thl_sec(shcol,nlevi)
-    real(kind=c_real), intent(in) :: qw_sec(shcol,nlevi)
-    real(kind=c_real), intent(in) :: qwthl_sec(shcol,nlevi)
     real(kind=c_real), intent(in) :: wthl_sec(shcol,nlevi)
     real(kind=c_real), intent(in) :: tke(shcol,nlev)
     real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
     real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
-    real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
-    real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
     real(kind=c_real), intent(in) :: isotropy_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: brunt_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: thetal_zi(shcol,nlevi)
-    real(kind=c_real), intent(in) :: wthv_sec_zi(shcol,nlevi)
     
     real(kind=c_real), intent(out) :: w3(shcol,nlevi)
 
     call compute_diag_third_shoc_moment(&
                              shcol, nlev, nlevi, w_sec, thl_sec, &
-                             qw_sec, qwthl_sec, wthl_sec, tke, dz_zt, &
-                             dz_zi, zt_grid, zi_grid, isotropy_zi, &
-                             brunt_zi, w_sec_zi, thetal_zi, wthv_sec_zi, &
+                             wthl_sec, tke, dz_zt, &
+                             dz_zi, isotropy_zi, &
+                             brunt_zi, w_sec_zi, thetal_zi, &
                              w3)
 
   end subroutine compute_diag_third_shoc_moment_c			     

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -86,6 +86,31 @@ interface
 
   end subroutine update_host_dse_f
 
+  subroutine compute_diag_third_shoc_moment_f(shcol, nlev, nlevi, w_sec, thl_sec, &
+                                              wthl_sec, tke, dz_zt, &
+                                              dz_zi, isotropy_zi, &
+                                              brunt_zi, w_sec_zi, thetal_zi, &
+                                              w3) bind(C)
+    use iso_c_binding
+
+    integer(kind=c_int), intent(in), value :: shcol
+    integer(kind=c_int), intent(in), value :: nlev
+    integer(kind=c_int), intent(in), value :: nlevi
+    real(kind=c_real), intent(in) :: w_sec(shcol,nlev)
+    real(kind=c_real), intent(in) :: thl_sec(shcol,nlevi)
+    real(kind=c_real), intent(in) :: wthl_sec(shcol,nlevi)
+    real(kind=c_real), intent(in) :: tke(shcol,nlev)
+    real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
+    real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: isotropy_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: brunt_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi)
+    real(kind=c_real), intent(in) :: thetal_zi(shcol,nlevi)
+
+    real(kind=c_real), intent(out) :: w3(shcol,nlevi)
+
+  end subroutine compute_diag_third_shoc_moment_f
+
   subroutine check_tke_f(shcol, nlev, tke) bind(C)
 
     use iso_c_binding


### PR DESCRIPTION
Port `compute_diag_third_shoc_moment` to C++.

This pull request was already reviewed here: https://github.com/E3SM-Project/scream/pull/602. I decided to switch to non-forked branches so the tester could run without approval, otherwise same code.