### PR TITLE
Update the capabilities of SCREAM's scream_input.yaml file

### DIFF
--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -2,9 +2,19 @@
 
 """
 Namelist creator for E3SM's SCREAM component
+
+This script is mostly for processing the scream_input.yaml file.
+
+That file supports some special syntax in addition to basic YAML:
+'${VAR}' will be used to refer to env variables in the CIME case
+
+'<cond : key1 => val1 : key2 => val2 : elseval>' will be used to express conditional
+statements. If cond matches key1, then the expression evaluates to val1; if cond
+matches key2, then the expression evaluates to val2; if it matches neither, then
+the expression evaluates to elseval. The elseval component of this expression is optional.
 """
 
-import os, sys
+import os, sys, re
 from collections import OrderedDict
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","cime")
@@ -20,11 +30,105 @@ from CIME.utils import expect, run_cmd_no_fail, safe_copy, SharedArea
 from CIME.buildnml import create_namelist_infile, parse_input
 
 # SCREAM imports
-from utils import ensure_yaml, multilevel_dict_change
+from utils import ensure_yaml
 ensure_yaml()
 import yaml
 
 logger = logging.getLogger(__name__)
+
+CIME_VAR_RE = re.compile(r'[$][{](\w+)[}]')
+TERN_RE     = re.compile(r'<\s*(\w+)\s*:')
+
+###############################################################################
+def do_cime_vars(entry, case):
+###############################################################################
+    m = CIME_VAR_RE.search(entry)
+    while m:
+        cime_var = m.groups()[0]
+        value = case.get_value(cime_var)
+        expect(value is not None, "Cannot resolve yaml entry {}, CIME has no value for {}".format(entry, cime_var))
+        entry = entry.replace("${{{}}}".format(cime_var), value)
+        m = CIME_VAR_RE.search(entry)
+
+    return entry
+
+###############################################################################
+def do_ternaries(entry, case):
+###############################################################################
+    m = TERN_RE.search(entry)
+    while m:
+        begin_tern_idx, end_cond_idx = m.span()
+        value = m.groups()[0]
+        opens = 1
+        idx = end_cond_idx
+        segments = [""]
+        for idx in range(end_cond_idx, len(entry)):
+            if entry[idx] == "<":
+                opens += 1
+            elif entry[idx] == ">" and entry[idx-1] != "=":
+                opens -= 1
+                if opens == 0:
+                    break
+
+            if entry[idx] == ":" and opens == 1:
+                segments.append("")
+            else:
+                segments[-1] += entry[idx]
+
+        expect(idx < len(entry), "Ternary parse error in string '{}'".format(entry))
+        end_tern_idx = idx + 1
+        best_val = None
+        for segment in segments:
+            components = segment.split("=>", 1)
+            if (len(components) == 1 or '<' in components[0]):
+                if best_val is None:
+                    best_val = do_ternaries(segment, case).strip()
+            else:
+                compare = re.compile(components[0].strip())
+                if compare.match(value):
+                    best_val = do_ternaries(components[-1], case).strip()
+                    break
+
+        expect(best_val is not None, "Couldn't resolve ternary for '{}', no matches".format(entry))
+
+        entry = entry[0:begin_tern_idx] + best_val + entry[end_tern_idx:]
+        m = TERN_RE.search(entry)
+
+    return entry
+
+###############################################################################
+def refine_type(entry):
+###############################################################################
+    try:
+        v = int(entry)
+        return v
+    except ValueError:
+        pass
+
+    try:
+        v = float(entry)
+        return v
+    except ValueError:
+        return entry
+
+###############################################################################
+def process_leaves(yaml_entry, case):
+###############################################################################
+    modified = False
+    for k, v in yaml_entry.items():
+        if isinstance(v, str):
+            orig_str = v
+            v = do_cime_vars(v, case)
+            v = do_ternaries(v, case)
+            if v != orig_str:
+                v = refine_type(v)
+                modified = True
+                yaml_entry[k] = v
+
+        elif isinstance(v, dict):
+            modified |= process_leaves(v, case)
+
+    return modified
 
 ###############################################################################
 def load_comments(filepath):
@@ -137,13 +241,6 @@ def buildnml(case, caseroot, compname):
     src      = os.path.join(case.get_value("SRCROOT"), "components/scream/data")
     yaml_tgt = os.path.join(target, "scream_input.yaml")
 
-    # Specify yaml input changes that are driven by case env
-    # maps key-tuple to case env name to lookup
-    yaml_changes = {
-        ("SCREAM", "Start Date"): "RUN_STARTDATE",
-        ("SCREAM", "Input Files", "input_root"): "DIN_LOC_ROOT"
-    }
-
     # Copy scream/data to rundir/data
     with SharedArea():
         if not os.path.isdir(target):
@@ -159,12 +256,7 @@ def buildnml(case, caseroot, compname):
     comments = load_comments(yaml_tgt)
     scream_input = ordered_load(yaml_tgt)
 
-    # Change yaml values based on case env
-    modified = False
-    for keys, envname in yaml_changes.items():
-        envval = case.get_value(envname)
-        expect("\n" not in envval, "Multiline env vals breaks us")
-        modified |= multilevel_dict_change(scream_input, keys, envval)
+    modified = process_leaves(scream_input, case)
 
     # If we have to re-dump the YAML file due to CIME case updates,
     # we need to also restore the original comments.

--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -8,10 +8,20 @@ This script is mostly for processing the scream_input.yaml file.
 That file supports some special syntax in addition to basic YAML:
 '${VAR}' will be used to refer to env variables in the CIME case
 
-'<cond : key1 => val1 : key2 => val2 : elseval>' will be used to express conditional
-statements. If cond matches key1, then the expression evaluates to val1; if cond
+'<switch_val : key1 => val1 : key2 => val2 : elseval>' will be used to express conditional
+statements. If switch_val matches key1, then the expression evaluates to val1; if switch_val
 matches key2, then the expression evaluates to val2; if it matches neither, then
 the expression evaluates to elseval. The elseval component of this expression is optional.
+
+Example, if you wanted tstep to depend on atm grid resolution:
+
+  tstep: "<${ATM_GRID} : ne4np4 => 300 : 30>"
+
+This would give all ne4 cases a timestep of 300, otherwise it would be 30.
+
+You could specify multiple grid->timestep relationships this way:
+
+  tstep: "<${ATM_GRID} : ne4np4 => 300 : ne30np4 => 100 : 30>"
 """
 
 import os, sys, re
@@ -37,7 +47,7 @@ import yaml
 logger = logging.getLogger(__name__)
 
 CIME_VAR_RE = re.compile(r'[$][{](\w+)[}]')
-TERN_RE     = re.compile(r'<\s*(\w+)\s*:')
+SWITCH_RE   = re.compile(r'<\s*(\w+)\s*:')
 
 ###############################################################################
 def do_cime_vars(entry, case):
@@ -53,11 +63,11 @@ def do_cime_vars(entry, case):
     return entry
 
 ###############################################################################
-def do_ternaries(entry, case):
+def do_switches(entry, case):
 ###############################################################################
-    m = TERN_RE.search(entry)
+    m = SWITCH_RE.search(entry)
     while m:
-        begin_tern_idx, end_cond_idx = m.span()
+        begin_switch_idx, end_cond_idx = m.span()
         value = m.groups()[0]
         opens = 1
         idx = end_cond_idx
@@ -75,24 +85,24 @@ def do_ternaries(entry, case):
             else:
                 segments[-1] += entry[idx]
 
-        expect(idx < len(entry), "Ternary parse error in string '{}'".format(entry))
-        end_tern_idx = idx + 1
+        expect(idx < len(entry), "Switch statement parse error in string '{}'".format(entry))
+        end_switch_idx = idx + 1
         best_val = None
         for segment in segments:
             components = segment.split("=>", 1)
             if (len(components) == 1 or '<' in components[0]):
                 if best_val is None:
-                    best_val = do_ternaries(segment, case).strip()
+                    best_val = do_switches(segment, case).strip()
             else:
                 compare = re.compile(components[0].strip())
                 if compare.match(value):
-                    best_val = do_ternaries(components[-1], case).strip()
+                    best_val = do_switches(components[-1], case).strip()
                     break
 
-        expect(best_val is not None, "Couldn't resolve ternary for '{}', no matches".format(entry))
+        expect(best_val is not None, "Couldn't resolve switch statement for '{}', no matches".format(entry))
 
-        entry = entry[0:begin_tern_idx] + best_val + entry[end_tern_idx:]
-        m = TERN_RE.search(entry)
+        entry = entry[0:begin_switch_idx] + best_val + entry[end_switch_idx:]
+        m = SWITCH_RE.search(entry)
 
     return entry
 
@@ -119,7 +129,7 @@ def process_leaves(yaml_entry, case):
         if isinstance(v, str):
             orig_str = v
             v = do_cime_vars(v, case)
-            v = do_ternaries(v, case)
+            v = do_switches(v, case)
             if v != orig_str:
                 v = refine_type(v)
                 modified = True

--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -55,8 +55,6 @@ SCREAM:
     input_root                  : "${DIN_LOC_ROOT}"
 
 
-  Test Var: "<${ATM_GRID} : ne4np4 => 42 : 420>"
-
 # Note: HOMME settings will be translated into data/namelist.nl
 HOMME:
   ctl_nl:

--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -49,11 +49,13 @@ Atmosphere Driver:
 
 SCREAM:
 
-  Start Date: 01-01-2000 # For CIME cases, do NOT set this! It will be set by CIME's RUN_STARTDATE
+  Start Date: "${RUN_STARTDATE}"
 
   Input Files:
-    input_root                  : default # this will default to DIN_LOC_ROOT for the current machine
+    input_root                  : "${DIN_LOC_ROOT}"
 
+
+  Test Var: "<${ATM_GRID} : ne4np4 => 42 : 420>"
 
 # Note: HOMME settings will be translated into data/namelist.nl
 HOMME:

--- a/components/scream/scripts/utils.py
+++ b/components/scream/scripts/utils.py
@@ -368,24 +368,3 @@ def _ensure_pylib_impl(libname, min_version=None, pip_libname=None):
 def ensure_yaml():   _ensure_pylib_impl("yaml", pip_libname="pyyaml",min_version='5.1')
 def ensure_pylint(): _ensure_pylib_impl("pylint")
 def ensure_psutil(): _ensure_pylib_impl("psutil")
-
-###############################################################################
-def multilevel_dict_change(ml_dict, keys, value):
-###############################################################################
-    """
-    Change an existing value in a multi-level dict (expects all keys to already
-    be in dict). Returns True if dict was modified
-    """
-    num_keys = len(keys)
-    modified = False
-    for idx, key in enumerate(keys):
-        expect(key in ml_dict, "No key {} in {}-th level of ml_dict {}".format(key, idx, ml_dict))
-        if idx == num_keys-1:
-            # Last key
-            if ml_dict[key] != value:
-                ml_dict[key] = value
-                modified = True
-        else:
-            ml_dict = ml_dict[key]
-
-    return modified


### PR DESCRIPTION
We add some customized syntax to increase the expressiveness
of the items in this file:

'${VAR}' will be used to refer to env variables in the CIME case

'<cond : key1 => val1 : key2 => val2 : elseval>' will be used to express conditional
statements. If cond matches key1, then the expression evaluates to val1; if cond
matches key2, then the expression evaluates to val2; if it matches neither, then
the expression evaluates to elseval. The elseval component of this expression is optional.

This should give SCREAM the ability to express what it needs in this file
without having to resort to lots of hardcoded special handling.