### PR TITLE
SCREAM: fix call to mpi_abort in scream_scorpio_interface.F90

### DIFF
--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -725,13 +725,14 @@ contains
     integer,           intent(in)    :: retVal
 
     type(pio_file_list_t), pointer :: curr => NULL()
+    integer :: ierr
 
     if (retVal .ne. PIO_NOERR) then
       write(*,'(I8,2x,A200)') retVal,trim(errMsg)
       ! Kill run
       call eam_pio_finalize() 
       call finalize_scream_session()
-      call mpi_abort(pio_mpicom,0,retVal)
+      call mpi_abort(pio_mpicom,retVal,ierr)
     end if
 
   end subroutine errorHandle


### PR DESCRIPTION
Fixes #979 

Note: merging this will cause shoc standalone test to fail. Should that failure be fixed in this PR? I say no. Let's merge this, and then turn the AT back on, so we make all other open PRs fail again.

Also, I'm skipping testing for this PR, since the shoc test will fail.