### PR TITLE
Change name of surf_latent_heat to surf_evaporation to match coupler.

### DIFF
--- a/components/scream/data/scream_output.yaml
+++ b/components/scream/data/scream_output.yaml
@@ -41,7 +41,7 @@ Fields:
       - p_mid
       - phis
       - pseudo_density
-      - surf_evaporation
+      - surf_evap
       - surf_mom_flux
       - surf_sens_flux
       - cldfrac_ice

--- a/components/scream/data/scream_output.yaml
+++ b/components/scream/data/scream_output.yaml
@@ -41,7 +41,7 @@ Fields:
       - p_mid
       - phis
       - pseudo_density
-      - surf_latent_flux
+      - surf_evaporation
       - surf_mom_flux
       - surf_sens_flux
       - cldfrac_ice

--- a/components/scream/src/control/surface_coupling.cpp
+++ b/components/scream/src/control/surface_coupling.cpp
@@ -112,7 +112,7 @@ register_import(const std::string& fname,
 
     // For import fluxes, we must change the sign as cpl and atm interprete the direction differently.
     if (fname == "surf_mom_flux"    || fname == "surf_sens_flux" ||
-        fname == "surf_latent_flux" || fname == "surf_lw_flux_up") {
+        fname == "surf_evaporation" || fname == "surf_lw_flux_up") {
       m_cpl_scream_sign_change_host(m_num_scream_imports) = -1;
     } else {
       m_cpl_scream_sign_change_host(m_num_scream_imports) = 1;

--- a/components/scream/src/control/surface_coupling.cpp
+++ b/components/scream/src/control/surface_coupling.cpp
@@ -112,7 +112,7 @@ register_import(const std::string& fname,
 
     // For import fluxes, we must change the sign as cpl and atm interprete the direction differently.
     if (fname == "surf_mom_flux"    || fname == "surf_sens_flux" ||
-        fname == "surf_evaporation" || fname == "surf_lw_flux_up") {
+        fname == "surf_evap"        || fname == "surf_lw_flux_up") {
       m_cpl_scream_sign_change_host(m_num_scream_imports) = -1;
     } else {
       m_cpl_scream_sign_change_host(m_num_scream_imports) = 1;

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -257,7 +257,7 @@ TEST_CASE ("recreate_mct_coupling")
 
   // Create import fields
   const auto nondim = Units::nondimensional();
-  FID surf_evaporation_id ("surf_evaporation",   scalar2d_layout, kg/(m*m)/s, grid_name);
+  FID surf_evap_id        ("surf_evap",   scalar2d_layout, kg/(m*m)/s, grid_name);
   FID surf_sens_flux_id   ("surf_sens_flux",     scalar2d_layout, W/(m*m), grid_name);
   FID surf_mom_flux_id    ("surf_mom_flux",      vector2d_layout, W/(m*m), grid_name);
   FID sfc_alb_dir_vis_id  ("sfc_alb_dir_vis",    scalar2d_layout, nondim,  grid_name);
@@ -283,7 +283,7 @@ TEST_CASE ("recreate_mct_coupling")
   // Register fields and tracer group in a FieldManager
   auto fm = std::make_shared<FieldManager> (grid);
   fm->registration_begins();
-  fm->register_field(FR{surf_evaporation_id});
+  fm->register_field(FR{surf_evap_id});
   fm->register_field(FR{surf_sens_flux_id});
   fm->register_field(FR{surf_mom_flux_id});
   fm->register_field(FR{sfc_alb_dir_vis_id});
@@ -302,7 +302,7 @@ TEST_CASE ("recreate_mct_coupling")
   fm->registration_ends();
 
   // Create alias to field views
-  auto surf_evaporation_f = fm->get_field(surf_evaporation_id);
+  auto surf_evap_f        = fm->get_field(surf_evap_id);
   auto surf_sens_flux_f   = fm->get_field(surf_sens_flux_id);
   auto surf_mom_flux_f    = fm->get_field(surf_mom_flux_id);
   auto sfc_alb_dir_vis_f  = fm->get_field(sfc_alb_dir_vis_id);
@@ -321,7 +321,7 @@ TEST_CASE ("recreate_mct_coupling")
   const auto& Q_name = group.m_bundle->get_header().get_identifier().name();
   auto Q = fm->get_field(Q_name);
 
-  auto surf_evaporation_d = surf_evaporation_f.get_view<Real*>();
+  auto surf_evap_d        = surf_evap_f.get_view<Real*>();
   auto surf_sens_flux_d   = surf_sens_flux_f.get_view<Real*>();
   auto surf_mom_flux_d    = surf_mom_flux_f.get_view<Real**>();
   auto sfc_alb_dir_vis_d  = sfc_alb_dir_vis_f.get_view<Real*>();
@@ -336,7 +336,7 @@ TEST_CASE ("recreate_mct_coupling")
   auto qv_d               = qv_f.get_view<Real**>();
   auto precip_liq_surf_d  = precip_liq_surf_f.get_view<Real*>();
 
-  auto surf_evaporation_h = surf_evaporation_f.get_view<Real*,Host>();
+  auto surf_evap_h        = surf_evap_f.get_view<Real*,Host>();
   auto surf_sens_flux_h   = surf_sens_flux_f.get_view<Real*,Host>();
   auto surf_mom_flux_h    = surf_mom_flux_f.get_view<Real**,Host>();
   auto sfc_alb_dir_vis_h  = sfc_alb_dir_vis_f.get_view<Real*,Host>();
@@ -382,7 +382,7 @@ TEST_CASE ("recreate_mct_coupling")
   coupler.register_import("unused",           21);
   coupler.register_import("surf_sens_flux",   22);
   coupler.register_import("surf_lw_flux_up",  23);
-  coupler.register_import("surf_evaporation", 24);
+  coupler.register_import("surf_evap",        24);
   coupler.register_import("unused",           25);
   coupler.register_import("unused",           26);
   coupler.register_import("unused",           27);
@@ -434,7 +434,7 @@ TEST_CASE ("recreate_mct_coupling")
   for (int i=0; i<nruns; ++i) {
 
     // Set import field views to 0
-    surf_evaporation_f.deep_copy(0.0);
+    surf_evap_f.deep_copy(0.0);
     surf_sens_flux_f.deep_copy(0.0);
     surf_mom_flux_f.deep_copy(0.0);
     sfc_alb_dir_vis_f.deep_copy(0.0);
@@ -467,7 +467,7 @@ TEST_CASE ("recreate_mct_coupling")
     coupler.do_export();
 
     // Sync host to device
-    surf_evaporation_f.sync_to_host();
+    surf_evap_f.sync_to_host();
     surf_sens_flux_f.sync_to_host();
     surf_mom_flux_f.sync_to_host();
     sfc_alb_dir_vis_f.sync_to_host();
@@ -496,7 +496,7 @@ TEST_CASE ("recreate_mct_coupling")
       REQUIRE (surf_mom_flux_h   (icol, 1) == -import_raw_data[20 + icol*num_cpl_imports]); // 6th scream import (21st cpl import)
       REQUIRE (surf_sens_flux_h  (icol)    == -import_raw_data[22 + icol*num_cpl_imports]); // 7th scream import (23rd cpl import)
       REQUIRE (surf_lw_flux_up_h (icol)    == -import_raw_data[23 + icol*num_cpl_imports]); // 8th scream import (24th cpl import)
-      REQUIRE (surf_evaporation_h(icol)    == -import_raw_data[24 + icol*num_cpl_imports]); // 9th scream import (24th cpl import)
+      REQUIRE (surf_evap_h       (icol)    == -import_raw_data[24 + icol*num_cpl_imports]); // 9th scream import (24th cpl import)
 
       // Exports
 

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -257,7 +257,7 @@ TEST_CASE ("recreate_mct_coupling")
 
   // Create import fields
   const auto nondim = Units::nondimensional();
-  FID surf_latent_flux_id ("surf_latent_flux",   scalar2d_layout, W/(m*m), grid_name);
+  FID surf_evaporation_id ("surf_evaporation",   scalar2d_layout, kg/(m*m)/s, grid_name);
   FID surf_sens_flux_id   ("surf_sens_flux",     scalar2d_layout, W/(m*m), grid_name);
   FID surf_mom_flux_id    ("surf_mom_flux",      vector2d_layout, W/(m*m), grid_name);
   FID sfc_alb_dir_vis_id  ("sfc_alb_dir_vis",    scalar2d_layout, nondim,  grid_name);
@@ -283,7 +283,7 @@ TEST_CASE ("recreate_mct_coupling")
   // Register fields and tracer group in a FieldManager
   auto fm = std::make_shared<FieldManager> (grid);
   fm->registration_begins();
-  fm->register_field(FR{surf_latent_flux_id});
+  fm->register_field(FR{surf_evaporation_id});
   fm->register_field(FR{surf_sens_flux_id});
   fm->register_field(FR{surf_mom_flux_id});
   fm->register_field(FR{sfc_alb_dir_vis_id});
@@ -302,7 +302,7 @@ TEST_CASE ("recreate_mct_coupling")
   fm->registration_ends();
 
   // Create alias to field views
-  auto surf_latent_flux_f = fm->get_field(surf_latent_flux_id);
+  auto surf_evaporation_f = fm->get_field(surf_evaporation_id);
   auto surf_sens_flux_f   = fm->get_field(surf_sens_flux_id);
   auto surf_mom_flux_f    = fm->get_field(surf_mom_flux_id);
   auto sfc_alb_dir_vis_f  = fm->get_field(sfc_alb_dir_vis_id);
@@ -321,7 +321,7 @@ TEST_CASE ("recreate_mct_coupling")
   const auto& Q_name = group.m_bundle->get_header().get_identifier().name();
   auto Q = fm->get_field(Q_name);
 
-  auto surf_latent_flux_d = surf_latent_flux_f.get_view<Real*>();
+  auto surf_evaporation_d = surf_evaporation_f.get_view<Real*>();
   auto surf_sens_flux_d   = surf_sens_flux_f.get_view<Real*>();
   auto surf_mom_flux_d    = surf_mom_flux_f.get_view<Real**>();
   auto sfc_alb_dir_vis_d  = sfc_alb_dir_vis_f.get_view<Real*>();
@@ -336,7 +336,7 @@ TEST_CASE ("recreate_mct_coupling")
   auto qv_d               = qv_f.get_view<Real**>();
   auto precip_liq_surf_d  = precip_liq_surf_f.get_view<Real*>();
 
-  auto surf_latent_flux_h = surf_latent_flux_f.get_view<Real*,Host>();
+  auto surf_evaporation_h = surf_evaporation_f.get_view<Real*,Host>();
   auto surf_sens_flux_h   = surf_sens_flux_f.get_view<Real*,Host>();
   auto surf_mom_flux_h    = surf_mom_flux_f.get_view<Real**,Host>();
   auto sfc_alb_dir_vis_h  = sfc_alb_dir_vis_f.get_view<Real*,Host>();
@@ -382,7 +382,7 @@ TEST_CASE ("recreate_mct_coupling")
   coupler.register_import("unused",           21);
   coupler.register_import("surf_sens_flux",   22);
   coupler.register_import("surf_lw_flux_up",  23);
-  coupler.register_import("surf_latent_flux", 24);
+  coupler.register_import("surf_evaporation", 24);
   coupler.register_import("unused",           25);
   coupler.register_import("unused",           26);
   coupler.register_import("unused",           27);
@@ -434,7 +434,7 @@ TEST_CASE ("recreate_mct_coupling")
   for (int i=0; i<nruns; ++i) {
 
     // Set import field views to 0
-    surf_latent_flux_f.deep_copy(0.0);
+    surf_evaporation_f.deep_copy(0.0);
     surf_sens_flux_f.deep_copy(0.0);
     surf_mom_flux_f.deep_copy(0.0);
     sfc_alb_dir_vis_f.deep_copy(0.0);
@@ -467,7 +467,7 @@ TEST_CASE ("recreate_mct_coupling")
     coupler.do_export();
 
     // Sync host to device
-    surf_latent_flux_f.sync_to_host();
+    surf_evaporation_f.sync_to_host();
     surf_sens_flux_f.sync_to_host();
     surf_mom_flux_f.sync_to_host();
     sfc_alb_dir_vis_f.sync_to_host();
@@ -496,7 +496,7 @@ TEST_CASE ("recreate_mct_coupling")
       REQUIRE (surf_mom_flux_h   (icol, 1) == -import_raw_data[20 + icol*num_cpl_imports]); // 6th scream import (21st cpl import)
       REQUIRE (surf_sens_flux_h  (icol)    == -import_raw_data[22 + icol*num_cpl_imports]); // 7th scream import (23rd cpl import)
       REQUIRE (surf_lw_flux_up_h (icol)    == -import_raw_data[23 + icol*num_cpl_imports]); // 8th scream import (24th cpl import)
-      REQUIRE (surf_latent_flux_h(icol)    == -import_raw_data[24 + icol*num_cpl_imports]); // 9th scream import (24th cpl import)
+      REQUIRE (surf_evaporation_h(icol)    == -import_raw_data[24 + icol*num_cpl_imports]); // 9th scream import (24th cpl import)
 
       // Exports
 

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -78,7 +78,7 @@ module scream_cpl_indices
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_taux')) = 'surf_mom_flux'
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_tauy')) = 'surf_mom_flux'
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_sen'))  = 'surf_sens_flux'
-    scr_names_x2a(mct_avect_indexra(x2a,'Faxx_evap')) = 'surf_latent_flux'
+    scr_names_x2a(mct_avect_indexra(x2a,'Faxx_evap')) = 'surf_evaporation'
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_lwup')) = 'surf_lw_flux_up'
 
     vec_comp_x2a(mct_avect_indexra(x2a,'Faxx_taux')) = 0

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -78,7 +78,7 @@ module scream_cpl_indices
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_taux')) = 'surf_mom_flux'
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_tauy')) = 'surf_mom_flux'
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_sen'))  = 'surf_sens_flux'
-    scr_names_x2a(mct_avect_indexra(x2a,'Faxx_evap')) = 'surf_evaporation'
+    scr_names_x2a(mct_avect_indexra(x2a,'Faxx_evap')) = 'surf_evap'
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_lwup')) = 'surf_lw_flux_up'
 
     vec_comp_x2a(mct_avect_indexra(x2a,'Faxx_taux')) = 0

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -69,7 +69,7 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   add_field<Required>("pref_mid",         pref_mid_layout,      Pa,      grid_name, ps);
   add_field<Required>("omega",            scalar3d_layout_mid,  Pa/s,    grid_name, ps);
   add_field<Required>("surf_sens_flux",   scalar2d_layout_col,  W/m2,    grid_name);
-  add_field<Required>("surf_evaporation", scalar2d_layout_col,  kg/m2/s, grid_name);
+  add_field<Required>("surf_evap",        scalar2d_layout_col,  kg/m2/s, grid_name);
   add_field<Required>("surf_mom_flux",    surf_mom_flux_layout, N/m2,    grid_name);
 
   add_field<Updated> ("T_mid",            scalar3d_layout_mid, K,       grid_name, ps);
@@ -252,7 +252,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   const auto& pseudo_density   = get_field_in("pseudo_density").get_view<const Spack**>();
   const auto& omega            = get_field_in("omega").get_view<const Spack**>();
   const auto& surf_sens_flux   = get_field_in("surf_sens_flux").get_view<const Real*>();
-  const auto& surf_evaporation = get_field_in("surf_evaporation").get_view<const Real*>();
+  const auto& surf_evap        = get_field_in("surf_evap").get_view<const Real*>();
   const auto& surf_mom_flux    = get_field_in("surf_mom_flux").get_view<const Real**>();
   const auto& qc               = get_field_out("qc").get_view<Spack**>();
   const auto& qv               = get_field_out("qv").get_view<Spack**>();
@@ -289,7 +289,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   const Real z_surf = 0.0;
 
   shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,z_surf,m_cell_area,
-                                T_mid,p_mid,p_int,pseudo_density,omega,phis,surf_sens_flux,surf_evaporation,
+                                T_mid,p_mid,p_int,pseudo_density,omega,phis,surf_sens_flux,surf_evap,
                                 surf_mom_flux,qv,qc,tke,tke_copy,z_mid,z_int,cell_length,
                                 dse,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
                                 wtracer_sfc,wm_zt,inv_exner,thlm,qw);

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -66,11 +66,11 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
   // These variables are needed by the interface, but not actually passed to shoc_main.
   // TODO: Replace pref_mid in the FM with pref_mid read in from the grid data.
-  add_field<Required>("pref_mid",         pref_mid_layout,      Pa,   grid_name, ps);
-  add_field<Required>("omega",            scalar3d_layout_mid,  Pa/s, grid_name, ps);
-  add_field<Required>("surf_sens_flux",   scalar2d_layout_col,  W/m2, grid_name);
-  add_field<Required>("surf_latent_flux", scalar2d_layout_col,  W/m2, grid_name);
-  add_field<Required>("surf_mom_flux",    surf_mom_flux_layout, N/m2, grid_name);
+  add_field<Required>("pref_mid",         pref_mid_layout,      Pa,      grid_name, ps);
+  add_field<Required>("omega",            scalar3d_layout_mid,  Pa/s,    grid_name, ps);
+  add_field<Required>("surf_sens_flux",   scalar2d_layout_col,  W/m2,    grid_name);
+  add_field<Required>("surf_evaporation", scalar2d_layout_col,  kg/m2/s, grid_name);
+  add_field<Required>("surf_mom_flux",    surf_mom_flux_layout, N/m2,    grid_name);
 
   add_field<Updated> ("T_mid",            scalar3d_layout_mid, K,       grid_name, ps);
   add_field<Updated> ("qv",               scalar3d_layout_mid, Qunit,   grid_name, "tracers", ps);
@@ -252,7 +252,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   const auto& pseudo_density   = get_field_in("pseudo_density").get_view<const Spack**>();
   const auto& omega            = get_field_in("omega").get_view<const Spack**>();
   const auto& surf_sens_flux   = get_field_in("surf_sens_flux").get_view<const Real*>();
-  const auto& surf_latent_flux = get_field_in("surf_latent_flux").get_view<const Real*>();
+  const auto& surf_evaporation = get_field_in("surf_evaporation").get_view<const Real*>();
   const auto& surf_mom_flux    = get_field_in("surf_mom_flux").get_view<const Real**>();
   const auto& qc               = get_field_out("qc").get_view<Spack**>();
   const auto& qv               = get_field_out("qv").get_view<Spack**>();
@@ -289,7 +289,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   const Real z_surf = 0.0;
 
   shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,z_surf,m_cell_area,
-                                T_mid,p_mid,p_int,pseudo_density,omega,phis,surf_sens_flux,surf_latent_flux,
+                                T_mid,p_mid,p_int,pseudo_density,omega,phis,surf_sens_flux,surf_evaporation,
                                 surf_mom_flux,qv,qc,tke,tke_copy,z_mid,z_int,cell_length,
                                 dse,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
                                 wtracer_sfc,wm_zt,inv_exner,thlm,qw);

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -160,7 +160,7 @@ public:
 
       wpthlp_sfc(i) = surf_sens_flux(i)/(cpair*rrho_i(i,nlevi_v)[nlevi_p]);
       wpthlp_sfc(i) = wpthlp_sfc(i)*inv_exner_int_surf;
-      wprtp_sfc(i)  = surf_latent_flux(i)/rrho_i(i,nlevi_v)[nlevi_p];
+      wprtp_sfc(i)  = surf_evaporation(i)/rrho_i(i,nlevi_v)[nlevi_p];
       upwp_sfc(i)   = surf_mom_flux(i,0)/rrho_i(i,nlevi_v)[nlevi_p];
       vpwp_sfc(i)   = surf_mom_flux(i,1)/rrho_i(i,nlevi_v)[nlevi_p];
 
@@ -181,7 +181,7 @@ public:
     view_2d_const        omega;
     view_1d_const        phis;
     view_1d_const        surf_sens_flux;
-    view_1d_const        surf_latent_flux;
+    view_1d_const        surf_evaporation;
     sview_2d_const       surf_mom_flux;
     view_2d_const        qv;
     view_2d              z_mid;
@@ -213,7 +213,7 @@ public:
                        const view_1d_const& area_,
                        const view_2d_const& T_mid_, const view_2d_const& p_mid_, const view_2d_const& p_int_, const view_2d_const& pseudo_density_,
                        const view_2d_const& omega_,
-                       const view_1d_const& phis_, const view_1d_const& surf_sens_flux_, const view_1d_const& surf_latent_flux_,
+                       const view_1d_const& phis_, const view_1d_const& surf_sens_flux_, const view_1d_const& surf_evaporation_,
                        const sview_2d_const& surf_mom_flux_,
                        const view_2d_const& qv_, const view_2d& qc_,
                        const view_2d& tke_, const view_2d& tke_copy_,
@@ -237,7 +237,7 @@ public:
       omega = omega_;
       phis = phis_;
       surf_sens_flux = surf_sens_flux_;
-      surf_latent_flux = surf_latent_flux_;
+      surf_evaporation = surf_evaporation_;
       surf_mom_flux = surf_mom_flux_;
       qv = qv_;
       // OUT

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -160,7 +160,7 @@ public:
 
       wpthlp_sfc(i) = surf_sens_flux(i)/(cpair*rrho_i(i,nlevi_v)[nlevi_p]);
       wpthlp_sfc(i) = wpthlp_sfc(i)*inv_exner_int_surf;
-      wprtp_sfc(i)  = surf_evaporation(i)/rrho_i(i,nlevi_v)[nlevi_p];
+      wprtp_sfc(i)  = surf_evap(i)/rrho_i(i,nlevi_v)[nlevi_p];
       upwp_sfc(i)   = surf_mom_flux(i,0)/rrho_i(i,nlevi_v)[nlevi_p];
       vpwp_sfc(i)   = surf_mom_flux(i,1)/rrho_i(i,nlevi_v)[nlevi_p];
 
@@ -181,7 +181,7 @@ public:
     view_2d_const        omega;
     view_1d_const        phis;
     view_1d_const        surf_sens_flux;
-    view_1d_const        surf_evaporation;
+    view_1d_const        surf_evap;
     sview_2d_const       surf_mom_flux;
     view_2d_const        qv;
     view_2d              z_mid;
@@ -213,7 +213,7 @@ public:
                        const view_1d_const& area_,
                        const view_2d_const& T_mid_, const view_2d_const& p_mid_, const view_2d_const& p_int_, const view_2d_const& pseudo_density_,
                        const view_2d_const& omega_,
-                       const view_1d_const& phis_, const view_1d_const& surf_sens_flux_, const view_1d_const& surf_evaporation_,
+                       const view_1d_const& phis_, const view_1d_const& surf_sens_flux_, const view_1d_const& surf_evap_,
                        const sview_2d_const& surf_mom_flux_,
                        const view_2d_const& qv_, const view_2d& qc_,
                        const view_2d& tke_, const view_2d& tke_copy_,
@@ -237,7 +237,7 @@ public:
       omega = omega_;
       phis = phis_;
       surf_sens_flux = surf_sens_flux_;
-      surf_evaporation = surf_evaporation_;
+      surf_evap = surf_evap_;
       surf_mom_flux = surf_mom_flux_;
       qv = qv_;
       // OUT

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -42,7 +42,7 @@ Fields:
       - p_mid
       - phis
       - pseudo_density
-      - surf_evaporation
+      - surf_evap
       - surf_mom_flux
       - surf_sens_flux
       - cldfrac_ice

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -42,7 +42,7 @@ Fields:
       - p_mid
       - phis
       - pseudo_density
-      - surf_latent_flux
+      - surf_evaporation
       - surf_mom_flux
       - surf_sens_flux
       - cldfrac_ice

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 Initial Conditions:
   Physics GLL:
     Filename: homme_shoc_cld_p3_rrtmgp_init_ne2np4.nc
-    surf_latent_flux: 0.0
+    surf_evaporation: 0.0
     surf_sens_flux: 0.0
 
 Atmosphere Processes:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 Initial Conditions:
   Physics GLL:
     Filename: homme_shoc_cld_p3_rrtmgp_init_ne2np4.nc
-    surf_evaporation: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
 
 Atmosphere Processes:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -42,7 +42,7 @@ Fields:
       - p_mid
       - phis
       - pseudo_density
-      - surf_evaporation
+      - surf_evap
       - surf_mom_flux
       - surf_sens_flux
       - cldfrac_ice

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -42,7 +42,7 @@ Fields:
       - p_mid
       - phis
       - pseudo_density
-      - surf_latent_flux
+      - surf_evaporation
       - surf_mom_flux
       - surf_sens_flux
       - cldfrac_ice

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 Initial Conditions:
   Physics GLL:
     Filename: homme_shoc_cld_spa_p3_rrtmgp_init_ne2np4.nc
-    surf_latent_flux: 0.0
+    surf_evaporation: 0.0
     surf_sens_flux: 0.0
 
 Atmosphere Processes:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 Initial Conditions:
   Physics GLL:
     Filename: homme_shoc_cld_spa_p3_rrtmgp_init_ne2np4.nc
-    surf_evaporation: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
 
 Atmosphere Processes:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
@@ -98,8 +98,8 @@ configure_file(${SCREAM_SRC_DIR}/dynamics/homme/tests/theta.nl
                ${CMAKE_CURRENT_BINARY_DIR}/namelist.nl)
 
 # Copy initial conditions files
-GetInputFile(init/homme_physics_ne2np4.nc
-  ${CMAKE_CURRENT_BINARY_DIR}/homme_physics_ne2np4.nc)
+GetInputFile(init/homme_physics_ne2np4_20220204.nc
+  ${CMAKE_CURRENT_BINARY_DIR}/homme_physics_ne2np4_20220204.nc)
 
 # Create vcoord directory
 file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/vcoord)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 Initial Conditions:
   Restart Run: false
   Physics GLL:
-    Filename: homme_physics_ne2np4.nc
+    Filename: homme_physics_ne2np4_20220204.nc
     w_int: 0.0 # Start from zero vert velocity
 
 Atmosphere Processes:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 Initial Conditions:
   Restart Run: false
   Physics GLL:
-    Filename: homme_physics_ne2np4.nc
+    Filename: homme_physics_ne2np4_20220204.nc
     w_int: 0.0 # Start from zero vert velocity
 
 Atmosphere Processes:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -39,7 +39,7 @@ Initial Conditions:
     Filename: shoc_cld_p3_rrtmgp_init_ne2np4.nc
     Load Latitude:  true
     Load Longitude: true
-    surf_latent_flux: 0.0
+    surf_evaporation: 0.0
     surf_sens_flux: 0.0
 
 # The parameters for I/O control

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -39,7 +39,7 @@ Initial Conditions:
     Filename: shoc_cld_p3_rrtmgp_init_ne2np4.nc
     Load Latitude:  true
     Load Longitude: true
-    surf_evaporation: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
 
 # The parameters for I/O control

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
@@ -39,7 +39,7 @@ Field Names:
   - p_mid
   - phis
   - pseudo_density
-  - surf_latent_flux
+  - surf_evaporation
   - surf_mom_flux
   - surf_sens_flux
   - cldfrac_ice

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
@@ -39,7 +39,7 @@ Field Names:
   - p_mid
   - phis
   - pseudo_density
-  - surf_evaporation
+  - surf_evap
   - surf_mom_flux
   - surf_sens_flux
   - cldfrac_ice

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -44,7 +44,7 @@ Initial Conditions:
     Filename: shoc_cld_spa_p3_rrtmgp_init_ne2np4.nc
     Load Latitude:  true
     Load Longitude: true
-    surf_evaporation: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
 
 # The parameters for I/O control

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -44,7 +44,7 @@ Initial Conditions:
     Filename: shoc_cld_spa_p3_rrtmgp_init_ne2np4.nc
     Load Latitude:  true
     Load Longitude: true
-    surf_latent_flux: 0.0
+    surf_evaporation: 0.0
     surf_sens_flux: 0.0
 
 # The parameters for I/O control

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -39,7 +39,7 @@ Field Names:
   - p_mid
   - phis
   - pseudo_density
-  - surf_latent_flux
+  - surf_evaporation
   - surf_mom_flux
   - surf_sens_flux
   - cldfrac_ice

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -39,7 +39,7 @@ Field Names:
   - p_mid
   - phis
   - pseudo_density
-  - surf_evaporation
+  - surf_evap
   - surf_mom_flux
   - surf_sens_flux
   - cldfrac_ice

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -28,7 +28,7 @@ Grids Manager:
 Initial Conditions:
   Point Grid:
     Filename: shoc_init_ne2np4.nc
-    surf_latent_flux: 0.0
+    surf_evaporation: 0.0
     surf_sens_flux: 0.0
 
 # The parameters for I/O control

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -28,7 +28,7 @@ Grids Manager:
 Initial Conditions:
   Point Grid:
     Filename: shoc_init_ne2np4.nc
-    surf_evaporation: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
 
 # The parameters for I/O control


### PR DESCRIPTION
This commit change the name of the field manager variable
surf_latent_heat to be surf_evaporation.  Which is what the actual
variable passed by the component coupler represents.

This commit also changes the units of the variable in the FM to
match the units in the component coupler.