### PR TITLE
add c++ error function call

### DIFF
--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -53,6 +53,7 @@ if (NOT CUDA_BUILD)
     shoc_length.cpp
     shoc_energy_fixer.cpp
     shoc_compute_shoc_vapor.cpp
+    shoc_error_function.cpp
   ) # SHOC ETI SRCS
 endif()
 

--- a/components/scream/src/physics/shoc/shoc_error_function.cpp
+++ b/components/scream/src/physics/shoc/shoc_error_function.cpp
@@ -1,0 +1,13 @@
+#include "shoc_error_function_impl.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation for the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream

--- a/components/scream/src/physics/shoc/shoc_error_function_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_error_function_impl.hpp
@@ -1,0 +1,25 @@
+#ifndef SHOC_ERROR_FUNCTION_IMPL_HPP
+#define SHOC_ERROR_FUNCTION_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Implementation of shoc error_function. Clients should NOT
+ * #include this file, but include shoc_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::error_function(const Scalar &input,
+                                    Scalar       &output)
+{
+  output = std::erf(input);
+}
+
+} // namespace shoc
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -305,6 +305,9 @@ struct Functions
     const uview_1d<Spack>&       host_dse);
   KOKKOS_FUNCTION
   static void compute_shoc_vapor(const Int& shcol, const Int& nlev, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& ql, const uview_1d<Spack>& qv);
+
+  KOKKOS_FUNCTION
+  static void error_function(const Scalar& input, Scalar& output);
 }; // struct Functions
 
 } // namespace shoc
@@ -338,6 +341,7 @@ struct Functions
 #include "shoc_length_impl.hpp"
 # include "shoc_energy_fixer_impl.hpp"
 # include "shoc_compute_shoc_vapor_impl.hpp"
+# include "shoc_error_function_impl.hpp"
 #endif // KOKKOS_ENABLE_CUDA
 
 #endif

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -259,6 +259,8 @@ void shoc_pblintd_cldcheck_c(Int shcol, Int nlev, Int nlevi, Real* zi, Real* cld
 
 void compute_shoc_vapor_c(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv);
 
+void error_function_c(Real input, Real* output);
+
 } // end _c function decls
 
 namespace scream {
@@ -751,6 +753,12 @@ void compute_shoc_vapor(ComputeShocVaporData& d)
   d.transpose<ekat::TransposeDirection::c2f>();
   compute_shoc_vapor_c(d.shcol(), d.nlev(), d.qw, d.ql, d.qv);
   d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void error_function(ErrorFunctionData& d)
+{
+  shoc_init(1, true);
+  error_function_c(d.input, &d.output);
 }
 // end _c impls
 
@@ -1932,6 +1940,12 @@ void shoc_energy_fixer_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, R
 void compute_shoc_vapor_f(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv)
 {
   // TODO
+}
+
+void error_function_f(Real input, Real* output)
+{
+  using SHF = Functions<Real, DefaultDevice>;  
+  SHF::error_function(input, output[0]);
 }
 } // namespace shoc
 } // namespace scream

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -837,6 +837,12 @@ struct ComputeShocVaporData : public PhysicsTestData {
   
   SHOC_NO_SCALAR(ComputeShocVaporData, 2)
 };
+
+struct ErrorFunctionData
+{
+  Real input, output;
+};
+
 // Glue functions to call fortran from from C++ with the Data struct
 void shoc_grid                                      (SHOCGridData &d);
 void shoc_diag_obklen                               (SHOCObklenData &d);
@@ -899,6 +905,8 @@ void diag_second_moments_lbycond                    (DiagSecondMomentsLbycondDat
 void diag_second_moments(DiagSecondMomentsData& d);
 void diag_second_shoc_moments(DiagSecondShocMomentsData& d);
 void compute_shoc_vapor(ComputeShocVaporData& d);
+void error_function(ErrorFunctionData& d);
+
 extern "C" { // _f function decls
 
 void calc_shoc_varorcovar_f(Int shcol, Int nlev, Int nlevi, Real tunefac,
@@ -955,6 +963,7 @@ void shoc_energy_fixer_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, R
                          Real* wqw_sfc, Real* rho_zt, Real* tke, Real* pint,
                          Real* host_dse);
 void compute_shoc_vapor_f(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv);
+void error_function_f(Real input, Real* output);
 } // end _f function decls
 
 }  // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -1320,4 +1320,14 @@ contains
 
     call compute_shoc_vapor(shcol, nlev, qw, ql, qv)
   end subroutine compute_shoc_vapor_c
+
+  subroutine error_function_c(input, output) bind (C)
+    use shoc, only: error_function
+
+    real(kind=c_real), intent(in), value :: input
+    real(kind=c_real), intent(out) :: output
+
+    call error_function(input,output)
+  end subroutine error_function_c
+
 end module shoc_iso_c

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -342,6 +342,14 @@ end subroutine shoc_energy_fixer_f
     real(kind=c_real) , intent(in), dimension(shcol, nlev) :: qw, ql
     real(kind=c_real) , intent(out), dimension(shcol, nlev) :: qv
   end subroutine compute_shoc_vapor_f
+
+subroutine error_function_f(input, output) bind(C)
+  use iso_c_binding
+
+  real(kind=c_real) , value, intent(in) :: input
+  real(kind=c_real) , intent(out) :: output
+end subroutine error_function_f
+
 end interface
 
 end module shoc_iso_f

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ set(SHOC_TESTS_SRCS
     shoc_diag_second_shoc_moments_tests.cpp
     shoc_pblintd_cldcheck_tests.cpp
     shoc_compute_shoc_vapor_tests.cpp
+    shoc_error_function_tests.cpp
     ) # SHOC_TESTS_SRCS
 
 # NOTE: tests inside this if statement won't be built in a baselines-only build

--- a/components/scream/src/physics/shoc/tests/shoc_error_function_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_error_function_tests.cpp
@@ -1,0 +1,102 @@
+#include "catch2/catch.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestErrorFunction {
+
+  static void run_property()
+  {
+    static constexpr int num_tests = 5;
+    static constexpr Real inputs[num_tests] = {0, 100, -50, 0.25, -1.3};
+
+    for (int i=0; i<num_tests; ++i) {
+      ErrorFunctionData SDS;
+
+      // fill in data
+      SDS.input = inputs[i];
+
+      // Call the fortran implementation
+      error_function(SDS);
+
+      REQUIRE(SDS.output >= -1);
+      REQUIRE(SDS.output <= 1);
+    }
+  }
+
+  static void run_bfb()
+  {
+    static constexpr Int num_runs = 5;
+
+    ErrorFunctionData SDS_f90[num_runs];
+    ErrorFunctionData SDS_cxx[num_runs];
+
+    // Generate random input data
+    std::default_random_engine generator;
+    std::uniform_real_distribution<Real> data_dist(-1, 1);
+    for (auto& d : SDS_f90) {
+      d.input = data_dist(generator);
+    }
+
+    // Copy data to C++ version
+    for (Int i=0; i<num_runs; ++i) {
+      SDS_cxx[i].input = SDS_f90[i].input;
+    }
+
+    // Get data from fortran
+    for (auto& d : SDS_f90) {
+      // expects data in C layout
+      error_function(d);
+    }
+
+    // Get data from cxx
+    for (auto& d : SDS_cxx) {
+      error_function_f(d.input, &d.output);
+    }
+
+    // Verify BFB results, all data should be in C layout
+    for (Int i = 0; i < num_runs; ++i) {
+      ErrorFunctionData& d_f90 = SDS_f90[i];
+      ErrorFunctionData& d_cxx = SDS_cxx[i];
+      REQUIRE(d_f90.output == d_cxx.output);
+    }
+  }
+};
+
+}  // namespace unit_test
+}  // namespace shoc
+}  // namespace scream
+
+namespace {
+
+TEST_CASE("error_function_property", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestErrorFunction;
+
+  TestStruct::run_property();
+}
+
+TEST_CASE("error_function_bfb", "shoc")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestErrorFunction;
+
+  TestStruct::run_bfb();
+}
+
+} // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -112,6 +112,7 @@ struct UnitWrap {
     struct TestDiagSecondShocMoments;
     struct TestPblintdCldCheck;
     struct TestComputeShocVapor;
+    struct TestErrorFunction;
   };
 
 };


### PR DESCRIPTION
Have shoc.F90 function call std::erf instead of the version defined in `cam/src/utils/error_function.F90`.