### PR TITLE
SCREAM: add support for c compiler in test-all-scream

### DIFF
--- a/components/scream/scripts/gather-all-data
+++ b/components/scream/scripts/gather-all-data
@@ -54,7 +54,7 @@ OR
     )
 
     parser.add_argument("run", help="What to run on the machine, cwd for the command will be root-dir. "
-                        "Supported magic strings: $cxx_compiler $f90_compiler $kokkos $machine $scream_docs $scream")
+                        "Supported magic strings: $cxx_compiler $f90_compiler $c_compiler $kokkos $machine $scream_docs $scream")
 
     parser.add_argument("-c", "--commit", help="Commit to test. Default is current HEAD.")
 

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -2,7 +2,8 @@ from utils import run_cmd_no_fail
 
 import os, pathlib
 import concurrent.futures as threading3
-from machines_specs import get_mach_env_setup_command, get_mach_cxx_compiler, get_mach_f90_compiler, get_mach_batch_command, get_mach_testing_resources
+from machines_specs import get_mach_env_setup_command, get_mach_batch_command, get_mach_testing_resources, \
+                           get_mach_cxx_compiler, get_mach_f90_compiler, get_mach_c_compiler
 
 ###############################################################################
 class GatherAllData(object):
@@ -26,6 +27,7 @@ class GatherAllData(object):
         env_setup    = get_mach_env_setup_command(machine)
         cxx_compiler = get_mach_cxx_compiler(machine)
         f90_compiler = get_mach_f90_compiler(machine)
+        c_compiler   = get_mach_c_compiler(machine)
         batch        = get_mach_batch_command(machine)
 
         env_setup.append("CTEST_PARALLEL_LEVEL={}".format(get_mach_testing_resources(machine)))
@@ -65,6 +67,7 @@ class GatherAllData(object):
             replace("$kokkos", str(kokkos_loc)).\
             replace("$cxx_compiler", cxx_compiler).\
             replace("$f90_compiler", f90_compiler).\
+            replace("$c_compiler", c_compiler).\
             replace("$machine", machine).\
             replace("$scream_docs", str(scream_docs_repo)).\
             replace("$scream", str(scream_repo))

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -17,69 +17,69 @@ import pathlib
 
 MACHINE_METADATA = {
     "melvin"   : (["module purge", "module load sems-env", "module load sems-gcc/7.3.0 sems-openmpi/1.10.1 sems-gcc/7.3.0 sems-git/2.10.1 sems-cmake/3.12.2 sems-python/3.5.2"],
-                 ["mpicxx","mpifort"],
+                 ["mpicxx","mpifort","mpicc"],
                   "",
                   24,
                   24,
                   ""),
     "blake"    : (["module purge", "module load openmpi/2.1.5/intel/19.1.144 git/2.9.4 cmake/3.12.3 python/3.7.3"],
-                 ["mpicxx","mpifort"],
+                 ["mpicxx","mpifort","mpicc"],
                   "srun",
                   48,
                   48,
                   "/home/projects/e3sm/scream/pr-autotester/master-baselines/blake/"),
     "weaver"   : (["module purge", "module load devpack/20190814/openmpi/4.0.1/gcc/7.2.0/cuda/10.1.105 git/2.10.1 python/3.7.3", "module switch cmake/3.18.0"],
-                 ["mpicxx","mpifort"],
+                 ["mpicxx","mpifort","mpicc"],
                   "bsub -I -q rhel7W",
                   40,
                   4,
                   "/home/projects/e3sm/scream/pr-autotester/master-baselines/weaver/"),
     "mappy"   : (["module purge", "module load sems-env sems-python/3.5.2 sems-gcc/9.2.0 sems-cmake/3.12.2 sems-git/2.10.1 sems-openmpi/4.0.2"],
-                 ["mpicxx","mpifort"],
+                 ["mpicxx","mpifort","mpicc"],
                   "",
                   48,
                   48,
                   "/sems-data-store/ACME/baselines/scream/master-baselines"),
     "lassen" : (["module --force purge", "module load git gcc/7.3.1 cuda/10.1.243 cmake/3.14.5 spectrum-mpi netcdf/4.7.0 python/3.7.2", "export LLNL_USE_OMPI_VARS='y'"],
-                 ["mpicxx","mpifort"],
+                 ["mpicxx","mpifort","mpicc"],
                   "bsub -q pdebug",
                   44,
                   4,
                   ""),
     "quartz" : (["module --force purge", "module load StdEnv cmake/3.14.5 mkl/2019.0 intel/19.0.4 netcdf-fortran/4.4.4 netcdf/4.4.1.1"],
-                 ["mpicxx","mpifort"],
+                 ["mpicxx","mpifort","mpicc"],
                   "salloc --partition=pdebug",
                   36,
                   36,
                   ""),
     "syrah"  : (["module --force purge", "module load StdEnv cmake/3.14.5 mkl/2019.0 intel/19.0.4 netcdf-fortran/4.4.4 netcdf/4.4.1.1"],
-                 ["mpicxx","mpifort"],
+                 ["mpicxx","mpifort","mpicc"],
                   "salloc --partition=pdebug",
                   16,
                   16,
                   ""),
     "summit" : (["module purge", "module load cmake/3.15.2 gcc/6.4.0 spectrum-mpi/10.3.0.1-20190611 cuda/10.1.168 python/3.6.6-anaconda3-5.3.0"],
-                ["mpicxx","mpifort"],
+                ["mpicxx","mpifort","mpicc"],
                 "bsub -I -q batch -W 0:30 -P cli115 -nnodes 1",
                 44,
                 6,
                 ""),
     "cori"   : (["eval $(../../cime/scripts/Tools/get_case_env)", "export OMP_NUM_THREADS=68"],
-                ["CC","ftn"],
+                ["CC","ftn","cc"],
                 "srun --time 02:00:00 --nodes=1 --constraint=knl,quad,cache --exclusive -q regular --account e3sm",
                 68,
                 68,
                 ""),
     "compy"   : (["module purge", "module load cmake/3.11.4 gcc/8.1.0  mvapich2/2.3.1 python/3.7.3"],
-                 ["mpicxx","mpifort"],
+                 ["mpicxx","mpifort","mpicc"],
                   "",
                   40,
                   40,
                   ""),
 
-    "linux-generic" : ([],["mpicxx","mpifort"],"", get_cpu_core_count(), get_cpu_core_count(),""),
-    "linux-generic-debug" : ([],["mpicxx","mpifort"],"", get_cpu_core_count(), get_cpu_core_count(),""),
-    "linux-generic-serial" : ([],["mpicxx","mpifort"],"", get_cpu_core_count(), get_cpu_core_count(),""),
+    "linux-generic" : ([],["mpicxx","mpifort","mpicc"],"", get_cpu_core_count(), get_cpu_core_count(),""),
+    "linux-generic-debug" : ([],["mpicxx","mpifort","mpicc"],"", get_cpu_core_count(), get_cpu_core_count(),""),
+    "linux-generic-serial" : ([],["mpicxx","mpifort","mpicc"],"", get_cpu_core_count(), get_cpu_core_count(),""),
 }
 
 ###############################################################################
@@ -111,6 +111,14 @@ def get_mach_f90_compiler (machine):
     expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
     return MACHINE_METADATA[machine][1][1]
+
+###############################################################################
+def get_mach_c_compiler (machine):
+###############################################################################
+
+    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+
+    return MACHINE_METADATA[machine][1][2]
 
 ###############################################################################
 def get_mach_batch_command (machine):

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -37,6 +37,7 @@ OR
 
     parser.add_argument("-cxx","--cxx-compiler", help="C++ compiler", default=None)
     parser.add_argument("-f90","--f90-compiler", help="F90 compiler", default=None)
+    parser.add_argument("--c-compiler", help="C compiler", default=None)
 
     parser.add_argument("-s", "--submit", action="store_true", help="Submit results to dashboad, requires machine")
     parser.add_argument("-p", "--parallel", action="store_true",

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -4,7 +4,7 @@ from utils import run_cmd, run_cmd_no_fail, check_minimum_python_version, get_cu
 
 from machines_specs import get_mach_compilation_resources, get_mach_testing_resources, \
                            get_mach_baseline_root_dir, setup_mach_env, \
-                           get_mach_cxx_compiler, get_mach_f90_compiler
+                           get_mach_cxx_compiler, get_mach_f90_compiler, get_mach_c_compiler
 
 check_minimum_python_version(3, 4)
 
@@ -18,7 +18,7 @@ class TestAllScream(object):
 ###############################################################################
 
     ###########################################################################
-    def __init__(self, cxx_compiler, f90_compiler, submit=False, parallel=False, fast_fail=False,
+    def __init__(self, cxx_compiler, f90_compiler, c_compiler, submit=False, parallel=False, fast_fail=False,
                  baseline_ref=None, baseline_dir=None, machine=None, no_tests=False, keep_tree=False,
                  custom_cmake_opts=(), custom_env_vars=(), tests=(),
                  integration_test="JENKINS_HOME" in os.environ, root_dir=None, dry_run=False,
@@ -27,6 +27,7 @@ class TestAllScream(object):
 
         self._cxx_compiler            = cxx_compiler
         self._f90_compiler            = f90_compiler
+        self._c_compiler              = c_compiler
         self._submit                  = submit
         self._parallel                = parallel
         self._fast_fail               = fast_fail
@@ -103,9 +104,12 @@ class TestAllScream(object):
             self._cxx_compiler = get_mach_cxx_compiler(self._machine)
         if self._f90_compiler is None:
             self._f90_compiler = get_mach_f90_compiler(self._machine)
+        if self._c_compiler is None:
+            self._c_compiler = get_mach_c_compiler(self._machine)
 
         self._f90_compiler = run_cmd_no_fail("which {}".format(self._f90_compiler))
         self._cxx_compiler = run_cmd_no_fail("which {}".format(self._cxx_compiler))
+        self._c_compiler   = run_cmd_no_fail("which {}".format(self._c_compiler))
 
         ###################################
         #      Compute baseline info      #
@@ -315,6 +319,7 @@ class TestAllScream(object):
     ###############################################################################
         result  = "{}-C {}".format("" if for_ctest else "cmake ", self.get_machine_file())
         result += " -DCMAKE_CXX_COMPILER={}".format(self._cxx_compiler)
+        result += " -DCMAKE_C_COMPILER={}".format(self._c_compiler)
         result += " -DCMAKE_Fortran_COMPILER={}".format(self._f90_compiler)
         for key, value in extra_configs:
             result += " -D{}={}".format(key, value)


### PR DESCRIPTION
Adds flags and whatnot to testing machinery, so that we can use/specify a C compiler (needed in the near future, e.g., by scorpio).

This PR is simply mimicking what #718 did for the fortran compiler.