### PR TITLE
Introduce a unit test for spa_main

### DIFF
--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -124,11 +124,6 @@ void SPA::initialize_impl (const RunType /* run_type */)
 {
   // Initialize SPA pressure state stucture and set pointers for the SPA output data to
   // field managed variables.
-  SPAPressureState.ncols         = m_num_cols;
-  SPAPressureState.nlevs         = m_num_levs;
-  SPAPressureState.hyam          = get_field_in("hyam").get_view<const Pack*>();
-  SPAPressureState.hybm          = get_field_in("hybm").get_view<const Pack*>();
-  SPAPressureState.pmid          = get_field_in("p_mid").get_view<const Pack**>();
   SPAData_out.CCN3               = get_field_out("nc_activated").get_view<Pack**>();
   SPAData_out.AER_G_SW           = get_field_out("aero_g_sw").get_view<Pack***>();
   SPAData_out.AER_SSA_SW         = get_field_out("aero_ssa_sw").get_view<Pack***>();
@@ -179,7 +174,8 @@ void SPA::run_impl (const int /* dt */)
   SPAFunc::update_spa_timestate(m_spa_data_file,m_nswbands,m_nlwbands,ts,SPAHorizInterp,SPATimeState,SPAData_start,SPAData_end);
 
   // Call the main SPA routine to get interpolated aerosol forcings.
-  SPAFunc::spa_main(SPATimeState, SPAPressureState,SPAData_start,SPAData_end,SPAData_out,m_num_cols,m_num_levs,m_nswbands,m_nlwbands);
+  const auto& pmid_tgt = get_field_in("p_mid").get_view<const Pack**>();
+  SPAFunc::spa_main(SPATimeState, pmid_tgt,SPAData_start,SPAData_end,SPAData_out,m_num_cols,m_num_levs,m_nswbands,m_nlwbands);
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -156,12 +156,12 @@ void SPA::initialize_impl (const RunType /* run_type */)
   // Note: only the number of levels associated with this data haven't been set.  We can
   //       take this information directly from the spa data file.
   scorpio::register_file(m_spa_data_file,scorpio::Read);
-  SPAHorizInterp.source_grid_nlevs = scorpio::get_dimlen_c2f(m_spa_data_file.c_str(),"lev");
+  const int source_data_nlevs = scorpio::get_dimlen_c2f(m_spa_data_file.c_str(),"lev")+2; // Add 2 for padding
   SPAHorizInterp.m_comm = m_comm;
 
   // Initialize the size of the SPAData structures:
-  SPAData_start = SPAFunc::SPAData(m_dofs_gids.size(), SPAHorizInterp.source_grid_nlevs, m_nswbands, m_nlwbands);
-  SPAData_end   = SPAFunc::SPAData(m_dofs_gids.size(), SPAHorizInterp.source_grid_nlevs, m_nswbands, m_nlwbands);
+  SPAData_start = SPAFunc::SPAData(m_dofs_gids.size(), source_data_nlevs, m_nswbands, m_nlwbands);
+  SPAData_end   = SPAFunc::SPAData(m_dofs_gids.size(), source_data_nlevs, m_nswbands, m_nlwbands);
 
   // Update the local time state information and load the first set of SPA data for interpolation:
   auto ts = timestamp();

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.hpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.hpp
@@ -109,7 +109,6 @@ protected:
 
   // Structures to store the data used for interpolation
   SPAFunc::SPATimeState     SPATimeState;
-  SPAFunc::SPAPressureState SPAPressureState;
   SPAFunc::SPAData          SPAData_start;
   SPAFunc::SPAData          SPAData_end;
   SPAFunc::SPAHorizInterp   SPAHorizInterp;

--- a/components/scream/src/physics/spa/spa_functions.hpp
+++ b/components/scream/src/physics/spa/spa_functions.hpp
@@ -167,7 +167,7 @@ struct SPAFunctions
     // Number of columns and levels on source grid
     // Note, the number of columns on target grid should already be known.
     //       these are given based on the simulation grid.
-    Int source_grid_ncols, source_grid_nlevs;
+    Int source_grid_ncols;
     // 1D index of weights.  Needs decoder indexing, see below
     view_1d<Real> weights;
     // 1D index of source grid column.

--- a/components/scream/src/physics/spa/spa_functions.hpp
+++ b/components/scream/src/physics/spa/spa_functions.hpp
@@ -92,9 +92,11 @@ struct SPAFunctions
       ,nswbands(nswbands_)
       ,nlwbands(nlwbands_)
     {
-      PS        = view_1d<Real>("",ncols);
-      CCN3      = view_2d<Spack>("",ncols,nlevs);
-      AER_G_SW  = view_3d<Spack>("",ncols,nswbands,nlevs); 
+      hyam       = view_1d<Spack>("",nlevs);
+      hybm       = view_1d<Spack>("",nlevs);
+      PS         = view_1d<Real>("",ncols);
+      CCN3       = view_2d<Spack>("",ncols,nlevs);
+      AER_G_SW   = view_3d<Spack>("",ncols,nswbands,nlevs); 
       AER_SSA_SW = view_3d<Spack>("",ncols,nswbands,nlevs); 
       AER_TAU_SW = view_3d<Spack>("",ncols,nswbands,nlevs); 
       AER_TAU_LW = view_3d<Spack>("",ncols,nlwbands,nlevs); 
@@ -104,6 +106,8 @@ struct SPAFunctions
     Int nlevs;
     Int nswbands;
     Int nlwbands;
+    // Hybrid Coordinates
+    view_1d<Spack> hyam, hybm;
     // PS unit = Pa: Surface pressure
     view_1d<Real> PS;
     // CCN3: CCN concentration at S=0.1%, units = #/cm3, dimensions = (ncol,nlev)
@@ -121,6 +125,23 @@ struct SPAFunctions
 
   struct SPAOutput {
     SPAOutput() = default;
+    SPAOutput(const int ncol_, const int nlev_, const int nswbands_, const int nlwbands_) :
+      ncols(ncol_)
+      ,nlevs(nlev_)
+      ,nswbands(nswbands_)
+      ,nlwbands(nlwbands_)
+    {
+      CCN3       = view_2d<Spack>("",ncols,nlevs);
+      AER_G_SW   = view_3d<Spack>("",ncols,nswbands,nlevs); 
+      AER_SSA_SW = view_3d<Spack>("",ncols,nswbands,nlevs); 
+      AER_TAU_SW = view_3d<Spack>("",ncols,nswbands,nlevs); 
+      AER_TAU_LW = view_3d<Spack>("",ncols,nlwbands,nlevs); 
+    }
+    // Basic spatial dimensions of the data
+    Int ncols;
+    Int nlevs;
+    Int nswbands;
+    Int nlwbands;
     // CCN3: CCN concentration at S=0.1%, units = #/cm3, dimensions = (ncol,nlev)
     view_2d<Spack> CCN3;
     // AER_G_SW - 14 bands

--- a/components/scream/src/physics/spa/spa_functions.hpp
+++ b/components/scream/src/physics/spa/spa_functions.hpp
@@ -73,17 +73,6 @@ struct SPAFunctions
     Real days_this_month;
   }; // SPATimeState
 
-  struct SPAPressureState {
-    SPAPressureState() = default;
-    // Number of horizontal columns and vertical levels for the data
-    Int ncols;
-    Int nlevs;
-    // Hybrid coordinate values
-    view_1d<const Spack> hyam, hybm;
-    // Current simulation pressure levels
-    view_2d<const Spack> pmid;
-  }; // SPAPressureState
-
   struct SPAData {
     SPAData() = default;
     SPAData(const int ncol_, const int nlev_, const int nswbands_, const int nlwbands_) :
@@ -191,7 +180,7 @@ struct SPAFunctions
   // SPA routines
   static void spa_main(
     const SPATimeState& time_state,
-    const SPAPressureState& pressure_state,
+    const view_2d<const Spack>& p_tgt,
     const SPAData&   data_beg,
     const SPAData&   data_end,
     const SPAOutput& data_out,

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -92,7 +92,7 @@ template <typename S, typename D>
 void SPAFunctions<S,D>
 ::spa_main(
   const SPATimeState& time_state,
-  const SPAPressureState& pressure_state,
+  const view_2d<const Spack>& p_tgt,
   const SPAData&   data_beg,
   const SPAData&   data_end,
   const SPAOutput& data_out,
@@ -107,7 +107,6 @@ void SPAFunctions<S,D>
   auto& t_len = time_state.days_this_month;
 
   const int nlevs_src = data_beg.nlevs;
-  const auto& p_tgt = pressure_state.pmid;  //TODO: since this is the only place pressure state is used, should just pass this one view.
 
   // For now we require that the Data in and the Data out have the same number of columns.
   EKAT_REQUIRE(ncols_tgt==data_beg.ncols);

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -73,10 +73,7 @@ ScalarT linear_interp(const ScalarT& x0, const ScalarT& x1, const ScalarS& t_nor
 // Inputs:
 //   time_state: A structure defined in spa_functions.hpp which handles
 //     the current temporal state of the simulation.
-//   pressure_state: A structure defined in spa_functions.hpp which handles
-//     the vertical pressure profile for the atmospheric simulation state, and
-//     all of the data needed to reconstruct the vertical pressure profile for
-//     the SPA data.  See hybrid coordinate (hyam,hybm) and surface pressure (PS)
+//   p_tgt: the vertical pressure profile for the atmospheric simulation state
 //   data_beg: A structure defined in spa_functions.hpp which handles the full
 //     set of SPA data for the beginning of the month.
 //   data_end: Similar to data_beg, but for SPA data for the end of the month.
@@ -214,7 +211,7 @@ void SPAFunctions<S,D>
   // for more details. 
   using LIV = ekat::LinInterp<Real,Spack::n>;
 
-  LIV VertInterp(ncols_atm,pressure_state.nlevs,nlevs_atm);
+  LIV VertInterp(ncols_tgt,nlevs_src,nlevs_tgt);
   /* Parallel loop strategy:
    * 1. Loop over all simulation columns (i index)
    * 2. Where applicable, loop over all aerosol bands (n index)

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -655,8 +655,8 @@ void SPAFunctions<S,D>
     hyam_h(pack)[kidx] = hyam_v_h(kk);
     hybm_h(pack)[kidx] = hybm_v_h(kk);
   }
-  const int pack = (source_data_nlevs+2) / Spack::n;
-  const int kidx = (source_data_nlevs+2) % Spack::n;
+  const int pack = (source_data_nlevs+1) / Spack::n;
+  const int kidx = (source_data_nlevs+1) % Spack::n;
   hyam_h(pack)[kidx] = 1e5; 
   hybm_h(pack)[kidx] = 0.0;
   

--- a/components/scream/src/physics/spa/tests/CMakeLists.txt
+++ b/components/scream/src/physics/spa/tests/CMakeLists.txt
@@ -16,7 +16,6 @@ CreateUnitTest(spa_one_to_one_remap_test "spa_one_to_one_remap_test.cpp" "${NEED
 )
 CreateUnitTest(spa_main_test "spa_main_test.cpp" "${NEED_LIBS}"
   LABELS "spa"
-  MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
 )
 
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/spa_main.yaml

--- a/components/scream/src/physics/spa/tests/CMakeLists.txt
+++ b/components/scream/src/physics/spa/tests/CMakeLists.txt
@@ -14,5 +14,13 @@ CreateUnitTest(spa_one_to_one_remap_test "spa_one_to_one_remap_test.cpp" "${NEED
   LABELS "spa"
   MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
 )
+CreateUnitTest(spa_main_test "spa_main_test.cpp" "${NEED_LIBS}"
+  LABELS "spa"
+  MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+)
 
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/spa_main.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/spa_main.yaml)
 GetInputFile(init/spa_data_for_testing.nc ${CMAKE_CURRENT_BINARY_DIR}/spa_data_for_testing.nc)
+GetInputFile(init/spa_file_unified_and_complete_ne4_scream.nc
+  ${CMAKE_CURRENT_BINARY_DIR}/data/spa_file_unified_and_complete_ne4_scream.nc)

--- a/components/scream/src/physics/spa/tests/spa_main.yaml
+++ b/components/scream/src/physics/spa/tests/spa_main.yaml
@@ -1,0 +1,8 @@
+%YAML 1.1
+---
+SPA Data File: @CMAKE_CURRENT_BINARY_DIR@/data/spa_file_unified_and_complete_ne4_scream.nc
+ncols: 866
+nlevs: 72
+nswbands: 14
+nlwbands: 16
+...

--- a/components/scream/src/physics/spa/tests/spa_main_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_main_test.cpp
@@ -20,6 +20,8 @@ using namespace scream;
 using namespace spa;
 
 template <typename S>
+using view_1d_host = typename KokkosTypes<DefaultDevice>::template view_1d<S>::HostMirror;
+template <typename S>
 using view_1d = typename KokkosTypes<DefaultDevice>::template view_1d<S>;
 template <typename S>
 using view_2d = typename KokkosTypes<DefaultDevice>::template view_2d<S>;
@@ -30,7 +32,7 @@ using SPAFunc = spa::SPAFunctions<Real, DefaultDevice>;
 using Spack = SPAFunc::Spack;
 
 // Helper Functions
-void compute_max_min(const view_1d<const Spack>& input, const int start, const int end, Real& min, Real& max);
+void compute_max_min(const view_1d_host<const Spack>& input, const int start, const int end, Real& min, Real& max);
 
 TEST_CASE("spa_read_data","spa")
 {
@@ -160,8 +162,6 @@ TEST_CASE("spa_read_data","spa")
       pmid_tgt_h(dof_i,kpack)[kidx] = ps_beg(dof_i)*hybm_h(kpack_pad)[kidx_pad] + P0*hyam_h(kpack_pad)[kidx_pad];
     }
   }
-  int kpack_pad = (nlevs+1) / Spack::n;
-  int kidx_pad  = (nlevs+1) % Spack::n;
   Kokkos::deep_copy(pmid_tgt,pmid_tgt_h);
 
   // Run SPA main
@@ -411,7 +411,7 @@ TEST_CASE("spa_read_data","spa")
 } // run_property
 
 // Helper function
-void compute_max_min(const view_1d<const Spack>& input, const int start, const int end, Real& min, Real& max)
+void compute_max_min(const view_1d_host<const Spack>& input, const int start, const int end, Real& min, Real& max)
 {
   int kpack, kidx;
   // Initialize min and max with first entry in input

--- a/components/scream/src/physics/spa/tests/spa_main_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_main_test.cpp
@@ -1,0 +1,381 @@
+#include "catch2/catch.hpp"
+
+#include "share/io/scream_scorpio_interface.hpp"
+#include "physics/spa/spa_functions.hpp"
+#include "share/util/scream_time_stamp.hpp"
+
+#include "ekat/ekat_pack.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "ekat/ekat_parse_yaml_file.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <thread>
+
+namespace {
+
+using namespace scream;
+using namespace spa;
+
+template <typename S>
+using view_1d = typename KokkosTypes<DefaultDevice>::template view_1d<S>;
+template <typename S>
+using view_2d = typename KokkosTypes<DefaultDevice>::template view_2d<S>;
+template <typename S>
+using view_3d = typename KokkosTypes<DefaultDevice>::template view_3d<S>;
+
+using SPAFunc = spa::SPAFunctions<Real, DefaultDevice>;
+using Spack = SPAFunc::Spack;
+
+// Dummy pressure state structure that is non-const for pmid.  Needed to set up the test.
+struct PressureState {
+  PressureState() = default;
+  PressureState(const int ncol_, const int nlev_) :
+    ncols(ncol_)
+    ,nlevs(nlev_)
+  {
+    pmid = view_2d<Spack>("",ncols,nlevs);
+  }
+  // Number of horizontal columns and vertical levels for the data
+  Int ncols;
+  Int nlevs;
+  // Current simulation pressure levels
+  view_2d<Spack> pmid;
+}; // PressureState
+
+TEST_CASE("spa_read_data","spa")
+{
+  using C = scream::physics::Constants<Real>;
+  static constexpr auto P0 = C::P0;
+
+  // Set up the mpi communicator and init the pio subsystem
+  ekat::Comm spa_comm(MPI_COMM_WORLD);  // MPI communicator group used for I/O set as ekat object.
+  MPI_Fint fcomm = MPI_Comm_c2f(spa_comm.mpi_comm());  // MPI communicator group used for I/O.  In our simple test we use MPI_COMM_WORLD, however a subset could be used.
+  scorpio::eam_init_pio_subsystem(fcomm);   // Gather the initial PIO subsystem data creater by component coupler
+
+  // Establish the SPA function object
+  using SPAFunc = spa::SPAFunctions<Real, DefaultDevice>;
+  using Spack = SPAFunc::Spack;
+  using gid_type = SPAFunc::gid_type;
+
+  std::string fname = "spa_main.yaml";
+  ekat::ParameterList test_params("Atmosphere Driver");
+  REQUIRE_NOTHROW ( parse_yaml_file(fname,test_params) );
+  test_params.print();
+
+  std::string spa_data_file = test_params.get<std::string>("SPA Data File");
+  Int ncols    = test_params.get<Int>("ncols");
+  Int nlevs    = test_params.get<Int>("nlevs");
+  Int nswbands = test_params.get<Int>("nswbands");
+  Int nlwbands = test_params.get<Int>("nlwbands");
+
+  // Break the test set of columns into local degrees of freedom per mpi rank
+  auto comm_size = spa_comm.size();
+  auto comm_rank = spa_comm.rank();
+
+  int my_ncols = ncols/comm_size + (comm_rank < ncols%comm_size ? 1 : 0);
+  view_1d<gid_type> dofs_gids("",my_ncols);
+  gid_type min_dof = 1; // Start global-ids from 1
+  Kokkos::parallel_for("", my_ncols, KOKKOS_LAMBDA(const int& ii) {
+    dofs_gids(ii) = min_dof + static_cast<gid_type>(comm_rank + ii*comm_size);
+  });
+  // Make sure that the total set of columns has been completely broken up.
+  Int test_total_ncols = 0;
+  spa_comm.all_reduce(&my_ncols,&test_total_ncols,1,MPI_SUM);
+  REQUIRE(test_total_ncols == ncols);
+
+  // Set up the set of SPA structures needed to run the test
+  SPAFunc::SPAHorizInterp spa_horiz_interp;
+  spa_horiz_interp.m_comm = spa_comm;
+  SPAFunc::set_remap_weights_one_to_one(ncols,min_dof,dofs_gids,spa_horiz_interp);
+  SPAFunc::SPATimeState     spa_time_state;
+  PressureState             pressure_state(dofs_gids.size(), nlevs);
+  SPAFunc::SPAPressureState spa_pressure_state;
+  SPAFunc::SPAData          spa_data_beg(dofs_gids.size(), nlevs, nswbands, nlwbands);
+  SPAFunc::SPAData          spa_data_end(dofs_gids.size(), nlevs, nswbands, nlwbands);
+  SPAFunc::SPAOutput        spa_data_out(dofs_gids.size(), nlevs, nswbands, nlwbands);
+
+  // Verify that the interpolated values match the data, since no temporal or vertical interpolation
+  // should be done at this point.
+  
+  // Create local host views of all relevant data:
+  auto hyam_h         = Kokkos::create_mirror_view(spa_data_beg.hyam);
+  auto hybm_h         = Kokkos::create_mirror_view(spa_data_beg.hybm);
+  // Beg data for time interpolation
+  auto ps_beg         = Kokkos::create_mirror_view(spa_data_beg.PS);
+  auto ccn3_beg       = Kokkos::create_mirror_view(spa_data_beg.CCN3);
+  auto aer_g_sw_beg   = Kokkos::create_mirror_view(spa_data_beg.AER_G_SW);
+  auto aer_ssa_sw_beg = Kokkos::create_mirror_view(spa_data_beg.AER_SSA_SW);
+  auto aer_tau_sw_beg = Kokkos::create_mirror_view(spa_data_beg.AER_TAU_SW);
+  auto aer_tau_lw_beg = Kokkos::create_mirror_view(spa_data_beg.AER_TAU_LW);
+  // End data for time interpolation
+  auto ps_end         = Kokkos::create_mirror_view(spa_data_end.PS);
+  auto ccn3_end       = Kokkos::create_mirror_view(spa_data_end.CCN3);
+  auto aer_g_sw_end   = Kokkos::create_mirror_view(spa_data_end.AER_G_SW);
+  auto aer_ssa_sw_end = Kokkos::create_mirror_view(spa_data_end.AER_SSA_SW);
+  auto aer_tau_sw_end = Kokkos::create_mirror_view(spa_data_end.AER_TAU_SW);
+  auto aer_tau_lw_end = Kokkos::create_mirror_view(spa_data_end.AER_TAU_LW);
+  // Output
+  auto ccn3_h       = Kokkos::create_mirror_view(spa_data_out.CCN3);
+  auto aer_g_sw_h   = Kokkos::create_mirror_view(spa_data_out.AER_G_SW);
+  auto aer_ssa_sw_h = Kokkos::create_mirror_view(spa_data_out.AER_SSA_SW);
+  auto aer_tau_sw_h = Kokkos::create_mirror_view(spa_data_out.AER_TAU_SW);
+  auto aer_tau_lw_h = Kokkos::create_mirror_view(spa_data_out.AER_TAU_LW);
+  
+  // First initialize the start and end month data:  Set for January
+  util::TimeStamp ts(1900,1,1,0,0,0);
+  SPAFunc::update_spa_timestate(spa_data_file,nswbands,nlwbands,ts,spa_horiz_interp,spa_time_state,spa_data_beg,spa_data_end);
+
+  Kokkos::deep_copy(hyam_h        ,spa_data_beg.hyam);
+  Kokkos::deep_copy(hybm_h        ,spa_data_beg.hybm);
+  Kokkos::deep_copy(ps_beg        ,spa_data_beg.PS);
+  Kokkos::deep_copy(ccn3_beg      ,spa_data_beg.CCN3);
+  Kokkos::deep_copy(aer_g_sw_beg  ,spa_data_beg.AER_G_SW);
+  Kokkos::deep_copy(aer_ssa_sw_beg,spa_data_beg.AER_SSA_SW);
+  Kokkos::deep_copy(aer_tau_sw_beg,spa_data_beg.AER_TAU_SW);
+  Kokkos::deep_copy(aer_tau_lw_beg,spa_data_beg.AER_TAU_LW);
+  Kokkos::deep_copy(ps_end        ,spa_data_end.PS);
+  Kokkos::deep_copy(ccn3_end      ,spa_data_end.CCN3);
+  Kokkos::deep_copy(aer_g_sw_end  ,spa_data_end.AER_G_SW);
+  Kokkos::deep_copy(aer_ssa_sw_end,spa_data_end.AER_SSA_SW);
+  Kokkos::deep_copy(aer_tau_sw_end,spa_data_end.AER_TAU_SW);
+  Kokkos::deep_copy(aer_tau_lw_end,spa_data_end.AER_TAU_LW);
+
+  // Create the pressure state.  Note, we need to create the pmid values for the actual data.  We will build it based on the PS and hya/bm
+  // coordinates in the beginning data.
+  auto dofs_gids_h = Kokkos::create_mirror_view(dofs_gids);
+  Kokkos::deep_copy(dofs_gids_h,dofs_gids);
+  spa_pressure_state.ncols = dofs_gids.size(); 
+  spa_pressure_state.nlevs = nlevs;
+
+  spa_pressure_state.pmid  = pressure_state.pmid;
+  auto pmid_h = Kokkos::create_mirror_view(pressure_state.pmid);
+
+  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
+    for (int kk=0;kk<nlevs;kk++) {
+      int kpack = kk / Spack::n;
+      int kidx  = kk % Spack::n;
+      pmid_h(dof_i,kpack)[kidx] = ps_beg(dof_i)*hybm_h(kpack)[kidx] + P0*hyam_h(kpack)[kidx];
+    }
+  }
+  Kokkos::deep_copy(pressure_state.pmid,pmid_h);
+  Kokkos::deep_copy(spa_data_beg.hyam,hyam_h);
+  Kokkos::deep_copy(spa_data_beg.hybm,hybm_h);
+
+  // Run SPA main
+  SPAFunc::spa_main(spa_time_state,spa_pressure_state,spa_data_beg,spa_data_end,spa_data_out,dofs_gids.size(),nlevs,nswbands,nlwbands);
+
+  Kokkos::deep_copy(ccn3_h      , spa_data_out.CCN3);
+  Kokkos::deep_copy(aer_g_sw_h  , spa_data_out.AER_G_SW);
+  Kokkos::deep_copy(aer_ssa_sw_h, spa_data_out.AER_SSA_SW);
+  Kokkos::deep_copy(aer_tau_sw_h, spa_data_out.AER_TAU_SW);
+  Kokkos::deep_copy(aer_tau_lw_h, spa_data_out.AER_TAU_LW);
+
+  // The output data should match the input data exactly since there is no time interpolation
+  // and the pmid profile should match the constructed profile within spa_main.
+  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
+    for (int kk=0;kk<nlevs;kk++) {
+      int kpack = kk / Spack::n;
+      int kidx  = kk % Spack::n;
+      REQUIRE(ccn3_h(dof_i,kpack)[kidx] == ccn3_beg(dof_i,kpack)[kidx] );
+      for (int n=0;n<nswbands;n++) {
+        REQUIRE(aer_g_sw_h(dof_i,n,kpack)[kidx]   == aer_g_sw_beg(dof_i,n,kpack)[kidx]   );
+        REQUIRE(aer_ssa_sw_h(dof_i,n,kpack)[kidx] == aer_ssa_sw_beg(dof_i,n,kpack)[kidx] );
+        REQUIRE(aer_tau_sw_h(dof_i,n,kpack)[kidx] == aer_tau_sw_beg(dof_i,n,kpack)[kidx] );
+      }
+      for (int n=0;n<nlwbands;n++) {
+        REQUIRE(aer_tau_lw_h(dof_i,n,kpack)[kidx] == aer_tau_lw_beg(dof_i,n,kpack)[kidx] );
+      }
+    }
+  }
+
+  // Add a month and recalculate.  Should now match the end of the month data.
+  ts += util::days_in_month(ts.get_year(),ts.get_month())*86400;
+  spa_time_state.t_now = ts.frac_of_year_in_days();
+
+  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
+    for (int kk=0;kk<nlevs;kk++) {
+      int kpack = kk / Spack::n;
+      int kidx  = kk % Spack::n;
+      pmid_h(dof_i,kpack)[kidx] = ps_end(dof_i)*hybm_h(kpack)[kidx] + P0*hyam_h(kpack)[kidx];
+    }
+  }
+  Kokkos::deep_copy(pressure_state.pmid,pmid_h);
+  
+  SPAFunc::spa_main(spa_time_state,spa_pressure_state,spa_data_beg,spa_data_end,spa_data_out,dofs_gids.size(),nlevs,nswbands,nlwbands);
+  Kokkos::deep_copy(ccn3_h      , spa_data_out.CCN3);
+  Kokkos::deep_copy(aer_g_sw_h  , spa_data_out.AER_G_SW);
+  Kokkos::deep_copy(aer_ssa_sw_h, spa_data_out.AER_SSA_SW);
+  Kokkos::deep_copy(aer_tau_sw_h, spa_data_out.AER_TAU_SW);
+  Kokkos::deep_copy(aer_tau_lw_h, spa_data_out.AER_TAU_LW);
+
+  // The output data should match the input data exactly since there is no time interpolation
+  // and the pmid profile should match the constructed profile within spa_main.
+  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
+    for (int kk=0;kk<nlevs;kk++) {
+      int kpack = kk / Spack::n;
+      int kidx  = kk % Spack::n;
+      REQUIRE(ccn3_h(dof_i,kpack)[kidx] == ccn3_end(dof_i,kpack)[kidx] );
+      for (int n=0;n<nswbands;n++) {
+        REQUIRE(aer_g_sw_h(dof_i,n,kpack)[kidx]   == aer_g_sw_end(dof_i,n,kpack)[kidx]   );
+        REQUIRE(aer_ssa_sw_h(dof_i,n,kpack)[kidx] == aer_ssa_sw_end(dof_i,n,kpack)[kidx] );
+        REQUIRE(aer_tau_sw_h(dof_i,n,kpack)[kidx] == aer_tau_sw_end(dof_i,n,kpack)[kidx] );
+      }
+      for (int n=0;n<nlwbands;n++) {
+        //ASDREQUIRE((aer_tau_lw_h(dof_i,n,kpack)[kidx] - aer_tau_lw_end(dof_i,n,kpack)[kidx])<1e-11 );
+        REQUIRE(aer_tau_lw_h(dof_i,n,kpack)[kidx] == aer_tau_lw_end(dof_i,n,kpack)[kidx] );
+      }
+    }
+  }
+
+  // Add a few days and update spa data.  Make sure that the output values are not outside of the bounds
+  // of the actual SPA data 
+  ts += (int)(util::days_in_month(ts.get_year(),ts.get_month())*0.5)*86400;
+  SPAFunc::update_spa_timestate(spa_data_file,nswbands,nlwbands,ts,spa_horiz_interp,spa_time_state,spa_data_beg,spa_data_end);
+  Kokkos::deep_copy(ps_beg        ,spa_data_beg.PS);
+  Kokkos::deep_copy(ccn3_beg      ,spa_data_beg.CCN3);
+  Kokkos::deep_copy(aer_g_sw_beg  ,spa_data_beg.AER_G_SW);
+  Kokkos::deep_copy(aer_ssa_sw_beg,spa_data_beg.AER_SSA_SW);
+  Kokkos::deep_copy(aer_tau_sw_beg,spa_data_beg.AER_TAU_SW);
+  Kokkos::deep_copy(aer_tau_lw_beg,spa_data_beg.AER_TAU_LW);
+  Kokkos::deep_copy(ps_end        ,spa_data_end.PS);
+  Kokkos::deep_copy(ccn3_end      ,spa_data_end.CCN3);
+  Kokkos::deep_copy(aer_g_sw_end  ,spa_data_end.AER_G_SW);
+  Kokkos::deep_copy(aer_ssa_sw_end,spa_data_end.AER_SSA_SW);
+  Kokkos::deep_copy(aer_tau_sw_end,spa_data_end.AER_TAU_SW);
+  Kokkos::deep_copy(aer_tau_lw_end,spa_data_end.AER_TAU_LW);
+  // Create a target pressure profile to interpolate onto that has a slightly higher surface pressure that the bounds.
+  // This will force extrapolation.
+  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
+    for (int kk=0;kk<nlevs;kk++) {
+      int kpack = kk / Spack::n;
+      int kidx  = kk % Spack::n;
+      Real ps = 1.05*std::max(ps_beg(dof_i),ps_end(dof_i));
+      pmid_h(dof_i,kpack)[kidx] = ps*hybm_h(kpack)[kidx] + P0*hyam_h(kpack)[kidx];
+    }
+  }
+  Kokkos::deep_copy(pressure_state.pmid,pmid_h);
+
+  SPAFunc::spa_main(spa_time_state,spa_pressure_state,spa_data_beg,spa_data_end,spa_data_out,dofs_gids.size(),nlevs,nswbands,nlwbands);
+  Kokkos::deep_copy(ccn3_h      , spa_data_out.CCN3);
+  Kokkos::deep_copy(aer_g_sw_h  , spa_data_out.AER_G_SW);
+  Kokkos::deep_copy(aer_ssa_sw_h, spa_data_out.AER_SSA_SW);
+  Kokkos::deep_copy(aer_tau_sw_h, spa_data_out.AER_TAU_SW);
+  Kokkos::deep_copy(aer_tau_lw_h, spa_data_out.AER_TAU_LW);
+
+  // Calculate the min and max values for all spa input data for all columns 
+  auto ccn3_bnds       = view_2d<Real>("",2,ncols);
+  auto aer_sw_g_bnds   = view_3d<Real>("",2,ncols,nswbands);
+  auto aer_sw_ssa_bnds = view_3d<Real>("",2,ncols,nswbands);
+  auto aer_sw_tau_bnds = view_3d<Real>("",2,ncols,nswbands);
+  auto aer_lw_tau_bnds = view_3d<Real>("",2,ncols,nlwbands);
+  auto ccn3_bnds_h       = Kokkos::create_mirror_view(ccn3_bnds      );
+  auto aer_sw_g_bnds_h   = Kokkos::create_mirror_view(aer_sw_g_bnds  );
+  auto aer_sw_ssa_bnds_h = Kokkos::create_mirror_view(aer_sw_ssa_bnds);
+  auto aer_sw_tau_bnds_h = Kokkos::create_mirror_view(aer_sw_tau_bnds);
+  auto aer_lw_tau_bnds_h = Kokkos::create_mirror_view(aer_lw_tau_bnds);
+  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
+    for (int kk=0;kk<nlevs;kk++) {
+      int kpack = kk / Spack::n;
+      int kidx  = kk % Spack::n;
+//      REQUIRE(ccn3_h(dof_i,kpack)[kidx] >= 0);
+      Real tmp_min, tmp_max;
+      tmp_min = std::min(ccn3_beg(dof_i,kpack)[kidx],ccn3_end(dof_i,kpack)[kidx]);
+      tmp_max = std::max(ccn3_beg(dof_i,kpack)[kidx],ccn3_end(dof_i,kpack)[kidx]);
+      if (kk == 0) {
+        ccn3_bnds_h(0,dof_i) = tmp_min; 
+        ccn3_bnds_h(1,dof_i) = tmp_max;
+      } else {
+        ccn3_bnds_h(0,dof_i) = std::min(ccn3_bnds_h(0,dof_i), tmp_min);
+        ccn3_bnds_h(1,dof_i) = std::max(ccn3_bnds_h(1,dof_i), tmp_max);
+      }
+      for (int n=0;n<nswbands;n++) {
+        Real tmp_min_g, tmp_max_g;
+        tmp_min_g = std::min(aer_g_sw_beg(dof_i,n,kpack)[kidx],aer_g_sw_end(dof_i,n,kpack)[kidx]);
+        tmp_max_g = std::max(aer_g_sw_beg(dof_i,n,kpack)[kidx],aer_g_sw_end(dof_i,n,kpack)[kidx]);
+        Real tmp_min_ssa, tmp_max_ssa;
+        tmp_min_ssa = std::min(aer_ssa_sw_beg(dof_i,n,kpack)[kidx],aer_ssa_sw_end(dof_i,n,kpack)[kidx]);
+        tmp_max_ssa = std::max(aer_ssa_sw_beg(dof_i,n,kpack)[kidx],aer_ssa_sw_end(dof_i,n,kpack)[kidx]);
+        Real tmp_min_tau, tmp_max_tau;
+        tmp_min_tau = std::min(aer_tau_sw_beg(dof_i,n,kpack)[kidx],aer_tau_sw_end(dof_i,n,kpack)[kidx]);
+        tmp_max_tau = std::max(aer_tau_sw_beg(dof_i,n,kpack)[kidx],aer_tau_sw_end(dof_i,n,kpack)[kidx]);
+
+        if (kk == 0) {
+          aer_sw_g_bnds_h(0,dof_i,n)   = tmp_min_g; 
+          aer_sw_g_bnds_h(1,dof_i,n)   = tmp_max_g;
+          aer_sw_tau_bnds_h(0,dof_i,n) = tmp_min_tau;
+          aer_sw_tau_bnds_h(1,dof_i,n) = tmp_max_tau;
+          aer_sw_ssa_bnds_h(0,dof_i,n) = tmp_min_ssa;
+          aer_sw_ssa_bnds_h(1,dof_i,n) = tmp_max_ssa;
+        } else {
+          aer_sw_g_bnds_h(0,dof_i,n)   = std::min(aer_sw_g_bnds_h(0,dof_i,n),  tmp_min_g); 
+          aer_sw_g_bnds_h(1,dof_i,n)   = std::max(aer_sw_g_bnds_h(1,dof_i,n),  tmp_max_g);
+          aer_sw_tau_bnds_h(0,dof_i,n) = std::min(aer_sw_tau_bnds_h(0,dof_i,n),tmp_min_tau);
+          aer_sw_tau_bnds_h(1,dof_i,n) = std::max(aer_sw_tau_bnds_h(1,dof_i,n),tmp_max_tau);
+          aer_sw_ssa_bnds_h(0,dof_i,n) = std::min(aer_sw_ssa_bnds_h(0,dof_i,n),tmp_min_ssa);
+          aer_sw_ssa_bnds_h(1,dof_i,n) = std::max(aer_sw_ssa_bnds_h(1,dof_i,n),tmp_max_ssa);
+        }
+      }
+      for (int n=0;n<nlwbands;n++) {
+        Real tmp_min_tau, tmp_max_tau;
+        tmp_min_tau = std::min(aer_tau_lw_beg(dof_i,n,kpack)[kidx],aer_tau_lw_end(dof_i,n,kpack)[kidx]);
+        tmp_max_tau = std::max(aer_tau_lw_beg(dof_i,n,kpack)[kidx],aer_tau_lw_end(dof_i,n,kpack)[kidx]);
+        if (kk == 0) {
+          aer_lw_tau_bnds_h(0,dof_i,n) = tmp_min_tau;
+          aer_lw_tau_bnds_h(1,dof_i,n) = tmp_max_tau;
+        } else {
+          aer_lw_tau_bnds_h(0,dof_i,n) = std::min(aer_lw_tau_bnds_h(0,dof_i,n), tmp_min_tau);
+          aer_lw_tau_bnds_h(1,dof_i,n) = std::max(aer_lw_tau_bnds_h(1,dof_i,n), tmp_max_tau);
+        }
+      }
+    }
+  }
+  // Make sure the extremes are within a reasonable range, then check that the interpolated data is within the extremes.
+  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
+    REQUIRE(ccn3_bnds_h(0,dof_i)>=0.0);
+    for (int n=0;n<nswbands;n++) {
+      REQUIRE(aer_sw_g_bnds_h  (0,dof_i,n) >= -1.0 );
+      REQUIRE(aer_sw_ssa_bnds_h(0,dof_i,n) >=  0.0 );
+      REQUIRE(aer_sw_tau_bnds_h(0,dof_i,n) >=  0.0 );
+      REQUIRE(aer_sw_g_bnds_h  (1,dof_i,n) <=  1.01 );
+      REQUIRE(aer_sw_ssa_bnds_h(1,dof_i,n) <=  1.0 );
+    }
+    for (int n=0;n<nlwbands;n++) {
+      REQUIRE(aer_lw_tau_bnds_h(0,dof_i,n) >=  0.0 );
+    }
+  }
+
+  // Make sure the output data is within the same bounds as the input data.
+  Real tol = 1.1;
+  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
+    for (int kk=0;kk<nlevs;kk++) {
+      int kpack = kk / Spack::n;
+      int kidx  = kk % Spack::n;
+      REQUIRE(ccn3_h(dof_i,kpack)[kidx]>=tol*ccn3_bnds_h(0,dof_i));
+      REQUIRE(ccn3_h(dof_i,kpack)[kidx]<=tol*ccn3_bnds_h(1,dof_i));
+      for (int n=0;n<nswbands;n++) {
+        REQUIRE(aer_g_sw_h(dof_i,n,kpack)[kidx]   >= tol*aer_sw_g_bnds_h  (0,dof_i,n) );
+        REQUIRE(aer_ssa_sw_h(dof_i,n,kpack)[kidx] >= tol*aer_sw_ssa_bnds_h(0,dof_i,n) );
+        REQUIRE(aer_tau_sw_h(dof_i,n,kpack)[kidx] >= tol*aer_sw_tau_bnds_h(0,dof_i,n) );
+        REQUIRE(aer_g_sw_h(dof_i,n,kpack)[kidx]   <= tol*aer_sw_g_bnds_h  (1,dof_i,n) );
+        REQUIRE(aer_ssa_sw_h(dof_i,n,kpack)[kidx] <= tol*aer_sw_ssa_bnds_h(1,dof_i,n) );
+        REQUIRE(aer_tau_sw_h(dof_i,n,kpack)[kidx] <= tol*aer_sw_tau_bnds_h(1,dof_i,n) );
+      }
+      for (int n=0;n<nlwbands;n++) {
+        REQUIRE(aer_tau_lw_h(dof_i,n,kpack)[kidx] >= tol*aer_lw_tau_bnds_h(0,dof_i,n) );
+        REQUIRE(aer_tau_lw_h(dof_i,n,kpack)[kidx] <= tol*aer_lw_tau_bnds_h(1,dof_i,n) );
+      }
+    }
+  }
+
+
+
+
+  // All Done 
+  scorpio::eam_pio_finalize();
+} // run_property
+
+} // namespace
+

--- a/components/scream/src/physics/spa/tests/spa_main_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_main_test.cpp
@@ -353,28 +353,25 @@ TEST_CASE("spa_read_data","spa")
   using col_type = view_1d<Real>::HostMirror;
   auto check_bounds = [&](const col_type& data,const col_type& output) {
     auto data_minmax   = compute_max_min(data,0,nlevs+1);
-    auto output_minmax = compute_max_min(output,0,nlevs);
-    REQUIRE( data_minmax.first  >= output_minmax.first );
+    auto output_minmax = compute_max_min(output,0,nlevs-1);
+    REQUIRE( data_minmax.first  <= output_minmax.first );
     REQUIRE( data_minmax.second >= output_minmax.second );
   };
 
   for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
+    auto ssv = [&](const view_3d<Spack>& v, const int col, const int band) -> col_type {
+      return ekat::subview(ekat::scalarize(v),col,band);
+    };
     const auto& ccn3_in  = ekat::subview(ekat::scalarize(ccn3_beg),dof_i);
     const auto& ccn3_out = ekat::subview(ekat::scalarize(ccn3_h),dof_i);
     check_bounds( ccn3_in, ccn3_out );
     for (int n=0;n<nswbands;n++) {
-      auto ssv = [&](const view_3d<Spack>& v, const int dof_i, const int n) -> col_type {
-        return ekat::subview(ekat::scalarize(v),dof_i,n);
-      };
-      check_bounds (ssv(aer_g_sw_h,dof_i,n),ssv(aer_g_sw_beg,dof_i,n));
-      check_bounds (ssv(aer_ssa_sw_h,dof_i,n),ssv(aer_ssa_sw_beg,dof_i,n));
-      check_bounds (ssv(aer_tau_sw_h,dof_i,n),ssv(aer_tau_sw_beg,dof_i,n));
+      check_bounds (ssv(aer_g_sw_beg,dof_i,n),ssv(aer_g_sw_h,dof_i,n));
+      check_bounds (ssv(aer_ssa_sw_beg,dof_i,n),ssv(aer_ssa_sw_h,dof_i,n));
+      check_bounds (ssv(aer_tau_sw_beg,dof_i,n),ssv(aer_tau_sw_h,dof_i,n));
     }
     for (int n=0;n<nlwbands;n++) {
-      auto ssv = [&](const view_3d<Spack>& v, const int dof_i, const int n) -> col_type {
-        return ekat::subview(ekat::scalarize(v),dof_i,n);
-      };
-      check_bounds (ssv(aer_tau_lw_h,dof_i,n),ssv(aer_tau_lw_beg,dof_i,n));
+      check_bounds (ssv(aer_tau_lw_beg,dof_i,n),ssv(aer_tau_lw_h,dof_i,n));
     }
   }
  /* ====================================================================

--- a/components/scream/src/physics/spa/tests/spa_main_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_main_test.cpp
@@ -359,7 +359,7 @@ TEST_CASE("spa_read_data","spa")
   };
 
   for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
-    auto ssv = [&](const view_3d<Spack>& v, const int col, const int band) -> col_type {
+    auto ssv = [&](const view_3d<Spack>::HostMirror& v, const int col, const int band) -> col_type {
       return ekat::subview(ekat::scalarize(v),col,band);
     };
     const auto& ccn3_in  = ekat::subview(ekat::scalarize(ccn3_beg),dof_i);

--- a/components/scream/src/physics/spa/tests/spa_main_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_main_test.cpp
@@ -366,7 +366,15 @@ TEST_CASE("spa_read_data","spa")
       auto ssv = [&](const view_3d<Spack>& v, const int dof_i, const int n) -> col_type {
         return ekat::subview(ekat::scalarize(v),dof_i,n);
       };
+      check_bounds (ssv(aer_g_sw_h,dof_i,n),ssv(aer_g_sw_beg,dof_i,n));
       check_bounds (ssv(aer_ssa_sw_h,dof_i,n),ssv(aer_ssa_sw_beg,dof_i,n));
+      check_bounds (ssv(aer_tau_sw_h,dof_i,n),ssv(aer_tau_sw_beg,dof_i,n));
+    }
+    for (int n=0;n<nlwbands;n++) {
+      auto ssv = [&](const view_3d<Spack>& v, const int dof_i, const int n) -> col_type {
+        return ekat::subview(ekat::scalarize(v),dof_i,n);
+      };
+      check_bounds (ssv(aer_tau_lw_h,dof_i,n),ssv(aer_tau_lw_beg,dof_i,n));
     }
   }
  /* ====================================================================


### PR DESCRIPTION
This new test focuses on the spa_main routine and will check the
temporal and vertical interpolation of SPA data.  It has three parts:

1. It checks that if the timestamp is at the beginning of the month
   with the same pressure profile as the SPA data the interpolated
   data matches the SPA input data for the beginning of the month.
2. It checks the same as with (1) except when the timestamp is at
   the end of the month.
3. It picks a few days into the month and checks that the interpolated
   data remains within the bounds of the actual SPA data.
   Note, it forces the vertical interpolation to handle cases when the
   target pressure profile is outside of the data pressure profile by
   constructing a target pressure profile with a surface pressure that
   is 5% bigger.

This commit also changes where the hybrid coordinate system is read for
input SPA data, rather than using the local hybrid coordinate system, which
could be different than the SPA data, it grabs the hybrid levels directly
from the SPA data file.

Finally, using padding for the SPA source data, this commit takes care of an
issue where extrapolated data was far out of reasonable bounds for SPA data.
The new approach more closely mirrors what is currently being done in the F90
implementation of the SPA interpolation.