### PR TITLE
Introduces a calculate_density function to the common physics functions

### DIFF
--- a/components/scream/src/share/util/scream_common_physics_functions.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions.hpp
@@ -25,6 +25,18 @@ struct PhysicsFunctions
   // ---------------------------------------------------------------- //
 
   //-----------------------------------------------------------------------------------------------//
+  // Determines the density given the definition of pseudo_density passed by the dycore
+  //   rho = pseudo_density/dz/g
+  // where,
+  //   pseudo_density is the pressure level thickness given a shallow atmosphere, [Pa]
+  //   dz             is the geopotential thickness of the layer, [m]
+  //   g              is the gravitational constant, [m/s2] - defined in physics_constants.hpp
+  //-----------------------------------------------------------------------------------------------//
+  template<typename ScalarT>
+  KOKKOS_INLINE_FUNCTION
+  static ScalarT calculate_density(const ScalarT& pseudo_density, const ScalarT& dz);
+
+  //-----------------------------------------------------------------------------------------------//
   // Applies Exners Function which follows:
   //   Exner = (P/P0)^(Rd/Cp),
   // where,
@@ -216,12 +228,18 @@ struct PhysicsFunctions
   template <typename S>
   using view_1d = typename KT::template view_1d<S>;
 
+  template<typename ScalarT, typename InputProviderP, typename InputProviderZ>
+  KOKKOS_INLINE_FUNCTION
+  static void calculate_density (const MemberType& team,
+                                 const InputProviderP& pseudo_density,
+                                 const InputProviderZ& dz,
+                                 const view_1d<ScalarT>& density);
+
   template<typename ScalarT, typename InputProviderP>
   KOKKOS_INLINE_FUNCTION
   static void exner_function (const MemberType& team,
                               const InputProviderP& pressure,
                               const view_1d<ScalarT>& exner);
-
 
   template<typename ScalarT, typename InputProviderT, typename InputProviderP>
   KOKKOS_INLINE_FUNCTION

--- a/components/scream/src/share/util/scream_common_physics_functions_impl.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions_impl.hpp
@@ -9,6 +9,32 @@ namespace scream {
 template<typename DeviceT>
 template<typename ScalarT>
 KOKKOS_INLINE_FUNCTION
+ScalarT PhysicsFunctions<DeviceT>::calculate_density(const ScalarT& pseudo_density, const ScalarT& dz)
+{
+  using C = scream::physics::Constants<Real>;
+
+  static constexpr auto g = C::gravit;
+
+  return pseudo_density/dz/g;
+}
+
+template<typename DeviceT>
+template<typename ScalarT, typename InputProviderP, typename InputProviderZ>
+KOKKOS_INLINE_FUNCTION
+void PhysicsFunctions<DeviceT>::calculate_density(const MemberType& team,
+                                                  const InputProviderP& pseudo_density,
+                                                  const InputProviderZ& dz,
+                                                  const view_1d<ScalarT>& density)
+{
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,density.extent(0)),
+                       [&] (const int k) {
+    density(k) = calculate_density(pseudo_density(k),dz(k));
+  });
+}
+
+template<typename DeviceT>
+template<typename ScalarT>
+KOKKOS_INLINE_FUNCTION
 ScalarT PhysicsFunctions<DeviceT>::exner_function(const ScalarT& pressure)
 {
   using C = scream::physics::Constants<Real>;


### PR DESCRIPTION
Introduces a calculate_density function to the common physics functions framework.

The density calculation takes advantage of the definition of pseudo_density
passed to physics by the dynamics.  Psuedo_density assumes a shallow atmosphere,
i.e. cell area doesn't change with cell height.  As a result the expression for
density (rho) is a rather simple expression in terms of pseudo_density and dz.

This commit also introduces a set of new unit tests to test the calculate_density
function.

The calculate_density function will be needed for surface coupling, which requires the density of the bottom
layer of the atmosphere.

[BFB]