### PR TITLE
SCREAM: upgrade to machine specs for weaver

### DIFF
--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -15,6 +15,16 @@ from utils import expect, get_cpu_core_count, run_cmd_no_fail
 
 import os, sys, pathlib
 
+def get_weaver_queue():
+  out = run_cmd_no_fail("bhosts | awk '{ if($2==\"ok\" && $6==0) print $1}' | head -1")
+  if (out in ["weaver1", "weaver2", "weaver3", "weaver4", "weaver5", "weaver6", "weaver7", "weaver8"] or out==""):
+    queue = "rhel7W"
+  else:
+    queue = "dev"
+
+  return queue
+    
+
 MACHINE_METADATA = {
     "melvin"   : (["module purge", "module load sems-env", "module load sems-gcc/7.3.0 sems-openmpi/1.10.1 sems-gcc/7.3.0 sems-git/2.10.1 sems-cmake/3.12.2 sems-python/3.5.2"],
                  ["mpicxx","mpifort","mpicc"],
@@ -35,7 +45,7 @@ MACHINE_METADATA = {
                   "/home/projects/e3sm/scream/pr-autotester/master-baselines/blake/"),
     "weaver"   : (["module purge", "module load devpack/20190814/openmpi/4.0.1/gcc/7.2.0/cuda/10.1.105 git/2.10.1 python/3.7.3", "module switch cmake/3.18.0", "export PATH=/ascldap/users/projects/e3sm/scream/libs/netcdf-fortran/install/weaver/bin:$PATH"],
                  ["mpicxx","mpifort","mpicc"],
-                  "bsub -I -q rhel7W -n 4",
+                  "bsub -I -q {} -n 4".format(get_weaver_queue()),
                   40,
                   4,
                   "/home/projects/e3sm/scream/pr-autotester/master-baselines/weaver/"),


### PR DESCRIPTION
Weaver has two queues, both with V100 GPUs. Sometimes the default queue is full, with jobs that run for hours, and no end in sight. In this context, it might be handy to submit to the other queue, especially if it's a somewhat urgent PR (hot fix, or blocking other PRs). So I added some bash commands to run when the MACHINE_METADATA dict is built, which help to select the second queue if the first one is full. The bash command builds on `bhosts`, and uses awk to filter the lines/colomns, looking for nodes with no jobs running, and that are not currently unavailable:

```
bhosts | awk '{ if($2=="ok" && $6==0) print $1}' | head -1
```
To see why, this is the output of `bhosts`:

```
HOST_NAME          STATUS       JL/U    MAX  NJOBS    RUN  SSUSP  USUSP    RSV 
weaver1            unavail         -     40      0      0      0      0      0
weaver10           ok              -     40      0      0      0      0      0
weaver11           closed          -      0      0      0      0      0      0
weaver12           unavail         -      0      0      0      0      0      0
weaver2            ok              -     40      4      4      0      0      0
weaver3            closed          -     40     40     40      0      0      0
weaver4            closed          -     40     40     40      0      0      0
weaver5            ok              -     40      1      1      0      0      0
weaver6            closed          -     40     40     40      0      0      0
weaver7            closed          -     40     40     40      0      0      0
weaver8            closed          -     40     40     40      0      0      0
weaver9            unavail         -     40      0      0      0      0      0
```

The output is then matched against the list of nodes in the default queue, to establish if that's ok, or if we want to try the other one. I manually tested this on weaver right now (the queue is full), and it works:

```
Job <9815> is submitted to queue <dev>.
<<Waiting for dispatch ...>>
<<Starting on weaver10>>
```

I want to wait till the default queue is empty, to ensure it works also if the other branch of the if statement is taken (so don't add AUTOMERGE!).

Note: if the default queue is full, I always go immediately on the dev queue (without checking if its full), since the dev queue is virtually never used (`bqueues` shows basically no users trying to use it).