### PR TITLE
update pd remapper

### DIFF
--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -179,42 +179,31 @@ public:
 
     switch (dims.size) {
       case 1:
-      {
         return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
                         dims.dims[0]);
-      }
       case 2:
-      {
         return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
                         dims.dims[0],
                         dims.dims[1]);
-      }
       case 3:
-      {
         return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
                         dims.dims[0],
                         dims.dims[1],
                         dims.dims[2]);
-      }
       case 4:
-      {
         return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
                         dims.dims[0],
                         dims.dims[1],
                         dims.dims[2],
                         dims.dims[3]);
-      }
       case 5:
-      {
         return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
                         dims.dims[0],
                         dims.dims[1],
                         dims.dims[2],
                         dims.dims[3],
                         dims.dims[4]);
-      }
       case 6:
-      {
         return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
                         dims.dims[0],
                         dims.dims[1],
@@ -222,7 +211,6 @@ public:
                         dims.dims[3],
                         dims.dims[4],
                         dims.dims[5]);
-      }
       default:
         EKAT_KERNEL_ERROR_MSG("Error! Unhandled case in switch statement.\n");
 
@@ -515,7 +503,7 @@ initialize_device_variables()
 }
 
 template<typename RealType>
- template <typename ScalarT, typename MT>
+template <typename ScalarT, typename MT>
 KOKKOS_FUNCTION
 void PhysicsDynamicsRemapper<RealType>::
 set_dyn_to_zero(const MT& team) const
@@ -527,7 +515,6 @@ set_dyn_to_zero(const MT& team) const
 
   switch (phys_layout(i)) {
     case etoi(LayoutType::Scalar2D):
-    {
       if (is_state_field_dev(i)) {
         auto dyn = reshape<ScalarT,4> (dyn_ptrs(i), dyn_dims(i));
         auto v = ekat::subview_1(dyn,itl);
@@ -551,9 +538,7 @@ set_dyn_to_zero(const MT& team) const
         });
       }
       break;
-    }
     case etoi(LayoutType::Vector2D):
-    {
       if (is_state_field_dev(i)) {
         auto dyn = reshape<ScalarT,5> (dyn_ptrs(i), dyn_dims(i));
         auto v = ekat::subview_1(dyn,itl);
@@ -581,9 +566,7 @@ set_dyn_to_zero(const MT& team) const
         });
       }
       break;
-    }
     case etoi(LayoutType::Scalar3D):
-    {
       if (is_state_field_dev(i)) {
         auto dyn = reshape<ScalarT,5> (dyn_ptrs(i), dyn_dims(i));
         auto v = ekat::subview_1(dyn,itl);
@@ -612,9 +595,7 @@ set_dyn_to_zero(const MT& team) const
         });
       }
       break;
-    }
     case etoi(LayoutType::Vector3D):
-    {
       if (is_state_field_dev(i)) {
         auto dyn = reshape<ScalarT,6> (dyn_ptrs(i), dyn_dims(i));
         auto v = ekat::subview_1(dyn,itl);
@@ -646,7 +627,6 @@ set_dyn_to_zero(const MT& team) const
         });
       }
       break;
-    }
     default:
       EKAT_KERNEL_ERROR_MSG("Error! Unhandled case in switch statement.\n");
   }
@@ -674,7 +654,6 @@ do_remap_fwd() const
     switch (phys_layout(i)) {
       case etoi(LayoutType::Scalar2D):
       case etoi(LayoutType::Vector2D):
-      {
         if (pack_alloc_property(i) == AllocPropType::PackAlloc) {
           set_dyn_to_zero<pack_type>(team);
           team.team_barrier();
@@ -692,10 +671,8 @@ do_remap_fwd() const
           local_remap_fwd_2d<Real>(team, num_cols, lid2elgp, p2d);
         }
         break;
-      }
       case etoi(LayoutType::Scalar3D):
       case etoi(LayoutType::Vector3D):
-      {
         if (pack_alloc_property(i) == AllocPropType::PackAlloc) {
           set_dyn_to_zero<pack_type>(team);
           team.team_barrier();
@@ -713,7 +690,6 @@ do_remap_fwd() const
           local_remap_fwd_3d<Real>(team, num_cols, lid2elgp, p2d);
         }
         break;
-      }
       default:
         EKAT_KERNEL_ERROR_MSG("Error! Unhandled case in switch statement.\n");
     }
@@ -755,7 +731,6 @@ do_remap_bwd() const
     switch (phys_layout(i)) {
       case etoi(LayoutType::Scalar2D):
       case etoi(LayoutType::Vector2D):
-      {
         if (pack_alloc_property(i) == AllocPropType::PackAlloc) {
           local_remap_bwd_2d<pack_type>(team, num_fields, lid2elgp, p2d);
         } else if (pack_alloc_property(i) == AllocPropType::SmallPackAlloc) {
@@ -764,10 +739,8 @@ do_remap_bwd() const
           local_remap_bwd_2d<Real>(team, num_fields, lid2elgp, p2d);
         }
         break;
-      }
       case etoi(LayoutType::Scalar3D):
       case etoi(LayoutType::Vector3D):
-      {
         if (pack_alloc_property(i) == AllocPropType::PackAlloc) {
           local_remap_bwd_3d<pack_type>(team, num_fields, lid2elgp, p2d);
         } else if (pack_alloc_property(i) == AllocPropType::SmallPackAlloc) {
@@ -776,7 +749,6 @@ do_remap_bwd() const
           local_remap_bwd_3d<Real>(team, num_fields, lid2elgp, p2d);
         }
         break;
-      }
       default:
         EKAT_KERNEL_ERROR_MSG("Error! Unhandled case in switch statement.\n");
     }

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -163,11 +163,11 @@ public:
 
   template <typename ScalarT, typename MT, typename VT1, typename VT2>
   KOKKOS_FUNCTION
-  void local_remap_bwd_2d (const MT& team, const int num_fields, const int num_cols, const VT1 lid2elgp, const VT2 p2d) const;
+  void local_remap_bwd_2d (const MT& team, const int num_fields, const VT1 lid2elgp, const VT2 p2d) const;
 
   template <typename ScalarT, typename MT, typename VT1, typename VT2>
   KOKKOS_FUNCTION
-  void local_remap_bwd_3d (const MT& team, const int num_fields, const int num_cols, const VT1 lid2elgp, const VT2 p2d) const;
+  void local_remap_bwd_3d (const MT& team, const int num_fields, const VT1 lid2elgp, const VT2 p2d) const;
 
   void create_p2d_map ();
 
@@ -757,11 +757,11 @@ do_remap_bwd() const
       case etoi(LayoutType::Vector2D):
       {
         if (pack_alloc_property(i) == AllocPropType::PackAlloc) {
-          local_remap_bwd_2d<pack_type>(team, num_fields, num_cols, lid2elgp, p2d);
+          local_remap_bwd_2d<pack_type>(team, num_fields, lid2elgp, p2d);
         } else if (pack_alloc_property(i) == AllocPropType::SmallPackAlloc) {
-          local_remap_bwd_2d<small_pack_type>(team, num_fields, num_cols, lid2elgp, p2d);
+          local_remap_bwd_2d<small_pack_type>(team, num_fields, lid2elgp, p2d);
         } else {
-          local_remap_bwd_2d<Real>(team, num_fields, num_cols, lid2elgp, p2d);
+          local_remap_bwd_2d<Real>(team, num_fields, lid2elgp, p2d);
         }
         break;
       }
@@ -769,11 +769,11 @@ do_remap_bwd() const
       case etoi(LayoutType::Vector3D):
       {
         if (pack_alloc_property(i) == AllocPropType::PackAlloc) {
-          local_remap_bwd_3d<pack_type>(team, num_fields, num_cols, lid2elgp, p2d);
+          local_remap_bwd_3d<pack_type>(team, num_fields, lid2elgp, p2d);
         } else if (pack_alloc_property(i) == AllocPropType::SmallPackAlloc) {
-          local_remap_bwd_3d<small_pack_type>(team, num_fields, num_cols, lid2elgp, p2d);
+          local_remap_bwd_3d<small_pack_type>(team, num_fields, lid2elgp, p2d);
         } else {
-          local_remap_bwd_3d<Real>(team, num_fields, num_cols, lid2elgp, p2d);
+          local_remap_bwd_3d<Real>(team, num_fields, lid2elgp, p2d);
         }
         break;
       }
@@ -1141,7 +1141,7 @@ template<typename RealType>
 template <typename ScalarT, typename MT, typename VT1, typename VT2>
 KOKKOS_FUNCTION
 void PhysicsDynamicsRemapper<RealType>::
-local_remap_bwd_2d (const MT& team, const int num_fields, const int num_cols, const VT1 lid2elgp, const VT2 p2d) const
+local_remap_bwd_2d (const MT& team, const int num_fields, const VT1 lid2elgp, const VT2 p2d) const
 {
   const int rank = team.league_rank();
   const int i = rank%num_fields;
@@ -1198,7 +1198,7 @@ template<typename RealType>
 template <typename ScalarT, typename MT, typename VT1, typename VT2>
 KOKKOS_FUNCTION
 void PhysicsDynamicsRemapper<RealType>::
-local_remap_bwd_3d (const MT& team, const int num_fields, const int num_cols, const VT1 lid2elgp, const VT2 p2d) const
+local_remap_bwd_3d (const MT& team, const int num_fields, const VT1 lid2elgp, const VT2 p2d) const
 {
   const int rank = team.league_rank();
   const int i = rank%num_fields;


### PR DESCRIPTION
For remap_bwd, I use a `TeamPolicy` over `ncols*nfields`. This speeds up things _slightly_. For remap_fwd I keep it the same since changing to `TeamPolicy` over `ncols*nfields` slows things down because the `set_dyn_to_zero()` call must be inside a `TeamPolicy` over `nfields`.

I also created a `reshape` function for views (as suggested in https://github.com/E3SM-Project/scream/pull/934)