### PR TITLE
test-all-scream: Add valgrind mode

### DIFF
--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -109,6 +109,8 @@ class TestAllScream(object):
                      ("SCREAM_SMALL_PACK_SIZE", "1"),
                      ("EKAT_DEFAULT_BFB", "True")],
             "opt" : [("CMAKE_BUILD_TYPE", "Release")],
+            "valg" : [("CMAKE_BUILD_TYPE", "Debug"),
+                      ("EKAT_ENABLE_VALGRIND", "True")],
         }
 
         self._test_full_names = OrderedDict([
@@ -116,11 +118,13 @@ class TestAllScream(object):
             ("sp"  , "full_sp_debug"),
             ("fpe" , "debug_nopack_fpe"),
             ("opt" , "release"),
+            ("valg" , "valgrind"),
         ])
 
         if not self._tests:
             # default to all test types except do not do fpe on CUDA
             self._tests = list(self._test_full_names.keys())
+            self._tests.remove("valg") # don't want this on by default
             if is_cuda_machine(self._machine):
                 self._tests.remove("fpe")
         else:
@@ -232,6 +236,7 @@ class TestAllScream(object):
             "sp"  : ctest_max_jobs,
             "fpe" : ctest_max_jobs,
             "opt" : ctest_max_jobs,
+            "valg" : ctest_max_jobs,
         }
 
         # Deduce how many compilation resources per test
@@ -247,6 +252,7 @@ class TestAllScream(object):
             "sp"  : make_max_jobs,
             "fpe" : make_max_jobs,
             "opt" : make_max_jobs,
+            "valg" : make_max_jobs,
         }
 
         if self._parallel:


### PR DESCRIPTION
Current status on mappy: a valg test takes about 24 minutes on mappy and the following tests fail:

```
	 12 - homme_pd_remap_ut_np1_omp1 (Failed)
	 13 - homme_pd_remap_ut_np2_omp1 (Failed)
	 14 - homme_pd_remap_ut_np3_omp1 (Failed)
	 15 - homme_pd_remap_ut_np4_omp1 (Failed)
	 52 - shoc_tests_ut_np1_omp1 (Failed)
	 53 - shoc_tests_ut_np1_omp2 (Failed)
	 54 - shoc_tests_ut_np1_omp3 (Failed)
	 55 - shoc_tests_ut_np1_omp4 (Failed)
	 56 - shoc_tests_ut_np1_omp5 (Failed)
	 57 - shoc_tests_ut_np1_omp6 (Failed)
	 58 - shoc_tests_ut_np1_omp7 (Failed)
	 59 - shoc_tests_ut_np1_omp8 (Failed)
	 60 - shoc_tests_ut_np1_omp9 (Failed)
	 61 - shoc_tests_ut_np1_omp10 (Failed)
	 62 - shoc_tests_ut_np1_omp11 (Failed)
	 63 - shoc_tests_ut_np1_omp12 (Failed)
	 64 - shoc_tests_ut_np1_omp13 (Failed)
	 65 - shoc_tests_ut_np1_omp14 (Failed)
	 66 - shoc_tests_ut_np1_omp15 (Failed)
	 67 - shoc_tests_ut_np1_omp16 (Failed)
	 68 - shoc_run_and_cmp_cxx_ut_np1_omp16 (Failed)
	 72 - homme_stand_alone_ut_np1_omp1 (Failed)
	 73 - p3_stand_alone_ut_np1_omp1 (Failed)
	 75 - shoc_stand_alone_ut_np1_omp1 (Failed)
```