### PR TITLE
SCREAM: add ability to specify version when installing python pkg

### DIFF
--- a/components/scream/scripts/utils.py
+++ b/components/scream/scripts/utils.py
@@ -315,7 +315,7 @@ def ensure_pip():
     _ = import_module("pip")
 
 ###############################################################################
-def pip_install_lib(libname, min_version=None, pipname=None):
+def pip_install_lib(min_version=None, pipname=None):
 ###############################################################################
     """
     Ask pip to install a version of a package which is >= min_version
@@ -348,7 +348,7 @@ def _ensure_pylib_impl(libname, min_version=None, pipname=None):
         pkg = import_module(libname)
 
         if min_version is not None and parse_version(pkg.__version__) < parse_version(min_version):
-            print("Detected an old version ({}) for {} (required >= {}), will attempt to install version {} locally".format(pkg.__version__,libname,min_version,min_version))
+            print("Detected version for package {} is too old: detected {}, required >= {}. Script will attempt to install required version locally".format(libname, pkg.__version__,min_version))
             install = True
 
     except ImportError:
@@ -358,7 +358,7 @@ def _ensure_pylib_impl(libname, min_version=None, pipname=None):
         install = True
 
     if install:
-        pip_install_lib(libname,min_version,pipname)
+        pip_install_lib(min_version,pipname)
         _ = import_module(libname)
 
 # We've accepted these outside dependencies


### PR DESCRIPTION
I was getting weird yaml files when configuring scream via CIME, and could not figure out why things where working fine for others.

Eventually, I found out the version of my pyyaml was quite old. The utility `ensure_yaml` was not checking versions, so since _a_ version of pyyaml was installed, it did not proceed to download/install a newer one.

To fix this, we can now specify (optionally) a version for the packages we need. Our python scripts will then proceed to pip install the package if the import fails (like they did before) _or_ if the import succeeds, but the version loaded is older than the minimum version (if specified).