### PR TITLE
Add flag to register SPA variables with PBUF only when SPA is active

### DIFF
--- a/components/eam/src/physics/cam/micro_p3_interface.F90
+++ b/components/eam/src/physics/cam/micro_p3_interface.F90
@@ -295,7 +295,9 @@ end subroutine micro_p3_readnl
    call pbuf_add_field('QV_PREV',     'global',dtype_r8,(/pcols,pver/), qv_prev_idx)
    call pbuf_add_field('T_PREV',      'global',dtype_r8,(/pcols,pver/), t_prev_idx)
  !! for prescribed CCN
-   call pbuf_add_field('MON_CCN',  'global', dtype_r8,(/pcols,pver,12/),mon_ccn_idx)
+   if (do_prescribed_CCN) then
+      call pbuf_add_field('MON_CCN',  'global', dtype_r8,(/pcols,pver,12/),mon_ccn_idx)
+   end if
 
    if (masterproc) write(iulog,'(A20)') '    P3 register finished'
   end subroutine micro_p3_register

--- a/components/eam/src/physics/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/rrtmgp/radiation.F90
@@ -346,10 +346,12 @@ contains
       end if
 
     !for SPA
-      call pbuf_add_field('ATBLM', 'global', dtype_r8, (/pcols,pverp,nlwbands,12/), aer_tau_bnd_lw_mon_idx)
-      call pbuf_add_field('ATBSM', 'global', dtype_r8, (/pcols,pverp,nswbands,12/), aer_tau_bnd_sw_mon_idx)
-      call pbuf_add_field('ASBSM', 'global', dtype_r8, (/pcols,pverp,nswbands,12/), aer_ssa_bnd_sw_mon_idx)
-      call pbuf_add_field('AABSM', 'global', dtype_r8, (/pcols,pverp,nswbands,12/), aer_asm_bnd_sw_mon_idx)
+      if (do_SPA_optics) then
+         call pbuf_add_field('ATBLM', 'global', dtype_r8, (/pcols,pverp,nlwbands,12/), aer_tau_bnd_lw_mon_idx)
+         call pbuf_add_field('ATBSM', 'global', dtype_r8, (/pcols,pverp,nswbands,12/), aer_tau_bnd_sw_mon_idx)
+         call pbuf_add_field('ASBSM', 'global', dtype_r8, (/pcols,pverp,nswbands,12/), aer_ssa_bnd_sw_mon_idx)
+         call pbuf_add_field('AABSM', 'global', dtype_r8, (/pcols,pverp,nswbands,12/), aer_asm_bnd_sw_mon_idx)
+      end if
 
    end subroutine radiation_register
 


### PR DESCRIPTION
This commit makes sure that PBUF variables intended for use only when SPA is active are only registered with the PBUF when SPA is active.

This remedies an issue where the out-of-the-box SCREAMv0 had difficulty
writing restart files given the size of the SPA PBUF variables footprint.

A subsequent PR will have to address the issue writing a restart when SPA
is active.

[BFB]