### PR TITLE
Quick fix to timestamp.to_string() routine.

### DIFF
--- a/components/scream/src/share/util/scream_time_stamp.cpp
+++ b/components/scream/src/share/util/scream_time_stamp.cpp
@@ -94,9 +94,13 @@ std::string TimeStamp::to_string () const {
   const int m = (ss % 3600) / 60;
   const int s = (ss % 3600) % 60;
   const std::string zero = "00";
+  const std::string single = "0";
   // For h:m:s, check if 0, and if so, use "00" rather than to_string, which returns "0"
+  // if <10 use "0x" rather than to_string, which returns just one character.
   return std::to_string(m_mm+1) + "-" + std::to_string(m_dd+1) + "-" + std::to_string(m_yy) + " " + 
-         (h==0 ? zero : std::to_string(h)) + ":" + (m==0 ? zero : std::to_string(m)) + ":" + (s==0 ? zero : std::to_string(s));
+         (h==0 ? zero : (h<10 ? single+std::to_string(h) : std::to_string(h))) + ":" + 
+         (m==0 ? zero : (m<10 ? single+std::to_string(m) : std::to_string(m))) + ":" + 
+         (s==0 ? zero : (s<10 ? single+std::to_string(s) : std::to_string(s)));
 }
 
 TimeStamp& TimeStamp::operator+=(const double seconds) {

--- a/components/scream/src/share/util/scream_time_stamp.cpp
+++ b/components/scream/src/share/util/scream_time_stamp.cpp
@@ -7,6 +7,9 @@
 #include <cmath>
 #include <vector>
 #include <algorithm>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
 
 namespace scream {
 namespace util {
@@ -93,14 +96,16 @@ std::string TimeStamp::to_string () const {
   const int h =  ss / 3600;
   const int m = (ss % 3600) / 60;
   const int s = (ss % 3600) % 60;
-  const std::string zero = "00";
-  const std::string single = "0";
-  // For h:m:s, check if 0, and if so, use "00" rather than to_string, which returns "0"
-  // if <10 use "0x" rather than to_string, which returns just one character.
-  return std::to_string(m_mm+1) + "-" + std::to_string(m_dd+1) + "-" + std::to_string(m_yy) + " " + 
-         (h==0 ? zero : (h<10 ? single+std::to_string(h) : std::to_string(h))) + ":" + 
-         (m==0 ? zero : (m<10 ? single+std::to_string(m) : std::to_string(m))) + ":" + 
-         (s==0 ? zero : (s<10 ? single+std::to_string(s) : std::to_string(s)));
+
+  std::ostringstream ymdhms;
+  ymdhms << std::setw(4) << std::setfill('0') << m_yy << "-";
+  ymdhms << std::setw(2) << std::setfill('0') << m_mm+1 << "-";
+  ymdhms << std::setw(2) << std::setfill('0') << m_dd+1 << " ";
+  ymdhms << std::setw(2) << std::setfill('0') << h << ":";
+  ymdhms << std::setw(2) << std::setfill('0') << m << ":";
+  ymdhms << std::setw(2) << std::setfill('0') << s;
+  return ymdhms.str();
+
 }
 
 TimeStamp& TimeStamp::operator+=(const double seconds) {


### PR DESCRIPTION
Added logic for the case when the hour, minute or second in the time
is between 1-9.

Also switches the timestamp string order to YYYY-MM-DD HH:MM:SS
i.e. year first not last.

Before: this would print single digit for the string
Now: prints 2 digits starting with 0.

This is helpful when creating filenames for writing output.

ex. If HH-MM-SS = 1-21-1
before: 1:21:1
now: 01:21:01

note that IO will strip the ":" for the filenames so in the above example we would have a string 1211 vs 012101.  The former could be 1-21-1, or 12-1-1, or 1-2-11.  There is no ambiguity in the latter.