### PR TITLE
port diag_third_shoc_moments

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -428,9 +428,9 @@ subroutine shoc_main ( &
     !  needed for the PDF closure
     call diag_third_shoc_moments(&
        shcol,nlev,nlevi,&                   ! Input
-       w_sec,thl_sec,qw_sec,qwthl_sec,&     ! Input
+       w_sec,thl_sec,&                      ! Input
        wthl_sec,isotropy,brunt,&            ! Input
-       thetal,tke,wthv_sec,&                ! Input
+       thetal,tke,&                         ! Input
        dz_zt,dz_zi,zt_grid,zi_grid,&        ! Input
        w3)                                  ! Output
 
@@ -1563,9 +1563,9 @@ end subroutine diag_second_moments_ubycond
 
 subroutine diag_third_shoc_moments(&
           shcol,nlev,nlevi, &                 ! Input
-          w_sec, thl_sec, qw_sec, qwthl_sec,& ! Input
+          w_sec, thl_sec, &                   ! Input
           wthl_sec, isotropy, brunt,&         ! Input
-          thetal,tke,wthv_sec,&               ! Input
+          thetal,tke,&                        ! Input
           dz_zt, dz_zi, zt_grid, zi_grid,&    ! Input
           w3)                                 ! Output
 
@@ -1588,10 +1588,6 @@ subroutine diag_third_shoc_moments(&
   real(rtype), intent(in) :: w_sec(shcol,nlev)
   ! second order liquid wat. potential temperature [K^2]
   real(rtype), intent(in) :: thl_sec(shcol,nlevi)
-  ! second order total water mixing ratio [kg2/kg2]
-  real(rtype), intent(in) :: qw_sec(shcol,nlevi)
-  ! covariance of temp and moisture [K kg/kg]
-  real(rtype), intent(in) :: qwthl_sec(shcol,nlevi)
   ! vertical flux of heat [K m/s]
   real(rtype), intent(in) :: wthl_sec(shcol,nlevi)
   ! return to isotropy timescale [s]
@@ -1602,8 +1598,6 @@ subroutine diag_third_shoc_moments(&
   real(rtype), intent(in) :: thetal(shcol,nlev)
   ! turbulent kinetic energy [m2/s2]
   real(rtype), intent(in) :: tke(shcol,nlev)
-  ! buoyancy flux [K m/s]
-  real(rtype), intent(in) :: wthv_sec(shcol,nlev)
   ! thickness centered on thermodynamic grid [m]
   real(rtype), intent(in) :: dz_zt(shcol,nlev)
   ! thickness centered on interface grid [m]
@@ -1622,14 +1616,12 @@ subroutine diag_third_shoc_moments(&
   real(rtype) :: isotropy_zi(shcol,nlevi)
   real(rtype) :: brunt_zi(shcol,nlevi)
   real(rtype) :: thetal_zi(shcol,nlevi)
-  real(rtype) :: wthv_sec_zi(shcol,nlevi)
 
   ! Interpolate variables onto the interface levels
   call linear_interp(zt_grid,zi_grid,isotropy,isotropy_zi,nlev,nlevi,shcol,0._rtype)
   call linear_interp(zt_grid,zi_grid,brunt,brunt_zi,nlev,nlevi,shcol,largeneg)
   call linear_interp(zt_grid,zi_grid,w_sec,w_sec_zi,nlev,nlevi,shcol,(2._rtype/3._rtype)*mintke)
   call linear_interp(zt_grid,zi_grid,thetal,thetal_zi,nlev,nlevi,shcol,0._rtype)
-  call linear_interp(zt_grid,zi_grid,wthv_sec,wthv_sec_zi,nlev,nlevi,shcol,largeneg)
 
   !Diagnose the third moment of the vertical-velocity
   call compute_diag_third_shoc_moment(&

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -1574,6 +1574,10 @@ subroutine diag_third_shoc_moments(&
   !  for the skewness calculation in the PDF.
   !  This calculation follows that of Canuto et al. (2001)
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    use shoc_iso_f, only: diag_third_shoc_moments_f
+#endif
+
   implicit none
 
 ! INPUT VARIABLES
@@ -1616,6 +1620,19 @@ subroutine diag_third_shoc_moments(&
   real(rtype) :: isotropy_zi(shcol,nlevi)
   real(rtype) :: brunt_zi(shcol,nlevi)
   real(rtype) :: thetal_zi(shcol,nlevi)
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  if (use_cxx) then
+      call diag_third_shoc_moments_f(&
+        shcol,nlev,nlevi, &                 ! Input
+        w_sec, thl_sec, &                   ! Input
+        wthl_sec, isotropy, brunt,&         ! Input
+        thetal,tke,&                        ! Input
+        dz_zt, dz_zi, zt_grid, zi_grid,&    ! Input
+        w3)                                 ! Output
+     return
+  endif
+#endif
 
   ! Interpolate variables onto the interface levels
   call linear_interp(zt_grid,zi_grid,isotropy,isotropy_zi,nlev,nlevi,shcol,0._rtype)

--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -54,6 +54,7 @@ if (NOT CUDA_BUILD)
     shoc_energy_fixer.cpp
     shoc_compute_shoc_vapor.cpp
     shoc_update_prognostics_implicit.cpp
+    shoc_diag_third_shoc_moments.cpp
   ) # SHOC ETI SRCS
 endif()
 

--- a/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
@@ -113,7 +113,8 @@ void Functions<S,D>
     w3(k).set(range_pack1 > 0 && range_pack1 < nlev,
               (aa1-sp(1.2)*x1-sp(1.5)*f5)/(Spack(c_diag_3rd_mom)-sp(1.2)*x0+aa0));
   });
-
+  team.team_barrier();
+  
   // Set upper condition: w3(i,0) = 0
   w3(0)[0] = 0;
 }

--- a/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
@@ -113,7 +113,6 @@ void Functions<S,D>
     w3(k).set(range_pack1 > 0 && range_pack1 < nlev,
               (aa1-sp(1.2)*x1-sp(1.5)*f5)/(Spack(c_diag_3rd_mom)-sp(1.2)*x0+aa0));
   });
-  team.team_barrier();
   
   // Set upper condition: w3(i,0) = 0
   w3(0)[0] = 0;

--- a/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
@@ -113,7 +113,7 @@ void Functions<S,D>
     w3(k).set(range_pack1 > 0 && range_pack1 < nlev,
               (aa1-sp(1.2)*x1-sp(1.5)*f5)/(Spack(c_diag_3rd_mom)-sp(1.2)*x0+aa0));
   });
-  
+
   // Set upper condition: w3(i,0) = 0
   w3(0)[0] = 0;
 }

--- a/components/scream/src/physics/shoc/shoc_constants.hpp
+++ b/components/scream/src/physics/shoc/shoc_constants.hpp
@@ -11,15 +11,16 @@ namespace scream {
 template <typename Scalar>
 struct Constants
     {
-      static constexpr Scalar mintke         = 0.0004;  // Minimum TKE [m2/s2]
-      static constexpr Scalar maxtke         = 50.0;    // Maximum TKE [m2/s2]
-      static constexpr Scalar minlen         = 20.0;    // Lower limit for mixing length [m]
-      static constexpr Scalar maxlen         = 20000.0; // Upper limit for mixing length [m]
-      static constexpr Scalar maxiso         = 20000.0; // Upper limit for isotropy time scale [s]
-      static constexpr Scalar length_fac     = 0.5;     // Mixing length scaling parameter
-      static constexpr Scalar c_diag_3rd_mom = 7.0;     // Coefficient for diag third moment parameters
-      static constexpr Scalar w3clip         = 1.2;     // Third moment of vertical velocity
-      static constexpr Scalar ustar_min      = 0.01;    // Minimum surface friction velocity
+      static constexpr Scalar mintke         = 0.0004;       // Minimum TKE [m2/s2]
+      static constexpr Scalar maxtke         = 50.0;         // Maximum TKE [m2/s2]
+      static constexpr Scalar minlen         = 20.0;         // Lower limit for mixing length [m]
+      static constexpr Scalar maxlen         = 20000.0;      // Upper limit for mixing length [m]
+      static constexpr Scalar maxiso         = 20000.0;      // Upper limit for isotropy time scale [s]
+      static constexpr Scalar length_fac     = 0.5;          // Mixing length scaling parameter
+      static constexpr Scalar c_diag_3rd_mom = 7.0;          // Coefficient for diag third moment parameters
+      static constexpr Scalar w3clip         = 1.2;          // Third moment of vertical velocity
+      static constexpr Scalar ustar_min      = 0.01;         // Minimum surface friction velocity
+      static constexpr Scalar largeneg       = -99999999.99; // Large negative value used for linear_interp threshold
     };
 
   } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments.cpp
+++ b/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments.cpp
@@ -1,0 +1,13 @@
+#include "shoc_diag_third_shoc_moments_impl.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation for using the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream

--- a/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments_impl.hpp
@@ -41,7 +41,7 @@ void Functions<S,D>::diag_third_shoc_moments(
   // Interpolate variables onto the interface levels
   linear_interp(team,zt_grid,zi_grid,isotropy,isotropy_zi,nlev,nlevi,0);
   linear_interp(team,zt_grid,zi_grid,brunt,brunt_zi,nlev,nlevi,largeneg);
-  linear_interp(team,zt_grid,zi_grid,w_sec,w_sec_zi,nlev,nlevi,(2.0/3.0)*mintke);
+  linear_interp(team,zt_grid,zi_grid,w_sec,w_sec_zi,nlev,nlevi,sp(2.0/3.0)*mintke);
   linear_interp(team,zt_grid,zi_grid,thetal,thetal_zi,nlev,nlevi,0);
   team.team_barrier();
 

--- a/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments_impl.hpp
@@ -49,6 +49,7 @@ void Functions<S,D>::diag_third_shoc_moments(
   compute_diag_third_shoc_moment(team,nlev,nlevi,w_sec,thl_sec,wthl_sec,
                                  tke, dz_zt, dz_zi,isotropy_zi, brunt_zi,
                                  w_sec_zi,thetal_zi,w3);
+  team.team_barrier();
 
   // Perform clipping to prevent unrealistically large values from occuring
   clipping_diag_third_shoc_moments(team,nlevi,w_sec_zi,w3);

--- a/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments_impl.hpp
@@ -1,0 +1,61 @@
+#ifndef SHOC_DIAG_THIRD_SHOC_MOMENTS_IMPL_HPP
+#define SHOC_DIAG_THIRD_SHOC_MOMENTS_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Implementation of shoc diag_third_shoc_moments. Clients should NOT
+ * #include this file, but include shoc_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::diag_third_shoc_moments(
+  const MemberType&            team,
+  const Int&                   nlev,
+  const Int&                   nlevi,
+  const uview_1d<const Spack>& w_sec,
+  const uview_1d<const Spack>& thl_sec,
+  const uview_1d<const Spack>& wthl_sec,
+  const uview_1d<const Spack>& isotropy,
+  const uview_1d<const Spack>& brunt,
+  const uview_1d<const Spack>& thetal,
+  const uview_1d<const Spack>& tke,
+  const uview_1d<const Spack>& dz_zt,
+  const uview_1d<const Spack>& dz_zi,
+  const uview_1d<const Spack>& zt_grid,
+  const uview_1d<const Spack>& zi_grid,
+  const uview_1d<Spack>&       w_sec_zi,
+  const uview_1d<Spack>&       isotropy_zi,
+  const uview_1d<Spack>&       brunt_zi,
+  const uview_1d<Spack>&       thetal_zi,
+  const uview_1d<Spack>&       w3)
+{
+  // Constants
+  const auto largeneg = SC::largeneg;
+  const auto mintke = SC::mintke;
+
+  // Interpolate variables onto the interface levels
+  linear_interp(team,zt_grid,zi_grid,isotropy,isotropy_zi,nlev,nlevi,0);
+  linear_interp(team,zt_grid,zi_grid,brunt,brunt_zi,nlev,nlevi,largeneg);
+  linear_interp(team,zt_grid,zi_grid,w_sec,w_sec_zi,nlev,nlevi,(2.0/3.0)*mintke);
+  linear_interp(team,zt_grid,zi_grid,thetal,thetal_zi,nlev,nlevi,0);
+  team.team_barrier();
+
+  //Diagnose the third moment of the vertical-velocity
+  compute_diag_third_shoc_moment(team,nlev,nlevi,w_sec,thl_sec,wthl_sec,
+                                 tke, dz_zt, dz_zi,isotropy_zi, brunt_zi,
+                                 w_sec_zi,thetal_zi,w3);
+  team.team_barrier();
+
+  // Perform clipping to prevent unrealistically large values from occuring
+  clipping_diag_third_shoc_moments(team,nlevi,w_sec_zi,w3);
+}
+
+} // namespace shoc
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments_impl.hpp
@@ -49,7 +49,6 @@ void Functions<S,D>::diag_third_shoc_moments(
   compute_diag_third_shoc_moment(team,nlev,nlevi,w_sec,thl_sec,wthl_sec,
                                  tke, dz_zt, dz_zi,isotropy_zi, brunt_zi,
                                  w_sec_zi,thetal_zi,w3);
-  team.team_barrier();
 
   // Perform clipping to prevent unrealistically large values from occuring
   clipping_diag_third_shoc_moments(team,nlevi,w_sec_zi,w3);

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -303,11 +303,35 @@ struct Functions
     const uview_1d<const Spack>& pint,
     const uview_1d<Spack>&       rho_zi,
     const uview_1d<Spack>&       host_dse);
+
   KOKKOS_FUNCTION
   static void compute_shoc_vapor(const Int& shcol, const Int& nlev, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& ql, const uview_1d<Spack>& qv);
-  KOKKOS_FUNCTION
+
   KOKKOS_FUNCTION
   static void update_prognostics_implicit(const Int& shcol, const Int& nlev, const Int& nlevi, const Int& num_tracer, const Spack& dtime, const uview_1d<const Spack>& dz_zt, const uview_1d<const Spack>& dz_zi, const uview_1d<const Spack>& rho_zt, const uview_1d<const Spack>& zt_grid, const uview_1d<const Spack>& zi_grid, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& uw_sfc, const uview_1d<const Spack>& vw_sfc, const uview_1d<const Spack>& wthl_sfc, const uview_1d<const Spack>& wqw_sfc, const uview_1d<const Spack>& wtracer_sfc, const uview_1d<Spack>& thetal, const uview_1d<Spack>& qw, const uview_1d<Spack>& tracer, const uview_1d<Spack>& tke, const uview_1d<Spack>& u_wind, const uview_1d<Spack>& v_wind);
+
+  KOKKOS_FUNCTION
+  static void diag_third_shoc_moments(
+    const MemberType&            team,
+    const Int&                   nlev,
+    const Int&                   nlevi,
+    const uview_1d<const Spack>& w_sec,
+    const uview_1d<const Spack>& thl_sec,
+    const uview_1d<const Spack>& wthl_sec,
+    const uview_1d<const Spack>& isotropy,
+    const uview_1d<const Spack>& brunt,
+    const uview_1d<const Spack>& thetal,
+    const uview_1d<const Spack>& tke,
+    const uview_1d<const Spack>& dz_zt,
+    const uview_1d<const Spack>& dz_zi,
+    const uview_1d<const Spack>& zt_grid,
+    const uview_1d<const Spack>& zi_grid,
+    const uview_1d<Spack>&       w_sec_zi,
+    const uview_1d<Spack>&       isotropy_zi,
+    const uview_1d<Spack>&       brunt_zi,
+    const uview_1d<Spack>&       thetal_zi,
+    const uview_1d<Spack>&       w3);
+
 }; // struct Functions
 
 } // namespace shoc
@@ -338,10 +362,11 @@ struct Functions
 # include "shoc_diag_obklen_impl.hpp"
 # include "shoc_pblintd_cldcheck_impl.hpp"
 # include "shoc_compute_conv_time_shoc_length_impl.hpp"
-#include "shoc_length_impl.hpp"
+# include "shoc_length_impl.hpp"
 # include "shoc_energy_fixer_impl.hpp"
 # include "shoc_compute_shoc_vapor_impl.hpp"
 # include "shoc_update_prognostics_implicit_impl.hpp"
+# include "shoc_diag_third_shoc_moments_impl.hpp"
 #endif // KOKKOS_ENABLE_CUDA
 
 #endif

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -159,9 +159,9 @@ void shoc_diag_second_moments_srf_c(Int shcol, Real* wthl_sfc, Real* uw_sfc, Rea
                                    Real* ustar2, Real* wstar);
 
 void diag_third_shoc_moments_c(Int shoc, Int nlev, Int nlevi, Real *w_sec,
-                               Real *thl_sec, Real *qw_sec, Real *qwthl_sec,
+                               Real *thl_sec,
                                Real *wthl_sec, Real *isotropy, Real *brunt,
-                               Real *thetal, Real *tke, Real *wthv_sec,
+                               Real *thetal, Real *tke,
                                Real *dz_zt, Real *dz_zi, Real *zt_grid,
                                Real *zi_grid, Real *w3);
 
@@ -575,9 +575,9 @@ void shoc_diag_second_moments_srf(SHOCSecondMomentSrfData& d)
 void diag_third_shoc_moments(SHOCDiagThirdMomData &d) {
   shoc_init(d.nlev(), true);
   d.transpose<ekat::TransposeDirection::c2f>();
-  diag_third_shoc_moments_c(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,d.qw_sec,
-                            d.qwthl_sec,d.wthl_sec,d.isotropy,d.brunt,d.thetal,
-                            d.tke,d.wthv_sec,d.dz_zt,d.dz_zi,d.zt_grid,d.zi_grid,
+  diag_third_shoc_moments_c(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,
+                            d.wthl_sec,d.isotropy,d.brunt,d.thetal,
+                            d.tke,d.dz_zt,d.dz_zi,d.zt_grid,d.zi_grid,
                             d.w3);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
@@ -1942,9 +1942,93 @@ void compute_shoc_vapor_f(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv)
 {
   // TODO
 }
+
 void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_tracer, Real dtime, Real* dz_zt, Real* dz_zi, Real* rho_zt, Real* zt_grid, Real* zi_grid, Real* tk, Real* tkh, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, Real* wqw_sfc, Real* wtracer_sfc, Real* thetal, Real* qw, Real* tracer, Real* tke, Real* u_wind, Real* v_wind)
 {
   // TODO
 }
+
+void diag_third_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* w_sec, Real* thl_sec,
+                               Real* wthl_sec, Real* isotropy, Real* brunt, Real* thetal,
+                               Real* tke, Real* dz_zt, Real* dz_zi, Real* zt_grid, Real* zi_grid,
+                               Real* w3)
+{
+  using SHF = Functions<Real, DefaultDevice>;
+
+  using Spack      = typename SHF::Spack;
+  using view_2d    = typename SHF::view_2d<Spack>;
+  using KT         = typename SHF::KT;
+  using ExeSpace   = typename KT::ExeSpace;
+  using MemberType = typename SHF::MemberType;
+
+  Kokkos::Array<view_2d, 12> temp_d;
+  Kokkos::Array<int, 12> dim1_sizes = {shcol, shcol, shcol, shcol,
+                                       shcol, shcol, shcol, shcol,
+                                       shcol, shcol, shcol, shcol};
+  Kokkos::Array<int, 12> dim2_sizes = {nlev, nlevi, nlevi,  nlev,
+                                       nlev,  nlev,  nlev,  nlev,
+                                       nlevi, nlev,  nlevi, nlevi};
+  Kokkos::Array<const Real*, 12> ptr_array = {w_sec, thl_sec, wthl_sec, isotropy,
+                                              brunt, thetal,  tke,      dz_zt,
+                                              dz_zi, zt_grid, zi_grid,  w3};
+
+  // Sync to device
+  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+
+  view_2d
+    wsec_d(temp_d[0]),
+    thl_sec_d(temp_d[1]),
+    wthl_sec_d(temp_d[2]),
+    isotropy_d(temp_d[3]),
+    brunt_d(temp_d[4]),
+    thetal_d(temp_d[5]),
+    tke_d(temp_d[6]),
+    dz_zt_d(temp_d[7]),
+    dz_zi_d(temp_d[8]),
+    zt_grid_d(temp_d[9]),
+    zi_grid_d(temp_d[10]),
+    w3_d(temp_d[11]);
+
+  // Local variables
+  const Int nk_pack_nlevi = ekat::npack<Spack>(nlevi);
+  view_2d w_sec_zi_d("w_sec_zi", shcol, nk_pack_nlevi);
+  view_2d isotropy_zi_d("isotropy_zi", shcol, nk_pack_nlevi);
+  view_2d brunt_zi_d("brunt_zi", shcol, nk_pack_nlevi);
+  view_2d thetal_zi_d("thetal_zi", shcol, nk_pack_nlevi);
+
+  const Int nk_pack = ekat::npack<Spack>(nlev);
+  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+    const Int i = team.league_rank();
+
+    const auto wsec_s = ekat::subview(wsec_d, i);
+    const auto thl_sec_s = ekat::subview(thl_sec_d, i);
+    const auto wthl_sec_s = ekat::subview(wthl_sec_d, i);
+    const auto isotropy_s = ekat::subview(isotropy_d, i);
+    const auto brunt_s = ekat::subview(brunt_d, i);
+    const auto thetal_s = ekat::subview(thetal_d, i);
+    const auto tke_s = ekat::subview(tke_d, i);
+    const auto dz_zt_s = ekat::subview(dz_zt_d, i);
+    const auto dz_zi_s = ekat::subview(dz_zi_d, i);
+    const auto zt_grid_s = ekat::subview(zt_grid_d, i);
+    const auto zi_grid_s = ekat::subview(zi_grid_d, i);
+    const auto w_sec_zi_s = ekat::subview(w_sec_zi_d, i);
+    const auto isotropy_zi_s = ekat::subview(isotropy_zi_d, i);
+    const auto brunt_zi_s = ekat::subview(brunt_zi_d, i);
+    const auto thetal_zi_s = ekat::subview(thetal_zi_d, i);
+    const auto w3_s = ekat::subview(w3_d, i);
+
+    SHF::diag_third_shoc_moments(team, nlev, nlevi, wsec_s, thl_sec_s,
+                                 wthl_sec_s, isotropy_s, brunt_s, thetal_s, tke_s,
+                                 dz_zt_s, dz_zi_s, zt_grid_s, zi_grid_s,
+                                 w_sec_zi_s, isotropy_zi_s, brunt_zi_s, thetal_zi_s,
+                                 w3_s);
+  });
+
+  // Sync back to host
+  Kokkos::Array<view_2d, 1> inout_views = {w3_d};
+  ekat::device_to_host<int,1>({w3}, shcol, nlevi, inout_views, true);
+}
+
 } // namespace shoc
 } // namespace scream

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -566,15 +566,15 @@ struct SHOCSecondMomentSrfData : public PhysicsTestData {
 //Create data structure to hold data for diag_third_shoc_moments
 struct SHOCDiagThirdMomData : public PhysicsTestData {
   // Inputs
-  Real *w_sec, *thl_sec, *qw_sec, *qwthl_sec, *wthl_sec, *tke;
+  Real *w_sec, *thl_sec, *wthl_sec, *tke;
   Real *dz_zt, *dz_zi, *zt_grid, *zi_grid, *isotropy, *brunt;
-  Real *thetal, *wthv_sec;
+  Real *thetal;
 
   // Output
   Real *w3;
 
   SHOCDiagThirdMomData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt, &zt_grid, &brunt, &thetal, &wthv_sec, &isotropy}, {&thl_sec, &wthl_sec, &qw_sec, &qwthl_sec, &zi_grid, &dz_zi, &w3}) {}
+    PhysicsTestData(shcol_, nlev_, nlevi_, {&w_sec, &tke, &dz_zt, &zt_grid, &brunt, &thetal, &isotropy}, {&thl_sec, &wthl_sec, &zi_grid, &dz_zi, &w3}) {}
 
   SHOC_NO_SCALAR(SHOCDiagThirdMomData, 3);
 };//SHOCDiagThirdMomData
@@ -971,6 +971,11 @@ void shoc_energy_fixer_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, R
                          Real* host_dse);
 void compute_shoc_vapor_f(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv);
 void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_tracer, Real dtime, Real* dz_zt, Real* dz_zi, Real* rho_zt, Real* zt_grid, Real* zi_grid, Real* tk, Real* tkh, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, Real* wqw_sfc, Real* wtracer_sfc, Real* thetal, Real* qw, Real* tracer, Real* tke, Real* u_wind, Real* v_wind);
+void diag_third_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* w_sec, Real* thl_sec,
+                               Real* wthl_sec, Real* isotropy, Real* brunt, Real* thetal,
+                               Real* tke, Real* dz_zt, Real* dz_zi, Real* zt_grid, Real* zi_grid,
+                               Real* w3);
+
 } // end _f function decls
 
 }  // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -863,9 +863,9 @@ contains
  end subroutine shoc_diag_second_moments_srf_c
 
   subroutine diag_third_shoc_moments_c(&
-                             shcol, nlev, nlevi, w_sec, thl_sec, qw_sec, &
-                             qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
-                             tke, wthv_sec, dz_zt, dz_zi, &
+                             shcol, nlev, nlevi, w_sec, thl_sec, &
+                             wthl_sec, isotropy, brunt, thetal, &
+                             tke, dz_zt, dz_zi, &
                              zt_grid, zi_grid, w3) bind(C)
   use shoc, only: diag_third_shoc_moments
 
@@ -874,14 +874,11 @@ contains
     integer(kind=c_int), intent(in), value :: nlevi
     real(kind=c_real), intent(in) :: w_sec(shcol,nlev)
     real(kind=c_real), intent(in) :: thl_sec(shcol,nlevi)
-    real(kind=c_real), intent(in) :: qw_sec(shcol,nlevi)
-    real(kind=c_real), intent(in) :: qwthl_sec(shcol,nlevi)
     real(kind=c_real), intent(in) :: wthl_sec(shcol,nlevi)
     real(kind=c_real), intent(in) :: isotropy(shcol,nlev)
     real(kind=c_real), intent(in) :: brunt(shcol,nlev)
     real(kind=c_real), intent(in) :: thetal(shcol,nlev)
     real(kind=c_real), intent(in) :: tke(shcol,nlev)
-    real(kind=c_real), intent(in) :: wthv_sec(shcol,nlev)
     real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
     real(kind=c_real), intent(in) :: dz_zi(shcol,nlevi)
     real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
@@ -890,9 +887,9 @@ contains
     real(kind=c_real), intent(out) :: w3(shcol,nlevi)
 
     call diag_third_shoc_moments(&
-                     shcol, nlev, nlevi, w_sec, thl_sec, qw_sec, &
-                     qwthl_sec, wthl_sec, isotropy, brunt, thetal, &
-                     tke, wthv_sec, dz_zt, dz_zi, zt_grid, zi_grid, w3)
+                     shcol, nlev, nlevi, w_sec, thl_sec, &
+                     wthl_sec, isotropy, brunt, thetal, &
+                     tke, dz_zt, dz_zi, zt_grid, zi_grid, w3)
 
   end subroutine diag_third_shoc_moments_c
 
@@ -1320,6 +1317,7 @@ contains
 
     call compute_shoc_vapor(shcol, nlev, qw, ql, qv)
   end subroutine compute_shoc_vapor_c
+
   subroutine update_prognostics_implicit_c(shcol, nlev, nlevi, num_tracer, dtime, dz_zt, dz_zi, rho_zt, zt_grid, zi_grid, tk, tkh, uw_sfc, vw_sfc, wthl_sfc, wqw_sfc, wtracer_sfc, thetal, qw, tracer, tke, u_wind, v_wind) bind(C)
     use shoc, only : update_prognostics_implicit
 
@@ -1334,4 +1332,6 @@ contains
 
     call update_prognostics_implicit(shcol, nlev, nlevi, num_tracer, dtime, dz_zt, dz_zi, rho_zt, zt_grid, zi_grid, tk, tkh, uw_sfc, vw_sfc, wthl_sfc, wqw_sfc, wtracer_sfc, thetal, qw, tracer, tke, u_wind, v_wind)
   end subroutine update_prognostics_implicit_c
+
 end module shoc_iso_c
+

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -342,6 +342,7 @@ end subroutine shoc_energy_fixer_f
     real(kind=c_real) , intent(in), dimension(shcol, nlev) :: qw, ql
     real(kind=c_real) , intent(out), dimension(shcol, nlev) :: qv
   end subroutine compute_shoc_vapor_f
+
   subroutine update_prognostics_implicit_f(shcol, nlev, nlevi, num_tracer, dtime, dz_zt, dz_zi, rho_zt, zt_grid, zi_grid, tk, tkh, uw_sfc, vw_sfc, wthl_sfc, wqw_sfc, wtracer_sfc, thetal, qw, tracer, tke, u_wind, v_wind) bind(C)
     use iso_c_binding
 
@@ -354,6 +355,17 @@ end subroutine shoc_energy_fixer_f
     real(kind=c_real) , intent(inout), dimension(shcol, nlev) :: thetal, qw, tke, u_wind, v_wind
     real(kind=c_real) , intent(inout), dimension(shcol, nlev, num_tracer) :: tracer
   end subroutine update_prognostics_implicit_f
+
+subroutine diag_third_shoc_moments_f(shcol, nlev, nlevi, w_sec, thl_sec, wthl_sec, isotropy, brunt,&
+                                     thetal, tke, dz_zt, dz_zi, zt_grid, zi_grid, w3) bind(C)
+  use iso_c_binding
+
+  integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi
+  real(kind=c_real) , intent(in), dimension(shcol, nlev) :: w_sec, isotropy, brunt, thetal, tke, dz_zt, zt_grid
+  real(kind=c_real) , intent(in), dimension(shcol, nlevi) :: thl_sec, wthl_sec, dz_zi, zi_grid
+  real(kind=c_real) , intent(out), dimension(shcol, nlevi) :: w3
+end subroutine diag_third_shoc_moments_f
+
 end interface
 
 end module shoc_iso_f

--- a/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
@@ -45,10 +45,6 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
     static constexpr Real w_sec[nlev] = {0.2, 0.3, 0.5, 0.3, 0.1};
     // Define potential temperature second moment [K2]
     static constexpr Real thl_sec[nlevi] = {0.5, 0.9, 1.2, 0.8, 0.4, 0.3};
-    // Define second moment total water second moment [kg^2/kg^2]
-    static constexpr Real qw_sec[nlevi] = {1e-7, 3e-7, 2e-7, 1.4e-6, 5e-7, 4e-7};
-    // Define covarance of thetal and qw [K kg/kg]
-    static constexpr Real qwthl_sec[nlevi] = {1e-3, 3e-3, 2e-3, 1.4e-3, 5e-3, 4e-3};
     // Define vertical flux of temperature [K m/s]
     static constexpr Real wthl_sec[nlevi] = {0.003, -0.03, -0.04, -0.01, 0.01, 0.03};
     // Define the heights on the zi grid [m]
@@ -59,8 +55,6 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
     static constexpr Real brunt[nlev] = {4e-5, 3e-5, 2e-5, 2e-5, -1e-5};
     // Define the potential temperature on zi grid [K]
     static constexpr Real thetal[nlev] = {330, 320, 310, 300, 305};
-    // Define the buoyancy flux on zi grid [K m/s]
-    static constexpr Real wthv_sec[nlev] = {0.002, 0.03, 0.04, 0.02, 0.04};
 
     // Define TKE [m2/s2], compute from w_sec
     Real tke[nlev];
@@ -106,7 +100,6 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
         SDS.isotropy[offset] = isotropy[n];
         SDS.brunt[offset] = brunt[n];
         SDS.thetal[offset] = thetal[n];
-        SDS.wthv_sec[offset] = wthv_sec[n];
       }
 
       // Fill in test data on zi_grid.
@@ -116,8 +109,6 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
         SDS.dz_zi[offset] = dz_zi[n];
         SDS.zi_grid[offset] = zi_grid[n];
         SDS.thl_sec[offset] = thl_sec[n];
-        SDS.qw_sec[offset] = qw_sec[n];
-        SDS.qwthl_sec[offset] = qwthl_sec[n];
         SDS.wthl_sec[offset] = wthl_sec[n];
 
       }
@@ -147,7 +138,6 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
         REQUIRE(SDS.dz_zi[offset] >= 0);
         REQUIRE(SDS.zi_grid[offset] >= 0);
         REQUIRE(SDS.thl_sec[offset] >= 0);
-        REQUIRE(SDS.qw_sec[offset] >= 0);
       }
     }
 
@@ -213,7 +203,57 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
 
   static void run_bfb()
   {
-    // TODO
+    SHOCDiagThirdMomData SDS_f90[] = {
+      //               shcol, nlev, nlevi
+      SHOCDiagThirdMomData(10, 71, 72),
+      SHOCDiagThirdMomData(10, 12, 13),
+      SHOCDiagThirdMomData(7,  16, 17),
+      SHOCDiagThirdMomData(2, 7, 8),
+    };
+
+    static constexpr Int num_runs = sizeof(SDS_f90) / sizeof(SHOCDiagThirdMomData);
+
+    // Generate random input data
+    for (auto& d : SDS_f90) {
+      d.randomize();
+    }
+
+    // Create copies of data for use by cxx. Needs to happen before fortran calls so that
+    // inout data is in original state
+    SHOCDiagThirdMomData SDS_cxx[] = {
+      SHOCDiagThirdMomData(SDS_f90[0]),
+      SHOCDiagThirdMomData(SDS_f90[1]),
+      SHOCDiagThirdMomData(SDS_f90[2]),
+      SHOCDiagThirdMomData(SDS_f90[3]),
+    };
+
+    // Assume all data is in C layout
+
+    // Get data from fortran
+    for (auto& d : SDS_f90) {
+      // expects data in C layout
+      diag_third_shoc_moments(d);
+    }
+
+    // Get data from cxx
+    for (auto& d : SDS_cxx) {
+      d.transpose<ekat::TransposeDirection::c2f>();
+      // expects data in fortran layout
+      diag_third_shoc_moments_f(d.shcol(),d.nlev(),d.nlevi(),d.w_sec,d.thl_sec,
+                                d.wthl_sec,d.isotropy,d.brunt,d.thetal,
+                                d.tke,d.dz_zt,d.dz_zi,d.zt_grid,d.zi_grid,
+                                d.w3);
+      d.transpose<ekat::TransposeDirection::f2c>();
+    }
+
+    // Verify BFB results, all data should be in C layout
+    for (Int i = 0; i < num_runs; ++i) {
+      SHOCDiagThirdMomData& d_f90 = SDS_f90[i];
+      SHOCDiagThirdMomData& d_cxx = SDS_cxx[i];
+      for (Int k = 0; k < d_f90.total1x3(); ++k) {
+        REQUIRE(d_f90.w3[k] == d_cxx.w3[k]);
+      }
+    }
   }
 };
 

--- a/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_third_tests.cpp
@@ -215,7 +215,7 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
 
     // Generate random input data
     for (auto& d : SDS_f90) {
-      d.randomize();
+      d.randomize({{d.thetal, {300, 301}}});
     }
 
     // Create copies of data for use by cxx. Needs to happen before fortran calls so that


### PR DESCRIPTION
Port `diag_third_shoc_moments`.

`qw_sec`, `qwthl_sec`and `wthv_sec` are unused variables.