### PR TITLE
Fix a rare race condition in shoc_diag_second_moments_impl

### DIFF
--- a/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_calc_shoc_varorcovar_impl.hpp
@@ -11,13 +11,13 @@ KOKKOS_FUNCTION
 void Functions<S,D>
 ::calc_shoc_varorcovar(
   const MemberType&            team,
-  const Int&                   nlev, 
+  const Int&                   nlev,
   const Scalar& tunefac,
-  const uview_1d<const Spack>& isotropy_zi, 
+  const uview_1d<const Spack>& isotropy_zi,
   const uview_1d<const Spack>& tkh_zi,
   const uview_1d<const Spack>& dz_zi,
-  const uview_1d<const Spack>& invar1, 
-  const uview_1d<const Spack>& invar2, 
+  const uview_1d<const Spack>& invar1,
+  const uview_1d<const Spack>& invar2,
   const uview_1d<Spack>&       varorcovar)
 {
   const Int nlev_pack = ekat::npack<Spack>(nlev);

--- a/components/scream/src/physics/shoc/shoc_diag_second_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_second_moments_impl.hpp
@@ -13,15 +13,16 @@ namespace shoc {
 
 template<typename S, typename D>
 KOKKOS_FUNCTION
-void Functions<S,D>::diag_second_moments(const MemberType& team, const Int& nlev, const Int& nlevi, 
-                     const uview_1d<const Spack>& thetal, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& u_wind, 
-                     const uview_1d<const Spack>& v_wind, const uview_1d<const Spack>& tke, const uview_1d<const Spack>& isotropy, 
-                     const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& dz_zi, 
-                     const uview_1d<const Spack>& zt_grid, const uview_1d<const Spack>& zi_grid, const uview_1d<const Spack>& shoc_mix,
-                     const uview_1d<Spack>& isotropy_zi, const uview_1d<Spack>& tkh_zi, const uview_1d<Spack>& tk_zi, 
-                     const uview_1d<Spack>& thl_sec, const uview_1d<Spack>& qw_sec, const uview_1d<Spack>& wthl_sec, const uview_1d<Spack>& wqw_sec, 
-                     const uview_1d<Spack>& qwthl_sec, const uview_1d<Spack>& uw_sec, const uview_1d<Spack>& vw_sec, const uview_1d<Spack>& wtke_sec, 
-                     const uview_1d<Spack>& w_sec)
+void Functions<S,D>::diag_second_moments(
+  const MemberType& team, const Int& nlev, const Int& nlevi,
+  const uview_1d<const Spack>& thetal, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& u_wind,
+  const uview_1d<const Spack>& v_wind, const uview_1d<const Spack>& tke, const uview_1d<const Spack>& isotropy,
+  const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& dz_zi,
+  const uview_1d<const Spack>& zt_grid, const uview_1d<const Spack>& zi_grid, const uview_1d<const Spack>& shoc_mix,
+  const uview_1d<Spack>& isotropy_zi, const uview_1d<Spack>& tkh_zi, const uview_1d<Spack>& tk_zi,
+  const uview_1d<Spack>& thl_sec, const uview_1d<Spack>& qw_sec, const uview_1d<Spack>& wthl_sec, const uview_1d<Spack>& wqw_sec,
+  const uview_1d<Spack>& qwthl_sec, const uview_1d<Spack>& uw_sec, const uview_1d<Spack>& vw_sec, const uview_1d<Spack>& wtke_sec,
+  const uview_1d<Spack>& w_sec)
 {
   // Purpose of this subroutine is to diagnose the second
   //  order moments needed for the SHOC parameterization.
@@ -44,7 +45,8 @@ void Functions<S,D>::diag_second_moments(const MemberType& team, const Int& nlev
   // Interpolate some variables from the midpoint grid to the interface grid
   linear_interp(team, zt_grid, zi_grid, isotropy, isotropy_zi, nlev, nlevi, 0);
   linear_interp(team, zt_grid, zi_grid, tkh,      tkh_zi,      nlev, nlevi, 0);
-  linear_interp(team, zt_grid, zi_grid, tk,       tk_zi,       nlev, nlevi, 0); 
+  linear_interp(team, zt_grid, zi_grid, tk,       tk_zi,       nlev, nlevi, 0);
+  team.team_barrier();
 
   // Vertical velocity variance is assumed to be propotional to the TKE
   const Int nlev_pack = ekat::npack<Spack>(nlev);


### PR DESCRIPTION
The tk_zi view was being used as output in one call and input
in a later call without a barrier in-between.

Also, cleanup some whitespace issues.

Fixes #742 