### PR TITLE
Add F-SCREAM-LR-DYAMOND2-MPASSI and F-SCREAM-HR-DYAMOND2-MPASSI

### DIFF
--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -164,6 +164,16 @@
   </compset>
   
   <compset>
+    <alias>F2010-SCREAM-LR-DYAMOND2-MPASSI</alias>
+    <lname>2010_EAM%SCREAM-LR-DYAMOND2_ELM45%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>F2010-SCREAM-HR-DYAMOND2-MPASSI</alias>
+    <lname>2010_EAM%SCREAM-HR-DYAMOND2_ELM45%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>FDPSCREAMA97</alias>
       <lname>AR97_EAM%DPSCREAM_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>


### PR DESCRIPTION
Enable MPASSI for SCREAM F-cases for DYAMOND2 LR and HR configurations.
