### PR TITLE
add memory buffer to AD

### DIFF
--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -327,6 +327,9 @@ void AtmosphereDriver::initialize_atm_procs ()
     m_atm_process_group->set_updated_group(group);
   }
 
+  // Initialize memory buffer for all atm processes
+  m_atm_process_group->initialize_atm_memory_buffer(memory_buffer);
+
   // Initialize the processes
   m_atm_process_group->initialize(m_current_ts);
 

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -9,6 +9,7 @@
 #include "share/scream_types.hpp"
 #include "share/io/output_manager.hpp"
 #include "share/io/scorpio_input.hpp"
+#include "share/atm_process/ATMBufferManager.hpp"
 
 #include "ekat/mpi/ekat_comm.hpp"
 #include "ekat/ekat_parameter_list.hpp"
@@ -119,6 +120,8 @@ protected:
   ekat::ParameterList                                 m_atm_params;
 
   OutputManager                                       m_output_manager;
+
+  ATMBufferManager                                    memory_buffer;
 
   // Surface coupling stuff
   std::shared_ptr<SurfaceCoupling>            m_surface_coupling;

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -100,9 +100,13 @@ int P3Microphysics::requested_buffer_size_in_bytes() const
   const Int nk_pack = ekat::npack<Spack>(m_num_levs);
 
   // Number of Reals needed by local views in the interface
-  const int interface_request = Buffer::num_1d_scalar*m_num_cols*sizeof(Real) +
-                                Buffer::num_2d_vector*m_num_cols*nk_pack*sizeof(Spack) +
-                                Buffer::num_2d_scalar*m_num_cols*3*sizeof(Real);
+  const int interface_request =
+      // 1d view scalar, size (ncol)
+      Buffer::num_1d_scalar*m_num_cols*sizeof(Real) +
+      // 2d view packed, size (ncol, nlev_packs)
+      Buffer::num_2d_vector*m_num_cols*nk_pack*sizeof(Spack) +
+      // 2d view scalar, size (ncol, 3)
+      m_num_cols*3*sizeof(Real);
 
   // Number of Reals needed by the WorkspaceManager passed to p3_main
   const auto policy       = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -95,6 +95,79 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
 }
 
 // =========================================================================================
+int P3Microphysics::requested_buffer_size_in_bytes() const
+{
+  const Int nk_pack = ekat::npack<Spack>(m_num_levs);
+
+  // Number of Reals needed by local views in the interface
+  const int interface_request = Buffer::num_1d_scalar*m_num_cols*sizeof(Real) +
+                                Buffer::num_2d_vector*m_num_cols*nk_pack*sizeof(Spack) +
+                                Buffer::num_2d_scalar*m_num_cols*3*sizeof(Real);
+
+  // Number of Reals needed by the WorkspaceManager passed to p3_main
+  const auto policy       = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);
+  const int wsm_request   = WSM::get_total_bytes_needed(nk_pack, 52, policy);
+
+  return interface_request + wsm_request;
+}
+
+// =========================================================================================
+void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
+{
+  EKAT_REQUIRE_MSG(buffer_manager.allocated_bytes() >= requested_buffer_size_in_bytes(), "Error! Buffers size not sufficient.\n");
+
+  Real* mem = reinterpret_cast<Real*>(buffer_manager.get_memory());
+
+  // 1d scalar views
+  m_buffer.precip_liq_surf = decltype(m_buffer.precip_liq_surf)(mem, m_num_cols);
+  mem += m_buffer.precip_liq_surf.size();
+  m_buffer.precip_ice_surf = decltype(m_buffer.precip_ice_surf)(mem, m_num_cols);
+  mem += m_buffer.precip_ice_surf.size();
+
+  // 2d scalar views
+  m_buffer.col_location = decltype(m_buffer.col_location)(mem, m_num_cols, 3);
+  mem += m_buffer.col_location.size();
+
+  Spack* s_mem = reinterpret_cast<Spack*>(mem);
+
+  // 2d packed views
+  const Int nk_pack = ekat::npack<Spack>(m_num_levs);
+
+  m_buffer.inv_exner = decltype(m_buffer.inv_exner)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.inv_exner.size();
+  m_buffer.th_atm = decltype(m_buffer.th_atm)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.th_atm.size();
+  m_buffer.cld_frac_l = decltype(m_buffer.cld_frac_l)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.cld_frac_l.size();
+  m_buffer.cld_frac_i = decltype(m_buffer.cld_frac_i)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.cld_frac_i.size();
+  m_buffer.cld_frac_r = decltype(m_buffer.cld_frac_r)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.cld_frac_r.size();
+  m_buffer.dz = decltype(m_buffer.dz)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.dz.size();
+  m_buffer.qv2qi_depos_tend = decltype(m_buffer.qv2qi_depos_tend)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.qv2qi_depos_tend.size();
+  m_buffer.rho_qi = decltype(m_buffer.rho_qi)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.rho_qi.size();
+  m_buffer.precip_liq_flux = decltype(m_buffer.precip_liq_flux)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.precip_liq_flux.size();
+  m_buffer.precip_ice_flux = decltype(m_buffer.precip_ice_flux)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.precip_ice_flux.size();
+
+  // WSM data
+  m_buffer.wsm_data = s_mem;
+
+  // Compute workspace manager size to check used memory
+  // vs. requested memory
+  const auto policy  = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);
+  const int wsm_size = WSM::get_total_bytes_needed(nk_pack, 52, policy)/sizeof(Spack);
+  s_mem += wsm_size;
+
+  int used_mem = (reinterpret_cast<Real*>(s_mem) - buffer_manager.get_memory())*sizeof(Real);
+  EKAT_REQUIRE_MSG(used_mem==requested_buffer_size_in_bytes(), "Error! Used memory != requested memory for P3Microphysics.");
+}
+
+// =========================================================================================
 void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
 {
   m_current_ts = t0;
@@ -112,12 +185,15 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   const  auto& cld_frac_t     = m_p3_fields_in["cldfrac_tot"].get_reshaped_view<const Pack**>();
   const  auto& zi             = m_p3_fields_in["z_int"].get_reshaped_view<const Pack**>();
   const  auto& qv             = m_p3_fields_out["qv"].get_reshaped_view<Pack**>();
-  view_2d inv_exner("inv_exner",m_num_cols,nk_pack);
-  view_2d th_atm("th_atm",m_num_cols,nk_pack);
-  view_2d cld_frac_l("cld_frac_l",m_num_cols,nk_pack);
-  view_2d cld_frac_i("cld_frac_i",m_num_cols,nk_pack);
-  view_2d cld_frac_r("cld_frac_r",m_num_cols,nk_pack);
-  view_2d dz("dz",m_num_cols,nk_pack);
+
+  // Alias local variables from temporary buffer
+  auto inv_exner  = m_buffer.inv_exner;
+  auto th_atm     = m_buffer.th_atm;
+  auto cld_frac_l = m_buffer.cld_frac_l;
+  auto cld_frac_i = m_buffer.cld_frac_i;
+  auto cld_frac_r = m_buffer.cld_frac_r;
+  auto dz         = m_buffer.dz;
+
   // -- Set values for the post-amble structure
   p3_preproc.set_variables(m_num_cols,nk_pack,pmid,pseudo_density,T_atm,cld_frac_t,qv,
                         inv_exner, th_atm, cld_frac_l, cld_frac_i, cld_frac_r, dz);
@@ -149,22 +225,15 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   diag_inputs.dz              = p3_preproc.dz;
   diag_inputs.inv_exner       = p3_preproc.inv_exner;
   // --Diagnostic Outputs
-  view_1d precip_liq_surf("precip_liq_surf",m_num_cols);
-  view_1d precip_ice_surf("precip_ice_surf",m_num_cols);
-  view_2d qv2qi_depos_tend("qv2qi_depos_tend",m_num_cols,m_num_levs);
-  view_2d rho_qi("rho_qi",m_num_cols,m_num_levs);
-  view_2d precip_liq_flux("precip_liq_flux",m_num_cols,m_num_levs);
-  view_2d precip_ice_flux("precip_ice_flux",m_num_cols,m_num_levs);
-
   diag_outputs.diag_eff_radius_qc = m_p3_fields_out["eff_radius_qc"].get_reshaped_view<Pack**>();
   diag_outputs.diag_eff_radius_qi = m_p3_fields_out["eff_radius_qi"].get_reshaped_view<Pack**>();
 
-  diag_outputs.precip_liq_surf  = precip_liq_surf; 
-  diag_outputs.precip_ice_surf  = precip_ice_surf; 
-  diag_outputs.qv2qi_depos_tend = qv2qi_depos_tend; 
-  diag_outputs.rho_qi           = rho_qi;
-  diag_outputs.precip_liq_flux  = precip_liq_flux;
-  diag_outputs.precip_ice_flux  = precip_ice_flux;
+  diag_outputs.precip_liq_surf  = m_buffer.precip_liq_surf;
+  diag_outputs.precip_ice_surf  = m_buffer.precip_ice_surf;
+  diag_outputs.qv2qi_depos_tend = m_buffer.qv2qi_depos_tend;
+  diag_outputs.rho_qi           = m_buffer.rho_qi;
+  diag_outputs.precip_liq_flux  = m_buffer.precip_liq_flux;
+  diag_outputs.precip_ice_flux  = m_buffer.precip_ice_flux;
   // --Infrastructure
   // dt is passed as an argument to run_impl
   infrastructure.it  = 0;
@@ -174,8 +243,7 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   infrastructure.kte = m_num_levs-1;
   infrastructure.predictNc = true;     // Hard-coded for now, TODO: make this a runtime option 
   infrastructure.prescribedCCN = true; // Hard-coded for now, TODO: make this a runtime option
-  sview_2d col_location("col_location", m_num_cols, 3);
-  infrastructure.col_location = col_location; // TODO: Initialize this here and now when P3 has access to lat/lon for each column.
+  infrastructure.col_location = m_buffer.col_location; // TODO: Initialize this here and now when P3 has access to lat/lon for each column.
   // --History Only
   history_only.liq_ice_exchange = m_p3_fields_out["micro_liq_ice_exchange"].get_reshaped_view<Pack**>();
   history_only.vap_liq_exchange = m_p3_fields_out["micro_vap_liq_exchange"].get_reshaped_view<Pack**>();
@@ -216,9 +284,14 @@ void P3Microphysics::run_impl (const Real dt)
   infrastructure.dt = dt;
   infrastructure.it++;
 
+  // WorkspaceManager for internal local variables
+  const Int nk_pack = ekat::npack<Spack>(m_num_levs);
+  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);
+  ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(m_buffer.wsm_data, nk_pack, 52, policy);
+
   // Run p3 main
   P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
-                                       history_only, m_num_cols, m_num_levs);
+               history_only, workspace_mgr, m_num_cols, m_num_levs);
 
   // Conduct the post-processing of the p3_main output.
   Kokkos::parallel_for(

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -214,23 +214,25 @@ public:
 
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {
+    // 1d view scalar, size (ncol)
     static constexpr int num_1d_scalar = 2;
-    static constexpr int num_2d_scalar = 1;
+    // 2d view packed, size (ncol, nlev_packs)
     static constexpr int num_2d_vector = 10;
 
-    uview_1d  precip_liq_surf;
-    uview_1d  precip_ice_surf;
+    uview_1d precip_liq_surf;
+    uview_1d precip_ice_surf;
+    uview_2d inv_exner;
+    uview_2d th_atm;
+    uview_2d cld_frac_l;
+    uview_2d cld_frac_i;
+    uview_2d cld_frac_r;
+    uview_2d dz;
+    uview_2d qv2qi_depos_tend;
+    uview_2d rho_qi;
+    uview_2d precip_liq_flux;
+    uview_2d precip_ice_flux;
+
     suview_2d col_location;
-    uview_2d  inv_exner;
-    uview_2d  th_atm;
-    uview_2d  cld_frac_l;
-    uview_2d  cld_frac_i;
-    uview_2d  cld_frac_r;
-    uview_2d  dz;
-    uview_2d  qv2qi_depos_tend;
-    uview_2d  rho_qi;
-    uview_2d  precip_liq_flux;
-    uview_2d  precip_ice_flux;
 
     Spack* wsm_data;
   };

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -27,11 +27,17 @@ namespace scream
   using Smask        = typename P3F::Smask;
   using Pack         = ekat::Pack<Real,Spack::n>;
   using PF           = scream::PhysicsFunctions<DefaultDevice>;
+  using KT           = ekat::KokkosTypes<DefaultDevice>;
+  using WSM          = ekat::WorkspaceManager<Spack, KT::Device>;
 
   using view_1d  = typename P3F::view_1d<Real>;
   using view_2d  = typename P3F::view_2d<Spack>;
   using view_2d_const  = typename P3F::view_2d<const Spack>;
   using sview_2d = typename KokkosTypes<DefaultDevice>::template view_2d<Real>;
+
+  using uview_1d  = Unmanaged<view_1d>;
+  using uview_2d  = Unmanaged<view_2d>;
+  using suview_2d = Unmanaged<sview_2d>;
 
 class P3Microphysics : public AtmosphereProcess
 {
@@ -206,6 +212,29 @@ public:
   }; // p3_postamble
   /* --------------------------------------------------------------------------------------------*/
 
+  // Structure for storing local variables initialized using the ATMBufferManager
+  struct Buffer {
+    static constexpr int num_1d_scalar = 2;
+    static constexpr int num_2d_scalar = 1;
+    static constexpr int num_2d_vector = 10;
+
+    uview_1d  precip_liq_surf;
+    uview_1d  precip_ice_surf;
+    suview_2d col_location;
+    uview_2d  inv_exner;
+    uview_2d  th_atm;
+    uview_2d  cld_frac_l;
+    uview_2d  cld_frac_i;
+    uview_2d  cld_frac_r;
+    uview_2d  dz;
+    uview_2d  qv2qi_depos_tend;
+    uview_2d  rho_qi;
+    uview_2d  precip_liq_flux;
+    uview_2d  precip_ice_flux;
+
+    Spack* wsm_data;
+  };
+
 protected:
 
   // The three main overrides for the subcomponent
@@ -217,6 +246,12 @@ protected:
   void set_required_field_impl (const Field<const Real>& f);
   void set_computed_field_impl (const Field<      Real>& f);
 
+  // Computes total number of Reals needed for local variables
+  int requested_buffer_size_in_bytes() const;
+
+  // Set local variables using memory provided by
+  // the ATMBufferManager
+  void init_buffers(const ATMBufferManager &buffer_manager);
 
   std::map<std::string,const_field_type>  m_p3_fields_in;
   std::map<std::string,field_type>        m_p3_fields_out;
@@ -244,6 +279,9 @@ protected:
   Int m_num_cols;
   Int m_num_levs;
   Int m_nk_pack;
+
+  // Struct which contains local variables
+  Buffer m_buffer;
 
   // Store the structures for each arguement to p3_main;
   P3F::P3PrognosticState   prog_state;

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -87,7 +87,8 @@ struct Functions
 
   using MemberType = typename KT::MemberType;
 
-  using Workspace = typename ekat::WorkspaceManager<Spack, Device>::Workspace;
+  using WorkspaceManager = typename ekat::WorkspaceManager<Spack, Device>;
+  using Workspace        = typename WorkspaceManager::Workspace;
 
   // This struct stores prognostic variables evolved by P3.
   struct P3PrognosticState {
@@ -956,6 +957,7 @@ struct Functions
     const P3DiagnosticOutputs& diagnostic_outputs,
     const P3Infrastructure& infrastructure,
     const P3HistoryOnly& history_only,
+    const WorkspaceManager& workspace_mgr,
     Int nj, // number of columns
     Int nk); // number of vertical cells per column
 

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -914,6 +914,7 @@ Int Functions<S,D>
   const P3DiagnosticOutputs& diagnostic_outputs,
   const P3Infrastructure& infrastructure,
   const P3HistoryOnly& history_only,
+  const WorkspaceManager& workspace_mgr,
   Int nj,
   Int nk)
 {
@@ -925,8 +926,6 @@ Int Functions<S,D>
 
   const Int nk_pack = ekat::npack<Spack>(nk);
   const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
-
-  ekat::WorkspaceManager<Spack, Device> workspace_mgr(nk_pack, 52, policy);
 
   // load constants into local vars
   const     Scalar inv_dt          = 1 / infrastructure.dt;

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -1,6 +1,7 @@
 #ifndef SCREAM_RRTMGP_RADIATION_HPP
 #define SCREAM_RRTMGP_RADIATION_HPP
 
+#include "physics/rrtmgp/scream_rrtmgp_interface.hpp"
 #include "share/atm_process/atmosphere_process.hpp"
 #include "ekat/ekat_parameter_list.hpp"
 #include <string>
@@ -88,6 +89,62 @@ public:
       "co" , "ch4", "o2", "n2"
   };
 
+  // Structure for storing local variables initialized using the ATMBufferManager
+  struct Buffer {
+    static constexpr int num_1d_ncol        = 1;
+    static constexpr int num_1d_string_ngas = 1;
+    static constexpr int num_2d_nlay        = 14;
+    static constexpr int num_2d_nlay_p1     = 7;
+    static constexpr int num_2d_nswbands    = 2;
+    static constexpr int num_3d_ngas        = 1;
+
+    // 1d size (ncol)
+    real1d mu0;
+
+    // 2d size (ncol, nlay)
+    real2d p_lay;
+    real2d t_lay;
+    real2d p_del;
+    real2d qc;
+    real2d qi;
+    real2d cldfrac_tot;
+    real2d eff_radius_qc;
+    real2d eff_radius_qi;
+    real2d tmp2d;
+    real2d lwp;
+    real2d iwp;
+    real2d sw_heating;
+    real2d lw_heating;
+    real2d rad_heating;
+
+    // 2d size (ncol, nlay+1)
+    real2d p_lev;
+    real2d t_lev;
+    real2d sw_flux_up;
+    real2d sw_flux_dn;
+    real2d sw_flux_dn_dir;
+    real2d lw_flux_up;
+    real2d lw_flux_dn;
+
+    // 2d size (ncol, nswbands)
+    real2d sfc_alb_dir;
+    real2d sfc_alb_dif;
+
+    // 3d size (ncol, nlay, ngas)
+    real3d gas_vmr;
+  };
+
+protected:
+
+  // Computes total number of Reals needed for local variables
+  int requested_buffer_size_in_bytes() const;
+
+  // Set local variables using memory provided by
+  // the ATMBufferManager
+  void init_buffers(const ATMBufferManager &buffer_manager);
+
+  // Struct which contains local variables
+  Buffer m_buffer;
 };  // class RRTMGPRadiation
 
 }  // namespace scream

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -93,6 +93,7 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   // Tracer group
   add_group<Updated>("tracers",grid->name(),Bundling::Required);
 }
+
 // =========================================================================================
 void SHOCMacrophysics::
 set_updated_group (const FieldGroup<Real>& group)
@@ -114,6 +115,130 @@ set_updated_group (const FieldGroup<Real>& group)
 
   // Calculate number of advected tracers
   m_num_tracers = group.m_info->size();
+}
+
+// =========================================================================================
+int SHOCMacrophysics::requested_buffer_size_in_bytes() const
+{
+  const int nlev_packs       = ekat::npack<Spack>(m_num_levs);
+  const int nlevi_packs      = ekat::npack<Spack>(m_num_levs+1);
+  const int num_tracer_packs = ekat::npack<Spack>(m_num_tracers);
+
+  // Number of Reals needed by local views in the interface
+  const int interface_request = Buffer::num_1d_scalar*m_num_cols*sizeof(Real) +
+                                Buffer::num_2d_vector_mid*m_num_cols*nlev_packs*sizeof(Spack) +
+                                Buffer::num_2d_vector_int*m_num_cols*nlevi_packs*sizeof(Spack) +
+                                Buffer::num_2d_vector_tr*m_num_cols*num_tracer_packs*sizeof(Spack);
+
+  // Number of Reals needed by the WorkspaceManager passed to shoc_main
+  const auto policy       = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
+  const int n_wind_slots  = ekat::npack<Spack>(2)*Spack::n;
+  const int n_trac_slots  = ekat::npack<Spack>(m_num_tracers+3)*Spack::n;
+  const int wsm_request   = WSM::get_total_bytes_needed(nlevi_packs, 13+(n_wind_slots+n_trac_slots), policy);
+
+  return interface_request + wsm_request;
+}
+
+// =========================================================================================
+void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
+{
+  EKAT_REQUIRE_MSG(buffer_manager.allocated_bytes() >= requested_buffer_size_in_bytes(), "Error! Buffers size not sufficient.\n");
+
+  Real* mem = reinterpret_cast<Real*>(buffer_manager.get_memory());
+
+  // 1d scalar views
+  m_buffer.cell_length = decltype(m_buffer.cell_length)(mem, m_num_cols);
+  mem += m_buffer.cell_length.size();
+  m_buffer.wpthlp_sfc = decltype(m_buffer.wpthlp_sfc)(mem, m_num_cols);
+  mem += m_buffer.wpthlp_sfc.size();
+  m_buffer.wprtp_sfc = decltype(m_buffer.wprtp_sfc)(mem, m_num_cols);
+  mem += m_buffer.wprtp_sfc.size();
+  m_buffer.upwp_sfc = decltype(m_buffer.upwp_sfc)(mem, m_num_cols);
+  mem += m_buffer.upwp_sfc.size();
+  m_buffer.vpwp_sfc = decltype(m_buffer.vpwp_sfc)(mem, m_num_cols);
+  mem += m_buffer.vpwp_sfc.size();
+
+  Spack* s_mem = reinterpret_cast<Spack*>(mem);
+
+  // 2d packed views
+  const int nlev_packs       = ekat::npack<Spack>(m_num_levs);
+  const int nlevi_packs      = ekat::npack<Spack>(m_num_levs+1);
+  const int num_tracer_packs = ekat::npack<Spack>(m_num_tracers);
+
+  m_buffer.rrho = decltype(m_buffer.rrho)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.rrho.size();
+  m_buffer.rrho_i = decltype(m_buffer.rrho_i)(s_mem, m_num_cols, nlevi_packs);
+  s_mem += m_buffer.rrho_i.size();
+  m_buffer.thv = decltype(m_buffer.thv)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.thv.size();
+  m_buffer.dz = decltype(m_buffer.dz)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.dz .size();
+  m_buffer.zt_grid = decltype(m_buffer.zt_grid)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.zt_grid.size();
+  m_buffer.zi_grid = decltype(m_buffer.zi_grid)(s_mem, m_num_cols, nlevi_packs);
+  s_mem += m_buffer.zi_grid.size();
+  m_buffer.wtracer_sfc = decltype(m_buffer.wtracer_sfc)(s_mem, m_num_cols, num_tracer_packs);
+  s_mem += m_buffer.wtracer_sfc.size();
+  m_buffer.wm_zt = decltype(m_buffer.wm_zt)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.wm_zt.size();
+  m_buffer.exner = decltype(m_buffer.exner)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.exner.size();
+  m_buffer.thlm = decltype(m_buffer.thlm)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.thlm.size();
+  m_buffer.qw = decltype(m_buffer.qw)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.qw.size();
+  m_buffer.s = decltype(m_buffer.s)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.s.size();
+  m_buffer.qv_copy = decltype(m_buffer.qv_copy)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.qv_copy.size();
+  m_buffer.qc_copy = decltype(m_buffer.qc_copy)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.qc_copy.size();
+  m_buffer.tke_copy = decltype(m_buffer.tke_copy)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.tke_copy.size();
+  m_buffer.shoc_ql2 = decltype(m_buffer.shoc_ql2)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.shoc_ql2.size();
+  m_buffer.shoc_mix = decltype(m_buffer.shoc_mix)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.shoc_mix.size();
+  m_buffer.isotropy = decltype(m_buffer.isotropy)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.isotropy.size();
+  m_buffer.w_sec = decltype(m_buffer.w_sec)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.w_sec.size();
+  m_buffer.thl_sec = decltype(m_buffer.thl_sec)(s_mem, m_num_cols, nlevi_packs);
+  s_mem += m_buffer.thl_sec.size();
+  m_buffer.qw_sec = decltype(m_buffer.qw_sec)(s_mem, m_num_cols, nlevi_packs);
+  s_mem += m_buffer.qw_sec.size();
+  m_buffer.qwthl_sec = decltype(m_buffer.qwthl_sec)(s_mem, m_num_cols, nlevi_packs);
+  s_mem += m_buffer.qwthl_sec.size();
+  m_buffer.wthl_sec = decltype(m_buffer.wthl_sec)(s_mem, m_num_cols, nlevi_packs);
+  s_mem += m_buffer.wthl_sec.size();
+  m_buffer.wqw_sec = decltype(m_buffer.wqw_sec)(s_mem, m_num_cols, nlevi_packs);
+  s_mem += m_buffer.wqw_sec.size();
+  m_buffer.wtke_sec = decltype(m_buffer.wtke_sec)(s_mem, m_num_cols, nlevi_packs);
+  s_mem += m_buffer.wtke_sec.size();
+  m_buffer.uw_sec = decltype(m_buffer.uw_sec)(s_mem, m_num_cols, nlevi_packs);
+  s_mem += m_buffer.uw_sec.size();
+  m_buffer.vw_sec = decltype(m_buffer.vw_sec)(s_mem, m_num_cols, nlevi_packs);
+  s_mem += m_buffer.vw_sec.size();
+  m_buffer.w3 = decltype(m_buffer.w3)(s_mem, m_num_cols, nlevi_packs);
+  s_mem += m_buffer.w3.size();
+  m_buffer.wqls_sec = decltype(m_buffer.wqls_sec)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.wqls_sec.size();
+  m_buffer.brunt = decltype(m_buffer.brunt)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.brunt.size();
+
+  // WSM data
+  m_buffer.wsm_data = s_mem;
+
+  // Compute workspace manager size to check used memory
+  // vs. requested memory
+  const auto policy      = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
+  const int n_wind_slots = ekat::npack<Spack>(2)*Spack::n;
+  const int n_trac_slots = ekat::npack<Spack>(m_num_tracers+3)*Spack::n;
+  const int wsm_size     = WSM::get_total_bytes_needed(nlevi_packs, 13+(n_wind_slots+n_trac_slots), policy)/sizeof(Spack);
+  s_mem += wsm_size;
+
+  int used_mem = (reinterpret_cast<Real*>(s_mem) - buffer_manager.get_memory())*sizeof(Real);
+  EKAT_REQUIRE_MSG(used_mem==requested_buffer_size_in_bytes(), "Error! Used memory != requested memory for SHOCMacrophysics.");
 }
 
 // =========================================================================================
@@ -142,31 +267,28 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   const auto& inv_qc_relvar    = m_shoc_fields_out["inv_qc_relvar"].get_reshaped_view<Spack**>();
   const auto& phis             = m_shoc_fields_in["phis"].get_reshaped_view<const Real*>();
 
-  const int nlev_packs = ekat::npack<Spack>(m_num_levs);
-  const int nlevi_packs = ekat::npack<Spack>(m_num_levs+1);
-  const int num_tracer_packs = ekat::npack<Spack>(m_num_tracers);
-
-  view_1d cell_length("cell_length",m_num_cols),
-          wpthlp_sfc("wpthlp_sfc",m_num_cols),
-          wprtp_sfc("wprtp_sfc",m_num_cols),
-          upwp_sfc("upwp_sfc",m_num_cols),
-          vpwp_sfc("vpwp_sfc",m_num_cols);
-
-  view_2d rrho("rrho",m_num_cols,nlev_packs),
-          rrho_i("rrhoi",m_num_cols,nlevi_packs),
-          thv("thv",m_num_cols,nlev_packs),
-          dz("dz",m_num_cols,nlev_packs),
-          zt_grid("zt_grid",m_num_cols,nlev_packs),
-          zi_grid("zi_grid",m_num_cols,nlevi_packs),
-          wtracer_sfc("wtracer_sfc",m_num_cols,num_tracer_packs),
-          wm_zt("wm_zt",m_num_cols,nlev_packs),
-          exner("exner",m_num_cols,nlev_packs),
-          thlm("thlm",m_num_cols,nlev_packs),
-          qw("qw",m_num_cols,nlev_packs),
-          s("s",m_num_cols,nlev_packs),
-          qv_copy("qv_copy",m_num_cols,nlev_packs),
-          qc_copy("qc_copy",m_num_cols,nlev_packs),
-          tke_copy("tke_copy",m_num_cols,nlev_packs);
+  // Alias local variables from temporary buffer
+  auto cell_length = m_buffer.cell_length;
+  auto wpthlp_sfc  = m_buffer.wpthlp_sfc;
+  auto wprtp_sfc   = m_buffer.wprtp_sfc;
+  auto upwp_sfc    = m_buffer.upwp_sfc;
+  auto vpwp_sfc    = m_buffer.vpwp_sfc;
+  auto rrho        = m_buffer.rrho;
+  auto rrho_i      = m_buffer.rrho_i;
+  auto thv         = m_buffer.thv;
+  auto dz          = m_buffer.dz;
+  auto zt_grid     = m_buffer.zt_grid;
+  auto zi_grid     = m_buffer.zi_grid;
+  auto wtracer_sfc = m_buffer.wtracer_sfc;
+  auto wm_zt       = m_buffer.wm_zt;
+  auto exner       = m_buffer.exner;
+  auto thlm        = m_buffer.thlm;
+  auto qw          = m_buffer.qw;
+  auto s           = m_buffer.s;
+  auto qv_copy     = m_buffer.qv_copy;
+  auto qc_copy     = m_buffer.qc_copy;
+  auto tke_copy    = m_buffer.tke_copy;
+  auto shoc_ql2    = m_buffer.shoc_ql2;
 
   shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,m_cell_area,
                                 T_mid,z_int,z_mid,p_mid,pseudo_density,omega,phis,surf_sens_flux,surf_latent_flux,
@@ -205,43 +327,24 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   input_output.shoc_ql      = shoc_preprocess.qc_copy;
 
   // Output Variables
-  output.pblh = m_shoc_fields_out["pbl_height"].get_reshaped_view<Real*>();
-
-  view_2d shoc_ql2("shoc_ql2",m_num_cols,nlev_packs);
+  output.pblh     = m_shoc_fields_out["pbl_height"].get_reshaped_view<Real*>();
   output.shoc_ql2 = shoc_ql2;
 
   // Ouput (diagnostic)
-  // TODO: A temporary buffer should be added to the AD for these local
-  //       views.
-  view_2d shoc_mix("shoc_mix",m_num_cols,nlev_packs);
-  view_2d isotropy("isotropy",m_num_cols,nlev_packs);
-  view_2d w_sec("w_sec",m_num_cols,nlev_packs);
-  view_2d thl_sec("thl_sec",m_num_cols,nlevi_packs);
-  view_2d qw_sec("qw_sec",m_num_cols,nlevi_packs);
-  view_2d qwthl_sec("qwthl_sec",m_num_cols,nlevi_packs);
-  view_2d wthl_sec("wthl_sec",m_num_cols,nlevi_packs);
-  view_2d wqw_sec("wqw_sec",m_num_cols,nlevi_packs);
-  view_2d wtke_sec("wtke_sec",m_num_cols,nlevi_packs);
-  view_2d uw_sec("uw_sec",m_num_cols,nlevi_packs);
-  view_2d vw_sec("vw_sec",m_num_cols,nlevi_packs);
-  view_2d w3("w3",m_num_cols,nlevi_packs);
-  view_2d wqls_sec("wqls_sec",m_num_cols,nlev_packs);
-  view_2d brunt("brunt",m_num_cols,nlev_packs);
-
-  history_output.shoc_mix  = shoc_mix;
-  history_output.isotropy  = isotropy;
-  history_output.w_sec     = w_sec;
-  history_output.thl_sec   = thl_sec;
-  history_output.qw_sec    = qw_sec;
-  history_output.qwthl_sec = qwthl_sec;
-  history_output.wthl_sec  = wthl_sec;
-  history_output.wqw_sec   = wqw_sec;
-  history_output.wtke_sec  = wtke_sec;
-  history_output.uw_sec    = uw_sec;
-  history_output.vw_sec    = vw_sec;
-  history_output.w3        = w3;
-  history_output.wqls_sec  = wqls_sec;
-  history_output.brunt     = brunt;
+  history_output.shoc_mix  = m_buffer.shoc_mix;
+  history_output.isotropy  = m_buffer.isotropy;
+  history_output.w_sec     = m_buffer.w_sec;
+  history_output.thl_sec   = m_buffer.thl_sec;
+  history_output.qw_sec    = m_buffer.qw_sec;
+  history_output.qwthl_sec = m_buffer.qwthl_sec;
+  history_output.wthl_sec  = m_buffer.wthl_sec;
+  history_output.wqw_sec   = m_buffer.wqw_sec;
+  history_output.wtke_sec  = m_buffer.wtke_sec;
+  history_output.uw_sec    = m_buffer.uw_sec;
+  history_output.vw_sec    = m_buffer.vw_sec;
+  history_output.w3        = m_buffer.w3;
+  history_output.wqls_sec  = m_buffer.wqls_sec;
+  history_output.brunt     = m_buffer.brunt;
 
   shoc_postprocess.set_variables(m_num_cols,m_num_levs,
                                  rrho,qv,qv_copy,qc,qc_copy,tke,tke_copy,shoc_ql2,
@@ -259,13 +362,14 @@ void SHOCMacrophysics::run_impl (const Real dt)
     it.second.sync_to_host();
   }
 
-  {
-    const auto nlev_packs = ekat::npack<Spack>(m_num_cols);
-    const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
-    Kokkos::parallel_for("shoc_preprocess",
-                         policy,
-                         shoc_preprocess);
-  }
+  const auto nlev_packs  = ekat::npack<Spack>(m_num_levs);
+  const auto nlevi_packs = ekat::npack<Spack>(m_num_levs+1);
+  const auto policy      = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
+
+  // Preprocessing of SHOC inputs
+  Kokkos::parallel_for("shoc_preprocess",
+                       policy,
+                       shoc_preprocess);
   Kokkos::fence();
 
 
@@ -281,17 +385,19 @@ void SHOCMacrophysics::run_impl (const Real dt)
   hdtime = dt;
   m_nadv = ekat::impl::max(hdtime/dt,sp(1));
 
+  // WorkspaceManager for internal local variables
+  const int n_wind_slots = ekat::npack<Spack>(2)*Spack::n;
+  const int n_trac_slots = ekat::npack<Spack>(m_num_tracers+3)*Spack::n;
+  ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(m_buffer.wsm_data, nlevi_packs, 13+(n_wind_slots+n_trac_slots), policy);
+
   // Run shoc main
   SHF::shoc_main(m_num_cols, m_num_levs, m_num_levs+1, m_npbl, m_nadv, m_num_tracers, dt,
-                 input,input_output,output,history_output);
+                 workspace_mgr,input,input_output,output,history_output);
 
-  {
-    const auto nlev_packs = ekat::npack<Spack>(m_num_cols);
-    const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
-    Kokkos::parallel_for("shoc_postprocess",
-                         policy,
-                         shoc_postprocess);
-  }
+  // Postprocessing of SHOC outputs
+  Kokkos::parallel_for("shoc_postprocess",
+                       policy,
+                       shoc_postprocess);
   Kokkos::fence();
 
   // Get a copy of the current timestamp (at the beginning of the step) and

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -66,7 +66,8 @@ struct Functions
 
   using MemberType = typename KT::MemberType;
 
-  using Workspace       = typename ekat::WorkspaceManager<Spack,  Device>::Workspace;
+  using WorkspaceMgr = typename ekat::WorkspaceManager<Spack,  Device>;
+  using Workspace    = typename WorkspaceMgr::Workspace;
 
   // This struct stores input views for shoc_main.
   struct SHOCInput {
@@ -620,6 +621,7 @@ struct Functions
     const Int&               nadv,                 // Number of times to loop SHOC
     const Int&               num_q_tracers,        // Number of tracers
     const Scalar&            dtime,                // SHOC timestep [s]
+    const WorkspaceMgr&      workspace_mgr,        // WorkspaceManager for local variables
     const SHOCInput&         shoc_input,           // Input
     const SHOCInputOutput&   shoc_input_output,    // Input/Output
     const SHOCOutput&        shoc_output,          // Output

--- a/components/scream/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.cpp
@@ -2837,7 +2837,14 @@ Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, 
                                              uw_sec_d,    vw_sec_d,   w3_d,      wqls_sec_d,
                                              brunt_d,     isotropy_d};
 
+  // Create local workspace
+  const auto nlevi_packs = ekat::npack<Spack>(nlevi);
+  const int n_wind_slots = ekat::npack<Spack>(2)*Spack::n;
+  const int n_trac_slots = ekat::npack<Spack>(num_qtracers+3)*Spack::n;
+  ekat::WorkspaceManager<Spack, SHF::KT::Device> workspace_mgr(nlevi_packs, 13+(n_wind_slots+n_trac_slots), policy);
+
   const auto elapsed_microsec = SHF::shoc_main(shcol, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
+                                               workspace_mgr,
                                                shoc_input, shoc_input_output, shoc_output, shoc_history_output);
 
   // Copy wind back into separate views and

--- a/components/scream/src/physics/shoc/shoc_main_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_main_impl.hpp
@@ -285,34 +285,27 @@ void Functions<S,D>::shoc_main_internal(
 
 template<typename S, typename D>
 Int Functions<S,D>::shoc_main(
-  const Int&               shcol,        // Number of SHOC columns in the array
-  const Int&               nlev,         // Number of levels
-  const Int&               nlevi,        // Number of levels on interface grid
-  const Int&               npbl,         // Maximum number of levels in pbl from surface
-  const Int&               nadv,         // Number of times to loop SHOC
-  const Int&               num_qtracers, // Number of tracers
-  const Scalar&            dtime,        // SHOC timestep [s]
-  const SHOCInput&         shoc_input,
-  const SHOCInputOutput&   shoc_input_output,
-  const SHOCOutput&        shoc_output,
-  const SHOCHistoryOutput& shoc_history_output)
+  const Int&               shcol,               // Number of SHOC columns in the array
+  const Int&               nlev,                // Number of levels
+  const Int&               nlevi,               // Number of levels on interface grid
+  const Int&               npbl,                // Maximum number of levels in pbl from surface
+  const Int&               nadv,                // Number of times to loop SHOC
+  const Int&               num_qtracers,        // Number of tracers
+  const Scalar&            dtime,               // SHOC timestep [s]
+  const WorkspaceMgr&      workspace_mgr,       // WorkspaceManager for local variables
+  const SHOCInput&         shoc_input,          // Input
+  const SHOCInputOutput&   shoc_input_output,   // Input/Output
+  const SHOCOutput&        shoc_output,         // Output
+  const SHOCHistoryOutput& shoc_history_output) // Output (diagnostic)
 {
   using ExeSpace = typename KT::ExeSpace;
-
-  // Number of packs for nlev, nlevi
-  const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto nlevi_packs = ekat::npack<Spack>(nlevi);
-
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
-
-  const int n_wind_slots = ekat::npack<Spack>(2)*Spack::n;
-  const int n_trac_slots = ekat::npack<Spack>(num_qtracers+3)*Spack::n;
-  ekat::WorkspaceManager<Spack, Device> workspace_mgr(nlevi_packs, 13+(n_wind_slots+n_trac_slots), policy);
 
   // Start timer
   auto start = std::chrono::steady_clock::now();
 
   // SHOC main loop
+  const auto nlev_packs = ekat::npack<Spack>(nlev);
+  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/scream/src/share/atm_process/ATMBufferManager.hpp
+++ b/components/scream/src/share/atm_process/ATMBufferManager.hpp
@@ -1,0 +1,58 @@
+#ifndef SCREAM_ATM_BUFFERS_MANAGER_HPP
+#define SCREAM_ATM_BUFFERS_MANAGER_HPP
+
+#include "share/scream_types.hpp"
+#include "ekat/ekat_assert.hpp"
+
+namespace scream {
+
+// Struct which allows for the allocation of a single
+// memory buffer for all ATM processes.
+struct ATMBufferManager {
+
+  template <typename S>
+  using view_1d = typename KokkosTypes<DefaultDevice>::template view_1d<S>;
+
+  ATMBufferManager()
+  {
+    m_size      = 0;
+    m_allocated = false;
+  }
+
+  ~ATMBufferManager() = default;
+
+  // Each ATM process should request the number of bytes
+  // needed for local variables. Since no two process runs at
+  // the same time, the total allocation will be the maximum
+  // of each request.
+  void request_bytes (const int num_bytes) {
+    ekat::error::runtime_check(num_bytes%sizeof(Real)==0,
+                               "Error! Must request number of bytes which is divisible by sizeof(Real).\n");
+
+    const int num_reals = num_bytes/sizeof(Real);
+    m_size = std::max(num_reals, m_size);
+  }
+
+  Real* get_memory () const { return m_buffer.data(); }
+
+  int allocated_bytes () const { return m_size*sizeof(Real); }
+
+  void allocate () {
+    ekat::error::runtime_check(!m_allocated, "Error! Cannot call 'allocate' more than once.\n");
+
+    m_buffer = view_1d<Real>("",m_size);
+    m_allocated = true;
+  }
+
+  bool allocated () const { return m_allocated; }
+
+protected:
+
+  view_1d<Real> m_buffer;
+  int           m_size;
+  bool          m_allocated;
+};
+
+} // scream
+
+#endif // SCREAM_ATM_BUFFERS_MANAGER_HPP

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -2,6 +2,7 @@
 #define SCREAM_ATMOSPHERE_PROCESS_HPP
 
 #include "share/atm_process/atmosphere_process_utils.hpp"
+#include "share/atm_process/ATMBufferManager.hpp"
 #include "share/field/field_identifier.hpp"
 #include "share/field/field_manager.hpp"
 #include "share/field/field_request.hpp"
@@ -210,6 +211,13 @@ public:
     }
     return false;
   }
+
+  // Computes total number of Reals needed for local variables
+  virtual int requested_buffer_size_in_bytes () const { return 0; }
+
+  // Set local variables using memory provided by
+  // the ATMBufferManager
+  virtual void init_buffers(const ATMBufferManager& /*buffer_manager*/) {}
 
 protected:
 

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -235,4 +235,14 @@ process_required_field (const FieldRequest& req) {
   }
 }
 
+void AtmosphereProcessGroup::initialize_atm_memory_buffer(ATMBufferManager &memory_buffer) {
+  for (auto& atm_proc : m_atm_processes) {
+    memory_buffer.request_bytes(atm_proc->requested_buffer_size_in_bytes());
+  }
+  memory_buffer.allocate();
+  for (auto& atm_proc : m_atm_processes) {
+    atm_proc->init_buffers(memory_buffer);
+  }
+}
+
 } // namespace scream

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -63,6 +63,9 @@ public:
 
   ScheduleType get_schedule_type () const { return m_group_schedule_type; }
 
+  // Initialize memory buffer for each process
+  void initialize_atm_memory_buffer (ATMBufferManager& memory_buffer);
+
 protected:
 
   // Adds fid to the list of required/computed fields of the group (as a whole).


### PR DESCRIPTION
Adds a AD-wide memory buffer which each process can request an allocation.

Changes:
- Adds memory buffer manager struct: `ATMBufferManager`.
- Each ATM process can request memory (in bytes) and initialize any local variables through the buffer manager. This is called for each process during the initialization phase in `atmosphere_process_group.cpp`.
- `WorkspaceManager` memory is also included in the request. The WSM variable is changed to be an input into the `_main()` functions instead of constructed internally