### PR TITLE
Fix SC team policy issue on GPU

### DIFF
--- a/components/scream/src/control/surface_coupling_export.cpp
+++ b/components/scream/src/control/surface_coupling_export.cpp
@@ -43,7 +43,7 @@ void SurfaceCoupling::do_export (const bool init_phase)
     // Local copy, to deal with CUDA's handling of *this.
     const int num_levs = m_num_levs;
 
-    const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, num_levs);
+    const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(m_num_cols, num_levs);
     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const Kokkos::TeamPolicy<KT::ExeSpace>::member_type& team) {
       const int i = team.league_rank();
 

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -235,7 +235,7 @@ TEST_CASE ("recreate_mct_coupling")
 
   // Some constants
   constexpr int ncols = 4;
-  constexpr int nlevs = 8;
+  constexpr int nlevs = 72;
   constexpr int nruns = 10;
 
   // Create a comm


### PR DESCRIPTION
Addresses first issue in https://github.com/E3SM-Project/scream/issues/1443. Changes the `sc_ut` test to trigger the error and then add the fix.