### PR TITLE
Add an aquaplanet compset for SCREAMv0

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -87,6 +87,10 @@
 <ncdata dyn="se" hgrid="ne30np4"  nlev="72"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/homme/cami_aquaplanet_ne30np4_L72_c190215.nc</ncdata>
 <ncdata dyn="se" hgrid="ne45np4"  nlev="72"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/homme/cami_aquaplanet_ne45np4_L72_c20200611.nc</ncdata>
 
+<!-- SCREAM L128 Aquaplanet -->
+<ncdata dyn="se" hgrid="ne4np4"   nlev="128" aquaplanet="1" ic_ymd="101" >atm/cam/inic/homme/cami_aquaplanet_ne4np4_L128_20200204.nc</ncdata>
+<ncdata dyn="se" hgrid="ne30np4"  nlev="128" aquaplanet="1" ic_ymd="101" >atm/cam/inic/homme/cami_aquaplanet_ne30np4_L128_20200207.nc</ncdata>
+
 <!-- E3SM L72 RCE -->
 <ncdata dyn="se" hgrid="ne4np4"   nlev="72"  aquaplanet="1" rce="1" ic_ymd="101" >atm/cam/inic/homme/cami_rcemip_ne4np4_L72_c190919.nc</ncdata>
 <ncdata dyn="se" hgrid="ne30np4"  nlev="72"  aquaplanet="1" rce="1" ic_ymd="101" >atm/cam/inic/homme/cami_rcemip_ne30np4_L72_c190919.nc</ncdata>

--- a/components/eam/bld/namelist_files/use_cases/aquaplanet_SCREAM-HR.xml
+++ b/components/eam/bld/namelist_files/use_cases/aquaplanet_SCREAM-HR.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set Aquaplanet to True -->
+<aqua_planet>.true.</aqua_planet>
+
+<!-- Solar data (insolation of 1365) -->
+<solar_data_file      >atm/cam/solar/ape_solar_ave_tsi_1365.nc </solar_data_file>
+<solar_htng_spctrl_scl>.true. </solar_htng_spctrl_scl>
+<solar_data_type      >FIXED  </solar_data_type>
+
+<!-- 2010 GHG values from CMIP6 input4MIPS -->
+<!-- <co2vmr>312.821e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in
+     cime/src/drivers/mct/cime_config/config_component_acme.xml -->
+<ch4vmr>1807.851e-9</ch4vmr>
+<n2ovmr>323.141e-9</n2ovmr>
+<f11vmr>768.7644e-12</f11vmr>
+<f12vmr>531.2820e-12</f12vmr>
+
+<!-- zonally symmetric prescribed ozone -->
+<prescribed_ozone_type    > CYCLICAL              </prescribed_ozone_type>
+<prescribed_ozone_datapath> atm/cam/ozone         </prescribed_ozone_datapath>
+<prescribed_ozone_file    > apeozone_cam3_5_54.nc </prescribed_ozone_file>
+<prescribed_ozone_name    > OZONE                 </prescribed_ozone_name>
+<prescribed_ozone_cycle_yr> 1990                  </prescribed_ozone_cycle_yr>
+
+<!-- Disable linoz since we want to use prescribed ozone -->
+<linoz_data_file            ></linoz_data_file>
+<linoz_data_path            ></linoz_data_path>
+
+<!-- Mostly non-aquaplanet-specific settings below here -->
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc    >.false.</use_hetfrz_classnuc>
+<use_preexisting_ice    >.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc   >.false.</hist_hetfrz_classnuc>
+
+<!-- For Polar mods-->
+<sscav_tuning            >.true.</sscav_tuning>
+<demott_ice_nuc          >.true.</demott_ice_nuc>
+<liqcf_fix               >.true.</liqcf_fix>
+<regen_fix               >.true.</regen_fix>
+<resus_fix               >.true.</resus_fix>
+<mam_amicphys_optaa      >1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning    >.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.false.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+<cldfrc_dp1>         0.045D0</cldfrc_dp1>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<dust_emis_fact      > 2.05D0    </dust_emis_fact>
+<seasalt_emis_scale  > 0.85      </seasalt_emis_scale>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<effgw_oro>          0.25    </effgw_oro>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<so4_sz_thresh_icenuc  > 0.05e-6   </so4_sz_thresh_icenuc>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<taubgnd                 >2.5D-3 </taubgnd>
+<raytau0                 >5.0D0</raytau0>
+<nucleate_ice_subgrid    >1.2D0</nucleate_ice_subgrid>
+<n_so4_monolayers_pcage  > 8.0D0     </n_so4_monolayers_pcage>
+
+<!-- Parameters specific to deep convection (default off for HR compset) -->
+<deep_scheme             > 'off'  </deep_scheme>
+
+<!-- Macrophysics/microphysics coupling -->
+<cld_macmic_num_steps hgrid="ne4np4"   > 6 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne30np4"  > 6 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne120np4" > 3 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne256np4" > 3 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne512np4" > 1 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne1024np4"> 1 </cld_macmic_num_steps>
+
+<!-- Energy fixer options -->
+<ieflx_opt  > 0     </ieflx_opt>
+
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
+<!-- sim_year used for CLM datasets and SST forcings -->
+<sim_year>2010</sim_year>
+
+<!-- Land datasets set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
+
+<!-- Prescribed aerosol options -->
+<use_hetfrz_classnuc>.false.</use_hetfrz_classnuc>
+<aerodep_flx_type>'CYCLICAL'</aerodep_flx_type>
+<aerodep_flx_datapath>atm/cam/chem/trop_mam/aero</aerodep_flx_datapath>
+<aerodep_flx_file nlev="72">mam4_0.9x1.2_L72_2000clim_c170323.nc</aerodep_flx_file>
+<aerodep_flx_file nlev="128">mam4_0.9x1.2_L128_2000clim_c191106.nc</aerodep_flx_file>
+<aerodep_flx_cycle_yr>01</aerodep_flx_cycle_yr>
+<prescribed_aero_type>'CYCLICAL'</prescribed_aero_type>
+<prescribed_aero_datapath>atm/cam/chem/trop_mam/aero</prescribed_aero_datapath>
+<prescribed_aero_file nlev="72">mam4_0.9x1.2_L72_2000clim_c170323.nc</prescribed_aero_file>
+<prescribed_aero_file nlev="128">mam4_0.9x1.2_L128_2000clim_c191106.nc</prescribed_aero_file>
+<prescribed_aero_cycle_yr>01</prescribed_aero_cycle_yr>
+
+<!-- Do radiation every five minutes for ne1024 -->
+<iradsw hgrid="ne1024np4"> 4 </iradsw>
+<iradlw hgrid="ne1024np4"> 4 </iradlw>
+
+<!-- Settings related to the SCREAM NH dycore -->
+<theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
+<tstep_type> 9 </tstep_type>
+<!-- Settings specific for ne256 configuration -->
+<se_tstep hgrid="ne256np4"> 37.5 </se_tstep>
+<dt_tracer_factor hgrid="ne256np4"> 8 </dt_tracer_factor>
+<hypervis_subcycle_q hgrid="ne256np4"> 8 </hypervis_subcycle_q>
+
+<!-- Use the less sensitive advection scheme -->
+<semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
+
+<!-- Turn off Gravity Waves -->
+<use_gw_front>.false.</use_gw_front>
+<use_gw_oro>.false.</use_gw_oro>
+<use_gw_convect>.false.</use_gw_convect>
+
+</namelist_defaults>

--- a/components/eam/bld/namelist_files/use_cases/aquaplanet_SCREAM-LR.xml
+++ b/components/eam/bld/namelist_files/use_cases/aquaplanet_SCREAM-LR.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set Aquaplanet to True -->
+<aqua_planet>.true.</aqua_planet>
+
+<!-- Solar data (insolation of 1365) -->
+<solar_data_file      >atm/cam/solar/ape_solar_ave_tsi_1365.nc </solar_data_file>
+<solar_htng_spctrl_scl>.true. </solar_htng_spctrl_scl>
+<solar_data_type      >FIXED  </solar_data_type>
+
+<!-- 2010 GHG values from CMIP6 input4MIPS -->
+<!-- <co2vmr>312.821e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in
+     cime/src/drivers/mct/cime_config/config_component_acme.xml -->
+<ch4vmr>1807.851e-9</ch4vmr>
+<n2ovmr>323.141e-9</n2ovmr>
+<f11vmr>768.7644e-12</f11vmr>
+<f12vmr>531.2820e-12</f12vmr>
+
+<!-- zonally symmetric prescribed ozone -->
+<prescribed_ozone_type    > CYCLICAL              </prescribed_ozone_type>
+<prescribed_ozone_datapath> atm/cam/ozone         </prescribed_ozone_datapath>
+<prescribed_ozone_file    > apeozone_cam3_5_54.nc </prescribed_ozone_file>
+<prescribed_ozone_name    > OZONE                 </prescribed_ozone_name>
+<prescribed_ozone_cycle_yr> 1990                  </prescribed_ozone_cycle_yr>
+
+<!-- Disable linoz since we want to use prescribed ozone -->
+<linoz_data_file            ></linoz_data_file>
+<linoz_data_path            ></linoz_data_path>
+
+<!-- Mostly non-aquaplanet-specific settings below here -->
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc    >.false.</use_hetfrz_classnuc>
+<use_preexisting_ice    >.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc   >.false.</hist_hetfrz_classnuc>
+
+<!-- For Polar mods-->
+<sscav_tuning            >.true.</sscav_tuning>
+<convproc_do_aer         >.true.</convproc_do_aer>
+<convproc_do_gas         >.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc          >.true.</demott_ice_nuc>
+<liqcf_fix               >.true.</liqcf_fix>
+<regen_fix               >.true.</regen_fix>
+<resus_fix               >.true.</resus_fix>
+<mam_amicphys_optaa      >1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning    >.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+<cldfrc_dp1>         0.045D0</cldfrc_dp1>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<dust_emis_fact      > 2.05D0    </dust_emis_fact>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<effgw_oro>          0.25    </effgw_oro>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<so4_sz_thresh_icenuc  > 0.05e-6   </so4_sz_thresh_icenuc>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<taubgnd                 >2.5D-3 </taubgnd>
+<raytau0                 >5.0D0</raytau0>
+<prc_exp                 >3.19D0</prc_exp>
+<prc_exp1                >-1.2D0</prc_exp1>
+<nucleate_ice_subgrid    >1.2D0</nucleate_ice_subgrid>
+
+<!-- Parameters specific to deep convection (default off for HR compset) -->
+<deep_scheme             > 'ZM'   </deep_scheme>
+<zmconv_c0_lnd           > 0.007  </zmconv_c0_lnd>
+<zmconv_c0_ocn           > 0.007  </zmconv_c0_ocn>
+<zmconv_dmpdz            >-0.7e-3 </zmconv_dmpdz>
+<zmconv_ke               > 5E-6   </zmconv_ke>
+<zmconv_tiedke_add       > 0.8D0  </zmconv_tiedke_add>
+<zmconv_cape_cin         > 1      </zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   > 2      </zmconv_mx_bot_lyr_adj>
+
+<!-- Macrophysics/microphysics coupling -->
+<cld_macmic_num_steps hgrid="ne4np4"   > 6 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne30np4"  > 6 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne120np4" > 3 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne256np4" > 3 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne512np4" > 1 </cld_macmic_num_steps>
+<cld_macmic_num_steps hgrid="ne1024np4"> 1 </cld_macmic_num_steps>
+
+<!-- SHOC timestep -->
+<shoc_timestep> 150.0D0 </shoc_timestep>
+
+<!-- Energy fixer options -->
+<ieflx_opt  > 0     </ieflx_opt>
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<!-- COPIED FROM "CAM" USE CASE; TODO: IS THIS NECESSARY FOR SCREAM? -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
+<!-- sim_year used for CLM datasets and SST forcings -->
+<sim_year>2015</sim_year>
+
+<!-- Land datasets set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
+
+<!-- Prescribed aerosol options -->
+<use_hetfrz_classnuc>.false.</use_hetfrz_classnuc>
+<aerodep_flx_type>'CYCLICAL'</aerodep_flx_type>
+<aerodep_flx_datapath>atm/cam/chem/trop_mam/aero</aerodep_flx_datapath>
+<aerodep_flx_file nlev="72">mam4_0.9x1.2_L72_2000clim_c170323.nc</aerodep_flx_file>
+<aerodep_flx_file nlev="128">mam4_0.9x1.2_L128_2000clim_c191106.nc</aerodep_flx_file>
+<aerodep_flx_cycle_yr>01</aerodep_flx_cycle_yr>
+<prescribed_aero_type>'CYCLICAL'</prescribed_aero_type>
+<prescribed_aero_datapath>atm/cam/chem/trop_mam/aero</prescribed_aero_datapath>
+<prescribed_aero_file nlev="72">mam4_0.9x1.2_L72_2000clim_c170323.nc</prescribed_aero_file>
+<prescribed_aero_file nlev="128">mam4_0.9x1.2_L128_2000clim_c191106.nc</prescribed_aero_file>
+<prescribed_aero_cycle_yr>01</prescribed_aero_cycle_yr>
+
+<!-- Do radiation every five minutes for ne1024 -->
+<iradsw hgrid="ne1024np4"> 4 </iradsw>
+<iradlw hgrid="ne1024np4"> 4 </iradlw>
+
+<!-- Use the less sensitive advection scheme -->
+<semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>
+
+</namelist_defaults>

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -84,6 +84,7 @@
       <!-- SCREAM configurations -->
       <value compset="_EAM%SCREAM-LR">-phys default -shoc_sgs -microphys p3 -chem spa -nlev 72 -rad rrtmgp -bc_dep_to_snow_updates -cppdefs '-DSCREAM'</value>
       <value compset="_EAM%SCREAM-HR">-phys default -shoc_sgs -microphys p3 -chem spa -nlev 128 -rad rrtmgp -bc_dep_to_snow_updates -cppdefs '-DSCREAM'</value>
+      <value compset="_EAM%SCREAM.*-AQUA">-aquaplanet</value>
 
       <!-- Doubly Periodic SCREAM -->
       <value compset="AR97_EAM%DPSCREAM">-phys default -scam -dpcrm_mode -nlev 72 -shoc_sgs -microphys p3 -rad rrtmgp -chem spa -cppdefs '-DSCREAM'</value>
@@ -142,11 +143,13 @@
       <value compset="AR97_EAM"     >scam_arm97</value>
       <value compset="SCAM_EAM"        >scam_generic</value>
       <value compset="PIPD_EAM"        >1850-PD_cam5</value>
-      <value compset="2010_EAM.*SCREAM-LR" >2010_scream_lr</value>
-      <value compset="2010_EAM.*SCREAM-HR" >2010_scream_hr</value>
-      <value compset="AR97_EAM.*DPSCREAM"  >dpscream_arm97</value>
-      <value compset="2010_EAM.*SCREAM-LR-DYAMOND2" >2010_scream_lr_dyamond2</value>
-      <value compset="2010_EAM.*SCREAM-HR-DYAMOND2" >2010_scream_hr_dyamond2</value>  
+      <value compset="2010_EAM%SCREAM-LR" >2010_scream_lr</value>
+      <value compset="2010_EAM%SCREAM-HR" >2010_scream_hr</value>
+      <value compset="AR97_EAM%DPSCREAM"  >dpscream_arm97</value>
+      <value compset="2010_EAM%SCREAM-LR-DYAMOND2" >2010_scream_lr_dyamond2</value>
+      <value compset="2010_EAM%SCREAM-HR-DYAMOND2" >2010_scream_hr_dyamond2</value>
+      <value compset="_EAM%SCREAM-LR-AQUA">aquaplanet_SCREAM-LR</value>
+      <value compset="_EAM%SCREAM-HR-AQUA">aquaplanet_SCREAM-HR</value>
       <!-- Aqua planet -->
       <value compset="_EAM%AQUA"     >aquaplanet_EAMv1</value>
       <!-- Radiative-Convective Equilibrium (RCE) -->
@@ -231,12 +234,12 @@
     <desc compset="_EAM%MG1M"   >MG1.0 w/ modified activation:</desc>
     <desc compset="_EAM%UNI"    >UNICON (modified mg1.0):</desc>
     <desc compset="EAM.*_BGC%B">EAM prognostic CO2 cycle turned on.</desc>
-    <desc compset="_EAM.*SCREAM-LR-DYAMOND1">Fortran version of SCREAM with SHOC, P3, RRTMGP, and prescribed aerosol. Initialized for DYAMOND1 (2016-08-01).</desc>
-    <desc compset="_EAM.*SCREAM-HR-DYAMOND1">Fortran version of SCREAM with NH dycore, SHOC, P3, RRTMGP, prescribed aerosol, and no deep convection. Initialized for DYAMOND1 (2016-08-01).</desc>
-    <desc compset="_EAM.*SCREAM-LR-DYAMOND2">Fortran version of SCREAM with SHOC, P3, RRTMGP, and prescribed aerosol. Initialized for DYAMOND2 (2020-01-20).</desc>
-    <desc compset="_EAM.*SCREAM-HR-DYAMOND2">Fortran version of SCREAM with NH dycore, SHOC, P3, RRTMGP, prescribed aerosol, and no deep convection. Initialized for DYAMOND2 (2020-01-20).</desc>
-    <desc compset="_EAM.*SCREAM-LR_">Fortran version of SCREAM with SHOC, P3, RRTMGP, and prescribed aerosol.</desc>
-    <desc compset="_EAM.*SCREAM-HR_">Fortran version of SCREAM with NH dycore, SHOC, P3, RRTMGP, prescribed aerosol, and no deep convection.</desc>
+    <desc compset="_EAM%SCREAM-LR-DYAMOND1">Fortran version of SCREAM with SHOC, P3, RRTMGP, and prescribed aerosol. Initialized for DYAMOND1 (2016-08-01).</desc>
+    <desc compset="_EAM%SCREAM-HR-DYAMOND1">Fortran version of SCREAM with NH dycore, SHOC, P3, RRTMGP, prescribed aerosol, and no deep convection. Initialized for DYAMOND1 (2016-08-01).</desc>
+    <desc compset="_EAM%SCREAM-LR-DYAMOND2">Fortran version of SCREAM with SHOC, P3, RRTMGP, and prescribed aerosol. Initialized for DYAMOND2 (2020-01-20).</desc>
+    <desc compset="_EAM%SCREAM-HR-DYAMOND2">Fortran version of SCREAM with NH dycore, SHOC, P3, RRTMGP, prescribed aerosol, and no deep convection. Initialized for DYAMOND2 (2020-01-20).</desc>
+    <desc compset="_EAM%SCREAM-LR_">Fortran version of SCREAM with SHOC, P3, RRTMGP, and prescribed aerosol.</desc>
+    <desc compset="_EAM%SCREAM-HR_">Fortran version of SCREAM with NH dycore, SHOC, P3, RRTMGP, prescribed aerosol, and no deep convection.</desc>
     <!-- MMF / Super-Parameterization -->
     <desc compset="_EAM%MMF1"     >E3SM-MMF (Fortran w/ OpenACC offload),RRTMGP, 1-mom micro, prescribed aerosol</desc>
     <desc compset="_EAM%MMF2-ECPP">E3SM-MMF (Fortran no GPU offload),    RRTMGP, 2-mom micro, prognostic aerosol, ECPP </desc>

--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -132,6 +132,17 @@
   <!-- SCREAM compsets -->
   <!-- *********************************** -->  
   
+  <!-- SCREAM aquaplanet -->
+  <compset>
+    <alias>F-SCREAM-LR-AQP1</alias>
+    <lname>2000_EAM%SCREAM-LR-AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>F-SCREAM-HR-AQP1</alias>
+    <lname>2000_EAM%SCREAM-HR-AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
+  </compset>
+
   <!-- SCREAM compsets with CMIP6 2010 forcings -->
   <compset>
     <alias>F2010-SCREAM-LR</alias>

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -76,6 +76,9 @@ logical :: spectralflux  = .false. ! calculate fluxes (up and down) per band.
 
 logical :: use_rad_dt_cosz  = .false. ! if true, uses the radiation dt for all cosz calculations !BSINGH - Added for solar insolation calc.
 
+! Flag to indicate whether to read optics from spa netcdf file
+! NOTE: added for consistency with RRTMGP; this is non-functioning for RRTMG!
+logical :: do_spa_optics = .false.
 
 character(len=4) :: diag(0:N_DIAG) =(/'    ','_d1 ','_d2 ','_d3 ','_d4 ','_d5 ','_d6 ','_d7 ','_d8 ','_d9 ','_d10'/)
 
@@ -117,7 +120,8 @@ subroutine radiation_readnl(nlfile, dtime_in)
 
    ! Variables defined in namelist
    namelist /radiation_nl/ iradsw, iradlw, irad_always, &
-                           use_rad_dt_cosz, spectralflux
+                           use_rad_dt_cosz, spectralflux, &
+                           do_spa_optics
 
    ! Read the namelist, only if called from master process
    ! TODO: better documentation and cleaner logic here?
@@ -142,7 +146,13 @@ subroutine radiation_readnl(nlfile, dtime_in)
    call mpibcast(irad_always, 1, mpi_integer, mstrid, mpicom, ierr)
    call mpibcast(use_rad_dt_cosz, 1, mpi_logical, mstrid, mpicom, ierr)
    call mpibcast(spectralflux, 1, mpi_logical, mstrid, mpicom, ierr)
+   call mpibcast(do_spa_optics, 1, mpi_logical, mstrid, mpicom, ierr)
 #endif
+
+   ! Make sure nobody tries to use SPA optics with RRTMG
+   if (do_spa_optics) then
+      call endrun(trim(subroutine_name) // ':: SPA optics is not supported with RRTMG')
+   end if
 
    ! Convert iradsw, iradlw and irad_always from hours to timesteps if necessary
    if (present(dtime_in)) then
@@ -363,13 +373,13 @@ end function radiation_nextsw_cday
 
 !================================================================================================
 
-  subroutine radiation_init(phys_state)
+  subroutine radiation_init(phys_state, pbuf)
 !-----------------------------------------------------------------------
 !
 ! Initialize the radiation parameterization, add fields to the history buffer
 ! 
 !-----------------------------------------------------------------------
-    use physics_buffer, only: pbuf_get_index
+    use physics_buffer, only: pbuf_get_index, physics_buffer_desc
     use phys_grid,      only: npchunks, get_ncols_p, chunks, knuhcs, ngcols, dyn_to_latlon_gcol_map
     use cam_history,    only: addfld, horiz_only, add_default
     use constituents,   only: cnst_get_ind
@@ -392,6 +402,7 @@ end function radiation_nextsw_cday
 #endif
 
     type(physics_state), intent(in) :: phys_state(begchunk:endchunk)
+    type(physics_buffer_desc), pointer :: pbuf(:,:)  ! Added for compatibility with SPA
 
     integer :: icall, nmodes
     logical :: active_calls(0:N_DIAG)


### PR DESCRIPTION
This adds two new aquaplanet compsets for SCREAMv0 (F-SCREAM-LR-AQP1 and F-SCREAM-HR-AQP1). Two new use case files were needed to set namelist options, copied largely from the existing EAM use cases for AQP configurations. These compsets are needed to generate initial conditions for SCREAMv1 tests until SCREAMv1 correctly deals with topography, but will be useful in their own right as well. Fixes #878