### PR TITLE
Mappy setup was not safe to call if already called

### DIFF
--- a/components/scream/scripts/jenkins/mappy_setup
+++ b/components/scream/scripts/jenkins/mappy_setup
@@ -1,3 +1,4 @@
+module purge
 source /projects/sems/modulefiles/utils/sems-archive-modules-init.sh
 module load sems-env
 export PATH=/ascldap/users/jgfouca/packages/Python-3.8.5/bin:$PATH


### PR DESCRIPTION
The purge makes it recallable.

This should fix the scripts-test fails on the dashboard.