### PR TITLE
Major warning cleanup

### DIFF
--- a/components/eam/src/physics/cam/micro_p3.F90
+++ b/components/eam/src/physics/cam/micro_p3.F90
@@ -460,9 +460,9 @@ contains
   END SUBROUTINE p3_main_part1
 
   SUBROUTINE p3_main_part2(kts, kte, kbot, ktop, kdir, do_predict_nc, do_prescribed_CCN, dt, inv_dt, &
-       pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, ni_activated, &
+       pres, exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, ni_activated, &
        inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r, qv_prev, t_prev, &
-       t_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, qv, th_atm, qc, nc, qr, nr, qi, ni, &
+       t_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofaci, acn, qv, th_atm, qc, nc, qr, nr, qi, ni, &
        qm, bm, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, qc_incld, qr_incld, qi_incld, qm_incld, nc_incld, nr_incld, &
        ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, qv2qi_depos_tend, precip_total_tend, &
        nevapr, qr_evap_tend, vap_liq_exchange, vap_ice_exchange, liq_ice_exchange, pratot, &
@@ -476,10 +476,10 @@ contains
     logical(btype), intent(in) :: do_predict_nc, do_prescribed_CCN
     real(rtype), intent(in) :: dt, inv_dt
 
-    real(rtype), intent(in), dimension(kts:kte) :: pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l,  &
+    real(rtype), intent(in), dimension(kts:kte) :: pres, exner, inv_cld_frac_l,  &
          inv_cld_frac_i, inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r, qv_prev, t_prev
 
-    real(rtype), intent(inout), dimension(kts:kte) :: t_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn,        &
+    real(rtype), intent(inout), dimension(kts:kte) :: t_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofaci, acn,        &
          qv, th_atm, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, qc_incld, qr_incld,                    &
          qi_incld, qm_incld, nc_incld, nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1,      &
          cdistr, mu_r, lamr, logn0r, qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend, vap_liq_exchange,                            &
@@ -1363,11 +1363,11 @@ contains
        if (.not. (is_nucleat_possible .or. is_hydromet_present)) goto 333
 
        call p3_main_part2(kts, kte, kbot, ktop, kdir, do_predict_nc, do_prescribed_CCN, dt, inv_dt, &
-            pres(i,:), dpres(i,:), dz(i,:), nc_nuceat_tend(i,:), exner(i,:), inv_exner(i,:), &
+            pres(i,:), exner(i,:), &
             inv_cld_frac_l(i,:), inv_cld_frac_i(i,:), inv_cld_frac_r(i,:), ni_activated(i,:), inv_qc_relvar(i,:), &
             cld_frac_i(i,:), cld_frac_l(i,:), cld_frac_r(i,:), qv_prev(i,:), t_prev(i,:), &
             t_atm(i,:), rho(i,:), inv_rho(i,:), qv_sat_l(i,:), &
-            qv_sat_i(i,:), qv_supersat_i(i,:), rhofacr(i,:), rhofaci(i,:), acn(i,:), qv(i,:), th_atm(i,:), &
+            qv_sat_i(i,:), qv_supersat_i(i,:), rhofaci(i,:), acn(i,:), qv(i,:), th_atm(i,:), &
             qc(i,:), nc(i,:), qr(i,:), nr(i,:), qi(i,:), ni(i,:), qm(i,:), &
             bm(i,:), latent_heat_vapor(i,:), latent_heat_sublim(i,:), latent_heat_fusion(i,:), qc_incld(i,:), qr_incld(i,:), &
             qi_incld(i,:), qm_incld(i,:), nc_incld(i,:), nr_incld(i,:), ni_incld(i,:), &
@@ -3356,7 +3356,7 @@ qr2qv_evap_tend,nr_evap_tend)
    real(rtype), intent(in)  :: t,t_prev,latent_heat_sublim,dqsdt,dt
    real(rtype), intent(out) :: qr2qv_evap_tend
    real(rtype), intent(out) :: nr_evap_tend
-   real(rtype) :: cld_frac, eps_eff, tau_eff, tau_r, ssat_r, A_c, sup_r,inv_dt
+   real(rtype) :: cld_frac, eps_eff, tau_eff, tau_r, ssat_r, A_c, inv_dt
    real(rtype) :: equilib_evap_tend, tscale_weight, instant_evap_tend
 
    !Initialize variables
@@ -4023,7 +4023,7 @@ subroutine generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_
 
    type(realptr), intent(in), dimension(num_arrays), target :: vs, fluxes, qnx
 
-   integer :: tmpint1, k_temp, i
+   integer :: tmpint1, k_temp
    real(rtype) :: dt_sub
 
    !-- compute dt_sub

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -205,9 +205,9 @@ void p3_main_part1_c(
 
 void p3_main_part2_c(
   Int kts, Int kte, Int kbot, Int ktop, Int kdir, bool do_predict_nc, bool do_prescribed_CCN, Real dt, Real inv_dt,
-  Real* pres, Real* dpres, Real* dz, Real* nc_nuceat_tend, Real* exner, Real* inv_exner, Real* inv_cld_frac_l, Real* inv_cld_frac_i,
+  Real* pres, Real* exner, Real* inv_cld_frac_l, Real* inv_cld_frac_i,
   Real* inv_cld_frac_r, Real* ni_activated, Real* inv_qc_relvar, Real* cld_frac_i, Real* cld_frac_l, Real* cld_frac_r, Real* qv_prev, Real* t_prev,
-  Real* T_atm, Real* rho, Real* inv_rho, Real* qv_sat_l, Real* qv_sat_i, Real* qv_supersat_i, Real* rhofacr, Real* rhofaci, Real* acn,
+  Real* T_atm, Real* rho, Real* inv_rho, Real* qv_sat_l, Real* qv_sat_i, Real* qv_supersat_i, Real* rhofaci, Real* acn,
   Real* qv, Real* th_atm, Real* qc, Real* nc, Real* qr, Real* nr, Real* qi, Real* ni,
   Real* qm, Real* bm, Real* latent_heat_vapor, Real* latent_heat_sublim, Real* latent_heat_fusion, Real* qc_incld,
   Real* qr_incld, Real* qi_incld, Real* qm_incld, Real* nc_incld, Real* nr_incld,
@@ -777,9 +777,9 @@ void p3_main_part2(P3MainPart2Data& d)
   p3_init();
   p3_main_part2_c(
     d.kts, d.kte, d.kbot, d.ktop, d.kdir, d.do_predict_nc, d.do_prescribed_CCN, d.dt, d.inv_dt,
-    d.pres, d.dpres, d.dz, d.nc_nuceat_tend, d.exner, d.inv_exner, d.inv_cld_frac_l, d.inv_cld_frac_i, d.inv_cld_frac_r, d.ni_activated, d.inv_qc_relvar,
+    d.pres, d.exner, d.inv_cld_frac_l, d.inv_cld_frac_i, d.inv_cld_frac_r, d.ni_activated, d.inv_qc_relvar,
     d.cld_frac_i, d.cld_frac_l, d.cld_frac_r, d.qv_prev, d.t_prev,
-    d.T_atm, d.rho, d.inv_rho, d.qv_sat_l, d.qv_sat_i, d.qv_supersat_i, d.rhofacr, d.rhofaci, d.acn, d.qv, d.th_atm, d.qc, d.nc, d.qr, d.nr, d.qi, d.ni,
+    d.T_atm, d.rho, d.inv_rho, d.qv_sat_l, d.qv_sat_i, d.qv_supersat_i, d.rhofaci, d.acn, d.qv, d.th_atm, d.qc, d.nc, d.qr, d.nr, d.qi, d.ni,
     d.qm, d.bm, d.latent_heat_vapor, d.latent_heat_sublim, d.latent_heat_fusion, d.qc_incld, d.qr_incld, d.qi_incld, d.qm_incld, d.nc_incld, d.nr_incld,
     d.ni_incld, d.bm_incld, d.mu_c, d.nu, d.lamc, d.cdist, d.cdist1, d.cdistr, d.mu_r, d.lamr, d.logn0r, d.qv2qi_depos_tend, d.precip_total_tend,
     d.nevapr, d.qr_evap_tend, d.vap_liq_exchange, d.vap_ice_exchange, d.liq_ice_exchange, d.pratot,

--- a/components/scream/src/physics/p3/p3_iso_c.f90
+++ b/components/scream/src/physics/p3/p3_iso_c.f90
@@ -869,9 +869,9 @@ subroutine  update_prognostic_ice_c(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
  end subroutine p3_main_part1_c
 
  subroutine p3_main_part2_c(kts, kte, kbot, ktop, kdir, do_predict_nc, do_prescribed_CCN, dt, inv_dt, &
-       pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, &
+       pres, exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, &
        ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r, qv_prev, t_prev, &
-       T_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, qv, th_atm, qc, nc, qr, nr, qi, ni, &
+       T_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofaci, acn, qv, th_atm, qc, nc, qr, nr, qi, ni, &
        qm, bm, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, qc_incld, qr_incld, qi_incld, qm_incld, nc_incld, nr_incld, &
        ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, qv2qi_depos_tend, precip_total_tend, &
        nevapr, qr_evap_tend, vap_liq_exchange, vap_ice_exchange, liq_ice_exchange, pratot, &
@@ -884,10 +884,10 @@ subroutine  update_prognostic_ice_c(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
    logical(kind=c_bool), value, intent(in) :: do_predict_nc, do_prescribed_CCN
    real(kind=c_real), value, intent(in) :: dt, inv_dt
 
-   real(kind=c_real), intent(in), dimension(kts:kte) :: pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l, inv_cld_frac_i, &
+   real(kind=c_real), intent(in), dimension(kts:kte) :: pres, exner, inv_cld_frac_l, inv_cld_frac_i, &
         inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r, qv_prev, t_prev
 
-   real(kind=c_real), intent(inout), dimension(kts:kte) :: T_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, &
+   real(kind=c_real), intent(inout), dimension(kts:kte) :: T_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofaci, acn, &
         qv, th_atm, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, qc_incld, qr_incld, &
         qi_incld, qm_incld, nc_incld, nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, &
         cdistr, mu_r, lamr, logn0r, qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend, vap_liq_exchange, &
@@ -899,8 +899,8 @@ subroutine  update_prognostic_ice_c(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
    real(kind=c_real), dimension(kts:kte,49) :: p3_tend_out
 
    call p3_main_part2(kts, kte, kbot, ktop, kdir, do_predict_nc, do_prescribed_CCN, dt, inv_dt, &
-        pres, dpres, dz, nc_nuceat_tend, exner, inv_exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r, qv_prev, t_prev, &
-        T_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn, qv, th_atm, qc, nc, qr, nr, qi, ni, &
+        pres, exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i, cld_frac_l, cld_frac_r, qv_prev, t_prev, &
+        T_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofaci, acn, qv, th_atm, qc, nc, qr, nr, qi, ni, &
         qm, bm, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, qc_incld, qr_incld, qi_incld, qm_incld, nc_incld, nr_incld, &
         ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr, mu_r, lamr, logn0r, qv2qi_depos_tend, precip_total_tend, &
         nevapr, qr_evap_tend, vap_liq_exchange, vap_ice_exchange, liq_ice_exchange, pratot, &

--- a/components/scream/src/physics/p3/scream_p3_interface.F90
+++ b/components/scream/src/physics/p3/scream_p3_interface.F90
@@ -137,11 +137,8 @@ contains
     ! real(kind=c_real) :: rim(pcols,pver)        !rime mixing ratio                      kg/kg
     real(kind=c_real) :: precip_liq_surf(pcols)         !precipitation rate, liquid             m s-1
     real(kind=c_real) :: precip_ice_surf(pcols)         !precipitation rate, solid              m s-1
-    real(kind=c_real) :: diag_equiv_reflectivity(pcols,pver)    !equivalent reflectivity                dBZ
     ! real(kind=c_real) :: diag_eff_radius_qc(pcols,pver)  !effective radius, cloud                m
     ! real(kind=c_real) :: diag_eff_radius_qi(pcols,pver)  !effective radius, ice                  m
-    real(kind=c_real) :: diag_vm_qi(pcols,pver)   !mass-weighted fall speed of ice        m s-1
-    real(kind=c_real) :: diag_diam_qi(pcols,pver)    !mean diameter of ice                   m
     real(kind=c_real) :: rho_qi(pcols,pver)  !bulk density of ice                    kg m-1
     real(kind=c_real) :: precip_liq_flux(pcols,pver+1)     !grid-box average rain flux (kg m^-2s^-1) pverp
     real(kind=c_real) :: precip_ice_flux(pcols,pver+1)     !grid-box average ice/snow flux (kg m^-2s^-1) pverp
@@ -156,8 +153,6 @@ contains
     real(kind=c_real) :: precip_total_tend(pcols,pver)      !total precip
     real(kind=c_real) :: nevapr(pcols,pver)     !evap. of total precip
     real(kind=c_real) :: qr_evap_tend(pcols,pver)  !rain evaporation
-    real(kind=c_real) :: pratot(pcols,pver)     !accretion of cloud by rain
-    real(kind=c_real) :: prctot(pcols,pver)     !autoconversion of cloud by rain
     real(kind=c_real) :: mu(pcols,pver)         !Size distribution shape parameter for radiation
     real(kind=c_real) :: lambdac(pcols,pver)    !Size distribution slope parameter for radiation
     real(kind=c_real) :: dei(pcols,pver)        !Diameter for ice

--- a/components/scream/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
@@ -30,28 +30,28 @@ struct UnitWrap::UnitTest<D>::TestIceNucleation {
     //Loop over logicals being both true and false. Use boolean:integer equivalence to loop.
     for (int do_predict_nc =0; do_predict_nc<2; do_predict_nc++){
       for (int do_prescribed_CCN = 0; do_prescribed_CCN<2; do_prescribed_CCN++){
-    
+
 	IceNucleationData self[max_pack_size] = {
 	  // temp,    inv_rho,   ni,     ni_activated,      qv_supersat_i,      inv_dt, do_predict_nc, do_prescribed_CCN
-	  {2.106E+02, 8.852E-01, 0.974E+04, 9.221E+03, 5.100E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.052E+02, 8.852E-01, 0.874E+04, 8.221E+03, 4.100E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.352E+02, 8.900E-01, 0.723E+04, 7.221E+03, 3.100E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.212E+02, 9.900E-01, 0.623E+04, 6.221E+03, 2.100E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.106E+02, 8.852E-01, 0.974E+04, 9.221E+03, 5.100E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.052E+02, 8.852E-01, 0.874E+04, 8.221E+03, 4.100E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.352E+02, 8.900E-01, 0.723E+04, 7.221E+03, 3.100E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.212E+02, 9.900E-01, 0.623E+04, 6.221E+03, 2.100E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
 
-	  {2.251E+02, 0.100E+01, 0.574E+04, 5.221E+03, 1.100E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.710E+02, 0.100E+01, 0.474E+04, 4.221E+03, 8.100E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.052E+02, 0.100E+01, 0.323E+04, 3.221E+03, 4.100E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.502E+02, 0.100E+01, 0.223E+04, 2.221E+03, 2.100E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.251E+02, 0.100E+01, 0.574E+04, 5.221E+03, 1.100E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.710E+02, 0.100E+01, 0.474E+04, 4.221E+03, 8.100E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.052E+02, 0.100E+01, 0.323E+04, 3.221E+03, 4.100E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.502E+02, 0.100E+01, 0.223E+04, 2.221E+03, 2.100E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
 
-	  {2.552E+02, 0.950E+00, 0.150E+04, 9.221E+02, 9.952E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.452E+02, 0.950E+00, 0.974E+03, 8.221E+02, 4.952E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.352E+02, 0.950E+00, 0.823E+03, 7.221E+02, 1.952E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.252E+02, 0.950E+00, 0.723E+03, 6.221E+02, 9.952E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.552E+02, 0.950E+00, 0.150E+04, 9.221E+02, 9.952E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.452E+02, 0.950E+00, 0.974E+03, 8.221E+02, 4.952E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.352E+02, 0.950E+00, 0.823E+03, 7.221E+02, 1.952E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.252E+02, 0.950E+00, 0.723E+03, 6.221E+02, 9.952E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
 
-	  {1.990E+02, 1.069E+00, 0.674E+03, 5.221E+01, 6.952E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.952E+02, 1.069E+00, 0.574E+03, 4.221E+01, 3.952E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.852E+02, 1.069E+00, 0.423E+03, 3.221E+01, 1.952E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
-	  {2.702E+02, 1.069E+00, 0.323E+03, 2.221E+01, 9.952E-01, inv_dt, do_predict_nc, do_prescribed_CCN }
+	  {1.990E+02, 1.069E+00, 0.674E+03, 5.221E+01, 6.952E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.952E+02, 1.069E+00, 0.574E+03, 4.221E+01, 3.952E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.852E+02, 1.069E+00, 0.423E+03, 3.221E+01, 1.952E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.702E+02, 1.069E+00, 0.323E+03, 2.221E+01, 9.952E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 }
 	};
 
 	// Run the fortran code
@@ -81,7 +81,7 @@ struct UnitWrap::UnitTest<D>::TestIceNucleation {
 	    // outputs
 	    Spack qv2qi_nucleat_tend{0.0};
 	    Spack ni_nucleat_tend{0.0};
-	    Functions::ice_nucleation(temp, inv_rho, ni, ni_activated, qv_supersat_i, self_device(0).inv_dt, do_predict_nc, 
+	    Functions::ice_nucleation(temp, inv_rho, ni, ni_activated, qv_supersat_i, self_device(0).inv_dt, do_predict_nc,
 				      do_prescribed_CCN, qv2qi_nucleat_tend, ni_nucleat_tend);
 
 	    for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {
@@ -91,7 +91,7 @@ struct UnitWrap::UnitTest<D>::TestIceNucleation {
 	  });
 
 	Kokkos::deep_copy(self_host, self_device);
-	
+
 	for (Int s = 0; s < max_pack_size; ++s) {
 	  REQUIRE(self[s].qv2qi_nucleat_tend == self_host(s).qv2qi_nucleat_tend);
 	  REQUIRE(self[s].ni_nucleat_tend    == self_host(s).ni_nucleat_tend);

--- a/components/scream/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
@@ -28,30 +28,30 @@ struct UnitWrap::UnitTest<D>::TestIceNucleation {
     constexpr Scalar inv_dt           = 9.558E-04;
 
     //Loop over logicals being both true and false. Use boolean:integer equivalence to loop.
-    for (int do_predict_nc =0; do_predict_nc<2; do_predict_nc++){
-      for (int do_prescribed_CCN = 0; do_prescribed_CCN<2; do_prescribed_CCN++){
+    for (bool do_predict_nc : {false, true}) {
+      for (bool do_prescribed_CCN : {false, true}) {
 
 	IceNucleationData self[max_pack_size] = {
 	  // temp,    inv_rho,   ni,     ni_activated,      qv_supersat_i,      inv_dt, do_predict_nc, do_prescribed_CCN
-	  {2.106E+02, 8.852E-01, 0.974E+04, 9.221E+03, 5.100E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.052E+02, 8.852E-01, 0.874E+04, 8.221E+03, 4.100E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.352E+02, 8.900E-01, 0.723E+04, 7.221E+03, 3.100E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.212E+02, 9.900E-01, 0.623E+04, 6.221E+03, 2.100E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.106E+02, 8.852E-01, 0.974E+04, 9.221E+03, 5.100E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.052E+02, 8.852E-01, 0.874E+04, 8.221E+03, 4.100E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.352E+02, 8.900E-01, 0.723E+04, 7.221E+03, 3.100E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.212E+02, 9.900E-01, 0.623E+04, 6.221E+03, 2.100E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
 
-	  {2.251E+02, 0.100E+01, 0.574E+04, 5.221E+03, 1.100E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.710E+02, 0.100E+01, 0.474E+04, 4.221E+03, 8.100E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.052E+02, 0.100E+01, 0.323E+04, 3.221E+03, 4.100E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.502E+02, 0.100E+01, 0.223E+04, 2.221E+03, 2.100E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.251E+02, 0.100E+01, 0.574E+04, 5.221E+03, 1.100E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.710E+02, 0.100E+01, 0.474E+04, 4.221E+03, 8.100E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.052E+02, 0.100E+01, 0.323E+04, 3.221E+03, 4.100E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.502E+02, 0.100E+01, 0.223E+04, 2.221E+03, 2.100E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
 
-	  {2.552E+02, 0.950E+00, 0.150E+04, 9.221E+02, 9.952E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.452E+02, 0.950E+00, 0.974E+03, 8.221E+02, 4.952E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.352E+02, 0.950E+00, 0.823E+03, 7.221E+02, 1.952E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.252E+02, 0.950E+00, 0.723E+03, 6.221E+02, 9.952E-02, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
+	  {2.552E+02, 0.950E+00, 0.150E+04, 9.221E+02, 9.952E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.452E+02, 0.950E+00, 0.974E+03, 8.221E+02, 4.952E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.352E+02, 0.950E+00, 0.823E+03, 7.221E+02, 1.952E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.252E+02, 0.950E+00, 0.723E+03, 6.221E+02, 9.952E-02, inv_dt, do_predict_nc, do_prescribed_CCN },
 
-	  {1.990E+02, 1.069E+00, 0.674E+03, 5.221E+01, 6.952E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.952E+02, 1.069E+00, 0.574E+03, 4.221E+01, 3.952E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.852E+02, 1.069E+00, 0.423E+03, 3.221E+01, 1.952E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 },
-	  {2.702E+02, 1.069E+00, 0.323E+03, 2.221E+01, 9.952E-01, inv_dt, do_predict_nc>0, do_prescribed_CCN>0 }
+	  {1.990E+02, 1.069E+00, 0.674E+03, 5.221E+01, 6.952E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.952E+02, 1.069E+00, 0.574E+03, 4.221E+01, 3.952E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.852E+02, 1.069E+00, 0.423E+03, 3.221E+01, 1.952E-01, inv_dt, do_predict_nc, do_prescribed_CCN },
+	  {2.702E+02, 1.069E+00, 0.323E+03, 2.221E+01, 9.952E-01, inv_dt, do_predict_nc, do_prescribed_CCN }
 	};
 
 	// Run the fortran code

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -115,7 +115,7 @@ struct Baseline {
     for (int i = i_start; i < i_end; ++i) { // predict_nc is false or true
       for (int j = j_start; j< j_end; ++j) { //prescribed_CCN is false or true
 	//                 initial condit,     dt,  nsteps, prescribe or predict nc, prescribe CCN or not
-	params_.push_back({ic::Factory::mixed, 300, nsteps, i,                       j });
+	params_.push_back({ic::Factory::mixed, 300, nsteps, i>0,                     j>0 });
       }
     }
   }

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -1252,10 +1252,7 @@ void linear_interp_f(Real* x1, Real* x2, Real* y1, Real* y2, Int km1, Int km2, I
 {
   using SHF = Functions<Real, DefaultDevice>;
 
-  using Scalar     = typename SHF::Scalar;
   using Spack      = typename SHF::Spack;
-  using Pack1d     = typename ekat::Pack<Real,1>;
-  using view_1d    = typename SHF::view_1d<Pack1d>;
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
@@ -1392,7 +1389,7 @@ void shoc_energy_integrals_f(Int shcol, Int nlev, Real *host_dse, Real *pdel,
   });
 
   // Sync back to host
-  std::vector<view_2d> inout_views = {se_int_d, ke_int_d, wv_int_d, wl_int_d};
+  std::vector<view_1d> inout_views = {se_int_d, ke_int_d, wv_int_d, wl_int_d};
   ekat::device_to_host({se_int,ke_int,wv_int,wl_int}, shcol, inout_views);
 }
 
@@ -1466,7 +1463,6 @@ void diag_second_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* q
           Real* wtke_sec, Real* w_sec)
 {
   using SHOC       = Functions<Real, DefaultDevice>;
-  using Scalar     = typename SHOC::Scalar;
   using Spack      = typename SHOC::Spack;
   using view_2d    = typename SHOC::view_2d<Spack>;
   using KT         = typename SHOC::KT;
@@ -1563,7 +1559,6 @@ void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Re
   using Scalar        = typename SHOC::Scalar;
   using Spack         = typename SHOC::Spack;
   using view_2d       = typename SHOC::view_2d<Spack>;
-  using view_1d       = typename SHOC::view_1d<Spack>;
   using KT            = typename SHOC::KT;
   using ExeSpace      = typename KT::ExeSpace;
   using MemberType    = typename SHOC::MemberType;
@@ -1772,8 +1767,8 @@ void check_length_scale_shoc_length_f(Int nlev, Int shcol, Real* host_dx, Real* 
   using MemberType = typename SHF::MemberType;
 
   // Sync to device
-  std::vector<view_1d, 2> temp_1d_d;
-  std::vector<view_2d, 1> temp_2d_d;
+  std::vector<view_1d> temp_1d_d(2);
+  std::vector<view_2d> temp_2d_d(1);
   ekat::host_to_device({host_dx,host_dy}, shcol, temp_1d_d);
   ekat::host_to_device({shoc_mix}, shcol, nlev, temp_2d_d, true);
 
@@ -1870,9 +1865,6 @@ void shoc_diag_obklen_f(Int shcol, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, R
   using Scalar     = typename SHF::Scalar;
   using Pack1d     = typename ekat::Pack<Real,1>;
   using view_1d    = typename SHF::view_1d<Pack1d>;
-  using KT         = typename SHF::KT;
-  using ExeSpace   = typename KT::ExeSpace;
-  using MemberType = typename SHF::MemberType;
 
   // Sync to device
   std::vector<view_1d> temp_d(7);
@@ -1939,7 +1931,7 @@ void shoc_pblintd_cldcheck_f(Int shcol, Int nlev, Int nlevi, Real* zi, Real* cld
     zi_2d  (cldcheck_2d[0]),
     cldn_2d(cldcheck_2d[1]);
 
-  std::vector<view_1d, 1> cldcheck_1d;
+  std::vector<view_1d> cldcheck_1d(1);
   ekat::host_to_device({pblh}, shcol, cldcheck_1d);
 
   view_1d pblh_1d (cldcheck_1d[0]);
@@ -2011,8 +2003,8 @@ void shoc_length_f(Int shcol, Int nlev, Int nlevi, Real* host_dx, Real* host_dy,
   std::vector<int> dim1_sizes(10, shcol);
   std::vector<int> dim2_sizes = {nlev, nlev, nlevi, nlev, nlevi,
                                  nlev, nlev, nlev,  nlev, nlev};
-  std::vector<const Real*, 10> ptr_array = {tke,      zt_grid, zi_grid, dz_zt, dz_zi,
-                                            wthv_sec, thetal,  thv,     brunt, shoc_mix};
+  std::vector<const Real*> ptr_array = {tke,      zt_grid, zi_grid, dz_zt, dz_zi,
+                                        wthv_sec, thetal,  thv,     brunt, shoc_mix};
   // Sync to device
   ekat::host_to_device({host_dx, host_dy, pblh}, shcol, temp_1d_d);
   ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d_d, true);
@@ -2881,7 +2873,7 @@ void vd_shoc_decomp_and_solve_f(Int shcol, Int nlev, Int nlevi, Int num_rhs, Rea
 
   std::vector<int> dim1_sizes(num_2d_arrays, shcol);
   std::vector<int> dim2_sizes = {nlevi, nlevi, nlev};
-  std::vector<const Real*, num_2d_arrays> ptr_array = {kv_term, tmpi, rdp_zt};
+  std::vector<const Real*> ptr_array = {kv_term, tmpi, rdp_zt};
 
   // Sync to device
   ekat::host_to_device({flux}, shcol, temp_1d_d);
@@ -2932,7 +2924,6 @@ void shoc_grid_f(Int shcol, Int nlev, Int nlevi, Real* zt_grid, Real* zi_grid, R
 {
   using SHF = Functions<Real, DefaultDevice>;
 
-  using Scalar     = typename SHF::Scalar;
   using Spack      = typename SHF::Spack;
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
@@ -2975,7 +2966,7 @@ void shoc_grid_f(Int shcol, Int nlev, Int nlevi, Real* zt_grid, Real* zi_grid, R
 
   // Sync back to host
   std::vector<view_2d> inout_views = {dz_zt_d, dz_zi_d, rho_zt_d};
-  ekat::device_to_host({dz_zt, dz_zi, rho_zt}, {shcol, shcol, shcol}, {nlev, nlevi, nlev}, inout_views, true);
+  ekat::device_to_host<Int>({dz_zt, dz_zi, rho_zt}, {shcol, shcol, shcol}, {nlev, nlevi, nlev}, inout_views, true);
 }
 
 void eddy_diffusivities_f(Int nlev, Int shcol, Real* obklen, Real* pblh, Real* zt_grid, Real* shoc_mix, Real* sterm_zt,

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -707,8 +707,8 @@ void diag_second_moments(DiagSecondMomentsData& d)
 {
   shoc_init(d.nlev, true);
   d.transpose<ekat::TransposeDirection::c2f>();
-  diag_second_moments_c(d.shcol, d.nlev, d.nlevi, d.thetal, d.qw, d.u_wind, d.v_wind, d.tke, d.isotropy, d.tkh, d.tk, 
-       d.dz_zi, d.zt_grid, d.zi_grid, d.shoc_mix, d.thl_sec, d.qw_sec, d.wthl_sec, d.wqw_sec, d.qwthl_sec, d.uw_sec, 
+  diag_second_moments_c(d.shcol, d.nlev, d.nlevi, d.thetal, d.qw, d.u_wind, d.v_wind, d.tke, d.isotropy, d.tkh, d.tk,
+       d.dz_zi, d.zt_grid, d.zi_grid, d.shoc_mix, d.thl_sec, d.qw_sec, d.wthl_sec, d.wqw_sec, d.qwthl_sec, d.uw_sec,
        d.vw_sec, d.wtke_sec, d.w_sec);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
@@ -717,8 +717,8 @@ void diag_second_shoc_moments(DiagSecondShocMomentsData& d)
 {
   shoc_init(d.nlev, true);
   d.transpose<ekat::TransposeDirection::c2f>();
-  diag_second_shoc_moments_c(d.shcol, d.nlev, d.nlevi, d.thetal, d.qw, d.u_wind, d.v_wind, d.tke, d.isotropy, d.tkh, 
-      d.tk, d.dz_zi, d.zt_grid, d.zi_grid, d.shoc_mix, d.wthl_sfc, d.wqw_sfc, d.uw_sfc, d.vw_sfc, d.thl_sec, d.qw_sec, 
+  diag_second_shoc_moments_c(d.shcol, d.nlev, d.nlevi, d.thetal, d.qw, d.u_wind, d.v_wind, d.tke, d.isotropy, d.tkh,
+      d.tk, d.dz_zi, d.zt_grid, d.zi_grid, d.shoc_mix, d.wthl_sfc, d.wqw_sfc, d.uw_sfc, d.vw_sfc, d.thl_sec, d.qw_sec,
       d.wthl_sec, d.wqw_sec, d.qwthl_sec, d.uw_sec, d.vw_sec, d.wtke_sec, d.w_sec);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
@@ -834,10 +834,10 @@ void calc_shoc_varorcovar_f(Int shcol, Int nlev, Int nlevi, Real tunefac,
 
   static constexpr Int num_arrays = 6;
 
-  Kokkos::Array<view_2d, num_arrays> temp_d;
-  Kokkos::Array<int, num_arrays> dim1_sizes     = {shcol,       shcol,  shcol, shcol,  shcol,  shcol};
-  Kokkos::Array<int, num_arrays> dim2_sizes     = {nlevi,       nlevi,  nlevi, nlev,   nlev,   nlevi};
-  Kokkos::Array<const Real*, num_arrays> ptr_array = {isotropy_zi, tkh_zi, dz_zi, invar1, invar2, varorcovar};
+  std::vector<view_2d> temp_d(num_arrays);
+  std::vector<int> dim1_sizes(num_arrays, shcol);
+  std::vector<int> dim2_sizes        = {nlevi,       nlevi,  nlevi, nlev,   nlev,   nlevi};
+  std::vector<const Real*> ptr_array = {isotropy_zi, tkh_zi, dz_zi, invar1, invar2, varorcovar};
 
   // Sync to device
   ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
@@ -867,8 +867,8 @@ void calc_shoc_varorcovar_f(Int shcol, Int nlev, Int nlevi, Real tunefac,
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {varorcovar_d};
-  ekat::device_to_host<int,1>({varorcovar}, {shcol}, {nlevi}, inout_views, true);
+  std::vector<view_2d> inout_views = {varorcovar_d};
+  ekat::device_to_host({varorcovar}, shcol, nlevi, inout_views, true);
 }
 
 void calc_shoc_vertflux_f(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
@@ -884,10 +884,10 @@ void calc_shoc_vertflux_f(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
 
   static constexpr Int num_arrays = 4;
 
-  Kokkos::Array<view_2d, num_arrays> temp_d;
-  Kokkos::Array<Int, num_arrays> dim1_sizes     = {shcol,  shcol, shcol, shcol};
-  Kokkos::Array<Int, num_arrays> dim2_sizes     = {nlevi,  nlevi, nlev,  nlevi};
-  Kokkos::Array<const Real*, num_arrays> ptr_array = {tkh_zi, dz_zi, invar, vertflux};
+  std::vector<view_2d> temp_d(num_arrays);
+  std::vector<Int> dim1_sizes(num_arrays, shcol);
+  std::vector<Int> dim2_sizes        = {nlevi,  nlevi, nlev,  nlevi};
+  std::vector<const Real*> ptr_array = {tkh_zi, dz_zi, invar, vertflux};
 
   // Sync to device
   ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
@@ -912,8 +912,8 @@ void calc_shoc_vertflux_f(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {vertflux_d};
-  ekat::device_to_host<Int,1>({vertflux}, {{shcol}}, {{nlevi}}, inout_views, true);
+  std::vector<view_2d> inout_views = {vertflux_d};
+  ekat::device_to_host({vertflux}, shcol, nlevi, inout_views, true);
 }
 
 void shoc_diag_second_moments_srf_f(Int shcol, Real* wthl_sfc, Real* uw_sfc, Real* vw_sfc, Real* ustar2, Real* wstar)
@@ -923,7 +923,7 @@ void shoc_diag_second_moments_srf_f(Int shcol, Real* wthl_sfc, Real* uw_sfc, Rea
   using Pack1      = typename ekat::Pack<Real, 1>;
   using view_1d    = typename SHOC::view_1d<Pack1>;
 
-  Kokkos::Array<view_1d, 3> temp_d;
+  std::vector<view_1d> temp_d(3);
   ekat::host_to_device({wthl_sfc, uw_sfc, vw_sfc}, shcol, temp_d);
 
   // inputs
@@ -951,8 +951,8 @@ void shoc_diag_second_moments_srf_f(Int shcol, Real* wthl_sfc, Real* uw_sfc, Rea
      wstar_d(i)[0]  = wstar_s;
    });
 
-  Kokkos::Array<view_1d, 2> out_views = {ustar2_d, wstar_d};
-  ekat::device_to_host({ustar2, wstar}, shcol, out_views);
+  std::vector<view_1d> inout_views = {ustar2_d, wstar_d};
+  ekat::device_to_host({ustar2, wstar}, shcol, inout_views);
 }
 
 void shoc_diag_second_moments_ubycond_f(Int shcol, Real* thl_sec, Real* qw_sec, Real* wthl_sec, Real* wqw_sec, Real* qwthl_sec, Real* uw_sec, Real* vw_sec,
@@ -996,7 +996,7 @@ void shoc_diag_second_moments_ubycond_f(Int shcol, Real* thl_sec, Real* qw_sec, 
 
   });
 
-  Kokkos::Array<view_1d, 8> host_views = {thl_sec_d, qw_sec_d, qwthl_sec_d, wthl_sec_d, wqw_sec_d, uw_sec_d, vw_sec_d, wtke_sec_d};
+  std::vector<view_1d> host_views = {thl_sec_d, qw_sec_d, qwthl_sec_d, wthl_sec_d, wqw_sec_d, uw_sec_d, vw_sec_d, wtke_sec_d};
 
   ekat::device_to_host({thl_sec, qw_sec, qwthl_sec, wthl_sec, wqw_sec, uw_sec, vw_sec, wtke_sec}, shcol, host_views);
 }
@@ -1015,15 +1015,13 @@ void update_host_dse_f(Int shcol, Int nlev, Real* thlm, Real* shoc_ql, Real* exn
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_1d, 1> temp_1d_d;
-  Kokkos::Array<view_2d, 5> temp_2d_d;
-  Kokkos::Array<int, 5> dim1_sizes     = {shcol,  shcol, shcol, shcol, shcol};
-  Kokkos::Array<int, 5> dim2_sizes     = {nlev,  nlev, nlev,  nlev, nlev};
-  Kokkos::Array<const Real*, 5> ptr_array = {thlm, shoc_ql, exner, zt_grid, host_dse};
+  std::vector<view_1d> temp_1d_d(1);
+  std::vector<view_2d> temp_2d_d(5);
+  std::vector<const Real*> ptr_array = {thlm,  shoc_ql, exner, zt_grid, host_dse};
 
   // Sync to device
   ekat::host_to_device({phis}, shcol, temp_1d_d);
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d_d, true);
+  ekat::host_to_device(ptr_array, shcol, nlev, temp_2d_d, true);
 
   view_1d phis_d(temp_1d_d[0]);
 
@@ -1050,8 +1048,8 @@ void update_host_dse_f(Int shcol, Int nlev, Real* thlm, Real* shoc_ql, Real* exn
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {host_dse_d};
-  ekat::device_to_host<int,1>({host_dse}, {shcol}, {nlev}, inout_views, true);
+  std::vector<view_2d> inout_views = {host_dse_d};
+  ekat::device_to_host({host_dse}, shcol, nlev, inout_views, true);
 }
 
 void compute_diag_third_shoc_moment_f(Int shcol, Int nlev, Int nlevi, Real* w_sec,
@@ -1068,25 +1066,20 @@ void compute_diag_third_shoc_moment_f(Int shcol, Int nlev, Int nlevi, Real* w_se
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_2d, 11> temp_d;
-  Kokkos::Array<size_t, 11> dim1_sizes     = {shcol,       shcol,
-                                              shcol,       shcol,
-                                              shcol,       shcol,
-                                              shcol,       shcol,
-                                              shcol,       shcol,
-                                              shcol};
-  Kokkos::Array<size_t, 11> dim2_sizes     = {nlev,        nlevi,
-                                              nlevi,       nlev,
-                                              nlev,        nlevi,
-                                              nlevi,       nlevi,
-                                              nlevi,       nlevi,
-                                              nlevi};
-  Kokkos::Array<const Real*, 11> ptr_array = {w_sec,       thl_sec,
-                                              wthl_sec,    tke,
-                                              dz_zt,       dz_zi,
-                                              isotropy_zi, brunt_zi,
-                                              w_sec_zi,    thetal_zi,
-                                              w3};
+  std::vector<view_2d> temp_d(11);
+  std::vector<Int> dim1_sizes(11, shcol);
+  std::vector<Int> dim2_sizes     = {nlev,        nlevi,
+                                     nlevi,       nlev,
+                                     nlev,        nlevi,
+                                     nlevi,       nlevi,
+                                     nlevi,       nlevi,
+                                     nlevi};
+  std::vector<const Real*> ptr_array = {w_sec,       thl_sec,
+                                        wthl_sec,    tke,
+                                        dz_zt,       dz_zi,
+                                        isotropy_zi, brunt_zi,
+                                        w_sec_zi,    thetal_zi,
+                                        w3};
 
   // Sync to device
   ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
@@ -1127,8 +1120,8 @@ void compute_diag_third_shoc_moment_f(Int shcol, Int nlev, Int nlevi, Real* w_se
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {w3_d};
-  ekat::device_to_host<int,1>({w3}, {shcol}, {nlevi}, inout_views, true);
+  std::vector<view_2d> inout_views = {w3_d};
+  ekat::device_to_host({w3}, shcol, nlevi, inout_views, true);
 }
 
 void shoc_pblintd_init_pot_f(Int shcol, Int nlev, Real *thl, Real* ql, Real* q,
@@ -1143,7 +1136,7 @@ void shoc_pblintd_init_pot_f(Int shcol, Int nlev, Real *thl, Real* ql, Real* q,
 
   static constexpr Int num_arrays = 3;
 
-  Kokkos::Array<view_2d, num_arrays> temp_d;
+  std::vector<view_2d> temp_d(num_arrays);
   ekat::host_to_device({thl, ql, q}, shcol, nlev, temp_d, true);
 
   view_2d thl_d(temp_d[0]),
@@ -1165,8 +1158,8 @@ void shoc_pblintd_init_pot_f(Int shcol, Int nlev, Real *thl, Real* ql, Real* q,
     SHOC::shoc_pblintd_init_pot(team, nlev, thl_1d, ql_1d, q_1d, thv_1d);
   });
 
-  Kokkos::Array<view_2d, 1> inout_views = {thv_d};
-  ekat::device_to_host<int,1>({thv}, {shcol}, {nlev}, inout_views, true);
+  std::vector<view_2d> inout_views = {thv_d};
+  ekat::device_to_host({thv}, shcol, nlev, inout_views, true);
 }
 
 void compute_shoc_mix_shoc_length_f(Int nlev, Int shcol, Real* tke, Real* brunt, Real* tscale,
@@ -1174,24 +1167,22 @@ void compute_shoc_mix_shoc_length_f(Int nlev, Int shcol, Real* tke, Real* brunt,
 {
   using SHF = Functions<Real, DefaultDevice>;
 
-   using Scalar     = typename SHF::Scalar;
-   using Spack      = typename SHF::Spack;
-   using Pack1d     = typename ekat::Pack<Real,1>;
-   using view_1d    = typename SHF::view_1d<Pack1d>;
-   using view_2d    = typename SHF::view_2d<Spack>;
-   using KT         = typename SHF::KT;
-   using ExeSpace   = typename KT::ExeSpace;
-   using MemberType = typename SHF::MemberType;
+  using Scalar     = typename SHF::Scalar;
+  using Spack      = typename SHF::Spack;
+  using Pack1d     = typename ekat::Pack<Real,1>;
+  using view_1d    = typename SHF::view_1d<Pack1d>;
+  using view_2d    = typename SHF::view_2d<Spack>;
+  using KT         = typename SHF::KT;
+  using ExeSpace   = typename KT::ExeSpace;
+  using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_1d, 2> temp_1d_d;
-  Kokkos::Array<view_2d, 4> temp_2d_d;
-  Kokkos::Array<size_t, 4> dim1_sizes     = {shcol, shcol, shcol,   shcol};
-  Kokkos::Array<size_t, 4> dim2_sizes     = {nlev,  nlev,  nlev,    nlev};
-  Kokkos::Array<const Real*, 4> ptr_array = {tke,   brunt, zt_grid, shoc_mix};
+  std::vector<view_1d> temp_1d_d(2);
+  std::vector<view_2d> temp_2d_d(4);
+  std::vector<const Real*> ptr_array = {tke,   brunt, zt_grid, shoc_mix};
 
   // Sync to device
   ekat::host_to_device({tscale,l_inf}, shcol, temp_1d_d);
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d_d, true);
+  ekat::host_to_device(ptr_array, shcol, nlev, temp_2d_d, true);
 
   view_1d
     tscale_d (temp_1d_d[0]),
@@ -1221,8 +1212,8 @@ void compute_shoc_mix_shoc_length_f(Int nlev, Int shcol, Real* tke, Real* brunt,
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {shoc_mix_d};
-  ekat::device_to_host<int,1>({shoc_mix}, {shcol}, {nlev}, inout_views, true);
+  std::vector<view_2d> inout_views = {shoc_mix_d};
+  ekat::device_to_host({shoc_mix}, shcol, nlev, inout_views, true);
 }
 
 void check_tke_f(Int shcol, Int nlev, Real* tke)
@@ -1234,7 +1225,7 @@ void check_tke_f(Int shcol, Int nlev, Real* tke)
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHOC::MemberType;
 
-  Kokkos::Array<view_2d, 1> temp_2d_d;
+  std::vector<view_2d> temp_2d_d(1);
 
   // Sync to device
   ekat::host_to_device({tke}, shcol, nlev, temp_2d_d, true);
@@ -1253,8 +1244,8 @@ void check_tke_f(Int shcol, Int nlev, Real* tke)
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {tke_d};
-  ekat::device_to_host<int,1>({tke}, {shcol}, {nlev}, inout_views, true);
+  std::vector<view_2d> inout_views = {tke_d};
+  ekat::device_to_host({tke}, shcol, nlev, inout_views, true);
 }
 
 void linear_interp_f(Real* x1, Real* x2, Real* y1, Real* y2, Int km1, Int km2, Int ncol, Real minthresh)
@@ -1270,10 +1261,10 @@ void linear_interp_f(Real* x1, Real* x2, Real* y1, Real* y2, Int km1, Int km2, I
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_2d, 3> temp_2d_d;
-  Kokkos::Array<size_t, 3> dim1_sizes     = {ncol, ncol, ncol};
-  Kokkos::Array<size_t, 3> dim2_sizes     = {km1,  km2,  km1};
-  Kokkos::Array<const Real*, 3> ptr_array = {x1,   x2,   y1};
+  std::vector<view_2d> temp_2d_d(3);
+  std::vector<Int> dim1_sizes(3, ncol);
+  std::vector<Int> dim2_sizes     = {km1,  km2,  km1};
+  std::vector<const Real*> ptr_array = {x1,   x2,   y1};
 
   // Sync to device
   ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d_d, true);
@@ -1298,8 +1289,8 @@ void linear_interp_f(Real* x1, Real* x2, Real* y1, Real* y2, Int km1, Int km2, I
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {y2_d};
-  ekat::device_to_host<int,1>({y2}, {ncol}, {km2}, inout_views, true);
+  std::vector<view_2d> inout_views = {y2_d};
+  ekat::device_to_host({y2}, ncol, km2, inout_views, true);
 }
 
 void clipping_diag_third_shoc_moments_f(Int nlevi, Int shcol, Real *w_sec_zi,
@@ -1313,13 +1304,9 @@ void clipping_diag_third_shoc_moments_f(Int nlevi, Int shcol, Real *w_sec_zi,
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_2d, 2> temp_d;
-  Kokkos::Array<size_t, 2> dim1_sizes     = {shcol, shcol};
-  Kokkos::Array<size_t, 2> dim2_sizes     = {nlevi, nlevi};
-  Kokkos::Array<const Real*, 2> ptr_array = {w_sec_zi, w3};
-
   // Sync to device
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+  std::vector<view_2d> temp_d(2);
+  ekat::host_to_device({w_sec_zi, w3}, shcol, nlevi, temp_d, true);
 
   view_2d
     w_sec_zi_d(temp_d[0]),
@@ -1337,8 +1324,8 @@ void clipping_diag_third_shoc_moments_f(Int nlevi, Int shcol, Real *w_sec_zi,
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {w3_d};
-  ekat::device_to_host<int,1>({w3}, {shcol}, {nlevi}, inout_views, true);
+  std::vector<view_2d> inout_views = {w3_d};
+  ekat::device_to_host({w3}, shcol, nlevi, inout_views, true);
 }
 
 void shoc_energy_integrals_f(Int shcol, Int nlev, Real *host_dse, Real *pdel,
@@ -1356,13 +1343,11 @@ void shoc_energy_integrals_f(Int shcol, Int nlev, Real *host_dse, Real *pdel,
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_2d, 6> temp_d;
-  Kokkos::Array<int, 6> dim1_sizes        = {shcol,   shcol, shcol, shcol, shcol,  shcol};
-  Kokkos::Array<int, 6> dim2_sizes        = {nlev,     nlev, nlev,  nlev,  nlev,   nlev};
-  Kokkos::Array<const Real*, 6> ptr_array = {host_dse, pdel, rtm,   rcm,   u_wind, v_wind};
+  std::vector<view_2d> temp_d(6);
+  std::vector<const Real*> ptr_array = {host_dse, pdel, rtm,   rcm,   u_wind, v_wind};
 
   // Sync to device
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+  ekat::host_to_device(ptr_array, shcol, nlev, temp_d, true);
 
   // inputs
   view_2d
@@ -1407,8 +1392,8 @@ void shoc_energy_integrals_f(Int shcol, Int nlev, Real *host_dse, Real *pdel,
   });
 
   // Sync back to host
-  Kokkos::Array<view_1d, 4> inout_views = {se_int_d, ke_int_d, wv_int_d, wl_int_d};
-  ekat::device_to_host<int,4>({se_int,ke_int,wv_int,wl_int},shcol,inout_views);
+  std::vector<view_2d> inout_views = {se_int_d, ke_int_d, wv_int_d, wl_int_d};
+  ekat::device_to_host({se_int,ke_int,wv_int,wl_int}, shcol, inout_views);
 }
 
 void diag_second_moments_lbycond_f(Int shcol, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* ustar2, Real* wstar,
@@ -1419,7 +1404,7 @@ void diag_second_moments_lbycond_f(Int shcol, Real* wthl_sfc, Real* wqw_sfc, Rea
   using Pack1      = typename ekat::Pack<Real, 1>;
   using view_1d    = typename SHOC::view_1d<Pack1>;
 
-  Kokkos::Array<view_1d, 6> lbycond_d;
+  std::vector<view_1d> lbycond_d(6);
   ekat::host_to_device({wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, ustar2, wstar}, shcol, lbycond_d);
 
   // inputs
@@ -1471,7 +1456,7 @@ void diag_second_moments_lbycond_f(Int shcol, Real* wthl_sfc, Real* wqw_sfc, Rea
     qwthlo_d (i)[0] = qwthlo_s;
   });
 
-  Kokkos::Array<view_1d, 8> host_views = {wthlo_d, wqwo_d, uwo_d, vwo_d, wtkeo_d, thlo_d, qwo_d, qwthlo_d};
+  std::vector<view_1d> host_views = {wthlo_d, wqwo_d, uwo_d, vwo_d, wtkeo_d, thlo_d, qwo_d, qwthlo_d};
   ekat::device_to_host({wthl_sec, wqw_sec, uw_sec, vw_sec, wtke_sec, thl_sec, qw_sec, qwthl_sec}, shcol, host_views);
 }
 
@@ -1488,13 +1473,12 @@ void diag_second_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* q
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHOC::MemberType;
 
-  Kokkos::Array<size_t, 20> dim1_array = {shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol,
-                            shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol};
-  Kokkos::Array<size_t, 20> dim2_array = {nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev, nlev,
-                            nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi};
+  std::vector<Int> dim1_array(20, shcol);
+  std::vector<Int> dim2_array = {nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev, nlev,
+                                 nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi};
 
-  Kokkos::Array<view_2d, 20> temp_2d;
-  Kokkos::Array<const Real*, 20> ptr_array = {thetal, qw, u_wind, v_wind, tke, isotropy, tkh, tk, zt_grid, shoc_mix,
+  std::vector<view_2d> temp_2d(20);
+  std::vector<const Real*> ptr_array = {thetal, qw, u_wind, v_wind, tke, isotropy, tkh, tk, zt_grid, shoc_mix,
                       thl_sec, qw_sec, wthl_sec, wqw_sec, qwthl_sec, uw_sec, vw_sec, wtke_sec, dz_zi, zi_grid};
 
   ekat::host_to_device(ptr_array, dim1_array, dim2_array, temp_2d, true);
@@ -1564,15 +1548,15 @@ void diag_second_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* q
 
   });
 
-  Kokkos::Array<size_t, 9> dim1 = {shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol};
-  Kokkos::Array<size_t, 9> dim2 = {nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlev };
-  Kokkos::Array<view_2d, 9> host_views = {thl_sec_2d, qw_sec_2d, wthl_sec_2d, wqw_sec_2d, qwthl_sec_2d, uw_sec_2d, vw_sec_2d, wtke_sec_2d, w_sec_2d};
+  std::vector<Int> dim1(9, shcol);
+  std::vector<Int> dim2 = {nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlev };
+  std::vector<view_2d> host_views = {thl_sec_2d, qw_sec_2d, wthl_sec_2d, wqw_sec_2d, qwthl_sec_2d, uw_sec_2d, vw_sec_2d, wtke_sec_2d, w_sec_2d};
   ekat::device_to_host({thl_sec, qw_sec, wthl_sec, wqw_sec, qwthl_sec, uw_sec, vw_sec, wtke_sec, w_sec}, dim1, dim2, host_views, true);
 }
 
-void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* tke, 
-                                Real* isotropy, Real* tkh, Real* tk, Real* dz_zi, Real* zt_grid, Real* zi_grid, Real* shoc_mix, 
-                                Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* thl_sec, Real* qw_sec, Real* wthl_sec, 
+void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* tke,
+                                Real* isotropy, Real* tkh, Real* tk, Real* dz_zi, Real* zt_grid, Real* zi_grid, Real* shoc_mix,
+                                Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* thl_sec, Real* qw_sec, Real* wthl_sec,
                                 Real* wqw_sec, Real* qwthl_sec, Real* uw_sec, Real* vw_sec, Real* wtke_sec, Real* w_sec)
 {
   using SHOC          = Functions<Real, DefaultDevice>;
@@ -1586,7 +1570,7 @@ void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Re
   using Pack1         = typename ekat::Pack<Real, 1>;
   using view_pack1_1d = typename SHOC::view_1d<Pack1>;
 
-  Kokkos::Array<view_pack1_1d, 4> pack1_1d;
+  std::vector<view_pack1_1d> pack1_1d(4);
   ekat::host_to_device({wthl_sfc, wqw_sfc, uw_sfc, vw_sfc}, shcol, pack1_1d);
 
   view_pack1_1d wthl_1d  (pack1_1d[0]),
@@ -1594,13 +1578,11 @@ void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Re
                 uw_1d    (pack1_1d[2]),
                 vw_1d    (pack1_1d[3]);
 
-  Kokkos::Array<size_t, 20> dim1_array = {shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol,
-                            shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol};
-  Kokkos::Array<size_t, 20> dim2_array = {nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev, nlev,
-                            nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi};
-
-  Kokkos::Array<view_2d, 20> temp_2d;
-  Kokkos::Array<const Real*, 20> ptr_array = {thetal, qw, u_wind, v_wind, tke, isotropy, tkh, tk, zt_grid, shoc_mix,
+  std::vector<Int> dim1_array(20, shcol);
+  std::vector<Int> dim2_array = {nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev,  nlev, nlev,
+                                 nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi};
+  std::vector<view_2d> temp_2d(20);
+  std::vector<const Real*> ptr_array = {thetal, qw, u_wind, v_wind, tke, isotropy, tkh, tk, zt_grid, shoc_mix,
                       thl_sec, qw_sec, wthl_sec, wqw_sec, qwthl_sec, uw_sec, vw_sec, wtke_sec, dz_zi, zi_grid};
 
   ekat::host_to_device(ptr_array, dim1_array, dim2_array, temp_2d, true);
@@ -1679,9 +1661,9 @@ void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Re
        uw_sec_1d, vw_sec_1d, wtke_sec_1d, w_sec_1d);
   });
 
-  Kokkos::Array<size_t, 9> dim1 = {shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol, shcol};
-  Kokkos::Array<size_t, 9> dim2 = {nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlev };
-  Kokkos::Array<view_2d, 9> host_2d_views = {thl_sec_2d, qw_sec_2d, wthl_sec_2d, wqw_sec_2d, qwthl_sec_2d, uw_sec_2d, vw_sec_2d, wtke_sec_2d, w_sec_2d};
+  std::vector<Int> dim1(9, shcol);
+  std::vector<Int> dim2 = {nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlevi, nlev };
+  std::vector<view_2d> host_2d_views = {thl_sec_2d, qw_sec_2d, wthl_sec_2d, wqw_sec_2d, qwthl_sec_2d, uw_sec_2d, vw_sec_2d, wtke_sec_2d, w_sec_2d};
   ekat::device_to_host({thl_sec, qw_sec, wthl_sec, wqw_sec, qwthl_sec, uw_sec, vw_sec, wtke_sec, w_sec}, dim1, dim2, host_2d_views, true);
 }
 
@@ -1695,10 +1677,10 @@ void compute_brunt_shoc_length_f(Int nlev, Int nlevi, Int shcol, Real* dz_zt, Re
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_2d, 4> temp_d;
-  Kokkos::Array<int, 4> dim1_sizes        = {shcol, shcol, shcol,  shcol};
-  Kokkos::Array<int, 4> dim2_sizes        = {nlev,  nlev,  nlevi,  nlev};
-  Kokkos::Array<const Real*, 4> ptr_array = {dz_zt, thv,   thv_zi, brunt};
+  std::vector<view_2d> temp_d(4);
+  std::vector<int> dim1_sizes(4, shcol);
+  std::vector<int> dim2_sizes        = {nlev,  nlev,  nlevi,  nlev};
+  std::vector<const Real*> ptr_array = {dz_zt, thv,   thv_zi, brunt};
 
   // Sync to device
   ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
@@ -1723,8 +1705,8 @@ void compute_brunt_shoc_length_f(Int nlev, Int nlevi, Int shcol, Real* dz_zt, Re
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {brunt_d};
-  ekat::device_to_host<int,1>({brunt}, {shcol}, {nlev}, inout_views, true);
+  std::vector<view_2d> inout_views = {brunt_d};
+  ekat::device_to_host({brunt}, shcol, nlev, inout_views, true);
 }
 
 void compute_l_inf_shoc_length_f(Int nlev, Int shcol, Real *zt_grid, Real *dz_zt,
@@ -1741,13 +1723,9 @@ void compute_l_inf_shoc_length_f(Int nlev, Int shcol, Real *zt_grid, Real *dz_zt
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_2d, 3> temp_d;
-  Kokkos::Array<int, 3> dim1_sizes        = {shcol,   shcol, shcol};
-  Kokkos::Array<int, 3> dim2_sizes        = {nlev,     nlev, nlev};
-  Kokkos::Array<const Real*, 3> ptr_array = {zt_grid, dz_zt, tke};
-
   // Sync to device
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+  std::vector<view_2d> temp_d(3);
+  ekat::host_to_device({zt_grid, dz_zt, tke}, shcol, nlev, temp_d, true);
 
   // inputs
   view_2d
@@ -1776,8 +1754,8 @@ void compute_l_inf_shoc_length_f(Int nlev, Int shcol, Real *zt_grid, Real *dz_zt
   });
 
   // Sync back to host
-  Kokkos::Array<view_1d, 1> inout_views = {l_inf_d};
-  ekat::device_to_host<int,1>({l_inf},shcol,inout_views);
+  std::vector<view_1d> inout_views = {l_inf_d};
+  ekat::device_to_host({l_inf}, shcol, inout_views);
 }
 
 void check_length_scale_shoc_length_f(Int nlev, Int shcol, Real* host_dx, Real* host_dy, Real* shoc_mix)
@@ -1793,15 +1771,11 @@ void check_length_scale_shoc_length_f(Int nlev, Int shcol, Real* host_dx, Real* 
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_1d, 2> temp_1d_d;
-  Kokkos::Array<view_2d, 1> temp_2d_d;
-  Kokkos::Array<int, 1> dim1_sizes        = {shcol};
-  Kokkos::Array<int, 1> dim2_sizes        = {nlev};
-  Kokkos::Array<const Real*, 1> ptr_array = {shoc_mix};
-
   // Sync to device
+  std::vector<view_1d, 2> temp_1d_d;
+  std::vector<view_2d, 1> temp_2d_d;
   ekat::host_to_device({host_dx,host_dy}, shcol, temp_1d_d);
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d_d, true);
+  ekat::host_to_device({shoc_mix}, shcol, nlev, temp_2d_d, true);
 
   view_1d
     host_dx_d(temp_1d_d[0]),
@@ -1823,8 +1797,8 @@ void check_length_scale_shoc_length_f(Int nlev, Int shcol, Real* host_dx, Real* 
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {shoc_mix_d};
-  ekat::device_to_host<int,1>({shoc_mix}, {shcol}, {nlev}, inout_views, true);
+  std::vector<view_2d> inout_views = {shoc_mix_d};
+  ekat::device_to_host({shoc_mix}, shcol, nlev, inout_views, true);
 }
 
 void compute_conv_vel_shoc_length_f(Int nlev, Int shcol, Real *pblh, Real *zt_grid,
@@ -1842,15 +1816,11 @@ void compute_conv_vel_shoc_length_f(Int nlev, Int shcol, Real *pblh, Real *zt_gr
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_1d, 1> temp_1d_d;
-  Kokkos::Array<view_2d, 4> temp_2d_d;
-  Kokkos::Array<int, 4> dim1_sizes        = {shcol,   shcol, shcol, shcol};
-  Kokkos::Array<int, 4> dim2_sizes        = {nlev,     nlev, nlev,  nlev};
-  Kokkos::Array<const Real*, 4> ptr_array = {zt_grid, dz_zt, thv,   wthv_sec};
-
   // Sync to device
+  std::vector<view_1d> temp_1d_d(1);
+  std::vector<view_2d> temp_2d_d(4);
   ekat::host_to_device({pblh}, shcol, temp_1d_d);
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d_d, true);
+  ekat::host_to_device({zt_grid, dz_zt, thv, wthv_sec}, shcol, nlev, temp_2d_d, true);
 
   // inputs
   view_1d
@@ -1888,8 +1858,8 @@ void compute_conv_vel_shoc_length_f(Int nlev, Int shcol, Real *pblh, Real *zt_gr
   });
 
   // Sync back to host
-  Kokkos::Array<view_1d, 1> inout_views = {conv_vel_d};
-  ekat::device_to_host<int,1>({conv_vel},shcol,inout_views);
+  std::vector<view_1d> inout_views = {conv_vel_d};
+  ekat::device_to_host({conv_vel}, shcol, inout_views);
 }
 
 void shoc_diag_obklen_f(Int shcol, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, Real* wqw_sfc, Real* thl_sfc,
@@ -1904,11 +1874,10 @@ void shoc_diag_obklen_f(Int shcol, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, R
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_1d, 7> temp_d;
-  Kokkos::Array<const Real*, 7> ptr_array = {uw_sfc, vw_sfc, wthl_sfc, wqw_sfc, thl_sfc,
-                                             cldliq_sfc, qv_sfc};
-
   // Sync to device
+  std::vector<view_1d> temp_d(7);
+  std::vector<const Real*> ptr_array = {uw_sfc, vw_sfc, wthl_sfc, wqw_sfc, thl_sfc,
+                                        cldliq_sfc, qv_sfc};
   ekat::host_to_device(ptr_array, shcol, temp_d);
 
   // Inputs
@@ -1949,8 +1918,8 @@ void shoc_diag_obklen_f(Int shcol, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, R
   });
 
   // Sync back to host
-  Kokkos::Array<view_1d, 3> inout_views = {ustar_d, kbfs_d, obklen_d};
-  ekat::device_to_host<int,3>({ustar, kbfs, obklen}, shcol, inout_views);
+  std::vector<view_1d> inout_views = {ustar_d, kbfs_d, obklen_d};
+  ekat::device_to_host({ustar, kbfs, obklen}, shcol, inout_views);
 }
 
 void shoc_pblintd_cldcheck_f(Int shcol, Int nlev, Int nlevi, Real* zi, Real* cldn, Real* pblh) {
@@ -1960,17 +1929,17 @@ void shoc_pblintd_cldcheck_f(Int shcol, Int nlev, Int nlevi, Real* zi, Real* cld
   using view_2d = typename SHOC::view_2d<Pack1>;
   using view_1d = typename SHOC::view_1d<Pack1>;
 
-  Kokkos::Array<size_t, 2> dim1  = {shcol, shcol};
-  Kokkos::Array<size_t, 2> dim2  = {nlevi,  nlev};
+  std::vector<Int> dim1(2, shcol);
+  std::vector<Int> dim2  = {nlevi,  nlev};
 
-  Kokkos::Array<view_2d, 2> cldcheck_2d;
+  std::vector<view_2d> cldcheck_2d(2);
   ekat::host_to_device({zi, cldn}, dim1, dim2, cldcheck_2d, true);
 
   view_2d
-         zi_2d  (cldcheck_2d[0]),
-         cldn_2d(cldcheck_2d[1]);
+    zi_2d  (cldcheck_2d[0]),
+    cldn_2d(cldcheck_2d[1]);
 
-  Kokkos::Array<view_1d, 1> cldcheck_1d;
+  std::vector<view_1d, 1> cldcheck_1d;
   ekat::host_to_device({pblh}, shcol, cldcheck_1d);
 
   view_1d pblh_1d (cldcheck_1d[0]);
@@ -1987,9 +1956,8 @@ void shoc_pblintd_cldcheck_f(Int shcol, Int nlev, Int nlevi, Real* zi, Real* cld
 
   });
 
-  Kokkos::Array<view_1d, 1> host_views = {pblh_1d};
-
-  ekat::device_to_host<int,1>({pblh}, shcol, host_views);
+  std::vector<view_1d> inout_views = {pblh_1d};
+  ekat::device_to_host({pblh}, shcol, inout_views);
 }
 
 void compute_conv_time_shoc_length_f(Int shcol, Real *pblh, Real *conv_vel, Real *tscale)
@@ -1999,7 +1967,7 @@ void compute_conv_time_shoc_length_f(Int shcol, Real *pblh, Real *conv_vel, Real
   using Pack1      = typename ekat::Pack<Real, 1>;
   using view_1d    = typename SHF::view_1d<Pack1>;
 
-  Kokkos::Array<view_1d, 3> temp_d;
+  std::vector<view_1d> temp_d(3);
   ekat::host_to_device({pblh, conv_vel, tscale}, shcol, temp_d);
 
   view_1d
@@ -2019,7 +1987,7 @@ void compute_conv_time_shoc_length_f(Int shcol, Real *pblh, Real *conv_vel, Real
      tscale_d(i)[0]  = tscale_s;
    });
 
-  Kokkos::Array<view_1d, 2> inout_views = {conv_vel_d, tscale_d};
+  std::vector<view_1d> inout_views = {conv_vel_d, tscale_d};
   ekat::device_to_host({conv_vel, tscale}, shcol, inout_views);
 }
 
@@ -2038,14 +2006,13 @@ void shoc_length_f(Int shcol, Int nlev, Int nlevi, Real* host_dx, Real* host_dy,
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_1d, 3> temp_1d_d;
-  Kokkos::Array<view_2d, 10> temp_2d_d;
-  Kokkos::Array<int, 10> dim1_sizes = {shcol, shcol, shcol, shcol, shcol,
-                                       shcol, shcol, shcol, shcol, shcol};
-  Kokkos::Array<int, 10> dim2_sizes = {nlev, nlev, nlevi, nlev, nlevi,
-                                       nlev, nlev, nlev,  nlev, nlev};
-  Kokkos::Array<const Real*, 10> ptr_array = {tke,      zt_grid, zi_grid, dz_zt, dz_zi,
-                                              wthv_sec, thetal,  thv,     brunt, shoc_mix};
+  std::vector<view_1d> temp_1d_d(3);
+  std::vector<view_2d> temp_2d_d(10);
+  std::vector<int> dim1_sizes(10, shcol);
+  std::vector<int> dim2_sizes = {nlev, nlev, nlevi, nlev, nlevi,
+                                 nlev, nlev, nlev,  nlev, nlev};
+  std::vector<const Real*, 10> ptr_array = {tke,      zt_grid, zi_grid, dz_zt, dz_zi,
+                                            wthv_sec, thetal,  thv,     brunt, shoc_mix};
   // Sync to device
   ekat::host_to_device({host_dx, host_dy, pblh}, shcol, temp_1d_d);
   ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d_d, true);
@@ -2099,8 +2066,8 @@ void shoc_length_f(Int shcol, Int nlev, Int nlevi, Real* host_dx, Real* host_dy,
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 2> out_views = {brunt_d,shoc_mix_d};
-  ekat::device_to_host<int,2>({brunt,shoc_mix},shcol,nlev,out_views,true);
+  std::vector<view_2d> inout_views = {brunt_d,shoc_mix_d};
+  ekat::device_to_host({brunt,shoc_mix}, shcol, nlev, inout_views, true);
 }
 
 void shoc_energy_fixer_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* zt_grid,
@@ -2120,16 +2087,15 @@ void shoc_energy_fixer_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, R
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_1d, 10> temp_1d_d;
-  Kokkos::Array<const Real*, 10> ptr_array_1d = {se_b, ke_b, wv_b, wl_b,     se_a,
-                                                 ke_a, wv_a, wl_a, wthl_sfc, wqw_sfc};
-  Kokkos::Array<view_2d, 6> temp_2d_d;
-  Kokkos::Array<int, 6> dim1_sizes           = {shcol,   shcol,   shcol,
-                                                shcol,   shcol,   shcol};
-  Kokkos::Array<int, 6> dim2_sizes           = {nlev,    nlevi,   nlevi,
-                                                nlev,    nlev,    nlev};
-  Kokkos::Array<const Real*, 6> ptr_array_2d = {zt_grid, zi_grid, pint,
-                                                rho_zt,  tke,     host_dse};
+  std::vector<view_1d> temp_1d_d(10);
+  std::vector<const Real*> ptr_array_1d = {se_b, ke_b, wv_b, wl_b,     se_a,
+                                           ke_a, wv_a, wl_a, wthl_sfc, wqw_sfc};
+  std::vector<view_2d> temp_2d_d(6);
+  std::vector<int> dim1_sizes(6, shcol);
+  std::vector<int> dim2_sizes           = {nlev,    nlevi,   nlevi,
+                                           nlev,    nlev,    nlev};
+  std::vector<const Real*> ptr_array_2d = {zt_grid, zi_grid, pint,
+                                           rho_zt,  tke,     host_dse};
 
   // Sync to device
   ekat::host_to_device(ptr_array_1d, shcol, temp_1d_d);
@@ -2188,8 +2154,8 @@ void shoc_energy_fixer_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, R
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {host_dse_d};
-  ekat::device_to_host<int,1>({host_dse}, {shcol}, {nlev}, inout_views, true);
+  std::vector<view_2d> inout_views = {host_dse_d};
+  ekat::device_to_host({host_dse}, shcol, nlev, inout_views, true);
 }
 
 void compute_shoc_vapor_f(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv)
@@ -2204,13 +2170,9 @@ void compute_shoc_vapor_f(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv)
 
   static constexpr Int num_arrays = 3;
 
-  Kokkos::Array<view_2d, num_arrays> temp_d;
-  Kokkos::Array<int, num_arrays> dim1_sizes = {shcol, shcol, shcol};
-  Kokkos::Array<int, num_arrays> dim2_sizes = {nlev,  nlev,  nlev};
-  Kokkos::Array<const Real*, num_arrays> ptr_array = {qw,  ql, qv};
-
   // Sync to device
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+  std::vector<view_2d> temp_d(num_arrays);
+  ekat::host_to_device( {qw,  ql, qv}, shcol, nlev, temp_d, true);
 
   // Inputs/Outputs
   view_2d
@@ -2231,8 +2193,8 @@ void compute_shoc_vapor_f(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv)
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> out_views = {qv_d};
-  ekat::device_to_host<int, 1>({qv}, {shcol}, {nlev}, out_views, true);
+  std::vector<view_2d> inout_views = {qv_d};
+  ekat::device_to_host({qv}, shcol, nlev, inout_views, true);
 }
 
 void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_tracer, Real dtime,
@@ -2256,19 +2218,17 @@ void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_trace
 
   static constexpr Int num_2d_arrays = 13;
 
-  Kokkos::Array<view_1d, 4> temp_1d_d;
-  Kokkos::Array<view_2d, num_2d_arrays> temp_2d_d;
-  Kokkos::Array<view_3d, 1> temp_3d_d;
+  std::vector<view_1d> temp_1d_d(4);
+  std::vector<view_2d> temp_2d_d(num_2d_arrays);
+  std::vector<view_3d> temp_3d_d(1);
 
-  Kokkos::Array<int, num_2d_arrays> dim1_sizes = {shcol, shcol, shcol, shcol, shcol,
-                                                  shcol, shcol, shcol, shcol, shcol,
-                                                  shcol, shcol, shcol};
-  Kokkos::Array<int, num_2d_arrays> dim2_sizes = {nlev, nlevi, nlev,       nlev, nlevi,
-                                                  nlev, nlev,  num_tracer, nlev, nlev,
-                                                  nlev, nlev,  nlev};
-  Kokkos::Array<const Real*, num_2d_arrays> ptr_array = {dz_zt, dz_zi,  rho_zt,       zt_grid, zi_grid,
-                                                         tk,    tkh,    wtracer_sfc,  thetal,  qw,
-                                                         tke,   u_wind, v_wind};
+  std::vector<int> dim1_sizes(num_2d_arrays, shcol);
+  std::vector<int> dim2_sizes = {nlev, nlevi, nlev,       nlev, nlevi,
+                                 nlev, nlev,  num_tracer, nlev, nlev,
+                                 nlev, nlev,  nlev};
+  std::vector<const Real*> ptr_array = {dz_zt, dz_zi,  rho_zt,       zt_grid, zi_grid,
+                                        tk,    tkh,    wtracer_sfc,  thetal,  qw,
+                                        tke,   u_wind, v_wind};
 
   // Sync to device
   ekat::host_to_device({uw_sfc, vw_sfc, wthl_sfc, wqw_sfc}, shcol, temp_1d_d);
@@ -2362,11 +2322,11 @@ void update_prognostics_implicit_f(Int shcol, Int nlev, Int nlevi, Int num_trace
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 5> inout_views_2d = {thetal_d, qw_d, u_wind_d, v_wind_d, tke_d};
-  ekat::device_to_host<int,5>({thetal, qw, u_wind, v_wind, tke}, {shcol}, {nlev}, inout_views_2d, true);
+  std::vector<view_2d> inout_views_2d = {thetal_d, qw_d, u_wind_d, v_wind_d, tke_d};
+  ekat::device_to_host({thetal, qw, u_wind, v_wind, tke}, shcol, nlev, inout_views_2d, true);
 
-  Kokkos::Array<view_3d, 1> inout_views_3d = {tracer_d};
-  ekat::device_to_host<int,1>({tracer}, shcol, nlev, num_tracer, inout_views_3d, true);
+  std::vector<view_3d> inout_views = {tracer_d};
+  ekat::device_to_host({tracer}, shcol, nlev, num_tracer, inout_views, true);
 }
 
 void diag_third_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* w_sec, Real* thl_sec,
@@ -2382,16 +2342,14 @@ void diag_third_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* w_sec, Real
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_2d, 12> temp_d;
-  Kokkos::Array<int, 12> dim1_sizes = {shcol, shcol, shcol, shcol,
-                                       shcol, shcol, shcol, shcol,
-                                       shcol, shcol, shcol, shcol};
-  Kokkos::Array<int, 12> dim2_sizes = {nlev, nlevi, nlevi,  nlev,
-                                       nlev,  nlev,  nlev,  nlev,
-                                       nlevi, nlev,  nlevi, nlevi};
-  Kokkos::Array<const Real*, 12> ptr_array = {w_sec, thl_sec, wthl_sec, isotropy,
-                                              brunt, thetal,  tke,      dz_zt,
-                                              dz_zi, zt_grid, zi_grid,  w3};
+  std::vector<view_2d> temp_d(12);
+  std::vector<int> dim1_sizes(12, shcol);
+  std::vector<int> dim2_sizes = {nlev, nlevi, nlevi,  nlev,
+                                 nlev,  nlev,  nlev,  nlev,
+                                 nlevi, nlev,  nlevi, nlevi};
+  std::vector<const Real*> ptr_array = {w_sec, thl_sec, wthl_sec, isotropy,
+                                        brunt, thetal,  tke,      dz_zt,
+                                        dz_zi, zt_grid, zi_grid,  w3};
 
   // Sync to device
   ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
@@ -2447,8 +2405,8 @@ void diag_third_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* w_sec, Real
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> inout_views = {w3_d};
-  ekat::device_to_host<int,1>({w3}, shcol, nlevi, inout_views, true);
+  std::vector<view_2d> inout_views = {w3_d};
+  ekat::device_to_host({w3}, shcol, nlevi, inout_views, true);
 }
 
 void adv_sgs_tke_f(Int nlev, Int shcol, Real dtime, Real* shoc_mix, Real* wthv_sec,
@@ -2464,13 +2422,11 @@ void adv_sgs_tke_f(Int nlev, Int shcol, Real dtime, Real* shoc_mix, Real* wthv_s
 
   static constexpr Int num_arrays = 6;
 
-  Kokkos::Array<view_2d,     num_arrays> temp_d;
-  Kokkos::Array<int,         num_arrays> dim1_sizes = {shcol,    shcol,    shcol,    shcol, shcol, shcol };
-  Kokkos::Array<int,         num_arrays> dim2_sizes = {nlev,     nlev,     nlev,     nlev,  nlev,  nlev  };
-  Kokkos::Array<const Real*, num_arrays> ptr_array  = {shoc_mix, wthv_sec, sterm_zt, tk,    tke,   a_diss};
+  std::vector<view_2d> temp_d(num_arrays);
+  std::vector<const Real*> ptr_array  = {shoc_mix, wthv_sec, sterm_zt, tk,    tke,   a_diss};
 
   // Sync to device
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+  ekat::host_to_device(ptr_array, shcol, nlev, temp_d, true);
 
   view_2d
     //input
@@ -2500,8 +2456,8 @@ void adv_sgs_tke_f(Int nlev, Int shcol, Real dtime, Real* shoc_mix, Real* wthv_s
     });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 2> inout_views = {tke_d, a_diss_d};
-  ekat::device_to_host<int,2>({tke, a_diss}, {shcol}, {nlev}, inout_views, true);
+  std::vector<view_2d> inout_views = {tke_d, a_diss_d};
+  ekat::device_to_host({tke, a_diss}, shcol, nlev, inout_views, true);
 }
 
 void shoc_assumed_pdf_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, Real* w_field,
@@ -2519,16 +2475,14 @@ void shoc_assumed_pdf_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, 
 
   static constexpr Int num_arrays = 18;
 
-  Kokkos::Array<view_2d, num_arrays> temp_d;
-  Kokkos::Array<int, num_arrays> dim1_sizes = {shcol, shcol, shcol, shcol, shcol, shcol,
-                                               shcol, shcol, shcol, shcol, shcol, shcol,
-                                               shcol, shcol, shcol, shcol, shcol, shcol};
-  Kokkos::Array<int, num_arrays> dim2_sizes = {nlev,  nlev,  nlevi, nlevi, nlevi, nlev,
-                                               nlevi, nlevi, nlevi, nlev,  nlev,  nlev,
-                                               nlevi, nlev,  nlev,  nlev,  nlev,  nlev};
-  Kokkos::Array<const Real*, num_arrays> ptr_array = {thetal,  qw,           thl_sec, qw_sec,  wthl_sec, w_sec,
-                                                      wqw_sec, qwthl_sec,    w3,      w_field, pres,     zt_grid,
-                                                      zi_grid, shoc_cldfrac, shoc_ql, wqls,    wthv_sec, shoc_ql2};
+  std::vector<view_2d> temp_d(num_arrays);
+  std::vector<int> dim1_sizes(num_arrays, shcol);
+  std::vector<int> dim2_sizes = {nlev,  nlev,  nlevi, nlevi, nlevi, nlev,
+                                 nlevi, nlevi, nlevi, nlev,  nlev,  nlev,
+                                 nlevi, nlev,  nlev,  nlev,  nlev,  nlev};
+  std::vector<const Real*> ptr_array = {thetal,  qw,           thl_sec, qw_sec,  wthl_sec, w_sec,
+                                        wqw_sec, qwthl_sec,    w3,      w_field, pres,     zt_grid,
+                                        zi_grid, shoc_cldfrac, shoc_ql, wqls,    wthv_sec, shoc_ql2};
   // Sync to device
   ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
 
@@ -2599,8 +2553,8 @@ void shoc_assumed_pdf_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, 
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 5> out_views = {shoc_cldfrac_d, shoc_ql_d, wqls_d, wthv_sec_d, shoc_ql2_d};
-  ekat::device_to_host<int, 5>({shoc_cldfrac, shoc_ql, wqls, wthv_sec, shoc_ql2}, {shcol}, {nlev}, out_views, true);
+  std::vector<view_2d> out_views = {shoc_cldfrac_d, shoc_ql_d, wqls_d, wthv_sec_d, shoc_ql2_d};
+  ekat::device_to_host({shoc_cldfrac, shoc_ql, wqls, wthv_sec, shoc_ql2}, shcol, nlev, out_views, true);
 }
 void compute_shr_prod_f(Int nlevi, Int nlev, Int shcol, Real* dz_zi, Real* u_wind, Real* v_wind, Real* sterm)
 {
@@ -2614,10 +2568,10 @@ void compute_shr_prod_f(Int nlevi, Int nlev, Int shcol, Real* dz_zi, Real* u_win
 
   static constexpr Int num_arrays = 4;
 
-  Kokkos::Array<view_2d,     num_arrays> temp_d;
-  Kokkos::Array<int,         num_arrays> dim1_sizes = {shcol,  shcol,  shcol, shcol};
-  Kokkos::Array<int,         num_arrays> dim2_sizes = {nlevi,   nlev,   nlev, nlevi};
-  Kokkos::Array<const Real*, num_arrays> ptr_array  = {dz_zi, u_wind, v_wind, sterm};
+  std::vector<view_2d> temp_d(num_arrays);
+  std::vector<int> dim1_sizes(num_arrays, shcol);
+  std::vector<int> dim2_sizes = {nlevi,   nlev,   nlev, nlevi};
+  std::vector<const Real*> ptr_array  = {dz_zi, u_wind, v_wind, sterm};
 
   // Sync to device
   ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
@@ -2647,9 +2601,8 @@ void compute_shr_prod_f(Int nlevi, Int nlev, Int shcol, Real* dz_zi, Real* u_win
     });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> out_views = {sterm_d};
-  ekat::device_to_host<int, 1>({sterm}, {shcol}, {nlevi}, out_views, true);
-
+  std::vector<view_2d> inout_views = {sterm_d};
+  ekat::device_to_host({sterm}, shcol, nlevi, inout_views, true);
 }
 
 void compute_tmpi_f(Int nlevi, Int shcol, Real dtime, Real *rho_zi, Real *dz_zi, Real *tmpi)
@@ -2664,13 +2617,9 @@ void compute_tmpi_f(Int nlevi, Int shcol, Real dtime, Real *rho_zi, Real *dz_zi,
 
   static constexpr Int num_arrays = 3;
 
-  Kokkos::Array<view_2d, num_arrays> temp_d;
-  Kokkos::Array<int, num_arrays> dim1_sizes = {shcol, shcol, shcol};
-  Kokkos::Array<int, num_arrays> dim2_sizes = {nlevi, nlevi, nlevi};
-  Kokkos::Array<const Real*, num_arrays> ptr_array = {rho_zi,  dz_zi, tmpi};
-
   // Sync to device
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+  std::vector<view_2d> temp_d(num_arrays);
+  ekat::host_to_device({rho_zi,  dz_zi, tmpi}, shcol, nlevi, temp_d, true);
 
   // Inputs/Outputs
   view_2d
@@ -2691,8 +2640,8 @@ void compute_tmpi_f(Int nlevi, Int shcol, Real dtime, Real *rho_zi, Real *dz_zi,
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> out_views = {tmpi_d};
-  ekat::device_to_host<int, 1>({tmpi}, {shcol}, {nlevi}, out_views, true);
+  std::vector<view_2d> inout_views = {tmpi_d};
+  ekat::device_to_host({tmpi}, shcol, nlevi, inout_views, true);
 }
 
 void integ_column_stability_f(Int nlev, Int shcol, Real *dz_zt,
@@ -2711,13 +2660,9 @@ void integ_column_stability_f(Int nlev, Int shcol, Real *dz_zt,
 
   static constexpr Int num_arrays = 3;
 
-  Kokkos::Array<view_2d, num_arrays> temp_d;
-  Kokkos::Array<int, num_arrays> dim1_sizes = {shcol, shcol, shcol};
-  Kokkos::Array<int, num_arrays> dim2_sizes = {nlev,  nlev,  nlev};
-  Kokkos::Array<const Real*, num_arrays> ptr_array = {dz_zt, pres, brunt};
-
   // Sync to device
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+  std::vector<view_2d> temp_d(num_arrays);
+  ekat::host_to_device({dz_zt, pres, brunt}, shcol, nlev, temp_d, true);
 
   // Inputs
   view_2d
@@ -2749,8 +2694,8 @@ void integ_column_stability_f(Int nlev, Int shcol, Real *dz_zt,
     });
 
   // Sync back to host
-  Kokkos::Array<view_1d, 1> inout_views = {brunt_int_d};
-  ekat::device_to_host<int,1>({brunt_int},shcol,inout_views);
+  std::vector<view_1d> inout_views = {brunt_int_d};
+  ekat::device_to_host({brunt_int}, shcol, inout_views);
 }
 
 void isotropic_ts_f(Int nlev, Int shcol, Real* brunt_int, Real* tke,
@@ -2767,17 +2712,15 @@ void isotropic_ts_f(Int nlev, Int shcol, Real* brunt_int, Real* tke,
   using ExeSpace   = typename KT::ExeSpace;
   using MemberType = typename SHF::MemberType;
 
-  Kokkos::Array<view_1d, 1> temp_1d; // for 1d array
+  std::vector<view_1d> temp_1d(1); // for 1d array
 
   static constexpr Int num_arrays = 4;
-  Kokkos::Array<view_2d, num_arrays> temp_2d; //for 2d arrays
-  Kokkos::Array<int, num_arrays> dim1_sizes = {shcol, shcol, shcol, shcol};
-  Kokkos::Array<int, num_arrays> dim2_sizes = {nlev,  nlev,  nlev,  nlev};
-  Kokkos::Array<const Real*, num_arrays> ptr_array = {tke, a_diss, brunt, isotropy};
+  std::vector<view_2d> temp_2d(num_arrays); //for 2d arrays
+  std::vector<const Real*> ptr_array = {tke, a_diss, brunt, isotropy};
 
   // Sync to device
   ekat::host_to_device({brunt_int}, shcol, temp_1d);
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d, true);
+  ekat::host_to_device(ptr_array, shcol, nlev, temp_2d, true);
 
   //inputs
   view_1d brunt_int_d(temp_1d[0]);
@@ -2808,8 +2751,8 @@ void isotropic_ts_f(Int nlev, Int shcol, Real* brunt_int, Real* tke,
     });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> out_views = {isotropy_d};
-  ekat::device_to_host<int, 1>({isotropy}, {shcol}, {nlev}, out_views, true);
+  std::vector<view_2d> inout_views = {isotropy_d};
+  ekat::device_to_host({isotropy}, shcol, nlev, inout_views, true);
 
 }
 
@@ -2825,13 +2768,9 @@ void dp_inverse_f(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_zt)
 
   static constexpr Int num_arrays = 3;
 
-  Kokkos::Array<view_2d, num_arrays> temp_d;
-  Kokkos::Array<int, num_arrays> dim1_sizes = {shcol, shcol, shcol};
-  Kokkos::Array<int, num_arrays> dim2_sizes = {nlev,  nlev,  nlev};
-  Kokkos::Array<const Real*, num_arrays> ptr_array = {rho_zt,  dz_zt, rdp_zt};
-
   // Sync to device
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_d, true);
+  std::vector<view_2d> temp_d(num_arrays);
+  ekat::host_to_device({rho_zt,  dz_zt, rdp_zt}, shcol, nlev, temp_d, true);
 
   // Inputs/Outputs
   view_2d
@@ -2852,8 +2791,8 @@ void dp_inverse_f(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_zt)
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 1> out_views = {rdp_zt_d};
-  ekat::device_to_host<int, 1>({rdp_zt}, {shcol}, {nlev}, out_views, true);
+  std::vector<view_2d> inout_views = {rdp_zt_d};
+  ekat::device_to_host({rdp_zt}, shcol, nlev, inout_views, true);
 }
 
 void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* host_dx, Real* host_dy, Real* thv, Real* zt_grid, Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner, Real* phis, Real* host_dse, Real* tke, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk, Real* shoc_ql, Real* shoc_cldfrac, Real* pblh, Real* shoc_mix, Real* isotropy, Real* w_sec, Real* thl_sec, Real* qw_sec, Real* qwthl_sec, Real* wthl_sec, Real* wqw_sec, Real* wtke_sec, Real* uw_sec, Real* vw_sec, Real* w3, Real* wqls_sec, Real* brunt, Real* shoc_ql2)
@@ -2875,7 +2814,7 @@ void pblintd_init_f(Int shcol, Int nlev, Real* z, bool* check, Real* rino, Real*
   using view_1d    = typename SHOC::view_1d<Pack1>;
   using view_2d    = typename SHOC::view_2d<Spack>;
 
-  Kokkos::Array<view_2d, 2> views_2d;
+  std::vector<view_2d> views_2d(2);
   ekat::host_to_device({z, rino}, shcol, nlev, views_2d, true);
 
   view_2d z_2d   (views_2d[0]),
@@ -2905,14 +2844,10 @@ void pblintd_init_f(Int shcol, Int nlev, Real* z, bool* check, Real* rino, Real*
     pblh_d(i)[0] = pblh_s;
   });
 
-  Kokkos::Array<view_2d, 1> out_2d_views = {rino_2d};
-  ekat::device_to_host<int, 1>({rino}, shcol, nlev, out_2d_views, true);
-
-  Kokkos::Array<view_1d, 1> out_1d_views = {pblh_d};
-  ekat::device_to_host<int, 1>({pblh}, shcol, out_1d_views);
-
-//  Kokkos::Array<SHOC::view_1d<bool>, 1> out_1d_bool_views = {check_d};
-//  ekat::device_to_host<int, 1>({check}, shcol, out_1d_bool_views);
+  std::vector<view_1d> inout_views_1d = {pblh_d};
+  std::vector<view_2d> inout_views_2d = {rino_2d};
+  ekat::device_to_host({pblh}, shcol, inout_views_1d);
+  ekat::device_to_host({rino}, shcol, nlev, inout_views_2d, true);
 
   Kokkos::deep_copy(host_check_d, check_d);
   for (auto s = 0; s < shcol; ++s) {
@@ -2940,13 +2875,13 @@ void vd_shoc_decomp_and_solve_f(Int shcol, Int nlev, Int nlevi, Int num_rhs, Rea
   static constexpr Int num_2d_arrays = 3;
   static constexpr Int num_3d_arrays = 1;
 
-  Kokkos::Array<view_1d, num_1d_arrays> temp_1d_d;
-  Kokkos::Array<view_2d, num_2d_arrays> temp_2d_d;
-  Kokkos::Array<view_3d, num_3d_arrays> temp_3d_d;
+  std::vector<view_1d> temp_1d_d(num_1d_arrays);
+  std::vector<view_2d> temp_2d_d(num_2d_arrays);
+  std::vector<view_3d> temp_3d_d(num_3d_arrays);
 
-  Kokkos::Array<int, num_2d_arrays> dim1_sizes = {shcol, shcol, shcol};
-  Kokkos::Array<int, num_2d_arrays> dim2_sizes = {nlevi, nlevi, nlev};
-  Kokkos::Array<const Real*, num_2d_arrays> ptr_array = {kv_term, tmpi, rdp_zt};
+  std::vector<int> dim1_sizes(num_2d_arrays, shcol);
+  std::vector<int> dim2_sizes = {nlevi, nlevi, nlev};
+  std::vector<const Real*, num_2d_arrays> ptr_array = {kv_term, tmpi, rdp_zt};
 
   // Sync to device
   ekat::host_to_device({flux}, shcol, temp_1d_d);
@@ -2989,8 +2924,8 @@ void vd_shoc_decomp_and_solve_f(Int shcol, Int nlev, Int nlevi, Int num_rhs, Rea
   });
 
   // Sync back to host
-  Kokkos::Array<view_3d, 1> inout_views = {var_d};
-  ekat::device_to_host<int, 1>({var}, shcol, nlev, num_rhs, inout_views, true);
+  std::vector<view_3d> inout_views = {var_d};
+  ekat::device_to_host({var}, shcol, nlev, num_rhs, inout_views, true);
 }
 
 void shoc_grid_f(Int shcol, Int nlev, Int nlevi, Real* zt_grid, Real* zi_grid, Real* pdel, Real* dz_zt, Real* dz_zi, Real* rho_zt)
@@ -3005,13 +2940,12 @@ void shoc_grid_f(Int shcol, Int nlev, Int nlevi, Real* zt_grid, Real* zi_grid, R
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_2d_arrays = 6;
-  Kokkos::Array<view_2d, num_2d_arrays> temp_2d_d;
-  Kokkos::Array<int, num_2d_arrays> dim1_sizes = {shcol, shcol, shcol,
-                                                  shcol, shcol, shcol};
-  Kokkos::Array<int, num_2d_arrays> dim2_sizes = {nlev, nlevi, nlev,
-                                                  nlev, nlevi, nlev};
-  Kokkos::Array<const Real*, num_2d_arrays> ptr_array = {zt_grid, zi_grid, pdel,
-                                                         dz_zt,   dz_zi,   rho_zt};
+  std::vector<view_2d> temp_2d_d(num_2d_arrays);
+  std::vector<int> dim1_sizes(num_2d_arrays, shcol);
+  std::vector<int> dim2_sizes = {nlev, nlevi, nlev,
+                                 nlev, nlevi, nlev};
+  std::vector<const Real*> ptr_array = {zt_grid, zi_grid, pdel,
+                                        dz_zt,   dz_zi,   rho_zt};
 
   // Sync to device
   ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d_d, true);
@@ -3040,8 +2974,8 @@ void shoc_grid_f(Int shcol, Int nlev, Int nlevi, Real* zt_grid, Real* zi_grid, R
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 3> inout_views = {dz_zt_d, dz_zi_d, rho_zt_d};
-  ekat::device_to_host<int,3>({dz_zt, dz_zi, rho_zt}, {shcol, shcol, shcol}, {nlev, nlevi, nlev}, inout_views, true);
+  std::vector<view_2d> inout_views = {dz_zt_d, dz_zi_d, rho_zt_d};
+  ekat::device_to_host({dz_zt, dz_zi, rho_zt}, {shcol, shcol, shcol}, {nlev, nlevi, nlev}, inout_views, true);
 }
 
 void eddy_diffusivities_f(Int nlev, Int shcol, Real* obklen, Real* pblh, Real* zt_grid, Real* shoc_mix, Real* sterm_zt,
@@ -3061,19 +2995,15 @@ void eddy_diffusivities_f(Int nlev, Int shcol, Real* obklen, Real* pblh, Real* z
   static constexpr Int num_1d_arrays = 2;
   static constexpr Int num_2d_arrays = 7;
 
-  Kokkos::Array<view_1d, num_1d_arrays> temp_1d_d;
-  Kokkos::Array<view_2d, num_2d_arrays> temp_2d_d;
+  std::vector<view_1d> temp_1d_d(num_1d_arrays);
+  std::vector<view_2d> temp_2d_d(num_2d_arrays);
 
-  Kokkos::Array<int, num_2d_arrays> dim1_sizes = {shcol, shcol, shcol, shcol,
-                                                  shcol, shcol, shcol};
-  Kokkos::Array<int, num_2d_arrays> dim2_sizes = {nlev, nlev, nlev, nlev,
-                                                  nlev, nlev, nlev};
-  Kokkos::Array<const Real*, num_2d_arrays> ptr_array = {zt_grid, shoc_mix, sterm_zt, isotropy,
-                                                         tke,     tkh,      tk};
+  std::vector<const Real*> ptr_array = {zt_grid, shoc_mix, sterm_zt, isotropy,
+                                        tke,     tkh,      tk};
 
   // Sync to device
   ekat::host_to_device({obklen, pblh}, shcol, temp_1d_d);
-  ekat::host_to_device(ptr_array, dim1_sizes, dim2_sizes, temp_2d_d, true);
+  ekat::host_to_device(ptr_array, shcol, nlev, temp_2d_d, true);
 
   view_1d
     obklen_d(temp_1d_d[0]),
@@ -3108,8 +3038,8 @@ void eddy_diffusivities_f(Int nlev, Int shcol, Real* obklen, Real* pblh, Real* z
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 2> inout_views = {tkh_d, tk_d};
-  ekat::device_to_host<int,2>({tkh, tk}, shcol, nlev, inout_views, true);
+  std::vector<view_2d> inout_views = {tkh_d, tk_d};
+  ekat::device_to_host({tkh, tk}, shcol, nlev, inout_views, true);
 }
 
 void pblintd_surf_temp_f(Int shcol, Int nlev, Int nlevi, Real* z, Real* ustar, Real* obklen, Real* kbfs, Real* thv, Real* tlv, Real* pblh, bool* check, Real* rino)
@@ -3143,15 +3073,14 @@ void shoc_tke_f(Int shcol, Int nlev, Int nlevi, Real dtime, Real* wthv_sec, Real
   static constexpr Int num_1d_arrays = 2;
   static constexpr Int num_2d_arrays = 14;
 
-  Kokkos::Array<view_1d, num_1d_arrays> temp_1d_d;
-  Kokkos::Array<view_2d, num_2d_arrays> temp_2d_d;
+  std::vector<view_1d> temp_1d_d(num_1d_arrays);
+  std::vector<view_2d> temp_2d_d(num_2d_arrays);
 
-  Kokkos::Array<int, num_2d_arrays> dim1_sizes = {shcol, shcol, shcol, shcol, shcol, shcol, shcol,
-                                                  shcol, shcol, shcol, shcol, shcol, shcol, shcol};
-  Kokkos::Array<int, num_2d_arrays> dim2_sizes = {nlev, nlev, nlev,  nlev, nlevi, nlev, nlev,
-                                                  nlev, nlev, nlevi, nlev, nlev,  nlev, nlev};
-  Kokkos::Array<const Real*, num_2d_arrays> ptr_array = {wthv_sec, shoc_mix, u_wind,  v_wind, dz_zi, dz_zt, pres,
-                                                         brunt,    zt_grid,  zi_grid, tke,    tk,    tkh,   isotropy};
+  std::vector<int> dim1_sizes(num_2d_arrays, shcol);
+  std::vector<int> dim2_sizes = {nlev, nlev, nlev,  nlev, nlevi, nlev, nlev,
+                                 nlev, nlev, nlevi, nlev, nlev,  nlev, nlev};
+  std::vector<const Real*> ptr_array = {wthv_sec, shoc_mix, u_wind,  v_wind, dz_zi, dz_zt, pres,
+                                        brunt,    zt_grid,  zi_grid, tke,    tk,    tkh,   isotropy};
 
   // Sync to device
   ekat::host_to_device({obklen, pblh}, shcol, temp_1d_d);
@@ -3217,8 +3146,8 @@ void shoc_tke_f(Int shcol, Int nlev, Int nlevi, Real dtime, Real* wthv_sec, Real
   });
 
   // Sync back to host
-  Kokkos::Array<view_2d, 4> inout_views = {tke_d, tk_d, tkh_d, isotropy_d};
-  ekat::device_to_host<int,4>({tke, tk, tkh, isotropy}, shcol, nlev, inout_views, true);
+  std::vector<view_2d> inout_views = {tke_d, tk_d, tkh_d, isotropy_d};
+  ekat::device_to_host({tke, tk, tkh, isotropy}, shcol, nlev, inout_views, true);
 }
 
 } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -69,7 +69,7 @@ struct ShocEnergyFixerData : public PhysicsTestData {
   Real *host_dse;
 
   ShocEnergyFixerData(Int shcol_, Int nlev_, Int nlevi_, Real dtime_, Int nadv_) :
-    PhysicsTestData({{ shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_ }}, {{ &zt_grid, &rho_zt, &tke, &host_dse }, { &zi_grid, &pint }, { &se_b, &ke_b, &wv_b, &wl_b, &se_a, &ke_a, &wv_a, &wl_a, &wthl_sfc, &wqw_sfc }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_), dtime(dtime_), nadv(nadv_) {}
+    PhysicsTestData({{ shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_ }}, {{ &zt_grid, &rho_zt, &tke, &host_dse }, { &zi_grid, &pint }, { &se_b, &ke_b, &wv_b, &wl_b, &se_a, &ke_a, &wv_a, &wl_a, &wthl_sfc, &wqw_sfc }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_), nadv(nadv_), dtime(dtime_) {}
 
   PTD_STD_DEF(ShocEnergyFixerData, 5, shcol, nlev, nlevi, dtime, nadv);
 };
@@ -98,7 +98,7 @@ struct ShocEnergyTotalFixerData : public PhysicsTestData {
   Real *te_a, *te_b;
 
   ShocEnergyTotalFixerData(Int shcol_, Int nlev_, Int nlevi_, Real dtime_, Int nadv_) :
-    PhysicsTestData({{ shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_ }}, {{ &zt_grid, &rho_zt }, { &zi_grid }, { &se_b, &ke_b, &wv_b, &wl_b, &se_a, &ke_a, &wv_a, &wl_a, &wthl_sfc, &wqw_sfc, &te_a, &te_b }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_), dtime(dtime_), nadv(nadv_) {}
+    PhysicsTestData({{ shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_ }}, {{ &zt_grid, &rho_zt }, { &zi_grid }, { &se_b, &ke_b, &wv_b, &wl_b, &se_a, &ke_a, &wv_a, &wl_a, &wthl_sfc, &wqw_sfc, &te_a, &te_b }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_), nadv(nadv_), dtime(dtime_) {}
 
   PTD_STD_DEF(ShocEnergyTotalFixerData, 5, shcol, nlev, nlevi, dtime, nadv);
 };
@@ -113,7 +113,7 @@ struct ShocEnergyThresholdFixerData : public PhysicsTestData {
   Int *shoctop;
 
   ShocEnergyThresholdFixerData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData({{ shcol_, nlevi_ }, { shcol_, nlev_ }, { shcol_ }, { shcol_ }}, {{ &pint }, { &tke }, { &te_a, &te_b, &se_dis }}, {{ &shoctop }}), shcol(shcol_), nlevi(nlevi_), nlev(nlev_) {}
+    PhysicsTestData({{ shcol_, nlevi_ }, { shcol_, nlev_ }, { shcol_ }, { shcol_ }}, {{ &pint }, { &tke }, { &te_a, &te_b, &se_dis }}, {{ &shoctop }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_)  {}
 
   PTD_STD_DEF(ShocEnergyThresholdFixerData, 3, shcol, nlev, nlevi);
 };
@@ -142,7 +142,7 @@ struct CalcShocVertfluxData : public PhysicsTestData {
   Real *vertflux;
 
   CalcShocVertfluxData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData({{ shcol_, nlevi_ }, { shcol_, nlev_ }}, {{ &tkh_zi, &dz_zi, &vertflux }, { &invar }}), shcol(shcol_), nlevi(nlevi_), nlev(nlev_) {}
+    PhysicsTestData({{ shcol_, nlevi_ }, { shcol_, nlev_ }}, {{ &tkh_zi, &dz_zi, &vertflux }, { &invar }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_) {}
 
   PTD_STD_DEF(CalcShocVertfluxData, 3, shcol, nlev, nlevi);
 };
@@ -157,14 +157,14 @@ struct CalcShocVarorcovarData : public PhysicsTestData {
   Real *varorcovar;
 
   CalcShocVarorcovarData(Int shcol_, Int nlev_, Int nlevi_, Real tunefac_) :
-    PhysicsTestData({{ shcol_, nlevi_ }, { shcol_, nlev_ }}, {{ &isotropy_zi, &tkh_zi, &dz_zi, &varorcovar }, { &invar1, &invar2 }}), shcol(shcol_), nlevi(nlevi_), nlev(nlev_), tunefac(tunefac_) {}
+    PhysicsTestData({{ shcol_, nlevi_ }, { shcol_, nlev_ }}, {{ &isotropy_zi, &tkh_zi, &dz_zi, &varorcovar }, { &invar1, &invar2 }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_), tunefac(tunefac_) {}
 
   PTD_STD_DEF(CalcShocVarorcovarData, 4, shcol, nlev, nlevi, tunefac);
 };
 
 struct ComputeTmpiData : public PhysicsTestData {
   // Inputs
-  Int nlevi, shcol;
+  Int shcol, nlevi;
   Real dtime;
   Real *rho_zi, *dz_zi;
 
@@ -179,7 +179,7 @@ struct ComputeTmpiData : public PhysicsTestData {
 
 struct DpInverseData : public PhysicsTestData {
   // Inputs
-  Int nlev, shcol;
+  Int shcol, nlev;
   Real *rho_zt, *dz_zt;
 
   // Outputs
@@ -236,7 +236,7 @@ struct TkeSrfFluxTermData : public PhysicsTestData {
 
 struct IntegColumnStabilityData : public PhysicsTestData {
   // Inputs
-  Int nlev, shcol;
+  Int shcol, nlev;
   Real *dz_zt, *pres, *brunt;
 
   // Outputs
@@ -281,21 +281,21 @@ struct ShocTkeData : public PhysicsTestData {
 
 struct ComputeShrProdData : public PhysicsTestData {
   // Inputs
-  Int nlevi, nlev, shcol;
+  Int shcol, nlev, nlevi;
   Real *dz_zi, *u_wind, *v_wind;
 
   // Outputs
   Real *sterm;
 
   ComputeShrProdData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData({{ shcol_, nlevi_ }, { shcol_, nlev_ }}, {{ &dz_zi, &sterm }, { &u_wind, &v_wind }}), shcol(shcol_), nlevi(nlevi_), nlev(nlev_) {}
+    PhysicsTestData({{ shcol_, nlevi_ }, { shcol_, nlev_ }}, {{ &dz_zi, &sterm }, { &u_wind, &v_wind }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_) {}
 
   PTD_STD_DEF(ComputeShrProdData, 3, shcol, nlev, nlevi);
 };
 
 struct IsotropicTsData : public PhysicsTestData {
   // Inputs
-  Int nlev, shcol;
+  Int shcol, nlev;
   Real *brunt_int, *tke, *a_diss, *brunt;
 
   // Outputs
@@ -309,7 +309,7 @@ struct IsotropicTsData : public PhysicsTestData {
 
 struct AdvSgsTkeData : public PhysicsTestData {
   // Inputs
-  Int nlev, shcol;
+  Int shcol, nlev;
   Real dtime;
   Real *shoc_mix, *wthv_sec, *sterm_zt, *tk;
 
@@ -327,7 +327,7 @@ struct AdvSgsTkeData : public PhysicsTestData {
 
 struct EddyDiffusivitiesData : public PhysicsTestData {
   // Inputs
-  Int nlev, shcol;
+  Int shcol, nlev;
   Real *obklen, *pblh, *zt_grid, *shoc_mix, *sterm_zt, *isotropy, *tke;
 
   // Outputs
@@ -355,7 +355,7 @@ struct ShocLengthData : public PhysicsTestData {
 
 struct ComputeBruntShocLengthData : public PhysicsTestData {
   // Inputs
-  Int nlev, nlevi, shcol;
+  Int shcol, nlev, nlevi;
   Real *dz_zt, *thv, *thv_zi;
 
   // Outputs
@@ -369,7 +369,7 @@ struct ComputeBruntShocLengthData : public PhysicsTestData {
 
 struct ComputeLInfShocLengthData : public PhysicsTestData {
   // Inputs
-  Int nlev, shcol;
+  Int shcol, nlev;
   Real *zt_grid, *dz_zt, *tke;
 
   // Inputs/Outputs
@@ -383,7 +383,7 @@ struct ComputeLInfShocLengthData : public PhysicsTestData {
 
 struct ComputeConvVelShocLengthData : public PhysicsTestData {
   // Inputs
-  Int nlev, shcol;
+  Int shcol, nlev;
   Real *pblh, *zt_grid, *dz_zt, *thv, *wthv_sec;
 
   // Inputs/Outputs
@@ -411,7 +411,7 @@ struct ComputeConvTimeShocLengthData : public PhysicsTestData {
 
 struct ComputeShocMixShocLengthData : public PhysicsTestData {
   // Inputs
-  Int nlev, shcol;
+  Int shcol, nlev;
   Real *tke, *brunt, *tscale, *zt_grid, *l_inf;
 
   // Outputs
@@ -425,7 +425,7 @@ struct ComputeShocMixShocLengthData : public PhysicsTestData {
 
 struct CheckLengthScaleShocLengthData : public PhysicsTestData {
   // Inputs
-  Int nlev, shcol;
+  Int shcol, nlev;
   Real *host_dx, *host_dy;
 
   // Inputs/Outputs
@@ -487,7 +487,7 @@ struct W3DiagThirdShocMomentData {
 
 struct ClippingDiagThirdShocMomentsData : public PhysicsTestData {
   // Inputs
-  Int nlevi, shcol;
+  Int shcol, nlevi;
   Real *w_sec_zi;
 
   // Inputs/Outputs
@@ -516,7 +516,7 @@ struct DiagSecondMomentsSrfData : public PhysicsTestData {
 struct LinearInterpData : public PhysicsTestData {
   // Inputs
   Real *x1, *x2, *y1;
-  Int km1, km2, ncol;
+  Int ncol, km1, km2;
   Real minthresh;
 
   // Outputs
@@ -703,7 +703,7 @@ struct PblintdCldcheckData : public PhysicsTestData {
   Real *pblh;
 
   PblintdCldcheckData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData({{ shcol_, nlevi_ }, { shcol_, nlev_ }, { shcol_ }}, {{ &zi }, { &cldn }, { &pblh }}), shcol(shcol_), nlevi(nlevi_), nlev(nlev_) {}
+    PhysicsTestData({{ shcol_, nlevi_ }, { shcol_, nlev_ }, { shcol_ }}, {{ &zi }, { &cldn }, { &pblh }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_) {}
 
   PTD_STD_DEF(PblintdCldcheckData, 3, shcol, nlev, nlevi);
 };
@@ -795,7 +795,7 @@ struct ShocMainData : public PhysicsTestData {
   Real *pblh, *shoc_mix, *isotropy, *w_sec, *thl_sec, *qw_sec, *qwthl_sec, *wthl_sec, *wqw_sec, *wtke_sec, *uw_sec, *vw_sec, *w3, *wqls_sec, *brunt, *shoc_ql2;
 
   ShocMainData(Int shcol_, Int nlev_, Int nlevi_, Int num_qtracers_, Real dtime_, Int nadv_) :
-    PhysicsTestData({{ shcol_ }, { shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_, num_qtracers_ }, { shcol_, nlev_, num_qtracers_ }}, {{ &host_dx, &host_dy, &wthl_sfc, &wqw_sfc, &uw_sfc, &vw_sfc, &phis, &pblh }, { &thv, &zt_grid, &pres, &pdel, &w_field, &exner, &host_dse, &tke, &thetal, &qw, &u_wind, &v_wind, &wthv_sec, &tkh, &tk, &shoc_ql, &shoc_cldfrac, &shoc_mix, &isotropy, &w_sec, &wqls_sec, &brunt, &shoc_ql2 }, { &zi_grid, &presi, &thl_sec, &qw_sec, &qwthl_sec, &wthl_sec, &wqw_sec, &wtke_sec, &uw_sec, &vw_sec, &w3 }, { &wtracer_sfc }, { &qtracers }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_), num_qtracers(num_qtracers_), dtime(dtime_), nadv(nadv_) {}
+    PhysicsTestData({{ shcol_ }, { shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_, num_qtracers_ }, { shcol_, nlev_, num_qtracers_ }}, {{ &host_dx, &host_dy, &wthl_sfc, &wqw_sfc, &uw_sfc, &vw_sfc, &phis, &pblh }, { &thv, &zt_grid, &pres, &pdel, &w_field, &exner, &host_dse, &tke, &thetal, &qw, &u_wind, &v_wind, &wthv_sec, &tkh, &tk, &shoc_ql, &shoc_cldfrac, &shoc_mix, &isotropy, &w_sec, &wqls_sec, &brunt, &shoc_ql2 }, { &zi_grid, &presi, &thl_sec, &qw_sec, &qwthl_sec, &wthl_sec, &wqw_sec, &wtke_sec, &uw_sec, &vw_sec, &w3 }, { &wtracer_sfc }, { &qtracers }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_), nadv(nadv_), num_qtracers(num_qtracers_), dtime(dtime_) {}
 
   PTD_STD_DEF(ShocMainData, 6, shcol, nlev, nlevi, num_qtracers, dtime, nadv);
 };
@@ -830,7 +830,7 @@ struct VdShocDecompandSolveData : public PhysicsTestData {
   VdShocDecompandSolveData(Int shcol_, Int nlev_, Int nlevi_, Real dtime_, Int n_rhs_) :
     PhysicsTestData({{shcol_}, {shcol_, nlev_},               {shcol_, nlevi_},  {shcol_, nlev_, n_rhs_}},
                     {{&flux}, {&rdp_zt, &du, &dl, &d, &rhs}, {&kv_term, &tmpi}, {&var }                }, {}),
-                    shcol(shcol_), nlev(nlev_), nlevi(nlevi_), dtime(dtime_), n_rhs(n_rhs_) {}
+                    shcol(shcol_), nlev(nlev_), nlevi(nlevi_), n_rhs(n_rhs_), dtime(dtime_) {}
 
   PTD_STD_DEF(VdShocDecompandSolveData, 5, shcol, nlev, nlevi, dtime, n_rhs);
 };
@@ -839,14 +839,14 @@ struct PblintdInitData : public PhysicsTestData {
   // Inputs
   Int shcol, nlev;
   Real *z;
-  
+
   // Outputs
   bool *check;
   Real *rino, *pblh;
-  
+
   PblintdInitData(Int shcol_, Int nlev_) :
     PhysicsTestData({{ shcol_, nlev_ }, { shcol_ }, { shcol_ }}, {{ &z, &rino }, { &pblh }}, {}, {{ &check }}), shcol(shcol_), nlev(nlev_) {}
-  
+
   PTD_STD_DEF(PblintdInitData, 2, shcol, nlev);
 };
 
@@ -854,17 +854,17 @@ struct PblintdSurfTempData : public PhysicsTestData {
   // Inputs
   Int shcol, nlev, nlevi;
   Real *z, *ustar, *obklen, *kbfs, *thv;
-  
+
   // Inputs/Outputs
   Real *pblh, *rino;
   bool *check;
-  
+
   // Outputs
   Real *tlv;
-  
+
   PblintdSurfTempData(Int shcol_, Int nlev_, Int nlevi_) :
     PhysicsTestData({{ shcol_, nlev_ }, { shcol_ }, { shcol_ }}, {{ &z, &thv, &rino }, { &ustar, &obklen, &kbfs, &tlv, &pblh }}, {}, {{ &check }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_) {}
-  
+
   PTD_STD_DEF(PblintdSurfTempData, 3, shcol, nlev, nlevi);
 };
 
@@ -873,13 +873,13 @@ struct PblintdCheckPblhData : public PhysicsTestData {
   Int shcol, nlev, nlevi;
   Real *z, *ustar;
   bool *check;
-  
+
   // Outputs
   Real *pblh;
-  
+
   PblintdCheckPblhData(Int shcol_, Int nlev_, Int nlevi_) :
     PhysicsTestData({{ shcol_, nlev_ }, { shcol_ }, { shcol_ }}, {{ &z }, { &ustar, &pblh }}, {}, {{ &check }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_) {}
-  
+
   PTD_STD_DEF(PblintdCheckPblhData, 3, shcol, nlev, nlevi);
 };
 
@@ -887,13 +887,13 @@ struct PblintdData : public PhysicsTestData {
   // Inputs
   Int shcol, nlev, nlevi;
   Real *z, *zi, *thl, *ql, *q, *u, *v, *ustar, *obklen, *kbfs, *cldn;
-  
+
   // Outputs
   Real *pblh;
-  
+
   PblintdData(Int shcol_, Int nlev_, Int nlevi_) :
     PhysicsTestData({{ shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_ }}, {{ &z, &thl, &ql, &q, &u, &v, &cldn }, { &zi }, { &ustar, &obklen, &kbfs, &pblh }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_) {}
-  
+
   PTD_STD_DEF(PblintdData, 3, shcol, nlev, nlevi);
 };
 
@@ -1010,9 +1010,9 @@ void diag_second_moments_lbycond_f(Int shcol, Real* wthl_sfc, Real* wqw_sfc, Rea
 void diag_second_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* tke, Real* isotropy,
                           Real* tkh, Real* tk, Real* dz_zi, Real* zt_grid, Real* zi_grid, Real* shoc_mix, Real* thl_sec, Real* qw_sec,
                           Real* wthl_sec, Real* wqw_sec, Real* qwthl_sec, Real* uw_sec, Real* vw_sec, Real* wtke_sec, Real* w_sec);
-void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* tke, 
-                                Real* isotropy, Real* tkh, Real* tk, Real* dz_zi, Real* zt_grid, Real* zi_grid, Real* shoc_mix, 
-                                Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* thl_sec, Real* qw_sec, Real* wthl_sec, 
+void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* tke,
+                                Real* isotropy, Real* tkh, Real* tk, Real* dz_zi, Real* zt_grid, Real* zi_grid, Real* shoc_mix,
+                                Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* thl_sec, Real* qw_sec, Real* wthl_sec,
                                 Real* wqw_sec, Real* qwthl_sec, Real* uw_sec, Real* vw_sec, Real* wtke_sec, Real* w_sec);
 void shoc_diag_obklen_f(Int shcol, Real* uw_sfc, Real* vw_sfc, Real* wthl_sfc, Real* wqw_sfc,
                         Real* thl_sfc, Real* cldliq_sfc, Real* qv_sfc, Real* ustar, Real* kbfs, Real* obklen);

--- a/components/scream/src/physics/shoc/tests/shoc_diag_second_moments_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_second_moments_tests.cpp
@@ -53,7 +53,6 @@ struct UnitWrap::UnitTest<D>::TestDiagSecondMoments {
 
     // establish reasonable bounds for checking result
     static constexpr Real thl_sec_ubound = 1000; // [K^s]
-    static constexpr Real qw_sec_ubound = 1e-3; // [kg/kg]
     static constexpr Real qwthl_sec_bound = 1e-1; // [K kg/kg]
     static constexpr Real wthl_sec_bound = 10; // [K m/s]
     static constexpr Real wqw_sec_bound = 1e-3; // [kg/kg m/s]

--- a/components/scream/src/physics/shoc/tests/shoc_diag_second_shoc_moments_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_diag_second_shoc_moments_tests.cpp
@@ -60,7 +60,6 @@ struct UnitWrap::UnitTest<D>::TestDiagSecondShocMoments {
 
     // establish reasonable bounds for checking result
     static constexpr Real thl_sec_ubound = 1000; // [K^s]
-    static constexpr Real qw_sec_ubound = 1e-3; // [kg/kg]
     static constexpr Real qwthl_sec_bound = 1e-1; // [K kg/kg]
     static constexpr Real wthl_sec_bound = 10; // [K m/s]
     static constexpr Real wqw_sec_bound = 1e-3; // [kg/kg m/s]

--- a/components/scream/src/physics/shoc/tests/shoc_energy_dse_fixer_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_dse_fixer_tests.cpp
@@ -25,8 +25,6 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyDseFixer {
 
   static void run_property()
   {
-    static constexpr Real gravit  = scream::physics::Constants<Real>::gravit;
-    static constexpr Real Cpair   = scream::physics::Constants<Real>::Cpair;
     static constexpr Int shcol    = 6;
     static constexpr Int nlev     = 5;
 

--- a/components/scream/src/physics/shoc/tests/shoc_length_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_length_tests.cpp
@@ -58,9 +58,6 @@ struct UnitWrap::UnitTest<D>::TestShocLength {
     // compute geometric grid mesh
     const auto grid_mesh = sqrt(host_dx*host_dy);
 
-    // set bound to check output
-    static constexpr Real brunt_bound = 1;
-
     // Grid stuff to compute based on zi_grid
     Real zt_grid[nlev];
     Real dz_zt[nlev];

--- a/components/scream/src/physics/shoc/tests/shoc_shoc_main_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_shoc_main_tests.cpp
@@ -18,7 +18,6 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
   static void run_property()
   {
     static constexpr Real mintke = scream::shoc::Constants<Real>::mintke;
-    static constexpr Real maxtke = scream::shoc::Constants<Real>::maxtke;
     static constexpr Real minlen = scream::shoc::Constants<Real>::minlen;
     static constexpr Real maxlen = scream::shoc::Constants<Real>::maxlen;
     static constexpr Real maxiso = scream::shoc::Constants<Real>::maxiso;

--- a/components/scream/src/physics/shoc/tests/shoc_tke_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tke_tests.cpp
@@ -70,8 +70,6 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
     Real pblh = 1000;
     // Define pressure [Pa]
     Real pres[nlev] = {85000, 87500, 90000, 95000, 100000};
-    // Define brunt Vaisalla frequency
-    Real brunt[nlev] = {0.1, 0.1, 0.1, 0.1, 0.1};
 
     // Define TKE initial [m2/s2]
     Real tke_init[nlev] = {0.01, 0.01, 0.01, 0.01, 0.01};

--- a/components/scream/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
@@ -89,7 +89,6 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit {
     Real zt_grid[nlev];
     Real dz_zt[nlev];
     Real dz_zi[nlevi];
-    Real w_sec[nlev];
     // Compute heights on midpoint grid
     for(Int n = 0; n < nlev; ++n) {
       zt_grid[n] = 0.5*(zi_grid[n]+zi_grid[n+1]);

--- a/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_w3_diag_third_moms_tests.cpp
@@ -58,9 +58,6 @@ struct UnitWrap::UnitTest<D>::TestW3diagThirdMoms {
     // Verify result is negative
     REQUIRE(SDS.w3 < 0);
 
-    // save output
-    Real w3_test1 = SDS.w3;
-
     // TEST TWO
     // Modify parameters to decrease w3
     // decrease this term
@@ -73,9 +70,6 @@ struct UnitWrap::UnitTest<D>::TestW3diagThirdMoms {
 
     // Verify result has decreased
     REQUIRE(SDS.w3 < SDS.aa1);
-
-    // Save result
-    Real w3_test2 = SDS.w3;
 
     // TEST THREE
     // Modify parameters to get positive result

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
@@ -15,7 +15,7 @@ ZMDeepConvection::ZMDeepConvection (const ekat::Comm& comm,const ekat::Parameter
   , m_zm_params(params)
 {
   m_initializer = create_field_initializer<ZMInputsInitializer>();
-  
+
 }
 
 void ZMDeepConvection::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
@@ -41,19 +41,19 @@ void ZMDeepConvection::set_grids(const std::shared_ptr<const GridsManager> grids
   FieldLayout vector3d_layout_mid{ {COL,CMP,VL}, {nc,QSZ,NVL} };
   FieldLayout tracers_layout { {COL,VAR,VL}, {nc,QSZ,NVL} };
   FieldLayout scalar2d_layout{ {COL}, {nc} };
- 
+
   std::vector<FieldLayout> layout_opts = {scalar3d_layout_mid, scalar3d_layout_int,
 					vector3d_layout_mid, tracers_layout, scalar2d_layout};
- 
+
   set_grid_opts();
-  
+
   for ( auto i = opt_map.begin(); i != opt_map.end(); ++i) {
     m_required_fields.emplace((i->second).name, layout_opts[((i->second).field_idx)], Q, grid->name());
     if ( (i->second).isOut == true ) {
       m_computed_fields.emplace((i->second).name, layout_opts[((i->second).field_idx)], Q, grid->name());
     }
   }
-  
+
 }
 
 // =========================================================================================
@@ -66,9 +66,8 @@ void ZMDeepConvection::initialize_impl (const util::TimeStamp& t0)
   using strvec = std::vector<std::string>;
   const strvec& allowed_to_init = m_zm_params.get<strvec>("Initializable Inputs",strvec(0));
   const bool can_init_all = m_zm_params.get<bool>("Can Initialize All Inputs", false);
-  const bool init_all_or_none = m_zm_params.get<bool>("Must Init All Inputs Or None", true);
   const strvec& initable = can_init_all ? zm_inputs : allowed_to_init;
-  
+
   if (initable.size()>0) {
     bool all_inited = true, all_uninited = true;
     for (const auto& name : initable) {
@@ -102,31 +101,31 @@ void ZMDeepConvection::run_impl (const Real dt)
 
   Real** temp = &m_raw_ptrs_out["fracis"];
   Real*** fracis = &temp;
- 
-  zm_main_f90(*m_raw_ptrs_out["lchnk"], *m_raw_ptrs_out["ncol"], m_raw_ptrs_out["t"], 
-  	      m_raw_ptrs_out["qh"], m_raw_ptrs_out["prec"], m_raw_ptrs_out["jctop"], 
-              m_raw_ptrs_out["jcbot"], m_raw_ptrs_out["pblh"], m_raw_ptrs_out["zm"], 
-              m_raw_ptrs_out["geos"], m_raw_ptrs_out["zi"], m_raw_ptrs_out["qtnd"], 
-              m_raw_ptrs_out["heat"], m_raw_ptrs_out["pap"], m_raw_ptrs_out["paph"], 
-              m_raw_ptrs_out["dpp"], *m_raw_ptrs_out["delt"], m_raw_ptrs_out["mcon"], 
-	      m_raw_ptrs_out["cme"], m_raw_ptrs_out["cape"], m_raw_ptrs_out["tpert"], 
-              m_raw_ptrs_out["dlf"], m_raw_ptrs_out["plfx"], m_raw_ptrs_out["zdu"], 
-	      m_raw_ptrs_out["rprd"], m_raw_ptrs_out["mu"], m_raw_ptrs_out["md"], 
-              m_raw_ptrs_out["du"], m_raw_ptrs_out["eu"], m_raw_ptrs_out["ed"], 
-	      m_raw_ptrs_out["dp"], m_raw_ptrs_out["dsubcld"], m_raw_ptrs_out["jt"], 
-	      m_raw_ptrs_out["maxg"], m_raw_ptrs_out["ideep"], *m_raw_ptrs_out["lengath"], 
-              m_raw_ptrs_out["ql"], m_raw_ptrs_out["rliq"], m_raw_ptrs_out["landfrac"], 
-              m_raw_ptrs_out["hu_nm1"], m_raw_ptrs_out["cnv_nm1"], m_raw_ptrs_out["tm1"], 
-              m_raw_ptrs_out["qm1"], &m_raw_ptrs_out["t_star"], &m_raw_ptrs_out["q_star"], 
-              m_raw_ptrs_out["dcape"], m_raw_ptrs_out["q"], &m_raw_ptrs_out["tend_s"], 
-              &m_raw_ptrs_out["tend_q"], &m_raw_ptrs_out["cld"], m_raw_ptrs_out["snow"], 
-              m_raw_ptrs_out["ntprprd"], m_raw_ptrs_out["ntsnprd"], 
-              &m_raw_ptrs_out["flxprec"], &m_raw_ptrs_out["flxsnow"], 
-              *m_raw_ptrs_out["ztodt"], m_raw_ptrs_out["pguall"], m_raw_ptrs_out["pgdall"], 
-              m_raw_ptrs_out["icwu"], *m_raw_ptrs_out["ncnst"], fracis); 
+
+  zm_main_f90(*m_raw_ptrs_out["lchnk"], *m_raw_ptrs_out["ncol"], m_raw_ptrs_out["t"],
+  	      m_raw_ptrs_out["qh"], m_raw_ptrs_out["prec"], m_raw_ptrs_out["jctop"],
+              m_raw_ptrs_out["jcbot"], m_raw_ptrs_out["pblh"], m_raw_ptrs_out["zm"],
+              m_raw_ptrs_out["geos"], m_raw_ptrs_out["zi"], m_raw_ptrs_out["qtnd"],
+              m_raw_ptrs_out["heat"], m_raw_ptrs_out["pap"], m_raw_ptrs_out["paph"],
+              m_raw_ptrs_out["dpp"], *m_raw_ptrs_out["delt"], m_raw_ptrs_out["mcon"],
+	      m_raw_ptrs_out["cme"], m_raw_ptrs_out["cape"], m_raw_ptrs_out["tpert"],
+              m_raw_ptrs_out["dlf"], m_raw_ptrs_out["plfx"], m_raw_ptrs_out["zdu"],
+	      m_raw_ptrs_out["rprd"], m_raw_ptrs_out["mu"], m_raw_ptrs_out["md"],
+              m_raw_ptrs_out["du"], m_raw_ptrs_out["eu"], m_raw_ptrs_out["ed"],
+	      m_raw_ptrs_out["dp"], m_raw_ptrs_out["dsubcld"], m_raw_ptrs_out["jt"],
+	      m_raw_ptrs_out["maxg"], m_raw_ptrs_out["ideep"], *m_raw_ptrs_out["lengath"],
+              m_raw_ptrs_out["ql"], m_raw_ptrs_out["rliq"], m_raw_ptrs_out["landfrac"],
+              m_raw_ptrs_out["hu_nm1"], m_raw_ptrs_out["cnv_nm1"], m_raw_ptrs_out["tm1"],
+              m_raw_ptrs_out["qm1"], &m_raw_ptrs_out["t_star"], &m_raw_ptrs_out["q_star"],
+              m_raw_ptrs_out["dcape"], m_raw_ptrs_out["q"], &m_raw_ptrs_out["tend_s"],
+              &m_raw_ptrs_out["tend_q"], &m_raw_ptrs_out["cld"], m_raw_ptrs_out["snow"],
+              m_raw_ptrs_out["ntprprd"], m_raw_ptrs_out["ntsnprd"],
+              &m_raw_ptrs_out["flxprec"], &m_raw_ptrs_out["flxsnow"],
+              *m_raw_ptrs_out["ztodt"], m_raw_ptrs_out["pguall"], m_raw_ptrs_out["pgdall"],
+              m_raw_ptrs_out["icwu"], *m_raw_ptrs_out["ncnst"], fracis);
   m_current_ts += dt;
-  for (int i = 0; i < zm_inputs.size(); i++){
-  	m_zm_fields_out.at(zm_inputs[i]).get_header().get_tracking().update_time_stamp(m_current_ts);
+  for (size_t i = 0; i < zm_inputs.size(); i++){
+    m_zm_fields_out.at(zm_inputs[i]).get_header().get_tracking().update_time_stamp(m_current_ts);
   }
 }
 // =========================================================================================
@@ -145,8 +144,8 @@ void ZMDeepConvection::register_fields (FieldRepository<Real>& field_repo) const
  }
 
 void ZMDeepConvection::set_required_field_impl (const Field<const Real>& f) {
-  // @Meredith: Diff between add_me_as_a_customer and get_tracking().add_customer? 
-  
+  // @Meredith: Diff between add_me_as_a_customer and get_tracking().add_customer?
+
   // Store a copy of the field. We need this in order to do some tracking checks
   // at the beginning of the run call. Other than that, there would be really
   // no need to store a scream field here; we could simply set the view ptr

--- a/components/scream/src/physics/zm/zm_inputs_initializer.cpp
+++ b/components/scream/src/physics/zm/zm_inputs_initializer.cpp
@@ -10,21 +10,21 @@ namespace scream
 {
 
 using namespace std;
-std::vector<string> zm_inputs = {"limcnv_in", "no_deep_pbl_in","lchnk", "ncol", "t", "qh", "prec", 
-			"jctop", "jcbot", "pblh", "zm", "geos", "zi", "qtnd", "heat", 
+std::vector<string> zm_inputs = {"limcnv_in", "no_deep_pbl_in","lchnk", "ncol", "t", "qh", "prec",
+			"jctop", "jcbot", "pblh", "zm", "geos", "zi", "qtnd", "heat",
 			"pap", "paph", "dpp", "delt", "mcon", "cme", "cape", "tpert",
-			"dlf", "pflx", "zdu", "rprd", "mu", "md", "du", "eu", "ed", 
-			"dp", "dsubcld", "jt", "maxg", "ideep", "lengath", "ql", 
-			"rliq", "landfrac", "hu_nm1", "cnv_nm1", "tm1", "qm1", "t_star", 
-			"q_star", "dcape", "q", "tend_s", "tend_q", "cld", "snow", 
-			"ntprprd", "ztodt", "ntsnprd", "flxprec", "flxsnow", "pguall", 
+			"dlf", "pflx", "zdu", "rprd", "mu", "md", "du", "eu", "ed",
+			"dp", "dsubcld", "jt", "maxg", "ideep", "lengath", "ql",
+			"rliq", "landfrac", "hu_nm1", "cnv_nm1", "tm1", "qm1", "t_star",
+			"q_star", "dcape", "q", "tend_s", "tend_q", "cld", "snow",
+			"ntprprd", "ztodt", "ntsnprd", "flxprec", "flxsnow", "pguall",
 			"pgdall", "icwu", "ncnst", "fracis"};
 
 
 const int INPUT_SIZE = 63;
 
 
-//Layout options are set as an int 
+//Layout options are set as an int
 //to be passed into the GridOpts struct
 const int SCALAR_3D_MID = 0;
 const int SCALAR_3D_INT = 1;
@@ -58,7 +58,7 @@ void set_grid_opts_helper(GridOpts O, string n, bool out, const Units* unit, int
 
 void set_grid_opts(){
 
-  // Declares the field structs 
+  // Declares the field structs
   GridOpts limcnv_in;
   GridOpts no_deep_pbl_in;
   GridOpts lchnk;
@@ -122,9 +122,9 @@ void set_grid_opts(){
   GridOpts icwu;
   GridOpts ncnst;
   GridOpts fracis;
-  
+
   // Sets the value of the grid opt struct categories
-  set_grid_opts_helper(limcnv_in, "limcnv_in", true, NULL, NULL);
+  set_grid_opts_helper(limcnv_in, "limcnv_in", true, NULL, 0);
   set_grid_opts_helper(no_deep_pbl_in, "no_deep_pbl_in", true, NULL, VECTOR_3D_MID);
   set_grid_opts_helper(lchnk, "lchnk", true, &Pa, SCALAR_3D_MID); //temperature(K)
   set_grid_opts_helper(ncol, "ncol", true, &Pa, SCALAR_3D_MID); //temperature(K)
@@ -187,12 +187,12 @@ void set_grid_opts(){
   set_grid_opts_helper(icwu, "icwu", true, NULL, VECTOR_3D_MID);
   set_grid_opts_helper(ncnst, "ncnst", true, NULL, VECTOR_3D_MID);
   set_grid_opts_helper(fracis, "fracis", true, NULL, VECTOR_3D_MID);
-} 
+}
 
 void ZMInputsInitializer::add_field (const field_type &f)
 {
   const auto& id = f.get_header().get_identifier();
-  
+
   m_fields.emplace(id.name(),f);
   m_fields_id.insert(id);
 }
@@ -234,7 +234,7 @@ void ZMInputsInitializer :: initialize_fields(){
       return;
     }
   }
-  
+
 
     EKAT_REQUIRE_MSG (count==INPUT_SIZE,
     "Error! ZMInputsInitializer is expected to init _______________.\n"
@@ -258,5 +258,3 @@ void ZMInputsInitializer :: initialize_fields(){
 
 
 } // namespace scream
-
-


### PR DESCRIPTION
1. Remove many hundreds of warnings from scream
2. Update EKAT
3. Change _f implementation to use new host_to_device/device_to_host API that uses vectors instead of Kokkos::Array.
4. Whitespace clean up various files... probably a good idea to view PR changes with whitespace changes filtered out

With this PR, screams builds without warnings except for a few from zm_conv.F90 which I was less comfortable modifying. I'm adding a review request for @AaronDonahue since I did touch some zm stuff.

As a side note, there are still lots of warnings coming from eam.

Fixes #524 