### PR TITLE
P3 post-amble processing of variables

### DIFF
--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -141,7 +141,7 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   view_2d cld_frac_r("cld_frac_r",m_num_cols,nk_pack);
   view_2d dz("dz",m_num_cols,nk_pack);
   // -- Set values for the post-amble structure
-  p3_preproc.set_values(m_num_cols,nk_pack,pmid,T_atm,ast,zi,
+  p3_preproc.set_variables(m_num_cols,nk_pack,pmid,T_atm,ast,zi,
                         exner, th_atm, cld_frac_l, cld_frac_i, cld_frac_r, dz);
   // --Prognostic State Variables:
   prog_state.qc     = m_p3_fields_out["qc"].get_reshaped_view<Pack**>();
@@ -208,7 +208,7 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   history_only.vap_liq_exchange = m_p3_fields_out["vap_liq_exchange"].get_reshaped_view<Pack**>();
   history_only.vap_ice_exchange = m_p3_fields_out["vap_ice_exchange"].get_reshaped_view<Pack**>();
   // -- Set values for the post-amble structure
-  p3_postproc.set_values(m_num_cols,nk_pack,prog_state.th,p3_preproc.exner,T_atm,t_prev,prog_state.qv,qv_prev);
+  p3_postproc.set_variables(m_num_cols,nk_pack,prog_state.th,p3_preproc.exner,T_atm,t_prev,prog_state.qv,qv_prev);
 
   // We may have to init some fields from within P3. This can be the case in a P3 standalone run.
   // Some options:

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -129,6 +129,19 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   // Initialize all of the structures that are passed to p3_main in run_impl.
   // Note: Some variables in the structures are not stored in the field manager.  For these
   //       variables a local view is constructed.
+  const Int nk_pack = ekat::npack<Spack>(m_num_levs);
+  auto pmid  = m_p3_fields_in["pmid"].get_reshaped_view<const Pack**>();
+  auto T_atm = m_p3_fields_out["T_atm"].get_reshaped_view<Pack**>();
+  auto ast   = m_p3_fields_in["ast"].get_reshaped_view<const Pack**>();
+  auto zi    = m_p3_fields_in["zi"].get_reshaped_view<const Pack**>();
+  view_2d exner("exner",m_num_cols,nk_pack);
+  view_2d th_atm("th_atm",m_num_cols,nk_pack);
+  view_2d cld_frac_l("cld_frac_l",m_num_cols,nk_pack);
+  view_2d cld_frac_i("cld_frac_i",m_num_cols,nk_pack);
+  view_2d cld_frac_r("cld_frac_r",m_num_cols,nk_pack);
+  view_2d dz("dz",m_num_cols,nk_pack);
+  p3_preproc.set_values(m_num_cols,nk_pack,pmid,T_atm,ast,zi,
+                        exner, th_atm, cld_frac_l, cld_frac_i, cld_frac_r, dz);
   // --Prognostic State Variables:
   prog_state.qc     = m_p3_fields_out["qc"].get_reshaped_view<Pack**>();
   prog_state.nc     = m_p3_fields_out["nc"].get_reshaped_view<Pack**>();
@@ -139,6 +152,7 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   prog_state.ni     = m_p3_fields_out["ni"].get_reshaped_view<Pack**>();
   prog_state.bm     = m_p3_fields_out["bm"].get_reshaped_view<Pack**>();
   prog_state.qv     = m_p3_fields_out["qv"].get_reshaped_view<Pack**>();
+  prog_state.th     = p3_preproc.th_atm;
   // --Diagnostic Input Variables:
   diag_inputs.nc_nuceat_tend  = m_p3_fields_in["nc_nuceat_tend"].get_reshaped_view<const Pack**>();
   diag_inputs.nccn            = m_p3_fields_in["nccn_prescribed"].get_reshaped_view<const Pack**>();
@@ -148,6 +162,11 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   diag_inputs.dpres           = m_p3_fields_in["dp"].get_reshaped_view<const Pack**>();
   diag_inputs.qv_prev         = m_p3_fields_out["qv_prev"].get_reshaped_view<Pack**>();
   diag_inputs.t_prev          = m_p3_fields_out["T_prev"].get_reshaped_view<Pack**>();
+  diag_inputs.cld_frac_l = p3_preproc.cld_frac_l;
+  diag_inputs.cld_frac_i = p3_preproc.cld_frac_i;
+  diag_inputs.cld_frac_r = p3_preproc.cld_frac_r;
+  diag_inputs.dz         = p3_preproc.dz;
+  diag_inputs.exner      = p3_preproc.exner;
   // --Diagnostic Outputs
   view_1d precip_liq_surf("precip_liq_surf",m_num_cols);
   view_1d precip_ice_surf("precip_ice_surf",m_num_cols);
@@ -258,34 +277,35 @@ void P3Microphysics::run_impl (const Real dt)
   auto T_atm  = m_p3_fields_out["T_atm"].get_reshaped_view<Pack**>();
   auto ast    = m_p3_fields_in["ast"].get_reshaped_view<const Pack**>();
   auto zi     = m_p3_fields_in["zi"].get_reshaped_view<const Pack**>();
-  auto pmid            = m_p3_fields_in["pmid"].get_reshaped_view<const Pack**>();
+  auto pmid   = m_p3_fields_in["pmid"].get_reshaped_view<const Pack**>();
 
   // Assign values to local arrays used by P3, these are now stored in p3_loc.
-  const Int nk_pack = ekat::npack<Spack>(m_num_levs);
-  run_local_vars p3_loc(m_num_cols,nk_pack,pmid,T_atm,ast,zi);
   Kokkos::parallel_for(
     "p3_main_local_vals",
     Kokkos::RangePolicy<>(0,m_num_cols),
-    p3_loc
+    p3_preproc
   ); // Kokkos::parallel_for(p3_main_local_vals)
   Kokkos::fence();
 
   // Update the variables in the p3 input structures with local values.
-  prog_state.th          = p3_loc.th_atm;
-
-  diag_inputs.cld_frac_l = p3_loc.cld_frac_l;
-  diag_inputs.cld_frac_i = p3_loc.cld_frac_i;
-  diag_inputs.cld_frac_r = p3_loc.cld_frac_r;
-  diag_inputs.dz         = p3_loc.dz;
-  diag_inputs.exner      = p3_loc.exner;
 
   infrastructure.dt = dt;
   infrastructure.it++;
 
+//ASD  const Int nk_pack = ekat::npack<Spack>(m_num_levs);
+//ASD  view_2d th_temp("th_temp",m_num_cols,nk_pack);
+//ASD  Kokkos::deep_copy(th_temp,prog_state.qc);
+
   // Run p3 main
   P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
                                        history_only, m_num_cols, m_num_levs);
-
+//ASD  printf(" it=%2d \n",infrastructure.it);
+//ASD  for (int kk=0;kk<m_num_levs;kk++)
+//ASD  {
+//ASD    int ipack = kk / Spack::n;
+//ASD    int ivec  = kk % Spack::n;
+//ASD    printf("ASD - (%d) = %e, %e, %e\n",kk,th_temp(0,ipack)[ivec],prog_state.qc(0,ipack)[ivec],p3_preproc.th_atm(0,ipack)[ivec]);
+//ASD  }
   // Get a copy of the current timestamp (at the beginning of the step) and
   // advance it, updating the p3 fields.
   auto ts = timestamp();

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -73,9 +73,9 @@ public:
   // the set of fields stored in the field manager.  A structure like this defines those operations,
   // which can then be called during run_imple in the main .cpp code.
   // Structure to handle the local generation of data needed by p3_main in run_impl
-  struct run_local_vars {
-    run_local_vars() = default; 
-    run_local_vars(const int ncol, const int npack, view_2d_const pmid_, view_2d T_atm_, view_2d_const ast_, view_2d_const zi_) : 
+  struct p3_preamble {
+    p3_preamble() = default; 
+    p3_preamble(const int ncol, const int npack, view_2d_const pmid_, view_2d T_atm_, view_2d_const ast_, view_2d_const zi_) : 
       m_ncol(ncol),
       m_npack(npack),
       // IN
@@ -169,7 +169,7 @@ public:
       cld_frac_r = cld_frac_r_;
       dz = dz_;
     }
-  }; // run_local_vars
+  }; // p3_preamble
   /* --------------------------------------------------------------------------------------------*/
 
 protected:
@@ -213,7 +213,7 @@ protected:
   P3F::P3DiagnosticOutputs diag_outputs;
   P3F::P3HistoryOnly       history_only;
   P3F::P3Infrastructure    infrastructure;
-  run_local_vars           p3_preproc;
+  p3_preamble              p3_preproc;
   // Iteration count is internal to P3 and keeps track of the number of times p3_main has been called.
   // infrastructure.it is passed as an arguement to p3_main and is used for identifying which iteration an error occurs. 
 

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -100,12 +100,12 @@ public:
           // Hard-coded max-overlap cloud fraction calculation.  Cycle through the layers from top to bottom and determine if the rain fraction needs to
           // be updated to match the cloud fraction in the layer above.  It is necessary to calculate the location of the layer directly above this one,
           // labeled ipack_m1 and ivec_m1 respectively.  Note, the top layer has no layer above it, which is why we have the kstr index in the loop.
-          Int col = ipack*Spack::n + ivec;
-          Int ipack_m1 = (col - 1) / Spack::n;
-          Int ivec_m1  = (col - 1) % Spack::n;
-          Int ipack_p1 = (col + 1) / Spack::n;
-          Int ivec_p1  = (col + 1) % Spack::n;
-          if (col!=0) { /* Not applicable at the very top layer */
+          Int lev = ipack*Spack::n + ivec;  // Determine the level at this pack/vec location.
+          Int ipack_m1 = (lev - 1) / Spack::n;
+          Int ivec_m1  = (lev - 1) % Spack::n;
+          Int ipack_p1 = (lev + 1) / Spack::n;
+          Int ivec_p1  = (lev + 1) % Spack::n;
+          if (lev != 0) { /* Not applicable at the very top layer */
             cld_frac_r(icol,ipack)[ivec] = ast(icol,ipack_m1)[ivec_m1]>cld_frac_r(icol,ipack)[ivec] ? 
                                               ast(icol,ipack_m1)[ivec_m1] :
                                               cld_frac_r(icol,ipack)[ivec];

--- a/components/scream/src/physics/p3/p3_inputs_initializer.cpp
+++ b/components/scream/src/physics/p3/p3_inputs_initializer.cpp
@@ -200,38 +200,38 @@ void P3InputsInitializer::initialize_fields ()
   {
     for (int k = nk-1;k>=0;k--)
     {
-    int icol  = icol_i % icol_in_max;
-    int ipack = k / Spack::n;
-    int ivec  = k % Spack::n;
-    int ipack_m1 = (k-1) / Spack::n;
-    int ivec_m1  = (k-1) % Spack::n;
-    h_qv(icol_i,ipack)[ivec]              = h_qv(icol,ipack)[ivec]                              ;
-    h_th_atm(icol_i,ipack)[ivec]          = h_th_atm(icol,ipack)[ivec]                          ;
-    h_T_atm(icol_i,ipack)[ivec]           = h_th_atm(icol,ipack)[ivec]*h_exner(icol,ipack)[ivec];
-    h_pmid(icol_i,ipack)[ivec]            = h_pmid(icol,ipack)[ivec]                            ;
-    h_dz(icol_i,ipack)[ivec]              = h_dz(icol,ipack)[ivec]                              ;
-    h_nc_nuceat_tend(icol_i,ipack)[ivec]  = h_nc_nuceat_tend(icol,ipack)[ivec]                  ;
-    h_nccn_prescribed(icol_i,ipack)[ivec] = h_nccn_prescribed(icol,ipack)[ivec]                 ;
-    h_ni_activated(icol_i,ipack)[ivec]    = h_ni_activated(icol,ipack)[ivec]                    ;
-    h_inv_qc_relvar(icol_i,ipack)[ivec]   = h_inv_qc_relvar(icol,ipack)[ivec]                   ;
-    h_qc(icol_i,ipack)[ivec]              = h_qc(icol,ipack)[ivec]                              ;
-    h_nc(icol_i,ipack)[ivec]              = h_nc(icol,ipack)[ivec]                              ;
-    h_qr(icol_i,ipack)[ivec]              = h_qr(icol,ipack)[ivec]                              ;
-    h_nr(icol_i,ipack)[ivec]              = h_nr(icol,ipack)[ivec]                              ;
-    h_qi(icol_i,ipack)[ivec]              = h_qi(icol,ipack)[ivec]                              ;
-    h_ni(icol_i,ipack)[ivec]              = h_ni(icol,ipack)[ivec]                              ;
-    h_qm(icol_i,ipack)[ivec]              = h_qm(icol,ipack)[ivec]                              ;
-    h_bm(icol_i,ipack)[ivec]              = h_bm(icol,ipack)[ivec]                              ;
-    h_dp(icol_i,ipack)[ivec]              = h_dp(icol,ipack)[ivec]                              ;
-    h_exner(icol_i,ipack)[ivec]           = h_exner(icol,ipack)[ivec]                           ;
-    h_ast(icol_i,ipack)[ivec]             = h_ast(icol,ipack)[ivec]                             ;
-    h_qv_prev(icol_i,ipack)[ivec]         = h_qv_prev(icol,ipack)[ivec]                         ;
-    h_T_prev(icol_i,ipack)[ivec]          = h_T_prev(icol,ipack)[ivec]                          ;
-    // Initialize arrays not provided in input file
-    h_zi(icol_i,ipack)[ivec] = (k==nk-1) ? 0 :
-                                           h_zi(icol_i,ipack_m1)[ivec_m1] + h_dz(icol_i,ipack)[ivec];
-    }
-  }
+      int icol  = icol_i % (icol_in_max+1);
+      int ipack = k / Spack::n;
+      int ivec  = k % Spack::n;
+      int ipack_p1 = (k+1) / Spack::n;
+      int ivec_p1  = (k+1) % Spack::n;
+      h_qv(icol_i,ipack)[ivec]              = h_qv(icol,ipack)[ivec]                              ;
+      h_th_atm(icol_i,ipack)[ivec]          = h_th_atm(icol,ipack)[ivec]                          ;
+      h_T_atm(icol_i,ipack)[ivec]           = h_th_atm(icol,ipack)[ivec]*h_exner(icol,ipack)[ivec];
+      h_pmid(icol_i,ipack)[ivec]            = h_pmid(icol,ipack)[ivec]                            ;
+      h_dz(icol_i,ipack)[ivec]              = h_dz(icol,ipack)[ivec]                              ;
+      h_nc_nuceat_tend(icol_i,ipack)[ivec]  = h_nc_nuceat_tend(icol,ipack)[ivec]                  ;
+      h_nccn_prescribed(icol_i,ipack)[ivec] = h_nccn_prescribed(icol,ipack)[ivec]                 ;
+      h_ni_activated(icol_i,ipack)[ivec]    = h_ni_activated(icol,ipack)[ivec]                    ;
+      h_inv_qc_relvar(icol_i,ipack)[ivec]   = h_inv_qc_relvar(icol,ipack)[ivec]                   ;
+      h_qc(icol_i,ipack)[ivec]              = h_qc(icol,ipack)[ivec]                              ;
+      h_nc(icol_i,ipack)[ivec]              = h_nc(icol,ipack)[ivec]                              ;
+      h_qr(icol_i,ipack)[ivec]              = h_qr(icol,ipack)[ivec]                              ;
+      h_nr(icol_i,ipack)[ivec]              = h_nr(icol,ipack)[ivec]                              ;
+      h_qi(icol_i,ipack)[ivec]              = h_qi(icol,ipack)[ivec]                              ;
+      h_ni(icol_i,ipack)[ivec]              = h_ni(icol,ipack)[ivec]                              ;
+      h_qm(icol_i,ipack)[ivec]              = h_qm(icol,ipack)[ivec]                              ;
+      h_bm(icol_i,ipack)[ivec]              = h_bm(icol,ipack)[ivec]                              ;
+      h_dp(icol_i,ipack)[ivec]              = h_dp(icol,ipack)[ivec]                              ;
+      h_exner(icol_i,ipack)[ivec]           = h_exner(icol,ipack)[ivec]                           ;
+      h_ast(icol_i,ipack)[ivec]             = h_ast(icol,ipack)[ivec]                             ;
+      h_qv_prev(icol_i,ipack)[ivec]         = h_qv_prev(icol,ipack)[ivec]                         ;
+      h_T_prev(icol_i,ipack)[ivec]          = h_T_prev(icol,ipack)[ivec]                          ;
+      // Initialize arrays not provided in input file
+      if (k==nk-1) { h_zi(icol_i,ipack_p1)[ivec_p1] = 0.0; } // If this is the bottom layer then initialize zi[nk]
+      h_zi(icol_i,ipack)[ivec] = h_zi(icol_i,ipack_p1)[ivec_p1] + h_dz(icol_i,ipack)[ivec];
+    } // for k
+  } // for icol_i
 
   // Deep copy back to device
   Kokkos::deep_copy(d_T_atm          , h_T_atm          ); 


### PR DESCRIPTION
Introduce post-processing of the output variables from P3.

This commit introduces a structure to the p3 interface header that similar to the pre-processing structure already in the code.  Typically, an atmospheric process does not produce variables needed by other processes in an appropriate format.  P3 is no exception.

This commit introduces a structure to the p3_interface header file which will update field managed variables that are needed in the next timestep and/or by other processes.  This action tracks with what is already done in micro_p3_interface.F90 in the EAM version of the code.

There are a number of variables that are missing, but noted in the comments.  It is likely that as new processes, such as SHOC and Radiation, are added we will need to update the post-processing code to provide the values these processes need.  But instead of guessing what those might be, this PR only focuses on the variables that are needed by Dynamics and P3.

This PR also fixes a bug that was discovered in how the `zi` variable is initialized in the p3_inputs_intializer code.

Addresses one part of #864 .

NBFB for p3_stand_alone test - doesn't touch the actual P3 code.