### PR TITLE
Prevent evaporate_rain from over-depleting qr

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -3329,6 +3329,13 @@ qr2qv_evap_tend,nr_evap_tend)
       !negative (adding mass) if A_c (other processes) are losing mass. We don't
       !allow rain evap to also condense by forcing qr2qv_evap_tend to be positive
       qr2qv_evap_tend = max(0._rtype, qr2qv_evap_tend)
+
+      !We can't evaporate more rain mass than we had to start with
+      !Sanity check: We're applying to rainy region outside cloud here because
+      !qr inside cloud should be protected from evap. Conversion to rainy-area
+      !ave just below scales by (cldfrac_r - cld_frac)/cldfrac_r < 1 so 
+      !total qr isn't pushed negative. 
+      qr2qv_evap_tend = min(qr2qv_evap_tend,qr_incld*inv_dt)
       
       !Evap rate so far is an average over the rainy area outside clouds.
       !Turn this into an average over the entire raining area

--- a/components/scream/src/physics/p3/p3_evaporate_rain_impl.hpp
+++ b/components/scream/src/physics/p3/p3_evaporate_rain_impl.hpp
@@ -180,6 +180,14 @@ void Functions<S,D>
     //allow rain evap to also condense by forcing qr2qv_evap_tend to be positive
     qr2qv_evap_tend.set(is_rain_evap && (qr2qv_evap_tend<0), 0);
 
+    //We can't evaporate more rain mass than we had to start with
+    //Note: We're applying to rainy region outside cloud here because
+    //qr inside cloud should be protected from evap. Conversion to rainy-area
+    //average just below scales by (cldfrac_r - cld_frac)/cldfrac_r < 1 so 
+    //total qr isn't pushed negative. 
+    qr2qv_evap_tend.set(is_rain_evap && (qr2qv_evap_tend>qr_incld*inv_dt),
+			qr_incld*inv_dt);
+    
     //Evap rate so far is an average over the rainy area outside clouds.
     //Turn this into an average over the entire raining area
     qr2qv_evap_tend.set(is_rain_evap, qr2qv_evap_tend*(cld_frac_r-cld_frac)/cld_frac_r);

--- a/components/scream/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
@@ -106,6 +106,7 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
       REQUIRE( std::abs(qrtend[0] - qr_tiny[0]/dt
 			*(cld_frac_r[0]-cld_frac_l[0])/cld_frac_r[0])<1e-8 );
       REQUIRE( std::abs(nrtend[0] - qrtend[0]*nr_incld[0]/qr_tiny[0]) < 1e-8 );//always true
+      REQUIRE( nrtend[0] <= nr_incld[0]/dt); //keep end-of-step nr positive. Should always be true.
 
     //if no rainy areas outside cloud, don't evap
     Functions::evaporate_rain(qr_incld,qc_incld,nr_incld,qi_incld,
@@ -123,7 +124,16 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip
 			      qrtend,nrtend);
     REQUIRE( std::abs(qrtend[0])<1e-8 );
     REQUIRE( std::abs(nrtend[0])<1e-8 );
-    
+
+    //for case with lots of evap, make sure doesn't overdeplete qr_incld
+    Functions::evaporate_rain(qr_incld,qc_incld,nr_incld,qi_incld,
+			      //qv -> qv*0.1 to encourage lots of rain evap
+			      cld_frac_l,cld_frac_r,qv*0.1,qv_prev,qv_sat_l,qv_sat_i,
+			      ab,abi,epsr,epsi_tot,t,t_prev,latent_heat_sublim,dqsdt,dt,
+			      qrtend,nrtend);
+    REQUIRE( qrtend[0] <= qr_incld[0]/dt);
+    REQUIRE( nrtend[0] <= nr_incld[0]/dt); //keep end-of-step nr positive. Should always be true.
+	     
   }; //end run_property
     
   static void run_bfb(){

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -150,10 +150,10 @@ interface
   subroutine linear_interp_f(x1, x2, y1, y2, km1, km2, ncol, minthresh) bind(C)
     use iso_c_binding
 
+    integer(kind=c_int) , value, intent(in) :: km1, km2, ncol
     real(kind=c_real) , intent(in), dimension(ncol, km1) :: x1, y1
     real(kind=c_real) , intent(in), dimension(ncol, km2) :: x2
     real(kind=c_real) , intent(out), dimension(ncol, km2) :: y2
-    integer(kind=c_int) , value, intent(in) :: km1, km2, ncol
     real(kind=c_real) , value, intent(in) :: minthresh
   end subroutine linear_interp_f
 


### PR DESCRIPTION
evaporate_rain wasn't checking whether it was removing more qr than existed to start with. Also added property unit test to check that this doesn't happen again. 