### PR TITLE
Simplified Field class and surrounding datatypes.

### DIFF
--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -81,7 +81,6 @@ void AtmosphereDriver::initialize (const ekat::Comm& atm_comm,
                                    const ekat::ParameterList& params,
                                    const util::TimeStamp& t0)
 {
-  using device_type = DefaultDevice;
   m_atm_comm = atm_comm;
   m_atm_params = params;
   m_current_ts = t0;
@@ -107,32 +106,32 @@ void AtmosphereDriver::initialize (const ekat::Comm& atm_comm,
 
   // By now, the processes should have fully built the ids of their
   // required/computed fields. Let them register them in the repo
-  m_device_field_repo = std::make_shared<FieldRepository<Real,device_type>>();
-  m_device_field_repo->registration_begins();
-  m_atm_process_group->register_fields(*m_device_field_repo);
-  m_device_field_repo->registration_ends();
+  m_field_repo = std::make_shared<FieldRepository<Real> >();
+  m_field_repo->registration_begins();
+  m_atm_process_group->register_fields(*m_field_repo);
+  m_field_repo->registration_ends();
 
   // Set all the fields in the processes needing them (before, they only had ids)
   // Input fields will be handed to the processes as const
   const auto& inputs  = m_atm_process_group->get_required_fields();
   const auto& outputs = m_atm_process_group->get_computed_fields();
   for (const auto& id : inputs) {
-    m_atm_process_group->set_required_field(m_device_field_repo->get_field(id).get_const());
+    m_atm_process_group->set_required_field(m_field_repo->get_field(id).get_const());
   }
   // Internal fields are fields that the atm proc group both computes and requires
   // (in that order). These are present only in case of sequential splitting
   for (const auto& id : m_atm_process_group->get_internal_fields()) {
-    m_atm_process_group->set_internal_field(m_device_field_repo->get_field(id));
+    m_atm_process_group->set_internal_field(m_field_repo->get_field(id));
   }
   // Output fields are handed to the processes as writable
   for (const auto& id : outputs) {
-    m_atm_process_group->set_computed_field(m_device_field_repo->get_field(id));
+    m_atm_process_group->set_computed_field(m_field_repo->get_field(id));
   }
 
   // Note: remappers should be setup *after* fields have been set in the atm processes,
   //       just in case some atm proc sets some extra data in the field header,
   //       that some remappers may actually need.
-  m_atm_process_group->setup_remappers(*m_device_field_repo);
+  m_atm_process_group->setup_remappers(*m_field_repo);
 
   // Initialize the processes
   m_atm_process_group->initialize(t0);
@@ -146,15 +145,15 @@ void AtmosphereDriver::initialize (const ekat::Comm& atm_comm,
   inspect_atm_dag ();
 
   // Set time steamp t0 to all fields
-  for (auto& field_map_it : *m_device_field_repo) {
+  for (auto& field_map_it : *m_field_repo) {
     for (auto& f_it : field_map_it.second) {
       f_it.second.get_header().get_tracking().update_time_stamp(t0);
     }
   }
 
 #ifdef SCREAM_DEBUG
-  create_bkp_device_field_repo();
-  m_atm_process_group->set_field_repos(*m_device_field_repo,m_bkp_device_field_repo);
+  create_bkp_field_repo();
+  m_atm_process_group->set_field_repos(*m_field_repo,m_bkp_field_repo);
 #endif
 }
 
@@ -173,16 +172,16 @@ void AtmosphereDriver::run (const Real dt) {
 void AtmosphereDriver::finalize ( /* inputs? */ ) {
   m_atm_process_group->finalize( /* inputs ? */ );
 
-  m_device_field_repo->clean_up();
+  m_field_repo->clean_up();
 #ifdef SCREAM_DEBUG
-  m_bkp_device_field_repo.clean_up();
+  m_bkp_field_repo.clean_up();
 #endif
 }
 
 void AtmosphereDriver::init_atm_inputs () {
   const auto& atm_inputs = m_atm_process_group->get_required_fields();
   for (const auto& id : atm_inputs) {
-    auto& f = m_device_field_repo->get_field(id);
+    auto& f = m_field_repo->get_field(id);
     auto init_type = f.get_header_ptr()->get_tracking().get_init_type();
     if (init_type!=InitType::None) {
       auto initializer = f.get_header_ptr()->get_tracking().get_initializer().lock();
@@ -231,9 +230,9 @@ void AtmosphereDriver::inspect_atm_dag () {
 }
 
 #ifdef SCREAM_DEBUG
-void AtmosphereDriver::create_bkp_device_field_repo () {
-  m_bkp_device_field_repo.registration_begins();
-  for (const auto& it : *m_device_field_repo) {
+void AtmosphereDriver::create_bkp_field_repo () {
+  m_bkp_field_repo.registration_begins();
+  for (const auto& it : *m_field_repo) {
     for (const auto& id_field : it.second) {
       const auto& id = id_field.first;
       const auto& f = id_field.second;
@@ -244,18 +243,18 @@ void AtmosphereDriver::create_bkp_device_field_repo () {
       for (const auto& group : groups) {
         grps.insert(group);
       }
-      m_bkp_device_field_repo.register_field(id,grps);
+      m_bkp_field_repo.register_field(id,grps);
     }
   }
-  m_bkp_device_field_repo.registration_ends();
+  m_bkp_field_repo.registration_ends();
 
   // Deep copy the fields
-  for (const auto& it : *m_device_field_repo) {
+  for (const auto& it : *m_field_repo) {
     for (const auto& id_field : it.second) {
       const auto& id = id_field.first;
       const auto& f  = id_field.second;
       auto src = f.get_view();
-      auto tgt = m_bkp_device_field_repo.get_field(id).get_view();
+      auto tgt = m_bkp_field_repo.get_field(id).get_view();
 
       Kokkos::deep_copy(tgt,src);
     }

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -36,8 +36,6 @@ class AtmosphereDriver
 {
 public:
 
-  using device_type = DefaultDevice;
-
   // The initialization method should:
   //   1) create all the subcomponents needed, given the current simulation parameters
   //   2) initialize all the subcomponents
@@ -58,9 +56,9 @@ public:
   // Clean up the driver (includes cleaning up the parameterizations and the fm's);
   void finalize ( /* inputs */ );
 
-  const FieldRepository<Real,device_type>& get_field_repo () const { return *m_device_field_repo; }
+  const FieldRepository<Real>& get_field_repo () const { return *m_field_repo; }
 #ifdef SCREAM_DEBUG
-  const FieldRepository<Real,device_type>& get_bkp_field_repo () const { return m_bkp_device_field_repo; }
+  const FieldRepository<Real>& get_bkp_field_repo () const { return m_bkp_field_repo; }
 #endif
 
   // Get atmosphere time stamp
@@ -70,12 +68,12 @@ protected:
   void init_atm_inputs ();
   void inspect_atm_dag ();
 #ifdef SCREAM_DEBUG
-  void create_bkp_device_field_repo ();
+  void create_bkp_field_repo ();
 #endif
 
-  std::shared_ptr<FieldRepository<Real,device_type>>  m_device_field_repo;
+  std::shared_ptr<FieldRepository<Real> >  m_field_repo;
 #ifdef SCREAM_DEBUG
-  FieldRepository<Real,device_type>                   m_bkp_device_field_repo;
+  FieldRepository<Real>                    m_bkp_field_repo;
 #endif
   ekat::WeakPtrSet<FieldInitializer>                  m_field_initializers;
 

--- a/components/scream/src/control/tests/dummy_atm_proc.hpp
+++ b/components/scream/src/control/tests/dummy_atm_proc.hpp
@@ -8,11 +8,10 @@ namespace scream {
 
 // === A dummy atm process, on Physics grid === //
 
-template<typename DeviceType, int PackSize, bool forward>
+template<int PackSize, bool forward>
 class DummyProcess : public scream::AtmosphereProcess {
 public:
-  using device_type = DeviceType;
-  using exec_space  = typename device_type::execution_space;
+  using exec_space  = typename DefaultDevice::execution_space;
 
   DummyProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
    : m_comm(comm)
@@ -97,7 +96,7 @@ public:
   void finalize_impl ( ) {}
 
   // Register all fields in the given repo
-  void register_fields (FieldRepository<Real, device_type>& field_repo) const {
+  void register_fields (FieldRepository<Real>& field_repo) const {
     using pack_type = ekat::Pack<Real,PackSize>;
     field_repo.template register_field<pack_type>(*m_input_fids.begin());
     field_repo.template register_field<pack_type>(*m_output_fids.begin());
@@ -110,10 +109,10 @@ public:
 protected:
 
   // Setting the field in the atmosphere process
-  void set_required_field_impl (const Field<const Real, device_type>& f) {
+  void set_required_field_impl (const Field<const Real>& f) {
     m_input = f;
   }
-  void set_computed_field_impl (const Field<      Real, device_type>& f) {
+  void set_computed_field_impl (const Field<      Real>& f) {
     m_output = f;
   }
 
@@ -122,8 +121,8 @@ protected:
   std::set<FieldIdentifier> m_input_fids;
   std::set<FieldIdentifier> m_output_fids;
 
-  Field<const Real,device_type> m_input;
-  Field<Real,device_type>       m_output;
+  Field<const Real> m_input;
+  Field<Real>       m_output;
 
   std::shared_ptr<const AbstractGrid>   m_grid;
 

--- a/components/scream/src/control/tests/dummy_atm_setup.hpp
+++ b/components/scream/src/control/tests/dummy_atm_setup.hpp
@@ -11,14 +11,13 @@ namespace scream {
 
 void dummy_atm_init (const int num_cols, const int nvl, const ekat::Comm& comm) {
   using namespace scream;
-  using device_type = DefaultDevice;
 
   // Need to register products in the factory *before* we create any AtmosphereProcessGroup,
   // which rely on factory for process creation. The initialize method of the AD does that.
   // While we're at it, check that the case insensitive key of the factory works.
   auto& proc_factory = AtmosphereProcessFactory::instance();
-  proc_factory.register_product("physics_fwd",&create_atmosphere_process<DummyProcess<device_type,2,true>>);
-  proc_factory.register_product("physics_bwd",&create_atmosphere_process<DummyProcess<device_type,4,false>>);
+  proc_factory.register_product("physics_fwd",&create_atmosphere_process<DummyProcess<2,true>>);
+  proc_factory.register_product("physics_bwd",&create_atmosphere_process<DummyProcess<4,false>>);
 
   // Need to register grids managers before we create the driver
   auto& gm_factory = GridsManagerFactory::instance();
@@ -34,7 +33,7 @@ void dummy_atm_init (const int num_cols, const int nvl, const ekat::Comm& comm) 
   upgm.set_grid(dummy_grid_fwd);
   upgm.set_grid(dummy_grid_bwd);
   upgm.set_reference_grid("Physics_fwd");
-  using remapper_type = DummyPhysicsGridRemapper<Real,device_type>;
+  using remapper_type = DummyPhysicsGridRemapper<Real>;
   upgm.set_remapper(std::make_shared<remapper_type>(dummy_grid_fwd,dummy_grid_bwd));
   upgm.set_remapper(std::make_shared<remapper_type>(dummy_grid_bwd,dummy_grid_fwd));
 }

--- a/components/scream/src/control/tests/dummy_grid.hpp
+++ b/components/scream/src/control/tests/dummy_grid.hpp
@@ -5,11 +5,11 @@ namespace scream {
 
 // === A dummy physics grids for this test === //
 
-template<typename ScalarType, typename DeviceType>
-class DummyPhysicsGridRemapper : public AbstractRemapper<ScalarType,DeviceType>
+template<typename RealType>
+class DummyPhysicsGridRemapper : public AbstractRemapper<RealType>
 {
 public:
-  using base_type       = AbstractRemapper<ScalarType,DeviceType>;
+  using base_type       = AbstractRemapper<RealType>;
   using grid_type       = typename base_type::grid_type;
   using field_type      = typename base_type::field_type;
   using identifier_type = typename base_type::identifier_type;

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -166,7 +166,7 @@ void P3Microphysics::finalize_impl()
 }
 
 // =========================================================================================
-void P3Microphysics::register_fields (FieldRepository<Real, device_type>& field_repo) const {
+void P3Microphysics::register_fields (FieldRepository<Real>& field_repo) const {
   for (auto& fid : m_required_fields) {
     field_repo.register_field(fid);
   }
@@ -175,7 +175,7 @@ void P3Microphysics::register_fields (FieldRepository<Real, device_type>& field_
   }
 }
 
-void P3Microphysics::set_required_field_impl (const Field<const Real, device_type>& f) {
+void P3Microphysics::set_required_field_impl (const Field<const Real>& f) {
   // Store a copy of the field. We need this in order to do some tracking checks
   // at the beginning of the run call. Other than that, there would be really
   // no need to store a scream field here; we could simply set the view ptr
@@ -189,7 +189,7 @@ void P3Microphysics::set_required_field_impl (const Field<const Real, device_typ
   add_me_as_customer(f);
 }
 
-void P3Microphysics::set_computed_field_impl (const Field<      Real, device_type>& f) {
+void P3Microphysics::set_computed_field_impl (const Field<      Real>& f) {
   // Store a copy of the field. We need this in order to do some tracking updates
   // at the end of the run call. Other than that, there would be really
   // no need to store a scream field here; we could simply set the view ptr

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -21,8 +21,8 @@ namespace scream
 class P3Microphysics : public AtmosphereProcess
 {
 public:
-  using field_type       = Field<      Real,device_type>;
-  using const_field_type = Field<const Real,device_type>;
+  using field_type       = Field<      Real>;
+  using const_field_type = Field<const Real>;
 
   // Constructors
   P3Microphysics (const ekat::Comm& comm, const ekat::ParameterList& params);
@@ -47,7 +47,7 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
   // Register all fields in the given repo
-  void register_fields (FieldRepository<Real, device_type>& field_repo) const;
+  void register_fields (FieldRepository<Real>& field_repo) const;
 
   // Get the set of required/computed fields
   const std::set<FieldIdentifier>& get_required_fields () const { return m_required_fields; }
@@ -61,8 +61,8 @@ protected:
   void finalize_impl   ();
 
   // Setting the fields in the atmospheric process
-  void set_required_field_impl (const Field<const Real, device_type>& f);
-  void set_computed_field_impl (const Field<      Real, device_type>& f);
+  void set_required_field_impl (const Field<const Real>& f);
+  void set_computed_field_impl (const Field<      Real>& f);
 
   std::set<FieldIdentifier> m_required_fields;
   std::set<FieldIdentifier> m_computed_fields;

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -22,12 +22,12 @@ namespace scream {
     void RRTMGPRadiation::finalize_impl  () {}
 
     // Register all required and computed field in the field repository
-    void RRTMGPRadiation::register_fields(FieldRepository<Real, device_type>& field_repo) const {
+    void RRTMGPRadiation::register_fields(FieldRepository<Real>& field_repo) const {
         for (auto& fid: m_required_fields) { field_repo.register_field(fid); }
         for (auto& fid: m_computed_fields) { field_repo.register_field(fid); }
     }
 
-    void RRTMGPRadiation::set_required_field_impl(const Field<const Real, device_type>& f) {
+    void RRTMGPRadiation::set_required_field_impl(const Field<const Real>& f) {
         /* The following copied from the P3 code */
         //const auto& name = f.get_header().get_identifier().name();
         //m_rrtmgp_fields_in.emplace(name,f);
@@ -38,7 +38,7 @@ namespace scream {
         //add_me_as_customer(f);
     }
 
-    void RRTMGPRadiation::set_computed_field_impl(const Field<      Real, device_type>& f) {
+    void RRTMGPRadiation::set_computed_field_impl(const Field<      Real>& f) {
         /* The following copied from the P3 code */
         //const auto& name = f.get_header().get_identifier().name();
         //m_rrtmgp_fields_out.emplace(name,f);

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -13,8 +13,8 @@ namespace scream {
 
     class RRTMGPRadiation : public AtmosphereProcess {
         public:
-            using field_type       = Field<      Real, device_type>;
-            using const_field_type = Field<const Real, device_type>;
+            using field_type       = Field<      Real>;
+            using const_field_type = Field<const Real>;
 
             // Constructors
             RRTMGPRadiation (const ekat::Comm& comm, const ekat::ParameterList& params);
@@ -39,7 +39,7 @@ namespace scream {
             void set_grids (const std::shared_ptr<const GridsManager> grid_manager);
 
             // Register all fields in the given repo
-            void register_fields (FieldRepository<Real, device_type>& field_repo) const;
+            void register_fields (FieldRepository<Real>& field_repo) const;
 
             // Get the set of required/computed fields
             const std::set<FieldIdentifier>& get_required_fields () const { return m_required_fields; }
@@ -52,8 +52,8 @@ namespace scream {
             void finalize_impl   ();
 
             // Set fields in the atmosphere process
-            void set_required_field_impl (const Field<const Real, device_type>& f);
-            void set_computed_field_impl (const Field<      Real, device_type>& f);
+            void set_required_field_impl (const Field<const Real>& f);
+            void set_computed_field_impl (const Field<      Real>& f);
 
             std::set<FieldIdentifier> m_required_fields;
             std::set<FieldIdentifier> m_computed_fields;

--- a/components/scream/src/physics/share/physics_only_grids_manager.cpp
+++ b/components/scream/src/physics/share/physics_only_grids_manager.cpp
@@ -24,7 +24,7 @@ do_create_remapper (const grid_ptr_type from_grid,
   EKAT_REQUIRE_MSG(from_grid->name()==to_grid->name(),
                    "Error! So far, PhysicsOnlyGridsManager assumes only one type of grid for physiccs.\n");
 
-  return std::make_shared<IdentityRemapper<Real,device_type>>(from_grid);
+  return std::make_shared<IdentityRemapper<Real> >(from_grid);
 }
 
 void PhysicsOnlyGridsManager::build_grid (const std::string& grid_name) {

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -94,7 +94,7 @@ void SHOCMacrophysics::finalize_impl()
 }
 // =========================================================================================
 
-void SHOCMacrophysics::register_fields (FieldRepository<Real, device_type>& field_repo) const {
+void SHOCMacrophysics::register_fields (FieldRepository<Real>& field_repo) const {
   for (auto& fid : m_required_fields) {
     field_repo.register_field(fid);
   }
@@ -103,7 +103,7 @@ void SHOCMacrophysics::register_fields (FieldRepository<Real, device_type>& fiel
   }
 }
 
-void SHOCMacrophysics::set_required_field_impl (const Field<const Real, device_type>& f) {
+void SHOCMacrophysics::set_required_field_impl (const Field<const Real>& f) {
   // Store a copy of the field. We need this in order to do some tracking checks
   // at the beginning of the run call. Other than that, there would be really
   // no need to store a scream field here; we could simply set the view ptr
@@ -114,7 +114,7 @@ void SHOCMacrophysics::set_required_field_impl (const Field<const Real, device_t
   f.get_header_ptr()->get_tracking().add_customer(weak_from_this());
 }
 
-void SHOCMacrophysics::set_computed_field_impl (const Field<      Real, device_type>& f) {
+void SHOCMacrophysics::set_computed_field_impl (const Field<Real>& f) {
   // Store a copy of the field. We need this in order to do some tracking updates
   // at the end of the run call. Other than that, there would be really
   // no need to store a scream field here; we could simply set the view ptr

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -21,8 +21,8 @@ namespace scream
 class SHOCMacrophysics : public scream::AtmosphereProcess
 {
 public:
-  using field_type       = Field<      Real,device_type>;
-  using const_field_type = Field<const Real,device_type>;
+  using field_type       = Field<      Real>;
+  using const_field_type = Field<const Real>;
 
   // Constructors
   SHOCMacrophysics (const ekat::Comm& comm, const ekat::ParameterList& params);
@@ -47,7 +47,7 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
   // Register all fields in the given repo
-  void register_fields (FieldRepository<Real, device_type>& field_repo) const;
+  void register_fields (FieldRepository<Real>& field_repo) const;
 
   // Get the set of required/computed fields
   const std::set<FieldIdentifier>& get_required_fields () const { return m_required_fields; }
@@ -61,8 +61,8 @@ protected:
   void finalize_impl   ();
 
   // Setting the fields in the atmospheric process
-  void set_required_field_impl (const Field<const Real, device_type>& f);
-  void set_computed_field_impl (const Field<      Real, device_type>& f);
+  void set_required_field_impl (const Field<const Real>& f);
+  void set_computed_field_impl (const Field<      Real>& f);
 
   std::set<FieldIdentifier> m_required_fields;
   std::set<FieldIdentifier> m_computed_fields;

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
@@ -135,7 +135,7 @@ void ZMDeepConvection::finalize_impl()
   zm_finalize_f90 ();
 }
 // =========================================================================================
-void ZMDeepConvection::register_fields (FieldRepository<Real, device_type>& field_repo) const {
+void ZMDeepConvection::register_fields (FieldRepository<Real>& field_repo) const {
    for (auto& fid : m_required_fields) {
      field_repo.register_field(fid);
    }
@@ -144,7 +144,7 @@ void ZMDeepConvection::register_fields (FieldRepository<Real, device_type>& fiel
    }
  }
 
-void ZMDeepConvection::set_required_field_impl (const Field<const Real, device_type>& f) {
+void ZMDeepConvection::set_required_field_impl (const Field<const Real>& f) {
   // @Meredith: Diff between add_me_as_a_customer and get_tracking().add_customer? 
   
   // Store a copy of the field. We need this in order to do some tracking checks
@@ -160,7 +160,7 @@ void ZMDeepConvection::set_required_field_impl (const Field<const Real, device_t
 
 }
 
-void ZMDeepConvection::set_computed_field_impl (const Field<      Real, device_type>& f) {
+void ZMDeepConvection::set_computed_field_impl (const Field<      Real>& f) {
   // Store a copy of the field. We need this in order to do some tracking updates
   // at the end of the run call. Other than that, there would be really
   // no need to store a scream field here; we could simply set the view ptr

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.hpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.hpp
@@ -20,8 +20,8 @@ namespace scream
 class ZMDeepConvection : public AtmosphereProcess
 {
 public:
-  using field_type       = Field<      Real,device_type>;
-  using const_field_type = Field<const Real,device_type>;
+  using field_type       = Field<      Real>;
+  using const_field_type = Field<const Real>;
 
   // Constructors
   ZMDeepConvection (const ekat::Comm& comm, const ekat::ParameterList& params);
@@ -51,7 +51,7 @@ public:
   void finalize_impl   ();
 
   // Register all fields in the given repo
-  void register_fields (FieldRepository<Real, device_type>& field_repo) const;
+  void register_fields (FieldRepository<Real>& field_repo) const;
 
   // Get the set of required/computed fields
   const std::set<FieldIdentifier>& get_required_fields () const { return m_required_fields; }
@@ -60,8 +60,8 @@ public:
 protected:
 
   // Setting the fields in the atmospheric process
-  void set_required_field_impl (const Field<const Real, device_type>& f);
-  void set_computed_field_impl (const Field<      Real, device_type>& f);
+  void set_required_field_impl (const Field<const Real>& f);
+  void set_computed_field_impl (const Field<      Real>& f);
 
   std::set<FieldIdentifier> m_required_fields;
   std::set<FieldIdentifier> m_computed_fields;

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -49,7 +49,6 @@ namespace scream
 class AtmosphereProcess : public ekat::enable_shared_from_this<AtmosphereProcess>
 {
 public:
-  using device_type = DefaultDevice; // may need to template class on this
   using TimeStamp = util::TimeStamp;
 
   virtual ~AtmosphereProcess () = default;
@@ -100,7 +99,8 @@ public:
     finalize_impl(/* what inputs? */);
   }
 
-  // These methods set fields in the atm process. Fields live on device and they are all 1d.
+  // These methods set fields in the atm process. Fields live on the default
+  // device and they are all 1d.
   // If the process *needs* to store the field as n-dimensional field, use the
   // template function 'get_reshaped_view' (see field.hpp for details).
   // Note: this method will be called *after* set_grid, but *before* initialize.
@@ -109,13 +109,13 @@ public:
   //       However, if this process is of type Group, we don't really want to add it
   //       as provider/customer. The group is just a 'design layer', and the stored processes
   //       are the actuall providers/customers.
-  void set_required_field (const Field<const Real, device_type>& f) {
+  void set_required_field (const Field<const Real>& f) {
     ekat::error::runtime_check(requires(f.get_header().get_identifier()),
                          "Error! This atmosphere process does not require this field. "
                          "Something is wrong up the call stack. Please, contact developers.\n");
     set_required_field_impl (f);
   }
-  void set_computed_field (const Field<Real, device_type>& f) {
+  void set_computed_field (const Field<Real>& f) {
     ekat::error::runtime_check(computes(f.get_header().get_identifier()),
                          "Error! This atmosphere process does not compute this field. "
                          "Something is wrong up the call stack. Please, contact developers.\n");
@@ -123,7 +123,7 @@ public:
   }
 
   // Register required/computed fields in the field repo
-  virtual void register_fields (FieldRepository<Real, device_type>& field_repo) const = 0;
+  virtual void register_fields (FieldRepository<Real>& field_repo) const = 0;
 
   // These two methods allow the driver to figure out what process need
   // a given field and what process updates a given field.
@@ -151,16 +151,16 @@ protected:
     return t_;
   }
 
-  void add_me_as_provider (const Field<Real, device_type>& f) {
+  void add_me_as_provider (const Field<Real>& f) {
     f.get_header_ptr()->get_tracking().add_provider(weak_from_this());
   }
 
-  void add_me_as_customer (const Field<const Real, device_type>& f) {
+  void add_me_as_customer (const Field<const Real>& f) {
     f.get_header_ptr()->get_tracking().add_customer(weak_from_this());
   }
 
-  virtual void set_required_field_impl (const Field<const Real, device_type>& f) = 0;
-  virtual void set_computed_field_impl (const Field<      Real, device_type>& f) = 0;
+  virtual void set_required_field_impl (const Field<const Real>& f) = 0;
+  virtual void set_computed_field_impl (const Field<      Real>& f) = 0;
 
 private:
 

--- a/components/scream/src/share/atm_process/atmosphere_process_dag.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_dag.hpp
@@ -13,7 +13,7 @@ public:
   static constexpr int VERB_MAX = 4;
 
   void create_dag (const group_type& atm_procs);
-  
+
   void add_field_initializer (const FieldInitializer& initializer);
 
   void write_dag (const std::string& fname, const int verbosity = VERB_MAX) const;

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -217,7 +217,7 @@ void AtmosphereProcessGroup::initialize_impl (const TimeStamp& t0) {
 }
 
 void AtmosphereProcessGroup::
-setup_remappers (const FieldRepository<Real, device_type>& field_repo) {
+setup_remappers (const FieldRepository<Real>& field_repo) {
   // Now that all fields have been set, we can set the fields in the remappers
   for (int iproc=0; iproc<m_group_size; ++iproc) {
     for (auto& it : m_inputs_remappers[iproc]) {
@@ -371,7 +371,7 @@ void AtmosphereProcessGroup::finalize_impl (/* what inputs? */) {
   }
 }
 
-void AtmosphereProcessGroup::register_fields (FieldRepository<Real, device_type>& field_repo) const {
+void AtmosphereProcessGroup::register_fields (FieldRepository<Real>& field_repo) const {
   for (int iproc=0; iproc<m_group_size; ++iproc) {
     const auto& atm_proc = m_atm_processes[iproc];
     atm_proc->register_fields(field_repo);
@@ -411,7 +411,7 @@ void AtmosphereProcessGroup::register_fields (FieldRepository<Real, device_type>
   }
 }
 
-void AtmosphereProcessGroup::set_required_field_impl (const Field<const Real, device_type>& f) {
+void AtmosphereProcessGroup::set_required_field_impl (const Field<const Real>& f) {
   const auto& fid = f.get_header().get_identifier();
   for (auto atm_proc : m_atm_processes) {
     if (atm_proc->requires(fid)) {
@@ -420,7 +420,7 @@ void AtmosphereProcessGroup::set_required_field_impl (const Field<const Real, de
   }
 }
 
-void AtmosphereProcessGroup::set_computed_field_impl (const Field<Real, device_type>& f) {
+void AtmosphereProcessGroup::set_computed_field_impl (const Field<Real>& f) {
   const auto& fid = f.get_header().get_identifier();
   for (auto atm_proc : m_atm_processes) {
     if (atm_proc->computes(fid)) {
@@ -438,8 +438,8 @@ void AtmosphereProcessGroup::set_computed_field_impl (const Field<Real, device_t
 
 #ifdef SCREAM_DEBUG
 void AtmosphereProcessGroup::
-set_field_repos (const FieldRepository<Real, device_type>& repo,
-                 const FieldRepository<Real, device_type>& bkp_repo) {
+set_field_repos (const FieldRepository<Real>& repo,
+                 const FieldRepository<Real>& bkp_repo) {
   m_field_repo = &repo;
   m_bkp_field_repo = &bkp_repo;
   for (auto atm_proc : m_atm_processes) {
@@ -485,7 +485,7 @@ views_are_equal(const field_type& f1, const field_type& f2) {
 }
 #endif
 
-void AtmosphereProcessGroup::set_internal_field (const Field<Real, device_type>& f)
+void AtmosphereProcessGroup::set_internal_field (const Field<Real>& f)
 {
   const auto& fid = f.get_header().get_identifier();
   for (int iproc=0; iproc<m_group_size; ++iproc) {

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -26,7 +26,7 @@ class AtmosphereProcessGroup : public AtmosphereProcess
 {
 public:
   using atm_proc_type     = AtmosphereProcess;
-  using remapper_type     = AbstractRemapper<Real, device_type>;
+  using remapper_type     = AbstractRemapper<Real>;
   using remapper_ptr_type = std::shared_ptr<remapper_type>;
 
   // Constructor(s)
@@ -52,7 +52,7 @@ public:
   void final_setup ();
 
   // Register all fields in the given repo
-  void register_fields (FieldRepository<Real, device_type>& field_repo) const;
+  void register_fields (FieldRepository<Real>& field_repo) const;
 
   // The methods used to query the process for its inputs/outputs
   const std::set<FieldIdentifier>&  get_required_fields () const { return m_required_fields; }
@@ -67,7 +67,7 @@ public:
     return m_atm_processes.at(i);
   }
 
-  void setup_remappers (const FieldRepository<Real, device_type>& field_repo);
+  void setup_remappers (const FieldRepository<Real>& field_repo);
 
   const std::vector<std::map<std::string,remapper_ptr_type>>&
   get_inputs_remappers () const { return m_inputs_remappers; }
@@ -78,11 +78,11 @@ public:
   ScheduleType get_schedule_type () const { return m_group_schedule_type; }
 
 #ifdef SCREAM_DEBUG
-  void set_field_repos (const FieldRepository<Real, device_type>& repo,
-                        const FieldRepository<Real, device_type>& bkp_repo);
+  void set_field_repos (const FieldRepository<Real>& repo,
+                        const FieldRepository<Real>& bkp_repo);
 #endif
 
-  void set_internal_field (const Field<Real, device_type>& f);
+  void set_internal_field (const Field<Real>& f);
 
 protected:
 
@@ -95,8 +95,8 @@ protected:
   void run_parallel   (const Real dt);
 
   // The methods to set the fields in the process
-  void set_required_field_impl (const Field<const Real, device_type>& f);
-  void set_computed_field_impl (const Field<      Real, device_type>& f);
+  void set_required_field_impl (const Field<const Real>& f);
+  void set_computed_field_impl (const Field<      Real>& f);
 
   // Method to build the identifier of a field on the reference grid given
   // an identifier on a different grid
@@ -152,11 +152,11 @@ protected:
   std::vector<std::map<std::string,remapper_ptr_type>> m_outputs_remappers;
 
 #ifdef SCREAM_DEBUG
-  using field_type = Field<Real, device_type>;
+  using field_type = Field<Real>;
   bool views_are_equal (const field_type& v1, const field_type& v2);
 
-  const FieldRepository<Real, device_type>*   m_field_repo;
-  const FieldRepository<Real, device_type>*   m_bkp_field_repo;
+  const FieldRepository<Real>*   m_field_repo;
+  const FieldRepository<Real>*   m_bkp_field_repo;
 
 #endif
 };

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -18,19 +18,15 @@ struct is_scream_field : public std::false_type {};
 
 // ======================== FIELD ======================== //
 
-// A field should be composed of metadata info (the header) and a pointer to the view
-// TODO: make a FieldBase class, without the view (just meta-data), without templating on
-//       the device type. Then make Field inherit from FieldBase, templating it on the
-//       device type. This way, we can pass FieldBase around, and the individual atm
-//       atm processes will try to cast to Field<Real,MyDeviceType>. This way, we can
-//       allow different atm processes to run on different device types.
-
-template<typename ScalarType, typename Device>
+// A field is composed of metadata info (the header) and a pointer to a view.
+// Fields are always stored as 1D arrays of real-valued data. The associated
+// view can be reshaped as needed to match a desired layout for a given client.
+template<typename RealType>
 class Field {
 public:
 
-  using value_type           = ScalarType;
-  using device_type          = Device;
+  using value_type           = RealType;
+  using device_type          = DefaultDevice;
   using header_type          = FieldHeader;
   using identifier_type      = header_type::identifier_type;
   using view_type            = typename KokkosTypes<device_type>::template view<value_type*>;
@@ -38,12 +34,12 @@ public:
   using const_value_type     = typename std::add_const<value_type>::type;
   using non_const_value_type = typename std::remove_const<value_type>::type;
 
-  using field_type           = Field<value_type, device_type>;
-  using const_field_type     = Field<const_value_type, device_type>;
-  using nonconst_field_type  = Field<non_const_value_type, device_type>;
+  using field_type           = Field<value_type>;
+  using const_field_type     = Field<const_value_type>;
+  using nonconst_field_type  = Field<non_const_value_type>;
 
-  // Statically check that ScalarType is not an array.
-  static_assert(view_type::Rank==1, "Error! ScalarType should not be an array type.\n");
+  // Statically check that RealType is not an array.
+  static_assert(view_type::Rank==1, "Error! RealType should not be an array type.\n");
 
   // Constructor(s)
   Field () = default;
@@ -51,11 +47,11 @@ public:
 
   // This constructor allows const->const, nonconst->nonconst, and nonconst->const copies
   template<typename SrcDT>
-  Field (const Field<SrcDT,device_type>& src);
+  Field (const Field<SrcDT>& src);
 
   // Assignment: allows const->const, nonconst->nonconst, and nonconst->const copies
   template<typename SrcDT>
-  Field& operator= (const Field<SrcDT,device_type>& src);
+  Field& operator= (const Field<SrcDT>& src);
 
   // ---- Getters and const methods---- //
   const header_type& get_header () const { return *m_header; }
@@ -95,13 +91,13 @@ protected:
   bool                            m_allocated;
 };
 
-template<typename ScalarType, typename DeviceType>
-struct is_scream_field<Field<ScalarType,DeviceType>> : public std::true_type {};
+template<typename RealType>
+struct is_scream_field<Field<RealType> > : public std::true_type {};
 
 // ================================= IMPLEMENTATION ================================== //
 
-template<typename ScalarType, typename Device>
-Field<ScalarType,Device>::
+template<typename RealType>
+Field<RealType>::
 Field (const identifier_type& id)
  : m_header    (new header_type(id))
  , m_allocated (false)
@@ -110,15 +106,15 @@ Field (const identifier_type& id)
   m_header->get_alloc_properties().request_value_type_allocation<value_type>();
 }
 
-template<typename ScalarType, typename Device>
-template<typename SrcScalarType>
-Field<ScalarType,Device>::
-Field (const Field<SrcScalarType,Device>& src)
+template<typename RealType>
+template<typename SrcRealType>
+Field<RealType>::
+Field (const Field<SrcRealType>& src)
  : m_header    (src.get_header_ptr())
  , m_view      (src.get_view())
  , m_allocated (src.is_allocated())
 {
-  using src_field_type = Field<SrcScalarType,Device>;
+  using src_field_type = Field<SrcRealType>;
 
   // Check that underlying value type
   static_assert(std::is_same<non_const_value_type,
@@ -131,11 +127,11 @@ Field (const Field<SrcScalarType,Device>& src)
                 "Error! Cannot create a nonconst field from a const field.\n");
 }
 
-template<typename ScalarType, typename Device>
-template<typename SrcScalarType>
-Field<ScalarType,Device>&
-Field<ScalarType,Device>::
-operator= (const Field<SrcScalarType,Device>& src) {
+template<typename RealType>
+template<typename SrcRealType>
+Field<RealType>&
+Field<RealType>::
+operator= (const Field<SrcRealType>& src) {
 
   using src_field_type = typename std::remove_reference<decltype(src)>::type;
 #ifndef CUDA_BUILD // TODO Figure out why nvcc isn't like this bit of code.
@@ -171,10 +167,10 @@ operator= (const Field<SrcScalarType,Device>& src) {
   return *this;
 }
 
-template<typename ScalarType, typename Device>
+template<typename RealType>
 template<typename DT>
-ekat::Unmanaged<typename KokkosTypes<Device>::template view<DT> >
-Field<ScalarType,Device>::get_reshaped_view () const {
+ekat::Unmanaged<typename KokkosTypes<DefaultDevice>::template view<DT> >
+Field<RealType>::get_reshaped_view () const {
   // The dst value types
   using DstValueType = typename ekat::ValueType<DT>::type;
 
@@ -193,7 +189,7 @@ Field<ScalarType,Device>::get_reshaped_view () const {
                        "Error! Source field allocation is not compatible with the destination field's value type.\n");
 
   // The destination view type
-  using DstView = ekat::Unmanaged<typename KokkosTypes<Device>::template view<DT> >;
+  using DstView = ekat::Unmanaged<typename KokkosTypes<DefaultDevice>::template view<DT> >;
   typename DstView::traits::array_layout kokkos_layout;
 
   const int num_values = alloc_prop.get_alloc_size() / sizeof(DstValueType);
@@ -216,8 +212,8 @@ Field<ScalarType,Device>::get_reshaped_view () const {
   return DstView (reinterpret_cast<DstValueType*>(m_view.data()),kokkos_layout);
 }
 
-template<typename ScalarType, typename Device>
-void Field<ScalarType,Device>::allocate_view ()
+template<typename RealType>
+void Field<RealType>::allocate_view ()
 {
   // Not sure if simply returning would be safe enough. Re-allocating
   // would definitely be error prone (someone may have already gotten

--- a/components/scream/src/share/field/field_initializer.hpp
+++ b/components/scream/src/share/field/field_initializer.hpp
@@ -21,10 +21,8 @@ namespace scream {
 
 class FieldInitializer : public ekat::enable_shared_from_this<FieldInitializer> {
 public:
-  using device_type = DefaultDevice; // may need to template class on this
-
-  using field_type       = Field<      Real,device_type>;
-  using const_field_type = Field<const Real,device_type>;
+  using field_type       = Field<      Real>;
+  using const_field_type = Field<const Real>;
 
   virtual ~FieldInitializer () = default;
 

--- a/components/scream/src/share/grid/grids_manager.hpp
+++ b/components/scream/src/share/grid/grids_manager.hpp
@@ -22,10 +22,9 @@ class GridsManager
 {
 public:
   using grid_type         = AbstractGrid;
-  using device_type       = grid_type::device_type;
   using grid_ptr_type     = std::shared_ptr<grid_type>;
   using grid_repo_type    = std::map<std::string, grid_ptr_type>;
-  using remapper_type     = AbstractRemapper<Real,device_type>;
+  using remapper_type     = AbstractRemapper<Real>;
   using remapper_ptr_type = std::shared_ptr<remapper_type>;
 
   GridsManager () = default;
@@ -59,7 +58,7 @@ public:
 
     if (from_grid->name()==to_grid->name()) {
       // We can handle the identity remapper from here
-      remapper = std::make_shared<IdentityRemapper<Real,device_type>>(from_grid);
+      remapper = std::make_shared<IdentityRemapper<Real> >(from_grid);
     } else {
       remapper = do_create_remapper(from_grid,to_grid);
     }

--- a/components/scream/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/scream/src/share/grid/remap/abstract_remapper.hpp
@@ -22,13 +22,12 @@ namespace scream
 // but as of now (07/2019) it is not the intent and projected use
 // of this class in the scream framework
 
-template<typename ScalarType, typename DeviceType>
+template<typename RealType>
 class AbstractRemapper
 {
 public:
-  using scalar_type     = ScalarType;
-  using device_type     = DeviceType;
-  using field_type      = Field<scalar_type,device_type>;
+  using real_type       = RealType;
+  using field_type      = Field<real_type>;
   using identifier_type = typename field_type::identifier_type;
   using layout_type     = typename identifier_type::layout_type;
   using grid_type       = AbstractGrid;
@@ -186,8 +185,8 @@ protected:
   int                 m_num_bound_fields;
 };
 
-template<typename ScalarType, typename DeviceType>
-AbstractRemapper<ScalarType,DeviceType>::
+template<typename RealType>
+AbstractRemapper<RealType>::
 AbstractRemapper (const grid_ptr_type& src_grid,
                   const grid_ptr_type& tgt_grid)
  : m_state                 (RepoState::Clean)
@@ -202,8 +201,8 @@ AbstractRemapper (const grid_ptr_type& src_grid,
   EKAT_REQUIRE_MSG(static_cast<bool>(tgt_grid), "Error! Invalid target grid pointer.\n");
 }
 
-template<typename ScalarType, typename DeviceType>
-void AbstractRemapper<ScalarType,DeviceType>::
+template<typename RealType>
+void AbstractRemapper<RealType>::
 registration_begins () {
   EKAT_REQUIRE_MSG(m_state==RepoState::Clean,
                        "Error! Cannot start registration on a non-clean repo.\n"
@@ -214,8 +213,8 @@ registration_begins () {
   m_state = RepoState::Open;
 }
 
-template<typename ScalarType, typename DeviceType>
-void AbstractRemapper<ScalarType,DeviceType>::
+template<typename RealType>
+void AbstractRemapper<RealType>::
 register_field (const identifier_type& src, const identifier_type& tgt) {
   EKAT_REQUIRE_MSG(m_state!=RepoState::Clean,
                        "Error! Cannot register fields in the remapper at this time.\n"
@@ -238,16 +237,16 @@ register_field (const identifier_type& src, const identifier_type& tgt) {
   ++m_num_registered_fields;
 }
 
-template<typename ScalarType, typename DeviceType>
-void AbstractRemapper<ScalarType,DeviceType>::
+template<typename RealType>
+void AbstractRemapper<RealType>::
 register_field (const field_type& src, const field_type& tgt) {
   register_field(src.get_header().get_identifier(),
                  tgt.get_header().get_identifier());
   bind_field(src,tgt);
 }
 
-template<typename ScalarType, typename DeviceType>
-void AbstractRemapper<ScalarType,DeviceType>::
+template<typename RealType>
+void AbstractRemapper<RealType>::
 unregister_field (const identifier_type& src, const identifier_type& tgt) {
   EKAT_REQUIRE_MSG(m_state==RepoState::Open,
                      "Error! You can only un-register fields during the registration phase.\n");
@@ -269,8 +268,8 @@ unregister_field (const identifier_type& src, const identifier_type& tgt) {
   m_fields_are_bound.erase(m_fields_are_bound.begin()+ifield);
 }
 
-template<typename ScalarType, typename DeviceType>
-void AbstractRemapper<ScalarType,DeviceType>::
+template<typename RealType>
+void AbstractRemapper<RealType>::
 bind_field (const field_type& src, const field_type& tgt) {
   EKAT_REQUIRE_MSG(m_state!=RepoState::Clean,
                      "Error! Cannot bind fields in the remapper at this time.\n"
@@ -299,8 +298,8 @@ bind_field (const field_type& src, const field_type& tgt) {
   ++m_num_bound_fields;
 }
 
-template<typename ScalarType, typename DeviceType>
-void AbstractRemapper<ScalarType,DeviceType>::
+template<typename RealType>
+void AbstractRemapper<RealType>::
 registration_ends () {
   EKAT_REQUIRE_MSG(m_state!=RepoState::Closed,
                        "Error! Cannot call registration_ends at this time.\n"
@@ -314,11 +313,11 @@ registration_ends () {
 }
 
 // A short name for an AbstractRemapper factory
-template<typename ScalarType, typename Device>
+template<typename RealType>
 using RemapperFactory =
-    ekat::Factory<AbstractRemapper<ScalarType,Device>,
+    ekat::Factory<AbstractRemapper<RealType>,
                   ekat::CaseInsensitiveString,
-                  std::shared_ptr<AbstractRemapper<ScalarType,Device>>,
+                  std::shared_ptr<AbstractRemapper<RealType> >,
                   const ekat::ParameterList&>;
 
 } // namespace scream

--- a/components/scream/src/share/grid/remap/combo_remapper.hpp
+++ b/components/scream/src/share/grid/remap/combo_remapper.hpp
@@ -8,7 +8,7 @@ namespace scream
 
 /*
  *  A remapper representing the chaining of two remappers
- *  
+ *
  *  This remapper is rather simple: like InverseRemapper,
  *  it delegates all the work to the underlying remapper(s).
  *  The only additional duty of this remapper is to create
@@ -22,11 +22,11 @@ namespace scream
  *        to create this remapper, and then only interact with
  *        the combo remapper.
  */
-template<typename ScalarType, typename DeviceType>
-class ComboRemapper : public AbstractRemapper<ScalarType,DeviceType>
+template<typename RealType>
+class ComboRemapper : public AbstractRemapper<RealType>
 {
 public:
-  using base_type       = AbstractRemapper<ScalarType,DeviceType>;
+  using base_type       = AbstractRemapper<RealType>;
   using field_type      = typename base_type::field_type;
   using identifier_type = typename base_type::identifier_type;
   using layout_type     = typename base_type::layout_type;

--- a/components/scream/src/share/grid/remap/identity_remapper.hpp
+++ b/components/scream/src/share/grid/remap/identity_remapper.hpp
@@ -22,11 +22,11 @@ namespace scream
  *  there is no need to actually access the data.
  */
 
-template<typename ScalarType, typename DeviceType>
-class IdentityRemapper : public AbstractRemapper<ScalarType,DeviceType>
+template<typename RealType>
+class IdentityRemapper : public AbstractRemapper<RealType>
 {
 public:
-  using base_type       = AbstractRemapper<ScalarType,DeviceType>;
+  using base_type       = AbstractRemapper<RealType>;
   using field_type      = typename base_type::field_type;
   using identifier_type = typename base_type::identifier_type;
   using layout_type     = typename base_type::layout_type;

--- a/components/scream/src/share/grid/remap/inverse_remapper.hpp
+++ b/components/scream/src/share/grid/remap/inverse_remapper.hpp
@@ -7,11 +7,11 @@ namespace scream
 {
 
 // Performs remap by chaining two remap strategies
-template<typename ScalarType, typename DeviceType>
-class InverseRemapper : public AbstractRemapper<ScalarType,DeviceType>
+template<typename RealType>
+class InverseRemapper : public AbstractRemapper<RealType>
 {
 public:
-  using base_type       = AbstractRemapper<ScalarType,DeviceType>;
+  using base_type       = AbstractRemapper<RealType>;
   using field_type      = typename base_type::field_type;
   using identifier_type = typename base_type::identifier_type;
   using layout_type     = typename base_type::layout_type;

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -41,7 +41,7 @@ public:
   const ekat::Comm& get_comm () const { return m_comm; }
 
   // Register all fields in the given repo
-  void register_fields (FieldRepository<Real, device_type>& /* field_repo */) const {}
+  void register_fields (FieldRepository<Real>& /* field_repo */) const {}
 
   // Providing a list of required and computed fields
   const std::set<FieldIdentifier>&  get_required_fields () const { return m_fids_in; }
@@ -61,8 +61,8 @@ protected:
   void finalize_impl ( /* inputs */ ) {}
 
   // Setting the field in the atmosphere process
-  void set_required_field_impl (const Field<const Real, device_type>& /* f */) {}
-  void set_computed_field_impl (const Field<      Real, device_type>& /* f */) {}
+  void set_required_field_impl (const Field<const Real>& /* f */) {}
+  void set_computed_field_impl (const Field<      Real>& /* f */) {}
 
   std::set<FieldIdentifier> m_fids_in;
   std::set<FieldIdentifier> m_fids_out;
@@ -213,8 +213,8 @@ setup_upgm (const int ne) {
   upgm->set_grid(dummy_phys_grid);
   upgm->set_reference_grid(dummy_phys_grid->name());
 
-  using dummy_remapper = DummySEGridRemapper<Real,DefaultDevice>;
-  using inverse_remapper = InverseRemapper<Real,DefaultDevice>;
+  using dummy_remapper = DummySEGridRemapper<Real>;
+  using inverse_remapper = InverseRemapper<Real>;
   auto dummy_phys_dyn_remapper = std::make_shared<dummy_remapper>(dummy_phys_grid,dummy_dyn_grid);
   auto dummy_phys_dyn_remapper2 = std::make_shared<dummy_remapper>(dummy_phys_grid,dummy_dyn_grid);
   auto dummy_dyn_phys_remapper = std::make_shared<inverse_remapper>(dummy_phys_dyn_remapper2);

--- a/components/scream/src/share/tests/dummy_se_grid_remapper.hpp
+++ b/components/scream/src/share/tests/dummy_se_grid_remapper.hpp
@@ -21,11 +21,11 @@ namespace scream
  *  Every call to the actual remap methods doesn't do anything.
  */
 
-template<typename ScalarType, typename DeviceType>
-class DummySEGridRemapper : public AbstractRemapper<ScalarType,DeviceType>
+template<typename RealType>
+class DummySEGridRemapper : public AbstractRemapper<RealType>
 {
 public:
-  using base_type       = AbstractRemapper<ScalarType,DeviceType>;
+  using base_type       = AbstractRemapper<RealType>;
   using field_type      = typename base_type::field_type;
   using identifier_type = typename base_type::identifier_type;
   using layout_type     = typename base_type::layout_type;

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -63,8 +63,6 @@ TEST_CASE("field", "") {
   using namespace scream;
   using namespace ekat::units;
 
-  using Device = DefaultDevice;
-
   std::vector<FieldTag> tags = {FieldTag::Element, FieldTag::GaussPoint, FieldTag::VerticalLevel};
   std::vector<int> dims = {2, 3, 12};
 
@@ -73,11 +71,11 @@ TEST_CASE("field", "") {
 
   // Check copy constructor
   SECTION ("copy ctor") {
-    Field<Real,Device> f1 (fid);
+    Field<Real> f1 (fid);
 
     f1.allocate_view();
 
-    Field<const Real,Device> f2 = f1;
+    Field<const Real> f2 = f1;
     REQUIRE(f2.get_header_ptr()==f1.get_header_ptr());
     REQUIRE(f2.get_view()==f1.get_view());
     REQUIRE(f2.is_allocated());
@@ -85,7 +83,7 @@ TEST_CASE("field", "") {
 
   // Check if we can extract a reshaped view
   SECTION ("reshape simple") {
-    Field<Real,Device> f1 (fid);
+    Field<Real> f1 (fid);
 
     // Should not be able to reshape before allocating
     REQUIRE_THROWS(f1.get_reshaped_view<Real*>());
@@ -102,7 +100,7 @@ TEST_CASE("field", "") {
 
   // Check if we can request multiple value types
   SECTION ("reshape multiple value types") {
-    Field<Real,Device> f1 (fid);
+    Field<Real> f1 (fid);
     f1.get_header().get_alloc_properties().request_value_type_allocation<Pack<Real,8>>();
     f1.allocate_view();
 
@@ -166,7 +164,7 @@ TEST_CASE("field_repo", "") {
   fid7.set_grid_name("grid_3");
   fid8.set_grid_name("grid_3");
 
-  FieldRepository<Real,DefaultDevice>  repo;
+  FieldRepository<Real>  repo;
 
   // Should not be able to register fields yet
   REQUIRE_THROWS(repo.register_field(fid1,"group_1"));


### PR DESCRIPTION
This PR comes from a discussion I had with Luca last week about how we might simplify Fields and make it more obvious how they're intended to be used.

It removes the Device template parameter from the Field class and its associated types. This expresses our decision to always store Field data on DefaultDevice (CPU for CPU-enabled calculations, and GPU for GPU-enabled
ones).

We also change the remaining template parameter from ScalarType to RealType in the Field and related classes, to reflect the fact that Fields are always stored as 1D arrays of real-valued numbers (and never Packs).

Hopefully, these two changes simplify the Field class, and make it easier to understand the relationships between Fields and their (possible reshaped) views.

In order to make these changes, I had to make very minor edits in the atmosphere process types and their P3/SHOC/ZM/Radiation subclasses. Apologies for the inconvenience.