### PR TITLE
Add more structured support for f90 compilers in testing scripts

### DIFF
--- a/components/scream/scripts/gather-all-data
+++ b/components/scream/scripts/gather-all-data
@@ -67,7 +67,7 @@ OR
                         help="Run tests on local machine, only using this script to manage env and batch submission.")
 
     parser.add_argument("-k", "--kokkos", help="Use to select specific kokkos installation. "
-                        "Default will be scream-repo/externals/kokkos. "
+                        "Only supported for scream-docs runs. "
                         "Supported magic strings: $machine $compiler")
 
     parser.add_argument("-r", "--root-dir",

--- a/components/scream/scripts/gather-all-data
+++ b/components/scream/scripts/gather-all-data
@@ -44,7 +44,7 @@ OR
     > {0} './scripts/test-all-scream --cxx-compiler $cxx_compiler --f90-compiler $f90_compiler -m $machine' -l -m $machine
 
     \033[1;32m# Do correctness testing for scream-docs micro apps \033[0m
-    > {0} './test-all $compiler $kokkos' -o
+    > {0} './test-all $cxx_compiler $kokkos' -o
 
     \033[1;32m# Do a scaling performance test for lin-interp on blake \033[0m
     > {0} '$scream/scripts/perf-analysis ncol:8000 km1:128 km2:256 minthresh:0.001 repeat:10 --kokkos=$kokkos --test=lin-interp/li_ref --test=lin-interp/li_kokkos --test=lin-interp/li_vect -s ncol:2:128000' -m blake -o
@@ -54,7 +54,7 @@ OR
     )
 
     parser.add_argument("run", help="What to run on the machine, cwd for the command will be root-dir. "
-                        "Supported magic strings: $compiler $kokkos $machine $scream_docs $scream")
+                        "Supported magic strings: $cxx_compiler $f90_compiler $kokkos $machine $scream_docs $scream")
 
     parser.add_argument("-c", "--commit", help="Commit to test. Default is current HEAD.")
 
@@ -68,7 +68,7 @@ OR
 
     parser.add_argument("-k", "--kokkos", help="Use to select specific kokkos installation. "
                         "Only supported for scream-docs runs. "
-                        "Supported magic strings: $machine $compiler")
+                        "Supported magic strings: $machine $cxx_compiler")
 
     parser.add_argument("-r", "--root-dir",
                         help="The root directory of the scream src you want to test. "

--- a/components/scream/scripts/gather-all-data
+++ b/components/scream/scripts/gather-all-data
@@ -38,10 +38,10 @@ OR
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Test scream on all platforms \033[0m
-    > {0} './scripts/test-all-scream $compiler -m $machine'
+    > {0} './scripts/test-all-scream --cxx-compiler $cxx_compiler --f90-compiler $f90_compiler -m $machine'
 
     \033[1;32m# Do correctness testing locally for SCREAM (expects ./scream and ./scream-docs) \033[0m
-    > {0} './scripts/test-all-scream $compiler -m $machine' -l -m $machine
+    > {0} './scripts/test-all-scream --cxx-compiler $cxx_compiler --f90-compiler $f90_compiler -m $machine' -l -m $machine
 
     \033[1;32m# Do correctness testing for scream-docs micro apps \033[0m
     > {0} './test-all $compiler $kokkos' -o

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -50,19 +50,18 @@ class GatherAllData(object):
 
         repo = scream_docs_repo if self._scream_docs else scream_repo
 
-        # Compute kokkos location
-        if self._kokkos:
-            expect (self._scream_docs, "Error! Scream runs do not allow to specify a user-provided kokkos installation.")
-            kokkos_loc = pathlib.Path(self._kokkos.replace("$machine", machine).replace("$compiler", compiler))
-
         local_cmd = self._run
         # Do magic replacements here
         local_cmd = local_cmd.\
             replace("$compiler", compiler).\
-            replace("$kokkos", str(kokkos_loc)).\
             replace("$machine", machine).\
             replace("$scream_docs", str(scream_docs_repo)).\
             replace("$scream", str(scream_repo))
+        if self._kokkos:
+            # Compute kokkos location and do magic replacement
+            expect (self._scream_docs, "Error! Scream runs do not allow to specify a user-provided kokkos installation.")
+            kokkos_loc = pathlib.Path(self._kokkos.replace("$machine", machine).replace("$compiler", compiler))
+            local_cmd.replace("$kokkos", str(kokkos_loc)).\
 
         # Scream-docs tests may depend on scream's Kokkos and scripts, so update scream repo too if we're doing
         # a scream-docs test.

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -52,9 +52,8 @@ class GatherAllData(object):
 
         # Compute kokkos location
         if self._kokkos:
+            expect (self._scream_docs, "Error! Scream runs do not allow to specify a user-provided kokkos installation.")
             kokkos_loc = pathlib.Path(self._kokkos.replace("$machine", machine).replace("$compiler", compiler))
-        else:
-            kokkos_loc = pathlib.Path(scream_repo.parent.parent, "externals", "kokkos")
 
         local_cmd = self._run
         # Do magic replacements here

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -22,7 +22,7 @@ MACHINE_METADATA = {
                   24,
                   24,
                   ""),
-    "blake"    : (["module purge", "module load openmpi/2.1.5/intel/19.1.144 git/2.9.4 cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-blake/bin:$PATH"],
+    "blake"    : (["module purge", "module load openmpi/2.1.5/intel/19.1.144 git/2.9.4 cmake/3.12.3 python/3.7.3"],
                  ["mpicxx","mpifort"],
                   "srun",
                   48,

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -146,7 +146,7 @@ def get_mach_baseline_root_dir (machine,default_dir):
     if MACHINE_METADATA[machine][5]=="":
         return default_dir
     else:
-        return MACHINE_METADATA[machine][6]
+        return MACHINE_METADATA[machine][5]
 
 ###############################################################################
 def setup_mach_env (machine):

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -13,72 +13,73 @@
 
 from utils import expect, get_cpu_core_count, run_cmd_no_fail
 import os
+import pathlib
 
 MACHINE_METADATA = {
     "melvin"   : (["module purge", "module load sems-env", "module load sems-gcc/7.3.0 sems-openmpi/1.10.1 sems-gcc/7.3.0 sems-git/2.10.1 sems-cmake/3.12.2 sems-python/3.5.2"],
-                  "$(which mpicxx)",
+                 ["mpicxx","mpifort"],
                   "",
                   24,
                   24,
                   ""),
     "blake"    : (["module purge", "module load openmpi/2.1.5/intel/19.1.144 git/2.9.4 cmake/3.12.3", "export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-blake/bin:$PATH"],
-                  "$(which mpicxx)",
+                 ["mpicxx","mpifort"],
                   "srun",
                   48,
                   48,
                   "/home/projects/e3sm/scream/pr-autotester/master-baselines/blake/"),
     "weaver"   : (["module purge", "module load devpack/20190814/openmpi/4.0.1/gcc/7.2.0/cuda/10.1.105 git/2.10.1 python/3.7.3", "module switch cmake/3.18.0"],
-                  "$(which mpicxx)",
+                 ["mpicxx","mpifort"],
                   "bsub -I -q rhel7W",
                   40,
                   4,
                   "/home/projects/e3sm/scream/pr-autotester/master-baselines/weaver/"),
     "mappy"   : (["module purge", "module load sems-env sems-python/3.5.2 sems-gcc/9.2.0 sems-cmake/3.12.2 sems-git/2.10.1 sems-openmpi/4.0.2"],
-                  "$(which mpicxx)",
+                 ["mpicxx","mpifort"],
                   "",
                   48,
                   48,
                   "/sems-data-store/ACME/baselines/scream/master-baselines"),
     "lassen" : (["module --force purge", "module load git gcc/7.3.1 cuda/10.1.243 cmake/3.14.5 spectrum-mpi netcdf/4.7.0 python/3.7.2", "export LLNL_USE_OMPI_VARS='y'"],
-                  "$(which mpicxx)",
+                 ["mpicxx","mpifort"],
                   "bsub -Ip",
                   44,
                   4,
                   ""),
     "quartz" : (["module --force purge", "module load StdEnv cmake/3.14.5 mkl/2019.0 intel/19.0.4 netcdf-fortran/4.4.4 netcdf/4.4.1.1"],
-                  "$(which mpicxx)",
+                 ["mpicxx","mpifort"],
                   "salloc --partition=pdebug",
                   36,
                   36,
                   ""),
     "syrah"  : (["module --force purge", "module load StdEnv cmake/3.14.5 mkl/2019.0 intel/19.0.4 netcdf-fortran/4.4.4 netcdf/4.4.1.1"],
-                  "$(which mpicxx)",
+                 ["mpicxx","mpifort"],
                   "salloc --partition=pdebug",
                   16,
                   16,
                   ""),
     "summit" : (["module purge", "module load cmake/3.15.2 gcc/6.4.0 spectrum-mpi/10.3.0.1-20190611 cuda/10.1.168 python/3.6.6-anaconda3-5.3.0"],
-                "$(which mpicxx)",
+                ["mpicxx","mpifort"],
                 "bsub -I -q batch -W 0:30 -P cli115 -nnodes 1",
                 44,
                 6,
                 ""),
     "cori"   : (["eval $(../../cime/scripts/Tools/get_case_env)", "export OMP_NUM_THREADS=68"],
-                "$(which CC)",
+                ["CC","ftn"],
                 "srun --time 02:00:00 --nodes=1 --constraint=knl,quad,cache --exclusive -q regular --account e3sm",
                 68,
                 68,
                 ""),
     "compy"   : (["module purge", "module load cmake/3.11.4 gcc/8.1.0  mvapich2/2.3.1 python/3.7.3"],
-                  "$(which mpicxx)",
+                 ["mpicxx","mpifort"],
                   "",
                   40,
                   40,
                   ""),
 
-    "linux-generic" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
-    "linux-generic-debug" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
-    "linux-generic-serial" : ([],"$(which mpicxx)","", get_cpu_core_count(), get_cpu_core_count(),""),
+    "linux-generic" : ([],["mpicxx","mpifort"],"", get_cpu_core_count(), get_cpu_core_count(),""),
+    "linux-generic-debug" : ([],["mpicxx","mpifort"],"", get_cpu_core_count(), get_cpu_core_count(),""),
+    "linux-generic-serial" : ([],["mpicxx","mpifort"],"", get_cpu_core_count(), get_cpu_core_count(),""),
 }
 
 ###############################################################################
@@ -101,7 +102,15 @@ def get_mach_cxx_compiler (machine):
 
     expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
-    return MACHINE_METADATA[machine][1]
+    return MACHINE_METADATA[machine][1][0]
+
+###############################################################################
+def get_mach_f90_compiler (machine):
+###############################################################################
+
+    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+
+    return MACHINE_METADATA[machine][1][1]
 
 ###############################################################################
 def get_mach_batch_command (machine):
@@ -137,7 +146,7 @@ def get_mach_baseline_root_dir (machine,default_dir):
     if MACHINE_METADATA[machine][5]=="":
         return default_dir
     else:
-        return MACHINE_METADATA[machine][5]
+        return MACHINE_METADATA[machine][6]
 
 ###############################################################################
 def setup_mach_env (machine):

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -25,22 +25,20 @@ OR
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run all tests on current machine \033[0m
     > cd $scream_repo/components/scream
-    > ./scripts/test-all-scream $(which mpicxx) -m melvin
+    > ./scripts/test-all-scream --cxx-compiler $(which mpicxx) --f90-compiler $(which mpifort) -m melvin
 
     \033[1;32m# Run all tests on current machine with custom flags\033[0m
     > cd $scream_repo/components/scream
-    > ./scripts/test-all-scream $(which mpicxx) -m melvin -c "CMAKE_CXX_FLAGS=-O1 -O2"
+    > ./scripts/test-all-scream --cxx-compiler $(which mpicxx) --f90-compiler $(which mpifort) -m melvin -c "CMAKE_CXX_FLAGS=-O1 -O2"
 """.format(pathlib.Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    parser.add_argument("cxx", help="C++ compiler")
-
-    parser.add_argument("-k", "--kokkos", help="Kokkos installation to use. Default is to build our own.")
+    parser.add_argument("-cxx","--cxx-compiler", help="C++ compiler", default=None)
+    parser.add_argument("-f90","--f90-compiler", help="F90 compiler", default=None)
 
     parser.add_argument("-s", "--submit", action="store_true", help="Submit results to dashboad, requires machine")
-
     parser.add_argument("-p", "--parallel", action="store_true",
                         help="Launch the different build types stacks in parallel")
 
@@ -53,12 +51,12 @@ OR
     parser.add_argument("--baseline-dir", default=None,
         help="Use baselines from the given directory, skip baseline creation.")
 
-    parser.add_argument("-m", "--machine",
-        help="Provide machine name. This is required for internal kokkos builds and dashboard submission")
+    parser.add_argument("-m", "--machine", required=True,
+        help="Provide machine name. This is *always* required")
 
     parser.add_argument("--no-tests", action="store_true", help="Only build baselines, skip testing phase")
 
-    parser.add_argument("--keep-tree", action="store_true",
+    parser.add_argument("-k", "--keep-tree", action="store_true",
         help="Allow to keep the current work tree when testing against HEAD (only valid with `-b HEAD`)")
 
     parser.add_argument("-c", "--custom-cmake-opts", action="append", default=[],


### PR DESCRIPTION
This PR is mainly focused on better structuring our compilers support in our testing scripts, but also does a couple more things. Here are the main points:

- cxx compiler is not longer captured without flag, and now needs `--cxx-compiler` (`-cxx` is a short version).
- added similar flag for f90 compiler: `--f90-compiler` (`-f90` is a short version).
- if compilers are not specified, test-all queries machine_specs for default compilers (which means `-m mach_name` must be passed).
- scream testing no longer allows to specify an existing kokkos installation, and instead always builds the internal one (via ekat).
- the `-k` flag in test-all has been rebranded as a short for the existing `--keep-tree`.
- gather-all still allows to specify an existing kokkos installation if `--scream-docs` is selected.
- using system modules for python on blake.