### PR TITLE
SCREAM: bug fix in test-all-scream

### DIFF
--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -558,7 +558,7 @@ class TestAllScream(object):
         cmake_config = self.generate_cmake_config(self._tests_cmake_args[test], for_ctest=True)
         ctest_config = self.generate_ctest_config(cmake_config, [], test)
 
-        if self._quick_rerun:
+        if self._quick_rerun and pathlib.Path("{}/CMakeCache.txt".format(test_dir)).is_file():
             # Do not purge bld dir, and do not rerun config step.
             # Note: make will still rerun cmake if some cmake file has changed
             ctest_config += "-DSKIP_CONFIG_STEP=TRUE "


### PR DESCRIPTION
The --quick-rerun option should skip the config step only if it was already performed (e.g., CMakeCache.txt is found in the directory).

Note: the presence of CMakeCache.txt is not per se enough to guarantee that 'make' will succeed when run from the bld dir, possibly automatically running cmake again (e.g., the file might be corrupted, or there may not be a Makefile in the folder). But it is a reasonable compromise.