### PR TITLE
Fix to get past insufficient slots error

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -545,6 +545,9 @@
    </batch_system>
 
    <batch_system MACH="weaver" type="lsf" >
+     <submit_args>
+       <arg flag="-n" name=" $TOTALPES/$MAX_MPITASKS_PER_NODE"/>
+     </submit_args>
      <queues>
        <queue walltimemax="02:00" default="true">rhel7W</queue>
      </queues>


### PR DESCRIPTION
Forgot to push this in last PR. I have no idea why the insufficient slots error was happening because, in the batch script directives, it was asking for 24 slots. bsub on weaver seems to insist this is provided as a command line argument?