### PR TITLE
SCREAM: fix for mappy in machine_specs.py

### DIFF
--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -35,7 +35,7 @@ MACHINE_METADATA = {
                   "/home/projects/e3sm/scream/pr-autotester/master-baselines/weaver/"),
     "mappy"   : (["module purge", "module load sems-env sems-python/3.5.2 sems-gcc/9.2.0 sems-cmake/3.12.2 sems-git/2.10.1 sems-openmpi/4.0.2"],
                   "$(which mpicxx)",
-                  "mpirun",
+                  "",
                   48,
                   48,
                   "/sems-data-store/ACME/baselines/scream/master-baselines"),


### PR DESCRIPTION
There's no batch system on mappy. Don't use mpirun.

This is causing 64 copies of the test command to run. It may be the only reason AT tests are failing on mappy, but even if there's more, this makes impossible to parse the output of the test job.