### PR TITLE
hotfix to handle bug that with shoc_init being declared as a KOKKOS_FUNCTION

### DIFF
--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -573,7 +573,6 @@ struct Functions
     const uview_1d<const Spack>& dz_zt,
     const uview_1d<Spack>&       rdp_zt);
 
-  KOKKOS_FUNCTION
   static Int shoc_init(
     const Int&                  nbot_shoc,
     const Int&                  ntop_shoc,


### PR DESCRIPTION
This is a hotfix to the function shoc_init that caused a build error when using the LC machine lassen.