### PR TITLE
add get_dse function

### DIFF
--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -132,6 +132,15 @@ struct Functions
   KOKKOS_FUNCTION
   static Spack get_dz(const Spack& zi_top, const Spack& zi_bot, const Smask& range_mask);
 
+  // Compute dry static energy (DSE).
+  // The result unit is in J/kg
+  // The inputs are
+  //   T_mid is the atmospheric temperature. Units in K.
+  //   z_mid is the geopotential height above surface at midpoints. Units in m.
+  //   surf_geopotential is the surface geopotential height. Units in m.
+  KOKKOS_FUNCTION
+  static Spack get_dse(const Spack& T_mid, const Spack& z_mid, const Real surf_geopotential, const Smask& range_mask);
+
 };
 
 } // namespace physics

--- a/components/scream/src/physics/share/physics_universal_impl.hpp
+++ b/components/scream/src/physics/share/physics_universal_impl.hpp
@@ -106,7 +106,30 @@ Functions<S,D>::get_dz(const Spack& zi_top, const Spack& zi_bot, const Smask& ra
   return result;
 }
 //-----------------------------------------------------------------------------------------------//
+// Compute dry static energy (DSE).
+// The result unit is in J/kg
+// The inputs are
+//   T_mid is the atmospheric temperature. Units in K.
+//   z_mid is the geopotential height above surface at midpoints. Units in m.
+//   surf_geopotential is the surface geopotential height. Units in m.
+template <typename S, typename D>
+KOKKOS_FUNCTION
+typename Functions<S,D>::Spack
+Functions<S,D>::get_dse(const Spack& T_mid, const Spack& z_mid, const Real surf_geopotential, const Smask& range_mask)
+{
+  static constexpr Scalar cp  = C::CP;
+  static constexpr Scalar ggr = C::gravit;
 
+  Spack result;
+  const Spack dse = cp*T_mid + ggr*z_mid + surf_geopotential;
+  // Check that there are no obvious errors in the result.
+  EKAT_KERNEL_ASSERT_MSG(!((isnan(dse) && range_mask).any()), "Error in get_dse, dse has NaN values.\n"); // exit with an error message
+  EKAT_KERNEL_ASSERT_MSG(!(((dse <= 0) && range_mask).any()), "Error in get_dse, dse has negative values.\n"); // exit with an error message
+  // Set the values of the result
+  result.set(range_mask,dse);
+  return result;
+}
+//-----------------------------------------------------------------------------------------------//
 
 } // namespace physics
 } // namespace scream

--- a/components/scream/src/physics/share/physics_universal_impl.hpp
+++ b/components/scream/src/physics/share/physics_universal_impl.hpp
@@ -125,7 +125,7 @@ Functions<S,D>::get_dse(const Spack& T_mid, const Spack& z_mid, const Real surf_
   // Check that there are no obvious errors in the result.
   EKAT_KERNEL_ASSERT_MSG((isnan(T_mid) && range_mask).none(), "Error in get_dse, T_mid has NaN values.\n"); // exit with an error message
   EKAT_KERNEL_ASSERT_MSG((isnan(z_mid) && range_mask).none(), "Error in get_dse, z_mid has NaN values.\n"); // exit with an error message
-  EKAT_KERNEL_ASSERT_MSG((isnan(surf_geopotential) && range_mask).none(), "Error in get_dse, surf_geopotential has NaN values.\n"); // exit with an error message
+  EKAT_KERNEL_ASSERT_MSG(!isnan(surf_geopotential), "Error in get_dse, surf_geopotential has NaN values.\n"); // exit with an error message
   EKAT_KERNEL_ASSERT_MSG(((dse <= 0) && range_mask).none(), "Error in get_dse, dse has negative values.\n"); // exit with an error message
 
   return dse;

--- a/components/scream/src/physics/share/physics_universal_impl.hpp
+++ b/components/scream/src/physics/share/physics_universal_impl.hpp
@@ -120,14 +120,15 @@ Functions<S,D>::get_dse(const Spack& T_mid, const Spack& z_mid, const Real surf_
   static constexpr Scalar cp  = C::CP;
   static constexpr Scalar ggr = C::gravit;
 
-  Spack result;
-  const Spack dse = cp*T_mid + ggr*z_mid + surf_geopotential;
+  const Spack dse(range_mask, cp*T_mid + ggr*z_mid + surf_geopotential);
+
   // Check that there are no obvious errors in the result.
-  EKAT_KERNEL_ASSERT_MSG(!((isnan(dse) && range_mask).any()), "Error in get_dse, dse has NaN values.\n"); // exit with an error message
-  EKAT_KERNEL_ASSERT_MSG(!(((dse <= 0) && range_mask).any()), "Error in get_dse, dse has negative values.\n"); // exit with an error message
-  // Set the values of the result
-  result.set(range_mask,dse);
-  return result;
+  EKAT_KERNEL_ASSERT_MSG((isnan(T_mid) && range_mask).none(), "Error in get_dse, T_mid has NaN values.\n"); // exit with an error message
+  EKAT_KERNEL_ASSERT_MSG((isnan(z_mid) && range_mask).none(), "Error in get_dse, z_mid has NaN values.\n"); // exit with an error message
+  EKAT_KERNEL_ASSERT_MSG((isnan(surf_geopotential) && range_mask).none(), "Error in get_dse, surf_geopotential has NaN values.\n"); // exit with an error message
+  EKAT_KERNEL_ASSERT_MSG(((dse <= 0) && range_mask).none(), "Error in get_dse, dse has negative values.\n"); // exit with an error message
+
+  return dse;
 }
 //-----------------------------------------------------------------------------------------------//
 

--- a/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
+++ b/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
@@ -7,6 +7,7 @@
 
 #include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "ekat/util/ekat_test_utils.hpp"
 
 namespace scream {
 namespace physics {
@@ -215,9 +216,19 @@ struct UnitWrap::UnitTest<D>::TestUniversal
         Real zi_top = zi_bot + (k+1); 
         dz_tests(zi_top,zi_bot,errors);
         // DSE Test
-        Real temp = k+1;
-        Real height = k+1;
-        Real surface_height = k+1;
+        std::random_device rd;
+        using rngAlg = std::mt19937_64;
+        const unsigned int catchRngSeed = Catch::rngSeed();
+        const unsigned int seed = catchRngSeed==0 ? rd() : catchRngSeed;
+        rngAlg engine(seed);
+        using RPDF = std::uniform_real_distribution<Real>;
+        RPDF pdf(1e-3,1e3);
+
+        Real temp,height,surface_height;
+        ekat::genRandArray(&temp,1,engine,pdf);
+        ekat::genRandArray(&height,1,engine,pdf);
+        ekat::genRandArray(&surface_height,1,engine,pdf);
+
         dse_tests(temp,height,surface_height,errors);
       }
 


### PR DESCRIPTION
Compute dry static energy (DSE) instead of requiring as an input in the field manager. Function is added to `physics/share/physics_functions.hpp`.

Addresses Issue https://github.com/E3SM-Project/scream/issues/955.