### PR TITLE
Change output netcdf time units to days

### DIFF
--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -213,7 +213,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
       register_dimension(filename,"time","time",0);
 
       // Register time as a variable.
-      auto time_units="s since " + m_case_t0.get_date_string() + " " + m_case_t0.get_time_string();
+      auto time_units="days since " + m_case_t0.get_date_string() + " " + m_case_t0.get_time_string();
       register_variable(filename,"time","time",time_units,1,{"time"},  PIO_REAL,"time");
 
       // Make all output streams register their dims/vars
@@ -249,7 +249,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     }
 
     // Update time and nsteps in the output file
-    pio_update_time(filename,timestamp.seconds_from(m_case_t0));
+    pio_update_time(filename,timestamp.seconds_from(m_case_t0)/86400.0);
     if (m_is_model_restart_output) {
       // Only write nsteps on model restart
       set_int_attribute_c2f(filename.c_str(),"nsteps",timestamp.get_num_steps());
@@ -258,7 +258,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
 
   // Run the output streams
   for (auto& it : m_output_streams) {
-    // Note: filename might referencing an invalid string, but it's only used
+    // Note: filename might reference an invalid string, but it's only used
     //       in case is_write_step=true, in which case it will *for sure* contain
     //       a valid file name.
     it->run(filename,is_write_step,m_output_control.nsteps_since_last_write);

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -213,7 +213,8 @@ void OutputManager::run(const util::TimeStamp& timestamp)
       register_dimension(filename,"time","time",0);
 
       // Register time as a variable.
-      register_variable(filename,"time","time",1,{"time"},  PIO_REAL,"time");
+      auto time_units='s since '+m_case_t0.get_date_string()+' '+m_case_t0.get_time_string();
+      register_variable(filename,"time","time",time_units,1,{"time"},  PIO_REAL,"time");
 
       // Make all output streams register their dims/vars
       for (auto& it : m_output_streams) {
@@ -229,10 +230,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
       if (is_checkpoint_step) { 
         set_int_attribute_c2f (filename.c_str(),"avg_count",m_output_control.nsteps_since_last_write);
       }
-      auto t0_date = m_case_t0.get_date()[0]*10000 + m_case_t0.get_date()[1]*100 + m_case_t0.get_date()[2];
-      auto t0_time = m_case_t0.get_time()[0]*10000 + m_case_t0.get_time()[1]*100 + m_case_t0.get_time()[2];
-      set_int_attribute_c2f(filename.c_str(),"start_date",t0_date);
-      set_int_attribute_c2f(filename.c_str(),"start_time",t0_time);
+
       filespecs.is_open = true;
     }
 

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -249,7 +249,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     }
 
     // Update time and nsteps in the output file
-    pio_update_time(filename,timestamp.seconds_from(m_case_t0)/86400.0);
+    pio_update_time(filename,timestamp.days_from(m_case_t0));
     if (m_is_model_restart_output) {
       // Only write nsteps on model restart
       set_int_attribute_c2f(filename.c_str(),"nsteps",timestamp.get_num_steps());

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -213,7 +213,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
       register_dimension(filename,"time","time",0);
 
       // Register time as a variable.
-      auto time_units='s since '+m_case_t0.get_date_string()+' '+m_case_t0.get_time_string();
+      auto time_units="s since " + m_case_t0.get_date_string() + " " + m_case_t0.get_time_string();
       register_variable(filename,"time","time",time_units,1,{"time"},  PIO_REAL,"time");
 
       // Make all output streams register their dims/vars
@@ -230,7 +230,10 @@ void OutputManager::run(const util::TimeStamp& timestamp)
       if (is_checkpoint_step) { 
         set_int_attribute_c2f (filename.c_str(),"avg_count",m_output_control.nsteps_since_last_write);
       }
-
+      auto t0_date = m_case_t0.get_date()[0]*10000 + m_case_t0.get_date()[1]*100 + m_case_t0.get_date()[2];
+      auto t0_time = m_case_t0.get_time()[0]*10000 + m_case_t0.get_time()[1]*100 + m_case_t0.get_time()[2];
+      set_int_attribute_c2f(filename.c_str(),"start_date",t0_date);
+      set_int_attribute_c2f(filename.c_str(),"start_time",t0_time);
       filespecs.is_open = true;
     }
 

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -628,17 +628,21 @@ contains
     integer                       :: retval
 
     ! TODO change options below to match specific simulation case
-    retval=pio_put_att (File, PIO_GLOBAL, 'source', 'SCREAM')
-    retval=pio_put_att (File, PIO_GLOBAL, 'case', 'TEST 1')
-    retval=pio_put_att (File, PIO_GLOBAL, 'title', 'SCORPIO TEST')
-    retval=pio_put_att (File, PIO_GLOBAL, 'logname','THE GIT LOG HASH')
-    retval=pio_put_att (File, PIO_GLOBAL, 'host', 'THE HOST')
-    retval=pio_put_att (File, PIO_GLOBAL, 'Version', &
-           '0')
-    retval=pio_put_att (File, PIO_GLOBAL, 'revision_Id', &
-           'None')
-    retval=pio_put_att (File, PIO_GLOBAL, 'initial_file', 'NONE FOR NOW')
-    retval=pio_put_att (File, PIO_GLOBAL, 'topography_file', 'NONE FOR NOW')
+    retval=pio_put_att (File, PIO_GLOBAL, 'source', 'E3SM Atmosphere Model Version 4')
+    retval=pio_put_att (File, PIO_GLOBAL, 'case', 'TEST 1') ! NEED TO FIX THIS!!!
+    retval=pio_put_att (File, PIO_GLOBAL, 'title', 'EAMv4 History File')
+    retval=pio_put_att (File, PIO_GLOBAL, 'git_hash','THE GIT LOG HASH')  ! NEED TO FIX THIS!!!
+    retval=pio_put_att (File, PIO_GLOBAL, 'host', 'THE HOST')  ! NEED TO FIX THIS!!!
+    retval=pio_put_att (File, PIO_GLOBAL, 'Version', '1.0')
+    retval=pio_put_att (File, PIO_GLOBAL, 'revision_Id', 'None')  !WHAT IS THIS? NOT IN EAM.
+    retval=pio_put_att (File, PIO_GLOBAL, 'initial_file', 'NONE FOR NOW')  !NEED TO FIX THIS
+    retval=pio_put_att (File, PIO_GLOBAL, 'topography_file', 'NONE FOR NOW')  !NEED TO FIX THIS
+    retval=pio_put_att (File, PIO_GLOBAL, 'contact', 'e3sm-data-support@llnl.gov')
+    retval=pio_put_att (File, PIO_GLOBAL, 'institution_id', 'E3SM-Project')
+    retval=pio_put_att (File, PIO_GLOBAL, 'product', 'model-output')
+    retval=pio_put_att (File, PIO_GLOBAL, 'realm','atmos')
+    retval=pio_put_att (File, PIO_GLOBAL, 'Conventions','None yet')
+    retval=pio_put_att (File, PIO_GLOBAL, 'institution', 'LLNL (Lawrence Livermore National Laboratory, Livermore, CA 94550, USA); ANL (Argonne National Laboratory, Argonne, IL 60439, USA); BNL (Brookhaven National Laboratory, Upton, NY 11973, USA); LANL (Los Alamos National Laboratory, Los Alamos, NM 87545, USA); LBNL (Lawrence Berkeley National Laboratory, Berkeley, CA 94720, USA); ORNL (Oak Ridge National Laboratory, Oak Ridge, TN 37831, USA); PNNL (Pacific Northwest National Laboratory, Richland, WA 99352, USA); SNL (Sandia National Laboratories, Albuquerque, NM 87185, USA). Mailing address: LLNL Climate Program, c/o David C. Bader, Principal Investigator, L-103, 7000 East Avenue, Livermore, CA 94550, USA')
 
   end subroutine eam_pio_createHeader
 !=====================================================================!

--- a/components/scream/src/share/util/scream_time_stamp.cpp
+++ b/components/scream/src/share/util/scream_time_stamp.cpp
@@ -95,7 +95,7 @@ int TimeStamp::seconds_from (const TimeStamp& ts) const {
 }
 
 double TimeStamp::days_from (const TimeStamp& ts) const {
-  return ((double)*this.seconds_from(ts)/86400.0);
+  return seconds_from(ts)/86400.0;
 }
 
 std::string TimeStamp::to_string () const {

--- a/components/scream/src/share/util/scream_time_stamp.cpp
+++ b/components/scream/src/share/util/scream_time_stamp.cpp
@@ -94,6 +94,10 @@ int TimeStamp::seconds_from (const TimeStamp& ts) const {
   return *this-ts;
 }
 
+double TimeStamp::days_from (const TimeStamp& ts) const {
+  return ((double)*this.seconds_from(ts)/86400.0);
+}
+
 std::string TimeStamp::to_string () const {
 
   auto time = get_time_string ();

--- a/components/scream/src/share/util/scream_time_stamp.hpp
+++ b/components/scream/src/share/util/scream_time_stamp.hpp
@@ -36,6 +36,7 @@ public:
 
   int sec_of_day () const { return m_time[0]*3600 + m_time[1]*60 + m_time[2]; }
   int seconds_from (const TimeStamp& ts) const;
+  double days_from (const TimeStamp& ts) const;
 
   std::string to_string () const;
   std::string get_date_string () const;


### PR DESCRIPTION
This small PR changes netcdf output to use units "days since <start of simulation>". It also changes global attributes to match EAM conventions for variables that always have the same text.