### PR TITLE
Fix to allow dynamics output for DP-SCREAM

### DIFF
--- a/components/eam/src/dynamics/se/stepon.F90
+++ b/components/eam/src/dynamics/se/stepon.F90
@@ -429,8 +429,8 @@ subroutine stepon_run2(phys_state, phys_tend, dyn_in, dyn_out )
    ! we will output dycore variables here to ensure they are always at the same
    ! time as what the physics is writing.  
    ! in single_column mode, dycore is not fully initialized so dont use
-   ! outfld() on dycore decompositions
-   if (.not. single_column) then 
+   ! outfld() on dycore decompositions, but allow it for doubly periodic CRM
+   if (.not. single_column .or. dp_crm) then
    if (hist_fld_active('VOR')) then
       call compute_zeta_C0(tmp_dyn,dyn_in%elem,par,tl_f)
       do ie=1,nelemd


### PR DESCRIPTION
Dynamics output was not enabled for DP-SCREAM since the single column model (SCM) logical is active (to use the SCM infrastructure).  Thus add the dp_crm flag logical where dynamics output is written to allow this output for DP-SCREAM.