### PR TITLE
P3 F90 diagnostic bug fix (fixes chronically failing DP-SCREAM Mappy tests)

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -658,12 +658,12 @@
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="false">
-      <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
-      <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
-      <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
-      <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
-      <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
-      <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
+      <init_path lang="python">/projects/sems/install/rhel7-x86_64/sems/v2/lmod/lmod/8.3/gcc/10.1.0/zbzzu7k/lmod/lmod/init/env_modules_python.py</init_path>
+      <init_path lang="perl">/projects/sems/install/rhel7-x86_64/sems/v2/lmod/lmod/8.3/gcc/10.1.0/zbzzu7k/lmod/lmod/init/perl</init_path>
+      <init_path lang="sh">/projects/sems/install/rhel7-x86_64/sems/v2/lmod/lmod/8.3/gcc/10.1.0/zbzzu7k/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/projects/sems/install/rhel7-x86_64/sems/v2/lmod/lmod/8.3/gcc/10.1.0/zbzzu7k/lmod/lmod/init/csh</init_path>
+      <cmd_path lang="python">/projects/sems/install/rhel7-x86_64/sems/v2/lmod/lmod/8.3/gcc/10.1.0/zbzzu7k/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="perl">/projects/sems/install/rhel7-x86_64/sems/v2/lmod/lmod/8.3/gcc/10.1.0/zbzzu7k/lmod/lmod/libexec/lmod perl</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -86,7 +86,7 @@
       <value compset="_EAM%SCREAM-HR">-phys default -shoc_sgs -microphys p3 -chem none -nlev 128 -rad rrtmgp -bc_dep_to_snow_updates</value>
 
       <!-- Doubly Periodic SCREAM -->
-      <value compset="AR97_EAM%DPSCREAM">-phys default -scam -dpcrm_mode -nlev 72 -shoc_sgs -microphys p3 -rad rrtmgp -chem none</value>
+      <value compset="AR97_EAM%DPSCREAM">-phys default -scam -dpcrm_mode -nlev 72 -shoc_sgs -microphys p3 -rad rrtmgp -chem spa</value>
 
       <!-- Aquaplanet -->
       <value compset="_EAM%AQUA"   >-nlev 72 -clubb_sgs -microphys mg2 -aquaplanet -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -bc_dep_to_snow_updates </value>

--- a/components/eam/src/physics/cam/micro_p3_interface.F90
+++ b/components/eam/src/physics/cam/micro_p3_interface.F90
@@ -1356,16 +1356,16 @@ end subroutine micro_p3_readnl
 
     !WRITE OUTPUT
     !=============
-   call outfld('AQRAIN',      aqrain,      pcols, lchnk)
-   call outfld('ANRAIN',      anrain,      pcols, lchnk)
+   call outfld('AQRAIN',      aqrain,      pcols,    lchnk)
+   call outfld('ANRAIN',      anrain,      pcols,    lchnk)
    call outfld('AREL',        efcout,      pcols,    lchnk)
    call outfld('AREI',        efiout,      pcols,    lchnk) 
    call outfld('AWNC' ,       ncout,       pcols,    lchnk)
    call outfld('AWNI' ,       niout,       pcols,    lchnk)
-   call outfld('FICE',        nfice,       pcols, lchnk)
+   call outfld('FICE',        nfice,       pcols,    lchnk)
    call outfld('FREQL',       freql,       pcols,    lchnk)
    call outfld('FREQI',       freqi,       pcols,    lchnk)
-   call outfld('FREQR',       freqr,       pcols, lchnk)
+   call outfld('FREQR',       freqr,       pcols,    lchnk)
    call outfld('CDNUMC',      cdnumc,      pcols,    lchnk)
 
    call outfld('CLOUDFRAC_LIQ_MICRO',  cld_frac_l,      pcols, lchnk)

--- a/components/eam/src/physics/cam/micro_p3_interface.F90
+++ b/components/eam/src/physics/cam/micro_p3_interface.F90
@@ -1314,9 +1314,9 @@ end subroutine micro_p3_readnl
            numrain(:ncol,top_lev:) * rho(:ncol,top_lev:), &
            rho(:ncol,top_lev:), rho_h2o)
 
-      aqrain = rain * cld_frac_r
-      anrain = numrain * cld_frac_r
-      freqr = cld_frac_r
+      aqrain(:ncol,top_lev:) = rain(:ncol,top_lev:) * cld_frac_r(:ncol,top_lev:)
+      anrain(:ncol,top_lev:) = numrain(:ncol,top_lev:) * cld_frac_r(:ncol,top_lev:)
+      freqr(:ncol,top_lev:) = cld_frac_r(:ncol,top_lev:)
       reff_rain(:ncol,top_lev:) = drout2(:ncol,top_lev:) * &
            1.5_rtype * 1.e6_rtype
    end where
@@ -1356,16 +1356,16 @@ end subroutine micro_p3_readnl
 
     !WRITE OUTPUT
     !=============
-   call outfld('AQRAIN',      aqrain,      psetcols, lchnk)
-   call outfld('ANRAIN',      anrain,      psetcols, lchnk)
+   call outfld('AQRAIN',      aqrain,      pcols, lchnk)
+   call outfld('ANRAIN',      anrain,      pcols, lchnk)
    call outfld('AREL',        efcout,      pcols,    lchnk)
    call outfld('AREI',        efiout,      pcols,    lchnk) 
    call outfld('AWNC' ,       ncout,       pcols,    lchnk)
    call outfld('AWNI' ,       niout,       pcols,    lchnk)
-   call outfld('FICE',        nfice,       psetcols, lchnk)
+   call outfld('FICE',        nfice,       pcols, lchnk)
    call outfld('FREQL',       freql,       pcols,    lchnk)
    call outfld('FREQI',       freqi,       pcols,    lchnk)
-   call outfld('FREQR',       freqr,       psetcols, lchnk)
+   call outfld('FREQR',       freqr,       pcols, lchnk)
    call outfld('CDNUMC',      cdnumc,      pcols,    lchnk)
 
    call outfld('CLOUDFRAC_LIQ_MICRO',  cld_frac_l,      pcols, lchnk)


### PR DESCRIPTION
DP-SCREAM F90 CIME tests (ERP and ERS) have been chronically failing on Mappy with gnu compiler.  This PR fixes the underlying issue which was related to an output error for ANRAIN, AQRAIN, and FREQR diagnostics (these were the only three variables that had differences in the said ERP and ERS test fails).

Lines 1317-1319 are the culprits for the fails where indices bounds needs to be added to match the "where" statement search.  Thus, the fails were NOT DP specific but indicative of a general output bug with P3.  The DP tests were only catching them because DP tests output higher frequency *eam.h0* files, whereas the standard LR and HR tests never output *eam.h0* files.  

While not culprits of the fails, lines 1359-1369 fixes and inconsistency error where "psetcols" was being used in the outfld call.  "psetcols" should only be used if the code is enabled for sub-column use (which P3 implementation is not).  In our case, psetcols = pcols (as far as I can tell), but is a consistency fix.

Finally, the DP tests have been modified to use SPA (instead of the old prescribed aerosol model), to be consistent with SCREAMv0.1/v1.0