### PR TITLE
Update shoc timing structure

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -192,9 +192,9 @@ subroutine shoc_main ( &
      w_sec, thl_sec, qw_sec, qwthl_sec,&  ! Output (diagnostic)
      wthl_sec, wqw_sec, wtke_sec,&        ! Output (diagnostic)
      uw_sec, vw_sec, w3,&                 ! Output (diagnostic)
-     wqls_sec, brunt, shoc_ql2,&          ! Output (diagnostic)
+     wqls_sec, brunt, shoc_ql2 &          ! Output (diagnostic)
 #ifdef SCREAM_CONFIG_IS_CMAKE
-     elapsed_s &
+     , elapsed_s &
 #endif
      )
 

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -192,7 +192,11 @@ subroutine shoc_main ( &
      w_sec, thl_sec, qw_sec, qwthl_sec,&  ! Output (diagnostic)
      wthl_sec, wqw_sec, wtke_sec,&        ! Output (diagnostic)
      uw_sec, vw_sec, w3,&                 ! Output (diagnostic)
-     wqls_sec, brunt, shoc_ql2)           ! Output (diagnostic)
+     wqls_sec, brunt, shoc_ql2,&          ! Output (diagnostic)
+#ifdef SCREAM_CONFIG_IS_CMAKE
+     elapsed_s &
+#endif
+     )
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
     use shoc_iso_f, only: shoc_main_f
@@ -314,6 +318,11 @@ subroutine shoc_main ( &
   ! return to isotropic timescale [s]
   real(rtype), intent(out) :: isotropy(shcol,nlev)
 
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  real(rtype), optional, intent(out) :: elapsed_s ! duration of main loop in seconds
+#endif
+
+
   !============================================================================
 ! LOCAL VARIABLES
 
@@ -344,6 +353,10 @@ subroutine shoc_main ( &
               wv_a(shcol),wl_a(shcol)
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
+  integer :: clock_count1, clock_count_rate, clock_count_max, clock_count2, clock_count_diff
+#endif
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
   if (use_cxx) then
     call shoc_main_f(shcol, nlev, nlevi, dtime, nadv, npbl,& ! Input
                      host_dx, host_dy,thv, &                 ! Input
@@ -363,6 +376,10 @@ subroutine shoc_main ( &
                      wqls_sec, brunt, shoc_ql2)              ! Output (diagnostic)
      return
   endif
+#endif
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+    call system_clock(clock_count1, clock_count_rate, clock_count_max)
 #endif
 
   ! Compute integrals of static energy, kinetic energy, water vapor, and liquid water
@@ -523,6 +540,15 @@ subroutine shoc_main ( &
      shoc_qv,u_wind,v_wind,&              ! Input
      ustar,obklen,kbfs,shoc_cldfrac,&     ! Input
      pblh)                                ! Output
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  call system_clock(clock_count2, clock_count_rate, clock_count_max)
+  clock_count_diff = clock_count2 - clock_count1
+  if (present(elapsed_s)) then
+    elapsed_s = real(clock_count_diff) / real(clock_count_rate)
+  endif
+#endif
+
   return
 
 end subroutine shoc_main

--- a/components/scream/src/physics/shoc/shoc_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_f90.cpp
@@ -11,7 +11,7 @@ extern "C" {
   void shoc_init_c(int nlev, Real gravit, Real rair, Real rh2o, Real cpair,
                    Real zvir, Real latvap, Real latice, Real karman);
   void shoc_use_cxx_c(bool use_cxx);
-  void shoc_main_c(int shcol, int nlev, int nlevi, Real dtime, int nadv,
+  Int shoc_main_c(int shcol, int nlev, int nlevi, Real dtime, int nadv,
                    Real* host_dx, Real* host_dy, Real* thv, Real* zt_grid,
                    Real* zi_grid, Real* pres, Real* presi, Real* pdel,
                    Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc,
@@ -23,7 +23,7 @@ extern "C" {
                    Real* shoc_mix, Real* isotropy, Real* w_sec, Real* thl_sec,
                    Real* qw_sec, Real* qwthl_sec, Real* wthl_sec, Real* wqw_sec,
                    Real* wtke_sec, Real* uw_sec, Real* vw_sec, Real* w3,
-                   Real* wqls_sec, Real* brunt, Real* shoc_ql2);
+                   Real* wqls_sec, Real* brunt, Real* shoc_ql2, Real* elapsed_s);
 }
 
 namespace scream {
@@ -139,21 +139,43 @@ void shoc_init(Int nlev, bool use_fortran, bool force_reinit) {
   shoc_use_cxx_c(!use_fortran);
 }
 
-void shoc_main(FortranData& d) {
-  shoc_main_c((int)d.shcol, (int)d.nlev, (int)d.nlevi, d.dtime, (int)d.nadv,
-              d.host_dx.data(), d.host_dy.data(), d.thv.data(),
-              d.zt_grid.data(), d.zi_grid.data(), d.pres.data(), d.presi.data(),
-              d.pdel.data(), d.wthl_sfc.data(), d.wqw_sfc.data(), d.uw_sfc.data(),
-              d.vw_sfc.data(), d.wtracer_sfc.data(), (int)d.num_qtracers,
-              d.w_field.data(), d.exner.data(), d.phis.data(), d.host_dse.data(),
-              d.tke.data(), d.thetal.data(), d.qw.data(), d.u_wind.data(),
-              d.v_wind.data(), d.qtracers.data(), d.wthv_sec.data(), d.tkh.data(),
-              d.tk.data(), d.shoc_ql.data(), d.shoc_cldfrac.data(), d.pblh.data(),
-              d.shoc_mix.data(), d.isotropy.data(), d.w_sec.data(),
-              d.thl_sec.data(), d.qw_sec.data(), d.qwthl_sec.data(),
-              d.wthl_sec.data(), d.wqw_sec.data(), d.wtke_sec.data(),
-              d.uw_sec.data(), d.vw_sec.data(), d.w3.data(), d.wqls_sec.data(),
-              d.brunt.data(), d.shoc_ql2.data() );
+Int shoc_main(FortranData& d, bool use_fortran) {
+  if (use_fortran) {
+    Real elapsed_s;
+    shoc_main_c((int)d.shcol, (int)d.nlev, (int)d.nlevi, d.dtime, (int)d.nadv,
+                d.host_dx.data(), d.host_dy.data(), d.thv.data(),
+                d.zt_grid.data(), d.zi_grid.data(), d.pres.data(), d.presi.data(),
+                d.pdel.data(), d.wthl_sfc.data(), d.wqw_sfc.data(), d.uw_sfc.data(),
+                d.vw_sfc.data(), d.wtracer_sfc.data(), (int)d.num_qtracers,
+                d.w_field.data(), d.exner.data(), d.phis.data(), d.host_dse.data(),
+                d.tke.data(), d.thetal.data(), d.qw.data(), d.u_wind.data(),
+                d.v_wind.data(), d.qtracers.data(), d.wthv_sec.data(), d.tkh.data(),
+                d.tk.data(), d.shoc_ql.data(), d.shoc_cldfrac.data(), d.pblh.data(),
+                d.shoc_mix.data(), d.isotropy.data(), d.w_sec.data(),
+                d.thl_sec.data(), d.qw_sec.data(), d.qwthl_sec.data(),
+                d.wthl_sec.data(), d.wqw_sec.data(), d.wtke_sec.data(),
+                d.uw_sec.data(), d.vw_sec.data(), d.w3.data(), d.wqls_sec.data(),
+                d.brunt.data(), d.shoc_ql2.data(), &elapsed_s);
+    return static_cast<Int>(elapsed_s * 1000000);
+  } else {
+    const int npbl = d.nlev;
+    return shoc_main_f((int)d.shcol, (int)d.nlev, (int)d.nlevi, d.dtime, (int)d.nadv,
+                       npbl, d.host_dx.data(), d.host_dy.data(),
+                       d.thv.data(), d.zt_grid.data(), d.zi_grid.data(), d.pres.data(),
+                       d.presi.data(), d.pdel.data(), d.wthl_sfc.data(),
+                       d.wqw_sfc.data(), d.uw_sfc.data(), d.vw_sfc.data(),
+                       d.wtracer_sfc.data(), (int)d.num_qtracers,
+                       d.w_field.data(), d.exner.data(), d.phis.data(), d.host_dse.data(),
+                       d.tke.data(), d.thetal.data(), d.qw.data(),
+                       d.u_wind.data(), d.v_wind.data(), d.qtracers.data(), d.wthv_sec.data(),
+                       d.tkh.data(), d.tk.data(), d.shoc_ql.data(),
+                       d.shoc_cldfrac.data(), d.pblh.data(), d.shoc_mix.data(), d.isotropy.data(),
+                       d.w_sec.data(), d.thl_sec.data(),
+                       d.qw_sec.data(), d.qwthl_sec.data(), d.wthl_sec.data(), d.wqw_sec.data(),
+                       d.wtke_sec.data(), d.uw_sec.data(),
+                       d.vw_sec.data(), d.w3.data(), d.wqls_sec.data(), d.brunt.data(),
+                       d.shoc_ql2.data());
+  }
 }
 
 int test_FortranData () {
@@ -373,7 +395,7 @@ int test_shoc_ic (bool use_fortran, bool gen_plot_scripts) {
   // 3. Run 100 steps, each of size dtime = 10 (as in that method)
   d->nadv = 100;
   d->dtime = 10;
-  shoc_main(*d);
+  shoc_main(*d,use_fortran);
 
   // 4. Generate a Python script that plots the results.
   {

--- a/components/scream/src/physics/shoc/shoc_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_f90.hpp
@@ -71,7 +71,7 @@ private:
 void shoc_init(Int nlev, bool use_fortran=false, bool force_reinit=false);
 
 // Run SHOC subroutines, populating inout and out fields of d.
-void shoc_main(FortranData& d);
+ekat::Int shoc_main(FortranData& d, bool use_fortran);
 
 // We will likely want to remove these checks in the future, as we're not tied
 // to the exact implementation or arithmetic in SHOC. For now, these checks are

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -270,7 +270,15 @@ void update_prognostics_implicit_c(Int shcol, Int nlev, Int nlevi, Int num_trace
                                    Real* wqw_sfc, Real* wtracer_sfc, Real* thetal, Real* qw, Real* tracer,
                                    Real* tke, Real* u_wind, Real* v_wind);
 
-void shoc_main_c(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* host_dx, Real* host_dy, Real* thv, Real* zt_grid, Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner, Real* phis, Real* host_dse, Real* tke, Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk, Real* shoc_ql, Real* shoc_cldfrac, Real* pblh, Real* shoc_mix, Real* isotropy, Real* w_sec, Real* thl_sec, Real* qw_sec, Real* qwthl_sec, Real* wthl_sec, Real* wqw_sec, Real* wtke_sec, Real* uw_sec, Real* vw_sec, Real* w3, Real* wqls_sec, Real* brunt, Real* shoc_ql2);
+void shoc_main_c(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Real* host_dx, Real* host_dy,
+                 Real* thv, Real* zt_grid, Real* zi_grid, Real* pres, Real* presi, Real* pdel,
+                 Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc, Real* wtracer_sfc,
+                 Int num_qtracers, Real* w_field, Real* exner, Real* phis, Real* host_dse, Real* tke,
+                 Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* qtracers, Real* wthv_sec,
+                 Real* tkh, Real* tk, Real* shoc_ql, Real* shoc_cldfrac, Real* pblh, Real* shoc_mix,
+                 Real* isotropy, Real* w_sec, Real* thl_sec, Real* qw_sec, Real* qwthl_sec, Real* wthl_sec,
+                 Real* wqw_sec, Real* wtke_sec, Real* uw_sec, Real* vw_sec, Real* w3, Real* wqls_sec,
+                 Real* brunt, Real* shoc_ql2, Real* elapsed_s);
 
 void pblintd_height_c(Int shcol, Int nlev, Real* z, Real* u, Real* v, Real* ustar, Real* thv, Real* thv_ref, Real* pblh, Real* rino, bool* check);
 
@@ -749,7 +757,12 @@ void shoc_main(ShocMainData& d)
 {
   shoc_init(d.nlev, true, true);
   d.transpose<ekat::TransposeDirection::c2f>();
-  shoc_main_c(d.shcol, d.nlev, d.nlevi, d.dtime, d.nadv, d.host_dx, d.host_dy, d.thv, d.zt_grid, d.zi_grid, d.pres, d.presi, d.pdel, d.wthl_sfc, d.wqw_sfc, d.uw_sfc, d.vw_sfc, d.wtracer_sfc, d.num_qtracers, d.w_field, d.exner, d.phis, d.host_dse, d.tke, d.thetal, d.qw, d.u_wind, d.v_wind, d.qtracers, d.wthv_sec, d.tkh, d.tk, d.shoc_ql, d.shoc_cldfrac, d.pblh, d.shoc_mix, d.isotropy, d.w_sec, d.thl_sec, d.qw_sec, d.qwthl_sec, d.wthl_sec, d.wqw_sec, d.wtke_sec, d.uw_sec, d.vw_sec, d.w3, d.wqls_sec, d.brunt, d.shoc_ql2);
+  shoc_main_c(d.shcol, d.nlev, d.nlevi, d.dtime, d.nadv, d.host_dx, d.host_dy, d.thv, d.zt_grid, d.zi_grid,
+              d.pres, d.presi, d.pdel, d.wthl_sfc, d.wqw_sfc, d.uw_sfc, d.vw_sfc, d.wtracer_sfc,
+              d.num_qtracers, d.w_field, d.exner, d.phis, d.host_dse, d.tke, d.thetal, d.qw,
+              d.u_wind, d.v_wind, d.qtracers, d.wthv_sec, d.tkh, d.tk, d.shoc_ql, d.shoc_cldfrac, d.pblh,
+              d.shoc_mix, d.isotropy, d.w_sec, d.thl_sec, d.qw_sec, d.qwthl_sec, d.wthl_sec, d.wqw_sec,
+              d.wtke_sec, d.uw_sec, d.vw_sec, d.w3, d.wqls_sec, d.brunt, d.shoc_ql2, &d.elapsed_s);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 
@@ -768,7 +781,7 @@ void shoc_main_with_init(ShocMainData& d)
               d.w_field, d.exner, d.phis, d.host_dse, d.tke, d.thetal, d.qw, d.u_wind, d.v_wind, d.qtracers,
               d.wthv_sec, d.tkh, d.tk, d.shoc_ql, d.shoc_cldfrac, d.pblh, d.shoc_mix, d.isotropy, d.w_sec,
               d.thl_sec, d.qw_sec, d.qwthl_sec, d.wthl_sec, d.wqw_sec, d.wtke_sec, d.uw_sec, d.vw_sec, d.w3,
-              d.wqls_sec, d.brunt, d.shoc_ql2);
+              d.wqls_sec, d.brunt, d.shoc_ql2, &d.elapsed_s);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -2800,13 +2800,13 @@ int shoc_init_f(Int nlev, Real *pref_mid, Int nbot_shoc, Int ntop_shoc)
   return SHF::shoc_init(nbot_shoc,ntop_shoc,pref_mid_d);
 }
 
-void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, Real* host_dx, Real* host_dy, Real* thv, Real* zt_grid,
-                 Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc,
-                 Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner, Real* phis, Real* host_dse, Real* tke,
-                 Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk,
-                 Real* shoc_ql, Real* shoc_cldfrac, Real* pblh, Real* shoc_mix, Real* isotropy, Real* w_sec, Real* thl_sec,
-                 Real* qw_sec, Real* qwthl_sec, Real* wthl_sec, Real* wqw_sec, Real* wtke_sec, Real* uw_sec, Real* vw_sec,
-                 Real* w3, Real* wqls_sec, Real* brunt, Real* shoc_ql2)
+Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, Real* host_dx, Real* host_dy, Real* thv, Real* zt_grid,
+                Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc,
+                Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner, Real* phis, Real* host_dse, Real* tke,
+                Real* thetal, Real* qw, Real* u_wind, Real* v_wind, Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk,
+                Real* shoc_ql, Real* shoc_cldfrac, Real* pblh, Real* shoc_mix, Real* isotropy, Real* w_sec, Real* thl_sec,
+                Real* qw_sec, Real* qwthl_sec, Real* wthl_sec, Real* wqw_sec, Real* wtke_sec, Real* uw_sec, Real* vw_sec,
+                Real* w3, Real* wqls_sec, Real* brunt, Real* shoc_ql2)
 {
   // tkh is a local variable in C++ impl
   (void)tkh;
@@ -2950,7 +2950,6 @@ void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl,
 
   const auto elapsed_microsec = SHF::shoc_main(shcol, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
                                                shoc_input, shoc_input_output, shoc_output, shoc_history_output);
-  (void)elapsed_microsec;
 
   // Copy wind back into separate views
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
@@ -3006,6 +3005,8 @@ void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl,
   // 3d
   std::vector<view_3d> out_views_3d = {qtracers_d};
   ekat::device_to_host({qtracers}, shcol, nlev, num_qtracers, out_views_3d, true);
+
+  return elapsed_microsec;
 }
 
 void pblintd_height_f(Int shcol, Int nlev, Real* z, Real* u, Real* v, Real* ustar, Real* thv, Real* thv_ref, Real* pblh, Real* rino, bool* check)

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -798,6 +798,8 @@ struct ShocMainData : public PhysicsTestData {
   // Outputs
   Real *pblh, *shoc_mix, *isotropy, *w_sec, *thl_sec, *qw_sec, *qwthl_sec, *wthl_sec, *wqw_sec, *wtke_sec, *uw_sec, *vw_sec, *w3, *wqls_sec, *brunt, *shoc_ql2;
 
+  Real elapsed_s;
+
   ShocMainData(Int shcol_, Int nlev_, Int nlevi_, Int num_qtracers_, Real dtime_, Int nadv_, Int nbot_shoc_, Int ntop_shoc_) :
     PhysicsTestData({{ shcol_ }, { shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_, num_qtracers_ }, { shcol_, nlev_, num_qtracers_ }, { nlev_ }},
                     {{ &host_dx, &host_dy, &wthl_sfc, &wqw_sfc, &uw_sfc, &vw_sfc, &phis, &pblh },

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -1053,14 +1053,14 @@ void isotropic_ts_f(Int nlev, Int shcol, Real* brunt_int, Real* tke,
 void dp_inverse_f(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_zt);
 
 int shoc_init_f(Int nlev, Real* pref_mid, Int nbot_shoc, Int ntop_shoc);
-void shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, Real* host_dx, Real* host_dy, Real* thv,
-                 Real* zt_grid, Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc,
-                 Real* uw_sfc, Real* vw_sfc, Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner,
-                 Real* phis, Real* host_dse, Real* tke, Real* thetal, Real* qw, Real* u_wind, Real* v_wind,
-                 Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk, Real* shoc_ql, Real* shoc_cldfrac, Real* pblh,
-                 Real* shoc_mix, Real* isotropy, Real* w_sec, Real* thl_sec, Real* qw_sec, Real* qwthl_sec,
-                 Real* wthl_sec, Real* wqw_sec, Real* wtke_sec, Real* uw_sec, Real* vw_sec, Real* w3, Real* wqls_sec,
-                 Real* brunt, Real* shoc_ql2);
+Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, Real* host_dx, Real* host_dy, Real* thv,
+                Real* zt_grid, Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc,
+                Real* uw_sfc, Real* vw_sfc, Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner,
+                Real* phis, Real* host_dse, Real* tke, Real* thetal, Real* qw, Real* u_wind, Real* v_wind,
+                Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk, Real* shoc_ql, Real* shoc_cldfrac, Real* pblh,
+                Real* shoc_mix, Real* isotropy, Real* w_sec, Real* thl_sec, Real* qw_sec, Real* qwthl_sec,
+                Real* wthl_sec, Real* wqw_sec, Real* wtke_sec, Real* uw_sec, Real* vw_sec, Real* w3, Real* wqls_sec,
+                Real* brunt, Real* shoc_ql2);
 
 void pblintd_height_f(Int shcol, Int nlev, Real* z, Real* u, Real* v, Real* ustar, Real* thv, Real* thv_ref, Real* pblh, Real* rino, bool* check);
 

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -78,7 +78,7 @@ contains
      wtracer_sfc, num_qtracers, w_field, exner,phis, host_dse, tke, thetal,  &
      qw, u_wind, v_wind, qtracers, wthv_sec, tkh, tk, shoc_ql, shoc_cldfrac, &
      pblh, shoc_mix, isotropy, w_sec, thl_sec, qw_sec, qwthl_sec, wthl_sec,  &
-     wqw_sec, wtke_sec, uw_sec, vw_sec, w3, wqls_sec, brunt, shoc_ql2) bind(C)
+     wqw_sec, wtke_sec, uw_sec, vw_sec, w3, wqls_sec, brunt, shoc_ql2, elapsed_s) bind(C)
     use shoc, only : shoc_main
 
     integer(kind=c_int), value, intent(in) :: shcol, nlev, nlevi, num_qtracers, nadv
@@ -107,12 +107,14 @@ contains
     real(kind=c_real), intent(out), dimension(shcol, nlev) :: wqls_sec, isotropy, &
          brunt,shoc_ql2
 
+    real(kind=c_real), intent(out) :: elapsed_s
+
     call shoc_main(shcol, nlev, nlevi, dtime, nadv, host_dx, host_dy, thv,   &
      zt_grid, zi_grid, pres, presi, pdel, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, &
      wtracer_sfc, num_qtracers, w_field, exner, phis, host_dse, tke, thetal, &
      qw, u_wind, v_wind, qtracers, wthv_sec, tkh, tk, shoc_ql, shoc_cldfrac, &
      pblh, shoc_mix, isotropy, w_sec, thl_sec, qw_sec, qwthl_sec, wthl_sec,  &
-     wqw_sec, wtke_sec, uw_sec, vw_sec, w3, wqls_sec, brunt,shoc_ql2 )
+     wqw_sec, wtke_sec, uw_sec, vw_sec, w3, wqls_sec, brunt,shoc_ql2,elapsed_s)
   end subroutine shoc_main_c
 
   subroutine shoc_use_cxx_c(arg_use_cxx) bind(C)

--- a/components/scream/src/physics/shoc/shoc_main_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_main_impl.hpp
@@ -384,6 +384,7 @@ Int Functions<S,D>::shoc_main(
 
     shoc_output.pblh(i)[0] = pblh_s;
   });
+  Kokkos::fence();
 
   auto finish = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finish - start);

--- a/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
@@ -114,8 +114,7 @@ struct Baseline {
     Int nerr = 0;
 
     // These times are thrown out, I just wanted to be able to use auto
-    auto start = std::chrono::steady_clock::now(), finish = start;
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
+    Int duration = 0;
 
     for (auto ps : params_) {
       for (Int r = -1; r < m_repeat; ++r) {
@@ -135,13 +134,10 @@ struct Baseline {
         }
 
         for (int it = 0; it < m_num_iters; ++it) {
-          start  = std::chrono::steady_clock::now();
-
-          shoc_main(*d);
+          Int current_microsec = shoc_main(*d, use_fortran);
 
           if (r != -1 && m_repeat > 0) { // do not count the "cold" run
-            finish = std::chrono::steady_clock::now();
-            duration += std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
+            duration += current_microsec;
           }
 
           if (m_repeat == 0) {
@@ -150,7 +146,7 @@ struct Baseline {
         }
       }
       if (m_repeat > 0) {
-        const double report_time = (1e-6*duration.count()) / m_repeat;
+        const double report_time = (1e-6*duration) / m_repeat;
 
         printf("Time = %1.3e seconds\n", report_time);
       }
@@ -178,7 +174,7 @@ struct Baseline {
           std::cout << "--- checking case # " << case_num << ", timestep # = " << (it+1)*ps.nadv
                      << " ---\n" << std::flush;
           read(fid, d_ref);
-          shoc_main(*d);
+          shoc_main(*d,use_fortran);
           ne = compare(tol, d_ref, d);
           if (ne) std::cout << "Ref impl failed.\n";
           nerr += ne;


### PR DESCRIPTION
Small changes to the shoc timings to avoid counting variable initialization. This makes shoc match the structure of p3.