### PR TITLE
Add -DSCREAM to enable SCREAM features from upstream

### DIFF
--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -82,11 +82,11 @@
       <value compset="_EAM%ADIAB"     >-phys adiabatic</value>
 
       <!-- SCREAM configurations -->
-      <value compset="_EAM%SCREAM-LR">-phys default -shoc_sgs -microphys p3 -chem spa -nlev 72 -rad rrtmgp -bc_dep_to_snow_updates</value>
-      <value compset="_EAM%SCREAM-HR">-phys default -shoc_sgs -microphys p3 -chem spa -nlev 128 -rad rrtmgp -bc_dep_to_snow_updates</value>
+      <value compset="_EAM%SCREAM-LR">-phys default -shoc_sgs -microphys p3 -chem spa -nlev 72 -rad rrtmgp -bc_dep_to_snow_updates -cppdefs '-DSCREAM'</value>
+      <value compset="_EAM%SCREAM-HR">-phys default -shoc_sgs -microphys p3 -chem spa -nlev 128 -rad rrtmgp -bc_dep_to_snow_updates -cppdefs '-DSCREAM'</value>
 
       <!-- Doubly Periodic SCREAM -->
-      <value compset="AR97_EAM%DPSCREAM">-phys default -scam -dpcrm_mode -nlev 72 -shoc_sgs -microphys p3 -rad rrtmgp -chem spa</value>
+      <value compset="AR97_EAM%DPSCREAM">-phys default -scam -dpcrm_mode -nlev 72 -shoc_sgs -microphys p3 -rad rrtmgp -chem spa -cppdefs '-DSCREAM'</value>
 
       <!-- Aquaplanet -->
       <value compset="_EAM%AQUA"   >-nlev 72 -clubb_sgs -microphys mg2 -aquaplanet -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -bc_dep_to_snow_updates </value>


### PR DESCRIPTION
Add a -DSCREAM compile flag to SCREAM compsets to enable SCREAM-specific
features that have been pushed upstream to E3SM. This should generally
be useful to allow pushing SCREAM-specific changes upstream to the E3SM
repo to prevent conflicts with upstream merges, and is immediately
necessary to enable the correct setting of `adjust_ps` before the next
upstream merge goes in, the setting of which has been moved upstream protected by the
`ifdef SCREAM` conditional to maintain BFB for EAM compsets but allow
for the correct SCREAM setting.

[B4B]