### PR TITLE
Reset default cosp_ncolumns to 10

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -915,6 +915,12 @@ if ($rad_pkg eq 'rrtmg' or $chem =~ /waccm_mozart/) {
 # COSP simulator
 if ($cfg->get('cosp')) {
     add_default($nl, 'docosp', 'val'=>'.true.');
+
+    # following serves to always set a default when no matching value found in  namelist_defaults_eam.xml
+    my $val = undef;
+    $val = get_default_value('cosp_ncolumns');
+    $val = 50 if (! defined($val) );
+    add_default($nl, 'cosp_ncolumns','val'=>"$val");
 }
 
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1804,5 +1804,6 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <so4_sz_thresh_icenuc phys="default"> 0.080e-6   </so4_sz_thresh_icenuc>
 <micro_mg_berg_eff_factor phys="default" clubb_sgs="1"> 0.7D0      </micro_mg_berg_eff_factor>
 <cldfrc_dp1  phys="default"> 0.018D0    </cldfrc_dp1>
+<cosp_ncolumns phys="default" hgrid="ne1024np4"> 10 </cosp_ncolumns>
 
 </namelist_defaults>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1804,6 +1804,6 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <so4_sz_thresh_icenuc phys="default"> 0.080e-6   </so4_sz_thresh_icenuc>
 <micro_mg_berg_eff_factor phys="default" clubb_sgs="1"> 0.7D0      </micro_mg_berg_eff_factor>
 <cldfrc_dp1  phys="default"> 0.018D0    </cldfrc_dp1>
-<cosp_ncolumns phys="default" hgrid="ne1024np4"> 10 </cosp_ncolumns>
+<cosp_ncolumns phys="default"> 10 </cosp_ncolumns>
 
 </namelist_defaults>


### PR DESCRIPTION
The hardwired default for cosp_ncolumns is 50. This PR resets it to
10 in namelist_defaults_eam.xml, and the new default is grid 
independent for all config with phys='default'. When cosp_lite is true,
cosp_ncolumns is always set to 10. cosp_ncolumns is also set to 10 when
any of the following is true: cosp_passive, cosp_active, cosp_isccp,
and cosp_amwg. Note that setting cosp_lisccp_sim = .true. does not lead to
cosp_isccp = .true. during runtime. But it does serve to set lisccp_sim to
true, which is the actual control for everything regarding the ISCCP simulator.

[BFB] would impact cosp output for simulations that not effectively 
set default to 10, for example, when not using cosp_lite or cosp_amwg.