### PR TITLE
SCREAM: fix test-all-scream if work dir is specified

### DIFF
--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -55,7 +55,7 @@ class TestAllScream(object):
         self._preserve_env            = preserve_env
         self._tests                   = tests
         self._root_dir                = root_dir
-        self._work_dir                = work_dir
+        self._work_dir                = None if work_dir is None else Path(work_dir)
         self._integration_test        = integration_test
         self._quick_rerun             = quick_rerun
         self._quick_rerun_failed      = quick_rerun_failed


### PR DESCRIPTION
The member _work_dir has to be created as a Path object, otherwise we cannot use the / operator to append later on. Before this commit, `self._work_dir` was inited as either None or a string (depending on the input `work_dir`).