### PR TITLE
output fix for SCREAM SCM

### DIFF
--- a/components/eam/src/dynamics/se/se_single_column_mod.F90
+++ b/components/eam/src/dynamics/se/se_single_column_mod.F90
@@ -288,7 +288,7 @@ subroutine apply_SC_forcing(elem,hvcoord,tl,n,t_before_advance,nets,nete)
         call outfld('QDIFF',qdiff_out,npsq,ie)
       else
         call outfld('TDIFF',tdiff_dyn,plon,begchunk)
-        call outfld('QDIFF',tdiff_dyn,plon,begchunk)
+        call outfld('QDIFF',qdiff_dyn,plon,begchunk)
       endif
     
     enddo


### PR DESCRIPTION
The wrong variable was being output for "QDIFF" (water vapor differences wrt to observations).  

Note that this error is specific to the SCREAM SCM since output needs to be done differently to accommodate for the IOP infrastructure; thus needs to be fixed in the SCREAM repo rather than the E3SM repo.