### PR TITLE
SCREAM: bug fix in column ops packed scan sum

### DIFF
--- a/components/scream/src/share/util/scream_column_ops.hpp
+++ b/components/scream/src/share/util/scream_column_ops.hpp
@@ -475,7 +475,7 @@ protected:
           }
           x_i(k)[0] = s;
 
-          const auto this_pack_end = pack_info::vec_end(num_mid_levels,k);
+          const auto this_pack_end = pack_info::vec_end(num_mid_levels+1,k);
           for (int i=1; i<this_pack_end; ++i) {
             x_i(k)[i] = x_i(k)[i-1] + dx_m(k)[i-1];
           }


### PR DESCRIPTION
The packed version of scan sum had a bug in the case where the number of packs is the same for both midpoints and interface quantities (e.g., 72 levels with packsize 16, yields 5 packs for both mid/int quantities).

Thanks @brhillman and @AaronDonahue for spotting this issue!