### PR TITLE
Remove surface emissions from F2010 SCREAM use_cases

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -83,53 +83,6 @@
 <!-- Energy fixer options -->
 <ieflx_opt  > 0     </ieflx_opt>
 
-<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<ext_frc_type         >CYCLICAL</ext_frc_type>
-<ext_frc_cycle_yr     >2010</ext_frc_cycle_yr>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1x1_2010_clim_c20190821.nc </so2_ext_file>
-<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1x1_2010_clim_c20190821.nc </soag_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1x1_2010_clim_c20190821.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1x1_2010_clim_c20190821.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1x1_2010_clim_c20190821.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1x1_2010_clim_c20190821.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1x1_2010_clim_c20190821.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1x1_2010_clim_c20190821.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1x1_2010_clim_c20190821.nc </so4_a2_ext_file>
-
-<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<srf_emis_type        >CYCLICAL</srf_emis_type>
-<srf_emis_cycle_yr    >2010</srf_emis_cycle_yr>
-<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1x1_2010_clim_c20190821.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1x1_2010_clim_c20190821.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1x1_2010_clim_c20190821.nc </mam7_num_a1_emis_file> 
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1x1_2010_clim_c20190821.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1x1_2010_clim_c20190821.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1x1_2010_clim_c20190821.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1x1_2010_clim_c20190821.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1x1_2010_clim_c20190821.nc </so4_a2_emis_file>
-
-<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<!-- NOTE: In order to set these, we would need to enable prognostic aerosol -->
-<!--tracer_cnst_type    >CYCLICAL</tracer_cnst_type-->
-<!--tracer_cnst_cycle_yr>2015</tracer_cnst_cycle_yr-->
-<!--tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file-->
-<!--tracer_cnst_filelist>''</tracer_cnst_filelist-->
-<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
-
-<!-- Marine organic aerosol namelist settings -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<mam_mom_mixing_state>3</mam_mom_mixing_state>
-<mam_mom_cycle_yr  >1                                                                    </mam_mom_cycle_yr>
-<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                  </mam_mom_datapath>
-<mam_mom_datatype  >'CYCLICAL'										                     </mam_mom_datatype>
-<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc' </mam_mom_filename> <!-- Using the 2000 file, for now -->
-<mam_mom_fixed_tod >0											                         </mam_mom_fixed_tod>
-<mam_mom_fixed_ymd >0											                         </mam_mom_fixed_ymd>
-<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'		 </mam_mom_specifier>
 
 <!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
 <!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
@@ -145,7 +98,7 @@
 <drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
 
 <!-- sim_year used for CLM datasets and SST forcings -->
-<sim_year>2015</sim_year>
+<sim_year>2010</sim_year>
 
 <!-- Land datasets set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
 

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_hr_dyamond2.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_hr_dyamond2.xml
@@ -89,53 +89,6 @@
 <!-- Energy fixer options -->
 <ieflx_opt  > 0     </ieflx_opt>
 
-<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<ext_frc_type         >CYCLICAL</ext_frc_type>
-<ext_frc_cycle_yr     >2010</ext_frc_cycle_yr>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1x1_2010_clim_c20190821.nc </so2_ext_file>
-<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1x1_2010_clim_c20190821.nc </soag_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1x1_2010_clim_c20190821.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1x1_2010_clim_c20190821.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1x1_2010_clim_c20190821.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1x1_2010_clim_c20190821.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1x1_2010_clim_c20190821.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1x1_2010_clim_c20190821.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1x1_2010_clim_c20190821.nc </so4_a2_ext_file>
-
-<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<srf_emis_type        >CYCLICAL</srf_emis_type>
-<srf_emis_cycle_yr    >2010</srf_emis_cycle_yr>
-<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1x1_2010_clim_c20190821.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1x1_2010_clim_c20190821.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1x1_2010_clim_c20190821.nc </mam7_num_a1_emis_file> 
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1x1_2010_clim_c20190821.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1x1_2010_clim_c20190821.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1x1_2010_clim_c20190821.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1x1_2010_clim_c20190821.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1x1_2010_clim_c20190821.nc </so4_a2_emis_file>
-
-<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<!-- NOTE: In order to set these, we would need to enable prognostic aerosol -->
-<!--tracer_cnst_type    >CYCLICAL</tracer_cnst_type-->
-<!--tracer_cnst_cycle_yr>2015</tracer_cnst_cycle_yr-->
-<!--tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file-->
-<!--tracer_cnst_filelist>''</tracer_cnst_filelist-->
-<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
-
-<!-- Marine organic aerosol namelist settings -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<mam_mom_mixing_state>3</mam_mom_mixing_state>
-<mam_mom_cycle_yr  >1                                                                    </mam_mom_cycle_yr>
-<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                  </mam_mom_datapath>
-<mam_mom_datatype  >'CYCLICAL'										                     </mam_mom_datatype>
-<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc' </mam_mom_filename> <!-- Using the 2000 file, for now -->
-<mam_mom_fixed_tod >0											                         </mam_mom_fixed_tod>
-<mam_mom_fixed_ymd >0											                         </mam_mom_fixed_ymd>
-<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'		 </mam_mom_specifier>
 
 <!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
 <!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
@@ -151,7 +104,7 @@
 <drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
 
 <!-- sim_year used for CLM datasets and SST forcings -->
-<sim_year>2015</sim_year>
+<sim_year>2010</sim_year>
 
 <!-- Land datasets set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
 

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -94,54 +94,6 @@
 <!-- Energy fixer options -->
 <ieflx_opt  > 0     </ieflx_opt>
 
-<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<ext_frc_type         >CYCLICAL</ext_frc_type>
-<ext_frc_cycle_yr     >2010</ext_frc_cycle_yr>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1x1_2010_clim_c20190821.nc </so2_ext_file>
-<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1x1_2010_clim_c20190821.nc </soag_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1x1_2010_clim_c20190821.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1x1_2010_clim_c20190821.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1x1_2010_clim_c20190821.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1x1_2010_clim_c20190821.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1x1_2010_clim_c20190821.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1x1_2010_clim_c20190821.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1x1_2010_clim_c20190821.nc </so4_a2_ext_file>
-
-<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<srf_emis_type        >CYCLICAL</srf_emis_type>
-<srf_emis_cycle_yr    >2010</srf_emis_cycle_yr>
-<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1x1_2010_clim_c20190821.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1x1_2010_clim_c20190821.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1x1_2010_clim_c20190821.nc </mam7_num_a1_emis_file> 
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1x1_2010_clim_c20190821.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1x1_2010_clim_c20190821.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1x1_2010_clim_c20190821.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1x1_2010_clim_c20190821.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1x1_2010_clim_c20190821.nc </so4_a2_emis_file>
-
-<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<!-- NOTE: In order to set these, we would need to enable prognostic aerosol -->
-<!--tracer_cnst_type    >CYCLICAL</tracer_cnst_type-->
-<!--tracer_cnst_cycle_yr>2015</tracer_cnst_cycle_yr-->
-<!--tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file-->
-<!--tracer_cnst_filelist>''</tracer_cnst_filelist-->
-<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
-
-<!-- Marine organic aerosol namelist settings -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<mam_mom_mixing_state>3</mam_mom_mixing_state>
-<mam_mom_cycle_yr  >1                                                                    </mam_mom_cycle_yr>
-<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                  </mam_mom_datapath>
-<mam_mom_datatype  >'CYCLICAL'										                     </mam_mom_datatype>
-<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc' </mam_mom_filename> <!-- Using the 2000 file, for now -->
-<mam_mom_fixed_tod >0											                         </mam_mom_fixed_tod>
-<mam_mom_fixed_ymd >0											                         </mam_mom_fixed_ymd>
-<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'		 </mam_mom_specifier>
-
 <!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
 <!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
 <chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>

--- a/components/cam/bld/namelist_files/use_cases/2010_scream_lr_dyamond2.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_scream_lr_dyamond2.xml
@@ -96,54 +96,6 @@
 <!-- Energy fixer options -->
 <ieflx_opt  > 0     </ieflx_opt>
 
-<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<ext_frc_type         >CYCLICAL</ext_frc_type>
-<ext_frc_cycle_yr     >2010</ext_frc_cycle_yr>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1x1_2010_clim_c20190821.nc </so2_ext_file>
-<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1x1_2010_clim_c20190821.nc </soag_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1x1_2010_clim_c20190821.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1x1_2010_clim_c20190821.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1x1_2010_clim_c20190821.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1x1_2010_clim_c20190821.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1x1_2010_clim_c20190821.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1x1_2010_clim_c20190821.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1x1_2010_clim_c20190821.nc </so4_a2_ext_file>
-
-<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<srf_emis_type        >CYCLICAL</srf_emis_type>
-<srf_emis_cycle_yr    >2010</srf_emis_cycle_yr>
-<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1x1_2010_clim_c20190821.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1x1_2010_clim_c20190821.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1x1_2010_clim_c20190821.nc </mam7_num_a1_emis_file> 
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1x1_2010_clim_c20190821.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1x1_2010_clim_c20190821.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1x1_2010_clim_c20190821.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1x1_2010_clim_c20190821.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1x1_2010_clim_c20190821.nc </so4_a2_emis_file>
-
-<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<!-- NOTE: In order to set these, we would need to enable prognostic aerosol -->
-<!--tracer_cnst_type    >CYCLICAL</tracer_cnst_type-->
-<!--tracer_cnst_cycle_yr>2015</tracer_cnst_cycle_yr-->
-<!--tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file-->
-<!--tracer_cnst_filelist>''</tracer_cnst_filelist-->
-<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
-
-<!-- Marine organic aerosol namelist settings -->
-<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
-<mam_mom_mixing_state>3</mam_mom_mixing_state>
-<mam_mom_cycle_yr  >1                                                                    </mam_mom_cycle_yr>
-<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                  </mam_mom_datapath>
-<mam_mom_datatype  >'CYCLICAL'										                     </mam_mom_datatype>
-<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc' </mam_mom_filename> <!-- Using the 2000 file, for now -->
-<mam_mom_fixed_tod >0											                         </mam_mom_fixed_tod>
-<mam_mom_fixed_ymd >0											                         </mam_mom_fixed_ymd>
-<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'		 </mam_mom_specifier>
-
 <!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
 <!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
 <chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>


### PR DESCRIPTION
Because SCREAM simulations are running with prescribed aerosols, surface emissions of aerosol or chemical species is unnecessary. These are removed in this PR. 