### PR TITLE
SCREAM: do not inject scream's types in the global namespace

### DIFF
--- a/components/scream/src/physics/share/physics_share.hpp
+++ b/components/scream/src/physics/share/physics_share.hpp
@@ -3,7 +3,7 @@
 
 #include "share/scream_types.hpp"
 
-using scream::Real;
+namespace scream {
 
 extern "C" {
 
@@ -20,6 +20,6 @@ Real cxx_erf(Real input);
 
 }
 
-#endif
+} // namespace scream
 
-
+#endif // SCREAM_PHYSICS_SHARE_HPP


### PR DESCRIPTION
Fix #1014