### PR TITLE
SCREAM: added env-setup print option to test-all-scream

### DIFF
--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -101,6 +101,9 @@ OR
     parser.add_argument("-d", "--dry-run", action="store_true",
                         help="Do a dry run, commands will be printed but not executed")
 
+    parser.add_argument("--print-mach-setup", action="store_true",
+        help="Prints environment used on given machine, then quits immediately.")
+
     parser.add_argument("--make-parallel-level", action="store", type=int, default=0,
         help="Max number of jobs to be created during compilation. If not provided, use default for given machine.")
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -3,7 +3,7 @@ from utils import run_cmd, run_cmd_no_fail, check_minimum_python_version, get_cu
     get_common_ancestor, merge_git_ref, checkout_git_ref, print_last_commit
 
 from machines_specs import get_mach_compilation_resources, get_mach_testing_resources, \
-    get_mach_baseline_root_dir, setup_mach_env, is_cuda_machine, \
+    get_mach_baseline_root_dir, setup_mach_env, is_cuda_machine, get_mach_env_setup_command, \
     get_mach_cxx_compiler, get_mach_f90_compiler, get_mach_c_compiler, is_machine_supported
 
 check_minimum_python_version(3, 4)
@@ -22,7 +22,7 @@ class TestAllScream(object):
                  baseline_ref=None, baseline_dir=None, machine=None, no_tests=False, keep_tree=False,
                  custom_cmake_opts=(), custom_env_vars=(), preserve_env=False, tests=(),
                  integration_test="JENKINS_HOME" in os.environ, local=False, root_dir=None, work_dir=None,
-                 quick_rerun=False,quick_rerun_failed=False,dry_run=False,
+                 quick_rerun=False,quick_rerun_failed=False,dry_run=False,print_mach_setup=False,
                  make_parallel_level=0, ctest_parallel_level=0):
     ###########################################################################
 
@@ -48,6 +48,7 @@ class TestAllScream(object):
         self._quick_rerun             = quick_rerun
         self._quick_rerun_failed      = quick_rerun_failed
         self._dry_run                 = dry_run
+        self._print_mach_setup        = print_mach_setup
         self._must_generate_baselines = False
 
         if self._quick_rerun_failed:
@@ -649,6 +650,12 @@ class TestAllScream(object):
     ###############################################################################
     def test_all_scream(self):
     ###############################################################################
+
+        if self._print_mach_setup:
+            # Simply print mach env, then return
+            s = " && ".join(get_mach_env_setup_command(self._machine))
+            print ("\nBash commands for machine '{}' setup:\n\n  {}\n".format(self._machine,s))
+            return True
 
         # Add any override the user may have requested
         for env_var in self._custom_env_vars:


### PR DESCRIPTION
Doing
```
  ./scripts/test-all-scream --print-mach-setup -m $machine
```
will print the bash commands needed to setup the env on machine `$machine`, and then exit immediately. Useful to go on a machine and manually config/build/run/debug scream, making sure the env is the same that test-all-scream would use.