### PR TITLE
Fix issue where fortran's implicit save of variables was unintended causing non-bfb with threading

### DIFF
--- a/components/eam/src/physics/cam/micro_p3.F90
+++ b/components/eam/src/physics/cam/micro_p3.F90
@@ -2428,11 +2428,13 @@ table_val_qi_fallspd,acn,lamc, mu_c,qc_incld,qccol,    &
    real(rtype), intent(out) :: vtrmi1
    real(rtype), intent(out) :: rho_qm_cloud
 
-   real(rtype) :: iTc = 0.0_rtype
-   real(rtype) :: Vt_qc = 0.0_rtype
-   real(rtype) :: D_c  = 0.0_rtype
-   real(rtype) :: V_impact = 0.0_rtype
-   real(rtype) :: Ri = 0.0_rtype
+   real(rtype) :: iTc, Vt_qc, D_c, V_impact, Ri
+
+   iTc = 0.0_rtype
+   Vt_qc = 0.0_rtype
+   D_c  = 0.0_rtype
+   V_impact = 0.0_rtype
+   Ri = 0.0_rtype
 
    ! if (qi_incld(i,k).ge.qsmall .and. t_atm(i,k).lt.T_zerodegc) then
    !  NOTE:  condition applicable for cloud only; modify when rain is added back


### PR DESCRIPTION
Fix an issue where fortran's implicit save of variables set on same line as declaration

was unintended and caused an issue when threading used.
Specifically in subroutine calc_rime_density
Results are now BFB when comparing with different number of MPI's (for example).
These now pass:
ERS_D_P48x2.ne4pg2_ne4pg2.F2010-SCREAM-HR
REP_D_P48x2.ne4pg2_ne4pg2.F2010-SCREAM-HR
PEM_D_P48x2.ne4pg2_ne4pg2.F2010-SCREAM-LR

However, the results may not be BFB with results before this change.
In subsequent tests, it appears results are BFB with non-DEBUG builds, but are most likely not for DEBUG builds.

Fixes #911