### PR TITLE
Added a test fixture to p3 unit tests to generate rain tables.

### DIFF
--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -58,14 +58,12 @@ endif()
 CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
                EXE_ARGS "${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
-               DEP p3_tests_ut_np1_omp1
                PROPERTIES FIXTURES_REQUIRED p3_tables
                EXCLUDE_MAIN_CPP)
 
 CreateUnitTest(p3_run_and_cmp_f90 "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
                EXE_ARGS "-f ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
-               DEP p3_tests_ut_np1_omp1
                PROPERTIES FIXTURES_REQUIRED p3_tables
                EXCLUDE_MAIN_CPP)
 

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -40,14 +40,34 @@ set(P3_TESTS_SRCS
     p3_water_vapor_conservation_tests.cpp
  ) # P3_TESTS_SRCS
 
+# The p3_test_setup executable generates tables used by all p3 tests. This
+# executable is a test fixture in the sense of CMake, so we mark it with the
+# FIXTURES_SETUP property, and we make p3_tests and p3_run_and_cmp_* depend on
+# it via the FIXTURES_REQUIRED property.
+# (See https://cmake.org/cmake/help/latest/prop_test/FIXTURES_REQUIRED.html)
+CreateUnitTest(p3_test_setup p3_test_setup.cpp "${NEED_LIBS}"
+               PROPERTIES FIXTURES_SETUP p3_tables)
+
 # NOTE: tests inside this if statement won't be built in a baselines-only build
 if (NOT ${SCREAM_BASELINES_ONLY})
-  CreateUnitTest(p3_tests "${P3_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP p3_tests_ut_np1_omp1)
+  CreateUnitTest(p3_tests "${P3_TESTS_SRCS}" "${NEED_LIBS}"
+                 THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC}
+                 PROPERTIES FIXTURES_REQUIRED p3_tables)
 endif()
 
-CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}" THREADS ${SCREAM_TEST_MAX_THREADS} EXE_ARGS "${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline" DEP p3_tests_ut_np1_omp1 EXCLUDE_MAIN_CPP)
+CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}"
+               THREADS ${SCREAM_TEST_MAX_THREADS}
+               EXE_ARGS "${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
+               DEP p3_tests_ut_np1_omp1
+               PROPERTIES FIXTURES_REQUIRED p3_tables
+               EXCLUDE_MAIN_CPP)
 
-CreateUnitTest(p3_run_and_cmp_f90 "p3_run_and_cmp.cpp" "${NEED_LIBS}" THREADS ${SCREAM_TEST_MAX_THREADS} EXE_ARGS "-f ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline" DEP p3_tests_ut_np1_omp1 EXCLUDE_MAIN_CPP)
+CreateUnitTest(p3_run_and_cmp_f90 "p3_run_and_cmp.cpp" "${NEED_LIBS}"
+               THREADS ${SCREAM_TEST_MAX_THREADS}
+               EXE_ARGS "-f ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
+               DEP p3_tests_ut_np1_omp1
+               PROPERTIES FIXTURES_REQUIRED p3_tables
+               EXCLUDE_MAIN_CPP)
 
 # By default, baselines should be created using all fortran
 add_custom_target(p3_baseline_f90

--- a/components/scream/src/physics/p3/tests/p3_test_setup.cpp
+++ b/components/scream/src/physics/p3/tests/p3_test_setup.cpp
@@ -3,7 +3,6 @@
 
 #include <cstdio>
 #include "physics/p3/p3_f90.hpp"
-//#include "physics/p3/p3_functions_f90.hpp"
 
 int main(int argc, char* argv[]) {
   std::printf("Generating p3 rain tables...\n");

--- a/components/scream/src/physics/p3/tests/p3_test_setup.cpp
+++ b/components/scream/src/physics/p3/tests/p3_test_setup.cpp
@@ -1,0 +1,12 @@
+// This is a tiny program that calls p3_init() to generate tables used by
+// the p3 unit tests.
+
+#include <cstdio>
+#include "physics/p3/p3_f90.hpp"
+//#include "physics/p3/p3_functions_f90.hpp"
+
+int main(int argc, char* argv[]) {
+  std::printf("Generating p3 rain tables...\n");
+  scream::p3::p3_init();
+  return 0;
+}


### PR DESCRIPTION
This pull request adds a test "fixture" that runs before all p3 tests, making sure the rain tables are generated in advance. It requires #777 to go in first, as it needs one of the recently-added enhancements to Ekat's unit test creation function. When that PR gets merged, I'll rebase this one and we can see how it works.