### PR TITLE
Change Ck tunings to a stronger tuning for stable BL conditions

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -3166,10 +3166,10 @@ subroutine eddy_diffusivities(nlev, shcol, obklen, pblh, zt_grid, &
   real(rtype), parameter :: Ckh = 0.1_rtype
   real(rtype), parameter :: Ckm = 0.1_rtype
   ! Default eddy coefficients for stable PBL diffusivities
-  real(rtype), parameter :: Ckh_s_def = 1e-2_rtype
-  real(rtype), parameter :: Ckm_s_def = 1e-2_rtype
+  real(rtype), parameter :: Ckh_s_def = 0.1_rtype
+  real(rtype), parameter :: Ckm_s_def = 0.1_rtype
   ! Minimum allowable value for stability diffusivities
-  real(rtype), parameter :: Ck_s_min = 1e-2_rtype
+  real(rtype), parameter :: Ck_s_min = 0.1_rtype
 
   !store zt_grid at nlev in 1d array
   zt_grid_1d(1:shcol) = zt_grid(1:shcol,nlev)


### PR DESCRIPTION
For our dyamond2 tunings, we had moved to a lightly tuned Ck tuning to improve the warmer temperature bias over the NH continents. However, this potentially made the model susceptible to cold temperature episodes at the surface. 
This tuning changes the Ck parameters (“Ckh_s_def”, “Ckm_s_def”, and “Ck_s_min” ) to 0.1 from 1e-2. Running with this changed allowed us to continue running even after getting into a cold episode situation. 
```/global/cscratch1/sd/terai/e3sm_scratch/cori-knl/20201123.SCREAMv0dyamond2_ck_0pt1.F2010-SCREAM-HR-DYAMOND2.ne1024pg2_r0125_oRRS18to6v3.cori-knl.1536x8x16/run```