### PR TITLE
Add surface radiative fluxes to surface coupling

### DIFF
--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -274,6 +274,12 @@ TEST_CASE ("recreate_mct_coupling")
   FID pseudo_density_id  ("pseudo_density",  scalar3d_layout, Pa,     grid_name);
   FID qv_id              ("qv",              scalar3d_layout, nondim, grid_name);
   FID precip_liq_surf_id ("precip_liq_surf", scalar2d_layout, m/s,    grid_name);
+  FID sfc_flux_dir_nir_id("sfc_flux_dir_nir", scalar2d_layout, W/(m*m), grid_name);
+  FID sfc_flux_dir_vis_id("sfc_flux_dir_vis", scalar2d_layout, W/(m*m), grid_name);
+  FID sfc_flux_dif_nir_id("sfc_flux_dif_nir", scalar2d_layout, W/(m*m), grid_name);
+  FID sfc_flux_dif_vis_id("sfc_flux_dif_vis", scalar2d_layout, W/(m*m), grid_name);
+  FID sfc_flux_sw_net_id ("sfc_flux_sw_net",  scalar2d_layout, W/(m*m), grid_name);
+  FID sfc_flux_lw_dn_id  ("sfc_flux_lw_dn",   scalar2d_layout, W/(m*m), grid_name);
 
   // NOTE: if you add fields above, you will have to modify these counters too.
   const int num_cpl_imports    = 30;
@@ -297,6 +303,12 @@ TEST_CASE ("recreate_mct_coupling")
   fm->register_field(FR{pseudo_density_id});
   fm->register_field(FR{qv_id,"tracers"});
   fm->register_field(FR{precip_liq_surf_id});
+  fm->register_field(FR{sfc_flux_dir_nir_id});
+  fm->register_field(FR{sfc_flux_dir_vis_id});
+  fm->register_field(FR{sfc_flux_dif_nir_id});
+  fm->register_field(FR{sfc_flux_dif_vis_id});
+  fm->register_field(FR{sfc_flux_sw_net_id});
+  fm->register_field(FR{sfc_flux_lw_dn_id});
 
   fm->register_group(GR("tracers", grid_name ,Bundling::Required));
   fm->registration_ends();
@@ -316,6 +328,12 @@ TEST_CASE ("recreate_mct_coupling")
   auto pseudo_density_f   = fm->get_field(pseudo_density_id);
   auto qv_f               = fm->get_field(qv_id);
   auto precip_liq_surf_f  = fm->get_field(precip_liq_surf_id);
+  auto sfc_flux_dir_nir_f = fm->get_field(sfc_flux_dir_nir_id);
+  auto sfc_flux_dir_vis_f = fm->get_field(sfc_flux_dir_vis_id);
+  auto sfc_flux_dif_nir_f = fm->get_field(sfc_flux_dif_nir_id);
+  auto sfc_flux_dif_vis_f = fm->get_field(sfc_flux_dif_vis_id);
+  auto sfc_flux_sw_net_f  = fm->get_field(sfc_flux_sw_net_id);
+  auto sfc_flux_lw_dn_f   = fm->get_field(sfc_flux_lw_dn_id);
 
   auto group = fm->get_field_group("tracers");
   const auto& Q_name = group.m_bundle->get_header().get_identifier().name();
@@ -335,6 +353,12 @@ TEST_CASE ("recreate_mct_coupling")
   auto pseudo_density_d   = pseudo_density_f.get_view<Real**>();
   auto qv_d               = qv_f.get_view<Real**>();
   auto precip_liq_surf_d  = precip_liq_surf_f.get_view<Real*>();
+  auto sfc_flux_dir_nir_d = sfc_flux_dir_nir_f.get_view<Real*>();
+  auto sfc_flux_dir_vis_d = sfc_flux_dir_vis_f.get_view<Real*>();
+  auto sfc_flux_dif_nir_d = sfc_flux_dif_nir_f.get_view<Real*>();
+  auto sfc_flux_dif_vis_d = sfc_flux_dif_vis_f.get_view<Real*>();
+  auto sfc_flux_sw_net_d  = sfc_flux_sw_net_f.get_view<Real*>();
+  auto sfc_flux_lw_dn_d   = sfc_flux_lw_dn_f.get_view<Real*>();
 
   auto surf_latent_flux_h = surf_latent_flux_f.get_view<Real*,Host>();
   auto surf_sens_flux_h   = surf_sens_flux_f.get_view<Real*,Host>();
@@ -350,6 +374,12 @@ TEST_CASE ("recreate_mct_coupling")
   auto horiz_winds_h      = horiz_winds_f.get_view<Real***,Host>();
   auto qv_h               = qv_f.get_view<Real**,Host>();
   auto precip_liq_surf_h  = precip_liq_surf_f.get_view<Real*,Host>();
+  auto sfc_flux_dir_nir_h = sfc_flux_dir_nir_f.get_view<Real*,Host>();
+  auto sfc_flux_dir_vis_h = sfc_flux_dir_vis_f.get_view<Real*,Host>();
+  auto sfc_flux_dif_nir_h = sfc_flux_dif_nir_f.get_view<Real*,Host>();
+  auto sfc_flux_dif_vis_h = sfc_flux_dif_vis_f.get_view<Real*,Host>();
+  auto sfc_flux_sw_net_h  = sfc_flux_sw_net_f.get_view<Real*,Host>();
+  auto sfc_flux_lw_dn_h   = sfc_flux_lw_dn_f.get_view<Real*,Host>();
 
   // Create SC object and set number of import/export fields
   control::SurfaceCoupling coupler(fm);
@@ -404,13 +434,13 @@ TEST_CASE ("recreate_mct_coupling")
   coupler.register_export("set_zero",        12);
   coupler.register_export("set_zero",        13);
   coupler.register_export("set_zero",        14);
-  coupler.register_export("Faxa_rainl",      15);
-  coupler.register_export("set_zero",        16);
-  coupler.register_export("set_zero",        17);
-  coupler.register_export("set_zero",        18);
-  coupler.register_export("set_zero",        19);
-  coupler.register_export("set_zero",        20);
-  coupler.register_export("set_zero",        21);
+  coupler.register_export("Faxa_rainl",      15);  
+  coupler.register_export("sfc_flux_lw_dn",  16);
+  coupler.register_export("sfc_flux_dir_nir",17);
+  coupler.register_export("sfc_flux_dir_vis",18);
+  coupler.register_export("sfc_flux_dif_nir",19);
+  coupler.register_export("sfc_flux_dif_vis",20);
+  coupler.register_export("sfc_flux_sw_net", 21);
   coupler.register_export("set_zero",        22);
   coupler.register_export("set_zero",        23);
   coupler.register_export("set_zero",        24);
@@ -449,6 +479,12 @@ TEST_CASE ("recreate_mct_coupling")
     ekat::genRandArray(horiz_winds_d,engine,pdf);
     ekat::genRandArray(pseudo_density_d,engine,pdf);
     ekat::genRandArray(precip_liq_surf_d,engine,pdf);
+    ekat::genRandArray(sfc_flux_lw_dn_d,engine,pdf);
+    ekat::genRandArray(sfc_flux_dir_nir_d,engine,pdf);
+    ekat::genRandArray(sfc_flux_dir_vis_d,engine,pdf);
+    ekat::genRandArray(sfc_flux_dif_nir_d,engine,pdf);
+    ekat::genRandArray(sfc_flux_dif_vis_d,engine,pdf);
+    ekat::genRandArray(sfc_flux_sw_net_d,engine,pdf);
     auto Q_size = Q.get_header().get_alloc_properties().get_num_scalars();
     ekat::genRandArray(Q.get_internal_view_data<Real,Host>(),Q_size,engine,pdf);
 
@@ -480,6 +516,12 @@ TEST_CASE ("recreate_mct_coupling")
     horiz_winds_f.sync_to_host();
     pseudo_density_f.sync_to_host();
     precip_liq_surf_f.sync_to_host();
+    sfc_flux_lw_dn_f.sync_to_host();
+    sfc_flux_dir_nir_f.sync_to_host();
+    sfc_flux_dir_vis_f.sync_to_host();
+    sfc_flux_dif_nir_f.sync_to_host();
+    sfc_flux_dif_vis_f.sync_to_host();
+    sfc_flux_sw_net_f.sync_to_host();
     Q.sync_to_host();
 
     // Check values
@@ -507,6 +549,12 @@ TEST_CASE ("recreate_mct_coupling")
       REQUIRE (export_raw_data[6 + icol*num_cpl_exports]  == qv_h             (icol,    nlevs-1)); // 7th export
       REQUIRE (export_raw_data[7 + icol*num_cpl_exports]  == p_mid_h          (icol,    nlevs-1)); // 8th export
       REQUIRE (export_raw_data[15 + icol*num_cpl_exports] == C::RHO_H2O*precip_liq_surf_h(icol));  // 16th export
+      REQUIRE (export_raw_data[16 + icol*num_cpl_exports] == sfc_flux_lw_dn_h(icol));              // 17th export
+      REQUIRE (export_raw_data[17 + icol*num_cpl_exports] == sfc_flux_dir_nir_h(icol));            // 18th export
+      REQUIRE (export_raw_data[18 + icol*num_cpl_exports] == sfc_flux_dir_vis_h(icol));            // 19th export
+      REQUIRE (export_raw_data[19 + icol*num_cpl_exports] == sfc_flux_dif_nir_h(icol));            // 20th export
+      REQUIRE (export_raw_data[20 + icol*num_cpl_exports] == sfc_flux_dif_vis_h(icol));            // 21st export
+      REQUIRE (export_raw_data[21 + icol*num_cpl_exports] == sfc_flux_sw_net_h(icol));             // 22nd export
 
       // These exports should be set to 0
       REQUIRE (export_raw_data[1  + icol*num_cpl_exports] == 0); // 2nd export
@@ -516,13 +564,7 @@ TEST_CASE ("recreate_mct_coupling")
       REQUIRE (export_raw_data[12 + icol*num_cpl_exports] == 0); // 13th export
       REQUIRE (export_raw_data[13 + icol*num_cpl_exports] == 0); // 14th export
       REQUIRE (export_raw_data[14 + icol*num_cpl_exports] == 0); // 15th export
-      REQUIRE (export_raw_data[16 + icol*num_cpl_exports] == 0); // 17th export
-      REQUIRE (export_raw_data[17 + icol*num_cpl_exports] == 0);
-      REQUIRE (export_raw_data[18 + icol*num_cpl_exports] == 0);
-      REQUIRE (export_raw_data[19 + icol*num_cpl_exports] == 0);
-      REQUIRE (export_raw_data[20 + icol*num_cpl_exports] == 0);
-      REQUIRE (export_raw_data[21 + icol*num_cpl_exports] == 0);
-      REQUIRE (export_raw_data[22 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[22 + icol*num_cpl_exports] == 0); // 23rd export
       REQUIRE (export_raw_data[23 + icol*num_cpl_exports] == 0);
       REQUIRE (export_raw_data[24 + icol*num_cpl_exports] == 0);
       REQUIRE (export_raw_data[25 + icol*num_cpl_exports] == 0);

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -7,7 +7,7 @@ module scream_cpl_indices
 
   ! Focus only on the ones that scream imports/exports (subsets of x2a and a2x)
   integer, parameter, public :: num_scream_imports       = 9
-  integer, parameter, public :: num_scream_exports       = 9
+  integer, parameter, public :: num_scream_exports       = 15
   integer, public :: num_cpl_imports, num_cpl_exports
 
   ! cpl indices for import/export fields
@@ -94,12 +94,25 @@ module scream_cpl_indices
     scr_names_a2x(mct_avect_indexra(a2x,'Sa_shum'))    = 'qv'
     scr_names_a2x(mct_avect_indexra(a2x,'Sa_dens'))    = 'Sa_dens'
     scr_names_a2x(mct_avect_indexra(a2x,'Faxa_rainl')) = 'Faxa_rainl'
+    scr_names_a2x(mct_avect_indexra(a2x,'Faxa_swndr')) = 'sfc_flux_dir_nir'
+    scr_names_a2x(mct_avect_indexra(a2x,'Faxa_swvdr')) = 'sfc_flux_dir_vis'
+    scr_names_a2x(mct_avect_indexra(a2x,'Faxa_swndf')) = 'sfc_flux_dif_nir'
+    scr_names_a2x(mct_avect_indexra(a2x,'Faxa_swvdf')) = 'sfc_flux_dif_vis'
+    scr_names_a2x(mct_avect_indexra(a2x,'Faxa_swnet')) = 'sfc_flux_sw_net'
+    scr_names_a2x(mct_avect_indexra(a2x,'Faxa_lwdn'))  = 'sfc_flux_lw_dn'
 
     vec_comp_a2x(mct_avect_indexra(a2x,'Sa_u')) = 0
     vec_comp_a2x(mct_avect_indexra(a2x,'Sa_v')) = 1
 
-    ! SCREAM needs to run before this field can be exported
+    ! SCREAM needs to run before this field can be exported as they
+    ! rely on fields computed by SCREAM
     can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_rainl')) = .false.
+    can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_swndr')) = .false.
+    can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_swvdr')) = .false.
+    can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_swndf')) = .false.
+    can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_swvdf')) = .false.
+    can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_swnet')) = .false.
+    can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_lwdn'))  = .false.
 
     ! Trim names
     do i=1,num_cpl_imports


### PR DESCRIPTION
Recently implemented surface radiative fluxes need to be exported in SurfaceCoupling.  