### PR TITLE
Fixing blake_setup jenkins script

### DIFF
--- a/components/scream/scripts/jenkins/blake_setup
+++ b/components/scream/scripts/jenkins/blake_setup
@@ -1,4 +1,4 @@
-export PATH=/ascldap/users/jgfouca/packages/Python-3.6.8-blake/bin:$PATH
+module load python/3.7.3
 
 source ./scream/components/scream/scripts/jenkins/sandia_son_proxy
 


### PR DESCRIPTION
Fixes a problem with `blake_setup` script, which was trying to add a python folder inside @jgfouca home directory to the PATH. The problem is that his home folder does not have read/execute permissions (as it is common) for others.

Since we already resort on python3 modules on weaver/mappy, do the same on blake: load the python3 module (rather than adding a hard-coded folder to the PATH).