### PR TITLE
Clean up max/min code

### DIFF
--- a/components/scream/src/physics/shoc/shoc_check_length_scale_shoc_length_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_check_length_scale_shoc_length_impl.hpp
@@ -16,16 +16,12 @@ void Functions<S,D>::check_length_scale_shoc_length(
   const uview_1d<Spack>& shoc_mix)
 {
   const auto minlen = scream::shoc::Constants<Real>::minlen;
-  const auto maxlen = scream::shoc::Constants<Real>::maxlen;
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
-    // Ensure shoc_mix is in the interval [minval, maxval]
-    shoc_mix(k).set(maxlen < shoc_mix(k), maxlen);
-    shoc_mix(k).set(minlen > shoc_mix(k), minlen);
-
-    const auto tmp_val = sqrt(host_dx*host_dy);
-    shoc_mix(k).set(tmp_val < shoc_mix(k), tmp_val);
+    // Ensure shoc_mix is in the interval [minval, sqrt(host_dx*host_dy)]
+    shoc_mix(k) = ekat::min(std::sqrt(host_dx*host_dy),
+                            ekat::max(minlen, shoc_mix(k)));
   });
 }
 

--- a/components/scream/src/physics/shoc/shoc_compute_conv_time_shoc_length_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_conv_time_shoc_length_impl.hpp
@@ -18,8 +18,7 @@ void Functions<S,D>::compute_conv_time_shoc_length(
   Scalar&       conv_vel,
   Scalar&       tscale)
 {
-  const Scalar tmp_val = (conv_vel > 0 ? conv_vel : 0);
-  conv_vel = std::pow(tmp_val, C::THIRD);
+  conv_vel = std::pow(ekat::impl::max(conv_vel, sp(0)), C::THIRD);
 
   if (conv_vel > 0) {
       tscale = pblh/conv_vel;

--- a/components/scream/src/physics/shoc/shoc_compute_shoc_mix_shoc_length_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_shoc_mix_shoc_length_impl.hpp
@@ -25,18 +25,13 @@ void Functions<S,D>
   const auto vk = C::Karman;
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
-    Spack tkes(ekat::sqrt(tke(k)));
+    const Spack tkes = ekat::sqrt(tke(k));
+    const Spack brunt2 = ekat::max(0, brunt(k));
 
-    Spack brunt2(0);
-    brunt2.set(brunt(k) >= 0, brunt(k));
-
-    Spack return_val(maxlen);
-    Spack comp_val(sp(2.8284)*(ekat::sqrt(1/((1/(tscale*tkes*vk*zt_grid(k)))
-                                            +(1/(tscale*tkes*l_inf))
-                                            +sp(0.01)*(brunt2/tke(k)))))/length_fac);
-    return_val.set(return_val > comp_val, comp_val);
-
-    shoc_mix(k) = return_val;
+    shoc_mix(k) = ekat::min(maxlen,
+                            sp(2.8284)*(ekat::sqrt(1/((1/(tscale*tkes*vk*zt_grid(k)))
+                            + (1/(tscale*tkes*l_inf))
+                            + sp(0.01)*(brunt2/tke(k)))))/length_fac);
   });
 }
 

--- a/components/scream/src/physics/shoc/shoc_diag_obklen_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_obklen_impl.hpp
@@ -40,7 +40,7 @@ void Functions<S,D>::shoc_diag_obklen(
   const Scalar ustar_val = std::sqrt(uw_sfc*uw_sfc + vw_sfc*vw_sfc);
 
   // Outputs
-  ustar = (ustar_min > ustar_val ? ustar_min : ustar_val);
+  ustar = ekat::impl::max(ustar_min, ustar_val);
   kbfs = wthl_sfc + eps*th_sfc*wqw_sfc;
   obklen = -thv_sfc*(ustar*ustar*ustar)/(ggr*vk*(kbfs + sign_val));
 }


### PR DESCRIPTION
Found the `ekat::max/min(Pack, Pack)` function during my last PR and realized I could clean up a lot of my past contributions. Also includes changes to `ekat::impl::max(a,b)` instead of `(a>b ? a : b)` type expressions, and some shortening of code.