### PR TITLE
Fields subviews

### DIFF
--- a/components/scream/cmake/tpls/Scorpio.cmake
+++ b/components/scream/cmake/tpls/Scorpio.cmake
@@ -55,6 +55,11 @@ macro (CreateScorpioTarget CREATE_FLIB)
     else ()
       # Not a CIME build. Add scorpio as a subdir
       add_subdirectory (${E3SM_EXTERNALS_DIR}/scorpio ${CMAKE_BINARY_DIR}/externals/scorpio)
+      EkatDisableAllWarning(pioc)
+      EkatDisableAllWarning(gptl)
+      if (CREATE_FLIB)
+        EkatDisableAllWarning(pioc)
+      endif()
     endif()
   endif ()
 

--- a/components/scream/src/control/surface_coupling.cpp
+++ b/components/scream/src/control/surface_coupling.cpp
@@ -91,7 +91,7 @@ register_import(const std::string& fname,
                          "Error! Unexpected tag '" + e2str(tags[1]) + "' for second dimension of export field '" + fname + "'.\n");
       EKAT_REQUIRE_MSG(tags.back()!=VL || vecComp==-1, "Error! Vector component specified, but field '" + fname + "' is a 3d scalar.\n");
 
-      info.col_stride = alloc_prop.get_last_dim_extent<Real>();
+      info.col_stride = alloc_prop.get_last_extent();
       info.col_offset = vecComp;
       break;
     case 3:
@@ -101,7 +101,7 @@ register_import(const std::string& fname,
                          "Error! Unexpected tag '" + e2str(tags[2]) + "' for third dimension of export field '" + fname + "'.\n");
       EKAT_REQUIRE_MSG(vecComp>=0, "Error! Vector component not specified for 3d vector field '" + fname + "/.\n");
 
-      info.col_stride = layout.dim(1)*alloc_prop.get_last_dim_extent<Real>();
+      info.col_stride = layout.dim(1)*alloc_prop.get_last_extent();
       info.col_offset = tags[1]==VL ? 0 : vecComp;
       break;
     default:
@@ -175,7 +175,7 @@ register_export (const std::string& fname,
                          "Error! Unexpected tag '" + e2str(tags[1]) + "' for second dimension of import field '" + fname + "'.\n");
       EKAT_REQUIRE_MSG(tags.back()!=VL || vecComp==-1, "Error! Vector component specified, but field '" + fname + "' is a 3d scalar.\n");
 
-      info.col_stride = alloc_prop.get_last_dim_extent<Real>();
+      info.col_stride = alloc_prop.get_last_extent();
       info.col_offset = tags[1]==VL ? 0 : vecComp;
       break;
     case 3:
@@ -185,7 +185,7 @@ register_export (const std::string& fname,
                          "Error! Unexpected tag '" + e2str(tags[2]) + "' for third dimension of import field '" + fname + "'.\n");
       EKAT_REQUIRE_MSG(vecComp>=0, "Error! Vector component not specified for 3d vector field '" + fname + "/.\n");
 
-      info.col_stride = layout.dim(1)*alloc_prop.get_last_dim_extent<Real>();
+      info.col_stride = layout.dim(1)*alloc_prop.get_last_extent();
       info.col_offset = vecComp;
       break;
     default:

--- a/components/scream/src/control/surface_coupling.hpp
+++ b/components/scream/src/control/surface_coupling.hpp
@@ -105,8 +105,8 @@ protected:
 protected:
 #endif
 
-  using import_value_type  = import_field_type::value_type;
-  using export_value_type  = export_field_type::value_type;
+  using import_value_type  = import_field_type::RT;
+  using export_value_type  = export_field_type::RT;
 
   // Packed, device-friendly verson of the helper structures above
   view_1d<device_type,Info<import_value_type>>  m_scream_imports_dev;

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -125,6 +125,7 @@ void HommeDynamics::initialize_impl (const util::TimeStamp& /* t0 */)
 
   constexpr int NTL  = HOMMEXX_NUM_TIME_LEVELS;
   constexpr int NVL  = HOMMEXX_NUM_LEV;
+  constexpr int NVLI = HOMMEXX_NUM_LEV_P;
   constexpr int QNTL = HOMMEXX_Q_NUM_TIME_LEVELS;
 
   // Computed fields
@@ -147,13 +148,13 @@ void HommeDynamics::initialize_impl (const util::TimeStamp& /* t0 */)
     } else if (name=="phi") {
       // Geopotential
       auto& phi = state.m_phinh_i;
-      auto phi_in = f.get_reshaped_view<Scalar*[NTL][NP][NP][NVL]>();
+      auto phi_in = f.get_reshaped_view<Scalar*[NTL][NP][NP][NVLI]>();
       using phi_type = std::remove_reference<decltype(phi)>::type;
       phi = phi_type(phi_in.data(),num_elems);
     } else if (name=="w") {
       // Geopotential
       auto& w = state.m_w_i;
-      auto w_in = f.get_reshaped_view<Scalar*[NTL][NP][NP][NVL]>();
+      auto w_in = f.get_reshaped_view<Scalar*[NTL][NP][NP][NVLI]>();
       using w_type = std::remove_reference<decltype(w)>::type;
       w = w_type(w_in.data(),num_elems);
     } else if (name=="dp") {

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -309,10 +309,10 @@ do_remap_fwd() const
     const auto& phys_alloc_prop = ph.get_alloc_properties();
     const auto& dyn_alloc_prop  = dh.get_alloc_properties();
 
-    const bool phys_pack_alloc = phys_alloc_prop.template is_allocation_compatible_with_value_type<pack_type>();
-    const bool dyn_pack_alloc  = dyn_alloc_prop.template  is_allocation_compatible_with_value_type<pack_type>();
-    const bool phys_small_pack_alloc = phys_alloc_prop.template is_allocation_compatible_with_value_type<small_pack_type>();
-    const bool dyn_small_pack_alloc  = dyn_alloc_prop.template  is_allocation_compatible_with_value_type<small_pack_type>();
+    const bool phys_pack_alloc = phys_alloc_prop.template is_compatible<pack_type>();
+    const bool dyn_pack_alloc  = dyn_alloc_prop.template  is_compatible<pack_type>();
+    const bool phys_small_pack_alloc = phys_alloc_prop.template is_compatible<small_pack_type>();
+    const bool dyn_small_pack_alloc  = dyn_alloc_prop.template  is_compatible<small_pack_type>();
 
     const auto phys_lt = get_layout_type(ph.get_identifier().get_layout().tags());
     switch (phys_lt) {
@@ -360,10 +360,10 @@ do_remap_bwd() const {
     const auto& phys_alloc_prop = ph.get_alloc_properties();
     const auto& dyn_alloc_prop  = dh.get_alloc_properties();
 
-    const bool phys_pack_alloc = phys_alloc_prop.template is_allocation_compatible_with_value_type<pack_type>();
-    const bool dyn_pack_alloc  = dyn_alloc_prop.template  is_allocation_compatible_with_value_type<pack_type>();
-    const bool phys_small_pack_alloc = phys_alloc_prop.template is_allocation_compatible_with_value_type<small_pack_type>();
-    const bool dyn_small_pack_alloc  = dyn_alloc_prop.template  is_allocation_compatible_with_value_type<small_pack_type>();
+    const bool phys_pack_alloc = phys_alloc_prop.template is_compatible<pack_type>();
+    const bool dyn_pack_alloc  = dyn_alloc_prop.template  is_compatible<pack_type>();
+    const bool phys_small_pack_alloc = phys_alloc_prop.template is_compatible<small_pack_type>();
+    const bool dyn_small_pack_alloc  = dyn_alloc_prop.template  is_compatible<small_pack_type>();
 
     const int itl = m_is_state_field[i] ? (m_is_tracer_field[i] ? tl.np1_qdp : tl.np1) : -1;
 

--- a/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -178,17 +178,17 @@ TEST_CASE("remap", "") {
   Field<Real> ts_3d_field_dyn (ts_3d_dyn_fid);
 
   // Request allocation to fit packs of reals for 3d views
-  s_3d_field_phys.get_header().get_alloc_properties().request_value_type_allocation<PackType>();
-  v_3d_field_phys.get_header().get_alloc_properties().request_value_type_allocation<PackType>();
-  ss_3d_field_phys.get_header().get_alloc_properties().request_value_type_allocation<PackType>();
-  vs_3d_field_phys.get_header().get_alloc_properties().request_value_type_allocation<PackType>();
-  ts_3d_field_phys.get_header().get_alloc_properties().request_value_type_allocation<PackType>();
+  s_3d_field_phys.get_header().get_alloc_properties().request_allocation<PackType>();
+  v_3d_field_phys.get_header().get_alloc_properties().request_allocation<PackType>();
+  ss_3d_field_phys.get_header().get_alloc_properties().request_allocation<PackType>();
+  vs_3d_field_phys.get_header().get_alloc_properties().request_allocation<PackType>();
+  ts_3d_field_phys.get_header().get_alloc_properties().request_allocation<PackType>();
 
-  s_3d_field_dyn.get_header().get_alloc_properties().request_value_type_allocation<PackType>();
-  v_3d_field_dyn.get_header().get_alloc_properties().request_value_type_allocation<PackType>();
-  ss_3d_field_dyn.get_header().get_alloc_properties().request_value_type_allocation<PackType>();
-  vs_3d_field_dyn.get_header().get_alloc_properties().request_value_type_allocation<PackType>();
-  ts_3d_field_dyn.get_header().get_alloc_properties().request_value_type_allocation<PackType>();
+  s_3d_field_dyn.get_header().get_alloc_properties().request_allocation<PackType>();
+  v_3d_field_dyn.get_header().get_alloc_properties().request_allocation<PackType>();
+  ss_3d_field_dyn.get_header().get_alloc_properties().request_allocation<PackType>();
+  vs_3d_field_dyn.get_header().get_alloc_properties().request_allocation<PackType>();
+  ts_3d_field_dyn.get_header().get_alloc_properties().request_allocation<PackType>();
   ts_3d_field_dyn.get_header().set_extra_data("Is Tracer State", true);
 
   // Allocate view

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -320,7 +320,7 @@ void P3Microphysics::set_required_field_impl (const Field<const Real>& f) {
   // in the Homme's view, and be done with it.
   const auto& name = f.get_header().get_identifier().name();
   m_p3_fields_in.emplace(name,f);
-  m_p3_host_views_in[name] = f.get_view<HostDevice>();
+  m_p3_host_views_in[name] = f.get_view<Host>();
   m_raw_ptrs_in[name] = m_p3_host_views_in[name].data();
 
   // Add myself as customer to the field
@@ -334,7 +334,7 @@ void P3Microphysics::set_computed_field_impl (const Field<      Real>& f) {
   // in the Homme's view, and be done with it.
   const auto& name = f.get_header().get_identifier().name();
   m_p3_fields_out.emplace(name,f);
-  m_p3_host_views_out[name] = f.get_view<HostDevice>();
+  m_p3_host_views_out[name] = f.get_view<Host>();
   m_raw_ptrs_out[name] = m_p3_host_views_out[name].data();
 
   // Add myself as provider for the field

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -243,22 +243,23 @@ void P3Microphysics::run_impl (const Real dt)
 
   // Copy inputs to host. Copy also outputs, cause we might "update" them, rather than overwrite them.
   for (auto& it : m_p3_fields_in) {
-    Kokkos::deep_copy(m_p3_host_views_in.at(it.first),it.second.get_view());
+    it.second.sync_to_host();
   }
   for (auto& it : m_p3_fields_out) {
-    Kokkos::deep_copy(m_p3_host_views_out.at(it.first),it.second.get_view());
+    it.second.sync_to_host();
   }
 
   // Copy outputs back to device
+  // LB: why?!?
   for (auto& it : m_p3_fields_out) {
-    Kokkos::deep_copy(it.second.get_view(),m_p3_host_views_out.at(it.first));
+    it.second.sync_to_dev();
   }
 
   // Gather views needed to pre-process local variables.
   auto T_atm  = m_p3_fields_out["T_atm"].get_reshaped_view<Pack**>();
   auto ast    = m_p3_fields_in["ast"].get_reshaped_view<const Pack**>();
   auto zi     = m_p3_fields_in["zi"].get_reshaped_view<const Pack**>();
-  auto pmid            = m_p3_fields_in["pmid"].get_reshaped_view<const Pack**>();
+  auto pmid   = m_p3_fields_in["pmid"].get_reshaped_view<const Pack**>();
 
   // Assign values to local arrays used by P3, these are now stored in p3_loc.
   const Int nk_pack = ekat::npack<Spack>(m_num_levs);
@@ -319,7 +320,7 @@ void P3Microphysics::set_required_field_impl (const Field<const Real>& f) {
   // in the Homme's view, and be done with it.
   const auto& name = f.get_header().get_identifier().name();
   m_p3_fields_in.emplace(name,f);
-  m_p3_host_views_in[name] = Kokkos::create_mirror_view(f.get_view());
+  m_p3_host_views_in[name] = f.get_view<HostDevice>();
   m_raw_ptrs_in[name] = m_p3_host_views_in[name].data();
 
   // Add myself as customer to the field
@@ -333,7 +334,7 @@ void P3Microphysics::set_computed_field_impl (const Field<      Real>& f) {
   // in the Homme's view, and be done with it.
   const auto& name = f.get_header().get_identifier().name();
   m_p3_fields_out.emplace(name,f);
-  m_p3_host_views_out[name] = Kokkos::create_mirror_view(f.get_view());
+  m_p3_host_views_out[name] = f.get_view<HostDevice>();
   m_raw_ptrs_out[name] = m_p3_host_views_out[name].data();
 
   // Add myself as provider for the field

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -164,8 +164,11 @@ protected:
   std::map<std::string,const_field_type>  m_p3_fields_in;
   std::map<std::string,field_type>        m_p3_fields_out;
 
-  std::map<std::string,const_field_type::view_type::HostMirror>  m_p3_host_views_in;
-  std::map<std::string,field_type::view_type::HostMirror>        m_p3_host_views_out;
+  using host_view_in_type  = const_field_type::view_type<const_field_type::RT*>;
+  using host_view_out_type =       field_type::view_type<      field_type::RT*>;
+
+  std::map<std::string,host_view_in_type>   m_p3_host_views_in;
+  std::map<std::string,host_view_out_type>  m_p3_host_views_out;
 
   std::map<std::string,const Real*>  m_raw_ptrs_in;
   std::map<std::string,Real*>        m_raw_ptrs_out;

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -164,8 +164,12 @@ protected:
   std::map<std::string,const_field_type>  m_p3_fields_in;
   std::map<std::string,field_type>        m_p3_fields_out;
 
-  using host_view_in_type  = const_field_type::view_type<const_field_type::RT*>;
-  using host_view_out_type =       field_type::view_type<      field_type::RT*>;
+  template<typename T>
+  using view_type = field_type::view_type<T*>;
+
+  using host_view_in_type  = typename view_type<const_field_type::RT>::HostMirror;
+  using host_view_out_type = typename view_type<field_type::RT>::HostMirror;
+
 
   std::map<std::string,host_view_in_type>   m_p3_host_views_in;
   std::map<std::string,host_view_out_type>  m_p3_host_views_out;

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -167,9 +167,11 @@ protected:
   template<typename T>
   using view_type = field_type::view_type<T*>;
 
-  using host_view_in_type  = typename view_type<const_field_type::RT>::HostMirror;
-  using host_view_out_type = typename view_type<field_type::RT>::HostMirror;
+  template<typename T>
+  using host_view_type = field_type::get_view_type<view_type<T>,Host>;
 
+  using host_view_in_type   = host_view_type<const_field_type::RT>;
+  using host_view_out_type  = host_view_type<      field_type::RT>;
 
   std::map<std::string,host_view_in_type>   m_p3_host_views_in;
   std::map<std::string,host_view_out_type>  m_p3_host_views_out;

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -5,6 +5,8 @@
 #include "physics/share/physics_functions.hpp" // also for ETI not on GPUs
 #include "physics/share/physics_saturation_impl.hpp"
 
+#include "ekat/kokkos/ekat_subview_utils.hpp"
+
 namespace scream {
 namespace p3 {
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -1,9 +1,11 @@
 #include "shoc_functions_f90.hpp"
 
+#include "shoc_f90.hpp"
+
 #include "ekat/ekat_assert.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/ekat_pack_kokkos.hpp"
-#include "shoc_f90.hpp"
+#include "ekat/kokkos/ekat_subview_utils.hpp"
 
 #include <random>
 

--- a/components/scream/src/physics/shoc/shoc_main_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_main_impl.hpp
@@ -2,6 +2,9 @@
 #define SHOC_MAIN_IMPL_HPP
 
 #include "shoc_functions.hpp" // for ETI only but harmless for GPU
+
+#include "ekat/kokkos/ekat_subview_utils.hpp"
+
 #include <iomanip>
 
 namespace scream {

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
@@ -152,8 +152,9 @@ void ZMDeepConvection::set_required_field_impl (const Field<const Real>& f) {
   // in the Homme's view, and be done with it.
   const auto& name = f.get_header().get_identifier().name();
   m_zm_fields_in.emplace(name,f);
-  m_zm_host_views_in[name] = f.get_view<HostDevice>();
+  m_zm_host_views_in[name] = f.get_view<Host>();
   m_raw_ptrs_in[name] = m_zm_host_views_in[name].data();
+
   // Add myself as customer to the field
   add_me_as_customer(f);
 
@@ -166,7 +167,7 @@ void ZMDeepConvection::set_computed_field_impl (const Field<      Real>& f) {
   // in the Homme's view, and be done with it.
   const auto& name = f.get_header().get_identifier().name();
   m_zm_fields_out.emplace(name,f);
-  m_zm_host_views_out[name] = f.get_view<HostDevice>();
+  m_zm_host_views_out[name] = f.get_view<Host>();
   m_raw_ptrs_out[name] = m_zm_host_views_out[name].data();
 
   // Add myself as provider for the field

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
@@ -93,10 +93,10 @@ void ZMDeepConvection::run_impl (const Real dt)
 
   // Copy inputs to host. Copy also outputs, cause we might "update" them, rather than overwrite them.
   for (auto& it : m_zm_fields_in) {
-    Kokkos::deep_copy(m_zm_host_views_in.at(it.first),it.second.get_view());
+    it.second.sync_to_host();
   }
   for (auto& it : m_zm_fields_out) {
-    Kokkos::deep_copy(m_zm_host_views_out.at(it.first),it.second.get_view());
+    it.second.sync_to_host();
   }
 
   Real** temp = &m_raw_ptrs_out["fracis"];
@@ -152,7 +152,7 @@ void ZMDeepConvection::set_required_field_impl (const Field<const Real>& f) {
   // in the Homme's view, and be done with it.
   const auto& name = f.get_header().get_identifier().name();
   m_zm_fields_in.emplace(name,f);
-  m_zm_host_views_in[name] = Kokkos::create_mirror_view(f.get_view());
+  m_zm_host_views_in[name] = f.get_view<HostDevice>();
   m_raw_ptrs_in[name] = m_zm_host_views_in[name].data();
   // Add myself as customer to the field
   add_me_as_customer(f);
@@ -166,7 +166,7 @@ void ZMDeepConvection::set_computed_field_impl (const Field<      Real>& f) {
   // in the Homme's view, and be done with it.
   const auto& name = f.get_header().get_identifier().name();
   m_zm_fields_out.emplace(name,f);
-  m_zm_host_views_out[name] = Kokkos::create_mirror_view(f.get_view());
+  m_zm_host_views_out[name] = f.get_view<HostDevice>();
   m_raw_ptrs_out[name] = m_zm_host_views_out[name].data();
 
   // Add myself as provider for the field

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.hpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.hpp
@@ -69,8 +69,11 @@ protected:
   std::map<std::string,const_field_type>  m_zm_fields_in;
   std::map<std::string,field_type>        m_zm_fields_out;
 
-  using host_view_in_type  = const_field_type::view_type<const_field_type::RT*>;
-  using host_view_out_type =       field_type::view_type<      field_type::RT*>;
+  template<typename T>
+  using view_1d = field_type::view_type<T*>;
+
+  using host_view_in_type  = typename view_1d<const_field_type::RT>::HostMirror;
+  using host_view_out_type = typename view_1d<field_type::RT>::HostMirror;
 
   std::map<std::string,host_view_in_type>   m_zm_host_views_in;
   std::map<std::string,host_view_out_type>  m_zm_host_views_out;

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.hpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.hpp
@@ -69,9 +69,11 @@ protected:
   std::map<std::string,const_field_type>  m_zm_fields_in;
   std::map<std::string,field_type>        m_zm_fields_out;
 
-  std::map<std::string,const_field_type::view_type::HostMirror>  m_zm_host_views_in;
-  std::map<std::string,field_type::view_type::HostMirror>        m_zm_host_views_out;
+  using host_view_in_type  = const_field_type::view_type<const_field_type::RT*>;
+  using host_view_out_type =       field_type::view_type<      field_type::RT*>;
 
+  std::map<std::string,host_view_in_type>   m_zm_host_views_in;
+  std::map<std::string,host_view_out_type>  m_zm_host_views_out;
 
   util::TimeStamp   m_current_ts;
   ekat::Comm              m_zm_comm;

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.hpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.hpp
@@ -70,10 +70,13 @@ protected:
   std::map<std::string,field_type>        m_zm_fields_out;
 
   template<typename T>
-  using view_1d = field_type::view_type<T*>;
+  using view_type = field_type::view_type<T*>;
 
-  using host_view_in_type  = typename view_1d<const_field_type::RT>::HostMirror;
-  using host_view_out_type = typename view_1d<field_type::RT>::HostMirror;
+  template<typename T>
+  using host_view_type = field_type::get_view_type<view_type<T>,Host>;
+
+  using host_view_in_type   = host_view_type<const_field_type::RT>;
+  using host_view_out_type  = host_view_type<      field_type::RT>;
 
   std::map<std::string,host_view_in_type>   m_zm_host_views_in;
   std::map<std::string,host_view_out_type>  m_zm_host_views_out;

--- a/components/scream/src/physics/zm/zm_inputs_initializer.cpp
+++ b/components/scream/src/physics/zm/zm_inputs_initializer.cpp
@@ -11,14 +11,14 @@ namespace scream
 
 using namespace std;
 std::vector<string> zm_inputs = {"limcnv_in", "no_deep_pbl_in","lchnk", "ncol", "t", "qh", "prec",
-			"jctop", "jcbot", "pblh", "zm", "geos", "zi", "qtnd", "heat",
-			"pap", "paph", "dpp", "delt", "mcon", "cme", "cape", "tpert",
-			"dlf", "pflx", "zdu", "rprd", "mu", "md", "du", "eu", "ed",
-			"dp", "dsubcld", "jt", "maxg", "ideep", "lengath", "ql",
-			"rliq", "landfrac", "hu_nm1", "cnv_nm1", "tm1", "qm1", "t_star",
-			"q_star", "dcape", "q", "tend_s", "tend_q", "cld", "snow",
-			"ntprprd", "ztodt", "ntsnprd", "flxprec", "flxsnow", "pguall",
-			"pgdall", "icwu", "ncnst", "fracis"};
+      "jctop", "jcbot", "pblh", "zm", "geos", "zi", "qtnd", "heat",
+      "pap", "paph", "dpp", "delt", "mcon", "cme", "cape", "tpert",
+      "dlf", "pflx", "zdu", "rprd", "mu", "md", "du", "eu", "ed",
+      "dp", "dsubcld", "jt", "maxg", "ideep", "lengath", "ql",
+      "rliq", "landfrac", "hu_nm1", "cnv_nm1", "tm1", "qm1", "t_star",
+      "q_star", "dcape", "q", "tend_s", "tend_q", "cld", "snow",
+      "ntprprd", "ztodt", "ntsnprd", "flxprec", "flxsnow", "pguall",
+      "pgdall", "icwu", "ncnst", "fracis"};
 
 
 const int INPUT_SIZE = 63;
@@ -29,7 +29,6 @@ const int INPUT_SIZE = 63;
 const int SCALAR_3D_MID = 0;
 const int SCALAR_3D_INT = 1;
 const int VECTOR_3D_MID = 2;
-const int TRACERS = 3;
 const int LINEAR = 4;
 
 using namespace std;

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -1,4 +1,5 @@
 #include "share/atm_process/atmosphere_process_group.hpp"
+#include "share/field/field_utils.hpp"
 
 #include "ekat/std_meta/ekat_std_utils.hpp"
 #include "ekat/util/ekat_string_utils.hpp"
@@ -477,34 +478,6 @@ set_field_repos (const FieldRepository<Real>& repo,
   }
 }
 
-bool AtmosphereProcessGroup::
-views_are_equal(const field_type& f1, const field_type& f2) {
-  const auto& layout = f1.get_header().get_identifier().get_layout();
-  const int size = layout.size();
-  const int last_dim_alloc_size = f1.get_header().get_alloc_properties().get_last_dim_alloc_size();
-  const int last_alloc_dim = last_dim_alloc_size / sizeof(Real);
-  const int last_dim = layout.dim(layout.rank()-1);
-
-  const auto v1 = f1.get_view();
-  const auto v2 = f2.get_view();
-
-  using exec_space = field_type::view_type::execution_space;
-  Kokkos::RangePolicy<exec_space> policy(0,size);
-  int num_diffs = 0;
-  Kokkos::parallel_reduce(
-    policy,
-    [=](const int i, int& sum){
-      const int outer_dim = i / last_dim;
-      const int inner_dim = i % last_dim;
-      const int idx = outer_dim*last_alloc_dim + inner_dim;
-
-      if (v1(idx)!=v2(idx)) {
-        ++sum;
-      }
-    },num_diffs
-  );
-  return (num_diffs == 0);
-}
 #endif
 
 FieldIdentifier

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -160,11 +160,9 @@ protected:
 
 #ifdef SCREAM_DEBUG
   using field_type = Field<Real>;
-  bool views_are_equal (const field_type& v1, const field_type& v2);
 
   const FieldRepository<Real>*   m_field_repo;
   const FieldRepository<Real>*   m_bkp_field_repo;
-
 #endif
 };
 

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -360,9 +360,8 @@ auto Field<RealType>::get_reshaped_view () const
   // to something like a pack), or to a view of the correct rank
   constexpr int DstRank = DstView::rank;
 
-  EKAT_REQUIRE_MSG(DstRank==field_layout.rank() || DstRank==1,
-      "Error! You can only reshape to a 1d view (possibly with different value tyep),\n"
-      "       or to a view of the correct rank (equal to the FieldLayout's one).\n");
+  EKAT_REQUIRE_MSG(DstRank==field_layout.rank(),
+      "Error! You can only reshape to a view of the correct rank (equal to the FieldLayout's one).\n");
 
   // Check the reinterpret cast makes sense for the Dst value types (need integer sizes ratio)
   EKAT_REQUIRE_MSG(alloc_prop.template is_compatible<DstValueType>(),

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -217,9 +217,7 @@ protected:
   if_t<(N<=2),
        get_view_type<view_ND_type<T,N-1>,Space>>
   get_subview_1 (const get_view_type<view_ND_type<T,N>,Space>&, const int) const {
-    get_view_type<view_ND_type<T,N-1>,Space> sv;
     EKAT_ERROR_MSG ("Error! Cannot subview a rank2 view along the second dimension without losing LayoutRight.\n");
-    return sv;
   }
 
   template<typename Space,typename T,int N>

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -100,6 +100,20 @@ public:
   get_reshaped_view () const;
 
   // Returns a subview of this field, slicing at entry k along dimension idim
+  // NOTES:
+  //   - the output field stores *the same* 1d view as this field. In order
+  //     to get the N-1 dimensional view, call get_reshaped_view<DT>(), using
+  //     the correct N-1 dimensional data type DT.
+  //   - when calling get_reshaped_view<DT>() on the N-1 dimensional subfield,
+  //     we first get an N-dimensional view, then subview it at index k along
+  //     dimension idim.
+  //   - idim must be either 0 or 1. This is b/c we cannot subview an N-dim
+  //     view along idim=2+ while keeping LayoutRight. Kokkos would force the
+  //     resulting view to have layout stride, which would conflict with the
+  //     return type of get_reshaped_view<DT>().
+  //   - If the field rank is 2, then idim cannot be 1. This is b/c Kokkos
+  //     specializes view's traits for LayoutRight of rank 1, not allowing
+  //     to store a stride for the slowest dimension.
   field_type subfield (const std::string& sf_name, const int idim, const int k) const;
   field_type subfield (const int idim, const int k) const;
 

--- a/components/scream/src/share/field/field_alloc_prop.cpp
+++ b/components/scream/src/share/field/field_alloc_prop.cpp
@@ -5,39 +5,149 @@ namespace scream {
 FieldAllocProp::FieldAllocProp ()
  : m_value_type_sizes (0)
  , m_scalar_type_size (0)
- , m_scalar_type_name ("")
  , m_alloc_size       (0)
  , m_committed        (false)
 {
-  // Nothing to be done here
+  // Set to something invalid
+  m_subview_idx = std::make_pair(-1,-1);
 }
 
-void FieldAllocProp::commit (const FieldLayout& layout)
+FieldAllocProp& FieldAllocProp::operator= (const FieldAllocProp& src)
 {
-  if (m_committed) {
+  if  (&src!=this) {
+    EKAT_REQUIRE_MSG (m_scalar_type_size==0,
+        "Error! Cannot assign FieldAllocProp if the dst obj is not clean.\n");
+
+    m_layout = src.m_layout;
+    m_value_type_sizes = src.m_value_type_sizes;
+    m_scalar_type_size = src.m_scalar_type_size;
+    m_last_extent = src.m_last_extent;
+    m_alloc_size = src.m_alloc_size;
+    m_subview_idx = src.m_subview_idx;
+    m_contiguous = src.m_contiguous;
+    m_committed = src.m_committed;
+  }
+  return *this;
+}
+
+FieldAllocProp FieldAllocProp::
+subview (const int idim, const int k) const {
+  EKAT_REQUIRE_MSG(is_committed(),
+      "Error! Subview requires alloc properties to be committed.\n");
+  EKAT_REQUIRE_MSG (idim==0 || idim==1,
+      "Error! Subviewing is only allowed along first or second dimension.\n");
+  EKAT_REQUIRE_MSG (idim<m_layout->rank(),
+      "Error! Dimension index out of bounds.\n");
+  EKAT_REQUIRE_MSG (k>=0 && k<m_layout->dim(idim),
+      "Error! Index along the dimension is out of bounds.\n");
+
+  // Set new layout basic stuff
+  FieldAllocProp props;
+  props.m_committed = false;
+  props.m_scalar_type_size = m_scalar_type_size;
+  props.m_alloc_size = m_alloc_size / m_layout->dim(idim);
+  props.m_subview_idx = std::make_pair(idim,k);
+
+  // Output is contioguous if a) this->m_contiguous=true,
+  // b) idim==0, or if m_layout->dim(i)==1 for i<idim
+  props.m_contiguous = m_contiguous;
+  for (int i=0; i<idim; ++i) {
+    if (m_layout->dim(i)>0) {
+      props.m_contiguous = false;
+      break;
+    }
+  }
+
+  // The output props should still store a FieldLayout, in case
+  // they are further subviewed. We have all we need here to build
+  // a layout from scratch, but it would duplicate what is inside
+  // the FieldIdentifier that will be built for the corresponding
+  // field. Therefore, we'll require the user to still call 'commit',
+  // passing the layout from the field id.
+  // HOWEVER, this may cause bugs, cause the user might make a mistake,
+  // and pass the wrong layout. Therefore, we build a "temporary" one,
+  // which will be replaced during the call to 'commit'.
+  std::vector<FieldTag> tags = m_layout->tags();
+  std::vector<int> dims = m_layout->dims();
+  tags.erase(tags.begin()+idim);
+  dims.erase(dims.begin()+idim);
+  props.m_layout = std::make_shared<layout_type>(tags,dims);
+
+  // Figure out strides
+  const int rm1 = m_layout->rank()-1;
+  if (idim==rm1) {
+    // We're slicing the possibly padded dim, so everything else is as in the layout
+    props.m_last_extent = m_layout->dim(idim);
+  } else {
+    // We are keeping the last dim, so same last extent
+    props.m_last_extent = m_last_extent;
+  }
+  return props;
+}
+
+int FieldAllocProp::get_alloc_size () const {
+  EKAT_REQUIRE_MSG(is_committed(),
+      "Error! You cannot query the allocation properties until they have been committed.");
+  return m_alloc_size;
+}
+
+int FieldAllocProp::get_last_extent () const {
+  EKAT_REQUIRE_MSG(is_committed(),
+      "Error! You cannot query the allocation strides until after calling commit().");
+  return m_last_extent;
+}
+
+void FieldAllocProp::commit (const layout_ptr_type& layout)
+{
+  if (is_committed()) {
     // TODO: should we issue a warning? Error? For now, I simply do nothing
     return;
   }
 
-  // Sanity checks: we must have requested at least one value type, and the identifier needs all dimensions set by now.
-  EKAT_REQUIRE_MSG(m_value_type_sizes.size()>0, "Error! No value types requested for the allocation.\n");
-  EKAT_REQUIRE_MSG(layout.are_dimensions_set(), "Error! You need all field dimensions set before committing the allocation properties.\n");
+  EKAT_REQUIRE_MSG (layout,
+      "Error! Invalid input layout pointer.\n");
 
-  // Loop on all value type sizes.
-  m_last_dim_alloc_size = 0;
-  for (auto vts : m_value_type_sizes) {
-    // The number of scalar_type in a value_type
-    const int num_scalars_in_value_type = vts / m_scalar_type_size;
+  if (m_alloc_size>0) {
+    // This obj was created as a subview of another alloc props obj.
+    // Check that input layout matches the stored one, then replace the ptr.
+    EKAT_REQUIRE_MSG (*layout==*m_layout,
+        "Error! The input field layout does not match the stored one.\n");
 
-    // The number of value_type's needed in the fast-striding dimension
-    const int num_last_dim_value_types = (layout.dims().back() + num_scalars_in_value_type - 1) / num_scalars_in_value_type;
-
-    // The size of such allocation (along the last dim only)
-    m_last_dim_alloc_size = std::max(m_last_dim_alloc_size, vts * num_last_dim_value_types);
+    m_layout = layout;
+    m_committed = true;
+    return;
   }
 
-  m_alloc_size = (layout.size() / layout.dims().back()) // All except the last dimension
-                 * m_last_dim_alloc_size;
+  // Sanity checks: we must have requested at least one value type, and the identifier needs all dimensions set by now.
+  EKAT_REQUIRE_MSG(m_value_type_sizes.size()>0,
+      "Error! No value types requested for the allocation.\n");
+  EKAT_REQUIRE_MSG(layout->are_dimensions_set(),
+      "Error! You need all field dimensions set before committing the allocation properties.\n");
+
+  // Store pointer to layout for future use (in case subview is called)
+  m_layout = layout;
+
+  // Loop on all value type sizes.
+  m_last_extent = 0;
+  int last_phys_extent = m_layout->dims().back();
+  for (auto vts : m_value_type_sizes) {
+    // The number of scalar_type in a value_type
+    const int vt_len = vts / m_scalar_type_size;
+
+    // The number of value_type's needed in the fast-striding dimension
+    const int num_vt = (last_phys_extent + vt_len - 1) / vt_len;
+
+    // The total number of scalars with num_vt value_type entries
+    const int num_st = num_vt*vt_len;
+
+    // The size of such allocation (along the last dim only)
+    m_last_extent = std::max(m_last_extent, num_st);
+  }
+
+  m_alloc_size = (m_layout->size() / last_phys_extent) // All except the last dimension
+                 * m_last_extent * m_scalar_type_size;
+
+  m_contiguous = true;
 
   m_committed = true;
 }

--- a/components/scream/src/share/field/field_alloc_prop.hpp
+++ b/components/scream/src/share/field/field_alloc_prop.hpp
@@ -16,20 +16,42 @@ namespace scream
  *  Small structure holding a few properties of the field allocation
  *
  *  This class allows to keep track of a field allocation properties.
- *  The reason for this is that the allocation could be different from
- *  what one would infer by simply looking at the field identifier.
- *  For instance, say you need a 2d field with dimensions (3,10).
- *  In the field repo, this would be stored as a 1d field: View<Real*>.
- *  Let's say you have one class that uses the field as View<Real**>,
- *  with dimensions (3,10), and another class that used the field in
- *  a packed way, as View<Pack<Real,4>**>. The second view will have
- *  dimensions (3,4), in terms of its value type (i.e., Pack<Real,4>).
- *  This means the field needs an allocation bigger than 30 Real's, namely
- *  36 Real's. This class does the book-keeping for the allocation size,
- *  so that 1) the field can be allocated with enough memory to accommodate
- *  all requests, 2) customers of the field can check what the allocation
- *  is, so that they know whether there is padding in the field, and
- *  3) query whether the allocation is compatible with a given value type.
+ *  There are three needs for these info: allocation, reshaping, and subviews.
+ *    - At allocation time, we need to know the alloc size, but this might
+ *      be *larger* than what the field layout would suggest, in case
+ *      padding was used to accommodate use of the fields with packs.
+ *
+ *      For instance, say you declare a field with dimensions (3,10).
+ *      In the field repo, this would be stored as a 1d field: View<Real*>.
+ *      Let's say you have one class that uses the field as View<Real**>,
+ *      and another class that used the field in a packed way, taht is,
+ *      as View<Pack<Real,4>**>. The second view will have dimensions (3,4),
+        in terms of its value type (i.e., Pack<Real,4>).
+ *      This means the field needs an allocation bigger than 30 Real's, namely
+ *      3*4*4=36 Real's. This class does the book-keeping for the allocation size,
+ *      so that 1) the field can be allocated with enough memory to accommodate
+ *      all requests, 2) customers of the field can check what the allocation
+ *      is, so that they know whether there is padding in the field, and
+ *      3) query whether the allocation is compatible with a given value type.
+ *      The last point allows one to check if the view can be reshaped
+ *      as, say, View<Pack<Real,16>> or not. Notice that a field can be
+ *      reshaped as, say, View<Pack<Real,16>> even if no request for
+ *      such large pack was made. E.g., if the field dimensions are
+ *      (10,128), then the last dim allows packing with pack size 16.
+ *    - Fields are stored as 1d views (basically, just a pointer), so
+ *      users need to call the get_reshaped_view<T>() to use it with
+ *      a different data type. E.g., to use the field as a 2d field,
+ *      with Pack<Real,8> as scalar type, one needs to call
+ *        auto v = f.get_reshaped_view<Pack<Real,8>**>()
+ *      The alloc props are queried to establish 1) whether the allocation
+ *      is compatible with a pack-8 scalar type, and 2) how the dimensions
+ *      of the resulting view should be.
+ *    - It is possible (with some limitations) to have a Field being a
+ *      "subview" of a bigger field. E.g., tracers are allocated as a big
+ *      array Q, but one may just be interested in a single one (e.g., qv),
+ *      yet still use it as a Field. This requires some care during the
+ *      get_reshaped_view method, so the field alloc props can be used
+ *      to detect whether we are in this scenario.
  *
  *  Note: at every request for a new value_type, this class checks the
  *        underlying scalar_type. We ASSUME that the dimensions in the
@@ -38,115 +60,122 @@ namespace scream
 
 class FieldAllocProp {
 public:
+  using layout_type      = FieldLayout;
+  using layout_ptr_type  = std::shared_ptr<const layout_type>;
 
   FieldAllocProp ();
-  
+
+  FieldAllocProp& operator= (const FieldAllocProp&);
+
+  // Return allocation props of an unmanaged subivew of this field
+  // at entry k along dimension idim.
+  FieldAllocProp subview (const int idim, const int k) const;
+
   // Request allocation able to accommodate the given ValueType
   template<typename ValueType>
-  void request_value_type_allocation ();
+  void request_allocation ();
 
-  // Locks the properties, preventing furter value types requests
-  void commit (const FieldLayout& layout);
+  // Request allocation able to accommodate the given ValueType
+  template<typename ScalarType>
+  void request_allocation (int pack_size);
+
+  // Locks the allocation properties, preventing furter value types requests
+  void commit (const layout_ptr_type& layout);
 
   // ---- Getters ---- //
-  bool is_committed   () const { return m_committed; }
+
+  // Whether commit has been called
+  bool is_committed () const { return m_committed; }
+
+  // Get the overall allocation size (in Bytes)
   int  get_alloc_size () const;
-  int  get_last_dim_alloc_size () const;
 
-  template<typename Valuetype>
-  int get_last_dim_extent () const;
+  // Wether this allocation is contiguous
+  bool contiguous () const { return m_contiguous; }
 
+  // Size of the last extent in the alloction (i.e., number of scalars in it)
+  int  get_last_extent () const;
+
+  // Return the slice information of this subview allocation.
+  const std::pair<int,int>& get_subview_idx () const { return m_subview_idx; }
+
+  // Whether the allocation properties are compatible with ValueType
   template<typename ValueType>
-  bool is_allocation_compatible_with_value_type () const;
-
-  // This is here just in case we need it for debugging.
-  const std::vector<int>& get_requested_value_types_sizes () const { return m_value_type_sizes; }
+  bool is_compatible () const;
 
 protected:
 
+  // The FieldLayout associated to this allocation
+  layout_ptr_type     m_layout;
+
+  // The list of requested value types for this allocation
   std::vector<int>    m_value_type_sizes;
 
-  int         m_scalar_type_size;
-  std::string m_scalar_type_name;
+  // The size of the scalar type
+  int   m_scalar_type_size;
 
+  // The extent along the last dimension for this allocation
+  int   m_last_extent;
+
+  // The total size of this allocation.
   int   m_alloc_size;
-  int   m_last_dim_alloc_size;
 
+  // If this allocation is a subview of another, this pair stores the
+  // dimension idim and entry k along dimension idim of the slice.
+  std::pair<int,int>  m_subview_idx;
+
+  // Whether the allocation is contiguous
+  bool  m_contiguous;
+
+  // Whether commit was called (i.e., no more value type requests allowed)
   bool  m_committed;
 };
 
 // ================================= IMPLEMENTATION ================================== //
 
 template<typename ValueType>
-void FieldAllocProp::request_value_type_allocation () {
+void FieldAllocProp::request_allocation () {
+  using ekat::ScalarTraits;
+  using scalar_type = typename ScalarTraits<ValueType>::scalar_type;
+  const int n = sizeof(ValueType) / sizeof(scalar_type);
+  request_allocation<scalar_type>(n);
+}
 
+template<typename ScalarType>
+void FieldAllocProp::request_allocation (const int pack_size) {
   using ekat::ScalarTraits;
   using namespace ekat::error;
 
   ekat::error::runtime_check(!m_committed, "Error! Cannot change allocation properties after they have been commited.\n");
   
-  constexpr int vts = sizeof(ValueType);
+  const int vts = sizeof(ScalarType)*pack_size;
   if (m_scalar_type_size==0) {
     // This is the first time we receive a request. Set the scalar type properties
-    m_scalar_type_size = sizeof(typename ScalarTraits<ValueType>::scalar_type);
-    m_scalar_type_name = ScalarTraits<typename ScalarTraits<ValueType>::scalar_type>::name();
+    m_scalar_type_size = sizeof(ScalarType);
   } else {
-
-    // Make sure the scalar_type of the new requested type coincides with the one already stored
-    runtime_check(ScalarTraits<typename ScalarTraits<ValueType>::scalar_type>::name()==m_scalar_type_name,
-                  "Error! There was already a value type request for this allocation, and the stored scalar_type name (" +
-                  m_scalar_type_name + ") does not match the one from the new request (" + ScalarTraits<ValueType>::name() + ").\n");
-    runtime_check(sizeof(typename ScalarTraits<ValueType>::scalar_type)==m_scalar_type_size,
-                  "Error! There was already a value type request for this allocation, and the size of the stored scalar_type (" +
-                  std::to_string(m_scalar_type_size) + ") does not match the size of the scalar_type of the new request (" +
-                  std::to_string(sizeof(typename ScalarTraits<ValueType>::scalar_type)) + ").\n");
-
-    // Furthermore, if value type is not the same as scalar type (by comparing name and size), ValueType *must* be a pack
-    const std::string vtn = ScalarTraits<ValueType>::name();
-    runtime_check( (m_scalar_type_name==vtn && m_scalar_type_size==vts) || ScalarTraits<ValueType>::is_simd,
-                    "Error! Template argument ValueType must be either the ScalarType of this allocation, or a pack type.\n");
+    // Make sure the new scalar_type coincides with the one already stored (check name and size)
+    runtime_check(sizeof(ScalarType)==m_scalar_type_size,
+                  std::string("Error! Scalar type incompatible with current allocation request:\n") +
+                  "         stored scalar type size: " + std::to_string(m_scalar_type_size) + "\n" +
+                  "         requested scalar type name: " + std::to_string(sizeof(ScalarType)) + "\n");
   }
-
-  // If ValueType only contains N scalar_type inside, this will pass. If not, then it's a bad ValueType,
-  // or you have a wrong scalar_type in the specialization of ScalarTraits<ValueType>. Either way, error out.
-  EKAT_REQUIRE_MSG(vts % m_scalar_type_size == 0,
-                     "Error! The size of the scalar_type (" + std::to_string(m_scalar_type_size) +
-                     ") does not divide the size of the given value_type (" + std::to_string(vts) + ").\n");
 
   // Store the size of the value type.
   m_value_type_sizes.push_back(vts);
 }
 
-inline int FieldAllocProp::get_alloc_size () const {
-  ekat::error::runtime_check(m_committed,"Error! You cannot query the allocation properties until they have been committed.");
-  return m_alloc_size;
-}
-
-inline int FieldAllocProp::get_last_dim_alloc_size () const {
-  ekat::error::runtime_check(m_committed,"Error! You cannot query the allocation properties until they have been committed.");
-  return m_last_dim_alloc_size;
-}
-
-template<typename Valuetype>
-inline int FieldAllocProp::get_last_dim_extent () const {
-  ekat::error::runtime_check(m_committed,"Error! You cannot query the allocation properties until they have been committed.");
-  EKAT_REQUIRE_MSG(is_allocation_compatible_with_value_type<Valuetype>(),
-                     "Error! Allocation is not compatible with given value type.\n");
-
-  return get_last_dim_alloc_size() / m_scalar_type_size;
-}
-
 template<typename ValueType>
-bool FieldAllocProp::is_allocation_compatible_with_value_type () const {
-  using NonConstValueType = typename std::remove_const<ValueType>::type;
+bool FieldAllocProp::is_compatible () const {
   using ekat::ScalarTraits;
 
-  constexpr int  sts = sizeof(typename ScalarTraits<ValueType>::scalar_type);
-  constexpr int  vts = sizeof(ValueType);
-  const auto stn = ScalarTraits<typename ScalarTraits<NonConstValueType>::scalar_type>::name();
+  constexpr int sts = sizeof(typename ScalarTraits<ValueType>::scalar_type);
+  constexpr int vts = sizeof(ValueType);
+  constexpr int vlen = vts / sts;
 
-  return stn==m_scalar_type_name
-      && sts==m_scalar_type_size && (m_last_dim_alloc_size%vts==0);
+  // Allocation is compatible with ValueType if
+  //   - the scalar type of ValueType has the same size as m_scalar_type_size
+  //   - the size of ValueType must divide the last dim stride
+  return sts==m_scalar_type_size && (m_last_extent%vlen==0);
 }
 
 } // namespace scream

--- a/components/scream/src/share/field/field_header.cpp
+++ b/components/scream/src/share/field/field_header.cpp
@@ -5,10 +5,30 @@ namespace scream
 
 FieldHeader::FieldHeader (const identifier_type& id)
  : m_identifier (id)
- , m_tracking (m_identifier.name())
+ , m_tracking (create_tracking(id.name()))
  , m_alloc_prop ()
 {
   // Nothing to be done here
+}
+
+FieldHeader::FieldHeader (const identifier_type& id,
+                          std::shared_ptr<FieldHeader> parent,
+                          const int idim, const int k)
+ : m_identifier (id)
+{
+  EKAT_REQUIRE_MSG (parent!=nullptr,
+      "Error! Invalid pointer for parent header.\n");
+  EKAT_REQUIRE_MSG (id.get_layout_ptr()!=nullptr,
+      "Error! Input field identifier has an invalid layout pointer.\n");
+
+  m_parent = parent;
+
+  m_tracking = create_tracking(id.name(),parent->get_tracking_ptr());
+
+  m_alloc_prop = parent->get_alloc_properties().subview(idim,k);
+  m_alloc_prop.commit(id.get_layout_ptr());
+
+  m_tracking->register_as_children_in_parent();
 }
 
 void FieldHeader::
@@ -24,6 +44,11 @@ set_extra_data (const std::string& key,
   } else {
     m_extra_data[key] = data;
   }
+}
+
+void FieldHeader::register_inside_parent () {
+  auto me = shared_from_this ();
+  // m_parent.lock()->m_children.push_back(me);
 }
 
 } // namespace scream

--- a/components/scream/src/share/field/field_header.hpp
+++ b/components/scream/src/share/field/field_header.hpp
@@ -79,7 +79,7 @@ public:
         FieldAllocProp& get_alloc_properties ()       { return m_alloc_prop; }
 
   // Get parent (if any)
-  std::weak_ptr<FieldHeader> get_parent () { return m_parent; }
+  std::weak_ptr<FieldHeader> get_parent () const { return m_parent; }
 
   // Get the extra data
   const extra_data_type& get_extra_data () const { return m_extra_data; }

--- a/components/scream/src/share/field/field_identifier.hpp
+++ b/components/scream/src/share/field/field_identifier.hpp
@@ -4,6 +4,7 @@
 #include "share/field/field_layout.hpp"
 #include "ekat/util/ekat_string_utils.hpp"
 #include "ekat/util/ekat_units.hpp"
+#include "ekat/std_meta/ekat_std_enable_shared_from_this.hpp"
 
 #include <vector>
 
@@ -19,11 +20,12 @@ namespace scream
  *  There is no additional meta data about this field.
  */
 
-class FieldIdentifier {
+class FieldIdentifier : ekat::enable_shared_from_this<FieldIdentifier> {
 public:
-  using layout_type = FieldLayout;
-  using ci_string   = ekat::CaseInsensitiveString;
-  using Units       = ekat::units::Units;
+  using layout_type     = FieldLayout;
+  using layout_ptr_type = std::shared_ptr<const layout_type>;
+  using ci_string       = ekat::CaseInsensitiveString;
+  using Units           = ekat::units::Units;
 
   // Constructor(s)
   FieldIdentifier () = delete;
@@ -31,15 +33,7 @@ public:
   FieldIdentifier (const std::string& name,
                    const layout_type& layout,
                    const Units& units,
-                   const std::string& grid_name = "");
-  FieldIdentifier (const std::string& name,
-                   const std::vector<FieldTag>& tags,
-                   const Units& units,
-                   const std::string& grid_name = "");
-  FieldIdentifier (const std::string& name,
-                   const std::initializer_list<FieldTag>& tags,
-                   const Units& units,
-                   const std::string& grid_name = "");
+                   const std::string& grid_name);
 
   // Delete assignment, to prevent overwriting identifiers sneakyly
   FieldIdentifier& operator= (const FieldIdentifier&) = delete;
@@ -47,20 +41,20 @@ public:
   // ----- Getters ----- //
 
   // Name and layout informations
-  const std::string&  name          () const { return m_name;      }
-  const layout_type&  get_layout    () const { return m_layout;    }
-  const Units&        get_units     () const { return m_units;     }
-  const std::string&  get_grid_name () const { return m_grid_name; }
+  const std::string&      name           () const { return m_name;      }
+  const layout_type&      get_layout     () const { return *m_layout;   }
+  const layout_ptr_type&  get_layout_ptr () const { return m_layout;    }
+  const Units&            get_units      () const { return m_units;     }
+  const std::string&      get_grid_name  () const { return m_grid_name; }
 
   // The identifier string
   const std::string& get_id_string () const { return m_identifier; }
 
   // ----- Setters ----- //
 
-  // Note: as soon as a dimension is set, it cannot be changed.
-  void set_dimension  (const int idim, const int dimension);
-  void set_dimensions (const std::vector<int>& dims);
-  void set_grid_name  (const std::string& grid_name);
+  // Note: as soon as the layout is set, it cannot be changed.
+  void set_layout (const layout_type& layout);
+  void set_layout (const layout_ptr_type& layout);
 
   // We reimplement the equality operator for identifiers comparison (needed for some std container)
   friend bool operator== (const FieldIdentifier&, const FieldIdentifier&);
@@ -72,7 +66,7 @@ protected:
 
   ci_string       m_name;
 
-  layout_type     m_layout;
+  layout_ptr_type m_layout;
 
   Units           m_units;
 

--- a/components/scream/src/share/field/field_layout.hpp
+++ b/components/scream/src/share/field/field_layout.hpp
@@ -47,7 +47,7 @@ public:
 
   bool is_dimension_set  (const int idim) const;
   bool are_dimensions_set () const;
-  
+
   // ----- Setters ----- //
 
   // Note: as soon as a dimension is set, it cannot be changed.

--- a/components/scream/src/share/field/field_repository.hpp
+++ b/components/scream/src/share/field/field_repository.hpp
@@ -192,7 +192,7 @@ register_field (const identifier_type& id, const std::set<std::string>& groups_n
   auto it_bool = map.emplace(id,field_type(id));
 
   // Make sure the field can accommodate the requested value type
-  it_bool.first->second.get_header().get_alloc_properties().template request_value_type_allocation<RequestedValueType>();
+  it_bool.first->second.get_header().get_alloc_properties().template request_allocation<RequestedValueType>();
 
   // Finally, add the field to the given groups
   for (const auto& group_name : groups_names) {

--- a/components/scream/src/share/field/field_tracking.hpp
+++ b/components/scream/src/share/field/field_tracking.hpp
@@ -55,7 +55,7 @@ public:
   using atm_proc_set_type = ekat::WeakPtrSet<AtmosphereProcess>;
 
   FieldTracking() = delete;
-  FieldTracking(const std::string& name);
+  explicit FieldTracking(const std::string& name);
   FieldTracking(const FieldTracking&) = default;
   FieldTracking(const std::string& name,
                 const std::shared_ptr<FieldTracking>& parent);
@@ -94,7 +94,7 @@ public:
   void add_to_group (const std::string& group_name);
 
   // Set the time stamp for this field. This can only be called once, due to TimeStamp implementation.
-  // NOTE: if the field has 'children' (see below), their ts will be udpated too.
+  // NOTE: if the field has 'children' (see below), their ts will be updated too.
   //       However, if the field has a 'parent' (see below), the parent's ts will not be updated.
   void update_time_stamp (const TimeStamp& ts);
 

--- a/components/scream/src/share/field/field_tracking.hpp
+++ b/components/scream/src/share/field/field_tracking.hpp
@@ -1,7 +1,6 @@
 #ifndef SCREAM_FIELD_TRACKING_HPP
 #define SCREAM_FIELD_TRACKING_HPP
 
-#include "share/field/field_utils.hpp"
 #include "share/scream_types.hpp"
 
 #include "share/util/scream_time_stamp.hpp"
@@ -14,6 +13,29 @@
 #include <set>
 
 namespace scream {
+
+// How a field has to be init-ed
+// Note: internally, Value still creates a FieldInitializer object, but can be done
+//       behind the scenes by the infrastructure
+enum class InitType {
+  // NotNeeded,    // No initialization is needed for this field
+  Value,        // Should be inited to a specific value
+  Initializer,  // A FieldInitializer object should take care of this
+  None          // No initialization is needed/expected
+};
+
+inline std::string e2str (const InitType e) {
+  std::string s;
+  switch (e) {
+    // case InitType::NotNeeded:   s = "NotNeeded";    break;
+    case InitType::None:        s = "None";         break;
+    case InitType::Value:       s = "Value";        break;
+    case InitType::Initializer: s = "Initializer";  break;
+    default: s = "INVALID";
+  }
+
+  return s;
+}
 
 // Forward declarations
 class AtmosphereProcess;

--- a/components/scream/src/share/field/field_utils.hpp
+++ b/components/scream/src/share/field/field_utils.hpp
@@ -6,29 +6,6 @@
 
 namespace scream {
 
-// How a field has to be init-ed
-// Note: internally, Value still creates a FieldInitializer object, but can be done
-//       behind the scenes by the infrastructure
-enum class InitType {
-  // NotNeeded,    // No initialization is needed for this field
-  Value,        // Should be inited to a specific value
-  Initializer,  // A FieldInitializer object should take care of this
-  None          // No initialization is needed/expected
-};
-
-inline std::string e2str (const InitType e) {
-  std::string s;
-  switch (e) {
-    // case InitType::NotNeeded:   s = "NotNeeded";    break;
-    case InitType::None:        s = "None";         break;
-    case InitType::Value:       s = "Value";        break;
-    case InitType::Initializer: s = "Initializer";  break;
-    default: s = "INVALID";
-  }
-
-  return s;
-}
-
 // The type of the layout, that is, the kind of field it represent.
 enum class LayoutType {
   Invalid,

--- a/components/scream/src/share/field/field_utils.hpp
+++ b/components/scream/src/share/field/field_utils.hpp
@@ -2,6 +2,8 @@
 #define SCREAM_FIELD_UTILS_HPP
 
 #include "field_tag.hpp"
+#include "field.hpp"
+
 #include "ekat/std_meta/ekat_std_utils.hpp"
 
 namespace scream {
@@ -100,6 +102,52 @@ inline LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
   }
   
   return result;
+}
+
+template<typename RT1, typename RT2>
+bool views_are_equal(const Field<RT1>& f1, const Field<RT2>& f2) {
+  static_assert(std::is_same<typename std::remove_cv<RT1>::type,
+                             typename std::remove_cv<RT2>::type>::value,
+                "Error! Real types must be the same (except possibly for cv qualifiers).\n");
+  // Get physical layout (same for both fields)
+  const auto& layout = f1.get_header().get_identifier().get_layout();
+  EKAT_REQUIRE_MSG (f2.get_header().get_identifier().get_layout()==layout,
+      "Error! You should only call 'views_are_equal' with two fields with the same physical layout.\n");
+
+  // The alloc props might be different, so we need to get both, and handle views separately
+  const auto& p1 = f1.get_header().get_alloc_properties();
+  const auto& p2 = f2.get_header().get_alloc_properties();
+
+  // Get physical and allocation sizes
+  const int size = layout.size();
+  const int last_phys_dim = layout.dims().back();
+  const int ext1 = p1.get_last_extent();
+  const int ext2 = p2.get_last_extent();
+
+  // Get views
+  const auto v1 = f1.get_view();
+  const auto v2 = f2.get_view();
+
+  // Simple range policy for a 1d view
+  using exec_space = typename decltype(v1)::execution_space;
+  Kokkos::RangePolicy<exec_space> policy(0,size);
+
+  int num_diffs = 0;
+  Kokkos::parallel_reduce(policy,KOKKOS_LAMBDA(const int i, int& sum){
+      // Separate last (physical) dimension from the others (if any)
+      const int outer_dims = i / last_phys_dim;
+      const int inner_dim  = i % last_phys_dim;
+      const int idx1 = outer_dims*ext1 + inner_dim;
+      const int idx2 = outer_dims*ext2 + inner_dim;
+
+      if (v1(idx1)!=v2(idx2)) {
+        printf("iter,i,j,idx1,idx2:%d,%d,%d,%d,%d\n",i,outer_dims,inner_dim,idx1,idx2);
+        printf("v1(idx) = %3.15f\nv2(idx) = %3.15f\n",v1(idx1),v2(idx2));
+        ++sum;
+      }
+    },num_diffs
+  );
+  return (num_diffs == 0);
 }
 
 } // namespace scream

--- a/components/scream/src/share/grid/abstract_grid.hpp
+++ b/components/scream/src/share/grid/abstract_grid.hpp
@@ -76,8 +76,11 @@ public:
   const std::string& name () const { return m_name; }
 
   // Native layout of a dof. This is the natural way to index a dof in the grid.
-  // E.g., for a 2d structured grid, this could be a set of 2 indices.
-  virtual FieldLayout get_native_dof_layout () const  = 0;
+  // E.g., for a 2d field on a SE grid, this will be (nelem,np,np)
+  virtual FieldLayout get_2d_scalar_layout () const = 0;
+  virtual FieldLayout get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const = 0;
+  virtual FieldLayout get_3d_scalar_layout (const bool midpoints) const = 0;
+  virtual FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const = 0;
 
   int get_num_vertical_levels () const { return m_num_vert_levs; }
 

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -32,10 +32,39 @@ PointGrid (const std::string& grid_name,
 }
 
 FieldLayout
-PointGrid::get_native_dof_layout () const
+PointGrid::get_2d_scalar_layout () const
 {
   using namespace ShortFieldTagsNames;
+
   return FieldLayout({COL},{m_num_local_dofs});
+}
+
+FieldLayout
+PointGrid::get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const
+{
+  using namespace ShortFieldTagsNames;
+
+  return FieldLayout({COL,vector_tag},{m_num_local_dofs,vector_dim});
+}
+
+FieldLayout
+PointGrid::get_3d_scalar_layout (const bool midpoints) const
+{
+  using namespace ShortFieldTagsNames;
+
+  int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
+
+  return FieldLayout({COL,VL},{m_num_local_dofs,nvl});
+}
+
+FieldLayout
+PointGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const
+{
+  using namespace ShortFieldTagsNames;
+
+  int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
+
+  return FieldLayout({COL,vector_tag,VL},{m_num_local_dofs,vector_dim,nvl});
 }
 
 void PointGrid::
@@ -50,7 +79,6 @@ set_dofs (const dofs_list_type& dofs)
 
   m_dofs_gids  = dofs;
 }
-
 
 void PointGrid::
 set_geometry_data (const std::string& name, const geo_view_type& data) {

--- a/components/scream/src/share/grid/point_grid.hpp
+++ b/components/scream/src/share/grid/point_grid.hpp
@@ -35,7 +35,10 @@ public:
 
   // Native layout of a dof. This is the natural way to index a dof in the grid.
   // E.g., for a 2d structured grid, this could be a set of 2 indices.
-  FieldLayout get_native_dof_layout () const override;
+  FieldLayout get_2d_scalar_layout () const override;
+  FieldLayout get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const override;
+  FieldLayout get_3d_scalar_layout (const bool midpoints) const override;
+  FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const override;
 
   void set_dofs (const dofs_list_type& dofs);
   void set_geometry_data (const std::string& name, const geo_view_type& data) override;

--- a/components/scream/src/share/grid/se_grid.cpp
+++ b/components/scream/src/share/grid/se_grid.cpp
@@ -61,5 +61,40 @@ set_geometry_data (const std::string& name, const geo_view_type& data) {
   m_geo_views[name] = data;
 }
 
+FieldLayout
+SEGrid::get_2d_scalar_layout () const
+{
+  using namespace ShortFieldTagsNames;
+
+  return FieldLayout({EL,GP,GP},{m_num_local_elem,m_num_gp,m_num_gp});
+}
+
+FieldLayout
+SEGrid::get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const
+{
+  using namespace ShortFieldTagsNames;
+
+  return FieldLayout({EL,vector_tag,GP,GP},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp});
+}
+
+FieldLayout
+SEGrid::get_3d_scalar_layout (const bool midpoints) const
+{
+  using namespace ShortFieldTagsNames;
+
+  int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
+
+  return FieldLayout({EL,GP,GP,VL},{m_num_local_elem,m_num_gp,m_num_gp,nvl});
+}
+
+FieldLayout
+SEGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const
+{
+  using namespace ShortFieldTagsNames;
+
+  int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
+
+  return FieldLayout({EL,vector_tag,GP,GP,VL},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp,nvl});
+}
 
 } // namespace scream

--- a/components/scream/src/share/grid/se_grid.hpp
+++ b/components/scream/src/share/grid/se_grid.hpp
@@ -21,8 +21,10 @@ public:
   virtual ~SEGrid () = default;
 
   // Native layout of a dof. This is the natural way to index a dof in the grid.
-  // E.g., for a 2d structured grid, this could be a set of 2 indices.
-  FieldLayout get_native_dof_layout () const override;
+  FieldLayout get_2d_scalar_layout () const override;
+  FieldLayout get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const override;
+  FieldLayout get_3d_scalar_layout (const bool midpoints) const override;
+  FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const override;
 
   // Set the dofs gids as well as their coordinates (ie,igp,jgp) in the grid
   void set_dofs (const dofs_list_type&      dofs,
@@ -36,14 +38,6 @@ protected:
   int                       m_num_local_elem;
   int                       m_num_gp;
 };
-
-inline FieldLayout
-SEGrid::get_native_dof_layout () const
-{
-  using namespace ShortFieldTagsNames;
-
-  return FieldLayout({EL,GP,GP},{m_num_local_elem,m_num_gp,m_num_gp});
-}
 
 } // namespace scream
 

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -190,17 +190,12 @@ std::shared_ptr<FieldRepository<Real>> get_test_repo(const Int num_lcols, const 
   std::vector<Int>     dims_v  = {num_levs};
   std::vector<Int>     dims_2d = {num_lcols,num_levs};
 
-  FieldIdentifier fid1("field_1",tag_h,m);
-  FieldIdentifier fid2("field_2",tag_v,kg);
-  FieldIdentifier fid3("field_3",tag_2d,kg/m);
+  using FL = FieldLayout;
+  const std::string gn = "Physics";
+  FieldIdentifier fid1("field_1",FL{tag_h,dims_h},m,gn);
+  FieldIdentifier fid2("field_2",FL{tag_v,dims_v},kg,gn);
+  FieldIdentifier fid3("field_3",FL{tag_2d,dims_2d},kg/m,gn);
 
-  fid1.set_dimensions(dims_h);
-  fid2.set_dimensions(dims_v);
-  fid3.set_dimensions(dims_2d);
-
-  fid1.set_grid_name("Physics");
-  fid2.set_grid_name("Physics");
-  fid3.set_grid_name("Physics");
   // Register fields with repo
   repo->registration_begins();
   repo->register_field(fid1,{"output"});

--- a/components/scream/src/share/io/tests/restart.cpp
+++ b/components/scream/src/share/io/tests/restart.cpp
@@ -180,17 +180,12 @@ std::shared_ptr<FieldRepository<Real>> get_test_repo(const Int num_lcols, const 
   std::vector<Int>     dims_v  = {num_levs};
   std::vector<Int>     dims_2d = {num_lcols,num_levs};
 
-  FieldIdentifier fid1("field_1",tag_h,m);
-  FieldIdentifier fid2("field_2",tag_v,kg);
-  FieldIdentifier fid3("field_3",tag_2d,kg/m);
+  using FL = FieldLayout;
+  const std::string gn = "Physics";
+  FieldIdentifier fid1("field_1",FL{tag_h,dims_h},m,gn);
+  FieldIdentifier fid2("field_2",FL{tag_v,dims_v},kg,gn);
+  FieldIdentifier fid3("field_3",FL{tag_2d,dims_2d},kg/m,gn);
 
-  fid1.set_dimensions(dims_h);
-  fid2.set_dimensions(dims_v);
-  fid3.set_dimensions(dims_2d);
-
-  fid1.set_grid_name("Physics");
-  fid2.set_grid_name("Physics");
-  fid3.set_grid_name("Physics");
   // Register fields with repo
   repo->registration_begins();
   repo->register_field(fid1,{"output","restart"});

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -67,9 +67,6 @@ protected:
   std::set<FieldIdentifier> m_fids_in;
   std::set<FieldIdentifier> m_fids_out;
 
-  std::vector<FieldIdentifier> m_vec_fids_in;
-  std::vector<FieldIdentifier> m_vec_fids_out;
-
   std::string m_name;
   std::string m_grid_name;
 
@@ -84,30 +81,18 @@ public:
   MyDynamics (const ekat::Comm& comm,const ekat::ParameterList& params)
    : base(comm,params)
   {
-    using namespace ShortFieldTagsNames;
-    using namespace ekat::units;
-
-    FieldIdentifier tend("Temperature tendency",{EL,GP,GP,VL},K/s);
-    m_vec_fids_in.push_back(tend);
-
-    FieldIdentifier temp("Temperature",{EL,GP,GP,VL},K);
-    m_vec_fids_out.push_back(temp);
+    // Nothing to do here
   }
 
   void set_grids (const std::shared_ptr<const GridsManager> gm) {
-    auto grid = gm->get_grid(m_grid_name);
-    const auto nvl = grid->get_num_vertical_levels();
-    auto dyn_lt = grid->get_native_dof_layout();
+    using namespace ekat::units;
 
-    auto& tend = m_vec_fids_in.front();
-    tend.set_grid_name(grid->name());
-    tend.set_dimensions({dyn_lt.dim(0),dyn_lt.dim(1),dyn_lt.dim(2),nvl});
-    m_fids_in.insert(tend);
+    const auto grid = gm->get_grid(m_grid_name);
+    const auto dyn_lt = grid->get_3d_scalar_layout(true);
 
-    auto& temp = m_vec_fids_out.front();
-    temp.set_grid_name(grid->name());
-    temp.set_dimensions({dyn_lt.dim(0),dyn_lt.dim(1),dyn_lt.dim(2),nvl});
-    m_fids_out.insert(temp);
+    m_fids_in.emplace("Temperature tendency",dyn_lt,K/s,m_grid_name);
+
+    m_fids_out.emplace("Temperature",dyn_lt,K,m_grid_name);
   }
 };
 
@@ -119,30 +104,18 @@ public:
   MyPhysicsA (const ekat::Comm& comm,const ekat::ParameterList& params)
    : base(comm,params)
   {
-    using namespace ShortFieldTagsNames;
-    using namespace ekat::units;
-
-    FieldIdentifier temp("Temperature",{COL,VL},K);
-    m_vec_fids_in.push_back(temp);
-
-    FieldIdentifier qA("Concentration A",{COL,VL},kg/pow(m,3));
-    m_vec_fids_out.push_back(qA);
+    // Nothing to do here
   }
 
   void set_grids (const std::shared_ptr<const GridsManager> gm) {
-    auto grid = gm->get_grid(m_grid_name);
-    const auto nvl = grid->get_num_vertical_levels();
-    auto phys_lt = grid->get_native_dof_layout();
+    using namespace ekat::units;
 
-    auto& temp = m_vec_fids_in.front();
-    temp.set_grid_name(grid->name());
-    temp.set_dimensions({phys_lt.dim(0),nvl});
-    m_fids_in.insert(temp);
+    const auto grid = gm->get_grid(m_grid_name);
+    const auto phys_lt = grid->get_3d_scalar_layout (true);
 
-    auto& qA = m_vec_fids_out.front();
-    qA.set_grid_name(grid->name());
-    qA.set_dimensions({phys_lt.dim(0),nvl});
-    m_fids_out.insert(qA);
+    m_fids_in.emplace("Temperature",phys_lt,K,m_grid_name);
+
+    m_fids_out.emplace("Concentration A",phys_lt,kg/pow(m,3),m_grid_name);
   }
 };
 
@@ -154,37 +127,19 @@ public:
   MyPhysicsB (const ekat::Comm& comm,const ekat::ParameterList& params)
    : base(comm,params)
   {
-    using namespace ShortFieldTagsNames;
-    using namespace ekat::units;
-
-    FieldIdentifier temp("Temperature",{COL,VL},K);
-    m_vec_fids_in.push_back(temp);
-    FieldIdentifier qA("Concentration A",{COL,VL},kg/pow(m,3));
-    m_vec_fids_in.push_back(qA);
-
-    FieldIdentifier tend("Temperature tendency",{COL,VL},K/s);
-    m_vec_fids_out.push_back(tend);
+    // Nothing to do here
   }
 
   void set_grids (const std::shared_ptr<const GridsManager> gm) {
-    auto grid = gm->get_grid(m_grid_name);
-    const auto nvl = grid->get_num_vertical_levels();
-    auto phys_lt = grid->get_native_dof_layout();
+    using namespace ekat::units;
 
-    auto& temp = m_vec_fids_in.front();
-    temp.set_grid_name(grid->name());
-    temp.set_dimensions({phys_lt.dim(0),nvl});
-    m_fids_in.insert(temp);
+    const auto grid = gm->get_grid(m_grid_name);
+    const auto phys_lt = grid->get_3d_scalar_layout (true);
 
-    auto& qA = m_vec_fids_in[1];
-    qA.set_grid_name(grid->name());
-    qA.set_dimensions({phys_lt.dim(0),nvl});
-    m_fids_in.insert(qA);
+    m_fids_in.emplace("Temperature",phys_lt,K,m_grid_name);
+    m_fids_in.emplace("Concentration A",phys_lt,kg/pow(m,3),m_grid_name);
 
-    auto& tend = m_vec_fids_out.front();
-    tend.set_grid_name(grid->name());
-    tend.set_dimensions({phys_lt.dim(0),nvl});
-    m_fids_out.insert(tend);
+    m_fids_out.emplace("Temperature tendency",phys_lt,K/s,m_grid_name);
   }
 };
 

--- a/components/scream/src/share/tests/dummy_se_point_remapper.hpp
+++ b/components/scream/src/share/tests/dummy_se_point_remapper.hpp
@@ -44,26 +44,32 @@ public:
 
   FieldLayout create_src_layout (const FieldLayout& tgt) const override {
     using namespace ShortFieldTagsNames;
-    auto ncol = this->get_src_grid()->get_native_dof_layout().dim(0);
+    using TV = std::vector<FieldTag>;
+    using IV = std::vector<int>;
+
+    auto ncol = this->get_src_grid()->get_2d_scalar_layout().dim(0);
 
     const auto rank = tgt.rank();
     EKAT_REQUIRE_MSG (rank==3 || rank==4 || rank==5,
       "Error! Target layout not supported. Remember that this class has limited support.\n");
     switch (rank) {
       case 3:
-        return FieldLayout ({COL},{ncol});
+        return FieldLayout (TV{COL},IV{ncol});
       case 4:
-        return FieldLayout ({COL,VL},{ncol,tgt.dim(3)});
+        return FieldLayout (TV{COL,VL},IV{ncol,tgt.dim(3)});
       case 5:
-        return FieldLayout ({COL,CMP,VL},{ncol,tgt.dim(1),tgt.dim(4)});
+        return FieldLayout (TV{COL,CMP,VL},IV{ncol,tgt.dim(1),tgt.dim(4)});
       default:
-        return FieldLayout ({},{});
+        return FieldLayout (TV{},IV{});
     }
   }
 
   FieldLayout create_tgt_layout (const FieldLayout& src) const override {
     using namespace ShortFieldTagsNames;
-    auto nele = this->get_tgt_grid()->get_native_dof_layout().dim(0);
+    using TV = std::vector<FieldTag>;
+    using IV = std::vector<int>;
+
+    auto nele = this->get_tgt_grid()->get_2d_scalar_layout().dim(0);
 
     const auto rank = src.rank();
     EKAT_REQUIRE_MSG (rank==1 || rank==2 || rank==3,
@@ -71,13 +77,13 @@ public:
 
     switch (rank) {
       case 1:
-        return FieldLayout ({EL,GP,GP},{nele,4,4});
+        return FieldLayout (TV{EL,GP,GP},IV{nele,4,4});
       case 2:
-        return FieldLayout ({EL,GP,GP,src.tag(1)},{nele,4,4,src.dim(1)});
+        return FieldLayout (TV{EL,GP,GP,src.tag(1)},IV{nele,4,4,src.dim(1)});
       case 3:
-        return FieldLayout ({EL,CMP,GP,GP,VL},{nele,src.dim(1),4,4,src.dim(2)});
+        return FieldLayout (TV{EL,CMP,GP,GP,VL},IV{nele,src.dim(1),4,4,src.dim(2)});
       default:
-        return FieldLayout ({},{});
+        return FieldLayout (TV{},IV{});
     }
   }
 

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -200,8 +200,8 @@ TEST_CASE("field", "") {
     // Wrong rank for the subfield f2
     REQUIRE_THROWS(f2.get_reshaped_view<Real****>());
 
-    auto v4d_h = f1.get_reshaped_view<Real****,HostDevice>();
-    auto v3d_h = f2.get_reshaped_view<Real***,HostDevice>();
+    auto v4d_h = f1.get_reshaped_view<Real****,Host>();
+    auto v3d_h = f2.get_reshaped_view<Real***,Host>();
     for (int i=0; i<d1[0]; ++i)
       for (int j=0; j<d1[2]; ++j)
         for (int k=0; k<d1[3]; ++k) {
@@ -214,7 +214,7 @@ TEST_CASE("field", "") {
 
     // Views not yet allocated
     REQUIRE_THROWS(f.get_view());
-    REQUIRE_THROWS(f.get_view<HostDevice>());
+    REQUIRE_THROWS(f.get_view<Host>());
     REQUIRE_THROWS(f.sync_to_host());
     REQUIRE_THROWS(f.sync_to_dev());
 
@@ -233,7 +233,7 @@ TEST_CASE("field", "") {
     Kokkos::deep_copy(v2d_hm,v2d);
 
     // Get reshaped view straight on Host
-    auto v2dh = f.get_reshaped_view<Real**,HostDevice>();
+    auto v2dh = f.get_reshaped_view<Real**,Host>();
 
     // The two should match
     const auto& dims = fid.get_layout().dims();

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -200,14 +200,12 @@ TEST_CASE("field", "") {
     // Wrong rank for the subfield f2
     REQUIRE_THROWS(f2.get_reshaped_view<Real****>());
 
-    auto v4dh = Kokkos::create_mirror_view(v4d);
-    auto v3dh = Kokkos::create_mirror_view(v3d);
-    Kokkos::deep_copy(v4dh,v4d);
-    Kokkos::deep_copy(v3dh,v3d);
+    auto v4d_h = f1.get_reshaped_view<Real****,HostDevice>();
+    auto v3d_h = f2.get_reshaped_view<Real***,HostDevice>();
     for (int i=0; i<d1[0]; ++i)
       for (int j=0; j<d1[2]; ++j)
         for (int k=0; k<d1[3]; ++k) {
-          REQUIRE (v4dh(i,ivar,j,k)==v3dh(i,j,k));
+          REQUIRE (v4d_h(i,ivar,j,k)==v3d_h(i,j,k));
         }
   }
 

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -7,53 +7,60 @@
 #include "share/field/field_positivity_check.hpp"
 #include "share/field/field_within_interval_check.hpp"
 #include "share/field/field_monotonicity_check.hpp"
+#include "share/field/field_utils.hpp"
 
 #include "ekat/ekat_pack.hpp"
 
 namespace {
 
+TEST_CASE("field_layout") {
+  using namespace scream;
+  using namespace ShortFieldTagsNames;
+
+  FieldLayout l({EL,GP,GP});
+
+  // Should not be able to set a dimensions vector of wrong rank
+  REQUIRE_THROWS(l.set_dimensions({1,2}));
+
+  l.set_dimensions({1,2,3});
+
+  // Should not be able to reset the dimensions once they are set
+  REQUIRE_THROWS(l.set_dimensions({1,2,3}));
+}
+
 TEST_CASE("field_identifier", "") {
   using namespace scream;
   using namespace ekat::units;
+  using namespace ShortFieldTagsNames;
 
 #ifdef SCREAM_FORCE_RUN_FAIL
   REQUIRE(false); // force this test to fail
 #endif
 
-  std::vector<FieldTag> tags1 = {FieldTag::Element, FieldTag::GaussPoint, FieldTag::GaussPoint};
-  std::vector<FieldTag> tags2 = {FieldTag::Element, FieldTag::Component, FieldTag::VerticalLevel};
+  std::vector<FieldTag> tags1 = {EL, VL, CMP};
+  std::vector<FieldTag> tags2 = {EL, CMP, VL};
 
-  FieldIdentifier fid1 ("field_1", tags1, m/s);
-  FieldIdentifier fid2 ("field_1", tags1, m/s);
-  FieldIdentifier fid3 ("field_1", tags2, m/s);
-  FieldIdentifier fid4 ("field_2", tags2, m/s);
+  std::vector<int> dims1 = {2, 3, 4};
+  std::vector<int> dims2 = {2, 4, 3};
+
+  FieldIdentifier fid1 ("field_1", {tags1,dims1}, kg, "some_grid");
+  FieldIdentifier fid2 ("field_1", {tags1,dims1}, kg, "some_grid");
+  FieldIdentifier fid3 ("field_1", {tags1,dims2}, kg, "some_grid");
+  FieldIdentifier fid4 ("field_2", {tags1,dims2}, kg, "some_grid");
+  FieldIdentifier fid5 ("field_2", {tags2,dims2}, kg, "some_grid");
+  FieldIdentifier fid6 ("field_2", {tags2,dims2}, m, "some_grid");
+  FieldIdentifier fid7 ("field_2", {tags2,dims2}, m, "some_other_grid");
 
   REQUIRE (fid1==fid2);
   REQUIRE (fid2!=fid3);
   REQUIRE (fid3!=fid4);
-
-  std::vector<int> dims1 = {2, 3, 4};
-  std::vector<int> dims2 = {2, 3, 3};
-
-  // Should not be able to set negative dimensions, or a non existing extent
-  REQUIRE_THROWS(fid1.set_dimension(0,-1));
-  REQUIRE_THROWS(fid1.set_dimension(-1,1));
-  REQUIRE_THROWS(fid1.set_dimension(3,1));
-
-  // Should not be able to set a dimensions vector of wrong rank
-  REQUIRE_THROWS(fid1.set_dimensions({1,2}));
-
-  fid1.set_dimensions(dims1);
-  fid2.set_dimensions(dims2);
-
-  // Should not be able to reset the dimensions once they are set
-  REQUIRE_THROWS(fid2.set_dimensions(dims2));
-
-  REQUIRE (fid1!=fid2);
+  REQUIRE (fid4!=fid5);
+  REQUIRE (fid5!=fid6);
+  REQUIRE (fid6!=fid7);
 
   // Check that has_tag option works
-  REQUIRE(fid1.get_layout().has_tag(FieldTag::GaussPoint));
-  REQUIRE(!fid1.get_layout().has_tag(FieldTag::Component));
+  REQUIRE(fid1.get_layout().has_tag(CMP));
+  REQUIRE(!fid1.get_layout().has_tag(GP));
 }
 
 TEST_CASE("field_tracking", "") {
@@ -66,34 +73,22 @@ TEST_CASE("field_tracking", "") {
 
   REQUIRE_THROWS  (track.update_time_stamp(time1));
 }
-  template<typename ST, int N>
-  using Pack = ekat::Pack<ST,N>;
 
 TEST_CASE("field", "") {
-
   using namespace scream;
+  using namespace ShortFieldTagsNames;
   using namespace ekat::units;
+  using P4 = ekat::Pack<Real,4>;
+  using P8 = ekat::Pack<Real,8>;
+  using P16 = ekat::Pack<Real,16>;
 
-  std::vector<FieldTag> tags = {FieldTag::Element, FieldTag::GaussPoint, FieldTag::VerticalLevel};
-  std::vector<int> dims = {2, 3, 12};
+  std::vector<FieldTag> tags = {COL,VL};
+  std::vector<int> dims = {3,24};
 
-  FieldIdentifier fid ("field_1", tags, m/s);
-  fid.set_dimensions(dims);
-
-  // Check copy constructor
-  SECTION ("copy ctor") {
-    Field<Real> f1 (fid);
-
-    f1.allocate_view();
-
-    Field<const Real> f2 = f1;
-    REQUIRE(f2.get_header_ptr()==f1.get_header_ptr());
-    REQUIRE(f2.get_view()==f1.get_view());
-    REQUIRE(f2.is_allocated());
-  }
+  FieldIdentifier fid ("field_1", {tags,dims}, m/s,"some_grid");
 
   // Check if we can extract a reshaped view
-  SECTION ("reshape simple") {
+  SECTION ("reshape") {
     Field<Real> f1 (fid);
 
     // Should not be able to reshape before allocating
@@ -101,39 +96,80 @@ TEST_CASE("field", "") {
 
     f1.allocate_view();
 
-    // Should not be able to reshape to this data type
-    REQUIRE_THROWS(f1.get_reshaped_view<Pack<Real,8>>());
+    // Reshape should work with both dynamic and static dims
+    auto v1 = f1.get_reshaped_view<Real[3][24]>();
+    auto v2 = f1.get_reshaped_view<Real**>();
 
-    auto v1d = f1.get_view();
-    auto v3d = f1.get_reshaped_view<Real[2][3][12]>();
-    REQUIRE(v3d.size()==v1d.size());
-  }
+    REQUIRE(v1.size()==v2.size());
 
-  // Check if we can request multiple value types
-  SECTION ("reshape multiple value types") {
-    Field<Real> f1 (fid);
-    f1.get_header().get_alloc_properties().request_value_type_allocation<Pack<Real,8>>();
-    f1.allocate_view();
+    // But if wrong static length is used, we should throw
+    REQUIRE_THROWS(f1.get_reshaped_view<Real[3][16]>());
 
-    auto v1d = f1.get_view();
-    auto v3d_1 = f1.get_reshaped_view<Pack<Real,8>***>();
-    auto v3d_2 = f1.get_reshaped_view<Pack<Real,4>***>();
-    auto v3d_3 = f1.get_reshaped_view<Real***>();
-    auto v3d_4 = f1.get_reshaped_view<Real[2][3][16]>();
+    // Should not be able to reshape to this data type...
+    REQUIRE_THROWS(f1.get_reshaped_view<P16**>());
+    // But this should work
+    REQUIRE_NOTHROW(f1.get_reshaped_view<P8**>());
+
+    // Using packs (of allowable size) of different pack sizes
+    // should lead to views with different extents.
+    // Since there's no padding, their extent on last dimension
+    // should be the phys dim divided by pack size.
+    auto v3 = f1.get_reshaped_view<P8**>();
+    auto v4 = f1.get_reshaped_view<P4**>();
+    REQUIRE (v4.size() == 2*v3.size());
+    REQUIRE (v4.extent_int(0) == fid.get_layout().dim(0));
+    REQUIRE (v3.extent_int(0) == fid.get_layout().dim(0));
+    REQUIRE (v4.extent_int(1) == fid.get_layout().dim(1) / P4::n);
+    REQUIRE (v3.extent_int(1) == fid.get_layout().dim(1) / P8::n);
 
     // The memory spans should be identical
-    REQUIRE (v3d_1.impl_map().memory_span()==v3d_2.impl_map().memory_span());
-    REQUIRE (v3d_1.impl_map().memory_span()==v3d_3.impl_map().memory_span());
-    REQUIRE (v3d_1.impl_map().memory_span()==v3d_4.impl_map().memory_span());
-
-    // Sizes differ, since they are in terms of the stored value type.
-    // Each Pack<Real,8> corresponds to two Pack<Real,4>, which corresponds to 4 Real's.
-    REQUIRE(2*v3d_1.size()==v3d_2.size());
-    REQUIRE(8*v3d_1.size()==v3d_3.size());
-    REQUIRE(8*v3d_1.size()==v3d_4.size());
+    REQUIRE (v3.impl_map().memory_span()==v4.impl_map().memory_span());
 
     // Trying to reshape into something that the allocation cannot accommodate should throw
-    REQUIRE_THROWS (f1.get_reshaped_view<Pack<Real,32>***>());
+    REQUIRE_THROWS (f1.get_reshaped_view<P16***>());
+  }
+
+  SECTION ("compare") {
+
+    Field<Real> f1(fid), f2(fid);
+    f2.get_header().get_alloc_properties().request_allocation<P16>();
+    f1.allocate_view();
+    f2.allocate_view();
+
+    using kt = ekat::KokkosTypes<ekat::DefaultDevice>;
+    auto v1 = f1.get_reshaped_view<Real**>();
+    auto v2 = f2.get_reshaped_view<P8**>();
+    auto dim0 = fid.get_layout().dim(0);
+    auto dim1 = fid.get_layout().dim(1);
+    Kokkos::parallel_for(kt::RangePolicy(0,dim0*dim1),
+                         KOKKOS_LAMBDA(int idx) {
+      int i = idx / dim1;
+      int j = idx % dim1;
+      v1(i,j) = i*dim1+j;
+
+      int jpack = j / P8::n;
+      int jvec = j % P8::n;
+      v2(i,jpack)[jvec] = i*dim1+j;
+    });
+    Kokkos::fence();
+
+    // The views were filled the same way, so they should test equal
+    // NOTE: this cmp function only test the "actual" field, discarding padding.
+    REQUIRE(views_are_equal(f1,f2));
+  }
+
+  // Check copy constructor
+  SECTION ("copy ctor") {
+    Field<Real> f1 (fid);
+
+    f1.allocate_view();
+    Kokkos::deep_copy(f1.get_view(),3.0);
+
+    Field<const Real> f2 = f1;
+    REQUIRE(f2.get_header_ptr()==f1.get_header_ptr());
+    REQUIRE(f2.get_view()==f1.get_view());
+    REQUIRE(f2.is_allocated());
+    REQUIRE(views_are_equal(f1,f2));
   }
 }
 
@@ -145,37 +181,23 @@ TEST_CASE("field_repo", "") {
   std::vector<FieldTag> tags2 = {FieldTag::Column};
   std::vector<FieldTag> tags3 = {FieldTag::VerticalLevel};
 
-  const auto km = 1000*m;
-
-  FieldIdentifier fid1("field_1", tags1, m/s);
-  FieldIdentifier fid2("field_2", tags1, m/s);
-  FieldIdentifier fid3("field_2", tags2, m/s);
-  FieldIdentifier fid4("field_2", tags2, km/s);
-  FieldIdentifier fid5("field_3", tags2, km/s);
-  FieldIdentifier fid6("field_4", tags2, km/s);
-  FieldIdentifier fid7("field_5", tags2, km/s);
-  FieldIdentifier fid8("field_5", tags3, km/s);
-
   std::vector<int> dims1 = {2, 3, 4};
   std::vector<int> dims2 = {2, 3, 3};
   std::vector<int> dims3 = {13};
   std::vector<int> dims4 = {6};
 
-  fid1.set_dimensions(dims1);
-  fid2.set_dimensions(dims2);
-  fid3.set_dimensions(dims3);
-  fid4.set_dimensions(dims3);
-  fid5.set_dimensions(dims3);
-  fid6.set_dimensions(dims3);
-  fid7.set_dimensions(dims3);
-  fid8.set_dimensions(dims4);
+  const auto km = 1000*m;
 
-  fid2.set_grid_name("grid_1");
-  fid3.set_grid_name("grid_2");
-  fid7.set_grid_name("grid_3");
-  fid8.set_grid_name("grid_3");
+  FieldIdentifier fid1("field_1", {tags1, dims1},  m/s, "grid_1");
+  FieldIdentifier fid2("field_2", {tags1, dims2},  m/s, "grid_1");
+  FieldIdentifier fid3("field_2", {tags2, dims3},  m/s, "grid_2");
+  FieldIdentifier fid4("field_2", {tags2, dims3}, km/s, "grid_1");
+  FieldIdentifier fid5("field_3", {tags2, dims3}, km/s, "grid_1");
+  FieldIdentifier fid6("field_4", {tags2, dims3}, km/s, "grid_1");
+  FieldIdentifier fid7("field_5", {tags2, dims3}, km/s, "grid_3");
+  FieldIdentifier fid8("field_5", {tags3, dims4}, km/s, "grid_3");
 
-  FieldRepository<Real>  repo;
+  FieldRepository<Real> repo;
 
   // Should not be able to register fields yet
   REQUIRE_THROWS(repo.register_field(fid1,"group_1"));
@@ -258,8 +280,7 @@ TEST_CASE("field_property_check", "") {
   std::vector<FieldTag> tags = {FieldTag::Element, FieldTag::GaussPoint, FieldTag::VerticalLevel};
   std::vector<int> dims = {2, 3, 12};
 
-  FieldIdentifier fid ("field_1", tags, m/s);
-  fid.set_dimensions(dims);
+  FieldIdentifier fid ("field_1",{tags,dims}, m/s,"some_grid");
 
   // Check positivity.
   SECTION ("field_positivity_check") {

--- a/components/scream/src/share/tests/grid_tests.cpp
+++ b/components/scream/src/share/tests/grid_tests.cpp
@@ -34,7 +34,7 @@ TEST_CASE("point_grid", "") {
     REQUIRE(i == host_lid_to_idx(i, 0));
   }
 
-  auto layout = grid->get_native_dof_layout();
+  auto layout = grid->get_2d_scalar_layout();
   REQUIRE(layout.tags().size() == 1);
   REQUIRE(layout.tag(0) == COL);
 }
@@ -52,7 +52,7 @@ TEST_CASE("se_grid", "") {
   REQUIRE(grid.get_num_vertical_levels() == num_levels);
   REQUIRE(grid.get_num_local_dofs() == num_elems*num_gp*num_gp);
 
-  auto layout = grid.get_native_dof_layout();
+  auto layout = grid.get_2d_scalar_layout();
   REQUIRE(layout.tags().size() == 3);
   REQUIRE(layout.tag(0) == EL);
   REQUIRE(layout.tag(1) == GP);


### PR DESCRIPTION
This PR introduces the possibility to create a field as a "subview" of another. The allowed scenarios are relatively limited, but should be enough to accommodate the use cases we need in scream.

In particular, we can
 -  subview a field by slicing its "leading" dimension (the slowest striding one);
 -  subview a field by slicing its second dimension, IF the input field rank is 3 or more (due to limits in kokkos).
 
 Both these operations can be repeated (so one could strip away, say, the first 3 dimensions). But in all likelihood, only one application of the subview will always be enough in scream.
 
Subviewing is as simple as
```
  // subview f1 at 4th entry along 2nd dim, and use f2_id as field identifier for f2
  auto f2 = f1.subfield(1, 3); // Keeps same name
  auto f3 = f1.subfield("new_name",1,3); // Different field name
```

Important detail (I need to improve the documentation): the view stored in f2 is _the same_ view that is stored in f1. The actual subviewing of it only happens during the call to `get_reshaped_view`. This means that if you do `f2.get_view()` you get the same thing that you would get with `f1.get_view()`. This may be important if `f2` is strided (like in this case, because it subviews f1 along the second dimension). In this case, doing something like
```
Kokkos::deep_copy(f2.get_view()),1.0); // likely not what you expected
```
will fill _the whole original view_ with ones, rather than just filling the subview. In order to get the actual subview, use `get_reshaped_view`:

```
auto v2 = f2.get_reshaped_view<Real***>(); // Will throw if f2 has rank!=3.
Kokkos::deep_copy(v2,1.0); // Ok, only the part of f1 corresponding to f2 gets filled with ones.
``` 