### PR TITLE
Change exner to inv_exner in SHOC

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -294,7 +294,7 @@ subroutine shoc_main ( &
   real(rtype), intent(in) :: vw_sfc(shcol)
   ! Surface flux for tracers [varies]
   real(rtype), intent(in) :: wtracer_sfc(shcol,num_qtracers)
-  ! Exner function [-]
+  ! Inverse of the exner function [-]
   real(rtype), intent(in) :: inv_exner(shcol,nlev)
   ! Host model surface geopotential height
   real(rtype), intent(in) :: phis(shcol)
@@ -3749,7 +3749,7 @@ end subroutine shoc_energy_integrals
 
 subroutine update_host_dse(&
          shcol,nlev,thlm,&                 ! Input
-         shoc_ql,inv_exner,zt_grid,phis,&      ! Input
+         shoc_ql,inv_exner,zt_grid,phis,&  ! Input
          host_dse)                         ! Output
 
 #ifdef SCREAM_CONFIG_IS_CMAKE

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -182,8 +182,8 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
   s_mem += m_buffer.wtracer_sfc.size();
   m_buffer.wm_zt = decltype(m_buffer.wm_zt)(s_mem, m_num_cols, nlev_packs);
   s_mem += m_buffer.wm_zt.size();
-  m_buffer.exner = decltype(m_buffer.exner)(s_mem, m_num_cols, nlev_packs);
-  s_mem += m_buffer.exner.size();
+  m_buffer.inv_exner = decltype(m_buffer.inv_exner)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.inv_exner.size();
   m_buffer.thlm = decltype(m_buffer.thlm)(s_mem, m_num_cols, nlev_packs);
   s_mem += m_buffer.thlm.size();
   m_buffer.qw = decltype(m_buffer.qw)(s_mem, m_num_cols, nlev_packs);
@@ -282,7 +282,7 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   auto zi_grid     = m_buffer.zi_grid;
   auto wtracer_sfc = m_buffer.wtracer_sfc;
   auto wm_zt       = m_buffer.wm_zt;
-  auto exner       = m_buffer.exner;
+  auto inv_exner   = m_buffer.inv_exner;
   auto thlm        = m_buffer.thlm;
   auto qw          = m_buffer.qw;
   auto s           = m_buffer.s;
@@ -295,7 +295,7 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
                                 T_mid,z_int,z_mid,p_mid,pseudo_density,omega,phis,surf_sens_flux,surf_latent_flux,
                                 surf_u_mom_flux,surf_v_mom_flux,qv,qv_copy,qc,qc_copy,tke,tke_copy,cell_length,
                                 s,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
-                                wtracer_sfc,wm_zt,exner,thlm,qw);
+                                wtracer_sfc,wm_zt,inv_exner,thlm,qw);
 
   // Input Variables:
   input.dx          = shoc_preprocess.cell_length;
@@ -312,7 +312,7 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   input.uw_sfc      = shoc_preprocess.upwp_sfc;
   input.vw_sfc      = shoc_preprocess.vpwp_sfc;
   input.wtracer_sfc = shoc_preprocess.wtracer_sfc;
-  input.exner       = shoc_preprocess.exner;
+  input.inv_exner   = shoc_preprocess.inv_exner;
   input.phis        = phis;
 
   // Input/Output Variables

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -110,7 +110,7 @@ public:
         const Spack exner_ik = PF::exner_function(p_mid_ik);
         const Smask nonzero = (exner_ik != 0);
         EKAT_KERNEL_ASSERT((nonzero || !in_nlev_range).any());
-        inv_exner(i,k).set(nonzero, 1.0/exner_ik);
+        inv_exner(i,k).set(nonzero, 1/exner_ik);
 
         tke(i,k) = ekat::max(sp(0.004), tke(i,k));
 

--- a/components/scream/src/physics/shoc/shoc_f90.cpp
+++ b/components/scream/src/physics/shoc/shoc_f90.cpp
@@ -16,7 +16,7 @@ extern "C" {
                    Real* zi_grid, Real* pres, Real* presi, Real* pdel,
                    Real* wthl_sfc, Real* wqw_sfc, Real* uw_sfc, Real* vw_sfc,
                    Real* wtracer_sfc, int num_qtracers, Real* w_field,
-                   Real* exner, Real* phis, Real* host_dse, Real* tke,
+                   Real* inv_exner, Real* phis, Real* host_dse, Real* tke,
                    Real* thetal, Real* qw, Real* u_wind, Real* v_wind,
                    Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk,
                    Real* shoc_ql, Real* shoc_cldfrac, Real* pblh,
@@ -51,7 +51,7 @@ FortranData::FortranData(Int shcol_, Int nlev_, Int nlevi_,
   uw_sfc = Array1("Surface momentum flux (u direction) [m2/s2]", shcol);
   vw_sfc = Array1("Surface momentum flux (v direction) [m2/s2]", shcol);
   wtracer_sfc = Array2("Surface tracer flux [various]", shcol, num_qtracers);
-  exner = Array2("Exner function [-]", shcol, nlev);
+  inv_exner = Array2("Inverse of the Exner function [-]", shcol, nlev);
   phis = Array1("Host model surface geopotential height [m?]", shcol);
 
   // In/out variables
@@ -103,7 +103,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(zt_grid); fdipb(zi_grid); fdipb(pres); fdipb(presi); fdipb(pdel);
   fdipb(thv); fdipb(w_field);
   fdipb(wthl_sfc); fdipb(wqw_sfc); fdipb(uw_sfc); fdipb(vw_sfc);
-  fdipb(wtracer_sfc); fdipb(exner);
+  fdipb(wtracer_sfc); fdipb(inv_exner);
   fdipb(phis);
 
   fdipb(host_dse); fdipb(tke); fdipb(thetal); fdipb(qw);
@@ -149,7 +149,7 @@ Int shoc_main(FortranData& d, bool use_fortran) {
                 d.zt_grid.data(), d.zi_grid.data(), d.pres.data(), d.presi.data(),
                 d.pdel.data(), d.wthl_sfc.data(), d.wqw_sfc.data(), d.uw_sfc.data(),
                 d.vw_sfc.data(), d.wtracer_sfc.data(), (int)d.num_qtracers,
-                d.w_field.data(), d.exner.data(), d.phis.data(), d.host_dse.data(),
+                d.w_field.data(), d.inv_exner.data(), d.phis.data(), d.host_dse.data(),
                 d.tke.data(), d.thetal.data(), d.qw.data(), d.u_wind.data(),
                 d.v_wind.data(), d.qtracers.data(), d.wthv_sec.data(), d.tkh.data(),
                 d.tk.data(), d.shoc_ql.data(), d.shoc_cldfrac.data(), d.pblh.data(),
@@ -167,7 +167,7 @@ Int shoc_main(FortranData& d, bool use_fortran) {
                        d.presi.data(), d.pdel.data(), d.wthl_sfc.data(),
                        d.wqw_sfc.data(), d.uw_sfc.data(), d.vw_sfc.data(),
                        d.wtracer_sfc.data(), (int)d.num_qtracers,
-                       d.w_field.data(), d.exner.data(), d.phis.data(), d.host_dse.data(),
+                       d.w_field.data(), d.inv_exner.data(), d.phis.data(), d.host_dse.data(),
                        d.tke.data(), d.thetal.data(), d.qw.data(),
                        d.u_wind.data(), d.v_wind.data(), d.qtracers.data(), d.wthv_sec.data(),
                        d.tkh.data(), d.tk.data(), d.shoc_ql.data(),
@@ -301,7 +301,7 @@ void gen_plot_script(const std::vector<std::shared_ptr<FortranData> >& data,
       "                  'qw', 'u_wind', 'v_wind', 'w_field', 'tke', 'tkh',\n"
       "                  'shoc_mix', 'isotropy', 'wtke_sec', 'uw_sec', 'vw_sec', 'wthl_sec',\n"
       "                  'wqw_sec', 'w_sec', 'thl_sec', 'qw_sec',\n"
-      "                  'w3', 'wqls_sec', 'brunt', 'qtracers', 'host_dse', 'exner','shoc_ql2']\n"
+      "                  'w3', 'wqls_sec', 'brunt', 'qtracers', 'host_dse', 'inv_exner','shoc_ql2']\n"
       "        for i in range(len(plotno)):\n"
       "            if i == 0 or plotno[i] != plotno[i-1]:\n"
       "                if first: axs.append(pl.subplot(5, 5, plotno[i]))\n"
@@ -359,7 +359,7 @@ void gen_plot_script(const std::vector<std::shared_ptr<FortranData> >& data,
       WRITE_FIELD(brunt);
       WRITE_FIELD(qtracers);
       WRITE_FIELD(host_dse);
-      WRITE_FIELD(exner);
+      WRITE_FIELD(inv_exner);
       WRITE_FIELD(shoc_ql2);
       fprintf(fp, "    },\n");
 #undef WRITE_FIELD

--- a/components/scream/src/physics/shoc/shoc_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_f90.hpp
@@ -27,7 +27,7 @@ struct FortranData {
   Array1 host_dx, host_dy;
   Array2 zt_grid, zi_grid, pres, presi, pdel, thv, w_field;
   Array1 wthl_sfc, wqw_sfc, uw_sfc, vw_sfc;
-  Array2 wtracer_sfc, exner;
+  Array2 wtracer_sfc, inv_exner;
   Array1 phis;
 
   // In-out

--- a/components/scream/src/physics/shoc/shoc_functions.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions.hpp
@@ -101,8 +101,8 @@ struct Functions
     view_1d<const Scalar> vw_sfc;
     // Surface flux for tracers [varies]
     view_2d<const Spack>  wtracer_sfc;
-    // Exner function [-]
-    view_2d<const Spack>  exner;
+    // Inverse of the exner function [-]
+    view_2d<const Spack>  inv_exner;
     // Host model surface geopotential height
     view_1d<const Scalar> phis;
   };
@@ -219,7 +219,7 @@ struct Functions
     const Int& nlev,
     const uview_1d<const Spack>& thlm,
     const uview_1d<const Spack>& shoc_ql,
-    const uview_1d<const Spack>& exner,
+    const uview_1d<const Spack>& inv_exner,
     const uview_1d<const Spack>& zt_grid,
     const Scalar& phis,
     const uview_1d<Spack>& host_dse);
@@ -577,7 +577,7 @@ struct Functions
     const Scalar&                uw_sfc,
     const Scalar&                vw_sfc,
     const uview_1d<const Spack>& wtracer_sfc,
-    const uview_1d<const Spack>& exner,
+    const uview_1d<const Spack>& inv_exner,
     const Scalar&                phis,
     // Local Workspace
     const Workspace&             workspace,

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -48,13 +48,13 @@ struct ShocDiagObklenData : public PhysicsTestData {
 struct UpdateHostDseData : public PhysicsTestData {
   // Inputs
   Int shcol, nlev;
-  Real *thlm, *shoc_ql, *exner, *zt_grid, *phis;
+  Real *thlm, *shoc_ql, *inv_exner, *zt_grid, *phis;
 
   // Outputs
   Real *host_dse;
 
   UpdateHostDseData(Int shcol_, Int nlev_) :
-    PhysicsTestData({{ shcol_, nlev_ }, { shcol_ }}, {{ &thlm, &shoc_ql, &exner, &zt_grid, &host_dse }, { &phis }}), shcol(shcol_), nlev(nlev_) {}
+    PhysicsTestData({{ shcol_, nlev_ }, { shcol_ }}, {{ &thlm, &shoc_ql, &inv_exner, &zt_grid, &host_dse }, { &phis }}), shcol(shcol_), nlev(nlev_) {}
 
   PTD_STD_DEF(UpdateHostDseData, 2, shcol, nlev);
 };
@@ -772,7 +772,7 @@ struct ShocMainData : public PhysicsTestData {
   // Inputs
   Int shcol, nlev, nlevi, nadv, num_qtracers;
   Real dtime;
-  Real *host_dx, *host_dy, *thv, *zt_grid, *zi_grid, *pres, *presi, *pdel, *wthl_sfc, *wqw_sfc, *uw_sfc, *vw_sfc, *wtracer_sfc, *w_field, *exner, *phis;
+  Real *host_dx, *host_dy, *thv, *zt_grid, *zi_grid, *pres, *presi, *pdel, *wthl_sfc, *wqw_sfc, *uw_sfc, *vw_sfc, *wtracer_sfc, *w_field, *inv_exner, *phis;
 
   // Inputs for shoc_init
   Int nbot_shoc, ntop_shoc;
@@ -789,7 +789,7 @@ struct ShocMainData : public PhysicsTestData {
   ShocMainData(Int shcol_, Int nlev_, Int nlevi_, Int num_qtracers_, Real dtime_, Int nadv_, Int nbot_shoc_, Int ntop_shoc_) :
     PhysicsTestData({{ shcol_ }, { shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_, num_qtracers_ }, { shcol_, nlev_, num_qtracers_ }, { nlev_ }},
                     {{ &host_dx, &host_dy, &wthl_sfc, &wqw_sfc, &uw_sfc, &vw_sfc, &phis, &pblh },
-                     { &thv, &zt_grid, &pres, &pdel, &w_field, &exner, &host_dse, &tke, &thetal,
+                     { &thv, &zt_grid, &pres, &pdel, &w_field, &inv_exner, &host_dse, &tke, &thetal,
                        &qw, &u_wind, &v_wind, &wthv_sec, &tkh, &tk, &shoc_ql, &shoc_cldfrac,
                        &shoc_mix, &isotropy, &w_sec, &wqls_sec, &brunt, &shoc_ql2 },
                      { &zi_grid, &presi, &thl_sec, &qw_sec, &qwthl_sec, &wthl_sec,
@@ -965,7 +965,7 @@ void shoc_diag_second_moments_srf_f(Int shcol, Real* wthl, Real* uw, Real* vw,
                           Real* ustar2, Real* wstar);
 void shoc_diag_second_moments_ubycond_f(Int shcol, Real* thl, Real* qw, Real* wthl,
                           Real* wqw, Real* qwthl, Real* uw, Real* vw, Real* wtke);
-void update_host_dse_f(Int shcol, Int nlev, Real* thlm, Real* shoc_ql, Real* exner, Real* zt_grid,
+void update_host_dse_f(Int shcol, Int nlev, Real* thlm, Real* shoc_ql, Real* inv_exner, Real* zt_grid,
                        Real* phis, Real* host_dse);
 void compute_diag_third_shoc_moment_f(Int shcol, Int nlev, Int nlevi, Real* w_sec,
                                       Real* thl_sec, Real* wthl_sec, Real* tke,
@@ -1036,7 +1036,7 @@ void dp_inverse_f(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_zt);
 int shoc_init_f(Int nlev, Real* pref_mid, Int nbot_shoc, Int ntop_shoc);
 Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, Real* host_dx, Real* host_dy, Real* thv,
                 Real* zt_grid, Real* zi_grid, Real* pres, Real* presi, Real* pdel, Real* wthl_sfc, Real* wqw_sfc,
-                Real* uw_sfc, Real* vw_sfc, Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* exner,
+                Real* uw_sfc, Real* vw_sfc, Real* wtracer_sfc, Int num_qtracers, Real* w_field, Real* inv_exner,
                 Real* phis, Real* host_dse, Real* tke, Real* thetal, Real* qw, Real* u_wind, Real* v_wind,
                 Real* qtracers, Real* wthv_sec, Real* tkh, Real* tk, Real* shoc_ql, Real* shoc_cldfrac, Real* pblh,
                 Real* shoc_mix, Real* isotropy, Real* w_sec, Real* thl_sec, Real* qw_sec, Real* qwthl_sec,

--- a/components/scream/src/physics/shoc/shoc_ic_cases.cpp
+++ b/components/scream/src/physics/shoc/shoc_ic_cases.cpp
@@ -54,7 +54,7 @@ void flip_vertically(FortranData& d)
   flip_vertically(d.presi);
   flip_vertically(d.pdel);
   flip_vertically(d.w_field);
-  flip_vertically(d.exner);
+  flip_vertically(d.inv_exner);
   flip_vertically(d.host_dse);
   flip_vertically(d.tke);
   flip_vertically(d.thetal);
@@ -202,8 +202,8 @@ FortranData::Ptr make_standard(const Int shcol, Int nlev, Int num_qtracers) {
     // Compute pressure differences and host_dse / exner.
     for (Int k = 0; k < nlev; ++k) {
       d.pdel(i, k) = std::abs(d.presi(i, k+1) - d.presi(i, k));
-      d.exner(i, k) = pow(d.pres(i, k)/consts::P0, consts::Rair/consts::Cpair);
-      d.host_dse(i, k) = consts::Cpair * d.exner(i, k) * d.thv(i, k) +
+      d.inv_exner(i, k) = 1.0/pow(d.pres(i, k)/consts::P0, consts::Rair/consts::Cpair);
+      d.host_dse(i, k) = consts::Cpair * d.thv(i, k)/d.inv_exner(i, k) +
                          consts::gravit * d.zt_grid(i, k);
     }
 

--- a/components/scream/src/physics/shoc/shoc_ic_cases.cpp
+++ b/components/scream/src/physics/shoc/shoc_ic_cases.cpp
@@ -202,7 +202,7 @@ FortranData::Ptr make_standard(const Int shcol, Int nlev, Int num_qtracers) {
     // Compute pressure differences and host_dse / exner.
     for (Int k = 0; k < nlev; ++k) {
       d.pdel(i, k) = std::abs(d.presi(i, k+1) - d.presi(i, k));
-      d.inv_exner(i, k) = 1.0/pow(d.pres(i, k)/consts::P0, consts::Rair/consts::Cpair);
+      d.inv_exner(i, k) = 1/pow(d.pres(i, k)/consts::P0, consts::Rair/consts::Cpair);
       d.host_dse(i, k) = consts::Cpair * d.thv(i, k)/d.inv_exner(i, k) +
                          consts::gravit * d.zt_grid(i, k);
     }

--- a/components/scream/src/physics/shoc/shoc_ic_cases.cpp
+++ b/components/scream/src/physics/shoc/shoc_ic_cases.cpp
@@ -199,7 +199,7 @@ FortranData::Ptr make_standard(const Int shcol, Int nlev, Int num_qtracers) {
     compute_column_pressure(i, d.nlev, d.zt_grid, d.pres);
     compute_column_pressure(i, d.nlevi, d.zi_grid, d.presi);
 
-    // Compute pressure differences and host_dse / exner.
+    // Compute pressure differences and host_dse * exner.
     for (Int k = 0; k < nlev; ++k) {
       d.pdel(i, k) = std::abs(d.presi(i, k+1) - d.presi(i, k));
       d.inv_exner(i, k) = 1/pow(d.pres(i, k)/consts::P0, consts::Rair/consts::Cpair);

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -75,7 +75,7 @@ contains
 
   subroutine shoc_main_c(shcol,nlev,nlevi,dtime,nadv,host_dx, host_dy, thv,  &
      zt_grid, zi_grid, pres, presi, pdel, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, &
-     wtracer_sfc, num_qtracers, w_field, exner,phis, host_dse, tke, thetal,  &
+     wtracer_sfc, num_qtracers, w_field, inv_exner, phis, host_dse, tke, thetal,  &
      qw, u_wind, v_wind, qtracers, wthv_sec, tkh, tk, shoc_ql, shoc_cldfrac, &
      pblh, shoc_mix, isotropy, w_sec, thl_sec, qw_sec, qwthl_sec, wthl_sec,  &
      wqw_sec, wtke_sec, uw_sec, vw_sec, w3, wqls_sec, brunt, shoc_ql2, elapsed_s) bind(C)
@@ -91,7 +91,7 @@ contains
     real(kind=c_real), intent(in), dimension(shcol, nlev) :: pdel, thv, w_field
     real(kind=c_real), intent(in), dimension(shcol) :: wthl_sfc, wqw_sfc, uw_sfc, vw_sfc
     real(kind=c_real), intent(in), dimension(shcol, num_qtracers) :: wtracer_sfc
-    real(kind=c_real), intent(in), dimension(shcol, nlev) :: exner
+    real(kind=c_real), intent(in), dimension(shcol, nlev) :: inv_exner
     real(kind=c_real), intent(in), dimension(shcol) :: phis
 
     real(kind=c_real), intent(inout), dimension(shcol, nlev) :: host_dse, tke, &
@@ -111,7 +111,7 @@ contains
 
     call shoc_main(shcol, nlev, nlevi, dtime, nadv, host_dx, host_dy, thv,   &
      zt_grid, zi_grid, pres, presi, pdel, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, &
-     wtracer_sfc, num_qtracers, w_field, exner, phis, host_dse, tke, thetal, &
+     wtracer_sfc, num_qtracers, w_field, inv_exner, phis, host_dse, tke, thetal, &
      qw, u_wind, v_wind, qtracers, wthv_sec, tkh, tk, shoc_ql, shoc_cldfrac, &
      pblh, shoc_mix, isotropy, w_sec, thl_sec, qw_sec, qwthl_sec, wthl_sec,  &
      wqw_sec, wtke_sec, uw_sec, vw_sec, w3, wqls_sec, brunt,shoc_ql2,elapsed_s)
@@ -414,7 +414,7 @@ contains
 
   end subroutine eddy_diffusivities_c
 
-  subroutine update_host_dse_c(shcol, nlev, thlm, shoc_ql, exner, zt_grid, &
+  subroutine update_host_dse_c(shcol, nlev, thlm, shoc_ql, inv_exner, zt_grid, &
                                phis, host_dse) bind (C)
     use shoc, only: update_host_dse
 
@@ -422,13 +422,13 @@ contains
     integer(kind=c_int), intent(in), value :: nlev
     real(kind=c_real), intent(in) :: thlm(shcol,nlev)
     real(kind=c_real), intent(in) :: shoc_ql(shcol,nlev)
-    real(kind=c_real), intent(in) :: exner(shcol,nlev)
+    real(kind=c_real), intent(in) :: inv_exner(shcol,nlev)
     real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
     real(kind=c_real), intent(in) :: phis(shcol)
 
     real(kind=c_real), intent(out) :: host_dse(shcol,nlev)
 
-    call update_host_dse(shcol, nlev, thlm, shoc_ql, exner, zt_grid, &
+    call update_host_dse(shcol, nlev, thlm, shoc_ql, inv_exner, zt_grid, &
                            phis, host_dse)
 
   end subroutine update_host_dse_c

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -70,7 +70,7 @@ interface
 
   end subroutine shoc_diag_second_moments_ubycond_f
 
-  subroutine update_host_dse_f(shcol, nlev, thlm, shoc_ql, exner, zt_grid, &
+  subroutine update_host_dse_f(shcol, nlev, thlm, shoc_ql, inv_exner, zt_grid, &
        phis, host_dse) bind (C)
     use iso_c_binding
 
@@ -78,7 +78,7 @@ interface
     integer(kind=c_int), intent(in), value :: nlev
     real(kind=c_real), intent(in) :: thlm(shcol,nlev)
     real(kind=c_real), intent(in) :: shoc_ql(shcol,nlev)
-    real(kind=c_real), intent(in) :: exner(shcol,nlev)
+    real(kind=c_real), intent(in) :: inv_exner(shcol,nlev)
     real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
     real(kind=c_real), intent(in) :: phis(shcol)
 
@@ -403,13 +403,13 @@ subroutine dp_inverse_f(nlev, shcol, rho_zt, dz_zt, rdp_zt) bind(C)
   real(kind=c_real), intent(out) :: rdp_zt(shcol,nlev)
 end subroutine dp_inverse_f
 
-  subroutine shoc_main_f(shcol, nlev, nlevi, dtime, nadv, npbl, host_dx, host_dy, thv, zt_grid, zi_grid, pres, presi, pdel, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, wtracer_sfc, num_qtracers, w_field, exner, phis, host_dse, tke, thetal, qw, u_wind, v_wind, qtracers, wthv_sec, tkh, tk, shoc_ql, shoc_cldfrac, pblh, shoc_mix, isotropy, w_sec, thl_sec, qw_sec, qwthl_sec, wthl_sec, wqw_sec, wtke_sec, uw_sec, vw_sec, w3, wqls_sec, brunt, shoc_ql2) bind(C)
+  subroutine shoc_main_f(shcol, nlev, nlevi, dtime, nadv, npbl, host_dx, host_dy, thv, zt_grid, zi_grid, pres, presi, pdel, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, wtracer_sfc, num_qtracers, w_field, inv_exner, phis, host_dse, tke, thetal, qw, u_wind, v_wind, qtracers, wthv_sec, tkh, tk, shoc_ql, shoc_cldfrac, pblh, shoc_mix, isotropy, w_sec, thl_sec, qw_sec, qwthl_sec, wthl_sec, wqw_sec, wtke_sec, uw_sec, vw_sec, w3, wqls_sec, brunt, shoc_ql2) bind(C)
     use iso_c_binding
 
     integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi, nadv, num_qtracers, npbl
     real(kind=c_real) , value, intent(in) :: dtime
     real(kind=c_real) , intent(in), dimension(shcol) :: host_dx, host_dy, wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, phis
-    real(kind=c_real) , intent(in), dimension(shcol, nlev) :: thv, zt_grid, pres, pdel, w_field, exner
+    real(kind=c_real) , intent(in), dimension(shcol, nlev) :: thv, zt_grid, pres, pdel, w_field, inv_exner
     real(kind=c_real) , intent(in), dimension(shcol, nlevi) :: zi_grid, presi
     real(kind=c_real) , intent(in), dimension(shcol, num_qtracers) :: wtracer_sfc
     real(kind=c_real) , intent(inout), dimension(shcol, nlev) :: host_dse, tke, thetal, qw, u_wind, v_wind, wthv_sec, tkh, tk, shoc_ql, shoc_cldfrac

--- a/components/scream/src/physics/shoc/shoc_main_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_main_impl.hpp
@@ -86,7 +86,7 @@ void Functions<S,D>::shoc_main_internal(
   const Scalar&                uw_sfc,
   const Scalar&                vw_sfc,
   const uview_1d<const Spack>& wtracer_sfc,
-  const uview_1d<const Spack>& exner,
+  const uview_1d<const Spack>& inv_exner,
   const Scalar&                phis,
   // Workspace/Local Variables
   const Workspace&             workspace,
@@ -241,7 +241,7 @@ void Functions<S,D>::shoc_main_internal(
   // Use SHOC outputs to update the host model
   // temperature
   update_host_dse(team,nlev,thetal,shoc_ql, // Input
-                  exner,zt_grid,phis,       // Input
+                  inv_exner,zt_grid,phis,   // Input
                   host_dse);                // Output
 
   team.team_barrier();
@@ -332,7 +332,7 @@ Int Functions<S,D>::shoc_main(
     const auto thv_s          = ekat::subview(shoc_input.thv, i);
     const auto w_field_s      = ekat::subview(shoc_input.w_field, i);
     const auto wtracer_sfc_s  = ekat::subview(shoc_input.wtracer_sfc, i);
-    const auto exner_s        = ekat::subview(shoc_input.exner, i);
+    const auto inv_exner_s    = ekat::subview(shoc_input.inv_exner, i);
     const auto host_dse_s     = ekat::subview(shoc_input_output.host_dse, i);
     const auto tke_s          = ekat::subview(shoc_input_output.tke, i);
     const auto thetal_s       = ekat::subview(shoc_input_output.thetal, i);
@@ -365,7 +365,7 @@ Int Functions<S,D>::shoc_main(
                        dx_s, dy_s, zt_grid_s, zi_grid_s,                      // Input
                        pres_s, presi_s, pdel_s, thv_s, w_field_s,             // Input
                        wthl_sfc_s, wqw_sfc_s, uw_sfc_s, vw_sfc_s,             // Input
-                       wtracer_sfc_s, exner_s, phis_s,                        // Input
+                       wtracer_sfc_s, inv_exner_s, phis_s,                    // Input
                        workspace,                                             // Workspace
                        host_dse_s, tke_s, thetal_s, qw_s, u_wind_s, v_wind_s, // Input/Output
                        wthv_sec_s, qtracers_s, tk_s, shoc_cldfrac_s,          // Input/Output

--- a/components/scream/src/physics/shoc/shoc_update_host_dse_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_update_host_dse_impl.hpp
@@ -14,7 +14,7 @@ void Functions<S,D>
   const Int& nlev,
   const uview_1d<const Spack>& thlm,
   const uview_1d<const Spack>& shoc_ql,
-  const uview_1d<const Spack>& exner,
+  const uview_1d<const Spack>& inv_exner,
   const uview_1d<const Spack>& zt_grid,
   const Scalar& phis,
   const uview_1d<Spack>& host_dse)
@@ -27,7 +27,7 @@ void Functions<S,D>
   const auto ggr = C::gravit;
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
-      Spack temp = (thlm(k)+(lcond/cp)*shoc_ql(k))/exner(k);
+      Spack temp = (thlm(k)+(lcond/cp)*shoc_ql(k))/inv_exner(k);
       host_dse(k) = cp*temp+ggr*zt_grid(k)+phis;
   });
 }

--- a/components/scream/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
@@ -38,8 +38,8 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
 
     // Liquid water potential temperature [K]
     static constexpr Real thlm[nlev] = {350, 325, 315, 310, 300};
-    // Exner function [-]
-    static constexpr Real exner[nlev] = {0.1, 0.3, 0.5, 0.7, 1.0};
+    // Inverse of the Exner function [-]
+    static constexpr Real inv_exner[nlev] = {0.1, 0.3, 0.5, 0.7, 1.0};
     // Cloud condensate [kg/kg]
     static constexpr Real shoc_ql[nlev] = {5e-6, 8e-5, 4e-4, 3e-4, 1e-6};
     // Mid-point heights [m]
@@ -63,7 +63,7 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
 
         SDS.thlm[offset] = thlm[n];
         SDS.zt_grid[offset] = zt_grid[n];
-        SDS.exner[offset] = exner[n];
+        SDS.inv_exner[offset] = inv_exner[n];
 
         // Force the first column of cloud liquid
         //   to be zero!
@@ -81,7 +81,7 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
 
         REQUIRE(SDS.thlm[offset] > 0);
         REQUIRE(SDS.shoc_ql[offset] >= 0);
-        REQUIRE(SDS.exner[offset] > 0);
+        REQUIRE(SDS.inv_exner[offset] > 0);
         REQUIRE(SDS.zt_grid[offset] >= 0);
 
         // make sure the two columns are different and
@@ -162,7 +162,7 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
     for (auto& d : SDS_cxx) {
       d.transpose<ekat::TransposeDirection::c2f>();
       // expects data in fortran layout
-      update_host_dse_f(d.shcol,d.nlev,d.thlm,d.shoc_ql,d.exner,d.zt_grid,
+      update_host_dse_f(d.shcol,d.nlev,d.thlm,d.shoc_ql,d.inv_exner,d.zt_grid,
                          d.phis,d.host_dse);
       d.transpose<ekat::TransposeDirection::f2c>();
     }

--- a/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
@@ -136,7 +136,7 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
       // Compute the inverse of the exner function
       const Real exner = std::pow(pres[n]/p0,Rair/Cpair);
       REQUIRE(exner > 0);
-      inv_exner[n] = 1.0/exner;
+      inv_exner[n] = 1/exner;
     }
 
     // Load up tracer input array with random data

--- a/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
@@ -94,6 +94,8 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
     static constexpr Real tke_lbound = 0; // [m2/s2]
     static constexpr Real tke_ubound = 5; // [m2/s2]
     static constexpr Real wind_bounds = 10; // [m/s]
+    static constexpr Real dse_upper = 5e5; // [J/kg]
+    static constexpr Real dse_lower = 1e5; // [J/kg]
 
     // Compute some inputs based on the above
 
@@ -229,6 +231,8 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
         const auto offset = n + s * nlev;
         // Check that zt increases upward
         REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
+        // Check that inverse of exner increases upward
+        REQUIRE(SDS.exner[offset + 1] - SDS.exner[offset] < 0);
       }
 
       // Check that zi increases upward
@@ -286,6 +290,15 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
         else if (SDS.shoc_cldfrac[offset] == 0){
           REQUIRE(SDS.shoc_ql[offset] == 0);
         }
+
+        // Verify that dse increases with height upward
+        if (n < nlev-1){
+          REQUIRE(SDS.host_dse[offset + 1] - SDS.host_dse[offset] < 0);
+        }
+
+        // Verify that DSE falls within some reasonable bounds
+        REQUIRE(SDS.host_dse[offset] > dse_lower);
+        REQUIRE(SDS.host_dse[offset] < dse_upper);
 
         // Verify that w2 is less than tke
         REQUIRE(std::abs(SDS.w_sec[offset] < SDS.tke[offset]));

--- a/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
@@ -232,7 +232,7 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
         // Check that zt increases upward
         REQUIRE(SDS.zt_grid[offset + 1] - SDS.zt_grid[offset] < 0);
         // Check that inverse of exner increases upward
-        REQUIRE(SDS.exner[offset + 1] - SDS.exner[offset] < 0);
+        REQUIRE(SDS.inv_exner[offset + 1] - SDS.inv_exner[offset] < 0);
       }
 
       // Check that zi increases upward

--- a/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_main_tests.cpp
@@ -116,7 +116,7 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
 
     // Compute variables related to temperature
     Real host_dse[shcol][nlev];
-    Real thetal[nlev], thv[nlev], exner[nlev];
+    Real thetal[nlev], thv[nlev], inv_exner[nlev];
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
         // Compute the dry static energy
@@ -133,8 +133,10 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
       thetal[n] = pot_temp - (LatVap/Cpair)*shoc_ql[n];
       // Virtual potential temperature
       thv[n] = pot_temp * (1 + 0.61*qv - shoc_ql[n]);
-      // Compute exner function
-      exner[n] = std::pow(pres[n]/p0,Rair/Cpair);
+      // Compute the inverse of the exner function
+      const Real exner = std::pow(pres[n]/p0,Rair/Cpair);
+      REQUIRE(exner > 0);
+      inv_exner[n] = 1.0/exner;
     }
 
     // Load up tracer input array with random data
@@ -188,7 +190,7 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
         SDS.pdel[offset] = pdel[n];
         SDS.thv[offset] = thv[n];
         SDS.w_field[offset] = w_field[n];
-        SDS.exner[offset] = exner[n];
+        SDS.inv_exner[offset] = inv_exner[n];
         SDS.shoc_ql[offset] = shoc_ql[n];
         SDS.shoc_cldfrac[offset] = shoc_cldfrac[n];
         SDS.qw[offset] = qw[n];
@@ -402,7 +404,7 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
       shoc_main_f(d.shcol, d.nlev, d.nlevi, d.dtime, d.nadv, npbl, d.host_dx, d.host_dy,
                   d.thv, d.zt_grid, d.zi_grid, d.pres, d.presi, d.pdel, d.wthl_sfc,
                   d.wqw_sfc, d.uw_sfc, d.vw_sfc, d.wtracer_sfc, d.num_qtracers,
-                  d.w_field, d.exner, d.phis, d.host_dse, d.tke, d.thetal, d.qw,
+                  d.w_field, d.inv_exner, d.phis, d.host_dse, d.tke, d.thetal, d.qw,
                   d.u_wind, d.v_wind, d.qtracers, d.wthv_sec, d.tkh, d.tk, d.shoc_ql,
                   d.shoc_cldfrac, d.pblh, d.shoc_mix, d.isotropy, d.w_sec, d.thl_sec,
                   d.qw_sec, d.qwthl_sec, d.wthl_sec, d.wqw_sec, d.wtke_sec, d.uw_sec,


### PR DESCRIPTION
It appears that C++ shoc is using the `inv_exner`, but calling it `exner`. Example: 
```
update_host_dse C++:
  temp = (thlm + (lcond/cp)*ql)/exner 
  host_dse = cp*temp + ggr*zt + phis

update_host_dse F90:
  temp = (thlm + (lcond/cp)*ql)/inv_exner 
  host_dse = cp*temp + ggr*zt + phis
```
This PR changes the name.

Also, in `atmosphere_macrophysics.hpp` `exner` was being computed and passed into `shoc_main()` where it is used as `inv_exner`. This PR corrects this.

Lastly, we expect `shoc_run_and_cmp` to fail since we needed to change it to input `inv_exner`(see comments). 