### PR TITLE
Update homme namelist options for SCREAMv1 run.

### DIFF
--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -7,18 +7,28 @@ Atmosphere Driver:
     Schedule Type: Sequential
     Process 0:
       Process Name: Homme
-      Grid:         Dynamics
+      Enable Output Fields Checks: false
+      Enable Input Fields Checks: false
+      Grid: Dynamics
     Process 1:
       Process Name: SHOC
+      Enable Output Fields Checks: false
+      Enable Input Fields Checks: false
       Grid: Physics GLL
     Process 2:
       Process Name: CldFraction
+      Enable Output Fields Checks: false
+      Enable Input Fields Checks: false
       Grid: Physics GLL
     Process 3:
       Process Name: P3
+      Enable Output Fields Checks: false
+      Enable Input Fields Checks: false
       Grid: Physics GLL
     Process 4:
       Process Name: RRTMGP
+      Enable Output Fields Checks: false
+      Enable Input Fields Checks: false
       Grid: Physics GLL
       active_gases:
       - h2o
@@ -29,6 +39,12 @@ Atmosphere Driver:
       - ch4
       - o2
       - n2
+
+  Time Stepping:
+    Time Step: 300
+    Start Time: [12, 30, 00]      # Hours, Minutes, Seconds
+    Start Date: [2000, 2, 1]    # Year, Month, Day
+    Number of Steps: 288
 
   Grids Manager:
     Type: Dynamics Driven
@@ -61,31 +77,32 @@ HOMME:
     partmethod        : 4
     cubed_sphere_map  : 0
     topology          : cube
-    test_case         : jw_baroclinic
     u_perturb         : 1
     rotate_grid       : 0
     ne                : 4
     statefreq         : 9999
     mesh_file         : /dev/null
     tstep             : 300
-    nu                : 7.0e+15
-    nu_div            : 1.0e+15
-    nu_p              : 7.0e+15
-    nu_q              : 7.0e+15
-    nu_s              : -1
-    nu_top            : 2.5e+5
+    nu                :  .000000034
+    nu_div            : -1 
+    nu_p              : .000000034
+    nu_q              : .000000034
+    nu_s              : .000000034
+    nu_top            : 
     se_ftype          : 0
     limiter_option    : 9
-    vert_remap_q_alg  : 1
-    hypervis_scaling  : 0
+    vert_remap_q_alg  : 10
+    hypervis_scaling  : 3.0
     hypervis_order    : 2
-    hypervis_subcycle : 2
-    hypervis_subcycle_tom : 0
-    theta_hydrostatic_mode : false
-    theta_advect_form : 0
-    tstep_type        : 10
-    dt_remap_factor   : 3
+    hypervis_subcycle : 1
+    hypervis_subcycle_tom : 1
+    theta_hydrostatic_mode : true
+    theta_advect_form : 1
+    tstep_type        : 5
+    dt_remap_factor   : 1
     dt_tracer_factor  : 1
+    transport_alg     : 12
+    moisture:           moist
 
   vert_nl:
     vfile_mid : ./data/scream-72m.ascii

--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -63,6 +63,10 @@ Atmosphere Driver:
     Dynamics:
       tracers: tracers, Physics GLL
 
+  # The parameters for I/O control
+  Scorpio:
+    Output YAML Files: ["data/screamv1_output.yaml"]
+
 SCREAM:
 
   Start Date: "${RUN_STARTDATE}"
@@ -83,12 +87,12 @@ HOMME:
     statefreq         : 9999
     mesh_file         : /dev/null
     tstep             : 300
-    nu                :  .000000034
+    nu                : 3.4e-8 
     nu_div            : -1 
-    nu_p              : .000000034
-    nu_q              : .000000034
-    nu_s              : .000000034
-    nu_top            : 
+    nu_p              : -1
+    nu_q              : -1
+    nu_s              : -1
+    nu_top            : 2.5e+5
     se_ftype          : 0
     limiter_option    : 9
     vert_remap_q_alg  : 10
@@ -101,7 +105,6 @@ HOMME:
     tstep_type        : 5
     dt_remap_factor   : 1
     dt_tracer_factor  : 1
-    transport_alg     : 12
     moisture:           moist
 
   vert_nl:

--- a/components/scream/data/screamv1_output.yaml
+++ b/components/scream/data/screamv1_output.yaml
@@ -1,0 +1,65 @@
+%YAML 1.1
+---
+Casename: SCREAMv1_output_hydrostatic
+Averaging Type: Instant
+Max Snapshots Per File: 1000
+Fields:
+  Physics GLL:
+    Field Names:
+      - T_mid
+      - qv
+      - T_prev_micro_step
+      - qc
+      - qr
+      - qi
+      - qm
+      - nc
+      - nr
+      - ni
+      - bm
+      - qv_prev_micro_step
+      - eff_radius_qc
+      - eff_radius_qi
+      - micro_liq_ice_exchange
+      - micro_vap_liq_exchange
+      - micro_vap_ice_exchange
+      - tke
+      - cldfrac_liq
+      - cldfrac_tot
+      - eddy_diff_mom
+      - sgs_buoy_flux
+      - inv_qc_relvar
+      - pbl_height
+      - LW_flux_up
+      - LW_flux_dn
+      - SW_flux_up
+      - SW_flux_dn
+      - SW_flux_dn_dir
+      - phi_int
+      - ps
+      - omega
+      - p_int
+      - p_mid
+      - phis
+      - pseudo_density
+      - surf_latent_flux
+      - surf_mom_flux
+      - surf_sens_flux
+      - cldfrac_ice
+      - nc_activated
+      - ni_activated
+      - nc_nuceat_tend
+      - eff_radius_qc
+      - eff_radius_qi
+      - sfc_alb_dir_nir
+      - sfc_alb_dir_vis
+      - sfc_alb_dif_nir
+      - sfc_alb_dif_vis
+      - surf_lw_flux_up
+
+Output Control:
+  Frequency: 12
+  Frequency Units: Steps
+  Timestamp in Filename: false
+  MPI Ranks in Filename: true
+...


### PR DESCRIPTION
This commit changes the default homme namelist options as defined in
the scream_input.yaml file to match those of a recent simulation which
was able to run 30 days.