### PR TITLE
Upgrade perf infrastructure

### DIFF
--- a/components/scream/scripts/perf_analysis.py
+++ b/components/scream/scripts/perf_analysis.py
@@ -173,7 +173,7 @@ class PerfAnalysis(object):
 
         cmd = self.formulate_cmd(test_exe)
         results = []
-        with open("{}.perf.log".format(test_exe), "w") as fd:
+        with open("{}.perf.log".format(os.path.split(test_exe)[1].split(" ")[0]), "w") as fd:
             fd.write(cmd + "\n\n")
             fd.write("ENV: \n{}\n\n".format(run_cmd_no_fail("env")))
             for _ in range(self._num_runs):
@@ -199,7 +199,7 @@ class PerfAnalysis(object):
     def perf_analysis(self):
     ###############################################################################
         if self._use_existing:
-            expect(os.path.isdir("p3") and os.path.exists("CMakeCache.txt"),
+            expect(os.path.exists("CMakeCache.txt"),
                    "{} doesn't look like a build directory".format(os.getcwd()))
 
         else:

--- a/components/scream/src/physics/p3/p3_f90.cpp
+++ b/components/scream/src/physics/p3/p3_f90.cpp
@@ -35,7 +35,7 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   do_predict_nc = true;
   do_prescribed_CCN = true;
   dt = -1; // model time step, s; set to invalid -1
-  it = 1;  // seems essentially unused
+  it = 1;
   // In/out
   qc              = Array2("cloud liquid water mixing ratio, kg/kg", ncol, nlev);
   nc              = Array2("cloud liquid drop number, #/kg", ncol, nlev);

--- a/components/scream/src/physics/p3/p3_ic_cases.cpp
+++ b/components/scream/src/physics/p3/p3_ic_cases.cpp
@@ -91,9 +91,6 @@ FortranData::Ptr make_mixed (const Int ncol, const Int nlev) {
     // deposition/condensation-freezing needs t<258.15 and >5% supersat.
     d.qv(i,33) = 1e-4;
 
-    // input variables.
-    d.dt = 1800;
-
     // set qv_prev and t_prev to qv and T vals
     for (k = 0; k < nk; ++k){
       d.qv_prev(i,k) = d.qv(i,k);

--- a/components/scream/src/physics/p3/p3_ic_cases.cpp
+++ b/components/scream/src/physics/p3/p3_ic_cases.cpp
@@ -8,10 +8,10 @@ namespace p3 {
 namespace ic {
 
 // From mixed_case_data.py in scream-docs at commit 4bbea4.
-FortranData::Ptr make_mixed (const Int ncol) {
+FortranData::Ptr make_mixed (const Int ncol, const Int nlev) {
   using consts = scream::physics::Constants<Real>;
 
-  const Int nk = 72;
+  const Int nk = nlev;
   Int k;
   const auto dp = std::make_shared<FortranData>(ncol, nk);
   auto& d = *dp;
@@ -119,9 +119,9 @@ FortranData::Ptr make_mixed (const Int ncol) {
   return dp;
 }
 
-FortranData::Ptr Factory::create (IC ic, Int ncol) {
+FortranData::Ptr Factory::create (IC ic, Int ncol, Int nlev) {
  switch (ic) {
-   case mixed: return make_mixed(ncol);
+   case mixed: return make_mixed(ncol, nlev);
  default:
    EKAT_REQUIRE_MSG(false, "Not an IC: " << ic);
  }

--- a/components/scream/src/physics/p3/p3_ic_cases.hpp
+++ b/components/scream/src/physics/p3/p3_ic_cases.hpp
@@ -12,7 +12,7 @@ FortranData::Ptr make_mixed(Int ncol);
 struct Factory {
   enum IC { mixed };
 
-  static FortranData::Ptr create(IC ic, Int ncol = 1);
+  static FortranData::Ptr create(IC ic, Int ncol = 1, Int nlev = 72);
 };
 
 } // namespace ic

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -263,7 +263,7 @@ int main (int argc, char** argv) {
       "  -f                  Use fortran impls instead of c++. Default False.\n"
       "  -t <tol>            Tolerance for relative error. Default 0.\n"
       "  -s <steps>          Number of timesteps. Default=6.\n"
-      "  -d <seconds>        Length of timestep. Default=300.\n"
+      "  -dt <seconds>       Length of timestep. Default=300.\n"
       "  -i <cols>           Number of columns. Default=3.\n"
       "  -k <nlev>           Number of vertical levels. Default=72.\n"
       "  -r <repeat>         Number of repetitions, implies timing run (generate + no I/O). Default=0.\n"
@@ -294,7 +294,7 @@ int main (int argc, char** argv) {
       ++i;
       timesteps = std::atoi(argv[i]);
     }
-    if (ekat::argv_matches(argv[i], "-d", "--dt")) {
+    if (ekat::argv_matches(argv[i], "-dt", "--dt")) {
       expect_another_arg(i, argc);
       ++i;
       dt = std::atoi(argv[i]);

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -93,10 +93,8 @@ static Int compare (const std::string& label, const Scalar* a,
 }
 
 struct Baseline {
-  Baseline (const Int nsteps=6, const Int dt=300, const Int ncol=3, const Int nlev=72, const Int repeat=0, const std::string predict_nc="both", const std::string prescribed_CCN="both") :
-    m_nsteps(nsteps), m_dt(dt), m_ncol(ncol), m_nlev(nlev), m_repeat(repeat)
+  Baseline (const Int nsteps, const Real dt, const Int ncol, const Int nlev, const Int repeat, const std::string predict_nc, const std::string prescribed_CCN)
   {
-
     //If predict_nc="both", start looping at i_start=0 (false) and end after i_start=1 (true)
     //otherwise, modify start and end to only loop over case of interest. Test that predict_nc
     //is only yes, no, or both is done below so not bothering here.
@@ -114,8 +112,8 @@ struct Baseline {
 
     for (int i = i_start; i < i_end; ++i) { // predict_nc is false or true
       for (int j = j_start; j< j_end; ++j) { //prescribed_CCN is false or true
-	//                 initial condit,     prescribe or predict nc, prescribe CCN or not
-	params_.push_back({ic::Factory::mixed, i>0,                     j>0 });
+	//                 initial condit,     repeat, nsteps, ncol, nlev, dt, prescribe or predict nc, prescribe CCN or not
+	params_.push_back({ic::Factory::mixed, repeat, nsteps, ncol, nlev, dt, i>0,                     j>0 });
       }
     }
   }
@@ -129,12 +127,12 @@ struct Baseline {
 
     for (auto ps : params_) {
       // Run reference p3 on this set of parameters.
-      for (Int r = -1; r < m_repeat; ++r) {
-        const auto d = ic::Factory::create(ps.ic, m_ncol, m_nlev);
+      for (Int r = -1; r < ps.repeat; ++r) {
+        const auto d = ic::Factory::create(ps.ic, ps.ncol, ps.nlev);
         set_params(ps, *d);
         p3_init();
 
-        if (m_repeat > 0 && r == -1) {
+        if (ps.repeat > 0 && r == -1) {
           std::cout << "Running P3 with ni=" << d->ncol << ", nk=" << d->nlev
                     << ", dt=" << d->dt << ", ts=" << d->it << ", predict_nc=" << d->do_predict_nc;
 
@@ -144,21 +142,21 @@ struct Baseline {
           std::cout << std::endl;
         }
 
-        for (int it=0; it<m_nsteps; it++) {
+        for (int it=0; it<ps.nsteps; it++) {
           Int current_microsec = p3_main(*d, use_fortran);
 
-          if (r != -1 && m_repeat > 0) { // do not count the "cold" run
+          if (r != -1 && ps.repeat > 0) { // do not count the "cold" run
             total_duration_microsec += current_microsec;
           }
 
-          if (m_repeat == 0) {
+          if (ps.repeat == 0) {
             write(fid, d); // Save the fields to the baseline file.
           }
         }
       }
 
-      if (m_repeat > 0) {
-        const double report_time = (1e-6*total_duration_microsec) / m_repeat;
+      if (ps.repeat > 0) {
+        const double report_time = (1e-6*total_duration_microsec) / ps.repeat;
 
         printf("Time = %1.3e seconds\n", report_time);
       }
@@ -174,16 +172,16 @@ struct Baseline {
     for (auto ps : params_) {
       case_num++;
       // Read the reference impl's data from the baseline file.
-      const auto d_ref = ic::Factory::create(ps.ic, m_ncol);
+      const auto d_ref = ic::Factory::create(ps.ic, ps.ncol, ps.nlev);
       set_params(ps, *d_ref);
       // Now run a sequence of other impls. This includes the reference
       // implementation b/c it's likely we'll want to change it as we go.
       {
-        const auto d = ic::Factory::create(ps.ic, m_ncol, m_nlev);
+        const auto d = ic::Factory::create(ps.ic, ps.ncol, ps.nlev);
         set_params(ps, *d);
         p3_init();
-        for (int it=0; it<m_nsteps; it++) {
-          std::cout << "--- checking case # " << case_num << ", timestep # " << it+1 << " of " << m_nsteps << " ---\n" << std::flush;
+        for (int it=0; it<ps.nsteps; it++) {
+          std::cout << "--- checking case # " << case_num << ", timestep # " << it+1 << " of " << ps.nsteps << " ---\n" << std::flush;
           read(fid, d_ref);
           p3_main(*d, use_fortran);
           ne = compare(tol, d_ref, d);
@@ -196,17 +194,19 @@ struct Baseline {
   }
 
 private:
-  // Things that do not vary between runs
-  Int m_nsteps, m_dt, m_ncol, m_nlev, m_repeat;
 
-  // Things that vary between runs
+  // Full specification for a run
   struct ParamSet {
     ic::Factory::IC ic;
-    bool do_predict_nc;
-    bool do_prescribed_CCN;
+    Int repeat, nsteps, ncol, nlev;
+    Real dt;
+    bool do_predict_nc, do_prescribed_CCN;
   };
 
   static void set_params (const ParamSet& ps, FortranData& d) {
+    // Items not set by factory
+    d.dt                = ps.dt;
+    d.it                = ps.nsteps;
     d.do_predict_nc     = ps.do_predict_nc;
     d.do_prescribed_CCN = ps.do_prescribed_CCN;
   }
@@ -338,7 +338,7 @@ int main (int argc, char** argv) {
   baseline_fn += std::to_string(sizeof(scream::Real));
 
   scream::initialize_scream_session(argc, argv); {
-    Baseline bln(timesteps, dt, ncol, nlev, repeat, predict_nc, prescribed_ccn);
+    Baseline bln(timesteps, static_cast<Real>(dt), ncol, nlev, repeat, predict_nc, prescribed_ccn);
     if (generate) {
       std::cout << "Generating to " << baseline_fn << "\n";
       nerr += bln.generate_baseline(baseline_fn, use_fortran);

--- a/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
@@ -243,7 +243,7 @@ int main (int argc, char** argv) {
       "  -f                Use fortran impls instead of c++.\n"
       "  -t <tol>          Tolerance for relative error.\n"
       "  -s <steps>        Number of timesteps. Default=10.\n"
-      "  -d <seconds>      Length of timestep. Default=150.\n"
+      "  -dt <seconds>     Length of timestep. Default=150.\n"
       "  -i <cols>         Number of columns(ncol). Default=8.\n"
       "  -k <nlev>         Number of vertical levels. Default=72.\n"
       "  -q <num_qtracers> Number of q tracers. Default=3.\n"
@@ -275,7 +275,7 @@ int main (int argc, char** argv) {
       ++i;
       nsteps = std::atoi(argv[i]);
     }
-    if (ekat::argv_matches(argv[i], "-d", "--dt")) {
+    if (ekat::argv_matches(argv[i], "-dt", "--dt")) {
       expect_another_arg(i, argc);
       ++i;
       dt = std::atoi(argv[i]);

--- a/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
@@ -100,12 +100,9 @@ static Int compare (const std::string& label, const Scalar* a,
 
 struct Baseline {
 
-  Baseline (const Int num_iters, const Int shcol, const Int repeat) :
-    m_num_iters(num_iters), // Number of iterations (nadv steps of size dtime per iteration).
-    m_repeat(repeat)
+  Baseline (const Int nsteps, const Real dt, const Int ncol, const Int nlev, const Int num_qtracers, const Int nadv, const Int repeat)
   {
-    //                 ic,                    shcol, nlev, num_qtracers, nadv, dtime
-    params_.push_back({ic::Factory::standard, shcol, 72,   3,            15,   150});
+    params_.push_back({ic::Factory::standard, repeat, nsteps, ncol, nlev, num_qtracers, nadv, dt});
   }
 
   Int generate_baseline (const std::string& filename, bool use_fortran) {
@@ -117,15 +114,15 @@ struct Baseline {
     Int duration = 0;
 
     for (auto ps : params_) {
-      for (Int r = -1; r < m_repeat; ++r) {
+      for (Int r = -1; r < ps.repeat; ++r) {
         // Run reference shoc on this set of parameters.
-        const auto d = ic::Factory::create(ps.ic, ps.shcol, ps.nlev, ps.num_qtracers);
+        const auto d = ic::Factory::create(ps.ic, ps.ncol, ps.nlev, ps.num_qtracers);
         set_params(ps, *d);
         shoc_init(ps.nlev, use_fortran);
 
-        if (m_repeat > 0 && r == -1) {
+        if (ps.repeat > 0 && r == -1) {
           std::cout << "Running SHOC with ni=" << d->shcol << ", nk=" << d->nlev
-                    << ", dt=" << d->dtime << ", ts=" << m_num_iters;
+                    << ", dt=" << d->dtime << ", ts=" << ps.nsteps;
 
           if (!use_fortran) {
             std::cout << ", small_packn=" << SCREAM_SMALL_PACK_SIZE;
@@ -133,20 +130,20 @@ struct Baseline {
           std::cout << std::endl;
         }
 
-        for (int it = 0; it < m_num_iters; ++it) {
+        for (int it = 0; it < ps.nsteps; ++it) {
           Int current_microsec = shoc_main(*d, use_fortran);
 
-          if (r != -1 && m_repeat > 0) { // do not count the "cold" run
+          if (r != -1 && ps.repeat > 0) { // do not count the "cold" run
             duration += current_microsec;
           }
 
-          if (m_repeat == 0) {
+          if (ps.repeat == 0) {
             write(fid, d);
           }
         }
       }
-      if (m_repeat > 0) {
-        const double report_time = (1e-6*duration) / m_repeat;
+      if (ps.repeat > 0) {
+        const double report_time = (1e-6*duration) / ps.repeat;
 
         printf("Time = %1.3e seconds\n", report_time);
       }
@@ -162,15 +159,15 @@ struct Baseline {
     for (auto ps : params_) {
       case_num++;
       // Read the reference impl's data from the baseline file.
-      const auto d_ref = ic::Factory::create(ps.ic, ps.shcol, ps.nlev, ps.num_qtracers);
+      const auto d_ref = ic::Factory::create(ps.ic, ps.ncol, ps.nlev, ps.num_qtracers);
       set_params(ps, *d_ref);
       // Now run a sequence of other impls. This includes the reference
       // implementation b/c it's likely we'll want to change it as we go.
       {
-        const auto d = ic::Factory::create(ps.ic, ps.shcol, ps.nlev, ps.num_qtracers);
+        const auto d = ic::Factory::create(ps.ic, ps.ncol, ps.nlev, ps.num_qtracers);
         set_params(ps, *d);
         shoc_init(ps.nlev, use_fortran);
-        for (int it = 0; it < m_num_iters; it++) {
+        for (int it = 0; it < ps.nsteps; it++) {
           std::cout << "--- checking case # " << case_num << ", timestep # = " << (it+1)*ps.nadv
                      << " ---\n" << std::flush;
           read(fid, d_ref);
@@ -185,18 +182,16 @@ struct Baseline {
   }
 
 private:
-  Int m_num_iters, m_repeat;
-
   struct ParamSet {
     ic::Factory::IC ic;
-    Int shcol, nlev, num_qtracers, nadv;
-    Real dtime;
+    Int repeat, nsteps, ncol, nlev, num_qtracers, nadv;
+    Real dt;
   };
 
   static void set_params (const ParamSet& ps, FortranData& d) {
-    // shcol, nlev, num_qtracers are already set by the Factory.
-    d.nadv = ps.nadv;
-    d.dtime = ps.dtime;
+    // ncol, nlev, num_qtracers are already set by the Factory.
+    d.nadv  = ps.nadv;
+    d.dtime = ps.dt;
   }
 
   std::vector<ParamSet> params_;
@@ -244,20 +239,28 @@ int main (int argc, char** argv) {
     std::cout <<
       argv[0] << " [options] baseline-filename\n"
       "Options:\n"
-      "  -g          Generate baseline file.\n"
-      "  -f          Use fortran impls instead of c++.\n"
-      "  -t <tol>    Tolerance for relative error.\n"
-      "  -s <steps>  Number of timesteps. Default=10.\n"
-      "  -i <cols>   Number of columns(shcol). Default=8.\n"
-      "  -r <repeat> Number of repetitions, implies timing run (generate + no I/O). Default=0.\n";
+      "  -g                Generate baseline file.\n"
+      "  -f                Use fortran impls instead of c++.\n"
+      "  -t <tol>          Tolerance for relative error.\n"
+      "  -s <steps>        Number of timesteps. Default=10.\n"
+      "  -d <seconds>      Length of timestep. Default=150.\n"
+      "  -i <cols>         Number of columns(ncol). Default=8.\n"
+      "  -k <nlev>         Number of vertical levels. Default=72.\n"
+      "  -q <num_qtracers> Number of q tracers. Default=3.\n"
+      "  -n <nadv>         Number of SHOC loops per timestep. Default=15.\n"
+      "  -r <repeat>       Number of repetitions, implies timing run (generate + no I/O). Default=0.\n";
 
     return 1;
   }
 
   bool generate = false, use_fortran = false;
   scream::Real tol = 0;
-  Int num_iters = 10;
-  Int shcol = 8;
+  Int nsteps = 10;
+  Int dt = 150;
+  Int ncol = 8;
+  Int nlev = 72;
+  Int num_qtracers = 3;
+  Int nadv = 15;
   Int repeat = 0;
   for (int i = 1; i < argc-1; ++i) {
     if (ekat::argv_matches(argv[i], "-g", "--generate")) generate = true;
@@ -270,12 +273,32 @@ int main (int argc, char** argv) {
     if (ekat::argv_matches(argv[i], "-s", "--steps")) {
       expect_another_arg(i, argc);
       ++i;
-      num_iters = std::atoi(argv[i]);
+      nsteps = std::atoi(argv[i]);
     }
-    if (ekat::argv_matches(argv[i], "-i", "--shcol")) {
+    if (ekat::argv_matches(argv[i], "-d", "--dt")) {
       expect_another_arg(i, argc);
       ++i;
-      shcol = std::atoi(argv[i]);
+      dt = std::atoi(argv[i]);
+    }
+    if (ekat::argv_matches(argv[i], "-i", "--ncol")) {
+      expect_another_arg(i, argc);
+      ++i;
+      ncol = std::atoi(argv[i]);
+    }
+    if (ekat::argv_matches(argv[i], "-k", "--nlev")) {
+      expect_another_arg(i, argc);
+      ++i;
+      nlev = std::atoi(argv[i]);
+    }
+    if (ekat::argv_matches(argv[i], "-q", "--num-qtracers")) {
+      expect_another_arg(i, argc);
+      ++i;
+      num_qtracers = std::atoi(argv[i]);
+    }
+    if (ekat::argv_matches(argv[i], "-n", "--nadv")) {
+      expect_another_arg(i, argc);
+      ++i;
+      nadv = std::atoi(argv[i]);
     }
     if (ekat::argv_matches(argv[i], "-r", "--repeat")) {
       expect_another_arg(i, argc);
@@ -292,7 +315,7 @@ int main (int argc, char** argv) {
   baseline_fn += std::to_string(sizeof(scream::Real));
 
   scream::initialize_scream_session(argc, argv); {
-    Baseline bln(num_iters, shcol, repeat);
+    Baseline bln(nsteps, static_cast<Real>(dt), ncol, nlev, num_qtracers, nadv, repeat);
     if (generate) {
       std::cout << "Generating to " << baseline_fn << "\n";
       nerr += bln.generate_baseline(baseline_fn, use_fortran);


### PR DESCRIPTION
Cleanup of the run_and_cmp (both shoc and p3) and make them more configurable.

These exes should be the gold standard for measuring performance for standalone scream.

Still need to figure out why @bartgol was seeing different numbers when he was using p3_tests for measuring p3 performance.