### PR TITLE
Move conversion of nc_prescribed out of p3_main code and into the interface

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -373,7 +373,7 @@
 
 <!-- SPA input files and defaults -->
 <spa_datapath>atm/cam/chem/spa </spa_datapath>
-<spa_file>spa_file_unified_and_clipped_c20210525.nc</spa_file>
+<spa_file>spa_mixing_ratio_data.nc</spa_file>
 
 
 <!-- CAM-Chem aerosols (2000 climatology) -->

--- a/components/eam/src/physics/cam/micro_p3.F90
+++ b/components/eam/src/physics/cam/micro_p3.F90
@@ -411,10 +411,11 @@ contains
 
           if (do_prescribed_CCN) then
              !nccn_prescribed is an in-cloud value so make it grid average in this assignment
-             nc(k) = max(nc(k),nccn_prescribed(k)*1.0e6*inv_rho(k))
+             nc(k) = max(nc(k),nccn_prescribed(k))
           else if (do_predict_nc) then
              nc(k) = max(nc(k) + nc_nuceat_tend(k) * dt,0.0_rtype)
           else
+             ! nccnst is in units of #/m3 so needs to be converted.
              nc(k) = nccnst*inv_rho(k)
           endif
        endif

--- a/components/eam/src/physics/cam/micro_p3_interface.F90
+++ b/components/eam/src/physics/cam/micro_p3_interface.F90
@@ -744,7 +744,8 @@ end subroutine micro_p3_readnl
                               rho_h2os, &
                               qsmall, &
                               mincld, & 
-                              inv_cp 
+                              inv_cp, &
+                              grav=g 
 
     !INPUT/OUTPUT VARIABLES
     type(physics_state),         intent(in)    :: state
@@ -1046,6 +1047,15 @@ end subroutine micro_p3_readnl
        ! ccn is uniformly distributed throughout the cell, but P3 computes in-cloud values assuming cell-averages are comprised 
        ! of zero values outside cloud. Preemptively multiplying by cldfrac here is needed to get the correct in-cloud ccn value in P3
        nccn_prescribed = ccn_trcdat*cld_frac_l
+       ! SPA produced ccn is in units of #/cm3 rather than #/kg, so we need to
+       ! convert
+       if (is_spa_active) then
+          do icol = 1,ncol
+             do k = 1,pver
+                nccn_prescribed(icol,k) = nccn_prescribed(icol,k)*1.0e6_rtype * (dz(icol,k)*grav)/state%pmid(icol,k)
+             end do
+          end do
+       end if 
     end if
 
     ! CALL P3

--- a/components/eam/src/physics/cam/micro_p3_interface.F90
+++ b/components/eam/src/physics/cam/micro_p3_interface.F90
@@ -744,8 +744,7 @@ end subroutine micro_p3_readnl
                               rho_h2os, &
                               qsmall, &
                               mincld, & 
-                              inv_cp, &
-                              grav=g 
+                              inv_cp
 
     !INPUT/OUTPUT VARIABLES
     type(physics_state),         intent(in)    :: state
@@ -1047,15 +1046,6 @@ end subroutine micro_p3_readnl
        ! ccn is uniformly distributed throughout the cell, but P3 computes in-cloud values assuming cell-averages are comprised 
        ! of zero values outside cloud. Preemptively multiplying by cldfrac here is needed to get the correct in-cloud ccn value in P3
        nccn_prescribed = ccn_trcdat*cld_frac_l
-       ! SPA produced ccn is in units of #/cm3 rather than #/kg, so we need to
-       ! convert
-       if (is_spa_active) then
-          do icol = 1,ncol
-             do k = 1,pver
-                nccn_prescribed(icol,k) = nccn_prescribed(icol,k)*1.0e6_rtype * (dz(icol,k)*grav)/state%pmid(icol,k)
-             end do
-          end do
-       end if 
     end if
 
     ! CALL P3

--- a/components/scream/src/physics/p3/p3_ic_cases.cpp
+++ b/components/scream/src/physics/p3/p3_ic_cases.cpp
@@ -21,6 +21,9 @@ FortranData::Ptr make_mixed (const Int ncol, const Int nlev) {
     // subsequently modified here. For columns i > 0, introduce some small
     // variations.
 
+    // nccn_presribed for the cases where do_prescribed_CCN=true
+    for (k=0; k < nk; ++k) d.nccn_prescribed(i,k) = (100.0 + i/ncol - k/nk) * 1e6;
+
     // max cld at ~700mb, decreasing to 0 at 900mb.
     for (k = 0; k < 15; ++k) d.qc(i,nk-20+k) = 1e-4*(1 - double(k)/14);
     for (k = 0; k < nk; ++k) d.nc(i,k) = 1e6;

--- a/components/scream/src/physics/p3/p3_main_impl.hpp
+++ b/components/scream/src/physics/p3/p3_main_impl.hpp
@@ -185,10 +185,11 @@ void Functions<S,D>
       // prescribe that value
 
       if (do_prescribed_CCN) {
-         nc(k).set(not_drymass, max(nc(k), nccn_prescribed(k)*1.0e6*inv_rho(k)));
+         nc(k).set(not_drymass, max(nc(k), nccn_prescribed(k)));
       } else if (predictNc) {
          nc(k).set(not_drymass, max(nc(k) + nc_nuceat_tend(k) * dt, 0.0));
       } else {
+         // nccnst is in units of #/m3 so needs to be converted.
          nc(k).set(not_drymass, nccnst*inv_rho(k));
       }
 


### PR DESCRIPTION
Previously, the nc_prescribed values passed to p3_main, gathered from SPA,
had units of #/cm3.  These needed to be converted to the units of nc, #/kg.

This was done inside of the p3_main routine, which could cause confusion in
the future if we adopt a different aerosol scheme to SPA.  Instead, the
unit conversion is now done in the p3 interface and explicitly done when
SPA is active.

This commit also introduces non-zero values for nccn_prescribed in the
p3_run_and_cmp tests.  In testing the changes in this test it was discovered
there wasn't any nccn_prescribed coverage for the p3_run_and_cmp tests.

[BFB]