### PR TITLE
SCREAM: improve output of scream config string

### DIFF
--- a/components/scream/src/share/scream_config.cpp
+++ b/components/scream/src/share/scream_config.cpp
@@ -1,14 +1,18 @@
 #include "scream_config.hpp"
-#include "ekat/util/ekat_arch.hpp"
 #include "scream_types.hpp"
+
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/ekat_assert.hpp"
 
 namespace scream {
 
 std::string scream_config_string() {
-  auto config = ekat::ekat_config_string();
-
-  config += "\nsizeof(Real) = " + std::to_string(sizeof(Real)) + "\n";
-  config += "default pack size = " + std::to_string(SCREAM_PACK_SIZE) + "\n";
+  std::string config = "\n-------- EKAT CONFIGS --------\n\n";
+  config += ekat::ekat_config_string();
+  config += "\n-------- SCREAM CONFIGS --------\n\n";
+  config += " sizeof(Real) = " + std::to_string(sizeof(Real)) + "\n";
+  config += " default pack size = " + std::to_string(SCREAM_PACK_SIZE) + "\n";
+  config += "-------------------------------\n";
 
   return config;
 }


### PR DESCRIPTION
Two minor mods, both affecting the output of `scream_config_string()`, which is printed during the initialization of a scream session:

- separate ekat configs from scream ones in the banner;
- update ekat, so that the correct default fpe mask is printed.