### PR TITLE
Quick fix to a build error where the variable "thrd" was not defined in the bfb_math.inc file

### DIFF
--- a/components/eam/src/physics/cam/bfb_math.inc
+++ b/components/eam/src/physics/cam/bfb_math.inc
@@ -29,7 +29,7 @@
 #  define bfb_erf(val) cxx_erf(val)
 #else
 #  define bfb_pow(base, exp) (base)**(exp)
-#  define bfb_cbrt(base) (base)**thrd
+#  define bfb_cbrt(base) (base)**(1.0/3.0)
 #  define bfb_gamma(val) gamma(val)
 #  define bfb_log(val) log(val)
 #  define bfb_log10(val) log10(val)

--- a/components/eam/src/physics/cam/bfb_math.inc
+++ b/components/eam/src/physics/cam/bfb_math.inc
@@ -29,7 +29,7 @@
 #  define bfb_erf(val) cxx_erf(val)
 #else
 #  define bfb_pow(base, exp) (base)**(exp)
-#  define bfb_cbrt(base) (base)**(1.0/3.0)
+#  define bfb_cbrt(base) (base)**(1.0D0/3.0D0)
 #  define bfb_gamma(val) gamma(val)
 #  define bfb_log(val) log(val)
 #  define bfb_log10(val) log10(val)


### PR DESCRIPTION
 Fixes a build error that occurs when building scream through CIME related to a variable not being properly
defined in the bfb_math.inc file.

[BFB]