### PR TITLE
Allow changing a subfield's slice idx at runtime

### DIFF
--- a/components/scream/src/control/surface_coupling.cpp
+++ b/components/scream/src/control/surface_coupling.cpp
@@ -353,15 +353,15 @@ get_col_info(const std::shared_ptr<const FieldHeader>& fh,
                      "Error! SurfaceCoupling expects all subfields to have parents "
                      "with LayoutType::Vector3D.\n");
 
-    const auto& idx = fh->get_alloc_properties().get_subview_idx();
+    const auto& sv_info = fh->get_alloc_properties().get_subview_info();
 
     // Recall: idx = (idim,k) = (dimension where slice happened, index along said dimension).
     // Field class only allows idim=0,1. But we should never be in the case of idim=0, here.
     // If we have idim=0, it means that the parent field did not have COL as tag[0].
-    EKAT_REQUIRE_MSG(idx.first==1, "Error! Bizarre scenario discovered. Contact developers.\n");
+    EKAT_REQUIRE_MSG(sv_info.dim_idx==1, "Error! Bizarre scenario discovered. Contact developers.\n");
 
     // Additional col_offset
-    col_offset += idx.second*parent->get_alloc_properties().get_last_extent();
+    col_offset += sv_info.slice_idx*parent->get_alloc_properties().get_last_extent();
 
     // Additional product for col_stride
     col_stride *= parent->get_identifier().get_layout().dim(1);

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -190,11 +190,13 @@ public:
   //     to store a stride for the slowest dimension.
   //   - If dynamic = true, it is possible to "reset" the slice index (k) at runtime.
   field_type subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
-                       const int idim, const int k, const bool dynamic = false) const;
-  field_type subfield (const std::string& sf_name, const int idim, const int k, const bool dynamic = false) const;
+                       const int idim, const int index, const bool dynamic = false) const;
+  field_type subfield (const std::string& sf_name, const int idim,
+                       const int index, const bool dynamic = false) const;
   field_type subfield (const int idim, const int k, const bool dynamic = false) const;
 
   // If this field is a vector field, get a subfield for the ith component.
+  // If dynamic = true, it is possible to "reset" the component index at runtime.
   // Note: throws if this is not a vector field.
   field_type get_component (const int i, const bool dynamic = false);
 
@@ -578,7 +580,7 @@ deep_copy (const RT value) {
 template<typename RealType>
 Field<RealType> Field<RealType>::
 subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
-          const int idim, const int k, const bool dynamic) const {
+          const int idim, const int index, const bool dynamic) const {
 
   const auto& id = m_header->get_identifier();
   const auto& lt = id.get_layout();
@@ -600,7 +602,7 @@ subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
   // Create empty subfield, then set header and views
   // Note: we can access protected members, since it's the same type
   field_type sf;
-  sf.m_header = create_subfield_header(sf_id,m_header,idim,k,dynamic);
+  sf.m_header = create_subfield_header(sf_id,m_header,idim,index,dynamic);
   sf.m_view_d = m_view_d;
   sf.m_view_h = m_view_h;
   sf.m_prop_checks = std::make_shared<property_check_list>();
@@ -610,15 +612,15 @@ subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
 
 template<typename RealType>
 Field<RealType> Field<RealType>::
-subfield (const std::string& sf_name, const int idim, const int k, const bool dynamic) const {
+subfield (const std::string& sf_name, const int idim, const int index, const bool dynamic) const {
   const auto& id = m_header->get_identifier();
-  return subfield(sf_name,id.get_units(),idim,k,dynamic);
+  return subfield(sf_name,id.get_units(),idim,index,dynamic);
 }
 
 template<typename RealType>
 Field<RealType> Field<RealType>::
-subfield (const int idim, const int k, const bool dynamic) const {
-  return subfield(m_header->get_identifier().name(),idim,k,dynamic);
+subfield (const int idim, const int index, const bool dynamic) const {
+  return subfield(m_header->get_identifier().name(),idim,index,dynamic);
 }
 
 template<typename RealType>

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -188,14 +188,15 @@ public:
   //   - If the field rank is 2, then idim cannot be 1. This is b/c Kokkos
   //     specializes view's traits for LayoutRight of rank 1, not allowing
   //     to store a stride for the slowest dimension.
+  //   - If dynamic = true, it is possible to "reset" the slice index (k) at runtime.
   field_type subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
-                       const int idim, const int k) const;
-  field_type subfield (const std::string& sf_name, const int idim, const int k) const;
-  field_type subfield (const int idim, const int k) const;
+                       const int idim, const int k, const bool dynamic = false) const;
+  field_type subfield (const std::string& sf_name, const int idim, const int k, const bool dynamic = false) const;
+  field_type subfield (const int idim, const int k, const bool dynamic = false) const;
 
   // If this field is a vector field, get a subfield for the ith component.
   // Note: throws if this is not a vector field.
-  field_type get_component (const int i);
+  field_type get_component (const int i, const bool dynamic = false);
 
   // Checks whether the underlying view has been already allocated.
   bool is_allocated () const { return m_view_d.data()!=nullptr; }
@@ -577,7 +578,7 @@ deep_copy (const RT value) {
 template<typename RealType>
 Field<RealType> Field<RealType>::
 subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
-          const int idim, const int k) const {
+          const int idim, const int k, const bool dynamic) const {
 
   const auto& id = m_header->get_identifier();
   const auto& lt = id.get_layout();
@@ -599,7 +600,7 @@ subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
   // Create empty subfield, then set header and views
   // Note: we can access protected members, since it's the same type
   field_type sf;
-  sf.m_header = create_subfield_header(sf_id,m_header,idim,k);
+  sf.m_header = create_subfield_header(sf_id,m_header,idim,k,dynamic);
   sf.m_view_d = m_view_d;
   sf.m_view_h = m_view_h;
   sf.m_prop_checks = std::make_shared<property_check_list>();
@@ -609,20 +610,20 @@ subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
 
 template<typename RealType>
 Field<RealType> Field<RealType>::
-subfield (const std::string& sf_name, const int idim, const int k) const {
+subfield (const std::string& sf_name, const int idim, const int k, const bool dynamic) const {
   const auto& id = m_header->get_identifier();
-  return subfield(sf_name,id.get_units(),idim,k);
+  return subfield(sf_name,id.get_units(),idim,k,dynamic);
 }
 
 template<typename RealType>
 Field<RealType> Field<RealType>::
-subfield (const int idim, const int k) const {
-  return subfield(m_header->get_identifier().name(),idim,k);
+subfield (const int idim, const int k, const bool dynamic) const {
+  return subfield(m_header->get_identifier().name(),idim,k,dynamic);
 }
 
 template<typename RealType>
 Field<RealType> Field<RealType>::
-get_component (const int i) {
+get_component (const int i, const bool dynamic) {
   const auto& layout = get_header().get_identifier().get_layout();
   const auto& fname = get_header().get_identifier().name();
   EKAT_REQUIRE_MSG (layout.is_vector_layout(),
@@ -633,7 +634,7 @@ get_component (const int i) {
   EKAT_REQUIRE_MSG (i>=0 && i<layout.dim(idim),
       "Error! Component index out of bounds [0," + std::to_string(layout.dim(idim)) + ").\n");
 
-  return subfield (idim,i);
+  return subfield (idim,i,dynamic);
 }
 
 template<typename RealType>
@@ -712,9 +713,9 @@ auto Field<RealType>::get_ND_view () const ->
     auto v_np1 = f.get_ND_view<HD,T,N+1>();
 
     // Now we can subview v_np1 at the correct slice
-    const auto& idx = m_header->get_alloc_properties().get_subview_idx();
-    const int idim = idx.first;
-    const int k    = idx.second;
+    const auto& info = m_header->get_alloc_properties().get_subview_info();
+    const int idim = info.dim_idx;
+    const int k    = info.slice_idx;
 
     // So far we can only subview at first or second dimension.
     EKAT_REQUIRE_MSG (idim==0 || idim==1,

--- a/components/scream/src/share/field/field_alloc_prop.hpp
+++ b/components/scream/src/share/field/field_alloc_prop.hpp
@@ -59,6 +59,27 @@ namespace scream
  *        field layout refer to that scalar_type.
  */
 
+// Helper struct to store info related to the subviewing process
+struct SubviewInfo {
+  SubviewInfo () = default;
+  SubviewInfo (const int dim, const int slice, const int extent, const bool is_dynamic) :
+    dim_idx(dim), slice_idx(slice), dim_extent(extent), dynamic(is_dynamic) {}
+  SubviewInfo (const SubviewInfo&) = default;
+  SubviewInfo& operator= (const SubviewInfo&) = default;
+
+  int dim_idx    = -1;  // Dimension along which slicing happened
+  int slice_idx  = -1;  // Slice along dimension $dim_idx
+  int dim_extent = -1;  // Extent of dimension $dim_idx
+  bool dynamic   = false; // Whether this is a dynamic subview (slice_idx can change)
+};
+
+inline bool operator== (const SubviewInfo& lhs, const SubviewInfo& rhs) {
+  return lhs.dim_idx==rhs.dim_idx &&
+         lhs.slice_idx==rhs.slice_idx &&
+         lhs.dim_extent==rhs.dim_extent &&
+         lhs.dynamic==rhs.dynamic;
+}
+
 class FieldAllocProp {
 public:
   using layout_type      = FieldLayout;
@@ -70,8 +91,9 @@ public:
   FieldAllocProp& operator= (const FieldAllocProp&);
 
   // Return allocation props of an unmanaged subivew of this field
-  // at entry k along dimension idim.
-  FieldAllocProp subview (const int idim, const int k) const;
+  // at entry k along dimension idim. If dynamic = true, then it will be
+  // possible to change the entry index (k) at runtime.
+  FieldAllocProp subview (const int idim, const int k, const bool dynamic) const;
 
   // Request allocation able to accommodate the given ValueType
   template<typename ValueType>
@@ -92,10 +114,19 @@ public:
   // Locks the allocation properties, preventing furter value types requests
   void commit (const layout_ptr_type& layout);
 
+  // For dynamic subfield, reset the slice index
+  void reset_subview_idx (const int idx);
+
   // ---- Getters ---- //
 
   // Whether commit has been called
   bool is_committed () const { return m_committed; }
+
+  // Whether this field is a subfield of another
+  bool is_subfield () const { return m_subview_info.dim_idx>=0; }
+
+  // Whether this field is a dynamic subfield of another
+  bool is_dynamic_subfield () const { return m_subview_info.dynamic; }
 
   // Get the overall allocation size (in Bytes)
   int  get_alloc_size () const;
@@ -114,7 +145,7 @@ public:
   int  get_padding () const;
 
   // Return the slice information of this subview allocation.
-  const std::pair<int,int>& get_subview_idx () const { return m_subview_idx; }
+  const SubviewInfo& get_subview_info () const { return m_subview_info; }
 
   // Whether the allocation properties are compatible with ValueType
   template<typename ValueType>
@@ -140,9 +171,9 @@ protected:
   // The total size of this allocation.
   int   m_alloc_size;
 
-  // If this allocation is a subview of another, this pair stores the
-  // dimension idim and entry k along dimension idim of the slice.
-  std::pair<int,int>  m_subview_idx;
+  // If this allocation is a subview of another, store info about the subview
+  // process (see SubviewInfo documentation for details)
+  SubviewInfo         m_subview_info;
 
   // Whether the allocation is contiguous
   bool  m_contiguous;

--- a/components/scream/src/share/field/field_header.cpp
+++ b/components/scream/src/share/field/field_header.cpp
@@ -7,7 +7,6 @@ namespace scream
 FieldHeader::FieldHeader (const identifier_type& id)
  : m_identifier (id)
  , m_tracking (create_tracking())
- , m_alloc_prop ()
 {
   // Nothing to be done here
 }
@@ -32,7 +31,7 @@ set_extra_data (const std::string& key,
 std::shared_ptr<FieldHeader>
 create_subfield_header (const FieldIdentifier& id,
                         std::shared_ptr<FieldHeader> parent,
-                        const int idim, const int k)
+                        const int idim, const int k, const bool dynamic)
 {
   // Sanity checks
   EKAT_REQUIRE_MSG (parent!=nullptr,
@@ -52,7 +51,7 @@ create_subfield_header (const FieldIdentifier& id,
   }
 
   // Create alloc props
-  fh->m_alloc_prop = parent->get_alloc_properties().subview(idim,k);
+  fh->m_alloc_prop = parent->get_alloc_properties().subview(idim,k,dynamic);
   fh->m_alloc_prop.commit(id.get_layout_ptr());
 
   return fh;

--- a/components/scream/src/share/field/field_header.hpp
+++ b/components/scream/src/share/field/field_header.hpp
@@ -84,7 +84,7 @@ protected:
   friend std::shared_ptr<FieldHeader>
   create_subfield_header (const FieldIdentifier&,
                           std::shared_ptr<FieldHeader>,
-                          const int, const int);
+                          const int, const int, const bool);
 
   // Static information about the field: name, rank, tags
   identifier_type                 m_identifier;
@@ -114,7 +114,7 @@ create_header(const Args&... args) {
 std::shared_ptr<FieldHeader>
 create_subfield_header (const FieldIdentifier& id,
                         std::shared_ptr<FieldHeader> parent,
-                        const int idim, const int k);
+                        const int idim, const int k, const bool dynamic);
 
 } // namespace scream
 

--- a/components/scream/src/share/field/field_manager.hpp
+++ b/components/scream/src/share/field/field_manager.hpp
@@ -111,6 +111,11 @@ protected:
   // The actual repo.
   repo_type           m_fields;
 
+  // When registering subfields, we might end up registering the subfield before
+  // the parent field. So at registration time, simply keep track of the subfields,
+  // and create them at registration_ends() time, after all other fields.
+  std::map<std::string,FieldRequest> m_subfield_requests;
+
   // The map group_name -> FieldGroupInfo
   group_info_map      m_field_groups;
 
@@ -175,11 +180,26 @@ void FieldManager<RealType>::register_field (const FieldRequest& req)
         "         - input id:  " + id.get_id_string() + "\n"
         "         - stored id: " + id0.get_id_string() + "\n"
         "       Please, check and make sure all atmosphere processes use the same layout for a given field.\n");
+
+    // Do not allow to mix subfield requests with normal requests for now.
+    // TODO: you might be able to relax this. It's ok if field F was requested as subfield of G,
+    //       and also requested without knowledge of parent fields.
+    EKAT_REQUIRE_MSG (
+        (req.subview_info.dim_idx==-1) ||
+        m_subfield_requests.find(id.name())==m_subfield_requests.end() ||
+        m_subfield_requests.at(id.name()).subview_info==req.subview_info,
+        "Error! Inconsistent requests for a subfield.");
   }
 
-  // Make sure the field can accommodate the requested value type
-  constexpr int real_size = sizeof(RealType);
-  m_fields[id.name()]->get_header().get_alloc_properties().request_allocation(real_size,req.pack_size);
+  if (req.subview_info.dim_idx>=0) {
+    // This is a request for a subfield. Store request info, so we can correctly set up
+    // the subfield at the end of registration_ends() call
+    m_subfield_requests.emplace(id.name(),req);
+  } else {
+    // Make sure the field can accommodate the requested value type
+    constexpr int real_size = sizeof(RealType);
+    m_fields[id.name()]->get_header().get_alloc_properties().request_allocation(real_size,req.pack_size);
+  }
 
   // Finally, add the field to the given groups
   // Note: we do *not* set the group info struct in the field header yet.
@@ -844,8 +864,21 @@ registration_ends ()
       continue;
     }
 
-    // A brand new field. Allocate it
-    it.second->allocate_view();
+    // Skip requests for subfields, since we need to have all fields allocated first
+    if (m_subfield_requests.find(it.first)==m_subfield_requests.end()) {
+      // A brand new field. Allocate it
+      it.second->allocate_view();
+    }
+  }
+
+  // Now allocate subfields
+  for (const auto& it : m_subfield_requests) {
+    auto f = get_field_ptr(it.first);
+    const auto& sv_info = it.second.subview_info;
+    const auto& fid = f->get_header().get_identifier();
+    const auto& p = m_fields.at(it.second.parent_name);
+
+    *f = p->subfield (fid.name(),fid.get_units(),sv_info.dim_idx,sv_info.slice_idx,sv_info.dynamic);
   }
 
   for (const auto& it : m_field_groups) {

--- a/components/scream/src/share/field/field_request.hpp
+++ b/components/scream/src/share/field/field_request.hpp
@@ -1,7 +1,8 @@
 #ifndef SCREAM_FIELD_REQUEST_HPP
 #define SCREAM_FIELD_REQUEST_HPP
 
-#include "share/field//field_identifier.hpp"
+#include "share/field/field_identifier.hpp"
+#include "share/field/field_alloc_prop.hpp"
 #include "share/util/scream_utils.hpp"
 
 namespace scream {
@@ -233,10 +234,23 @@ struct FieldRequest {
    : FieldRequest(FID(name,layout,u,grid),std::list<std::string>{group},ps)
   { /* Nothing to do here */ }
 
+  FieldRequest (const FID& fid, const FieldRequest& parent, int idim, int k, bool dynamic)
+   : FieldRequest (fid)
+  {
+    subview_info.dim_idx = idim;
+    subview_info.slice_idx = k;
+    subview_info.dim_extent = parent.fid.get_layout().dim(idim);
+    subview_info.dynamic = dynamic;
+
+    parent_name = parent.fid.name();
+  }
+
   // Data
   FieldIdentifier           fid;
   int                       pack_size;
   std::list<std::string>    groups;
+  SubviewInfo               subview_info;
+  std::string               parent_name;
 };
 
 // In order to use FieldRequest in std sorted containers (like std::set),

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -351,19 +351,25 @@ TEST_CASE("field_mgr", "") {
 
   const int ncols = 4;
   const int nlevs = 7;
+  const int subview_dim = 1;
+  const int subview_slice = 0;
 
   std::vector<FieldTag> tags1 = {COL,LEV};
   std::vector<FieldTag> tags2 = {EL,GP,GP};
+  std::vector<FieldTag> tags3 = {COL,CMP,LEV};
 
   std::vector<int> dims1 = {ncols,nlevs};
   std::vector<int> dims2 = {2,4,4};
   std::vector<int> dims3 = {ncols,nlevs+1};
+  std::vector<int> dims4 = {ncols,10,nlevs};
 
   const auto km = 1000*m;
 
   FID fid1("field_1", {tags1, dims1},  m/s, "phys");
   FID fid2("field_2", {tags1, dims1},  m/s, "phys");
   FID fid3("field_3", {tags1, dims1},  m/s, "phys");
+  FID fid4("field_4", {tags3, dims4},  m/s, "phys");
+  FID fid5("field_5", {tags1, dims1},  m/s, "phys");
 
   FID bad1("field_1", {tags2, dims2},  m/s, "dyn");  // Bad grid
   FID bad2("field_2", {tags1, dims1}, km/s, "phys"); // Bad units
@@ -384,11 +390,15 @@ TEST_CASE("field_mgr", "") {
   field_mgr.register_field(FR{fid3,"group_4"});
   field_mgr.register_field(FR{fid3,SL{"group_1","group_2","group_3"}});
   field_mgr.register_field(FR{fid2,"group_4"});
+  field_mgr.register_field(FR{fid4});
+  field_mgr.register_field(FR{fid5,FR{fid4},subview_dim,subview_slice,true}); // Register a dynamic subfield
 
   // === Invalid registration calls === //
   REQUIRE_THROWS(field_mgr.register_field(FR{bad1}));
   REQUIRE_THROWS(field_mgr.register_field(FR{bad2}));
   REQUIRE_THROWS(field_mgr.register_field(FR{bad2}));
+  REQUIRE_THROWS(field_mgr.register_field(FR{fid5,FR{fid4},1,0,false})); // Cannot register inconsistent subfields
+
   field_mgr.registration_ends();
 
   // Should not be able to register fields anymore
@@ -396,12 +406,14 @@ TEST_CASE("field_mgr", "") {
 
   // Check registration is indeed closed
   REQUIRE (field_mgr.repository_state()==RepoState::Closed);
-  REQUIRE (field_mgr.size()==3);
+  REQUIRE (field_mgr.size()==5);
 
   // Get all fields
   auto f1 = field_mgr.get_field(fid1.name());
   auto f2 = field_mgr.get_field(fid2.name());
   auto f3 = field_mgr.get_field(fid3.name());
+  auto f4 = field_mgr.get_field(fid4.name());
+  auto f5 = field_mgr.get_field(fid5.name());
   REQUIRE_THROWS(field_mgr.get_field("bad")); // Not in the field_mgr
   REQUIRE(f1.get_header().get_identifier()==fid1);
 
@@ -449,6 +461,20 @@ TEST_CASE("field_mgr", "") {
 
   REQUIRE (f1_padding==ekat::PackInfo<Pack::n>::padding(nlevs));
   REQUIRE (f2_padding==ekat::PackInfo<16>::padding(nlevs));
+
+  // Verify f5 is a subfield of f4
+  auto f5_ap = f5.get_header().get_alloc_properties();
+  REQUIRE (f5_ap.is_subfield());
+  REQUIRE (f5_ap.is_dynamic_subfield());
+  REQUIRE (f5_ap.get_subview_info().dim_idx==subview_dim);
+  REQUIRE (f5_ap.get_subview_info().slice_idx==subview_slice);
+
+  // Fill f4 with random numbers, and verify corresponding subview of f5 gets same values.
+  auto engine = setup_random_test(&comm);
+  using RPDF = std::uniform_real_distribution<Real>;
+  RPDF pdf(0.0,1.0);
+  randomize(f5,engine,pdf);
+  REQUIRE (views_are_equal(f5,f4.get_component(subview_slice)));
 }
 
 TEST_CASE("tracers_bundle", "") {


### PR DESCRIPTION
Currently, subfields are constructed by providing the dimension along which the field has to be subviewed, as well as the index along said dimension. These two indices are then frozen for the lifetime of the subfield.

This PR allows one to change the slice index of the subfield at runtime (a "dynamic" subfield). This is particularly useful for subviewing dynamics state fields, which have a "TimeLevel" dimension, which is simply used to store stages during the timestepping, and the "end-of-step" field could be stored in any of the time levels.

With dyn subfields, one can register both the state and a subfield of the state. The latter can be passed to several other routines (or atm procs), and all dynamics needs to do is move the index of the subview. Something like this:

```
field_type u_with_tl (...); // a 6-dimensional field
field_type u_no_tl = u_with_tl.subfield("u",1,0,true);
...
// Change tl where 'u_no_tl' points to
u_no_tl.get_header().get_alloc_prop().reset_subview_idx(new_tl);
```
Notice that this doesn't break anything in the downstream code _provided that they don't pre-extract the N-dim view_. That is, the downstream code cannot do
```
u_no_tl_view = u_no_tl.get_view<Real*****>();
```
until it's actually time to use the data. Pre-storing such view would cause it to always point to the same slice of `u_with_tl`. If instead they call `get_view<Real*****>()` every time they need to access the view, the correct up-to-date slice will be extracted from the parent field.

NOTE: this feature is to help outputing dyn fields with the native dyn grid layout (i.e., without remapping to phys grid first), in a subsequent PR.