### PR TITLE
Should never change global git configs

### DIFF
--- a/components/scream/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/scream/scripts/jenkins/jenkins_common_impl.sh
@@ -28,8 +28,10 @@ if [ $skip_testing -eq 0 ]; then
 
   source scripts/jenkins/${NODE_NAME}_setup
 
-  git config --global user.email "jenkins@ignore.com"
-  git config --global user.name "Jenkins Jenkins"
+  if [[ "$(whoami)" == "e3sm-jenkins" ]]; then
+      git config --local user.email "jenkins@ignore.com"
+      git config --local user.name "Jenkins Jenkins"
+  fi
 
   SUBMIT="--submit"
   if [ -n "$PULLREQUESTNUM" ]; then


### PR DESCRIPTION
Limit the change to the local repo and only do it for e3sm-jenkins.

The prior implementation inadvertently changed my personal git config such
that all my subsequent commits were done as authoer "Jenkins Jenkins".