### PR TITLE
Enable setting fixed orbital parameters

### DIFF
--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -39,10 +39,21 @@ Atmosphere Driver:
       - ch4
       - o2
       - n2
+      # Year to use for orbital calculations. If positive, use a fixed year for
+      # orbital computations, in the same way EAM F-compsets are configured. If
+      # negative, compute using current model year. This setting will be IGNORED
+      # if orbital parameters below are set to non-negative values in favor of
+      # using fixed orbital parameters (e.g., for aquaplanet compsets)
+      Orbital Year: -9999 # Negative means compute from current year
+      # Orbital parameters; if positive, use orbital parameters specified
+      # and ignore orbital year setting.
+      Orbital Eccentricity: "<${COMPSET} : .*SCREAM%AQUA.* => 0 : -9999>"  # Eccentricity for orbital computations
+      Orbital Obliquity:    "<${COMPSET} : .*SCREAM%AQUA.* => 0 : -9999>"  # Obliquity for orbital computations
+      Orbital MVELP:        "<${COMPSET} : .*SCREAM%AQUA.* => 0 : -9999>"  # Vernal Equinox Mean Longitude of Perihelion
 
   Time Stepping:
     Time Step: 300
-    Start Time: [12, 30, 00]      # Hours, Minutes, Seconds
+    Start Time: [12, 30, 00]    # Hours, Minutes, Seconds
     Start Date: [2000, 2, 1]    # Year, Month, Day
     Number of Steps: 288
 

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -60,6 +60,12 @@ public:
   // If > 0, use constant orbital year for duration of simulation
   // If < 0, use year from timestamp for orbital parameters
   Int m_orbital_year;
+  // Orbital parameters, used for zenith angle calculations.
+  // If >= 0, bypass computation based on orbital year and use fixed parameters
+  // If <  0, compute based on orbital year, specified above
+  Real m_orbital_eccen;  // Eccentricity
+  Real m_orbital_obliq;  // Obliquity
+  Real m_orbital_mvelp;  // Vernal Equinox Mean Longitude of Perihelion
 
   // Fixed solar zenith angle to use for shortwave calculations
   // This is only used if a positive value is supplied

--- a/components/scream/src/physics/rrtmgp/share/shr_orb_mod_c2f.F90
+++ b/components/scream/src/physics/rrtmgp/share/shr_orb_mod_c2f.F90
@@ -1,9 +1,10 @@
 module shr_orb_mod_c2f
 
    use iso_c_binding
-   use shr_orb_mod, only: shr_orb_params, shr_orb_decl, shr_orb_cosz
+   use shr_orb_mod, only: shr_orb_params, shr_orb_decl, shr_orb_cosz, SHR_ORB_UNDEF_INT
    implicit none
    public :: shr_orb_params_c2f, shr_orb_decl_c2f, shr_orb_cosz_c2f
+   integer(c_int), bind(C) :: shr_orb_undef_int_c2f = SHR_ORB_UNDEF_INT
 
 contains
 

--- a/components/scream/src/physics/rrtmgp/share/shr_orb_mod_c2f.hpp
+++ b/components/scream/src/physics/rrtmgp/share/shr_orb_mod_c2f.hpp
@@ -1,5 +1,6 @@
 #ifndef SHR_ORB_MOD_C2F_HPP
 #define SHR_ORB_MOD_C2F_HPP
+extern "C" int shr_orb_undef_int_c2f;
 extern "C" void shr_orb_params_c2f(
         int *orb_year , double *eccen, double *mvelpp, double *lambm0,
         double *obliqr, double *delta, double *eccf


### PR DESCRIPTION
Enable setting fixed orbital parameters. This is needed for aquaplanet
configurations, in which we need to set orbital parameters to perpetual
equinox conditions (by setting eccentricity and obliquity to zero). This
exposes these parameters to the AD through YAML options, and adds
default values to the scream/data/scream_input.yaml file based on
compset regex. The new behavior now checks if non-negative orbital
parameters are passed via the yaml file, and if they are, bypasses the
computation of orbital parameters based on year in favor of using the
fixed parameters. Note that ALL parameters must be non-negative, or else
all parameters will be computed instead in shr_orb_params.

[Non-B4B] (only for aquaplanet CIME test on mappy, v1 standalone is all B4B)