### PR TITLE
Do not set CTEST_PARALLEL_LEVEL for scripts-ctest-driver

### DIFF
--- a/components/scream/scripts/scripts_ctest_driver.py
+++ b/components/scream/scripts/scripts_ctest_driver.py
@@ -49,7 +49,9 @@ class ScriptsCtestDriver(object):
 
         self._work_dir.mkdir(parents=True)
 
-        setup_mach_env(self._machine)
+        # Load env, but do not set CTEST_PARALLEL_JOBS. This code runs on login
+        # nodes, so resource probing will not always be accurate.
+        setup_mach_env(self._machine, ctest_j=-1)
 
     ###############################################################################
     def generate_ctest_config(self, extra_configs):


### PR DESCRIPTION
It runs on login, not compute, nodes so the probed resources won't
always be accurate.