### PR TITLE
SCREAM: fix shoc CMakeLists.txt

### DIFF
--- a/components/scream/src/physics/shoc/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/CMakeLists.txt
@@ -14,12 +14,6 @@ set(SHOC_SRCS
   shoc_iso_f.f90
   ${SCREAM_BASE_DIR}/../eam/src/physics/cam/shoc.F90
   atmosphere_macrophysics.cpp
-  shoc_diag_second_moments_srf.cpp
-  shoc_diag_second_moments_ubycond.cpp
-  shoc_diag_second_moments_lbycond.cpp
-  shoc_pblintd_init_pot.cpp
-  shoc_pblintd_cldcheck.cpp
-  shoc_check_tke.cpp
 )
 
 set(SHOC_HEADERS
@@ -31,42 +25,48 @@ set(SHOC_HEADERS
 # Add ETI source files if not on CUDA
 if (NOT CUDA_BUILD)
   list(APPEND SHOC_SRCS
-    shoc_update_host_dse.cpp
+    shoc_adv_sgs_tke.cpp
+    shoc_assumed_pdf.cpp
     shoc_calc_shoc_varorcovar.cpp
     shoc_calc_shoc_vertflux.cpp
-    shoc_linear_interp.cpp
-    shoc_compute_shoc_mix_shoc_length.cpp
-    shoc_compute_diag_third_shoc_moment.cpp
-    shoc_clipping_diag_third_shoc_moments.cpp
-    shoc_energy_integrals.cpp
-    shoc_diag_second_moments_lbycond.cpp
-    shoc_diag_second_moments.cpp
-    shoc_diag_second_shoc_moments.cpp
-    shoc_compute_brunt_shoc_length.cpp
     shoc_check_length_scale_shoc_length.cpp
+    shoc_check_tke.cpp
+    shoc_clipping_diag_third_shoc_moments.cpp
+    shoc_compute_brunt_shoc_length.cpp
+    shoc_compute_diag_third_shoc_moment.cpp
     shoc_compute_l_inf_shoc_length.cpp
-    shoc_diag_obklen.cpp
-    shoc_compute_shr_prod.cpp
-    shoc_length.cpp
-    shoc_energy_fixer.cpp
+    shoc_compute_shoc_mix_shoc_length.cpp
     shoc_compute_shoc_vapor.cpp
-    shoc_update_prognostics_implicit.cpp
-    shoc_diag_third_shoc_moments.cpp
-    shoc_assumed_pdf.cpp
-    shoc_adv_sgs_tke.cpp
+    shoc_compute_shr_prod.cpp
     shoc_compute_tmpi.cpp
+    shoc_diag_obklen.cpp
+    shoc_diag_second_moments.cpp
+    shoc_diag_second_moments_lbycond.cpp
+    shoc_diag_second_moments_lbycond.cpp
+    shoc_diag_second_moments_srf.cpp
+    shoc_diag_second_moments_ubycond.cpp
+    shoc_diag_second_shoc_moments.cpp
+    shoc_diag_third_shoc_moments.cpp
+    shoc_dp_inverse.cpp
+    shoc_eddy_diffusivities.cpp
+    shoc_energy_fixer.cpp
+    shoc_energy_integrals.cpp
+    shoc_grid.cpp
     shoc_integ_column_stability.cpp
     shoc_isotropic_ts.cpp
-    shoc_dp_inverse.cpp
+    shoc_length.cpp
+    shoc_linear_interp.cpp
     shoc_main.cpp
-    shoc_pblintd_height.cpp
-    shoc_tridiag_solver.cpp
-    shoc_pblintd_surf_temp.cpp
-    shoc_pblintd_check_pblh.cpp
     shoc_pblintd.cpp
-    shoc_grid.cpp
-    shoc_eddy_diffusivities.cpp
+    shoc_pblintd_check_pblh.cpp
+    shoc_pblintd_cldcheck.cpp
+    shoc_pblintd_height.cpp
+    shoc_pblintd_init_pot.cpp
+    shoc_pblintd_surf_temp.cpp
     shoc_tke.cpp
+    shoc_tridiag_solver.cpp
+    shoc_update_host_dse.cpp
+    shoc_update_prognostics_implicit.cpp
   ) # SHOC ETI SRCS
 endif()
 


### PR DESCRIPTION
Some cpp files that are only used for ETI were compiled also on GPU builds. The big downside is that, on GPU, each of these files causes the compilation of the *whole* shoc::Functions class.