### PR TITLE
Adapt SCREAM to the changes regarding test-launcher in EKAT

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -22,44 +22,12 @@ list(APPEND CMAKE_MODULE_PATH
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/tpls
      ${EKAT_CMAKE_PATH}
-     ${EKAT_CMAKE_PATH}/mpi
      ${EKAT_CMAKE_PATH}/pkg_build
 )
 if (SCREAM_CIME_BUILD)
   list(APPEND CMAKE_MODULE_PATH
        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cime)
 endif ()
-
-include(EkatMpiUtils)
-
-# We should avoid cxx bindings in mpi; they are already deprecated,
-# and can cause headaches at link time, cause they require -lmpi_cxx
-# (for openpmi; -lmpicxx for mpich) flag.
-DisableMpiCxxBindings()
-
-if (Kokkos_ENABLE_CUDA)
-  if (Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE)
-    if (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK)
-      string (CONCAT msg
-          "Kokkos_ENALBE_CUDA_RELOCATABLE_DEVICE_CODE=ON, and Kokkos_ENALBE_DEBUG_BOUNDS_CHECK=ON.\n"
-          "   -> Disabling bounds checks, to prevent internal compiler errors.")
-      message(WARNING "${msg}")
-      set (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK OFF CACHE BOOL "" FORCE)
-    else()
-      string (CONCAT msg
-          "Kokkos_ENALBE_CUDA_RELOCATABLE_DEVICE_CODE=ON.\n"
-          "   -> Disabling bounds checks, to prevent internal compiler errors.")
-      message(STATUS "${msg}")
-      set (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK OFF CACHE BOOL "" FORCE)
-    endif()
-  endif()
-  include(EkatBuildKokkos)
-  # Note: we need Kokkos_SOURCE_DIR to be defined *before* calling EkatSetNvccWrapper.
-  EkatSetKokkosSourceDir()
-
-  include (EkatSetNvccWrapper)
-  EkatSetNvccWrapper()
-endif()
 
 # Homme's composef90 library (built for f90 support) requires Kokkos::Serial
 # to be defined, which in turn requires the CMake var Kokkos_ENABLE_SERIAL
@@ -83,6 +51,24 @@ if (NOT SCREAM_CIME_BUILD)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   set(LAST_GIT_COMMIT_SHA ${LAST_GIT_COMMIT_SHA} CACHE STRING "The sha of the last git commit.")
   message(STATUS "The sha of the last commit is ${LAST_GIT_COMMIT_SHA}")
+endif()
+
+if (Kokkos_ENABLE_CUDA)
+  if (Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE)
+    if (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK)
+      string (CONCAT msg
+          "Kokkos_ENALBE_CUDA_RELOCATABLE_DEVICE_CODE=ON, and Kokkos_ENALBE_DEBUG_BOUNDS_CHECK=ON.\n"
+          "   -> Disabling bounds checks, to prevent internal compiler errors.")
+      message(WARNING "${msg}")
+      set (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK OFF CACHE BOOL "" FORCE)
+    else()
+      string (CONCAT msg
+          "Kokkos_ENALBE_CUDA_RELOCATABLE_DEVICE_CODE=ON.\n"
+          "   -> Disabling bounds checks, to prevent internal compiler errors.")
+      message(STATUS "${msg}")
+      set (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK OFF CACHE BOOL "" FORCE)
+    endif()
+  endif()
 endif()
 
 set(SCREAM_DOUBLE_PRECISION TRUE CACHE BOOL "Set to double precision (default True)")

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -117,9 +117,6 @@ else ()
   set (SCREAM_DEBUG FALSE)
 endif()
 
-enable_testing()
-include(CTest)
-
 set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp")
 
 # Determine if this is a Cuda build.
@@ -336,10 +333,6 @@ print_var(SCREAM_TPL_LIBRARIES)
 # whether to include scream_config.h.
 add_definitions(-DSCREAM_CONFIG_IS_CMAKE)
 
-if (EKAT_ENABLE_CUDA_MEMCHECK)
-  add_definitions(-DEKAT_ENABLE_CUDA_MEMCHECK)
-endif()
-
 # Hooks for testing test-all-scream within test-scripts
 if ($ENV{SCREAM_FORCE_BUILD_FAIL})
   add_definitions(-DSCREAM_FORCE_BUILD_FAIL)
@@ -374,6 +367,44 @@ print_var(SCREAM_DYNAMICS_DYCORE)
 set (SCREAM_F90_MODULES ${CMAKE_CURRENT_BINARY_DIR}/modules)
 
 file(MAKE_DIRECTORY ${SCREAM_TEST_DATA_DIR})
+
+#######################################
+#         Testing configs             #
+#######################################
+
+# Only add testing options if we're not in a "lib-only" build
+# or in a 'fake' build (used to test the testing scripts)
+if (NOT SCREAM_LIB_ONLY OR DEFINED ENV{SCREAM_FAKE_ONLY})
+  enable_testing()
+  include(CTest)
+  option (SCREAM_TEST_LAUNCHER_BUFFER "Whether test-launcher should buffer all out and print all at once. Useful for avoiding interleaving output when multiple tests are running concurrently" OFF)
+  option (SCREAM_ENABLE_VALGRIND "Whether tests should be run through valgrind" OFF)
+  option (SCREAM_ENABLE_CUDA_MEMCHECK "Whether tests should be run through cuda-memcheck" OFF)
+  if (SCREAM_ENABLE_CUDA_MEMCHECK AND NOT Kokkos_ENABLE_CUDA)
+    message(FATAL_ERROR "Makes no sense to turn on cuda-memcheck without CUDA")
+  endif()
+
+  if (SCREAM_ENABLE_CUDA_MEMCHECK AND SCREAM_ENABLE_VALGRIND)
+    message(FATAL_ERROR "Cannot simultanously enable valgrind and cuda-memcheck")
+  endif()
+
+  # Generate suppressions file for testing
+  include (EkatValgrindSupport)
+  EkatGenerateValgrindSuppressions (
+    MPIEXEC ${CMAKE_CXX_COMPILER}
+    SUPP_FILE_DIR ${SCREAM_BIN_DIR}
+  )
+
+  # Configure/install test-launcher to build/install folder
+  if (CUDA_BUILD)
+    set (TEST_LAUNCHER_ON_GPU True)
+  else()
+    set (TEST_LAUNCHER_ON_GPU False)
+  endif()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bin/test-launcher
+                 ${CMAKE_BINARY_DIR}/bin/test-launcher)
+endif()
+#######################################
 
 add_custom_target(baseline)
 add_custom_target(baseline_cxx)

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -186,7 +186,7 @@ set(SCREAM_LIB_ONLY ${DEFAULT_LIB_ONLY} CACHE BOOL "Only build libraries, no exe
 set(SCREAM_AUTOTESTER ${DEFAULT_AUTOTESTER} CACHE BOOL "This is an autotester run; may disable some tests")
 set(NetCDF_Fortran_PATHS ${DEFAULT_NetCDF_Fortran_PATHS} CACHE FILEPATH "Path to netcdf fortran installation")
 set(NetCDF_C_PATHS ${DEFAULT_NetCDF_C_PATHS} CACHE FILEPATH "Path to netcdf C installation")
-set(SCREAM_MACHINE $DEFAULT_SCREAM_MACHINE CACHE STRING "The CIME/SCREAM name for the current machine")
+set(SCREAM_MACHINE ${DEFAULT_SCREAM_MACHINE} CACHE STRING "The CIME/SCREAM name for the current machine")
 
 # Handle input root
 if (SCREAM_MACHINE)

--- a/components/scream/bin/test-launcher
+++ b/components/scream/bin/test-launcher
@@ -119,7 +119,6 @@ def run_test(buffer_output,print_omp_affinity,exec_args):
 
     # If run with --resource-spec-file, we will have some special env var set
     if "CTEST_RESOURCE_GROUP_COUNT" in env:
-        print ("HAS RESOURCE SPECS")
         # Total number of resources for this test (for all ranks/threads)
         res_count = int(env["CTEST_RESOURCE_GROUP_COUNT"])
         my_res_id = myrank % res_count
@@ -156,7 +155,7 @@ def run_test(buffer_output,print_omp_affinity,exec_args):
 
         # This file is to be run through cmake's configure_file, which will expand the
         # variable TEST_LAUNCHER_ON_GPU to either True or False
-        if ${CUDA_BUILD}:
+        if ${TEST_LAUNCHER_ON_GPU}:
             expect (len(my_ids)==1, "Error! For GPU runs, each rank should use only one device.")
             exec_args.append(" --ekat-kokkos-device {}".format(ids[0]))
         else:

--- a/components/scream/bin/test-launcher
+++ b/components/scream/bin/test-launcher
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+import argparse, pathlib, os, sys, subprocess
+
+###############################################################################
+def expect(condition, error_msg, exc_type=SystemExit, error_prefix="ERROR:"):
+###############################################################################
+    """
+    Similar to assert except doesn't generate an ugly stacktrace. Useful for
+    checking user error, not programming error.
+
+    >>> expect(True, "error1")
+    >>> expect(False, "error2")
+    Traceback (most recent call last):
+        ...
+    SystemExit: ERROR: error2
+    """
+    if not condition:
+        msg = error_prefix + " " + error_msg
+        raise exc_type(msg)
+
+###############################################################################
+def run_cmd(cmd, env):
+###############################################################################
+    """
+    We've noticed some LLNL clusters cannot run MPI programs via subprocess for
+    some unknown and extremely subtle reason. Therefore, we use os.system unless
+    the user requests buffering, in which case we must use subprocess.
+    """
+    prev_env = dict(os.environ)
+
+    print("RUN: {}\nFROM: {}".format(cmd, os.getcwd()))
+
+    os.environ = env
+    stat = os.system(cmd)
+    os.environ = prev_env
+
+    return stat
+
+###############################################################################
+def run_cmd_buff(cmd, env):
+###############################################################################
+    arg_stderr = subprocess.STDOUT
+
+    print("RUN: {}\nFROM: {}".format(cmd, os.getcwd()))
+
+    proc = subprocess.Popen(cmd,
+                            shell=True,
+                            stdout=subprocess.PIPE,
+                            stderr=arg_stderr,
+                            env=env)
+
+    output, _ = proc.communicate()
+    if output is not None:
+        try:
+            output = output.decode('utf-8', errors='ignore')
+            output = output.strip()
+        except AttributeError:
+            print("Something funky for output")
+
+    stat = proc.wait()
+
+    return stat, output
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n{0} -- <executable> [<exe-args>]
+OR
+{0} --help
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Lightweight python wrapper for a test that handles thread binding.\033[0m
+    > {0} -- ./my_exec
+
+""".format(pathlib.Path(args[0]).name),
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("-b","--buffer-output", action="store_true",
+                        help="Buffer all out and print all at once. Useful for avoiding interleaving output when multiple tests are running concurrently")
+    parser.add_argument("-p","--print-omp-affinity", help="Print threads affinity at runtime",action="store_true")
+
+    return parser.parse_known_args(args[1:])
+
+###############################################################################
+def run_test(buffer_output,print_omp_affinity,exec_args):
+###############################################################################
+
+    expect(len(exec_args) >= 2 and exec_args[0] == "--",
+           "Expected exec_args='-- <exe> [<exe-args>], got: {}".format(exec_args))
+
+    env = os.environ
+
+    omp_env = []
+    if print_omp_affinity:
+        omp_env.append("OMP_DISPLAY_ENV=verbose")
+        omp_env.append("OMP_DISPLAY_AFFINITY=true")
+
+    # Be sure to respect user env settings if they are there
+    if "OMP_PROC_BIND" not in env:
+        omp_env.append("OMP_PROC_BIND=spread")
+
+    if "OMP_PLACES" not in env:
+        omp_env.append("OMP_PLACES=threads")
+
+    # Check if we're run with MPI
+    if "${EKAT_MPIRUN_COMM_WORLD_SIZE}" in env and "${EKAT_MPIRUN_COMM_WORLD_RANK}" in env:
+        nranks = int(env["${EKAT_MPIRUN_COMM_WORLD_SIZE}"])
+        myrank = int(env["${EKAT_MPIRUN_COMM_WORLD_RANK}"])
+    else:
+        nranks = 1
+        myrank = 0
+
+    # Start with all env vars settings
+    cmd = " ".join(omp_env)
+
+    # If run with --resource-spec-file, we will have some special env var set
+    if "CTEST_RESOURCE_GROUP_COUNT" in env:
+        print ("HAS RESOURCE SPECS")
+        # Total number of resources for this test (for all ranks/threads)
+        res_count = int(env["CTEST_RESOURCE_GROUP_COUNT"])
+        my_res_id = myrank % res_count
+
+        # Get the list of devices ids in my resource group
+        key = "CTEST_RESOURCE_GROUP_" + str(my_res_id)
+        expect(key in env, "Error! CTEST_RESOURCE_GROUP_COUNT found in the env, but can't find {}".format(key))
+        my_res_name = env[key]
+        expect (my_res_name=="devices", "Error! My ctest resource group should be 'devices'.")
+        key += "_DEVICES"
+        expect(key in env, "Error! CTEST_RESOURCE_GROUP_{} found in the env, but can't find {}".format(my_res_id,key))
+        my_res_str = env[key]
+
+        # Split the CTEST_RESOURCE_GROUP_[N]_DEVICE string into tokens, and get the slots ids
+        my_res = my_res_str.split(';')
+        ids = []
+        for res in my_res:
+            id_slots_tokens = res.split(',')
+            id_tokens = id_slots_tokens[0].split(':')
+            ids.append(int(id_tokens[1]))
+
+        # CTest should already present these in lexicographic order, which should match
+        # numeric order thanks to our recent change to prepend leading 0's to fill empty
+        # digits. This sort shouldn't be necessary but it can't hurt.
+        ids.sort()
+
+        # Convert back to str so ids can be used in shell commands
+        ids = [str(item) for item in ids]
+
+        # Now get the chunk of ids that belongs to this rank
+        expect (len(ids) % nranks == 0, "Error! Number of ranks does not divide the number of resources.")
+        ids_per_rank = int(len(ids) / nranks)
+        my_ids = ids[myrank*ids_per_rank : (myrank+1)*ids_per_rank]
+
+        # This file is to be run through cmake's configure_file, which will expand the
+        # variable TEST_LAUNCHER_ON_GPU to either True or False
+        if ${CUDA_BUILD}:
+            expect (len(my_ids)==1, "Error! For GPU runs, each rank should use only one device.")
+            exec_args.append(" --ekat-kokkos-device {}".format(ids[0]))
+        else:
+            # Start placing on the correct cpu set
+            cmd += " taskset -c " + ",".join(my_ids)
+
+    else:
+        print ("NO RESOURCE SPECS")
+
+    cmd += " {}".format(" ".join(exec_args[1:]))
+
+    if buffer_output:
+        stat, out = run_cmd_buff(cmd, env)
+        sys.stdout.flush()
+        sys.stdout.write(out)
+        sys.stdout.flush()
+    else:
+        stat = run_cmd(cmd, env)
+
+    return stat==0
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    options, rest = parse_command_line(sys.argv, description)
+    success = run_test(**vars(options), exec_args=rest)
+
+    sys.exit(0 if success else 1)
+
+###############################################################################
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -93,10 +93,10 @@ class TestAllScream(object):
             "opt" : [("CMAKE_BUILD_TYPE", "Release")],
             "valg" : [("CMAKE_BUILD_TYPE", "Debug"),
                       ("SCREAM_TEST_PROFILE", "SHORT"),
-                      ("EKAT_ENABLE_VALGRIND", "True")],
+                      ("SCREAM_ENABLE_VALGRIND", "True")],
             "cmc"  : [("CMAKE_BUILD_TYPE", "Debug"),
                       ("SCREAM_TEST_PROFILE", "SHORT"),
-                      ("EKAT_ENABLE_CUDA_MEMCHECK", "True")],
+                      ("SCREAM_ENABLE_CUDA_MEMCHECK", "True")],
             "cov" : [("CMAKE_BUILD_TYPE", "Debug"),
                       ("EKAT_ENABLE_COVERAGE", "True")],
         }
@@ -460,7 +460,7 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         # The output coming from all tests at the same time will be a mixed-up mess
         # unless we tell test-launcher to buffer all output
         if self._extra_verbose:
-            result += " -DEKAT_TEST_LAUNCHER_BUFFER=True "
+            result += " -DSCREAM_TEST_LAUNCHER_BUFFER=True "
 
         # User-requested config options
         custom_opts_keys = []

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ set(P3_TESTS_SRCS
 # it via the FIXTURES_REQUIRED property.
 # (See https://cmake.org/cmake/help/latest/prop_test/FIXTURES_REQUIRED.html)
 CreateUnitTest(p3_test_setup p3_test_setup.cpp "${NEED_LIBS}"
-               EXCLUDE_MAIN_CPP PROPERTIES FIXTURES_SETUP p3_tables)
+               EXCLUDE_CATCH_MAIN PROPERTIES FIXTURES_SETUP p3_tables)
 
 if (SCREAM_DEBUG AND NOT EKAT_ENABLE_CUDA_MEMCHECK)
   set (FORCE_RUN_DIFF_FAILS TRUE)
@@ -73,14 +73,14 @@ CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
                EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
                PROPERTIES FIXTURES_REQUIRED p3_tables
-               EXCLUDE_MAIN_CPP
+               EXCLUDE_CATCH_MAIN
                LABELS "p3;physics")
 
 CreateUnitTest(p3_run_and_cmp_f90 "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
                EXE_ARGS "-f -b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
                PROPERTIES FIXTURES_REQUIRED p3_tables
-               EXCLUDE_MAIN_CPP
+               EXCLUDE_CATCH_MAIN
                LABELS "p3;physics")
 
 # Make sure that a diff from baselines triggers a failed test (in debug only)
@@ -89,7 +89,7 @@ CreateUnitTest(p3_run_and_cmp_cxx_fail "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
                EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
                PROPERTIES FIXTURES_REQUIRED p3_tables WILL_FAIL ${FORCE_RUN_DIFF_FAILS}
-               EXCLUDE_MAIN_CPP
+               EXCLUDE_CATCH_MAIN
                LABELS "p3;physics;fail")
 
 # By default, baselines should be created using all fortran (make baseline). If the user wants

--- a/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ if (NOT ${SCREAM_BASELINES_ONLY})
     CreateUnitTest(
         rrtmgp_tests rrtmgp_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"
         EXE_ARGS "-i ${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc -b ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc"
-        EXCLUDE_MAIN_CPP
+        EXCLUDE_CATCH_MAIN
     )
     CreateUnitTest(
         rrtmgp_unit_tests rrtmgp_unit_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -79,12 +79,12 @@ endif()
 CreateUnitTest(shoc_run_and_cmp_cxx "shoc_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
                EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
-               EXCLUDE_MAIN_CPP)
+               EXCLUDE_CATCH_MAIN)
 
 CreateUnitTest(shoc_run_and_cmp_f90 "shoc_run_and_cmp.cpp" "${NEED_LIBS}"
                THREADS ${SCREAM_TEST_MAX_THREADS}
                EXE_ARGS "-f -b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
-               EXCLUDE_MAIN_CPP)
+               EXCLUDE_CATCH_MAIN)
 
 # By default, baselines should be created using all fortran (make baseline). If the user wants
 # to use CXX to generate their baselines, they should use "make baseline_cxx".

--- a/components/scream/src/scream_config.h.in
+++ b/components/scream/src/scream_config.h.in
@@ -49,4 +49,7 @@
 // Whether experimental code should be enabled
 #cmakedefine SCREAM_ENABLE_EXPERIMENTAL
 
+// Whether scream is configured to be tested with cuda-memcheck
+#cmakedefine SCREAM_ENABLE_CUDA_MEMCHECK
+
 #endif

--- a/components/scream/src/share/scream_types.hpp
+++ b/components/scream/src/share/scream_types.hpp
@@ -40,7 +40,7 @@ enum class RunType {
 // We cannot expect BFB results between f90 and cxx if optimizations are on.
 // Same goes for cuda-memcheck because it makes the bfb math layer prohibitively
 // expensive and so must be turned off.
-#if defined (NDEBUG) || defined (EKAT_ENABLE_CUDA_MEMCHECK)
+#if defined (NDEBUG) || defined (SCREAM_ENABLE_CUDA_MEMCHECK)
 static constexpr bool SCREAM_BFB_TESTING = false;
 #else
 static constexpr bool SCREAM_BFB_TESTING = true;


### PR DESCRIPTION
This PR depends on E3SM-Project/EKAT#179, so it will be updated once that PR is merged.

The PR also brings in recent changes regarding MPI, though it could do more: all the compilers for scream could be changed from the MPI wrappers to the native ones (e.g., use `g++` instead of `mpicxx`), which simplifies things when building for CUDA. Perhaps something for another PR.