### PR TITLE
Beydoun/precip ice fraction 2

### DIFF
--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -409,8 +409,9 @@ end function shoc_implements_cnst
     call addfld('BRUNT',(/'lev'/), 'A', 's-1', 'Brunt frequency')
     call addfld('RELVAR',(/'lev'/), 'A', 'kg/kg', 'SHOC cloud liquid relative variance')
     call addfld('ICE_CLOUD_FRAC',(/'lev'/), 'A', '', 'Ice number aware cloud fraction')
-    call addfld('PRECIP_ICE_FRAC',(/'lev'/), 'A', '', 'Precipitating ice fraction')
+    call addfld('PRECIPITATING_ICE_FRAC',(/'lev'/), 'A', '', 'Precipitating ice fraction')
     call addfld('LIQ_CLOUD_FRAC',(/'lev'/), 'A', '', 'Liquid cloud fraction')
+    call addfld('TOT_CLOUD_FRAC',(/'lev'/), 'A', '', 'total cloud fraction')
 
     call add_default('SHOC_TKE', 1, ' ')
     call add_default('WTHV_SEC', 1, ' ')
@@ -434,8 +435,9 @@ end function shoc_implements_cnst
     call add_default('BRUNT',1,' ')
     call add_default('RELVAR',1,' ')
     call add_default('ICE_CLOUD_FRAC',1,' ')
-    call add_default('PRECIP_ICE_FRAC',1,' ')
+    call add_default('PRECIPITATING_ICE_FRAC',1,' ')
     call add_default('LIQ_CLOUD_FRAC',1,' ')
+    call add_default('TOT_CLOUD_FRAC',1,' ')
 
     ! ---------------------------------------------------------------!
     ! Initialize SHOC                                                !
@@ -576,8 +578,9 @@ end function shoc_implements_cnst
    real(r8) :: zi_g(pcols,pverp)
    real(r8) :: cloud_frac(pcols,pver)          ! CLUBB cloud fraction                          [fraction]
    real(r8) :: ice_cloud_frac(pcols,pver)          ! ice number aware cloud fraction, 0 or 1
-   real(r8) :: precip_ice_frac(pcols,pver)        ! precipitating ice fraction, 0 or 1
-   real(r8) :: liq_cloud_frac(pcols,pver)        ! precipitating ice fraction, 0 or 1 
+   real(r8) :: precipitating_ice_frac(pcols,pver)        ! precipitating ice fraction, 0 or 1
+   real(r8) :: liq_cloud_frac(pcols,pver)     
+   real(r8) :: tot_cloud_frac(pcols,pver)         
    real(r8) :: dlf2(pcols,pver)
    real(r8) :: isotropy(pcols,pver)
    real(r8) :: host_dx, host_dy
@@ -1087,7 +1090,8 @@ end function shoc_implements_cnst
 
     liq_cloud_frac = 0.0_r8
     ice_cloud_frac = 0.0_r8
-    precip_ice_frac = 0.0_r8
+    precipitating_ice_frac = 0.0_r8
+    tot_cloud_frac = 0.0_r8
  
     do k=1,pver
       do i=1,ncol
@@ -1097,9 +1101,10 @@ end function shoc_implements_cnst
            if (state1%q(i,k,ixnumice) .ge. state1%q(i,k,ixcldice)*5.0e7_r8) then
               ice_cloud_frac(i,k) = 1.0_r8
            else
-              precip_ice_frac(i,k) = 1.0_r8
+              precipitating_ice_frac(i,k) = 1.0_r8
            endif
         endif
+        tot_cloud_frac(i,k) = min(1.0_r8, max(ice_cloud_frac(i,k),liq_cloud_frac(i,k))+deepcu(i,k))
       enddo
     enddo
    
@@ -1145,8 +1150,9 @@ end function shoc_implements_cnst
     call outfld('RELVAR',relvar,pcols,lchnk)
     call outfld('SHOC_QL',rcm,pcols,lchnk)
     call outfld('ICE_CLOUD_FRAC',ice_cloud_frac,pcols,lchnk)
-    call outfld('PRECIP_ICE_FRAC',precip_ice_frac,pcols,lchnk)
+    call outfld('PRECIPITATING_ICE_FRAC',precipitating_ice_frac,pcols,lchnk)
     call outfld('LIQ_CLOUD_FRAC',liq_cloud_frac,pcols,lchnk)
+    call outfld('TOT_CLOUD_FRAC',tot_cloud_frac,pcols,lchnk)
 
 #endif    
     return         

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -1083,8 +1083,7 @@ end function shoc_implements_cnst
  
     !  Add liq, ice, and precipitating ice fractions here. These are purely
     !  diagnostic outputs and do not impact the rest of the code. The qi threshold for
-    !  setting ice_cloud_fraction to 1 currently set 1e-8 kg/kg but can be
-    !  changed based on what we think is sensible. 
+    !  setting ice_cloud_fraction and the qi dependent ni_threshold are tunable. 
 
     liq_cloud_frac = 0.0_r8
     ice_cloud_frac = 0.0_r8

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -1086,13 +1086,16 @@ end function shoc_implements_cnst
     !  setting ice_cloud_fraction to 1 currently set 1e-8 kg/kg but can be
     !  changed based on what we think is sensible. 
 
+    liq_cloud_frac = 0.0_r8
+    ice_cloud_frac = 0.0_r8
+    precip_ice_frac = 0.0_r8
  
     do k=1,pver
       do i=1,ncol
         cloud_frac(i,k) = min(ast(i,k)+deepcu(i,k),1.0_r8)
         liq_cloud_frac(i,k) = alst(i,k)
         if (state1%q(i,k,ixcldice) .ge. 1.0e-8_r8) then 
-           if (state1%q(i,k,ixnumice) .ge. state1%q(i,k,ixcldice)*1.0e9_r8) then
+           if (state1%q(i,k,ixnumice) .ge. state1%q(i,k,ixcldice)*5.0e7_r8) then
               ice_cloud_frac(i,k) = 1.0_r8
            else
               precip_ice_frac(i,k) = 1.0_r8


### PR DESCRIPTION
PR adds diagnostic output for liquid cloud fraction, ice cloud fraction, and precipitating ice fraction. These new hydrometeor fractions are purely diagnostic and have no impact on internal code calculations.