### PR TITLE
SCREAM: allow to specify a work dir for test-all-scream

### DIFF
--- a/components/scream/cmake/ctest_script.cmake
+++ b/components/scream/cmake/ctest_script.cmake
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.9)
 
 set(CTEST_BUILD_NAME "scream_unit_tests_${BUILD_NAME_MOD}")
 
-get_filename_component(working_dir ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
-set(CTEST_SOURCE_DIRECTORY "${working_dir}")
-set(CTEST_BINARY_DIRECTORY "${working_dir}/ctest-build/${BUILD_NAME_MOD}")
+get_filename_component(SCREAM_ROOT ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
+set(CTEST_SOURCE_DIRECTORY "${SCREAM_ROOT}")
+set(CTEST_BINARY_DIRECTORY "${BUILD_WORK_DIR}")
 
 if(NOT DEFINED dashboard_model)
   set(dashboard_model Experimental)

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -86,6 +86,9 @@ OR
                         help="The root directory of the scream src you want to test. "
                         "Default will be the scream src containing this script.")
 
+    parser.add_argument("-w", "--work-dir",
+        help="The work directory where all the building/testing will happen. Defaults to ${root_dir}/ctest-build")
+
     parser.add_argument("-d", "--dry-run", action="store_true",
                         help="Do a dry run, commands will be printed but not executed")
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -62,7 +62,7 @@ class TestAllScream(object):
             expect(pathlib.Path(self._work_dir).absolute().is_dir(),
                    "Error! Work directory '{}' does not exist.".format(self._work_dir))
         else:
-            self._work_dir = self._root_dir.absolute().joinPath("ctest-build")
+            self._work_dir = self._root_dir.absolute().joinpath("ctest-build")
 
         expect (not self._baseline_dir or self._work_dir != self._baseline_dir,
                 "Error! For your safety, do NOT use '{}' to store baselines. Move them to a different directory (even a subdirectory of that works).".format(self._work_dir))

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -473,6 +473,10 @@ class TestAllScream(object):
         if stat != 0:
             print("WARNING: Failed to create baselines:\n{}".format(err))
             return False
+        else:
+            # Clean up the directory, by removing everything but the 'data' subfolder
+            run_cmd_no_fail("find -maxdepth 1 -not -name data ! -path . -exec rm -rf {} \;",
+                            from_dir=test_dir,verbose=True)
 
         return True
 


### PR DESCRIPTION
Upon request from @AaronDonahue , I added the capability of requesting a specific folder for test-all-scream to work in.

This can be helpful for users on systems with limited disk quota, so that they can keep the src code in their home folder, but dump all the build/testing stuff in a scratch location.

The new option is to be used as `test-all-scream -w some_dir` or `test-all-scream --work-dir some_dir`. If not provided, we build in the same folder as we used to (i.e., `/path/to/scream-src-folder/ctest-build`).