### PR TITLE
FieldInitializer modifications

### DIFF
--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -33,7 +33,7 @@ public:
 
   std::set<std::string> get_required_grids () const {
     static std::set<std::string> s;
-    s.insert("SE Dynamics");
+    s.insert("Dynamics");
     return s;
   }
 

--- a/components/scream/src/dynamics/homme/homme_inputs_initializer.hpp
+++ b/components/scream/src/dynamics/homme/homme_inputs_initializer.hpp
@@ -2,13 +2,17 @@
 #define SCREAM_HOMME_INPUTS_INITIALIZER_HPP
 
 #include "share/field/field_initializer.hpp"
+#include "share/grid/remap/abstract_remapper.hpp"
 
 namespace scream {
 
 class HommeInputsInitializer : public FieldInitializer
 {
 public:
-  using field_type       = Field<      Real>;
+  using field_type = Field<Real>;
+  using remapper_ptr_type = std::shared_ptr<AbstractRemapper<Real>>;
+
+  HommeInputsInitializer () = default;
 
   // Constructor(s) & Destructor
   virtual ~HommeInputsInitializer () = default;
@@ -23,10 +27,13 @@ public:
 protected:
 
   void add_field (const field_type& f) override;
+  void add_field (const field_type& f, const field_type& f_ref,
+                  const remapper_ptr_type& remapper) override;
 
   // Members
-  std::set<FieldIdentifier>               m_fids;
-  std::set<ekat::CaseInsensitiveString>   m_names;
+  std::set<FieldIdentifier>                 m_fids;
+
+  std::shared_ptr<AbstractRemapper<Real>>   m_remapper;
 
   bool m_fields_inited = false;
 };

--- a/components/scream/src/physics/p3/p3_inputs_initializer.cpp
+++ b/components/scream/src/physics/p3/p3_inputs_initializer.cpp
@@ -14,6 +14,34 @@ void P3InputsInitializer::add_field (const field_type &f)
   m_fields_id.insert(id);
 }
 
+void P3InputsInitializer::
+add_field (const field_type &f, const field_type& f_ref,
+           const remapper_ptr_type& remapper)
+{
+  if (m_remapper) {
+    // Sanity check
+    EKAT_REQUIRE_MSG (m_remapper->get_src_grid()->name()==remapper->get_src_grid()->name(),
+      "Error! A remapper was already set in P3InputsInitializer, but its src grid differs from"
+      "       the grid of the input remapper of this call.\n");
+  } else {
+    m_remapper = remapper;
+    m_remapper->registration_begins();
+  }
+
+  const auto& id = f.get_header().get_identifier();
+  const auto& id_ref = f_ref.get_header().get_identifier();
+
+  // To the AD, we only expose the fact that we init f_ref...
+  m_fields_id.insert(id_ref);
+
+  // ...but P3 only knows how to init f...
+  m_fields.emplace(id.name(),f);
+
+  // ...hence, we remap to f_ref.
+  m_remapper->register_field(f, f_ref);
+}
+
+
 // =========================================================================================
 void P3InputsInitializer::initialize_fields ()
 {
@@ -97,6 +125,15 @@ void P3InputsInitializer::initialize_fields ()
     // Init FQ to 0
     auto d_FQ = m_fields.at("FQ").get_view();
     Kokkos::deep_copy(d_FQ,Real(0));
+  }
+
+  if (m_remapper) {
+    m_remapper->registration_ends();
+
+    m_remapper->remap(true);
+
+    // Now we can destroy the remapper
+    m_remapper = nullptr;
   }
 }
 

--- a/components/scream/src/physics/p3/p3_inputs_initializer.hpp
+++ b/components/scream/src/physics/p3/p3_inputs_initializer.hpp
@@ -13,7 +13,7 @@ public:
 
   // The name of the initializer
   std::string name () const { return "P3InputsInitializer"; }
-  
+
   // Initialize fields
   void initialize_fields ();
 
@@ -24,10 +24,14 @@ public:
 protected:
 
   void add_field (const field_type& f);
+  void add_field (const field_type& f, const field_type& f_ref,
+                  const remapper_ptr_type& remapper);
 
   std::map<std::string,const field_type>  m_fields;
 
   std::set<FieldIdentifier> m_fields_id;
+
+  std::shared_ptr<AbstractRemapper<Real>> m_remapper;
 };
 
 } // namespace scream

--- a/components/scream/src/physics/zm/zm_inputs_initializer.hpp
+++ b/components/scream/src/physics/zm/zm_inputs_initializer.hpp
@@ -14,22 +14,26 @@ public:
   virtual ~ZMInputsInitializer () = default;
 
   // The name of the initializer
-  std::string name () const { return "ZMInputsInitializer"; }
+  std::string name () const override { return "ZMInputsInitializer"; }
   
   // Initialize fields
-  void initialize_fields ();
+  void initialize_fields () override;
 
-  const std::set<FieldIdentifier>& get_inited_fields () const {
+  const std::set<FieldIdentifier>& get_inited_fields () const override {
     return m_fields_id;
   }
 
 protected:
 
-  void add_field (const field_type& f);
+  void add_field (const field_type& f) override;
+  void add_field (const field_type& f, const field_type& f_ref,
+                  const remapper_ptr_type& remapper) override;
 
   std::map<std::string,const field_type>  m_fields;
 
   std::set<FieldIdentifier> m_fields_id;
+
+  std::shared_ptr<AbstractRemapper<Real>> m_remapper;
 };
 
 } // namespace scream

--- a/components/scream/src/share/atm_process/atmosphere_process_dag.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_dag.cpp
@@ -71,7 +71,7 @@ void AtmProcDAG::add_field_initializer (const FieldInitializer& initializer)
   m_nodes.push_back(Node());
   auto& n = m_nodes.back();
   n.id = m_nodes.size()-1;
-  n.name = initializer.name();
+  n.name = initializer.name() + " (init only)";
   m_unmet_deps[n.id].clear();
 
   for (const auto& f : inited_fields) {

--- a/components/scream/src/share/field/field_initializer.hpp
+++ b/components/scream/src/share/field/field_initializer.hpp
@@ -1,28 +1,33 @@
 #ifndef SCREAM_FIELD_INITIALIZER_HPP
 #define SCREAM_FIELD_INITIALIZER_HPP
 
-#include "share/scream_types.hpp"
-#include "ekat/std_meta/ekat_std_enable_shared_from_this.hpp"
+#include "share/grid/grids_manager.hpp"
 #include "share/field/field.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/std_meta/ekat_std_enable_shared_from_this.hpp"
 
 namespace scream {
 
 /*
  * A class responsible to initialize a field
  *
- * A FieldInitializer object has to be able to initialize
- * one or more field. This capability will be exploited by
- * the AtmosphereDriver (AD), to make sure all atm inputs
- * are initialized at the beginning of the simulation.
+ * A FieldInitializer object has to be able to initialize one or more fields.
+ * This capability will be exploited by the AtmosphereDriver (AD), to make sure
+ * all atm inputs are initialized at the beginning of the simulation.
  *
- * Most likely, some atm proc will also inherit from this class,
- * since they will claim the role of initializer for some fields.
+ * If the initializer initializes a field on a grid that is *not* the reference grid,
+ * it will also be asked to init a copy of the field on the reference grid.
+ * One way to achieve this is to pass to MyInitializer the grids manager, so that 
+ * it can build a remapper from its grid(s) to the reference grid.
+ * The remapper will then be used to remap the inited fields onto the reference grid.
  */
 
 class FieldInitializer : public ekat::enable_shared_from_this<FieldInitializer> {
 public:
-  using field_type       = Field<      Real>;
-  using const_field_type = Field<const Real>;
+  using field_type        = Field<      Real>;
+  using const_field_type  = Field<const Real>;
+  using remapper_ptr_type = std::shared_ptr<AbstractRemapper<Real>>;
 
   virtual ~FieldInitializer () = default;
 
@@ -45,11 +50,16 @@ public:
 
   // Store the field to be init-ed.
   virtual void add_field (const field_type& f) = 0;
+
+  // If f is not on the ref grid, pass both f and f_ref to the initializer.
+  // The initializer must initialize BOTH.
+  virtual void add_field (const field_type& f, const field_type& f_ref,
+                          const remapper_ptr_type& remapper) = 0;
 };
 
 // Create a field initializer, and correctly set up the (weak) pointer to self.
 template <typename FieldInitType>
-inline std::shared_ptr<FieldInitializer>
+inline std::shared_ptr<FieldInitType>
 create_field_initializer () {
   auto ptr = std::make_shared<FieldInitType>();
   ptr->setSelfPointer(ptr);

--- a/components/scream/src/share/field/field_repository.hpp
+++ b/components/scream/src/share/field/field_repository.hpp
@@ -82,6 +82,7 @@ public:
   const field_type& get_field (const identifier_type& identifier) const;
   const field_type& get_field(const std::string name,const std::string grid) const;
   const groups_map_type& get_field_groups () const { return m_field_groups; }
+  const alias_map_type& get_alias_fields (const std::string& name) const;
 
   // Iterators, to allow range for loops over the repo.
   typename repo_type::const_iterator begin() const { return m_fields.begin(); }
@@ -248,6 +249,15 @@ FieldRepository<RealType>::get_field (const std::string name, const std::string 
   EKAT_REQUIRE_MSG(f_matches.size()==1, "Error! get_field: " + name + " found " + std::to_string(f_matches.size()) + " matches on grid " + grid + ".\n");
   // Use this field id to grab field itself.
   return get_field(f_matches[0]);
+}
+
+template<typename RealType>
+const typename FieldRepository<RealType>::alias_map_type&
+FieldRepository<RealType>::get_alias_fields (const std::string& name) const
+{
+  auto it = m_fields.find(name);
+  EKAT_REQUIRE_MSG (it!=m_fields.end(), "Error! Field aliases not found.\n");
+  return it->second;
 }
 
 template<typename RealType>

--- a/components/scream/src/share/field/field_value_initializer.hpp
+++ b/components/scream/src/share/field/field_value_initializer.hpp
@@ -39,6 +39,12 @@ protected:
   void add_field (const field_type& f) {
     m_field = f;
   }
+
+  void add_field (const field_type& /* f */, const field_type& f_ref,
+                  const remapper_ptr_type& /* remapper */) {
+    // No need to remap anything, since it's trivial to init f_ref instead of f.
+    m_field = f_ref;
+  }
 };
 
 // Create a field initializer, and correctly set up the (weak) pointer to self.

--- a/components/scream/src/share/grid/grids_manager.hpp
+++ b/components/scream/src/share/grid/grids_manager.hpp
@@ -22,7 +22,7 @@ class GridsManager
 {
 public:
   using grid_type         = AbstractGrid;
-  using grid_ptr_type     = std::shared_ptr<grid_type>;
+  using grid_ptr_type     = std::shared_ptr<const grid_type>;
   using grid_repo_type    = std::map<std::string, grid_ptr_type>;
   using remapper_type     = AbstractRemapper<Real>;
   using remapper_ptr_type = std::shared_ptr<remapper_type>;

--- a/components/scream/src/share/tests/CMakeLists.txt
+++ b/components/scream/src/share/tests/CMakeLists.txt
@@ -9,5 +9,7 @@ if (NOT ${SCREAM_BASELINES_ONLY})
   CreateUnitTest(grid "grid_tests.cpp" scream_share)
 
   # Test atmosphere processes
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/atm_process_tests.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/atm_process_tests.yaml COPYONLY)
   CreateUnitTest(atm_proc "atm_process_tests.cpp" scream_share)
 endif()

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -9,6 +9,8 @@
 #include "share/grid/remap/inverse_remapper.hpp"
 #include "share/tests/dummy_se_point_remapper.hpp"
 
+#include "ekat/ekat_parse_yaml_file.hpp"
+
 namespace scream {
 
 template<AtmosphereProcessType PType>
@@ -197,11 +199,11 @@ setup_upgm (const int ne) {
 
   // Note: our test does not use actual dof info, but we need to set these
   //       views in the SEGrid's, so that the num local dofs is set
-  SEGrid::dofs_list_type dyn_dofs("",nelem*np*np);
-  SEGrid::dofs_list_type phys_dofs("",ncols);
+  AbstractGrid::dofs_list_type dyn_dofs("",nelem*np*np);
+  AbstractGrid::dofs_list_type phys_dofs("",ncols);
 
-  SEGrid::lid_to_idx_map_type dyn_dofs_map ("",nelem*np*np,3);
-  SEGrid::lid_to_idx_map_type phys_dofs_map ("",ncols,1);
+  AbstractGrid::lid_to_idx_map_type dyn_dofs_map ("",nelem*np*np,3);
+  AbstractGrid::lid_to_idx_map_type phys_dofs_map ("",ncols,1);
 
   // Greate a grids manager
   auto upgm = std::make_shared<UserProvidedGridsManager>();
@@ -214,6 +216,7 @@ setup_upgm (const int ne) {
 
   using dummy_remapper = DummySEPointRemapper<Real>;
   using inverse_remapper = InverseRemapper<Real>;
+  using identity_remapper = IdentityRemapper<Real>;
   auto dummy_phys_dyn_remapper = std::make_shared<dummy_remapper>(dummy_phys_grid,dummy_dyn_grid);
   auto dummy_phys_dyn_remapper2 = std::make_shared<dummy_remapper>(dummy_phys_grid,dummy_dyn_grid);
   auto dummy_dyn_phys_remapper = std::make_shared<inverse_remapper>(dummy_phys_dyn_remapper2);
@@ -231,28 +234,10 @@ TEST_CASE("process_factory", "") {
   // A world comm
   ekat::Comm comm(MPI_COMM_WORLD);
 
-  // Create a parameter list for inputs
+  // Load ad parameter list
+  std::string fname = "atm_process_tests.yaml";
   ekat::ParameterList params ("Atmosphere Processes");
-
-  params.set("Number of Entries",2);
-  params.set<std::string>("Schedule Type","Sequential");
-
-  auto& p0 = params.sublist("Process 0");
-  p0.set<std::string>("Process Name", "MyDynamics");
-  p0.set<std::string>("Grid Name", "Dynamics");
-
-  auto& p1 = params.sublist("Process 1");
-  p1.set<std::string>("Process Name", "Group");
-  p1.set("Number of Entries",2);
-  p1.set<std::string>("Schedule Type","Sequential");
-
-  auto& p1_0 = p1.sublist("Process 0");
-  p1_0.set<std::string>("Process Name", "MyPhysicsA");
-  p1_0.set<std::string>("Grid Name", "Physics");
-
-  auto& p1_1 = p1.sublist("Process 1");
-  p1_1.set<std::string>("Process Name", "MyPhysicsB");
-  p1_1.set<std::string>("Grid Name", "Physics");
+  REQUIRE_NOTHROW ( parse_yaml_file(fname,params) );
 
   // Create then factory, and register constructors
   auto& factory = AtmosphereProcessFactory::instance();

--- a/components/scream/src/share/tests/atm_process_tests.yaml
+++ b/components/scream/src/share/tests/atm_process_tests.yaml
@@ -5,7 +5,7 @@ Schedule Type: Sequential
 
 Process 0:
   Process Name: MyDynamics
-  Grid Name: SE Dynamics
+  Grid Name: Dynamics
 Process 1:
   Process Name: Group
   Number of Entries: 2
@@ -13,8 +13,8 @@ Process 1:
 
   Process 0:
     Process Name: MyPhysicsA
-    Grid Name: SE Physics
+    Grid Name: Physics
   Process 1:
     Process Name: MyPhysicsB
-    Grid Name: SE Physics
+    Grid Name: Physics
 ...

--- a/components/scream/tests/scream_homme_dyn_ut_nlev72_qsize4/input.yaml
+++ b/components/scream/tests/scream_homme_dyn_ut_nlev72_qsize4/input.yaml
@@ -11,5 +11,5 @@ Atmosphere Processes:
 
 Grids Manager:
   Type: Dynamics Driven
-  Reference Grid: SE Dynamics
+  Reference Grid: Physics
 ...


### PR DESCRIPTION
This PR ensures that a FieldInitializer is able to init fields both on the grid that they are defined on, as well as on the reference grid (if those are the same, everything behaves as it did before).

This upgrade is necessary. Recall that the AD atm dag always starts from the ref grid, so the atm inputs are _all_ on the reference grid, and remappers are used to map fields onto different grids. So if an initializer inits fields only on a non-ref grid, we have 2 issues:
- the DAG check would fail (nobody is init-ing the corresponding field on the ref grid);
- even disabling the DAG checks, the remapper would overwrite the field on the non-ref grid (the one that the initializer inited) with whatever was in the corresponding ref-grid field (zeros or garbage, depending on how the view was inited by kokkos).

The solution in this PR is simple: if a field initializer inits F on a non-ref grid, when it's time to set the field in the initializer, we pass both F and F_ref (the copy on the ref grid) _and_ a remapper from the grid to the ref grid. If the initializer does not know how to handle the ref grid, it can simply init F, then use the remapper to init F_ref. Note: some initializers (like FieldValueInitializer) can init F_ref directly, without need of a remapper.