### PR TITLE
Add units and long-name to SCREAM netcdf output

### DIFF
--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -1,6 +1,7 @@
 #include "share/io/scorpio_output.hpp"
 #include "ekat/std_meta/ekat_std_utils.hpp"
 #include "share/io/scorpio_input.hpp"
+#include "ekat/util/ekat_units.hpp"
 
 #include "ekat/util/ekat_string_utils.hpp"
 
@@ -353,6 +354,7 @@ void AtmosphereOutput::register_variables(const std::string& filename)
     std::string io_decomp_tag = "Real";  // Note, for now we only assume REAL variables.  This may change in the future.
     std::vector<std::string> vec_of_dims;
     const auto& layout = fid.get_layout();
+    std::string units = to_string(fid.get_units());
     for (int i=0; i<fid.get_layout().rank(); ++i) {
       const auto tag_name = get_nc_tag_name(layout.tag(i), layout.dim(i));
       // Concatenate the dimension string to the io-decomp string
@@ -375,7 +377,7 @@ void AtmosphereOutput::register_variables(const std::string& filename)
      // TODO  Need to change dtype to allow for other variables.
     // Currently the field_manager only stores Real variables so it is not an issue,
     // but in the future if non-Real variables are added we will want to accomodate that.
-    register_variable(filename, name, name, vec_of_dims.size(), vec_of_dims, PIO_REAL, io_decomp_tag);
+    register_variable(filename, name, name, units, vec_of_dims.size(), vec_of_dims, PIO_REAL, io_decomp_tag);
   }
 } // register_variables
 /* ---------------------------------------------------------- */

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -213,7 +213,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
       register_dimension(filename,"time","time",0);
 
       // Register time as a variable.
-      register_variable(filename,"time","time",1,{"time"},  PIO_REAL,"time");
+      register_variable(filename,"time","time","sec",1,{"time"},  PIO_REAL,"time");
 
       // Make all output streams register their dims/vars
       for (auto& it : m_output_streams) {

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -213,7 +213,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
       register_dimension(filename,"time","time",0);
 
       // Register time as a variable.
-      register_variable(filename,"time","time","sec",1,{"time"},  PIO_REAL,"time");
+      register_variable(filename,"time","time","s",1,{"time"},  PIO_REAL,"time");
 
       // Make all output streams register their dims/vars
       for (auto& it : m_output_streams) {

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -549,6 +549,11 @@ contains
       ierr = PIO_def_var(pio_atm_file%pioFileDesc, trim(shortname), hist_var%dtype, hist_var%dimid(:numdims), hist_var%piovar)
       call errorHandle("PIO ERROR: could not define variable "//trim(shortname),ierr)
 
+      !PMC
+      ierr=PIO_put_att(pio_atm_file%pioFileDesc, hist_var%piovar, 'units', 'pigs')
+      ierr=PIO_put_att(pio_atm_file%pioFileDesc, hist_var%piovar, 'long_name', 'chickens')
+
+      
       ! Update the number of variables on file
       pio_atm_file%varcounter = pio_atm_file%varcounter + 1
     else

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -479,9 +479,10 @@ contains
   !                 decomposition for reading this variable.  It is ok to reuse
   !                 the pio_decomp_tag for variables that have the same
   !                 dimensionality.  See get_decomp for more details.
-  subroutine register_variable(filename,shortname,longname,numdims,var_dimensions,dtype,pio_decomp_tag)
+  subroutine register_variable(filename,shortname,longname,units,numdims,var_dimensions,dtype,pio_decomp_tag)
     character(len=*), intent(in) :: filename         ! Name of the file to register this variable with
     character(len=*), intent(in) :: shortname,longname       ! short and long names for the variable.  Short: variable name in file, Long: more descriptive name
+    character(len=*), intent(in) :: units                    ! units for variable
     integer, intent(in)          :: numdims                  ! Number of dimensions for this variable, including time dimension
     character(len=*), intent(in) :: var_dimensions(numdims)  ! String array with shortname descriptors for each dimension of variable.
     integer, intent(in)          :: dtype                    ! datatype for this variable, REAL, DOUBLE, INTEGER, etc.
@@ -496,7 +497,7 @@ contains
     character(len=256)           :: dimlen_str
 
     type(hist_var_list_t), pointer :: curr, prev
-
+    
     var_found = .false.
 
     ! Find the pointer for this file
@@ -529,6 +530,7 @@ contains
       ! Populate meta-data associated with this variable
       hist_var%name      = trim(shortname)
       hist_var%long_name = trim(longname)
+      hist_var%units = trim(units)
       hist_var%numdims   = numdims
       hist_var%dtype     = dtype
       hist_var%pio_decomp_tag = trim(pio_decomp_tag)
@@ -550,11 +552,10 @@ contains
       call errorHandle("PIO ERROR: could not define variable "//trim(shortname),ierr)
 
       !PMC
-      ierr=PIO_put_att(pio_atm_file%pioFileDesc, hist_var%piovar, 'units', 'pigs')
-      ierr=PIO_put_att(pio_atm_file%pioFileDesc, hist_var%piovar, 'long_name', 'chickens')
+      ierr=PIO_put_att(pio_atm_file%pioFileDesc, hist_var%piovar, 'units', hist_var%units )
+      ierr=PIO_put_att(pio_atm_file%pioFileDesc, hist_var%piovar, 'long_name', hist_var%long_name )
 
-      
-      ! Update the number of variables on file
+            ! Update the number of variables on file
       pio_atm_file%varcounter = pio_atm_file%varcounter + 1
     else
       ! The var was already registered by another input/output instance. Check that everything matches
@@ -562,6 +563,9 @@ contains
       if ( trim(hist_var%long_name) .ne. trim(longname) ) then
         ! Different long name
         call errorHandle("PIO Error: variable "//trim(shortname)//", already registered with different longname, in file: "//trim(filename),-999)
+     elseif ( trim(hist_var%units) .ne. trim(units) ) then
+        ! Different units
+        call errorHandle("PIO Error: variable "//trim(shortname)//", already registered with different units, in file: "//trim(filename),-999)
       elseif (hist_var%dtype .ne. dtype) then
         ! Different data type
         call errorHandle("PIO Error: variable "//trim(shortname)//", already registered with different dtype, in file: "//trim(filename),-999)

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -26,7 +26,7 @@ extern "C" {
   void eam_pio_closefile_c2f(const char*&& filename);
   void pio_update_time_c2f(const char*&& filename,const Real time);
   void register_dimension_c2f(const char*&& filename, const char*&& shortname, const char*&& longname, const int length);
-  void register_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
+  void register_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const char*&& units, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
   void get_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
   void eam_pio_enddef_c2f(const char*&& filename);
 
@@ -102,7 +102,7 @@ void get_variable(const std::string &filename, const std::string& shortname, con
   get_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
 }
 /* ----------------------------------------------------------------- */
-void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
+void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
 
   /* Convert the vector of strings that contains the variable dimensions to a char array */
   const char** var_dimensions_c = new const char*[numdims];
@@ -110,13 +110,13 @@ void register_variable(const std::string &filename, const std::string& shortname
   {
     var_dimensions_c[ii] = var_dimensions[ii].c_str();
   }
-  register_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), numdims, var_dimensions_c, dtype, pio_decomp_tag.c_str());
+  register_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), units.c_str(), numdims, var_dimensions_c, dtype, pio_decomp_tag.c_str());
   delete[] var_dimensions_c;
 }
 /* ----------------------------------------------------------------- */
-void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
+void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
 
-  register_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
+  register_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), units.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
 }
 /* ----------------------------------------------------------------- */
 void eam_pio_enddef(const std::string &filename) {

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -46,8 +46,8 @@ namespace scorpio {
   /* Register a dimension coordinate with a file. Called during the file setup. */
   void register_dimension(const std::string& filename,const std::string& shortname, const std::string& longname, const int length);
   /* Register a variable with a file.  Called during the file setup, for an output stream. */
-  void register_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
-  void register_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
+  void register_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
+  void register_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
   /* Register a variable with a file.  Called during the file setup, for an input stream. */
   void get_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
   void get_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag);

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -183,11 +183,12 @@ contains
     call set_int_attribute(file_name,attr_name,val)
   end subroutine set_int_attribute_c2f
 !=====================================================================!
-  subroutine register_variable_c2f(filename_in, shortname_in, longname_in, numdims, var_dimensions_in, dtype, pio_decomp_tag_in) bind(c)
+  subroutine register_variable_c2f(filename_in, shortname_in, longname_in, units_in, numdims, var_dimensions_in, dtype, pio_decomp_tag_in) bind(c)
     use scream_scorpio_interface, only : register_variable
     type(c_ptr), intent(in)                :: filename_in
     type(c_ptr), intent(in)                :: shortname_in
     type(c_ptr), intent(in)                :: longname_in
+    type(c_ptr), intent(in)                :: units_in
     integer(kind=c_int), value, intent(in) :: numdims
     type(c_ptr), intent(in)                :: var_dimensions_in(numdims)
     integer(kind=c_int), value, intent(in) :: dtype
@@ -196,6 +197,7 @@ contains
     character(len=256) :: filename
     character(len=256) :: shortname
     character(len=256) :: longname
+    character(len=256) :: units
     character(len=256) :: var_dimensions(numdims)
     character(len=256) :: pio_decomp_tag
     integer            :: ii
@@ -203,12 +205,13 @@ contains
     call convert_c_string(filename_in,filename)
     call convert_c_string(shortname_in,shortname)
     call convert_c_string(longname_in,longname)
+    call convert_c_string(units_in,units)
     call convert_c_string(pio_decomp_tag_in,pio_decomp_tag)
     do ii = 1,numdims
       call convert_c_string(var_dimensions_in(ii), var_dimensions(ii))
     end do
    
-    call register_variable(filename,shortname,longname,numdims,var_dimensions,dtype,pio_decomp_tag)
+    call register_variable(filename,shortname,longname,units,numdims,var_dimensions,dtype,pio_decomp_tag)
 
   end subroutine register_variable_c2f
 !=====================================================================!


### PR DESCRIPTION
SCREAMv1 netcdf output files lacked info about the units of each variable as well as a long name explaining them. This PR adds that.