### PR TITLE
Add needed team_barrier() to Homme interface

### DIFF
--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -440,7 +440,8 @@ void HommeDynamics::initialize_impl (const util::TimeStamp& /* t0 */)
     auto p_mid = ws.take("p_mid");
     ColOps::column_scan<true>(team,nlevs,dp,p_int,ps0);
     ColOps::compute_midpoint_values(team,nlevs,p_int,p_mid);
-    
+    team.team_barrier();
+
     // Convert T->Theta->Theta*dp->VTheta*dp
     auto T      = ekat::subview(vtheta_dp,ie,n0,igp,jgp);
     auto vTh_dp = ekat::subview(vtheta_dp,ie,n0,igp,jgp);
@@ -762,7 +763,8 @@ void HommeDynamics::homme_post_process () {
 
     ColOps::column_scan<true>(team,nlevs,dp,p_int,ps0);
     ColOps::compute_midpoint_values(team,nlevs,p_int,p_mid);
-    
+    team.team_barrier();
+
     // Convert VTheta_dp->VTheta->Theta->T
     auto T   = ekat::subview(T_view,icol);
     auto v   = ekat::subview(v_view,icol);


### PR DESCRIPTION
When running through CIME with `OMP_NUM_THREADS >1`, there was an internal Homme `NaN` check triggered for  `vTh_dp`. These team_barriers after calculating `p_mid` and before `vTh_dp` fixed the values. Once this was fixed, the 2nd team_barrier was necessary to stop SHOC from erroring out early with negative temperature.

Interestingly enough, these doesn't matter for the homme_physics test.