### PR TITLE
Simple fix to all AD based SHOC tests that zero out the surface fluxes.

### DIFF
--- a/components/scream/tests/coupled/homme_physics/input.yaml
+++ b/components/scream/tests/coupled/homme_physics/input.yaml
@@ -11,6 +11,8 @@ Initial Conditions:
     horiz_winds_prev: horiz_winds
     w_int: 0.0 # Start from zero vert velocity
     w_int_prev: 0.0
+    surf_latent_flux: 0.0
+    surf_sens_flux: 0.0
   Dynamics:
     tracers: tracers, Physics GLL
 

--- a/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/input.yaml
@@ -35,4 +35,6 @@ Initial Conditions:
     Filename: shoc_cld_p3_rrtmgp_init_ne2np4.nc
     Load Latitude:  true
     Load Longitude: true
+    surf_latent_flux: 0.0
+    surf_sens_flux: 0.0
 ...

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -22,6 +22,8 @@ Grids Manager:
 Initial Conditions:
   Point Grid:
     Filename: shoc_init_ne2np4.nc
+    surf_latent_flux: 0.0
+    surf_sens_flux: 0.0
 
 # The name of the output control file for this test.
 Output Manager:


### PR DESCRIPTION
Having a constant surface flux caused the temperature in some columns
to decrease over time at the surface because the fluxes removed energy
from the column.  This led to any test with shoc in it eventually going to
unrealistic temperature values over time.

This is a minor issue as it's impact is only felt after a significant number
of steps.  But it is an issue and exposes a error in our test setup which this
commit solves.

Note, there seems to be a bug that causes an error when attempting to zero out the surface momentum flux.  This may need to be addressed and a similar fix added to the shoc tests.