### PR TITLE
test-all-scream: A few minor fixes

### DIFF
--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -80,7 +80,7 @@ class GatherAllData(object):
                 .format(scream_repo)
 
         extra_env = ""
-        if not is_cuda_machine():
+        if not is_cuda_machine(machine):
             extra_env = "OMP_PROC_BIND=spread "
 
         repo_setup = "true" if (self._local) else "git fetch && git checkout {} && git submodule update --init --recursive".format(self._commit)

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -3,7 +3,7 @@ from utils import run_cmd_no_fail
 import os, pathlib
 import concurrent.futures as threading3
 from machines_specs import get_mach_env_setup_command, get_mach_batch_command, get_mach_testing_resources, \
-                           get_mach_cxx_compiler, get_mach_f90_compiler, get_mach_c_compiler
+                           get_mach_cxx_compiler, get_mach_f90_compiler, get_mach_c_compiler, is_cuda_machine
 
 ###############################################################################
 class GatherAllData(object):
@@ -80,8 +80,7 @@ class GatherAllData(object):
                 .format(scream_repo)
 
         extra_env = ""
-        is_cuda_machine = "cuda" in env_setup_str
-        if not is_cuda_machine:
+        if not is_cuda_machine():
             extra_env = "OMP_PROC_BIND=spread "
 
         repo_setup = "true" if (self._local) else "git fetch && git checkout {} && git submodule update --init --recursive".format(self._commit)

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -149,6 +149,8 @@ def get_mach_baseline_root_dir(machine,default_dir):
 ###############################################################################
 def is_cuda_machine(machine):
 ###############################################################################
+    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+
     env_setup     = get_mach_env_setup_command(machine)
     env_setup_str = " && ".join(env_setup)
 

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -83,73 +83,63 @@ MACHINE_METADATA = {
 }
 
 ###############################################################################
-def is_machine_supported (machine):
+def is_machine_supported(machine):
 ###############################################################################
-
     return machine in MACHINE_METADATA.keys()
 
 ###############################################################################
-def get_mach_env_setup_command (machine):
+def get_mach_env_setup_command(machine):
 ###############################################################################
-
-    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
     return MACHINE_METADATA[machine][0]
 
 ###############################################################################
-def get_mach_cxx_compiler (machine):
+def get_mach_cxx_compiler(machine):
 ###############################################################################
-
-    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
     return MACHINE_METADATA[machine][1][0]
 
 ###############################################################################
-def get_mach_f90_compiler (machine):
+def get_mach_f90_compiler(machine):
 ###############################################################################
-
-    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
     return MACHINE_METADATA[machine][1][1]
 
 ###############################################################################
-def get_mach_c_compiler (machine):
+def get_mach_c_compiler(machine):
 ###############################################################################
-
-    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
     return MACHINE_METADATA[machine][1][2]
 
 ###############################################################################
-def get_mach_batch_command (machine):
+def get_mach_batch_command(machine):
 ###############################################################################
-
-    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
     return MACHINE_METADATA[machine][2]
 
 ###############################################################################
-def get_mach_compilation_resources (machine):
+def get_mach_compilation_resources(machine):
 ###############################################################################
-
-    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
     return MACHINE_METADATA[machine][3]
 
 ###############################################################################
-def get_mach_testing_resources (machine):
+def get_mach_testing_resources(machine):
 ###############################################################################
-
-    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
     return MACHINE_METADATA[machine][4]
 
-
 ###############################################################################
-def get_mach_baseline_root_dir (machine,default_dir):
+def get_mach_baseline_root_dir(machine,default_dir):
 ###############################################################################
-
-    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
     if MACHINE_METADATA[machine][5]=="":
         return default_dir
@@ -157,10 +147,17 @@ def get_mach_baseline_root_dir (machine,default_dir):
         return MACHINE_METADATA[machine][5]
 
 ###############################################################################
-def setup_mach_env (machine):
+def is_cuda_machine(machine):
 ###############################################################################
+    env_setup     = get_mach_env_setup_command(machine)
+    env_setup_str = " && ".join(env_setup)
 
-    expect (is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    return "cuda" in env_setup_str.lower()
+
+###############################################################################
+def setup_mach_env(machine):
+###############################################################################
+    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
 
     env_setup = get_mach_env_setup_command(machine)
 

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -47,7 +47,7 @@ OR
     parser.add_argument("-f90","--f90-compiler", help="F90 compiler", default=None)
     parser.add_argument("--c-compiler", help="C compiler", default=None)
 
-    parser.add_argument("-s", "--submit", action="store_true", help="Submit results to dashboad, requires machine")
+    parser.add_argument("-s", "--submit", action="store_true", help="Submit results to dashboad")
     parser.add_argument("-p", "--parallel", action="store_true",
                         help="Launch the different build types stacks in parallel")
 

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -60,7 +60,7 @@ OR
     parser.add_argument("--baseline-dir", default=None,
         help="Use baselines from the given directory, skip baseline creation.")
 
-    parser.add_argument("-m", "--machine", required=True,
+    parser.add_argument("-m", "--machine",
         help="Provide machine name. This is *always* required")
 
     parser.add_argument("--no-tests", action="store_true", help="Only build baselines, skip testing phase")

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -3,8 +3,8 @@ from utils import run_cmd, run_cmd_no_fail, check_minimum_python_version, get_cu
     get_common_ancestor, merge_git_ref, checkout_git_ref, print_last_commit
 
 from machines_specs import get_mach_compilation_resources, get_mach_testing_resources, \
-                           get_mach_baseline_root_dir, setup_mach_env, \
-                           get_mach_cxx_compiler, get_mach_f90_compiler, get_mach_c_compiler
+    get_mach_baseline_root_dir, setup_mach_env, is_cuda_machine, \
+    get_mach_cxx_compiler, get_mach_f90_compiler, get_mach_c_compiler
 
 check_minimum_python_version(3, 4)
 
@@ -91,10 +91,9 @@ class TestAllScream(object):
                                   "fpe" : "debug_nopack_fpe"}
 
         if not self._tests:
-            is_cuda_machine = "OMPI_CXX" in os.environ
             # always do dbg and sp tests, do not do fpe test on CUDA
             self._tests = ["dbg", "sp"]
-            if not is_cuda_machine:
+            if not is_cuda_machine():
                 self._tests.append("fpe")
         else:
             for t in self._tests:

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -57,7 +57,7 @@ class TestAllScream(object):
             if "CIME_MACHINE" in os.environ and is_machine_supported(os.environ["CIME_MACHINE"]):
                 self._machine = os.environ["CIME_MACHINE"]
             else:
-                expect(self._machine is not None, "Machine is now required by test-all-scream")
+                expect(False, "Machine is now required by test-all-scream")
 
         # Unless the user claims to know what he/she is doing, we setup the env.
         if not self._preserve_env:


### PR DESCRIPTION
1) Restore the ability of test_all_scream to detect CUDA builds and skip
   fpe test if so.
2) Skip various not-None checks on self._machine since we now expect it to
   always be set.
3) Python strings containing `\` must be declared as raw or else this character
   will be interpreted as an escape character.