### PR TITLE
[WIP] port shoc_energy_fixer

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -460,7 +460,7 @@ subroutine shoc_main ( &
      zt_grid,zi_grid,&                     ! Input
      se_b,ke_b,wv_b,wl_b,&                 ! Input
      se_a,ke_a,wv_a,wl_a,&                 ! Input
-     wthl_sfc,wqw_sfc,pdel,&               ! Input
+     wthl_sfc,wqw_sfc,&                    ! Input
      rho_zt,tke,presi,&                    ! Input
      host_dse)                             ! Input/Output
 
@@ -3498,9 +3498,13 @@ subroutine shoc_energy_fixer(&
          zt_grid,zi_grid,&              ! Input
          se_b,ke_b,wv_b,wl_b,&          ! Input
          se_a,ke_a,wv_a,wl_a,&          ! Input
-         wthl_sfc,wqw_sfc,pdel,&        ! Input
+         wthl_sfc,wqw_sfc,&             ! Input
          rho_zt,tke,pint,&              ! Input
          host_dse)                      ! Input/Output
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  use shoc_iso_f, only: shoc_energy_fixer_f
+#endif
 
   implicit none
 
@@ -3535,8 +3539,6 @@ subroutine shoc_energy_fixer(&
   real(rtype), intent(in) :: wthl_sfc(shcol)
   ! Surface latent heat flux [kg/kg m/s]
   real(rtype), intent(in) :: wqw_sfc(shcol)
-  ! pressure differenes [Pa]
-  real(rtype), intent(in) :: pdel(shcol,nlev)
   ! heights on midpoint grid [m]
   real(rtype), intent(in) :: zt_grid(shcol,nlev)
   ! heights on interface grid [m]
@@ -3555,6 +3557,19 @@ subroutine shoc_energy_fixer(&
   ! LOCAL VARIABLES
   real(rtype) :: se_dis(shcol), te_a(shcol), te_b(shcol)
   integer :: shoctop(shcol)
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+   if (use_cxx) then
+      call shoc_energy_fixer_f(shcol,nlev,nlevi,dtime,nadv,& ! Input
+                              zt_grid,zi_grid,&              ! Input
+                              se_b,ke_b,wv_b,wl_b,&          ! Input
+                              se_a,ke_a,wv_a,wl_a,&          ! Input
+                              wthl_sfc,wqw_sfc,&             ! Input
+                              rho_zt,tke,pint,&              ! Input
+                              host_dse)                      ! Input/Output
+      return
+   endif
+#endif
 
   call shoc_energy_total_fixer(&
          shcol,nlev,nlevi,dtime,nadv,&  ! Input

--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -47,6 +47,7 @@ if (NOT CUDA_BUILD)
     shoc_compute_conv_vel_shoc_length.cpp
     shoc_compute_l_inf_shoc_length.cpp
     shoc_diag_obklen.cpp
+    shoc_energy_fixer.cpp
   ) # SHOC ETI SRCS
 endif()
 

--- a/components/scream/src/physics/shoc/shoc_energy_fixer.cpp
+++ b/components/scream/src/physics/shoc/shoc_energy_fixer.cpp
@@ -1,0 +1,13 @@
+#include "shoc_energy_fixer_impl.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation using the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream

--- a/components/scream/src/physics/shoc/shoc_energy_fixer_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_energy_fixer_impl.hpp
@@ -1,0 +1,92 @@
+#ifndef SHOC_ENERGY_FIXER_IMPL_HPP
+#define SHOC_ENERGY_FIXER_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Implementation of shoc shoc_energy_fixer. Clients should NOT
+ * #include this file, but include shoc_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::shoc_energy_fixer(
+  const MemberType&            team,
+  const Int&                   nlev,
+  const Int&                   nlevi,
+  const Scalar&                dtime,
+  const Int&                   nadv,
+  const uview_1d<const Spack>& zt_grid,
+  const uview_1d<const Spack>& zi_grid,
+  const Scalar&                se_b,
+  const Scalar&                ke_b,
+  const Scalar&                wv_b,
+  const Scalar&                wl_b,
+  const Scalar&                se_a,
+  const Scalar&                ke_a,
+  const Scalar&                wv_a,
+  const Scalar&                wl_a,
+  const Scalar&                wthl_sfc,
+  const Scalar&                wqw_sfc,
+  const uview_1d<const Spack>& rho_zt,
+  const uview_1d<const Spack>& tke,
+  const uview_1d<const Spack>& pint,
+  const uview_1d<Spack>&       rho_zi,
+  const uview_1d<Spack>&       host_dse)
+{
+  // Constants
+  const auto cp = C::CP;
+  const auto lcond = C::LatVap;
+  const auto lice = C::LatIce;
+  const auto mintke = SC::mintke;
+  const auto ggr = C::gravit;
+
+  // Local variables
+  Scalar te_a = 0;
+  Scalar te_b = 0;
+  Scalar se_dis = 0;
+  Int shoctop = 0;
+
+  // Compute linear interpolation of data into rho_zi
+  linear_interp(team,zt_grid,zi_grid,rho_zt,rho_zi,nlev,nlevi,0);
+  team.team_barrier();
+
+  // Compute the host timestep
+  const Scalar hdtime = dtime*float(nadv);
+
+  // Compute the total energy before and after SHOC call
+  const auto s_rho_zi = ekat::scalarize(rho_zi);
+  const Scalar shf = wthl_sfc*cp*s_rho_zi(nlevi-1);
+  const Scalar lhf = wqw_sfc*s_rho_zi(nlevi-1);
+  te_a = se_a + ke_a + (lcond+lice)*wv_a +lice*wl_a;
+  te_b = se_b + ke_b + (lcond+lice)*wv_b + lice*wl_b;
+  te_b += (shf+lhf*(lcond+lice))*hdtime;
+
+  // Limit the energy fixer to find highest layer where SHOC is active.
+  // Find first level where tke is higher than lowest threshold.
+  const auto s_tke = ekat::scalarize(tke);
+  const auto s_pint = ekat::scalarize(pint);
+  while (s_tke(shoctop) == mintke && shoctop < nlev-2) {
+    shoctop += 1;
+  }
+
+  // Compute the disbalance of total energy, over depth where SHOC is active.
+  se_dis = (te_a - te_b)/(s_pint(nlevi-1) - s_pint(shoctop));
+
+  // Update host_dse
+  const int begin_pack = shoctop/Spack::n;
+  const auto nlev_packs = ekat::npack<Spack>(nlev);
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, begin_pack, nlev_packs), [&] (const Int& k) {
+    auto range_pack = ekat::range<IntSmallPack>(k*Spack::n);
+
+    host_dse(k).set(range_pack >= shoctop && range_pack < nlev, host_dse(k)-se_dis*ggr);
+  });
+}
+
+} // namespace shoc
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -243,6 +243,31 @@ struct Functions
     Scalar&       ustar,
     Scalar&       kbfs,
     Scalar&       obklen);
+
+  KOKKOS_FUNCTION
+  static void shoc_energy_fixer(
+    const MemberType&            team,
+    const Int&                   nlev,
+    const Int&                   nlevi,
+    const Scalar&                dtime,
+    const Int&                   nadv,
+    const uview_1d<const Spack>& zt_grid,
+    const uview_1d<const Spack>& zi_grid,
+    const Scalar&                se_b,
+    const Scalar&                ke_b,
+    const Scalar&                wv_b,
+    const Scalar&                wl_b,
+    const Scalar&                se_a,
+    const Scalar&                ke_a,
+    const Scalar&                wv_a,
+    const Scalar&                wl_a,
+    const Scalar&                wthl_sfc,
+    const Scalar&                wqw_sfc,
+    const uview_1d<const Spack>& rho_zt,
+    const uview_1d<const Spack>& tke,
+    const uview_1d<const Spack>& pint,
+    const uview_1d<Spack>&       rho_zi,
+    const uview_1d<Spack>&       host_dse);
 }; // struct Functions
 
 } // namespace shoc
@@ -271,6 +296,7 @@ struct Functions
 # include "shoc_check_length_scale_shoc_length_impl.hpp"
 # include "shoc_compute_conv_vel_shoc_length_impl.hpp"
 # include "shoc_diag_obklen_impl.hpp"
+# include "shoc_energy_fixer_impl.hpp"
 #endif // KOKKOS_ENABLE_CUDA
 
 #endif

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -34,7 +34,7 @@ void shoc_energy_fixer_c(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv,
                          Real *zt_grid, Real *zi_grid, Real *se_b, Real *ke_b,
                          Real *wv_b, Real *wl_b, Real *se_a, Real *ke_a,
                          Real *wv_a, Real *wl_a, Real *wthl_sfc, Real *wqw_sfc,
-                         Real *pdel, Real *rho_zt, Real *tke, Real *pint,
+                         Real *rho_zt, Real *tke, Real *pint,
                          Real *host_dse);
 
 void shoc_energy_integrals_c(Int shcol, Int nlev, Real *host_dse, Real *pdel,
@@ -350,7 +350,7 @@ void shoc_energy_fixer(SHOCEnergyfixerData &d){
   shoc_energy_fixer_c(d.shcol(), d.nlev(), d.nlevi(), d.dtime, d.nadv,
                       d.zt_grid, d.zi_grid, d.se_b, d.ke_b, d.wv_b,
                       d.wl_b, d.se_a, d.ke_a, d.wv_a, d.wl_a, d.wthl_sfc,
-                      d.wqw_sfc, d.pdel, d.rho_zt, d.tke, d.pint,
+                      d.wqw_sfc, d.rho_zt, d.tke, d.pint,
                       d.host_dse);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
@@ -1606,6 +1606,95 @@ void shoc_diag_obklen_f(Int shcol, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, R
   // Sync back to host
   Kokkos::Array<view_1d, 3> inout_views = {ustar_d, kbfs_d, obklen_d};
   ekat::device_to_host<int,3>({ustar, kbfs, obklen}, shcol, inout_views);
+}
+
+void shoc_energy_fixer_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* zt_grid,
+                         Real* zi_grid, Real* se_b, Real* ke_b, Real* wv_b, Real* wl_b,
+                         Real* se_a, Real* ke_a, Real* wv_a, Real* wl_a, Real* wthl_sfc,
+                         Real* wqw_sfc, Real* rho_zt, Real* tke, Real* pint,
+                         Real* host_dse)
+{
+  using SHF = Functions<Real, DefaultDevice>;
+
+  using Scalar     = typename SHF::Scalar;
+  using Spack      = typename SHF::Spack;
+  using Pack1d     = typename ekat::Pack<Real,1>;
+  using view_1d    = typename SHF::view_1d<Pack1d>;
+  using view_2d    = typename SHF::view_2d<Spack>;
+  using KT         = typename SHF::KT;
+  using ExeSpace   = typename KT::ExeSpace;
+  using MemberType = typename SHF::MemberType;
+
+  Kokkos::Array<view_1d, 10> temp_1d_d;
+  Kokkos::Array<const Real*, 10> ptr_array_1d = {se_b, ke_b, wv_b, wl_b,     se_a,
+                                                 ke_a, wv_a, wl_a, wthl_sfc, wqw_sfc};
+  Kokkos::Array<view_2d, 6> temp_2d_d;
+  Kokkos::Array<int, 6> dim1_sizes           = {shcol,   shcol,   shcol,
+                                                shcol,   shcol,   shcol};
+  Kokkos::Array<int, 6> dim2_sizes           = {nlev,    nlevi,   nlevi,
+                                                nlev,    nlev,    nlev};
+  Kokkos::Array<const Real*, 6> ptr_array_2d = {zt_grid, zi_grid, pint,
+                                                rho_zt,  tke,     host_dse};
+
+  // Sync to device
+  ekat::host_to_device(ptr_array_1d, shcol, temp_1d_d);
+  ekat::host_to_device(ptr_array_2d, dim1_sizes, dim2_sizes, temp_2d_d, true);
+
+  view_1d
+    se_b_d(temp_1d_d[0]),
+    ke_b_d(temp_1d_d[1]),
+    wv_b_d(temp_1d_d[2]),
+    wl_b_d(temp_1d_d[3]),
+    se_a_d(temp_1d_d[4]),
+    ke_a_d(temp_1d_d[5]),
+    wv_a_d(temp_1d_d[6]),
+    wl_a_d(temp_1d_d[7]),
+    wthl_sfc_d(temp_1d_d[8]),
+    wqw_sfc_d(temp_1d_d[9]);
+
+  view_2d
+    zt_grid_d(temp_2d_d[0]),
+    zi_grid_d(temp_2d_d[1]),
+    pint_d(temp_2d_d[2]),
+    rho_zt_d(temp_2d_d[3]),
+    tke_d(temp_2d_d[4]),
+    host_dse_d(temp_2d_d[5]);
+
+  // Local variable
+  view_2d rho_zi_d("rho_zi", shcol, ekat::npack<Spack>(nlevi));
+
+  const Int nk_pack = ekat::npack<Spack>(nlev);
+  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+    const Int i = team.league_rank();
+
+    const Scalar se_b_s{se_b_d(i)[0]};
+    const Scalar ke_b_s{ke_b_d(i)[0]};
+    const Scalar wv_b_s{wv_b_d(i)[0]};
+    const Scalar wl_b_s{wl_b_d(i)[0]};
+    const Scalar se_a_s{se_a_d(i)[0]};
+    const Scalar ke_a_s{ke_a_d(i)[0]};
+    const Scalar wv_a_s{wv_a_d(i)[0]};
+    const Scalar wl_a_s{wl_a_d(i)[0]};
+    const Scalar wthl_sfc_s{wthl_sfc_d(i)[0]};
+    const Scalar wqw_sfc_s{wqw_sfc_d(i)[0]};
+
+    const auto zt_grid_s = ekat::subview(zt_grid_d, i);
+    const auto zi_grid_s = ekat::subview(zi_grid_d, i);
+    const auto pint_s = ekat::subview(pint_d, i);
+    const auto rho_zt_s = ekat::subview(rho_zt_d, i);
+    const auto tke_s = ekat::subview(tke_d, i);
+    const auto rho_zi_s = ekat::subview(rho_zi_d, i);
+    const auto host_dse_s = ekat::subview(host_dse_d, i);
+
+    SHF::shoc_energy_fixer(team,nlev,nlevi,dtime,nadv,zt_grid_s,zi_grid_s,se_b_s,
+                           ke_b_s,wv_b_s,wl_b_s,se_a_s,ke_a_s,wv_a_s,wl_a_s,
+                           wthl_sfc_s,wqw_sfc_s,rho_zt_s,tke_s,pint_s,rho_zi_s,host_dse_s);
+  });
+
+  // Sync back to host
+  Kokkos::Array<view_2d, 1> inout_views = {host_dse_d};
+  ekat::device_to_host<int,1>({host_dse}, {shcol}, {nlev}, inout_views, true);
 }
 
 } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -266,7 +266,7 @@ struct SHOCEnergyfixerData : public PhysicsTestData {
   Int nadv;
   Real dtime;
   Real *zt_grid, *zi_grid, *se_b, *wv_b, *pint;
-  Real *se_a, *ke_b, *wl_b, *ke_a, *tke, *pdel;
+  Real *se_a, *ke_b, *wl_b, *ke_a, *tke;
   Real *wv_a, *wl_a, *wthl_sfc, *wqw_sfc, *rho_zt;
 
   // Output
@@ -274,7 +274,7 @@ struct SHOCEnergyfixerData : public PhysicsTestData {
 
   //functions to initialize data
   SHOCEnergyfixerData(Int shcol_, Int nlev_, Int nlevi_, Real dtime_, Real nadv_) :
-    PhysicsTestData(shcol_, nlev_, nlevi_, {&host_dse, &zt_grid, &pdel, &rho_zt, &tke}, {&zi_grid, &pint}, {&se_b, &ke_b, &wv_b, &wl_b, &se_a, &ke_a, &wv_a, &wl_a, &wthl_sfc, &wqw_sfc}), nadv(nadv_), dtime(dtime_) {}
+    PhysicsTestData(shcol_, nlev_, nlevi_, {&host_dse, &zt_grid, &rho_zt, &tke}, {&zi_grid, &pint}, {&se_b, &ke_b, &wv_b, &wl_b, &se_a, &ke_a, &wv_a, &wl_a, &wthl_sfc, &wqw_sfc}), nadv(nadv_), dtime(dtime_) {}
 
   SHOC_SCALARS(SHOCEnergyfixerData, 3, 2, dtime, nadv);
 };//SHOCEnergyfixerData
@@ -913,7 +913,11 @@ void diag_second_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* q
 void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* tke, Real* isotropy, Real* tkh, Real* tk, Real* dz_zi, Real* zt_grid, Real* zi_grid, Real* shoc_mix, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* thl_sec, Real* qw_sec, Real* wthl_sec, Real* wqw_sec, Real* qwthl_sec, Real* uw_sec, Real* vw_sec, Real* wtke_sec, Real* w_sec);
 void shoc_diag_obklen_f(Int shcol, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, Real* wqw_sfc,
                         Real* thl_sfc, Real* cldliq_sfc, Real* qv_sfc, Real* ustar, Real* kbfs, Real* obklen);
-
+void shoc_energy_fixer_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* zt_grid,
+                         Real* zi_grid, Real* se_b, Real* ke_b, Real* wv_b, Real* wl_b,
+                         Real* se_a, Real* ke_a, Real* wv_a, Real* wl_a, Real* wthl_sfc,
+                         Real* wqw_sfc, Real* rho_zt, Real* tke, Real* pint,
+                         Real* host_dse);
 } // end _f function decls
 
 }  // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -403,7 +403,7 @@ contains
   subroutine shoc_energy_fixer_c(shcol, nlev, nlevi, dtime, nadv, &
                                  zt_grid, zi_grid, se_b, ke_b, wv_b, &
                                  wl_b, se_a, ke_a, wv_a, wl_a, wthl_sfc, &
-                                 wqw_sfc, pdel, rho_zt, tke, pint, &
+                                 wqw_sfc, rho_zt, tke, pint, &
                                  host_dse) bind (C)
     use shoc, only: shoc_energy_fixer
 
@@ -424,7 +424,6 @@ contains
     real(kind=c_real), intent(in) :: wl_a(shcol)
     real(kind=c_real), intent(in) :: wthl_sfc(shcol)
     real(kind=c_real), intent(in) :: wqw_sfc(shcol)
-    real(kind=c_real), intent(in) :: pdel(shcol,nlev)
     real(kind=c_real), intent(in) :: rho_zt(shcol,nlev)
     real(kind=c_real), intent(in) :: tke(shcol,nlev)
     real(kind=c_real), intent(in) :: pint(shcol,nlevi)
@@ -434,7 +433,7 @@ contains
     call shoc_energy_fixer(shcol, nlev, nlevi, dtime, nadv, &
                            zt_grid, zi_grid, se_b, ke_b, wv_b, &
                            wl_b, se_a, ke_a, wv_a, wl_a, wthl_sfc, &
-                           wqw_sfc, pdel, rho_zt, tke, pint, &
+                           wqw_sfc, rho_zt, tke, pint, &
                            host_dse)
 
   end subroutine shoc_energy_fixer_c

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -274,6 +274,20 @@ subroutine shoc_diag_obklen_f(shcol, uw_sfc, vw_sfc, wthl_sfc, wqw_sfc, thl_sfc,
 
 end subroutine shoc_diag_obklen_f
 
+subroutine shoc_energy_fixer_f(shcol, nlev, nlevi, dtime, nadv, zt_grid, zi_grid,&
+                               se_b, ke_b, wv_b, wl_b, se_a, ke_a, wv_a, wl_a,&
+                               wthl_sfc, wqw_sfc, rho_zt, tke, pint, host_dse) bind(C)
+  use iso_c_binding
+
+  integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi, nadv
+  real(kind=c_real) , value, intent(in) :: dtime
+  real(kind=c_real) , intent(in), dimension(shcol, nlev) :: zt_grid, rho_zt, tke
+  real(kind=c_real) , intent(in), dimension(shcol, nlevi) :: zi_grid, pint
+  real(kind=c_real) , intent(in), dimension(shcol) :: se_b, ke_b, wv_b, wl_b, se_a, ke_a, wv_a, wl_a, wthl_sfc, wqw_sfc
+  real(kind=c_real) , intent(inout), dimension(shcol, nlev) :: host_dse
+
+end subroutine shoc_energy_fixer_f
+
 end interface
 
 end module shoc_iso_f


### PR DESCRIPTION
Port `shoc_energy_fixer` to C++.

Note, I decided to implement `shoc_energy_total_fixer`, `shoc_energy_threshold_fixer`, and `shoc_energy_dse_fixer` all inside `shoc_energy_fixer` since these functions are called nowhere else in shoc.F90. Also, `pdel` was an unused input so I removed. 