### PR TITLE
Hot-fix for namelist variables that caused SCREAMv0 to fail building

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -813,8 +813,10 @@ add_default($nl,'use_hetfrz_classnuc');
 add_default($nl,'hist_hetfrz_classnuc');
 add_default($nl,'gw_convect_hcf');
 add_default($nl,'linoz_psc_t');
-add_default($nl,'micro_mg_dcs_tdep');
-add_default($nl,'micro_mincdnc');
+if ($cfg->get('microphys') =~ /^mg2/) {
+    add_default($nl,'micro_mg_dcs_tdep');
+    add_default($nl,'micro_mincdnc');
+}
 add_default($nl,'microp_aero_wsub_scheme');
 add_default($nl,'microp_aero_wsubmin');
 add_default($nl,'use_preexisting_ice');

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -101,8 +101,8 @@
       <value compset="_EAM%ADIAB"     >-phys adiabatic</value>
 
       <!-- SCREAM configurations -->
-      <value compset="_EAM%SCREAM-LR">-phys cam5 -shoc_sgs -microphys p3 -chem none -nlev 72 -rad rrtmgp -bc_dep_to_snow_updates</value>
-      <value compset="_EAM%SCREAM-HR">-phys cam5 -shoc_sgs -microphys p3 -chem none -nlev 128 -rad rrtmgp -bc_dep_to_snow_updates</value>
+      <value compset="_EAM%SCREAM-LR">-phys default -shoc_sgs -microphys p3 -chem none -nlev 72 -rad rrtmgp -bc_dep_to_snow_updates</value>
+      <value compset="_EAM%SCREAM-HR">-phys default -shoc_sgs -microphys p3 -chem none -nlev 128 -rad rrtmgp -bc_dep_to_snow_updates</value>
 
       <!-- Aquaplanet -->
       <value compset="_EAM%AQUA"   >-nlev 72 -clubb_sgs -microphys mg2 -aquaplanet -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -bc_dep_to_snow_updates </value>


### PR DESCRIPTION
Hot-fix for namelist variables that caused SCREAMv0 to fail during the build.

In particular, build-namelist could not find default namelist variables and
thus threw an error.  The namelist variables in question only had default values
assigned when microp_scheme=mg2.

These namelist variables were introduced during the upstream merge, and understandably
had not been tested when the microphysics scheme was P3 not MG2.