### PR TITLE
Update EKAT submodule, and fix SCREAM build configuration issues

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -22,20 +22,12 @@ list(APPEND CMAKE_MODULE_PATH
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/tpls
      ${EKAT_CMAKE_PATH}
-     ${EKAT_CMAKE_PATH}/mpi
      ${EKAT_CMAKE_PATH}/pkg_build
 )
 if (SCREAM_CIME_BUILD)
   list(APPEND CMAKE_MODULE_PATH
        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cime)
 endif ()
-
-include(EkatMpiUtils)
-
-# We should avoid cxx bindings in mpi; they are already deprecated,
-# and can cause headaches at link time, cause they require -lmpi_cxx
-# (for openpmi; -lmpicxx for mpich) flag.
-DisableMpiCxxBindings()
 
 if (Kokkos_ENABLE_CUDA)
   if (Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE)
@@ -53,12 +45,6 @@ if (Kokkos_ENABLE_CUDA)
       set (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK OFF CACHE BOOL "" FORCE)
     endif()
   endif()
-  include(EkatBuildKokkos)
-  # Note: we need Kokkos_SOURCE_DIR to be defined *before* calling EkatSetNvccWrapper.
-  EkatSetKokkosSourceDir()
-
-  include (EkatSetNvccWrapper)
-  EkatSetNvccWrapper()
 endif()
 
 # Homme's composef90 library (built for f90 support) requires Kokkos::Serial
@@ -309,6 +295,12 @@ BuildEkat(PREFIX "SCREAM")
 # Set compiler-specific flags
 include(EkatSetCompilerFlags)
 SetCompilerFlags()
+
+include(EkatMpiUtils)
+# We should avoid cxx bindings in mpi; they are already deprecated,
+# and can cause headaches at link time, cause they require -lmpi_cxx
+# (for openpmi; -lmpicxx for mpich) flag.
+DisableMpiCxxBindings()
 
 if (SCREAM_DOUBLE_PRECISION)
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -171,7 +171,7 @@ if (NF_CONFIG_SEARCH)
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
   if (NF_STATUS EQUAL 0)
-    set(DEFAULT_NetCDF_Fortran_PATHS ${NF_CONFIG_OUTPUT})
+    set(DEFAULT_NetCDF_Fortran_PATH ${NF_CONFIG_OUTPUT})
   endif()
 endif()
 
@@ -183,7 +183,7 @@ if (NC_CONFIG_SEARCH)
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
   if (NC_STATUS EQUAL 0)
-    set(DEFAULT_NetCDF_C_PATHS ${NC_CONFIG_OUTPUT})
+    set(DEFAULT_NetCDF_C_PATH ${NC_CONFIG_OUTPUT})
   endif()
 endif()
 
@@ -201,9 +201,9 @@ set(SCREAM_MPI_EXTRA_ARGS ${DEFAULT_MPI_EXTRA_ARGS} CACHE STRING "Options for mp
 set(SCREAM_MPI_NP_FLAG ${DEFAULT_MPI_NP_FLAG} CACHE STRING "The mpirun flag for designating the total number of ranks")
 set(SCREAM_LIB_ONLY ${DEFAULT_LIB_ONLY} CACHE BOOL "Only build libraries, no exes")
 set(SCREAM_AUTOTESTER ${DEFAULT_AUTOTESTER} CACHE BOOL "This is an autotester run; may disable some tests")
-set(NetCDF_Fortran_PATHS ${DEFAULT_NetCDF_Fortran_PATHS} CACHE FILEPATH "Path to netcdf fortran installation")
-set(NetCDF_C_PATHS ${DEFAULT_NetCDF_C_PATHS} CACHE FILEPATH "Path to netcdf C installation")
-set(SCREAM_MACHINE $DEFAULT_SCREAM_MACHINE CACHE STRING "The CIME/SCREAM name for the current machine")
+set(NetCDF_Fortran_PATH ${DEFAULT_NetCDF_Fortran_PATH} CACHE FILEPATH "Path to netcdf fortran installation")
+set(NetCDF_C_PATH ${DEFAULT_NetCDF_C_PATH} CACHE FILEPATH "Path to netcdf C installation")
+set(SCREAM_MACHINE ${DEFAULT_SCREAM_MACHINE} CACHE STRING "The CIME/SCREAM name for the current machine")
 
 # Handle input root
 if (SCREAM_MACHINE)

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -294,7 +294,8 @@ BuildEkat(PREFIX "SCREAM")
 
 # Set compiler-specific flags
 include(EkatSetCompilerFlags)
-SetCompilerFlags()
+ResetFlags()
+SetCommonFlags()
 
 include(EkatMpiUtils)
 # We should avoid cxx bindings in mpi; they are already deprecated,

--- a/components/scream/cmake/BuildCprnc.cmake
+++ b/components/scream/cmake/BuildCprnc.cmake
@@ -23,7 +23,7 @@ macro(BuildCprnc)
       set(SCC ${CMAKE_C_COMPILER})
       set(SFC ${CMAKE_Fortran_COMPILER})
       set(FFLAGS \"${CMAKE_Fortran_FLAGS}\")
-      set(NETCDF_PATH ${NetCDF_Fortran_PATHS})
+      set(NETCDF_PATH ${NetCDF_Fortran_PATH})
       "
     )
     set(SRC_ROOT ${SCREAM_BASE_DIR}/../..)

--- a/components/scream/cmake/BuildCprnc.cmake
+++ b/components/scream/cmake/BuildCprnc.cmake
@@ -5,6 +5,7 @@
 #
 # to your CMakeLists.txt.
 
+include (EkatUtils)
 macro(BuildCprnc)
 
   # Make sure this is built only once
@@ -28,6 +29,7 @@ macro(BuildCprnc)
     )
     set(SRC_ROOT ${SCREAM_BASE_DIR}/../..)
     add_subdirectory(${SRC_ROOT}/cime/tools/cprnc ${BLDROOT})
+    EkatDisableAllWarning(cprnc)
 
     set(CPRNC_BINARY ${BLDROOT}/cprnc CACHE INTERNAL "")
 

--- a/components/scream/cmake/machine-files/lassen.cmake
+++ b/components/scream/cmake/machine-files/lassen.cmake
@@ -2,7 +2,7 @@
 set (EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/cmake/machine-files)
 include (${EKAT_MACH_FILES_PATH}/kokkos/nvidia-v100.cmake)
 include (${EKAT_MACH_FILES_PATH}/kokkos/cuda.cmake)
-set(NetCDF_Fortran_PATHS /usr/gdata/climdat/libs/netcdf-fortran/install/lassen/fortran CACHE STRING "")
+set(NetCDF_Fortran_PATH /usr/gdata/climdat/libs/netcdf-fortran/install/lassen/fortran CACHE STRING "")
 set(BLAS_LIBRARIES /usr/gdata/climdat/libs/blas/libblas.a CACHE STRING "")
 set(LAPACK_LIBRARIES /usr/gdata/climdat/libs/lapack/liblapack.a CACHE STRING "")
 set(SCREAM_MPIRUN_EXE "jsrun -E LD_PRELOAD=/opt/ibm/spectrum_mpi/lib/pami_471/libpami.so" CACHE STRING "")

--- a/components/scream/docs/source-tree.md
+++ b/components/scream/docs/source-tree.md
@@ -4,9 +4,6 @@ All SCREAM-specific code can be found in `components/scream` within the
 [SCREAM repo](https://github.com/E3SM-Project/scream). Here's how things are
 organized:
 
-+ `bin`: Miscellaneous tools for helping with the build process. Currently, this
-  directory only contains a template for generating the `scream_mpicxx` compiler
-  script.
 + `cime_config`: Tools and XML files for integrating SCREAM with E3SM via the
   CIME framework.
 + `cmake`: CMake functions and macros used by the configuration/build system.

--- a/components/scream/scripts/query-scream
+++ b/components/scream/scripts/query-scream
@@ -20,8 +20,8 @@ OR
 {0} --help
 
 \033[1mEXAMPLES:\033[0m
-    \033[1;32m# Query machine 'mappy' for parameter 'mpicxx' \033[0m
-    > {0} mappy mpicxx
+    \033[1;32m# Query machine 'mappy' for parameter 'cxx_compiler' \033[0m
+    > {0} mappy cxx_compiler
 """.format(pathlib.Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -448,10 +448,10 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         # even if no netcdf is available
         stat, f_path, _ = run_cmd("nf-config --prefix")
         if stat == 0:
-            result += " -DNetCDF_Fortran_PATHS={}".format(f_path)
+            result += " -DNetCDF_Fortran_PATH={}".format(f_path)
         stat, c_path, _ = run_cmd("nc-config --prefix")
         if stat == 0:
-            result += " -DNetCDF_C_PATHS={}".format(c_path)
+            result += " -DNetCDF_C_PATH={}".format(c_path)
 
         # Test-specific cmake options
         for key, value in extra_configs:

--- a/components/scream/src/dynamics/homme/CMakeLists.txt
+++ b/components/scream/src/dynamics/homme/CMakeLists.txt
@@ -1,3 +1,5 @@
+include (EkatSetCompilerFlags)
+
 # Set cmake config options for Homme
 set (HOMME_SOURCE_DIR ${SCREAM_BASE_DIR}/../homme CACHE INTERNAL "Homme source directory")
 set (HOMME_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/homme CACHE INTERNAL "Homme binary directory")
@@ -161,6 +163,8 @@ macro (CreateDynamicsLib HOMME_TARGET NP PLEV QSIZE)
       target_link_libraries (${hommeLibName} csm_share)
     endif ()
     target_link_libraries (${hommeLibName} composec++)
+    SetCudaFlags(${hommeLibName})
+    SetOmpFlags(${hommeLibName})
 
     # target_link_options is supported since 3.13, but there's a bug with static libs until 3.17
     # see https://gitlab.kitware.com/cmake/cmake/-/issues/20022 for details

--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -58,10 +58,10 @@ set(INTERFACE_SRC
   rrtmgp_test_utils.cpp
 )
 add_library(scream_rrtmgp ${INTERFACE_SRC})
-find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATHS}/lib)
+find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATH}/lib)
 target_link_libraries(scream_rrtmgp PUBLIC ${NETCDF_C} rrtmgp yakl scream_share physics_share share_util)
 target_include_directories(scream_rrtmgp SYSTEM PUBLIC
-    ${NetCDF_C_PATHS}/include ${SCREAM_BASE_DIR}/../../externals ${EAM_RRTMGP_DIR}/external)
+    ${NetCDF_C_PATH}/include ${SCREAM_BASE_DIR}/../../externals ${EAM_RRTMGP_DIR}/external)
 
 # Build tests
 if (NOT SCREAM_LIB_ONLY)

--- a/components/scream/src/physics/rrtmgp/share/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/share/CMakeLists.txt
@@ -49,3 +49,8 @@ endforeach ()
 set(share_sources ${FORTRAN_SOURCE})
 
 add_library(share_util ${share_sources})
+
+# These CPP macros are needed in shr_infnan_mod
+target_compile_definitions(share_util PUBLIC
+  $<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CXX_COMPILER_ID:GNU>>:CPRGNU>
+  $<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CXX_COMPILER_ID:Intel>>:CPRINTEL>)

--- a/components/scream/src/share/CMakeLists.txt
+++ b/components/scream/src/share/CMakeLists.txt
@@ -1,3 +1,5 @@
+include (EkatSetCompilerFlags)
+
 set(SHARE_SRC
   scream_config.cpp
   scream_session.cpp
@@ -40,6 +42,7 @@ if (Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE)
     target_link_options(scream_share PUBLIC "--remove-duplicate-link-files")
   endif()
 endif()
+SetOmpFlags(scream_share Fortran)
 
 # The "build_cf_dictionary" target downloads an XML file containing valid field
 # names and aliases based on the CF conventions, and transforms it into a YAML

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
@@ -5,7 +5,7 @@ include (BuildCprnc)
 BuildCprnc()
 
 # Needed for RRTMGP
-find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATHS}/lib)
+find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATH}/lib)
 # Get or create the dynamics lib
 #                 HOMME_TARGET   NP PLEV QSIZE_D
 CreateDynamicsLib("theta-l_kokkos"  4   72   35)

--- a/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT ${SCREAM_BASELINES_ONLY})
 
     SET (TEST_LABELS "rrtmgp;physics")
     # Required libraries
-    find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATHS}/lib)
+    find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATH}/lib)
     set (NEED_LIBS scream_rrtmgp rrtmgp ${NETCDF_C} scream_control scream_share physics_share yakl)
 
     CreateUnitTest(


### PR DESCRIPTION
This PR updates the EKAT submodule with the version from E3SM-Project/ekat#197. There were a few issues related to flags and MPI, which caused some issues in SCREAM. The EKAT pr fixes them, and this PR implements the few changes needed to build with the new version of EKAT.

Closes #1429 .