### PR TITLE
perf-analysis update for scream

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -1108,7 +1108,11 @@ contains
        diag_eff_radius_qi,rho_qi,do_predict_nc, &
        dpres,exner,qv2qi_depos_tend,precip_total_tend,nevapr,qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,  &
        p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
-       vap_ice_exchange,qv_prev,t_prev,col_location)
+       vap_ice_exchange,qv_prev,t_prev,col_location &
+#ifdef SCREAM_CONFIG_IS_CMAKE
+       , elapsed_s &
+#endif
+)
 
     !----------------------------------------------------------------------------------------!
     !                                                                                        !
@@ -1185,6 +1189,10 @@ contains
     real(rtype), intent(in),    dimension(its:ite,3)            :: col_location
     real(rtype), intent(in),    dimension(its:ite,kts:kte)      :: inv_qc_relvar
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    real(rtype), intent(out) :: elapsed_s ! duration of main loop in seconds
+#endif
+
     !
     !----- Local variables and parameters:  -------------------------------------------------!
     !
@@ -1231,6 +1239,10 @@ contains
     logical(btype), parameter :: debug_ABORT  = .false.  !.true. will result in forced abort in s/r 'check_values'
 
     real(rtype),dimension(its:ite,kts:kte) :: qc_old, nc_old, qr_old, nr_old, qi_old, ni_old, qv_old, th_atm_old
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    integer :: clock_count1, clock_count_rate, clock_count_max, clock_count2, clock_count_diff
+#endif
 
     !-----------------------------------------------------------------------------------!
     !  End of variables/parameters declarations
@@ -1302,6 +1314,10 @@ contains
     ni_old = ni   ! Ice  # microphysics tendency, initialize
     qv_old = qv         ! Vapor  microphysics tendency, initialize
     th_atm_old = th_atm         ! Pot. Temp. microphysics tendency, initialize
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    call system_clock(clock_count1, clock_count_rate, clock_count_max)
+#endif
 
     !==
     !-----------------------------------------------------------------------------------!
@@ -1437,6 +1453,12 @@ contains
        !.....................................................
 
     enddo i_loop_main
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    call system_clock(clock_count2, clock_count_rate, clock_count_max)
+    clock_count_diff = clock_count2 - clock_count1
+    elapsed_s = real(clock_count_diff) / real(clock_count_rate)
+#endif
 
     !PMC deleted "if WRF" stuff
     !PMC deleted typeDiags optional output stuff

--- a/components/scream/scripts/perf-analysis
+++ b/components/scream/scripts/perf-analysis
@@ -23,13 +23,13 @@ OR
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run p3 ref with 1 horizontal and 111 vertical columns over 300s with 30s timesteps and 10 internal repitions \033[0m
-    > {0} ni:1 nk:111 dt:30 ts:10 kdir:1 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=micro-sed/p3_ref
+    > {0} ni:1 nk:111 dt:30 ts:10 kdir:1 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=ref:"micro-sed/p3_ref"
 
     \033[1;32m# Run p3 ref comparing against p3 vanilla with same params as above except scaling ni to 1024  \033[0m
-    > {0} ni:1 nk:111 dt:30 ts:10 kdir:1 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=micro-sed/p3_ref --test=micro-sed/p3_vanilla -s ni:2:1024
+    > {0} ni:1 nk:111 dt:30 ts:10 kdir:1 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=ref:"micro-sed/p3_ref" --test=vanilla:"micro-sed/p3_vanilla" -s ni:2:1024
 
     \033[1;32m# Run lin-interp ref comparing against lin-interp vanilla scaling from ncol=1000 to 128,000 \033[0m
-    > {0} ncol:1000 km1:128 km2:256 minthresh:0.001 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=lin-interp/li_ref --test=lin-interp/li_vanilla -s ncol:2:128000
+    > {0} ncol:1000 km1:128 km2:256 minthresh:0.001 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=ref:lin-interp/li_ref --test=vanilla:lin-interp/li_vanilla -s ncol:2:128000
 """.format(os.path.basename(args[0])),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -44,7 +44,7 @@ OR
     parser.add_argument("-n", "--num-runs", type=int, default=1, help="Number of times to repeat run")
 
     parser.add_argument("-t", "--test", dest="tests", action="append",
-                        help="Select which tests/exes to run. First one will be used as reference point")
+                        help="Select which tests/exes to run. First one will be used as reference point. Format is TESTNAME:CMD. Supports string replacement via using the arg name in all caps; any arg not replaced in this manner will have its value appended to the test cmd as an arg.")
 
     parser.add_argument("-c", "--cmake-options", default="",
                         help="Extra options to pass to cmake")
@@ -65,6 +65,12 @@ OR
     parser.add_argument("-d", "--scream-docs", action="store_true",
                         help="Measure something in the scream-docs repo instead of main repo")
 
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Increase verbosity")
+
+    parser.add_argument("--cd", action="store_true",
+                        help="Change directory to the dir containing the exe before running")
+
     args = parser.parse_args(args[1:])
 
     args.cmake_options += " -DCMAKE_BUILD_TYPE=Release"
@@ -79,7 +85,7 @@ OR
 
     argmap = OrderedDict()
     for argdef in args.argmap:
-        expect(argdef.count(":") == 1, "Arg definition '{}' had wrong format, expect NAME:VAL")
+        expect(argdef.count(":") == 1, "Arg definition '{}' had wrong format, expect NAME:VAL".format(argdef))
         argname, starting_val = argdef.split(":")
         argmap[argname] = float(starting_val) if "." in starting_val else int(starting_val)
 
@@ -90,11 +96,18 @@ OR
         expect(not (scaling_exp.varname == "threads" and args.force_threads is None),
                "Need to set --force-threads if doing a threading scaling experiment")
 
+    testmap = OrderedDict()
+    for argtest in args.tests:
+        expect(argtest.count(":") == 1, "test definition '{}' had wrong format, expect NAME:CMDS".format(argtest))
+        testname, testdef = argtest.split(":")
+        testmap[testname] = testdef
+
     delattr(args, "scaling")
     delattr(args, "kokkos")
     delattr(args, "cxx")
     args.scaling_exp = scaling_exp
     args.argmap = argmap
+    args.tests = testmap
     return args
 
 ###############################################################################

--- a/components/scream/scripts/perf-analysis
+++ b/components/scream/scripts/perf-analysis
@@ -80,6 +80,8 @@ OR
     if args.cxx:
         args.cmake_options += " -DCMAKE_CXX_COMPILER={}".format(args.cxx)
 
+    args.cmake_options += " -C ../cmake/machine-files/{}.cmake".format(args.machine)
+
     expect(not args.plot_friendly or args.scaling, "Doesn't make sense to have plot friendly output without a scaling experiment")
     expect(args.tests, "Need at least one test/exe")
 

--- a/components/scream/scripts/perf-analysis
+++ b/components/scream/scripts/perf-analysis
@@ -62,11 +62,15 @@ OR
 
     parser.add_argument("-m", "--machine", default=socket.gethostname().rstrip("0123456789"), help="Manually set machine. Defaults to hostname.")
 
+    parser.add_argument("-d", "--scream-docs", action="store_true",
+                        help="Measure something in the scream-docs repo instead of main repo")
+
     args = parser.parse_args(args[1:])
 
-    expect(args.kokkos, "--kokkos is currently required")
+    args.cmake_options += " -DCMAKE_BUILD_TYPE=Release"
+    if args.kokkos:
+        args.cmake_options += " -DKokkos_DIR={}".format(args.kokkos)
 
-    args.cmake_options += " -DCMAKE_BUILD_TYPE=Release -DKokkos_DIR={}".format(args.kokkos)
     if args.cxx:
         args.cmake_options += " -DCMAKE_CXX_COMPILER={}".format(args.cxx)
 

--- a/components/scream/scripts/perf_analysis.py
+++ b/components/scream/scripts/perf_analysis.py
@@ -159,7 +159,7 @@ class PerfAnalysis(object):
     def run_test(self, test_cmd):
     ###############################################################################
         if self._cd:
-            test_path, test_exe = os.path.split()
+            test_path, test_exe = os.path.split(test_cmd)
             test_path = None if not test_path else test_path
         else:
             test_exe = test_cmd

--- a/components/scream/scripts/perf_analysis.py
+++ b/components/scream/scripts/perf_analysis.py
@@ -69,7 +69,7 @@ class PerfAnalysis(object):
 ###############################################################################
 
     ###########################################################################
-    def __init__(self, argmap, force_threads, num_runs, tests, cmake_options, use_existing, scaling_exp, plot_friendly, machine, scream_docs):
+    def __init__(self, argmap, force_threads, num_runs, tests, cmake_options, use_existing, scaling_exp, plot_friendly, machine, scream_docs, verbose, cd):
     ###########################################################################
         self._argmap        = argmap
         self._force_threads = force_threads
@@ -81,12 +81,20 @@ class PerfAnalysis(object):
         self._plot_friendly = plot_friendly
         self._machine       = machine
         self._scream_docs   = scream_docs
+        self._verbose       = verbose
+        self._cd            = cd
 
     ###############################################################################
     def build(self):
     ###############################################################################
+        cmake_cmd = "cmake {} ..".format(self._cmake_options)
+
+        if self._verbose:
+            print("In dir {}, building with cmake command: {}\nOutput will be stored in build.perf.log".\
+                  format(os.getcwd(), cmake_cmd))
+
         with open("build.perf.log", "w") as fd:
-            cmake_cmd = "cmake {} ..".format(self._cmake_options)
+
             make_cmd  = "make -j8 VERBOSE=1"
             fd.write(cmake_cmd + "\n")
             fd.write(run_cmd_no_fail(cmake_cmd, combine_output=True) + "\n\n")
@@ -131,18 +139,42 @@ class PerfAnalysis(object):
         expect(False, "Failed to find threads in:\n\n{}".format(output))
 
     ###############################################################################
-    def run_test(self, exename):
+    def formulate_cmd(self, test_exe):
     ###############################################################################
-        self.machine_specific_init(self._scaling_exp.threads)
-        self.test_specific_init(exename, self._scaling_exp.threads)
         prefix = "" if "NUMA_PREFIX" not in os.environ else "{} ".format(os.environ["NUMA_PREFIX"])
-        cmd = "{}./{} {}".format(prefix, exename, " ".join([str(item) for item in self._scaling_exp.values(incl_threads=False)]))
+        replaced = []
+        for name, val in zip(self._argmap.keys(), self._scaling_exp.values(incl_threads=False)):
+            if name.upper() in test_exe:
+                test_exe.replace(name.upper(), val)
+                replaced.append(name)
+
+        for name, val in zip(self._argmap.keys(), self._scaling_exp.values(incl_threads=False)):
+            if name not in replaced:
+                test_exe += " {}".format(val)
+
+        cmd = "{}./{}".format(prefix, test_exe)
+        return cmd
+
+    ###############################################################################
+    def run_test(self, test_cmd):
+    ###############################################################################
+        if self._cd:
+            test_path, test_exe = os.path.split()
+            test_path = None if not test_path else test_path
+        else:
+            test_exe = test_cmd
+            test_path = None
+
+        self.machine_specific_init(self._scaling_exp.threads)
+        self.test_specific_init(test_exe, self._scaling_exp.threads)
+
+        cmd = self.formulate_cmd(test_exe)
         results = []
-        with open("{}.perf.log".format(exename), "w") as fd:
+        with open("{}.perf.log".format(test_exe), "w") as fd:
             fd.write(cmd + "\n\n")
             fd.write("ENV: \n{}\n\n".format(run_cmd_no_fail("env")))
             for _ in range(self._num_runs):
-                output = run_cmd_no_fail(cmd, verbose=not self._plot_friendly)
+                output = run_cmd_no_fail(cmd, from_dir=test_path, verbose=(not self._plot_friendly or self._verbose))
                 fd.write(output + "\n\n")
                 results.append(self.get_time(output))
 
@@ -186,8 +218,8 @@ class PerfAnalysis(object):
                 print("RUNNING {}".format(" ".join(["{}={}".format(name, val) for name, val in zip(self._argmap.keys(), self._scaling_exp.values(incl_threads=False))])))
 
             reference = None
-            for test in self._tests:
-                med_time, threads = self.run_test(test)
+            for test, test_cmd in self._tests.items():
+                med_time, threads = self.run_test(test_cmd)
                 self._scaling_exp.threads = threads
 
                 if self._plot_friendly:

--- a/components/scream/scripts/perf_analysis.py
+++ b/components/scream/scripts/perf_analysis.py
@@ -136,7 +136,10 @@ class PerfAnalysis(object):
                 threads = int(items[items.index("nthread") + 1])
                 return threads
 
-        expect(False, "Failed to find threads in:\n\n{}".format(output))
+        if "OMP_NUM_THREADS" in os.environ:
+            return int(os.environ["OMP_NUM_THREADS"])
+        else:
+            return 1
 
     ###############################################################################
     def formulate_cmd(self, test_exe):

--- a/components/scream/scripts/perf_analysis.py
+++ b/components/scream/scripts/perf_analysis.py
@@ -69,7 +69,7 @@ class PerfAnalysis(object):
 ###############################################################################
 
     ###########################################################################
-    def __init__(self, argmap, force_threads, num_runs, tests, cmake_options, use_existing, scaling_exp, plot_friendly, machine):
+    def __init__(self, argmap, force_threads, num_runs, tests, cmake_options, use_existing, scaling_exp, plot_friendly, machine, scream_docs):
     ###########################################################################
         self._argmap        = argmap
         self._force_threads = force_threads
@@ -80,6 +80,7 @@ class PerfAnalysis(object):
         self._scaling_exp   = scaling_exp
         self._plot_friendly = plot_friendly
         self._machine       = machine
+        self._scream_docs   = scream_docs
 
     ###############################################################################
     def build(self):
@@ -167,7 +168,8 @@ class PerfAnalysis(object):
                    "{} doesn't look like a build directory".format(os.getcwd()))
 
         else:
-            expect(os.path.basename(os.getcwd()) == "micro-apps", "Please run from micro-apps directory")
+            if self._scream_docs:
+                expect(os.path.basename(os.getcwd()) == "micro-apps", "Please run from micro-apps directory")
 
             tmpdir = tempfile.mkdtemp(prefix="build", dir=os.getcwd())
             os.chdir(tmpdir)

--- a/components/scream/scripts/perf_analysis.py
+++ b/components/scream/scripts/perf_analysis.py
@@ -145,7 +145,7 @@ class PerfAnalysis(object):
         replaced = []
         for name, val in zip(self._argmap.keys(), self._scaling_exp.values(incl_threads=False)):
             if name.upper() in test_exe:
-                test_exe.replace(name.upper(), val)
+                test_exe.replace(name.upper(), str(val))
                 replaced.append(name)
 
         for name, val in zip(self._argmap.keys(), self._scaling_exp.values(incl_threads=False)):

--- a/components/scream/scripts/perf_analysis.py
+++ b/components/scream/scripts/perf_analysis.py
@@ -95,7 +95,7 @@ class PerfAnalysis(object):
 
         with open("build.perf.log", "w") as fd:
 
-            make_cmd  = "make -j8 VERBOSE=1"
+            make_cmd  = "make -j16 VERBOSE=1"
             fd.write(cmake_cmd + "\n")
             fd.write(run_cmd_no_fail(cmake_cmd, combine_output=True) + "\n\n")
             fd.write(make_cmd + "\n")
@@ -145,7 +145,7 @@ class PerfAnalysis(object):
         replaced = []
         for name, val in zip(self._argmap.keys(), self._scaling_exp.values(incl_threads=False)):
             if name.upper() in test_exe:
-                test_exe.replace(name.upper(), str(val))
+                test_exe = test_exe.replace(name.upper(), str(val))
                 replaced.append(name)
 
         for name, val in zip(self._argmap.keys(), self._scaling_exp.values(incl_threads=False)):

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -129,8 +129,6 @@ void p3_init () {
 
 Int p3_main (const FortranData& d, bool use_fortran) {
   if (use_fortran) {
-    // There should be very little overhead on the fortran side, so we can do timings
-    // here.
     Real elapsed_s;
     p3_main_c(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(),
               d.th_atm.data(), d.qv.data(), d.dt, d.qi.data(),

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -23,7 +23,7 @@ extern "C" {
                  Real* precip_liq_flux, Real* precip_ice_flux, // 1 extra column size
                  Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, Real* mu_c, Real* lamc,
                  Real* liq_ice_exchange, Real* vap_liq_exchange,
-                 Real* vap_ice_exchange, Real* qv_prev, Real* t_prev);
+                 Real* vap_ice_exchange, Real* qv_prev, Real* t_prev, Real* elapsed_s);
 }
 
 namespace scream {
@@ -131,7 +131,7 @@ Int p3_main (const FortranData& d, bool use_fortran) {
   if (use_fortran) {
     // There should be very little overhead on the fortran side, so we can do timings
     // here.
-    auto start = std::chrono::steady_clock::now();
+    Real elapsed_s;
     p3_main_c(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(),
               d.th_atm.data(), d.qv.data(), d.dt, d.qi.data(),
               d.qm.data(), d.ni.data(), d.bm.data(),
@@ -143,10 +143,8 @@ Int p3_main (const FortranData& d, bool use_fortran) {
               d.precip_liq_flux.data(), d.precip_ice_flux.data(), d.cld_frac_r.data(), d.cld_frac_l.data(),
               d.cld_frac_i.data(), d.mu_c.data(), d.lamc.data(),
               d.liq_ice_exchange.data(),
-              d.vap_liq_exchange.data(),d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data());
-    auto finish = std::chrono::steady_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
-    return duration.count();
+              d.vap_liq_exchange.data(),d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data(), &elapsed_s);
+    return static_cast<Int>(elapsed_s * 1000000);
   }
   else {
     return p3_main_f(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(), d.th_atm.data(),

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -127,9 +127,11 @@ void p3_init () {
   }
 }
 
-void p3_main (const FortranData& d, bool use_fortran) {
+Int p3_main (const FortranData& d, bool use_fortran) {
   if (use_fortran) {
-    
+    // There should be very little overhead on the fortran side, so we can do timings
+    // here.
+    auto start = std::chrono::steady_clock::now();
     p3_main_c(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(),
               d.th_atm.data(), d.qv.data(), d.dt, d.qi.data(),
               d.qm.data(), d.ni.data(), d.bm.data(),
@@ -142,20 +144,22 @@ void p3_main (const FortranData& d, bool use_fortran) {
               d.cld_frac_i.data(), d.mu_c.data(), d.lamc.data(),
               d.liq_ice_exchange.data(),
               d.vap_liq_exchange.data(),d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data());
-    
+    auto finish = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
+    return duration.count();
   }
   else {
-    p3_main_f(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(), d.th_atm.data(),
-              d.qv.data(), d.dt, d.qi.data(), d.qm.data(), d.ni.data(),
-              d.bm.data(), d.pres.data(), d.dz.data(), d.nc_nuceat_tend.data(),
-              d.ni_activated.data(), d.inv_qc_relvar.data(), d.it, d.precip_liq_surf.data(),
-              d.precip_ice_surf.data(), 1, d.ncol, 1, d.nlev, d.diag_eff_radius_qc.data(),
-              d.diag_eff_radius_qi.data(), d.rho_qi.data(), d.do_predict_nc,
-              d.dpres.data(), d.exner.data(), d.qv2qi_depos_tend.data(), d.precip_total_tend.data(),
-              d.nevapr.data(), d.qr_evap_tend.data(), d.precip_liq_flux.data(), d.precip_ice_flux.data(),
-              d.cld_frac_r.data(), d.cld_frac_l.data(), d.cld_frac_i.data(), d.mu_c.data(),
-              d.lamc.data(), d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),
-              d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data() );
+    return p3_main_f(d.qc.data(), d.nc.data(), d.qr.data(), d.nr.data(), d.th_atm.data(),
+                     d.qv.data(), d.dt, d.qi.data(), d.qm.data(), d.ni.data(),
+                     d.bm.data(), d.pres.data(), d.dz.data(), d.nc_nuceat_tend.data(),
+                     d.ni_activated.data(), d.inv_qc_relvar.data(), d.it, d.precip_liq_surf.data(),
+                     d.precip_ice_surf.data(), 1, d.ncol, 1, d.nlev, d.diag_eff_radius_qc.data(),
+                     d.diag_eff_radius_qi.data(), d.rho_qi.data(), d.do_predict_nc,
+                     d.dpres.data(), d.exner.data(), d.qv2qi_depos_tend.data(), d.precip_total_tend.data(),
+                     d.nevapr.data(), d.qr_evap_tend.data(), d.precip_liq_flux.data(), d.precip_ice_flux.data(),
+                     d.cld_frac_r.data(), d.cld_frac_l.data(), d.cld_frac_i.data(), d.mu_c.data(),
+                     d.lamc.data(), d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),
+                     d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data() );
 
   }
 }

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -62,7 +62,9 @@ private:
 };
 
 void p3_init();
-void p3_main(const FortranData& d, bool use_fortran=false);
+
+// Returns number of microseconds of p3_main execution
+Int p3_main(const FortranData& d, bool use_fortran=false);
 
 // We will likely want to remove these checks in the future, as we're not tied
 // to the exact implementation or arithmetic in P3. For now, these checks are

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -947,7 +947,8 @@ struct Functions
     const uview_1d<Spack>& diag_equiv_reflectivity,
     const uview_1d<Spack>& diag_eff_radius_qc);
 
-  static void p3_main(
+  // Return microseconds elapsed
+  static Int p3_main(
     const P3PrognosticState& prognostic_state,
     const P3DiagnosticInputs& diagnostic_inputs,
     const P3DiagnosticOutputs& diagnostic_outputs,

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -792,7 +792,7 @@ void p3_main_part3(P3MainPart3Data& d)
   p3_init();
   p3_main_part3_c(
     d.kts, d.kte, d.kbot, d.ktop, d.kdir,
-    d.exner, d.cld_frac_l, d.cld_frac_r, d.cld_frac_i, 
+    d.exner, d.cld_frac_l, d.cld_frac_r, d.cld_frac_i,
     d.rho, d.inv_rho, d.rhofaci, d.qv, d.th_atm, d.qc, d.nc, d.qr, d.nr, d.qi, d.ni, d.qm, d.bm, d.latent_heat_vapor, d.latent_heat_sublim,
     d.mu_c, d.nu, d.lamc, d.mu_r, d.lamr, d.vap_liq_exchange,
     d. ze_rain, d.ze_ice, d.diag_vm_qi, d.diag_eff_radius_qi, d.diag_diam_qi, d.rho_qi, d.diag_equiv_reflectivity, d.diag_eff_radius_qc);
@@ -1150,9 +1150,9 @@ void evaporate_rain_f(Real qr_incld_, Real qc_incld_, Real nr_incld_, Real qi_in
 	cld_frac_l(cld_frac_l_), cld_frac_r(cld_frac_r_), qv(qv_), qv_prev(qv_prev_), qv_sat_l(qv_sat_l_), qv_sat_i(qv_sat_i_),
         ab(ab_), abi(abi_), epsr(epsr_), epsi_tot(epsi_tot_), t(t_), t_prev(t_prev_), latent_heat_sublim(latent_heat_sublim_),
         dqsdt(dqsdt_);
-      
+
       typename P3F::Scalar dt(dt_);
-      
+
       typename P3F::Spack qr2qv_evap_tend(local_qr2qv_evap_tend), nr_evap_tend(local_nr_evap_tend);
 
       P3F::evaporate_rain(qr_incld,qc_incld,nr_incld,qi_incld,
@@ -2383,19 +2383,19 @@ void ice_cldliq_wet_growth_f(Real rho_, Real temp_, Real pres_, Real rhofaci_, R
   const auto t_h = Kokkos::create_mirror_view(t_d);
 
   const bool log_wetgrowth_local = *log_wetgrowth_;
-  Real local_qr2qi_collect_tend = *qr2qi_collect_tend_, local_qc2qi_collect_tend = *qc2qi_collect_tend_, local_qc_growth_rate = *qc_growth_rate_, 
+  Real local_qr2qi_collect_tend = *qr2qi_collect_tend_, local_qc2qi_collect_tend = *qc2qi_collect_tend_, local_qc_growth_rate = *qc_growth_rate_,
        local_nr_ice_shed_tend = *nr_ice_shed_tend_, local_qc2qr_ice_shed_tend = *qc2qr_ice_shed_tend_;
 
   Kokkos::parallel_for(1, KOKKOS_LAMBDA(const Int&) {
 
-    Spack rho{rho_}, temp{temp_}, pres{pres_}, rhofaci{rhofaci_}, table_val_qi2qr_melting{table_val_qi2qr_melting_}, 
+    Spack rho{rho_}, temp{temp_}, pres{pres_}, rhofaci{rhofaci_}, table_val_qi2qr_melting{table_val_qi2qr_melting_},
           table_val_qi2qr_vent_melt{table_val_qi2qr_vent_melt_}, latent_heat_vapor{latent_heat_vapor_},
           latent_heat_fusion{latent_heat_fusion_}, dv{dv_}, kap{kap_}, mu{mu_}, sc{sc_}, qv{qv_}, qc_incld{qc_incld_}, qi_incld{qi_incld_},
           ni_incld{ni_incld_}, qr_incld{qr_incld_};
 
     Smask log_wetgrowth{log_wetgrowth_local};
 
-    Spack qr2qi_collect_tend{local_qr2qi_collect_tend}, qc2qi_collect_tend{local_qc2qi_collect_tend}, qc_growth_rate{local_qc_growth_rate}, 
+    Spack qr2qi_collect_tend{local_qr2qi_collect_tend}, qc2qi_collect_tend{local_qc2qi_collect_tend}, qc_growth_rate{local_qc_growth_rate},
           nr_ice_shed_tend{local_nr_ice_shed_tend}, qc2qr_ice_shed_tend{local_qc2qr_ice_shed_tend};
 
     P3F::ice_cldliq_wet_growth(rho, temp, pres, rhofaci, table_val_qi2qr_melting, table_val_qi2qr_vent_melt, latent_heat_vapor, latent_heat_fusion, dv, kap, mu, sc, qv, qc_incld,
@@ -3089,7 +3089,7 @@ void p3_main_part3_f(
     nk, inout_views);
 }
 
-void p3_main_f(
+Int p3_main_f(
   Real* qc, Real* nc, Real* qr, Real* nr, Real* th_atm, Real* qv, Real dt,
   Real* qi, Real* qm, Real* ni, Real* bm, Real* pres, Real* dz,
   Real* nc_nuceat_tend, Real* ni_activated, Real* inv_qc_relvar, Int it, Real* precip_liq_surf,
@@ -3153,17 +3153,17 @@ void p3_main_f(
     dz_d                   (temp_d[counter++]),
     nc_nuceat_tend_d       (temp_d[counter++]),
     ni_activated_d         (temp_d[counter++]),
-    dpres_d                (temp_d[counter++]), 
+    dpres_d                (temp_d[counter++]),
     exner_d                (temp_d[counter++]), //5
     cld_frac_i_d           (temp_d[counter++]),
     cld_frac_l_d           (temp_d[counter++]),
     cld_frac_r_d           (temp_d[counter++]),
-    inv_qc_relvar_d        (temp_d[counter++]), 
+    inv_qc_relvar_d        (temp_d[counter++]),
     qc_d                   (temp_d[counter++]), //10
     nc_d                   (temp_d[counter++]),
     qr_d                   (temp_d[counter++]),
     nr_d                   (temp_d[counter++]),
-    qi_d                   (temp_d[counter++]), 
+    qi_d                   (temp_d[counter++]),
     qm_d                   (temp_d[counter++]), //15
     ni_d                   (temp_d[counter++]),
     bm_d                   (temp_d[counter++]),
@@ -3178,12 +3178,12 @@ void p3_main_f(
     lamc_d                 (temp_d[counter++]),
     qv2qi_depos_tend_d     (temp_d[counter++]),
     precip_total_tend_d    (temp_d[counter++]),
-    nevapr_d               (temp_d[counter++]), 
+    nevapr_d               (temp_d[counter++]),
     qr_evap_tend_d         (temp_d[counter++]), //30
     liq_ice_exchange_d     (temp_d[counter++]),
     vap_liq_exchange_d     (temp_d[counter++]),
     vap_ice_exchange_d     (temp_d[counter++]),
-    precip_liq_flux_d      (temp_d[counter++]), 
+    precip_liq_flux_d      (temp_d[counter++]),
     precip_ice_flux_d      (temp_d[counter++]), //35
     precip_liq_surf_temp_d (temp_d[counter++]),
     precip_ice_surf_temp_d (temp_d[counter++]); //37
@@ -3200,7 +3200,7 @@ void p3_main_f(
       col_location_d(i, j) = i+1;
     }
   });
-  
+
   // Pack our data into structs and ship it off to p3_main.
   P3F::P3PrognosticState prog_state{qc_d, nc_d, qr_d, nr_d, qi_d, qm_d,
                                     ni_d, bm_d, qv_d, th_atm_d};
@@ -3215,10 +3215,14 @@ void p3_main_f(
                                        do_predict_nc, col_location_d};
   P3F::P3HistoryOnly history_only{liq_ice_exchange_d, vap_liq_exchange_d,
                                   vap_ice_exchange_d};
-  
+
+  // In situations where we care about timings, we only want to time the p3_main call
+  auto start = std::chrono::steady_clock::now();
   P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
                history_only, nj, nk);
-  
+  auto finish = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
+
   Kokkos::parallel_for(nj, KOKKOS_LAMBDA(const Int& i) {
     precip_liq_surf_temp_d(0, i / Spack::n)[i % Spack::n] = precip_liq_surf_d(i);
     precip_ice_surf_temp_d(0, i / Spack::n)[i % Spack::n] = precip_ice_surf_d(i);
@@ -3240,13 +3244,15 @@ void p3_main_f(
   dim2_sizes_out[23] = nk+1; // precip_ice_flux
   dim1_sizes_out[24] = 1; dim2_sizes_out[24] = nj; // precip_liq_surf
   dim1_sizes_out[25] = 1; dim2_sizes_out[25] = nj; // precip_ice_surf
-  
+
   ekat::device_to_host({
       qc, nc, qr, nr, qi, qm, ni, bm, qv, th_atm, diag_eff_radius_qc, diag_eff_radius_qi,
       rho_qi, mu_c, lamc, qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend, liq_ice_exchange,
       vap_liq_exchange, vap_ice_exchange, precip_liq_flux, precip_ice_flux, precip_liq_surf, precip_ice_surf
     },
     dim1_sizes_out, dim2_sizes_out, inout_views, true);
+
+  return duration.count();
 }
 
 } // namespace p3

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3216,12 +3216,8 @@ Int p3_main_f(
   P3F::P3HistoryOnly history_only{liq_ice_exchange_d, vap_liq_exchange_d,
                                   vap_ice_exchange_d};
 
-  // In situations where we care about timings, we only want to time the p3_main call
-  auto start = std::chrono::steady_clock::now();
-  P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
-               history_only, nj, nk);
-  auto finish = std::chrono::steady_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
+  auto elapsed_microsec = P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
+                                       history_only, nj, nk);
 
   Kokkos::parallel_for(nj, KOKKOS_LAMBDA(const Int& i) {
     precip_liq_surf_temp_d(0, i / Spack::n)[i % Spack::n] = precip_liq_surf_d(i);
@@ -3252,7 +3248,7 @@ Int p3_main_f(
     },
     dim1_sizes_out, dim2_sizes_out, inout_views, true);
 
-  return duration.count();
+  return elapsed_microsec;
 }
 
 } // namespace p3

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -232,7 +232,7 @@ void p3_main_c(
   Real* diag_eff_radius_qi, Real* rho_qi, bool do_predict_nc, Real* dpres, Real* exner,
   Real* qv2qi_depos_tend, Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend, Real* precip_liq_flux,
   Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, Real* mu_c, Real* lamc,
-  Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev);
+  Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev, Real* elapsed_s);
 
 } // extern "C" : end _c decls
 
@@ -823,7 +823,7 @@ void p3_main(P3MainData& d)
     d.precip_ice_surf, d.its, d.ite, d.kts, d.kte, d.diag_eff_radius_qc, d.diag_eff_radius_qi,
     d.rho_qi, d.do_predict_nc, d.dpres, d.exner, d.qv2qi_depos_tend, d.precip_total_tend, d.nevapr,
     d.qr_evap_tend, d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i, d.mu_c, d.lamc,
-    d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange, d.qv_prev, d.t_prev);
+    d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange, d.qv_prev, d.t_prev, &d.elapsed_s);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -1154,7 +1154,7 @@ extern "C" {
 
 void p3_main_part3_f(
   Int kts, Int kte, Int kbot, Int ktop, Int kdir,
-  Real* exner, Real* cld_frac_l, Real* cld_frac_r, Real* cld_frac_i, 
+  Real* exner, Real* cld_frac_l, Real* cld_frac_r, Real* cld_frac_i,
   Real* rho, Real* inv_rho, Real* rhofaci, Real* qv, Real* th_atm, Real* qc, Real* nc, Real* qr, Real* nr, Real* qi, Real* ni, Real* qm, Real* bm, Real* latent_heat_vapor, Real* latent_heat_sublim,
   Real* mu_c, Real* nu, Real* lamc, Real* mu_r, Real* lamr, Real* vap_liq_exchange,
   Real*  ze_rain, Real* ze_ice, Real* diag_vm_qi, Real* diag_eff_radius_qi, Real* diag_diam_qi, Real* rho_qi, Real* diag_equiv_reflectivity, Real* diag_eff_radius_qc);
@@ -1182,7 +1182,7 @@ struct P3MainData : public PhysicsTestData
        *precip_liq_flux, *precip_ice_flux, *precip_liq_surf, *precip_ice_surf;
 
   P3MainData(Int its_, Int ite_, Int kts_, Int kte_, Int it_, Real dt_, bool do_predict_nc_);
-  
+
   PTD_DATA_COPY_CTOR(P3MainData, 7);
   PTD_ASSIGN_OP(P3MainData, 7, its, ite, kts, kte, it, dt, do_predict_nc);
 };
@@ -1191,7 +1191,7 @@ void p3_main(P3MainData& d);
 
 extern "C" {
 
-void p3_main_f(
+Int p3_main_f(
   Real* qc, Real* nc, Real* qr, Real* nr, Real* th_atm, Real* qv, Real dt,
   Real* qi, Real* qm, Real* ni, Real* bm, Real* pres, Real* dz,
   Real* nc_nuceat_tend, Real* ni_activated, Real* inv_qc_relvar, Int it, Real* precip_liq_surf,

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -1180,6 +1180,7 @@ struct P3MainData : public PhysicsTestData
   Real *diag_eff_radius_qc, *diag_eff_radius_qi, *rho_qi, *mu_c, *lamc, *qv2qi_depos_tend, *precip_total_tend, *nevapr,
        *qr_evap_tend, *liq_ice_exchange, *vap_liq_exchange, *vap_ice_exchange,
        *precip_liq_flux, *precip_ice_flux, *precip_liq_surf, *precip_ice_surf;
+  Real elapsed_s;
 
   P3MainData(Int its_, Int ite_, Int kts_, Int kte_, Int it_, Real dt_, bool do_predict_nc_);
 

--- a/components/scream/src/physics/p3/p3_ic_cases.cpp
+++ b/components/scream/src/physics/p3/p3_ic_cases.cpp
@@ -59,7 +59,7 @@ FortranData::Ptr make_mixed (const Int ncol) {
     // and used by P3. It can range between 0.1 and 10.0. Setting to a typical value of 1.0
     // here.
     for (k = 0; k < nk; ++k) d.inv_qc_relvar(i,k) = 1.0;
-    
+
     // To get potential temperature, start by making absolute temperature vary
     // between 150K at top of atmos and 300k at surface, then convert to potential
     // temp.
@@ -99,7 +99,7 @@ FortranData::Ptr make_mixed (const Int ncol) {
       d.qv_prev(i,k) = d.qv(i,k);
       d.t_prev(i,k) = T_atm(k);
     }
-    
+
     // compute vertical grid spacing dz (in m) from pres and theta.
     static constexpr double
       g = 9.8; // gravity, m/s^2

--- a/components/scream/src/physics/p3/p3_iso_c.f90
+++ b/components/scream/src/physics/p3/p3_iso_c.f90
@@ -108,7 +108,7 @@ contains
        pres,dz,nc_nuceat_tend,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_eff_radius_qc,     &
        diag_eff_radius_qi,rho_qi,do_predict_nc, dpres,exner,qv2qi_depos_tend,precip_total_tend,nevapr, &
        qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,mu_c,lamc,liq_ice_exchange, &
-       vap_liq_exchange, vap_ice_exchange, qv_prev, t_prev) bind(C)
+       vap_liq_exchange, vap_ice_exchange, qv_prev, t_prev, elapsed_s) bind(C)
     use micro_p3, only : p3_main
 
     real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, qv, th_atm
@@ -139,6 +139,8 @@ contains
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: qv_prev
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: t_prev
 
+    real(kind=c_real), intent(out) :: elapsed_s
+
     real(kind=c_real), dimension(its:ite,kts:kte,49)   :: p3_tend_out
     real(kind=c_real), dimension(its:ite,3) :: col_location
     integer :: i
@@ -150,7 +152,7 @@ contains
          pres,dz,nc_nuceat_tend,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_eff_radius_qc, &
          diag_eff_radius_qi,rho_qi,do_predict_nc,dpres,exner,qv2qi_depos_tend,precip_total_tend,nevapr, &
          qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,p3_tend_out,mu_c,lamc,liq_ice_exchange,&
-         vap_liq_exchange, vap_ice_exchange, qv_prev, t_prev, col_location)
+         vap_liq_exchange, vap_ice_exchange, qv_prev, t_prev, col_location, elapsed_s)
   end subroutine p3_main_c
 
   subroutine micro_p3_utils_init_c(Cpair, Rair, RH2O, RHO_H2O, &

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -1144,6 +1144,7 @@ Int Functions<S,D>
                  team, ocol_location);
 #endif
   });
+  Kokkos::fence();
 
   auto finish = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finish - start);

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -887,7 +887,7 @@ void Functions<S,D>
 }
 
 template <typename S, typename D>
-void Functions<S,D>
+Int Functions<S,D>
 ::p3_main(
   const P3PrognosticState& prognostic_state,
   const P3DiagnosticInputs& diagnostic_inputs,
@@ -926,6 +926,9 @@ void Functions<S,D>
 
   // per-column bools
   view_2d<bool> bools("bools", nj, 2);
+
+  // we do not want to measure init stuff
+  auto start = std::chrono::steady_clock::now();
 
   // p3_main loop
   Kokkos::parallel_for(
@@ -1141,6 +1144,10 @@ void Functions<S,D>
                  team, ocol_location);
 #endif
   });
+
+  auto finish = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
+  return duration.count();
 }
 
 } // namespace p3

--- a/components/scream/src/physics/p3/scream_p3_interface.F90
+++ b/components/scream/src/physics/p3/scream_p3_interface.F90
@@ -166,6 +166,7 @@ contains
     real(kind=c_real) :: vap_ice_exchange(pcols,pver) ! sum of vap-ice phase change tendenices
     real(kind=c_real) :: inv_qc_relvar(pcols,pver)        ! 1/(var(qc)/mean(qc)**2) for P3 subgrid qc.
     real(kind=c_real) :: inv_cp
+    real(kind=c_real) :: elapsed_s
 
     real(kind=c_real) :: col_location(pcols,3)
 
@@ -306,7 +307,8 @@ contains
          vap_ice_exchange(its:ite,kts:kte),& ! OUT sum of vap-ice phase change tendencies
          qv_prev(its:ite,kts:kte),&          ! IN qv from prev step
          t_prev(its:ite,kts:kte),&           ! IN T from prev step
-         col_location(its:ite,3)           & ! IN location of columns
+         col_location(its:ite,3),           & ! IN location of columns
+         elapsed_s &
          )
     do i = its,ite
       do k = kts,kte

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -246,7 +246,7 @@ int main (int argc, char** argv) {
       "  -t <tol>    Tolerance for relative error. Default 0.\n";
       "  -s <steps>  Number of timesteps. Default=6.\n";
       "  -i <cols>   Number of columns. Default=6.\n";
-      "  -r <repeat> Number of repititions, implies timing run (generate + no I/O). Default=0.\n";
+      "  -r <repeat> Number of repetitions, implies timing run (generate + no I/O). Default=0.\n";
     return 1;
   }
 

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -110,8 +110,7 @@ struct Baseline {
     Int nerr = 0;
 
     // These times are thrown out, I just wanted to be able to use auto
-    auto start = std::chrono::steady_clock::now(), finish = start;
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
+    Int total_duration_microsec = 0;
 
     for (auto ps : params_) {
       // Run reference p3 on this set of parameters.
@@ -131,15 +130,10 @@ struct Baseline {
         }
 
         for (int it=0; it<ps.it; it++) {
-          if (r != -1 && m_repeat > 0) { // do not count the "cold" run
-            start  = std::chrono::steady_clock::now();
-          }
-
-          p3_main(*d, use_fortran);
+          Int current_microsec = p3_main(*d, use_fortran);
 
           if (r != -1 && m_repeat > 0) { // do not count the "cold" run
-            finish = std::chrono::steady_clock::now();
-            duration += std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
+            total_duration_microsec += current_microsec;
           }
 
           if (m_repeat == 0) {
@@ -149,7 +143,7 @@ struct Baseline {
       }
 
       if (m_repeat > 0) {
-        const double report_time = (1e-6*duration.count()) / m_repeat;
+        const double report_time = (1e-6*total_duration_microsec) / m_repeat;
 
         printf("Time = %1.3e seconds\n", report_time);
       }

--- a/components/scream/src/share/scream_config.cpp
+++ b/components/scream/src/share/scream_config.cpp
@@ -7,7 +7,7 @@ namespace scream {
 std::string scream_config_string() {
   auto config = ekat::ekat_config_string();
 
-  config += "sizeof(Real) = " + std::to_string(sizeof(Real)) + "\n";
+  config += "\nsizeof(Real) = " + std::to_string(sizeof(Real)) + "\n";
   config += "default pack size = " + std::to_string(SCREAM_PACK_SIZE) + "\n";
 
   return config;


### PR DESCRIPTION
Change list:
1) Upgrades to perf-analysis script for more-flexible commands and better support for primary scream repo operations
2) Add more-precise timings for P3 CXX by excluding initialization
3) Add more-precise timings for P3 f90 by excluding initialization
4) Additional flags for controlling p3_run_and_cmp behavior 