### PR TITLE
Quick fix to the default settings for scream_output.yaml

### DIFF
--- a/components/scream/data/scream_output.yaml
+++ b/components/scream/data/scream_output.yaml
@@ -59,6 +59,5 @@ Fields:
 Output Control:
   Frequency: 12
   Frequency Units: Steps
-  Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...


### PR DESCRIPTION
This commit fixes an issue where long CIME runs would not produce
multiple output files when a file was full.  By not storing the
timestamp in the filename, each "new" file would have the same name
as the last file and then overwrite it.

This should not be turned on by default.