### PR TITLE
SCREAM: allow user to have a local mach specs file

### DIFF
--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -12,7 +12,7 @@
 #       subdirs are located (full_debug, full_sp_debug, debug_no_fpe).
 
 from utils import expect, get_cpu_core_count, run_cmd_no_fail
-import os
+import os, sys
 import pathlib
 
 MACHINE_METADATA = {
@@ -82,6 +82,14 @@ MACHINE_METADATA = {
     "linux-generic-serial" : ([],["mpicxx","mpifort","mpicc"],"", get_cpu_core_count(), get_cpu_core_count(),""),
 }
 
+if (pathlib.Path("~/.cime/scream_mach_specs.py").expanduser().is_file()):
+    sys.path.append(str(pathlib.Path("~/.cime").expanduser()))
+    from scream_mach_specs import MACHINE_METADATA as LOCAL_MD
+    if len(LOCAL_MD) == 6:
+        MACHINE_METADATA["local"] = LOCAL_MD
+    else:
+        print("WARNING! File '~/.cime/scream_mach_specs.py' was found, but the MACHINE_METADATA in there is badly formatted. Ignoring it.")
+
 ###############################################################################
 def is_machine_supported(machine):
 ###############################################################################
@@ -90,66 +98,82 @@ def is_machine_supported(machine):
 ###############################################################################
 def get_mach_env_setup_command(machine):
 ###############################################################################
-    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine),
+           "Machine {} is not currently supported by scream testing system.\n"
+           " Note: you can also create a file `~/.cime/scream_mach_specs.py` with your local machine specs.".format(machine))
 
     return MACHINE_METADATA[machine][0]
 
 ###############################################################################
 def get_mach_cxx_compiler(machine):
 ###############################################################################
-    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine),
+           "Machine {} is not currently supported by scream testing system.\n"
+           " Note: you can also create a file `~/.cime/scream_mach_specs.py` with your local machine specs.".format(machine))
 
     return MACHINE_METADATA[machine][1][0]
 
 ###############################################################################
 def get_mach_f90_compiler(machine):
 ###############################################################################
-    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine),
+           "Machine {} is not currently supported by scream testing system.\n"
+           " Note: you can also create a file `~/.cime/scream_mach_specs.py` with your local machine specs.".format(machine))
 
     return MACHINE_METADATA[machine][1][1]
 
 ###############################################################################
 def get_mach_c_compiler(machine):
 ###############################################################################
-    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine),
+           "Machine {} is not currently supported by scream testing system.\n"
+           " Note: you can also create a file `~/.cime/scream_mach_specs.py` with your local machine specs.".format(machine))
 
     return MACHINE_METADATA[machine][1][2]
+
 
 ###############################################################################
 def get_mach_batch_command(machine):
 ###############################################################################
-    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine),
+           "Machine {} is not currently supported by scream testing system.\n"
+           " Note: you can also create a file `~/.cime/scream_mach_specs.py` with your local machine specs.".format(machine))
 
     return MACHINE_METADATA[machine][2]
 
 ###############################################################################
 def get_mach_compilation_resources(machine):
 ###############################################################################
-    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine),
+           "Machine {} is not currently supported by scream testing system.\n"
+           " Note: you can also create a file `~/.cime/scream_mach_specs.py` with your local machine specs.".format(machine))
 
     return MACHINE_METADATA[machine][3]
 
 ###############################################################################
 def get_mach_testing_resources(machine):
 ###############################################################################
-    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine),
+           "Machine {} is not currently supported by scream testing system.\n"
+           " Note: you can also create a file `~/.cime/scream_mach_specs.py` with your local machine specs.".format(machine))
 
     return MACHINE_METADATA[machine][4]
 
 ###############################################################################
 def get_mach_baseline_root_dir(machine,default_dir):
 ###############################################################################
-    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine),
+           "Machine {} is not currently supported by scream testing system.\n"
+           " Note: you can also create a file `~/.cime/scream_mach_specs.py` with your local machine specs.".format(machine))
 
-    if MACHINE_METADATA[machine][5]=="":
-        return default_dir
-    else:
-        return MACHINE_METADATA[machine][5]
+    return MACHINE_METADATA[machine][5]
 
 ###############################################################################
 def is_cuda_machine(machine):
 ###############################################################################
-    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine),
+           "Machine {} is not currently supported by scream testing system.\n"
+           " Note: you can also create a file `~/.cime/scream_mach_specs.py` with your local machine specs.".format(machine))
 
     env_setup     = get_mach_env_setup_command(machine)
     env_setup_str = " && ".join(env_setup)
@@ -159,7 +183,9 @@ def is_cuda_machine(machine):
 ###############################################################################
 def setup_mach_env(machine):
 ###############################################################################
-    expect(is_machine_supported(machine), "Error! Machine {} is not currently supported by scream testing system.".format(machine))
+    expect(is_machine_supported(machine),
+           "Machine {} is not currently supported by scream testing system.\n"
+           " Note: you can also create a file `~/.cime/scream_mach_specs.py` with your local machine specs.".format(machine))
 
     env_setup = get_mach_env_setup_command(machine)
 

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -82,6 +82,10 @@ OR
     parser.add_argument("-i", "--integration-test", action="store_true", default="JENKINS_HOME" in os.environ,
                         help="Merge origin/master into this branch before testing.")
 
+    parser.add_argument("-l", "--local", action="store_true",
+                        help="Allow to not specify a machine name, and have test-all-scream to look"
+                             "for '~/.cime/scream_mach_specs.py' for machine specifications.")
+
     parser.add_argument("-r", "--root-dir",
                         help="The root directory of the scream src you want to test. "
                         "Default will be the scream src containing this script.")


### PR DESCRIPTION
I grew tired of typing `-m linux-generic --baseline-dir /path/to/my/baselines` when using test-all-scream on my laptop. I wanted a "faster" way to tell test-all about the baseline directory. So I added a new capability to test-all-scream.

You can now pass the `-l` (or `--local`) flag, and test-all-scream will look for `scream_mach_specs.py` inside the `~/.cime` folder (which you might already have if you run cime stuff on your local machine). This file must contain a list called MACHINE_METADATA, which contains what each entry of the dict in `scripts/machine_specs.py` does.

The local run is mutually exclusive with the `-m` flag (so you can't do `-m blake -l`). Also, an error is thrown if asking for `-l` but no specs file is found in `~/.cime`. In that folder, test-all-scream will also look for a cmake cache file called `scream_mach_file.cmake`, and error out if that is not found.

Now I can do `test-all-scream -l --baseline-dir AUTO` instead of `test-all-scream -m linux-generic --baseline-dir /my/very/long/path/to/baselines`.

Edit: also, using the scream_mach_specs.py file I don't need to manually setup my environment so that all required packages are in the PATH/LD_LIBRARY_PATH every time (remember that linux-generic in scripts/machine_specs.py has no env setup). Instead, I can put all the env setup commands in my local `~/.cime/scream_mach_specs.py` file, and simply invoke test-all-scream from a fresh terminal with no env/modules setup.