### PR TITLE
Some updates to scream scripts

### DIFF
--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -2,7 +2,7 @@ from utils import run_cmd_no_fail
 
 import os, pathlib
 import concurrent.futures as threading3
-from machines_specs import get_mach_env_setup_command, get_mach_batch_command, get_mach_testing_resources, \
+from machines_specs import get_mach_env_setup_command, get_mach_batch_command, \
                            get_mach_cxx_compiler, get_mach_f90_compiler, get_mach_c_compiler
 
 ###############################################################################

--- a/components/scream/scripts/gather_all_data.py
+++ b/components/scream/scripts/gather_all_data.py
@@ -3,7 +3,7 @@ from utils import run_cmd_no_fail
 import os, pathlib
 import concurrent.futures as threading3
 from machines_specs import get_mach_env_setup_command, get_mach_batch_command, get_mach_testing_resources, \
-                           get_mach_cxx_compiler, get_mach_f90_compiler, get_mach_c_compiler, is_cuda_machine
+                           get_mach_cxx_compiler, get_mach_f90_compiler, get_mach_c_compiler
 
 ###############################################################################
 class GatherAllData(object):
@@ -30,7 +30,6 @@ class GatherAllData(object):
         c_compiler   = get_mach_c_compiler(machine)
         batch        = get_mach_batch_command(machine)
 
-        env_setup.append("CTEST_PARALLEL_LEVEL={}".format(get_mach_testing_resources(machine)))
         env_setup_str = " && ".join(env_setup)
 
         root_dir = pathlib.Path(str(self._root_dir).replace("$machine", machine))
@@ -79,13 +78,10 @@ class GatherAllData(object):
             setup = "cd {} && git fetch && git reset --hard origin/master && git submodule update --init --recursive && "\
                 .format(scream_repo)
 
-        extra_env = ""
-        if not is_cuda_machine(machine):
-            extra_env = "OMP_PROC_BIND=spread "
-
         repo_setup = "true" if (self._local) else "git fetch && git checkout {} && git submodule update --init --recursive".format(self._commit)
 
-        cmd = "{}cd {} && {} && {} && {}{} {}".format(setup, repo, env_setup_str, repo_setup, extra_env, batch, local_cmd)
+        cmd = "{setup}cd {repo} && {env_setup} && {repo_setup} && {batch} {local_cmd}".\
+              format(setup=setup, repo=repo, env_setup=env_setup_str, repo_setup=repo_setup, batch=batch, local_cmd=local_cmd)
 
         return cmd
 

--- a/components/scream/scripts/scream-env-cmd
+++ b/components/scream/scripts/scream-env-cmd
@@ -46,7 +46,9 @@ OR
 ###############################################################################
 def dump_scream_env(mach):
 ###############################################################################
-    print(" && ".join(get_mach_env_setup_command(mach)))
+    commands = get_mach_env_setup_command(mach)
+    print(" && ".join(commands))
+    print("\n".join(commands), file=sys.stderr)
 
 ###############################################################################
 def _main_func(description):

--- a/components/scream/scripts/scripts-tests
+++ b/components/scream/scripts/scripts-tests
@@ -17,7 +17,7 @@ If you are on a batch machine, it is expected that you are on a compute node.
 TODO: Add doctests to libs
 """
 
-from utils import run_cmd, check_minimum_python_version, expect
+from utils import run_cmd, check_minimum_python_version, expect, get_current_head
 check_minimum_python_version(3, 4)
 
 from machines_specs import is_machine_supported, is_cuda_machine, get_all_supported_machines
@@ -62,6 +62,8 @@ def run_cmd_store_output(test_obj, cmd, output_file):
 ###############################################################################
     output_file.parent.mkdir(parents=True, exist_ok=True)
     output = run_cmd_assert_result(test_obj, cmd, from_dir=TEST_DIR)
+    head = get_current_head()
+    output = output.replace(head, "CURRENT_HEAD_NORMALIZED")
     output_file.write_text(output)
 
 ###############################################################################
@@ -69,6 +71,8 @@ def run_cmd_check_baseline(test_obj, cmd, baseline_path):
 ###############################################################################
     test_obj.assertTrue(baseline_path.is_file(), msg="Missing baseline {}".format(baseline_path))
     output = run_cmd_assert_result(test_obj, cmd, from_dir=TEST_DIR)
+    head = get_current_head()
+    output = output.replace(head, "CURRENT_HEAD_NORMALIZED")
     diff = difflib.unified_diff(
         baseline_path.read_text().splitlines(),
         output.splitlines(),

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -73,10 +73,24 @@ class TestAllScream(object):
         else:
             expect (not self._local, "Specifying a machine while passing '-l,--local' is ambiguous.")
 
+        ##################################################
+        #   Deduce how many testing resources per test   #
+        ##################################################
+
+        if ctest_parallel_level > 0:
+            ctest_max_jobs = ctest_parallel_level
+            print("Note: honoring requested value for ctest parallel level: {}".format(ctest_max_jobs))
+        elif "CTEST_PARALLEL_LEVEL" in os.environ:
+            ctest_max_jobs = int(os.environ["CTEST_PARALLEL_LEVEL"])
+            print("Note: honoring environment value for ctest parallel level: {}".format(ctest_max_jobs))
+        else:
+            ctest_max_jobs = get_mach_testing_resources(self._machine)
+            print("Note: no value passed for --ctest-parallel-level. Using the default for this machine: {}".format(ctest_max_jobs))
+
         # Unless the user claims to know what he/she is doing, we setup the env.
         if not self._preserve_env:
             # Setup the env on this machine
-            setup_mach_env(self._machine)
+            setup_mach_env(self._machine, ctest_j=ctest_max_jobs)
 
         # Compute root dir
         if not self._root_dir:
@@ -216,20 +230,6 @@ class TestAllScream(object):
 
         if self._must_generate_baselines:
             print("Using commit {} to generate baselines".format(self._baseline_ref))
-
-        ##################################################
-        #   Deduce how many testing resources per test   #
-        ##################################################
-
-        if ctest_parallel_level > 0:
-            ctest_max_jobs = ctest_parallel_level
-            print("Note: honoring requested value for ctest parallel level: {}".format(ctest_max_jobs))
-        elif "CTEST_PARALLEL_LEVEL" in os.environ:
-            ctest_max_jobs = int(os.environ["CTEST_PARALLEL_LEVEL"])
-            print("Note: honoring environment value for ctest parallel level: {}".format(ctest_max_jobs))
-        else:
-            ctest_max_jobs = get_mach_testing_resources(self._machine)
-            print("Note: no value passed for --ctest-parallel-level. Using the default for this machine: {}".format(ctest_max_jobs))
 
         self._testing_res_count = {
             "dbg" : ctest_max_jobs,


### PR DESCRIPTION
Main change: Fully encapsulte env considerations in get_mach_env_setup_command  …

Some settings like OMP_PROC_BIND and CTEST_PARALLEL_LEVEL were not
being handled by this function. Now that they are, this increases the
usefullness of scream-env-cmd and improves the overall coherence of
tools.

Other changes:
* scripts-tests baseline normalization so that changes in HEAD's name do not cause diffs
* some cleanup of repeated code in machines_specs