### PR TITLE
dyamond2 specific: Fix bug where code looks for clm2.r file rather than elm.r for branch runs

### DIFF
--- a/components/elm/cime_config/buildnml
+++ b/components/elm/cime_config/buildnml
@@ -142,9 +142,9 @@ def buildnml(case, caseroot, compname):
         elmicfile = ""
         elm_startfile = ""
         if run_type == "hybrid" or run_type == "branch":
-            elm_startfile = "{}.clm2{}.r.{}-{}.nc".format(run_refcase, inst_string, run_refdate, run_reftod)
+            elm_startfile = "{}.elm{}.r.{}-{}.nc".format(run_refcase, inst_string, run_refdate, run_reftod)
             if not os.path.exists(os.path.join(rundir, elm_startfile)):
-                elm_startfile = "{}.clm2.r.{}-{}.nc".format(run_refcase, run_refdate, run_reftod)
+                elm_startfile = "{}.elm.r.{}-{}.nc".format(run_refcase, run_refdate, run_reftod)
 
             elmicfile = " {} = '{}'".format(startfiletype, elm_startfile)
 


### PR DESCRIPTION
dyamond2 specific: Currently, branch runs will look for clm2.r files for branch or hybrid runs. This quick bug fix makes it so that it looks for elm.r files. 
The issue has been identified in e3sm (https://github.com/E3SM-Project/E3SM/issues/3905), so better for master to wait for an upstream merge. 