### PR TITLE
SCREAM: fix compilation error on CUDA

### DIFF
--- a/components/scream/src/control/CMakeLists.txt
+++ b/components/scream/src/control/CMakeLists.txt
@@ -16,7 +16,7 @@ if (Kokkos_ENABLE_CUDA)
   # This is to silence some nvcc warning that is a CUDA compiler bug
   # See https://github.com/kokkos/kokkos/issues/1473 for more details
   target_compile_options (scream_control PUBLIC
-    -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored)
+      $<$<COMPILE_LANGUAGE:CXX>:-Xcudafe --diag_suppress=esa_on_defaulted_function_ignored>)
 endif()
 
 if (NOT SCREAM_LIB_ONLY)


### PR DESCRIPTION
#1411 (merged ~4h ago) introduced a cmake bug for our v1 build on CUDA.

The `-Xcudafe xyz` flag for the `scream_control` lib was PUBLIC, and not language specific, so when linking control to the `atm` lib, it caused F90 compilation errors.