### PR TITLE
SCREAM: fix test-all-scream support for arbitrary work dir

### DIFF
--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -149,7 +149,8 @@ class TestAllScream(object):
                    "Bad root-dir '{}', should be: $scream_repo/components/scream".format(self._root_dir))
 
         if self._work_dir is not None:
-            expect(Path(self._work_dir).absolute().is_dir(),
+            self._work_dir = Path(self._work_dir).absolute()
+            expect(self._work_dir.is_dir(),
                    "Error! Work directory '{}' does not exist.".format(self._work_dir))
         else:
             self._work_dir = self._root_dir.absolute().joinpath("ctest-build")


### PR DESCRIPTION
 Before this fix, running `./scripts/test-all-scream -w my_dir -t dbg ...` would
 
 - put the ctest resource file in `./my_dir/full_debug`
 - build the project in `./my_dir/full_debug/my_dir/full_debug`
 
Resolving work dir as an absolute path (like it's done for the default one) seems to fix this.

@jgfouca I suspect we don't test this feature (and it's not that crucial), so I'm integrating without testing.