### PR TITLE
Add local homme memory to AD mem buffer

### DIFF
--- a/components/homme/src/share/cxx/CaarFunctor.hpp
+++ b/components/homme/src/share/cxx/CaarFunctor.hpp
@@ -31,11 +31,17 @@ public:
   CaarFunctor(const Elements &elements, const Tracers &tracers,
               const ReferenceElement &ref_FE, const HybridVCoord &hvcoord,
               const SphereOperators &sphere_ops, const SimulationParams& params);
+  CaarFunctor(const int num_elems, const SimulationParams& params);
   CaarFunctor(const CaarFunctor &) = delete;
 
   ~CaarFunctor();
 
   CaarFunctor &operator=(const CaarFunctor &) = delete;
+
+  bool setup_needed() { return !is_setup; }
+  void setup(const Elements &elements, const Tracers &tracers,
+             const ReferenceElement &ref_FE, const HybridVCoord &hvcoord,
+             const SphereOperators &sphere_ops);
 
   int requested_buffer_size () const;
   void init_buffers(const FunctorsBuffersManager& fbm);
@@ -47,6 +53,7 @@ public:
 
 private:
   std::unique_ptr<CaarFunctorImpl> m_caar_impl;
+  bool is_setup;
 };
 
 } // Namespace Homme

--- a/components/homme/src/share/cxx/EulerStepFunctor.cpp
+++ b/components/homme/src/share/cxx/EulerStepFunctor.cpp
@@ -9,8 +9,29 @@
 namespace Homme {
 
 EulerStepFunctor
-::EulerStepFunctor () {
+::EulerStepFunctor ()
+  : is_setup(true) {
   p_ = std::make_shared<EulerStepFunctorImpl>();
+}
+
+// This constructor is useful for using buffer functionality without
+// having all other Functor information available.
+// If this constructor is used, the setup() function must be called
+// before using any other EulerStepFunctor functions.
+EulerStepFunctor
+::EulerStepFunctor (const int num_elems)
+  : is_setup(false)
+{
+  p_ = std::make_shared<EulerStepFunctorImpl>(num_elems);
+}
+
+void EulerStepFunctor::setup()
+{
+  // Sanity check
+  assert (!is_setup);
+
+  p_->setup();
+  is_setup = true;
 }
 
 void EulerStepFunctor::reset (const SimulationParams& params) {
@@ -25,21 +46,33 @@ void EulerStepFunctor::init_buffers (const FunctorsBuffersManager& fbm) {
 }
 
 void EulerStepFunctor::init_boundary_exchanges () {
+  // The Functor needs to be fully setup to use this function
+  assert (is_setup);
+
   p_->init_boundary_exchanges();
 }
 
 void EulerStepFunctor::precompute_divdp () {
+  // The Functor needs to be fully setup to use this function
+  assert (is_setup);
+
   p_->precompute_divdp();
 }
 
 void EulerStepFunctor
 ::euler_step (const int np1_qdp, const int n0_qdp, const Real dt,
               const Real rhs_multiplier, const DSSOption DSSopt) {
+  // The Functor needs to be fully setup to use this function
+  assert (is_setup);
+
   p_->euler_step(np1_qdp, n0_qdp, dt, rhs_multiplier, DSSopt);
 }
 
 void EulerStepFunctor
 ::qdp_time_avg (const int n0_qdp, const int np1_qdp) {
+  // The Functor needs to be fully setup to use this function
+  assert (is_setup);
+
   p_->qdp_time_avg(n0_qdp, np1_qdp);
 }
 

--- a/components/homme/src/share/cxx/EulerStepFunctor.hpp
+++ b/components/homme/src/share/cxx/EulerStepFunctor.hpp
@@ -23,6 +23,11 @@ class EulerStepFunctor {
 public:
   EulerStepFunctor();
 
+  EulerStepFunctor(const int num_elems);
+
+  bool setup_needed() { return !is_setup; }
+  void setup();
+
   void reset(const SimulationParams& params);
 
   int requested_buffer_size () const;
@@ -40,6 +45,9 @@ public:
   static bool is_quasi_monotone (const int& limiter_option) {
     return limiter_option == 8 || limiter_option == 9;
   }
+
+private:
+  bool is_setup;
 };
 
 } // namespace Homme

--- a/components/homme/src/share/cxx/FunctorsBuffersManager.cpp
+++ b/components/homme/src/share/cxx/FunctorsBuffersManager.cpp
@@ -27,6 +27,29 @@ void FunctorsBuffersManager:: allocate () {
   Errors::runtime_check(!m_allocated, "Error! Cannot call 'allocate' more than once.\n");
 
   m_buffer = ExecViewManaged<Real*>("",m_size);
+
+#ifdef HOMMEXX_BFB_TESTING
+  generate_random_data();
+#endif
+
+  m_allocated = true;
+}
+
+void FunctorsBuffersManager:: allocate (Real* data, const int new_size) {
+  Errors::runtime_check(!m_allocated, "Error! Cannot call 'allocate' more than once.\n");
+
+  m_size   = new_size;
+  m_buffer = ExecViewManaged<Real*>(data, m_size);
+
+#ifdef HOMMEXX_BFB_TESTING
+  generate_random_data();
+#endif
+
+  m_allocated = true;
+}
+
+void generate_random_data ()
+{
 #ifdef HOMMEXX_BFB_TESTING
   // Here's the catch: when malloc allocates memory, it *may* get a fresh
   // new page from the OS. If that happens, the OS will zero-out the provided
@@ -36,13 +59,13 @@ void FunctorsBuffersManager:: allocate () {
   // them, a unit test would pass with zero-ed memory.
   // Therefore, we randomly initialize the buffer, to protect against false
   // positives.
+  generate_random_data();
   using rngalg = std::mt19937_64;
   using rpdf = std::uniform_real_distribution<Real>;
   std::random_device rd;
   rngalg engine(rd());
   genRandArray(m_buffer,engine,rpdf(0.1,10.0));
 #endif
-  m_allocated = true;
 }
 
 } // namespace Homme

--- a/components/homme/src/share/cxx/FunctorsBuffersManager.hpp
+++ b/components/homme/src/share/cxx/FunctorsBuffersManager.hpp
@@ -25,6 +25,11 @@ struct FunctorsBuffersManager {
 
   void allocate ();
 
+  // Reset m_size and allocate using input data.
+  // This is useful if the user wants to allocate
+  // buffer data outside of Homme.
+  void allocate (Real* data, const int new_size);
+
   bool allocated () const { return m_allocated; }
 
 protected:
@@ -32,6 +37,10 @@ protected:
   ExecViewManaged<Real*> m_buffer;
   int   m_size;
   bool  m_allocated;
+
+private:
+
+  void generate_random_data();
 };
 
 } // Homme

--- a/components/homme/src/share/cxx/HyperviscosityFunctor.cpp
+++ b/components/homme/src/share/cxx/HyperviscosityFunctor.cpp
@@ -9,15 +9,13 @@
 #include "FunctorsBuffersManager.hpp"
 
 #include "Context.hpp"
-#include "ElementsGeometry.hpp"
-#include "ElementsState.hpp"
-#include "ElementsDerivedState.hpp"
-#include "SimulationParams.hpp"
+
 
 namespace Homme
 {
 
 HyperviscosityFunctor::HyperviscosityFunctor ()
+  : is_setup(true)
 {
   auto& c = Context::singleton();
   auto& params   = c.get<SimulationParams>();
@@ -28,6 +26,17 @@ HyperviscosityFunctor::HyperviscosityFunctor ()
   m_hvf_impl.reset (new HyperviscosityFunctorImpl(params,geometry,state,derived));
 }
 
+// This constructor is useful for using buffer functionality without
+// having all other Functor information available.
+// If this constructor is used, the setup() function must be called
+// before using any other HyperviscosityFunctor functions.
+HyperviscosityFunctor::HyperviscosityFunctor(const int num_elems, const SimulationParams& params)
+  : is_setup(false)
+{
+  // Build functor impl
+  m_hvf_impl.reset (new HyperviscosityFunctorImpl(num_elems,params));
+}
+
 HyperviscosityFunctor::~HyperviscosityFunctor ()
 {
   // This empty destructor (where HyperviscosityFunctorImpl type is completely known)
@@ -35,6 +44,19 @@ HyperviscosityFunctor::~HyperviscosityFunctor ()
   // deleter, which needs to know the size of the stored type, and which
   // would be called from the implicitly declared default destructor, which
   // would be in the header file, where HyperviscosityFunctorImpl type is incomplete.
+}
+
+void HyperviscosityFunctor::setup(const ElementsGeometry &geometry,
+                                  const ElementsState &state,
+                                  const ElementsDerivedState &derived)
+{
+  assert (m_hvf_impl);
+
+  // Sanity check
+  assert (!is_setup);
+
+  m_hvf_impl->setup(geometry, state, derived);
+  is_setup = true;
 }
 
 int HyperviscosityFunctor::requested_buffer_size () const {

--- a/components/homme/src/share/cxx/HyperviscosityFunctor.hpp
+++ b/components/homme/src/share/cxx/HyperviscosityFunctor.hpp
@@ -8,6 +8,10 @@
 #define HOMMEXX_HYPERVISCOSITY_FUNCTOR_HPP
 
 #include "Types.hpp"
+#include "ElementsGeometry.hpp"
+#include "ElementsState.hpp"
+#include "ElementsDerivedState.hpp"
+#include "SimulationParams.hpp"
 
 #include <memory>
 
@@ -16,6 +20,7 @@ namespace Homme
 
 class HyperviscosityFunctorImpl;
 struct FunctorsBuffersManager;
+class SimulationParams;
 
 class HyperviscosityFunctor
 {
@@ -23,7 +28,14 @@ public:
 
   HyperviscosityFunctor ();
 
+  HyperviscosityFunctor (const int num_elems, const SimulationParams& params);
+
   ~HyperviscosityFunctor ();
+
+  bool setup_needed() { return !is_setup; }
+  void setup(const ElementsGeometry&     geometry,
+             const ElementsState&        state,
+             const ElementsDerivedState& derived);
 
   int requested_buffer_size () const;
   void init_buffers    (const FunctorsBuffersManager& fbm);
@@ -35,6 +47,7 @@ public:
 private:
 
   std::unique_ptr<HyperviscosityFunctorImpl>  m_hvf_impl;
+  bool is_setup;
 };
 
 } // namespace Homme

--- a/components/homme/src/share/cxx/VerticalRemapManager.cpp
+++ b/components/homme/src/share/cxx/VerticalRemapManager.cpp
@@ -18,38 +18,53 @@ namespace Homme {
 
 struct VerticalRemapManager::Impl {
   Impl(const SimulationParams &params, const Elements &e, const Tracers &t,
-       const HybridVCoord &h) {
+       const HybridVCoord &h)
+    : m_hvcoord(h)
+    , m_params(params)
+    , m_elements(e)
+    , m_tracers(t)
+  {
+    setup_remmapper();
+  }
+
+  Impl(const SimulationParams &params, const HybridVCoord &h)
+    : m_hvcoord(h)
+    , m_params(params)
+  {}
+
+  void setup_remmapper ()
+  {
     using namespace Remap;
     using namespace Remap::Ppm;
-    if (params.remap_alg == RemapAlg::PPM_FIXED_PARABOLA) {
-      if (params.rsplit != 0) {
+    if (m_params.remap_alg == RemapAlg::PPM_FIXED_PARABOLA) {
+      if (m_params.rsplit != 0) {
         remapper = std::make_shared<RemapFunctor<
             true, PpmVertRemap<PpmFixedParabola>> >(
-            params.qsize, e, t, h);
+            m_params.qsize, m_elements, m_tracers, m_hvcoord);
       } else {
         remapper = std::make_shared<RemapFunctor<
             false, PpmVertRemap<PpmFixedParabola>> >(
-            params.qsize, e, t, h);
+            m_params.qsize, m_elements, m_tracers, m_hvcoord);
       }
-    } else if (params.remap_alg == RemapAlg::PPM_FIXED_MEANS) {
-      if (params.rsplit != 0) {
+    } else if (m_params.remap_alg == RemapAlg::PPM_FIXED_MEANS) {
+      if (m_params.rsplit != 0) {
         remapper = std::make_shared<RemapFunctor<
             true, PpmVertRemap<PpmFixedMeans>> >(
-            params.qsize, e, t, h);
+            m_params.qsize, m_elements, m_tracers, m_hvcoord);
       } else {
         remapper = std::make_shared<RemapFunctor<
             false, PpmVertRemap<PpmFixedMeans>> >(
-            params.qsize, e, t, h);
+            m_params.qsize, m_elements, m_tracers, m_hvcoord);
       }
-    } else if (params.remap_alg == RemapAlg::PPM_MIRRORED) {
-      if (params.rsplit != 0) {
+    } else if (m_params.remap_alg == RemapAlg::PPM_MIRRORED) {
+      if (m_params.rsplit != 0) {
         remapper = std::make_shared<RemapFunctor<
             true, PpmVertRemap<PpmMirrored>> >(
-            params.qsize, e, t, h);
+            m_params.qsize, m_elements, m_tracers, m_hvcoord);
       } else {
         remapper = std::make_shared<RemapFunctor<
             false, PpmVertRemap<PpmMirrored>> >(
-            params.qsize, e, t, h);
+            m_params.qsize, m_elements, m_tracers, m_hvcoord);
       }
     } else {
       Errors::runtime_abort(
@@ -58,29 +73,98 @@ struct VerticalRemapManager::Impl {
     }
   }
 
+  void setup (const Elements &e, const Tracers &t)
+  {
+    m_elements = e;
+    m_tracers  = t;
+
+    setup_remmapper();
+  }
+
   std::shared_ptr<Remap::Remapper> remapper;
+
+  HybridVCoord     m_hvcoord;
+  SimulationParams m_params;
+  Elements         m_elements;
+  Tracers          m_tracers;
+
 };
 
-VerticalRemapManager::VerticalRemapManager() {
+VerticalRemapManager::VerticalRemapManager()
+  : is_setup(true)
+{
   const auto &h = Context::singleton().get<HybridVCoord>();
   const auto &p = Context::singleton().get<SimulationParams>();
   const auto &e = Context::singleton().get<Elements>();
+  m_num_elems = e.num_elems();
   const auto &t = Context::singleton().get<Tracers>();
   assert(p.params_set);
   p_.reset(new Impl(p, e, t, h));
 }
 
+VerticalRemapManager::VerticalRemapManager(const int num_elems)
+  : m_num_elems(num_elems)
+  , is_setup(false)
+{
+  const auto &h = Context::singleton().get<HybridVCoord>();
+  const auto &p = Context::singleton().get<SimulationParams>();
+  assert(p.params_set);
+  p_.reset(new Impl(p, h));
+}
+
+void VerticalRemapManager::setup ()
+{
+  assert(!is_setup);
+
+  const auto &e = Context::singleton().get<Elements>();
+  assert(m_num_elems == e.num_elems()); // Sanity check
+
+  const auto &t = Context::singleton().get<Tracers>();
+  p_->setup(e,t);
+
+  is_setup = true;
+}
+
 void VerticalRemapManager::run_remap(int np1, int np1_qdp, double dt) const {
+  assert(is_setup);
+
   assert(p_);
   assert(p_->remapper);
   p_->remapper->run_remap(np1, np1_qdp, dt);
 }
 
+struct TempTagStruct  {};
+
 int VerticalRemapManager::requested_buffer_size () const {
   assert (p_);
   assert (p_->remapper);
 
-  return p_->remapper->requested_buffer_size();
+  if (is_setup) {
+    return p_->remapper->requested_buffer_size();
+  }
+  // If the struct is not fully setup, we must manually compute
+  // buffer request, since internally the Element functor is required.
+  else {
+#ifdef HOMMEXX_BFB_TESTING
+    const bool process_nh_vars = true;
+#else
+    const bool process_nh_vars = !(p_->m_params.theta_hydrostatic_mode);
+#endif
+    if (p_->m_params.rsplit == 0 || !process_nh_vars) {
+      return 0;
+    } else {
+      const int iters = 2;
+      const int team_size = (iters*m_num_elems > 0 ? iters*m_num_elems : 1);
+      TeamUtils<ExecSpace> dummy_tu(Homme::get_default_team_policy<ExecSpace,TempTagStruct>(team_size));
+
+      using temp_type = ExecViewUnmanaged<Scalar*  [NP][NP][NUM_LEV  ]>;
+      using phi_type  = ExecViewUnmanaged<Scalar*  [NP][NP][NUM_LEV_P]>;
+
+      const int temp_size = temp_type::shmem_size(dummy_tu.get_num_ws_slots())/sizeof(Real);
+      const int phi_size  = phi_type::shmem_size(dummy_tu.get_num_ws_slots())/sizeof(Real);
+      return temp_size + phi_size;
+    }
+  }
 }
 
 void VerticalRemapManager::init_buffers(const FunctorsBuffersManager& fbm) {

--- a/components/homme/src/share/cxx/VerticalRemapManager.hpp
+++ b/components/homme/src/share/cxx/VerticalRemapManager.hpp
@@ -16,14 +16,23 @@ class FunctorsBuffersManager;
 struct VerticalRemapManager {
   VerticalRemapManager();
 
+  VerticalRemapManager(const int num_elems);
+
   void run_remap(int np1, int np1_qdp, double dt) const;
 
   int requested_buffer_size () const;
   void init_buffers(const FunctorsBuffersManager& fbm);
 
+  bool setup_needed () { return !is_setup; }
+
+  void setup ();
+
 private:
   struct Impl;
   std::shared_ptr<Impl> p_;
+
+  int m_num_elems;
+  bool is_setup;
 };
 
 }

--- a/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
@@ -83,17 +83,18 @@ struct CaarFunctorImpl {
 
   Scalar                      m_scale2g_last_int_pack;
 
-  const int                   m_rsplit;
-  const bool                  m_theta_hydrostatic_mode;
-  const AdvectionForm         m_theta_advection_form;
+  const int           m_num_elems;
+  const int           m_rsplit;
+  const bool          m_theta_hydrostatic_mode;
+  const AdvectionForm m_theta_advection_form;
 
-  const HybridVCoord          m_hvcoord;
-  const ElementsState         m_state;
-  const ElementsDerivedState  m_derived;
-  const ElementsGeometry      m_geometry;
-  EquationOfState             m_eos;
-  Buffers                     m_buffers;
-  const deriv_type            m_deriv;
+  HybridVCoord          m_hvcoord;
+  ElementsState         m_state;
+  ElementsDerivedState  m_derived;
+  ElementsGeometry      m_geometry;
+  EquationOfState       m_eos;
+  Buffers               m_buffers;
+  deriv_type            m_deriv;
 
   SphereOperators             m_sphere_ops;
 
@@ -121,7 +122,8 @@ struct CaarFunctorImpl {
   CaarFunctorImpl(const Elements &elements, const Tracers &/* tracers */,
                   const ReferenceElement &ref_FE, const HybridVCoord &hvcoord,
                   const SphereOperators &sphere_ops, const SimulationParams& params)
-      : m_rsplit(params.rsplit)
+      : m_num_elems(elements.num_elems())
+      , m_rsplit(params.rsplit)
       , m_theta_hydrostatic_mode(params.theta_hydrostatic_mode)
       , m_theta_advection_form(params.theta_adv_form)
       , m_hvcoord(hvcoord)
@@ -130,13 +132,44 @@ struct CaarFunctorImpl {
       , m_geometry(elements.m_geometry)
       , m_deriv(ref_FE.get_deriv())
       , m_sphere_ops(sphere_ops)
-      , m_policy_pre (Homme::get_default_team_policy<ExecSpace,TagPreExchange>(elements.num_elems()))
-      , m_policy_post (0,elements.num_elems()*NP*NP)
-      , m_policy_dp3d_lim (Homme::get_default_team_policy<ExecSpace,TagDp3dLimiter>(elements.num_elems()))
+      , m_policy_pre (Homme::get_default_team_policy<ExecSpace,TagPreExchange>(m_num_elems))
+      , m_policy_post (0,m_num_elems*NP*NP)
+      , m_policy_dp3d_lim (Homme::get_default_team_policy<ExecSpace,TagDp3dLimiter>(m_num_elems))
       , m_tu(m_policy_pre)
   {
     // Initialize equation of state
     m_eos.init(params.theta_hydrostatic_mode,m_hvcoord);
+
+    // Make sure the buffers in sph op are large enough for this functor's needs
+    m_sphere_ops.allocate_buffers(m_tu);
+  }
+
+  CaarFunctorImpl(const int num_elems, const SimulationParams& params)
+      : m_num_elems(num_elems)
+      , m_rsplit(params.rsplit)
+      , m_theta_hydrostatic_mode(params.theta_hydrostatic_mode)
+      , m_theta_advection_form(params.theta_adv_form)
+      , m_policy_pre (Homme::get_default_team_policy<ExecSpace,TagPreExchange>(m_num_elems))
+      , m_policy_post (0,num_elems*NP*NP)
+      , m_policy_dp3d_lim (Homme::get_default_team_policy<ExecSpace,TagDp3dLimiter>(m_num_elems))
+      , m_tu(m_policy_pre)
+  {}
+
+
+  void setup (const Elements &elements, const Tracers &/*tracers*/,
+              const ReferenceElement &ref_FE, const HybridVCoord &hvcoord,
+              const SphereOperators &sphere_ops)
+  {
+    assert(m_num_elems == elements.num_elems()); // Sanity check
+    m_hvcoord = hvcoord;
+    m_state = elements.m_state;
+    m_derived = elements.m_derived;
+    m_geometry = elements.m_geometry;
+    m_deriv = ref_FE.get_deriv();
+    m_sphere_ops = sphere_ops;
+
+    // Initialize equation of state
+    m_eos.init(m_theta_hydrostatic_mode,m_hvcoord);
 
     // Make sure the buffers in sph op are large enough for this functor's needs
     m_sphere_ops.allocate_buffers(m_tu);

--- a/components/homme/src/theta-l_kokkos/cxx/ForcingFunctor.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ForcingFunctor.hpp
@@ -33,7 +33,16 @@ public:
   struct TagTracersPost {};
 
   ForcingFunctor ()
-   : m_policy_states(1,1)       // Need to init in constructor. Fix sizes in the body.
+   : m_state(Context::singleton().get<ElementsState>())
+   , m_forcing(Context::singleton().get<ElementsForcing>())
+   , m_geometry(Context::singleton().get<ElementsGeometry>())
+   , m_tracers(Context::singleton().get<Tracers>())
+   , m_hvcoord(Context::singleton().get<HybridVCoord>())
+   , m_num_state_elems(m_state.num_elems())
+   , m_num_tracer_elems(m_tracers.num_elems())
+   , m_num_tracers(m_tracers.num_tracers())
+   , is_setup(true)
+   , m_policy_states(1,1)       // Need to init in constructor. Fix sizes in the body.
    , m_policy_tracers_pre(1,1)
    , m_policy_tracers(1,1)
    , m_policy_tracers_post(1,1)
@@ -42,24 +51,6 @@ public:
    , m_tu_tracers(m_policy_tracers)
    , m_tu_tracers_post(m_policy_tracers_post)
   {
-    const auto& c = Context::singleton();
-    const auto& p = c.get<SimulationParams>();
-
-    m_hydrostatic = p.theta_hydrostatic_mode;
-    m_qsize = p.qsize;
-
-    m_state    = c.get<ElementsState>();
-    m_forcing  = c.get<ElementsForcing>();
-    m_geometry = c.get<ElementsGeometry>();
-    m_tracers  = c.get<Tracers>();
-    m_hvcoord  = c.get<HybridVCoord>();
-
-    // TODO: this may change, depending on the simulation params
-    m_adjust_ps = true;
-
-    m_eos.init(m_hydrostatic,m_hvcoord);
-    m_elem_ops.init(m_hvcoord);
-
     // Check everything is init-ed
     assert (m_state.num_elems()>0);
     assert (m_forcing.num_elems()>0);
@@ -67,11 +58,60 @@ public:
     assert (m_geometry.num_elems()>0);
     assert (m_hvcoord.m_inited);
 
+    init_params();
+
     // Create the team policy
-    m_policy_states = Homme::get_default_team_policy<ExecSpace,TagStates>(m_state.num_elems());
-    m_policy_tracers_pre = Homme::get_default_team_policy<ExecSpace,TagTracersPre>(m_tracers.num_elems());
-    m_policy_tracers = Homme::get_default_team_policy<ExecSpace,TagTracers>(m_tracers.num_elems()*m_tracers.num_tracers());
-    m_policy_tracers_post = Homme::get_default_team_policy<ExecSpace,TagTracersPost>(m_tracers.num_elems());
+    init_team_policies();
+  }
+
+  // This constructor is useful for using buffer functionality without
+  // having all other Functor information available.
+  // If this constructor is used, the setup() function must be called
+  // before using any other ForcingFunctor functions.
+  ForcingFunctor (const int num_state_elems, const int num_tracer_elems, const int num_tracers)
+    : m_hvcoord(Context::singleton().get<HybridVCoord>())
+    , m_num_state_elems(num_state_elems)
+    , m_num_tracer_elems(num_tracer_elems)
+    , m_num_tracers(num_tracers)
+    , is_setup(false)
+    , m_policy_states(1,1)       // Need to init in constructor. Fix sizes in the body.
+    , m_policy_tracers_pre(1,1)
+    , m_policy_tracers(1,1)
+    , m_policy_tracers_post(1,1)
+    , m_tu_states(m_policy_states)
+    , m_tu_tracers_pre(m_policy_tracers_pre)
+    , m_tu_tracers(m_policy_tracers)
+    , m_tu_tracers_post(m_policy_tracers_post)
+  {
+    assert (m_hvcoord.m_inited);
+
+    init_params();
+
+    // Create the team policy
+    init_team_policies();
+  }
+
+  void init_params ()
+  {
+    const auto& c = Context::singleton();
+    const auto& p = c.get<SimulationParams>();
+
+    m_hydrostatic = p.theta_hydrostatic_mode;
+    m_qsize = p.qsize;
+
+    // TODO: this may change, depending on the simulation params
+    m_adjust_ps = true;
+
+    m_eos.init(m_hydrostatic,m_hvcoord);
+    m_elem_ops.init(m_hvcoord);
+  }
+
+  void init_team_policies ()
+  {
+    m_policy_states = Homme::get_default_team_policy<ExecSpace,TagStates>(m_num_state_elems);
+    m_policy_tracers_pre = Homme::get_default_team_policy<ExecSpace,TagTracersPre>(m_num_tracer_elems);
+    m_policy_tracers = Homme::get_default_team_policy<ExecSpace,TagTracers>(m_num_tracer_elems*m_num_tracers);
+    m_policy_tracers_post = Homme::get_default_team_policy<ExecSpace,TagTracersPost>(m_num_tracer_elems);
 
     m_tu_states       = TeamUtils<ExecSpace>(m_policy_states);
     m_tu_tracers_pre  = TeamUtils<ExecSpace>(m_policy_tracers_pre);
@@ -79,9 +119,36 @@ public:
     m_tu_tracers_post = TeamUtils<ExecSpace>(m_policy_tracers_post);
   }
 
+  bool setup_needed () { return !is_setup; }
+
+  void setup ()
+  {
+    assert(!is_setup);
+
+    const auto& c = Context::singleton();
+
+    m_state    = c.get<ElementsState>();
+    m_forcing  = c.get<ElementsForcing>();
+    m_geometry = c.get<ElementsGeometry>();
+    m_tracers  = c.get<Tracers>();
+
+    // Check everything is init-ed
+    assert (m_state.num_elems()>0);
+    assert (m_forcing.num_elems()>0);
+    assert (m_tracers.num_elems()>0);
+    assert (m_geometry.num_elems()>0);
+
+    // Sanity checks
+    assert(m_num_state_elems == m_state.num_elems());
+    assert(m_num_tracer_elems == m_tracers.num_elems());
+    assert(m_num_tracers == m_tracers.num_tracers());
+
+    is_setup = true;
+  }
+
   int requested_buffer_size () const {
     const int nslots = m_tu_tracers.get_num_ws_slots();
-    const int nelems = m_state.num_elems();
+    const int nelems = m_num_state_elems;
     constexpr int mid_size = NP*NP*NUM_LEV*VECTOR_SIZE;
     constexpr int int_size = NP*NP*NUM_LEV_P*VECTOR_SIZE;
 
@@ -91,23 +158,22 @@ public:
 
   void init_buffers (const FunctorsBuffersManager& fbm) {
     const int num_slots = m_tu_tracers.get_num_ws_slots();
-    const int num_elems = m_state.num_elems();
 
     constexpr int mid_size = NP*NP*NUM_LEV;
 
     Scalar* mem = reinterpret_cast<Scalar*>(fbm.get_memory());
 
-    m_tn1 = decltype(m_tn1)(mem,num_elems);
-    mem += mid_size*num_elems;
+    m_tn1 = decltype(m_tn1)(mem,m_num_state_elems);
+    mem += mid_size*m_num_state_elems;
 
-    m_dp_adj = decltype(m_dp_adj)(mem,num_elems);
-    mem += mid_size*num_elems;
+    m_dp_adj = decltype(m_dp_adj)(mem,m_num_state_elems);
+    mem += mid_size*m_num_state_elems;
 
-    m_pnh = decltype(m_pnh)(mem,num_elems);
-    mem += mid_size*num_elems;
+    m_pnh = decltype(m_pnh)(mem,m_num_state_elems);
+    mem += mid_size*m_num_state_elems;
 
-    m_exner = decltype(m_exner)(mem,num_elems);
-    mem += mid_size*num_elems;
+    m_exner = decltype(m_exner)(mem,m_num_state_elems);
+    mem += mid_size*m_num_state_elems;
 
     m_Rstar = decltype(m_Rstar)(mem,num_slots);
     mem += mid_size*num_slots;
@@ -116,6 +182,9 @@ public:
   }
 
   void states_forcing (const Real dt, const int np1) {
+    // The Functor needs to be fully setup to use this function
+    assert (is_setup);
+
     m_dt = dt;
     m_np1 = np1;
 
@@ -167,6 +236,9 @@ public:
   }
 
   void tracers_forcing (const Real dt, const int np1, const int np1_qdp, const bool adjustment, const MoistDry moisture) {
+    // The Functor needs to be fully setup to use this function
+    assert (is_setup);
+
     m_dt = dt;
     m_np1 = np1;
     m_np1_qdp = np1_qdp;
@@ -446,6 +518,12 @@ private:
   HybridVCoord      m_hvcoord;
   ElementOps        m_elem_ops;
   EquationOfState   m_eos;
+
+  const int m_num_state_elems;
+  const int m_num_tracer_elems;
+  const int m_num_tracers;
+
+  bool is_setup;
 
   ExecViewUnmanaged<Scalar*[NP][NP][NUM_LEV]>   m_Rstar;
   ExecViewUnmanaged<Scalar*[NP][NP][NUM_LEV]>   m_dp_adj;

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -23,15 +23,38 @@ HyperviscosityFunctorImpl (const SimulationParams&     params,
                            const ElementsState&        state,
                            const ElementsDerivedState& derived)
  : m_data (params.hypervis_subcycle,params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,params.nu_p,params.nu_s,params.hypervis_scaling)
+ , m_num_elems(state.num_elems())
  , m_state   (state)
  , m_derived (derived)
  , m_geometry (geometry)
  , m_sphere_ops (Context::singleton().get<SphereOperators>())
  , m_hvcoord (Context::singleton().get<HybridVCoord>())
- , m_policy_update_states (Homme::get_default_team_policy<ExecSpace,TagUpdateStates>(state.num_elems()))
- , m_policy_first_laplace (Homme::get_default_team_policy<ExecSpace,TagFirstLaplaceHV>(state.num_elems()))
- , m_policy_pre_exchange (Homme::get_default_team_policy<ExecSpace, TagHyperPreExchange>(state.num_elems()))
+ , m_policy_update_states (Homme::get_default_team_policy<ExecSpace,TagUpdateStates>(m_num_elems))
+ , m_policy_first_laplace (Homme::get_default_team_policy<ExecSpace,TagFirstLaplaceHV>(m_num_elems))
+ , m_policy_pre_exchange (Homme::get_default_team_policy<ExecSpace, TagHyperPreExchange>(m_num_elems))
  , m_tu(m_policy_update_states)
+{
+  init_params(params);
+
+  // Make sure the sphere operators have buffers large enough to accommodate this functor's needs
+  m_sphere_ops.allocate_buffers(m_tu);
+}
+
+HyperviscosityFunctorImpl::
+HyperviscosityFunctorImpl (const int num_elems, const SimulationParams &params)
+  : m_data (params.hypervis_subcycle,params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,params.nu_p,params.nu_s,params.hypervis_scaling)
+  , m_num_elems(num_elems)
+  , m_hvcoord (Context::singleton().get<HybridVCoord>())
+  , m_policy_update_states (Homme::get_default_team_policy<ExecSpace,TagUpdateStates>(m_num_elems))
+  , m_policy_first_laplace (Homme::get_default_team_policy<ExecSpace,TagFirstLaplaceHV>(m_num_elems))
+  , m_policy_pre_exchange (Homme::get_default_team_policy<ExecSpace, TagHyperPreExchange>(m_num_elems))
+  , m_tu(m_policy_update_states)
+{
+  init_params(params);
+}
+
+
+void HyperviscosityFunctorImpl::init_params(const SimulationParams& params)
 {
   // Sanity check
   assert(params.params_set);
@@ -62,6 +85,17 @@ HyperviscosityFunctorImpl (const SimulationParams&     params,
 #else
   m_process_nh_vars = !params.theta_hydrostatic_mode;
 #endif
+}
+
+void HyperviscosityFunctorImpl::setup(const ElementsGeometry&     geometry,
+                                      const ElementsState&        state,
+                                      const ElementsDerivedState& derived)
+{
+  m_state = state;
+  assert(m_num_elems == m_state.num_elems()); //Sanity check
+  m_derived = derived;
+  m_geometry = geometry;
+  m_sphere_ops = Context::singleton().get<SphereOperators>();
 
   // Make sure the sphere operators have buffers large enough to accommodate this functor's needs
   m_sphere_ops.allocate_buffers(m_tu);
@@ -74,7 +108,6 @@ int HyperviscosityFunctorImpl::requested_buffer_size () const {
   constexpr int size_bhm_scalar =   NP*NP*NUM_BIHARMONIC_LEV*VECTOR_SIZE;
   constexpr int size_bhm_vector = 2*NP*NP*NUM_BIHARMONIC_LEV*VECTOR_SIZE;
 
-  const int nelems = m_geometry.num_elems();
   const int nteams = m_tu.get_num_ws_slots();
 
   // Number of scalar/vector int/mid/bhm buffers needed, with size nteams/nelems
@@ -85,9 +118,9 @@ int HyperviscosityFunctorImpl::requested_buffer_size () const {
   const int bhm_scalars_nteams = 2 + (m_process_nh_vars ? 2 : 0);
   const int bhm_vectors_nteams = 1;
 
-  const int size = nelems*(mid_scalars_nelems*size_mid_scalar +
-                           mid_vectors_nelems*size_mid_vector +
-                           int_scalars_nelems*size_int_scalar) +
+  const int size = m_num_elems*(mid_scalars_nelems*size_mid_scalar +
+                                mid_vectors_nelems*size_mid_vector +
+                                int_scalars_nelems*size_int_scalar) +
                    nteams*(bhm_scalars_nteams*size_bhm_scalar +
                            bhm_vectors_nteams*size_bhm_vector);
 

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
@@ -89,6 +89,14 @@ public:
                              const ElementsState&        state,
                              const ElementsDerivedState& derived);
 
+  HyperviscosityFunctorImpl (const int num_elems, const SimulationParams& params);
+
+  void init_params(const SimulationParams& params);
+
+  void setup(const ElementsGeometry&     geometry,
+             const ElementsState&        state,
+             const ElementsDerivedState& derived);
+
   int requested_buffer_size () const;
   void init_buffers (const FunctorsBuffersManager& fbm);
   void init_boundary_exchanges();
@@ -427,6 +435,7 @@ public:
 
 protected:
 
+  const int             m_num_elems;
   HyperviscosityData    m_data;
   ElementsState         m_state;
   ElementsDerivedState  m_derived;

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -309,10 +309,15 @@ contains
     ! Optional Input
     !
      logical(kind=c_bool), optional :: allocate_buffer  ! Whether functor memory buffer should be allocated internally
-    if (.not. present(allocate_buffer)) allocate_buffer = logical(.true.,c_bool)
 
     ! Initialize the C++ functors in the C++ context
-    call init_functors_c (logical(allocate_buffer,c_bool))
+    ! If no argument allocate_buffer is present,
+    ! let Homme internally allocate buffers
+    if (present(allocate_buffer)) then
+      call init_functors_c (logical(allocate_buffer,c_bool))
+    else
+      call init_functors_c (logical(.true.,c_bool))
+    endif
 
     ! Initialize boundary exchange structure in C++
     call init_boundary_exchanges_c ()

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -301,11 +301,18 @@ contains
     call prim_init_diags_views (elem)
   end subroutine prim_init_elements_views
 
-  subroutine prim_init_kokkos_functors ()
+  subroutine prim_init_kokkos_functors (allocate_buffer)
+    use iso_c_binding, only : c_bool
     use theta_f2c_mod, only : init_functors_c, init_boundary_exchanges_c
 
+    !
+    ! Optional Input
+    !
+     logical(kind=c_bool), optional :: allocate_buffer  ! Whether functor memory buffer should be allocated internally
+    if (.not. present(allocate_buffer)) allocate_buffer = logical(.true.,c_bool)
+
     ! Initialize the C++ functors in the C++ context
-    call init_functors_c ()
+    call init_functors_c (logical(allocate_buffer,c_bool))
 
     ! Initialize boundary exchange structure in C++
     call init_boundary_exchanges_c ()

--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -127,7 +127,12 @@ interface
   end subroutine init_reference_element_c
 
   ! Create C++ functors
-  subroutine init_functors_c () bind(c)
+  subroutine init_functors_c (allocate_buffer) bind(c)
+  use iso_c_binding, only: c_bool
+  !
+  ! Inputs
+  !
+  logical(kind=c_bool), intent(in) :: allocate_buffer
   end subroutine init_functors_c
 
   ! Initialize C++ boundary exchange structures

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -394,7 +394,7 @@ void AtmosphereDriver::initialize_atm_procs ()
   }
 
   // Initialize memory buffer for all atm processes
-  m_atm_process_group->initialize_atm_memory_buffer(memory_buffer);
+  m_atm_process_group->initialize_atm_memory_buffer(m_memory_buffer);
 
   // Initialize the processes
   m_atm_process_group->initialize(m_current_ts);

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -105,6 +105,8 @@ public:
 
   const std::shared_ptr<GridsManager>& get_grids_manager () const { return m_grids_manager; }
 
+  const ATMBufferManager& get_memory_buffer() const { return m_memory_buffer; }
+
 protected:
 
   void initialize_constant_field(const FieldRequest& freq, const ekat::ParameterList& ic_pl);
@@ -120,7 +122,7 @@ protected:
 
   OutputManager                                       m_output_manager;
 
-  ATMBufferManager                                    memory_buffer;
+  ATMBufferManager                                    m_memory_buffer;
 
   // Surface coupling stuff
   std::shared_ptr<SurfaceCoupling>            m_surface_coupling;

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -76,6 +76,13 @@ protected:
                          const std::vector<FieldTag>& tags,
                          const std::vector<int>& dims);
 
+  // Computes total number of bytes needed for local variables
+  int requested_buffer_size_in_bytes() const;
+
+  // Set local variables using memory provided by
+  // the ATMBufferManager
+  void init_buffers(const ATMBufferManager &buffer_manager);
+
   // Fields on reference and dynamics grid
   // NOTE: the dyn grid fields are *NOT* in the FieldManager. We still use
   //       scream Field's (rather than, e.g., raw views) cause we want to use

--- a/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -127,6 +127,9 @@ contains
     use homme_context_mod, only: is_model_inited, is_data_structures_inited, &
                                  elem, hybrid, hvcoord, deriv, tl
 
+    ! Local variable
+    logical(kind=c_bool), parameter :: allocate_buffer = .false.
+
     if (.not. is_data_structures_inited) then
       call abortmp ("Error! 'prim_init_data_structures_f90' has not been called yet.\n")
     elseif (is_model_inited) then
@@ -139,7 +142,10 @@ contains
     call model_init2(elem,hybrid,deriv,hvcoord,tl,1,nelemd)
 
     ! Initialize the C++ functors in the C++ context
-    call prim_init_kokkos_functors ()
+    ! Here we set allocate_buffer=false since the AD
+    ! allocates local memory for each process from a
+    ! single buffer.
+    call prim_init_kokkos_functors (allocate_buffer)
 
     ! Init grid views, ref_states views, and diags views
     call prim_init_grid_views (elem)

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -248,7 +248,7 @@ protected:
   void set_required_field_impl (const Field<const Real>& f);
   void set_computed_field_impl (const Field<      Real>& f);
 
-  // Computes total number of Reals needed for local variables
+  // Computes total number of bytes needed for local variables
   int requested_buffer_size_in_bytes() const;
 
   // Set local variables using memory provided by

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -137,7 +137,7 @@ public:
 
 protected:
 
-  // Computes total number of Reals needed for local variables
+  // Computes total number of bytes needed for local variables
   int requested_buffer_size_in_bytes() const;
 
   // Set local variables using memory provided by

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -398,7 +398,7 @@ protected:
   void set_required_field_impl (const Field<const Real>& f);
   void set_computed_field_impl (const Field<      Real>& f);
 
-  // Computes total number of Reals needed for local variables
+  // Computes total number of bytes needed for local variables
   int requested_buffer_size_in_bytes() const;
 
   // Set local variables using memory provided by

--- a/components/scream/tests/uncoupled/homme/homme_stand_alone.cpp
+++ b/components/scream/tests/uncoupled/homme/homme_stand_alone.cpp
@@ -12,6 +12,7 @@
 #include "Context.hpp"
 #include "SimulationParams.hpp"
 #include "Types.hpp"
+#include "FunctorsBuffersManager.hpp"
 
 #include "ekat/util/ekat_feutils.hpp"
 #include "ekat/ekat_assert.hpp"
@@ -56,6 +57,15 @@ TEST_CASE("scream_homme_stand_alone", "scream_homme_stand_alone") {
   // Init, run, and finalize
   util::TimeStamp time (0,0,0,0);
   ad.initialize(atm_comm,ad_params,time);
+
+  // Add checks to verify AD memory buffer and Homme FunctorsBuffersManager
+  // are the same size and reference the same memory.
+  auto& fbm  = Homme::Context::singleton().get<Homme::FunctorsBuffersManager>();
+  auto& memory_buffer = ad.get_memory_buffer();
+  EKAT_ASSERT_MSG(fbm.allocated_size()*sizeof(Real) == (long unsigned int)memory_buffer.allocated_bytes(),
+                  "Error! AD memory buffer and Homme FunctorsBuffersManager have mismatched sizes.");
+  EKAT_ASSERT_MSG(fbm.get_memory() == memory_buffer.get_memory(),
+                  "Error! AD memory buffer and Homme FunctorsBuffersManager reference different memory.");
 
   // Have to wait till now to get homme's parameters, cause it only gets init-ed during the driver initialization
   const auto& sp = Homme::Context::singleton().get<Homme::SimulationParams>();


### PR DESCRIPTION
Use AD mem buffer for local Homme views.

Two parts: 
1. Changing Homme code to allow for partial construction of Functors, i.e., construct Functors with minimal information to get the requested buffer size, then setup the rest of the Functors before use (and after all info is available). This should not alter any Homme tests, only add additional options for the AD.
2. Use the AD mem buffer in `atmosphere_dynamics.cpp`. We hook into the `FunctorBuffersManager` to query to amount of memory requested, and provide the `FunctorBuffersManager` with memory (instead of it allocating itself).