### PR TITLE
Add logic to specify mach-specific flags in scream

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT DEFINED PROJECT_NAME)
-  cmake_minimum_required(VERSION 3.3)
+  cmake_minimum_required(VERSION 3.13)
   cmake_policy(SET CMP0057 NEW)
   set(SCREAM_CIME_BUILD FALSE)
 else()

--- a/components/scream/cmake/BuildCprnc.cmake
+++ b/components/scream/cmake/BuildCprnc.cmake
@@ -5,6 +5,7 @@
 #
 # to your CMakeLists.txt.
 
+include (MachSpecificFlags)
 macro(BuildCprnc)
 
   # Make sure this is built only once
@@ -29,6 +30,7 @@ macro(BuildCprnc)
     set(SRC_ROOT ${SCREAM_BASE_DIR}/../..)
     add_subdirectory(${SRC_ROOT}/cime/tools/cprnc ${BLDROOT})
 
+    AddMachSpecificFlags(cprnc)
     set(CPRNC_BINARY ${BLDROOT}/cprnc CACHE INTERNAL "")
 
     configure_file (${SCREAM_BASE_DIR}/cmake/CprncTest.cmake.in

--- a/components/scream/cmake/MachSpecificFlags.cmake
+++ b/components/scream/cmake/MachSpecificFlags.cmake
@@ -1,0 +1,33 @@
+# This macro adds interface flags to the input target, by probing the
+# CACHE variables SCREAM_FLAGS and SCREAM_<LANG>_FLAGS. The former
+# are added to the C, CXX, and Fortran interface compile options
+# of the target, while the latter are only added to the interface
+# compile options of the corresponding language. If LANG=LD, the
+# macro sets interface link options on the target.
+
+set (SCREAM_FLAGS "" CACHE STRING "Mach specific global flags")
+set (SCREAM_F_FLAGS "" CACHE STRING "Mach specific Fortran flags")
+set (SCREAM_C_FLAGS "" CACHE STRING "Mach specific C flags")
+set (SCREAM_CXX_FLAGS "" CACHE STRING "Mach specific CXX flags")
+set (SCREAM_LD_FLAGS "" CACHE STRING "Mach specific Linker flags")
+
+macro (AddMachSpecificFlags targetName)
+  if (SCREAM_FLAGS)
+    target_compile_options (${targetName} PUBLIC ${SCREAM_FLAGS})
+  endif()
+  if (SCREAM_F_FLAGS)
+    target_compile_options (${targetName} PUBLIC
+      $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_F_FLAGS}>)
+  endif()
+  if (SCREAM_C_FLAGS)
+    target_compile_options (${targetName} PUBLIC
+      $<$<COMPILE_LANGUAGE:C>:${SCREAM_C_FLAGS}>)
+  endif()
+  if (SCREAM_CXX_FLAGS)
+    target_compile_options (${targetName} PUBLIC
+      $<$<COMPILE_LANGUAGE:CXX>:${SCREAM_CXX_FLAGS}>)
+  endif()
+  if (SCREAM_LD_FLAGS)
+    target_link_options (${targetName} PUBLIC ${SCREAM_LD_FLAGS})
+  endif()
+endmacro()

--- a/components/scream/cmake/machine-files/quartz.cmake
+++ b/components/scream/cmake/machine-files/quartz.cmake
@@ -5,9 +5,11 @@ include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
 # Enable Broadwell arch in Kokkos
 option(Kokkos_ARCH_BDW "" ON)
 
-set(CMAKE_CXX_FLAGS "-w -cxxlib=/usr/tce/packages/gcc/gcc-8.3.1/rh" CACHE STRING "" FORCE)
-set(CMAKE_EXE_LINKER_FLAGS "-L/usr/tce/packages/gcc/gcc-8.3.1/rh/lib/gcc/x86_64-redhat-linux/8/ -mkl" CACHE STRING "" FORCE)
 set(SCREAM_MPIRUN_EXE "srun" CACHE STRING "")
 set(SCREAM_MPI_NP_FLAG "-n" CACHE STRING "")
 set(SCREAM_MPI_EXTRA_ARGS "" CACHE STRING "")
 set(SCREAM_INPUT_ROOT "/usr/gdata/climdat/ccsm3data/inputdata" CACHE STRING "")
+
+# Mach-specific flags
+set(SCREAM_CXX_FLAGS "-w -cxxlib=/usr/tce/packages/gcc/gcc-8.3.1/rh" CACHE STRING "")
+set(SCREAM_LD_FLAGS "-L/usr/tce/packages/gcc/gcc-8.3.1/rh/lib/gcc/x86_64-redhat-linux/8/ -mkl" CACHE STRING "")

--- a/components/scream/cmake/machine-files/syrah.cmake
+++ b/components/scream/cmake/machine-files/syrah.cmake
@@ -5,9 +5,11 @@ include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
 # Enable Sandy Bridge arch in Kokkos
 option(Kokkos_ARCH_SNB "" ON)
 
-set(CMAKE_CXX_FLAGS "-w -cxxlib=/usr/tce/packages/gcc/gcc-8.3.1/rh" CACHE STRING "" FORCE)
-set(CMAKE_EXE_LINKER_FLAGS "-L/usr/tce/packages/gcc/gcc-8.3.1/rh/lib/gcc/x86_64-redhat-linux/8/ -mkl" CACHE STRING "" FORCE)
 set(SCREAM_MPIRUN_EXE "srun" CACHE STRING "")
 set(SCREAM_MPI_NP_FLAG "-n" CACHE STRING "")
 set(SCREAM_MPI_EXTRA_ARGS "" CACHE STRING "")
 set(SCREAM_INPUT_ROOT "/usr/gdata/climdat/ccsm3data/inputdata/" CACHE STRING "")
+
+# Mach-specific flags
+set(SCREAM_CXX_FLAGS "-w -cxxlib=/usr/tce/packages/gcc/gcc-8.3.1/rh" CACHE STRING "")
+set(SCREAM_LD_FLAGS "-L/usr/tce/packages/gcc/gcc-8.3.1/rh/lib/gcc/x86_64-redhat-linux/8/ -mkl" CACHE STRING "")

--- a/components/scream/cmake/tpls/Scorpio.cmake
+++ b/components/scream/cmake/tpls/Scorpio.cmake
@@ -1,3 +1,5 @@
+include (MachSpecificFlags)
+
 # If this is a CIME build, create IMPORTED target to wrap scorpio libs.
 # Otherwise, simply add scorpio subdirectory.
 set (E3SM_EXTERNALS_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../../externals CACHE INTERNAL "")
@@ -81,5 +83,8 @@ macro (CreateScorpioTargets)
     EkatDisableAllWarning(pioc)
     EkatDisableAllWarning(piof)
     EkatDisableAllWarning(gptl)
+
+    # Only need to add flags to gptl, since the other two link against this
+    AddMachSpecificFlags(gptl)
   endif ()
 endmacro()

--- a/components/scream/src/share/CMakeLists.txt
+++ b/components/scream/src/share/CMakeLists.txt
@@ -1,3 +1,5 @@
+include (MachSpecificFlags)
+
 set(SHARE_SRC
   scream_config.cpp
   scream_session.cpp
@@ -40,6 +42,7 @@ if (Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE)
     target_link_options(scream_share PUBLIC "--remove-duplicate-link-files")
   endif()
 endif()
+AddMachSpecificFlags(scream_share)
 
 # The "build_cf_dictionary" target downloads an XML file containing valid field
 # names and aliases based on the CF conventions, and transforms it into a YAML


### PR DESCRIPTION
Instead of having mach files populate the `CMAKE_<LANG>_FLAGS`, introduce new cache vars, which scream can use to add compile/link flags.

To be fair, these flags need not be mach-specific, but the primary goal is to put mach-specific flags in the mach files, without the need to pollute CMAKE variables.

Notes:
- I manually tested on my laptop that the cache entries `SCREAM_FLAGS` and `SCREAM_<LANG>_FLAGS` (with LANG=F,C,CXX,LD) are correctly added to the targets, including downstream ones.
- So far, I only added "global" scream cache vars, so any flag specified in these vars is added to _all_ scream targets, including downstream deps. @jgfouca I am not sure how this will impact e3sm.exe, but I suspect it's fine. Worst case scenario, we can make the `atm` lib link all scream deps with PRIVATE, so that e3sm.exe is not affected by compile flags that are only needed for SCREAM.