### PR TITLE
Change weaver to use netcdf mode for PIO

### DIFF
--- a/cime_config/machines/config_pio.xml
+++ b/cime_config/machines/config_pio.xml
@@ -52,6 +52,7 @@
       <value mach="userdefined">netcdf</value>
       <value mach="melvin">netcdf</value>
       <value mach="mappy">netcdf</value>
+      <value mach="weaver">netcdf</value>
       <value mach="eastwind">netcdf</value>
       <value mach="constance">netcdf</value>
       <value mach="cascade">netcdf</value>


### PR DESCRIPTION
Fixes SMS_D_Ln2_P24x1.ne4_ne4.F2000-SCREAMv1-AQP1, and it actually passes now!

SMS_D_Ln2_P24x1.ne4_ne4.F2000SCREAMv1.weaver_gnugpu.scream-30min_ts still fails with an error coming from elm (land):

```
 check_downscale_consistency ERROR: column-level forcing differs from gridcell-level forcing for urban point
 c, g =         4183         280
 ENDRUN:ERROR in /home/jgfouca/scream/components/elm/src/main/atm2lndMod.F90 at line 440
```

At this point, I may have to ask for outside assistance since I don't know the first thing about elm.