### PR TITLE
SCREAM: created separate field tags for midpoints and interface levels

### DIFF
--- a/components/scream/src/control/tests/dummy_atm_proc.hpp
+++ b/components/scream/src/control/tests/dummy_atm_proc.hpp
@@ -56,10 +56,10 @@ public:
     std::vector<FieldTag> tags;
     std::vector<int> dims;
     if (m_grid->name()=="Point Grid A") {
-      tags = {COL,VL};
+      tags = {COL,LEV};
       dims = {num_cols, num_levs};
     } else {
-      tags = {VL,COL};
+      tags = {LEV,COL};
       dims = {num_levs,num_cols};
     }
     FieldLayout layout (tags,dims);
@@ -148,7 +148,7 @@ public:
       const auto view_C = m_outputs["C"].get_reshaped_view<Real**>();
 
       Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-        // A to BC is on grid A: (COL,VL)
+        // A to BC is on grid A: (COL,LEV)
         const int icol = idx / nlevs;
         const int ilev = idx % nlevs;
 
@@ -161,7 +161,7 @@ public:
       const auto view_C = m_outputs["C"].get_reshaped_view<Real**>();
 
       Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-        // Group to Group is on grid B: (VL,COL)
+        // Group to Group is on grid B: (LEV,COL)
         const int icol = idx / nlevs;
         const int ilev = idx % nlevs;
 
@@ -174,7 +174,7 @@ public:
       const auto view_A = m_outputs["A"].get_reshaped_view<Real**>();
 
       Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-        // Group to A is on grid A: (COL,VL)
+        // Group to A is on grid A: (COL,LEV)
         const int icol = idx / nlevs;
         const int ilev = idx % nlevs;
 

--- a/components/scream/src/control/tests/dummy_grid.hpp
+++ b/components/scream/src/control/tests/dummy_grid.hpp
@@ -9,8 +9,8 @@ namespace scream {
  * The dummy remapper has limited abilities. It can only handle
  * rank 1 and rank 2 fields, from 'Point Grid A' and 'Point Grid B'.
  * Rank 1 fields are simply deep-copied, while rank 2 fields get
- * their layout swapped during remap (meaning a (COL,VL) field
- * is remapped into a (VL,COL) field).
+ * their layout swapped during remap (meaning a (COL,LEV) field
+ * is remapped into a (LEV,COL) field).
  */
 
 template<typename RealType>

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -47,8 +47,8 @@ TEST_CASE ("surface_coupling")
   // Create some field ids, and register them in a field repo
   // Note: we create two repos, so we can compare outputs with inputs
   FID s2d_id("s2d",FL{{COL},{ncols}},Pa,grid->name());
-  FID s3d_id("s3d",FL{{COL,VL},{ncols,nlevs}},Pa,grid->name());
-  FID v3d_id("v3d",FL{{COL,CMP,VL},{ncols,2,nlevs}},m/s,grid->name());
+  FID s3d_id("s3d",FL{{COL,LEV},{ncols,nlevs}},Pa,grid->name());
+  FID v3d_id("v3d",FL{{COL,CMP,LEV},{ncols,2,nlevs}},m/s,grid->name());
 
   // NOTE: if you add fields abovew, you will have to modify these counters too.
   const int num_s2d = 1;

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -62,23 +62,18 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
 
   // Create the identifiers of input and output fields
   using namespace ShortFieldTagsNames;
-  using Tags = std::vector<FieldTag>;
-  Tags dyn_3d_scalar_tags        {EL,       GP,GP,VL};
-  Tags dyn_3d_vector_tags        {EL,   CMP,GP,GP,VL};
-  Tags dyn_3d_scalar_state_tags  {EL,TL,    GP,GP,VL};
-  Tags dyn_3d_vector_state_tags  {EL,TL,CMP,GP,GP,VL};
 
   // Inputs
-  FieldLayout FM_layout  { {EL,CMP,GP,GP,VL}, {ne,nmf,NGP,NGP,NVL} };
-  FieldLayout FT_layout  { {EL,    GP,GP,VL}, {ne,    NGP,NGP,NVL} };
+  FieldLayout FM_layout  { {EL,CMP,GP,GP,LEV}, {ne,nmf,NGP,NGP,NVL} };
+  FieldLayout FT_layout  { {EL,    GP,GP,LEV}, {ne,    NGP,NGP,NVL} };
 
   m_required_fields.emplace("FM", FM_layout, m/pow(s,2), dyn_grid_name);
   m_required_fields.emplace("FT", FT_layout, K/s,        dyn_grid_name);
 
   // Outputs
-  FieldLayout dyn_scalar_3d_mid_layout { dyn_3d_scalar_state_tags,  {ne, NTL,    NGP,NGP,NVL} };
-  FieldLayout dyn_scalar_3d_int_layout { dyn_3d_scalar_state_tags,  {ne, NTL,    NGP,NGP,NVL+1} };
-  FieldLayout dyn_vector_3d_mid_layout { dyn_3d_vector_state_tags,  {ne, NTL,  2,NGP,NGP,NVL} };
+  FieldLayout dyn_scalar_3d_mid_layout { {EL,TL,GP,GP,LEV},      {ne, NTL,    NGP,NGP,NVL} };
+  FieldLayout dyn_scalar_3d_int_layout { {EL,TL,GP,GP,ILEV},     {ne, NTL,    NGP,NGP,NVL+1} };
+  FieldLayout dyn_vector_3d_mid_layout { {EL,TL,CMP,GP,GP,LEV},  {ne, NTL,  2,NGP,NGP,NVL} };
   m_computed_fields.emplace("u",       dyn_vector_3d_mid_layout, m/s, dyn_grid_name);
   m_computed_fields.emplace("vtheta",  dyn_scalar_3d_mid_layout, K,   dyn_grid_name);
   m_computed_fields.emplace("phi",     dyn_scalar_3d_int_layout, Pa*pow(m,3)/kg, dyn_grid_name);

--- a/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -113,17 +113,17 @@ TEST_CASE("remap", "") {
   // Create tags and dimensions
   std::vector<FieldTag> s_2d_dyn_tags   = {EL,          GP, GP    };
   std::vector<FieldTag> v_2d_dyn_tags   = {EL,     CMP, GP, GP    };
-  std::vector<FieldTag> s_3d_dyn_tags   = {EL,          GP, GP, VL};
-  std::vector<FieldTag> v_3d_dyn_tags   = {EL,     CMP, GP, GP, VL};
-  std::vector<FieldTag> ss_3d_dyn_tags  = {EL, TL,      GP, GP, VL};
-  std::vector<FieldTag> vs_3d_dyn_tags  = {EL, TL, CMP, GP, GP, VL};
+  std::vector<FieldTag> s_3d_dyn_tags   = {EL,          GP, GP, LEV};
+  std::vector<FieldTag> v_3d_dyn_tags   = {EL,     CMP, GP, GP, LEV};
+  std::vector<FieldTag> ss_3d_dyn_tags  = {EL, TL,      GP, GP, LEV};
+  std::vector<FieldTag> vs_3d_dyn_tags  = {EL, TL, CMP, GP, GP, LEV};
 
   std::vector<FieldTag> s_2d_phys_tags  = {COL         };
   std::vector<FieldTag> v_2d_phys_tags  = {COL, CMP    };
-  std::vector<FieldTag> s_3d_phys_tags  = {COL,      VL};
-  std::vector<FieldTag> v_3d_phys_tags  = {COL, CMP, VL};
-  std::vector<FieldTag> vs_3d_phys_tags = {COL, CMP, VL};
-  std::vector<FieldTag> ss_3d_phys_tags = {COL,      VL};
+  std::vector<FieldTag> s_3d_phys_tags  = {COL,      LEV};
+  std::vector<FieldTag> v_3d_phys_tags  = {COL, CMP, LEV};
+  std::vector<FieldTag> vs_3d_phys_tags = {COL, CMP, LEV};
+  std::vector<FieldTag> ss_3d_phys_tags = {COL,      LEV};
 
   std::vector<int> s_2d_dyn_dims   = {nle,          np, np     };
   std::vector<int> v_2d_dyn_dims   = {nle,       2, np, np     };

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -53,8 +53,8 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   using namespace ShortFieldTagsNames;
 
   // Layout for 3D (2d horiz X 1d vertical) variable defined at mid-level and interfaces 
-  FieldLayout scalar3d_layout_mid { {COL,VL}, {m_num_cols,m_num_levs} };
-  FieldLayout scalar3d_layout_int { {COL,VL}, {m_num_cols,m_num_levs+1} };
+  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
+  FieldLayout scalar3d_layout_int { {COL,ILEV}, {m_num_cols,m_num_levs+1} };
 
   // Define fields needed in P3.
   // Note: p3_main is organized by a set of 5 structures, variables below are organized

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -40,11 +40,11 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
   // Layout for 2D (1d horiz X 1d vertical) variable
   FieldLayout scalar2d_layout_col{ {COL}, {m_num_cols} };
-  FieldLayout scalar2d_layout_lev{ {VL},  {m_num_levs} };
+  FieldLayout scalar2d_layout_lev{ {LEV},  {m_num_levs} };
 
   // Layout for 3D (2d horiz X 1d vertical) variable defined at mid-level and interfaces
-  FieldLayout scalar3d_layout_mid { {COL,VL}, {m_num_cols,m_num_levs} };
-  FieldLayout scalar3d_layout_int { {COL,VL}, {m_num_cols,m_num_levs+1} };
+  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
+  FieldLayout scalar3d_layout_int { {COL,ILEV}, {m_num_cols,m_num_levs+1} };
 
   // Define fields needed in SHOC.
   // Note: shoc_main is organized by a set of 5 structures, variables below are organized

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
@@ -36,10 +36,10 @@ void ZMDeepConvection::set_grids(const std::shared_ptr<const GridsManager> grids
 
   using namespace ShortFieldTagsNames;
 
-  FieldLayout scalar3d_layout_mid { {COL,VL}, {nc,NVL} }; // Note that C++ and Fortran read array dimensions in reverse
-  FieldLayout scalar3d_layout_int { {COL,VL}, {nc,NVL+1} }; // Note that C++ and Fortran read array dimensions in reverse
-  FieldLayout vector3d_layout_mid{ {COL,CMP,VL}, {nc,QSZ,NVL} };
-  FieldLayout tracers_layout { {COL,VAR,VL}, {nc,QSZ,NVL} };
+  FieldLayout scalar3d_layout_mid { {COL,LEV}, {nc,NVL} }; // Note that C++ and Fortran read array dimensions in reverse
+  FieldLayout scalar3d_layout_int { {COL,ILEV}, {nc,NVL+1} }; // Note that C++ and Fortran read array dimensions in reverse
+  FieldLayout vector3d_layout_mid{ {COL,CMP,LEV}, {nc,QSZ,NVL} };
+  FieldLayout tracers_layout { {COL,VAR,LEV}, {nc,QSZ,NVL} };
   FieldLayout scalar2d_layout{ {COL}, {nc} };
 
   std::vector<FieldLayout> layout_opts = {scalar3d_layout_mid, scalar3d_layout_int,

--- a/components/scream/src/share/field/field_group.hpp
+++ b/components/scream/src/share/field/field_group.hpp
@@ -42,7 +42,7 @@ namespace scream {
  *
  * E.g., say we have 3d scalar fields F1,F2,F3,F4 belonging to group MyGroup,
  * which is then allocated as a bundled field F. F will have layout
- * given by grid->get_3d_vector_layout(). Say this layout is (COL,CMP,VL).
+ * given by grid->get_3d_vector_layout(). Say this layout is (COL,CMP,LEV).
  * Each field is subviewed along m_subview_dim=1, at entry 0,1,2,3 respectively.
  * Note: as of 02/2021 m_subview_dim is *always* 1, but we store this bit
  *       of info nevertheless, in case things change later on.

--- a/components/scream/src/share/field/field_tag.hpp
+++ b/components/scream/src/share/field/field_tag.hpp
@@ -27,12 +27,14 @@ namespace scream
 enum class FieldTag {
   Invalid,
   Element,
-  VerticalLevel,
+  LevelMidPoint,
+  LevelInterface,
   Column,
   GaussPoint,
   Component,
-  ComponentX,
-  ComponentY,
+  Component1,
+  Component2,
+  Component3,
   TimeLevel,
   Variable
 };
@@ -46,8 +48,11 @@ inline std::string e2str (const FieldTag ft) {
     case FieldTag::Element:
       name = "EL";
       break;
-    case FieldTag::VerticalLevel:
-      name = "VL";
+    case FieldTag::LevelMidPoint:
+      name = "LEV";
+      break;
+    case FieldTag::LevelInterface:
+      name = "ILEV";
       break;
     case FieldTag::TimeLevel:
       name = "TL";
@@ -61,11 +66,14 @@ inline std::string e2str (const FieldTag ft) {
     case FieldTag::Component:
       name = "CMP";
       break;
-    case FieldTag::ComponentX:
-      name = "CMPX";
+    case FieldTag::Component1:
+      name = "CMP1";
       break;
-    case FieldTag::ComponentY:
-      name = "CMPY";
+    case FieldTag::Component2:
+      name = "CMP2";
+      break;
+    case FieldTag::Component3:
+      name = "CMP3";
       break;
     case FieldTag::Variable:
       name = "VAR";
@@ -85,10 +93,12 @@ namespace ShortFieldTagsNames {
   constexpr auto GP   = FieldTag::GaussPoint;
   constexpr auto TL   = FieldTag::TimeLevel;
   constexpr auto VAR  = FieldTag::Variable;
-  constexpr auto VL   = FieldTag::VerticalLevel;
+  constexpr auto LEV  = FieldTag::LevelMidPoint;
+  constexpr auto ILEV = FieldTag::LevelInterface;
   constexpr auto CMP  = FieldTag::Component;
-  constexpr auto CMPX = FieldTag::ComponentX;
-  constexpr auto CMPY = FieldTag::ComponentY;
+  constexpr auto CMP1 = FieldTag::Component1;
+  constexpr auto CMP2 = FieldTag::Component2;
+  constexpr auto CMP3 = FieldTag::Component3;
 }
 
 } // namespace scream

--- a/components/scream/src/share/field/field_utils.hpp
+++ b/components/scream/src/share/field/field_utils.hpp
@@ -22,18 +22,9 @@ enum class LayoutType {
 inline LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
   using ekat::erase;
   using ekat::count;
+  using namespace ShortFieldTagsNames;
 
   auto tags = field_tags;
-
-  constexpr auto EL   = FieldTag::Element;
-  constexpr auto COL  = FieldTag::Column;
-  constexpr auto GP   = FieldTag::GaussPoint;
-  constexpr auto TL   = FieldTag::TimeLevel;
-  constexpr auto CMP  = FieldTag::Component;
-  constexpr auto CMPX = FieldTag::ComponentX;
-  constexpr auto CMPY = FieldTag::ComponentY;
-  constexpr auto VAR  = FieldTag::Variable;
-  constexpr auto VL   = FieldTag::VerticalLevel;
 
   const int n_element = count(tags,EL);
   const int n_column  = count(tags,COL);
@@ -66,22 +57,22 @@ inline LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
       result = LayoutType::Scalar2D;
       break;
     case 1:
-      // The only tag left should be 'Component', 'TimeLevel', 'Variable', or 'VerticalLevel
+      // The only tag left should be 'CMP', 'TL', 'VAR', or 'LEV'/'ILEV'
       if (tags[0]==CMP || tags[0]==TL || tags[0]==VAR) {
         result = LayoutType::Vector2D;
-      } else if (tags[0]==VL) {
+      } else if (tags[0]==LEV || tags[0]==ILEV) {
         result = LayoutType::Scalar3D;
       }
       break;
     case 2:
-      // Two possible scenarios:
-      //  1) <Component|Variable|TimeLevel,VerticalLevel>
-      //  2) <Variable|TimeLevel,Component>
-      //  3) <TimeLevel,Variable>
-      //  4) <ComponentX,ComponentY>
-      if (tags[1]==VL && (tags[0]==CMP || tags[0]==VAR || tags[0]==TL)) {
+      // Possible scenarios:
+      //  1) <CMP|VAR|TL,LEV|ILEV>
+      //  2) <VAR|TL,CMP>
+      //  3) <TL,VAR>
+      //  4) <CMP1,CMP2>
+      if ( (tags[1]==LEV || tags[1]==ILEV) && (tags[0]==CMP || tags[0]==VAR || tags[0]==TL)) {
         result = LayoutType::Vector3D;
-      } else if ((tags[0]==CMPX && tags[1]==CMPY) ||
+      } else if ((tags[0]==CMP1 && tags[1]==CMP2) ||
                  (tags[1]==CMP && (tags[0]==VAR || tags[0]==TL)) ||
                  (tags[0]==TL && tags[1]==VAR)) {
         result = LayoutType::Tensor2D;
@@ -89,11 +80,11 @@ inline LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
       break;
     case 3:
       // The only scenarios are:
-      //  1) <ComponentX, ComponentY, VerticalLevel>
-      //  2) <TimeLevel,  Variable, VerticalLevel>
-      //  3) <TimeLevel|Variable,  Component, VerticalLevel>
-      if (tags[2]==VL) {
-        if ((tags[0]==CMPX && tags[1]==CMPY) ||
+      //  1) <CMP1, CMP2, LEV|ILEV>
+      //  2) <TL,  VAR, LEV|ILEV>
+      //  3) <TL|VAR,  CMP, LEV|ILEV>
+      if (tags[2]==LEV || tags[2]==ILEV) {
+        if ((tags[0]==CMP1 && tags[1]==CMP2) ||
             (tags[0]==TL && (tags[1]==VAR || tags[1]==CMP)) ||
             (tags[0]==VAR && tags[1]==CMP)) {
           result = LayoutType::Tensor3D;

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -53,6 +53,7 @@ PointGrid::get_3d_scalar_layout (const bool midpoints) const
   using namespace ShortFieldTagsNames;
 
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
+  auto VL = midpoints ? LEV : ILEV;
 
   return FieldLayout({COL,VL},{m_num_local_dofs,nvl});
 }
@@ -63,6 +64,7 @@ PointGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag
   using namespace ShortFieldTagsNames;
 
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
+  auto VL = midpoints ? LEV : ILEV;
 
   return FieldLayout({COL,vector_tag,VL},{m_num_local_dofs,vector_dim,nvl});
 }

--- a/components/scream/src/share/grid/se_grid.cpp
+++ b/components/scream/src/share/grid/se_grid.cpp
@@ -83,6 +83,7 @@ SEGrid::get_3d_scalar_layout (const bool midpoints) const
   using namespace ShortFieldTagsNames;
 
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
+  auto VL = midpoints ? LEV : ILEV;
 
   return FieldLayout({EL,GP,GP,VL},{m_num_local_elem,m_num_gp,m_num_gp,nvl});
 }
@@ -93,6 +94,7 @@ SEGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, c
   using namespace ShortFieldTagsNames;
 
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
+  auto VL = midpoints ? LEV : ILEV;
 
   return FieldLayout({EL,vector_tag,GP,GP,VL},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp,nvl});
 }

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -181,12 +181,14 @@ TEST_CASE("input_output_basic","io")
 /*===================================================================================================================*/
 std::shared_ptr<FieldRepository<Real>> get_test_repo(const Int num_lcols, const Int num_levs)
 {
+  using namespace ShortFieldTagsNames;
+
   // Create a repo
   std::shared_ptr<FieldRepository<Real>>  repo = std::make_shared<FieldRepository<Real>>();
   // Create some fields for this repo
-  std::vector<FieldTag> tag_h  = {FieldTag::Column};
-  std::vector<FieldTag> tag_v  = {FieldTag::VerticalLevel};
-  std::vector<FieldTag> tag_2d = {FieldTag::Column,FieldTag::VerticalLevel};
+  std::vector<FieldTag> tag_h  = {COL};
+  std::vector<FieldTag> tag_v  = {LEV};
+  std::vector<FieldTag> tag_2d = {COL,LEV};
 
   std::vector<Int>     dims_h  = {num_lcols};
   std::vector<Int>     dims_v  = {num_levs};
@@ -200,7 +202,6 @@ std::shared_ptr<FieldRepository<Real>> get_test_repo(const Int num_lcols, const 
   FieldIdentifier fid4("field_packed",FL{tag_2d,dims_2d},kg/m,gn);
 
   // Register fields with repo
-  using Spack        = ekat::Pack<Int,SCREAM_SMALL_PACK_SIZE>;
   // Make sure packsize isn't bigger than the packsize for this machine, but not so big that we end up with only 1 pack.
   const int packsize = 2;
   using Pack         = ekat::Pack<Real,packsize>;

--- a/components/scream/src/share/io/tests/restart.cpp
+++ b/components/scream/src/share/io/tests/restart.cpp
@@ -161,12 +161,14 @@ TEST_CASE("restart","io")
 /*===================================================================================================================*/
 std::shared_ptr<FieldRepository<Real>> get_test_repo(const Int num_lcols, const Int num_levs)
 {
+  using namespace ShortFieldTagsNames;
+
   // Create a repo
   std::shared_ptr<FieldRepository<Real>>  repo = std::make_shared<FieldRepository<Real>>();
   // Create some fields for this repo
-  std::vector<FieldTag> tag_h  = {FieldTag::Column};
-  std::vector<FieldTag> tag_v  = {FieldTag::VerticalLevel};
-  std::vector<FieldTag> tag_2d = {FieldTag::Column,FieldTag::VerticalLevel};
+  std::vector<FieldTag> tag_h  = {COL};
+  std::vector<FieldTag> tag_v  = {LEV};
+  std::vector<FieldTag> tag_2d = {COL,LEV};
 
   std::vector<Int>     dims_h  = {num_lcols};
   std::vector<Int>     dims_v  = {num_levs};

--- a/components/scream/src/share/tests/dummy_se_point_remapper.hpp
+++ b/components/scream/src/share/tests/dummy_se_point_remapper.hpp
@@ -56,9 +56,9 @@ public:
       case 3:
         return FieldLayout (TV{COL},IV{ncol});
       case 4:
-        return FieldLayout (TV{COL,VL},IV{ncol,tgt.dim(3)});
+        return FieldLayout (TV{COL,tgt.tags().back()},IV{ncol,tgt.dim(3)});
       case 5:
-        return FieldLayout (TV{COL,CMP,VL},IV{ncol,tgt.dim(1),tgt.dim(4)});
+        return FieldLayout (TV{COL,CMP,tgt.tags().back()},IV{ncol,tgt.dim(1),tgt.dim(4)});
       default:
         return FieldLayout (TV{},IV{});
     }
@@ -81,7 +81,7 @@ public:
       case 2:
         return FieldLayout (TV{EL,GP,GP,src.tag(1)},IV{nele,4,4,src.dim(1)});
       case 3:
-        return FieldLayout (TV{EL,CMP,GP,GP,VL},IV{nele,src.dim(1),4,4,src.dim(2)});
+        return FieldLayout (TV{EL,CMP,GP,GP,src.tags().back()},IV{nele,src.dim(1),4,4,src.dim(2)});
       default:
         return FieldLayout (TV{},IV{});
     }

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -41,8 +41,8 @@ TEST_CASE("field_identifier", "") {
   REQUIRE(false); // force this test to fail
 #endif
 
-  std::vector<FieldTag> tags1 = {EL, VL, CMP};
-  std::vector<FieldTag> tags2 = {EL, CMP, VL};
+  std::vector<FieldTag> tags1 = {EL, LEV, CMP};
+  std::vector<FieldTag> tags2 = {EL, CMP, LEV};
 
   std::vector<int> dims1 = {2, 3, 4};
   std::vector<int> dims2 = {2, 4, 3};
@@ -88,7 +88,7 @@ TEST_CASE("field", "") {
   using P8 = ekat::Pack<Real,8>;
   using P16 = ekat::Pack<Real,16>;
 
-  std::vector<FieldTag> tags = {COL,VL};
+  std::vector<FieldTag> tags = {COL,LEV};
   std::vector<int> dims = {3,24};
 
   FieldIdentifier fid ("field_1", {tags,dims}, m/s,"some_grid");
@@ -186,7 +186,7 @@ TEST_CASE("field", "") {
 
   // Subfields
   SECTION ("subfield") {
-    std::vector<FieldTag> t1 = {COL,VAR,CMP,VL};
+    std::vector<FieldTag> t1 = {COL,VAR,CMP,LEV};
     std::vector<int> d1 = {3,10,2,24};
 
     FieldIdentifier fid1("4d",{t1,d1},m/s,"some_grid");
@@ -262,8 +262,8 @@ TEST_CASE("field_repo", "") {
 
   std::vector<FieldTag> tags1 = {EL, GP, GP};
   std::vector<FieldTag> tags2 = {COL};
-  std::vector<FieldTag> tags3 = {VL};
-  std::vector<FieldTag> tags4 = {COL,VL};
+  std::vector<FieldTag> tags3 = {ILEV};
+  std::vector<FieldTag> tags4 = {COL,LEV};
 
   std::vector<int> dims1 = {2, 3, 4};
   std::vector<int> dims2 = {2, 3, 3};
@@ -380,7 +380,7 @@ TEST_CASE("tracers_bundle", "") {
   const int ncols = 4;
   const int nlevs = 7;
 
-  std::vector<FieldTag> tags = {COL,VL};
+  std::vector<FieldTag> tags = {COL,LEV};
   std::vector<int> dims = {ncols,nlevs};
 
   const auto nondim = Units::nondimensional();
@@ -483,8 +483,9 @@ TEST_CASE("field_property_check", "") {
 
   using namespace scream;
   using namespace ekat::units;
+  using namespace ShortFieldTagsNames;
 
-  std::vector<FieldTag> tags = {FieldTag::Element, FieldTag::GaussPoint, FieldTag::VerticalLevel};
+  std::vector<FieldTag> tags = {EL, GP, LEV};
   std::vector<int> dims = {2, 3, 12};
 
   FieldIdentifier fid ("field_1",{tags,dims}, m/s,"some_grid");


### PR DESCRIPTION
Two separate tags are helpful for I/O, where we need two different dimensions registered in the nc files. It also makes it simpler to spot errors, and makes the code a bit more verbose.

Note: the tags short names (which always match to the string you get with `e2str(tag)`) can be changed. I thought `LEV` and `ILEV` were clear enough, but we can use more verbose ones, like `MID_LEV` and `INT_LEV`, if you prefer.

Closes #648.