### PR TITLE
Aarondonahue/add diagnostic class

### DIFF
--- a/components/scream/src/CMakeLists.txt
+++ b/components/scream/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(share)
 
 add_subdirectory(dynamics)
 add_subdirectory(physics)
+add_subdirectory(diagnostics)
 add_subdirectory(control)
 if (PROJECT_NAME STREQUAL "E3SM")
   add_subdirectory(mct_coupling)

--- a/components/scream/src/diagnostics/CMakeLists.txt
+++ b/components/scream/src/diagnostics/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(DIAGNOSTIC_SRCS
- potential_temperature.cpp
+  potential_temperature.cpp
 )
 
 set(DIAGNOSTIC_HEADERS

--- a/components/scream/src/diagnostics/CMakeLists.txt
+++ b/components/scream/src/diagnostics/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(DIAGNOSTIC_SRCS
+ potential_temperature.cpp
+)
+
+set(DIAGNOSTIC_HEADERS
+  potential_temperature.hpp
+) 
+
+add_library(diagnostics ${DIAGNOSTIC_SRCS})
+target_include_directories(diagnostics PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../share)
+target_link_libraries(diagnostics scream_share)
+target_compile_options(diagnostics PUBLIC)
+
+add_subdirectory(tests)

--- a/components/scream/src/diagnostics/CMakeLists.txt
+++ b/components/scream/src/diagnostics/CMakeLists.txt
@@ -2,13 +2,8 @@ set(DIAGNOSTIC_SRCS
   potential_temperature.cpp
 )
 
-set(DIAGNOSTIC_HEADERS
-  potential_temperature.hpp
-) 
-
 add_library(diagnostics ${DIAGNOSTIC_SRCS})
 target_include_directories(diagnostics PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../share)
-target_link_libraries(diagnostics scream_share)
-target_compile_options(diagnostics PUBLIC)
+target_link_libraries(diagnostics PUBLIC scream_share)
 
 add_subdirectory(tests)

--- a/components/scream/src/diagnostics/potential_temperature.cpp
+++ b/components/scream/src/diagnostics/potential_temperature.cpp
@@ -1,0 +1,64 @@
+#include "diagnostics/potential_temperature.hpp"
+
+namespace scream
+{
+
+// =========================================================================================
+PotentialTemperatureDiagnostic::PotentialTemperatureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
+  : AtmosphereProcess(comm,params)
+{
+  // Nothing to do here
+}
+
+// =========================================================================================
+void PotentialTemperatureDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
+{
+  using namespace ekat::units;
+  using namespace ShortFieldTagsNames;
+
+  auto Q = kg/kg;
+  Q.set_string("kg/kg");
+
+  const auto& grid_name = m_params.get<std::string>("Grid");
+  auto grid  = grids_manager->get_grid(grid_name);
+  m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
+  m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
+
+  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
+  constexpr int ps = Pack::n;
+
+  // The fields required for this diagnostic to be computed
+  add_field<Required>("T_mid",          scalar3d_layout_mid, K,  grid_name, ps);
+  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa, grid_name, ps);
+
+  // Construct and allocate the diagnostic field
+  FieldIdentifier fid (name(), scalar3d_layout_mid, K, grid_name);
+  m_diagnostic_output = Field(fid);
+  m_diagnostic_output.allocate_view();
+
+}
+// =========================================================================================
+void PotentialTemperatureDiagnostic::initialize_impl(const RunType /* run_type */)
+{
+  const auto& T_mid          = get_field_in("T_mid").get_view<const Pack**>();
+  const auto& p_mid          = get_field_in("p_mid").get_view<const Pack**>();
+
+  const auto& output         = m_diagnostic_output.get_view<Pack**>();
+
+  const auto nk_pack  = ekat::npack<Spack>(m_num_levs);
+
+  run_diagnostic.set_variables(m_num_cols,nk_pack,p_mid,T_mid,output);
+}
+// =========================================================================================
+void PotentialTemperatureDiagnostic::run_impl(const int dt)
+{
+
+  Kokkos::parallel_for("PotentialTemperatureDiagnostic",
+                       Kokkos::RangePolicy<>(0,m_num_cols),
+                       run_diagnostic
+  );
+  Kokkos::fence();
+
+}
+// =========================================================================================
+} //namespace scream

--- a/components/scream/src/diagnostics/potential_temperature.cpp
+++ b/components/scream/src/diagnostics/potential_temperature.cpp
@@ -5,7 +5,7 @@ namespace scream
 
 // =========================================================================================
 PotentialTemperatureDiagnostic::PotentialTemperatureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
-  : AtmosphereProcess(comm,params)
+  : AtmosphereDiagnostic(comm,params)
 {
   // Nothing to do here
 }
@@ -59,6 +59,11 @@ void PotentialTemperatureDiagnostic::run_impl(const int dt)
   );
   Kokkos::fence();
 
+}
+// =========================================================================================
+void PotentialTemperatureDiagnostic::finalize_impl()
+{
+  // Nothing to do
 }
 // =========================================================================================
 } //namespace scream

--- a/components/scream/src/diagnostics/potential_temperature.cpp
+++ b/components/scream/src/diagnostics/potential_temperature.cpp
@@ -53,8 +53,9 @@ void PotentialTemperatureDiagnostic::initialize_impl(const RunType /* run_type *
 void PotentialTemperatureDiagnostic::run_impl(const int dt)
 {
 
+  const auto nk_pack  = ekat::npack<Spack>(m_num_levs);
   Kokkos::parallel_for("PotentialTemperatureDiagnostic",
-                       Kokkos::RangePolicy<>(0,m_num_cols),
+                       Kokkos::RangePolicy<>(0,m_num_cols*nk_pack),
                        run_diagnostic
   );
   Kokkos::fence();

--- a/components/scream/src/diagnostics/potential_temperature.hpp
+++ b/components/scream/src/diagnostics/potential_temperature.hpp
@@ -1,0 +1,94 @@
+#ifndef EAMXX_POTENTIAL_TEMP_DIAGNOSTIC_HPP
+#define EAMXX_POTENTIAL_TEMP_DIAGNOSTIC_HPP
+
+#include "share/atm_process/atmosphere_diagnostic.hpp"
+#include "share/util/scream_common_physics_functions.hpp"
+
+namespace scream
+{
+
+/*
+ * This diagnostic will produce the potential temperature.
+ */
+
+class PotentialTemperatureDiagnostic : public AtmosphereDiagnostic
+{
+public:
+  template <typename S>
+  using SmallPack     = ekat::Pack<S,SCREAM_SMALL_PACK_SIZE>;
+
+  using Spack         = SmallPack<Real>;
+  using Pack          = ekat::Pack<Real,Spack::n>;
+  using PF            = scream::PhysicsFunctions<DefaultDevice>;
+  using KT            = KokkosTypes<DefaultDevice>;
+  using view_2d       = typename KT::template view_2d<Spack>;
+  using view_2d_const = typename KT::template view_2d<const Spack>;
+
+  // Constructors
+  PotentialTemperatureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
+
+  // Set type to diagnostic
+  AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
+
+  // The name of the diagnostic
+  std::string name () const { return "Potential Temperature"; } 
+
+  // Get the required grid for the diagnostic
+  std::set<std::string> get_required_grids () const {
+    static std::set<std::string> s;
+    s.insert(m_params.get<std::string>("Grid"));
+    return s;
+  }
+
+  // Set the grid
+  void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
+
+  // Actual diagnostic calculation 
+  struct run_diagnostic_impl {
+    run_diagnostic_impl() = default;
+    // Functor for Kokkos loop
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const int icol) const {
+      for (int jpack=0;jpack<m_npack;jpack++) {
+        const Spack& T_mid_ij(T_mid(icol,jpack));
+        const Spack& p_mid_ij(p_mid(icol,jpack));
+        output(icol,jpack) = PF::calculate_theta_from_T(T_mid_ij,p_mid_ij);
+      }
+    }
+    int m_ncol, m_npack;
+    view_2d_const T_mid;
+    view_2d_const p_mid;
+    view_2d       output;
+    // assign variables to this structure
+    void set_variables(const int ncol, const int npack,
+      const view_2d_const& pmid_, const view_2d_const& tmid_, const view_2d& output_)
+    {
+      m_ncol = ncol;
+      m_npack = npack;
+      // IN
+      T_mid = tmid_;
+      p_mid = pmid_;
+      // OUT
+      output = output_;
+    }
+  }; // struct run_diagnostic_impl
+
+protected:
+
+  // The three main overrides for the subcomponent
+  void initialize_impl (const RunType run_type);
+  void run_impl        (const int dt);
+  void finalize_impl   ();
+
+  // Keep track of field dimensions
+  Int m_num_cols; 
+  Int m_num_levs;
+
+  // Structure to run the diagnostic
+  run_diagnostic_impl  run_diagnostic;
+
+}; // class PotentialTemperatureDiagnostic
+
+} //namespace scream
+
+#endif // EAMXX_POTENTIAL_TEMP_DIAGNOSTIC_HPP

--- a/components/scream/src/diagnostics/potential_temperature.hpp
+++ b/components/scream/src/diagnostics/potential_temperature.hpp
@@ -48,12 +48,12 @@ public:
     run_diagnostic_impl() = default;
     // Functor for Kokkos loop
     KOKKOS_INLINE_FUNCTION
-    void operator()(const int icol) const {
-      for (int jpack=0;jpack<m_npack;jpack++) {
-        const Spack& T_mid_ij(T_mid(icol,jpack));
-        const Spack& p_mid_ij(p_mid(icol,jpack));
-        output(icol,jpack) = PF::calculate_theta_from_T(T_mid_ij,p_mid_ij);
-      }
+    void operator() (const int& idx) const {
+      const int icol  = idx / m_npack;
+      const int jpack = idx % m_npack;
+      const Spack& T_mid_ij(T_mid(icol,jpack));
+      const Spack& p_mid_ij(p_mid(icol,jpack));
+      output(icol,jpack) = PF::calculate_theta_from_T(T_mid_ij,p_mid_ij);
     }
     int m_ncol, m_npack;
     view_2d_const T_mid;

--- a/components/scream/src/diagnostics/tests/CMakeLists.txt
+++ b/components/scream/src/diagnostics/tests/CMakeLists.txt
@@ -2,8 +2,7 @@
 if (NOT ${SCREAM_BASELINES_ONLY})
   include(ScreamUtils)
 
-  CreateUnitTest(dummy_diag "dummy_diag_test.cpp" "scream_share;diagnostics")
   # Test potential temperature diagnostic
-  CreateUnitTest(potential_temperature "potential_temperature_test.cpp" "scream_share;diagnostics")
+  CreateUnitTest(potential_temperature "potential_temperature_test.cpp" "scream_share;diagnostics" LABELS "diagnostics" )
 
 endif()

--- a/components/scream/src/diagnostics/tests/CMakeLists.txt
+++ b/components/scream/src/diagnostics/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+# NOTE: tests inside this if statement won't be built in a baselines-only build
+if (NOT ${SCREAM_BASELINES_ONLY})
+  include(ScreamUtils)
+
+  # Test potential temperature diagnostic
+  CreateUnitTest(potential_temperature "potential_temperature_test.cpp" scream_share diagnostics)
+
+endif()

--- a/components/scream/src/diagnostics/tests/CMakeLists.txt
+++ b/components/scream/src/diagnostics/tests/CMakeLists.txt
@@ -2,7 +2,8 @@
 if (NOT ${SCREAM_BASELINES_ONLY})
   include(ScreamUtils)
 
+  CreateUnitTest(dummy_diag "dummy_diag_test.cpp" "scream_share;diagnostics")
   # Test potential temperature diagnostic
-  CreateUnitTest(potential_temperature "potential_temperature_test.cpp" scream_share diagnostics)
+  CreateUnitTest(potential_temperature "potential_temperature_test.cpp" "scream_share;diagnostics")
 
 endif()

--- a/components/scream/src/diagnostics/tests/CMakeLists.txt
+++ b/components/scream/src/diagnostics/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # NOTE: tests inside this if statement won't be built in a baselines-only build
-if (NOT ${SCREAM_BASELINES_ONLY})
+if (NOT SCREAM_BASELINES_ONLY)
   include(ScreamUtils)
 
   # Test potential temperature diagnostic

--- a/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
@@ -123,7 +123,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  TeamPolicy policy(ncols, 1);
+  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_mid_packs);
 
   // Input (randomized) views
   view_1d temperature("temperature",num_mid_packs),

--- a/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
@@ -1,24 +1,29 @@
-#include <catch2/catch.hpp>
+#include "catch2/catch.hpp"
 
 #include "share/grid/mesh_free_grids_manager.hpp"
-
 #include "share/atm_process/atmosphere_diagnostic.hpp"
 #include "diagnostics/potential_temperature.hpp"
 
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_parse_yaml_file.hpp"
+#include "physics/share/physics_constants.hpp"
+
+#include "share/util/scream_setup_random_test.hpp"
+#include "share/util/scream_common_physics_functions.hpp"
+#include "share/field/field_utils.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "ekat/util/ekat_test_utils.hpp"
+
+#include <iomanip>
 
 namespace scream {
 
-
 std::shared_ptr<GridsManager>
-create_gm (const ekat::Comm& comm) {
+create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
 
   const int num_local_elems = 4;
   const int np = 4;
-  const int nlevs = 32;
-  const int num_local_cols = 13;
-  const int num_global_cols = num_local_cols*comm.size();
+  const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
   gm_params.set<std::string>("Reference Grid", "Point Grid");
@@ -33,18 +38,122 @@ create_gm (const ekat::Comm& comm) {
   return gm;
 }
 
-TEST_CASE("potential_temperature_diagnostic", "") {
+template<typename ScalarT, int NumLevels>
+struct ChecksHelpers {
 
-  using namespace scream;
+  static bool is_non_negative (const ScalarT& s, const int k) {
+    return not ( k<NumLevels && (s<0 || std::isnan(s)) );
+  }
+  static bool equal (const ScalarT& lhs, const ScalarT& rhs) {
+    return lhs==rhs;
+  }
+  static bool approx_equal (const ScalarT lhs, const ScalarT rhs,
+                            const int k, const ScalarT tol) {
+    using std::abs;
+    return not ( k<NumLevels && abs(lhs-rhs)>=tol );
+  }
+  static bool approx_equal (const ScalarT computed, const ScalarT expected, const ScalarT tol) {
+    using std::abs;
+    return abs(computed-expected)/abs(expected) < tol;
+  }
+};
+
+template<typename T, int N, int NumLevels>
+struct ChecksHelpers<ekat::Pack<T,N>,NumLevels> {
+  using ScalarT = ekat::Pack<T,N>;
+
+  static bool is_non_negative (const ScalarT& s, const int k) {
+    const auto range = ekat::range<ScalarT>(k*N);
+    const auto range_mask = range < NumLevels;
+    return ( range_mask && (s<0 || isnan(s) ) ).none();
+  }
+  static bool equal (const ScalarT& lhs, const ScalarT& rhs) {
+    return (lhs==rhs).all();
+  }
+  static bool approx_equal (const ScalarT& lhs, const ScalarT& rhs,
+                            const int k, const T tol) {
+    const auto range = ekat::range<ScalarT>(k*N);
+    const auto range_mask = range < NumLevels;
+    return (range_mask && abs(lhs-rhs)>=tol).none();
+  }
+  static bool approx_equal (const ScalarT& computed, const ScalarT& expected, const T tol) {
+    return (abs(computed-expected)/abs(expected) < tol).all();
+  }
+};
+
+// Helper function. Create Mirror View and Deep-Copy (CMVDC)
+template<typename ViewT>
+auto cmvdc (const ViewT& v_d) -> typename ViewT::HostMirror {
+  auto v_h = Kokkos::create_mirror_view(v_d);
+  Kokkos::deep_copy(v_h,v_d);
+  return v_h;
+}
+
+//-----------------------------------------------------------------------------------------------//
+template<typename ScalarT, typename DeviceT>
+void run(std::mt19937_64& engine)
+{
+  using STraits    = ekat::ScalarTraits<ScalarT>;
+  using RealType   = typename STraits::scalar_type;
+
+  using PF         = scream::PhysicsFunctions<DeviceT>;
+  using PC         = scream::physics::Constants<RealType>;
+
+  using KT         = ekat::KokkosTypes<DeviceT>;
+  using ExecSpace  = typename KT::ExeSpace;
+  using TeamPolicy = typename KT::TeamPolicy;
+  using MemberType = typename KT::MemberType;
+  using view_1d    = typename KT::template view_1d<ScalarT>;
+  using rview_1d   = typename KT::template view_1d<RealType>;
+
+  static constexpr auto test_tol = PC::macheps*1e3;
+
+  constexpr int pack_size = sizeof(ScalarT) / sizeof(RealType);
+  using pack_info = ekat::PackInfo<pack_size>;
+
+  constexpr int num_levs = 32; // Number of levels to use for tests.
+  const     int num_mid_packs = pack_info::num_packs(num_levs);
+  const     int num_int_packs = pack_info::num_packs(num_levs+1);
+
+  using Check = ChecksHelpers<ScalarT,num_levs>;
+
 
   // A world comm
   ekat::Comm comm(MPI_COMM_WORLD);
 
+  // Create a grids manager - single column for these tests
+  auto gm = create_gm(comm,1,num_levs);
+
+  // Kokkos Policy
+  TeamPolicy policy(ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(1, 1));
+
+  // Input (randomized) views
+  view_1d temperature("temperature",num_mid_packs),
+          pressure("pressure",num_mid_packs);
+  // Output views
+  view_1d theta("theta",num_mid_packs);
+
+  auto dview_as_real = [&] (const view_1d& v) -> rview_1d {
+    return rview_1d(reinterpret_cast<RealType*>(v.data()),v.size()*pack_size);
+  };
+  auto hview_as_real = [&] (const typename view_1d::HostMirror& v) -> typename rview_1d::HostMirror {
+    return typename rview_1d::HostMirror(reinterpret_cast<RealType*>(v.data()),v.size()*pack_size);
+  };
+
+  // Construct random input data
+  using RPDF = std::uniform_real_distribution<RealType>;
+  RPDF pdf_pres(0.0,PC::P0),
+       pdf_temp(200.0,400.0);
+
+  //contruct random integers
+  using IPDF = std::uniform_int_distribution<int>;
+  IPDF pdf_rand_int(1,100);
+
+  ekat::genRandArray(dview_as_real(temperature),     engine,pdf_temp);
+  ekat::genRandArray(dview_as_real(pressure),        engine,pdf_pres);
+
   // A time stamp
   util::TimeStamp t0 ({2022,1,1},{0,0,0});
-
-  // Create a grids manager
-  auto gm = create_gm(comm);
 
   // Construct the Diagnostic
   ekat::ParameterList params;
@@ -54,32 +163,115 @@ TEST_CASE("potential_temperature_diagnostic", "") {
   diag->set_grids(gm);
 
   // Set the required fields for the diagnostic.
+  std::map<std::string,Field> input_fields;
   for (const auto& req : diag->get_required_field_requests()) {
     Field f(req.fid);
     f.allocate_view();
     const auto name = f.name();
-    if (name == "T_mid") {
-      f.deep_copy(270.0);
-    } else if (name == "p_mid") {
-      f.deep_copy(10000.0);
-    } else {
-      REQUIRE(false);
-    }
     f.get_header().get_tracking().update_time_stamp(t0);
     diag->set_required_field(f.get_const());
     REQUIRE_THROWS(diag->set_computed_field(f));
+    input_fields.emplace(name,f);
   }
 
   // Initialize the diagnostic
   diag->initialize(t0,RunType::Initial);
 
-  // Run the diagnostic
+  // Run tests
+  const ScalarT p0   = PC::P0;
+  const ScalarT zero = 0.0;
+  const ScalarT one  = 1.0;
+
+  // Get views of input data and set to random values
+  const auto& T_mid_f = input_fields["T_mid"];
+  const auto& T_mid_v = T_mid_f.get_view<ScalarT**>();
+  const auto& p_mid_f = input_fields["p_mid"];
+  const auto& p_mid_v = p_mid_f.get_view<ScalarT**>();
+
+  // Test 1 - property tests 
+  //  - theta(T=0) = 0
+  {
+  Field zero_f = T_mid_f;  // Field with only zeros
+  zero_f.deep_copy(0.0);
+  Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
+    const int i = team.league_rank();
+    const auto& T_sub = ekat::subview(T_mid_v,i);
+    const auto& p_sub = ekat::subview(p_mid_v,i);
+    Kokkos::deep_copy(T_sub,zero);
+    Kokkos::deep_copy(p_sub,p0);
+  });
+  Kokkos::fence();
   const auto& diag_out = diag->get_diagnostic(100.0);
+  REQUIRE(views_are_equal(diag_out,zero_f));
+  }
+  //  - theta=T when p=p0
+  {
+  Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
+    const int i = team.league_rank();
+    const auto& T_sub = ekat::subview(T_mid_v,i);
+    const auto& p_sub = ekat::subview(p_mid_v,i);
+    Kokkos::deep_copy(T_sub,temperature);
+    Kokkos::deep_copy(p_sub,p0);
+  });
+  Kokkos::fence();
+  const auto& diag_out = diag->get_diagnostic(100.0);
+  REQUIRE(views_are_equal(diag_out,T_mid_f));
+  }
+  // The output from the diagnostic should match what would happen if we called "calculate_theta_from_T" directly
+  {
+  Field theta_f = T_mid_f;
+  theta_f.deep_copy(0.0);
+  const auto& theta_v = theta_f.get_view<ScalarT**>();
+  Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
+    const int i = team.league_rank();
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& k) {
+      theta_v(i,k) = PF::calculate_theta_from_T(T_mid_v(i,k),p_mid_v(i,k));
+    });
+    team.team_barrier();
+  });
+  Kokkos::fence();
+  const auto& diag_out = diag->get_diagnostic(100.0);
+  REQUIRE(views_are_equal(diag_out,theta_f));
+  }
  
   // Finalize the diagnostic
   diag->finalize(); 
 
+} // run()
 
-}
+TEST_CASE("potential_temp_test", "potential_temp_test]"){
+  // Run tests for both Real and Pack, and for (potentially) different pack sizes
+  using scream::Real;
+  using Device = scream::DefaultDevice;
 
-} //namspace scream
+  constexpr int num_runs = 5;
+
+  auto engine = scream::setup_random_test();
+
+  std::cout << " -> Number of randomized runs: " << num_runs << "\n\n";
+
+  printf(" -> Testing Real scalar type...");
+  for (int irun=0; irun<num_runs; ++irun) {
+    run<Real,Device>(engine);
+  }
+  printf("ok!\n");
+
+  printf(" -> Testing Pack<Real,%d> scalar type...",SCREAM_SMALL_PACK_SIZE);
+  for (int irun=0; irun<num_runs; ++irun) {
+    run<ekat::Pack<Real,SCREAM_SMALL_PACK_SIZE>,Device>(engine);
+  }
+  printf("ok!\n");
+
+  if (SCREAM_PACK_SIZE!=SCREAM_SMALL_PACK_SIZE) {
+    printf(" -> Testing Pack<Real,%d> scalar type...",SCREAM_PACK_SIZE);
+    for (int irun=0; irun<num_runs; ++irun) {
+      run<ekat::Pack<Real,SCREAM_PACK_SIZE>,Device>(engine);
+    }
+    printf("ok!\n");
+  }
+
+  printf("\n");
+
+} // TEST_CASE
+
+} // namespace

--- a/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
@@ -1,0 +1,72 @@
+#include <catch2/catch.hpp>
+
+#include "share/grid/mesh_free_grids_manager.hpp"
+
+#include "share/atm_process/atmosphere_diagnostic.hpp"
+#include "diagnostics/potential_temperature.hpp"
+
+#include "ekat/ekat_parameter_list.hpp"
+#include "ekat/ekat_parse_yaml_file.hpp"
+
+namespace scream {
+
+
+std::shared_ptr<GridsManager>
+create_gm (const ekat::Comm& comm) {
+
+  const int num_local_elems = 4;
+  const int np = 4;
+  const int nlevs = 10;
+  const int num_local_cols = 13;
+  const int num_global_cols = num_local_cols*comm.size();
+
+  ekat::ParameterList gm_params;
+  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.sublist("Mesh Free").set<int>("Number of Global Columns", num_global_cols);
+  gm_params.sublist("Mesh Free").set<int>("Number of Local Elements", num_local_elems);
+  gm_params.sublist("Mesh Free").set<int>("Number of Vertical Levels", nlevs);
+  gm_params.sublist("Mesh Free").set<int>("Number of Gauss Points", np);
+
+  auto gm = create_mesh_free_grids_manager(comm,gm_params);
+  gm->build_all_grids();
+
+  return gm;
+}
+
+TEST_CASE("potential_temperature_diagnostic", "") {
+
+  using namespace scream;
+
+  // A world comm
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  // A time stamp
+  util::TimeStamp t0 ({2022,1,1},{0,0,0});
+
+  // Create a grids manager
+  auto gm = create_gm(comm);
+
+  // Construct the Diagnostic
+  ekat::ParameterList params;
+  params.set<std::string>("Diagnostic Name", "Potential Temperature");
+  params.set<std::string>("Grid Name", "Point Grid");
+  auto diag = std::make_shared<PotentialTemperatureDiagnostic>(comm,params);
+//  diag->set_grids(gm);
+//
+//  // Set the required fields for the diagnostic.
+//  for (const auto& req : diag->get_required_field_requests()) {
+//    Field f(req.fid);
+//    f.allocate_view();
+//    diag->set_required_field(f.get_const());
+//  }
+//
+//  // Initialize the diagnostic
+//  diag->initialize(t0,RunType::Initial);
+//  
+//  // Finalize the diagnostic
+//  diag->finalize(); 
+
+
+}
+
+} //namspace scream

--- a/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
@@ -208,7 +208,7 @@ void run(std::mt19937_64& engine)
   // The output from the diagnostic should match what would happen if we called "calculate_theta_from_T" directly
   {
   Field theta_f = T_mid_f;
-  theta_f.deep_copy(0.0);
+  theta_f.deep_copy<double,Host>(0.0);
   const auto& theta_v = theta_f.get_view<ScalarT**>();
   Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
     const int i = team.league_rank();

--- a/components/scream/src/share/CMakeLists.txt
+++ b/components/scream/src/share/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SHARE_SRC
   atm_process/atmosphere_process.cpp
   atm_process/atmosphere_process_group.cpp
   atm_process/atmosphere_process_dag.cpp
+  atm_process/atmosphere_diagnostic.cpp
   field/field_alloc_prop.cpp
   field/field_identifier.cpp
   field/field_header.cpp

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
@@ -1,0 +1,14 @@
+#include "share/atm_process/atmosphere_diagnostic.hpp"
+
+namespace scream
+{
+
+AtmosphereDiagnostic::
+AtmosphereDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
+  : AtmosphereProcess(comm,params)
+{
+  // Nothing to do here
+}
+
+} // namespace scream
+

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
@@ -11,16 +11,16 @@ AtmosphereDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
 }
 
 // Function to retrieve the diagnostic output which is stored in m_diagnostic_output
-Field& AtmosphereDiagnostic::get_diagnostic (const Real dt) {
+Field AtmosphereDiagnostic::get_diagnostic (const Real dt) {
   run(dt);
-  return m_diagnostic_output;
+  return m_diagnostic_output.get_const();
 }
 
-void AtmosphereDiagnostic::set_computed_field_impl (const Field& f) {
+void AtmosphereDiagnostic::set_computed_field (const Field& f) {
   EKAT_ERROR_MSG("Error! Diagnostics are not allowed to compute fields. See " + name() + ".\n");
 }
 
-void AtmosphereDiagnostic::set_computed_group_impl (const FieldGroup& group) {
+void AtmosphereDiagnostic::set_computed_group (const FieldGroup& group) {
   EKAT_ERROR_MSG("Error! Diagnostics are not allowed to compute field groups. See " + name() + ".\n");
 }
 

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
@@ -10,6 +10,11 @@ AtmosphereDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
   // Nothing to do here
 }
 
+// Function to retrieve the diagnostic output which is stored in m_diagnostic_output
+Field& AtmosphereDiagnostic::get_diagnostic (const Real dt) {
+  run(dt);
+  return m_diagnostic_output;
+}
 
 void AtmosphereDiagnostic::set_computed_field_impl (const Field& f) {
   EKAT_ERROR_MSG("Error! Diagnostics are not allowed to compute fields. See " + name() + ".\n");

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
@@ -10,5 +10,14 @@ AtmosphereDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
   // Nothing to do here
 }
 
+
+void AtmosphereDiagnostic::set_computed_field_impl (const Field& f) {
+  EKAT_ERROR_MSG("Error! Diagnostics are not allowed to compute fields. See " + name() + ".\n");
+}
+
+void AtmosphereDiagnostic::set_computed_group_impl (const FieldGroup& group) {
+  EKAT_ERROR_MSG("Error! Diagnostics are not allowed to compute field groups. See " + name() + ".\n");
+}
+
 } // namespace scream
 

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -40,8 +40,8 @@ public:
   // Getting the diagnostic output
   Field get_diagnostic (const Real dt);
 
-  void set_computed_field (const Field& f);
-  void set_computed_group (const FieldGroup& group);
+  void set_computed_field (const Field& f) final;
+  void set_computed_group (const FieldGroup& group) final;
 protected:
 
   // Diagnostics are meant to return a field

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -39,6 +39,9 @@ public:
 
 protected:
 
+  void set_computed_field_impl (const Field& f);
+  void set_computed_group_impl (const FieldGroup& group);
+
   // Diagnostics are meant to return a field
   Field m_diagnostic_output;
 

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -37,6 +37,9 @@ public:
   // The type of subcomponent
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
+  // Getting the diagnostic output
+  Field& get_diagnostic (const Real dt);
+
 protected:
 
   void set_computed_field_impl (const Field& f);

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -38,12 +38,11 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // Getting the diagnostic output
-  Field& get_diagnostic (const Real dt);
+  Field get_diagnostic (const Real dt);
 
+  void set_computed_field (const Field& f);
+  void set_computed_group (const FieldGroup& group);
 protected:
-
-  void set_computed_field_impl (const Field& f);
-  void set_computed_group_impl (const FieldGroup& group);
 
   // Diagnostics are meant to return a field
   Field m_diagnostic_output;

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -1,0 +1,50 @@
+#ifndef SCREAM_ATMOSPHERE_DIAGNOSTIC_HPP
+#define SCREAM_ATMOSPHERE_DIAGNOSTIC_HPP
+
+#include "share/atm_process/atmosphere_process.hpp"
+
+namespace scream
+{
+
+/*
+ * A class representing an atmosphere diagnostic.
+ * Diagnostics are similar to atmosphere processes in that
+ * they take field(s) as input and produce some output.
+ * 
+ * This subclass definition makes a few distinctions that are
+ * unique to diagnostics.
+ * 
+ * 1) Fields from the field manager can only be accessed as "Required".
+ *    Meaning that an atmosphere diagnostic can not compute or update
+ *    a field in the field manager.
+ *    - note, if you want to update something in the field manager it
+ *            should happen in an atmosphere process.
+ * 2) Diagnostics produce a single field output.
+ *    Typically the field output will be to buffered memory, meaning it
+ *    could be overwritten later in the simulation.
+ *    A diagnostic output is meant to be used for OUTPUT or a PROPERTY CHECK.
+ */
+
+class AtmosphereDiagnostic : public AtmosphereProcess
+{
+public:
+
+  // Constructor(s)
+  explicit AtmosphereDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
+
+  virtual ~AtmosphereDiagnostic () = default;
+
+  // The type of subcomponent
+  AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
+
+protected:
+
+  // Diagnostics are meant to return a field
+  Field m_diagnostic_output;
+
+
+};
+
+} //namespace scream
+
+#endif // SCREAM_ATMOSPHERE_DIAGNOSTIC_HPP

--- a/components/scream/src/share/atm_process/atmosphere_process_utils.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_utils.hpp
@@ -15,14 +15,16 @@ enum class CheckFailHandling {
 enum class AtmosphereProcessType {
   Dynamics,   // Process responsible of handling the dynamics
   Physics,    // Process handling a physics parametrization
-  Group       // Process that groups a bunch of processes (so they look as a single process)
+  Group,      // Process that groups a bunch of processes (so they look as a single process)
+  Diagnostic  // Process that handles a diagnostic output
 };
 
 inline std::string e2str (const AtmosphereProcessType ap_type) {
   switch (ap_type) {
-    case AtmosphereProcessType::Dynamics:  return "Atmosphere Dynamics";
-    case AtmosphereProcessType::Physics:   return "Atmosphere Physics Parametrization";
-    case AtmosphereProcessType::Group:     return "Atmosphere Process Group";
+    case AtmosphereProcessType::Dynamics:   return "Atmosphere Dynamics";
+    case AtmosphereProcessType::Physics:    return "Atmosphere Physics Parametrization";
+    case AtmosphereProcessType::Group:      return "Atmosphere Process Group";
+    case AtmosphereProcessType::Diagnostic: return "Atmosphere Diagnostic";
     default:
       ekat::error::runtime_abort("Error! Unrecognized atmosphere process type.\n");
   }

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -348,9 +348,6 @@ deep_copy (const Field& field_src) {
     default:
       EKAT_ERROR_MSG ("Error! Unrecognized field data type in Field::deep_copy.\n");
   }
-
-  // Sync back to host
-  sync_to_host();
 }
 
 template<typename ST, HostOrDevice HD>
@@ -385,9 +382,6 @@ deep_copy (const ST value) {
     default:
       EKAT_ERROR_MSG ("Error! Unrecognized field data type in Field::deep_copy.\n");
   }
-
-  // Sync back to host
-  sync_to_host();
 }
 
 template<typename ST, HostOrDevice HD>

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -348,6 +348,9 @@ deep_copy (const Field& field_src) {
     default:
       EKAT_ERROR_MSG ("Error! Unrecognized field data type in Field::deep_copy.\n");
   }
+
+  // Sync back to host
+  sync_to_host();
 }
 
 template<typename ST, HostOrDevice HD>
@@ -382,6 +385,9 @@ deep_copy (const ST value) {
     default:
       EKAT_ERROR_MSG ("Error! Unrecognized field data type in Field::deep_copy.\n");
   }
+
+  // Sync back to host
+  sync_to_host();
 }
 
 template<typename ST, HostOrDevice HD>

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -91,11 +91,6 @@ public:
   // Return some sort of name, linked to PType
   std::string name () const { return m_name; }
 
-  // Routine to get diagnostic
-  Field& get_diagnostic (const int dt) {
-    run_impl( dt );
-    return m_diagnostic_output;
-  }
 protected:
 
   // The initialization method should prepare all stuff needed to import/export from/to

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -3,6 +3,7 @@
 #include "share/atm_process/atmosphere_process.hpp"
 #include "share/atm_process/atmosphere_process_group.hpp"
 #include "share/atm_process/atmosphere_process_dag.hpp"
+#include "share/atm_process/atmosphere_diagnostic.hpp"
 
 #include "share/property_checks/field_positivity_check.hpp"
 #include "share/grid/se_grid.hpp"
@@ -68,6 +69,125 @@ create_gm (const ekat::Comm& comm) {
   return gm;
 }
 
+// =============================== Diagnostics ========================== //
+// A dummy diagnostic
+class DummyDiag : public AtmosphereDiagnostic {
+
+public:
+  DummyDiag (const ekat::Comm& comm, const ekat::ParameterList& params)
+    : AtmosphereDiagnostic(comm, params)
+  {
+    m_name = params.get<std::string> ("Diagnostic Name");
+    m_grid_name = params.get<std::string> ("Grid Name");
+  }
+
+  // The type of grids on which the diagnostic is defined
+  std::set<std::string> get_required_grids () const {
+    static std::set<std::string> s;
+    s.insert(m_grid_name);
+    return s;
+  }
+
+  // Return some sort of name, linked to PType
+  std::string name () const { return m_name; }
+
+  // Routine to get diagnostic
+  Field& get_diagnostic (const int dt) {
+    run_impl( dt );
+    return m_diagnostic_output;
+  }
+protected:
+
+  // The initialization method should prepare all stuff needed to import/export from/to
+  // f90 structures.
+  void initialize_impl (const RunType /* run_type */ ) {}
+
+  // The run method is responsible for exporting atm states to the e3sm coupler, and
+  // import surface states from the e3sm coupler.
+  void run_impl (const int /* dt */) {}
+
+  // Clean up
+  void finalize_impl ( /* inputs */ ) {}
+
+  std::string m_name;
+  std::string m_grid_name;
+
+};
+
+class DiagIdentity : public DummyDiag
+{
+public:
+  DiagIdentity (const ekat::Comm& comm, const ekat::ParameterList& params)
+    : DummyDiag(comm,params)
+  {
+    // Nothing to do here
+  }
+
+  std::string name() const { return "Identity Dianostic"; }
+
+  void set_grids (const std::shared_ptr<const GridsManager> gm) {
+    using namespace ekat::units;
+
+    const auto grid = gm->get_grid(m_grid_name);
+    const auto lt = grid->get_2d_scalar_layout ();
+
+    add_field<Required>("Field A",lt,K,m_grid_name);
+
+    // We have to initialize the m_diagnostic_output:
+    FieldIdentifier fid (name(), lt, K, m_grid_name);
+    m_diagnostic_output = Field(fid);
+    m_diagnostic_output.allocate_view();
+  }
+protected:
+    void run_impl (const int /* dt */) {
+      auto f = get_field_in("Field A", m_grid_name);
+      auto v_A = f.get_view<const Real*,Host>();
+      auto v_me = m_diagnostic_output.get_view<Real*,Host>();
+      for (size_t i=0; i<v_me.size(); ++i) {
+        v_me[i] = v_A[i];
+      }
+    }
+};
+
+class DiagSum : public DummyDiag
+{
+public:
+  DiagSum (const ekat::Comm& comm, const ekat::ParameterList&params)
+    : DummyDiag(comm,params)
+  {
+    // Nothing to do here
+  }
+
+  std::string name() const { return "Summation Dianostic"; }
+
+  void set_grids (const std::shared_ptr<const GridsManager> gm) {
+    using namespace ekat::units;
+
+    const auto grid = gm->get_grid(m_grid_name);
+    const auto lt = grid->get_2d_scalar_layout ();
+
+    add_field<Required>("Field A",lt,K,m_grid_name);
+    add_field<Required>("Field B",lt,K,m_grid_name);
+
+    // We have to initialize the m_diagnostic_output:
+    FieldIdentifier fid (name(), lt, K, m_grid_name);
+    m_diagnostic_output = Field(fid);
+    m_diagnostic_output.allocate_view();
+  }
+
+protected:
+    void run_impl (const int /* dt */) {
+      auto f_A = get_field_in("Field A", m_grid_name);
+      auto f_B = get_field_in("Field B", m_grid_name);
+      auto v_A = f_A.get_view<const Real*,Host>();
+      auto v_B = f_B.get_view<const Real*,Host>();
+      auto v_me = m_diagnostic_output.get_view<Real*,Host>();
+      for (size_t i=0; i<v_me.size(); ++i) {
+        v_me[i] = v_A[i]+v_B[i];
+      }
+    }
+};
+// =============================== Processes ========================== //
 // A dummy atm proc
 class DummyProcess : public scream::AtmosphereProcess {
 public:
@@ -208,6 +328,36 @@ protected:
   }
 };
 
+class AddTwo : public DummyProcess
+{
+public:
+  AddTwo (const ekat::Comm& comm,const ekat::ParameterList& params)
+   : DummyProcess(comm,params)
+  {
+    // Nothing to do here
+  }
+
+  // The type of the atm proc
+  AtmosphereProcessType type () const { return AtmosphereProcessType::Physics; }
+
+  void set_grids (const std::shared_ptr<const GridsManager> gm) {
+    using namespace ekat::units;
+
+    const auto grid = gm->get_grid(m_grid_name);
+    const auto lt = grid->get_2d_scalar_layout ();
+
+    add_field<Updated>("Field B",lt,K,m_grid_name);
+  }
+protected:
+    void run_impl (const int /* dt */) {
+    auto v = get_field_out("Field B", m_grid_name).get_view<Real*,Host>();
+
+    for (int i=0; i<v.extent_int(0); ++i) {
+      v[i] += Real(2.0);
+    }
+  }
+};
+
 
 // ================================ TESTS ============================== //
 
@@ -228,6 +378,7 @@ TEST_CASE("process_factory", "") {
   factory.register_product("Bar",&create_atmosphere_process<Bar>);
   factory.register_product("Baz",&create_atmosphere_process<Baz>);
   factory.register_product("grouP",&create_atmosphere_process<AtmosphereProcessGroup>);
+  factory.register_product("DiagIdentity",&create_atmosphere_process<DiagIdentity>);
 
   // Create the processes
   std::shared_ptr<AtmosphereProcess> atm_process (factory.create("group",comm,params));
@@ -426,6 +577,106 @@ TEST_CASE ("subcycling") {
   REQUIRE (v.size()==v_sub.size());
   for (size_t i=0; i<v.size(); ++i) {
     REQUIRE (v_sub[i]==5*v[i]);
+  }
+}
+
+TEST_CASE ("diagnostics") {
+
+  //TODO: This test needs a field manager so that changes in Field A are seen everywhere.
+  using namespace scream;
+
+  // A world comm
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  // A time stamp
+  util::TimeStamp t0 ({2022,1,1},{0,0,0});
+
+  // Create a grids manager
+  auto gm = create_gm(comm);
+
+  // Use the AddOne process to generate the field data to use with diagnostic
+  ekat::ParameterList params_proc_A;
+  params_proc_A.set<std::string>("Process Name", "AddOne");
+  params_proc_A.set<std::string>("Grid Name", "Point Grid");
+  auto ap1     = std::make_shared<AddOne>(comm,params_proc_A);
+  ap1->set_grids(gm);
+
+  // Use the AddTwo process to generate the field data to use with diagnostic
+  ekat::ParameterList params_proc_B;
+  params_proc_B.set<std::string>("Process Name", "AddTwo");
+  params_proc_B.set<std::string>("Grid Name", "Point Grid");
+  auto ap2     = std::make_shared<AddTwo>(comm,params_proc_B);
+  ap2->set_grids(gm);
+
+  // Create the identity diagnostic
+  ekat::ParameterList params_identity;
+  params_identity.set<std::string>("Diagnostic Name", "DiagIdentity");
+  params_identity.set<std::string>("Grid Name", "Point Grid");
+  auto diag_identity = std::make_shared<DiagIdentity>(comm,params_identity);
+  diag_identity->set_grids(gm);
+
+  // Create the sum diagnostic
+  ekat::ParameterList params_sum;
+  params_sum.set<std::string>("Diagnostic Name", "DiagSum");
+  params_sum.set<std::string>("Grid Name", "Point Grid");
+  auto diag_sum = std::make_shared<DiagSum>(comm,params_sum);
+  diag_sum->set_grids(gm);
+
+  // Create fields for ap1
+  for(const auto& req : ap1->get_required_field_requests()) {
+    printf("ASD hello\n");
+    Field f(req.fid);
+    f.allocate_view();
+    f.deep_copy(0);
+    f.get_header().get_tracking().update_time_stamp(t0);
+    // Set the required and computed fields for the process and for the diagnostic(s)
+    ap1->set_required_field(f.get_const());
+    ap1->set_computed_field(f);
+    diag_identity->set_required_field(f.get_const());
+    diag_sum->set_required_field(f.get_const());
+  }
+
+  // Create fields for ap2
+  for(const auto& req : ap2->get_required_field_requests()) {
+    printf("ASD goodbye\n");
+    Field f(req.fid);
+    f.allocate_view();
+    f.deep_copy(0);
+    f.get_header().get_tracking().update_time_stamp(t0);
+    // Set the required and computed fields for the process and for the diagnostic(s)
+    ap2->set_required_field(f.get_const());
+    ap2->set_computed_field(f);
+    diag_sum->set_required_field(f.get_const());
+  }
+
+  ap1->initialize(t0,RunType::Initial);
+  ap2->initialize(t0,RunType::Initial);
+  diag_identity->initialize(t0,RunType::Initial);
+  diag_sum->initialize(t0,RunType::Initial);
+
+  // Run the AddOne process for one timestep
+  const int dt = 5;  // Note, neither process use dt so really can be any value.
+  ap1->run(dt);
+  ap2->run(dt);
+
+  // Run the diagnostics
+  auto f_identity = diag_identity->get_diagnostic(dt);
+  auto f_sum      = diag_sum->get_diagnostic(dt);
+
+  // For the identity diagnostic check that the fields match
+  auto f_A        = ap1->get_field_out("Field A");
+  auto f_B        = ap2->get_field_out("Field B");
+  auto v_A        = f_A.get_view<const Real*,Host>();
+  auto v_B        = f_B.get_view<const Real*,Host>();
+  auto v_identity = f_identity.get_view<const Real*,Host>();
+  auto v_sum      = f_sum.get_view<const Real*,Host>();
+  REQUIRE (v_A.size()==v_identity.size());
+  REQUIRE (v_A.size()==v_sum.size());
+  REQUIRE (v_B.size()==v_sum.size());
+  for (size_t i=0; i<v_A.size(); ++i) {
+    REQUIRE (v_identity[i]==v_A[i]);
+    REQUIRE (v_sum[i]==v_A[i]+v_B[i]);
+    REQUIRE (v_sum[i]==3);
   }
 }
 

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -620,9 +620,9 @@ TEST_CASE ("diagnostics") {
     REQUIRE_THROWS(diag_fail->set_computed_field(f));
     if (name == "Field A") {
       diag_identity->set_required_field(f.get_const());
-      f.deep_copy(1.0);
+      f.deep_copy<double,Host>(1.0);
     } else {
-      f.deep_copy(2.0);
+      f.deep_copy<double,Host>(2.0);
     } 
     input_fields.emplace(name,f);
   }

--- a/components/scream/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/scream/src/share/tests/common_physics_functions_tests.cpp
@@ -425,7 +425,7 @@ TEST_CASE("common_physics_functions_test", "[common_physics_functions_test]"){
 
   auto engine = scream::setup_random_test();
 
-  std::cout << " -> Number of randomized runs: " << num_runs << "\n\n";
+  printf(" -> Number of randomized runs: %d\n\n", num_runs);
 
   printf(" -> Testing Real scalar type...");
   for (int irun=0; irun<num_runs; ++irun) {


### PR DESCRIPTION
This commit will introduce a diagnostic class to the EAMXX infrastructure.  

The diagnostic class is a sub-class of the atmosphere process class with a few limitations.  The purpose of the diagnostic class is to make it possible to define a diagnostic that can be used for property checking or as simulation output, without having to add a new field to field manager.

The unique properties of the diagnostic class are as follows:
1. Only allowed to access fields in the field manager as "required", meaning a diagnostic class object cannot change a field managed variable.
2. Has the "get_diagnostic" routine which provides a Field as output that contains all of the diagnostic data and metadata.
3. That field is also stored internally to the diagnostic class, but in contrast to a field managed variable will use shared memory.  In other words, the memory footprint of a diagnostic class should be relatively small, and importantly, the data for a diagnostic class cannot be trusted unless the diagnostic has just been run, that is because all diagnostic objects share the same field memory.

This commit does not make diagnostics callable from the output streams, that will be the subject of a subsequent PR.