### PR TITLE
SCREAM: fix machine specs check for "local" machine

### DIFF
--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -71,7 +71,7 @@ MACHINE_METADATA = {
 if pathlib.Path("~/.cime/scream_mach_specs.py").expanduser().is_file(): # pylint: disable=no-member
     sys.path.append(str(pathlib.Path("~/.cime").expanduser()))
     from scream_mach_specs import MACHINE_METADATA as LOCAL_MD # pylint: disable=import-error
-    if len(LOCAL_MD) == 6:
+    if len(LOCAL_MD) == 4:
         MACHINE_METADATA["local"] = LOCAL_MD
     else:
         print("WARNING! File '~/.cime/scream_mach_specs.py' was found, but the MACHINE_METADATA in there is badly formatted. Ignoring it.")


### PR DESCRIPTION
PR #1284 changed the machine specs format, but missed to fix how the script checks for a user-defined machine specs for the "local" machine (used with `-l` flag).

Note: I'm skipping testing, since none of our tests uses the `-l` feature of `test-all-scream`.