### PR TITLE
Changes equal to approx equal for wet<-->dry mmr test

### DIFF
--- a/components/scream/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/scream/src/share/tests/common_physics_functions_tests.cpp
@@ -98,7 +98,6 @@ void run(std::mt19937_64& engine)
   view_1d temperature("temperature",num_mid_packs),
           height("height",num_mid_packs),
           qv("qv",num_mid_packs),
-          rand_int("rand_int",num_mid_packs),
           pressure("pressure",num_mid_packs),
           pseudo_density("pseudo_density",num_mid_packs),
           dz_for_testing("dz_for_testing",num_mid_packs),
@@ -144,7 +143,6 @@ void run(std::mt19937_64& engine)
   ekat::genRandArray(dview_as_real(temperature),     engine,pdf_temp);
   ekat::genRandArray(dview_as_real(height),          engine,pdf_height);
   ekat::genRandArray(dview_as_real(qv),              engine,pdf_qv);
-  ekat::genRandArray(dview_as_real(rand_int),        engine,pdf_rand_int);
   ekat::genRandArray(dview_as_real(pressure),        engine,pdf_pres);
   ekat::genRandArray(dview_as_real(pseudo_density),  engine,pdf_dp);
   ekat::genRandArray(dview_as_real(mmr_for_testing), engine,pdf_mmr);

--- a/components/scream/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/scream/src/share/tests/common_physics_functions_tests.cpp
@@ -241,6 +241,12 @@ void run(std::mt19937_64& engine)
   // mmr_test3: Compute drymmr from wetmmr0 and then use the result to compute wetmmr, which should be approximately
   //            equal to wetmmr0
 
+  // mmr_test4: [to test mathematical properties of the function] Compute drymmr from wetmmr0 and then use the result to
+  //            compute wetmmr. "qv" should be in the form of 2^k+1 (1 is added as we have [1-qv] in the numerator or
+  //            denominator of this function), so that the results of wet->dry->wet are exactly
+  //            the same as the initial input mmr(wetmmr0). This is a mathematical property test, so physically invalid qv
+  //            values are also acceptable
+
   REQUIRE( Check::equal(PF::calculate_wetmmr_from_drymmr(zero,qv0),zero) ); //mmr_test1
   REQUIRE( Check::equal(PF::calculate_drymmr_from_wetmmr(zero,qv0),zero) ); //mmr_test2
 
@@ -248,6 +254,12 @@ void run(std::mt19937_64& engine)
   tmp = PF::calculate_drymmr_from_wetmmr(wetmmr0,qv0);//get drymmr from wetmmr0
   tmp = PF::calculate_wetmmr_from_drymmr(tmp, qv0);//convert it back to wetmmr0
   REQUIRE( Check::approx_equal(tmp,wetmmr0,test_tol) );// wetmmr0 should be equal to tmp
+
+  //mmr_test4
+  ScalarT qv0_2k_m1 = pow(2,qv0)+1; // 2^qv0+1 (qv0 is just used as a random number here)
+  tmp = PF::calculate_drymmr_from_wetmmr(wetmmr0,qv0_2k_m1);//get drymmr from wetmmr0
+  tmp = PF::calculate_wetmmr_from_drymmr(tmp, qv0_2k_m1);//convert it back to wetmmr0
+  REQUIRE( Check::equal(tmp,wetmmr0) );// wetmmr0 should be exactly equal to tmp
 
   // DZ property tests:
   //  - calculate_dz(pseudo_density=0) = 0

--- a/components/scream/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/scream/src/share/tests/common_physics_functions_tests.cpp
@@ -238,7 +238,8 @@ void run(std::mt19937_64& engine)
   qv0  = pdf_qv(engine);  // This is an input for mmr_tests, so it won't be modified by mmr tests
   // mmr_test1: For zero drymmr, wetmmr should be zero
   // mmr_test2: For zero wetmmr, drymmr should be zero
-  // mmr_test3: Compute drymmr from wetmmr0 and then use the result to compute wetmmr, which should be equal to wetmmr0
+  // mmr_test3: Compute drymmr from wetmmr0 and then use the result to compute wetmmr, which should be approximately
+  //            equal to wetmmr0
 
   REQUIRE( Check::equal(PF::calculate_wetmmr_from_drymmr(zero,qv0),zero) ); //mmr_test1
   REQUIRE( Check::equal(PF::calculate_drymmr_from_wetmmr(zero,qv0),zero) ); //mmr_test2
@@ -246,7 +247,7 @@ void run(std::mt19937_64& engine)
   //mmr_test3
   tmp = PF::calculate_drymmr_from_wetmmr(wetmmr0,qv0);//get drymmr from wetmmr0
   tmp = PF::calculate_wetmmr_from_drymmr(tmp, qv0);//convert it back to wetmmr0
-  REQUIRE( Check::equal(tmp,wetmmr0) );// wetmmr0 should be equal to tmp
+  REQUIRE( Check::approx_equal(tmp,wetmmr0,test_tol) );// wetmmr0 should be equal to tmp
 
   // DZ property tests:
   //  - calculate_dz(pseudo_density=0) = 0


### PR DESCRIPTION
Strict equal comparison was failing on some nightly test machines. This PR changes `equal` to `approx_equal` to see if the tests pass. A new test has been added where strict `equal` test is used with qv=2^k+1 (where k is a random number)