### PR TITLE
Change minthresh of a liner_interp call

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1542,7 +1542,7 @@ subroutine diag_third_shoc_moments(&
   call linear_interp(zt_grid,zi_grid,isotropy,isotropy_zi,nlev,nlevi,shcol,0._rtype)
   call linear_interp(zt_grid,zi_grid,brunt,brunt_zi,nlev,nlevi,shcol,largeneg)
   call linear_interp(zt_grid,zi_grid,w_sec,w_sec_zi,nlev,nlevi,shcol,(2._rtype/3._rtype)*mintke)
-  call linear_interp(zt_grid,zi_grid,thetal,thetal_zi,nlev,nlevi,shcol,0._rtype)
+  call linear_interp(zt_grid,zi_grid,thetal,thetal_zi,nlev,nlevi,shcol,tiny)
   call linear_interp(zt_grid,zi_grid,wthv_sec,wthv_sec_zi,nlev,nlevi,shcol,largeneg)
 
   !Diagnose the third moment of the vertical-velocity


### PR DESCRIPTION
I'm porting `diag_third_shoc_moments`, and ran across this bug when doing randomized testing. Since `thetal_zi` will be used in `clipping_diag_third_shoc_moments` as `bet2 = ggr/thetal_zi`, then `thetal_zi != 0`.  