### PR TITLE
remove extra constant

### DIFF
--- a/components/scream/src/physics/shoc/shoc_constants.hpp
+++ b/components/scream/src/physics/shoc/shoc_constants.hpp
@@ -15,7 +15,6 @@ struct Constants
       static constexpr Scalar maxtke         = 50.0;    // Maximum TKE [m2/s2]
       static constexpr Scalar minlen         = 20.0;    // Lower limit for mixing length [m]
       static constexpr Scalar maxlen         = 20000.0; // Upper limit for mixing length [m]
-      static constexpr Scalar minlen         = 20.0;    // Lower limit for mixing length [m]
       static constexpr Scalar maxiso         = 20000.0; // Upper limit for isotropy time scale [s]
       static constexpr Scalar length_fac     = 0.5;     // Mixing length scaling parameter
       static constexpr Scalar c_diag_3rd_mom = 7.0;     // Coefficient for diag third moment parameters


### PR DESCRIPTION
Constant is double defined, causing tests to fail.