### PR TITLE
Compute and apply radiative heating

### DIFF
--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -51,6 +51,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Required>("eff_radius_qi", scalar3d_layout_mid, micron, grid->name());
 
   // Set computed (output) fields
+  add_field<Computed>("T_mid"     , scalar3d_layout_mid, K  , grid->name());
   add_field<Computed>("SW_flux_dn", scalar3d_layout_int, Wm2, grid->name());
   add_field<Computed>("SW_flux_up", scalar3d_layout_int, Wm2, grid->name());
   add_field<Computed>("SW_flux_dn_dir", scalar3d_layout_int, Wm2, grid->name());
@@ -84,7 +85,6 @@ void RRTMGPRadiation::run_impl (const Real /* dt */) {
   // Get device views
   auto d_pmid = m_rrtmgp_fields_in.at("p_mid").get_reshaped_view<const Real**>();
   auto d_pint = m_rrtmgp_fields_in.at("pint").get_reshaped_view<const Real**>();
-  auto d_tmid = m_rrtmgp_fields_in.at("T_mid").get_reshaped_view<const Real**>();
   auto d_tint = m_rrtmgp_fields_in.at("tint").get_reshaped_view<const Real**>();
   auto d_gas_vmr = m_rrtmgp_fields_in.at("gas_vmr").get_reshaped_view<const Real***>();
   auto d_sfc_alb_dir = m_rrtmgp_fields_in.at("surf_alb_direct").get_reshaped_view<const Real**>();
@@ -94,6 +94,7 @@ void RRTMGPRadiation::run_impl (const Real /* dt */) {
   auto d_iwp = m_rrtmgp_fields_in.at("iwp").get_reshaped_view<const Real**>();
   auto d_rel = m_rrtmgp_fields_in.at("eff_radius_qc").get_reshaped_view<const Real**>();
   auto d_rei = m_rrtmgp_fields_in.at("eff_radius_qi").get_reshaped_view<const Real**>();
+  auto d_tmid = m_rrtmgp_fields_out.at("T_mid").get_reshaped_view<Real**>();
   auto d_sw_flux_up = m_rrtmgp_fields_out.at("SW_flux_up").get_reshaped_view<Real**>();
   auto d_sw_flux_dn = m_rrtmgp_fields_out.at("SW_flux_dn").get_reshaped_view<Real**>();
   auto d_sw_flux_dn_dir = m_rrtmgp_fields_out.at("SW_flux_dn_dir").get_reshaped_view<Real**>();

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -79,7 +79,7 @@ void RRTMGPRadiation::initialize_impl(const util::TimeStamp& /* t0 */) {
   rrtmgp::rrtmgp_initialize(gas_concs);
 }
 
-void RRTMGPRadiation::run_impl (const Real /* dt */) {
+void RRTMGPRadiation::run_impl (const Real dt) {
   // Get data from AD; RRTMGP wants YAKL views
   // TODO: how can I just keep these around without having to create every time?
   // They are just pointers, so should be able to keep them somewhere else and just associate them once?

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -40,7 +40,6 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   // Set required (input) fields here
   add_field<Required>("p_mid" , scalar3d_layout_mid, Pa, grid->name());
   add_field<Required>("pint", scalar3d_layout_int, Pa, grid->name());
-  add_field<Required>("T_mid" , scalar3d_layout_mid, K , grid->name());
   add_field<Required>("tint" , scalar3d_layout_int, K , grid->name());
   add_field<Required>("gas_vmr", gas_layout, kgkg, grid->name());
   add_field<Required>("surf_alb_direct", scalar2d_swband_layout, nondim, grid->name());
@@ -52,7 +51,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Required>("eff_radius_qi", scalar3d_layout_mid, micron, grid->name());
 
   // Set computed (output) fields
-  add_field<Computed>("T_mid"     , scalar3d_layout_mid, K  , grid->name());
+  add_field<Updated >("T_mid"     , scalar3d_layout_mid, K  , grid->name());
   add_field<Computed>("SW_flux_dn", scalar3d_layout_int, Wm2, grid->name());
   add_field<Computed>("SW_flux_up", scalar3d_layout_int, Wm2, grid->name());
   add_field<Computed>("SW_flux_dn_dir", scalar3d_layout_int, Wm2, grid->name());

--- a/components/scream/src/physics/rrtmgp/rrtmgp_heating_rate.hpp
+++ b/components/scream/src/physics/rrtmgp/rrtmgp_heating_rate.hpp
@@ -1,0 +1,28 @@
+#ifndef RRTMGP_HEATING_RATE_HPP
+#define RRTMGP_HEATING_RATE_HPP
+#include "physics/share/physics_constants.hpp"
+namespace scream {
+    namespace rrtmgp {
+        // Provide a routine to compute heating due to radiative fluxes. This is
+        // computed as net flux into a layer, converted to a heating rate. It is
+        // the responsibility of the user to ensure fields are passed with the
+        // proper units. I.e., pressure at level interfaces should be in Pa,
+        // fluxes in W m-2, Cpair in J kg-1 K-1, gravit in m s-2. This will give
+        // heating in units of K s-1.
+        template <class T, int myMem, int myStyle> void compute_heating_rate (
+                yakl::Array<T,2,myMem,myStyle> const &flux_up, yakl::Array<T,2,myMem,myStyle> const &flux_dn, 
+                yakl::Array<T,2,myMem,myStyle> const &plev   , yakl::Array<T,2,myMem,myStyle> &heating_rate
+            ) {
+            using physconst = scream::physics::Constants<Real>;
+            auto ncol = flux_up.dimension[0];
+            auto nlay = flux_up.dimension[1]-1;
+            parallel_for(Bounds<2>(nlay,ncol), YAKL_LAMBDA(int ilay, int icol) {
+                heating_rate(icol,ilay) = (
+                    flux_up(icol,ilay+1) - flux_up(icol,ilay) - 
+                    flux_dn(icol,ilay+1) + flux_dn(icol,ilay)
+                ) * physconst::gravit / (physconst::Cpair * (plev(icol,ilay+1) - plev(icol,ilay)));
+            });
+        }
+    }
+}
+#endif

--- a/components/scream/src/physics/rrtmgp/rrtmgp_heating_rate.hpp
+++ b/components/scream/src/physics/rrtmgp/rrtmgp_heating_rate.hpp
@@ -11,13 +11,13 @@ namespace scream {
         // proper units. I.e., pressure at level interfaces should be in Pa,
         // fluxes in W m-2, Cpair in J kg-1 K-1, gravit in m s-2. This will give
         // heating in units of K s-1.
-        // TODO: we should probably update this to use the pseudo-density dp instead
-        // of approximating dp by differencing the level interface pressures.
+        // TODO: we should probably update this to use the pseudo-density pdel instead
+        // of approximating pdel by differencing the level interface pressures.
         // We are leaving this for the time being for consistency with SCREAMv0,
         // from which this code was directly ported.
         template <class T, int myMem, int myStyle> void compute_heating_rate (
                 yakl::Array<T,2,myMem,myStyle> const &flux_up, yakl::Array<T,2,myMem,myStyle> const &flux_dn, 
-                yakl::Array<T,2,myMem,myStyle> const &dp     , yakl::Array<T,2,myMem,myStyle> &heating_rate
+                yakl::Array<T,2,myMem,myStyle> const &pdel   , yakl::Array<T,2,myMem,myStyle> &heating_rate
             ) {
             using physconst = scream::physics::Constants<Real>;
             auto ncol = flux_up.dimension[0];
@@ -26,7 +26,7 @@ namespace scream {
                 heating_rate(icol,ilay) = (
                     flux_up(icol,ilay+1) - flux_up(icol,ilay) - 
                     flux_dn(icol,ilay+1) + flux_dn(icol,ilay)
-                ) * physconst::gravit / (physconst::Cpair * dp(icol,ilay));
+                ) * physconst::gravit / (physconst::Cpair * pdel(icol,ilay));
             });
         }
     }

--- a/components/scream/src/physics/rrtmgp/rrtmgp_heating_rate.hpp
+++ b/components/scream/src/physics/rrtmgp/rrtmgp_heating_rate.hpp
@@ -1,6 +1,8 @@
 #ifndef RRTMGP_HEATING_RATE_HPP
 #define RRTMGP_HEATING_RATE_HPP
 #include "physics/share/physics_constants.hpp"
+#include "YAKL/YAKL.h"
+#include "cpp/const.h"
 namespace scream {
     namespace rrtmgp {
         // Provide a routine to compute heating due to radiative fluxes. This is

--- a/components/scream/src/physics/rrtmgp/rrtmgp_heating_rate.hpp
+++ b/components/scream/src/physics/rrtmgp/rrtmgp_heating_rate.hpp
@@ -11,6 +11,10 @@ namespace scream {
         // proper units. I.e., pressure at level interfaces should be in Pa,
         // fluxes in W m-2, Cpair in J kg-1 K-1, gravit in m s-2. This will give
         // heating in units of K s-1.
+        // TODO: we should probably update this to use the pseudo-density dp instead
+        // of approximating dp by differencing the level interface pressures.
+        // We are leaving this for the time being for consistency with SCREAMv0,
+        // from which this code was directly ported.
         template <class T, int myMem, int myStyle> void compute_heating_rate (
                 yakl::Array<T,2,myMem,myStyle> const &flux_up, yakl::Array<T,2,myMem,myStyle> const &flux_dn, 
                 yakl::Array<T,2,myMem,myStyle> const &plev   , yakl::Array<T,2,myMem,myStyle> &heating_rate

--- a/components/scream/src/physics/rrtmgp/rrtmgp_heating_rate.hpp
+++ b/components/scream/src/physics/rrtmgp/rrtmgp_heating_rate.hpp
@@ -17,7 +17,7 @@ namespace scream {
         // from which this code was directly ported.
         template <class T, int myMem, int myStyle> void compute_heating_rate (
                 yakl::Array<T,2,myMem,myStyle> const &flux_up, yakl::Array<T,2,myMem,myStyle> const &flux_dn, 
-                yakl::Array<T,2,myMem,myStyle> const &plev   , yakl::Array<T,2,myMem,myStyle> &heating_rate
+                yakl::Array<T,2,myMem,myStyle> const &dp     , yakl::Array<T,2,myMem,myStyle> &heating_rate
             ) {
             using physconst = scream::physics::Constants<Real>;
             auto ncol = flux_up.dimension[0];
@@ -26,7 +26,7 @@ namespace scream {
                 heating_rate(icol,ilay) = (
                     flux_up(icol,ilay+1) - flux_up(icol,ilay) - 
                     flux_dn(icol,ilay+1) + flux_dn(icol,ilay)
-                ) * physconst::gravit / (physconst::Cpair * (plev(icol,ilay+1) - plev(icol,ilay)));
+                ) * physconst::gravit / (physconst::Cpair * dp(icol,ilay));
             });
         }
     }

--- a/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
@@ -19,6 +19,11 @@ if (NOT ${SCREAM_BASELINES_ONLY})
         EXCLUDE_MAIN_CPP
     )
     set_target_properties(rrtmgp_tests PROPERTIES COMPILE_FLAGS "${YAKL_CXX_FLAGS}")
+    set (SRC rrtmgp_unit_tests.cpp rrtmgp_test_utils.cpp)
+    CreateUnitTest(
+        rrtmgp_unit_tests "${SRC}" "${NEED_LIBS}" LABELS "rrtmgp;physics"
+    )
+    set_target_properties(rrtmgp_unit_tests PROPERTIES COMPILE_FLAGS "${YAKL_CXX_FLAGS}")
 endif()
 
 # Build baseline code

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
@@ -7,21 +7,20 @@ TEST_CASE("rrtmgp_test_heating") {
     if (!yakl::isInitialized()) { yakl::init(); }
 
     // Test heating rate function by passing simple inputs
-    auto plev = real2d("plev", 1, 2);
+    auto dp = real2d("dp", 1, 1);
     auto flux_up = real2d("flux_up", 1, 2);
     auto flux_dn = real2d("flux_dn", 1, 2);
     auto heating = real2d("heating", 1, 1);
     // Simple no-heating test
     // NOTE: parallel_for because we need to do these in a kernel on the device
     parallel_for(1, YAKL_LAMBDA(int dummy) {
-        plev(1, 1) = 10;
-        plev(1, 2) = 20;
+        dp(1, 1) = 10;
         flux_up(1, 1) = 1.0;
         flux_up(1, 2) = 1.0;
         flux_dn(1, 1) = 1.0;
         flux_dn(1, 2) = 1.0;
     });
-    scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, plev, heating);
+    scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, dp, heating);
     REQUIRE(heating.createHostCopy()(1,1) == 0);
 
     // Simple net postive heating; net flux into layer should be 1.0
@@ -35,9 +34,9 @@ TEST_CASE("rrtmgp_test_heating") {
     using physconst = scream::physics::Constants<double>;
     auto g = physconst::gravit; //9.81;
     auto cp_air = physconst::Cpair; //1005.0;
-    auto pdel = plev.createHostCopy()(1,2) - plev.createHostCopy()(1,1);
+    auto pdel = dp.createHostCopy()(1,1);
     auto heating_ref = 1.0 * g / (cp_air * pdel);
-    scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, plev, heating);
+    scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, dp, heating);
     REQUIRE(heating.createHostCopy()(1,1) == heating_ref);
 
     // Simple net negative heating; net flux into layer should be -1.0
@@ -49,11 +48,11 @@ TEST_CASE("rrtmgp_test_heating") {
         flux_dn(1,2) = 1.0;
     });
     heating_ref = -1.0 * g / (cp_air * pdel);
-    scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, plev, heating);
+    scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, dp, heating);
     REQUIRE(heating.createHostCopy()(1,1) == heating_ref);
 
     // Clean up
-    plev.deallocate();
+    dp.deallocate();
     flux_up.deallocate();
     flux_dn.deallocate();
     heating.deallocate();

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
@@ -1,0 +1,52 @@
+#include "catch2/catch.hpp"
+#include "physics/rrtmgp/rrtmgp_heating_rate.hpp"
+#include "YAKL/YAKL.h"
+#include "physics/share/physics_constants.hpp"
+TEST_CASE("rrtmgp_test_heating") {
+    // Initialize YAKL
+    if (!yakl::isInitialized()) { yakl::init(); }
+
+    // Test heating rate function by passing simple inputs
+    auto plev = real2d("plev", 1, 2);
+    auto flux_up = real2d("flux_up", 1, 2);
+    auto flux_dn = real2d("flux_dn", 1, 2);
+    auto heating = real2d("heating", 1, 1);
+    // Simple no-heating test
+    plev(1, 1) = 10;
+    plev(1, 2) = 20;
+    flux_up(1, 1) = 1.0;
+    flux_up(1, 2) = 1.0;
+    flux_dn(1, 1) = 1.0;
+    flux_dn(1, 2) = 1.0;
+    scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, plev, heating);
+    REQUIRE(heating(1,1) == 0);
+
+    // Simple net postive heating; net flux into layer should be 1.0
+    flux_up(1, 1) = 1.0;
+    flux_up(1, 2) = 1.0;
+    flux_dn(1, 1) = 1.5;
+    flux_dn(1, 2) = 0.5;
+    using physconst = scream::physics::Constants<double>;
+    auto g = physconst::gravit; //9.81;
+    auto cp_air = physconst::Cpair; //1005.0;
+    auto pdel = plev(1,2) - plev(1,1);
+    auto heating_ref = 1.0 * g / (cp_air * pdel);
+    scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, plev, heating);
+    REQUIRE(heating(1,1) == heating_ref);
+
+    // Simple net negative heating; net flux into layer should be -1.0
+    flux_up(1,1) = 1.5;
+    flux_up(1,2) = 0.5;
+    flux_dn(1,1) = 1.0;
+    flux_dn(1,2) = 1.0;
+    heating_ref = -1.0 * g / (cp_air * pdel);
+    scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, plev, heating);
+    REQUIRE(heating(1,1) == heating_ref);
+
+    // Clean up
+    plev.deallocate();
+    flux_up.deallocate();
+    flux_dn.deallocate();
+    heating.deallocate();
+    yakl::finalize();
+}

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
@@ -12,36 +12,45 @@ TEST_CASE("rrtmgp_test_heating") {
     auto flux_dn = real2d("flux_dn", 1, 2);
     auto heating = real2d("heating", 1, 1);
     // Simple no-heating test
-    plev(1, 1) = 10;
-    plev(1, 2) = 20;
-    flux_up(1, 1) = 1.0;
-    flux_up(1, 2) = 1.0;
-    flux_dn(1, 1) = 1.0;
-    flux_dn(1, 2) = 1.0;
+    // NOTE: parallel_for because we need to do these in a kernel on the device
+    parallel_for(1, YAKL_LAMBDA(int dummy) {
+        plev(1, 1) = 10;
+        plev(1, 2) = 20;
+        flux_up(1, 1) = 1.0;
+        flux_up(1, 2) = 1.0;
+        flux_dn(1, 1) = 1.0;
+        flux_dn(1, 2) = 1.0;
+    });
     scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, plev, heating);
-    REQUIRE(heating(1,1) == 0);
+    REQUIRE(heating.createHostCopy()(1,1) == 0);
 
     // Simple net postive heating; net flux into layer should be 1.0
-    flux_up(1, 1) = 1.0;
-    flux_up(1, 2) = 1.0;
-    flux_dn(1, 1) = 1.5;
-    flux_dn(1, 2) = 0.5;
+    // NOTE: parallel_for because we need to do these in a kernel on the device
+    parallel_for(1, YAKL_LAMBDA(int dummy) {
+        flux_up(1, 1) = 1.0;
+        flux_up(1, 2) = 1.0;
+        flux_dn(1, 1) = 1.5;
+        flux_dn(1, 2) = 0.5;
+    });
     using physconst = scream::physics::Constants<double>;
     auto g = physconst::gravit; //9.81;
     auto cp_air = physconst::Cpair; //1005.0;
-    auto pdel = plev(1,2) - plev(1,1);
+    auto pdel = plev.createHostCopy()(1,2) - plev.createHostCopy()(1,1);
     auto heating_ref = 1.0 * g / (cp_air * pdel);
     scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, plev, heating);
-    REQUIRE(heating(1,1) == heating_ref);
+    REQUIRE(heating.createHostCopy()(1,1) == heating_ref);
 
     // Simple net negative heating; net flux into layer should be -1.0
-    flux_up(1,1) = 1.5;
-    flux_up(1,2) = 0.5;
-    flux_dn(1,1) = 1.0;
-    flux_dn(1,2) = 1.0;
+    // NOTE: parallel_for because we need to do these in a kernel on the device
+    parallel_for(1, YAKL_LAMBDA(int dummy) {
+        flux_up(1,1) = 1.5;
+        flux_up(1,2) = 0.5;
+        flux_dn(1,1) = 1.0;
+        flux_dn(1,2) = 1.0;
+    });
     heating_ref = -1.0 * g / (cp_air * pdel);
     scream::rrtmgp::compute_heating_rate(flux_up, flux_dn, plev, heating);
-    REQUIRE(heating(1,1) == heating_ref);
+    REQUIRE(heating.createHostCopy()(1,1) == heating_ref);
 
     // Clean up
     plev.deallocate();

--- a/components/scream/tests/rrtmgp/input.yaml
+++ b/components/scream/tests/rrtmgp/input.yaml
@@ -21,6 +21,7 @@ Grids Manager:
 Initial Conditions:
   p_mid: 0.0
   pint: 0.0
+  pseudo_density: 0.0
   T_mid: 0.0
   tint: 0.0
   gas_vmr: 0.0

--- a/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
+++ b/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
@@ -149,7 +149,7 @@ namespace scream {
         ad.run(300.0);
 
         // Dumb check to verify that we did indeed update temperature
-        REQUIRE(t_lay(1,1) != T_mid0(1,1));
+        REQUIRE(t_lay.createHostCopy()(1,1) != T_mid0.createHostCopy()(1,1));
         T_mid0.deallocate();
 
         // Check values; need to get fluxes from field manager first

--- a/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
+++ b/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
@@ -96,6 +96,7 @@ namespace scream {
         auto d_pmid = field_mgr.get_field("p_mid").get_reshaped_view<Real**>();
         auto d_tmid = field_mgr.get_field("T_mid").get_reshaped_view<Real**>();
         auto d_pint = field_mgr.get_field("pint").get_reshaped_view<Real**>();
+        auto d_pdel = field_mgr.get_field("pseudo_density").get_reshaped_view<Real**>();
         auto d_tint = field_mgr.get_field("tint").get_reshaped_view<Real**>();
         auto d_sfc_alb_dir = field_mgr.get_field("surf_alb_direct").get_reshaped_view<Real**>();
         auto d_sfc_alb_dif = field_mgr.get_field("surf_alb_diffuse").get_reshaped_view<Real**>();
@@ -107,6 +108,7 @@ namespace scream {
         auto d_gas_vmr = field_mgr.get_field("gas_vmr").get_reshaped_view<Real***>();
         yakl::Array<double,2,memDevice,yakl::styleFortran> p_lay("p_lay", d_pmid.data(), ncol, nlay);
         yakl::Array<double,2,memDevice,yakl::styleFortran> t_lay("t_lay", d_tmid.data(), ncol, nlay);
+        yakl::Array<double,2,memDevice,yakl::styleFortran> p_del("p_del", d_pdel.data(), ncol, nlay);
         yakl::Array<double,2,memDevice,yakl::styleFortran> p_lev("p_lev", d_pint.data(), ncol, nlay+1);
         yakl::Array<double,2,memDevice,yakl::styleFortran> t_lev("t_lev", d_tint.data(), ncol, nlay+1);
         yakl::Array<double,2,memDevice,yakl::styleFortran> sfc_alb_dir("sfc_alb_dir", d_sfc_alb_dir.data(), ncol, nswbands);
@@ -117,6 +119,11 @@ namespace scream {
         yakl::Array<double,2,memDevice,yakl::styleFortran> rei("rei", d_rei.data(), ncol, nlay);
         yakl::Array<double,1,memDevice,yakl::styleFortran> mu0("mu0", d_mu0.data(), ncol);
         yakl::Array<double,3,memDevice,yakl::styleFortran> gas_vmr("gas_vmr", d_gas_vmr.data(), ncol, nlay, ngas);
+
+        // Need to calculate a dummy pseudo_density for our test problem
+        parallel_for(Bounds<2>(nlay,ncol), YAKL_LAMBDA(int ilay, int icol) {
+            p_del(icol,ilay) = abs(p_lev(icol,ilay+1) - p_lev(icol,ilay));
+        });
 
         // Read in dummy Garand atmosphere; if this were an actual model simulation,
         // these would be passed as inputs to the driver

--- a/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
+++ b/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
@@ -141,8 +141,16 @@ namespace scream {
         });
         gas_concs.reset();
 
+        // Before running, make a copy of T_mid so we can see changes
+        auto T_mid0 = real2d("T_mid0", ncol, nlay);
+        t_lay.deep_copy_to(T_mid0);
+
         // Run driver
         ad.run(300.0);
+
+        // Dumb check to verify that we did indeed update temperature
+        REQUIRE(t_lay(1,1) != T_mid0(1,1));
+        T_mid0.deallocate();
 
         // Check values; need to get fluxes from field manager first
         // The AD should have called RRTMGP to calculate these values in the ad.run() call


### PR DESCRIPTION
Compute and apply radiative heating in the radiation interface code. This computes the atmosphere heating rate from the fluxes and applies the heating to the temperature field. This makes temperature a "computed" field in the radiation interface. Since radiation was not coupled with any other processes yet, this is BFB. Unit tests are added to test the routine added that computes the heating, and a very rudimentary test is added that verifies that temperature is updated. Fixes #953.