### PR TITLE
SCREAM: update sems modules and flags for mappy

### DIFF
--- a/components/scream/cmake/machine-files/mappy.cmake
+++ b/components/scream/cmake/machine-files/mappy.cmake
@@ -2,4 +2,6 @@
 set (EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/cmake/machine-files)
 set(SCREAM_SPA_DATA_DIR "/sems-data-store/ACME/inputdata/scream" CACHE STRING "")
 
+set (CMAKE_Fortran_FLAGS "-fallow-argument-mismatch" CACHE STRING "")
+
 include (${EKAT_MACH_FILES_PATH}/mappy.cmake)

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -34,7 +34,7 @@ MACHINE_METADATA = {
                  ["mpicxx","mpifort","mpicc"],
                   "bsub -I -q rhel7W -n 4",
                   "/home/projects/e3sm/scream/pr-autotester/master-baselines/weaver/"),
-    "mappy"   : (["module purge", "module load sems-env sems-gcc/9.2.0 sems-cmake/3.19.1 sems-git/2.10.1 sems-openmpi/4.0.2 sems-netcdf"],
+    "mappy"   : (["module purge", "module load sems-gcc/10.1.0 sems-cmake/3.21.1 sems-git/2.29.0 sems-openmpi/4.0.5 sems-netcdf-c sems-netcdf-fortran sems-parallel-netcdf"],
                  ["mpicxx","mpifort","mpicc"],
                   "",
                   "/sems-data-store/ACME/baselines/scream/master-baselines"),


### PR DESCRIPTION
SEMS modules changed on mappy, and gcc 10 needs some extra flags to work around some stricter checks that MPI would fail.

Internal scream tests pass on mappy, but I'm still trying to figure out CIME testing, given the compiler changes.