### PR TITLE
Set prescribed aerosol noise to zero and add bc_dep_to_snow_updates to scream compsets

### DIFF
--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -138,8 +138,8 @@
       <value compset="_EAM%ADIAB"     >-phys adiabatic</value>
 
       <!-- SCREAM configurations -->
-      <value compset="_EAM%SCREAM-LR">-phys cam5 -shoc_sgs -microphys p3 -chem none -nlev 72 -rad rrtmgp</value>
-      <value compset="_EAM%SCREAM-HR">-phys cam5 -shoc_sgs -microphys p3 -chem none -nlev 128 -rad rrtmgp</value>
+      <value compset="_EAM%SCREAM-LR">-phys cam5 -shoc_sgs -microphys p3 -chem none -nlev 72 -rad rrtmgp -bc_dep_to_snow_updates</value>
+      <value compset="_EAM%SCREAM-HR">-phys cam5 -shoc_sgs -microphys p3 -chem none -nlev 128 -rad rrtmgp -bc_dep_to_snow_updates</value>
 
       <!-- Aquaplanet -->
       <value compset="_EAM%AQUA"   >-phys cam5 -nlev 72 -clubb_sgs -microphys mg2 -aquaplanet -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -bc_dep_to_snow_updates </value>

--- a/components/eam/src/chemistry/utils/prescribed_aero.F90
+++ b/components/eam/src/chemistry/utils/prescribed_aero.F90
@@ -481,7 +481,10 @@ end subroutine spec_c_to_a
     ! random sampling is off (randn=0) in single column model setting. 
     if (single_column) then
       randn = 0._r8
-    endif
+   endif
+
+   ! turn off random sampling for scream simulations
+   randn = 0._r8
     
     do i = 1, aero_cnt
        !Species with '_a' are updated using random sampling.


### PR DESCRIPTION
This small PR does two things.
1) Sets the daily random noise in the prescribed aerosol field to always be zero. 
2) Adds bc_dep_to_snow_updates to the scream compsets