### PR TITLE
P3 Bugfix: protect tau_r from div-by-zero

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3201,7 +3201,6 @@ qr2qv_evap_tend,nr_evap_tend)
    !Initialize variables
    qr2qv_evap_tend = 0.0_rtype
    nr_evap_tend = 0.0_rtype
-   tau_r = 1._rtype/epsr
    inv_dt=1._rtype/dt
    
    !Compute absolute supersaturation.
@@ -3267,6 +3266,10 @@ qr2qv_evap_tend,nr_evap_tend)
          !gets big.
          call rain_evap_tscale_weight(dt/tau_eff,tscale_weight)
 
+         !tau_r is only used in this "else" branch so only define it here.
+         !outside this branch qr_incld could be < qsmall, in which case epsr=0.
+         tau_r = 1._rtype/epsr
+         
          !in limit of very long timescales, evap must balance A_c.
          !(1/tau_r)/(1/tau_eff) is the fraction of this total tendency assigned to rain
          !Will be >0 if A_c>0: increased supersat from other procs must be balanced by

--- a/components/scream/src/physics/p3/p3_evaporate_rain_impl.hpp
+++ b/components/scream/src/physics/p3/p3_evaporate_rain_impl.hpp
@@ -88,7 +88,6 @@ void Functions<S,D>
   //Initialize variables
   qr2qv_evap_tend = 0;
   nr_evap_tend = 0;
-  const Spack tau_r(1/epsr);
   const Scalar inv_dt = 1/dt;
   constexpr Scalar QSMALL   = C::QSMALL;
   constexpr Scalar Tmelt  = C::Tmelt;
@@ -118,7 +117,11 @@ void Functions<S,D>
   const Smask is_evap_area = cld_frac_r > cld_frac;
   const Smask is_rain_evap = qr_ge_qsmall && is_subsat && is_evap_area && context;
   if (is_rain_evap.any()){
-							 
+
+    //if qr_incld<QSMALL, epsr=0 causes div by 0 error for tau_r even though it isn't used.
+    Spack tau_r(0);
+    tau_r.set(is_rain_evap, 1/epsr);
+    
     //Compute total effective inverse saturation removal timescale eps_eff
     //qc saturation is handled by macrophysics so the qc saturation removal timescale is
     //not included here. Below freezing, eps_eff is the sum of the inverse saturation


### PR DESCRIPTION
tau_r=1/epsr was calculated even where qr_incld<qsmall => epsr was assigned to zero. tau_r wasn't actually used in this case, so I just moved the tau_r calculation within a qr_incld<qsmall branch (in both C++ and F90). 

This div-by-zero problem was never triggered by scream tests because epsr was always assumed to be a reasonable value. Balwinderfound this problem with e3sm-style tests in debug mode on compy. I was unable to reproduce them on quartz, but it makes conceptual sense that the original impl could cause issues.