### PR TITLE
SHOC surface sensible heat flux fix

### DIFF
--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -607,6 +607,7 @@ end function shoc_implements_cnst
    real(r8) :: minqn, rrho(pcols,pver), rrho_i(pcols,pverp)    ! minimum total cloud liquid + ice threshold    [kg/kg]
    real(r8) :: cldthresh, frac_limit
    real(r8) :: ic_limit, dum1
+   real(r8) :: inv_exner_surf
  
    real(r8) :: wpthlp_sfc(pcols), wprtp_sfc(pcols), upwp_sfc(pcols), vpwp_sfc(pcols)
    real(r8) :: wtracer_sfc(pcols,edsclr_dim)
@@ -816,9 +817,13 @@ end function shoc_implements_cnst
                       rrho_i(:ncol,:pverp),pver,pverp,ncol,0._r8)
 
    do i=1,ncol
-      !  Surface fluxes provided by host model
+      !  Compute inverse of exner function at surface
+      inv_exner_surf = 1._r8/((state1%pint(i,pverp)/p0_shoc)**(rair/cpair))
 
+      !  Surface fluxes provided by host model
       wpthlp_sfc(i) = cam_in%shf(i)/(cpair*rrho_i(i,pverp))       ! Sensible heat flux
+      wpthlp_sfc(i) = wpthlp_sfc(i)*inv_exner_surf
+
       wprtp_sfc(i)  = cam_in%cflx(i,1)/(rrho_i(i,pverp))      ! Latent heat flux
       upwp_sfc(i)   = cam_in%wsx(i)/rrho_i(i,pverp)               ! Surface meridional momentum flux
       vpwp_sfc(i)   = cam_in%wsy(i)/rrho_i(i,pverp)               ! Surface zonal momentum flux  

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -247,6 +247,7 @@ void SHOCMacrophysics::initialize_impl ()
   //       variables a local view is constructed.
   const auto& T_mid            = get_field_out("T_mid").get_view<Spack**>();
   const auto& p_mid            = get_field_in("p_mid").get_view<const Spack**>();
+  const auto& p_int            = get_field_in("p_int").get_view<const Spack**>();
   const auto& pseudo_density   = get_field_in("pseudo_density").get_view<const Spack**>();
   const auto& omega            = get_field_in("omega").get_view<const Spack**>();
   const auto& surf_sens_flux   = get_field_in("surf_sens_flux").get_view<const Real*>();
@@ -287,7 +288,7 @@ void SHOCMacrophysics::initialize_impl ()
   const Real z_surf = 0.0;
 
   shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,z_surf,m_cell_area,
-                                T_mid,p_mid,pseudo_density,omega,phis,surf_sens_flux,surf_latent_flux,
+                                T_mid,p_mid,p_int,pseudo_density,omega,phis,surf_sens_flux,surf_latent_flux,
                                 surf_mom_flux,qv,qc,tke,tke_copy,z_mid,z_int,cell_length,
                                 dse,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
                                 wtracer_sfc,wm_zt,inv_exner,thlm,qw);

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -299,7 +299,7 @@ void SHOCMacrophysics::initialize_impl ()
   input.zt_grid     = shoc_preprocess.zt_grid;
   input.zi_grid     = shoc_preprocess.zi_grid;
   input.pres        = p_mid;
-  input.presi       = get_field_in("p_int").get_view<const Spack**>();
+  input.presi       = p_int;
   input.pdel        = pseudo_density;
   input.thv         = shoc_preprocess.thv;
   input.w_field     = shoc_preprocess.wm_zt;

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -162,11 +162,11 @@ public:
       const auto& exner_int = PF::exner_function(p_int(i,nlevi_v)[nlevi_p]);
       const auto& inv_exner_int_surf = 1/exner_int;
 
-      wpthlp_sfc(i) = surf_sens_flux(i)/(cpair*rrho_i(i,nlev_v)[nlev_p]);
+      wpthlp_sfc(i) = surf_sens_flux(i)/(cpair*rrho_i(i,nlevi_v)[nlevi_p]);
       wpthlp_sfc(i) = wpthlp_sfc(i)*inv_exner_int_surf;
-      wprtp_sfc(i)  = surf_latent_flux(i)/rrho_i(i,nlev_v)[nlev_p];
-      upwp_sfc(i)   = surf_mom_flux(i,0)/rrho_i(i,nlev_v)[nlev_p];
-      vpwp_sfc(i)   = surf_mom_flux(i,1)/rrho_i(i,nlev_v)[nlev_p];
+      wprtp_sfc(i)  = surf_latent_flux(i)/rrho_i(i,nlevi_v)[nlevi_p];
+      upwp_sfc(i)   = surf_mom_flux(i,0)/rrho_i(i,nlevi_v)[nlevi_p];
+      vpwp_sfc(i)   = surf_mom_flux(i,1)/rrho_i(i,nlevi_v)[nlevi_p];
 
       const int num_qtracer_packs = ekat::npack<Spack>(num_qtracers);
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, num_qtracer_packs), [&] (const Int& q) {

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -159,7 +159,11 @@ public:
 
       const int nlev_v = (nlev-1)/Spack::n;
       const int nlev_p = (nlev-1)%Spack::n;
+      const auto& exner_int = PF::exner_function(p_int(i,nlevi_v)[nlevi_p]);
+      const auto& inv_exner_int_surf = 1/exner_int;
+
       wpthlp_sfc(i) = surf_sens_flux(i)/(cpair*rrho_i(i,nlev_v)[nlev_p]);
+      wpthlp_sfc(i) = wpthlp_sfc(i)*inv_exner_int_surf;
       wprtp_sfc(i)  = surf_latent_flux(i)/rrho_i(i,nlev_v)[nlev_p];
       upwp_sfc(i)   = surf_mom_flux(i,0)/rrho_i(i,nlev_v)[nlev_p];
       vpwp_sfc(i)   = surf_mom_flux(i,1)/rrho_i(i,nlev_v)[nlev_p];
@@ -176,6 +180,7 @@ public:
     view_1d_const        area;
     view_2d_const        T_mid;
     view_2d_const        p_mid;
+    view_2d_const        p_int;
     view_2d_const        pseudo_density;
     view_2d_const        omega;
     view_1d_const        phis;
@@ -210,7 +215,7 @@ public:
     // Assigning local variables
     void set_variables(const int ncol_, const int nlev_, const int num_qtracers_, const Real z_surf_,
                        const view_1d_const& area_,
-                       const view_2d_const& T_mid_, const view_2d_const& p_mid_, const view_2d_const& pseudo_density_,
+                       const view_2d_const& T_mid_, const view_2d_const& p_mid_, const view_2d_const& p_int_, const view_2d_const& pseudo_density_,
                        const view_2d_const& omega_,
                        const view_1d_const& phis_, const view_1d_const& surf_sens_flux_, const view_1d_const& surf_latent_flux_,
                        const sview_2d_const& surf_mom_flux_,
@@ -231,6 +236,7 @@ public:
       area = area_;
       T_mid = T_mid_;
       p_mid = p_mid_;
+      p_int = p_int_;
       pseudo_density = pseudo_density_;
       omega = omega_;
       phis = phis_;


### PR DESCRIPTION
Takes into account exner function when passing surface sensible heat flux to SHOC.  PR is answer changing.  However, all tests pass because the SHOC interface is NOT exercised in the SHOC run and compare tests.

Also this PR closes #1333 