### PR TITLE
Should not clean here, breaks AUTO baselines

### DIFF
--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -602,9 +602,6 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         print("Generating baselines for ref {}".format(self._baseline_ref))
         print("###############################################################################")
 
-        # First, create baseline directory for this test. If existing, nuke the content
-        self.create_tests_dirs(self._baseline_dir, True)
-
         commit = get_current_commit(commit=self._baseline_ref)
 
         # Switch to the baseline commit


### PR DESCRIPTION
Do a full clean at the beginning of generate_all_baselines deletes all pre-existing baselines that we were going to use later in the main testing. There is already code in the __init__ to ensure the baseline directories exist.