### PR TITLE
parallelize remap

### DIFF
--- a/components/scream/src/control/tests/dummy_grid.hpp
+++ b/components/scream/src/control/tests/dummy_grid.hpp
@@ -100,9 +100,6 @@ protected:
     m_fields[ifield].first  = src;
     m_fields[ifield].second = tgt;
   }
-  void do_unregister_field (const int ifield) override {
-    m_fields.erase(m_fields.begin()+ifield);
-  }
 
 // CUDA needs top level lambdas to be enclosed by a method that is public.
 #ifdef KOKKOS_ENABLE_CUDA

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -684,7 +684,14 @@ do_remap_fwd() const
         EKAT_KERNEL_ERROR_MSG("Error! Unhandled case in switch statement.\n");
     }
   };
-  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(num_fields, 1);
+
+  const auto concurrency = KT::ExeSpace::concurrency();
+#ifdef KOKKOS_ENABLE_CUDA
+  const int team_size = std::min(1024, std::min(128*num_cols,32*(concurrency/nfields+31)/32));
+#else
+  const int team_size = (concurrency<num_fields ? 1 : concurrency/num_fields);
+#endif
+  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_team_policy_force_team_size(num_fields, team_size);
   Kokkos::parallel_for(policy, field_loop);
   Kokkos::fence();
 
@@ -737,7 +744,14 @@ do_remap_bwd() const
         EKAT_KERNEL_ERROR_MSG("Error! Unhandled case in switch statement.\n");
     }
   };
-  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(num_fields, 1);
+
+  const auto concurrency = KT::ExeSpace::concurrency();
+#ifdef KOKKOS_ENABLE_CUDA
+  const int team_size = std::min(1024, std::min(128*num_cols,32*(concurrency/nfields+31)/32));
+#else
+  const int team_size = (concurrency<num_fields ? 1 : concurrency/num_fields);
+#endif
+  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_team_policy_force_team_size(num_fields, team_size);
   Kokkos::parallel_for(policy, field_loop);
   Kokkos::fence();
 }

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -77,7 +77,6 @@ protected:
   void do_registration_begins () override {}
   void do_register_field (const identifier_type& src, const identifier_type& tgt) override;
   void do_bind_field (const int ifield, const field_type& src, const field_type& tgt) override;
-  void do_unregister_field (const int ifield) override;
   void do_registration_ends () override;
 
   void setup_boundary_exchange ();
@@ -303,23 +302,6 @@ do_bind_field (const int ifield, const field_type& src, const field_type& tgt)
   // precompute fields needed on device during remapper
   if (this->m_state==RepoState::Closed &&
       (this->m_num_bound_fields+1)==this->m_num_registered_fields) {
-    setup_boundary_exchange ();
-    initialize_device_variables();
-  }
-}
-
-template<typename RealType>
-void PhysicsDynamicsRemapper<RealType>::
-do_unregister_field (const int ifield)
-{
-  m_phys.erase(m_phys.begin()+ifield);
-  m_dyn.erase(m_dyn.begin()+ifield);
-  m_is_state_field.erase(m_is_state_field.begin()+ifield);
-
-  // If unregistering this field makes all fields bound, we can setup the BE and
-  // precompute fields needed on device during remapper
-  if (this->m_state==RepoState::Closed &&
-      (this->m_num_bound_fields==(this->m_num_registered_fields+1))) {
     setup_boundary_exchange ();
     initialize_device_variables();
   }

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -421,8 +421,8 @@ initialize_device_variables()
 
     // Time levels
     h_is_state_field_dev(i) = m_is_state_field[i];
-    h_time_levels(0).first     = tl.n0;
-    h_time_levels(0).second    = tl.np1;
+    h_time_levels(0).first  = tl.n0;
+    h_time_levels(0).second = tl.np1;
   }
 
   Kokkos::deep_copy(phys_ptrs,   h_phys_ptrs);
@@ -433,6 +433,7 @@ initialize_device_variables()
   Kokkos::deep_copy(dyn_layout, h_dyn_layout);
   Kokkos::deep_copy(dyn_dims,   h_dyn_dims);
 
+  Kokkos::deep_copy(time_levels,         h_time_levels);
   Kokkos::deep_copy(pack_alloc_property, h_pack_alloc_property);
   Kokkos::deep_copy(is_state_field_dev,  h_is_state_field_dev);
 }
@@ -637,13 +638,11 @@ do_remap_fwd() const
           team.team_barrier();
 
           local_remap_fwd_2d<small_pack_type>(team, num_cols, lid2elgp, p2d);
-        } else if (pack_alloc_property(i) == AllocPropType::RealAlloc) {
+        } else {
           set_dyn_to_zero<Real>(team);
           team.team_barrier();
 
           local_remap_fwd_2d<Real>(team, num_cols, lid2elgp, p2d);
-        } else {
-
         }
         break;
       }
@@ -660,13 +659,11 @@ do_remap_fwd() const
           team.team_barrier();
 
           local_remap_fwd_3d<small_pack_type>(team, num_cols, lid2elgp, p2d);
-        } else if (pack_alloc_property(i) == AllocPropType::RealAlloc) {
+        } else {
           set_dyn_to_zero<Real>(team);
           team.team_barrier();
 
           local_remap_fwd_3d<Real>(team, num_cols, lid2elgp, p2d);
-        } else {
-
         }
         break;
       }
@@ -703,10 +700,8 @@ do_remap_bwd() const {
           local_remap_bwd_2d<pack_type>(team, num_cols, lid2elgp, p2d);
         } else if (pack_alloc_property(i) == AllocPropType::SmallPackAlloc) {
           local_remap_bwd_2d<small_pack_type>(team, num_cols, lid2elgp, p2d);
-        } else if (pack_alloc_property(i) == AllocPropType::RealAlloc) {
-          local_remap_bwd_2d<Real>(team, num_cols, lid2elgp, p2d);
         } else {
-
+          local_remap_bwd_2d<Real>(team, num_cols, lid2elgp, p2d);
         }
         break;
       }
@@ -717,10 +712,8 @@ do_remap_bwd() const {
           local_remap_bwd_3d<pack_type>(team, num_cols, lid2elgp, p2d);
         } else if (pack_alloc_property(i) == AllocPropType::SmallPackAlloc) {
           local_remap_bwd_3d<small_pack_type>(team, num_cols, lid2elgp, p2d);
-        } else if (pack_alloc_property(i) == AllocPropType::RealAlloc) {
-          local_remap_bwd_3d<Real>(team, num_cols, lid2elgp, p2d);
         } else {
-
+          local_remap_bwd_3d<Real>(team, num_cols, lid2elgp, p2d);
         }
         break;
       }

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -747,7 +747,7 @@ do_remap_bwd() const
 
   const auto concurrency = KT::ExeSpace::concurrency();
 #ifdef KOKKOS_ENABLE_CUDA
-  const int team_size = std::min(1024, std::min(128*num_cols,32*(concurrency/nfields+31)/32));
+  const int team_size = std::min(1024, std::min(128*num_cols,32*(concurrency/num_fields+31)/32));
 #else
   const int team_size = (concurrency<num_fields ? 1 : concurrency/num_fields);
 #endif

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -687,7 +687,7 @@ do_remap_fwd() const
 
   const auto concurrency = KT::ExeSpace::concurrency();
 #ifdef KOKKOS_ENABLE_CUDA
-  const int team_size = std::min(1024, std::min(128*num_cols,32*(concurrency/nfields+31)/32));
+  const int team_size = std::min(1024, std::min(128*num_cols,32*(concurrency/num_fields+31)/32));
 #else
   const int team_size = (concurrency<num_fields ? 1 : concurrency/num_fields);
 #endif

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -459,7 +459,6 @@ void PhysicsDynamicsRemapper<RealType>::
 set_dyn_to_zero(const MT& team) const
 {
   const int i = team.league_rank();
-
   const int itl = time_levels(0).first;
   const auto& dim_d = dyn_dims(i).dims;
 
@@ -639,7 +638,7 @@ do_remap_fwd() const
   const auto field_loop = KOKKOS_LAMBDA (const KT::MemberType& team) {
     const int i = team.league_rank();
 
-      if (has_parent(i)) return;
+    if (has_parent(i)) return;
 
     switch (phys_layout(i)) {
       case etoi(LayoutType::Scalar2D):
@@ -710,7 +709,7 @@ do_remap_bwd() const
   const auto field_loop = KOKKOS_LAMBDA (const KT::MemberType& team) {
     const int i = team.league_rank();
 
-      if (has_parent(i)) return;
+    if (has_parent(i)) return;
 
     switch (phys_layout(i)) {
       case etoi(LayoutType::Scalar2D):

--- a/components/scream/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/scream/src/share/grid/remap/abstract_remapper.hpp
@@ -58,10 +58,6 @@ public:
     register_field(create_src_fid(tgt),tgt);
   }
 
-  // This method unregisters source and target fields associated with the given
-  // identifiers, indicating that they are no longer to be remapped.
-  void unregister_field (const identifier_type& src, const identifier_type& tgt);
-
   // Call this to indicate that field registration is complete.
   void registration_ends ();
 
@@ -216,9 +212,6 @@ protected:
   // fields are bound to an index within the remapper.
   virtual void do_bind_field (const int ifield, const field_type& src, const field_type& tgt) = 0;
 
-  // Override this method to insert logic executed when a field is unregistered.
-  virtual void do_unregister_field (const int ifield) = 0;
-
   // Override this method to insert logic executed when the field registration
   // process ends.
   virtual void do_registration_ends () = 0;
@@ -332,29 +325,6 @@ register_field (const field_type& src, const field_type& tgt) {
   register_field(src.get_header().get_identifier(),
                  tgt.get_header().get_identifier());
   bind_field(src,tgt);
-}
-
-template<typename RealType>
-void AbstractRemapper<RealType>::
-unregister_field (const identifier_type& src, const identifier_type& tgt) {
-  EKAT_REQUIRE_MSG(m_state==RepoState::Open,
-                     "Error! You can only un-register fields during the registration phase.\n");
-
-  const int ifield = find_field(src,tgt);
-  EKAT_REQUIRE_MSG(ifield>=0,
-                     "Error! The src/tgt pair of fields \n"
-                     "         " + src.get_id_string() + "\n"
-                     "         " + tgt.get_id_string() + "\n"
-                     "       was not registered.\n");
-
-  const bool was_bound = m_fields_are_bound[ifield];
-  do_unregister_field(ifield);
-
-  --m_num_registered_fields;
-  if (was_bound) {
-    --m_num_bound_fields;
-  }
-  m_fields_are_bound.erase(m_fields_are_bound.begin()+ifield);
 }
 
 template<typename RealType>

--- a/components/scream/src/share/grid/remap/identity_remapper.hpp
+++ b/components/scream/src/share/grid/remap/identity_remapper.hpp
@@ -77,9 +77,6 @@ protected:
     m_fields[ifield].first  = src;
     m_fields[ifield].second = tgt;
   }
-  void do_unregister_field (const int ifield) override {
-    m_fields.erase(m_fields.begin()+ifield);
-  }
   void do_registration_ends () override {
     // Do nothing
   }

--- a/components/scream/src/share/grid/remap/inverse_remapper.hpp
+++ b/components/scream/src/share/grid/remap/inverse_remapper.hpp
@@ -71,10 +71,6 @@ protected:
                       const field_type& tgt) override {
     m_remapper->bind_field(tgt,src);
   }
-  void do_unregister_field (const int ifield) override {
-    m_remapper->unregister_field(m_remapper->get_src_field(ifield).get_header().get_identifier(),
-                                 m_remapper->get_tgt_field(ifield).get_header().get_identifier());
-  }
   void do_registration_ends () override {
     m_remapper->registration_ends();
   }

--- a/components/scream/src/share/scream_types.hpp
+++ b/components/scream/src/share/scream_types.hpp
@@ -20,6 +20,7 @@ using Real = float;
 using ekat::KokkosTypes;
 using ekat::DefaultDevice;
 using ekat::HostDevice;
+using ekat::Unmanaged;
 
 // Miscellanea
 

--- a/components/scream/src/share/tests/dummy_se_point_remapper.hpp
+++ b/components/scream/src/share/tests/dummy_se_point_remapper.hpp
@@ -120,9 +120,6 @@ protected:
     m_fields[ifield].first  = src;
     m_fields[ifield].second = tgt;
   }
-  void do_unregister_field (const int ifield) override {
-    m_fields.erase(m_fields.begin()+ifield);
-  }
   void do_registration_ends () override {
     // Do nothing
   }


### PR DESCRIPTION
Changes `PhysicsDynamics` remappers to parallelize over fields. No new test is written, relying on the one that already exists (shouldn't be an issue).
Main changes:
1. In both `do_remap_fwd/bwd`, the `for(num_fields)` was replaced with `parallel_for(TeamPolicy, num_fields)`.
2. All info needed on device is computed in a new function `initialize_device_variables()` which is called at the end of `do_registration_ends()`.
3. Added the pack logic to 2d remmaping methods (was just 3d). 
4. New function `set_dyn_to_zero()` sets the relevant portion of the dynamics view to 0. Called right before `local_remap_fwd_2d/3d()`. This function may be unnecessary if there is a `set_zero` like method on device, but I could not find it..