### PR TITLE
Allow output of subfields

### DIFF
--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -84,6 +84,7 @@ void AtmosphereInput::pull_input()
     // Get all the info for this field.
     auto l_dims = fl.dims();
     const auto padding = fap.get_padding();
+    const auto num_reals = fap.get_alloc_size() / sizeof(Real);
 
     if (auto p = fh.get_parent().lock()) {
       // The hard case: we cannot call 'get_view', and even the reshaped view
@@ -96,7 +97,7 @@ void AtmosphereInput::pull_input()
       using host_view_1d_type = typename field_type::HM<dev_view_1d_type>;
 
       // Use a 1d view of correct size for scorpio reading
-      host_view_1d_type temp_view("",fap.get_alloc_size());
+      host_view_1d_type temp_view("",num_reals);
       grid_read_data_array(m_filename,name,l_dims,m_dofs_sizes.at(name),
                            padding,temp_view.data());
 

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -85,7 +85,7 @@ class AtmosphereOutput
 {
 public:
   using dofs_list_type = AbstractGrid::dofs_list_type;
-  using view_type_host = typename KokkosTypes<HostDevice>::view_1d<Real>;
+  using view_1d_host = typename KokkosTypes<HostDevice>::view_1d<Real>;
   using input_type     = AtmosphereInput;
 
   virtual ~AtmosphereOutput () = default;
@@ -162,7 +162,8 @@ protected:
   std::map<std::string,Int>              m_dims;
   typename dofs_list_type::HostMirror    m_gids_host;
   // Local views of each field to be used for "averaging" output and writing to file.
-  std::map<std::string,view_type_host>   m_view_local;
+
+  std::map<std::string,view_1d_host>   m_host_views_1d;
 
   // Manage when files are open and closed, and what type of file I am writing.
   bool m_is_init = false;


### PR DESCRIPTION
This PR allows to output fields that are subfields of another field (which implies that they are strided). For instance, it allows to output a single tracer, rather than the whole tracer array Q.