### PR TITLE
Clean up context mask in p3

### DIFF
--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -275,8 +275,7 @@ struct Functions
   KOKKOS_FUNCTION
   static void prevent_ice_overdepletion(
     const Spack& pres, const Spack& T_atm, const Spack& qv, const Spack& latent_heat_sublim, const Scalar& inv_dt,
-    Spack& qv2qi_vapdep_tend, Spack& qi2qv_sublim_tend, const Smask& range_mask = Smask(true),
-    const Smask& context = Smask(true) );
+    Spack& qv2qi_vapdep_tend, Spack& qi2qv_sublim_tend, const Smask& context = Smask(true) );
 
   //------------------------------------------------------------------------------------------!
   // Finds indices in 3D ice (only) lookup table
@@ -620,7 +619,6 @@ struct Functions
                                     const Spack& qi_incld, const Spack& qc_incld,
                                     const Spack& ni_incld, const Spack& nc_incld,
                                     Spack& qc2qi_collect_tend, Spack& nc_collect_tend, Spack& qc2qr_ice_shed_tend, Spack& ncshdc,
-				    const Smask& range_mask = Smask(true),
                                     const Smask& context = Smask(true));
 
   // TODO (comments)
@@ -675,8 +673,7 @@ struct Functions
 			  const Spack& table_val_qi2qr_melting, const Spack& table_val_qi2qr_vent_melt, const Spack& latent_heat_vapor, const Spack& latent_heat_fusion,
 			  const Spack& dv, const Spack& sc, const Spack& mu, const Spack& kap,
 			  const Spack& qv, const Spack& qi_incld, const Spack& ni_incld,
-			  Spack& qi2qr_melt_tend, Spack& ni2nr_melt_tend, const Smask& range_mask = Smask(true),
-                          const Smask& context = Smask(true));
+			  Spack& qi2qr_melt_tend, Spack& ni2nr_melt_tend, const Smask& context = Smask(true));
 
   //liquid-phase dependent processes:
   KOKKOS_FUNCTION
@@ -731,8 +728,7 @@ struct Functions
                                     const Spack& kap, const Spack& mu, const Spack& sc, const Spack& qv, const Spack& qc_incld,
                                     const Spack& qi_incld, const Spack& ni_incld, const Spack& qr_incld,
                                     Smask& log_wetgrowth, Spack& qr2qi_collect_tend, Spack& qc2qi_collect_tend, Spack& qc_growth_rate,
-				    Spack& nr_ice_shed_tend, Spack& qc2qr_ice_shed_tend, const Smask& range_mask = Smask(true),
-                                    const Smask& context = Smask(true));
+				    Spack& nr_ice_shed_tend, Spack& qc2qr_ice_shed_tend, const Smask& context = Smask(true));
 
   // Note: not a kernel function
   static void get_latent_heat(const Int& nj, const Int& nk, view_2d<Spack>& v, view_2d<Spack>& s, view_2d<Spack>& f);

--- a/components/scream/src/physics/p3/p3_functions_f90.cpp
+++ b/components/scream/src/physics/p3/p3_functions_f90.cpp
@@ -2988,7 +2988,7 @@ void p3_main_part2_f(
       qm_incld_d, nc_incld_d, nr_incld_d, ni_incld_d, bm_incld_d,
       mu_c_d, nu_d, lamc_d, cdist_d, cdist1_d, cdistr_d, mu_r_d, lamr_d,
       logn0r_d, qv2qi_depos_tend_d, precip_total_tend_d, nevapr_d, qr_evap_tend_d, vap_liq_exchange_d,
-      vap_ice_exchange_d, liq_ice_exchange_d, pratot_d, prctot_d, bools_d(0));
+      vap_ice_exchange_d, liq_ice_exchange_d, pratot_d, prctot_d, bools_d(0),nk);
   });
 
   // Sync back to host. Skip intent in variables.

--- a/components/scream/src/physics/p3/p3_ice_cldliq_wet_growth_impl.hpp
+++ b/components/scream/src/physics/p3/p3_ice_cldliq_wet_growth_impl.hpp
@@ -16,8 +16,7 @@ void Functions<S,D>
   const Spack& table_val_qi2qr_vent_melt, const Spack& latent_heat_vapor, const Spack& latent_heat_fusion, const Spack& dv,
   const Spack& kap, const Spack& mu, const Spack& sc, const Spack& qv, const Spack& qc_incld,
   const Spack& qi_incld, const Spack& ni_incld, const Spack& qr_incld,
-  Smask& log_wetgrowth, Spack& qr2qi_collect_tend, Spack& qc2qi_collect_tend, Spack& qc_growth_rate, Spack& nr_ice_shed_tend, Spack& qc2qr_ice_shed_tend,
-  const Smask& range_mask, const Smask& context)
+  Smask& log_wetgrowth, Spack& qr2qi_collect_tend, Spack& qc2qi_collect_tend, Spack& qc_growth_rate, Spack& nr_ice_shed_tend, Spack& qc2qr_ice_shed_tend, const Smask& context)
 {
   using physics = scream::physics::Functions<Scalar, Device>;
 
@@ -43,7 +42,7 @@ void Functions<S,D>
   Spack dum1{0.};
 
   if (any_if.any()) {
-    qsat0 = physics::qv_sat( zerodeg,pres, false, range_mask );
+    qsat0 = physics::qv_sat( zerodeg,pres, false, context );
 
     qc_growth_rate.set(any_if,
                ((table_val_qi2qr_melting+table_val_qi2qr_vent_melt*cbrt(sc)*sqrt(rhofaci*rho/mu))*

--- a/components/scream/src/physics/p3/p3_ice_collection_impl.hpp
+++ b/components/scream/src/physics/p3/p3_ice_collection_impl.hpp
@@ -15,7 +15,7 @@ void Functions<S,D>
   const Spack& qi_incld, const Spack& qc_incld,
   const Spack& ni_incld, const Spack& nc_incld,
   Spack& qc2qi_collect_tend, Spack& nc_collect_tend, Spack& qc2qr_ice_shed_tend, Spack& ncshdc,
-  const Smask& range_mask, const Smask& context)
+  const Smask& context)
 {
   constexpr Scalar qsmall = C::QSMALL;
   constexpr Scalar tmelt  = C::Tmelt;

--- a/components/scream/src/physics/p3/p3_ice_melting_impl.hpp
+++ b/components/scream/src/physics/p3/p3_ice_melting_impl.hpp
@@ -16,8 +16,7 @@ void Functions<S,D>
   const Spack& table_val_qi2qr_melting, const Spack& table_val_qi2qr_vent_melt, const Spack& latent_heat_vapor, const Spack& latent_heat_fusion,
   const Spack& dv, const Spack& sc, const Spack& mu, const Spack& kap,
   const Spack& qv, const Spack& qi_incld, const Spack& ni_incld,
-  Spack& qi2qr_melt_tend, Spack& ni2nr_melt_tend, const Smask& range_mask,
-  const Smask& context)
+  Spack& qi2qr_melt_tend, Spack& ni2nr_melt_tend, const Smask& context)
 {
   // Notes Left over from WRF Version:
   // need to add back accelerated melting due to collection of ice mass by rain (pracsw1)
@@ -36,7 +35,7 @@ void Functions<S,D>
 
   if (has_melt_qi.any()) {
     //    Note that qsat0 should be with respect to liquid. Confirmed F90 code did this.
-    const auto qsat0 = physics::qv_sat(Spack(Tmelt), pres, false, range_mask); //"false" here means NOT saturation w/ respect to ice.
+    const auto qsat0 = physics::qv_sat(Spack(Tmelt), pres, false, context); //"false" here means NOT saturation w/ respect to ice.
 
     qi2qr_melt_tend.set(has_melt_qi, ( (table_val_qi2qr_melting+table_val_qi2qr_vent_melt*cbrt(sc)*sqrt(rhofaci*rho/mu))
 			     *((T_atm-Tmelt)*kap-rho*latent_heat_vapor*dv*(qsat0-qv))

--- a/components/scream/src/physics/p3/p3_prevent_ice_overdepletion_impl.hpp
+++ b/components/scream/src/physics/p3/p3_prevent_ice_overdepletion_impl.hpp
@@ -18,15 +18,14 @@ KOKKOS_FUNCTION
 void Functions<S,D>
 ::prevent_ice_overdepletion(
   const Spack& pres, const Spack& T_atm, const Spack& qv, const Spack& latent_heat_sublim, const Scalar& inv_dt,
-  Spack& qv2qi_vapdep_tend, Spack& qi2qv_sublim_tend, const Smask& range_mask,
-  const Smask& context)
+  Spack& qv2qi_vapdep_tend, Spack& qi2qv_sublim_tend, const Smask& context)
 {
   using physics = scream::physics::Functions<Scalar, Device>;
 
   constexpr Scalar cp = C::CP;
   constexpr Scalar rv = C::RH2O;
 
-  const auto dumqv_sat_i = physics::qv_sat(T_atm,pres,true, range_mask);
+  const auto dumqv_sat_i = physics::qv_sat(T_atm,pres,true, context);
   const auto qdep_satadj = (qv-dumqv_sat_i) /
     (1 + square(latent_heat_sublim) * dumqv_sat_i / (cp * rv * square(T_atm))) * inv_dt;
   qv2qi_vapdep_tend.set(context, qv2qi_vapdep_tend * min(1, max(0,  qdep_satadj) / max(qv2qi_vapdep_tend, sp(1.e-20))));


### PR DESCRIPTION
This PR:

1. Fixes a bug in run_bfb_p3_main_part2 where nk was getting set to a default value of -1 in p3_main_part2_f which caused range_mask to always be false. Range_mask was computed appropriately in full model runs, but not when part2 was called directly for a unit test. Fix was just adding nk as an input variable in the part2 call in p3_functions_f90.cpp.
2. Includes `|| !range_mask` as a condition in the `skip_all` logical calculation: range_mask is false wherever a cell is included solely to pad out our pack arrays, so you certainly shouldn't be doing calculations with it. 
3. For the 4 functions which took both range_mask and not_skip_all as inputs, only pass not_skip_all. 