### PR TITLE
DP-SCREAM mpi communicator for Data ocean initialization fix

### DIFF
--- a/share/util/shr_scam_mod.F90
+++ b/share/util/shr_scam_mod.F90
@@ -712,7 +712,7 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, scm_multcols, scm_nx, scm_ny, &
       end do
       close( unitn )
       call shr_file_freeUnit(unitn)
-      call shr_strdata_readnml(SCAMSDAT,'docn_in')
+      call shr_strdata_readnml(SCAMSDAT,'docn_in',mpicom=ocn_mpicom)
       call shr_dmodel_readgrid(SCAMSDAT%grid,SCAMSDAT%gsmap,SCAMSDAT%nxg,SCAMSDAT%nyg,SCAMSDAT%nzg, &
            SCAMSDAT%domainfile, ocn_compid, ocn_mpicom, '2d1d', readfrac=.true., &
            scmmode=.true.,scm_multcols=scm_multcols,scmlon=scmlon,scmlat=scmlat, &


### PR DESCRIPTION
Add mpi rank when reading in data ocean namelist to prevent it for doing this for all processes.  This fix does not change the solution, but prevents the log files from being inundated by lots of messages when many processors are used.  Previously only the SCM (which always uses one processor) only used this code so the communicator was not included for this call.