### PR TITLE
Fixes memory leak in calcsize_diag

### DIFF
--- a/components/eam/src/chemistry/utils/modal_aero_calcsize.F90
+++ b/components/eam/src/chemistry/utils/modal_aero_calcsize.F90
@@ -21,6 +21,8 @@ use constituents,     only: pcnst, cnst_name
 
 use ref_pres,         only: top_lev => clim_modal_aero_top_lev
 
+use shr_log_mod ,     only: errMsg => shr_log_errMsg
+
 #ifdef MODAL_AERO
 
 ! these are the variables needed for the diagnostic calculation of dry radius
@@ -473,7 +475,6 @@ end subroutine modal_aero_calcsize_init
 subroutine modal_aero_calcsize_sub(state, deltat, pbuf, ptend, do_adjust_in, &
    do_aitacc_transfer_in, list_idx_in, dgnumdry_m)
 
-  use shr_log_mod ,  only: errMsg => shr_log_errMsg
 
    !-----------------------------------------------------------------------
    !
@@ -499,7 +500,7 @@ subroutine modal_aero_calcsize_sub(state, deltat, pbuf, ptend, do_adjust_in, &
    logical,  optional :: do_adjust_in
    logical,  optional :: do_aitacc_transfer_in
    integer,  optional :: list_idx_in
-   real(r8), optional, pointer :: dgnumdry_m(:,:,:) ! interstital aerosol dry number mode radius (m)
+   real(r8), optional, intent(inout), allocatable, target :: dgnumdry_m(:,:,:) ! interstital aerosol dry number mode radius (m)
 
 #ifdef MODAL_AERO
 
@@ -609,8 +610,10 @@ subroutine modal_aero_calcsize_sub(state, deltat, pbuf, ptend, do_adjust_in, &
    end if
 
    if(present(list_idx_in)) then
-      if(.not. present(dgnumdry_m)) call endrun('list_idx_in is present but dgnumdry_m' // &
-      ' pointer is missing'//errmsg(__FILE__,__LINE__))
+      if(.not. present(dgnumdry_m)) call endrun('list_idx_in is present but dgnumdry_m is missing '//errmsg(__FILE__,__LINE__))
+
+      if(.not. allocated(dgnumdry_m)) &
+           call endrun('list_idx_in is present but dgnumdry_m is not allocated '//errmsg(__FILE__,__LINE__))
    endif
 
    lchnk = state%lchnk
@@ -1440,7 +1443,7 @@ subroutine modal_aero_calcsize_diag(state, pbuf, list_idx_in, dgnum_m)
    type(physics_buffer_desc), pointer :: pbuf(:)      ! physics buffer
 
    integer,  optional, intent(in)   :: list_idx_in    ! diagnostic list index
-   real(r8), optional, pointer      :: dgnum_m(:,:,:) ! interstital aerosol dry number mode radius (m)
+   real(r8), optional, target, allocatable, intent(inout)  :: dgnum_m(:,:,:) ! interstital aerosol dry number mode radius (m)
 
    ! local
    integer  :: i, k, l1, n
@@ -1481,13 +1484,13 @@ subroutine modal_aero_calcsize_diag(state, pbuf, list_idx_in, dgnum_m)
 
    if (present(list_idx_in)) then
       if (.not. present(dgnum_m)) then
-         call endrun('modal_aero_calcsize_diag called for'// &
-                     'diagnostic list but dgnum_m pointer not present')
+         call endrun('modal_aero_calcsize_diag called with '// &
+              'list_idx_in but dgnum_m is not present '//errmsg(__FILE__,__LINE__))
       end if
-      allocate(dgnum_m(pcols,pver,nmodes), stat=stat)
-      if (stat > 0) then
-         call endrun('modal_aero_calcsize_diag: allocation FAILURE: dgnum_m')
-      end if
+      if (.not. allocated(dgnum_m)) then
+         call endrun('modal_aero_calcsize_diag called with '// &
+              'list_idx_in but dgnum_m is not allocated '//errmsg(__FILE__,__LINE__))
+      endif
    end if
 
    do n = 1, nmodes

--- a/components/eam/src/chemistry/utils/modal_aero_wateruptake.F90
+++ b/components/eam/src/chemistry/utils/modal_aero_wateruptake.F90
@@ -15,7 +15,8 @@ use cam_history,      only: addfld, add_default, outfld
 use cam_logfile,      only: iulog
 use ref_pres,         only: top_lev => clim_modal_aero_top_lev
 use phys_control,     only: phys_getopts
-use cam_abortutils,       only: endrun
+use cam_abortutils,   only: endrun
+use shr_log_mod,      only: errMsg => shr_log_errMsg
 
 implicit none
 private
@@ -144,12 +145,12 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    type(physics_buffer_desc),   pointer       :: pbuf(:)        ! physics buffer
    ! Optional inputs for diagnostic mode
    integer,  optional,          intent(in)    :: list_idx_in
-   real(r8), optional,          pointer       :: dgnumdry_m(:,:,:)
-   real(r8), optional,          pointer       :: dgnumwet_m(:,:,:)
-   real(r8), optional,          pointer       :: qaerwat_m(:,:,:)
-   real(r8), optional,          pointer       :: wetdens_m(:,:,:)
+   real(r8), optional, allocatable, target, intent(in)    :: dgnumdry_m(:,:,:)
+   real(r8), optional, allocatable, target, intent(inout) :: dgnumwet_m(:,:,:)
+   real(r8), optional, allocatable, target, intent(inout) :: qaerwat_m(:,:,:)
+   real(r8), optional, allocatable, target, intent(inout) :: wetdens_m(:,:,:)
    ! optional input relative humidty (overrides clearsky RH estimate below)
-   real(r8), optional,          intent(in)    :: clear_rh_in(pcols,pver) 
+   real(r8), optional,          intent(in)    :: clear_rh_in(pcols,pver)
 
    !----------------------------------------------------------------------------
    ! local variables
@@ -224,15 +225,15 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
       ! check that all optional args for diagnostic mode are present
       if (.not. present(dgnumdry_m) .or. .not. present(dgnumwet_m) .or. &
           .not. present(qaerwat_m)  .or. .not. present(wetdens_m)) then
-         call endrun('modal_aero_wateruptake_dr called for'// &
-                     'diagnostic list but required args not present')
+         call endrun('modal_aero_wateruptake_dr called '// &
+              'with list_idx_in but required args not present '//errmsg(__FILE__,__LINE__))
       end if
 
-      ! arrays for diagnostic calculations must be associated
-      if (.not. associated(dgnumdry_m) .or. .not. associated(dgnumwet_m) .or. &
-          .not. associated(qaerwat_m)  .or. .not. associated(wetdens_m)) then
-         call endrun('modal_aero_wateruptake_dr called for'// &
-                     'diagnostic list but required args not associated')
+      ! arrays for diagnostic calculations must be allocated
+      if (.not. allocated(dgnumdry_m) .or. .not. allocated(dgnumwet_m) .or. &
+          .not. allocated(qaerwat_m)  .or. .not. allocated(wetdens_m)) then
+         call endrun('modal_aero_wateruptake_dr called '// &
+              'with list_idx_in but required args not allocated '//errmsg(__FILE__,__LINE__))
       end if
    end if ! if present(list_idx_in)
 

--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -68,11 +68,11 @@ character(len=4) :: diag(0:n_diag) = (/'    ','_d1 ','_d2 ','_d3 ','_d4 ','_d5 '
 
 !Declare the following threadprivate variables to be used for calcsize and water uptake
 !These are defined as module level variables to aviod allocation-deallocation in a loop
-real(r8), pointer :: dgnumdry_m(:,:,:) ! number mode dry diameter for all modes
-real(r8), pointer :: dgnumwet_m(:,:,:) ! number mode wet diameter for all modes
-real(r8), pointer :: qaerwat_m(:,:,:)  ! aerosol water (g/g) for all modes
-real(r8), pointer :: wetdens_m(:,:,:)  ! aerosol water (g/g) for all modes
-!$OMP THREADPRIVATE(dgnumdry_m, dgnumwet_m, qaerwat_m)
+real(r8), allocatable :: dgnumdry_m(:,:,:) ! number mode dry diameter for all modes
+real(r8), allocatable, target :: dgnumwet_m(:,:,:) ! number mode wet diameter for all modes
+real(r8), allocatable, target :: qaerwat_m(:,:,:)  ! aerosol water (g/g) for all modes
+real(r8), allocatable, target :: wetdens_m(:,:,:)  ! aerosol water (g/g) for all modes
+!$OMP THREADPRIVATE(dgnumdry_m, dgnumwet_m, qaerwat_m, wetdens_m)
 
 logical :: clim_modal_aero ! true when radiatively constituents present (nmodes>0)
 logical :: prog_modal_aero ! Prognostic modal aerosols present


### PR DESCRIPTION
This PR fixes a memory leak by removing "allocate" statement and changes all pointers to allocatable arrays in calsize_diag and wateruptake routines