### PR TITLE
v0: RH output on pressure levels was broken

### DIFF
--- a/components/eam/src/physics/cam/cam_diagnostics.F90
+++ b/components/eam/src/physics/cam/cam_diagnostics.F90
@@ -1319,10 +1319,11 @@ end subroutine diag_conv_tend_ini
     if (moist_physics) then
 
        ! Relative humidity
+       call qsat(state%t(:ncol,:), state%pmid(:ncol,:), &
+            tem2(:ncol,:), ftem(:ncol,:))
+       ftem(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
+
        if (hist_fld_active('RELHUM')) then
-          call qsat(state%t(:ncol,:), state%pmid(:ncol,:), &
-               tem2(:ncol,:), ftem(:ncol,:))
-          ftem(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
           call outfld ('RELHUM  ',ftem    ,pcols   ,lchnk     )
        end if
 


### PR DESCRIPTION
RH on pressure levels (e.g. RH700) was available as a model output, but unless 3d RH was also output, pressure level RH would be interpolated from a field that hadn't been initialized. This PR just makes sure that RH is always defined so RH on pressure levels is correctly defined.