### PR TITLE
Move scream_config.h config later in file

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -254,12 +254,6 @@ print_var(SCREAM_TPL_LIBRARIES)
 # whether to include scream_config.h.
 add_definitions(-DSCREAM_CONFIG_IS_CMAKE)
 
-# Generate scream_config.h and scream_config.f
-include (EkatUtils)
-EkatConfigFile(${CMAKE_CURRENT_SOURCE_DIR}/src/scream_config.h.in
-               ${CMAKE_CURRENT_BINARY_DIR}/src/scream_config.h
-               F90_FILE ${CMAKE_CURRENT_BINARY_DIR}/src/scream_config.f)
-
 # Hooks for testing test-all-scream within test-scripts
 if ($ENV{SCREAM_FORCE_BUILD_FAIL})
   add_definitions(-DSCREAM_FORCE_BUILD_FAIL)
@@ -308,3 +302,9 @@ endif()
 
 # Build any tools in the scripts/ dir.
 add_subdirectory(scripts)
+
+# Generate scream_config.h and scream_config.f
+include (EkatUtils)
+EkatConfigFile(${CMAKE_CURRENT_SOURCE_DIR}/src/scream_config.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/src/scream_config.h
+               F90_FILE ${CMAKE_CURRENT_BINARY_DIR}/src/scream_config.f)


### PR DESCRIPTION
With this PR, a SCREAMV1 case (SMS.ne4_ne4.F2000-SCREAM-SA) is buildable through CIME. The case will not run correctly (crashes during init) because there's still lots of runtime stuff that needs to be hooked together.

On caveat on mappy: GCC-9.2 is needed to support EPYC-specific compiler flags but switching to that compiler causes memleak issues with the V0 scream cime tests, so we can't just change config_machines.xml. I made a temporary change to my local config_machines.xml so I could work on mappy:

```
@@ -673,7 +673,7 @@
         <command name="load">sems-cmake/3.12.2</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">sems-gcc/7.3.0</command>
+        <command name="load">sems-gcc/9.2.0</command>
```
which I did not push.

Fixes #813 

