### PR TITLE
Introduce new option for intialization, allowing a string argument

### DIFF
--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -196,7 +196,7 @@ initialize_fields (const util::TimeStamp& t0)
     // First, check if the input file contains constant values for some of the fields
     if (ic_pl.isParameter(name)) {
       // The user provided a constant value for this field. Simply use that.
-      initialize_one_field(name, ic_pl);
+      initialize_one_field<double>(name, ic_pl);
     } else {
       // The field does not have a constant value, so we expect to find it in the nc file
       ic_fields.set(ekat::strint("field",ifield+1),name); 
@@ -230,6 +230,7 @@ initialize_fields (const util::TimeStamp& t0)
   m_ad_status |= s_fields_inited;
 }
 
+template<typename T>
 void AtmosphereDriver::initialize_one_field(const std::string& name, const ekat::ParameterList& ic_pl)
 {
   printf("ASD - name = %s\n",name.c_str());  //ASD - DELETE
@@ -243,7 +244,7 @@ void AtmosphereDriver::initialize_one_field(const std::string& name, const ekat:
   if (layout.is_vector_layout()) {
     const auto idim = layout.get_vector_dim();
     const auto vec_dim = layout.dim(idim);
-    const auto& values = ic_pl.get<std::vector<Real>>(name);
+    const auto& values = ic_pl.get<std::vector<T>>(name);
     EKAT_REQUIRE_MSG (values.size()==static_cast<size_t>(vec_dim),
         "Error! Initial condition values array for '" + name + "' has the wrong dimension.\n"
         "       Field dimension: " + std::to_string(vec_dim) + "\n"
@@ -257,7 +258,7 @@ void AtmosphereDriver::initialize_one_field(const std::string& name, const ekat:
       printf("    - [%d] = %f\n",comp,values[comp]);    // ASD-DELETE
     }
   } else {
-    const auto& value = ic_pl.get<double>(name);
+    const auto& value = ic_pl.get<T>(name);
     printf("    - val = %f\n",value);  //ASD - DELETE
     f.set_value(value);
   }

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -198,11 +198,11 @@ initialize_fields (const util::TimeStamp& t0)
     if (ic_pl.isParameter(name)) {
       // The user provided a constant value for this field. Simply use that.
       if (ic_pl.isType<double>(name) or ic_pl.isType<std::vector<double>>(name)) {
-        initialize_one_field(name, ic_pl);
+        initialize_constant_field(name, ic_pl);
       } else if (ic_pl.isType<std::string>(name)) {
         ic_fields_to_copy.push_back(name);
       } else {
-        EKAT_REQUIRE_MSG (false, "ERROR: invalid assignment for variable " + name + ", only double or string arguments are allowed");
+        EKAT_REQUIRE_MSG (false, "ERROR: invalid assignment for variable " + name + ", only scalar double or string, or vector double arguments are allowed");
       }
     } else {
       // The field does not have a constant value, so we expect to find it in the nc file
@@ -237,7 +237,7 @@ initialize_fields (const util::TimeStamp& t0)
     const auto& name_src = ic_pl.get<std::string>(name_tgt);
     auto f_tgt = m_field_repo->get_field(name_tgt,m_grids_manager->get_reference_grid()->name());
     auto f_src = m_field_repo->get_field(name_src,m_grids_manager->get_reference_grid()->name());
-    f_tgt.set_value(f_src);
+    f_tgt.deep_copy(f_src);
   }
 
   m_current_ts = t0;
@@ -245,7 +245,7 @@ initialize_fields (const util::TimeStamp& t0)
   m_ad_status |= s_fields_inited;
 }
 
-void AtmosphereDriver::initialize_one_field(const std::string& name, const ekat::ParameterList& ic_pl)
+void AtmosphereDriver::initialize_constant_field(const std::string& name, const ekat::ParameterList& ic_pl)
 {
   auto f = m_field_repo->get_field(name,m_grids_manager->get_reference_grid()->name());
   // The user provided a constant value for this field. Simply use that.
@@ -267,11 +267,11 @@ void AtmosphereDriver::initialize_one_field(const std::string& name, const ekat:
     // considering that this code is executed during initialization only.
     for (int comp=0; comp<vec_dim; ++comp) {
       auto f_i = f.get_component(comp);
-      f_i.set_value(values[comp]);
+      f_i.deep_copy(values[comp]);
     }
   } else {
     const auto& value = ic_pl.get<double>(name);
-    f.set_value(value);
+    f.deep_copy(value);
   }
 }
 

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -70,7 +70,6 @@ public:
   // Load initial conditions for atm inputs
   void initialize_fields (const util::TimeStamp& t0);
 
-  template<typename T>
   void initialize_one_field(const std::string& name, const ekat::ParameterList& ic_pl);
 
   // Initialie I/O structures for output

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -69,6 +69,7 @@ public:
 
   // Load initial conditions for atm inputs
   void initialize_fields (const util::TimeStamp& t0);
+  void initialize_one_field(const std::string& name, const ekat::ParameterList& ic_pl);
 
   // Initialie I/O structures for output
   void initialize_output_manager ();

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -70,7 +70,7 @@ public:
   // Load initial conditions for atm inputs
   void initialize_fields (const util::TimeStamp& t0);
 
-  void initialize_one_field(const std::string& name, const ekat::ParameterList& ic_pl);
+  void initialize_constant_field(const std::string& name, const ekat::ParameterList& ic_pl);
 
   // Initialie I/O structures for output
   void initialize_output_manager ();

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -69,6 +69,8 @@ public:
 
   // Load initial conditions for atm inputs
   void initialize_fields (const util::TimeStamp& t0);
+
+  template<typename T>
   void initialize_one_field(const std::string& name, const ekat::ParameterList& ic_pl);
 
   // Initialie I/O structures for output

--- a/components/scream/src/control/tests/ad_tests.cpp
+++ b/components/scream/src/control/tests/ad_tests.cpp
@@ -31,6 +31,16 @@ TEST_CASE ("group_requirements","[!throws]")
   // Init and run a single time step
   util::TimeStamp init_time(0,0,0,0.0);
   ad.initialize(atm_comm,ad_params,init_time);
+  // Verify that after initialization field "E" matches field "A"
+  auto& field_repo = ad.get_field_repo();
+  const auto& view_A = field_repo.get_field("A","Point Grid A").get_reshaped_view<const Real**>();
+  const auto& view_E = field_repo.get_field("E","Point Grid A").get_reshaped_view<const Real**>();
+  for (int icol=0;icol<num_cols;++icol) {
+    for (int jlev=0;jlev<num_vl;++jlev) {
+      REQUIRE(view_E(icol,jlev)==view_A(icol,jlev));
+    }
+  }
+  // Resume ad run and testing.
   ad.run(1.0);
   ad.finalize ();
 

--- a/components/scream/src/control/tests/ad_tests.cpp
+++ b/components/scream/src/control/tests/ad_tests.cpp
@@ -33,8 +33,8 @@ TEST_CASE ("group_requirements","[!throws]")
   ad.initialize(atm_comm,ad_params,init_time);
   // Verify that after initialization field "E" matches field "A"
   auto& field_repo = ad.get_field_repo();
-  const auto& view_A = field_repo.get_field("A","Point Grid A").get_reshaped_view<const Real**>();
-  const auto& view_E = field_repo.get_field("E","Point Grid A").get_reshaped_view<const Real**>();
+  const auto& view_A = field_repo.get_field("A","Point Grid A").get_reshaped_view<const Real**, Host>();
+  const auto& view_E = field_repo.get_field("E","Point Grid A").get_reshaped_view<const Real**, Host>();
   for (int icol=0;icol<num_cols;++icol) {
     for (int jlev=0;jlev<num_vl;++jlev) {
       REQUIRE(view_E(icol,jlev)==view_A(icol,jlev));

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -8,6 +8,7 @@ Initial Conditions:
   A: 1.0
   B: 2.0
   C: 3.0
+  D: [4.0, 5.0]
 
 Atmosphere Processes:
   Number of Entries: 3

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -9,6 +9,7 @@ Initial Conditions:
   B: 2.0
   C: 3.0
   D: [4.0, 5.0]
+  E: "A"
 
 Atmosphere Processes:
   Number of Entries: 3

--- a/components/scream/src/control/tests/dummy_atm_proc.hpp
+++ b/components/scream/src/control/tests/dummy_atm_proc.hpp
@@ -63,11 +63,14 @@ public:
       dims = {num_levs,num_cols};
     }
     FieldLayout layout (tags,dims);
+    // To test vector input
+    FieldLayout layout_vec ( {COL,CMP,LEV}, {num_cols,2,num_levs} );
 
     if (m_dummy_type==A2G) {
       m_input_fids.emplace("A",layout,ekat::units::m,m_grid->name());
       m_output_fids.emplace("B",layout,ekat::units::m,m_grid->name());
       m_output_fids.emplace("C",layout,ekat::units::m,m_grid->name());
+      m_input_fids.emplace("D",layout_vec,ekat::units::m,m_grid->name());
     } else if (m_dummy_type == G2A) {
       m_output_fids.emplace("A",layout,ekat::units::m,m_grid->name());
     }
@@ -76,7 +79,9 @@ public:
   // Register all fields in the given repo
   void register_fields (FieldRepository<Real>& field_repo) const {
     if (m_dummy_type==A2G) {
-      field_repo.register_field(*m_input_fids.begin());
+      for (const auto& in : m_input_fids) {
+        field_repo.register_field(in);
+      }
       for (const auto& out : m_output_fids) {
         field_repo.register_field(out,"The Group");
       }

--- a/components/scream/src/control/tests/dummy_atm_proc.hpp
+++ b/components/scream/src/control/tests/dummy_atm_proc.hpp
@@ -71,6 +71,7 @@ public:
       m_output_fids.emplace("B",layout,ekat::units::m,m_grid->name());
       m_output_fids.emplace("C",layout,ekat::units::m,m_grid->name());
       m_input_fids.emplace("D",layout_vec,ekat::units::m,m_grid->name());
+      m_input_fids.emplace("E",layout,ekat::units::m,m_grid->name());
     } else if (m_dummy_type == G2A) {
       m_output_fids.emplace("A",layout,ekat::units::m,m_grid->name());
     }

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -479,12 +479,7 @@ deep_copy (const field_type& field_src) {
           " to field " + get_header().get_identifier().name() + ".  Layouts don't match.");
   const auto  rank = layout.rank();
   // Note: we can't just do a deep copy on get_view<HD>(), since this
-  //       field might be a subfield of another. So check the header
-  //       first, to see if we have a parent. If not, deep copy is fine.
-  //       If we do, we need to get the reshaped view first.
-  const auto parent = get_header().get_parent();
-  // We have a parent. We only want to set *this* field to value,
-  // not the rest of the parent field. We need the reshaped view
+  //       field might be a subfield of another. We need the reshaped view.
   switch (rank) {
     case 1:
       {
@@ -511,6 +506,13 @@ deep_copy (const field_type& field_src) {
       {
         auto v     = get_reshaped_view<RT****,HD>();
         auto v_src = field_src.get_reshaped_view<RT****,HD>();
+        Kokkos::deep_copy(v,v_src);
+      }
+      break;
+    case 5:
+      {
+        auto v     = get_reshaped_view<RT*****,HD>();
+        auto v_src = field_src.get_reshaped_view<RT*****,HD>();
         Kokkos::deep_copy(v,v_src);
       }
       break;
@@ -558,6 +560,12 @@ deep_copy (const RT value) {
       case 4:
         {
           auto v = get_reshaped_view<RT****,HD>();
+          Kokkos::deep_copy(v,value);
+        }
+        break;
+      case 5:
+        {
+          auto v = get_reshaped_view<RT*****,HD>();
           Kokkos::deep_copy(v,value);
         }
         break;

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -146,11 +146,11 @@ public:
 
   // Set the field to a constant value (on host or device)
   template<HostOrDevice HD = Device>
-  void set_value (const RT value);
+  void deep_copy (const RT value);
 
   // Copy the data from one field to this field
   template<HostOrDevice HD = Device>
-  void set_value (const field_type& field_src);
+  void deep_copy (const field_type& field_src);
 
   // Returns a subview of this field, slicing at entry k along dimension idim
   // NOTES:
@@ -471,63 +471,58 @@ sync_to_dev () const {
 template<typename RealType>
 template<HostOrDevice HD>
 void Field<RealType>::
-set_value (const field_type& field_src) {
+deep_copy (const field_type& field_src) {
   const auto& layout     = get_header().get_identifier().get_layout();
   const auto& layout_src = field_src.get_header().get_identifier().get_layout();
   EKAT_REQUIRE_MSG(layout==layout_src,
        "ERROR: Unable to copy field " + field_src.get_header().get_identifier().name() + 
-          " to field " + get_header().get_identifier().name() + " during initialization.  Layouts don't match.");
+          " to field " + get_header().get_identifier().name() + ".  Layouts don't match.");
   const auto  rank = layout.rank();
   // Note: we can't just do a deep copy on get_view<HD>(), since this
   //       field might be a subfield of another. So check the header
   //       first, to see if we have a parent. If not, deep copy is fine.
   //       If we do, we need to get the reshaped view first.
   const auto parent = get_header().get_parent();
-  if (parent.lock()==nullptr) {
-    // No parent. Deep copying to get_view<HD>() is safe.
-    Kokkos::deep_copy (get_view<HD>(),field_src.get_view<HD>());
-  } else {
-    // We have a parent. We only want to set *this* field to value,
-    // not the rest of the parent field. We need the reshaped view
-    switch (rank) {
-      case 1:
-        {
-          auto v     = get_reshaped_view<RT*,HD>();
-          auto v_src = field_src.get_reshaped_view<RT*,HD>();
-          Kokkos::deep_copy(v,v_src);
-        }
-        break;
-      case 2:
-        {
-          auto v     = get_reshaped_view<RT**,HD>();
-          auto v_src = field_src.get_reshaped_view<RT**,HD>();
-          Kokkos::deep_copy(v,v_src);
-        }
-        break;
-      case 3:
-        {
-          auto v     = get_reshaped_view<RT***,HD>();
-          auto v_src = field_src.get_reshaped_view<RT***,HD>();
-          Kokkos::deep_copy(v,v_src);
-        }
-        break;
-      case 4:
-        {
-          auto v     = get_reshaped_view<RT****,HD>();
-          auto v_src = field_src.get_reshaped_view<RT****,HD>();
-          Kokkos::deep_copy(v,v_src);
-        }
-        break;
-      default:
-        EKAT_ERROR_MSG ("Error! Unsupported field rank in 'set_value'.\n");
-    }
+  // We have a parent. We only want to set *this* field to value,
+  // not the rest of the parent field. We need the reshaped view
+  switch (rank) {
+    case 1:
+      {
+        auto v     = get_reshaped_view<RT*,HD>();
+        auto v_src = field_src.get_reshaped_view<RT*,HD>();
+        Kokkos::deep_copy(v,v_src);
+      }
+      break;
+    case 2:
+      {
+        auto v     = get_reshaped_view<RT**,HD>();
+        auto v_src = field_src.get_reshaped_view<RT**,HD>();
+        Kokkos::deep_copy(v,v_src);
+      }
+      break;
+    case 3:
+      {
+        auto v     = get_reshaped_view<RT***,HD>();
+        auto v_src = field_src.get_reshaped_view<RT***,HD>();
+        Kokkos::deep_copy(v,v_src);
+      }
+      break;
+    case 4:
+      {
+        auto v     = get_reshaped_view<RT****,HD>();
+        auto v_src = field_src.get_reshaped_view<RT****,HD>();
+        Kokkos::deep_copy(v,v_src);
+      }
+      break;
+    default:
+      EKAT_ERROR_MSG ("Error! Unsupported field rank in 'deep_copy'.\n");
   }
 }
 
 template<typename RealType>
 template<HostOrDevice HD>
 void Field<RealType>::
-set_value (const RT value) {
+deep_copy (const RT value) {
   // Note: we can't just do a deep copy on get_view<HD>(), since this
   //       field might be a subfield of another. So check the header
   //       first, to see if we have a parent. If not, deep copy is fine.
@@ -567,7 +562,7 @@ set_value (const RT value) {
         }
         break;
       default:
-        EKAT_ERROR_MSG ("Error! Unsupported field rank in 'set_value'.\n");
+        EKAT_ERROR_MSG ("Error! Unsupported field rank in 'deep_copy'.\n");
     }
   }
 }

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -184,7 +184,7 @@ TEST_CASE("field", "") {
     REQUIRE(views_are_equal(f1,f2));
   }
 
-  SECTION ("set_value") {
+  SECTION ("deep_copy") {
     std::vector<FieldTag> t1 = {COL,VAR,LEV};
     std::vector<int> d1 = {3,2,24};
 
@@ -192,7 +192,7 @@ TEST_CASE("field", "") {
 
     Field<Real> f1(fid1);
     f1.allocate_view();
-    f1.set_value(1.0);
+    f1.deep_copy(1.0);
     f1.sync_to_host();
     auto v = f1.get_view<Host>();
     for (int i=0; i<fid1.get_layout().size(); ++i) {
@@ -254,8 +254,8 @@ TEST_CASE("field", "") {
     // f0 is scalar, no vector dimension
     REQUIRE_THROWS(f0.get_component(0));
 
-    f0.set_value(1.0);
-    f1.set_value(2.0);
+    f0.deep_copy(1.0);
+    f1.deep_copy(2.0);
 
     f_vec.sync_to_host();
 


### PR DESCRIPTION
This PR will make it possible to pass a string as an parameter list value in the control YAML file for any field that needs to be intialized.  Currently, only a double precision value is possible, which causes the field to be initialized uniformly to that value.

Allowing a string to be passed will open up the door to designating another field which can be copied into the specific field in question.

An example would be in initializing the variable `T_prev_micro_step` in P3-Microphysics.  For an initial run this is usually set to equal the initial temperature, `T_mid`.  Currently we would have to store a copy of `T_prev_micro_step` within the netCDF initial file, this PR will make it possible to simply designate `T_mid` as having the same initial values as `T_prev_micro_step`.

It will also allow a user to take a netCDF file with perhaps different names and still populate the appropriate fields in SCREAM.

Addresses #975 

Depends on EKAT PR: https://github.com/E3SM-Project/EKAT/pull/97