### PR TITLE
test-all-scream: add new test regex limit option

### DIFF
--- a/components/scream/cmake/ctest_script.cmake
+++ b/components/scream/cmake/ctest_script.cmake
@@ -54,7 +54,7 @@ else ()
         set(INCLUDE_REGEX "resource_spread_thread")
       elseif (DEFINED ENV{SCREAM_TEST_RANK_SPREAD})
         set(INCLUDE_REGEX "resource_spread_rank")
-      else()
+      elseif(NOT INCLUDE_REGEX)
         set(INCLUDE_REGEX ".") # all
       endif()
 

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -125,6 +125,9 @@ OR
     parser.add_argument("-x", "--extra-verbose", action="store_true",
                         help="Have ctest run in extra-verbose mode, which should print full output from all tests")
 
+    parser.add_argument("--limit-test-regex",
+                        help="Limit ctest to running only tests that match this regex")
+
     return parser.parse_args(args[1:])
 
 ###############################################################################

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -28,7 +28,7 @@ class TestAllScream(object):
                  integration_test=False, local=False, root_dir=None, work_dir=None,
                  quick_rerun=False,quick_rerun_failed=False,dry_run=False,
                  make_parallel_level=0, ctest_parallel_level=0, update_expired_baselines=False,
-                 extra_verbose=False):
+                 extra_verbose=False, limit_test_regex=None):
     ###########################################################################
 
         # When using scripts-tests, we can't pass "-l" to test-all-scream,
@@ -63,6 +63,7 @@ class TestAllScream(object):
         self._tests_needing_baselines = []
         self._update_expired_baselines= update_expired_baselines
         self._extra_verbose           = extra_verbose
+        self._limit_test_regex        = limit_test_regex
 
         self._test_full_names = OrderedDict([
             ("dbg" , "full_debug"),
@@ -548,6 +549,8 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         work_dir = self._work_dir/name
         result += "-DBUILD_WORK_DIR={} ".format(work_dir)
         result += "-DBUILD_NAME_MOD={} ".format(name)
+        if self._limit_test_regex:
+            result += "-DINCLUDE_REGEX={} ".format(self._limit_test_regex)
         result += '-S {}/cmake/ctest_script.cmake -DCMAKE_COMMAND="{}" '.format(self._root_dir, cmake_config)
 
         # Ctest can only competently manage test pinning across a single instance of ctest. For


### PR DESCRIPTION
Will allow user to run test-all-scream on specific tests only. I was able to use this option to do a very quick check of a single test:

```
./scripts/test-all-scream -m mappy -t dbg --limit-test-regex=utils --baseline-dir=AUTO
...
Test project /home/jgfouca/scream-clean/components/scream/ctest-build/full_debug
    Start 1: utils_ut_np1_omp1
1/1 Test #1: utils_ut_np1_omp1 ................   Passed    0.22 sec

100% tests passed, 0 tests failed out of 1
```

I want to leverage this option for quicker debugging of Lassen test-all-scream issues.