### PR TITLE
SCREAM: define and enable default fpes based on SCREAM_FPE

### DIFF
--- a/components/scream/src/share/scream_session.cpp
+++ b/components/scream/src/share/scream_session.cpp
@@ -1,14 +1,27 @@
 #include "scream_session.hpp"
 #include "scream_config.hpp"
 
+#include "ekat/ekat_assert.hpp"
 #include "ekat/ekat_session.hpp"
+#include "ekat/util/ekat_feutils.hpp"
 
 #include <iostream>
 
 namespace scream {
 
+static int get_default_fpes () {
+#ifdef SCREAM_FPE
+  return (FE_DIVBYZERO |
+          FE_INVALID   |
+          FE_OVERFLOW);
+#else
+  return 0;
+#endif
+}
+
 void initialize_scream_session (bool print_config) {
   ekat::initialize_ekat_session(false);
+  ekat::enable_fpes(get_default_fpes());
 
   if (print_config) 
     std::cout << scream_config_string() << "\n";
@@ -16,6 +29,7 @@ void initialize_scream_session (bool print_config) {
 
 void initialize_scream_session (int argc, char **argv, bool print_config) {
   ekat::initialize_ekat_session(argc,argv,false);
+  ekat::enable_fpes(get_default_fpes());
   if (print_config) 
     std::cout << scream_config_string() << "\n";
 }


### PR DESCRIPTION
Up to now, we were actually *never* enabling FPEs in scream. EKAT does not really define default fpes (see github issue https://github.com/E3SM-Project/EKAT/issues/114), so our fpe builds ended up being just...builds.

Scream should take control of defining its own default fpes, as well as enabling them when a scream session starts. The fix is simple, but it had to be manually tested. In fact, since FPE are not a language feature, but an OS feature, we cannot "capture" them. There _is_, to be fair, a way to test the FPE mask (see [here](https://github.com/E3SM-Project/EKAT/blob/master/tests/utils/debug_tools_tests.cpp) to see what EKAT does for that), but it's rather clunky, and messes with OS calls. However, if we think there would be value in it, we can run a test that verifies that the macro SCREAM_FPE indeed enables our default fpe mask, but running some buggy code and verifying that the FPE is raised.