### PR TITLE
Scorpio read input interface allow for specific time level to be read

### DIFF
--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -136,13 +136,31 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
 /* ---------------------------------------------------------- */
 void AtmosphereInput::read_variables ()
 {
+  // The default read input is to use the last step set for this
+  // file by eam_update_timesnap.
+  // To trigger the default in the read_variables routine we pass
+  // a negative value for the time level.
+  read_variables(-999);
+}
+/* ---------------------------------------------------------- */
+// Note: The timelevel argument provides a way to control which
+//       time snap to read input from in the file.  If a negative
+//       number is provided the routine will read input at the
+//       last time level set by running eam_update_timesnap.
+void AtmosphereInput::read_variables (const int timelevel)
+{
   EKAT_REQUIRE_MSG (m_is_inited,
       "Error! The init method has not been called yet.\n");
 
   for (auto const& name : m_fields_names) {
 
     // Read the data
-    scorpio::grid_read_data_array(m_filename,name,m_host_views_1d.at(name).data());
+    if (timelevel < 0)
+    {
+      scorpio::grid_read_data_array(m_filename,name,m_host_views_1d.at(name).data());
+    } else {
+      scorpio::grid_read_data_array(m_filename,name,timelevel,m_host_views_1d.at(name).data());
+    }
 
     // If we have a field manager, make sure the data is correctly
     // synced to both host and device views of the field.

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -134,20 +134,11 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
 }
 
 /* ---------------------------------------------------------- */
-void AtmosphereInput::read_variables ()
-{
-  // The default read input is to use the last step set for this
-  // file by eam_update_timesnap.
-  // To trigger the default in the read_variables routine we pass
-  // a negative value for the time level.
-  read_variables(-999);
-}
-/* ---------------------------------------------------------- */
-// Note: The timelevel argument provides a way to control which
+// Note: The time_index argument provides a way to control which
 //       time snap to read input from in the file.  If a negative
 //       number is provided the routine will read input at the
 //       last time level set by running eam_update_timesnap.
-void AtmosphereInput::read_variables (const int timelevel)
+void AtmosphereInput::read_variables (const int time_index)
 {
   EKAT_REQUIRE_MSG (m_is_inited,
       "Error! The init method has not been called yet.\n");
@@ -155,12 +146,7 @@ void AtmosphereInput::read_variables (const int timelevel)
   for (auto const& name : m_fields_names) {
 
     // Read the data
-    if (timelevel < 0)
-    {
-      scorpio::grid_read_data_array(m_filename,name,m_host_views_1d.at(name).data());
-    } else {
-      scorpio::grid_read_data_array(m_filename,name,timelevel,m_host_views_1d.at(name).data());
-    }
+    scorpio::grid_read_data_array(m_filename,name,time_index,m_host_views_1d.at(name).data());
 
     // If we have a field manager, make sure the data is correctly
     // synced to both host and device views of the field.

--- a/components/scream/src/share/io/scorpio_input.hpp
+++ b/components/scream/src/share/io/scorpio_input.hpp
@@ -136,6 +136,7 @@ public:
 
   // Read fields that were required via parameter list.
   void read_variables ();
+  void read_variables (const int timelevel);
   int read_int_scalar (const std::string& name);
   void finalize();
 

--- a/components/scream/src/share/io/scorpio_input.hpp
+++ b/components/scream/src/share/io/scorpio_input.hpp
@@ -135,8 +135,7 @@ public:
             const std::map<std::string,FieldLayout>&  layouts);
 
   // Read fields that were required via parameter list.
-  void read_variables ();
-  void read_variables (const int timelevel);
+  void read_variables (const int time_index = -1);
   int read_int_scalar (const std::string& name);
   void finalize();
 

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -171,7 +171,11 @@ void AtmosphereOutput::run_impl(const Real time, const std::string& time_str)
   const bool is_write_step = is_output_step || is_checkpoint_step;
   std::string filename;
   if (is_write_step) {
-    filename = compute_filename_root(m_casename) + "." + time_str;
+    if (m_num_snapshots_in_file==0) {
+      // A new file has been opened and we need a new filename for it.
+      m_filename = compute_filename_root(m_casename) + "." + time_str;
+    }
+    filename = m_filename;
     // If we are going to write an output checkpoint file, or a model restart file,
     // we need to append to the filename ".rhist" or ".r" respectively, and add
     // the filename to the rpointer.atm file.

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -207,7 +207,7 @@ void AtmosphereOutput::run_impl(const Real time, const std::string& time_str)
       }
     }
 
-    // Set the timelevel for this snap in the pio file.
+    // Set the time_index for this snap in the pio file.
     pio_update_time(filename,time);
     if (is_output_step) {
       // We're adding one snapshot to the file

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -142,6 +142,9 @@ protected:
   // The output filename root
   std::string       m_casename;
 
+  // The output filename
+  std::string       m_filename;
+
   // How to combine multiple snapshots in the output: Instant, Max, Min, Average
   std::string       m_avg_type;
 

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -1253,12 +1253,13 @@ contains
   !  grid_read_darray_1d: Read a variable defined on this grid
   !
   !---------------------------------------------------------------------------
-  subroutine grid_read_darray_1d(filename, varname, var_data_ptr)
+  subroutine grid_read_darray_1d(filename, varname, var_data_ptr, timelevel)
 
     ! Dummy arguments
-    character(len=*), intent(in) :: filename       ! PIO filename
-    character(len=*), intent(in) :: varname
-    type (c_ptr),     intent(in) :: var_data_ptr
+    character(len=*), intent(in)  :: filename       ! PIO filename
+    character(len=*), intent(in)  :: varname
+    type (c_ptr),     intent(in)  :: var_data_ptr
+    integer, optional, intent(in) :: timelevel
 
     ! Local variables
     type(pio_atm_file_t),pointer       :: pio_atm_file
@@ -1272,7 +1273,11 @@ contains
     call get_var(pio_atm_file,varname,var)
 
     ! Set the timesnap we are reading
-    call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
+    if (present(timelevel)) then
+      call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(timelevel,kind=pio_offset_kind))
+    else
+      call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
+    end if
     
     ! We don't want the extent along the 'time' dimension
     var_size = SIZE(var%compdof)

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -1253,13 +1253,13 @@ contains
   !  grid_read_darray_1d: Read a variable defined on this grid
   !
   !---------------------------------------------------------------------------
-  subroutine grid_read_darray_1d(filename, varname, var_data_ptr, timelevel)
+  subroutine grid_read_darray_1d(filename, varname, var_data_ptr, time_index)
 
     ! Dummy arguments
-    character(len=*), intent(in)  :: filename       ! PIO filename
-    character(len=*), intent(in)  :: varname
-    type (c_ptr),     intent(in)  :: var_data_ptr
-    integer, optional, intent(in) :: timelevel
+    character(len=*), intent(in) :: filename       ! PIO filename
+    character(len=*), intent(in) :: varname
+    type (c_ptr),     intent(in) :: var_data_ptr
+    integer, intent(in)          :: time_index
 
     ! Local variables
     type(pio_atm_file_t),pointer       :: pio_atm_file
@@ -1273,8 +1273,8 @@ contains
     call get_var(pio_atm_file,varname,var)
 
     ! Set the timesnap we are reading
-    if (present(timelevel)) then
-      call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(timelevel,kind=pio_offset_kind))
+    if (time_index .gt. 0) then
+      call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(time_index,kind=pio_offset_kind))
     else
       call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
     end if

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -17,7 +17,8 @@ extern "C" {
   void register_file_c2f(const char*&& filename, const int& mode);
   void set_decomp_c2f(const char*&& filename);
   void set_dof_c2f(const char*&& filename,const char*&& varname,const Int dof_len,const Int *x_dof);
-  void grid_read_data_array_c2f_real(const char*&& filename, const char*&& varname, Real *&hbuf);
+  void grid_read_data_array_c2f(const char*&& filename, const char*&& varname, Real *&hbuf);
+  void grid_read_data_array_wtime_c2f(const char*&& filename, const char*&& varname, Real *&hbuf, const Int timelevel);
   void grid_read_data_array_c2f_int(const char*&& filename, const char*&& varname, const Int dim1_length, Int *hbuf);
 
   void grid_write_data_array_c2f_real(const char*&& filename, const char*&& varname, const Real*& hbuf);
@@ -131,7 +132,11 @@ void count_pio_atm_file() {
 }
 /* ----------------------------------------------------------------- */
 void grid_read_data_array(const std::string &filename, const std::string &varname, Real *hbuf) {
-  grid_read_data_array_c2f_real(filename.c_str(),varname.c_str(),hbuf);
+  grid_read_data_array_c2f(filename.c_str(),varname.c_str(),hbuf);
+}
+/* ----------------------------------------------------------------- */
+void grid_read_data_array(const std::string &filename, const std::string &varname, const int timelevel, Real *hbuf) {
+  grid_read_data_array_wtime_c2f(filename.c_str(),varname.c_str(),hbuf,timelevel);
 }
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const Real* hbuf) {

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -17,8 +17,7 @@ extern "C" {
   void register_file_c2f(const char*&& filename, const int& mode);
   void set_decomp_c2f(const char*&& filename);
   void set_dof_c2f(const char*&& filename,const char*&& varname,const Int dof_len,const Int *x_dof);
-  void grid_read_data_array_c2f(const char*&& filename, const char*&& varname, Real *&hbuf);
-  void grid_read_data_array_wtime_c2f(const char*&& filename, const char*&& varname, Real *&hbuf, const Int timelevel);
+  void grid_read_data_array_c2f(const char*&& filename, const char*&& varname, const Int time_index, Real *&hbuf);
   void grid_read_data_array_c2f_int(const char*&& filename, const char*&& varname, const Int dim1_length, Int *hbuf);
 
   void grid_write_data_array_c2f_real(const char*&& filename, const char*&& varname, const Real*& hbuf);
@@ -131,12 +130,8 @@ void count_pio_atm_file() {
 
 }
 /* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname, Real *hbuf) {
-  grid_read_data_array_c2f(filename.c_str(),varname.c_str(),hbuf);
-}
-/* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname, const int timelevel, Real *hbuf) {
-  grid_read_data_array_wtime_c2f(filename.c_str(),varname.c_str(),hbuf,timelevel);
+void grid_read_data_array(const std::string &filename, const std::string &varname, const int time_index, Real *hbuf) {
+  grid_read_data_array_c2f(filename.c_str(),varname.c_str(),time_index,hbuf);
 }
 /* ----------------------------------------------------------------- */
 void grid_write_data_array(const std::string &filename, const std::string &varname, const Real* hbuf) {

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -58,8 +58,7 @@ namespace scorpio {
   void pio_update_time(const std::string &filename, const Real time);
 
   /* Read data for a specific variable from a specific file. */
-  void grid_read_data_array (const std::string &filename, const std::string &varname, Real* hbuf);
-  void grid_read_data_array (const std::string &filename, const std::string &varname, const int timelevel, Real* hbuf);
+  void grid_read_data_array (const std::string &filename, const std::string &varname, const int time_index, Real* hbuf);
   /* Write data for a specific variable to a specific file. */
   void grid_write_data_array(const std::string &filename, const std::string &varname, const Real* hbuf);
 

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -59,6 +59,7 @@ namespace scorpio {
 
   /* Read data for a specific variable from a specific file. */
   void grid_read_data_array (const std::string &filename, const std::string &varname, Real* hbuf);
+  void grid_read_data_array (const std::string &filename, const std::string &varname, const int timelevel, Real* hbuf);
   /* Write data for a specific variable to a specific file. */
   void grid_write_data_array(const std::string &filename, const std::string &varname, const Real* hbuf);
 

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -256,11 +256,12 @@ contains
 
   end subroutine grid_write_data_array_c2f_real
 !=====================================================================!
-  subroutine grid_read_data_array_c2f(filename_in,varname_in,var_data_ptr) bind(c)
+  subroutine grid_read_data_array_c2f(filename_in,varname_in,time_index,var_data_ptr) bind(c)
     use scream_scorpio_interface, only: grid_read_data_array
 
     type(c_ptr), intent(in) :: filename_in
     type(c_ptr), intent(in) :: varname_in
+    integer(kind=c_int), value, intent(in) :: time_index
     type(c_ptr), intent(in) :: var_data_ptr
 
     character(len=256) :: filename
@@ -268,25 +269,8 @@ contains
 
     call convert_c_string(filename_in,filename)
     call convert_c_string(varname_in,varname)
-    call grid_read_data_array(filename,varname,var_data_ptr)
+    call grid_read_data_array(filename,varname,var_data_ptr,time_index)
 
   end subroutine grid_read_data_array_c2f
-!=====================================================================!
-  subroutine grid_read_data_array_wtime_c2f(filename_in,varname_in,var_data_ptr,timelevel) bind(c)
-    use scream_scorpio_interface, only: grid_read_data_array
-
-    type(c_ptr), intent(in) :: filename_in
-    type(c_ptr), intent(in) :: varname_in
-    type(c_ptr), intent(in) :: var_data_ptr
-    integer(kind=c_int), value, intent(in) :: timelevel
-
-    character(len=256) :: filename
-    character(len=256) :: varname
-
-    call convert_c_string(filename_in,filename)
-    call convert_c_string(varname_in,varname)
-    call grid_read_data_array(filename,varname,var_data_ptr,timelevel)
-
-  end subroutine grid_read_data_array_wtime_c2f
 !=====================================================================!
 end module scream_scorpio_interface_iso_c2f

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -256,7 +256,7 @@ contains
 
   end subroutine grid_write_data_array_c2f_real
 !=====================================================================!
-  subroutine grid_read_data_array_c2f_real(filename_in,varname_in,var_data_ptr) bind(c)
+  subroutine grid_read_data_array_c2f(filename_in,varname_in,var_data_ptr) bind(c)
     use scream_scorpio_interface, only: grid_read_data_array
 
     type(c_ptr), intent(in) :: filename_in
@@ -270,6 +270,23 @@ contains
     call convert_c_string(varname_in,varname)
     call grid_read_data_array(filename,varname,var_data_ptr)
 
-  end subroutine grid_read_data_array_c2f_real
+  end subroutine grid_read_data_array_c2f
+!=====================================================================!
+  subroutine grid_read_data_array_wtime_c2f(filename_in,varname_in,var_data_ptr,timelevel) bind(c)
+    use scream_scorpio_interface, only: grid_read_data_array
+
+    type(c_ptr), intent(in) :: filename_in
+    type(c_ptr), intent(in) :: varname_in
+    type(c_ptr), intent(in) :: var_data_ptr
+    integer(kind=c_int), value, intent(in) :: timelevel
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_read_data_array(filename,varname,var_data_ptr,timelevel)
+
+  end subroutine grid_read_data_array_wtime_c2f
 !=====================================================================!
 end module scream_scorpio_interface_iso_c2f

--- a/components/scream/src/share/io/tests/CMakeLists.txt
+++ b/components/scream/src/share/io/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ foreach (MPI_RANKS RANGE 1 ${SCREAM_TEST_MAX_RANKS})
   configure_file(io_test_average.yaml io_test_average_np${MPI_RANKS}.yaml)
   configure_file(io_test_max.yaml io_test_max_np${MPI_RANKS}.yaml)
   configure_file(io_test_min.yaml io_test_min_np${MPI_RANKS}.yaml)
+  configure_file(io_test_multisnap.yaml io_test_multisnap_np${MPI_RANKS}.yaml)
   configure_file(io_test_restart.yaml io_test_restart_np${MPI_RANKS}.yaml)
   configure_file(io_test_restart_check.yaml io_test_restart_check_np${MPI_RANKS}.yaml)
 

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -113,8 +113,9 @@ TEST_CASE("input_output_basic","io")
     f.deep_copy(ekat::ScalarTraits<Real>::invalid());
   }
 
-  // At this point we should have 4 files output:
+  // At this point we should have 5 files output:
   // 1 file each for averaged, instantaneous, min and max data.
+  // And 1 file with multiple time snaps of instantaneous data.
   // Cycle through each output and make sure it is correct.
   // We can use the produced output files to simultaneously check output quality and the
   // ability to read input.
@@ -123,7 +124,7 @@ TEST_CASE("input_output_basic","io")
   auto min_params = get_in_params("Min",io_comm);
   auto max_params = get_in_params("Max",io_comm);
   auto multi_params = get_in_params("Multisnap",io_comm);
-  Real tol = pow(10,-6);
+  Real tol = 100*std::numeric_limits<Real>::epsilon();
   // Check instant output
   input_type ins_input(io_comm,ins_params,field_manager);
   ins_input.read_variables();

--- a/components/scream/src/share/io/tests/io_test_multisnap.yaml
+++ b/components/scream/src/share/io/tests/io_test_multisnap.yaml
@@ -1,0 +1,11 @@
+%YAML 1.1
+---
+Casename: io_multisnap_test_np${MPI_RANKS}
+Averaging Type: Instant
+Grid: Physics
+Max Snapshots Per File: 10
+Fields: [field_1, field_2, field_3, field_packed]
+Output:
+  Frequency: 1
+  Frequency Units: Steps
+...


### PR DESCRIPTION
This PR introduces the ability to read input at a specific time level in files that may contain more than one time level of data.

A new test is introduced that first writes output for every time step in a 10 time step run and then reads each time snap individually and checks that it matches.

This is a necessary precursor to the SPA phase 2 work.

This PR also fixes a bug where it wasn't possible to write multiple time steps to output.  Per the above test, this is now tested as well.