### PR TITLE
Create `get_dz` function to determine dz using the equation of state

### DIFF
--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -141,6 +141,15 @@ struct Functions
   KOKKOS_FUNCTION
   static Spack get_dz(const Spack& pseudo_density, const Spack& p_mid, const Spack& T_mid, const Spack& qv, const Smask& range_mask);
 
+  KOKKOS_FUNCTION
+  template<typename InputProvider>
+  static void get_dz(const int nlev, 
+                     const InputProvider& psuedo_density,
+                     const InputProvider& p_mid,
+                     const InputProvider& T_mid,
+                     const InputProvider& qv,
+                     const view_1d<Scalar>& dz);
+
   // Compute dry static energy (DSE).
   // The result unit is in J/kg
   // The inputs are

--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -131,6 +131,15 @@ struct Functions
   //   zi_bot is the distance above the surface of the bottom of the layer.  Units in m
   KOKKOS_FUNCTION
   static Spack get_dz(const Spack& zi_top, const Spack& zi_bot, const Smask& range_mask);
+  // Determine the physical thickness of a vertical layer
+  // The result is dz, units in m
+  // The inputs are
+  //   pseudo_density is the pressure level thickness, Pa
+  //   p_mid          is the avgerage atmosphere pressure over the level, Pa
+  //   T_mid          is the atmospheric temperature, K - needed for T_virtual
+  //   qv             is the water vapor mass mixing ratio, kg/kg - needed for T_virtual
+  KOKKOS_FUNCTION
+  static Spack get_dz(const Spack& pseudo_density, const Spack& p_mid, const Spack& T_mid, const Spack& qv, const Smask& range_mask);
 
   // Compute dry static energy (DSE).
   // The result unit is in J/kg

--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -141,8 +141,8 @@ struct Functions
   KOKKOS_FUNCTION
   static Spack get_dz(const Spack& pseudo_density, const Spack& p_mid, const Spack& T_mid, const Spack& qv, const Smask& range_mask);
 
-  KOKKOS_FUNCTION
   template<typename InputProvider>
+  KOKKOS_FUNCTION
   static void get_dz(const int nlev, 
                      const InputProvider& psuedo_density,
                      const InputProvider& p_mid,

--- a/components/scream/src/physics/share/physics_universal_impl.hpp
+++ b/components/scream/src/physics/share/physics_universal_impl.hpp
@@ -118,8 +118,8 @@ Functions<S,D>::get_dz(const Spack& pseudo_density, const Spack& p_mid, const Sp
 }
 
 template <typename S, typename D>
-KOKKOS_FUNCTION
 template <typename InputProvider>
+KOKKOS_FUNCTION
 void Functions<S,D>::get_dz(const int nlev, 
                             const InputProvider& psuedo_density,
                             const InputProvider& p_mid,

--- a/components/scream/src/physics/share/physics_universal_impl.hpp
+++ b/components/scream/src/physics/share/physics_universal_impl.hpp
@@ -116,6 +116,21 @@ Functions<S,D>::get_dz(const Spack& pseudo_density, const Spack& p_mid, const Sp
   result.set(range_mask,dz);
   return result;
 }
+
+template <typename S, typename D>
+KOKKOS_FUNCTION
+template <typename InputProvider>
+void Functions<S,D>::get_dz(const int nlev, 
+                            const InputProvider& psuedo_density,
+                            const InputProvider& p_mid,
+                            const InputProvider& T_mid,
+                            const InputProvider& qv,
+                            const view_1d<S>& dz)
+{
+  Kokkos::parallel_for("get_dz",nlev,[&](const int ilev) {
+    dz[ilev] = get_dz(psuedo_density[ilev],p_mid[ilev],T_mid[ilev],qv[ilev],Smask(true))[0];
+  }); 
+}
 //-----------------------------------------------------------------------------------------------//
 // Determines the vertical layer thickness given the interface heights:
 //   dz = zi_top-zi_bot,

--- a/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
+++ b/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
@@ -294,9 +294,7 @@ struct UnitWrap::UnitTest<D>::TestUniversal
       physics::get_dz(num_levs,pseudo_density, pressure, temp, qv, dz_view);
       for (int k=0;k<num_levs;++k)
       {
-        Spack T_in(temp(k));
-        Spack qv_in(qv(k));
-        Real T_virtual_exp = physics::get_virtual_temperature(T_in,qv_in,Smask(true))[0];
+        Real T_virtual_exp = physics::get_virtual_temperature(temp(k),qv(k),Smask(true))[0];
         Real dz_exp = pseudo_density[k]*rd*T_virtual_exp/(pressure[k]*ggr);
         // Exner test
         //   - Pressure at level k is just k*dp, so each pressure level is dp in thickness.

--- a/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
+++ b/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
@@ -294,7 +294,9 @@ struct UnitWrap::UnitTest<D>::TestUniversal
       physics::get_dz(num_levs,pseudo_density, pressure, temp, qv, dz_view);
       for (int k=0;k<num_levs;++k)
       {
-        Real T_virtual_exp = (temp[k]*(qv[k]+ep_2))/(ep_2*(1.0+qv[k]));
+        Spack T_in(temp(k));
+        Spack qv_in(qv(k));
+        Real T_virtual_exp = physics::get_virtual_temperature(T_in,qv_in,Smask(true))[0];
         Real dz_exp = pseudo_density[k]*rd*T_virtual_exp/(pressure[k]*ggr);
         // Exner test
         //   - Pressure at level k is just k*dp, so each pressure level is dp in thickness.


### PR DESCRIPTION
This PR overloads the `get_dz` function in the universal physics to allow for a calculation of `dz` given the equation of state.

Addresses part of #1002 