### PR TITLE
Update SHOC default tunable parameters

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -792,9 +792,9 @@
 <do_shoc_sgs                 > .false. </do_shoc_sgs>
 <do_shoc_sgs   shoc_sgs="1"  > .true. </do_shoc_sgs>
 <shoc_timestep               > -1 </shoc_timestep>
-<shoc_thl2tune               > 0.15D0 </shoc_thl2tune>
-<shoc_qw2tune                > 0.15D0 </shoc_qw2tune>
-<shoc_qwthl2tune             > 0.15D0 </shoc_qwthl2tune>
+<shoc_thl2tune               > 1.0D0 </shoc_thl2tune>
+<shoc_qw2tune                > 1.0D0 </shoc_qw2tune>
+<shoc_qwthl2tune             > 1.0D0 </shoc_qwthl2tune>
 <shoc_w2tune                 > 1.0D0 </shoc_w2tune>
 <shoc_length_fac             > 0.5D0 </shoc_length_fac>
 <shoc_c_diag_3rd_mom         > 7.0D0 </shoc_c_diag_3rd_mom>
@@ -806,8 +806,8 @@
 <shoc_Ckm                    > 0.1D0 </shoc_Ckm>
 <shoc_Ckh_s_min              > 0.1D0 </shoc_Ckh_s_min>
 <shoc_Ckm_s_min              > 0.1D0 </shoc_Ckm_s_min>
-<shoc_Ckh_s_max              > 1.0D0 </shoc_Ckh_s_max>
-<shoc_Ckm_s_max              > 1.0D0 </shoc_Ckm_s_max>
+<shoc_Ckh_s_max              > 0.1D0 </shoc_Ckh_s_max>
+<shoc_Ckm_s_max              > 0.1D0 </shoc_Ckm_s_max>
 
 <!-- CLUBB options -->
 <clubb_rainevap_turb                              > .false. </clubb_rainevap_turb>

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -53,9 +53,9 @@ real(rtype) :: vk    ! von karmann constant [-]
 
 ! Set default values, if not overwritten by namelist.
 !  All are unitless (unless units are stated)
-real(rtype) :: thl2tune = 0.15_rtype ! Temperature variance tuning factor
-real(rtype) :: qw2tune = 0.15_rtype ! Moisture variance tuning factor
-real(rtype) :: qwthl2tune = 0.15_rtype ! Temperature moisture covariance
+real(rtype) :: thl2tune = 1.0_rtype ! Temperature variance tuning factor
+real(rtype) :: qw2tune = 1.0_rtype ! Moisture variance tuning factor
+real(rtype) :: qwthl2tune = 1.0_rtype ! Temperature moisture covariance
 real(rtype) :: w2tune = 1.0_rtype ! Vertical velocity variance
 real(rtype) :: length_fac = 0.5_rtype ! Length scale factor
 real(rtype) :: c_diag_3rd_mom = 7.0_rtype ! w3 factor
@@ -67,8 +67,8 @@ real(rtype) :: Ckh = 0.1_rtype ! Eddy diffusivity coefficient for heat
 real(rtype) :: Ckm = 0.1_rtype ! Eddy diffusivity coefficient for momentum
 real(rtype) :: Ckh_s_min = 0.1_rtype ! Stable PBL diffusivity minimum for heat
 real(rtype) :: Ckm_s_min = 0.1_rtype ! Stable PBL diffusivity minimum for momentum
-real(rtype) :: Ckh_s_max = 1.0_rtype ! Stable PBL diffusivity maximum for heat
-real(rtype) :: Ckm_s_max = 1.0_rtype ! Stable PBL diffusivity maximum for momentum
+real(rtype) :: Ckh_s_max = 0.1_rtype ! Stable PBL diffusivity maximum for heat
+real(rtype) :: Ckm_s_max = 0.1_rtype ! Stable PBL diffusivity maximum for momentum
 
 !=========================================================
 ! Private module parameters

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -2864,6 +2864,13 @@ subroutine shoc_assumed_pdf_compute_s(&
       qn=s
     endif
   endif
+  
+  ! Prevent possibility of empty clouds or rare occurence of 
+  !  cloud liquid less than zero
+  if (qn .le. 0._rtype) then
+    C=0._rtype
+    qn=0._rtype
+  endif
 
 end subroutine shoc_assumed_pdf_compute_s
 

--- a/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
@@ -282,6 +282,12 @@ void Functions<S,D>::shoc_assumed_pdf(
           qn1.set(std_s1_C1_not_small, s1*C1+(std_s1/sqrt2pi)*ekat::exp(-sp(0.5)*ekat::square(s1/std_s1)));
         }
         qn1.set(!std_s1_not_small && s1 > 0, s1);
+        
+        // Checking to prevent empty clouds
+        const auto qn1_le_zero = qn1 <= 0;
+        C1.set(qn1_le_zero,0);
+        qn1.set(qn1_le_zero,0);
+        
         ql1 = ekat::min(qn1, qw1_1);
 
         // Second plume
@@ -317,6 +323,11 @@ void Functions<S,D>::shoc_assumed_pdf(
           }
           qn2.set(nequal && !std_s2_not_small && s2 > 0, s2);
         }
+        
+        // Checking to prevent empty clouds
+        const auto qn2_le_zero = qn2 <= 0;
+        C2.set(qn2_le_zero,0);
+        qn2.set(qn2_le_zero,0);
 
         ql2 = ekat::min(qn2, qw1_2);
       }

--- a/components/scream/src/physics/shoc/shoc_diag_second_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_second_moments_impl.hpp
@@ -31,13 +31,13 @@ void Functions<S,D>::diag_second_moments(
   //  u, v, TKE, and tracers are computed here as well as the
   //  correlation of qw and thetal.
 
-  const auto thl2tune = 0.15;
+  const auto thl2tune = 1.0;
 
   // moisture variance
-  const auto qw2tune = 0.15;
+  const auto qw2tune = 1.0;
 
   // temp moisture covariance
-  const auto qwthl2tune = 0.15;
+  const auto qwthl2tune = 1.0;
 
   // vertical velocity variance
   const auto w2tune = 1;

--- a/components/scream/src/physics/shoc/shoc_diag_second_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_second_moments_impl.hpp
@@ -31,13 +31,13 @@ void Functions<S,D>::diag_second_moments(
   //  u, v, TKE, and tracers are computed here as well as the
   //  correlation of qw and thetal.
 
-  const auto thl2tune = 1.0;
+  const auto thl2tune = 1;
 
   // moisture variance
-  const auto qw2tune = 1.0;
+  const auto qw2tune = 1;
 
   // temp moisture covariance
-  const auto qwthl2tune = 1.0;
+  const auto qwthl2tune = 1;
 
   // vertical velocity variance
   const auto w2tune = 1;

--- a/components/scream/src/physics/shoc/shoc_eddy_diffusivities_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_eddy_diffusivities_impl.hpp
@@ -38,8 +38,8 @@ void Functions<S,D>::eddy_diffusivities(
   const Scalar Ckh = 0.1;
   const Scalar Ckm = 0.1;
   // Maximum eddy coefficients for stable PBL diffusivities
-  const Scalar Ckh_s_max = 1;
-  const Scalar Ckm_s_max = 1;
+  const Scalar Ckh_s_max = 0.1;
+  const Scalar Ckm_s_max = 0.1;
   // Minimum allowable value for stability diffusivities
   const Scalar Ckh_s_min = 0.1;
   const Scalar Ckm_s_min = 0.1;


### PR DESCRIPTION
This PR updates certain SHOC tunable parameters to their optimal/intended values.  Specifically:

- SHOC scalar variances tunable parameters are now set to 1.0
- SHOC stable boundary layer diffusivities are now set 0.1 (these were the values that were used for the DYAMOND 2 run in Caldwell et al. 2021 but they were never updated in master).

F90 and C++ codes have both been updated to reflect this.

This PR will change answers, therefore SHOC run and compare tests (F90 and C++) are expected fails.