### PR TITLE
Add a SCREAMv1 aquaplanet compset

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -424,6 +424,7 @@ _TESTS = {
         "time"  : "03:00:00",
         "tests" : (
             "SMS_D_Ln2_P24x1.ne4_ne4.F2000SCREAMv1.scream-30min_ts",
+            "SMS_D_Ln2_P24x1.ne4_ne4.F2000-SCREAMv1-AQP1.scream-30min_ts",
             )
     },
 

--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -31,7 +31,7 @@ import yaml
 logger = logging.getLogger(__name__)
 
 CIME_VAR_RE = re.compile(r'[$][{](\w+)[}]')
-SWITCH_RE   = re.compile(r'<\s*(\w+)\s*:')
+SWITCH_RE   = re.compile(r'<\s*([^:]+)\s*:')
 
 ###############################################################################
 def do_cime_vars(entry, case):

--- a/components/scream/cime_config/config_component.xml
+++ b/components/scream/cime_config/config_component.xml
@@ -28,7 +28,6 @@
     <default_value></default_value>
     <values modifier='additive'>
       <value compset="_SCREAM">SCREAM_NP 4 SCREAM_NUM_VERTICAL_LEV 72 SCREAM_NUM_TRACERS 35</value>
-      <value compset="-AQP">SCREAM_AQUAPLANET</value>
     </values>
     <group>build_component_scream</group>
     <file>env_build.xml</file>

--- a/components/scream/cime_config/config_component.xml
+++ b/components/scream/cime_config/config_component.xml
@@ -28,6 +28,7 @@
     <default_value></default_value>
     <values modifier='additive'>
       <value compset="_SCREAM">SCREAM_NP 4 SCREAM_NUM_VERTICAL_LEV 72 SCREAM_NUM_TRACERS 35</value>
+      <value compset="-AQP">SCREAM_AQUAPLANET</value>
     </values>
     <group>build_component_scream</group>
     <file>env_build.xml</file>

--- a/components/scream/cime_config/config_compsets.xml
+++ b/components/scream/cime_config/config_compsets.xml
@@ -21,4 +21,10 @@
       <support_level>Experimental, under development</support_level>
   </compset>
 
+  <compset>
+      <alias>F2000-SCREAMv1-AQP1</alias> <!-- atm aquaplanet compset (using SCREAMv1), 2000 initial conditions -->
+      <lname>2000_SCREAM%AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
+      <support_level>Experimental, under development</support_level>
+  </compset>
+
 </compsets>

--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -38,7 +38,7 @@ Atmosphere Driver:
 
   Initial Conditions:
     Physics GLL:
-      Filename: ./data/init_ne4np4.nc
+      Filename: "<${COMPSET} : .*SCREAM%AQUA.* => /sems-data-store/ACME/bhillma/scream/data/init_files/ne4np4_L72/aqua/homme_shoc_cld_spa_p3_rrtmgp_init_ne4np4_L72.nc : ./data/init_ne4np4.nc>"
       # Set X_prev = X
       T_mid_prev: T_mid
       horiz_winds_prev: horiz_winds

--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -38,7 +38,7 @@ Atmosphere Driver:
 
   Initial Conditions:
     Physics GLL:
-      Filename: "<${COMPSET} : .*SCREAM%AQUA.* => /sems-data-store/ACME/bhillma/scream/data/init_files/ne4np4_L72/aqua/homme_shoc_cld_spa_p3_rrtmgp_init_ne4np4_L72.nc : ./data/init_ne4np4.nc>"
+      Filename: "<${COMPSET} : .*SCREAM%AQUA.* => ${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc : ./data/init_ne4np4.nc>"
       # Set X_prev = X
       T_mid_prev: T_mid
       horiz_winds_prev: horiz_winds

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -802,6 +802,11 @@ void AtmosphereDriver::run (const int dt) {
   // Make sure the end of the time step is after the current start_time
   EKAT_REQUIRE_MSG (dt>0, "Error! Input time step must be positive.\n");
 
+  // Print current timestamp information
+  if (m_atm_comm.am_i_root()) {
+    std::cout << "Atmosphere step = " << m_current_ts.get_num_steps() << "; model time = " << m_current_ts.get_date_string() << " " << m_current_ts.get_time_string() << std::endl;
+  }
+
   if (m_surface_coupling) {
     // Import fluxes from the component coupler (if any)
     m_surface_coupling->do_import();

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -188,7 +188,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   // get_field_out("nr").add_property_check(positivity_check);
   // get_field_out("ni").add_property_check(positivity_check);
   // get_field_out("bm").add_property_check(positivity_check);
-  auto T_interval_check = std::make_shared<FieldWithinIntervalCheck>(150, 500);
+  auto T_interval_check = std::make_shared<FieldWithinIntervalCheck>(140, 500);
   add_property_check<Updated>(get_field_out("T_mid").get_header().get_identifier(),T_interval_check);
 
   // Initialize p3

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -350,7 +350,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
                                  T_mid, dse, z_mid, phis);
 
   // Set field property checks for the fields in this process
-  auto T_interval_check = std::make_shared<FieldWithinIntervalCheck>(150, 500);
+  auto T_interval_check = std::make_shared<FieldWithinIntervalCheck>(140, 500);
   auto positivity_check = std::make_shared<FieldPositivityCheck>();
 
   add_property_check<Computed>(get_field_out("T_mid").get_header().get_identifier(),T_interval_check);


### PR DESCRIPTION
Add a SCREAMv1 aquaplanet compset (F2000-SCREAMv1-AQP1). Changes are made to `scream_input.yaml` to pull the proper initial condition from the machine-specific inputdata location. However, this is not yet configured to work with `check_inputdata` to automatically download the initial condition file if it does not already exist locally, so for now we'd need to setup each machine manually. Also adds stdout message to print current timestep in AD. This should be considered a placeholder until we implement more robust logging capabilities.