### PR TITLE
Add needed team_barrier()

### DIFF
--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -516,6 +516,7 @@ void HommeDynamics::homme_post_process () {
     auto p_int = ekat::subview(p_int_view,icol);
 
     ColOps::column_scan<true>(team,nlevs,dp,p_int,ps0);
+    team.team_barrier();
     ColOps::compute_midpoint_values(team,nlevs,p_int,p_mid);
     team.team_barrier();
 
@@ -748,6 +749,7 @@ void HommeDynamics::import_initial_conditions () {
     auto p_int = ws.take("p_int");
     auto p_mid = ws.take("p_mid");
     ColOps::column_scan<true>(team,nlevs,dp,p_int,ps0);
+    team.team_barrier();
     ColOps::compute_midpoint_values(team,nlevs,p_int,p_mid);
     team.team_barrier();
     


### PR DESCRIPTION
Running through CIME, again I saw the issues with `OMP_NUM_THREAD > 1`. Still not sure why this bug is not caught in the scream coupled/uncoupled tests. 