### PR TITLE
port shoc_assumed_pdf

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -2010,6 +2010,10 @@ subroutine shoc_assumed_pdf(&
   !  TKE equation.  This code follows the appendix of
   !  Larson et al. (2002) for Analytic Double Gaussian 1
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  use shoc_iso_f, only: shoc_assumed_pdf_f
+#endif
+
   implicit none
 
 ! INPUT VARIABLES
@@ -2086,6 +2090,20 @@ subroutine shoc_assumed_pdf(&
   real(rtype) :: thl_sec_zt(shcol,nlev)
   real(rtype) :: qwthl_sec_zt(shcol,nlev)
   real(rtype) :: qw_sec_zt(shcol,nlev)
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  if (use_cxx) then
+     call shoc_assumed_pdf_f(&
+       shcol,nlev,nlevi, &                ! Input
+       thetal,qw,w_field,thl_sec,qw_sec,& ! Input
+       wthl_sec,w_sec, &                  ! Input
+       wqw_sec,qwthl_sec,w3,pres, &       ! Input
+       zt_grid,zi_grid,&                  ! Input
+       shoc_cldfrac,shoc_ql,&             ! Output
+       wqls,wthv_sec,shoc_ql2)            ! Output
+    return
+  endif
+#endif
 
   epsterm=rgas/rv
 
@@ -2456,7 +2474,7 @@ subroutine shoc_assumed_pdf_qw_parameters(&
     else
       Skew_qw=((1.2_rtype*Skew_w)/0.2_rtype)*(tsign-0.2_rtype)
     endif
-     qw2_1=min(100._rtype,max(0._rtype,(3._rtype*qw1_2*(1._rtype-a*bfb_square(qw1_1)-(1._rtype-a)*bfb_square(qw1_2)) &
+    qw2_1=min(100._rtype,max(0._rtype,(3._rtype*qw1_2*(1._rtype-a*bfb_square(qw1_1)-(1._rtype-a)*bfb_square(qw1_2)) &
       -(Skew_qw-a*bfb_cube(qw1_1)-(1._rtype-a)*bfb_cube(qw1_2)))/ &
       (3._rtype*a*(qw1_2-qw1_1))))*qwsec
 

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -2175,12 +2175,12 @@ subroutine shoc_assumed_pdf(&
          qw2_2,sqrtqw2_1,sqrtqw2_2)    ! Output
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      !  CONVERT FROM TILDA VARIABLES TO "REAL" VARIABLES
+      !  CONVERT FROM TILDE VARIABLES TO "REAL" VARIABLES
 
-      call shoc_assumed_pdf_tilda_to_real(&
+      call shoc_assumed_pdf_tilde_to_real(&
          w_first,sqrtw2,& ! Input
          w1_1)            ! Output
-      call shoc_assumed_pdf_tilda_to_real(&
+      call shoc_assumed_pdf_tilde_to_real(&
          w_first,sqrtw2,& ! Input
          w1_2)            ! Output
 
@@ -2492,12 +2492,12 @@ subroutine shoc_assumed_pdf_qw_parameters(&
 
 end subroutine shoc_assumed_pdf_qw_parameters
 
-subroutine shoc_assumed_pdf_tilda_to_real(&
+subroutine shoc_assumed_pdf_tilde_to_real(&
   w_first,sqrtw2,& ! intent-in
   w1)              ! intent-out
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  !  CONVERT FROM TILDA VARIABLES TO "REAL" VARIABLES
+  !  CONVERT FROM TILDE VARIABLES TO "REAL" VARIABLES
   implicit none
 
   ! intent-ins
@@ -2509,7 +2509,7 @@ subroutine shoc_assumed_pdf_tilda_to_real(&
 
   w1 = w1 * sqrtw2 + w_first
 
-end subroutine shoc_assumed_pdf_tilda_to_real
+end subroutine shoc_assumed_pdf_tilde_to_real
 
 subroutine shoc_assumed_pdf_inplume_correlations(&
   sqrtqw2_1, sqrtthl2_1, a, sqrtqw2_2, sqrtthl2_2,&              ! Input

--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -55,6 +55,7 @@ if (NOT CUDA_BUILD)
     shoc_compute_shoc_vapor.cpp
     shoc_update_prognostics_implicit.cpp
     shoc_diag_third_shoc_moments.cpp
+    shoc_assumed_pdf.cpp
   ) # SHOC ETI SRCS
 endif()
 

--- a/components/scream/src/physics/shoc/shoc_assumed_pdf.cpp
+++ b/components/scream/src/physics/shoc/shoc_assumed_pdf.cpp
@@ -1,0 +1,13 @@
+#include "shoc_assumed_pdf_impl.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation for the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream

--- a/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
@@ -293,7 +293,6 @@ void Functions<S,D>::shoc_assumed_pdf(
         qn2.set(!equal && std_s2 != 0 && C2 != 0, s2*C2+(std_s2/sqrt2pi)*ekat::exp(-sp(0.5)*ekat::square(s2/std_s2)));
         qn2.set(!equal && std_s2 == 0 && s2 > 0, s2);
         ql2 = ekat::min(qn2, qw1_2);
-
       }
 
       // Compute SGS cloud fraction

--- a/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
@@ -69,7 +69,7 @@ void Functions<S,D>::shoc_assumed_pdf(
   const Scalar basetemp = C::basetemp;
   const Scalar epsterm = rair/rv;
 
-  // Interpolate many variables from interface grid to themo grid
+  // Interpolate many variables from interface grid to thermo grid
   linear_interp(team,zi_grid,zt_grid,w3,w3_zt,nlevi,nlev,largeneg);
   linear_interp(team,zi_grid,zt_grid,thl_sec,thl_sec_zt,nlevi,nlev,0);
   linear_interp(team,zi_grid,zt_grid,wthl_sec,wthl_sec_zt,nlevi,nlev,largeneg);
@@ -199,13 +199,13 @@ void Functions<S,D>::shoc_assumed_pdf(
       sqrtqw2_2.set(condition, ekat::sqrt(qw2_2));
     }
 
-    // Convert from tilda variables to "real" variables
+    // Convert from tilde variables to "real" variables
      w1_1 *= sqrtw2;
      w1_1 += w_first;
      w1_2 *= sqrtw2;
      w1_2 += w_first;
 
-     // Find within-plume correlations. MAYBE NOT TESTED.
+     // Find within-plume correlations.
       Spack r_qwthl_1(0);
       {
         const Spack testvar = a*sqrtqw2_1*sqrtthl2_1 + (1 - a)*sqrtqw2_2*sqrtthl2_2;

--- a/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
@@ -1,0 +1,323 @@
+#ifndef SHOC_SHOC_ASSUMED_PDF_IMPL_HPP
+#define SHOC_SHOC_ASSUMED_PDF_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+#include "physics_functions.hpp"
+
+#include <iomanip>
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Implementation of shoc shoc_assumed_pdf. Clients should NOT
+ * #include this file, but include shoc_functions.hpp instead.
+ *
+ *  Purpose of this function is to calculate the
+ *  double Gaussian PDF of SHOC, which is the centerpiece
+ *  of the scheme.  The main outputs are the SGS cloud
+ *  fraction and liquid water amount, in addition to the
+ *  SGS buoyancy flux which is needed to close the SGS
+ *  TKE equation.  This code follows the appendix of
+ *  Larson et al. (2002) for Analytic Double Gaussian 1.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::shoc_assumed_pdf(
+  const MemberType&            team,
+  const Int&                   nlev,
+  const Int&                   nlevi,
+  const uview_1d<const Spack>& thetal,
+  const uview_1d<const Spack>& qw,
+  const uview_1d<const Spack>& w_field,
+  const uview_1d<const Spack>& thl_sec,
+  const uview_1d<const Spack>& qw_sec,
+  const uview_1d<const Spack>& wthl_sec,
+  const uview_1d<const Spack>& w_sec,
+  const uview_1d<const Spack>& wqw_sec,
+  const uview_1d<const Spack>& qwthl_sec,
+  const uview_1d<const Spack>& w3,
+  const uview_1d<const Spack>& pres,
+  const uview_1d<const Spack>& zt_grid,
+  const uview_1d<const Spack>& zi_grid,
+  const uview_1d<Spack>&       wthl_sec_zt,
+  const uview_1d<Spack>&       wqw_sec_zt,
+  const uview_1d<Spack>&       w3_zt,
+  const uview_1d<Spack>&       thl_sec_zt,
+  const uview_1d<Spack>&       qwthl_sec_zt,
+  const uview_1d<Spack>&       qw_sec_zt,
+  const uview_1d<Spack>&       shoc_cldfrac,
+  const uview_1d<Spack>&       shoc_ql,
+  const uview_1d<Spack>&       wqls,
+  const uview_1d<Spack>&       wthv_sec,
+  const uview_1d<Spack>&       shoc_ql2)
+{
+  // Tolerances, thresholds, and constants
+  const Scalar thl_tol = 1e-2;
+  const Scalar rt_tol = 1e-4;
+  const Scalar w_tol_sqd = 4e-4;
+  const Scalar w_thresh = 0;
+  const Scalar largeneg = SC::largeneg;
+  const Scalar rair = C::Rair;
+  const Scalar rv = C::RV;
+  const bool dothetal_skew = SC::dothetal_skew;
+  const Scalar basepres = C::P0;
+  const Scalar cp = C::CP;
+  const Scalar lcond = C::LatVap;
+  const Scalar pi = C::Pi;
+  const Scalar basetemp = C::basetemp;
+  const Scalar epsterm = rair/rv;
+
+  // Interpolate many variables from interface grid to themo grid
+  linear_interp(team,zi_grid,zt_grid,w3,w3_zt,nlevi,nlev,largeneg);
+  linear_interp(team,zi_grid,zt_grid,thl_sec,thl_sec_zt,nlevi,nlev,0);
+  linear_interp(team,zi_grid,zt_grid,wthl_sec,wthl_sec_zt,nlevi,nlev,largeneg);
+  linear_interp(team,zi_grid,zt_grid,qwthl_sec,qwthl_sec_zt,nlevi,nlev,largeneg);
+  linear_interp(team,zi_grid,zt_grid,wqw_sec,wqw_sec_zt,nlevi,nlev,largeneg);
+  linear_interp(team,zi_grid,zt_grid,qw_sec,qw_sec_zt,nlevi,nlev,0);
+
+  const Int nlev_pack = ekat::npack<Spack>(nlev);
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+
+    // Store active pack entries
+    const Smask is_last_pack(k == nlev_pack-1);
+    const int last_pack_indx = (nlev-1)%Spack::n;
+    const auto range = ekat::range<IntSmallPack>(k*Spack::n);
+    const Smask active_entries = (!is_last_pack ||
+                                  (is_last_pack && range < last_pack_indx));
+
+    // Initialize cloud variables to zero
+    shoc_cldfrac(k) = 0;
+    if (k==0) { shoc_ql(k)[0] = 0; }
+    shoc_ql2(k) = 0;
+
+    const auto pval = pres(k);
+
+    // Get all needed input moments for the PDF at this particular point
+    const auto thl_first = thetal(k);
+    const auto w_first = w_field(k);
+    const auto qw_first = qw(k);
+    const auto w3var = w3_zt(k);
+    const auto thlsec = thl_sec_zt(k);
+    const auto qwsec = qw_sec_zt(k);
+    const auto qwthlsec = qwthl_sec_zt(k);
+    const auto wqwsec = wqw_sec_zt(k);
+    const auto wthlsec = wthl_sec_zt(k);
+
+    // Compute square roots of some variables so we don't have to compute these again
+    const auto sqrtw2 = ekat::sqrt(w_sec(k));
+    const auto sqrtthl = ekat::max(thl_tol,ekat::sqrt(thlsec));
+    const auto sqrtqt = ekat::max(rt_tol,ekat::sqrt(qwsec));
+
+    // Find parameters for vertical velocity
+    Spack Skew_w(0), w1_1(w_first), w1_2(w_first), w2_1(0), w2_2(0), a(0.5);
+    {
+      const Smask condition = w_sec(k) > w_tol_sqd;
+
+      const Scalar tmp_val(0.4);
+      const Scalar one_m_tmp_val(1 - tmp_val);
+      const Scalar sqrtw2t(std::sqrt(1-tmp_val));
+
+      Skew_w.set(condition, w3var/ekat::sqrt(ekat::cube(w_sec(k))));
+      a.set(condition,
+            ekat::max(sp(0.01),
+                      ekat::min(sp(0.99),
+                                sp(0.5)*(1 - Skew_w*ekat::sqrt(1/(4*(one_m_tmp_val*one_m_tmp_val*one_m_tmp_val)
+                                                                  + ekat::square(Skew_w)))))));
+
+      w1_1.set(condition, ekat::sqrt((1 - a)/a)*sqrtw2t);
+      w1_2.set(condition, -1*ekat::sqrt(a/(1 - a))*sqrtw2t);
+      w2_1.set(condition, tmp_val*w_sec(k));
+      w2_2.set(condition, tmp_val*w_sec(k));
+    }
+
+    // Find parameters for thetal
+    Spack thl1_1(thl_first), thl1_2(thl_first), thl2_1(0), thl2_2(0),
+          sqrtthl2_1(0), sqrtthl2_2(0);
+    {
+      const Smask condition =  thlsec > (thl_tol*thl_tol) && ekat::abs(w1_2 - w1_1) > w_thresh;
+
+      const Spack corrtest1 = ekat::max(-1, ekat::min(1, wthlsec/(sqrtw2*sqrtthl)));
+      const Spack tmp_val_1(-corrtest1/w1_1), tmp_val_2(-corrtest1/w1_2);
+
+      Spack Skew_thl(0);
+      if (dothetal_skew == true) {
+        const auto tsign = ekat::abs(tmp_val_1 - tmp_val_2);
+        Skew_thl.set(tsign>sp(0.4), sp(1.2)*Skew_w);
+        Skew_thl.set(tsign>sp(0.2) && tsign<=sp(0.4), (((sp(1.2)*Skew_w)/sp(0.2))*(tsign-sp(0.2))));
+      }
+
+      thl2_1.set(condition,
+                 ekat::min(100,
+                           ekat::max(0, (3*tmp_val_1*(1 - a*ekat::square(tmp_val_2) - (1-a)*ekat::square(tmp_val_1))
+                                         - (Skew_thl - a*ekat::cube(tmp_val_2) - (1 - a)*ekat::cube(tmp_val_1)))
+                                         /(3*a*(tmp_val_1 - tmp_val_2))*thlsec)));
+      thl2_2.set(condition,
+                 ekat::min(100,
+                           ekat::max(0, (-3*tmp_val_2*(1 - a*ekat::square(tmp_val_2)
+                                         - (1 - a)*ekat::square(tmp_val_1))
+                                         + (Skew_thl - a*ekat::cube(tmp_val_2) - (1 - a)*ekat::cube(tmp_val_1)))
+                                         /(3*(1 - a)*(tmp_val_1 - tmp_val_2))*thlsec)));
+
+      thl1_1.set(condition, tmp_val_2*sqrtthl+thl_first);
+      thl1_2.set(condition, tmp_val_1*sqrtthl+thl_first);
+
+      sqrtthl2_1.set(condition, ekat::sqrt(thl2_1));
+      sqrtthl2_2.set(condition, ekat::sqrt(thl2_2));
+    }
+
+    // Find parameters for total water mixing ratio
+    Spack qw1_1(qw_first), qw1_2(qw_first), qw2_1(0), qw2_2(0),
+          sqrtqw2_1(0), sqrtqw2_2(0);
+    {
+      const Smask condition = qwsec > (rt_tol*rt_tol) && ekat::abs(w1_2 - w1_1) > w_thresh;
+
+      const Spack corrtest2 = ekat::max(-1, ekat::min(1, wqwsec/(sqrtw2*sqrtqt)));
+      const Spack tmp_val_1(-corrtest2/w1_1), tmp_val_2(-corrtest2/w1_2);
+
+      const auto tsign = ekat::abs(tmp_val_1 - tmp_val_2);
+      Spack Skew_qw(0);
+      Skew_qw.set(tsign>sp(0.4), sp(1.2)*Skew_w);
+      Skew_qw.set(tsign>sp(0.2) && tsign<=sp(0.4), (((sp(1.2)*Skew_w)/sp(0.2))*(tsign-sp(0.2))));
+
+      qw2_1.set(condition,
+                ekat::min(100,
+                          ekat::max(0, (3*tmp_val_1*(1 - a*ekat::square(tmp_val_2) - (1 - a)*ekat::square(tmp_val_1))
+                                        - (Skew_qw - a*ekat::cube(tmp_val_2) - (1 - a)*ekat::cube(tmp_val_1)))
+                                        /(3*a*(tmp_val_1 - tmp_val_2))))*qwsec);
+      qw2_2.set(condition,
+                ekat::min(100,
+                          ekat::max(0, (-3*tmp_val_2*(1 - a*ekat::square(tmp_val_2) - (1 - a)*ekat::square(tmp_val_1))
+                                        + (Skew_qw - a*ekat::cube(tmp_val_2) - (1 - a)*ekat::cube(tmp_val_1)))
+                                        /(3*(1 - a)*(tmp_val_1 - tmp_val_2))))*qwsec);
+
+      qw1_1.set(condition, tmp_val_2*sqrtqt+qw_first);
+      qw1_2.set(condition, tmp_val_1*sqrtqt+qw_first);
+
+      sqrtqw2_1.set(condition, ekat::sqrt(qw2_1));
+      sqrtqw2_2.set(condition, ekat::sqrt(qw2_2));
+    }
+
+    // Convert from tilda variables to "real" variables
+     w1_1 *= sqrtw2;
+     w1_1 += w_first;
+     w1_2 *= sqrtw2;
+     w1_2 += w_first;
+
+     // Find within-plume correlations. MAYBE NOT TESTED.
+      Spack r_qwthl_1(0);
+      {
+        const Spack testvar = a*sqrtqw2_1*sqrtthl2_1 + (1 - a)*sqrtqw2_2*sqrtthl2_2;
+        r_qwthl_1.set(testvar != 0,
+                      ekat::max(-1,
+                                ekat::min(1, (qwthlsec - a*(qw1_1 - qw_first)*(thl1_1 - thl_first)
+                                              - (1 - a)*(qw1_2 - qw_first)*(thl1_2 - thl_first))/testvar)));
+      }
+
+      // Begin to compute cloud property statistics
+      const Spack Tl1_1 = thl1_1/(ekat::pow(basepres/pval,(rair/cp)));
+      const Spack Tl1_2 = thl1_2/(ekat::pow(basepres/pval,(rair/cp)));
+
+      // Check to ensure Tl1_1 and Tl1_2 are not negative, endrun otherwise
+      const auto is_neg_Tl1_1 = (Tl1_1 <= 0) && active_entries;
+      const auto is_neg_Tl1_2 = (Tl1_2 <= 0) && active_entries;
+      EKAT_KERNEL_REQUIRE_MSG(!(is_neg_Tl1_1.any()), "Error! Tl1_1 has <= 0 values.\n"); //exit with an error message
+      EKAT_KERNEL_REQUIRE_MSG(!(is_neg_Tl1_2.any()), "Error! Tl1_2 has <= 0 values.\n"); //exit with an error message
+
+      // Compute qs and beta
+      Spack qs1(0), qs2(0), beta1(0), beta2(0);
+      {
+        // Compute MurphyKoop_svp
+        const int liquid = 0;
+        const Spack esval1_1 = scream::physics::Functions<S,D>::MurphyKoop_svp(Tl1_1,liquid,active_entries);
+        const Spack esval1_2 = scream::physics::Functions<S,D>::MurphyKoop_svp(Tl1_2,liquid,active_entries);
+        const Spack lstarn(lcond);
+
+        qs1 = sp(0.622)*esval1_1/ekat::max(esval1_1, pval - esval1_1);
+        beta1 = (rair/rv)*(lstarn/(rair*Tl1_1))*(lstarn/(cp*Tl1_1));
+
+        // Only compute qs2 and beta2 if the two plumes are not equal
+        const Smask condition = (Tl1_1 != Tl1_2);
+        qs2 = qs1;
+        beta2 = beta1;
+
+        qs2.set(condition, sp(0.622)*esval1_2/ekat::max(esval1_2, pval - esval1_2));
+        beta2.set(condition, (rair/rv)*(lstarn/(rair*Tl1_2))*(lstarn/(cp*Tl1_2)));
+      }
+
+      // Cloud computations
+
+      // Compute s terms.
+      Spack s1(0), std_s1(0), qn1(0), C1(0), ql1(0),
+            s2(0), std_s2(0), qn2(0), C2(0), ql2(0);
+      {
+        const Scalar sqrt2(std::sqrt(2)), sqrt2pi(std::sqrt(2*pi));
+
+        // First plume
+        const Spack cthl1=((1 + beta1*qw1_1)/ekat::square(1 + beta1*qs1))*(cp/lcond)*
+                                            beta1*qs1*ekat::pow(pval/basepres, (rair/cp));
+        const Spack cqt1 = 1/(1 + beta1*qs1);
+
+        std_s1 = ekat::sqrt(ekat::max(0,
+                                      ekat::square(cthl1)*thl2_1
+                                      + ekat::square(cqt1)*qw2_1 - 2*cthl1*sqrtthl2_1*cqt1*sqrtqw2_1*r_qwthl_1));
+        s1 = qw1_1-qs1*((1 + beta1*qw1_1)/(1 + beta1*qs1));
+        C1.set(std_s1 != 0, sp(0.5)*(1 + ekat::erf(s1/(sqrt2*std_s1))));
+        C1.set(std_s1 == 0 && s1 > 0, 1);
+        qn1.set(std_s1 != 0 && C1 != 0, s1*C1+(std_s1/sqrt2pi)*ekat::exp(-sp(0.5)*ekat::square(s1/std_s1)));
+        qn1.set(std_s1 == 0 && s1 > 0, s1);
+        ql1 = ekat::min(qn1, qw1_1);
+
+        // Second plume
+        // Only compute variables of the second plume if the two plumes are not equal
+        const Smask equal(qw1_1==qw1_2 && thl2_1==thl2_2 && qs1==qs2);
+        std_s2.set(equal, std_s1);
+        s2.set(equal, s1);
+        C2.set(equal, C1);
+        qn2.set(equal, qn1);
+
+        const Spack cthl2(!equal,
+                          ((1 + beta2*qw1_2)/ekat::square(1 + beta2*qs2))*(cp/lcond)*
+                           beta2*qs2*ekat::pow(pval/basepres, (rair/cp)));
+        const Spack cqt2(!equal,
+                         1/(1 + beta2*qs2));
+
+        std_s2.set(!equal,
+                   ekat::sqrt(ekat::max(0,
+                                        ekat::square(cthl2)*thl2_2
+                                        + ekat::square(cqt2)*qw2_2 - 2*cthl2*sqrtthl2_2*cqt2*sqrtqw2_2*r_qwthl_1)));
+        s2.set(!equal, qw1_2-qs2*((1 + beta2*qw1_2)/(1 + beta2*qs2)));
+        C2.set(!equal && std_s2 != 0, sp(0.5)*(1 + ekat::erf(s2/(sqrt2*std_s2))));
+        C2.set(!equal && std_s2 == 0 && s2 > 0, 1);
+        qn2.set(!equal && std_s2 != 0 && C2 != 0, s2*C2+(std_s2/sqrt2pi)*ekat::exp(-sp(0.5)*ekat::square(s2/std_s2)));
+        qn2.set(!equal && std_s2 == 0 && s2 > 0, s2);
+        ql2 = ekat::min(qn2, qw1_2);
+
+      }
+
+      // Compute SGS cloud fraction
+      shoc_cldfrac(k) = ekat::min(1, a*C1 + (1 - a)*C2);
+
+      // Compute SGS liquid water mixing ratio
+      shoc_ql(k) = ekat::max(0, a*ql1 + (1 - a)*ql2);
+
+      // Compute cloud liquid variance (CLUBB formulation, adjusted to SHOC parameters based)
+      shoc_ql2(k) = ekat::max(0, a*(s1*ql1 + C1*ekat::square(std_s1))
+                                 + (1 - a)*(s2*ql2 + C2*ekat::square(std_s2))
+                                 - ekat::square(shoc_ql(k)));
+
+      // Compute liquid water flux
+      wqls(k) = a*((w1_1 - w_first)*ql1) + (1 - a)*((w1_2 - w_first)*ql2);
+
+      // Compute the SGS buoyancy flux
+      wthv_sec(k) = wthlsec + ((1 - epsterm)/epsterm)*basetemp*wqwsec
+                   + ((lcond/cp)*ekat::pow(basepres/pval, (rair/cp))
+                   - (1/epsterm)*basetemp)*wqls(k);
+  });
+}
+
+} // namespace shoc
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/shoc/shoc_constants.hpp
+++ b/components/scream/src/physics/shoc/shoc_constants.hpp
@@ -21,6 +21,7 @@ struct Constants
       static constexpr Scalar w3clip         = 1.2;          // Third moment of vertical velocity
       static constexpr Scalar ustar_min      = 0.01;         // Minimum surface friction velocity
       static constexpr Scalar largeneg       = -99999999.99; // Large negative value used for linear_interp threshold
+      static constexpr bool   dothetal_skew  = false;        // Allow temperature skewness to be independent of moisture variance
     };
 
   } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -332,6 +332,36 @@ struct Functions
     const uview_1d<Spack>&       thetal_zi,
     const uview_1d<Spack>&       w3);
 
+  KOKKOS_FUNCTION
+  static void shoc_assumed_pdf(
+    const MemberType&            team,
+    const Int&                   nlev,
+    const Int&                   nlevi,
+    const uview_1d<const Spack>& thetal,
+    const uview_1d<const Spack>& qw,
+    const uview_1d<const Spack>& w_field,
+    const uview_1d<const Spack>& thl_sec,
+    const uview_1d<const Spack>& qw_sec,
+    const uview_1d<const Spack>& wthl_sec,
+    const uview_1d<const Spack>& w_sec,
+    const uview_1d<const Spack>& wqw_sec,
+    const uview_1d<const Spack>& qwthl_sec,
+    const uview_1d<const Spack>& w3,
+    const uview_1d<const Spack>& pres,
+    const uview_1d<const Spack>& zt_grid,
+    const uview_1d<const Spack>& zi_grid,
+    const uview_1d<Spack>&       wthl_sec_zt,
+    const uview_1d<Spack>&       wqw_sec_zt,
+    const uview_1d<Spack>&       w3_zt,
+    const uview_1d<Spack>&       thl_sec_zt,
+    const uview_1d<Spack>&       qwthl_sec_zt,
+    const uview_1d<Spack>&       qw_sec_zt,
+    const uview_1d<Spack>&       shoc_cldfrac,
+    const uview_1d<Spack>&       shoc_ql,
+    const uview_1d<Spack>&       wqls,
+    const uview_1d<Spack>&       wthv_sec,
+    const uview_1d<Spack>&       shoc_ql2);
+
 }; // struct Functions
 
 } // namespace shoc
@@ -367,6 +397,7 @@ struct Functions
 # include "shoc_compute_shoc_vapor_impl.hpp"
 # include "shoc_update_prognostics_implicit_impl.hpp"
 # include "shoc_diag_third_shoc_moments_impl.hpp"
+# include "shoc_assumed_pdf_impl.hpp"
 #endif // KOKKOS_ENABLE_CUDA
 
 #endif

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -180,7 +180,7 @@ void shoc_assumed_pdf_c(Int shcol, Int nlev, Int nlevi, Real *thetal, Real *qw,
                         Real *shoc_cldfrac, Real *shoc_ql, Real *wqls,
                         Real *wthv_sec, Real *shoc_ql2);
 
-void shoc_assumed_pdf_tilda_to_real_c(Real w_first, Real sqrtw2, Real* w1);
+void shoc_assumed_pdf_tilde_to_real_c(Real w_first, Real sqrtw2, Real* w1);
 
 void shoc_assumed_pdf_vv_parameters_c(Real w_first, Real w_sec, Real w3var,
                                       Real *Skew_w, Real *w1_1, Real *w1_2,
@@ -610,10 +610,10 @@ void shoc_assumed_pdf(SHOCAssumedpdfData &d)
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 
-void shoc_assumed_pdf_tilda_to_real(SHOCPDFtildaData &d)
+void shoc_assumed_pdf_tilde_to_real(SHOCPDFtildeData &d)
 {
   shoc_init(1, true);
-  shoc_assumed_pdf_tilda_to_real_c(d.w_first, d.sqrtw2, &d.w1);
+  shoc_assumed_pdf_tilde_to_real_c(d.w_first, d.sqrtw2, &d.w1);
 }
 
 void shoc_assumed_pdf_vv_parameters(SHOCPDFvvparamData &d)

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -2030,5 +2030,104 @@ void diag_third_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* w_sec, Real
   ekat::device_to_host<int,1>({w3}, shcol, nlevi, inout_views, true);
 }
 
+void shoc_assumed_pdf_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, Real* w_field,
+                        Real* thl_sec, Real* qw_sec, Real* wthl_sec, Real* w_sec, Real* wqw_sec,
+                        Real* qwthl_sec, Real* w3, Real* pres, Real* zt_grid, Real* zi_grid,
+                        Real* shoc_cldfrac, Real* shoc_ql, Real* wqls, Real* wthv_sec, Real* shoc_ql2)
+{
+  using SHF = Functions<Real, DefaultDevice>;
+
+  using Spack      = typename SHF::Spack;
+  using view_2d    = typename SHF::view_2d<Spack>;
+  using KT         = typename SHF::KT;
+  using ExeSpace   = typename KT::ExeSpace;
+  using MemberType = typename SHF::MemberType;
+
+  static constexpr Int num_arrays = 18;
+
+  Kokkos::Array<view_2d, num_arrays> temp_d;
+  Kokkos::Array<int, num_arrays> dim1_sizes = {shcol, shcol, shcol, shcol, shcol, shcol,
+                                               shcol, shcol, shcol, shcol, shcol, shcol,
+                                               shcol, shcol, shcol, shcol, shcol, shcol};
+  Kokkos::Array<int, num_arrays> dim2_sizes = {nlev,  nlev,  nlevi, nlevi, nlevi, nlev,
+                                               nlevi, nlevi, nlevi, nlev,  nlev,  nlev,
+                                               nlevi, nlev,  nlev,  nlev,  nlev,  nlev};
+  Kokkos::Array<const Real*, num_arrays> ptr_array = {thetal,  qw,           thl_sec, qw_sec,  wthl_sec, w_sec,
+                                                      wqw_sec, qwthl_sec,    w3,      w_field, pres,     zt_grid,
+                                                      zi_grid, shoc_cldfrac, shoc_ql, wqls,    wthv_sec, shoc_ql2};
+  // Sync to device
+  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+
+  // Inputs/Outputs
+  view_2d
+    thetal_d(temp_d[0]),
+    qw_d(temp_d[1]),
+    thl_sec_d(temp_d[2]),
+    qw_sec_d(temp_d[3]),
+    wthl_sec_d(temp_d[4]),
+    w_sec_d(temp_d[5]),
+    wqw_sec_d(temp_d[6]),
+    qwthl_sec_d(temp_d[7]),
+    w3_d(temp_d[8]),
+    w_field_d(temp_d[9]),
+    pres_d(temp_d[10]),
+    zt_grid_d(temp_d[11]),
+    zi_grid_d(temp_d[12]),
+    shoc_cldfrac_d(temp_d[13]),
+    shoc_ql_d(temp_d[14]),
+    wqls_d(temp_d[15]),
+    wthv_sec_d(temp_d[16]),
+    shoc_ql2_d(temp_d[17]);
+
+  // Local variables on thermo grid
+  const Int nk_pack = ekat::npack<Spack>(nlev);
+  view_2d
+    wthl_sec_zt_d("wthl_sec_zt", shcol, nk_pack),
+    wqw_sec_zt_d("wqw_sec_zt", shcol, nk_pack),
+    w3_zt_d("w3_zt", shcol, nk_pack),
+    thl_sec_zt_d("thl_sec_zt", shcol, nk_pack),
+    qwthl_sec_zt_d("qwthl_sec", shcol, nk_pack),
+    qw_sec_zt_d("qw_sec_zt", shcol, nk_pack);
+
+  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+    const Int i = team.league_rank();
+
+    const auto thetal_s = ekat::subview(thetal_d, i);
+    const auto qw_s = ekat::subview(qw_d, i);
+    const auto thl_sec_s = ekat::subview(thl_sec_d, i);
+    const auto qw_sec_s = ekat::subview(qw_sec_d, i);
+    const auto wthl_sec_s = ekat::subview(wthl_sec_d, i);
+    const auto w_sec_s = ekat::subview(w_sec_d, i);
+    const auto wqw_sec_s = ekat::subview(wqw_sec_d, i);
+    const auto qwthl_sec_s = ekat::subview(qwthl_sec_d, i);
+    const auto w3_s = ekat::subview(w3_d, i);
+    const auto w_field_s = ekat::subview(w_field_d, i);
+    const auto pres_s = ekat::subview(pres_d, i);
+    const auto zt_grid_s = ekat::subview(zt_grid_d, i);
+    const auto zi_grid_s = ekat::subview(zi_grid_d, i);
+    const auto shoc_cldfrac_s = ekat::subview(shoc_cldfrac_d, i);
+    const auto shoc_ql_s = ekat::subview(shoc_ql_d, i);
+    const auto wqls_s = ekat::subview(wqls_d, i);
+    const auto wthv_sec_s = ekat::subview(wthv_sec_d, i);
+    const auto shoc_ql2_s = ekat::subview(shoc_ql2_d, i);
+    const auto wthl_sec_zt_s = ekat::subview(wthl_sec_zt_d, i);
+    const auto wqw_sec_zt_s = ekat::subview(wqw_sec_zt_d, i);
+    const auto w3_zt_s = ekat::subview(w3_zt_d, i);
+    const auto thl_sec_zt_s = ekat::subview(thl_sec_zt_d, i);
+    const auto qwthl_sec_zt_s = ekat::subview(qwthl_sec_zt_d, i);
+    const auto qw_sec_zt_s = ekat::subview(qw_sec_zt_d, i);
+
+    SHF::shoc_assumed_pdf(team, nlev, nlevi, thetal_s, qw_s, w_field_s, thl_sec_s, qw_sec_s, wthl_sec_s, w_sec_s,
+                          wqw_sec_s, qwthl_sec_s, w3_s, pres_s, zt_grid_s, zi_grid_s,
+                          wthl_sec_zt_s, wqw_sec_zt_s, w3_zt_s, thl_sec_zt_s, qwthl_sec_zt_s, qw_sec_zt_s,
+                          shoc_cldfrac_s, shoc_ql_s, wqls_s, wthv_sec_s, shoc_ql2_s);
+  });
+
+  // Sync back to host
+  Kokkos::Array<view_2d, 5> out_views = {shoc_cldfrac_d, shoc_ql_d, wqls_d, wthv_sec_d, shoc_ql2_d};
+  ekat::device_to_host<int, 5>({shoc_cldfrac, shoc_ql, wqls, wthv_sec, shoc_ql2}, {shcol}, {nlev}, out_views, true);
+}
+
 } // namespace shoc
 } // namespace scream

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -975,6 +975,10 @@ void diag_third_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* w_sec, Real
                                Real* wthl_sec, Real* isotropy, Real* brunt, Real* thetal,
                                Real* tke, Real* dz_zt, Real* dz_zi, Real* zt_grid, Real* zi_grid,
                                Real* w3);
+void shoc_assumed_pdf_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, Real* w_field,
+                        Real* thl_sec, Real* qw_sec, Real* wthl_sec, Real* w_sec, Real* wqw_sec,
+                        Real* qwthl_sec, Real* w3, Real* pres, Real* zt_grid, Real* zi_grid,
+                        Real* shoc_cldfrac, Real* shoc_ql, Real* wqls, Real* wthv_sec, Real* shoc_ql2);
 
 } // end _f function decls
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -626,8 +626,8 @@ struct SHOCAssumedpdfData : public PhysicsTestData {
   SHOC_NO_SCALAR(SHOCAssumedpdfData, 3);
 };//SHOCAssumedpdfData
 
-//Create data structure to hold data for shoc_assumed_pdf_tilda_to_real
-struct SHOCPDFtildaData
+//Create data structure to hold data for shoc_assumed_pdf_tilde_to_real
+struct SHOCPDFtildeData
 {
   // inputs
   Real w_first, sqrtw2;
@@ -893,7 +893,7 @@ void linear_interp                                  (SHOCLinearInterpData &d);
 void diag_third_shoc_moments                        (SHOCDiagThirdMomData &d);
 void compute_diag_third_shoc_moment                 (SHOCCompThirdMomData &d);
 void shoc_assumed_pdf                               (SHOCAssumedpdfData &d);
-void shoc_assumed_pdf_tilda_to_real                 (SHOCPDFtildaData &d);
+void shoc_assumed_pdf_tilde_to_real                 (SHOCPDFtildeData &d);
 void shoc_assumed_pdf_vv_parameters                 (SHOCPDFvvparamData &d);
 void shoc_assumed_pdf_thl_parameters                (SHOCPDFthlparamData &d);
 void shoc_assumed_pdf_qw_parameters                 (SHOCPDFqwparamData &d);

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -974,17 +974,17 @@ contains
 
   end subroutine shoc_assumed_pdf_c
 
-  subroutine shoc_assumed_pdf_tilda_to_real_c(w_first, sqrtw2, w1) bind (C)
-    use shoc, only: shoc_assumed_pdf_tilda_to_real
+  subroutine shoc_assumed_pdf_tilde_to_real_c(w_first, sqrtw2, w1) bind (C)
+    use shoc, only: shoc_assumed_pdf_tilde_to_real
 
     real(kind=c_real), intent(in), value :: w_first
     real(kind=c_real), intent(in), value :: sqrtw2
 
     real(kind=c_real), intent(inout) :: w1
 
-    call shoc_assumed_pdf_tilda_to_real(w_first, sqrtw2, w1)
+    call shoc_assumed_pdf_tilde_to_real(w_first, sqrtw2, w1)
 
-  end subroutine shoc_assumed_pdf_tilda_to_real_c
+  end subroutine shoc_assumed_pdf_tilde_to_real_c
 
   subroutine shoc_assumed_pdf_vv_parameters_c(w_first,w_sec,w3var,&
                                               Skew_w,w1_1,w1_2,w2_1,w2_2,a) bind (C)

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -366,6 +366,17 @@ subroutine diag_third_shoc_moments_f(shcol, nlev, nlevi, w_sec, thl_sec, wthl_se
   real(kind=c_real) , intent(out), dimension(shcol, nlevi) :: w3
 end subroutine diag_third_shoc_moments_f
 
+subroutine shoc_assumed_pdf_f(shcol, nlev, nlevi, thetal, qw, w_field, thl_sec, qw_sec,&
+                              wthl_sec, w_sec, wqw_sec, qwthl_sec, w3, pres, zt_grid,&
+                              zi_grid, shoc_cldfrac, shoc_ql, wqls, wthv_sec, shoc_ql2) bind(C)
+  use iso_c_binding
+
+  integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi
+  real(kind=c_real) , intent(in), dimension(shcol, nlev) :: thetal, qw, w_field, w_sec, pres, zt_grid
+  real(kind=c_real) , intent(in), dimension(shcol, nlevi) :: thl_sec, qw_sec, wthl_sec, wqw_sec, qwthl_sec, w3, zi_grid
+  real(kind=c_real) , intent(out), dimension(shcol, nlev) :: shoc_cldfrac, shoc_ql, wqls, wthv_sec, shoc_ql2
+end subroutine shoc_assumed_pdf_f
+
 end interface
 
 end module shoc_iso_f

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -44,7 +44,7 @@ set(SHOC_TESTS_SRCS
     shoc_diag_third_tests.cpp
     shoc_compute_diag_third_tests.cpp
     shoc_assumed_pdf_tests.cpp
-    shoc_pdf_tildatoreal_tests.cpp
+    shoc_pdf_tildetoreal_tests.cpp
     shoc_pdf_vv_parameters_tests.cpp
     shoc_pdf_thl_parameters_tests.cpp
     shoc_pdf_qw_parameters_tests.cpp

--- a/components/scream/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
@@ -395,9 +395,64 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
 
   static void run_bfb()
   {
-    // TODO
-  }
+    SHOCAssumedpdfData SDS_f90[] = {
+      //              shcol, nlev, nlevi
+      SHOCAssumedpdfData(10, 71, 72),
+      SHOCAssumedpdfData(10, 12, 13),
+      SHOCAssumedpdfData(7,  16, 17),
+      SHOCAssumedpdfData(2, 7, 8),
+    };
 
+  static constexpr Int num_runs = sizeof(SDS_f90) / sizeof(SHOCAssumedpdfData);
+
+    // Generate random input data
+    for (auto& d : SDS_f90) {
+      d.randomize({ {d.thetal, {100, 500}} });
+    }
+
+    // Create copies of data for use by cxx. Needs to happen before fortran calls so that
+    // inout data is in original state
+    SHOCAssumedpdfData SDS_cxx[] = {
+      SHOCAssumedpdfData(SDS_f90[0]),
+      SHOCAssumedpdfData(SDS_f90[1]),
+      SHOCAssumedpdfData(SDS_f90[2]),
+      SHOCAssumedpdfData(SDS_f90[3]),
+    };
+
+    // Assume all data is in C layout
+
+    // Get data from fortran
+    for (auto& d : SDS_f90) {
+      // expects data in C layout
+      shoc_assumed_pdf(d);
+    }
+
+    int counter = 0;
+    // Get data from cxx
+    for (auto& d : SDS_cxx) {
+      std::cout << std::endl << "run" << ++counter << std::endl;
+      d.transpose<ekat::TransposeDirection::c2f>();
+      // expects data in fortran layout
+      shoc_assumed_pdf_f(d.shcol(), d.nlev(), d.nlevi(), d.thetal, d.qw, d.w_field,
+                         d.thl_sec, d.qw_sec, d.wthl_sec, d.w_sec, d.wqw_sec,
+                         d.qwthl_sec, d.w3, d.pres, d.zt_grid, d.zi_grid,
+                         d.shoc_cldfrac, d.shoc_ql, d.wqls, d.wthv_sec, d.shoc_ql2);
+      d.transpose<ekat::TransposeDirection::f2c>();
+    }
+
+    // Verify BFB results, all data should be in C layout
+    for (Int i = 0; i < num_runs; ++i) {
+      SHOCAssumedpdfData& d_f90 = SDS_f90[i];
+      SHOCAssumedpdfData& d_cxx = SDS_cxx[i];
+      for (Int k = 0; k < d_f90.total1x2(); ++k) {
+        REQUIRE(d_f90.shoc_cldfrac[k] == d_cxx.shoc_cldfrac[k]);
+        REQUIRE(d_f90.shoc_ql[k] == d_cxx.shoc_ql[k]);
+        REQUIRE(d_f90.wqls[k] == d_cxx.wqls[k]);
+        REQUIRE(d_f90.wthv_sec[k] == d_cxx.wthv_sec[k]);
+        REQUIRE(d_f90.shoc_ql2[k] == d_cxx.shoc_ql2[k]);
+      }
+    }
+  }
 };
 
 }  // namespace unit_test
@@ -418,7 +473,6 @@ TEST_CASE("shoc_assumed_pdf_bfb", "shoc")
   using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocAssumedPdf;
 
   TestStruct::run_bfb();
-
 }
 
 } // namespace

--- a/components/scream/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
@@ -407,7 +407,7 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
 
     // Generate random input data
     for (auto& d : SDS_f90) {
-      d.randomize({ {d.thetal, {100, 500}} });
+      d.randomize({ {d.thetal, {500, 700}} });
     }
 
     // Create copies of data for use by cxx. Needs to happen before fortran calls so that

--- a/components/scream/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
@@ -427,10 +427,8 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
       shoc_assumed_pdf(d);
     }
 
-    int counter = 0;
     // Get data from cxx
     for (auto& d : SDS_cxx) {
-      std::cout << std::endl << "run" << ++counter << std::endl;
       d.transpose<ekat::TransposeDirection::c2f>();
       // expects data in fortran layout
       shoc_assumed_pdf_f(d.shcol(), d.nlev(), d.nlevi(), d.thetal, d.qw, d.w_field,

--- a/components/scream/src/physics/shoc/tests/shoc_pdf_tildetoreal_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pdf_tildetoreal_tests.cpp
@@ -20,12 +20,12 @@ namespace shoc {
 namespace unit_test {
 
 template <typename D>
-struct UnitWrap::UnitTest<D>::TestShocPdfTildatoReal {
+struct UnitWrap::UnitTest<D>::TestShocPdfTildetoReal {
 
   static void run_property()
   {
     // Property tests for the SHOC function
-    //  shoc_assumed_pdf_tilda_to_real
+    //  shoc_assumed_pdf_tilde_to_real
 
     // TEST ONE
     // If variance of vertical velocity is zero then
@@ -39,7 +39,7 @@ struct UnitWrap::UnitTest<D>::TestShocPdfTildatoReal {
     Real w1 = 0.1;
 
     // Initialize data structure for bridging to F90
-    SHOCPDFtildaData SDS;
+    SHOCPDFtildeData SDS;
 
     // Fill the test data
     SDS.w_first = w_first;
@@ -47,7 +47,7 @@ struct UnitWrap::UnitTest<D>::TestShocPdfTildatoReal {
     SDS.w1 = w1;
 
     // Call the fortran implementation
-    shoc_assumed_pdf_tilda_to_real(SDS);
+    shoc_assumed_pdf_tilde_to_real(SDS);
 
     // Check the test, verify that vertical velocity is equal
     //  to the grid mean value
@@ -84,7 +84,7 @@ struct UnitWrap::UnitTest<D>::TestShocPdfTildatoReal {
       REQUIRE(SDS.sqrtw2 >= 0.0);
 
       // Call the fortran implementation
-      shoc_assumed_pdf_tilda_to_real(SDS);
+      shoc_assumed_pdf_tilde_to_real(SDS);
 
       // Make sure test value is greater than
       //  previous iteration
@@ -108,16 +108,16 @@ struct UnitWrap::UnitTest<D>::TestShocPdfTildatoReal {
 
 namespace {
 
-TEST_CASE("shoc_pdf_tildatoreal_property", "shoc")
+TEST_CASE("shoc_pdf_tildetoreal_property", "shoc")
 {
-  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfTildatoReal;
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfTildetoReal;
 
   TestStruct::run_property();
 }
 
-TEST_CASE("shoc_pdf_tildatoreal_bfb", "shoc")
+TEST_CASE("shoc_pdf_tildetoreal_bfb", "shoc")
 {
-  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfTildatoReal;
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestShocPdfTildetoReal;
 
   TestStruct::run_bfb();
 }

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -92,7 +92,7 @@ struct UnitWrap {
     struct TestShocCompDiagThird;
     struct TestShocDiagThird;
     struct TestShocLinearInt;
-    struct TestShocPdfTildatoReal;
+    struct TestShocPdfTildetoReal;
     struct TestShocVVParameters;
     struct TestShocThlParameters;
     struct TestShocQwParameters;


### PR DESCRIPTION
Port shoc_assumed_pdf. In shoc.F90, this function calls many different functions that appear only once. Instead of implementing each function separately, I implement them all as part of `shoc_assumed_pdf()`.

This  function has a lot of `pack.set(mask, ...)` statements which can be confusing. I have verified that, between my bfb test and the shoc_run_and_cmp, all conditions are tested, so every computation is included somewhere.