### PR TITLE
make tkh local in c++

### DIFF
--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -79,7 +79,6 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   m_required_fields.emplace("tke",        scalar3d_layout_mid, (m*m)/(s*s), grid_name);
   m_required_fields.emplace("horiz_wind", horiz_wind_layout,   m/s,         grid_name);
   m_required_fields.emplace("wthv_sec",   scalar3d_layout_mid, K*(m/s),     grid_name);
-  m_required_fields.emplace("tkh",        scalar3d_layout_mid, (m*m)/s,     grid_name);
   m_required_fields.emplace("tk",         scalar3d_layout_mid, (m*m)/s,     grid_name);
   m_required_fields.emplace("shoc_ql",    scalar3d_layout_mid, Qunit,           grid_name);
 
@@ -87,7 +86,6 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   m_computed_fields.emplace("tke",        scalar3d_layout_mid, (m*m)/(s*s), grid_name);
   m_computed_fields.emplace("horiz_wind", horiz_wind_layout,   m/s,         grid_name);
   m_computed_fields.emplace("wthv_sec",   scalar3d_layout_mid, K*(m/s),     grid_name);
-  m_computed_fields.emplace("tkh",        scalar3d_layout_mid, (m*m)/s,     grid_name);
   m_computed_fields.emplace("tk",         scalar3d_layout_mid, (m*m)/s,     grid_name);
   m_computed_fields.emplace("shoc_ql",    scalar3d_layout_mid, Qunit,       grid_name);
 
@@ -204,7 +202,6 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   input_output.wthv_sec     = m_shoc_fields_out["wthv_sec"].get_reshaped_view<Spack**>();
   input_output.qtracers     = shoc_preamble.tracers;
   input_output.tk           = m_shoc_fields_out["tk"].get_reshaped_view<Spack**>();
-  input_output.tkh          = m_shoc_fields_out["tkh"].get_reshaped_view<Spack**>();
   input_output.shoc_cldfrac = shoc_preamble.cloud_frac;
   input_output.shoc_ql      = shoc_preamble.shoc_ql;
 

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -129,8 +129,6 @@ struct Functions
     view_3d<Spack>  qtracers;
     // eddy coefficient for momentum [m2/s]
     view_2d<Spack>  tk;
-    // eddy coefficent for heat [m2/s]
-    view_2d<Spack>  tkh;
     // Cloud fraction [-]
     view_2d<Spack>  shoc_cldfrac;
     // cloud liquid mixing ratio [kg/kg]
@@ -615,7 +613,6 @@ struct Functions
     const uview_1d<Spack>&       wthv_sec,
     const uview_2d<Spack>&       qtracers,
     const uview_1d<Spack>&       tk,
-    const uview_1d<Spack>&       tkh,
     const uview_1d<Spack>&       shoc_cldfrac,
     const uview_1d<Spack>&       shoc_ql,
     // Output Variables

--- a/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
@@ -442,7 +442,6 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
         REQUIRE(d_f90.u_wind[k] == d_cxx.u_wind[k]);
         REQUIRE(d_f90.v_wind[k] == d_cxx.v_wind[k]);
         REQUIRE(d_f90.wthv_sec[k] == d_cxx.wthv_sec[k]);
-        REQUIRE(d_f90.tkh[k] == d_cxx.tkh[k]);
         REQUIRE(d_f90.tk[k] == d_cxx.tk[k]);
         REQUIRE(d_f90.shoc_ql[k] == d_cxx.shoc_ql[k]);
         REQUIRE(d_f90.shoc_cldfrac[k] == d_cxx.shoc_cldfrac[k]);

--- a/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
@@ -86,6 +86,13 @@ static Int compare (const std::string& label, const Scalar* a,
     const auto& fr = refi.getfield(i);
     const auto& fd = di.getfield(i);
     EKAT_ASSERT(fr.size == fd.size);
+
+    // tkh is an input/output of shoc_main() in shoc.F90,
+    // but is treated as a local variable in the c++
+    // version (tkh values are reset before its used in both).
+    // So we just skip the comparison.
+    if (fr.name == "tkh") continue;
+
     nerr += compare(fr.name, fr.data, fd.data, fr.size, tol);
   }
   return nerr;


### PR DESCRIPTION
Makes `tkh` a local variable in c++ `shoc_main` impl. It's an input/output currently, but the first time it is used (`eddy_diffusivities()`) all its values are reset so it isn't required as an input, and from issue https://github.com/E3SM-Project/scream/issues/957 it is also not needed as an output.

The way I get around testing is just to skip any comparison of fortran `tkh` to c++ `tkh` (see line 94 of `shoc_run_and_cmp.cpp`). This is hacky, but I think the alternative is to remove `tkh` as input/output of fortran code and remove any reference in the test data? Which I have no problem doing. 