### PR TITLE
Quick fix of typo impacting timer

### DIFF
--- a/components/eam/src/dynamics/se/dyn_comp.F90
+++ b/components/eam/src/dynamics/se/dyn_comp.F90
@@ -394,7 +394,7 @@ CONTAINS
            call t_startf('prim_run_subcycle')
            call prim_run_subcycle(dyn_state%elem,hybrid,nets,nete,&
                tstep, single_column_in, TimeLevel, hvcoord, n)
-           call t_stopf('prim_run_sybcycle')
+           call t_stopf('prim_run_subcycle')
          end do
        endif
 


### PR DESCRIPTION
Quick fix of typo in timer to warning messages in e3sm.log. that fills up the log file and slows down the F90 ne1024 simulations. 
Fixes #1228 