### PR TITLE
Fix area/lat/lon computations in phys_grid_mod

### DIFF
--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
@@ -173,8 +173,8 @@ void DynamicsDrivenGridsManager::build_dynamics_grid () {
     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const KT::MemberType& team) {
       const Int i = team.league_rank();
 
-      EKAT_ASSERT_MSG(!isnan(lat(i)), "Error! NaN values detected for latitude.");
-      EKAT_ASSERT_MSG(!isnan(lon(i)), "Error! NaN values detected for longitude.");
+      EKAT_KERNEL_ASSERT_MSG(!isnan(lat(i)), "Error! NaN values detected for latitude.");
+      EKAT_KERNEL_ASSERT_MSG(!isnan(lon(i)), "Error! NaN values detected for longitude.");
     });
 #endif
 
@@ -228,9 +228,9 @@ build_physics_grid (const std::string& name) {
     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const KT::MemberType& team) {
       const Int i = team.league_rank();
 
-      EKAT_ASSERT_MSG(!isnan(lat(i)),                   "Error! NaN values detected for latitude.");
-      EKAT_ASSERT_MSG(!isnan(lon(i)),                   "Error! NaN values detected for longitude.");
-      EKAT_ASSERT_MSG(area(i) >  0  && !isnan(area(i)), "Error! Non-positve or NaN values detected for area.");
+      EKAT_KERNEL_ASSERT_MSG(!isnan(lat(i)),                   "Error! NaN values detected for latitude.");
+      EKAT_KERNEL_ASSERT_MSG(!isnan(lon(i)),                   "Error! NaN values detected for longitude.");
+      EKAT_KERNEL_ASSERT_MSG(area(i) >  0  && !isnan(area(i)), "Error! Non-positve or NaN values detected for area.");
     });
 #endif
 

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.hpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.hpp
@@ -27,6 +27,13 @@ public:
 
   const grid_repo_type& get_repo () const { return m_grids; }
 
+#ifndef KOKKOS_ENABLE_CUDA
+protected:
+#endif
+
+  void build_dynamics_grid ();
+  void build_physics_grid  (const std::string& name);
+
 protected:
 
   std::string get_reference_grid_name () const {
@@ -36,9 +43,6 @@ protected:
   remapper_ptr_type
   do_create_remapper (const grid_ptr_type from_grid,
                       const grid_ptr_type to_grid) const;
-
-  void build_dynamics_grid ();
-  void build_physics_grid  (const std::string& name);
 
   void build_grid_codes ();
 


### PR DESCRIPTION
In phys_grid_mod, an assumption was made that element global ids were contiguous in mpi ranks (i.e., rank0 owned dofs `1,...,n1`, rank1 owned `n1+1,...,n2`, etc..). This is not the case. and so indexing needs to change when computing area and lat/lon. Now we order global geo arrays with all rank0 elements, then rank1 elements, etc. where the global id of each element is not necessarily its global index in the arrays. This matches the way dofs are handled in the same file:
```
      ! Fill local dofs part
      idof = 1
      do ie=1,nelemd
        do icol=1,elem(ie)%idxP%NumUniquePts
          i = elem(ie)%idxP%ia(icol)
          j = elem(ie)%idxP%ja(icol)

          dofs_l(idof) = elem(ie)%gdofP(i,j) ! idof+offset != elem(ie)%GlobalID necessarily
          idof = idof + 1
        enddo
      enddo

      call MPI_Allgatherv( MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
                                       dofs_g, g_ncols, g_offsets, MPIinteger_t, par%comm, ierr)
```
How area is computed:
```
      start = 1
      do ie=1,nelemd
        areaw = 1.0_c_double / elem(ie)%rspheremp(:,:)
        ncols = elem(ie)%idxP%NumUniquePts
        call UniquePoints(elem(ie)%idxP, areaw, area_l(start:start+ncols-1))
        start = start + ncols
      enddo

      call MPI_Allgatherv(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
                          area_g, g_ncols, g_offsets, MPIreal_t, &
                          par%comm, ierr)
```