### PR TITLE
SCREAM: disable baselines logic for certain builds in test-all-scream

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -214,6 +214,12 @@ set(SCREAM_BASELINES_ONLY FALSE CACHE BOOL "Whether building only baselines-rela
 # has the sole purpose of detecting memory errors. For these builds, we can disable baselines tests
 set(SCREAM_ENABLE_BASELINES_TESTS TRUE CACHE BOOL "Whether to run baselines-related tests")
 
+if (SCREAM_BASELINES_ONLY AND NOT SCREAM_ENABLE_BASELINES_TESTS)
+  message (FATAL_ERROR
+    "Makes no sense to set SCREAM_BASELINES_ONLY=ON,\n"
+    "but set SCREAM_ENABLE_BASELINES_TESTS=OFF.")
+endif()
+
 # Set number of vertical levels
 set(SCREAM_NUM_VERTICAL_LEV ${DEFAULT_NUM_VERTICAL_LEV} CACHE STRING
     "The number of levels used in the vertical grid."

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -212,12 +212,12 @@ set(SCREAM_BASELINES_ONLY FALSE CACHE BOOL "Whether building only baselines-rela
 
 # Certain builds are not meant to compare against baselines. For instance, a valgrind build
 # has the sole purpose of detecting memory errors. For these builds, we can disable baselines tests
-set(SCREAM_ENABLE_BASELINES_TESTS TRUE CACHE BOOL "Whether to run baselines-related tests")
+set(SCREAM_ENABLE_BASELINE_TESTS TRUE CACHE BOOL "Whether to run baselines-related tests")
 
-if (SCREAM_BASELINES_ONLY AND NOT SCREAM_ENABLE_BASELINES_TESTS)
+if (SCREAM_BASELINES_ONLY AND NOT SCREAM_ENABLE_BASELINE_TESTS)
   message (FATAL_ERROR
     "Makes no sense to set SCREAM_BASELINES_ONLY=ON,\n"
-    "but set SCREAM_ENABLE_BASELINES_TESTS=OFF.")
+    "but set SCREAM_ENABLE_BASELINE_TESTS=OFF.")
 endif()
 
 # Set number of vertical levels

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -206,9 +206,13 @@ endif()
 set(SCREAM_INPUT_ROOT ${DEFAULT_SCREAM_INPUT_ROOT} CACHE FILEPATH "Root of downloaded input files. Should match DIN_LOC_ROOT on CIME machines")
 
 # Assuming SCREAM_LIB_ONLY is FALSE (else, no exec is built at all), we provide the option
-# of building only baseline-related execs. By default, this option is off (menaing "build everything).
+# of building only baseline-related execs. By default, this option is off (menaing "build everything").
 # However, when generating baselines, this can be useful to reduce the amount of stuff compiled.
 set(SCREAM_BASELINES_ONLY FALSE CACHE BOOL "Whether building only baselines-related executables")
+
+# Certain builds are not meant to compare against baselines. For instance, a valgrind build
+# has the sole purpose of detecting memory errors. For these builds, we can disable baselines tests
+set(SCREAM_ENABLE_BASELINES_TESTS TRUE CACHE BOOL "Whether to run baselines-related tests")
 
 # Set number of vertical levels
 set(SCREAM_NUM_VERTICAL_LEV ${DEFAULT_NUM_VERTICAL_LEV} CACHE STRING

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -100,16 +100,20 @@ class TestAllScream(object):
             "fpe" : [("CMAKE_BUILD_TYPE", "Debug"),
                      ("SCREAM_PACK_SIZE", "1"),
                      ("SCREAM_SMALL_PACK_SIZE", "1"),
+                     ("SCREAM_ENABLE_BASELINE_TESTS", "False"),
                      ("EKAT_DEFAULT_BFB", "True")],
             "opt" : [("CMAKE_BUILD_TYPE", "Release")],
             "valg" : [("CMAKE_BUILD_TYPE", "Debug"),
                       ("SCREAM_TEST_PROFILE", "SHORT"),
+                     ("SCREAM_ENABLE_BASELINE_TESTS", "False"),
                       ("EKAT_ENABLE_VALGRIND", "True")],
             "cmc"  : [("CMAKE_BUILD_TYPE", "Debug"),
                       ("SCREAM_TEST_PROFILE", "SHORT"),
+                     ("SCREAM_ENABLE_BASELINE_TESTS", "False"),
                       ("EKAT_ENABLE_CUDA_MEMCHECK", "True")],
             "cov" : [("CMAKE_BUILD_TYPE", "Debug"),
-                      ("EKAT_ENABLE_COVERAGE", "True")],
+                     ("SCREAM_ENABLE_BASELINE_TESTS", "False"),
+                     ("EKAT_ENABLE_COVERAGE", "True")],
         }
 
         if self._quick_rerun_failed:

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -385,7 +385,7 @@ class TestAllScream(object):
     ###############################################################################
         """
         Check that all baselines are present (one subdir for all values of self._tests)
-        Note: if selt._test_uses_baselines[test]=False, skip the check
+        Note: if self._test_uses_baselines[test]=False, skip the check
         """
         # Sanity check
         expect(self._baseline_dir is not None,
@@ -416,7 +416,7 @@ class TestAllScream(object):
         expect(self._baseline_dir is not None, "Error! This routine should only be called when testing against pre-existing baselines.")
 
         for test in self._tests:
-            if selt._test_uses_baselines[test] and test not in self._tests_needing_baselines:
+            if self._test_uses_baselines[test] and test not in self._tests_needing_baselines:
                 # this test is not missing a baseline, but it may be expired.
 
                 baseline_file_sha = self.get_baseline_file_sha(test)

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ if (NOT SCREAM_BASELINES_ONLY)
                  LABELS "p3;physics;fail")
 endif()
 
-if (SCREAM_BASELINES_ONLY OR SCREAM_ENABLE_BASELINES_TESTS)
+if (SCREAM_ENABLE_BASELINES_TESTS)
   CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                  THREADS ${SCREAM_TEST_MAX_THREADS}
                  EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
@@ -92,18 +92,18 @@ if (SCREAM_BASELINES_ONLY OR SCREAM_ENABLE_BASELINES_TESTS)
                  PROPERTIES FIXTURES_REQUIRED p3_tables WILL_FAIL ${FORCE_RUN_DIFF_FAILS}
                  EXCLUDE_MAIN_CPP
                  LABELS "p3;physics;fail")
+
+  # By default, baselines should be created using all fortran (make baseline). If the user wants
+  # to use CXX to generate their baselines, they should use "make baseline_cxx".
+
+  add_custom_target(p3_baseline_f90
+    COMMAND ${CMAKE_COMMAND} -E env OMP_NUM_THREADS=${SCREAM_TEST_MAX_THREADS} $<TARGET_FILE:p3_run_and_cmp_f90> -f -g -b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline)
+
+  add_custom_target(p3_baseline_cxx
+    COMMAND ${CMAKE_COMMAND} -E env OMP_NUM_THREADS=${SCREAM_TEST_MAX_THREADS} $<TARGET_FILE:p3_run_and_cmp_cxx> -g -b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline)
+
+  add_dependencies(baseline     p3_baseline_f90)
+  add_dependencies(baseline_cxx p3_baseline_cxx)
 endif()
-
-# By default, baselines should be created using all fortran (make baseline). If the user wants
-# to use CXX to generate their baselines, they should use "make baseline_cxx".
-
-add_custom_target(p3_baseline_f90
-  COMMAND ${CMAKE_COMMAND} -E env OMP_NUM_THREADS=${SCREAM_TEST_MAX_THREADS} $<TARGET_FILE:p3_run_and_cmp_f90> -f -g -b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline)
-
-add_custom_target(p3_baseline_cxx
-  COMMAND ${CMAKE_COMMAND} -E env OMP_NUM_THREADS=${SCREAM_TEST_MAX_THREADS} $<TARGET_FILE:p3_run_and_cmp_cxx> -g -b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline)
-
-add_dependencies(baseline     p3_baseline_f90)
-add_dependencies(baseline_cxx p3_baseline_cxx)
 
 GetInputFile(tables/p3_lookup_table_1.dat-v4.1.1 data/p3_lookup_table_1.dat-v4.1.1)

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ if (NOT SCREAM_BASELINES_ONLY)
                  LABELS "p3;physics;fail")
 endif()
 
-if (SCREAM_ENABLE_BASELINES_TESTS)
+if (SCREAM_ENABLE_BASELINE_TESTS)
   CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}"
                  THREADS ${SCREAM_TEST_MAX_THREADS}
                  EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"

--- a/components/scream/src/physics/p3/tests/CMakeLists.txt
+++ b/components/scream/src/physics/p3/tests/CMakeLists.txt
@@ -55,7 +55,7 @@ else ()
 endif()
 
 # NOTE: tests inside this if statement won't be built in a baselines-only build
-if (NOT ${SCREAM_BASELINES_ONLY})
+if (NOT SCREAM_BASELINES_ONLY)
   CreateUnitTest(p3_tests "${P3_TESTS_SRCS}" "${NEED_LIBS}"
                  THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC}
                  PROPERTIES FIXTURES_REQUIRED p3_tables
@@ -69,28 +69,30 @@ if (NOT ${SCREAM_BASELINES_ONLY})
                  LABELS "p3;physics;fail")
 endif()
 
-CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}"
-               THREADS ${SCREAM_TEST_MAX_THREADS}
-               EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
-               PROPERTIES FIXTURES_REQUIRED p3_tables
-               EXCLUDE_MAIN_CPP
-               LABELS "p3;physics")
+if (SCREAM_BASELINES_ONLY OR SCREAM_ENABLE_BASELINES_TESTS)
+  CreateUnitTest(p3_run_and_cmp_cxx "p3_run_and_cmp.cpp" "${NEED_LIBS}"
+                 THREADS ${SCREAM_TEST_MAX_THREADS}
+                 EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
+                 PROPERTIES FIXTURES_REQUIRED p3_tables
+                 EXCLUDE_MAIN_CPP
+                 LABELS "p3;physics")
 
-CreateUnitTest(p3_run_and_cmp_f90 "p3_run_and_cmp.cpp" "${NEED_LIBS}"
-               THREADS ${SCREAM_TEST_MAX_THREADS}
-               EXE_ARGS "-f -b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
-               PROPERTIES FIXTURES_REQUIRED p3_tables
-               EXCLUDE_MAIN_CPP
-               LABELS "p3;physics")
+  CreateUnitTest(p3_run_and_cmp_f90 "p3_run_and_cmp.cpp" "${NEED_LIBS}"
+                 THREADS ${SCREAM_TEST_MAX_THREADS}
+                 EXE_ARGS "-f -b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
+                 PROPERTIES FIXTURES_REQUIRED p3_tables
+                 EXCLUDE_MAIN_CPP
+                 LABELS "p3;physics")
 
-# Make sure that a diff from baselines triggers a failed test (in debug only)
-CreateUnitTest(p3_run_and_cmp_cxx_fail "p3_run_and_cmp.cpp" "${NEED_LIBS}"
-               COMPILER_CXX_DEFS SCREAM_FORCE_RUN_DIFF
-               THREADS ${SCREAM_TEST_MAX_THREADS}
-               EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
-               PROPERTIES FIXTURES_REQUIRED p3_tables WILL_FAIL ${FORCE_RUN_DIFF_FAILS}
-               EXCLUDE_MAIN_CPP
-               LABELS "p3;physics;fail")
+  # Make sure that a diff from baselines triggers a failed test (in debug only)
+  CreateUnitTest(p3_run_and_cmp_cxx_fail "p3_run_and_cmp.cpp" "${NEED_LIBS}"
+                 COMPILER_CXX_DEFS SCREAM_FORCE_RUN_DIFF
+                 THREADS ${SCREAM_TEST_MAX_THREADS}
+                 EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/p3_run_and_cmp.baseline"
+                 PROPERTIES FIXTURES_REQUIRED p3_tables WILL_FAIL ${FORCE_RUN_DIFF_FAILS}
+                 EXCLUDE_MAIN_CPP
+                 LABELS "p3;physics;fail")
+endif()
 
 # By default, baselines should be created using all fortran (make baseline). If the user wants
 # to use CXX to generate their baselines, they should use "make baseline_cxx".

--- a/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
@@ -1,45 +1,45 @@
 include(ScreamUtils)
 
-# Required libraries
-set (NEED_LIBS scream_rrtmgp)
+# NOTE: tests inside this if statement won't be built in a baselines-only build
+if (NOT SCREAM_BASELINES_ONLY)
+  # Required libraries
+  set (NEED_LIBS scream_rrtmgp)
 
-# NOTE: tests inside this if statement are run only if this build has baseline tests
-if (NOT SCREAM_BASELINES_ONLY AND SCREAM_ENABLE_BASELINES_TESTS)
-    CreateUnitTest(
-        rrtmgp_tests rrtmgp_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"
-        EXE_ARGS "-i ${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc -b ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc"
-        EXCLUDE_MAIN_CPP
-    )
-    CreateUnitTest(
-        rrtmgp_unit_tests rrtmgp_unit_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"
-    )
+  CreateUnitTest(
+      rrtmgp_tests rrtmgp_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"
+      EXE_ARGS "-i ${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc -b ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc"
+      EXCLUDE_MAIN_CPP
+  )
+  CreateUnitTest(
+      rrtmgp_unit_tests rrtmgp_unit_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"
+  )
+
+  # Build baseline code
+  add_executable(generate_baseline generate_baseline.cpp)
+  target_link_libraries(generate_baseline PUBLIC ${NEED_LIBS})
+
+  # Copy RRTMGP absorption coefficient lookup tables to local data directory
+  # TODO: RRTMGP code and data should live in higher level "externals" directory
+  # not in the "eam" directory. We ultimately do not want dependencies on
+  # anything in EAM.
+  file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
+
+  configure_file(${EAM_RRTMGP_DIR}/external/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
+                 ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
+  configure_file(${EAM_RRTMGP_DIR}/external/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
+                 ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
+  configure_file(${EAM_RRTMGP_DIR}/external/examples/all-sky/rrtmgp-allsky.nc
+                 ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
+  configure_file(${EAM_RRTMGP_DIR}/external/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-sw.nc
+                 ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
+  configure_file(${EAM_RRTMGP_DIR}/external/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-lw.nc
+                 ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
+
+  add_custom_target(rrtmgp_allsky_baseline.nc
+      COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:generate_baseline>
+              ${EAM_RRTMGP_DIR}/external/examples/all-sky/rrtmgp-allsky.nc
+              ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc
+  )
+
+  add_dependencies(baseline rrtmgp_allsky_baseline.nc)
 endif()
-
-# Build baseline code
-add_executable(generate_baseline generate_baseline.cpp)
-target_link_libraries(generate_baseline PUBLIC ${NEED_LIBS})
-
-# Copy RRTMGP absorption coefficient lookup tables to local data directory
-# TODO: RRTMGP code and data should live in higher level "externals" directory
-# not in the "eam" directory. We ultimately do not want dependencies on
-# anything in EAM.
-file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
-
-configure_file(${EAM_RRTMGP_DIR}/external/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
-               ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
-configure_file(${EAM_RRTMGP_DIR}/external/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
-               ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
-configure_file(${EAM_RRTMGP_DIR}/external/examples/all-sky/rrtmgp-allsky.nc
-               ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
-configure_file(${EAM_RRTMGP_DIR}/external/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-sw.nc
-               ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
-configure_file(${EAM_RRTMGP_DIR}/external/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-lw.nc
-               ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
-
-add_custom_target(rrtmgp_allsky_baseline.nc
-    COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:generate_baseline>
-            ${EAM_RRTMGP_DIR}/external/examples/all-sky/rrtmgp-allsky.nc
-            ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc
-)
-
-add_dependencies(baseline rrtmgp_allsky_baseline.nc)

--- a/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
@@ -5,15 +5,6 @@ if (NOT SCREAM_BASELINES_ONLY)
   # Required libraries
   set (NEED_LIBS scream_rrtmgp)
 
-  CreateUnitTest(
-      rrtmgp_tests rrtmgp_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"
-      EXE_ARGS "-i ${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc -b ${SCREAM_BIN_DIR}/data/rrtmgp-allsky-baseline.nc"
-      EXCLUDE_MAIN_CPP
-  )
-  CreateUnitTest(
-      rrtmgp_unit_tests rrtmgp_unit_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"
-  )
-
   # Build baseline code
   add_executable(generate_baseline generate_baseline.cpp)
   target_link_libraries(generate_baseline PUBLIC ${NEED_LIBS})
@@ -36,14 +27,28 @@ if (NOT SCREAM_BASELINES_ONLY)
                  ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
 
   # Generate allsky baseline with the usual cmake custom command-target pair pattern
+  # Note: these "baselines" are not to compare scream with a previous version, but
+  #       rather to compare scream::rrtmgp with raw rrtmgp.
+  file (MAKE_DIRECTORY ${SCREAM_BIN_DIR}/data)
   add_custom_command (
-      OUTPUT  ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc
+      OUTPUT  ${SCREAM_BIN_DIR}/data/rrtmgp-allsky-baseline.nc
       COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:generate_baseline>
               ${EAM_RRTMGP_DIR}/external/examples/all-sky/rrtmgp-allsky.nc
-              ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc
+              ${SCREAM_BIN_DIR}/data/rrtmgp-allsky-baseline.nc
   )
   add_custom_target(rrtmgp_allsky_baseline.nc
-      DEPENDS ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc
+      DEPENDS ${SCREAM_BIN_DIR}/data/rrtmgp-allsky-baseline.nc
+  )
+
+  CreateUnitTest(
+      rrtmgp_tests rrtmgp_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"
+      EXE_ARGS "-i ${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc -b ${SCREAM_BIN_DIR}/data/rrtmgp-allsky-baseline.nc"
+      EXCLUDE_MAIN_CPP
+  )
+  add_dependencies (rrtmgp_tests rrtmgp_allsky_baseline.nc)
+
+  CreateUnitTest(
+      rrtmgp_unit_tests rrtmgp_unit_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"
   )
 
 endif()

--- a/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
@@ -3,8 +3,8 @@ include(ScreamUtils)
 # Required libraries
 set (NEED_LIBS scream_rrtmgp)
 
-# NOTE: tests inside this if statement won't be built in a baselines-only build
-if (NOT ${SCREAM_BASELINES_ONLY})
+# NOTE: tests inside this if statement are run only if this build has baseline tests
+if (NOT SCREAM_BASELINES_ONLY AND SCREAM_ENABLE_BASELINES_TESTS)
     CreateUnitTest(
         rrtmgp_tests rrtmgp_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"
         EXE_ARGS "-i ${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc -b ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc"

--- a/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if (NOT SCREAM_BASELINES_ONLY)
 
   CreateUnitTest(
       rrtmgp_tests rrtmgp_tests.cpp "${NEED_LIBS}" LABELS "rrtmgp;physics"
-      EXE_ARGS "-i ${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc -b ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc"
+      EXE_ARGS "-i ${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc -b ${SCREAM_BIN_DIR}/data/rrtmgp-allsky-baseline.nc"
       EXCLUDE_MAIN_CPP
   )
   CreateUnitTest(
@@ -35,11 +35,15 @@ if (NOT SCREAM_BASELINES_ONLY)
   configure_file(${EAM_RRTMGP_DIR}/external/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-lw.nc
                  ${CMAKE_CURRENT_BINARY_DIR}/data COPYONLY)
 
-  add_custom_target(rrtmgp_allsky_baseline.nc
+  # Generate allsky baseline with the usual cmake custom command-target pair pattern
+  add_custom_command (
+      OUTPUT  ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc
       COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:generate_baseline>
               ${EAM_RRTMGP_DIR}/external/examples/all-sky/rrtmgp-allsky.nc
               ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc
   )
+  add_custom_target(rrtmgp_allsky_baseline.nc
+      DEPENDS ${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc
+  )
 
-  add_dependencies(baseline rrtmgp_allsky_baseline.nc)
 endif()

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -72,19 +72,21 @@ set(SHOC_TESTS_SRCS
     ) # SHOC_TESTS_SRCS
 
 # NOTE: tests inside this if statement won't be built in a baselines-only build
-if (NOT ${SCREAM_BASELINES_ONLY})
+if (NOT SCREAM_BASELINES_ONLY)
   CreateUnitTest(shoc_tests "${SHOC_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP shoc_tests_ut_np1_omp1)
 endif()
 
-CreateUnitTest(shoc_run_and_cmp_cxx "shoc_run_and_cmp.cpp" "${NEED_LIBS}"
-               THREADS ${SCREAM_TEST_MAX_THREADS}
-               EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
-               EXCLUDE_MAIN_CPP)
+if (SCREAM_BASELINES_ONLY OR SCREAM_RUN_BASELINES_TESTS)
+  CreateUnitTest(shoc_run_and_cmp_cxx "shoc_run_and_cmp.cpp" "${NEED_LIBS}"
+                 THREADS ${SCREAM_TEST_MAX_THREADS}
+                 EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
+                 EXCLUDE_MAIN_CPP)
 
-CreateUnitTest(shoc_run_and_cmp_f90 "shoc_run_and_cmp.cpp" "${NEED_LIBS}"
-               THREADS ${SCREAM_TEST_MAX_THREADS}
-               EXE_ARGS "-f -b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
-               EXCLUDE_MAIN_CPP)
+  CreateUnitTest(shoc_run_and_cmp_f90 "shoc_run_and_cmp.cpp" "${NEED_LIBS}"
+                 THREADS ${SCREAM_TEST_MAX_THREADS}
+                 EXE_ARGS "-f -b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
+                 EXCLUDE_MAIN_CPP)
+endif()
 
 # By default, baselines should be created using all fortran (make baseline). If the user wants
 # to use CXX to generate their baselines, they should use "make baseline_cxx".

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -76,7 +76,7 @@ if (NOT SCREAM_BASELINES_ONLY)
   CreateUnitTest(shoc_tests "${SHOC_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP shoc_tests_ut_np1_omp1)
 endif()
 
-if (SCREAM_ENABLE_BASELINES_TESTS)
+if (SCREAM_ENABLE_BASELINE_TESTS)
   CreateUnitTest(shoc_run_and_cmp_cxx "shoc_run_and_cmp.cpp" "${NEED_LIBS}"
                  THREADS ${SCREAM_TEST_MAX_THREADS}
                  EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"

--- a/components/scream/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/scream/src/physics/shoc/tests/CMakeLists.txt
@@ -76,7 +76,7 @@ if (NOT SCREAM_BASELINES_ONLY)
   CreateUnitTest(shoc_tests "${SHOC_TESTS_SRCS}" "${NEED_LIBS}" THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC} DEP shoc_tests_ut_np1_omp1)
 endif()
 
-if (SCREAM_BASELINES_ONLY OR SCREAM_RUN_BASELINES_TESTS)
+if (SCREAM_ENABLE_BASELINES_TESTS)
   CreateUnitTest(shoc_run_and_cmp_cxx "shoc_run_and_cmp.cpp" "${NEED_LIBS}"
                  THREADS ${SCREAM_TEST_MAX_THREADS}
                  EXE_ARGS "-b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
@@ -86,16 +86,16 @@ if (SCREAM_BASELINES_ONLY OR SCREAM_RUN_BASELINES_TESTS)
                  THREADS ${SCREAM_TEST_MAX_THREADS}
                  EXE_ARGS "-f -b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline"
                  EXCLUDE_MAIN_CPP)
+
+  # By default, baselines should be created using all fortran (make baseline). If the user wants
+  # to use CXX to generate their baselines, they should use "make baseline_cxx".
+
+  add_custom_target(shoc_baseline_f90
+    COMMAND ${CMAKE_COMMAND} -E env OMP_NUM_THREADS=${SCREAM_TEST_MAX_THREADS} $<TARGET_FILE:shoc_run_and_cmp_f90> -f -g -b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline)
+
+  add_custom_target(shoc_baseline_cxx
+    COMMAND ${CMAKE_COMMAND} -E env OMP_NUM_THREADS=${SCREAM_TEST_MAX_THREADS} $<TARGET_FILE:shoc_run_and_cmp_cxx> -g -b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline)
+
+  add_dependencies(baseline     shoc_baseline_f90)
+  add_dependencies(baseline_cxx shoc_baseline_cxx)
 endif()
-
-# By default, baselines should be created using all fortran (make baseline). If the user wants
-# to use CXX to generate their baselines, they should use "make baseline_cxx".
-
-add_custom_target(shoc_baseline_f90
-  COMMAND ${CMAKE_COMMAND} -E env OMP_NUM_THREADS=${SCREAM_TEST_MAX_THREADS} $<TARGET_FILE:shoc_run_and_cmp_f90> -f -g -b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline)
-
-add_custom_target(shoc_baseline_cxx
-  COMMAND ${CMAKE_COMMAND} -E env OMP_NUM_THREADS=${SCREAM_TEST_MAX_THREADS} $<TARGET_FILE:shoc_run_and_cmp_cxx> -g -b ${SCREAM_TEST_DATA_DIR}/shoc_run_and_cmp.baseline)
-
-add_dependencies(baseline     shoc_baseline_f90)
-add_dependencies(baseline_cxx shoc_baseline_cxx)

--- a/components/scream/tests/coupled/CMakeLists.txt
+++ b/components/scream/tests/coupled/CMakeLists.txt
@@ -1,5 +1,5 @@
 # NOTE: if you have baseline-type tests, add the subdirectory OUTSIDE the following if statement
-if (NOT ${SCREAM_BASELINES_ONLY})
+if (NOT SCREAM_BASELINES_ONLY)
   add_subdirectory(physics_only)
   if (NOT "${SCREAM_DYNAMICS_DYCORE}" STREQUAL "NONE")
     add_subdirectory(dynamics_physics)

--- a/components/scream/tests/uncoupled/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/CMakeLists.txt
@@ -1,5 +1,5 @@
 # NOTE: if you have baseline-type tests, add the subdirectory OUTSIDE the following if statement
-if (NOT ${SCREAM_BASELINES_ONLY})
+if (NOT SCREAM_BASELINES_ONLY)
   if ("${SCREAM_DYNAMICS_DYCORE}" STREQUAL "HOMME")
     add_subdirectory(homme)
   endif()

--- a/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -10,8 +10,11 @@ if (NOT SCREAM_BASELINES_ONLY)
 
   CreateUnitTest(
       rrtmgp_standalone_unit rrtmgp_standalone_unit.cpp "${NEED_LIBS}" LABELS ${TEST_LABELS}
-      EXE_ARGS "--ekat-test-params rrtmgp_inputfile=${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc,rrtmgp_baseline=${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc"
+      EXE_ARGS "--ekat-test-params rrtmgp_inputfile=${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc,rrtmgp_baseline=${SCREAM_BIN_DIR}/data/rrtmgp-allsky-baseline.nc"
   )
+  # This test needs the allsky baselines file
+  add_dependencies (rrtmgp_standalone_unit rrtmgp_allsky_baseline.nc)
+
   target_include_directories(rrtmgp_standalone_unit PUBLIC
         ${SCREAM_BASE_DIR}/src/physics/rrtmgp
         ${SCREAM_BASE_DIR}/src/physics/rrtmgp/tests

--- a/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -1,66 +1,66 @@
 INCLUDE (ScreamUtils)
 
 # Test atmosphere processes
-if (NOT ${SCREAM_BASELINES_ONLY})
+if (NOT SCREAM_BASELINES_ONLY)
 
-    SET (TEST_LABELS "rrtmgp;physics")
-    # Required libraries
-    find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATH}/lib)
-    set (NEED_LIBS scream_rrtmgp rrtmgp ${NETCDF_C} scream_control scream_share physics_share yakl)
+  SET (TEST_LABELS "rrtmgp;physics")
+  # Required libraries
+  find_library(NETCDF_C netcdf HINTS ${NetCDF_C_PATH}/lib)
+  set (NEED_LIBS scream_rrtmgp rrtmgp ${NETCDF_C} scream_control scream_share physics_share yakl)
 
-    CreateUnitTest(
-        rrtmgp_standalone_unit rrtmgp_standalone_unit.cpp "${NEED_LIBS}" LABELS ${TEST_LABELS}
-        EXE_ARGS "--ekat-test-params rrtmgp_inputfile=${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc,rrtmgp_baseline=${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc"
-    )
-    target_include_directories(rrtmgp_standalone_unit PUBLIC
-          ${SCREAM_BASE_DIR}/src/physics/rrtmgp
-          ${SCREAM_BASE_DIR}/src/physics/rrtmgp/tests
-          ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp
-          ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/rrtmgp
-          ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/rrtmgp/kernels
-          ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/rte
-          ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/rte/kernels
-          ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/extensions/cloud_optics
-    )
+  CreateUnitTest(
+      rrtmgp_standalone_unit rrtmgp_standalone_unit.cpp "${NEED_LIBS}" LABELS ${TEST_LABELS}
+      EXE_ARGS "--ekat-test-params rrtmgp_inputfile=${CMAKE_CURRENT_BINARY_DIR}/data/rrtmgp-allsky.nc,rrtmgp_baseline=${SCREAM_TEST_DATA_DIR}/rrtmgp-allsky-baseline.nc"
+  )
+  target_include_directories(rrtmgp_standalone_unit PUBLIC
+        ${SCREAM_BASE_DIR}/src/physics/rrtmgp
+        ${SCREAM_BASE_DIR}/src/physics/rrtmgp/tests
+        ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp
+        ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/rrtmgp
+        ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/rrtmgp/kernels
+        ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/rte
+        ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/rte/kernels
+        ${SCREAM_BASE_DIR}/../eam/src/physics/rrtmgp/external/cpp/extensions/cloud_optics
+  )
 
-    ## Create free running rrtmgp stand alone test that runs from an initial condition file.
-    CreateUnitTest(
-        rrtmgp_standalone "rrtmgp_standalone.cpp" "${NEED_LIBS}" LABELS ${TEST_LABELS}
-        MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-        PROPERTIES FIXTURES_SETUP rrtmgp_generate_output_nc_files
-    )
+  ## Create free running rrtmgp stand alone test that runs from an initial condition file.
+  CreateUnitTest(
+      rrtmgp_standalone "rrtmgp_standalone.cpp" "${NEED_LIBS}" LABELS ${TEST_LABELS}
+      MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+      PROPERTIES FIXTURES_SETUP rrtmgp_generate_output_nc_files
+  )
 
-    # Copy yaml input file to run directory
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_unit.yaml
-                   ${CMAKE_CURRENT_BINARY_DIR}/input_unit.yaml COPYONLY)
+  # Copy yaml input file to run directory
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_unit.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/input_unit.yaml COPYONLY)
 
-    # Copy RRTMGP initial condition to local data directory
-    file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
+  # Copy RRTMGP initial condition to local data directory
+  file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
 
-    # Copy RRTMGP absorption coefficient lookup tables to local data directory
-    GetInputFile(init/rrtmgp-data-sw-g224-2018-12-04.nc
-      ${CMAKE_CURRENT_BINARY_DIR}/data)
-    GetInputFile(init/rrtmgp-data-lw-g256-2018-12-04.nc
-      ${CMAKE_CURRENT_BINARY_DIR}/data)
-    GetInputFile(init/rrtmgp-allsky.nc
-      ${CMAKE_CURRENT_BINARY_DIR}/data)
-    GetInputFile(init/rrtmgp-cloud-optics-coeffs-sw.nc
-      ${CMAKE_CURRENT_BINARY_DIR}/data)
-    GetInputFile(init/rrtmgp-cloud-optics-coeffs-lw.nc
-      ${CMAKE_CURRENT_BINARY_DIR}/data)
+  # Copy RRTMGP absorption coefficient lookup tables to local data directory
+  GetInputFile(init/rrtmgp-data-sw-g224-2018-12-04.nc
+    ${CMAKE_CURRENT_BINARY_DIR}/data)
+  GetInputFile(init/rrtmgp-data-lw-g256-2018-12-04.nc
+    ${CMAKE_CURRENT_BINARY_DIR}/data)
+  GetInputFile(init/rrtmgp-allsky.nc
+    ${CMAKE_CURRENT_BINARY_DIR}/data)
+  GetInputFile(init/rrtmgp-cloud-optics-coeffs-sw.nc
+    ${CMAKE_CURRENT_BINARY_DIR}/data)
+  GetInputFile(init/rrtmgp-cloud-optics-coeffs-lw.nc
+    ${CMAKE_CURRENT_BINARY_DIR}/data)
 
-    # The RRTMGP stand-alone test that runs multi-step
-    # Set AD configurable options
-    SetVarDependingOnTestProfile(NUM_STEPS 2 5 48)
-    set (ATM_TIME_STEP 1800)
+  # The RRTMGP stand-alone test that runs multi-step
+  # Set AD configurable options
+  SetVarDependingOnTestProfile(NUM_STEPS 2 5 48)
+  set (ATM_TIME_STEP 1800)
 
-    ## Copy (and configure) yaml files needed by tests
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-                   ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
-    configure_file(rrtmgp_standalone_output.yaml rrtmgp_standalone_output.yaml)
+  ## Copy (and configure) yaml files needed by tests
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
+  configure_file(rrtmgp_standalone_output.yaml rrtmgp_standalone_output.yaml)
 
-    GetInputFile(init/rrtmgp_init_ne2np4.nc
-      ${CMAKE_CURRENT_BINARY_DIR}/rrtmgp_init_ne2np4.nc)
+  GetInputFile(init/rrtmgp_init_ne2np4.nc
+    ${CMAKE_CURRENT_BINARY_DIR}/rrtmgp_init_ne2np4.nc)
 
   ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
   ## Only if max mpi ranks is >1

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
@@ -103,7 +103,7 @@ namespace scream {
         int ngas     =   8;  // TODO: get this intelligently
 
         // Make sure we have the right dimension sizes
-        REQUIRE(nlay == sw_flux_up_ref.dimension[1]-1);
+        REQUIRE(nlay == static_cast<int>(sw_flux_up_ref.dimension[1])-1);
 
         // Create yakl arrays to store the input data
         auto p_lay = real2d("p_lay", ncol, nlay);


### PR DESCRIPTION
For fpe/valg/cmc/cov builds we are not interested in comparing against baselines. Instead, we simply want to run the code to check for possible errors/leaks or to verify coverage.