### PR TITLE
Small bugfixes from upstream-merge in EAM

### DIFF
--- a/components/eam/src/chemistry/utils/modal_aero_calcsize.F90
+++ b/components/eam/src/chemistry/utils/modal_aero_calcsize.F90
@@ -22,8 +22,6 @@ use constituents,     only: pcnst, cnst_name, cnst_get_ind
 
 use ref_pres,         only: top_lev => clim_modal_aero_top_lev
 
-use shr_log_mod ,     only: errMsg => shr_log_errMsg
-
 #ifdef MODAL_AERO
 
 use modal_aero_data, only: ntot_amode, numptr_amode, modename_amode

--- a/components/eam/src/dynamics/se/se_single_column_mod.F90
+++ b/components/eam/src/dynamics/se/se_single_column_mod.F90
@@ -38,8 +38,8 @@ subroutine scm_setinitial(elem)
   integer inumliq, inumice, icldliq, icldice
 
   if (.not. use_replay .and. get_nstep() .eq. 0 .and. par%dynproc) then
-    call cnst_get_ind('NUMLIQ', inumliq, abort=.false.)
-    call cnst_get_ind('NUMICE', inumice, abort=.false.)
+    call cnst_get_ind('NUMLIQ', inumliq, abrtf=.false.)
+    call cnst_get_ind('NUMICE', inumice, abrtf=.false.)
     call cnst_get_ind('CLDLIQ', icldliq)
     call cnst_get_ind('CLDICE', icldice)
     


### PR DESCRIPTION
This commit fixes a couple of bugs that were introduced from the upstream-merge
that caused the build to throw an error.

In one case a function was declared twice from a use module statement.

In the other case, the keyword for the optional "abort" argument has
changed, which of course didn't touch two lines of code unique to the
SCREAM code base.