### PR TITLE
Move YAKL init and finalize

### DIFF
--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -81,9 +81,6 @@ void scream_create_atm_instance (const MPI_Fint& f_comm,
     // First of all, initialize the scream session
     scream::initialize_scream_session();
 
-    // Initialize yakl
-    if(!yakl::isInitialized()) { yakl::init(); }
-
     // Create the context
     auto& c = ScreamContext::singleton();
 

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -172,6 +172,10 @@ void RRTMGPRadiation::init_buffers(const ATMBufferManager &buffer_manager)
 
 void RRTMGPRadiation::initialize_impl(const util::TimeStamp& /* t0 */) {
   using PC = scream::physics::Constants<Real>;
+
+  // Initialize yakl
+  if(!yakl::isInitialized()) { yakl::init(); }
+
   // Names of active gases
   auto gas_names_yakl_offset = string1d("gas_names",m_ngas);
   m_gas_mol_weights          = view_1d_real("gas_mol_weights",m_ngas);
@@ -371,6 +375,9 @@ void RRTMGPRadiation::run_impl (const Real dt) {
 void RRTMGPRadiation::finalize_impl  () {
   gas_concs.reset();
   rrtmgp::rrtmgp_finalize();
+
+  // Finalize YAKL
+  yakl::finalize();
 }
 
 void RRTMGPRadiation::set_required_field_impl(const Field<const Real>& f) {

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -62,9 +62,7 @@ namespace scream {
             }
 
             // Initialize YAKL
-            if (!yakl::isInitialized()) {
-                yakl::init();
-            }
+            if (!yakl::isInitialized()) {  yakl::init(); }
 
             // Load and initialize absorption coefficient data
             load_and_init(k_dist_sw, coefficients_file_sw, gas_concs);

--- a/components/scream/tests/coupled/homme_physics/homme_shoc_cld_p3_rrtmgp.cpp
+++ b/components/scream/tests/coupled/homme_physics/homme_shoc_cld_p3_rrtmgp.cpp
@@ -46,9 +46,6 @@ TEST_CASE("scream_homme_stand_alone", "scream_homme_stand_alone") {
 
   ekat::enable_fpes(get_default_fpes());
 
-  // Initialize yakl
-  if(!yakl::isInitialized()) { yakl::init(); }
-
   // Load ad parameter list
   std::string fname = "input.yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
@@ -98,9 +95,11 @@ TEST_CASE("scream_homme_stand_alone", "scream_homme_stand_alone") {
   for (int i=0; i<num_dyn_iters; ++i) {
     ad.run(dt);
   }
+
+  // Finalize the drive. YAKL will be finalized inside
+  // RRTMGPRadiation::finalize_impl after RRTMGP has had the
+  // opportunity to deallocate all it's arrays.
   ad.finalize();
-  // Finalize YAKL
-  yakl::finalize();
 
 
   // If we got here, we were able to run homme

--- a/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp.cpp
+++ b/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp.cpp
@@ -18,9 +18,6 @@ TEST_CASE("shoc-stand-alone", "") {
 
   constexpr int num_iters = 5;
 
-  // Initialize yakl
-  if(!yakl::isInitialized()) { yakl::init(); }
-
   // Load ad parameter list
   std::string fname = "input.yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
@@ -51,8 +48,6 @@ TEST_CASE("shoc-stand-alone", "") {
 
   // Finalize 
   ad.finalize();
-  // Finalize YAKL
-  yakl::finalize();
 
   // If we got here, we were able to run shoc
   REQUIRE(true);

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_stand_alone.cpp
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_stand_alone.cpp
@@ -100,7 +100,6 @@ namespace scream {
         int nlay = grid->get_num_vertical_levels();
 
         // Get number of shortwave bands and number of gases from RRTMGP
-        int nswbands = scream::rrtmgp::k_dist_sw.get_nband();
         int ngas     =   8;  // TODO: get this intelligently
 
         // Make sure we have the right dimension sizes
@@ -320,12 +319,10 @@ namespace scream {
         lw_flux_up_ref.deallocate();
         lw_flux_dn_ref.deallocate();
 
-        // Finalize the driver; needs to come before yakl::finalize because
-        // rrtmgp::finalize() frees YAKL arrays
+        // Finalize the driver. YAKL will be finalized inside
+        // RRTMGPRadiation::finalize_impl after RRTMGP has had the
+        // opportunity to deallocate all it's arrays.
         ad.finalize();
-
-        // Finalize YAKL
-        yakl::finalize();
 
         // If we got this far, we were able to run the code through the AD
         REQUIRE(true);


### PR DESCRIPTION
Move `yakl::init` and `yakl::finalize` into the rrtmgp interface (calling `init()` only if it has not been initialized previously).