### PR TITLE
Remove updated groups from atm proc interface

### DIFF
--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -33,7 +33,7 @@ namespace control {
  *           remappers. The AD will *not* take care of remapping inputs/outputs of the process.
  *  4) Register all fields and all groups from all atm procs inside the field managers, and proceed
  *     to allocate fields. Each field manager (there is one FM per grid) will take care of
- *     accommodate all requests for packing as well as (if possible) bundling of groups.
+ *     accommodating all requests for packing as well as (if possible) bundling of groups.
  *     For more details, see the documentation in the share/field/field_request.hpp header.
  *  5) Set all the fields into the atm procs. Before this point, all the atm procs had were the
  *     FieldIdentifiers for their input/output fields and FieldGroupInfo for their input/output
@@ -55,6 +55,17 @@ namespace control {
  *     they can set up remappers from the reference grid to the grid they operate on. They can
  *     also utilize their input fields to perform initialization of some internal data structure.
  *
+ * For more info see header comments in the proper files:
+ *  - for field                -> src/share/field/field.hpp
+ *  - for field manager        -> src/share/field/field_manager.hpp
+ *  - for field groups         -> src/share/field/field_group.hpp
+ *  - for field/group requests -> src/share/field/field_request.hpp
+ *  - for grid                 -> src/share/grid/abstract_grid.hpp
+ *  - for grid manager         -> src/share/grid/grids_manager.hpp
+ *  - for atm proc             -> src/share/atm_process/atmosphere_process.hpp
+ *  - for atm proc group       -> src/share/atm_process/atmosphere_process_group.hpp
+ *  - for scorpio input/output -> src/share/io/scorpio_[input|output].hpp
+ *  - for output manager       -> src/share/io/scream_output_manager.hpp
  */
 
 AtmosphereDriver::

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -190,7 +190,7 @@ void AtmosphereDriver::create_fields()
   };
 
   process_imported_groups (m_atm_process_group->get_required_group_requests());
-  process_imported_groups (m_atm_process_group->get_updated_group_requests());
+  process_imported_groups (m_atm_process_group->get_computed_group_requests());
 
   // Close the FM's, allocate all fields
   for (auto it : m_grids_manager->get_repo()) {
@@ -201,14 +201,12 @@ void AtmosphereDriver::create_fields()
   // Set all the fields/groups in the processes. Input fields/groups will be handed
   // to the processes with const scalar type (const Real), to prevent them from
   // overwriting them (though, they can always cast away const...).
-  const auto& inputs  = m_atm_process_group->get_required_field_requests();
-  const auto& outputs = m_atm_process_group->get_computed_field_requests();
-  for (const auto& req : inputs) {
+  for (const auto& req : m_atm_process_group->get_required_field_requests()) {
     const auto& fid = req.fid;
     auto fm = get_field_mgr(fid.get_grid_name());
     m_atm_process_group->set_required_field(fm->get_field(fid).get_const());
   }
-  for (const auto& req : outputs) {
+  for (const auto& req : m_atm_process_group->get_computed_field_requests()) {
     const auto& fid = req.fid;
     auto fm = get_field_mgr(fid.get_grid_name());
     m_atm_process_group->set_computed_field(fm->get_field(fid));
@@ -218,10 +216,10 @@ void AtmosphereDriver::create_fields()
     auto group = fm->get_const_field_group(it.name);
     m_atm_process_group->set_required_group(group);
   }
-  for (const auto& it : m_atm_process_group->get_updated_group_requests()) {
+  for (const auto& it : m_atm_process_group->get_computed_group_requests()) {
     auto fm = get_field_mgr(it.grid);
     auto group = fm->get_field_group(it.name);
-    m_atm_process_group->set_updated_group(group);
+    m_atm_process_group->set_computed_group(group);
   }
 
   m_ad_status |= s_fields_created;

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -116,6 +116,8 @@ public:
 
   const ATMBufferManager& get_memory_buffer() const { return m_memory_buffer; }
 
+  const std::shared_ptr<AtmosphereProcessGroup>& get_atm_processes () const { return m_atm_process_group; }
+
 protected:
 
   void initialize_constant_field(const FieldIdentifier& fid, const ekat::ParameterList& ic_pl);

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -114,7 +114,7 @@ public:
 
   const std::shared_ptr<GridsManager>& get_grids_manager () const { return m_grids_manager; }
 
-  const ATMBufferManager& get_memory_buffer() const { return m_memory_buffer; }
+  const std::shared_ptr<ATMBufferManager>& get_memory_buffer() const { return m_memory_buffer; }
 
   const std::shared_ptr<AtmosphereProcessGroup>& get_atm_processes () const { return m_atm_process_group; }
 
@@ -123,20 +123,20 @@ protected:
   void initialize_constant_field(const FieldIdentifier& fid, const ekat::ParameterList& ic_pl);
   void register_groups ();
 
-  std::map<std::string,field_mgr_ptr>    m_field_mgrs;
+  std::map<std::string,field_mgr_ptr>       m_field_mgrs;
 
-  std::shared_ptr<AtmosphereProcessGroup>             m_atm_process_group;
+  std::shared_ptr<AtmosphereProcessGroup>   m_atm_process_group;
 
-  std::shared_ptr<GridsManager>                       m_grids_manager;
+  std::shared_ptr<GridsManager>             m_grids_manager;
 
-  ekat::ParameterList                                 m_atm_params;
+  ekat::ParameterList                       m_atm_params;
 
-  std::map<std::string,OutputManager>                 m_output_managers;
+  std::map<std::string,OutputManager>       m_output_managers;
 
-  ATMBufferManager                                    m_memory_buffer;
+  std::shared_ptr<ATMBufferManager>         m_memory_buffer;
 
   // Surface coupling stuff
-  std::shared_ptr<SurfaceCoupling>            m_surface_coupling;
+  std::shared_ptr<SurfaceCoupling>          m_surface_coupling;
 
   // This are the time stamps of the start and end of the time step.
   util::TimeStamp                       m_current_ts;

--- a/components/scream/src/control/tests/ad_tests.cpp
+++ b/components/scream/src/control/tests/ad_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "control/atmosphere_driver.hpp"
 #include "share/atm_process/atmosphere_process_group.hpp"
+#include "share/field/field_utils.hpp"
 
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/ekat_parse_yaml_file.hpp"
@@ -10,7 +11,7 @@
 
 namespace scream {
 
-TEST_CASE ("group_requirements","[!throws]")
+TEST_CASE ("ad_tests","[!throws]")
 {
   constexpr int num_cols = 4;
   constexpr int num_vl   = 2;
@@ -30,21 +31,53 @@ TEST_CASE ("group_requirements","[!throws]")
   control::AtmosphereDriver ad;
 
   // Init and run a single time step
-  util::TimeStamp init_time(2000,1,1,0,0,0);
-  ad.initialize(atm_comm,ad_params,init_time);
+  util::TimeStamp t0(2000,1,1,0,0,0);
+  ad.initialize(atm_comm,ad_params,t0);
 
-  // Verify that the atm proc group has 1 required field and 0 required groups.
+  // Verify that the atm proc group has the expected specs
   const auto& apg = ad.get_atm_processes();
   REQUIRE (apg->get_num_processes()==3);
-  REQUIRE (apg->get_fields_in().size()==1);
+  REQUIRE (apg->get_fields_in().size()==3);
   REQUIRE (apg->get_groups_in().size()==0);
+  REQUIRE (apg->get_fields_out().size()==3);
+  REQUIRE (apg->get_groups_out().size()==1);
 
-  auto field_mgr = ad.get_ref_grid_field_mgr();
-  // Resume ad run and testing.
+  // Check correct initialization of the input fields for the 1st process
+  const auto& f_in = apg->get_fields_in();
+  for (const auto& f : f_in) {
+    const auto& fn = f.get_header().get_identifier().name();
+
+    // Create 'target' field
+    Field<Real> check(f.get_header().get_identifier());
+    check.allocate_view();
+
+    // Fill target field based on what IC were in the yaml file
+    if (fn=="A" || fn=="Z") {
+      check.deep_copy(1.0);
+    } else if (fn=="V") {
+      check.get_component(0).deep_copy(2.0);
+      check.get_component(1).deep_copy(3.0);
+    } else {
+      EKAT_ERROR_MSG ("Error! Unexpected input field for this test.\n");
+    }
+
+    // Check the field
+    REQUIRE (views_are_equal(f,check));
+  }
+
+  // Run ad
   ad.run(10);
-  ad.finalize ();
 
-  // Cleanup atm factories and grids manager
+  // At this point, output fields should have timestamp updated
+  const auto& f_out = apg->get_fields_out();
+  auto t = t0 + 10;
+  for (const auto& f : f_out) {
+    const auto& f_ts = f.get_header().get_tracking().get_time_stamp();
+    REQUIRE (f_ts==t);
+  }
+
+  // Cleanup
+  ad.finalize ();
   dummy_atm_cleanup();
 }
 

--- a/components/scream/src/control/tests/ad_tests.cpp
+++ b/components/scream/src/control/tests/ad_tests.cpp
@@ -1,6 +1,7 @@
 #include "dummy_atm_setup.hpp"
 
 #include "control/atmosphere_driver.hpp"
+#include "share/atm_process/atmosphere_process_group.hpp"
 
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/ekat_parse_yaml_file.hpp"
@@ -31,15 +32,14 @@ TEST_CASE ("group_requirements","[!throws]")
   // Init and run a single time step
   util::TimeStamp init_time(2000,1,1,0,0,0);
   ad.initialize(atm_comm,ad_params,init_time);
-  // Verify that after initialization field "E" matches field "A"
+
+  // Verify that the atm proc group has 1 required field and 0 required groups.
+  const auto& apg = ad.get_atm_processes();
+  REQUIRE (apg->get_num_processes()==3);
+  REQUIRE (apg->get_fields_in().size()==1);
+  REQUIRE (apg->get_groups_in().size()==0);
+
   auto field_mgr = ad.get_ref_grid_field_mgr();
-  const auto& view_A = field_mgr->get_field("A").get_view<const Real**, Host>();
-  const auto& view_E = field_mgr->get_field("E").get_view<const Real**, Host>();
-  for (int icol=0;icol<num_cols;++icol) {
-    for (int jlev=0;jlev<num_vl;++jlev) {
-      REQUIRE(view_E(icol,jlev)==view_A(icol,jlev));
-    }
-  }
   // Resume ad run and testing.
   ad.run(10);
   ad.finalize ();

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -7,8 +7,8 @@ Initial Conditions:
   Point Grid:
     Filename: should_not_be_neeeded_and_code_will_throw_if_it_tries_to_open_this_nonexistent_file.nc
     A: 1.0
-    B: 2.0
-    C: 3.0
+    V: [2.0, 3.0]
+    Z: "A"
 
 Atmosphere Processes:
   Number of Entries: 3

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -9,8 +9,6 @@ Initial Conditions:
     A: 1.0
     B: 2.0
     C: 3.0
-    D: [4.0, 5.0]
-    E: "A"
 
 Atmosphere Processes:
   Number of Entries: 3

--- a/components/scream/src/control/tests/dummy_atm_proc.hpp
+++ b/components/scream/src/control/tests/dummy_atm_proc.hpp
@@ -55,6 +55,10 @@ public:
       add_field<Required>("A",layout,ekat::units::m,m_grid->name());
       add_field<Computed>("B",layout,ekat::units::m,m_grid->name(),"The Group");
       add_field<Computed>("C",layout,ekat::units::m,m_grid->name(),"The Group");
+      // These are not used at run time, but we use them to test
+      // the initialization of IC fields
+      add_field<Required>("V",layout_vec,ekat::units::m,m_grid->name());
+      add_field<Required>("Z",layout,ekat::units::m,m_grid->name());
     } else if (m_dummy_type == G2A) {
       add_field<Computed>("A",layout,ekat::units::m,m_grid->name());
       add_group<Required>("The Group",m_grid->name());

--- a/components/scream/src/control/tests/dummy_atm_proc.hpp
+++ b/components/scream/src/control/tests/dummy_atm_proc.hpp
@@ -55,12 +55,11 @@ public:
       add_field<Required>("A",layout,ekat::units::m,m_grid->name());
       add_field<Computed>("B",layout,ekat::units::m,m_grid->name(),"The Group");
       add_field<Computed>("C",layout,ekat::units::m,m_grid->name(),"The Group");
-      add_field<Required>("D",layout_vec,ekat::units::m,m_grid->name());
-      add_field<Required>("E",layout,ekat::units::m,m_grid->name());
     } else if (m_dummy_type == G2A) {
       add_field<Computed>("A",layout,ekat::units::m,m_grid->name());
       add_group<Required>("The Group",m_grid->name());
     } else {
+      add_field<Required>("B",layout,ekat::units::m,m_grid->name());
       add_group<Updated>("The Group",m_grid->name());
     }
   }

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -178,7 +178,7 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
 }
 
 void HommeDynamics::
-set_updated_group_impl (const FieldGroup<Real>& group)
+set_computed_group_impl (const FieldGroup<Real>& group)
 {
   const auto& name = group.m_info->m_group_name;
   EKAT_REQUIRE_MSG(name=="tracers",

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -71,7 +71,7 @@ protected:
   void finalize_impl   ();
 
   // Dynamics updates the "tracers" group, and needs to do some extra checks on the group.
-  void set_updated_group_impl (const FieldGroup<Real>& group);
+  void set_computed_group_impl (const FieldGroup<Real>& group);
 
   // Override the check computed fields impl so we can repair slightly negative tracer values.
   void check_computed_fields_impl ();

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -98,7 +98,7 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
 // =========================================================================================
 void SHOCMacrophysics::
-set_updated_group_impl (const FieldGroup<Real>& group)
+set_computed_group_impl (const FieldGroup<Real>& group)
 {
   EKAT_REQUIRE_MSG(group.m_info->size() >= 3,
                    "Error! Shoc requires at least 3 tracers (tke, qv, qc) as inputs.");

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -403,7 +403,7 @@ protected:
   void finalize_impl   ();
 
   // SHOC updates the 'tracers' group.
-  void set_updated_group_impl (const FieldGroup<Real>& group);
+  void set_computed_group_impl (const FieldGroup<Real>& group);
 
   // Computes total number of bytes needed for local variables
   int requested_buffer_size_in_bytes() const;

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -109,29 +109,14 @@ void AtmosphereProcess::set_required_group (const FieldGroup<const Real>& group)
   set_required_group_impl(group);
 }
 
-void AtmosphereProcess::set_updated_group (const FieldGroup<Real>& group) {
+void AtmosphereProcess::set_computed_group (const FieldGroup<Real>& group) {
   // Sanity check
-  EKAT_REQUIRE_MSG (updates_group(group.m_info->m_group_name,group.grid_name()),
-    "Error! This atmosphere process does not update the input group.\n"
+  EKAT_REQUIRE_MSG (computes_group(group.m_info->m_group_name,group.grid_name()),
+    "Error! This atmosphere process does not compute the input group.\n"
     "   group name: " + group.m_info->m_group_name + "\n"
     "   grid name : " + group.grid_name() + "\n"
     "   atm process: " + this->name() + "\n"
     "Something is wrong up the call stack. Please, contact developers.\n");
-
-  if (not ekat::contains(m_groups_in,group.get_const())) {
-    m_groups_in.emplace_back(group);
-    // AtmosphereProcessGroup is just a "container" of *real* atm processes,
-    // so don't add me as customer if I'm an atm proc group.
-    if (this->type()!=AtmosphereProcessType::Group) {
-      if (group.m_bundle) {
-        add_me_as_customer(group.m_bundle->get_const());
-      } else {
-        for (auto& it : group.m_fields) {
-          add_me_as_customer(it.second->get_const());
-        }
-      }
-    }
-  }
 
   if (not ekat::contains(m_groups_out,group)) {
     m_groups_out.emplace_back(group);
@@ -148,7 +133,7 @@ void AtmosphereProcess::set_updated_group (const FieldGroup<Real>& group) {
     }
   }
 
-  set_updated_group_impl(group);
+  set_computed_group_impl(group);
 }
 
 void AtmosphereProcess::check_required_fields () const { 
@@ -285,8 +270,8 @@ bool AtmosphereProcess::requires_group (const std::string& name, const std::stri
   }
   return false;
 }
-bool AtmosphereProcess::updates_group (const std::string& name, const std::string& grid) const {
-  for (const auto& it : m_updated_group_requests) {
+bool AtmosphereProcess::computes_group (const std::string& name, const std::string& grid) const {
+  for (const auto& it : m_computed_group_requests) {
     if (it.name==name && it.grid==grid) {
       return true;
     }

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -111,7 +111,7 @@ public:
   // corresponding set_xyz_impl method(s).
   // Note: this method will be called *after* set_grids, but *before* initialize.
   //       You are *guaranteed* that the views in the field/group are allocated by now.
-  // Note: you are *unlikely* to need to override these method. In 99.99% of the cases,
+  // Note: you are *unlikely* to need to override these methods. In 99.99% of the cases,
   //       overriding the corresponding _impl method should be enough. The class
   //       AtmosphereProcessGroup is the big exception to this, since it needs
   //       to perform some extra action *before* setting the field/group.

--- a/components/scream/src/share/atm_process/atmosphere_process_dag.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_dag.hpp
@@ -49,9 +49,9 @@ protected:
     std::string       name;
     int               id;
     std::set<int>     computed;     // output fields
-    std::set<int>     required;     // input fields
-    std::set<int>     gr_updated;   // in-out groups
-    std::set<int>     gr_required;  // input groups
+    std::set<int>     required;     // input  fields
+    std::set<int>     gr_computed;  // output groups
+    std::set<int>     gr_required;  // input  groups
   };
 
   // Assign an id to each field identifier

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -145,6 +145,12 @@ void AtmosphereProcessGroup::finalize_impl (/* what inputs? */) {
 
 void AtmosphereProcessGroup::
 set_required_field (const Field<const Real>& f) {
+  if (m_group_schedule_type==ScheduleType::Parallel) {
+    // In parallel splitting, all required fields are *actual* inputs,
+    // and the base class impl is fine.
+    AtmosphereProcess::set_required_field(f);
+  }
+
   // Find the first process that requires this group
   const auto& fid = f.get_header().get_identifier();
   int first_proc_that_needs_f = -1;
@@ -161,11 +167,11 @@ set_required_field (const Field<const Real>& f) {
     "   atm process: " + this->name() + "\n"
     "Something is wrong up the call stack. Please, contact developers.\n");
 
-  // Loop over all the fields in the group, and see if they are all computed
-  // by a previous process. If so, then this group is not a "required" group
-  // for this group.
-  // NOTE: the case where the group itself is computed by a previous atm proc
-  // is already handled during `set_grids` (see process_required_group).
+  // Loop over all the fields in the FieldGroup (FG), and see if they are all computed
+  // by a previous process. If so, then this FG is not a "required" FG
+  // for this AtmosphereProcessGroup.
+  // NOTE: the case where the FG itself is computed by a previous atm proc
+  //       is already handled during `set_grids` (see process_required_group).
   // NOTE: we still check also the groups computed by the previous procs,
   //       in case they contain some of the fields in this group.
   bool computed = false;
@@ -207,6 +213,12 @@ endloop:
 
 void AtmosphereProcessGroup::
 set_required_group (const FieldGroup<const Real>& group) {
+  if (m_group_schedule_type==ScheduleType::Parallel) {
+    // In parallel splitting, all required group are *actual* inputs,
+    // and the base class impl is fine.
+    AtmosphereProcess::set_required_group(group);
+  }
+
   // Find the first process that requires this group
   int first_proc_that_needs_group = -1;
   for (int iproc=0; iproc<m_group_size; ++iproc) {

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -60,6 +60,11 @@ public:
   // Initialize memory buffer for each process
   void initialize_atm_memory_buffer (ATMBufferManager& memory_buffer);
 
+  // The APG class needs to perform special checks before establishing whether
+  // a required group/field is indeed a required group for this APG
+  void set_required_field (const Field<const Real>& field);
+  void set_required_group (const FieldGroup<const Real>& group);
+
 protected:
 
   // Adds fid to the list of required/computed fields of the group (as a whole).

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -75,10 +75,10 @@ protected:
   void run_parallel   (const Real dt);
 
   // The methods to set the fields/groups in the right processes of the group
-  void set_required_group_impl (const FieldGroup<const Real>& group);
-  void set_updated_group_impl (const FieldGroup<Real>& group);
   void set_required_field_impl (const Field<const Real>& f);
   void set_computed_field_impl (const Field<      Real>& f);
+  void set_required_group_impl (const FieldGroup<const Real>& group);
+  void set_computed_group_impl (const FieldGroup<      Real>& group);
 
   // The name of the group. This is usually a concatenation of the names of the individual processes
   std::string       m_group_name;

--- a/components/scream/tests/uncoupled/homme/homme_standalone.cpp
+++ b/components/scream/tests/uncoupled/homme/homme_standalone.cpp
@@ -73,9 +73,10 @@ TEST_CASE("scream_homme_standalone", "scream_homme_standalone") {
   // are the same size and reference the same memory.
   auto& fbm  = Homme::Context::singleton().get<Homme::FunctorsBuffersManager>();
   auto& memory_buffer = ad.get_memory_buffer();
-  EKAT_ASSERT_MSG(fbm.allocated_size()*sizeof(Real) == (long unsigned int)memory_buffer.allocated_bytes(),
+  REQUIRE (memory_buffer);
+  EKAT_ASSERT_MSG(fbm.allocated_size()*sizeof(Real) == (long unsigned int)memory_buffer->allocated_bytes(),
                   "Error! AD memory buffer and Homme FunctorsBuffersManager have mismatched sizes.");
-  EKAT_ASSERT_MSG(fbm.get_memory() == memory_buffer.get_memory(),
+  EKAT_ASSERT_MSG(fbm.get_memory() == memory_buffer->get_memory(),
                   "Error! AD memory buffer and Homme FunctorsBuffersManager reference different memory.");
 
   printf("Start time stepping loop...       [  0%%]\n");


### PR DESCRIPTION
The asymmetry between fields and groups has puzzled more than one person so far. This PR makes the treatment of field groups more similar to that of fields.

Additionally, fix the treatment of required fields/groups in the AtmosphereProcessGroup class.