### PR TITLE
Only compute SW radiative fluxes for daytime columns

### DIFF
--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -288,11 +288,18 @@ namespace scream {
             fluxes_day.flux_dn     = flux_dn_day; //real2d("flux_dn"    , nday,nlay+1);
             fluxes_day.flux_dn_dir = flux_dn_dir_day; //real2d("flux_dn_dir", nday,nlay+1);
             rte_sw(optics, top_at_1, mu0_day, toa_flux, sfc_alb_dir_T, sfc_alb_dif_T, fluxes_day);
-            
-            // Expand fluxes to all columns
+
+            // Zero out all fluxes before expanding daytime fluxes
             auto &flux_up = fluxes.flux_up;
             auto &flux_dn = fluxes.flux_dn;
             auto &flux_dn_dir = fluxes.flux_dn_dir;
+            parallel_for(Bounds<2>(nlay+1,nday), YAKL_LAMBDA(int ilev, int icol) {
+                flux_up    (icol,ilev) = 0;
+                flux_dn    (icol,ilev) = 0;
+                flux_dn_dir(icol,ilev) = 0;
+            });
+            
+            // Expand daytime fluxes to all columns
             parallel_for(Bounds<2>(nlay+1,nday), YAKL_LAMBDA(int ilev, int iday) {
                 int icol = dayIndices(iday);
                 flux_up    (icol,ilev) = flux_up_day    (iday,ilev);

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -293,7 +293,7 @@ namespace scream {
             auto &flux_up = fluxes.flux_up;
             auto &flux_dn = fluxes.flux_dn;
             auto &flux_dn_dir = fluxes.flux_dn_dir;
-            parallel_for(Bounds<2>(nlay+1,nday), YAKL_LAMBDA(int ilev, int icol) {
+            parallel_for(Bounds<2>(nlay+1,ncol), YAKL_LAMBDA(int ilev, int icol) {
                 flux_up    (icol,ilev) = 0;
                 flux_dn    (icol,ilev) = 0;
                 flux_dn_dir(icol,ilev) = 0;

--- a/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/CMakeLists.txt
@@ -14,12 +14,10 @@ SET (NEED_LIBS shoc cld_fraction p3 scream_rrtmgp rrtmgp ${NETCDF_C} scream_cont
 # Add source files
 set (SRC shoc_cld_p3_rrtmgp.cpp ${SCREAM_BASE_DIR}/src/physics/rrtmgp/tests/rrtmgp_test_utils.cpp)
 
-# Test atmosphere processes. Temporarily disabled for AT because it has FPEs. Also
-# disabled if valgrind is ON because it takes too long.
-if (NOT SCREAM_AUTOTESTER)
-  CreateUnitTest(shoc_cld_p3_rrtmgp "${SRC}" "${NEED_LIBS}" LABELS "shoc;cld;p3;rrtmgp;physics")
-  set_target_properties(shoc_cld_p3_rrtmgp PROPERTIES COMPILE_FLAGS "${YAKL_CXX_FLAGS}")
-  target_include_directories(shoc_cld_p3_rrtmgp PUBLIC
+# Test atmosphere processes.
+CreateUnitTest(shoc_cld_p3_rrtmgp "${SRC}" "${NEED_LIBS}" LABELS "shoc;cld;p3;rrtmgp;physics")
+set_target_properties(shoc_cld_p3_rrtmgp PROPERTIES COMPILE_FLAGS "${YAKL_CXX_FLAGS}")
+target_include_directories(shoc_cld_p3_rrtmgp PUBLIC
     ${SCREAM_BASE_DIR}/src/physics/rrtmgp
     ${SCREAM_BASE_DIR}/src/physics/rrtmgp/tests
     ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp
@@ -29,7 +27,6 @@ if (NOT SCREAM_AUTOTESTER)
     ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/rte/kernels
     ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/extensions/cloud_optics
 )
-endif()
 
 ## Copy yaml input file to run directory
 FILE (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)


### PR DESCRIPTION
RRTMGP expects inputs to the shortwave (SW) solvers to be daytime only. Thus, no checks are made that the cosine of the solar zenith angle is greater than 0 (that the sun is above the horizon). Thus, floating point exceptions are encountered if nighttime columns are passed, due to division by the cosine of the solar zenith angle in the RRTMGP codes. To prevent this, we need to subset the inputs to the SW code to contain only daytime columns, and then expand the outputs back to all columns (filling in zeros for the fluxes where columns are not sunlit). This is consistent with the EAM treatment. Fixes #1102 