### PR TITLE
Quick fix for coupled stand-alone tests and machine config file

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1438,7 +1438,7 @@
         <command name="load">git</command>
         <command name="load">intel/19.0.4</command>
         <command name="load">mvapich2/2.3</command>
-        <command name="load">cmake/3.14.5</command>
+        <command name="load">cmake/3.18.0</command>
         <command name="load">netcdf-fortran/4.4.4</command>
         <command name="load">pnetcdf/1.9.0</command>
       </modules>
@@ -1489,7 +1489,7 @@
         <command name="load">git</command>
         <command name="load">intel/19.0.4</command>
         <command name="load">mvapich2/2.3</command>
-        <command name="load">cmake/3.14.5</command>
+        <command name="load">cmake/3.18.0</command>
         <command name="load">netcdf-fortran/4.4.4</command>
         <command name="load">pnetcdf/1.9.0</command>
       </modules>

--- a/components/scream/tests/coupled/homme_physics/input.yaml
+++ b/components/scream/tests/coupled/homme_physics/input.yaml
@@ -4,7 +4,7 @@ Debug:
   Atmosphere DAG Verbosity Level: 5
 
 Initial Conditions:
-  Initial Conditions File: homme_shoc_cld_p3_rad_init_ne4np4.nc
+  Initial Conditions File: homme_shoc_cld_p3_rad_init_ne2np4.nc
   # Set X_prev = X
   T_mid_prev: T_mid
   horiz_winds_prev: horiz_winds

--- a/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/input.yaml
@@ -29,7 +29,7 @@ Grids Manager:
 
 # The name of the file containing the initial conditions for this test.
 Initial Conditions:
-  Initial Conditions File: shoc_cld_p3_rrtmgp_init_ne4np4.nc
+  Initial Conditions File: shoc_cld_p3_rrtmgp_init_ne2np4.nc
   skip_init_lat: false
   skip_init_lon: false
 ...


### PR DESCRIPTION
Fix the input.yaml file for coupled stand alone tests to reflect the change 
from ne4np4 initial condition files to ne2np4.

Fix the machine specs for LC quartz and syrah to reflect the need for
a newer cmake version in the latest version of Kokkos - introduced in
the latest upstream merge.