### PR TITLE
Changes to use larger EPS_AGRID for bi-grid ne1024pg2

### DIFF
--- a/driver-mct/cime_config/buildnml
+++ b/driver-mct/cime_config/buildnml
@@ -51,6 +51,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['bfbflag'] = 'on' if case.get_value('BFBFLAG') else 'off'
     config['continue_run'] = '.true.' if case.get_value('CONTINUE_RUN') else '.false.'
     config['atm_grid'] = case.get_value('ATM_GRID')
+    config['lnd_grid'] = case.get_value('LND_GRID')
     config['compocn'] = case.get_value('COMP_OCN')
 
     docn_mode = case.get_value("DOCN_MODE")

--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -1463,6 +1463,7 @@
     <values>
       <value>$EPS_AGRID</value>
       <value atm_grid="ne0np4_northamericax4v1">3.e-10</value>
+      <value atm_grid="ne1024np4.pg2" lnd_grid="ne1024np4.pg2">1.e-10</value>
     </values>
   </entry>
 


### PR DESCRIPTION
Default EPS_AGRID is 1.0e-12. For bi-grid configuration with
both atm and lnd on ne1024pg2, a larger EPS=1.0e-10 is needed.
The changes introduced allow the smaller EPS_AGRID=1.0e-12
continue to be used for tri-grid configuration such as
ne1024pg2_r0125_oRRS18to6v3.

Also refer to E3SM issue #4437 and scream issue #1140.

[BFB]