### PR TITLE
Fix model_restart test on GPU

### DIFF
--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -1,8 +1,11 @@
+include(EkatUtils)
+include(EkatSetCompilerFlags
+)
 # Add CUDA flags for YAKL
 set(YAKL_CXX_FLAGS "")
 if (CUDA_BUILD)
-    set(YAKL_ARCH "CUDA")
-    list(APPEND YAKL_CXX_FLAGS -DYAKL_ARCH_CUDA --expt-extended-lambda --expt-relaxed-constexpr)
+  set(YAKL_ARCH "CUDA")
+  list(APPEND YAKL_CXX_FLAGS -DYAKL_ARCH_CUDA --expt-extended-lambda --expt-relaxed-constexpr)
 endif()
 
 # RRTMGP++ requires YAKL
@@ -28,6 +31,7 @@ set(EXTERNAL_SRC
 )
 add_library(rrtmgp ${EXTERNAL_SRC})
 EkatDisableAllWarning(rrtmgp)
+SetCudaFlags(rrtmgp)
 target_link_libraries(rrtmgp PUBLIC yakl)
 target_include_directories(rrtmgp PUBLIC 
     ${SCREAM_BASE_DIR}/../../externals/YAKL

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
@@ -19,7 +19,7 @@ set (NEED_LIBS cld_fraction shoc p3 scream_rrtmgp rrtmgp ${NETCDF_C} ${dynLibNam
 # We can use the same namelist for all tests, using 3 different input yaml files
 
 # Create a single executable for all the 3 runs
-CreateUnitTestExec(model_restart model_restart.cpp "${NEED_LIBS};ekat_test_main;ekat_test_session;ekat")
+CreateUnitTestExec(model_restart model_restart.cpp "${NEED_LIBS}")
 
 # Create the baseline (run all 6 timsteps in a single run)
 CreateUnitTestFromExec(model_baseline model_restart


### PR DESCRIPTION
The test was failing since, after the last ekat update (which moved CUDA flags out of CMAKE_CXX_FLAGS, in favor of a per-target basis) we were no longer setting `--fmad=false` on rrtmgp.

This PR also updates EKAT.

Fixes #1453 