### PR TITLE
Refactor tridiag solver

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -693,9 +693,9 @@ subroutine update_prognostics_implicit( &
   real(rtype) :: flux_dummy(shcol)
   real(rtype) :: ksrf(shcol), wtke_sfc(shcol)
 
-  real(rtype) :: du(shcol,nlev) ! superdiagonal for solver
-  real(rtype) :: dl(shcol,nlev) ! subdiagonal for solver
-  real(rtype) :: d(shcol,nlev)  ! diagonal for solver
+  real(rtype) :: du(shcol,nlev) ! Superdiagonal for solver
+  real(rtype) :: dl(shcol,nlev) ! Factorized subdiagonal for solver
+  real(rtype) :: d(shcol,nlev)  ! Factorized diagonal for solver
 
   ! linearly interpolate tkh, tk, and air density onto the interface grids
   call linear_interp(zt_grid,zi_grid,tkh,tkh_zi,nlev,nlevi,shcol,0._rtype)


### PR DESCRIPTION
The solver in SHOC (`vd_shoc_decomp/vd_shoc_solver`) has a different order of operations that the bfb solver in `ekat_tridiag.hpp`. I have re worked the solver in shoc.F90 so that when the solver is added to C++ we can have a BFB version for testing. The new `vd_shoc_decomp` returns `du` (superdiag), `dl` (subdiag), and `d` (diag), instead of `ca, cc, denom, ze`, and now `vd_shoc_solve` only requires `du, dl, d, rhs`.

As expected, shoc_run_and_cmp fails. The diff on all machines is similar to other non-bfb changes, namely `host_dse` has the largest rel_diff `~ 8e-2`.

I did my own testing, comparing the output of the old solver to the new one. I ran shoc_run_and_cmp and comparing the largest relative diff for any single entry in the output, for any of the solver calls (`5+num_tracers` solves in each `update_prognostics_implicit` call), and found that over every timestep, the largest rel_diff for any single entry was ~ 1e-04(SP) and 1e-12 (DP), which were both in the first timestep. For subsequent timesteps, all largest diffs were ~1e-6 (SP) and 1e- 15(DP).