### PR TITLE
Changes to GroupRequest logic, AtmosphereProcess interfaces, and AD handling of initial conditions.

### DIFF
--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -401,7 +401,7 @@ initialize_fields (const util::TimeStamp& t0)
         // There are fields to read from the nc file. We must have a valid nc file then.
         ekat::ParameterList ic_reader_params;
         ic_reader_params.set("Fields",ic_fields_names[grid_name]);
-        ic_reader_params.set("Filename",ic_pl_grid.get<std::string>("Initial Conditions File"));
+        ic_reader_params.set("Filename",ic_pl_grid.get<std::string>("Filename"));
 
         const auto& field_mgr = it.second;
         AtmosphereInput ic_reader(m_atm_comm,ic_reader_params,field_mgr);
@@ -443,7 +443,7 @@ initialize_fields (const util::TimeStamp& t0)
 
         ekat::ParameterList lat_lon_params;
         lat_lon_params.set("Fields",fnames);
-        lat_lon_params.set("Filename",ic_pl_grid.get<std::string>("Initial Conditions File"));
+        lat_lon_params.set("Filename",ic_pl_grid.get<std::string>("Filename"));
 
         AtmosphereInput lat_lon_reader(m_atm_comm,lat_lon_params);
         lat_lon_reader.init(grid,host_views,layouts);

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -114,7 +114,7 @@ public:
 
 protected:
 
-  void initialize_constant_field(const FieldRequest& freq, const ekat::ParameterList& ic_pl);
+  void initialize_constant_field(const FieldIdentifier& fid, const ekat::ParameterList& ic_pl);
   void register_groups ();
 
   std::map<std::string,field_mgr_ptr>    m_field_mgrs;

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -5,7 +5,7 @@ Debug:
 
 Initial Conditions:
   Point Grid:
-    Initial Conditions File: should_not_be_neeeded_and_code_will_throw_if_it_tries_to_open_this_nonexistent_file.nc
+    Filename: should_not_be_neeeded_and_code_will_throw_if_it_tries_to_open_this_nonexistent_file.nc
     A: 1.0
     B: 2.0
     C: 3.0

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -4,12 +4,13 @@ Debug:
   Atmosphere DAG Verbosity Level: 5
 
 Initial Conditions:
-  Initial Conditions File: should_not_be_neeeded_and_code_will_throw_if_it_tries_to_open_this_nonexistent_file.nc
-  A: 1.0
-  B: 2.0
-  C: 3.0
-  D: [4.0, 5.0]
-  E: "A"
+  Point Grid:
+    Initial Conditions File: should_not_be_neeeded_and_code_will_throw_if_it_tries_to_open_this_nonexistent_file.nc
+    A: 1.0
+    B: 2.0
+    C: 3.0
+    D: [4.0, 5.0]
+    E: "A"
 
 Atmosphere Processes:
   Number of Entries: 3
@@ -17,7 +18,7 @@ Atmosphere Processes:
 
   Process 0:
     Process Name: Dummy
-    Sub Name: A to BC
+    Sub Name: A to Group
     Grid Name: Point Grid
   Process 1:
     Process Name: Dummy

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -451,8 +451,8 @@ TEST_CASE ("recreate_mct_coupling")
     ekat::genRandArray(Q.get_internal_view_data<Host>(),Q_size,engine,pdf);
 
     // Fill import_raw_data with random values
-    for (int i=0; i<ncols*num_cpl_imports; ++i) {
-      import_raw_data[i] = pdf(engine);
+    for (int icol=0; icol<ncols*num_cpl_imports; ++icol) {
+      import_raw_data[icol] = pdf(engine);
     }
 
     // Set all export_raw_data to -1 (might be helpful for debugging)

--- a/components/scream/src/dynamics/homme/CMakeLists.txt
+++ b/components/scream/src/dynamics/homme/CMakeLists.txt
@@ -158,7 +158,7 @@ macro (CreateDynamicsLib HOMME_TARGET NP PLEV QSIZE)
     # target_link_options is supported since 3.13, but there's a bug with static libs until 3.17
     # see https://gitlab.kitware.com/cmake/cmake/-/issues/20022 for details
     if(${CMAKE_VERSION} VERSION_GREATER "3.17.0")
-      target_link_options(${hommeLibName} PRIVATE "${HOMME_LINKER_FLAGS}")
+      target_link_options(${hommeLibName} PUBLIC "${HOMME_LINKER_FLAGS}")
     else ()
       target_link_libraries(${hommeLibName} "${HOMME_LINKER_FLAGS}")
     endif ()

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -724,7 +724,7 @@ void HommeDynamics::import_initial_conditions () {
   using PF = PhysicsFunctions<DefaultDevice>;
 
   const auto dp3d      = get_internal_field("dp3d",dgn).get_view<Pack*****>();
-  const auto ps        = get_internal_field("ps",dgn).get_view<Pack****>();
+  const auto ps        = get_internal_field("ps",dgn).get_view<Real****>();
   const auto v         = get_internal_field("v",dgn).get_view<Pack******>();
   const auto w_i       = get_internal_field("w_i",dgn).get_view<Pack*****>();
   const auto phinh_i   = get_internal_field("phinh_i",dgn).get_view<Pack*****>();

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -27,7 +27,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/util/scream_common_physics_functions.hpp"
 #include "share/util//scream_column_ops.hpp"
-#include "share/field/field_property_checks/field_positivity_check.hpp"
 
 // Ekat includes
 #include "ekat/ekat_assert.hpp"
@@ -315,10 +314,6 @@ void HommeDynamics::initialize_impl (const util::TimeStamp& /* t0 */)
 
   // Complete homme model initialization
   prim_init_model_f90 ();
-
-  // Set positivity check on the tracers
-  // auto positivity_check = std::make_shared<FieldPositivityCheck<Real> >();
-  // get_group_out("Q",m_ref_grid->name()).m_bundle->add_property_check(positivity_check);
 }
 
 void HommeDynamics::run_impl (const Real dt)

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -164,7 +164,7 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
   create_internal_field("FM",{COL,CMP,LEV},{ncols,3,NVL},m_ref_grid->name());
   create_internal_field("FT",{COL,    LEV},{ncols,  NVL},m_ref_grid->name());
 
-  // Dynamics backs out tendencies from the states, and pass those to Homme.
+  // Dynamics backs out tendencies from the states, and passes those to Homme.
   // After Homme completes, we remap the updates state to the ref grid.
   // Thus, is more convenient to use two different remappers: the pd remapper
   // will remap into Homme's forcing views, while the dp remapper will remap
@@ -182,7 +182,6 @@ void HommeDynamics::
 set_updated_group_impl (const FieldGroup<Real>& group)
 {
   const auto& name = group.m_info->m_group_name;
-  // const int ftype = get_homme_param<int>("ftype");
   EKAT_REQUIRE_MSG(name=="tracers",
     "Error! We were not expecting a field group called '" << name << "\n");
 

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -54,12 +54,17 @@ protected:
 #endif
   void homme_pre_process (const Real dt);
   void homme_post_process ();
-  // These are the three main interfaces:
 
 #ifndef KOKKOS_ENABLE_CUDA
   // Cuda requires methods enclosing __device__ lambda's to be public
 protected:
 #endif
+  // Sets the scream-allocated views inside the Homme c++ structures
+  void init_homme_views ();
+
+  // Propagates initial conditions to homme
+  void import_initial_conditions ();
+
   void initialize_impl (const util::TimeStamp& t0);
 protected:
   void run_impl        (const Real dt);
@@ -83,12 +88,6 @@ protected:
 
   // Retrieves an internal field, given field name and grid name.
   Field<Real>& get_internal_field (const std::string& name, const std::string& grid);
-
-  // Sets the scream-allocated views inside the Homme c++ structures
-  void init_homme_views ();
-
-  // Propagates initial conditions to homme
-  void import_initial_conditions ();
 
 
   // Some helper fields. WARNING: only one copy for each internal field!

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -48,9 +48,6 @@ public:
   // Note: field_mgrs[grid_name] is the FM on grid $grid_name
   void register_fields (const std::map<std::string,std::shared_ptr<FieldManager<Real>>>& field_mgrs) const;
 
-  // Dynamics updates 'TRACERS'.
-  void set_updated_group (const FieldGroup<Real>& group);
-
 #ifndef KOKKOS_ENABLE_CUDA
   // Cuda requires methods enclosing __device__ lambda's to be public
 protected:
@@ -68,13 +65,8 @@ protected:
   void run_impl        (const Real dt);
   void finalize_impl   ();
 
-  // Setting the fields in the atmosphere process
-  void set_required_field_impl (const Field<const Real>& f);
-  void set_computed_field_impl (const Field<      Real>& f);
-
-  void create_dyn_field (const std::string& name,
-                         const std::vector<FieldTag>& tags,
-                         const std::vector<int>& dims);
+  // Dynamics updates the "tracers" group, and needs to do some extra checks on the group.
+  void set_updated_group_impl (const FieldGroup<Real>& group);
 
   // Computes total number of bytes needed for local variables
   int requested_buffer_size_in_bytes() const;
@@ -83,17 +75,30 @@ protected:
   // the ATMBufferManager
   void init_buffers(const ATMBufferManager &buffer_manager);
 
-  // Fields on reference and dynamics grid
-  // NOTE: the dyn grid fields are *NOT* in the FieldManager. We still use
-  //       scream Field's (rather than, e.g., raw views) cause we want to use
-  //       the remapper infrastructure to remap from/to ref grid to/from dyn grid.
-  std::map<std::string,field_type>  m_ref_grid_fields;
-  std::map<std::string,field_type>  m_dyn_grid_fields;
+  // Creates an internal field, not to be shared with the AD's FieldManager
+  void create_internal_field (const std::string& name,
+                              const std::vector<FieldTag>& tags,
+                              const std::vector<int>& dims,
+                              const std::string& grid);
+
+  // Retrieves an internal field, given field name and grid name.
+  Field<Real>& get_internal_field (const std::string& name, const std::string& grid);
+
+  // Sets the scream-allocated views inside the Homme c++ structures
+  void init_homme_views ();
+
+  // Propagates initial conditions to homme
+  void import_initial_conditions ();
+
+
+  // Some helper fields. WARNING: only one copy for each internal field!
+  std::map<std::string,field_type>  m_internal_fields;
 
   // Remapper for inputs and outputs, plus a special one for initial conditions
   std::shared_ptr<AbstractRemapper<Real>>   m_p2d_remapper;
   std::shared_ptr<AbstractRemapper<Real>>   m_d2p_remapper;
-  std::shared_ptr<AbstractRemapper<Real>>   m_ic_remapper;
+  std::shared_ptr<AbstractRemapper<Real>>   m_ic_remapper_fwd;
+  std::shared_ptr<AbstractRemapper<Real>>   m_ic_remapper_bwd;
 
   // The dynamics and reference grids
   std::shared_ptr<const AbstractGrid>  m_dyn_grid;

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -7,6 +7,7 @@
 #include "dynamics/homme/homme_dynamics_helpers.hpp"
 
 #include "share/grid/remap/abstract_remapper.hpp"
+#include "share/util/scream_utils.hpp"
 
 #include "ekat/ekat_pack.hpp"
 #include "ekat/ekat_assert.hpp"

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -176,44 +176,54 @@ public:
   reshape (Pointer& p, const Dims& dims) const {
     using uview_nd = Unmanaged<typename KokkosTypes<device_type>::template view_ND<ScalarT,N>>;
 
+    uview_nd ret_view;
+
     switch (dims.size) {
       case 1:
-        return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
-                        dims.dims[0]);
+        ret_view = uview_nd(reinterpret_cast<ScalarT*>(p.get()),
+                            dims.dims[0]);
+        break;
       case 2:
-        return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
-                        dims.dims[0],
-                        dims.dims[1]);
+        ret_view = uview_nd(reinterpret_cast<ScalarT*>(p.get()),
+                            dims.dims[0],
+                            dims.dims[1]);
+        break;
       case 3:
-        return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
-                        dims.dims[0],
-                        dims.dims[1],
-                        dims.dims[2]);
+        ret_view = uview_nd(reinterpret_cast<ScalarT*>(p.get()),
+                            dims.dims[0],
+                            dims.dims[1],
+                            dims.dims[2]);
+        break;
       case 4:
-        return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
-                        dims.dims[0],
-                        dims.dims[1],
-                        dims.dims[2],
-                        dims.dims[3]);
+        ret_view = uview_nd(reinterpret_cast<ScalarT*>(p.get()),
+                            dims.dims[0],
+                            dims.dims[1],
+                            dims.dims[2],
+                            dims.dims[3]);
+        break;
       case 5:
-        return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
-                        dims.dims[0],
-                        dims.dims[1],
-                        dims.dims[2],
-                        dims.dims[3],
-                        dims.dims[4]);
+        ret_view = uview_nd(reinterpret_cast<ScalarT*>(p.get()),
+                            dims.dims[0],
+                            dims.dims[1],
+                            dims.dims[2],
+                            dims.dims[3],
+                            dims.dims[4]);
+        break;
       case 6:
-        return uview_nd(reinterpret_cast<ScalarT*>(p.get()),
-                        dims.dims[0],
-                        dims.dims[1],
-                        dims.dims[2],
-                        dims.dims[3],
-                        dims.dims[4],
-                        dims.dims[5]);
+        ret_view = uview_nd(reinterpret_cast<ScalarT*>(p.get()),
+                            dims.dims[0],
+                            dims.dims[1],
+                            dims.dims[2],
+                            dims.dims[3],
+                            dims.dims[4],
+                            dims.dims[5]);
+        break;
       default:
         EKAT_KERNEL_ERROR_MSG("Error! Unhandled case in switch statement.\n");
 
     }
+
+    return ret_view;
   }
 };
 

--- a/components/scream/src/dynamics/homme/tests/theta-ndays.nl
+++ b/components/scream/src/dynamics/homme/tests/theta-ndays.nl
@@ -7,7 +7,6 @@ test_case              = "jw_baroclinic"
 u_perturb              = 1
 rotate_grid            = 0
 ne                     = ${HOMME_TEST_NE}
-qsize                  = ${HOMME_TEST_QSIZE}
 ndays                  = ${HOMME_TEST_NDAYS}
 statefreq              = 9999
 restartfreq            = 43200

--- a/components/scream/src/dynamics/homme/tests/theta-nmax.nl
+++ b/components/scream/src/dynamics/homme/tests/theta-nmax.nl
@@ -7,7 +7,6 @@ test_case              = "jw_baroclinic"
 u_perturb              = 1
 rotate_grid            = 0
 ne                     = ${HOMME_TEST_NE}
-qsize                  = ${HOMME_TEST_QSIZE}
 nmax                   = ${HOMME_TEST_NMAX}
 statefreq              = 9999
 restartfreq            = 43200

--- a/components/scream/src/physics/cld_fraction/atmosphere_cld_fraction.cpp
+++ b/components/scream/src/physics/cld_fraction/atmosphere_cld_fraction.cpp
@@ -57,8 +57,8 @@ void CldFraction::initialize_impl (const util::TimeStamp& /* t0 */)
 {
   // Set property checks for fields in this process
   auto frac_interval_check = std::make_shared<FieldWithinIntervalCheck<Real> >(0,1);
-  m_fields_out["cldfrac_ice"].add_property_check(frac_interval_check);
-  m_fields_out["cldfrac_tot"].add_property_check(frac_interval_check);
+  get_field_out("cldfrac_ice").add_property_check(frac_interval_check);
+  get_field_out("cldfrac_tot").add_property_check(frac_interval_check);
 }
 
 // =========================================================================================
@@ -66,20 +66,12 @@ void CldFraction::run_impl (const Real dt)
 {
   // Calculate ice cloud fraction and total cloud fraction given the liquid cloud fraction
   // and the ice mass mixing ratio. 
-  auto qi   = m_fields_in["qi"].get_view<const Pack**>();
-  auto liq_cld_frac = m_fields_in["cldfrac_liq"].get_view<const Pack**>();
-  auto ice_cld_frac = m_fields_out["cldfrac_ice"].get_view<Pack**>();
-  auto tot_cld_frac = m_fields_out["cldfrac_tot"].get_view<Pack**>();
+  auto qi   = get_field_in("qi").get_view<const Pack**>();
+  auto liq_cld_frac = get_field_in("cldfrac_liq").get_view<const Pack**>();
+  auto ice_cld_frac = get_field_out("cldfrac_ice").get_view<Pack**>();
+  auto tot_cld_frac = get_field_out("cldfrac_tot").get_view<Pack**>();
 
   CldFractionFunc::main(m_num_cols,m_num_levs,qi,liq_cld_frac,ice_cld_frac,tot_cld_frac);
-
-  // Get a copy of the current timestamp (at the beginning of the step) and
-  // advance it,
-  auto ts = timestamp();
-  ts += dt;
-  for (auto& f : m_fields_out) {
-    f.second.get_header().get_tracking().update_time_stamp(ts);
-  }
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -179,21 +179,21 @@ void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
 }
 
 // =========================================================================================
-void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
+void P3Microphysics::initialize_impl (const util::TimeStamp& /* t0 */)
 {
   // Set property checks for fields in this process
-  auto positivity_check = std::make_shared<FieldPositivityCheck<Real> >();
-  m_fields_out["qv"].add_property_check(positivity_check);
-  m_fields_out["qc"].add_property_check(positivity_check);
-  m_fields_out["qr"].add_property_check(positivity_check);
-  m_fields_out["qi"].add_property_check(positivity_check);
-  m_fields_out["qm"].add_property_check(positivity_check);
-  m_fields_out["nc"].add_property_check(positivity_check);
-  m_fields_out["nr"].add_property_check(positivity_check);
-  m_fields_out["ni"].add_property_check(positivity_check);
-  m_fields_out["bm"].add_property_check(positivity_check);
+  // auto positivity_check = std::make_shared<FieldPositivityCheck<Real> >();
+  // get_field_out("qv").add_property_check(positivity_check);
+  // get_field_out("qc").add_property_check(positivity_check);
+  // get_field_out("qr").add_property_check(positivity_check);
+  // get_field_out("qi").add_property_check(positivity_check);
+  // get_field_out("qm").add_property_check(positivity_check);
+  // get_field_out("nc").add_property_check(positivity_check);
+  // get_field_out("nr").add_property_check(positivity_check);
+  // get_field_out("ni").add_property_check(positivity_check);
+  // get_field_out("bm").add_property_check(positivity_check);
   auto T_interval_check = std::make_shared<FieldWithinIntervalCheck<Real> >(150, 500);
-  m_fields_out["T_mid"].add_property_check(T_interval_check);
+  get_field_out("T_mid").add_property_check(T_interval_check);
   
 
   // Initialize p3
@@ -203,12 +203,11 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   // Note: Some variables in the structures are not stored in the field manager.  For these
   //       variables a local view is constructed.
   const Int nk_pack = ekat::npack<Spack>(m_num_levs);
-  const  auto& pmid           = m_fields_in["p_mid"].get_view<const Pack**>();
-  const  auto& pseudo_density = m_fields_in["pseudo_density"].get_view<const Pack**>();
-  const  auto& T_atm          = m_fields_out["T_mid"].get_view<Pack**>();
-  const  auto& cld_frac_t     = m_fields_in["cldfrac_tot"].get_view<const Pack**>();
-  const  auto& zi             = m_fields_in["z_int"].get_view<const Pack**>();
-  const  auto& qv             = m_fields_out["qv"].get_view<Pack**>();
+  const  auto& pmid           = get_field_in("p_mid").get_view<const Pack**>();
+  const  auto& pseudo_density = get_field_in("pseudo_density").get_view<const Pack**>();
+  const  auto& T_atm          = get_field_out("T_mid").get_view<Pack**>();
+  const  auto& cld_frac_t     = get_field_in("cldfrac_tot").get_view<const Pack**>();
+  const  auto& qv             = get_field_out("qv").get_view<Pack**>();
 
   // Alias local variables from temporary buffer
   auto inv_exner  = m_buffer.inv_exner;
@@ -222,26 +221,26 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   p3_preproc.set_variables(m_num_cols,nk_pack,pmid,pseudo_density,T_atm,cld_frac_t,qv,
                         inv_exner, th_atm, cld_frac_l, cld_frac_i, cld_frac_r, dz);
   // --Prognostic State Variables:
-  prog_state.qc     = m_fields_out["qc"].get_view<Pack**>();
-  prog_state.nc     = m_fields_out["nc"].get_view<Pack**>();
-  prog_state.qr     = m_fields_out["qr"].get_view<Pack**>();
-  prog_state.nr     = m_fields_out["nr"].get_view<Pack**>();
-  prog_state.qi     = m_fields_out["qi"].get_view<Pack**>();
-  prog_state.qm     = m_fields_out["qm"].get_view<Pack**>();
-  prog_state.ni     = m_fields_out["ni"].get_view<Pack**>();
-  prog_state.bm     = m_fields_out["bm"].get_view<Pack**>();
+  prog_state.qc     = get_field_out("qc").get_view<Pack**>();
+  prog_state.nc     = get_field_out("nc").get_view<Pack**>();
+  prog_state.qr     = get_field_out("qr").get_view<Pack**>();
+  prog_state.nr     = get_field_out("nr").get_view<Pack**>();
+  prog_state.qi     = get_field_out("qi").get_view<Pack**>();
+  prog_state.qm     = get_field_out("qm").get_view<Pack**>();
+  prog_state.ni     = get_field_out("ni").get_view<Pack**>();
+  prog_state.bm     = get_field_out("bm").get_view<Pack**>();
   prog_state.th     = p3_preproc.th_atm;
   prog_state.qv     = p3_preproc.qv;
   // --Diagnostic Input Variables:
-  diag_inputs.nc_nuceat_tend  = m_fields_in["nc_nuceat_tend"].get_view<const Pack**>();
-  diag_inputs.nccn            = m_fields_in["nc_activated"].get_view<const Pack**>();
-  diag_inputs.ni_activated    = m_fields_in["ni_activated"].get_view<const Pack**>();
-  diag_inputs.inv_qc_relvar   = m_fields_in["inv_qc_relvar"].get_view<const Pack**>();
-  diag_inputs.pres            = m_fields_in["p_mid"].get_view<const Pack**>();
+  diag_inputs.nc_nuceat_tend  = get_field_in("nc_nuceat_tend").get_view<const Pack**>();
+  diag_inputs.nccn            = get_field_in("nc_activated").get_view<const Pack**>();
+  diag_inputs.ni_activated    = get_field_in("ni_activated").get_view<const Pack**>();
+  diag_inputs.inv_qc_relvar   = get_field_in("inv_qc_relvar").get_view<const Pack**>();
+  diag_inputs.pres            = get_field_in("p_mid").get_view<const Pack**>();
   diag_inputs.dpres           = p3_preproc.pseudo_density;
-  auto qv_prev                = m_fields_out["qv_prev_micro_step"].get_view<Pack**>();
+  auto qv_prev                = get_field_out("qv_prev_micro_step").get_view<Pack**>();
   diag_inputs.qv_prev         = qv_prev;
-  auto t_prev                 = m_fields_out["T_prev_micro_step"].get_view<Pack**>();
+  auto t_prev                 = get_field_out("T_prev_micro_step").get_view<Pack**>();
   diag_inputs.t_prev          = t_prev;
   diag_inputs.cld_frac_l      = p3_preproc.cld_frac_l;
   diag_inputs.cld_frac_i      = p3_preproc.cld_frac_i;
@@ -249,10 +248,10 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   diag_inputs.dz              = p3_preproc.dz;
   diag_inputs.inv_exner       = p3_preproc.inv_exner;
   // --Diagnostic Outputs
-  diag_outputs.diag_eff_radius_qc = m_fields_out["eff_radius_qc"].get_view<Pack**>();
-  diag_outputs.diag_eff_radius_qi = m_fields_out["eff_radius_qi"].get_view<Pack**>();
+  diag_outputs.diag_eff_radius_qc = get_field_out("eff_radius_qc").get_view<Pack**>();
+  diag_outputs.diag_eff_radius_qi = get_field_out("eff_radius_qi").get_view<Pack**>();
 
-  diag_outputs.precip_liq_surf  = m_fields_out["precip_liq_surf"].get_view<Real*>();
+  diag_outputs.precip_liq_surf  = get_field_out("precip_liq_surf").get_view<Real*>();
   diag_outputs.precip_ice_surf  = m_buffer.precip_ice_surf;
   diag_outputs.qv2qi_depos_tend = m_buffer.qv2qi_depos_tend;
   diag_outputs.rho_qi           = m_buffer.rho_qi;
@@ -269,9 +268,9 @@ void P3Microphysics::initialize_impl (const util::TimeStamp& t0)
   infrastructure.prescribedCCN = true; // Hard-coded for now, TODO: make this a runtime option
   infrastructure.col_location = m_buffer.col_location; // TODO: Initialize this here and now when P3 has access to lat/lon for each column.
   // --History Only
-  history_only.liq_ice_exchange = m_fields_out["micro_liq_ice_exchange"].get_view<Pack**>();
-  history_only.vap_liq_exchange = m_fields_out["micro_vap_liq_exchange"].get_view<Pack**>();
-  history_only.vap_ice_exchange = m_fields_out["micro_vap_ice_exchange"].get_view<Pack**>();
+  history_only.liq_ice_exchange = get_field_out("micro_liq_ice_exchange").get_view<Pack**>();
+  history_only.vap_liq_exchange = get_field_out("micro_vap_liq_exchange").get_view<Pack**>();
+  history_only.vap_ice_exchange = get_field_out("micro_vap_ice_exchange").get_view<Pack**>();
   // -- Set values for the post-amble structure
   p3_postproc.set_variables(m_num_cols,nk_pack,prog_state.th,pmid,T_atm,t_prev,prog_state.qv,qv_prev,
       diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi);
@@ -310,15 +309,6 @@ void P3Microphysics::run_impl (const Real dt)
     p3_postproc
   ); // Kokkos::parallel_for(p3_main_local_vals)
   Kokkos::fence();
-
-  // Get a copy of the current timestamp (at the beginning of the step) and
-  // advance it, updating the p3 fields.
-  auto ts = timestamp();
-  ts += dt;
-  for (auto& f : m_fields_out) {
-    f.second.get_header().get_tracking().update_time_stamp(ts);
-  }
-
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -2,12 +2,12 @@
 set(YAKL_CXX_FLAGS "")
 if (CUDA_BUILD)
     set(YAKL_ARCH "CUDA")
-    set(YAKL_CXX_FLAGS "-DYAKL_ARCH_CUDA --expt-extended-lambda --expt-relaxed-constexpr ${YAKL_CXX_FLAGS}")
+    list(APPEND YAKL_CXX_FLAGS -DYAKL_ARCH_CUDA --expt-extended-lambda --expt-relaxed-constexpr)
 endif()
 
 # RRTMGP++ requires YAKL
-add_subdirectory(${SCREAM_BASE_DIR}/../../externals/YAKL ${CMAKE_CURRENT_BINARY_DIR}/YAKL_build)
-target_compile_options(yakl PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-fno-default-real-8 -fno-default-double-8>)
+add_subdirectory(${SCREAM_BASE_DIR}/../../externals/YAKL ${CMAKE_BINARY_DIR}/externals/YAKL)
+target_compile_options(yakl PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${YAKL_CXX_FLAGS}>)
 EkatDisableAllWarning(yakl)
 
 # We will need the shr_orb_mod source too; this builds library share_util
@@ -15,7 +15,6 @@ add_subdirectory(share ${CMAKE_CURRENT_BINARY_DIR}/share_util)
 
 # Build RRTMGP library; this builds the core RRTMGP external source as a library named "rrtmgp"
 # NOTE: The external RRTMGP build needs some fixes to work with CUDA in a library build, so for now we will build these ourselves
-#add_subdirectory(${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp ${CMAKE_CURRENT_BINARY_DIR}/rrtmgp_build)
 set(EXTERNAL_SRC
   ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp
   ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/rrtmgp/mo_rrtmgp_constants.cpp
@@ -27,8 +26,7 @@ set(EXTERNAL_SRC
 )
 add_library(rrtmgp ${EXTERNAL_SRC})
 EkatDisableAllWarning(rrtmgp)
-target_link_libraries(rrtmgp yakl)
-target_compile_options(rrtmgp PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${YAKL_CXX_FLAGS}>)
+target_link_libraries(rrtmgp PUBLIC yakl)
 target_include_directories(rrtmgp PUBLIC 
     ${SCREAM_BASE_DIR}/../../externals/YAKL
     ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp
@@ -52,11 +50,9 @@ set(INTERFACE_SRC
   tests/rrtmgp_test_utils.cpp
 )
 add_library(scream_rrtmgp ${INTERFACE_SRC})
-target_compile_options(scream_rrtmgp PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${YAKL_CXX_FLAGS}>)
 find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATHS}/lib)
-target_link_libraries(scream_rrtmgp ${NETCDF_C} rrtmgp yakl scream_share physics_share share_util)
+target_link_libraries(scream_rrtmgp PUBLIC ${NETCDF_C} rrtmgp yakl scream_share physics_share share_util)
 target_include_directories(scream_rrtmgp SYSTEM PUBLIC ${NetCDF_C_PATHS}/include)
-target_include_directories(scream_rrtmgp PUBLIC ${SCREAM_INCLUDE_DIRS})
 target_include_directories(scream_rrtmgp SYSTEM PUBLIC ${SCREAM_BASE_DIR}/../../externals)
 target_include_directories(scream_rrtmgp SYSTEM PUBLIC ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external)
 

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -216,26 +216,26 @@ void RRTMGPRadiation::run_impl (const Real dt) {
   Kokkos::deep_copy(h_lon,m_lon);
 
   // Get data from the FieldManager
-  auto d_pmid = m_fields_in.at("p_mid").get_view<const Real**>();
-  auto d_pint = m_fields_in.at("p_int").get_view<const Real**>();
-  auto d_pdel = m_fields_in.at("pseudo_density").get_view<const Real**>();
-  auto d_tint = m_fields_in.at("t_int").get_view<const Real**>();
-  auto d_sfc_alb_dir_vis = m_fields_in.at("sfc_alb_dir_vis").get_view<const Real*>();
-  auto d_sfc_alb_dir_nir = m_fields_in.at("sfc_alb_dir_nir").get_view<const Real*>();
-  auto d_sfc_alb_dif_vis = m_fields_in.at("sfc_alb_dif_vis").get_view<const Real*>();
-  auto d_sfc_alb_dif_nir = m_fields_in.at("sfc_alb_dif_nir").get_view<const Real*>();
-  auto d_qv = m_fields_in.at("qv").get_view<const Real**>();
-  auto d_qc = m_fields_in.at("qc").get_view<const Real**>();
-  auto d_qi = m_fields_in.at("qi").get_view<const Real**>();
-  auto d_cldfrac_tot = m_fields_in.at("cldfrac_tot").get_view<const Real**>();
-  auto d_rel = m_fields_in.at("eff_radius_qc").get_view<const Real**>();
-  auto d_rei = m_fields_in.at("eff_radius_qi").get_view<const Real**>();
-  auto d_tmid = m_fields_out.at("T_mid").get_view<Real**>();
-  auto d_sw_flux_up = m_fields_out.at("SW_flux_up").get_view<Real**>();
-  auto d_sw_flux_dn = m_fields_out.at("SW_flux_dn").get_view<Real**>();
-  auto d_sw_flux_dn_dir = m_fields_out.at("SW_flux_dn_dir").get_view<Real**>();
-  auto d_lw_flux_up = m_fields_out.at("LW_flux_up").get_view<Real**>();
-  auto d_lw_flux_dn = m_fields_out.at("LW_flux_dn").get_view<Real**>();
+  auto d_pmid = get_field_in("p_mid").get_view<const Real**>();
+  auto d_pint = get_field_in("p_int").get_view<const Real**>();
+  auto d_pdel = get_field_in("pseudo_density").get_view<const Real**>();
+  auto d_tint = get_field_in("t_int").get_view<const Real**>();
+  auto d_sfc_alb_dir_vis = get_field_in("sfc_alb_dir_vis").get_view<const Real*>();
+  auto d_sfc_alb_dir_nir = get_field_in("sfc_alb_dir_nir").get_view<const Real*>();
+  auto d_sfc_alb_dif_vis = get_field_in("sfc_alb_dif_vis").get_view<const Real*>();
+  auto d_sfc_alb_dif_nir = get_field_in("sfc_alb_dif_nir").get_view<const Real*>();
+  auto d_qv = get_field_in("qv").get_view<const Real**>();
+  auto d_qc = get_field_in("qc").get_view<const Real**>();
+  auto d_qi = get_field_in("qi").get_view<const Real**>();
+  auto d_cldfrac_tot = get_field_in("cldfrac_tot").get_view<const Real**>();
+  auto d_rel = get_field_in("eff_radius_qc").get_view<const Real**>();
+  auto d_rei = get_field_in("eff_radius_qi").get_view<const Real**>();
+  auto d_tmid = get_field_out("T_mid").get_view<Real**>();
+  auto d_sw_flux_up = get_field_out("SW_flux_up").get_view<Real**>();
+  auto d_sw_flux_dn = get_field_out("SW_flux_dn").get_view<Real**>();
+  auto d_sw_flux_dn_dir = get_field_out("SW_flux_dn_dir").get_view<Real**>();
+  auto d_lw_flux_up = get_field_out("LW_flux_up").get_view<Real**>();
+  auto d_lw_flux_dn = get_field_out("LW_flux_dn").get_view<Real**>();
 
   // Create YAKL arrays. RRTMGP expects YAKL arrays with styleFortran, i.e., data has ncol
   // as the fastest index. For this reason we must copy the data.
@@ -300,6 +300,7 @@ void RRTMGPRadiation::run_impl (const Real dt) {
     const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int i = team.league_rank();
+
       mu0(i+1) = d_mu0(i);
       sfc_alb_dir_vis(i+1) = d_sfc_alb_dir_vis(i);
       sfc_alb_dir_nir(i+1) = d_sfc_alb_dir_nir(i);
@@ -330,7 +331,7 @@ void RRTMGPRadiation::run_impl (const Real dt) {
   for (int igas = 0; igas < m_ngas; igas++) {
     auto name = m_gas_names[igas];
     auto fm_name = name=="h2o" ? "qv" : name;
-    auto d_temp  = m_fields_in.at(fm_name).get_view<const Real**>();
+    auto d_temp  = get_field_in(fm_name).get_view<const Real**>();
     const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_nlay, m_ncol);
     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int k = team.league_rank();

--- a/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
@@ -1,12 +1,5 @@
 include(ScreamUtils)
 
-# Set flags needed for YAKL
-set(YAKL_CXX_FLAGS "")
-if (CUDA_BUILD)
-    set(YAKL_ARCH "CUDA")
-    list(APPEND YAKL_CXX_FLAGS -DYAKL_ARCH_CUDA --expt-extended-lambda --expt-relaxed-constexpr)
-endif()
-
 # Required libraries
 set (NEED_LIBS scream_rrtmgp)
 
@@ -18,18 +11,15 @@ if (NOT ${SCREAM_BASELINES_ONLY})
         EXE_ARGS "${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc"
         EXCLUDE_MAIN_CPP
     )
-    target_compile_options(rrtmgp_tests PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${YAKL_CXX_FLAGS}>)
     set (SRC rrtmgp_unit_tests.cpp rrtmgp_test_utils.cpp)
     CreateUnitTest(
         rrtmgp_unit_tests "${SRC}" "${NEED_LIBS}" LABELS "rrtmgp;physics"
     )
-    target_compile_options(rrtmgp_unit_tests PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${YAKL_CXX_FLAGS}>)
 endif()
 
 # Build baseline code
 set (GEN_BASELINE_SRC generate_baseline.cpp rrtmgp_test_utils.cpp)
 add_executable(generate_baseline "${GEN_BASELINE_SRC}")
-target_compile_options(generate_baseline PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${YAKL_CXX_FLAGS}>)
 target_link_libraries(generate_baseline ${NEED_LIBS})
 
 # Copy RRTMGP absorption coefficient lookup tables to local data directory

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -347,11 +347,7 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& /* t0 */)
   auto T_interval_check = std::make_shared<FieldWithinIntervalCheck<Real> >(150, 500);
   auto positivity_check = std::make_shared<FieldPositivityCheck<Real> >();
   get_field_out("T_mid").add_property_check(T_interval_check);
-  // get_field_out("qv").add_property_check(positivity_check);
-  // get_field_out("qc").add_property_check(positivity_check);
   get_field_out("tke").add_property_check(positivity_check);
-  // get_group_out("tracers").m_bundle->add_property_check(positivity_check);
-
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -101,7 +101,7 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
 // =========================================================================================
 void SHOCMacrophysics::
-set_updated_group (const FieldGroup<Real>& group)
+set_updated_group_impl (const FieldGroup<Real>& group)
 {
   EKAT_REQUIRE_MSG(group.m_info->size() >= 3,
                    "Error! Shoc requires at least 3 tracers (tke, qv, qc) as inputs.");
@@ -113,10 +113,6 @@ set_updated_group (const FieldGroup<Real>& group)
 
   EKAT_REQUIRE_MSG(group.m_info->m_bundled,
       "Error! Shoc expects bundled fields for tracers.\n");
-
-  // Add Q bundle as in/out field
-  m_fields_in["Q"]  = *group.m_bundle;
-  m_fields_out["Q"] = *group.m_bundle;
 
   // Calculate number of advected tracers
   m_num_tracers = group.m_info->size();
@@ -243,27 +239,27 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
 }
 
 // =========================================================================================
-void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
+void SHOCMacrophysics::initialize_impl (const util::TimeStamp& /* t0 */)
 {
   // Initialize all of the structures that are passed to shoc_main in run_impl.
   // Note: Some variables in the structures are not stored in the field manager.  For these
   //       variables a local view is constructed.
-  const auto& T_mid            = m_fields_out["T_mid"].get_view<Spack**>();
-  const auto& z_int            = m_fields_in["z_int"].get_view<const Spack**>();
-  const auto& z_mid            = m_fields_in["z_mid"].get_view<const Spack**>();
-  const auto& p_mid            = m_fields_in["p_mid"].get_view<const Spack**>();
-  const auto& pseudo_density   = m_fields_in["pseudo_density"].get_view<const Spack**>();
-  const auto& omega            = m_fields_in["omega"].get_view<const Spack**>();
-  const auto& surf_sens_flux   = m_fields_in["surf_sens_flux"].get_view<const Real*>();
-  const auto& surf_latent_flux = m_fields_in["surf_latent_flux"].get_view<const Real*>();
-  const auto& surf_mom_flux    = m_fields_in["surf_mom_flux"].get_view<const Real**>();
-  const auto& qc               = m_fields_out["qc"].get_view<Spack**>();
-  const auto& qv               = m_fields_out["qv"].get_view<Spack**>();
-  const auto& tke              = m_fields_out["tke"].get_view<Spack**>();
-  const auto& cldfrac_liq      = m_fields_out["cldfrac_liq"].get_view<Spack**>();
-  const auto& sgs_buoy_flux    = m_fields_out["sgs_buoy_flux"].get_view<Spack**>();
-  const auto& inv_qc_relvar    = m_fields_out["inv_qc_relvar"].get_view<Spack**>();
-  const auto& phis             = m_fields_in["phis"].get_view<const Real*>();
+  const auto& T_mid            = get_field_out("T_mid").get_view<Spack**>();
+  const auto& z_int            = get_field_in("z_int").get_view<const Spack**>();
+  const auto& z_mid            = get_field_in("z_mid").get_view<const Spack**>();
+  const auto& p_mid            = get_field_in("p_mid").get_view<const Spack**>();
+  const auto& pseudo_density   = get_field_in("pseudo_density").get_view<const Spack**>();
+  const auto& omega            = get_field_in("omega").get_view<const Spack**>();
+  const auto& surf_sens_flux   = get_field_in("surf_sens_flux").get_view<const Real*>();
+  const auto& surf_latent_flux = get_field_in("surf_latent_flux").get_view<const Real*>();
+  const auto& surf_mom_flux    = get_field_in("surf_mom_flux").get_view<const Real**>();
+  const auto& qc               = get_field_out("qc").get_view<Spack**>();
+  const auto& qv               = get_field_out("qv").get_view<Spack**>();
+  const auto& tke              = get_field_out("tke").get_view<Spack**>();
+  const auto& cldfrac_liq      = get_field_out("cldfrac_liq").get_view<Spack**>();
+  const auto& sgs_buoy_flux    = get_field_out("sgs_buoy_flux").get_view<Spack**>();
+  const auto& inv_qc_relvar    = get_field_out("inv_qc_relvar").get_view<Spack**>();
+  const auto& phis             = get_field_in("phis").get_view<const Real*>();
 
   // Alias local variables from temporary buffer
   auto cell_length = m_buffer.cell_length;
@@ -298,7 +294,7 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   input.zt_grid     = shoc_preprocess.zt_grid;
   input.zi_grid     = shoc_preprocess.zi_grid;
   input.pres        = p_mid;
-  input.presi       = m_fields_in["p_int"].get_view<const Spack**>();
+  input.presi       = get_field_in("p_int").get_view<const Spack**>();
   input.pdel        = pseudo_density;
   input.thv         = shoc_preprocess.thv;
   input.w_field     = shoc_preprocess.wm_zt;
@@ -315,15 +311,15 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   input_output.tke          = shoc_preprocess.tke_copy;
   input_output.thetal       = shoc_preprocess.thlm;
   input_output.qw           = shoc_preprocess.qw;
-  input_output.horiz_wind   = m_fields_out["horiz_winds"].get_view<Spack***>();
+  input_output.horiz_wind   = get_field_out("horiz_winds").get_view<Spack***>();
   input_output.wthv_sec     = sgs_buoy_flux;
-  input_output.qtracers     = m_fields_out["Q"].get_view<Spack***>();
-  input_output.tk           = m_fields_out["eddy_diff_mom"].get_view<Spack**>();
+  input_output.qtracers     = get_group_out("tracers").m_bundle->get_view<Spack***>();
+  input_output.tk           = get_field_out("eddy_diff_mom").get_view<Spack**>();
   input_output.shoc_cldfrac = cldfrac_liq;
   input_output.shoc_ql      = qc;
 
   // Output Variables
-  output.pblh     = m_fields_out["pbl_height"].get_view<Real*>();
+  output.pblh     = get_field_out("pbl_height").get_view<Real*>();
   output.shoc_ql2 = shoc_ql2;
 
   // Ouput (diagnostic)
@@ -350,11 +346,11 @@ void SHOCMacrophysics::initialize_impl (const util::TimeStamp& t0)
   // Set field property checks for the fields in this process
   auto T_interval_check = std::make_shared<FieldWithinIntervalCheck<Real> >(150, 500);
   auto positivity_check = std::make_shared<FieldPositivityCheck<Real> >();
-  m_fields_out["T_mid"].add_property_check(T_interval_check);
-  m_fields_out["qv"].add_property_check(positivity_check);
-  m_fields_out["qc"].add_property_check(positivity_check);
-  m_fields_out["tke"].add_property_check(positivity_check);
-  m_fields_out["Q"].add_property_check(positivity_check);
+  get_field_out("T_mid").add_property_check(T_interval_check);
+  // get_field_out("qv").add_property_check(positivity_check);
+  // get_field_out("qc").add_property_check(positivity_check);
+  get_field_out("tke").add_property_check(positivity_check);
+  // get_group_out("tracers").m_bundle->add_property_check(positivity_check);
 
 }
 
@@ -373,7 +369,7 @@ void SHOCMacrophysics::run_impl (const Real dt)
 
 
   // Calculate maximum number of levels in pbl from surface
-  const auto pref_mid = m_fields_in["pref_mid"].get_view<const Spack*>();
+  const auto pref_mid = get_field_in("pref_mid").get_view<const Spack*>();
   const int ntop_shoc = 0;
   const int nbot_shoc = m_num_levs;
   m_npbl = SHF::shoc_init(nbot_shoc,ntop_shoc,pref_mid);
@@ -398,15 +394,6 @@ void SHOCMacrophysics::run_impl (const Real dt)
                        policy,
                        shoc_postprocess);
   Kokkos::fence();
-
-  // Get a copy of the current timestamp (at the beginning of the step) and
-  // advance it, updating the shoc fields.
-  auto ts = timestamp();
-  ts += dt;
-  //Q->get_header().get_tracking().update_time_stamp(ts);
-  for (auto& f : m_fields_out) {
-    f.second.get_header().get_tracking().update_time_stamp(ts);
-  }
 }
 // =========================================================================================
 void SHOCMacrophysics::finalize_impl()

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -74,9 +74,6 @@ public:
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
-  // SHOC updates the 'TRACERS' group.
-  void set_updated_group (const FieldGroup<Real>& group);
-
   /*--------------------------------------------------------------------------------------------*/
   // Most individual processes have a pre-processing step that constructs needed variables from
   // the set of fields stored in the field manager.  A structure like this defines those operations,
@@ -404,6 +401,9 @@ protected:
   void initialize_impl (const util::TimeStamp& t0);
   void run_impl        (const Real dt);
   void finalize_impl   ();
+
+  // SHOC updates the 'tracers' group.
+  void set_updated_group_impl (const FieldGroup<Real>& group);
 
   // Computes total number of bytes needed for local variables
   int requested_buffer_size_in_bytes() const;

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -110,7 +110,6 @@ void SPA::init_buffers(const ATMBufferManager &buffer_manager)
 
   // 2d packed views
   const Int num_mid_packs    = ekat::npack<Spack>(m_num_levs);
-  const Int num_int_packs = ekat::npack<Spack>(m_num_levs+1);
 
   m_buffer.p_mid_src = decltype(m_buffer.p_mid_src)(s_mem, m_num_cols, num_mid_packs);
   s_mem += m_buffer.p_mid_src.size();
@@ -144,7 +143,7 @@ void SPA::initialize_impl (const util::TimeStamp& /* t0 */)
 }
 
 // =========================================================================================
-void SPA::run_impl (const Real dt)
+void SPA::run_impl (const Real /* dt */)
 {
   /* Gather time and state information for interpolation */
   auto ts = timestamp();
@@ -158,12 +157,6 @@ void SPA::run_impl (const Real dt)
 
   // Call the main SPA routine to get interpolated aerosol forcings.
   SPAFunc::spa_main(SPATimeState, SPAPressureState,SPAData_start,SPAData_end,SPAData_out,m_num_cols,m_num_levs,m_nswbands,m_nlwbands);
-
-  // Advance current timestamp.
-  ts += dt;
-  for (auto& f : m_fields_out) {
-    f.second.get_header().get_tracking().update_time_stamp(ts);
-  }
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol_hack.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol_hack.cpp
@@ -10,31 +10,31 @@ void SPA::initialize_spa_impl ()
 {
   SPAPressureState.ncols         = m_num_cols;
   SPAPressureState.nlevs         = m_num_levs;
-  SPAPressureState.hyam          = m_fields_in["hyam"].get_view<const Pack*>();
-  SPAPressureState.hybm          = m_fields_in["hybm"].get_view<const Pack*>();
-  SPAPressureState.ps_this_month = m_fields_in["PS_beg"].get_view<const Real*>();
-  SPAPressureState.ps_next_month = m_fields_in["PS_end"].get_view<const Real*>();
-  SPAPressureState.pmid          = m_fields_in["p_mid"].get_view<const Pack**>();
+  SPAPressureState.hyam          = get_field_in("hyam").get_view<const Pack*>();
+  SPAPressureState.hybm          = get_field_in("hybm").get_view<const Pack*>();
+  SPAPressureState.ps_this_month = get_field_in("PS_beg").get_view<const Real*>();
+  SPAPressureState.ps_next_month = get_field_in("PS_end").get_view<const Real*>();
+  SPAPressureState.pmid          = get_field_in("p_mid").get_view<const Pack**>();
 
-  SPAData_start.CCN3             = m_fields_in["CCN3_beg"].get_view<const Pack**>();
-  SPAData_end.CCN3               = m_fields_in["CCN3_end"].get_view<const Pack**>();
-  SPAData_out.CCN3               = m_fields_out["nc_activated"].get_view<Pack**>();
+  SPAData_start.CCN3             = get_field_in("CCN3_beg").get_view<const Pack**>();
+  SPAData_end.CCN3               = get_field_in("CCN3_end").get_view<const Pack**>();
+  SPAData_out.CCN3               = get_field_out("nc_activated").get_view<Pack**>();
 
-  SPAData_start.AER_G_SW         = m_fields_in["AER_G_SW_beg"].get_view<const Pack***>();
-  SPAData_end.AER_G_SW           = m_fields_in["AER_G_SW_end"].get_view<const Pack***>();
-  SPAData_out.AER_G_SW           = m_fields_out["aero_g_sw"].get_view<Pack***>();
+  SPAData_start.AER_G_SW         = get_field_in("AER_G_SW_beg").get_view<const Pack***>();
+  SPAData_end.AER_G_SW           = get_field_in("AER_G_SW_end").get_view<const Pack***>();
+  SPAData_out.AER_G_SW           = get_field_out("aero_g_sw").get_view<Pack***>();
 
-  SPAData_start.AER_SSA_SW       = m_fields_in["AER_SSA_SW_beg"].get_view<const Pack***>();
-  SPAData_end.AER_SSA_SW         = m_fields_in["AER_SSA_SW_end"].get_view<const Pack***>();
-  SPAData_out.AER_SSA_SW         = m_fields_out["aero_ssa_sw"].get_view<Pack***>();
+  SPAData_start.AER_SSA_SW       = get_field_in("AER_SSA_SW_beg").get_view<const Pack***>();
+  SPAData_end.AER_SSA_SW         = get_field_in("AER_SSA_SW_end").get_view<const Pack***>();
+  SPAData_out.AER_SSA_SW         = get_field_out("aero_ssa_sw").get_view<Pack***>();
 
-  SPAData_start.AER_TAU_SW       = m_fields_in["AER_TAU_SW_beg"].get_view<const Pack***>();
-  SPAData_end.AER_TAU_SW         = m_fields_in["AER_TAU_SW_end"].get_view<const Pack***>();
-  SPAData_out.AER_TAU_SW         = m_fields_out["aero_tau_sw"].get_view<Pack***>();
+  SPAData_start.AER_TAU_SW       = get_field_in("AER_TAU_SW_beg").get_view<const Pack***>();
+  SPAData_end.AER_TAU_SW         = get_field_in("AER_TAU_SW_end").get_view<const Pack***>();
+  SPAData_out.AER_TAU_SW         = get_field_out("aero_tau_sw").get_view<Pack***>();
 
-  SPAData_start.AER_TAU_LW       = m_fields_in["AER_TAU_LW_beg"].get_view<const Pack***>();
-  SPAData_end.AER_TAU_LW         = m_fields_in["AER_TAU_LW_end"].get_view<const Pack***>();
-  SPAData_out.AER_TAU_LW         = m_fields_out["aero_tau_lw"].get_view<Pack***>();
+  SPAData_start.AER_TAU_LW       = get_field_in("AER_TAU_LW_beg").get_view<const Pack***>();
+  SPAData_end.AER_TAU_LW         = get_field_in("AER_TAU_LW_end").get_view<const Pack***>();
+  SPAData_out.AER_TAU_LW         = get_field_out("aero_tau_lw").get_view<Pack***>();
 }
 
-}
+} // namespace scream

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -5,8 +5,8 @@
 #include "ekat/kokkos/ekat_subview_utils.hpp"
 #include "ekat/util/ekat_lin_interp.hpp"
 
-/*-----------------------------------------------------------------*/
-/* The main SPA routines used to convert SPA data into a format that
+/*-----------------------------------------------------------------
+ * The main SPA routines used to convert SPA data into a format that
  * is usable by the rest of the atmosphere processes.
  *
  * SPA or Simple Prescribed Aerosols provides a way to prescribe
@@ -52,7 +52,7 @@
  * that are used in EAM to construct the physics pressure profiles.
  * The SPA data is then projected onto the simulation pressure profile (pmid)
  * using EKAT linear interpolation. 
-/*-----------------------------------------------------------------*/
+-----------------------------------------------------------------*/
 
 namespace scream {
 namespace spa {

--- a/components/scream/src/share/CMakeLists.txt
+++ b/components/scream/src/share/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SHARE_SRC
   scream_config.cpp
   scream_session.cpp
+  atm_process/atmosphere_process.cpp
   atm_process/atmosphere_process_group.cpp
   atm_process/atmosphere_process_dag.cpp
   field/field_alloc_prop.cpp

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -1,0 +1,534 @@
+#include "share/atm_process/atmosphere_process.hpp"
+
+#include "ekat/ekat_assert.hpp"
+
+#include <set>
+#include <stdexcept>
+
+namespace scream
+{
+
+void AtmosphereProcess::initialize (const TimeStamp& t0) {
+  set_fields_and_groups_pointers();
+  m_time_stamp = t0;
+  initialize_impl(m_time_stamp);
+}
+
+void AtmosphereProcess::run (const Real dt) {
+  // Make sure required fields are valid
+  check_required_fields();
+
+  // Let the derived class do the actual run
+  run_impl(dt);
+
+  // Make sure computed fields are valid
+  check_computed_fields();
+
+  // Update all output fields time stamps
+  m_time_stamp += dt;
+  update_time_stamps ();
+}
+
+void AtmosphereProcess::finalize (/* what inputs? */) {
+  finalize_impl(/* what inputs? */);
+}
+
+void AtmosphereProcess::set_required_field (const Field<const Real>& f) {
+  // Sanity check
+  EKAT_REQUIRE_MSG (requires_field(f.get_header().get_identifier()),
+    "Error! Input field is not required by this atm process.\n"
+    "    field id: " + f.get_header().get_identifier().get_id_string() + "\n"
+    "    atm process: " + this->name() + "\n"
+    "Something is wrong up the call stack. Please, contact developers.\n");
+
+  if (not ekat::contains(m_fields_in,f)) {
+    m_fields_in.emplace_back(f);
+  }
+
+  // AtmosphereProcessGroup is just a "container" of *real* atm processes,
+  // so don't add me as customer if I'm an atm proc group.
+  if (this->type()!=AtmosphereProcessType::Group) {
+    // Add myself as customer to the field
+    add_me_as_customer(f);
+  }
+
+  set_required_field_impl (f);
+}
+
+void AtmosphereProcess::set_computed_field (const Field<Real>& f) {
+  // Sanity check
+  EKAT_REQUIRE_MSG (computes_field(f.get_header().get_identifier()),
+    "Error! Input field is not computed by this atm process.\n"
+    "   field id: " + f.get_header().get_identifier().get_id_string() + "\n"
+    "   atm process: " + this->name() + "\n"
+    "Something is wrong up the call stack. Please, contact developers.\n");
+
+  if (not ekat::contains(m_fields_out,f)) {
+    m_fields_out.emplace_back(f);
+  }
+
+  // AtmosphereProcessGroup is just a "container" of *real* atm processes,
+  // so don't add me as provider if I'm an atm proc group.
+  if (this->type()!=AtmosphereProcessType::Group) {
+    // Add myself as provider for the field
+    add_me_as_provider(f);
+  }
+
+  set_computed_field_impl (f);
+}
+
+void AtmosphereProcess::set_required_group (const FieldGroup<const Real>& group) {
+  // Sanity check
+  EKAT_REQUIRE_MSG (requires_group(group.m_info->m_group_name,group.grid_name()),
+    "Error! This atmosphere process does not require the input group.\n"
+    "   group name: " + group.m_info->m_group_name + "\n"
+    "   grid name : " + group.grid_name() + "\n"
+    "   atm process: " + this->name() + "\n"
+    "Something is wrong up the call stack. Please, contact developers.\n");
+
+  if (not ekat::contains(m_groups_in,group)) {
+    m_groups_in.emplace_back(group);
+    // AtmosphereProcessGroup is just a "container" of *real* atm processes,
+    // so don't add me as customer if I'm an atm proc group.
+    if (this->type()!=AtmosphereProcessType::Group) {
+      if (group.m_bundle) {
+        add_me_as_customer(*group.m_bundle);
+      } else {
+        for (auto& it : group.m_fields) {
+          add_me_as_customer(*it.second);
+        }
+      }
+    }
+  }
+
+  set_required_group_impl(group);
+}
+
+void AtmosphereProcess::set_updated_group (const FieldGroup<Real>& group) {
+  // Sanity check
+  EKAT_REQUIRE_MSG (updates_group(group.m_info->m_group_name,group.grid_name()),
+    "Error! This atmosphere process does not update the input group.\n"
+    "   group name: " + group.m_info->m_group_name + "\n"
+    "   grid name : " + group.grid_name() + "\n"
+    "   atm process: " + this->name() + "\n"
+    "Something is wrong up the call stack. Please, contact developers.\n");
+
+  if (not ekat::contains(m_groups_in,group.get_const())) {
+    m_groups_in.emplace_back(group);
+    // AtmosphereProcessGroup is just a "container" of *real* atm processes,
+    // so don't add me as customer if I'm an atm proc group.
+    if (this->type()!=AtmosphereProcessType::Group) {
+      if (group.m_bundle) {
+        add_me_as_customer(group.m_bundle->get_const());
+      } else {
+        for (auto& it : group.m_fields) {
+          add_me_as_customer(it.second->get_const());
+        }
+      }
+    }
+  }
+
+  if (not ekat::contains(m_groups_out,group)) {
+    m_groups_out.emplace_back(group);
+    // AtmosphereProcessGroup is just a "container" of *real* atm processes,
+    // so don't add me as provider if I'm an atm proc group.
+    if (this->type()!=AtmosphereProcessType::Group) {
+      if (group.m_bundle) {
+        add_me_as_provider(*group.m_bundle);
+      } else {
+        for (auto& it : group.m_fields) {
+          add_me_as_provider(*it.second);
+        }
+      }
+    }
+  }
+
+  set_updated_group_impl(group);
+}
+
+void AtmosphereProcess::check_required_fields () const { 
+  // AtmosphereProcessGroup is just a "container" of *real* atm processes,
+  // so don't run checks here, and let the *real* atm process do the checks
+  if (this->type()==AtmosphereProcessType::Group) {
+    return;
+  }
+
+  // First run any process specific checks.
+  // check_required_fields_impl();
+  // Now run all field property checks on all fields
+  for (const auto& field : m_fields_in) {
+    EKAT_REQUIRE_MSG (field.get_header().get_tracking().get_time_stamp().is_valid(),
+        "Error! Found an input field that is still not initialized.\n"
+        "    field: " + field.get_header().get_identifier().name() + "\n"
+        "    grid name: " + field.get_header().get_identifier().get_grid_name() + "\n"
+        "    atm process: " + this->name() + "\n");
+    for (const auto& pc : field.get_property_checks()) {
+      EKAT_REQUIRE_MSG(pc.check(field),
+         "Error: Input field field property check failed.\n"
+         "   field: " + field.get_header().get_identifier().name() + "\n"
+         "   grid name: " + field.get_header().get_identifier().get_grid_name() + "\n"
+         "   property check: " + pc.name() + "\n"
+         "   atm process: " + this->name() + "\n");
+  }}
+  for (const auto& group : m_groups_in) {
+    if (group.m_bundle) {
+      auto& field = *group.m_bundle;
+      EKAT_REQUIRE_MSG (field.get_header().get_tracking().get_time_stamp().is_valid(),
+          "Error! Found an input group bundled field that is still not initialized.\n"
+          "    group name: " + group.m_info->m_group_name + "\n"
+          "    grid name: " + group.grid_name() + "\n"
+          "    atm process: " + this->name() + "\n");
+      for (const auto& pc : field.get_property_checks()) {
+        EKAT_REQUIRE_MSG(pc.check(field),
+           "Error: Input group bundled field field property check failed.\n"
+           "   group name: " + group.m_info->m_group_name + "\n"
+           "   grid name: " + group.grid_name() + "\n"
+           "   property check: " + pc.name() + "\n"
+           "   atm process: " + this->name() + "\n");
+      }
+    }
+    for (auto it : group.m_fields) {
+      auto& field = *it.second;
+      EKAT_REQUIRE_MSG (field.get_header().get_tracking().get_time_stamp().is_valid(),
+          "Error! Found an input group containing a field that is still not initialized.\n"
+          "    atm process: " + this->name() + "\n"
+          "    group name: " + group.m_info->m_group_name + "\n"
+          "    grid name: " + group.grid_name() + "\n"
+          "    field name: " + field.get_header().get_identifier().name() + "\n");
+      for (const auto& pc : field.get_property_checks()) {
+        EKAT_REQUIRE_MSG(pc.check(field),
+           "Error: Input group field field property check failed.\n"
+           "   group name: " + group.m_info->m_group_name + "\n"
+           "   grid name: " + group.grid_name() + "\n"
+           "   field: " + field.get_header().get_identifier().name() + "\n"
+           "   property check: " + pc.name() + "\n"
+           "   atm process: " + this->name() + "\n");
+      }
+    }
+  }
+}
+
+void AtmosphereProcess::check_computed_fields () {
+  // AtmosphereProcessGroup is just a "container" of *real* atm processes,
+  // so don't run checks here, and let the *real* atm process do the checks
+  if (this->type()==AtmosphereProcessType::Group) {
+    return;
+  }
+  // First run any process specific checks, so that derived class have a chance
+  // to repair computed fields if desired/doable/appropriate.
+  check_computed_fields_impl();
+  // Now run all field property checks on all fields
+  for (const auto& field : m_fields_out) {
+    for (const auto& pc : field.get_property_checks()) {
+      EKAT_REQUIRE_MSG(pc.check(field),
+         "Error: Output field field property check failed.\n"
+         "   field: " + field.get_header().get_identifier().name() + "\n"
+         "   grid name: " + field.get_header().get_identifier().get_grid_name() + "\n"
+         "   property check: " + pc.name() + "\n"
+         "   atm process: " + this->name() + "\n");
+  }}
+  for (const auto& group : m_groups_out) {
+    if (group.m_bundle) {
+      auto& field = *group.m_bundle;
+      for (const auto& pc : field.get_property_checks()) {
+        EKAT_REQUIRE_MSG(pc.check(field),
+           "Error: Output group bundled field field property check failed.\n"
+           "   group name: " + group.m_info->m_group_name + "\n"
+           "   grid name: " + group.grid_name() + "\n"
+           "   property check: " + pc.name() + "\n"
+           "   atm process: " + this->name() + "\n");
+      }
+    }
+    for (auto it : group.m_fields) {
+      auto& field = *it.second;
+      for (const auto& pc : field.get_property_checks()) {
+        EKAT_REQUIRE_MSG(pc.check(field),
+           "Error: Output group field field property check failed.\n"
+           "   group name: " + group.m_info->m_group_name + "\n"
+           "   grid name: " + group.grid_name() + "\n"
+           "   field: " + field.get_header().get_identifier().name() + "\n"
+           "   property check: " + pc.name() + "\n"
+           "   atm process: " + this->name() + "\n");
+      }
+    }
+  }
+}
+
+
+bool AtmosphereProcess::requires_field (const FieldIdentifier& id) const {
+  for (const auto& it : m_required_field_requests) {
+    if (it.fid==id) {
+      return true;
+    }
+  }
+  return false;
+}
+bool AtmosphereProcess::computes_field (const FieldIdentifier& id) const {
+  for (const auto& it : m_computed_field_requests) {
+    if (it.fid==id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool AtmosphereProcess::requires_group (const std::string& name, const std::string& grid) const {
+  for (const auto& it : m_required_group_requests) {
+    if (it.name==name && it.grid==grid) {
+      return true;
+    }
+  }
+  return false;
+}
+bool AtmosphereProcess::updates_group (const std::string& name, const std::string& grid) const {
+  for (const auto& it : m_updated_group_requests) {
+    if (it.name==name && it.grid==grid) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void AtmosphereProcess::update_time_stamps () {
+  const auto& t = timestamp();
+
+  // Update *all* output fields, regardless of whether they were touched
+  // at all during this time step.
+  for (auto& f : m_fields_out) {
+    f.get_header().get_tracking().update_time_stamp(t);
+  }
+}
+
+void AtmosphereProcess::add_me_as_provider (const Field<Real>& f) {
+  f.get_header_ptr()->get_tracking().add_provider(weak_from_this());
+}
+
+void AtmosphereProcess::add_me_as_customer (const Field<const Real>& f) {
+  f.get_header_ptr()->get_tracking().add_customer(weak_from_this());
+}
+
+// Convenience function to retrieve input/output fields
+Field<const Real>& AtmosphereProcess::
+get_field_in(const std::string& field_name, const std::string& grid_name) {
+  try {
+    return *m_fields_in_pointers.at(field_name).at(grid_name);
+  } catch (const std::out_of_range&) {
+    // std::out_of_range would message would not help detecting where
+    // the exception originated, so print a more meaningful message.
+    EKAT_ERROR_MSG (
+        "Error! Could not locate input field in this atm proces.\n"
+        "   atm proc name: " + this->name() + "\n"
+        "   field name: " + field_name + "\n"
+        "   grid name: " + grid_name + "\n");
+  }
+}
+
+Field<const Real>& AtmosphereProcess::
+get_field_in(const std::string& field_name) {
+  try {
+    auto& copies = m_fields_in_pointers.at(field_name);
+    EKAT_REQUIRE_MSG (copies.size()==1,
+        "Error! Attempt to find input field providing only the name,\n"
+        "       but multiple copies (on different grids) are present.\n"
+        "  field name: " + field_name + "\n"
+        "  atm process: " + this->name() + "\n"
+        "  number of copies: " + std::to_string(copies.size()) + "\n");
+    return *copies.begin()->second;
+  } catch (const std::out_of_range&) {
+    // std::out_of_range would message would not help detecting where
+    // the exception originated, so print a more meaningful message.
+    EKAT_ERROR_MSG (
+        "Error! Could not locate input field in this atm proces.\n"
+        "   atm proc name: " + this->name() + "\n"
+        "   field name: " + field_name + "\n");
+  }
+}
+
+Field<Real>& AtmosphereProcess::
+get_field_out(const std::string& field_name, const std::string& grid_name) {
+  try {
+    return *m_fields_out_pointers.at(field_name).at(grid_name);
+  } catch (const std::out_of_range&) {
+    // std::out_of_range would message would not help detecting where
+    // the exception originated, so print a more meaningful message.
+    EKAT_ERROR_MSG (
+        "Error! Could not locate output field in this atm proces.\n"
+        "   atm proc name: " + this->name() + "\n"
+        "   field name: " + field_name + "\n"
+        "   grid name: " + grid_name + "\n");
+  }
+}
+
+Field<Real>& AtmosphereProcess::
+get_field_out(const std::string& field_name) {
+  try {
+    auto& copies = m_fields_out_pointers.at(field_name);
+    EKAT_REQUIRE_MSG (copies.size()==1,
+        "Error! Attempt to find output field providing only the name,\n"
+        "       but multiple copies (on different grids) are present.\n"
+        "  field name: " + field_name + "\n"
+        "  atm process: " + this->name() + "\n"
+        "  number of copies: " + std::to_string(copies.size()) + "\n");
+    return *copies.begin()->second;
+  } catch (const std::out_of_range&) {
+    // std::out_of_range would message would not help detecting where
+    // the exception originated, so print a more meaningful message.
+    EKAT_ERROR_MSG (
+        "Error! Could not locate output field in this atm proces.\n"
+        "   atm proc name: " + this->name() + "\n"
+        "   field name: " + field_name + "\n");
+  }
+}
+
+FieldGroup<const Real>& AtmosphereProcess::
+get_group_in(const std::string& group_name, const std::string& grid_name) {
+  try {
+    return *m_groups_in_pointers.at(group_name).at(grid_name);
+  } catch (const std::out_of_range&) {
+    // std::out_of_range would message would not help detecting where
+    // the exception originated, so print a more meaningful message.
+    EKAT_ERROR_MSG (
+        "Error! Could not locate input group in this atm proces.\n"
+        "   atm proc name: " + this->name() + "\n"
+        "   group name: " + group_name + "\n"
+        "   grid name: " + grid_name + "\n");
+  }
+}
+
+FieldGroup<const Real>& AtmosphereProcess::
+get_group_in(const std::string& group_name) {
+  try {
+    auto& copies = m_groups_in_pointers.at(group_name);
+    EKAT_REQUIRE_MSG (copies.size()==1,
+        "Error! Attempt to find input group providing only the name,\n"
+        "       but multiple copies (on different grids) are present.\n"
+        "  group name: " + group_name + "\n"
+        "  atm process: " + this->name() + "\n"
+        "  number of copies: " + std::to_string(copies.size()) + "\n");
+    return *copies.begin()->second;
+  } catch (const std::out_of_range&) {
+    // std::out_of_range would message would not help detecting where
+    // the exception originated, so print a more meaningful message.
+    EKAT_ERROR_MSG (
+        "Error! Could not locate input group in this atm proces.\n"
+        "   atm proc name: " + this->name() + "\n"
+        "   group name: " + group_name + "\n");
+  }
+}
+
+FieldGroup<Real>& AtmosphereProcess::
+get_group_out(const std::string& group_name, const std::string& grid_name) {
+  try {
+    return *m_groups_out_pointers.at(group_name).at(grid_name);
+  } catch (const std::out_of_range&) {
+    // std::out_of_range would message would not help detecting where
+    // the exception originated, so print a more meaningful message.
+    EKAT_ERROR_MSG (
+        "Error! Could not locate output group in this atm proces.\n"
+        "   atm proc name: " + this->name() + "\n"
+        "   group name: " + group_name + "\n"
+        "   grid name: " + grid_name + "\n");
+  }
+}
+
+FieldGroup<Real>& AtmosphereProcess::
+get_group_out(const std::string& group_name) {
+  try {
+    auto& copies = m_groups_out_pointers.at(group_name);
+    EKAT_REQUIRE_MSG (copies.size()==1,
+        "Error! Attempt to find output group providing only the name,\n"
+        "       but multiple copies (on different grids) are present.\n"
+        "  group name: " + group_name + "\n"
+        "  atm process: " + this->name() + "\n"
+        "  number of copies: " + std::to_string(copies.size()) + "\n");
+    return *copies.begin()->second;
+  } catch (const std::out_of_range&) {
+    // std::out_of_range would message would not help detecting where
+    // the exception originated, so print a more meaningful message.
+    EKAT_ERROR_MSG (
+        "Error! Could not locate output group in this atm proces.\n"
+        "   atm proc name: " + this->name() + "\n"
+        "   group name: " + group_name + "\n");
+  }
+}
+
+void AtmosphereProcess::set_fields_and_groups_pointers () {
+  for (auto& f : m_fields_in) {
+    const auto& fid = f.get_header().get_identifier();
+    m_fields_in_pointers[fid.name()][fid.get_grid_name()] = &f;
+  }
+  for (auto& f : m_fields_out) {
+    const auto& fid = f.get_header().get_identifier();
+    m_fields_out_pointers[fid.name()][fid.get_grid_name()] = &f;
+  }
+  for (auto& g : m_groups_in) {
+    const auto& group_name = g.m_info->m_group_name;
+    m_groups_in_pointers[group_name][g.grid_name()] = &g;
+  }
+  for (auto& g : m_groups_out) {
+    const auto& group_name = g.m_info->m_group_name;
+    m_groups_out_pointers[group_name][g.grid_name()] = &g;
+  }
+}
+
+void AtmosphereProcess::
+alias_field_in (const std::string& field_name,
+                const std::string& grid_name,
+                const std::string& alias_name)
+{
+  try {
+    m_fields_in_pointers[alias_name][grid_name] = m_fields_in_pointers.at(field_name).at(grid_name);
+  } catch (const std::out_of_range&) {
+    EKAT_ERROR_MSG (
+        "Error! Could not locate input field for aliasing request.\n"
+        "    - field name: " + field_name + "\n"
+        "    - grid name:  " + grid_name + "\n");
+  }
+}
+
+void AtmosphereProcess::
+alias_field_out (const std::string& field_name,
+                 const std::string& grid_name,
+                 const std::string& alias_name)
+{
+  try {
+    m_fields_out_pointers[alias_name][grid_name] = m_fields_out_pointers.at(field_name).at(grid_name);
+  } catch (const std::out_of_range&) {
+    EKAT_ERROR_MSG (
+        "Error! Could not locate output field for aliasing request.\n"
+        "    - field name: " + field_name + "\n"
+        "    - grid name:  " + grid_name + "\n");
+  }
+}
+
+void AtmosphereProcess::
+alias_group_in (const std::string& group_name,
+                const std::string& grid_name,
+                const std::string& alias_name)
+{
+  try {
+    m_groups_in_pointers[alias_name][grid_name] = m_groups_in_pointers.at(group_name).at(grid_name);
+  } catch (const std::out_of_range&) {
+    EKAT_ERROR_MSG (
+        "Error! Could not locate input group for aliasing request.\n"
+        "    - group name: " + group_name + "\n"
+        "    - grid name:  " + grid_name + "\n");
+  }
+}
+
+void AtmosphereProcess::
+alias_group_out (const std::string& group_name,
+                 const std::string& grid_name,
+                 const std::string& alias_name)
+{
+  try {
+    m_groups_out_pointers[alias_name][grid_name] = m_groups_out_pointers.at(group_name).at(grid_name);
+  } catch (const std::out_of_range&) {
+    EKAT_ERROR_MSG (
+        "Error! Could not locate output group for aliasing request.\n"
+        "    - group name: " + group_name + "\n"
+        "    - grid name:  " + grid_name + "\n");
+  }
+}
+
+} // namespace scream

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -119,7 +119,7 @@ public:
   // Derived classes can perform additional checks (or repairs) by overriding the
   // corresponding check_xyz_fields_impl method(s).
   // Note: We don't want inputs to be 'repaired', since they might break assumptions
-  //       in other atm procs (e.g., some atm procs might haave a "backup" copy).
+  //       in other atm procs (e.g., some atm procs might have a "backup" copy).
   //       However, we allow computed fields to be repaired, so check_computed_fields
   //       is not a const method.  If a process wants to repair computed fields
   //       it can do so by overriding the "check_computed_fields_impl" routine.
@@ -302,7 +302,7 @@ protected:
   // These methods set up an extra pointer in the m_[fields|groups]_[in|out]_pointers,
   // for convenience of use (e.g., use a short name for a field/group).
   // Note: these methods do *not* create a copy of the field/group. Also, notice that
-  //       these methors need to be created *after* set_fields_and_groups_pointers().
+  //       these methods need to be created *after* set_fields_and_groups_pointers().
   void alias_field_in (const std::string& field_name,
                        const std::string& grid_name,
                        const std::string& alias_name);

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -10,17 +10,15 @@
 #include "share/field/field_group.hpp"
 #include "share/grid/grids_manager.hpp"
 
-#include "ekat/ekat_assert.hpp"
 #include "ekat/mpi/ekat_comm.hpp"
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/util/ekat_factory.hpp"
 #include "ekat/util/ekat_string_utils.hpp"
 #include "ekat/std_meta/ekat_std_enable_shared_from_this.hpp"
-#include "ekat/std_meta/ekat_std_utils.hpp"
 
 #include <string>
 #include <set>
-#include <type_traits>
+#include <list>
 
 namespace scream
 {
@@ -66,6 +64,13 @@ class AtmosphereProcess : public ekat::enable_shared_from_this<AtmosphereProcess
 public:
   using TimeStamp      = util::TimeStamp;
   using ci_string      = ekat::CaseInsensitiveString;
+  using       field_type = Field<      Real>;
+  using const_field_type = Field<const Real>;
+  using       group_type = FieldGroup<      Real>;
+  using const_group_type = FieldGroup<const Real>;
+
+  template<typename T>
+  using str_map = std::map<std::string,T>;
 
   virtual ~AtmosphereProcess () = default;
 
@@ -82,192 +87,67 @@ public:
   virtual const ekat::Comm& get_comm () const = 0;
 
   // Give the grids manager to the process, so it can grab its grid
-  // IMPORTANT: the process is *expected* to have valid field ids for
-  //            required/computed fields once this method returns.
-  //            This means that all tags/dims must be set upon return.
+  // Upon return, the atm proc should have a valid and complete list
+  // of in/out/inout FieldRequest and GroupRequest.
   virtual void set_grids (const std::shared_ptr<const GridsManager> grids_manager) = 0;
 
   // These are the three main interfaces:
-  //   - the initialize method sets up all the stuff the process needs to run,
+  //   - the initialize method sets up all the stuff the process needs in order to run,
   //     including arrays/views, parameters, and precomputed stuff.
   //   - the run method time-advances the process by one time step.
-  //     We could decide whether we want to assume that other process may
-  //     be running at the same time, or whether each process can assume
-  //     that no other process is currently inside a call to 'run'.
   //   - the finalize method makes sure, if necessary, that all resources are freed.
-  // NOTE: You don't override these methods. Override the protected methods
-  // NOTE: initialize_impl, run_impl, and finalize_impl instead.
-  // The initialize/finalize method should be called just once per simulation (should
-  // we enforce that? It depends on what resources we init/free, and how), while the
-  // run method can (and usually will) be called multiple times.
-  // We should put asserts to verify that the process has been init-ed, when
-  // run/finalize is called.
-  void initialize (const TimeStamp& t0) {
-    t_ = t0;
-    initialize_impl(t_);
-  }
-  void run        (const Real dt) {
-    // Make sure required fields are valid
-    check_required_fields();
-    // Call the subclass's run method and update it afterward.
-    run_impl(dt);
-    t_ += dt;
-    // Make sure computed fields are valid
-    check_computed_fields();
-  }
-  void finalize   (/* what inputs? */) {
-    finalize_impl(/* what inputs? */);
-  }
+  // TODO: should we check that initialize/finalize are called once per simulation?
+  //       Whether it's a needed check depends on what resources we init/free, and how.
+  // TODO: should we check that initialize has been called, when calling run/finalize?
+  void initialize (const TimeStamp& t0);
+  void run (const Real dt);
+  void finalize   (/* what inputs? */);
 
-  // These methods set fields in the atm process. Fields live on the default
-  // device and they are all 1d.
-  // If the process *needs* to store the field as n-dimensional field, use the
-  // template function 'get_view' (see field.hpp for details).
+  // These methods set fields/groups in the atm process. The fields/groups are stored
+  // in a list (with some helpers maps that can be used to quickly retrieve them).
+  // If derived class need additional bookkeping/checks, they can override the
+  // corresponding set_xyz_impl method(s).
   // Note: this method will be called *after* set_grids, but *before* initialize.
-  //       You are *guaranteed* that the view in the Field f is allocated by now.
-  // Note: it would be tempting to add this process as provider/customer right here.
-  //       However, if this process is of type Group, we don't really want to add it
-  //       as provider/customer. The group is just a 'design layer', and the stored
-  //       processes are the actuall providers/customers.
-  void set_required_field (const Field<const Real>& f) {
-    EKAT_REQUIRE_MSG (requires_field(f.get_header().get_identifier()),
-        "Error! This atmosphere process does not require\n  " +
-        f.get_header().get_identifier().get_id_string() +
-        "\nSomething is wrong up the call stack. Please, contact developers.\n");
-  
-    const auto& name = f.get_header().get_identifier().name();
-    m_fields_in.emplace(name,f);
-  
-    // Add myself as customer to the field
-    if (this->type()!=AtmosphereProcessType::Group) {
-      add_me_as_customer(f);
-    }
+  //       You are *guaranteed* that the views in the field/group are allocated by now.
+  void set_required_field (const Field<const Real>& f);
+  void set_computed_field (const Field<Real>& f);
+  void set_required_group (const FieldGroup<const Real>& group);
+  void set_updated_group (const FieldGroup<Real>& group);
 
-    set_required_field_impl (f);
-  }
-  void set_computed_field (const Field<Real>& f) {
-    EKAT_REQUIRE_MSG (computes_field(f.get_header().get_identifier()),
-        "Error! This atmosphere process does not compute\n  " +
-        f.get_header().get_identifier().get_id_string() +
-        "\nSomething is wrong up the call stack. Please, contact developers.\n");
-
-    const auto& name = f.get_header().get_identifier().name();
-    m_fields_out.emplace(name,f);
-  
-    // Add myself as provider for the field
-    if (this->type()!=AtmosphereProcessType::Group) {
-      add_me_as_provider(f);
-    }
-
-    set_computed_field_impl (f);
-  }
-
-  // These methods check all the fields coming into and out of a process to make sure
-  // they are still valid.  To do this, the routines cycles through all of the
-  // required and computed fields, respectively, and run whatever property checks have
-  // been assigned to them.
-  // Note: We do want to encourage repairing fields that are being passed to a specific
-  //       process, so we set the "check_required_fields" routine to be const.
-  //       On the other hand, we may want to allow computed fields to be repaired, so
-  //       we leave that one non-const.  If a process wants to repair computed fields
+  // These methods checks that all the in/out fields of this atm process are valid.
+  // For each field, these routines run all the property checks stored in the field.
+  // Derived classes can perform additional checks (or repairs) by overriding the
+  // corresponding check_xyz_fields_impl method(s).
+  // Note: We don't want inputs to be 'repaired', since they might break assumptions
+  //       in other atm procs (e.g., some atm procs might haave a "backup" copy).
+  //       However, we allow computed fields to be repaired, so check_computed_fields
+  //       is not a const method.  If a process wants to repair computed fields
   //       it can do so by overriding the "check_computed_fields_impl" routine.
-  void check_required_fields () const { 
-    // First run any process specific checks.
-    check_required_fields_impl();
-    // Now run all field property checks on all fields
-    for (auto& f : m_fields_in) {
-      auto& field = f.second;
-      for (auto& pc : field.get_property_checks()) {
-        EKAT_REQUIRE_MSG(pc.check(field),
-           "Error: Field Property Check Fail: " << pc.name() << ",\n      field: " << f.first << ",\n      before process: " << this->name());
-      }
-    }
-  }
-  void check_computed_fields () {
-    // First run any process specific checks.  If a process wants to repair any computed fields
-    // here is where that is done.
-    check_computed_fields_impl();
-    // Now run all field property checks on all fields
-    for (auto& f : m_fields_out) {
-      auto& field = f.second;
-      for (auto& pc : field.get_property_checks()) {
-        EKAT_REQUIRE_MSG(pc.check(field),
-           "Error: Field Property Check Fail: " << pc.name() << ",\n      field: " << f.first << ",\n      after process: " << this->name());
-      }
-    }
-  }
+  void check_required_fields () const;
+  void check_computed_fields ();
 
-  // Note: for the following (unlike set_required/computed_field, we do provide an
-  //       implementation, since requiring a group is "rare".
-  // Note: from the group, derived class can extract individual fields, and,
-  //       if needed, they can check that the group was allocated as a bundle,
-  //       and if so, and if desired, they can access the bundled field directly.
-  //       See field_group.hpp for more details.
-  virtual void set_required_group (const FieldGroup<const Real>& /* group */) {
-    EKAT_ERROR_MSG (
-      "Error! This atmosphere process does not require a group of fields, meaning\n"
-      "       that 'get_required_group_requests' was not overridden in this class, or that\n"
-      "       its override returns an empty set.\n"
-      "       If you override 'get_required_group_requests' to return a non-empty set,\n"
-      "       then you must also override 'set_required_group_request' in your derived class.\n"
-    );
-  }
-  virtual void set_updated_group (const FieldGroup<Real>& /* group */) {
-    EKAT_ERROR_MSG (
-      "Error! This atmosphere process does not update a group of fields, meaning\n"
-      "       that 'get_updated_group_requests' was not overridden in this class, or that\n"
-      "       its override returns an empty set.\n"
-      "       If you override 'get_updated_group_requests' to return a non-empty set,\n"
-      "       then you must also override 'set_updated_group_request' in your derived class.\n"
-    );
-  }
-
-  // These two methods allow the driver to figure out what process need
-  // a given field and what process updates a given field.
+  // These methods allow the AD to figure out what each process needs, with very fine
+  // grain detail. See field_request.hpp for more info on what FieldRequest and GroupRequest
+  // are, and field_group.hpp for what groups of fields are.
   const std::set<FieldRequest>& get_required_field_requests () const { return m_required_field_requests; }
   const std::set<FieldRequest>& get_computed_field_requests () const { return m_computed_field_requests; }
-
-  // If needed, an Atm Proc can claim to need/update a whole group of fields, without really knowing
-  // a priori how many they are, or even what they are. Each entry of the returned set is a pair
-  // of strings, where the 1st is the group name, and the 2nd the grid name. If the same group is
-  // needed on multiple grids, two separate entries are needed.
   const std::set<GroupRequest>& get_required_group_requests () const { return m_required_group_requests; }
   const std::set<GroupRequest>& get_updated_group_requests  () const { return m_updated_group_requests; }
 
-  // NOTE: C++20 will introduce the method 'contains' for std::set. Till then, use our util free function
-  bool requires_field (const FieldIdentifier& id) const {
-    for (const auto& it : m_required_field_requests) {
-      if (it.fid==id) {
-        return true;
-      }
-    }
-    return false;
-  }
-  bool computes_field (const FieldIdentifier& id) const {
-    for (const auto& it : m_computed_field_requests) {
-      if (it.fid==id) {
-        return true;
-      }
-    }
-    return false;
-  }
+  // These sets allow to get all the actual in/out fields stored by the atm proc
+  // Note: if an atm proc requires a group, then all the fields in the group, as well as
+  //       the bundled field (if present) will be added as required fields for this atm proc.
+  //       See field_group.hpp for more info about groups of fields.
+  const std::list<const_field_type>& get_fields_in  () const { return m_fields_in;  }
+  const std::list<      field_type>& get_fields_out () const { return m_fields_out; }
+  const std::list<const_group_type>& get_groups_in  () const { return m_groups_in;  }
+  const std::list<      group_type>& get_groups_out () const { return m_groups_out; }
 
-  bool requires_group (const std::string& name, const std::string& grid) const {
-    for (const auto& it : m_required_group_requests) {
-      if (it.name==name && it.grid==grid) {
-        return true;
-      }
-    }
-    return false;
-  }
-  bool updates_group (const std::string& name, const std::string& grid) const {
-    for (const auto& it : m_updated_group_requests) {
-      if (it.name==name && it.grid==grid) {
-        return true;
-      }
-    }
-    return false;
-  }
+  // Whether this atm proc requested the field/group as in/out/inout, via a FieldRequest/GroupRequest.
+  bool requires_field (const FieldIdentifier& id) const;
+  bool computes_field (const FieldIdentifier& id) const;
+  bool requires_group (const std::string& name, const std::string& grid) const;
+  bool updates_group (const std::string& name, const std::string& grid) const;
 
   // Computes total number of bytes needed for local variables
   virtual int requested_buffer_size_in_bytes () const { return 0; }
@@ -285,12 +165,13 @@ protected:
   };
 
   // Derived classes can used these method, so that if we change how fields/groups
-  // requirement are stored (e.g., std::set -> std::list), they don't need to change
+  // requirement are stored (e.g., change the std container), they don't need to change
   // their implementation.
-
-  // Field requests. Provide plenty of overloads to make it simple to add field request.
+  // We provide plenty of overloads to make it simple to add field request.
   // E.g., provide a FID directly vs provide its ctor args; or provide groups list and
   // no pack size vs single group and pack size.
+
+  // Field requests
   template<RequestType RT>
   void add_field (const std::string& name, const FieldLayout& layout,
                   const ekat::units::Units& u, const std::string& grid_name,
@@ -344,8 +225,9 @@ protected:
   // Group requests
   template<RequestType RT>
   void add_group (const std::string& name, const std::string& grid, const int ps, const Bundling b,
-                  const GroupRequest* p, const Relationship t, const std::list<std::string>& excl)
-  { add_group<RT>(GroupRequest(name,grid,ps,b,p,t,excl)); }
+                  const DerivationType t, const std::string& src_name, const std::string& src_grid,
+                  const std::list<std::string>& excl)
+  { add_group<RT>(GroupRequest(name,grid,ps,b,t,src_name,src_grid,excl)); }
 
   template<RequestType RT>
   void add_group (const std::string& name, const std::string& grid_name,
@@ -366,64 +248,105 @@ protected:
     groups.emplace(req);
   }
 
-  // Override this method to initialize your subclass.
+  // Override this method to initialize the derived
   virtual void initialize_impl(const TimeStamp& t0) = 0;
 
-  // Override this method to define how your subclass runs forward one step
+  // Override this method to define how the derived runs forward one step
   // (of size dt). This method is called before the timestamp is updated.
   virtual void run_impl(const Real dt) = 0;
 
-  // Override this method to finalize your subclass.
+  // Override this method to finalize the derived class
   virtual void finalize_impl(/* what inputs? */) = 0;
 
   // This provides access to this process's timestamp.
-  const TimeStamp& timestamp() const {
-    return t_;
-  }
+  const TimeStamp& timestamp() const { return m_time_stamp; }
 
-  void add_me_as_provider (const Field<Real>& f) {
-    f.get_header_ptr()->get_tracking().add_provider(weak_from_this());
-  }
+  // These three methods modify the FieldTracking of the input field (see field_tracking.hpp)
+  void update_time_stamps ();
+  void add_me_as_provider (const Field<Real>& f);
+  void add_me_as_customer (const Field<const Real>& f);
 
-  void add_me_as_customer (const Field<const Real>& f) {
-    f.get_header_ptr()->get_tracking().add_customer(weak_from_this());
-  }
-
-  // The base class already registers the required and computed fields in
-  // the set_required/computed_field main routines.  These impl definitions
-  // provide a way for subclasses to define extra field bookkeeping that
-  // is not already covered by the `set_required/computed_field`.  It is
-  // not essential for subclasses to overwrite these two routines, but it
-  // is possible.
-  virtual void set_required_field_impl (const Field<const Real>& f) {};
-  virtual void set_computed_field_impl (const Field<      Real>& f) {};
+  // The base class already registers the required/computed/updated fields/groups in
+  // the set_required/computed_field and set_required/updated_group routines.
+  // These impl methods provide a way for derived classes to add more specialized
+  // actions, such as extra fields bookkeeping, extra checks, or create copies.
+  // Since most derived classes do not need to perform additional actions,
+  // we provide empty implementations.
+  virtual void set_required_field_impl (const Field<const Real>& /* f */) {}
+  virtual void set_computed_field_impl (const Field<      Real>& /* f */) {}
+  virtual void set_required_group_impl (const FieldGroup<const Real>& /* group */) {}
+  virtual void set_updated_group_impl  (const FieldGroup<      Real>& /* group */) {}
 
   // The Base class already runs all registered field checks for all fields.
   // Similar to the set_required/computed_field_impl comment above, it is
-  // not necessary for a subclass to overwrite these two routines, but it
-  // is possible.  A subclass may want to add extra checks or controls
-  // that occur before or after a process is run that could be included
-  // in an override of these two routine.  An example of an extra check 
-  // that a subclass may want to add would include field repair if a 
-  // field check fails.
+  // not necessary for a derived class to overwrite these two routines.
+  // An example of a case where a derived class may want to override these is
+  // if the derived class is able to 'repair' a field in case the check fails.
+  // See field_property_check.hpp for more info on check/repair.
   virtual void check_required_fields_impl () const {}
   virtual void check_computed_fields_impl () {}
 
-  using field_type       = Field<      Real>;
-  using const_field_type = Field<const Real>;
-  std::map<std::string,const_field_type>  m_fields_in;
-  std::map<std::string,field_type>        m_fields_out;
+  // Convenience function to retrieve input/output fields from the field/group (and grid) name.
+  // Note: the version without grid name only works if there is only one copy of the field/group.
+  //       In that case, the single copy is returned, regardless of the associated grid name.
+  Field<const Real>& get_field_in(const std::string& field_name, const std::string& grid_name);
+  Field<const Real>& get_field_in(const std::string& field_name);
+  Field<Real>& get_field_out(const std::string& field_name, const std::string& grid_name);
+  Field<Real>& get_field_out(const std::string& field_name);
+
+  FieldGroup<const Real>& get_group_in(const std::string& group_name, const std::string& grid_name);
+  FieldGroup<const Real>& get_group_in(const std::string& group_name);
+  FieldGroup<Real>& get_group_out(const std::string& group_name, const std::string& grid_name);
+  FieldGroup<Real>& get_group_out(const std::string& group_name);
+
+  // These methods set up an extra pointer in the m_[fields|groups]_[in|out]_pointers,
+  // for convenience of use (e.g., use a short name for a field/group).
+  // Note: these methods do *not* create a copy of the field/group. Also, notice that
+  //       these methors need to be created *after* set_fields_and_groups_pointers().
+  void alias_field_in (const std::string& field_name,
+                       const std::string& grid_name,
+                       const std::string& alias_name);
+
+  void alias_field_out (const std::string& field_name,
+                        const std::string& grid_name,
+                        const std::string& alias_name);
+
+  void alias_group_in (const std::string& group_name,
+                       const std::string& grid_name,
+                       const std::string& alias_name);
+
+  void alias_group_out (const std::string& group_name,
+                        const std::string& grid_name,
+                        const std::string& alias_name);
 
 private:
+  // Called from initialize, this method creates the m_[fields|groups]_[in|out]_pointers
+  // maps, which are used inside the get_[field|group]_[in|out] methods.
+  void set_fields_and_groups_pointers ();
+
+  // Store input/output fields and groups.
+  std::list<const_group_type>  m_groups_in;
+  std::list<      group_type>  m_groups_out;
+  std::list<const_field_type>  m_fields_in;
+  std::list<      field_type>  m_fields_out;
+
+  // These maps help to retrieve a field/group stored in the lists above. E.g.,
+  //   auto ptr = m_field_in_pointers[field_name][grid_name];
+  // then *ptr is a field in m_fields_in, with name $field_name, on grid $grid_name.
+  str_map<str_map< const_group_type* >> m_groups_in_pointers;
+  str_map<str_map<       group_type* >> m_groups_out_pointers;
+  str_map<str_map< const_field_type* >> m_fields_in_pointers;
+  str_map<str_map<       field_type* >> m_fields_out_pointers;
+
+  // The list of in/out/inout field/group requests.
   std::set<FieldRequest>   m_required_field_requests;
   std::set<FieldRequest>   m_computed_field_requests;
-
   std::set<GroupRequest>   m_required_group_requests;
   std::set<GroupRequest>   m_updated_group_requests;
 
   // This process's copy of the timestamp, which is set on initialization and
   // updated during stepping.
-  TimeStamp t_;
+  TimeStamp m_time_stamp;
 };
 
 // A short name for the factory for atmosphere processes
@@ -432,7 +355,7 @@ private:
 //          atmosphere process class name as templated argument. If you roll your own creator function, you
 //          *MUST* ensure that it correctly sets up the self pointer after creating the shared_ptr.
 //          This is *necessary* until we can safely switch to std::enable_shared_from_this.
-//          For more details, see the comments at the top of util/scream_std_enable_shared_from_this.hpp.
+//          For more details, see the comments at the top of ekat_std_enable_shared_from_this.hpp.
 using AtmosphereProcessFactory =
     ekat::Factory<AtmosphereProcess,
                   ekat::CaseInsensitiveString,

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -144,7 +144,7 @@ void AtmosphereProcessGroup::finalize_impl (/* what inputs? */) {
 }
 
 void AtmosphereProcessGroup::
-set_required_group (const FieldGroup<const Real>& group)
+set_required_group_impl (const FieldGroup<const Real>& group)
 {
   for (int iproc=0; iproc<m_group_size; ++iproc) {
     auto atm_proc = m_atm_processes[iproc];
@@ -156,7 +156,7 @@ set_required_group (const FieldGroup<const Real>& group)
 }
 
 void AtmosphereProcessGroup::
-set_updated_group (const FieldGroup<Real>& group)
+set_updated_group_impl (const FieldGroup<Real>& group)
 {
   for (int iproc=0; iproc<m_group_size; ++iproc) {
     auto atm_proc = m_atm_processes[iproc];

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -51,9 +51,6 @@ public:
 
   void final_setup ();
 
-  void set_required_group (const FieldGroup<const Real>& group);
-  void set_updated_group (const FieldGroup<Real>& group);
-
   // --- Methods specific to AtmosphereProcessGroup --- //
   int get_num_processes () const { return m_atm_processes.size(); }
 
@@ -80,9 +77,12 @@ protected:
   void run_sequential (const Real dt);
   void run_parallel   (const Real dt);
 
-  // The methods to set the fields in the process
+  // The methods to set the fields/groups in the right processes of the group
+  void set_required_group_impl (const FieldGroup<const Real>& group);
+  void set_updated_group_impl (const FieldGroup<Real>& group);
   void set_required_field_impl (const Field<const Real>& f);
   void set_computed_field_impl (const Field<      Real>& f);
+
 
   // The communicator that each process in this group uses
   ekat::Comm        m_comm;

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -296,6 +296,13 @@ protected:
   std::shared_ptr<property_check_list>    m_prop_checks;
 };
 
+// We use this to find a FieldGroup in a std container.
+// We do NOT allow two entries with same field identifier in such containers.
+template<typename RT1, typename RT2>
+bool operator== (const Field<RT1>& lhs, const Field<RT2>& rhs) {
+  return lhs.get_header().get_identifier() == rhs.get_header().get_identifier();
+}
+
 // ================================= IMPLEMENTATION ================================== //
 
 template<typename RealType>

--- a/components/scream/src/share/field/field_alloc_prop.hpp
+++ b/components/scream/src/share/field/field_alloc_prop.hpp
@@ -1,13 +1,14 @@
 #ifndef SCREAM_FIELD_ALLOC_PROP_HPP
 #define SCREAM_FIELD_ALLOC_PROP_HPP
 
-#include "share/field/field_identifier.hpp"
+#include "share/field/field_layout.hpp"
 #include "share/scream_types.hpp"
 
 #include "ekat/ekat_scalar_traits.hpp"
 #include "ekat/ekat_assert.hpp"
 
 #include <vector>
+#include <memory>
 
 namespace scream
 {
@@ -55,7 +56,7 @@ namespace scream
  *
  *  Note: at every request for a new value_type, this class checks the
  *        underlying scalar_type. We ASSUME that the dimensions in the
- *        field identifier refer to that scalar_type.
+ *        field layout refer to that scalar_type.
  */
 
 class FieldAllocProp {

--- a/components/scream/src/share/field/field_group.hpp
+++ b/components/scream/src/share/field/field_group.hpp
@@ -128,6 +128,8 @@ struct FieldGroup {
   FieldGroup<RealType>& operator= (const FieldGroup<RT>& src) {
     m_info = src.m_info;
     copy_fields<RT> (src);
+
+    return *this;
   }
 
   const std::string& grid_name () const {

--- a/components/scream/src/share/field/field_group.hpp
+++ b/components/scream/src/share/field/field_group.hpp
@@ -188,6 +188,14 @@ private:
   }
 };
 
+// We use this to find a FieldGroup in a std container.
+// We do NOT allow two entries with same group name and grid name in such containers.
+template<typename RT>
+bool operator== (const FieldGroup<RT>& lhs, const FieldGroup<RT>& rhs) {
+  return lhs.m_info->m_group_name == rhs.m_info->m_group_name &&
+         lhs.grid_name() == rhs.grid_name();
+}
+
 } // namespace scream
 
 #endif // SCREAM_FIELD_GROUP_HPP

--- a/components/scream/src/share/field/field_group.hpp
+++ b/components/scream/src/share/field/field_group.hpp
@@ -7,6 +7,7 @@
 
 #include <list>
 #include <map>
+#include <type_traits>
 
 namespace scream {
 
@@ -92,6 +93,7 @@ class Field;
 template<typename RealType>
 struct FieldGroup {
   using field_type = Field<RealType>;
+  using const_field_type = typename field_type::const_field_type;
   using ci_string = FieldGroupInfo::ci_string;
 
   FieldGroup (const std::string& name)
@@ -102,12 +104,43 @@ struct FieldGroup {
 
   FieldGroup (const FieldGroup&) = default;
 
+  // Allows to copy a non-const group into a const one.
+  template<typename RT,
+           typename = typename std::enable_if<
+               not std::is_same<RT,RealType>::value
+               and std::is_const<RealType>::value
+             >::type
+           >
+  FieldGroup (const FieldGroup<RT>& src) {
+    *this = src;
+  }
+
+  FieldGroup<typename const_field_type::RT> get_const () const {
+    return FieldGroup<typename const_field_type::RT>(*this);
+  }
+
+  template<typename RT,
+           typename = typename std::enable_if<
+               not std::is_same<RT,RealType>::value
+               and std::is_const<RealType>::value
+             >::type
+           >
+  FieldGroup<RealType>& operator= (const FieldGroup<RT>& src) {
+    m_info = src.m_info;
+    copy_fields<RT> (src);
+  }
+
   const std::string& grid_name () const {
-    EKAT_REQUIRE_MSG(m_fields.size()>0,
+    EKAT_REQUIRE_MSG(m_fields.size()>0 || m_bundle,
         "Error! Cannot establish the group grid name until fields have been added.\n");
 
-    const auto& id = m_fields.begin()->second->get_header().get_identifier();
-    return id.get_grid_name();
+    if (m_bundle) {
+      const auto& id = m_bundle->get_header().get_identifier();
+      return id.get_grid_name();
+    } else {
+      const auto& id = m_fields.begin()->second->get_header().get_identifier();
+      return id.get_grid_name();
+    }
   }
 
   // The fields in this group
@@ -119,6 +152,40 @@ struct FieldGroup {
 
   // The info of this group.
   std::shared_ptr<FieldGroupInfo>  m_info;
+
+private:
+
+  // Only used inside this class;
+  FieldGroup () = default;
+
+  // Make non-const version friend of const version, and viceversa
+  template<typename RT>
+  friend struct FieldGroup;
+
+  template<typename RT>
+  typename std::enable_if<
+    std::is_same<RT,RealType>::value
+  >::type
+  copy_fields (const FieldGroup<RT>& src) {
+    m_bundle = src.m_bundle;
+    for (auto it : src.m_fields) {
+      m_fields[it.first] = it.second;
+    }
+  }
+
+  template<typename RT>
+  typename std::enable_if<
+    not std::is_same<RT,RealType>::value
+    and std::is_const<RealType>::value
+  >::type
+  copy_fields (const FieldGroup<RT>& src) {
+    if (src.m_bundle) {
+      m_bundle = std::make_shared<const_field_type>(src.m_bundle->get_const());
+    }
+    for (const auto& it : src.m_fields) {
+      m_fields[it.first] = std::make_shared<const_field_type>(it.second->get_const());
+    }
+  }
 };
 
 } // namespace scream

--- a/components/scream/src/share/field/field_header.cpp
+++ b/components/scream/src/share/field/field_header.cpp
@@ -6,7 +6,7 @@ namespace scream
 
 FieldHeader::FieldHeader (const identifier_type& id)
  : m_identifier (id)
- , m_tracking (create_tracking(id.name()))
+ , m_tracking (create_tracking())
  , m_alloc_prop ()
 {
   // Nothing to be done here
@@ -45,7 +45,7 @@ create_subfield_header (const FieldIdentifier& id,
   fh->create_parent_child_link(parent);
 
   // Create tracking, and set up parent/child
-  fh->m_tracking = create_tracking(id.name());
+  fh->m_tracking = create_tracking();
   fh->m_tracking->create_parent_child_link(parent->get_tracking_ptr());
   if (parent->get_tracking().get_time_stamp().is_valid()) {
     fh->m_tracking->update_time_stamp(parent->get_tracking().get_time_stamp());

--- a/components/scream/src/share/field/field_manager.hpp
+++ b/components/scream/src/share/field/field_manager.hpp
@@ -103,6 +103,8 @@ public:
 
 protected:
 
+  void pre_process_group_requests ();
+
   // The state of the repository
   RepoState           m_repo_state;
 
@@ -131,8 +133,6 @@ FieldManager (const grid_ptr_type& grid)
   : m_repo_state (RepoState::Clean)
   , m_grid       (grid)
 {
-  // m_field_groups["tracers"] = std::make_shared<group_info_type>("tracers");
-
   EKAT_REQUIRE_MSG (m_grid!=nullptr,
       "Error! Input grid pointer is not valid.");
 }
@@ -188,15 +188,21 @@ void FieldManager<RealType>::register_field (const FieldRequest& req)
   //       that each field belongs to.
   for (const auto& group_name : req.groups) {
     // Get group (and init ptr, if necessary)
-    auto& group = m_field_groups[group_name];
-    if (group==nullptr) {
-      group = std::make_shared<group_info_type>(group_name);
+    auto& group_info = m_field_groups[group_name];
+    if (group_info==nullptr) {
+      group_info = std::make_shared<group_info_type>(group_name);
     }
 
     // Add the field name to the list of fields belonging to this group
-    if (ekat::find(group->m_fields_names,id.name())==group->m_fields_names.end()) {
-      group->m_fields_names.push_back(id.name());
+    if (ekat::find(group_info->m_fields_names,id.name())==group_info->m_fields_names.end()) {
+      group_info->m_fields_names.push_back(id.name());
     }
+
+    // In order to simplify the logic in pre_process_group_requests,
+    // add a "trivial" GroupRequest for this group, meaning no bundling,
+    // pack size 1, and no derivation from another group. This ensure that each group
+    // in m_field_groups also appears in the m_group_requests map.
+    register_group(GroupRequest(group_name,m_grid->name()));
   }
 
   // Add not a NaN property check
@@ -263,21 +269,44 @@ get_field_group (const std::string& group_name) const
   // Set the info in the group
   group.m_info = m_field_groups.at(group_name);
 
-  // Find all the fields and set them in the group
-  for (const auto& fname : group.m_info->m_fields_names) {
-    auto f = get_field_ptr(fname);
-    group.m_fields[fname] = f;
+  // IMPORTANT: this group might have been created as a "Copy" (see field_request.hpp)
+  //            of another group. In this case, we only allocate the bundled group,
+  //            and we don't create individual subfields. Users can still extract
+  //            subfields on the fly, if need be, by using the names/idx data in m_info.
+  auto it = m_group_requests.find(group_name);
+  bool allocate_subfields = true;
+  if (it!=m_group_requests.end()) {
+    for (const auto& req : it->second) {
+      if (req.derived_type==DerivationType::Copy) {
+        allocate_subfields = false;
+        break;
+      }
+    }
+  }
+
+  if (allocate_subfields) {
+    // Find all the fields and set them in the group
+    for (const auto& fname : group.m_info->m_fields_names) {
+      auto f = get_field_ptr(fname);
+      group.m_fields[fname] = f;
+    }
   }
 
   // Fetch the bundle field (if bundled)
   if (group.m_info->m_bundled) {
-    // We can get the parent from any of the fields in the group.
-    auto p = group.m_fields.begin()->second->get_header().get_parent().lock();
-    EKAT_REQUIRE_MSG(p!=nullptr,
-        "Error! A field belonging to a bundled field group is missing its 'parent'.\n");
+    if (allocate_subfields) {
+      // We can get the parent from any of the fields in the group.
+      auto p = group.m_fields.begin()->second->get_header().get_parent().lock();
+      EKAT_REQUIRE_MSG(p!=nullptr,
+          "Error! A field belonging to a bundled field group is missing its 'parent'.\n");
 
-    const auto& p_id = p->get_identifier();
-    group.m_bundle = get_field_ptr(p_id);
+      const auto& p_id = p->get_identifier();
+      group.m_bundle = get_field_ptr(p_id);
+    } else {
+      // This group was copied, and therefore we know we created the bundled field with
+      // the same name as the group itself. So simply fetch that field
+      group.m_bundle = get_field_ptr(group_name);
+    }
   }
 
   return group;
@@ -300,22 +329,45 @@ get_const_field_group (const std::string& group_name) const
   // Set the info in the group
   group.m_info = m_field_groups.at(group_name);
 
-  // Find all the fields and set them in the group
-  for (const auto& fname : group.m_info->m_fields_names) {
-    auto f = get_field_ptr(fname);
-    auto cf = std::make_shared<const_field_type>(f->get_const());
-    group.m_fields[fname] = cf;
+  // IMPORTANT: this group might have been created as a "Copy" (see field_request.hpp)
+  //            of another group. In this case, we only allocate the bundled group,
+  //            and we don't create individual subfields. Users can still extract
+  //            subfields on the fly, if need be, by using the names/idx data in m_info.
+  auto it = m_group_requests.find(group_name);
+  bool allocate_subfields = true;
+  if (it!=m_group_requests.end()) {
+    for (const auto& req : it->second) {
+      if (req.derived_type==DerivationType::Copy) {
+        allocate_subfields = false;
+        break;
+      }
+    }
+  }
+
+  if (allocate_subfields) {
+    // Find all the fields and set them in the group
+    for (const auto& fname : group.m_info->m_fields_names) {
+      auto f = get_field_ptr(fname);
+      auto cf = std::make_shared<const_field_type>(f->get_const());
+      group.m_fields[fname] = cf;
+    }
   }
 
   // Fetch the bundle field (if bundled)
   if (group.m_info->m_bundled) {
-    // We can get the parent from any of the fields in the group.
-    auto p = group.m_fields.begin()->second->get_header().get_parent().lock();
-    EKAT_REQUIRE_MSG(p!=nullptr,
-        "Error! A field belonging to a bundled field group is missing its 'parent'.\n");
+    if (allocate_subfields) {
+      // We can get the parent from any of the fields in the group.
+      auto p = group.m_fields.begin()->second->get_header().get_parent().lock();
+      EKAT_REQUIRE_MSG(p!=nullptr,
+          "Error! A field belonging to a bundled field group is missing its 'parent'.\n");
 
-    const auto& p_id = p->get_identifier();
-    group.m_bundle = std::make_shared<const_field_type>(get_field_ptr(p_id)->get_const());
+      const auto& p_id = p->get_identifier();
+      group.m_bundle = std::make_shared<const_field_type>(get_field_ptr(p_id)->get_const());
+    } else {
+      // This group was copied, and therefore we know we created the bundled field with
+      // the same name as the group itself. So simply fetch that field
+      group.m_bundle = std::make_shared<const_field_type>(get_field_ptr(group_name)->get_const());
+    }
   }
 
   return group;
@@ -362,8 +414,8 @@ registration_ends ()
   // all the requests:
   //  1) ensure all groups contain the desired members. This means that we need to
   //     loop over GroupRequest (GR), and make sure there are fields registered in those
-  //     groups (querying m_field_groups info structs). If a GR is 'relative' to another
-  //     GR, like a 'Child' group (see GR header for details), we make sure the group
+  //     groups (querying m_field_groups info structs). If a GR is derived from another
+  //     GR, like a 'Subset' group (see GR header for details), we make sure the group
   //     is in m_field_groups (if not, add it), and contains all the proper fields.
   //  2) Focus only on GR that require (or prefer) a bundled group, discarding others.
   //     All the remaining group can simply "grab" individual fields later (and they
@@ -402,90 +454,31 @@ registration_ends ()
   //        to remove.
   //
 
-  // This lambda process a group request, and ensures the group contains only what it should contain
-  auto ensure_group_members_correctness = [&] (const GroupRequest& r) {
-    if (r.relative==nullptr || r.relative_type==Relationship::Parent) {
-      // This request is either not related to another group, or it is a superset
-      // of another group. Either way, the group of this request must exist.
-      // TODO: should this be removed? What if a group is 'optional'?
-      EKAT_REQUIRE_MSG (m_field_groups.find(r.name)!=m_field_groups.end(),
-          "Error! Found a requested group that has no fields associated to it.\n"
-          "    -  Group name: " + r.name + "\n"
-          "    -  Grid name:  " + r.grid + "\n");
-    } else {
-      // If this request is a relative (alias or subset) of a relative group, then the
-      // relative group must exist.
-      EKAT_REQUIRE_MSG(m_field_groups.find(r.relative->name)!=m_field_groups.end(),
-          "Error! Found a requested group with a relative that has no fields associated to it.\n"
-          "    -  Group name:    " + r.name + "\n"
-          "    -  Relative name: " + r.relative->name + "\n"
-          "    -  Relative type: " + e2str(r.relative_type) + "\n"
-          "    -  Grid name:     " + r.grid + "\n");
-    }
 
-    if (r.relative!=nullptr) {
-      if (r.relative_type==Relationship::Child || r.relative_type==Relationship::Alias) {
-        // All fields in the child/alias group must be added to this group
-        auto& members = m_field_groups.at(r.name)->m_fields_names;
-        const auto& relatives = m_field_groups.at(r.relative->name)->m_fields_names;
-        for (const auto& n : relatives) {
-          if (!ekat::contains(members,n)) {
-            members.push_back(n);
-          }
-        }
-      } else if (r.relative_type==Relationship::Parent) {
-        // We take all fields in the parent group and add them to this group,
-        // provided that they are not in the 'exclude' list.
-        auto& members = m_field_groups.at(r.name)->m_fields_names;
-        const auto& relatives = m_field_groups.at(r.relative->name)->m_fields_names;
-        for (const auto& n : relatives) {
-          if (!ekat::contains(members,n) && !ekat::contains(r.exclude,n)) {
-            members.push_back(n);
-          }
-        }
-      }
-    }
-
-    // Additional check. Say group G1 is a subset of G2=(f1,f2,f3), excluding f2.
-    // If by chance, someone registered field f2 as part of G1, we have inconsistent
-    // requests. Rather than allow sneaky bugs to go in, let's error out.
-    const auto& members = m_field_groups.at(r.name)->m_fields_names;
-    for (const auto& e : r.exclude) {
-      EKAT_REQUIRE_MSG (not ekat::contains(members,e),
-          "Error! Found group containing fields that were supposed to be excluded from relative group fields list.\n"
-          "       Most likely cause is that someone individually registered a field as part of this group, while\n"
-          "       someone else requested this group as subset of another group, excluding this field.\n"
-          "    -  Group name: " + r.name + "\n"
-          "    -  Grid name:  " + r.grid + "\n"
-          "    -  Field name: " + e + "\n");
-
-    }
-  };
-
-  // First, check groups are well defined, and contain the correct members
-  for (const auto& greqs : m_group_requests) {
-    for (const auto& r : greqs.second) {
-      ensure_group_members_correctness (r);
-    }
-  }
-  for (const auto& it : m_field_groups) {
-    EKAT_REQUIRE_MSG (it.second->size()>0,
-        "Error! We have a group in this Field Manager that has no members.\n"
-        "       Group name: " + it.first + "\n"
-        "       Grid name:  " + m_grid->name() + "\n");
-  }
+  // Start by processing group request. This function will ensure that, if there's a
+  // request for group A that depends on the content of group B, the FieldGroupInfo
+  // for group A is updated to contain the correct fields, based on the content
+  // of group B. It also checks that the requests are not inconsistent.
+  pre_process_group_requests ();
 
   // Gather a list of groups to be bundled
-  std::list<std::string> groups_to_bundle;
+  // NOTE: copied groups are always created bundled, but in a second phase,
+  //       without creating individual subfields.
+  std::list<std::string> groups_to_bundle, copied_groups;
   for (const auto& greqs : m_group_requests) {
     for (const auto& r : greqs.second) {
-      if (r.bundling!=Bundling::NotNeeded) {
+      if (r.derived_type!=DerivationType::Copy && r.bundling!=Bundling::NotNeeded) {
         // There's at least one request for this group to be bunlded.
-        groups_to_bundle.push_back(r.name);
-        break;
+        groups_to_bundle.push_back(greqs.first);
+      } else if (r.derived_type==DerivationType::Copy) {
+        copied_groups.push_back(greqs.first);
       }
     }
   }
+  groups_to_bundle.sort();
+  copied_groups.sort();
+  groups_to_bundle.unique();
+  copied_groups.unique();
 
   // Homme currently wants qv to be the first tracer. We should be able to
   // modify Homme, to use something like qv_idx. However, that requires
@@ -495,7 +488,7 @@ registration_ends ()
   if (has_field("qv")) {
     auto it = ekat::find(groups_to_bundle,"tracers");
     if (it!=groups_to_bundle.end()) {
-      // Bring tracers to the front
+      // Bring tracers to the front, so it will be processed first
       std::swap(*it,groups_to_bundle.front());
 
       // Adding the 'fake' group G=(qv) at the front of groups_to_bundle ensures qv won't be put
@@ -627,8 +620,8 @@ registration_ends ()
 
       // Ok, if we got here, it means we can allocate the cluster as a field, and then subview all the groups
       // Steps:
-      //  - check if there's a group in the cluster containing all the fields. If yes, use that
-      //    group name for the bundled field, otherwise make one up from the names of all groups.
+      //  - check if there's a group in the cluster containing all the fields. If yes, use that group
+      //    name for the bundled field, otherwise make one up from the names of all groups in the cluster.
       //  - allocate the cluster field F.
       //  - loop over the groups in the cluster, and subview F at the proper (contiguous) indices.
 
@@ -638,7 +631,7 @@ registration_ends ()
       if (qv_it!=cluster_ordered_fields.end()) {
         // Check that qv comes first or last (if last, reverse the list). If not, error out.
         // NOTE: I *think* this should not happen, unless 'tracers' is a subgroup of a bigger group.
-        EKAT_REQUIRE_MSG(qv_it==cluster_ordered_fields.begin() || qv_it==(cluster_ordered_fields.end()--),
+        EKAT_REQUIRE_MSG(qv_it==cluster_ordered_fields.begin() || std::next(qv_it,1)==cluster_ordered_fields.end(),
             "Error! The water vapor field has to be the first tracer, but it is not.\n");
 
         if (qv_it!=cluster_ordered_fields.begin()) {
@@ -789,9 +782,61 @@ registration_ends ()
   }
 
   // Now that all bundled fields have been taken care of, we can
-  //  - allocate remaining fields
+  //  - create copied groups (as a bundled field) and update their info
+  //  - allocate remaining fields (not part of a bundled field)
   //  - update the tracking of each field, by adding the group info of all
   //    the groups the field belongs to.
+  for (const auto& gname : copied_groups) {
+    using namespace ShortFieldTagsNames;
+    auto& info  = *m_field_groups.at(gname);
+    const int   size  = info.size();
+
+    // The units for the bundled field are nondimensional, cause checking whether
+    // all fields in the bundle have the same units so we can use those is too long and pointless.
+    auto nondim = ekat::units::Units::nondimensional();
+
+    // Take any of the fields in the group to be copied, and determine
+    // whether they are 2d or 3d.
+    auto f1 = m_fields.at(info.m_fields_names.front());
+    auto f1_layout = f1->get_header().get_identifier().get_layout();
+    auto lt = get_layout_type(f1_layout.tags());
+    FieldLayout g_layout = FieldLayout::invalid();
+    if (lt==LayoutType::Scalar2D) {
+      g_layout = m_grid->get_2d_vector_layout(CMP,size);
+    } else {
+      bool mid = f1_layout.tags().back()==LEV;
+      g_layout = m_grid->get_3d_vector_layout(mid,CMP,size);
+    }
+
+    FieldIdentifier g_fid(gname,g_layout,nondim,m_grid->name());
+    register_field(g_fid);
+    const auto& G = m_fields.at(g_fid.name());
+
+    // Loop over the requests, and set the alloc props
+    auto& G_ap = G->get_header().get_alloc_properties();
+    constexpr auto real_size = sizeof(RealType);
+    for (const auto& req : m_group_requests.at(gname)) {
+      G_ap.request_allocation(real_size,req.pack_size);
+    }
+    G->allocate_view();
+
+    // Now, update the group info of the copied group, by setting the
+    // correct subview_idx, in case the user wants to extract the
+    // individual fields as Field structs.
+    // NOTE: individual fields are *not* registered in the repo,
+    //       but the user *can* create subfields, if needed.
+    //       E.g., user might create subfields for remapping purposes.
+    // Note: as of 08/2021, idim should *always* be 1, but we store it just in case,
+    //       to avoid bugs in the future.
+    const auto& G_tags = g_layout.tags();
+    const int idim = std::distance(G_tags.begin(),ekat::find(G_tags,CMP));
+    for (int i=0; i<size; ++i) {
+      const auto& fn = *std::next(info.m_fields_names.begin(),i);
+      info.m_subview_dim = idim;
+      info.m_subview_idx [fn] = i;
+    }
+    info.m_bundled = true;
+  }
 
   for (auto& it : m_fields) {
     if (it.second->is_allocated()) {
@@ -804,13 +849,17 @@ registration_ends ()
   }
 
   for (const auto& it : m_field_groups) {
-    auto fgi = it.second;
-
+    if (ekat::contains(copied_groups,it.first)) {
+      // Copied groups use the same field names as the group they copied,
+      // but those fields do not belong to the copy group.
+      continue;
+    }
     // Get fields in this group
-    const auto& fnames = fgi->m_fields_names;
+    auto group_info = it.second;
+    const auto& fnames = group_info->m_fields_names;
     for (const auto& fn : fnames) {
       // Update the field tracking
-      m_fields.at(fn)->get_header().get_tracking().add_to_group(fgi);
+      m_fields.at(fn)->get_header().get_tracking().add_to_group(group_info);
     }
   }
 
@@ -843,6 +892,201 @@ std::shared_ptr<typename FieldManager<RealType>::field_type>
 FieldManager<RealType>::get_field_ptr (const std::string& name) const {
   auto it = m_fields.find(name);
   return it==m_fields.end() ? nullptr : it->second;
+}
+
+template<typename RealType>
+void FieldManager<RealType>::pre_process_group_requests () {
+  // GroupRequests that are formulated in terms of another group (i.e., where
+  // req.derived_type!=DerivationType::None), need a preprocessing step.
+  // This step needs to do two things: 1) make sure the group contains all
+  // the fields it needs, and 2) make sure the different group requests are
+  // consistent and valid. Point 1 is necessary, since nobody may have added
+  // any field to the group. E.g., if group B is a subset of group A={f1,f2,f3}
+  // with f1 removed, we need to make sure B={f2,f3} (might be nobody registered
+  // f2 and f3 as part of B). Point 2 is to make sure we don't ask for things
+  // that are either too complicated to handle (and likely never going to be needed)
+  // or inconsistent. E.g., if group A is requested as a "Copy" of group B,
+  // and group B is requested as a "Copy" of group A (whish is copying which?).
+  // Note: it is allowed for requests to be "chained". E.g., group A can be
+  // listed as subset of B={f1,f2,f3,f4}, with f4 removed, and group B can be
+  // listed as subset of A, with f2 removed.
+  // Since requests can be "chained" (in the sense explained above), we must process
+  // them in the "right" order. That is, if we have a req for group A that
+  // depends on group B, and there are reqs for group B that depend on other groups,
+  // we must process group B first. So first, let's sort group requests
+  // so that they are in the correct order
+
+  // A list storing the order in which we process the requests.
+  std::list<std::string> ordered_groups;
+  while (ordered_groups.size()<m_group_requests.size()) {
+    // If this iteration of the while loop does not increase the size of ordered_groups,
+    // then there are circular deps, and we need to error out.
+    size_t curr_size = ordered_groups.size();
+
+    for (const auto& greqs : m_group_requests) {
+      if (ekat::contains(ordered_groups,greqs.first)) {
+        // We already processed this group
+        continue;
+      }
+
+      // In order for this group to be able to be processed,
+      // it must only have deps on groups already added to ordered_groups.
+      bool can_process_this_group = true;
+      for (const auto& req : greqs.second) {
+        if (req.derived_type!=DerivationType::None &&
+            not ekat::contains(ordered_groups,req.src_name)) {
+          can_process_this_group = false;
+          break;
+        }
+      }
+
+      if (can_process_this_group) {
+        // Ok, this group does not depend on any other group, or it depends
+        // on groups we already processed. Append it to ordered_groups.
+        ordered_groups.push_back(greqs.first);
+      }
+    }
+
+    EKAT_REQUIRE_MSG (curr_size<ordered_groups.size(),
+        "Error! There are circular dependencies between group requests.\n"
+        "       The FieldManager cannot handle them.\n");
+
+  }
+
+  // Now we have an order in which we can process group requests. Go in order.
+  for (const auto& gname : ordered_groups) {
+    const auto& reqs = m_group_requests.at(gname);
+
+    // First, we add any field needed to the corresponding FieldGroupInfo
+    // Note: we only need to parse Superset, Subset, and Copy requests
+    auto& info = m_field_groups.at(gname);
+    for (const auto& r : reqs) {
+      switch(r.derived_type) {
+        case DerivationType::None: // [[fallthrough]] // c++17 keyword
+        case DerivationType::Import:
+          break;
+        case DerivationType::Copy:  // [[fallthrough]] // c++17 keyword
+        case DerivationType::Superset:
+          for (const auto& fname : m_field_groups.at(r.src_name)->m_fields_names) {
+            // Since we don't want to sort field names lists, adding duplciates
+            // would make removing them hard, so might as well check before adding names.
+            if (not ekat::contains(info->m_fields_names,fname)) {
+              info->m_fields_names.push_back(fname);
+            }
+          }
+          break;
+        case DerivationType::Subset:
+          for (const auto& fname : m_field_groups.at(r.src_name)->m_fields_names) {
+            // Since we don't want to sort field names lists, adding duplciates
+            // would make removing them hard, so might as well check before adding names.
+            if (not ekat::contains(info->m_fields_names,fname) &&
+                not ekat::contains(r.exclude,fname)) {
+              info->m_fields_names.push_back(fname);
+            }
+          }
+          break;
+      }
+    }
+
+    // Now that all groups contain all fields, we can check consistency.
+    for (const auto& req : reqs) {
+      // Depending on the derivation type (if any), do different checks
+      switch (req.derived_type) {
+        case DerivationType::None:
+          // Nothing to do for this request.
+          break;
+        case DerivationType::Import:
+          // An imported group cannot depend on other groups. That is, we don't allow
+          // to do something like G1 = import(G2,from_grid_blah) + G3.
+          // We allow, however, to have multiple 'Import' requests, simply with different
+          // pack sizes or bundling requests
+          for (const auto& r : reqs) {
+            if (r.derived_type!=DerivationType::None) {
+              EKAT_REQUIRE_MSG (r.derived_type==DerivationType::Import,
+                  "Error! An Impor request cannot be mixed with non-Import requests.\n"
+                  "  group name: " + req.name + "\n"
+                  "  second req type: " + e2str(req.derived_type) + "\n");
+              EKAT_REQUIRE_MSG (r.src_name==req.src_name &&
+                                r.src_grid==req.src_grid,
+                  "Error! An Impor request cannot be mixed with other Import requests\n"
+                  "       of different groups or from different grids.\n"
+                  "  group name: " + req.name + "\n"
+                  "  current req source group: " + req.src_name + "\n"
+                  "  current req source grid: " + req.src_grid + "\n"
+                  "  second req source group: " + r.src_name + "\n"
+                  "  second req source grid: " + r.src_grid + "\n");
+            }
+          }
+
+          break;
+        case DerivationType::Copy:
+          // We can only copy a group from this grid
+          EKAT_REQUIRE_MSG (req.src_grid==m_grid->name(),
+              "Error! Use 'Copy' group requests to copy a group from the same grid.\n");
+          // Make sure we're not mixing 'Copy' with other requests types other than Copy or None
+          for (const auto& r : reqs) {
+            if (r.derived_type!=DerivationType::None) {
+              EKAT_REQUIRE_MSG (r.derived_type==DerivationType::Copy,
+                  "Error! A Copy request cannot be mixed with non-Copy requests.\n"
+                  "  group name: " + req.name + "\n"
+                  "  second req type: " + e2str(req.derived_type) + "\n");
+              EKAT_REQUIRE_MSG (r.src_name==req.src_name,
+                  "Error! A Copy request cannot be mixed with other Copy requests of different groups.\n"
+                  "  group name: " + req.name + "\n"
+                  "  current req source group: " + req.src_name + "\n"
+                  "  second req source group: " + r.src_name + "\n");
+            }
+          }
+
+          break;
+        case DerivationType::Subset:
+        {
+          // Say group A is a subset of B={f1,f2,f3}, with f2 removed. If someone registered
+          // field f2 as part of A, then we have an inconsistency. We also have an inconsistency
+          // if someone asked for A to be a superset of C={f2,f3}, since f2 was supposed to be removed.
+          const auto& fnames = m_field_groups.at(gname)->m_fields_names;
+          for (const auto& excl : req.exclude) {
+            EKAT_REQUIRE_MSG (not ekat::contains(fnames,excl),
+                "Error! Found a request for group A to be a subset of group B,\n"
+                "       but one of the excluded fields was explicitly (via register_field)\n"
+                "       or implicitly (via another group request) added to group A.\n"
+                "  current group (A): " + gname + "\n"
+                "  superset group (B): " + req.src_name + "\n"
+                "  field name: " + excl + "\n");
+          }
+          // Also check that all fields of this group are in the source group
+          const auto& rel_fnames = m_field_groups.at(req.src_name)->m_fields_names;
+          for (const auto& f : fnames) {
+            EKAT_REQUIRE_MSG (ekat::contains(rel_fnames,f),
+                "Error! Found a request for group A to be a subset of group B,\n"
+                "       but it contains a field not in the group B.\n"
+                "       Most likely reason: the was also a request for group A\n"
+                "       to be a superset of group C, which was not a subset of B\n"
+                "  current group (A): " + f + "\n"
+                "  superset group (B): " + req.src_name + "\n"
+                "  field name: " + f + "\n");
+          }
+          break;
+        }
+        case DerivationType::Superset:
+        {
+          const auto& fnames = m_field_groups.at(gname)->m_fields_names;
+          const auto& rel_fnames = m_field_groups.at(req.src_name)->m_fields_names;
+          for (const auto& f : rel_fnames) {
+            EKAT_REQUIRE_MSG (ekat::contains(fnames,f),
+                "Error! Found a request for group A to be a superset of group B,\n"
+                "       but group B contains a field not in group A.\n"
+                "       Most likely reason: the was also a request for group A\n"
+                "       to be a subset of group C, which was not a superset of B\n"
+                "  current group (A): " + f + "\n"
+                "  subset group (B): " + req.src_name + "\n"
+                "  field name: " + f + "\n");
+          }
+          break;
+        }
+      }
+    }
+  }
 }
 
 } // namespace scream

--- a/components/scream/src/share/field/field_request.hpp
+++ b/components/scream/src/share/field/field_request.hpp
@@ -2,7 +2,7 @@
 #define SCREAM_FIELD_REQUEST_HPP
 
 #include "share/field//field_identifier.hpp"
-#include "share/util//scream_utils.hpp"
+#include "share/util/scream_utils.hpp"
 
 namespace scream {
 

--- a/components/scream/src/share/field/field_request.hpp
+++ b/components/scream/src/share/field/field_request.hpp
@@ -2,7 +2,7 @@
 #define SCREAM_FIELD_REQUEST_HPP
 
 #include "share/field//field_identifier.hpp"
-#include "share/scream_types.hpp"
+#include "share/util//scream_utils.hpp"
 
 namespace scream {
 
@@ -13,20 +13,31 @@ enum class Bundling : int {
   NotNeeded
 };
 
-// Whether two groups (see below) are related.
-enum class Relationship : int {
+// What's the relation of group A and group B. In particular, if group A is 'derived'
+// from group B, this enum explains how it is derived.
+//  - None: not a "derived" request
+//  - Import: group B is on a different grid than group A. This derivation type makes
+//            sure that there is a replica of B on the grid associated with A.
+//  - Copy: a hard copy of the group B is created, with only the "bundled" field being
+//          allocated, to avoid creating two copies of the samae field.
+//          This derivation type requires group A and group B to be on the *same* grid.
+//  - Superset: all fields in A also appear in B (the *same* fields)
+//  - Subset: all fields in B also appear in A (the *same* fields)
+enum class DerivationType : int {
   None,
-  Alias,
-  Parent,
-  Child
+  Import,
+  Copy,
+  Superset,
+  Subset
 };
 
-inline std::string e2str (const Relationship rt) {
+inline std::string e2str (const DerivationType rt) {
   switch (rt) {
-    case Relationship::None:    return "None";
-    case Relationship::Alias:   return "Alias";
-    case Relationship::Child:   return "Child";
-    case Relationship::Parent:  return "Parent";
+    case DerivationType::None:      return "None";
+    case DerivationType::Import:    return "Import";
+    case DerivationType::Copy:      return "Copy";
+    case DerivationType::Subset:    return "Subset";
+    case DerivationType::Superset:  return "Superset";
   }
   return "INVALID";
 }
@@ -55,35 +66,34 @@ struct GroupRequest {
   //  - bundling: whether the group should be bundled (see field_group.hpp)
   //  - r: allows to specify specs of this request in terms of another.
   //  - t: the relationshipt of group in request r compared to this one.
-  //       E.g.: t=Parent means r->name is a superset of group this->name.
-  //  - excl: if t=Parent, this group contains all field in r, *except* those in this list.
+  //       E.g.: t=Superset means r->name is a superset of group this->name.
+  //  - exclude: if t=Superset/Subset, this group contains all field in r, *except/plus* those in this list.
   GroupRequest (const std::string& name_, const std::string& grid_, const int ps, const Bundling b,
-                const GroupRequest* r, const Relationship t, const std::list<std::string>& excl = {})
-   : name(name_), grid(grid_), pack_size(ps), bundling(b)
+                const DerivationType rt, const std::string& src_name_, const std::string& src_grid_,
+                const std::list<std::string>& exclude_ = {})
+   : name(name_), grid(grid_), pack_size(ps), bundling(b), derived_type(rt)
   {
     EKAT_REQUIRE_MSG(pack_size>=1, "Error! Invalid pack size request.\n");
-    if (r!=nullptr) {
-      relative = std::make_shared<GroupRequest>(*r);
-      relative_type = t;
-      EKAT_REQUIRE_MSG (t!=Relationship::None,
-          "Error! RelativType cannot be None if the relative pointer is not null.\n");
-      EKAT_REQUIRE_MSG (excl.size()==0 || t==Relationship::Parent,
-          "Error! You can only exclude fields from a relative group if the input GroupRequest ptr is a Parent.\n");
-      exclude = excl;
+    if (rt!=DerivationType::None) {
+      src_name = src_name_;
+      src_grid = src_grid_;
 
-      // TODO: should we relax this? Not allowing multiple levels of nested
-      //       relativeing makes it easier for the AD and FM to correctly allocated
-      //       fields...
-      EKAT_REQUIRE_MSG (r->relative==nullptr,
-          "Error! We cannot handle multiple levels of nested groups.\n");
+      EKAT_REQUIRE_MSG (src_grid==grid || rt==DerivationType::Import,
+          "Error! We only allow cross-grid group derivation if the derivation type is 'Import'.");
+
+      EKAT_REQUIRE_MSG (exclude_.size()==0 || rt==DerivationType::Subset,
+          "Error! You can only exclude fields when deriving a group from another if this group\n"
+          "       is a subset of the source group.\n");
+      exclude = exclude_;
     }
   }
 
-  // Convenience overloads of the ctor
+  // Convenience ctors when some features are not needed
   GroupRequest (const std::string& name_, const std::string& grid_,
                 const int ps, const Bundling b = Bundling::NotNeeded)
-   : GroupRequest(name_,grid_,ps,b,nullptr,Relationship::None,{})
+   : GroupRequest(name_,grid_,ps,b,DerivationType::None,"","",{})
   { /* Nothing to do here */ }
+
   GroupRequest (const std::string& name_, const std::string& grid_,
                 const Bundling b = Bundling::NotNeeded)
    : GroupRequest(name_,grid_,1,b)
@@ -91,26 +101,27 @@ struct GroupRequest {
 
   // Default copy ctor is perfectly fine
   GroupRequest (const GroupRequest&) = default;
-
   
+  // Main parts of a group request
   std::string name;   // Group name
   std::string grid;   // Grid name
   int pack_size;      // Request an allocation that can accomodate Pack<Real,pack_size>
+  Bundling bundling;  // Whether the group should be allocated as a single n+1 dimensional field
 
   // The following members allow to specify a request in terms of another group.
   // A possible use of this is when an atm proc wants to create G1 "excluding"
   // some fields from G2, and have the remaining ones still contiguous in mem (i.e.,
   // accessible with a bundled array). This will inform the FM to rearrange the fields
   // in G2 so that the subset of fields that are in G1 appear contiguously.
+  // Another use is to create group G2 on grid B to contain the same fields of
+  // group G1 on grid A, without knowing what's in G1 a priori.
   // See comments in FieldManager::registration_ends() for more details
-  std::shared_ptr<GroupRequest>   relative;
-
-  Bundling bundling;
-
-  // Note: relative_type is what the group relative->name is *to me*. So, if relative_type=Child,
-  //       then the group relative->name contains a subset of the fields in the group this->name;
-  Relationship relative_type;
-  std::list<std::string> exclude;
+  // Note: derived_type is what *this group* is for $src_name. So, if derived_type=Subset,
+  //       then this group is a subset of the group $src_name.
+  DerivationType derived_type;
+  std::string src_name;
+  std::string src_grid;
+  std::list<std::string> exclude;  // Only for derived_type=Subset
 };
 
 // In order to use GroupRequest in std sorted containers (like std::set),
@@ -118,30 +129,57 @@ struct GroupRequest {
 inline bool operator< (const GroupRequest& lhs,
                        const GroupRequest& rhs)
 {
+  // Order by group name first
   if (lhs.name<rhs.name) {
     return true;
-  } else if (lhs.name==rhs.name) {
-    if (lhs.grid<rhs.grid) {
-      return true;
-    } else if (lhs.grid==rhs.grid) {
-      if (lhs.pack_size < rhs.pack_size) {
-        return true;
-      } else if (lhs.pack_size==rhs.pack_size) {
-        if (lhs.relative==nullptr) {
-          return rhs.relative!=nullptr;
-        } else if (rhs.relative!=nullptr) {
-          if ( (*lhs.relative) < (*rhs.relative) ) {
-            return true;
-          } else if ( ! ( (*rhs.relative)<(*lhs.relative)) ) {
-            return etoi(lhs.bundling) < etoi(rhs.bundling) ||
-                   (etoi(lhs.bundling) == etoi(rhs.bundling) &&
-                    etoi(lhs.relative_type) < etoi(rhs.relative_type));
-          }
-        }
-      }
-    }
+  } else if (lhs.name>rhs.name) {
+    return false;
   }
-  return false;
+
+  // Same group name, order by grid
+  if (lhs.grid<rhs.grid) {
+    return true;
+  } else if (lhs.grid>rhs.grid) {
+    return false;
+  }
+
+  // Same grid name, order by pack size
+  if (lhs.pack_size < rhs.pack_size) {
+    return true;
+  } else if (lhs.pack_size>rhs.pack_size) {
+    return false;
+  }
+
+  // Same pack size, order by bundling
+  if (etoi(lhs.bundling)<etoi(rhs.bundling)) {
+    return true;
+  } else if (etoi(lhs.bundling)>etoi(rhs.bundling)) {
+    return false;
+  }
+
+  // Same bundling, order by derivation type
+  if (etoi(lhs.derived_type)<etoi(rhs.derived_type)) {
+    return true;
+  } else if (etoi(lhs.derived_type)<etoi(rhs.derived_type)) {
+    return false;
+  }
+
+  // Same derivation type, order by source group name
+  if (lhs.src_name<rhs.src_name) {
+    return true;
+  } else if (lhs.src_name>rhs.src_name) {
+    return false;
+  }
+
+  // Same souce group name, order by source group grid
+  if (lhs.src_grid<rhs.src_grid) {
+    return true;
+  } else if (lhs.src_grid>rhs.src_grid) {
+    return false;
+  }
+
+  // Same source group grid, order by exclude fields
+  return (lhs.exclude<rhs.exclude);
 }
 
 /*

--- a/components/scream/src/share/field/field_tracking.cpp
+++ b/components/scream/src/share/field/field_tracking.cpp
@@ -2,12 +2,6 @@
 
 namespace scream {
 
-FieldTracking::FieldTracking (const std::string& name)
- : m_name (name)
-{
-  // Nothing to do here
-}
-
 void FieldTracking::add_provider (const std::weak_ptr<AtmosphereProcess>& provider) {
   m_providers.insert(provider);
 }

--- a/components/scream/src/share/field/field_tracking.hpp
+++ b/components/scream/src/share/field/field_tracking.hpp
@@ -12,8 +12,6 @@
 
 #include <memory>   // For std::weak_ptr
 #include <string>
-#include <list>
-#include <set>
 
 namespace scream {
 
@@ -29,8 +27,7 @@ public:
   using atm_proc_ptr_type = std::weak_ptr<AtmosphereProcess>;
   using atm_proc_set_type = ekat::WeakPtrSet<AtmosphereProcess>;
 
-  FieldTracking() = delete;
-  explicit FieldTracking(const std::string& name);
+  FieldTracking() = default;
   FieldTracking(const FieldTracking&) = default;
 
   // No assignment, to prevent tampering with tracking (e.g., rewinding time stamps)
@@ -63,8 +60,6 @@ public:
   //       However, if the field has a 'parent' (see FamilyTracking), the parent's ts will not be updated.
   void update_time_stamp (const TimeStamp& ts);
 
-  const std::string& name () const { return m_name; }
-
 protected:
 
   // We keep the field name just to make debugging messages more helpful
@@ -72,12 +67,6 @@ protected:
 
   // Tracking the updates of the field
   TimeStamp         m_time_stamp;
-
-  // These are to be used to track the order in which providers update the field at each time step.
-  // One can use this information to track when a field gets updated during a timestep. It can be
-  // particularly useful in the case of parallel schedules.
-  std::set<std::string>   m_last_timestep_providers;
-  std::set<std::string>   m_curr_timestep_providers;
 
   // List of provider/customer processes. A provider is an atm process that computes/updates the field.
   // A customer is an atm process that uses the field just as an input.
@@ -87,13 +76,15 @@ protected:
 
   // Groups are used to bundle together fields, so that a process can request all of them
   // without knowing/listing all their names. For instance, the dynamics process needs to
-  // get all tracers, which need to be advected. However, dyamics has no idea of what are
-  // the tracers names, and neither should it care. Groups can come to rescue here, allowing
-  // dynamics to request all fields that have been marked as 'tracers'.
+  // get all tracers, which need to be advected. However, dynamics has no idea (a priori)
+  // of what are the tracers names or how many there are, and neither should it care.
+  // FieldGroup's allow atm procs to request all fields that have been marked as 'tracers'.
+  // Here, we keep track of all the groups that this field belongs to.
   ekat::WeakPtrSet<const FieldGroupInfo>    m_groups;
 };
 
-// Use this free function to exploit features of enable_from_this
+// Use this free function to exploit features of enable_shared_from_this,
+// as well as features from FamilyTracking.
 template<typename... Args>
 inline std::shared_ptr<FieldTracking>
 create_tracking(const Args&... args) {

--- a/components/scream/src/share/scream_types.hpp
+++ b/components/scream/src/share/scream_types.hpp
@@ -49,18 +49,6 @@ sp (const T val) {
   return Real(val);
 }
 
-// Micro-utility, that given an enum returns the underlying int.
-// The only use of this is if you need to sort scoped enums.
-template<typename EnumT>
-KOKKOS_FUNCTION
-constexpr typename
-std::enable_if<std::is_enum<EnumT>::value,
-               typename std::underlying_type<EnumT>::type
-              >::type
-etoi (const EnumT e) {
-  return static_cast<typename std::underlying_type<EnumT>::type>(e);
-}
-
 } // namespace scream
 
 #endif // SCREAM_TYPES_HPP

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -539,11 +539,11 @@ TEST_CASE("multiple_bundles") {
 
   GroupRequest g1_req ("group1",grid_name,Bundling::Required);
   GroupRequest g2_req ("group2",grid_name,Bundling::Required);
-  // group3 += group2
+  // Include all group2 in group3
   GroupRequest g3_req ("group3",grid_name,4,Bundling::Required,DerivationType::Superset,g2_req.name,g2_req.grid);
-  // group4 = group2
+  // Create group4 as a copy of group2
   GroupRequest g4_req ("group4",grid_name,4,Bundling::Required,DerivationType::Copy,g2_req.name,g2_req.grid);
-  // group5 += (group1 - {c,d})
+  // Extend group5 by adding all fields in group1 *except* 'c' and 'd'.
   GroupRequest g5_req ("group5",grid_name,4,Bundling::Preferred,DerivationType::Subset,g1_req.name,g1_req.grid,SL{"c","d"});
 
   // The above group specs should give the following groups:

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -70,7 +70,7 @@ TEST_CASE("field_identifier", "") {
 TEST_CASE("field_tracking", "") {
   using namespace scream;
 
-  FieldTracking track("track");
+  FieldTracking track;
   util::TimeStamp time1(0,0,0,10.0);
   util::TimeStamp time2(0,0,0,20.0);
   REQUIRE_NOTHROW (track.update_time_stamp(time2));

--- a/components/scream/src/share/util/scream_utils.hpp
+++ b/components/scream/src/share/util/scream_utils.hpp
@@ -2,12 +2,25 @@
 #define SCREAM_UTILS_HPP
 
 #include <ekat/ekat_assert.hpp>
+#include <ekat/kokkos/ekat_kokkos_types.hpp>
 
 #include <list>
 #include <algorithm>
 #include <map>
 
 namespace scream {
+
+// Micro-utility, that given an enum returns the underlying int.
+// The only use of this is if you need to sort scoped enums.
+template<typename EnumT>
+KOKKOS_FUNCTION
+constexpr typename
+std::enable_if<std::is_enum<EnumT>::value,
+               typename std::underlying_type<EnumT>::type
+              >::type
+etoi (const EnumT e) {
+  return static_cast<typename std::underlying_type<EnumT>::type>(e);
+}
 
 // This routine tries to find an arrangment of elements that allow each
 // of the input groups to be a contiguous subarray of the global arrangement.

--- a/components/scream/tests/coupled/homme_physics/CMakeLists.txt
+++ b/components/scream/tests/coupled/homme_physics/CMakeLists.txt
@@ -30,7 +30,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
 # Discretization/algorithm settings
 set (HOMME_TEST_NE 2)
 set (HOMME_TEST_LIM 9)
-set (HOMME_TEST_QSIZE 1)
 set (HOMME_TEST_RSPLIT 3)
 set (HOMME_TEST_NMAX 24)
 set (HOMME_TEST_TIME_STEP 300)

--- a/components/scream/tests/coupled/homme_physics/CMakeLists.txt
+++ b/components/scream/tests/coupled/homme_physics/CMakeLists.txt
@@ -2,12 +2,6 @@ include (ScreamUtils)
 
 # Needed for RRTMGP
 find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATHS}/lib)
-## Add CUDA flags for YAKL
-if (CUDA_BUILD)
-    set(ARCH "CUDA")
-    set(YAKL_CXX_FLAGS "-D__USE_CUDA__ --expt-extended-lambda --expt-relaxed-constexpr ${CUDA_FLAGS} ${YAKL_CXX_FLAGS}")
-endif()
-
 # Get or create the dynamics lib
 #                 HOMME_TARGET   NP PLEV QSIZE_D
 CreateDynamicsLib("theta-l_kokkos"  4   72   35)
@@ -18,7 +12,6 @@ set (NEED_LIBS cld_fraction shoc p3 scream_rrtmgp rrtmgp ${NETCDF_C} ${dynLibNam
 set (SRC shoc_cld_p3_rrtmgp.cpp ${SCREAM_BASE_DIR}/src/physics/rrtmgp/tests/rrtmgp_test_utils.cpp)
 if (NOT SCREAM_AUTOTESTER) # TODO: This test should be reinstated once the homme+physics test is fixed.
   CreateUnitTest(homme_shoc_cld_p3_rrtmgp "homme_shoc_cld_p3_rrtmgp.cpp" "${NEED_LIBS}" EXE_ARGS "< namelist.nl" LABELS "dynamics;driver;shoc;cld;p3;rrtmgp;physics")
-  set_target_properties(homme_shoc_cld_p3_rrtmgp PROPERTIES COMPILE_FLAGS "${YAKL_CXX_FLAGS}")
 endif()
 
 # Copy yaml input file to run directory

--- a/components/scream/tests/coupled/homme_physics/input.yaml
+++ b/components/scream/tests/coupled/homme_physics/input.yaml
@@ -4,12 +4,15 @@ Debug:
   Atmosphere DAG Verbosity Level: 5
 
 Initial Conditions:
-  Initial Conditions File: homme_shoc_cld_p3_rad_init_ne2np4.nc
-  # Set X_prev = X
-  T_mid_prev: T_mid
-  horiz_winds_prev: horiz_winds
-  w_int: 0.0 # Start from zero vert velocity
-  w_int_prev: 0.0
+  Physics GLL:
+    Initial Conditions File: homme_shoc_cld_p3_rad_init_ne2np4.nc
+    # Set X_prev = X
+    T_mid_prev: T_mid
+    horiz_winds_prev: horiz_winds
+    w_int: 0.0 # Start from zero vert velocity
+    w_int_prev: 0.0
+  Dynamics:
+    tracers: tracers, Physics GLL
 
 Atmosphere Processes:
   Number of Entries: 5

--- a/components/scream/tests/coupled/homme_physics/input.yaml
+++ b/components/scream/tests/coupled/homme_physics/input.yaml
@@ -5,7 +5,7 @@ Debug:
 
 Initial Conditions:
   Physics GLL:
-    Initial Conditions File: homme_shoc_cld_p3_rad_init_ne2np4.nc
+    Filename: homme_shoc_cld_p3_rad_init_ne2np4.nc
     # Set X_prev = X
     T_mid_prev: T_mid
     horiz_winds_prev: horiz_winds

--- a/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/CMakeLists.txt
@@ -1,12 +1,5 @@
 INCLUDE (ScreamUtils)
 
-## Add CUDA flags for YAKL
-set(YAKL_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-if (CUDA_BUILD)
-    set(YAKL_ARCH "CUDA")
-    set(YAKL_CXX_FLAGS "-DYAKL_ARCH_CUDA--expt-extended-lambda --expt-relaxed-constexpr ${YAKL_CXX_FLAGS}")
-endif()
-
 ## Create test
 # Required libraries
 find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATHS}/lib)
@@ -17,7 +10,6 @@ set (SRC shoc_cld_p3_rrtmgp.cpp ${SCREAM_BASE_DIR}/src/physics/rrtmgp/tests/rrtm
 
 # Test atmosphere processes.
 CreateUnitTest(shoc_cld_p3_rrtmgp "${SRC}" "${NEED_LIBS}" LABELS "shoc;cld;p3;rrtmgp;physics")
-set_target_properties(shoc_cld_p3_rrtmgp PROPERTIES COMPILE_FLAGS "${YAKL_CXX_FLAGS}")
 target_include_directories(shoc_cld_p3_rrtmgp PUBLIC
     ${SCREAM_BASE_DIR}/src/physics/rrtmgp
     ${SCREAM_BASE_DIR}/src/physics/rrtmgp/tests

--- a/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/input.yaml
@@ -30,7 +30,8 @@ Grids Manager:
 
 # The name of the file containing the initial conditions for this test.
 Initial Conditions:
-  Initial Conditions File: shoc_cld_p3_rrtmgp_init_ne2np4.nc
-  Load Latitude:  true
-  Load Longitude: true
+  Physics:
+    Filename: shoc_cld_p3_rrtmgp_init_ne2np4.nc
+    Load Latitude:  true
+    Load Longitude: true
 ...

--- a/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp.cpp
+++ b/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp.cpp
@@ -45,7 +45,7 @@ TEST_CASE("shoc-stand-alone", "") {
 
   for (int i=0; i<num_iters; ++i) {
     if (i % 10 == 0) {
-      printf("  -  %5.2f\%\nRun iteration: %d, ",(Real)i/Real(num_iters)*100,i+1);
+      printf("  -  %5.2f%%\nRun iteration: %d, ",(Real)i/Real(num_iters)*100,i+1);
     } else {
       printf("%d, ",i);
     }

--- a/components/scream/tests/uncoupled/cld_fraction/cld_fraction_standalone.cpp
+++ b/components/scream/tests/uncoupled/cld_fraction/cld_fraction_standalone.cpp
@@ -80,7 +80,7 @@ TEST_CASE("cld_fraction-stand-alone", "") {
   // Run the code
   for (int i=0; i<num_iters; ++i) {
     if (i % 10 == 0) {
-      printf("  -  %5.2f\%\nRun iteration: %d, ",Real(i)/Real(num_iters)*100,i+1);
+      printf("  -  %5.2f%%\nRun iteration: %d, ",Real(i)/Real(num_iters)*100,i+1);
     } else {
       printf("%d, ",i);
     }

--- a/components/scream/tests/uncoupled/cld_fraction/input.yaml
+++ b/components/scream/tests/uncoupled/cld_fraction/input.yaml
@@ -19,6 +19,7 @@ Grids Manager:
 
 # The name of the file containing the initial conditions for this test.
 Initial Conditions:
-  cldfrac_liq: 0.0
-  qi: 0.0 
+  Physics:
+    cldfrac_liq: 0.0
+    qi: 0.0 
 ...

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -4,12 +4,15 @@ Debug:
   Atmosphere DAG Verbosity Level: 5
 
 Initial Conditions:
-  Initial Conditions File: homme_standalone_ne4np4.nc
-  # Set X_prev = X
-  T_mid_prev: T_mid
-  horiz_winds_prev: horiz_winds
-  w_int: 0.0 # Start from zero vert velocity
-  w_int_prev: 0.0
+  Physics GLL:
+    Initial Conditions File: homme_standalone_ne4np4.nc
+    # Set X_prev = X
+    T_mid_prev: T_mid
+    horiz_winds_prev: horiz_winds
+    w_int: 0.0 # Start from zero vert velocity
+    w_int_prev: 0.0
+  Dynamics:
+    tracers: tracers, Physics GLL
 
 Atmosphere Processes:
   Number of Entries: 1

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -5,7 +5,7 @@ Debug:
 
 Initial Conditions:
   Physics GLL:
-    Initial Conditions File: homme_standalone_ne4np4.nc
+    Filename: homme_standalone_ne4np4.nc
     # Set X_prev = X
     T_mid_prev: T_mid
     horiz_winds_prev: horiz_winds

--- a/components/scream/tests/uncoupled/p3/input.yaml
+++ b/components/scream/tests/uncoupled/p3/input.yaml
@@ -19,7 +19,8 @@ Grids Manager:
 
 # The name of the file containing the initial conditions for this test.
 Initial Conditions:
-  Initial Conditions File: p3_init_ne2np4.nc
+  Physics:
+    Initial Conditions File: p3_init_ne2np4.nc
 
 # The parameters for I/O control
 SCORPIO:

--- a/components/scream/tests/uncoupled/p3/input.yaml
+++ b/components/scream/tests/uncoupled/p3/input.yaml
@@ -20,7 +20,7 @@ Grids Manager:
 # The name of the file containing the initial conditions for this test.
 Initial Conditions:
   Physics:
-    Initial Conditions File: p3_init_ne2np4.nc
+    Filename: p3_init_ne2np4.nc
 
 # The parameters for I/O control
 SCORPIO:

--- a/components/scream/tests/uncoupled/p3/p3_standalone.cpp
+++ b/components/scream/tests/uncoupled/p3/p3_standalone.cpp
@@ -48,7 +48,7 @@ TEST_CASE("p3-stand-alone", "") {
   ad.initialize(atm_comm,ad_params,time);
   for (int i=0; i<num_iters; ++i) {
     if (i % 10 == 0) {
-      printf("  -  %f\%\nRun iteration: %d, ",Real(i)/Real(num_iters)*100,i+1);
+      printf("  -  %f%%\nRun iteration: %d, ",Real(i)/Real(num_iters)*100,i+1);
     } else {
       printf("%d, ",i);
     }

--- a/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -1,11 +1,5 @@
 INCLUDE (ScreamUtils)
 
-# Add CUDA flags for YAKL
-set(YAKL_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-if (CUDA_BUILD)
-    set(YAKL_ARCH "CUDA")
-    set(YAKL_CXX_FLAGS "-DYAKL_ARCH_CUDA --expt-extended-lambda --expt-relaxed-constexpr ${YAKL_CXX_FLAGS}")
-endif()
 # Test atmosphere processes
 if (NOT ${SCREAM_BASELINES_ONLY})
 
@@ -20,8 +14,6 @@ if (NOT ${SCREAM_BASELINES_ONLY})
         rrtmgp_standalone "${SRC}" "${NEED_LIBS}" LABELS "rrtmgp;physics"
         EXE_ARGS "--ekat-test-params rrtmgp_inputfile=${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc,rrtmgp_baseline=${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc"
     )
-    message(STATUS "rrtmgp_standalone YAKL_CXX_FLAGS: ${YAKL_CXX_FLAGS}")
-    set_target_properties(rrtmgp_standalone PROPERTIES COMPILE_FLAGS "${YAKL_CXX_FLAGS}")
     target_include_directories(rrtmgp_standalone PUBLIC
           ${SCREAM_BASE_DIR}/src/physics/rrtmgp
           ${SCREAM_BASE_DIR}/src/physics/rrtmgp/tests

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -20,7 +20,7 @@ Grids Manager:
     Number of global columns: 128
     Number of vertical levels: 42
 
-# The name of the file containing the initial conditions for this test.
+# Specifications for setting initial conditions
 Initial Conditions:
   p_mid: 0.0
   p_int: 0.0

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -22,27 +22,28 @@ Grids Manager:
 
 # Specifications for setting initial conditions
 Initial Conditions:
-  p_mid: 0.0
-  p_int: 0.0
-  pseudo_density: 0.0
-  T_mid: 0.0
-  t_int: 0.0
-  sfc_alb_dir_vis: 0.0
-  sfc_alb_dir_nir: 0.0
-  sfc_alb_dif_vis: 0.0
-  sfc_alb_dif_nir: 0.0
-  cos_zenith: 0.0
-  qc: 0.0
-  qi: 0.0
-  cldfrac_tot: 0.0
-  eff_radius_qc: 0.0
-  eff_radius_qi: 0.0
-  qv: 0.0
-  co2: 0.0
-  o3: 0.0
-  n2o: 0.0
-  co: 0.0
-  ch4: 0.0
-  o2: 0.0
-  n2: 0.0
+  Physics:
+    p_mid: 0.0
+    p_int: 0.0
+    pseudo_density: 0.0
+    T_mid: 0.0
+    t_int: 0.0
+    sfc_alb_dir_vis: 0.0
+    sfc_alb_dir_nir: 0.0
+    sfc_alb_dif_vis: 0.0
+    sfc_alb_dif_nir: 0.0
+    cos_zenith: 0.0
+    qc: 0.0
+    qi: 0.0
+    cldfrac_tot: 0.0
+    eff_radius_qc: 0.0
+    eff_radius_qi: 0.0
+    qv: 0.0
+    co2: 0.0
+    o3: 0.0
+    n2o: 0.0
+    co: 0.0
+    ch4: 0.0
+    o2: 0.0
+    n2: 0.0
 ...

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -21,7 +21,7 @@ Grids Manager:
 # The name of the file containing the initial conditions for this test.
 Initial Conditions:
   Physics:
-    Initial Conditions File: shoc_init_ne2np4.nc
+    Filename: shoc_init_ne2np4.nc
 
 # The name of the output control file for this test.
 Output Manager:

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -20,7 +20,8 @@ Grids Manager:
 
 # The name of the file containing the initial conditions for this test.
 Initial Conditions:
-  Initial Conditions File: shoc_init_ne2np4.nc
+  Physics:
+    Initial Conditions File: shoc_init_ne2np4.nc
 
 # The name of the output control file for this test.
 Output Manager:

--- a/components/scream/tests/uncoupled/shoc/shoc_standalone.cpp
+++ b/components/scream/tests/uncoupled/shoc/shoc_standalone.cpp
@@ -49,7 +49,7 @@ TEST_CASE("shoc-stand-alone", "") {
 
   for (int i=0; i<num_iters; ++i) {
     if (i % 10 == 0) {
-      printf("  -  %5.2f\%\nRun iteration: %d, ",Real(i)/Real(num_iters)*100,i+1);
+      printf("  -  %5.2f%%\nRun iteration: %d, ",Real(i)/Real(num_iters)*100,i+1);
     } else {
       printf("%d, ",i);
     }

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -19,7 +19,8 @@ Grids Manager:
 
 # The name of the file containing the initial conditions for this test.
 Initial Conditions:
-  Initial Conditions File: spa_init_ne2np4.nc
+  Physics:
+    Initial Conditions File: spa_init_ne2np4.nc
 
 # The name of the output control file for this test.
 Output Manager:

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -20,7 +20,7 @@ Grids Manager:
 # The name of the file containing the initial conditions for this test.
 Initial Conditions:
   Physics:
-    Initial Conditions File: spa_init_ne2np4.nc
+    Filename: spa_init_ne2np4.nc
 
 # The name of the output control file for this test.
 Output Manager:


### PR DESCRIPTION
I apologize for the size of the PR, but the more I tried to accommodate something, the more I realized it was by far easier if I modified something else.

This PR started with one goal: fix how Homme creates the Q_prev copy of the tracers group. It ended up doing more. Here's a tentative list of what it does:

- reworked implementation of `contiguous_superset`. I think the number of LOC increased, but it is imho easier to follow now.
- changed names/impl of GroupRequests (GR) derived on other GRs. E.g., Relationship->DerivationType, Child->Subset, Parent->Superset.
- make FM correctly handle copy of groups: Copy only allowed on the same grid, and the individual fields are not created to avoid clashes with the subfields of original group.
- move most impl of AtmosphereProcess (AP) class into a cpp file (the hpp was getting too long, making hard to see the class interfaces at a glance).
- store all fields/groups in/out in the base AP class, provide getters for derived class (so they can't add more fields to the list, which could mess up some infrastructure logic, like that there is 1-1 correspondence between m_fields_in and the required fields requests).
- allow derived classes to not override any set_blah_impl method, unless *really* needed. All basic bookkeping is already in the AP class
- make AD load IC for field on any grid. This does not yet support loading fields from nc file directly on dyn grid. But at least one can init a dyn grid field to a constant or equal to another field on the phys grid (via syntax `field_1: field_2, Physics_GLL`).

There might be more, but it's late, and I need to go to bed. I wanted to put this in before taking off for the long weekend.

A couple of things that I did not address:
- Homme needs Q_prev only for ftype 0, but currently it always creates it. Fix this by introducing some checks on ftype.
- I realized we have some pb when creating a subgroup of a group, asking for it to be bundled. E.g., SHOC wants a subset of the tracers, and would like them bundled. However, we never create the subfield `Q_shoc=Q(:,1:num_shoc_tr,:)`, since we can only handle subfield that completely slice away a dimension (rather than taking an extent). I have an idea in mind on how to extend this, to allow, say, `subfield(const int idim, const int k0, const int n)`, with `k0` being the 1st index along dimension `idim` to subview, and `n` being the number of slices. But it may take some time, so we need to see how big of a priority it is (I suspect we want it in the long run though).