### PR TITLE
[WIP] Write p3 parameters in namelist_defaults_cam to atm_in

### DIFF
--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -3547,6 +3547,13 @@ if ($cfg->get('microphys') =~ /^mg2/) {
     add_default($nl, 'mg_prc_coeff_fix');    
 }
 
+if ($cfg->get('microphys') =~ /^p3/) {
+    add_default($nl, 'nucleate_ice_subgrid');
+    add_default($nl, 'so4_sz_thresh_icenuc');
+    add_default($nl, 'cld_macmic_num_steps');
+}
+
+
 # Sub-column switches for physics packages
 # Check that a subcol_scheme is specified if use_subcol_microp is turned on (true)
 add_default($nl, 'subcol_scheme');


### PR DESCRIPTION
This PR makes sure that p3 parameters added to namelist_defaults_cam are not missed and are written to atm_in during the build. 