### PR TITLE
DP-SCREAM nightly test fix

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -392,8 +392,8 @@ _TESTS = {
             "REP.ne4pg2_ne4pg2.F2010-SCREAM-LR",
             "PEM.ne4pg2_ne4pg2.F2010-SCREAM-HR",
             "PEM.ne4pg2_ne4pg2.F2010-SCREAM-LR",
-            "SMS_R_Ln10.ne4_ne4.FDPSCREAMA97.dp-scream",
-            "ERS_R_Ln10.ne4_ne4.FDPSCREAMA97.dp-scream",
+            "SMS_R_Ln10.ne4_ne4.FDPSCREAMA97",
+            "ERS_R_Ln10.ne4_ne4.FDPSCREAMA97",
             )
     },
 


### PR DESCRIPTION
Remove unneeded and problematic test modifier from DP SCREAM tests, which was causing the nightly tests to fail.