### PR TITLE
Pass cloud mixing ratios to radiation instead of in-cloud mass

### DIFF
--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -85,9 +85,6 @@ namespace scream {
                 // NOTE: these thresholds (from E3SM) seem arbitrary, but included here for consistency
                 // This limits in-cloud mixing ratio to 0.005 kg/kg. According to note in cloud_diagnostics
                 // in EAM, this is consistent with limits in MG2. Is this true for P3?
-                // Note also that this limits cloud fraction in the computation to 0.0001, to avoid
-                // dividing by zero. But if cloud fraction is zero, should we not just make incloud mixing
-                // ration zero as well? In that case, we would probably expect mixing_ratio to also be zero.
                 auto incloud_mixing_ratio = std::min(mixing_ratio(icol,ilay) / std::max(0.0001, cloud_fraction(icol,ilay)), 0.005);
                 // Compute layer-integrated cloud mass (per unit area)
                 cloud_mass(icol,ilay) = incloud_mixing_ratio * dp(icol,ilay) / physconst::gravit;

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -4,6 +4,8 @@
 #include "cpp/rrtmgp/mo_gas_optics_rrtmgp.h"
 #include "cpp/extensions/cloud_optics/mo_cloud_optics.h"
 #include "cpp/rte/mo_fluxes.h"
+#include "cpp/const.h"
+#include "physics/share/physics_constants.hpp"
 
 namespace scream {
     namespace rrtmgp {
@@ -64,6 +66,30 @@ namespace scream {
                 GasConcs &gas_concs,
                 OpticalProps1scl &clouds,
                 FluxesBroadband &fluxes);
+        /* 
+         * Provide a function to convert cloud (water and ice) mixing ratios to layer mass per unit area
+         * (what E3SM refers to as "in-cloud water paths", a terminology we shun here to avoid confusion
+         * with the standard practice of using "water path" to refer to the total column-integrated
+         * quantities).
+         */
+        template<class T, int myMem, int myStyle> void mixing_ratio_to_layer_mass(
+                yakl::Array<T,2,myMem,myStyle> const &mixing_ratio, 
+                yakl::Array<T,2,myMem,myStyle> const &cloud_fraction, 
+                yakl::Array<T,2,myMem,myStyle> const &dp, 
+                yakl::Array<T,2,myMem,myStyle>       &layer_mass) {
+            real incloud_mixing_ratio;
+            int ncol = mixing_ratio.dimension[0];
+            int nlay = mixing_ratio.dimension[1];
+            using physconst = scream::physics::Constants<Real>;
+            parallel_for(Bounds<2>(nlay, ncol), YAKL_LAMBDA(int ilay, int icol) {
+                // Compute in-cloud mixing ratio (mixing ratio of the cloudy part of the layer)
+                // NOTE: these thresholds (from E3SM) seem arbitrary, but included here for consistency
+                incloud_mixing_ratio = std::min(mixing_ratio(icol,ilay) / std::max(0.0001, cloud_fraction(icol,ilay)), 0.005);
+                // Compute layer-integrated cloud mass (per unit area)
+                layer_mass(icol,ilay) = incloud_mixing_ratio * dp(icol,ilay) / physconst::gravit;
+            });
+        }
+
     } // namespace rrtmgp
 }  // namespace scream
 

--- a/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
@@ -68,10 +68,11 @@ int main (int argc, char** argv) {
     real2d iwp ("iwp", ncol, nlay);
     real2d rel ("rel", ncol, nlay);
     real2d rei ("rei", ncol, nlay);
+    real2d cld ("cld", ncol, nlay);
     rrtmgpTest::dummy_atmos(
         inputfile, ncol, p_lay, t_lay,
         sfc_alb_dir, sfc_alb_dif, mu0,
-        lwp, iwp, rel, rei
+        lwp, iwp, rel, rei, cld
     );
 
     // Setup flux outputs; In a real model run, the fluxes would be
@@ -119,6 +120,7 @@ int main (int argc, char** argv) {
     iwp.deallocate();
     rel.deallocate();
     rei.deallocate();
+    cld.deallocate();
     sw_flux_up_ref.deallocate();
     sw_flux_dn_ref.deallocate();
     sw_flux_dn_dir_ref.deallocate();

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_test_utils.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_test_utils.cpp
@@ -41,7 +41,7 @@ namespace rrtmgpTest {
             std::string inputfile, 
             int ncol, real2d &p_lay, real2d &t_lay,
             real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0,
-            real2d &lwp, real2d &iwp, real2d &rel, real2d &rei) {
+            real2d &lwp, real2d &iwp, real2d &rel, real2d &rei, real2d &cld) {
 
         // Setup boundary conditions, solar zenith angle, etc
         // NOTE: this stuff would come from the model in a real run
@@ -57,12 +57,12 @@ namespace rrtmgpTest {
         // needs the CloudOptics object only because it uses the min and max
         // valid values from the lookup tables for liquid and ice water path to
         // create a dummy atmosphere.
-        dummy_clouds(scream::rrtmgp::cloud_optics_sw, p_lay, t_lay, lwp, iwp, rel, rei);
+        dummy_clouds(scream::rrtmgp::cloud_optics_sw, p_lay, t_lay, lwp, iwp, rel, rei, cld);
     }
 
     void dummy_clouds(
             CloudOptics &cloud_optics, real2d &p_lay, real2d &t_lay, 
-            real2d &lwp, real2d &iwp, real2d &rel, real2d &rei) {
+            real2d &lwp, real2d &iwp, real2d &rel, real2d &rei, real2d &cloud_mask) {
 
         // Problem sizes
         int ncol = t_lay.dimension[0];
@@ -76,7 +76,7 @@ namespace rrtmgpTest {
         // Restrict clouds to troposphere (> 100 hPa = 100*100 Pa) and not very close to the ground (< 900 hPa), and
         // put them in 2/3 of the columns since that's roughly the total cloudiness of earth.
         // Set sane values for liquid and ice water path.
-        real2d cloud_mask("cloud_mask", ncol, nlay);
+        // NOTE: these "sane" values are in g/m2!
         parallel_for( Bounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
             cloud_mask(icol,ilay) = p_lay(icol,ilay) > 100._wp * 100._wp && p_lay(icol,ilay) < 900._wp * 100._wp && mod(icol, 3) != 0;
             // Ice and liquid will overlap in a few layers

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_test_utils.hpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_test_utils.hpp
@@ -6,13 +6,13 @@ namespace rrtmgpTest {
     bool all_equals(real2d &arr1, real2d &arr2);
     void dummy_clouds(
             CloudOptics &cloud_optics, real2d &p_lay, real2d &t_lay, 
-            real2d &lwp, real2d &iwp, real2d &rel, real2d &rei
+            real2d &lwp, real2d &iwp, real2d &rel, real2d &rei, real2d &cld
         );
     void dummy_atmos(
             std::string inputfile,
             int ncol, real2d &p_lay, real2d &t_lay,
             real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0,
-            real2d &lwp, real2d &iwp, real2d &rel, real2d &rei
+            real2d &lwp, real2d &iwp, real2d &rel, real2d &rei, real2d &cld
         );
     void read_fluxes(
             std::string inputfile, 

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
@@ -77,10 +77,11 @@ int main(int argc, char** argv) {
     real2d iwp("iwp", ncol, nlay);
     real2d rel("rel", ncol, nlay);
     real2d rei("rei", ncol, nlay);
+    real2d cld("cld", ncol, nlay);
     rrtmgpTest::dummy_atmos(
             inputfile, ncol, p_lay, t_lay,
             sfc_alb_dir, sfc_alb_dif, mu0,
-            lwp, iwp, rel, rei
+            lwp, iwp, rel, rei, cld
         );
 
     // Setup flux outputs; In a real model run, the fluxes would be
@@ -142,6 +143,7 @@ int main(int argc, char** argv) {
     iwp.deallocate();
     rel.deallocate();
     rei.deallocate();
+    cld.deallocate();
     yakl::finalize();
 
     return nerr != 0 ? 1 : 0;

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
@@ -78,9 +78,9 @@ TEST_CASE("rrtmgp_test_mixing_ratio_to_cloud_mass") {
         mixing_ratio(1,1) = 0.0001;
         cloud_fraction(1,1) = 1.0;
     });
-    auto cloud_mass_ref = mixing_ratio(1,1) * dp(1,1) / physconst::gravit;
+    auto cloud_mass_ref = mixing_ratio.createHostCopy()(1,1) / cloud_fraction.createHostCopy()(1,1) * dp.createHostCopy()(1,1) / physconst::gravit;
     scream::rrtmgp::mixing_ratio_to_cloud_mass(mixing_ratio, cloud_fraction, dp, cloud_mass);
-    REQUIRE(cloud_mass(1,1) == cloud_mass_ref);
+    REQUIRE(cloud_mass.createHostCopy()(1,1) == cloud_mass_ref);
 
     // Test with no cloud
     parallel_for(1, YAKL_LAMBDA(int dummy) {
@@ -90,7 +90,7 @@ TEST_CASE("rrtmgp_test_mixing_ratio_to_cloud_mass") {
     });
     cloud_mass_ref = 0.0;
     scream::rrtmgp::mixing_ratio_to_cloud_mass(mixing_ratio, cloud_fraction, dp, cloud_mass);
-    REQUIRE(cloud_mass(1,1) == cloud_mass_ref);
+    REQUIRE(cloud_mass.createHostCopy()(1,1) == cloud_mass_ref);
  
      // Test with empty clouds (cloud fraction but with no associated mixing ratio)
      // This case could happen if we use a total cloud fraction, but compute layer
@@ -102,7 +102,7 @@ TEST_CASE("rrtmgp_test_mixing_ratio_to_cloud_mass") {
     });
     cloud_mass_ref = 0.0;
     scream::rrtmgp::mixing_ratio_to_cloud_mass(mixing_ratio, cloud_fraction, dp, cloud_mass);
-    REQUIRE(cloud_mass(1,1) == cloud_mass_ref);
+    REQUIRE(cloud_mass.createHostCopy()(1,1) == cloud_mass_ref);
  
     // Test with cell half filled with cloud
     parallel_for(1, YAKL_LAMBDA(int dummy) {
@@ -110,7 +110,14 @@ TEST_CASE("rrtmgp_test_mixing_ratio_to_cloud_mass") {
         mixing_ratio(1,1) = 0.0001;
         cloud_fraction(1,1) = 0.5;
     });
-    cloud_mass_ref = mixing_ratio(1,1) / cloud_fraction(1,1) * dp(1,1) / physconst::gravit;
+    cloud_mass_ref = mixing_ratio.createHostCopy()(1,1) / cloud_fraction.createHostCopy()(1,1) * dp.createHostCopy()(1,1) / physconst::gravit;
     scream::rrtmgp::mixing_ratio_to_cloud_mass(mixing_ratio, cloud_fraction, dp, cloud_mass);
-    REQUIRE(cloud_mass(1,1) == cloud_mass_ref);
+    REQUIRE(cloud_mass.createHostCopy()(1,1) == cloud_mass_ref);
+
+    // Clean up
+    dp.deallocate();
+    mixing_ratio.deallocate();
+    cloud_fraction.deallocate();
+    cloud_mass.deallocate();
+    yakl::finalize();
 }

--- a/components/scream/tests/rrtmgp/input.yaml
+++ b/components/scream/tests/rrtmgp/input.yaml
@@ -28,8 +28,9 @@ Initial Conditions:
   surf_alb_direct: 0.0
   surf_alb_diffuse: 0.0
   cos_zenith: 0.0
-  lwp: 0.0
-  iwp: 0.0
+  qc: 0.0
+  qi: 0.0
+  cldfrac_tot: 0.0
   eff_radius_qc: 0.0
   eff_radius_qi: 0.0
 ...


### PR DESCRIPTION
Pass cloud water and ice mixing ratios into radiation interface instead of expecting in-cloud water and ice mass (i.e., what is called in-cloud liquid and ice water path in EAM). This requires radiation to compute these quantities from the mixing ratios, but it makes more sense to keep this localized to radiation and just pass standard fields through the field manager, rather than requiring microphysics to compute things that are only needed by the radiation code. Fixes #965.