### PR TITLE
Update the temperature conversion universal functions

### DIFF
--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -180,7 +180,7 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   history_only.vap_ice_exchange = m_p3_fields_out["micro_vap_ice_exchange"].get_reshaped_view<Pack**>();
   // -- Set values for the post-amble structure
   p3_postproc.set_variables(m_num_cols,nk_pack,prog_state.th,p3_preproc.exner,T_atm,t_prev,prog_state.qv,qv_prev,
-      diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi);
+      diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi,diag_inputs.pres);
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -84,7 +84,7 @@ public:
         // Potential temperature
         const Spack oT_atm(T_atm(icol,ipack));
         const Smask oT_atm_mask(!isnan(oT_atm) and oT_atm>0.0);
-        auto oth = physics_fun::T_to_th(oT_atm,oexner,oT_atm_mask);
+        auto oth = physics_fun::get_potential_temperature(oT_atm,opmid,oT_atm_mask);
         th_atm(icol,ipack).set(oT_atm_mask,oth);
         // Cloud fraction and dz
         const Spack oast(ast(icol,ipack));
@@ -134,7 +134,7 @@ public:
     view_2d       dz;
     // Assigning local variables
     void set_variables(const int ncol, const int npack,
-           view_2d_const pmid_, view_2d T_atm_, view_2d_const ast_, view_2d_const zi_,
+           const view_2d_const pmid_, const view_2d T_atm_, const view_2d_const ast_, const view_2d_const zi_,
            view_2d exner_, view_2d th_atm_, view_2d cld_frac_l_, view_2d cld_frac_i_, view_2d cld_frac_r_, view_2d dz_
            )
     {
@@ -167,9 +167,10 @@ public:
       for (int ipack=0;ipack<m_npack;ipack++) {
         // Update the atmospheric temperature and the previous temperature.
         const Spack oexner(exner(icol,ipack));
+        const Spack op_mid(p_mid(icol,ipack));
         const Spack oth_atm(th_atm(icol,ipack));
         const Smask oth_atm_mask(!isnan(oth_atm) and oth_atm>0.0);
-        auto oT = physics_fun::th_to_T(oth_atm,oexner,oth_atm_mask);
+        auto oT = physics_fun::get_potential_temperature_inv(oth_atm,op_mid,oth_atm_mask);
         T_atm(icol,ipack).set(oth_atm_mask,oT);
         T_prev(icol,ipack).set(oth_atm_mask,T_atm(icol,ipack));
         // Update qv_prev
@@ -188,6 +189,7 @@ public:
     view_2d       T_atm;
     view_2d       exner;
     view_2d       th_atm;
+    view_2d_const p_mid;
     view_2d       T_prev;
     view_2d       qv;
     view_2d       qv_prev;
@@ -196,12 +198,14 @@ public:
     // Assigning local values
     void set_variables(const int ncol, const int npack,
                     view_2d th_atm_, view_2d exner_, view_2d T_atm_, view_2d T_prev_,
-                    view_2d qv_, view_2d qv_prev_, view_2d diag_eff_radius_qc_, view_2d diag_eff_radius_qi_)
+                    view_2d qv_, view_2d qv_prev_, view_2d diag_eff_radius_qc_, view_2d diag_eff_radius_qi_,
+                    const view_2d_const p_mid_)
     {
       m_ncol  = ncol;
       m_npack = npack;
       // IN
       th_atm      = th_atm_;
+      p_mid       = p_mid_;
       exner       = exner_;
       qv          = qv_;
       // OUT

--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -114,8 +114,14 @@ struct Functions
   //   T_mid is the atmospheric temperature, units in K
   //   Exners function, unitless.  Exners function can be derived using `get_exner` defined above.
   KOKKOS_FUNCTION
-  static Spack T_to_th(const Spack& T_atm, const Spack& exner, const Smask& range_mask);
+  static Spack get_potential_temperature(const Spack& T_mid, const Spack& exner, const Smask& range_mask);
 
+  KOKKOS_FUNCTION
+  template <typename InputProvider>
+  static void get_potential_temperature(const int nlev,
+                                        const InputProvider& T_mid,
+                                        const InputProvider& exner,
+                                        const view_1d<Scalar>& T_potential);
   // Converts potential temperature into temperature
   // The result is the temperature, units in K
   // The inputs are

--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -153,7 +153,7 @@ struct Functions
   KOKKOS_FUNCTION
   static Spack get_dse(const Spack& T_mid, const Spack& z_mid, const Real surf_geopotential, const Smask& range_mask);
 
-  // Comput virtual temperature
+  // Compute virtual temperature
   // The result unit is in K
   // The inputs are
   //   T_mid is the atmospheric temperature.  Units in K.

--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -112,29 +112,29 @@ struct Functions
   // The result is the potential temperature, units in K
   // The inputs are
   //   T_mid is the atmospheric temperature, units in K
-  //   Exners function, unitless.  Exners function can be derived using `get_exner` defined above.
+  //   p_mid is the atmospheric pressure, units in Pa.  Used with Exners function using `get_exner` defined above.
   KOKKOS_FUNCTION
-  static Spack get_potential_temperature(const Spack& T_mid, const Spack& exner, const Smask& range_mask);
+  static Spack get_potential_temperature(const Spack& T_mid, const Spack& p_mid, const Smask& range_mask);
 
   KOKKOS_FUNCTION
   template <typename InputProvider>
   static void get_potential_temperature(const int nlev,
                                         const InputProvider& T_mid,
-                                        const InputProvider& exner,
+                                        const InputProvider& p_mid,
                                         const view_1d<Scalar>& T_potential);
   // Converts potential temperature into temperature
   // The result is the temperature, units in K
   // The inputs are
   //   Potential Temperature, units in K
-  //   Exners function, unitless.  Exners function can be derived using `get_exner` defined above.
+  //   p_mid is the atmospheric pressure, units in Pa.  Used with Exners function using `get_exner` defined above.
   KOKKOS_FUNCTION
-  static Spack get_potential_temperature_inv(const Spack& th_mid, const Spack& exner, const Smask& range_mask);
+  static Spack get_potential_temperature_inv(const Spack& th_mid, const Spack& p_mid, const Smask& range_mask);
 
   KOKKOS_FUNCTION
   template <typename InputProvider>
   static void get_potential_temperature_inv(const int nlev,
                                              const InputProvider& th_mid,
-                                             const InputProvider& exner,
+                                             const InputProvider& p_mid,
                                              const view_1d<Scalar>& T_mid);
   // Determine the physical thickness of a vertical layer
   // The result is dz, units in m

--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -160,6 +160,13 @@ struct Functions
   //   qv    is the water vapor mass mixing ratio.  Units in kg/kg
   KOKKOS_FUNCTION
   static Spack get_virtual_temperature(const Spack& T_mid, const Spack& qv, const Smask& range_mask);
+
+  KOKKOS_FUNCTION
+  template <typename InputProvider>
+  static void get_virtual_temperature(const int nlev,
+                                      const InputProvider& T_mid,
+                                      const InputProvider& qv,
+                                      const view_1d<Scalar>& T_virtual);
 };
 
 } // namespace physics

--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -116,8 +116,8 @@ struct Functions
   KOKKOS_FUNCTION
   static Spack get_potential_temperature(const Spack& T_mid, const Spack& p_mid, const Smask& range_mask);
 
-  KOKKOS_FUNCTION
   template <typename InputProvider>
+  KOKKOS_FUNCTION
   static void get_potential_temperature(const int nlev,
                                         const InputProvider& T_mid,
                                         const InputProvider& p_mid,
@@ -130,8 +130,8 @@ struct Functions
   KOKKOS_FUNCTION
   static Spack get_potential_temperature_inv(const Spack& th_mid, const Spack& p_mid, const Smask& range_mask);
 
-  KOKKOS_FUNCTION
   template <typename InputProvider>
+  KOKKOS_FUNCTION
   static void get_potential_temperature_inv(const int nlev,
                                              const InputProvider& th_mid,
                                              const InputProvider& p_mid,
@@ -161,8 +161,8 @@ struct Functions
   KOKKOS_FUNCTION
   static Spack get_virtual_temperature(const Spack& T_mid, const Spack& qv, const Smask& range_mask);
 
-  KOKKOS_FUNCTION
   template <typename InputProvider>
+  KOKKOS_FUNCTION
   static void get_virtual_temperature(const int nlev,
                                       const InputProvider& T_mid,
                                       const InputProvider& qv,

--- a/components/scream/src/physics/share/physics_functions.hpp
+++ b/components/scream/src/physics/share/physics_functions.hpp
@@ -128,8 +128,14 @@ struct Functions
   //   Potential Temperature, units in K
   //   Exners function, unitless.  Exners function can be derived using `get_exner` defined above.
   KOKKOS_FUNCTION
-  static Spack th_to_T(const Spack& th_atm, const Spack& exner, const Smask& range_mask);
+  static Spack get_potential_temperature_inv(const Spack& th_mid, const Spack& exner, const Smask& range_mask);
 
+  KOKKOS_FUNCTION
+  template <typename InputProvider>
+  static void get_potential_temperature_inv(const int nlev,
+                                             const InputProvider& th_mid,
+                                             const InputProvider& exner,
+                                             const view_1d<Scalar>& T_mid);
   // Determine the physical thickness of a vertical layer
   // The result is dz, units in m
   // The inputs are

--- a/components/scream/src/physics/share/physics_universal_impl.hpp
+++ b/components/scream/src/physics/share/physics_universal_impl.hpp
@@ -50,13 +50,15 @@ Functions<S,D>::get_exner(const Spack& P, const Smask& range_mask)
 // where
 //   th_mid is the potential temperature, K
 //   T_mid  is the temperature, K
+//   p_mid  is the pressure, Pa  -> used to calculate exners formula.
 //   exner  is the exners formula, see definition above, unitless
 template <typename S, typename D>
 KOKKOS_FUNCTION
 typename Functions<S,D>::Spack
-Functions<S,D>::get_potential_temperature(const Spack& T_mid, const Spack& exner, const Smask& range_mask)
+Functions<S,D>::get_potential_temperature(const Spack& T_mid, const Spack& p_mid, const Smask& range_mask)
 {
   Spack result;
+  const Spack exner  = get_exner(p_mid,range_mask);
   const Spack th_mid = T_mid/exner;
   // Check that there are no obvious errors in the result.
   check_temperature(th_mid,"get_potential_temperature",range_mask);
@@ -70,11 +72,11 @@ KOKKOS_FUNCTION
 template <typename InputProvider>
 void Functions<S,D>::get_potential_temperature(const int nlev,
                                                const InputProvider& T_mid,
-                                               const InputProvider& exner,
+                                               const InputProvider& p_mid,
                                                const view_1d<S>& T_potential)
 {
   Kokkos::parallel_for("get_potential_temperature",nlev,[&](const int& ilev) {
-    T_potential[ilev] = get_potential_temperature(T_mid[ilev],exner[ilev],Smask(true))[0];
+    T_potential[ilev] = get_potential_temperature(T_mid[ilev],p_mid[ilev],Smask(true))[0];
   });
 }
 
@@ -84,13 +86,15 @@ void Functions<S,D>::get_potential_temperature(const int nlev,
 // where
 //   th_mid is the potential temperature, K
 //   T_mid  is the temperature, K
+//   p_mid  is the pressure, Pa  -> used to calculate exners formula.
 //   exner  is the exners formula, see definition above, unitless
 template <typename S, typename D>
 KOKKOS_FUNCTION
 typename Functions<S,D>::Spack
-Functions<S,D>::get_potential_temperature_inv(const Spack& th_mid, const Spack& exner, const Smask& range_mask)
+Functions<S,D>::get_potential_temperature_inv(const Spack& th_mid, const Spack& p_mid, const Smask& range_mask)
 {
   Spack result;
+  const Spack exner = get_exner(p_mid,range_mask);
   const Spack T_mid = th_mid*exner;
   // Check that there are no obvious errors in the result.
   check_temperature(T_mid,"inverse get_potential_temperature",range_mask);
@@ -104,11 +108,11 @@ KOKKOS_FUNCTION
 template <typename InputProvider>
 void Functions<S,D>::get_potential_temperature_inv(const int nlev,
                                            const InputProvider& th_mid,
-                                           const InputProvider& exner,
+                                           const InputProvider& p_mid,
                                            const view_1d<Scalar>& T_mid)
 {
   Kokkos::parallel_for("get_potential_temperature_inv",nlev,[&](const int& ilev) {
-    T_mid[ilev] = get_potential_temperature_inv(th_mid[ilev],exner[ilev],Smask(true))[0];
+    T_mid[ilev] = get_potential_temperature_inv(th_mid[ilev],p_mid[ilev],Smask(true))[0];
   });
 }
 //-----------------------------------------------------------------------------------------------//

--- a/components/scream/src/physics/share/physics_universal_impl.hpp
+++ b/components/scream/src/physics/share/physics_universal_impl.hpp
@@ -68,8 +68,8 @@ Functions<S,D>::get_potential_temperature(const Spack& T_mid, const Spack& p_mid
 }
 
 template <typename S, typename D>
-KOKKOS_FUNCTION
 template <typename InputProvider>
+KOKKOS_FUNCTION
 void Functions<S,D>::get_potential_temperature(const int nlev,
                                                const InputProvider& T_mid,
                                                const InputProvider& p_mid,
@@ -104,8 +104,8 @@ Functions<S,D>::get_potential_temperature_inv(const Spack& th_mid, const Spack& 
 }
 
 template <typename S, typename D>
-KOKKOS_FUNCTION
 template <typename InputProvider>
+KOKKOS_FUNCTION
 void Functions<S,D>::get_potential_temperature_inv(const int nlev,
                                            const InputProvider& th_mid,
                                            const InputProvider& p_mid,
@@ -185,8 +185,8 @@ Functions<S,D>::get_virtual_temperature(const Spack& T_mid, const Spack& qv, con
 }
 
 template <typename S, typename D>
-KOKKOS_FUNCTION
 template <typename InputProvider>
+KOKKOS_FUNCTION
 void Functions<S,D>::get_virtual_temperature(const int nlev,
                                              const InputProvider& T_mid,
                                              const InputProvider& qv,

--- a/components/scream/src/physics/share/physics_universal_impl.hpp
+++ b/components/scream/src/physics/share/physics_universal_impl.hpp
@@ -180,6 +180,18 @@ Functions<S,D>::get_virtual_temperature(const Spack& T_mid, const Spack& qv, con
   return T_virt;
 }
 
+template <typename S, typename D>
+KOKKOS_FUNCTION
+template <typename InputProvider>
+void Functions<S,D>::get_virtual_temperature(const int nlev,
+                                             const InputProvider& T_mid,
+                                             const InputProvider& qv,
+                                             const view_1d<S>& T_virtual)
+{
+  Kokkos::parallel_for("get_potential_temperature_inv",nlev,[&](const int& ilev) {
+    T_virtual[ilev] = get_virtual_temperature_inv(T_mid[ilev],qv[ilev],Smask(true))[0];
+  });
+}
 //-----------------------------------------------------------------------------------------------//
 } // namespace physics
 } // namespace scream

--- a/components/scream/src/physics/share/physics_universal_impl.hpp
+++ b/components/scream/src/physics/share/physics_universal_impl.hpp
@@ -193,7 +193,7 @@ void Functions<S,D>::get_virtual_temperature(const int nlev,
                                              const view_1d<S>& T_virtual)
 {
   Kokkos::parallel_for("get_potential_temperature_inv",nlev,[&](const int& ilev) {
-    T_virtual[ilev] = get_virtual_temperature_inv(T_mid[ilev],qv[ilev],Smask(true))[0];
+    T_virtual[ilev] = get_virtual_temperature(T_mid[ilev],qv[ilev],Smask(true))[0];
   });
 }
 //-----------------------------------------------------------------------------------------------//

--- a/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
+++ b/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
@@ -160,7 +160,7 @@ struct UnitWrap::UnitTest<D>::TestUniversal
       static constexpr Scalar ep_2   = C::ep_2;
       // Gather the machine epsilon for the error tolerance
       static constexpr Scalar eps = C::macheps;
-      Real tol = 1000*eps;
+      Real tol = 2000*eps;
 
       // Create dummy level data for testing:
       Real pres_top = 200.;

--- a/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
+++ b/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
@@ -61,7 +61,7 @@ struct UnitWrap::UnitTest<D>::TestUniversal
     //========================================================
     // Test conversion of temperature to potential temperature, and vice versa
     //========================================================
-    // This function tests both the T_to_th and th_to_T universal conversion functions.
+    // This function tests both the get_potential_temperature and th_to_T universal conversion functions.
     //
     // Inputs:
     //   T_in:    An example temperature, K.
@@ -78,10 +78,10 @@ struct UnitWrap::UnitTest<D>::TestUniversal
     // Test conversion from temperature (T) to potential temperature (th)
     // Use T_in to convert from T to th
     // Note: T to th conversion is just a simple formula of th = T/exner
-    const Spack th_atm = physics::T_to_th(T,exner,Smask(true));
+    const Spack th_mid = physics::get_potential_temperature(T,exner,Smask(true));
     Real expected_th = T_in/exner[0];
-    if (std::abs(th_atm[0]-expected_th)>tol) {
-      printf("T to th test: abs(th_atm-expected_th)=%e is larger than the tol=%e\n",std::abs(th_atm[0]-expected_th),tol);
+    if (std::abs(th_mid[0]-expected_th)>tol) {
+      printf("get_potential_temperature test: abs(th_mid-expected_th)=%e is larger than the tol=%e\n",std::abs(th_mid[0]-expected_th),tol);
       errors++;
     }
 
@@ -91,14 +91,14 @@ struct UnitWrap::UnitTest<D>::TestUniversal
     const Spack T_atm = physics::th_to_T(T,exner,Smask(true));
     Real expected_T = T_in*exner[0];
     if (std::abs(T_atm[0]-expected_T)>tol) {
-      printf("T to th test: abs(th_atm-expected_th)=%e is larger than the tol=%e\n",std::abs(T_atm[0]-expected_T),tol);
+      printf("th to Ttest: abs(T_mid-expected_T)=%e is larger than the tol=%e\n",std::abs(T_atm[0]-expected_T),tol);
       errors++;
     }
 
-    // Test that T_to_th and th_to_T are inverses of each other.
+    // Test that get_potential_temperature and th_to_T are inverses of each other.
     // Test T to th as inverses of each other
     // Converting T to th and then back to T should return the same value again.
-    const Spack th_temp = physics::T_to_th(T,exner,Smask(true));
+    const Spack th_temp = physics::get_potential_temperature(T,exner,Smask(true));
     const Spack T_new   = physics::th_to_T(th_temp,exner,Smask(true));
     if (std::abs(T_new[0]-T_in)>tol) {
       printf("T to th test: abs[ T_new (%.3e) - T_in (%.3e) ]=%e is larger than the tol=%e\n",T_new[0],T_in,std::abs(T_new[0]-T_in),tol);
@@ -106,7 +106,7 @@ struct UnitWrap::UnitTest<D>::TestUniversal
     }
     // and vice versa
     const Spack T_temp = physics::th_to_T(T,exner,Smask(true));
-    const Spack th_new = physics::T_to_th(T_temp,exner,Smask(true));
+    const Spack th_new = physics::get_potential_temperature(T_temp,exner,Smask(true));
     if (std::abs(th_new[0]-T_in)>tol) {
       printf("T to th test: abs[ th_new (%.3e) - T_in (%.3e) ]=%e is larger than the tol=%e\n",th_new[0],T_in,std::abs(th_new[0]-T_in),tol);
       errors++;

--- a/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
+++ b/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
@@ -78,7 +78,7 @@ struct UnitWrap::UnitTest<D>::TestUniversal
     // Test conversion from temperature (T) to potential temperature (th)
     // Use T_in to convert from T to th
     // Note: T to th conversion is just a simple formula of th = T/exner
-    const Spack th_mid = physics::get_potential_temperature(T,exner,Smask(true));
+    const Spack th_mid = physics::get_potential_temperature(T,pres,Smask(true));
     Real expected_th = T_in/exner[0];
     if (std::abs(th_mid[0]-expected_th)>tol) {
       printf("get_potential_temperature test: abs(th_mid-expected_th)=%e is larger than the tol=%e\n",std::abs(th_mid[0]-expected_th),tol);
@@ -88,27 +88,27 @@ struct UnitWrap::UnitTest<D>::TestUniversal
     // Test conversion from potential temperature (th) to temperature (T)
     // Use T_in to convert from th to T, note, we use T_in again because we are just testing the formula and T_in should be sufficient for that.
     // Note: th to T conversion is just a simple formula of T = th*exner
-    const Spack T_mid = physics::get_potential_temperature_inv(T,exner,Smask(true));
+    const Spack T_mid = physics::get_potential_temperature_inv(T,pres,Smask(true));
     Real expected_T = T_in*exner[0];
     if (std::abs(T_mid[0]-expected_T)>tol) {
-      printf("th to Ttest: abs(T_mid-expected_T)=%e is larger than the tol=%e\n",std::abs(T_mid[0]-expected_T),tol);
+      printf("th to T test: abs(T_mid-expected_T)=%e is larger than the tol=%e\n",std::abs(T_mid[0]-expected_T),tol);
       errors++;
     }
 
     // Test that get_potential_temperature and get_potential_temperature_inv are inverses of each other.
     // Test T to th as inverses of each other
     // Converting T to th and then back to T should return the same value again.
-    const Spack th_temp = physics::get_potential_temperature(T,exner,Smask(true));
-    const Spack T_new   = physics::get_potential_temperature_inv(th_temp,exner,Smask(true));
+    const Spack th_temp = physics::get_potential_temperature(T,pres,Smask(true));
+    const Spack T_new   = physics::get_potential_temperature_inv(th_temp,pres,Smask(true));
     if (std::abs(T_new[0]-T_in)>tol) {
-      printf("T to th test: abs[ T_new (%.3e) - T_in (%.3e) ]=%e is larger than the tol=%e\n",T_new[0],T_in,std::abs(T_new[0]-T_in),tol);
+      printf("T to th and back again test: abs[ T_new (%.3e) - T_in (%.3e) ]=%e is larger than the tol=%e\n",T_new[0],T_in,std::abs(T_new[0]-T_in),tol);
       errors++;
     }
     // and vice versa
-    const Spack T_temp = physics::get_potential_temperature_inv(T,exner,Smask(true));
-    const Spack th_new = physics::get_potential_temperature(T_temp,exner,Smask(true));
+    const Spack T_temp = physics::get_potential_temperature_inv(T,pres,Smask(true));
+    const Spack th_new = physics::get_potential_temperature(T_temp,pres,Smask(true));
     if (std::abs(th_new[0]-T_in)>tol) {
-      printf("T to th test: abs[ th_new (%.3e) - T_in (%.3e) ]=%e is larger than the tol=%e\n",th_new[0],T_in,std::abs(th_new[0]-T_in),tol);
+      printf("th to T and back again test: abs[ th_new (%.3e) - T_in (%.3e) ]=%e is larger than the tol=%e\n",th_new[0],T_in,std::abs(th_new[0]-T_in),tol);
       errors++;
     }
   } // T_th_conversion_test

--- a/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
+++ b/components/scream/src/physics/share/tests/physics_universal_unit_tests.cpp
@@ -61,7 +61,7 @@ struct UnitWrap::UnitTest<D>::TestUniversal
     //========================================================
     // Test conversion of temperature to potential temperature, and vice versa
     //========================================================
-    // This function tests both the get_potential_temperature and th_to_T universal conversion functions.
+    // This function tests both the get_potential_temperature and get_potential_temperature_inv universal conversion functions.
     //
     // Inputs:
     //   T_in:    An example temperature, K.
@@ -88,24 +88,24 @@ struct UnitWrap::UnitTest<D>::TestUniversal
     // Test conversion from potential temperature (th) to temperature (T)
     // Use T_in to convert from th to T, note, we use T_in again because we are just testing the formula and T_in should be sufficient for that.
     // Note: th to T conversion is just a simple formula of T = th*exner
-    const Spack T_atm = physics::th_to_T(T,exner,Smask(true));
+    const Spack T_mid = physics::get_potential_temperature_inv(T,exner,Smask(true));
     Real expected_T = T_in*exner[0];
-    if (std::abs(T_atm[0]-expected_T)>tol) {
-      printf("th to Ttest: abs(T_mid-expected_T)=%e is larger than the tol=%e\n",std::abs(T_atm[0]-expected_T),tol);
+    if (std::abs(T_mid[0]-expected_T)>tol) {
+      printf("th to Ttest: abs(T_mid-expected_T)=%e is larger than the tol=%e\n",std::abs(T_mid[0]-expected_T),tol);
       errors++;
     }
 
-    // Test that get_potential_temperature and th_to_T are inverses of each other.
+    // Test that get_potential_temperature and get_potential_temperature_inv are inverses of each other.
     // Test T to th as inverses of each other
     // Converting T to th and then back to T should return the same value again.
     const Spack th_temp = physics::get_potential_temperature(T,exner,Smask(true));
-    const Spack T_new   = physics::th_to_T(th_temp,exner,Smask(true));
+    const Spack T_new   = physics::get_potential_temperature_inv(th_temp,exner,Smask(true));
     if (std::abs(T_new[0]-T_in)>tol) {
       printf("T to th test: abs[ T_new (%.3e) - T_in (%.3e) ]=%e is larger than the tol=%e\n",T_new[0],T_in,std::abs(T_new[0]-T_in),tol);
       errors++;
     }
     // and vice versa
-    const Spack T_temp = physics::th_to_T(T,exner,Smask(true));
+    const Spack T_temp = physics::get_potential_temperature_inv(T,exner,Smask(true));
     const Spack th_new = physics::get_potential_temperature(T_temp,exner,Smask(true));
     if (std::abs(th_new[0]-T_in)>tol) {
       printf("T to th test: abs[ th_new (%.3e) - T_in (%.3e) ]=%e is larger than the tol=%e\n",th_new[0],T_in,std::abs(th_new[0]-T_in),tol);
@@ -262,8 +262,8 @@ struct UnitWrap::UnitTest<D>::TestUniversal
         Real p_val  = pow( pres/p0, rd*inv_cp);
         exner_tests(pres,p_val,errors);
         // T and TH conversion TEST
-        Real T_atm = tmelt + k;
-        T_th_conversion_test(T_atm,pres,errors);
+        Real T_mid = tmelt + k;
+        T_th_conversion_test(T_mid,pres,errors);
         // DZ Test
         //   - Determine the z-layer bottom and top as being the (k+1) thick.
         //     Allow for varying interface heights by setting zi_bot equal to the sum(0,...,k).


### PR DESCRIPTION
This PR updates the temperature universal conversion functions to support whole-column operations.

This PR updates the universal physics tests to take advantage of column-based operations.

This PR updates the pre and post amble for P3 to reflect the changes to the temperature conversion functions.