### PR TITLE
Add a suite of homme_shoc_cld_p3_rrtmgp multi-rank BFB tests.

### DIFF
--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -389,7 +389,6 @@ namespace scream {
             // Surface temperature
             auto p_lay_host = p_lay.createHostCopy();
             bool top_at_1 = p_lay_host(1, 1) < p_lay_host(1, nlay);
-            auto t_lev_host = t_lev.createHostCopy();
             parallel_for(Bounds<1>(ncol), YAKL_LAMBDA(int icol) {
                 t_sfc(icol) = t_lev(icol, merge(nlay+1, 1, top_at_1));
             });

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -129,7 +129,7 @@ protected:
   std::vector<int> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
   void new_file(const std::string& filename);
-  void run_impl(const Real time, const std::string& time_str);
+  void run_impl(const Real time);
   std::string compute_filename_root (const std::string& casename) const;
   void combine (const Real& new_val, Real& curr_val) const;
 
@@ -197,6 +197,11 @@ protected:
   // outputs old output isn't accidentally overwritten.  This option is primarily
   // used for unit testing.
   bool m_filename_with_time_string = true;
+  // Where this output file will attach the number of mpi_ranks used in the simulation
+  // to the output file name.  The default is false.  This feature is useful when running
+  // multirank tests where we are interested in saving output with different ranks to the
+  // same generic filename.
+  bool m_filename_with_mpiranks = false;
 };
 
 // ===================== IMPLEMENTATION ======================== //

--- a/components/scream/tests/coupled/homme_physics/CMakeLists.txt
+++ b/components/scream/tests/coupled/homme_physics/CMakeLists.txt
@@ -5,17 +5,27 @@ include (ScreamUtils)
 CreateDynamicsLib("theta-l_kokkos"  4   72   35)
 
 # Create the test
+SET (TEST_LABELS "dynamics;driver;shoc;cld;p3;rrtmgp;physics")
 set (NEED_LIBS cld_fraction shoc p3 scream_rrtmgp ${dynLibName} scream_control scream_share physics_share)
 CreateUnitTest(homme_shoc_cld_p3_rrtmgp "homme_shoc_cld_p3_rrtmgp.cpp" "${NEED_LIBS}"
-               LABELS "dynamics;driver;shoc;cld;p3;rrtmgp;physics")
+               LABELS ${TEST_LABELS} 
+               MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+               PROPERTIES FIXTURES_SETUP homme_shoc_cld_p3_rrtmgp_main
+)
 
 # Set AD configurable options
 set (ATM_TIME_STEP 1800)
 SetVarDependingOnTestProfile(NUM_STEPS 2 8 48)  # 1h 4h 24h
 
-# Configure yaml input file to run directory
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-               ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
+## Copy (and configure) yaml files needed by tests
+foreach (MPI_RANKS RANGE 1 ${SCREAM_TEST_MAX_RANKS})
+    
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/input_np${MPI_RANKS}.yaml)
+  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/homme_shoc_cld_p3_rrtmgp_output.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/homme_shoc_cld_p3_rrtmgp_output_np${MPI_RANKS}.yaml)
+    
+endforeach()
 
 # Set homme's test options, so that we can configure the namelist correctly
 # Discretization/algorithm settings
@@ -76,3 +86,25 @@ CONFIGURE_FILE(${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/extensions/
                ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
 CONFIGURE_FILE(${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-lw.nc
                ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
+
+## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
+## Only if max mpi ranks is >1
+# This test requires CPRNC
+if (SCREAM_TEST_MAX_RANKS GREATER 1)
+  include (BuildCprnc)
+  BuildCprnc()
+  SET (BASE_TEST_NAME "homme_shoc_cld_p3_rrtmgp")
+  foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+    set (SRC_FILE "${BASE_TEST_NAME}_output_np${MPI_RANKS}.INSTANT.Steps_x${NUM_STEPS}.nc")
+    set (TGT_FILE "${BASE_TEST_NAME}_output_np1.INSTANT.Steps_x${NUM_STEPS}.nc")
+    configure_file (${SCREAM_BASE_DIR}/cmake/CprncTest.cmake
+                    ${CMAKE_CURRENT_BINARY_DIR}/CprncTest_np${MPI_RANKS}.cmake @ONLY)
+    set(TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+    add_test (NAME ${TEST_NAME} 
+              COMMAND cmake -P CprncTest_np${MPI_RANKS}.cmake
+              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}"
+              RESOURCE_LOCK ${BASE_TEST_NAME}
+              FIXTURES_REQUIRED homme_shoc_cld_p3_rrtmgp_main)
+  endforeach()
+endif()

--- a/components/scream/tests/coupled/homme_physics/CMakeLists.txt
+++ b/components/scream/tests/coupled/homme_physics/CMakeLists.txt
@@ -15,7 +15,7 @@ CreateUnitTest(homme_shoc_cld_p3_rrtmgp "homme_shoc_cld_p3_rrtmgp.cpp" "${NEED_L
 
 # Set AD configurable options
 set (ATM_TIME_STEP 1800)
-SetVarDependingOnTestProfile(NUM_STEPS 2 8 48)  # 1h 4h 24h
+SetVarDependingOnTestProfile(NUM_STEPS 2 4 48)  # 1h 2h 24h
 
 ## Copy (and configure) yaml files needed by tests
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml

--- a/components/scream/tests/coupled/homme_physics/CMakeLists.txt
+++ b/components/scream/tests/coupled/homme_physics/CMakeLists.txt
@@ -10,7 +10,7 @@ set (NEED_LIBS cld_fraction shoc p3 scream_rrtmgp ${dynLibName} scream_control s
 CreateUnitTest(homme_shoc_cld_p3_rrtmgp "homme_shoc_cld_p3_rrtmgp.cpp" "${NEED_LIBS}"
                LABELS ${TEST_LABELS} 
                MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-               PROPERTIES FIXTURES_SETUP homme_shoc_cld_p3_rrtmgp_main
+               PROPERTIES FIXTURES_SETUP homme_shoc_cld_p3_rrtmgp_generate_output_nc_files
 )
 
 # Set AD configurable options
@@ -18,14 +18,10 @@ set (ATM_TIME_STEP 1800)
 SetVarDependingOnTestProfile(NUM_STEPS 2 8 48)  # 1h 4h 24h
 
 ## Copy (and configure) yaml files needed by tests
-foreach (MPI_RANKS RANGE 1 ${SCREAM_TEST_MAX_RANKS})
-    
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/input_np${MPI_RANKS}.yaml)
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/homme_shoc_cld_p3_rrtmgp_output.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/homme_shoc_cld_p3_rrtmgp_output_np${MPI_RANKS}.yaml)
-    
-endforeach()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/homme_shoc_cld_p3_rrtmgp_output.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/homme_shoc_cld_p3_rrtmgp_output.yaml)
 
 # Set homme's test options, so that we can configure the namelist correctly
 # Discretization/algorithm settings
@@ -95,8 +91,8 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
   BuildCprnc()
   SET (BASE_TEST_NAME "homme_shoc_cld_p3_rrtmgp")
   foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
-    set (SRC_FILE "${BASE_TEST_NAME}_output_np${MPI_RANKS}.INSTANT.Steps_x${NUM_STEPS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_output_np1.INSTANT.Steps_x${NUM_STEPS}.nc")
+    set (SRC_FILE "${BASE_TEST_NAME}_output.INSTANT.Steps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
+    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.Steps_x${NUM_STEPS}.np1.nc")
     configure_file (${SCREAM_BASE_DIR}/cmake/CprncTest.cmake
                     ${CMAKE_CURRENT_BINARY_DIR}/CprncTest_np${MPI_RANKS}.cmake @ONLY)
     set(TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
@@ -105,6 +101,6 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}"
               RESOURCE_LOCK ${BASE_TEST_NAME}
-              FIXTURES_REQUIRED homme_shoc_cld_p3_rrtmgp_main)
+              FIXTURES_REQUIRED homme_shoc_cld_p3_rrtmgp_generate_output_nc_files)
   endforeach()
 endif()

--- a/components/scream/tests/coupled/homme_physics/homme_shoc_cld_p3_rrtmgp.cpp
+++ b/components/scream/tests/coupled/homme_physics/homme_shoc_cld_p3_rrtmgp.cpp
@@ -36,7 +36,7 @@ TEST_CASE("scream_homme_physics", "scream_homme_physics") {
   ekat::enable_fpes(get_default_fpes());
 
   // Load ad parameter list
-  std::string fname = "input_np" + std::to_string(atm_comm.size()) + ".yaml";
+  std::string fname = "input.yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
   REQUIRE_NOTHROW ( parse_yaml_file(fname,ad_params) );
 

--- a/components/scream/tests/coupled/homme_physics/homme_shoc_cld_p3_rrtmgp.cpp
+++ b/components/scream/tests/coupled/homme_physics/homme_shoc_cld_p3_rrtmgp.cpp
@@ -30,10 +30,13 @@ TEST_CASE("scream_homme_physics", "scream_homme_physics") {
   using namespace scream;
   using namespace scream::control;
 
+  // Create a comm
+  ekat::Comm atm_comm (MPI_COMM_WORLD);
+
   ekat::enable_fpes(get_default_fpes());
 
   // Load ad parameter list
-  std::string fname = "input.yaml";
+  std::string fname = "input_np" + std::to_string(atm_comm.size()) + ".yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
   REQUIRE_NOTHROW ( parse_yaml_file(fname,ad_params) );
 
@@ -54,9 +57,6 @@ TEST_CASE("scream_homme_physics", "scream_homme_physics") {
 
   // Create the driver
   AtmosphereDriver ad;
-
-  // Create a comm
-  ekat::Comm atm_comm (MPI_COMM_WORLD);
 
   // Init, run, and finalize
   // NOTE: Kokkos is finalize in ekat_catch_main.cpp, and YAKL is finalized

--- a/components/scream/tests/coupled/homme_physics/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/homme_physics/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -1,7 +1,8 @@
 %YAML 1.1
 ---
-Casename: homme_shoc_cld_p3_rrtmgp_output_np${MPI_RANKS}
+Casename: homme_shoc_cld_p3_rrtmgp_output
 Timestamp in Filename: false
+MPI Ranks in Filename: true
 Averaging Type: Instant
 Grid: Physics GLL
 Max Snapshots Per File: 1

--- a/components/scream/tests/coupled/homme_physics/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/homme_physics/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -1,0 +1,65 @@
+%YAML 1.1
+---
+Casename: homme_shoc_cld_p3_rrtmgp_output_np${MPI_RANKS}
+Timestamp in Filename: false
+Averaging Type: Instant
+Grid: Physics GLL
+Max Snapshots Per File: 1
+Fields:
+  - T_mid
+  - T_prev_micro_step
+  - qv
+  - qc
+  - qr
+  - qi
+  - qm
+  - nc
+  - nr
+  - ni
+  - bm
+  - qv_prev_micro_step
+  - eff_radius_qc
+  - eff_radius_qi
+  - micro_liq_ice_exchange
+  - micro_vap_liq_exchange
+  - micro_vap_ice_exchange
+  - tke
+  - cldfrac_liq
+  - cldfrac_tot
+  - eddy_diff_mom
+  - horiz_winds
+  - sgs_buoy_flux
+  - inv_qc_relvar
+  - pbl_height
+  - LW_flux_up
+  - LW_flux_dn
+  - SW_flux_up
+  - SW_flux_dn
+  - SW_flux_dn_dir
+  - horiz_winds_prev
+  - phi_int
+  - ps
+  - omega
+  - p_int
+  - p_mid
+  - phis
+  - pseudo_density
+  - surf_latent_flux
+  - surf_mom_flux
+  - surf_sens_flux
+  - cldfrac_ice
+  - nc_activated
+  - ni_activated
+  - nc_nuceat_tend
+  - eff_radius_qc
+  - eff_radius_qi
+  - sfc_alb_dir_nir
+  - sfc_alb_dir_vis
+  - sfc_alb_dif_nir
+  - sfc_alb_dif_vis
+  - surf_lw_flux_up
+ 
+Output:
+  Frequency: ${NUM_STEPS}
+  Frequency Units: Steps
+...

--- a/components/scream/tests/coupled/homme_physics/input.yaml
+++ b/components/scream/tests/coupled/homme_physics/input.yaml
@@ -50,5 +50,5 @@ Grids Manager:
 # The parameters for I/O control
 SCORPIO:
   Output YAML Files:
-    Physics GLL: ["homme_shoc_cld_p3_rrtmgp_output_np${MPI_RANKS}.yaml"]
+    Physics GLL: ["homme_shoc_cld_p3_rrtmgp_output.yaml"]
 ...

--- a/components/scream/tests/coupled/homme_physics/input.yaml
+++ b/components/scream/tests/coupled/homme_physics/input.yaml
@@ -46,4 +46,9 @@ Grids Manager:
   Reference Grid: Physics GLL
   Dynamics Driven:
     Dynamics Namelist File Name: namelist.nl
+
+# The parameters for I/O control
+SCORPIO:
+  Output YAML Files:
+    Physics GLL: ["homme_shoc_cld_p3_rrtmgp_output_np${MPI_RANKS}.yaml"]
 ...

--- a/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/CMakeLists.txt
@@ -5,7 +5,7 @@ SET (TEST_LABELS "shoc;cld;p3;rrtmgp;physics")
 SET (NEED_LIBS shoc cld_fraction p3 scream_rrtmgp scream_control scream_share physics_share)
 CreateUnitTest(shoc_cld_p3_rrtmgp shoc_cld_p3_rrtmgp.cpp "${NEED_LIBS}" LABELS ${TEST_LABELS}
   MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-  PROPERTIES FIXTURES_SETUP shoc_cld_p3_rrmtgp_main
+  PROPERTIES FIXTURES_SETUP shoc_cld_p3_rrmtgp_generate_output_nc_files
 )
 
 # Set AD configurable options
@@ -35,14 +35,10 @@ configure_file(${RRTMGP_EXT_DIR}/extensions/cloud_optics/rrtmgp-cloud-optics-coe
 configure_file(${RRTMGP_EXT_DIR}/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-lw.nc
                ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
 ## Copy (and configure) yaml files needed by tests
-foreach (MPI_RANKS RANGE 1 ${SCREAM_TEST_MAX_RANKS})
-  
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/input_np${MPI_RANKS}.yaml)
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/shoc_cld_p3_rrtmgp_output.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/shoc_cld_p3_rrtmgp_output_np${MPI_RANKS}.yaml)
-  
-endforeach()
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/shoc_cld_p3_rrtmgp_output.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/shoc_cld_p3_rrtmgp_output.yaml)
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if max mpi ranks is >1
 # This test requires CPRNC
@@ -51,8 +47,8 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
   BuildCprnc()
   SET (BASE_TEST_NAME "shoc_cld_p3_rrtmgp")
   foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
-    set (SRC_FILE "${BASE_TEST_NAME}_output_np${MPI_RANKS}.INSTANT.Steps_x${NUM_STEPS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_output_np1.INSTANT.Steps_x${NUM_STEPS}.nc")
+    set (SRC_FILE "${BASE_TEST_NAME}_output.INSTANT.Steps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
+    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.Steps_x${NUM_STEPS}.np1.nc")
     configure_file (${SCREAM_BASE_DIR}/cmake/CprncTest.cmake
                     ${CMAKE_CURRENT_BINARY_DIR}/CprncTest_np${MPI_RANKS}.cmake @ONLY)
     set(TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
@@ -61,6 +57,6 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}"
               RESOURCE_LOCK ${BASE_TEST_NAME}
-              FIXTURES_REQUIRED shoc_cld_p3_rrmtgp_main)
+              FIXTURES_REQUIRED shoc_cld_p3_rrmtgp_generate_output_nc_files)
   endforeach()
 endif()

--- a/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/input.yaml
@@ -45,5 +45,5 @@ Initial Conditions:
 # The parameters for I/O control
 SCORPIO:
   Output YAML Files:
-    Point Grid: ["shoc_cld_p3_rrtmgp_output_np${MPI_RANKS}.yaml"]
+    Point Grid: ["shoc_cld_p3_rrtmgp_output.yaml"]
 ...

--- a/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp.cpp
+++ b/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp.cpp
@@ -21,7 +21,7 @@ TEST_CASE("shoc-stand-alone", "") {
   ekat::Comm atm_comm (MPI_COMM_WORLD);
 
   // Load ad parameter list
-  std::string fname = "input_np" + std::to_string(atm_comm.size()) + ".yaml";
+  std::string fname = "input.yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
   REQUIRE_NOTHROW ( parse_yaml_file(fname,ad_params) );
 

--- a/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
@@ -1,7 +1,8 @@
 %YAML 1.1
 ---
-Casename: shoc_cld_p3_rrtmgp_output_np${MPI_RANKS}
+Casename: shoc_cld_p3_rrtmgp_output
 Timestamp in Filename: false
+MPI Ranks in Filename: true
 Averaging Type: Instant
 Grid: Physics
 Max Snapshots Per File: 1

--- a/components/scream/tests/uncoupled/cld_fraction/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/cld_fraction/CMakeLists.txt
@@ -6,7 +6,7 @@ set (NEED_LIBS cld_fraction scream_control scream_share)
 CreateUnitTest(cld_fraction_standalone "cld_fraction_standalone.cpp" "${NEED_LIBS}" LABELS "cld_fraction;physics")
 
 # Set AD configurable options
-SetVarDependingOnTestProfile(NUM_STEPS 2 24 48)
+set (NUM_STEPS 1)
 set (ATM_TIME_STEP 1800)
 
 # Configure yaml input file to run directory

--- a/components/scream/tests/uncoupled/homme/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/homme/CMakeLists.txt
@@ -16,7 +16,7 @@ CreateUnitTest(homme_standalone "homme_standalone.cpp" "${NEED_LIBS}"
 
 # Set AD configurable options
 set (ATM_TIME_STEP 1800)
-SetVarDependingOnTestProfile(NUM_STEPS 2 8 48)  # 1h 4h 24h
+SetVarDependingOnTestProfile(NUM_STEPS 2 4 48)  # 1h 2h 24h
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)

--- a/components/scream/tests/uncoupled/homme/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/homme/CMakeLists.txt
@@ -5,18 +5,29 @@ include (ScreamUtils)
 CreateDynamicsLib("theta-l_kokkos"  4   72   35)
 
 # Create the test
+SET (TEST_LABELS "dynamics;driver")
 set (NEED_LIBS ${dynLibName} scream_control scream_share)
 
 CreateUnitTest(homme_standalone "homme_standalone.cpp" "${NEED_LIBS}"
-               LABELS "dynamics;driver")
+               LABELS ${TEST_LABELS} 
+               MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+               PROPERTIES FIXTURES_SETUP homme_only
+)
 
 # Set AD configurable options
 set (ATM_TIME_STEP 1800)
-SetVarDependingOnTestProfile(NUM_STEPS 2 8 48)  # 1h 4h 24h
+#SetVarDependingOnTestProfile(NUM_STEPS 2 8 48)  # 1h 4h 24h
+set (NUM_STEPS 1)
 
-# Configure yaml input file to run directory
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-               ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
+## Copy (and configure) yaml files needed by tests
+foreach (MPI_RANKS RANGE 1 ${SCREAM_TEST_MAX_RANKS})
+    
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/input_np${MPI_RANKS}.yaml)
+  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/homme_standalone_output.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/homme_standalone_output_np${MPI_RANKS}.yaml)
+    
+endforeach()
 
 # Set homme's test options, so that we can configure the namelist correctly
 
@@ -63,3 +74,25 @@ configure_file(${HOMME_SOURCE_DIR}/test/vcoord/acme-72i.ascii
                ${CMAKE_CURRENT_BINARY_DIR}/vcoord COPYONLY)
 configure_file(${HOMME_SOURCE_DIR}/test/vcoord/acme-72m.ascii
                ${CMAKE_CURRENT_BINARY_DIR}/vcoord COPYONLY)
+
+## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
+## Only if max mpi ranks is >1
+# This test requires CPRNC
+if (SCREAM_TEST_MAX_RANKS GREATER 1)
+  include (BuildCprnc)
+  BuildCprnc()
+  SET (BASE_TEST_NAME "homme")
+  foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+    set (SRC_FILE "${BASE_TEST_NAME}_output_np${MPI_RANKS}.INSTANT.Steps_x${NUM_STEPS}.nc")
+    set (TGT_FILE "${BASE_TEST_NAME}_output_np1.INSTANT.Steps_x${NUM_STEPS}.nc")
+    configure_file (${SCREAM_BASE_DIR}/cmake/CprncTest.cmake
+                    ${CMAKE_CURRENT_BINARY_DIR}/CprncTest_np${MPI_RANKS}.cmake @ONLY)
+    set(TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+    add_test (NAME ${TEST_NAME} 
+              COMMAND cmake -P CprncTest_np${MPI_RANKS}.cmake
+              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}"
+              RESOURCE_LOCK ${BASE_TEST_NAME}
+              FIXTURES_REQUIRED homme_only)
+  endforeach()
+endif()

--- a/components/scream/tests/uncoupled/homme/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/homme/CMakeLists.txt
@@ -11,23 +11,17 @@ set (NEED_LIBS ${dynLibName} scream_control scream_share)
 CreateUnitTest(homme_standalone "homme_standalone.cpp" "${NEED_LIBS}"
                LABELS ${TEST_LABELS} 
                MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-               PROPERTIES FIXTURES_SETUP homme_only
+               PROPERTIES FIXTURES_SETUP homme_generate_output_nc_files
 )
 
 # Set AD configurable options
 set (ATM_TIME_STEP 1800)
-#SetVarDependingOnTestProfile(NUM_STEPS 2 8 48)  # 1h 4h 24h
-set (NUM_STEPS 1)
+SetVarDependingOnTestProfile(NUM_STEPS 2 8 48)  # 1h 4h 24h
 
-## Copy (and configure) yaml files needed by tests
-foreach (MPI_RANKS RANGE 1 ${SCREAM_TEST_MAX_RANKS})
-    
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/input_np${MPI_RANKS}.yaml)
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/homme_standalone_output.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/homme_standalone_output_np${MPI_RANKS}.yaml)
-    
-endforeach()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/homme_standalone_output.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/homme_standalone_output.yaml)
 
 # Set homme's test options, so that we can configure the namelist correctly
 
@@ -83,8 +77,8 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
   BuildCprnc()
   SET (BASE_TEST_NAME "homme")
   foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
-    set (SRC_FILE "${BASE_TEST_NAME}_output_np${MPI_RANKS}.INSTANT.Steps_x${NUM_STEPS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_output_np1.INSTANT.Steps_x${NUM_STEPS}.nc")
+    set (SRC_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
+    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np1.nc")
     configure_file (${SCREAM_BASE_DIR}/cmake/CprncTest.cmake
                     ${CMAKE_CURRENT_BINARY_DIR}/CprncTest_np${MPI_RANKS}.cmake @ONLY)
     set(TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
@@ -93,6 +87,6 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}"
               RESOURCE_LOCK ${BASE_TEST_NAME}
-              FIXTURES_REQUIRED homme_only)
+              FIXTURES_REQUIRED homme_generate_output_nc_files)
   endforeach()
 endif()

--- a/components/scream/tests/uncoupled/homme/homme_standalone.cpp
+++ b/components/scream/tests/uncoupled/homme/homme_standalone.cpp
@@ -37,7 +37,7 @@ TEST_CASE("scream_homme_standalone", "scream_homme_standalone") {
   ekat::Comm atm_comm (MPI_COMM_WORLD);
 
   // Load ad parameter list
-  std::string fname = "input_np" + std::to_string(atm_comm.size()) + ".yaml";
+  std::string fname = "input.yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
   REQUIRE_NOTHROW ( parse_yaml_file(fname,ad_params) );
 

--- a/components/scream/tests/uncoupled/homme/homme_standalone.cpp
+++ b/components/scream/tests/uncoupled/homme/homme_standalone.cpp
@@ -33,8 +33,11 @@ TEST_CASE("scream_homme_standalone", "scream_homme_standalone") {
 
   ekat::enable_fpes(get_default_fpes());
 
+  // Create a comm
+  ekat::Comm atm_comm (MPI_COMM_WORLD);
+
   // Load ad parameter list
-  std::string fname = "input.yaml";
+  std::string fname = "input_np" + std::to_string(atm_comm.size()) + ".yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
   REQUIRE_NOTHROW ( parse_yaml_file(fname,ad_params) );
 
@@ -59,9 +62,6 @@ TEST_CASE("scream_homme_standalone", "scream_homme_standalone") {
   // Need to register grids managers before we create the driver
   auto& gm_factory = GridsManagerFactory::instance();
   gm_factory.register_product("Dynamics Driven",create_dynamics_driven_grids_manager);
-
-  // Create a comm
-  ekat::Comm atm_comm (MPI_COMM_WORLD);
 
   // Create the driver
   AtmosphereDriver ad;

--- a/components/scream/tests/uncoupled/homme/homme_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/homme/homme_standalone_output.yaml
@@ -1,0 +1,22 @@
+%YAML 1.1
+---
+Casename: homme_output_np${MPI_RANKS}
+Timestamp in Filename: false
+Averaging Type: Instant
+Grid: Physics GLL
+Max Snapshots Per File: 1
+Fields:
+  - T_mid
+  - qv
+  - ps
+  - p_int
+  - p_mid
+  - pseudo_density
+  - horiz_winds
+  - w_int
+  - phi_int
+ 
+Output:
+  Frequency: ${NUM_STEPS}
+  Frequency Units: Steps
+...

--- a/components/scream/tests/uncoupled/homme/homme_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/homme/homme_standalone_output.yaml
@@ -1,7 +1,8 @@
 %YAML 1.1
 ---
-Casename: homme_output_np${MPI_RANKS}
+Casename: homme_standalone_output
 Timestamp in Filename: false
+MPI Ranks in Filename: true
 Averaging Type: Instant
 Grid: Physics GLL
 Max Snapshots Per File: 1

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -34,5 +34,5 @@ Grids Manager:
 # The parameters for I/O control
 SCORPIO:
   Output YAML Files:
-    Physics GLL: ["homme_standalone_output_np${MPI_RANKS}.yaml"]
+    Physics GLL: ["homme_standalone_output.yaml"]
 ...

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -30,4 +30,9 @@ Grids Manager:
   Reference Grid: Physics GLL
   Dynamics Driven:
     Dynamics Namelist File Name: namelist.nl
+
+# The parameters for I/O control
+SCORPIO:
+  Output YAML Files:
+    Physics GLL: ["homme_standalone_output_np${MPI_RANKS}.yaml"]
 ...

--- a/components/scream/tests/uncoupled/p3/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/p3/CMakeLists.txt
@@ -5,7 +5,7 @@ SET (TEST_LABELS "p3;physics")
 set (NEED_LIBS p3 scream_control scream_share)
 CreateUnitTest(p3_standalone "p3_standalone.cpp" "${NEED_LIBS}" LABELS ${TEST_LABELS}
   MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-  PROPERTIES FIXTURES_SETUP p3_main
+  PROPERTIES FIXTURES_SETUP p3_generate_output_nc_files
 )
 
 # Set AD configurable options
@@ -13,13 +13,9 @@ set (ATM_TIME_STEP 1800)
 SetVarDependingOnTestProfile(NUM_STEPS 2 5 48)  # 1h 2.5h 24h
 
 ## Copy (and configure) yaml files needed by tests
-foreach (MPI_RANKS RANGE 1 ${SCREAM_TEST_MAX_RANKS})
-  
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/input_np${MPI_RANKS}.yaml)
-  CONFIGURE_FILE(p3_standalone_output.yaml p3_standalone_output_np${MPI_RANKS}.yaml)
-  
-endforeach()
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
+CONFIGURE_FILE(p3_standalone_output.yaml p3_standalone_output.yaml)
 
 # Copy p3 lookup tables to local data directory
 file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
@@ -39,8 +35,8 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
   BuildCprnc()
   SET (BASE_TEST_NAME "p3")
   foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
-    set (SRC_FILE "${BASE_TEST_NAME}_standalone_output_np${MPI_RANKS}.INSTANT.Steps_x${NUM_STEPS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output_np1.INSTANT.Steps_x${NUM_STEPS}.nc")
+    set (SRC_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
+    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np1.nc")
     configure_file (${SCREAM_BASE_DIR}/cmake/CprncTest.cmake
                     ${CMAKE_CURRENT_BINARY_DIR}/CprncTest_np${MPI_RANKS}.cmake @ONLY)
     set(TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
@@ -49,6 +45,6 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}"
               RESOURCE_LOCK ${BASE_TEST_NAME}
-              FIXTURES_REQUIRED p3_main)
+              FIXTURES_REQUIRED p3_generate_output_nc_files)
   endforeach()
 endif()

--- a/components/scream/tests/uncoupled/p3/input.yaml
+++ b/components/scream/tests/uncoupled/p3/input.yaml
@@ -31,5 +31,5 @@ Initial Conditions:
 # The parameters for I/O control
 SCORPIO:
   Output YAML Files:
-    Point Grid: ["p3_standalone_output_np${MPI_RANKS}.yaml"]
+    Point Grid: ["p3_standalone_output.yaml"]
 ...

--- a/components/scream/tests/uncoupled/p3/p3_standalone.cpp
+++ b/components/scream/tests/uncoupled/p3/p3_standalone.cpp
@@ -21,7 +21,7 @@ TEST_CASE("p3-stand-alone", "") {
   ekat::Comm atm_comm (MPI_COMM_WORLD);
 
   // Load ad parameter list
-  std::string fname = "input_np" + std::to_string(atm_comm.size()) + ".yaml";
+  std::string fname = "input.yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
   REQUIRE_NOTHROW ( parse_yaml_file(fname,ad_params) );
 

--- a/components/scream/tests/uncoupled/p3/p3_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/p3/p3_standalone_output.yaml
@@ -1,7 +1,8 @@
 %YAML 1.1
 ---
-Casename: p3_standalone_output_np${MPI_RANKS}
+Casename: p3_standalone_output
 Timestamp in Filename: false
+MPI Ranks in Filename: true
 Averaging Type: Instant
 Grid: Point Grid
 Max Snapshots Per File: 1

--- a/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -27,7 +27,7 @@ if (NOT ${SCREAM_BASELINES_ONLY})
     CreateUnitTest(
         rrtmgp_standalone "rrtmgp_standalone.cpp" "${NEED_LIBS}" LABELS ${TEST_LABELS}
         MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-        PROPERTIES FIXTURES_SETUP rrtmgp_main
+        PROPERTIES FIXTURES_SETUP rrtmgp_generate_output_nc_files
     )
 
     # Copy yaml input file to run directory
@@ -55,13 +55,10 @@ if (NOT ${SCREAM_BASELINES_ONLY})
     set (ATM_TIME_STEP 1800)
 
     ## Copy (and configure) yaml files needed by tests
-    foreach (MPI_RANKS RANGE 1 ${SCREAM_TEST_MAX_RANKS})
+    CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+                   ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
+    CONFIGURE_FILE(rrtmgp_standalone_output.yaml rrtmgp_standalone_output.yaml)
       
-      CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-                     ${CMAKE_CURRENT_BINARY_DIR}/input_np${MPI_RANKS}.yaml)
-      CONFIGURE_FILE(rrtmgp_standalone_output.yaml rrtmgp_standalone_output_np${MPI_RANKS}.yaml)
-      
-    endforeach()
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/rrtmgp_init_ne2np4.nc
                    ${CMAKE_CURRENT_BINARY_DIR}/rrtmgp_init_ne2np4.nc COPYONLY)
 
@@ -73,8 +70,8 @@ if (NOT ${SCREAM_BASELINES_ONLY})
     BuildCprnc()
     SET (BASE_TEST_NAME "rrtmgp")
     foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
-      set (SRC_FILE "${BASE_TEST_NAME}_standalone_output_np${MPI_RANKS}.INSTANT.Steps_x${NUM_STEPS}.nc")
-      set (TGT_FILE "${BASE_TEST_NAME}_standalone_output_np1.INSTANT.Steps_x${NUM_STEPS}.nc")
+      set (SRC_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
+      set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np1.nc")
       configure_file (${SCREAM_BASE_DIR}/cmake/CprncTest.cmake
                       ${CMAKE_CURRENT_BINARY_DIR}/CprncTest_np${MPI_RANKS}.cmake @ONLY)
       set(TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
@@ -83,7 +80,7 @@ if (NOT ${SCREAM_BASELINES_ONLY})
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
       set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}"
                 RESOURCE_LOCK ${BASE_TEST_NAME}
-                FIXTURES_REQUIRED rrtmgp_main)
+                FIXTURES_REQUIRED rrtmgp_generate_output_nc_files)
     endforeach()
   endif()
 endif()

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -37,5 +37,5 @@ Initial Conditions:
 # The parameters for I/O control
 SCORPIO:
   Output YAML Files:
-    Point Grid: ["rrtmgp_standalone_output_np${MPI_RANKS}.yaml"]
+    Point Grid: ["rrtmgp_standalone_output.yaml"]
 ...

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone.cpp
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone.cpp
@@ -21,7 +21,7 @@ TEST_CASE("rrtmgp-stand-alone", "") {
   ekat::Comm atm_comm (MPI_COMM_WORLD);
 
   // Load ad parameter list
-  std::string fname = "input_np" + std::to_string(atm_comm.size()) + ".yaml";
+  std::string fname = "input.yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
   REQUIRE_NOTHROW ( parse_yaml_file(fname,ad_params) );
 

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
@@ -1,7 +1,8 @@
 %YAML 1.1
 ---
-Casename: rrtmgp_standalone_output_np${MPI_RANKS}
+Casename: rrtmgp_standalone_output
 Timestamp in Filename: false
+MPI Ranks in Filename: true
 Averaging Type: Instant
 Grid: Physics
 Max Snapshots Per File: 1

--- a/components/scream/tests/uncoupled/shoc/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/shoc/CMakeLists.txt
@@ -5,7 +5,7 @@ SET (TEST_LABELS "shoc;physics")
 set (NEED_LIBS shoc scream_control scream_share)
 CreateUnitTest(shoc_standalone "shoc_standalone.cpp" "${NEED_LIBS}" LABELS ${TEST_LABELS}
   MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-  PROPERTIES FIXTURES_SETUP shoc_main
+  PROPERTIES FIXTURES_SETUP shoc_generate_output_nc_files
 )
 
 # Set AD configurable options
@@ -15,15 +15,9 @@ set (ATM_TIME_STEP 1800)
 # Copy input files to run directory
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/shoc_init_ne2np4.nc
                ${CMAKE_CURRENT_BINARY_DIR}/shoc_init_ne2np4.nc COPYONLY)
-
-## Copy (and configure) yaml files needed by tests
-foreach (MPI_RANKS RANGE 1 ${SCREAM_TEST_MAX_RANKS})
-  
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/input_np${MPI_RANKS}.yaml)
-  CONFIGURE_FILE(shoc_standalone_output.yaml shoc_standalone_output_np${MPI_RANKS}.yaml)
-  
-endforeach()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
+CONFIGURE_FILE(shoc_standalone_output.yaml shoc_standalone_output.yaml)
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if max mpi ranks is >1
@@ -33,8 +27,8 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
   BuildCprnc()
   SET (BASE_TEST_NAME "shoc")
   foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
-    set (SRC_FILE "${BASE_TEST_NAME}_standalone_output_np${MPI_RANKS}.INSTANT.Steps_x${NUM_STEPS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output_np1.INSTANT.Steps_x${NUM_STEPS}.nc")
+    set (SRC_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
+    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np1.nc")
     configure_file (${SCREAM_BASE_DIR}/cmake/CprncTest.cmake
                     ${CMAKE_CURRENT_BINARY_DIR}/CprncTest_np${MPI_RANKS}.cmake @ONLY)
     set(TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
@@ -43,6 +37,6 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}"
               RESOURCE_LOCK ${BASE_TEST_NAME}
-              FIXTURES_REQUIRED shoc_main)
+              FIXTURES_REQUIRED shoc_generate_output_nc_files)
   endforeach()
 endif()

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -34,5 +34,5 @@ Initial Conditions:
 # The parameters for I/O control
 SCORPIO:
   Output YAML Files:
-    Point Grid: ["shoc_standalone_output_np${MPI_RANKS}.yaml"]
+    Point Grid: ["shoc_standalone_output.yaml"]
 ...

--- a/components/scream/tests/uncoupled/shoc/shoc_standalone.cpp
+++ b/components/scream/tests/uncoupled/shoc/shoc_standalone.cpp
@@ -21,7 +21,7 @@ TEST_CASE("shoc-stand-alone", "") {
   ekat::Comm atm_comm (MPI_COMM_WORLD);
 
   // Load ad parameter list
-  std::string fname = "input_np" + std::to_string(atm_comm.size()) + ".yaml";
+  std::string fname = "input.yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
   REQUIRE_NOTHROW ( parse_yaml_file(fname,ad_params) );
 

--- a/components/scream/tests/uncoupled/shoc/shoc_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/shoc/shoc_standalone_output.yaml
@@ -1,7 +1,8 @@
 %YAML 1.1
 ---
-Casename: shoc_standalone_output_np${MPI_RANKS}
+Casename: shoc_standalone_output
 Timestamp in Filename: false
+MPI Ranks in Filename: true
 Averaging Type: Instant
 Grid: Point Grid
 Max Snapshots Per File: 1

--- a/components/scream/tests/uncoupled/spa/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/spa/CMakeLists.txt
@@ -5,7 +5,7 @@ SET (TEST_LABELS "spa;physics")
 set (NEED_LIBS spa scream_control scream_share)
 CreateUnitTest(spa_stand_alone "spa_stand_alone.cpp" "${NEED_LIBS}" LABELS ${TEST_LABELS}
   MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-  PROPERTIES FIXTURES_SETUP spa_main
+  PROPERTIES FIXTURES_SETUP spa_generate_output_nc_files
 )
 
 # Set AD configurable options
@@ -13,14 +13,10 @@ SetVarDependingOnTestProfile(NUM_STEPS 2 4 48)
 set (ATM_TIME_STEP 864000)
 
 ## Copy (and configure) yaml files needed by tests
-foreach (MPI_RANKS RANGE 1 ${SCREAM_TEST_MAX_RANKS})
-
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/input_np${MPI_RANKS}.yaml)
-  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/spa_standalone_output.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/spa_standalone_output_np${MPI_RANKS}.yaml)
-
-endforeach()
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/spa_standalone_output.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/spa_standalone_output.yaml)
 
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/spa_init_ne2np4.nc
                ${CMAKE_CURRENT_BINARY_DIR}/spa_init_ne2np4.nc COPYONLY)
@@ -33,8 +29,8 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
   BuildCprnc()
   SET (BASE_TEST_NAME "spa")
   foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
-    set (SRC_FILE "${BASE_TEST_NAME}_standalone_output_np${MPI_RANKS}.INSTANT.Steps_x${NUM_STEPS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output_np1.INSTANT.Steps_x${NUM_STEPS}.nc")
+    set (SRC_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
+    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np1.nc")
     configure_file (${SCREAM_BASE_DIR}/cmake/CprncTest.cmake
                     ${CMAKE_CURRENT_BINARY_DIR}/CprncTest_np${MPI_RANKS}.cmake @ONLY)
     set(TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
@@ -43,6 +39,6 @@ if (SCREAM_TEST_MAX_RANKS GREATER 1)
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}"
               RESOURCE_LOCK ${BASE_TEST_NAME}
-              FIXTURES_REQUIRED spa_main)
+              FIXTURES_REQUIRED spa_generate_output_nc_files)
   endforeach()
 endif()

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -31,5 +31,5 @@ Initial Conditions:
 # The parameters for I/O control
 SCORPIO:
   Output YAML Files:
-    Point Grid: ["spa_standalone_output_np${MPI_RANKS}.yaml"]
+    Point Grid: ["spa_standalone_output.yaml"]
 ...

--- a/components/scream/tests/uncoupled/spa/spa_stand_alone.cpp
+++ b/components/scream/tests/uncoupled/spa/spa_stand_alone.cpp
@@ -22,7 +22,7 @@ TEST_CASE("spa-stand-alone", "") {
   ekat::Comm atm_comm (MPI_COMM_WORLD);
 
   // Load ad parameter list
-  std::string fname = "input_np" + std::to_string(atm_comm.size()) + ".yaml";
+  std::string fname = "input.yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
   REQUIRE_NOTHROW ( parse_yaml_file(fname,ad_params) );
 

--- a/components/scream/tests/uncoupled/spa/spa_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/spa/spa_standalone_output.yaml
@@ -1,7 +1,8 @@
 %YAML 1.1
 ---
-Casename: spa_standalone_output_np${MPI_RANKS}
+Casename: spa_standalone_output
 Timestamp in Filename: false
+MPI Ranks in Filename: true
 Averaging Type: Instant
 Grid: Physics
 Max Snapshots Per File: 1


### PR DESCRIPTION
    This work expands the previous work on contrusting multiple mpi rank
    versions of the tests that go through the AD to include the homme+physics
    test.