### PR TITLE
Refactor handling of scream_input.yaml

### DIFF
--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -5,23 +5,7 @@ Namelist creator for E3SM's SCREAM component
 
 This script is mostly for processing the scream_input.yaml file.
 
-That file supports some special syntax in addition to basic YAML:
-'${VAR}' will be used to refer to env variables in the CIME case
-
-'<switch_val : key1 => val1 : key2 => val2 : elseval>' will be used to express conditional
-statements. If switch_val matches key1, then the expression evaluates to val1; if switch_val
-matches key2, then the expression evaluates to val2; if it matches neither, then
-the expression evaluates to elseval. The elseval component of this expression is optional.
-
-Example, if you wanted tstep to depend on atm grid resolution:
-
-  tstep: "<${ATM_GRID} : ne4np4 => 300 : 30>"
-
-This would give all ne4 cases a timestep of 300, otherwise it would be 30.
-
-You could specify multiple grid->timestep relationships this way:
-
-  tstep: "<${ATM_GRID} : ne4np4 => 300 : ne30np4 => 100 : 30>"
+See SCREAM_YAML_README for documentation on how to use scream_input.yaml.
 """
 
 import os, sys, re
@@ -36,8 +20,8 @@ sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), "script
 # Cime imports
 from standard_script_setup import *
 from CIME.case import Case
-from CIME.utils import expect, run_cmd_no_fail, safe_copy, SharedArea
-from CIME.buildnml import create_namelist_infile, parse_input
+from CIME.utils import expect, safe_copy, SharedArea
+from CIME.buildnml import parse_input
 
 # SCREAM imports
 from utils import ensure_yaml
@@ -63,7 +47,7 @@ def do_cime_vars(entry, case):
     return entry
 
 ###############################################################################
-def do_switches(entry, case):
+def do_switches(entry):
 ###############################################################################
     m = SWITCH_RE.search(entry)
     while m:
@@ -92,11 +76,11 @@ def do_switches(entry, case):
             components = segment.split("=>", 1)
             if (len(components) == 1 or '<' in components[0]):
                 if best_val is None:
-                    best_val = do_switches(segment, case).strip()
+                    best_val = do_switches(segment).strip()
             else:
                 compare = re.compile(components[0].strip())
                 if compare.match(value):
-                    best_val = do_switches(components[-1], case).strip()
+                    best_val = do_switches(components[-1]).strip()
                     break
 
         expect(best_val is not None, "Couldn't resolve switch statement for '{}', no matches".format(entry))
@@ -129,7 +113,7 @@ def process_leaves(yaml_entry, case):
         if isinstance(v, str):
             orig_str = v
             v = do_cime_vars(v, case)
-            v = do_switches(v, case)
+            v = do_switches(v)
             if v != orig_str:
                 v = refine_type(v)
                 modified = True
@@ -139,61 +123,6 @@ def process_leaves(yaml_entry, case):
             modified |= process_leaves(v, case)
 
     return modified
-
-###############################################################################
-def load_comments(filepath):
-###############################################################################
-    """
-    Loading and dumping YAML files does not preserve the whitespace or comments
-    from the original. Since SCREAM users will be interacting with the scream_input.yaml,
-    we really want to keep these comments. This function will parse the text of
-    a YAML file and store the comments and whitespace in a simple list of 3-ples
-    [(do_insert, line idx, text)] with the idea that this data can be applied
-    to a freshly generated YAML file via the apply_comments function.
-    """
-    with open(filepath, "r") as fd:
-        lines = fd.readlines()
-
-    result = []
-    for idx, line in enumerate(lines):
-        sline = line.strip()
-
-        if sline.startswith("%YAML"):
-            result.append((True, idx, line))
-        elif sline in ["---", "..."]:
-            result.append((True, idx, line))
-        elif sline == "":
-            result.append((True, idx, line))
-        elif "#" in line:
-            try:
-                before, after = line.split("#")
-            except ValueError:
-                expect(False, "Bad line, too many #: {}".format(line))
-            before_nows = before.strip()
-            if before_nows == "":
-                result.append((True, idx, line))
-            else:
-                result.append((False, idx, after))
-
-    return result
-
-###############################################################################
-def apply_comments(filepath, comments):
-###############################################################################
-    """
-    Apply the comments from load_comments to a freshly generated YAML file.
-    """
-    with open(filepath, "r") as fd:
-        lines = fd.readlines()
-
-    for is_insert, idx, contents in comments:
-        if is_insert:
-            lines.insert(idx, contents)
-        else:
-            lines[idx] = "{} # {}".format(lines[idx].rstrip(), contents)
-
-    with open(filepath, "w") as fd:
-        fd.writelines(lines)
 
 ###############################################################################
 def ordered_load(item, Loader=yaml.SafeLoader, object_pairs_hook=OrderedDict):
@@ -262,17 +191,14 @@ def buildnml(case, caseroot, compname):
             if not os.path.exists(os.path.join(target, item)):
                 safe_copy(os.path.join(src, item), target)
 
-    # Load scream inputs from yaml and store original-file comments
-    comments = load_comments(yaml_tgt)
+    # Load scream inputs from yaml
     scream_input = ordered_load(yaml_tgt)
 
     modified = process_leaves(scream_input, case)
 
-    # If we have to re-dump the YAML file due to CIME case updates,
-    # we need to also restore the original comments.
+    # Check If we have to re-dump the YAML file due to CIME case updates
     if modified:
         ordered_dump(scream_input, yaml_tgt)
-        apply_comments(yaml_tgt, comments)
 
     # Create homme namelists from scream inputs
     homme_nl_path = os.path.join(rundir, scream_input["Atmosphere Driver"]["Grids Manager"]["Dynamics Driven"]["Dynamics Namelist File Name"])

--- a/components/scream/data/SCREAM_YAML_README
+++ b/components/scream/data/SCREAM_YAML_README
@@ -1,0 +1,51 @@
+
+INTRO:
+
+The scream_input.yaml is the key file for configuring a SCREAM run. This file will be
+processed and copied to $case/run/scream_input.yaml by scream's buidnml script, which
+is called during case.setup. Note, this is for runtime coniguration
+only. Cmake/build-time configuration should be done through SCREAM_CMAKE_OPTIONS.
+
+For inline comments, see the version of scream_input.yaml that lives in the repo
+(components/scream/data/scream_input.yaml)
+
+Note, the $case/run/scream_input.yaml will NEVER be overwritten by subsequent
+calls to case.setup/buildnml in order to avoid blowing away potential local
+modifications. To force a regeneration of this file, it should be removed from the
+case and `./case.setup --reset` should be called.
+
+SECTIONS:
+
+  Atmosphere Driver: Contains settings for the AD. Can turn off processes by editing "Number of Entries" and
+  changing the Process N list.
+
+  SCREAM: For general SCREAM settings
+
+  HOMME: For HOMME settings. These settings will be translated into data/namelist.nl
+
+SYNTAX:
+
+This file supports some special syntax in addition to basic YAML:
+'${VAR}' will be used to refer to env variables in the CIME case
+
+'<switch_val : key1 => val1 : key2 => val2 : elseval>' will be used to express conditional
+statements. If switch_val matches key1, then the expression evaluates to val1; if switch_val
+matches key2, then the expression evaluates to val2; if it matches neither, then
+the expression evaluates to elseval. The elseval component of this expression is optional.
+
+Example, if you wanted tstep to depend on atm grid resolution:
+
+  tstep: "<${ATM_GRID} : ne4np4 => 300 : 30>"
+
+This would give all ne4 cases a timestep of 300, otherwise it would be 30.
+
+You could specify multiple grid->timestep relationships this way:
+
+  tstep: "<${ATM_GRID} : ne4np4 => 300 : ne30np4 => 100 : 30>"
+
+Regex matching is supported:
+
+  tstep: "<${ATM_GRID} : .*ne4.* => 300 : .*ne30.* => 100 : 30>"
+
+Note: none of this special syntax will be automatically reprocessed if the case XML values
+are changed. Regenerating this file is necessary if relevant case XML values are modified.

--- a/components/scream/data/SCREAM_YAML_README
+++ b/components/scream/data/SCREAM_YAML_README
@@ -32,6 +32,7 @@ This file supports some special syntax in addition to basic YAML:
 statements. If switch_val matches key1, then the expression evaluates to val1; if switch_val
 matches key2, then the expression evaluates to val2; if it matches neither, then
 the expression evaluates to elseval. The elseval component of this expression is optional.
+You can have any number (N>=1) of key => val sections.
 
 Example, if you wanted tstep to depend on atm grid resolution:
 


### PR DESCRIPTION
A fair bit of effort was made to preserve the comments in the repo
file for screan_input.yaml during the processing of that file for
the case. The idea was that users would be interacting with this
file in their cases and we wanted them to have access to our comments
directly to assist them.

YAML does not have any internal mechasisms for preserving comments
when parsing/dumping YAML content, so I had added some hacky code
to read comments separately and reestablish them in the file manually.

After a few months of developers creating CIME SCREAM V1
cases, it seems this approach has been a source of syntax errors
in this case's version of this file, so this PR is a rethink of
the approach.

Instead of relying solely on inline comments in the repo's scream_input.yaml,
we provide a separate SCREAM_INPUT_README file for full documentation
on how to use scream_input.yaml.