### PR TITLE
Ports integ_column_stability to C++/Kokkos

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -2933,10 +2933,6 @@ subroutine integ_column_stability(nlev, shcol, dz_zt, pres, brunt, brunt_int)
 #ifdef SCREAM_CONFIG_IS_CMAKE
   if (use_cxx) then
      call integ_column_stability_f(nlev, shcol, dz_zt, pres, brunt, brunt_int)
-     do i = 1, shcol
-        write(102,*)i,brunt_int(i)
-     enddo
-
      return
   endif
 #endif
@@ -2950,9 +2946,6 @@ subroutine integ_column_stability(nlev, shcol, dz_zt, pres, brunt, brunt_int)
      enddo
   enddo
 
-  do i = 1, shcol
-     write(103,*)i,brunt_int(i)
-  enddo
   return
 
 end subroutine integ_column_stability

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -365,7 +365,7 @@ subroutine shoc_main ( &
 
     ! Compute the planetary boundary layer height, which is an
     !   input needed for the length scale calculation.
-    
+
     ! Update SHOC water vapor, to be used by the next two routines
     call compute_shoc_vapor(&
        shcol,nlev,qw,shoc_ql,&              ! Input
@@ -479,12 +479,12 @@ subroutine shoc_main ( &
 
   ! Update PBLH, as other routines outside of SHOC
   !  may require this variable.
-  
+
   ! Update SHOC water vapor, to be used by the next two routines
   call compute_shoc_vapor(&
      shcol,nlev,qw,shoc_ql,&              ! Input
      shoc_qv)                             ! Output
-  
+
   call shoc_diag_obklen(&
      shcol,uw_sfc,vw_sfc,&                          ! Input
      wthl_sfc,wqw_sfc,thetal(:shcol,nlev),&         ! Input
@@ -719,7 +719,7 @@ subroutine update_prognostics_implicit( &
 
   ! compute surface fluxes for liq. potential temp, water and tke
   call sfc_fluxes(shcol, num_tracer, dtime, rho_zi(:,nlevi), rdp_zt(:,nlev), &
-                  wthl_sfc, wqw_sfc, wtke_sfc, wtracer_sfc, & 
+                  wthl_sfc, wqw_sfc, wtke_sfc, wtracer_sfc, &
                   thetal(:,nlev), qw(:,nlev), tke(:,nlev), tracer(:,nlev,:))
 
   ! Call decomp for momentum variables
@@ -952,7 +952,7 @@ subroutine sfc_fluxes(shcol, num_tracer, dtime, rho_zi_sfc, rdp_zt_sfc, wthl_sfc
      thetal(i) = thetal(i) + cmnfac * wthl_sfc(i)
      qw(i)     = qw(i)     + cmnfac * wqw_sfc(i)
      tke(i)    = tke(i)    + cmnfac * wtke_sfc(i)
-  
+
      ! surface fluxes for tracers
      do p = 1, num_tracer
         wtracer(i,p) = wtracer(i,p) + cmnfac * wtracer_sfc(i,p)
@@ -1348,7 +1348,7 @@ subroutine diag_second_moments(&
      call diag_second_moments_f(shcol,nlev,nlevi,thetal,qw,u_wind,v_wind,tke, &         ! Input
                                 isotropy,tkh,tk,dz_zi,zt_grid,zi_grid,shoc_mix, &      ! Input
                                 thl_sec,qw_sec,wthl_sec,wqw_sec,qwthl_sec,uw_sec,vw_sec,wtke_sec, &    ! Input/Output
-                                w_sec)                                 
+                                w_sec)
       return
    endif
 #endif
@@ -2933,6 +2933,10 @@ subroutine integ_column_stability(nlev, shcol, dz_zt, pres, brunt, brunt_int)
 #ifdef SCREAM_CONFIG_IS_CMAKE
   if (use_cxx) then
      call integ_column_stability_f(nlev, shcol, dz_zt, pres, brunt, brunt_int)
+     do i = 1, shcol
+        write(102,*)i,brunt_int(i)
+     enddo
+
      return
   endif
 #endif
@@ -2946,6 +2950,9 @@ subroutine integ_column_stability(nlev, shcol, dz_zt, pres, brunt, brunt_int)
      enddo
   enddo
 
+  do i = 1, shcol
+     write(103,*)i,brunt_int(i)
+  enddo
   return
 
 end subroutine integ_column_stability
@@ -3926,7 +3933,7 @@ subroutine shoc_diag_obklen(&
 #ifdef SCREAM_CONFIG_IS_CMAKE
   use shoc_iso_f, only: shoc_diag_obklen_f
 #endif
-    
+
   implicit none
 
 ! INPUT VARIABLES
@@ -4480,7 +4487,7 @@ subroutine compute_brunt_shoc_length(nlev,nlevi,shcol,dz_zt,thv,thv_zi,brunt)
 #ifdef SCREAM_CONFIG_IS_CMAKE
   use shoc_iso_f, only: compute_brunt_shoc_length_f
 #endif
-  
+
   implicit none
   integer, intent(in) :: nlev, nlevi, shcol
   ! Grid difference centereted on thermo grid [m]
@@ -4499,7 +4506,7 @@ subroutine compute_brunt_shoc_length(nlev,nlevi,shcol,dz_zt,thv,thv_zi,brunt)
     return
   endif
 #endif
-  
+
   do k=1,nlev
     do i=1,shcol
       brunt(i,k) = (ggr/thv(i,k)) * (thv_zi(i,k) - thv_zi(i,k+1))/dz_zt(i,k)
@@ -4516,7 +4523,7 @@ subroutine compute_l_inf_shoc_length(nlev,shcol,zt_grid,dz_zt,tke,l_inf)
 #ifdef SCREAM_CONFIG_IS_CMAKE
   use shoc_iso_f, only: compute_l_inf_shoc_length_f
 #endif
- 
+
   implicit none
   integer, intent(in) :: nlev, shcol
   real(rtype), intent(in) :: zt_grid(shcol,nlev), dz_zt(shcol,nlev), tke(shcol,nlev)
@@ -4700,7 +4707,7 @@ subroutine check_length_scale_shoc_length(nlev,shcol,host_dx,host_dy,shoc_mix)
     return
   endif
 #endif
-  
+
   do k=1,nlev
     do i=1,shcol
       shoc_mix(i,k)=min(maxlen,shoc_mix(i,k))

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -2909,6 +2909,10 @@ end subroutine shoc_tke
 
 subroutine integ_column_stability(nlev, shcol, dz_zt, pres, brunt, brunt_int)
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  use shoc_iso_f, only: integ_column_stability_f
+#endif
+
   implicit none
   !intent-ins
   integer,     intent(in) :: nlev, shcol
@@ -2925,6 +2929,13 @@ subroutine integ_column_stability(nlev, shcol, dz_zt, pres, brunt, brunt_int)
 
   !local variables
   integer :: i, k
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  if (use_cxx) then
+     call integ_column_stability_f(nlev, shcol, dz_zt, pres, brunt, brunt_int)
+     return
+  endif
+#endif
 
   brunt_int(1:shcol) = 0._rtype
   do k = 1, nlev

--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -57,6 +57,7 @@ if (NOT CUDA_BUILD)
     shoc_diag_third_shoc_moments.cpp
     shoc_assumed_pdf.cpp
     shoc_compute_tmpi.cpp
+    shoc_integ_column_stability.cpp
     shoc_dp_inverse.cpp
     shoc_shoc_main.cpp
   ) # SHOC ETI SRCS

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -385,6 +385,15 @@ struct Functions
     const uview_1d<Spack>&       tmpi);
 
   KOKKOS_FUNCTION
+  static void integ_column_stability(
+    const MemberType&            team,
+    const Int&                   nlev,
+    const uview_1d<const Spack>& dz_zt,
+    const uview_1d<const Spack>& pres,
+    const uview_1d<const Spack>& brunt,
+    Scalar&                      brunt_int);
+
+  KOKKOS_FUNCTION
   static void dp_inverse(
     const MemberType&            team,
     const Int&                   nlev,
@@ -431,6 +440,7 @@ struct Functions
 # include "shoc_diag_third_shoc_moments_impl.hpp"
 # include "shoc_assumed_pdf_impl.hpp"
 # include "shoc_compute_tmpi_impl.hpp"
+# include "shoc_integ_column_stability_impl.hpp"
 # include "shoc_dp_inverse_impl.hpp"
 # include "shoc_shoc_main_impl.hpp"
 #endif // KOKKOS_ENABLE_CUDA

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -2358,7 +2358,7 @@ void integ_column_stability_f(Int nlev, Int shcol, Real *dz_zt,
       //declare output as a scalar
       Scalar brunt_int_s{0};
 
-      //SHF::integ_column_stability(team, nlev, dz_zt_s, pres_s, brunt_s, brunt_int_s);
+      SHF::integ_column_stability(team, nlev, dz_zt_s, pres_s, brunt_s, brunt_int_s);
 
       brunt_int_d(i)[0] = brunt_int_s;
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -65,8 +65,8 @@ void compute_tmpi_c(Int nlevi, Int shcol, Real dtime, Real *rho_zi,
 
 void dp_inverse_c(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_zt);
 
-void sfc_fluxes_c(Int shcol, Int num_tracer, Real dtime, Real *rho_zi_sfc, 
-                  Real *rdp_zt_sfc, Real *wthl_sfc, Real *wqw_sfc, Real *wtracer_sfc, 
+void sfc_fluxes_c(Int shcol, Int num_tracer, Real dtime, Real *rho_zi_sfc,
+                  Real *rdp_zt_sfc, Real *wthl_sfc, Real *wqw_sfc, Real *wtracer_sfc,
                   Real *wtke_sfc, Real *thetal, Real *qw, Real *tke, Real *tracer);
 
 void impli_srf_stress_term_c(Int shcol, Real *rho_zi_sfc, Real *uw_sfc,
@@ -307,7 +307,7 @@ void sfc_fluxes(SHOCSfcfluxesData &d){
   shoc_init(1, true); // single layer function
   d.transpose<ekat::TransposeDirection::c2f>();
   sfc_fluxes_c(d.shcol(), d.num_tracer(), d.dtime, d.rho_zi_sfc, d.rdp_zt_sfc,
-               d.wthl_sfc, d.wqw_sfc, d.wtke_sfc, d.wtracer_sfc, d.thetal, d.qw, 
+               d.wthl_sfc, d.wqw_sfc, d.wtke_sfc, d.wtracer_sfc, d.thetal, d.qw,
                d.tke, d.tracer);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
@@ -720,7 +720,7 @@ void shoc_pblintd_init_pot(SHOCPblintdInitPotData& d)
 void diag_second_moments_lbycond(DiagSecondMomentsLbycondData& d)
 {
   shoc_init(64, true);  // Single level routine
-  diag_second_moments_lbycond_c(d.shcol(), d.wthl_sfc, d.wqw_sfc, d.uw_sfc, d.vw_sfc, d.ustar2, d.wstar, 
+  diag_second_moments_lbycond_c(d.shcol(), d.wthl_sfc, d.wqw_sfc, d.uw_sfc, d.vw_sfc, d.ustar2, d.wstar,
                                 d.wthl_sec, d.wqw_sec, d.uw_sec, d.vw_sec, d.wtke_sec, d.thl_sec, d.qw_sec, d.qwthl_sec);
 }
 
@@ -728,8 +728,8 @@ void diag_second_moments(DiagSecondMomentsData& d)
 {
   shoc_init(d.nlev(), true);
   d.transpose<ekat::TransposeDirection::c2f>();
-  diag_second_moments_c(d.shcol(), d.nlev(), d.nlevi(), d.thetal, d.qw, d.u_wind, d.v_wind, d.tke, d.isotropy, d.tkh, d.tk, 
-                        d.dz_zi, d.zt_grid, d.zi_grid, d.shoc_mix, d.thl_sec, d.qw_sec, d.wthl_sec, d.wqw_sec, d.qwthl_sec, 
+  diag_second_moments_c(d.shcol(), d.nlev(), d.nlevi(), d.thetal, d.qw, d.u_wind, d.v_wind, d.tke, d.isotropy, d.tkh, d.tk,
+                        d.dz_zi, d.zt_grid, d.zi_grid, d.shoc_mix, d.thl_sec, d.qw_sec, d.wthl_sec, d.wqw_sec, d.qwthl_sec,
                         d.uw_sec, d.vw_sec, d.wtke_sec, d.w_sec);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
@@ -1368,7 +1368,7 @@ void shoc_energy_integrals_f(Int shcol, Int nlev, Real *host_dse, Real *pdel,
   ekat::device_to_host<int,4>({se_int,ke_int,wv_int,wl_int},shcol,inout_views);
 }
 
-void diag_second_moments_lbycond_f(Int shcol, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* ustar2, Real* wstar, 
+void diag_second_moments_lbycond_f(Int shcol, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* ustar2, Real* wstar,
      Real* wthl_sec, Real* wqw_sec, Real* uw_sec, Real* vw_sec, Real* wtke_sec, Real* thl_sec, Real* qw_sec, Real* qwthl_sec)
 {
   using SHOC       = Functions<Real, DefaultDevice>;
@@ -1431,10 +1431,10 @@ void diag_second_moments_lbycond_f(Int shcol, Real* wthl_sfc, Real* wqw_sfc, Rea
   Kokkos::Array<view_1d, 8> host_views = {wthlo_d, wqwo_d, uwo_d, vwo_d, wtkeo_d, thlo_d, qwo_d, qwthlo_d};
   ekat::device_to_host({wthl_sec, wqw_sec, uw_sec, vw_sec, wtke_sec, thl_sec, qw_sec, qwthl_sec}, shcol, host_views);
 }
- 
-void diag_second_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, 
-          Real* tke, Real* isotropy, Real* tkh, Real* tk, Real* dz_zi, Real* zt_grid, Real* zi_grid, Real* shoc_mix, 
-          Real* thl_sec, Real* qw_sec, Real* wthl_sec, Real* wqw_sec, Real* qwthl_sec, Real* uw_sec, Real* vw_sec, 
+
+void diag_second_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, Real* u_wind, Real* v_wind,
+          Real* tke, Real* isotropy, Real* tkh, Real* tk, Real* dz_zi, Real* zt_grid, Real* zi_grid, Real* shoc_mix,
+          Real* thl_sec, Real* qw_sec, Real* wthl_sec, Real* wqw_sec, Real* qwthl_sec, Real* uw_sec, Real* vw_sec,
           Real* wtke_sec, Real* w_sec)
 {
   using SHOC       = Functions<Real, DefaultDevice>;
@@ -1447,11 +1447,11 @@ void diag_second_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* q
 
   Kokkos::Array<size_t, 20> dim1_array = {shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol,
                             shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol};
-  Kokkos::Array<size_t, 20> dim2_array = {nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev, nlev, 
+  Kokkos::Array<size_t, 20> dim2_array = {nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev, nlev,
                             nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi};
 
   Kokkos::Array<view_2d, 20> temp_2d;
-  Kokkos::Array<const Real*, 20> ptr_array = {thetal, qw, u_wind, v_wind, tke, isotropy, tkh, tk, zt_grid, shoc_mix, 
+  Kokkos::Array<const Real*, 20> ptr_array = {thetal, qw, u_wind, v_wind, tke, isotropy, tkh, tk, zt_grid, shoc_mix,
                       thl_sec, qw_sec, wthl_sec, wqw_sec, qwthl_sec, uw_sec, vw_sec, wtke_sec, dz_zi, zi_grid};
 
   ekat::host_to_device(ptr_array, dim1_array, dim2_array, temp_2d, true);
@@ -1513,12 +1513,12 @@ void diag_second_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* q
     const auto tkh_zi_1d      = ekat::subview(tkh_zi_2d, i);
     const auto tk_zi_1d       = ekat::subview(tk_zi_2d, i);
 
-    SHOC::diag_second_moments(team, nlev, nlevi, thetal_1d, qw_1d, u_wind_1d, v_wind_1d, tke_1d, isotropy_1d, tkh_1d, tk_1d, 
+    SHOC::diag_second_moments(team, nlev, nlevi, thetal_1d, qw_1d, u_wind_1d, v_wind_1d, tke_1d, isotropy_1d, tkh_1d, tk_1d,
                      dz_zi_1d, zt_grid_1d, zi_grid_1d, shoc_mix_1d, isotropy_zi_1d, tkh_zi_1d, tk_zi_1d,
                      thl_sec_1d, qw_sec_1d, wthl_sec_1d, wqw_sec_1d,
                      qwthl_sec_1d, uw_sec_1d, vw_sec_1d, wtke_sec_1d, w_sec_1d);
 
-    
+
   });
 
   Kokkos::Array<size_t, 9> dim1 = {shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol};
@@ -2314,6 +2314,59 @@ void compute_tmpi_f(Int nlevi, Int shcol, Real dtime, Real *rho_zi, Real *dz_zi,
 void integ_column_stability_f(Int nlev, Int shcol, Real *dz_zt,
                               Real *pres, Real* brunt, Real *brunt_int)
 {
+  using SHF = Functions<Real, DefaultDevice>;
+
+  using Scalar     = typename SHF::Scalar;
+  using Pack1      = typename ekat::Pack<Real, 1>;
+  using view_1d    = typename SHF::view_1d<Pack1>;
+  using Spack      = typename SHF::Spack;
+  using view_2d    = typename SHF::view_2d<Spack>;
+  using KT         = typename SHF::KT;
+  using ExeSpace   = typename KT::ExeSpace;
+  using MemberType = typename SHF::MemberType;
+
+  static constexpr Int num_arrays = 3;
+
+  Kokkos::Array<view_2d, num_arrays> temp_d;
+  Kokkos::Array<int, num_arrays> dim1_sizes = {shcol, shcol, shcol};
+  Kokkos::Array<int, num_arrays> dim2_sizes = {nlev,  nlev,  nlev};
+  Kokkos::Array<const Real*, num_arrays> ptr_array = {dz_zt, pres, brunt};
+
+  // Sync to device
+  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+
+  // Inputs
+  view_2d
+    dz_zt_d(temp_d[0]),
+    pres_d (temp_d[1]),
+    brunt_d(temp_d[2]);
+
+  //Output
+  view_1d brunt_int_d("brunt_int", shcol);
+
+  const Int nk_pack = ekat::npack<Spack>(nlev);
+  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+      const Int i = team.league_rank();
+
+      // create subviews of the views
+      const auto dz_zt_s = ekat::subview(dz_zt_d, i);
+      const auto pres_s  = ekat::subview(pres_d, i);
+      const auto brunt_s = ekat::subview(brunt_d, i);
+
+      //declare output as a scalar
+      Scalar brunt_int_s{0};
+
+      //SHF::integ_column_stability(team, nlev, dz_zt_s, pres_s, brunt_s, brunt_int_s);
+
+      brunt_int_d(i)[0] = brunt_int_s;
+
+    });
+
+  // Sync back to host
+  Kokkos::Array<view_1d, 1> inout_views = {brunt_int_d};
+  ekat::device_to_host<int,1>({brunt_int},shcol,inout_views);
 }
 
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -2311,6 +2311,12 @@ void compute_tmpi_f(Int nlevi, Int shcol, Real dtime, Real *rho_zi, Real *dz_zi,
   ekat::device_to_host<int, 1>({tmpi}, {shcol}, {nlevi}, out_views, true);
 }
 
+void integ_column_stability_f(Int nlev, Int shcol, Real *dz_zt,
+                              Real *pres, Real* brunt, Real *brunt_int)
+{
+}
+
+
 void dp_inverse_f(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_zt)
 {
   using SHF = Functions<Real, DefaultDevice>;

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -1001,6 +1001,8 @@ void shoc_assumed_pdf_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, 
                         Real* qwthl_sec, Real* w3, Real* pres, Real* zt_grid, Real* zi_grid,
                         Real* shoc_cldfrac, Real* shoc_ql, Real* wqls, Real* wthv_sec, Real* shoc_ql2);
 void compute_tmpi_f(Int nlevi, Int shcol, Real dtime, Real *rho_zi, Real *dz_zi, Real *tmpi);
+void integ_column_stability_f(Int nlev, Int shcol, Real *dz_zt,
+                              Real *pres, Real *brunt, Real *brunt_int);
 void dp_inverse_f(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_zt);
 
 void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* host_dx, Real* host_dy, Real* thv, Real* zt_grid, Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner, Real* phis, Real* host_dse, Real* tke, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk, Real* shoc_ql, Real* shoc_cldfrac, Real* pblh, Real* shoc_mix, Real* isotropy, Real* w_sec, Real* thl_sec, Real* qw_sec, Real* qwthl_sec, Real* wthl_sec, Real* wqw_sec, Real* wtke_sec, Real* uw_sec, Real* vw_sec, Real* w3, Real* wqls_sec, Real* brunt, Real* shoc_ql2);

--- a/components/scream/src/physics/shoc/shoc_integ_column_stability.cpp
+++ b/components/scream/src/physics/shoc/shoc_integ_column_stability.cpp
@@ -1,0 +1,14 @@
+#include "shoc_integ_column_stability_impl.hpp"
+
+namespace scream {
+namespace shoc {
+
+/*
+ * Explicit instantiation for using the default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace shoc
+} // namespace scream
+

--- a/components/scream/src/physics/shoc/shoc_integ_column_stability_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_integ_column_stability_impl.hpp
@@ -17,20 +17,23 @@ void Functions<S,D>
   const uview_1d<const Spack>& brunt,
   Scalar&                      brunt_int)
 {
+  //Lower troposphere pressure [Pa]
   static constexpr auto troppres = 80000;
 
   using ExeSpaceUtils = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
 
-  
+
   ExeSpaceUtils::view_reduction(team,0,nlev,
                                 [&] (const int k) -> Spack {
 
+    //calculate only when pressure is > troposphere pressure
     auto press_gt_troppress = (pres(k) > troppres);
 
-    Spack my_result(0);
-    my_result.set(press_gt_troppress, dz_zt(k) * brunt(k));
+    Spack return_val(0); //initialize return value for brunt_int
+    return_val.set(press_gt_troppress, dz_zt(k) * brunt(k));// compute brunt_int for each column
 
-    return my_result ;
+    return return_val ;
+
     }, brunt_int);
 
 }

--- a/components/scream/src/physics/shoc/shoc_integ_column_stability_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_integ_column_stability_impl.hpp
@@ -1,0 +1,41 @@
+#ifndef SHOC_INTEG_COLUMN_STABILITY_IMPL_HPP
+#define SHOC_INTEG_COLUMN_STABILITY_IMPL_HPP
+
+#include "shoc_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace shoc {
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>
+::integ_column_stability(
+  const MemberType&            team,
+  const Int&                   nlev,
+  const uview_1d<const Spack>& dz_zt,
+  const uview_1d<const Spack>& pres,
+  const uview_1d<const Spack>& brunt,
+  Scalar&                      brunt_int)
+{
+  static constexpr auto troppres = 80000;
+
+  using ExeSpaceUtils = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+
+  // Compute se_int
+  ExeSpaceUtils::view_reduction(team,0,nlev,
+                                [&] (const int k) -> Spack {
+
+    auto press_gt_troppress = (pres(k) > troppres);
+
+    Spack my_result(0);
+    my_result.set(press_gt_troppress, dz_zt(k) * brunt(k));
+
+    return my_result ;
+  }, brunt_int);
+
+}
+
+} // namespace shoc
+} // namespace scream
+
+#endif

--- a/components/scream/src/physics/shoc/shoc_integ_column_stability_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_integ_column_stability_impl.hpp
@@ -21,7 +21,7 @@ void Functions<S,D>
 
   using ExeSpaceUtils = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
 
-  // Compute se_int
+  
   ExeSpaceUtils::view_reduction(team,0,nlev,
                                 [&] (const int k) -> Spack {
 
@@ -31,7 +31,7 @@ void Functions<S,D>
     my_result.set(press_gt_troppress, dz_zt(k) * brunt(k));
 
     return my_result ;
-  }, brunt_int);
+    }, brunt_int);
 
 }
 

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -394,7 +394,8 @@ end subroutine compute_tmpi_f
 subroutine integ_column_stability_f(nlev, shcol, dz_zt, pres, brunt, brunt_int) bind(C)
   use iso_c_binding
 
-  integer(kind=c_int), intent(in) :: nlev, shcol
+  integer(kind=c_int), intent(in), value :: nlev
+  integer(kind=c_int), intent(in), value :: shcol
   real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
   real(kind=c_real), intent(in) :: pres(shcol,nlev)
   real(kind=c_real), intent(in) :: brunt(shcol,nlev)

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -189,7 +189,7 @@ subroutine shoc_energy_integrals_f(shcol, nlev, host_dse, pdel,&
 
 end subroutine shoc_energy_integrals_f
 
-subroutine diag_second_moments_lbycond_f(shcol, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, ustar2, wstar, & 
+subroutine diag_second_moments_lbycond_f(shcol, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, ustar2, wstar, &
   wthl_sec, wqw_sec, uw_sec, vw_sec, wtke_sec, thl_sec, qw_sec, qwthl_sec) bind(C)
   use iso_c_binding
 
@@ -198,7 +198,7 @@ subroutine diag_second_moments_lbycond_f(shcol, wthl_sfc, wqw_sfc, uw_sfc, vw_sf
   real(kind=c_real) , intent(out), dimension(shcol) :: wthl_sec, wqw_sec, uw_sec, vw_sec, wtke_sec, thl_sec, qw_sec, qwthl_sec
 end subroutine diag_second_moments_lbycond_f
 
-subroutine diag_second_moments_f(shcol, nlev, nlevi, thetal, qw, u_wind, v_wind, tke, isotropy, tkh, tk, dz_zi, zt_grid, zi_grid, & 
+subroutine diag_second_moments_f(shcol, nlev, nlevi, thetal, qw, u_wind, v_wind, tke, isotropy, tkh, tk, dz_zi, zt_grid, zi_grid, &
                                  shoc_mix, thl_sec, qw_sec, wthl_sec, wqw_sec, qwthl_sec, uw_sec, vw_sec, wtke_sec, w_sec) bind(C)
   use iso_c_binding
 
@@ -390,6 +390,17 @@ subroutine compute_tmpi_f(nlevi, shcol, dtime, rho_zi, dz_zi, tmpi) bind(C)
 
   real(kind=c_real), intent(out) :: tmpi(shcol,nlevi)
 end subroutine compute_tmpi_f
+
+subroutine integ_column_stability_f(nlev, shcol, dz_zt, pres, brunt, brunt_int) bind(C)
+  use iso_c_binding
+
+  integer(kind=c_int), intent(in) :: nlev, shcol
+  real(kind=c_real), intent(in) :: dz_zt(shcol,nlev)
+  real(kind=c_real), intent(in) :: pres(shcol,nlev)
+  real(kind=c_real), intent(in) :: brunt(shcol,nlev)
+  real(kind=c_real), intent(out) :: brunt_int(shcol)
+
+end subroutine integ_column_stability_f
 
 subroutine dp_inverse_f(nlev, shcol, rho_zt, dz_zt, rdp_zt) bind(C)
   use iso_c_binding

--- a/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
@@ -94,11 +94,11 @@ static Int compare (const std::string& label, const Scalar* a,
 struct Baseline {
 
   // Number of iterations (nadv steps of size dtime per iteration).
-  const int num_iters = 10;
+  const int num_iters = 1;
 
   Baseline () {
     //                 ic, shcol, nlev, num_qtracers, nadv, dtime
-    params_.push_back({ic::Factory::standard, 8, 72, 3, 15, 150});
+    params_.push_back({ic::Factory::standard, 1, 3, 1, 1, 1});
   }
 
   Int generate_baseline (const std::string& filename, bool use_fortran) {

--- a/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
@@ -94,11 +94,11 @@ static Int compare (const std::string& label, const Scalar* a,
 struct Baseline {
 
   // Number of iterations (nadv steps of size dtime per iteration).
-  const int num_iters = 1;
+  const int num_iters = 10;
 
   Baseline () {
     //                 ic, shcol, nlev, num_qtracers, nadv, dtime
-    params_.push_back({ic::Factory::standard, 1, 3, 1, 1, 1});
+    params_.push_back({ic::Factory::standard, 8, 72, 3, 15, 150});
   }
 
   Int generate_baseline (const std::string& filename, bool use_fortran) {


### PR DESCRIPTION
Property test for "integ_column_stabilibity" has already been implemented therefore this PR implements just the fortran->C++ bridge. BFB unit test has also been added to this PR.