### PR TITLE
Major upgrades to scripts and testing

### DIFF
--- a/components/scream/scripts/git_utils.py
+++ b/components/scream/scripts/git_utils.py
@@ -4,6 +4,8 @@ Git-related Utilities
 
 from utils import expect, run_cmd, run_cmd_no_fail
 
+import os
+
 ###############################################################################
 def get_current_branch(repo=None):
 ###############################################################################
@@ -18,7 +20,7 @@ def get_current_branch(repo=None):
     return None if output=="HEAD" else output
 
 ###############################################################################
-def get_current_commit(short=False, repo=None, tag=False, commit=None):
+def get_current_commit(short=False, repo=None, tag=False, commit="HEAD"):
 ###############################################################################
     """
     Return the sha1 of the current HEAD commit
@@ -26,10 +28,13 @@ def get_current_commit(short=False, repo=None, tag=False, commit=None):
     >>> get_current_commit() is not None
     True
     """
+    # This is for testing only
+    if "SCREAM_FAKE_GIT_HEAD" in os.environ:
+        return os.environ["SCREAM_FAKE_GIT_HEAD"]
+
     if tag:
         rc, output, err = run_cmd("git describe --tags $(git log -n1 --pretty='%h')", from_dir=repo)
     else:
-        commit = "HEAD" if commit is None else commit
         rc, output, err = run_cmd("git rev-parse {} {}".format("--short" if short else "", commit), from_dir=repo)
 
     if rc != 0:
@@ -50,23 +55,28 @@ def get_current_head(repo=None):
         return branch
 
 ###############################################################################
-def git_refs_difference (src_ref, tgt_ref, repo=None):
+def git_refs_difference (cmp_ref, head="HEAD", repo=None):
 ###############################################################################
     """
-    Return the difference in commits between src and tgg refs.
+    Return the difference in commits between cmp_ref and head.
     In particular, it returns two numbers: the number of commits
-    in src that are not in tgt, and the number of commits in tgt
-    that are not in src. The former is how much src is "ahead" of tgt,
-    while the latter is how much src is "behind" tgt.
+    in cmp_ref that are not in head, and the number of commits in head
+    that are not in cmp_ref. The former is how much head is behind cmp_ref,
+    while the latter is how much head is ahead of cmp_ref.
     """
+    if "SCREAM_FAKE_GIT_HEAD" in os.environ:
+        expect("SCREAM_FAKE_AHEAD" in os.environ,
+               "git_refs_difference cannot be used with SCREAM_FAKE_GIT_HEAD and without SCREAM_FAKE_AHEAD")
+        return 0, int(os.environ["SCREAM_FAKE_AHEAD"])
 
-    cmd = "git rev-list --left-right --count {}...{}".format(src_ref,tgt_ref)
+    cmd = "git rev-list --left-right --count {}...{}".format(cmp_ref, head)
     out = run_cmd_no_fail("{}".format(cmd), from_dir=repo)
 
-    ahead_behind = out.split()
-    expect(len(ahead_behind)==2, "Error! Something went wrong when running {}".format(cmd))
+    behind_ahead = out.split()
+    expect(len(behind_ahead)==2, "Error! Something went wrong when running {}".format(cmd))
+    behind, ahead = int(behind_ahead[0]), int(behind_ahead[1])
 
-    return ahead_behind
+    return behind, ahead
 
 ###############################################################################
 def is_repo_clean(repo=None, silent=False):
@@ -131,7 +141,7 @@ def print_last_commit(git_ref=None, repo=None, dry_run=False):
         print("Last commit on ref '{}'".format(git_ref))
     else:
         git_ref = get_current_head(repo) if git_ref is None else git_ref
-        last_commit = run_cmd_no_fail("git log {} -1 --oneline".format(git_ref), from_dir=repo)
+        last_commit = get_current_commit(commit=git_ref)
         print("Last commit on ref '{}': {}".format(git_ref, last_commit))
 
 ###############################################################################
@@ -142,18 +152,18 @@ def checkout_git_ref(git_ref, verbose=False, repo=None, dry_run=False):
     """
     if dry_run:
         print("Would checkout {}".format(git_ref))
-    elif get_current_commit() != get_current_commit(commit=git_ref):
+    elif get_current_commit(repo=repo) != get_current_commit(repo=repo, commit=git_ref):
         expect(is_repo_clean(repo=repo), "If we need to change HEAD, then the repo must be clean before running")
         expect(git_ref is not None, "Missing git-ref")
 
         run_cmd_no_fail("git checkout {}".format(git_ref), from_dir=repo)
         update_submodules(repo=repo)
-        git_commit = get_current_commit()
+        git_commit = get_current_commit(repo=repo)
         expect(is_repo_clean(repo=repo), "Something went wrong when checking out git ref '{}'".format(git_ref))
 
         if verbose:
             print("Switched to '{}' ({})".format(git_ref,git_commit))
-            print_last_commit(git_ref=git_ref)
+            print_last_commit(repo=repo, git_ref=git_ref)
 
 ###############################################################################
 def get_git_toplevel_dir(repo=None):

--- a/components/scream/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/scream/scripts/jenkins/jenkins_common_impl.sh
@@ -20,7 +20,10 @@ fi
 
 if [ $skip_testing -eq 0 ]; then
   # User did not request to skip tests. Proceed with testing.
-  source ./scream/components/scream/scripts/jenkins/${NODE_NAME}_setup
+
+  cd scream/components/scream
+
+  source scripts/jenkins/${NODE_NAME}_setup
 
   git config --global user.email "jenkins@ignore.com"
   git config --global user.name "Jenkins Jenkins"
@@ -34,29 +37,23 @@ if [ $skip_testing -eq 0 ]; then
   # IF such dir is not found, then the default (ctest-build/baselines) is used
   BASELINES_DIR=AUTO
 
-  ./scream/components/scream/scripts/gather-all-data "./scripts/test-all-scream --baseline-dir $BASELINES_DIR \$compiler -c EKAT_DISABLE_TPL_WARNINGS=ON -p -i -m \$machine $SUBMIT" -l -m $SCREAM_MACHINE
+  ./scripts/gather-all-data "./scripts/test-all-scream --baseline-dir $BASELINES_DIR \$compiler -c EKAT_DISABLE_TPL_WARNINGS=ON -p -i -m \$machine $SUBMIT" -l -m $SCREAM_MACHINE
 
   # Add a valgrind test for mappy for nightlies
   if [[ -n "$SUBMIT" && "$SCREAM_MACHINE" == "mappy" ]]; then
-      ./scream/components/scream/scripts/gather-all-data "./scripts/test-all-scream -t valg --baseline-dir $BASELINES_DIR \$compiler -c EKAT_DISABLE_TPL_WARNINGS=ON -p -i -m \$machine $SUBMIT" -l -m $SCREAM_MACHINE
+    ./scripts/gather-all-data "./scripts/test-all-scream -t valg --baseline-dir $BASELINES_DIR \$compiler -c EKAT_DISABLE_TPL_WARNINGS=ON -p -i -m \$machine $SUBMIT" -l -m $SCREAM_MACHINE
   fi
 
   # Uncomment this once pylint is available on target machines
-  # if [ $test_scripts -eq 1 ]; then
-  #     cd scream/components/scream/scripts
-  #     ./scripts-tests -g
-  #     if [ $? -ne 0 ]; then
-  #       exit 1
-  #     fi
-  #     ./scripts-tests -c
-  #     if [ $? -ne 0 ]; then
-  #       exit 1
-  #     fi
-  #     ./scripts-tests -f -m $SCREAM_MACHINE
-  #     if [ $? -ne 0 ]; then
-  #       exit 1
-  #     fi
-  # fi
+  if [ $test_scripts -eq 1 ]; then
+    # JGF: I'm not sure there's much value in these dry-run comparisons
+    # since we aren't changing HEADs
+    ./scripts/scripts-tests -g
+    ./scripts/scripts-tests -c
+
+    ./scripts/scripts-tests -f -m $SCREAM_MACHINE
+  fi
+
 else
   echo "Tests were skipped, since the Github label 'CI: Integrate Without Testing' was found.\n"
 fi

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -23,7 +23,6 @@ def get_weaver_queue():
         queue = "dev"
 
     return queue
-    
 
 MACHINE_METADATA = {
     "melvin"   : (["module purge", "module load sems-env", "module load sems-gcc/7.3.0 sems-openmpi/1.10.1 sems-gcc/7.3.0 sems-git/2.10.1 sems-cmake/3.12.2 sems-python/3.5.2"],

--- a/components/scream/scripts/scripts-tests
+++ b/components/scream/scripts/scripts-tests
@@ -17,17 +17,20 @@ If you are on a batch machine, it is expected that you are on a compute node.
 TODO: Add doctests to libs
 """
 
-from utils import run_cmd, check_minimum_python_version, expect
-from git_utils import get_current_head
+from utils import run_cmd, check_minimum_python_version, expect, ensure_pylint, run_cmd_no_fail
 
 check_minimum_python_version(3, 4)
 
 from machines_specs import is_machine_supported, is_cuda_machine, get_all_supported_machines
 
-import unittest, pathlib, argparse, sys, difflib
+from git_utils import get_current_branch, get_current_commit, get_current_head, git_refs_difference, \
+    is_repo_clean, get_common_ancestor, checkout_git_ref, get_git_toplevel_dir
+
+import unittest, argparse, sys, difflib, shutil
+from pathlib import Path
 
 # Globals
-TEST_DIR = pathlib.Path(__file__).resolve().parent
+TEST_DIR = Path(__file__).resolve().parent
 CONFIG = {
     "machine"  : None,
     "compare"  : False,
@@ -38,7 +41,7 @@ CONFIG = {
 ###############################################################################
 def run_cmd_assert_result(test_obj, cmd, from_dir=None, expect_works=True, env=None, verbose=False):
 ###############################################################################
-    from_dir = pathlib.Path() if from_dir is None else from_dir
+    from_dir = Path() if from_dir is None else from_dir
     stat, output, errput = run_cmd(cmd, from_dir=from_dir, env=env, verbose=verbose)
     problem = None
     if expect_works and stat != 0:
@@ -95,7 +98,34 @@ def test_cmake_cache_contents(test_obj, build_name, cache_var, expected_value):
                          msg="For CMake cache variable {}, expected value '{}', got '{}'".format(cache_var, expected_value, value))
 
 ###############################################################################
-class TestBaseOuter: # Hide the base class from test scanner
+def test_baseline_has_sha(test_obj, test_dir, build_name, expected_sha):
+###############################################################################
+    baseline_sha_file = test_dir.parent/"ctest-build"/"baselines"/build_name/"baseline_git_sha"
+    test_obj.assertTrue(baseline_sha_file.exists())
+    with baseline_sha_file.open("r") as fd:
+        baseline_sha = fd.read().strip()
+
+    test_obj.assertEqual(baseline_sha, expected_sha)
+
+###############################################################################
+def add_file_and_commit(repo, filename, contents, commit_msg):
+###############################################################################
+    filepath = repo / filename
+    with filepath.open("w") as fd:
+        fd.write(contents)
+
+    run_cmd_no_fail("git add {}".format(filename), from_dir=repo)
+    run_cmd_no_fail("git commit -m {}".format(commit_msg), from_dir=repo)
+
+###############################################################################
+def test_branch_switch(test_obj, repo, branch_name):
+###############################################################################
+    checkout_git_ref(branch_name, repo=repo)
+    test_obj.assertEqual(get_current_branch(repo=repo), branch_name)
+    test_obj.assertEqual(get_current_head(repo=repo), branch_name)
+
+###############################################################################
+class TestBaseOuter: # Hides the TestBase class from test scanner
     class TestBase(unittest.TestCase):
 ###############################################################################
 
@@ -129,6 +159,7 @@ class TestBaseOuter: # Hide the base class from test scanner
             run_cmd_assert_result(self, "python3 -m doctest {}".format(self._source_file), from_dir=TEST_DIR)
 
         def test_pylint(self):
+            ensure_pylint()
             run_cmd_assert_result(self, "pylint --disable C --disable R {}".format(self._source_file), from_dir=TEST_DIR)
 
         def test_gen_baseline(self):
@@ -163,12 +194,65 @@ class TestMachinesSpecs(TestBaseOuter.TestBase):
     def __init__(self, *internal_args):
         super(TestMachinesSpecs, self).__init__("machines_specs.py", [], *internal_args)
 
+
 ###############################################################################
 class TestUtils(TestBaseOuter.TestBase):
 ###############################################################################
 
     def __init__(self, *internal_args):
         super(TestUtils, self).__init__("utils.py", [], *internal_args)
+
+    def test_git_utils(self):
+        git_test_root = TEST_DIR/"git-test-root"
+        if git_test_root.exists():
+            # we will need to bump minimum version to >3.6 before we can assume
+            # standard library calls will work with Path objects
+            shutil.rmtree(str(git_test_root))
+
+        git_test_root.mkdir()
+
+        run_cmd_no_fail("git init .", from_dir=git_test_root)
+
+        add_file_and_commit(git_test_root, "foo", "hi", "init")
+
+        self.assertEqual(get_current_branch(repo=git_test_root), "master")
+        init_commit = get_current_commit(repo=git_test_root)
+
+        run_cmd_no_fail("git checkout -b testbranch", from_dir=git_test_root)
+        add_file_and_commit(git_test_root, "bar", "there", "branch_first")
+        self.assertEqual(get_current_branch(repo=git_test_root), "testbranch")
+
+        test_branch_switch(self, git_test_root, "master")
+        add_file_and_commit(git_test_root, "baz", "aloha", "master2")
+
+        test_branch_switch(self, git_test_root, "testbranch")
+        branch_first = get_current_commit(repo=git_test_root)
+        add_file_and_commit(git_test_root, "blah", "hola", "branch2")
+        add_file_and_commit(git_test_root, "bag", "adios", "branch3")
+        self.assertEqual(get_current_branch(repo=git_test_root), "testbranch")
+        self.assertEqual(get_current_head(repo=git_test_root), "testbranch")
+        self.assertNotEqual(branch_first, get_current_commit(repo=git_test_root))
+
+        self.assertEqual(get_common_ancestor("master", repo=git_test_root), init_commit)
+        self.assertTrue(is_repo_clean(repo=git_test_root))
+        self.assertEqual(str(git_test_root), get_git_toplevel_dir(repo=git_test_root))
+
+        behind, ahead = git_refs_difference("master", repo=git_test_root)
+        self.assertEqual(behind, 1)
+        self.assertEqual(ahead, 3)
+
+        behind, ahead = git_refs_difference("master", "master", repo=git_test_root)
+        self.assertEqual(behind, 0)
+        self.assertEqual(ahead, 0)
+
+        filepath = git_test_root / "foo"
+        with filepath.open("a") as fd:
+            fd.write("moretext")
+
+        self.assertFalse(is_repo_clean(repo=git_test_root))
+
+        # cleanup if everything worked fine
+        shutil.rmtree(str(git_test_root))
 
 ###############################################################################
 class TestTestAllScream(TestBaseOuter.TestBase):
@@ -193,7 +277,9 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             test_cmake_cache_contents(self, "full_debug", "CMAKE_BUILD_TYPE", "Debug")
             test_cmake_cache_contents(self, "full_debug", "SCREAM_DOUBLE_PRECISION", "TRUE")
             test_cmake_cache_contents(self, "full_debug", "SCREAM_FPE", "FALSE")
-            if not is_cuda_machine(self._machine):
+            if is_cuda_machine(self._machine):
+                test_cmake_cache_contents(self, "full_debug", "SCREAM_PACK_SIZE", "1")
+            else:
                 test_cmake_cache_contents(self, "full_debug", "SCREAM_PACK_SIZE", "16")
         else:
             self.skipTest("Skipping full run")
@@ -205,8 +291,11 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             test_cmake_cache_contents(self, "full_sp_debug", "CMAKE_BUILD_TYPE", "Debug")
             test_cmake_cache_contents(self, "full_sp_debug", "SCREAM_DOUBLE_PRECISION", "FALSE")
             test_cmake_cache_contents(self, "full_sp_debug", "SCREAM_FPE", "FALSE")
-            if not is_cuda_machine(self._machine):
-                test_cmake_cache_contents(self, "full_debug", "SCREAM_PACK_SIZE", "16")
+            if is_cuda_machine(self._machine):
+                test_cmake_cache_contents(self, "full_sp_debug", "SCREAM_PACK_SIZE", "1")
+            else:
+                test_cmake_cache_contents(self, "full_sp_debug", "SCREAM_PACK_SIZE", "16")
+
         else:
             self.skipTest("Skipping full run")
 
@@ -220,6 +309,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
                 test_cmake_cache_contents(self, "debug_nopack_fpe", "CMAKE_BUILD_TYPE", "Debug")
                 test_cmake_cache_contents(self, "debug_nopack_fpe", "SCREAM_DOUBLE_PRECISION", "TRUE")
                 test_cmake_cache_contents(self, "debug_nopack_fpe", "SCREAM_FPE", "TRUE")
+                test_cmake_cache_contents(self, "debug_nopack_fpe", "SCREAM_PACK_SIZE", "1")
         else:
             self.skipTest("Skipping full run")
 
@@ -248,6 +338,48 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         if self._full:
             cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_RUN_DIFF=True -m $machine -b HEAD -k -t dbg", self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR, expect_works=False)
+        else:
+            self.skipTest("Skipping full run")
+
+    def test_baseline_handling(self):
+        if self._full:
+            baseline_dir = TEST_DIR.parent/"ctest-build"/"baselines"
+
+            # Start a couple new tests, baselines will be generated
+            cmd = self.get_cmd("SCREAM_FAKE_GIT_HEAD=FAKE1 ./test-all-scream -m $machine -b HEAD -k -t dbg -t sp", self._machine, dry_run=False)
+            run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
+
+            test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE1")
+            test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE1")
+
+            # Re-run reusing baselines from above
+            cmd = self.get_cmd("SCREAM_FAKE_GIT_HEAD=FAKE2 ./test-all-scream -m $machine --baseline-dir={} -b HEAD -k -t dbg -t sp".format(baseline_dir), self._machine, dry_run=False)
+            run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
+
+            test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE1")
+            test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE1")
+
+            # Re-run dbg reusing baselines from above with a fake commit that's not ahead
+            cmd = self.get_cmd("SCREAM_FAKE_AHEAD=0 SCREAM_FAKE_GIT_HEAD=FAKE2 ./test-all-scream -m $machine --baseline-dir={} -b HEAD -k -t dbg -u".format(baseline_dir), self._machine, dry_run=False)
+            run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
+
+            test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE1")
+            test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE1")
+
+            # Re-run dbg reusing baselines from above but expire them
+            cmd = self.get_cmd("SCREAM_FAKE_AHEAD=1 SCREAM_FAKE_GIT_HEAD=FAKE2 ./test-all-scream -m $machine --baseline-dir={} -b HEAD -k -t dbg -u".format(baseline_dir), self._machine, dry_run=False)
+            run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
+
+            test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE2")
+            test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE1")
+
+            # Re-run without reusing baselines, should force regeneration
+            cmd = self.get_cmd("SCREAM_FAKE_GIT_HEAD=FAKE3 ./test-all-scream -m $machine -b HEAD -k -t dbg -t sp".format(baseline_dir), self._machine, dry_run=False)
+            run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
+
+            test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE3")
+            test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE3")
+
         else:
             self.skipTest("Skipping full run")
 
@@ -318,7 +450,7 @@ OR
     > {0} -c
     > {0} -f -m $machine
 
-""".format(pathlib.Path(args[0]).name)
+""".format(Path(args[0]).name)
 
     parser = argparse.ArgumentParser(
         usage=help_str,

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -72,6 +72,9 @@ OR
     parser.add_argument("--baseline-dir", default=None,
         help="Use baselines from the given directory, skip baseline creation.")
 
+    parser.add_argument("-u", "--update-expired-baselines", action="store_true",
+        help="Update baselines that appear to be expired.")
+
     parser.add_argument("-m", "--machine",
         help="Provide machine name. This is *always* required")
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -8,11 +8,13 @@ from machines_specs import get_mach_compilation_resources, get_mach_testing_reso
 
 check_minimum_python_version(3, 4)
 
-import os, shutil, pathlib
+import os, shutil
 import concurrent.futures as threading3
 import itertools
 import json
+
 from collections import OrderedDict
+from pathlib import Path
 
 ###############################################################################
 class TestAllScream(object):
@@ -25,7 +27,7 @@ class TestAllScream(object):
                  custom_cmake_opts=(), custom_env_vars=(), preserve_env=False, tests=(),
                  integration_test="JENKINS_HOME" in os.environ, local=False, root_dir=None, work_dir=None,
                  quick_rerun=False,quick_rerun_failed=False,dry_run=False,
-                 make_parallel_level=0, ctest_parallel_level=0):
+                 make_parallel_level=0, ctest_parallel_level=0, update_expired_baselines=False):
     ###########################################################################
 
         # When using scripts-tests, we can't pass "-l" to test-all-scream,
@@ -57,7 +59,8 @@ class TestAllScream(object):
         self._quick_rerun             = quick_rerun
         self._quick_rerun_failed      = quick_rerun_failed
         self._dry_run                 = dry_run
-        self._must_generate_baselines = False
+        self._tests_needing_baselines = []
+        self._update_expired_baselines= update_expired_baselines
 
         self._test_full_names = OrderedDict([
             ("dbg" , "full_debug"),
@@ -102,14 +105,14 @@ class TestAllScream(object):
 
         # Compute root dir (where repo is) and work dir (where build/test will happen)
         if not self._root_dir:
-            self._root_dir = pathlib.Path(__file__).resolve().parent.parent
+            self._root_dir = Path(__file__).resolve().parent.parent
         else:
-            self._root_dir = pathlib.Path(self._root_dir).resolve()
+            self._root_dir = Path(self._root_dir).resolve()
             expect(self._root_dir.is_dir() and self._root_dir.parts()[-2:] == ('scream', 'components'),
                    "Bad root-dir '{}', should be: $scream_repo/components/scream".format(self._root_dir))
 
         if self._work_dir is not None:
-            expect(pathlib.Path(self._work_dir).absolute().is_dir(),
+            expect(Path(self._work_dir).absolute().is_dir(),
                    "Error! Work directory '{}' does not exist.".format(self._work_dir))
         else:
             self._work_dir = self._root_dir.absolute().joinpath("ctest-build")
@@ -129,10 +132,7 @@ class TestAllScream(object):
         ###################################
 
         expect (not self._baseline_dir or self._work_dir != self._baseline_dir,
-                "Error! For your safety, do NOT use '{}' to store baselines. Move them to a different directory (even a subdirectory of that works).".format(self._work_dir))
-
-        expect(not (self._baseline_ref and self._baseline_dir),
-               "Makes no sense to specify a baseline generation commit if using pre-existing baselines ")
+                "Error! For your safety, do NOT use '{}' to store baselines. Move them to a different directory (even a subdirectory if that works).".format(self._work_dir))
 
         # If no baseline ref/dir was provided, try to figure out one based on other options
         if self._baseline_dir is None and self._baseline_ref is None:
@@ -172,45 +172,30 @@ class TestAllScream(object):
             self._baseline_ref = "origin/master"
             merge_git_ref(git_ref=self._baseline_ref, verbose=True, dry_run=self._dry_run)
 
+            # Always update expired baselines if this is an integration test
+            self._update_expired_baselines = True
+
         # By now, we should have at least one between baseline_dir and baseline_ref set (possibly both)
-        default_baselines_root_dir = pathlib.Path(self._work_dir,"baselines")
+        default_baselines_root_dir = self._work_dir/"baselines"
         if self._baseline_dir is None:
             # Use default baseline dir, and create it if necessary
-            self._baseline_dir = pathlib.Path(default_baselines_root_dir).absolute()
-            self._baseline_dir.mkdir(parents=True,exist_ok=True)
-        elif self._baseline_dir == "AUTO":
-            # We treat the "AUTO" string as a request for automatic baseline dir.
-            self._baseline_dir = get_mach_baseline_root_dir(self._machine)
-        self._baseline_dir = pathlib.Path(self._baseline_dir).absolute()
+            self._baseline_dir = Path(default_baselines_root_dir).absolute()
+            self.create_tests_dirs(self._baseline_dir, True) # Wipe out previous baselines
 
-        # Make sure the baseline folders exist (do not purge content if they exist)
-        self.create_tests_dirs(self._baseline_dir, False)
-        
-        # Name of the file used to store/check the git sha of the repo used to generate baselines,
-        # and name of the file used to store/check the builds for which baselines are available
-        # Store it once to avoid typos-like bugs
-        self._baseline_sha_file   = pathlib.Path(self._baseline_dir, "baseline_git_sha")
-        self._baseline_names_file = pathlib.Path(self._baseline_dir, "baseline_names")
+        else:
+            if self._baseline_dir == "AUTO":
+                # We treat the "AUTO" string as a request for automatic baseline dir.
+                self._baseline_dir = get_mach_baseline_root_dir(self._machine)
+            else:
+                self._baseline_dir = Path(self._baseline_dir).absolute()
 
-        baseline_ref_sha = get_current_commit(commit=self._baseline_ref)
+            # Make sure the baseline folders exist (but do not purge content if they exist)
+            self.create_tests_dirs(self._baseline_dir, False)
 
         print ("Checking baselines directory: {}".format(self._baseline_dir))
-        if not self.baselines_are_present():
-            print (" -> Some baselines were not found. Rebuilding them.")
-            self._must_generate_baselines = True
-        else:
-            print (" -> Baselines found.")
-
-        if self._integration_test:
-            print ("Integration test requires up-to-date baseline. Checking if baselines are expired.")
-            if self.baselines_are_expired(expected_baseline_sha=baseline_ref_sha):
-                print (" -> Baselines expired. Rebuilding them.")
-                self._must_generate_baselines = True
-            else:
-                print (" -> Baselines not expired. Skipping baselines generation.")
-
-        if self._must_generate_baselines:
-            print("Using commit {} to generate baselines".format(self._baseline_ref))
+        self.baselines_are_present()
+        if self._update_expired_baselines:
+            self.baselines_are_expired()
 
         ##################################################
         #   Deduce how many testing resources per test   #
@@ -320,7 +305,7 @@ class TestAllScream(object):
     ###############################################################################
 
         # Make sure the baseline root directory exists
-        expect(root.is_dir(), "{} is not a valid directory".format(root))
+        root.mkdir(parents=True,exist_ok=True)
 
         # Create build directories (one per test)
         for test in self._tests:
@@ -337,93 +322,101 @@ class TestAllScream(object):
                 test_dir.mkdir(parents=True)
 
     ###############################################################################
+    def get_baseline_file_sha(self, test):
+    ###############################################################################
+        baseline_file = (self.get_preexisting_baseline(test).parent)/"baseline_git_sha"
+        if baseline_file.exists():
+            with baseline_file.open("r") as fd:
+                return fd.read().strip()
+
+        return None
+
+    ###############################################################################
+    def set_baseline_file_sha(self, test, sha):
+    ###############################################################################
+        baseline_file = (self.get_preexisting_baseline(test).parent)/"baseline_git_sha"
+        with baseline_file.open("w") as fd:
+            return fd.write(sha)
+
+    ###############################################################################
     def get_test_dir(self, root, test):
     ###############################################################################
-        return pathlib.Path(root, self._test_full_names[test])
+        return root/self._test_full_names[test]
 
     ###############################################################################
     def get_preexisting_baseline(self, test):
     ###############################################################################
         expect(self._baseline_dir is not None, "Cannot supply preexisting baseline without baseline dir")
-        return pathlib.Path(self._baseline_dir, self._test_full_names[test], "data")
+        return self._baseline_dir/self._test_full_names[test]/"data"
 
     ###############################################################################
     def baselines_are_present (self):
     ###############################################################################
-        # Check that all baselines are present (one subdir for all values of self._tests)
-
+        """
+        Check that all baselines are present (one subdir for all values of self._tests)
+        """
         # Sanity check
         expect(self._baseline_dir is not None,
                 "Error! Baseline directory not correctly set.")
 
-        # Even if a single baseline is missing, we consider all the baselines not present
         for test in self._tests:
-            test_baseline_dir = self.get_test_dir(self._baseline_dir, test)
-            data_dir = pathlib.Path(test_baseline_dir, "data")
+            data_dir = self.get_preexisting_baseline(test)
             if not data_dir.is_dir():
-                return False
-
-        # Note: inside this script we don't know what kind of file should be in the baseline "data" dirs.
-        #       If the actual files are missing, some other part of the testing will crash.
-        return True
+                self._tests_needing_baselines.append(test)
+                print(" -> Test {} is missing baselines".format(test))
+            else:
+                print(" -> Test {} appears to have baselines".format(test))
 
     ###############################################################################
-    def baselines_are_expired (self, expected_baseline_sha):
+    def baselines_are_expired(self):
     ###############################################################################
-        # Baselines are expired if either:
-        #  1) there is no file in baseline_dir containing the sha of the baselines
-        #  2) the baselines sha does not match the one passed to this function
+        """
+        Baselines are expired if either:
+          1) there is no file in baseline_dir containing the sha of the baselines
+          2) the baselines sha does not match baseline_ref
+        """
+        baseline_ref_sha = get_current_commit(commit=self._baseline_ref)
 
         # Sanity check
         expect(self._baseline_dir is not None, "Error! This routine should only be called when testing against pre-existing baselines.")
 
-        # The file specifying what baselines were built during last baselines generation msut be there
-        if not self._baseline_names_file.exists():
-            return True
-
-        # It might happen that we generate baselines for all build types, then later on
-        # for some reason we manually generate baselines for only one build type. The other
-        # baselines will still be there, but may be expired. Therefore, we check the
-        # baselines_names file, to see what baselines were built last time. If all the
-        # baselines we need are there, then we're good
-        valid_baselines = run_cmd_no_fail("cat {}".format(self._baseline_names_file.resolve()))
         for test in self._tests:
-            if not test in valid_baselines:
-                return True
+            if test not in self._tests_needing_baselines:
+                # this test is not missing a baseline, but it may be expired.
 
-        # No sha file => baselines expired
-        if not self._baseline_sha_file.exists():
-            return True
+                baseline_file_sha = self.get_baseline_file_sha(test)
+                if baseline_file_sha is None:
+                    self._tests_needing_baselines.append(test)
+                    print(" -> Test {} has no stored sha so must be considered expired".format(test))
+                else:
+                    num_ref_is_behind_file, num_ref_is_ahead_file = git_refs_difference(baseline_file_sha, baseline_ref_sha)
 
-        # Different sha => baselines expired
-        baseline_sha = run_cmd_no_fail("cat {}".format(self._baseline_sha_file))
+                    # If the copy in our repo is behind, then we need to update the repo
+                    expect (num_ref_is_behind_file==0 or not self._integration_test,
+"""Error! Your repo seems stale, since the baseline sha in your repo is behind
+the one last used to generated them. We do *not* allow an integration
+test to replace baselines with older ones, for security reasons.
+If this is a legitimate case where baselines need to be 'rewound',
+e.g. b/c of a (hopefully VERY RARE) force push to master, then
+remove existing baselines first. Otherwise, please run 'git fetch $remote'.
+ - baseline_ref: {}
+ - repo baseline sha: {}
+ - last used baseline sha: {}""".format(self._baseline_ref,baseline_ref_sha,baseline_file_sha))
 
-        ahead_behind = git_refs_difference(expected_baseline_sha,baseline_sha)
-        ahead = int(ahead_behind[0])
-        behind = int(ahead_behind[1])
-
-        # If the copy in our repo is behind, then we need to update the repo
-        expect (behind==0 or not self._integration_test,
-            "Error! Your repo seems stale, since the baseline sha in your repo is behind\n"
-            "       the one last used to generated them. We do *not* allow an integration\n"
-            "       test to replace baselines with older ones, for security reasons.\n"
-            "       If this is a legitimate case where baselines need to be 'rewound',\n"
-            "       e.g. b/c of a (hopefully VERY RARE) force push to master, then\n"
-            "       remove existing baselines first. Otherwise, please run 'git fetch $remote'.\n"
-            "   - baseline_ref: {}\n"
-            "   - repo baseline sha: {}\n"
-            "   - last used baseline sha: {}\n".format(self._baseline_ref,expected_baseline_sha,baseline_sha))
-
-        # If the copy in our repo is not ahead, then baselines are not expired
-        return ahead>0
+                    # If the copy in our repo is not ahead, then baselines are not expired
+                    if num_ref_is_ahead_file > 0:
+                        self._tests_needing_baselines.append(test)
+                        print(" -> Test {} baselines are expired because they were generated with an earlier commit".format(test))
+                    else:
+                        print(" -> Test {} baselines are valid and do not need to be regenerated".format(test))
 
     ###############################################################################
     def get_machine_file(self):
     ###############################################################################
         if self._local:
-            return pathlib.Path("~/.cime/scream_mach_file.cmake").expanduser()
+            return Path("~/.cime/scream_mach_file.cmake").expanduser()
         else:
-            return pathlib.Path(self._root_dir, "cmake", "machine-files", "{}.cmake".format(self._machine))
+            return self._root_dir/"cmake"/"machine-files"/"{}.cmake".format(self._machine)
 
     ###############################################################################
     def generate_cmake_config(self, extra_configs, for_ctest=False):
@@ -544,7 +537,7 @@ class TestAllScream(object):
         for key, value in extra_configs:
             result += "-D{}={} ".format(key, value)
 
-        work_dir = pathlib.Path(self._work_dir).joinpath(name)
+        work_dir = self._work_dir/name
         result += "-DBUILD_WORK_DIR={} ".format(work_dir)
         result += "-DBUILD_NAME_MOD={} ".format(name)
         result += '-S {}/cmake/ctest_script.cmake -DCMAKE_COMMAND="{}" '.format(self._root_dir, cmake_config)
@@ -558,9 +551,12 @@ class TestAllScream(object):
         return result
 
     ###############################################################################
-    def generate_baselines(self, test):
+    def generate_baselines(self, test, commit):
     ###############################################################################
         test_dir = self.get_test_dir(self._baseline_dir, test)
+
+        # First, create baseline directory for this test. If existing, nuke the content
+        self.create_tests_dirs(test_dir, True)
 
         cmake_config = self.generate_cmake_config(self._tests_cmake_args[test])
         cmake_config += " -DSCREAM_BASELINES_ONLY=ON"
@@ -592,6 +588,9 @@ class TestAllScream(object):
             run_cmd_no_fail(r"find -maxdepth 1 -not -name data ! -path . -exec rm -rf {} \;",
                             from_dir=test_dir, verbose=True, dry_run=self._dry_run)
 
+            # Store the sha used for baselines generation
+            self.set_baseline_file_sha(test, commit)
+
         return True
 
     ###############################################################################
@@ -603,19 +602,18 @@ class TestAllScream(object):
         print("Generating baselines for ref {}".format(self._baseline_ref))
         print("###############################################################################")
 
-        # First, create build directories (one per test). If existing, nuke the content
-        self.create_tests_dirs(self._baseline_dir, True)
+        commit = get_current_commit(commit=self._baseline_ref)
 
         # Switch to the baseline commit
         checkout_git_ref(self._baseline_ref, verbose=True, dry_run=self._dry_run)
 
         success = True
-        num_workers = len(self._tests) if self._parallel else 1
+        num_workers = len(self._tests_needing_baselines) if self._parallel else 1
         with threading3.ProcessPoolExecutor(max_workers=num_workers) as executor:
 
             future_to_test = {
-                executor.submit(self.generate_baselines, test) : test
-                for test in self._tests}
+                executor.submit(self.generate_baselines, test, commit) : test
+                for test in self._tests_needing_baselines}
 
             for future in threading3.as_completed(future_to_test):
                 test = future_to_test[future]
@@ -624,15 +622,6 @@ class TestAllScream(object):
                 if not success and self._fast_fail:
                     print('Generation of baselines for build {} failed'.format(self._test_full_names[test]))
                     return False
-
-        if success:
-            # Store the sha used for baselines generation
-            run_cmd_no_fail("echo '{}' > {}".format(get_current_commit(commit=self._baseline_ref),self._baseline_sha_file))
-            # Store the name of the builds for which we created a baseline
-            tmp_string = ""
-            for test in self._tests:
-                tmp_string += " {}".format(test)
-            run_cmd_no_fail("echo '{}' > {}".format(tmp_string,self._baseline_names_file))
 
         # Switch back to the branch commit
         checkout_git_ref(git_head_ref, verbose=True, dry_run=self._dry_run)
@@ -652,7 +641,7 @@ class TestAllScream(object):
         cmake_config = self.generate_cmake_config(self._tests_cmake_args[test], for_ctest=True)
         ctest_config = self.generate_ctest_config(cmake_config, [], test)
 
-        if self._quick_rerun and pathlib.Path("{}/CMakeCache.txt".format(test_dir)).is_file():
+        if self._quick_rerun and (test_dir/"CMakeCache.txt").is_file():
             # Do not purge bld dir, and do not rerun config step.
             # Note: make will still rerun cmake if some cmake file has changed
             ctest_config += "-DSKIP_CONFIG_STEP=TRUE "
@@ -702,7 +691,7 @@ class TestAllScream(object):
             if not s:
                 print("Build type {} failed. Here's a list of failed tests:".format(self._test_full_names[t]))
                 test_dir = self.get_test_dir(self._work_dir,t)
-                test_results_dir = pathlib.Path(test_dir, "Testing", "Temporary")
+                test_results_dir = test_dir/"Testing"/"Temporary"
                 for result in test_results_dir.glob("LastTestsFailed*"):
                     print(result.read_text())
 
@@ -720,7 +709,7 @@ class TestAllScream(object):
         success = True
         try:
             # If needed, generate baselines first
-            if self._must_generate_baselines:
+            if self._tests_needing_baselines:
                 expect(self._baseline_ref is not None, "Missing baseline ref")
 
                 success = self.generate_all_baselines()


### PR DESCRIPTION
1) Enable scripts-tests in the AT if the 'scripts' label is on. Ensure_pylint
is called prior to the pylint tests and so this should work regardless of
preexisting pylint availability.
2) Add a full test suite for git_utils
3) Add testing to verify that test-all-scream baselines are being handled correctly.
Testing this thoroughly required the ability to spoof git states.
4) Add test-all-scream ability to know which specific test-types are missing
baselines or have expired baselines.