### PR TITLE
Bugfix to when we reset the number of nsteps since the last write.

### DIFF
--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -270,12 +270,14 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     // Finish up any updates to output file
     sync_outfile(filename);
 
+    // Now that we've written output to this file we need reset the nsteps.
+    control.nsteps_since_last_write = 0;
+
     // Check if we need to close the output file
     if (filespecs.file_is_full()) {
       eam_pio_closefile(filename);
       filespecs.num_snapshots_in_file = 0;
       filespecs.is_open = false;
-      control.nsteps_since_last_write = 0;
     }
 
     // Whether we wrote an output or a checkpoint, the checkpoint counter needs to be reset


### PR DESCRIPTION
This commit fixes a bug where we only reset the number of steps since
the last write in the output manager when an output file was full.  Since
we use this value to update any averaging output fields we want to reset
it every time we write output, even in cases where an output file can hold
more output timesnaps.