### PR TITLE
Update jenkins script to better handle out-of-date PRs

### DIFF
--- a/components/scream/scripts/git-merge-ref
+++ b/components/scream/scripts/git-merge-ref
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+"""
+A command-line tool foro calling merge_git_ref
+"""
+
+from utils import check_minimum_python_version
+check_minimum_python_version(3, 4)
+
+import argparse, sys, pathlib
+
+from git_utils import merge_git_ref
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n{0} <ref> [--verbose]
+OR
+{0} --help
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Merge origin/master into current HEAD \033[0m
+    > {0} origin/master
+""".format(pathlib.Path(args[0]).name),
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("git_ref", help="The git ref to merge")
+
+    parser.add_argument("-r", "--repo", help="Path to repo. Default is whatever repo contains pwd")
+
+    parser.add_argument("-v", "--verbose", action="store_true", help="Turn on verbose output")
+
+    parser.add_argument("-d", "--dry-run", action="store_true", help="Do a dry run")
+
+    return parser.parse_args(args[1:])
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    merge_git_ref(**vars(parse_command_line(sys.argv, description)))
+
+###############################################################################
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/components/scream/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/scream/scripts/jenkins/jenkins_common_impl.sh
@@ -125,6 +125,10 @@ if [ $skip_testing -eq 0 ]; then
       # are caused by this PR and not simply because the PR is too far behind master
       if [ -n "$PULLREQUESTNUM" ]; then
         ./scripts/git-merge-ref origin/master
+        if [[ $? != 0 ]]; then
+            echo "MERGE FAILED! Please resolve conflicts"
+            exit 1
+        fi
       fi
 
       if [[ $test_v0 == 1 ]]; then


### PR DESCRIPTION
If CIME tests are requested by the AT, do an upstream merge
before the CIME tests are run so that we know any DIFF is
caused by this PR and not just that the PR is old.

Use a new simple CLI hook for git_merge_ref so we can reuse
this nice functionality without having to duplicate it in bash.