### PR TITLE
Apply scaling to incoming solar flux to account for orbital eccentricity

### DIFF
--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -544,7 +544,7 @@ void RRTMGPRadiation::run_impl (const int dt) {
     lw_flux_up, lw_flux_dn, 
     sw_bnd_flux_up, sw_bnd_flux_dn, sw_bnd_flux_dir,
     lw_bnd_flux_up, lw_bnd_flux_dn, 
-    get_comm().am_i_root()
+    eccf, get_comm().am_i_root()
   );
 
   // Compute and apply heating rates

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -40,7 +40,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   kgkg.set_string("kg/kg");
   auto m3 = m * m * m;
   auto Wm2 = W / m / m;
-  Wm2.set_string("W/m2)");
+  Wm2.set_string("W/m2");
   auto nondim = m/m;  // dummy unit for non-dimensional fields
   auto micron = m / 1000000;
 

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -66,7 +66,7 @@ namespace scream {
                 real2d &lw_flux_up, real2d &lw_flux_dn,
                 real3d &sw_bnd_flux_up, real3d &sw_bnd_flux_dn, real3d &sw_bnd_flux_dn_dir,
                 real3d &lw_bnd_flux_up, real3d &lw_bnd_flux_dn,
-                const bool i_am_root = true);
+                const Real tsi_scaling, const bool i_am_root = true);
         /*
          * Perform any clean-up tasks
          */
@@ -80,7 +80,7 @@ namespace scream {
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0,
                 OpticalProps2str &aerosol, OpticalProps2str &clouds,
-                FluxesByband &fluxes, const bool i_am_root);
+                FluxesByband &fluxes, const Real tsi_scaling, const bool i_am_root);
         /*
          * Longwave driver (called by rrtmgp_main)
          */

--- a/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
@@ -125,6 +125,7 @@ int main (int argc, char** argv) {
     // Do something interesting here...
     // NOTE: these will get replaced with AD stuff that handles these
     std::cout << "rrtmgp_main..." << std::endl;
+    const Real tsi_scaling = 1;
     rrtmgp::rrtmgp_main(
         ncol, nlay,
         p_lay, t_lay, p_lev, t_lev, gas_concs,
@@ -135,7 +136,7 @@ int main (int argc, char** argv) {
         sw_flux_up, sw_flux_dn, sw_flux_dn_dir,
         lw_flux_up, lw_flux_dn,
         sw_bnd_flux_up, sw_bnd_flux_dn, sw_bnd_flux_dir,
-        lw_bnd_flux_up, lw_bnd_flux_dn
+        lw_bnd_flux_up, lw_bnd_flux_dn, tsi_scaling
     );
 
     // Write fluxes

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
@@ -157,6 +157,7 @@ int main(int argc, char** argv) {
 
     // Run RRTMGP code on dummy atmosphere
     std::cout << "Run RRTMGP...\n";
+    const Real tsi_scaling = 1;
     scream::rrtmgp::rrtmgp_main(
             ncol, nlay,
             p_lay, t_lay, p_lev, t_lev, gas_concs,
@@ -167,7 +168,7 @@ int main(int argc, char** argv) {
             sw_flux_up, sw_flux_dn, sw_flux_dir,
             lw_flux_up, lw_flux_dn,
             sw_bnd_flux_up, sw_bnd_flux_dn, sw_bnd_flux_dir,
-            lw_bnd_flux_up, lw_bnd_flux_dn);
+            lw_bnd_flux_up, lw_bnd_flux_dn, tsi_scaling);
 
     // Check values against baseline
     std::cout << "Check values...\n";

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -11,6 +11,10 @@ Atmosphere Processes:
     Grid: Point Grid
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
+    # Set orbital parameters to constants for consistency with RRTMGP test problem
+    Orbital Eccentricity: 0
+    Orbital Obliquity: 0
+    Orbital MVELP: 0
     Fixed Solar Zenith Angle: 0.86
 
 Grids Manager:


### PR DESCRIPTION
Apply scaling to incoming solar flux in radiation interface to account for changing earth-sun distance due to orbital eccentricity. This follows the implementation in EAM to apply the eccentricity factor computed in `shr_orb_mod` to the incoming solar flux read from the RRTMGP input data. This factor was already computed in `RRTMGPRadiation::run_impl` in the call to `shr_orb_decl`, but we needed an additional argument added to `rrtmgp_main` and `rrtmgp_sw` to pass this factor down to where it is applied. The `input_unit.yaml` file for the test `rrtmgp_standalone_unit` is modified to set eccentricity (and the other orbital parameters) to zero to keep from scaling fluxes in this test, since we are comparing against a reference problem that does not include any scaling in that test. This will be BFB for all v1 standalone tests, but diff for the v1 CIME tests.