### PR TITLE
add shoc_init

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -345,22 +345,22 @@ subroutine shoc_main ( &
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
   if (use_cxx) then
-    call shoc_main_f(shcol, nlev, nlevi, dtime, nadv, &   ! Input
-    host_dx, host_dy,thv, &              ! Input
-    zt_grid,zi_grid,pres,presi,pdel,&    ! Input
-    wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, & ! Input
-    wtracer_sfc,num_qtracers,w_field, &  ! Input
-    exner,phis, &                        ! Input
-    host_dse, tke, thetal, qw, &         ! Input/Output
-    u_wind, v_wind,qtracers,&            ! Input/Output
-    wthv_sec,tkh,tk,&                    ! Input/Output
-    shoc_ql,shoc_cldfrac,&               ! Input/Output
-    pblh,&                               ! Output
-    shoc_mix, isotropy,&                 ! Output (diagnostic)
-    w_sec, thl_sec, qw_sec, qwthl_sec,&  ! Output (diagnostic)
-    wthl_sec, wqw_sec, wtke_sec,&        ! Output (diagnostic)
-    uw_sec, vw_sec, w3,&                 ! Output (diagnostic)
-    wqls_sec, brunt, shoc_ql2)           ! Output (diagnostic)
+    call shoc_main_f(shcol, nlev, nlevi, dtime, nadv, npbl,& ! Input
+                     host_dx, host_dy,thv, &                 ! Input
+                     zt_grid,zi_grid,pres,presi,pdel,&       ! Input
+                     wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, &    ! Input
+                     wtracer_sfc,num_qtracers,w_field, &     ! Input
+                     exner,phis, &                           ! Input
+                     host_dse, tke, thetal, qw, &            ! Input/Output
+                     u_wind, v_wind,qtracers,&               ! Input/Output
+                     wthv_sec,tkh,tk,&                       ! Input/Output
+                     shoc_ql,shoc_cldfrac,&                  ! Input/Output
+                     pblh,&                                  ! Output
+                     shoc_mix, isotropy,&                    ! Output (diagnostic)
+                     w_sec, thl_sec, qw_sec, qwthl_sec,&     ! Output (diagnostic)
+                     wthl_sec, wqw_sec, wtke_sec,&           ! Output (diagnostic)
+                     uw_sec, vw_sec, w3,&                    ! Output (diagnostic)
+                     wqls_sec, brunt, shoc_ql2)              ! Output (diagnostic)
      return
   endif
 #endif

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -324,8 +324,12 @@ void SHOCMacrophysics::run_impl (const Real dt)
                        shoc_preamble); // Kokkos::parallel_for(shoc_main_local_vals)
   Kokkos::fence();
 
-  // TODO: add shoc_init function, for now hard coded.
-  m_npbl = m_num_levs;
+
+  // Calculate maximum number of levels in pbl from surface
+  const auto pref_mid = m_shoc_fields_in["pref_mid"].get_reshaped_view<const Spack*>();
+  const int ntop_shoc = 0;
+  const int nbot_shoc = m_num_levs;
+  m_npbl = SHF::shoc_init(nbot_shoc,ntop_shoc,pref_mid);
 
   // For now set the host timestep to the shoc timestep. This forces
   // number of SHOC timesteps (nadv) to be 1.

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -290,7 +290,8 @@ protected:
   ekat::Comm          m_shoc_comm;
   ekat::ParameterList m_shoc_params;
 
-  // Keep track of field dimensions
+  // Keep track of field dimensions and other scalar values
+  // needed in shoc_main
   Int m_num_cols;
   Int m_num_levs;
   Int m_npbl;

--- a/components/scream/src/physics/shoc/shoc_constants.hpp
+++ b/components/scream/src/physics/shoc/shoc_constants.hpp
@@ -22,6 +22,7 @@ struct Constants
     static constexpr Scalar ustar_min      = 0.01;         // Minimum surface friction velocity
     static constexpr Scalar largeneg       = -99999999.99; // Large negative value used for linear_interp threshold
     static constexpr bool   dothetal_skew  = false;        // Allow temperature skewness to be independent of moisture variance
+    static constexpr Scalar pblmaxp        = 4e4;          // PBL max depth in pressure units
   };
 
   } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -574,6 +574,12 @@ struct Functions
     const uview_1d<Spack>&       rdp_zt);
 
   KOKKOS_FUNCTION
+  static Int shoc_init(
+    const Int&                  nbot_shoc,
+    const Int&                  ntop_shoc,
+    const view_1d<const Spack>& pref_mid);
+
+  KOKKOS_FUNCTION
   static void shoc_main_internal(
     const MemberType&            team,
     const Int&                   nlev,         // Number of levels

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -18,9 +18,12 @@ using scream::Int;
 
 extern "C" {
 
-void shoc_init_c(int nlev, Real gravit, Real rair, Real rh2o, Real cpair,
-                 Real zvir, Real latvap, Real latice, Real karman,
-                 Real* pref_mid, int nbot_shoc, int ntop_shoc);
+// Special shoc_init function for shoc_main_bfb test
+void shoc_init_for_main_bfb_c(int nlev, Real gravit, Real rair, Real rh2o, Real cpair,
+                              Real zvir, Real latvap, Real latice, Real karman,
+                              Real* pref_mid, int nbot_shoc, int ntop_shoc);
+void shoc_use_cxx_c(bool use_cxx);
+
 
 void shoc_grid_c(int shcol, int nlev, int nlevi, Real *zt_grid, Real *zi_grid,
                  Real *pdel, Real *dz_zt, Real *dzi_zi, Real *rho_zt);
@@ -747,6 +750,25 @@ void shoc_main(ShocMainData& d)
   shoc_init(d.nlev, true, true);
   d.transpose<ekat::TransposeDirection::c2f>();
   shoc_main_c(d.shcol, d.nlev, d.nlevi, d.dtime, d.nadv, d.host_dx, d.host_dy, d.thv, d.zt_grid, d.zi_grid, d.pres, d.presi, d.pdel, d.wthl_sfc, d.wqw_sfc, d.uw_sfc, d.vw_sfc, d.wtracer_sfc, d.num_qtracers, d.w_field, d.exner, d.phis, d.host_dse, d.tke, d.thetal, d.qw, d.u_wind, d.v_wind, d.qtracers, d.wthv_sec, d.tkh, d.tk, d.shoc_ql, d.shoc_cldfrac, d.pblh, d.shoc_mix, d.isotropy, d.w_sec, d.thl_sec, d.qw_sec, d.qwthl_sec, d.wthl_sec, d.wqw_sec, d.wtke_sec, d.uw_sec, d.vw_sec, d.w3, d.wqls_sec, d.brunt, d.shoc_ql2);
+  d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void shoc_main_with_init(ShocMainData& d)
+{
+  using C = scream::physics::Constants<Real>;
+
+  d.transpose<ekat::TransposeDirection::c2f>();
+  shoc_init_for_main_bfb_c(d.nlev, C::gravit, C::Rair, C::RH2O, C::Cpair, C::ZVIR, C::LatVap, C::LatIce, C::Karman,
+                           d.pref_mid, d.nbot_shoc, d.ntop_shoc+1);
+  shoc_use_cxx_c(false);
+
+
+  shoc_main_c(d.shcol, d.nlev, d.nlevi, d.dtime, d.nadv, d.host_dx, d.host_dy, d.thv, d.zt_grid, d.zi_grid,
+              d.pres, d.presi, d.pdel, d.wthl_sfc, d.wqw_sfc, d.uw_sfc, d.vw_sfc, d.wtracer_sfc, d.num_qtracers,
+              d.w_field, d.exner, d.phis, d.host_dse, d.tke, d.thetal, d.qw, d.u_wind, d.v_wind, d.qtracers,
+              d.wthv_sec, d.tkh, d.tk, d.shoc_ql, d.shoc_cldfrac, d.pblh, d.shoc_mix, d.isotropy, d.w_sec,
+              d.thl_sec, d.qw_sec, d.qwthl_sec, d.wthl_sec, d.wqw_sec, d.wtke_sec, d.uw_sec, d.vw_sec, d.w3,
+              d.wqls_sec, d.brunt, d.shoc_ql2);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 
@@ -2764,7 +2786,21 @@ void dp_inverse_f(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_zt)
   ekat::device_to_host({rdp_zt}, shcol, nlev, inout_views, true);
 }
 
-void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* host_dx, Real* host_dy, Real* thv, Real* zt_grid,
+int shoc_init_f(Int nlev, Real *pref_mid, Int nbot_shoc, Int ntop_shoc)
+{
+  using SHF  = Functions<Real, DefaultDevice>;
+  using Spack       = typename SHF::Spack;
+  using view_1d     = typename SHF::view_1d<Spack>;
+
+  // Sync to device
+  std::vector<view_1d> temp_d(1);
+  ekat::host_to_device({pref_mid}, nlev, temp_d);
+  view_1d pref_mid_d(temp_d[0]);
+
+  return SHF::shoc_init(nbot_shoc,ntop_shoc,pref_mid_d);
+}
+
+void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, Real* host_dx, Real* host_dy, Real* thv, Real* zt_grid,
                  Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc,
                  Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner, Real* phis, Real* host_dse, Real* tke,
                  Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk,
@@ -2889,7 +2925,6 @@ void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* hos
                                              uw_sec_d,    vw_sec_d,   w3_d,      wqls_sec_d,
                                              brunt_d,     isotropy_d};
 
-  const Int npbl = nlev;
   const auto elapsed_microsec = SHF::shoc_main(shcol, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
                                                shoc_input, shoc_input_output, shoc_output, shoc_history_output);
   (void)elapsed_microsec;

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -788,16 +788,31 @@ struct ShocMainData : public PhysicsTestData {
   Real dtime;
   Real *host_dx, *host_dy, *thv, *zt_grid, *zi_grid, *pres, *presi, *pdel, *wthl_sfc, *wqw_sfc, *uw_sfc, *vw_sfc, *wtracer_sfc, *w_field, *exner, *phis;
 
+  // Inputs for shoc_init
+  Int nbot_shoc, ntop_shoc;
+  Real *pref_mid;
+
   // Inputs/Outputs
   Real *host_dse, *tke, *thetal, *qw, *u_wind, *v_wind, *qtracers, *wthv_sec, *tkh, *tk, *shoc_ql, *shoc_cldfrac;
 
   // Outputs
   Real *pblh, *shoc_mix, *isotropy, *w_sec, *thl_sec, *qw_sec, *qwthl_sec, *wthl_sec, *wqw_sec, *wtke_sec, *uw_sec, *vw_sec, *w3, *wqls_sec, *brunt, *shoc_ql2;
 
-  ShocMainData(Int shcol_, Int nlev_, Int nlevi_, Int num_qtracers_, Real dtime_, Int nadv_) :
-    PhysicsTestData({{ shcol_ }, { shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_, num_qtracers_ }, { shcol_, nlev_, num_qtracers_ }}, {{ &host_dx, &host_dy, &wthl_sfc, &wqw_sfc, &uw_sfc, &vw_sfc, &phis, &pblh }, { &thv, &zt_grid, &pres, &pdel, &w_field, &exner, &host_dse, &tke, &thetal, &qw, &u_wind, &v_wind, &wthv_sec, &tkh, &tk, &shoc_ql, &shoc_cldfrac, &shoc_mix, &isotropy, &w_sec, &wqls_sec, &brunt, &shoc_ql2 }, { &zi_grid, &presi, &thl_sec, &qw_sec, &qwthl_sec, &wthl_sec, &wqw_sec, &wtke_sec, &uw_sec, &vw_sec, &w3 }, { &wtracer_sfc }, { &qtracers }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_), nadv(nadv_), num_qtracers(num_qtracers_), dtime(dtime_) {}
+  ShocMainData(Int shcol_, Int nlev_, Int nlevi_, Int num_qtracers_, Real dtime_, Int nadv_, Int nbot_shoc_, Int ntop_shoc_) :
+    PhysicsTestData({{ shcol_ }, { shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_, num_qtracers_ }, { shcol_, nlev_, num_qtracers_ }, { nlev_ }},
+                    {{ &host_dx, &host_dy, &wthl_sfc, &wqw_sfc, &uw_sfc, &vw_sfc, &phis, &pblh },
+                     { &thv, &zt_grid, &pres, &pdel, &w_field, &exner, &host_dse, &tke, &thetal,
+                       &qw, &u_wind, &v_wind, &wthv_sec, &tkh, &tk, &shoc_ql, &shoc_cldfrac,
+                       &shoc_mix, &isotropy, &w_sec, &wqls_sec, &brunt, &shoc_ql2 },
+                     { &zi_grid, &presi, &thl_sec, &qw_sec, &qwthl_sec, &wthl_sec,
+                       &wqw_sec, &wtke_sec, &uw_sec, &vw_sec, &w3 },
+                     { &wtracer_sfc },
+                     { &qtracers },
+                     { &pref_mid }}),
+                    shcol(shcol_), nlev(nlev_), nlevi(nlevi_), nadv(nadv_),
+                    num_qtracers(num_qtracers_), dtime(dtime_), nbot_shoc(nbot_shoc_), ntop_shoc(ntop_shoc_) {}
 
-  PTD_STD_DEF(ShocMainData, 6, shcol, nlev, nlevi, num_qtracers, dtime, nadv);
+  PTD_STD_DEF(ShocMainData, 8, shcol, nlev, nlevi, num_qtracers, dtime, nadv, nbot_shoc, ntop_shoc);
 };
 
 struct PblintdHeightData : public PhysicsTestData {
@@ -947,6 +962,7 @@ void diag_second_shoc_moments                       (DiagSecondShocMomentsData& 
 void compute_shoc_vapor                             (ComputeShocVaporData& d);
 void update_prognostics_implicit                    (UpdatePrognosticsImplicitData& d);
 void shoc_main                                      (ShocMainData& d);
+void shoc_main_with_init                            (ShocMainData& d);
 void pblintd_height                                 (PblintdHeightData& d);
 void vd_shoc_decomp_and_solve                       (VdShocDecompandSolveData& d);
 void pblintd_surf_temp(PblintdSurfTempData& d);
@@ -1036,7 +1052,8 @@ void isotropic_ts_f(Int nlev, Int shcol, Real* brunt_int, Real* tke,
                     Real* a_diss, Real* brunt, Real* isotropy);
 void dp_inverse_f(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_zt);
 
-void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* host_dx, Real* host_dy, Real* thv,
+int shoc_init_f(Int nlev, Real* pref_mid, Int nbot_shoc, Int ntop_shoc);
+void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, Real* host_dx, Real* host_dy, Real* thv,
                  Real* zt_grid, Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc,
                  Real* uw_sfc, Real* vw_sfc, Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner,
                  Real* phis, Real* host_dse, Real* tke, Real* thetal, Real* qw, Real* u_wind, Real* v_wind,

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -47,6 +47,32 @@ contains
     npbl = nlev ! set pbl layer explicitly so we don't need pref_mid.
   end subroutine shoc_init_c
 
+  ! shoc_init for shoc_main_bfb testing
+  subroutine shoc_init_for_main_bfb_c(nlev, gravit, rair, rh2o, cpair, &
+                                      zvir, latvap, latice, karman,pref_mid,&
+                                      nbot_shoc, ntop_shoc) bind(c)
+    use shoc, only: shoc_init, npbl
+
+    integer(kind=c_int), value, intent(in) :: nlev ! number of levels
+    integer(kind=c_int), value, intent(in) :: nbot_shoc ! Bottom level to which SHOC is applied
+    integer(kind=c_int), value, intent(in) :: ntop_shoc ! Top level to which SHOC is applied
+
+    real(kind=c_real), value, intent(in)  :: gravit ! gravity
+    real(kind=c_real), value, intent(in)  :: rair   ! dry air gas constant
+    real(kind=c_real), value, intent(in)  :: rh2o   ! water vapor gas constant
+    real(kind=c_real), value, intent(in)  :: cpair  ! specific heat of dry air
+    real(kind=c_real), value, intent(in)  :: zvir   ! rh2o/rair - 1
+    real(kind=c_real), value, intent(in)  :: latvap ! latent heat of vaporization
+    real(kind=c_real), value, intent(in)  :: latice ! latent heat of fusion
+    real(kind=c_real), value, intent(in)  :: karman ! Von Karman's constant
+
+    real(kind=c_real), intent(in), dimension(nlev) :: pref_mid ! reference pressures at midpoints
+    call shoc_init(nlev, gravit, rair, rh2o, cpair, &
+                   zvir, latvap, latice, karman, &
+                   pref_mid, nbot_shoc, ntop_shoc)
+  end subroutine shoc_init_for_main_bfb_c
+
+
   subroutine shoc_main_c(shcol,nlev,nlevi,dtime,nadv,host_dx, host_dy, thv,  &
      zt_grid, zi_grid, pres, presi, pdel, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, &
      wtracer_sfc, num_qtracers, w_field, exner,phis, host_dse, tke, thetal,  &

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -434,10 +434,10 @@ subroutine dp_inverse_f(nlev, shcol, rho_zt, dz_zt, rdp_zt) bind(C)
   real(kind=c_real), intent(out) :: rdp_zt(shcol,nlev)
 end subroutine dp_inverse_f
 
-  subroutine shoc_main_f(shcol, nlev, nlevi, dtime, nadv, host_dx, host_dy, thv, zt_grid, zi_grid, pres, presi, pdel, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, wtracer_sfc, num_qtracers, w_field, exner, phis, host_dse, tke, thetal, qw, u_wind, v_wind, qtracers, wthv_sec, tkh, tk, shoc_ql, shoc_cldfrac, pblh, shoc_mix, isotropy, w_sec, thl_sec, qw_sec, qwthl_sec, wthl_sec, wqw_sec, wtke_sec, uw_sec, vw_sec, w3, wqls_sec, brunt, shoc_ql2) bind(C)
+  subroutine shoc_main_f(shcol, nlev, nlevi, dtime, nadv, npbl, host_dx, host_dy, thv, zt_grid, zi_grid, pres, presi, pdel, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, wtracer_sfc, num_qtracers, w_field, exner, phis, host_dse, tke, thetal, qw, u_wind, v_wind, qtracers, wthv_sec, tkh, tk, shoc_ql, shoc_cldfrac, pblh, shoc_mix, isotropy, w_sec, thl_sec, qw_sec, qwthl_sec, wthl_sec, wqw_sec, wtke_sec, uw_sec, vw_sec, w3, wqls_sec, brunt, shoc_ql2) bind(C)
     use iso_c_binding
 
-    integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi, nadv, num_qtracers
+    integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi, nadv, num_qtracers, npbl
     real(kind=c_real) , value, intent(in) :: dtime
     real(kind=c_real) , intent(in), dimension(shcol) :: host_dx, host_dy, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, phis
     real(kind=c_real) , intent(in), dimension(shcol, nlev) :: thv, zt_grid, pres, pdel, w_field, exner

--- a/components/scream/src/physics/shoc/shoc_main_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_main_impl.hpp
@@ -369,8 +369,6 @@ Int Functions<S,D>::shoc_main(
     const auto X1_s       = Kokkos::subview(X1_d, i, Kokkos::ALL(), Kokkos::ALL());
     const auto qtracers_s = Kokkos::subview(shoc_input_output.qtracers, i, Kokkos::ALL(), Kokkos::ALL());
 
-                         std::cout << npbl << std::endl;
-
     shoc_main_internal(team, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
                        host_dx_s, host_dy_s, zt_grid_s, zi_grid_s,             // Input
                        pres_s, presi_s, pdel_s, thv_s, w_field_s,              // Input

--- a/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
@@ -147,7 +147,7 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
       }
     }
     // Initialize data structure for bridging to F90
-    ShocMainData SDS(shcol,nlev,nlevi,num_qtracers,dtime,nadv);
+    ShocMainData SDS(shcol,nlev,nlevi,num_qtracers,dtime,nadv,0,0);
 
     // Test the inputs are good
     REQUIRE(SDS.shcol == shcol);
@@ -317,19 +317,43 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
   static void run_bfb()
   {
     ShocMainData f90_data[] = {
-      // shcol, nlev, nlevi, num_qtracers, dtime, nadv
-      ShocMainData(12, 72, 73,  5, 5, 15),
-      ShocMainData(8,  12, 13,  3, 6, 10),
-      ShocMainData(7,  16, 17,  3, 1,  1),
-      ShocMainData(2,   7,  8,  2, 1,  5)
+      // shcol, nlev, nlevi, num_qtracers, dtime, nadv, nbot_shoc, ntop_shoc(C++ indexing)
+      ShocMainData(12, 72, 73,  5, 5, 15, 72, 0),
+      ShocMainData(8,  12, 13,  3, 6, 10, 8, 3),
+      ShocMainData(7,  16, 17,  3, 1,  1, 12, 0),
+      ShocMainData(2,   7,  8,  2, 1,  5, 7, 4)
     };
 
+    static constexpr Int num_runs = sizeof(f90_data) / sizeof(ShocMainData);
+
     // Generate random input data
+    int count = 0;
     for (auto& d : f90_data) {
+
+      // 3 types of pref_mid ranges:
+      std::pair<Real,Real> pref_mid_range;
+      if (count == 0) {
+        // all(pref_mid) >= pblmaxp
+        pref_mid_range.first  = 1e5;
+        pref_mid_range.second = 8e5;
+      }
+      else if (count == 1) {
+        // all(pref_mid) < pblmaxp
+        pref_mid_range.first  = 1e3;
+        pref_mid_range.second = 8e3;
+      }
+      else {
+        // both pref_mid >= pblmaxp and pref_mid < pblmaxp values
+        pref_mid_range.first  = 1e4;
+        pref_mid_range.second = 8e4;
+      }
+      ++count;
+
       d.randomize({{d.presi, {700e2,1000e2}},
                    {d.tkh, {3,20}},
                    {d.wthl_sfc, {-1,1}},
-                   {d.thetal, {900, 1000}}});
+                   {d.thetal, {900, 1000}},
+                   {d.pref_mid, pref_mid_range}});
 
       // Generate grid as decreasing set of points.
       // Allows interpolated values to stay withing
@@ -364,13 +388,15 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
     // Get data from fortran
     for (auto& d : f90_data) {
       // expects data in C layout
-      shoc_main(d);
+      shoc_main_with_init(d);
     }
 
     // Get data from cxx
     for (auto& d : cxx_data) {
       d.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
-      shoc_main_f(d.shcol, d.nlev, d.nlevi, d.dtime, d.nadv, d.host_dx, d.host_dy,
+      const int npbl = shoc_init_f(d.nlev, d.pref_mid, d.nbot_shoc, d.ntop_shoc);
+
+      shoc_main_f(d.shcol, d.nlev, d.nlevi, d.dtime, d.nadv, npbl, d.host_dx, d.host_dy,
                   d.thv, d.zt_grid, d.zi_grid, d.pres, d.presi, d.pdel, d.wthl_sfc,
                   d.wqw_sfc, d.uw_sfc, d.vw_sfc, d.wtracer_sfc, d.num_qtracers,
                   d.w_field, d.exner, d.phis, d.host_dse, d.tke, d.thetal, d.qw,
@@ -383,7 +409,6 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
 
     // Verify BFB results, all data should be in C layout
 #ifndef NDEBUG
-    static constexpr Int num_runs = sizeof(f90_data) / sizeof(ShocMainData);
     for (Int i = 0; i < num_runs; ++i) {
       ShocMainData& d_f90 = f90_data[i];
       ShocMainData& d_cxx = cxx_data[i];


### PR DESCRIPTION
Ports `shoc_init()` to calculate `npbl` for `shoc_main()`.

In shoc.F90, `npbl` is a global index, not an output of `shoc_init()`. For bfb testing purposes, I just included `shoc_init()` in the `shoc_main_bfb` test and made sure to hit each of the main scenarios, namely `npbl = 1`, `npbl = nlev`, `1 < npbl < nlev`.