### PR TITLE
Compute cell area in PointGrid and use for dx/dy in SHOC

### DIFF
--- a/components/scream/src/physics/share/physics_constants.hpp
+++ b/components/scream/src/physics/share/physics_constants.hpp
@@ -95,6 +95,7 @@ struct Constants
   static constexpr Scalar f2r           = 0.32;
   static constexpr Scalar nmltratio     = 0.2; // ratio of rain number produced to ice number loss from melting
   static constexpr Scalar basetemp      = 300.0;
+  static constexpr Scalar r_earth       = 6.376e6; // Radius of the earth in m
 
   // Table dimension constants
   static constexpr int VTABLE_DIM0    = 300;

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -27,8 +27,13 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
   const auto& grid_name = m_shoc_params.get<std::string>("Grid");
   auto grid = grids_manager->get_grid(grid_name);
+
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
+
+  // TODO: In preprocessing, we assume area is in meters. This may not
+  //       always be the case.
+  m_cell_area = grid->get_geometry_data("area"); // area of each cell
 
   // Define the different field layouts that will be used for this process
   using namespace ShortFieldTagsNames;
@@ -141,7 +146,9 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   const int nlevi_packs = ekat::npack<Spack>(m_num_levs+1);
   const int num_tracer_packs = ekat::npack<Spack>(m_num_tracers);
 
-  view_1d wpthlp_sfc("wpthlp_sfc",m_num_cols),
+  view_1d host_dx("host_dx",m_num_cols),
+          host_dy("host_dy",m_num_cols),
+          wpthlp_sfc("wpthlp_sfc",m_num_cols),
           wprtp_sfc("wprtp_sfc",m_num_cols),
           upwp_sfc("upwp_sfc",m_num_cols),
           vpwp_sfc("vpwp_sfc",m_num_cols);
@@ -162,15 +169,15 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
           qc_copy("qc_copy",m_num_cols,nlev_packs),
           tke_copy("tke_copy",m_num_cols,nlev_packs);
 
-  shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,T_mid,
-                                z_int,z_mid,p_mid,pseudo_density,omega,phis,surf_sens_flux,surf_latent_flux,
-                                surf_u_mom_flux,surf_v_mom_flux,qv,qv_copy,qc,qc_copy,tke,tke_copy,
+  shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,m_cell_area,
+                                T_mid,z_int,z_mid,p_mid,pseudo_density,omega,phis,surf_sens_flux,surf_latent_flux,
+                                surf_u_mom_flux,surf_v_mom_flux,qv,qv_copy,qc,qc_copy,tke,tke_copy,host_dx,host_dy,
                                 s,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
                                 wtracer_sfc,wm_zt,exner,thlm,qw);
 
   // Input Variables:
-  input.host_dx     = m_shoc_fields_in["host_dx"].get_reshaped_view<const Real*>();
-  input.host_dy     = m_shoc_fields_in["host_dy"].get_reshaped_view<const Real*>();
+  input.host_dx     = shoc_preprocess.host_dx;
+  input.host_dy     = shoc_preprocess.host_dy;
   input.zt_grid     = shoc_preprocess.zt_grid;
   input.zi_grid     = shoc_preprocess.zi_grid;
   input.pres        = p_mid;

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -146,8 +146,7 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   const int nlevi_packs = ekat::npack<Spack>(m_num_levs+1);
   const int num_tracer_packs = ekat::npack<Spack>(m_num_tracers);
 
-  view_1d host_dx("host_dx",m_num_cols),
-          host_dy("host_dy",m_num_cols),
+  view_1d cell_length("cell_length",m_num_cols),
           wpthlp_sfc("wpthlp_sfc",m_num_cols),
           wprtp_sfc("wprtp_sfc",m_num_cols),
           upwp_sfc("upwp_sfc",m_num_cols),
@@ -171,13 +170,13 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
 
   shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,m_cell_area,
                                 T_mid,z_int,z_mid,p_mid,pseudo_density,omega,phis,surf_sens_flux,surf_latent_flux,
-                                surf_u_mom_flux,surf_v_mom_flux,qv,qv_copy,qc,qc_copy,tke,tke_copy,host_dx,host_dy,
+                                surf_u_mom_flux,surf_v_mom_flux,qv,qv_copy,qc,qc_copy,tke,tke_copy,cell_length,
                                 s,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
                                 wtracer_sfc,wm_zt,exner,thlm,qw);
 
   // Input Variables:
-  input.host_dx     = shoc_preprocess.host_dx;
-  input.host_dy     = shoc_preprocess.host_dy;
+  input.dx          = shoc_preprocess.cell_length;
+  input.dy          = shoc_preprocess.cell_length;
   input.zt_grid     = shoc_preprocess.zt_grid;
   input.zi_grid     = shoc_preprocess.zi_grid;
   input.pres        = p_mid;

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -206,7 +206,7 @@ public:
 
     // Assigning local variables
     void set_variables(const int ncol_, const int nlev_, const int num_qtracers_,
-                       const view_1d_const& area_,
+                       const view_1d_const_double& area_,
                        const view_2d_const& T_mid_, const view_2d_const& z_int_,
                        const view_2d_const& z_mid_, const view_2d_const& p_mid_, const view_2d_const& pseudo_density_,
                        const view_2d_const& omega_,

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -149,6 +149,9 @@ public:
       const int nlev_v = (nlev-1)/Spack::n;
       const int nlev_p = (nlev-1)%Spack::n;
 
+      host_dx(i) = sqrt(area(i));
+      host_dy(i) = host_dx(i);
+
       wpthlp_sfc(i) = surf_sens_flux(i)/(cpair*rrho_i(i,nlev_v)[nlev_p]);
       wprtp_sfc(i)  = surf_latent_flux(i)/rrho_i(i,nlev_v)[nlev_p];
       upwp_sfc(i)   = surf_u_mom_flux(i)/rrho_i(i,nlev_v)[nlev_p];
@@ -161,6 +164,7 @@ public:
 
     // Local variables
     int ncol, nlev, num_qtracers;
+    view_1d_const area;
     view_2d_const T_mid;
     view_2d_const z_int;
     view_2d_const z_mid;
@@ -174,6 +178,8 @@ public:
     view_1d_const surf_v_mom_flux;
     view_2d_const qv;
     view_2d       qv_copy;
+    view_1d       host_dx;
+    view_1d       host_dy;
     view_2d       qc;
     view_2d       qc_copy;
     view_2d       shoc_s;
@@ -198,13 +204,15 @@ public:
 
     // Assigning local variables
     void set_variables(const int ncol_, const int nlev_, const int num_qtracers_,
+                       const view_1d_const& area_,
                        const view_2d_const& T_mid_, const view_2d_const& z_int_,
                        const view_2d_const& z_mid_, const view_2d_const& p_mid_, const view_2d_const& pseudo_density_,
                        const view_2d_const& omega_,
                        const view_1d_const& phis_, const view_1d_const& surf_sens_flux_, const view_1d_const& surf_latent_flux_,
                        const view_1d_const& surf_u_mom_flux_, const view_1d_const& surf_v_mom_flux_,
                        const view_2d_const& qv_, const view_2d& qv_copy_, const view_2d& qc_, const view_2d& qc_copy_,
-                       const view_2d& tke_, const view_2d& tke_copy_, const view_2d& s_, const view_2d& rrho_, const view_2d& rrho_i_,
+                       const view_2d& tke_, const view_2d& tke_copy_, const view_1d& dx_, const view_1d& dy_,
+                       const view_2d& s_, const view_2d& rrho_, const view_2d& rrho_i_,
                        const view_2d& thv_, const view_2d& dz_,const view_2d& zt_grid_,const view_2d& zi_grid_, const view_1d& wpthlp_sfc_,
                        const view_1d& wprtp_sfc_,const view_1d& upwp_sfc_,const view_1d& vpwp_sfc_, const view_2d& wtracer_sfc_,
                        const view_2d& wm_zt_,const view_2d& exner_,const view_2d& thlm_,const view_2d& qw_)
@@ -213,6 +221,7 @@ public:
       nlev = nlev_;
       num_qtracers = num_qtracers_;
       // IN
+      area = area_;
       T_mid = T_mid_;
       z_int = z_int_;
       z_mid = z_mid_;
@@ -232,6 +241,8 @@ public:
       shoc_s = s_;
       tke = tke_;
       tke_copy = tke_copy_;
+      host_dx = dx_;
+      host_dy = dy_;
       rrho = rrho_;
       rrho_i = rrho_i_;
       thv = thv_;
@@ -345,6 +356,8 @@ protected:
   Int m_nadv;
   Int m_num_tracers;
   Int hdtime;
+
+  KokkosTypes<DefaultDevice>::view_1d<double> m_cell_area;
 
   // Store the structures for each arguement to shoc_main;
   SHF::SHOCInput input;

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -28,16 +28,17 @@ class SHOCMacrophysics : public scream::AtmosphereProcess
   using C            = physics::Constants<Real>;
   using KT           = ekat::KokkosTypes<DefaultDevice>;
 
-  using Spack = typename SHF::Spack;
-  using IntSmallPack = typename SHF::IntSmallPack;
-  using Smask = typename SHF::Smask;
-  using view_1d  = typename SHF::view_1d<Real>;
-  using view_1d_const  = typename SHF::view_1d<const Real>;
-  using view_2d  = typename SHF::view_2d<SHF::Spack>;
-  using view_2d_const  = typename SHF::view_2d<const Spack>;
-  using sview_2d = typename KokkosTypes<DefaultDevice>::template view_2d<Real>;
-  using view_3d = typename SHF::view_3d<Spack>;
-  using view_3d_const = typename SHF::view_3d<const Spack>;
+  using Spack                = typename SHF::Spack;
+  using IntSmallPack         = typename SHF::IntSmallPack;
+  using Smask                = typename SHF::Smask;
+  using view_1d              = typename SHF::view_1d<Real>;
+  using view_1d_const        = typename SHF::view_1d<const Real>;
+  using view_1d_const_double = typename SHF::view_1d<const double>;
+  using view_2d              = typename SHF::view_2d<SHF::Spack>;
+  using view_2d_const        = typename SHF::view_2d<const Spack>;
+  using sview_2d             = typename KokkosTypes<DefaultDevice>::template view_2d<Real>;
+  using view_3d              = typename SHF::view_3d<Spack>;
+  using view_3d_const        = typename SHF::view_3d<const Spack>;
 
 public:
   using field_type       = Field<      Real>;
@@ -164,43 +165,43 @@ public:
 
     // Local variables
     int ncol, nlev, num_qtracers;
-    view_1d_const area;
-    view_2d_const T_mid;
-    view_2d_const z_int;
-    view_2d_const z_mid;
-    view_2d_const p_mid;
-    view_2d_const pseudo_density;
-    view_2d_const omega;
-    view_1d_const phis;
-    view_1d_const surf_sens_flux;
-    view_1d_const surf_latent_flux;
-    view_1d_const surf_u_mom_flux;
-    view_1d_const surf_v_mom_flux;
-    view_2d_const qv;
-    view_2d       qv_copy;
-    view_1d       host_dx;
-    view_1d       host_dy;
-    view_2d       qc;
-    view_2d       qc_copy;
-    view_2d       shoc_s;
-    view_2d       tke;
-    view_2d       tke_copy;
-    view_2d       rrho;
-    view_2d       rrho_i;
-    view_2d       thv;
-    view_2d       dz;
-    view_2d       zt_grid;
-    view_2d       zi_grid;
-    view_1d       wpthlp_sfc;
-    view_1d       wprtp_sfc;
-    view_1d       upwp_sfc;
-    view_1d       vpwp_sfc;
-    view_2d       wtracer_sfc;
-    view_2d       wm_zt;
-    view_2d       exner;
-    view_2d       thlm;
-    view_2d       qw;
-    view_2d       cloud_frac;
+    view_1d_const_double area;
+    view_2d_const        T_mid;
+    view_2d_const        z_int;
+    view_2d_const        z_mid;
+    view_2d_const        p_mid;
+    view_2d_const        pseudo_density;
+    view_2d_const        omega;
+    view_1d_const        phis;
+    view_1d_const        surf_sens_flux;
+    view_1d_const        surf_latent_flux;
+    view_1d_const        surf_u_mom_flux;
+    view_1d_const        surf_v_mom_flux;
+    view_2d_const        qv;
+    view_2d              qv_copy;
+    view_1d              host_dx;
+    view_1d              host_dy;
+    view_2d              qc;
+    view_2d              qc_copy;
+    view_2d              shoc_s;
+    view_2d              tke;
+    view_2d              tke_copy;
+    view_2d              rrho;
+    view_2d              rrho_i;
+    view_2d              thv;
+    view_2d              dz;
+    view_2d              zt_grid;
+    view_2d              zi_grid;
+    view_1d              wpthlp_sfc;
+    view_1d              wprtp_sfc;
+    view_1d              upwp_sfc;
+    view_1d              vpwp_sfc;
+    view_2d              wtracer_sfc;
+    view_2d              wm_zt;
+    view_2d              exner;
+    view_2d              thlm;
+    view_2d              qw;
+    view_2d              cloud_frac;
 
     // Assigning local variables
     void set_variables(const int ncol_, const int nlev_, const int num_qtracers_,

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -150,8 +150,10 @@ public:
       const int nlev_v = (nlev-1)/Spack::n;
       const int nlev_p = (nlev-1)%Spack::n;
 
-      host_dx(i) = sqrt(area(i));
-      host_dy(i) = host_dx(i);
+      // For now, we are considering dy=dx. Here, we
+      // will need to compute dx/dy instead of cell_length
+      // if we have dy!=dx.
+      cell_length(i) = sqrt(area(i));
 
       wpthlp_sfc(i) = surf_sens_flux(i)/(cpair*rrho_i(i,nlev_v)[nlev_p]);
       wprtp_sfc(i)  = surf_latent_flux(i)/rrho_i(i,nlev_v)[nlev_p];
@@ -179,8 +181,7 @@ public:
     view_1d_const        surf_v_mom_flux;
     view_2d_const        qv;
     view_2d              qv_copy;
-    view_1d              host_dx;
-    view_1d              host_dy;
+    view_1d              cell_length;
     view_2d              qc;
     view_2d              qc_copy;
     view_2d              shoc_s;
@@ -212,7 +213,7 @@ public:
                        const view_1d_const& phis_, const view_1d_const& surf_sens_flux_, const view_1d_const& surf_latent_flux_,
                        const view_1d_const& surf_u_mom_flux_, const view_1d_const& surf_v_mom_flux_,
                        const view_2d_const& qv_, const view_2d& qv_copy_, const view_2d& qc_, const view_2d& qc_copy_,
-                       const view_2d& tke_, const view_2d& tke_copy_, const view_1d& dx_, const view_1d& dy_,
+                       const view_2d& tke_, const view_2d& tke_copy_, const view_1d& cell_length_,
                        const view_2d& s_, const view_2d& rrho_, const view_2d& rrho_i_,
                        const view_2d& thv_, const view_2d& dz_,const view_2d& zt_grid_,const view_2d& zi_grid_, const view_1d& wpthlp_sfc_,
                        const view_1d& wprtp_sfc_,const view_1d& upwp_sfc_,const view_1d& vpwp_sfc_, const view_2d& wtracer_sfc_,
@@ -242,8 +243,7 @@ public:
       shoc_s = s_;
       tke = tke_;
       tke_copy = tke_copy_;
-      host_dx = dx_;
-      host_dy = dy_;
+      cell_length = cell_length_;
       rrho = rrho_;
       rrho_i = rrho_i_;
       thv = thv_;

--- a/components/scream/src/physics/shoc/shoc_check_length_scale_shoc_length_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_check_length_scale_shoc_length_impl.hpp
@@ -11,8 +11,8 @@ KOKKOS_FUNCTION
 void Functions<S,D>::check_length_scale_shoc_length(
   const MemberType&      team,
   const Int&             nlev,
-  const Scalar&          host_dx,
-  const Scalar&          host_dy,
+  const Scalar&          dx,
+  const Scalar&          dy,
   const uview_1d<Spack>& shoc_mix)
 {
   const auto minlen = scream::shoc::Constants<Real>::minlen;
@@ -20,7 +20,7 @@ void Functions<S,D>::check_length_scale_shoc_length(
   const Int nlev_pack = ekat::npack<Spack>(nlev);
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
     // Ensure shoc_mix is in the interval [minval, sqrt(host_dx*host_dy)]
-    shoc_mix(k) = ekat::min(std::sqrt(host_dx*host_dy),
+    shoc_mix(k) = ekat::min(std::sqrt(dx*dy),
                             ekat::max(minlen, shoc_mix(k)));
   });
 }

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -73,9 +73,9 @@ struct Functions
     SHOCInput() = default;
 
     // Grid spacing of host model in x direction [m]
-    view_1d<const Scalar> host_dx;
+    view_1d<const Scalar> dx;
     // grid spacing of host model in y direction [m]
-    view_1d<const Scalar> host_dy;
+    view_1d<const Scalar> dy;
     // heights, for thermo grid [m]
     view_2d<const Spack>  zt_grid;
     // heights, for interface grid [m]
@@ -347,8 +347,8 @@ struct Functions
   static void check_length_scale_shoc_length(
     const MemberType&      team,
     const Int&             nlev,
-    const Scalar&          host_dx,
-    const Scalar&          host_dy,
+    const Scalar&          dx,
+    const Scalar&          dy,
     const uview_1d<Spack>& shoc_mix);
 
   KOKKOS_FUNCTION
@@ -374,8 +374,8 @@ struct Functions
     const MemberType&            team,
     const Int&                   nlev,
     const Int&                   nlevi,
-    const Scalar&                host_dx,
-    const Scalar&                host_dy,
+    const Scalar&                dx,
+    const Scalar&                dy,
     const uview_1d<const Spack>& zt_grid,
     const uview_1d<const Spack>& zi_grid,
     const uview_1d<const Spack>& dz_zt,

--- a/components/scream/src/physics/shoc/shoc_length_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_length_impl.hpp
@@ -13,8 +13,8 @@ void Functions<S,D>
   const MemberType&            team,
   const Int&                   nlev,
   const Int&                   nlevi,
-  const Scalar&                host_dx,
-  const Scalar&                host_dy,
+  const Scalar&                dx,
+  const Scalar&                dy,
   const uview_1d<const Spack>& zt_grid,
   const uview_1d<const Spack>& zi_grid,
   const uview_1d<const Spack>& dz_zt,
@@ -39,7 +39,7 @@ void Functions<S,D>
   compute_shoc_mix_shoc_length(team,nlev,tke,brunt,zt_grid,l_inf,shoc_mix);
   team.team_barrier();
 
-  check_length_scale_shoc_length(team,nlev,host_dx,host_dy,shoc_mix);
+  check_length_scale_shoc_length(team,nlev,dx,dy,shoc_mix);
 
   // Release temporary variable from the workspace
   workspace.release(thv_zi);

--- a/components/scream/src/physics/shoc/shoc_main_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_main_impl.hpp
@@ -69,8 +69,8 @@ void Functions<S,D>::shoc_main_internal(
   const Int&                   num_qtracers, // Number of tracers
   const Scalar&                dtime,        // SHOC timestep [s]
   // Input Variables
-  const Scalar&                host_dx,
-  const Scalar&                host_dy,
+  const Scalar&                dx,
+  const Scalar&                dy,
   const uview_1d<const Spack>& zt_grid,
   const uview_1d<const Spack>& zi_grid,
   const uview_1d<const Spack>& pres,
@@ -178,11 +178,11 @@ void Functions<S,D>::shoc_main_internal(
             pblh);                    // Output
 
     // Update the turbulent length scale
-    shoc_length(team,nlev,nlevi,host_dx,host_dy, // Input
-                zt_grid,zi_grid,dz_zt,           // Input
-                tke,thv,                         // Input
-                workspace,                       // Workspace
-                brunt,shoc_mix);                 // Output
+    shoc_length(team,nlev,nlevi,dx,dy, // Input
+                zt_grid,zi_grid,dz_zt, // Input
+                tke,thv,               // Input
+                workspace,             // Workspace
+                brunt,shoc_mix);       // Output
 
     // Advance the SGS TKE equation
     shoc_tke(team,nlev,nlevi,dtime,wthv_sec,    // Input
@@ -318,8 +318,8 @@ Int Functions<S,D>::shoc_main(
 
     auto workspace = workspace_mgr.get_workspace(team);
 
-    const Scalar host_dx_s{shoc_input.host_dx(i)};
-    const Scalar host_dy_s{shoc_input.host_dy(i)};
+    const Scalar dx_s{shoc_input.dx(i)};
+    const Scalar dy_s{shoc_input.dy(i)};
     const Scalar wthl_sfc_s{shoc_input.wthl_sfc(i)};
     const Scalar wqw_sfc_s{shoc_input.wqw_sfc(i)};
     const Scalar uw_sfc_s{shoc_input.uw_sfc(i)};
@@ -365,7 +365,7 @@ Int Functions<S,D>::shoc_main(
     const auto qtracers_s = Kokkos::subview(shoc_input_output.qtracers, i, Kokkos::ALL(), Kokkos::ALL());
 
     shoc_main_internal(team, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
-                       host_dx_s, host_dy_s, zt_grid_s, zi_grid_s,            // Input
+                       dx_s, dy_s, zt_grid_s, zi_grid_s,                      // Input
                        pres_s, presi_s, pdel_s, thv_s, w_field_s,             // Input
                        wthl_sfc_s, wqw_sfc_s, uw_sfc_s, vw_sfc_s,             // Input
                        wtracer_sfc_s, exner_s, phis_s,                        // Input

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -126,7 +126,8 @@ create_point_grid (const std::string& grid_name,
   using device_type       = DefaultDevice;
   using kokkos_types      = KokkosTypes<device_type>;
   using geo_view_type     = kokkos_types::view_1d<double>;
-  using KT = KokkosTypes<DefaultDevice>;
+  using KT                = KokkosTypes<DefaultDevice>;
+  using C                 = scream::physics::Constants<double>;
 
   // Store cell area, longitude, and latitude in geometry data.
   // For  longitude and latitude, set values to NaN since they
@@ -137,8 +138,8 @@ create_point_grid (const std::string& grid_name,
 
   // Estimate cell area for a uniform grid by taking the surface area
   // of the earth divided by the number of columns
-  const double rearth    = 6.376e6;
-  const double pi        = scream::physics::Constants<double>::Pi;
+  const double rearth    = C::r_earth;
+  const double pi        = C::Pi;
   const Real   cell_area = 4*pi*rearth*rearth/num_global_cols;
 
   const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(num_global_cols, num_vertical_lev);

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -132,15 +132,15 @@ create_point_grid (const std::string& grid_name,
   // Store cell area, longitude, and latitude in geometry data.
   // For  longitude and latitude, set values to NaN since they
   // are currently not required from any application using PointGrid
-  geo_view_type area("area", num_global_cols);
-  geo_view_type lon ("lon",  num_global_cols);
-  geo_view_type lat ("lat",  num_global_cols);
+  geo_view_type area("area", num_my_cols);
+  geo_view_type lon ("lon",  num_my_cols);
+  geo_view_type lat ("lat",  num_my_cols);
 
   // Estimate cell area for a uniform grid by taking the surface area
   // of the earth divided by the number of columns
   const double rearth    = C::r_earth;
   const double pi        = C::Pi;
-  const double cell_area = 4*pi*rearth*rearth/num_global_cols;
+  const double cell_area = 4*pi*rearth*rearth/num_my_cols;
 
   const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(num_global_cols, num_vertical_lev);
   Kokkos::parallel_for("area_loop", policy, KOKKOS_LAMBDA (const KT::MemberType& team) {

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -140,7 +140,7 @@ create_point_grid (const std::string& grid_name,
   // of the earth divided by the number of columns
   const double rearth    = C::r_earth;
   const double pi        = C::Pi;
-  const Real   cell_area = 4*pi*rearth*rearth/num_global_cols;
+  const double cell_area = 4*pi*rearth*rearth/num_global_cols;
 
   const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(num_global_cols, num_vertical_lev);
   Kokkos::parallel_for("area_loop", policy, KOKKOS_LAMBDA (const KT::MemberType& team) {

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -142,7 +142,7 @@ create_point_grid (const std::string& grid_name,
   const double pi        = C::Pi;
   const double cell_area = 4*pi*rearth*rearth/num_my_cols;
 
-  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(num_global_cols, num_vertical_lev);
+  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(num_my_cols, num_vertical_lev);
   Kokkos::parallel_for("area_loop", policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
     const int i = team.league_rank();
     area(i) = cell_area;


### PR DESCRIPTION
Instead of `host_dx/dy` being a FM variable, we now compute cell area in the PointGrid and use this to calculate `host_dx/dy` in SHOC pre-processing. The cell area is estimated to be `4*pi*R^2/num_cols`m.