### PR TITLE
Redo scream_cpl_indices for SurfaceCoupling

### DIFF
--- a/components/scream/src/control/surface_coupling.hpp
+++ b/components/scream/src/control/surface_coupling.hpp
@@ -44,8 +44,8 @@ public:
   // This allocates some service views. Since not all imported
   // data is used by SCREAM, we distinguish between cpl
   // imports and SCREAM imports for book keeping.
-  void set_num_fields (const int num_cpl_imports, const int num_scream_imports, const int num_exports);
-
+  void set_num_fields (const int num_cpl_imports, const int num_scream_imports,
+                       const int num_cpl_exports);
   // Version of the above function when num_cpl_imports = num_scream_imports
   void set_num_fields (const int num_imports, const int num_exports)
   { set_num_fields(num_imports, num_imports, num_exports); }
@@ -153,9 +153,10 @@ protected:
 
   field_mgr_ptr m_field_mgr;
 
-  int           m_num_scream_imports;
   int           m_num_cpl_imports;
-  int           m_num_exports;
+  int           m_num_scream_imports;
+  int           m_num_cpl_exports;
+  int           m_num_scream_exports;
 
   int           m_num_cols;
   int           m_num_levs;

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -176,7 +176,7 @@ TEST_CASE ("surface_coupling")
     ekat::genRandArray(G3d_exp.get_internal_view_data<Host>(),G3d_size,engine,pdf);
 
     // Set all raw_data to -1 (might be helpful for debugging)
-    std::fill_n(raw_data,4*ncols,-1);
+    std::fill_n(raw_data,ncols*num_fields,-1);
 
     // Perform export
     exporter.do_export();
@@ -274,9 +274,9 @@ TEST_CASE ("recreate_mct_coupling")
   FID precip_liq_surf_id ("precip_liq_surf", scalar2d_layout, m/s,    grid_name);
 
   // NOTE: if you add fields above, you will have to modify these counters too.
-  const int num_cpl_imports    = 21;
+  const int num_cpl_imports    = 30;
   const int num_scream_imports = 8;
-  const int num_exports        = 13;
+  const int num_cpl_exports    = 35;
 
   // Register fields and tracer group in a FieldManager
   auto fm = std::make_shared<FieldManager<Real>> (grid);
@@ -351,21 +351,21 @@ TEST_CASE ("recreate_mct_coupling")
 
   // Create SC object and set number of import/export fields
   control::SurfaceCoupling coupler(fm);
-  coupler.set_num_fields(num_cpl_imports, num_scream_imports, num_exports);
+  coupler.set_num_fields(num_cpl_imports, num_scream_imports, num_cpl_exports);
 
   // Register fields in the coupler. These match the scr_names_x2a/a2x from
   // scream_cpl_indices.F90. When radiation is fully implemented, RRTMGP
   // fields will be replaced with correct fields.
-  coupler.register_import("surf_latent_flux", 0);
-  coupler.register_import("surf_sens_flux",   1);
+  coupler.register_import("unused",           0);
+  coupler.register_import("unused",           1);
   coupler.register_import("unused",           2);
-  coupler.register_import("surf_mom_flux",    3, 0);
-  coupler.register_import("surf_mom_flux",    4, 1);
-  coupler.register_import("unused",           5);
-  coupler.register_import("sfc_alb_dir_vis",  6);
-  coupler.register_import("sfc_alb_dir_nir",  7);
-  coupler.register_import("sfc_alb_dif_vis",  8);
-  coupler.register_import("sfc_alb_dif_nir",  9);
+  coupler.register_import("sfc_alb_dir_vis",  3);
+  coupler.register_import("sfc_alb_dir_nir",  4);
+  coupler.register_import("sfc_alb_dif_vis",  5);
+  coupler.register_import("sfc_alb_dif_nir",  6);
+  coupler.register_import("unused",           7);
+  coupler.register_import("unused",           8);
+  coupler.register_import("unused",           9);
   coupler.register_import("unused",           10);
   coupler.register_import("unused",           11);
   coupler.register_import("unused",           12);
@@ -375,26 +375,58 @@ TEST_CASE ("recreate_mct_coupling")
   coupler.register_import("unused",           16);
   coupler.register_import("unused",           17);
   coupler.register_import("unused",           18);
-  coupler.register_import("unused",           19);
-  coupler.register_import("unused",           20);
+  coupler.register_import("surf_mom_flux",    19, 0);
+  coupler.register_import("surf_mom_flux",    20, 1);
+  coupler.register_import("unused",           21);
+  coupler.register_import("surf_sens_flux",   22);
+  coupler.register_import("unused",           23);
+  coupler.register_import("surf_latent_flux", 24);
+  coupler.register_import("unused",           25);
+  coupler.register_import("unused",           26);
+  coupler.register_import("unused",           27);
+  coupler.register_import("unused",           28);
+  coupler.register_import("unused",           29);
 
-  coupler.register_export("T_mid",            0);
-  coupler.register_export("Sa_ptem",          1);
-  coupler.register_export("z_mid",            2);
-  coupler.register_export("horiz_winds",      3, 0);
-  coupler.register_export("horiz_winds",      4, 1);
-  coupler.register_export("p_mid",            5);
-  coupler.register_export("Sa_dens",          6);
-  coupler.register_export("qv",               7);
-  coupler.register_export("set_zero",         8);
-  coupler.register_export("precip_liq_surf",  9);
-  coupler.register_export("set_zero",         10);
-  coupler.register_export("set_zero",         11);
-  coupler.register_export("set_zero",         12);
+  coupler.register_export("z_mid",           0);
+  coupler.register_export("set_zero",        1);
+  coupler.register_export("horiz_winds",     2, 0);
+  coupler.register_export("horiz_winds",     3, 1);
+  coupler.register_export("T_mid",           4);
+  coupler.register_export("Sa_ptem",         5);
+  coupler.register_export("qv",              6);
+  coupler.register_export("p_mid",           7);
+  coupler.register_export("Sa_dens",         8);
+  coupler.register_export("set_zero",        9);
+  coupler.register_export("set_zero",        10);
+  coupler.register_export("set_zero",        11);
+  coupler.register_export("set_zero",        12);
+  coupler.register_export("set_zero",        13);
+  coupler.register_export("set_zero",        14);
+  coupler.register_export("precip_liq_surf", 15);
+  coupler.register_export("set_zero",        16);
+  coupler.register_export("set_zero",        17);
+  coupler.register_export("set_zero",        18);
+  coupler.register_export("set_zero",        19);
+  coupler.register_export("set_zero",        20);
+  coupler.register_export("set_zero",        21);
+  coupler.register_export("set_zero",        22);
+  coupler.register_export("set_zero",        23);
+  coupler.register_export("set_zero",        24);
+  coupler.register_export("set_zero",        25);
+  coupler.register_export("set_zero",        26);
+  coupler.register_export("set_zero",        27);
+  coupler.register_export("set_zero",        28);
+  coupler.register_export("set_zero",        29);
+  coupler.register_export("set_zero",        30);
+  coupler.register_export("set_zero",        31);
+  coupler.register_export("set_zero",        32);
+  coupler.register_export("set_zero",        33);
+  coupler.register_export("set_zero",        34);
+
 
   // Complete setup of importer/exporter, providing raw_data
   double* import_raw_data = new double[ncols*num_cpl_imports];
-  double* export_raw_data = new double[ncols*num_exports];
+  double* export_raw_data = new double[ncols*num_cpl_exports];
   coupler.registration_ends(import_raw_data, export_raw_data);
 
   for (int i=0; i<nruns; ++i) {
@@ -424,7 +456,7 @@ TEST_CASE ("recreate_mct_coupling")
     }
 
     // Set all export_raw_data to -1 (might be helpful for debugging)
-    std::fill_n(export_raw_data, num_exports*ncols, -1);
+    std::fill_n(export_raw_data, num_cpl_exports*ncols, -1);
 
     // Perform import
     coupler.do_import();
@@ -453,31 +485,53 @@ TEST_CASE ("recreate_mct_coupling")
 
       // Imports
 
-      REQUIRE (surf_latent_flux_h(icol)    == import_raw_data[0 + icol*num_cpl_imports]); // 1st scream import
-      REQUIRE (surf_sens_flux_h  (icol)    == import_raw_data[1 + icol*num_cpl_imports]); // 2nd scream import
-      REQUIRE (surf_mom_flux_h   (icol, 0) == import_raw_data[3 + icol*num_cpl_imports]); // 3rd scream import (4th cpl import)
-      REQUIRE (surf_mom_flux_h   (icol, 1) == import_raw_data[4 + icol*num_cpl_imports]); // 4th scream import (5th cpl import)
-      REQUIRE (sfc_alb_dir_vis_h (icol)    == import_raw_data[6 + icol*num_cpl_imports]); // 5th scream import (7th cpl import)
-      REQUIRE (sfc_alb_dir_nir_h (icol)    == import_raw_data[7 + icol*num_cpl_imports]); // 6th scream import (8th cpl import)
-      REQUIRE (sfc_alb_dif_vis_h (icol)    == import_raw_data[8 + icol*num_cpl_imports]); // 7th scream import (9th cpl import)
-      REQUIRE (sfc_alb_dif_nir_h (icol)    == import_raw_data[9 + icol*num_cpl_imports]); // 8th scream import (10th cpl import)
+      REQUIRE (sfc_alb_dir_vis_h (icol)    == import_raw_data[3 + icol*num_cpl_imports]);  // 1st scream import (4th cpl import)
+      REQUIRE (sfc_alb_dir_nir_h (icol)    == import_raw_data[4 + icol*num_cpl_imports]);  // 2nd scream import (5th cpl import)
+      REQUIRE (sfc_alb_dif_vis_h (icol)    == import_raw_data[5 + icol*num_cpl_imports]);  // 3rd scream import (6th cpl import)
+      REQUIRE (sfc_alb_dif_nir_h (icol)    == import_raw_data[6 + icol*num_cpl_imports]);  // 4th scream import (7th cpl import)
+      REQUIRE (surf_mom_flux_h   (icol, 0) == import_raw_data[19 + icol*num_cpl_imports]); // 5th scream import (20th cpl import)
+      REQUIRE (surf_mom_flux_h   (icol, 1) == import_raw_data[20 + icol*num_cpl_imports]); // 6th scream import (21st cpl import)
+      REQUIRE (surf_sens_flux_h  (icol)    == import_raw_data[22 + icol*num_cpl_imports]); // 7th scream import (23rd cpl import)
+      REQUIRE (surf_latent_flux_h(icol)    == import_raw_data[24 + icol*num_cpl_imports]); // 8th scream import (24th cpl import)
 
       // Exports
 
       // These exports are direct values from a scream field
-      REQUIRE (export_raw_data[0 + icol*num_exports] == T_mid_h          (icol,    nlevs-1)); // 1st export
-      REQUIRE (export_raw_data[2 + icol*num_exports] == z_mid_h          (icol,    nlevs-1)); // 3rd export
-      REQUIRE (export_raw_data[3 + icol*num_exports] == horiz_winds_h    (icol, 0, nlevs-1)); // 4th export
-      REQUIRE (export_raw_data[4 + icol*num_exports] == horiz_winds_h    (icol, 1, nlevs-1)); // 5th export
-      REQUIRE (export_raw_data[5 + icol*num_exports] == p_mid_h          (icol,    nlevs-1)); // 6th export
-      REQUIRE (export_raw_data[7 + icol*num_exports] == qv_h             (icol,    nlevs-1)); // 8th export
-      REQUIRE (export_raw_data[9 + icol*num_exports] == precip_liq_surf_h(icol            )); // 10th export
+      REQUIRE (export_raw_data[0 + icol*num_cpl_exports]  == z_mid_h          (icol,    nlevs-1)); // 1st export
+      REQUIRE (export_raw_data[2 + icol*num_cpl_exports]  == horiz_winds_h    (icol, 0, nlevs-1)); // 3rd export
+      REQUIRE (export_raw_data[3 + icol*num_cpl_exports]  == horiz_winds_h    (icol, 1, nlevs-1)); // 4th export
+      REQUIRE (export_raw_data[4 + icol*num_cpl_exports]  == T_mid_h          (icol,    nlevs-1)); // 5th export
+      REQUIRE (export_raw_data[6 + icol*num_cpl_exports]  == qv_h             (icol,    nlevs-1)); // 7th export
+      REQUIRE (export_raw_data[7 + icol*num_cpl_exports]  == p_mid_h          (icol,    nlevs-1)); // 8th export
+      REQUIRE (export_raw_data[15 + icol*num_cpl_exports] == precip_liq_surf_h(icol            )); // 16th export
 
       // These exports should be set to 0
-      REQUIRE (export_raw_data[8  + icol*num_exports] == 0); // 9th export
-      REQUIRE (export_raw_data[10 + icol*num_exports] == 0); // 11th export
-      REQUIRE (export_raw_data[11 + icol*num_exports] == 0); // 12th export
-      REQUIRE (export_raw_data[12 + icol*num_exports] == 0); // 13th export
+      REQUIRE (export_raw_data[1  + icol*num_cpl_exports] == 0); // 2nd export
+      REQUIRE (export_raw_data[9  + icol*num_cpl_exports] == 0); // 10th export
+      REQUIRE (export_raw_data[10 + icol*num_cpl_exports] == 0); // 11th export
+      REQUIRE (export_raw_data[11 + icol*num_cpl_exports] == 0); // 12th export
+      REQUIRE (export_raw_data[12 + icol*num_cpl_exports] == 0); // 13th export
+      REQUIRE (export_raw_data[13 + icol*num_cpl_exports] == 0); // 14th export
+      REQUIRE (export_raw_data[14 + icol*num_cpl_exports] == 0); // 15th export
+      REQUIRE (export_raw_data[16 + icol*num_cpl_exports] == 0); // 17th export
+      REQUIRE (export_raw_data[17 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[18 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[19 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[20 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[21 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[22 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[23 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[24 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[25 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[26 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[27 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[28 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[29 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[30 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[31 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[32 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[33 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[34 + icol*num_cpl_exports] == 0); // 35th export
     }
   }
 

--- a/components/scream/src/mct_coupling/atm_comp_mct.F90
+++ b/components/scream/src/mct_coupling/atm_comp_mct.F90
@@ -53,7 +53,8 @@ CONTAINS
     use iso_c_binding,      only: c_ptr, c_loc, c_int, c_char
     use scream_f2c_mod,     only: scream_create_atm_instance, scream_setup_surface_coupling, &
                                   scream_init_atm
-    use scream_cpl_indices, only: scream_set_cpl_indices, num_exports, num_cpl_imports, num_scream_imports, &
+    use scream_cpl_indices, only: scream_set_cpl_indices, num_cpl_exports, &
+                                  num_cpl_imports, num_scream_imports, &
                                   scr_names_x2a, scr_names_a2x, index_x2a, index_a2x, vec_comp_x2a, vec_comp_a2x
     use ekat_string_utils,  only: string_f2c
 
@@ -154,7 +155,7 @@ CONTAINS
     call scream_setup_surface_coupling (c_loc(scr_names_x2a), c_loc(index_x2a), c_loc(x2a%rAttr), c_loc(vec_comp_x2a), &
                                         num_cpl_imports, num_scream_imports, &
                                         c_loc(scr_names_a2x), c_loc(index_a2x), c_loc(a2x%rAttr), c_loc(vec_comp_a2x), &
-                                        num_exports)
+                                        num_cpl_exports)
 
     !----------------------------------------------------------------------------
     ! Reset shr logging to my log file

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -6,20 +6,13 @@ module scream_cpl_indices
   private
 
   ! Focus only on the ones that scream imports/exports (subsets of x2a and a2x)
-  integer, parameter, public :: num_required_cpl_imports = 21
   integer, parameter, public :: num_scream_imports       = 8
-  integer, parameter, public :: num_required_exports     = 12
-  integer, parameter, public :: num_optional_cpl_imports = 0
-  integer, parameter, public :: num_optional_exports     = 1
-  integer, parameter, public :: num_cpl_imports = num_required_cpl_imports + num_optional_cpl_imports
-  integer, parameter, public :: num_exports     = num_required_exports + num_optional_exports
+  integer, parameter, public :: num_scream_exports       = 9
+  integer, public :: num_cpl_imports, num_cpl_exports
 
+  ! cpl indices for import/export fields
   integer(kind=c_int), public, allocatable, target :: index_x2a(:)
   integer(kind=c_int), public, allocatable, target :: index_a2x(:)
-
-  ! Names used by the component coupler for import/export fields
-  character(len=32,kind=c_char), public, allocatable, target :: cpl_names_a2x(:)
-  character(len=32,kind=c_char), public, allocatable, target :: cpl_names_x2a(:)
 
   ! Names used by scream for import/export fields
   character(len=32,kind=c_char), public, allocatable, target :: scr_names_a2x(:)
@@ -29,15 +22,14 @@ module scream_cpl_indices
   integer(kind=c_int), public, allocatable, target :: vec_comp_a2x(:)
   integer(kind=c_int), public, allocatable, target :: vec_comp_x2a(:)
 
-
-
   public :: scream_set_cpl_indices
 
-contains
+  contains
 
   subroutine scream_set_cpl_indices (x2a, a2x)
     use iso_c_binding,  only: C_NULL_CHAR
     use mct_mod,        only: mct_aVect, mct_avect_indexra
+
     !
     ! Input(s)
     !
@@ -47,183 +39,66 @@ contains
     !
     integer :: i,idx
 
-    allocate (index_x2a(num_cpl_imports))
-    allocate (index_a2x(num_exports))
+    ! total number of import/export var in data
+    num_cpl_imports = size(x2a%rAttr,1)
+    num_cpl_exports = size(a2x%rAttr,1)
 
-    allocate (cpl_names_x2a(num_cpl_imports))
-    allocate (cpl_names_a2x(num_exports))
+    allocate (index_x2a(num_cpl_imports))
+    allocate (index_a2x(num_cpl_exports))
 
     allocate (scr_names_x2a(num_cpl_imports))
-    allocate (scr_names_a2x(num_exports))
+    allocate (scr_names_a2x(num_cpl_exports))
 
     allocate (vec_comp_x2a(num_cpl_imports))
-    allocate (vec_comp_a2x(num_exports))
+    allocate (vec_comp_a2x(num_cpl_exports))
 
-    ! Determine attribute vector indices
-
-    ! List of cpl names of inputs that scream cares about
-
-    !------------------------------------------------------------------------------------------
-    !Following inputs are surface values so they are dimensioned (1:ncol) for each chunk.
-    !"cam_in" derived type is populated using these inputs in atm_import_export.F90
-    !using values from other model components
-    !"cam_in" is then used by SCREAM model
-    !------------------------------------------------------------------------------------------
-
-    !Comments after the inputs below are organized as follows:
-    !Long name [units] (cam_in member which captures the input) [List of parameterizations which are using this input currently]
-
-    cpl_names_x2a(1)  = 'Faxx_evap' ! Surface water vapor flux    [kg/kg](cam_in%cflx(:,1)) [SHOC/check_energy_chng]
-    cpl_names_x2a(2)  = 'Faxx_sen'  ! Surface sensible heat flux  [W/m2] (cam_in%shf)  [SHOC/check_energy_chng]
-    cpl_names_x2a(3)  = 'Faxx_lat'  ! Surface latent heat flux    [W/m2] (cam_in%lhf)  [energy fixer qqflx_fixer/qneg4]
-    cpl_names_x2a(4)  = 'Faxx_taux' ! Surface stress in X         [N/m2] (cam_in%wsx)  [SHOC]
-    cpl_names_x2a(5)  = 'Faxx_tauy' ! Surface stress in Y         [N/m2] (cam_in%wsx)  [SHOC]
-    cpl_names_x2a(6)  = 'Faxx_lwup' ! long wave up radiation flux [W/m2] (cam_in%lwup) [RRTMGP]
-    cpl_names_x2a(7)  = 'Sx_avsdr'  ! short wave direct albedo    [no units] (cam_in%asdir)[RRTMGP]
-    cpl_names_x2a(8)  = 'Sx_anidr'  ! long wave direct albedo     [no units] (cam_in%aldir)[RRTMGP]
-    cpl_names_x2a(9)  = 'Sx_avsdf'  ! short wave difuse albedo    [no units] (cam_in%asdif)[RRTMGP]
-    cpl_names_x2a(10) = 'Sx_anidf'  ! long wave difuse albedo     [no units] (cam_in%aldif)[RRTMGP]
-    cpl_names_x2a(11) = 'Sx_t'      ! Surface temperature         [K]        (cam_in%ts)   [check_energy/output- not used anywhere else]
-    cpl_names_x2a(12) = 'Sl_snowh'  ! Water equivalent snow depth [m]        (cam_in%snowhland) [SHOC]
-    cpl_names_x2a(13) = 'Si_snowh'  ! Snow depth over ice         [m]        (cam_in%snowhice)  [***UNUSED***]
-    cpl_names_x2a(14) = 'Sx_tref'   ! Reference height temperature[K]        (cam_in%tref)      [***UNUSED***]
-
-    cpl_names_x2a(15) = 'Sx_qref'   ! Reference height humidity   [kg/kg]    (cam_in%qref)      [***UNUSED***]
-    cpl_names_x2a(16) = 'Sx_u10'    ! 10m wind speed              [m/s]      (cam_in%u10)       [***UNUSED***]
-    cpl_names_x2a(17) = 'Sf_ifrac'  ! Fraction of sfc area covered by sea-ice [no units] (cam_in%icefrac) [RRTMGP]
-
-    !NOTE: Sf_ofrac (or ocean frac) is being used by aqua_planet and old schemes like vertical_diffusion,
-    !Park stratiform_tend and macrophysics
-    cpl_names_x2a(18) = 'Sf_ofrac'  ! Fraction of sfc area covered by ocean   [no units] (cam_in%ocnfrac) [***UNUSED***]
-    cpl_names_x2a(19) = 'Sf_lfrac'  ! Fraction of sfc area covered by land    [no units] (cam_in%landfrac)[SHOC/RRTMGP/ZM]
-
-    !NOTE:SHOC computes So_ustar (or ustar) internally
-    cpl_names_x2a(20) = 'So_ustar'  ! Friction/shear velocity     [m/s]      (cam_in%ustar) [***UNUSED***]
-    cpl_names_x2a(21) = 'So_re'     ! ???? (cam_in%re) [***UNUSED***]
-
-    ! Names used by scream for the input fields above.
-    ! Unused fields are marked and skipped during surface coupling.
-    scr_names_x2a(1)  = 'surf_latent_flux'
-    scr_names_x2a(2)  = 'surf_sens_flux'
-    scr_names_x2a(3)  = 'unused'
-    scr_names_x2a(4)  = 'surf_mom_flux'
-    scr_names_x2a(5)  = 'surf_mom_flux'
-    scr_names_x2a(6)  = 'unused'
-    scr_names_x2a(7)  = 'sfc_alb_dir_vis'
-    scr_names_x2a(8)  = 'sfc_alb_dir_nir'
-    scr_names_x2a(9)  = 'sfc_alb_dif_vis'
-    scr_names_x2a(10) = 'sfc_alb_dif_nir'
-    scr_names_x2a(11) = 'unused'
-    scr_names_x2a(12) = 'unused'
-    scr_names_x2a(13) = 'unused'
-    scr_names_x2a(14) = 'unused'
-    scr_names_x2a(15) = 'unused'
-    scr_names_x2a(16) = 'unused'
-    scr_names_x2a(17) = 'unused'
-    scr_names_x2a(18) = 'unused'
-    scr_names_x2a(19) = 'unused'
-    scr_names_x2a(20) = 'unused'
-    scr_names_x2a(21) = 'unused'
-
-    ! Default import vector components to -1. Set surf_mom_flux components.
-    do i=1,num_required_cpl_imports
+    ! Initialize arrays
+    do i=1,num_cpl_imports
+      index_x2a(i) = i
+      scr_names_x2a(i) = 'unused'
       vec_comp_x2a(i) = -1
     enddo
-    vec_comp_x2a(4) = 0
-    vec_comp_x2a(5) = 1
-
-
-    ! List of cpl names of outputs that scream needs to pass back to cpl
-
-    !Following outputs are computed in control/camsrfexch.F90 using internal SCREAM variables
-
-    !comments after the outputs are organized as follows:
-    !Long name [units] (cam_out derived type member) [optional comment about how it is computed]
-
-    cpl_names_a2x(1)  = 'Sa_tbot'     ! Lowest model level temperature [K] (cam_out%tbot)
-    cpl_names_a2x(2)  = 'Sa_ptem'     ! Potential temperature          [K] (cam_out%thbot)[Computed from temperature and exner function]
-    cpl_names_a2x(3)  = 'Sa_z'        ! Geopotential height above surface at midpoints [m] (cam_out%zbot)
-    cpl_names_a2x(4)  = 'Sa_u'        ! Zonal wind        [m/s]  (cam_out%ubot)
-    cpl_names_a2x(5)  = 'Sa_v'        ! Meridional wind   [m/s]  (cam_out%vbot)
-    cpl_names_a2x(6)  = 'Sa_pbot'     ! midpoint pressure [Pa]   (cam_out%pbot)
-    cpl_names_a2x(7)  = 'Sa_dens'     ! Density           [kg/m3](cam_out%rho) [Computed as pbot/(rair*tbot)]
-    cpl_names_a2x(8)  = 'Sa_shum'     ! Specific humidity [kg/kg](cam_out%qbot(i,1)[surface water vapor, i.e., state%q(1:ncol,pver,1)]
-
-    !-------------------------------------------------------------------------------------------------
-    !Important notes regarding following 4 cpl_names_a2x variables (for cpl_names_a2x indexed 9 to 12):
-    !
-    !1. All the prec* variables have the units of m/s in the model but they are converted to mm/s when
-    !they are assigned to the respective cam_out members in components/eam/src/cpl/atm_import_export.F90
-    !
-    !2. Convective precip variables (precc and precsc, definitions below) should be zero for SCREAM since
-    !   convection scheme is turned off in SCREAM
-    !   'precc'  is Convective precipitation rate (liq + ice)
-    !   'precsc' is Convective snow rate (water equivalent)
-    !
-    !3. Large scale precip is carried in the following variables:
-    !   'precl'  is Large-scale (stable) precipitation rate (liq + ice)
-    !   'precsl' is Large-scale (stable) snow rate (water equivalent)
-    !-------------------------------------------------------------------------------------------------
-
-    !Faxa_rainc is (precc-precsc), therefore it is just the "liquid" part of the convective prec
-    !cam_out variable corresponding to "Faxa_rainc" should be zero for SCREAM
-    cpl_names_a2x(9)  = 'Faxa_rainc'  ! Liquid convective precip  [mm/s] (cam_out%precc-cam_out%precsc) [Obtained from Deep conv.]
-
-    !Faxa_rainl is precl-precsl, therefore it is just the "liquid" part of the large scale prec
-    cpl_names_a2x(10) = 'Faxa_rainl'  ! Liquid large-scale precip [mm/s] (cam_out%precl-cam_out%precsl) [obtained from P3]
-
-    !cam_out variable corresponding to "Faxa_snowc" should be zero for SCREAM
-    cpl_names_a2x(11) = 'Faxa_snowc'  ! Convective snow rate      [mm/s] (cam_out%precsc) [Obtained from Deep Conv.]
-    cpl_names_a2x(12) = 'Faxa_snowl'  ! Large-scale (stable) snow rate [mm/s] (cam_out%precsl) [Obtained from P3]
-
-    cpl_names_a2x(13)  = 'Sa_co2prog' ! Always 0.0_r8 as it is not computed by SCREAM (prognostic co2 is turned off)
-
-    ! Names used by scream for the output fields above. Some field retain
-    ! their cpl_name, which will be combinations of multiple scream fields
-    ! (this logic is taken car of in SurfaceCoupling). Others will be set
-    ! to 0 (set_zero).
-    scr_names_a2x(1)  = 'T_mid'
-    scr_names_a2x(2)  = 'Sa_ptem'
-    scr_names_a2x(3)  = 'z_mid'
-    scr_names_a2x(4)  = 'horiz_winds'
-    scr_names_a2x(5)  = 'horiz_winds'
-    scr_names_a2x(6)  = 'p_mid'
-    scr_names_a2x(7)  = 'Sa_dens'
-    scr_names_a2x(8)  = 'qv'
-    scr_names_a2x(9)  = 'set_zero'
-    scr_names_a2x(10) = 'precip_liq_surf'
-    scr_names_a2x(11) = 'set_zero'
-    scr_names_a2x(12) = 'set_zero'
-    scr_names_a2x(13) = 'set_zero'
-
-    ! Default export vector components to -1. Set horiz_winds components.
-    do i=1,num_exports
+    do i=1,num_cpl_exports
+      index_a2x(i) = i
+      scr_names_a2x(i) = 'set_zero'
       vec_comp_a2x(i) = -1
     enddo
-    vec_comp_a2x(4) = 0
-    vec_comp_a2x(5) = 1
 
-    do i=1,num_required_cpl_imports
-      index_x2a(i) = mct_avect_indexra(x2a,TRIM(cpl_names_x2a(i)))
+    ! The following are imported to SCREAM
+    scr_names_x2a(mct_avect_indexra(x2a,'Sx_avsdr'))  = 'sfc_alb_dir_vis'
+    scr_names_x2a(mct_avect_indexra(x2a,'Sx_anidr'))  = 'sfc_alb_dir_nir'
+    scr_names_x2a(mct_avect_indexra(x2a,'Sx_avsdf'))  = 'sfc_alb_dif_vis'
+    scr_names_x2a(mct_avect_indexra(x2a,'Sx_anidf'))  = 'sfc_alb_dif_nir'
+    scr_names_x2a(mct_avect_indexra(x2a,'Faxx_taux')) = 'surf_mom_flux'
+    scr_names_x2a(mct_avect_indexra(x2a,'Faxx_tauy')) = 'surf_mom_flux'
+    scr_names_x2a(mct_avect_indexra(x2a,'Faxx_sen'))  = 'surf_sens_flux'
+    scr_names_x2a(mct_avect_indexra(x2a,'Faxx_evap')) = 'surf_latent_flux'
+
+    vec_comp_x2a(mct_avect_indexra(x2a,'Faxx_taux')) = 0
+    vec_comp_x2a(mct_avect_indexra(x2a,'Faxx_tauy')) = 1
+
+    ! The following are exported from SCREAM
+    scr_names_a2x(mct_avect_indexra(a2x,'Sa_z'))      = 'z_mid'
+    scr_names_a2x(mct_avect_indexra(a2x,'Sa_u'))      = 'horiz_winds'
+    scr_names_a2x(mct_avect_indexra(a2x,'Sa_v'))      = 'horiz_winds'
+    scr_names_a2x(mct_avect_indexra(a2x,'Sa_tbot'))   = 'T_mid'
+    scr_names_a2x(mct_avect_indexra(a2x,'Sa_ptem'))   = 'Sa_ptem'
+    scr_names_a2x(mct_avect_indexra(a2x,'Sa_pbot'))   = 'p_mid'
+    scr_names_a2x(mct_avect_indexra(a2x,'Sa_shum'))   = 'qv'
+    scr_names_a2x(mct_avect_indexra(a2x,'Sa_dens'))   = 'Sa_dens'
+    scr_names_a2x(mct_avect_indexra(a2x,'Faxa_lwdn')) = 'precip_liq_surf'
+
+    vec_comp_a2x(mct_avect_indexra(a2x,'Sa_u')) = 0
+    vec_comp_a2x(mct_avect_indexra(a2x,'Sa_v')) = 1
+
+    ! Trim names
+    do i=1,num_cpl_imports
       scr_names_x2a(i) = TRIM(scr_names_x2a(i)) // C_NULL_CHAR
     enddo
-    do i=num_required_cpl_imports+1,num_cpl_imports
-      index_x2a(i) = mct_avect_indexra(x2a,TRIM(cpl_names_x2a(i)),perrWith='quiet')
-      scr_names_x2a(i) = TRIM(scr_names_x2a(i)) // C_NULL_CHAR
-    enddo
 
-    do i=1,num_required_exports
-      index_a2x(i) = mct_avect_indexra(a2x,TRIM(cpl_names_a2x(i)))
+    do i=1,num_cpl_exports
       scr_names_a2x(i) = TRIM(scr_names_a2x(i)) // C_NULL_CHAR
     enddo
-    do i=num_required_exports+1,num_exports
-      index_a2x(i) = mct_avect_indexra(a2x,TRIM(cpl_names_a2x(i)),perrWith='quiet')
-      scr_names_a2x(i) = TRIM(scr_names_a2x(i)) // C_NULL_CHAR
-    enddo
-
-    ! We no longer need the cpl names
-    deallocate(cpl_names_a2x)
-    deallocate(cpl_names_x2a)
 
   end subroutine scream_set_cpl_indices
 

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -124,7 +124,7 @@ void scream_setup_surface_coupling (
     const char*& x2a_names, const int*& x2a_indices, double*& cpl_x2a_ptr, const int*& vec_comp_x2a,
     const int& num_cpl_imports, const int& num_scream_imports,
     const char*& a2x_names, const int*& a2x_indices, double*& cpl_a2x_ptr, const int*& vec_comp_a2x,
-    const int& num_exports)
+    const int& num_cpl_exports)
 {
   fpe_guard_wrapper([&](){
     // Fortran gives a 1d array of 32char strings. So let's memcpy the input char
@@ -132,21 +132,22 @@ void scream_setup_surface_coupling (
     // makes sure of that).
     using name_t = char[32];
     name_t* names_in = new name_t[num_cpl_imports];
-    name_t* names_out = new name_t[num_exports];
+    name_t* names_out = new name_t[num_cpl_exports];
     std::memcpy(names_in,x2a_names,num_cpl_imports*32*sizeof(char));
-    std::memcpy(names_out,a2x_names,num_exports*32*sizeof(char));
+    std::memcpy(names_out,a2x_names,num_cpl_exports*32*sizeof(char));
 
     // Get the SurfaceCoupling from the AD, then register the fields
     const auto& ad = get_ad();
     const auto& sc = ad.get_surface_coupling();
 
-    // Register import/export fields
-    sc->set_num_fields(num_cpl_imports,num_scream_imports,num_exports);
+    // Register import/export fields. The indices from Fortran
+    // are 1-based, we convert to 0-based
+    sc->set_num_fields(num_cpl_imports,num_scream_imports,num_cpl_exports);
     for (int i=0; i<num_cpl_imports; ++i) {
-      sc->register_import(names_in[i],x2a_indices[i],vec_comp_x2a[i]);
+      sc->register_import(names_in[i],x2a_indices[i]-1,vec_comp_x2a[i]);
     }
-    for (int i=0; i<num_exports; ++i) {
-      sc->register_export(names_out[i],a2x_indices[i],vec_comp_a2x[i]);
+    for (int i=0; i<num_cpl_exports; ++i) {
+      sc->register_export(names_out[i],a2x_indices[i]-1,vec_comp_a2x[i]);
     }
 
     sc->registration_ends(cpl_x2a_ptr, cpl_a2x_ptr);

--- a/components/scream/src/mct_coupling/scream_f2c_mod.F90
+++ b/components/scream/src/mct_coupling/scream_f2c_mod.F90
@@ -44,14 +44,14 @@ interface
   subroutine scream_setup_surface_coupling (x2a_names, x2a_indices, x2a_ptr, vec_comp_x2a, &
                                             num_cpl_imports, num_scream_imports, &
                                             a2x_names, a2x_indices, a2x_ptr, vec_comp_a2x, &
-                                            num_exports) bind(c)
+                                            num_cpl_exports) bind(c)
     use iso_c_binding, only: c_ptr, c_int
     !
     ! Input(s)
     !
     type(c_ptr),         intent(in) :: x2a_indices, x2a_names, x2a_ptr, vec_comp_x2a
     type(c_ptr),         intent(in) :: a2x_indices, a2x_names, a2x_ptr, vec_comp_a2x
-    integer(kind=c_int), intent(in) :: num_cpl_imports, num_scream_imports, num_exports
+    integer(kind=c_int), intent(in) :: num_cpl_imports, num_scream_imports, num_cpl_exports
   end subroutine scream_setup_surface_coupling
 
   ! This subroutine performs completes the initialization of the atm instance.


### PR DESCRIPTION
Simplify `scream_cpl_indices.F90`. Previously not all cpl fields were present. Now, I just query the cpl array that contains the import/export data for its size, explicitly define all the fields needed by scream, and set all other fields to "unused" (import) or "set_zero" (export). 

Also update SC test to match this. 