### PR TITLE
add snowl to CPL

### DIFF
--- a/components/scream/data/scream_output.yaml
+++ b/components/scream/data/scream_output.yaml
@@ -17,6 +17,8 @@ Fields:
       - nr
       - ni
       - bm
+      - precip_liq_surf
+      - precip_ice_surf
       - qv_prev_micro_step
       - eff_radius_qc
       - eff_radius_qi

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -802,11 +802,6 @@ void AtmosphereDriver::run (const int dt) {
   // Make sure the end of the time step is after the current start_time
   EKAT_REQUIRE_MSG (dt>0, "Error! Input time step must be positive.\n");
 
-  // Print current timestamp information
-  if (m_atm_comm.am_i_root()) {
-    std::cout << "Atmosphere step = " << m_current_ts.get_num_steps() << "; model time = " << m_current_ts.get_date_string() << " " << m_current_ts.get_time_string() << std::endl;
-  }
-
   if (m_surface_coupling) {
     // Import fluxes from the component coupler (if any)
     m_surface_coupling->do_import();

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -802,6 +802,11 @@ void AtmosphereDriver::run (const int dt) {
   // Make sure the end of the time step is after the current start_time
   EKAT_REQUIRE_MSG (dt>0, "Error! Input time step must be positive.\n");
 
+    // Print current timestamp information
+  if (m_atm_comm.am_i_root()) {
+    std::cout << "Atmosphere step = " << m_current_ts.get_num_steps() << "; model time = " << m_current_ts.get_date_string() << " " << m_current_ts.get_time_string() << std::endl;
+  }
+  
   if (m_surface_coupling) {
     // Import fluxes from the component coupler (if any)
     m_surface_coupling->do_import();

--- a/components/scream/src/control/surface_coupling.cpp
+++ b/components/scream/src/control/surface_coupling.cpp
@@ -55,6 +55,7 @@ set_num_fields (const int num_cpl_imports, const int num_scream_imports,
   Sa_ptem    = decltype(Sa_ptem)    ("", m_num_cols);
   Sa_dens    = decltype(Sa_dens)    ("", m_num_cols);
   Faxa_rainl = decltype(Faxa_rainl) ("", m_num_cols);
+  Faxa_snowl = decltype(Faxa_snowl) ("", m_num_cols);
   zero_view  = decltype(zero_view)  ("", m_num_cols);
   Kokkos::deep_copy(zero_view, 0.0);
 
@@ -189,6 +190,7 @@ register_export (const std::string& fname,
     else if (fname == "Sa_ptem")    info.data = Sa_ptem.data();
     else if (fname == "Sa_dens")    info.data = Sa_dens.data();
     else if (fname == "Faxa_rainl") info.data = Faxa_rainl.data();
+    else if (fname == "Faxa_snowl") info.data = Faxa_snowl.data();
     else                            EKAT_ERROR_MSG("Error! Unrecognized export field name \"" + fname + "\".");
 
     // Get column offset and stride

--- a/components/scream/src/control/surface_coupling.hpp
+++ b/components/scream/src/control/surface_coupling.hpp
@@ -140,6 +140,7 @@ protected:
   view_1d<device_type,Real> Sa_ptem;
   view_1d<device_type,Real> Sa_dens;
   view_1d<device_type,Real> Faxa_rainl;
+  view_1d<device_type,Real> Faxa_snowl;
   view_1d<device_type,Real> zero_view;
 
   // Dummy field to allow for the storage of the FieldIdentifier for debugging (not currently used)

--- a/components/scream/src/control/surface_coupling_export.cpp
+++ b/components/scream/src/control/surface_coupling_export.cpp
@@ -22,7 +22,7 @@ void SurfaceCoupling::do_export (const bool init_phase)
   const bool scream_ad_run =
       (m_field_mgr->has_field("qv") && m_field_mgr->has_field("T_mid") &&
        m_field_mgr->has_field("p_mid") && m_field_mgr->has_field("pseudo_density") &&
-       m_field_mgr->has_field("precip_liq_surf"));
+       m_field_mgr->has_field("precip_liq_surf") && m_field_mgr->has_field("precip_ice_surf"));
   if (scream_ad_run) {
     const int last_entry = m_num_levs-1;
     const auto& qv              = m_field_mgr->get_field("qv").get_view<const Real**>();
@@ -30,6 +30,7 @@ void SurfaceCoupling::do_export (const bool init_phase)
     const auto& p_mid           = m_field_mgr->get_field("p_mid").get_view<const Real**>();
     const auto& pseudo_density  = m_field_mgr->get_field("pseudo_density").get_view<const Real**>();
     const auto& precip_liq_surf = m_field_mgr->get_field("precip_liq_surf").get_view<const Real*>();
+    const auto& precip_ice_surf = m_field_mgr->get_field("precip_ice_surf").get_view<const Real*>();
     const auto l_dz             = dz;
     const auto l_z_int          = z_int;
     const auto l_z_mid          = z_mid;
@@ -37,6 +38,7 @@ void SurfaceCoupling::do_export (const bool init_phase)
     const auto l_Sa_ptem        = Sa_ptem;
     const auto l_Sa_dens        = Sa_dens;
     const auto l_Faxa_rainl     = Faxa_rainl;
+    const auto l_Faxa_snowl     = Faxa_snowl;
 
     // Local copy, to deal with CUDA's handling of *this.
     const int num_levs = m_num_levs;
@@ -68,6 +70,7 @@ void SurfaceCoupling::do_export (const bool init_phase)
       l_Sa_ptem(i)    = PF::calculate_theta_from_T(T_mid_i(last_entry), p_mid_i(last_entry));
       l_Sa_dens(i)    = PF::calculate_density(pseudo_density_i(last_entry), dz_i(last_entry));
       l_Faxa_rainl(i) = precip_liq_surf(i)*C::RHO_H2O;
+      l_Faxa_snowl(i) = precip_ice_surf(i)*C::RHO_H2O; //p3_ice_sed_impl.hpp uses INV_RHO_H2O
     });
   }
 

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -274,6 +274,7 @@ TEST_CASE ("recreate_mct_coupling")
   FID pseudo_density_id  ("pseudo_density",  scalar3d_layout, Pa,     grid_name);
   FID qv_id              ("qv",              scalar3d_layout, nondim, grid_name);
   FID precip_liq_surf_id ("precip_liq_surf", scalar2d_layout, m/s,    grid_name);
+  FID precip_ice_surf_id ("precip_ice_surf", scalar2d_layout, m/s,    grid_name);
   FID sfc_flux_dir_nir_id("sfc_flux_dir_nir", scalar2d_layout, W/(m*m), grid_name);
   FID sfc_flux_dir_vis_id("sfc_flux_dir_vis", scalar2d_layout, W/(m*m), grid_name);
   FID sfc_flux_dif_nir_id("sfc_flux_dif_nir", scalar2d_layout, W/(m*m), grid_name);
@@ -284,7 +285,7 @@ TEST_CASE ("recreate_mct_coupling")
   // NOTE: if you add fields above, you will have to modify these counters too.
   const int num_cpl_imports    = 30;
   const int num_scream_imports = 9;
-  const int num_cpl_exports    = 35;
+  const int num_cpl_exports    = 36;
 
   // Register fields and tracer group in a FieldManager
   auto fm = std::make_shared<FieldManager> (grid);
@@ -303,6 +304,7 @@ TEST_CASE ("recreate_mct_coupling")
   fm->register_field(FR{pseudo_density_id});
   fm->register_field(FR{qv_id,"tracers"});
   fm->register_field(FR{precip_liq_surf_id});
+  fm->register_field(FR{precip_ice_surf_id});
   fm->register_field(FR{sfc_flux_dir_nir_id});
   fm->register_field(FR{sfc_flux_dir_vis_id});
   fm->register_field(FR{sfc_flux_dif_nir_id});
@@ -328,6 +330,7 @@ TEST_CASE ("recreate_mct_coupling")
   auto pseudo_density_f   = fm->get_field(pseudo_density_id);
   auto qv_f               = fm->get_field(qv_id);
   auto precip_liq_surf_f  = fm->get_field(precip_liq_surf_id);
+  auto precip_ice_surf_f  = fm->get_field(precip_ice_surf_id);
   auto sfc_flux_dir_nir_f = fm->get_field(sfc_flux_dir_nir_id);
   auto sfc_flux_dir_vis_f = fm->get_field(sfc_flux_dir_vis_id);
   auto sfc_flux_dif_nir_f = fm->get_field(sfc_flux_dif_nir_id);
@@ -353,6 +356,7 @@ TEST_CASE ("recreate_mct_coupling")
   auto pseudo_density_d   = pseudo_density_f.get_view<Real**>();
   auto qv_d               = qv_f.get_view<Real**>();
   auto precip_liq_surf_d  = precip_liq_surf_f.get_view<Real*>();
+  auto precip_ice_surf_d  = precip_ice_surf_f.get_view<Real*>();
   auto sfc_flux_dir_nir_d = sfc_flux_dir_nir_f.get_view<Real*>();
   auto sfc_flux_dir_vis_d = sfc_flux_dir_vis_f.get_view<Real*>();
   auto sfc_flux_dif_nir_d = sfc_flux_dif_nir_f.get_view<Real*>();
@@ -374,6 +378,7 @@ TEST_CASE ("recreate_mct_coupling")
   auto horiz_winds_h      = horiz_winds_f.get_view<Real***,Host>();
   auto qv_h               = qv_f.get_view<Real**,Host>();
   auto precip_liq_surf_h  = precip_liq_surf_f.get_view<Real*,Host>();
+  auto precip_ice_surf_h  = precip_ice_surf_f.get_view<Real*,Host>();
   auto sfc_flux_dir_nir_h = sfc_flux_dir_nir_f.get_view<Real*,Host>();
   auto sfc_flux_dir_vis_h = sfc_flux_dir_vis_f.get_view<Real*,Host>();
   auto sfc_flux_dif_nir_h = sfc_flux_dif_nir_f.get_view<Real*,Host>();
@@ -435,13 +440,13 @@ TEST_CASE ("recreate_mct_coupling")
   coupler.register_export("set_zero",        13);
   coupler.register_export("set_zero",        14);
   coupler.register_export("Faxa_rainl",      15);  
-  coupler.register_export("sfc_flux_lw_dn",  16);
-  coupler.register_export("sfc_flux_dir_nir",17);
-  coupler.register_export("sfc_flux_dir_vis",18);
-  coupler.register_export("sfc_flux_dif_nir",19);
-  coupler.register_export("sfc_flux_dif_vis",20);
-  coupler.register_export("sfc_flux_sw_net", 21);
-  coupler.register_export("set_zero",        22);
+  coupler.register_export("Faxa_snowl",      16);
+  coupler.register_export("sfc_flux_lw_dn",  17);
+  coupler.register_export("sfc_flux_dir_nir",18);
+  coupler.register_export("sfc_flux_dir_vis",19);
+  coupler.register_export("sfc_flux_dif_nir",20);
+  coupler.register_export("sfc_flux_dif_vis",21);
+  coupler.register_export("sfc_flux_sw_net", 22);
   coupler.register_export("set_zero",        23);
   coupler.register_export("set_zero",        24);
   coupler.register_export("set_zero",        25);
@@ -454,6 +459,7 @@ TEST_CASE ("recreate_mct_coupling")
   coupler.register_export("set_zero",        32);
   coupler.register_export("set_zero",        33);
   coupler.register_export("set_zero",        34);
+  coupler.register_export("set_zero",        35);
 
 
   // Complete setup of importer/exporter, providing raw_data
@@ -479,6 +485,7 @@ TEST_CASE ("recreate_mct_coupling")
     ekat::genRandArray(horiz_winds_d,engine,pdf);
     ekat::genRandArray(pseudo_density_d,engine,pdf);
     ekat::genRandArray(precip_liq_surf_d,engine,pdf);
+    ekat::genRandArray(precip_ice_surf_d,engine,pdf);
     ekat::genRandArray(sfc_flux_lw_dn_d,engine,pdf);
     ekat::genRandArray(sfc_flux_dir_nir_d,engine,pdf);
     ekat::genRandArray(sfc_flux_dir_vis_d,engine,pdf);
@@ -516,6 +523,7 @@ TEST_CASE ("recreate_mct_coupling")
     horiz_winds_f.sync_to_host();
     pseudo_density_f.sync_to_host();
     precip_liq_surf_f.sync_to_host();
+    precip_ice_surf_f.sync_to_host();
     sfc_flux_lw_dn_f.sync_to_host();
     sfc_flux_dir_nir_f.sync_to_host();
     sfc_flux_dir_vis_f.sync_to_host();
@@ -549,12 +557,13 @@ TEST_CASE ("recreate_mct_coupling")
       REQUIRE (export_raw_data[6 + icol*num_cpl_exports]  == qv_h             (icol,    nlevs-1)); // 7th export
       REQUIRE (export_raw_data[7 + icol*num_cpl_exports]  == p_mid_h          (icol,    nlevs-1)); // 8th export
       REQUIRE (export_raw_data[15 + icol*num_cpl_exports] == C::RHO_H2O*precip_liq_surf_h(icol));  // 16th export
-      REQUIRE (export_raw_data[16 + icol*num_cpl_exports] == sfc_flux_lw_dn_h(icol));              // 17th export
-      REQUIRE (export_raw_data[17 + icol*num_cpl_exports] == sfc_flux_dir_nir_h(icol));            // 18th export
-      REQUIRE (export_raw_data[18 + icol*num_cpl_exports] == sfc_flux_dir_vis_h(icol));            // 19th export
-      REQUIRE (export_raw_data[19 + icol*num_cpl_exports] == sfc_flux_dif_nir_h(icol));            // 20th export
-      REQUIRE (export_raw_data[20 + icol*num_cpl_exports] == sfc_flux_dif_vis_h(icol));            // 21st export
-      REQUIRE (export_raw_data[21 + icol*num_cpl_exports] == sfc_flux_sw_net_h(icol));             // 22nd export
+      REQUIRE (export_raw_data[16 + icol*num_cpl_exports] == C::RHO_H2O*precip_ice_surf_h(icol));  // 17th export
+      REQUIRE (export_raw_data[17 + icol*num_cpl_exports] == sfc_flux_lw_dn_h(icol));              // 18th export
+      REQUIRE (export_raw_data[18 + icol*num_cpl_exports] == sfc_flux_dir_nir_h(icol));            // 19th export
+      REQUIRE (export_raw_data[19 + icol*num_cpl_exports] == sfc_flux_dir_vis_h(icol));            // 20th export
+      REQUIRE (export_raw_data[20 + icol*num_cpl_exports] == sfc_flux_dif_nir_h(icol));            // 21st export
+      REQUIRE (export_raw_data[21 + icol*num_cpl_exports] == sfc_flux_dif_vis_h(icol));            // 22nd export
+      REQUIRE (export_raw_data[22 + icol*num_cpl_exports] == sfc_flux_sw_net_h(icol));             // 23rd export
 
       // These exports should be set to 0
       REQUIRE (export_raw_data[1  + icol*num_cpl_exports] == 0); // 2nd export
@@ -564,8 +573,7 @@ TEST_CASE ("recreate_mct_coupling")
       REQUIRE (export_raw_data[12 + icol*num_cpl_exports] == 0); // 13th export
       REQUIRE (export_raw_data[13 + icol*num_cpl_exports] == 0); // 14th export
       REQUIRE (export_raw_data[14 + icol*num_cpl_exports] == 0); // 15th export
-      REQUIRE (export_raw_data[22 + icol*num_cpl_exports] == 0); // 23rd export
-      REQUIRE (export_raw_data[23 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[23 + icol*num_cpl_exports] == 0); // 24th export
       REQUIRE (export_raw_data[24 + icol*num_cpl_exports] == 0);
       REQUIRE (export_raw_data[25 + icol*num_cpl_exports] == 0);
       REQUIRE (export_raw_data[26 + icol*num_cpl_exports] == 0);
@@ -576,7 +584,8 @@ TEST_CASE ("recreate_mct_coupling")
       REQUIRE (export_raw_data[31 + icol*num_cpl_exports] == 0);
       REQUIRE (export_raw_data[32 + icol*num_cpl_exports] == 0);
       REQUIRE (export_raw_data[33 + icol*num_cpl_exports] == 0);
-      REQUIRE (export_raw_data[34 + icol*num_cpl_exports] == 0); // 35th export
+      REQUIRE (export_raw_data[34 + icol*num_cpl_exports] == 0);
+      REQUIRE (export_raw_data[35 + icol*num_cpl_exports] == 0); // 35th export
     }
   }
 

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -7,7 +7,7 @@ module scream_cpl_indices
 
   ! Focus only on the ones that scream imports/exports (subsets of x2a and a2x)
   integer, parameter, public :: num_scream_imports       = 9
-  integer, parameter, public :: num_scream_exports       = 15
+  integer, parameter, public :: num_scream_exports       = 16
   integer, public :: num_cpl_imports, num_cpl_exports
 
   ! cpl indices for import/export fields
@@ -94,6 +94,7 @@ module scream_cpl_indices
     scr_names_a2x(mct_avect_indexra(a2x,'Sa_shum'))    = 'qv'
     scr_names_a2x(mct_avect_indexra(a2x,'Sa_dens'))    = 'Sa_dens'
     scr_names_a2x(mct_avect_indexra(a2x,'Faxa_rainl')) = 'Faxa_rainl'
+    scr_names_a2x(mct_avect_indexra(a2x,'Faxa_snowl')) = 'Faxa_snowl'
     scr_names_a2x(mct_avect_indexra(a2x,'Faxa_swndr')) = 'sfc_flux_dir_nir'
     scr_names_a2x(mct_avect_indexra(a2x,'Faxa_swvdr')) = 'sfc_flux_dir_vis'
     scr_names_a2x(mct_avect_indexra(a2x,'Faxa_swndf')) = 'sfc_flux_dif_nir'
@@ -107,6 +108,7 @@ module scream_cpl_indices
     ! SCREAM needs to run before this field can be exported as they
     ! rely on fields computed by SCREAM
     can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_rainl')) = .false.
+    can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_snowl')) = .false.
     can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_swndr')) = .false.
     can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_swvdr')) = .false.
     can_be_exported_during_init(mct_avect_indexra(a2x,'Faxa_swndf')) = .false.

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -86,6 +86,7 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
 
   // Diagnostic Outputs: (all fields are just outputs w.r.t. P3)
   add_field<Computed>("precip_liq_surf",    scalar2d_layout,     m/s,    grid_name);
+  add_field<Computed>("precip_ice_surf",    scalar2d_layout,     m/s,    grid_name);
   add_field<Computed>("eff_radius_qc",      scalar3d_layout_mid, micron, grid_name, ps);
   add_field<Computed>("eff_radius_qi",      scalar3d_layout_mid, micron, grid_name, ps);
 
@@ -125,10 +126,6 @@ void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
   EKAT_REQUIRE_MSG(buffer_manager.allocated_bytes() >= requested_buffer_size_in_bytes(), "Error! Buffers size not sufficient.\n");
 
   Real* mem = reinterpret_cast<Real*>(buffer_manager.get_memory());
-
-  // 1d scalar views
-  m_buffer.precip_ice_surf = decltype(m_buffer.precip_ice_surf)(mem, m_num_cols);
-  mem += m_buffer.precip_ice_surf.size();
 
   // 2d scalar views
   m_buffer.col_location = decltype(m_buffer.col_location)(mem, m_num_cols, 3);
@@ -245,7 +242,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   diag_outputs.diag_eff_radius_qi = get_field_out("eff_radius_qi").get_view<Pack**>();
 
   diag_outputs.precip_liq_surf  = get_field_out("precip_liq_surf").get_view<Real*>();
-  diag_outputs.precip_ice_surf  = m_buffer.precip_ice_surf;
+  diag_outputs.precip_ice_surf  = get_field_out("precip_ice_surf").get_view<Real*>();
   diag_outputs.qv2qi_depos_tend = m_buffer.qv2qi_depos_tend;
   diag_outputs.rho_qi           = m_buffer.rho_qi;
   diag_outputs.precip_liq_flux  = m_buffer.precip_liq_flux;

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -307,12 +307,11 @@ public:
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {
     // 1d view scalar, size (ncol)
-    static constexpr int num_1d_scalar = 1;
+    static constexpr int num_1d_scalar = 0; //no 2d vars now, but keeping 1d struct for future expansion
     // 2d view packed, size (ncol, nlev_packs)
     static constexpr int num_2d_vector = 8;
     static constexpr int num_2dp1_vector = 2;
 
-    uview_1d precip_ice_surf;
     uview_2d inv_exner;
     uview_2d th_atm;
     uview_2d cld_frac_l;


### PR DESCRIPTION
A mistake in (my) understanding led us to not pass frozen hydrometeors to surface components. This PR adds precip_ice_surf to the field manager (and adds precip_ice_surf and precip_liq_surf) as default history outputs!), then passes precip_ice_surf to the a2x_Faxa_snowl variable in CPL. 

This will be non-bfb for C++ runs using the whole model but should be BFB for all unit tests. Note in particular that sc_tests.cpp (the unit tests for the coupler) is in the process of being reworked and as it stands wouldn't benefit from including snowl anyways... so I didn't include snowl in any tests. It might also fail for tests using default history output since I've added a few more history variables.