### PR TITLE
Set topography views inside Homme.

### DIFF
--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -87,10 +87,6 @@ interface
     type (c_ptr) , intent(in) :: phis_ptr, gradphis_ptr
   end subroutine init_geopotential_c
 
-  ! Uses phis to compute gradphis
-  subroutine compute_gradphis_c () bind(c)
-  end subroutine
-
   ! Initializes C++ diagnostics arrays with ptrs provided from f90
   subroutine init_diagnostics_c (elem_state_q_ptr, elem_accum_qvar_ptr, elem_accum_qmass_ptr, &
                                  elem_accum_q1mass_ptr, elem_accum_iener_ptr,                 &

--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -87,6 +87,10 @@ interface
     type (c_ptr) , intent(in) :: phis_ptr, gradphis_ptr
   end subroutine init_geopotential_c
 
+  ! Uses phis to compute gradphis
+  subroutine compute_gradphis_c () bind(c)
+  end subroutine
+
   ! Initializes C++ diagnostics arrays with ptrs provided from f90
   subroutine init_diagnostics_c (elem_state_q_ptr, elem_accum_qvar_ptr, elem_accum_qmass_ptr, &
                                  elem_accum_q1mass_ptr, elem_accum_iener_ptr,                 &

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -576,8 +576,8 @@ create_internal_field (const std::string& name,
   m_internal_fields[name+grid] = f;
 }
 
-Field<Real>& HommeDynamics::
-get_internal_field (const std::string& name, const std::string& grid) {
+const Field<Real>& HommeDynamics::
+get_internal_field (const std::string& name, const std::string& grid) const {
   auto it = m_internal_fields.find(name+grid);
   EKAT_REQUIRE_MSG (it!=m_internal_fields.end(),
       "Error! Internal field '" + name + "' on grid '" + grid + "' not found.\n");

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -45,6 +45,9 @@ public:
   // Note: field_mgrs[grid_name] is the FM on grid $grid_name
   void register_fields (const std::map<std::string,std::shared_ptr<FieldManager<Real>>>& field_mgrs) const;
 
+  // Retrieves an internal field, given field name and grid name.
+  const Field<Real>& get_internal_field (const std::string& name, const std::string& grid) const;
+
 #ifndef KOKKOS_ENABLE_CUDA
   // Cuda requires methods enclosing __device__ lambda's to be public
 protected:
@@ -66,6 +69,7 @@ protected:
   void update_pressure ();
 
   void initialize_impl ();
+
 protected:
   void run_impl        (const int dt);
   void finalize_impl   ();
@@ -88,10 +92,6 @@ protected:
                               const std::vector<FieldTag>& tags,
                               const std::vector<int>& dims,
                               const std::string& grid);
-
-  // Retrieves an internal field, given field name and grid name.
-  Field<Real>& get_internal_field (const std::string& name, const std::string& grid);
-
 
   // Some helper fields. WARNING: only one copy for each internal field!
   std::map<std::string,field_type>  m_internal_fields;

--- a/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -77,9 +77,10 @@ contains
 
   subroutine prim_copy_cxx_to_f90 (copy_phis)
     use iso_c_binding,     only: c_ptr, c_loc
-    use homme_context_mod, only: tl
-    use dimensions_mod,    only: nlevp
-    use theta_f2c_mod,     only: cxx_push_results_to_f90
+    use homme_context_mod, only: tl, elem
+    use dimensions_mod,    only: nlevp, nelemd, np
+    use kinds,             only: real_kind
+    use theta_f2c_mod,     only: cxx_push_results_to_f90, init_geopotential_c, compute_gradphis_c
     use element_state,     only: elem_state_v, elem_state_w_i, elem_state_vtheta_dp,     &
                               elem_state_phinh_i, elem_state_dp3d, elem_state_ps_v,   &
                               elem_state_Qdp, elem_state_Q, elem_derived_omega_p,     &
@@ -94,6 +95,11 @@ contains
     type (c_ptr) :: elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr, elem_state_phinh_i_ptr
     type (c_ptr) :: elem_state_dp3d_ptr, elem_state_Qdp_ptr, elem_state_Q_ptr, elem_state_ps_v_ptr
     type (c_ptr) :: elem_derived_omega_p_ptr
+
+    integer :: ie
+    type (c_ptr) :: elem_state_phis_local_ptr, elem_derived_gradphis_local_ptr
+    real (kind=real_kind), target, dimension(np,np)   :: elem_state_phis_local
+    real (kind=real_kind), target, dimension(np,np,2) :: elem_gradphis_local
     
     ! Set pointers to states
     elem_state_v_ptr         = c_loc(elem_state_v)
@@ -113,6 +119,19 @@ contains
     if (copy_phis) then
       ! Set phis=phi(bottom)
       elem_state_phis(:,:,:) = elem_state_phinh_i(:,:,nlevp,tl%n0,:)
+
+      ! Set geopotential views
+      elem_state_phis_local_ptr       = c_loc(elem_state_phis_local)
+      elem_derived_gradphis_local_ptr = c_loc(elem_gradphis_local)
+      do ie=1,nelemd
+        elem_state_phis_local = elem(ie)%state%phis
+        elem_gradphis_local   = elem(ie)%derived%gradphis
+        call init_geopotential_c (ie-1, elem_state_phis_local_ptr, elem_derived_gradphis_local_ptr)
+      enddo
+
+      ! Calculate gradphis
+      call compute_gradphis_c ()
+
     endif
   end subroutine prim_copy_cxx_to_f90
 

--- a/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -76,15 +76,16 @@ contains
   end subroutine prim_init_data_structures_f90
 
   subroutine prim_copy_cxx_to_f90 (copy_phis)
-    use iso_c_binding,     only: c_ptr, c_loc
-    use homme_context_mod, only: tl, elem
-    use dimensions_mod,    only: nlevp, nelemd, np
-    use kinds,             only: real_kind
-    use theta_f2c_mod,     only: cxx_push_results_to_f90, init_geopotential_c, compute_gradphis_c
-    use element_state,     only: elem_state_v, elem_state_w_i, elem_state_vtheta_dp,     &
-                              elem_state_phinh_i, elem_state_dp3d, elem_state_ps_v,   &
-                              elem_state_Qdp, elem_state_Q, elem_derived_omega_p,     &
-                              elem_state_phis
+    use iso_c_binding,       only: c_ptr, c_loc
+    use homme_context_mod,   only: tl, elem, deriv
+    use dimensions_mod,      only: nlevp, nelemd, np
+    use kinds,               only: real_kind
+    use derivative_mod_base, only: gradient_sphere
+    use theta_f2c_mod,       only: cxx_push_results_to_f90, init_geopotential_c
+    use element_state,       only: elem_state_v, elem_state_w_i, elem_state_vtheta_dp,   &
+                                   elem_state_phinh_i, elem_state_dp3d, elem_state_ps_v, &
+                                   elem_state_Qdp, elem_state_Q, elem_derived_omega_p,   &
+                                   elem_state_phis
     !
     ! Inputs
     !
@@ -126,12 +127,10 @@ contains
       do ie=1,nelemd
         elem_state_phis_local = elem(ie)%state%phis
         elem_gradphis_local   = elem(ie)%derived%gradphis
+
+        elem_gradphis_local = gradient_sphere(elem_state_phis_local, deriv, elem(ie)%Dinv)
         call init_geopotential_c (ie-1, elem_state_phis_local_ptr, elem_derived_gradphis_local_ptr)
       enddo
-
-      ! Calculate gradphis
-      call compute_gradphis_c ()
-
     endif
   end subroutine prim_copy_cxx_to_f90
 

--- a/components/scream/tests/uncoupled/homme/homme_standalone.cpp
+++ b/components/scream/tests/uncoupled/homme/homme_standalone.cpp
@@ -80,7 +80,9 @@ TEST_CASE("scream_homme_standalone", "scream_homme_standalone") {
 
     const auto& atm_process_group = ad.get_atm_processes();
     const auto& process = atm_process_group->get_process(0);
-    const scream::HommeDynamics* homme_process = static_cast<const scream::HommeDynamics*>(&(*process));
+    auto homme_process = std::dynamic_pointer_cast<const HommeDynamics>(process);
+    EKAT_REQUIRE_MSG (process, "Error! Cast to HommeDynamics failed.\n");
+
     const auto phinh_i = homme_process->get_internal_field("phinh_i","Dynamics").get_view<Real*****>();
 
     int nelem = Homme::Context::singleton().get<Homme::ElementsGeometry>().num_elems();

--- a/components/scream/tests/uncoupled/homme/homme_standalone.cpp
+++ b/components/scream/tests/uncoupled/homme/homme_standalone.cpp
@@ -1,6 +1,7 @@
 #include "catch2/catch.hpp"
 
 #include "control/atmosphere_driver.hpp"
+#include "share/atm_process/atmosphere_process_group.hpp"
 #include "dynamics/register_dynamics.hpp"
 #include "dynamics/homme/atmosphere_dynamics.hpp"
 #include "dynamics/homme/dynamics_driven_grids_manager.hpp"
@@ -14,6 +15,9 @@
 // Hommexx includes
 #include "Context.hpp"
 #include "FunctorsBuffersManager.hpp"
+#include "ElementsGeometry.hpp"
+#include "TimeLevel.hpp"
+#include "dynamics/homme/homme_dimensions.hpp"
 
 #include <iomanip>
 
@@ -68,6 +72,29 @@ TEST_CASE("scream_homme_standalone", "scream_homme_standalone") {
 
   // Init, run, and finalize
   ad.initialize(atm_comm,ad_params,t0);
+
+  // Check that topography data from the FM matches Homme.
+  {
+    auto& geo = Homme::Context::singleton().get<Homme::ElementsGeometry>();
+    auto phis = geo.m_phis;
+
+    const auto& atm_process_group = ad.get_atm_processes();
+    const auto& process = atm_process_group->get_process(0);
+    const scream::HommeDynamics* homme_process = static_cast<const scream::HommeDynamics*>(&(*process));
+    const auto phinh_i = homme_process->get_internal_field("phinh_i","Dynamics").get_view<Real*****>();
+
+    int nelem = Homme::Context::singleton().get<Homme::ElementsGeometry>().num_elems();
+    int n0 = Homme::Context::singleton().get<Homme::TimeLevel>().n0;
+    constexpr int NVL = HOMMEXX_NUM_PHYSICAL_LEV;
+
+    Kokkos::parallel_for(Kokkos::RangePolicy<>(0,nelem*NP*NP),
+                         KOKKOS_LAMBDA (const int idx) {
+      const int ie = idx/(NP*NP);
+      const int ip = (idx/NP)%NP;
+      const int jp = idx%NP;
+      EKAT_KERNEL_ASSERT(phinh_i(ie,n0,ip,jp,NVL) == phis(ie,ip,jp));
+    });
+  }
 
   // Add checks to verify AD memory buffer and Homme FunctorsBuffersManager
   // are the same size and reference the same memory.


### PR DESCRIPTION
Set topography views inside Homme. This requires:
1. Linking FM phis to homme elem%state%phis to ElementGeometry::m_phis
2. Calling `compute_gradphis_c()` (which requires adding link in homme/src/theta-l_kokkos/theta_f2c_mod.F90)

Edit: No longer adding anything to Homme. Instead, using `use derivative_mod_base, only: gradient_sphere` to compute `gradphis`