### PR TITLE
Add SPA to the set of default processes run for all SCREAMv1 F-Case

### DIFF
--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -26,7 +26,7 @@ Atmosphere Driver:
       Enable Input Fields Checks: false
       Grid: Physics GLL
       SPA Remap File: none 
-      SPA Data File: @SCREAM_INPUT_ROOT@/scream/spa_file_unified_and_complete_ne4_scream.nc
+      SPA Data File: ${DIN_LOC_ROOT}/scream/spa_file_unified_and_complete_ne4_scream.nc
       # TODO: Fix the SPA remap file and data file to be dependent on the grid resolution.  For now we hardcode the ne4 case.
     Process 4:
       Process Name: P3

--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -3,7 +3,7 @@
 Atmosphere Driver:
 
   Atmosphere Processes:
-    Number of Entries: 5
+    Number of Entries: 6
     Schedule Type: Sequential
     Process 0:
       Process Name: Homme
@@ -21,11 +21,19 @@ Atmosphere Driver:
       Enable Input Fields Checks: false
       Grid: Physics GLL
     Process 3:
+      Process Name: SPA
+      Enable Output Fields Checks: false
+      Enable Input Fields Checks: false
+      Grid: Physics GLL
+      SPA Remap File: none 
+      SPA Data File: @SCREAM_INPUT_ROOT@/scream/spa_file_unified_and_complete_ne4_scream.nc
+      # TODO: Fix the SPA remap file and data file to be dependent on the grid resolution.  For now we hardcode the ne4 case.
+    Process 4:
       Process Name: P3
       Enable Output Fields Checks: false
       Enable Input Fields Checks: false
       Grid: Physics GLL
-    Process 4:
+    Process 5:
       Process Name: RRTMGP
       Enable Output Fields Checks: false
       Enable Input Fields Checks: false

--- a/components/scream/data/scream_output.yaml
+++ b/components/scream/data/scream_output.yaml
@@ -55,9 +55,15 @@ Fields:
       - sfc_alb_dif_nir
       - sfc_alb_dif_vis
       - surf_lw_flux_up
+      - aero_g_sw
+      - aero_ssa_sw
+      - aero_tau_lw
+      - aero_tau_sw
+      - nc_activated
+      - p_mid
 
 Output Control:
-  Frequency: 12
+  Frequency: 2
   Frequency Units: Steps
   MPI Ranks in Filename: true
 ...


### PR DESCRIPTION
This commit adds SPA to the set of processes in the default
scream_input.yaml file.  This will make sure that all F-Compset
runs also include SPA.

NOTE: This PR temporarily hardcodes the default case to be on an ne4
mesh.  SPA requires different mapping files depending on the resolution
of the simulation.  We will need to update the build infrastructure
to accomodate switching files depending on the resolution of the simulation.