### PR TITLE
Adding some code comments to document AbstractRemapper interface methods

### DIFF
--- a/components/scream/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/scream/src/share/grid/remap/abstract_remapper.hpp
@@ -42,15 +42,6 @@ public:
   // Call this before you begin registering fields with this remapper.
   void registration_begins ();
 
-  // Specify that all given source fields be packed into the single "packed"
-  // target field identified by packed_tgt. The target field must have a layout
-  // with a sufficient rank to accommodate the fields being packed into it. In
-  // the inverse mapping, the target (source) fields are unpacked from the
-  // source (target) field in the same order in which they were packed.
-  // This method must be called before any other field registration method.
-  void register_packing (const std::vector<field_type>& src_fields,
-                         const identifier_type& packed_tgt);
-
   // This method registers a source field to be remapped to a target field.
   void register_field (const field_type& src, const field_type& tgt);
 
@@ -316,15 +307,6 @@ unregister_field (const identifier_type& src, const identifier_type& tgt) {
     --m_num_bound_fields;
   }
   m_fields_are_bound.erase(m_fields_are_bound.begin()+ifield);
-}
-
-template<typename RealType>
-void AbstractRemapper<RealType>::
-register_packing (const std::vector<field_type>& src_fields,
-                  const identifier_type& packed_tgt) {
-  EKAT_REQUIRE_MSG(m_state==RepoState::Open,
-                   "Error! You can only register fields to be packed during "
-                   "the registration phase.\n");
 }
 
 template<typename RealType>

--- a/components/scream/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/scream/src/share/grid/remap/abstract_remapper.hpp
@@ -189,9 +189,10 @@ protected:
   virtual void do_remap_bwd () const = 0;
 
   // This helper function searches for a pair of source and target field
-  // identifiers in the remapper's set of bound fields, and returns the index to
-  // which they are bound, or -1 if no such pair of bound fields exists within
-  // the remapper.
+  // identifiers in the remapper's set of bound fields. It returns -1 if fields
+  // were not registered at all (via the field identifier). If they were
+  // registered, it returns the index, regardless of whether the fields have
+  // already been bound.
   int find_field (const identifier_type& src,
                   const identifier_type& tgt) {
     int ifield = -1;
@@ -218,10 +219,15 @@ protected:
   int           m_num_fields;
   int           m_num_registered_fields;
 
-  // This vector stores a boolean whose elements are the indices of fields that
-  // have been bound to the remapper. This vector is necessary because the
-  // binding of fields is separate from their regіstration: recall that one may
-  // register a field using its identifier, and bind the actual field later.
+  // This vector maps the indices of registered fields to booleans that indicate
+  // whether these fields have been bound to the remapper. This vector is
+  // necessary because the binding of fields is separate from their
+  // regіstration: recall that one may register a field using its identifier,
+  // and bind the actual field later.
+  // NOTE: vector<bool> is a strange beast, and doesn't necessary behave as
+  // NOTE: expected. Use caution when manipulating this member, and don't
+  // NOTE: rely on the usual assumptions about how the boolean elements are
+  // NOTE: stored.
   std::vector<bool>   m_fields_are_bound;
   int                 m_num_bound_fields;
 };

--- a/components/scream/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/scream/src/share/grid/remap/abstract_remapper.hpp
@@ -15,7 +15,7 @@ namespace scream
 
 // An abstract interface for a remapper
 
-// A remapper is basically a functor, that, given two fields
+// A remapper is basically a functor, that, given two fields,
 // copies the first into the second, or viceversa. The copy must
 // account for different layouts and/or different mpi distributions.
 // This concept can be extended to remaps that involve interpolation,
@@ -32,6 +32,7 @@ public:
   using layout_type     = typename identifier_type::layout_type;
   using grid_type       = AbstractGrid;
   using grid_ptr_type   = std::shared_ptr<const grid_type>;
+  using ci_string       = ekat::CaseInsensitiveString;
 
   AbstractRemapper (const grid_ptr_type& src_grid,
                     const grid_ptr_type& tgt_grid);
@@ -43,6 +44,14 @@ public:
   void register_field (const identifier_type& src, const identifier_type& tgt);
   void unregister_field (const identifier_type& src, const identifier_type& tgt);
   void registration_ends ();
+
+  // Specify that all source fields belonging to the group identified by the
+  // given case-insensitive string be packed into a "packed" field (of rank 2)
+  // with the given target identifier. In the inverse mapping, these fields will
+  // be unpacked from the source field into their target fields in the same
+  // order in which they were packed.
+  void register_packing(const ci_string& group_name,
+                        const identifier_type& packed_tgt);
 
   // The user is allowed to only provide identifiers in the registration phase.
   // In that case, fields have to be bound after registration is complete, and

--- a/components/scream/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/scream/src/share/grid/remap/abstract_remapper.hpp
@@ -39,19 +39,31 @@ public:
 
   virtual ~AbstractRemapper () = default;
 
+  // Call this before you begin registering fields with this remapper.
   void registration_begins ();
+
+  // This method registers a source field to be remapped to a target field.
   void register_field (const field_type& src, const field_type& tgt);
+
+  // This method registers a source field to be remapped to a target field
+  // using fields associated with the given field identifiers.
   void register_field (const identifier_type& src, const identifier_type& tgt);
+
+  // This method unregisters source and target fields associated with the given
+  // identifiers, indicating that they are no longer to be remapped.
   void unregister_field (const identifier_type& src, const identifier_type& tgt);
-  void registration_ends ();
 
   // Specify that all source fields belonging to the group identified by the
-  // given case-insensitive string be packed into a "packed" field (of rank 2)
-  // with the given target identifier. In the inverse mapping, these fields will
-  // be unpacked from the source field into their target fields in the same
-  // order in which they were packed.
-  void register_packing(const ci_string& group_name,
-                        const identifier_type& packed_tgt);
+  // given case-insensitive string be packed into a "packed" field with the
+  // given target identifier. The "packed" field must have a layout with a
+  // sufficient rank to accommodate the fields being packed into it. In the
+  // inverse mapping, these fields are unpacked from the source field into their
+  // target fields in the same order in which they were packed.
+  void register_packing (const ci_string& group_name,
+                         const identifier_type& packed_tgt);
+
+  // Call this to indicate that field registration is complete.
+  void registration_ends ();
 
   // The user is allowed to only provide identifiers in the registration phase.
   // In that case, fields have to be bound after registration is complete, and

--- a/components/scream/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/scream/src/share/grid/remap/abstract_remapper.hpp
@@ -42,6 +42,15 @@ public:
   // Call this before you begin registering fields with this remapper.
   void registration_begins ();
 
+  // Specify that all given source fields be packed into the single "packed"
+  // target field identified by packed_tgt. The target field must have a layout
+  // with a sufficient rank to accommodate the fields being packed into it. In
+  // the inverse mapping, the target (source) fields are unpacked from the
+  // source (target) field in the same order in which they were packed.
+  // This method must be called before any other field registration method.
+  void register_packing (const std::vector<field_type>& src_fields,
+                         const identifier_type& packed_tgt);
+
   // This method registers a source field to be remapped to a target field.
   void register_field (const field_type& src, const field_type& tgt);
 
@@ -52,15 +61,6 @@ public:
   // This method unregisters source and target fields associated with the given
   // identifiers, indicating that they are no longer to be remapped.
   void unregister_field (const identifier_type& src, const identifier_type& tgt);
-
-  // Specify that all source fields belonging to the group identified by the
-  // given case-insensitive string be packed into a "packed" field with the
-  // given target identifier. The "packed" field must have a layout with a
-  // sufficient rank to accommodate the fields being packed into it. In the
-  // inverse mapping, these fields are unpacked from the source field into their
-  // target fields in the same order in which they were packed.
-  void register_packing (const ci_string& group_name,
-                         const identifier_type& packed_tgt);
 
   // Call this to indicate that field registration is complete.
   void registration_ends ();
@@ -287,6 +287,15 @@ unregister_field (const identifier_type& src, const identifier_type& tgt) {
     --m_num_bound_fields;
   }
   m_fields_are_bound.erase(m_fields_are_bound.begin()+ifield);
+}
+
+template<typename RealType>
+void AbstractRemapper<RealType>::
+register_packing (const std::vector<field_type>& src_fields,
+                  const identifier_type& packed_tgt) {
+  EKAT_REQUIRE_MSG(m_state==RepoState::Open,
+                   "Error! You can only register fields to be packed during "
+                   "the registration phase.\n");
 }
 
 template<typename RealType>

--- a/components/scream/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/scream/src/share/grid/remap/abstract_remapper.hpp
@@ -224,10 +224,9 @@ protected:
   // necessary because the binding of fields is separate from their
   // regіstration: recall that one may register a field using its identifier,
   // and bind the actual field later.
-  // NOTE: vector<bool> is a strange beast, and doesn't necessary behave as
-  // NOTE: expected. Use caution when manipulating this member, and don't
-  // NOTE: rely on the usual assumptions about how the boolean elements are
-  // NOTE: stored.
+  // NOTE: vector<bool> is a strange beast, and doesn't necessarily behave as
+  // expected. Use caution when manipulating this member, and don't rely on the
+  // usual assumptions about how the boolean elements are stored.
   std::vector<bool>   m_fields_are_bound;
   int                 m_num_bound_fields;
 };

--- a/components/scream/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/scream/src/share/grid/remap/abstract_remapper.hpp
@@ -97,18 +97,23 @@ public:
   grid_ptr_type get_src_grid () const { return m_src_grid; }
   grid_ptr_type get_tgt_grid () const { return m_tgt_grid; }
 
+  // Returns the source field identifier for a specified field index (assigned
+  // during field registration).
   const identifier_type& get_src_field_id (const int ifield) const {
     EKAT_REQUIRE_MSG(ifield>=0 && ifield<m_num_registered_fields,
                        "Error! Field index out of bounds.\n");
     return do_get_src_field_id(ifield);
   }
 
+  // Returns the target field identifier for a specified field index (assigned
+  // during field registration).
   const identifier_type& get_tgt_field_id (const int ifield) const {
     EKAT_REQUIRE_MSG(ifield>=0 && ifield<m_num_registered_fields,
                        "Error! Field index out of bounds.\n");
     return do_get_tgt_field_id(ifield);
   }
 
+  // Returns the source field for the given field index.
   const field_type& get_src_field (const int ifield) const {
     EKAT_REQUIRE_MSG(m_state==RepoState::Closed,
                        "Error! Cannot call 'get_src_field' until registration has ended.\n");
@@ -117,6 +122,7 @@ public:
     return do_get_src_field(ifield);
   }
 
+  // Returns the target field for the given field index.
   const field_type& get_tgt_field (const int ifield) const {
     EKAT_REQUIRE_MSG(m_state==RepoState::Closed,
                        "Error! Cannot call 'get_tgt_field' until registration has ended.\n");
@@ -148,7 +154,7 @@ public:
 
   int get_num_fields () const {
     EKAT_REQUIRE_MSG(m_state!=RepoState::Open,
-                       "Error! Cannot call 'get_num_fields' durin the registration phase.\n");
+                     "Error! Cannot call 'get_num_fields' during the registration phase.\n");
     return m_num_fields;
   }
 
@@ -164,15 +170,37 @@ protected:
   virtual const field_type& do_get_src_field (const int ifield) const = 0;
   virtual const field_type& do_get_tgt_field (const int ifield) const = 0;
 
+  // Override this method to insert logic executed at the beginning of the field
+  // registration process.
   virtual void do_registration_begins () = 0;
+
+  // Override this method to insert logic executed when a pair of source/target
+  // field identifiers are registered.
   virtual void do_register_field (const identifier_type& src, const identifier_type& tgt) = 0;
+
+  // Override this method to insert logic executed when a pair of source/target
+  // fields are bound to an index within the remapper.
   virtual void do_bind_field (const int ifield, const field_type& src, const field_type& tgt) = 0;
+
+  // Override this method to insert logic executed when a field is unregistered.
   virtual void do_unregister_field (const int ifield) = 0;
+
+  // Override this method to insert logic executed when the field registration
+  // process ends.
   virtual void do_registration_ends () = 0;
 
+  // Override this method to implement the forward remapping process using
+  // the protected data members of this class.
   virtual void do_remap_fwd () const = 0;
+
+  // Override this method to implement the backward/inverse remapping process
+  // using the protected data members of this class.
   virtual void do_remap_bwd () const = 0;
 
+  // This helper function searches for a pair of source and target field
+  // identifiers in the remapper's set of bound fields, and returns the index to
+  // which they are bound, or -1 if no such pair of bound fields exists within
+  // the remapper.
   int find_field (const identifier_type& src,
                   const identifier_type& tgt) {
     int ifield = -1;
@@ -199,9 +227,10 @@ protected:
   int           m_num_fields;
   int           m_num_registered_fields;
 
-  // Whether fields have been provided. Recall that the user may register
-  // fields passing only an identifier, and actually bind fields only
-  // at a later moment.
+  // This vector stores a boolean whose elements are the indices of fields that
+  // have been bound to the remapper. This vector is necessary because the
+  // binding of fields is separate from their regіstration: recall that one may
+  // register a field using its identifier, and bind the actual field later.
   std::vector<bool>   m_fields_are_bound;
   int                 m_num_bound_fields;
 };


### PR DESCRIPTION
These aren't comprehensive, but they do describe some important operations for registering/binding fields.

No code changes--only comments added.