### PR TITLE
Update SCREAM CreateUnitTest macro

### DIFF
--- a/components/scream/cmake/ScreamUtils.cmake
+++ b/components/scream/cmake/ScreamUtils.cmake
@@ -3,8 +3,8 @@ include(EkatCreateUnitTest)
 include(EkatUtils)
 
 # This function takes the following arguments:
-#    - target_name: the name of the executable
-#    - target_srcs: a list of src files for the executable
+#    - test_name: the base name of the test. We create an executable with this name unless TEST_EXE is passed.
+#    - test_srcs: a list of src files for the executable. An empty list should be provided if TEST_EXE is passed.
 #      Note: no need to include catch_main; this macro will add it
 #    - scream_libs: a list of scream libraries needed by the executable
 #    - compiler_defs (optional): a list of additional defines for the compiler, default is nothing
@@ -18,11 +18,11 @@ include(EkatUtils)
 macro (SetVarDependingOnTestProfile var_name val_short val_medium val_long)
   string (TOUPPER ${SCREAM_TEST_PROFILE} profile)
   if (profile STREQUAL "SHORT")
-    set (${var_name} ${val_short})
+    set(${var_name} ${val_short})
   elseif(profile STREQUAL "MEDIUM")
-    set (${var_name} ${val_medium})
+    set(${var_name} ${val_medium})
   elseif(profile STREQUAL "LONG")
-    set (${var_name} ${val_long})
+    set(${var_name} ${val_long})
   else()
     message("Error! Unrecognized testing profile '${profile}'.")
     message("  Valid test profile options: ${SCREAM_TEST_VALID_PROFILES}")
@@ -30,9 +30,9 @@ macro (SetVarDependingOnTestProfile var_name val_short val_medium val_long)
   endif()
 endmacro()
 
-function(CreateUnitTest target_name target_srcs scream_libs)
+function(CreateUnitTest test_name test_srcs scream_libs)
   set(options EXCLUDE_MAIN_CPP SERIAL PRINT_OMP_AFFINITY)
-  set(oneValueArgs EXE_ARGS DEP)
+  set(oneValueArgs TEST_EXE EXE_ARGS DEP)
   set(multiValueArgs
     MPI_RANKS THREADS
     INCLUDE_DIRS
@@ -44,90 +44,57 @@ function(CreateUnitTest target_name target_srcs scream_libs)
   cmake_parse_arguments(PARSE_ARGV 3 CreateUnitTest "${options}" "${oneValueArgs}" "${multiValueArgs}")
   CheckMacroArgs(CreateUnitTest CreateUnitTest "${options}" "${oneValueArgs}" "${multiValueArgs}")
 
-  set (TEST_INCLUDE_DIRS
-       ${SCREAM_INCLUDE_DIRS}
-       ${CMAKE_CURRENT_SOURCE_DIR}
-       ${CMAKE_CURRENT_BINARY_DIR}
-       ${SCREAM_F90_MODULES}
-       ${CreateUnitTest_INCLUDE_DIRS}
+  set(TEST_INCLUDE_DIRS
+    ${SCREAM_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${SCREAM_F90_MODULES}
+    ${CreateUnitTest_INCLUDE_DIRS}
   )
 
-  set (test_libs "${scream_libs}")
+  set(test_libs "${scream_libs}")
   list(APPEND test_libs "${SCREAM_TPL_LIBRARIES}")
 
-  # Note: some args are likely empty, so check them before adding them,
-  #       or you would have either a) a keyword followed by nothing (error),
-  #       or b) to add a space at front or back (causing EKAT to think that
-  #       that option is present, when it's not).
-  set (cut_options EXCLUDE_TEST_SESSION)
-  if (CreateUnitTest_EXCLUDE_MAIN_CPP)
-    list(APPEND cut_options EXCLUDE_MAIN_CPP)
-  endif()
-  if (CreateUnitTest_SERIAL)
-    list(APPEND cut_options SERIAL)
-  endif()
-  if (CreateUnitTest_PRINT_OMP_AFFINITY)
-    list(APPEND cut_options PRINT_OMP_AFFINITY)
-  endif()
-  if (CreateUnitTest_DEP)
-    list(APPEND cut_options DEP ${CreateUnitTest_DEP})
-  endif()
-  if (CreateUnitTest_PROPERTIES)
-    list(APPEND cut_options PROPERTIES ${CreateUnitTest_PROPERTIES})
-  endif()
-  if (CreateUnitTest_LABELS)
-    list(APPEND cut_options LABELS ${CreateUnitTest_LABELS})
-  endif()
-  if (CreateUnitTest_MPI_RANKS)
-    list(APPEND cut_options MPI_RANKS ${CreateUnitTest_MPI_RANKS})
-  endif ()
-  if (CreateUnitTest_THREADS)
-    list(APPEND cut_options THREADS ${CreateUnitTest_THREADS})
-  endif ()
-  if (CreateUnitTest_EXE_ARGS)
-    list(APPEND cut_options EXE_ARGS ${CreateUnitTest_EXE_ARGS})
-  endif ()
+  #
+  # Convert CreateUnitTest options/args to EkatCreateUnitTest options/args
+  #
+  set(skip_list "INCLUDE_DIRS;COMPILER_F_FLAGS")
+
+  set(cut_options EXCLUDE_TEST_SESSION)
+
+  foreach(item IN LISTS options oneValueArgs multiValueArgs)
+    if (NOT item IN_LIST skip_list AND CreateUnitTest_${item})
+      if (item IN_LIST options)
+        list(APPEND cut_options ${item})
+      else()
+        list(APPEND cut_options ${item} ${CreateUnitTest_${item}})
+      endif()
+    endif()
+  endforeach()
+
   if (SCREAM_MPI_EXTRA_ARGS)
     list(APPEND cut_options MPI_EXTRA_ARGS ${SCREAM_MPI_EXTRA_ARGS})
   endif ()
-  if (CreateUnitTest_COMPILER_DEFS)
-    list(APPEND cut_options COMPILER_DEFS ${CreateUnitTest_COMPILER_DEFS})
-  endif ()
-  if (CreateUnitTest_COMPILER_C_DEFS)
-    list(APPEND cut_options COMPILER_C_DEFS ${CreateUnitTest_COMPILER_C_DEFS})
-  endif ()
-  if (CreateUnitTest_COMPILER_CXX_DEFS)
-    list(APPEND cut_options COMPILER_CXX_DEFS ${CreateUnitTest_COMPILER_CXX_DEFS})
-  endif ()
-  if (CreateUnitTest_COMPILER_F_DEFS)
-    list(APPEND cut_options COMPILER_F_DEFS ${CreateUnitTest_C_COMPILER_DEFS})
-  endif ()
-  if (CreateUnitTest_COMPILER_FLAGS)
-    list(APPEND cut_options COMPILER_FLAGS ${CreateUnitTest_C_COMPILER_DEFS})
-  endif ()
-  if (CreateUnitTest_COMPILER_C_FLAGS)
-    list(APPEND cut_options COMPILER_C_FLAGS ${CreateUnitTest_C_COMPILER_DEFS})
-  endif ()
-  if (CreateUnitTest_COMPILER_CXX_FLAGS)
-    list(APPEND cut_options COMPILER_CXX_FLAGS ${CreateUnitTest_C_COMPILER_DEFS})
-  endif ()
+
   if (CreateUnitTest_COMPILER_F_FLAGS OR SCREAM_Fortran_FLAGS)
-    list(APPEND cut_options COMPILER_F_FLAGS ${CreateUnitTest_C_COMPILER_DEFS} ${SCREAM_Fortran_FLAGS})
+    list(APPEND cut_options COMPILER_F_FLAGS ${CreateUnitTest_F_COMPILER_DEFS} ${SCREAM_Fortran_FLAGS})
   endif ()
 
+  #
   # If asking for mpi/omp ranks/threads, verify we stay below the max number of threads
+  #
   if (CreateUnitTest_MPI_RANKS OR CreateUnitTest_THREADS)
     list(LENGTH CreateUnitTest_MPI_RANKS NUM_MPI_RANK_ARGS)
     list(LENGTH CreateUnitTest_THREADS   NUM_THREAD_ARGS)
     if (NUM_MPI_RANK_ARGS EQUAL 0)
-      set (MAX_RANKS 1)
+      set(MAX_RANKS 1)
     elseif (NUM_MPI_RANK_ARGS GREATER 1)
       list(GET CreateUnitTest_MPI_RANKS 1 MAX_RANKS)
     else()
       list(GET CreateUnitTest_MPI_RANKS 0 MAX_RANKS)
     endif()
     if (NUM_THREAD_ARGS EQUAL 0)
-      set (MAX_THREADS 1)
+      set(MAX_THREADS 1)
     elseif (NUM_THREAD_ARGS GREATER 1)
       list(GET CreateUnitTest_THREADS   1 MAX_THREADS)
     else()
@@ -140,7 +107,7 @@ function(CreateUnitTest target_name target_srcs scream_libs)
         "Error! Invalid max threads/ranks combination. When invoking CreateUnitTest,\n"
         "you must ensure that the product of the max requested mpi ranks and\n"
         "the max requested omp threads is lower than SCREAM_TEST_MAX_TOTAL_THREADS.\n"
-        "   - test exec name: ${target_name}\n"
+        "   - test exec name: ${test_name}\n"
         "   - requested max MPI ranks: ${MAX_RANKS}\n"
         "   - requested max OMP threads: ${MAX_THREADS}\n"
         "   - resulting max threads needed: ${NUM_THREADS_NEEDED}\n"
@@ -150,8 +117,7 @@ function(CreateUnitTest target_name target_srcs scream_libs)
     endif()
   endif()
 
-
-  EkatCreateUnitTest(${target_name} "${target_srcs}"
+  EkatCreateUnitTest(${test_name} "${test_srcs}"
     MPI_EXEC_NAME ${SCREAM_MPIRUN_EXE}
     MPI_NP_FLAG ${SCREAM_MPI_NP_FLAG}
     INCLUDE_DIRS ${TEST_INCLUDE_DIRS}

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -455,7 +455,7 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         # The output coming from all tests at the same time will be a mixed-up mess
         # unless we tell test-launcher to buffer all output
         if self._extra_verbose:
-            result += " -DEKAT_TEST_LAUNCHER_NO_BUFFER=True "
+            result += " -DEKAT_TEST_LAUNCHER_BUFFER=True "
 
         # User-requested config options
         custom_opts_keys = []

--- a/components/scream/tests/generic/infra/CMakeLists.txt
+++ b/components/scream/tests/generic/infra/CMakeLists.txt
@@ -11,7 +11,8 @@ if (SCREAM_TEST_MAX_TOTAL_THREADS GREATER_EQUAL 16)
     THREADS 1 4 1
     MPI_RANKS 4)
 
-  CreateUnitTest(resource_spread_rank "resource_spread.cpp" "${NEED_LIBS}"
+  CreateUnitTest(resource_spread_rank "" ""
+    TEST_EXE resource_spread_thread
     PRINT_OMP_AFFINITY
     THREADS 4
     MPI_RANKS 1 4 1)


### PR DESCRIPTION
1) Adds same support for TEST_EXE that was added to the EKAT macro.
2) Use loops to avoid having to explicitly pass along every individual
option to the ekat macro.
3) Change resource_spread tests to take advantage of the new TEST_EXE
capability.
4) Update EKAT