### PR TITLE
Use vector-valued wind in SHOC

### DIFF
--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -72,8 +72,6 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   // Input/Output variables
   m_required_fields.emplace("s",        scalar3d_layout_mid, J/kg,        grid_name);
   m_required_fields.emplace("tke",      scalar3d_layout_mid, (m*m)/(s*s), grid_name);
-  m_required_fields.emplace("u",        scalar3d_layout_mid, m/s,         grid_name);
-  m_required_fields.emplace("v",        scalar3d_layout_mid, m/s,         grid_name);
   m_required_fields.emplace("wthv_sec", scalar3d_layout_mid, K*(m/s),     grid_name);
   m_required_fields.emplace("tkh",      scalar3d_layout_mid, (m*m)/s,     grid_name);
   m_required_fields.emplace("tk",       scalar3d_layout_mid, (m*m)/s,     grid_name);
@@ -81,8 +79,6 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
   m_computed_fields.emplace("s",        scalar3d_layout_mid, J/kg,        grid_name);
   m_computed_fields.emplace("tke",      scalar3d_layout_mid, (m*m)/(s*s), grid_name);
-  m_computed_fields.emplace("u",        scalar3d_layout_mid, m/s,         grid_name);
-  m_computed_fields.emplace("v",        scalar3d_layout_mid, m/s,         grid_name);
   m_computed_fields.emplace("wthv_sec", scalar3d_layout_mid, K*(m/s),     grid_name);
   m_computed_fields.emplace("tkh",      scalar3d_layout_mid, (m*m)/s,     grid_name);
   m_computed_fields.emplace("tk",       scalar3d_layout_mid, (m*m)/s,     grid_name);
@@ -93,28 +89,42 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
   // Tracer group
   m_inout_groups_req.emplace("TRACERS",grid->name());
+
+  // Wind group
+  m_inout_groups_req.emplace("horiz_wind",grid->name());
 }
 // =========================================================================================
 void SHOCMacrophysics::
 set_updated_group (const FieldGroup<Real>& group)
 {
-  EKAT_REQUIRE_MSG(group.m_info->size() >= 3,
-                   "Error! Shoc requires at least 3 tracers (tke, shoc_qv, shoc_ql) as inputs.");
-
   const auto& name = group.m_info->m_group_name;
 
-  EKAT_REQUIRE_MSG(name=="TRACERS",
+  EKAT_REQUIRE_MSG(name=="TRACERS" || name=="horiz_wind",
     "Error! We were not expecting a field group called '" << name << "\n");
 
   EKAT_REQUIRE_MSG(group.m_info->m_bundled,
-      "Error! Shoc expects bundled fields for tracers.\n");
+      "Error! Shoc expects bundled fields for tracers and wind.\n");
 
-  // Add Q bundle as in/out field
-  m_shoc_fields_in["Q"]  = *group.m_bundle;
-  m_shoc_fields_out["Q"] = *group.m_bundle;
+  if (name=="TRACERS") {
+    EKAT_REQUIRE_MSG(group.m_info->size() >= 3,
+                     "Error! Shoc requires at least 3 tracers (tke, shoc_qv, shoc_ql) as inputs.");
 
-  // Calculate number of advected tracers
-  m_num_tracers = m_shoc_fields_in["Q"].get_header().get_identifier().get_layout().dim(1);
+    // Add Q bundle as in/out field
+    m_shoc_fields_in["Q"]  = *group.m_bundle;
+    m_shoc_fields_out["Q"] = *group.m_bundle;
+
+    // Calculate number of advected tracers
+    m_num_tracers = m_shoc_fields_in["Q"].get_header().get_identifier().get_layout().dim(1);
+  }
+
+  if (name=="horiz_wind") {
+    EKAT_REQUIRE_MSG(group.m_info->size() == 2,
+                     "Error! Shoc requires exactly 2 wind vectors (u, v) as inputs.");
+
+    // Add V bundle as in/out field
+    m_shoc_fields_in["V"]  = *group.m_bundle;
+    m_shoc_fields_out["V"] = *group.m_bundle;
+  }
 }
 
 // =========================================================================================
@@ -141,8 +151,6 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   auto shoc_qv  = m_shoc_fields_out["shoc_qv"].get_reshaped_view<Spack**>();
   auto tke      = m_shoc_fields_out["tke"].get_reshaped_view<Spack**>();
   auto s        = m_shoc_fields_out["s"].get_reshaped_view<Spack**>();
-  auto u        = m_shoc_fields_out["u"].get_reshaped_view<Spack**>();
-  auto v        = m_shoc_fields_out["v"].get_reshaped_view<Spack**>();
   auto Q        = m_shoc_fields_out["Q"].get_reshaped_view<Spack***>();
 
   const int nlev_packs = ekat::npack<Spack>(m_num_levs);
@@ -173,8 +181,7 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
 
   shoc_preamble.set_variables(m_num_cols,m_num_levs,m_num_tracers,nlev_packs,num_tracer_packs,t,alst,
                               zi,zm,pmid,pdel,omega,shf,cflx_k0,wsx,wsy,shoc_qv,Q,shoc_ql,tke,
-                              s,u,v,
-                              rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
+                              s,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
                               wtracer_sfc,wm_zt,exner,thlm,qw,cloud_frac,tracers);
 
   // Input Variables:
@@ -200,8 +207,7 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   input_output.tke          = shoc_preamble.tke_zt;
   input_output.thetal       = shoc_preamble.thlm;
   input_output.qw           = shoc_preamble.qw;
-  input_output.u_wind       = shoc_preamble.um;
-  input_output.v_wind       = shoc_preamble.vm;
+  input_output.horiz_wind   = m_shoc_fields_out["V"].get_reshaped_view<Spack***>();
   input_output.wthv_sec     = m_shoc_fields_out["wthv_sec"].get_reshaped_view<Spack**>();
   input_output.qtracers     = shoc_preamble.tracers;
   input_output.tk           = m_shoc_fields_out["tk"].get_reshaped_view<Spack**>();
@@ -313,13 +319,18 @@ void SHOCMacrophysics::finalize_impl()
 
 void SHOCMacrophysics::register_fields (FieldRepository<Real>& field_repo) const {
   std::set<ci_string> q_names =
-    { "shoc_ql", "shoc_qv", "tke"};
+    { "shoc_ql", "shoc_qv", "tke" };
+  std::set<ci_string> v_names =
+    { "u", "v" };
 
   for (auto& fid : m_required_fields) {
     const auto& name = fid.name();
     if (q_names.count(name)>0) {
       field_repo.register_field<Spack>(fid,"TRACERS");
-    } else {
+    } else if (v_names.count(name)>0) {
+      field_repo.register_field<Spack>(fid,"horiz_wind");
+    }
+    else {
       field_repo.register_field<Spack>(fid);
     }
   }
@@ -327,6 +338,8 @@ void SHOCMacrophysics::register_fields (FieldRepository<Real>& field_repo) const
     const auto& name = fid.name();
     if (q_names.count(name)>0) {
       field_repo.register_field<Spack>(fid,"TRACERS");
+    } else if (v_names.count(name)>0) {
+      field_repo.register_field<Spack>(fid,"horiz_wind");
     } else {
       field_repo.register_field<Spack>(fid);
     }

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -186,8 +186,6 @@ public:
     view_2d       shoc_ql;
     view_2d       shoc_s;
     view_2d       tke_zt;
-    view_2d       um;
-    view_2d       vm;
     view_2d       rrho;
     view_2d       rrho_i;
     view_2d       thv;
@@ -214,7 +212,7 @@ public:
                        view_2d_const omega_,
                        view_1d_const shf_, view_1d_const cflx_, view_1d_const wsx_, view_1d_const wsy_,
                        view_2d_const shoc_qv_, view_3d Q_, view_2d shoc_ql_, view_2d tke_,
-                       view_2d s_, view_2d u_, view_2d v_, view_2d rrho_, view_2d rrho_i_,view_2d thv_,
+                       view_2d s_, view_2d rrho_, view_2d rrho_i_,view_2d thv_,
                        view_2d dz_,view_2d zt_grid_,view_2d zi_grid_, view_1d wpthlp_sfc_,
                        view_1d wprtp_sfc_,view_1d upwp_sfc_,view_1d vpwp_sfc_, view_2d wtracer_sfc_,
                        view_2d wm_zt_,view_2d exner_,view_2d thlm_,view_2d qw_,view_2d cloud_frac_,view_3d tracers_)
@@ -242,8 +240,6 @@ public:
       shoc_ql = shoc_ql_;
       shoc_s = s_;
       tke_zt = tke_;
-      um = u_;
-      vm = v_;
       rrho = rrho_;
       rrho_i = rrho_i_;
       thv = thv_;

--- a/components/scream/src/physics/shoc/shoc_compute_shr_prod_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_shr_prod_impl.hpp
@@ -19,15 +19,15 @@ void Functions<S,D>
   const Int&                   nlevi,
   const Int&                   nlev,
   const uview_1d<const Spack>& dz_zi,
-  const uview_1d<const Spack>& u_wind,
-  const uview_1d<const Spack>& v_wind,
+  const uview_2d<const Spack> &horiz_wind,
   const uview_1d<Spack>&       sterm)
 {
   const Int nlev_pack = ekat::npack<Spack>(nlev);
 
   //scalarize so that we can use shift to compute the differece  ( x(k-1) - x )
-  const auto sclr_uwind = scalarize(u_wind); //for u_wind
-  const auto sclr_vwind = scalarize(v_wind); //for v_wind
+  const auto sclr_wind = scalarize(horiz_wind);
+  const auto sclr_uwind = ekat::subview(sclr_wind,0);
+  const auto sclr_vwind = ekat::subview(sclr_wind,1);
 
   //compute shear production term
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
@@ -45,7 +45,7 @@ void Functions<S,D>
     const Spack v_grad(range_pack1 > 0 && range_pack1 < nlev, grid_dz*(v_up_grid - v_grid));
 
     //compute shear production
-    sterm(k)           = u_grad*u_grad+v_grad*v_grad;
+    sterm(k) = u_grad*u_grad+v_grad*v_grad;
   });
   /*
    * Set lower and upper boundary for shear production
@@ -53,7 +53,7 @@ void Functions<S,D>
    * been taken into account for the TKE boundary condition,
    * thus zero out here
     */
-  sterm(0)[0]     = 0;
+  sterm(0)[0] = 0;
   const Int nlevi_pack = ekat::npack<Spack>(nlevi);
   const Int last_pack_entry = (nlevi%Spack::n == 0 ? Spack::n-1 : nlevi%Spack::n-1);
   sterm(nlevi_pack-1)[last_pack_entry] = 0;

--- a/components/scream/src/physics/shoc/shoc_diag_second_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_second_moments_impl.hpp
@@ -13,10 +13,9 @@ namespace shoc {
 
 template<typename S, typename D>
 KOKKOS_FUNCTION
-void Functions<S,D>::diag_second_moments(
-  const MemberType& team, const Int& nlev, const Int& nlevi,
-  const uview_1d<const Spack>& thetal, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& u_wind,
-  const uview_1d<const Spack>& v_wind, const uview_1d<const Spack>& tke, const uview_1d<const Spack>& isotropy,
+void Functions<S,D>::diag_second_moments(const MemberType& team, const Int& nlev, const Int& nlevi,
+  const uview_1d<const Spack>& thetal, const uview_1d<const Spack>& qw, const uview_2d<const Spack> &horiz_wind,
+  const uview_1d<const Spack>& tke, const uview_1d<const Spack>& isotropy,
   const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& dz_zi,
   const uview_1d<const Spack>& zt_grid, const uview_1d<const Spack>& zi_grid, const uview_1d<const Spack>& shoc_mix,
   const uview_1d<Spack>& isotropy_zi, const uview_1d<Spack>& tkh_zi, const uview_1d<Spack>& tk_zi,
@@ -73,9 +72,11 @@ void Functions<S,D>::diag_second_moments(
   calc_shoc_vertflux(team, nlev, tkh_zi, dz_zi, tke, wtke_sec);
 
   // Calculate vertical flux for momentum (zonal wind)
+  const auto u_wind = ekat::subview(horiz_wind, 0);
   calc_shoc_vertflux(team, nlev, tk_zi, dz_zi, u_wind, uw_sec);
 
   // Calculate vertical flux for momentum (meridional wind)
+  const auto v_wind = ekat::subview(horiz_wind, 1);
   calc_shoc_vertflux(team, nlev, tk_zi, dz_zi, v_wind, vw_sec);
 }
 

--- a/components/scream/src/physics/shoc/shoc_diag_second_shoc_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_second_shoc_moments_impl.hpp
@@ -13,14 +13,14 @@ namespace shoc {
 
 template<typename S, typename D>
 KOKKOS_FUNCTION
-void Functions<S,D>::diag_second_shoc_moments(const MemberType& team, const Int& nlev, const Int& nlevi, 
-       const uview_1d<const Spack>& thetal, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& u_wind, 
-       const uview_1d<const Spack>& v_wind, const uview_1d<const Spack>& tke, const uview_1d<const Spack>& isotropy,
-       const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& dz_zi, 
-       const uview_1d<const Spack>& zt_grid, const uview_1d<const Spack>& zi_grid, const uview_1d<const Spack>& shoc_mix, 
-       const Scalar& wthl_sfc, const Scalar& wqw_sfc, const Scalar& uw_sfc, const Scalar& vw_sfc, Scalar& ustar2, Scalar& wstar, 
+void Functions<S,D>::diag_second_shoc_moments(const MemberType& team, const Int& nlev, const Int& nlevi,
+       const uview_1d<const Spack>& thetal, const uview_1d<const Spack>& qw, const uview_2d<const Spack> &horiz_wind,
+       const uview_1d<const Spack>& tke, const uview_1d<const Spack>& isotropy,
+       const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& dz_zi,
+       const uview_1d<const Spack>& zt_grid, const uview_1d<const Spack>& zi_grid, const uview_1d<const Spack>& shoc_mix,
+       const Scalar& wthl_sfc, const Scalar& wqw_sfc, const Scalar& uw_sfc, const Scalar& vw_sfc, Scalar& ustar2, Scalar& wstar,
        const Workspace workspace, const uview_1d<Spack>& thl_sec,
-       const uview_1d<Spack>& qw_sec, const uview_1d<Spack>& wthl_sec, const uview_1d<Spack>& wqw_sec, const uview_1d<Spack>& qwthl_sec, 
+       const uview_1d<Spack>& qw_sec, const uview_1d<Spack>& wthl_sec, const uview_1d<Spack>& wqw_sec, const uview_1d<Spack>& qwthl_sec,
        const uview_1d<Spack>& uw_sec, const uview_1d<Spack>& vw_sec, const uview_1d<Spack>& wtke_sec, const uview_1d<Spack>& w_sec)
 {
   // This is the main routine to compute the second
@@ -50,7 +50,7 @@ void Functions<S,D>::diag_second_shoc_moments(const MemberType& team, const Int&
   // Diagnose the second order moments, for points away from boundaries.  this is
   //  the main computation for the second moments
   diag_second_moments(team, nlev, nlevi,
-                     thetal, qw, u_wind,v_wind, tke, isotropy,tkh, tk, dz_zi, zt_grid, zi_grid, shoc_mix,
+                     thetal, qw, horiz_wind, tke, isotropy,tkh, tk, dz_zi, zt_grid, zi_grid, shoc_mix,
                      isotropy_zi, tkh_zi, tk_zi, thl_sec, qw_sec, wthl_sec, wqw_sec,
                      qwthl_sec, uw_sec, vw_sec, wtke_sec, w_sec);
   team.team_barrier();

--- a/components/scream/src/physics/shoc/shoc_energy_integrals_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_energy_integrals_impl.hpp
@@ -16,8 +16,7 @@ void Functions<S,D>
   const uview_1d<const Spack>& pdel,
   const uview_1d<const Spack>& rtm,
   const uview_1d<const Spack>& rcm,
-  const uview_1d<const Spack>& u_wind,
-  const uview_1d<const Spack>& v_wind,
+  const uview_2d<const Spack> &horiz_wind,
   Scalar&                      se_int,
   Scalar&                      ke_int,
   Scalar&                      wv_int,
@@ -35,7 +34,7 @@ void Functions<S,D>
   // Compute ke_int
   ExeSpaceUtils::view_reduction(team,0,nlev,
                                 [&] (const int k) -> Spack {
-    return sp(0.5)*(ekat::square(u_wind(k))+ekat::square(v_wind(k)))*pdel(k)/ggr;
+    return sp(0.5)*(ekat::square(horiz_wind(0,k))+ekat::square(horiz_wind(1,k)))*pdel(k)/ggr;
   }, ke_int);
 
   // Compute wv_int

--- a/components/scream/src/physics/shoc/shoc_main_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_main_impl.hpp
@@ -93,8 +93,7 @@ void Functions<S,D>::shoc_main_internal(
   const uview_1d<Spack>&       tke,
   const uview_1d<Spack>&       thetal,
   const uview_1d<Spack>&       qw,
-  const uview_1d<Spack>&       u_wind,
-  const uview_1d<Spack>&       v_wind,
+  const uview_2d<Spack>&       horiz_wind,
   const uview_1d<Spack>&       wthv_sec,
   const uview_2d<Spack>&       qtracers,
   const uview_1d<Spack>&       tk,
@@ -139,8 +138,8 @@ void Functions<S,D>::shoc_main_internal(
   // for the computation of total energy before SHOC is called.  This is for an
   // effort to conserve energy since liquid water potential temperature (which SHOC
   // conserves) and static energy (which E3SM conserves) are not exactly equal.
-  shoc_energy_integrals(team,nlev,host_dse,pdel,qw,shoc_ql,u_wind,v_wind, // Input
-                        se_b,ke_b,wv_b,wl_b);                             // Output
+  shoc_energy_integrals(team,nlev,host_dse,pdel,qw,shoc_ql,horiz_wind, // Input
+                        se_b,ke_b,wv_b,wl_b);                          // Output
 
   for (Int t=0; t<nadv; ++t) {
     // Check TKE to make sure values lie within acceptable
@@ -171,13 +170,13 @@ void Functions<S,D>::shoc_main_internal(
                     shoc_qv(nlev_v)[nlev_p], // Input
                     ustar,kbfs,obklen);      // Output
 
-    pblintd(team,nlev,nlevi,npbl,     // Input
-            zt_grid,zi_grid,thetal,   // Input
-            shoc_ql,shoc_qv,u_wind,   // Input
-            v_wind,ustar,obklen,kbfs, // Input
-            shoc_cldfrac,             // Input
-            workspace,                // Workspace
-            pblh);                    // Output
+    pblintd(team,nlev,nlevi,npbl,         // Input
+            zt_grid,zi_grid,thetal,       // Input
+            shoc_ql,shoc_qv,              // Input
+            horiz_wind,ustar,obklen,kbfs, // Input
+            shoc_cldfrac,                 // Input
+            workspace,                    // Workspace
+            pblh);                        // Output
 
     // Update the turbulent length scale
     shoc_length(team,nlev,nlevi,host_dx,host_dy, // Input
@@ -187,13 +186,13 @@ void Functions<S,D>::shoc_main_internal(
                 brunt,shoc_mix);                 // Output
 
     // Advance the SGS TKE equation
-    shoc_tke(team,nlev,nlevi,dtime,wthv_sec,    // Input
-             shoc_mix,dz_zi,dz_zt,pres,u_wind,  // Input
-             v_wind,brunt,obklen,zt_grid,       // Input
-             zi_grid,pblh,                      // Input
-             workspace,                         // Workspace
-             tke,tk,tkh,                        // Input/Output
-             isotropy);                         // Output
+    shoc_tke(team,nlev,nlevi,dtime,wthv_sec,  // Input
+             shoc_mix,dz_zi,dz_zt,pres,       // Input
+             horiz_wind,brunt,obklen,zt_grid, // Input
+             zi_grid,pblh,                    // Input
+             workspace,                       // Workspace
+             tke,tk,tkh,                      // Input/Output
+             isotropy);                       // Output
 
     // Update SHOC prognostic variables here
     // via implicit diffusion solver
@@ -202,10 +201,10 @@ void Functions<S,D>::shoc_main_internal(
                                 dz_zi,rho_zt,zt_grid,zi_grid,tk,tkh,uw_sfc, // Input
                                 vw_sfc,wthl_sfc,wqw_sfc,wtracer_sfc,        // Input
                                 workspace,                                  // Workspace
-                                X1,thetal,qw,qtracers,tke,u_wind,v_wind);   // Input/Output
+                                X1,thetal,qw,qtracers,tke,horiz_wind);      // Input/Output
 
     // Diagnose the second order moments
-    diag_second_shoc_moments(team,nlev,nlevi,thetal,qw,u_wind,v_wind,   // Input
+    diag_second_shoc_moments(team,nlev,nlevi,thetal,qw,horiz_wind,      // Input
                              tke,isotropy,tkh,tk,dz_zi,zt_grid,zi_grid, // Input
                              shoc_mix,wthl_sfc,wqw_sfc,uw_sfc,vw_sfc,   // Input
                              ustar2,wstar,                              // Input/Output
@@ -243,9 +242,9 @@ void Functions<S,D>::shoc_main_internal(
                   host_dse);                // Output
 
   team.team_barrier();
-  shoc_energy_integrals(team,nlev,host_dse,pdel,  // Input
-                        qw,shoc_ql,u_wind,v_wind, // Input
-                        se_a,ke_a,wv_a,wl_a);     // Output
+  shoc_energy_integrals(team,nlev,host_dse,pdel, // Input
+                        qw,shoc_ql,horiz_wind,   // Input
+                        se_a,ke_a,wv_a,wl_a);    // Output
 
   shoc_energy_fixer(team,nlev,nlevi,dtime,nadv,zt_grid,zi_grid, // Input
                     se_b,ke_b,wv_b,wl_b,se_a,ke_a,wv_a,wl_a,    // Input
@@ -274,7 +273,7 @@ void Functions<S,D>::shoc_main_internal(
 
   pblintd(team,nlev,nlevi,npbl,zt_grid,   // Input
           zi_grid,thetal,shoc_ql,shoc_qv, // Input
-          u_wind,v_wind,ustar,obklen,     // Input
+          horiz_wind,ustar,obklen,        // Input
           kbfs,shoc_cldfrac,              // Input
           workspace,                      // Workspace
           pblh);                          // Output
@@ -343,8 +342,7 @@ Int Functions<S,D>::shoc_main(
     const auto tke_s          = ekat::subview(shoc_input_output.tke, i);
     const auto thetal_s       = ekat::subview(shoc_input_output.thetal, i);
     const auto qw_s           = ekat::subview(shoc_input_output.qw, i);
-    const auto u_wind_s       = ekat::subview(shoc_input_output.u_wind, i);
-    const auto v_wind_s       = ekat::subview(shoc_input_output.v_wind, i);
+    const auto horiz_wind_s   = ekat::subview(shoc_input_output.horiz_wind, i);
     const auto wthv_sec_s     = ekat::subview(shoc_input_output.wthv_sec, i);
     const auto tk_s           = ekat::subview(shoc_input_output.tk, i);
     const auto tkh_s          = ekat::subview(shoc_input_output.tkh, i);
@@ -376,7 +374,7 @@ Int Functions<S,D>::shoc_main(
                        wtracer_sfc_s, exner_s, phis_s,                         // Input
                        workspace,                                              // Workspace
                        X1_s,                                                   // Local variable
-                       host_dse_s, tke_s, thetal_s, qw_s, u_wind_s, v_wind_s,  // Input/Output
+                       host_dse_s, tke_s, thetal_s, qw_s, horiz_wind_s,        // Input/Output
                        wthv_sec_s, qtracers_s, tk_s, tkh_s, shoc_cldfrac_s,    // Input/Output
                        shoc_ql_s,                                              // Input/Output
                        pblh_s, shoc_ql2_s,                                     // Output

--- a/components/scream/src/physics/shoc/shoc_pblintd_height_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_pblintd_height_impl.hpp
@@ -21,8 +21,7 @@ void Functions<S,D>::pblintd_height(
   const Int& nlev,
   const Int& npbl,
   const uview_1d<const Spack>& z,
-  const uview_1d<const Spack>& u,
-  const uview_1d<const Spack>& v,
+  const uview_2d<const Spack>& horiz_wind,
   const Scalar& ustar,
   const uview_1d<const Spack>& thv,
   const Scalar& thv_ref,
@@ -54,8 +53,8 @@ void Functions<S,D>::pblintd_height(
     Spack vvk(0);
     vvk.set(in_range,
             ekat::max(tiny,
-                      ekat::square(u(k) - u(nlev_v)[nlev_p]) +
-                      ekat::square(v(k) - v(nlev_v)[nlev_p]) +
+                      ekat::square(horiz_wind(0,k) - horiz_wind(0,nlev_v)[nlev_p]) +
+                      ekat::square(horiz_wind(1,k) - horiz_wind(1,nlev_v)[nlev_p]) +
                       fac*(ustar*ustar)));
     rino(k).set(in_range,
                 ggr*(thv(k) - thv_ref)*(z(k) - z(nlev_v)[nlev_p])/(thv(nlev_v)[nlev_p]*vvk));

--- a/components/scream/src/physics/shoc/shoc_pblintd_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_pblintd_impl.hpp
@@ -49,8 +49,7 @@ void Functions<S,D>::pblintd(
   const uview_1d<const Spack>& thl,
   const uview_1d<const Spack>& ql,
   const uview_1d<const Spack>& q,
-  const uview_1d<const Spack>& u,
-  const uview_1d<const Spack>& v,
+  const uview_2d<const Spack>& horiz_wind,
   const Scalar&                ustar,
   const Scalar&                obklen,
   const Scalar&                kbfs,
@@ -79,7 +78,7 @@ void Functions<S,D>::pblintd(
 
   // PBL height calculation
   team.team_barrier();
-  pblintd_height(team,nlev,npbl,z,u,v,ustar,
+  pblintd_height(team,nlev,npbl,z,horiz_wind,ustar,
                  thv,thv(nlev_v)[nlev_p],
                  pblh,rino,check);
 
@@ -90,7 +89,7 @@ void Functions<S,D>::pblintd(
   // Improve pblh estimate for unstable conditions using the convective
   // temperature excess as reference temperature:
   team.team_barrier();
-  pblintd_height(team,nlev,npbl,z,u,v,ustar,
+  pblintd_height(team,nlev,npbl,z,horiz_wind,ustar,
                  thv,tlv,
                  pblh,rino,check);
 

--- a/components/scream/src/physics/shoc/shoc_tke_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_tke_impl.hpp
@@ -29,8 +29,7 @@ void Functions<S,D>::shoc_tke(
   const uview_1d<const Spack>& dz_zi,
   const uview_1d<const Spack>& dz_zt,
   const uview_1d<const Spack>& pres,
-  const uview_1d<const Spack>& u_wind,
-  const uview_1d<const Spack>& v_wind,
+  const uview_2d<const Spack> &horiz_wind,
   const uview_1d<const Spack>& brunt,
   const Scalar&                obklen,
   const uview_1d<const Spack>& zt_grid,
@@ -54,7 +53,7 @@ void Functions<S,D>::shoc_tke(
 
   // Compute shear production term, which is on interface levels
   // This follows the methods of Bretheron and Park (2010)
-  compute_shr_prod(team,nlevi,nlev,dz_zi,u_wind,v_wind,sterm);
+  compute_shr_prod(team,nlevi,nlev,dz_zi,horiz_wind,sterm);
 
   // Interpolate shear term from interface to thermo grid
   team.team_barrier();

--- a/components/scream/src/physics/shoc/shoc_update_prognostics_implicit_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_update_prognostics_implicit_impl.hpp
@@ -37,8 +37,7 @@ void Functions<S,D>::update_prognostics_implicit(
   const uview_1d<Spack>&       qw,
   const uview_2d<Spack>&       tracer,
   const uview_1d<Spack>&       tke,
-  const uview_1d<Spack>&       u_wind,
-  const uview_1d<Spack>&       v_wind)
+  const uview_2d<Spack>&       horiz_wind)
 {
   // Define temporary variables
   uview_1d<Spack> tmpi, tkh_zi,
@@ -90,8 +89,8 @@ void Functions<S,D>::update_prognostics_implicit(
     const Scalar taux = rho*uw;
     const Scalar tauy = rho*vw;
 
-    const Scalar u_wind_sfc = u_wind(last_nlev_pack)[last_nlev_indx];
-    const Scalar v_wind_sfc = v_wind(last_nlev_pack)[last_nlev_indx];
+    const Scalar u_wind_sfc = horiz_wind(0, last_nlev_pack)[last_nlev_indx];
+    const Scalar v_wind_sfc = horiz_wind(1, last_nlev_pack)[last_nlev_indx];
 
     const Scalar ws = ekat::impl::max(std::sqrt((u_wind_sfc*u_wind_sfc) + v_wind_sfc*v_wind_sfc), wsmin);
     const Scalar tau = std::sqrt(taux*taux + tauy*tauy);
@@ -119,8 +118,11 @@ void Functions<S,D>::update_prognostics_implicit(
 
   // Store RHS values in X1 and tracer for 1st and 2nd solve respectively
   team.team_barrier();
+  const auto u_wind = ekat::subview(horiz_wind, 0);
+  const auto v_wind = ekat::subview(horiz_wind, 1);
   const auto s_u_wind = ekat::scalarize(u_wind);
   const auto s_v_wind = ekat::scalarize(v_wind);
+
   const auto s_thetal = ekat::scalarize(thetal);
   const auto s_qw = ekat::scalarize(qw);
   const auto s_tke = ekat::scalarize(tke);


### PR DESCRIPTION
In SHOC, instead of `u_wind` and `v_wind`, now just `horiz_wind`.

For BFB testing, in the `blah_f()` functions in `shoc_functions_f90.cpp` I just create an extra `horiz_wind` view and copy both `u_wind` and `v_wind` view into `horiz_wind`. This is not efficient, but I believe these functions are only really used for BFB testing so this was just easier. I can change it if needed.