### PR TITLE
Setup "reparing" instances of negative tracer mass after the dynamics step

### DIFF
--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -818,29 +818,6 @@ void HommeDynamics::import_initial_conditions () {
 // =========================================================================================
 void HommeDynamics::
 check_computed_fields_impl () {
-//ASD  using KT = KokkosTypes<DefaultDevice>;
-//ASD  constexpr int N = sizeof(Homme::Scalar) / sizeof(Real);
-//ASD  using Pack = ekat::Pack<Real,N>;
-//ASD  using ColOps = ColumnOps<DefaultDevice,Real>;
-//ASD
-//ASD  const auto ncols = m_ref_grid->get_num_local_dofs();
-//ASD  const auto nlevs = m_ref_grid->get_num_vertical_levels();
-//ASD  const auto npacks= ekat::PackInfo<N>::num_packs(nlevs);
-//ASD
-//ASD  const auto& Q_view  = m_ref_grid_fields.at("Q").get_view<Pack***>();
-//ASD
-//ASD  using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
-//ASD  const auto policy = ESU::get_thread_range_parallel_scan_team_policy(ncols,Q_view.extent(1));
-//ASD
-//ASD  Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
-//ASD    const int& icol = team.league_rank();
-//ASD    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,Q_view.extent(1)),
-//ASD                         [&](const int qidx) {
-//ASD      auto q_chk  = ekat::subview(Q_view,icol,qidx);
-//ASD      
-//ASD    });
-//ASD    team.team_barrier();
-//ASD  });
     auto& field = m_fields_out["Q"];
     for (auto& pc : field.get_property_checks()) {
       if (!pc.check(field) and pc.can_repair()) {

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -834,12 +834,11 @@ check_computed_fields_impl () {
     // Create a local copy of a lower bound check to ensure we are not encountering truly
     // bad negative tracer values.
     Real tol = -1e-20;
-    auto lower_bound_check = FieldLowerBoundCheck<Real>(tol);
-    lower_bound_check.check(Q);
+    auto lower_bound_check = std::make_shared<FieldLowerBoundCheck<Real>>(tol);
+    lower_bound_check->check(Q);
     // Now repair negative tracers using a lower bounds check at 0.0
-    auto lower_bound_repair = FieldLowerBoundCheck<Real>(0.0);
-    lower_bound_repair.repair(Q);
-
+    auto lower_bound_repair = std::make_shared<FieldLowerBoundCheck<Real>>(0.0);
+    lower_bound_repair->repair(Q);
   
 }
 // =========================================================================================

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -73,6 +73,9 @@ protected:
   // Dynamics updates the "tracers" group, and needs to do some extra checks on the group.
   void set_updated_group_impl (const FieldGroup<Real>& group);
 
+  // Override the check computed fields impl so we can repair slightly negative tracer values.
+  void check_computed_fields_impl ();
+
   // Computes total number of bytes needed for local variables
   int requested_buffer_size_in_bytes() const;
 

--- a/components/scream/src/dynamics/homme/interface/homme_grid_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_grid_mod.F90
@@ -118,8 +118,8 @@ contains
           elgpgp(3,idof) = ip-1
 
           gids(idof) = INT(elem(ie)%gdofP(ip,jp),kind=c_int)
-          lat(idof)  = elem(ie)%spherep(ip,jp)%lat
-          lon(idof)  = elem(ie)%spherep(ip,jp)%lon
+          lat(idof)  = elem(ie)%spherep(ip,jp)%lat * 180.0/3.14
+          lon(idof)  = elem(ie)%spherep(ip,jp)%lon * 180.0/3.14
 
           idof = idof + 1
         enddo

--- a/components/scream/src/dynamics/homme/interface/homme_grid_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_grid_mod.F90
@@ -89,6 +89,7 @@ contains
   subroutine get_dyn_grid_data_f90 (gids_ptr, elgpgp_ptr, lat_ptr, lon_ptr) bind(c)
     use homme_context_mod, only: elem
     use dimensions_mod,    only: nelemd, np
+    use shr_const_mod,     only: pi=>SHR_CONST_PI
     !
     ! Input(s)
     !
@@ -118,8 +119,8 @@ contains
           elgpgp(3,idof) = ip-1
 
           gids(idof) = INT(elem(ie)%gdofP(ip,jp),kind=c_int)
-          lat(idof)  = elem(ie)%spherep(ip,jp)%lat * 180.0/3.14
-          lon(idof)  = elem(ie)%spherep(ip,jp)%lon * 180.0/3.14
+          lat(idof)  = elem(ie)%spherep(ip,jp)%lat * 180.0/pi
+          lon(idof)  = elem(ie)%spherep(ip,jp)%lon * 180.0/pi
 
           idof = idof + 1
         enddo

--- a/components/scream/src/dynamics/homme/interface/phys_grid_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/phys_grid_mod.F90
@@ -157,6 +157,7 @@ contains
   subroutine get_my_phys_data (gids, lat, lon, area, pg_type)
     use homme_context_mod, only: elem, iam
     use dimensions_mod,    only: nelemd
+    use shr_const_mod,     only: pi=>SHR_CONST_PI
     !
     ! Input(s)
     !
@@ -198,8 +199,8 @@ contains
       ndofs = get_num_local_columns ()
       do idof=1,ndofs
         gids(idof) = g_dofs(g_offsets(iam+1) + idof)
-        lat(idof)  = g_lat(g_offsets(iam+1) + idof) * 180.0/3.14
-        lon(idof)  = g_lon(g_offsets(iam+1) + idof) * 180.0/3.14
+        lat(idof)  = g_lat(g_offsets(iam+1) + idof) * 180.0/pi
+        lon(idof)  = g_lon(g_offsets(iam+1) + idof) * 180.0/pi
         area(idof) = g_area(g_offsets(iam+1) + idof)
       enddo
 

--- a/components/scream/src/dynamics/homme/interface/phys_grid_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/phys_grid_mod.F90
@@ -198,8 +198,8 @@ contains
       ndofs = get_num_local_columns ()
       do idof=1,ndofs
         gids(idof) = g_dofs(g_offsets(iam+1) + idof)
-        lat(idof)  = g_lat(g_offsets(iam+1) + idof)
-        lon(idof)  = g_lon(g_offsets(iam+1) + idof)
+        lat(idof)  = g_lat(g_offsets(iam+1) + idof) * 180.0/3.14
+        lon(idof)  = g_lon(g_offsets(iam+1) + idof) * 180.0/3.14
         area(idof) = g_area(g_offsets(iam+1) + idof)
       enddo
 

--- a/components/scream/src/share/field/field_property_checks/field_lower_bound_check.hpp
+++ b/components/scream/src/share/field/field_property_checks/field_lower_bound_check.hpp
@@ -29,8 +29,7 @@ public:
   // apply repairs to the field.
   explicit FieldLowerBoundCheck (const_RT lower_bound,
                                  bool can_repair = true) : 
-    FieldWithinIntervalCheck<RealType>(lower_bound, std::numeric_limits<RealType>::max(), can_repair),
-    m_lower_bound(lower_bound)
+    FieldWithinIntervalCheck<RealType>(lower_bound, std::numeric_limits<RealType>::max(), can_repair)
     {
       // Do Nothing
     }
@@ -38,12 +37,7 @@ public:
   // Overrides.
 
   // The name of the field check
-  std::string name () const override { return "Lower Bound Check of " + std::to_string(m_lower_bound); }
-
-  protected:
-
-  // Lower bound
-  RealType m_lower_bound;
+  std::string name () const override { return "Lower Bound Check of " + std::to_string(this->m_lower_bound); }
 
 };
 

--- a/components/scream/src/share/field/field_property_checks/field_lower_bound_check.hpp
+++ b/components/scream/src/share/field/field_property_checks/field_lower_bound_check.hpp
@@ -17,7 +17,6 @@ namespace scream
 template<typename RealType>
 class FieldLowerBoundCheck: public FieldWithinIntervalCheck<RealType> {
 public:
-  using non_const_RT = typename FieldPropertyCheck<RealType>::non_const_RT;
   using const_RT     = typename FieldPropertyCheck<RealType>::const_RT;
 
   // No default constructor -- we need a lower bound.

--- a/components/scream/src/share/field/field_property_checks/field_lower_bound_check.hpp
+++ b/components/scream/src/share/field/field_property_checks/field_lower_bound_check.hpp
@@ -1,0 +1,52 @@
+#ifndef SCREAM_FIELD_LOWER_BOUND_CHECK_HPP
+#define SCREAM_FIELD_LOWER_BOUND_CHECK_HPP
+
+#include "share/field/field_property_checks/field_within_interval_check.hpp"
+
+#include "ekat/util/ekat_math_utils.hpp"
+
+namespace scream
+{
+
+// This field property check returns true if all data in a given field are
+// bounded below by the given lower bounds, and false if not.
+// It can repair a field that fails the check by clipping all unbounded values
+// to the lower bound.
+// Note: The lower bound check is a sub-class of the within interval check with
+// the upper bound set to the numeric limit.
+template<typename RealType>
+class FieldLowerBoundCheck: public FieldWithinIntervalCheck<RealType> {
+public:
+  using non_const_RT = typename FieldPropertyCheck<RealType>::non_const_RT;
+  using const_RT     = typename FieldPropertyCheck<RealType>::const_RT;
+
+  // No default constructor -- we need a lower bound.
+  FieldLowerBoundCheck () = delete;
+
+  // Constructor with lower and bound. By default, this property check
+  // can repair fields that fail the check by overwriting nonpositive values
+  // with the given lower bound. If can_repair is false, the check cannot
+  // apply repairs to the field.
+  explicit FieldLowerBoundCheck (const_RT lower_bound,
+                                 bool can_repair = true) : 
+    FieldWithinIntervalCheck<RealType>(lower_bound, std::numeric_limits<RealType>::max(), can_repair),
+    m_lower_bound(lower_bound)
+    {
+      // Do Nothing
+    }
+
+  // Overrides.
+
+  // The name of the field check
+  std::string name () const override { return "Lower Bound Check of " + std::to_string(m_lower_bound); }
+
+  protected:
+
+  // Lower bound
+  RealType m_lower_bound;
+
+};
+
+} // namespace scream
+
+#endif // SCREAM_FIELD_LOWER_BOUND_CHECK_HPP

--- a/components/scream/src/share/field/field_property_checks/field_upper_bound_check.hpp
+++ b/components/scream/src/share/field/field_property_checks/field_upper_bound_check.hpp
@@ -1,0 +1,50 @@
+#ifndef SCREAM_FIELD_UPPER_BOUND_CHECK_HPP
+#define SCREAM_FIELD_UPPER_BOUND_CHECK_HPP
+
+#include "share/field/field_property_checks/field_within_interval_check.hpp"
+
+#include "ekat/util/ekat_math_utils.hpp"
+
+namespace scream
+{
+
+// This field property check returns true if all data in a given field are
+// bounded above by the given upper bound, and false if not.
+// It can repair a field that fails the check by clipping all unbounded values
+// to the upper bound.
+// Note: The upper bound check is a sub-class of the within interval check with
+// the upper bound set to the numeric limit.
+template<typename RealType>
+class FieldUpperBoundCheck: public FieldWithinIntervalCheck<RealType> {
+public:
+  using non_const_RT = typename FieldPropertyCheck<RealType>::non_const_RT;
+  using const_RT     = typename FieldPropertyCheck<RealType>::const_RT;
+
+  // No default constructor -- we need an upper bound.
+  FieldUpperBoundCheck () = delete;
+
+  // Constructor with upper bound. By default, this property check
+  // can repair fields that fail the check by overwriting nonpositive values
+  // with the given upper bound. If can_repair is false, the check cannot
+  // apply repairs to the field.
+  explicit FieldUpperBoundCheck (const_RT upper_bound,
+                                 bool can_repair = true) : 
+    FieldWithinIntervalCheck<RealType>(-std::numeric_limits<RealType>::max(), upper_bound, can_repair)
+    {
+      // Do Nothing
+    }
+
+  // Overrides.
+
+  // The name of the field check
+  std::string name () const override { return "Upper Bound Check of " + std::to_string(m_upper_bound); }
+
+protected:
+
+  // Upper bound
+  RealType m_upper_bound;
+};
+
+} // namespace scream
+
+#endif // SCREAM_FIELD_UPPER_BOUND_CHECK_HPP

--- a/components/scream/src/share/field/field_property_checks/field_upper_bound_check.hpp
+++ b/components/scream/src/share/field/field_property_checks/field_upper_bound_check.hpp
@@ -37,12 +37,8 @@ public:
   // Overrides.
 
   // The name of the field check
-  std::string name () const override { return "Upper Bound Check of " + std::to_string(m_upper_bound); }
+  std::string name () const override { return "Upper Bound Check of " + std::to_string(this->m_upper_bound); }
 
-protected:
-
-  // Upper bound
-  RealType m_upper_bound;
 };
 
 } // namespace scream

--- a/components/scream/src/share/field/field_property_checks/field_upper_bound_check.hpp
+++ b/components/scream/src/share/field/field_property_checks/field_upper_bound_check.hpp
@@ -17,7 +17,6 @@ namespace scream
 template<typename RealType>
 class FieldUpperBoundCheck: public FieldWithinIntervalCheck<RealType> {
 public:
-  using non_const_RT = typename FieldPropertyCheck<RealType>::non_const_RT;
   using const_RT     = typename FieldPropertyCheck<RealType>::const_RT;
 
   // No default constructor -- we need an upper bound.

--- a/components/scream/src/share/field/field_property_checks/field_within_interval_check.hpp
+++ b/components/scream/src/share/field/field_property_checks/field_within_interval_check.hpp
@@ -38,7 +38,7 @@ public:
   // Overrides.
 
   // The name of the field check
-  std::string name () const override { return "Within Interval Field Check"; }
+  std::string name () const override { return "Within Interval [" + std::to_string(m_lower_bound) + "," + std::to_string(m_upper_bound) + "] Field Check"; }
 
   bool check(const Field<const_RT>& field) const override {
     using RT = non_const_RT;

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -633,6 +633,9 @@ TEST_CASE("field_property_check", "") {
     Field<Real> f1(fid);
     auto positivity_check = std::make_shared<FieldPositivityCheck<Real> >();
     REQUIRE(not positivity_check->can_repair());
+    // Note: Here we will test the ability to add a check to a field and then
+    //       access it using get_property_checks.  Subsequent tests will use
+    //       the checker directly on the field.
     f1.add_property_check(positivity_check);
     f1.allocate_view();
     const int num_reals = f1.get_header().get_alloc_properties().get_num_scalars();
@@ -659,7 +662,6 @@ TEST_CASE("field_property_check", "") {
     Field<Real> f1(fid);
     auto positivity_check = std::make_shared<FieldPositivityCheck<Real> >(1);
     REQUIRE(positivity_check->can_repair());
-    f1.add_property_check(positivity_check);
     f1.allocate_view();
     const int num_reals = f1.get_header().get_alloc_properties().get_num_scalars();
 
@@ -668,18 +670,15 @@ TEST_CASE("field_property_check", "") {
     auto f1_data = f1.get_internal_view_data<Host>();
     ekat::genRandArray(f1_data,num_reals,engine,neg_pdf);
     f1.sync_to_dev();
-    for (auto& p : f1.get_property_checks()) {
-      REQUIRE(not p.check(f1));
-      p.repair(f1);
-      REQUIRE(p.check(f1));
-    }
+    REQUIRE(not positivity_check->check(f1));
+    positivity_check->repair(f1);
+    REQUIRE(positivity_check->check(f1));
   }
 
   // Check that values are not NaN
   SECTION("field_not_nan_check") {
     Field<Real> f1(fid);
     auto nan_check = std::make_shared<FieldNaNCheck<Real>>();
-    f1.add_property_check(nan_check);
     f1.allocate_view();
     const int num_reals = f1.get_header().get_alloc_properties().get_num_scalars();
 
@@ -687,17 +686,13 @@ TEST_CASE("field_property_check", "") {
     auto f1_data = f1.get_internal_view_data<Host>();
     ekat::genRandArray(f1_data,num_reals,engine,neg_pdf);
     f1.sync_to_dev();
-    for (auto& p : f1.get_property_checks()) {
-      REQUIRE(p.check(f1));
-    }
+    REQUIRE(nan_check->check(f1));
 
     // Assign a NaN value to the field, make sure it fails the check,
     Int midpt = num_reals / 2;
     f1_data[midpt] = std::numeric_limits<Real>::quiet_NaN();
     f1.sync_to_dev();
-    for (auto& p : f1.get_property_checks()) {
-      REQUIRE(not p.check(f1));
-    }
+    REQUIRE(not nan_check->check(f1));
   }
 
   // Check that the values of a field lie within an interval.
@@ -705,7 +700,6 @@ TEST_CASE("field_property_check", "") {
     Field<Real> f1(fid);
     auto interval_check = std::make_shared<FieldWithinIntervalCheck<Real> >(0, 1);
     REQUIRE(interval_check->can_repair());
-    f1.add_property_check(interval_check);
     f1.allocate_view();
     const int num_reals = f1.get_header().get_alloc_properties().get_num_scalars();
 
@@ -713,9 +707,7 @@ TEST_CASE("field_property_check", "") {
     auto f1_data = f1.get_internal_view_data<Host>();
     ekat::genRandArray(f1_data,num_reals,engine,pos_pdf);
     f1.sync_to_dev();
-    for (auto& p : f1.get_property_checks()) {
-      REQUIRE(p.check(f1));
-    }
+    REQUIRE(interval_check->check(f1));
 
     // Assign out-of-bounds values to the field, make sure it fails the check,
     // and then repair the field so it passes.
@@ -723,11 +715,9 @@ TEST_CASE("field_property_check", "") {
       f1_data[i] *= -1;
     }
     f1.sync_to_dev();
-    for (auto& p : f1.get_property_checks()) {
-      REQUIRE(not p.check(f1));
-      p.repair(f1);
-      REQUIRE(p.check(f1));
-    }
+    REQUIRE(not interval_check->check(f1));
+    interval_check->repair(f1);
+    REQUIRE(interval_check->check(f1));
   }
 
   // Check that the values of a field are above a lower bound
@@ -735,7 +725,6 @@ TEST_CASE("field_property_check", "") {
     Field<Real> f1(fid);
     auto lower_bound_check = std::make_shared<FieldLowerBoundCheck<Real> >(-1.0);
     REQUIRE(lower_bound_check->can_repair());
-    f1.add_property_check(lower_bound_check);
     f1.allocate_view();
     const int num_reals = f1.get_header().get_alloc_properties().get_num_scalars();
 
@@ -745,9 +734,7 @@ TEST_CASE("field_property_check", "") {
       f1_data[i] = std::numeric_limits<Real>::max() - i*1.0; 
     }
     f1.sync_to_dev();
-    for (auto& p : f1.get_property_checks()) {
-      REQUIRE(p.check(f1));
-    }
+    REQUIRE(lower_bound_check->check(f1));
 
     // Assign out-of-bounds values to the field, make sure it fails the check,
     // and then repair the field so it passes.
@@ -755,11 +742,9 @@ TEST_CASE("field_property_check", "") {
       f1_data[i] = -2.0*(i+1);
     }
     f1.sync_to_dev();
-    for (auto& p : f1.get_property_checks()) {
-      REQUIRE(not p.check(f1));
-      p.repair(f1);
-      REQUIRE(p.check(f1));
-    }
+    REQUIRE(not lower_bound_check->check(f1));
+    lower_bound_check->repair(f1);
+    REQUIRE(lower_bound_check->check(f1));
     // Should have repaired to the lower bound:
     f1.sync_to_host();
     for (int i=0; i<num_reals; ++i)
@@ -773,7 +758,6 @@ TEST_CASE("field_property_check", "") {
     Field<Real> f1(fid);
     auto upper_bound_check = std::make_shared<FieldUpperBoundCheck<Real> >(1.0);
     REQUIRE(upper_bound_check->can_repair());
-    f1.add_property_check(upper_bound_check);
     f1.allocate_view();
     const int num_reals = f1.get_header().get_alloc_properties().get_num_scalars();
 
@@ -783,9 +767,7 @@ TEST_CASE("field_property_check", "") {
       f1_data[i] = -std::numeric_limits<Real>::max() + i*1.0; 
     }
     f1.sync_to_dev();
-    for (auto& p : f1.get_property_checks()) {
-      REQUIRE(p.check(f1));
-    }
+    REQUIRE(upper_bound_check->check(f1));
 
     // Assign out-of-bounds values to the field, make sure it fails the check,
     // and then repair the field so it passes.
@@ -793,11 +775,9 @@ TEST_CASE("field_property_check", "") {
       f1_data[i] = 2.0*(i+1);
     }
     f1.sync_to_dev();
-    for (auto& p : f1.get_property_checks()) {
-      REQUIRE(not p.check(f1));
-      p.repair(f1);
-      REQUIRE(p.check(f1));
-    }
+    REQUIRE(not upper_bound_check->check(f1));
+    upper_bound_check->repair(f1);
+    REQUIRE(upper_bound_check->check(f1));
     // Should have repaired to the upper bound:
     f1.sync_to_host();
     for (int i=0; i<num_reals; ++i)


### PR DESCRIPTION
- Repairing tracers after dynamics

This addresses the issue where some tracers appear to be negative after dynamics, albeit essentially well within epsilon of 0.0.  Here we clip these values.

 - Make it so that the dynamics grid reports lat/lon in units of degrees
to the grids manager.

This is needed because everywhere else in the code lat/lon is assumed to be in degrees.  The immediate impact is that rrtmgp is currently calculating the zenith angle assuming lat/lon is in degrees.  So in the Homme+physics test rrtmgp has no daylight columns.

 - Clean up the call to tracers_forcing in the dynamics interface.

This is needed to ensure that ftype=2 is a valid option.