### PR TITLE
Only output to scream on rank0

### DIFF
--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -106,7 +106,7 @@ protected:
   // Homme dyn parameters
   ekat::ParameterList     m_params;
 
-  // The MPI communicator associated witht his atm process
+  // The MPI communicator associated witht this atm process
   ekat::Comm              m_dynamics_comm;
 };
 

--- a/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -42,7 +42,7 @@ contains
       call abortmp ("Error! 'homme_init_grids_f90 was not called yet.\n")
     endif
 
-    print *, "Initing prim data structures..."
+    if (par%masterproc) print *, "Initing prim data structures..."
 
     ! ==================================
     ! Initialize derivative structure

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -379,7 +379,7 @@ void RRTMGPRadiation::run_impl (const Real dt) {
     sfc_alb_dir, sfc_alb_dif, mu0,
     lwp, iwp, rel, rei,
     sw_flux_up, sw_flux_dn, sw_flux_dn_dir,
-    lw_flux_up, lw_flux_dn
+    lw_flux_up, lw_flux_dn, get_comm()
   );
 
   // Compute and apply heating rates

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -379,7 +379,7 @@ void RRTMGPRadiation::run_impl (const Real dt) {
     sfc_alb_dir, sfc_alb_dif, mu0,
     lwp, iwp, rel, rei,
     sw_flux_up, sw_flux_dn, sw_flux_dn_dir,
-    lw_flux_up, lw_flux_dn, get_comm()
+    lw_flux_up, lw_flux_dn, get_comm().am_i_root()
   );
 
   // Compute and apply heating rates

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -142,7 +142,7 @@ namespace scream {
                 real2d &lwp, real2d &iwp, real2d &rel, real2d &rei,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
                 real2d &lw_flux_up, real2d &lw_flux_dn,
-                const ekat::Comm &comm) {
+                const bool i_am_root) {
 
             // Setup pointers to RRTMGP SW fluxes
             FluxesBroadband fluxes_sw;
@@ -164,7 +164,7 @@ namespace scream {
                 ncol, nlay,
                 k_dist_sw, p_lay, t_lay, p_lev, t_lev, gas_concs, 
                 sfc_alb_dir, sfc_alb_dif, mu0, clouds_sw, fluxes_sw,
-                comm
+                i_am_root
             );
 
             // Do longwave
@@ -238,7 +238,7 @@ namespace scream {
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, OpticalProps2str &clouds,
                 FluxesBroadband &fluxes,
-                const ekat::Comm &comm) {
+                const bool i_am_root) {
 
             // Get problem sizes
             int nbnd = k_dist.get_nband();
@@ -272,7 +272,7 @@ namespace scream {
             // Copy data back to the device
             dayIndices_h.deep_copy_to(dayIndices);
             if (nday == 0) { 
-                if (comm.am_i_root()) std::cout << "WARNING: no daytime columns found for this chunk!\n";
+                if (i_am_root) std::cout << "WARNING: no daytime columns found for this chunk!\n";
                 return;
             }
 

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -141,7 +141,7 @@ namespace scream {
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0,
                 real2d &lwp, real2d &iwp, real2d &rel, real2d &rei,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
-                real2d &lw_flux_up, real2d &lw_flux_dn, ekat::Comm comm) {
+                real2d &lw_flux_up, real2d &lw_flux_dn, ekat::Comm &comm) {
 
             // Setup pointers to RRTMGP SW fluxes
             FluxesBroadband fluxes_sw;
@@ -235,7 +235,7 @@ namespace scream {
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, OpticalProps2str &clouds,
-                FluxesBroadband &fluxes, ekat::Comm comm) {
+                FluxesBroadband &fluxes, ekat::Comm &comm) {
 
             // Get problem sizes
             int nbnd = k_dist.get_nband();

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -136,12 +136,13 @@ namespace scream {
 
         void rrtmgp_main(
                 const int ncol, const int nlay,
-                real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev, 
+                real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0,
                 real2d &lwp, real2d &iwp, real2d &rel, real2d &rei,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
-                real2d &lw_flux_up, real2d &lw_flux_dn, ekat::Comm &comm) {
+                real2d &lw_flux_up, real2d &lw_flux_dn,
+                const ekat::Comm &comm) {
 
             // Setup pointers to RRTMGP SW fluxes
             FluxesBroadband fluxes_sw;
@@ -230,12 +231,14 @@ namespace scream {
         }
 
 
-        void rrtmgp_sw(const int ncol, const int nlay,
+        void rrtmgp_sw(
+                const int ncol, const int nlay,
                 GasOpticsRRTMGP &k_dist,
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, OpticalProps2str &clouds,
-                FluxesBroadband &fluxes, ekat::Comm &comm) {
+                FluxesBroadband &fluxes,
+                const ekat::Comm &comm) {
 
             // Get problem sizes
             int nbnd = k_dist.get_nband();

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -141,7 +141,7 @@ namespace scream {
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0,
                 real2d &lwp, real2d &iwp, real2d &rel, real2d &rei,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
-                real2d &lw_flux_up, real2d &lw_flux_dn) {
+                real2d &lw_flux_up, real2d &lw_flux_dn, ekat::Comm comm) {
 
             // Setup pointers to RRTMGP SW fluxes
             FluxesBroadband fluxes_sw;
@@ -162,7 +162,8 @@ namespace scream {
             rrtmgp_sw(
                 ncol, nlay,
                 k_dist_sw, p_lay, t_lay, p_lev, t_lev, gas_concs, 
-                sfc_alb_dir, sfc_alb_dif, mu0, clouds_sw, fluxes_sw
+                sfc_alb_dir, sfc_alb_dif, mu0, clouds_sw, fluxes_sw,
+                comm
             );
 
             // Do longwave
@@ -229,13 +230,12 @@ namespace scream {
         }
 
 
-        void rrtmgp_sw(
-                const int ncol, const int nlay,
+        void rrtmgp_sw(const int ncol, const int nlay,
                 GasOpticsRRTMGP &k_dist,
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, OpticalProps2str &clouds,
-                FluxesBroadband &fluxes) {
+                FluxesBroadband &fluxes, ekat::Comm comm) {
 
             // Get problem sizes
             int nbnd = k_dist.get_nband();
@@ -269,7 +269,7 @@ namespace scream {
             // Copy data back to the device
             dayIndices_h.deep_copy_to(dayIndices);
             if (nday == 0) { 
-                std::cout << "WARNING: no daytime columns found for this chunk!\n";
+                if (comm.am_i_root()) std::cout << "WARNING: no daytime columns found for this chunk!\n";
                 return;
             }
 

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -42,7 +42,10 @@ namespace scream {
                 real1d &sfc_alb_dif_vis, real1d &sfc_alb_dif_nir,
                 real2d &sfc_alb_dir,     real2d &sfc_alb_dif);
         /*
-         * Main driver code to run RRTMGP
+         * Main driver code to run RRTMGP. Optional input
+         * i_am_root is defaulted to true, and is used to
+         * determine whether or not info should be printed
+         * to the screen.
          */
         extern void rrtmgp_main(
                 const int ncol, const int nlay,
@@ -52,7 +55,7 @@ namespace scream {
                 real2d &lwp, real2d &iwp, real2d &rel, real2d &rei,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
                 real2d &lw_flux_up, real2d &lw_flux_dn,
-                const ekat::Comm &comm = ekat::Comm(MPI_COMM_WORLD));
+                const bool i_am_root = true);
         /*
          * Perform any clean-up tasks
          */
@@ -65,7 +68,7 @@ namespace scream {
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, OpticalProps2str &clouds,
-                FluxesBroadband &fluxes, const ekat::Comm &comm);
+                FluxesBroadband &fluxes, const bool i_am_root);
         /*
          * Longwave driver (called by rrtmgp_main)
          */

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -44,13 +44,15 @@ namespace scream {
         /*
          * Main driver code to run RRTMGP
          */
-        extern void rrtmgp_main(const int ncol, const int nlay,
+        extern void rrtmgp_main(
+                const int ncol, const int nlay,
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0,
                 real2d &lwp, real2d &iwp, real2d &rel, real2d &rei,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
-                real2d &lw_flux_up, real2d &lw_flux_dn, ekat::Comm &comm);
+                real2d &lw_flux_up, real2d &lw_flux_dn,
+                const ekat::Comm &comm = ekat::Comm(MPI_COMM_WORLD));
         /*
          * Perform any clean-up tasks
          */
@@ -63,7 +65,7 @@ namespace scream {
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, OpticalProps2str &clouds,
-                FluxesBroadband &fluxes, ekat::Comm &comm);
+                FluxesBroadband &fluxes, const ekat::Comm &comm);
         /*
          * Longwave driver (called by rrtmgp_main)
          */

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -50,7 +50,7 @@ namespace scream {
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0,
                 real2d &lwp, real2d &iwp, real2d &rel, real2d &rei,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
-                real2d &lw_flux_up, real2d &lw_flux_dn, ekat::Comm comm);
+                real2d &lw_flux_up, real2d &lw_flux_dn, ekat::Comm &comm);
         /*
          * Perform any clean-up tasks
          */
@@ -63,7 +63,7 @@ namespace scream {
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, OpticalProps2str &clouds,
-                FluxesBroadband &fluxes, ekat::Comm comm);
+                FluxesBroadband &fluxes, ekat::Comm &comm);
         /*
          * Longwave driver (called by rrtmgp_main)
          */

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -7,6 +7,8 @@
 #include "cpp/const.h"
 #include "physics/share/physics_constants.hpp"
 
+#include "ekat/mpi/ekat_comm.hpp"
+
 namespace scream {
     namespace rrtmgp {
         /* 
@@ -42,14 +44,13 @@ namespace scream {
         /*
          * Main driver code to run RRTMGP
          */
-        extern void rrtmgp_main(
-                const int ncol, const int nlay,
+        extern void rrtmgp_main(const int ncol, const int nlay,
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0,
                 real2d &lwp, real2d &iwp, real2d &rel, real2d &rei,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
-                real2d &lw_flux_up, real2d &lw_flux_dn);
+                real2d &lw_flux_up, real2d &lw_flux_dn, ekat::Comm comm);
         /*
          * Perform any clean-up tasks
          */
@@ -57,13 +58,12 @@ namespace scream {
         /*
          * Shortwave driver (called by rrtmgp_main)
          */
-        extern void rrtmgp_sw(
-                const int ncol, const int nlay,
-                GasOpticsRRTMGP &k_dist, 
-                real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev, 
-                GasConcs &gas_concs, 
+        extern void rrtmgp_sw(const int ncol, const int nlay,
+                GasOpticsRRTMGP &k_dist,
+                real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
+                GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, OpticalProps2str &clouds,
-                FluxesBroadband &fluxes);
+                FluxesBroadband &fluxes, ekat::Comm comm);
         /*
          * Longwave driver (called by rrtmgp_main)
          */

--- a/components/scream/src/share/util/scream_test_session.cpp
+++ b/components/scream/src/share/util/scream_test_session.cpp
@@ -14,8 +14,8 @@
  * of these routines).
  */
 
-void ekat_initialize_test_session (int argc, char** argv) {
-  scream::initialize_scream_session (argc,argv);
+void ekat_initialize_test_session (int argc, char** argv, const bool print_config) {
+  scream::initialize_scream_session (argc,argv,print_config);
 }
 
 void ekat_finalize_test_session () {


### PR DESCRIPTION
A few instances where screen output was on all processes. Only output if we are rank0. Also updates EKAT submodule to incorporate changes related to this.