### PR TITLE
Fix setting RUN_STARTDATE for SCREAM compsets

### DIFF
--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -576,6 +576,10 @@
 	<value  compset="C2R4_EAM">2004-01-01</value>
 	<value  compset="AR95_EAM">1995-07-18</value>
 	<value  compset="AR97_EAM">1997-06-19</value>
+    <value  compset="_EAM%SCREAM-LR-DYAMOND1">2016-08-01</value>
+    <value  compset="_EAM%SCREAM-HR-DYAMOND1">2016-08-01</value>
+    <value  compset="_EAM%SCREAM-LR-DYAMOND2">2020-01-20</value>
+    <value  compset="_EAM%SCREAM-HR-DYAMOND2">2020-01-20</value>
       </values>
     </entry>
 


### PR DESCRIPTION
It looks like our setting of RUN_STARTDATE for the DYAMOND2 compsets somehow got lost in the shuffle of the recent upstream merge. Thus, when creating new cases using the DYAMOND compsets the run startdate would default to 0001-01-01, which is not what we want!

[B4B] (for everything other than DYAMOND compsets)