### PR TITLE
Fix valid_values string for do_spa_optics

### DIFF
--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3870,7 +3870,7 @@ Default: -1
 </entry>
 
 <entry id="do_spa_optics" type="logical" category="radiation"
-       group="radiation_nl" valid_values=".true., .false." >
+       group="radiation_nl" valid_values=".true.,.false." >
 Specify if optics are read in from spa ncdf file.
 Default: FALSE
 </entry>


### PR DESCRIPTION
The namelist definition entry for do_spa_optics contained a space
between list items in `valid_values`, which apparently confusing
`build-namelist` and would throw an error if `do_spa_optics=.false.`
appeared in the namelist.

[BFB]