### PR TITLE
[WIP] port shoc_length

### DIFF
--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -47,6 +47,8 @@ if (NOT CUDA_BUILD)
     shoc_compute_conv_vel_shoc_length.cpp
     shoc_compute_l_inf_shoc_length.cpp
     shoc_diag_obklen.cpp
+    shoc_compute_conv_time_shoc_length.cpp
+    shoc_length.cpp
   ) # SHOC ETI SRCS
 endif()
 

--- a/components/scream/src/physics/shoc/shoc_compute_conv_time_shoc_length.cpp
+++ b/components/scream/src/physics/shoc/shoc_compute_conv_time_shoc_length.cpp
@@ -1,0 +1,13 @@
+#include "shoc_compute_conv_time_shoc_length_impl.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation using the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream

--- a/components/scream/src/physics/shoc/shoc_compute_conv_time_shoc_length_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_conv_time_shoc_length_impl.hpp
@@ -1,0 +1,37 @@
+#ifndef SHOC_COMPUTE_CONV_TIME_SHOC_LENGTH_IMPL_HPP
+#define SHOC_COMPUTE_CONV_TIME_SHOC_LENGTH_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Implementation of shoc compute_conv_time_shoc_length. Clients should NOT
+ * #include this file, but include shoc_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::compute_conv_time_shoc_length(
+  const Scalar& pblh,
+  Scalar&       conv_vel,
+  Scalar&       tscale)
+{
+  // Take the cubed root and avoid negative values
+  conv_vel = std::pow((conv_vel>0 ? conv_vel : 0), C::THIRD);
+
+  // Compute eddy turnover timescale. If convective
+  // velocity scale is zero then set to a minimum
+  // threshold (100).
+  if (conv_vel > 0) {
+      tscale = pblh/conv_vel;
+  } else {
+    tscale = 100;
+  }
+}
+
+} // namespace shoc
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -243,6 +243,30 @@ struct Functions
     Scalar&       ustar,
     Scalar&       kbfs,
     Scalar&       obklen);
+
+  KOKKOS_FUNCTION
+  static void compute_conv_time_shoc_length(
+    const Scalar& pblh,
+    Scalar&       conv_vel,
+    Scalar&       tscale);
+
+  KOKKOS_FUNCTION
+  static void shoc_length(
+    const MemberType&            team,
+    const Int&                   nlev,
+    const Int&                   nlevi,
+    const Scalar&                host_dx,
+    const Scalar&                host_dy,
+    const Scalar&                pblh,
+    const uview_1d<const Spack>& tke,
+    const uview_1d<const Spack>& zt_grid,
+    const uview_1d<const Spack>& zi_grid,
+    const uview_1d<const Spack>& dz_zt,
+    const uview_1d<const Spack>& wthv_sec,
+    const uview_1d<const Spack>& thv,
+    const uview_1d<Spack>&       thv_zi,
+    const uview_1d<Spack>&       brunt,
+    const uview_1d<Spack>&       shoc_mix);
 }; // struct Functions
 
 } // namespace shoc
@@ -271,6 +295,8 @@ struct Functions
 # include "shoc_check_length_scale_shoc_length_impl.hpp"
 # include "shoc_compute_conv_vel_shoc_length_impl.hpp"
 # include "shoc_diag_obklen_impl.hpp"
+# include "shoc_compute_conv_time_shoc_length_impl.hpp"
+# include "shoc_length_impl.hpp"
 #endif // KOKKOS_ENABLE_CUDA
 
 #endif

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -104,10 +104,10 @@ void eddy_diffusivities_c(Int nlev, Int shcol, Real *obklen, Real *pblh,
 void calc_shoc_vertflux_c(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
 			  Real *dz_zi, Real *invar, Real *vertflux);
 
-void shoc_length_c(Int shcol, Int nlev, Int nlevi, Real *tke, Real *host_dx,
-                   Real *host_dy, Real *pblh, Real *zt_grid, Real *zi_grid,
-                   Real *dz_zt, Real *dz_zi, Real *thetal, Real *wthv_sec,
-                   Real *thv, Real *brunt, Real *shoc_mix);
+void shoc_length_c(Int shcol, Int nlev, Int nlevi, Real* host_dx, Real* host_dy,
+                   Real* pblh, Real* tke, Real* zt_grid, Real* zi_grid, Real* dz_zt,
+                   Real* wthv_sec, Real* thv, Real* brunt,
+                   Real* shoc_mix);
 
 void compute_brunt_shoc_length_c(Int nlev, Int nlevi, Int shcol ,Real *dz_zt,
                                  Real *thv, Real *thv_zi, Real *brunt);
@@ -459,8 +459,8 @@ void eddy_diffusivities(SHOCEddydiffData &d) {
 void shoc_length(SHOCLengthData &d){
   shoc_init(d.nlev(), true);
   d.transpose<ekat::TransposeDirection::c2f>();
-  shoc_length_c(d.shcol(),d.nlev(),d.nlevi(),d.tke,d.host_dx,d.host_dy,
-                d.pblh,d.zt_grid,d.zi_grid,d.dz_zt,d.dz_zi,d.thetal,
+  shoc_length_c(d.shcol(),d.nlev(),d.nlevi(),d.host_dx,d.host_dy,
+                d.pblh,d.tke,d.zt_grid,d.zi_grid,d.dz_zt,
                 d.wthv_sec,d.thv,d.brunt,d.shoc_mix);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
@@ -1606,6 +1606,115 @@ void shoc_diag_obklen_f(Int shcol, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, R
   // Sync back to host
   Kokkos::Array<view_1d, 3> inout_views = {ustar_d, kbfs_d, obklen_d};
   ekat::device_to_host<int,3>({ustar, kbfs, obklen}, shcol, inout_views);
+}
+
+void compute_conv_time_shoc_length_f(Int shcol, Real* pblh, Real* conv_vel, Real* tscale)
+{
+  using SHF = Functions<Real, DefaultDevice>;
+
+  using Scalar     = typename SHF::Scalar;
+  using Pack1d     = typename ekat::Pack<Real,1>;
+  using view_1d    = typename SHF::view_1d<Pack1d>;
+  using KT         = typename SHF::KT;
+  using ExeSpace   = typename KT::ExeSpace;
+  using MemberType = typename SHF::MemberType;
+
+  Kokkos::Array<view_1d, 3> temp_d;
+  ekat::host_to_device({pblh, conv_vel, tscale}, shcol, temp_d);
+
+  view_1d
+    pblh_d(temp_d[0]),
+    conv_vel_d(temp_d[1]),
+    tscale_d(temp_d[2]);
+
+  Kokkos::parallel_for("compute_conv_time_shoc_length", shcol, KOKKOS_LAMBDA (const int& i) {
+     Scalar pblh_s{pblh_d(i)[0]};
+     Scalar conv_vel_s{conv_vel_d(i)[0]};
+     Scalar tscale_s{tscale_d(i)[0]};
+
+     SHF::compute_conv_time_shoc_length(pblh_s, conv_vel_s, tscale_s);
+
+     conv_vel_d(i)[0] = conv_vel_s;
+     tscale_d(i)[0] = tscale_s;
+   });
+
+  Kokkos::Array<view_1d, 2> inout_views = {conv_vel_d, tscale_d};
+  ekat::device_to_host<int, 2>({conv_vel, tscale}, shcol, inout_views);
+}
+
+void shoc_length_f(Int shcol, Int nlev, Int nlevi, Real* host_dx, Real* host_dy,
+                   Real* pblh, Real* tke, Real* zt_grid, Real* zi_grid, Real* dz_zt,
+                   Real* wthv_sec, Real* thv, Real* brunt,
+                   Real* shoc_mix)
+{
+  using SHF = Functions<Real, DefaultDevice>;
+
+  using Scalar     = typename SHF::Scalar;
+  using Spack      = typename SHF::Spack;
+  using Pack1d     = typename ekat::Pack<Real,1>;
+  using view_1d    = typename SHF::view_1d<Pack1d>;
+  using view_2d    = typename SHF::view_2d<Spack>;
+  using KT         = typename SHF::KT;
+  using ExeSpace   = typename KT::ExeSpace;
+  using MemberType = typename SHF::MemberType;
+
+  Kokkos::Array<view_1d, 3> temp_1d_d;
+  Kokkos::Array<view_2d, 8> temp_2d_d;
+  Kokkos::Array<int, 8> dim1_sizes = {shcol, shcol, shcol, shcol,
+                                      shcol, shcol, shcol, shcol};
+  Kokkos::Array<int, 8> dim2_sizes = {nlev, nlev, nlevi, nlev,
+                                      nlev, nlev, nlev, nlev};
+  Kokkos::Array<const Real*, 8> ptr_array = {tke, zt_grid, zi_grid, dz_zt,
+                                             wthv_sec, thv, brunt, shoc_mix};
+
+  // Sync to device
+  ekat::host_to_device({host_dx, host_dy, pblh}, shcol, temp_1d_d);
+  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d_d, true);
+
+  view_1d
+    host_dx_d(temp_1d_d[0]),
+    host_dy_d(temp_1d_d[1]),
+    pblh_d(temp_1d_d[2]);
+
+  view_2d
+    tke_d(temp_2d_d[0]),
+    zt_grid_d(temp_2d_d[1]),
+    zi_grid_d(temp_2d_d[2]),
+    dz_zt_d(temp_2d_d[3]),
+    wthv_sec_d(temp_2d_d[4]),
+    thv_d(temp_2d_d[5]),
+    brunt_d(temp_2d_d[6]),
+    shoc_mix_d(temp_2d_d[7]);
+
+  // Local variable
+  view_2d thv_zi_d("thv_zi", shcol, ekat::npack<Spack>(nlevi));
+
+  const Int nk_pack = ekat::npack<Spack>(nlev);
+  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+    const Int i = team.league_rank();
+
+    const Scalar host_dx_s{host_dx_d(i)[0]};
+    const Scalar host_dy_s{host_dy_d(i)[0]};
+    const Scalar pblh_s{pblh_d(i)[0]};
+
+    const auto tke_s = ekat::subview(tke_d, i);
+    const auto zt_grid_s = ekat::subview(zt_grid_d, i);
+    const auto zi_grid_s = ekat::subview(zi_grid_d, i);
+    const auto dz_zt_s = ekat::subview(dz_zt_d, i);
+    const auto wthv_sec_s = ekat::subview(wthv_sec_d, i);
+    const auto thv_s = ekat::subview(thv_d, i);
+    const auto thv_zi_s = ekat::subview(thv_zi_d, i);
+    const auto brunt_s = ekat::subview(brunt_d, i);
+    const auto shoc_mix_s = ekat::subview(shoc_mix_d, i);
+
+    SHF::shoc_length(team, nlev, nlevi, host_dx_s, host_dy_s, pblh_s, tke_s, zt_grid_s, zi_grid_s, dz_zt_s,
+                     wthv_sec_s, thv_s, thv_zi_s, brunt_s, shoc_mix_s);
+  });
+
+  // Sync back to host
+  Kokkos::Array<view_2d, 2> inout_views = {brunt_d, shoc_mix_d};
+  ekat::device_to_host<int, 2>({brunt, shoc_mix}, shcol, nlev, inout_views, true);
 }
 
 } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -376,14 +376,14 @@ struct SHOCVarorcovarData : public PhysicsTestData {
 //Create data structure to hold data for shoc_length
 struct SHOCLengthData : public PhysicsTestData {
   // Inputs
-  Real *tke, *host_dx, *host_dy, *pblh, *zt_grid, *zi_grid;
-  Real *dz_zt, *dz_zi, *wthv_sec, *thetal, *thv;
+  Real *host_dx, *host_dy, *pblh, *tke, *zt_grid, *zi_grid;
+  Real *dz_zt, *wthv_sec, *thv;
 
   // Outputs
   Real *brunt, *shoc_mix;
 
   SHOCLengthData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData(shcol_, nlev_, nlevi_, {&tke, &zt_grid, &dz_zt, &wthv_sec, &thetal, &thv, &brunt, &shoc_mix}, {&zi_grid, &dz_zi}, {&host_dx, &host_dy, &pblh}) {}
+    PhysicsTestData(shcol_, nlev_, nlevi_, {&tke, &zt_grid, &dz_zt, &wthv_sec, &thv, &brunt, &shoc_mix}, {&zi_grid}, {&host_dx, &host_dy, &pblh}) {}
 
   SHOC_NO_SCALAR(SHOCLengthData, 3);
 };//SHOCLengthData
@@ -914,6 +914,10 @@ void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Re
 void shoc_diag_obklen_f(Int shcol, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, Real* wqw_sfc,
                         Real* thl_sfc, Real* cldliq_sfc, Real* qv_sfc, Real* ustar, Real* kbfs, Real* obklen);
 
+void compute_conv_time_shoc_length_f(Int shcol, Real* pblh, Real* conv_vel, Real* tscale);
+void shoc_length_f(Int shcol, Int nlev, Int nlevi, Real* host_dx, Real* host_dy,
+                   Real* pblh, Real* tke, Real* zt_grid, Real* zi_grid, Real* dz_zt,
+                   Real* wthv_sec, Real* thv, Real* brunt, Real* shoc_mix);
 } // end _f function decls
 
 }  // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -562,31 +562,29 @@ contains
 
   end subroutine calc_shoc_vertflux_c
 
-  subroutine shoc_length_c(shcol, nlev, nlevi, tke, host_dx, host_dy, pblh, &
-                zt_grid, zi_grid, dz_zt, dz_zi, thetal, wthv_sec, thv, &
+  subroutine shoc_length_c(shcol, nlev, nlevi, host_dx, host_dy, pblh, tke, &
+                zt_grid, zi_grid, dz_zt, wthv_sec, thv, &
 		brunt, shoc_mix) bind (C)
     use shoc, only: shoc_length
 
     integer(kind=c_int), intent(in), value :: shcol
     integer(kind=c_int), intent(in), value :: nlev
     integer(kind=c_int), intent(in), value :: nlevi
-    real(kind=c_real), intent(in) :: tke(shcol,nlev)
     real(kind=c_real), intent(in) :: host_dx(shcol)
     real(kind=c_real), intent(in) :: host_dy(shcol)
     real(kind=c_real), intent(in) :: pblh(shcol)
+    real(kind=c_real), intent(in) :: tke(shcol,nlev)
     real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
     real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
     real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
-    real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: wthv_sec(shcol,nlev)
-    real(kind=c_real), intent(in) :: thetal(shcol,nlev)
     real(kind=c_real), intent(in) :: thv(shcol,nlev)
 
     real(kind=c_real), intent(out) :: brunt(shcol,nlev)
     real(kind=c_real), intent(out) :: shoc_mix(shcol,nlev)
 
-    call shoc_length(shcol, nlev, nlevi, tke, host_dx, host_dy, pblh, &
-                zt_grid, zi_grid, dz_zt, dz_zi, thetal, wthv_sec, thv, &
+    call shoc_length(shcol, nlev, nlevi, host_dx, host_dy, pblh, tke, &
+                zt_grid, zi_grid, dz_zt, wthv_sec, thv, &
 		brunt, shoc_mix)
 
   end subroutine shoc_length_c

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -274,6 +274,31 @@ subroutine shoc_diag_obklen_f(shcol, uw_sfc, vw_sfc, wthl_sfc, wqw_sfc, thl_sfc,
 
 end subroutine shoc_diag_obklen_f
 
+subroutine compute_conv_time_shoc_length_f(shcol, pblh, conv_vel, tscale) bind(C)
+
+  use iso_c_binding
+
+  integer(kind=c_int) , value, intent(in) :: shcol
+  real(kind=c_real) , intent(in), dimension(shcol) :: pblh
+  real(kind=c_real) , intent(inout), dimension(shcol) :: conv_vel, tscale
+
+end subroutine compute_conv_time_shoc_length_f
+
+subroutine shoc_length_f(shcol, nlev, nlevi, host_dx, host_dy, pblh, tke,&
+                         zt_grid, zi_grid, dz_zt, wthv_sec,&
+                         thv, brunt, shoc_mix) bind(C)
+  use iso_c_binding
+
+  integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi
+
+  real(kind=c_real) , intent(in), dimension(shcol) :: host_dx, host_dy, pblh
+
+  real(kind=c_real) , intent(in), dimension(shcol, nlev) :: tke, zt_grid, dz_zt, wthv_sec, thv
+  real(kind=c_real) , intent(in), dimension(shcol, nlevi) :: zi_grid
+  real(kind=c_real) , intent(out), dimension(shcol, nlev) :: brunt, shoc_mix
+
+end subroutine shoc_length_f
+
 end interface
 
 end module shoc_iso_f

--- a/components/scream/src/physics/shoc/shoc_length.cpp
+++ b/components/scream/src/physics/shoc/shoc_length.cpp
@@ -1,0 +1,13 @@
+#include "shoc_length_impl.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation using the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream

--- a/components/scream/src/physics/shoc/shoc_length_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_length_impl.hpp
@@ -36,6 +36,7 @@ void Functions<S,D>::shoc_length(
 
   // Interpolate virtual potential temperature onto interface grid
   linear_interp(team,zt_grid,zi_grid,thv,thv_zi,nlev,nlevi,0);
+  team.team_barrier();
 
   // Define the brunt vaisalia frequency
   compute_brunt_shoc_length(team,nlev,nlevi,dz_zt,thv,thv_zi,brunt);

--- a/components/scream/src/physics/shoc/shoc_length_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_length_impl.hpp
@@ -1,0 +1,65 @@
+#ifndef SHOC_LENGTH_IMPL_HPP
+#define SHOC_LENGTH_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+#include <iomanip>
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Implementation of shoc shoc_length. Clients should NOT
+ * #include this file, but include shoc_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::shoc_length(
+  const MemberType&            team,
+  const Int&                   nlev,
+  const Int&                   nlevi,
+  const Scalar&                host_dx,
+  const Scalar&                host_dy,
+  const Scalar&                pblh,
+  const uview_1d<const Spack>& tke,
+  const uview_1d<const Spack>& zt_grid,
+  const uview_1d<const Spack>& zi_grid,
+  const uview_1d<const Spack>& dz_zt,
+  const uview_1d<const Spack>& wthv_sec,
+  const uview_1d<const Spack>& thv,
+  const uview_1d<Spack>&       thv_zi,
+  const uview_1d<Spack>&       brunt,
+  const uview_1d<Spack>&       shoc_mix)
+{
+  // Compute the SHOC mixing length scale, which is used to
+  // compute the turbulent dissipation in the SGS TKE equation
+
+  // Interpolate virtual potential temperature onto interface grid
+  linear_interp(team,zt_grid,zi_grid,thv,thv_zi,nlev,nlevi,0);
+
+  // Define the brunt vaisalia frequency
+  compute_brunt_shoc_length(team,nlev,nlevi,dz_zt,thv,thv_zi,brunt);
+
+  // Find l_inf
+  Scalar l_inf = 0;
+  compute_l_inf_shoc_length(team,nlev,zt_grid,dz_zt,tke,l_inf);
+
+  // Determine the convective velocity scale of the planetary boundary layer
+  Scalar conv_vel = 0;
+  compute_conv_vel_shoc_length(team,nlev,pblh,zt_grid,dz_zt,thv,wthv_sec,conv_vel);
+
+  // Compute cubed root of conv_vel and compute eddy turnover timescale.
+  Scalar tscale = 0;
+  compute_conv_time_shoc_length(pblh,conv_vel,tscale);
+
+  // Compute mixing-length
+  compute_shoc_mix_shoc_length(team,nlev,tke,brunt,tscale,zt_grid,l_inf,shoc_mix);
+
+  // Do checks on the length scale.
+  check_length_scale_shoc_length(team,nlev,host_dx,host_dy,shoc_mix);
+}
+
+} // namespace shoc
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/shoc/tests/shoc_conv_time_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_conv_time_length_tests.cpp
@@ -168,7 +168,55 @@ struct UnitWrap::UnitTest<D>::TestCompShocConvTime {
 
   static void run_bfb()
   {
-    // TODO
+    SHOCConvtimeData SDS_f90[] = {
+      //             shcol
+      SHOCConvtimeData(12),
+      SHOCConvtimeData(10),
+      SHOCConvtimeData(7),
+      SHOCConvtimeData(2)
+    };
+
+    static constexpr Int num_runs = sizeof(SDS_f90) / sizeof(SHOCConvtimeData);
+
+    // Generate random input data
+    for (auto& d : SDS_f90) {
+      d.randomize();
+    }
+
+    // Create copies of data for use by cxx. Needs to happen before fortran calls so that
+    // inout data is in original state
+    SHOCConvtimeData SDS_cxx[] = {
+      SHOCConvtimeData(SDS_f90[0]),
+      SHOCConvtimeData(SDS_f90[1]),
+      SHOCConvtimeData(SDS_f90[2]),
+      SHOCConvtimeData(SDS_f90[3])
+    };
+
+    // Assume all data is in C layout
+
+    // Get data from fortran
+    for (auto& d : SDS_f90) {
+      // expects data in C layout
+      compute_conv_time_shoc_length(d);
+    }
+
+    // Get data from cxx
+    for (auto& d : SDS_cxx) {
+      d.transpose<ekat::TransposeDirection::c2f>();
+      // expects data in fortran layout
+      compute_conv_time_shoc_length_f(d.shcol(),d.pblh,d.conv_vel,d.tscale);
+      d.transpose<ekat::TransposeDirection::f2c>();
+    }
+
+    // Verify BFB results, all data should be in C layout
+    for (Int i = 0; i < num_runs; ++i) {
+      SHOCConvtimeData& d_f90 = SDS_f90[i];
+      SHOCConvtimeData& d_cxx = SDS_cxx[i];
+      for (Int s = 0; s < d_f90.dim1; ++s) {
+        REQUIRE(d_f90.conv_vel[s] == d_cxx.conv_vel[s]);
+        REQUIRE(d_f90.tscale[s] == d_cxx.tscale[s]);
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Ports `shoc_length` and `compute_conv_time_shoc_length` to C++.

In `shoc_length`, I have rearranged inputs in F90 (C++ had different order than F90, I chose to match to C++). Also, `dz_zi` and `thetal` were unused and so I removed them.