### PR TITLE
change  lammin to use 2mm instead of 0.8mm max mean drop diameter

### DIFF
--- a/components/eam/src/physics/cam/micro_p3.F90
+++ b/components/eam/src/physics/cam/micro_p3.F90
@@ -1858,8 +1858,8 @@ contains
        mu_r = mu_r_constant
        lamr   = bfb_cbrt(cons1*nr*(mu_r+3._rtype)*(mu_r+2._rtype)*(mu_r+1._rtype)/(qr))  ! recalculate slope based on mu_r
        lammax = (mu_r+1._rtype)*1.e+5_rtype   ! check for slope
-       lammin = (mu_r+1._rtype)*1250._rtype   ! set to small value since breakup is explicitly included (mean size 0.8 mm)
-
+       lammin = (mu_r+1._rtype)*500._rtype  !500=1/(2mm) is inverse of max allowed number-weighted mean raindrop diameter
+       
        ! apply lambda limiters for rain
        if (lamr.lt.lammin) then
           lamr = lammin

--- a/components/scream/src/physics/p3/p3_dsd2_impl.hpp
+++ b/components/scream/src/physics/p3/p3_dsd2_impl.hpp
@@ -107,8 +107,9 @@ get_rain_dsd2 (
 
     // check for slope
     const auto lammax = (mu_r+1.)*sp(1.e+5);
-    // set to small value since breakup is explicitly included (mean size 0.8 mm)
-    const auto lammin = (mu_r+1.)*sp(1250.0);
+    //Below, 500 is inverse of max allowable number-weighted mean raindrop size=2mm
+    //Since breakup is explicitly included, mean raindrop size can be relatively small
+    const auto lammin = (mu_r+1.)*500; 
 
     // apply lambda limiters for rain
     const auto lt = qr_gt_small && (lamr < lammin);


### PR DESCRIPTION
Implements #1234 by just hardcoding the desired new maximum number weighted mean raindrop diameter. Hardcoding is probably sufficient because this isn't a parameter folks should be changing often. Also, we want to have a grand effort to expose tuning parameters in C++ all at once, so I don't want to waste time wiring this up now.

This PR just changes a single parameter value from 1250 to 500 as recommended by https://journals.ametsoc.org/view/journals/mwre/147/10/mwr-d-18-0398.1.xml. Koby says this change reduces LWCF bias overall in ne30 and mostly eliminates surface precip bias between India and Africa. 