### PR TITLE
Separate gas_vmr into separate gas concentration species in rrtmgp interface

### DIFF
--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -161,7 +161,7 @@ void RRTMGPRadiation::init_buffers(const ATMBufferManager &buffer_manager)
 
 void RRTMGPRadiation::initialize_impl(const util::TimeStamp& /* t0 */) {
   // Names of active gases
-  // TODO: Is there anyway to store the gas_names_1d information somewhere once,
+  // TODO: Is there any way to store the gas_names_1d information somewhere once,
   // rather than populate this array every step?
   // It appears that "gas_concs.init(...)" requires a YAKL string1d array as input,
   // which would need to be defined with its size pre-initialization, but this breaks the
@@ -201,14 +201,6 @@ void RRTMGPRadiation::run_impl (const Real dt) {
   auto d_sw_flux_dn_dir = m_rrtmgp_fields_out.at("SW_flux_dn_dir").get_reshaped_view<Real**>();
   auto d_lw_flux_up = m_rrtmgp_fields_out.at("LW_flux_up").get_reshaped_view<Real**>();
   auto d_lw_flux_dn = m_rrtmgp_fields_out.at("LW_flux_dn").get_reshaped_view<Real**>();
-  auto d_qv  = m_rrtmgp_fields_in.at("qv").get_reshaped_view<const Real**>();
-  auto d_co2 = m_rrtmgp_fields_in.at("co2").get_reshaped_view<const Real**>();
-  auto d_o3  = m_rrtmgp_fields_in.at("o3").get_reshaped_view<const Real**>();
-  auto d_n2o = m_rrtmgp_fields_in.at("n2o").get_reshaped_view<const Real**>();
-  auto d_co  = m_rrtmgp_fields_in.at("co").get_reshaped_view<const Real**>();
-  auto d_ch4 = m_rrtmgp_fields_in.at("ch4").get_reshaped_view<const Real**>();
-  auto d_o2  = m_rrtmgp_fields_in.at("o2").get_reshaped_view<const Real**>();
-  auto d_n2  = m_rrtmgp_fields_in.at("n2").get_reshaped_view<const Real**>();
 
   // Create YAKL arrays. RRTMGP expects YAKL arrays with styleFortran, i.e., data has ncol
   // as the fastest index. For this reason we must copy the data.

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -90,8 +90,7 @@ int RRTMGPRadiation::requested_buffer_size_in_bytes() const
   const int interface_request = Buffer::num_1d_ncol*m_ncol*sizeof(Real) +
                                 Buffer::num_2d_nlay*m_ncol*m_nlay*sizeof(Real) +
                                 Buffer::num_2d_nlay_p1*m_ncol*(m_nlay+1)*sizeof(Real) +
-                                Buffer::num_2d_nswbands*m_ncol*m_nswbands*sizeof(Real) +
-                                Buffer::num_3d_ngas*m_ncol*m_nlay*m_ngas*sizeof(Real);
+                                Buffer::num_2d_nswbands*m_ncol*m_nswbands*sizeof(Real);
 
   return interface_request;
 } // RRTMGPRadiation::requested_buffer_size

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -172,10 +172,7 @@ void RRTMGPRadiation::initialize_impl(const util::TimeStamp& /* t0 */) {
   }
   Kokkos::deep_copy(m_gas_mol_weights,gas_mol_w_host);
   // Initialize GasConcs object to pass to RRTMGP initializer;
-  // This is just to provide gas names
-  // Make GasConcs from m_gas_names_yakl_offset
-  GasConcs gas_concs;
-  gas_concs.init(m_gas_names_yakl_offset,1,1);
+  gas_concs.init(m_gas_names_yakl_offset,m_ncol,m_nlay);
   rrtmgp::rrtmgp_initialize(gas_concs);
 
 }
@@ -254,10 +251,7 @@ void RRTMGPRadiation::run_impl (const Real dt) {
   }
   Kokkos::fence();
 
-  // Create and populate a GasConcs object to pass to RRTMGP driver
-  // TODO: Can gas_concs be a class variable that only needs to be init'd once?
-  GasConcs gas_concs;
-  gas_concs.init(m_gas_names_yakl_offset,m_ncol,m_nlay);
+  // Populate GasConcs object to pass to RRTMGP driver
   auto tmp2d = m_buffer.tmp2d;
   for (int igas = 0; igas < m_ngas; igas++) {
     auto name = m_gas_names_yakl_offset(igas+1);
@@ -348,6 +342,7 @@ void RRTMGPRadiation::run_impl (const Real dt) {
 }
 
 void RRTMGPRadiation::finalize_impl  () {
+  gas_concs.reset();
   rrtmgp::rrtmgp_finalize();
 }
 

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -48,7 +48,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   // Set up dimension layouts
   FieldLayout scalar2d_layout     { {COL   }, {m_ncol    } };
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_ncol,m_nlay} };
-  FieldLayout scalar3d_layout_int { {COL,LEV}, {m_ncol,m_nlay+1} };
+  FieldLayout scalar3d_layout_int { {COL,ILEV}, {m_ncol,m_nlay+1} };
   // Use VAR field tag for gases for now; consider adding a tag?
   FieldLayout scalar2d_swband_layout { {COL,SWBND}, {m_ncol,m_nswbands} };
 
@@ -61,8 +61,8 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Required>("surf_alb_direct", scalar2d_swband_layout, nondim, grid->name(), ps);
   add_field<Required>("surf_alb_diffuse", scalar2d_swband_layout, nondim, grid->name(), ps);
   add_field<Required>("cos_zenith", scalar2d_layout, nondim, grid->name(), ps);
-  add_field<Required>("qc", scalar3d_layout_mid, kg/kg, grid->name(), ps);
-  add_field<Required>("qi", scalar3d_layout_mid, kg/kg, grid->name(), ps);
+  add_field<Required>("qc", scalar3d_layout_mid, kgkg, grid->name(), ps);
+  add_field<Required>("qi", scalar3d_layout_mid, kgkg, grid->name(), ps);
   add_field<Required>("cldfrac_tot", scalar3d_layout_mid, nondim, grid->name(), ps);
   add_field<Required>("eff_radius_qc", scalar3d_layout_mid, micron, grid->name(), ps);
   add_field<Required>("eff_radius_qi", scalar3d_layout_mid, micron, grid->name(), ps);

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -1,4 +1,6 @@
 #include "ekat/ekat_assert.hpp"
+#include "ekat/ekat_pack_kokkos.hpp"
+#include "physics/rrtmgp/scream_rrtmgp_interface.hpp"
 #include "physics/rrtmgp/atmosphere_radiation.hpp"
 #include "physics/rrtmgp/rrtmgp_heating_rate.hpp"
 #include "cpp/rrtmgp/mo_gas_concentrations.h"
@@ -37,39 +39,39 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_ncol,m_nlay} };
   FieldLayout scalar3d_layout_int { {COL,LEV}, {m_ncol,m_nlay+1} };
   // Use VAR field tag for gases for now; consider adding a tag?
-  FieldLayout gas_layout          { {COL,LEV,NGAS}, {m_ncol,m_nlay,m_ngas} };
   FieldLayout scalar2d_swband_layout { {COL,SWBND}, {m_ncol,m_nswbands} };
 
+  constexpr int ps = ekat::Pack<Real,SCREAM_SMALL_PACK_SIZE>::n;
   // Set required (input) fields here
-  add_field<Required>("p_mid" , scalar3d_layout_mid, Pa, grid->name());
-  add_field<Required>("p_int", scalar3d_layout_int, Pa, grid->name());
-  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa, grid->name());
-  add_field<Required>("t_int" , scalar3d_layout_int, K , grid->name());
-  add_field<Required>("surf_alb_direct", scalar2d_swband_layout, nondim, grid->name());
-  add_field<Required>("surf_alb_diffuse", scalar2d_swband_layout, nondim, grid->name());
-  add_field<Required>("cos_zenith", scalar2d_layout, nondim, grid->name());
-  add_field<Required>("qc", scalar3d_layout_mid, kg/kg, grid->name());
-  add_field<Required>("qi", scalar3d_layout_mid, kg/kg, grid->name());
-  add_field<Required>("cldfrac_tot", scalar3d_layout_mid, nondim, grid->name());
-  add_field<Required>("eff_radius_qc", scalar3d_layout_mid, micron, grid->name());
-  add_field<Required>("eff_radius_qi", scalar3d_layout_mid, micron, grid->name());
+  add_field<Required>("p_mid" , scalar3d_layout_mid, Pa, grid->name(), ps);
+  add_field<Required>("p_int", scalar3d_layout_int, Pa, grid->name(), ps);
+  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa, grid->name(), ps);
+  add_field<Required>("t_int" , scalar3d_layout_int, K , grid->name(), ps);
+  add_field<Required>("surf_alb_direct", scalar2d_swband_layout, nondim, grid->name(), ps);
+  add_field<Required>("surf_alb_diffuse", scalar2d_swband_layout, nondim, grid->name(), ps);
+  add_field<Required>("cos_zenith", scalar2d_layout, nondim, grid->name(), ps);
+  add_field<Required>("qc", scalar3d_layout_mid, kg/kg, grid->name(), ps);
+  add_field<Required>("qi", scalar3d_layout_mid, kg/kg, grid->name(), ps);
+  add_field<Required>("cldfrac_tot", scalar3d_layout_mid, nondim, grid->name(), ps);
+  add_field<Required>("eff_radius_qc", scalar3d_layout_mid, micron, grid->name(), ps);
+  add_field<Required>("eff_radius_qi", scalar3d_layout_mid, micron, grid->name(), ps);
   // Set of required gas concentration fields
-  add_field<Required>("qv", scalar3d_layout_mid,kgkg,grid->name());  // Called "h2o" in radiation
-  add_field<Required>("co2",scalar3d_layout_mid,kgkg,grid->name());
-  add_field<Required>("o3", scalar3d_layout_mid,kgkg,grid->name());
-  add_field<Required>("n2o",scalar3d_layout_mid,kgkg,grid->name());
-  add_field<Required>("co", scalar3d_layout_mid,kgkg,grid->name());
-  add_field<Required>("ch4",scalar3d_layout_mid,kgkg,grid->name());
-  add_field<Required>("o2", scalar3d_layout_mid,kgkg,grid->name());
-  add_field<Required>("n2", scalar3d_layout_mid,kgkg,grid->name());
+  add_field<Required>("qv", scalar3d_layout_mid,kgkg,grid->name(), ps);  // Called "h2o" in radiation
+  add_field<Required>("co2",scalar3d_layout_mid,kgkg,grid->name(), ps);
+  add_field<Required>("o3", scalar3d_layout_mid,kgkg,grid->name(), ps);
+  add_field<Required>("n2o",scalar3d_layout_mid,kgkg,grid->name(), ps);
+  add_field<Required>("co", scalar3d_layout_mid,kgkg,grid->name(), ps);
+  add_field<Required>("ch4",scalar3d_layout_mid,kgkg,grid->name(), ps);
+  add_field<Required>("o2", scalar3d_layout_mid,kgkg,grid->name(), ps);
+  add_field<Required>("n2", scalar3d_layout_mid,kgkg,grid->name(), ps);
 
   // Set computed (output) fields
-  add_field<Updated >("T_mid"     , scalar3d_layout_mid, K  , grid->name());
-  add_field<Computed>("SW_flux_dn", scalar3d_layout_int, Wm2, grid->name());
-  add_field<Computed>("SW_flux_up", scalar3d_layout_int, Wm2, grid->name());
-  add_field<Computed>("SW_flux_dn_dir", scalar3d_layout_int, Wm2, grid->name());
-  add_field<Computed>("LW_flux_up", scalar3d_layout_int, Wm2, grid->name());
-  add_field<Computed>("LW_flux_dn", scalar3d_layout_int, Wm2, grid->name());
+  add_field<Updated >("T_mid"     , scalar3d_layout_mid, K  , grid->name(), ps);
+  add_field<Computed>("SW_flux_dn", scalar3d_layout_int, Wm2, grid->name(), ps);
+  add_field<Computed>("SW_flux_up", scalar3d_layout_int, Wm2, grid->name(), ps);
+  add_field<Computed>("SW_flux_dn_dir", scalar3d_layout_int, Wm2, grid->name(), ps);
+  add_field<Computed>("LW_flux_up", scalar3d_layout_int, Wm2, grid->name(), ps);
+  add_field<Computed>("LW_flux_dn", scalar3d_layout_int, Wm2, grid->name(), ps);
 
 }  // RRTMGPRadiation::set_grids
 

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -187,6 +187,7 @@ void RRTMGPRadiation::run_impl (const Real dt) {
   auto d_sfc_alb_dir = m_rrtmgp_fields_in.at("surf_alb_direct").get_reshaped_view<const Real**>();
   auto d_sfc_alb_dif = m_rrtmgp_fields_in.at("surf_alb_diffuse").get_reshaped_view<const Real**>();
   auto d_mu0 = m_rrtmgp_fields_in.at("cos_zenith").get_reshaped_view<const Real*>();
+  auto d_qv = m_rrtmgp_fields_in.at("qv").get_reshaped_view<const Real**>();
   auto d_qc = m_rrtmgp_fields_in.at("qc").get_reshaped_view<const Real**>();
   auto d_qi = m_rrtmgp_fields_in.at("qi").get_reshaped_view<const Real**>();
   auto d_cldfrac_tot = m_rrtmgp_fields_in.at("cldfrac_tot").get_reshaped_view<const Real**>();
@@ -261,7 +262,7 @@ void RRTMGPRadiation::run_impl (const Real dt) {
     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int k = team.league_rank();
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, m_ncol), [&] (const int& i) {
-        tmp2d(i+1,k+1) = PF::calculate_vmr_from_mmr(m_gas_mol_weights[igas],d_temp(i,k)); // Note that for YAKL arrays i and k start with index 1
+        tmp2d(i+1,k+1) = PF::calculate_vmr_from_mmr(m_gas_mol_weights[igas],d_qv(i,k),d_temp(i,k)); // Note that for YAKL arrays i and k start with index 1
       });
     });
     Kokkos::fence();

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -16,6 +16,7 @@ class RRTMGPRadiation : public AtmosphereProcess {
 public:
   using field_type       = Field<      Real>;
   using const_field_type = Field<const Real>;
+  using view_1d_real     = typename ekat::KokkosTypes<DefaultDevice>::template view_1d<Real>;
 
   // Constructors
   RRTMGPRadiation (const ekat::Comm& comm, const ekat::ParameterList& params);
@@ -86,6 +87,7 @@ public:
   int m_ngas;
   std::vector<std::string> m_gas_names;
   string1d                 m_gas_names_yakl_offset; // Set of gas names with index offset by 1 to interface with YAKL.
+  view_1d_real             m_gas_mol_weights;
 
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -85,7 +85,7 @@ public:
   // These are the gases that we keep track of
   int m_ngas;
   std::vector<std::string> m_gas_names;
-  string1d m_gas_names_1d;
+  string1d                 m_gas_names_yakl_offset; // Set of gas names with index offset by 1 to interface with YAKL.
 
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -1,6 +1,7 @@
 #ifndef SCREAM_RRTMGP_RADIATION_HPP
 #define SCREAM_RRTMGP_RADIATION_HPP
 
+#include "cpp/rrtmgp/mo_gas_concentrations.h"
 #include "physics/rrtmgp/scream_rrtmgp_interface.hpp"
 #include "share/atm_process/atmosphere_process.hpp"
 #include "ekat/ekat_parameter_list.hpp"
@@ -88,6 +89,7 @@ public:
   std::vector<std::string> m_gas_names;
   string1d                 m_gas_names_yakl_offset; // Set of gas names with index offset by 1 to interface with YAKL.
   view_1d_real             m_gas_mol_weights;
+  GasConcs gas_concs;
 
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -87,7 +87,6 @@ public:
   // These are the gases that we keep track of
   int m_ngas;
   std::vector<std::string> m_gas_names;
-  string1d                 m_gas_names_yakl_offset; // Set of gas names with index offset by 1 to interface with YAKL.
   view_1d_real             m_gas_mol_weights;
   GasConcs gas_concs;
 

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -85,6 +85,7 @@ public:
   // These are the gases that we keep track of
   int m_ngas;
   std::vector<std::string> m_gas_names;
+  string1d m_gas_names_1d;
 
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -83,11 +83,8 @@ public:
   const int m_nlwbands = 16;
 
   // These are the gases that we keep track of
-  const int m_ngas = 8;
-  const std::string m_gas_names[8] = {
-      "h2o", "co2", "o3", "n2o",
-      "co" , "ch4", "o2", "n2"
-  };
+  int m_ngas;
+  std::vector<std::string> m_gas_names;
 
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -139,9 +139,15 @@ namespace scream {
 
             // Needed for consistency with all-sky example problem?
             cloud_optics.set_ice_roughness(2);
+ 
+            // Limit effective radii to be within bounds of lookup table
+            auto rel_limited = real2d("rel_limited", ncol, nlay);
+            auto rei_limited = real2d("rei_limited", ncol, nlay);
+            limit_to_bounds(rel, cloud_optics.radliq_lwr, cloud_optics.radliq_upr, rel_limited);
+            limit_to_bounds(rei, cloud_optics.radice_lwr, cloud_optics.radice_upr, rei_limited);
 
             // Calculate cloud optics
-            cloud_optics.cloud_optics(ncol, nlay, lwp, iwp, rel, rei, clouds);
+            cloud_optics.cloud_optics(ncol, nlay, lwp, iwp, rel_limited, rei_limited, clouds);
 
             // Return optics
             return clouds;
@@ -161,8 +167,14 @@ namespace scream {
             // Needed for consistency with all-sky example problem?
             cloud_optics.set_ice_roughness(2);
 
+            // Limit effective radii to be within bounds of lookup table
+            auto rel_limited = real2d("rel_limited", ncol, nlay);
+            auto rei_limited = real2d("rei_limited", ncol, nlay);
+            limit_to_bounds(rel, cloud_optics.radliq_lwr, cloud_optics.radliq_upr, rel_limited);
+            limit_to_bounds(rei, cloud_optics.radice_lwr, cloud_optics.radice_upr, rei_limited);
+
             // Calculate cloud optics
-            cloud_optics.cloud_optics(ncol, nlay, lwp, iwp, rel, rei, clouds);
+            cloud_optics.cloud_optics(ncol, nlay, lwp, iwp, rel_limited, rei_limited, clouds);
 
             // Return optics
             return clouds;

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -91,6 +91,18 @@ namespace scream {
             });
         }
 
+        /*
+         * Routine to limit a quantity to set bounds. Used to make sure
+         * effective radii are within the bounds of the cloud optical
+         * property look-up tables, but could be used to limit other
+         * fields as well.
+         */
+        template<class S, class T> void limit_to_bounds(S const &arr_in, T const lower, T const upper, S &arr_out) {
+            yakl::c::parallel_for(arr_in.totElems(), YAKL_LAMBDA(int i) {
+                arr_out.data()[i] = min(max(arr_in.data()[i], lower), upper);
+            });
+        }
+
     } // namespace rrtmgp
 }  // namespace scream
 

--- a/components/scream/src/physics/share/physics_constants.hpp
+++ b/components/scream/src/physics/share/physics_constants.hpp
@@ -110,6 +110,7 @@ struct Constants
 
   // Gases
   static const std::map<std::string,Scalar> gas_mol_weights;
+  static Scalar get_gas_mol_weight(std::string gas_name);
 };
 
 // Gases
@@ -117,7 +118,7 @@ struct Constants
 // used to determine the volume mixing ratio for each gas.
 template <typename Scalar>
 const std::map<std::string,Scalar> Constants<Scalar>::gas_mol_weights = {
-  {"h2o", Constants<Scalar>::MWH2O},
+  {"h2o", Scalar(Constants<Scalar>::MWH2O)},
   {"co2", 44.0095},
   {"o3" , 47.9982},
   {"n2o", 44.0128},
@@ -126,6 +127,11 @@ const std::map<std::string,Scalar> Constants<Scalar>::gas_mol_weights = {
   {"o2" , 31.998},
   {"n2" , 28.0134}
 };
+
+template <typename Scalar>
+Scalar Constants<Scalar>::get_gas_mol_weight(std::string gas_name) {
+  return Constants<Scalar>::gas_mol_weights.at(gas_name);
+}
 
 template <typename Scalar>
 constexpr Scalar Constants<Scalar>::NSMALL;

--- a/components/scream/src/physics/share/physics_constants.hpp
+++ b/components/scream/src/physics/share/physics_constants.hpp
@@ -87,7 +87,7 @@ struct Constants
   static constexpr Scalar Avogad        = 6.02214e26;
   static constexpr Scalar Boltz         = 1.38065e-23;
   static constexpr Scalar Rgas          = Avogad * Boltz;
-  static constexpr Scalar MWWV          = 18.016;
+  static constexpr Scalar MWWV          = 18.016;  //TODO: Aaron - Isn't this just MWH2O? Should we just have one of these?
   static constexpr Scalar RWV           = Rgas / MWWV;
   static constexpr Scalar ZVIR          = (RWV / Rair) - 1.0;
   static constexpr Scalar max_total_ni  = 500.e+3;  // maximum total ice concentration (sum of all categories) (m)
@@ -108,6 +108,23 @@ struct Constants
   // = 3 Khairoutdinov and Kogan 2000
   static constexpr int IPARAM         = 3;
 
+  // Gases
+  static const std::map<std::string,Scalar> gas_mol_weights;
+};
+
+// Gases
+// Define the molecular weight for each gas, which can then be
+// used to determine the volume mixing ratio for each gas.
+template <typename Scalar>
+const std::map<std::string,Scalar> Constants<Scalar>::gas_mol_weights = {
+  {"H2O", Constants<Scalar>::MWH2O},
+  {"CO2", 44.0095},
+  {"O3" , 47.9982},
+  {"N2O", 44.0128},
+  {"CO" , 28.0101},
+  {"CH4", 16.04246},
+  {"O2" , 31.998},
+  {"N2" , 28.0134}
 };
 
 template <typename Scalar>

--- a/components/scream/src/physics/share/physics_constants.hpp
+++ b/components/scream/src/physics/share/physics_constants.hpp
@@ -130,6 +130,8 @@ const std::map<std::string,Scalar> Constants<Scalar>::gas_mol_weights = {
 
 template <typename Scalar>
 Scalar Constants<Scalar>::get_gas_mol_weight(std::string gas_name) {
+  //TODO: Possible improvement would be to design a device friendly function
+  //      here instead of just a std::map lookup, which only works on host.
   return Constants<Scalar>::gas_mol_weights.at(gas_name);
 }
 

--- a/components/scream/src/physics/share/physics_constants.hpp
+++ b/components/scream/src/physics/share/physics_constants.hpp
@@ -117,14 +117,14 @@ struct Constants
 // used to determine the volume mixing ratio for each gas.
 template <typename Scalar>
 const std::map<std::string,Scalar> Constants<Scalar>::gas_mol_weights = {
-  {"H2O", Constants<Scalar>::MWH2O},
-  {"CO2", 44.0095},
-  {"O3" , 47.9982},
-  {"N2O", 44.0128},
-  {"CO" , 28.0101},
-  {"CH4", 16.04246},
-  {"O2" , 31.998},
-  {"N2" , 28.0134}
+  {"h2o", Constants<Scalar>::MWH2O},
+  {"co2", 44.0095},
+  {"o3" , 47.9982},
+  {"n2o", 44.0128},
+  {"co" , 28.0101},
+  {"ch4", 16.04246},
+  {"o2" , 31.998},
+  {"n2" , 28.0134}
 };
 
 template <typename Scalar>

--- a/components/scream/src/physics/share/physics_constants.hpp
+++ b/components/scream/src/physics/share/physics_constants.hpp
@@ -87,7 +87,7 @@ struct Constants
   static constexpr Scalar Avogad        = 6.02214e26;
   static constexpr Scalar Boltz         = 1.38065e-23;
   static constexpr Scalar Rgas          = Avogad * Boltz;
-  static constexpr Scalar MWWV          = 18.016;  //TODO: Aaron - Isn't this just MWH2O? Should we just have one of these?
+  static constexpr Scalar MWWV          = MWH2O;
   static constexpr Scalar RWV           = Rgas / MWWV;
   static constexpr Scalar ZVIR          = (RWV / Rair) - 1.0;
   static constexpr Scalar max_total_ni  = 500.e+3;  // maximum total ice concentration (sum of all categories) (m)

--- a/components/scream/src/share/util/scream_common_physics_functions.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions.hpp
@@ -140,7 +140,7 @@ struct PhysicsFunctions
   //-----------------------------------------------------------------------------------------------//
   template<typename ScalarT>
   KOKKOS_INLINE_FUNCTION
-  static ScalarT calculate_vmr_from_mmr(const std::string& gas_name, const ScalarT& mmr);
+  static ScalarT calculate_vmr_from_mmr(const Real& gas_mol_weight, const ScalarT& mmr);
 
   //-----------------------------------------------------------------------------------------------//
   // Calculate the volume mixing ratio given the wet mass mixing ratio:
@@ -154,7 +154,7 @@ struct PhysicsFunctions
   //-----------------------------------------------------------------------------------------------//
   template<typename ScalarT>
   KOKKOS_INLINE_FUNCTION
-  static ScalarT calculate_mmr_from_vmr(const std::string& gas_name, const ScalarT& vmr);
+  static ScalarT calculate_mmr_from_vmr(const Real& gas_mol_weight, const ScalarT& vmr);
 
   // ---------------------------------------------------------------- //
   //                     Whole column Functions                       //
@@ -248,14 +248,14 @@ struct PhysicsFunctions
   template<typename ScalarT, typename InputProviderX>
   KOKKOS_INLINE_FUNCTION
   static void calculate_vmr_from_mmr(const MemberType& team,
-                                     const std::string gas_name,
+                                     const Real gas_mol_weight,
                                      const InputProviderX& mmr,
                                      const view_1d<ScalarT>& vmr);
 
   template<typename ScalarT, typename InputProviderX>
   KOKKOS_INLINE_FUNCTION
   static void calculate_mmr_from_vmr(const MemberType& team,
-                                     const std::string gas_name,
+                                     const Real gas_mol_weight,
                                      const InputProviderX& vmr,
                                      const view_1d<ScalarT>& mmr);
 

--- a/components/scream/src/share/util/scream_common_physics_functions.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions.hpp
@@ -143,7 +143,7 @@ struct PhysicsFunctions
   static ScalarT calculate_vmr_from_mmr(const Real& gas_mol_weight, const ScalarT& mmr);
 
   //-----------------------------------------------------------------------------------------------//
-  // Calculate the volume mixing ratio given the wet mass mixing ratio:
+  // Calculate wet mass mixing ratio the given the volume mixing ratio:
   //   X_mmr = a*X_vmr / (1 + a*X_vmr)
   // where
   //   X_vmr          is the volume mixing ratio X

--- a/components/scream/src/share/util/scream_common_physics_functions.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions.hpp
@@ -141,6 +141,21 @@ struct PhysicsFunctions
   template<typename ScalarT>
   KOKKOS_INLINE_FUNCTION
   static ScalarT calculate_vmr_from_mmr(const std::string& gas_name, const ScalarT& mmr);
+
+  //-----------------------------------------------------------------------------------------------//
+  // Calculate the volume mixing ratio given the wet mass mixing ratio:
+  //   X_mmr = a*X_vmr / (1 + a*X_vmr)
+  // where
+  //   X_vmr          is the volume mixing ratio X
+  //   X_mmr          is the mass mixing ratio of X
+  //   mol_weight_air is the molecular weight of dry air
+  //   mol_weight_X   is the molecular weight of X
+  //   a = mol_weight_X/mol_weight_air is the ratio of the molecular weight of the gas to the molecular weight of dry air
+  //-----------------------------------------------------------------------------------------------//
+  template<typename ScalarT>
+  KOKKOS_INLINE_FUNCTION
+  static ScalarT calculate_mmr_from_vmr(const std::string& gas_name, const ScalarT& vmr);
+
   // ---------------------------------------------------------------- //
   //                     Whole column Functions                       //
   // ---------------------------------------------------------------- //
@@ -236,6 +251,13 @@ struct PhysicsFunctions
                                      const std::string gas_name,
                                      const InputProviderX& mmr,
                                      const view_1d<ScalarT>& vmr);
+
+  template<typename ScalarT, typename InputProviderX>
+  KOKKOS_INLINE_FUNCTION
+  static void calculate_mmr_from_vmr(const MemberType& team,
+                                     const std::string gas_name,
+                                     const InputProviderX& vmr,
+                                     const view_1d<ScalarT>& mmr);
 
   //-----------------------------------------------------------------------------------------------//
   // Determines the vertical layer interface height from the vertical layer thicknesses:

--- a/components/scream/src/share/util/scream_common_physics_functions.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions.hpp
@@ -131,30 +131,32 @@ struct PhysicsFunctions
 
   //-----------------------------------------------------------------------------------------------//
   // Calculate the volume mixing ratio given the wet mass mixing ratio:
-  //   X_vmr = X_mmr / (1 - X_mmr) * mol_weight_air/mol_weight_X
+  //   X_vmr = X_mmr / (1 - qv) * mol_weight_air/mol_weight_X
   // where
   //   X_vmr          is the volume mixing ratio X
   //   X_mmr          is the mass mixing ratio of X
+  //   qv             is the water vapor mass mixing ratio
   //   mol_weight_air is the molecular weight of dry air
   //   mol_weight_X   is the molecular weight of X
   //-----------------------------------------------------------------------------------------------//
   template<typename ScalarT>
   KOKKOS_INLINE_FUNCTION
-  static ScalarT calculate_vmr_from_mmr(const Real& gas_mol_weight, const ScalarT& mmr);
+  static ScalarT calculate_vmr_from_mmr(const Real& gas_mol_weight, const ScalarT& qv, const ScalarT& mmr);
 
   //-----------------------------------------------------------------------------------------------//
   // Calculate wet mass mixing ratio the given the volume mixing ratio:
-  //   X_mmr = a*X_vmr / (1 + a*X_vmr)
+  //   X_mmr = a*X_vmr * (1 -qv)
   // where
   //   X_vmr          is the volume mixing ratio X
   //   X_mmr          is the mass mixing ratio of X
+  //   qv             is the water vapor mass mixing ratio
   //   mol_weight_air is the molecular weight of dry air
   //   mol_weight_X   is the molecular weight of X
   //   a = mol_weight_X/mol_weight_air is the ratio of the molecular weight of the gas to the molecular weight of dry air
   //-----------------------------------------------------------------------------------------------//
   template<typename ScalarT>
   KOKKOS_INLINE_FUNCTION
-  static ScalarT calculate_mmr_from_vmr(const Real& gas_mol_weight, const ScalarT& vmr);
+  static ScalarT calculate_mmr_from_vmr(const Real& gas_mol_weight, const ScalarT& qv, const ScalarT& vmr);
 
   // ---------------------------------------------------------------- //
   //                     Whole column Functions                       //
@@ -245,17 +247,19 @@ struct PhysicsFunctions
                             const InputProviderQ& qv,
                             const view_1d<ScalarT>& dz);
 
-  template<typename ScalarT, typename InputProviderX>
+  template<typename ScalarT, typename InputProviderQ, typename InputProviderX>
   KOKKOS_INLINE_FUNCTION
   static void calculate_vmr_from_mmr(const MemberType& team,
                                      const Real gas_mol_weight,
+                                     const InputProviderQ& qv,
                                      const InputProviderX& mmr,
                                      const view_1d<ScalarT>& vmr);
 
-  template<typename ScalarT, typename InputProviderX>
+  template<typename ScalarT, typename InputProviderQ, typename InputProviderX>
   KOKKOS_INLINE_FUNCTION
   static void calculate_mmr_from_vmr(const MemberType& team,
                                      const Real gas_mol_weight,
+                                     const InputProviderQ& qv,
                                      const InputProviderX& vmr,
                                      const view_1d<ScalarT>& mmr);
 

--- a/components/scream/src/share/util/scream_common_physics_functions.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions.hpp
@@ -129,6 +129,18 @@ struct PhysicsFunctions
   static ScalarT calculate_dz (const ScalarT& pseudo_density, const ScalarT& p_mid,
                                const ScalarT& T_mid, const ScalarT& qv);
 
+  //-----------------------------------------------------------------------------------------------//
+  // Calculate the volume mixing ratio given the wet mass mixing ratio:
+  //   X_vmr = X_mmr / (1 - X_mmr) * mol_weight_air/mol_weight_X
+  // where
+  //   X_vmr          is the volume mixing ratio X
+  //   X_mmr          is the mass mixing ratio of X
+  //   mol_weight_air is the molecular weight of dry air
+  //   mol_weight_X   is the molecular weight of X
+  //-----------------------------------------------------------------------------------------------//
+  template<typename ScalarT>
+  KOKKOS_INLINE_FUNCTION
+  static ScalarT calculate_vmr_from_mmr(const std::string& gas_name, const ScalarT& mmr);
   // ---------------------------------------------------------------- //
   //                     Whole column Functions                       //
   // ---------------------------------------------------------------- //
@@ -218,6 +230,13 @@ struct PhysicsFunctions
                             const InputProviderQ& qv,
                             const view_1d<ScalarT>& dz);
 
+  template<typename ScalarT, typename InputProviderX>
+  KOKKOS_INLINE_FUNCTION
+  static void calculate_vmr_from_mmr(const MemberType& team,
+                                     const std::string gas_name,
+                                     const InputProviderX& mmr,
+                                     const view_1d<ScalarT>& vmr);
+
   //-----------------------------------------------------------------------------------------------//
   // Determines the vertical layer interface height from the vertical layer thicknesses:
   //   z_int = int_0^z(dz)
@@ -234,7 +253,7 @@ struct PhysicsFunctions
                                const Real z_surf,
                                const view_1d<ScalarT>& z_int);
 
-
+  
 
 }; // struct PhysicsFunctions
 

--- a/components/scream/src/share/util/scream_common_physics_functions_impl.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions_impl.hpp
@@ -211,53 +211,55 @@ void PhysicsFunctions<DeviceT>::calculate_z_int(const MemberType& team,
 template<typename DeviceT>
 template<typename ScalarT>
 KOKKOS_INLINE_FUNCTION
-ScalarT PhysicsFunctions<DeviceT>::calculate_vmr_from_mmr(const Real& gas_mol_weight, const ScalarT& mmr)
+ScalarT PhysicsFunctions<DeviceT>::calculate_vmr_from_mmr(const Real& gas_mol_weight, const ScalarT& qv, const ScalarT& mmr)
 {
   using C = scream::physics::Constants<Real>;
   constexpr Real air_mol_weight   = C::MWdry;
 
-  return mmr / (1.0 - mmr) * air_mol_weight/gas_mol_weight;
+  return mmr / (1.0 - qv) * air_mol_weight/gas_mol_weight;
 
 }
 
 template<typename DeviceT>
-template<typename ScalarT, typename InputProviderX>
+template<typename ScalarT, typename InputProviderQ, typename InputProviderX>
 KOKKOS_INLINE_FUNCTION
 void PhysicsFunctions<DeviceT>::calculate_vmr_from_mmr(const MemberType& team,
                                                        const Real gas_mol_weight,
+                                                       const InputProviderQ& qv,
                                                        const InputProviderX& mmr,
                                                        const view_1d<ScalarT>& vmr)
 {
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team,vmr.extent(0)),
                        [&] (const int k) {
-    vmr(k) = calculate_vmr_from_mmr(gas_mol_weight,mmr(k));
+    vmr(k) = calculate_vmr_from_mmr(gas_mol_weight,qv(k),mmr(k));
   });
 }
 
 template<typename DeviceT>
 template<typename ScalarT>
 KOKKOS_INLINE_FUNCTION
-ScalarT PhysicsFunctions<DeviceT>::calculate_mmr_from_vmr(const Real& gas_mol_weight, const ScalarT& vmr)
+ScalarT PhysicsFunctions<DeviceT>::calculate_mmr_from_vmr(const Real& gas_mol_weight, const ScalarT& qv, const ScalarT& vmr)
 {
   using C = scream::physics::Constants<Real>;
   constexpr Real air_mol_weight   = C::MWdry;
   const Real mol_weight_ratio = gas_mol_weight/air_mol_weight;
 
-  return mol_weight_ratio*vmr / (1.0 + mol_weight_ratio*vmr); 
+  return mol_weight_ratio * vmr * (1.0 - qv); 
 
 }
 
 template<typename DeviceT>
-template<typename ScalarT, typename InputProviderX>
+template<typename ScalarT, typename InputProviderQ, typename InputProviderX>
 KOKKOS_INLINE_FUNCTION
 void PhysicsFunctions<DeviceT>::calculate_mmr_from_vmr(const MemberType& team,
                                                        const Real gas_mol_weight,
+                                                       const InputProviderQ& qv,
                                                        const InputProviderX& vmr,
                                                        const view_1d<ScalarT>& mmr)
 {
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team,mmr.extent(0)),
                        [&] (const int k) {
-    mmr(k) = calculate_mmr_from_vmr(gas_mol_weight,vmr(k));
+    mmr(k) = calculate_mmr_from_vmr(gas_mol_weight,qv(k),vmr(k));
   });
 }
 

--- a/components/scream/src/share/util/scream_common_physics_functions_impl.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions_impl.hpp
@@ -211,14 +211,12 @@ void PhysicsFunctions<DeviceT>::calculate_z_int(const MemberType& team,
 template<typename DeviceT>
 template<typename ScalarT>
 KOKKOS_INLINE_FUNCTION
-ScalarT PhysicsFunctions<DeviceT>::calculate_vmr_from_mmr(const std::string& gas_name, const ScalarT& mmr)
+ScalarT PhysicsFunctions<DeviceT>::calculate_vmr_from_mmr(const Real& gas_mol_weight, const ScalarT& mmr)
 {
   using C = scream::physics::Constants<Real>;
   constexpr Real air_mol_weight   = C::MWdry;
-  constexpr auto& gas_mol_weights = C::gas_mol_weights;
-  EKAT_REQUIRE(gas_mol_weights.find(gas_name)!=gas_mol_weights.end());
 
-  return mmr / (1.0 - mmr) * air_mol_weight/gas_mol_weights.at(gas_name);
+  return mmr / (1.0 - mmr) * air_mol_weight/gas_mol_weight;
 
 }
 
@@ -226,26 +224,24 @@ template<typename DeviceT>
 template<typename ScalarT, typename InputProviderX>
 KOKKOS_INLINE_FUNCTION
 void PhysicsFunctions<DeviceT>::calculate_vmr_from_mmr(const MemberType& team,
-                                                       const std::string gas_name,
+                                                       const Real gas_mol_weight,
                                                        const InputProviderX& mmr,
                                                        const view_1d<ScalarT>& vmr)
 {
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team,vmr.extent(0)),
                        [&] (const int k) {
-    vmr(k) = calculate_vmr_from_mmr(gas_name,mmr(k));
+    vmr(k) = calculate_vmr_from_mmr(gas_mol_weight,mmr(k));
   });
 }
 
 template<typename DeviceT>
 template<typename ScalarT>
 KOKKOS_INLINE_FUNCTION
-ScalarT PhysicsFunctions<DeviceT>::calculate_mmr_from_vmr(const std::string& gas_name, const ScalarT& vmr)
+ScalarT PhysicsFunctions<DeviceT>::calculate_mmr_from_vmr(const Real& gas_mol_weight, const ScalarT& vmr)
 {
   using C = scream::physics::Constants<Real>;
   constexpr Real air_mol_weight   = C::MWdry;
-  constexpr auto& gas_mol_weights = C::gas_mol_weights;
-  EKAT_REQUIRE(gas_mol_weights.find(gas_name)!=gas_mol_weights.end());
-  const Real mol_weight_ratio = gas_mol_weights.at(gas_name)/air_mol_weight;
+  const Real mol_weight_ratio = gas_mol_weight/air_mol_weight;
 
   return mol_weight_ratio*vmr / (1.0 + mol_weight_ratio*vmr); 
 
@@ -255,13 +251,13 @@ template<typename DeviceT>
 template<typename ScalarT, typename InputProviderX>
 KOKKOS_INLINE_FUNCTION
 void PhysicsFunctions<DeviceT>::calculate_mmr_from_vmr(const MemberType& team,
-                                                       const std::string gas_name,
+                                                       const Real gas_mol_weight,
                                                        const InputProviderX& vmr,
                                                        const view_1d<ScalarT>& mmr)
 {
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team,mmr.extent(0)),
                        [&] (const int k) {
-    mmr(k) = calculate_mmr_from_vmr(gas_name,vmr(k));
+    mmr(k) = calculate_mmr_from_vmr(gas_mol_weight,vmr(k));
   });
 }
 

--- a/components/scream/tests/rrtmgp/input.yaml
+++ b/components/scream/tests/rrtmgp/input.yaml
@@ -24,7 +24,6 @@ Initial Conditions:
   pseudo_density: 0.0
   T_mid: 0.0
   t_int: 0.0
-  gas_vmr: 0.0
   surf_alb_direct: 0.0
   surf_alb_diffuse: 0.0
   cos_zenith: 0.0
@@ -33,4 +32,12 @@ Initial Conditions:
   cldfrac_tot: 0.0
   eff_radius_qc: 0.0
   eff_radius_qi: 0.0
+  qv: 0.0
+  co2: 0.0
+  o3: 0.0
+  n2o: 0.0
+  co: 0.0
+  ch4: 0.0
+  o2: 0.0
+  n2: 0.0
 ...

--- a/components/scream/tests/rrtmgp/input.yaml
+++ b/components/scream/tests/rrtmgp/input.yaml
@@ -9,6 +9,7 @@ Atmosphere Processes:
   Process 0:
     Process Name: RRTMGP
     Grid: Physics
+    active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 Grids Manager:
   Type: Physics Only

--- a/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
+++ b/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
@@ -17,6 +17,7 @@
 #include "mo_garand_atmos_io.h"
 #include "Intrinsics.h"
 #include "rrtmgp_test_utils.hpp"
+#include "share/util/scream_common_physics_functions.hpp"
 
 /*
  * Run standalone test problem for RRTMGP and compare with baseline
@@ -34,6 +35,7 @@ namespace scream {
     TEST_CASE("rrtmgp_scream_stand_alone", "") {
         using namespace scream;
         using namespace scream::control;
+        using PF = scream::PhysicsFunctions<DefaultDevice>;
 
         // Get baseline name (needs to be passed as an arg)
         std::string inputfile = ekat::TestSession::get().params.at("rrtmgp_inputfile");
@@ -200,14 +202,14 @@ namespace scream {
               d_pint(i,k) = p_lev(i+1,k+1);
               d_tint(i,k) = t_lev(i+1,k+1);
 
-              d_qv(i,k)  = gas_vmr(i+1,k+1,1);
-              d_co2(i,k) = gas_vmr(i+1,k+1,2);
-              d_o3(i,k)  = gas_vmr(i+1,k+1,3);
-              d_n2o(i,k) = gas_vmr(i+1,k+1,4);
-              d_co(i,k)  = gas_vmr(i+1,k+1,5);
-              d_ch4(i,k) = gas_vmr(i+1,k+1,6);
-              d_o2(i,k)  = gas_vmr(i+1,k+1,7);
-              d_n2(i,k)  = gas_vmr(i+1,k+1,8);
+              d_qv(i,k)  = PF::calculate_mmr_from_vmr("h2o",gas_vmr(i+1,k+1,1));
+              d_co2(i,k) = PF::calculate_mmr_from_vmr("co2",gas_vmr(i+1,k+1,2));
+              d_o3(i,k)  = PF::calculate_mmr_from_vmr("o3",gas_vmr(i+1,k+1,3));
+              d_n2o(i,k) = PF::calculate_mmr_from_vmr("n2o",gas_vmr(i+1,k+1,4));
+              d_co(i,k)  = PF::calculate_mmr_from_vmr("co",gas_vmr(i+1,k+1,5));
+              d_ch4(i,k) = PF::calculate_mmr_from_vmr("ch4",gas_vmr(i+1,k+1,6));
+              d_o2(i,k)  = PF::calculate_mmr_from_vmr("o2",gas_vmr(i+1,k+1,7));
+              d_n2(i,k)  = PF::calculate_mmr_from_vmr("n2",gas_vmr(i+1,k+1,8));
             });
 
             d_pint(i,nlay) = p_lev(i+1,nlay+1);

--- a/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
+++ b/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
@@ -173,7 +173,15 @@ namespace scream {
         auto d_rei = field_mgr.get_field("eff_radius_qi").get_reshaped_view<Real**>();
         auto d_cld = field_mgr.get_field("cldfrac_tot").get_reshaped_view<Real**>();
         auto d_mu0 = field_mgr.get_field("cos_zenith").get_reshaped_view<Real*>();
-        auto d_gas_vmr = field_mgr.get_field("gas_vmr").get_reshaped_view<Real***>();
+
+        auto d_qv  = field_mgr.get_field("qv").get_reshaped_view<Real**>();
+        auto d_co2 = field_mgr.get_field("co2").get_reshaped_view<Real**>();
+        auto d_o3  = field_mgr.get_field("o3").get_reshaped_view<Real**>();
+        auto d_n2o = field_mgr.get_field("n2o").get_reshaped_view<Real**>();
+        auto d_co  = field_mgr.get_field("co").get_reshaped_view<Real**>();
+        auto d_ch4 = field_mgr.get_field("ch4").get_reshaped_view<Real**>();
+        auto d_o2  = field_mgr.get_field("o2").get_reshaped_view<Real**>();
+        auto d_n2  = field_mgr.get_field("n2").get_reshaped_view<Real**>();
         {
           const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, nlay);
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
@@ -184,17 +192,22 @@ namespace scream {
               d_pmid(i,k) = p_lay(i+1,k+1);
               d_tmid(i,k) = t_lay(i+1,k+1);
               d_pdel(i,k) = p_del(i+1,k+1);
-              d_qc(i,k)  = qc(i+1,k+1);
-              d_qi(i,k)  = qi(i+1,k+1);
+              d_qc(i,k)   = qc(i+1,k+1);
+              d_qi(i,k)   = qi(i+1,k+1);
               d_rel(i,k)  = rel(i+1,k+1);
               d_rei(i,k)  = rei(i+1,k+1);
               d_cld(i,k)  = cld(i+1,k+1);
               d_pint(i,k) = p_lev(i+1,k+1);
               d_tint(i,k) = t_lev(i+1,k+1);
 
-              Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, ngas), [&] (const int& g) {
-                d_gas_vmr(i,k,g) = gas_vmr(i+1,k+1,g+1);
-              });
+              d_qv(i,k)  = gas_vmr(i+1,k+1,1);
+              d_co2(i,k) = gas_vmr(i+1,k+1,2);
+              d_o3(i,k)  = gas_vmr(i+1,k+1,3);
+              d_n2o(i,k) = gas_vmr(i+1,k+1,4);
+              d_co(i,k)  = gas_vmr(i+1,k+1,5);
+              d_ch4(i,k) = gas_vmr(i+1,k+1,6);
+              d_o2(i,k)  = gas_vmr(i+1,k+1,7);
+              d_n2(i,k)  = gas_vmr(i+1,k+1,8);
             });
 
             d_pint(i,nlay) = p_lev(i+1,nlay+1);

--- a/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
+++ b/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
@@ -213,15 +213,17 @@ namespace scream {
               d_cld(i,k)  = cld(i+1,k+1);
               d_pint(i,k) = p_lev(i+1,k+1);
               d_tint(i,k) = t_lev(i+1,k+1);
-
-              d_qv(i,k)  = PF::calculate_mmr_from_vmr(h2o_mol,gas_vmr(i+1,k+1,1));
-              d_co2(i,k) = PF::calculate_mmr_from_vmr(co2_mol,gas_vmr(i+1,k+1,2));
-              d_o3(i,k)  = PF::calculate_mmr_from_vmr(o3_mol,gas_vmr(i+1,k+1,3));
-              d_n2o(i,k) = PF::calculate_mmr_from_vmr(n2o_mol,gas_vmr(i+1,k+1,4));
-              d_co(i,k)  = PF::calculate_mmr_from_vmr(co_mol,gas_vmr(i+1,k+1,5));
-              d_ch4(i,k) = PF::calculate_mmr_from_vmr(ch4_mol,gas_vmr(i+1,k+1,6));
-              d_o2(i,k)  = PF::calculate_mmr_from_vmr(o2_mol,gas_vmr(i+1,k+1,7));
-              d_n2(i,k)  = PF::calculate_mmr_from_vmr(n2_mol,gas_vmr(i+1,k+1,8));
+              // Note that gas_vmr(i+1,k+1,1) should be the vmr for qv and since we need qv to calculate the mmr we derive qv separately.
+              Real qv_dry = gas_vmr(i+1,k+1,1)*PC::ep_2;
+              Real qv_wet = qv_dry/(1.0+qv_dry);
+              d_qv(i,k)  = qv_wet;//PF::calculate_mmr_from_vmr(h2o_mol, qv_wet, gas_vmr(i+1,k+1,1));
+              d_co2(i,k) = PF::calculate_mmr_from_vmr(co2_mol, qv_wet, gas_vmr(i+1,k+1,2));
+              d_o3(i,k)  = PF::calculate_mmr_from_vmr(o3_mol,  qv_wet, gas_vmr(i+1,k+1,3));
+              d_n2o(i,k) = PF::calculate_mmr_from_vmr(n2o_mol, qv_wet, gas_vmr(i+1,k+1,4));
+              d_co(i,k)  = PF::calculate_mmr_from_vmr(co_mol,  qv_wet, gas_vmr(i+1,k+1,5));
+              d_ch4(i,k) = PF::calculate_mmr_from_vmr(ch4_mol, qv_wet, gas_vmr(i+1,k+1,6));
+              d_o2(i,k)  = PF::calculate_mmr_from_vmr(o2_mol,  qv_wet, gas_vmr(i+1,k+1,7));
+              d_n2(i,k)  = PF::calculate_mmr_from_vmr(n2_mol,  qv_wet, gas_vmr(i+1,k+1,8));
             });
 
             d_pint(i,nlay) = p_lev(i+1,nlay+1);

--- a/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
+++ b/components/scream/tests/rrtmgp/rrtmgp_stand_alone.cpp
@@ -36,6 +36,7 @@ namespace scream {
         using namespace scream;
         using namespace scream::control;
         using PF = scream::PhysicsFunctions<DefaultDevice>;
+        using PC = scream::physics::Constants<Real>;
 
         // Get baseline name (needs to be passed as an arg)
         std::string inputfile = ekat::TestSession::get().params.at("rrtmgp_inputfile");
@@ -184,6 +185,17 @@ namespace scream {
         auto d_ch4 = field_mgr.get_field("ch4").get_reshaped_view<Real**>();
         auto d_o2  = field_mgr.get_field("o2").get_reshaped_view<Real**>();
         auto d_n2  = field_mgr.get_field("n2").get_reshaped_view<Real**>();
+
+        // Gather molecular weights of all the active gases in the test for conversion
+        // to mass-mixing-ratio.
+        auto h2o_mol = PC::get_gas_mol_weight("h2o");
+        auto co2_mol = PC::get_gas_mol_weight("co2");
+        auto o3_mol  = PC::get_gas_mol_weight("o3");
+        auto n2o_mol = PC::get_gas_mol_weight("n2o");
+        auto co_mol  = PC::get_gas_mol_weight("co");
+        auto ch4_mol = PC::get_gas_mol_weight("ch4");
+        auto o2_mol  = PC::get_gas_mol_weight("o2");
+        auto n2_mol  = PC::get_gas_mol_weight("n2");
         {
           const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, nlay);
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
@@ -202,14 +214,14 @@ namespace scream {
               d_pint(i,k) = p_lev(i+1,k+1);
               d_tint(i,k) = t_lev(i+1,k+1);
 
-              d_qv(i,k)  = PF::calculate_mmr_from_vmr("h2o",gas_vmr(i+1,k+1,1));
-              d_co2(i,k) = PF::calculate_mmr_from_vmr("co2",gas_vmr(i+1,k+1,2));
-              d_o3(i,k)  = PF::calculate_mmr_from_vmr("o3",gas_vmr(i+1,k+1,3));
-              d_n2o(i,k) = PF::calculate_mmr_from_vmr("n2o",gas_vmr(i+1,k+1,4));
-              d_co(i,k)  = PF::calculate_mmr_from_vmr("co",gas_vmr(i+1,k+1,5));
-              d_ch4(i,k) = PF::calculate_mmr_from_vmr("ch4",gas_vmr(i+1,k+1,6));
-              d_o2(i,k)  = PF::calculate_mmr_from_vmr("o2",gas_vmr(i+1,k+1,7));
-              d_n2(i,k)  = PF::calculate_mmr_from_vmr("n2",gas_vmr(i+1,k+1,8));
+              d_qv(i,k)  = PF::calculate_mmr_from_vmr(h2o_mol,gas_vmr(i+1,k+1,1));
+              d_co2(i,k) = PF::calculate_mmr_from_vmr(co2_mol,gas_vmr(i+1,k+1,2));
+              d_o3(i,k)  = PF::calculate_mmr_from_vmr(o3_mol,gas_vmr(i+1,k+1,3));
+              d_n2o(i,k) = PF::calculate_mmr_from_vmr(n2o_mol,gas_vmr(i+1,k+1,4));
+              d_co(i,k)  = PF::calculate_mmr_from_vmr(co_mol,gas_vmr(i+1,k+1,5));
+              d_ch4(i,k) = PF::calculate_mmr_from_vmr(ch4_mol,gas_vmr(i+1,k+1,6));
+              d_o2(i,k)  = PF::calculate_mmr_from_vmr(o2_mol,gas_vmr(i+1,k+1,7));
+              d_n2(i,k)  = PF::calculate_mmr_from_vmr(n2_mol,gas_vmr(i+1,k+1,8));
             });
 
             d_pint(i,nlay) = p_lev(i+1,nlay+1);


### PR DESCRIPTION
This PR replaces the `gas_vmr` variable in the field manager with a set of individual gas concentrations. 

This will simplify the requirement that the "h2o" gas concentration in rrtmgp reflect the most up-to-date water vapor content, `qv`.

This step also makes it possible to designate some gas concentrations as constant homogenous while setting others to be initialized by the initial file.

This PR also updates the rrtmgp interface to register all variables as packed, which will facilitate coupling between rrtmgp and the other atmosphere processes.

[BFB]