### PR TITLE
non-bfb changes for shoc_assumed_pdf porting

### DIFF
--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -2190,7 +2190,7 @@ subroutine shoc_assumed_pdf_vv_parameters(&
   real(rtype) :: w_tol_sqd
   w_tol_sqd = bfb_square(2.e-2_rtype)
 
-  Skew_w=w3var/bfb_pow(w_sec,(3./2.))
+  Skew_w=w3var/bfb_sqrt(bfb_cube(w_sec))
 
   if (w_sec .le. w_tol_sqd) then
     Skew_w=0._rtype

--- a/components/cam/src/physics/cam/shoc.F90
+++ b/components/cam/src/physics/cam/shoc.F90
@@ -1997,7 +1997,7 @@ subroutine shoc_assumed_pdf(&
 
   thl_tol=1.e-2_rtype
   rt_tol=1.e-4_rtype
-  w_tol_sqd=(2.e-2_rtype)**2
+  w_tol_sqd=bfb_square(2.e-2_rtype)
   w_thresh=0.0_rtype
 
   ! Initialize cloud variables to zero
@@ -2033,9 +2033,9 @@ subroutine shoc_assumed_pdf(&
 
       ! Compute square roots of some variables so we don't
       !  have to compute these again
-      sqrtw2 = sqrt(w_sec(i,k))
-      sqrtthl = max(thl_tol,sqrt(thlsec))
-      sqrtqt = max(rt_tol,sqrt(qwsec))
+      sqrtw2 = bfb_sqrt(w_sec(i,k))
+      sqrtthl = max(thl_tol,bfb_sqrt(thlsec))
+      sqrtqt = max(rt_tol,bfb_sqrt(qwsec))
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       !  FIND PARAMETERS FOR VERTICAL VELOCITY
@@ -2187,9 +2187,10 @@ subroutine shoc_assumed_pdf_vv_parameters(&
   real(rtype) :: sqrtw2t
 
   ! parameters
-  real(rtype), parameter :: w_tol_sqd=(2.e-2_rtype)**2
+  real(rtype) :: w_tol_sqd
+  w_tol_sqd = bfb_square(2.e-2_rtype)
 
-  Skew_w=w3var/w_sec**(3./2.)
+  Skew_w=w3var/bfb_pow(w_sec,(3./2.))
 
   if (w_sec .le. w_tol_sqd) then
     Skew_w=0._rtype
@@ -2203,12 +2204,12 @@ subroutine shoc_assumed_pdf_vv_parameters(&
     w2_1=0.4_rtype
     w2_2=0.4_rtype
 
-    a=max(0.01_rtype,min(0.5_rtype*(1._rtype-Skew_w*sqrt(1._rtype/(4._rtype*(1._rtype-w2_1)**3+Skew_w**2))),0.99_rtype))
+    a=max(0.01_rtype,min(0.5_rtype*(1._rtype-Skew_w*bfb_sqrt(1._rtype/(4._rtype*bfb_cube(1._rtype-w2_1)+bfb_square(Skew_w)))),0.99_rtype))
 
-    sqrtw2t=sqrt(1._rtype-w2_1)
+    sqrtw2t=bfb_sqrt(1._rtype-w2_1)
 
-    w1_1=sqrt((1._rtype-a)/a)*sqrtw2t
-    w1_2=-1._rtype*sqrt(a/(1._rtype-a))*sqrtw2t
+    w1_1=bfb_sqrt((1._rtype-a)/a)*sqrtw2t
+    w1_2=-1._rtype*bfb_sqrt(a/(1._rtype-a))*sqrtw2t
 
     w2_1=w2_1*w_sec
     w2_2=w2_2*w_sec
@@ -2257,7 +2258,7 @@ subroutine shoc_assumed_pdf_thl_parameters(&
 
   corrtest1=max(-1._rtype,min(1._rtype,wthlsec/(sqrtw2*sqrtthl)))
 
-  if (thlsec .le. thl_tol**2 .or. abs(w1_2-w1_1) .le. w_thresh) then
+  if (thlsec .le. bfb_square(thl_tol) .or. abs(w1_2-w1_1) .le. w_thresh) then
     thl1_1=thl_first
     thl1_2=thl_first
     thl2_1=0._rtype
@@ -2283,20 +2284,20 @@ subroutine shoc_assumed_pdf_thl_parameters(&
       Skew_thl = 0.0_rtype
     endif
 
-    thl2_1=min(100._rtype,max(0._rtype,(3._rtype*thl1_2*(1._rtype-a*thl1_1**2-(1._rtype-a)*thl1_2**2) &
-            -(Skew_thl-a*thl1_1**3-(1._rtype-a)*thl1_2**3))/ &
+    thl2_1=min(100._rtype,max(0._rtype,(3._rtype*thl1_2*(1._rtype-a*bfb_square(thl1_1)-(1._rtype-a)*bfb_square(thl1_2)) &
+            -(Skew_thl-a*bfb_cube(thl1_1)-(1._rtype-a)*bfb_cube(thl1_2)))/ &
             (3._rtype*a*(thl1_2-thl1_1))))*thlsec
 
-    thl2_2=min(100._rtype,max(0._rtype,(-3._rtype*thl1_1*(1._rtype-a*thl1_1**2-(1._rtype-a)*thl1_2**2) &
-      +(Skew_thl-a*thl1_1**3-(1._rtype-a)*thl1_2**3))/ &
+    thl2_2=min(100._rtype,max(0._rtype,(-3._rtype*thl1_1*(1._rtype-a*bfb_square(thl1_1)-(1._rtype-a)*bfb_square(thl1_2)) &
+      +(Skew_thl-a*bfb_cube(thl1_1)-(1._rtype-a)*bfb_cube(thl1_2)))/ &
       (3._rtype*(1._rtype-a)*(thl1_2-thl1_1))))*thlsec
 
 
     thl1_1=thl1_1*sqrtthl+thl_first
     thl1_2=thl1_2*sqrtthl+thl_first
 
-    sqrtthl2_1=sqrt(thl2_1)
-    sqrtthl2_2=sqrt(thl2_2)
+    sqrtthl2_1=bfb_sqrt(thl2_1)
+    sqrtthl2_2=bfb_sqrt(thl2_2)
 
   endif
 
@@ -2340,7 +2341,7 @@ subroutine shoc_assumed_pdf_qw_parameters(&
   corrtest2=max(-1.0_rtype,min(1.0_rtype,wqwsec/(sqrtw2*sqrtqt)))
 
 
-  if (qwsec .le. rt_tol**2 .or. abs(w1_2-w1_1) .le. w_thresh) then
+  if (qwsec .le. bfb_square(rt_tol) .or. abs(w1_2-w1_1) .le. w_thresh) then
     qw1_1=qw_first
     qw1_2=qw_first
     qw2_1=0._rtype
@@ -2361,19 +2362,19 @@ subroutine shoc_assumed_pdf_qw_parameters(&
     else
       Skew_qw=((1.2_rtype*Skew_w)/0.2_rtype)*(tsign-0.2_rtype)
     endif
-     qw2_1=min(100._rtype,max(0._rtype,(3._rtype*qw1_2*(1._rtype-a*qw1_1**2-(1._rtype-a)*qw1_2**2) &
-      -(Skew_qw-a*qw1_1**3-(1._rtype-a)*qw1_2**3))/ &
+     qw2_1=min(100._rtype,max(0._rtype,(3._rtype*qw1_2*(1._rtype-a*bfb_square(qw1_1)-(1._rtype-a)*bfb_square(qw1_2)) &
+      -(Skew_qw-a*bfb_cube(qw1_1)-(1._rtype-a)*bfb_cube(qw1_2)))/ &
       (3._rtype*a*(qw1_2-qw1_1))))*qwsec
 
-    qw2_2=min(100._rtype,max(0._rtype,(-3._rtype*qw1_1*(1._rtype-a*qw1_1**2-(1._rtype-a)*qw1_2**2) &
-      +(Skew_qw-a*qw1_1**3-(1._rtype-a)*qw1_2**3))/ &
+    qw2_2=min(100._rtype,max(0._rtype,(-3._rtype*qw1_1*(1._rtype-a*bfb_square(qw1_1)-(1._rtype-a)*bfb_square(qw1_2)) &
+      +(Skew_qw-a*bfb_cube(qw1_1)-(1._rtype-a)*bfb_cube(qw1_2)))/ &
       (3._rtype*(1._rtype-a)*(qw1_2-qw1_1))))*qwsec
 
     qw1_1=qw1_1*sqrtqt+qw_first
     qw1_2=qw1_2*sqrtqt+qw_first
 
-    sqrtqw2_1=sqrt(qw2_1)
-    sqrtqw2_2=sqrt(qw2_2)
+    sqrtqw2_1=bfb_sqrt(qw2_1)
+    sqrtqw2_2=bfb_sqrt(qw2_2)
 
   endif
 
@@ -2451,7 +2452,7 @@ subroutine shoc_assumed_pdf_compute_temperature(&
   ! intent-out
   real(rtype), intent(out) :: Tl1
 
-  TL1 = thl1/((basepres/pval)**(rgas/cp))
+  TL1 = thl1/(bfb_pow(basepres/pval,(rgas/cp)))
 
 end subroutine shoc_assumed_pdf_compute_temperature
 
@@ -2529,26 +2530,28 @@ subroutine shoc_assumed_pdf_compute_s(&
   real(rtype), intent(out) :: C
 
   ! local variables
-  real(rtype) :: cthl, cqt
+  real(rtype) :: cthl, cqt, tmp_val
 
   ! Parameters
-  real(rtype), parameter :: sqrt2 = sqrt(2._rtype)
-  real(rtype), parameter :: sqrt2pi = sqrt(2._rtype*pi)
+  real(rtype) :: sqrt2, sqrt2pi
+  sqrt2 = bfb_sqrt(2._rtype)
+  sqrt2pi = bfb_sqrt(2._rtype*pi)
 
   s=qw1-qs1*((1._rtype+beta*qw1)/(1._rtype+beta*qs1))
-  cthl=((1._rtype+beta*qw1)/(1._rtype+beta*qs1)**2)*(cp/lcond) &
-    *beta*qs1*(pval/basepres)**(rgas/cp)
+  cthl=((1._rtype+beta*qw1)/bfb_square(1._rtype+beta*qs1))*(cp/lcond) &
+    *beta*qs1*bfb_pow(pval/basepres, (rgas/cp))
 
   cqt=1._rtype/(1._rtype+beta*qs1)
-  std_s=sqrt(max(0._rtype,cthl**2*thl2+cqt**2*qw2-2._rtype*cthl &
-    *sqrtthl2*cqt*sqrtqw2*r_qwthl))
+  tmp_val=max(0._rtype,bfb_square(cthl)*thl2+bfb_square(cqt)*qw2-2._rtype*cthl &
+    *sqrtthl2*cqt*sqrtqw2*r_qwthl)
+  std_s=bfb_sqrt(tmp_val)
 
   qn=0._rtype
   C=0._rtype
 
   if (std_s .ne. 0.0_rtype) then
     C=0.5_rtype*(1._rtype+erf(s/(sqrt2*std_s)))
-    IF (C .ne. 0._rtype) qn=s*C+(std_s/sqrt2pi)*exp(-0.5_rtype*(s/std_s)**2)
+    IF (C .ne. 0._rtype) qn=s*C+(std_s/sqrt2pi)*exp(-0.5_rtype*bfb_square(s/std_s))
   else
     if (s .gt. 0._rtype) then
       C=1.0_rtype
@@ -2599,8 +2602,8 @@ subroutine shoc_assumed_pdf_compute_cloud_liquid_variance(&
   ! intent-out
   real(rtype), intent(out) :: shoc_ql2
 
-  shoc_ql2 = a * ( s1*ql1 + C1*std_s1**2.0 )                  &
-    + ( 1._rtype-a ) * ( s2*ql2 + C2*std_s2**2.0 ) - shoc_ql**2.0
+  shoc_ql2 = a * ( s1*ql1 + C1*bfb_square(std_s1) )                  &
+    + ( 1._rtype-a ) * ( s2*ql2 + C2*bfb_square(std_s2) ) - bfb_square(shoc_ql)
   shoc_ql2 = max( 0._rtype, shoc_ql2 )
 
 end subroutine shoc_assumed_pdf_compute_cloud_liquid_variance
@@ -2643,7 +2646,7 @@ subroutine shoc_assumed_pdf_compute_buoyancy_flux(&
   real(rtype), intent(out) :: wthv_sec
 
   wthv_sec=wthlsec+((1._rtype-epsterm)/epsterm)*basetemp*wqwsec &
-  +((lcond/cp)*(basepres/pval)**(rgas/cp)-(1._rtype/epsterm)*basetemp)*wqls
+  +((lcond/cp)*bfb_pow(basepres/pval,(rgas/cp))-(1._rtype/epsterm)*basetemp)*wqls
 
 end subroutine shoc_assumed_pdf_compute_buoyancy_flux
 


### PR DESCRIPTION
Several changes to `bfb_*()` function for `shoc_assumed_pdf` porting.

All changes to `bfb_square()` and `bfb_sqrt()` cause no change to output from bfb testing, however, like other bfb changes, `bfb_cube` and `bfb_pow` can change the `shoc_run_and_cmp` output by a significant amount (~1e-1, `host_dse` is always the largest).

Again, I test all these by calculating the relative difference between variables containing `bfb_cube(x)` and those containing `x**3` everywhere it is used during ./shoc_run_and_cmp (likewise with `bfb_pow`). For all of these changes, the maximum relative difference of any one change is
`abs(old_val - new_val)/abs(old_val) < 7e-06(SP), 3e-14 (DP)` 