### PR TITLE
CTEST_PARALLEL_LEVEL was not being exported

### DIFF
--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -129,7 +129,7 @@ def get_mach_env_setup_command(machine, ctest_j=None):
 
     mach_custom_env = MACHINE_METADATA[machine][0]
     ctest_j = get_mach_testing_resources(machine) if ctest_j is None else ctest_j
-    mach_custom_env.append("CTEST_PARALLEL_LEVEL={}".format(ctest_j))
+    mach_custom_env.append("export CTEST_PARALLEL_LEVEL={}".format(ctest_j))
     if not is_cuda_machine(machine):
         mach_custom_env.append("export OMP_PROC_BIND=spread")
 


### PR DESCRIPTION
Caused scream-env-cmd, and related bash functions, to not
work as intended.