### PR TITLE
WIP: P3 bugfix: as hydrometeors sediment, recalculate the top of the layer with condensate

### DIFF
--- a/components/eam/src/physics/cam/micro_p3.F90
+++ b/components/eam/src/physics/cam/micro_p3.F90
@@ -3745,20 +3745,20 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,   &
       dt_left   = dt  !time remaining for sedi over full model (mp) time step
       prt_accum = 0._rtype  !precip rate for individual category
 
-      !find bottom
-      do k = kbot,k_qxtop,kdir
-         if (qr(k).ge.qsmall) then
-            k_qxbot = k
-            exit
-         endif
-      enddo
-
       substep_sedi_r: do while (dt_left.gt.1.e-4_rtype)
 
          Co_max = 0._rtype
          V_qr = 0._rtype
          V_nr = 0._rtype
 
+         !find bottom inside dt loop because kbot moves down as rain sediments.
+         do k = kbot,k_qxtop,kdir
+            if (qr(k).ge.qsmall) then
+               k_qxbot = k
+               exit
+            endif
+         enddo
+         
          kloop_sedi_r1: do k = k_qxtop,k_qxbot,-kdir
 
             qr_notsmall_r1: if (qr_incld(k)>qsmall) then

--- a/components/scream/src/physics/p3/p3_rain_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_rain_sed_impl.hpp
@@ -89,8 +89,8 @@ void Functions<S,D>
     while (dt_left > C::dt_left_tol) {
       Scalar Co_max = 0.0;
 
-      //Recompute k_qxtop every substep since may move down and there may not be
-      //any condensate left in the column at all!
+      //Recompute k_qxtop every substep since it sediments downward, potentially
+      //resulting in a cloud-free column which would cause crashes if not handled
       k_qxtop = find_top(team, sqr, qsmall, kbot, ktop, kdir, log_qxpresent);
       if (!log_qxpresent) {
 	dt_left = 0; //if no water left, just skip to end of timestep

--- a/components/scream/src/physics/p3/p3_rain_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_rain_sed_impl.hpp
@@ -76,15 +76,17 @@ void Functions<S,D>
   bool log_qxpresent;
   const Int k_qxtop = find_top(team, sqr, qsmall, kbot, ktop, kdir, log_qxpresent);
 
+  //Skip all calculations if there's no rain to sediment
   if (log_qxpresent) {
     Scalar dt_left   = dt;  // time remaining for sedi over full model (mp) time step
-    Scalar prt_accum = 0.0; // precip rate for individual category
-
-    // find bottom
-    Int k_qxbot = find_bottom(team, sqr, qsmall, kbot, k_qxtop, kdir, log_qxpresent);
+    Scalar prt_accum = 0.0; // precip rate
 
     while (dt_left > C::dt_left_tol) {
       Scalar Co_max = 0.0;
+
+      // find bottom of rainy area. Occurs inside dt substep since rain advects down.
+      Int k_qxbot = find_bottom(team, sqr, qsmall, kbot, k_qxtop, kdir, log_qxpresent);
+      
       Int kmin, kmax;
       Int kmin_scalar = ( kdir == 1 ? k_qxbot : k_qxtop);
       Int kmax_scalar = ( kdir == 1 ? k_qxtop : k_qxbot);


### PR DESCRIPTION
P3 currently computes the top and bottom layers in each column which contain condensate mass before substepping sedimentation to ensure CFL stability. The generalized_sedimentation routine moves the bottom layer containing condensate down one level each time it is called, ensuring sedimentation is able to fall to the surface without getting caught. The top layer is never updated even though condensate can fall out of it. This would be fine except that the top layer actually containing condensate can fall all the way to the surface (i.e. you started with condensate but it all rained out during the CFL substepping). When this happens, the code crashes because it can't calculate a CFL number when nothing is sedimenting. Recalculating the precipitating layer top every substep also may result in less layers to process and hence a performance gain... but finding the top every substep probably offsets that improvement. 

This bugfix should be BFB since it just skips cells which didn't have anything in them anyways. 

