### PR TITLE
Create tracers as subviews of a large Q array

### DIFF
--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -110,7 +110,7 @@ void AtmosphereDriver::initialize (const ekat::Comm& atm_comm,
   m_field_repo->registration_begins();
   m_atm_process_group->register_fields(*m_field_repo);
   register_groups();
-  m_field_repo->registration_ends();
+  m_field_repo->registration_ends(m_grids_manager);
 
   // Set all the fields in the processes needing them (before, they only had ids)
   // Input fields will be handed to the processes as const

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -226,7 +226,7 @@ void AtmosphereDriver::register_groups () {
 
   // Given a list of group-grid pairs (A,B), make sure there is a copy
   // of each field in group A on grid B registered in the repo.
-  auto lambda = [&](const std::set<GroupRequest>& groups_grids) {
+  auto has_group_fields_on_grid = [&](const std::set<GroupRequest>& groups_grids) {
     const auto& groups_info = m_field_repo->get_groups_info();
 
     for (const auto& gg : groups_grids) {
@@ -285,8 +285,10 @@ void AtmosphereDriver::register_groups () {
       }
     }
   };
-  lambda( m_atm_process_group->get_required_groups() );
-  lambda( m_atm_process_group->get_updated_groups() );
+
+  // Call the above lambda on both required and updated groups.
+  has_group_fields_on_grid( m_atm_process_group->get_required_groups() );
+  has_group_fields_on_grid( m_atm_process_group->get_updated_groups() );
 }
 
 void AtmosphereDriver::init_atm_inputs () {

--- a/components/scream/src/control/surface_coupling.cpp
+++ b/components/scream/src/control/surface_coupling.cpp
@@ -1,5 +1,7 @@
 #include "control/surface_coupling.hpp"
 
+#include "share/field/field_utils.hpp"
+
 namespace scream {
 namespace control {
 
@@ -74,39 +76,8 @@ register_import(const std::string& fname,
   // Set cpl index
   info.cpl_idx = cpl_idx;
 
-  const auto& layout = field.get_header().get_identifier().get_layout();
-  const auto& alloc_prop = field.get_header().get_alloc_properties();
-  const auto& tags = layout.tags();
-
-  using namespace ShortFieldTagsNames;
-
-  switch (layout.rank()) {
-    case 1:
-      EKAT_REQUIRE_MSG(vecComp==-1, "Error! Vector component specified, but field '" + fname + "' is a 2d scalar.\n");
-      info.col_stride = 1;
-      info.col_offset = 0;
-      break;
-    case 2:
-      EKAT_REQUIRE_MSG(tags[1]==VL || tags[1]==VAR || tags[1]==CMP,
-                         "Error! Unexpected tag '" + e2str(tags[1]) + "' for second dimension of export field '" + fname + "'.\n");
-      EKAT_REQUIRE_MSG(tags.back()!=VL || vecComp==-1, "Error! Vector component specified, but field '" + fname + "' is a 3d scalar.\n");
-
-      info.col_stride = alloc_prop.get_last_extent();
-      info.col_offset = vecComp;
-      break;
-    case 3:
-      EKAT_REQUIRE_MSG(tags[1]==VAR || tags[1]==CMP,
-                         "Error! Unexpected tag '" + e2str(tags[1]) + "' for second dimension of export field '" + fname + "'.\n");
-      EKAT_REQUIRE_MSG(tags[2]==VL,
-                         "Error! Unexpected tag '" + e2str(tags[2]) + "' for third dimension of export field '" + fname + "'.\n");
-      EKAT_REQUIRE_MSG(vecComp>=0, "Error! Vector component not specified for 3d vector field '" + fname + "/.\n");
-
-      info.col_stride = layout.dim(1)*alloc_prop.get_last_extent();
-      info.col_offset = tags[1]==VL ? 0 : vecComp;
-      break;
-    default:
-      EKAT_ERROR_MSG("Error! Unsupported field rank for import field '" + fname + "'.\n");
-  }
+  // Get column offset and stride
+  get_col_info (field.get_header_ptr(), vecComp, info.col_offset, info.col_stride);
 
   // Store the identifier of this field, for debug purposes
   m_imports_fids.insert(field.get_header().get_identifier());
@@ -156,41 +127,8 @@ register_export (const std::string& fname,
   // Set cpl index
   info.cpl_idx = cpl_idx;
 
-  // To figure out col_stride and col_offset, we need to inspect the field layout,
-  // as well as its allocation properties (to handle the case od padding)
-  const auto& layout = field.get_header().get_identifier().get_layout();
-  const auto& alloc_prop = field.get_header().get_alloc_properties();
-  const auto& tags = layout.tags();
-
-  using namespace ShortFieldTagsNames;
-
-  switch (layout.rank()) {
-    case 1:
-      EKAT_REQUIRE_MSG(vecComp==-1, "Error! Vector component specified, but field '" + fname + "' is a 2d scalar.\n");
-      info.col_stride = 1;
-      info.col_offset = 0;
-      break;
-    case 2:
-      EKAT_REQUIRE_MSG(tags[1]==VL || tags[1]==VAR || tags[1]==CMP,
-                         "Error! Unexpected tag '" + e2str(tags[1]) + "' for second dimension of import field '" + fname + "'.\n");
-      EKAT_REQUIRE_MSG(tags.back()!=VL || vecComp==-1, "Error! Vector component specified, but field '" + fname + "' is a 3d scalar.\n");
-
-      info.col_stride = alloc_prop.get_last_extent();
-      info.col_offset = tags[1]==VL ? 0 : vecComp;
-      break;
-    case 3:
-      EKAT_REQUIRE_MSG(tags[1]==VAR || tags[1]==CMP,
-                         "Error! Unexpected tag '" + e2str(tags[1]) + "' for second dimension of import field '" + fname + "'.\n");
-      EKAT_REQUIRE_MSG(tags[2]==VL,
-                         "Error! Unexpected tag '" + e2str(tags[2]) + "' for third dimension of import field '" + fname + "'.\n");
-      EKAT_REQUIRE_MSG(vecComp>=0, "Error! Vector component not specified for 3d vector field '" + fname + "/.\n");
-
-      info.col_stride = layout.dim(1)*alloc_prop.get_last_extent();
-      info.col_offset = vecComp;
-      break;
-    default:
-      EKAT_ERROR_MSG("Error! Unsupported field rank for import field '" + fname + "'.\n");
-  }
+  // Get column offset and stride
+  get_col_info (field.get_header_ptr(), vecComp, info.col_offset, info.col_stride);
 
   // Store the identifier of this field, for debug purposes
   m_exports_fids.insert(field.get_header().get_identifier());
@@ -311,6 +249,89 @@ void SurfaceCoupling::do_export ()
 
   // Deep copy fields from device to cpl host array
   Kokkos::deep_copy(m_cpl_exports_view_h,m_cpl_exports_view_d);
+}
+
+void SurfaceCoupling::
+get_col_info(const std::shared_ptr<const FieldHeader>& fh,
+             int vecComp, int& col_offset, int& col_stride) const
+{
+  // Each field is seen as a certain number of columns worth of data (CWD)
+  // at every column point. E.g., a field with layout (ncols,nlevs) is 1 CWD,
+  // while a field with layout (ncols,3,nlevs) is 3 CWD.
+  // The col_offset encodes the offset of this colum *within a single mesh
+  // point icol". So for a vector layout (ncols,3,nlevs), to import/export
+  // the icomp-th component of the field, we'd have col_offset=icomp. For scalar
+  // layouts, the offset is always 0 (only 1 CWD per mesh point).
+  // HOWEVER: if this field was a subview of another field, things are a bit
+  // more involved. Say the field F1 (ncols,3,nlevs) is a subview of a larger
+  // field F2 with layout (ncols,nvars,3,nlevs), corresponding to ivar=2.
+  // Then, F2 has 3*nvars CWD per mesh point. Since the underlying data ptr
+  // is the same, to get the correct col_offset, we need to figure out the
+  // offset inside F2. In this case, it would be col_offset = ivar*3+icomp.
+
+  using namespace ShortFieldTagsNames;
+
+  // Get this field layout info
+  const auto& layout = fh->get_identifier().get_layout();
+  const auto& dims = layout.dims();
+
+  auto lt = get_layout_type(layout.tags());
+  const bool scalar = lt==LayoutType::Scalar2D || lt==LayoutType::Scalar3D;
+  const bool vector = lt==LayoutType::Vector2D || lt==LayoutType::Vector3D;
+  EKAT_REQUIRE_MSG(scalar || vector,
+      "Error! Support for tensor fields not yet implemented in surface coupling.\n");
+  EKAT_REQUIRE_MSG( (vecComp<0) == scalar,
+      "Error! You can and must specify a vector component only for vector fields.\n");
+
+  vecComp = std::max(0,vecComp);
+
+  // Product of dimensions of field, without counting space dims, that is,
+  // the product of dimensions of the "analytical" field.
+  int dims_prod = 1;
+
+  // Compute initial offset based on this field rank and requested component
+  col_offset = vecComp;
+  if (vector) {
+    dims_prod = dims[1];
+  }
+
+  // If rank>1, there always is some stride
+  col_stride = 1;
+  if (layout.rank()>1) {
+    // Note: use alloc prop's last extent, cause it includes padding (if any);
+    col_stride = fh->get_alloc_properties().get_last_extent();
+    if (layout.rank()>2) {
+      col_stride *= dims[1];
+    }
+  }
+
+  // Recursively go through parent field, adding offset depending
+  // on the location of the slice.
+  // Note: as of now, I don't expect there to be "a grandparent" for this field,
+  //       so we could avoid the while loop. However, the logic is so simple, that
+  //       I may as well add it, and be safe down the road if it happens.
+  std::shared_ptr<const FieldHeader> me = fh;
+  std::shared_ptr<const FieldHeader> p  = me->get_parent().lock();
+  while (p!=nullptr) {
+    const auto& idx = me->get_alloc_properties().get_subview_idx();
+
+    // Recall: idx = (idim,k) = (dimension where slice happened, index along said dimension).
+    // Field class only allows idim=0,1. But we should never be in the case of idim=0, here.
+    // If we have idim=0, it means that the parent field did not have CL has tag[0]...
+    EKAT_REQUIRE_MSG(idx.first==1, "Error! Bizarre scenario discovered. Contact developers.\n");
+
+    // Update the offset
+    col_offset += idx.second*dims_prod;
+
+    // Update stride.
+    col_stride *= p->get_identifier().get_layout().dim(1);
+
+    // Update trail_dims, in case there's another parent.
+    dims_prod *= p->get_identifier().get_layout().dim(1);
+
+    me = p;
+    p = me->get_parent().lock();
+  }
 }
 
 } // namespace control

--- a/components/scream/src/control/surface_coupling.hpp
+++ b/components/scream/src/control/surface_coupling.hpp
@@ -105,6 +105,9 @@ protected:
 protected:
 #endif
 
+  void get_col_info (const std::shared_ptr<const FieldHeader>& fh,
+                     int vecComp, int& col_offset, int& col_stride) const;
+
   using import_value_type  = import_field_type::RT;
   using export_value_type  = export_field_type::RT;
 

--- a/components/scream/src/control/tests/dummy_atm_proc.hpp
+++ b/components/scream/src/control/tests/dummy_atm_proc.hpp
@@ -85,23 +85,23 @@ public:
     }
   }
 
-  void set_required_group (const ci_string_pair& /* group_and_grid */,
-                           const std::set<Field<const Real>>& field_group) {
+  void set_required_group (const FieldGroup<const Real>& field_group) {
     EKAT_REQUIRE_MSG (m_dummy_type==G2A,
                       "Error! This atmosphere process does not require a group of fields.\n");
 
-    for (const auto& f : field_group) {
+    for (const auto& it : field_group.m_fields) {
+      const auto& f = *it.second.lock();
       const auto& fid = f.get_header().get_identifier();
       m_inputs.emplace(fid.name(),f);
       m_input_fids.emplace(fid);
     }
   }
-  void set_updated_group (const ci_string_pair& /* group_and_grid */,
-                          const std::set<Field<Real>>& field_group) {
+  void set_updated_group (const FieldGroup<Real>& field_group) {
     EKAT_REQUIRE_MSG (m_dummy_type==G2G,
                       "Error! This atmosphere process does not require a group of fields.\n");
 
-    for (const auto& f : field_group) {
+    for (const auto& it : field_group.m_fields) {
+      const auto& f = *it.second.lock();
       const auto& fid = f.get_header().get_identifier();
       m_inputs.emplace(fid.name(),f.get_const());
       m_input_fids.emplace(fid);
@@ -113,17 +113,17 @@ public:
   // Providing a list of required and computed fields
   const std::set<FieldIdentifier>&  get_required_fields () const { return m_input_fids; }
   const std::set<FieldIdentifier>&  get_computed_fields () const { return m_output_fids; }
-  std::set<ci_string_pair> get_required_groups () const {
-    std::set<ci_string_pair> s;
+  std::set<GroupRequest> get_required_groups () const {
+    std::set<GroupRequest> s;
     if (m_dummy_type==G2A) {
-      s.insert(ci_string_pair("The Group",m_grid->name()));
+      s.insert(GroupRequest("The Group",m_grid->name()));
     }
     return s;
   }
-  std::set<ci_string_pair> get_updated_groups () const {
-    std::set<ci_string_pair> s;
+  std::set<GroupRequest> get_updated_groups () const {
+    std::set<GroupRequest> s;
     if (m_dummy_type==G2G) {
-      s.insert(ci_string_pair("The Group",m_grid->name()));
+      s.insert(GroupRequest("The Group",m_grid->name()));
     }
     return s;
   }

--- a/components/scream/src/control/tests/dummy_atm_proc.hpp
+++ b/components/scream/src/control/tests/dummy_atm_proc.hpp
@@ -90,9 +90,9 @@ public:
                       "Error! This atmosphere process does not require a group of fields.\n");
 
     for (const auto& it : field_group.m_fields) {
-      const auto& f = *it.second.lock();
-      const auto& fid = f.get_header().get_identifier();
-      m_inputs.emplace(fid.name(),f);
+      const auto& f = it.second;
+      const auto& fid = f->get_header().get_identifier();
+      m_inputs.emplace(fid.name(),*f);
       m_input_fids.emplace(fid);
     }
   }
@@ -101,11 +101,11 @@ public:
                       "Error! This atmosphere process does not require a group of fields.\n");
 
     for (const auto& it : field_group.m_fields) {
-      const auto& f = *it.second.lock();
-      const auto& fid = f.get_header().get_identifier();
-      m_inputs.emplace(fid.name(),f.get_const());
+      const auto& f = it.second;
+      const auto& fid = f->get_header().get_identifier();
+      m_inputs.emplace(fid.name(),f->get_const());
       m_input_fids.emplace(fid);
-      m_outputs.emplace(fid.name(),f);
+      m_outputs.emplace(fid.name(),*f);
       m_output_fids.emplace(fid);
     }
   }

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -56,7 +56,7 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
 
   // Sanity check for the grid. This should *always* pass, since Homme builds the grids
   EKAT_REQUIRE_MSG(get_num_local_elems_f90()==ne,
-      "Error! The number of elements computed from the Dynamis grid num_dof()\n"
+      "Error! The number of elements computed from the Dynamics grid num_dof()\n"
       "       does not match the number of elements internal in Homme.\n");
   const int nmf = get_homme_param<int>("num momentum forcings");
 

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -47,9 +47,14 @@ public:
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real>& field_repo) const;
 
+  void set_required_group (const FieldGroup<const Real>& group);
+  void set_updated_group (const FieldGroup<Real>& group);
+
   // Get the set of required/computed fields
   const std::set<FieldIdentifier>&  get_required_fields () const { return m_required_fields; }
   const std::set<FieldIdentifier>&  get_computed_fields () const { return m_computed_fields; }
+  std::set<GroupRequest> get_required_groups () const { return m_in_groups_req; }
+  std::set<GroupRequest> get_updated_groups () const { return m_inout_groups_req; }
 
 protected:
 
@@ -64,12 +69,17 @@ protected:
 
   std::set<FieldIdentifier> m_required_fields;
   std::set<FieldIdentifier> m_computed_fields;
+  std::set<GroupRequest>    m_in_groups_req;
+  std::set<GroupRequest>    m_inout_groups_req;
 
   std::map<std::string,const_field_type>  m_dyn_fields_in;
   std::map<std::string,field_type>        m_dyn_fields_out;
 
   // For certain tests, dynamics needs to init states
   std::shared_ptr<FieldInitializer>       m_initializer;
+
+  // For standalong tests, we might need the grid info later
+  std::shared_ptr<const AbstractGrid>  m_dyn_grid;
 
   ekat::ParameterList     m_params;
   ekat::Comm              m_dynamics_comm;

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -47,6 +47,7 @@ public:
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real>& field_repo) const;
 
+  // Dynamics requires 'TRACERS TENDENCY', and updates 'TRACERS'.
   void set_required_group (const FieldGroup<const Real>& group);
   void set_updated_group (const FieldGroup<Real>& group);
 

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -325,11 +325,27 @@ void P3Microphysics::finalize_impl()
 
 // =========================================================================================
 void P3Microphysics::register_fields (FieldRepository<Real>& field_repo) const {
+  std::set<ci_string> q_names =
+    { "qv","qc","qr","qi","qm","nc","nr","ni","bm",
+      "nccn_prescribed", "ni_activated",
+      "inv_qc_relvar","mu_c","lamc","nevapr",
+      "liq_ice_exchange","vap_liq_exchange","vap_ice_exchange"};
+
   for (auto& fid : m_required_fields) {
-    field_repo.register_field<Pack>(fid);
+    const auto& name = fid.name();
+    if (q_names.count(name)>0) {
+      field_repo.register_field<Pack>(fid,"TRACERS");
+    } else {
+      field_repo.register_field<Pack>(fid);
+    }
   }
   for (auto& fid : m_computed_fields) {
-    field_repo.register_field<Pack>(fid);
+    const auto& name = fid.name();
+    if (q_names.count(name)>0) {
+      field_repo.register_field<Pack>(fid,"TRACERS");
+    } else {
+      field_repo.register_field<Pack>(fid);
+    }
   }
 }
 

--- a/components/scream/src/physics/p3/p3_inputs_initializer.cpp
+++ b/components/scream/src/physics/p3/p3_inputs_initializer.cpp
@@ -96,62 +96,37 @@ void P3InputsInitializer::initialize_fields ()
 
   // Initialize the fields that we expect.
   // Get device views
-  auto d_T_atm           = m_fields.at("T_atm").get_reshaped_view<Pack**>();
-  auto d_ast             = m_fields.at("ast").get_reshaped_view<Pack**>();
-  auto d_ni_activated    = m_fields.at("ni_activated").get_reshaped_view<Pack**>();
-  auto d_nc_nuceat_tend  = m_fields.at("nc_nuceat_tend").get_reshaped_view<Pack**>();
-  auto d_pmid            = m_fields.at("pmid").get_reshaped_view<Pack**>();
-  auto d_dp              = m_fields.at("dp").get_reshaped_view<Pack**>();
-  auto d_zi              = m_fields.at("zi").get_reshaped_view<Pack**>();
-  auto d_qv_prev         = m_fields.at("qv_prev").get_reshaped_view<Pack**>();
-  auto d_T_prev          = m_fields.at("T_prev").get_reshaped_view<Pack**>();
-  auto d_qv              = m_fields.at("qv").get_reshaped_view<Pack**>();
-  auto d_qc              = m_fields.at("qc").get_reshaped_view<Pack**>();
-  auto d_qr              = m_fields.at("qr").get_reshaped_view<Pack**>();
-  auto d_qi              = m_fields.at("qi").get_reshaped_view<Pack**>();
-  auto d_qm              = m_fields.at("qm").get_reshaped_view<Pack**>();
-  auto d_nc              = m_fields.at("nc").get_reshaped_view<Pack**>();
-  auto d_nr              = m_fields.at("nr").get_reshaped_view<Pack**>();
-  auto d_ni              = m_fields.at("ni").get_reshaped_view<Pack**>();
-  auto d_bm              = m_fields.at("bm").get_reshaped_view<Pack**>();
-  auto d_nccn_prescribed = m_fields.at("nccn_prescribed").get_reshaped_view<Pack**>();
-  auto d_inv_qc_relvar   = m_fields.at("inv_qc_relvar").get_reshaped_view<Pack**>();
+  auto h_T_atm           = m_fields.at("T_atm").get_reshaped_view<Pack**,Host>();
+  auto h_ast             = m_fields.at("ast").get_reshaped_view<Pack**,Host>();
+  auto h_ni_activated    = m_fields.at("ni_activated").get_reshaped_view<Pack**,Host>();
+  auto h_nc_nuceat_tend  = m_fields.at("nc_nuceat_tend").get_reshaped_view<Pack**,Host>();
+  auto h_pmid            = m_fields.at("pmid").get_reshaped_view<Pack**,Host>();
+  auto h_dp              = m_fields.at("dp").get_reshaped_view<Pack**,Host>();
+  auto h_zi              = m_fields.at("zi").get_reshaped_view<Pack**,Host>();
+  auto h_qv_prev         = m_fields.at("qv_prev").get_reshaped_view<Pack**,Host>();
+  auto h_T_prev          = m_fields.at("T_prev").get_reshaped_view<Pack**,Host>();
+  auto h_qv              = m_fields.at("qv").get_reshaped_view<Pack**,Host>();
+  auto h_qc              = m_fields.at("qc").get_reshaped_view<Pack**,Host>();
+  auto h_qr              = m_fields.at("qr").get_reshaped_view<Pack**,Host>();
+  auto h_qi              = m_fields.at("qi").get_reshaped_view<Pack**,Host>();
+  auto h_qm              = m_fields.at("qm").get_reshaped_view<Pack**,Host>();
+  auto h_nc              = m_fields.at("nc").get_reshaped_view<Pack**,Host>();
+  auto h_nr              = m_fields.at("nr").get_reshaped_view<Pack**,Host>();
+  auto h_ni              = m_fields.at("ni").get_reshaped_view<Pack**,Host>();
+  auto h_bm              = m_fields.at("bm").get_reshaped_view<Pack**,Host>();
+  auto h_nccn_prescribed = m_fields.at("nccn_prescribed").get_reshaped_view<Pack**,Host>();
+  auto h_inv_qc_relvar   = m_fields.at("inv_qc_relvar").get_reshaped_view<Pack**,Host>();
 
   // Set local views which are used in some of the initialization
   auto mdims = m_fields.at("qc").get_header().get_identifier().get_layout();
   Int ncol = mdims.dim(0); 
   Int nk   = mdims.dim(1);
   const Int nk_pack = ekat::npack<Spack>(nk);
-  view_2d d_th_atm("th_atm",ncol,nk_pack);        
-  view_2d d_dz("dz",ncol,nk_pack);                
-  view_2d d_exner("exner",ncol,nk_pack);          
+  view_2d::HostMirror h_th_atm("th_atm",ncol,nk_pack);        
+  view_2d::HostMirror h_dz("dz",ncol,nk_pack);                
+  view_2d::HostMirror h_exner("exner",ncol,nk_pack);          
   
-  // Create host mirrors for all views
-  auto h_T_atm            = Kokkos::create_mirror_view(d_T_atm          ); 
-  auto h_ast              = Kokkos::create_mirror_view(d_ast            ); 
-  auto h_ni_activated     = Kokkos::create_mirror_view(d_ni_activated   ); 
-  auto h_nc_nuceat_tend   = Kokkos::create_mirror_view(d_nc_nuceat_tend ); 
-  auto h_pmid             = Kokkos::create_mirror_view(d_pmid           ); 
-  auto h_dp               = Kokkos::create_mirror_view(d_dp             ); 
-  auto h_zi               = Kokkos::create_mirror_view(d_zi             ); 
-  auto h_qv_prev          = Kokkos::create_mirror_view(d_qv_prev        ); 
-  auto h_T_prev           = Kokkos::create_mirror_view(d_T_prev         ); 
-  auto h_qv               = Kokkos::create_mirror_view(d_qv             ); 
-  auto h_qc               = Kokkos::create_mirror_view(d_qc             ); 
-  auto h_qr               = Kokkos::create_mirror_view(d_qr             ); 
-  auto h_qi               = Kokkos::create_mirror_view(d_qi             ); 
-  auto h_qm               = Kokkos::create_mirror_view(d_qm             ); 
-  auto h_nc               = Kokkos::create_mirror_view(d_nc             ); 
-  auto h_nr               = Kokkos::create_mirror_view(d_nr             ); 
-  auto h_ni               = Kokkos::create_mirror_view(d_ni             ); 
-  auto h_bm               = Kokkos::create_mirror_view(d_bm             ); 
-  auto h_nccn_prescribed  = Kokkos::create_mirror_view(d_nccn_prescribed); 
-  auto h_inv_qc_relvar    = Kokkos::create_mirror_view(d_inv_qc_relvar  ); 
-  auto h_th_atm           = Kokkos::create_mirror_view(d_th_atm         ); 
-  auto h_dz               = Kokkos::create_mirror_view(d_dz             ); 
-  auto h_exner            = Kokkos::create_mirror_view(d_exner          ); 
-
- // Initalize from text file 
+  // Initalize from text file 
   std::ifstream fid("p3_init_vals.txt", std::ifstream::in);
   EKAT_REQUIRE_MSG(!fid.fail(),"Error in p3_inputs_initializer.cpp loading p3_init_vals.txt file");
   std::string tmp_line;
@@ -234,26 +209,26 @@ void P3InputsInitializer::initialize_fields ()
   } // for icol_i
 
   // Deep copy back to device
-  Kokkos::deep_copy(d_T_atm          , h_T_atm          ); 
-  Kokkos::deep_copy(d_ast            , h_ast            );
-  Kokkos::deep_copy(d_ni_activated   , h_ni_activated   ); 
-  Kokkos::deep_copy(d_nc_nuceat_tend , h_nc_nuceat_tend ); 
-  Kokkos::deep_copy(d_pmid           , h_pmid           ); 
-  Kokkos::deep_copy(d_dp             , h_dp             ); 
-  Kokkos::deep_copy(d_zi             , h_zi             ); 
-  Kokkos::deep_copy(d_qv_prev        , h_qv_prev        ); 
-  Kokkos::deep_copy(d_T_prev         , h_T_prev         ); 
-  Kokkos::deep_copy(d_qv             , h_qv             ); 
-  Kokkos::deep_copy(d_qc             , h_qc             ); 
-  Kokkos::deep_copy(d_qr             , h_qr             ); 
-  Kokkos::deep_copy(d_qi             , h_qi             ); 
-  Kokkos::deep_copy(d_qm             , h_qm             ); 
-  Kokkos::deep_copy(d_nc             , h_nc             ); 
-  Kokkos::deep_copy(d_nr             , h_nr             ); 
-  Kokkos::deep_copy(d_ni             , h_ni             ); 
-  Kokkos::deep_copy(d_bm             , h_bm             ); 
-  Kokkos::deep_copy(d_nccn_prescribed, h_nccn_prescribed); 
-  Kokkos::deep_copy(d_inv_qc_relvar  , h_inv_qc_relvar  ); 
+  m_fields.at("T_atm").sync_to_dev();
+  m_fields.at("ast").sync_to_dev();
+  m_fields.at("ni_activated").sync_to_dev();
+  m_fields.at("nc_nuceat_tend").sync_to_dev();
+  m_fields.at("pmid").sync_to_dev();
+  m_fields.at("dp").sync_to_dev();
+  m_fields.at("zi").sync_to_dev();
+  m_fields.at("qv_prev").sync_to_dev();
+  m_fields.at("T_prev").sync_to_dev();
+  m_fields.at("qv").sync_to_dev();
+  m_fields.at("qc").sync_to_dev();
+  m_fields.at("qr").sync_to_dev();
+  m_fields.at("qi").sync_to_dev();
+  m_fields.at("qm").sync_to_dev();
+  m_fields.at("nc").sync_to_dev();
+  m_fields.at("nr").sync_to_dev();
+  m_fields.at("ni").sync_to_dev();
+  m_fields.at("bm").sync_to_dev();
+  m_fields.at("nccn_prescribed").sync_to_dev();
+  m_fields.at("inv_qc_relvar").sync_to_dev();
 
   if (m_remapper) {
     m_remapper->registration_ends();

--- a/components/scream/src/physics/p3/p3_inputs_initializer.cpp
+++ b/components/scream/src/physics/p3/p3_inputs_initializer.cpp
@@ -95,7 +95,7 @@ void P3InputsInitializer::initialize_fields ()
     "       and make sure they agree on who's initializing each field.\n");
 
   // Initialize the fields that we expect.
-  // Get device views
+  // Ask directly for host mirrors.
   auto h_T_atm           = m_fields.at("T_atm").get_reshaped_view<Pack**,Host>();
   auto h_ast             = m_fields.at("ast").get_reshaped_view<Pack**,Host>();
   auto h_ni_activated    = m_fields.at("ni_activated").get_reshaped_view<Pack**,Host>();
@@ -208,7 +208,7 @@ void P3InputsInitializer::initialize_fields ()
     } // for k
   } // for icol_i
 
-  // Deep copy back to device
+  // Use Field interface to deep copy back to device
   m_fields.at("T_atm").sync_to_dev();
   m_fields.at("ast").sync_to_dev();
   m_fields.at("ni_activated").sync_to_dev();

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -49,9 +49,12 @@ public:
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real>& field_repo) const;
 
-  // Get the set of required/computed fields
+  void set_updated_group (const FieldGroup<Real>& group);
+
+  // Get the set of required/computed fields and groups
   const std::set<FieldIdentifier>& get_required_fields () const { return m_required_fields; }
   const std::set<FieldIdentifier>& get_computed_fields () const { return m_computed_fields; }
+  std::set<GroupRequest> get_updated_groups () const { return m_inout_groups_req; }
 
 protected:
 
@@ -66,9 +69,11 @@ protected:
 
   std::set<FieldIdentifier> m_required_fields;
   std::set<FieldIdentifier> m_computed_fields;
+  std::set<GroupRequest>    m_inout_groups_req;
 
   std::map<std::string,const_field_type>  m_shoc_fields_in;
   std::map<std::string,field_type>        m_shoc_fields_out;
+  std::map<std::string,FieldGroup<Real>>  m_shoc_groups_inout;
 
   ekat::Comm              m_shoc_comm;
   ekat::ParameterList     m_shoc_params;

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -49,6 +49,7 @@ public:
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real>& field_repo) const;
 
+  // SHOC updates the 'TRACERS' group.
   void set_updated_group (const FieldGroup<Real>& group);
 
   // Get the set of required/computed fields and groups

--- a/components/scream/src/physics/shoc/scream_shoc_interface.F90
+++ b/components/scream/src/physics/shoc/scream_shoc_interface.F90
@@ -93,14 +93,13 @@ contains
 
   end subroutine shoc_init_f90
   !====================================================================!
-  subroutine shoc_main_f90 (dtime,q,FQ) bind(c)
+  subroutine shoc_main_f90 (dtime,q) bind(c)
 
     use shoc,           only: shoc_main
 
 !    real, intent(in) :: q(pcols,pver,9) ! Tracer mass concentrations from SCREAM      kg/kg
     real(kind=c_real), intent(in)    :: dtime ! Timestep
     real(kind=c_real), intent(inout) :: q(pcols,pver,qsize) ! Tracer mass concentrations from SCREAM kg/kg
-    real(kind=c_real), intent(inout) :: FQ(pcols,4,pver) ! Tracer mass concentrations from SCREAM kg/kg
 
     real(kind=c_real) :: cldliq(pcols,pver)     !cloud liquid water mixing ratio        kg/kg
     real(kind=c_real) :: numliq(pcols,pver)     !cloud liquid water drop concentraiton  #/kg
@@ -166,8 +165,7 @@ contains
     end do
 
     test = test + dtime
-    FQ(1,1,1) = 9e9
-    print '(a15,f16.8,4e16.8)', 'SHOC run = ', test, qtest, sum(q), sum(qv), sum(FQ(:,:,:))
+    print '(a15,f16.8,3e16.8)', 'SHOC run = ', test, qtest, sum(q), sum(qv)
 
   end subroutine shoc_main_f90
   !====================================================================!

--- a/components/scream/src/physics/shoc/scream_shoc_interface.hpp
+++ b/components/scream/src/physics/shoc/scream_shoc_interface.hpp
@@ -13,7 +13,7 @@ extern "C"
 
 // Fortran routines to be called from C
 void shoc_init_f90     (Real* q);
-void shoc_main_f90     (const Real& dtime, Real* q, Real* FQ);
+void shoc_main_f90     (const Real& dtime, Real* q);
 void shoc_finalize_f90 ();
 
 } // extern "C"

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
@@ -117,7 +117,7 @@ void ZMDeepConvection::run_impl (const Real dt)
               m_raw_ptrs_out["ql"], m_raw_ptrs_out["rliq"], m_raw_ptrs_out["landfrac"],
               m_raw_ptrs_out["hu_nm1"], m_raw_ptrs_out["cnv_nm1"], m_raw_ptrs_out["tm1"],
               m_raw_ptrs_out["qm1"], &m_raw_ptrs_out["t_star"], &m_raw_ptrs_out["q_star"],
-              m_raw_ptrs_out["dcape"], m_raw_ptrs_out["q"], &m_raw_ptrs_out["tend_s"],
+              m_raw_ptrs_out["dcape"], m_raw_ptrs_out["qv"], &m_raw_ptrs_out["tend_s"],
               &m_raw_ptrs_out["tend_q"], &m_raw_ptrs_out["cld"], m_raw_ptrs_out["snow"],
               m_raw_ptrs_out["ntprprd"], m_raw_ptrs_out["ntsnprd"],
               &m_raw_ptrs_out["flxprec"], &m_raw_ptrs_out["flxsnow"],

--- a/components/scream/src/physics/zm/zm_inputs_initializer.cpp
+++ b/components/scream/src/physics/zm/zm_inputs_initializer.cpp
@@ -243,15 +243,14 @@ void ZMInputsInitializer :: initialize_fields(){
 
 
 
-  for (size_t i = 0; i < zm_inputs.size(); i++){
+  for (const auto& name : zm_inputs) {
     //Get and store device view using input name
-    Kokkos::View<Real*, Kokkos::LayoutRight, DefaultDevice> d_v = m_fields.at(zm_inputs[i]).get_view();
-    //Create and store host mirrors using device views
-    Kokkos::View<scream::Real*, Kokkos::LayoutRight, HostDevice> h_m = Kokkos::create_mirror_view(d_v);
-    //Create and store host mirrors raw pointers
-    // Real* r_p = h_m.data();
-    //Deep copy back to device
-    Kokkos::deep_copy(d_v, h_m);
+    const auto& f = m_fields.at(name);
+    
+    // TODO: Do something to init fields
+
+    // If init was on host, uncomment this line
+    f.sync_to_dev();
   }
 }
 

--- a/components/scream/src/physics/zm/zm_inputs_initializer.cpp
+++ b/components/scream/src/physics/zm/zm_inputs_initializer.cpp
@@ -16,7 +16,7 @@ std::vector<string> zm_inputs = {"limcnv_in", "no_deep_pbl_in","lchnk", "ncol", 
       "dlf", "pflx", "zdu", "rprd", "mu", "md", "du", "eu", "ed",
       "dp", "dsubcld", "jt", "maxg", "ideep", "lengath", "ql",
       "rliq", "landfrac", "hu_nm1", "cnv_nm1", "tm1", "qm1", "t_star",
-      "q_star", "dcape", "q", "tend_s", "tend_q", "cld", "snow",
+      "q_star", "dcape", "qv", "tend_s", "tend_q", "cld", "snow",
       "ntprprd", "ztodt", "ntsnprd", "flxprec", "flxsnow", "pguall",
       "pgdall", "icwu", "ncnst", "fracis"};
 
@@ -106,7 +106,7 @@ void set_grid_opts(){
   GridOpts t_star;
   GridOpts q_star;
   GridOpts dcape;
-  GridOpts q;
+  GridOpts qv;
   GridOpts tend_s;
   GridOpts tend_q;
   GridOpts cld;
@@ -171,7 +171,7 @@ void set_grid_opts(){
   set_grid_opts_helper(t_star, "t_star", true, NULL, SCALAR_3D_MID);
   set_grid_opts_helper(q_star, "q_star", true, NULL, SCALAR_3D_MID);
   set_grid_opts_helper(dcape, "dcape", true, NULL, LINEAR);
-  set_grid_opts_helper(q, "q", true, NULL, SCALAR_3D_MID);
+  set_grid_opts_helper(qv, "qv", true, NULL, SCALAR_3D_MID);
   set_grid_opts_helper(tend_s, "tend_s", true, NULL, LINEAR);
   set_grid_opts_helper(tend_q, "tend_q", true, NULL, LINEAR);
   set_grid_opts_helper(cld, "cld", true, NULL, LINEAR);

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -143,15 +143,17 @@ public:
   void set_required_field (const Field<const Real>& f) {
     ekat::error::runtime_check(
         requires(f.get_header().get_identifier()),
-        "Error! This atmosphere process does not require this field. "
-        "Something is wrong up the call stack. Please, contact developers.\n");
+        "Error! This atmosphere process does not require\n  " +
+        f.get_header().get_identifier().get_id_string() +
+        "\nSomething is wrong up the call stack. Please, contact developers.\n");
     set_required_field_impl (f);
   }
   void set_computed_field (const Field<Real>& f) {
     ekat::error::runtime_check(
         computes(f.get_header().get_identifier()),
-        "Error! This atmosphere process does not compute this field. "
-        "Something is wrong up the call stack. Please, contact developers.\n");
+        "Error! This atmosphere process does not compute\n  " +
+        f.get_header().get_identifier().get_id_string() +
+        "\nSomething is wrong up the call stack. Please, contact developers.\n");
     set_computed_field_impl (f);
   }
 

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -5,6 +5,7 @@
 #include "share/field/field_identifier.hpp"
 #include "share/field/field_repository.hpp"
 #include "share/field/field.hpp"
+#include "share/field/field_group.hpp"
 #include "share/grid/grids_manager.hpp"
 
 #include "ekat/ekat_assert.hpp"
@@ -137,8 +138,13 @@ public:
     set_computed_field_impl (f);
   }
 
-  virtual void set_required_group (const ci_string_pair& /* group_and_grid */,
-                                   const std::set<Field<const Real>>& /* group */) {
+  // Note: for the following (unlike set_required/computed_field, we do provide an
+  //       implementation, since requiring a group is "rare".
+  // Note: from the group, derived class can extract individual fields, and,
+  //       if needed, they can check that the group was allocated as a bundle,
+  //       and if so, and if desired, they can access the bundled field directly.
+  //       See field_group.hpp for more details.
+  virtual void set_required_group (const FieldGroup<const Real>& /* group */) {
     ekat::error::runtime_abort(
       "Error! This atmosphere process does not require a group of fields, meaning\n"
       "       that 'get_required_groups' was not overridden in this class, or that\n"
@@ -147,8 +153,7 @@ public:
       "       then you must also override 'set_required_group' in your derived class.\n"
     );
   }
-  virtual void set_updated_group (const ci_string_pair& /* group_and_grid */,
-                                  const std::set<Field<Real>>& /* group */) {
+  virtual void set_updated_group (const FieldGroup<Real>& /* group */) {
     ekat::error::runtime_abort(
       "Error! This atmosphere process does not update a group of fields, meaning\n"
       "       that 'get_updated_groups' was not overridden in this class, or that\n"

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -64,7 +64,21 @@ public:
   using TimeStamp      = util::TimeStamp;
   using ci_string      = ekat::CaseInsensitiveString;
 
-  // A group request allow to request a group of fields.
+  /*
+   * A struct used to request a group of fields.
+   *
+   * Groups are simply a labels attached to a Field object (see field_tracking.hpp).
+   * They can be useful when a class need to access a certain group of fields,
+   * in a way that is agnostic to how many fields are in said group.
+   * A GroupRequest is a lightweight struct that an AP can expose if it needs a group
+   * of fields, without caring how many there are, or how they are called.
+   * A typical example is an AP that needs to advect tracers (like Dynamics does):
+   * it treats tracers agnostically, and does not really care how many there are.
+   * So the AP exposes this need as a GroupRequest. Later, it will be provided
+   * with a FieldGroup, which allows to access all the fields in the group
+   * individually, and, if the allocation permits it, as a single N+1 dimensional
+   * field. For more details about the FieldGroup struct, see field_group.hpp.
+   */
   struct GroupRequest {
     GroupRequest (const std::string& name_, const std::string& grid_, const int ps = 1)
      : name(name_), grid(grid_), pack_size(ps)
@@ -78,8 +92,6 @@ public:
     ci_string grid;
     // Request an allocation that can accomodate a value type like Pack<Real,pack_size>
     int       pack_size;
-
-    friend bool operator<(const GroupRequest&, const GroupRequest&);
   };
 
   virtual ~AtmosphereProcess () = default;
@@ -258,7 +270,8 @@ private:
   TimeStamp t_;
 };
 
-// To allow using GroupRequest in std sorted containers
+// In order to use GroupRequest in std sorted containers (like std::set),
+// we need to provide an overload of op< or std::less.
 inline bool operator< (const AtmosphereProcess::GroupRequest& lhs,
                        const AtmosphereProcess::GroupRequest& rhs)
 {

--- a/components/scream/src/share/atm_process/atmosphere_process_dag.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_dag.cpp
@@ -349,9 +349,9 @@ add_nodes (const group_type& atm_procs,
           node.computed.insert(fid_id);
           m_fid_to_last_provider[fid_id] = id;
         }
-        for (auto itg : proc->get_updated_groups()) {
+        for (const auto& itg : proc->get_updated_groups()) {
           EKAT_REQUIRE_MSG (field_repo, "Error! Field repo pointer is null.\n");
-          auto group = field_repo->get_const_field_group(itg.first,itg.second);
+          auto group = field_repo->get_const_field_group(itg.name,itg.grid);
           for (const auto& f : group.m_fields) {
             const auto& fid = f.second.lock()->get_header().get_identifier();
             const int fid_id = add_fid(fid);
@@ -368,7 +368,7 @@ add_nodes (const group_type& atm_procs,
         }
         for (auto itg : proc->get_required_groups()) {
           EKAT_REQUIRE_MSG (field_repo, "Error! Field repo pointer is null.\n");
-          auto group = field_repo->get_const_field_group(itg.first,itg.second);
+          auto group = field_repo->get_const_field_group(itg.name,itg.grid);
           for (const auto& f : group.m_fields) {
             const auto& fid = f.second.lock()->get_header().get_identifier();
             const int fid_id = add_fid(fid);

--- a/components/scream/src/share/atm_process/atmosphere_process_dag.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_dag.cpp
@@ -352,8 +352,8 @@ add_nodes (const group_type& atm_procs,
         for (auto itg : proc->get_updated_groups()) {
           EKAT_REQUIRE_MSG (field_repo, "Error! Field repo pointer is null.\n");
           auto group = field_repo->get_const_field_group(itg.first,itg.second);
-          for (const auto& f : group) {
-            const auto& fid = f.get_header().get_identifier();
+          for (const auto& f : group.m_fields) {
+            const auto& fid = f.second.lock()->get_header().get_identifier();
             const int fid_id = add_fid(fid);
             node.required.insert(fid_id);
             auto it = m_fid_to_last_provider.find(fid_id);
@@ -369,8 +369,8 @@ add_nodes (const group_type& atm_procs,
         for (auto itg : proc->get_required_groups()) {
           EKAT_REQUIRE_MSG (field_repo, "Error! Field repo pointer is null.\n");
           auto group = field_repo->get_const_field_group(itg.first,itg.second);
-          for (const auto& f : group) {
-            const auto& fid = f.get_header().get_identifier();
+          for (const auto& f : group.m_fields) {
+            const auto& fid = f.second.lock()->get_header().get_identifier();
             const int fid_id = add_fid(fid);
             node.computed.insert(fid_id);
             m_fid_to_last_provider[fid_id] = id;

--- a/components/scream/src/share/atm_process/atmosphere_process_dag.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_dag.cpp
@@ -352,8 +352,8 @@ add_nodes (const group_type& atm_procs,
         for (const auto& itg : proc->get_updated_groups()) {
           EKAT_REQUIRE_MSG (field_repo, "Error! Field repo pointer is null.\n");
           auto group = field_repo->get_const_field_group(itg.name,itg.grid);
-          for (const auto& f : group.m_fields) {
-            const auto& fid = f.second.lock()->get_header().get_identifier();
+          for (const auto& it_f : group.m_fields) {
+            const auto& fid = it_f.second->get_header().get_identifier();
             const int fid_id = add_fid(fid);
             node.required.insert(fid_id);
             auto it = m_fid_to_last_provider.find(fid_id);
@@ -369,8 +369,8 @@ add_nodes (const group_type& atm_procs,
         for (auto itg : proc->get_required_groups()) {
           EKAT_REQUIRE_MSG (field_repo, "Error! Field repo pointer is null.\n");
           auto group = field_repo->get_const_field_group(itg.name,itg.grid);
-          for (const auto& f : group.m_fields) {
-            const auto& fid = f.second.lock()->get_header().get_identifier();
+          for (const auto& it_f : group.m_fields) {
+            const auto& fid = it_f.second->get_header().get_identifier();
             const int fid_id = add_fid(fid);
             node.computed.insert(fid_id);
             m_fid_to_last_provider[fid_id] = id;

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -337,10 +337,10 @@ set_required_group (const FieldGroup<const Real>& group)
     if (atm_proc->requires_group(name,grid)) {
       atm_proc->set_required_group(group);
       // We also might need to add each field of the group to the remap in/out
-      for (auto& it : group.m_fields) {
-        auto f = it.second.lock();
-        const auto& fid = f->get_header().get_identifier();
-        const auto r_in  = m_inputs_remappers[iproc].at(fid.get_grid_name());
+      for (const auto& it : group.m_fields) {
+        const auto& f = *it.second;
+        const auto& fid = f.get_header().get_identifier();
+        const auto& r_in  = m_inputs_remappers[iproc].at(fid.get_grid_name());
         process_required_field(fid,r_in);
       }
     }
@@ -362,9 +362,9 @@ set_updated_group (const FieldGroup<Real>& group)
     if (atm_proc->updates_group(name,grid)) {
       atm_proc->set_updated_group(group);
       // We also might need to add each field of the group to the remap in/out
-      for (auto it : group.m_fields) {
-        auto f = it.second.lock();
-        const auto& fid = f->get_header().get_identifier();
+      for (const auto& it : group.m_fields) {
+        const auto& f = *it.second;
+        const auto& fid = f.get_header().get_identifier();
         const auto r_in  = m_inputs_remappers[iproc].at(fid.get_grid_name());
         const auto r_out = m_outputs_remappers[iproc].at(fid.get_grid_name());
         process_required_field(fid,r_in);

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -325,7 +325,7 @@ void AtmosphereProcessGroup::finalize_impl (/* what inputs? */) {
 void AtmosphereProcessGroup::
 set_required_group (const FieldGroup<const Real>& group)
 {
-  EKAT_REQUIRE_MSG(group.m_fields.size()>0,
+  EKAT_REQUIRE_MSG(group.m_info->size()>0,
     "Error! We were not expecting an empty field group.\n");
 
   const auto& name = group.m_info->m_group_name;
@@ -350,7 +350,7 @@ set_required_group (const FieldGroup<const Real>& group)
 void AtmosphereProcessGroup::
 set_updated_group (const FieldGroup<Real>& group)
 {
-  EKAT_REQUIRE_MSG(group.m_fields.size()>0,
+  EKAT_REQUIRE_MSG(group.m_info->size()>0,
     "Error! We were not expecting an empty field group.\n");
 
   const auto& name = group.m_info->m_group_name;

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -414,21 +414,21 @@ void AtmosphereProcessGroup::register_fields (FieldRepository<Real>& field_repo)
   }
 }
 
-std::set<AtmosphereProcessGroup::ci_string_pair>
+std::set<AtmosphereProcessGroup::GroupRequest>
 AtmosphereProcessGroup::get_required_groups () const {
-  std::set<AtmosphereProcessGroup::ci_string_pair> groups;
+  std::set<AtmosphereProcessGroup::GroupRequest> groups;
   for (auto atm_proc : m_atm_processes) {
-    auto groups_i = atm_proc->get_required_groups();
+    const auto& groups_i = atm_proc->get_required_groups();
     groups.insert(groups_i.begin(),groups_i.end());
   }
   return groups;
 }
 
-std::set<AtmosphereProcessGroup::ci_string_pair>
+std::set<AtmosphereProcessGroup::GroupRequest>
 AtmosphereProcessGroup::get_updated_groups () const {
-  std::set<AtmosphereProcessGroup::ci_string_pair> groups;
+  std::set<AtmosphereProcessGroup::GroupRequest> groups;
   for (auto atm_proc : m_atm_processes) {
-    auto groups_i = atm_proc->get_updated_groups();
+    const auto& groups_i = atm_proc->get_updated_groups();
     groups.insert(groups_i.begin(),groups_i.end());
   }
   return groups;

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -51,10 +51,8 @@ public:
 
   void final_setup ();
 
-  void set_required_group (const ci_string_pair& group_and_grid,
-                           const std::set<Field<const Real>>& group);
-  void set_updated_group (const ci_string_pair& group_and_grid,
-                          const std::set<Field<Real>>& group);
+  void set_required_group (const FieldGroup<const Real>& group);
+  void set_updated_group (const FieldGroup<Real>& group);
 
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real>& field_repo) const;

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -61,8 +61,8 @@ public:
   const std::set<FieldIdentifier>&  get_required_fields () const { return m_required_fields; }
   const std::set<FieldIdentifier>&  get_computed_fields () const { return m_computed_fields; }
 
-  std::set<ci_string_pair> get_required_groups () const;
-  std::set<ci_string_pair> get_updated_groups () const;
+  std::set<GroupRequest> get_required_groups () const;
+  std::set<GroupRequest> get_updated_groups () const;
 
   // --- Methods specific to AtmosphereProcessGroup --- //
 

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -313,10 +313,11 @@ operator= (const Field<SrcRealType>& src) {
                 "Error! Cannot create a nonconst field from a const field.\n");
 
   // If the field has a valid header (i.e., m_header!=nullptr), then
-  // we only allow assignment of fields with the *same* identifier.
+  // we only allow assignment of fields with the *same* identifier,
+  // AND if the field was not yet allocated.
   EKAT_REQUIRE_MSG(
       m_header==nullptr ||
-      m_header->get_identifier()==src.get_header().get_identifier(),
+      (!m_allocated && m_header->get_identifier()==src.get_header().get_identifier()),
       "Error! Assignment of fields with different (and non-null) identifiers is prohibited.\n");
 
   // Since the type of *this and src may be different, we cannot do the usual

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -159,6 +159,8 @@ public:
   //   - If the field rank is 2, then idim cannot be 1. This is b/c Kokkos
   //     specializes view's traits for LayoutRight of rank 1, not allowing
   //     to store a stride for the slowest dimension.
+  field_type subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
+                       const int idim, const int k) const;
   field_type subfield (const std::string& sf_name, const int idim, const int k) const;
   field_type subfield (const int idim, const int k) const;
 
@@ -436,7 +438,9 @@ sync_to_dev () const {
 
 template<typename RealType>
 Field<RealType> Field<RealType>::
-subfield (const std::string& sf_name, const int idim, const int k) const {
+subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
+          const int idim, const int k) const {
+
   const auto& id = m_header->get_identifier();
   const auto& lt = id.get_layout();
 
@@ -452,13 +456,20 @@ subfield (const std::string& sf_name, const int idim, const int k) const {
   tags.erase(tags.begin()+idim);
   dims.erase(dims.begin()+idim);
   FieldLayout sf_lt(tags,dims);
-  FieldIdentifier sf_id(sf_name,sf_lt,id.get_units(),id.get_grid_name());
+  FieldIdentifier sf_id(sf_name,sf_lt,sf_units,id.get_grid_name());
 
   // Create header
   auto sv_h = create_header(sf_id,m_header,idim,k);
 
   // Return subfield
   return field_type(sv_h,m_view_d);
+}
+
+template<typename RealType>
+Field<RealType> Field<RealType>::
+subfield (const std::string& sf_name, const int idim, const int k) const {
+  const auto& id = m_header->get_identifier();
+  return subfield(sf_name,id.get_units(),idim,k);
 }
 
 template<typename RealType>

--- a/components/scream/src/share/field/field_alloc_prop.cpp
+++ b/components/scream/src/share/field/field_alloc_prop.cpp
@@ -87,9 +87,9 @@ subview (const int idim, const int k) const {
 
 void FieldAllocProp::request_allocation (const int scalar_size, const int pack_size) {
   using ekat::ScalarTraits;
-  using namespace ekat::error;
 
-  ekat::error::runtime_check(!m_committed, "Error! Cannot change allocation properties after they have been commited.\n");
+  EKAT_REQUIRE_MSG(!m_committed,
+      "Error! Cannot change allocation properties after they have been commited.\n");
 
   const int vts = scalar_size*pack_size;
   if (m_scalar_type_size==0) {
@@ -97,10 +97,10 @@ void FieldAllocProp::request_allocation (const int scalar_size, const int pack_s
     m_scalar_type_size = scalar_size;
   } else {
     // Make sure the new scalar_type coincides with the one already stored (check name and size)
-    runtime_check(scalar_size==m_scalar_type_size,
-                  std::string("Error! Scalar type incompatible with current allocation request:\n") +
-                  "         stored scalar type size: " + std::to_string(m_scalar_type_size) + "\n" +
-                  "         requested scalar type size: " + std::to_string(scalar_size) + "\n");
+    EKAT_REQUIRE_MSG(scalar_size==m_scalar_type_size,
+        "Error! Scalar type incompatible with current allocation request:\n"
+        "         stored scalar type size: " + std::to_string(m_scalar_type_size) + "\n" +
+        "         requested scalar type size: " + std::to_string(scalar_size) + "\n");
   }
 
   // Store the size of the value type.

--- a/components/scream/src/share/field/field_alloc_prop.hpp
+++ b/components/scream/src/share/field/field_alloc_prop.hpp
@@ -75,9 +75,17 @@ public:
   template<typename ValueType>
   void request_allocation ();
 
-  // Request allocation able to accommodate the given ValueType
+  // Request allocation able to accommodate a pack of ScalarType of the given pack size
   template<typename ScalarType>
   void request_allocation (int pack_size);
+
+  // Request allocation able to accommodate pack_size scalars,
+  // where scalars have size scalar_size
+  void request_allocation (int scalar_size, int pack_size);
+
+  // Request allocation able to accommodate all the alloc props in src.
+  // Note: src does not need to be committed yet.
+  void request_allocation (const FieldAllocProp& src);
 
   // Locks the allocation properties, preventing furter value types requests
   void commit (const layout_ptr_type& layout);
@@ -144,25 +152,7 @@ void FieldAllocProp::request_allocation () {
 
 template<typename ScalarType>
 void FieldAllocProp::request_allocation (const int pack_size) {
-  using ekat::ScalarTraits;
-  using namespace ekat::error;
-
-  ekat::error::runtime_check(!m_committed, "Error! Cannot change allocation properties after they have been commited.\n");
-  
-  const int vts = sizeof(ScalarType)*pack_size;
-  if (m_scalar_type_size==0) {
-    // This is the first time we receive a request. Set the scalar type properties
-    m_scalar_type_size = sizeof(ScalarType);
-  } else {
-    // Make sure the new scalar_type coincides with the one already stored (check name and size)
-    runtime_check(sizeof(ScalarType)==m_scalar_type_size,
-                  std::string("Error! Scalar type incompatible with current allocation request:\n") +
-                  "         stored scalar type size: " + std::to_string(m_scalar_type_size) + "\n" +
-                  "         requested scalar type name: " + std::to_string(sizeof(ScalarType)) + "\n");
-  }
-
-  // Store the size of the value type.
-  m_value_type_sizes.push_back(vts);
+  request_allocation (sizeof(ScalarType),pack_size);
 }
 
 template<typename ValueType>

--- a/components/scream/src/share/field/field_group.hpp
+++ b/components/scream/src/share/field/field_group.hpp
@@ -1,0 +1,117 @@
+#ifndef SCREAM_FIELD_GROUP_HPP
+#define SCREAM_FIELD_GROUP_HPP
+
+#include <ekat/util/ekat_string_utils.hpp>
+#include <ekat/std_meta/ekat_std_utils.hpp>
+
+#include <set>
+#include <map>
+
+namespace scream {
+
+/*
+ * A FieldGroup is a small structure storing some info on a group of fields
+ * (wrapped in a FieldGroupInfo sturct), as well as pointers to the fields.
+ *
+ * A group is basically a "label" attached to fields, to allow users to
+ * query the repo for all fields that have such label attached. A field can
+ * belong to any number of groups, or no group at all.
+ *
+ * A FieldGroupInfo stores:
+ *
+ *   - a list of the field names associated to this group;
+ *   - whether the field were allocated as a single "bundled" field,
+ *     with each field extracted as a "subview" of the bundled one;
+ *   - if the allocation was "bundled", also store for each field
+ *     the index that was used to extract the corresponding subview.
+ *
+ * A FieldGroup contains:
+ *
+ *   - a FieldGroupInfo struct
+ *   - a list of fields pointers
+ *   - a grid name (the grid where the fields are)
+ *
+ * The same FieldGroupInfo can be recycled for several FieldGroup's, each living
+ * on a different grid.
+ *
+ * Notice that, if the allocation was bundled, the big bundle is allocated
+ * with layout given by grid->get_Xd_vector_layout(), where grid is the
+ * grid object where the fields are defined on, and X=2 or 3.
+ * Each field is then subviewed at entry k (different for each field)
+ * along dimension I (same for all field) of the big bundle field.
+ *
+ * E.g., say we have 3d scalar fields F1,F2,F3,F4 belonging to group MyGroup,
+ * which is then allocated as a bundled field F. F will have layout
+ * given by grid->get_3d_vector_layout(). Say this layout is (COL,CMP,VL).
+ * Each field is subviewed along m_subview_dim=1, at entry 0,1,2,3 respectively.
+ * Note: as of 02/2021 m_subview_dim is *always* 1, but we store this bit
+ *       of info nevertheless, in case things change later on.
+ */
+
+struct FieldGroupInfo
+{
+  using ci_string  = ekat::CaseInsensitiveString;
+
+  // Default initialize everything
+  FieldGroupInfo (const ci_string& group_name)
+    : m_group_name (group_name)
+    , m_fields_names{}
+    , m_bundled (false)
+    , m_subview_dim(-1)
+    , m_subview_idx{}
+  {
+    // Nothing to do here
+  }
+
+  // The name of the group
+  ci_string m_group_name;
+
+  // The names of the fields in this group
+  std::set<ci_string>   m_fields_names;
+
+  // Whether the group was allocated as a bundle
+  bool m_bundled;
+
+  // If bundled, each field is subviewed along a different entry
+  // along the same dimension.
+  int m_subview_dim;
+
+  // If bundled, for each field name, store the idx used
+  // to subview each field from the bundle.
+  std::map<ci_string,int>  m_subview_idx;
+};
+
+template<typename RealType>
+class Field;
+
+template<typename RealType>
+struct FieldGroup {
+  using field_type = Field<RealType>;
+  using ci_string = FieldGroupInfo::ci_string;
+
+  FieldGroup (const std::string& name, const std::string& grid)
+   : m_info (new FieldGroupInfo(name))
+   , m_grid_name(grid)
+  {
+    // Nothing to do here
+  }
+
+  int size() const { return m_fields.size(); }
+
+  // The fields in this group (weak ptrs to avoid cyclic deps)
+  std::map<ci_string,std::weak_ptr<field_type>> m_fields;
+
+  // If m_info->m_bundled is true, this is the field that all fields
+  // in m_fields are a subview of.
+  std::weak_ptr<field_type> m_bundle;
+
+  // The info of this group.
+  std::shared_ptr<FieldGroupInfo>  m_info;
+
+  // The grid where these field live on
+  ci_string  m_grid_name;
+};
+
+} // namespace scream
+
+#endif // SCREAM_FIELD_GROUP_HPP

--- a/components/scream/src/share/field/field_group.hpp
+++ b/components/scream/src/share/field/field_group.hpp
@@ -98,12 +98,12 @@ struct FieldGroup {
 
   int size() const { return m_fields.size(); }
 
-  // The fields in this group (weak ptrs to avoid cyclic deps)
-  std::map<ci_string,std::weak_ptr<field_type>> m_fields;
+  // The fields in this group
+  std::map<ci_string,std::shared_ptr<field_type>> m_fields;
 
   // If m_info->m_bundled is true, this is the field that all fields
   // in m_fields are a subview of.
-  std::weak_ptr<field_type> m_bundle;
+  std::shared_ptr<field_type> m_bundle;
 
   // The info of this group.
   std::shared_ptr<FieldGroupInfo>  m_info;

--- a/components/scream/src/share/field/field_group.hpp
+++ b/components/scream/src/share/field/field_group.hpp
@@ -63,6 +63,8 @@ struct FieldGroupInfo
     // Nothing to do here
   }
 
+  int size() const { return m_fields_names.size(); }
+
   // The name of the group
   ci_string m_group_name;
 
@@ -96,7 +98,7 @@ struct FieldGroup {
     // Nothing to do here
   }
 
-  int size() const { return m_fields.size(); }
+  FieldGroup (const FieldGroup&) = default;
 
   // The fields in this group
   std::map<ci_string,std::shared_ptr<field_type>> m_fields;

--- a/components/scream/src/share/field/field_header.cpp
+++ b/components/scream/src/share/field/field_header.cpp
@@ -46,9 +46,4 @@ set_extra_data (const std::string& key,
   }
 }
 
-void FieldHeader::register_inside_parent () {
-  auto me = shared_from_this ();
-  // m_parent.lock()->m_children.push_back(me);
-}
-
 } // namespace scream

--- a/components/scream/src/share/field/field_header.hpp
+++ b/components/scream/src/share/field/field_header.hpp
@@ -84,8 +84,6 @@ public:
   // Get the extra data
   const extra_data_type& get_extra_data () const { return m_extra_data; }
 
-  void register_inside_parent ();
-
 protected:
 
   // Static information about the field: name, rank, tags

--- a/components/scream/src/share/field/field_layout.hpp
+++ b/components/scream/src/share/field/field_layout.hpp
@@ -37,7 +37,8 @@ public:
   FieldTag tag  (const int idim) const;
   bool has_tag (const FieldTag t) const { return ekat::contains(m_tags,t); }
 
-  int      rank ()               const  { return m_rank; }
+  // The rank is the number of tags associated to this field.
+  int     rank () const  { return m_rank; }
 
   int dim (const FieldTag tag) const;
   int dim (const int idim) const;

--- a/components/scream/src/share/field/field_monotonicity_check.hpp
+++ b/components/scream/src/share/field/field_monotonicity_check.hpp
@@ -14,16 +14,18 @@ namespace scream
 template<typename RealType>
 class FieldMonotonicityCheck: public FieldPropertyCheck<RealType> {
 public:
+  using non_const_RT = typename FieldPropertyCheck<RealType>::non_const_RT;
+  using const_RT     = typename FieldPropertyCheck<RealType>::const_RT;
 
   // Default constructor.
   FieldMonotonicityCheck () {}
 
   // Overrides.
 
-  bool check(const Field<RealType>& field) const override {
+  bool check(const Field<const_RT>& field) const override {
     auto view = field.get_view();
-    RealType sign;
-    Kokkos::parallel_reduce(view.extent(0), KOKKOS_LAMBDA(Int i, RealType& s) {
+    non_const_RT sign;
+    Kokkos::parallel_reduce(view.extent(0), KOKKOS_LAMBDA(Int i, non_const_RT& s) {
       if ((i > 0) && (i < view.extent_int(0)-1)) {
         auto diff1 = view(i) - view(i-1);
         auto diff2 = view(i+1) - view(i);
@@ -31,7 +33,7 @@ public:
       } else {
         s *= 1;
       }
-    }, Kokkos::Prod<RealType>(sign));
+    }, Kokkos::Prod<non_const_RT>(sign));
     return (sign > 0);
   }
 

--- a/components/scream/src/share/field/field_positivity_check.hpp
+++ b/components/scream/src/share/field/field_positivity_check.hpp
@@ -15,20 +15,22 @@ namespace scream
 template<typename RealType>
 class FieldPositivityCheck: public FieldPropertyCheck<RealType> {
 public:
+  using non_const_RT = typename FieldPropertyCheck<RealType>::non_const_RT;
+  using const_RT     = typename FieldPropertyCheck<RealType>::const_RT;
 
   // Default constructor -- cannot repair fields that fail the check.
   FieldPositivityCheck () : m_lower_bound(0) {}
 
   // Constructor with lower bound -- can repair fields that fail the check
   // by overwriting nonpositive values with the given lower bound.
-  explicit FieldPositivityCheck (RealType lower_bound) :
+  explicit FieldPositivityCheck (const_RT lower_bound) :
     m_lower_bound(lower_bound) {
     EKAT_ASSERT_MSG(lower_bound > 0, "lower_bound must be positive.");
   }
 
   // Overrides.
 
-  bool check(const Field<RealType>& field) const override {
+  bool check(const Field<const_RT>& field) const override {
     auto view = field.get_view();
     RealType min_val = std::numeric_limits<RealType>::max();
     Kokkos::parallel_reduce(view.extent(0), KOKKOS_LAMBDA(Int i, RealType& m) {
@@ -41,7 +43,7 @@ public:
     return (m_lower_bound > 0);
   }
 
-  void repair(Field<RealType>& field) const override {
+  void repair(Field<non_const_RT>& field) const override {
     if (can_repair()) {
       auto view = field.get_view();
       RealType lower_bound = m_lower_bound;
@@ -56,7 +58,6 @@ protected:
 
   // The given lower bound (0 if not supplied).
   RealType m_lower_bound;
-
 };
 
 } // namespace scream

--- a/components/scream/src/share/field/field_property_check.hpp
+++ b/components/scream/src/share/field/field_property_check.hpp
@@ -1,6 +1,8 @@
 #ifndef SCREAM_FIELD_PROPERTY_CHECK_HPP
 #define SCREAM_FIELD_PROPERTY_CHECK_HPP
 
+#include <type_traits>
+
 namespace scream
 {
 
@@ -23,6 +25,8 @@ template<typename RealType> class Field;
 template<typename RealType>
 class FieldPropertyCheck {
 public:
+  using non_const_RT = typename std::remove_const<RealType>::type;
+  using const_RT     = typename std::add_const<RealType>::type;
 
   // Constructor(s)
   FieldPropertyCheck () = default;
@@ -33,11 +37,11 @@ public:
   // No assignment operator, either.
   FieldPropertyCheck& operator=(const FieldPropertyCheck&) = delete;
 
-  virtual ~FieldPropertyCheck() {}
+  virtual ~FieldPropertyCheck()  = default;
 
   // Override this method to perform a property check on a Field. The method
   // returns true if the property check passes, and false if it fails.
-  virtual bool check(const Field<RealType>& field) const = 0;
+  virtual bool check(const Field<const_RT>& field) const = 0;
 
   // Override this method to return true if the property check is capable of
   // attempting to fix a field to make it satisfy a property check.
@@ -46,17 +50,17 @@ public:
   // Override this method to attempt to repair a field that doesn't pass this
   // property check. The field must be checked again to determine whether the
   // repair is successful. NOTE the const in this method!
-  virtual void repair(Field<RealType>& field) const = 0;
+  virtual void repair(Field<non_const_RT>& field) const = 0;
 
   // Override this method to provide a more efficient way to check and repair
   // a field in a single pass (applicable only to property checks that can
   // repair a field).
-  virtual void check_and_repair(Field<RealType>& field) const {
-    if (!check(field) && can_repair()) {
+  virtual void check_and_repair(Field<non_const_RT>& field) const {
+    EKAT_REQUIRE_MSG(can_repair(), "Error! This property check cannot repair the field.\n");
+    if (!check(field)) {
       repair(field);
     }
   }
-
 };
 
 } // namespace scream

--- a/components/scream/src/share/field/field_repository.hpp
+++ b/components/scream/src/share/field/field_repository.hpp
@@ -77,6 +77,8 @@ public:
   template<typename RequestedValueType = RT>
   void register_field (const identifier_type& identifier);
 
+  void register_field (const identifier_type& identifier, const int pack_size, const std::string& field_group);
+
   // Get information about the state of the repo
   int size () const { return m_fields.size(); }
   int internal_size () const;
@@ -226,6 +228,15 @@ register_field (const identifier_type& id, const std::set<std::string>& groups_n
     // Add the field name to the set of fields belonging to this group
     group->m_fields_names.insert(id.name());
   }
+}
+
+template<typename RealType>
+void FieldRepository<RealType>::
+register_field (const identifier_type& identifier, const int pack_size, const std::string& field_group)
+{
+  register_field(identifier,field_group);
+  auto f = get_field_ptr(identifier);
+  f->get_header().get_alloc_properties().template request_allocation<RealType>(pack_size);
 }
 
 template<typename RealType>

--- a/components/scream/src/share/field/field_repository.hpp
+++ b/components/scream/src/share/field/field_repository.hpp
@@ -517,7 +517,7 @@ registration_ends (const std::shared_ptr<const GridsManager>& gm) {
         // Note: as of 02/2021, idim should *always* be 1, but we store it just in case,
         //       to avoid bugs in the future.
         const int idim = std::distance(Q_tags.begin(),ekat::find(Q_tags,VAR));
-        auto q = Q->subfield(fname,idim,iq);
+        auto q = Q->subfield(fname,fh.get_identifier().get_units(),idim,iq);
 
         // Either this is the first tracer we set in the group (m_subview_dim still -1),
         // or idim should match what was already in the group info.
@@ -543,7 +543,7 @@ registration_ends (const std::shared_ptr<const GridsManager>& gm) {
         // Note: as of 02/2021, idim should *always* be 1, but we store it just in case,
         //       to avoid bugs in the future.
         const int idim = std::distance(FQ_tags.begin(),ekat::find(FQ_tags,VAR));
-        auto fq = FQ->subfield(fname,idim,iq);
+        auto fq = FQ->subfield(fname,fh.get_identifier().get_units(),idim,iq);
 
         // Either this is the first tracer we set in the group (m_subview_dim still -1),
         // or idim should match what was already in the group info.

--- a/components/scream/src/share/field/field_tracking.hpp
+++ b/components/scream/src/share/field/field_tracking.hpp
@@ -1,6 +1,7 @@
 #ifndef SCREAM_FIELD_TRACKING_HPP
 #define SCREAM_FIELD_TRACKING_HPP
 
+#include "share/field/field_group.hpp"
 #include "share/scream_types.hpp"
 
 #include "share/util/scream_time_stamp.hpp"
@@ -80,7 +81,7 @@ public:
   std::weak_ptr<FieldTracking> get_parent () const { return m_parent; }
 
   // List of field groups that this field belongs to
-  const std::set<ci_string>& get_groups_names () const { return m_groups; }
+  const ekat::WeakPtrSet<const FieldGroupInfo>& get_groups_info () const { return m_groups; }
 
   // ----- Setters ----- //
 
@@ -91,7 +92,7 @@ public:
   void set_value_initializer (const Real value);
 
   // Add the field to a given group
-  void add_to_group (const std::string& group_name);
+  void add_to_group (const std::shared_ptr<const FieldGroupInfo>& group);
 
   // Set the time stamp for this field. This can only be called once, due to TimeStamp implementation.
   // NOTE: if the field has 'children' (see below), their ts will be updated too.
@@ -141,7 +142,7 @@ protected:
   // get all tracers, which need to be advected. However, dyamics has no idea of what are
   // the tracers names, and neither should it care. Groups can come to rescue here, allowing
   // dynamics to request all fields that have been marked as 'tracers'.
-  std::set<ci_string>    m_groups;
+  ekat::WeakPtrSet<const FieldGroupInfo>    m_groups;
 };
 
 // Use this free function to exploit features of enable_from_this

--- a/components/scream/src/share/grid/abstract_grid.hpp
+++ b/components/scream/src/share/grid/abstract_grid.hpp
@@ -76,7 +76,8 @@ public:
   const std::string& name () const { return m_name; }
 
   // Native layout of a dof. This is the natural way to index a dof in the grid.
-  // E.g., for a 2d field on a SE grid, this will be (nelem,np,np)
+  // E.g., for a scalar 2d field on a SE grid, this will be (nelem,np,np),
+  //       for a vector 3d field on a Point grid it will be (ncols,vector_dim,nlevs)
   virtual FieldLayout get_2d_scalar_layout () const = 0;
   virtual FieldLayout get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const = 0;
   virtual FieldLayout get_3d_scalar_layout (const bool midpoints) const = 0;

--- a/components/scream/src/share/io/output_manager.hpp
+++ b/components/scream/src/share/io/output_manager.hpp
@@ -262,11 +262,11 @@ inline void OutputManager::make_restart_param_list(ekat::ParameterList& params)
   // set fields for restart
   // If a developer wants a field to be stored in the restart file than they must add the "restart" group tag
   // to that field when registering the field with the field repository.
-  auto& restart_fields = m_device_field_repo->get_field_groups_names().at("restart");
+  auto restart_fields = m_device_field_repo->get_field_group("restart","Physics");
   auto& field_params = params.sublist("FIELDS");
-  field_params.set<Int>("Number of Fields",restart_fields.size());
+  field_params.set<Int>("Number of Fields",restart_fields.m_fields.size());
   Int it_cnt = 0;
-  for (auto it : restart_fields)
+  for (auto it : restart_fields.m_info->m_fields_names)
   {
     ++it_cnt;
     std::string f_it = "field ";

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -299,7 +299,6 @@ TEST_CASE("field_repo", "") {
   repo.register_field(fid7,"group_7");
   repo.register_field(fid8,"group_7");
   // Test for packed field
-  using Spack        = ekat::Pack<Int,SCREAM_SMALL_PACK_SIZE>;
   using Pack         = ekat::Pack<Real,8>;
   repo.register_field<Pack>(fid9);
   // Should not be able to register the same field name with two different units

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -400,16 +400,16 @@ TEST_CASE("tracers_bundle", "") {
 
   FieldRepository<Real> repo;
   repo.registration_begins();
-  repo.register_field(qv_id,"ADVECTED");
-  repo.register_field(qc_id,"ADVECTED");
-  repo.register_field(qr_id,"ADVECTED");
+  repo.register_field(qv_id,"TRACERS");
+  repo.register_field(qc_id,"TRACERS");
+  repo.register_field(qr_id,"TRACERS");
   repo.registration_ends(gm);
 
   auto qv = repo.get_field(qv_id);
   auto qc = repo.get_field(qc_id);
   auto qr = repo.get_field(qr_id);
 
-  auto group = repo.get_field_group("ADVECTED",grid_name);
+  auto group = repo.get_field_group("TRACERS",grid_name);
   // The repo should have allocated the group bundled
   REQUIRE (group.m_info->m_bundled);
 

--- a/components/scream/src/share/util/map_key_iterator.hpp
+++ b/components/scream/src/share/util/map_key_iterator.hpp
@@ -1,0 +1,54 @@
+#ifndef SCREAM_MAP_KEY_ITERATOR_HPP
+#define SCREAM_MAP_KEY_ITERATOR_HPP
+
+#include <map>
+
+namespace scream {
+
+/*
+ * An iterator that allows to iterate over the keys of a map only.
+ *
+ * The reason to have this class is that we can expose a way to
+ * access the keys of a map without exposing the actual content
+ * of the pair. This is very handy for map<K,std::shared_ptr<V>>,
+ * where even if the map is const, iterating over it allows one
+ * to modify the pointees.
+ * By offering a key-iterator, one can iterate over the keys of
+ * the map, without exposing the values in any way.
+ * Note: this is similar to python's dictionary 'keys()' method.
+ */
+
+template<typename MapType>
+class map_key_iterator;
+template<typename MapType>
+class map_key_const_iterator;
+
+template<typename Key, typename Value>
+class map_key_iterator<std::map<Key,Value>> final : public std::map<Key, Value>::iterator
+{
+public:
+  using map_iterator = typename std::map<Key,Value>::iterator;
+
+  map_key_iterator ( ) : map_iterator ( ) { };
+  map_key_iterator ( map_iterator it_ ) : map_iterator ( it_ ) { };
+
+  Key *operator -> ( ) { return ( Key * const ) &( map_iterator::operator -> ( )->first ); }
+  Key operator * ( ) { return map_iterator::operator * ( ).first; }
+};
+
+template<typename Key, typename Value>
+class map_key_const_iterator<std::map<Key,Value>> final : public std::map<Key, Value>::const_iterator
+{
+public:
+  using map_const_iterator = typename std::map<Key,Value>::const_iterator;
+
+  map_key_const_iterator ( ) : map_const_iterator ( ) { };
+  map_key_const_iterator ( map_const_iterator it_ ) : map_const_iterator ( it_ ) { };
+
+  const Key *operator -> ( ) { return ( const Key * const ) &( map_const_iterator::operator -> ( )->first ); }
+  Key operator * ( ) { return map_const_iterator::operator * ( ).first; }
+};
+
+} // namespace scream
+
+#endif // SCREAM_MAP_KEY_ITERATOR_HPP

--- a/components/scream/src/share/util/map_key_iterator.hpp
+++ b/components/scream/src/share/util/map_key_iterator.hpp
@@ -32,7 +32,7 @@ public:
   map_key_iterator ( ) : map_iterator ( ) { };
   map_key_iterator ( map_iterator it_ ) : map_iterator ( it_ ) { };
 
-  Key *operator -> ( ) { return ( Key * const ) &( map_iterator::operator -> ( )->first ); }
+  Key *operator -> ( ) { return ( Key * ) &( map_iterator::operator -> ( )->first ); }
   Key operator * ( ) { return map_iterator::operator * ( ).first; }
 };
 
@@ -45,7 +45,7 @@ public:
   map_key_const_iterator ( ) : map_const_iterator ( ) { };
   map_key_const_iterator ( map_const_iterator it_ ) : map_const_iterator ( it_ ) { };
 
-  const Key *operator -> ( ) { return ( const Key * const ) &( map_const_iterator::operator -> ( )->first ); }
+  const Key *operator -> ( ) { return ( const Key * ) &( map_const_iterator::operator -> ( )->first ); }
   Key operator * ( ) { return map_const_iterator::operator * ( ).first; }
 };
 


### PR DESCRIPTION
This PR introduce some mods to a bunch of the AD classes (field stack, atm proc stack, driver). The main goal is to allow the allocation of the tracers group (so far called "ADVECTED") as a single field `Q`, and then 'subview' each individual tracer from `Q`.

Note: This is sitll a WIP (e.g., no tests yet), but I'm not adding the WIP label, so that the AT will help me find GPU errors as I'm developing, so I can fix them while I'm still working on it.