### PR TITLE
SCREAM: fix env setup for summit

### DIFF
--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -68,7 +68,7 @@ MACHINE_METADATA = {
                 "bsub -I -q batch -W 0:30 -P cli115 -nnodes 1",
                 44,
                 6,
-                ""),
+                "/gpfs/alpine/cli115/proj-shared/scream/master-baselines"),
     "cori"   : (["eval $(../../cime/scripts/Tools/get_case_env)", "export OMP_NUM_THREADS=68"],
                 ["CC","ftn","cc"],
                 "srun --time 02:00:00 --nodes=1 --constraint=knl,quad,cache --exclusive -q regular --account e3sm",

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -63,7 +63,7 @@ MACHINE_METADATA = {
                   16,
                   16,
                   ""),
-    "summit" : (["module purge", "module load cmake/3.15.2 gcc/6.4.0 spectrum-mpi/10.3.0.1-20190611 cuda/10.1.168 python/3.6.6-anaconda3-5.3.0"],
+    "summit" : (["module purge", "module load cmake/3.15.2 gcc/6.4.0 spectrum-mpi/10.3.0.1-20190611 cuda/10.1.168 python/3.6.6-anaconda3-5.3.0 netcdf/4.6.1 netcdf-fortran/4.4.4 openblas/0.3.9-nothreads","unset OMPI_CXX"],
                 ["mpicxx","mpifort","mpicc"],
                 "bsub -I -q batch -W 0:30 -P cli115 -nnodes 1",
                 44,


### PR DESCRIPTION
On summit, loading mpi modules causes `OMPI_CXX` to be set to `g++`. Unfortunately, this means that `ekat_mpicxx` will refuse to set `OMPI_CXX=/path/to/nvcc_wrapper`, since it is designed to honor the env var if currently set (the idea was to allow the user to set it to something particular, if they wanted).

To get around this, I added a `unset OMPI_CXX` to summit env setup string. I also added loading the modules for netcdf and blas.