### PR TITLE
Remove the dependence of the scorpio input and output on the grids manager

### DIFF
--- a/components/scream/src/share/io/output_manager.hpp
+++ b/components/scream/src/share/io/output_manager.hpp
@@ -110,12 +110,12 @@ protected:
   ekat::Comm                                   atm_comm;
   ekat::Comm                                   pio_comm; 
   ekat::ParameterList                          m_params;
-  std::shared_ptr<const FieldManager<Real>> m_device_field_manager;
+  std::shared_ptr<const FieldManager<Real>>    m_device_field_manager;
   std::shared_ptr<const GridsManager>          m_grids_manager;
 
   bool                                 param_set = false;
   bool                                 gm_set    = false;
-  bool                                 fm_set  = false;
+  bool                                 fm_set    = false;
   bool                        m_runtype_restart  = false;
 
 }; // class OutputManager
@@ -126,14 +126,18 @@ protected:
  * stream.  See scorpio_output.hpp for more information on what the parameter list needs.         */
 inline void OutputManager::new_output(const ekat::ParameterList& params)
 {
-  auto output_instance = std::make_shared<output_type>(pio_comm,params,m_device_field_manager,m_grids_manager,m_runtype_restart);
+  auto grid_name = params.get<std::string>("GRID");
+  auto grid = m_grids_manager->get_grid(grid_name);
+  auto output_instance = std::make_shared<output_type>(pio_comm,params,m_device_field_manager,grid,m_runtype_restart);
   output_instance->init();
   m_output_streams.push_back(output_instance);
 }
 /* --------------------------------------------------------------------- */
 inline void OutputManager::new_output(const ekat::ParameterList& params, const bool runtype_restart)
 {
-  auto output_instance = std::make_shared<output_type>(pio_comm,params,m_device_field_manager,m_grids_manager,runtype_restart);
+  auto grid_name = params.get<std::string>("GRID");
+  auto grid = m_grids_manager->get_grid(grid_name);
+  auto output_instance = std::make_shared<output_type>(pio_comm,params,m_device_field_manager,grid,runtype_restart);
   output_instance->init();
   m_output_streams.push_back(output_instance);
 }
@@ -152,7 +156,7 @@ inline void OutputManager::init()
   // Make sure params, fm and grids manager are already set
   EKAT_REQUIRE_MSG(param_set,"Error! Output manager requires a parameter list to be set before initialization");
   EKAT_REQUIRE_MSG(gm_set,   "Error! Output manager requires a grids manager to be set before initialization");
-  EKAT_REQUIRE_MSG(fm_set, "Error! Output manager requires a field fm to be set before initialization");
+  EKAT_REQUIRE_MSG(fm_set,   "Error! Output manager requires a field fm to be set before initialization");
   // First parse the param list for output.
   // Starting with the stride.  NOTE: Only a stride of 1 is supported right now.  TODO: Allow for stride of any value.
   Int stride = m_params.get<Int>("PIO Stride",1);

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -18,7 +18,7 @@ void AtmosphereInput::
 pull_input(const std::string& filename, const std::string& var_name,
            const std::vector<std::string>& var_dims,
            const bool has_columns, const std::vector<int>& dim_lens,
-           const int padding, Real* data)
+           const int padding, const grid_ptr_type& grid, Real* data)
 {
   using namespace scream::scorpio;
   
@@ -125,11 +125,20 @@ void AtmosphereInput::init()
   }
 
   // Check setup against information from grid manager:
-  auto grid = m_grid_mgr->get_grid(m_grid_name);
-  EKAT_REQUIRE_MSG(grid->get_2d_scalar_layout().tags().front()==COL,
-      "Error with input grid! scorpio_input.hpp class only supports input on a Physics grid for now.\n");
+  if (!m_grid_set) {
+    m_grid = m_grid_mgr->get_grid(m_grid_name);
+    m_grid_set = true;
+  }
+  if (!m_grid_set) {
+  EKAT_REQUIRE_MSG(m_grid->get_2d_scalar_layout().tags().front()==COL,
+      "Error with input grid! scorpio_input.hpp class only supports input on a Physics based grid for now.\n");
+    m_grid = m_grid_mgr->get_grid(m_grid_name);
+    m_grid_set = true;
+  }
+  EKAT_REQUIRE_MSG(m_grid->get_2d_scalar_layout().tags().front()==COL,
+      "Error with input grid! scorpio_input.hpp class only supports input on a Physics based grid for now.\n");
 
-  auto gids_dev = grid->get_dofs_gids();
+  auto gids_dev = m_grid->get_dofs_gids();
   m_gids_host = Kokkos::create_mirror_view( gids_dev );
   Kokkos::deep_copy(m_gids_host,gids_dev); 
 

--- a/components/scream/src/share/io/scorpio_input.hpp
+++ b/components/scream/src/share/io/scorpio_input.hpp
@@ -81,11 +81,25 @@ class AtmosphereInput
 {
 public:
   using dofs_list_type = AbstractGrid::dofs_list_type;
+  using grid_type      = AbstractGrid;
+  using grid_ptr_type  = std::shared_ptr<const grid_type>;
   template<int N>
   using view_ND_host = typename KokkosTypes<DefaultDevice>::template view_ND<Real,N>::HostMirror;
   using view_1d_host = view_ND_host<1>;
 
   // --- Constructor(s) & Destructor --- //
+  AtmosphereInput (const ekat::Comm& comm, const ekat::ParameterList& params,
+                   const std::shared_ptr<const FieldManager<Real>>& field_mgr,
+                   const grid_ptr_type& grid)
+    : m_params    (params)
+    , m_comm      (comm)
+    , m_field_mgr (field_mgr)
+    , m_grid      (grid)
+    , m_grid_set  (true)
+  {
+    // Nothing to do here
+  }
+
   AtmosphereInput (const ekat::Comm& comm, const ekat::ParameterList& params,
                    const std::shared_ptr<const FieldManager<Real>>& field_mgr,
                    const std::shared_ptr<const GridsManager>& grid_mgr)
@@ -106,6 +120,16 @@ public:
     // Nothing to do here
   }
 
+  AtmosphereInput (const ekat::Comm& comm, const std:: string grid_name,
+                   const grid_ptr_type& grid)
+    : m_comm      (comm)
+    , m_grid      (grid)
+    , m_grid_name (grid_name)
+    , m_grid_set  (true)
+  {
+    // Nothing to do here
+  }
+
   virtual ~AtmosphereInput () = default;
 
   // --- Methods --- //
@@ -122,7 +146,7 @@ public:
   void pull_input (const std::string& filename, const std::string& var_name,
                    const std::vector<std::string>& var_dims,
                    const bool has_columns, const std::vector<int>& dim_lens,
-                   const int padding, Real* data);
+                   const int padding, const grid_ptr_type& grid, Real* data);
 
   // Determine padding from the type of the variable.
   template<typename ValueType>
@@ -136,7 +160,12 @@ public:
     const int padding = ekat::PackInfo<pack_size>::padding(dim_lens.back());
     // Make sure to pass the data as a Real pointer.
     auto data_real = reinterpret_cast<Real*>(data);
-    pull_input(filename, var_name, var_dims, has_columns, dim_lens, padding, data_real);
+    if (m_grid_set) {
+      pull_input(filename, var_name, var_dims, has_columns, dim_lens, padding, m_grid, data_real);
+    } else {
+      auto grid = m_grid_mgr->get_grid(m_grid_name);
+      pull_input(filename, var_name, var_dims, has_columns, dim_lens, padding, grid, data_real);
+    }
   }
 
   void init();
@@ -158,6 +187,8 @@ protected:
 
   std::shared_ptr<const FieldManager<Real>>   m_field_mgr;
   std::shared_ptr<const GridsManager>         m_grid_mgr;
+  grid_ptr_type                               m_grid;
+  bool                                        m_grid_set = false;
   
   std::string m_filename;
   std::string m_avg_type;

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -85,12 +85,39 @@ class AtmosphereOutput
 {
 public:
   using dofs_list_type = AbstractGrid::dofs_list_type;
+  using grid_type      = AbstractGrid;
+  using grid_ptr_type  = std::shared_ptr<const grid_type>;
   using view_1d_host = typename KokkosTypes<HostDevice>::view_1d<Real>;
   using input_type     = AtmosphereInput;
 
   virtual ~AtmosphereOutput () = default;
 
   // Constructor
+  AtmosphereOutput(const ekat::Comm& comm, const ekat::ParameterList& params, 
+                   const std::shared_ptr<const FieldManager<Real>>& field_mgr,
+                   const grid_ptr_type& grid)
+  {
+    m_comm      = comm;
+    m_params    = params;
+    m_field_mgr = field_mgr;
+    m_grid      = grid;
+    m_grid_set  = true;
+    m_read_restart_hist = false;
+  }
+  // Constructor
+  AtmosphereOutput(const ekat::Comm& comm, const ekat::ParameterList& params, 
+                   const std::shared_ptr<const FieldManager<Real>>& field_mgr,
+                   const grid_ptr_type& grid,
+                   const bool read_restart_hist)
+  {
+    m_comm      = comm;
+    m_params    = params;
+    m_field_mgr = field_mgr;
+    m_grid      = grid;
+    m_grid_set  = true;
+    m_read_restart_hist = read_restart_hist;
+  }
+
   AtmosphereOutput(const ekat::Comm& comm, const ekat::ParameterList& params, 
                    const std::shared_ptr<const FieldManager<Real>>& field_mgr,
                    const std::shared_ptr<const GridsManager>& grid_mgr)
@@ -140,6 +167,8 @@ protected:
   ekat::Comm                                  m_comm;
   std::shared_ptr<const FieldManager<Real>>   m_field_mgr;
   std::shared_ptr<const GridsManager>         m_grid_mgr;
+  grid_ptr_type                               m_grid;
+  bool                                        m_grid_set = false;
   
   // Main output control data
   std::string m_casename;

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -119,7 +119,7 @@ TEST_CASE("input_output_basic","io")
   auto max_params = get_in_params("Max",io_comm);
   Real tol = pow(10,-6);
   // Check instant output
-  input_type ins_input(io_comm,ins_params,field_manager,grid_man);
+  input_type ins_input(io_comm,ins_params,field_manager,grid);
   ins_input.pull_input();
   auto f1 = field_manager->get_field("field_1");
   auto f2 = field_manager->get_field("field_2");

--- a/components/scream/src/share/io/tests/restart.cpp
+++ b/components/scream/src/share/io/tests/restart.cpp
@@ -146,8 +146,6 @@ TEST_CASE("restart","io")
     for (Int jj=0;jj<num_levs;++jj) {
       REQUIRE(std::abs(field2_hst(jj)   -((jj+1)/10.+15))<tol);
       REQUIRE(std::abs(field3_hst(ii,jj)-((jj+1)/10.+ii))<tol);  //Note, field 3 is not restarted, so doesn't have the +15
-      std::cout << "f  : " << field4_hst(ii,0,jj) << "\n";
-      std::cout << "tgt: " << ((jj+1)/10.+ii+15) << "\n";
       REQUIRE(std::abs(field4_hst(ii,0,jj)-((jj+1)/10.+ii+15))<tol);
       REQUIRE(std::abs(field4_hst(ii,1,jj)-(-((jj+1)/10.+ii)+15))<tol);
     }


### PR DESCRIPTION
In the I/O interface the grids_manager was only really needed to
determine the global degree's of freedom each rank is responsible
for.  Which is in turn used with PIO to read/write input/output.

In reality, it should be possible to pass an arbitrary grid with this
information, which would in principle allow I/O to handle files that
are not on the simulation grid.

In particular, this is a necessary precursor to full implementation
of SPA in SCREAM.