### PR TITLE
add bfb_erf

### DIFF
--- a/components/eam/src/physics/cam/bfb_math.inc
+++ b/components/eam/src/physics/cam/bfb_math.inc
@@ -7,7 +7,7 @@
 ! that use these macros:
 !
 ! use physics_share_f2c, only: cxx_pow, cxx_sqrt, cxx_cbrt, cxx_gamma, cxx_log, &
-!                              cxx_log10, cxx_exp, cxx_tanh
+!                              cxx_log10, cxx_exp, cxx_tanh, cxx_erf
 
 #ifndef SCREAM_BFB_MATH_INC
 #define SCREAM_BFB_MATH_INC
@@ -26,6 +26,7 @@
 #  define bfb_exp(val) cxx_exp(val)
 #  define bfb_expm1(val) cxx_expm1(val)
 #  define bfb_tanh(val) cxx_tanh(val)
+#  define bfb_erf(val) cxx_erf(val)
 #else
 #  define bfb_pow(base, exp) (base)**(exp)
 #  define bfb_cbrt(base) (base)**thrd
@@ -37,6 +38,7 @@
 #  define bfb_tanh(val) tanh(val)
 #  define bfb_sqrt(val) sqrt(val)
 #  define bfb_tanh(val) tanh(val)
+#  define bfb_erf(val) erf(val)
 #endif
 
 #endif

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -18,7 +18,7 @@ module shoc
 ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
   use physics_share_f2c, only: cxx_pow, cxx_sqrt, cxx_cbrt, cxx_gamma, cxx_log, &
-                               cxx_log10, cxx_exp
+                               cxx_log10, cxx_exp, cxx_erf
 #endif
 
 implicit none
@@ -2635,7 +2635,7 @@ subroutine shoc_assumed_pdf_compute_s(&
   C=0._rtype
 
   if (std_s .ne. 0.0_rtype) then
-    C=0.5_rtype*(1._rtype+erf(s/(sqrt2*std_s)))
+    C=0.5_rtype*(1._rtype+bfb_erf(s/(sqrt2*std_s)))
     IF (C .ne. 0._rtype) qn=s*C+(std_s/sqrt2pi)*exp(-0.5_rtype*bfb_square(s/std_s))
   else
     if (s .gt. 0._rtype) then

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -2636,7 +2636,7 @@ subroutine shoc_assumed_pdf_compute_s(&
 
   if (std_s .ne. 0.0_rtype) then
     C=0.5_rtype*(1._rtype+bfb_erf(s/(sqrt2*std_s)))
-    IF (C .ne. 0._rtype) qn=s*C+(std_s/sqrt2pi)*exp(-0.5_rtype*bfb_square(s/std_s))
+    IF (C .ne. 0._rtype) qn=s*C+(std_s/sqrt2pi)*bfb_exp(-0.5_rtype*bfb_square(s/std_s))
   else
     if (s .gt. 0._rtype) then
       C=1.0_rtype

--- a/components/scream/src/physics/share/physics_share.cpp
+++ b/components/scream/src/physics/share/physics_share.cpp
@@ -48,6 +48,7 @@ static Scalar wrap_name(Scalar input) {                 \
   cuda_wrap_single_arg(cxx_exp, std::exp)
   cuda_wrap_single_arg(cxx_expm1, std::expm1)
   cuda_wrap_single_arg(cxx_tanh, std::tanh)
+  cuda_wrap_single_arg(cxx_erf, std::erf)
 
 #undef cuda_wrap_single_arg
 };
@@ -132,6 +133,15 @@ Real cxx_tanh(Real input)
   return CudaWrap<Real, DefaultDevice>::cxx_tanh(input);
 #else
   return std::tanh(input);
+#endif
+}
+
+Real cxx_erf(Real input)
+{
+#ifdef KOKKOS_ENABLE_CUDA
+  return CudaWrap<Real, DefaultDevice>::cxx_erf(input);
+#else
+  return std::erf(input);
 #endif
 }
 

--- a/components/scream/src/physics/share/physics_share.hpp
+++ b/components/scream/src/physics/share/physics_share.hpp
@@ -16,6 +16,7 @@ Real cxx_log10(Real input);
 Real cxx_exp(Real input);
 Real cxx_expm1(Real input);
 Real cxx_tanh(Real input);
+Real cxx_erf(Real input);
 
 }
 

--- a/components/scream/src/physics/share/physics_share_f2c.F90
+++ b/components/scream/src/physics/share/physics_share_f2c.F90
@@ -112,6 +112,16 @@ interface
     real(kind=c_real)            :: cxx_tanh
   end function cxx_tanh
 
+  function cxx_erf(input) bind(C)
+    use iso_c_binding
+
+    !arguments:
+    real(kind=c_real), value, intent(in)  :: input
+
+    ! return
+    real(kind=c_real) :: cxx_erf
+  end function cxx_erf
+
 end interface
 
 end module physics_share_f2c


### PR DESCRIPTION
Adds `bfb_erf` for `shoc_assumed_pdf` porting.