### PR TITLE
[WIP] Increasing the maximal rain size in P3 from 0.8-mm to 2.0-mm

### DIFF
--- a/components/eam/src/physics/cam/micro_p3.F90
+++ b/components/eam/src/physics/cam/micro_p3.F90
@@ -52,7 +52,7 @@ module micro_p3
        clbfact_dep,iparam, isize, densize, rimsize, rcollsize, ice_table_size, collect_table_size, &
        get_latent_heat, T_zerodegc, pi=>pi_e3sm, dnu, &
        T_rainfrz, T_icenuc, T_homogfrz, iulog=>iulog_e3sm, &
-       masterproc=>masterproc_e3sm, calculate_incloud_mixingratios, mu_r_constant, &
+       masterproc=>masterproc_e3sm, calculate_incloud_mixingratios, mu_r_constant, inv_Drmax, &
        lookup_table_1a_dum1_c, &
        p3_qc_autocon_expon, p3_qc_accret_expon
 
@@ -1857,7 +1857,7 @@ contains
        mu_r = mu_r_constant
        lamr   = bfb_cbrt(cons1*nr*(mu_r+3._rtype)*(mu_r+2._rtype)*(mu_r+1._rtype)/(qr))  ! recalculate slope based on mu_r
        lammax = (mu_r+1._rtype)*1.e+5_rtype   ! check for slope
-       lammin = (mu_r+1._rtype)*1250._rtype   ! set to small value since breakup is explicitly included (mean size 0.8 mm)
+       lammin = (mu_r+1._rtype)*inv_Drmax     ! set to small value since breakup is explicitly included (mean size 2.0 mm)
 
        ! apply lambda limiters for rain
        if (lamr.lt.lammin) then

--- a/components/eam/src/physics/cam/micro_p3_utils.F90
+++ b/components/eam/src/physics/cam/micro_p3_utils.F90
@@ -56,6 +56,8 @@ module micro_p3_utils
     real(rtype), parameter, public :: rho_h2os = 917._rtype  ! bulk density water solid
     real(rtype), parameter, public :: dropmass = 5.2e-7_rtype
 
+    real(rtype), parameter, public :: inv_Drmax = 1.0_rtype/(2.0e-3_rtype) ! inverse of maximum allowed rain number-weighted mean diameter in m (2-mm) 
+
     ! particle mass-diameter relationship
     ! currently we assume spherical particles for cloud ice/snow
     ! m = cD^d


### PR DESCRIPTION
The original number-weighted maximal rain size was limited in old versions of the P3 scheme to 0.8-mm.
This diameter size is smaller then typical stratiform precipitation, let alone convective precip. 
For a 3-km resolution cloud microphysics this maximal size is likely to be reached many times along a simulation.

The rain maximal size is affected by the ice category melting, rain-collection + breakup, as well as size sorting (e.g., sedimentation). Although, there weren't major updates in the corresponding processes in P3, the current maximal size of P3 is 2-mm.