### PR TITLE
Update SCREAM CreateUnitTest functions

### DIFF
--- a/components/scream/tests/generic/infra/CMakeLists.txt
+++ b/components/scream/tests/generic/infra/CMakeLists.txt
@@ -6,14 +6,16 @@ set(NEED_LIBS ekat scream_share)
 CreateUnitTest(fake_test "fake_test.cpp" "${NEED_LIBS}")
 
 if (SCREAM_TEST_MAX_TOTAL_THREADS GREATER_EQUAL 16)
-  CreateUnitTest(resource_spread_thread "resource_spread.cpp" "${NEED_LIBS}"
+  CreateUnitTestExec("resource_spread" "resource_spread.cpp" "${NEED_LIBS}")
+
+  CreateUnitTestFromExec("resource_spread_thread" "resource_spread"
     PRINT_OMP_AFFINITY
     THREADS 1 4 1
     MPI_RANKS 4)
 
-  CreateUnitTest(resource_spread_rank "" ""
-    TEST_EXE resource_spread_thread
+  CreateUnitTestFromExec("resource_spread_rank" "resource_spread"
     PRINT_OMP_AFFINITY
     THREADS 4
     MPI_RANKS 1 4 1)
+
 endif()


### PR DESCRIPTION
Needed to be refactored along similar lines as the recent
EkatCreateUnitTest function refactors.

This EKAT update contains changes to test-launcher that should fix testing on LLNL machines syrah and quartz.