### PR TITLE
Compute and expose surface radiative fluxes

### DIFF
--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -24,6 +24,7 @@ set(EXTERNAL_SRC
   ${EAM_RRTMGP_DIR}/external/cpp/rte/kernels/mo_fluxes_broadband_kernels.cpp
   ${EAM_RRTMGP_DIR}/external/cpp/rte/kernels/mo_optical_props_kernels.cpp
   ${EAM_RRTMGP_DIR}/external/cpp/rte/kernels/mo_rte_solver_kernels.cpp
+  ${EAM_RRTMGP_DIR}/external/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.cpp
 )
 add_library(rrtmgp ${EXTERNAL_SRC})
 EkatDisableAllWarning(rrtmgp)

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -40,7 +40,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   kgkg.set_string("kg/kg");
   auto m3 = m * m * m;
   auto Wm2 = W / m / m;
-  Wm2.set_string("Wm2");
+  Wm2.set_string("W/m2)");
   auto nondim = m/m;  // dummy unit for non-dimensional fields
   auto micron = m / 1000000;
 

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -511,7 +511,7 @@ void RRTMGPRadiation::run_impl (const int dt) {
   // Index to surface (bottom of model); used to get surface fluxes below
   const int kbot = nlay+1;
 
-  // Compute diffuse flux as difference between total and direct
+  // Compute diffuse flux as difference between total and direct; use YAKL parallel_for here because these are YAKL objects
   parallel_for(Bounds<3>(m_nswbands,m_nlay+1,m_ncol), YAKL_LAMBDA(int ibnd, int ilev, int icol) {
     sw_bnd_flux_dif(icol,ilev,ibnd) = sw_bnd_flux_dn(icol,ilev,ibnd) - sw_bnd_flux_dir(icol,ilev,ibnd);
   });

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -98,6 +98,8 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   // sols       sfc_flux_dir_vis   solar UV/visible direct flux
   // solld      sfc_flux_dif_nir   solar near-ID diffuse flux
   // solsd      sfc_flux_dif_vis   solar UV/visible diffuse flux
+  // netsw      sfc_flux_sw_net    net (down - up) SW flux at surface
+  // flwds      sfc_flux_lw_dn     downwelling LW flux at surface
   // --------------------------------------------------------------
   add_field<Computed>("sfc_flux_dir_nir", scalar2d_layout, Wm2, grid->name());
   add_field<Computed>("sfc_flux_dir_vis", scalar2d_layout, Wm2, grid->name());

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -520,8 +520,8 @@ void RRTMGPRadiation::run_impl (const int dt) {
   rrtmgp::compute_broadband_surface_fluxes(
       m_ncol, kbot, m_nswbands,
       sw_bnd_flux_dir, sw_bnd_flux_dif, 
-      sfc_flux_dir_nir, sfc_flux_dir_vis, 
-      sfc_flux_dif_nir, sfc_flux_dif_vis
+      sfc_flux_dir_vis, sfc_flux_dir_nir, 
+      sfc_flux_dif_vis, sfc_flux_dif_nir
   );
 
   // Copy output data back to FieldManager

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -78,10 +78,12 @@ public:
 
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {
-    static constexpr int num_1d_ncol        = 6;
+    static constexpr int num_1d_ncol        = 10;
     static constexpr int num_2d_nlay        = 14;
     static constexpr int num_2d_nlay_p1     = 7;
     static constexpr int num_2d_nswbands    = 2;
+    static constexpr int num_3d_nswbands    = 4;
+    static constexpr int num_3d_nlwbands    = 2;
 
     // 1d size (ncol)
     real1d mu0;
@@ -90,6 +92,10 @@ public:
     real1d sfc_alb_dif_vis;
     real1d sfc_alb_dif_nir;
     uview_1d<Real> cosine_zenith;
+    real1d sfc_flux_dir_vis;
+    real1d sfc_flux_dir_nir;
+    real1d sfc_flux_dif_vis;
+    real1d sfc_flux_dif_nir;
 
     // 2d size (ncol, nlay)
     real2d p_lay;
@@ -115,6 +121,16 @@ public:
     real2d sw_flux_dn_dir;
     real2d lw_flux_up;
     real2d lw_flux_dn;
+
+    // 3d size (ncol, nlay+1, nswbands)
+    real3d sw_bnd_flux_up;
+    real3d sw_bnd_flux_dn;
+    real3d sw_bnd_flux_dir;
+    real3d sw_bnd_flux_dif;
+
+    // 3d size (ncol, nlay+1, nlwbands)
+    real3d lw_bnd_flux_up;
+    real3d lw_bnd_flux_dn;
 
     // 2d size (ncol, nswbands)
     real2d sfc_alb_dir;

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -157,7 +157,7 @@ namespace scream {
             // Threshold between visible and infrared is 0.7 micron, or 14286 cm^-1.
             const real visible_wavenumber_threshold = 14286;
             auto wavenumber_limits = k_dist_sw.get_band_lims_wavenumber();
-            parallel_for(Bounds<2>(nswbands, ncol), YAKL_LAMBDA(const int ibnd, const int icol) {
+            parallel_for(Bounds<2>(nswbands, ncol), YAKL_DEVICE_LAMBDA(const int ibnd, const int icol) {
 
                 // Wavenumber is in the visible if it is above the visible wavenumber
                 // threshold, and in the infrared if it is below the threshold

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -144,13 +144,13 @@ namespace scream {
                 const bool i_am_root) {
 
             // Setup pointers to RRTMGP SW fluxes
-            FluxesBroadband fluxes_sw;
+            FluxesByband fluxes_sw;
             fluxes_sw.flux_up = sw_flux_up;
             fluxes_sw.flux_dn = sw_flux_dn;
             fluxes_sw.flux_dn_dir = sw_flux_dn_dir;
 
             // Setup pointers to RRTMGP LW fluxes
-            FluxesBroadband fluxes_lw;
+            FluxesByband fluxes_lw;
             fluxes_lw.flux_up = lw_flux_up;
             fluxes_lw.flux_dn = lw_flux_dn;
 
@@ -236,7 +236,7 @@ namespace scream {
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, OpticalProps2str &clouds,
-                FluxesBroadband &fluxes,
+                FluxesByband &fluxes,
                 const bool i_am_root) {
 
             // Get problem sizes
@@ -348,7 +348,7 @@ namespace scream {
             auto flux_up_day = real2d("flux_up_day", nday, nlay+1);
             auto flux_dn_day = real2d("flux_dn_day", nday, nlay+1);
             auto flux_dn_dir_day = real2d("flux_dn_dir_day", nday, nlay+1);
-            FluxesBroadband fluxes_day;
+            FluxesByband fluxes_day;
             fluxes_day.flux_up     = flux_up_day; //real2d("flux_up"    , nday,nlay+1);
             fluxes_day.flux_dn     = flux_dn_day; //real2d("flux_dn"    , nday,nlay+1);
             fluxes_day.flux_dn_dir = flux_dn_dir_day; //real2d("flux_dn_dir", nday,nlay+1);
@@ -370,7 +370,7 @@ namespace scream {
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 OpticalProps1scl &clouds,
-                FluxesBroadband &fluxes) {
+                FluxesByband &fluxes) {
 
             // Problem size
             int nbnd = k_dist.get_nband();

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -41,6 +41,14 @@ namespace scream {
                 real1d &sfc_alb_dif_vis, real1d &sfc_alb_dif_nir,
                 real2d &sfc_alb_dir,     real2d &sfc_alb_dif);
         /*
+         * Compute broadband visible/UV and near-infrared surface fluxes.
+         */
+        extern void compute_broadband_surface_fluxes(
+                const int ncol, const int ktop, const int nswbands,
+                real3d &sw_bnd_flux_dir , real3d &sw_bnd_flux_dif ,
+                real1d &sfc_flux_dir_vis, real1d &sfc_flux_dir_nir,
+                real1d &sfc_flux_dif_vis, real1d &sfc_flux_dif_nir);
+        /*
          * Main driver code to run RRTMGP. Optional input
          * i_am_root is defaulted to true, and is used to
          * determine whether or not info should be printed
@@ -54,6 +62,8 @@ namespace scream {
                 real2d &lwp, real2d &iwp, real2d &rel, real2d &rei,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
                 real2d &lw_flux_up, real2d &lw_flux_dn,
+                real3d &sw_bnd_flux_up, real3d &sw_bnd_flux_dn, real3d &sw_bnd_flux_dn_dir,
+                real3d &lw_bnd_flux_up, real3d &lw_bnd_flux_dn,
                 const bool i_am_root = true);
         /*
          * Perform any clean-up tasks

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -3,10 +3,9 @@
 
 #include "cpp/rrtmgp/mo_gas_optics_rrtmgp.h"
 #include "cpp/extensions/cloud_optics/mo_cloud_optics.h"
-#include "cpp/rte/mo_fluxes.h"
+#include "cpp/extensions/fluxes_byband/mo_fluxes_byband.h"
 #include "cpp/rrtmgp_const.h"
 #include "physics/share/physics_constants.hpp"
-
 #include "ekat/mpi/ekat_comm.hpp"
 
 namespace scream {
@@ -68,7 +67,7 @@ namespace scream {
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, OpticalProps2str &clouds,
-                FluxesBroadband &fluxes, const bool i_am_root);
+                FluxesByband &fluxes, const bool i_am_root);
         /*
          * Longwave driver (called by rrtmgp_main)
          */
@@ -78,7 +77,7 @@ namespace scream {
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 OpticalProps1scl &clouds,
-                FluxesBroadband &fluxes);
+                FluxesByband &fluxes);
         /* 
          * Provide a function to convert cloud (water and ice) mixing ratios to layer mass per unit area
          * (what E3SM refers to as "in-cloud water paths", a terminology we shun here to avoid confusion

--- a/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
@@ -85,14 +85,20 @@ int main (int argc, char** argv) {
     // input/outputs into the driver (persisting between calls), and
     // we would just have to setup the pointers to them in the
     // FluxesBroadband object
-    real2d sw_flux_up ("sw_flux_up" ,ncol,nlay+1);
-    real2d sw_flux_dn ("sw_flux_dn" ,ncol,nlay+1);
-    real2d sw_flux_dn_dir("sw_flux_dn_dir",ncol,nlay+1);
-    real2d lw_flux_up ("lw_flux_up" ,ncol,nlay+1);
-    real2d lw_flux_dn ("lw_flux_dn" ,ncol,nlay+1);
+    const int nswbands = 14;
+    const int nlwbands = 16;
+    real2d sw_flux_up ("sw_flux_up" , ncol, nlay+1);
+    real2d sw_flux_dn ("sw_flux_dn" , ncol, nlay+1);
+    real2d sw_flux_dn_dir("sw_flux_dn_dir", ncol, nlay+1);
+    real2d lw_flux_up ("lw_flux_up" , ncol, nlay+1);
+    real2d lw_flux_dn ("lw_flux_dn" , ncol, nlay+1);
+    real3d sw_bnd_flux_up ("sw_bnd_flux_up" , ncol, nlay+1, nswbands);
+    real3d sw_bnd_flux_dn ("sw_bnd_flux_dn" , ncol, nlay+1, nswbands);
+    real3d sw_bnd_flux_dir("sw_bnd_flux_dir", ncol, nlay+1, nswbands);
+    real3d lw_bnd_flux_up ("lw_bnd_flux_up" ,ncol, nlay+1, nlwbands);
+    real3d lw_bnd_flux_dn ("lw_bnd_flux_dn" ,ncol, nlay+1, nlwbands);
 
     // Compute band-by-band surface_albedos.
-    const auto nswbands = 14;
     real2d sfc_alb_dir("sfc_alb_dir", ncol, nswbands);
     real2d sfc_alb_dif("sfc_alb_dif", ncol, nswbands);
     rrtmgp::compute_band_by_band_surface_albedos(
@@ -111,7 +117,9 @@ int main (int argc, char** argv) {
         sfc_alb_dir, sfc_alb_dif, mu0,
         lwp, iwp, rel, rei,
         sw_flux_up, sw_flux_dn, sw_flux_dn_dir,
-        lw_flux_up, lw_flux_dn
+        lw_flux_up, lw_flux_dn,
+        sw_bnd_flux_up, sw_bnd_flux_dn, sw_bnd_flux_dir,
+        lw_bnd_flux_up, lw_bnd_flux_dn
     );
 
     // Write fluxes
@@ -151,6 +159,11 @@ int main (int argc, char** argv) {
     sw_flux_dn_dir.deallocate();
     lw_flux_up.deallocate();
     lw_flux_dn.deallocate();
+    sw_bnd_flux_up.deallocate();
+    sw_bnd_flux_dn.deallocate();
+    sw_bnd_flux_dir.deallocate();
+    lw_bnd_flux_up.deallocate();
+    lw_bnd_flux_dn.deallocate();
 
     gas_concs.reset();
     rrtmgp::rrtmgp_finalize();

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
@@ -119,14 +119,20 @@ int main(int argc, char** argv) {
     // we would just have to setup the pointers to them in the
     // FluxesBroadband object
     std::cout << "Setup fluxes...\n";
-    real2d sw_flux_up ("sw_flux_up" ,ncol,nlay+1);
-    real2d sw_flux_dn ("sw_flux_dn" ,ncol,nlay+1);
-    real2d sw_flux_dir("sw_flux_dir",ncol,nlay+1);
-    real2d lw_flux_up ("lw_flux_up" ,ncol,nlay+1);
-    real2d lw_flux_dn ("lw_flux_dn" ,ncol,nlay+1);
+    const auto nswbands = scream::rrtmgp::k_dist_sw.get_nband();
+    const auto nlwbands = scream::rrtmgp::k_dist_lw.get_nband();
+    real2d sw_flux_up ("sw_flux_up" , ncol, nlay+1);
+    real2d sw_flux_dn ("sw_flux_dn" , ncol, nlay+1);
+    real2d sw_flux_dir("sw_flux_dir", ncol, nlay+1);
+    real2d lw_flux_up ("lw_flux_up" , ncol, nlay+1);
+    real2d lw_flux_dn ("lw_flux_dn" , ncol, nlay+1);
+    real3d sw_bnd_flux_up ("sw_bnd_flux_up" , ncol, nlay+1, nswbands);
+    real3d sw_bnd_flux_dn ("sw_bnd_flux_dn" , ncol, nlay+1, nswbands);
+    real3d sw_bnd_flux_dir("sw_bnd_flux_dir", ncol, nlay+1, nswbands);
+    real3d lw_bnd_flux_up ("lw_bnd_flux_up" , ncol, nlay+1, nlwbands);
+    real3d lw_bnd_flux_dn ("lw_bnd_flux_dn" , ncol, nlay+1, nlwbands);
 
     // Compute band-by-band surface_albedos.
-    const auto nswbands = scream::rrtmgp::k_dist_sw.get_nband();
     real2d sfc_alb_dir("sfc_alb_dir", ncol, nswbands);
     real2d sfc_alb_dif("sfc_alb_dif", ncol, nswbands);
     rrtmgp::compute_band_by_band_surface_albedos(
@@ -143,7 +149,9 @@ int main(int argc, char** argv) {
             sfc_alb_dir, sfc_alb_dif, mu0,
             lwp, iwp, rel, rei,
             sw_flux_up, sw_flux_dn, sw_flux_dir,
-            lw_flux_up, lw_flux_dn);
+            lw_flux_up, lw_flux_dn,
+            sw_bnd_flux_up, sw_bnd_flux_dn, sw_bnd_flux_dir,
+            lw_bnd_flux_up, lw_bnd_flux_dn);
 
     // Check values against baseline
     std::cout << "Check values...\n";
@@ -171,6 +179,11 @@ int main(int argc, char** argv) {
     sw_flux_dir.deallocate();
     lw_flux_up.deallocate();
     lw_flux_dn.deallocate();
+    sw_bnd_flux_up.deallocate();
+    sw_bnd_flux_dn.deallocate();
+    sw_bnd_flux_dir.deallocate();
+    lw_bnd_flux_up.deallocate();
+    lw_bnd_flux_dn.deallocate();
     p_lay.deallocate();
     t_lay.deallocate();
     p_lev.deallocate();

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
@@ -284,10 +284,11 @@ TEST_CASE("rrtmgp_test_compute_broadband_surface_flux") {
     );
     // Check computed surface fluxes
     std::cout << "Check computed fluxes...\n";
-    REQUIRE(sfc_flux_dir_nir(1) == 0.5);
-    REQUIRE(sfc_flux_dir_vis(1) == 0.5);
-    REQUIRE(sfc_flux_dif_nir(1) == 0.5);
-    REQUIRE(sfc_flux_dif_vis(1) == 0.5);
+    const double tol = 1e-10;  // tolerance on floating point inequality for assertions
+    REQUIRE(std::abs(sfc_flux_dir_nir.createHostCopy()(1) - 0.5) < tol);
+    REQUIRE(std::abs(sfc_flux_dir_vis.createHostCopy()(1) - 0.5) < tol);
+    REQUIRE(std::abs(sfc_flux_dif_nir.createHostCopy()(1) - 0.5) < tol);
+    REQUIRE(std::abs(sfc_flux_dif_vis.createHostCopy()(1) - 0.5) < tol);
     // ---------------------------------
 
     // ---------------------------------
@@ -315,10 +316,10 @@ TEST_CASE("rrtmgp_test_compute_broadband_surface_flux") {
     );
     // Check computed surface fluxes
     std::cout << "Check computed fluxes...\n";
-    REQUIRE(sfc_flux_dir_nir(1) == 9);
-    REQUIRE(sfc_flux_dir_vis(1) == 0);
-    REQUIRE(sfc_flux_dif_nir(1) == 9);
-    REQUIRE(sfc_flux_dif_vis(1) == 0);
+    REQUIRE(std::abs(sfc_flux_dir_nir.createHostCopy()(1) - 9.0) < tol);
+    REQUIRE(std::abs(sfc_flux_dir_vis.createHostCopy()(1) - 0.0) < tol);
+    REQUIRE(std::abs(sfc_flux_dif_nir.createHostCopy()(1) - 9.0) < tol);
+    REQUIRE(std::abs(sfc_flux_dif_vis.createHostCopy()(1) - 0.0) < tol);
     // ---------------------------------
  
     // ---------------------------------
@@ -346,10 +347,10 @@ TEST_CASE("rrtmgp_test_compute_broadband_surface_flux") {
     );
     // Check computed surface fluxes
     std::cout << "Check computed fluxes...\n";
-    REQUIRE(sfc_flux_dir_nir(1) == 0);
-    REQUIRE(sfc_flux_dir_vis(1) == 4);
-    REQUIRE(sfc_flux_dif_nir(1) == 0);
-    REQUIRE(sfc_flux_dif_vis(1) == 4);
+    REQUIRE(std::abs(sfc_flux_dir_nir.createHostCopy()(1) - 0.0) < tol);
+    REQUIRE(std::abs(sfc_flux_dir_vis.createHostCopy()(1) - 4.0) < tol);
+    REQUIRE(std::abs(sfc_flux_dif_nir.createHostCopy()(1) - 0.0) < tol);
+    REQUIRE(std::abs(sfc_flux_dif_vis.createHostCopy()(1) - 4.0) < tol);
     // ---------------------------------
 
     // ---------------------------------
@@ -377,10 +378,10 @@ TEST_CASE("rrtmgp_test_compute_broadband_surface_flux") {
     );
     // Check computed surface fluxes
     std::cout << "Check computed fluxes...\n";
-    REQUIRE(sfc_flux_dir_nir(1) == 10.5);
-    REQUIRE(sfc_flux_dir_vis(1) == 21.5);
-    REQUIRE(sfc_flux_dif_nir(1) == 20.0);
-    REQUIRE(sfc_flux_dif_vis(1) == 26.0);
+    REQUIRE(std::abs(sfc_flux_dir_nir.createHostCopy()(1) - 10.5) < tol);
+    REQUIRE(std::abs(sfc_flux_dir_vis.createHostCopy()(1) - 21.5) < tol);
+    REQUIRE(std::abs(sfc_flux_dif_nir.createHostCopy()(1) - 20.0) < tol);
+    REQUIRE(std::abs(sfc_flux_dif_vis.createHostCopy()(1) - 26.0) < tol);
     // ---------------------------------
 
     // Finalize YAKL

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
@@ -217,3 +217,112 @@ TEST_CASE("rrtmgp_test_zenith") {
     REQUIRE(std::abs(coszrs-coszrs_ref)<1e-14);
 
 }
+
+TEST_CASE("rrtmgp_test_compute_broadband_surface_flux") {
+
+    // Initialize YAKL
+    if (!yakl::isInitialized()) { yakl::init(); }
+
+    // Create arrays
+    const int ncol = 1;
+    const int nlay = 1;
+    const int nbnd = 14;
+    const int kbot = nlay + 1;
+    auto sfc_flux_dir_nir = real1d("sfc_flux_dir_nir", ncol);
+    auto sfc_flux_dir_vis = real1d("sfc_flux_dir_vis", ncol);
+    auto sfc_flux_dif_nir = real1d("sfc_flux_dif_nir", ncol);
+    auto sfc_flux_dif_vis = real1d("sfc_flux_dif_vis", ncol);
+
+    // Need to initialize RRTMGP with dummy gases
+    std::cout << "Init gases...\n";
+    GasConcs gas_concs;
+    int ngas = 8;
+    string1d gas_names("gas_names",ngas);
+    gas_names(1) = std::string("h2o");
+    gas_names(2) = std::string("co2");
+    gas_names(3) = std::string("o3" );
+    gas_names(4) = std::string("n2o");
+    gas_names(5) = std::string("co" );
+    gas_names(6) = std::string("ch4");
+    gas_names(7) = std::string("o2" );
+    gas_names(8) = std::string("n2" );
+    gas_concs.init(gas_names,ncol,nlay);
+    std::cout << "Init RRTMGP...\n";
+    scream::rrtmgp::rrtmgp_initialize(gas_concs);
+
+    // Create a simple test case; We expect, given the input data, that band 10
+    // will straddle the NIR and VIS, bands 1-9 will be purely NIR, and bands 11-14
+    // will be purely VIS. So devise a test for this; this should return 0.5 for 
+    // both NIR and VIS fluxes
+    auto sw_bnd_flux_dir = real3d("sw_bnd_flux_dir", ncol, nlay+1, nbnd);
+    auto sw_bnd_flux_dif = real3d("sw_bnd_flux_dif", ncol, nlay+1, nbnd);
+    parallel_for(Bounds<3>(nbnd,nlay+1,ncol), YAKL_LAMBDA(int ibnd, int ilay, int icol) {
+        if (ibnd < 10) {
+            sw_bnd_flux_dir(icol,ilay,ibnd) = 0;
+            sw_bnd_flux_dif(icol,ilay,ibnd) = 0;
+        } else if (ibnd == 10) {
+            sw_bnd_flux_dir(icol,ilay,ibnd) = 1;
+            sw_bnd_flux_dif(icol,ilay,ibnd) = 1;
+        } else {
+            sw_bnd_flux_dir(icol,ilay,ibnd) = 0;
+            sw_bnd_flux_dif(icol,ilay,ibnd) = 0;
+        }
+    });
+    // Compute surface fluxes
+    // This will require RRTMGP being initialized, since the band limits need to be setup
+    std::cout << "Compute broadband surface fluxes...\n";
+    scream::rrtmgp::compute_broadband_surface_fluxes(
+        ncol, kbot, nbnd,
+        sw_bnd_flux_dir, sw_bnd_flux_dif,
+        sfc_flux_dir_vis, sfc_flux_dir_nir,
+        sfc_flux_dif_vis, sfc_flux_dif_nir
+    );
+    // Check computed surface fluxes
+    std::cout << "Check computed fluxes...\n";
+    REQUIRE(sfc_flux_dir_nir(1) == 0.5);
+    REQUIRE(sfc_flux_dir_vis(1) == 0.5);
+    REQUIRE(sfc_flux_dif_nir(1) == 0.5);
+    REQUIRE(sfc_flux_dif_vis(1) == 0.5);
+
+    // Test case, only flux in NIR bands
+    parallel_for(Bounds<3>(nbnd,nlay+1,ncol), YAKL_LAMBDA(int ibnd, int ilay, int icol) {
+        if (ibnd < 10) {
+            sw_bnd_flux_dir(icol,ilay,ibnd) = 1;
+            sw_bnd_flux_dif(icol,ilay,ibnd) = 1;
+        } else if (ibnd == 10) {
+            sw_bnd_flux_dir(icol,ilay,ibnd) = 0;
+            sw_bnd_flux_dif(icol,ilay,ibnd) = 0;
+        } else {
+            sw_bnd_flux_dir(icol,ilay,ibnd) = 0;
+            sw_bnd_flux_dif(icol,ilay,ibnd) = 0;
+        }
+    });
+    // Compute surface fluxes
+    // This will require RRTMGP being initialized, since the band limits need to be setup
+    std::cout << "Compute broadband surface fluxes...\n";
+    scream::rrtmgp::compute_broadband_surface_fluxes(
+        ncol, kbot, nbnd,
+        sw_bnd_flux_dir, sw_bnd_flux_dif,
+        sfc_flux_dir_vis, sfc_flux_dir_nir,
+        sfc_flux_dif_vis, sfc_flux_dif_nir
+    );
+    // Check computed surface fluxes
+    std::cout << "Check computed fluxes...\n";
+    REQUIRE(sfc_flux_dir_nir(1) == 9);
+    REQUIRE(sfc_flux_dir_vis(1) == 0);
+    REQUIRE(sfc_flux_dif_nir(1) == 9);
+    REQUIRE(sfc_flux_dif_vis(1) == 0);
+
+    // Finalize YAKL
+    std::cout << "Free memory...\n";
+    scream::rrtmgp::rrtmgp_finalize();
+    gas_concs.reset();
+    gas_names.deallocate();
+    sw_bnd_flux_dir.deallocate();
+    sw_bnd_flux_dif.deallocate();
+    sfc_flux_dir_nir.deallocate();
+    sfc_flux_dir_vis.deallocate();
+    sfc_flux_dif_nir.deallocate();
+    sfc_flux_dif_vis.deallocate();
+    if (yakl::isInitialized()) { yakl::finalize(); }
+}


### PR DESCRIPTION
Compute and expose surface radiative fluxes from RRTMGP to the Atmosphere Driver. The surface models expect broadband UV+visible (vis) and near infrared (nir) radiative fluxes, but we neglected to implement these fluxes in our initial RRTMGP-to-AD interface, and hence we have been neglecting to pass surface radiative fluxes from the atmosphere to the surface models. Modifications here compute these special broadband quantities from the band-resolved radiative fluxes computed by RRTMGP, and add these fluxes to the FieldManager so that the AD can then export them to the surface models (exporting of those fluxes will need to be handled in a subsequent PR, this PR only deals with the radiation interface responsibility of adding the computed fluxes to the FieldManager). In order to accomplish this, the following modifications are made:
  - Use the RRTMGP `FluxesByband` flux class instead of the `FluxesBroadband` class, which includes not just the broadband integrated fluxes but also the band-resolved fluxes computed by RRTMGP
  - Register YAKL arrays in the radiation buffer to hold the band-resolved fluxes as well as computed surface fluxes
  - Pass band-resolved fluxes back out of `rrtmgp_main` to be used by `run_impl`
  - Add a function to compute surface fluxes from the band-resolved 3D fluxes
  - Register fields in the FM for the new surface fluxes, and copy computed surface fluxes into the FM in `run_impl`