### PR TITLE
Adding property checks to Fields.

### DIFF
--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -44,10 +44,10 @@ public:
   static_assert(view_type::Rank==1, "Error! RealType should not be an array type.\n");
 
   // A Field maintains a list of shared_ptrs to FieldPropertyChecks that can
-  // determine whether it satisfies certain properties. We use the pointer_list
+  // determine whether it satisfies certain properties. We use the PointerList
   // class to provide simple access to the property checks.
   using property_check_type = FieldPropertyCheck<ScalarType, device_type>;
-  using property_check_list = pointer_list<std::shared_ptr<property_check_type>,
+  using property_check_list = PointerList<std::shared_ptr<property_check_type>,
                                            property_check_type>;
   using property_check_iterator = typename property_check_list::const_iterator;
 

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -46,7 +46,7 @@ public:
   // A Field maintains a list of shared_ptrs to FieldPropertyChecks that can
   // determine whether it satisfies certain properties. We use the PointerList
   // class to provide simple access to the property checks.
-  using property_check_type = FieldPropertyCheck<ScalarType, device_type>;
+  using property_check_type = FieldPropertyCheck<RealType>;
   using property_check_list = PointerList<std::shared_ptr<property_check_type>,
                                            property_check_type>;
   using property_check_iterator = typename property_check_list::const_iterator;

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -48,7 +48,7 @@ public:
   // class to provide simple access to the property checks.
   using property_check_type = FieldPropertyCheck<ScalarType, device_type>;
   using property_check_list = pointer_list<std::shared_ptr<property_check_type>,
-                                           const property_check_type>;
+                                           property_check_type>;
   using property_check_iterator = typename property_check_list::const_iterator;
 
   // Constructor(s)

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -49,7 +49,7 @@ public:
   using property_check_type = FieldPropertyCheck<RealType>;
   using property_check_list = PointerList<std::shared_ptr<property_check_type>,
                                            property_check_type>;
-  using property_check_iterator = typename property_check_list::const_iterator;
+  using property_check_iterator = typename property_check_list::iterator;
 
   // Constructor(s)
   Field () = default;
@@ -75,16 +75,16 @@ public:
 
   // Adds a propery check to this field.
   void add_property_check(std::shared_ptr<property_check_type> property_check) {
-    m_prop_checks.append(property_check);
+    m_prop_checks->append(property_check);
   }
 
   // These (forward) iterators allow access to the set of property checks on the
   // field.
   property_check_iterator property_check_begin() const {
-    return m_prop_checks.begin();
+    return m_prop_checks->begin();
   }
   property_check_iterator property_check_end() const {
-    return m_prop_checks.end();
+    return m_prop_checks->end();
   }
 
   // Allows to get the underlying view, reshaped for a different data type.
@@ -115,7 +115,7 @@ protected:
   bool                            m_allocated;
 
   // List of property checks for this field.
-  property_check_list m_prop_checks;
+  std::shared_ptr<property_check_list> m_prop_checks;
 };
 
 template<typename RealType>
@@ -128,6 +128,7 @@ Field<RealType>::
 Field (const identifier_type& id)
  : m_header    (new header_type(id))
  , m_allocated (false)
+ , m_prop_checks(new property_check_list)
 {
   // At the very least, the allocation properties need to accommodate this field's value_type.
   m_header->get_alloc_properties().request_value_type_allocation<value_type>();

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -2,6 +2,7 @@
 #define SCREAM_FIELD_HPP
 
 #include "share/field/field_header.hpp"
+#include "share/field/field_property_check.hpp"
 #include "share/scream_types.hpp"
 
 #include "ekat/ekat_type_traits.hpp"
@@ -41,6 +42,10 @@ public:
   // Statically check that RealType is not an array.
   static_assert(view_type::Rank==1, "Error! RealType should not be an array type.\n");
 
+  using prop_check_type           = FieldPropertyCheck<ScalarType, DeviceType>;
+  using prop_check_iterator       = std::vector<std::shared_ptr<prop_check_type> >::iterator;
+  using prop_check_const_iterator = std::vector<std::shared_ptr<prop_check_type> >::const_iterator;
+
   // Constructor(s)
   Field () = default;
   explicit Field (const identifier_type& id);
@@ -62,6 +67,17 @@ public:
 
   // Returns a const_field_type copy of this field
   const_field_type get_const () const { return const_field_type(*this); }
+
+  // Adds a propery check to this field.
+  void add_prop_check(std::shared_ptr<prop_check_type> prop_check) {
+    m_prop_checks.push_back(prop_check);
+  }
+
+  // Allows access to the set of property checks on the field.
+  field_prop_check_iterator field_prop_check_begin() { return m_prop_checks.begin(); }
+  field_prop_check_const_iterator field_prop_check_begin() const { return m_prop_checks.begin(); }
+  field_prop_check_iterator field_prop_check_end() { return m_prop_checks.end(); }
+  field_prop_check_const_iterator field_prop_check_end() const { return m_prop_checks.end(); }
 
   // Allows to get the underlying view, reshaped for a different data type.
   // The class will check that the requested data type is compatible with the
@@ -89,6 +105,9 @@ protected:
 
   // Keep track of whether the field has been allocated
   bool                            m_allocated;
+
+  // List of property checks for this field.
+  std::vector<FieldPropertyCheck<ScalarType, DeviceType> > m_prop_checks;
 };
 
 template<typename RealType>

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -75,7 +75,7 @@ public:
 
   // Adds a propery check to this field.
   void add_property_check(std::shared_ptr<property_check_type> property_check) {
-    m_prop_checks.push_back(property_check);
+    m_prop_checks.append(property_check);
   }
 
   // These (forward) iterators allow access to the set of property checks on the

--- a/components/scream/src/share/field/field_boundedness_check.hpp
+++ b/components/scream/src/share/field/field_boundedness_check.hpp
@@ -2,6 +2,7 @@
 #define SCREAM_FIELD_BOUNDEDNESS_CHECK_HPP
 
 #include "share/field/field.hpp"
+#include "ekat/util/ekat_math_utils.hpp"
 
 namespace scream
 {
@@ -38,8 +39,8 @@ public:
       if (i == 0) {
         mm.min_val = mm.max_val = host_view(0);
       } else {
-        mm.min_val = std::min(mm.min_val, host_view(i));
-        mm.max_val = std::max(mm.max_val, host_view(i));
+        mm.min_val = ekat::impl::min(mm.min_val, host_view(i));
+        mm.max_val = ekat::impl::max(mm.max_val, host_view(i));
       }
     }, Kokkos::MinMax<ScalarType>(minmax));
     return ((minmax.min_val >= m_lower_bound) && (minmax.max_val <= m_upper_bound));

--- a/components/scream/src/share/field/field_boundedness_check.hpp
+++ b/components/scream/src/share/field/field_boundedness_check.hpp
@@ -35,9 +35,13 @@ public:
     typename Kokkos::MinMax<ScalarType>::value_type minmax;
     Kokkos::parallel_reduce(host_view.extent(0), KOKKOS_LAMBDA(Int i,
         typename Kokkos::MinMax<ScalarType>::value_type& mm) {
-      mm.min_val = std::min(host_view(0), host_view(i));
-      mm.max_val = std::max(host_view(0), host_view(i));
-    }, minmax);
+      if (i == 0) {
+        mm.min_val = mm.max_val = host_view(0);
+      } else {
+        mm.min_val = std::min(mm.min_val, host_view(i));
+        mm.max_val = std::max(mm.max_val, host_view(i));
+      }
+    }, Kokkos::MinMax<ScalarType>(minmax));
     return ((minmax.min_val >= m_lower_bound) && (minmax.max_val <= m_upper_bound));
   }
 

--- a/components/scream/src/share/field/field_boundedness_check.hpp
+++ b/components/scream/src/share/field/field_boundedness_check.hpp
@@ -1,0 +1,69 @@
+#ifndef SCREAM_FIELD_BOUNDEDNESS_CHECK_HPP
+#define SCREAM_FIELD_BOUNDEDNESS_CHECK_HPP
+
+#include "share/field/field.hpp"
+
+namespace scream
+{
+
+// This field property check returns true if all data in a given field are
+// bounded by the given upper and lower bounds (inclusively), and false if not.
+// It can repair a field that fails the check by clipping all unbounded values
+// to their closest bound.
+template<typename ScalarType, typename Device>
+class FieldBoundednessCheck: public FieldPropertyCheck<ScalarType, Device> {
+public:
+
+  // No default constructor -- we need lower and upper bounds.
+  FieldBoundednessCheck () = delete;
+
+  // Constructor with lower and upper bounds -- can repair fields that fail the check
+  // by overwriting nonpositive values with the given lower bound.
+  explicit FieldBoundednessCheck (ScalarType lower_bound,
+                                  ScalarType upper_bound) :
+    m_lower_bound(lower_bound),
+    m_upper_bound(upper_bound) {
+    EKAT_ASSERT_MSG(lower_bound < upper_bound,
+                    "lower_bound must be less than upper_bound.");
+  }
+
+  // Overrides.
+
+  bool check(const Field<ScalarType, Device>& field) const override {
+    auto host_view = Kokkos::create_mirror_view(field.get_view());
+    Kokkos::deep_copy(host_view, field.get_view());
+    bool bounded = true;
+    Kokkos::parallel_reduce(host_view.extent(0), KOKKOS_LAMBDA(Int i, bool& b) {
+      b = b && ((host_view(i) >= m_lower_bound) && ((host_view(i) <= m_upper_bound)));
+    }, bounded);
+    return bounded;
+  }
+
+  bool can_repair() const override {
+    return true;
+  }
+
+  void repair(Field<ScalarType, Device>& field) const override {
+    auto host_view = Kokkos::create_mirror_view(field.get_view());
+    Kokkos::deep_copy(host_view, field.get_view());
+    Kokkos::parallel_for(host_view.extent(0), KOKKOS_LAMBDA(Int i) {
+      auto fi = host_view(i);
+      if (fi < m_lower_bound) {
+        host_view(i) = m_lower_bound;
+      } else if (fi > m_upper_bound) {
+        host_view(i) = m_upper_bound;
+      }
+    });
+    Kokkos::deep_copy(field.get_view(), host_view);
+  }
+
+protected:
+
+  // Lower and upper bounds.
+  ScalarType m_lower_bound, m_upper_bound;
+
+};
+
+} // namespace scream
+
+#endif // SCREAM_FIELD_BOUNDEDNESS_CHECK_HPP

--- a/components/scream/src/share/field/field_monotonicity_check.hpp
+++ b/components/scream/src/share/field/field_monotonicity_check.hpp
@@ -21,13 +21,12 @@ public:
   // Overrides.
 
   bool check(const Field<ScalarType, Device>& field) const override {
-    auto host_view = Kokkos::create_mirror_view(field.get_view());
-    Kokkos::deep_copy(host_view, field.get_view());
+    auto view = field.get_view();
     ScalarType sign;
-    Kokkos::parallel_reduce(host_view.extent(0), KOKKOS_LAMBDA(Int i, ScalarType& s) {
-      if ((i > 0) && (i < host_view.extent(0)-1)) {
-        auto diff1 = host_view(i) - host_view(i-1);
-        auto diff2 = host_view(i+1) - host_view(i);
+    Kokkos::parallel_reduce(view.extent(0), KOKKOS_LAMBDA(Int i, ScalarType& s) {
+      if ((i > 0) && (i < view.extent(0)-1)) {
+        auto diff1 = view(i) - view(i-1);
+        auto diff2 = view(i+1) - view(i);
         s *= (diff1 * diff2 > 0) ? (diff1 * diff2) : 0;
       } else {
         s *= 1;

--- a/components/scream/src/share/field/field_monotonicity_check.hpp
+++ b/components/scream/src/share/field/field_monotonicity_check.hpp
@@ -11,8 +11,8 @@ namespace scream
 // repairs to nonmonotonic fields can be performed. There are ways of repairing
 // non-monotonic fields given certain assumptions, but we do not make such
 // assumptions here.
-template<typename ScalarType, typename Device>
-class FieldMonotonicityCheck: public FieldPropertyCheck<ScalarType, Device> {
+template<typename Realtype>
+class FieldMonotonicityCheck: public FieldPropertyCheck<Realtype> {
 public:
 
   // Default constructor.
@@ -20,10 +20,10 @@ public:
 
   // Overrides.
 
-  bool check(const Field<ScalarType, Device>& field) const override {
+  bool check(const Field<Realtype>& field) const override {
     auto view = field.get_view();
-    ScalarType sign;
-    Kokkos::parallel_reduce(view.extent(0), KOKKOS_LAMBDA(Int i, ScalarType& s) {
+    Realtype sign;
+    Kokkos::parallel_reduce(view.extent(0), KOKKOS_LAMBDA(Int i, Realtype& s) {
       if ((i > 0) && (i < view.extent(0)-1)) {
         auto diff1 = view(i) - view(i-1);
         auto diff2 = view(i+1) - view(i);
@@ -31,7 +31,7 @@ public:
       } else {
         s *= 1;
       }
-    }, Kokkos::Prod<ScalarType>(sign));
+    }, Kokkos::Prod<Realtype>(sign));
     return (sign > 0);
   }
 
@@ -39,7 +39,7 @@ public:
     return false;
   }
 
-  void repair(Field<ScalarType, Device>& field) const override {
+  void repair(Field<Realtype>& field) const override {
     EKAT_REQUIRE_MSG(false, "Cannot repair a non-monotonic field!");
   }
 };

--- a/components/scream/src/share/field/field_monotonicity_check.hpp
+++ b/components/scream/src/share/field/field_monotonicity_check.hpp
@@ -11,8 +11,8 @@ namespace scream
 // repairs to nonmonotonic fields can be performed. There are ways of repairing
 // non-monotonic fields given certain assumptions, but we do not make such
 // assumptions here.
-template<typename Realtype>
-class FieldMonotonicityCheck: public FieldPropertyCheck<Realtype> {
+template<typename RealType>
+class FieldMonotonicityCheck: public FieldPropertyCheck<RealType> {
 public:
 
   // Default constructor.
@@ -20,10 +20,10 @@ public:
 
   // Overrides.
 
-  bool check(const Field<Realtype>& field) const override {
+  bool check(const Field<RealType>& field) const override {
     auto view = field.get_view();
-    Realtype sign;
-    Kokkos::parallel_reduce(view.extent(0), KOKKOS_LAMBDA(Int i, Realtype& s) {
+    RealType sign;
+    Kokkos::parallel_reduce(view.extent(0), KOKKOS_LAMBDA(Int i, RealType& s) {
       if ((i > 0) && (i < view.extent(0)-1)) {
         auto diff1 = view(i) - view(i-1);
         auto diff2 = view(i+1) - view(i);
@@ -31,7 +31,7 @@ public:
       } else {
         s *= 1;
       }
-    }, Kokkos::Prod<Realtype>(sign));
+    }, Kokkos::Prod<RealType>(sign));
     return (sign > 0);
   }
 
@@ -39,7 +39,7 @@ public:
     return false;
   }
 
-  void repair(Field<Realtype>& field) const override {
+  void repair(Field<RealType>& field) const override {
     EKAT_REQUIRE_MSG(false, "Cannot repair a non-monotonic field!");
   }
 };

--- a/components/scream/src/share/field/field_monotonicity_check.hpp
+++ b/components/scream/src/share/field/field_monotonicity_check.hpp
@@ -23,13 +23,17 @@ public:
   bool check(const Field<ScalarType, Device>& field) const override {
     auto host_view = Kokkos::create_mirror_view(field.get_view());
     Kokkos::deep_copy(host_view, field.get_view());
-    bool monotonic = true;
-    Kokkos::parallel_reduce(host_view.extent(0), KOKKOS_LAMBDA(Int i, bool& m) {
+    ScalarType sign;
+    Kokkos::parallel_reduce(host_view.extent(0), KOKKOS_LAMBDA(Int i, ScalarType& s) {
       if ((i > 0) && (i < host_view.extent(0)-1)) {
-        m = m && ((host_view(i+1) > host_view(i)) && (host_view(i) > host_view(i-1)));
+        auto diff1 = host_view(i) - host_view(i-1);
+        auto diff2 = host_view(i+1) - host_view(i);
+        s = (diff1 * diff2 > 0) ? (diff1 * diff2) : 0;
+      } else {
+        s = 1;
       }
-    }, monotonic);
-    return monotonic;
+    }, Kokkos::Prod<ScalarType>(sign));
+    return (sign > 0);
   }
 
   bool can_repair() const override {

--- a/components/scream/src/share/field/field_monotonicity_check.hpp
+++ b/components/scream/src/share/field/field_monotonicity_check.hpp
@@ -28,9 +28,9 @@ public:
       if ((i > 0) && (i < host_view.extent(0)-1)) {
         auto diff1 = host_view(i) - host_view(i-1);
         auto diff2 = host_view(i+1) - host_view(i);
-        s = (diff1 * diff2 > 0) ? (diff1 * diff2) : 0;
+        s *= (diff1 * diff2 > 0) ? (diff1 * diff2) : 0;
       } else {
-        s = 1;
+        s *= 1;
       }
     }, Kokkos::Prod<ScalarType>(sign));
     return (sign > 0);

--- a/components/scream/src/share/field/field_monotonicity_check.hpp
+++ b/components/scream/src/share/field/field_monotonicity_check.hpp
@@ -1,0 +1,46 @@
+#ifndef SCREAM_FIELD_MONOTONICITY_CHECK_HPP
+#define SCREAM_FIELD_MONOTONICITY_CHECK_HPP
+
+#include "share/field/field.hpp"
+
+namespace scream
+{
+
+// This field property check returns true if all data in a given field are
+// monotonically increasing or decreasing, and false if not. Currently, no
+// repairs to nonmonotonic fields can be performed. There are ways of repairing
+// non-monotonic fields given certain assumptions, but we do not make such
+// assumptions here.
+template<typename ScalarType, typename Device>
+class FieldMonotonicityCheck: public FieldPropertyCheck<ScalarType, Device> {
+public:
+
+  // Default constructor.
+  FieldMonotonicityCheck () {}
+
+  // Overrides.
+
+  bool check(const Field<ScalarType, Device>& field) const override {
+    auto host_view = Kokkos::create_mirror_view(field.get_view());
+    Kokkos::deep_copy(host_view, field.get_view());
+    bool monotonic = true;
+    Kokkos::parallel_reduce(host_view.extent(0), KOKKOS_LAMBDA(Int i, bool& m) {
+      if ((i > 0) && (i < host_view.extent(0)-1)) {
+        m = m && ((host_view(i+1) > host_view(i)) && (host_view(i) > host_view(i-1)));
+      }
+    }, monotonic);
+    return monotonic;
+  }
+
+  bool can_repair() const override {
+    return false;
+  }
+
+  void repair(Field<ScalarType, Device>& field) const override {
+    EKAT_ASSERT_MSG(false, "Cannot repair a non-monotonic field!");
+  }
+};
+
+} // namespace scream
+
+#endif // SCREAM_FIELD_MONOTONICITY_CHECK_HPP

--- a/components/scream/src/share/field/field_monotonicity_check.hpp
+++ b/components/scream/src/share/field/field_monotonicity_check.hpp
@@ -41,7 +41,7 @@ public:
   }
 
   void repair(Field<ScalarType, Device>& field) const override {
-    EKAT_ASSERT_MSG(false, "Cannot repair a non-monotonic field!");
+    EKAT_REQUIRE_MSG(false, "Cannot repair a non-monotonic field!");
   }
 };
 

--- a/components/scream/src/share/field/field_positivity_check.hpp
+++ b/components/scream/src/share/field/field_positivity_check.hpp
@@ -31,10 +31,10 @@ public:
     auto f_view = field.get_view();
     auto host_view = Kokkos::create_mirror_view(field.get_view());
     Kokkos::deep_copy(host_view, field.get_view());
-    ScalarType min_val = -90000000;//host_view(0);
+    ScalarType min_val;
     Kokkos::parallel_reduce(host_view.extent(0), KOKKOS_LAMBDA(Int i, ScalarType& m) {
-      m = std::min(m, host_view(i));
-    }, min_val);
+      m = std::min(host_view(0), host_view(i));
+    }, Kokkos::Min<ScalarType>(min_val));
     return (min_val > 0);
   }
 

--- a/components/scream/src/share/field/field_positivity_check.hpp
+++ b/components/scream/src/share/field/field_positivity_check.hpp
@@ -2,6 +2,7 @@
 #define SCREAM_FIELD_POSITIVITY_CHECK_HPP
 
 #include "share/field/field.hpp"
+#include "ekat/util/ekat_math_utils.hpp"
 
 namespace scream
 {
@@ -33,7 +34,11 @@ public:
     Kokkos::deep_copy(host_view, field.get_view());
     ScalarType min_val;
     Kokkos::parallel_reduce(host_view.extent(0), KOKKOS_LAMBDA(Int i, ScalarType& m) {
-      m = std::min(host_view(0), host_view(i));
+      if (i == 0) {
+        m = host_view(0);
+      } else {
+        m = ekat::impl::min(m, host_view(i));
+      }
     }, Kokkos::Min<ScalarType>(min_val));
     return (min_val > 0);
   }

--- a/components/scream/src/share/field/field_positivity_check.hpp
+++ b/components/scream/src/share/field/field_positivity_check.hpp
@@ -1,0 +1,67 @@
+#ifndef SCREAM_FIELD_POSITIVITY_CHECK_HPP
+#define SCREAM_FIELD_POSITIVITY_CHECK_HPP
+
+#include "share/field/field.hpp"
+
+namespace scream
+{
+
+// This field property check returns true if all data in a given field are
+// positive, and false if not. If constructed with a specific lower bound, it
+// can repair a field that fails the check by setting all nonpositive values
+// to that lower bound. If no specific lower bound is given (i.e. if the
+// default constructor is used), no repairs can be made.
+template<typename ScalarType, typename Device>
+class FieldPositivityCheck: public FieldPropertyCheck<ScalarType, Device> {
+public:
+
+  // Default constructor -- cannot repair fields that fail the check.
+  FieldPositivityCheck () : m_lower_bound(0) {}
+
+  // Constructor with lower bound -- can repair fields that fail the check
+  // by overwriting nonpositive values with the given lower bound.
+  explicit FieldPositivityCheck (ScalarType lower_bound) :
+    m_lower_bound(lower_bound) {
+    EKAT_ASSERT_MSG(lower_bound > 0, "lower_bound must be positive.");
+  }
+
+  // Overrides.
+
+  bool check(const Field<ScalarType, Device>& field) const override {
+    auto f_view = field.get_view();
+    auto host_view = Kokkos::create_mirror_view(field.get_view());
+    Kokkos::deep_copy(host_view, field.get_view());
+    ScalarType min_val = -90000000;//host_view(0);
+    Kokkos::parallel_reduce(host_view.extent(0), KOKKOS_LAMBDA(Int i, ScalarType& m) {
+      m = std::min(m, host_view(i));
+    }, min_val);
+    return (min_val > 0);
+  }
+
+  bool can_repair() const override {
+    return (m_lower_bound > 0);
+  }
+
+  void repair(Field<ScalarType, Device>& field) const override {
+    if (can_repair()) {
+      auto host_view = Kokkos::create_mirror_view(field.get_view());
+      Kokkos::deep_copy(host_view, field.get_view());
+      Kokkos::parallel_for(host_view.extent(0), KOKKOS_LAMBDA(Int i) {
+        if (host_view(i) < m_lower_bound) {
+          host_view(i) = m_lower_bound;
+        }
+      });
+      Kokkos::deep_copy(field.get_view(), host_view);
+    }
+  }
+
+protected:
+
+  // The given lower bound (0 if not supplied).
+  ScalarType m_lower_bound;
+
+};
+
+} // namespace scream
+
+#endif // SCREAM_FIELD_POSITIVITY_CHECK_HPP

--- a/components/scream/src/share/field/field_property_check.hpp
+++ b/components/scream/src/share/field/field_property_check.hpp
@@ -27,6 +27,14 @@ public:
   // Constructor(s)
   FieldPropertyCheck () = default;
 
+  // No copy constructor.
+  FieldPropertyCheck(const FieldPropertyCheck&) = delete;
+
+  // No assignment operator, either.
+  FieldPropertyCheck& operator=(const FieldPropertyCheck&) = delete;
+
+  virtual ~FieldPropertyCheck() {}
+
   // Override this method to perform a property check on a Field. The method
   // returns true if the property check passes, and false if it fails.
   virtual bool check(const Field<ScalarType, Device>& field) const = 0;

--- a/components/scream/src/share/field/field_property_check.hpp
+++ b/components/scream/src/share/field/field_property_check.hpp
@@ -29,7 +29,7 @@ public:
 
   // Override this method to perform a property check on a Field. The method
   // returns true if the property check passes, and false if it fails.
-  virtual bool check(const Field<ScalarType, DeviceType>& field) const = 0;
+  virtual bool check(const Field<ScalarType, Device>& field) const = 0;
 
   // Override this method to return true if the property check is capable of
   // attempting to fix a field to make it satisfy a property check.
@@ -37,8 +37,8 @@ public:
 
   // Override this method to attempt to repair a field that doesn't pass this
   // property check. The field must be checked again to determine whether the
-  // repair is successful.
-  virtual void repair(Field<ScalarType, DeviceType>& field) = 0;
+  // repair is successful. NOTE the const in this method!
+  virtual void repair(Field<ScalarType, Device>& field) const = 0;
 
 };
 

--- a/components/scream/src/share/field/field_property_check.hpp
+++ b/components/scream/src/share/field/field_property_check.hpp
@@ -5,7 +5,7 @@ namespace scream
 {
 
 // Forward declaration of Field.
-template<typename ScalarType, typename Device> class Field;
+template<typename RealType> class Field;
 
 // =================== FIELD PROPERTY CHECK ======================== //
 
@@ -20,7 +20,7 @@ template<typename ScalarType, typename Device> class Field;
 //
 // FieldPropertyCheck is an abstract base class that provides an interface to
 // be implemented by a subclass.
-template<typename ScalarType, typename Device>
+template<typename RealType>
 class FieldPropertyCheck {
 public:
 
@@ -37,7 +37,7 @@ public:
 
   // Override this method to perform a property check on a Field. The method
   // returns true if the property check passes, and false if it fails.
-  virtual bool check(const Field<ScalarType, Device>& field) const = 0;
+  virtual bool check(const Field<RealType>& field) const = 0;
 
   // Override this method to return true if the property check is capable of
   // attempting to fix a field to make it satisfy a property check.
@@ -46,12 +46,12 @@ public:
   // Override this method to attempt to repair a field that doesn't pass this
   // property check. The field must be checked again to determine whether the
   // repair is successful. NOTE the const in this method!
-  virtual void repair(Field<ScalarType, Device>& field) const = 0;
+  virtual void repair(Field<RealType>& field) const = 0;
 
   // Override this method to provide a more efficient way to check and repair
   // a field in a single pass (applicable only to property checks that can
   // repair a field).
-  virtual void check_and_repair(Field<ScalarType, Device>& field) const {
+  virtual void check_and_repair(Field<RealType>& field) const {
     if (!check(field) && can_repair()) {
       repair(field);
     }

--- a/components/scream/src/share/field/field_property_check.hpp
+++ b/components/scream/src/share/field/field_property_check.hpp
@@ -48,6 +48,15 @@ public:
   // repair is successful. NOTE the const in this method!
   virtual void repair(Field<ScalarType, Device>& field) const = 0;
 
+  // Override this method to provide a more efficient way to check and repair
+  // a field in a single pass (applicable only to property checks that can
+  // repair a field).
+  virtual void check_and_repair(Field<ScalarType, Device>& field) const {
+    if (!check(field) && can_repair()) {
+      repair(field);
+    }
+  }
+
 };
 
 } // namespace scream

--- a/components/scream/src/share/field/field_property_check.hpp
+++ b/components/scream/src/share/field/field_property_check.hpp
@@ -1,0 +1,47 @@
+#ifndef SCREAM_FIELD_PROPERTY_CHECK_HPP
+#define SCREAM_FIELD_PROPERTY_CHECK_HPP
+
+namespace scream
+{
+
+// Forward declaration of Field.
+template<typename ScalarType, typename Device> class Field;
+
+// =================== FIELD PROPERTY CHECK ======================== //
+
+// A Field can have zero or more "property check" objects associated with it.
+// Each of these objects performs a check on a field to verify it has a certain
+// property. If the property is not satisfied, user can requests that the
+// property check try to fix it.
+//
+// A property can be as simple as the field's values being bounded, or can be
+// more involved, referencing other fields (e.g., |f1 - f2| < C), and can even
+// involve differential operators (e.g., |div(f)| < eps).
+//
+// FieldPropertyCheck is an abstract base class that provides an interface to
+// be implemented by a subclass.
+template<typename ScalarType, typename Device>
+class FieldPropertyCheck {
+public:
+
+  // Constructor(s)
+  FieldPropertyCheck () = default;
+
+  // Override this method to perform a property check on a Field. The method
+  // returns true if the property check passes, and false if it fails.
+  virtual bool check(const Field<ScalarType, DeviceType>& field) const = 0;
+
+  // Override this method to return true if the property check is capable of
+  // attempting to fix a field to make it satisfy a property check.
+  virtual bool can_repair() const = 0;
+
+  // Override this method to attempt to repair a field that doesn't pass this
+  // property check. The field must be checked again to determine whether the
+  // repair is successful.
+  virtual void repair(Field<ScalarType, DeviceType>& field) = 0;
+
+};
+
+} // namespace scream
+
+#endif // SCREAM_FIELD_PROPERTY_CHECK_HPP

--- a/components/scream/src/share/field/field_within_interval_check.hpp
+++ b/components/scream/src/share/field/field_within_interval_check.hpp
@@ -1,5 +1,5 @@
-#ifndef SCREAM_FIELD_BOUNDEDNESS_CHECK_HPP
-#define SCREAM_FIELD_BOUNDEDNESS_CHECK_HPP
+#ifndef SCREAM_FIELD_WITHIN_INTERVAL_CHECK_HPP
+#define SCREAM_FIELD_WITHIN_INTERVAL_CHECK_HPP
 
 #include "share/field/field.hpp"
 #include "ekat/util/ekat_math_utils.hpp"
@@ -12,20 +12,24 @@ namespace scream
 // It can repair a field that fails the check by clipping all unbounded values
 // to their closest bound.
 template<typename ScalarType, typename Device>
-class FieldBoundednessCheck: public FieldPropertyCheck<ScalarType, Device> {
+class FieldWithinIntervalCheck: public FieldPropertyCheck<ScalarType, Device> {
 public:
 
   // No default constructor -- we need lower and upper bounds.
-  FieldBoundednessCheck () = delete;
+  FieldWithinIntervalCheck () = delete;
 
-  // Constructor with lower and upper bounds -- can repair fields that fail the check
-  // by overwriting nonpositive values with the given lower bound.
-  explicit FieldBoundednessCheck (ScalarType lower_bound,
-                                  ScalarType upper_bound) :
+  // Constructor with lower and upper bounds. By default, this property check
+  // can repair fields that fail the check by overwriting nonpositive values
+  // with the given lower bound. If can_repair is false, the check cannot
+  // apply repairs to the field.
+  explicit FieldWithinIntervalCheck (ScalarType lower_bound,
+                                     ScalarType upper_bound,
+                                     bool can_repair = true) :
     m_lower_bound(lower_bound),
-    m_upper_bound(upper_bound) {
-    EKAT_ASSERT_MSG(lower_bound < upper_bound,
-                    "lower_bound must be less than upper_bound.");
+    m_upper_bound(upper_bound),
+    m_can_repair(can_repair) {
+    EKAT_ASSERT_MSG(lower_bound <= upper_bound,
+                    "lower_bound must be less than or equal to upper_bound.");
   }
 
   // Overrides.
@@ -47,27 +51,34 @@ public:
   }
 
   bool can_repair() const override {
-    return true;
+    return m_can_repair;
   }
 
   void repair(Field<ScalarType, Device>& field) const override {
-    auto host_view = Kokkos::create_mirror_view(field.get_view());
-    Kokkos::deep_copy(host_view, field.get_view());
-    Kokkos::parallel_for(host_view.extent(0), KOKKOS_LAMBDA(Int i) {
-      auto fi = host_view(i);
-      if (fi < m_lower_bound) {
-        host_view(i) = m_lower_bound;
-      } else if (fi > m_upper_bound) {
-        host_view(i) = m_upper_bound;
-      }
-    });
-    Kokkos::deep_copy(field.get_view(), host_view);
+    if (m_can_repair) {
+      auto host_view = Kokkos::create_mirror_view(field.get_view());
+      Kokkos::deep_copy(host_view, field.get_view());
+      Kokkos::parallel_for(host_view.extent(0), KOKKOS_LAMBDA(Int i) {
+        auto fi = host_view(i);
+        if (fi < m_lower_bound) {
+          host_view(i) = m_lower_bound;
+        } else if (fi > m_upper_bound) {
+          host_view(i) = m_upper_bound;
+        }
+      });
+      Kokkos::deep_copy(field.get_view(), host_view);
+    } else {
+      EKAT_REQUIRE_MSG(false, "Cannot repair the field!");
+    }
   }
 
 protected:
 
   // Lower and upper bounds.
   ScalarType m_lower_bound, m_upper_bound;
+
+  // Can we repair a field?
+  bool m_can_repair;
 
 };
 

--- a/components/scream/src/share/field/field_within_interval_check.hpp
+++ b/components/scream/src/share/field/field_within_interval_check.hpp
@@ -11,8 +11,8 @@ namespace scream
 // bounded by the given upper and lower bounds (inclusively), and false if not.
 // It can repair a field that fails the check by clipping all unbounded values
 // to their closest bound.
-template<typename ScalarType, typename Device>
-class FieldWithinIntervalCheck: public FieldPropertyCheck<ScalarType, Device> {
+template<typename Realtype>
+class FieldWithinIntervalCheck: public FieldPropertyCheck<Realtype> {
 public:
 
   // No default constructor -- we need lower and upper bounds.
@@ -22,8 +22,8 @@ public:
   // can repair fields that fail the check by overwriting nonpositive values
   // with the given lower bound. If can_repair is false, the check cannot
   // apply repairs to the field.
-  explicit FieldWithinIntervalCheck (ScalarType lower_bound,
-                                     ScalarType upper_bound,
+  explicit FieldWithinIntervalCheck (Realtype lower_bound,
+                                     Realtype upper_bound,
                                      bool can_repair = true) :
     m_lower_bound(lower_bound),
     m_upper_bound(upper_bound),
@@ -34,18 +34,18 @@ public:
 
   // Overrides.
 
-  bool check(const Field<ScalarType, Device>& field) const override {
+  bool check(const Field<Realtype>& field) const override {
     auto view = field.get_view();
-    typename Kokkos::MinMax<ScalarType>::value_type minmax;
+    typename Kokkos::MinMax<Realtype>::value_type minmax;
     Kokkos::parallel_reduce(view.extent(0), KOKKOS_LAMBDA(Int i,
-        typename Kokkos::MinMax<ScalarType>::value_type& mm) {
+        typename Kokkos::MinMax<Realtype>::value_type& mm) {
       if (i == 0) {
         mm.min_val = mm.max_val = view(0);
       } else {
         mm.min_val = ekat::impl::min(mm.min_val, view(i));
         mm.max_val = ekat::impl::max(mm.max_val, view(i));
       }
-    }, Kokkos::MinMax<ScalarType>(minmax));
+    }, Kokkos::MinMax<Realtype>(minmax));
     return ((minmax.min_val >= m_lower_bound) && (minmax.max_val <= m_upper_bound));
   }
 
@@ -53,7 +53,7 @@ public:
     return m_can_repair;
   }
 
-  void repair(Field<ScalarType, Device>& field) const override {
+  void repair(Field<Realtype>& field) const override {
     if (m_can_repair) {
       auto view = field.get_view();
       Kokkos::parallel_for(view.extent(0), KOKKOS_LAMBDA(Int i) {
@@ -72,7 +72,7 @@ public:
 protected:
 
   // Lower and upper bounds.
-  ScalarType m_lower_bound, m_upper_bound;
+  Realtype m_lower_bound, m_upper_bound;
 
   // Can we repair a field?
   bool m_can_repair;

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -257,8 +257,8 @@ TEST_CASE("field_property_check", "") {
 
   // Check positivity.
   SECTION ("field_positivity_check") {
-    Field<Real,Device> f1(fid);
-    auto positivity_check = std::make_shared<FieldPositivityCheck<Real, Device> >();
+    Field<Real> f1(fid);
+    auto positivity_check = std::make_shared<FieldPositivityCheck<Real> >();
     REQUIRE(not positivity_check->can_repair());
     f1.add_property_check(positivity_check);
     f1.allocate_view();
@@ -287,8 +287,8 @@ TEST_CASE("field_property_check", "") {
 
   // Check positivity with repairs.
   SECTION ("field_positivity_check_with_repairs") {
-    Field<Real,Device> f1(fid);
-    auto positivity_check = std::make_shared<FieldPositivityCheck<Real, Device> >(1);
+    Field<Real> f1(fid);
+    auto positivity_check = std::make_shared<FieldPositivityCheck<Real> >(1);
     REQUIRE(positivity_check->can_repair());
     f1.add_property_check(positivity_check);
     f1.allocate_view();
@@ -310,8 +310,8 @@ TEST_CASE("field_property_check", "") {
 
   // Check that the values of a field lie within an interval.
   SECTION ("field_within_interval_check") {
-    Field<Real,Device> f1(fid);
-    auto interval_check = std::make_shared<FieldWithinIntervalCheck<Real, Device> >(0, 100);
+    Field<Real> f1(fid);
+    auto interval_check = std::make_shared<FieldWithinIntervalCheck<Real> >(0, 100);
     REQUIRE(interval_check->can_repair());
     f1.add_property_check(interval_check);
     f1.allocate_view();
@@ -343,8 +343,8 @@ TEST_CASE("field_property_check", "") {
 
   // Check monotonicity.
   SECTION ("field_monotonicity_check") {
-    Field<Real,Device> f1(fid);
-    auto mono_check = std::make_shared<FieldMonotonicityCheck<Real, Device> >();
+    Field<Real> f1(fid);
+    auto mono_check = std::make_shared<FieldMonotonicityCheck<Real> >();
     REQUIRE(not mono_check->can_repair());
     f1.add_property_check(mono_check);
     f1.allocate_view();

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -380,50 +380,6 @@ TEST_CASE("field_property_check", "") {
       REQUIRE_THROWS(iter->repair(f1)); // we can't repair it, either
     }
   }
-
-  // Check if we can extract a reshaped view
-  SECTION ("reshape simple") {
-    Field<Real,Device> f1 (fid);
-
-    // Should not be able to reshape before allocating
-    REQUIRE_THROWS(f1.get_reshaped_view<Real*>());
-
-    f1.allocate_view();
-
-    // Should not be able to reshape to this data type
-    REQUIRE_THROWS(f1.get_reshaped_view<Pack<Real,8>>());
-
-    auto v1d = f1.get_view();
-    auto v3d = f1.get_reshaped_view<Real[2][3][12]>();
-    REQUIRE(v3d.size()==v1d.size());
-  }
-
-  // Check if we can request multiple value types
-  SECTION ("reshape multiple value types") {
-    Field<Real,Device> f1 (fid);
-    f1.get_header().get_alloc_properties().request_value_type_allocation<Pack<Real,8>>();
-    f1.allocate_view();
-
-    auto v1d = f1.get_view();
-    auto v3d_1 = f1.get_reshaped_view<Pack<Real,8>***>();
-    auto v3d_2 = f1.get_reshaped_view<Pack<Real,4>***>();
-    auto v3d_3 = f1.get_reshaped_view<Real***>();
-    auto v3d_4 = f1.get_reshaped_view<Real[2][3][16]>();
-
-    // The memory spans should be identical
-    REQUIRE (v3d_1.impl_map().memory_span()==v3d_2.impl_map().memory_span());
-    REQUIRE (v3d_1.impl_map().memory_span()==v3d_3.impl_map().memory_span());
-    REQUIRE (v3d_1.impl_map().memory_span()==v3d_4.impl_map().memory_span());
-
-    // Sizes differ, since they are in terms of the stored value type.
-    // Each Pack<Real,8> corresponds to two Pack<Real,4>, which corresponds to 4 Real's.
-    REQUIRE(2*v3d_1.size()==v3d_2.size());
-    REQUIRE(8*v3d_1.size()==v3d_3.size());
-    REQUIRE(8*v3d_1.size()==v3d_4.size());
-
-    // Trying to reshape into something that the allocation cannot accommodate should throw
-    REQUIRE_THROWS (f1.get_reshaped_view<Pack<Real,32>***>());
-  }
 }
 
 } // anonymous namespace

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -5,7 +5,7 @@
 #include "share/field/field.hpp"
 #include "share/field/field_repository.hpp"
 #include "share/field/field_positivity_check.hpp"
-#include "share/field/field_boundedness_check.hpp"
+#include "share/field/field_within_interval_check.hpp"
 #include "share/field/field_monotonicity_check.hpp"
 
 #include "ekat/ekat_pack.hpp"
@@ -308,12 +308,12 @@ TEST_CASE("field_property_check", "") {
     }
   }
 
-  // Check boundedness.
-  SECTION ("field_boundedness_check") {
+  // Check that the values of a field lie within an interval.
+  SECTION ("field_with_interval_check") {
     Field<Real,Device> f1(fid);
-    auto boundedness_check = std::make_shared<FieldBoundednessCheck<Real, Device> >(1, 72);
-    REQUIRE(boundedness_check->can_repair());
-    f1.add_property_check(boundedness_check);
+    auto interval_check = std::make_shared<FieldWithinIntervalCheck<Real, Device> >(1, 72);
+    REQUIRE(interval_check->can_repair());
+    f1.add_property_check(interval_check);
     f1.allocate_view();
 
     // Assign positive values to the field and make sure it passes our test for
@@ -377,6 +377,7 @@ TEST_CASE("field_property_check", "") {
     Kokkos::deep_copy(f1_view, host_view);
     for (auto iter = f1.property_check_begin(); iter != f1.property_check_end(); iter++) {
       REQUIRE(not iter->check(f1));
+      REQUIRE_THROWS(iter->repair(f1)); // we can't repair it, either
     }
   }
 

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -309,9 +309,9 @@ TEST_CASE("field_property_check", "") {
   }
 
   // Check that the values of a field lie within an interval.
-  SECTION ("field_with_interval_check") {
+  SECTION ("field_within_interval_check") {
     Field<Real,Device> f1(fid);
-    auto interval_check = std::make_shared<FieldWithinIntervalCheck<Real, Device> >(1, 72);
+    auto interval_check = std::make_shared<FieldWithinIntervalCheck<Real, Device> >(0, 100);
     REQUIRE(interval_check->can_repair());
     f1.add_property_check(interval_check);
     f1.allocate_view();
@@ -321,7 +321,7 @@ TEST_CASE("field_property_check", "") {
     auto f1_view = f1.get_view();
     auto host_view = Kokkos::create_mirror_view(f1_view);
     for (int i = 0; i < host_view.extent(0); ++i) {
-      host_view(i) = i+1;
+      host_view(i) = i;
     }
     Kokkos::deep_copy(f1_view, host_view);
     for (auto iter = f1.property_check_begin(); iter != f1.property_check_end(); iter++) {

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -267,18 +267,18 @@ TEST_CASE("field_property_check", "") {
     // positivity.
     auto f1_view = f1.get_view();
     auto host_view = Kokkos::create_mirror_view(f1_view);
-    Kokkos::parallel_for(host_view.extent(0), KOKKOS_LAMBDA(Int i) {
+    for (int i = 0; i < host_view.extent(0); ++i) {
       host_view(i) = i+1;
-    });
+    }
     Kokkos::deep_copy(f1_view, host_view);
     for (auto iter = f1.property_check_begin(); iter != f1.property_check_end(); iter++) {
       REQUIRE(iter->check(f1));
     }
 
     // Assign non-positive values to the field and make sure it fails the check.
-    Kokkos::parallel_for(host_view.extent(0), KOKKOS_LAMBDA(Int i) {
+    for (int i = 0; i < host_view.extent(0); ++i) {
       host_view(i) = -i;
-    });
+    }
     Kokkos::deep_copy(f1_view, host_view);
     for (auto iter = f1.property_check_begin(); iter != f1.property_check_end(); iter++) {
       REQUIRE(not iter->check(f1));
@@ -297,9 +297,9 @@ TEST_CASE("field_property_check", "") {
     // and then repair the field so it passes.
     auto f1_view = f1.get_view();
     auto host_view = Kokkos::create_mirror_view(f1_view);
-    Kokkos::parallel_for(host_view.extent(0), KOKKOS_LAMBDA(Int i) {
+    for (int i = 0; i < host_view.extent(0); ++i) {
       host_view(i) = -i;
-    });
+    }
     Kokkos::deep_copy(f1_view, host_view);
     for (auto iter = f1.property_check_begin(); iter != f1.property_check_end(); iter++) {
       REQUIRE(not iter->check(f1));
@@ -320,9 +320,9 @@ TEST_CASE("field_property_check", "") {
     // positivity.
     auto f1_view = f1.get_view();
     auto host_view = Kokkos::create_mirror_view(f1_view);
-    Kokkos::parallel_for(host_view.extent(0), KOKKOS_LAMBDA(Int i) {
+    for (int i = 0; i < host_view.extent(0); ++i) {
       host_view(i) = i+1;
-    });
+    }
     Kokkos::deep_copy(f1_view, host_view);
     for (auto iter = f1.property_check_begin(); iter != f1.property_check_end(); iter++) {
       REQUIRE(iter->check(f1));
@@ -330,9 +330,9 @@ TEST_CASE("field_property_check", "") {
 
     // Assign non-positive values to the field, make sure it fails the check,
     // and then repair the field so it passes.
-    Kokkos::parallel_for(host_view.extent(0), KOKKOS_LAMBDA(Int i) {
+    for (int i = 0; i < host_view.extent(0); ++i) {
       host_view(i) = -i;
-    });
+    }
     Kokkos::deep_copy(f1_view, host_view);
     for (auto iter = f1.property_check_begin(); iter != f1.property_check_end(); iter++) {
       REQUIRE(not iter->check(f1));
@@ -353,9 +353,9 @@ TEST_CASE("field_property_check", "") {
     // passes our test for positivity.
     auto f1_view = f1.get_view();
     auto host_view = Kokkos::create_mirror_view(f1_view);
-    Kokkos::parallel_for(host_view.extent(0), KOKKOS_LAMBDA(Int i) {
+    for (int i = 0; i < host_view.extent(0); ++i) {
       host_view(i) = i+1;
-    });
+    }
     Kokkos::deep_copy(f1_view, host_view);
     for (auto iter = f1.property_check_begin(); iter != f1.property_check_end(); iter++) {
       REQUIRE(iter->check(f1));
@@ -363,9 +363,9 @@ TEST_CASE("field_property_check", "") {
 
     // Assign monotonically-decreasing values to the field and make sure it
     // also passes the check.
-    Kokkos::parallel_for(host_view.extent(0), KOKKOS_LAMBDA(Int i) {
+    for (int i = 0; i < host_view.extent(0); ++i) {
       host_view(i) = -i;
-    });
+    }
     Kokkos::deep_copy(f1_view, host_view);
     for (auto iter = f1.property_check_begin(); iter != f1.property_check_end(); iter++) {
       REQUIRE(iter->check(f1));

--- a/components/scream/src/share/util/pointer_list.hpp
+++ b/components/scream/src/share/util/pointer_list.hpp
@@ -5,11 +5,11 @@
 
 namespace scream {
 
-// A pointer_list is a linearly traversible list of pointers that provides
+// A PointerList is a linearly traversible list of pointers that provides
 // iterators that automatically double-dereference their referents. Under the
-// covers, a pointer_list is just a vector of the given pointer type.
+// covers, a PointerList is just a vector of the given pointer type.
 template <typename PointerType, typename ValueType>
-class pointer_list final {
+class PointerList final {
 
 public:
 

--- a/components/scream/src/share/util/pointer_list.hpp
+++ b/components/scream/src/share/util/pointer_list.hpp
@@ -23,15 +23,16 @@ public:
     using base_iter_type = typename std::vector<PointerType>::iterator;
 
     explicit iterator(base_iter_type iter) : m_iter(iter) {}
-    iterator(const base_iter_type& iter) : m_iter(iter.m_iter) {}
+    iterator(const iterator& iter) : m_iter(iter.m_iter) {}
     iterator& operator=(const iterator& iter) {
       m_iter = iter.m_iter;
       return *this;
     }
 
     iterator& operator++() { m_iter++; return *this;}
+    iterator operator++(int) { auto retval = *this; m_iter++; return retval; }
     bool operator==(iterator other) const {return m_iter == other.m_iter;}
-    bool operator!=(iterator other) const {return !(*this == other);}
+    bool operator!=(iterator other) const {return m_iter != other.m_iter;}
     pointer operator->() const {return *m_iter;}
     reference operator*() const {return **m_iter;}
   private:
@@ -48,15 +49,16 @@ public:
     using base_iter_type = typename std::vector<PointerType>::const_iterator;
 
     explicit const_iterator(base_iter_type iter) : m_iter(iter) {}
-    const_iterator(const base_iter_type& iter) : m_iter(iter.m_iter) {}
+    const_iterator(const const_iterator& iter) : m_iter(iter.m_iter) {}
     const_iterator& operator=(const const_iterator& iter) {
       m_iter = iter.m_iter;
       return *this;
     }
 
-    iterator& operator++() { m_iter++; return *this;}
-    bool operator==(iterator other) const {return m_iter == other.m_iter;}
-    bool operator!=(iterator other) const {return !(*this == other);}
+    const_iterator& operator++() { m_iter++; return *this;}
+    const_iterator operator++(int) { auto retval = *this; m_iter++; return retval; }
+    bool operator==(const_iterator other) const {return m_iter == other.m_iter;}
+    bool operator!=(const_iterator other) const {return m_iter != other.m_iter;}
     pointer operator->() const {return *m_iter;}
     reference operator*() const {return **m_iter;}
   private:
@@ -64,10 +66,10 @@ public:
   };
 
   // These iterators provide access to the list's contents.
-  iterator begin();
-  const_iterator begin() const;
-  iterator end();
-  const_iterator end() const;
+  iterator begin() { return iterator(m_list.begin()); }
+  const_iterator begin() const { return const_iterator(m_list.begin()); }
+  iterator end() { return iterator(m_list.end()); }
+  const_iterator end() const { return const_iterator(m_list.end()); }
 
   // Returns the number of elements in the list.
   size_t size() const { return m_list.size(); }

--- a/components/scream/src/share/util/pointer_list.hpp
+++ b/components/scream/src/share/util/pointer_list.hpp
@@ -1,0 +1,79 @@
+#ifndef SCREAM_POINTER_LIST
+#define SCREAM_POINTER_LIST
+
+#include <vector>
+
+namespace scream {
+
+// A pointer_list is a linearly traversible list of pointers that provides
+// iterators that automatically double-dereference their referents. Under the
+// covers, a pointer_list is just a vector of the given pointer type.
+template <typename PointerType, typename ValueType>
+class pointer_list final {
+
+public:
+
+  class iterator final {
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ValueType;
+    using difference_type = std::ptrdiff_t;
+    using pointer = PointerType;
+    using reference = ValueType&;
+    using base_iter_type = typename std::vector<PointerType>::iterator;
+
+    explicit iterator(base_iter_type iter) : m_iter(iter) {}
+    iterator(const base_iter_type& iter) : m_iter(iter.m_iter) {}
+    iterator& operator=(const iterator& iter) {
+      m_iter = iter.m_iter;
+      return *this;
+    }
+
+    iterator& operator++() { m_iter++; return *this;}
+    bool operator==(iterator other) const {return m_iter == other.m_iter;}
+    bool operator!=(iterator other) const {return !(*this == other);}
+    pointer operator->() const {return *m_iter;}
+    const reference& operator*() const {return **m_iter;}
+  private:
+    base_iter_type m_iter;
+  };
+
+  class const_iterator final {
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = const ValueType;
+    using difference_type = std::ptrdiff_t;
+    using pointer = PointerType;
+    using reference = const ValueType&;
+    using base_iter_type = typename std::vector<PointerType>::const_iterator;
+
+    explicit const_iterator(base_iter_type iter) : m_iter(iter) {}
+    const_iterator(const base_iter_type& iter) : m_iter(iter.m_iter) {}
+    const_iterator& operator=(const const_iterator& iter) {
+      m_iter = iter.m_iter;
+      return *this;
+    }
+
+    iterator& operator++() { m_iter++; return *this;}
+    bool operator==(iterator other) const {return m_iter == other.m_iter;}
+    bool operator!=(iterator other) const {return !(*this == other);}
+    pointer operator->() const {return *m_iter;}
+    const reference& operator*() const {return **m_iter;}
+  private:
+    base_iter_type m_iter;
+  };
+
+  // These iterators provide access to the list's contents.
+  iterator begin();
+  const_iterator begin() const;
+  iterator end();
+  const_iterator end() const;
+
+private:
+
+  std::vector<PointerType> m_list;
+};
+
+} // end namespace scream
+
+#endif

--- a/components/scream/src/share/util/pointer_list.hpp
+++ b/components/scream/src/share/util/pointer_list.hpp
@@ -33,7 +33,7 @@ public:
     bool operator==(iterator other) const {return m_iter == other.m_iter;}
     bool operator!=(iterator other) const {return !(*this == other);}
     pointer operator->() const {return *m_iter;}
-    const reference& operator*() const {return **m_iter;}
+    reference operator*() const {return **m_iter;}
   private:
     base_iter_type m_iter;
   };
@@ -43,7 +43,7 @@ public:
     using iterator_category = std::forward_iterator_tag;
     using value_type = const ValueType;
     using difference_type = std::ptrdiff_t;
-    using pointer = PointerType;
+    using pointer = const PointerType;
     using reference = const ValueType&;
     using base_iter_type = typename std::vector<PointerType>::const_iterator;
 
@@ -58,7 +58,7 @@ public:
     bool operator==(iterator other) const {return m_iter == other.m_iter;}
     bool operator!=(iterator other) const {return !(*this == other);}
     pointer operator->() const {return *m_iter;}
-    const reference& operator*() const {return **m_iter;}
+    reference operator*() const {return **m_iter;}
   private:
     base_iter_type m_iter;
   };
@@ -68,6 +68,12 @@ public:
   const_iterator begin() const;
   iterator end();
   const_iterator end() const;
+
+  // Returns the number of elements in the list.
+  size_t size() const { return m_list.size(); }
+
+  // Adds a pointer to the end of the list.
+  void append(PointerType ptr) { m_list.push_back(ptr); }
 
 private:
 


### PR DESCRIPTION
This PR adds a new class, `FieldPropertyCheck`, that operates on a `Field`, checking to see whether it possesses a certain property (or set of properties), and returning `true` if so and `false` otherwise. A `FieldPropertyCheck` can also attempt to "repair" a `Field` so that it has the desired property or properties.

Additionally, we make it possible to add one or more `FieldPropertyCheck`s to a `Field`. The property checks are managed via shared pointers to make it less complicated for a number of fields to be checked for certain properties.

Finally, we add a `PointerList` type that manages pointers to types, making it possible to easily manipulate them with const- and non-const iterators, and not much else. We use this `PointerList` type to store pointers to the property checks for a `Field`.

I'm making this PR visible before adding unit tests for the property checks, to make sure I've not misunderstood something. That's why it's got the [WIP] tag.

## Property Checks Implemented

We've got three property checks coming in with this PR (and tested with unit tests):

1. A positivity check (`FieldPositivityCheck`): checks that all field values are positive. You can construct it with a lower bound if you want the check to be able to repair the field (and set all non-positive values to that lower bound).
2. A boundedness check (`FieldBoundednessCheck`): checks that all field values fall within [fmin, fmax]. Repairs fields by projecting all values outside that interval to their nearest endpoints.
3. A monotonicity check (`FieldMonotonicityCheck`): checks that a field is monotonically increasing or decreasing. This check can't repair a non-monotonic field without making some assumptions, so I didn't pick that fight.

Closes #566 