### PR TITLE
SCREAM: add options to test-all-scream for quick testing

### DIFF
--- a/components/scream/cmake/ctest_script.cmake
+++ b/components/scream/cmake/ctest_script.cmake
@@ -17,8 +17,11 @@ set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 
 ctest_start(${dashboard_model} TRACK ${dashboard_track})
 
-separate_arguments(OPTIONS_LIST UNIX_COMMAND "${CMAKE_COMMAND}")
-ctest_configure(OPTIONS "${OPTIONS_LIST}" RETURN_VALUE CONFIG_ERROR_CODE)
+if (NOT SKIP_CONFIG_STEP)
+  # Config step is not to be skipped
+  separate_arguments(OPTIONS_LIST UNIX_COMMAND "${CMAKE_COMMAND}")
+  ctest_configure(OPTIONS "${OPTIONS_LIST}" RETURN_VALUE CONFIG_ERROR_CODE)
+endif()
 
 if (CONFIG_ERROR_CODE)
   set (TEST_FAILS TRUE)

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -88,6 +88,11 @@ OR
 
     parser.add_argument("-w", "--work-dir",
         help="The work directory where all the building/testing will happen. Defaults to ${root_dir}/ctest-build")
+    parser.add_argument("--quick-rerun", action="store_true",
+                        help="Do not clean the build dir, and do not reconfigure. Just (incremental) build and test.")
+
+    parser.add_argument("--quick-rerun-failed", action="store_true",
+                        help="Do not clean the build dir, and do not reconfigure. Just (incremental) build and retest failed tests only.")
 
     parser.add_argument("-d", "--dry-run", action="store_true",
                         help="Do a dry run, commands will be printed but not executed")

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -563,7 +563,7 @@ class TestAllScream(object):
             # Note: make will still rerun cmake if some cmake file has changed
             ctest_config += "-DSKIP_CONFIG_STEP=TRUE "
             if self._quick_rerun_failed:
-              ctest_config += "--rerun-failed "
+                ctest_config += "--rerun-failed "
         else:
             # This directory might have been used also to build the model to generate baselines.
             # Although it's ok to build in the same dir, we MUST make sure to erase cmake's cache
@@ -588,8 +588,8 @@ class TestAllScream(object):
             # Create this test's build dir
             if test_dir.exists():
                 if not self._quick_rerun:
-                  shutil.rmtree(str(test_dir))
-                  test_dir.mkdir(parents=True)
+                    shutil.rmtree(str(test_dir))
+                    test_dir.mkdir(parents=True)
             else:
                 test_dir.mkdir(parents=True)
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -21,7 +21,8 @@ class TestAllScream(object):
     def __init__(self, cxx_compiler, f90_compiler, c_compiler, submit=False, parallel=False, fast_fail=False,
                  baseline_ref=None, baseline_dir=None, machine=None, no_tests=False, keep_tree=False,
                  custom_cmake_opts=(), custom_env_vars=(), preserve_env=False, tests=(),
-                 integration_test="JENKINS_HOME" in os.environ, root_dir=None, work_dir=None, dry_run=False,
+                 integration_test="JENKINS_HOME" in os.environ, root_dir=None, work_dir=None,
+                 quick_rerun=False,quick_rerun_failed=False,dry_run=False,
                  make_parallel_level=0, ctest_parallel_level=0):
     ###########################################################################
 
@@ -43,8 +44,13 @@ class TestAllScream(object):
         self._root_dir                = root_dir
         self._work_dir                = work_dir
         self._integration_test        = integration_test
+        self._quick_rerun             = quick_rerun
+        self._quick_rerun_failed      = quick_rerun_failed
         self._dry_run                 = dry_run
         self._must_generate_baselines = False
+
+        if self._quick_rerun_failed:
+            self._quick_rerun = True
 
         ############################################
         #  Sanity checks and helper structs setup  #
@@ -552,10 +558,17 @@ class TestAllScream(object):
         cmake_config = self.generate_cmake_config(self._tests_cmake_args[test], for_ctest=True)
         ctest_config = self.generate_ctest_config(cmake_config, [], test)
 
-        # This directory might have been used also to build the model to generate baselines.
-        # Although it's ok to build in the same dir, we MUST make sure to erase cmake's cache
-        # and internal files from the previous build (CMakeCache.txt and CMakeFiles folder)
-        run_cmd_no_fail("rm -rf CMake*", from_dir=test_dir)
+        if self._quick_rerun:
+            # Do not purge bld dir, and do not rerun config step.
+            # Note: make will still rerun cmake if some cmake file has changed
+            ctest_config += "-DSKIP_CONFIG_STEP=TRUE "
+            if self._quick_rerun_failed:
+              ctest_config += "--rerun-failed "
+        else:
+            # This directory might have been used also to build the model to generate baselines.
+            # Although it's ok to build in the same dir, we MUST make sure to erase cmake's cache
+            # and internal files from the previous build (CMakeCache.txt and CMakeFiles folder)
+            run_cmd_no_fail("rm -rf CMake*", from_dir=test_dir)
 
         success = run_cmd(ctest_config, from_dir=test_dir, arg_stdout=None, arg_stderr=None, verbose=True, dry_run=self._dry_run)[0] == 0
 
@@ -574,9 +587,11 @@ class TestAllScream(object):
 
             # Create this test's build dir
             if test_dir.exists():
-                shutil.rmtree(str(test_dir))
-
-            test_dir.mkdir(parents=True)
+                if not self._quick_rerun:
+                  shutil.rmtree(str(test_dir))
+                  test_dir.mkdir(parents=True)
+            else:
+                test_dir.mkdir(parents=True)
 
         success = True
         tests_success = {


### PR DESCRIPTION
This small upgrade to test-all-scream might help people to speed up development cycles while still relying on test-all-scream.

Currently, if one does a small modification to the source code and runs test-all-scream again, all the libraries/execs have to be rebuilt from scratch. This is the default behavior, which protects from dirty build dirs, which sometimes can cause things to work even if they shouldn't. However, for normal development, we don't want to rebuild the whole project, and incremental builds can save time.

I personally manually build scream outside the src tree, mostly because of test-all-scream is slow (for what said above). This new option makes test-all-scream more amenable for my needs.

The two options are `--quick-rerun` and `--quick-rerun-failed`. They both skip the config step in ctest, and simply build and test the project, but starting from the current status of the build dir (hence, only rebuilding what changed). The former reruns all tests, while the latter only reruns the tests that failed.

Note:
- if all tests passed in all the previous runs (meaning, there is no LastTestsFailed_XYZ file in the Testing/Temporary subdir of the build dir), then `--quick-rerun-failed` is the same as `--quick-rerun` (this follows from how ctest handles the `--rerun-failed`.
- if testing against a baseline commit, baselines will still be regenerated. To unleash the full potential of this option, provide a baseline dir, so that only the test phase is executed. Also, you can use this together with `-k`, which allows to test a dirty repo (with uncommited changes).