### PR TITLE
For Cori, add "module load perl5-extras"

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -180,6 +180,7 @@
         <command name="load">git</command>
         <command name="rm">cmake</command>
         <command name="load">cmake/3.14.4</command>
+        <command name="load">perl5-extras</command>
       </modules>
     </module_system>
 
@@ -332,6 +333,7 @@
         <command name="load">git</command>
         <command name="rm">cmake</command>
         <command name="load">cmake/3.14.4</command>
+        <command name="load">perl5-extras</command>
       </modules>
 
       <!--command name="list">&gt;&amp; ml.txt</command-->


### PR DESCRIPTION
For Cori, add "module load perl5-extras".
This will find the missing perl module and allow cases to work again.
Same fix applied to e3sm master https://github.com/E3SM-Project/E3SM/pull/4243
As no cases are working on Cori thought it would be good to make a quick fix.
[bfb]