### PR TITLE
Add arg to jsrun for summit

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3106,7 +3106,7 @@
         <arg name="latency_priority">--latency_priority $ENV{LTC_PRT}</arg>
         <arg name="stdio_mode">--stdio_mode prepended</arg>
         <arg name="thread_vars">$ENV{JSRUN_THREAD_VARS}</arg>
-         <arg name="smpiargs">--smpiargs="-gpu"</arg>
+        <arg name="smpiargs">--smpiargs="-gpu"</arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3106,6 +3106,7 @@
         <arg name="latency_priority">--latency_priority $ENV{LTC_PRT}</arg>
         <arg name="stdio_mode">--stdio_mode prepended</arg>
         <arg name="thread_vars">$ENV{JSRUN_THREAD_VARS}</arg>
+         <arg name="smpiargs">--smpiargs="-gpu"</arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -52,7 +52,7 @@ MACHINE_METADATA = {
                  ["mpicxx","mpifort","mpicc"],
                   "salloc --partition=pbatch --time=60",
                   ""),
-    "summit" : (["module purge", "module load cmake/3.18.4 gcc/7.5.0 spectrum-mpi/10.4.0.3-20210112 cuda/10.1.168 python/3.7-anaconda3 netcdf-c/4.8.0 netcdf-fortran/4.4.5 openblas/0.3.5","unset OMPI_CXX", "export OMP_COMM_WORLD_RANK=0"],
+    "summit" : (["module purge", "module load cmake/3.18.4 gcc/7.5.0 spectrum-mpi/10.4.0.3-20210112 cuda/10.1.168 python/3.7-anaconda3 netcdf-c/4.8.0 netcdf-fortran/4.4.5 openblas/0.3.5","unset OMPI_CXX", "export OMPI_COMM_WORLD_RANK=0"],
                 ["mpicxx","mpifort","mpicc"],
                 "bsub -I -q batch -W 0:30 -P cli115 -nnodes 1",
                 "/gpfs/alpine/cli115/proj-shared/scream/master-baselines"),


### PR DESCRIPTION
Adds jsrun arg `--smpiargs="-gpu"`. Needed for CIME runs on summit to not fail.

@jgfouca The 2nd commit is something that I'm curious if it is a typo. From [the open mpi FAQ](https://www.open-mpi.org/faq/?category=running#:~:text=OMPI_COMM_WORLD_RANK) it seems as if the variable should have an "I". But I could be missing something..