### PR TITLE
DP-SCREAM large scale forcing bug fix

### DIFF
--- a/components/eam/src/control/forecast.F90
+++ b/components/eam/src/control/forecast.F90
@@ -315,6 +315,11 @@ subroutine forecast(lat, psm1, psm2,ps, &
          (qminus(1,k,m) - qminus(1,k-1,m)))
      enddo
 
+     ! thermal expansion term due to LS vertical advection
+     do k=1,plev
+       tfcst(k) = tfcst(k) + ztodt*wfld(k)*t3m1(k)*rair/(cpair*pmidm1(k))
+     enddo
+
 !
 !  SLT is used for constituents only
 !  so that a centered approximation is used for T, U and V, and Q


### PR DESCRIPTION
If the selected DP-SCREAM case does not include the 3D large scale (LS) tendencies in the IOP forcing file then the effects of LS vertical advection need to computed.  In DP-SCREAM this is done using an Eulerian calculation.  However, the thermal expansion/compression term due to LS vertical advection was missing for temperature, thus this PR adds it.

This bug fix is B4B for non DP runs but is answer changing for select (but not all) DP-SCREAM runs.  It will be b4b for the ARM97 case, which is used for the SCREAM nightly tests.  Hence, the "B4B" flag.