### PR TITLE
Allow scorpio I/O on dynamics grid

### DIFF
--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -237,7 +237,7 @@ void AtmosphereDriver::initialize_output_managers (const bool restarted_run) {
   auto& io_params = m_atm_params.sublist("SCORPIO");
   for (auto it : m_grids_manager->get_repo()) {
     auto fm = m_field_mgrs.at(it.first);
-    m_output_managers[it.first].setup(m_atm_comm,io_params,fm,restarted_run);
+    m_output_managers[it.first].setup(m_atm_comm,io_params,fm,m_grids_manager,restarted_run);
   }
 
   m_ad_status |= s_output_inited;

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
@@ -15,6 +15,7 @@ namespace scream
 DynamicsDrivenGridsManager::
 DynamicsDrivenGridsManager (const ekat::Comm& comm,
                             const ekat::ParameterList& p)
+ : m_comm (comm)
 {
   if (!is_parallel_inited_f90()) {
     // While we're here, we can init homme's parallel session
@@ -92,33 +93,24 @@ build_grids (const std::set<std::string>& grid_names,
              const std::string& reference_grid) {
   m_ref_grid_name = reference_grid;
 
-  // Retrieve all grid codes
-  std::set<int> codes;
+  // Retrieve all physics grids codes
+  std::vector<int> pg_codes;
   for (const auto& gn : grid_names) {
     // Sanity check first
     EKAT_REQUIRE_MSG (supported_grids().count(gn)==1,
                       "Error! Grid '" + gn + "' is not supported by this grid manager.\n");
 
-    codes.insert(m_grid_codes.at(gn));
+    auto code = m_grid_codes.at(gn);
+    if (code>=0) {
+      pg_codes.push_back(code);
+    }
   }
   // Also check the ref grid (and retrieve its code)
   EKAT_REQUIRE_MSG (supported_grids().count(reference_grid)==1,
                     "Error! Grid '" +reference_grid + "' is not supported by this grid manager.\n");
-  codes.insert(m_grid_codes.at(reference_grid));
-
-  // Deduce the phys grid type we need
-  int pgN = -1;
-  for (auto code : codes) {
-    if (code>=0) {
-      int N = code % 10;
-      EKAT_REQUIRE_MSG (pgN==-1 || N==pgN,
-                        "Error! Mixing different types of physics grid is not allowed.\n"
-                        "       You can, however, have phys grids with different *balancing* options.\n");
-      pgN = N;
-    }
-  }
-
-  init_grids_f90 (pgN);
+  pg_codes.push_back(m_grid_codes.at(reference_grid));
+  const int* codes_ptr = pg_codes.data();
+  init_grids_f90 (codes_ptr,pg_codes.size());
 
   // We know we need the dyn grid, so build it
   build_dynamics_grid ();
@@ -129,7 +121,7 @@ build_grids (const std::set<std::string>& grid_names,
     }
   }
 
-  if (reference_grid!="Dynamics") {
+  if (m_grids.find(reference_grid)==m_grids.end()) {
     build_physics_grid(reference_grid);
   }
 
@@ -139,14 +131,17 @@ build_grids (const std::set<std::string>& grid_names,
 
 void DynamicsDrivenGridsManager::build_dynamics_grid () {
   if (m_grids.find("Dynamics")==m_grids.end()) {
+    // Build the Physics GLL grid, to be used as 'unique grid' in the dyn grid
+    build_physics_grid("Physics GLL");
+    auto phys_gll = m_grids.at("Physics GLL");
 
     // Get dimensions and create "empty" grid
     const int nlelem = get_num_local_elems_f90();
-    const int ngelem = get_num_global_elems_f90();
     const int nlev   = get_nlev_f90();
-    auto dyn_grid = std::make_shared<SEGrid>("Dynamics",ngelem,nlelem,NP,nlev);
+    auto dyn_grid = std::make_shared<SEGrid>("Dynamics",nlelem,HOMMEXX_NP,nlev,phys_gll,m_comm);
+    dyn_grid->setSelfPointer(dyn_grid);
 
-    const int ndofs = nlelem*NP*NP;
+    const int ndofs = nlelem*HOMMEXX_NP*HOMMEXX_NP;
 
     // Create the gids, elgpgp, coords, area views
     AbstractGrid::dofs_list_type      dofs("dyn dofs",ndofs);
@@ -179,7 +174,8 @@ void DynamicsDrivenGridsManager::build_dynamics_grid () {
 #endif
 
     // Set dofs and geo data in the grid
-    dyn_grid->set_dofs (dofs, elgpgp);
+    dyn_grid->set_dofs (dofs);
+    dyn_grid->set_lid_to_idx_map(elgpgp);
     dyn_grid->set_geometry_data ("lat", lat);
     dyn_grid->set_geometry_data ("lon", lon);
 
@@ -198,10 +194,10 @@ build_physics_grid (const std::string& name) {
 
     // Get dimensions and create "empty" grid
     const int nlev  = get_nlev_f90();
-    const int nlcols = get_num_local_columns_f90 ();
-    const int ngcols = get_num_global_columns_f90 ();
+    const int nlcols = get_num_local_columns_f90 (pg_type % 10);
 
-    auto phys_grid = std::make_shared<PointGrid>(name,ngcols,nlcols,nlev);
+    auto phys_grid = std::make_shared<PointGrid>(name,nlcols,nlev,m_comm);
+    phys_grid->setSelfPointer(phys_grid);
 
     // Create the gids, coords, area views
     AbstractGrid::dofs_list_type dofs("phys dofs",nlcols);

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
@@ -101,6 +101,8 @@ build_grids (const std::set<std::string>& grid_names,
                       "Error! Grid '" + gn + "' is not supported by this grid manager.\n");
 
     auto code = m_grid_codes.at(gn);
+    // Dyn grid has a negative code, while phys grids codes are >=0.
+    // We only need to store the phys grids codes.
     if (code>=0) {
       pg_codes.push_back(code);
     }
@@ -257,7 +259,7 @@ build_grid_codes () {
   constexpr int gll_t = 10;  // Physics GLL Twin
   constexpr int pg2_t = 12;  // Physics PG2 Twin
   constexpr int pg3_t = 13;  // Physics PG3 Twin
-  constexpr int pg4_t = 13;  // Physics PG4 Twin
+  constexpr int pg4_t = 14;  // Physics PG4 Twin
 
   for (const auto& name : m_valid_grid_names) {
     int code;

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.hpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.hpp
@@ -46,6 +46,8 @@ protected:
 
   void build_grid_codes ();
 
+  ekat::Comm      m_comm;
+
   grid_repo_type  m_grids;
 
   std::string m_ref_grid_name;

--- a/components/scream/src/dynamics/homme/homme_dimensions.hpp
+++ b/components/scream/src/dynamics/homme/homme_dimensions.hpp
@@ -20,6 +20,8 @@ namespace scream {
 #define HOMMEXX_NUM_LEV_P           NUM_LEV_P
 #define HOMMEXX_NUM_INTERFACE_LEV   NUM_INTERFACE_LEV
 
+#define HOMMEXX_PACK_SIZE           VECTOR_SIZE
+
 #else
 
 constexpr int HOMMEXX_QSIZE_D            = QSIZE_D;
@@ -32,6 +34,8 @@ constexpr int HOMMEXX_Q_NUM_TIME_LEVELS  = Homme::Q_NUM_TIME_LEVELS;
 constexpr int HOMMEXX_NUM_LEV            = Homme::NUM_LEV;
 constexpr int HOMMEXX_NUM_LEV_P          = Homme::NUM_LEV_P;
 constexpr int HOMMEXX_NUM_INTERFACE_LEV  = Homme::NUM_INTERFACE_LEV;
+
+constexpr int HOMMEXX_PACK_SIZE          = Homme::VECTOR_SIZE;
 
 #endif
 

--- a/components/scream/src/dynamics/homme/interface/homme_params_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_params_mod.F90
@@ -522,7 +522,7 @@ contains
   end function get_homme_bool_param_f90
 
   subroutine set_homme_int_param_f90 (param_name_c, param_value) bind(c)
-    use dimensions_mod,    only: qsize, qsize_d, nlev, np
+    use dimensions_mod,    only: qsize, nlev
     use control_mod,       only: ftype, use_moisture
     use time_mod,          only: nmax
     !
@@ -539,6 +539,8 @@ contains
     call c_f_pointer(param_name_c,param_name)
     len = index(param_name, C_NULL_CHAR) -1
     select case(param_name(1:len))
+      case("ne")
+        ne = param_value
       case("ftype")
         ftype = param_value
       case("qsize")

--- a/components/scream/src/dynamics/homme/interface/phys_grid_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/phys_grid_mod.F90
@@ -7,77 +7,125 @@ module phys_grid_mod
   implicit none
   private
 
-  public :: phys_grid_init, cleanup_grid_init_data
+  public :: phys_grids_init, cleanup_grid_init_data
   public :: finalize_phys_grid
   public :: get_my_phys_data
   public :: get_num_local_columns, get_num_global_columns
 
   ! Available options for pg balancing
-  integer, public, parameter :: pg_default   = 0
-  integer, public, parameter :: pg_twin_cols = 1  ! Not yet supported in SCREAM!
+  integer, public, parameter :: load_bal_none      = 0
+  integer, public, parameter :: load_bal_twin_cols = 1  ! Not yet supported in SCREAM!
 
+  ! Max phys grid N. Convention: pgN=0 -> GLL grid, pgN=1,2,3,4 -> FV grid
+  integer, public, parameter :: pgN_min = 0
+  integer, public, parameter :: pgN_max = 4
+  integer, public, parameter :: num_pgN = pgN_max - pgN_min + 1
+
+  ! Global grid info
   ! Arrays of size nprocs
-  integer (kind=c_int), pointer :: g_dofs_per_rank(:)     ! Number of cols on each rank
   integer (kind=c_int), pointer :: g_elem_per_rank(:)     ! Number of elems on each rank
   integer (kind=c_int), pointer :: g_elem_offsets(:)      ! Offset of each rank in global nelem-sized arrays
-  integer (kind=c_int), pointer :: g_dofs_offsets(:)      ! Offset of each rank in global ngcols-sized arrays
-
-  ! Global arrays are spliced by rank, meaning that all entries on rank N come *before*
-  ! all entries on rank N+1. That's because the most common use is to grab the values
-  ! on the a given rank (usually, my rank), for which one can use the g_dofs_offsets
-  ! to establish the start/end points.
-
-  ! Arrays of size ngcols
-  real (kind=c_double), pointer :: g_lat(:)     ! Latitude coordinates
-  real (kind=c_double), pointer :: g_lon(:)     ! Longitude coordinates
-  real (kind=c_double), pointer :: g_area(:)    ! Column area
-  integer (kind=c_int), pointer :: g_dofs(:)    ! Column global index
-
   ! Arrays of size nelem
   integer (kind=c_int), pointer :: g_elem_gids(:)         ! List of elem gids, spliced by rank
-  integer (kind=c_int), pointer :: g_dofs_per_elem(:)     ! List of num dofs on each elem, spliced by rank
 
-  integer, public :: fv_nphys = 0
+  ! This struct holds the global info of a physics grid.
+  ! NOTE: there is one struct for each pg type,
+  type :: pg_specs_t
+    ! Arrays of size nprocs
+    integer (kind=c_int), pointer :: g_dofs_per_rank(:)     ! Number of cols on each rank
+    integer (kind=c_int), pointer :: g_dofs_offsets(:)      ! Offset of each rank in global ngcols-sized arrays
 
-  logical :: is_phys_grid_inited = .false.
+    ! Global arrays are spliced by rank, meaning that all entries on rank N come *before*
+    ! all entries on rank N+1. That's because the most common use is to grab the values
+    ! on the a given rank (usually, my rank), for which one can use the g_dofs_offsets
+    ! to establish the start/end points.
+
+    ! Arrays of size ngcols
+    real (kind=c_double), pointer :: g_lat(:)     ! Latitude coordinates
+    real (kind=c_double), pointer :: g_lon(:)     ! Longitude coordinates
+    real (kind=c_double), pointer :: g_area(:)    ! Column area
+    integer (kind=c_int), pointer :: g_dofs(:)    ! Column global index
+
+    ! Arrays of size nelem
+    integer (kind=c_int), pointer :: g_dofs_per_elem(:)     ! List of num dofs on each elem, spliced by rank
+
+    integer :: pgN
+    logical :: inited = .false.
+  end type pg_specs_t
+
+  type(pg_specs_t), target :: pg_specs (pgN_min:pgN_max)
 
 ! To get MPI_IN_PLACE and MPI_DATATYPE_NULL
 #include <mpif.h>
+  ! Note: in this module, we often use MPI_IN_PLACE,0,MPI_DATATYPE_NULL
+  !       for the src array specs in Allgatherv calls. These special values 
+  !       inform MPI that src array is aliasing the dst one, so MPI will
+  !       grab the src data from the dst array, using the offsets info
 
 contains
 
-  subroutine check_phys_grid_inited ()
-    if (.not. is_phys_grid_inited) then
-      call abortmp ("Error! Physics grid was not inited.\n")
+  subroutine check_phys_grid_inited (pgN)
+    !
+    ! Inputs(s)
+    !
+    integer, intent(in) :: pgN  ! The phys grid type to check
+    !
+    ! Local(s)
+    !
+    character(1) :: str
+
+    write(str, '(I1)') pgN
+    if (pgN .lt. pgN_min .or. pgN .gt. pgN_max) then
+      call abortmp ("Error! Physics grid '"//str//"' is not supported.\n")
+    endif
+
+    if (.not. pg_specs(pgN)%inited) then
+      call abortmp ("Error! Physics grid '"//str//"' was not inited.\n")
     endif
   end subroutine check_phys_grid_inited
 
-  subroutine phys_grid_init (pgN)
+  subroutine phys_grids_init (pg_types)
     use gllfvremap_mod,    only: gfr_init
     use homme_context_mod, only: elem, par
     use dimensions_mod,    only: nelem, nelemd
     !
     ! Input(s)
     !
-    integer (kind=c_int), intent(in) :: pgN
+    integer (kind=c_int), intent(in) :: pg_types(:)
     !
     ! Local(s)
     !
-    integer :: ldofs, ierr, proc, ngcols, ie, gid, offset
-    integer, allocatable :: dofs_per_elem (:)
+    integer :: ie, ierr, proc, i, load_bal, pgN, fvN
+    logical :: do_gll
+    character(2) :: str
 
-    ! Note: in the following, we often use MPI_IN_PLACE,0,MPI_DATATYPE_NULL
-    !       for the src array specs in Allgatherv calls. These special values 
-    !       inform MPI that src array is aliasing the dst one, so MPI will
-    !       grab the src data from the dst array, using the offsets info
+    fvN = -1
+    do_gll = .false.
+    do i=1, size(pg_types)
+      pgN = mod(pg_types(i),10)
+      load_bal = pg_types(i) / 10
 
-    if (pgN>0) then
-      fv_nphys = pgN
-      call gfr_init(par, elem, fv_nphys)
-    endif
+      if (load_bal .ne. load_bal_none) then
+        write(str,'(I2)') load_bal
+        call abortmp("Error! Load balancing option '"//str//"' not supported.")
+      endif
 
-    ! Set this right away, so calls to get_num_[local|global]_columns doesn't crap out
-    is_phys_grid_inited = .true.
+      if (pgN .lt. pgN_min .or. pgN .gt. pgN_max) then
+        write(str,'(I2)') pgN
+        call abortmp("Error! Physics grid type '"//str//"' not supported.")
+      endif
+
+      if (pgN .gt. 0) then
+        if (fvN .ne. -1 .and. fvN .ne. pgN) then
+          call abortmp("Error! Only ONE finite volume phys grid can be enabled.")
+        endif
+        fvN = pgN
+      else
+        do_gll = .true.
+      endif
+    enddo
+
+    ! Compute elem-related quantities, which are common to all phys grids
 
     ! Gather num elems on each rank
     allocate(g_elem_per_rank(par%nprocs))
@@ -99,9 +147,418 @@ contains
     call MPI_Allgatherv( MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
                          g_elem_gids, g_elem_per_rank, g_elem_offsets, MPIinteger_t, par%comm, ierr)
 
+    ! Now init grid-specific quantities for the requested pg types
+    if (do_gll) then
+      call phys_grid_init (0)
+    endif
+    if (fvN .gt. 0) then
+      call phys_grid_init (fvN)
+    endif
+  end subroutine phys_grids_init
+
+  !   integer :: ldofs, ierr, proc, ngcols, ie, gid, offset
+  !   integer, allocatable :: dofs_per_elem (:)
+
+  !   ! Note: in the following, we often use MPI_IN_PLACE,0,MPI_DATATYPE_NULL
+  !   !       for the src array specs in Allgatherv calls. These special values 
+  !   !       inform MPI that src array is aliasing the dst one, so MPI will
+  !   !       grab the src data from the dst array, using the offsets info
+
+  !   if (pgN>0) then
+  !     fv_nphys = pgN
+  !     call gfr_init(par, elem, fv_nphys)
+  !   endif
+
+  !   ! Set this right away, so calls to get_num_[local|global]_columns doesn't crap out
+  !   is_phys_grid_inited = .true.
+
+  !   ! Gather num elems on each rank
+  !   allocate(g_elem_per_rank(par%nprocs))
+  !   call MPI_Allgather(nelemd, 1, MPIinteger_t, g_elem_per_rank, 1, MPIinteger_t, par%comm, ierr)
+
+  !   ! Compute offset of each rank in the g_elem_per_rank array
+  !   ! This allows each rank to know where to fill arrays of size num_global_elements
+  !   allocate(g_elem_offsets(par%nprocs))
+  !   g_elem_offsets = 0
+  !   do proc=2,par%nprocs
+  !     g_elem_offsets(proc) = g_elem_offsets(proc-1) + g_elem_per_rank(proc-1)
+  !   enddo
+
+  !   ! Gather elem GIDs on each rank
+  !   allocate(g_elem_gids(nelem))
+  !   do ie=1,nelemd
+  !     g_elem_gids(g_elem_offsets(par%rank+1)+ie) = elem(ie)%globalID
+  !   enddo
+  !   call MPI_Allgatherv( MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
+  !                        g_elem_gids, g_elem_per_rank, g_elem_offsets, MPIinteger_t, par%comm, ierr)
+
+  !   ! Gather the number of unique cols on each rank
+  !   allocate(g_dofs_per_rank(par%nprocs))
+  !   call MPI_Allgather(get_num_local_columns(), 1, MPIinteger_t, g_dofs_per_rank, 1, MPIinteger_t, par%comm, ierr)
+
+  !   ! Gather the number of unique cols on each element
+  !   ! NOTE: we use a temp (dofs_per_elem) rather than g_dofs, since in g_dofs we order by
+  !   !       elem GID. But elem GIDs may not be distributed linearly across ranks
+  !   !       (e.g., proc0 may own [1-20,41-60],and proc1 may owns [21-40]), while in order
+  !   !       to use Allgatherv, we need the send buffer to be contiguous. So in dofs_per_elem
+  !   !       we order the data *by rank*. Once the gather is complete, we copy the data from
+  !   !       dofs_per_elem into g_dofs_per_elem, ordering by elem GID instead.
+  !   !
+  !   allocate(dofs_per_elem(nelem))
+  !   do ie=1,nelemd
+  !     dofs_per_elem(g_elem_offsets(par%rank+1)+ie) = elem(ie)%idxP%NumUniquePts
+  !   enddo
+  !   call MPI_Allgatherv( MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
+  !                        dofs_per_elem, g_elem_per_rank, g_elem_offsets, MPIinteger_t, par%comm, ierr)
+
+  !   allocate(g_dofs_per_elem(nelem))
+  !   do proc=1,par%nprocs
+  !     offset = g_elem_offsets(proc)
+  !     do ie=1,g_elem_per_rank(proc)
+  !       g_dofs_per_elem(g_elem_gids(offset+ie)) = dofs_per_elem(offset+ie)
+  !     enddo
+  !   enddo
+
+  !   ! Compute global dofs
+  !   call compute_global_dofs ()
+
+  !   ! Compute area and lat/lon coords
+  !   call compute_global_coords ()
+  !   call compute_global_area ()
+
+  ! end subroutine phys_grid_init
+
+  subroutine cleanup_grid_init_data ()
+    !
+    ! Local(s)
+    !
+    integer :: pgN
+
+    ! Cleanup data no longer needed in each pg_specs_t struct
+    do pgN = pgN_min,pgN_max
+      if (pg_specs(pgN)%inited) then
+        ! nprocs-sized arrays
+        deallocate(pg_specs(pgN)%g_dofs_per_rank)
+
+        ! nelem-sized arrays
+        deallocate(pg_specs(pgN)%g_dofs_per_elem)
+      endif
+    enddo
+
+    ! Cleanup global elem-related arrays
+    deallocate(g_elem_per_rank)
+    deallocate(g_elem_offsets)
+    deallocate(g_elem_gids)
+  end subroutine cleanup_grid_init_data
+
+  subroutine finalize_phys_grid ()
+    use gllfvremap_mod, only: gfr_finish
+    !
+    ! Local(s)
+    !
+    integer :: pgN
+
+    do pgN = pgN_min,pgN_max
+      if (pg_specs(pgN)%inited) then
+        deallocate(pg_specs(pgN)%g_area)
+        deallocate(pg_specs(pgN)%g_lat)
+        deallocate(pg_specs(pgN)%g_lon)
+        deallocate(pg_specs(pgN)%g_dofs)
+
+        deallocate(pg_specs(pgN)%g_dofs_offsets)
+
+        if (pgN>0) then
+          call gfr_finish()
+        endif
+
+        pg_specs(pgN)%inited = .false.
+      endif
+    enddo
+  end subroutine finalize_phys_grid
+
+  function get_num_local_columns (pgN) result (ncols)
+    use dimensions_mod,    only: nelemd
+    use homme_context_mod, only: elem
+    !
+    ! Input(s)
+    !
+    integer, intent(in) :: pgN
+    !
+    ! Local(s)
+    !
+    integer :: ncols, ie
+
+    ! Sanity check
+    call check_phys_grid_inited(pgN)
+
+    if (pgN>0) then
+      ncols = nelemd*pgN*pgN
+    else
+      ncols = 0
+      do ie=1,nelemd
+        ncols = ncols + elem(ie)%idxP%NumUniquePts
+      enddo
+    endif
+  end function get_num_local_columns
+
+  function get_num_global_columns (pgN) result (num_cols) bind(c)
+    use dimensions_mod,    only: nelem, np
+    !
+    ! Input(s)
+    !
+    integer (kind=c_int), intent(in) :: pgN
+    !
+    ! Local(s)
+    !
+    integer (kind=c_int) :: num_cols
+
+    ! Sanity check
+    call check_phys_grid_inited(pgN)
+
+    if (pgN>0) then
+      num_cols = nelem*pgN*pgN
+    else
+      num_cols = nelem*(np-1)*(np-1)+2
+    endif
+  end function get_num_global_columns
+
+  subroutine get_my_phys_data (gids, lat, lon, area, pg_type)
+    use homme_context_mod, only: iam
+    use shr_const_mod,     only: pi=>SHR_CONST_PI
+    !
+    ! Input(s)
+    !
+    integer(kind=c_int), pointer, intent(in) :: gids(:)
+    real(kind=c_double), pointer, intent(in) :: lat(:), lon(:), area(:)
+    integer(kind=c_int),          intent(in) :: pg_type
+    !
+    ! Local(s)
+    !
+    integer :: pgN, load_bal, idof, ndofs
+    type(pg_specs_t), pointer :: pgs
+
+    ! Possible values for pg_type:
+    !   0 : physics grid on GLL nodes
+    !   2 : physics grid on FV points in 2x2 subcell (PG2)
+    !   3 : physics grid on FV points in 3x3 subcell (PG3)
+    !   4 : physics grid on FV points in 4x4 subcell (PG4)
+    !  10 : GLL points, use twin columns
+    !  12 : PG2 points, use twin columns
+    !  13 : PG3 points, use twin columns
+    !  14 : PG4 points, use twin columns
+    ! In general:
+    !   *0 => GLL nodes, *N,N>0 => FV points
+    !   1* => redistribute using twin columns
+
+    pgN = mod(pg_type,10)
+
+    call check_phys_grid_inited (pgN)
+
+    pgs => pg_specs(pgN)
+
+    load_bal = pg_type / 10
+
+    if (load_bal .ne. load_bal_none) then
+      call abortmp ("Error! No load balancing option implemented in scream yet.")
+    else
+      ! TODO: when you enable twin columns, you'll have to manually
+      !       do the search, since you can't just grab the offset-ed entries
+      ndofs = get_num_local_columns (pgN)
+      do idof=1,ndofs
+        gids(idof) = pgs%g_dofs(pgs%g_dofs_offsets(iam+1) + idof)
+        lat(idof)  = pgs%g_lat (pgs%g_dofs_offsets(iam+1) + idof) * 180.0_c_double / pi
+        lon(idof)  = pgs%g_lon (pgs%g_dofs_offsets(iam+1) + idof) * 180.0_c_double / pi
+        area(idof) = pgs%g_area(pgs%g_dofs_offsets(iam+1) + idof)
+      enddo
+
+    endif
+  end subroutine get_my_phys_data
+
+  subroutine compute_global_dofs (pg)
+    use dimensions_mod,    only: nelem
+    use homme_context_mod, only: par
+    !
+    ! Input(s)
+    !
+    type(pg_specs_t), intent(inout) :: pg
+    !
+    ! Local(s)
+    !
+    integer :: ie, icol, idof, proc, elem_gid, elem_offset
+    integer, allocatable :: exclusive_scan_dofs_per_elem(:)
+
+    allocate(exclusive_scan_dofs_per_elem(nelem))
+    allocate(pg%g_dofs(get_num_global_columns(pg%pgN)))
+
+    exclusive_scan_dofs_per_elem(1) = 0
+    do ie=2,nelem
+      exclusive_scan_dofs_per_elem(ie) = exclusive_scan_dofs_per_elem(ie-1) + pg%g_dofs_per_elem(ie-1)
+    enddo
+
+    if (pg%pgN .gt. 0) then
+      ! TODO
+      call abortmp ("Error! Finite volume physics grid not yet implemented in scream.")
+    else
+      ! physics is on GLL grid
+      allocate (pg%g_dofs_offsets(par%nprocs))
+
+      pg%g_dofs_offsets(1)=0
+      do proc=2,par%nprocs
+        pg%g_dofs_offsets(proc) = pg%g_dofs_offsets(proc-1) + pg%g_dofs_per_rank(proc-1)
+      enddo
+
+      idof = 1
+      do proc=1,par%nprocs
+        elem_offset = g_elem_offsets(proc)
+        do ie=1,g_elem_per_rank(proc)
+          elem_gid = g_elem_gids(elem_offset+ie)
+          do icol=1,pg%g_dofs_per_elem(elem_gid)
+            pg%g_dofs(idof) = exclusive_scan_dofs_per_elem(elem_gid)+icol
+            idof = idof+1
+          enddo
+        enddo
+      enddo
+    endif
+  end subroutine compute_global_dofs
+
+  subroutine compute_global_area(pg)
+    use dof_mod,           only: UniquePoints
+    use dimensions_mod,    only: np, nelemd
+    use homme_context_mod, only: elem, par, iam, masterproc
+    !
+    ! Input(s)
+    !
+    type(pg_specs_t), intent(inout) :: pg
+    !
+    ! Local(s)
+    !
+    real(kind=c_double), pointer :: area_l(:)
+    real(kind=c_double), dimension(np,np)  :: areaw
+    integer :: ie, offset, start, ierr, ncols
+
+    if (masterproc) then
+      write(iulog,*) 'INFO: Non-scalable action: Computing global area in SE dycore.'
+    endif
+
+    if (pg%pgN .gt. 0) then
+      ! TODO
+      call abortmp ("Error! Finite volume physics grid not yet implemented in scream.")
+    else
+      ! physics is on GLL grid
+      allocate(pg%g_area(get_num_global_columns(pg%pgN)))
+
+      offset = pg%g_dofs_offsets(iam+1)
+
+      ncols = get_num_local_columns(pg%pgN)
+      area_l => pg%g_area(offset+1 : offset+ncols)
+      start = 1
+      do ie=1,nelemd
+        areaw = 1.0_c_double / elem(ie)%rspheremp(:,:)
+        ncols = elem(ie)%idxP%NumUniquePts
+        call UniquePoints(elem(ie)%idxP, areaw, area_l(start:start+ncols-1))
+        start = start + ncols
+      enddo
+
+      ncols = get_num_local_columns(pg%pgN)
+      ! Note: using MPI_IN_PLACE,0,MPI_DATATYPE_NULL for the src array
+      !       informs MPI that src array is aliasing the dst one, so
+      !       MPI will grab the src part from dst, using the offsets info
+      call MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
+                          pg%g_area, pg%g_dofs_per_rank, pg%g_dofs_offsets, MPIreal_t, &
+                          par%comm, ierr)
+    endif
+  end subroutine compute_global_area
+
+  subroutine compute_global_coords(pg)
+    use dimensions_mod,    only: nelemd
+    use dof_mod,           only: UniqueCoords
+    use homme_context_mod, only: elem, par, iam, masterproc
+    !
+    ! Input(s)
+    !
+    type(pg_specs_t), intent(inout) :: pg
+    !
+    ! Local(s)
+    !
+    real(kind=c_double), pointer :: lat_l(:), lon_l(:)
+    integer  :: ncols, ie, offset, start, ierr
+
+    if (masterproc) then
+      write(iulog,*) 'INFO: Non-scalable action: Computing global coords in SE dycore.'
+    end if
+
+    if (pg%pgN > 0) then
+      ! TODO
+      call abortmp("Error! Finite volume physics grid not yet implemented.")
+    else
+      allocate(pg%g_lat(get_num_global_columns(pg%pgN)))
+      allocate(pg%g_lon(get_num_global_columns(pg%pgN)))
+
+      ! physics is on GLL grid
+
+      offset = pg%g_dofs_offsets(iam+1)
+
+      ncols = get_num_local_columns(pg%pgN)
+      lat_l => pg%g_lat(offset+1 : offset+ncols)
+      lon_l => pg%g_lon(offset+1 : offset+ncols)
+      start = 1
+      do ie=1,nelemd
+        ncols = elem(ie)%idxP%NumUniquePts
+        call UniqueCoords(elem(ie)%idxP, elem(ie)%spherep, &
+                          lat_l(start:start+ncols-1),      &
+                          lon_l(start:start+ncols-1))
+        start = start + ncols
+      enddo
+
+      ncols = get_num_local_columns(pg%pgN)
+
+      ! Note: using MPI_IN_PLACE,0,MPI_DATATYPE_NULL for the src array
+      !       informs MPI that src array is aliasing the dst one, so
+      !       MPI will grab the src part from dst, using the offsets info
+      call MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
+                          pg%g_lat, pg%g_dofs_per_rank, pg%g_dofs_offsets, MPIreal_t, &
+                          par%comm, ierr)
+      call MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
+                          pg%g_lon, pg%g_dofs_per_rank, pg%g_dofs_offsets, MPIreal_t, &
+                          par%comm, ierr)
+    endif
+  end subroutine compute_global_coords
+
+  subroutine phys_grid_init (pgN)
+    use gllfvremap_mod,    only: gfr_init
+    use homme_context_mod, only: elem, par
+    use dimensions_mod,    only: nelem, nelemd
+    !
+    ! Input(s)
+    !
+    integer, intent(in), target :: pgN
+    !
+    ! Local(s)
+    !
+    integer, allocatable :: dofs_per_elem (:)
+    integer :: ierr, proc, ie, offset
+    character(2) :: str
+    type(pg_specs_t), pointer :: pg
+
+    pg => pg_specs(pgN)
+
+    if (pg%inited) then
+      write (str, '(I1)') pgN
+      call abortmp("Error! Physics grid with pgN="//str//" was already inited.")
+    endif
+
+    ! Set this to true immediately, so we can call get_num_xyz_columns
+    pg%inited = .true.
+    pg%pgN = pgN
+
+    if (pgN>0) then
+      call gfr_init(par, elem, pgN)
+    endif
+
     ! Gather the number of unique cols on each rank
-    allocate(g_dofs_per_rank(par%nprocs))
-    call MPI_Allgather(get_num_local_columns(), 1, MPIinteger_t, g_dofs_per_rank, 1, MPIinteger_t, par%comm, ierr)
+    allocate(pg%g_dofs_per_rank(par%nprocs))
+    call MPI_Allgather(get_num_local_columns(pg%pgN), 1, MPIinteger_t, &
+                       pg%g_dofs_per_rank, 1, MPIinteger_t, par%comm, ierr)
 
     ! Gather the number of unique cols on each element
     ! NOTE: we use a temp (dofs_per_elem) rather than g_dofs, since in g_dofs we order by
@@ -118,296 +575,19 @@ contains
     call MPI_Allgatherv( MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
                          dofs_per_elem, g_elem_per_rank, g_elem_offsets, MPIinteger_t, par%comm, ierr)
 
-    allocate(g_dofs_per_elem(nelem))
+    allocate(pg%g_dofs_per_elem(nelem))
     do proc=1,par%nprocs
       offset = g_elem_offsets(proc)
       do ie=1,g_elem_per_rank(proc)
-        g_dofs_per_elem(g_elem_gids(offset+ie)) = dofs_per_elem(offset+ie)
+        pg%g_dofs_per_elem(g_elem_gids(offset+ie)) = dofs_per_elem(offset+ie)
       enddo
     enddo
 
-    ! Compute global dofs
-    call compute_global_dofs ()
-
-    ! Compute area and lat/lon coords
-    call compute_global_coords ()
-    call compute_global_area ()
-
+    ! Compute arrays of global coords, area, dofs
+    call compute_global_dofs (pg)
+    call compute_global_coords (pg)
+    call compute_global_area (pg)
   end subroutine phys_grid_init
 
-  subroutine cleanup_grid_init_data ()
-    if (is_phys_grid_inited) then
-      ! nprocs-sized arrays
-      deallocate(g_dofs_per_rank)
-      deallocate(g_elem_per_rank)
-      deallocate(g_elem_offsets)
-
-      ! nelem-sized arrays
-      deallocate(g_dofs_per_elem)
-      deallocate(g_elem_gids)
-    endif
-  end subroutine cleanup_grid_init_data
-
-  subroutine finalize_phys_grid ()
-    use gllfvremap_mod, only: gfr_finish
-
-    if (fv_nphys>0) then
-      call gfr_finish()
-    endif
-
-    deallocate(g_area)
-    deallocate(g_lat)
-    deallocate(g_lon)
-    deallocate(g_dofs)
-
-    is_phys_grid_inited = .false.
-  end subroutine finalize_phys_grid
-
-  function get_num_local_columns () result (ncols)
-    use dimensions_mod,    only: nelemd
-    use homme_context_mod, only: elem
-    !
-    ! Local(s)
-    !
-    integer :: ncols, ie
-
-    ! Sanity check
-    call check_phys_grid_inited()
-
-    if (fv_nphys>0) then
-      ncols = nelemd*fv_nphys*fv_nphys
-    else
-      ncols = 0
-      do ie=1,nelemd
-        ncols = ncols + elem(ie)%idxP%NumUniquePts
-      enddo
-    endif
-  end function get_num_local_columns
-
-  function get_num_global_columns () result (num_cols) bind(c)
-    use homme_context_mod, only: is_geometry_inited, elem
-    use dimensions_mod,    only: nelem, np
-    !
-    ! Local(s)
-    !
-    integer (kind=c_int) :: num_cols
-    integer :: ie
-
-    ! Sanity check
-    call check_phys_grid_inited()
-
-    if (fv_nphys>0) then
-      num_cols = nelem*fv_nphys*fv_nphys
-    else
-      num_cols = nelem*(np-1)*(np-1)+2
-    endif
-  end function get_num_global_columns
-
-  subroutine get_my_phys_data (gids, lat, lon, area, pg_type)
-    use homme_context_mod, only: elem, iam
-    use dimensions_mod,    only: nelemd
-    use shr_const_mod,     only: pi=>SHR_CONST_PI
-    !
-    ! Input(s)
-    !
-    integer(kind=c_int), pointer, intent(in) :: gids(:)
-    real(kind=c_double), pointer, intent(in) :: lat(:), lon(:), area(:)
-    integer(kind=c_int),          intent(in) :: pg_type
-    !
-    ! Local(s)
-    !
-    integer :: pgN, balancing_opt, idof, ndofs
-
-    call check_phys_grid_inited ()
-
-    ! Possible values for pg_type:
-    !   0 : physics grid on GLL nodes
-    !   2 : physics grid on FV points in 2x2 subcell (PG2)
-    !   3 : physics grid on FV points in 3x3 subcell (PG3)
-    !   4 : physics grid on FV points in 4x4 subcell (PG4)
-    !  10 : GLL points, use twin columns
-    !  12 : PG2 points, use twin columns
-    !  13 : PG3 points, use twin columns
-    !  14 : PG4 points, use twin columns
-    ! In general:
-    !   *0 => GLL nodes, *N,N>0 => FV points
-    !   1* => redistribute using twin columns
-
-    pgN = mod(pg_type,10)
-    if (pgN .ne. fv_nphys) then
-      call abortmp ("Error! Requested N for phys grid different from what was used at init time.")
-    endif
-
-    balancing_opt = pg_type / 10
-
-    if (balancing_opt .ne. pg_default) then
-      call abortmp ("Error! Twin columns not yet implemented for physics grid.")
-    else
-      ! TODO: when you enable twin columns, you'll have to manually
-      !       do the search, since you can't just grab the offset-ed entries
-      ndofs = get_num_local_columns ()
-      do idof=1,ndofs
-        gids(idof) = g_dofs(g_dofs_offsets(iam+1) + idof)
-        lat(idof)  = g_lat(g_dofs_offsets(iam+1) + idof) * 180.0_c_double / pi
-        lon(idof)  = g_lon(g_dofs_offsets(iam+1) + idof) * 180.0_c_double / pi
-        area(idof) = g_area(g_dofs_offsets(iam+1) + idof)
-      enddo
-
-    endif
-  end subroutine get_my_phys_data
-
-  subroutine compute_global_dofs ()
-    use dimensions_mod,    only: nelemd,nelem
-    use homme_context_mod, only: elem, par, iam
-    !
-    ! Local(s)
-    !
-    integer (kind=c_int), pointer :: dofs_l(:)
-    integer :: ie, icol, idof, proc, elem_gid, elem_offset
-    integer, allocatable :: exclusive_scan_dofs_per_elem(:)
-
-    if (associated(g_dofs)) then
-      call abortmp ("Error! compute_global_dofs was already called.")
-    endif
-
-    allocate(exclusive_scan_dofs_per_elem(nelem))
-    allocate(g_dofs(get_num_global_columns()))
-
-    exclusive_scan_dofs_per_elem(1) = 0
-    do ie=2,nelem
-      exclusive_scan_dofs_per_elem(ie) = exclusive_scan_dofs_per_elem(ie-1) + g_dofs_per_elem(ie-1)
-    enddo
-
-    if (fv_nphys .gt. 0) then
-      ! TODO
-      call abortmp ("Error! Phys grid N>0 not yet implemented in scream.")
-    else
-      allocate (g_dofs_offsets(par%nprocs))
-      g_dofs_offsets(1)=0
-      do proc=2,par%nprocs
-        g_dofs_offsets(proc) = g_dofs_offsets(proc-1) + g_dofs_per_rank(proc-1)
-      enddo
-
-      idof = 1
-      do proc=1,par%nprocs
-        elem_offset = g_elem_offsets(proc)
-        do ie=1,g_elem_per_rank(proc)
-          elem_gid = g_elem_gids(elem_offset+ie)
-          do icol=1,g_dofs_per_elem(elem_gid)
-            g_dofs(idof) = exclusive_scan_dofs_per_elem(elem_gid)+icol
-            idof = idof+1
-          enddo
-        enddo
-      enddo
-    endif
-
-  end subroutine compute_global_dofs
-
-  subroutine compute_global_area()
-    use dof_mod,           only: UniquePoints
-    use dimensions_mod,    only: np, nelemd
-    use homme_context_mod, only: elem, par, iam, masterproc
-    !
-    ! Local(s)
-    !
-    real(kind=c_double), pointer :: area_l(:)
-    real(kind=c_double), dimension(np,np)  :: areaw
-    integer  :: ie, offset, start, ierr, ncols
-
-    if (masterproc) then
-      write(iulog,*) 'INFO: Non-scalable action: Computing global area in SE dycore.'
-    endif
-
-    if (associated(g_area)) then
-      call abortmp ("Error! compute_global_area was already called.")
-    endif
-
-    allocate(g_area(get_num_global_columns()))
-
-    if (fv_nphys > 0) then
-      ! TODO
-      call abortmp("Error! Not yet implemented. Why didn't you get an error before?")
-    else
-      ! physics is on GLL grid
-      offset = g_dofs_offsets(iam+1)
-
-      ncols = get_num_local_columns()
-      area_l => g_area(offset+1 : offset+ncols)
-      start = 1
-      do ie=1,nelemd
-        areaw = 1.0_c_double / elem(ie)%rspheremp(:,:)
-        ncols = elem(ie)%idxP%NumUniquePts
-        call UniquePoints(elem(ie)%idxP, areaw, area_l(start:start+ncols-1))
-        start = start + ncols
-      enddo
-
-      ncols = get_num_local_columns()
-      ! Note: using MPI_IN_PLACE,0,MPI_DATATYPE_NULL for the src array
-      !       informs MPI that src array is aliasing the dst one, so
-      !       MPI will grab the src part from dst, using the offsets info
-      call MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
-                          g_area, g_dofs_per_rank, g_dofs_offsets, MPIreal_t, &
-                          par%comm, ierr)
-    endif
-
-  end subroutine compute_global_area
-
-  subroutine compute_global_coords()
-    use dimensions_mod,    only: nelemd
-    use dof_mod,           only: UniqueCoords
-    use gllfvremap_mod,    only: gfr_f_get_latlon
-    use homme_context_mod, only: elem, par, iam, masterproc
-    use parallel_mod,      only: abortmp
-    !
-    ! Local(s)
-    !
-    real(kind=c_double), pointer :: lat_l(:), lon_l(:)
-    integer  :: ncols, ie, offset, start, ierr
-
-    if (associated(g_lat) .or. associated(g_lon)) then
-      call abortmp ("Error! compute_global_coords was already called.")
-    endif
-
-    allocate(g_lat(get_num_global_columns()))
-    allocate(g_lon(get_num_global_columns()))
-
-    if (masterproc) then
-      write(iulog,*) 'INFO: Non-scalable action: Computing global coords in SE dycore.'
-    end if
-
-    if (fv_nphys > 0) then
-      ! TODO
-      call abortmp("Error! Not yet implemented. Why didn't you get an error before?")
-    else
-      ! physics is on GLL grid
-
-      offset = g_dofs_offsets(iam+1)
-
-      ncols = get_num_local_columns()
-      lat_l => g_lat(offset+1 : offset+ncols)
-      lon_l => g_lon(offset+1 : offset+ncols)
-      start = 1
-      do ie=1,nelemd
-        ncols = elem(ie)%idxP%NumUniquePts
-        call UniqueCoords(elem(ie)%idxP, elem(ie)%spherep, &
-                          lat_l(start:start+ncols-1),      &
-                          lon_l(start:start+ncols-1))
-        start = start + ncols
-      enddo
-
-      ncols = get_num_local_columns()
-
-      ! Note: using MPI_IN_PLACE,0,MPI_DATATYPE_NULL for the src array
-      !       informs MPI that src array is aliasing the dst one, so
-      !       MPI will grab the src part from dst, using the offsets info
-      call MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
-                          g_lat, g_dofs_per_rank, g_dofs_offsets, MPIreal_t, &
-                          par%comm, ierr)
-      call MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
-                          g_lon, g_dofs_per_rank, g_dofs_offsets, MPIreal_t, &
-                          par%comm, ierr)
-    end if
-
-  end subroutine compute_global_coords
 
 end module phys_grid_mod

--- a/components/scream/src/dynamics/homme/interface/scream_homme_interface.hpp
+++ b/components/scream/src/dynamics/homme/interface/scream_homme_interface.hpp
@@ -37,7 +37,7 @@ bool is_hommexx_functors_inited_f90 ();
 // Generic setup
 void init_parallel_f90 (const int& f_comm);
 void init_params_f90 (const char*& fname);
-void init_grids_f90 (const int& pgN);
+void init_grids_f90 (const int*& pg_types, const int num_pg_types);
 void cleanup_grid_init_data_f90 ();
 void finalize_geometry_f90 ();
 
@@ -52,8 +52,8 @@ void prim_finalize_f90 ();
 // Grids specs
 int get_nlev_f90 ();
 int get_np_f90 ();
-int get_num_local_columns_f90 ();
-int get_num_global_columns_f90 ();
+int get_num_local_columns_f90 (const int pgN);
+int get_num_global_columns_f90 (const int pgN);
 int get_num_local_elems_f90 ();
 int get_num_global_elems_f90 ();
 void get_dyn_grid_data_f90 (AbstractGrid::gid_type* const& gids,

--- a/components/scream/src/dynamics/homme/tests/CMakeLists.txt
+++ b/components/scream/src/dynamics/homme/tests/CMakeLists.txt
@@ -10,11 +10,13 @@ if (NOT SCREAM_BASELINES_ONLY)
   CreateUnitTest(homme_pd_remap
       "homme_pd_remap_tests.cpp;test_helper_mod.F90"
       "scream_share;${dynLibName}"
-      MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
+      MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+      LABELS "dynamics")
 
   # Test I/O on dyn grid
   CreateUnitTest(dyn_grid_io
       "dyn_grid_io.cpp;test_helper_mod.F90"
       "scream_share;scream_io;${dynLibName}"
-      MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
+      MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+      LABELS "dynamics;io")
 endif()

--- a/components/scream/src/dynamics/homme/tests/CMakeLists.txt
+++ b/components/scream/src/dynamics/homme/tests/CMakeLists.txt
@@ -11,4 +11,10 @@ if (NOT SCREAM_BASELINES_ONLY)
       "homme_pd_remap_tests.cpp;test_helper_mod.F90"
       "scream_share;${dynLibName}"
       MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
+
+  # Test I/O on dyn grid
+  CreateUnitTest(dyn_grid_io
+      "dyn_grid_io.cpp;test_helper_mod.F90"
+      "scream_share;scream_io;${dynLibName}"
+      MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
 endif()

--- a/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -161,6 +161,13 @@ TEST_CASE("dyn_grid_io")
   output.run(ts);
   output.finalize();
 
+  // Clear the content of the dyn fields, to avoid seeing the same numbers
+  // only b/c nothing was in fact read.
+  for (const auto& fn : fnames) {
+    auto f = fm_dyn->get_field(fn);
+    f.deep_copy(-1.0);
+  }
+
   // Next, let's load all fields from file directly into the dyn grid fm
   io_params.set<std::string>("Filename","dyn_grid_io.INSTANT.Steps_x1.0001-03-04.000004.nc");
   AtmosphereInput input (comm,io_params,fm_dyn, gm);

--- a/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -148,10 +148,12 @@ TEST_CASE("dyn_grid_io")
   dyn2ctrl->remap(false); // Remap bwd to get data from ctrl to dyn
 
   // Now try to write all fields to file from the dyn grid fm
+  // IMPORTANT! Make the file name dependent on comm size, so all tests
+  //            can run in parallel without race conditions on the nc file.
   ekat::ParameterList io_params;
   io_params.set<int>("Max Snapshots Per File",1);
   io_params.set<std::string>("Averaging Type","Instant");
-  io_params.set<std::string>("Casename","dyn_grid_io");
+  io_params.set<std::string>("Casename","dyn_grid_io_np" + std::to_string(comm.size()));
   io_params.set<std::vector<std::string>>("Fields",fnames);
   io_params.sublist("Output").set<int>("Frequency",1);
   io_params.sublist("Output").set<std::string>("Frequency Units","Steps");
@@ -169,7 +171,7 @@ TEST_CASE("dyn_grid_io")
   }
 
   // Next, let's load all fields from file directly into the dyn grid fm
-  io_params.set<std::string>("Filename","dyn_grid_io.INSTANT.Steps_x1.0001-03-04.000004.nc");
+  io_params.set<std::string>("Filename","dyn_grid_io_np" + std::to_string(comm.size()) + ".INSTANT.Steps_x1.0001-03-04.000004.nc");
   AtmosphereInput input (comm,io_params,fm_dyn, gm);
   input.read_variables();
 

--- a/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -1,0 +1,183 @@
+#include <catch2/catch.hpp>
+
+#include "TimeLevel.hpp"
+
+#include "dynamics/homme/dynamics_driven_grids_manager.hpp"
+#include "dynamics/homme/homme_dimensions.hpp"
+#include "dynamics/homme/interface/scream_homme_interface.hpp"
+
+#include "share/io/scorpio_input.hpp"
+#include "share/io/scorpio_output.hpp"
+
+#include "share/field/field_utils.hpp"
+#include "share/field/field_manager.hpp"
+#include "share/grid/grids_manager.hpp"
+#include "share/util/scream_setup_random_test.hpp"
+#include "share/util/scream_time_stamp.hpp"
+
+#include "ekat/util/ekat_units.hpp"
+#include "ekat/ekat_parameter_list.hpp"
+#include "ekat/mpi/ekat_comm.hpp"
+
+extern "C" {
+// These are specific C/F calls for these tests (i.e., not part of scream_homme_interface.hpp)
+void init_test_params_f90 ();
+void cleanup_test_f90 ();
+}
+
+namespace {
+
+TEST_CASE("dyn_grid_io")
+{
+  using namespace scream;
+  using namespace ShortFieldTagsNames;
+  constexpr int np  = HOMMEXX_NP;
+  constexpr int nlev = HOMMEXX_NUM_PHYSICAL_LEV;
+
+  ekat::Comm comm(MPI_COMM_WORLD);  // MPI communicator group used for I/O set as ekat object.
+
+  // Initialize the pio_subsystem for this test:
+  MPI_Fint fcomm = MPI_Comm_c2f(comm.mpi_comm());
+  scorpio::eam_init_pio_subsystem(fcomm);
+
+  // Init homme context
+  if (!is_parallel_inited_f90()) {
+    auto comm_f = MPI_Comm_c2f(MPI_COMM_WORLD);
+    init_parallel_f90(comm_f);
+  }
+  init_test_params_f90 ();
+
+  // The homme context
+  auto& c = Homme::Context::singleton();
+
+  // The TimeLevel structure is needed by the PD remapper
+  // Note: we don't remap states, so doesn't matter what values we pick
+  c.create_if_not_there<Homme::TimeLevel>();
+  auto& tl = c.get<Homme::TimeLevel>();
+  tl.np1 = 0;
+  tl.nm1 = 1;
+  tl.n0  = 2;
+
+  // Set parameters
+  constexpr int ne = 2;
+  set_homme_param("ne",ne);
+
+  // Create the grids
+  ekat::ParameterList params;
+  auto gm = std::make_shared<DynamicsDrivenGridsManager>(comm,params);
+  std::set<std::string> grids_names = {"Physics GLL","Dynamics"};
+  gm->build_grids(grids_names,"Physics GLL");
+
+  auto dyn_grid  = gm->get_grid("Dynamics");
+  auto phys_grid = gm->get_grid("Physics GLL");
+
+  // Local counters
+  const int nelems = get_num_local_elems_f90();
+  const int ncols  = phys_grid->get_num_local_dofs();
+  EKAT_REQUIRE_MSG(ncols>0, "Internal test error! Fix dyn_grid_io, please.\n");
+  EKAT_REQUIRE_MSG(nelems>0, "Internal test error! Fix dyn_grid_io, please.\n");
+
+  // Create physics and dynamics Fields
+  FieldLayout layout_dyn_1({EL,GP,GP,LEV},{nelems,np,np,nlev});
+  FieldLayout layout_dyn_2({EL,CMP,GP,GP,LEV},{nelems,2,np,np,nlev});
+  FieldLayout layout_dyn_3({EL,GP,GP},{nelems,np,np});
+
+  FieldLayout layout_phys_1({COL,LEV},{ncols,nlev});
+  FieldLayout layout_phys_2({COL,CMP,LEV},{ncols,2,nlev});
+  FieldLayout layout_phys_3({COL},{ncols});
+
+  auto nondim = ekat::units::Units::nondimensional();
+  FieldIdentifier fid_dyn_1 ("field_1",layout_dyn_1,nondim,dyn_grid->name());
+  FieldIdentifier fid_dyn_2 ("field_2",layout_dyn_2,nondim,dyn_grid->name());
+  FieldIdentifier fid_dyn_3 ("field_3",layout_dyn_3,nondim,dyn_grid->name());
+
+  FieldIdentifier fid_phys_1 ("field_1",layout_phys_1,nondim,phys_grid->name());
+  FieldIdentifier fid_phys_2 ("field_2",layout_phys_2,nondim,phys_grid->name());
+  FieldIdentifier fid_phys_3 ("field_3",layout_phys_3,nondim,phys_grid->name());
+
+  auto fm_dyn = std::make_shared<FieldManager<Real>> (dyn_grid);
+  auto fm_phys= std::make_shared<FieldManager<Real>> (phys_grid);
+  auto fm_ctrl= std::make_shared<FieldManager<Real>> (phys_grid);
+
+  fm_dyn->registration_begins();
+  fm_phys->registration_begins();
+  fm_ctrl->registration_begins();
+
+  const int ps = HOMMEXX_PACK_SIZE;
+  util::TimeStamp ts(1,2,3,4);
+
+  fm_dyn->register_field(FieldRequest(fid_dyn_1,ps));
+  fm_dyn->register_field(FieldRequest(fid_dyn_2,ps));
+  fm_dyn->register_field(FieldRequest(fid_dyn_3));
+
+  fm_phys->register_field(FieldRequest(fid_phys_1,ps));
+  fm_phys->register_field(FieldRequest(fid_phys_2,ps));
+  fm_phys->register_field(FieldRequest(fid_phys_3));
+
+  fm_ctrl->register_field(FieldRequest(fid_phys_1,ps));
+  fm_ctrl->register_field(FieldRequest(fid_phys_2,ps));
+  fm_ctrl->register_field(FieldRequest(fid_phys_3));
+
+  fm_dyn->registration_ends();
+  fm_phys->registration_ends();
+  fm_ctrl->registration_ends();
+  fm_dyn->init_fields_time_stamp(ts);
+  fm_phys->init_fields_time_stamp(ts);
+  fm_ctrl->init_fields_time_stamp(ts);
+
+  std::vector<std::string> fnames = {"field_1", "field_2", "field_3"};
+
+  // Ranodmize control fields, then remap to dyn fields
+  std::uniform_real_distribution<Real> pdf(0.01,100.0);
+  auto engine = setup_random_test(&comm);
+  auto dyn2phys = gm->create_remapper(dyn_grid,phys_grid);
+  auto dyn2ctrl = gm->create_remapper(dyn_grid,phys_grid);
+  dyn2phys->registration_begins();
+  dyn2ctrl->registration_begins();
+  for (const auto& fn : fnames) {
+    auto fd = fm_dyn->get_field(fn);
+    auto fp = fm_phys->get_field(fn);
+    auto fc = fm_ctrl->get_field(fn);
+    dyn2ctrl->register_field(fd,fc);
+    dyn2phys->register_field(fd,fp);
+    randomize(fc,engine,pdf);
+
+  }
+  dyn2phys->registration_ends();
+  dyn2ctrl->registration_ends();
+  dyn2ctrl->remap(false); // Remap bwd to get data from ctrl to dyn
+
+  // Now try to write all fields to file from the dyn grid fm
+  ekat::ParameterList io_params;
+  io_params.set<int>("Max Snapshots Per File",1);
+  io_params.set<std::string>("Averaging Type","Instant");
+  io_params.set<std::string>("Casename","dyn_grid_io");
+  io_params.set<std::vector<std::string>>("Fields",fnames);
+  io_params.sublist("Output").set<int>("Frequency",1);
+  io_params.sublist("Output").set<std::string>("Frequency Units","Steps");
+
+  AtmosphereOutput output(comm,io_params,fm_dyn,gm);
+  output.init();
+  output.run(ts);
+  output.finalize();
+
+  // Next, let's load all fields from file directly into the dyn grid fm
+  io_params.set<std::string>("Filename","dyn_grid_io.INSTANT.Steps_x1.0001-03-04.000004.nc");
+  AtmosphereInput input (comm,io_params,fm_dyn, gm);
+  input.read_variables();
+
+  // Remap dyn->phys, and compare against ctrl
+  dyn2phys->remap(true);
+  for (const auto& fn : fnames) {
+    auto fp = fm_phys->get_field(fn);
+    auto fc = fm_ctrl->get_field(fn);
+    REQUIRE(views_are_equal(fp,fc));
+  }
+
+  // Cleanup everything
+  scorpio::eam_pio_finalize();
+  Homme::Context::finalize_singleton();
+  cleanup_test_f90();
+}
+
+} // anonymous namespace

--- a/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -21,7 +21,7 @@
 
 extern "C" {
 // These are specific C/F calls for these tests (i.e., not part of scream_homme_interface.hpp)
-void set_test_params_f90 (const int& ne_in);
+void init_test_params_f90 ();
 void cleanup_test_f90 ();
 }
 
@@ -51,6 +51,7 @@ TEST_CASE("remap", "") {
     auto comm_f = MPI_Comm_c2f(MPI_COMM_WORLD);
     init_parallel_f90(comm_f);
   }
+  init_test_params_f90 ();
 
   // We'll use this extensively, so let's use a short ref name
   auto& c = Homme::Context::singleton();
@@ -61,7 +62,7 @@ TEST_CASE("remap", "") {
 
   // Set parameters
   constexpr int ne = 2;
-  set_test_params_f90 (ne);
+  set_homme_param("ne",ne);
 
   // Create the grids
   ekat::ParameterList params;
@@ -594,6 +595,7 @@ TEST_CASE("combo_remap", "") {
     auto comm_f = MPI_Comm_c2f(MPI_COMM_WORLD);
     init_parallel_f90(comm_f);
   }
+  init_test_params_f90 ();
 
   // We'll use this extensively, so let's use a short ref name
   auto& c = Homme::Context::singleton();
@@ -604,7 +606,7 @@ TEST_CASE("combo_remap", "") {
 
   // Set parameters
   constexpr int ne = 2;
-  set_test_params_f90 (ne);
+  set_homme_param("ne",ne);
 
   // Create the grids
   ekat::ParameterList params;

--- a/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -39,6 +39,8 @@ TEST_CASE("remap", "") {
   using FID = FieldIdentifier;
   using FL  = FieldLayout;
 
+  constexpr int pg_gll = 0;
+
   // Create a comm
   ekat::Comm comm(MPI_COMM_WORLD);
 
@@ -69,7 +71,7 @@ TEST_CASE("remap", "") {
 
   // Local counters
   const int num_local_elems = get_num_local_elems_f90();
-  const int num_local_cols = get_num_local_columns_f90();
+  const int num_local_cols = get_num_local_columns_f90(pg_gll);
   EKAT_REQUIRE_MSG(num_local_cols>0, "Internal test error! Fix homme_pd_remap_tests, please.\n");
 
   // Get physics and dynamics grids, and their dofs
@@ -580,6 +582,8 @@ TEST_CASE("combo_remap", "") {
   using FID = FieldIdentifier;
   using FL  = FieldLayout;
 
+  constexpr int pg_gll = 0;
+
   // Create a comm
   ekat::Comm comm(MPI_COMM_WORLD);
 
@@ -610,7 +614,7 @@ TEST_CASE("combo_remap", "") {
 
   // Local counters
   const int num_local_elems = get_num_local_elems_f90();
-  const int num_local_cols = get_num_local_columns_f90();
+  const int num_local_cols = get_num_local_columns_f90(pg_gll);
   EKAT_REQUIRE_MSG(num_local_cols>0, "Internal test error! Fix homme_pd_remap_tests, please.\n");
 
   // Get physics and dynamics grids, and their dofs

--- a/components/scream/src/dynamics/homme/tests/test_helper_mod.F90
+++ b/components/scream/src/dynamics/homme/tests/test_helper_mod.F90
@@ -2,23 +2,18 @@ module test_helper_mod
 
   implicit none
 
-  public :: set_test_params_f90
+  public :: init_test_params_f90
   public :: cleanup_test_f90
 
 contains
 
-  subroutine set_test_params_f90 (ne_in) bind(c)
-    use iso_c_binding,     only: c_int
-    use dimensions_mod,    only: ne
+  ! This routine marks the params as inited in the F90 interface to homme,
+  ! as well as hard codes some parameters that prescribe a cubed-sphere mesh
+  subroutine init_test_params_f90 () bind(c)
     use control_mod,       only: topology, cubed_sphere_map, partmethod
     use params_mod,        only: SFCURVE
     use homme_context_mod, only: is_params_inited
     use physical_constants, only : domain_size, DD_PI
-
-    !
-    ! Inputs
-    !
-    integer (kind=c_int), intent(in) :: ne_in
 
     ! Hard coded choices for cubed sphere
     topology = 'cube'
@@ -26,11 +21,8 @@ contains
     partmethod = SFCURVE
     domain_size = 4.0D0*DD_PI
 
-    ! Set desired resolution
-    ne = ne_in
-
     is_params_inited = .true.
-  end subroutine set_test_params_f90
+  end subroutine init_test_params_f90
 
   subroutine cleanup_test_f90 () bind(c)
     use schedtype_mod,     only: schedule

--- a/components/scream/src/share/CMakeLists.txt
+++ b/components/scream/src/share/CMakeLists.txt
@@ -17,6 +17,7 @@ else()
     field/field_header.cpp
     field/field_layout.cpp
     field/field_tracking.cpp
+    grid/abstract_grid.cpp
     grid/se_grid.cpp
     grid/point_grid.cpp
     grid/user_provided_grids_manager.cpp

--- a/components/scream/src/share/field/field_alloc_prop.cpp
+++ b/components/scream/src/share/field/field_alloc_prop.cpp
@@ -5,6 +5,7 @@ namespace scream {
 FieldAllocProp::FieldAllocProp ()
  : m_value_type_sizes (0)
  , m_scalar_type_size (0)
+ , m_pack_size_max    (0)
  , m_alloc_size       (0)
  , m_committed        (false)
 {
@@ -21,6 +22,7 @@ FieldAllocProp& FieldAllocProp::operator= (const FieldAllocProp& src)
     m_layout = src.m_layout;
     m_value_type_sizes = src.m_value_type_sizes;
     m_scalar_type_size = src.m_scalar_type_size;
+    m_pack_size_max = src.m_pack_size_max;
     m_last_extent = src.m_last_extent;
     m_alloc_size = src.m_alloc_size;
     m_subview_idx = src.m_subview_idx;
@@ -45,6 +47,7 @@ subview (const int idim, const int k) const {
   FieldAllocProp props;
   props.m_committed = false;
   props.m_scalar_type_size = m_scalar_type_size;
+  props.m_pack_size_max = m_pack_size_max;
   props.m_alloc_size = m_alloc_size / m_layout->dim(idim);
   props.m_subview_idx = std::make_pair(idim,k);
 
@@ -160,6 +163,9 @@ void FieldAllocProp::commit (const layout_ptr_type& layout)
     // The number of scalar_type in a value_type
     const int vt_len = vts / m_scalar_type_size;
 
+    // Update the max pack size
+    m_pack_size_max = std::max(m_pack_size_max,vt_len);
+
     // The number of value_type's needed in the fast-striding dimension
     const int num_vt = (last_phys_extent + vt_len - 1) / vt_len;
 
@@ -182,6 +188,12 @@ int FieldAllocProp::get_alloc_size () const {
   EKAT_REQUIRE_MSG(is_committed(),
       "Error! You cannot query the allocation properties until they have been committed.");
   return m_alloc_size;
+}
+
+int FieldAllocProp::get_largest_pack_size () const {
+  EKAT_REQUIRE_MSG(is_committed(),
+      "Error! You cannot query the allocation properties until they have been committed.");
+  return m_pack_size_max;
 }
 
 int FieldAllocProp::get_last_extent () const {

--- a/components/scream/src/share/field/field_alloc_prop.hpp
+++ b/components/scream/src/share/field/field_alloc_prop.hpp
@@ -65,6 +65,7 @@ public:
   using layout_ptr_type  = std::shared_ptr<const layout_type>;
 
   FieldAllocProp ();
+  FieldAllocProp (const FieldAllocProp&) = default;
 
   FieldAllocProp& operator= (const FieldAllocProp&);
 
@@ -102,6 +103,9 @@ public:
   // Get number of m_scalar_type_size-sized scalars in the allocation.
   int  get_num_scalars () const { return get_alloc_size () / m_scalar_type_size; }
 
+  // Get the largest pack size that this allocation was requested to accommodate
+  int  get_largest_pack_size () const;
+
   // Wether this allocation is contiguous
   bool contiguous () const { return m_contiguous; }
 
@@ -126,6 +130,9 @@ protected:
 
   // The size of the scalar type
   int   m_scalar_type_size;
+
+  // The largest pack size that was requested
+  int   m_pack_size_max;
 
   // The extent along the last dimension for this allocation
   int   m_last_extent;

--- a/components/scream/src/share/grid/abstract_grid.cpp
+++ b/components/scream/src/share/grid/abstract_grid.cpp
@@ -1,0 +1,165 @@
+#include "share/grid//abstract_grid.hpp"
+#include <Kokkos_CopyViews.hpp>
+#include <algorithm>
+#include <cstring>
+#include <string>
+
+namespace scream
+{
+// Constructor(s) & Destructor
+AbstractGrid::
+AbstractGrid (const std::string& name,
+              const GridType type,
+              const int num_local_dofs,
+              const int num_vertical_lev,
+              const ekat::Comm& comm)
+ : m_type (type)
+ , m_name (name)
+ , m_num_local_dofs (num_local_dofs)
+ , m_num_vert_levs  (num_vertical_lev)
+ , m_comm (comm)
+{
+  // Sanity checks
+  EKAT_REQUIRE_MSG (m_num_local_dofs>=0, "Error! Number of local dofs must be non-negative.\n");
+  EKAT_REQUIRE_MSG (m_num_vert_levs>=2, "Error! Number of vertical levels must be at least 2.\n");
+
+  m_comm.all_reduce(&m_num_local_dofs,&m_num_global_dofs,1,MPI_SUM);
+}
+
+AbstractGrid::
+AbstractGrid (const std::string& name,
+              const GridType type,
+              const int num_local_dofs,
+              const int num_vertical_lev,
+              const std::shared_ptr<const AbstractGrid>& unique_grid,
+              const ekat::Comm& comm)
+ : AbstractGrid(name,type,num_local_dofs,num_vertical_lev,comm)
+{
+  set_unique_grid(unique_grid);
+}
+
+bool AbstractGrid::is_unique () const {
+  // If a unique grid was passed, then assume we're not unique
+  if (m_unique_grid) {
+    return false;
+  }
+
+  EKAT_REQUIRE_MSG (m_dofs_gids.size()>0,
+      "Error! We cannot establish if this grid is unique before the dofs GIDs are set.\n");
+
+  // Get a copy of gids on host. CAREFUL: do not use create_mirror_view,
+  // since it would create a shallow copy on CPU devices, but we need a
+  // deep copy, to prevent altering order of gids.
+  decltype(m_dofs_gids)::HostMirror dofs_h("",m_dofs_gids.size());
+  Kokkos::deep_copy(dofs_h,m_dofs_gids);
+
+  std::sort(dofs_h.data(),dofs_h.data()+m_num_local_dofs);
+  auto end = std::unique(dofs_h.data(),dofs_h.data()+m_num_local_dofs);
+
+  int locally_unique = end==(dofs_h.data()+m_num_local_dofs);
+  int unique;
+  m_comm.all_reduce(&locally_unique,&unique,1,MPI_PROD);
+  if (unique==0) {
+    return false;
+  }
+
+  // Each rank has unique gids locally. Now it's time to verify if they are also globally unique.
+  int max_dofs;
+  m_comm.all_reduce(&m_num_local_dofs,&max_dofs,1,MPI_MAX);
+  int* gids = new int[max_dofs];
+  int unique_gids = 1;
+
+  for (int pid=0; pid<m_comm.size(); ++pid) {
+    // Rank pid broadcasts its gids, everyone else checks if there are duplicates
+    if (pid==m_comm.rank()) {
+      std::memcpy(gids,dofs_h.data(),m_num_local_dofs);
+    }
+
+    int ndofs = m_num_local_dofs;
+    m_comm.broadcast(&ndofs,1,pid);
+    m_comm.broadcast(gids,ndofs,pid);
+
+    int my_unique_gids = 1;
+    if (pid!=m_comm.rank()) {
+      // Checking two sorted arrays of length m and n for elements in common is O(m+n) ops.
+      int i=0, j=0;
+      while (i<m_num_local_dofs && j<ndofs && my_unique_gids==1) {
+        if (dofs_h[i]<gids[j]) {
+          ++i;
+        } else if (dofs_h[i]>gids[j]) {
+          ++j;
+        } else {
+          // Found a match. We can stop here
+          my_unique_gids = 0;
+          break;
+        }
+      }
+    }
+    m_comm.all_reduce(&my_unique_gids,&unique_gids,1,MPI_PROD);
+    if (unique_gids==0) {
+      break;
+    }
+  }
+  delete[] gids;
+
+  return unique_gids;
+}
+
+void AbstractGrid::
+set_dofs (const dofs_list_type& dofs)
+{
+  // Sanity checks
+  EKAT_REQUIRE_MSG (not m_dofs_set, "Error! Dofs cannot be re-set, once set.\n");
+
+  EKAT_REQUIRE_MSG (dofs.extent_int(0)==m_num_local_dofs,
+      "Error! Wrong size for the input dofs list. It should match the number of local dofs stored in the mesh.\n"
+      "       Expected gids list size: " + std::to_string(m_num_local_dofs) + "\n"
+      "       Input gids list size   : " + std::to_string(dofs.size()) + "\n");
+
+  m_dofs_gids  = dofs;
+
+  m_comm.barrier();
+
+  m_dofs_set = true;
+}
+
+void AbstractGrid::
+set_lid_to_idx_map (const lid_to_idx_map_type& lid_to_idx)
+{
+  // Sanity checks
+  EKAT_REQUIRE_MSG (not m_lid_to_idx_set, "Error! The lid->idx map cannot be re-set, once set.\n");
+
+  EKAT_REQUIRE_MSG (lid_to_idx.extent_int(0)==m_num_local_dofs &&
+                    lid_to_idx.extent_int(1)==get_2d_scalar_layout().rank(),
+      "Error! Wrong size(s) for the input lid_to_idx map. They should match (num_local_dofs, 2d layout rank).\n"
+      "       Expected sizes: (" + std::to_string(m_num_local_dofs) + "," + std::to_string(get_2d_scalar_layout().rank()) + ")\n"
+      "       Input map sizes: (" + std::to_string(lid_to_idx.extent(0)) + "," + std::to_string(lid_to_idx.extent(1)) + ")\n");
+
+  // TODO: We should check that the gids of the unique grid (if present) are a subset of m_dofs_gids.
+  // TODO: Should the aforementioned check be global or local (w.r.t. m_comm)?
+
+  m_lid_to_idx = lid_to_idx;
+
+  m_comm.barrier();
+
+  m_lid_to_idx_set = true;
+}
+
+std::shared_ptr<const AbstractGrid>
+AbstractGrid::get_unique_grid () const {
+  // If this grid is unique, return it, otherwise return the stored unique grid.
+  return is_unique() ? shared_from_this() : m_unique_grid;
+}
+
+void AbstractGrid::
+set_unique_grid (const std::shared_ptr<const AbstractGrid>& unique_grid) {
+  // Sanity check
+  EKAT_REQUIRE_MSG (unique_grid, "Error! Unique grid pointer is invalid.\n");
+  EKAT_REQUIRE_MSG (unique_grid->is_unique(), "Error! Unique grid is not, in fact, unique.\n");
+  EKAT_REQUIRE_MSG (unique_grid->get_num_global_dofs()<=m_num_global_dofs,
+      "Error! The unique grid has more global dofs than this grid.\n");
+
+  m_unique_grid = unique_grid;
+}
+
+} // namespace scream

--- a/components/scream/src/share/grid/abstract_grid.hpp
+++ b/components/scream/src/share/grid/abstract_grid.hpp
@@ -1,11 +1,15 @@
 #ifndef SCREAM_ABSTRACT_GRID_HPP
 #define SCREAM_ABSTRACT_GRID_HPP
 
+#include "ekat/std_meta/ekat_std_enable_shared_from_this.hpp"
 #include "share/grid/grid_utils.hpp"
 #include "share/field/field_layout.hpp"
 #include "share/scream_types.hpp"
 
+#include "ekat/mpi//ekat_comm.hpp"
+
 #include <map>
+#include <memory>
 
 namespace scream
 {
@@ -24,16 +28,30 @@ namespace scream
  *     rank of the scalar field layout, and i_k less than the i-th dimension
  *     in the scalar field layout
  *
- * The native dof layout is the way one would naturally index dofs in the grid.
- * For instance, on a cartesian 2d grid, this would be done with 2 indices.
- * On a Spectral Element grid, it would be 3 indices (element, gauss pt, gauss pt).
- * This is the layout that a 2d scalar field would have on this grid.
- * Having the grid exposing this layout, allows downstream classes to not avoid
+ * The methods get_Xd_Y_layout, with X=2,3, and Y=scalar,vector, will return the
+ * FieldLayout of a 2d/3d scalar/vector field on this grid.
+ * Having the grid exposing these layout allows downstream classes to avoid
  * assumptions or switches on the particular grid, and simply rely on common
- * grid interfaces.
+ * grid interfaces to retrieve the correct layout, based on known field properties,
+ * like spatial dimension or "physical" rank.
+ *
+ * The grid class also offers the ability to retrieve a "unique" grid associated
+ * with this grid. A unique grid is a grid where each GID appears *once* globally.
+ * This means that no two MPI rank can have the same dof GID, but also that each
+ * GID must appear only once on each rank.
+ * An example of *non*-unique grid is a SEGrid, where the same dof GID is shared
+ * by neighboring spectral elements.
+ * If the grid is not unique, the corresponding unique grid must have been passed
+ * at construction time in order to access it. On the other hand, if a valid
+ * unique grid is passed at construction time, this->is_unique() will always
+ * return fals, and get_unique_grid() will always return the grid passed at
+ * construction time, regardless of whether the current grid is in fact unique or not.
+ * Also, notice that the ctor cannot check that the dofs in the unique_grid
+ * are indeed a subset of the dofs of the current grid, since the dofs are not
+ * set yet.
  */
 
-class AbstractGrid
+class AbstractGrid : public ekat::enable_shared_from_this<AbstractGrid>
 {
 public:
   using gid_type          = int;           // TODO: use int64_t? int? template class on gid_type?
@@ -50,24 +68,18 @@ public:
   using lid_to_idx_map_type = kokkos_types::view<int**>;
 
   // Constructor(s) & Destructor
-  AbstractGrid (const GridType type,
-                const std::string& name)
-   : AbstractGrid(0,0,type,name)
-  {
-    // Nothing to do here
-  }
-
-  AbstractGrid (int num_local_dofs,
-                int num_global_dofs,
+  AbstractGrid (const std::string& name,
                 const GridType type,
-                const std::string& name)
-   : m_type (type)
-   , m_name (name)
-   , m_num_local_dofs  (num_local_dofs)
-   , m_num_global_dofs (num_global_dofs)
-  {
-    // Nothing to do here
-  }
+                const int num_local_dofs,
+                const int num_vertical_lev,
+                const ekat::Comm& comm);
+
+  AbstractGrid (const std::string& name,
+                const GridType type,
+                const int num_local_dofs,
+                const int num_vertical_lev,
+                const std::shared_ptr<const AbstractGrid>& unique_grid,
+                const ekat::Comm& comm);
 
   virtual ~AbstractGrid () = default;
 
@@ -85,22 +97,39 @@ public:
 
   int get_num_vertical_levels () const { return m_num_vert_levs; }
 
+  // Whether this grid contains unique dof GIDs
+  bool is_unique () const;
+
+  // Retrieve the unique grid associated with this grid
+  std::shared_ptr<const AbstractGrid> get_unique_grid () const;
+
   // The number of dofs on this MPI rank
   int get_num_local_dofs  () const { return m_num_local_dofs;  }
   gid_type get_num_global_dofs () const { return m_num_global_dofs; }
 
+  // Set the dofs list
+  // NOTE: this method must be called on all ranks in the stored comm.
+  void set_dofs (const dofs_list_type& dofs);
+
   // Get a 1d view containing the dof gids
-  const dofs_list_type& get_dofs_gids () const { return m_dofs_gids; }
+  const dofs_list_type& get_dofs_gids () const;
+
+  // Set the the map dof_lid->dof_indices, where the indices are the ones used
+  // to access the dof in the layout returned by get_2d_scalar_layout().
+  // NOTE: this method must be called on all ranks in the stored comm.
+  void set_lid_to_idx_map (const lid_to_idx_map_type& lid_to_idx);
 
   // Get a 2d view, where (i,j) entry contains the j-th coordinate of
   // the i-th dof in the native dof layout.
-  const lid_to_idx_map_type& get_lid_to_idx_map () const { return m_lid_to_idx; }
+  const lid_to_idx_map_type& get_lid_to_idx_map () const;
 
   // Set/get geometric views. The setter is virtual, so each grid can check if "name" is supported.
   virtual void set_geometry_data (const std::string& name, const geo_view_type& data) = 0;
   const geo_view_type& get_geometry_data (const std::string& name) const;
 
 protected:
+
+  void set_unique_grid (const std::shared_ptr<const AbstractGrid>& unique_grid);
 
   // The grid name and type
   GridType     m_type;
@@ -111,6 +140,11 @@ protected:
   int m_num_global_dofs;
   int m_num_vert_levs;
 
+  // Whether the dofs have been set
+  bool m_dofs_set = false;
+  // Whether the lid->idx map has been set
+  bool m_lid_to_idx_set = false;
+
   // The global ID of each dof
   dofs_list_type        m_dofs_gids;
 
@@ -118,6 +152,12 @@ protected:
   lid_to_idx_map_type   m_lid_to_idx;
 
   geo_view_map_type     m_geo_views;
+
+  // The unique grid associated with this grid, in case this grid is not unique.
+  std::shared_ptr<const AbstractGrid> m_unique_grid;
+
+  // The MPI comm containing the ranks across which the global mesh is partitioned
+  ekat::Comm            m_comm;
 };
 
 inline const AbstractGrid::geo_view_type&
@@ -125,6 +165,22 @@ AbstractGrid::get_geometry_data (const std::string& name) const {
   EKAT_REQUIRE_MSG (m_geo_views.find(name)!=m_geo_views.end(),
                     "Error! Grid '" + m_name + "' does not store geometric data '" + name + "'.\n");
   return m_geo_views.at(name);
+}
+
+inline const AbstractGrid::dofs_list_type&
+AbstractGrid::get_dofs_gids () const {
+  // Sanity check
+  EKAT_REQUIRE_MSG (m_dofs_gids.size()>0, "Error! You must call 'set_dofs' first.\n");
+
+  return m_dofs_gids;
+}
+
+inline const AbstractGrid::lid_to_idx_map_type&
+AbstractGrid::get_lid_to_idx_map () const {
+  // Sanity check
+  EKAT_REQUIRE_MSG (m_dofs_gids.size()>0, "Error! You must call 'set_dofs' first.\n");
+
+  return m_lid_to_idx;
 }
 
 } // namespace scream

--- a/components/scream/src/share/grid/abstract_grid.hpp
+++ b/components/scream/src/share/grid/abstract_grid.hpp
@@ -86,6 +86,7 @@ public:
   // Grid description utilities
   GridType type () const { return m_type; }
   const std::string& name () const { return m_name; }
+  const ekat::Comm& get_comm () const { return m_comm; }
 
   // Native layout of a dof. This is the natural way to index a dof in the grid.
   // E.g., for a scalar 2d field on a SE grid, this will be (nelem,np,np),

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -9,13 +9,11 @@ namespace scream {
 
 PointGrid::
 PointGrid (const std::string& grid_name,
-           const int          num_global_cols,
            const int          num_my_cols,
-           const int          num_vertical_levels)
- : AbstractGrid(GridType::Point,grid_name)
+           const int          num_vertical_levels,
+           const ekat::Comm&  comm)
+ : AbstractGrid(grid_name,GridType::Point,num_my_cols,num_vertical_levels,comm)
 {
-  m_num_global_dofs = num_global_cols;
-  m_num_local_dofs  = num_my_cols;
   m_num_vert_levs   = num_vertical_levels;
 
   // Sanity checks
@@ -27,11 +25,25 @@ PointGrid (const std::string& grid_name,
                     "Error! The number of global columns is smaller than the local one.\n");
 
   // The lid->idx map is the identity map.
-  m_lid_to_idx = decltype(m_lid_to_idx)("lid to idx",m_num_local_dofs,1);
-
-  auto h_lid_to_idx = Kokkos::create_mirror_view(m_lid_to_idx);
+  decltype(m_lid_to_idx) lid_to_idx("lid to idx",m_num_local_dofs,1);
+  auto h_lid_to_idx = Kokkos::create_mirror_view(lid_to_idx);
   std::iota(h_lid_to_idx.data(),h_lid_to_idx.data()+m_num_local_dofs,0);
-  Kokkos::deep_copy(m_lid_to_idx,h_lid_to_idx);
+  Kokkos::deep_copy(lid_to_idx,h_lid_to_idx);
+
+  // Note: we use the base class set method, rather than directly using m_lid_to_idx,
+  //       so that we can perform sanity checks on inputs consistency.
+  set_lid_to_idx_map(lid_to_idx);
+}
+
+PointGrid::
+PointGrid (const std::string& grid_name,
+           const int          num_my_cols,
+           const int          num_vertical_levels,
+           const std::shared_ptr<const AbstractGrid>& unique_grid,
+           const ekat::Comm&  comm)
+ : PointGrid(grid_name,num_my_cols,num_vertical_levels,comm)
+{
+  set_unique_grid(unique_grid);
 }
 
 FieldLayout
@@ -73,19 +85,6 @@ PointGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag
 }
 
 void PointGrid::
-set_dofs (const dofs_list_type& dofs)
-{
-  // Sanity checks
-  EKAT_REQUIRE_MSG (
-    dofs.extent_int(0)==m_num_local_dofs,
-    "Error! Input views have the wrong size:\n"
-    "   expected: " + std::to_string(m_num_local_dofs) + "\n"
-    "   provided: " + std::to_string(dofs.extent_int(0)) + "\n");
-
-  m_dofs_gids  = dofs;
-}
-
-void PointGrid::
 set_geometry_data (const std::string& name, const geo_view_type& data) {
   // Sanity checks
   EKAT_REQUIRE_MSG (data.extent_int(0)==m_num_local_dofs,
@@ -115,7 +114,8 @@ create_point_grid (const std::string& grid_name,
     dof_offset += remainder;
   }
 
-  auto grid = std::make_shared<PointGrid>(grid_name,num_global_cols,num_my_cols,num_vertical_lev);
+  auto grid = std::make_shared<PointGrid>(grid_name,num_my_cols,num_vertical_lev,comm);
+  grid->setSelfPointer(grid);
 
   PointGrid::dofs_list_type dofs_gids ("phys dofs",num_my_cols);
   auto h_dofs_gids = Kokkos::create_mirror_view(dofs_gids);

--- a/components/scream/src/share/grid/point_grid.hpp
+++ b/components/scream/src/share/grid/point_grid.hpp
@@ -1,6 +1,7 @@
 #ifndef SCREAM_POINT_GRID_HPP
 #define SCREAM_POINT_GRID_HPP
 
+#include <memory>
 #include "share/grid/abstract_grid.hpp"
 #include "share/scream_types.hpp"
 
@@ -27,9 +28,15 @@ class PointGrid : public AbstractGrid
 public:
 
   PointGrid (const std::string& grid_name,
-             const int num_global_cols,
              const int num_my_cols,
-             const int num_vertical_levels);
+             const int num_vertical_levels,
+             const ekat::Comm& comm);
+
+  PointGrid (const std::string& grid_name,
+             const int num_my_cols,
+             const int num_vertical_levels,
+             const std::shared_ptr<const AbstractGrid>& unique_grid,
+             const ekat::Comm& comm);
 
   virtual ~PointGrid () = default;
 
@@ -40,7 +47,6 @@ public:
   FieldLayout get_3d_scalar_layout (const bool midpoints) const override;
   FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const override;
 
-  void set_dofs (const dofs_list_type& dofs);
   void set_geometry_data (const std::string& name, const geo_view_type& data) override;
 };
 

--- a/components/scream/src/share/grid/se_grid.cpp
+++ b/components/scream/src/share/grid/se_grid.cpp
@@ -4,50 +4,31 @@ namespace scream {
 
 SEGrid::
 SEGrid (const std::string& grid_name,
-        const int num_global_elements,
         const int num_my_elements,
         const int num_gauss_pts,
-        const int num_vertical_levels)
- : AbstractGrid (GridType::SE, grid_name)
- , m_num_local_elem (num_my_elements)
- , m_num_gp         (num_gauss_pts)
+        const int num_vertical_levels,
+        const ekat::Comm& comm)
+ : AbstractGrid (grid_name,GridType::SE,num_my_elements*num_gauss_pts*num_gauss_pts,num_vertical_levels,comm)
 {
   // Sanity checks
-  EKAT_REQUIRE_MSG (
-    num_global_elements>=num_my_elements,
-    "Error! The number of local element is larger than the global one.\n"
-    "       Did you call the constructor with the two swapped?\n");
+  EKAT_REQUIRE_MSG (num_my_elements>=0, "Error! Number of local elements must be non-negative.\n");
+  EKAT_REQUIRE_MSG (num_gauss_pts>=2, "Error! Number of gauss points must be at least 2.\n");
+  EKAT_REQUIRE_MSG (num_vertical_levels>=2, "Error! Number of vertical levels must be at least 2.\n");
 
-  m_num_local_dofs  = m_num_local_elem*m_num_gp*m_num_gp;
-  m_num_global_dofs = num_global_elements*m_num_gp*m_num_gp;
-  m_num_vert_levs   = num_vertical_levels;
+  m_num_local_elem = num_my_elements;
+  m_num_gp         = num_gauss_pts;
 }
 
-void SEGrid::
-set_dofs (const dofs_list_type&      dofs,
-          const lid_to_idx_map_type& lid_to_idx)
+SEGrid::
+SEGrid (const std::string& grid_name,
+        const int num_my_elements,
+        const int num_gauss_pts,
+        const int num_vertical_levels,
+        const std::shared_ptr<const AbstractGrid>& unique_grid,
+        const ekat::Comm& comm)
+ : SEGrid(grid_name,num_my_elements,num_gauss_pts,num_vertical_levels,comm)
 {
-  // Sanity checks
-  EKAT_REQUIRE_MSG (
-    dofs.extent_int(0)==lid_to_idx.extent_int(0),
-    "Error! Input views dimension do not match:\n"
-    "         num gids: " + std::to_string(dofs.extent_int(0)) + "\n"
-    "         num lids: " + std::to_string(lid_to_idx.extent_int(0)) + "\n");
-
-  EKAT_REQUIRE_MSG (
-    dofs.extent_int(0)==m_num_local_dofs,
-    "Error! Input views have the wrong size:\n"
-    "   expected: " + std::to_string(m_num_local_dofs) + "\n"
-    "   provided: " + std::to_string(dofs.extent_int(0)) + "\n");
-
-  EKAT_REQUIRE_MSG (
-    lid_to_idx.extent_int(1)==3,
-    "Error! Invalid extent(1) for lid_to_idx input:\n"
-      "   expected: 3\n"
-      "   provided: " + std::to_string(lid_to_idx.extent_int(1)) + "\n");
-
-  m_dofs_gids  = dofs;
-  m_lid_to_idx = lid_to_idx;
+  set_unique_grid (unique_grid);
 }
 
 void SEGrid::

--- a/components/scream/src/share/grid/se_grid.hpp
+++ b/components/scream/src/share/grid/se_grid.hpp
@@ -1,6 +1,7 @@
 #ifndef SCREAM_SE_GRID_HPP
 #define SCREAM_SE_GRID_HPP
 
+#include "ekat/mpi/ekat_comm.hpp"
 #include "share/grid/abstract_grid.hpp"
 #include "share/scream_types.hpp"
 #include "ekat/ekat_assert.hpp"
@@ -13,10 +14,17 @@ class SEGrid : public AbstractGrid
 public:
 
   SEGrid (const std::string& grid_name,
-          const int num_global_elements,
           const int num_my_elements,
           const int num_gauss_pts,
-          const int num_vertical_levels);
+          const int num_vertical_levels,
+          const ekat::Comm& comm);
+
+  SEGrid (const std::string& grid_name,
+          const int num_my_elements,
+          const int num_gauss_pts,
+          const int num_vertical_levels,
+          const std::shared_ptr<const AbstractGrid>& unique_grid,
+          const ekat::Comm& comm);
 
   virtual ~SEGrid () = default;
 
@@ -26,17 +34,13 @@ public:
   FieldLayout get_3d_scalar_layout (const bool midpoints) const override;
   FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const override;
 
-  // Set the dofs gids as well as their coordinates (ie,igp,jgp) in the grid
-  void set_dofs (const dofs_list_type&      dofs,
-                 const lid_to_idx_map_type& lid_to_elgpgp);
-
   void set_geometry_data (const std::string& name, const geo_view_type& data) override;
 
 protected:
 
   // SE dims
-  int                       m_num_local_elem;
-  int                       m_num_gp;
+  int       m_num_local_elem;
+  int       m_num_gp;
 };
 
 } // namespace scream

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -1,6 +1,7 @@
 #include "share/io/scorpio_input.hpp"
 
 #include "ekat/ekat_parameter_list.hpp"
+#include "share/io/scream_scorpio_interface.hpp"
 
 #include <numeric>
 
@@ -243,7 +244,7 @@ void AtmosphereInput::init_scorpio_structures()
   // registered, and sets up scorpio for reading.
 
   // Register netCDF file for input.
-  scorpio::register_infile(m_filename);
+  scorpio::register_file(m_filename,scorpio::Read);
 
   // Register variables with netCDF file.
   register_variables();

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -120,8 +120,6 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
   // Sanity checks
   EKAT_REQUIRE_MSG (not m_grid, "Error! Grid pointer was already set.\n");
   EKAT_REQUIRE_MSG (grid, "Error! Input grid pointer is invalid.\n");
-  EKAT_REQUIRE_MSG (grid->name()=="Physics" || grid->name()=="Physics GLL",
-      "Error! I/O only supports output on a Physics or Physics GLL grid.\n");
   EKAT_REQUIRE_MSG (grid->is_unique(),
       "Error! I/O only supports grids which are 'unique', meaning that the\n"
       "       map dof_gid->proc_id is well defined.\n");

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -432,8 +432,6 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
   // Sanity checks
   EKAT_REQUIRE_MSG (not m_grid, "Error! Grid pointer was already set.\n");
   EKAT_REQUIRE_MSG (grid, "Error! Input grid pointer is invalid.\n");
-  EKAT_REQUIRE_MSG (grid->name()=="Physics" || grid->name()=="Physics GLL",
-      "Error! I/O only supports output on a Physics or Physics GLL grid.\n");
   EKAT_REQUIRE_MSG (grid->is_unique(),
       "Error! I/O only supports grids which are 'unique', meaning that the\n"
       "       map dof_gid->proc_id is well defined.\n");

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -505,7 +505,7 @@ void AtmosphereOutput::new_file(const std::string& filename)
   using namespace scream::scorpio;
 
   // Register new netCDF file for output.
-  register_outfile(filename);
+  register_file(filename,Write);
 
   // Register dimensions with netCDF file.
   for (auto it : m_dims) {

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -1,4 +1,6 @@
 #include "scream_output_manager.hpp"
+#include <cmath>
+#include <memory>
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/mpi/ekat_comm.hpp"
 
@@ -8,11 +10,13 @@ namespace scream
 void OutputManager::
 setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
        const std::shared_ptr<const fm_type>& field_mgr,
+       const std::shared_ptr<const gm_type>& grids_mgr,
        const bool runtype_restart)
 {
   m_io_comm   = io_comm;
   m_params    = params;
   m_field_mgr = field_mgr;
+  m_grids_mgr = grids_mgr;
   m_runtype_restart = runtype_restart;
 
   // Check for model restart output
@@ -89,10 +93,11 @@ void OutputManager::finalize()
 void OutputManager::
 add_output_stream(const ekat::ParameterList& params, const bool model_restart_output)
 {
-  auto output = std::make_shared<output_type>(m_io_comm,params,m_field_mgr,
+  auto output = std::make_shared<output_type>(m_io_comm,params,m_field_mgr,m_grids_mgr,
                                               m_runtype_restart, model_restart_output);
   m_output_streams.push_back(output);
 }
+
 /*===============================================================================================*/
 void OutputManager::make_restart_param_list(ekat::ParameterList& params)
 {

--- a/components/scream/src/share/io/scream_output_manager.hpp
+++ b/components/scream/src/share/io/scream_output_manager.hpp
@@ -57,6 +57,7 @@ class OutputManager
 {
 public:
   using fm_type = FieldManager<Real>;
+  using gm_type = GridsManager;
 
   // Constructor(s) & Destructor
   OutputManager () = default;
@@ -67,6 +68,7 @@ public:
   //  - model_restart_output: whether this output stream is to write a model restart file
   void setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
               const std::shared_ptr<const fm_type>& field_mgr,
+              const std::shared_ptr<const gm_type>& grids_mgr,
               const bool runtype_restart);
   void run(util::TimeStamp& current_ts);
   void finalize();
@@ -80,13 +82,14 @@ protected:
   // Craft the restart parameter list
   void make_restart_param_list(ekat::ParameterList& params);
 
-  using output_type = AtmosphereOutput;
+  using output_type     = AtmosphereOutput;
   using output_ptr_type = std::shared_ptr<output_type>;
 
   std::vector<output_ptr_type>        m_output_streams;
   ekat::Comm                          m_io_comm;
   ekat::ParameterList                 m_params;
   std::shared_ptr<const fm_type>      m_field_mgr;
+  std::shared_ptr<const gm_type>      m_grids_mgr;
 
   bool m_runtype_restart  = false;
 

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -1210,7 +1210,7 @@ contains
     real(rtype), dimension(:), pointer :: var_data
     type(pio_atm_file_t), pointer      :: pio_atm_file
     type(hist_var_t), pointer          :: var
-    integer                            :: ierr,var_size,ndims,i
+    integer                            :: ierr,var_size
     logical                            :: found
 
     call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
@@ -1253,7 +1253,7 @@ contains
     ! Local variables
     type(pio_atm_file_t),pointer       :: pio_atm_file
     type(hist_var_t), pointer          :: var
-    integer                            :: ierr, var_size, ndims, i
+    integer                            :: ierr, var_size
     logical                            :: found
     real(rtype), dimension(:), pointer :: var_data
 

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -14,7 +14,7 @@ using scream::Int;
 extern "C" {
 
 // Fortran routines to be called from C++
-  void register_infile_c2f(const char*&& filename);
+  void register_file_c2f(const char*&& filename, const int& mode);
   void set_decomp_c2f(const char*&& filename);
   void set_dof_c2f(const char*&& filename,const char*&& varname,const Int dof_len,const Int *x_dof);
   void grid_read_data_array_c2f_real(const char*&& filename, const char*&& varname, Real *&hbuf);
@@ -23,7 +23,6 @@ extern "C" {
   void grid_write_data_array_c2f_real(const char*&& filename, const char*&& varname, const Real*& hbuf);
   void eam_init_pio_subsystem_c2f(const int mpicom, const int compid, const bool local);
   void eam_pio_finalize_c2f();
-  void register_outfile_c2f(const char*&& filename);
   void sync_outfile_c2f(const char*&& filename);
   void eam_pio_closefile_c2f(const char*&& filename);
   void pio_update_time_c2f(const char*&& filename,const Real time);
@@ -53,20 +52,13 @@ void eam_pio_finalize() {
   GPTLfinalize();
 }
 /* ----------------------------------------------------------------- */
-void register_outfile(const std::string& filename) {
-
-
-  register_outfile_c2f(filename.c_str());
+void register_file(const std::string& filename, const FileMode mode) {
+  register_file_c2f(filename.c_str(),mode);
 }
 /* ----------------------------------------------------------------- */
 void eam_pio_closefile(const std::string& filename) {
 
   eam_pio_closefile_c2f(filename.c_str());
-}
-/* ----------------------------------------------------------------- */
-void register_infile(const std::string& filename) {
-
-  register_infile_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
 void sync_outfile(const std::string& filename) {

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -132,11 +132,11 @@ void count_pio_atm_file() {
 /* ----------------------------------------------------------------- */
 void grid_read_data_array(const std::string &filename, const std::string &varname, Real *hbuf) {
   grid_read_data_array_c2f_real(filename.c_str(),varname.c_str(),hbuf);
-};
+}
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const Real* hbuf) {
   grid_write_data_array_c2f_real(filename.c_str(),varname.c_str(),hbuf);
-};
+}
 /* ----------------------------------------------------------------- */
 
 } // namespace scorpio

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -22,16 +22,21 @@ static constexpr int PIO_INT = 4;
 
 namespace scream {
 namespace scorpio {
+
+  // WARNING: these values must match the ones of file_purpose_in and file_purpose_out
+  // in the scream_scorpio_interface F90 module
+  enum FileMode {
+    Read = 1,
+    Write = 2
+  };
   /* All scorpio usage requires that the pio_subsystem is initialized. Happens only once per simulation */
   void eam_init_pio_subsystem(const int mpicom);
   /* Cleanup scorpio with pio_finalize */
   void eam_pio_finalize();
   /* Close a file currently open in scorpio */
   void eam_pio_closefile(const std::string& filename);
-  /* Register a new file for output with scorpio module */
-  void register_outfile(const std::string& filename);
-  /* Register a new file to be used for input with the scorpio module */
-  void register_infile(const std::string& filename);
+  /* Register a new file to be used for input/output with the scorpio module */
+  void register_file(const std::string& filename, const FileMode mode);
   /* Every timestep each output file needs to be synced, call once per timestep, per file */
   void sync_outfile(const std::string& filename);
   /* Sets the IO decompostion for all variables in a particular filename.  Required after all variables have been registered.  Called once per file. */

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -28,27 +28,17 @@ contains
     call eam_pio_finalize()
   end subroutine eam_pio_finalize_c2f
 !=====================================================================!
-  subroutine register_outfile_c2f(filename_in) bind(c)
-    use scream_scorpio_interface, only : register_outfile
+  subroutine register_file_c2f(filename_in,purpose) bind(c)
+    use scream_scorpio_interface, only : register_file
     type(c_ptr), intent(in) :: filename_in
+    integer, intent(in)     :: purpose
 
-    character(len=256)       :: filename
+    character(len=256)      :: filename
 
     call convert_c_string(filename_in,filename)
-    call register_outfile(trim(filename))
+    call register_file(trim(filename),purpose)
 
-  end subroutine register_outfile_c2f
-!=====================================================================!
-  subroutine register_infile_c2f(filename_in) bind(c)
-    use scream_scorpio_interface, only : register_infile
-    type(c_ptr), intent(in) :: filename_in
-
-    character(len=256)       :: filename
-
-    call convert_c_string(filename_in,filename)
-    call register_infile(trim(filename))
-
-  end subroutine register_infile_c2f
+  end subroutine register_file_c2f
 !=====================================================================!
   subroutine sync_outfile_c2f(filename_in) bind(c)
     use scream_scorpio_interface, only : eam_sync_piofile

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -30,8 +30,8 @@ contains
 !=====================================================================!
   subroutine register_file_c2f(filename_in,purpose) bind(c)
     use scream_scorpio_interface, only : register_file
-    type(c_ptr), intent(in) :: filename_in
-    integer, intent(in)     :: purpose
+    type(c_ptr), intent(in)         :: filename_in
+    integer(kind=c_int), intent(in) :: purpose
 
     character(len=256)      :: filename
 

--- a/components/scream/src/share/io/tests/CMakeLists.txt
+++ b/components/scream/src/share/io/tests/CMakeLists.txt
@@ -1,16 +1,12 @@
 #include(ScreamUtils)
 include(ScreamUtils)
 
-set (ARRAY_SCORPIO_SRCS
-  io.cpp
-  restart.cpp
-)
-
-## Test atmosphere processes
+## Test output
 CreateUnitTest(io_test "io.cpp" scream_io LABELS "io"
   MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
 )
 
+## Test restart
 CreateUnitTest(restart_test "restart.cpp" scream_io LABELS "io"
   MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
 )

--- a/components/scream/src/share/io/tests/restart.cpp
+++ b/components/scream/src/share/io/tests/restart.cpp
@@ -32,8 +32,8 @@ get_test_fm(std::shared_ptr<const AbstractGrid> grid);
 std::shared_ptr<FieldManager<Real>>
 backup_fm(const std::shared_ptr<FieldManager<Real>>& src);
 
-std::shared_ptr<const AbstractGrid>
-get_test_grid(const ekat::Comm& io_comm, const Int num_gcols, const Int num_levs);
+std::shared_ptr<UserProvidedGridsManager>
+get_test_gm(const ekat::Comm& io_comm, const Int num_gcols, const Int num_levs);
 
 ekat::ParameterList get_om_params(const ekat::Comm& comm, const std::string& grid, const bool check);
 
@@ -59,7 +59,8 @@ TEST_CASE("restart","io")
   Int num_levs = 3;
 
   // First set up a field manager and grids manager to interact with the output functions
-  auto grid = get_test_grid(io_comm,num_gcols,num_levs);
+  auto gm = get_test_gm(io_comm,num_gcols,num_levs);
+  auto grid = gm->get_grid("Physics");
   auto field_manager = get_test_fm(grid);
   randomize_fields(*field_manager,seed);
 
@@ -70,7 +71,7 @@ TEST_CASE("restart","io")
   // Create an Output manager for testing output
   OutputManager output_manager;
   auto output_params = get_om_params(io_comm,grid->name(),false);
-  output_manager.setup(io_comm,output_params,field_manager,false);
+  output_manager.setup(io_comm,output_params,field_manager,gm,false);
 
   // Construct a timestamp
   util::TimeStamp time (0,0,0,0);
@@ -169,7 +170,7 @@ TEST_CASE("restart","io")
   util::TimeStamp time_res (0,0,0,15);
   auto output_params_res = get_om_params(io_comm,grid->name(),true);
   OutputManager output_manager_res;
-  output_manager_res.setup(io_comm,output_params_res,fm_res,true);
+  output_manager_res.setup(io_comm,output_params_res,fm_res,gm,true);
 
   // Run 5 more steps from the restart, to get to the next output step.
   // We should be generating the same output file as before.
@@ -182,6 +183,7 @@ TEST_CASE("restart","io")
 
   // Finalize everything
   scorpio::eam_pio_finalize();
+  gm->clean_up();
 } // TEST_CASE restart
 
 /*===================================================================================================================*/
@@ -270,10 +272,12 @@ void randomize_fields (const FieldManager<Real>& fm, const int seed)
 }
 
 /*===================================================================================================================*/
-std::shared_ptr<const AbstractGrid>
-get_test_grid(const ekat::Comm& io_comm, const Int num_gcols, const Int num_levs)
+std::shared_ptr<UserProvidedGridsManager> get_test_gm(const ekat::Comm& io_comm, const Int num_gcols, const Int num_levs)
 {
-  return create_point_grid("Physics",num_gcols,num_levs,io_comm);
+  auto pg =  create_point_grid("Physics",num_gcols,num_levs,io_comm);
+  auto gm = std::make_shared<UserProvidedGridsManager>();
+  gm->set_grid(pg);
+  return gm;
 }
 /*===================================================================================================================*/
 ekat::ParameterList get_om_params(const ekat::Comm& comm, const std::string& grid, const bool check)

--- a/components/scream/src/share/tests/CMakeLists.txt
+++ b/components/scream/src/share/tests/CMakeLists.txt
@@ -12,7 +12,8 @@ if (NOT ${SCREAM_BASELINES_ONLY})
   CreateUnitTest(field "field_tests.cpp" scream_share)
 
   # Test grids
-  CreateUnitTest(grid "grid_tests.cpp" scream_share)
+  CreateUnitTest(grid "grid_tests.cpp" scream_share
+    MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
 
   # Test common physics functions
   CreateUnitTest(common_physics "common_physics_functions_tests.cpp" scream_share)

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -131,7 +131,6 @@ setup_upgm (const int ne) {
   ekat::Comm comm(MPI_COMM_WORLD);
 
   const int num_local_elems = 4;
-  const int num_global_elems = 4*comm.size();
   const int np = 4;
   const int nvl = 128;
   const int ncols = 6*ne*ne*9 + 2;
@@ -146,9 +145,10 @@ setup_upgm (const int ne) {
 
   // Create a grids manager
   auto upgm = std::make_shared<UserProvidedGridsManager>();
-  auto dummy_dyn_grid  = std::make_shared<SEGrid>("Dynamics",num_global_elems,num_local_elems,np,nvl);
+  auto dummy_dyn_grid  = std::make_shared<SEGrid>("Dynamics",num_local_elems,np,nvl,comm);
   auto dummy_phys_grid = create_point_grid("Physics",ncols,nvl,comm);
-  dummy_dyn_grid->set_dofs(dyn_dofs,dyn_dofs_map);
+  dummy_dyn_grid->set_dofs(dyn_dofs);
+  dummy_dyn_grid->set_lid_to_idx_map(dyn_dofs_map);
   upgm->set_grid(dummy_dyn_grid);
   upgm->set_grid(dummy_phys_grid);
   upgm->set_reference_grid(dummy_phys_grid->name());

--- a/components/scream/src/share/tests/grid_tests.cpp
+++ b/components/scream/src/share/tests/grid_tests.cpp
@@ -46,7 +46,7 @@ TEST_CASE("se_grid", "") {
   int num_my_elems = 10;
   int num_elems = 10*comm.size();
   int num_gp = 4, num_levels = 72;
-  SEGrid grid("se_grid",num_elems,num_my_elems, num_gp, num_levels);
+  SEGrid grid("se_grid",num_my_elems,num_gp,num_levels,comm);
   REQUIRE(grid.type() == GridType::SE);
   REQUIRE(grid.name() == "se_grid");
   REQUIRE(grid.get_num_vertical_levels() == num_levels);
@@ -78,7 +78,8 @@ TEST_CASE("se_grid", "") {
   // Move the data to the device and set the DOFs.
   Kokkos::deep_copy(dofs, host_dofs);
   Kokkos::deep_copy(dofs_map, host_dofs_map);
-  grid.set_dofs(dofs, dofs_map);
+  grid.set_dofs(dofs);
+  grid.set_lid_to_idx_map(dofs_map);
 }
 
 } // anonymous namespace

--- a/components/scream/src/share/tests/grid_tests.cpp
+++ b/components/scream/src/share/tests/grid_tests.cpp
@@ -16,15 +16,19 @@ using namespace scream::ShortFieldTagsNames;
 TEST_CASE("point_grid", "") {
 
   ekat::Comm comm(MPI_COMM_WORLD);
-  int num_procs = comm.size();
 
-  const int num_cols = 128*num_procs, num_levels = 72;
+  const int num_procs = comm.size();
+  const int num_local_cols = 128;
+  const int num_global_cols = num_local_cols*num_procs;
+  const int num_levels = 72;
 
-  auto grid = create_point_grid("my_grid", num_cols, num_levels, comm);
+  auto grid = create_point_grid("my_grid", num_global_cols, num_levels, comm);
   REQUIRE(grid->type() == GridType::Point);
   REQUIRE(grid->name() == "my_grid");
   REQUIRE(grid->get_num_vertical_levels() == num_levels);
-  REQUIRE(grid->get_num_local_dofs() == 128);
+  REQUIRE(grid->get_num_local_dofs()  == num_local_cols);
+  REQUIRE(grid->get_num_global_dofs() == num_global_cols);
+  REQUIRE(grid->is_unique());
 
   auto lid_to_idx = grid->get_lid_to_idx_map();
   auto host_lid_to_idx = Kokkos::create_mirror_view(lid_to_idx);
@@ -40,17 +44,35 @@ TEST_CASE("point_grid", "") {
 }
 
 TEST_CASE("se_grid", "") {
+  // Assume a "strip" of elements:
+  //
+  //  *---*---*     *---*
+  //  |   |   | ... |   *
+  //  *---*---*     *---*
+  //
+  // partitioned evenly across ranks. Use this config to establish
+  // a unique numbering for each element, using the following:
+  //
+  //   1--5--9-13  13-17-21-25
+  //   |  |  |  |   |  |  |  |
+  //   2--6-10-14  14-18-22-26
+  //   |  |  |  |   |  |  |  |
+  //   3--7-11-15  15-19-23-27
+  //   |  |  |  |   |  |  |  |
+  //   4--8-12-16  16-20-24-28
 
-  // Make the grid and check its initial state.
   ekat::Comm comm(MPI_COMM_WORLD);
-  int num_my_elems = 10;
-  int num_elems = 10*comm.size();
-  int num_gp = 4, num_levels = 72;
-  SEGrid grid("se_grid",num_my_elems,num_gp,num_levels,comm);
+
+  const int num_local_elems = 10;
+  const int num_global_elems = num_local_elems*comm.size();
+  const int num_gp = 4;
+  const int num_levels = 72;
+
+  SEGrid grid("se_grid",num_local_elems,num_gp,num_levels,comm);
   REQUIRE(grid.type() == GridType::SE);
   REQUIRE(grid.name() == "se_grid");
   REQUIRE(grid.get_num_vertical_levels() == num_levels);
-  REQUIRE(grid.get_num_local_dofs() == num_elems*num_gp*num_gp);
+  REQUIRE(grid.get_num_local_dofs() == num_local_elems*num_gp*num_gp);
 
   auto layout = grid.get_2d_scalar_layout();
   REQUIRE(layout.tags().size() == 3);
@@ -59,19 +81,36 @@ TEST_CASE("se_grid", "") {
   REQUIRE(layout.tag(2) == GP);
 
   // Set up the degrees of freedom.
-  SEGrid::dofs_list_type dofs("", num_elems*num_gp*num_gp);
+  SEGrid::dofs_list_type dofs("", num_local_elems*num_gp*num_gp);
   auto host_dofs = Kokkos::create_mirror_view(dofs);
-  SEGrid::lid_to_idx_map_type dofs_map("", num_elems*num_gp*num_gp, 3);
+  SEGrid::lid_to_idx_map_type dofs_map("", num_local_elems*num_gp*num_gp, 3);
   auto host_dofs_map = Kokkos::create_mirror_view(dofs_map);
-  for (int ie = 0; ie < num_elems; ++ie) {
-    for (int igp = 0; igp < num_gp; ++igp) {
+
+  // Count unique local dofs. On all elems except the very last one (on rank N),
+  // we have num_gp*(num_gp-1) unique dofs;
+  int num_elem_unique_dofs = num_gp*(num_gp-1);
+  int num_local_unique_dofs = num_local_elems*num_elem_unique_dofs;
+  int offset = num_local_unique_dofs*comm.rank();
+
+  for (int ie = 0; ie < num_local_elems; ++ie) {
+    int elem_offset = offset + ie*num_elem_unique_dofs;
+    for (int igp = 0; igp < num_gp-1; ++igp) {
       for (int jgp = 0; jgp < num_gp; ++jgp) {
         int idof = ie*num_gp*num_gp + igp*num_gp + jgp;
-        host_dofs(idof) = idof;
+        int gid = offset + ie*num_elem_unique_dofs + igp*num_gp + jgp;
+        host_dofs(idof) = gid;
         host_dofs_map(idof, 0) = ie;
         host_dofs_map(idof, 1) = igp;
         host_dofs_map(idof, 2) = jgp;
       }
+    }
+    for (int jgp = 0; jgp < num_gp; ++jgp) {
+      int idof = ie*num_gp*num_gp + (num_gp-1)*num_gp + jgp;
+      int gid = offset + (ie+1)*num_elem_unique_dofs + jgp;
+      host_dofs(idof) = gid;
+      host_dofs_map(idof, 0) = ie;
+      host_dofs_map(idof, 1) = num_gp-1;
+      host_dofs_map(idof, 2) = jgp;
     }
   }
 
@@ -80,6 +119,9 @@ TEST_CASE("se_grid", "") {
   Kokkos::deep_copy(dofs_map, host_dofs_map);
   grid.set_dofs(dofs);
   grid.set_lid_to_idx_map(dofs_map);
+
+  // Dofs gids are replicated along edges, so the SE grid should *not* be unique
+  REQUIRE (not grid.is_unique());
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This PR allows to perform scorpio I/O on the dyn grid (and, more generally, on a grid with repeated dofs). This required to add the ability to store a ptr to a "unique" grid inside a grid. The output manager, uses this grid to build an auxiliary field manager (on the unique grid) to use for I/O, and a remapper (from grid to unique-grid) to be run right before running the output stream.

This is work in progress. In particular, there is no capability to _load_ fields directly from the dyn grid (which is the feature needed to have a BFB restart of HOMME).

NOTE: this PR is built on top of #1162 , so even if it appears as if it contains many commits, the list will get shorter once that PR goes in (I will also rebase on master after that happens, if necessary). In particular, only the commits starting at 5599335 are peculiar to this PR. 