### PR TITLE
Fix lassen machine spec to submit a longer job to regular queue

### DIFF
--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -42,7 +42,7 @@ MACHINE_METADATA = {
                   "/sems-data-store/ACME/baselines/scream/master-baselines"),
     "lassen" : (["module --force purge", "module load git gcc/7.3.1 cuda/10.1.243 cmake/3.14.5 spectrum-mpi lapack python/3.7.2", "export LLNL_USE_OMPI_VARS='y'"],
                  ["mpicxx","mpifort","mpicc"],
-                  "bsub -q pdebug",
+                  "bsub -q pbatch -W 45",
                   44,
                   4,
                   ""),


### PR DESCRIPTION
Adjusts lassen machine specs to submit testing jobs to the regular queue for a slightly longer time than the debug queue allows.  Necessary to complete tests and submit to dashboard.

[BFB]