### PR TITLE
Bugfix to namelist defaults in EAM for HR compset with ne4

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1120,7 +1120,9 @@
 <!-- zm conv -->
 <zmconv_c0_lnd                                                        > 0.0030D0 </zmconv_c0_lnd>
 <zmconv_c0_lnd  microphys="p3"  clubb_sgs="1"    phys="default"       > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                  hgrid="ne120np4" phys="default"       > 0.0035D0 </zmconv_c0_lnd>
 <zmconv_c0_ocn                                                        > 0.0030D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                  hgrid="ne120np4" phys="default"       > 0.0035D0 </zmconv_c0_ocn>
 
 <zmconv_tau			                                                      > 3600</zmconv_tau>
 <zmconv_alfa			                                                      > 0.1</zmconv_alfa>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -29,7 +29,8 @@
 <dtime dyn="sld"                   >3600</dtime>
 
 <!-- Initial conditions -->
-<ncdata           hgrid="64x128"    nlev="72"              ic_ymd="101" >atm/cam/inic/gaus/cami_0000-01-01_64x128_L72_c031210.nc</ncdata>
+<ncdata          hgrid="64x128"   nlev="72"             ic_ymd="101" >atm/cam/inic/gaus/cami_0000-01-01_64x128_L72_c031210.nc</ncdata>
+<ncdata dyn="se" hgrid="ne4np4"   nlev="128"            ic_ymd="101" >atm/cam/inic/homme/cami_mam3_Linoz_ne4np4_L128_20200205.nc</ncdata>
 <ncdata dyn="se" hgrid="ne4np4"   nlev="72"             ic_ymd="101" >atm/cam/inic/homme/cami_mam3_Linoz_ne4np4_L72_c160909.nc</ncdata>
 <ncdata dyn="se" hgrid="ne4np4"   nlev="30"             ic_ymd="101" >atm/cam/inic/homme/cami_mam3_0000-01-01_ne4np4_L30_c161102.nc</ncdata>
 <ncdata dyn="se" hgrid="ne11np4"  nlev="72"             ic_ymd="101" >atm/cam/inic/homme/cami_mam3_Linoz_ne11np4_L72_c160622.nc</ncdata>


### PR DESCRIPTION
This commit fixes a bug where the default ncdata entry for the case
when the ne4np4 grid is used with 128 levels was deleted.
This caused the build to fail when running the HR compsets at coarse resolution
because no default ncdata value was detected.

The entry for ne4np4 w/ 128 levels was inadvertantly deleted during an upstream
merge.

[BFB]