### PR TITLE
add data copy to radiation-ad

### DIFF
--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -88,9 +88,6 @@ public:
       "co" , "ch4", "o2", "n2"
   };
 
-private: 
-    void require_unpadded(const Field<const Real>& f);
-
 };  // class RRTMGPRadiation
 
 }  // namespace scream

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -33,9 +33,10 @@ namespace scream {
          * Main driver code to run RRTMGP
          */
         extern void rrtmgp_main(
-                real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev, 
+                const int ncol, const int nlay,
+                real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
-                real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, 
+                real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0,
                 real2d &lwp, real2d &iwp, real2d &real, real2d &rei,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
                 real2d &lw_flux_up, real2d &lw_flux_dn);
@@ -47,6 +48,7 @@ namespace scream {
          * Shortwave driver (called by rrtmgp_main)
          */
         extern void rrtmgp_sw(
+                const int ncol, const int nlay,
                 GasOpticsRRTMGP &k_dist, 
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev, 
                 GasConcs &gas_concs, 
@@ -56,6 +58,7 @@ namespace scream {
          * Longwave driver (called by rrtmgp_main)
          */
         extern void rrtmgp_lw(
+                const int ncol, const int nlay,
                 GasOpticsRRTMGP &k_dist,
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,

--- a/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
@@ -89,6 +89,7 @@ int main (int argc, char** argv) {
     // NOTE: these will get replaced with AD stuff that handles these
     std::cout << "rrtmgp_main..." << std::endl;
     rrtmgp::rrtmgp_main(
+        ncol, nlay,
         p_lay, t_lay, p_lev, t_lev, gas_concs,
         sfc_alb_dir, sfc_alb_dif, mu0,
         lwp, iwp, rel, rei,

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
@@ -97,7 +97,8 @@ int main(int argc, char** argv) {
     // Run RRTMGP code on dummy atmosphere
     std::cout << "Run RRTMGP...\n";
     scream::rrtmgp::rrtmgp_main(
-            p_lay, t_lay, p_lev, t_lev, gas_concs, 
+            ncol, nlay,
+            p_lay, t_lay, p_lev, t_lev, gas_concs,
             sfc_alb_dir, sfc_alb_dif, mu0,
             lwp, iwp, rel, rei,
             sw_flux_up, sw_flux_dn, sw_flux_dir,


### PR DESCRIPTION
In `atmosphere_radiation.cpp` and `rrtmgp_stand_alone.cpp`, copy data to and from YAKL arrays. Previously, no copy was being performed, and (since YAKL arrays there were assuming `ncol` as the fastest index) the Kokkos views in the FM had incorrect entries.

A consequence of this PR is that the FM can now contain padded views.

This PR also updates the RRTMGP submodule and corrects calls to RRTMGP to have correct inputs based on the updates.