### PR TITLE
Disable spread tests if not enough resources to run them

### DIFF
--- a/components/scream/tests/generic/infra/CMakeLists.txt
+++ b/components/scream/tests/generic/infra/CMakeLists.txt
@@ -5,7 +5,7 @@ set(NEED_LIBS ekat scream_share)
 # Add the fake test
 CreateUnitTest(fake_test "fake_test.cpp" "${NEED_LIBS}")
 
-if (SCREAM_TEST_MAX_THREADS GREATER_EQUAL 4 AND SCREAM_TEST_MAX_RANKS GREATER_EQUAL 4)
+if (SCREAM_TEST_MAX_TOTAL_THREADS GREATER_EQUAL 16)
   CreateUnitTest(resource_spread_thread "resource_spread.cpp" "${NEED_LIBS}"
     THREADS 1 4 1
     MPI_RANKS 4)


### PR DESCRIPTION
This should fix scripts-tests on weaver.