### PR TITLE
Fix creation of cmake targets wrapping scorpio libs in CIME builds

### DIFF
--- a/components/scream/cmake/tpls/CsmShare.cmake
+++ b/components/scream/cmake/tpls/CsmShare.cmake
@@ -38,7 +38,7 @@ macro (CreateCsmShareTarget)
     # Create the piof imported target, and link it to csm_share, so that cmake will correctly
     # attach it to any downstream target linking against csm_share
     include(${SCREAM_TPLS_MODULE_DIR}/Scorpio.cmake)
-    CreateScorpioTarget(TRUE)
+    CreateScorpioTargets()
     target_link_libraries(csm_share INTERFACE piof)
   endif ()
 endmacro()

--- a/components/scream/cmake/tpls/Scorpio.cmake
+++ b/components/scream/cmake/tpls/Scorpio.cmake
@@ -4,19 +4,26 @@ set (E3SM_EXTERNALS_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../../externals CACHE IN
 
 set (SCREAM_TPLS_MODULE_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "")
 
-macro (CreateScorpioTarget CREATE_FLIB)
+macro (CreateScorpioTargets)
 
-  # If we didn't already parsed this script, proceed
-  if (NOT TARGET pioc)
+  if (SCREAM_CIME_BUILD)
+    # For CIME builds, we simply wrap the already built pioc/piof libs into a cmake target
+    if (NOT DEFINED INSTALL_SHAREDPATH)
+      message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
+    endif ()
 
-    if (SCREAM_CIME_BUILD)
-      # For CIME builds, we simply wrap the already built pioc/piof libs into a cmake target
-      if (NOT DEFINED INSTALL_SHAREDPATH)
-        message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
-      endif ()
+    # If we already parsed this script, then pioc/piof are already targets
+    if (NOT TARGET pioc)
+      if (TARGET piof)
+        message (FATAL_ERROR "Something is off: pioc was not yet imported but piof was.")
+      endif()
 
       set (SCORPIO_LIB_DIR ${INSTALL_SHAREDPATH}/lib)
       set (SCORPIO_INC_DIR ${INSTALL_SHAREDPATH}/include)
+
+      ######################
+      #        PIOc        #
+      ######################
 
       # Look for pioc in INSTALL_SHAREDPATH/lib
       find_library(SCORPIO_C_LIB pioc REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
@@ -26,6 +33,10 @@ macro (CreateScorpioTarget CREATE_FLIB)
       set_target_properties(pioc PROPERTIES
                 IMPORTED_LOCATION "${SCORPIO_C_LIB}"
                 INTERFACE_INCLUDE_DIRECTORIES ${INSTALL_SHAREDPATH}/include)
+
+      ######################
+      #  PIOc dependencies #
+      ######################
 
       # Look for pioc deps, and attach them to the pioc target, so that cmake will
       # propagate them to any downstream target linking against pioc
@@ -38,31 +49,37 @@ macro (CreateScorpioTarget CREATE_FLIB)
         target_link_libraries(pioc INTERFACE "${pnetcdf_lib}")
       endif ()
 
-      # If f lib is requested (and we didn't already parsed this script), proceed
-      if (CREATE_FLIB AND NOT TARGET piof)
-        # Look for piof lib in INSTALL_SHAREDPATH/lib
-        find_library(SCORPIO_F_LIB piof REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
+      ######################
+      #        PIOf        #
+      ######################
 
-        # Create the imported library that scream targets can link to
-        add_library(piof UNKNOWN IMPORTED GLOBAL)
-        set_target_properties(piof PROPERTIES
-                IMPORTED_LOCATION "${SCORPIO_F_LIB}"
-                INTERFACE_INCLUDE_DIRECTORIES ${INSTALL_SHAREDPATH}/include)
-        # Link pioc and netcdf-fortran, so cmake will propagate them to any downstream
-        # target linking against piof
-        target_link_libraries(piof INTERFACE "${netcdf_f_lib};pioc")
-      endif ()
-    else ()
-      # Not a CIME build. Add scorpio as a subdir
-      add_subdirectory (${E3SM_EXTERNALS_DIR}/scorpio ${CMAKE_BINARY_DIR}/externals/scorpio)
-      EkatDisableAllWarning(pioc)
-      EkatDisableAllWarning(gptl)
-      # target piof is not always created by scorpio depending on CMake settings
-      # if it is created, we don't want to see warnings from it when building SCREAM
-      if (TARGET piof)
-        EkatDisableAllWarning(piof)
-      endif()
+      # Look for piof lib in INSTALL_SHAREDPATH/lib
+      find_library(SCORPIO_F_LIB piof REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
+
+      # Create the imported library that scream targets can link to
+      add_library(piof UNKNOWN IMPORTED GLOBAL)
+      set_target_properties(piof PROPERTIES
+              IMPORTED_LOCATION "${SCORPIO_F_LIB}"
+              INTERFACE_INCLUDE_DIRECTORIES ${INSTALL_SHAREDPATH}/include)
+      # Link pioc and netcdf-fortran, so cmake will propagate them to any downstream
+      # target linking against piof
+      target_link_libraries(piof INTERFACE "${netcdf_f_lib};pioc")
+    endif ()
+  elseif (NOT TARGET pioc)
+    # Not a CIME build. We'll add scorpio as a subdir
+    if (TARGET piof)
+      message (FATAL_ERROR "Something is off: pioc ws not yet created but piof was.")
     endif()
-  endif ()
 
+    # We don't need (yet) SCORPIO tools
+    option (PIO_ENABLE_TOOLS "Enable SCORPIO tools" OFF)
+
+    # This is the default, but just in case scorpio changes it
+    option (PIO_ENABLE_FORTRAN "Enable the Fortran library builds" ON)
+
+    add_subdirectory (${E3SM_EXTERNALS_DIR}/scorpio ${CMAKE_BINARY_DIR}/externals/scorpio)
+    EkatDisableAllWarning(pioc)
+    EkatDisableAllWarning(piof)
+    EkatDisableAllWarning(gptl)
+  endif ()
 endmacro()

--- a/components/scream/src/physics/spa/CMakeLists.txt
+++ b/components/scream/src/physics/spa/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_library(spa atmosphere_prescribed_aerosol.cpp)
 target_link_libraries(spa physics_share scream_share)
 
-add_subdirectory(tests)
+if (NOT SCREAM_LIB_ONLY)
+  add_subdirectory(tests)
+endif()

--- a/components/scream/src/share/io/CMakeLists.txt
+++ b/components/scream/src/share/io/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SCREAM_SCORPIO_SRCS
 
 # Create or import scorpio targets
 include (${SCREAM_BASE_DIR}/cmake/tpls/Scorpio.cmake)
-CreateScorpioTarget(TRUE) # Note: the input is whether we want FLIB too. We want/need both, so look for both
+CreateScorpioTargets()
 
 set (SCREAM_CIME_LIBS
      pioc


### PR DESCRIPTION
This should fix the link error related to `piof` that @ndkeen was seeing when building V1.

I try to build v1 on my machine with master, and was able to reproduce the link error. With this fix, the link error disappears.

Upon fixing the link error, I also added an if, to skip SPA unit tests in a SCREAM_LIB_ONLY build (which is the default in a CIME build).