### PR TITLE
Scale Faxa_rainl in SC::do_export

### DIFF
--- a/components/scream/src/control/surface_coupling.cpp
+++ b/components/scream/src/control/surface_coupling.cpp
@@ -51,10 +51,11 @@ set_num_fields (const int num_cpl_imports, const int num_scream_imports,
   z_mid = decltype(z_mid) ("", m_num_cols, m_num_levs);
 
   // These fields contain export data
-  Sa_z         = decltype(Sa_z)      ("", m_num_cols);
-  Sa_ptem      = decltype(Sa_ptem)   ("", m_num_cols);
-  Sa_dens      = decltype(Sa_dens)   ("", m_num_cols);
-  zero_view    = decltype(zero_view) ("", m_num_cols);
+  Sa_z       = decltype(Sa_z)       ("", m_num_cols);
+  Sa_ptem    = decltype(Sa_ptem)    ("", m_num_cols);
+  Sa_dens    = decltype(Sa_dens)    ("", m_num_cols);
+  Faxa_rainl = decltype(Faxa_rainl) ("", m_num_cols);
+  zero_view  = decltype(zero_view)  ("", m_num_cols);
   Kokkos::deep_copy(zero_view, 0.0);
 
   // These will be incremented every time we register an import/export.
@@ -183,11 +184,12 @@ register_export (const std::string& fname,
   } else {
 
     // Set view data ptr
-    if (fname == "set_zero")     info.data = zero_view.data();
-    else if (fname == "Sa_z")    info.data = Sa_z.data();
-    else if (fname == "Sa_ptem") info.data = Sa_ptem.data();
-    else if (fname == "Sa_dens") info.data = Sa_dens.data();
-    else                         EKAT_ERROR_MSG("Error! Unrecognized export field name \"" + fname + "\".");
+    if (fname == "set_zero")        info.data = zero_view.data();
+    else if (fname == "Sa_z")       info.data = Sa_z.data();
+    else if (fname == "Sa_ptem")    info.data = Sa_ptem.data();
+    else if (fname == "Sa_dens")    info.data = Sa_dens.data();
+    else if (fname == "Faxa_rainl") info.data = Faxa_rainl.data();
+    else                            EKAT_ERROR_MSG("Error! Unrecognized export field name \"" + fname + "\".");
 
     // Get column offset and stride
     get_col_info (dummy_field.get_header_ptr(), vecComp, info.col_offset, info.col_stride);

--- a/components/scream/src/control/surface_coupling.hpp
+++ b/components/scream/src/control/surface_coupling.hpp
@@ -145,6 +145,7 @@ protected:
   view_1d<device_type,Real> Sa_z;
   view_1d<device_type,Real> Sa_ptem;
   view_1d<device_type,Real> Sa_dens;
+  view_1d<device_type,Real> Faxa_rainl;
   view_1d<device_type,Real> zero_view;
 
   // Dummy field to allow for the storage of the FieldIdentifier for debugging (not currently used)

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -1,6 +1,7 @@
 #include "share/grid/point_grid.hpp"
 #include "share/util/scream_setup_random_test.hpp"
 #include "control/surface_coupling.hpp"
+#include "physics/share/physics_constants.hpp"
 
 #include <ekat/util/ekat_test_utils.hpp>
 
@@ -230,6 +231,7 @@ TEST_CASE ("recreate_mct_coupling")
   using FR     = FieldRequest;
   using GR     = GroupRequest;
   using RPDF   = std::uniform_real_distribution<Real>;
+  using C = scream::physics::Constants<Real>;
 
   // Some constants
   constexpr int ncols = 4;
@@ -402,7 +404,7 @@ TEST_CASE ("recreate_mct_coupling")
   coupler.register_export("set_zero",        12);
   coupler.register_export("set_zero",        13);
   coupler.register_export("set_zero",        14);
-  coupler.register_export("precip_liq_surf", 15);
+  coupler.register_export("Faxa_rainl",      15);
   coupler.register_export("set_zero",        16);
   coupler.register_export("set_zero",        17);
   coupler.register_export("set_zero",        18);
@@ -504,7 +506,7 @@ TEST_CASE ("recreate_mct_coupling")
       REQUIRE (export_raw_data[4 + icol*num_cpl_exports]  == T_mid_h          (icol,    nlevs-1)); // 5th export
       REQUIRE (export_raw_data[6 + icol*num_cpl_exports]  == qv_h             (icol,    nlevs-1)); // 7th export
       REQUIRE (export_raw_data[7 + icol*num_cpl_exports]  == p_mid_h          (icol,    nlevs-1)); // 8th export
-      REQUIRE (export_raw_data[15 + icol*num_cpl_exports] == precip_liq_surf_h(icol            )); // 16th export
+      REQUIRE (export_raw_data[15 + icol*num_cpl_exports] == C::RHO_H2O*precip_liq_surf_h(icol));  // 16th export
 
       // These exports should be set to 0
       REQUIRE (export_raw_data[1  + icol*num_cpl_exports] == 0); // 2nd export

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -93,7 +93,7 @@ module scream_cpl_indices
     scr_names_a2x(mct_avect_indexra(a2x,'Sa_pbot'))    = 'p_mid'
     scr_names_a2x(mct_avect_indexra(a2x,'Sa_shum'))    = 'qv'
     scr_names_a2x(mct_avect_indexra(a2x,'Sa_dens'))    = 'Sa_dens'
-    scr_names_a2x(mct_avect_indexra(a2x,'Faxa_rainl')) = 'precip_liq_surf'
+    scr_names_a2x(mct_avect_indexra(a2x,'Faxa_rainl')) = 'Faxa_rainl'
 
     vec_comp_a2x(mct_avect_indexra(a2x,'Sa_u')) = 0
     vec_comp_a2x(mct_avect_indexra(a2x,'Sa_v')) = 1


### PR DESCRIPTION
To match EAM, we should be scaling `precip_liq_surf` by `RHO_H2O = 1000` when exporting to `Faxa_rainl`.

I chose to treat `Faxa_rainl` as a computed field, which is `1000*precip_liq_surf`. Another solution could be to store a view of constant multiples and apply that directly during export (much like the new "sign switching" import stuff works with -1.

Selecting "Hide whitespace" when looking at the files makes seeing the changes easier.