### PR TITLE
Finalize scream session for CIME runs

### DIFF
--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -213,6 +213,9 @@ void scream_finalize (/* args ? */) {
 
     // Clean up the context
     scream::ScreamContext::singleton().clean_up();
+
+    // Finalize scream session
+    scream::finalize_scream_session();
   });
 }
 


### PR DESCRIPTION
SCREAM was not being finalized in `mct_coupling`. Thus, CUDA was not being finalized. With this fix, CIME runs of SCREAMv1 run on weaver.