### PR TITLE
HOMME: remove pointless cmake targets for cxx (homme) targets.

### DIFF
--- a/components/homme/src/preqx_kokkos/CMakeLists.txt
+++ b/components/homme/src/preqx_kokkos/CMakeLists.txt
@@ -242,20 +242,3 @@ MACRO(PREQX_KOKKOS_SETUP)
   SET(USE_OPENACC FALSE)
 
 ENDMACRO(PREQX_KOKKOS_SETUP)
-
-# Build exec only if HOMME_BUILD_EXECS is true
-IF (HOMME_BUILD_EXECS)
-  PREQX_KOKKOS_SETUP()
-
-  ############################################################################
-  # createTestExec(exec_name exec_type NP NC PLEV USE_PIO USE_ENERGY QSIZE_D)
-  ############################################################################
-  createTestExec(preqx_kokkos preqx_kokkos ${PREQX_NP} ${PREQX_NC} ${PREQX_PLEV} ${PREQX_USE_PIO}  ${PREQX_USE_ENERGY} ${QSIZE_D})
-ENDIF ()
-
-IF (HOMME_BUILD_LIBS)
-  PREQX_KOKKOS_SETUP()
-
-  createExecLib(preqx_kokkos_lib preqx_kokkos "${PREQX_DEPS}" "${EXEC_LIB_INCLUDE_DIRS}"
-      ${PREQX_NP} ${PREQX_PLEV} ${PREQX_USE_ENERGY} ${QSIZE_D})
-ENDIF ()

--- a/components/homme/src/theta-l_kokkos/CMakeLists.txt
+++ b/components/homme/src/theta-l_kokkos/CMakeLists.txt
@@ -252,21 +252,3 @@ MACRO(THETAL_KOKKOS_SETUP)
   SET(USE_OPENACC FALSE)
 
 ENDMACRO(THETAL_KOKKOS_SETUP)
-
-# Build exec only if HOMME_BUILD_EXECS is true
-IF (HOMME_BUILD_EXECS)
-  THETAL_KOKKOS_SETUP()
-
-  ############################################################################
-  # createTestExec(exec_name exec_type NP NC PLEV USE_PIO USE_ENERGY QSIZE_D)
-  ############################################################################
-  createTestExec(theta-l_kokkos theta-l_kokkos ${PREQX_NP} ${PREQX_NC} ${PREQX_PLEV} ${PREQX_USE_PIO}  ${PREQX_USE_ENERGY} ${QSIZE_D})
-ENDIF ()
-
-IF (HOMME_BUILD_LIBS)
-  THETAL_KOKKOS_SETUP()
-
-  createExecLib(theta-l_kokkos_lib theta-l_kokkos "${THETAL_DEPS}" "${EXEC_LIB_INCLUDE_DIRS}"
-      ${PREQX_NP} ${PREQX_PLEV} ${PREQX_USE_ENERGY} ${QSIZE_D})
-ENDIF ()
-


### PR DESCRIPTION
There are cmake targets built inside the preqx/theta folders, which are not used by any test. They can be either executables or libraries (depending on how HOMME was configured). Not building these can save some compilation time. More importantly, though, these targets (which are handled internally by homme, with no inputs from scream) seem to be responsible for some internal compiler errors on CUDA, so removing them is actually a priority, to get the AT working (though we could probably have also manipulated the target property to remove it from the 'all' target, but that seems a bit more involved and intrusive).

Note: this commit is replicated in the upstream PR in E3SM.