### PR TITLE
Port compute_shoc_vapor

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -576,6 +576,10 @@ subroutine compute_shoc_vapor( &
   !   based on SHOC's prognostic total water mixing ratio
   !   and diagnostic cloud water mixing ratio.
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  use shoc_iso_f, only: compute_shoc_vapor_f
+#endif
+
   implicit none
 
 ! INPUT VARIABLES
@@ -594,6 +598,13 @@ subroutine compute_shoc_vapor( &
 
 ! LOCAL VARIABLES
   integer :: i, k
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  if (use_cxx) then
+    call compute_shoc_vapor_f(shcol,nlev,qw,ql,qv)
+     return
+  endif
+#endif
 
   do k = 1, nlev
     do i = 1, shcol

--- a/components/scream/src/physics/shoc/shoc_compute_shoc_vapor.cpp
+++ b/components/scream/src/physics/shoc/shoc_compute_shoc_vapor.cpp
@@ -4,8 +4,7 @@ namespace scream {
 namespace shoc {
 
 /*
- * Explicit instantiation for doing compute_shoc_vapor on Reals using the
- * default device.
+ * Explicit instantiation for using the default device.
  */
 
 template struct Functions<Real,DefaultDevice>;

--- a/components/scream/src/physics/shoc/shoc_compute_shoc_vapor_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_shoc_vapor_impl.hpp
@@ -9,14 +9,25 @@ namespace shoc {
 /*
  * Implementation of shoc compute_shoc_vapor. Clients should NOT
  * #include this file, but include shoc_functions.hpp instead.
+ *
+ * This function computes water vapor
+ * based on SHOC's prognostic total water mixing ratio
+ * and diagnostic cloud water mixing ratio.
  */
 
 template<typename S, typename D>
 KOKKOS_FUNCTION
-void Functions<S,D>::compute_shoc_vapor(const Int& shcol, const Int& nlev, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& ql, const uview_1d<Spack>& qv)
+void Functions<S,D>::compute_shoc_vapor(
+  const MemberType&            team,
+  const Int&                   nlev,
+  const uview_1d<const Spack>& qw,
+  const uview_1d<const Spack>& ql,
+  const uview_1d<Spack>&       qv)
 {
-  // TODO
-  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+  const Int nlev_pack = ekat::npack<Spack>(nlev);
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+    qv(k) = qw(k) - ql(k);
+  });
 }
 
 } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -305,7 +305,12 @@ struct Functions
     const uview_1d<Spack>&       host_dse);
 
   KOKKOS_FUNCTION
-  static void compute_shoc_vapor(const Int& shcol, const Int& nlev, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& ql, const uview_1d<Spack>& qv);
+  static void compute_shoc_vapor(
+    const MemberType&            team,
+    const Int&                   nlev,
+    const uview_1d<const Spack>& qw,
+    const uview_1d<const Spack>& ql,
+    const uview_1d<Spack>&       qv);
 
   KOKKOS_FUNCTION
   static void update_prognostics_implicit(const Int& shcol, const Int& nlev, const Int& nlevi, const Int& num_tracer, const Spack& dtime, const uview_1d<const Spack>& dz_zt, const uview_1d<const Spack>& dz_zi, const uview_1d<const Spack>& rho_zt, const uview_1d<const Spack>& zt_grid, const uview_1d<const Spack>& zi_grid, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& uw_sfc, const uview_1d<const Spack>& vw_sfc, const uview_1d<const Spack>& wthl_sfc, const uview_1d<const Spack>& wqw_sfc, const uview_1d<const Spack>& wtracer_sfc, const uview_1d<Spack>& thetal, const uview_1d<Spack>& qw, const uview_1d<Spack>& tracer, const uview_1d<Spack>& tke, const uview_1d<Spack>& u_wind, const uview_1d<Spack>& v_wind);

--- a/components/scream/src/physics/shoc/tests/shoc_compute_shoc_vapor_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_compute_shoc_vapor_tests.cpp
@@ -88,7 +88,11 @@ struct UnitWrap::UnitTest<D>::TestComputeShocVapor {
   static void run_bfb()
   {
     ComputeShocVaporData f90_data[] = {
-      // TODO
+      //              shcol, nlev
+      ComputeShocVaporData(10, 71),
+      ComputeShocVaporData(10, 12),
+      ComputeShocVaporData(7,  16),
+      ComputeShocVaporData(2,   7),
     };
 
     static constexpr Int num_runs = sizeof(f90_data) / sizeof(ComputeShocVaporData);
@@ -101,7 +105,10 @@ struct UnitWrap::UnitTest<D>::TestComputeShocVapor {
     // Create copies of data for use by cxx. Needs to happen before fortran calls so that
     // inout data is in original state
     ComputeShocVaporData cxx_data[] = {
-      // TODO
+      ComputeShocVaporData(f90_data[0]),
+      ComputeShocVaporData(f90_data[1]),
+      ComputeShocVaporData(f90_data[2]),
+      ComputeShocVaporData(f90_data[3]),
     };
 
     // Assume all data is in C layout
@@ -126,10 +133,8 @@ struct UnitWrap::UnitTest<D>::TestComputeShocVapor {
       for (Int k = 0; k < d_f90.total1x2(); ++k) {
         REQUIRE(d_f90.qv[k] == d_cxx.qv[k]);
       }
-
     }
   } // run_bfb
-
 };
 
 } // namespace unit_test


### PR DESCRIPTION
Port compute_shoc_vapor. The boilerplate was generated in a previous PR, this is the implementation and test. 