### PR TITLE
SHOC property test cleanup

### DIFF
--- a/components/scream/src/physics/shoc/shoc_constants.hpp
+++ b/components/scream/src/physics/shoc/shoc_constants.hpp
@@ -14,6 +14,7 @@ struct Constants
       static constexpr Scalar mintke         = 0.0004;  // Minimum TKE [m2/s2]
       static constexpr Scalar maxtke         = 50.0;    // Maximum TKE [m2/s2]
       static constexpr Scalar maxlen         = 20000.0; // Upper limit for mixing length [m]
+      static constexpr Scalar minlen         = 20.0;    // Lower limit for mixing length [m]
       static constexpr Scalar length_fac     = 0.5;     // Mixing length scaling parameter
       static constexpr Scalar c_diag_3rd_mom = 7.0;     // Coefficient for diag third moment parameters
       static constexpr Scalar w3clip         = 1.2;     // Third moment of vertical velocity

--- a/components/scream/src/physics/shoc/shoc_constants.hpp
+++ b/components/scream/src/physics/shoc/shoc_constants.hpp
@@ -15,6 +15,7 @@ struct Constants
       static constexpr Scalar maxtke         = 50.0;    // Maximum TKE [m2/s2]
       static constexpr Scalar maxlen         = 20000.0; // Upper limit for mixing length [m]
       static constexpr Scalar minlen         = 20.0;    // Lower limit for mixing length [m]
+      static constexpr Scalar maxiso         = 20000.0; // Upper limit for isotropy time scale [s]
       static constexpr Scalar length_fac     = 0.5;     // Mixing length scaling parameter
       static constexpr Scalar c_diag_3rd_mom = 7.0;     // Coefficient for diag third moment parameters
       static constexpr Scalar w3clip         = 1.2;     // Third moment of vertical velocity

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -248,21 +248,21 @@ contains
 
   subroutine check_tke_c(shcol, nlev, tke) bind(C)
     use shoc, only: check_tke
-    
+
     integer(kind=c_int), intent(in), value :: shcol
     integer(kind=c_int), intent(in), value :: nlev
-    
+
     real(kind=c_real), intent(inout) :: tke(shcol,nlev)
-    
-    call check_tke(shcol,nlev,tke)    
-  
+
+    call check_tke(shcol,nlev,tke)
+
   end subroutine check_tke_c
-  
+
   subroutine shoc_tke_c(shcol, nlev, nlevi, dtime, wthv_sec, shoc_mix, dz_zi, &
                         dz_zt, pres, u_wind, v_wind, brunt, obklen, zt_grid, &
 			zi_grid, pblh, tke, tk, tkh, isotropy) bind(C)
     use shoc, only: shoc_tke
-    
+
     integer(kind=c_int), intent(in), value :: shcol
     integer(kind=c_int), intent(in), value :: nlev
     integer(kind=c_int), intent(in), value :: nlevi
@@ -283,12 +283,12 @@ contains
     real(kind=c_real), intent(inout) :: tke(shcol,nlev)
     real(kind=c_real), intent(inout) :: tk(shcol,nlev)
     real(kind=c_real), intent(inout) :: tkh(shcol,nlev)
-    real(kind=c_real), intent(out) :: isotropy(shcol,nlev) 
-    
+    real(kind=c_real), intent(out) :: isotropy(shcol,nlev)
+
     call shoc_tke(shcol, nlev, nlevi, dtime, wthv_sec, shoc_mix, dz_zi, &
                         dz_zt, pres, u_wind, v_wind, brunt, obklen, zt_grid, &
 			zi_grid, pblh, tke, tk, tkh, isotropy)
-			
+
   end subroutine shoc_tke_c
 
   subroutine integ_column_stability_c(nlev, shcol, dz_zt, pres, brunt, brunt_int) bind (C)
@@ -320,7 +320,7 @@ contains
 
     call compute_shr_prod(nlevi, nlev, shcol, dz_zi, u_wind, v_wind, sterm)
 
-  end subroutine compute_shr_prod_c			                   
+  end subroutine compute_shr_prod_c
 
   subroutine isotropic_ts_c(nlev, shcol, brunt_int, tke, a_diss, brunt, isotropy) bind (C)
     use shoc, only: isotropic_ts
@@ -377,7 +377,7 @@ contains
     real(kind=c_real), intent(out) :: tk(shcol,nlev)
 
     call eddy_diffusivities(nlev, shcol, obklen, pblh, zt_grid, &
-     shoc_mix, sterm_zt, isotropy, tke, tkh, tk)
+                        shoc_mix, sterm_zt, isotropy, tke, tkh, tk)
 
   end subroutine eddy_diffusivities_c
 
@@ -399,7 +399,7 @@ contains
                            phis, host_dse)
 
   end subroutine update_host_dse_c
-  
+
   subroutine shoc_energy_fixer_c(shcol, nlev, nlevi, dtime, nadv, &
                                  zt_grid, zi_grid, se_b, ke_b, wv_b, &
                                  wl_b, se_a, ke_a, wv_a, wl_a, wthl_sfc, &
@@ -428,9 +428,9 @@ contains
     real(kind=c_real), intent(in) :: rho_zt(shcol,nlev)
     real(kind=c_real), intent(in) :: tke(shcol,nlev)
     real(kind=c_real), intent(in) :: pint(shcol,nlevi)
-    
+
     real(kind=c_real), intent(inout) :: host_dse(shcol,nlev)
-    
+
     call shoc_energy_fixer(shcol, nlev, nlevi, dtime, nadv, &
                            zt_grid, zi_grid, se_b, ke_b, wv_b, &
                            wl_b, se_a, ke_a, wv_a, wl_a, wthl_sfc, &
@@ -463,7 +463,7 @@ contains
                                se_int, ke_int, wv_int, wl_int)
 
   end subroutine shoc_energy_integrals_c
-  
+
   subroutine shoc_energy_total_fixer_c(&
                                 shcol,nlev,nlevi,dtime,nadv,&
                                 zt_grid,zi_grid,&
@@ -478,7 +478,7 @@ contains
     integer(kind=c_int), intent(in), value :: nlevi
     integer(kind=c_int), intent(in), value :: nadv
     real(kind=c_real), intent(in), value :: dtime
-    
+
     real(kind=c_real), intent(in) :: se_b(shcol)
     real(kind=c_real), intent(in) :: ke_b(shcol)
     real(kind=c_real), intent(in) :: wv_b(shcol)
@@ -513,12 +513,12 @@ contains
     integer(kind=c_int), intent(in), value :: shcol
     integer(kind=c_int), intent(in), value :: nlev
     integer(kind=c_int), intent(in), value :: nlevi
-    
+
     real(kind=c_real), intent(in) :: pint(shcol,nlevi)
     real(kind=c_real), intent(in) :: tke(shcol,nlev)
     real(kind=c_real), intent(in) :: te_a(shcol)
     real(kind=c_real), intent(in) :: te_b(shcol)
-    
+
     real(kind=c_real), intent(out) :: se_dis(shcol)
     integer(kind=c_int), intent(out) :: shoctop(shcol)
 
@@ -527,7 +527,7 @@ contains
                                      se_dis,shoctop)
 
   end subroutine shoc_energy_threshold_fixer_c
-  
+
   subroutine shoc_energy_dse_fixer_c(shcol,nlev, &
                                      se_dis,shoctop, &
                                      host_dse) bind (C)
@@ -544,7 +544,7 @@ contains
                                se_dis,shoctop, &
                                host_dse)
 
-  end subroutine shoc_energy_dse_fixer_c  
+  end subroutine shoc_energy_dse_fixer_c
 
   subroutine calc_shoc_vertflux_c(shcol, nlev, nlevi, tkh_zi, dz_zi, invar, vertflux) bind (C)
     use shoc, only: calc_shoc_vertflux
@@ -561,18 +561,18 @@ contains
     call calc_shoc_vertflux(shcol, nlev, nlevi, tkh_zi, dz_zi, invar, vertflux)
 
   end subroutine calc_shoc_vertflux_c
-  
+
   subroutine shoc_length_c(shcol, nlev, nlevi, tke, host_dx, host_dy, pblh, &
                 zt_grid, zi_grid, dz_zt, dz_zi, thetal, wthv_sec, thv, &
 		brunt, shoc_mix) bind (C)
     use shoc, only: shoc_length
-    
+
     integer(kind=c_int), intent(in), value :: shcol
     integer(kind=c_int), intent(in), value :: nlev
     integer(kind=c_int), intent(in), value :: nlevi
     real(kind=c_real), intent(in) :: tke(shcol,nlev)
     real(kind=c_real), intent(in) :: host_dx(shcol)
-    real(kind=c_real), intent(in) :: host_dy(shcol)  
+    real(kind=c_real), intent(in) :: host_dy(shcol)
     real(kind=c_real), intent(in) :: pblh(shcol)
     real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
     real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
@@ -581,14 +581,14 @@ contains
     real(kind=c_real), intent(in) :: wthv_sec(shcol,nlev)
     real(kind=c_real), intent(in) :: thetal(shcol,nlev)
     real(kind=c_real), intent(in) :: thv(shcol,nlev)
-    
+
     real(kind=c_real), intent(out) :: brunt(shcol,nlev)
     real(kind=c_real), intent(out) :: shoc_mix(shcol,nlev)
-    
+
     call shoc_length(shcol, nlev, nlevi, tke, host_dx, host_dy, pblh, &
                 zt_grid, zi_grid, dz_zt, dz_zi, thetal, wthv_sec, thv, &
 		brunt, shoc_mix)
-		
+
   end subroutine shoc_length_c
 
   subroutine compute_brunt_shoc_length_c(nlev,nlevi,shcol,dz_zt,thv,thv_zi,brunt) bind (C)
@@ -598,16 +598,15 @@ contains
     integer(kind=c_int), intent(in), value :: nlevi
     integer(kind=c_int), intent(in), value :: shcol
     real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
-    real(kind=c_real), intent(in) :: thv(shcol,nlev)  
+    real(kind=c_real), intent(in) :: thv(shcol,nlev)
     real(kind=c_real), intent(in) :: thv_zi(shcol,nlevi)
 
     real(kind=c_real), intent(out) :: brunt(shcol,nlev)
 
     call compute_brunt_shoc_length(nlev,nlevi,shcol,dz_zt,thv,thv_zi,brunt)
 
-  end subroutine compute_brunt_shoc_length_c  
-  
-  
+  end subroutine compute_brunt_shoc_length_c
+
   subroutine compute_l_inf_shoc_length_c(nlev,shcol,zt_grid,dz_zt,tke,l_inf) bind (C)
     use shoc, only: compute_l_inf_shoc_length
 
@@ -615,15 +614,14 @@ contains
     integer(kind=c_int), intent(in), value :: shcol
     real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
     real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
-    real(kind=c_real), intent(in) :: tke(shcol,nlev)  
+    real(kind=c_real), intent(in) :: tke(shcol,nlev)
 
     real(kind=c_real), intent(out) :: l_inf(shcol)
 
     call compute_l_inf_shoc_length(nlev,shcol,zt_grid,dz_zt,tke,l_inf)
 
-  end subroutine compute_l_inf_shoc_length_c  
-  
-  
+  end subroutine compute_l_inf_shoc_length_c
+
   subroutine compute_conv_vel_shoc_length_c(nlev,shcol,pblh,zt_grid,dz_zt,&
                                             thv,wthv_sec,conv_vel) bind (C)
     use shoc, only: compute_conv_vel_shoc_length
@@ -634,26 +632,26 @@ contains
     real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
     real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
     real(kind=c_real), intent(in) :: thv(shcol,nlev)
-    real(kind=c_real), intent(in) :: wthv_sec(shcol,nlev)  
+    real(kind=c_real), intent(in) :: wthv_sec(shcol,nlev)
 
     real(kind=c_real), intent(out) :: conv_vel(shcol)
 
     call compute_conv_vel_shoc_length(nlev,shcol,pblh,zt_grid,dz_zt,thv,wthv_sec,conv_vel)
 
-  end subroutine compute_conv_vel_shoc_length_c 
-  
+  end subroutine compute_conv_vel_shoc_length_c
+
   subroutine compute_conv_time_shoc_length_c(shcol,pblh,conv_vel,tscale) bind (C)
     use shoc, only: compute_conv_time_shoc_length
 
     integer(kind=c_int), intent(in), value :: shcol
-    real(kind=c_real), intent(in) :: pblh(shcol)  
+    real(kind=c_real), intent(in) :: pblh(shcol)
     real(kind=c_real), intent(inout) :: conv_vel(shcol)
     real(kind=c_real), intent(out) :: tscale(shcol)
 
     call compute_conv_time_shoc_length(shcol,pblh,conv_vel,tscale)
 
-  end subroutine compute_conv_time_shoc_length_c 
-  
+  end subroutine compute_conv_time_shoc_length_c
+
   subroutine compute_shoc_mix_shoc_length_c(nlev,shcol,tke,brunt,tscale,&
                                          zt_grid,l_inf,shoc_mix) bind (C)
     use shoc, only: compute_shoc_mix_shoc_length
@@ -664,42 +662,42 @@ contains
     real(kind=c_real), intent(in) :: brunt(shcol,nlev)
     real(kind=c_real), intent(in) :: tscale(shcol)
     real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
-    real(kind=c_real), intent(in) :: l_inf(shcol) 
+    real(kind=c_real), intent(in) :: l_inf(shcol)
 
     real(kind=c_real), intent(out) :: shoc_mix(shcol,nlev)
 
     call compute_shoc_mix_shoc_length(nlev,shcol,tke,brunt,tscale,zt_grid,&
                                       l_inf,shoc_mix)
 
-  end subroutine compute_shoc_mix_shoc_length_c 
-  
+  end subroutine compute_shoc_mix_shoc_length_c
+
   subroutine check_length_scale_shoc_length_c(nlev,shcol,host_dx,host_dy,shoc_mix) bind (C)
     use shoc, only: check_length_scale_shoc_length
 
     integer(kind=c_int), intent(in), value :: nlev
     integer(kind=c_int), intent(in), value :: shcol
     real(kind=c_real), intent(in) :: host_dx(shcol)
-    real(kind=c_real), intent(in) :: host_dy(shcol)  
+    real(kind=c_real), intent(in) :: host_dy(shcol)
 
     real(kind=c_real), intent(inout) :: shoc_mix(shcol,nlev)
 
     call check_length_scale_shoc_length(nlev,shcol,host_dx,host_dy,shoc_mix)
 
   end subroutine check_length_scale_shoc_length_c
-  
+
   subroutine clipping_diag_third_shoc_moments_c(nlevi,shcol,w_sec_zi,w3) bind (C)
     use shoc, only: clipping_diag_third_shoc_moments
 
     integer(kind=c_int), intent(in), value :: nlevi
     integer(kind=c_int), intent(in), value :: shcol
-    real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi) 
+    real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi)
 
     real(kind=c_real), intent(inout) :: w3(shcol,nlevi)
 
     call clipping_diag_third_shoc_moments(nlevi,shcol,w_sec_zi,w3)
 
   end subroutine clipping_diag_third_shoc_moments_c
-  
+
   subroutine fterms_input_for_diag_third_shoc_moment_c(&
                          dz_zi, dz_zt, dz_zt_kc, &
                          isotropy_zi, brunt_zi, thetal_zi, &
@@ -725,11 +723,11 @@ contains
                          thedz, thedz2, iso, isosqrd, buoy_sgs2, bet2)
 
   end subroutine fterms_input_for_diag_third_shoc_moment_c
-  
+
   subroutine f0_to_f5_diag_third_shoc_moment_c(&
                           thedz, thedz2, bet2, iso, isosqrd, &
                           wthl_sec, wthl_sec_kc, wthl_sec_kb, &
-                          thl_sec, thl_sec_kc, thl_sec_kb, & 
+                          thl_sec, thl_sec_kc, thl_sec_kb, &
                           w_sec, w_sec_kc,w_sec_zi, &
                           tke, tke_kc, &
                           f0, f1, f2, f3, f4, f5) bind (C)
@@ -762,28 +760,28 @@ contains
     call f0_to_f5_diag_third_shoc_moment(&
                           thedz, thedz2, bet2, iso, isosqrd, &
                           wthl_sec, wthl_sec_kc, wthl_sec_kb, &
-                          thl_sec, thl_sec_kc, thl_sec_kb, & 
+                          thl_sec, thl_sec_kc, thl_sec_kb, &
                           w_sec, w_sec_kc,w_sec_zi, &
                           tke, tke_kc, &
                           f0, f1, f2, f3, f4, f5)
 
   end subroutine f0_to_f5_diag_third_shoc_moment_c
-  
+
   subroutine w3_diag_third_shoc_moment_c(aa0, aa1, x0, x1, f5, w3) bind (c)
     use shoc, only: w3_diag_third_shoc_moment
-    
+
     real(kind=c_real), intent(in), value :: aa0
     real(kind=c_real), intent(in), value :: aa1
     real(kind=c_real), intent(in), value :: x0
     real(kind=c_real), intent(in), value :: x1
     real(kind=c_real), intent(in), value :: f5
-    
+
     real(kind=c_real), intent(out) :: w3
 
     w3 = w3_diag_third_shoc_moment(aa0, aa1, x0, x1, f5)
-    
+
   end subroutine w3_diag_third_shoc_moment_c
-  
+
   subroutine omega_terms_diag_third_shoc_moment_c(&
                           buoy_sgs2, f3, f4,&
 			  omega0, omega1, omega2) bind (C)
@@ -801,8 +799,8 @@ contains
                           buoy_sgs2, f3, f4, &
 			  omega0, omega1, omega2)
 
-  end subroutine omega_terms_diag_third_shoc_moment_c 
-  
+  end subroutine omega_terms_diag_third_shoc_moment_c
+
   subroutine x_y_terms_diag_third_shoc_moment_c(&
                           buoy_sgs2, f0, f1, f2,&
 			  x0, y0, x1, y1) bind (C)
@@ -822,8 +820,8 @@ contains
                           buoy_sgs2, f0, f1, f2,&
 			  x0, y0, x1, y1)
 
-  end subroutine x_y_terms_diag_third_shoc_moment_c 
-  
+  end subroutine x_y_terms_diag_third_shoc_moment_c
+
   subroutine aa_terms_diag_third_shoc_moment_c(&
                           omega0, omega1, omega2,&
 			  x0, x1, y0, y1, &
@@ -846,7 +844,7 @@ contains
 			  x0, x1, y0, y1, &
 			  aa0, aa1)
 
-  end subroutine aa_terms_diag_third_shoc_moment_c        
+  end subroutine aa_terms_diag_third_shoc_moment_c
 
   subroutine shoc_diag_second_moments_srf_c(shcol, wthl, uw, vw, ustar2, wstar) bind(C)
    use shoc, only: diag_second_moments_srf
@@ -865,7 +863,7 @@ contains
                              tke, wthv_sec, dz_zt, dz_zi, &
                              zt_grid, zi_grid, w3) bind(C)
   use shoc, only: diag_third_shoc_moments
-  
+
     integer(kind=c_int), intent(in), value :: shcol
     integer(kind=c_int), intent(in), value :: nlev
     integer(kind=c_int), intent(in), value :: nlevi
@@ -883,16 +881,16 @@ contains
     real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
     real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
-    
+
     real(kind=c_real), intent(out) :: w3(shcol,nlevi)
-    
+
     call diag_third_shoc_moments(&
                      shcol, nlev, nlevi, w_sec, thl_sec, qw_sec, &
                      qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
                      tke, wthv_sec, dz_zt, dz_zi, zt_grid, zi_grid, w3)
-			     
+
   end subroutine diag_third_shoc_moments_c
- 
+
   subroutine compute_diag_third_shoc_moment_c(&
                              shcol, nlev, nlevi, w_sec, thl_sec, &
                              wthl_sec, tke, dz_zt, dz_zi, isotropy_zi, &
@@ -912,7 +910,7 @@ contains
     real(kind=c_real), intent(in) :: brunt_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: w_sec_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: thetal_zi(shcol,nlevi)
-    
+
     real(kind=c_real), intent(out) :: w3(shcol,nlevi)
 
     call compute_diag_third_shoc_moment(&
@@ -922,7 +920,7 @@ contains
                              brunt_zi, w_sec_zi, thetal_zi, &
                              w3)
 
-  end subroutine compute_diag_third_shoc_moment_c			     
+  end subroutine compute_diag_third_shoc_moment_c
 
   subroutine linear_interp_c(x1, x2, y1, y2, km1, km2, ncol, minthresh) bind(C)
     use shoc, only : linear_interp
@@ -979,21 +977,21 @@ contains
 
     real(kind=c_real), intent(in), value :: w_first
     real(kind=c_real), intent(in), value :: sqrtw2
-    
+
     real(kind=c_real), intent(inout) :: w1
 
     call shoc_assumed_pdf_tilda_to_real(w_first, sqrtw2, w1)
 
-  end subroutine shoc_assumed_pdf_tilda_to_real_c   
-  
-  subroutine shoc_assumed_pdf_vv_parameters_c(w_first,w_sec,w3var,&         
+  end subroutine shoc_assumed_pdf_tilda_to_real_c
+
+  subroutine shoc_assumed_pdf_vv_parameters_c(w_first,w_sec,w3var,&
                                               Skew_w,w1_1,w1_2,w2_1,w2_2,a) bind (C)
     use shoc, only: shoc_assumed_pdf_vv_parameters
 
     real(kind=c_real), intent(in), value :: w_first
     real(kind=c_real), intent(in), value :: w_sec
     real(kind=c_real), intent(in), value :: w3var
-    
+
     real(kind=c_real), intent(out) :: Skew_w
     real(kind=c_real), intent(out) :: w1_1
     real(kind=c_real), intent(out) :: w1_2
@@ -1001,13 +999,13 @@ contains
     real(kind=c_real), intent(out) :: w2_2
     real(kind=c_real), intent(out) :: a
 
-    call shoc_assumed_pdf_vv_parameters(w_first,w_sec,w3var,&         
+    call shoc_assumed_pdf_vv_parameters(w_first,w_sec,w3var,&
                                         Skew_w,w1_1,w1_2,w2_1,w2_2,a)
 
-  end subroutine shoc_assumed_pdf_vv_parameters_c   
-  
+  end subroutine shoc_assumed_pdf_vv_parameters_c
+
   subroutine shoc_assumed_pdf_thl_parameters_c(&
-                           wthlsec,sqrtw2,sqrtthl,thlsec,thl_first,& 
+                           wthlsec,sqrtw2,sqrtthl,thlsec,thl_first,&
                            w1_1,w1_2,Skew_w,a,dothetal_skew,&
                            thl1_1,thl1_2,thl2_1,thl2_2,sqrtthl2_1,&
                            sqrtthl2_2) bind (C)
@@ -1032,15 +1030,15 @@ contains
     real(kind=c_real), intent(out) :: sqrtthl2_2
 
     call shoc_assumed_pdf_thl_parameters(&
-                           wthlsec,sqrtw2,sqrtthl,thlsec,thl_first,& 
+                           wthlsec,sqrtw2,sqrtthl,thlsec,thl_first,&
                            w1_1,w1_2,Skew_w,a,dothetal_skew,&
                            thl1_1,thl1_2,thl2_1,thl2_2,sqrtthl2_1,&
                            sqrtthl2_2)
 
-  end subroutine shoc_assumed_pdf_thl_parameters_c  
-  
+  end subroutine shoc_assumed_pdf_thl_parameters_c
+
   subroutine shoc_assumed_pdf_qw_parameters_c(&
-                           wqwsec,sqrtw2,Skew_w,sqrtqt,qwsec,& 
+                           wqwsec,sqrtw2,Skew_w,sqrtqt,qwsec,&
                            w1_1,w1_2,qw_first,a,&
                            qw1_1,qw1_2,qw2_1,qw2_2,sqrtqw2_1,&
                            sqrtqw2_2) bind (C)
@@ -1064,13 +1062,13 @@ contains
     real(kind=c_real), intent(out) :: sqrtqw2_2
 
     call shoc_assumed_pdf_qw_parameters(&
-                          wqwsec,sqrtw2,Skew_w,sqrtqt,qwsec,& 
+                          wqwsec,sqrtw2,Skew_w,sqrtqt,qwsec,&
                           w1_1,w1_2,qw_first,a,&
                           qw1_1,qw1_2,qw2_1,qw2_2,sqrtqw2_1,&
                           sqrtqw2_2)
 
   end subroutine shoc_assumed_pdf_qw_parameters_c
-  
+
   subroutine shoc_assumed_pdf_inplume_correlations_c(&
                 sqrtqw2_1,sqrtthl2_1,a,sqrtqw2_2,sqrtthl2_2,&
                 qwthlsec,qw1_1,qw_first,thl1_1,thl_first,qw1_2,thl1_2,&
@@ -1097,8 +1095,8 @@ contains
                 qwthlsec,qw1_1,qw_first,thl1_1,thl_first,qw1_2,thl1_2,&
                 r_qwthl_1)
 
-  end subroutine shoc_assumed_pdf_inplume_correlations_c    
-  
+  end subroutine shoc_assumed_pdf_inplume_correlations_c
+
   subroutine shoc_assumed_pdf_compute_temperature_c(&
                                    thl1,basepres,pval,Tl1) bind (C)
     use shoc, only: shoc_assumed_pdf_compute_temperature
@@ -1106,13 +1104,13 @@ contains
     real(kind=c_real), intent(in), value :: thl1
     real(kind=c_real), intent(in), value :: basepres
     real(kind=c_real), intent(in), value :: pval
-    
+
     real(kind=c_real), intent(out) :: Tl1
 
     call shoc_assumed_pdf_compute_temperature(thl1,basepres,pval,Tl1)
 
-  end subroutine shoc_assumed_pdf_compute_temperature_c    
-  
+  end subroutine shoc_assumed_pdf_compute_temperature_c
+
   subroutine shoc_assumed_pdf_compute_qs_c(&
                               Tl1_1,Tl1_2,pval,&
                               qs1,beta1,qs2,beta2) bind (C)
@@ -1121,7 +1119,7 @@ contains
     real(kind=c_real), intent(in), value :: Tl1_1
     real(kind=c_real), intent(in), value :: Tl1_2
     real(kind=c_real), intent(in), value :: pval
-    
+
     real(kind=c_real), intent(out) :: qs1
     real(kind=c_real), intent(out) :: beta1
     real(kind=c_real), intent(out) :: qs2
@@ -1131,8 +1129,8 @@ contains
                               Tl1_1,Tl1_2,pval,&
                               qs1,beta1,qs2,beta2)
 
-  end subroutine shoc_assumed_pdf_compute_qs_c  
-  
+  end subroutine shoc_assumed_pdf_compute_qs_c
+
   subroutine shoc_assumed_pdf_compute_s_c(&
                               qw1,qs1,beta,pval,thl2,&
                               qw2,sqrtthl2,sqrtqw2,r_qwthl,&
@@ -1148,7 +1146,7 @@ contains
     real(kind=c_real), intent(in), value :: sqrtthl2
     real(kind=c_real), intent(in), value :: sqrtqw2
     real(kind=c_real), intent(in), value :: r_qwthl
-    
+
     real(kind=c_real), intent(out) :: s
     real(kind=c_real), intent(out) :: std_s
     real(kind=c_real), intent(out) :: qn
@@ -1157,10 +1155,10 @@ contains
     call shoc_assumed_pdf_compute_s(&
                               qw1,qs1,beta,pval,thl2,&
                               qw2,sqrtthl2,sqrtqw2,r_qwthl,&
-                              s,std_s,qn,C)		      
+                              s,std_s,qn,C)
 
-  end subroutine shoc_assumed_pdf_compute_s_c 
-  
+  end subroutine shoc_assumed_pdf_compute_s_c
+
   subroutine shoc_assumed_pdf_compute_sgs_liquid_c(&
                               a,ql1,ql2,shoc_ql) bind (C)
     use shoc, only: shoc_assumed_pdf_compute_sgs_liquid
@@ -1168,14 +1166,14 @@ contains
     real(kind=c_real), intent(in), value :: a
     real(kind=c_real), intent(in), value :: ql1
     real(kind=c_real), intent(in), value :: ql2
-    
+
     real(kind=c_real), intent(out) :: shoc_ql
 
     call shoc_assumed_pdf_compute_sgs_liquid(&
                               a,ql1,ql2,shoc_ql)
 
-  end subroutine shoc_assumed_pdf_compute_sgs_liquid_c 
-  
+  end subroutine shoc_assumed_pdf_compute_sgs_liquid_c
+
   subroutine shoc_assumed_pdf_compute_cloud_liquid_variance_c(&
                                            a,s1,ql1,C1,std_s1,&
                                            s2,ql2,C2,std_s2,shoc_ql,&
@@ -1192,7 +1190,7 @@ contains
     real(kind=c_real), intent(in), value :: C2
     real(kind=c_real), intent(in), value :: std_s2
     real(kind=c_real), intent(in), value :: shoc_ql
-    
+
     real(kind=c_real), intent(out) :: shoc_ql2
 
     call shoc_assumed_pdf_compute_cloud_liquid_variance(&
@@ -1200,8 +1198,8 @@ contains
                                            s2,ql2,C2,std_s2,shoc_ql,&
                                            shoc_ql2)
 
-  end subroutine shoc_assumed_pdf_compute_cloud_liquid_variance_c 
-  
+  end subroutine shoc_assumed_pdf_compute_cloud_liquid_variance_c
+
   subroutine shoc_assumed_pdf_compute_liquid_water_flux_c(&
                                      a,w1_1,w_first,ql1,w1_2,ql2,&
                                      wqls) bind (C)
@@ -1213,15 +1211,15 @@ contains
     real(kind=c_real), intent(in), value :: ql1
     real(kind=c_real), intent(in), value :: w1_2
     real(kind=c_real), intent(in), value :: ql2
-    
+
     real(kind=c_real), intent(out) :: wqls
 
     call shoc_assumed_pdf_compute_liquid_water_flux(&
                                      a,w1_1,w_first,ql1,w1_2,ql2,&
                                      wqls)
 
-  end subroutine shoc_assumed_pdf_compute_liquid_water_flux_c  
-  
+  end subroutine shoc_assumed_pdf_compute_liquid_water_flux_c
+
   subroutine shoc_assumed_pdf_compute_buoyancy_flux_c(&
                                      wthlsec,epsterm,wqwsec,pval,wqls,&
                                      wthv_sec) bind (C)
@@ -1232,14 +1230,14 @@ contains
     real(kind=c_real), intent(in), value :: wqwsec
     real(kind=c_real), intent(in), value :: pval
     real(kind=c_real), intent(in), value :: wqls
-    
+
     real(kind=c_real), intent(out) :: wthv_sec
 
     call shoc_assumed_pdf_compute_buoyancy_flux(&
                                      wthlsec,epsterm,wqwsec,pval,wqls,&
                                      wthv_sec)
 
-  end subroutine shoc_assumed_pdf_compute_buoyancy_flux_c            
+  end subroutine shoc_assumed_pdf_compute_buoyancy_flux_c
 
  subroutine shoc_diag_second_moments_ubycond_c(shcol, thl, qw, wthl, wqw, qwthl, uw, vw, wtke) bind(C)
    use shoc, only: diag_second_moments_ubycond

--- a/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_aa_diag_third_moms_tests.cpp
@@ -27,11 +27,11 @@ struct UnitWrap::UnitTest<D>::TestAAdiagThirdMoms {
 
     // Tests for the SHOC function:
     //   aa_terms_diag_third_shoc_moment
-    
+
     // Run test two times.  One where 0 parameters stay the same
     //  and the other where 1 parameters vary.  Verify that the aa0
-    //  term remains constant between the two tests.  
-  
+    //  term remains constant between the two tests.
+
     // omega0 term
     constexpr static Real omega0 = 7.54e-2;
     // omega1 term
@@ -45,7 +45,7 @@ struct UnitWrap::UnitTest<D>::TestAAdiagThirdMoms {
     // x1 term
     constexpr static Real x1_test1a = 41.05;
     // y1 term
-    constexpr static Real y1_test1a = 375.69;            
+    constexpr static Real y1_test1a = 375.69;
 
     // Initialize data structure for bridging to F90
     SHOCAAdiagthirdmomsData SDS;
@@ -58,31 +58,31 @@ struct UnitWrap::UnitTest<D>::TestAAdiagThirdMoms {
     SDS.x1 = x1_test1a;
     SDS.y1 = y1_test1a;
     SDS.omega2 = omega2;
-      
-    // Call the fortran implementation    
-    aa_terms_diag_third_shoc_moment(SDS);  
-    
+
+    // Call the fortran implementation
+    aa_terms_diag_third_shoc_moment(SDS);
+
     // Save the output
     Real aa0_test1a = SDS.aa0;
     Real aa1_test1a = SDS.aa1;
-    
+
     // Load up data where only the 1 terms have varies
     SDS.x1 = 0.3*x1_test1a;
-    SDS.y1 = 0.3*y1_test1a;   
-    
-    // Call the fortran implementation    
-    aa_terms_diag_third_shoc_moment(SDS); 
-    
+    SDS.y1 = 0.3*y1_test1a;
+
+    // Call the fortran implementation
+    aa_terms_diag_third_shoc_moment(SDS);
+
     // Check the result
     REQUIRE(SDS.aa0 == aa0_test1a);
-    REQUIRE(SDS.aa1 < aa1_test1a);       
-    
+    REQUIRE(SDS.aa1 < aa1_test1a);
+
   }
-  
+
   static void run_bfb()
   {
     // TODO
-  }  
+  }
 
 };
 
@@ -95,7 +95,7 @@ namespace{
 TEST_CASE("shoc_aa_diag_third_moms_property", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestAAdiagThirdMoms;
-  
+
   TestStruct::run_property();
 }
 

--- a/components/scream/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
@@ -59,6 +59,12 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
 
     // All variances will be given zero or minimum threshold inputs
 
+    // Define some reasonable bounds for output
+    static constexpr Real wqls_bound = 0.1;
+    static constexpr Real wthv_sec_bound = 10;
+    static constexpr Real shoc_ql2_bound = 0.1;
+    static constexpr Real shoc_ql_bound = 0.1;
+
     Real zt_grid[nlev];
     // Compute heights on midpoint grid
     for(Int n = 0; n < nlev; ++n) {
@@ -189,8 +195,10 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
         REQUIRE( (SDS.shoc_cldfrac[offset] == 0  || SDS.shoc_cldfrac[offset] == 1) );
         REQUIRE(SDS.wqls[offset] == 0);
         REQUIRE(SDS.wthv_sec[offset] != 0);
+	REQUIRE(std::abs(SDS.wthv_sec[offset] < wthv_sec_bound));
         REQUIRE(SDS.shoc_ql2[offset] == 0);
         REQUIRE(SDS.shoc_ql[offset] >= 0);
+	REQUIRE(SDS.shoc_ql[offset] < shoc_ql_bound);
       }
     }
 
@@ -268,9 +276,9 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
         REQUIRE(SDS.shoc_ql[offset] > 0);
 
         REQUIRE(SDS.wqls[offset] < 0.1);
-        REQUIRE(SDS.wthv_sec[offset] < 10.0);
-        REQUIRE(SDS.shoc_ql2[offset] < 0.1);
-        REQUIRE(SDS.shoc_ql[offset] < 0.1);
+        REQUIRE(SDS.wthv_sec[offset] < wthv_sec_bound);
+        REQUIRE(SDS.shoc_ql2[offset] < shoc_ql2_bound);
+        REQUIRE(SDS.shoc_ql[offset] < shoc_ql_bound);
 
         // Now verify that the relationships in a strongly positive vertical
         //  velocity flux regime hold true, relative to a symmetric vertical
@@ -346,10 +354,10 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
         REQUIRE(SDS.shoc_ql2[offset] > 0);
         REQUIRE(SDS.shoc_ql[offset] >= 0);
 
-        REQUIRE(std::abs(SDS.wqls[offset] )< 0.1);
-        REQUIRE(std::abs(SDS.wthv_sec[offset]) < 10.0);
-        REQUIRE(SDS.shoc_ql2[offset] < 0.1);
-        REQUIRE(SDS.shoc_ql[offset] < 0.1);
+        REQUIRE(std::abs(SDS.wqls[offset] ) < wqls_bound);
+        REQUIRE(std::abs(SDS.wthv_sec[offset]) < wthv_sec_bound);
+        REQUIRE(SDS.shoc_ql2[offset] < shoc_ql2_bound);
+        REQUIRE(SDS.shoc_ql[offset] < shoc_ql_bound);
 
         // Now verify that the relationships in a strongly negative vertical
         //  velocity flux regime hold true, relative to a symmetric vertical

--- a/components/scream/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
@@ -77,7 +77,7 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
     // Load input data
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
         SDS.thetal[offset] = thetal[n];
         SDS.qw[offset] = qw[n];
@@ -88,7 +88,7 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
       }
 
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
 
         SDS.thl_sec[offset] = 0;
         SDS.qw_sec[offset] = 0;
@@ -124,14 +124,14 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev - 1; ++n) {
         const auto offset = n + s * nlev;
-        REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0.0);
-        REQUIRE(SDS.pres[offset + 1] - SDS.pres[offset] > 0.0);
+        REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
+        REQUIRE(SDS.pres[offset + 1] - SDS.pres[offset] > 0);
       }
 
       // Check that zi increase upward
       for(Int n = 0; n < nlevi - 1; ++n) {
         const auto offset = n + s * nlevi;
-        REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0.0);
+        REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0);
       }
 
     }
@@ -195,10 +195,10 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
         REQUIRE( (SDS.shoc_cldfrac[offset] == 0  || SDS.shoc_cldfrac[offset] == 1) );
         REQUIRE(SDS.wqls[offset] == 0);
         REQUIRE(SDS.wthv_sec[offset] != 0);
-	REQUIRE(std::abs(SDS.wthv_sec[offset] < wthv_sec_bound));
+        REQUIRE(std::abs(SDS.wthv_sec[offset] < wthv_sec_bound));
         REQUIRE(SDS.shoc_ql2[offset] == 0);
         REQUIRE(SDS.shoc_ql[offset] >= 0);
-	REQUIRE(SDS.shoc_ql[offset] < shoc_ql_bound);
+        REQUIRE(SDS.shoc_ql[offset] < shoc_ql_bound);
       }
     }
 
@@ -317,7 +317,7 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
     // Load input data
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
 
         SDS.w3[offset] = s*-1.0;
       }

--- a/components/scream/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
@@ -115,7 +115,7 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
 
         // Validate that values fall within some
         //  reasonable bounds for this variable.
-	REQUIRE(std::abs(SDS.brunt[offset]) < brunt_bound);
+        REQUIRE(std::abs(SDS.brunt[offset]) < brunt_bound);
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
@@ -39,11 +39,14 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
     //  to test a range of conditions.
 
     // Grid difference centered on thermo grid [m]
-    static constexpr Real dz_zt[nlev] = {100.0, 75.0, 50.0, 25.0, 10.0};
+    static constexpr Real dz_zt[nlev] = {100, 75, 50, 25, 10};
     // Virtual potential temperature on interface grid [K]
-    static constexpr Real thv_zi[nlevi] = {310.0, 305.0, 300.0, 300.0, 295.0, 305.0};
+    static constexpr Real thv_zi[nlevi] = {310, 305, 300, 300, 295, 305};
 
-    // Initialize data structure for bridgeing to F90
+    // Define reasonable bound for output
+    static constexpr Real brunt_bound = 1;
+
+    // Initialize data structure for bridging to F90
     SHOCBruntlengthData SDS(shcol, nlev, nlevi);
 
     // Test that the inputs are reasonable.
@@ -76,13 +79,13 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev - 1; ++n) {
         const auto offset = n + s * nlev;
-        REQUIRE(SDS.dz_zt[offset] > 0.0);
-        REQUIRE(SDS.thv[offset] > 0.0);
+        REQUIRE(SDS.dz_zt[offset] > 0);
+        REQUIRE(SDS.thv[offset] > 0);
       }
 
       for(Int n = 0; n < nlevi - 1; ++n) {
         const auto offset = n + s * nlevi;
-        REQUIRE(SDS.thv_zi[offset] > 0.0);
+        REQUIRE(SDS.thv_zi[offset] > 0);
       }
     }
 
@@ -98,22 +101,21 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
         //  is the correct sign given atmospheric conditions
 
         // well mixed layer
-        if (thv_zi[n] - thv_zi[n+1] == 0.0){
-          REQUIRE(SDS.brunt[offset] == 0.0);
+        if (thv_zi[n] - thv_zi[n+1] == 0){
+          REQUIRE(SDS.brunt[offset] == 0);
         }
         // unstable layer
-        if (thv_zi[n] - thv_zi[n+1] < 0.0){
-          REQUIRE(SDS.brunt[offset] < 0.0);
+        if (thv_zi[n] - thv_zi[n+1] < 0){
+          REQUIRE(SDS.brunt[offset] < 0);
         }
         // stable layer
-        if (thv_zi[n] - thv_zi[n+1] > 0.0){
-          REQUIRE(SDS.brunt[offset] > 0.0);
+        if (thv_zi[n] - thv_zi[n+1] > 0){
+          REQUIRE(SDS.brunt[offset] > 0);
         }
 
         // Validate that values fall within some
         //  reasonable bounds for this variable.
-        REQUIRE(SDS.brunt[offset < 1.0]);
-        REQUIRE(SDS.brunt[offset > -1.0]);
+	REQUIRE(std::abs(SDS.brunt[offset]) < brunt_bound);
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_check_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_check_length_tests.cpp
@@ -24,6 +24,8 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength {
 
   static void run_property()
   {
+    static constexpr Real maxlen = scream::shoc::Constants<Real>::maxlen;
+    static constexpr Real minlen = scream::shoc::Constants<Real>::minlen;
     static constexpr Int shcol    = 2;
     static constexpr Int nlev     = 5;
 
@@ -36,14 +38,14 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength {
     //  corrects these erroneous values.
 
     // Define the host grid box size x-direction [m]
-    static constexpr Real host_dx = 3000.0;
+    static constexpr Real host_dx = 3000;
     // Defin the host grid box size y-direction [m]
-    static constexpr Real host_dy = 5000.0;
+    static constexpr Real host_dy = 5000;
     // Define mixing length [m]
     //   In profile include values of zero and very large values
-    Real shoc_mix[nlev] = {50000.0, 4000.0, 2000.0, 0.0, 500.0};
+    Real shoc_mix[nlev] = {50000, 4000, 2000, 0, 500};
 
-    // Initialize data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCMixcheckData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
@@ -68,8 +70,8 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength {
 
     // Be sure that relevant variables are greater than zero
     for(Int s = 0; s < shcol; ++s) {
-      REQUIRE(SDS.host_dx[s] > 0.0);
-      REQUIRE(SDS.host_dy[s] > 0.0);
+      REQUIRE(SDS.host_dx[s] > 0);
+      REQUIRE(SDS.host_dy[s] > 0);
     }
 
     // Call the fortran implementation
@@ -81,7 +83,8 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength {
         const auto offset = n + s * nlev;
         // Require mixing length is greater than zero and is
         //  less than geometric grid mesh length + 1 m
-        REQUIRE(SDS.shoc_mix[offset] > 0.0);
+        REQUIRE(SDS.shoc_mix[offset] >= minlen);
+	REQUIRE(SDS.shoc_mix[offset] <= maxlen);
         REQUIRE(SDS.shoc_mix[offset] < 1.0+grid_mesh);
       }
     }

--- a/components/scream/src/physics/shoc/tests/shoc_check_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_check_length_tests.cpp
@@ -84,7 +84,7 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength {
         // Require mixing length is greater than zero and is
         //  less than geometric grid mesh length + 1 m
         REQUIRE(SDS.shoc_mix[offset] >= minlen);
-	REQUIRE(SDS.shoc_mix[offset] <= maxlen);
+        REQUIRE(SDS.shoc_mix[offset] <= maxlen);
         REQUIRE(SDS.shoc_mix[offset] < 1.0+grid_mesh);
       }
     }

--- a/components/scream/src/physics/shoc/tests/shoc_check_tke_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_check_tke_tests.cpp
@@ -24,6 +24,7 @@ struct UnitWrap::UnitTest<D>::TestShocCheckTke {
 
   static void run_property()
   {
+    static constexpr Real mintke = scream::shoc::Constants<Real>::mintke;
     static constexpr Int shcol    = 2;
     static constexpr Int nlev     = 5;
 
@@ -60,7 +61,7 @@ struct UnitWrap::UnitTest<D>::TestShocCheckTke {
 
 	// if input TKE was less than zero, verify it was adjusted
 	if (tke_input[n] < 0){
-	  REQUIRE(SDS.tke[offset] > 0);
+	  REQUIRE(SDS.tke[offset] >= mintke);
 	}
 	// Else make sure TKE remains untouched
 	else{

--- a/components/scream/src/physics/shoc/tests/shoc_check_tke_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_check_tke_tests.cpp
@@ -44,7 +44,7 @@ struct UnitWrap::UnitTest<D>::TestShocCheckTke {
       for(Int n = 0; n < nlev; ++n) {
         const auto offset = n + s * nlev;
 
-	SDS.tke[offset] = tke_input[n];
+        SDS.tke[offset] = tke_input[n];
       }
     }
 
@@ -59,14 +59,14 @@ struct UnitWrap::UnitTest<D>::TestShocCheckTke {
       for(Int n = 0; n < nlev; ++n) {
         const auto offset = n + s * nlev;
 
-	// if input TKE was less than zero, verify it was adjusted
-	if (tke_input[n] < 0){
-	  REQUIRE(SDS.tke[offset] >= mintke);
-	}
-	// Else make sure TKE remains untouched
-	else{
-	  REQUIRE(SDS.tke[offset] == tke_input[n]);
-	}
+        // if input TKE was less than zero, verify it was adjusted
+        if (tke_input[n] < 0){
+          REQUIRE(SDS.tke[offset] >= mintke);
+        }
+        // Else make sure TKE remains untouched
+        else{
+          REQUIRE(SDS.tke[offset] == tke_input[n]);
+        }
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
@@ -55,7 +55,7 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
         const auto offset = n + s * nlevi;
 
         SDS.w_sec_zi[offset] = w_sec_zi[n];
-	SDS.w3[offset] = w3_in[n];
+        SDS.w3[offset] = w3_in[n];
       }
     }
 
@@ -72,11 +72,11 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
         const auto offset = n + s * nlevi;
 
         REQUIRE(SDS.w_sec_zi[offset] <= 1);
-	if (abs(SDS.w3[offset]) > 1000){
-	  w3_large = true;
-	}
+        if (abs(SDS.w3[offset]) > 1000){
+          w3_large = true;
+        }
         SDS.w_sec_zi[offset] = w_sec_zi[n];
-	SDS.w3[offset] = w3_in[n];
+        SDS.w3[offset] = w3_in[n];
       }
       REQUIRE(w3_large == true);
     }
@@ -91,12 +91,12 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
 
-	if (abs(w3_in[n]) > 1000){
-	  REQUIRE(abs(SDS.w3[offset]) < abs(w3_in[n]));
-	  if (w3_in[n] < 0){
-	    REQUIRE(SDS.w3[offset] < 0);
-	  }
-	}
+        if (abs(w3_in[n]) > 1000){
+          REQUIRE(abs(SDS.w3[offset]) < abs(w3_in[n]));
+          if (w3_in[n] < 0){
+            REQUIRE(SDS.w3[offset] < 0);
+          }
+        }
 
       }
     }

--- a/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
@@ -29,15 +29,15 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
 
     // Tests for the SHOC function:
     //   clipping_diag_third_shoc_moments
-  
+
     //  Test to be sure that very high values of w3
-    //    are reduced but still the same sign   
-  
+    //    are reduced but still the same sign
+
     // Define the second moment of vertical velocity
-    static constexpr Real w_sec_zi[nlevi] = {0.3, 0.4, 0.5, 0.4, 0.1}; 
+    static constexpr Real w_sec_zi[nlevi] = {0.3, 0.4, 0.5, 0.4, 0.1};
     // Define the third moment of vertical velocity
-    static constexpr Real w3_in[nlevi] = {0.2, 99999, -99999, 0.2, 0.05}; 
-    
+    static constexpr Real w3_in[nlevi] = {0.2, 99999, -99999, 0.2, 0.05};
+
     // Define a local logical
     bool w3_large;
 
@@ -47,7 +47,7 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
     // Test that the inputs are reasonable.
     REQUIRE(SDS.shcol() > 0);
     REQUIRE(SDS.nlevi() > 1);
-    
+
     // load up the input data
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
@@ -58,11 +58,11 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
 	SDS.w3[offset] = w3_in[n];
       }
     }
-    
+
     // Verify the data
     // For this particular test wen want to be sure that
     //   the input has relatively small values of w2 (let's say
-    //   all smaller than 1, which is reasonable) and let's 
+    //   all smaller than 1, which is reasonable) and let's
     //   be sure that w3 has some very large unreasonable values
     for(Int s = 0; s < shcol; ++s) {
       // Initialize conditional to make sure there are
@@ -80,29 +80,29 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
       }
       REQUIRE(w3_large == true);
     }
-    
-    // Call the fortran implementation    
+
+    // Call the fortran implementation
     clipping_diag_third_shoc_moments(SDS);
-    
+
     // Check the result
-    // For large values of w3, verify that the result has been 
+    // For large values of w3, verify that the result has been
     //  reduced and is of the same sign
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
-	
+
 	if (abs(w3_in[n]) > 1000){
 	  REQUIRE(abs(SDS.w3[offset]) < abs(w3_in[n]));
 	  if (w3_in[n] < 0){
 	    REQUIRE(SDS.w3[offset] < 0);
 	  }
-	} 
-	
+	}
+
       }
-    }    
-    
+    }
+
   }
-  
+
   static void run_bfb()
   {
     SHOCClipthirdmomsData SDS_f90[] = {
@@ -165,7 +165,7 @@ namespace{
 TEST_CASE("shoc_clip_third_moms_property", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestClipThirdMoms;
-  
+
   TestStruct::run_property();
 }
 

--- a/components/scream/src/physics/shoc/tests/shoc_conv_time_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_conv_time_length_tests.cpp
@@ -39,11 +39,13 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
     //  For this function we test several one layer columns
 
     // PBL height [m]
-    static constexpr Real pblh[shcol] = {1000.0, 400.0, 10.0, 500.0, 300.0};
+    static constexpr Real pblh[shcol] = {1000, 400, 10, 500, 300};
     // Integrated convective velocity [m3/s3]
-    static constexpr Real conv_vel[shcol] = {10.0, -3.5, 0.1, -100.0, -0.4};
+    static constexpr Real conv_vel[shcol] = {10, -3.5, 0.1, -100, -0.4};
+    // Upper bound of expected result [s]
+    static constexpr Real tscale_upper = 10000;
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCConvtimeData SDS(shcol);
 
     // Test that the inputs are reasonable.
@@ -69,6 +71,7 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
     // Make sure that timescale is positive always
     for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.tscale[s] > 0.0);
+      REQUIRE(SDS.tscale[s] < tscale_upper);
     }
 
     // SECOND TEST
@@ -110,6 +113,12 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
       }
     }
 
+    // Make sure bounds fall in reasonable range
+    for (Int s = 0; s < shcol; ++s){
+      REQUIRE(SDS.tscale[s] < tscale_upper);
+      REQUIRE(SDS.tscale[s] > 0);
+    }
+
     // THIRD TEST
     // Constant conv_vel test
     // Given a set of inputs where conv_vel is constant but
@@ -148,6 +157,13 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
 	REQUIRE(SDS.pblh[s] > SDS.pblh[s+1]);
       }
     }
+
+    // Make sure bounds fall in reasonable range
+    for (Int s = 0; s < shcol; ++s){
+      REQUIRE(SDS.tscale[s] < tscale_upper);
+      REQUIRE(SDS.tscale[s] > 0);
+    }
+
   }
 
   static void run_bfb()

--- a/components/scream/src/physics/shoc/tests/shoc_conv_time_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_conv_time_length_tests.cpp
@@ -109,7 +109,7 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
     //  column, that the tscale is larger
     for (Int s = 0; s < shcol-1; ++s){
       if (SDS.tscale[s] > SDS.tscale[s+1]){
-	REQUIRE(SDS.conv_vel[s] < SDS.conv_vel[s+1]);
+        REQUIRE(SDS.conv_vel[s] < SDS.conv_vel[s+1]);
       }
     }
 
@@ -154,7 +154,7 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
     //  neighboring column, that the PBL depth is larger
     for (Int s = 0; s < shcol-1; ++s){
       if (SDS.tscale[s] > SDS.tscale[s+1]){
-	REQUIRE(SDS.pblh[s] > SDS.pblh[s+1]);
+        REQUIRE(SDS.pblh[s] > SDS.pblh[s+1]);
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_conv_vel_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_conv_vel_length_tests.cpp
@@ -69,16 +69,16 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
     for(Int s = 0; s < shcol; ++s) {
       SDS.pblh[s] = pblh;
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.dz_zt[offset] = dz_zt[n];
-	SDS.zt_grid[offset] = zt_grid[n];
-	SDS.thv[offset] = thv[n];
-	SDS.wthv_sec[offset] = wthv_sec[n];
+        SDS.dz_zt[offset] = dz_zt[n];
+        SDS.zt_grid[offset] = zt_grid[n];
+        SDS.thv[offset] = thv[n];
+        SDS.wthv_sec[offset] = wthv_sec[n];
         // for the second column, give negative values
-	if (s == 1){
-	  SDS.wthv_sec[offset] = -1*SDS.wthv_sec[offset];
-	}
+        if (s == 1){
+          SDS.wthv_sec[offset] = -1*SDS.wthv_sec[offset];
+        }
       }
     }
 
@@ -86,21 +86,21 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
 
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	// Be sure that relevant variables are greater than zero
-	REQUIRE(SDS.dz_zt[offset] > 0);
-	REQUIRE(SDS.thv[offset] > 0);
-	// Make sure sign of buoyancy flux is as expected
-	if (s == 0){
-	  REQUIRE(SDS.wthv_sec[offset] > 0);
-	}
-	else{
+        const auto offset = n + s * nlev;
+        // Be sure that relevant variables are greater than zero
+        REQUIRE(SDS.dz_zt[offset] > 0);
+        REQUIRE(SDS.thv[offset] > 0);
+        // Make sure sign of buoyancy flux is as expected
+        if (s == 0){
+          REQUIRE(SDS.wthv_sec[offset] > 0);
+        }
+        else{
           REQUIRE(SDS.wthv_sec[offset] < 0);
-	}
-	if (n < nlev-1){
+        }
+        if (n < nlev-1){
           // check that zt increases upward
           REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
-	}
+        }
       }
     }
 
@@ -133,11 +133,11 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
     // Fill in new test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.dz_zt[offset] = dz_zt_sym[n];
-	SDS.thv[offset] = thv_sym[n];
-	SDS.wthv_sec[offset] = wthv_sec_sym[n];
+        SDS.dz_zt[offset] = dz_zt_sym[n];
+        SDS.thv[offset] = thv_sym[n];
+        SDS.wthv_sec[offset] = wthv_sec_sym[n];
       }
     }
 
@@ -146,11 +146,11 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
     for(Int s = 0; s < shcol; ++s) {
       Real wthv_sum = 0;
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	// Be sure that relevant variables are greater than zero
-	REQUIRE(SDS.dz_zt[offset] > 0);
-	REQUIRE(SDS.thv[offset] > 0);
-	wthv_sum += SDS.wthv_sec[offset];
+        const auto offset = n + s * nlev;
+        // Be sure that relevant variables are greater than zero
+        REQUIRE(SDS.dz_zt[offset] > 0);
+        REQUIRE(SDS.thv[offset] > 0);
+        wthv_sum += SDS.wthv_sec[offset];
       }
       // Make sure inputs of buoyancy flux sum to zero
       REQUIRE(wthv_sum == approx_zero);

--- a/components/scream/src/physics/shoc/tests/shoc_conv_vel_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_conv_vel_length_tests.cpp
@@ -37,27 +37,33 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
     //   of conv_vel.
 
     // FIRST TEST
-    // Verify that given negatively buoyant conditions that the
-    //   result is also negative.
+    // Buoyancy test.  Verify that given positively buoyant conditions
+    //   in one column and negatively buoyant conditions in another
+    //   that the result is as expected (positive and negative,
+    //   respectively).
 
     // PBL height [m]
     // for this test set to be higher than highest zt_grid value
-    static constexpr Real pblh = 1000.0;
+    static constexpr Real pblh = 1000;
     // Grid difference centered on thermo grid [m]
-    static constexpr Real dz_zt[nlev] = {100.0, 100.0, 100.0, 100.0, 100.0};
+    static constexpr Real dz_zt[nlev] = {100, 100, 100, 100, 100};
     // Grid height centered on thermo grid [m]
-    static constexpr Real zt_grid[nlev] = {500.0, 400.0, 300.0, 200.0, 100.0};
+    static constexpr Real zt_grid[nlev] = {500, 400, 300, 200, 100};
     // Virtual potential temperature on interface grid [K]
-    static constexpr Real thv[nlev] = {310.0, 305.0, 300.0, 300.0, 295.0};
+    static constexpr Real thv[nlev] = {310, 305, 300, 300, 295};
     // Buoyancy flux [K m/s]
-    static constexpr Real wthv_sec[nlev] = {-0.02, -0.01, -0.04, -0.02, -0.05};
+    static constexpr Real wthv_sec[nlev] = {0.02, 0.01, 0.04, 0.02, 0.05};
 
-    // Initialzie data structure for bridgeing to F90
+    // Bounds to check result [m/s]
+    static constexpr Real conv_vel_bound = 10;
+
+    // Initialize data structure for bridging to F90
     SHOCConvvelData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
     REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev) );
-    REQUIRE(shcol > 0);
+    // For this test we want exactly two columns
+    REQUIRE(shcol == 2);
 
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
@@ -69,6 +75,10 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
 	SDS.zt_grid[offset] = zt_grid[n];
 	SDS.thv[offset] = thv[n];
 	SDS.wthv_sec[offset] = wthv_sec[n];
+        // for the second column, give negative values
+	if (s == 1){
+	  SDS.wthv_sec[offset] = -1*SDS.wthv_sec[offset];
+	}
       }
     }
 
@@ -78,14 +88,18 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
 	// Be sure that relevant variables are greater than zero
-	REQUIRE(SDS.dz_zt[offset] > 0.0);
-	REQUIRE(SDS.thv[offset] > 0.0);
-	// For this negative buoyancy test, verify that all parcels
-	//  have negative buoyancy flux.
-	REQUIRE(SDS.wthv_sec[offset] < 0.0);
+	REQUIRE(SDS.dz_zt[offset] > 0);
+	REQUIRE(SDS.thv[offset] > 0);
+	// Make sure sign of buoyancy flux is as expected
+	if (s == 0){
+	  REQUIRE(SDS.wthv_sec[offset] > 0);
+	}
+	else{
+          REQUIRE(SDS.wthv_sec[offset] < 0);
+	}
 	if (n < nlev-1){
           // check that zt increases upward
-          REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0.0);
+          REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
 	}
       }
     }
@@ -94,9 +108,14 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
     compute_conv_vel_shoc_length(SDS);
 
     // Check the results
-    // Make sure that conv_vel is negative
-    for(Int s = 0; s < shcol; ++s) {
-      REQUIRE(SDS.conv_vel[s] < 0.0);
+    // Make sure that conv_vel is positive in first
+    //  column and negative in the second
+    REQUIRE(SDS.conv_vel[0] > 0);
+    REQUIRE(SDS.conv_vel[1] < 0);
+
+    // Make sure result falls within reasonable bounds
+    for (Int s = 0; s < shcol; ++s){
+      REQUIRE(SDS.conv_vel[s] < std::abs(conv_vel_bound));
     }
 
     // SECOND TEST
@@ -105,9 +124,9 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
     //  result of conv_vel is also zero.  Here we need to assume
     //  a well mixed layer and constant profile of dz_zt
 
-    static constexpr Real dz_zt_sym[nlev] = {100.0, 100.0, 100.0, 100.0, 100.0};
+    static constexpr Real dz_zt_sym[nlev] = {100, 100, 100, 100, 100};
     // Virtual potential temperature on interface grid [K]
-    static constexpr Real thv_sym[nlev] = {300.0, 300.0, 300.0, 300.0, 300.0};
+    static constexpr Real thv_sym[nlev] = {300, 300, 300, 300, 300};
     // Buoyancy flux [K m/s]
     static constexpr Real wthv_sec_sym[nlev] = {0.04, 0.02, 0.00, -0.02, -0.04};
 
@@ -125,12 +144,12 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvVel {
     // Check that the inputs make sense
 
     for(Int s = 0; s < shcol; ++s) {
-      Real wthv_sum = 0.0;
+      Real wthv_sum = 0;
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
 	// Be sure that relevant variables are greater than zero
-	REQUIRE(SDS.dz_zt[offset] > 0.0);
-	REQUIRE(SDS.thv[offset] > 0.0);
+	REQUIRE(SDS.dz_zt[offset] > 0);
+	REQUIRE(SDS.thv[offset] > 0);
 	wthv_sum += SDS.wthv_sec[offset];
       }
       // Make sure inputs of buoyancy flux sum to zero

--- a/components/scream/src/physics/shoc/tests/shoc_diag_obklen_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_obklen_tests.cpp
@@ -50,7 +50,13 @@ struct UnitWrap::UnitTest<D>::TestShocDiagObklen {
     // Surface water vapor [kg/kg]
     static constexpr Real qv_sfc[shcol] = {1e-2, 2e-2, 1.5e-2, 9e-3, 5e-3};
 
-    // Initialzie data structure for bridgeing to F90
+    // Define bounds for reasonable output
+    static constexpr Real obklen_lower = -10;
+    static constexpr Real obklen_upper = 1000;
+    static constexpr Real ustar_bound = 10;
+    static constexpr Real kbfs_bound = 10;
+
+    // Initialize data structure for bridging to F90
     SHOCObklenData SDS(shcol);
 
     // Test that the inputs are reasonable.
@@ -99,9 +105,9 @@ struct UnitWrap::UnitTest<D>::TestShocDiagObklen {
       }
 
       // Verify output falls within some reasonable bounds
-      REQUIRE( (SDS.ustar[s] > -10 && SDS.ustar[s] < 10) );
-      REQUIRE( (SDS.kbfs[s] > -10 && SDS.kbfs[s] < 10) );
-      REQUIRE( (SDS.obklen[s] > -10 && SDS.obklen[s] < 1000));
+      REQUIRE(std::abs(SDS.ustar[s]) < ustar_bound);
+      REQUIRE(std::abs(SDS.kbfs[s]) < kbfs_bound);
+      REQUIRE( (SDS.obklen[s] > obklen_lower && SDS.obklen[s] < obklen_upper));
     }
 
     // TEST TWO

--- a/components/scream/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
@@ -70,13 +70,13 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
       SDS.pblh[s] = pblh;
       SDS.obklen[s] = obklen_reg[s];
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.tke[offset] = tke_reg;
-	SDS.zt_grid[offset] = zt_grid;
-	SDS.shoc_mix[offset] = shoc_mix_reg;
-	SDS.sterm_zt[offset] = sterm_zt_reg;
-	SDS.isotropy[offset] = isotropy_reg;
+        SDS.tke[offset] = tke_reg;
+        SDS.zt_grid[offset] = zt_grid;
+        SDS.shoc_mix[offset] = shoc_mix_reg;
+        SDS.sterm_zt[offset] = sterm_zt_reg;
+        SDS.isotropy[offset] = isotropy_reg;
       }
     }
 
@@ -86,13 +86,13 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
       // Make sure point we are testing is within PBL
       REQUIRE(SDS.zt_grid[s] < SDS.pblh[s]);
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	// Should be greater than zero
-	REQUIRE(SDS.tke[offset] > 0);
-	REQUIRE(SDS.zt_grid[offset] > 0);
-	REQUIRE(SDS.shoc_mix[offset] > 0);
-	REQUIRE(SDS.isotropy[offset] > 0);
-	REQUIRE(SDS.sterm_zt[offset] > 0);
+        const auto offset = n + s * nlev;
+        // Should be greater than zero
+        REQUIRE(SDS.tke[offset] > 0);
+        REQUIRE(SDS.zt_grid[offset] > 0);
+        REQUIRE(SDS.shoc_mix[offset] > 0);
+        REQUIRE(SDS.isotropy[offset] > 0);
+        REQUIRE(SDS.sterm_zt[offset] > 0);
       }
     }
 
@@ -102,11 +102,11 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     // Check to make sure the answers in the columns are different
     for(Int s = 0; s < shcol-1; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * nlev;
-	REQUIRE(SDS.tk[offset] != SDS.tk[offsets]);
-	REQUIRE(SDS.tkh[offset] != SDS.tkh[offsets]);
+        const auto offset = n + s * nlev;
+        // Get value corresponding to next column
+        const auto offsets = n + (s+1) * nlev;
+        REQUIRE(SDS.tk[offset] != SDS.tk[offsets]);
+        REQUIRE(SDS.tkh[offset] != SDS.tkh[offsets]);
       }
     }
 
@@ -140,12 +140,12 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
       // Column only input
       SDS.obklen[s] = obklen_stab[s];
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.tke[offset] = tke_stab;
-	SDS.shoc_mix[offset] = shoc_mix_stab[s];
-	SDS.sterm_zt[offset] = sterm_zt_stab[s];
-	SDS.isotropy[offset] = isotropy_stab;
+        SDS.tke[offset] = tke_stab;
+        SDS.shoc_mix[offset] = shoc_mix_stab[s];
+        SDS.sterm_zt[offset] = sterm_zt_stab[s];
+        SDS.isotropy[offset] = isotropy_stab;
       }
     }
 
@@ -154,12 +154,12 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
       // Make sure we are testing stable boundary layer
       REQUIRE(SDS.obklen[s] > 0);
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	// Should be greater than zero
-	REQUIRE(SDS.tke[offset] > 0);
-	REQUIRE(SDS.shoc_mix[offset] > 0);
-	REQUIRE(SDS.isotropy[offset] > 0);
-	REQUIRE(SDS.sterm_zt[offset] > 0);
+        const auto offset = n + s * nlev;
+        // Should be greater than zero
+        REQUIRE(SDS.tke[offset] > 0);
+        REQUIRE(SDS.shoc_mix[offset] > 0);
+        REQUIRE(SDS.isotropy[offset] > 0);
+        REQUIRE(SDS.sterm_zt[offset] > 0);
       }
     }
 
@@ -170,14 +170,14 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     //   when the length scale and shear term are larger
     for(Int s = 0; s < shcol-1; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * nlev;
-	if (SDS.shoc_mix[offset] < SDS.shoc_mix[offsets] &
+        const auto offset = n + s * nlev;
+        // Get value corresponding to next column
+        const auto offsets = n + (s+1) * nlev;
+        if (SDS.shoc_mix[offset] < SDS.shoc_mix[offsets] &
             SDS.sterm_zt[offset] < SDS.sterm_zt[offsets]){
           REQUIRE(SDS.tk[offset] < SDS.tkh[offsets]);
           REQUIRE(SDS.tkh[offset] < SDS.tkh[offsets]);
-	}
+        }
       }
     }
 
@@ -210,12 +210,12 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
       // Column only input
       SDS.obklen[s] = obklen_ustab[s];
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.tke[offset] = tke_ustab[s];
-	SDS.shoc_mix[offset] = shoc_mix_ustab;
-	SDS.sterm_zt[offset] = sterm_zt_ustab;
-	SDS.isotropy[offset] = isotropy_ustab[s];
+        SDS.tke[offset] = tke_ustab[s];
+        SDS.shoc_mix[offset] = shoc_mix_ustab;
+        SDS.sterm_zt[offset] = sterm_zt_ustab;
+        SDS.isotropy[offset] = isotropy_ustab[s];
       }
     }
 
@@ -224,12 +224,12 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
       // Make sure we are testing unstable boundary layer
       REQUIRE(SDS.obklen[s] < 0);
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	// Should be greater than zero
-	REQUIRE(SDS.tke[offset] > 0);
-	REQUIRE(SDS.shoc_mix[offset] > 0);
-	REQUIRE(SDS.isotropy[offset] > 0);
-	REQUIRE(SDS.sterm_zt[offset] > 0);
+        const auto offset = n + s * nlev;
+        // Should be greater than zero
+        REQUIRE(SDS.tke[offset] > 0);
+        REQUIRE(SDS.shoc_mix[offset] > 0);
+        REQUIRE(SDS.isotropy[offset] > 0);
+        REQUIRE(SDS.sterm_zt[offset] > 0);
       }
     }
 
@@ -240,14 +240,14 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     //  in the columns where isotropy and tke are smaller
     for(Int s = 0; s < shcol-1; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * nlev;
-	if (SDS.tke[offset] < SDS.tke[offsets] &
+        const auto offset = n + s * nlev;
+        // Get value corresponding to next column
+        const auto offsets = n + (s+1) * nlev;
+        if (SDS.tke[offset] < SDS.tke[offsets] &
             SDS.isotropy[offset] < SDS.isotropy[offsets]){
           REQUIRE(SDS.tk[offset] < SDS.tk[offsets]);
           REQUIRE(SDS.tkh[offset] < SDS.tkh[offsets]);
-	}
+        }
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
@@ -43,21 +43,21 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     //  are DIFFERENT
 
     // Monin Obukov length [m]
-    static constexpr Real obklen_reg[shcol] = {-1.0, 1.0};
+    static constexpr Real obklen_reg[shcol] = {-1, 1};
     // PBL depth [m]
-    static constexpr Real pblh = 1000.0;
+    static constexpr Real pblh = 1000;
     // zt_grid [m]
-    static constexpr Real zt_grid = 200.0;
+    static constexpr Real zt_grid = 200;
     // SHOC Mixing length [m]
-    static constexpr Real shoc_mix_reg = 1000.0;
+    static constexpr Real shoc_mix_reg = 1000;
     // Shear term [s-2]
     static constexpr Real sterm_zt_reg = 0.1;
     // Return to isotropy timescale [s]
-    static constexpr Real isotropy_reg = 500.0;
+    static constexpr Real isotropy_reg = 500;
     // Turbulent kinetic energy [m2/s2]
     static constexpr Real tke_reg = 0.4;
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCEddydiffData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
@@ -82,17 +82,17 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
 
     // Check that the inputs make sense
     for(Int s = 0; s < shcol; ++s) {
-      REQUIRE(SDS.pblh[s] > 0.0);
+      REQUIRE(SDS.pblh[s] > 0);
       // Make sure point we are testing is within PBL
       REQUIRE(SDS.zt_grid[s] < SDS.pblh[s]);
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 	// Should be greater than zero
-	REQUIRE(SDS.tke[offset] > 0.0);
-	REQUIRE(SDS.zt_grid[offset] > 0.0);
-	REQUIRE(SDS.shoc_mix[offset] > 0.0);
-	REQUIRE(SDS.isotropy[offset] > 0.0);
-	REQUIRE(SDS.sterm_zt[offset] > 0.0);
+	REQUIRE(SDS.tke[offset] > 0);
+	REQUIRE(SDS.zt_grid[offset] > 0);
+	REQUIRE(SDS.shoc_mix[offset] > 0);
+	REQUIRE(SDS.isotropy[offset] > 0);
+	REQUIRE(SDS.sterm_zt[offset] > 0);
       }
     }
 
@@ -117,13 +117,13 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     //   shear term should produce larger diffusivity values.
 
     // Monin Obukov length [m]
-    static constexpr Real obklen_stab[shcol] = {1.0, 1.0};
+    static constexpr Real obklen_stab[shcol] = {1, 1};
     // SHOC Mixing length [m]
-    static constexpr Real shoc_mix_stab[shcol] = {500.0, 550.0};
+    static constexpr Real shoc_mix_stab[shcol] = {100, 150};
     // Shear term [s-2]
     static constexpr Real sterm_zt_stab[shcol] = {0.1, 0.2};
     // Return to isotropy timescale [s]
-    static constexpr Real isotropy_stab = 500.0;
+    static constexpr Real isotropy_stab = 500;
     // Turbulent kinetic energy [m2/s2]
     static constexpr Real tke_stab = 0.4;
 
@@ -152,14 +152,14 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     // Check that the inputs make sense
     for(Int s = 0; s < shcol; ++s) {
       // Make sure we are testing stable boundary layer
-      REQUIRE(SDS.obklen[s] > 0.0);
+      REQUIRE(SDS.obklen[s] > 0);
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 	// Should be greater than zero
-	REQUIRE(SDS.tke[offset] > 0.0);
-	REQUIRE(SDS.shoc_mix[offset] > 0.0);
-	REQUIRE(SDS.isotropy[offset] > 0.0);
-	REQUIRE(SDS.sterm_zt[offset] > 0.0);
+	REQUIRE(SDS.tke[offset] > 0);
+	REQUIRE(SDS.shoc_mix[offset] > 0);
+	REQUIRE(SDS.isotropy[offset] > 0);
+	REQUIRE(SDS.sterm_zt[offset] > 0);
       }
     }
 
@@ -187,13 +187,13 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     //   inputs are modified.
 
     // Monin Obukov length [m]
-    static constexpr Real obklen_ustab[shcol] = {-1.0, -1.0};
+    static constexpr Real obklen_ustab[shcol] = {-1, -1};
     // SHOC Mixing length [m]
-    static constexpr Real shoc_mix_ustab = 500.0;
+    static constexpr Real shoc_mix_ustab = 500;
     // Shear term [s-2]
     static constexpr Real sterm_zt_ustab = 0.1;
     // Return to isotropy timescale [s]
-    static constexpr Real isotropy_ustab[shcol] = {500.0, 550.0};
+    static constexpr Real isotropy_ustab[shcol] = {500, 550};
     // Turbulent kinetic energy [m2/s2]
     static constexpr Real tke_ustab[shcol] = {0.4, 0.5};
 
@@ -222,14 +222,14 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
     // Check that the inputs make sense
     for(Int s = 0; s < shcol; ++s) {
       // Make sure we are testing unstable boundary layer
-      REQUIRE(SDS.obklen[s] < 0.0);
+      REQUIRE(SDS.obklen[s] < 0);
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 	// Should be greater than zero
-	REQUIRE(SDS.tke[offset] > 0.0);
-	REQUIRE(SDS.shoc_mix[offset] > 0.0);
-	REQUIRE(SDS.isotropy[offset] > 0.0);
-	REQUIRE(SDS.sterm_zt[offset] > 0.0);
+	REQUIRE(SDS.tke[offset] > 0);
+	REQUIRE(SDS.shoc_mix[offset] > 0);
+	REQUIRE(SDS.isotropy[offset] > 0);
+	REQUIRE(SDS.sterm_zt[offset] > 0);
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_energy_dse_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_dse_fixer_tests.cpp
@@ -60,9 +60,9 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyDseFixer {
       SDS.shoctop[s] = shoctop[s];
       SDS.se_dis[s] = se_dis;
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.host_dse[offset] = host_dse_input[n];
+        SDS.host_dse[offset] = host_dse_input[n];
       }
     }
 
@@ -74,9 +74,9 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyDseFixer {
       REQUIRE(SDS.shoctop[s] >= 1);
       REQUIRE(SDS.shoctop[s] <= nlev);
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	REQUIRE(SDS.host_dse[offset] > 0.0);
+        REQUIRE(SDS.host_dse[offset] > 0.0);
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_energy_dse_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_dse_fixer_tests.cpp
@@ -26,7 +26,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyDseFixer {
   static void run_property()
   {
     static constexpr Real gravit  = scream::physics::Constants<Real>::gravit;
-    static constexpr Real Cpair   = scream::physics::Constants<Real>::Cpair;    
+    static constexpr Real Cpair   = scream::physics::Constants<Real>::Cpair;
     static constexpr Int shcol    = 6;
     static constexpr Int nlev     = 5;
 
@@ -48,7 +48,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyDseFixer {
     // level indicee of SHOC top layer
     static constexpr Int shoctop[shcol] = {5, 3, 1, 2, 4, 4};
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCEnergydsefixerData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.

--- a/components/scream/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
@@ -78,7 +78,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
     Real host_dse_input[nlev];
     Real zt_grid[nlev];
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCEnergyfixerData SDS(shcol, nlev, nlevi, dtime, nadv);
 
     // Test that the inputs are reasonable.

--- a/components/scream/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
@@ -42,18 +42,18 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
 
     // Define host model dry static energy [J kg-1]
     static constexpr Real host_dse[nlev] = {350e3, 325e3, 315e3, 310e3, 300e3};
-    // Defin the pressure difference [hPa] (converted to Pa later)
-    static constexpr Real pdel[nlev]={100.0, 75.0, 50.0, 25.0, 10.0};
+    // Defin the pressure difference [Pa]
+    static constexpr Real pdel[nlev]={100e2, 75e2, 50e2, 25e2, 10e2};
     // Define zonal wind on nlev grid [m/s]
-    static constexpr Real u_wind[nlev] = {-4.0, -4.0, -3.0, -1.0, -2.0};
+    static constexpr Real u_wind[nlev] = {-4, -4, -3, -1, -2};
     // Define meridional wind on nlev grid [m/s]
-    static constexpr Real v_wind[nlev] = {1.0, 2.0, 3.0, 4.0, 5.0};
-    // Define the total water mixing ratio [g/kg] (converted to kg/kg later)
-    static constexpr Real rtm[nlev] = {7.0, 9.0, 11.0, 15.0, 20.0};
+    static constexpr Real v_wind[nlev] = {1, 2, 3, 4, 5};
+    // Define the total water mixing ratio [kg/kg]
+    static constexpr Real rtm[nlev] = {7e-3, 9e-3, 11e-3, 15e-3, 20e-3};
     // Define cloud mixing ratio [g/kg] (converted to kg/kg later)
-    static constexpr Real rcm[nlev] = {0.001, 0.01, 0.04, 0.002, 0.001};
+    static constexpr Real rcm[nlev] = {1e-6, 1e-5, 4e-5, 2e-6, 1e-6};
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCEnergyintData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
@@ -69,14 +69,13 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
 	// Add one degree K in the second column
 	SDS.host_dse[offset] = s+host_dse[n];
 
-	// convert to [kg/kg]
 	// Force the first column of cloud liquid
 	//   to be zero!
-	SDS.rcm[offset] = s*rcm[n]/1000.0;
-	SDS.rtm[offset] = rtm[n]/1000.0;
+	SDS.rcm[offset] = s*rcm[n];
+	SDS.rtm[offset] = rtm[n];
 
 	// convert to Pa
-	SDS.pdel[offset] = pdel[n]*100.0;
+	SDS.pdel[offset] = pdel[n];
 
 	// Increase winds with increasing columns
 	SDS.u_wind[offset] = (1.0+s)*u_wind[n];
@@ -90,9 +89,9 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 
-	REQUIRE(SDS.host_dse[offset] > 0.0);
-	REQUIRE(SDS.rcm[offset] >= 0.0);
-	REQUIRE(SDS.rtm[offset] > 0.0);
+	REQUIRE(SDS.host_dse[offset] > 0);
+	REQUIRE(SDS.rcm[offset] >= 0);
+	REQUIRE(SDS.rtm[offset] > 0);
 
 	// make sure the two columns are different and
 	//  as expected for the relevant variables
@@ -101,7 +100,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
 
           REQUIRE(abs(SDS.u_wind[offsets]) > abs(SDS.u_wind[offset]));
           REQUIRE(abs(SDS.v_wind[offsets]) > abs(SDS.v_wind[offset]));
-          REQUIRE(SDS.rcm[offset] == 0.0);
+          REQUIRE(SDS.rcm[offset] == 0);
           REQUIRE(SDS.rcm[offsets] > SDS.rcm[offset]);
 	}
       }
@@ -113,15 +112,15 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
     // Check test
     for(Int s = 0; s < shcol; ++s) {
       // Verify relevant integrals are reasonable
-      REQUIRE(SDS.se_int[s] > 0.0);
-      REQUIRE(SDS.ke_int[s] > 0.0);
-      REQUIRE(SDS.wv_int[s] > 0.0);
-      REQUIRE(SDS.wl_int[s] >= 0.0);
+      REQUIRE(SDS.se_int[s] > 0);
+      REQUIRE(SDS.ke_int[s] > 0);
+      REQUIRE(SDS.wv_int[s] > 0);
+      REQUIRE(SDS.wl_int[s] >= 0);
       // Do column comparison tests
       if (s == 0){
 	REQUIRE(SDS.ke_int[s+1] > SDS.ke_int[s]);
 	REQUIRE(SDS.wl_int[s+1] > SDS.wl_int[s]);
-	REQUIRE(SDS.wl_int[s] == 0.0);
+	REQUIRE(SDS.wl_int[s] == 0);
 	REQUIRE(SDS.se_int[s+1] > SDS.se_int[s]);
       }
     }

--- a/components/scream/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
@@ -64,22 +64,22 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	// Add one degree K in the second column
-	SDS.host_dse[offset] = s+host_dse[n];
+        // Add one degree K in the second column
+        SDS.host_dse[offset] = s+host_dse[n];
 
-	// Force the first column of cloud liquid
-	//   to be zero!
-	SDS.rcm[offset] = s*rcm[n];
-	SDS.rtm[offset] = rtm[n];
+        // Force the first column of cloud liquid
+        //   to be zero!
+        SDS.rcm[offset] = s*rcm[n];
+        SDS.rtm[offset] = rtm[n];
 
-	// convert to Pa
-	SDS.pdel[offset] = pdel[n];
+        // convert to Pa
+        SDS.pdel[offset] = pdel[n];
 
-	// Increase winds with increasing columns
-	SDS.u_wind[offset] = (1.0+s)*u_wind[n];
-	SDS.v_wind[offset] = (1.0+s)*v_wind[n];
+        // Increase winds with increasing columns
+        SDS.u_wind[offset] = (1.0+s)*u_wind[n];
+        SDS.v_wind[offset] = (1.0+s)*v_wind[n];
       }
     }
 
@@ -87,22 +87,22 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
 
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	REQUIRE(SDS.host_dse[offset] > 0);
-	REQUIRE(SDS.rcm[offset] >= 0);
-	REQUIRE(SDS.rtm[offset] > 0);
+        REQUIRE(SDS.host_dse[offset] > 0);
+        REQUIRE(SDS.rcm[offset] >= 0);
+        REQUIRE(SDS.rtm[offset] > 0);
 
-	// make sure the two columns are different and
-	//  as expected for the relevant variables
-	if (s == 0){
+        // make sure the two columns are different and
+        //  as expected for the relevant variables
+        if (s == 0){
           const auto offsets = n + (s+1) * nlev;
 
           REQUIRE(abs(SDS.u_wind[offsets]) > abs(SDS.u_wind[offset]));
           REQUIRE(abs(SDS.v_wind[offsets]) > abs(SDS.v_wind[offset]));
           REQUIRE(SDS.rcm[offset] == 0);
           REQUIRE(SDS.rcm[offsets] > SDS.rcm[offset]);
-	}
+        }
       }
     }
 
@@ -118,10 +118,10 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
       REQUIRE(SDS.wl_int[s] >= 0);
       // Do column comparison tests
       if (s == 0){
-	REQUIRE(SDS.ke_int[s+1] > SDS.ke_int[s]);
-	REQUIRE(SDS.wl_int[s+1] > SDS.wl_int[s]);
-	REQUIRE(SDS.wl_int[s] == 0);
-	REQUIRE(SDS.se_int[s+1] > SDS.se_int[s]);
+        REQUIRE(SDS.ke_int[s+1] > SDS.ke_int[s]);
+        REQUIRE(SDS.wl_int[s+1] > SDS.wl_int[s]);
+        REQUIRE(SDS.wl_int[s] == 0);
+        REQUIRE(SDS.se_int[s+1] > SDS.se_int[s]);
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_energy_threshold_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_threshold_fixer_tests.cpp
@@ -25,6 +25,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyThreshFixer {
 
   static void run_property()
   {
+    static constexpr Real mintke = scream::shoc::Constants<Real>::mintke;
     static constexpr Int shcol    = 2;
     static constexpr Int nlev     = 5;
     static constexpr auto nlevi   = nlev + 1;
@@ -35,31 +36,22 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyThreshFixer {
     // TEST ONE
     // Set up a reasonable profile verify results are as expected
 
-    // Host model TKE.  currently these values are dimensionless and
-    //  will be later multipled by tke_min value to get profile in [m2/s2]
-    Real tke_input[nlev] = {1.0, 1.0, 10.0, 40.0, 50.0};
-    //  Pressure at interface [hPa] (later converted to Pa)
-    Real pint[nlevi] = {500.0, 600.0, 700.0, 800.0, 900.0, 1000.0};
+    // Host model TKE  [m2/s2]
+    Real tke_input[nlev] = {mintke, mintke, 0.01, 0.4, 0.5};
+    //  Pressure at interface [Pa]
+    Real pint[nlevi] = {500e2, 600e2, 700e2, 800e2, 900e2, 1000e2};
 
     // Integrated total energy after SHOC.
-    static constexpr Real te_a = 100.0;
+    static constexpr Real te_a = 100;
     // Integrated total energy before SHOC
-    static constexpr Real te_b = 110.0;
-
-    // Tke minimum value
-    static constexpr Real tke_min = 0.0004;
+    static constexpr Real te_b = 110;
 
     // convert pressure to Pa
     for(Int n = 0; n < nlevi; ++n) {
-      pint[n] = 100.0*pint[n];
+      pint[n] = pint[n];
     }
 
-    // convert TKE from dimensionaless to [m2/s2]
-    for(Int n = 0; n < nlev; ++n) {
-      tke_input[n] = tke_min*tke_input[n];
-    }
-
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCEnergythreshfixerData SDS(shcol, nlev, nlevi);
 
     // Test that the inputs are reasonable.
@@ -90,7 +82,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyThreshFixer {
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 
-	REQUIRE(SDS.tke[offset] >= tke_min);
+	REQUIRE(SDS.tke[offset] >= mintke);
       }
     }
 
@@ -111,8 +103,8 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyThreshFixer {
 
       if (SDS.shoctop[s] < nlev){
         const auto offset_stop = (SDS.shoctop[s]-1) + s * nlev;
-        REQUIRE(SDS.tke[offset_stop] == tke_min);
-        REQUIRE(SDS.tke[offset_stop+1] > tke_min);
+        REQUIRE(SDS.tke[offset_stop] == mintke);
+        REQUIRE(SDS.tke[offset_stop+1] > mintke);
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_energy_threshold_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_threshold_fixer_tests.cpp
@@ -64,15 +64,15 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyThreshFixer {
       SDS.te_a[s] = te_a;
       SDS.te_b[s] = te_b;
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.tke[offset] = tke_input[n];
+        SDS.tke[offset] = tke_input[n];
       }
 
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
 
-	SDS.pint[offset] = pint[n];
+        SDS.pint[offset] = pint[n];
       }
     }
 
@@ -80,9 +80,9 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyThreshFixer {
 
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	REQUIRE(SDS.tke[offset] >= mintke);
+        REQUIRE(SDS.tke[offset] >= mintke);
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_energy_total_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_total_fixer_tests.cpp
@@ -33,19 +33,22 @@ struct UnitWrap::UnitTest<D>::TestShocTotEnergyFixer {
     //     shoc_energy_total_fixer
 
     // FIRST TEST
+    // Surface flux test.  Have two columns, one with zero surface fluxes
+    //   and the other with positive surface fluxes.  Verify the column
+    //   with surface fluxes has greater total energy "before".
 
     // Timestep [s]
-    static constexpr Real dtime = 300.0;
+    static constexpr Real dtime = 300;
     // Number of macmic steps
     static constexpr Int nadv = 2;
     // Air density [km/m3]
     static constexpr Real rho_zt[nlev] = {0.4, 0.6, 0.7, 0.9, 1.0};
     // Interface heights [m]
-    static constexpr Real zi_grid[nlevi] = {11000.0, 7500.0, 5000.0, 3000.0, 1500.0, 0.0};
+    static constexpr Real zi_grid[nlevi] = {11000, 7500, 5000, 3000, 1500, 0};
     // Define integrated static energy, kinetic energy, water vapor,
     //  and liquid water respectively
-    static constexpr Real se = 200.0;
-    static constexpr Real ke = 150.0;
+    static constexpr Real se = 200;
+    static constexpr Real ke = 150;
     static constexpr Real wv = 0.5;
     static constexpr Real wl = 0.1;
     // Define surface sensible heat flux [K m/s]
@@ -53,7 +56,7 @@ struct UnitWrap::UnitTest<D>::TestShocTotEnergyFixer {
     // Define surface total water flux [kg/kg m/s]
     static constexpr Real wqw_sfc = 0.01;
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCEnergytotData SDS(shcol, nlev, nlevi, dtime, nadv);
 
     // Test that the inputs are reasonable.
@@ -99,22 +102,22 @@ struct UnitWrap::UnitTest<D>::TestShocTotEnergyFixer {
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 
-	REQUIRE(SDS.zt_grid[offset] >= 0.0);
-	REQUIRE(SDS.rho_zt[offset] > 0.0);
+	REQUIRE(SDS.zt_grid[offset] >= 0);
+	REQUIRE(SDS.rho_zt[offset] > 0);
 
 	// Check that heights increase upward
 	if (n > nlev-1){
-          REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0.0);
+          REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
 	}
       }
       for (Int n = 0; n < nlevi; ++n){
 	const auto offset = n + s * nlevi;
 
-	REQUIRE(SDS.zi_grid[offset] >= 0.0);
+	REQUIRE(SDS.zi_grid[offset] >= 0);
 
 	// Check that heights increase upward
 	if (n > nlevi-1){
-          REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0.0);
+          REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0);
 	}
       }
     }

--- a/components/scream/src/physics/shoc/tests/shoc_energy_total_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_total_fixer_tests.cpp
@@ -82,17 +82,17 @@ struct UnitWrap::UnitTest<D>::TestShocTotEnergyFixer {
 
       // Fill in test data on zt_grid.
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	// For zt grid, set as midpoint of zi grid
-	SDS.zt_grid[offset] = 0.5*(zi_grid[n]+zi_grid[n+1]);
-	SDS.rho_zt[offset] = rho_zt[n];
+        // For zt grid, set as midpoint of zi grid
+        SDS.zt_grid[offset] = 0.5*(zi_grid[n]+zi_grid[n+1]);
+        SDS.rho_zt[offset] = rho_zt[n];
       }
       // Fill in test data on zi_grid.
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
 
-	SDS.zi_grid[offset] = zi_grid[n];
+        SDS.zi_grid[offset] = zi_grid[n];
       }
     }
 
@@ -100,25 +100,25 @@ struct UnitWrap::UnitTest<D>::TestShocTotEnergyFixer {
 
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	REQUIRE(SDS.zt_grid[offset] >= 0);
-	REQUIRE(SDS.rho_zt[offset] > 0);
+        REQUIRE(SDS.zt_grid[offset] >= 0);
+        REQUIRE(SDS.rho_zt[offset] > 0);
 
-	// Check that heights increase upward
-	if (n > nlev-1){
+        // Check that heights increase upward
+        if (n > nlev-1){
           REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
-	}
+        }
       }
       for (Int n = 0; n < nlevi; ++n){
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
 
-	REQUIRE(SDS.zi_grid[offset] >= 0);
+        REQUIRE(SDS.zi_grid[offset] >= 0);
 
-	// Check that heights increase upward
-	if (n > nlevi-1){
+        // Check that heights increase upward
+        if (n > nlevi-1){
           REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0);
-	}
+        }
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
@@ -59,15 +59,15 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
     for(Int s = 0; s < shcol; ++s) {
       SDS.phis[s] = phis;
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.thlm[offset] = thlm[n];
-	SDS.zt_grid[offset] = zt_grid[n];
-	SDS.exner[offset] = exner[n];
+        SDS.thlm[offset] = thlm[n];
+        SDS.zt_grid[offset] = zt_grid[n];
+        SDS.exner[offset] = exner[n];
 
-	// Force the first column of cloud liquid
-	//   to be zero!
-	SDS.shoc_ql[offset] = s*shoc_ql[n];
+        // Force the first column of cloud liquid
+        //   to be zero!
+        SDS.shoc_ql[offset] = s*shoc_ql[n];
 
       }
     }
@@ -77,27 +77,27 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
     for(Int s = 0; s < shcol; ++s) {
       REQUIRE(SDS.phis[s] >= 0.0);
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	REQUIRE(SDS.thlm[offset] > 0);
-	REQUIRE(SDS.shoc_ql[offset] >= 0);
-	REQUIRE(SDS.exner[offset] > 0);
-	REQUIRE(SDS.zt_grid[offset] >= 0);
+        REQUIRE(SDS.thlm[offset] > 0);
+        REQUIRE(SDS.shoc_ql[offset] >= 0);
+        REQUIRE(SDS.exner[offset] > 0);
+        REQUIRE(SDS.zt_grid[offset] >= 0);
 
-	// make sure the two columns are different and
-	//  as expected for the relevant variables
-	if (s == 0){
+        // make sure the two columns are different and
+        //  as expected for the relevant variables
+        if (s == 0){
           const auto offsets = n + (s+1) * nlev;
 
           REQUIRE(SDS.shoc_ql[offset] == 0);
           REQUIRE(SDS.shoc_ql[offsets] > SDS.shoc_ql[offset]);
-	}
+        }
 
-	// Check that heights and thlm increase upward
-	if (n < nlev-1){
+        // Check that heights and thlm increase upward
+        if (n < nlev-1){
           REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
-	  REQUIRE(SDS.thlm[offset + 1] - SDS.thlm[offset] < 0);
-	}
+          REQUIRE(SDS.thlm[offset + 1] - SDS.thlm[offset] < 0);
+        }
 
       }
     }
@@ -108,20 +108,20 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
     // Check test
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	// Verify dse is reasonable
-	REQUIRE(SDS.host_dse[offset] > 0);
+        const auto offset = n + s * nlev;
+        // Verify dse is reasonable
+        REQUIRE(SDS.host_dse[offset] > 0);
 
-	// Verify that dse increases with height upward
-	if (n < nlev-1){
+        // Verify that dse increases with height upward
+        if (n < nlev-1){
           REQUIRE(SDS.host_dse[offset + 1] - SDS.host_dse[offset] < 0);
-	}
+        }
 
-	// Verify that dse is greater in points with condensate loading
-	if (s == 0){
+        // Verify that dse is greater in points with condensate loading
+        if (s == 0){
           const auto offsets = n + (s+1) * nlev;
-	  REQUIRE(SDS.host_dse[offsets] > SDS.host_dse[offset]);
-	}
+          REQUIRE(SDS.host_dse[offsets] > SDS.host_dse[offset]);
+        }
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
@@ -37,17 +37,17 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
     //   dse if all other inputs are equal.
 
     // Liquid water potential temperature [K]
-    static constexpr Real thlm[nlev] = {350.0, 325.0, 315.0, 310.0, 300.0};
+    static constexpr Real thlm[nlev] = {350, 325, 315, 310, 300};
     // Exner function [-]
     static constexpr Real exner[nlev] = {0.1, 0.3, 0.5, 0.7, 1.0};
-    // Cloud condensate [g/kg] (converted to kg/kg when input)
-    static constexpr Real shoc_ql[nlev] = {0.005, 0.08, 0.04, 0.03, 0.001};
+    // Cloud condensate [kg/kg]
+    static constexpr Real shoc_ql[nlev] = {5e-6, 8e-5, 4e-4, 3e-4, 1e-6};
     // Mid-point heights [m]
-    static constexpr Real zt_grid[nlev] = {9000.0, 6000.0, 4000.0, 2000.0, 1000.0};
+    static constexpr Real zt_grid[nlev] = {9000, 6000, 4000, 2000, 1000};
     // Surface geopotential
-    static constexpr Real phis = 100.0;
+    static constexpr Real phis = 100;
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCEnergydseData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
@@ -65,10 +65,9 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
 	SDS.zt_grid[offset] = zt_grid[n];
 	SDS.exner[offset] = exner[n];
 
-	// convert to [kg/kg]
 	// Force the first column of cloud liquid
 	//   to be zero!
-	SDS.shoc_ql[offset] = s*shoc_ql[n]/1000.0;
+	SDS.shoc_ql[offset] = s*shoc_ql[n];
 
       }
     }
@@ -80,24 +79,24 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 
-	REQUIRE(SDS.thlm[offset] > 0.0);
-	REQUIRE(SDS.shoc_ql[offset] >= 0.0);
-	REQUIRE(SDS.exner[offset] > 0.0);
-	REQUIRE(SDS.zt_grid[offset] >= 0.0);
+	REQUIRE(SDS.thlm[offset] > 0);
+	REQUIRE(SDS.shoc_ql[offset] >= 0);
+	REQUIRE(SDS.exner[offset] > 0);
+	REQUIRE(SDS.zt_grid[offset] >= 0);
 
 	// make sure the two columns are different and
 	//  as expected for the relevant variables
 	if (s == 0){
           const auto offsets = n + (s+1) * nlev;
 
-          REQUIRE(SDS.shoc_ql[offset] == 0.0);
+          REQUIRE(SDS.shoc_ql[offset] == 0);
           REQUIRE(SDS.shoc_ql[offsets] > SDS.shoc_ql[offset]);
 	}
 
 	// Check that heights and thlm increase upward
 	if (n < nlev-1){
-          REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0.0);
-	  REQUIRE(SDS.thlm[offset + 1] - SDS.thlm[offset] < 0.0);
+          REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
+	  REQUIRE(SDS.thlm[offset + 1] - SDS.thlm[offset] < 0);
 	}
 
       }
@@ -111,11 +110,11 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
 	// Verify dse is reasonable
-	REQUIRE(SDS.host_dse[offset] > 0.0);
+	REQUIRE(SDS.host_dse[offset] > 0);
 
 	// Verify that dse increases with height upward
 	if (n < nlev-1){
-          REQUIRE(SDS.host_dse[offset + 1] - SDS.host_dse[offset] < 0.0);
+          REQUIRE(SDS.host_dse[offset + 1] - SDS.host_dse[offset] < 0);
 	}
 
 	// Verify that dse is greater in points with condensate loading

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_diag_third_moms_tests.cpp
@@ -27,11 +27,11 @@ struct UnitWrap::UnitTest<D>::TestFtermdiagThirdMoms {
 
     // Tests for the SHOC function:
     //   f0_to_f5_diag_third_shoc_moment
-  
+
     // TEST ONE
     // Zero test.  Given no gradients, verify that relevant
-    //  terms are zero. 
-    
+    //  terms are zero.
+
     // 1/grid spacing [m-1]
     constexpr static Real thedz = 0.1;
     // 1/grid spacing for two grids [m-1]
@@ -48,10 +48,10 @@ struct UnitWrap::UnitTest<D>::TestFtermdiagThirdMoms {
     constexpr static Real w_sec_zero = 0.4;
     // TKE [m2/s2]
     constexpr static Real tke_zero = 0.5;
-  
+
     // Initialize data structure for bridging to F90
     SHOCFtermdiagthirdmomsData SDS;
-    
+
     // Fill in data
     SDS.thedz = thedz;
     SDS.thedz2 = thedz2;
@@ -71,18 +71,18 @@ struct UnitWrap::UnitTest<D>::TestFtermdiagThirdMoms {
     SDS.w_sec_zi = w_sec_zero;
     SDS.tke = tke_zero;
     SDS.tke_kc = tke_zero;
-    
+
     // Be sure inputs are as we expect
     REQUIRE(SDS.thedz > 0);
     REQUIRE(SDS.thedz2 > 0);
     REQUIRE(SDS.wthl_sec_kc == SDS.wthl_sec_kb);
     REQUIRE(SDS.thl_sec_kc == SDS.thl_sec_kb);
-    REQUIRE(SDS.w_sec_kc == SDS.w_sec); 
-    REQUIRE(SDS.tke_kc == SDS.tke);          
-    
-    // Call the fortran implementation    
-    f0_to_f5_diag_third_shoc_moment(SDS);    
-    
+    REQUIRE(SDS.w_sec_kc == SDS.w_sec);
+    REQUIRE(SDS.tke_kc == SDS.tke);
+
+    // Call the fortran implementation
+    f0_to_f5_diag_third_shoc_moment(SDS);
+
     // Check result, make sure all outputs are zero
     REQUIRE(SDS.f0 == 0);
     REQUIRE(SDS.f1 == 0);
@@ -90,9 +90,9 @@ struct UnitWrap::UnitTest<D>::TestFtermdiagThirdMoms {
     REQUIRE(SDS.f3 == 0);
     REQUIRE(SDS.f4 == 0);
     REQUIRE(SDS.f5 == 0);
-    
-    // TEST TWO 
-    // Positive gradient test.  Feed the function values of the second 
+
+    // TEST TWO
+    // Positive gradient test.  Feed the function values of the second
     //  moments with positive gradients.  All fterms should have positive values
 
     // liquid water flux [K m/s]
@@ -100,22 +100,22 @@ struct UnitWrap::UnitTest<D>::TestFtermdiagThirdMoms {
     // liquid water flux [K m/s] above
     constexpr static Real wthl_sec_kc = 0.02;
     // liquid water flux [K m/s] below
-    constexpr static Real wthl_sec_kb = 0.00;        
+    constexpr static Real wthl_sec_kb = 0;
     // thetal variance [K^2]
     constexpr static Real thl_sec = 2;
     // thetal variance [K^2] above
     constexpr static Real thl_sec_kc = 2.5;
     // thetal variance [K^2]
-    constexpr static Real thl_sec_kb = 1.7;    
+    constexpr static Real thl_sec_kb = 1.7;
     // vertical velocity variance [m2/s2]
     constexpr static Real w_sec = 0.4;
     // vertical velocity variance [m2/s2] above
-    constexpr static Real w_sec_kc = 0.5;    
+    constexpr static Real w_sec_kc = 0.5;
     // TKE [m2/s2]
     constexpr static Real tke = 0.5;
     // TKE [m2/s2] above
-    constexpr static Real tke_kc = 0.55;    
-    
+    constexpr static Real tke_kc = 0.55;
+
     // Feed in data
     SDS.wthl_sec = wthl_sec;
     SDS.wthl_sec_kc = wthl_sec_kc;
@@ -128,31 +128,31 @@ struct UnitWrap::UnitTest<D>::TestFtermdiagThirdMoms {
     SDS.w_sec_zi = w_sec;
     SDS.tke = tke;
     SDS.tke_kc = tke_kc;
-    
+
     // Verify input is what we want for this test
     REQUIRE(wthl_sec > 0);
     REQUIRE(wthl_sec_kc > wthl_sec_kb);
     REQUIRE(thl_sec_kc > thl_sec_kb);
-    REQUIRE(w_sec_kc > w_sec); 
-    REQUIRE(tke_kc > tke);   
-    
-    // Call the fortran implementation    
-    f0_to_f5_diag_third_shoc_moment(SDS);    
+    REQUIRE(w_sec_kc > w_sec);
+    REQUIRE(tke_kc > tke);
 
-    // Check result, make sure all outputs are zero
+    // Call the fortran implementation
+    f0_to_f5_diag_third_shoc_moment(SDS);
+
+    // Check result, make sure all outputs are greater than zero
     REQUIRE(SDS.f0 > 0);
     REQUIRE(SDS.f1 > 0);
     REQUIRE(SDS.f2 > 0);
     REQUIRE(SDS.f3 > 0);
     REQUIRE(SDS.f4 > 0);
     REQUIRE(SDS.f5 > 0);
-    
+
   }
-  
+
   static void run_bfb()
   {
     // TODO
-  }  
+  }
 
 };
 
@@ -165,7 +165,7 @@ namespace{
 TEST_CASE("shoc_fterm_diag_third_moms_property", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestFtermdiagThirdMoms;
-  
+
   TestStruct::run_property();
 }
 

--- a/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_fterm_input_third_moms_tests.cpp
@@ -27,10 +27,10 @@ struct UnitWrap::UnitTest<D>::TestFtermInputThirdMoms {
 
     // Tests for the SHOC function:
     //   fterms_input_for_diag_third_shoc_moment
-  
+
     // TEST
-    // Given inputs, verify that output is reasonable  
-    
+    // Given inputs, verify that output is reasonable
+
     // grid spacing on interface grid [m]
     constexpr static Real dz_zi = 100;
     // grid spacing on midpoint grid [m]
@@ -39,53 +39,53 @@ struct UnitWrap::UnitTest<D>::TestFtermInputThirdMoms {
     constexpr static Real dz_zt_kc = 120;
     // Return to isotropic timescale [s]
     constexpr static Real isotropy_zi = 1000;
-    // Brunt vaisalla frequency [s] 
+    // Brunt vaisalla frequency [s]
     constexpr static Real brunt_zi = -0.05;
     // Potential temperature on interface grid [K]
     constexpr static Real thetal_zi = 300;
-    
+
     // Initialize data structure for bridging to F90
     SHOCFterminputthirdmomsData SDS;
-    
+
     SDS.dz_zi = dz_zi;
     SDS.dz_zt = dz_zt;
     SDS.dz_zt_kc = dz_zt_kc;
     SDS.isotropy_zi = isotropy_zi;
     SDS.brunt_zi = brunt_zi;
     SDS.thetal_zi = thetal_zi;
-    
-    // Check that input is physical 
+
+    // Check that input is physical
     REQUIRE(SDS.dz_zi > 0);
     REQUIRE(SDS.dz_zt > 0);
     REQUIRE(SDS.dz_zt_kc > 0);
     REQUIRE(SDS.isotropy_zi > 0);
     REQUIRE(SDS.thetal_zi > 0);
-    
-    // Call the fortran implementation    
-    fterms_input_for_diag_third_shoc_moment(SDS);  
-    
+
+    // Call the fortran implementation
+    fterms_input_for_diag_third_shoc_moment(SDS);
+
     // Verify the result
-    
+
     // Check that thedz2 is smaller than thedz.
     REQUIRE(SDS.thedz2 < SDS.thedz);
-    
+
     // Check that bet2 is smaller than thetal
     REQUIRE(SDS.bet2 < SDS.thetal_zi);
-    
+
     // Be sure that iso and isosqrd relationships hold
     if (SDS.isotropy_zi > 1){
       REQUIRE(SDS.isosqrd > SDS.iso);
-    }  
+    }
     else{
       REQUIRE(SDS.isosqrd < SDS.iso);
     }
-    
+
   }
-  
+
   static void run_bfb()
   {
     // TODO
-  }  
+  }
 
 };
 

--- a/components/scream/src/physics/shoc/tests/shoc_grid_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_grid_tests.cpp
@@ -32,13 +32,13 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
     static constexpr auto nlevi   = nlev + 1;
 
     // Define the midpoint height grid [m]
-    static constexpr Real zt_pts[nlev] = {10000., 5000., 1000., 500., 100.};
+    static constexpr Real zt_pts[nlev] = {10000, 5000, 1000, 500, 100};
     // Define the interface height grid [m]
-    static constexpr Real zi_pts[nlevi] = {12500., 7500., 3000., 750., 250.0, 0.};
+    static constexpr Real zi_pts[nlevi] = {12500, 7500, 3000, 750, 250, 0};
     // Define the air density [kg/m3]
     static constexpr Real density_zt[nlev] = {0.4, 0.6, 0.8, 1.0, 1.2};
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCGridData SDS(shcol, nlev, nlevi);
 
     // Test that the inputs are reasonable.
@@ -68,13 +68,13 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev - 1; ++n) {
 	const auto offset = n + s * nlev;
-	REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0.0);
+	REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
       }
 
       // Check that zi decreases upward
       for(Int n = 0; n < nlevi - 1; ++n) {
 	const auto offset = n + s * nlevi;
-	REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0.0);
+	REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0);
       }
     }
 
@@ -120,8 +120,8 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
 	REQUIRE(abs(SDS.rho_zt[offset] - density_zt[n]) <= std::numeric_limits<Real>::epsilon());
 
 	// check that the density has physically realistic values
-	REQUIRE(SDS.rho_zt[offset] <= 2.0);
-	REQUIRE(SDS.rho_zt[offset] > 0.0);
+	REQUIRE(SDS.rho_zt[offset] <= 2);
+	REQUIRE(SDS.rho_zt[offset] > 0);
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_grid_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_grid_tests.cpp
@@ -49,16 +49,16 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.zt_grid[offset] = zt_pts[n];
-	SDS.pdel[offset]    = density_zt[n] * gravit * (zi_pts[n]-zi_pts[n+1]);
+        SDS.zt_grid[offset] = zt_pts[n];
+        SDS.pdel[offset]    = density_zt[n] * gravit * (zi_pts[n]-zi_pts[n+1]);
       }
 
       // Fill in test data on zi_grid.
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset   = n + s * nlevi;
-	SDS.zi_grid[offset] = zi_pts[n];
+        const auto offset   = n + s * nlevi;
+        SDS.zi_grid[offset] = zi_pts[n];
       }
     }
 
@@ -67,14 +67,14 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
     // Check that zt decreases upward
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev - 1; ++n) {
-	const auto offset = n + s * nlev;
-	REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
+        const auto offset = n + s * nlev;
+        REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
       }
 
       // Check that zi decreases upward
       for(Int n = 0; n < nlevi - 1; ++n) {
-	const auto offset = n + s * nlevi;
-	REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0);
+        const auto offset = n + s * nlevi;
+        REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0);
       }
     }
 
@@ -85,10 +85,10 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
     for(Int s = 0; s < shcol; ++s) {
       Real zt_sum = 0;
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	REQUIRE(SDS.dz_zt[offset] > 0);
-	REQUIRE(SDS.dz_zt[offset] == zi_pts[n] - zi_pts[n+1]);
-	zt_sum += SDS.dz_zt[offset];
+        const auto offset = n + s * nlev;
+        REQUIRE(SDS.dz_zt[offset] > 0);
+        REQUIRE(SDS.dz_zt[offset] == zi_pts[n] - zi_pts[n+1]);
+        zt_sum += SDS.dz_zt[offset];
       }
       // Check that the sum of dz_zt is equal to the largest zi
       REQUIRE(zt_sum == SDS.zi_grid[0]);
@@ -101,10 +101,10 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
 
       Real zi_sum = 0;
       for(Int n = 1; n < nlevi - 1; ++n) {
-	const auto offset = n + s * nlevi;
-	REQUIRE(SDS.dz_zi[offset] > 0.0);
-	REQUIRE(SDS.dz_zi[offset] == zt_pts[n-1] - zt_pts[n]);
-	zi_sum += SDS.dz_zi[offset];
+        const auto offset = n + s * nlevi;
+        REQUIRE(SDS.dz_zi[offset] > 0.0);
+        REQUIRE(SDS.dz_zi[offset] == zt_pts[n-1] - zt_pts[n]);
+        zi_sum += SDS.dz_zi[offset];
       }
       // Check that the sum of dz_zi is equal to the largest zt
       zi_sum += SDS.dz_zi[nlevi - 1];
@@ -114,14 +114,14 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
     // Now check density
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	// check that the density is consistent with the hydrostatic approximation
-	REQUIRE(abs(SDS.rho_zt[offset] - density_zt[n]) <= std::numeric_limits<Real>::epsilon());
+        // check that the density is consistent with the hydrostatic approximation
+        REQUIRE(abs(SDS.rho_zt[offset] - density_zt[n]) <= std::numeric_limits<Real>::epsilon());
 
-	// check that the density has physically realistic values
-	REQUIRE(SDS.rho_zt[offset] <= 2);
-	REQUIRE(SDS.rho_zt[offset] > 0);
+        // check that the density has physically realistic values
+        REQUIRE(SDS.rho_zt[offset] <= 2);
+        REQUIRE(SDS.rho_zt[offset] > 0);
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_impli_comp_tmpi_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_impli_comp_tmpi_tests.cpp
@@ -43,7 +43,7 @@ struct UnitWrap::UnitTest<D>::TestImpCompTmpi {
     // Define timestep [s]
     static constexpr Real dtime = 300;
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCComptmpiData SDS(shcol, nlevi, dtime);
 
     // Test that the inputs are reasonable.
@@ -72,11 +72,11 @@ struct UnitWrap::UnitTest<D>::TestImpCompTmpi {
         REQUIRE( (SDS.rho_zi[offset] > 0 && SDS.rho_zi[offset] < 1.5) );
         // Make sure top level dz_zi value is zero
 	if (n == 0){
-          REQUIRE(SDS.dz_zi[offset] == 0.0);
+          REQUIRE(SDS.dz_zi[offset] == 0);
 	}
 	// Otherwise, should be greater than zero
 	else{
-          REQUIRE(SDS.dz_zi[offset] > 0.0);
+          REQUIRE(SDS.dz_zi[offset] > 0);
           // Verify that the second column has smaller dz values
           if (s < shcol-1){
             REQUIRE(SDS.dz_zi[offset] > SDS.dz_zi[offsets]);

--- a/components/scream/src/physics/shoc/tests/shoc_impli_comp_tmpi_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_impli_comp_tmpi_tests.cpp
@@ -55,27 +55,27 @@ struct UnitWrap::UnitTest<D>::TestImpCompTmpi {
     // Fill in test data on zi_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
 
         // Feed second column SMALLER dz values
-	SDS.dz_zi[offset] = dz_zi[n]/(1+s);
-	SDS.rho_zi[offset] = rho_zi[n];
+        SDS.dz_zi[offset] = dz_zi[n]/(1+s);
+        SDS.rho_zi[offset] = rho_zi[n];
       }
     }
 
     // Check that the inputs make sense
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlevi; ++n){
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
         const auto offsets = n + (1+s)*nlevi;
-	// make sure that density is in reasonable bounds
+        // make sure that density is in reasonable bounds
         REQUIRE( (SDS.rho_zi[offset] > 0 && SDS.rho_zi[offset] < 1.5) );
         // Make sure top level dz_zi value is zero
-	if (n == 0){
+        if (n == 0){
           REQUIRE(SDS.dz_zi[offset] == 0);
-	}
-	// Otherwise, should be greater than zero
-	else{
+        }
+        // Otherwise, should be greater than zero
+        else{
           REQUIRE(SDS.dz_zi[offset] > 0);
           // Verify that the second column has smaller dz values
           if (s < shcol-1){

--- a/components/scream/src/physics/shoc/tests/shoc_impli_dp_inverse_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_impli_dp_inverse_tests.cpp
@@ -49,20 +49,20 @@ struct UnitWrap::UnitTest<D>::TestImpDpInverse {
     // Fill in test data on zi_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
         // Feed second column SMALLER dz values
-	SDS.dz_zt[offset] = dz_zt[n]/(1+s);
-	SDS.rho_zt[offset] = rho_zt[n];
+        SDS.dz_zt[offset] = dz_zt[n]/(1+s);
+        SDS.rho_zt[offset] = rho_zt[n];
       }
     }
 
     // Check that the inputs make sense
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
         const auto offsets = n + (1+s)*nlev;
-	// make sure that density is in reasonable bounds
+        // make sure that density is in reasonable bounds
         REQUIRE( (SDS.rho_zt[offset] > 0 && SDS.rho_zt[offset] < 1.5) );
         REQUIRE(SDS.dz_zt[offset] > 0);
         // Verify that the second column has smaller dz values

--- a/components/scream/src/physics/shoc/tests/shoc_impli_dp_inverse_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_impli_dp_inverse_tests.cpp
@@ -39,7 +39,7 @@ struct UnitWrap::UnitTest<D>::TestImpDpInverse {
     // Define density on zt grid [kg/m3]
     static constexpr Real rho_zt[nlev] = {0.6, 0.8, 0.9, 1.0, 1.2};
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCDpinverseData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.

--- a/components/scream/src/physics/shoc/tests/shoc_impli_sfc_fluxes_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_impli_sfc_fluxes_tests.cpp
@@ -55,7 +55,7 @@ struct UnitWrap::UnitTest<D>::TestImpSfcFluxes {
     // time step [s]
     static constexpr Real dtime = 300;
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCSfcfluxesData SDS(shcol, dtime);
 
     // Test that the inputs are reasonable.

--- a/components/scream/src/physics/shoc/tests/shoc_impli_srf_stress_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_impli_srf_stress_tests.cpp
@@ -44,7 +44,7 @@ struct UnitWrap::UnitTest<D>::TestImpSfcStress {
     // Surface wind, meridional direction [m/s]
     static constexpr Real v_wind_sfc[shcol] = {-10, 2, 20, 0, 1};
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCImplsrfstressData SDS(shcol);
 
     // Test that the inputs are reasonable.

--- a/components/scream/src/physics/shoc/tests/shoc_impli_srf_tke_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_impli_srf_tke_tests.cpp
@@ -39,7 +39,7 @@ struct UnitWrap::UnitTest<D>::TestImpTkeSfcStress {
     // Surface moment flux, meridional direction [m3/s3]
     static constexpr Real vw_sfc[shcol] = {-0.01, -0.01, 0.3, 0, -0.3};
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCTkesrffluxData SDS(shcol);
 
     // Test that the inputs are reasonable.

--- a/components/scream/src/physics/shoc/tests/shoc_l_inf_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_l_inf_length_tests.cpp
@@ -35,11 +35,14 @@ struct UnitWrap::UnitTest<D>::TestLInfShocLength {
     //  that l_inf always gets larger per column.
 
     // Grid difference centered on thermo grid [m]
-    static constexpr Real dz_zt[nlev] = {100.0, 100.0, 100.0, 100.0, 100.0};
+    static constexpr Real dz_zt[nlev] = {100, 100, 100, 100, 100};
     // Grid height centered on thermo grid [m]
-    static constexpr Real zt_grid[nlev] = {500.0, 400.0, 300.0, 200.0, 100.0};
+    static constexpr Real zt_grid[nlev] = {500, 400, 300, 200, 100};
     // Turbulent kinetic energy [m2/s2]
     static constexpr Real tke[nlev] = {0.1, 0.15, 0.2, 0.25, 0.3};
+
+    // Set upper bound for checking output [m]
+    static constexpr Real l_inf_bound = 500;
 
     // Initialize data structure for bridgeing to F90
     SHOCInflengthData SDS(shcol, nlev);
@@ -69,12 +72,12 @@ struct UnitWrap::UnitTest<D>::TestLInfShocLength {
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
 	// Be sure that relevant variables are greater than zero
-	REQUIRE(SDS.dz_zt[offset] > 0.0);
-	REQUIRE(SDS.tke[offset] > 0.0);
-	REQUIRE(SDS.zt_grid[offset] > 0.0);
+	REQUIRE(SDS.dz_zt[offset] > 0);
+	REQUIRE(SDS.tke[offset] > 0);
+	REQUIRE(SDS.zt_grid[offset] > 0);
 	if (n < nlev-1){
           // check that zt increases upward
-          REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0.0);
+          REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
 	}
 	if (s < shcol-1){
           // Verify that zt_grid is offset larger column by column
@@ -88,9 +91,10 @@ struct UnitWrap::UnitTest<D>::TestLInfShocLength {
     compute_l_inf_shoc_length(SDS);
 
     // Check the results
-    // Make sure that conv_vel is negative
+    // Make sure result is bounded correctly
     for(Int s = 0; s < shcol; ++s) {
-      REQUIRE(SDS.l_inf[s] > 0.0);
+      REQUIRE(SDS.l_inf[s] > 0);
+      REQUIRE(SDS.l_inf[s] < l_inf_bound);
     }
 
     // Make sure that l_inf is getting larger

--- a/components/scream/src/physics/shoc/tests/shoc_l_inf_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_l_inf_length_tests.cpp
@@ -55,14 +55,14 @@ struct UnitWrap::UnitTest<D>::TestLInfShocLength {
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.dz_zt[offset] = dz_zt[n];
-	// Testing identical columns but one with larger zt heights.
-	//  first column set as "base" column, and the others
-	//  to a larger value of TKE uniformly.
-	SDS.zt_grid[offset] = (s*100.0)+zt_grid[n];
-	SDS.tke[offset] = tke[n];
+        SDS.dz_zt[offset] = dz_zt[n];
+        // Testing identical columns but one with larger zt heights.
+        //  first column set as "base" column, and the others
+        //  to a larger value of TKE uniformly.
+        SDS.zt_grid[offset] = (s*100.0)+zt_grid[n];
+        SDS.tke[offset] = tke[n];
       }
     }
 
@@ -70,20 +70,20 @@ struct UnitWrap::UnitTest<D>::TestLInfShocLength {
 
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	// Be sure that relevant variables are greater than zero
-	REQUIRE(SDS.dz_zt[offset] > 0);
-	REQUIRE(SDS.tke[offset] > 0);
-	REQUIRE(SDS.zt_grid[offset] > 0);
-	if (n < nlev-1){
+        const auto offset = n + s * nlev;
+        // Be sure that relevant variables are greater than zero
+        REQUIRE(SDS.dz_zt[offset] > 0);
+        REQUIRE(SDS.tke[offset] > 0);
+        REQUIRE(SDS.zt_grid[offset] > 0);
+        if (n < nlev-1){
           // check that zt increases upward
           REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
-	}
-	if (s < shcol-1){
+        }
+        if (s < shcol-1){
           // Verify that zt_grid is offset larger column by column
           const auto offsets = n + (s+1) * nlev;
-	  REQUIRE(SDS.zt_grid[offset] < SDS.zt_grid[offsets]);
-	}
+          REQUIRE(SDS.zt_grid[offset] < SDS.zt_grid[offsets]);
+        }
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_length_tests.cpp
@@ -89,23 +89,23 @@ struct UnitWrap::UnitTest<D>::TestShocLength {
       SDS.pblh[s] = pblh;
       // Fill in test data on zt_grid.
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	// for subsequent columns, increase TKE
-	SDS.tke[offset] = (s+1)*tke[n];
+        // for subsequent columns, increase TKE
+        SDS.tke[offset] = (s+1)*tke[n];
 
-	SDS.zt_grid[offset] = zt_grid[n];
-	SDS.thv[offset] = thv[n];
-	SDS.wthv_sec[offset] = wthv_sec[n];
-	SDS.dz_zt[offset] = dz_zt[n];
+        SDS.zt_grid[offset] = zt_grid[n];
+        SDS.thv[offset] = thv[n];
+        SDS.wthv_sec[offset] = wthv_sec[n];
+        SDS.dz_zt[offset] = dz_zt[n];
       }
 
       // Fill in test data on zi_grid
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
 
-	SDS.zi_grid[offset] = zi_grid[n];
-	SDS.dz_zi[offset] = dz_zi[n];
+        SDS.zi_grid[offset] = zi_grid[n];
+        SDS.dz_zi[offset] = dz_zi[n];
       }
     }
 
@@ -116,26 +116,26 @@ struct UnitWrap::UnitTest<D>::TestShocLength {
 
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	REQUIRE(SDS.zt_grid[offset] > 0);
-	REQUIRE(SDS.tke[offset] > 0);
-	REQUIRE(SDS.thv[offset] > 0);
-	REQUIRE(SDS.dz_zt[offset] > 0);
+        REQUIRE(SDS.zt_grid[offset] > 0);
+        REQUIRE(SDS.tke[offset] > 0);
+        REQUIRE(SDS.thv[offset] > 0);
+        REQUIRE(SDS.dz_zt[offset] > 0);
 
-	// Make sure TKE is larger in next column over
-	if (s < shcol-1){
-	  // get offset for "neighboring" column
-	  const auto offsets = n + (s+1) * nlev;
-	  REQUIRE(SDS.tke[offsets] > SDS.tke[offset]);
-	}
+        // Make sure TKE is larger in next column over
+        if (s < shcol-1){
+          // get offset for "neighboring" column
+          const auto offsets = n + (s+1) * nlev;
+          REQUIRE(SDS.tke[offsets] > SDS.tke[offset]);
+        }
       }
 
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	REQUIRE(SDS.zi_grid[offset] >= 0);
-	REQUIRE(SDS.dz_zi[offset] >= 0);
+        REQUIRE(SDS.zi_grid[offset] >= 0);
+        REQUIRE(SDS.dz_zi[offset] >= 0);
       }
     }
 
@@ -149,23 +149,23 @@ struct UnitWrap::UnitTest<D>::TestShocLength {
         // Require mixing length is greater than zero and is
         //  less than geometric grid mesh length + 1 m
         REQUIRE(SDS.shoc_mix[offset] >= minlen);
-	REQUIRE(SDS.shoc_mix[offset] <= maxlen);
+        REQUIRE(SDS.shoc_mix[offset] <= maxlen);
         REQUIRE(SDS.shoc_mix[offset] < 1.0+grid_mesh);
 
-	// Be sure brunt vaisalla frequency is reasonable
-	REQUIRE(std::abs(SDS.brunt[offset]) < 1);
+        // Be sure brunt vaisalla frequency is reasonable
+        REQUIRE(std::abs(SDS.brunt[offset]) < 1);
 
-	// Make sure length scale is larger when TKE is larger
-	if (s < shcol-1){
-	  // get offset for "neighboring" column
-	  const auto offsets = n + (s+1) * nlev;
-	  if (SDS.tke[offsets] > SDS.tke[offset]){
-	    REQUIRE(SDS.shoc_mix[offsets] > SDS.shoc_mix[offset]);
-	  }
-	  else{
-	    REQUIRE(SDS.shoc_mix[offsets] < SDS.shoc_mix[offset]);
-	  }
-	}
+        // Make sure length scale is larger when TKE is larger
+        if (s < shcol-1){
+          // get offset for "neighboring" column
+          const auto offsets = n + (s+1) * nlev;
+          if (SDS.tke[offsets] > SDS.tke[offset]){
+            REQUIRE(SDS.shoc_mix[offsets] > SDS.shoc_mix[offset]);
+          }
+          else{
+            REQUIRE(SDS.shoc_mix[offsets] < SDS.shoc_mix[offset]);
+          }
+        }
       }
     }
 
@@ -198,7 +198,7 @@ struct UnitWrap::UnitTest<D>::TestShocLength {
         // Require mixing length is greater than zero and is
         //  less than geometric grid mesh length + 1 m
         REQUIRE(SDS.shoc_mix[offset] > 0);
-	REQUIRE(SDS.shoc_mix[offset] <= maxlen);
+        REQUIRE(SDS.shoc_mix[offset] <= maxlen);
         REQUIRE(SDS.shoc_mix[offset] < 1.0+grid_mesh_small);
       }
     }

--- a/components/scream/src/physics/shoc/tests/shoc_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_length_tests.cpp
@@ -24,43 +24,48 @@ struct UnitWrap::UnitTest<D>::TestShocLength {
 
   static void run_property()
   {
+    static constexpr Real minlen = scream::shoc::Constants<Real>::minlen;
+    static constexpr Real maxlen = scream::shoc::Constants<Real>::maxlen;
     static constexpr Int shcol    = 2;
     static constexpr Int nlev     = 5;
     static constexpr Int nlevi    = nlev+1;
 
     // Tests for the upper level SHOC function:
     //   shoc_length
-    
+
     // TEST ONE
-    // Standard input and TKE test.  
-    // With reasonable inputs, verify outputs follow.  
+    // Standard input and TKE test.
+    // With reasonable inputs, verify outputs follow.
     // In addition, feed columns higher values of TKE and the length
     // scale for these columns should be gradually larger, given all other
-    // inputs are equal.  
+    // inputs are equal.
 
     // PBL height [m]
-    static constexpr Real pblh = 1000.0;
+    static constexpr Real pblh = 1000;
     // Define the host grid box size x-direction [m]
-    static constexpr Real host_dx = 3000; 
+    static constexpr Real host_dx = 3000;
     // Defin the host grid box size y-direction [m]
-    static constexpr Real host_dy = 5000; 
+    static constexpr Real host_dy = 5000;
     // Define the heights on the zt grid [m]
     static constexpr Real zi_grid[nlevi] = {9000, 5000, 1500, 900, 500, 0};
     // Virtual potential temperature on thermo grid [K]
-    static constexpr Real thv[nlev] = {315, 310, 305, 300, 295};    
+    static constexpr Real thv[nlev] = {315, 310, 305, 300, 295};
     // Buoyancy flux [K m/s]
-    static constexpr Real wthv_sec[nlev] = {0.02, 0.01, 0.04, 0.02, 0.05};   
+    static constexpr Real wthv_sec[nlev] = {0.02, 0.01, 0.04, 0.02, 0.05};
     // Turbulent kinetc energy [m2/s2]
     static constexpr Real tke[nlev] = {0.1, 0.15, 0.2, 0.25, 0.3};
-    
+
     // compute geometric grid mesh
     const auto grid_mesh = sqrt(host_dx*host_dy);
-    
+
+    // set bound to check output
+    static constexpr Real brunt_bound = 1;
+
     // Grid stuff to compute based on zi_grid
     Real zt_grid[nlev];
     Real dz_zt[nlev];
     Real dz_zi[nlevi];
-    // Compute heights on midpoint grid 
+    // Compute heights on midpoint grid
     for(Int n = 0; n < nlev; ++n) {
       zt_grid[n] = 0.5*(zi_grid[n]+zi_grid[n+1]);
       dz_zt[n] = zi_grid[n] - zi_grid[n+1];
@@ -76,48 +81,48 @@ struct UnitWrap::UnitTest<D>::TestShocLength {
 
     // Initialize data structure for bridging to F90
     SHOCLengthData SDS(shcol, nlev, nlevi);
-    
+
     // Load up input data
-    for(Int s = 0; s < shcol; ++s) {    
+    for(Int s = 0; s < shcol; ++s) {
       SDS.host_dx[s] = host_dx;
       SDS.host_dy[s] = host_dy;
       SDS.pblh[s] = pblh;
-      // Fill in test data on zt_grid.     
+      // Fill in test data on zt_grid.
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
-	
+
 	// for subsequent columns, increase TKE
 	SDS.tke[offset] = (s+1)*tke[n];
-	
+
 	SDS.zt_grid[offset] = zt_grid[n];
 	SDS.thv[offset] = thv[n];
 	SDS.wthv_sec[offset] = wthv_sec[n];
-	SDS.dz_zt[offset] = dz_zt[n];	    
+	SDS.dz_zt[offset] = dz_zt[n];
       }
-      
+
       // Fill in test data on zi_grid
       for(Int n = 0; n < nlevi; ++n) {
 	const auto offset = n + s * nlevi;
-	
+
 	SDS.zi_grid[offset] = zi_grid[n];
 	SDS.dz_zi[offset] = dz_zi[n];
-      }   
+      }
     }
-    
+
     // Check input data
     // for this test we need more than one column
     REQUIRE(SDS.shcol() > 1);
-    REQUIRE(SDS.nlevi() == SDS.nlev()+1);    
-    
-    for(Int s = 0; s < shcol; ++s) {     
+    REQUIRE(SDS.nlevi() == SDS.nlev()+1);
+
+    for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
-	
+
 	REQUIRE(SDS.zt_grid[offset] > 0);
 	REQUIRE(SDS.tke[offset] > 0);
 	REQUIRE(SDS.thv[offset] > 0);
 	REQUIRE(SDS.dz_zt[offset] > 0);
-	
+
 	// Make sure TKE is larger in next column over
 	if (s < shcol-1){
 	  // get offset for "neighboring" column
@@ -125,31 +130,31 @@ struct UnitWrap::UnitTest<D>::TestShocLength {
 	  REQUIRE(SDS.tke[offsets] > SDS.tke[offset]);
 	}
       }
-      
+
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
-	
+
 	REQUIRE(SDS.zi_grid[offset] >= 0);
 	REQUIRE(SDS.dz_zi[offset] >= 0);
       }
     }
-    
-    // Call the Fortran implementation 
+
+    // Call the Fortran implementation
     shoc_length(SDS);
 
     // Verify output
-    for(Int s = 0; s < shcol; ++s) {   
-      for(Int n = 0; n < nlev; ++n) { 
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
         const auto offset = n + s * nlev;
         // Require mixing length is greater than zero and is
         //  less than geometric grid mesh length + 1 m
-        REQUIRE(SDS.shoc_mix[offset] > 0.0); 
+        REQUIRE(SDS.shoc_mix[offset] >= minlen);
+	REQUIRE(SDS.shoc_mix[offset] <= maxlen);
         REQUIRE(SDS.shoc_mix[offset] < 1.0+grid_mesh);
-	
+
 	// Be sure brunt vaisalla frequency is reasonable
-	REQUIRE(SDS.brunt[offset] < 1);
-	REQUIRE(SDS.brunt[offset] > -1);
-	
+	REQUIRE(std::abs(SDS.brunt[offset]) < 1);
+
 	// Make sure length scale is larger when TKE is larger
 	if (s < shcol-1){
 	  // get offset for "neighboring" column
@@ -160,40 +165,41 @@ struct UnitWrap::UnitTest<D>::TestShocLength {
 	  else{
 	    REQUIRE(SDS.shoc_mix[offsets] < SDS.shoc_mix[offset]);
 	  }
-	}	
+	}
       }
     }
-    
+
     // TEST TWO
     // Small grid mesh test.  Given a very small grid mesh, verify that
     //  the length scale is confined to this value.  Input from first
     //  test will be recycled into this one.
-     
+
     // Define the host grid box size x-direction [m]
     static constexpr Real host_dx_small = 3;
     // Defin the host grid box size y-direction [m]
     static constexpr Real host_dy_small = 5;
-    
+
     // compute geometric grid mesh
     const auto grid_mesh_small = sqrt(host_dx_small*host_dy_small);
-    
+
     // Load new input
     for(Int s = 0; s < shcol; ++s) {
       SDS.host_dx[s] = host_dx_small;
       SDS.host_dy[s] = host_dy_small;
     }
-    
+
     // call fortran implentation
     shoc_length(SDS);
-    
+
     // Verify output
-    for(Int s = 0; s < shcol; ++s) {   
-      for(Int n = 0; n < nlev; ++n) { 
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
         const auto offset = n + s * nlev;
         // Require mixing length is greater than zero and is
         //  less than geometric grid mesh length + 1 m
-        REQUIRE(SDS.shoc_mix[offset] > 0.0);
-        REQUIRE(SDS.shoc_mix[offset] < 1.0+grid_mesh_small);	
+        REQUIRE(SDS.shoc_mix[offset] > 0);
+	REQUIRE(SDS.shoc_mix[offset] <= maxlen);
+        REQUIRE(SDS.shoc_mix[offset] < 1.0+grid_mesh_small);
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_linear_interp_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_linear_interp_tests.cpp
@@ -62,23 +62,23 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < km1; ++n) {
-	const auto offset = n + s * km1;
+        const auto offset = n + s * km1;
 
-	// For zt grid heights compute as midpoint
-	//  between interface heights
-	SDS.x1[offset] = 0.5*(zi_grid[n]+zi_grid[n+1]);
-	if (s == 0){
-	  SDS.y1[offset] = thetal_zt[n];
-	}
-	else{
-	  SDS.y1[offset] = u_wind_zt[n];
-	}
+        // For zt grid heights compute as midpoint
+        //  between interface heights
+        SDS.x1[offset] = 0.5*(zi_grid[n]+zi_grid[n+1]);
+        if (s == 0){
+          SDS.y1[offset] = thetal_zt[n];
+        }
+        else{
+          SDS.y1[offset] = u_wind_zt[n];
+        }
       }
 
       // Fill in test data on zi_grid.
       for(Int n = 0; n < km2; ++n) {
-	const auto offset   = n + s * km2;
-	SDS.x2[offset] = zi_grid[n];
+        const auto offset   = n + s * km2;
+        SDS.x2[offset] = zi_grid[n];
       }
     }
 
@@ -87,14 +87,14 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
     // Check that zt decreases upward
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < km1 - 1; ++n) {
-	const auto offset = n + s * km1;
-	REQUIRE(SDS.x1[offset + 1] - SDS.x1[offset] < 0.0);
+        const auto offset = n + s * km1;
+        REQUIRE(SDS.x1[offset + 1] - SDS.x1[offset] < 0.0);
       }
 
       // Check that zi decreases upward
       for(Int n = 0; n < km2 - 1; ++n) {
-	const auto offset = n + s * km2;
-	REQUIRE(SDS.x2[offset + 1] - SDS.x2[offset] < 0.0);
+        const auto offset = n + s * km2;
+        REQUIRE(SDS.x2[offset + 1] - SDS.x2[offset] < 0.0);
       }
     }
 
@@ -105,59 +105,59 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
 
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < km1; ++n) {
-	const auto offset = n + s * km1;
-	const auto offseti = n + s * km2;
+        const auto offset = n + s * km1;
+        const auto offseti = n + s * km2;
 
-	// check boundary points
-	// First upper boundary
-	if (n == 0){
-	  const auto uppergradient = SDS.y1[offset] - SDS.y1[offset+1];
-	  if (uppergradient > 0.0){
-	    // if upper gradient is positive then make sure that
-	    //  the temperature of the highest nlevi layer is greater
-	    //  than the tempature of the highest nlev layer
-	    REQUIRE(SDS.y2[offseti] > SDS.y1[offset]);
-	  }
-	  if (uppergradient < 0.0){
-	    REQUIRE(SDS.y2[offseti] < SDS.y1[offset]);
-	  }
-	  if (uppergradient == 0.0){
-	    REQUIRE(SDS.y2[offseti] == SDS.y2[offseti]);
-	  }
-	}
+        // check boundary points
+        // First upper boundary
+        if (n == 0){
+          const auto uppergradient = SDS.y1[offset] - SDS.y1[offset+1];
+          if (uppergradient > 0.0){
+            // if upper gradient is positive then make sure that
+            //  the temperature of the highest nlevi layer is greater
+            //  than the tempature of the highest nlev layer
+            REQUIRE(SDS.y2[offseti] > SDS.y1[offset]);
+          }
+          if (uppergradient < 0.0){
+            REQUIRE(SDS.y2[offseti] < SDS.y1[offset]);
+          }
+          if (uppergradient == 0.0){
+            REQUIRE(SDS.y2[offseti] == SDS.y2[offseti]);
+          }
+        }
 
         // Now the lower boundary
-	else if (n == km1-1){
-	  const auto lowergradient = SDS.y1[offset-1] - SDS.y1[offset];
-	  if (lowergradient > 0.0){
-	    // if lower gradient is positive then make sure that
-	    //  the temperature of the lowest nlevi layer is lower
-	    //  than the tempature of the lowest nlev layer
-	    REQUIRE(SDS.y2[offseti+1] < SDS.y1[offset]);
-	  }
-	  if (lowergradient < 0.0){
-	    REQUIRE(SDS.y2[offseti+1] > SDS.y1[offset]);
-	  }
-	  if (lowergradient == 0.0){
-	    REQUIRE(SDS.y2[offseti+1] == SDS.y2[offset]);
-	  }
-	}
+        else if (n == km1-1){
+          const auto lowergradient = SDS.y1[offset-1] - SDS.y1[offset];
+          if (lowergradient > 0.0){
+            // if lower gradient is positive then make sure that
+            //  the temperature of the lowest nlevi layer is lower
+            //  than the tempature of the lowest nlev layer
+            REQUIRE(SDS.y2[offseti+1] < SDS.y1[offset]);
+          }
+          if (lowergradient < 0.0){
+            REQUIRE(SDS.y2[offseti+1] > SDS.y1[offset]);
+          }
+          if (lowergradient == 0.0){
+            REQUIRE(SDS.y2[offseti+1] == SDS.y2[offset]);
+          }
+        }
 
-	// Now make sure all points are bounded as expected
-	else{
-	  const auto gradient = SDS.y1[offset-1] - SDS.y1[offset];
-	  if (gradient == 0.0){
-	    REQUIRE(SDS.y2[offseti] == SDS.y1[offset]);
-	  }
-	  else if (gradient > 0.0){
-	    REQUIRE(SDS.y2[offseti] < SDS.y1[offset-1]);
-	    REQUIRE(SDS.y2[offseti] > SDS.y1[offset]);
-	  }
-	  else {
-	    REQUIRE(SDS.y2[offseti] > SDS.y1[offset-1]);
-	    REQUIRE(SDS.y2[offseti] < SDS.y1[offset]);
-	  }
-	}
+        // Now make sure all points are bounded as expected
+        else{
+          const auto gradient = SDS.y1[offset-1] - SDS.y1[offset];
+          if (gradient == 0.0){
+            REQUIRE(SDS.y2[offseti] == SDS.y1[offset]);
+          }
+          else if (gradient > 0.0){
+            REQUIRE(SDS.y2[offseti] < SDS.y1[offset-1]);
+            REQUIRE(SDS.y2[offseti] > SDS.y1[offset]);
+          }
+          else {
+            REQUIRE(SDS.y2[offseti] > SDS.y1[offset-1]);
+            REQUIRE(SDS.y2[offseti] < SDS.y1[offset]);
+          }
+        }
 
       }
     }
@@ -173,20 +173,20 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
     // Fill in test data on zi_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < km2; ++n) {
-	const auto offset = n + s * km2;
+        const auto offset = n + s * km2;
 
-	// Load up stuff on interface grid.  Here we
-	//  are going to use information from the last test
-	//  to initialize our grid
-	SDS2.x1[offset] = SDS.x2[offset];
-	SDS2.y1[offset] = SDS.y2[offset];
+        // Load up stuff on interface grid.  Here we
+        //  are going to use information from the last test
+        //  to initialize our grid
+        SDS2.x1[offset] = SDS.x2[offset];
+        SDS2.y1[offset] = SDS.y2[offset];
       }
 
       // Load up stuff on midpoint grid, use output from
       //  the last test here.
       for(Int n = 0; n < km1; ++n) {
-	const auto offset   = n + s * km1;
-	SDS2.x2[offset] = SDS.x1[offset];
+        const auto offset   = n + s * km1;
+        SDS2.x2[offset] = SDS.x1[offset];
       }
     }
 
@@ -196,23 +196,23 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
 
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < km1; ++n) {
-	const auto offset = n + s * km1;
-	const auto offseti = n + s * km2;
+        const auto offset = n + s * km1;
+        const auto offseti = n + s * km2;
 
-	// compute gradient
-	const auto gradient = SDS2.y1[offseti] - SDS2.y1[offseti+1];
+        // compute gradient
+        const auto gradient = SDS2.y1[offseti] - SDS2.y1[offseti+1];
 
         if (gradient == 0.0){
-	  REQUIRE(SDS2.y2[offset] == SDS2.y1[offseti]);
-	}
-	else if (gradient > 0.0){
-	  REQUIRE(SDS2.y2[offset] > SDS2.y1[offseti+1]);
-	  REQUIRE(SDS2.y2[offset] < SDS2.y1[offseti]);
-	}
-	else {
-	  REQUIRE(SDS2.y2[offset] < SDS2.y1[offseti+1]);
-	  REQUIRE(SDS2.y2[offset] > SDS2.y1[offseti]);
-	}
+          REQUIRE(SDS2.y2[offset] == SDS2.y1[offseti]);
+        }
+        else if (gradient > 0.0){
+          REQUIRE(SDS2.y2[offset] > SDS2.y1[offseti+1]);
+          REQUIRE(SDS2.y2[offset] < SDS2.y1[offseti]);
+        }
+        else {
+          REQUIRE(SDS2.y2[offset] < SDS2.y1[offseti+1]);
+          REQUIRE(SDS2.y2[offset] > SDS2.y1[offseti]);
+        }
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_mix_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_mix_length_tests.cpp
@@ -40,13 +40,13 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
     // Define the brunt vasailla frequency [s-1]
     static constexpr Real brunt_cons = 0.001;
     // Define the assymptoic length [m]
-    static constexpr Real l_inf = 100.0;
+    static constexpr Real l_inf = 100;
     // Define the overturning timescale [s]
-    static constexpr Real tscale = 300.0;
+    static constexpr Real tscale = 300;
     // Define the heights on the zt grid [m]
-    static constexpr Real zt_grid[nlev] = {5000.0, 3000.0, 2000.0, 1000.0, 500.0};
+    static constexpr Real zt_grid[nlev] = {5000, 3000, 2000, 1000, 500};
 
-    // Initialize data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCMixlengthData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
@@ -73,12 +73,12 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
 
     // Be sure that relevant variables are greater than zero
     for(Int s = 0; s < shcol; ++s) {
-      REQUIRE(SDS.l_inf[s] > 0.0);
-      REQUIRE(SDS.tscale[s] > 0.0);
+      REQUIRE(SDS.l_inf[s] > 0);
+      REQUIRE(SDS.tscale[s] > 0);
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
-	REQUIRE(SDS.tke[offset] > 0.0);
-	REQUIRE(SDS.zt_grid[offset] > 0.0);
+	REQUIRE(SDS.tke[offset] > 0);
+	REQUIRE(SDS.zt_grid[offset] > 0);
 	if (s < shcol-1){
           // Verify that tke is larger column by column
           const auto offsets = n + (s+1) * nlev;
@@ -89,7 +89,7 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
       // Check that zt increases upward
       for(Int n = 0; n < nlev - 1; ++n) {
 	const auto offset = n + s * nlev;
-	REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0.0);
+	REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
       }
     }
 
@@ -101,7 +101,7 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
 	// Validate shoc_mix greater than zero everywhere
-	REQUIRE(SDS.shoc_mix[offset] > 0.0);
+	REQUIRE(SDS.shoc_mix[offset] > 0);
 	if (s < shcol-1){
           // Verify that mixing length increases column by column
           const auto offsets = n + (s+1) * nlev;
@@ -112,7 +112,7 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
       // Check that mixing length increases upward
       for(Int n = 0; n < nlev - 1; ++n) {
 	const auto offset = n + s * nlev;
-	REQUIRE(SDS.shoc_mix[offset + 1] - SDS.shoc_mix[offset] < 0.0);
+	REQUIRE(SDS.shoc_mix[offset + 1] - SDS.shoc_mix[offset] < 0);
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_mix_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_mix_length_tests.cpp
@@ -59,13 +59,13 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
       SDS.l_inf[s] = l_inf;
       SDS.tscale[s] = tscale;
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	// for the subsequent columns, increase
-	//  the amount of TKE
-	SDS.tke[offset] = (1.0+s)*tke_cons;
-	SDS.brunt[offset] = brunt_cons;
-	SDS.zt_grid[offset] = zt_grid[n];
+        // for the subsequent columns, increase
+        //  the amount of TKE
+        SDS.tke[offset] = (1.0+s)*tke_cons;
+        SDS.brunt[offset] = brunt_cons;
+        SDS.zt_grid[offset] = zt_grid[n];
       }
     }
 
@@ -76,20 +76,20 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
       REQUIRE(SDS.l_inf[s] > 0);
       REQUIRE(SDS.tscale[s] > 0);
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	REQUIRE(SDS.tke[offset] > 0);
-	REQUIRE(SDS.zt_grid[offset] > 0);
-	if (s < shcol-1){
+        const auto offset = n + s * nlev;
+        REQUIRE(SDS.tke[offset] > 0);
+        REQUIRE(SDS.zt_grid[offset] > 0);
+        if (s < shcol-1){
           // Verify that tke is larger column by column
           const auto offsets = n + (s+1) * nlev;
           REQUIRE(SDS.tke[offset] < SDS.tke[offsets]);
-	}
+        }
       }
 
       // Check that zt increases upward
       for(Int n = 0; n < nlev - 1; ++n) {
-	const auto offset = n + s * nlev;
-	REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
+        const auto offset = n + s * nlev;
+        REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
       }
     }
 
@@ -99,20 +99,20 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
     // Check the results
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	// Validate shoc_mix greater than zero everywhere
-	REQUIRE(SDS.shoc_mix[offset] > 0);
-	if (s < shcol-1){
+        const auto offset = n + s * nlev;
+        // Validate shoc_mix greater than zero everywhere
+        REQUIRE(SDS.shoc_mix[offset] > 0);
+        if (s < shcol-1){
           // Verify that mixing length increases column by column
           const auto offsets = n + (s+1) * nlev;
           REQUIRE(SDS.shoc_mix[offset] < SDS.shoc_mix[offsets]);
-	}
+        }
       }
 
       // Check that mixing length increases upward
       for(Int n = 0; n < nlev - 1; ++n) {
-	const auto offset = n + s * nlev;
-	REQUIRE(SDS.shoc_mix[offset + 1] - SDS.shoc_mix[offset] < 0);
+        const auto offset = n + s * nlev;
+        REQUIRE(SDS.shoc_mix[offset + 1] - SDS.shoc_mix[offset] < 0);
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_omega_diag_third_moms_tests.cpp
@@ -27,59 +27,59 @@ struct UnitWrap::UnitTest<D>::TestOmegadiagThirdMoms {
 
     // Tests for the SHOC function:
     //   omega_terms_diag_third_shoc_moment
-  
+
     // TEST ONE
-    // Call the function twice, with two different sets of terms.  
-    //  In the second test the fterms should be larger.  Verify 
+    // Call the function twice, with two different sets of terms.
+    //  In the second test the fterms should be larger.  Verify
     //  that the omega0 and omega1 terms are the same, but that the
-    //  omega2 term has increased.  
-  
+    //  omega2 term has increased.
+
     // buoyancy term (isotropy squared * brunt vaisalla frequency)
     constexpr static Real buoy_sgs2 = -100;
     // f3 term
     constexpr static Real f3_test1a = 14;
     // f4 term
     constexpr static Real f4_test1a = 5;
-  
+
     // Initialize data structure for bridging to F90
     SHOCOmegadiagthirdmomsData SDS;
-    
+
     // Load up the data
     SDS.buoy_sgs2 = buoy_sgs2;
     SDS.f3 = f3_test1a;
     SDS.f4 = f4_test1a;
-    
-    // Call the fortran implementation    
-    omega_terms_diag_third_shoc_moment(SDS);    
-    
+
+    // Call the fortran implementation
+    omega_terms_diag_third_shoc_moment(SDS);
+
     // Save test results
     Real omega0_test1a = SDS.omega0;
     Real omega1_test1a = SDS.omega1;
     Real omega2_test1a = SDS.omega2;
-    
+
     // Now load up data for second part of test
     // Feed in LARGER values
     SDS.f3 = 2*f3_test1a;
-    SDS.f4 = 2*f4_test1a;    
-    
-    // Call the fortran implementation    
+    SDS.f4 = 2*f4_test1a;
+
+    // Call the fortran implementation
     omega_terms_diag_third_shoc_moment(SDS);
-    
+
     // Now check the result
-    
+
     // omega0 and omega1 should NOT have changed
     REQUIRE(SDS.omega0 == omega0_test1a);
     REQUIRE(SDS.omega1 == omega1_test1a);
-    
+
     // omega2 should have increased
-    REQUIRE(SDS.omega2 > omega2_test1a);    
-    
+    REQUIRE(SDS.omega2 > omega2_test1a);
+
   }
-  
+
   static void run_bfb()
   {
     // TODO
-  }  
+  }
 
 };
 
@@ -92,7 +92,7 @@ namespace{
 TEST_CASE("shoc_omega_diag_third_moms_property", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestOmegadiagThirdMoms;
-  
+
   TestStruct::run_property();
 }
 

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_compute_buoyflux_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_compute_buoyflux_tests.cpp
@@ -42,6 +42,9 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompBuoyFlux {
     // Define the input pressure [Pa]
     static constexpr Real pval = 85000;
 
+    // Define reasonable bounds to check output [K m/s]
+    static constexpr Real wthv_sec_bound = 10;
+
     // Initialize data structure for bridging to F90
     SHOCPDFcompbuoyfluxData SDS;
 
@@ -103,6 +106,7 @@ struct UnitWrap::UnitTest<D>::TestShocPdfCompBuoyFlux {
     //  the liquid water flux
     REQUIRE(SDS.wthv_sec > SDS.wthlsec);
     REQUIRE(SDS.wthv_sec > SDS.wqls);
+    REQUIRE(std::abs(SDS.wthv_sec) < wthv_sec_bound);
   }
 
   static void run_bfb()

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_compute_qs_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_compute_qs_tests.cpp
@@ -32,11 +32,11 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeQs {
     //  the two gaussians are the same, verify that outputs are the same
 
     // Define temperature of Gaussian 1 [K]
-    static constexpr Real Tl1_1_eq = 290.0;
+    static constexpr Real Tl1_1_eq = 290;
     // Define temperature of Gaussian 2 [K]
     static constexpr Real Tl1_2_eq = Tl1_1_eq;
     // Define pressure value [Pa]
-    static constexpr Real pval_eq = 85000.0;
+    static constexpr Real pval_eq = 85000;
 
     // Initialize data structure for bridging to F90
     SHOCPDFcompqsData SDS;
@@ -61,7 +61,7 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeQs {
     // Pressure test.  Use the data from the last test and modify
     //  the pressure level to be lower and verify that qs1 is lower.
 
-    static constexpr Real pval_high = 100000.0;
+    static constexpr Real pval_high = 100000;
 
     // Save the result from last test
     Real qs1_test1 = SDS.qs1;

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_computetemp_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_computetemp_tests.cpp
@@ -44,6 +44,10 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeTemp {
     // Decrease base pres by a certain amount each test
     static constexpr Real presincr = -10000;
 
+    // Define reasonable bounds for checking
+    static constexpr Real Tl_lower_bound = 150;
+    static constexpr Real Tl_upper_bound = 350;
+
     Real Tl1_save;
 
     // Initialize data structure for bridging to F90
@@ -71,6 +75,10 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeTemp {
       shoc_assumed_pdf_compute_temperature(SDS);
 
       // Check the result
+      // Make sure temperature falls within reasonable bound
+      REQUIRE(SDS.Tl1 < Tl_upper_bound);
+      REQUIRE(SDS.Tl1 > Tl_lower_bound);
+
       // If pressure is greater than basepressure then
       //  make sure that temperature is greater than thetal
       if (SDS.pval > SDS.basepres){

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_qw_parameters_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_qw_parameters_tests.cpp
@@ -33,15 +33,15 @@ struct UnitWrap::UnitTest<D>::TestShocQwParameters {
     // gaussians is also larger
 
     // Define the flux of total water [kg/kg m/s] small value
-    static constexpr Real wqwsec_small = 0.0001;
+    static constexpr Real wqwsec_small = 1e-4;
     // Define the flux of total water [kg/kg m/s] large value
-    static constexpr Real wqwsec_large = 0.0005;
+    static constexpr Real wqwsec_large = 5e-4;
     // Define the standard deviation of vertical velocity [m/s]
     static constexpr Real sqrtw2_test1 = 0.5;
     // Define the variance of total water [kg^2/kg^2]
     static constexpr Real qwsec_test1 = 1e-4;
     // Define grid mean total water [kg/kg]
-    static constexpr Real qw_first_test1 = 0.015;
+    static constexpr Real qw_first_test1 = 1.5e-2;
     // Define first gaussian vertical velocity [m/s]
     static constexpr Real w1_1_test1 = 1.5;
     // Define second gaussian vertical velocity [m/s]
@@ -53,6 +53,11 @@ struct UnitWrap::UnitTest<D>::TestShocQwParameters {
 
     // conversion factor from kg/kg to g/kg
     static constexpr Real qvconv=1000;
+
+    // Define reasonable bounds checking for output
+    static constexpr Real qw_bound_low = 1e-3; // [kg/kg]
+    static constexpr Real qw_bound_high = 5e-2; // [kg/kg]
+    static constexpr Real qw2_bound_high = 1e-2; // [kg^2/kg^2]
 
     // Be sure this value is actually larger
     REQUIRE(wqwsec_large > wqwsec_small);
@@ -109,6 +114,14 @@ struct UnitWrap::UnitTest<D>::TestShocQwParameters {
 
     // Now check the result
     REQUIRE(qwgaus_diff_result2 > qwgaus_diff_result1);
+
+    // Make sure output is within reasonable bounds
+    REQUIRE( (SDS.qw1_1 > qw_bound_low && SDS.qw1_2 > qw_bound_low) );
+    REQUIRE( (SDS.qw1_1 < qw_bound_high && SDS.qw1_2 < qw_bound_high) );
+    REQUIRE( (SDS.qw2_1 > 0 && SDS.qw2_2 > 0) );
+    REQUIRE( (SDS.qw2_2 < qw2_bound_high && SDS.qw2_2 < qw2_bound_high) );
+    REQUIRE( (SDS.sqrtqw2_1 > 0 && SDS.sqrtqw2_2 > 0) );
+    REQUIRE( (SDS.sqrtqw2_1 < std::sqrt(qw2_bound_high) && SDS.sqrtqw2_2 < std::sqrt(qw2_bound_high)) );
 
     // TEST TWO
     // Run the test two times given idential inputs, except one test

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_thl_parameters_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_thl_parameters_tests.cpp
@@ -53,6 +53,11 @@ struct UnitWrap::UnitTest<D>::TestShocThlParameters {
     // Define logical
     static constexpr bool dothetal_skew = false;
 
+    // Define reasonable bounds checking for output
+    static constexpr Real thl_bound_low = 200; // [K]
+    static constexpr Real thl_bound_high = 400; // [K]
+    static constexpr Real thl2_bound_high = 50; // [K^2]
+
     // Be sure this value is actually larger
     REQUIRE(thlsec_large > thlsec_small);
 
@@ -115,6 +120,14 @@ struct UnitWrap::UnitTest<D>::TestShocThlParameters {
     // Now check the result
     REQUIRE(thl2_1_result2 > thl2_1_result1);
     REQUIRE(thl2_2_result2 > thl2_2_result1);
+
+    // Make sure output is within reasonable bounds
+    REQUIRE( (SDS.thl1_1 > thl_bound_low && SDS.thl1_2 > thl_bound_low) );
+    REQUIRE( (SDS.thl1_1 < thl_bound_high && SDS.thl1_2 < thl_bound_high) );
+    REQUIRE( (SDS.thl2_1 > 0 && SDS.thl2_2 > 0) );
+    REQUIRE( (SDS.thl2_2 < thl2_bound_high && SDS.thl2_2 < thl2_bound_high) );
+    REQUIRE( (SDS.sqrtthl2_1 > 0 && SDS.sqrtthl2_2 > 0) );
+    REQUIRE( (SDS.sqrtthl2_1 < std::sqrt(thl2_bound_high) && SDS.sqrtthl2_2 < std::sqrt(thl2_bound_high)) );
 
     // TEST TWO
     // For a case with identical input except wthlsec, verify that

--- a/components/scream/src/physics/shoc/tests/shoc_tke_adv_sgs_tke_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_adv_sgs_tke_tests.cpp
@@ -71,25 +71,25 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.shoc_mix[offset] = shoc_mix_gr[s];
-	SDS.wthv_sec[offset] = wthv_sec_gr[s];
-	SDS.sterm_zt[offset] = sterm_gr[s];
-	SDS.tke[offset] = tke_init_gr[s];
+        SDS.shoc_mix[offset] = shoc_mix_gr[s];
+        SDS.wthv_sec[offset] = wthv_sec_gr[s];
+        SDS.sterm_zt[offset] = sterm_gr[s];
+        SDS.tke[offset] = tke_init_gr[s];
       }
     }
 
     // Check that the inputs make sense
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	// time step, mixing length, TKE values,
-	// shear terms should all be greater than zero
-	REQUIRE(SDS.dtime > 0);
-	REQUIRE(SDS.shoc_mix[offset] > 0);
-	REQUIRE(SDS.tke[offset] > 0);
-	REQUIRE(SDS.sterm_zt[offset] >= 0);
+        const auto offset = n + s * nlev;
+        // time step, mixing length, TKE values,
+        // shear terms should all be greater than zero
+        REQUIRE(SDS.dtime > 0);
+        REQUIRE(SDS.shoc_mix[offset] > 0);
+        REQUIRE(SDS.tke[offset] > 0);
+        REQUIRE(SDS.sterm_zt[offset] >= 0);
       }
     }
 
@@ -100,22 +100,22 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
     //  TKE growth
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	// Require output to fall within reasonable bounds
-	REQUIRE(SDS.tke[offset] >= mintke);
-	REQUIRE(SDS.tke[offset] <= maxtke);
-	REQUIRE(SDS.a_diss[offset] <= adiss_upper_bound);
-	REQUIRE(SDS.a_diss[offset] >= 0);
+        // Require output to fall within reasonable bounds
+        REQUIRE(SDS.tke[offset] >= mintke);
+        REQUIRE(SDS.tke[offset] <= maxtke);
+        REQUIRE(SDS.a_diss[offset] <= adiss_upper_bound);
+        REQUIRE(SDS.a_diss[offset] >= 0);
 
-	if (s == 0){
+        if (s == 0){
           // Growth check
           REQUIRE(SDS.tke[offset] > tke_init_gr[s]);
-	}
-	else{
+        }
+        else{
           // Decay check
           REQUIRE(SDS.tke[offset] < tke_init_gr[s]);
-	}
+        }
       }
     }
 
@@ -136,25 +136,25 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.shoc_mix[offset] = shoc_mix_diss[s];
-	SDS.wthv_sec[offset] = wthv_sec_diss;
-	SDS.sterm_zt[offset] = sterm_diss;
-	SDS.tke[offset] = tke_init_diss;
+        SDS.shoc_mix[offset] = shoc_mix_diss[s];
+        SDS.wthv_sec[offset] = wthv_sec_diss;
+        SDS.sterm_zt[offset] = sterm_diss;
+        SDS.tke[offset] = tke_init_diss;
       }
     }
 
     // Check that the inputs make sense
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	// time step, mixing length, TKE values,
-	// shear terms should all be greater than zero
-	REQUIRE(SDS.dtime > 0);
-	REQUIRE(SDS.shoc_mix[offset] > 0);
-	REQUIRE(SDS.tke[offset] > 0);
-	REQUIRE(SDS.sterm_zt[offset] >= 0);
+        const auto offset = n + s * nlev;
+        // time step, mixing length, TKE values,
+        // shear terms should all be greater than zero
+        REQUIRE(SDS.dtime > 0);
+        REQUIRE(SDS.shoc_mix[offset] > 0);
+        REQUIRE(SDS.tke[offset] > 0);
+        REQUIRE(SDS.sterm_zt[offset] >= 0);
       }
     }
 
@@ -168,7 +168,7 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
     // Require output to fall within reasonable bounds
     for (Int s = 0; s < shcol; ++s){
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
         REQUIRE(SDS.a_diss[offset] <= adiss_upper_bound);
         REQUIRE(SDS.a_diss[offset] >= 0);
       }
@@ -176,15 +176,15 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
 
     for(Int s = 0; s < shcol-1; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * nlev;
-	if(SDS.shoc_mix[offset] > SDS.shoc_mix[offsets]){
+        const auto offset = n + s * nlev;
+        // Get value corresponding to next column
+        const auto offsets = n + (s+1) * nlev;
+        if(SDS.shoc_mix[offset] > SDS.shoc_mix[offsets]){
           REQUIRE(SDS.a_diss[offset] < SDS.a_diss[offsets]);
-	}
-	else {
+        }
+        else {
           REQUIRE(SDS.a_diss[offset] > SDS.a_diss[offsets]);
-	}
+        }
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
@@ -54,23 +54,23 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.dz_zt[offset] = dz_zt[n];
-	SDS.pres[offset] = pres[n];
-	SDS.brunt[offset] = brunt_sym[n];
+        SDS.dz_zt[offset] = dz_zt[n];
+        SDS.pres[offset] = pres[n];
+        SDS.brunt[offset] = brunt_sym[n];
       }
     }
 
     // Check that the inputs make sense
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	// Should be greater than zero
-	REQUIRE(SDS.dz_zt[offset] > 0);
-	// Make sure all pressure levels are in the
-	//  lower troposphere for this test
-	REQUIRE(SDS.pres[offset] > 80000);
+        const auto offset = n + s * nlev;
+        // Should be greater than zero
+        REQUIRE(SDS.dz_zt[offset] > 0);
+        // Make sure all pressure levels are in the
+        //  lower troposphere for this test
+        REQUIRE(SDS.pres[offset] > 80000);
       }
     }
 
@@ -93,16 +93,16 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	SDS.brunt[offset] = brunt_neg[n];
+        const auto offset = n + s * nlev;
+        SDS.brunt[offset] = brunt_neg[n];
       }
     }
 
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	// All points should be less than zero
-	REQUIRE(SDS.brunt[offset] < 0);
+        const auto offset = n + s * nlev;
+        // All points should be less than zero
+        REQUIRE(SDS.brunt[offset] < 0);
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
@@ -38,18 +38,13 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
 
     // Define height thickness on nlev grid [m]
     //   Do a uniform grid for symetric test
-    static constexpr Real dz_zt[nlev] = {30., 30., 30., 30., 30.};
-    // Define Pressure [hPa] (later convereted to Pa)
-    Real pres[nlev] = {850., 900., 925.0, 950.0, 1000.0};
+    static constexpr Real dz_zt[nlev] = {30, 30, 30, 30, 30};
+    // Define Pressure [Pa]
+    Real pres[nlev] = {850e2, 900e2, 925e2, 950e2, 1000e2};
     // Brunt Vaisalla frequency [/s]
     static constexpr Real brunt_sym[nlev] = {-0.5, -0.25, 0.0, 0.25, 0.5};
 
-    // Convert pres to Pa
-    for (Int n = 0; n < nlev; ++n){
-      pres[n] = pres[n]*100.0;
-    }
-
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCColstabData SDS(shcol, nlev);
 
     // Test that the inputs are reasonable.
@@ -72,10 +67,10 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 	// Should be greater than zero
-	REQUIRE(SDS.dz_zt[offset] > 0.0);
+	REQUIRE(SDS.dz_zt[offset] > 0);
 	// Make sure all pressure levels are in the
 	//  lower troposphere for this test
-	REQUIRE(SDS.pres[offset] > 80000.0);
+	REQUIRE(SDS.pres[offset] > 80000);
       }
     }
 
@@ -85,7 +80,7 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
     // Check test
     //  Verify that output is zero
     for(Int s = 0; s < shcol; ++s) {
-      REQUIRE(SDS.brunt_int[s] == 0.0);
+      REQUIRE(SDS.brunt_int[s] == 0);
     }
 
     // SECOND TEST
@@ -107,7 +102,7 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 	// All points should be less than zero
-	REQUIRE(SDS.brunt[offset] < 0.0);
+	REQUIRE(SDS.brunt[offset] < 0);
       }
     }
 
@@ -117,7 +112,7 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
     // Check test
     //  Verify that output is negative
     for(Int s = 0; s < shcol; ++s) {
-      REQUIRE(SDS.brunt_int[s] < 0.0);
+      REQUIRE(SDS.brunt_int[s] < 0);
     }
   }
 

--- a/components/scream/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
@@ -24,6 +24,7 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
 
   static void run_property()
   {
+    static constexpr Real maxiso = scream::shoc::Constants<Real>::maxiso;
     static constexpr Int shcol    = 2;
     static constexpr Int nlev     = 1;
 
@@ -47,7 +48,7 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
     // Dissipation rate [m2/s3]
     static constexpr Real diss_st = 0.1;
     // Brunt Vaisalla frequency [/s]
-    static constexpr Real brunt_st[shcol] = {-0.004, 0.004};
+    static constexpr Real brunt_st[shcol] = {-4e-3, 4e-3};
 
     // Initialzie data structure for bridgeing to F90
     SHOCIsotropicData SDS(shcol, nlev);
@@ -74,13 +75,22 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 	// Should be greater than zero
-	REQUIRE(SDS.tke[offset] > 0.0);
-	REQUIRE(SDS.a_diss[offset] > 0.0);
+	REQUIRE(SDS.tke[offset] > 0);
+	REQUIRE(SDS.a_diss[offset] > 0);
       }
     }
 
     // Call the fortran implementation
     isotropic_ts(SDS);
+
+    // Check that output falls within reasonable bounds
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
+        REQUIRE(SDS.isotropy[offset] <= maxiso);
+	REQUIRE(SDS.isotropy[offset] >= 0);
+      }
+    }
 
     // Check to make sure that column with positive
     //  brunt vaisalla frequency is smaller
@@ -89,7 +99,7 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
 	const auto offset = n + s * nlev;
 	// Get value corresponding to next column
 	const auto offsets = n + (s+1) * nlev;
-	if(SDS.brunt[offset] < 0.0 & SDS.brunt[offsets] > 0.0){
+	if(SDS.brunt[offset] < 0 & SDS.brunt[offsets] > 0){
           REQUIRE(SDS.isotropy[offset] > SDS.isotropy[offsets]);
 	}
 	else{
@@ -110,7 +120,7 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
     // Dissipation rate [m2/s3]
     static constexpr Real diss_diss[shcol] = {0.1, 0.2};
     // Brunt Vaisalla frequency [/s]
-    static constexpr Real brunt_diss = 0.004;
+    static constexpr Real brunt_diss = 4e-3;
 
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
@@ -129,13 +139,22 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 	// Should be greater than zero
-	REQUIRE(SDS.tke[offset] > 0.0);
-	REQUIRE(SDS.a_diss[offset] > 0.0);
+	REQUIRE(SDS.tke[offset] > 0);
+	REQUIRE(SDS.a_diss[offset] > 0);
       }
     }
 
     // Call the fortran implementation
     isotropic_ts(SDS);
+
+    // Check that output falls within reasonable bounds
+    for(Int s = 0; s < shcol; ++s) {
+      for(Int n = 0; n < nlev; ++n) {
+	const auto offset = n + s * nlev;
+        REQUIRE(SDS.isotropy[offset] <= maxiso);
+	REQUIRE(SDS.isotropy[offset] >= 0);
+      }
+    }
 
     // Check to make sure that column with positive
     //  brunt vaisalla frequency is smaller

--- a/components/scream/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
@@ -62,21 +62,21 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
       // Column only input
       SDS.brunt_int[s] = brunt_int_st;
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.tke[offset] = tke_st;
-	SDS.a_diss[offset] = diss_st;
-	SDS.brunt[offset] = brunt_st[s];
+        SDS.tke[offset] = tke_st;
+        SDS.a_diss[offset] = diss_st;
+        SDS.brunt[offset] = brunt_st[s];
       }
     }
 
     // Check that the inputs make sense
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	// Should be greater than zero
-	REQUIRE(SDS.tke[offset] > 0);
-	REQUIRE(SDS.a_diss[offset] > 0);
+        const auto offset = n + s * nlev;
+        // Should be greater than zero
+        REQUIRE(SDS.tke[offset] > 0);
+        REQUIRE(SDS.a_diss[offset] > 0);
       }
     }
 
@@ -86,9 +86,9 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
     // Check that output falls within reasonable bounds
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
         REQUIRE(SDS.isotropy[offset] <= maxiso);
-	REQUIRE(SDS.isotropy[offset] >= 0);
+        REQUIRE(SDS.isotropy[offset] >= 0);
       }
     }
 
@@ -96,15 +96,15 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
     //  brunt vaisalla frequency is smaller
     for(Int s = 0; s < shcol-1; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * nlev;
-	if(SDS.brunt[offset] < 0 & SDS.brunt[offsets] > 0){
+        const auto offset = n + s * nlev;
+        // Get value corresponding to next column
+        const auto offsets = n + (s+1) * nlev;
+        if(SDS.brunt[offset] < 0 & SDS.brunt[offsets] > 0){
           REQUIRE(SDS.isotropy[offset] > SDS.isotropy[offsets]);
-	}
-	else{
+        }
+        else{
           REQUIRE(SDS.isotropy[offset] < SDS.isotropy[offsets]);
-	}
+        }
       }
     }
 
@@ -126,21 +126,21 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
     for(Int s = 0; s < shcol; ++s) {
       SDS.brunt_int[s] = brunt_int_diss;
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.tke[offset] = tke_diss;
-	SDS.a_diss[offset] = diss_diss[s];
-	SDS.brunt[offset] = brunt_diss;
+        SDS.tke[offset] = tke_diss;
+        SDS.a_diss[offset] = diss_diss[s];
+        SDS.brunt[offset] = brunt_diss;
       }
     }
 
     // Check that the inputs make sense
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	// Should be greater than zero
-	REQUIRE(SDS.tke[offset] > 0);
-	REQUIRE(SDS.a_diss[offset] > 0);
+        const auto offset = n + s * nlev;
+        // Should be greater than zero
+        REQUIRE(SDS.tke[offset] > 0);
+        REQUIRE(SDS.a_diss[offset] > 0);
       }
     }
 
@@ -150,9 +150,9 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
     // Check that output falls within reasonable bounds
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
         REQUIRE(SDS.isotropy[offset] <= maxiso);
-	REQUIRE(SDS.isotropy[offset] >= 0);
+        REQUIRE(SDS.isotropy[offset] >= 0);
       }
     }
 
@@ -160,15 +160,15 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
     //  brunt vaisalla frequency is smaller
     for(Int s = 0; s < shcol-1; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	// Get value corresponding to next column
-	const auto offsets = n + (s+1) * nlev;
-	if(SDS.a_diss[offset] < SDS.a_diss[offsets]){
+        const auto offset = n + s * nlev;
+        // Get value corresponding to next column
+        const auto offsets = n + (s+1) * nlev;
+        if(SDS.a_diss[offset] < SDS.a_diss[offsets]){
           REQUIRE(SDS.isotropy[offset] > SDS.isotropy[offsets]);
-	}
-	else{
+        }
+        else{
           REQUIRE(SDS.isotropy[offset] < SDS.isotropy[offsets]);
-	}
+        }
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
@@ -43,14 +43,17 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
     // Define height thickness on nlevi grid [m]
     //   NOTE: First indicee is zero because it is never used
     //   Do a stretched grid
-    static constexpr Real dz_zi[nlevi] = {0.0, 500., 200., 100., 50., 10.};
+    static constexpr Real dz_zi[nlevi] = {0, 500, 200, 100, 50, 10};
     // Define zonal wind on nlev grid [m/s]
-    static constexpr Real u_wind_shr[nlev] = {2.0, 1.0, 0.0, -1.0, -2.0};
+    static constexpr Real u_wind_shr[nlev] = {2, 1, 0, -1, -2};
     // Define meridional wind on nlev grid [m/s]
-    static constexpr Real v_wind_shr[nlev] = {1.0, 2.0, 3.0, 4.0, 5.0};
+    static constexpr Real v_wind_shr[nlev] = {1, 2, 3, 4, 5};
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCTkeshearData SDS(shcol, nlev, nlevi);
+
+    // Define upper limit for reasonable bounds checking
+    static constexpr Real sterm_upper_bound = 1e-2;
 
     // Test that the inputs are reasonable.
     REQUIRE( (SDS.shcol() == shcol && SDS.nlev() == nlev && SDS.nlevi() == nlevi) );
@@ -80,11 +83,11 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
 	const auto offset = n + s * nlevi;
 	// Make sure top level dz_zi value is zero
 	if (n == 0){
-          REQUIRE(SDS.dz_zi[offset] == 0.0);
+          REQUIRE(SDS.dz_zi[offset] == 0);
 	}
 	// Otherwise, should be greater than zero
 	else{
-          REQUIRE(SDS.dz_zi[offset] > 0.0);
+          REQUIRE(SDS.dz_zi[offset] > 0);
 	}
       }
     }
@@ -99,12 +102,14 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
       //  for boundary points.
       for(Int n = 0; n < nlevi; ++n) {
 	const auto offset = n + s * nlevi;
+	// Make sure output falls within reasonable bound
+	REQUIRE(SDS.sterm[offset] < sterm_upper_bound);
 	if (n == 0 || n == nlevi-1){
           // Boundary point check
-          REQUIRE(SDS.sterm[offset] == 0.0);
+          REQUIRE(SDS.sterm[offset] == 0);
 	}
 	else{
-          REQUIRE(SDS.sterm[offset] > 0.0);
+          REQUIRE(SDS.sterm[offset] > 0);
 	}
       }
       // Now validate that shear term is ALWAYS
@@ -112,7 +117,7 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
       //  in mind to exclude boundary points, which should be zero
       for(Int n = 1; n < nlevi-2; ++n){
 	const auto offset = n + s * nlevi;
-	REQUIRE(SDS.sterm[offset]-SDS.sterm[offset+1] < 0.0);
+	REQUIRE(SDS.sterm[offset]-SDS.sterm[offset+1] < 0);
       }
     }
 
@@ -122,17 +127,17 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
     // term is zero everywhere.
 
     // Define zonal wind on nlev grid [m/s]
-    static constexpr Real u_wind_cons[nlev] = {10.0, 10.0, 10.0, 10.0, 10.0};
+    static constexpr Real u_wind_cons = 10;
     // Define meridional wind on nlev grid [m/s]
-    static constexpr Real v_wind_cons[nlev] = {-5.0, -5.0, -5.0, -5.0, -5.0};
+    static constexpr Real v_wind_cons = -5;
 
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
 
-	SDS.u_wind[offset] = u_wind_cons[n];
-	SDS.v_wind[offset] = v_wind_cons[n];
+	SDS.u_wind[offset] = u_wind_cons;
+	SDS.v_wind[offset] = v_wind_cons;
       }
     }
 
@@ -144,7 +149,7 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlevi; ++n) {
 	const auto offset = n + s * nlevi;
-	REQUIRE(SDS.sterm[offset] == 0.0);
+	REQUIRE(SDS.sterm[offset] == 0);
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
@@ -63,16 +63,16 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.u_wind[offset] = u_wind_shr[n];
-	SDS.v_wind[offset] = v_wind_shr[n];
+        SDS.u_wind[offset] = u_wind_shr[n];
+        SDS.v_wind[offset] = v_wind_shr[n];
       }
 
       // Fill in test data on zi_grid.
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset   = n + s * nlevi;
-	SDS.dz_zi[offset] = dz_zi[n];
+        const auto offset   = n + s * nlevi;
+        SDS.dz_zi[offset] = dz_zi[n];
       }
     }
 
@@ -80,15 +80,15 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
 
     for(Int s = 0; s < shcol; ++s) {
       for (Int n = 0; n < nlevi; ++n){
-	const auto offset = n + s * nlevi;
-	// Make sure top level dz_zi value is zero
-	if (n == 0){
+        const auto offset = n + s * nlevi;
+        // Make sure top level dz_zi value is zero
+        if (n == 0){
           REQUIRE(SDS.dz_zi[offset] == 0);
-	}
-	// Otherwise, should be greater than zero
-	else{
+        }
+        // Otherwise, should be greater than zero
+        else{
           REQUIRE(SDS.dz_zi[offset] > 0);
-	}
+        }
       }
     }
 
@@ -101,23 +101,23 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
       //  zero for non boundary points, but exactly zero
       //  for boundary points.
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset = n + s * nlevi;
-	// Make sure output falls within reasonable bound
-	REQUIRE(SDS.sterm[offset] < sterm_upper_bound);
-	if (n == 0 || n == nlevi-1){
+        const auto offset = n + s * nlevi;
+        // Make sure output falls within reasonable bound
+        REQUIRE(SDS.sterm[offset] < sterm_upper_bound);
+        if (n == 0 || n == nlevi-1){
           // Boundary point check
           REQUIRE(SDS.sterm[offset] == 0);
-	}
-	else{
+        }
+        else{
           REQUIRE(SDS.sterm[offset] > 0);
-	}
+        }
       }
       // Now validate that shear term is ALWAYS
       //  decreasing with height for these inputs, keeping
       //  in mind to exclude boundary points, which should be zero
       for(Int n = 1; n < nlevi-2; ++n){
-	const auto offset = n + s * nlevi;
-	REQUIRE(SDS.sterm[offset]-SDS.sterm[offset+1] < 0);
+        const auto offset = n + s * nlevi;
+        REQUIRE(SDS.sterm[offset]-SDS.sterm[offset+1] < 0);
       }
     }
 
@@ -134,10 +134,10 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.u_wind[offset] = u_wind_cons;
-	SDS.v_wind[offset] = v_wind_cons;
+        SDS.u_wind[offset] = u_wind_cons;
+        SDS.v_wind[offset] = v_wind_cons;
       }
     }
 
@@ -148,8 +148,8 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
     // Verify that shear term is zero everywhere
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset = n + s * nlevi;
-	REQUIRE(SDS.sterm[offset] == 0);
+        const auto offset = n + s * nlevi;
+        REQUIRE(SDS.sterm[offset] == 0);
       }
     }
   }

--- a/components/scream/src/physics/shoc/tests/shoc_tke_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_tests.cpp
@@ -24,6 +24,9 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
 
   static void run_property()
   {
+    static constexpr Real mintke = scream::shoc::Constants<Real>::mintke;
+    static constexpr Real maxtke = scream::shoc::Constants<Real>::maxtke;
+    static constexpr Real maxiso = scream::shoc::Constants<Real>::maxiso;
     static constexpr Int shcol    = 2;
     static constexpr Int nlev     = 5;
     static constexpr auto nlevi   = nlev + 1;
@@ -31,13 +34,13 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
     // Tests for the subroutine shoc_tke.  This is the top
     //  level function for the TKE module in SHOC.  Thus since
     //  all associated functions here contain property tests, the
-    //  purpose here is mostly to expose whether errors have been 
-    //  made in the input/output fields in these routines  
+    //  purpose here is mostly to expose whether errors have been
+    //  made in the input/output fields in these routines
 
     // TEST ONE
-    // For this test we will perform a TKE growth test.  
+    // For this test we will perform a TKE growth test.
     //  Will provide inputs that should always encourage TKE to
-    //  grow at each level.  
+    //  grow at each level.
 
     // Define height thickness on nlevi grid [m]
     //   NOTE: First indicee is zero because it is never used
@@ -53,8 +56,8 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
     Real u_wind[nlev] = {2, 1, 0, -1, -2};
     // Define meridional wind on nlev grid [m/s]
     Real v_wind[nlev] = {1, 2, 3, 4, 5};
-    // Define Obukov length [m] 
-    Real obklen = -1; 
+    // Define Obukov length [m]
+    Real obklen = -1;
     // Define thickness on the interface grid [m]
     Real dz_zi[nlevi] = {0, 100, 100, 100, 100, 50};
     // Define thickness on the thermo grid [m]
@@ -64,7 +67,7 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
     // Define the interface height grid [m]
     Real zi_grid[nlevi] = {500, 400, 300, 200, 100, 0};
     // Define PBL height [m]
-    Real pblh = 1000; 
+    Real pblh = 1000;
     // Define pressure [Pa]
     Real pres[nlev] = {85000, 87500, 90000, 95000, 100000};
     // Define brunt Vaisalla frequency
@@ -81,7 +84,7 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
       tk[n] = tkh[n];
     }
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialize data structure for bridging to F90
     SHOCTkeData SDS(shcol, nlev, nlevi, dtime);
 
     // Test that the inputs are reasonable.
@@ -124,30 +127,30 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
 	const auto offset = n + s * nlevi;
 	// Make sure top level dz_zi value is zero
 	if (n == 0){
-          REQUIRE(SDS.dz_zi[offset] == 0.0);
-	} 
+          REQUIRE(SDS.dz_zi[offset] == 0);
+	}
 	// Otherwise, should be greater than zero
 	else{
-          REQUIRE(SDS.dz_zi[offset] > 0.0);
+          REQUIRE(SDS.dz_zi[offset] > 0);
 	}
 	// Check that zi increases updward
 	if (n < nlevi-1){
-	  REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0.0);
+	  REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0);
 	}
       }
-      // nlev loop 
+      // nlev loop
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 	// Check that zt increases upward
 	if (n < nlev-1){
-	  REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0.0);
+	  REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
 	}
-	REQUIRE(SDS.dz_zt[offset] > 0.0);
-	REQUIRE(SDS.shoc_mix[offset] > 0.0);
-	REQUIRE(SDS.tke[offset] > 0.0);
-	REQUIRE(SDS.tkh[offset] > 0.0);
-	REQUIRE(SDS.tk[offset] > 0.0);
-	REQUIRE(SDS.pres[offset] > 0.0);
+	REQUIRE(SDS.dz_zt[offset] > 0);
+	REQUIRE(SDS.shoc_mix[offset] > 0);
+	REQUIRE(SDS.tke[offset] >= mintke);
+	REQUIRE(SDS.tkh[offset] > 0);
+	REQUIRE(SDS.tk[offset] > 0);
+	REQUIRE(SDS.pres[offset] > 0);
       }
     }
 
@@ -155,10 +158,10 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
     shoc_tke(SDS);
 
     // Check test
-    // Make sure that TKE has increased everwhere relative 
-    //   to initial value.  Also make sure that outputs fall 
+    // Make sure that TKE has increased everwhere relative
+    //   to initial value.  Also make sure that outputs fall
     //   within some reasonable bounds.
-    
+
     // Make array to save the result of TKE
     Real tke_test1[nlev*shcol];
 
@@ -166,25 +169,26 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
 	REQUIRE(SDS.tke[offset] > tke_init[n]);
-	REQUIRE(SDS.tke[offset] > 0.0);
-	REQUIRE(SDS.tke[offset] <= 50.0);
-	REQUIRE(SDS.tkh[offset] > 0.0);
-	REQUIRE(SDS.tk[offset] > 0.0);
-	REQUIRE(SDS.isotropy[offset] > 0.0); 
+	REQUIRE(SDS.tke[offset] >= mintke);
+	REQUIRE(SDS.tke[offset] <= maxtke);
+	REQUIRE(SDS.tkh[offset] > 0);
+	REQUIRE(SDS.tk[offset] > 0);
+	REQUIRE(SDS.isotropy[offset] >= 0);
+	REQUIRE(SDS.isotropy[offset] <= maxiso);
 	tke_test1[offset] = SDS.tke[offset];
       }
     }
-    
+
     // TEST TWO
-    // Decay test.  Now starting with the TKE from TEST ONE in 
-    // its spun up state, feed inputs that should always make 
-    // TKE decay.  
-    
+    // Decay test.  Now starting with the TKE from TEST ONE in
+    // its spun up state, feed inputs that should always make
+    // TKE decay.
+
     // New inputs below, all others are recycled
-    
+
     // characteristics of new input are negative buoyancy flux,
     //  small length scale, and a uniform wind profile.
-    
+
     // Buoyancy flux [K m/s]
     Real wthv_sec_decay[nlev] = {-0.05, -0.04, -0.03, -0.02, -0.03};
     // Length Scale [m]
@@ -193,28 +197,28 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
     Real u_wind_decay[nlev] = {1, 1, 1, 1, 1};
     // Define meridional wind on nlev grid [m/s]
     Real v_wind_decay[nlev] = {-2, -2, -2, -2, -2};
-    
+
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
-	
+
 	SDS.wthv_sec[offset] = wthv_sec_decay[n];
 	SDS.shoc_mix[offset] = shoc_mix_decay[n];
 	SDS.u_wind[offset] = u_wind_decay[n];
 	SDS.v_wind[offset] = v_wind_decay[n];
-	
+
       }
-    }    
+    }
 
     for(Int s = 0; s < shcol; ++s) {
-      // nlev loop 
+      // nlev loop
       for (Int n = 0; n < nlev; ++n){
 	const auto offset = n + s * nlev;
 	// be sure wind has no gradient
 	if (n < nlev-1){
-	  REQUIRE(SDS.u_wind[offset + 1] - SDS.u_wind[offset] == 0.0);
-	  REQUIRE(SDS.v_wind[offset + 1] - SDS.v_wind[offset] == 0.0);
+	  REQUIRE(SDS.u_wind[offset + 1] - SDS.u_wind[offset] == 0);
+	  REQUIRE(SDS.v_wind[offset + 1] - SDS.v_wind[offset] == 0);
 	}
 	// Be sure that buoyancy flux is less than zero
 	REQUIRE(SDS.wthv_sec[offset] < 0);
@@ -222,31 +226,32 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
 	REQUIRE(SDS.shoc_mix[offset] <= 100);
       }
     }
-    
+
     // Call the fortran implementation
-    shoc_tke(SDS);  
-    
+    shoc_tke(SDS);
+
     // Check the result
-    
+
     // Verify ALL outputs are reasonable and that TKE has decayed
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
 	const auto offset = n + s * nlev;
 	REQUIRE(SDS.tke[offset] < tke_test1[offset]);
-	REQUIRE(SDS.tke[offset] > 0.0);
-	REQUIRE(SDS.tke[offset] <= 50.0);
-	REQUIRE(SDS.tkh[offset] > 0.0);
-	REQUIRE(SDS.tk[offset] > 0.0);
-	REQUIRE(SDS.isotropy[offset] > 0.0); 
+	REQUIRE(SDS.tke[offset] >= mintke);
+	REQUIRE(SDS.tke[offset] <= maxtke);
+	REQUIRE(SDS.tkh[offset] > 0);
+	REQUIRE(SDS.tk[offset] > 0);
+	REQUIRE(SDS.isotropy[offset] >= 0);
+	REQUIRE(SDS.isotropy[offset] <= maxiso);
       }
-    }    
+    }
 
   }
-  
+
   static void run_bfb()
   {
     // TODO
-  }   
+  }
 
 };
 

--- a/components/scream/src/physics/shoc/tests/shoc_tke_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_tests.cpp
@@ -97,25 +97,25 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
       SDS.pblh[s] = pblh;
       SDS.obklen[s] = obklen;
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.wthv_sec[offset] = wthv_sec[n];
-	SDS.shoc_mix[offset] = shoc_mix[n];
-	SDS.u_wind[offset] = u_wind[n];
-	SDS.v_wind[offset] = v_wind[n];
-	SDS.dz_zt[offset] = dz_zt[n];
-	SDS.zt_grid[offset] = zt_grid[n];
-	SDS.pres[offset] = pres[n];
-	SDS.tke[offset] = tke_init[n];
-	SDS.tkh[offset] = tkh[n];
-	SDS.tk[offset] = tk[n];
+        SDS.wthv_sec[offset] = wthv_sec[n];
+        SDS.shoc_mix[offset] = shoc_mix[n];
+        SDS.u_wind[offset] = u_wind[n];
+        SDS.v_wind[offset] = v_wind[n];
+        SDS.dz_zt[offset] = dz_zt[n];
+        SDS.zt_grid[offset] = zt_grid[n];
+        SDS.pres[offset] = pres[n];
+        SDS.tke[offset] = tke_init[n];
+        SDS.tkh[offset] = tkh[n];
+        SDS.tk[offset] = tk[n];
       }
 
       // Fill in test data on zi_grid.
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset   = n + s * nlevi;
-	SDS.dz_zi[offset] = dz_zi[n];
-	SDS.zi_grid[offset] = zi_grid[n];
+        const auto offset   = n + s * nlevi;
+        SDS.dz_zi[offset] = dz_zi[n];
+        SDS.zi_grid[offset] = zi_grid[n];
       }
     }
 
@@ -124,33 +124,33 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
     for(Int s = 0; s < shcol; ++s) {
       // nlevi loop
       for (Int n = 0; n < nlevi; ++n){
-	const auto offset = n + s * nlevi;
-	// Make sure top level dz_zi value is zero
-	if (n == 0){
+        const auto offset = n + s * nlevi;
+        // Make sure top level dz_zi value is zero
+        if (n == 0){
           REQUIRE(SDS.dz_zi[offset] == 0);
-	}
-	// Otherwise, should be greater than zero
-	else{
+        }
+        // Otherwise, should be greater than zero
+        else{
           REQUIRE(SDS.dz_zi[offset] > 0);
-	}
-	// Check that zi increases updward
-	if (n < nlevi-1){
-	  REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0);
-	}
+        }
+        // Check that zi increases updward
+        if (n < nlevi-1){
+          REQUIRE(SDS.zi_grid[offset + 1] - SDS.zi_grid[offset] < 0);
+        }
       }
       // nlev loop
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	// Check that zt increases upward
-	if (n < nlev-1){
-	  REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
-	}
-	REQUIRE(SDS.dz_zt[offset] > 0);
-	REQUIRE(SDS.shoc_mix[offset] > 0);
-	REQUIRE(SDS.tke[offset] >= mintke);
-	REQUIRE(SDS.tkh[offset] > 0);
-	REQUIRE(SDS.tk[offset] > 0);
-	REQUIRE(SDS.pres[offset] > 0);
+        const auto offset = n + s * nlev;
+        // Check that zt increases upward
+        if (n < nlev-1){
+          REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
+        }
+        REQUIRE(SDS.dz_zt[offset] > 0);
+        REQUIRE(SDS.shoc_mix[offset] > 0);
+        REQUIRE(SDS.tke[offset] >= mintke);
+        REQUIRE(SDS.tkh[offset] > 0);
+        REQUIRE(SDS.tk[offset] > 0);
+        REQUIRE(SDS.pres[offset] > 0);
       }
     }
 
@@ -167,15 +167,15 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
 
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	REQUIRE(SDS.tke[offset] > tke_init[n]);
-	REQUIRE(SDS.tke[offset] >= mintke);
-	REQUIRE(SDS.tke[offset] <= maxtke);
-	REQUIRE(SDS.tkh[offset] > 0);
-	REQUIRE(SDS.tk[offset] > 0);
-	REQUIRE(SDS.isotropy[offset] >= 0);
-	REQUIRE(SDS.isotropy[offset] <= maxiso);
-	tke_test1[offset] = SDS.tke[offset];
+        const auto offset = n + s * nlev;
+        REQUIRE(SDS.tke[offset] > tke_init[n]);
+        REQUIRE(SDS.tke[offset] >= mintke);
+        REQUIRE(SDS.tke[offset] <= maxtke);
+        REQUIRE(SDS.tkh[offset] > 0);
+        REQUIRE(SDS.tk[offset] > 0);
+        REQUIRE(SDS.isotropy[offset] >= 0);
+        REQUIRE(SDS.isotropy[offset] <= maxiso);
+        tke_test1[offset] = SDS.tke[offset];
       }
     }
 
@@ -201,12 +201,12 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
     // Fill in test data on zt_grid.
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.wthv_sec[offset] = wthv_sec_decay[n];
-	SDS.shoc_mix[offset] = shoc_mix_decay[n];
-	SDS.u_wind[offset] = u_wind_decay[n];
-	SDS.v_wind[offset] = v_wind_decay[n];
+        SDS.wthv_sec[offset] = wthv_sec_decay[n];
+        SDS.shoc_mix[offset] = shoc_mix_decay[n];
+        SDS.u_wind[offset] = u_wind_decay[n];
+        SDS.v_wind[offset] = v_wind_decay[n];
 
       }
     }
@@ -214,16 +214,16 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
     for(Int s = 0; s < shcol; ++s) {
       // nlev loop
       for (Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	// be sure wind has no gradient
-	if (n < nlev-1){
-	  REQUIRE(SDS.u_wind[offset + 1] - SDS.u_wind[offset] == 0);
-	  REQUIRE(SDS.v_wind[offset + 1] - SDS.v_wind[offset] == 0);
-	}
-	// Be sure that buoyancy flux is less than zero
-	REQUIRE(SDS.wthv_sec[offset] < 0);
-	// Be sure length scale is reasonably small
-	REQUIRE(SDS.shoc_mix[offset] <= 100);
+        const auto offset = n + s * nlev;
+        // be sure wind has no gradient
+        if (n < nlev-1){
+          REQUIRE(SDS.u_wind[offset + 1] - SDS.u_wind[offset] == 0);
+          REQUIRE(SDS.v_wind[offset + 1] - SDS.v_wind[offset] == 0);
+        }
+        // Be sure that buoyancy flux is less than zero
+        REQUIRE(SDS.wthv_sec[offset] < 0);
+        // Be sure length scale is reasonably small
+        REQUIRE(SDS.shoc_mix[offset] <= 100);
       }
     }
 
@@ -235,14 +235,14 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
     // Verify ALL outputs are reasonable and that TKE has decayed
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
-	REQUIRE(SDS.tke[offset] < tke_test1[offset]);
-	REQUIRE(SDS.tke[offset] >= mintke);
-	REQUIRE(SDS.tke[offset] <= maxtke);
-	REQUIRE(SDS.tkh[offset] > 0);
-	REQUIRE(SDS.tk[offset] > 0);
-	REQUIRE(SDS.isotropy[offset] >= 0);
-	REQUIRE(SDS.isotropy[offset] <= maxiso);
+        const auto offset = n + s * nlev;
+        REQUIRE(SDS.tke[offset] < tke_test1[offset]);
+        REQUIRE(SDS.tke[offset] >= mintke);
+        REQUIRE(SDS.tke[offset] <= maxtke);
+        REQUIRE(SDS.tkh[offset] > 0);
+        REQUIRE(SDS.tk[offset] > 0);
+        REQUIRE(SDS.isotropy[offset] >= 0);
+        REQUIRE(SDS.isotropy[offset] <= maxiso);
       }
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
@@ -30,6 +30,9 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     static constexpr Int nlev     = 4;
     static constexpr auto nlevi   = nlev + 1;
 
+    // Property test for SHOC subroutine
+    //  calc_shoc_varorcovar
+
     //NOTE: This routine does not compute the (co)variance
     // for boundary points.  Input Grid values that are never used
     // are set to ZERO so as not to confuse the test data
@@ -38,10 +41,6 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     // Output values at boundary set to something other than
     // zero to check that they are not modified.
 
-    //IN: tunefac, isotropy_zi, tkh_zi, dz_zi,
-    //IN: invar1, invar2
-    //OUT: varorcovar
-
     //********************************************
     // TEST ONE
     // Verify the variance calculation is valid
@@ -49,21 +48,21 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     // Define data.  Some of this is recycled for tests two and three.
 
     // Define delta z on the nlevi grid [m]
-    static constexpr Real dz_zi[nlevi] = {0.0, 100.0, 50.0, 20.0, 0.0};
+    static constexpr Real dz_zi[nlevi] = {0, 100, 50, 20, 0};
     // Eddy coefficients on the nlevi grid [m2s-1]
-    static constexpr Real tkh_zi[nlevi] = {0.0, 10.0, 10.0, 10.0, 0.0};
+    static constexpr Real tkh_zi[nlevi] = {0, 10, 10, 10, 0};
     // Return to isotropy timescale [s]
-    static constexpr Real isotropy_zi[nlevi] = {0.0, 100.0, 100.0, 100.0, 0.0};
+    static constexpr Real isotropy_zi[nlevi] = {0.0, 100, 100, 100, 0};
     // Invar (in this example we use potential temperature) [K]
     //   this variable should be on the nlev grid
-    static constexpr Real invar_theta[nlev] = {320.0, 315.0, 315.0, 316.0};
+    static constexpr Real invar_theta[nlev] = {320, 315, 315, 316};
     // Initialize (co)variance on the nlevi grid, set boundaries
     //   to large values to make sure they are not modified
-    Real varorcovar[nlevi] = {100., 0., 0., 0., 100.};
+    Real varorcovar[nlevi] = {100, 0, 0, 0, 100};
     // Tuning factor
-    static constexpr Real tunefac=1.0;
+    static constexpr Real tunefac=1;
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialzie data structure for bridging to F90
     SHOCVarorcovarData SDS(shcol, nlev, nlevi, tunefac);
 
     // Test that the inputs are reasonable.
@@ -97,16 +96,16 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
 
     // Check that the inputs make sense
 
-    REQUIRE(SDS.tunefac > 0.0);
+    REQUIRE(SDS.tunefac > 0);
     // Check to make sure that dz_zi, tkh_zi, and isotropy_zi
     //  (outside of the boundaries) are greater than zero
     for(Int s = 0; s < shcol; ++s) {
       // do NOT check boundaries!
       for(Int n = 1; n < nlevi-1; ++n) {
 	const auto offset = n + s * nlevi;
-	REQUIRE(SDS.dz_zi[offset] > 0.0);
-	REQUIRE(SDS.tkh_zi[offset] > 0.0);
-	REQUIRE(SDS.isotropy_zi[offset] > 0.0);
+	REQUIRE(SDS.dz_zi[offset] > 0);
+	REQUIRE(SDS.tkh_zi[offset] > 0);
+	REQUIRE(SDS.isotropy_zi[offset] > 0);
       }
       // For this test make sure that invar1 = invar2
       for(Int n = 0; n < nlev; ++n){
@@ -125,18 +124,18 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
 
 	// validate that the boundary points have NOT been modified
 	if (n == 0 || n == nlevi){
-          REQUIRE(SDS.varorcovar[offset] == 100.0);
+          REQUIRE(SDS.varorcovar[offset] == 100);
 	}
 	else{
 
 	// Validate that all values are greater to
 	//   or equal to zero
 
-          REQUIRE(SDS.varorcovar[offset] >= 0.0);
+          REQUIRE(SDS.varorcovar[offset] >= 0);
 
           // well mixed layer test
-          if ((invar_theta[n-1] - invar_theta[n]) == 0.0){
-            REQUIRE(SDS.varorcovar[offset] == 0.0);
+          if ((invar_theta[n-1] - invar_theta[n]) == 0){
+            REQUIRE(SDS.varorcovar[offset] == 0);
           }
 	}
       }
@@ -147,15 +146,10 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     // Verify the Covariance calculation is valid
 
     // Now we check the covariance calculation
-    // Define an array to be total water [g/kg]
-    Real invar_qw[nlev] = {5.0, 10.0, 15.0, 20.0};
+    // Define an array to be total water [kg/kg]
+    Real invar_qw[nlev] = {5e-3, 10e-3, 15e-3, 20e-3};
 
     // NOTE: all other inputs are reused from test one
-
-    // convert total water to [kg/kg]
-    for (Int n = 0; n < nlev; ++n){
-      invar_qw[n] = invar_qw[n]/1000.;
-    }
 
     // Update invar2 to be total water
     for(Int s = 0; s < shcol; ++s) {
@@ -188,30 +182,30 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
 	// validate that the boundary points
 	//   have NOT been modified
 	if (n == 0 || n == nlevi){
-          REQUIRE(SDS.varorcovar[offset] == 100.);
+          REQUIRE(SDS.varorcovar[offset] == 100);
 	}
 	else{
 
           // well mixed layer test
-          if ((invar_theta[n-1] - invar_theta[n]) == 0.0 ||
-	      (invar_qw[n-1] - invar_qw[n]) == 0.0){
-            REQUIRE(SDS.varorcovar[offset] == 0.0);
+          if ((invar_theta[n-1] - invar_theta[n]) == 0 ||
+	      (invar_qw[n-1] - invar_qw[n]) == 0){
+            REQUIRE(SDS.varorcovar[offset] == 0);
           }
 
 	  // validate values are NEGATIVE if potential
 	  //  temperature INCREASES with height and total water
 	  //  DECREASES with height
-          if ((invar_theta[n-1] - invar_theta[n]) > 0.0 &&
-	      (invar_qw[n-1] - invar_qw[n]) < 0.0){
-            REQUIRE(SDS.varorcovar[offset] < 0.0);
+          if ((invar_theta[n-1] - invar_theta[n]) > 0 &&
+	      (invar_qw[n-1] - invar_qw[n]) < 0){
+            REQUIRE(SDS.varorcovar[offset] < 0);
           }
 
 	  // validate values are POSITIVE if both
 	  //   potential temperature and total water
 	  //   DECREASE with height
-          if ((invar_theta[n-1] - invar_theta[n]) < 0.0 &&
-	      (invar_qw[n-1] - invar_qw[n]) < 0.0){
-            REQUIRE(SDS.varorcovar[offset] > 0.0);
+          if ((invar_theta[n-1] - invar_theta[n]) < 0 &&
+	      (invar_qw[n-1] - invar_qw[n]) < 0){
+            REQUIRE(SDS.varorcovar[offset] > 0);
           }
 
 	}
@@ -227,7 +221,7 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     //  at a constant rate per GRID box.  Assign dz that INCREASES
     //  with height and check that varorcovar DECREASES with height
 
-    static constexpr Real invar_th2[nlev] = {320.0, 315.0, 310.0, 305.0};
+    static constexpr Real invar_th2[nlev] = {320, 315, 310, 305};
 
     // Update invar1 and invar2 to be identical
     for(Int s = 0; s < shcol; ++s) {
@@ -246,7 +240,7 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
       for(Int n = 1; n < nlevi-1; ++n) {
 	const auto offset = n + s * nlevi;
 	// Validate that values of dz_zi are INCREASING with height
-	REQUIRE(SDS.dz_zi[offset]-SDS.dz_zi[offset+1] > 0.0);
+	REQUIRE(SDS.dz_zi[offset]-SDS.dz_zi[offset+1] > 0);
       }
       // For this test make sure that invar1 = invar2
       for(Int n = 0; n < nlev; ++n){
@@ -265,7 +259,7 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
 
 	// Validate that values of varorcovar
 	//  are decreasing with height
-	REQUIRE(SDS.varorcovar[offset]-SDS.varorcovar[offset+1] < 0.0);
+	REQUIRE(SDS.varorcovar[offset]-SDS.varorcovar[offset+1] < 0);
 
       }
     }

--- a/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
@@ -74,23 +74,23 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     for(Int s = 0; s < shcol; ++s) {
       // First on the nlev grid
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	// Fill invar1 and invar2 with the SAME
-	//  variable for this case to test the
-	//  variance calculation of this function
-	SDS.invar1[offset] = invar_theta[n];
-	SDS.invar2[offset] = invar_theta[n];
+        // Fill invar1 and invar2 with the SAME
+        //  variable for this case to test the
+        //  variance calculation of this function
+        SDS.invar1[offset] = invar_theta[n];
+        SDS.invar2[offset] = invar_theta[n];
       }
 
       // Now for data on the nlevi grid
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
 
-	SDS.tkh_zi[offset] = tkh_zi[n];
-	SDS.isotropy_zi[offset] = isotropy_zi[n];
-	SDS.dz_zi[offset] = dz_zi[n];
-	SDS.varorcovar[offset] = varorcovar[n];
+        SDS.tkh_zi[offset] = tkh_zi[n];
+        SDS.isotropy_zi[offset] = isotropy_zi[n];
+        SDS.dz_zi[offset] = dz_zi[n];
+        SDS.varorcovar[offset] = varorcovar[n];
       }
     }
 
@@ -102,15 +102,15 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     for(Int s = 0; s < shcol; ++s) {
       // do NOT check boundaries!
       for(Int n = 1; n < nlevi-1; ++n) {
-	const auto offset = n + s * nlevi;
-	REQUIRE(SDS.dz_zi[offset] > 0);
-	REQUIRE(SDS.tkh_zi[offset] > 0);
-	REQUIRE(SDS.isotropy_zi[offset] > 0);
+        const auto offset = n + s * nlevi;
+        REQUIRE(SDS.dz_zi[offset] > 0);
+        REQUIRE(SDS.tkh_zi[offset] > 0);
+        REQUIRE(SDS.isotropy_zi[offset] > 0);
       }
       // For this test make sure that invar1 = invar2
       for(Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	REQUIRE(SDS.invar1[offset] == SDS.invar2[offset]);
+        const auto offset = n + s * nlev;
+        REQUIRE(SDS.invar1[offset] == SDS.invar2[offset]);
       }
     }
 
@@ -120,16 +120,16 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     // Check the results
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
 
-	// validate that the boundary points have NOT been modified
-	if (n == 0 || n == nlevi){
+        // validate that the boundary points have NOT been modified
+        if (n == 0 || n == nlevi){
           REQUIRE(SDS.varorcovar[offset] == 100);
-	}
-	else{
+        }
+        else{
 
-	// Validate that all values are greater to
-	//   or equal to zero
+        // Validate that all values are greater to
+        //   or equal to zero
 
           REQUIRE(SDS.varorcovar[offset] >= 0);
 
@@ -137,7 +137,7 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
           if ((invar_theta[n-1] - invar_theta[n]) == 0){
             REQUIRE(SDS.varorcovar[offset] == 0);
           }
-	}
+        }
       }
     }
 
@@ -155,9 +155,9 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     for(Int s = 0; s < shcol; ++s) {
       // First on the nlev grid
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	SDS.invar2[offset] = invar_qw[n];
+        SDS.invar2[offset] = invar_qw[n];
       }
     }
 
@@ -166,8 +166,8 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
       // For this test make sure that invar1 is NOT
       //  equal to invar2
       for(Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	REQUIRE(SDS.invar1[offset] != SDS.invar2[offset]);
+        const auto offset = n + s * nlev;
+        REQUIRE(SDS.invar1[offset] != SDS.invar2[offset]);
       }
     }
 
@@ -177,38 +177,38 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     // Check the results
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlevi; ++n) {
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
 
-	// validate that the boundary points
-	//   have NOT been modified
-	if (n == 0 || n == nlevi){
+        // validate that the boundary points
+        //   have NOT been modified
+        if (n == 0 || n == nlevi){
           REQUIRE(SDS.varorcovar[offset] == 100);
-	}
-	else{
+        }
+        else{
 
           // well mixed layer test
           if ((invar_theta[n-1] - invar_theta[n]) == 0 ||
-	      (invar_qw[n-1] - invar_qw[n]) == 0){
+              (invar_qw[n-1] - invar_qw[n]) == 0){
             REQUIRE(SDS.varorcovar[offset] == 0);
           }
 
-	  // validate values are NEGATIVE if potential
-	  //  temperature INCREASES with height and total water
-	  //  DECREASES with height
+          // validate values are NEGATIVE if potential
+          //  temperature INCREASES with height and total water
+          //  DECREASES with height
           if ((invar_theta[n-1] - invar_theta[n]) > 0 &&
-	      (invar_qw[n-1] - invar_qw[n]) < 0){
+              (invar_qw[n-1] - invar_qw[n]) < 0){
             REQUIRE(SDS.varorcovar[offset] < 0);
           }
 
-	  // validate values are POSITIVE if both
-	  //   potential temperature and total water
-	  //   DECREASE with height
+          // validate values are POSITIVE if both
+          //   potential temperature and total water
+          //   DECREASE with height
           if ((invar_theta[n-1] - invar_theta[n]) < 0 &&
-	      (invar_qw[n-1] - invar_qw[n]) < 0){
+              (invar_qw[n-1] - invar_qw[n]) < 0){
             REQUIRE(SDS.varorcovar[offset] > 0);
           }
 
-	}
+        }
       }
     }
 
@@ -227,25 +227,25 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     for(Int s = 0; s < shcol; ++s) {
       // First on the nlev grid
       for(Int n = 0; n < nlev; ++n) {
-	const auto offset = n + s * nlev;
+        const auto offset = n + s * nlev;
 
-	// Set both inputs to the same value
-	SDS.invar1[offset] = invar_th2[n];
-	SDS.invar2[offset] = invar_th2[n];
+        // Set both inputs to the same value
+        SDS.invar1[offset] = invar_th2[n];
+        SDS.invar2[offset] = invar_th2[n];
       }
     }
 
     // Check the inputs
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 1; n < nlevi-1; ++n) {
-	const auto offset = n + s * nlevi;
-	// Validate that values of dz_zi are INCREASING with height
-	REQUIRE(SDS.dz_zi[offset]-SDS.dz_zi[offset+1] > 0);
+        const auto offset = n + s * nlevi;
+        // Validate that values of dz_zi are INCREASING with height
+        REQUIRE(SDS.dz_zi[offset]-SDS.dz_zi[offset+1] > 0);
       }
       // For this test make sure that invar1 = invar2
       for(Int n = 0; n < nlev; ++n){
-	const auto offset = n + s * nlev;
-	REQUIRE(SDS.invar1[offset] == SDS.invar2[offset]);
+        const auto offset = n + s * nlev;
+        REQUIRE(SDS.invar1[offset] == SDS.invar2[offset]);
       }
     }
 
@@ -255,11 +255,11 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
     // Check the results
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 1; n < nlev-1; ++n) {
-	const auto offset = n + s * nlevi;
+        const auto offset = n + s * nlevi;
 
-	// Validate that values of varorcovar
-	//  are decreasing with height
-	REQUIRE(SDS.varorcovar[offset]-SDS.varorcovar[offset+1] < 0);
+        // Validate that values of varorcovar
+        //  are decreasing with height
+        REQUIRE(SDS.varorcovar[offset]-SDS.varorcovar[offset+1] < 0);
 
       }
     }

--- a/components/scream/src/physics/shoc/tests/shoc_vertflux_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_vertflux_tests.cpp
@@ -28,6 +28,9 @@ struct UnitWrap::UnitTest<D>::TestCalcShocVertflux {
     static constexpr Int nlev     = 4;
     static constexpr auto nlevi   = nlev + 1;
 
+    // Propert tests for SHOC subroutine
+    //   calc_shoc_vertflux
+
     //NOTE: This routine does not compute the vertical fluxes
     // for boundary points.  Input Grid values that are never used
     // are set to ZERO so as not to confuse the test data
@@ -51,7 +54,7 @@ struct UnitWrap::UnitTest<D>::TestCalcShocVertflux {
     //   of 1) and unstable boundary layer, 2) well mixed
     //   layer and 3) conditionally stable layer.
 
-    // Initialzie data structure for bridgeing to F90
+    // Initialzie data structure for bridging to F90
     SHOCVertfluxData SDS(shcol, nlev, nlevi);
 
     // Test that the inputs are reasonable.

--- a/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
@@ -26,11 +26,11 @@ struct UnitWrap::UnitTest<D>::TestW3diagThirdMoms {
   {
 
     // Tests for the SHOC function:
-    //   w3_diag_third_shoc_moment 
-    
+    //   w3_diag_third_shoc_moment
+
     // TEST ONE
     // Do series of tests to make sure output is as expected
-  
+
     // aa0 term
     constexpr static Real aa0_test1 = -0.2;
     // aa1 term
@@ -38,9 +38,9 @@ struct UnitWrap::UnitTest<D>::TestW3diagThirdMoms {
     // x0 term
     constexpr static Real x0_test1 = -4.31;
     // y0 term
-    constexpr static Real x1_test1 = 41.05;    
+    constexpr static Real x1_test1 = 41.05;
     // f5 term
-    constexpr static Real f5_test1 = 4;        
+    constexpr static Real f5_test1 = 4;
 
     // Initialize data structure for bridging to F90
     SHOCW3diagthirdmomsData SDS;
@@ -51,58 +51,57 @@ struct UnitWrap::UnitTest<D>::TestW3diagThirdMoms {
     SDS.x0 = x0_test1;
     SDS.x1 = x1_test1;
     SDS.f5 = f5_test1;
-      
-    // Call the fortran implementation    
-    w3_diag_third_shoc_moment(SDS);      
+
+    // Call the fortran implementation
+    w3_diag_third_shoc_moment(SDS);
 
     // Verify result is negative
     REQUIRE(SDS.w3 < 0);
- 
+
     // save output
     Real w3_test1 = SDS.w3;
 
     // TEST TWO
     // Modify parameters to decrease w3
     // decrease this term
-    constexpr static Real aa1_test2 = 2.65;    
-    
+    constexpr static Real aa1_test2 = 2.65;
+
     SDS.aa1 = aa1_test2;
-    
-    // Call the fortran implementation    
-    w3_diag_third_shoc_moment(SDS);      
-     
+
+    // Call the fortran implementation
+    w3_diag_third_shoc_moment(SDS);
+
     // Verify result has decreased
     REQUIRE(SDS.w3 < SDS.aa1);
-    
+
     // Save result
     Real w3_test2 = SDS.w3;
-    
+
     // TEST THREE
     // Modify parameters to get positive result
     // x0 term
     constexpr static Real x0_test3 = -4.31;
     // y0 term
-    constexpr static Real x1_test3 = -41.05;    
+    constexpr static Real x1_test3 = -41.05;
     // f5 term
     constexpr static Real f5_test3 = -4;
-    
+
     SDS.x0 = x0_test3;
     SDS.x1 = x1_test3;
-    SDS.f5 = f5_test3; 
-    
-    // Call the fortran implementation    
+    SDS.f5 = f5_test3;
+
+    // Call the fortran implementation
     w3_diag_third_shoc_moment(SDS);
-    
+
     // Verify the result is positive
-    REQUIRE(SDS.w3 > 0);       
-    
-    
+    REQUIRE(SDS.w3 > 0);
+
   }
-  
+
   static void run_bfb()
   {
     // TODO
-  }  
+  }
 
 };
 
@@ -115,7 +114,7 @@ namespace{
 TEST_CASE("shoc_w3_diag_third_moms_property", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestW3diagThirdMoms;
-  
+
   TestStruct::run_property();
 }
 

--- a/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_xy_diag_third_moms_tests.cpp
@@ -27,13 +27,13 @@ struct UnitWrap::UnitTest<D>::TestXYdiagThirdMoms {
 
     // Tests for the SHOC function:
     //   x_y_terms_diag_third_shoc_moment
-  
+
     // TEST ONE
-    // Call the function twice, with two different sets of terms.  
-    //  In the second test the fterms should be larger.  Verify 
+    // Call the function twice, with two different sets of terms.
+    //  In the second test the fterms should be larger.  Verify
     //  that the x0 and y0 terms are the same, but that the
-    //  x1 and y1 terms have increased. 
-    
+    //  x1 and y1 terms have increased.
+
     // buoyancy term (isotropy squared * brunt vaisalla frequency)
     constexpr static Real buoy_sgs2 = -100;
     // f0 term
@@ -41,51 +41,51 @@ struct UnitWrap::UnitTest<D>::TestXYdiagThirdMoms {
     // f3 term
     constexpr static Real f1_test1a = 8500;
     // f4 term
-    constexpr static Real f2_test1a = 30;    
+    constexpr static Real f2_test1a = 30;
 
     // Initialize data structure for bridging to F90
     SHOCXYdiagthirdmomsData SDS;
-    
+
     // Load up the data
     SDS.buoy_sgs2 = buoy_sgs2;
     SDS.f0 = f0_test1a;
     SDS.f1 = f1_test1a;
-    SDS.f2 = f2_test1a;    
-    
-    // Call the fortran implementation    
+    SDS.f2 = f2_test1a;
+
+    // Call the fortran implementation
     x_y_terms_diag_third_shoc_moment(SDS);
-    
+
     // Save test results
     Real x0_test1a = SDS.x0;
     Real y0_test1a = SDS.y0;
-    Real x1_test1a = SDS.x1; 
+    Real x1_test1a = SDS.x1;
     Real y1_test1a = SDS.y1;
-    
+
     // Now load up data for second part of test
     // Feed in LARGER values
     SDS.f0 = 1.2*f0_test1a;
     SDS.f1 = 1.2*f1_test1a;
-    SDS.f2 = 1.2*f2_test1a;         
+    SDS.f2 = 1.2*f2_test1a;
 
-    // Call the fortran implementation    
+    // Call the fortran implementation
     x_y_terms_diag_third_shoc_moment(SDS);
-    
+
     // Now check the result
-    
+
     // x0 and y0 terms should NOT have changed
     REQUIRE(SDS.x0 == x0_test1a);
-    REQUIRE(SDS.y0 == y0_test1a);  
-    
+    REQUIRE(SDS.y0 == y0_test1a);
+
     // x1 and y1 terms should have increased
     REQUIRE(SDS.x1 > x1_test1a);
-    REQUIRE(SDS.y1 > y1_test1a);      
-    
+    REQUIRE(SDS.y1 > y1_test1a);
+
   }
-  
+
   static void run_bfb()
   {
     // TODO
-  }  
+  }
 
 };
 
@@ -98,7 +98,7 @@ namespace{
 TEST_CASE("shoc_xy_diag_third_moms_property", "shoc")
 {
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestXYdiagThirdMoms;
-  
+
   TestStruct::run_property();
 }
 


### PR DESCRIPTION
This PR:

1) Cleans up the trailing white space mess I made.
2) Adds in more rigorous reasonable bounds checking to some tests.
3) Add in more SHOC constants to be used by the tests for said bounds checking.
4) Fixes various misspellings and typ@s.
5) Removes unit conversions when input data is defined (just define in SI units).
6) Untabify all SHOC property test files.