### PR TITLE
Update the p3 pre- and post- ambles to facilitate coupling with other processes

### DIFF
--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -100,12 +100,6 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   m_computed_fields.emplace("micro_liq_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
   m_computed_fields.emplace("micro_vap_liq_exchange", scalar3d_layout_mid, nondim, grid_name);
   m_computed_fields.emplace("micro_vap_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
-  // Deprecated: (these should be removed from the AD eventually)
-//ASD  m_computed_fields.emplace("precip_total_tend", scalar3d_layout_mid, mm,     grid_name);
-//ASD  m_computed_fields.emplace("qr_evap_tend",      scalar3d_layout_mid, mm/s,   grid_name);
-//ASD  m_computed_fields.emplace("nevapr",            scalar3d_layout_mid, nondim, grid_name);
-//ASD  m_computed_fields.emplace("mu_qc",             scalar3d_layout_mid, nondim, grid_name);
-//ASD  m_computed_fields.emplace("lambda_qc",         scalar3d_layout_mid, nondim, grid_name);
 
 }
 
@@ -194,11 +188,6 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   history_only.vap_liq_exchange = m_p3_fields_out["micro_vap_liq_exchange"].get_reshaped_view<Pack**>();
   history_only.vap_ice_exchange = m_p3_fields_out["micro_vap_ice_exchange"].get_reshaped_view<Pack**>();
   // Deprecated -- These are fields actively being deleted, but are still needed for F90 BFB tests.
-//ASD  diag_outputs.nevapr           = m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
-//ASD  diag_outputs.qr_evap_tend = m_p3_fields_out["qr_evap_tend"].get_reshaped_view<Pack**>();
-//ASD  diag_outputs.precip_total_tend  = m_p3_fields_out["precip_total_tend"].get_reshaped_view<Pack**>();
-//ASD  diag_outputs.mu_c               = m_p3_fields_out["mu_qc"].get_reshaped_view<Pack**>();
-//ASD  diag_outputs.lamc               = m_p3_fields_out["lambda_qc"].get_reshaped_view<Pack**>();
   view_2d nevapr("nevapr",m_num_cols,nk_pack);
   view_2d qr_evap_tend("qr_evap_tend",m_num_cols,nk_pack);
   view_2d precip_total_tend("precip_total_tend",m_num_cols,nk_pack);
@@ -211,10 +200,7 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   deprecated.lamc              = lamc; 
   // -- Set values for the post-amble structure
   p3_postproc.set_variables(m_num_cols,nk_pack,prog_state.th,p3_preproc.exner,T_atm,t_prev,prog_state.qv,qv_prev,
-      diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi,
-//ASD      diag_outputs.lamc,
-//ASD      diag_outputs.mu_c,
-      ast);
+      diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi,ast);
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -94,8 +94,6 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_computed_field("qv_prev_micro_step", scalar3d_layout_mid, Q,        grid_name);
   add_computed_field("T_prev_micro_step",  scalar3d_layout_mid, K,        grid_name);
   // Diagnostic Outputs: (all fields are just outputs w.r.t. P3)
-  m_computed_fields.emplace("mu_qc",             scalar3d_layout_mid, nondim, grid_name);
-  m_computed_fields.emplace("lambda_qc",         scalar3d_layout_mid, nondim, grid_name);
   m_computed_fields.emplace("eff_radius_qc",     scalar3d_layout_mid, m,      grid_name);
   m_computed_fields.emplace("eff_radius_qi",     scalar3d_layout_mid, m,      grid_name);
   // History Only: (all fields are just outputs and are really only meant for I/O purposes)
@@ -106,6 +104,8 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
 //ASD  m_computed_fields.emplace("precip_total_tend", scalar3d_layout_mid, mm,     grid_name);
 //ASD  m_computed_fields.emplace("qr_evap_tend",      scalar3d_layout_mid, mm/s,   grid_name);
 //ASD  m_computed_fields.emplace("nevapr",            scalar3d_layout_mid, nondim, grid_name);
+//ASD  m_computed_fields.emplace("mu_qc",             scalar3d_layout_mid, nondim, grid_name);
+//ASD  m_computed_fields.emplace("lambda_qc",         scalar3d_layout_mid, nondim, grid_name);
 
 }
 
@@ -169,8 +169,6 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   view_2d precip_liq_flux("precip_liq_flux",m_num_cols,m_num_levs);
   view_2d precip_ice_flux("precip_ice_flux",m_num_cols,m_num_levs);
 
-  diag_outputs.mu_c               = m_p3_fields_out["mu_qc"].get_reshaped_view<Pack**>();
-  diag_outputs.lamc               = m_p3_fields_out["lambda_qc"].get_reshaped_view<Pack**>();
   diag_outputs.diag_eff_radius_qc = m_p3_fields_out["eff_radius_qc"].get_reshaped_view<Pack**>();
   diag_outputs.diag_eff_radius_qi = m_p3_fields_out["eff_radius_qi"].get_reshaped_view<Pack**>();
 
@@ -199,15 +197,23 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
 //ASD  diag_outputs.nevapr           = m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
 //ASD  diag_outputs.qr_evap_tend = m_p3_fields_out["qr_evap_tend"].get_reshaped_view<Pack**>();
 //ASD  diag_outputs.precip_total_tend  = m_p3_fields_out["precip_total_tend"].get_reshaped_view<Pack**>();
+//ASD  diag_outputs.mu_c               = m_p3_fields_out["mu_qc"].get_reshaped_view<Pack**>();
+//ASD  diag_outputs.lamc               = m_p3_fields_out["lambda_qc"].get_reshaped_view<Pack**>();
   view_2d nevapr("nevapr",m_num_cols,nk_pack);
   view_2d qr_evap_tend("qr_evap_tend",m_num_cols,nk_pack);
   view_2d precip_total_tend("precip_total_tend",m_num_cols,nk_pack);
-  deprecated.nevapr            = nevapr; //m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
-  deprecated.qr_evap_tend      = qr_evap_tend; //m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
-  deprecated.precip_total_tend = precip_total_tend; //m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
+  view_2d mu_c("mu_c",m_num_cols,nk_pack);
+  view_2d lamc("lamc",m_num_cols,nk_pack);
+  deprecated.nevapr            = nevapr; 
+  deprecated.qr_evap_tend      = qr_evap_tend; 
+  deprecated.precip_total_tend = precip_total_tend; 
+  deprecated.mu_c              = mu_c; 
+  deprecated.lamc              = lamc; 
   // -- Set values for the post-amble structure
   p3_postproc.set_variables(m_num_cols,nk_pack,prog_state.th,p3_preproc.exner,T_atm,t_prev,prog_state.qv,qv_prev,
-      diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi,diag_outputs.lamc,diag_outputs.mu_c,
+      diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi,
+//ASD      diag_outputs.lamc,
+//ASD      diag_outputs.mu_c,
       ast);
 }
 

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -98,13 +98,13 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   m_computed_fields.emplace("lambda_qc",         scalar3d_layout_mid, nondim, grid_name);
   m_computed_fields.emplace("eff_radius_qc",     scalar3d_layout_mid, m,      grid_name);
   m_computed_fields.emplace("eff_radius_qi",     scalar3d_layout_mid, m,      grid_name);
-  m_computed_fields.emplace("precip_total_tend", scalar3d_layout_mid, mm,     grid_name);
-  m_computed_fields.emplace("qr_evap_tend",      scalar3d_layout_mid, mm/s,   grid_name);
   // History Only: (all fields are just outputs and are really only meant for I/O purposes)
   m_computed_fields.emplace("micro_liq_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
   m_computed_fields.emplace("micro_vap_liq_exchange", scalar3d_layout_mid, nondim, grid_name);
   m_computed_fields.emplace("micro_vap_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
   // Deprecated: (these should be removed from the AD eventually)
+//ASD  m_computed_fields.emplace("precip_total_tend", scalar3d_layout_mid, mm,     grid_name);
+//ASD  m_computed_fields.emplace("qr_evap_tend",      scalar3d_layout_mid, mm/s,   grid_name);
 //ASD  m_computed_fields.emplace("nevapr",            scalar3d_layout_mid, nondim, grid_name);
 
 }
@@ -173,8 +173,6 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   diag_outputs.lamc               = m_p3_fields_out["lambda_qc"].get_reshaped_view<Pack**>();
   diag_outputs.diag_eff_radius_qc = m_p3_fields_out["eff_radius_qc"].get_reshaped_view<Pack**>();
   diag_outputs.diag_eff_radius_qi = m_p3_fields_out["eff_radius_qi"].get_reshaped_view<Pack**>();
-  diag_outputs.precip_total_tend  = m_p3_fields_out["precip_total_tend"].get_reshaped_view<Pack**>();
-  diag_outputs.qr_evap_tend       = m_p3_fields_out["qr_evap_tend"].get_reshaped_view<Pack**>();
 
   diag_outputs.precip_liq_surf  = precip_liq_surf; 
   diag_outputs.precip_ice_surf  = precip_ice_surf; 
@@ -199,8 +197,14 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   history_only.vap_ice_exchange = m_p3_fields_out["micro_vap_ice_exchange"].get_reshaped_view<Pack**>();
   // Deprecated -- These are fields actively being deleted, but are still needed for F90 BFB tests.
 //ASD  diag_outputs.nevapr           = m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
+//ASD  diag_outputs.qr_evap_tend = m_p3_fields_out["qr_evap_tend"].get_reshaped_view<Pack**>();
+//ASD  diag_outputs.precip_total_tend  = m_p3_fields_out["precip_total_tend"].get_reshaped_view<Pack**>();
   view_2d nevapr("nevapr",m_num_cols,nk_pack);
-  deprecated.nevapr             = nevapr; //m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
+  view_2d qr_evap_tend("qr_evap_tend",m_num_cols,nk_pack);
+  view_2d precip_total_tend("precip_total_tend",m_num_cols,nk_pack);
+  deprecated.nevapr            = nevapr; //m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
+  deprecated.qr_evap_tend      = qr_evap_tend; //m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
+  deprecated.precip_total_tend = precip_total_tend; //m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
   // -- Set values for the post-amble structure
   p3_postproc.set_variables(m_num_cols,nk_pack,prog_state.th,p3_preproc.exner,T_atm,t_prev,prog_state.qv,qv_prev,
       diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi,diag_outputs.lamc,diag_outputs.mu_c,

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -94,12 +94,12 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_computed_field("qv_prev_micro_step", scalar3d_layout_mid, Q,        grid_name);
   add_computed_field("T_prev_micro_step",  scalar3d_layout_mid, K,        grid_name);
   // Diagnostic Outputs: (all fields are just outputs w.r.t. P3)
-  m_computed_fields.emplace("eff_radius_qc",     scalar3d_layout_mid, m,      grid_name);
-  m_computed_fields.emplace("eff_radius_qi",     scalar3d_layout_mid, m,      grid_name);
+  add_computed_fields.emplace("eff_radius_qc",     scalar3d_layout_mid, m,      grid_name);
+  add_computed_fields.emplace("eff_radius_qi",     scalar3d_layout_mid, m,      grid_name);
   // History Only: (all fields are just outputs and are really only meant for I/O purposes)
-  m_computed_fields.emplace("micro_liq_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
-  m_computed_fields.emplace("micro_vap_liq_exchange", scalar3d_layout_mid, nondim, grid_name);
-  m_computed_fields.emplace("micro_vap_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
+  add_computed_fields.emplace("micro_liq_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
+  add_computed_fields.emplace("micro_vap_liq_exchange", scalar3d_layout_mid, nondim, grid_name);
+  add_computed_fields.emplace("micro_vap_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
 
 }
 

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -200,7 +200,7 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   deprecated.lamc              = lamc; 
   // -- Set values for the post-amble structure
   p3_postproc.set_variables(m_num_cols,nk_pack,prog_state.th,p3_preproc.exner,T_atm,t_prev,prog_state.qv,qv_prev,
-      diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi,ast);
+      diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi);
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -94,12 +94,12 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_computed_field("qv_prev_micro_step", scalar3d_layout_mid, Q,        grid_name);
   add_computed_field("T_prev_micro_step",  scalar3d_layout_mid, K,        grid_name);
   // Diagnostic Outputs: (all fields are just outputs w.r.t. P3)
-  add_computed_fields.emplace("eff_radius_qc",     scalar3d_layout_mid, m,      grid_name);
-  add_computed_fields.emplace("eff_radius_qi",     scalar3d_layout_mid, m,      grid_name);
+  add_computed_field("eff_radius_qc",     scalar3d_layout_mid, m,      grid_name);
+  add_computed_field("eff_radius_qi",     scalar3d_layout_mid, m,      grid_name);
   // History Only: (all fields are just outputs and are really only meant for I/O purposes)
-  add_computed_fields.emplace("micro_liq_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
-  add_computed_fields.emplace("micro_vap_liq_exchange", scalar3d_layout_mid, nondim, grid_name);
-  add_computed_fields.emplace("micro_vap_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
+  add_computed_field("micro_liq_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
+  add_computed_field("micro_vap_liq_exchange", scalar3d_layout_mid, nondim, grid_name);
+  add_computed_field("micro_vap_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
 
 }
 

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -187,17 +187,6 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   history_only.liq_ice_exchange = m_p3_fields_out["micro_liq_ice_exchange"].get_reshaped_view<Pack**>();
   history_only.vap_liq_exchange = m_p3_fields_out["micro_vap_liq_exchange"].get_reshaped_view<Pack**>();
   history_only.vap_ice_exchange = m_p3_fields_out["micro_vap_ice_exchange"].get_reshaped_view<Pack**>();
-  // Deprecated -- These are fields actively being deleted, but are still needed for F90 BFB tests.
-  view_2d nevapr("nevapr",m_num_cols,nk_pack);
-  view_2d qr_evap_tend("qr_evap_tend",m_num_cols,nk_pack);
-  view_2d precip_total_tend("precip_total_tend",m_num_cols,nk_pack);
-  view_2d mu_c("mu_c",m_num_cols,nk_pack);
-  view_2d lamc("lamc",m_num_cols,nk_pack);
-  deprecated.nevapr            = nevapr; 
-  deprecated.qr_evap_tend      = qr_evap_tend; 
-  deprecated.precip_total_tend = precip_total_tend; 
-  deprecated.mu_c              = mu_c; 
-  deprecated.lamc              = lamc; 
   // -- Set values for the post-amble structure
   p3_postproc.set_variables(m_num_cols,nk_pack,prog_state.th,p3_preproc.exner,T_atm,t_prev,prog_state.qv,qv_prev,
       diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi);
@@ -242,7 +231,7 @@ void P3Microphysics::run_impl (const Real dt)
 
   // Run p3 main
   P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
-                                       history_only, deprecated, m_num_cols, m_num_levs);
+                                       history_only, m_num_cols, m_num_levs);
 
   // Conduct the post-processing of the p3_main output.
   Kokkos::parallel_for(

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -104,7 +104,7 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   m_computed_fields.emplace("micro_liq_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
   m_computed_fields.emplace("micro_vap_liq_exchange", scalar3d_layout_mid, nondim, grid_name);
   m_computed_fields.emplace("micro_vap_ice_exchange", scalar3d_layout_mid, nondim, grid_name);
-  // Depracated: (these should be removed from the AD eventually)
+  // Deprecated: (these should be removed from the AD eventually)
 //ASD  m_computed_fields.emplace("nevapr",            scalar3d_layout_mid, nondim, grid_name);
 
 }
@@ -197,10 +197,10 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   history_only.liq_ice_exchange = m_p3_fields_out["micro_liq_ice_exchange"].get_reshaped_view<Pack**>();
   history_only.vap_liq_exchange = m_p3_fields_out["micro_vap_liq_exchange"].get_reshaped_view<Pack**>();
   history_only.vap_ice_exchange = m_p3_fields_out["micro_vap_ice_exchange"].get_reshaped_view<Pack**>();
-  // Depracated -- These are fields actively being deleted, but are still needed for F90 BFB tests.
+  // Deprecated -- These are fields actively being deleted, but are still needed for F90 BFB tests.
 //ASD  diag_outputs.nevapr           = m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
   view_2d nevapr("nevapr",m_num_cols,nk_pack);
-  depracated.nevapr             = nevapr; //m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
+  deprecated.nevapr             = nevapr; //m_p3_fields_out["nevapr"].get_reshaped_view<Pack**>();
   // -- Set values for the post-amble structure
   p3_postproc.set_variables(m_num_cols,nk_pack,prog_state.th,p3_preproc.exner,T_atm,t_prev,prog_state.qv,qv_prev,
       diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi,diag_outputs.lamc,diag_outputs.mu_c,
@@ -246,7 +246,7 @@ void P3Microphysics::run_impl (const Real dt)
 
   // Run p3 main
   P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
-                                       history_only, depracated, m_num_cols, m_num_levs);
+                                       history_only, deprecated, m_num_cols, m_num_levs);
 
   // Conduct the post-processing of the p3_main output.
   Kokkos::parallel_for(

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -198,7 +198,9 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   history_only.vap_liq_exchange = m_p3_fields_out["micro_vap_liq_exchange"].get_reshaped_view<Pack**>();
   history_only.vap_ice_exchange = m_p3_fields_out["micro_vap_ice_exchange"].get_reshaped_view<Pack**>();
   // -- Set values for the post-amble structure
-  p3_postproc.set_variables(m_num_cols,nk_pack,prog_state.th,p3_preproc.exner,T_atm,t_prev,prog_state.qv,qv_prev);
+  p3_postproc.set_variables(m_num_cols,nk_pack,prog_state.th,p3_preproc.exner,T_atm,t_prev,prog_state.qv,qv_prev,
+      diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi,diag_outputs.lamc,diag_outputs.mu_c,
+      ast);
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -181,12 +181,12 @@ public:
         const Smask oqv_mask(!isnan(oqv) and oqv>0.0);
         qv_prev(icol,ipack).set(oqv_mask,oqv);
         // Limiter for low cloud fraction
-        Real mucon = 5.3;
-        Real dcon  = 25.e-6;
-        const Spack ocld_tot(cldfrac_tot(icol,ipack));
-        const Smask ocld_mask(!isnan(ocld_tot) and ocld_tot<1.e-4);
-        lambda_qc(icol,ipack).set(ocld_mask,mucon);
-        mu_qc(icol,ipack).set(ocld_mask,(mucon + 1.0)/dcon);
+//ASD        Real mucon = 5.3;
+//ASD        Real dcon  = 25.e-6;
+//ASD        const Spack ocld_tot(cldfrac_tot(icol,ipack));
+//ASD        const Smask ocld_mask(!isnan(ocld_tot) and ocld_tot<1.e-4);
+//ASD        lambda_qc(icol,ipack).set(ocld_mask,mucon);
+//ASD        mu_qc(icol,ipack).set(ocld_mask,(mucon + 1.0)/dcon);
         // Rescale effective radius' into microns
         for (int ivec=0;ivec<Spack::n;ivec++) {
           diag_eff_radius_qc(icol,ipack)[ivec] *= 1e6;
@@ -204,14 +204,16 @@ public:
     view_2d       qv_prev;
     view_2d       diag_eff_radius_qc;
     view_2d       diag_eff_radius_qi;
-    view_2d       lambda_qc;
-    view_2d       mu_qc;
+//ASD    view_2d       lambda_qc;
+//ASD    view_2d       mu_qc;
     view_2d_const cldfrac_tot;
     // Assigning local values
     void set_variables(const int ncol, const int npack,
                     view_2d th_atm_, view_2d exner_, view_2d T_atm_, view_2d T_prev_,
                     view_2d qv_, view_2d qv_prev_, view_2d diag_eff_radius_qc_, view_2d diag_eff_radius_qi_,
-                    view_2d lambda_qc_, view_2d mu_qc_, view_2d_const cldfrac_tot_
+//ASD                    view_2d lambda_qc_, 
+//ASD                    view_2d mu_qc_, 
+                    view_2d_const cldfrac_tot_
                    )
     {
       m_ncol  = ncol;
@@ -227,8 +229,8 @@ public:
       qv_prev            = qv_prev_;
       diag_eff_radius_qc = diag_eff_radius_qc_;
       diag_eff_radius_qi = diag_eff_radius_qi_;
-      lambda_qc          = lambda_qc_;
-      mu_qc              = mu_qc_;
+//ASD      lambda_qc          = lambda_qc_;
+//ASD      mu_qc              = mu_qc_;
       // TODO: This is a list of variables not yet defined for post-processing, but are
       // defined in the F90 p3 interface code.  So this list will need to be checked as
       // new processes come online to make sure their requirements from p3 are being met.

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -197,13 +197,10 @@ public:
     view_2d       qv_prev;
     view_2d       diag_eff_radius_qc;
     view_2d       diag_eff_radius_qi;
-    view_2d_const cldfrac_tot;
     // Assigning local values
     void set_variables(const int ncol, const int npack,
                     view_2d th_atm_, view_2d exner_, view_2d T_atm_, view_2d T_prev_,
-                    view_2d qv_, view_2d qv_prev_, view_2d diag_eff_radius_qc_, view_2d diag_eff_radius_qi_,
-                    view_2d_const cldfrac_tot_
-                   )
+                    view_2d qv_, view_2d qv_prev_, view_2d diag_eff_radius_qc_, view_2d diag_eff_radius_qi_)
     {
       m_ncol  = ncol;
       m_npack = npack;
@@ -211,7 +208,6 @@ public:
       th_atm      = th_atm_;
       exner       = exner_;
       qv          = qv_;
-      cldfrac_tot = cldfrac_tot_;
       // OUT
       T_atm              = T_atm_;
       T_prev             = T_prev_;

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -285,6 +285,7 @@ protected:
   P3F::P3DiagnosticOutputs diag_outputs;
   P3F::P3HistoryOnly       history_only;
   P3F::P3Infrastructure    infrastructure;
+  P3F::P3Depracated        depracated;
   p3_preamble              p3_preproc;
   p3_postamble             p3_postproc;
   // Iteration count is internal to P3 and keeps track of the number of times p3_main has been called.

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -285,7 +285,7 @@ protected:
   P3F::P3DiagnosticOutputs diag_outputs;
   P3F::P3HistoryOnly       history_only;
   P3F::P3Infrastructure    infrastructure;
-  P3F::P3Depracated        depracated;
+  P3F::P3Deprecated        deprecated;
   p3_preamble              p3_preproc;
   p3_postamble             p3_postproc;
   // Iteration count is internal to P3 and keeps track of the number of times p3_main has been called.

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -270,7 +270,6 @@ protected:
   P3F::P3DiagnosticOutputs diag_outputs;
   P3F::P3HistoryOnly       history_only;
   P3F::P3Infrastructure    infrastructure;
-  P3F::P3Deprecated        deprecated;
   p3_preamble              p3_preproc;
   p3_postamble             p3_postproc;
   // Iteration count is internal to P3 and keeps track of the number of times p3_main has been called.

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -180,13 +180,6 @@ public:
         const Spack oqv(qv(icol,ipack));
         const Smask oqv_mask(!isnan(oqv) and oqv>0.0);
         qv_prev(icol,ipack).set(oqv_mask,oqv);
-        // Limiter for low cloud fraction
-//ASD        Real mucon = 5.3;
-//ASD        Real dcon  = 25.e-6;
-//ASD        const Spack ocld_tot(cldfrac_tot(icol,ipack));
-//ASD        const Smask ocld_mask(!isnan(ocld_tot) and ocld_tot<1.e-4);
-//ASD        lambda_qc(icol,ipack).set(ocld_mask,mucon);
-//ASD        mu_qc(icol,ipack).set(ocld_mask,(mucon + 1.0)/dcon);
         // Rescale effective radius' into microns
         for (int ivec=0;ivec<Spack::n;ivec++) {
           diag_eff_radius_qc(icol,ipack)[ivec] *= 1e6;
@@ -204,15 +197,11 @@ public:
     view_2d       qv_prev;
     view_2d       diag_eff_radius_qc;
     view_2d       diag_eff_radius_qi;
-//ASD    view_2d       lambda_qc;
-//ASD    view_2d       mu_qc;
     view_2d_const cldfrac_tot;
     // Assigning local values
     void set_variables(const int ncol, const int npack,
                     view_2d th_atm_, view_2d exner_, view_2d T_atm_, view_2d T_prev_,
                     view_2d qv_, view_2d qv_prev_, view_2d diag_eff_radius_qc_, view_2d diag_eff_radius_qi_,
-//ASD                    view_2d lambda_qc_, 
-//ASD                    view_2d mu_qc_, 
                     view_2d_const cldfrac_tot_
                    )
     {
@@ -229,8 +218,6 @@ public:
       qv_prev            = qv_prev_;
       diag_eff_radius_qc = diag_eff_radius_qc_;
       diag_eff_radius_qi = diag_eff_radius_qi_;
-//ASD      lambda_qc          = lambda_qc_;
-//ASD      mu_qc              = mu_qc_;
       // TODO: This is a list of variables not yet defined for post-processing, but are
       // defined in the F90 p3 interface code.  So this list will need to be checked as
       // new processes come online to make sure their requirements from p3 are being met.

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -19,8 +19,7 @@ extern "C" {
                  Int it, Real* precip_liq_surf, Real* precip_ice_surf, Int its,
                  Int ite, Int kts, Int kte, Real* diag_eff_radius_qc, Real* diag_eff_radius_qi,
                  Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* exner,
-                 Real* qv2qi_depos_tend, 
-//ASD                 Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend,
+                 Real* qv2qi_depos_tend,
                  Real* precip_liq_flux, Real* precip_ice_flux, // 1 extra column size
                  Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i,
                  Real* liq_ice_exchange, Real* vap_liq_exchange,
@@ -65,16 +64,11 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   diag_eff_radius_qi = Array2("effective radius, ice, m", ncol, nlev);
   rho_qi             = Array2("bulk density of ice, kg/m", ncol, nlev);
   qv2qi_depos_tend   = Array2("qitend due to deposition/sublimation ", ncol, nlev);
-//ASD  precip_total_tend  = Array2("Total precipitation (rain + snow)", ncol, nlev);
-//ASD  nevapr             = Array2("evaporation of total precipitation (rain + snow)", ncol, nlev);
-//ASD  qr_evap_tend       = Array2("evaporation of rain", ncol, nlev);
   precip_liq_flux    = Array2("grid-box average rain flux (kg m^-2 s^-1), pverp", ncol, nlev+1);
   precip_ice_flux    = Array2("grid-box average ice/snow flux (kg m^-2 s^-1), pverp", ncol, nlev+1);
   cld_frac_r         = Array2("Rain cloud fraction", ncol, nlev);
   cld_frac_l         = Array2("Liquid cloud fraction", ncol, nlev);
   cld_frac_i         = Array2("Ice cloud fraction", ncol, nlev);
-//ASD  mu_c               = Array2("Size distribution shape paramter", ncol, nlev);
-//ASD  lamc               = Array2("Size distribution slope paramter", ncol, nlev);
   liq_ice_exchange   = Array2("sum of liq-ice phase change tendenices", ncol, nlev);
   vap_liq_exchange   = Array2("sum of vap-liq phase change tendenices", ncol, nlev);
   vap_ice_exchange   = Array2("sum of vap-ice phase change tendenices", ncol, nlev);
@@ -98,11 +92,8 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(qm); fdipb(bm); fdipb(precip_liq_surf); fdipb(precip_ice_surf);
   fdipb(diag_eff_radius_qc); fdipb(diag_eff_radius_qi); fdipb(rho_qi);
   fdipb(dpres); fdipb(exner); fdipb(qv2qi_depos_tend); 
-//ASD  fdipb(precip_total_tend);
-//ASD  fdipb(nevapr); fdipb(qr_evap_tend); 
   fdipb(precip_liq_flux); fdipb(precip_ice_flux);
   fdipb(cld_frac_r); fdipb(cld_frac_l); fdipb(cld_frac_i);
-//ASD  fdipb(mu_c); fdipb(lamc);
   fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
   fdipb(vap_ice_exchange); fdipb(qv_prev); fdipb(t_prev);;
 #undef fdipb
@@ -143,11 +134,8 @@ Int p3_main (const FortranData& d, bool use_fortran) {
               d.it, d.precip_liq_surf.data(), d.precip_ice_surf.data(), 1, d.ncol, 1, d.nlev,
               d.diag_eff_radius_qc.data(), d.diag_eff_radius_qi.data(), d.rho_qi.data(),
               d.do_predict_nc, d.do_prescribed_CCN, d.dpres.data(), d.exner.data(), d.qv2qi_depos_tend.data(),
-//ASD              d.precip_total_tend.data(), d.nevapr.data(), d.qr_evap_tend.data(),
-              d.precip_liq_flux.data(), d.precip_ice_flux.data(), d.cld_frac_r.data(), d.cld_frac_l.data(),
-              d.cld_frac_i.data(),
-              d.liq_ice_exchange.data(),
-              d.vap_liq_exchange.data(),d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data(), &elapsed_s);
+              d.precip_liq_flux.data(), d.precip_ice_flux.data(), d.cld_frac_r.data(), d.cld_frac_l.data(), d.cld_frac_i.data(),
+              d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data(), &elapsed_s);
     return static_cast<Int>(elapsed_s * 1000000);
   }
   else {
@@ -158,12 +146,8 @@ Int p3_main (const FortranData& d, bool use_fortran) {
                      d.precip_ice_surf.data(), 1, d.ncol, 1, d.nlev, d.diag_eff_radius_qc.data(),
                      d.diag_eff_radius_qi.data(), d.rho_qi.data(), d.do_predict_nc, d.do_prescribed_CCN,
                      d.dpres.data(), d.exner.data(), d.qv2qi_depos_tend.data(),
-//ASD                     d.precip_total_tend.data(),
-//ASD                     d.nevapr.data(), d.qr_evap_tend.data(),
                      d.precip_liq_flux.data(), d.precip_ice_flux.data(),
                      d.cld_frac_r.data(), d.cld_frac_l.data(), d.cld_frac_i.data(),
-//ASD                     d.mu_c.data(),
-//ASD                     d.lamc.data(), 
                      d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),
                      d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data() );
 

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -21,7 +21,7 @@ extern "C" {
                  Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* exner,
                  Real* qv2qi_depos_tend, Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend,
                  Real* precip_liq_flux, Real* precip_ice_flux, // 1 extra column size
-                 Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, Real* mu_c, Real* lamc,
+                 Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i,
                  Real* liq_ice_exchange, Real* vap_liq_exchange,
                  Real* vap_ice_exchange, Real* qv_prev, Real* t_prev, Real* elapsed_s);
 }
@@ -72,8 +72,8 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   cld_frac_r         = Array2("Rain cloud fraction", ncol, nlev);
   cld_frac_l         = Array2("Liquid cloud fraction", ncol, nlev);
   cld_frac_i         = Array2("Ice cloud fraction", ncol, nlev);
-  mu_c               = Array2("Size distribution shape paramter", ncol, nlev);
-  lamc               = Array2("Size distribution slope paramter", ncol, nlev);
+//ASD  mu_c               = Array2("Size distribution shape paramter", ncol, nlev);
+//ASD  lamc               = Array2("Size distribution slope paramter", ncol, nlev);
   liq_ice_exchange   = Array2("sum of liq-ice phase change tendenices", ncol, nlev);
   vap_liq_exchange   = Array2("sum of vap-liq phase change tendenices", ncol, nlev);
   vap_ice_exchange   = Array2("sum of vap-ice phase change tendenices", ncol, nlev);
@@ -99,7 +99,8 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(dpres); fdipb(exner); fdipb(qv2qi_depos_tend); fdipb(precip_total_tend);
   fdipb(nevapr); fdipb(qr_evap_tend); fdipb(precip_liq_flux); fdipb(precip_ice_flux);
   fdipb(cld_frac_r); fdipb(cld_frac_l); fdipb(cld_frac_i);
-  fdipb(mu_c); fdipb(lamc), fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
+//ASD  fdipb(mu_c); fdipb(lamc);
+  fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
   fdipb(vap_ice_exchange); fdipb(qv_prev); fdipb(t_prev);;
 #undef fdipb
 }
@@ -141,7 +142,7 @@ Int p3_main (const FortranData& d, bool use_fortran) {
               d.do_predict_nc, d.do_prescribed_CCN, d.dpres.data(), d.exner.data(), d.qv2qi_depos_tend.data(),
               d.precip_total_tend.data(), d.nevapr.data(), d.qr_evap_tend.data(),
               d.precip_liq_flux.data(), d.precip_ice_flux.data(), d.cld_frac_r.data(), d.cld_frac_l.data(),
-              d.cld_frac_i.data(), d.mu_c.data(), d.lamc.data(),
+              d.cld_frac_i.data(),
               d.liq_ice_exchange.data(),
               d.vap_liq_exchange.data(),d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data(), &elapsed_s);
     return static_cast<Int>(elapsed_s * 1000000);
@@ -155,8 +156,10 @@ Int p3_main (const FortranData& d, bool use_fortran) {
                      d.diag_eff_radius_qi.data(), d.rho_qi.data(), d.do_predict_nc, d.do_prescribed_CCN,
                      d.dpres.data(), d.exner.data(), d.qv2qi_depos_tend.data(), d.precip_total_tend.data(),
                      d.nevapr.data(), d.qr_evap_tend.data(), d.precip_liq_flux.data(), d.precip_ice_flux.data(),
-                     d.cld_frac_r.data(), d.cld_frac_l.data(), d.cld_frac_i.data(), d.mu_c.data(),
-                     d.lamc.data(), d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),
+                     d.cld_frac_r.data(), d.cld_frac_l.data(), d.cld_frac_i.data(),
+//ASD                     d.mu_c.data(),
+//ASD                     d.lamc.data(), 
+                     d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),
                      d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data() );
 
   }

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -19,7 +19,8 @@ extern "C" {
                  Int it, Real* precip_liq_surf, Real* precip_ice_surf, Int its,
                  Int ite, Int kts, Int kte, Real* diag_eff_radius_qc, Real* diag_eff_radius_qi,
                  Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* exner,
-                 Real* qv2qi_depos_tend, Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend,
+                 Real* qv2qi_depos_tend, 
+//ASD                 Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend,
                  Real* precip_liq_flux, Real* precip_ice_flux, // 1 extra column size
                  Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i,
                  Real* liq_ice_exchange, Real* vap_liq_exchange,
@@ -64,9 +65,9 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   diag_eff_radius_qi = Array2("effective radius, ice, m", ncol, nlev);
   rho_qi             = Array2("bulk density of ice, kg/m", ncol, nlev);
   qv2qi_depos_tend   = Array2("qitend due to deposition/sublimation ", ncol, nlev);
-  precip_total_tend  = Array2("Total precipitation (rain + snow)", ncol, nlev);
-  nevapr             = Array2("evaporation of total precipitation (rain + snow)", ncol, nlev);
-  qr_evap_tend       = Array2("evaporation of rain", ncol, nlev);
+//ASD  precip_total_tend  = Array2("Total precipitation (rain + snow)", ncol, nlev);
+//ASD  nevapr             = Array2("evaporation of total precipitation (rain + snow)", ncol, nlev);
+//ASD  qr_evap_tend       = Array2("evaporation of rain", ncol, nlev);
   precip_liq_flux    = Array2("grid-box average rain flux (kg m^-2 s^-1), pverp", ncol, nlev+1);
   precip_ice_flux    = Array2("grid-box average ice/snow flux (kg m^-2 s^-1), pverp", ncol, nlev+1);
   cld_frac_r         = Array2("Rain cloud fraction", ncol, nlev);
@@ -96,8 +97,10 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(nc); fdipb(qr); fdipb(nr); fdipb(qi); fdipb(ni);
   fdipb(qm); fdipb(bm); fdipb(precip_liq_surf); fdipb(precip_ice_surf);
   fdipb(diag_eff_radius_qc); fdipb(diag_eff_radius_qi); fdipb(rho_qi);
-  fdipb(dpres); fdipb(exner); fdipb(qv2qi_depos_tend); fdipb(precip_total_tend);
-  fdipb(nevapr); fdipb(qr_evap_tend); fdipb(precip_liq_flux); fdipb(precip_ice_flux);
+  fdipb(dpres); fdipb(exner); fdipb(qv2qi_depos_tend); 
+//ASD  fdipb(precip_total_tend);
+//ASD  fdipb(nevapr); fdipb(qr_evap_tend); 
+  fdipb(precip_liq_flux); fdipb(precip_ice_flux);
   fdipb(cld_frac_r); fdipb(cld_frac_l); fdipb(cld_frac_i);
 //ASD  fdipb(mu_c); fdipb(lamc);
   fdipb(liq_ice_exchange); fdipb(vap_liq_exchange);
@@ -140,7 +143,7 @@ Int p3_main (const FortranData& d, bool use_fortran) {
               d.it, d.precip_liq_surf.data(), d.precip_ice_surf.data(), 1, d.ncol, 1, d.nlev,
               d.diag_eff_radius_qc.data(), d.diag_eff_radius_qi.data(), d.rho_qi.data(),
               d.do_predict_nc, d.do_prescribed_CCN, d.dpres.data(), d.exner.data(), d.qv2qi_depos_tend.data(),
-              d.precip_total_tend.data(), d.nevapr.data(), d.qr_evap_tend.data(),
+//ASD              d.precip_total_tend.data(), d.nevapr.data(), d.qr_evap_tend.data(),
               d.precip_liq_flux.data(), d.precip_ice_flux.data(), d.cld_frac_r.data(), d.cld_frac_l.data(),
               d.cld_frac_i.data(),
               d.liq_ice_exchange.data(),
@@ -154,8 +157,10 @@ Int p3_main (const FortranData& d, bool use_fortran) {
                      d.ni_activated.data(), d.inv_qc_relvar.data(), d.it, d.precip_liq_surf.data(),
                      d.precip_ice_surf.data(), 1, d.ncol, 1, d.nlev, d.diag_eff_radius_qc.data(),
                      d.diag_eff_radius_qi.data(), d.rho_qi.data(), d.do_predict_nc, d.do_prescribed_CCN,
-                     d.dpres.data(), d.exner.data(), d.qv2qi_depos_tend.data(), d.precip_total_tend.data(),
-                     d.nevapr.data(), d.qr_evap_tend.data(), d.precip_liq_flux.data(), d.precip_ice_flux.data(),
+                     d.dpres.data(), d.exner.data(), d.qv2qi_depos_tend.data(),
+//ASD                     d.precip_total_tend.data(),
+//ASD                     d.nevapr.data(), d.qr_evap_tend.data(),
+                     d.precip_liq_flux.data(), d.precip_ice_flux.data(),
                      d.cld_frac_r.data(), d.cld_frac_l.data(), d.cld_frac_i.data(),
 //ASD                     d.mu_c.data(),
 //ASD                     d.lamc.data(), 

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -34,7 +34,7 @@ struct FortranData {
   Array2 diag_eff_radius_qc, diag_eff_radius_qi, rho_qi, qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend,
          precip_liq_flux, precip_ice_flux, cld_frac_r, cld_frac_l, cld_frac_i;
   Array3 p3_tend_out;
-  Array2 mu_c, lamc;
+//ASD  Array2 mu_c, lamc;
   Array2 liq_ice_exchange,vap_liq_exchange,vap_ice_exchange;
 
   FortranData(Int ncol, Int nlev);

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -32,10 +32,8 @@ struct FortranData {
   // Out
   Array1 precip_liq_surf, precip_ice_surf;
   Array2 diag_eff_radius_qc, diag_eff_radius_qi, rho_qi, qv2qi_depos_tend,
-//ASD         precip_total_tend, nevapr, qr_evap_tend,
          precip_liq_flux, precip_ice_flux, cld_frac_r, cld_frac_l, cld_frac_i;
   Array3 p3_tend_out;
-//ASD  Array2 mu_c, lamc;
   Array2 liq_ice_exchange,vap_liq_exchange,vap_ice_exchange;
 
   FortranData(Int ncol, Int nlev);

--- a/components/scream/src/physics/p3/p3_f90.hpp
+++ b/components/scream/src/physics/p3/p3_f90.hpp
@@ -31,7 +31,8 @@ struct FortranData {
     ni, qm, bm, dpres, exner, qv_prev, t_prev;
   // Out
   Array1 precip_liq_surf, precip_ice_surf;
-  Array2 diag_eff_radius_qc, diag_eff_radius_qi, rho_qi, qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend,
+  Array2 diag_eff_radius_qc, diag_eff_radius_qi, rho_qi, qv2qi_depos_tend,
+//ASD         precip_total_tend, nevapr, qr_evap_tend,
          precip_liq_flux, precip_ice_flux, cld_frac_r, cld_frac_l, cld_frac_i;
   Array3 p3_tend_out;
 //ASD  Array2 mu_c, lamc;

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -148,10 +148,6 @@ struct Functions
   // This struct stores diagnostic outputs computed by P3.
   struct P3DiagnosticOutputs {
     P3DiagnosticOutputs() = default;
-//ASD    // Size distribution shape parameter for radiation
-//ASD    view_2d<Spack> mu_c;
-//ASD    // Size distribution slope parameter for radiation
-//ASD    view_2d<Spack> lamc;
     // qitend due to deposition/sublimation
     view_2d<Spack> qv2qi_depos_tend;
     // Precipitation rate, liquid [m s-1]
@@ -164,12 +160,6 @@ struct Functions
     view_2d<Spack> diag_eff_radius_qi;
     // Bulk density of ice [kg m-3]
     view_2d<Spack> rho_qi;
-//ASD    // Total precipitation (rain + snow)
-//ASD    view_2d<Spack> precip_total_tend;
-//ASD    // Evaporation of total precipitation (rain + snow)
-//ASD    view_2d<Spack> nevapr;
-//ASD    // Evaporation of rain
-//ASD    view_2d<Spack> qr_evap_tend;
     // Grid-box average rain flux [kg m^-2 s^-1] pverp
     view_2d<Spack> precip_liq_flux;
     // Grid-box average ice/snow flux [kg m^-2 s^-1] pverp

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -164,12 +164,12 @@ struct Functions
     view_2d<Spack> diag_eff_radius_qi;
     // Bulk density of ice [kg m-3]
     view_2d<Spack> rho_qi;
-    // Total precipitation (rain + snow)
-    view_2d<Spack> precip_total_tend;
-//    // Evaporation of total precipitation (rain + snow)
-//    view_2d<Spack> nevapr;
-    // Evaporation of rain
-    view_2d<Spack> qr_evap_tend;
+//ASD    // Total precipitation (rain + snow)
+//ASD    view_2d<Spack> precip_total_tend;
+//ASD    // Evaporation of total precipitation (rain + snow)
+//ASD    view_2d<Spack> nevapr;
+//ASD    // Evaporation of rain
+//ASD    view_2d<Spack> qr_evap_tend;
     // Grid-box average rain flux [kg m^-2 s^-1] pverp
     view_2d<Spack> precip_liq_flux;
     // Grid-box average ice/snow flux [kg m^-2 s^-1] pverp
@@ -216,6 +216,10 @@ struct Functions
     P3Deprecated() = default;
     // Evaporation of total precipitation (rain + snow)
     view_2d<Spack> nevapr;
+    // Evaporation of rain
+    view_2d<Spack> qr_evap_tend;
+    // Total precipitation (rain + snow)
+    view_2d<Spack> precip_total_tend;
   };
 
   // -- Table3 --

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -148,10 +148,10 @@ struct Functions
   // This struct stores diagnostic outputs computed by P3.
   struct P3DiagnosticOutputs {
     P3DiagnosticOutputs() = default;
-    // Size distribution shape parameter for radiation
-    view_2d<Spack> mu_c;
-    // Size distribution slope parameter for radiation
-    view_2d<Spack> lamc;
+//ASD    // Size distribution shape parameter for radiation
+//ASD    view_2d<Spack> mu_c;
+//ASD    // Size distribution slope parameter for radiation
+//ASD    view_2d<Spack> lamc;
     // qitend due to deposition/sublimation
     view_2d<Spack> qv2qi_depos_tend;
     // Precipitation rate, liquid [m s-1]
@@ -220,6 +220,10 @@ struct Functions
     view_2d<Spack> qr_evap_tend;
     // Total precipitation (rain + snow)
     view_2d<Spack> precip_total_tend;
+    // Size distribution shape parameter for radiation
+    view_2d<Spack> mu_c;
+    // Size distribution slope parameter for radiation
+    view_2d<Spack> lamc;
   };
 
   // -- Table3 --

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -212,8 +212,8 @@ struct Functions
   };
 
   // This struct stores diagnostic outputs computed by P3.
-  struct P3Depracated {
-    P3Depracated() = default;
+  struct P3Deprecated {
+    P3Deprecated() = default;
     // Evaporation of total precipitation (rain + snow)
     view_2d<Spack> nevapr;
   };
@@ -973,7 +973,7 @@ struct Functions
     const P3DiagnosticOutputs& diagnostic_outputs,
     const P3Infrastructure& infrastructure,
     const P3HistoryOnly& history_only,
-    const P3Depracated& depracated,
+    const P3Deprecated& deprecated,
     Int nj, // number of columns
     Int nk); // number of vertical cells per column
 

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -201,21 +201,6 @@ struct Functions
     view_2d<Spack> vap_ice_exchange;
   };
 
-  // This struct stores diagnostic outputs computed by P3.
-  struct P3Deprecated {
-    P3Deprecated() = default;
-    // Evaporation of total precipitation (rain + snow)
-    view_2d<Spack> nevapr;
-    // Evaporation of rain
-    view_2d<Spack> qr_evap_tend;
-    // Total precipitation (rain + snow)
-    view_2d<Spack> precip_total_tend;
-    // Size distribution shape parameter for radiation
-    view_2d<Spack> mu_c;
-    // Size distribution slope parameter for radiation
-    view_2d<Spack> lamc;
-  };
-
   // -- Table3 --
 
   struct Table3 {
@@ -971,7 +956,6 @@ struct Functions
     const P3DiagnosticOutputs& diagnostic_outputs,
     const P3Infrastructure& infrastructure,
     const P3HistoryOnly& history_only,
-    const P3Deprecated& deprecated,
     Int nj, // number of columns
     Int nk); // number of vertical cells per column
 

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -166,8 +166,8 @@ struct Functions
     view_2d<Spack> rho_qi;
     // Total precipitation (rain + snow)
     view_2d<Spack> precip_total_tend;
-    // Evaporation of total precipitation (rain + snow)
-    view_2d<Spack> nevapr;
+//    // Evaporation of total precipitation (rain + snow)
+//    view_2d<Spack> nevapr;
     // Evaporation of rain
     view_2d<Spack> qr_evap_tend;
     // Grid-box average rain flux [kg m^-2 s^-1] pverp
@@ -209,6 +209,13 @@ struct Functions
     view_2d<Spack> vap_liq_exchange;
     // Sum of vap-ice phase change tendencies
     view_2d<Spack> vap_ice_exchange;
+  };
+
+  // This struct stores diagnostic outputs computed by P3.
+  struct P3Depracated {
+    P3Depracated() = default;
+    // Evaporation of total precipitation (rain + snow)
+    view_2d<Spack> nevapr;
   };
 
   // -- Table3 --
@@ -966,6 +973,7 @@ struct Functions
     const P3DiagnosticOutputs& diagnostic_outputs,
     const P3Infrastructure& infrastructure,
     const P3HistoryOnly& history_only,
+    const P3Depracated& depracated,
     Int nj, // number of columns
     Int nk); // number of vertical cells per column
 

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3345,7 +3345,10 @@ Int p3_main_f(
   P3F::P3DiagnosticInputs diag_inputs{nc_nuceat_tend_d, nccn_prescribed_d, ni_activated_d, inv_qc_relvar_d, cld_frac_i_d,
                                       cld_frac_l_d, cld_frac_r_d, pres_d, dz_d, dpres_d,
                                       exner_d, qv_prev_d, t_prev_d};
-  P3F::P3DiagnosticOutputs diag_outputs{mu_c_d, lamc_d, qv2qi_depos_tend_d, precip_liq_surf_d,
+  P3F::P3DiagnosticOutputs diag_outputs{
+//ASD                                        mu_c_d, 
+//ASD                                        lamc_d, 
+                                        qv2qi_depos_tend_d, precip_liq_surf_d,
                                         precip_ice_surf_d, diag_eff_radius_qc_d, diag_eff_radius_qi_d,
                                         rho_qi_d,
 //ASD                                        precip_total_tend_d, 
@@ -3356,7 +3359,7 @@ Int p3_main_f(
                                        do_predict_nc, do_prescribed_CCN, col_location_d};
   P3F::P3HistoryOnly history_only{liq_ice_exchange_d, vap_liq_exchange_d,
                                   vap_ice_exchange_d};
-  P3F::P3Deprecated  deprecated{nevapr_d,qr_evap_tend_d,precip_total_tend_d};
+  P3F::P3Deprecated  deprecated{nevapr_d,qr_evap_tend_d,precip_total_tend_d,mu_c_d,lamc_d};
 
   auto elapsed_microsec = P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
                                        history_only, deprecated, nj, nk);

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3354,10 +3354,10 @@ Int p3_main_f(
                                        do_predict_nc, do_prescribed_CCN, col_location_d};
   P3F::P3HistoryOnly history_only{liq_ice_exchange_d, vap_liq_exchange_d,
                                   vap_ice_exchange_d};
-  P3F::P3Depracated  depracated{nevapr_d};
+  P3F::P3Deprecated  deprecated{nevapr_d};
 
   auto elapsed_microsec = P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
-                                       history_only, depracated, nj, nk);
+                                       history_only, deprecated, nj, nk);
 
   Kokkos::parallel_for(nj, KOKKOS_LAMBDA(const Int& i) {
     precip_liq_surf_temp_d(0, i / Spack::n)[i % Spack::n] = precip_liq_surf_d(i);

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3345,16 +3345,9 @@ Int p3_main_f(
   P3F::P3DiagnosticInputs diag_inputs{nc_nuceat_tend_d, nccn_prescribed_d, ni_activated_d, inv_qc_relvar_d, cld_frac_i_d,
                                       cld_frac_l_d, cld_frac_r_d, pres_d, dz_d, dpres_d,
                                       exner_d, qv_prev_d, t_prev_d};
-  P3F::P3DiagnosticOutputs diag_outputs{
-//ASD                                        mu_c_d, 
-//ASD                                        lamc_d, 
-                                        qv2qi_depos_tend_d, precip_liq_surf_d,
+  P3F::P3DiagnosticOutputs diag_outputs{qv2qi_depos_tend_d, precip_liq_surf_d,
                                         precip_ice_surf_d, diag_eff_radius_qc_d, diag_eff_radius_qi_d,
-                                        rho_qi_d,
-//ASD                                        precip_total_tend_d, 
-//ASD                                        nevapr_d,
-//ASD                                        qr_evap_tend_d, 
-                                        precip_liq_flux_d, precip_ice_flux_d};
+                                        rho_qi_d,precip_liq_flux_d, precip_ice_flux_d};
   P3F::P3Infrastructure infrastructure{dt, it, its, ite, kts, kte,
                                        do_predict_nc, do_prescribed_CCN, col_location_d};
   P3F::P3HistoryOnly history_only{liq_ice_exchange_d, vap_liq_exchange_d,

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3268,10 +3268,11 @@ Int p3_main_f(
   };
 
   //PMC - hardcoding the index for each variable is very brittle :-(.
-  dim2_sizes[P3MainData::NUM_ARRAYS-4] = nk+1; // precip_liq_flux
-  dim2_sizes[P3MainData::NUM_ARRAYS-3] = nk+1; // precip_ice_flux
-  dim1_sizes[P3MainData::NUM_ARRAYS-2] = 1; dim2_sizes[P3MainData::NUM_ARRAYS-2] = nj; // precip_liq_surf
-  dim1_sizes[P3MainData::NUM_ARRAYS-1] = 1; dim2_sizes[P3MainData::NUM_ARRAYS-1] = nj; // precip_ice_surf
+  int dim_sizes_len = dim1_sizes.size(); 
+  dim2_sizes[dim_sizes_len-4] = nk+1; // precip_liq_flux
+  dim2_sizes[dim_sizes_len-3] = nk+1; // precip_ice_flux
+  dim1_sizes[dim_sizes_len-2] = 1; dim2_sizes[dim_sizes_len-2] = nj; // precip_liq_surf
+  dim1_sizes[dim_sizes_len-1] = 1; dim2_sizes[dim_sizes_len-1] = nj; // precip_ice_surf
 
   // Initialize outputs to avoid uninitialized read warnings in memory checkers
   for (size_t i = P3MainData::NUM_INPUT_ARRAYS; i < P3MainData::NUM_ARRAYS; ++i) {
@@ -3369,11 +3370,11 @@ Int p3_main_f(
   };
   std::vector<size_t> dim1_sizes_out(P3MainData::NUM_ARRAYS - 13, nj);
   std::vector<size_t> dim2_sizes_out(P3MainData::NUM_ARRAYS - 13, nk);
-  int dim_sizes_adj = P3MainData::NUM_ARRAYS-13;
-  dim2_sizes_out[dim_sizes_adj-4] = nk+1; // precip_liq_flux
-  dim2_sizes_out[dim_sizes_adj-3] = nk+1; // precip_ice_flux
-  dim1_sizes_out[dim_sizes_adj-2] = 1; dim2_sizes_out[dim_sizes_adj-2] = nj; // precip_liq_surf
-  dim1_sizes_out[dim_sizes_adj-1] = 1; dim2_sizes_out[dim_sizes_adj-1] = nj; // precip_ice_surf
+  int dim_sizes_out_len = dim1_sizes_out.size();
+  dim2_sizes_out[dim_sizes_out_len-4] = nk+1; // precip_liq_flux
+  dim2_sizes_out[dim_sizes_out_len-3] = nk+1; // precip_ice_flux
+  dim1_sizes_out[dim_sizes_out_len-2] = 1; dim2_sizes_out[dim_sizes_out_len-2] = nj; // precip_liq_surf
+  dim1_sizes_out[dim_sizes_out_len-1] = 1; dim2_sizes_out[dim_sizes_out_len-1] = nj; // precip_ice_surf
 
   ekat::device_to_host({
       qc, nc, qr, nr, qi, qm, ni, bm, qv, th_atm, diag_eff_radius_qc, diag_eff_radius_qi,

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3351,10 +3351,8 @@ Int p3_main_f(
                                        do_predict_nc, do_prescribed_CCN, col_location_d};
   P3F::P3HistoryOnly history_only{liq_ice_exchange_d, vap_liq_exchange_d,
                                   vap_ice_exchange_d};
-  P3F::P3Deprecated  deprecated{nevapr_d,qr_evap_tend_d,precip_total_tend_d,mu_c_d,lamc_d};
-
   auto elapsed_microsec = P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
-                                       history_only, deprecated, nj, nk);
+                                       history_only, nj, nk);
 
   Kokkos::parallel_for(nj, KOKKOS_LAMBDA(const Int& i) {
     precip_liq_surf_temp_d(0, i / Spack::n)[i % Spack::n] = precip_liq_surf_d(i);

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3267,7 +3267,6 @@ Int p3_main_f(
     liq_ice_exchange, vap_liq_exchange, vap_ice_exchange, precip_liq_flux, precip_ice_flux, precip_liq_surf, precip_ice_surf
   };
 
-  //PMC - hardcoding the index for each variable is very brittle :-(.
   int dim_sizes_len = dim1_sizes.size(); 
   dim2_sizes[dim_sizes_len-4] = nk+1; // precip_liq_flux
   dim2_sizes[dim_sizes_len-3] = nk+1; // precip_ice_flux

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3347,14 +3347,16 @@ Int p3_main_f(
                                       exner_d, qv_prev_d, t_prev_d};
   P3F::P3DiagnosticOutputs diag_outputs{mu_c_d, lamc_d, qv2qi_depos_tend_d, precip_liq_surf_d,
                                         precip_ice_surf_d, diag_eff_radius_qc_d, diag_eff_radius_qi_d,
-                                        rho_qi_d, precip_total_tend_d, 
+                                        rho_qi_d,
+//ASD                                        precip_total_tend_d, 
 //ASD                                        nevapr_d,
-                                        qr_evap_tend_d, precip_liq_flux_d, precip_ice_flux_d};
+//ASD                                        qr_evap_tend_d, 
+                                        precip_liq_flux_d, precip_ice_flux_d};
   P3F::P3Infrastructure infrastructure{dt, it, its, ite, kts, kte,
                                        do_predict_nc, do_prescribed_CCN, col_location_d};
   P3F::P3HistoryOnly history_only{liq_ice_exchange_d, vap_liq_exchange_d,
                                   vap_ice_exchange_d};
-  P3F::P3Deprecated  deprecated{nevapr_d};
+  P3F::P3Deprecated  deprecated{nevapr_d,qr_evap_tend_d,precip_total_tend_d};
 
   auto elapsed_microsec = P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
                                        history_only, deprecated, nj, nk);

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -3347,15 +3347,17 @@ Int p3_main_f(
                                       exner_d, qv_prev_d, t_prev_d};
   P3F::P3DiagnosticOutputs diag_outputs{mu_c_d, lamc_d, qv2qi_depos_tend_d, precip_liq_surf_d,
                                         precip_ice_surf_d, diag_eff_radius_qc_d, diag_eff_radius_qi_d,
-                                        rho_qi_d, precip_total_tend_d, nevapr_d,
+                                        rho_qi_d, precip_total_tend_d, 
+//ASD                                        nevapr_d,
                                         qr_evap_tend_d, precip_liq_flux_d, precip_ice_flux_d};
   P3F::P3Infrastructure infrastructure{dt, it, its, ite, kts, kte,
                                        do_predict_nc, do_prescribed_CCN, col_location_d};
   P3F::P3HistoryOnly history_only{liq_ice_exchange_d, vap_liq_exchange_d,
                                   vap_ice_exchange_d};
+  P3F::P3Depracated  depracated{nevapr_d};
 
   auto elapsed_microsec = P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
-                                       history_only, nj, nk);
+                                       history_only, depracated, nj, nk);
 
   Kokkos::parallel_for(nj, KOKKOS_LAMBDA(const Int& i) {
     precip_liq_surf_temp_d(0, i / Spack::n)[i % Spack::n] = precip_liq_surf_d(i);

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -230,7 +230,9 @@ void p3_main_c(
   Real* nc_nuceat_tend, Real* nccn_prescribed, Real* ni_activated, Real* inv_qc_relvar, Int it, Real* precip_liq_surf,
   Real* precip_ice_surf, Int its, Int ite, Int kts, Int kte, Real* diag_eff_radius_qc,
   Real* diag_eff_radius_qi, Real* rho_qi, bool do_predict_nc, bool do_prescribed, Real* dpres, Real* exner,
-  Real* qv2qi_depos_tend, Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend, Real* precip_liq_flux,
+  Real* qv2qi_depos_tend,
+//ASD  Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend,
+  Real* precip_liq_flux,
   Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i,
 //ASD
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev, Real* elapsed_s);
@@ -834,8 +836,10 @@ void p3_main(P3MainData& d)
     d.qc, d.nc, d.qr, d.nr, d.th_atm, d.qv, d.dt, d.qi, d.qm, d.ni,
     d.bm, d.pres, d.dz, d.nc_nuceat_tend, d.nccn_prescribed, d.ni_activated, d.inv_qc_relvar, d.it, d.precip_liq_surf,
     d.precip_ice_surf, d.its, d.ite, d.kts, d.kte, d.diag_eff_radius_qc, d.diag_eff_radius_qi,
-    d.rho_qi, d.do_predict_nc, d.do_prescribed_CCN, d.dpres, d.exner, d.qv2qi_depos_tend, d.precip_total_tend, d.nevapr,
-    d.qr_evap_tend, d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i,
+    d.rho_qi, d.do_predict_nc, d.do_prescribed_CCN, d.dpres, d.exner, d.qv2qi_depos_tend,
+//ASD    d.precip_total_tend, d.nevapr,
+//ASD    d.qr_evap_tend,
+    d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i,
     d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange, d.qv_prev, d.t_prev, &d.elapsed_s);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
@@ -3236,7 +3240,9 @@ Int p3_main_f(
   Real* nc_nuceat_tend, Real* nccn_prescribed, Real* ni_activated, Real* inv_qc_relvar, Int it, Real* precip_liq_surf,
   Real* precip_ice_surf, Int its, Int ite, Int kts, Int kte, Real* diag_eff_radius_qc,
   Real* diag_eff_radius_qi, Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* exner,
-  Real* qv2qi_depos_tend, Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend, Real* precip_liq_flux,
+  Real* qv2qi_depos_tend,
+//ASD  Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend,
+  Real* precip_liq_flux,
   Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, 
 //ASD  Real* mu_c, Real* lamc,
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev)
@@ -3269,16 +3275,18 @@ Int p3_main_f(
     qc, nc, qr, nr, qi, qm, ni, bm, qv, th_atm, qv_prev, t_prev, diag_eff_radius_qc, diag_eff_radius_qi,
     rho_qi, 
 //ASD    mu_c, lamc, 
-    qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend, liq_ice_exchange,
+    qv2qi_depos_tend,
+//ASD    precip_total_tend, nevapr, qr_evap_tend,
+     liq_ice_exchange,
     vap_liq_exchange, vap_ice_exchange, precip_liq_flux, precip_ice_flux, precip_liq_surf, precip_ice_surf
   };
 
   //PMC - hardcoding the index for each variable is very brittle :-(.
   //ASD
-  dim2_sizes[33] = nk+1; // precip_liq_flux
-  dim2_sizes[34] = nk+1; // precip_ice_flux
-  dim1_sizes[35] = 1; dim2_sizes[35] = nj; // precip_liq_surf
-  dim1_sizes[36] = 1; dim2_sizes[36] = nj; // precip_ice_surf
+  dim2_sizes[30] = nk+1; // precip_liq_flux
+  dim2_sizes[31] = nk+1; // precip_ice_flux
+  dim1_sizes[32] = 1; dim2_sizes[32] = nj; // precip_liq_surf
+  dim1_sizes[33] = 1; dim2_sizes[33] = nj; // precip_ice_surf
 
   // Initialize outputs to avoid uninitialized read warnings in memory checkers
   for (size_t i = P3MainData::NUM_INPUT_ARRAYS; i < P3MainData::NUM_ARRAYS; ++i) {
@@ -3320,9 +3328,9 @@ Int p3_main_f(
 //ASD    mu_c_d                 (temp_d[counter++]),
 //ASD - change counters too    lamc_d                 (temp_d[counter++]),
     qv2qi_depos_tend_d     (temp_d[counter++]),
-    precip_total_tend_d    (temp_d[counter++]),
-    nevapr_d               (temp_d[counter++]), //30
-    qr_evap_tend_d         (temp_d[counter++]),
+//ASD    precip_total_tend_d    (temp_d[counter++]),
+//ASD    nevapr_d               (temp_d[counter++]), //30
+//ASD    qr_evap_tend_d         (temp_d[counter++]),
     liq_ice_exchange_d     (temp_d[counter++]),
     vap_liq_exchange_d     (temp_d[counter++]),
     vap_ice_exchange_d     (temp_d[counter++]),
@@ -3337,6 +3345,9 @@ Int p3_main_f(
 
   view_2d mu_c_d("mu_c_d",nj,nk);
   view_2d lamc_d("lamc_d",nj,nk);
+  view_2d precip_total_tend_d("precip_total_tend_d",nj,nk);
+  view_2d nevapr_d("nevapr_d",nj,nk);
+  view_2d qr_evap_tend_d("qr_evap_tend_d",nj,nk);
 
   Kokkos::parallel_for(nj, KOKKOS_LAMBDA(const Int& i) {
     precip_liq_surf_d(i) = precip_liq_surf_temp_d(0, i / Spack::n)[i % Spack::n];
@@ -3375,23 +3386,27 @@ Int p3_main_f(
     qc_d, nc_d, qr_d, nr_d, qi_d, qm_d, ni_d, bm_d, qv_d, th_atm_d,
     diag_eff_radius_qc_d, diag_eff_radius_qi_d, rho_qi_d,
 //ASD    mu_c_d, lamc_d, 
-    qv2qi_depos_tend_d, precip_total_tend_d,
-    nevapr_d, qr_evap_tend_d, liq_ice_exchange_d, vap_liq_exchange_d,
+    qv2qi_depos_tend_d,
+//ASD    precip_total_tend_d,
+//ASD    nevapr_d, qr_evap_tend_d,
+    liq_ice_exchange_d, vap_liq_exchange_d,
     vap_ice_exchange_d, precip_liq_flux_d, precip_ice_flux_d, precip_liq_surf_temp_d, precip_ice_surf_temp_d
   };
   std::vector<size_t> dim1_sizes_out(P3MainData::NUM_ARRAYS - 13, nj);
   std::vector<size_t> dim2_sizes_out(P3MainData::NUM_ARRAYS - 13, nk);
 //ASD
-  dim2_sizes_out[20] = nk+1; // precip_liq_flux
-  dim2_sizes_out[21] = nk+1; // precip_ice_flux
-  dim1_sizes_out[22] = 1; dim2_sizes_out[22] = nj; // precip_liq_surf
-  dim1_sizes_out[23] = 1; dim2_sizes_out[23] = nj; // precip_ice_surf
+  dim2_sizes_out[17] = nk+1; // precip_liq_flux
+  dim2_sizes_out[18] = nk+1; // precip_ice_flux
+  dim1_sizes_out[19] = 1; dim2_sizes_out[19] = nj; // precip_liq_surf
+  dim1_sizes_out[20] = 1; dim2_sizes_out[20] = nj; // precip_ice_surf
 
   ekat::device_to_host({
       qc, nc, qr, nr, qi, qm, ni, bm, qv, th_atm, diag_eff_radius_qc, diag_eff_radius_qi,
       rho_qi, 
 //ASD      mu_c, lamc, 
-      qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend, liq_ice_exchange,
+      qv2qi_depos_tend,
+//ASD      precip_total_tend, nevapr, qr_evap_tend,
+      liq_ice_exchange,
       vap_liq_exchange, vap_ice_exchange, precip_liq_flux, precip_ice_flux, precip_liq_surf, precip_ice_surf
     },
     dim1_sizes_out, dim2_sizes_out, inout_views, true);

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -754,7 +754,8 @@ struct P3MainPart3Data : public PhysicsTestData
 
 struct P3MainData : public PhysicsTestData
 {
-  static constexpr size_t NUM_ARRAYS = 39;
+  //ASD
+  static constexpr size_t NUM_ARRAYS = 37;
   static constexpr size_t NUM_INPUT_ARRAYS = 24;
 
   // Inputs
@@ -1096,7 +1097,8 @@ Int p3_main_f(
   Real* precip_ice_surf, Int its, Int ite, Int kts, Int kte, Real* diag_eff_radius_qc,
   Real* diag_eff_radius_qi, Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* exner,
   Real* qv2qi_depos_tend, Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend, Real* precip_liq_flux,
-  Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, Real* mu_c, Real* lamc,
+  Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, 
+//ASD  Real* mu_c, Real* lamc,
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev);
 
 void ice_supersat_conservation_f(Real* qidep, Real* qinuc, Real cld_frac_i, Real qv, Real qv_sat_i, Real latent_heat_sublim, Real t_atm, Real dt, Real qi2qv_sublim_tend, Real qr2qv_evap_tend);

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -754,7 +754,6 @@ struct P3MainPart3Data : public PhysicsTestData
 
 struct P3MainData : public PhysicsTestData
 {
-  //ASD
   static constexpr size_t NUM_ARRAYS = 34;
   static constexpr size_t NUM_INPUT_ARRAYS = 24;
 
@@ -1096,11 +1095,7 @@ Int p3_main_f(
   Real* nc_nuceat_tend, Real* nccn_prescribed, Real* ni_activated, Real* inv_qc_relvar, Int it, Real* precip_liq_surf,
   Real* precip_ice_surf, Int its, Int ite, Int kts, Int kte, Real* diag_eff_radius_qc,
   Real* diag_eff_radius_qi, Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* exner,
-  Real* qv2qi_depos_tend,
-//ASD  Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend,
-  Real* precip_liq_flux,
-  Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, 
-//ASD  Real* mu_c, Real* lamc,
+  Real* qv2qi_depos_tend, Real* precip_liq_flux, Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, 
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev);
 
 void ice_supersat_conservation_f(Real* qidep, Real* qinuc, Real cld_frac_i, Real qv, Real qv_sat_i, Real latent_heat_sublim, Real t_atm, Real dt, Real qi2qv_sublim_tend, Real qr2qv_evap_tend);

--- a/components/scream/src/physics/p3/p3_functions_f90.hpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.hpp
@@ -755,7 +755,7 @@ struct P3MainPart3Data : public PhysicsTestData
 struct P3MainData : public PhysicsTestData
 {
   //ASD
-  static constexpr size_t NUM_ARRAYS = 37;
+  static constexpr size_t NUM_ARRAYS = 34;
   static constexpr size_t NUM_INPUT_ARRAYS = 24;
 
   // Inputs
@@ -1096,7 +1096,9 @@ Int p3_main_f(
   Real* nc_nuceat_tend, Real* nccn_prescribed, Real* ni_activated, Real* inv_qc_relvar, Int it, Real* precip_liq_surf,
   Real* precip_ice_surf, Int its, Int ite, Int kts, Int kte, Real* diag_eff_radius_qc,
   Real* diag_eff_radius_qi, Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* exner,
-  Real* qv2qi_depos_tend, Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend, Real* precip_liq_flux,
+  Real* qv2qi_depos_tend,
+//ASD  Real* precip_total_tend, Real* nevapr, Real* qr_evap_tend,
+  Real* precip_liq_flux,
   Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i, 
 //ASD  Real* mu_c, Real* lamc,
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev);

--- a/components/scream/src/physics/p3/p3_iso_c.f90
+++ b/components/scream/src/physics/p3/p3_iso_c.f90
@@ -107,7 +107,6 @@ contains
   subroutine p3_main_c(qc,nc,qr,nr,th_atm,qv,dt,qi,qm,ni,bm,   &
        pres,dz,nc_nuceat_tend,nccn_prescribed,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_eff_radius_qc,     &
        diag_eff_radius_qi,rho_qi,do_predict_nc,do_prescribed_CCN,dpres,exner,qv2qi_depos_tend, &
-!ASD       precip_total_tend,nevapr, qr_evap_tend,
        precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,liq_ice_exchange, &
        vap_liq_exchange, vap_ice_exchange, qv_prev, t_prev, elapsed_s) bind(C)
     use micro_p3, only : p3_main
@@ -127,13 +126,9 @@ contains
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: dpres
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: exner
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: qv2qi_depos_tend
-!ASD    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: precip_total_tend
-!ASD    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: nevapr
-!ASD    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: qr_evap_tend
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte+1)    :: precip_liq_flux
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte+1)    :: precip_ice_flux
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: cld_frac_i, cld_frac_l, cld_frac_r
-!ASD    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: mu_c_old, lamc_old
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: liq_ice_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_liq_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_ice_exchange

--- a/components/scream/src/physics/p3/p3_iso_c.f90
+++ b/components/scream/src/physics/p3/p3_iso_c.f90
@@ -106,8 +106,9 @@ contains
 
   subroutine p3_main_c(qc,nc,qr,nr,th_atm,qv,dt,qi,qm,ni,bm,   &
        pres,dz,nc_nuceat_tend,nccn_prescribed,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_eff_radius_qc,     &
-       diag_eff_radius_qi,rho_qi,do_predict_nc,do_prescribed_CCN,dpres,exner,qv2qi_depos_tend,precip_total_tend,nevapr, &
-       qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,liq_ice_exchange, &
+       diag_eff_radius_qi,rho_qi,do_predict_nc,do_prescribed_CCN,dpres,exner,qv2qi_depos_tend, &
+!ASD       precip_total_tend,nevapr, qr_evap_tend,
+       precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,liq_ice_exchange, &
        vap_liq_exchange, vap_ice_exchange, qv_prev, t_prev, elapsed_s) bind(C)
     use micro_p3, only : p3_main
 
@@ -126,9 +127,9 @@ contains
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: dpres
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: exner
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: qv2qi_depos_tend
-    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: precip_total_tend
-    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: nevapr
-    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: qr_evap_tend
+!ASD    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: precip_total_tend
+!ASD    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: nevapr
+!ASD    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: qr_evap_tend
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte+1)    :: precip_liq_flux
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte+1)    :: precip_ice_flux
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: cld_frac_i, cld_frac_l, cld_frac_r
@@ -144,6 +145,9 @@ contains
     real(kind=c_real), dimension(its:ite,kts:kte,49)   :: p3_tend_out
     real(kind=c_real), dimension(its:ite,3) :: col_location
     real(kind=c_real), dimension(its:ite,kts:kte)      :: mu_c, lamc
+    real(kind=c_real), dimension(its:ite,kts:kte)      :: precip_total_tend
+    real(kind=c_real), dimension(its:ite,kts:kte)      :: nevapr
+    real(kind=c_real), dimension(its:ite,kts:kte)      :: qr_evap_tend
     integer :: i
     do i = its,ite
       col_location(i,:) = real(i)

--- a/components/scream/src/physics/p3/p3_iso_c.f90
+++ b/components/scream/src/physics/p3/p3_iso_c.f90
@@ -107,7 +107,7 @@ contains
   subroutine p3_main_c(qc,nc,qr,nr,th_atm,qv,dt,qi,qm,ni,bm,   &
        pres,dz,nc_nuceat_tend,nccn_prescribed,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_eff_radius_qc,     &
        diag_eff_radius_qi,rho_qi,do_predict_nc,do_prescribed_CCN,dpres,exner,qv2qi_depos_tend,precip_total_tend,nevapr, &
-       qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,mu_c,lamc,liq_ice_exchange, &
+       qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,liq_ice_exchange, &
        vap_liq_exchange, vap_ice_exchange, qv_prev, t_prev, elapsed_s) bind(C)
     use micro_p3, only : p3_main
 
@@ -132,7 +132,7 @@ contains
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte+1)    :: precip_liq_flux
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte+1)    :: precip_ice_flux
     real(kind=c_real), intent(in),    dimension(its:ite,kts:kte)      :: cld_frac_i, cld_frac_l, cld_frac_r
-    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: mu_c, lamc
+!ASD    real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: mu_c_old, lamc_old
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: liq_ice_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_liq_exchange
     real(kind=c_real), intent(out),   dimension(its:ite,kts:kte)      :: vap_ice_exchange
@@ -143,6 +143,7 @@ contains
 
     real(kind=c_real), dimension(its:ite,kts:kte,49)   :: p3_tend_out
     real(kind=c_real), dimension(its:ite,3) :: col_location
+    real(kind=c_real), dimension(its:ite,kts:kte)      :: mu_c, lamc
     integer :: i
     do i = its,ite
       col_location(i,:) = real(i)

--- a/components/scream/src/physics/p3/p3_iso_f.f90
+++ b/components/scream/src/physics/p3/p3_iso_f.f90
@@ -607,21 +607,17 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
       pres,dz,nc_nuceat_tend,nccn_prescribed,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_equiv_reflectivity,diag_eff_radius_qc,     &
       diag_eff_radius_qi,diag_vm_qi,diag_diam_qi,rho_qi,do_predict_nc,do_prescribed_CCN, &
       dpres,exner,qv2qi_depos_tend, &
-!ASD      precip_total_tend,nevapr,qr_evap_tend,
       precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,  &
       pratot,prctot,liq_ice_exchange,vap_liq_exchange, vap_ice_exchange) bind(C)
 
    use iso_c_binding
 
    ! args
-!ASD
    integer(kind=c_int), value, intent(in)  :: its, ite, kts, kte, it
    real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, qi, qm, ni, bm, qv, th_atm
    real(kind=c_real), intent(in),  dimension(its:ite,kts:kte) :: pres, dz, nc_nuceat_tend, nccn_prescribed, ni_activated, dpres, exner, cld_frac_i, cld_frac_l, cld_frac_r, inv_qc_relvar
    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_equiv_reflectivity, diag_eff_radius_qc, diag_eff_radius_qi, diag_vm_qi, diag_diam_qi, rho_qi, &
-        qv2qi_depos_tend, &
-!ASD        precip_total_tend, nevapr, qr_evap_tend,
-        pratot, prctot, liq_ice_exchange, vap_liq_exchange, vap_ice_exchange
+        qv2qi_depos_tend, pratot, prctot, liq_ice_exchange, vap_liq_exchange, vap_ice_exchange
    real(kind=c_real), intent(out), dimension(its:ite,kts:kte+1) :: precip_liq_flux, precip_ice_flux
    real(kind=c_real), intent(out), dimension(its:ite) :: precip_liq_surf, precip_ice_surf
    logical(kind=c_bool), value, intent(in) :: do_predict_nc, do_prescribed_CCN

--- a/components/scream/src/physics/p3/p3_iso_f.f90
+++ b/components/scream/src/physics/p3/p3_iso_f.f90
@@ -606,7 +606,9 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
  subroutine p3_main_f(qc,nc,qr,nr,th_atm,qv,dt,qi,qm,ni,bm,   &
       pres,dz,nc_nuceat_tend,nccn_prescribed,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_equiv_reflectivity,diag_eff_radius_qc,     &
       diag_eff_radius_qi,diag_vm_qi,diag_diam_qi,rho_qi,do_predict_nc,do_prescribed_CCN, &
-      dpres,exner,qv2qi_depos_tend,precip_total_tend,nevapr,qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,  &
+      dpres,exner,qv2qi_depos_tend, &
+!ASD      precip_total_tend,nevapr,qr_evap_tend,
+      precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,  &
       pratot,prctot,liq_ice_exchange,vap_liq_exchange, vap_ice_exchange) bind(C)
 
    use iso_c_binding
@@ -617,7 +619,9 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
    real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, qi, qm, ni, bm, qv, th_atm
    real(kind=c_real), intent(in),  dimension(its:ite,kts:kte) :: pres, dz, nc_nuceat_tend, nccn_prescribed, ni_activated, dpres, exner, cld_frac_i, cld_frac_l, cld_frac_r, inv_qc_relvar
    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_equiv_reflectivity, diag_eff_radius_qc, diag_eff_radius_qi, diag_vm_qi, diag_diam_qi, rho_qi, &
-        qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend, pratot, prctot, liq_ice_exchange, vap_liq_exchange, vap_ice_exchange
+        qv2qi_depos_tend, &
+!ASD        precip_total_tend, nevapr, qr_evap_tend,
+        pratot, prctot, liq_ice_exchange, vap_liq_exchange, vap_ice_exchange
    real(kind=c_real), intent(out), dimension(its:ite,kts:kte+1) :: precip_liq_flux, precip_ice_flux
    real(kind=c_real), intent(out), dimension(its:ite) :: precip_liq_surf, precip_ice_surf
    logical(kind=c_bool), value, intent(in) :: do_predict_nc, do_prescribed_CCN

--- a/components/scream/src/physics/p3/p3_iso_f.f90
+++ b/components/scream/src/physics/p3/p3_iso_f.f90
@@ -607,17 +607,17 @@ subroutine  update_prognostic_ice_f(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
       pres,dz,nc_nuceat_tend,nccn_prescribed,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_equiv_reflectivity,diag_eff_radius_qc,     &
       diag_eff_radius_qi,diag_vm_qi,diag_diam_qi,rho_qi,do_predict_nc,do_prescribed_CCN, &
       dpres,exner,qv2qi_depos_tend,precip_total_tend,nevapr,qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,  &
-      pratot,prctot,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, vap_ice_exchange) bind(C)
+      pratot,prctot,liq_ice_exchange,vap_liq_exchange, vap_ice_exchange) bind(C)
 
    use iso_c_binding
 
    ! args
-
+!ASD
    integer(kind=c_int), value, intent(in)  :: its, ite, kts, kte, it
    real(kind=c_real), intent(inout), dimension(its:ite,kts:kte) :: qc, nc, qr, nr, qi, qm, ni, bm, qv, th_atm
    real(kind=c_real), intent(in),  dimension(its:ite,kts:kte) :: pres, dz, nc_nuceat_tend, nccn_prescribed, ni_activated, dpres, exner, cld_frac_i, cld_frac_l, cld_frac_r, inv_qc_relvar
-   real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_equiv_reflectivity, diag_eff_radius_qc, diag_eff_radius_qi, diag_vm_qi, diag_diam_qi, rho_qi, mu_c, &
-        lamc, qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend, pratot, prctot, liq_ice_exchange, vap_liq_exchange, vap_ice_exchange
+   real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_equiv_reflectivity, diag_eff_radius_qc, diag_eff_radius_qi, diag_vm_qi, diag_diam_qi, rho_qi, &
+        qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend, pratot, prctot, liq_ice_exchange, vap_liq_exchange, vap_ice_exchange
    real(kind=c_real), intent(out), dimension(its:ite,kts:kte+1) :: precip_liq_flux, precip_ice_flux
    real(kind=c_real), intent(out), dimension(its:ite) :: precip_liq_surf, precip_ice_surf
    logical(kind=c_bool), value, intent(in) :: do_predict_nc, do_prescribed_CCN

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -914,7 +914,6 @@ Int Functions<S,D>
   const P3DiagnosticOutputs& diagnostic_outputs,
   const P3Infrastructure& infrastructure,
   const P3HistoryOnly& history_only,
-  const P3Deprecated& deprecated,
   Int nj,
   Int nk)
 {
@@ -1047,12 +1046,6 @@ Int Functions<S,D>
     const auto olatent_heat_fusion = ekat::subview(latent_heat_fusion, i);
     const auto oqv_prev            = ekat::subview(diagnostic_inputs.qv_prev, i);
     const auto ot_prev             = ekat::subview(diagnostic_inputs.t_prev, i);
-    // Deprecated fields that are still needed for F90 BFB, to be removed eventually (TODO).
-    const auto omu_c               = ekat::subview(deprecated.mu_c, i);
-    const auto olamc               = ekat::subview(deprecated.lamc, i);
-    const auto oprecip_total_tend  = ekat::subview(deprecated.precip_total_tend, i);
-    const auto onevapr             = ekat::subview(deprecated.nevapr, i);
-    const auto oqr_evap_tend       = ekat::subview(deprecated.qr_evap_tend, i);
 
     // Need to watch out for race conditions with these shared variables
     bool &nucleationPossible  = bools(i, 0);

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -1030,18 +1030,8 @@ Int Functions<S,D>
     const auto oth                 = ekat::subview(prognostic_state.th, i);
     const auto odiag_eff_radius_qc = ekat::subview(diagnostic_outputs.diag_eff_radius_qc, i);
     const auto odiag_eff_radius_qi = ekat::subview(diagnostic_outputs.diag_eff_radius_qi, i);
-    const auto orho_qi             = ekat::subview(diagnostic_outputs.rho_qi, i);
-//ASD    const auto omu_c               = ekat::subview(diagnostic_outputs.mu_c, i);
-    const auto omu_c               = ekat::subview(deprecated.mu_c, i);
-//ASD    const auto olamc               = ekat::subview(diagnostic_outputs.lamc, i);
-    const auto olamc               = ekat::subview(deprecated.lamc, i);
     const auto oqv2qi_depos_tend   = ekat::subview(diagnostic_outputs.qv2qi_depos_tend, i);
-//ASD    const auto oprecip_total_tend  = ekat::subview(diagnostic_outputs.precip_total_tend, i);
-    const auto oprecip_total_tend  = ekat::subview(deprecated.precip_total_tend, i);
-//ASD    const auto onevapr             = ekat::subview(diagnostic_outputs.nevapr, i);
-    const auto onevapr             = ekat::subview(deprecated.nevapr, i);
-//ASD    const auto oqr_evap_tend       = ekat::subview(diagnostic_outputs.qr_evap_tend, i);
-    const auto oqr_evap_tend       = ekat::subview(deprecated.qr_evap_tend, i);
+    const auto orho_qi             = ekat::subview(diagnostic_outputs.rho_qi, i);
     const auto oprecip_liq_flux    = ekat::subview(diagnostic_outputs.precip_liq_flux, i);
     const auto oprecip_ice_flux    = ekat::subview(diagnostic_outputs.precip_ice_flux, i);
     const auto oliq_ice_exchange   = ekat::subview(history_only.liq_ice_exchange, i);
@@ -1052,6 +1042,12 @@ Int Functions<S,D>
     const auto olatent_heat_fusion = ekat::subview(latent_heat_fusion, i);
     const auto oqv_prev            = ekat::subview(diagnostic_inputs.qv_prev, i);
     const auto ot_prev             = ekat::subview(diagnostic_inputs.t_prev, i);
+    // Deprecated fields that are still needed for F90 BFB, to be removed eventually (TODO).
+    const auto omu_c               = ekat::subview(deprecated.mu_c, i);
+    const auto olamc               = ekat::subview(deprecated.lamc, i);
+    const auto oprecip_total_tend  = ekat::subview(deprecated.precip_total_tend, i);
+    const auto onevapr             = ekat::subview(deprecated.nevapr, i);
+    const auto oqr_evap_tend       = ekat::subview(deprecated.qr_evap_tend, i);
 
     // Need to watch out for race conditions with these shared variables
     bool &nucleationPossible  = bools(i, 0);

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -914,6 +914,7 @@ Int Functions<S,D>
   const P3DiagnosticOutputs& diagnostic_outputs,
   const P3Infrastructure& infrastructure,
   const P3HistoryOnly& history_only,
+  const P3Depracated& depracated,
   Int nj,
   Int nk)
 {
@@ -1034,7 +1035,8 @@ Int Functions<S,D>
     const auto olamc               = ekat::subview(diagnostic_outputs.lamc, i);
     const auto oqv2qi_depos_tend   = ekat::subview(diagnostic_outputs.qv2qi_depos_tend, i);
     const auto oprecip_total_tend  = ekat::subview(diagnostic_outputs.precip_total_tend, i);
-    const auto onevapr             = ekat::subview(diagnostic_outputs.nevapr, i);
+//ASD    const auto onevapr             = ekat::subview(diagnostic_outputs.nevapr, i);
+    const auto onevapr             = ekat::subview(depracated.nevapr, i);
     const auto oqr_evap_tend       = ekat::subview(diagnostic_outputs.qr_evap_tend, i);
     const auto oprecip_liq_flux    = ekat::subview(diagnostic_outputs.precip_liq_flux, i);
     const auto oprecip_ice_flux    = ekat::subview(diagnostic_outputs.precip_ice_flux, i);

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -1031,8 +1031,10 @@ Int Functions<S,D>
     const auto odiag_eff_radius_qc = ekat::subview(diagnostic_outputs.diag_eff_radius_qc, i);
     const auto odiag_eff_radius_qi = ekat::subview(diagnostic_outputs.diag_eff_radius_qi, i);
     const auto orho_qi             = ekat::subview(diagnostic_outputs.rho_qi, i);
-    const auto omu_c               = ekat::subview(diagnostic_outputs.mu_c, i);
-    const auto olamc               = ekat::subview(diagnostic_outputs.lamc, i);
+//ASD    const auto omu_c               = ekat::subview(diagnostic_outputs.mu_c, i);
+    const auto omu_c               = ekat::subview(deprecated.mu_c, i);
+//ASD    const auto olamc               = ekat::subview(diagnostic_outputs.lamc, i);
+    const auto olamc               = ekat::subview(deprecated.lamc, i);
     const auto oqv2qi_depos_tend   = ekat::subview(diagnostic_outputs.qv2qi_depos_tend, i);
 //ASD    const auto oprecip_total_tend  = ekat::subview(diagnostic_outputs.precip_total_tend, i);
     const auto oprecip_total_tend  = ekat::subview(deprecated.precip_total_tend, i);

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -1064,7 +1064,7 @@ Int Functions<S,D>
       &nc_incld, &nr_incld, &ni_incld, &bm_incld,
       &inv_rho, &prec, &rho, &rhofacr, &rhofaci, &acn, &qv_sat_l, &qv_sat_i, &sup, &qv_supersat_i,
       &tmparr1, &qtend_ignore, &ntend_ignore,
-      &omu_c, &olamc, &orho_qi, &oqv2qi_depos_tend, &oprecip_total_tend, &onevapr, &oprecip_liq_flux, &oprecip_ice_flux
+      &mu_c, &lamc, &orho_qi, &oqv2qi_depos_tend, &oprecip_total_tend, &onevapr, &oprecip_liq_flux, &oprecip_ice_flux
     };
 
     // initialize
@@ -1099,7 +1099,7 @@ Int Functions<S,D>
       ocld_frac_l, ocld_frac_r, oqv_prev, ot_prev, T_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn,
       oqv, oth, oqc, onc, oqr, onr, oqi, oni, oqm, obm, olatent_heat_vapor,
       olatent_heat_sublim, olatent_heat_fusion, qc_incld, qr_incld, qi_incld, qm_incld, nc_incld,
-      nr_incld, ni_incld, bm_incld, omu_c, nu, olamc, cdist, cdist1, cdistr,
+      nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr,
       mu_r, lamr, logn0r, oqv2qi_depos_tend, oprecip_total_tend, onevapr, oqr_evap_tend,
       ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange,
       pratot, prctot, hydrometeorsPresent, nk);
@@ -1122,7 +1122,7 @@ Int Functions<S,D>
     cloud_sedimentation(
       qc_incld, rho, inv_rho, ocld_frac_l, acn, inv_dz, dnu, team, workspace,
       nk, ktop, kbot, kdir, infrastructure.dt, inv_dt, infrastructure.predictNc,
-      oqc, onc, nc_incld, omu_c, olamc, qtend_ignore, ntend_ignore,
+      oqc, onc, nc_incld, mu_c, lamc, qtend_ignore, ntend_ignore,
       diagnostic_outputs.precip_liq_surf(i));
 
     // Rain sedimentation:  (adaptive substepping)
@@ -1151,7 +1151,7 @@ Int Functions<S,D>
     p3_main_part3(
       team, nk_pack, dnu, ice_table_vals, oexner, ocld_frac_l, ocld_frac_r, ocld_frac_i,
       rho, inv_rho, rhofaci, oqv, oth, oqc, onc, oqr, onr, oqi, oni,
-      oqm, obm, olatent_heat_vapor, olatent_heat_sublim, omu_c, nu, olamc, mu_r, lamr,
+      oqm, obm, olatent_heat_vapor, olatent_heat_sublim, mu_c, nu, lamc, mu_r, lamr,
       ovap_liq_exchange, ze_rain, ze_ice, diag_vm_qi, odiag_eff_radius_qi, diag_diam_qi,
       orho_qi, diag_equiv_reflectivity, odiag_eff_radius_qc);
 

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -914,7 +914,7 @@ Int Functions<S,D>
   const P3DiagnosticOutputs& diagnostic_outputs,
   const P3Infrastructure& infrastructure,
   const P3HistoryOnly& history_only,
-  const P3Depracated& depracated,
+  const P3Deprecated& deprecated,
   Int nj,
   Int nk)
 {
@@ -1036,7 +1036,7 @@ Int Functions<S,D>
     const auto oqv2qi_depos_tend   = ekat::subview(diagnostic_outputs.qv2qi_depos_tend, i);
     const auto oprecip_total_tend  = ekat::subview(diagnostic_outputs.precip_total_tend, i);
 //ASD    const auto onevapr             = ekat::subview(diagnostic_outputs.nevapr, i);
-    const auto onevapr             = ekat::subview(depracated.nevapr, i);
+    const auto onevapr             = ekat::subview(deprecated.nevapr, i);
     const auto oqr_evap_tend       = ekat::subview(diagnostic_outputs.qr_evap_tend, i);
     const auto oprecip_liq_flux    = ekat::subview(diagnostic_outputs.precip_liq_flux, i);
     const auto oprecip_ice_flux    = ekat::subview(diagnostic_outputs.precip_ice_flux, i);

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -1064,7 +1064,7 @@ Int Functions<S,D>
       &nc_incld, &nr_incld, &ni_incld, &bm_incld,
       &inv_rho, &prec, &rho, &rhofacr, &rhofaci, &acn, &qv_sat_l, &qv_sat_i, &sup, &qv_supersat_i,
       &tmparr1, &qtend_ignore, &ntend_ignore,
-      &mu_c, &lamc, &orho_qi, &oqv2qi_depos_tend, &oprecip_total_tend, &onevapr, &oprecip_liq_flux, &oprecip_ice_flux
+      &mu_c, &lamc, &orho_qi, &oqv2qi_depos_tend, &precip_total_tend, &nevapr, &oprecip_liq_flux, &oprecip_ice_flux
     };
 
     // initialize
@@ -1100,7 +1100,7 @@ Int Functions<S,D>
       oqv, oth, oqc, onc, oqr, onr, oqi, oni, oqm, obm, olatent_heat_vapor,
       olatent_heat_sublim, olatent_heat_fusion, qc_incld, qr_incld, qi_incld, qm_incld, nc_incld,
       nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr,
-      mu_r, lamr, logn0r, oqv2qi_depos_tend, oprecip_total_tend, onevapr, oqr_evap_tend,
+      mu_r, lamr, logn0r, oqv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend,
       ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange,
       pratot, prctot, hydrometeorsPresent, nk);
 

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -927,7 +927,7 @@ Int Functions<S,D>
   const Int nk_pack = ekat::npack<Spack>(nk);
   const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
 
-  ekat::WorkspaceManager<Spack, Device> workspace_mgr(nk_pack, 47, policy);
+  ekat::WorkspaceManager<Spack, Device> workspace_mgr(nk_pack, 52, policy);
 
   // load constants into local vars
   const     Scalar inv_dt          = 1 / infrastructure.dt;
@@ -966,7 +966,7 @@ Int Functions<S,D>
     //
     uview_1d<Spack>
       mu_r,   // shape parameter of rain
-      T_atm,      // temperature at the beginning of the microhpysics step [K]
+      T_atm,      // temperature at the beginning of the microphysics step [K]
 
       // 2D size distribution and fallspeed parameters
       lamr, logn0r, nu, cdist, cdist1, cdistr,
@@ -982,9 +982,12 @@ Int Functions<S,D>
       tmparr1, inv_exner, diag_equiv_reflectivity, diag_vm_qi, diag_diam_qi, pratot, prctot,
 
       // p3_tend_out, may not need these
-      qtend_ignore, ntend_ignore;
+      qtend_ignore, ntend_ignore,
 
-    workspace.template take_many_and_reset<41>(
+      // Variables still used in F90 but removed from C++ interface
+      mu_c, lamc, precip_total_tend, nevapr, qr_evap_tend;
+
+    workspace.template take_many_and_reset<46>(
       {
         "mu_r", "T_atm", "lamr", "logn0r", "nu", "cdist", "cdist1", "cdistr",
         "inv_cld_frac_i", "inv_cld_frac_l", "inv_cld_frac_r", "qc_incld", "qr_incld", "qi_incld", "qm_incld",
@@ -992,7 +995,8 @@ Int Functions<S,D>
         "inv_dz", "inv_rho", "ze_ice", "ze_rain", "prec", "rho",
         "rhofacr", "rhofaci", "acn", "qv_sat_l", "qv_sat_i", "sup", "qv_supersat_i",
         "tmparr1", "inv_exner", "diag_equiv_reflectivity", "diag_vm_qi", "diag_diam_qi",
-        "pratot", "prctot", "qtend_ignore", "ntend_ignore"
+        "pratot", "prctot", "qtend_ignore", "ntend_ignore",
+        "mu_c", "lamc", "precip_total_tend", "nevapr", "qr_evap_tend"
       },
       {
         &mu_r, &T_atm, &lamr, &logn0r, &nu, &cdist, &cdist1, &cdistr,
@@ -1001,9 +1005,10 @@ Int Functions<S,D>
         &inv_dz, &inv_rho, &ze_ice, &ze_rain, &prec, &rho,
         &rhofacr, &rhofaci, &acn, &qv_sat_l, &qv_sat_i, &sup, &qv_supersat_i,
         &tmparr1, &inv_exner, &diag_equiv_reflectivity, &diag_vm_qi, &diag_diam_qi,
-        &pratot, &prctot, &qtend_ignore, &ntend_ignore
+        &pratot, &prctot, &qtend_ignore, &ntend_ignore, 
+        &mu_c, &lamc, &precip_total_tend, &nevapr, &qr_evap_tend
       });
-
+      
     // Get single-column subviews of all inputs, shouldn't need any i-indexing
     // after this.
     const auto opres               = ekat::subview(diagnostic_inputs.pres, i);

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -1034,10 +1034,12 @@ Int Functions<S,D>
     const auto omu_c               = ekat::subview(diagnostic_outputs.mu_c, i);
     const auto olamc               = ekat::subview(diagnostic_outputs.lamc, i);
     const auto oqv2qi_depos_tend   = ekat::subview(diagnostic_outputs.qv2qi_depos_tend, i);
-    const auto oprecip_total_tend  = ekat::subview(diagnostic_outputs.precip_total_tend, i);
+//ASD    const auto oprecip_total_tend  = ekat::subview(diagnostic_outputs.precip_total_tend, i);
+    const auto oprecip_total_tend  = ekat::subview(deprecated.precip_total_tend, i);
 //ASD    const auto onevapr             = ekat::subview(diagnostic_outputs.nevapr, i);
     const auto onevapr             = ekat::subview(deprecated.nevapr, i);
-    const auto oqr_evap_tend       = ekat::subview(diagnostic_outputs.qr_evap_tend, i);
+//ASD    const auto oqr_evap_tend       = ekat::subview(diagnostic_outputs.qr_evap_tend, i);
+    const auto oqr_evap_tend       = ekat::subview(deprecated.qr_evap_tend, i);
     const auto oprecip_liq_flux    = ekat::subview(diagnostic_outputs.precip_liq_flux, i);
     const auto oprecip_ice_flux    = ekat::subview(diagnostic_outputs.precip_ice_flux, i);
     const auto oliq_ice_exchange   = ekat::subview(history_only.liq_ice_exchange, i);

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -51,7 +51,8 @@ CreateUnitTest(p3_test_setup p3_test_setup.cpp "${NEED_LIBS}"
 if (NOT ${SCREAM_BASELINES_ONLY})
   CreateUnitTest(p3_tests "${P3_TESTS_SRCS}" "${NEED_LIBS}"
                  THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC}
-                 PROPERTIES FIXTURES_REQUIRED p3_tables)
+                 PROPERTIES FIXTURES_REQUIRED p3_tables
+                 LABELS "p3;physics")
 endif()
 
 # Set inf tolerance for release builds. This will effectively disable all baseline
@@ -64,13 +65,15 @@ CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
                EXE_ARGS "${TOL_FLAG} ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
                PROPERTIES FIXTURES_REQUIRED p3_tables
-               EXCLUDE_MAIN_CPP)
+               EXCLUDE_MAIN_CPP
+               LABELS "p3;physics")
 
 CreateUnitTest(p3_run_and_cmp_f90 "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
                EXE_ARGS "${TOL_FLAG} -f ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
                PROPERTIES FIXTURES_REQUIRED p3_tables
-               EXCLUDE_MAIN_CPP)
+               EXCLUDE_MAIN_CPP
+               LABELS "p3;physics")
 
 # By default, baselines should be created using all fortran (make baseline). If the user wants
 # to use CXX to generate their baselines, they should use "make baseline_cxx".

--- a/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -388,8 +388,10 @@ static void run_bfb_p3_main()
       d.qc, d.nc, d.qr, d.nr, d.th_atm, d.qv, d.dt, d.qi, d.qm, d.ni,
       d.bm, d.pres, d.dz, d.nc_nuceat_tend, d.nccn_prescribed, d.ni_activated, d.inv_qc_relvar, d.it, d.precip_liq_surf,
       d.precip_ice_surf, d.its, d.ite, d.kts, d.kte, d.diag_eff_radius_qc, d.diag_eff_radius_qi,
-      d.rho_qi, d.do_predict_nc, d.do_prescribed_CCN, d.dpres, d.exner, d.qv2qi_depos_tend, d.precip_total_tend,
-      d.nevapr, d.qr_evap_tend, d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i, 
+      d.rho_qi, d.do_predict_nc, d.do_prescribed_CCN, d.dpres, d.exner, d.qv2qi_depos_tend,
+//ASD      d.precip_total_tend,
+//ASD      d.nevapr, d.qr_evap_tend,
+      d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i, 
 //ASD      d.mu_c,
 //ASD      d.lamc, 
       d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange, d.qv_prev, d.t_prev);

--- a/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -389,8 +389,10 @@ static void run_bfb_p3_main()
       d.bm, d.pres, d.dz, d.nc_nuceat_tend, d.nccn_prescribed, d.ni_activated, d.inv_qc_relvar, d.it, d.precip_liq_surf,
       d.precip_ice_surf, d.its, d.ite, d.kts, d.kte, d.diag_eff_radius_qc, d.diag_eff_radius_qi,
       d.rho_qi, d.do_predict_nc, d.do_prescribed_CCN, d.dpres, d.exner, d.qv2qi_depos_tend, d.precip_total_tend,
-      d.nevapr, d.qr_evap_tend, d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i, d.mu_c,
-      d.lamc, d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange, d.qv_prev, d.t_prev);
+      d.nevapr, d.qr_evap_tend, d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i, 
+//ASD      d.mu_c,
+//ASD      d.lamc, 
+      d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange, d.qv_prev, d.t_prev);
     d.transpose<ekat::TransposeDirection::f2c>();
   }
 

--- a/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -389,11 +389,7 @@ static void run_bfb_p3_main()
       d.bm, d.pres, d.dz, d.nc_nuceat_tend, d.nccn_prescribed, d.ni_activated, d.inv_qc_relvar, d.it, d.precip_liq_surf,
       d.precip_ice_surf, d.its, d.ite, d.kts, d.kte, d.diag_eff_radius_qc, d.diag_eff_radius_qi,
       d.rho_qi, d.do_predict_nc, d.do_prescribed_CCN, d.dpres, d.exner, d.qv2qi_depos_tend,
-//ASD      d.precip_total_tend,
-//ASD      d.nevapr, d.qr_evap_tend,
       d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i, 
-//ASD      d.mu_c,
-//ASD      d.lamc, 
       d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange, d.qv_prev, d.t_prev);
     d.transpose<ekat::TransposeDirection::f2c>();
   }

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -14,7 +14,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
   //ASD
-  REQUIRE(fdi.nfield() == 37);
+  REQUIRE(fdi.nfield() == 34);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,6 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  //ASD
   REQUIRE(fdi.nfield() == 34);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);

--- a/components/scream/src/physics/p3/tests/p3_tests.cpp
+++ b/components/scream/src/physics/p3/tests/p3_tests.cpp
@@ -13,7 +13,8 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 39);
+  //ASD
+  REQUIRE(fdi.nfield() == 37);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);

--- a/components/scream/tests/scream_p3/p3_standalone_output.yaml
+++ b/components/scream/tests/scream_p3/p3_standalone_output.yaml
@@ -13,22 +13,22 @@ FIELDS:
   field 2: T_prev_micro_step
   field 3: qv_prev_micro_step
   field 4: eff_radius_qc
-  field 5: micro_liq_ice_exchange
-  field 6: eff_radius_qi
+  field 5: eff_radius_qi
+  field 6: micro_liq_ice_exchange
   field 7: micro_vap_liq_exchange
   field 8: micro_vap_ice_exchange
-#  field 14: bm
-#  field 15: nc
-#  field 16: ni
-#  field 17: nr
-#  field 18: qc
-#  field 19: qi
-#  field 20: qm
-#  field 21: qr
-#  field 22: qv
-#  field 7: nevapr - depracated
-#  field 7: qr_evap_tend
-#  field 11: precip_total_tend
-#  field 4: lambda_qc
-#  field 6: mu_qc
+#  field 9: bm
+#  field 10: nc
+#  field 11: ni
+#  field 12: nr
+#  field 13: qc
+#  field 14: qi
+#  field 15: qm
+#  field 16: qr
+#  field 17: qv
+#  field 7: nevapr - deprecated
+#  field 7: qr_evap_tend - deprecated
+#  field 11: precip_total_tend - deprecated
+#  field 4: lambda_qc - deprecated
+#  field 6: mu_qc - deprecated
 ...

--- a/components/scream/tests/scream_p3/p3_standalone_output.yaml
+++ b/components/scream/tests/scream_p3/p3_standalone_output.yaml
@@ -8,20 +8,19 @@ FREQUENCY:
   OUT_OPTION: Steps
   OUT_MAX_STEPS: 1
 FIELDS:
-  Number of Fields: 13
+  Number of Fields: 12
   field 1: T_mid
   field 2: T_prev_micro_step
   field 3: qv_prev_micro_step
   field 4: lambda_qc
   field 5: micro_liq_ice_exchange
   field 6: mu_qc
-  field 7: nevapr
-  field 8: qr_evap_tend
-  field 9: micro_vap_liq_exchange
-  field 10: micro_vap_ice_exchange
-  field 11: eff_radius_qc
-  field 12: eff_radius_qi
-  field 13: precip_total_tend
+  field 7: qr_evap_tend
+  field 8: micro_vap_liq_exchange
+  field 9: micro_vap_ice_exchange
+  field 10: eff_radius_qc
+  field 11: eff_radius_qi
+  field 12: precip_total_tend
 #  field 14: bm
 #  field 15: nc
 #  field 16: ni
@@ -31,4 +30,5 @@ FIELDS:
 #  field 20: qm
 #  field 21: qr
 #  field 22: qv
+#  field 7: nevapr - depracated
 ...

--- a/components/scream/tests/scream_p3/p3_standalone_output.yaml
+++ b/components/scream/tests/scream_p3/p3_standalone_output.yaml
@@ -8,19 +8,17 @@ FREQUENCY:
   OUT_OPTION: Steps
   OUT_MAX_STEPS: 1
 FIELDS:
-  Number of Fields: 12
+  Number of Fields: 10
   field 1: T_mid
   field 2: T_prev_micro_step
   field 3: qv_prev_micro_step
   field 4: lambda_qc
   field 5: micro_liq_ice_exchange
   field 6: mu_qc
-  field 7: qr_evap_tend
-  field 8: micro_vap_liq_exchange
-  field 9: micro_vap_ice_exchange
-  field 10: eff_radius_qc
-  field 11: eff_radius_qi
-  field 12: precip_total_tend
+  field 7: micro_vap_liq_exchange
+  field 8: micro_vap_ice_exchange
+  field 9: eff_radius_qc
+  field 10: eff_radius_qi
 #  field 14: bm
 #  field 15: nc
 #  field 16: ni
@@ -31,4 +29,6 @@ FIELDS:
 #  field 21: qr
 #  field 22: qv
 #  field 7: nevapr - depracated
+#  field 7: qr_evap_tend
+#  field 11: precip_total_tend
 ...

--- a/components/scream/tests/scream_p3/p3_standalone_output.yaml
+++ b/components/scream/tests/scream_p3/p3_standalone_output.yaml
@@ -8,17 +8,15 @@ FREQUENCY:
   OUT_OPTION: Steps
   OUT_MAX_STEPS: 1
 FIELDS:
-  Number of Fields: 10
+  Number of Fields: 8
   field 1: T_mid
   field 2: T_prev_micro_step
   field 3: qv_prev_micro_step
-  field 4: lambda_qc
+  field 4: eff_radius_qc
   field 5: micro_liq_ice_exchange
-  field 6: mu_qc
+  field 6: eff_radius_qi
   field 7: micro_vap_liq_exchange
   field 8: micro_vap_ice_exchange
-  field 9: eff_radius_qc
-  field 10: eff_radius_qi
 #  field 14: bm
 #  field 15: nc
 #  field 16: ni
@@ -31,4 +29,6 @@ FIELDS:
 #  field 7: nevapr - depracated
 #  field 7: qr_evap_tend
 #  field 11: precip_total_tend
+#  field 4: lambda_qc
+#  field 6: mu_qc
 ...


### PR DESCRIPTION
This PR updates the pre- and post- ambles in P3 microphysics so that variables expected by other atmosphere processes are in the appropriate format. 

These changes also reflect decisions made about which variables will be carried in the field manager, and which variables will be computed on the fly in the pre-amble of a process.

Finally this PR will remove unused variables from P3, addressing issue #959 and #966.  Note, we have decided to keep these variables in the F90 code, as a result, this PR introduces a structure to the P3 interface that will hold "deprecated" variables that are no longer used in the cpp implementation but must be kept as long as our testing call F90 code, or until these variables are removed from the F90 code.