### PR TITLE
Port shoc solver functions

### DIFF
--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -61,6 +61,7 @@ if (NOT CUDA_BUILD)
     shoc_dp_inverse.cpp
     shoc_shoc_main.cpp
     shoc_pblintd_height.cpp
+    shoc_tridiag_solver.cpp
   ) # SHOC ETI SRCS
 endif()
 

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -52,6 +52,8 @@ struct Functions
   using view_1d = typename KT::template view_1d<S>;
   template <typename S>
   using view_2d = typename KT::template view_2d<S>;
+  template <typename S>
+  using view_3d = typename KT::template view_3d<S>;
 
   template <typename S, int N>
   using view_1d_ptr_array = typename KT::template view_1d_ptr_carray<S, N>;
@@ -403,8 +405,30 @@ struct Functions
 
   KOKKOS_FUNCTION
   static void shoc_main(const Int& shcol, const Int& nlev, const Int& nlevi, const Spack& dtime, const Int& nadv, const uview_1d<const Spack>& host_dx, const uview_1d<const Spack>& host_dy, const uview_1d<const Spack>& thv, const uview_1d<const Spack>& zt_grid, const uview_1d<const Spack>& zi_grid, const uview_1d<const Spack>& pres, const uview_1d<const Spack>& presi, const uview_1d<const Spack>& pdel, const uview_1d<const Spack>& wthl_sfc, const uview_1d<const Spack>& wqw_sfc, const uview_1d<const Spack>& uw_sfc, const uview_1d<const Spack>& vw_sfc, const uview_1d<const Spack>& wtracer_sfc, const Int& num_qtracers, const uview_1d<const Spack>& w_field, const uview_1d<const Spack>& exner, const uview_1d<const Spack>& phis, const uview_1d<Spack>& host_dse, const uview_1d<Spack>& tke, const uview_1d<Spack>& thetal, const uview_1d<Spack>& qw, const uview_1d<Spack>& u_wind, const uview_1d<Spack>& v_wind, const uview_1d<Spack>& qtracers, const uview_1d<Spack>& wthv_sec, const uview_1d<Spack>& tkh, const uview_1d<Spack>& tk, const uview_1d<Spack>& shoc_ql, const uview_1d<Spack>& shoc_cldfrac, const uview_1d<Spack>& pblh, const uview_1d<Spack>& shoc_mix, const uview_1d<Spack>& isotropy, const uview_1d<Spack>& w_sec, const uview_1d<Spack>& thl_sec, const uview_1d<Spack>& qw_sec, const uview_1d<Spack>& qwthl_sec, const uview_1d<Spack>& wthl_sec, const uview_1d<Spack>& wqw_sec, const uview_1d<Spack>& wtke_sec, const uview_1d<Spack>& uw_sec, const uview_1d<Spack>& vw_sec, const uview_1d<Spack>& w3, const uview_1d<Spack>& wqls_sec, const uview_1d<Spack>& brunt, const uview_1d<Spack>& shoc_ql2);
+
   KOKKOS_FUNCTION
   static void pblintd_height(const Int& shcol, const Int& nlev, const uview_1d<const Spack>& z, const uview_1d<const Spack>& u, const uview_1d<const Spack>& v, const uview_1d<const Spack>& ustar, const uview_1d<const Spack>& thv, const uview_1d<const Spack>& thv_ref, const uview_1d<Spack>& pblh, const uview_1d<Spack>& rino, const uview_1d<bool>& check);
+
+  KOKKOS_FUNCTION
+  static void vd_shoc_decomp(
+    const MemberType&            team,
+    const Int&                   nlev,
+    const uview_1d<const Spack>& kv_term,
+    const uview_1d<const Spack>& tmpi,
+    const uview_1d<const Spack>& rdp_zt,
+    const Scalar&                dtime,
+    const Scalar&                flux,
+    const uview_1d<Scalar>&      du,
+    const uview_1d<Scalar>&      dl,
+    const uview_1d<Scalar>&      d);
+
+  KOKKOS_FUNCTION
+  static void vd_shoc_solve(
+    const MemberType&       team,
+    const uview_1d<Scalar>& du,
+    const uview_1d<Scalar>& dl,
+    const uview_1d<Scalar>& d,
+    const uview_2d<Spack>&  var);
 }; // struct Functions
 
 } // namespace shoc
@@ -446,6 +470,7 @@ struct Functions
 # include "shoc_dp_inverse_impl.hpp"
 # include "shoc_shoc_main_impl.hpp"
 # include "shoc_pblintd_height_impl.hpp"
+# include "shoc_tridiag_solver_impl.hpp"
 #endif // KOKKOS_ENABLE_CUDA
 
 #endif // SHOC_FUNCTIONS_HPP

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -817,6 +817,23 @@ struct PblintdHeightData : public PhysicsTestData {
 
   PTD_STD_DEF(PblintdHeightData, 2, shcol, nlev);
 };
+struct VdShocDecompandSolveData : public PhysicsTestData {
+  // Inputs
+  Int shcol, nlev, nlevi, n_rhs;
+  Real dtime;
+  Real *kv_term, *tmpi, *rdp_zt, *flux;
+
+  // Inputs/Outputs
+  Real *du, *dl, *d;
+  Real *var, *rhs;
+
+  VdShocDecompandSolveData(Int shcol_, Int nlev_, Int nlevi_, Real dtime_, Int n_rhs_) :
+    PhysicsTestData({{shcol_}, {shcol_, nlev_},               {shcol_, nlevi_},  {shcol_, nlev_, n_rhs_}},
+                    {{&flux}, {&rdp_zt, &du, &dl, &d, &rhs}, {&kv_term, &tmpi}, {&var }                }, {}),
+                    shcol(shcol_), nlev(nlev_), nlevi(nlevi_), dtime(dtime_), n_rhs(n_rhs_) {}
+
+  PTD_STD_DEF(VdShocDecompandSolveData, 5, shcol, nlev, nlevi, dtime, n_rhs);
+};
 
 // Glue functions to call fortran from from C++ with the Data struct
 
@@ -883,7 +900,7 @@ void compute_shoc_vapor                             (ComputeShocVaporData& d);
 void update_prognostics_implicit                    (UpdatePrognosticsImplicitData& d);
 void shoc_main                                      (ShocMainData& d);
 void pblintd_height                                 (PblintdHeightData& d);
-
+void vd_shoc_decomp_and_solve                       (VdShocDecompandSolveData& d);
 extern "C" { // _f function decls
 
 void calc_shoc_varorcovar_f(Int shcol, Int nlev, Int nlevi, Real tunefac,
@@ -957,7 +974,11 @@ void integ_column_stability_f(Int nlev, Int shcol, Real *dz_zt,
 void dp_inverse_f(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_zt);
 
 void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* host_dx, Real* host_dy, Real* thv, Real* zt_grid, Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner, Real* phis, Real* host_dse, Real* tke, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk, Real* shoc_ql, Real* shoc_cldfrac, Real* pblh, Real* shoc_mix, Real* isotropy, Real* w_sec, Real* thl_sec, Real* qw_sec, Real* qwthl_sec, Real* wthl_sec, Real* wqw_sec, Real* wtke_sec, Real* uw_sec, Real* vw_sec, Real* w3, Real* wqls_sec, Real* brunt, Real* shoc_ql2);
+
 void pblintd_height_f(Int shcol, Int nlev, Real* z, Real* u, Real* v, Real* ustar, Real* thv, Real* thv_ref, Real* pblh, Real* rino, bool* check);
+
+void vd_shoc_decomp_and_solve_f(Int shcol, Int nlev, Int nlevi, Int num_rhs, Real* kv_term, Real* tmpi, Real* rdp_zt, Real dtime,
+                                Real* flux, Real* var);
 } // end _f function decls
 
 }  // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -1347,5 +1347,29 @@ contains
 
     call pblintd_height(shcol, nlev, z, u, v, ustar, thv, thv_ref, pblh, rino, check)
   end subroutine pblintd_height_c
+
+  subroutine vd_shoc_decomp_c(shcol, nlev, nlevi, kv_term, tmpi, rdp_zt, dtime, flux, du, dl, d) bind(C)
+    use shoc, only : vd_shoc_decomp
+
+    integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi
+    real(kind=c_real) , intent(in), dimension(shcol, nlevi) :: kv_term, tmpi
+    real(kind=c_real) , intent(in), dimension(shcol, nlev) :: rdp_zt
+    real(kind=c_real) , value, intent(in) :: dtime
+    real(kind=c_real) , intent(in), dimension(shcol) :: flux
+    real(kind=c_real) , intent(out), dimension(shcol, nlev) :: du, dl, d
+
+    call vd_shoc_decomp(shcol, nlev, nlevi, kv_term, tmpi, rdp_zt, dtime, flux, du, dl, d)
+  end subroutine vd_shoc_decomp_c
+
+  subroutine vd_shoc_solve_c(shcol, nlev, du, dl, d, var) bind(C)
+    use shoc, only : vd_shoc_solve
+
+    integer(kind=c_int) , value, intent(in) :: shcol, nlev
+    real(kind=c_real) , intent(in), dimension(shcol, nlev) :: du, dl, d
+    real(kind=c_real) , intent(inout), dimension(shcol, nlev) :: var
+
+    call vd_shoc_solve(shcol, nlev, du, dl, d, var)
+  end subroutine vd_shoc_solve_c
+
 end module shoc_iso_c
 

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -428,6 +428,7 @@ end subroutine dp_inverse_f
     real(kind=c_real) , intent(out), dimension(shcol, nlev) :: shoc_mix, isotropy, w_sec, wqls_sec, brunt, shoc_ql2
     real(kind=c_real) , intent(out), dimension(shcol, nlevi) :: thl_sec, qw_sec, qwthl_sec, wthl_sec, wqw_sec, wtke_sec, uw_sec, vw_sec, w3
   end subroutine shoc_main_f
+
   subroutine pblintd_height_f(shcol, nlev, z, u, v, ustar, thv, thv_ref, pblh, rino, check) bind(C)
     use iso_c_binding
 
@@ -438,6 +439,18 @@ end subroutine dp_inverse_f
     real(kind=c_real) , intent(inout), dimension(shcol, nlev) :: rino
     logical(kind=c_bool) , intent(inout), dimension(shcol) :: check
   end subroutine pblintd_height_f
+
+  subroutine vd_shoc_decomp_and_solve_f(shcol, nlev, nlevi, num_rhs, kv_term, tmpi, rdp_zt, dtime, flux, var) bind(C)
+    use iso_c_binding
+
+    integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi, num_rhs
+    real(kind=c_real) , intent(in), dimension(shcol, nlevi) :: kv_term, tmpi
+    real(kind=c_real) , intent(in), dimension(shcol, nlev) :: rdp_zt
+    real(kind=c_real) , value, intent(in) :: dtime
+    real(kind=c_real) , intent(in), dimension(shcol) :: flux
+    real(kind=c_real) , intent(inout), dimension(shcol, nlev) :: var
+  end subroutine vd_shoc_decomp_and_solve_f
+
 end interface
 
 end module shoc_iso_f

--- a/components/scream/src/physics/shoc/shoc_tridiag_solver.cpp
+++ b/components/scream/src/physics/shoc/shoc_tridiag_solver.cpp
@@ -1,0 +1,13 @@
+#include "shoc_tridiag_solver_impl.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation for using the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream

--- a/components/scream/src/physics/shoc/shoc_tridiag_solver_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_tridiag_solver_impl.hpp
@@ -1,0 +1,93 @@
+#ifndef SHOC_TRIDIAG_SOLVER_IMPL_HPP
+#define SHOC_TRIDIAG_SOLVER_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+#include "ekat/util/ekat_tridiag.hpp"
+
+namespace scream {
+namespace shoc {
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::vd_shoc_decomp(
+  const MemberType&            team,
+  const Int&                   nlev,
+  const uview_1d<const Spack>& kv_term,
+  const uview_1d<const Spack>& tmpi,
+  const uview_1d<const Spack>& rdp_zt,
+  const Scalar&                dtime,
+  const Scalar&                flux,
+  const uview_1d<Scalar>&       du,
+  const uview_1d<Scalar>&       dl,
+  const uview_1d<Scalar>&       d)
+{
+  const auto ggr = C::gravit;
+
+  const auto skv_term = scalarize(kv_term);
+  const auto stmpi = scalarize(tmpi);
+
+  const Int nlev_pack = ekat::npack<Spack>(nlev);
+
+  // Compute entries of the tridiagonal system
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+
+    // Compute local diagonals
+    Spack du_k, dl_k, d_k;
+
+    // Compute shift of kv_term and tmpi
+    Spack kv_term_k, kv_term_kp1, tmpi_k, tmpi_kp1;
+    auto range_pack = ekat::range<IntSmallPack>(k*Spack::n);
+    auto shift_range = range_pack;
+    shift_range.set(range_pack > nlev-1, 1); // don't calculate shift above nlev-1
+    ekat::index_and_shift<1>(skv_term, shift_range, kv_term_k, kv_term_kp1);
+    ekat::index_and_shift<1>(stmpi, shift_range, tmpi_k, tmpi_kp1);
+
+    // Determine superdiagonal (du) and subdiagonal (dl) coeffs of the
+    // tridiagonal diffusion matrix.
+    du_k = -kv_term_kp1*tmpi_kp1*rdp_zt(k);
+    dl_k = -kv_term(k)*tmpi(k)*rdp_zt(k);
+
+    // The bottom element of the superdiagonal (du) and the top element of
+    // the subdiagonal (dl) is set to zero (not included in linear system).
+    du_k.set(range_pack == nlev-1, 0);
+    dl_k.set(range_pack == 0, 0);
+
+    // The diagonal elements are a combination of du and dl (d=1-du-dl). Surface
+    // fluxes are applied explicitly in the diagonal at the top level.
+    d_k = 1 - du_k - dl_k;
+    d_k.set(range_pack == nlev-1, d_k + flux*dtime*ggr*rdp_zt(k));
+
+    // Diagonals must be scalar in nlev.
+    for (Int p=0; p<Spack::n && range_pack[p]<nlev; ++p) {
+      du(range_pack[p]) = du_k[p];
+      dl(range_pack[p]) = dl_k[p];
+      d (range_pack[p]) = d_k [p];
+    }
+  });
+}
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::vd_shoc_solve(
+  const MemberType&      team,
+  const uview_1d<Scalar>& du,
+  const uview_1d<Scalar>& dl,
+  const uview_1d<Scalar>& d,
+  const uview_2d<Spack>&  var)
+{
+#ifdef EKAT_DEFAULT_BFB
+  ekat::bfb(team, dl, d, du, var);
+#else
+#ifdef KOKKOS_ENABLE_CUDA
+  ekat::cr(team, dl, d, du, ekat::scalarize(var));
+#else
+  const auto f = [&] () { ekat::thomas(dl, d, du, var); };
+  Kokkos::single(Kokkos::PerTeam(team), f);
+#endif
+#endif
+}
+
+} // namespace shoc
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ set(SHOC_TESTS_SRCS
     shoc_update_prognostics_implicit_tests.cpp
     shoc_shoc_main_tests.cpp
     shoc_pblintd_height_tests.cpp
+    shoc_vd_shoc_decomp_and_solve_tests.cpp
     ) # SHOC_TESTS_SRCS
 
 # NOTE: tests inside this if statement won't be built in a baselines-only build

--- a/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
+++ b/components/scream/src/physics/shoc/tests/shoc_unit_tests_common.hpp
@@ -115,6 +115,7 @@ struct UnitWrap {
     struct TestUpdatePrognosticsImplicit;
     struct TestShocMain;
     struct TestPblintdHeight;
+    struct TestVdShocDecompandSolve;
   };
 
 };

--- a/components/scream/src/physics/shoc/tests/shoc_vd_shoc_decomp_and_solve_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_vd_shoc_decomp_and_solve_tests.cpp
@@ -1,0 +1,92 @@
+#include "catch2/catch.hpp"
+
+#include "share/scream_types.hpp"
+#include "ekat/ekat_pack.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "physics/shoc/shoc_functions.hpp"
+#include "physics/shoc/shoc_functions_f90.hpp"
+
+#include "shoc_unit_tests_common.hpp"
+
+namespace scream {
+namespace shoc {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestVdShocDecompandSolve {
+
+  static void run_bfb()
+  {
+    VdShocDecompandSolveData f90_data[] = {
+      // shcol, nlev, nlevi, dtime, n_rhs
+      VdShocDecompandSolveData(10, 71, 72, 5, 19),
+      VdShocDecompandSolveData(10, 12, 13, 2.5, 7),
+      VdShocDecompandSolveData(7, 16, 17, 1, 2),
+      VdShocDecompandSolveData(2, 7, 8, 1, 1)
+    };
+
+    static constexpr Int num_runs = sizeof(f90_data) / sizeof(VdShocDecompandSolveData);
+
+    // Generate random input data. Diagonals in solver data will be overwritten
+    // after results of decomp routine.
+    for (Int i = 0; i < num_runs; ++i) {
+      VdShocDecompandSolveData& d_f90 = f90_data[i];
+      d_f90.randomize();
+    }
+
+    // Create copies of data for use by cxx. Needs to happen before fortran calls so that
+    // inout data is in original state
+    VdShocDecompandSolveData cxx_data[] = {
+      VdShocDecompandSolveData(f90_data[0]),
+      VdShocDecompandSolveData(f90_data[1]),
+      VdShocDecompandSolveData(f90_data[2]),
+      VdShocDecompandSolveData(f90_data[3])
+    };
+
+    // Assume all data is in C layout
+
+    // Get data from fortran.
+    for (Int i = 0; i < num_runs; ++i) {
+      VdShocDecompandSolveData& d_f90 = f90_data[i];
+      // expects data in C layout
+      vd_shoc_decomp_and_solve(d_f90);
+    }
+
+    // Get data from cxx
+    for (Int i = 0; i < num_runs; ++i) {
+      VdShocDecompandSolveData& d_cxx = cxx_data[i];
+
+      d_cxx.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+      vd_shoc_decomp_and_solve_f(d_cxx.shcol, d_cxx.nlev, d_cxx.nlevi, d_cxx.n_rhs,
+                                 d_cxx.kv_term, d_cxx.tmpi, d_cxx.rdp_zt,
+                                 d_cxx.dtime, d_cxx.flux, d_cxx.var);
+      d_cxx.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
+    }
+
+    // Verify BFB results, all data should be in C layout
+    for (Int i = 0; i < num_runs; ++i) {
+      VdShocDecompandSolveData& d_f90 = f90_data[i];
+      VdShocDecompandSolveData& d_cxx = cxx_data[i];
+      for (Int k = 0; k < d_f90.total(d_f90.var); ++k) {
+        REQUIRE(d_f90.total(d_f90.var) == d_cxx.total(d_cxx.var));
+        REQUIRE(d_f90.var[k] == d_cxx.var[k]);
+      }
+    }
+  } // run_bfb
+
+};
+
+} // namespace unit_test
+} // namespace shoc
+} // namespace scream
+
+namespace {
+
+TEST_CASE("vd_shoc_solve_bfb", "[shoc]")
+{
+  using TestStruct = scream::shoc::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestVdShocDecompandSolve;
+
+  TestStruct::run_bfb();
+}
+
+} // empty namespace


### PR DESCRIPTION
Implementation of the shoc solver in C++ using ekat_tridiag functions. 

These changes do not replace the fortran solver (i.e., no linking calls from functions in shoc.F90), only implementations of the functions in shoc_functions.hpp. The solver will be called from Fortran when I port update_prognostics_implicit next.

I added a bfb test which compares both the decomposition and solver to Fortran.