### PR TITLE
Update YAKL and RRTMGP to fix memory leak on GPU

### DIFF
--- a/components/scream/src/physics/rrtmgp/mo_garand_atmos_io.h
+++ b/components/scream/src/physics/rrtmgp/mo_garand_atmos_io.h
@@ -3,7 +3,6 @@
 
 #include "cpp/rrtmgp_const.h"
 #include "cpp/rrtmgp/mo_gas_concentrations.h"
-
 #include "YAKL/YAKL.h"
 
 void read_atmos(std::string input_file, real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -6,7 +6,6 @@
 #include "cpp/extensions/cloud_optics/mo_cloud_optics.h"
 #include "cpp/rte/mo_rte_sw.h"
 #include "cpp/rte/mo_rte_lw.h"
-#include "cpp/rrtmgp_const.h"
 
 namespace scream {
     namespace rrtmgp {


### PR DESCRIPTION
The YAKL pool allocator had a bug that resulted in a memory leak when running on GPUs. This updates to the latest YAKL, which includes a fix for this. RRTMGP is also updated because the YAKL API is changed. This removes the requirement to export `GATOR_DISABLE=1` when running on summit.