### PR TITLE
Remove temporary override of tensor HV setting for ne4

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1363,13 +1363,6 @@
 <hypervis_order >     2 </hypervis_order>
 <hypervis_scaling> 3.0 </hypervis_scaling>
 
-<!-- special TEMPORARY defaults for scream for upstream merge  -->
-<nu hgrid="ne4np4"> 5.0e17  </nu>
-<hypervis_scaling hgrid="ne4np4" > 0 </hypervis_scaling>
-
-
-
-
 <!-- -1.0 indicates use the value for nu -->
 <nu_q> -1.0 </nu_q>
 <nu_p> -1.0 </nu_p>


### PR DESCRIPTION
Remove temporary override of namelist defaults to set tensor hyperviscosity for ne4. This override appears to have been put in 11 months ago, with the note that it was a temporary fix for an upstream merge, but I think we ultimately want to use tensor HV, and this is one area that makes EAM compsets non-BFB between the E3SM and SCREAM repos. If we make this change, then the only other thing that appears to be non-BFB between E3SM and SCREAM repos for F-cases is the setting of `adjust_ps`.

[non-B4B] (for v0 tests, should be B4B for v1 tests)