### PR TITLE
More print only rank0 and removing virtual get_comm()

### DIFF
--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -55,6 +55,9 @@ public:
   // Set comm for the whole atmosphere
   void set_comm (const ekat::Comm& atm_comm);
 
+  // Return comm for the whole atmosphere
+  const ekat::Comm& get_comm () const { return m_atm_comm; }
+
   // Set AD params
   void set_params (const ekat::ParameterList& params);
 

--- a/components/scream/src/control/tests/dummy_atm_proc.hpp
+++ b/components/scream/src/control/tests/dummy_atm_proc.hpp
@@ -19,9 +19,8 @@ public:
   };
 
   DummyProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
-   : m_comm(comm)
+    : AtmosphereProcess(comm, params)
   {
-    m_params = params;
     m_name = m_params.get<std::string>("Sub Name");
     if (m_name=="Group to Group") {
       m_dummy_type = G2G;
@@ -39,9 +38,6 @@ public:
 
   // Return some sort of name, linked to PType
   std::string name () const { return m_name; }
-
-  // The communicator associated with this atm process
-  const ekat::Comm& get_comm () const { return m_comm; }
 
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager) {
     using namespace ShortFieldTagsNames;
@@ -132,10 +128,7 @@ protected:
 
   std::string m_name;
 
-  ekat::ParameterList m_params;
   DummyType     m_dummy_type; 
-
-  ekat::Comm    m_comm;
 };
 
 } // namespace scream

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -37,8 +37,7 @@ namespace scream
 {
 
 HommeDynamics::HommeDynamics (const ekat::Comm& comm, const ekat::ParameterList& params)
- : m_params        (params)
- , m_dynamics_comm (comm)
+  : AtmosphereProcess(comm, params)
 {
   // Nothing to do here
 }

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -287,7 +287,7 @@ void HommeDynamics::initialize_impl (const util::TimeStamp& /* t0 */)
   const auto& Q_dyn_track = get_group_out("Q",dgn).m_bundle->get_header().get_tracking();
   for (auto wp : Q_dyn_track.get_providers()) { 
     auto sp = wp.lock();
-    printf("Q is provided by: %s\n",sp->name().c_str());
+    if (get_comm().am_i_root()) printf("Q is provided by: %s\n",sp->name().c_str());
   }
   EKAT_REQUIRE_MSG (
       rho_track.get_providers().size()==1,
@@ -597,7 +597,7 @@ void HommeDynamics::init_homme_views () {
   const int qsize = get_group_out("Q",dgn).m_info->size();
 
   // Print homme's parameters, so user can see whether something wasn't set right.
-  c.get<Homme::SimulationParams>().print();
+  if (get_comm().am_i_root()) c.get<Homme::SimulationParams>().print();
 
   // ------------ Set views in Homme ------------- //
   // Velocity

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -285,10 +285,6 @@ void HommeDynamics::initialize_impl (const util::TimeStamp& /* t0 */)
   const auto& rho_track = get_field_out("pseudo_density").get_header().get_tracking();
   const auto& w_i_track = get_field_out("w_int").get_header().get_tracking();
   const auto& Q_dyn_track = get_group_out("Q",dgn).m_bundle->get_header().get_tracking();
-  for (auto wp : Q_dyn_track.get_providers()) { 
-    auto sp = wp.lock();
-    if (get_comm().am_i_root()) printf("Q is provided by: %s\n",sp->name().c_str());
-  }
   EKAT_REQUIRE_MSG (
       rho_track.get_providers().size()==1,
       "Error! Someone other than Dynamics is trying to update the pseudo_density.\n");

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -38,9 +38,6 @@ public:
   // The name of the subcomponent
   std::string name () const { return "Dynamics"; }
 
-  // The communicator used by the dynamics
-  const ekat::Comm& get_comm () const { return m_dynamics_comm; }
-
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
@@ -105,12 +102,6 @@ protected:
   // The dynamics and reference grids
   std::shared_ptr<const AbstractGrid>  m_dyn_grid;
   std::shared_ptr<const AbstractGrid>  m_ref_grid;
-
-  // Homme dyn parameters
-  ekat::ParameterList     m_params;
-
-  // The MPI communicator associated witht this atm process
-  ekat::Comm              m_dynamics_comm;
 };
 
 } // namespace scream

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -64,11 +64,6 @@ const scream::control::AtmosphereDriver& get_ad () {
   return c.get<scream::control::AtmosphereDriver>();
 }
 
-const ekat::Comm& get_ekat_comm () {
-  const auto& c = scream::ScreamContext::singleton();
-  return c.get<ekat::Comm>();
-}
-
 } // anonymous namespace
 
 extern "C"
@@ -173,7 +168,7 @@ void scream_init_atm (const int& start_ymd,
     auto& ad = get_ad_nonconst();
 
     // Get the ekat comm
-    auto& atm_comm = get_ekat_comm();
+    auto& atm_comm = ad.get_comm();
 
     // Recall that e3sm uses the int YYYYMMDD to store a date
     if (atm_comm.am_i_root()) std::cout << "start_ymd: " << start_ymd << "\n";

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -64,6 +64,11 @@ const scream::control::AtmosphereDriver& get_ad () {
   return c.get<scream::control::AtmosphereDriver>();
 }
 
+const ekat::Comm& get_ekat_comm () {
+  const auto& c = scream::ScreamContext::singleton();
+  return c.get<ekat::Comm>();
+}
+
 } // anonymous namespace
 
 extern "C"
@@ -78,8 +83,6 @@ void scream_create_atm_instance (const MPI_Fint& f_comm,
   using namespace scream::control;
 
   fpe_guard_wrapper([&](){
-    // First of all, initialize the scream session
-    scream::initialize_scream_session();
 
     // Create the context
     auto& c = ScreamContext::singleton();
@@ -88,8 +91,13 @@ void scream_create_atm_instance (const MPI_Fint& f_comm,
     MPI_Comm mpi_comm_c = MPI_Comm_f2c(f_comm);
     auto& atm_comm = c.create<ekat::Comm>(mpi_comm_c);
 
+    // Initialize the scream session.
+    scream::initialize_scream_session(atm_comm.am_i_root());
+
     // Create a parameter list for inputs
-    printf("[scream] reading parameterr from yaml file: %s\n",input_yaml_file);
+    if (atm_comm.am_i_root()) {
+      printf("[scream] reading parameterr from yaml file: %s\n",input_yaml_file);
+    }
     ekat::ParameterList scream_params("Scream Parameters");
     parse_yaml_file (input_yaml_file, scream_params);
 
@@ -164,8 +172,11 @@ void scream_init_atm (const int& start_ymd,
     // Get the ad, then complete initialization
     auto& ad = get_ad_nonconst();
 
+    // Get the ekat comm
+    auto& atm_comm = get_ekat_comm();
+
     // Recall that e3sm uses the int YYYYMMDD to store a date
-    std::cout << "start_ymd: " << start_ymd << "\n";
+    if (atm_comm.am_i_root()) std::cout << "start_ymd: " << start_ymd << "\n";
     const int dd = start_ymd % 100;
     const int mm = (start_ymd / 100) % 100;
     const int yy = start_ymd / 10000;

--- a/components/scream/src/physics/cld_fraction/atmosphere_cld_fraction.cpp
+++ b/components/scream/src/physics/cld_fraction/atmosphere_cld_fraction.cpp
@@ -11,8 +11,7 @@ namespace scream
   using namespace cld_fraction;
 // =========================================================================================
 CldFraction::CldFraction (const ekat::Comm& comm, const ekat::ParameterList& params)
- : m_cldfraction_comm (comm)
- , m_cld_fraction_params (params)
+  : AtmosphereProcess(comm, params)
 {
   // Nothing to do here
 }
@@ -29,7 +28,7 @@ void CldFraction::set_grids(const std::shared_ptr<const GridsManager> grids_mana
   Q.set_string("kg/kg");
   Units nondim(0,0,0,0,0,0,0);
 
-  const auto& grid_name = m_cld_fraction_params.get<std::string>("Grid");
+  const auto& grid_name = m_params.get<std::string>("Grid");
   auto grid  = grids_manager->get_grid(grid_name);
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column

--- a/components/scream/src/physics/cld_fraction/atmosphere_cld_fraction.hpp
+++ b/components/scream/src/physics/cld_fraction/atmosphere_cld_fraction.hpp
@@ -37,13 +37,10 @@ public:
   // The name of the subcomponent
   std::string name () const { return "CldFraction"; }
 
-  // The communicator used by subcomponent
-  const ekat::Comm& get_comm () const { return m_cldfraction_comm; }
-
   // Get the required grid for subcomponent
   std::set<std::string> get_required_grids () const {
     static std::set<std::string> s;
-    s.insert(m_cld_fraction_params.get<std::string>("Grid"));
+    s.insert(m_params.get<std::string>("Grid"));
     return s;
   }
 
@@ -56,10 +53,6 @@ protected:
   void initialize_impl (const util::TimeStamp& t0);
   void run_impl        (const Real dt);
   void finalize_impl   ();
-
-  // TODO: store comm and params in the base class. It's pointless to have all subclasses store this stuff.
-  ekat::Comm          m_cldfraction_comm;
-  ekat::ParameterList m_cld_fraction_params;
 
   // Keep track of field dimensions and the iteration count
   Int m_num_cols; 

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -23,8 +23,7 @@ namespace scream
 
 // =========================================================================================
 P3Microphysics::P3Microphysics (const ekat::Comm& comm, const ekat::ParameterList& params)
- : m_p3_comm (comm)
- , m_p3_params (params)
+  : AtmosphereProcess(comm, params)
 {
   // Nothing to do here
 }
@@ -41,7 +40,7 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   Units nondim(0,0,0,0,0,0,0);
   auto micron = m / 1000000;
 
-  const auto& grid_name = m_p3_params.get<std::string>("Grid");
+  const auto& grid_name = m_params.get<std::string>("Grid");
   auto grid = grids_manager->get_grid(grid_name);
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -54,13 +54,10 @@ public:
   // The name of the subcomponent
   std::string name () const { return "Microphysics"; }
 
-  // The communicator used by subcomponent
-  const ekat::Comm& get_comm () const { return m_p3_comm; }
-
   // Get the required grid for subcomponent
   std::set<std::string> get_required_grids () const {
     static std::set<std::string> s;
-    s.insert(m_p3_params.get<std::string>("Grid"));
+    s.insert(m_params.get<std::string>("Grid"));
     return s;
   }
 
@@ -248,10 +245,6 @@ protected:
   // Set local variables using memory provided by
   // the ATMBufferManager
   void init_buffers(const ATMBufferManager &buffer_manager);
-
-  // TODO: store comm and params in the base class. It's pointless to have all subclasses store this stuff.
-  ekat::Comm          m_p3_comm;
-  ekat::ParameterList m_p3_params;
 
   // Keep track of field dimensions and the iteration count
   Int m_num_cols;

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -14,7 +14,9 @@ namespace scream {
   using MemberType = KT::MemberType;
 
 RRTMGPRadiation::RRTMGPRadiation (const ekat::Comm& comm, const ekat::ParameterList& params) 
-  : AtmosphereProcess::AtmosphereProcess(), m_rrtmgp_comm (comm), m_rrtmgp_params (params) {
+  : AtmosphereProcess(comm, params)
+{
+  // Nothing to do here
 }  // RRTMGPRadiation::RRTMGPRadiation
 
 // =========================================================================================
@@ -23,7 +25,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   using namespace ekat::units;
 
   // Gather the active gases from the rrtmgp parameter list and assign to the m_gas_names vector.
-  auto active_gases = m_rrtmgp_params.get<std::vector<std::string>>("active_gases");
+  auto active_gases = m_params.get<std::vector<std::string>>("active_gases");
   for (auto& it : active_gases) {
     // Make sure only unique names are added
     if (std::find(m_gas_names.begin(), m_gas_names.end(), it) == m_gas_names.end()) {
@@ -43,7 +45,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
 
   using namespace ShortFieldTagsNames;
 
-  const auto& grid_name = m_rrtmgp_params.get<std::string>("Grid");
+  const auto& grid_name = m_params.get<std::string>("Grid");
   auto grid = grids_manager->get_grid(grid_name);
   m_ncol = grid->get_num_local_dofs();
   m_nlay = grid->get_num_vertical_levels();
@@ -180,10 +182,10 @@ void RRTMGPRadiation::initialize_impl(const util::TimeStamp& /* t0 */) {
   // Determine orbital year. If Orbital Year is negative, use current year
   // from timestamp for orbital year; if positive, use provided orbital year
   // for duration of simulation.
-  m_orbital_year = m_rrtmgp_params.get<Int>("Orbital Year",-9999);
+  m_orbital_year = m_params.get<Int>("Orbital Year",-9999);
 
   // Determine whether or not we are using a fixed solar zenith angle (positive value)
-  m_fixed_solar_zenith_angle = m_rrtmgp_params.get<Real>("Fixed Solar Zenith Angle", -9999);
+  m_fixed_solar_zenith_angle = m_params.get<Real>("Fixed Solar Zenith Angle", -9999);
 
   // Initialize yakl
   if(!yakl::isInitialized()) { yakl::init(); }

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -34,13 +34,10 @@ public:
   // The name of the subcomponent
   std::string name () const { return "Radiation"; }
 
-  // The communicator used by the subcomponent
-  const ekat::Comm& get_comm () const { return m_rrtmgp_comm; }
-
   // Required grid for the subcomponent (??)
   std::set<std::string> get_required_grids () const {
       static std::set<std::string> s;
-      s.insert(m_rrtmgp_params.get<std::string>("Grid"));
+      s.insert(m_params.get<std::string>("Grid"));
       return s;
   }
 
@@ -53,10 +50,6 @@ public:
   void initialize_impl (const util::TimeStamp& t0);
   void run_impl        (const Real dt);
   void finalize_impl   ();
-
-  // TODO: store comm and params in the base class. It's pointless to have all subclasses store this stuff.
-  ekat::Comm            m_rrtmgp_comm;
-  ekat::ParameterList   m_rrtmgp_params;
 
   // Keep track of number of columns and levels
   int m_ncol;

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -8,12 +8,11 @@ namespace scream
 
 // =========================================================================================
 SHOCMacrophysics::SHOCMacrophysics (const ekat::Comm& comm,const ekat::ParameterList& params)
-  : m_shoc_comm   (comm)
-  , m_shoc_params (params)
+  : AtmosphereProcess(comm, params)
 {
-/* Anything that can be initialized without grid information can be initialized here.
- * Like universal constants, shoc options.
-*/
+  /* Anything that can be initialized without grid information can be initialized here.
+   * Like universal constants, shoc options.
+   */
 }
 
 // =========================================================================================
@@ -27,7 +26,7 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   Qunit.set_string("kg/kg");
   Units nondim(0,0,0,0,0,0,0);
 
-  const auto& grid_name = m_shoc_params.get<std::string>("Grid");
+  const auto& grid_name = m_params.get<std::string>("Grid");
   auto grid = grids_manager->get_grid(grid_name);
 
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -61,13 +61,10 @@ public:
   // The name of the subcomponent
   std::string name () const { return "Macrophysics"; }
 
-  // The communicator used by subcomponent
-  const ekat::Comm& get_comm () const { return m_shoc_comm; }
-
   // Get the required grid for subcomponent
   std::set<std::string> get_required_grids () const {
     static std::set<std::string> s;
-    s.insert(m_shoc_params.get<std::string>("Grid"));
+    s.insert(m_params.get<std::string>("Grid"));
     return s;
   }
 
@@ -411,10 +408,6 @@ protected:
   // Set local variables using memory provided by
   // the ATMBufferManager
   void init_buffers(const ATMBufferManager &buffer_manager);
-
-  // TODO: store comm and params in the base class. It's pointless to have all subclasses store this stuff.
-  ekat::Comm          m_shoc_comm;
-  ekat::ParameterList m_shoc_params;
 
   // Keep track of field dimensions and other scalar values
   // needed in shoc_main

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -12,8 +12,7 @@ namespace scream
   using namespace spa;
 // =========================================================================================
 SPA::SPA (const ekat::Comm& comm, const ekat::ParameterList& params)
- : m_spa_comm (comm)
- , m_spa_params (params)
+  : AtmosphereProcess(comm, params)
 {
   // Nothing to do here
 }
@@ -30,7 +29,7 @@ void SPA::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   Q.set_string("kg/kg");
   auto nondim = Units::nondimensional();
 
-  const auto& grid_name = m_spa_params.get<std::string>("Grid");
+  const auto& grid_name = m_params.get<std::string>("Grid");
   auto grid  = grids_manager->get_grid(grid_name);
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.hpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.hpp
@@ -49,13 +49,10 @@ public:
   // The name of the subcomponent
   std::string name () const { return "Simple Prescribed Aerosols (SPA)"; }
 
-  // The communicator used by subcomponent
-  const ekat::Comm& get_comm () const { return m_spa_comm; }
-
   // Get the required grid for subcomponent
   std::set<std::string> get_required_grids () const {
     static std::set<std::string> s;
-    s.insert(m_spa_params.get<std::string>("Grid"));
+    s.insert(m_params.get<std::string>("Grid"));
     return s;
   }
 
@@ -90,9 +87,6 @@ protected:
   // Set local variables using memory provided by
   // the ATMBufferManager
   void init_buffers(const ATMBufferManager &buffer_manager);
-
-  ekat::Comm          m_spa_comm;
-  ekat::ParameterList m_spa_params;
 
   // Keep track of field dimensions and the iteration count
   Int m_num_cols; 

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.cpp
@@ -21,10 +21,9 @@ namespace scream
 {
 
 ZMDeepConvection::ZMDeepConvection (const ekat::Comm& comm,const ekat::ParameterList& params )
-  : m_zm_comm (comm)
-  , m_zm_params(params)
+  : AtmosphereProcess(comm, params)
 {
-  // Nothing toww/ do here
+  // Nothing to do here
 }
 
 void ZMDeepConvection::set_grids(const std::shared_ptr<const GridsManager> grids_manager)

--- a/components/scream/src/physics/zm/atmosphere_deep_convection.hpp
+++ b/components/scream/src/physics/zm/atmosphere_deep_convection.hpp
@@ -32,9 +32,6 @@ public:
   // The name of the subcomponent
   std::string name () const { return "DeepConvection"; }
 
-  // The communicator used by subcomponent
-  const ekat::Comm& get_comm () const { return m_zm_comm; }
-
   // Get the required grid for subcomponent
   std::set<std::string> get_required_grids () const {
     static std::set<std::string> s;
@@ -70,10 +67,6 @@ protected:
 
   std::map<std::string,host_view_in_type>   m_zm_host_views_in;
   std::map<std::string,host_view_out_type>  m_zm_host_views_out;
-
-  // TODO: store comm and params in the base class. It's pointless to have all subclasses store this stuff.
-  ekat::Comm              m_zm_comm;
-  ekat::ParameterList     m_zm_params;
   
   std::map<std::string,const Real*>  m_raw_ptrs_in;
   std::map<std::string,Real*>        m_raw_ptrs_out;

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -8,6 +8,11 @@
 namespace scream
 {
 
+AtmosphereProcess::AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
+  : m_comm  (comm)
+  , m_params(params)
+{}
+
 void AtmosphereProcess::initialize (const TimeStamp& t0) {
   set_fields_and_groups_pointers();
   m_time_stamp = t0;

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -72,9 +72,6 @@ public:
   template<typename T>
   using str_map = std::map<std::string,T>;
 
-  // Default base constructor
-  AtmosphereProcess () = default;
-
   // Base constructor to set MPI communicator and params
   AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params);
 

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -72,6 +72,12 @@ public:
   template<typename T>
   using str_map = std::map<std::string,T>;
 
+  // Default base constructor
+  AtmosphereProcess () = default;
+
+  // Base constructor to set MPI communicator and params
+  AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params);
+
   virtual ~AtmosphereProcess () = default;
 
   // The type of the process (e.g., dynamics or physics)
@@ -82,9 +88,6 @@ public:
 
   // The name of the process
   virtual std::string name () const = 0;
-
-  // The communicator associated with this atm process
-  virtual const ekat::Comm& get_comm () const = 0;
 
   // Give the grids manager to the process, so it can grab its grid
   // Upon return, the atm proc should have a valid and complete list
@@ -102,6 +105,12 @@ public:
   void initialize (const TimeStamp& t0);
   void run (const Real dt);
   void finalize   (/* what inputs? */);
+
+  // Return the MPI communicator
+  const ekat::Comm& get_comm () const { return m_comm; }
+
+  // Return the parameter list
+  const ekat::ParameterList& get_params () const { return m_params; }
 
   // These methods set fields/groups in the atm process. The fields/groups are stored
   // in a list (with some helpers maps that can be used to quickly retrieve them).
@@ -318,6 +327,12 @@ protected:
   void alias_group_out (const std::string& group_name,
                         const std::string& grid_name,
                         const std::string& alias_name);
+
+  // MPI communicator
+  ekat::Comm m_comm;
+
+  // Parameter list
+  ekat::ParameterList m_params;
 
 private:
   // Called from initialize, this method creates the m_[fields|groups]_[in|out]_pointers

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -8,16 +8,16 @@ namespace scream {
 
 AtmosphereProcessGroup::
 AtmosphereProcessGroup (const ekat::Comm& comm, const ekat::ParameterList& params)
- : m_comm(comm)
+  : AtmosphereProcess(comm, params)
 {
   // Get number of processes in the group and the scheduling type (Sequential vs Parallel)
   m_group_size = params.get<int>("Number of Entries");
   EKAT_REQUIRE_MSG (m_group_size>0, "Error! Invalid group size.\n");
 
   if (m_group_size>1) {
-    if (params.get<std::string>("Schedule Type") == "Sequential") {
+    if (m_params.get<std::string>("Schedule Type") == "Sequential") {
       m_group_schedule_type = ScheduleType::Sequential;
-    } else if (params.get<std::string>("Schedule Type") == "Parallel") {
+    } else if (m_params.get<std::string>("Schedule Type") == "Parallel") {
       m_group_schedule_type = ScheduleType::Parallel;
       ekat::error::runtime_abort("Error! Parallel schedule not yet implemented.\n");
     } else {
@@ -53,7 +53,7 @@ AtmosphereProcessGroup (const ekat::Comm& comm, const ekat::ParameterList& param
       ekat::error::runtime_abort("Error! Parallel schedule type not yet implemented.\n");
     }
 
-    const auto& params_i = params.sublist(ekat::strint("Process",i));
+    const auto& params_i = m_params.sublist(ekat::strint("Process",i));
     const std::string& process_name = params_i.get<std::string>("Process Name");
     m_atm_processes.emplace_back(AtmosphereProcessFactory::instance().create(process_name,proc_comm,params_i));
 

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -43,9 +43,6 @@ public:
   // The name of the block
   std::string name () const { return m_group_name; }
 
-  // The communicator associated with this atm process
-  const ekat::Comm& get_comm () const { return m_comm; }
-
   // Grab the proper grid from the grids manager
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
@@ -82,10 +79,6 @@ protected:
   void set_updated_group_impl (const FieldGroup<Real>& group);
   void set_required_field_impl (const Field<const Real>& f);
   void set_computed_field_impl (const Field<      Real>& f);
-
-
-  // The communicator that each process in this group uses
-  ekat::Comm        m_comm;
 
   // The name of the group. This is usually a concatenation of the names of the individual processes
   std::string       m_group_name;

--- a/components/scream/src/share/scream_session.cpp
+++ b/components/scream/src/share/scream_session.cpp
@@ -20,7 +20,7 @@ static int get_default_fpes () {
 }
 
 void initialize_scream_session (bool print_config) {
-  ekat::initialize_ekat_session(false);
+  ekat::initialize_ekat_session(print_config);
   ekat::enable_fpes(get_default_fpes());
 
   if (print_config) 
@@ -28,7 +28,7 @@ void initialize_scream_session (bool print_config) {
 }
 
 void initialize_scream_session (int argc, char **argv, bool print_config) {
-  ekat::initialize_ekat_session(argc,argv,false);
+  ekat::initialize_ekat_session(argc,argv,print_config);
   ekat::enable_fpes(get_default_fpes());
   if (print_config) 
     std::cout << scream_config_string() << "\n";

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -18,7 +18,7 @@ class DummyProcess : public scream::AtmosphereProcess {
 public:
 
   DummyProcess (const ekat::Comm& comm,const ekat::ParameterList& params)
-   : m_comm(comm)
+    : AtmosphereProcess(comm, params)
   {
     m_name = params.get<std::string> ("Process Name");
     m_grid_name = params.get<std::string> ("Grid Name");
@@ -36,9 +36,6 @@ public:
 
   // Return some sort of name, linked to PType
   std::string name () const { return m_name; }
-
-  // The communicator associated with this atm process
-  const ekat::Comm& get_comm () const { return m_comm; }
 
   // Register all fields in the given field manager(s)
   void register_fields (const std::map<std::string,std::shared_ptr<FieldManager<Real>>>& /* field_mgrs */) const {}
@@ -58,8 +55,6 @@ protected:
 
   std::string m_name;
   std::string m_grid_name;
-
-  ekat::Comm    m_comm;
 };
 
 class MyDynamics : public DummyProcess<AtmosphereProcessType::Dynamics>


### PR DESCRIPTION
More fixes for only output on rank 0. Requires ekat to update.