### PR TITLE
Fix p3 tests "will-fail" logic on CUDA builds

### DIFF
--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -48,6 +48,12 @@ set(P3_TESTS_SRCS
 CreateUnitTest(p3_test_setup p3_test_setup.cpp "${NEED_LIBS}"
                EXCLUDE_MAIN_CPP PROPERTIES FIXTURES_SETUP p3_tables)
 
+if (SCREAM_DEBUG AND NOT EKAT_ENABLE_CUDA_MEMCHECK)
+  set (FORCE_RUN_DIFF_FAILS TRUE)
+else ()
+  set (FORCE_RUN_DIFF_FAILS FALSE)
+endif()
+
 # NOTE: tests inside this if statement won't be built in a baselines-only build
 if (NOT ${SCREAM_BASELINES_ONLY})
   CreateUnitTest(p3_tests "${P3_TESTS_SRCS}" "${NEED_LIBS}"
@@ -59,7 +65,7 @@ if (NOT ${SCREAM_BASELINES_ONLY})
   CreateUnitTest (p3_tests_fail p3_rain_sed_unit_tests.cpp "${NEED_LIBS}"
                  COMPILER_CXX_DEFS SCREAM_FORCE_RUN_DIFF
                  THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC}
-                 PROPERTIES FIXTURES_REQUIRED p3_tables WILL_FAIL ${SCREAM_DEBUG}
+                 PROPERTIES FIXTURES_REQUIRED p3_tables WILL_FAIL ${FORCE_RUN_DIFF_FAILS}
                  LABELS "p3;physics;fail")
 endif()
 
@@ -82,7 +88,7 @@ CreateUnitTest(p3_run_and_cmp_cxx_fail "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                COMPILER_CXX_DEFS SCREAM_FORCE_RUN_DIFF
                THREADS ${SCREAM_TEST_MAX_THREADS}
                EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
-               PROPERTIES FIXTURES_REQUIRED p3_tables WILL_FAIL ${SCREAM_DEBUG}
+               PROPERTIES FIXTURES_REQUIRED p3_tables WILL_FAIL ${FORCE_RUN_DIFF_FAILS}
                EXCLUDE_MAIN_CPP
                LABELS "p3;physics;fail")
 


### PR DESCRIPTION
The BFB tests are not run with cuda-memcheck builds (since the f90->cxx bridges are insanely expensive when running through memcheck). Therefore, even if `SCREAM_FORCE_RUN_DIFF` is set, and even if the two impl are indeed differing, no check is performed, so the tests pass. Hence, the ctest property WILL_FAIL should be FALSE for cuda memcheck builds.