### PR TITLE
use cbrt instead of bfb_pow

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -4389,7 +4389,6 @@ subroutine pblintd_surf_temp(&
 
     !===================
     ! const parameter for Diagnosis of PBL depth
-    real(rtype), parameter :: onet  = 1._rtype/3._rtype  ! 1/3 power in wind gradient expression
     real(rtype), parameter :: fak   =  8.5_rtype      ! Constant in surface temperature excess
     real(rtype), parameter :: betam = 15.0_rtype      ! Constant in wind gradient expression
     real(rtype), parameter :: sffrac=  0.1_rtype      ! Surface layer fraction of boundary layer
@@ -4413,7 +4412,7 @@ subroutine pblintd_surf_temp(&
        check(i)  = (kbfs(i) > 0._rtype)
        tlv(i)    = thv(i,nlev)
        if (check(i)) then
-          phiminv      = bfb_pow((1._rtype - binm*pblh(i)/obklen(i)), onet)
+          phiminv      = bfb_cbrt(1._rtype - binm*pblh(i)/obklen(i))
           rino(i,nlev) = 0.0_rtype
           tlv(i)       = thv(i,nlev) + kbfs(i)*fak/( ustar(i)*phiminv )
        end if

--- a/components/scream/src/physics/shoc/shoc_pblintd_surf_temp_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_pblintd_surf_temp_impl.hpp
@@ -20,7 +20,6 @@ void Functions<S,D>::pblintd_surf_temp(const Int& nlev, const Int& nlevi, const 
       Scalar& pblh, bool& check, const uview_1d<Spack>& rino)
 {
   // const parameter for Diagnosis of PBL depth
-  const Scalar onet  = 1./3.;
   const Scalar fak   =  8.5;
   const Scalar betam = 15.0;
   const Scalar sffrac=  0.1;
@@ -38,7 +37,7 @@ void Functions<S,D>::pblintd_surf_temp(const Int& nlev, const Int& nlevi, const 
   check  = kbfs > 0.;
   tlv    = thvs(nlev-1);
   if (check) {
-     const auto phiminv = std::pow((1 - binm*pblh/obklen), onet);
+     const auto phiminv = std::cbrt(1 - binm*pblh/obklen);
      rinos(nlev-1) = 0.0;
      tlv  = thvs(nlev-1) + kbfs*fak/(ustar*phiminv);
   }


### PR DESCRIPTION
@ambrad Does this make sense to do computationally? It's useful to me since, when running tests, `std::pow` cannot handle negative values, and randomizing inputs can lead to those. However, if it is computationally slower then I can work around with the test inputs.