### PR TITLE
Changes related to the handling of MPI, following EKAT update

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -189,7 +189,7 @@ set(SCREAM_LIB_ONLY ${DEFAULT_LIB_ONLY} CACHE BOOL "Only build libraries, no exe
 set(SCREAM_AUTOTESTER ${DEFAULT_AUTOTESTER} CACHE BOOL "This is an autotester run; may disable some tests")
 set(NetCDF_Fortran_PATHS ${DEFAULT_NetCDF_Fortran_PATHS} CACHE FILEPATH "Path to netcdf fortran installation")
 set(NetCDF_C_PATHS ${DEFAULT_NetCDF_C_PATHS} CACHE FILEPATH "Path to netcdf C installation")
-set(SCREAM_MACHINE $DEFAULT_SCREAM_MACHINE CACHE STRING "The CIME/SCREAM name for the current machine")
+set(SCREAM_MACHINE ${DEFAULT_SCREAM_MACHINE} CACHE STRING "The CIME/SCREAM name for the current machine")
 
 # Handle input root
 if (SCREAM_MACHINE)

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -157,7 +157,7 @@ if (NF_CONFIG_SEARCH)
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
   if (NF_STATUS EQUAL 0)
-    set(DEFAULT_NetCDF_Fortran_PATHS ${NF_CONFIG_OUTPUT})
+    set(DEFAULT_NetCDF_Fortran_PATH ${NF_CONFIG_OUTPUT})
   endif()
 endif()
 
@@ -169,7 +169,7 @@ if (NC_CONFIG_SEARCH)
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
   if (NC_STATUS EQUAL 0)
-    set(DEFAULT_NetCDF_C_PATHS ${NC_CONFIG_OUTPUT})
+    set(DEFAULT_NetCDF_C_PATH ${NC_CONFIG_OUTPUT})
   endif()
 endif()
 
@@ -187,8 +187,8 @@ set(SCREAM_MPI_EXTRA_ARGS ${DEFAULT_MPI_EXTRA_ARGS} CACHE STRING "Options for mp
 set(SCREAM_MPI_NP_FLAG ${DEFAULT_MPI_NP_FLAG} CACHE STRING "The mpirun flag for designating the total number of ranks")
 set(SCREAM_LIB_ONLY ${DEFAULT_LIB_ONLY} CACHE BOOL "Only build libraries, no exes")
 set(SCREAM_AUTOTESTER ${DEFAULT_AUTOTESTER} CACHE BOOL "This is an autotester run; may disable some tests")
-set(NetCDF_Fortran_PATHS ${DEFAULT_NetCDF_Fortran_PATHS} CACHE FILEPATH "Path to netcdf fortran installation")
-set(NetCDF_C_PATHS ${DEFAULT_NetCDF_C_PATHS} CACHE FILEPATH "Path to netcdf C installation")
+set(NetCDF_Fortran_PATH ${DEFAULT_NetCDF_Fortran_PATH} CACHE FILEPATH "Path to netcdf fortran installation")
+set(NetCDF_C_PATH ${DEFAULT_NetCDF_C_PATH} CACHE FILEPATH "Path to netcdf C installation")
 set(SCREAM_MACHINE ${DEFAULT_SCREAM_MACHINE} CACHE STRING "The CIME/SCREAM name for the current machine")
 
 # Handle input root

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -292,10 +292,6 @@ include(EkatBuildEkat)
 set (EKAT_ENABLE_TESTS OFF CACHE BOOL "Whether to build EKAT's tests. Off by default.")
 BuildEkat(PREFIX "SCREAM")
 
-# Set compiler-specific flags
-include(EkatSetCompilerFlags)
-SetCompilerFlags()
-
 if (SCREAM_DOUBLE_PRECISION)
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
     set(SCREAM_Fortran_FLAGS -real-size 64)

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -22,44 +22,12 @@ list(APPEND CMAKE_MODULE_PATH
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/tpls
      ${EKAT_CMAKE_PATH}
-     ${EKAT_CMAKE_PATH}/mpi
      ${EKAT_CMAKE_PATH}/pkg_build
 )
 if (SCREAM_CIME_BUILD)
   list(APPEND CMAKE_MODULE_PATH
        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cime)
 endif ()
-
-include(EkatMpiUtils)
-
-# We should avoid cxx bindings in mpi; they are already deprecated,
-# and can cause headaches at link time, cause they require -lmpi_cxx
-# (for openpmi; -lmpicxx for mpich) flag.
-DisableMpiCxxBindings()
-
-if (Kokkos_ENABLE_CUDA)
-  if (Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE)
-    if (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK)
-      string (CONCAT msg
-          "Kokkos_ENALBE_CUDA_RELOCATABLE_DEVICE_CODE=ON, and Kokkos_ENALBE_DEBUG_BOUNDS_CHECK=ON.\n"
-          "   -> Disabling bounds checks, to prevent internal compiler errors.")
-      message(WARNING "${msg}")
-      set (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK OFF CACHE BOOL "" FORCE)
-    else()
-      string (CONCAT msg
-          "Kokkos_ENALBE_CUDA_RELOCATABLE_DEVICE_CODE=ON.\n"
-          "   -> Disabling bounds checks, to prevent internal compiler errors.")
-      message(STATUS "${msg}")
-      set (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK OFF CACHE BOOL "" FORCE)
-    endif()
-  endif()
-  include(EkatBuildKokkos)
-  # Note: we need Kokkos_SOURCE_DIR to be defined *before* calling EkatSetNvccWrapper.
-  EkatSetKokkosSourceDir()
-
-  include (EkatSetNvccWrapper)
-  EkatSetNvccWrapper()
-endif()
 
 # Homme's composef90 library (built for f90 support) requires Kokkos::Serial
 # to be defined, which in turn requires the CMake var Kokkos_ENABLE_SERIAL
@@ -132,6 +100,24 @@ endif ()
 # Add CUDA as a language for CUDA builds
 if (CUDA_BUILD)
   enable_language(CUDA)
+endif()
+
+if (Kokkos_ENABLE_CUDA)
+  if (Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE)
+    if (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK)
+      string (CONCAT msg
+          "Kokkos_ENALBE_CUDA_RELOCATABLE_DEVICE_CODE=ON, and Kokkos_ENALBE_DEBUG_BOUNDS_CHECK=ON.\n"
+          "   -> Disabling bounds checks, to prevent internal compiler errors.")
+      message(WARNING "${msg}")
+      set (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK OFF CACHE BOOL "" FORCE)
+    else()
+      string (CONCAT msg
+          "Kokkos_ENALBE_CUDA_RELOCATABLE_DEVICE_CODE=ON.\n"
+          "   -> Disabling bounds checks, to prevent internal compiler errors.")
+      message(STATUS "${msg}")
+      set (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK OFF CACHE BOOL "" FORCE)
+    endif()
+  endif()
 endif()
 
 ### Scream default configuration options

--- a/components/scream/cmake/BuildCprnc.cmake
+++ b/components/scream/cmake/BuildCprnc.cmake
@@ -25,7 +25,7 @@ macro(BuildCprnc)
       set(SCC ${CMAKE_C_COMPILER})
       set(SFC ${CMAKE_Fortran_COMPILER})
       set(FFLAGS \"${CMAKE_Fortran_FLAGS}\")
-      set(NETCDF_PATH ${NetCDF_Fortran_PATHS})
+      set(NETCDF_PATH ${NetCDF_Fortran_PATH})
       "
     )
     set(SRC_ROOT ${SCREAM_BASE_DIR}/../..)

--- a/components/scream/cmake/BuildCprnc.cmake
+++ b/components/scream/cmake/BuildCprnc.cmake
@@ -5,6 +5,8 @@
 #
 # to your CMakeLists.txt.
 
+include (EkatUtils)
+
 macro(BuildCprnc)
 
   # Make sure this is built only once
@@ -28,6 +30,7 @@ macro(BuildCprnc)
     )
     set(SRC_ROOT ${SCREAM_BASE_DIR}/../..)
     add_subdirectory(${SRC_ROOT}/cime/tools/cprnc ${BLDROOT})
+    EkatDisableAllWarning(cprnc)
 
     set(CPRNC_BINARY ${BLDROOT}/cprnc CACHE INTERNAL "")
 

--- a/components/scream/cmake/machine-files/lassen.cmake
+++ b/components/scream/cmake/machine-files/lassen.cmake
@@ -2,7 +2,7 @@
 set (EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/cmake/machine-files)
 include (${EKAT_MACH_FILES_PATH}/kokkos/nvidia-v100.cmake)
 include (${EKAT_MACH_FILES_PATH}/kokkos/cuda.cmake)
-set(NetCDF_Fortran_PATHS /usr/gdata/climdat/libs/netcdf-fortran/install/lassen/fortran CACHE STRING "")
+set(NetCDF_Fortran_PATH /usr/gdata/climdat/libs/netcdf-fortran/install/lassen/fortran CACHE STRING "")
 set(BLAS_LIBRARIES /usr/gdata/climdat/libs/blas/libblas.a CACHE STRING "")
 set(LAPACK_LIBRARIES /usr/gdata/climdat/libs/lapack/liblapack.a CACHE STRING "")
 set(SCREAM_MPIRUN_EXE "jsrun -E LD_PRELOAD=/opt/ibm/spectrum_mpi/lib/pami_471/libpami.so" CACHE STRING "")

--- a/components/scream/cmake/tpls/Scorpio.cmake
+++ b/components/scream/cmake/tpls/Scorpio.cmake
@@ -53,6 +53,9 @@ macro (CreateScorpioTarget CREATE_FLIB)
         target_link_libraries(piof INTERFACE "${netcdf_f_lib};pioc")
       endif ()
     else ()
+      # We don't need (yet) SCORPIO tools
+      option (PIO_ENABLE_TOOLS "Enable SCORPIO tools" OFF)
+
       # Not a CIME build. Add scorpio as a subdir
       add_subdirectory (${E3SM_EXTERNALS_DIR}/scorpio ${CMAKE_BINARY_DIR}/externals/scorpio)
       EkatDisableAllWarning(pioc)

--- a/components/scream/docs/source-tree.md
+++ b/components/scream/docs/source-tree.md
@@ -4,9 +4,6 @@ All SCREAM-specific code can be found in `components/scream` within the
 [SCREAM repo](https://github.com/E3SM-Project/scream). Here's how things are
 organized:
 
-+ `bin`: Miscellaneous tools for helping with the build process. Currently, this
-  directory only contains a template for generating the `scream_mpicxx` compiler
-  script.
 + `cime_config`: Tools and XML files for integrating SCREAM with E3SM via the
   CIME framework.
 + `cmake`: CMake functions and macros used by the configuration/build system.

--- a/components/scream/scripts/query-scream
+++ b/components/scream/scripts/query-scream
@@ -20,8 +20,8 @@ OR
 {0} --help
 
 \033[1mEXAMPLES:\033[0m
-    \033[1;32m# Query machine 'mappy' for parameter 'mpicxx' \033[0m
-    > {0} mappy mpicxx
+    \033[1;32m# Query machine 'mappy' for parameter 'cxx_compiler' \033[0m
+    > {0} mappy cxx_compiler
 """.format(pathlib.Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -448,10 +448,10 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         # even if no netcdf is available
         stat, f_path, _ = run_cmd("nf-config --prefix")
         if stat == 0:
-            result += " -DNetCDF_Fortran_PATHS={}".format(f_path)
+            result += " -DNetCDF_Fortran_PATH={}".format(f_path)
         stat, c_path, _ = run_cmd("nc-config --prefix")
         if stat == 0:
-            result += " -DNetCDF_C_PATHS={}".format(c_path)
+            result += " -DNetCDF_C_PATH={}".format(c_path)
 
         # Test-specific cmake options
         for key, value in extra_configs:

--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -58,10 +58,10 @@ set(INTERFACE_SRC
   rrtmgp_test_utils.cpp
 )
 add_library(scream_rrtmgp ${INTERFACE_SRC})
-find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATHS}/lib)
+find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATH}/lib)
 target_link_libraries(scream_rrtmgp PUBLIC ${NETCDF_C} rrtmgp yakl scream_share physics_share share_util)
 target_include_directories(scream_rrtmgp SYSTEM PUBLIC
-    ${NetCDF_C_PATHS}/include ${SCREAM_BASE_DIR}/../../externals ${EAM_RRTMGP_DIR}/external)
+    ${NetCDF_C_PATH}/include ${SCREAM_BASE_DIR}/../../externals ${EAM_RRTMGP_DIR}/external)
 
 # Build tests
 if (NOT SCREAM_LIB_ONLY)

--- a/components/scream/src/physics/rrtmgp/share/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/share/CMakeLists.txt
@@ -48,4 +48,14 @@ foreach (SRC_FILE ${GENF90_SOURCE})
 endforeach ()
 set(share_sources ${FORTRAN_SOURCE})
 
+find_package (MPI REQUIRED COMPONENTS Fortran)
 add_library(share_util ${share_sources})
+if (NOT MPI_Fortran_FOUND)
+  message (FATAL_ERROR "share_util library *requires* MPI (Fortran component)")
+endif()
+target_link_libraries (share_util PUBLIC MPI::MPI_Fortran)
+
+# These CPP macros are needed in shr_infnan_mod
+target_compile_definitions(share_util PUBLIC
+  $<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CXX_COMPILER_ID:GNU>>:CPRGNU>
+  $<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CXX_COMPILER_ID:Intel>>:CPRINTEL>)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
@@ -5,7 +5,7 @@ include (BuildCprnc)
 BuildCprnc()
 
 # Needed for RRTMGP
-find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATHS}/lib)
+find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATH}/lib)
 # Get or create the dynamics lib
 #                 HOMME_TARGET   NP PLEV QSIZE_D
 CreateDynamicsLib("theta-l_kokkos"  4   72   35)

--- a/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT ${SCREAM_BASELINES_ONLY})
 
     SET (TEST_LABELS "rrtmgp;physics")
     # Required libraries
-    find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATHS}/lib)
+    find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATH}/lib)
     set (NEED_LIBS scream_rrtmgp rrtmgp ${NETCDF_C} scream_control scream_share physics_share yakl)
 
     CreateUnitTest(


### PR DESCRIPTION
EKAT has recently changed how it deals with MPI: rather than requiring mpi compiler wrappers, it links to MPI (using libs/flags found with `find_package(MPI REQUIRED)`).

EKAT is now capable of building with "raw" compilers rathern than the MPI wrappers (e.g. gcc instead of mpicc). However, building with raw compilers poses a lot of issues with upstream deps, which are not explicitly compiling/linking against MPI (relying on mpi wrappers adding those flags).

Nevertheless, turns out that (probably unrelated to this, and more related to Kokkos changes), we can do away with the `ekat_mpicxx` wrapper, which simplifies a bit our life on CUDA machines, and some cmake logic can be pruned.