### PR TITLE
Bug fixes and unit test for SurfaceCoupling class.

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -254,12 +254,6 @@ print_var(SCREAM_TPL_LIBRARIES)
 # whether to include scream_config.h.
 add_definitions(-DSCREAM_CONFIG_IS_CMAKE)
 
-# Generate scream_config.h and scream_config.f
-include (EkatUtils)
-EkatConfigFile(${CMAKE_CURRENT_SOURCE_DIR}/src/scream_config.h.in
-               ${CMAKE_CURRENT_BINARY_DIR}/src/scream_config.h
-               F90_FILE ${CMAKE_CURRENT_BINARY_DIR}/src/scream_config.f)
-
 # Hooks for testing test-all-scream within test-scripts
 if ($ENV{SCREAM_FORCE_BUILD_FAIL})
   add_definitions(-DSCREAM_FORCE_BUILD_FAIL)
@@ -305,6 +299,12 @@ add_subdirectory(src)
 if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)
 endif()
+
+# Generate scream_config.h and scream_config.f
+include (EkatUtils)
+EkatConfigFile(${CMAKE_CURRENT_SOURCE_DIR}/src/scream_config.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/src/scream_config.h
+               F90_FILE ${CMAKE_CURRENT_BINARY_DIR}/src/scream_config.f)
 
 # Build any tools in the scripts/ dir.
 add_subdirectory(scripts)

--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -10,7 +10,6 @@ Atmosphere Driver:
     Process 1:
       Process Name: P3
       Grid:         Physics GLL
-      Can Initialize All Inputs: true
     Process 2:
       Process Name: SHOC
       Grid:         Physics GLL

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -147,11 +147,6 @@ void AtmosphereDriver::initialize (const ekat::Comm& atm_comm,
   // Initialize atm inputs
   init_atm_inputs ();
 
-  // Now we can inspect the dag, including also checking that
-  // all fields are correctly inited. Any unmet dependency in
-  // the dag at this point has to be treated as an error.
-  inspect_atm_dag ();
-
   // Set time steamp t0 to all fields
   for (auto& field_map_it : *m_field_repo) {
     for (auto& f_it : field_map_it.second) {

--- a/components/scream/src/control/surface_coupling.hpp
+++ b/components/scream/src/control/surface_coupling.hpp
@@ -85,8 +85,11 @@ protected:
     // Index of the field inside the coupler 2d array
     int cpl_idx;
 
-    // Stride between two columns, i.e., number of scalars in a column (including padding)
-    int col_size;
+    // Stride between the 1st entry of two consecutive columns to be imported/exported.
+    // Note: this is >= that number of scalars in a column. E.g., for a vector field layout like
+    //       (ncols,2,nlevs), where we import/export only the 1st vector component, the stride
+    //       is 2*nlevs
+    int col_stride;
 
     // Offset to surface field from the column start. Should be 0 for scalar fields, but
     // may be non-zero for vector quantities for which we import/export the 2nd (or larger)

--- a/components/scream/src/control/tests/CMakeLists.txt
+++ b/components/scream/src/control/tests/CMakeLists.txt
@@ -8,4 +8,7 @@ if (NOT ${SCREAM_BASELINES_ONLY})
   # Copy yaml input file to run directory
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ad_tests.yaml
                  ${CMAKE_CURRENT_BINARY_DIR}/ad_tests.yaml COPYONLY)
+
+  # Unit test the surface coupling
+  CreateUnitTest(sc_ut "sc_tests.cpp" "scream_control" LABELS "driver")
 endif()

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -1,0 +1,127 @@
+#include "share/grid/point_grid.hpp"
+#include "control/surface_coupling.hpp"
+
+#include <ekat/util/ekat_test_utils.hpp>
+
+#include <catch2/catch.hpp>
+
+TEST_CASE ("surface_coupling")
+{
+  // Some namespaces/aliases
+  using namespace scream;
+  using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
+  using FL = FieldLayout;
+  using FID = FieldIdentifier;
+  using RPDF = std::uniform_real_distribution<Real>;
+  using rngAlg = std::mt19937_64;
+
+  // Some constants
+  constexpr int ncols = 4;
+  constexpr int nlevs = 8;
+  constexpr int nruns = 10;
+
+  // Create a comm
+  ekat::Comm comm (MPI_COMM_WORLD);
+
+  // The random numbers generator
+  std::random_device rd;
+  const unsigned int catchRngSeed = Catch::rngSeed();
+  const unsigned int seed = catchRngSeed==0 ? rd() : catchRngSeed;
+  if (comm.am_i_root()) {
+    std::cout << "seed: " << seed << (catchRngSeed==0 ? " (catch rng seed was 0)\n" : "\n");
+  }
+  rngAlg engine(seed);
+  RPDF pdf(0.0,1.0);
+
+  // Create a grid
+  auto grid = create_point_grid("my grid",ncols*comm.size(), nlevs, comm);
+
+  // Create some field ids, and register them in a field repo
+  // Note: we create two repos, so we can compare outputs with inputs
+  FID s2d_id("s2d",FL{{COL},{ncols}},Pa,grid->name());
+  FID s3d_id("s3d",FL{{COL,VL},{ncols,nlevs}},Pa,grid->name());
+  FID v3d_id("v3d",FL{{COL,CMP,VL},{ncols,2,nlevs}},m/s,grid->name());
+
+  FieldRepository<Real> repo_in, repo_out;
+  repo_in.registration_begins();
+  repo_in.register_field(s2d_id);
+  repo_in.register_field(s3d_id);
+  repo_in.register_field(v3d_id);
+  repo_in.registration_ends();
+  repo_out.registration_begins();
+  repo_out.register_field(s2d_id);
+  repo_out.register_field(s3d_id);
+  repo_out.register_field(v3d_id);
+  repo_out.registration_ends();
+
+  // Create two SC objects, to import and export
+  control::SurfaceCoupling importer(grid,repo_in);
+  control::SurfaceCoupling exporter(grid,repo_out);
+
+  importer.set_num_fields(4,0); // Recall that SC counts *scalar* fields, so vector3d counts as 2 fields
+  exporter.set_num_fields(0,4);
+
+  // Register fields in the importer/exporter
+  importer.register_import("s2d",0);
+  importer.register_import("s3d",1);
+  importer.register_import("v3d",2,0);
+  importer.register_import("v3d",3,1);
+  exporter.register_export("s2d",0);
+  exporter.register_export("s3d",1);
+  exporter.register_export("v3d",2,0);
+  exporter.register_export("v3d",3,1);
+
+  // Create a raw array big enough to contain all the 2d data for import/export
+  Real* raw_data = new Real[ncols*4];
+
+  // Complete setup of importer/exporter
+  importer.registration_ends(raw_data,nullptr);
+  exporter.registration_ends(nullptr,raw_data);
+
+  // Repeat experiment N times: fill export fields, export, import, check import fields
+  auto s2d_exp_d = repo_out.get_field(s2d_id).get_reshaped_view<Real*>();
+  auto s3d_exp_d = repo_out.get_field(s3d_id).get_reshaped_view<Real**>();
+  auto v3d_exp_d = repo_out.get_field(v3d_id).get_reshaped_view<Real***>();
+  auto s2d_imp_d = repo_in.get_field(s2d_id).get_reshaped_view<Real*>();
+  auto s3d_imp_d = repo_in.get_field(s3d_id).get_reshaped_view<Real**>();
+  auto v3d_imp_d = repo_in.get_field(v3d_id).get_reshaped_view<Real***>();
+  auto s2d_exp_h = Kokkos::create_mirror_view(s2d_exp_d);
+  auto s3d_exp_h = Kokkos::create_mirror_view(s3d_exp_d);
+  auto v3d_exp_h = Kokkos::create_mirror_view(v3d_exp_d);
+  auto s2d_imp_h = Kokkos::create_mirror_view(s2d_exp_d);
+  auto s3d_imp_h = Kokkos::create_mirror_view(s3d_exp_d);
+  auto v3d_imp_h = Kokkos::create_mirror_view(v3d_exp_d);
+  for (int i=0; i<nruns; ++i) {
+    // Fill export fields
+    ekat::genRandArray(s2d_exp_d,engine,pdf);
+    ekat::genRandArray(s3d_exp_d,engine,pdf);
+    ekat::genRandArray(v3d_exp_d,engine,pdf);
+
+    // Set all raw_data to -1 (might be helpful for debugging)
+    std::fill_n(raw_data,4*ncols,-1);
+
+    // Perform export
+    exporter.do_export();
+
+    // Perform import
+    importer.do_import();
+
+    // Check f_imported==f_exported (on surface only)
+    Kokkos::deep_copy(s2d_exp_h,s2d_exp_h);
+    Kokkos::deep_copy(s3d_exp_h,s3d_exp_h);
+    Kokkos::deep_copy(v3d_exp_h,v3d_exp_h);
+    Kokkos::deep_copy(s2d_imp_h,s2d_imp_h);
+    Kokkos::deep_copy(s3d_imp_h,s3d_imp_h);
+    Kokkos::deep_copy(v3d_imp_h,v3d_imp_h);
+    for (int icol=0; icol<ncols; ++icol) {
+      REQUIRE (s2d_exp_h(icol)==s2d_imp_h(icol));
+      REQUIRE (s3d_exp_h(icol,0)==s3d_imp_h(icol,0));
+      REQUIRE (v3d_exp_h(icol,0,0)==v3d_imp_h(icol,0,0));
+      REQUIRE (v3d_exp_h(icol,0,1)==v3d_imp_h(icol,0,1));
+    }
+  }
+
+  // Clean up
+  delete[] raw_data;
+}

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -91,7 +91,7 @@ TEST_CASE ("surface_coupling")
   exporter.register_export("v3d",3,1);
 
   // Create a raw array big enough to contain all the 2d data for import/export
-  Real* raw_data = new Real[ncols*num_fields];
+  double* raw_data = new double[ncols*num_fields];
 
   // Complete setup of importer/exporter
   importer.registration_ends(raw_data,nullptr);

--- a/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -141,9 +141,8 @@ contains
     ! If this is a standalone run, we need to copy initial f90 states to C++
     if (standalone) then
       call prim_init_state_views(elem)
+      call prim_printstate(elem, tl, hybrid,hvcoord,1, nelemd)
     endif
-
-    call prim_printstate(elem, tl, hybrid,hvcoord,1, nelemd)
 
     is_model_inited = .true.
 

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -52,27 +52,37 @@ contains
     ! Determine attribute vector indices
 
     ! List of cpl names of inputs that scream cares about
-    cpl_names_x2a(1)  = 'Faxx_evap' ! SHOC input
-    cpl_names_x2a(2)  = 'Faxx_sen'  ! SHOC input
-    cpl_names_x2a(3)  = 'Faxx_lat'  ! Needed for energy fixer (?)
-    cpl_names_x2a(4)  = 'Faxx_taux' ! SHOC input
-    cpl_names_x2a(5)  = 'Faxx_tauy' ! SHOC input
-    cpl_names_x2a(6)  = 'Faxx_lwup' ! RRTMGP input
-    cpl_names_x2a(7)  = 'Sx_avsdr'  ! RRTMGP input
-    cpl_names_x2a(8)  = 'Sx_anidr'  ! RRTMGP input
-    cpl_names_x2a(9)  = 'Sx_avsdf'  ! RRTMGP input
-    cpl_names_x2a(10) = 'Sx_anidf'  ! RRTMGP input
-    cpl_names_x2a(11) = 'Sx_t'      ! SHOC input (?)
-    cpl_names_x2a(12) = 'Sl_snowh'  ! SHOC input (?)
-    cpl_names_x2a(13) = 'Si_snowh'  ! UNUSED
-    cpl_names_x2a(14) = 'Sx_tref'   ! UNUSED
-    cpl_names_x2a(15) = 'Sx_qref'   ! UNUSED
-    cpl_names_x2a(16) = 'Sx_u10'    ! UNUSED
-    cpl_names_x2a(17) = 'Sf_ifrac'  ! RRTMGP input
-    cpl_names_x2a(18) = 'Sf_ofrac'  ! SHOCK input (?)
-    cpl_names_x2a(19) = 'Sf_lfrac'  ! RRTMGP input
-    cpl_names_x2a(20) = 'So_ustar'  ! SHOC (?): doesn't seem to be cam_in%ustar though
-    cpl_names_x2a(21) = 'So_re'     ! UNUSED
+
+    !Following inputs are surface values so they are dimensioned (1:ncol) for each chunk.
+    !"cam_in" derived type is populated using these inputs in atm_import_export.F90
+    !using values from other model components
+    !"cam_in" is then used by SCREAM model
+
+    !Comments after the inputs below are organized as follows:
+    !Long name [units] (cam_in member which captures the input) [List of parameterizations which are using this input currently]
+
+    cpl_names_x2a(1)  = 'Faxx_evap' ! Surface water vapor flux    [kg/kg](cam_in%cflx) [SHOC/check_energy_chng]
+    cpl_names_x2a(2)  = 'Faxx_sen'  ! Surface sensible heat flux  [W/m2] (cam_in%shf)  [SHOC/check_energy_chng]
+    cpl_names_x2a(3)  = 'Faxx_lat'  ! Surface latent heat flux    [W/m2] (cam_in%lhf)  [energy fixer qqflx_fixer/qneg4]????
+    cpl_names_x2a(4)  = 'Faxx_taux' ! Surface stress in X         [N/m2] (cam_in%wsx)  [SHOC]
+    cpl_names_x2a(5)  = 'Faxx_tauy' ! Surface stress in Y         [N/m2] (cam_in%wsx)  [SHOC]
+    cpl_names_x2a(6)  = 'Faxx_lwup' ! long wave up radiation flux [W/m2] (cam_in%lwup) [RRTMGP]
+    cpl_names_x2a(7)  = 'Sx_avsdr'  ! short wave direct albedo    [no units] (cam_in%asdir)[RRTMGP]
+    cpl_names_x2a(8)  = 'Sx_anidr'  ! long wave direct albedo     [no units] (cam_in%aldir)[RRTMGP]
+    cpl_names_x2a(9)  = 'Sx_avsdf'  ! short wave difuse albedo    [no units] (cam_in%asdif)[RRTMGP]
+    cpl_names_x2a(10) = 'Sx_anidf'  ! long wave difuse albedo     [no units] (cam_in%aldif)[RRTMGP]
+    cpl_names_x2a(11) = 'Sx_t'      ! Surface temperature         [K]        (cam_in%ts)   [SHOC?? seems like it is not used]****
+    cpl_names_x2a(12) = 'Sl_snowh'  ! Water equivalent snow depth [m]        (cam_in%snowhland) [SHOC]
+    cpl_names_x2a(13) = 'Si_snowh'  ! Snow depth over ice         [m]        (cam_in%snowhice)  [***UNUSED***]
+    cpl_names_x2a(14) = 'Sx_tref'   ! Reference height temperature[K]        (cam_in%tref)      [***UNUSED***]
+
+    cpl_names_x2a(15) = 'Sx_qref'   ! Reference height humidity   [kg/kg]    (cam_in%qref)      [***UNUSED***]
+    cpl_names_x2a(16) = 'Sx_u10'    ! 10m wind speed              [m/s]      (cam_in%u10)       [***UNUSED***]
+    cpl_names_x2a(17) = 'Sf_ifrac'  ! Fraction of sfc area covered by sea-ice [no units] (cam_in%icefrac) [RRTMGP]
+    cpl_names_x2a(18) = 'Sf_ofrac'  ! Fraction of sfc area covered by ocean   [no units] (cam_in%ocnfrac) [***UNUSED***] ****SHOC input (?)
+    cpl_names_x2a(19) = 'Sf_lfrac'  ! Fraction of sfc area covered by land    [no units] (cam_in%landfrac)[SHOC/RRTMGP/ZM]
+    cpl_names_x2a(20) = 'So_ustar'  ! Friction/shear velocity     [m/s]      (cam_in%ustar) [***UNUSED***]***** SHOC computes it internally
+    cpl_names_x2a(21) = 'So_re'     ! ???? (cam_in%re) [***UNUSED***]
 
     ! Names used by scream for the input fields above
     scr_names_x2a(1)  = 'surface_water_evaporation_flux'
@@ -98,19 +108,32 @@ contains
     scr_names_x2a(21) = 'So_re'
 
     ! List of cpl names of outputs that scream needs to pass back to cpl
-    cpl_names_a2x(1)  = 'Sa_tbot'     ! Temperature (HOMME)
-    cpl_names_a2x(2)  = 'Sa_ptem'     ! Potential temperature (HOMME)
-    cpl_names_a2x(3)  = 'Sa_z'        ! Z coord of bottom layers (in m? Pa?)
-    cpl_names_a2x(4)  = 'Sa_u'        ! Horiz velocity u-comp (HOMME)
-    cpl_names_a2x(5)  = 'Sa_v'        ! Horiz velocity v-comp (HOMME)
-    cpl_names_a2x(6)  = 'Sa_pbot'     ! Pressure (HOMME)
-    cpl_names_a2x(7)  = 'Sa_dens'     ! Density (derived from P, T)
-    cpl_names_a2x(8)  = 'Sa_shum'     ! Specific humidity (Computed by ...?)
-    cpl_names_a2x(9)  = 'Faxa_rainc'  ! Liquid convective precip. P3 (?)
-    cpl_names_a2x(10) = 'Faxa_rainl'  ! Liquire large-scale precip. P3 (?)
-    cpl_names_a2x(11) = 'Faxa_snowc'  ! Frozen convective precip. P3 (?)
-    cpl_names_a2x(12) = 'Faxa_snowl'  ! Frozen large scale precip. P3 (?)
-    cpl_names_a2x(13)  = 'Sa_co2prog' ! NOT COMPUTED by SCREAM (?)
+
+    !Following outputs are computed in control/camsrfexch.F90 using internal SCREAM variables
+
+    !comments after the outputs are organized as follows:
+    !Long name [units] (cam_out derived type member) [optional comment about how it is computed]
+
+    cpl_names_a2x(1)  = 'Sa_tbot'     ! Lowest model level temperature [K] (cam_out%tbot)
+    cpl_names_a2x(2)  = 'Sa_ptem'     ! Potential temperature          [K] (cam_out%thbot)[Computed from temperature and exner function]
+    cpl_names_a2x(3)  = 'Sa_z'        ! Geopotential height above surface at midpoints [m] (cam_out%zbot)
+    cpl_names_a2x(4)  = 'Sa_u'        ! Zonal wind        [m/s]  (cam_out%ubot)
+    cpl_names_a2x(5)  = 'Sa_v'        ! Meridional wind   [m/s]  (cam_out%vbot)
+    cpl_names_a2x(6)  = 'Sa_pbot'     ! midpoint pressure [Pa]   (cam_out%pbot)
+    cpl_names_a2x(7)  = 'Sa_dens'     ! Density           [kg/m3](cam_out%rho) [Computed as pbot/(rair*tbot)]
+    cpl_names_a2x(8)  = 'Sa_shum'     ! Specific humidity [kg/kg](cam_out%qbot(i,1)[surface water vapor, i.e., state%q(1:ncol,pver,1)]
+
+    !'precc'  is Convective precipitation rate (liq + ice)
+    !'precsc' is Convective snow rate (water equivalent)
+    cpl_names_a2x(9)  = 'Faxa_rainc'  ! Liquid convective precip  [mm/s] (cam_out%precc-cam_out%precsc) [which scheme computes this??? P3??]
+
+    !'precl'  is Large-scale (stable) precipitation rate (liq + ice)
+    !'precsl' is Large-scale (stable) snow rate (water equivalent)
+    cpl_names_a2x(10) = 'Faxa_rainl'  ! Liquid large-scale precip [mm/s] (cam_out%precl-cam_out%precsl) [which scheme computes this, P3???]
+
+    cpl_names_a2x(11) = 'Faxa_snowc'  ! Convective snow rate      [mm/s] (cam_out%precsc) [which scheme computes this, P3???]
+    cpl_names_a2x(12) = 'Faxa_snowl'  ! Large-scale (stable) snow rate [mm/s] (cam_out%precsl) [which scheme computes this, P3???]
+    cpl_names_a2x(13)  = 'Sa_co2prog' ! Always 0.0_r8 as it is not computed by SCREAM as prognostic co2 is turned off
 
     ! Names used by scream for the output fields above
     scr_names_a2x(1)  = 'surface_temperature'

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -133,11 +133,11 @@ contains
     !-------------------------------------------------------------------------------------------------
     !Important notes regarding following 4 cpl_names_a2x variables (for cpl_names_a2x indexed 9 to 12):
     !
-    !1. All the prec* variables has units of m/s in the model but they are converted to mm/s when
+    !1. All the prec* variables have the units of m/s in the model but they are converted to mm/s when
     !they are assigned to the respective cam_out members in components/eam/src/cpl/atm_import_export.F90
     !
     !2. Convective precip variables (precc and precsc, definitions below) should be zero for SCREAM since
-    !   convection schemes are turned off in SCREAM
+    !   convection scheme is turned off in SCREAM
     !   'precc'  is Convective precipitation rate (liq + ice)
     !   'precsc' is Convective snow rate (water equivalent)
     !

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -52,27 +52,27 @@ contains
     ! Determine attribute vector indices
 
     ! List of cpl names of inputs that scream cares about
-    cpl_names_x2a(1)  = 'Faxx_evap'
-    cpl_names_x2a(2)  = 'Faxx_sen'
-    cpl_names_x2a(3)  = 'Faxx_lat'
-    cpl_names_x2a(4)  = 'Faxx_taux'
-    cpl_names_x2a(5)  = 'Faxx_tauy'
-    cpl_names_x2a(6)  = 'Faxx_lwup'
-    cpl_names_x2a(7)  = 'Sx_avsdr'
-    cpl_names_x2a(8)  = 'Sx_anidr'
-    cpl_names_x2a(9)  = 'Sx_avsdf'
-    cpl_names_x2a(10) = 'Sx_anidf'
-    cpl_names_x2a(11) = 'Sx_t'
-    cpl_names_x2a(12) = 'Sl_snowh'
-    cpl_names_x2a(13) = 'Si_snowh'
-    cpl_names_x2a(14) = 'Sx_tref'
-    cpl_names_x2a(15) = 'Sx_qref'
-    cpl_names_x2a(16) = 'Sx_u10'
-    cpl_names_x2a(17) = 'Sf_ifrac'
-    cpl_names_x2a(18) = 'Sf_ofrac'
-    cpl_names_x2a(19) = 'Sf_lfrac'
-    cpl_names_x2a(20) = 'So_ustar'
-    cpl_names_x2a(21) = 'So_re'
+    cpl_names_x2a(1)  = 'Faxx_evap' ! SHOC input
+    cpl_names_x2a(2)  = 'Faxx_sen'  ! SHOC input
+    cpl_names_x2a(3)  = 'Faxx_lat'  ! Needed for energy fixer (?)
+    cpl_names_x2a(4)  = 'Faxx_taux' ! SHOC input
+    cpl_names_x2a(5)  = 'Faxx_tauy' ! SHOC input
+    cpl_names_x2a(6)  = 'Faxx_lwup' ! RRTMGP input
+    cpl_names_x2a(7)  = 'Sx_avsdr'  ! RRTMGP input
+    cpl_names_x2a(8)  = 'Sx_anidr'  ! RRTMGP input
+    cpl_names_x2a(9)  = 'Sx_avsdf'  ! RRTMGP input
+    cpl_names_x2a(10) = 'Sx_anidf'  ! RRTMGP input
+    cpl_names_x2a(11) = 'Sx_t'      ! SHOC input (?)
+    cpl_names_x2a(12) = 'Sl_snowh'  ! SHOC input (?)
+    cpl_names_x2a(13) = 'Si_snowh'  ! UNUSED
+    cpl_names_x2a(14) = 'Sx_tref'   ! UNUSED
+    cpl_names_x2a(15) = 'Sx_qref'   ! UNUSED
+    cpl_names_x2a(16) = 'Sx_u10'    ! UNUSED
+    cpl_names_x2a(17) = 'Sf_ifrac'  ! RRTMGP input
+    cpl_names_x2a(18) = 'Sf_ofrac'  ! SHOCK input (?)
+    cpl_names_x2a(19) = 'Sf_lfrac'  ! RRTMGP input
+    cpl_names_x2a(20) = 'So_ustar'  ! SHOC (?): doesn't seem to be cam_in%ustar though
+    cpl_names_x2a(21) = 'So_re'     ! UNUSED
 
     ! Names used by scream for the input fields above
     scr_names_x2a(1)  = 'surface_water_evaporation_flux'
@@ -98,19 +98,19 @@ contains
     scr_names_x2a(21) = 'So_re'
 
     ! List of cpl names of outputs that scream needs to pass back to cpl
-    cpl_names_a2x(1)  = 'Sa_tbot'
-    cpl_names_a2x(2)  = 'Sa_ptem'
-    cpl_names_a2x(3)  = 'Sa_z'
-    cpl_names_a2x(4)  = 'Sa_u'
-    cpl_names_a2x(5)  = 'Sa_v'
-    cpl_names_a2x(6)  = 'Sa_pbot'
-    cpl_names_a2x(7)  = 'Sa_dens'
-    cpl_names_a2x(8)  = 'Sa_shum'
-    cpl_names_a2x(9)  = 'Faxa_rainc'
-    cpl_names_a2x(10) = 'Faxa_rainl'
-    cpl_names_a2x(11) = 'Faxa_snowc'
-    cpl_names_a2x(12) = 'Faxa_snowl'
-    cpl_names_a2x(13)  = 'Sa_co2prog'
+    cpl_names_a2x(1)  = 'Sa_tbot'     ! Temperature (HOMME)
+    cpl_names_a2x(2)  = 'Sa_ptem'     ! Potential temperature (HOMME)
+    cpl_names_a2x(3)  = 'Sa_z'        ! Z coord of bottom layers (in m? Pa?)
+    cpl_names_a2x(4)  = 'Sa_u'        ! Horiz velocity u-comp (HOMME)
+    cpl_names_a2x(5)  = 'Sa_v'        ! Horiz velocity v-comp (HOMME)
+    cpl_names_a2x(6)  = 'Sa_pbot'     ! Pressure (HOMME)
+    cpl_names_a2x(7)  = 'Sa_dens'     ! Density (derived from P, T)
+    cpl_names_a2x(8)  = 'Sa_shum'     ! Specific humidity (Computed by ...?)
+    cpl_names_a2x(9)  = 'Faxa_rainc'  ! Liquid convective precip. P3 (?)
+    cpl_names_a2x(10) = 'Faxa_rainl'  ! Liquire large-scale precip. P3 (?)
+    cpl_names_a2x(11) = 'Faxa_snowc'  ! Frozen convective precip. P3 (?)
+    cpl_names_a2x(12) = 'Faxa_snowl'  ! Frozen large scale precip. P3 (?)
+    cpl_names_a2x(13)  = 'Sa_co2prog' ! NOT COMPUTED by SCREAM (?)
 
     ! Names used by scream for the output fields above
     scr_names_a2x(1)  = 'surface_temperature'


### PR DESCRIPTION
This PR fixes errors in the SC class, as well as adds a unit test for it. The UT simply exports and imports a field, checking that the result is equal to the input (at the surface only, obviously).

More still has to be done to make SC fully working in cime runs. In particular, all fields are still not present in the field repo, which causes the SC to throw errors. Skipping fields registration is not possible at the moment, since it would cause errors at run time (I haven't implemented a logic to skip fields, but i should add it at some point, since not all input fields from the cpl are needed by scream).