### PR TITLE
SCREAM: fix non-existent include dir warning

### DIFF
--- a/components/scream/src/physics/p3/CMakeLists.txt
+++ b/components/scream/src/physics/p3/CMakeLists.txt
@@ -1,11 +1,3 @@
-set(CIMEROOT ${SCREAM_BASE_DIR}/../../cime)
-list(APPEND CMAKE_MODULE_PATH ${CIMEROOT}/src/CMake)
-
-set(GENF90 ${CIMEROOT}/src/externals/genf90/genf90.pl)
-set(ENABLE_GENF90 True)
-include(genf90_utils)
-include(Sourcelist_utils)
-
 set(P3_SRCS
   p3_f90.cpp
   p3_functions_f90.cpp
@@ -63,7 +55,6 @@ endif()
 
 add_library(p3 ${P3_SRCS})
 target_include_directories(p3 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../share)
-target_include_directories(p3 SYSTEM PUBLIC ${CIMEROOT}/src/share/include)
 set_target_properties(p3 PROPERTIES Fortran_MODULE_DIRECTORY ${SCREAM_F90_MODULES})
 target_link_libraries(p3 physics_share scream_share)
 target_compile_options(p3 PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>)

--- a/components/scream/src/physics/share/CMakeLists.txt
+++ b/components/scream/src/physics/share/CMakeLists.txt
@@ -1,11 +1,3 @@
-set(CIMEROOT ${SCREAM_BASE_DIR}/../../cime)
-list(APPEND CMAKE_MODULE_PATH ${CIMEROOT}/src/CMake)
-
-set(GENF90 ${CIMEROOT}/src/externals/genf90/genf90.pl)
-set(ENABLE_GENF90 True)
-include(genf90_utils)
-include(Sourcelist_utils)
-
 set(PHYSICS_SHARE_SRCS
   physics_share_f2c.F90
   physics_share.cpp
@@ -25,7 +17,6 @@ if (NOT CUDA_BUILD)
 endif()
 
 add_library(physics_share ${PHYSICS_SHARE_SRCS})
-target_include_directories(physics_share SYSTEM PUBLIC ${CIMEROOT}/src/share/include)
 set_target_properties(physics_share PROPERTIES Fortran_MODULE_DIRECTORY ${SCREAM_F90_MODULES})
 target_link_libraries(physics_share scream_share)
 target_compile_options(physics_share PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>)

--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -1,11 +1,3 @@
-set(CIMEROOT ${SCREAM_BASE_DIR}/../../cime)
-list(APPEND CMAKE_MODULE_PATH ${CIMEROOT}/src/CMake)
-
-set(GENF90 ${CIMEROOT}/src/externals/genf90/genf90.pl)
-set(ENABLE_GENF90 True)
-include(genf90_utils)
-include(Sourcelist_utils)
-
 set(SHOC_SRCS
   shoc_f90.cpp
   shoc_functions_f90.cpp
@@ -72,7 +64,6 @@ endif()
 
 add_library(shoc ${SHOC_SRCS})
 target_include_directories(shoc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../share)
-target_include_directories(shoc SYSTEM PUBLIC ${CIMEROOT}/src/share/include)
 set_target_properties(shoc PROPERTIES Fortran_MODULE_DIRECTORY ${SCREAM_F90_MODULES})
 target_link_libraries(shoc physics_share scream_share)
 target_compile_options(shoc PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>)

--- a/components/scream/src/physics/zm/CMakeLists.txt
+++ b/components/scream/src/physics/zm/CMakeLists.txt
@@ -1,11 +1,3 @@
-set(CIMEROOT ${SCREAM_BASE_DIR}/../../cime)
-list(APPEND CMAKE_MODULE_PATH ${CIMEROOT}/src/CMake)
-
-set(GENF90 ${CIMEROOT}/src/externals/genf90/genf90.pl)
-set(ENABLE_GENF90 True)
-include(genf90_utils)
-include(Sourcelist_utils)
-
 set(ZM_SRCS
   ${SCREAM_BASE_DIR}/../eam/src/physics/cam/physics_utils.F90
   ${SCREAM_BASE_DIR}/../eam/src/physics/cam/scream_abortutils.F90
@@ -28,7 +20,6 @@ endif()
 
 add_library(zm ${ZM_SRCS})
 target_include_directories(zm PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../common)
-target_include_directories(zm SYSTEM PUBLIC ${CIMEROOT}/src/share/include)
 set_target_properties(zm PROPERTIES Fortran_MODULE_DIRECTORY ${SCREAM_F90_MODULES})
 target_link_libraries(zm physics_share scream_share)
 target_compile_options(zm PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>)


### PR DESCRIPTION
Also cleaned up some unused genF90-related cmake code.