### PR TITLE
Move table init out of p3_main()

### DIFF
--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -270,6 +270,12 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
       prog_state.qi, prog_state.qm, prog_state.ni,prog_state.bm,qv_prev,
       diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi);
 
+  // Load tables
+  P3F::init_kokkos_ice_lookup_tables(lookup_tables.ice_table_vals, lookup_tables.collect_table_vals);
+  P3F::init_kokkos_tables(lookup_tables.vn_table_vals, lookup_tables.vm_table_vals,
+                          lookup_tables.revap_table_vals, lookup_tables.mu_r_table_vals,
+                          lookup_tables.dnu_table_vals);
+
   // Setup WSM for internal local variables
   const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);
   workspace_mgr.setup(m_buffer.wsm_data, nk_pack, 52, policy);

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -356,6 +356,7 @@ protected:
   P3F::P3DiagnosticInputs  diag_inputs;
   P3F::P3DiagnosticOutputs diag_outputs;
   P3F::P3HistoryOnly       history_only;
+  P3F::P3LookupTables      lookup_tables;
   P3F::P3Infrastructure    infrastructure;
   p3_preamble              p3_preproc;
   p3_postamble             p3_postproc;

--- a/components/scream/src/physics/p3/atmosphere_microphysics_run.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics_run.cpp
@@ -22,7 +22,7 @@ void P3Microphysics::run_impl (const int dt)
 
   // Run p3 main
   P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
-               history_only, workspace_mgr, m_num_cols, m_num_levs);
+               history_only, lookup_tables, workspace_mgr, m_num_cols, m_num_levs);
 
   // Conduct the post-processing of the p3_main output.
   Kokkos::parallel_for(

--- a/components/scream/src/physics/p3/p3_functions.hpp
+++ b/components/scream/src/physics/p3/p3_functions.hpp
@@ -77,6 +77,22 @@ struct Functions
   template <typename S>
   using view_2d = typename KT::template view_2d<S>;
 
+  // lookup table values for rain shape parameter mu_r
+  using view_1d_table = typename KT::template view_1d_table<Scalar, C::MU_R_TABLE_DIM>;
+
+  // lookup table values for rain number- and mass-weighted fallspeeds and ventilation parameters
+  using view_2d_table = typename KT::template view_2d_table<Scalar, C::VTABLE_DIM0, C::VTABLE_DIM1>;
+
+  // ice lookup table values
+  using view_ice_table    = typename KT::template view<const Scalar[P3C::densize][P3C::rimsize][P3C::isize][P3C::ice_table_size]>;
+
+  // ice lookup table values for ice-rain collision/collection
+  using view_collect_table = typename KT::template view<const Scalar[P3C::densize][P3C::rimsize][P3C::isize][P3C::rcollsize][P3C::collect_table_size]>;
+
+  // droplet spectral shape parameter for mass spectra, used for Seifert and Beheng (2001)
+  // warm rain autoconversion/accretion option only (iparam = 1)
+  using view_dnu_table = typename KT::template view_1d_table<Scalar, P3C::dnusize>;
+
   template <typename S, int N>
   using view_1d_ptr_array = typename KT::template view_1d_ptr_carray<S, N>;
 
@@ -202,6 +218,20 @@ struct Functions
     view_2d<Spack> vap_ice_exchange;
   };
 
+  // This struct stores kokkos views for the lookup tables needed in p3_main()
+  struct P3LookupTables {
+    // lookup table values for rain shape parameter mu_r
+    view_1d_table mu_r_table_vals;
+    // lookup table values for rain number- and mass-weighted fallspeeds and ventilation parameters
+    view_2d_table vn_table_vals, vm_table_vals, revap_table_vals;
+    // ice lookup table values
+    view_ice_table ice_table_vals;
+    // ice lookup table values for ice-rain collision/collection
+    view_collect_table collect_table_vals;
+    // droplet spectral shape parameter for mass spectra
+    view_dnu_table dnu_table_vals;
+  };
+
   // -- Table3 --
 
   struct Table3 {
@@ -218,22 +248,6 @@ struct Functions
     IntSmallPack dumj;
     Spack dum3;
   };
-
-  // lookup table values for rain shape parameter mu_r
-  using view_1d_table = typename KT::template view_1d_table<Scalar, C::MU_R_TABLE_DIM>;
-
-  // lookup table values for rain number- and mass-weighted fallspeeds and ventilation parameters
-  using view_2d_table = typename KT::template view_2d_table<Scalar, C::VTABLE_DIM0, C::VTABLE_DIM1>;
-
-  // ice lookup table values
-  using view_ice_table    = typename KT::template view<const Scalar[P3C::densize][P3C::rimsize][P3C::isize][P3C::ice_table_size]>;
-
-  // ice lookup table values for ice-rain collision/collection
-  using view_collect_table = typename KT::template view<const Scalar[P3C::densize][P3C::rimsize][P3C::isize][P3C::rcollsize][P3C::collect_table_size]>;
-
-  // droplet spectral shape parameter for mass spectra, used for Seifert and Beheng (2001)
-  // warm rain autoconversion/accretion option only (iparam = 1)
-  using view_dnu_table = typename KT::template view_1d_table<Scalar, P3C::dnusize>;
 
   //
   // --------- Functions ---------
@@ -941,6 +955,7 @@ struct Functions
     const P3DiagnosticOutputs& diagnostic_outputs,
     const P3Infrastructure& infrastructure,
     const P3HistoryOnly& history_only,
+    const P3LookupTables& lookup_tables,
     const WorkspaceManager& workspace_mgr,
     Int nj, // number of columns
     Int nk); // number of vertical cells per column


### PR DESCRIPTION
Initializing these tables caused a bottle neck in the `p3_main()` call, making it to where we did not see strong scaling over MPI ranks (since the table dimensions are column independent). Now the initialization is done outside of `p3_main()`.