### PR TITLE
mct-coupling changes

### DIFF
--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -68,7 +68,7 @@ public:
   void create_fields ();
 
   // Sets a pre-built SurfaceCoupling object in the driver (for CIME runs only)
-  void set_surface_coupling (const std::shared_ptr<SurfaceCoupling>& sc);
+  void set_surface_coupling (const std::shared_ptr<SurfaceCoupling>& sc) { m_surface_coupling = sc; }
 
   // Load initial conditions for atm inputs
   void initialize_fields (const util::TimeStamp& t0);

--- a/components/scream/src/control/surface_coupling.cpp
+++ b/components/scream/src/control/surface_coupling.cpp
@@ -70,7 +70,7 @@ register_import(const std::string& fname,
                       "       Did you forget to call set_num_fields(..) ?\n");
   EKAT_REQUIRE_MSG (m_state!=RepoState::Closed, "Error! Registration phase has already ended.\n");
 
-  if (fname == "unused" || fname == "RRTMGP")
+  if (fname == "unused")
   {
     // Do nothing
   } else {

--- a/components/scream/src/mct_coupling/CMakeLists.txt
+++ b/components/scream/src/mct_coupling/CMakeLists.txt
@@ -37,6 +37,8 @@ set (SCREAM_LIBS
      ${dynLibName}
      p3
      shoc
+     scream_rrtmgp
+     cld_fraction
 )
 
 include (tpls/Mct)

--- a/components/scream/src/mct_coupling/atm_comp_mct.F90
+++ b/components/scream/src/mct_coupling/atm_comp_mct.F90
@@ -53,8 +53,8 @@ CONTAINS
     use iso_c_binding,      only: c_ptr, c_loc, c_int, c_char
     use scream_f2c_mod,     only: scream_create_atm_instance, scream_setup_surface_coupling, &
                                   scream_init_atm
-    use scream_cpl_indices, only: scream_set_cpl_indices, num_exports, num_imports, &
-                                  scr_names_x2a, scr_names_a2x, index_x2a, index_a2x
+    use scream_cpl_indices, only: scream_set_cpl_indices, num_exports, num_cpl_imports, num_scream_imports, &
+                                  scr_names_x2a, scr_names_a2x, index_x2a, index_a2x, vec_comp_x2a, vec_comp_a2x
     use ekat_string_utils,  only: string_f2c
 
     use mct_mod,        only: mct_aVect_init, mct_gsMap_lsize
@@ -151,8 +151,10 @@ CONTAINS
 
     ! Init surface coupling stuff in the AD
     call scream_set_cpl_indices (x2a, a2x)
-    call scream_setup_surface_coupling (c_loc(scr_names_x2a), c_loc(index_x2a), c_loc(x2a%rAttr), num_imports, &
-                                        c_loc(scr_names_a2x), c_loc(index_a2x), c_loc(a2x%rAttr), num_exports)
+    call scream_setup_surface_coupling (c_loc(scr_names_x2a), c_loc(index_x2a), c_loc(x2a%rAttr), c_loc(vec_comp_x2a), &
+                                        num_cpl_imports, num_scream_imports, &
+                                        c_loc(scr_names_a2x), c_loc(index_a2x), c_loc(a2x%rAttr), c_loc(vec_comp_a2x), &
+                                        num_exports)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to my log file

--- a/components/scream/src/mct_coupling/scream_f2c_mod.F90
+++ b/components/scream/src/mct_coupling/scream_f2c_mod.F90
@@ -41,15 +41,17 @@ interface
   ! This subroutine initializes the C++ structures in the AD that are
   ! responsible to handle import/export operation from/into the component
   ! coupler surface fluxes/state structures
-  subroutine scream_setup_surface_coupling (x2a_names, x2a_indices, x2a_ptr, num_imports, num_scream_imports,&
-                                            a2x_names, a2x_indices, a2x_ptr, num_exports) bind(c)
+  subroutine scream_setup_surface_coupling (x2a_names, x2a_indices, x2a_ptr, vec_comp_x2a, &
+                                            num_cpl_imports, num_scream_imports, &
+                                            a2x_names, a2x_indices, a2x_ptr, vec_comp_a2x, &
+                                            num_exports) bind(c)
     use iso_c_binding, only: c_ptr, c_int
     !
     ! Input(s)
     !
-    type(c_ptr),         intent(in) :: x2a_indices, x2a_names, x2a_ptr 
-    type(c_ptr),         intent(in) :: a2x_indices, a2x_names, a2x_ptr
-    integer(kind=c_int), intent(in) :: num_imports, num_scream_imports, num_exports
+    type(c_ptr),         intent(in) :: x2a_indices, x2a_names, x2a_ptr, vec_comp_x2a
+    type(c_ptr),         intent(in) :: a2x_indices, a2x_names, a2x_ptr, vec_comp_a2x
+    integer(kind=c_int), intent(in) :: num_cpl_imports, num_scream_imports, num_exports
   end subroutine scream_setup_surface_coupling
 
   ! This subroutine performs completes the initialization of the atm instance.


### PR DESCRIPTION
This updates the remaining mct-coupling code require to get CIME to build and begin to run. Answers remaining comments from #1128.

@bartgol I think it would be nice to have these mct-coupling changes in master. This is stripped of any CIME related config code. The difference in this PR and https://github.com/E3SM-Project/scream/pull/1152 is that now the code runs up until the DIRK failure (which I do not suspect is because of SurfaceCoupling).

Main additions:
1. YAKL must be initialized as in the rrtmgp tests
2. I created a `vec_comp_a2x/x2a` in `scream_cpl_indices.F90` so that I can pass exact field name "horiz_winds" through the coupler.
3. The new RRTMGP fields are now considered in mct-coupling.