### PR TITLE
Port Homme's ColumnOps framework to scream

### DIFF
--- a/components/homme/src/share/cxx/Config.hpp
+++ b/components/homme/src/share/cxx/Config.hpp
@@ -43,4 +43,11 @@
 # define HOMMEXX_CUDA_MAX_WARP_PER_TEAM 1
 #endif
 
+#if defined KOKKOS_COMPILER_GNU
+// See https://github.com/kokkos/kokkos-kernels/issues/129
+# define ConstExceptGnu
+#else
+# define ConstExceptGnu const
+#endif
+
 #endif // HOMMEXX_CONFIG_HPP

--- a/components/homme/src/share/cxx/utilities/BfbUtils.hpp
+++ b/components/homme/src/share/cxx/utilities/BfbUtils.hpp
@@ -118,7 +118,6 @@ bfb_pow_impl (ScalarType val, ExpType e) {
     Kokkos::abort("Cannot take powers of negative numbers.\n");
   }
   if (e<-1.0 || e>1.5) {
-    printf("Bad exponent: %3.15f\n",1);
     Kokkos::abort("bfb_pow x^a impl-ed with only -1.0<a<1.5 in mind.\n");
   }
   if (val==ScalarType(0)) {

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
@@ -582,7 +582,9 @@ struct DirkFunctorImpl {
     };
     parallel_for(Kokkos::TeamThreadRange(kv.team, 1), f2);
     const auto f3 = [&] (const int km1) {
-      const auto k = km1 + 1;
+      // The following is morally a const var, but there are issues with
+      // gnu and std=c++14. The macro ConstExceptGnu is defined in share/cxx/Config.hpp.
+      ConstExceptGnu auto k = km1 + 1;
       const auto kr = [&] (const int i) {
         dpnh_dp_i(k,i) = ((pnh(k,i) - pnh(k-1,i))/
                           ((dp3d(k-1,i) + dp3d(k,i))/2));
@@ -721,7 +723,9 @@ struct DirkFunctorImpl {
     };
     parallel_for(pt1, f1);
     const auto f2 = [&] (const int km1) {
-      const auto k = km1 + 1;
+      // The following is morally a const var, but there are issues with
+      // gnu and std=c++14. The macro ConstExceptGnu is defined in share/cxx/Config.hpp.
+      ConstExceptGnu  auto k = km1 + 1;
       const auto kmid = [&] (const int i) { // middle Jacobian rows
         const auto b = 2*a/(dp3d(k-1,i) + dp3d(k,i));
         dl(k,i) = b*(pnh(k-1,i)/dphi(k-1,i));

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -48,7 +48,7 @@ if (Kokkos_ENABLE_CUDA)
   EkatSetNvccWrapper()
 endif()
 
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 14)
 
 if (NOT SCREAM_CIME_BUILD)
   project(SCREAM CXX Fortran)

--- a/components/scream/src/physics/p3/p3_upwind_impl.hpp
+++ b/components/scream/src/physics/p3/p3_upwind_impl.hpp
@@ -32,7 +32,10 @@ void Functions<S,D>
     // Add 1 to make [kmin, kmax). But then the extra term (Spack::n -
     // 1) to determine pack index cancels the +1.
     kmax = (kmax_scalar + Spack::n) / Spack::n;
-  const Int k_top_pack = k_top / Spack::n;
+
+  // The following is morally a const var, but there are issues with
+  // gnu and std=c++14. The macro ConstExceptGnu is defined in ekat_kokkos_types.hpp.
+  ConstExceptGnu Int k_top_pack = k_top / Spack::n;
 
   // calculate fluxes
   Kokkos::parallel_for(

--- a/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
@@ -258,7 +258,7 @@ void Functions<S,D>::shoc_assumed_pdf(
       Spack s1(0), std_s1(0), qn1(0), C1(0), ql1(0),
             s2(0), std_s2(0), qn2(0), C2(0), ql2(0);
       {
-        const Scalar sqrt2(std::sqrt(2)), sqrt2pi(std::sqrt(2*pi));
+        const Scalar sqrt2(std::sqrt(Scalar(2.0))), sqrt2pi(std::sqrt(2*pi));
 
         // First plume
         const Spack cthl1=((1 + beta1*qw1_1)/ekat::square(1 + beta1*qs1))*(cp/lcond)*

--- a/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
@@ -81,7 +81,9 @@ void Functions<S,D>::shoc_assumed_pdf(
   linear_interp(team,zi_grid,zt_grid,wqw_sec,wqw_sec_zt,nlevi,nlev,largeneg);
   linear_interp(team,zi_grid,zt_grid,qw_sec,qw_sec_zt,nlevi,nlev,0);
 
-  const Int nlev_pack = ekat::npack<Spack>(nlev);
+  // The following is morally a const var, but there are issues with
+  // gnu and std=c++14. The macro ConstExceptGnu is defined in ekat_kokkos_types.hpp.
+  ConstExceptGnu Int nlev_pack = ekat::npack<Spack>(nlev);
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
 
     // Store active pack entries

--- a/components/scream/src/share/tests/CMakeLists.txt
+++ b/components/scream/src/share/tests/CMakeLists.txt
@@ -2,6 +2,9 @@
 if (NOT ${SCREAM_BASELINES_ONLY})
   include(ScreamUtils)
 
+  # Test column ops
+  CreateUnitTest(column_ops "column_ops.cpp" scream_share)
+
   # Test fields
   CreateUnitTest(field "field_tests.cpp" scream_share)
 

--- a/components/scream/src/share/tests/column_ops.cpp
+++ b/components/scream/src/share/tests/column_ops.cpp
@@ -431,7 +431,7 @@ TEST_CASE("column_ops_ps_1") {
 
 TEST_CASE("column_ops_ps_N") {
   // No point in re-running test for a larger pack size
-  if (!ekat::OnGpu<ekat::DefaultDevice>::value) {
+  if (!ekat::OnGpu<ekat::DefaultDevice::execution_space>::value) {
     using namespace scream;
     using device_type = DefaultDevice;
     using KT = ekat::KokkosTypes<device_type>;

--- a/components/scream/src/share/tests/column_ops.cpp
+++ b/components/scream/src/share/tests/column_ops.cpp
@@ -27,11 +27,11 @@ TEST_CASE ("combine_ops") {
   pack_type x;
 
   x = two;
-  combine<Replace>(two,x,1.0,0.0);
+  combine<Replace>(two,x);
   REQUIRE ( (x==two).all() );
 
   x = two;
-  combine<Scale>(two,x,3.0,0.0);
+  combine<Scale>(two,x,3.0);
   REQUIRE ( (x==six).all() );
 
   x = two;
@@ -43,19 +43,19 @@ TEST_CASE ("combine_ops") {
   REQUIRE ( (x==six).all() );
 
   x = two;
-  combine<ScaleAdd>(two,x,2.0,0.0);
+  combine<ScaleAdd>(two,x,2.0);
   REQUIRE ( (x==six).all() );
 
   x = two;
-  combine<Add>(two,x,1.0,0.0);
+  combine<Add>(two,x);
   REQUIRE ( (x==four).all() );
 
   x = two;
-  combine<Multiply>(two,x,1.0,0.0);
+  combine<Multiply>(two,x);
   REQUIRE ( (x==four).all() );
 
   x = four;
-  combine<Divide>(two,x,1.0,0.0);
+  combine<Divide>(two,x);
   REQUIRE ( (x==two).all() );
 }
 

--- a/components/scream/src/share/tests/column_ops.cpp
+++ b/components/scream/src/share/tests/column_ops.cpp
@@ -74,7 +74,7 @@ TEST_CASE("column_ops_ps_1") {
   using column_ops    = ColumnOps<device_type,Real,1>;
 
   constexpr int num_cols = 1;
-  constexpr int num_levs = 10;
+  constexpr int num_levs = 16;
 
   policy_type policy(num_cols,std::min(num_levs,exec_space::concurrency()));
 

--- a/components/scream/src/share/tests/column_ops.cpp
+++ b/components/scream/src/share/tests/column_ops.cpp
@@ -1,0 +1,637 @@
+#include <Kokkos_CopyViews.hpp>
+#include <Kokkos_Parallel.hpp>
+#include <catch2/catch.hpp>
+
+#include "ekat/kokkos/ekat_kokkos_types.hpp"
+#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include "share/util/scream_column_ops.hpp"
+
+namespace {
+
+TEST_CASE ("combine_ops") {
+  using namespace scream;
+  using pack_type = ekat::Pack<Real,SCREAM_PACK_SIZE>;
+
+  constexpr auto Replace     = CombineMode::Replace;
+  constexpr auto Scale       = CombineMode::Scale;
+  constexpr auto Update      = CombineMode::Update;
+  constexpr auto ScaleUpdate = CombineMode::ScaleUpdate;
+  constexpr auto ScaleAdd    = CombineMode::ScaleAdd;
+  constexpr auto Add         = CombineMode::Add;
+  constexpr auto Multiply    = CombineMode::Multiply;
+  constexpr auto Divide      = CombineMode::Divide;
+
+  pack_type two (2.0);
+  pack_type four (4.0);
+  pack_type six (6.0);
+  pack_type x;
+
+  x = two;
+  combine<Replace>(two,x,1.0,0.0);
+  REQUIRE ( (x==two).all() );
+
+  x = two;
+  combine<Scale>(two,x,3.0,0.0);
+  REQUIRE ( (x==six).all() );
+
+  x = two;
+  combine<Update>(two,x,1.0,2.0);
+  REQUIRE ( (x==six).all() );
+
+  x = two;
+  combine<ScaleUpdate>(two,x,2.0,1.0);
+  REQUIRE ( (x==six).all() );
+
+  x = two;
+  combine<ScaleAdd>(two,x,2.0,0.0);
+  REQUIRE ( (x==six).all() );
+
+  x = two;
+  combine<Add>(two,x,1.0,0.0);
+  REQUIRE ( (x==four).all() );
+
+  x = two;
+  combine<Multiply>(two,x,1.0,0.0);
+  REQUIRE ( (x==four).all() );
+
+  x = four;
+  combine<Divide>(two,x,1.0,0.0);
+  REQUIRE ( (x==two).all() );
+}
+
+TEST_CASE("column_ops_ps_1") {
+  using namespace scream;
+  using device_type = DefaultDevice;
+  using KT = ekat::KokkosTypes<device_type>;
+  using pack_type = ekat::Pack<Real,1>;
+  using exec_space = typename device_type::execution_space;
+
+  using view_2d_type  = KT::view_2d<pack_type>;
+  using uview_1d_type = KT::view_1d<pack_type>;
+  using policy_type   = KT::TeamPolicy;
+  using member_type   = KT::MemberType;
+  using column_ops    = ColumnOps<device_type,Real,1>;
+
+  constexpr int num_cols = 1;
+  constexpr int num_levs = 10;
+
+  policy_type policy(num_cols,std::min(num_levs,exec_space::concurrency()));
+
+  view_2d_type v_int("",num_cols,num_levs+1);
+  view_2d_type v_mid("",num_cols,num_levs);
+  view_2d_type dv_mid("",num_cols,num_levs);
+  auto v_int_h = Kokkos::create_mirror_view(v_int);
+  auto v_mid_h = Kokkos::create_mirror_view(v_mid);
+  auto dv_mid_h = Kokkos::create_mirror_view(dv_mid);
+
+  SECTION ("int_to_mid") {
+
+    // Fill v_int with odd numbers, so that v_mid should contain even ones.
+    for (int k=0; k<num_levs+1; ++k) {
+      v_int_h(0,k)[0] = 2*k+1;
+    }
+    Kokkos::deep_copy(v_int,v_int_h);
+
+    // Run column kernel
+    Kokkos::parallel_for(policy,
+                         KOKKOS_LAMBDA(const member_type& team){
+      const int icol = team.league_rank();
+      uview_1d_type v_i = ekat::subview(v_int,icol);
+      uview_1d_type v_m = ekat::subview(v_mid,icol);
+
+      column_ops::compute_midpoint_values(team,num_levs,v_i,v_m);
+    });
+    Kokkos::fence();
+
+    // Check answer
+    Kokkos::deep_copy(v_mid_h,v_mid);
+    for (int k=0; k<num_levs; ++k) {
+      REQUIRE (v_mid_h(0,k)[0] == 2*(k+1) );
+    }
+
+    // Re-do with lambda as provider
+    Kokkos::deep_copy(v_mid,pack_type(0));
+    Kokkos::parallel_for(policy,
+                         KOKKOS_LAMBDA(const member_type& team){
+      const int icol = team.league_rank();
+      
+      auto v_i = [&](const int k)->pack_type {
+        return v_int(icol,k);
+      };
+      uview_1d_type v_m = ekat::subview(v_mid,icol);
+
+      column_ops::compute_midpoint_values(team,num_levs,v_i,v_m);
+    });
+    Kokkos::fence();
+
+    // Check answer
+    Kokkos::deep_copy(v_mid_h,v_mid);
+    for (int k=0; k<num_levs; ++k) {
+      REQUIRE (v_mid_h(0,k)[0] == 2*(k+1) );
+    }
+  }
+
+  SECTION ("mid_to_int") {
+
+    // Fill v_mid with even numbers, so that v_int should contain odd ones.
+    for (int k=0; k<num_levs; ++k) {
+      v_mid_h(0,k)[0] = 2*(k+1);
+    }
+    Kokkos::deep_copy(v_mid,v_mid_h);
+
+    // Run column kernel
+    Kokkos::parallel_for(policy,
+                         KOKKOS_LAMBDA(const member_type& team){
+      const int icol = team.league_rank();
+      uview_1d_type v_i = ekat::subview(v_int,icol);
+      uview_1d_type v_m = ekat::subview(v_mid,icol);
+
+      column_ops::compute_interface_values(team,num_levs,v_m,1,2*num_levs+1,v_i);
+    });
+    Kokkos::fence();
+
+    // Check answer
+    Kokkos::deep_copy(v_int_h,v_int);
+    for (int k=0; k<num_levs+1; ++k) {
+      REQUIRE (v_int_h(0,k)[0] == 2*k+1 );
+    }
+
+    // Re-do with lambda as provider
+    Kokkos::deep_copy(v_int,pack_type(0));
+    Kokkos::parallel_for(policy,
+                         KOKKOS_LAMBDA(const member_type& team){
+      const int icol = team.league_rank();
+      
+      auto v_m = [&](const int k)->pack_type {
+        return v_mid(icol,k);
+      };
+      uview_1d_type v_i = ekat::subview(v_int,icol);
+
+      column_ops::compute_interface_values(team,num_levs,v_m,1,2*num_levs+1,v_i);
+    });
+    Kokkos::fence();
+
+    // Check answer
+    Kokkos::deep_copy(v_int_h,v_int);
+    for (int k=0; k<num_levs+1; ++k) {
+      REQUIRE (v_int_h(0,k)[0] == 2*k+1 );
+    }
+  }
+
+  SECTION ("delta") {
+
+    // Fill v_int with odd numbers, so that dv_mid=2 on all levels
+    for (int k=0; k<num_levs+1; ++k) {
+      v_int_h(0,k)[0] = 2*k+1;
+    }
+    Kokkos::deep_copy(v_int,v_int_h);
+
+    // Run column kernel
+    Kokkos::parallel_for(policy,
+                         KOKKOS_LAMBDA(const member_type& team){
+      const int icol = team.league_rank();
+      uview_1d_type v_i = ekat::subview(v_int,icol);
+      uview_1d_type dv_m = ekat::subview(dv_mid,icol);
+
+      column_ops::compute_midpoint_delta(team,num_levs,v_i,dv_m);
+    });
+    Kokkos::fence();
+
+    // Check answer
+    Kokkos::deep_copy(dv_mid_h,dv_mid);
+    for (int k=0; k<num_levs; ++k) {
+      REQUIRE (dv_mid_h(0,k)[0] == 2 );
+    }
+
+    // Re-do with lambda as provider
+    Kokkos::deep_copy(dv_mid,pack_type(0));
+    Kokkos::parallel_for(policy,
+                         KOKKOS_LAMBDA(const member_type& team){
+      const int icol = team.league_rank();
+      
+      auto v_i = [&](const int k)->pack_type {
+        return v_int(icol,k);
+      };
+      uview_1d_type dv_m = ekat::subview(dv_mid,icol);
+
+      column_ops::compute_midpoint_delta(team,num_levs,v_i,dv_m);
+    });
+    Kokkos::fence();
+
+    // Check answer
+    Kokkos::deep_copy(dv_mid_h,dv_mid);
+    for (int k=0; k<num_levs; ++k) {
+      REQUIRE (dv_mid_h(0,k)[0] == 2 );
+    }
+  }
+
+  SECTION ("scan_from_top") {
+
+    const Real s0 = -2.0; // If it worskfor s0!=0, it works for s0=0.
+
+    // Fill v_mid with integers, then use Gauss formula to check the sum
+    for (int k=0; k<num_levs; ++k) {
+      dv_mid_h(0,k)[0] = k+1;
+    }
+    Kokkos::deep_copy(dv_mid,dv_mid_h);
+
+    // Run column kernel
+    Kokkos::parallel_for(policy,
+                         KOKKOS_LAMBDA(const member_type& team){
+      const int icol = team.league_rank();
+      uview_1d_type v_i = ekat::subview(v_int,icol);
+      uview_1d_type dv_m = ekat::subview(dv_mid,icol);
+
+      column_ops::column_scan<true>(team,num_levs,dv_m,v_i,s0);
+    });
+    Kokkos::fence();
+
+    // Check answer
+    Kokkos::deep_copy(v_int_h,v_int);
+    for (int k=0; k<num_levs+1; ++k) {
+      REQUIRE (v_int_h(0,k)[0] == s0+k*(k+1)/2.0);
+    }
+
+    // Re-do with lambda as provider
+    Kokkos::deep_copy(v_int,pack_type(0));
+    Kokkos::parallel_for(policy,
+                         KOKKOS_LAMBDA(const member_type& team){
+      const int icol = team.league_rank();
+      
+      auto dv_m = [&](const int k)->pack_type {
+        return dv_mid(icol,k);
+      };
+      uview_1d_type v_i = ekat::subview(v_int,icol);
+
+      column_ops::column_scan<true>(team,num_levs,dv_m,v_i,s0);
+    });
+    Kokkos::fence();
+
+    // Check answer
+    Kokkos::deep_copy(v_int_h,v_int);
+    for (int k=0; k<num_levs+1; ++k) {
+      REQUIRE (v_int_h(0,k)[0] == s0+k*(k+1)/2.0);
+    }
+  }
+
+  SECTION ("scan_from_bot") {
+
+    const Real s0 = -2.0; // If it worskfor s0!=0, it works for s0=0.
+
+    // Fill v_mid with integers, then use Gauss formula to check the sum
+    for (int k=0; k<num_levs; ++k) {
+      const auto k_bwd = num_levs - k - 1;
+      dv_mid_h(0,k_bwd)[0] = k+1;
+    }
+    Kokkos::deep_copy(dv_mid,dv_mid_h);
+
+    // Run column kernel
+    Kokkos::parallel_for(policy,
+                         KOKKOS_LAMBDA(const member_type& team){
+      const int icol = team.league_rank();
+      uview_1d_type v_i = ekat::subview(v_int,icol);
+      uview_1d_type dv_m = ekat::subview(dv_mid,icol);
+
+      column_ops::column_scan<false>(team,num_levs,dv_m,v_i,s0);
+    });
+    Kokkos::fence();
+
+    // Check answer
+    Kokkos::deep_copy(v_int_h,v_int);
+    for (int k=0; k<num_levs+1; ++k) {
+      const auto k_bwd = num_levs - k;
+      REQUIRE (v_int_h(0,k_bwd)[0] == s0+k*(k+1)/2.0);
+    }
+
+    // Re-do with lambda as provider
+    Kokkos::deep_copy(v_int,pack_type(0));
+    Kokkos::parallel_for(policy,
+                         KOKKOS_LAMBDA(const member_type& team){
+      const int icol = team.league_rank();
+      
+      auto dv_m = [&](const int k)->pack_type {
+        return dv_mid(icol,k);
+      };
+      uview_1d_type v_i = ekat::subview(v_int,icol);
+
+      column_ops::column_scan<false>(team,num_levs,dv_m,v_i,s0);
+    });
+    Kokkos::fence();
+
+    // Check answer
+    Kokkos::deep_copy(v_int_h,v_int);
+    for (int k=0; k<num_levs+1; ++k) {
+      const auto k_bwd = num_levs - k;
+      REQUIRE (v_int_h(0,k_bwd)[0] == s0+k*(k+1)/2.0);
+    }
+  }
+}
+
+TEST_CASE("column_ops_ps_N") {
+  // No point in re-running test for a larger pack size
+  if (SCREAM_PACK_SIZE>1) {
+    using namespace scream;
+    using device_type = DefaultDevice;
+    using KT = ekat::KokkosTypes<device_type>;
+    constexpr int ps = SCREAM_PACK_SIZE;
+    using pack_type = ekat::Pack<Real,ps>;
+    using exec_space = typename device_type::execution_space;
+
+    using view_2d_type  = KT::view_2d<pack_type>;
+    using uview_1d_type = KT::view_1d<pack_type>;
+    using policy_type   = KT::TeamPolicy;
+    using member_type   = KT::MemberType;
+    using column_ops    = ColumnOps<device_type,Real,ps>;
+
+    constexpr int num_cols = 1;
+    // Test both the case where num_mid_packs==num_int_packs, and
+    // the case where num_int_packs=num_mid_packs+1.
+    for (int num_levs : {2*ps, 2*ps+1} ) {
+      const int num_mid_packs = ekat::PackInfo<ps>::num_packs(num_levs);
+      const int num_int_packs = ekat::PackInfo<ps>::num_packs(num_levs+1);
+
+      view_2d_type v_mid("",num_cols,num_mid_packs);
+      view_2d_type v_int("",num_cols,num_int_packs);
+      view_2d_type dv_mid("",num_cols,num_mid_packs);
+      auto v_int_h = Kokkos::create_mirror_view(v_int);
+      auto v_mid_h = Kokkos::create_mirror_view(v_mid);
+      auto dv_mid_h = Kokkos::create_mirror_view(dv_mid);
+
+      policy_type policy(num_cols,std::min(num_mid_packs,exec_space::concurrency()));
+
+      SECTION ("int_to_mid") {
+
+        // Fill v_int with odd numbers, so that v_mid should contain even ones.
+        for (int k=0; k<num_levs+1; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          v_int_h(0,ipack)[ivec] = 2*k+1;
+        }
+        Kokkos::deep_copy(v_int,v_int_h);
+
+        // Run column kernel
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const member_type& team){
+          const int icol = team.league_rank();
+          uview_1d_type v_i = ekat::subview(v_int,icol);
+          uview_1d_type v_m = ekat::subview(v_mid,icol);
+
+          column_ops::compute_midpoint_values(team,num_levs,v_i,v_m);
+        });
+        Kokkos::fence();
+
+        // Check answer
+        Kokkos::deep_copy(v_mid_h,v_mid);
+        for (int k=0; k<num_levs; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          REQUIRE (v_mid_h(0,ipack)[ivec] == 2*(k+1) );
+        }
+
+        // Re-do with lambda as provider
+        Kokkos::deep_copy(v_mid,pack_type(0));
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const member_type& team){
+          const int icol = team.league_rank();
+          
+          auto v_i = [&](const int k)->pack_type {
+            return v_int(icol,k);
+          };
+          uview_1d_type v_m = ekat::subview(v_mid,icol);
+
+          column_ops::compute_midpoint_values(team,num_levs,v_i,v_m);
+        });
+        Kokkos::fence();
+
+        // Check answer
+        Kokkos::deep_copy(v_mid_h,v_mid);
+        for (int k=0; k<num_levs; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          REQUIRE (v_mid_h(0,ipack)[ivec] == 2*(k+1) );
+        }
+      }
+
+      SECTION ("mid_to_int") {
+
+        // Fill v_mid with even numbers, so that v_int should contain odd ones.
+        for (int k=0; k<num_levs; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          v_mid_h(0,ipack)[ivec] = 2*(k+1);
+        }
+        Kokkos::deep_copy(v_mid,v_mid_h);
+
+        // Run column kernel
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const member_type& team){
+          const int icol = team.league_rank();
+          uview_1d_type v_i = ekat::subview(v_int,icol);
+          uview_1d_type v_m = ekat::subview(v_mid,icol);
+
+          column_ops::compute_interface_values(team,num_levs,v_m,1,2*num_levs+1,v_i);
+        });
+        Kokkos::fence();
+
+        // Check answer
+        Kokkos::deep_copy(v_int_h,v_int);
+        for (int k=0; k<num_levs+1; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          REQUIRE (v_int_h(0,ipack)[ivec] == 2*k+1 );
+        }
+
+        // Re-do with lambda as provider
+        Kokkos::deep_copy(v_int,pack_type(0));
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const member_type& team){
+          const int icol = team.league_rank();
+          
+          auto v_m = [&](const int k)->pack_type {
+            return v_mid(icol,k);
+          };
+          uview_1d_type v_i = ekat::subview(v_int,icol);
+
+          column_ops::compute_interface_values(team,num_levs,v_m,1,2*num_levs+1,v_i);
+        });
+        Kokkos::fence();
+
+        // Check answer
+        Kokkos::deep_copy(v_int_h,v_int);
+        for (int k=0; k<num_levs+1; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          REQUIRE (v_int_h(0,ipack)[ivec] == 2*k+1 );
+        }
+      }
+
+      SECTION ("delta") {
+
+        // Fill v_int with odd numbers, so that dv_mid=2 on all levels
+        for (int k=0; k<num_levs+1; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          v_int_h(0,ipack)[ivec] = 2*k+1;
+        }
+        Kokkos::deep_copy(v_int,v_int_h);
+
+        // Run column kernel
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const member_type& team){
+          const int icol = team.league_rank();
+          uview_1d_type v_i = ekat::subview(v_int,icol);
+          uview_1d_type dv_m = ekat::subview(dv_mid,icol);
+
+          column_ops::compute_midpoint_delta(team,num_levs,v_i,dv_m);
+        });
+        Kokkos::fence();
+
+        // Check answer
+        Kokkos::deep_copy(dv_mid_h,dv_mid);
+        for (int k=0; k<num_levs; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          REQUIRE (dv_mid_h(0,ipack)[ivec] == 2 );
+        }
+
+        // Re-do with lambda as provider
+        Kokkos::deep_copy(dv_mid,pack_type(0));
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const member_type& team){
+          const int icol = team.league_rank();
+          
+          auto v_i = [&](const int k)->pack_type {
+            return v_int(icol,k);
+          };
+          uview_1d_type dv_m = ekat::subview(dv_mid,icol);
+
+          column_ops::compute_midpoint_delta(team,num_levs,v_i,dv_m);
+        });
+        Kokkos::fence();
+
+        // Check answer
+        Kokkos::deep_copy(dv_mid_h,dv_mid);
+        for (int k=0; k<num_levs; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          REQUIRE (dv_mid_h(0,ipack)[ivec] == 2 );
+        }
+      }
+
+      SECTION ("scan_from_top") {
+
+        const Real s0 = -2.0; // If it worskfor s0!=0, it works for s0=0.
+
+        // Fill v_mid with integers, then use Gauss formula to check the sum
+        for (int k=0; k<num_levs; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          dv_mid_h(0,ipack)[ivec] = k+1;
+        }
+        Kokkos::deep_copy(dv_mid,dv_mid_h);
+
+        // Run column kernel
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const member_type& team){
+          const int icol = team.league_rank();
+          uview_1d_type v_i = ekat::subview(v_int,icol);
+          uview_1d_type dv_m = ekat::subview(dv_mid,icol);
+
+          column_ops::column_scan<true>(team,num_levs,dv_m,v_i,s0);
+        });
+        Kokkos::fence();
+
+        // Check answer
+        Kokkos::deep_copy(v_int_h,v_int);
+        for (int k=0; k<num_levs+1; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          REQUIRE (v_int_h(0,ipack)[ivec] == s0+k*(k+1)/2.0);
+        }
+
+        // Re-do with lambda as provider
+        Kokkos::deep_copy(v_int,pack_type(0));
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const member_type& team){
+          const int icol = team.league_rank();
+          
+          auto dv_m = [&](const int k)->pack_type {
+            return dv_mid(icol,k);
+          };
+          uview_1d_type v_i = ekat::subview(v_int,icol);
+
+          column_ops::column_scan<true>(team,num_levs,dv_m,v_i,s0);
+        });
+        Kokkos::fence();
+
+        // Check answer
+        Kokkos::deep_copy(v_int_h,v_int);
+        for (int k=0; k<num_levs+1; ++k) {
+          const int ipack = k / ps;
+          const int ivec  = k % ps;
+          REQUIRE (v_int_h(0,ipack)[ivec] == s0+k*(k+1)/2.0);
+        }
+      }
+
+      SECTION ("scan_from_bot") {
+
+        const Real s0 = -2.0; // If it worskfor s0!=0, it works for s0=0.
+
+        // Fill v_mid with integers, then use Gauss formula to check the sum
+        for (int k=0; k<num_levs; ++k) {
+          const auto k_bwd = num_levs - k - 1;
+          const int ipack = k_bwd / ps;
+          const int ivec  = k_bwd % ps;
+          dv_mid_h(0,ipack)[ivec] = k+1;
+        }
+        Kokkos::deep_copy(dv_mid,dv_mid_h);
+
+        // Run column kernel
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const member_type& team){
+          const int icol = team.league_rank();
+          uview_1d_type v_i = ekat::subview(v_int,icol);
+          uview_1d_type dv_m = ekat::subview(dv_mid,icol);
+
+          column_ops::column_scan<false>(team,num_levs,dv_m,v_i,s0);
+        });
+        Kokkos::fence();
+
+        // Check answer
+        Kokkos::deep_copy(v_int_h,v_int);
+        for (int k=0; k<num_levs+1; ++k) {
+          const auto k_bwd = num_levs - k;
+          const int ipack = k_bwd / ps;
+          const int ivec  = k_bwd % ps;
+          REQUIRE (v_int_h(0,ipack)[ivec] == s0+k*(k+1)/2.0);
+        }
+
+        // Re-do with lambda as provider
+        Kokkos::deep_copy(v_int,pack_type(0));
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const member_type& team){
+          const int icol = team.league_rank();
+          
+          auto dv_m = [&](const int k)->pack_type {
+            return dv_mid(icol,k);
+          };
+          uview_1d_type v_i = ekat::subview(v_int,icol);
+
+          column_ops::column_scan<false>(team,num_levs,dv_m,v_i,s0);
+        });
+        Kokkos::fence();
+
+        // Check answer
+        Kokkos::deep_copy(v_int_h,v_int);
+        for (int k=0; k<num_levs+1; ++k) {
+          const auto k_bwd = num_levs - k;
+          const int ipack = k_bwd / ps;
+          const int ivec  = k_bwd % ps;
+          REQUIRE (v_int_h(0,ipack)[ivec] == s0+k*(k+1)/2.0);
+        }
+      }
+    }
+  }
+}
+
+} // anonymous namespace

--- a/components/scream/src/share/tests/column_ops.cpp
+++ b/components/scream/src/share/tests/column_ops.cpp
@@ -4,6 +4,7 @@
 
 #include "ekat/kokkos/ekat_kokkos_types.hpp"
 #include "ekat/kokkos/ekat_subview_utils.hpp"
+#include "ekat/util/ekat_arch.hpp"
 #include "share/util/scream_column_ops.hpp"
 
 namespace {
@@ -430,7 +431,7 @@ TEST_CASE("column_ops_ps_1") {
 
 TEST_CASE("column_ops_ps_N") {
   // No point in re-running test for a larger pack size
-  if (SCREAM_PACK_SIZE>1) {
+  if (!ekat::OnGpu<ekat::DefaultDevice>::value) {
     using namespace scream;
     using device_type = DefaultDevice;
     using KT = ekat::KokkosTypes<device_type>;
@@ -448,6 +449,7 @@ TEST_CASE("column_ops_ps_N") {
     // Test both the case where num_mid_packs==num_int_packs, and
     // the case where num_int_packs=num_mid_packs+1.
     for (int num_levs : {2*ps, 2*ps+1} ) {
+      std::cout << "num_levs: " << num_levs << "\n";
       const int num_mid_packs = ekat::PackInfo<ps>::num_packs(num_levs);
       const int num_int_packs = ekat::PackInfo<ps>::num_packs(num_levs+1);
 

--- a/components/scream/src/share/util/scream_column_ops.hpp
+++ b/components/scream/src/share/util/scream_column_ops.hpp
@@ -72,7 +72,9 @@ public:
   template<typename T>
   using view_1d = typename KT::template view_1d<T>;
 
+  KOKKOS_INLINE_FUNCTION
   static constexpr scalar_type one  () { return scalar_type(1); }
+  KOKKOS_INLINE_FUNCTION
   static constexpr scalar_type zero () { return scalar_type(0); }
 
   // All functions have an 'input' provider template parameter. This can

--- a/components/scream/src/share/util/scream_column_ops.hpp
+++ b/components/scream/src/share/util/scream_column_ops.hpp
@@ -1,0 +1,489 @@
+#ifndef SCREAM_COLUMN_OPS_HPP
+#define SCREAM_COLUMN_OPS_HPP
+
+#include <type_traits>
+#include "ekat/ekat_pack.hpp"
+#include "ekat/ekat_pack_math.hpp"
+#include "share/util/scream_combine_ops.hpp"
+#include "share/scream_types.hpp"
+
+#include "ekat/kokkos/ekat_kokkos_types.hpp"
+#include "ekat/ekat_pack_utils.hpp"
+#include "ekat/util//ekat_arch.hpp"
+#include "ekat/ekat_pack.hpp"
+
+namespace scream {
+
+/*
+ *  ColumnOps: a series of utility kernels that operate on a single column
+ *
+ *  This class is responsible of implementing common kernels used in
+ *  scream to compute quantities at level midpoints and level interfaces.
+ *  For instance, compute interface quantities from midpoints
+ *  ones, or integrate over a column, or compute increments of midpoint
+ *  quantities (which will be defined at interfaces).
+ *  The kernels are meant to be launched from within a parallel region, with
+ *  team policy. More precisely, they are meant to be called from the outer most
+ *  parallel region. In other words, you should *not* be inside a TeamThreadRange
+ *  parallel loop when calling these kernels, since these kernels will attempt
+ *  to create such loops. Furthermore, these kernels *assume* that the team policy
+ *  vector length (on CUDA) is 1. We have no way of checking this (the vector length
+ *  is stored in the policy, but not in the team member), so you must make
+ *  sure that this is the case.
+ *
+ *  In the compute_* methods, InputProvider can either be a functor (e.g., a lambda)
+ *  or a 1d view. The only requirement is that operator()(int) is defined,
+ *  and returns a Pack<ScalarType,PackSize>.
+ *  For instance, one could use a lambda to compute the midpoint average of
+ *  the product of two interface quantities, like this:
+ *
+ *    using col_ops = ColumnOps<DefaultDevice,Real,N>;
+ *    using pack_type = typename col_ops::pack_type;
+ *    
+ *    auto prod = [&](const int k)->pack_type { return x(k)*y(k); }
+ *    col_ops::compute_midpoint_values(team,prod,output);
+ *
+ *  Note: all methods have a different impl, depending on whether PackSize>1.
+ *        The if statement is evaluated at compile-time, so there is no run-time
+ *        penalization. The only requirement is that both branches must compile.
+ *        Also, the impl for PackSize>1 is not thread safe (no ||for or single),
+ *        so it would *not* work on GPU. Hence, the whole class has a static_assert
+ *        to make sure we have PackSize==1 if we are in a GPU build.
+ */
+
+template<typename DeviceType, typename ScalarType, int PackSize>
+class ColumnOps {
+public:
+  // Expose template params
+  using device_type = DeviceType;
+  using scalar_type = ScalarType;
+  using pack_type   = ekat::Pack<scalar_type,PackSize>;
+
+  // Pack info
+  enum : int {
+    pack_size = PackSize,
+  };
+  using pack_info = ekat::PackInfo<pack_size>;
+
+  // Kokkos types
+  using exec_space = typename device_type::execution_space;
+  using KT = ekat::KokkosTypes<device_type>;
+
+  using TeamMember = typename KT::MemberType;
+
+  template<typename T>
+  using view_1d = typename KT::template view_1d<T>;
+
+
+  static constexpr scalar_type one  () { return scalar_type(1); }
+  static constexpr scalar_type zero () { return scalar_type(0); }
+
+  // All functions have an 'input' provider template parameter. This can
+  // either be a lambda (to allow input calculation on the fly) or a 1d view.
+  // By default, it is a view.
+  using DefaultProvider = view_1d<const pack_type>;
+
+  // Runs the input lambda with a TeamThreadRange parallel for over [0,count) range
+  template<typename Lambda>
+  KOKKOS_INLINE_FUNCTION
+  static void team_parallel_for (const TeamMember& team,
+                                 const int count,
+                                const Lambda& f) {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,count),f);
+  }
+
+  // Runs the input lambda with a TeamThreadRange parallel for over [start,end) range
+  template<typename Lambda>
+  KOKKOS_INLINE_FUNCTION
+  static void team_parallel_for (const TeamMember& team,
+                                 const int start,
+                                 const int end,
+                                 const Lambda& f) {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,start,end),f);
+  }
+
+  // Runs the input lambda with a TeamThreadRange parallel scan over [0,count) range
+  template<typename Lambda>
+  KOKKOS_INLINE_FUNCTION
+  static void team_parallel_scan (const TeamMember& team,
+                                  const int count,
+                                  const Lambda& f) {
+    Kokkos::parallel_scan(Kokkos::TeamThreadRange(team,count),f);
+  }
+  template<typename Lambda>
+  KOKKOS_INLINE_FUNCTION
+  static void team_parallel_scan (const TeamMember& team,
+                                  const int start,
+                                  const int end,
+                                  const Lambda& f) {
+    Kokkos::parallel_scan(Kokkos::TeamThreadRange(team,start,end),f);
+  }
+
+  // Runs the input lambda only for one team thread
+  template<typename Lambda>
+  KOKKOS_INLINE_FUNCTION
+  static void team_single (const TeamMember& team,
+                           const Lambda& f) {
+    Kokkos::single(Kokkos::PerTeam(team),f);
+  }
+
+  template<typename InputProvider>
+  KOKKOS_INLINE_FUNCTION
+  static void debug_checks (const int num_levels, const view_1d<pack_type>& x) {
+
+    // Mini function to check that InputProvider supports op()(int)->pack_type,
+    // and that the number of levels is compatible with pack_type and x's size.
+
+    const auto npacks_min = pack_info::num_packs(num_levels);
+    EKAT_KERNEL_ASSERT_MSG (num_levels>=0 && x.extent_int(0)>=npacks_min,
+        "Error! Number of levels out of bounds.\n");
+
+    using ret_type = decltype(std::declval<InputProvider>()(0));
+    using raw_ret_type = typename std::remove_const<typename std::remove_reference<ret_type>::type>::type;
+
+    static_assert(std::is_same<raw_ret_type,pack_type>::value,
+      "Error! InputProvider should expose op()(int), returning a pack type.\n");
+  }
+
+  // Safety checks
+  static_assert(!ekat::OnGpu<exec_space>::value || pack_size==1,
+                "Error! ColumnOps impl would be buggy on gpu if VECTOR_SIZE>1.\n");
+
+  // Compute X at level midpoints, given X at level interfaces
+  template<CombineMode CM = CombineMode::Replace,
+           typename InputProvider = DefaultProvider>
+  KOKKOS_INLINE_FUNCTION
+  static void
+  compute_midpoint_values (const TeamMember& team,
+                           const int num_mid_levels,
+                           const InputProvider& x_i,
+                           const view_1d<pack_type>& x_m,
+                           const scalar_type alpha = one(),
+                           const scalar_type beta = zero())
+  {
+    // Sanity checks
+    debug_checks<InputProvider>(num_mid_levels,x_m);
+
+    // For GPU (or any build with pack size 1), things are simpler
+    if (pack_size==1) {
+      team_parallel_for(team,num_mid_levels,
+                        [&](const int& k) {
+        auto tmp = ( x_i(k) + x_i(k+1) ) / 2.0;
+        combine<CM>(tmp, x_m(k), alpha, beta);
+      });
+    } else {
+
+      const auto NUM_MID_PACKS     = pack_info::num_packs(num_mid_levels);
+      const auto LAST_MID_PACK     = pack_info::last_pack_idx(num_mid_levels);
+      const auto LAST_INT_PACK     = pack_info::last_pack_idx(num_mid_levels+1);
+      const auto LAST_INT_PACK_END = pack_info::last_vec_end(num_mid_levels+1);
+
+      // Try to use SIMD operations as much as possible.
+      team_parallel_for(team,NUM_MID_PACKS-1,
+                        [&](const int k){
+        // Shift's first arg is the scalar to put in the "empty" spot at the end
+        pack_type tmp = ekat::shift_left(x_i(k+1)[0], x_i(k));
+        tmp += x_i(k);
+        tmp /= 2.0;
+        combine<CM>(tmp, x_m(k), alpha, beta);
+      });
+
+      team_single (team, [&]() {
+        // Last level pack treated separately, since int pack k+1 may not exist,
+        // depending on whether NUM_MID_PACKS==NUM_INT_PACKS.
+        // The shift left might not even "need" the 2nd arg (if num int packs == num mid packs),
+        // but passing the last x_int value takes care of both scenarios.
+        pack_type tmp = ekat::shift_left(x_i(LAST_INT_PACK)[LAST_INT_PACK_END-1], x_i(LAST_MID_PACK));
+
+        tmp += x_i(LAST_MID_PACK);
+        tmp /= 2.0;
+        combine<CM>(tmp, x_m(LAST_MID_PACK), alpha, beta);
+      });
+    }
+  }
+
+  // Compute X at level interfaces, given X at level midpoints and top/bot bc values
+  // Note: with proper bc, then x_int(x_mid(x_int))==x_int. However, this version
+  //       weighs neighboring cells equally, even if one is larger than the other.
+  // RECALL: k=0 is the model top, while k=num_mid_levels+1 is the surface!
+  template<CombineMode CM = CombineMode::Replace,
+           typename InputProvider = DefaultProvider>
+  KOKKOS_INLINE_FUNCTION
+  static void
+  compute_interface_values (const TeamMember& team,
+                            const int num_mid_levels,
+                            const InputProvider& x_m,
+                            const scalar_type& x_top,
+                            const scalar_type& x_bot,
+                            const view_1d<pack_type>& x_i,
+                            const scalar_type alpha = one(),
+                            const scalar_type beta = zero())
+  {
+    // Sanity checks
+    debug_checks<InputProvider>(num_mid_levels+1,x_i);
+
+    // For GPU (or any build with pack size 1), things are simpler
+    if (pack_size==1) {
+      team_parallel_for(team,1,num_mid_levels,
+                        [&](const int& k) {
+        auto tmp = ( x_m(k) + x_m(k-1) ) / 2.0;
+        combine<CM>(tmp, x_i(k), alpha, beta);
+      });
+
+      // Fix the top/bottom
+      team_single(team,[&](){
+        combine<CM>(x_top, x_i(0), alpha, beta);
+        combine<CM>(x_bot, x_i(num_mid_levels), alpha, beta);
+      });
+    } else {
+
+      const auto NUM_MID_PACKS     = pack_info::num_packs(num_mid_levels);
+      const auto LAST_INT_PACK     = pack_info::last_pack_idx(num_mid_levels+1);
+      const auto LAST_INT_PACK_END = pack_info::last_vec_end(num_mid_levels+1);
+
+      // Try to use SIMD operations as much as possible.
+      team_parallel_for(team,1,NUM_MID_PACKS,
+                        [&](const int k){
+        // Shift's first arg is the scalar to put in the "empty" spot at the beginning
+        auto tmp = ekat::shift_right(x_m(k-1)[pack_size-1], x_m(k));
+        tmp += x_m(k);
+        tmp /= 2.0;
+        combine<CM>(tmp, x_i(k), alpha, beta);
+      });
+
+      team_single(team,[&](){
+        // Treat first pack and BC separately. Note: can pick any val for tmp[0],
+        // since BC will overwrite anyways.
+        auto tmp = ekat::shift_right(zero(), x_m(0));
+        tmp += x_m(0);
+        tmp /= 2.0;
+        combine<CM>(tmp, x_i(0), alpha, beta);
+
+        // Fix top/bottom
+        combine<CM>(x_top, x_i(0)[0], alpha, beta);
+        combine<CM>(x_bot, x_i(LAST_INT_PACK)[LAST_INT_PACK_END-1], alpha, beta);
+      });
+    }
+  }
+
+  // Given X at level interfaces, compute dX at level midpoints.
+  template<CombineMode CM = CombineMode::Replace,
+           typename InputProvider = DefaultProvider>
+  KOKKOS_INLINE_FUNCTION
+  static void
+  compute_midpoint_delta (const TeamMember& team,
+                          const int num_mid_levels,
+                          const InputProvider& x_i,
+                          const view_1d<pack_type>& dx_m,
+                          const scalar_type alpha = one(),
+                          const scalar_type beta = zero())
+  {
+    // Sanity checks
+    debug_checks<InputProvider>(num_mid_levels,dx_m);
+
+    // For GPU (or any build with pack size 1), things are simpler
+    if (pack_size==1) {
+      team_parallel_for(team,num_mid_levels,
+                        [&](const int& k) {
+        auto tmp = x_i(k+1)-x_i(k);
+        combine<CM>(tmp,dx_m(k),alpha,beta);
+      });
+    } else {
+      const auto NUM_MID_PACKS     = pack_info::num_packs(num_mid_levels);
+      const auto LAST_MID_PACK     = NUM_MID_PACKS - 1;
+      const auto LAST_INT_PACK     = pack_info::last_pack_idx(num_mid_levels+1);
+      const auto LAST_INT_PACK_END = pack_info::last_vec_end(num_mid_levels+1);
+
+      // Try to use SIMD operations as much as possible.
+      team_parallel_for(team,NUM_MID_PACKS-1,
+                        [&](const int k){
+        auto tmp = ekat::shift_left(x_i(k+1)[0], x_i(k));
+        combine<CM>(tmp - x_i(k),dx_m(k),alpha,beta);
+      });
+
+      team_single(team, [&](){
+        // Last pack does not necessarily have a next pack, so needs to be treated apart.
+        auto tmp = ekat::shift_left(x_i(LAST_INT_PACK)[LAST_INT_PACK_END-1],x_i(LAST_MID_PACK));
+        combine<CM>(tmp - x_i(LAST_MID_PACK),dx_m(LAST_MID_PACK),alpha,beta);
+      });
+    }
+  }
+
+  // Scan sum of a quantity defined at midpoints, to retrieve its integral at interfaces.
+  // This function is the logical inverse of the one above
+  // Notes:
+  //  - FromTop: true means we scan over [0,num_mid_levels), while false is the opposite.
+  //    RECALL: k=0 is the model top, while k=num_mid_levels+1 is the surface!
+  //  - InputProvider: must provide an input al all mid levels
+  //  - s0: used as bc value at k=0 (Forward) or k=num_mid_levels (Backward)
+  template<bool FromTop, typename InputProvider>
+  KOKKOS_INLINE_FUNCTION
+  static void
+  column_scan (const TeamMember& team,
+               const int num_mid_levels,
+               const InputProvider& dx_m,
+               const view_1d<pack_type>& x_i,
+               const scalar_type& s0 = zero())
+  {
+    // Sanity checks
+    debug_checks<InputProvider>(num_mid_levels+1,x_i);
+
+    // Scan's impl is quite lengthy, so split impl into two fcns, depending on pack size.
+    column_scan_impl<pack_size,FromTop>(team,num_mid_levels,dx_m,x_i,s0);
+  }
+
+protected:
+
+  template<int PackLength,bool FromTop,typename InputProvider>
+  KOKKOS_INLINE_FUNCTION
+  static typename std::enable_if<PackLength==1>::type
+  column_scan_impl (const TeamMember& team,
+                    const int num_mid_levels,
+                    const InputProvider& dx_m,
+                    const view_1d<pack_type>& x_i,
+                    const scalar_type& s0 = zero())
+  {
+    // If statement is evaluated at compile time, and compiled away.
+    if (FromTop) {
+      team_single(team,[&](){
+        x_i(0)[0] = s0;
+      });
+      // No need for a barrier here
+
+      team_parallel_scan(team,num_mid_levels,
+                         [&](const int k, scalar_type& accumulator, const bool last) {
+        accumulator += dx_m(k)[0];
+        if (last) {
+          x_i(k+1)[0] = s0 + accumulator;
+        }
+      });
+    } else {
+      team_single(team,[&](){
+        x_i(num_mid_levels)[0] = s0;
+      });
+      // No need for a barrier here
+
+      team_parallel_scan(team,num_mid_levels,
+                         [&](const int k, scalar_type& accumulator, const bool last) {
+        const auto k_bwd = num_mid_levels - k - 1;
+        accumulator += dx_m(k_bwd)[0];
+        if (last) {
+          x_i(k_bwd)[0] = s0 + accumulator;
+        }
+      });
+    }
+  }
+
+  template<int PackLength,bool FromTop,typename InputProvider>
+  KOKKOS_INLINE_FUNCTION
+  static typename std::enable_if<(PackLength>1)>::type
+  column_scan_impl (const TeamMember& team,
+                    const int num_mid_levels,
+                    const InputProvider& dx_m,
+                    const view_1d<pack_type>& x_i,
+                    const scalar_type& s0 = zero())
+  {
+    // If statement is evaluated at compile time, and compiled away.
+    const int NUM_MID_PACKS = pack_info::num_packs(num_mid_levels);
+    const int NUM_INT_PACKS = pack_info::num_packs(num_mid_levels+1);
+    const int LAST_INT_PACK = NUM_INT_PACKS - 1;
+    const int LAST_MID_PACK = NUM_MID_PACKS - 1;
+
+    if (FromTop) {
+      // Te last interface pack is problematic, and needs to be pre-filled with zeros.
+      team_single(team,[&](){
+        x_i(LAST_INT_PACK) = zero();
+      });
+      team.team_barrier();
+
+      // First, do a packed reduction of x_m, to get x_i(k) = dx_m(0)+...+dx_m(k-1)
+      // Note: stop at NUM_INT_PACKS-2, to avoid OOB access.
+      team_parallel_scan(team,NUM_INT_PACKS-1,
+                         [&](const int& k, pack_type& accumulator, const bool last) {
+        accumulator += dx_m(k);
+        if (last) {
+          x_i(k+1) = accumulator;
+        }
+      });
+      team.team_barrier();
+
+      // Now let s = s0 + reduce_sum(x_i(k)). The second term is the sum of all dx_m
+      // on all "physical" levels on all previous packs.
+      // Then, do the scan over the current pack: x_i(k)[i] = s + dx_m(k)[0,...,i-1]
+      team_parallel_for(team,NUM_INT_PACKS,
+                        [&](const int k) {
+        scalar_type s = s0;
+        // If k==0, x_i(k) does not contain any scan sum (and may contain garbage), so ignore it
+        if (k!=0) {
+          ekat::reduce_sum<false>(x_i(k),s);
+        }
+        x_i(k)[0] = s;
+
+        // Note: if NUM_INT_PACKS>NUM_MID_PACKS, this_pack_end==1 on last int pack,
+        // so we will *not* access dx_m(LAST_INT_PACK) (which would be OOB).
+        const auto this_pack_end = pack_info::vec_end(num_mid_levels+1,k);
+        for (int i=1; i<this_pack_end; ++i) {
+          x_i(k)[i] = x_i(k)[i-1] + dx_m(k)[i-1];
+        }
+      });
+    } else {
+      // First, do a packed reduction of x_m, to get x_i(k) = dx_m(k)+...+dx_m(last_mid_pack)
+
+      // The last interface pack as well as possibly the 2nd last (depending on whether
+      // NUM_INT_PACKS==NUM_MID_PACKS or not) are problematic, and need to be pre-filled with zeros.
+      team_single(team,[&](){
+        x_i(LAST_INT_PACK) = zero();
+        x_i(LAST_MID_PACK) = zero();
+      });
+      team.team_barrier();
+
+      const auto LAST_MID_PACK_END = pack_info::last_vec_end(num_mid_levels);
+      team_parallel_scan(team,1,NUM_MID_PACKS,
+                         [&](const int& k, pack_type& accumulator, const bool last) {
+        const auto k_bwd = NUM_MID_PACKS - k;
+        accumulator += dx_m(k_bwd);
+        if (k==0 && LAST_MID_PACK_END!=pack_size) {
+          // Note: dx_m(LAST_MID_PACK) might contain junk, so we need to zero out
+          // the trailing part of the accumulator (if any)
+          for (int i=LAST_MID_PACK_END+1; i<pack_size; ++i) {
+            accumulator = zero();
+          }
+        }
+
+        if (last) {
+          x_i(k_bwd-1) = accumulator;
+        }
+      });
+
+      // Need to wait for the packed scan to be done before we move fwd
+      team.team_barrier();
+
+      // Now let s = s0 + reduce_sum(x_i(k)). The second term is the sum of all dx_m
+      // on all "physical" levels on all packs above current one.
+      // Then, do the scan over the current pack: x_i(k)[i] = s + dx_m(k)[i,...,pack_end]
+      team_parallel_for(team,NUM_INT_PACKS,
+                        [&](const int k) {
+        const auto k_bwd = NUM_INT_PACKS - k - 1;
+        const auto this_pack_end = pack_info::vec_end(num_mid_levels+1,k_bwd);
+
+        scalar_type s = s0;
+        if (k_bwd<NUM_MID_PACKS) {
+          ekat::reduce_sum(x_i(k_bwd),s);
+        }
+
+        // Note: if NUM_INT_PACKS>NUM_MID_PACKS, this_pack_end==1 on last int pack,
+        // so we will *not* access dx_m(LAST_INT_PACK) (which would be OOB).
+        auto tally = s;
+        auto& x_i_kbwd = x_i(k_bwd);
+        for (int i=this_pack_end-1; i>=0; --i) {
+          tally += dx_m(k_bwd)[i];
+          x_i_kbwd[i] = tally;
+        }
+      });
+    }
+  }
+};
+
+} // namespace Homme
+
+#endif // SCREAM_COLUMN_OPS_HPP

--- a/components/scream/src/share/util/scream_column_ops.hpp
+++ b/components/scream/src/share/util/scream_column_ops.hpp
@@ -20,8 +20,8 @@ namespace scream {
  *  This class is responsible of implementing common kernels used in
  *  scream to compute quantities at level midpoints and level interfaces.
  *  For instance, compute interface quantities from midpoints
- *  ones, or integrate over a column, or compute increments of midpoint
- *  quantities (which will be defined at interfaces).
+ *  ones, or integrate over a column, or compute increments of interface
+ *  quantities (which will be defined at midpoints).
  *  The kernels are meant to be launched from within a parallel region, with
  *  team policy. More precisely, they are meant to be called from the outer most
  *  parallel region. In other words, you should *not* be inside a TeamThreadRange
@@ -41,14 +41,11 @@ namespace scream {
  *    using pack_type = typename col_ops::pack_type;
  *    
  *    auto prod = [&](const int k)->pack_type { return x(k)*y(k); }
- *    col_ops::compute_midpoint_values(team,prod,output);
+ *    col_ops::compute_midpoint_values(team,nlevs,prod,output);
  *
  *  Note: all methods have a different impl, depending on whether PackSize>1.
  *        The if statement is evaluated at compile-time, so there is no run-time
  *        penalization. The only requirement is that both branches must compile.
- *        Also, the impl for PackSize>1 is not thread safe (no ||for or single),
- *        so it would *not* work on GPU. Hence, the whole class has a static_assert
- *        to make sure we have PackSize==1 if we are in a GPU build.
  */
 
 template<typename DeviceType, typename ScalarType, int PackSize>

--- a/components/scream/src/share/util/scream_column_ops.hpp
+++ b/components/scream/src/share/util/scream_column_ops.hpp
@@ -47,6 +47,8 @@ namespace scream {
  *  Note: all methods have a different impl, depending on whether PackSize>1.
  *        The if statement is evaluated at compile-time, so there is no run-time
  *        penalization. The only requirement is that both branches must compile.
+ *
+ *  RECALL: k=0 is the model top, while k=num_mid_levels+1 is the surface!
  */
 
 template<typename DeviceType, typename ScalarType, int PackSize>
@@ -222,10 +224,8 @@ public:
     }
   }
 
-  // Compute X at level interfaces, given X at level midpoints and top/bot bc values
-  // Note: with proper bc, then x_int(x_mid(x_int))==x_int. However, this version
-  //       weighs neighboring cells equally, even if one is larger than the other.
-  // RECALL: k=0 is the model top, while k=num_mid_levels+1 is the surface!
+  // Compute X at level interfaces, given X at level midpoints and top or bot bc.
+  // Note: with proper bc, then x_int(x_mid(x_int))==x_int.
   template<bool FixTop, typename InputProvider = DefaultProvider>
   KOKKOS_INLINE_FUNCTION
   static void
@@ -297,7 +297,6 @@ public:
   // This function is the logical inverse of the one above
   // Notes:
   //  - FromTop: true means we scan over [0,num_mid_levels), while false is the opposite.
-  //    RECALL: k=0 is the model top, while k=num_mid_levels+1 is the surface!
   //  - InputProvider: must provide an input al all mid levels
   //  - s0: used as bc value at k=0 (Forward) or k=num_mid_levels (Backward)
   template<bool FromTop, typename InputProvider>

--- a/components/scream/src/share/util/scream_column_ops.hpp
+++ b/components/scream/src/share/util/scream_column_ops.hpp
@@ -109,6 +109,15 @@ public:
                                   const int count,
                                   const Lambda& f)
   {
+    auto is_pow_of_2 = [](const int n)->bool {
+      // This seems funky, but write down a pow of 2 and a non-pow of 2 in binary (both positive),
+      // and you'll see why it works
+      return n>0 && (n & (n-1))==0;
+    };
+    EKAT_KERNEL_REQUIRE_MSG (!ekat::OnGpu<typename device_type::execution_space>::value ||
+                             is_pow_of_2(team.team_size()),
+      "Error! Team-level parallel_scan on CUDA only works for team sizes that are power of 2.\n"
+      "       You could try to reduce the team size to the previous pow of 2.\n");
     Kokkos::parallel_scan(Kokkos::TeamThreadRange(team,count),f);
   }
   template<typename Lambda>

--- a/components/scream/src/share/util/scream_combine_ops.hpp
+++ b/components/scream/src/share/util/scream_combine_ops.hpp
@@ -4,6 +4,7 @@
 // For KOKKOS_INLINE_FUNCTION
 #include <Kokkos_Core.hpp>
 #include <type_traits>
+#include "ekat/ekat_scalar_traits.hpp"
 
 namespace scream {
 
@@ -57,10 +58,12 @@ static constexpr bool needsBeta () {
 // This routine should have no overhead compared to a manual
 // update (assuming you call it with the proper CM)
 
-template<CombineMode CM, typename ScalarIn, typename ScalarOut, typename CoeffType>
+template<CombineMode CM, typename ScalarIn, typename ScalarOut,
+         typename CoeffType = typename ekat::ScalarTraits<ScalarIn>::scalar_type>
 KOKKOS_FORCEINLINE_FUNCTION
 void combine (const ScalarIn& newVal, ScalarOut& result,
-         const CoeffType alpha, const CoeffType beta){
+              const CoeffType alpha = CoeffType(1),
+              const CoeffType beta = CoeffType(0)){
   // Sanity check
   EKAT_KERNEL_ASSERT (needsAlpha<CM>() || alpha==CoeffType(1));
   EKAT_KERNEL_ASSERT (needsBeta<CM>() || beta==CoeffType(0));

--- a/components/scream/src/share/util/scream_combine_ops.hpp
+++ b/components/scream/src/share/util/scream_combine_ops.hpp
@@ -1,0 +1,100 @@
+#ifndef SCREAM_COMBINE_OPS_HPP
+#define SCREAM_COMBINE_OPS_HPP
+
+// For KOKKOS_INLINE_FUNCTION
+#include <Kokkos_Core.hpp>
+#include <type_traits>
+
+namespace scream {
+
+/*
+ * Flags used to specify how to handle a variable update.
+ * When computing f(x), there are a few ways to combine
+ * the result with the value of the variable were we want
+ * to store it:
+ *    y = alpha*f(x) + beta*y
+ *    y = y*f(x)
+ *    y = y/f(x)
+ * This enum can be used as template arg in some general functions,
+ * so that we can write a single f(x), and then combine:
+ *    combine<CM>(f(x),y,alpha,beta);
+ * The result has zero overhead compared to any specific version,
+ * since the if/switch statements involving the combine mode CM
+ * are compiled-away by the compiler
+ */
+
+enum class CombineMode {
+  Replace,      // out = in
+  Scale,        // out = alpha*in
+  Update,       // out = beta*out + in
+  ScaleUpdate,  // out = beta*out + alpha*in
+  ScaleAdd,     // out = out + alpha*in (special case of ScaleUpdate with beta=1)
+  Add,          // out = out + in (special case of ScaleAdd/Update with alpha=1, beta=1.0)
+  Multiply,     // out = out*in
+  Divide        // out = out/in
+};
+
+// Functions mostly used for debug purposes. They check whether a combine mode
+// requires valid alpha or beta coefficients.
+template<CombineMode CM>
+KOKKOS_INLINE_FUNCTION
+static constexpr bool needsAlpha () {
+  return CM==CombineMode::Scale || CM==CombineMode::ScaleAdd || CM==CombineMode::ScaleUpdate;
+}
+
+template<CombineMode CM>
+KOKKOS_INLINE_FUNCTION
+static constexpr bool needsBeta () {
+  return CM==CombineMode::Update || CM==CombineMode::ScaleUpdate;
+}
+
+
+// Small helper functions to combine a new value with an old one.
+// The template argument help reducing the number of operations
+// performed (the if is resolved at compile time). In the most
+// complete form, the function performs
+//    result = beta*result + alpha*newVal
+// This routine should have no overhead compared to a manual
+// update (assuming you call it with the proper CM)
+
+template<CombineMode CM, typename ScalarIn, typename ScalarOut, typename CoeffType>
+KOKKOS_FORCEINLINE_FUNCTION
+void combine (const ScalarIn& newVal, ScalarOut& result,
+         const CoeffType alpha, const CoeffType beta){
+  // Sanity check
+  EKAT_KERNEL_ASSERT (needsAlpha<CM>() || alpha==CoeffType(1));
+  EKAT_KERNEL_ASSERT (needsBeta<CM>() || beta==CoeffType(0));
+
+  switch (CM) {
+    case CombineMode::Replace:
+      result = newVal;
+      break;
+    case CombineMode::Scale:
+      result = alpha*newVal;
+      break;
+    case CombineMode::Update:
+      result *= beta;
+      result += newVal;
+      break;
+    case CombineMode::ScaleUpdate:
+      result *= beta;
+      result += alpha*newVal;
+      break;
+    case CombineMode::ScaleAdd:
+      result += alpha*newVal;
+      break;
+    case CombineMode::Add:
+      result += newVal;
+      break;
+    case CombineMode::Multiply:
+      result *= newVal;
+      break;
+    case CombineMode::Divide:
+      result /= newVal;
+      break;
+  }
+}
+
+} // namespace scream
+
+#endif // SCREAM_COMBINE_OPS_HPP


### PR DESCRIPTION
Porting the column interpolation/differentiation utilities from Homme to SCREAM. Requires some adaptation, since HOMME has compile-time number of levels, and also assumes these utilities are called from within a TeamThreadRange.