### PR TITLE
Add README for scripts

### DIFF
--- a/components/scream/README.md
+++ b/components/scream/README.md
@@ -21,3 +21,5 @@ For information about building SCREAM and running its tests, see
 
 You can also take a brief [tour of SCREAM's source tree](docs/source-tree.md).
 
+SCREAM comes with a python-based set of tools that compliments the CIME tool
+suite and also works with standalone SCREAM. See scripts/README.md for more.

--- a/components/scream/scripts/README.md
+++ b/components/scream/scripts/README.md
@@ -1,0 +1,90 @@
+# The SCREAM toolsuite
+
+This directory contains a python3-based set of tools for SCREAM that compliments the CIME tool
+suite and also works with standalone SCREAM. This document will list our tools, roughly in order
+of importance, along with a brief description. For more info on a tool, run it with `--help`. We will
+always strive to have an informative help dump that contains detailed info on a tool's purpose, args/options,
+and some example usages.
+
+## test-all-scream
+
+test-all-scream is our core testing script for standalone SCREAM. When developing on a branch, if this script
+runs successfully with the default options, then your branch can be considered to work on the current machine.
+When a PR is issued, our continuous integration will run this script (via gather-all-data (see below)) on your
+branch on all our core testing machines. If all those tests pass, then your PR will be eligible for merging.
+
+Because this tool is the foundation of our CI testing, you should always expect this tool to work correctly
+and have up-to-date documentation.
+
+## gather-all-data
+
+A tool for dispatching jobs to machines, loading the SCREAM env, and doing batch submissions. This tool is
+usually used to get test-all-scream jobs running on compute nodes on machines, but it can be used to run
+anything you want. Our CI system uses this tool to run test-all-scream. We have used this tool in the past
+to relatively easily gather performance data for SCREAM across all the platforms we care about with a single command.
+
+Because this tool is used in our CI testing, you should always expect this tool to work correctly
+and have up-to-date documentation.
+
+## scripts-tests
+
+A test suite for this toolsuite. This should be used for any significant developments to the core testing scritpts
+(test-all-scream or gather-all-data). This suite is NOT run by our CI system, so it's up to our toolsuite developers
+to remember to run this.
+
+Because this testsuite is used in developing our core test scripts, you should always expect this testsuite to pass
+and have up-to-date documentation.
+
+## scream-env-cmd
+
+A scream analog for modulecmd, a tool for dumping shell commands that would load the SCREAM approved env for
+your machine. Designed for easy integration with bash functions for easy loading of env.
+
+This tool is not used in our core testing tools, but it is simple and actively used by some of our developers
+when they work on various machines. It leverages the machines_specs.py library which is essential for the entire
+toolsuite and actively maintained, so you should expect this to tool work and load the correct env.
+
+## perf-analysis
+
+The tool we use to gather performance data for SCREAM. It supports scaling experiments, run repitition to reduce
+noise, and plot-friendly output among other features. The raw data for many of the plots used in SCREAM presentatons
+was generated with this tool.
+
+This tool is not used in our core testing tools and we only occassionally do major perfomance analysis on our code,
+so this tool can fall into minor disrepair.
+
+## plot
+
+The tool we use to plot performance data from perf-analysis. It
+supports a variety of options for color selection, line formatting
+customizations (bold, dashed, etc), font size, etc.
+
+This tool is not used in our core testing tools and we only occassionally do major perfomance analysis on our code,
+so this tool can fall into minor disrepair.
+
+## const-maker
+
+A tool for generating CXX and F90 source code for constant definitions where the constant is derived from
+a mathematical forumla. This is necessary because cxx constexprs don't always allow for math calls in the
+definition of the constant.
+
+This tool is not used in our core testing tools, but it is extremely simple and not coupled to anything else in the repo,
+so it should be expected to work.
+
+## gen-boiler
+
+A tool for parsing fortran source files and generating boilerplate for bridging, testing, etc. This is intended to be
+used in the situation where we are porting a fortran reference code to CXX like we did for P3 and SHOC.
+
+This tool is not used in our core testing tools and goes through long periods of time where it does not get used much
+(IE there are no active ongoing porting efforts). It is likely this tool will not work exactly as expected if it
+has not been run in a while or is being used on a package on which it has not been used before.
+
+## cf-xml-to-yaml
+
+Given an XML file containing the CF conventions for standardized field names
+(https://cfconventions.org/standard-names.html), this tool generates a YAML
+file with the same information.
+
+This tool is not used in our core testing tools, but it is extremely simple and not coupled to anything else in the repo,
+so it should be expected to work.

--- a/components/scream/scripts/cf-xml-to-yaml
+++ b/components/scream/scripts/cf-xml-to-yaml
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 """
 Given an XML file containing the CF conventions for standardized field names
@@ -8,10 +8,36 @@ file with the same information.
 Usage: cf-xml-to-yaml <cf-xml-file>
 """
 
-import sys, os
+import sys, os, argparse
 from math import *
 
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n{0} <xmlfile>
+OR
+{0} --help
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Convert FILE to YAML \033[0m
+    > {0} FILE
+""".format(os.path.basename(args[0])),
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("xmlfile",
+                        help="The path to the xml file. Expects a .xml extension. "
+                        "The YAML output file will be the same except using a .yaml extension")
+
+    args = parser.parse_args(args[1:])
+
+    return args
+
+###############################################################################
 class Entry:
+###############################################################################
     def __init__(self, id=None, units="", description=""):
         self.id = id
         self.units = units
@@ -66,18 +92,23 @@ def write_cf_yaml(entries, yaml_file):
             f.write('\n\n')
 
 ###############################################################################
-def main(description):
+def cf_xml_to_yaml(xmlfile):
 ###############################################################################
-    if len(sys.argv) < 2:
-        print(description)
-        exit(1)
-
     xml_file = sys.argv[1]
     yaml_file = xml_file.replace('.xml', '.yaml')
     entries = parse_cf_xml(xml_file)
     write_cf_yaml(entries, yaml_file)
 
+    return True
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    success = cf_xml_to_yaml(**vars(parse_command_line(sys.argv, description)))
+
+    sys.exit(0 if success else 1)
+
 ###############################################################################
 
 if (__name__ == "__main__"):
-    main(__doc__)
+    _main_func(__doc__)

--- a/components/scream/scripts/const-maker
+++ b/components/scream/scripts/const-maker
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 """
 Take a math expression not handled well by C++11 constexpr and produce a
@@ -45,7 +45,7 @@ def const_maker(varname, expr):
     s = "real(rtype), public, parameter :: {} = {:22.15e} ! {}".format(varname, val, expr)
     s = s.replace('e+','d+')
     s = s.replace('e-','d-')
-    print s
+    print(s)
 
     print("C++:")
     print("static constexpr Scalar {} = {:22.15e}; // {}".format(varname, val, expr))

--- a/components/scream/scripts/gather-all-data
+++ b/components/scream/scripts/gather-all-data
@@ -38,10 +38,10 @@ OR
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Test scream on all platforms \033[0m
-    > {0} './scripts/test-all-scream --cxx-compiler $cxx_compiler --f90-compiler $f90_compiler -m $machine'
+    > {0} './scripts/test-all-scream -m $machine'
 
     \033[1;32m# Do correctness testing locally for SCREAM (expects ./scream and ./scream-docs) \033[0m
-    > {0} './scripts/test-all-scream --cxx-compiler $cxx_compiler --f90-compiler $f90_compiler -m $machine' -l -m $machine
+    > {0} './scripts/test-all-scream -m $machine' -l -m $machine
 
     \033[1;32m# Do correctness testing for scream-docs micro apps \033[0m
     > {0} './test-all $cxx_compiler $kokkos' -o

--- a/components/scream/scripts/perf-analysis
+++ b/components/scream/scripts/perf-analysis
@@ -23,13 +23,19 @@ OR
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run p3 ref with 1 horizontal and 111 vertical columns over 300s with 30s timesteps and 10 internal repitions \033[0m
-    > {0} ni:1 nk:111 dt:30 ts:10 kdir:1 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=ref:"micro-sed/p3_ref"
+    > {0} ni:1 nk:111 dt:30 ts:10 kdir:1 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=ref:"micro-sed/p3_ref" -d
 
     \033[1;32m# Run p3 ref comparing against p3 vanilla with same params as above except scaling ni to 1024  \033[0m
-    > {0} ni:1 nk:111 dt:30 ts:10 kdir:1 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=ref:"micro-sed/p3_ref" --test=vanilla:"micro-sed/p3_vanilla" -s ni:2:1024
+    > {0} ni:1 nk:111 dt:30 ts:10 kdir:1 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=ref:"micro-sed/p3_ref" --test=vanilla:"micro-sed/p3_vanilla" -s ni:2:1024 -d
 
     \033[1;32m# Run lin-interp ref comparing against lin-interp vanilla scaling from ncol=1000 to 128,000 \033[0m
-    > {0} ncol:1000 km1:128 km2:256 minthresh:0.001 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=ref:lin-interp/li_ref --test=vanilla:lin-interp/li_vanilla -s ncol:2:128000
+    > {0} ncol:1000 km1:128 km2:256 minthresh:0.001 repeat:10 --kokkos=/home/jgfouca/kokkos-install/install --test=ref:lin-interp/li_ref --test=vanilla:lin-interp/li_vanilla -s ncol:2:128000 -d
+
+    \033[1;32m# Run main SCREAM P3 scaling from ncol=64 to 8192, doubling ncol \033[0m
+    > {0} ni:64 --test=ref:"src/physics/p3/tests/p3_run_and_cmp_cxx -r 10 -s 30 -i NI -p yes -c yes foo" -s ni:2:8192 --cd
+
+    \033[1;32m# Run main SCREAM SHOC scaling from ncol=64 to 8192, doubling ncol \033[0m
+    > {0} ni:64 --test=ref:"src/physics/shoc/tests/shoc_run_and_cmp_cxx -r 10 -s 30 -i NI foo" -s ni:2:8192 --cd
 """.format(os.path.basename(args[0])),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -40,6 +46,10 @@ OR
     parser.add_argument("--kokkos", help="Kokkos location")
 
     parser.add_argument("--cxx", default=os.getenv("MPICXX"), help="c++ compiler")
+
+    parser.add_argument("--cc", default=os.getenv("MPICC"), help="c compiler")
+
+    parser.add_argument("--f90", default=os.getenv("MPIF90"), help="f90 compiler")
 
     parser.add_argument("-n", "--num-runs", type=int, default=1, help="Number of times to repeat run")
 
@@ -80,6 +90,12 @@ OR
     if args.cxx:
         args.cmake_options += " -DCMAKE_CXX_COMPILER={}".format(args.cxx)
 
+    if args.cc:
+        args.cmake_options += " -DCMAKE_C_COMPILER={}".format(args.cc)
+
+    if args.f90:
+        args.cmake_options += " -DCMAKE_Fortran_COMPILER={}".format(args.f90)
+
     args.cmake_options += " -C ../cmake/machine-files/{}.cmake".format(args.machine)
 
     expect(not args.plot_friendly or args.scaling, "Doesn't make sense to have plot friendly output without a scaling experiment")
@@ -107,6 +123,8 @@ OR
     delattr(args, "scaling")
     delattr(args, "kokkos")
     delattr(args, "cxx")
+    delattr(args, "cc")
+    delattr(args, "f90")
     args.scaling_exp = scaling_exp
     args.argmap = argmap
     args.tests = testmap

--- a/components/scream/scripts/perf_analysis.py
+++ b/components/scream/scripts/perf_analysis.py
@@ -261,6 +261,8 @@ class PerfAnalysis(object):
             os.environ["OMP_NUM_THREADS"] = "96"
         elif self._machine in ["white", "weaver", "melvin"]:
             pass
+        elif self._machine == "mappy":
+            os.environ["OMP_NUM_THREADS"] = "46"
         else:
             print("WARNING: Unrecognized machine {}".format(self._machine))
 

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -3,8 +3,8 @@
 """
 Drive ctest testing of scream for a complete set of tests. This will be our
 gold standard to determine if the code is working or not on the current platform.
-
-Run from $scream-repo/components/scream
+For batch machines, this script expects to already be on a compute node; it does not
+do batch submissions.
 
 IMPORTANT: the default behavior of this script *changes your environment*,
            by loading machine-specific modules and setting machine-specific
@@ -26,18 +26,30 @@ def parse_command_line(args, description):
 OR
 {0} --help
 
-\033[1mEXAMPLES:\033[0m
-    \033[1;32m# Run all tests on current machine \033[0m
+\033[1mEXAMPLES (assumes user is on machine melvin):\033[0m
+    \033[1;32m# Run all tests on current machine using the SCREAM-approved env for this machine (this is the default env behavior) and your origin/master common ancestor for baseline generation (the default baseline behavior) \033[0m
     > cd $scream_repo/components/scream
-    > ./scripts/{0} --cxx-compiler $(which mpicxx) --f90-compiler $(which mpifort) -m melvin
+    > ./scripts/{0} -m melvin
 
-    \033[1;32m# Run all tests on current machine with custom flags *using machine's default environment* \033[0m
+    \033[1;32m# Run all tests on current machine with defaut behavior except using your current shell env \033[0m
     > cd $scream_repo/components/scream
-    > ./scripts/{0} --cxx-compiler $(which mpicxx) --f90-compiler $(which mpifort) -m melvin -c "CMAKE_CXX_FLAGS=-O1 -O2"
+    > ./scripts/{0} --preserve-env -m melvin
 
-    \033[1;32m# Run all tests on current machine with custom flags *but preserving user environment* \033[0m
+    \033[1;32m# Run all tests on current machine with default behavior except using a custom ref for baseline generation\033[0m
     > cd $scream_repo/components/scream
-    > ./scripts/{0} --cxx-compiler $(which mpicxx) --f90-compiler --preserve-env $(which mpifort) -m melvin -c "CMAKE_CXX_FLAGS=-O1 -O2"
+    > ./scripts/{0} -m melvin -b BASELINE_REF
+
+    \033[1;32m# Run all tests on current machine with default behavior except using pre-existing baselines (skips baseline generation) \033[0m
+    > cd $scream_repo/components/scream
+    > ./scripts/{0} -m melvin --baseline-dir=PATH_TO_BASELINES
+
+    \033[1;32m# Run only the dbg test on current machine with default behavior otherwise\033[0m
+    > cd $scream_repo/components/scream
+    > ./scripts/{0} -m melvin -t dbg
+
+    \033[1;32m# Run all tests on current machine with default behavior on a repo with uncommitted changes\033[0m
+    > cd $scream_repo/components/scream
+    > ./scripts/{0} -m melvin -k -b HEAD
 """.format(pathlib.Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -187,7 +187,7 @@ void Functions<S,D>
       if (do_prescribed_CCN) {
          nc(k).set(not_drymass, max(nc(k), nccn_prescribed(k)));
       } else if (predictNc) {
-         nc(k).set(not_drymass, max(nc(k) + nc_nuceat_tend(k) * dt, 0.0)); 
+         nc(k).set(not_drymass, max(nc(k) + nc_nuceat_tend(k) * dt, 0.0));
       } else {
          nc(k).set(not_drymass, nccnst*inv_rho(k));
       }
@@ -508,7 +508,7 @@ void Functions<S,D>
 
       // calculate wet growth
       ice_cldliq_wet_growth(
-        rho(k), T_atm(k), pres(k), rhofaci(k), table_val_qi2qr_melting, table_val_qi2qr_vent_melt, latent_heat_vapor(k), 
+        rho(k), T_atm(k), pres(k), rhofaci(k), table_val_qi2qr_melting, table_val_qi2qr_vent_melt, latent_heat_vapor(k),
         latent_heat_fusion(k), dv, kap, mu, sc, qv(k), qc_incld(k), qi_incld(k), ni_incld(k), qr_incld(k),
         wetgrowth, qr2qi_collect_tend, qc2qi_collect_tend, qc_growth_rate, nr_ice_shed_tend, qc2qr_ice_shed_tend, range_mask, not_skip_micro);
 
@@ -551,7 +551,7 @@ void Functions<S,D>
 		     cld_frac_l(k),cld_frac_r(k),qv(k),qv_prev(k),qv_sat_l(k),qv_sat_i(k),
 		     ab,abi,epsr,epsi_tot,T_atm(k),t_prev(k),latent_heat_sublim(k),dqsdt,dt,
 		     qr2qv_evap_tend,nr_evap_tend, not_skip_micro);
-      
+
       ice_deposition_sublimation(
         qi_incld(k), ni_incld(k), T_atm(k), qv_sat_l(k), qv_sat_i(k), epsi, abi, qv(k),
         qv2qi_vapdep_tend, qi2qv_sublim_tend, ni_sublim_tend, qc2qi_berg_tend, not_skip_micro);
@@ -589,7 +589,7 @@ void Functions<S,D>
     back_to_cell_average(
       cld_frac_l(k), cld_frac_r(k), cld_frac_i(k), qc2qr_accret_tend, qr2qv_evap_tend, qc2qr_autoconv_tend,
       nc_accret_tend, nc_selfcollect_tend, nc2nr_autoconv_tend, nr_selfcollect_tend, nr_evap_tend, ncautr, qi2qv_sublim_tend, nr_ice_shed_tend, qc2qi_hetero_freeze_tend,
-      qr2qi_collect_tend, qc2qr_ice_shed_tend, qi2qr_melt_tend, qc2qi_collect_tend, qr2qi_immers_freeze_tend, ni2nr_melt_tend, nc_collect_tend, 
+      qr2qi_collect_tend, qc2qr_ice_shed_tend, qi2qr_melt_tend, qc2qi_collect_tend, qr2qi_immers_freeze_tend, ni2nr_melt_tend, nc_collect_tend,
       ncshdc, nc2ni_immers_freeze_tend, nr_collect_tend, ni_selfcollect_tend,
       qv2qi_vapdep_tend, nr2ni_immers_freeze_tend, ni_sublim_tend, qv2qi_nucleat_tend, ni_nucleat_tend, qc2qi_berg_tend, not_skip_all);
 
@@ -713,13 +713,13 @@ void Functions<S,D>
     // Outputs associated with aerocom comparison:
     pratot(k).set(not_skip_all, qc2qr_accret_tend); // cloud drop accretion by rain
     prctot(k).set(not_skip_all, qc2qr_autoconv_tend); // cloud drop autoconversion to rain
-    
+
     //impose_max_total_ni is meant to operate on in-cloud vals. ni_incld is an output of
     //calculate_incloud_mixingratios below but we need to generate it earlier for impose_max_total_ni
     ni_incld(k).set(not_skip_all, ni(k)/cld_frac_i(k));
     impose_max_total_ni(ni_incld(k), max_total_ni, inv_rho(k), not_skip_all);
     ni(k).set(not_skip_all, ni_incld(k)*cld_frac_i(k));
-    
+
     // Recalculate in-cloud values for sedimentation
     calculate_incloud_mixingratios(
       qc(k), qr(k), qi(k), qm(k), nc(k), nr(k), ni(k), bm(k), inv_cld_frac_l(k), inv_cld_frac_i(k), inv_cld_frac_r(k),
@@ -851,7 +851,7 @@ void Functions<S,D>
       bm(k).set(qi_gt_small, bm_incld*cld_frac_i(k) );
 
       impose_max_total_ni(ni_incld, max_total_ni, inv_rho(k));
-      
+
       TableIce table_ice;
       lookup_ice(qi_incld, ni_incld, qm_incld, rhop, table_ice, qi_gt_small);
 
@@ -1071,7 +1071,7 @@ Int Functions<S,D>
     p3_main_part1(
       team, nk, infrastructure.predictNc, infrastructure.prescribedCCN, infrastructure.dt,
       opres, odpres, odz, onc_nuceat_tend, onccn_prescribed, oexner, inv_exner, inv_cld_frac_l, inv_cld_frac_i,
-      inv_cld_frac_r, olatent_heat_vapor, olatent_heat_sublim, olatent_heat_fusion, 
+      inv_cld_frac_r, olatent_heat_vapor, olatent_heat_sublim, olatent_heat_fusion,
       T_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr,
       rhofaci, acn, oqv, oth, oqc, onc, oqr, onr, oqi, oni, oqm,
       obm, qc_incld, qr_incld, qi_incld, qm_incld, nc_incld, nr_incld,
@@ -1081,10 +1081,10 @@ Int Functions<S,D>
     if (!(nucleationPossible || hydrometeorsPresent)) {
       return; // this is how you do a "continue" in a kokkos lambda
     }
-    
+
     // ------------------------------------------------------------------------------------------
     // main k-loop (for processes):
-    
+
     p3_main_part2(
       team, nk_pack, infrastructure.predictNc, infrastructure.prescribedCCN, infrastructure.dt, inv_dt,
       dnu, ice_table_vals, collect_table_vals, revap_table_vals, opres, odpres, odz, onc_nuceat_tend, oexner,
@@ -1100,7 +1100,7 @@ Int Functions<S,D>
     //NOTE: At this point, it is possible to have negative (but small) nc, nr, ni.  This is not
     //      a problem; those values get clipped to zero in the sedimentation section (if necessary).
     //      (This is not done above simply for efficiency purposes.)
-    
+
     if (!hydrometeorsPresent) return;
 
     // -----------------------------------------------------------------------------------------
@@ -1142,7 +1142,7 @@ Int Functions<S,D>
     // and compute diagnostic fields for output
     //
     p3_main_part3(
-      team, nk_pack, dnu, ice_table_vals, oexner, ocld_frac_l, ocld_frac_r, ocld_frac_i, 
+      team, nk_pack, dnu, ice_table_vals, oexner, ocld_frac_l, ocld_frac_r, ocld_frac_i,
       rho, inv_rho, rhofaci, oqv, oth, oqc, onc, oqr, onr, oqi, oni,
       oqm, obm, olatent_heat_vapor, olatent_heat_sublim, omu_c, nu, olamc, mu_r, lamr,
       ovap_liq_exchange, ze_rain, ze_ice, diag_vm_qi, odiag_eff_radius_qi, diag_diam_qi,

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -125,7 +125,6 @@ struct Baseline {
     EKAT_REQUIRE_MSG( fid, "generate_baseline can't write " << filename);
     Int nerr = 0;
 
-    // These times are thrown out, I just wanted to be able to use auto
     Int total_duration_microsec = 0;
 
     for (auto ps : params_) {
@@ -137,7 +136,7 @@ struct Baseline {
 
         if (m_repeat > 0 && r == -1) {
           std::cout << "Running P3 with ni=" << d->ncol << ", nk=" << d->nlev
-                    << ", dt=" << d->dt << ", ts=" << d->it << " predict_nc=" << d->do_predict_nc;
+                    << ", dt=" << d->dt << ", ts=" << d->it << ", predict_nc=" << d->do_predict_nc;
 
           if (!use_fortran) {
             std::cout << ", small_packn=" << SCREAM_SMALL_PACK_SIZE;

--- a/components/scream/src/physics/shoc/shoc_main_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_main_impl.hpp
@@ -308,14 +308,14 @@ Int Functions<S,D>::shoc_main(
   view_3d<Spack>
     X1_d("X1",shcol,nlev,ekat::npack<Spack>(2));
 
-  // Start timer
-  auto start = std::chrono::steady_clock::now();
-
-  // SHOC main loop
   const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
 
   ekat::WorkspaceManager<Spack, Device> workspace_mgr(nlevi_packs, 12, policy);
 
+  // Start timer
+  auto start = std::chrono::steady_clock::now();
+
+  // SHOC main loop
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
@@ -324,8 +324,6 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
       ShocMainData(2,   7,  8,  2, 1,  5, 7, 4)
     };
 
-    static constexpr Int num_runs = sizeof(f90_data) / sizeof(ShocMainData);
-
     // Generate random input data
     int count = 0;
     for (auto& d : f90_data) {
@@ -414,6 +412,8 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
 
     // Verify BFB results, all data should be in C layout
 #ifndef NDEBUG
+    static constexpr Int num_runs = sizeof(f90_data) / sizeof(ShocMainData);
+
     for (Int i = 0; i < num_runs; ++i) {
       ShocMainData& d_f90 = f90_data[i];
       ShocMainData& d_cxx = cxx_data[i];


### PR DESCRIPTION
Also:
1) Improve --help dumps for key tools
2) Make cf-xml-to-yaml consistent with other tools
3) All tools should be using python3
4) perf-analysis: updates needed to support SCREAM build system changes, make sure mappy is using 46 threads
5) Instrument shoc_run_and_cmp to support timings (same as was done for P3). Since shoc_main does not do
a lot of initialization, it basically jumps right in to the interesting part, I don't think we need to limit
timings within shoc_main, we can just time the entire call.