### PR TITLE
Revised theta_l definition to SHOC

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -3801,7 +3801,8 @@ subroutine update_host_dse(&
 
   do k=1,nlev
     do i=1,shcol
-      temp = (thlm(i,k)+(lcond/cp)*shoc_ql(i,k))/inv_exner(i,k)
+!      temp = (thlm(i,k)+(lcond/cp)*shoc_ql(i,k))/inv_exner(i,k)
+      temp = (thlm(i,k)/inv_exner(i,k))+(lcond/cp)*shoc_ql(i,k)
       host_dse(i,k) = cp*temp+ggr*zt_grid(i,k)+phis(i)
     enddo
   enddo

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -3801,7 +3801,6 @@ subroutine update_host_dse(&
 
   do k=1,nlev
     do i=1,shcol
-!      temp = (thlm(i,k)+(lcond/cp)*shoc_ql(i,k))/inv_exner(i,k)
       temp = (thlm(i,k)/inv_exner(i,k))+(lcond/cp)*shoc_ql(i,k)
       host_dse(i,k) = cp*temp+ggr*zt_grid(i,k)+phis(i)
     enddo

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -609,7 +609,7 @@ end function shoc_implements_cnst
    real(r8) :: minqn, rrho(pcols,pver), rrho_i(pcols,pverp)    ! minimum total cloud liquid + ice threshold    [kg/kg]
    real(r8) :: cldthresh, frac_limit
    real(r8) :: ic_limit, dum1
-   real(r8) :: inv_exner_surf
+   real(r8) :: inv_exner_surf, pot_temp
  
    real(r8) :: wpthlp_sfc(pcols), wprtp_sfc(pcols), upwp_sfc(pcols), vpwp_sfc(pcols)
    real(r8) :: wtracer_sfc(pcols,edsclr_dim)
@@ -777,7 +777,9 @@ end function shoc_implements_cnst
        um(i,k) = state1%u(i,k)
        vm(i,k) = state1%v(i,k)
        
-       thlm(i,k) = state1%t(i,k)*inv_exner(i,k)-(latvap/cpair)*state1%q(i,k,ixcldliq)
+       !thlm(i,k) = state1%t(i,k)*inv_exner(i,k)-(latvap/cpair)*state1%q(i,k,ixcldliq)
+       pot_temp = state1%t(i,k)*inv_exner(i,k)
+       thlm(i,k) = pot_temp-(pot_temp/state1%t(i,k))*(latvap/cpair)*state1%q(i,k,ixcldliq)
        thv(i,k) = state1%t(i,k)*inv_exner(i,k)*(1.0_r8+zvir*state1%q(i,k,ixq)-state1%q(i,k,ixcldliq)) 
  
        tke_zt(i,k) = max(tke_tol,state1%q(i,k,ixtke))

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -777,7 +777,6 @@ end function shoc_implements_cnst
        um(i,k) = state1%u(i,k)
        vm(i,k) = state1%v(i,k)
        
-       !thlm(i,k) = state1%t(i,k)*inv_exner(i,k)-(latvap/cpair)*state1%q(i,k,ixcldliq)
        pot_temp = state1%t(i,k)*inv_exner(i,k)
        thlm(i,k) = pot_temp-(pot_temp/state1%t(i,k))*(latvap/cpair)*state1%q(i,k,ixcldliq)
        thv(i,k) = state1%t(i,k)*inv_exner(i,k)*(1.0_r8+zvir*state1%q(i,k,ixq)-state1%q(i,k,ixcldliq)) 

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -114,7 +114,7 @@ public:
 
         // Temperature
         const auto& theta_zt = PF::calculate_theta_from_T(T_mid(i,k),p_mid(i,k));
-        thlm(i,k) = theta_zt - (latvap/cpair)*qc(i,k);
+        thlm(i,k) = theta_zt-(theta_zt/T_mid(i,k))*(latvap/cpair)*qc(i,k);
         thv(i,k)  = theta_zt*(1 + zvir*qv(i,k) - qc(i,k));
 
         // Vertical layer thickness

--- a/components/scream/src/physics/shoc/shoc_update_host_dse_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_update_host_dse_impl.hpp
@@ -27,7 +27,7 @@ void Functions<S,D>
   const auto ggr = C::gravit;
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
-      Spack temp = (thlm(k)+(lcond/cp)*shoc_ql(k))/inv_exner(k);
+      Spack temp = (thlm(k)/inv_exner(k))+(lcond/cp)*shoc_ql(k);
       host_dse(k) = cp*temp+ggr*zt_grid(k)+phis;
   });
 }


### PR DESCRIPTION
This PR assigns a less approximate definition of theta_l (liquid water potential temperature) to SHOC.  The effect is a much reduced work done by the energy fixer in certain columns.  DP-SCREAM simulations shows that this modification (tested for five cases at resolutions from 100 m to 5 km) has very minor impact on the model solution.  The F90 and cpp code have both been modified.

This PR is not b4b, thus SHOC run and compare is expected to fail.  

Fixes https://github.com/E3SM-Project/E3SM/issues/4600