### PR TITLE
Some valgrind fixes

### DIFF
--- a/components/scream/src/dynamics/homme/interface/phys_grid_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/phys_grid_mod.F90
@@ -28,6 +28,9 @@ module phys_grid_mod
 
   logical :: is_phys_grid_inited = .false.
 
+! To get MPI_IN_PLACE and MPI_DATATYPE_NULL
+#include <mpif.h>
+
 contains
 
   subroutine check_phys_grid_inited ()
@@ -230,7 +233,10 @@ contains
       enddo
 
       ! Gather all the other dofs
-      call MPI_Allgatherv( dofs_l, ncols, MPIinteger_t, &
+      ! Note: using MPI_IN_PLACE,0,MPI_DATATYPE_NULL for the src array
+      !       informs MPI that src array is aliasing the dst one, so
+      !       MPI will grab the src part from dst, using the offsets info
+      call MPI_Allgatherv( MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
                            dofs_g, g_ncols, g_offsets, MPIinteger_t, par%comm, ierr)
     endif
 
@@ -272,7 +278,10 @@ contains
       enddo
 
       ncols = get_num_local_columns()
-      call MPI_Allgatherv(area_l, ncols, MPIreal_t, &
+      ! Note: using MPI_IN_PLACE,0,MPI_DATATYPE_NULL for the src array
+      !       informs MPI that src array is aliasing the dst one, so
+      !       MPI will grab the src part from dst, using the offsets info
+      call MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
                           area_g, g_ncols, g_offsets, MPIreal_t, &
                           par%comm, ierr)
     endif
@@ -321,10 +330,13 @@ contains
 
       ncols = get_num_local_columns()
 
-      call MPI_Allgatherv(lat_l, ncols,   MPIreal_t, &
+      ! Note: using MPI_IN_PLACE,0,MPI_DATATYPE_NULL for the src array
+      !       informs MPI that src array is aliasing the dst one, so
+      !       MPI will grab the src part from dst, using the offsets info
+      call MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
                           lat_g, g_ncols, g_offsets, MPIreal_t, &
                           par%comm, ierr)
-      call MPI_Allgatherv(lon_l, ncols, MPIreal_t, &
+      call MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
                           lon_g, g_ncols, g_offsets, MPIreal_t, &
                           par%comm, ierr)
     end if

--- a/components/scream/src/physics/shoc/shoc_compute_brunt_shoc_length_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_brunt_shoc_length_impl.hpp
@@ -26,7 +26,7 @@ void Functions<S,D>::compute_brunt_shoc_length(
     Spack thv_zi_k, thv_zi_kp1;
     auto range_pack1 = ekat::range<IntSmallPack>(k*Spack::n);
     auto range_pack2 = range_pack1;
-    range_pack2.set(range_pack1 >= nlevi, 1);
+    range_pack2.set(range_pack1 >= (nlevi-1), nlevi-2);
     ekat::index_and_shift<1>(s_thv_zi, range_pack2, thv_zi_k, thv_zi_kp1);
 
     brunt(k) = (ggr/thv(k))*(thv_zi_k-thv_zi_kp1)/dz_zt(k);

--- a/components/scream/src/physics/shoc/shoc_grid_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_grid_impl.hpp
@@ -45,16 +45,18 @@ void Functions<S,D>::shoc_grid(
     auto range_pack_m1 = range_pack;
     // index for _km1 should never go below 0
     range_pack_m1.set(range_pack < 1, 1);
+    // and index for kp1 should never go above nlevi-1
+    range_pack.set(range_pack>=(nlevi-1),nlevi-2);
 
-    ekat::index_and_shift<1>(s_zi_grid, range_pack, zi_grid_k, zi_grid_kp1);
+    ekat::index_and_shift< 1>(s_zi_grid, range_pack,    zi_grid_k, zi_grid_kp1);
     ekat::index_and_shift<-1>(s_zt_grid, range_pack_m1, zt_grid_k, zt_grid_km1);
 
     // Define thickness of the thermodynamic gridpoints
     dz_zt(k) = zi_grid_k - zi_grid_kp1;
 
     // Define thickness of the interface grid points
+    dz_zi(k) = zt_grid_km1 - zt_grid_k;
     dz_zi(k).set(range_pack == 0, 0);
-    dz_zi(k).set(range_pack > 0, zt_grid_km1 - zt_grid_k);
 
     // Define the air density on the thermo grid
     rho_zt(k) = (1/ggr)*(pdel(k)/dz_zt(k));

--- a/components/scream/src/physics/shoc/shoc_linear_interp_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_linear_interp_impl.hpp
@@ -31,8 +31,13 @@ void Functions<S,D>::linear_interp(
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team, km2_pack), [&] (const Int& k2) {
       Spack x1, x1s, y1, y1s; // s->-1 shift
       auto indx_pack = ekat::range<IntSmallPack>(k2*Spack::n + 1);
+
+      // Avoid reading out of bounds for x1/y1
+      indx_pack.set(indx_pack>=km1, km1-1);
+
       ekat::index_and_shift<-1>(sx1, indx_pack, x1, x1s);
       ekat::index_and_shift<-1>(sy1, indx_pack, y1, y1s);
+
       y2(k2) = y1s + (y1-y1s)*(x2(k2)-x1s)/(x1-x1s);
     });
   }
@@ -47,7 +52,7 @@ void Functions<S,D>::linear_interp(
       Spack x1, x1s, y1, y1s; // s->-1 shift
       auto indx_pack = ekat::range<IntSmallPack>(k2*Spack::n);
       indx_pack.set(indx_pack < 1, 1); // special shift for 0 boundary case
-      indx_pack.set(indx_pack == km2-1, km1-1); // special shift for top boundary case
+      indx_pack.set(indx_pack >= km2-1, km1-1); // special shift for top boundary case
       ekat::index_and_shift<-1>(sx1, indx_pack, x1, x1s);
       ekat::index_and_shift<-1>(sy1, indx_pack, y1, y1s);
 

--- a/components/scream/src/physics/shoc/shoc_pblintd_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_pblintd_impl.hpp
@@ -61,7 +61,7 @@ void Functions<S,D>::pblintd(
   // Define temporary variables
   uview_1d<Spack> rino, thv;
   workspace.template take_many_contiguous_unsafe<2>(
-    {"rino", "rino"},
+    {"rino", "thv"},
     {&rino, &thv});
 
   const auto nlev_v = (nlev-1)/Spack::n;


### PR DESCRIPTION
This PR tries to remove some valgrind errors we see in our nightlies. It requires #E3SM-Project/EKAT90 to be merged first, so that I can update the ekat module to get those mods in, which is why I'm marking this as WIP for now.

So far, I removed a valgrind error in dynamics related to MPI, and a few in shoc related to the handling of boundaries during column differences (meaning computing stuff like `dz(k)=z(k+1)-z(k)`). But there are still more.