### PR TITLE
This commit is a quick bugfix to an issue that was causing the SCREAMv1

### DIFF
--- a/components/scream/src/mct_coupling/CMakeLists.txt
+++ b/components/scream/src/mct_coupling/CMakeLists.txt
@@ -39,6 +39,7 @@ set (SCREAM_LIBS
      shoc
      scream_rrtmgp
      cld_fraction
+     spa
 )
 
 include (tpls/Mct)


### PR DESCRIPTION
CIME based run to fail.  A previous commit changed the `register_physics.hpp`
header which meant that all functions that used that header needed to load
the spa library.  That PR forgot to fix the `mct_coupling` application.