### PR TITLE
use ekat::scalarize more in SHOC

### DIFF
--- a/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
@@ -85,14 +85,6 @@ void Functions<S,D>::shoc_assumed_pdf(
   // gnu and std=c++14. The macro ConstExceptGnu is defined in ekat_kokkos_types.hpp.
   ConstExceptGnu Int nlev_pack = ekat::npack<Spack>(nlev);
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
-
-    // Store active pack entries
-    const Smask is_last_pack(k == nlev_pack-1);
-    const int last_pack_indx = (nlev-1)%Spack::n;
-    const auto range = ekat::range<IntSmallPack>(k*Spack::n);
-    const Smask active_entries = (!is_last_pack ||
-                                  (is_last_pack && range < last_pack_indx));
-
     // Initialize cloud variables to zero
     shoc_cldfrac(k) = 0;
     if (k==0) { shoc_ql(k)[0] = 0; }
@@ -224,6 +216,9 @@ void Functions<S,D>::shoc_assumed_pdf(
       // Begin to compute cloud property statistics
       const Spack Tl1_1 = thl1_1/(ekat::pow(basepres/pval,(rair/cp)));
       const Spack Tl1_2 = thl1_2/(ekat::pow(basepres/pval,(rair/cp)));
+
+      const auto index_range = ekat::range<IntSmallPack>(k*Spack::n);
+      const Smask active_entries = (index_range < nlev);
 
       // Check to ensure Tl1_1 and Tl1_2 are not negative, endrun otherwise
       const auto is_neg_Tl1_1 = (Tl1_1 <= 0) && active_entries;

--- a/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
@@ -28,18 +28,17 @@ void Functions<S,D>
   const auto ggr = C::gravit;
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  const Int nlevi_pack = ekat::npack<Spack>(nlevi);
 
-  // Scalarize views for shifts
+  // Scalarize views for shifts and single entry access
   const auto s_dz_zt = scalarize(dz_zt);
   const auto s_wthl_sec = scalarize(wthl_sec);
   const auto s_thl_sec = scalarize(thl_sec);
   const auto s_w_sec = scalarize(w_sec);
   const auto s_tke = scalarize(tke);
+  const auto s_w3 = scalarize(w3);
 
   // Set lower condition: w3(i,nlevi) = 0
-  const Int last_pack_entry = (nlevi%Spack::n == 0 ? Spack::n-1 : nlevi%Spack::n-1);
-  w3(nlevi_pack-1)[last_pack_entry] = 0;
+  s_w3(nlevi-1) = 0;
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
     // Constants
@@ -115,7 +114,7 @@ void Functions<S,D>
   });
 
   // Set upper condition: w3(i,0) = 0
-  w3(0)[0] = 0;
+  s_w3(0) = 0;
 }
 
 } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_compute_shr_prod_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_shr_prod_impl.hpp
@@ -56,10 +56,9 @@ void Functions<S,D>
    * been taken into account for the TKE boundary condition,
    * thus zero out here
     */
-  sterm(0)[0]     = 0;
-  const Int nlevi_pack = ekat::npack<Spack>(nlevi);
-  const Int last_pack_entry = (nlevi%Spack::n == 0 ? Spack::n-1 : nlevi%Spack::n-1);
-  sterm(nlevi_pack-1)[last_pack_entry] = 0;
+  const auto s_sterm = ekat::scalarize(sterm);
+  s_sterm(0)       = 0;
+  s_sterm(nlevi-1) = 0;
 }
 
 } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_diag_second_shoc_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_second_shoc_moments_impl.hpp
@@ -37,14 +37,22 @@ void Functions<S,D>::diag_second_shoc_moments(const MemberType& team, const Int&
   shoc_diag_second_moments_srf(wthl_sfc, uw_sfc, vw_sfc, ustar2, wstar);
   team.team_barrier();
 
+  // Scalarize views for single entry access
+  const auto s_wthl_sec  = ekat::scalarize(wthl_sec);
+  const auto s_wqw_sec   = ekat::scalarize(wqw_sec);
+  const auto s_uw_sec    = ekat::scalarize(uw_sec);
+  const auto s_vw_sec    = ekat::scalarize(vw_sec);
+  const auto s_wtke_sec  = ekat::scalarize(wtke_sec);
+  const auto s_thl_sec   = ekat::scalarize(thl_sec);
+  const auto s_qw_sec    = ekat::scalarize(qw_sec);
+  const auto s_qwthl_sec = ekat::scalarize(qwthl_sec);
+
   // Diagnose the second order moments flux, for the lower boundary
-  const auto nlevi_npack = ekat::npack<Spack>(nlevi)-1;
-  const int nlevi_indx  = (nlevi-1)%Spack::n;
   shoc_diag_second_moments_lbycond(wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, ustar2, wstar,
-                                   wthl_sec(nlevi_npack)[nlevi_indx], wqw_sec(nlevi_npack)[nlevi_indx], 
-                                   uw_sec(nlevi_npack)[nlevi_indx], vw_sec(nlevi_npack)[nlevi_indx], 
-                                   wtke_sec(nlevi_npack)[nlevi_indx], thl_sec(nlevi_npack)[nlevi_indx], 
-                                   qw_sec(nlevi_npack)[nlevi_indx], qwthl_sec(nlevi_npack)[nlevi_indx]);
+                                   s_wthl_sec(nlevi-1), s_wqw_sec(nlevi-1),
+                                   s_uw_sec(nlevi-1), s_vw_sec(nlevi-1),
+                                   s_wtke_sec(nlevi-1), s_thl_sec(nlevi-1),
+                                   s_qw_sec(nlevi-1), s_qwthl_sec(nlevi-1));
   team.team_barrier();
 
   // Diagnose the second order moments, for points away from boundaries.  this is
@@ -56,9 +64,9 @@ void Functions<S,D>::diag_second_shoc_moments(const MemberType& team, const Int&
   team.team_barrier();
 
   // Diagnose the second order moments, calculate the upper boundary conditions
-  shoc_diag_second_moments_ubycond(thl_sec(0)[0], qw_sec(0)[0], wthl_sec(0)[0], 
-                                   wqw_sec(0)[0], qwthl_sec(0)[0], uw_sec(0)[0], 
-                                   vw_sec(0)[0], wtke_sec(0)[0]);
+  shoc_diag_second_moments_ubycond(s_thl_sec(0), s_qw_sec(0), s_wthl_sec(0),
+                                   s_wqw_sec(0), s_qwthl_sec(0), s_uw_sec(0),
+                                   s_vw_sec(0), s_wtke_sec(0));
 
   // Release temporary variables from the workspace
   workspace.template release_many_contiguous<3>(

--- a/components/scream/src/physics/shoc/shoc_eddy_diffusivities_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_eddy_diffusivities_impl.hpp
@@ -44,14 +44,13 @@ void Functions<S,D>::eddy_diffusivities(
   const Scalar Ckh_s_min = 0.1;
   const Scalar Ckm_s_min = 0.1;
 
-  // zt_grid at nlev
-  const Scalar zt_grid_1d = zt_grid((nlev-1)/Spack::n)[(nlev-1)%Spack::n];
+  const auto s_zt_grid = ekat::scalarize(zt_grid);
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
     // Dimensionless Okukhov length considering only
     // the lowest model grid layer height to scale
-    const auto z_over_L = zt_grid_1d/obklen;
+    const auto z_over_L = s_zt_grid(nlev-1)/obklen;
 
     // Compute diffusivity coefficient as function of dimensionless Obukhov,
     // given a critical value

--- a/components/scream/src/physics/shoc/shoc_grid_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_grid_impl.hpp
@@ -34,6 +34,7 @@ void Functions<S,D>::shoc_grid(
 
   const auto s_zi_grid = ekat::scalarize(zi_grid);
   const auto s_zt_grid = ekat::scalarize(zt_grid);
+  const auto s_dz_zi   = ekat::scalarize(dz_zi);
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
@@ -63,7 +64,7 @@ void Functions<S,D>::shoc_grid(
   });
 
   // Set lower condition for dz_zi
-  dz_zi((nlevi-1)/Spack::n)[(nlevi-1)%Spack::n] = zt_grid((nlev-1)/Spack::n)[(nlev-1)%Spack::n];
+  s_dz_zi(nlevi-1) = s_zt_grid(nlev-1);
 }
 
 } // namespace shoc

--- a/components/scream/src/physics/shoc/shoc_main_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_main_impl.hpp
@@ -124,14 +124,15 @@ void Functions<S,D>::shoc_main_internal(
     {"rho_zt", "shoc_qv", "dz_zt", "dz_zi", "tkh"},
     {&rho_zt, &shoc_qv, &dz_zt, &dz_zi, &tkh});
 
-  // View/pack indices for nlev, nlevi
-  const Int nlev_v = (nlev-1)/Spack::n;
-  const Int nlev_p = (nlev-1)%Spack::n;
-
-  // Local variables
+  // Local scalars
   Scalar se_b{0},   ke_b{0}, wv_b{0},   wl_b{0},
          se_a{0},   ke_a{0}, wv_a{0},   wl_a{0},
          ustar{0},  kbfs{0}, obklen{0}, ustar2{0}, wstar{0};
+
+  // Scalarize some views for single entry access
+  const auto s_thetal  = ekat::scalarize(thetal);
+  const auto s_shoc_ql = ekat::scalarize(shoc_ql);
+  const auto s_shoc_qv = ekat::scalarize(shoc_qv);
 
   // Compute integrals of static energy, kinetic energy, water vapor, and liquid water
   // for the computation of total energy before SHOC is called.  This is for an
@@ -162,12 +163,12 @@ void Functions<S,D>::shoc_main_internal(
                        shoc_qv);             // Output
 
     team.team_barrier();
-    shoc_diag_obklen(uw_sfc,vw_sfc,          // Input
-                     wthl_sfc, wqw_sfc,      // Input
-                    thetal(nlev_v)[nlev_p],  // Input
-                    shoc_ql(nlev_v)[nlev_p], // Input
-                    shoc_qv(nlev_v)[nlev_p], // Input
-                    ustar,kbfs,obklen);      // Output
+    shoc_diag_obklen(uw_sfc,vw_sfc,     // Input
+                     wthl_sfc, wqw_sfc, // Input
+                     s_thetal(nlev-1),  // Input
+                     s_shoc_ql(nlev-1), // Input
+                     s_shoc_qv(nlev-1), // Input
+                     ustar,kbfs,obklen); // Output
 
     pblintd(team,nlev,nlevi,npbl,     // Input
             zt_grid,zi_grid,thetal,   // Input
@@ -263,12 +264,12 @@ void Functions<S,D>::shoc_main_internal(
                      shoc_qv);             // Output
 
   team.team_barrier();
-  shoc_diag_obklen(uw_sfc,vw_sfc,           // Input
-                   wthl_sfc,wqw_sfc,        // Input
-                   thetal(nlev_v)[nlev_p],  // Input
-                   shoc_ql(nlev_v)[nlev_p], // Input
-                   shoc_qv(nlev_v)[nlev_p], // Input
-                   ustar,kbfs,obklen);      // Output
+  shoc_diag_obklen(uw_sfc,vw_sfc,      // Input
+                   wthl_sfc,wqw_sfc,   // Input
+                   s_thetal(nlev-1),   // Input
+                   s_shoc_ql(nlev-1),  // Input
+                   s_shoc_qv(nlev-1),  // Input
+                   ustar,kbfs,obklen); // Output
 
   pblintd(team,nlev,nlevi,npbl,zt_grid,   // Input
           zi_grid,thetal,shoc_ql,shoc_qv, // Input

--- a/components/scream/src/physics/shoc/shoc_pblintd_check_pblh_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_pblintd_check_pblh_impl.hpp
@@ -28,9 +28,8 @@ void Functions<S,D>::pblintd_check_pblh(const Int& nlevi, const Int& npbl,
    // latitude value for f so that c = 0.07/f = 700.  Also, do not allow
    // PBL to exceed some maximum (npbl) number of allowable points
    //
-   const auto npbl_pack = (nlevi-npbl-1)/Spack::n;
-   const auto npbl_indx = (nlevi-npbl-1)%Spack::n;
-   if (check) pblh = z(npbl_pack)[npbl_indx];
+   const auto s_z = ekat::scalarize(z);
+   if (check) pblh = s_z(nlevi-npbl-1);
    pblh = ekat::impl::max(pblh, 700*ustar);
 }
 

--- a/components/scream/src/physics/shoc/shoc_pblintd_surf_temp_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_pblintd_surf_temp_impl.hpp
@@ -25,20 +25,21 @@ void Functions<S,D>::pblintd_surf_temp(const Int& nlev, const Int& nlevi, const 
   const Scalar sffrac=  0.1;
   const Scalar binm  = betam*sffrac;
 
+  // Scalarize views for single entry access
+  const auto s_z    = ekat::scalarize(z);
+  const auto s_thv  = ekat::scalarize(thv);
+  const auto s_rino = ekat::scalarize(rino);
+
   // Estimate an effective surface temperature to account for surface
   // fluctuations
   if (check) {
-    const auto view_indx = (nlevi-npbl-1)/Spack::n;
-    const auto pack_indx = (nlevi-npbl-1)%Spack::n;
-    pblh = z(view_indx)[pack_indx];
+    pblh = s_z(nlevi-npbl-1);
   }
   check = (kbfs > 0);
 
-  const auto view_indx = (nlev-1)/Spack::n;
-  const auto pack_indx = (nlev-1)%Spack::n;
-  tlv = thv(view_indx)[pack_indx];
+  tlv = s_thv(nlev-1);
   if (check) {
-    rino(view_indx)[pack_indx] = 0;
+    s_rino(nlev-1) = 0;
     const Scalar phiminv = std::cbrt(1-binm*pblh/obklen);
     tlv += kbfs*fak/(ustar*phiminv);
   }


### PR DESCRIPTION
Adds a few instances of using `ekat::scalarize` instead of using pack index logic. Only an attempt to make the code more readable.