### PR TITLE
Remove subgrid enhancement information from SHOC for P3 process rates

### DIFF
--- a/components/eam/src/physics/cam/micro_p3.F90
+++ b/components/eam/src/physics/cam/micro_p3.F90
@@ -2515,7 +2515,7 @@ subroutine cldliq_immersion_freezing(t_atm,lamc,mu_c,cdist1,qc_incld,inv_qc_relv
       ! for future: calculate gamma(mu_c+4) in one place since its used multiple times  !AaronDonahue, TODO
       dum1 = bfb_exp(aimm*(T_zerodegc-t_atm))
       dum2 = bfb_cube(1._rtype/lamc)
-      sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, 2._rtype)
+      sbgrd_var_coef = 1._rtype    !no subgrid enhancement
       Q_nuc = sbgrd_var_coef*cons6*cdist1*bfb_gamma(7._rtype+mu_c)*dum1*bfb_square(dum2)
       N_nuc = cons5*cdist1*bfb_gamma(mu_c+4._rtype)*dum1*dum2
       qc2qi_hetero_freeze_tend = Q_nuc
@@ -2678,7 +2678,7 @@ subroutine cloud_rain_accretion(rho,inv_rho,qc_incld,nc_incld,qr_incld,inv_qc_re
      elseif (iparam.eq.3) then
         !Khroutdinov and Kogan (2000)
         !print*,'p3_qc_accret_expon = ',p3_qc_accret_expon
-        sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, 1.15_rtype ) !p3_qc_accret_expon
+        sbgrd_var_coef = 1._rtype    ! no subgrid enhancement
         qc2qr_accret_tend = sbgrd_var_coef*67._rtype*bfb_pow(qc_incld*qr_incld, 1.15_rtype) !p3_qc_accret_expon
         nc_accret_tend = qc2qr_accret_tend*nc_incld/qc_incld
      endif
@@ -2755,7 +2755,7 @@ subroutine cloud_water_autoconversion(rho,qc_incld,nc_incld,inv_qc_relvar,    &
 
       !Khroutdinov and Kogan (2000)
       !print*,'p3_qc_autocon_expon = ',p3_qc_autocon_expon
-      sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, 2.47_rtype)
+      sbgrd_var_coef = 1._rtype    ! no subgrid enhancement
       qc2qr_autoconv_tend = sbgrd_var_coef*1350._rtype*bfb_pow(qc_incld,2.47_rtype)*bfb_pow(nc_incld*1.e-6_rtype*rho,-1.79_rtype)
       !ncautr is change in nr: assume all new raindrops are 25 micron in diameter
       ncautr = qc2qr_autoconv_tend*cons3

--- a/components/eam/src/physics/cam/micro_p3.F90
+++ b/components/eam/src/physics/cam/micro_p3.F90
@@ -2515,6 +2515,7 @@ subroutine cldliq_immersion_freezing(t_atm,lamc,mu_c,cdist1,qc_incld,inv_qc_relv
       ! for future: calculate gamma(mu_c+4) in one place since its used multiple times  !AaronDonahue, TODO
       dum1 = bfb_exp(aimm*(T_zerodegc-t_atm))
       dum2 = bfb_cube(1._rtype/lamc)
+      ! sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, 2._rtype)
       sbgrd_var_coef = 1._rtype    !no subgrid enhancement
       Q_nuc = sbgrd_var_coef*cons6*cdist1*bfb_gamma(7._rtype+mu_c)*dum1*bfb_square(dum2)
       N_nuc = cons5*cdist1*bfb_gamma(mu_c+4._rtype)*dum1*dum2
@@ -2678,6 +2679,7 @@ subroutine cloud_rain_accretion(rho,inv_rho,qc_incld,nc_incld,qr_incld,inv_qc_re
      elseif (iparam.eq.3) then
         !Khroutdinov and Kogan (2000)
         !print*,'p3_qc_accret_expon = ',p3_qc_accret_expon
+        !sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, 1.15_rtype ) !p3_qc_accret_expon
         sbgrd_var_coef = 1._rtype    ! no subgrid enhancement
         qc2qr_accret_tend = sbgrd_var_coef*67._rtype*bfb_pow(qc_incld*qr_incld, 1.15_rtype) !p3_qc_accret_expon
         nc_accret_tend = qc2qr_accret_tend*nc_incld/qc_incld
@@ -2755,6 +2757,7 @@ subroutine cloud_water_autoconversion(rho,qc_incld,nc_incld,inv_qc_relvar,    &
 
       !Khroutdinov and Kogan (2000)
       !print*,'p3_qc_autocon_expon = ',p3_qc_autocon_expon
+      !sbgrd_var_coef = subgrid_variance_scaling(inv_qc_relvar, 2.47_rtype)
       sbgrd_var_coef = 1._rtype    ! no subgrid enhancement
       qc2qr_autoconv_tend = sbgrd_var_coef*1350._rtype*bfb_pow(qc_incld,2.47_rtype)*bfb_pow(nc_incld*1.e-6_rtype*rho,-1.79_rtype)
       !ncautr is change in nr: assume all new raindrops are 25 micron in diameter

--- a/components/scream/src/physics/p3/p3_autoconversion_impl.hpp
+++ b/components/scream/src/physics/p3/p3_autoconversion_impl.hpp
@@ -20,6 +20,7 @@ void Functions<S,D>
   constexpr Scalar CONS3 = C::CONS3;
   if(qc_not_small.any()){
     Spack sgs_var_coef;
+    // sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, sp(2.47) );
     sgs_var_coef = 1;
 
     qc2qr_autoconv_tend.set(qc_not_small,

--- a/components/scream/src/physics/p3/p3_autoconversion_impl.hpp
+++ b/components/scream/src/physics/p3/p3_autoconversion_impl.hpp
@@ -20,7 +20,7 @@ void Functions<S,D>
   constexpr Scalar CONS3 = C::CONS3;
   if(qc_not_small.any()){
     Spack sgs_var_coef;
-    sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, sp(2.47) );
+    sgs_var_coef = 1;
 
     qc2qr_autoconv_tend.set(qc_not_small,
               sgs_var_coef*1350*pow(qc_incld,sp(2.47))*pow(nc_incld*sp(1.e-6)*rho,sp(-1.79)));

--- a/components/scream/src/physics/p3/p3_cldliq_imm_freezing_impl.hpp
+++ b/components/scream/src/physics/p3/p3_cldliq_imm_freezing_impl.hpp
@@ -37,7 +37,7 @@ void Functions<S,D>
     inv_lamc3.set(qc_not_small_and_t_freezing, cube(1/lamc));
 
     Spack sgs_var_coef;
-    sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, 2);
+    sgs_var_coef = 1;
 
     qc2qi_hetero_freeze_tend.set(qc_not_small_and_t_freezing,
                sgs_var_coef * CONS6 * cdist1 * tgamma(7+mu_c) * expAimmDt *

--- a/components/scream/src/physics/p3/p3_cldliq_imm_freezing_impl.hpp
+++ b/components/scream/src/physics/p3/p3_cldliq_imm_freezing_impl.hpp
@@ -37,6 +37,7 @@ void Functions<S,D>
     inv_lamc3.set(qc_not_small_and_t_freezing, cube(1/lamc));
 
     Spack sgs_var_coef;
+    // sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, 2);
     sgs_var_coef = 1;
 
     qc2qi_hetero_freeze_tend.set(qc_not_small_and_t_freezing,

--- a/components/scream/src/physics/p3/p3_cloud_rain_acc_impl.hpp
+++ b/components/scream/src/physics/p3/p3_cloud_rain_acc_impl.hpp
@@ -25,6 +25,7 @@ void Functions<S,D>
   constexpr Scalar qsmall = C::QSMALL;
 
   Spack sgs_var_coef;
+  // sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, sp(1.15) );
   sgs_var_coef = 1;
 
   const auto qr_and_qc_not_small = (qr_incld >= qsmall) && (qc_incld >= qsmall) && context;

--- a/components/scream/src/physics/p3/p3_cloud_rain_acc_impl.hpp
+++ b/components/scream/src/physics/p3/p3_cloud_rain_acc_impl.hpp
@@ -25,7 +25,7 @@ void Functions<S,D>
   constexpr Scalar qsmall = C::QSMALL;
 
   Spack sgs_var_coef;
-  sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, sp(1.15) );
+  sgs_var_coef = 1;
 
   const auto qr_and_qc_not_small = (qr_incld >= qsmall) && (qc_incld >= qsmall) && context;
   if (qr_and_qc_not_small.any()) {


### PR DESCRIPTION
The subgrid enhancement coefficients are leading to very high conversion efficiency of cloud water to rain water and causing an increase in popcorn cumulus in the model. Because subgrid/subcloud variability of cloud water is difficult to diagnose and we do not expect the subgrid enhancement to be that large in the 3km model, they are set to 1. 
This change is a non-BFB change. 