### PR TITLE
Correct qc computation in shoc ad

### DIFF
--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -194,6 +194,8 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
   s_mem += m_buffer.dse.size();
   m_buffer.tke_copy = decltype(m_buffer.tke_copy)(s_mem, m_num_cols, nlev_packs);
   s_mem += m_buffer.tke_copy.size();
+  m_buffer.qc_copy = decltype(m_buffer.qc_copy)(s_mem, m_num_cols, nlev_packs);
+  s_mem += m_buffer.qc_copy.size();
   m_buffer.shoc_ql2 = decltype(m_buffer.shoc_ql2)(s_mem, m_num_cols, nlev_packs);
   s_mem += m_buffer.shoc_ql2.size();
   m_buffer.shoc_mix = decltype(m_buffer.shoc_mix)(s_mem, m_num_cols, nlev_packs);
@@ -283,6 +285,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   auto qw          = m_buffer.qw;
   auto dse         = m_buffer.dse;
   auto tke_copy    = m_buffer.tke_copy;
+  auto qc_copy     = m_buffer.qc_copy;
   auto shoc_ql2    = m_buffer.shoc_ql2;
 
   // For now, set z_int(i,nlevs) = z_surf = 0
@@ -290,7 +293,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
 
   shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,z_surf,m_cell_area,
                                 T_mid,p_mid,p_int,pseudo_density,omega,phis,surf_sens_flux,surf_latent_flux,
-                                surf_mom_flux,qv,qc,tke,tke_copy,z_mid,z_int,cell_length,
+                                surf_mom_flux,qv,qc,qc_copy,tke,tke_copy,z_mid,z_int,cell_length,
                                 dse,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
                                 wtracer_sfc,wm_zt,inv_exner,thlm,qw);
 
@@ -322,7 +325,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   input_output.qtracers     = get_group_out("tracers").m_bundle->get_view<Spack***>();
   input_output.tk           = get_field_out("eddy_diff_mom").get_view<Spack**>();
   input_output.shoc_cldfrac = cldfrac_liq;
-  input_output.shoc_ql      = qc;
+  input_output.shoc_ql      = qc_copy;
 
   // Output Variables
   output.pblh     = get_field_out("pbl_height").get_view<Real*>();
@@ -345,7 +348,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   history_output.brunt     = m_buffer.brunt;
 
   shoc_postprocess.set_variables(m_num_cols,m_num_levs,
-                                 rrho,qv,qw,qc,tke,tke_copy,shoc_ql2,
+                                 rrho,qv,qw,qc,qc_copy,tke,tke_copy,shoc_ql2,
                                  cldfrac_liq,sgs_buoy_flux,inv_qc_relvar,
                                  T_mid, dse, z_mid, phis);
 


### PR DESCRIPTION
The tracer `qc` must be treated like `tke` as it is a separate input into `shoc_main()`, updated separately from the tracer bundle.

Currently, `qc` is being updated as both `shoc_ql` and as a part of the tracer bundle inside `shoc_main()`. Here, we make those separate inputs and tell the AD to overwrite the tracer bundle with `shoc_ql`.