### PR TITLE
SCREAM: make test-all-scream print last commit oneline msg

### DIFF
--- a/components/scream/scripts/git_utils.py
+++ b/components/scream/scripts/git_utils.py
@@ -141,7 +141,7 @@ def print_last_commit(git_ref=None, repo=None, dry_run=False):
         print("Last commit on ref '{}'".format(git_ref))
     else:
         git_ref = get_current_head(repo) if git_ref is None else git_ref
-        last_commit = get_current_commit(commit=git_ref)
+        last_commit = run_cmd_no_fail("git log --oneline -1 {}".format(git_ref), from_dir=repo)
         print("Last commit on ref '{}': {}".format(git_ref, last_commit))
 
 ###############################################################################


### PR DESCRIPTION
As the title says. This changes output such as

```
Last commit on ref 'master': d529b0778f4b507f0909141f15b400b1fba25b74
```
to a more verbose
```
Last commit on ref 'master': d529b0778f Merge Pull Request #1197 from E3SM-Project/scream/jgfouca/upstream_merge_2021_09_16
```