### PR TITLE
Port update_prognostics_implicit

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -643,6 +643,10 @@ subroutine update_prognostics_implicit( &
          thetal,qw,tracer,tke,&           ! Input/Output
          u_wind,v_wind)                   ! Input/Output
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  use shoc_iso_f, only: update_prognostics_implicit_f
+#endif
+
   implicit none
 
 ! INPUT VARIABLES
@@ -710,6 +714,20 @@ subroutine update_prognostics_implicit( &
   real(rtype) :: du(shcol,nlev) ! Superdiagonal for solver
   real(rtype) :: dl(shcol,nlev) ! Factorized subdiagonal for solver
   real(rtype) :: d(shcol,nlev)  ! Factorized diagonal for solver
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  if (use_cxx) then
+    call update_prognostics_implicit_f(&
+           shcol,nlev,nlevi,num_tracer,&    ! Input
+           dtime,dz_zt,dz_zi,rho_zt,&       ! Input
+           zt_grid,zi_grid,tk,tkh,&         ! Input
+           uw_sfc,vw_sfc,wthl_sfc,wqw_sfc,& ! Input
+           wtracer_sfc,&                    ! Input
+           thetal,qw,tracer,tke,&           ! Input/Output
+           u_wind,v_wind)                   ! Input/Output
+     return
+  endif
+#endif
 
   ! linearly interpolate tkh, tk, and air density onto the interface grids
   call linear_interp(zt_grid,zi_grid,tkh,tkh_zi,nlev,nlevi,shcol,0._rtype)

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -331,7 +331,40 @@ struct Functions
     const uview_1d<Spack>&       qv);
 
   KOKKOS_FUNCTION
-  static void update_prognostics_implicit(const Int& shcol, const Int& nlev, const Int& nlevi, const Int& num_tracer, const Spack& dtime, const uview_1d<const Spack>& dz_zt, const uview_1d<const Spack>& dz_zi, const uview_1d<const Spack>& rho_zt, const uview_1d<const Spack>& zt_grid, const uview_1d<const Spack>& zi_grid, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& uw_sfc, const uview_1d<const Spack>& vw_sfc, const uview_1d<const Spack>& wthl_sfc, const uview_1d<const Spack>& wqw_sfc, const uview_1d<const Spack>& wtracer_sfc, const uview_1d<Spack>& thetal, const uview_1d<Spack>& qw, const uview_1d<Spack>& tracer, const uview_1d<Spack>& tke, const uview_1d<Spack>& u_wind, const uview_1d<Spack>& v_wind);
+  static void update_prognostics_implicit(
+    const MemberType&            team,
+    const Int&                   nlev,
+    const Int&                   nlevi,
+    const Int&                   num_tracer,
+    const Scalar&                dtime,
+    const uview_1d<const Spack>& dz_zt,
+    const uview_1d<const Spack>& dz_zi,
+    const uview_1d<const Spack>& rho_zt,
+    const uview_1d<const Spack>& zt_grid,
+    const uview_1d<const Spack>& zi_grid,
+    const uview_1d<const Spack>& tk,
+    const uview_1d<const Spack>& tkh,
+    const Scalar&                uw_sfc,
+    const Scalar&                vw_sfc,
+    const Scalar&                wthl_sfc,
+    const Scalar&                wqw_sfc,
+    const uview_1d<const Spack>& wtracer_sfc,
+    const uview_1d<Spack>&       rdp_zt,
+    const uview_1d<Spack>&       tmpi,
+    const uview_1d<Spack>&       tkh_zi,
+    const uview_1d<Spack>&       tk_zi,
+    const uview_1d<Spack>&       rho_zi,
+    const uview_1d<Scalar>&       du,
+    const uview_1d<Scalar>&       dl,
+    const uview_1d<Scalar>&       d,
+    const uview_2d<Spack>&       X1,
+    const uview_2d<Spack>&       X2,
+    const uview_1d<Spack>&       thetal,
+    const uview_1d<Spack>&       qw,
+    const uview_2d<Spack>&       tracer,
+    const uview_1d<Spack>&       tke,
+    const uview_1d<Spack>&       u_wind,
+    const uview_1d<Spack>&       v_wind);
 
   KOKKOS_FUNCTION
   static void diag_third_shoc_moments(

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -358,7 +358,6 @@ struct Functions
     const uview_1d<Scalar>&       dl,
     const uview_1d<Scalar>&       d,
     const uview_2d<Spack>&       X1,
-    const uview_2d<Spack>&       X2,
     const uview_1d<Spack>&       thetal,
     const uview_1d<Spack>&       qw,
     const uview_2d<Spack>&       tracer,

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -259,7 +259,11 @@ void shoc_pblintd_cldcheck_c(Int shcol, Int nlev, Int nlevi, Real* zi, Real* cld
 
 void compute_shoc_vapor_c(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv);
 
-void update_prognostics_implicit_c(Int shcol, Int nlev, Int nlevi, Int num_tracer, Real dtime, Real* dz_zt, Real* dz_zi, Real* rho_zt, Real* zt_grid, Real* zi_grid, Real* tk, Real* tkh, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, Real* wqw_sfc, Real* wtracer_sfc, Real* thetal, Real* qw, Real* tracer, Real* tke, Real* u_wind, Real* v_wind);
+void update_prognostics_implicit_c(Int shcol, Int nlev, Int nlevi, Int num_tracer, Real dtime,
+                                   Real* dz_zt, Real* dz_zi, Real* rho_zt, Real* zt_grid, Real* zi_grid,
+                                   Real* tk, Real* tkh, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc,
+                                   Real* wqw_sfc, Real* wtracer_sfc, Real* thetal, Real* qw, Real* tracer,
+                                   Real* tke, Real* u_wind, Real* v_wind);
 
 void shoc_main_c(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* host_dx, Real* host_dy, Real* thv, Real* zt_grid, Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner, Real* phis, Real* host_dse, Real* tke, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk, Real* shoc_ql, Real* shoc_cldfrac, Real* pblh, Real* shoc_mix, Real* isotropy, Real* w_sec, Real* thl_sec, Real* qw_sec, Real* qwthl_sec, Real* wthl_sec, Real* wqw_sec, Real* wtke_sec, Real* uw_sec, Real* vw_sec, Real* w3, Real* wqls_sec, Real* brunt, Real* shoc_ql2);
 
@@ -726,7 +730,10 @@ void update_prognostics_implicit(UpdatePrognosticsImplicitData& d)
 {
   shoc_init(d.nlev, true);
   d.transpose<ekat::TransposeDirection::c2f>();
-  update_prognostics_implicit_c(d.shcol, d.nlev, d.nlevi, d.num_tracer, d.dtime, d.dz_zt, d.dz_zi, d.rho_zt, d.zt_grid, d.zi_grid, d.tk, d.tkh, d.uw_sfc, d.vw_sfc, d.wthl_sfc, d.wqw_sfc, d.wtracer_sfc, d.thetal, d.qw, d.tracer, d.tke, d.u_wind, d.v_wind);
+  update_prognostics_implicit_c(d.shcol, d.nlev, d.nlevi, d.num_tracer, d.dtime,
+                                d.dz_zt, d.dz_zi, d.rho_zt, d.zt_grid, d.zi_grid,
+                                d.tk, d.tkh, d.uw_sfc, d.vw_sfc, d.wthl_sfc, d.wqw_sfc,
+                                d.wtracer_sfc, d.thetal, d.qw, d.tracer, d.tke, d.u_wind, d.v_wind);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 
@@ -2190,9 +2197,139 @@ void compute_shoc_vapor_f(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv)
   ekat::device_to_host<int, 1>({qv}, {shcol}, {nlev}, out_views, true);
 }
 
-void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_tracer, Real dtime, Real* dz_zt, Real* dz_zi, Real* rho_zt, Real* zt_grid, Real* zi_grid, Real* tk, Real* tkh, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, Real* wqw_sfc, Real* wtracer_sfc, Real* thetal, Real* qw, Real* tracer, Real* tke, Real* u_wind, Real* v_wind)
+void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_tracer, Real dtime,
+                                   Real* dz_zt, Real* dz_zi, Real* rho_zt, Real* zt_grid, Real* zi_grid,
+                                   Real* tk, Real* tkh, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc,
+                                   Real* wqw_sfc, Real* wtracer_sfc, Real* thetal, Real* qw, Real* tracer,
+                                   Real* tke, Real* u_wind, Real* v_wind)
 {
-  // TODO
+  using SHF = Functions<Real, DefaultDevice>;
+
+  using Scalar     = typename SHF::Scalar;
+  using Spack      = typename SHF::Spack;
+  using Pack1d     = typename ekat::Pack<Real,1>;
+  using view_1d    = typename SHF::view_1d<Pack1d>;
+  using view_2d    = typename SHF::view_2d<Spack>;
+  using view_2d_scalar = typename SHF::view_2d<Scalar>;
+  using view_3d    = typename SHF::view_3d<Spack>;
+  using KT         = typename SHF::KT;
+  using ExeSpace   = typename KT::ExeSpace;
+  using MemberType = typename SHF::MemberType;
+
+  static constexpr Int num_2d_arrays = 13;
+
+  Kokkos::Array<view_1d, 4> temp_1d_d;
+  Kokkos::Array<view_2d, num_2d_arrays> temp_2d_d;
+  Kokkos::Array<view_3d, 1> temp_3d_d;
+
+  Kokkos::Array<int, num_2d_arrays> dim1_sizes = {shcol, shcol, shcol, shcol, shcol,
+                                                  shcol, shcol, shcol, shcol, shcol,
+                                                  shcol, shcol, shcol};
+  Kokkos::Array<int, num_2d_arrays> dim2_sizes = {nlev, nlevi, nlev,       nlev, nlevi,
+                                                  nlev, nlev,  num_tracer, nlev, nlev,
+                                                  nlev, nlev,  nlev};
+  Kokkos::Array<const Real*, num_2d_arrays> ptr_array = {dz_zt, dz_zi,  rho_zt,       zt_grid, zi_grid,
+                                                         tk,    tkh,    wtracer_sfc,  thetal,  qw,
+                                                         tke,   u_wind, v_wind};
+
+  // Sync to device
+  ekat::host_to_device({uw_sfc, vw_sfc, wthl_sfc, wqw_sfc}, shcol, temp_1d_d);
+  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d_d, true);
+  ekat::host_to_device({tracer}, shcol, nlev, num_tracer, temp_3d_d, true);
+
+  view_1d
+    uw_sfc_d(temp_1d_d[0]),
+    vw_sfc_d(temp_1d_d[1]),
+    wthl_sfc_d(temp_1d_d[2]),
+    wqw_sfc_d(temp_1d_d[3]);
+
+  view_2d
+    dz_zt_d(temp_2d_d[0]),
+    dz_zi_d(temp_2d_d[1]),
+    rho_zt_d(temp_2d_d[2]),
+    zt_grid_d(temp_2d_d[3]),
+    zi_grid_d(temp_2d_d[4]),
+    tk_d(temp_2d_d[5]),
+    tkh_d(temp_2d_d[6]),
+    wtracer_sfc_d(temp_2d_d[7]),
+    thetal_d(temp_2d_d[8]),
+    qw_d(temp_2d_d[9]),
+    tke_d(temp_2d_d[10]),
+    u_wind_d(temp_2d_d[11]),
+    v_wind_d(temp_2d_d[12]);
+
+  view_3d
+    tracer_d(temp_3d_d[0]);
+
+  // Local variables
+  const Int nlev_packs = ekat::npack<Spack>(nlev);
+  const Int nlevi_packs = ekat::npack<Spack>(nlevi);
+  view_2d
+    rdp_zt_d("rdp_zt", shcol, nlev_packs),
+    tmpi_d("tmpi", shcol, nlevi_packs),
+    tkh_zi_d("tkh_zi", shcol, nlevi_packs),
+    tk_zi_d("tk_zi", shcol, nlevi_packs),
+    rho_zi_d("rho_zi", shcol, nlevi_packs);
+
+  view_2d_scalar
+    du_d("du", shcol, nlev),
+    dl_d("dl", shcol, nlev),
+    d_d("d", shcol, nlev);
+
+  view_3d
+    X1_d("X1",shcol,nlev,ekat::npack<Spack>(2)),
+    X2_d("X2",shcol,nlev,ekat::npack<Spack>(3+num_tracer));
+
+
+  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+    const Int i = team.league_rank();
+
+    const Scalar uw_sfc_s{uw_sfc_d(i)[0]};
+    const Scalar vw_sfc_s{vw_sfc_d(i)[0]};
+    const Scalar wthl_sfc_s{wthl_sfc_d(i)[0]};
+    const Scalar wqw_sfc_s{wqw_sfc_d(i)[0]};
+
+    const auto dz_zt_s = ekat::subview(dz_zt_d, i);
+    const auto dz_zi_s = ekat::subview(dz_zi_d, i);
+    const auto rho_zt_s = ekat::subview(rho_zt_d, i);
+    const auto zt_grid_s = ekat::subview(zt_grid_d, i);
+    const auto zi_grid_s = ekat::subview(zi_grid_d, i);
+    const auto tk_s = ekat::subview(tk_d, i);
+    const auto tkh_s = ekat::subview(tkh_d, i);
+    const auto wtracer_sfc_s = ekat::subview(wtracer_sfc_d, i);
+    const auto rdp_zt_s = ekat::subview(rdp_zt_d, i);
+    const auto tmpi_s = ekat::subview(tmpi_d, i);
+    const auto tkh_zi_s = ekat::subview(tkh_zi_d, i);
+    const auto tk_zi_s = ekat::subview(tk_zi_d, i);
+    const auto rho_zi_s = ekat::subview(rho_zi_d, i);
+    const auto du_s = ekat::subview(du_d, i);
+    const auto dl_s = ekat::subview(dl_d, i);
+    const auto d_s = ekat::subview(d_d, i);
+    const auto X1_s = Kokkos::subview(X1_d, i, Kokkos::ALL(), Kokkos::ALL());
+    const auto X2_s = Kokkos::subview(X2_d, i, Kokkos::ALL(), Kokkos::ALL());
+    const auto thetal_s = ekat::subview(thetal_d, i);
+    const auto qw_s = ekat::subview(qw_d, i);
+    const auto u_wind_s = ekat::subview(u_wind_d, i);
+    const auto v_wind_s = ekat::subview(v_wind_d, i);
+    const auto tke_s = ekat::subview(tke_d, i);
+    const auto tracer_s = Kokkos::subview(tracer_d, i, Kokkos::ALL(), Kokkos::ALL());
+
+    SHF::update_prognostics_implicit(team, nlev, nlevi, num_tracer, dtime,
+                                     dz_zt_s, dz_zi_s, rho_zt_s, zt_grid_s,
+                                     zi_grid_s, tk_s, tkh_s, uw_sfc_s, vw_sfc_s,
+                                     wthl_sfc_s, wqw_sfc_s, wtracer_sfc_s,
+                                     rdp_zt_s, tmpi_s, tkh_zi_s, tk_zi_s, rho_zi_s,
+                                     du_s, dl_s, d_s, X1_s, X2_s,
+                                     thetal_s, qw_s, tracer_s, tke_s, u_wind_s, v_wind_s);
+  });
+
+  // Sync back to host
+  Kokkos::Array<view_2d, 5> inout_views_2d = {thetal_d, qw_d, u_wind_d, v_wind_d, tke_d};
+  ekat::device_to_host<int,5>({thetal, qw, u_wind, v_wind, tke}, {shcol}, {nlev}, inout_views_2d, true);
+
+  Kokkos::Array<view_3d, 1> inout_views_3d = {tracer_d};
+  ekat::device_to_host<int,1>({tracer}, shcol, nlev, num_tracer, inout_views_3d, true);
 }
 
 void diag_third_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* w_sec, Real* thl_sec,

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -2260,6 +2260,8 @@ void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_trace
 
   view_3d
     tracer_d(temp_3d_d[0]);
+  Kokkos::resize(Kokkos::WithoutInitializing, tracer_d,
+                 shcol,nlev,ekat::npack<Spack>(num_tracer+3));
 
   // Local variables
   const Int nlev_packs = ekat::npack<Spack>(nlev);
@@ -2277,9 +2279,7 @@ void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_trace
     d_d("d", shcol, nlev);
 
   view_3d
-    X1_d("X1",shcol,nlev,ekat::npack<Spack>(2)),
-    X2_d("X2",shcol,nlev,ekat::npack<Spack>(3+num_tracer));
-
+    X1_d("X1",shcol,nlev,ekat::npack<Spack>(2));
 
   const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
@@ -2307,7 +2307,6 @@ void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_trace
     const auto dl_s = ekat::subview(dl_d, i);
     const auto d_s = ekat::subview(d_d, i);
     const auto X1_s = Kokkos::subview(X1_d, i, Kokkos::ALL(), Kokkos::ALL());
-    const auto X2_s = Kokkos::subview(X2_d, i, Kokkos::ALL(), Kokkos::ALL());
     const auto thetal_s = ekat::subview(thetal_d, i);
     const auto qw_s = ekat::subview(qw_d, i);
     const auto u_wind_s = ekat::subview(u_wind_d, i);
@@ -2320,7 +2319,7 @@ void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_trace
                                      zi_grid_s, tk_s, tkh_s, uw_sfc_s, vw_sfc_s,
                                      wthl_sfc_s, wqw_sfc_s, wtracer_sfc_s,
                                      rdp_zt_s, tmpi_s, tkh_zi_s, tk_zi_s, rho_zi_s,
-                                     du_s, dl_s, d_s, X1_s, X2_s,
+                                     du_s, dl_s, d_s, X1_s,
                                      thetal_s, qw_s, tracer_s, tke_s, u_wind_s, v_wind_s);
   });
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -963,7 +963,11 @@ void shoc_energy_fixer_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, R
                          Real* wqw_sfc, Real* rho_zt, Real* tke, Real* pint,
                          Real* host_dse);
 void compute_shoc_vapor_f(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv);
-void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_tracer, Real dtime, Real* dz_zt, Real* dz_zi, Real* rho_zt, Real* zt_grid, Real* zi_grid, Real* tk, Real* tkh, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, Real* wqw_sfc, Real* wtracer_sfc, Real* thetal, Real* qw, Real* tracer, Real* tke, Real* u_wind, Real* v_wind);
+void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_tracer, Real dtime,
+                                   Real* dz_zt, Real* dz_zi, Real* rho_zt, Real* zt_grid,
+                                   Real* zi_grid, Real* tk, Real* tkh, Real* uw_sfc, Real* vw_sfc,
+                                   Real* wthl_sfc, Real* wqw_sfc, Real* wtracer_sfc, Real* thetal,
+                                   Real* qw, Real* tracer, Real* tke, Real* u_wind, Real* v_wind);
 void diag_third_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* w_sec, Real* thl_sec,
                                Real* wthl_sec, Real* isotropy, Real* brunt, Real* thetal,
                                Real* tke, Real* dz_zt, Real* dz_zi, Real* zt_grid, Real* zi_grid,

--- a/components/scream/src/physics/shoc/shoc_update_prognostics_implicit.cpp
+++ b/components/scream/src/physics/shoc/shoc_update_prognostics_implicit.cpp
@@ -4,8 +4,7 @@ namespace scream {
 namespace shoc {
 
 /*
- * Explicit instantiation for doing update_prognostics_implicit on Reals using the
- * default device.
+ * Explicit instantiation for using the default device.
  */
 
 template struct Functions<Real,DefaultDevice>;

--- a/components/scream/src/physics/shoc/shoc_update_prognostics_implicit_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_update_prognostics_implicit_impl.hpp
@@ -70,25 +70,25 @@ void Functions<S,D>::update_prognostics_implicit(
   // and tke flux calc (wtke_sfc)
   Scalar ksrf, wtke_sfc;
   {
-    const auto wsmin = 1;
-    const auto ksrfmin = 1e-4;
-    const auto ustarmin = 0.01;
+    const Scalar wsmin = 1;
+    const Scalar ksrfmin = 1e-4;
+    const Scalar ustarmin = 0.01;
 
-    const auto rho = rho_zi(last_nlevi_pack)[last_nlevi_indx];
-    const auto uw = uw_sfc;
-    const auto vw = vw_sfc;
+    const Scalar rho = rho_zi(last_nlevi_pack)[last_nlevi_indx];
+    const Scalar uw = uw_sfc;
+    const Scalar vw = vw_sfc;
 
-    const auto taux = rho*uw;
-    const auto tauy = rho*vw;
+    const Scalar taux = rho*uw;
+    const Scalar tauy = rho*vw;
 
-    const auto u_wind_sfc = u_wind(last_nlev_pack)[last_nlev_indx];
-    const auto v_wind_sfc = v_wind(last_nlev_pack)[last_nlev_indx];
+    const Scalar u_wind_sfc = u_wind(last_nlev_pack)[last_nlev_indx];
+    const Scalar v_wind_sfc = v_wind(last_nlev_pack)[last_nlev_indx];
 
-    const auto ws = ekat::impl::max(std::sqrt((u_wind_sfc*u_wind_sfc) + v_wind_sfc*v_wind_sfc), sp(wsmin));
-    const auto tau = std::sqrt(taux*taux + tauy*tauy);
-    ksrf = ekat::impl::max(tau/ws, sp(ksrfmin));
+    const Scalar ws = ekat::impl::max(std::sqrt((u_wind_sfc*u_wind_sfc) + v_wind_sfc*v_wind_sfc), wsmin);
+    const Scalar tau = std::sqrt(taux*taux + tauy*tauy);
+    ksrf = ekat::impl::max(tau/ws, ksrfmin);
 
-    const auto ustar = ekat::impl::max(std::sqrt(std::sqrt(uw*uw + vw*vw)), sp(ustarmin));
+    const Scalar ustar = ekat::impl::max(std::sqrt(std::sqrt(uw*uw + vw*vw)), ustarmin);
     wtke_sfc = ustar*ustar*ustar;
   }
 

--- a/components/scream/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
@@ -335,8 +335,11 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit {
 
   static void run_bfb()
   {
-    UpdatePrognosticsImplicitData f90_data[] = {
-      // TODO
+    UpdatePrognosticsImplicitData f90_data[] = {      
+      UpdatePrognosticsImplicitData(10, 71, 72, 19, 5),
+      UpdatePrognosticsImplicitData(10, 12, 13, 7, 2.5),
+      UpdatePrognosticsImplicitData(7, 16, 17, 2, 1),
+      UpdatePrognosticsImplicitData(2, 7, 8, 1, 1)
     };
 
     static constexpr Int num_runs = sizeof(f90_data) / sizeof(UpdatePrognosticsImplicitData);
@@ -349,7 +352,10 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit {
     // Create copies of data for use by cxx. Needs to happen before fortran calls so that
     // inout data is in original state
     UpdatePrognosticsImplicitData cxx_data[] = {
-      // TODO
+      UpdatePrognosticsImplicitData(f90_data[0]),
+      UpdatePrognosticsImplicitData(f90_data[1]),
+      UpdatePrognosticsImplicitData(f90_data[2]),
+      UpdatePrognosticsImplicitData(f90_data[3]),
     };
 
     // Assume all data is in C layout
@@ -363,7 +369,10 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit {
     // Get data from cxx
     for (auto& d : cxx_data) {
       d.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
-      update_prognostics_implicit_f(d.shcol, d.nlev, d.nlevi, d.num_tracer, d.dtime, d.dz_zt, d.dz_zi, d.rho_zt, d.zt_grid, d.zi_grid, d.tk, d.tkh, d.uw_sfc, d.vw_sfc, d.wthl_sfc, d.wqw_sfc, d.wtracer_sfc, d.thetal, d.qw, d.tracer, d.tke, d.u_wind, d.v_wind);
+      update_prognostics_implicit_f(d.shcol, d.nlev, d.nlevi, d.num_tracer, d.dtime,
+                                    d.dz_zt, d.dz_zi, d.rho_zt, d.zt_grid, d.zi_grid,
+                                    d.tk, d.tkh, d.uw_sfc, d.vw_sfc, d.wthl_sfc, d.wqw_sfc,
+                                    d.wtracer_sfc, d.thetal, d.qw, d.tracer, d.tke, d.u_wind, d.v_wind);
       d.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
     }
 
@@ -372,19 +381,14 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit {
       UpdatePrognosticsImplicitData& d_f90 = f90_data[i];
       UpdatePrognosticsImplicitData& d_cxx = cxx_data[i];
       for (Int k = 0; k < d_f90.total(d_f90.thetal); ++k) {
-        REQUIRE(d_f90.total(d_f90.thetal) == d_cxx.total(d_cxx.thetal));
         REQUIRE(d_f90.thetal[k] == d_cxx.thetal[k]);
-        REQUIRE(d_f90.total(d_f90.thetal) == d_cxx.total(d_cxx.qw));
         REQUIRE(d_f90.qw[k] == d_cxx.qw[k]);
-        REQUIRE(d_f90.total(d_f90.thetal) == d_cxx.total(d_cxx.tke));
         REQUIRE(d_f90.tke[k] == d_cxx.tke[k]);
-        REQUIRE(d_f90.total(d_f90.thetal) == d_cxx.total(d_cxx.u_wind));
         REQUIRE(d_f90.u_wind[k] == d_cxx.u_wind[k]);
-        REQUIRE(d_f90.total(d_f90.thetal) == d_cxx.total(d_cxx.v_wind));
         REQUIRE(d_f90.v_wind[k] == d_cxx.v_wind[k]);
       }
+
       for (Int k = 0; k < d_f90.total(d_f90.tracer); ++k) {
-        REQUIRE(d_f90.total(d_f90.tracer) == d_cxx.total(d_cxx.tracer));
         REQUIRE(d_f90.tracer[k] == d_cxx.tracer[k]);
       }
 

--- a/components/scream/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
@@ -380,6 +380,12 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit {
     for (Int i = 0; i < num_runs; ++i) {
       UpdatePrognosticsImplicitData& d_f90 = f90_data[i];
       UpdatePrognosticsImplicitData& d_cxx = cxx_data[i];
+
+      REQUIRE(d_f90.total(d_f90.thetal) == d_cxx.total(d_cxx.thetal));
+      REQUIRE(d_f90.total(d_f90.qw) == d_cxx.total(d_cxx.qw));
+      REQUIRE(d_f90.total(d_f90.tke) == d_cxx.total(d_cxx.tke));
+      REQUIRE(d_f90.total(d_f90.u_wind) == d_cxx.total(d_cxx.u_wind));
+      REQUIRE(d_f90.total(d_f90.v_wind) == d_cxx.total(d_cxx.v_wind));
       for (Int k = 0; k < d_f90.total(d_f90.thetal); ++k) {
         REQUIRE(d_f90.thetal[k] == d_cxx.thetal[k]);
         REQUIRE(d_f90.qw[k] == d_cxx.qw[k]);
@@ -388,6 +394,7 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit {
         REQUIRE(d_f90.v_wind[k] == d_cxx.v_wind[k]);
       }
 
+      REQUIRE(d_f90.total(d_f90.tracer) == d_cxx.total(d_cxx.tracer));
       for (Int k = 0; k < d_f90.total(d_f90.tracer); ++k) {
         REQUIRE(d_f90.tracer[k] == d_cxx.tracer[k]);
       }


### PR DESCRIPTION
Ports `update_prognostics_implicit` subroutine to C++. The `update_prognostics_implicit` subroutine is the one that calls the tridiag solver. 