### PR TITLE
Add support for building cprnc

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -306,6 +306,8 @@ add_custom_target(baseline_cxx)
 add_subdirectory(src)
 if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)
+  include(BuildCprnc)
+  BuildCprnc()
 endif()
 
 # Generate scream_config.h and scream_config.f

--- a/components/scream/cmake/BuildCprnc.cmake
+++ b/components/scream/cmake/BuildCprnc.cmake
@@ -1,0 +1,21 @@
+# This cmake utility allows you to build cprnc just by adding
+#
+#   Include(BuildCprnc)
+#   BuildCprnc()
+#
+# to your CMakeLists.txt.
+
+function(BuildCprnc)
+
+  set(BLDROOT ${PROJECT_BINARY_DIR}/externals/cprnc)
+  file(WRITE ${BLDROOT}/Macros.cmake
+"
+set(SCC ${CMAKE_C_COMPILER})
+set(SFC ${CMAKE_Fortran_COMPILER})
+set(FFLAGS \"${CMAKE_Fortran_FLAGS}\")
+set(NETCDF_PATH ${NetCDF_Fortran_PATHS})
+"
+)
+  set(ENV{CIMEROOT} ${PROJECT_SOURCE_DIR}/../../cime)
+  add_subdirectory($ENV{CIMEROOT}/tools/cprnc ${BLDROOT})
+endfunction()


### PR DESCRIPTION
There has been interest in potentially using the CIME tool, cprnc, in SCREAM. The simplest way to offer it is to build it as an external. I little bit of hacky stuff is need to spoof the CIME Macros.cmake file which the cprnc CMake system expects.