### PR TITLE
Fix bug in pblintd_height()

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -4226,7 +4226,7 @@ subroutine pblintd(&
 #ifdef SCREAM_CONFIG_IS_CMAKE
   if (use_cxx) then
     call pblintd_f(&
-      shcol,nlev,nlevi,&             ! Input
+      shcol,nlev,nlevi,npbl,&        ! Input
       z,zi,thl,ql,&                  ! Input
       q,u,v,&                        ! Input
       ustar,obklen,kbfs,cldn,&       ! Input
@@ -4407,8 +4407,8 @@ subroutine pblintd_height(&
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
    if (use_cxx) then
-      call pblintd_height_f(shcol,nlev,z,u,v,ustar,thv,thv_ref,&             ! Input
-                            pblh,rino,check)          ! Output
+      call pblintd_height_f(shcol,nlev,npbl,z,u,v,ustar,thv,thv_ref,& ! Input
+                            pblh,rino,check)                          ! Output
       return
    endif
 #endif

--- a/components/scream/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/scream/src/physics/shoc/shoc_functions_f90.hpp
@@ -970,7 +970,7 @@ struct ShocMainData : public ShocTestGridDataBase {
 
 struct PblintdHeightData : public PhysicsTestData {
   // Inputs
-  Int shcol, nlev;
+  Int shcol, nlev, npbl;
   Real *z, *u, *v, *ustar, *thv, *thv_ref;
 
   // Inputs/Outputs
@@ -980,10 +980,10 @@ struct PblintdHeightData : public PhysicsTestData {
   // Outputs
   Real *pblh;
 
-  PblintdHeightData(Int shcol_, Int nlev_) :
-    PhysicsTestData({{ shcol_, nlev_ }, { shcol_ }, { shcol_ }}, {{ &z, &u, &v, &thv, &rino }, { &ustar, &thv_ref, &pblh }}, {}, {{ &check }}), shcol(shcol_), nlev(nlev_) {}
+  PblintdHeightData(Int shcol_, Int nlev_, Int npbl_) :
+    PhysicsTestData({{ shcol_, nlev_ }, { shcol_ }, { shcol_ }}, {{ &z, &u, &v, &thv, &rino }, { &ustar, &thv_ref, &pblh }}, {}, {{ &check }}), shcol(shcol_), nlev(nlev_), npbl(npbl_) {}
 
-  PTD_STD_DEF(PblintdHeightData, 2, shcol, nlev);
+  PTD_STD_DEF(PblintdHeightData, 3, shcol, nlev, npbl);
 };
 
 struct VdShocDecompandSolveData : public PhysicsTestData {
@@ -1039,16 +1039,16 @@ struct PblintdCheckPblhData : public PhysicsTestData {
 
 struct PblintdData : public PhysicsTestData {
   // Inputs
-  Int shcol, nlev, nlevi;
+  Int shcol, nlev, nlevi, npbl;
   Real *z, *zi, *thl, *ql, *q, *u, *v, *ustar, *obklen, *kbfs, *cldn;
 
   // Outputs
   Real *pblh;
 
-  PblintdData(Int shcol_, Int nlev_, Int nlevi_) :
-    PhysicsTestData({{ shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_ }}, {{ &z, &thl, &ql, &q, &u, &v, &cldn }, { &zi }, { &ustar, &obklen, &kbfs, &pblh }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_) {}
+  PblintdData(Int shcol_, Int nlev_, Int nlevi_, Int npbl_) :
+    PhysicsTestData({{ shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_ }}, {{ &z, &thl, &ql, &q, &u, &v, &cldn }, { &zi }, { &ustar, &obklen, &kbfs, &pblh }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_), npbl(npbl_) {}
 
-  PTD_STD_DEF(PblintdData, 3, shcol, nlev, nlevi);
+  PTD_STD_DEF(PblintdData, 4, shcol, nlev, nlevi, npbl);
 };
 
 // Glue functions to call fortran from from C++ with the Data struct
@@ -1208,7 +1208,7 @@ Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, 
                 Real* wthl_sec, Real* wqw_sec, Real* wtke_sec, Real* uw_sec, Real* vw_sec, Real* w3, Real* wqls_sec,
                 Real* brunt, Real* shoc_ql2);
 
-void pblintd_height_f(Int shcol, Int nlev, Real* z, Real* u, Real* v, Real* ustar, Real* thv, Real* thv_ref, Real* pblh, Real* rino, bool* check);
+void pblintd_height_f(Int shcol, Int nlev, Int npbl, Real* z, Real* u, Real* v, Real* ustar, Real* thv, Real* thv_ref, Real* pblh, Real* rino, bool* check);
 
 void vd_shoc_decomp_and_solve_f(Int shcol, Int nlev, Int nlevi, Int num_rhs, Real* kv_term, Real* tmpi, Real* rdp_zt, Real dtime,
                                 Real* flux, Real* var);
@@ -1217,7 +1217,7 @@ void pblintd_surf_temp_f(Int shcol, Int nlev, Int nlevi, Real* z, Real* ustar, R
 
 void pblintd_check_pblh_f(Int shcol, Int nlev, Int nlevi, Int npbl, Real* z, Real* ustar, bool* check, Real* pblh);
 
-void pblintd_f(Int shcol, Int nlev, Int nlevi, Real* z, Real* zi, Real* thl, Real* ql, Real* q, Real* u, Real* v, Real* ustar, Real* obklen, Real* kbfs, Real* cldn, Real* pblh);
+void pblintd_f(Int shcol, Int nlev, Int nlevi, Int npbl, Real* z, Real* zi, Real* thl, Real* ql, Real* q, Real* u, Real* v, Real* ustar, Real* obklen, Real* kbfs, Real* cldn, Real* pblh);
 void shoc_grid_f(Int shcol, Int nlev, Int nlevi, Real* zt_grid, Real* zi_grid, Real* pdel, Real* dz_zt, Real* dz_zi, Real* rho_zt);
 void eddy_diffusivities_f(Int nlev, Int shcol, Real* obklen, Real* pblh, Real* zt_grid, Real* shoc_mix, Real* sterm_zt, Real* isotropy,
                           Real* tke, Real* tkh, Real* tk);

--- a/components/scream/src/physics/shoc/shoc_iso_c.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_c.f90
@@ -1331,10 +1331,10 @@ contains
     call update_prognostics_implicit(shcol, nlev, nlevi, num_tracer, dtime, dz_zt, dz_zi, rho_zt, zt_grid, zi_grid, tk, tkh, uw_sfc, vw_sfc, wthl_sfc, wqw_sfc, wtracer_sfc, thetal, qw, tracer, tke, u_wind, v_wind)
   end subroutine update_prognostics_implicit_c
 
-  subroutine pblintd_height_c(shcol, nlev, z, u, v, ustar, thv, thv_ref, pblh, rino, check) bind(C)
+  subroutine pblintd_height_c(shcol, nlev, npbl_in, z, u, v, ustar, thv, thv_ref, pblh, rino, check) bind(C)
     use shoc, only : npbl, pblintd_height
 
-    integer(kind=c_int) , value, intent(in) :: shcol, nlev
+    integer(kind=c_int) , value, intent(in) :: shcol, nlev, npbl_in
     real(kind=c_real) , intent(in), dimension(shcol, nlev) :: z, u, v, thv
     real(kind=c_real) , intent(in), dimension(shcol) :: ustar, thv_ref
     real(kind=c_real) , intent(out), dimension(shcol) :: pblh
@@ -1342,7 +1342,7 @@ contains
     logical(kind=c_bool) , intent(inout), dimension(shcol) :: check
 
     ! setup npbl
-    npbl = nlev
+    npbl = npbl_in
     call pblintd_height(shcol, nlev, z, u, v, ustar, thv, thv_ref, pblh, rino, check)
   end subroutine pblintd_height_c
 
@@ -1399,15 +1399,17 @@ contains
     call pblintd_check_pblh(shcol, nlev, nlevi, z, ustar, check, pblh)
   end subroutine pblintd_check_pblh_c
 
-  subroutine pblintd_c(shcol, nlev, nlevi, z, zi, thl, ql, q, u, v, ustar, obklen, kbfs, cldn, pblh) bind(C)
-    use shoc, only : pblintd
+  subroutine pblintd_c(shcol, nlev, nlevi, npbl_in, z, zi, thl, ql, q, u, v, ustar, obklen, kbfs, cldn, pblh) bind(C)
+    use shoc, only : npbl, pblintd
 
-    integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi
+    integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi, npbl_in
     real(kind=c_real) , intent(in), dimension(shcol, nlev) :: z, thl, ql, q, u, v, cldn
     real(kind=c_real) , intent(in), dimension(shcol, nlevi) :: zi
     real(kind=c_real) , intent(in), dimension(shcol) :: ustar, obklen, kbfs
     real(kind=c_real) , intent(out), dimension(shcol) :: pblh
 
+    ! setup npbl
+    npbl = npbl_in
     call pblintd(shcol, nlev, nlevi, z, zi, thl, ql, q, u, v, ustar, obklen, kbfs, cldn, pblh)
   end subroutine pblintd_c
 end module shoc_iso_c

--- a/components/scream/src/physics/shoc/shoc_iso_f.f90
+++ b/components/scream/src/physics/shoc/shoc_iso_f.f90
@@ -428,10 +428,10 @@ end subroutine dp_inverse_f
     real(kind=c_real) , intent(out), dimension(shcol, nlev) :: isotropy
   end subroutine isotropic_ts_f
 
-  subroutine pblintd_height_f(shcol, nlev, z, u, v, ustar, thv, thv_ref, pblh, rino, check) bind(C)
+  subroutine pblintd_height_f(shcol, nlev, npbl, z, u, v, ustar, thv, thv_ref, pblh, rino, check) bind(C)
     use iso_c_binding
 
-    integer(kind=c_int) , value, intent(in) :: shcol, nlev
+    integer(kind=c_int) , value, intent(in) :: shcol, nlev, npbl
     real(kind=c_real) , intent(in), dimension(shcol, nlev) :: z, u, v, thv
     real(kind=c_real) , intent(in), dimension(shcol) :: ustar, thv_ref
     real(kind=c_real) , intent(out), dimension(shcol) :: pblh
@@ -472,10 +472,10 @@ end subroutine dp_inverse_f
     real(kind=c_real) , intent(inout), dimension(shcol) :: pblh
   end subroutine pblintd_check_pblh_f
 
-  subroutine pblintd_f(shcol, nlev, nlevi, z, zi, thl, ql, q, u, v, ustar, obklen, kbfs, cldn, pblh) bind(C)
+  subroutine pblintd_f(shcol, nlev, nlevi, npbl, z, zi, thl, ql, q, u, v, ustar, obklen, kbfs, cldn, pblh) bind(C)
     use iso_c_binding
 
-    integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi
+    integer(kind=c_int) , value, intent(in) :: shcol, nlev, nlevi, npbl
     real(kind=c_real) , intent(in), dimension(shcol, nlev) :: z, thl, ql, q, u, v, cldn
     real(kind=c_real) , intent(in), dimension(shcol, nlevi) :: zi
     real(kind=c_real) , intent(in), dimension(shcol) :: ustar, obklen, kbfs

--- a/components/scream/src/physics/shoc/shoc_pblintd_height_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_pblintd_height_impl.hpp
@@ -52,7 +52,7 @@ void Functions<S,D>::pblintd_height(
   const Int upper = nlev-1;
   const Int length = upper-lower;
   const Int lower_pack_indx = lower/Spack::n;
-  const Int upper_pack_indx = lower_pack_indx + (length+Spack::n-1)/Spack::n;
+  const Int upper_pack_indx = lower_pack_indx + (length+Spack::n)/Spack::n;
   Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, lower_pack_indx, upper_pack_indx),
                           [&] (const Int& k, Int& local_max) {
     auto indices_pack = ekat::range<IntSmallPack>(k*Spack::n);

--- a/components/scream/src/physics/shoc/shoc_pblintd_height_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_pblintd_height_impl.hpp
@@ -80,8 +80,6 @@ void Functions<S,D>::pblintd_height(
 
   }, Kokkos::Max<Int>(max_indx));
 
-  std::cout << max_indx << std::endl;
-
   // Set check=false and compute pblh only if
   // there was an index s.t. rino(k)>=ricr.
   if (max_indx != Kokkos::reduction_identity<Int>::max()) {

--- a/components/scream/src/physics/shoc/tests/shoc_pblintd_height_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pblintd_height_tests.cpp
@@ -43,7 +43,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdHeight {
     Real ustar = ustar_min;
 
     // Initialize dtata structure for bridging to F90
-    PblintdHeightData SDS(shcol,nlev);
+    PblintdHeightData SDS(shcol,nlev,nlev);
 
     // Require that the inputs are reasonable
     REQUIRE( (SDS.shcol == shcol && SDS.nlev == nlev) );
@@ -172,11 +172,15 @@ struct UnitWrap::UnitTest<D>::TestPblintdHeight {
   {
     auto engine = setup_random_test();
 
+    Int npbl_rand = rand()%72 + 1;
+
     PblintdHeightData f90_data[] = {
-      PblintdHeightData(10, 72),
-      PblintdHeightData(10, 12),
-      PblintdHeightData(7, 16),
-      PblintdHeightData(2, 7),
+      PblintdHeightData(10, 72, 1),
+      PblintdHeightData(10, 72, 72),
+      PblintdHeightData(10, 72, npbl_rand),
+      PblintdHeightData(10, 12, 1),
+      PblintdHeightData(7, 16, 1),
+      PblintdHeightData(2, 7, 1),
     };
 
     // Generate random input data
@@ -191,6 +195,8 @@ struct UnitWrap::UnitTest<D>::TestPblintdHeight {
       PblintdHeightData(f90_data[1]),
       PblintdHeightData(f90_data[2]),
       PblintdHeightData(f90_data[3]),
+      PblintdHeightData(f90_data[4]),
+      PblintdHeightData(f90_data[5]),
     };
 
     // Assume all data is in C layout
@@ -204,7 +210,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdHeight {
     // Get data from cxx
     for (auto& d : cxx_data) {
       d.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
-      pblintd_height_f(d.shcol, d.nlev, d.z, d.u, d.v, d.ustar, d.thv, d.thv_ref, d.pblh, d.rino, d.check);
+      pblintd_height_f(d.shcol, d.nlev, d.npbl, d.z, d.u, d.v, d.ustar, d.thv, d.thv_ref, d.pblh, d.rino, d.check);
       d.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
     }
 

--- a/components/scream/src/physics/shoc/tests/shoc_pblintd_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_pblintd_tests.cpp
@@ -57,7 +57,7 @@ struct UnitWrap::UnitTest<D>::TestPblintd {
     }
 
     // Initialize data structure for bridging to F90
-    PblintdData SDS(shcol, nlev, nlevi);
+    PblintdData SDS(shcol, nlev, nlevi, nlev);
 
     // Test that the inputs are reasonable
     REQUIRE( (SDS.shcol == shcol && SDS.nlev == nlev && SDS.nlevi == nlevi) );
@@ -140,11 +140,15 @@ struct UnitWrap::UnitTest<D>::TestPblintd {
   {
     auto engine = setup_random_test();
 
+    Int npbl_rand = rand()%71 + 1;
+
     PblintdData f90_data[] = {
-      PblintdData(10, 71, 72),
-      PblintdData(10, 12, 13),
-      PblintdData(7,  16, 17),
-      PblintdData(2, 7, 8),
+      PblintdData(10, 71, 72, 71),
+      PblintdData(10, 71, 72, 1),
+      PblintdData(10, 71, 72, npbl_rand),
+      PblintdData(10, 12, 13, 1),
+      PblintdData(7,  16, 17, 1),
+      PblintdData(2, 7, 8, 1),
     };
 
     // Generate random input data
@@ -160,6 +164,8 @@ struct UnitWrap::UnitTest<D>::TestPblintd {
       PblintdData(f90_data[1]),
       PblintdData(f90_data[2]),
       PblintdData(f90_data[3]),
+      PblintdData(f90_data[4]),
+      PblintdData(f90_data[5]),
     };
 
     // Assume all data is in C layout
@@ -173,7 +179,7 @@ struct UnitWrap::UnitTest<D>::TestPblintd {
     // Get data from cxx
     for (auto& d : cxx_data) {
       d.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
-      pblintd_f(d.shcol, d.nlev, d.nlevi, d.z, d.zi, d.thl, d.ql, d.q, d.u, d.v, d.ustar, d.obklen, d.kbfs, d.cldn, d.pblh);
+      pblintd_f(d.shcol, d.nlev, d.nlevi, d.npbl, d.z, d.zi, d.thl, d.ql, d.q, d.u, d.v, d.ustar, d.obklen, d.kbfs, d.cldn, d.pblh);
       d.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
     }
 


### PR DESCRIPTION
Bug with the `Kokkos::TeamThreadRange` range when upper and lower index were equal. Adds a varying `npbl` to tests using `pblintd_height()`.