### PR TITLE
SCREAM: add minor capability to populate-nc-file script

### DIFF
--- a/components/scream/scripts/populate-nc-file
+++ b/components/scream/scripts/populate-nc-file
@@ -66,6 +66,10 @@ OR
     parser.add_argument("-o","--overwrite", action="store_true", default=False,
                         help="Overwrite possibly existing variable values")
 
+    # Dimensions addition
+    parser.add_argument("-adims","--add-dimensions",nargs='+', default=[],
+                        help="Add dimensions, if not already existing")
+
     # Variables addition/manipulation
     parser.add_argument("-avars","--add-variables",nargs='+', default=[],
                         help="Add variables with given dimension, setting them to 0 everywhere")


### PR DESCRIPTION
NCO manipulation of nc files can remove dimensions if no variables depend on them. This feature allows to add dims back.

No testing, since these scripts are not used by scream (they're just for convenience).