### PR TITLE
Fix run_and_cmp tests

### DIFF
--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -56,22 +56,16 @@ if (NOT ${SCREAM_BASELINES_ONLY})
                  LABELS "p3;physics")
 endif()
 
-# Set inf tolerance for release builds. This will effectively disable all baseline
-# checking, but we still want to ensure things run without crashing
-if (CMAKE_BUILD_TYPE MATCHES ".*Rel.*")
-  set(TOL_FLAG "--tol inf")
-endif()
-
 CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
-               EXE_ARGS "${TOL_FLAG} -b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
+               EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
                PROPERTIES FIXTURES_REQUIRED p3_tables
                EXCLUDE_MAIN_CPP
                LABELS "p3;physics")
 
 CreateUnitTest(p3_run_and_cmp_f90 "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
-               EXE_ARGS "${TOL_FLAG} -f -b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
+               EXE_ARGS "-f -b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
                PROPERTIES FIXTURES_REQUIRED p3_tables
                EXCLUDE_MAIN_CPP
                LABELS "p3;physics")

--- a/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/scream/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -272,7 +272,7 @@ int main (int argc, char** argv) {
   }
 
   bool generate = false, use_fortran = false;
-  scream::Real tol = 0;
+  scream::Real tol = SCREAM_BFB_TESTING ? 0 : std::numeric_limits<Real>::infinity();
   Int timesteps = 6;
   Int dt = 300;
   Int ncol = 3;

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -76,20 +76,14 @@ if (NOT ${SCREAM_BASELINES_ONLY})
   CreateUnitTest(shoc_tests "${SHOC_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP shoc_tests_ut_np1_omp1)
 endif()
 
-# Set inf tolerance for release builds. This will effectively disable all baseline
-# checking, but we still want to ensure things run without crashing
-if (CMAKE_BUILD_TYPE MATCHES ".*Rel.*")
-  set(TOL_FLAG "--tol inf")
-endif()
-
 CreateUnitTest(shoc_run_and_cmp_cxx "shoc_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
-               EXE_ARGS "${TOL_FLAG} -b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
+               EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
                EXCLUDE_MAIN_CPP)
 
 CreateUnitTest(shoc_run_and_cmp_f90 "shoc_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
-               EXE_ARGS "${TOL_FLAG} -f -b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
+               EXE_ARGS "-f -b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
                EXCLUDE_MAIN_CPP)
 
 # By default, baselines should be created using all fortran (make baseline). If the user wants

--- a/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_run_and_cmp.cpp
@@ -254,7 +254,7 @@ int main (int argc, char** argv) {
   }
 
   bool generate = false, use_fortran = false;
-  scream::Real tol = 0;
+  scream::Real tol = SCREAM_BFB_TESTING ? 0 : std::numeric_limits<Real>::infinity();
   Int nsteps = 10;
   Int dt = 150;
   Int ncol = 8;


### PR DESCRIPTION
BFB checking needs to be off for cuda-memcheck as well as Release builds
now. Change the default tol for run_and_cmp programs to inf if SCREAM_BFB_TESTING
is off, which will catch both release and cuda-memcheck.