### PR TITLE
Change FieldAllocProp, to store alloc size as 64 bit int

### DIFF
--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.cpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.cpp
@@ -181,7 +181,7 @@ template<typename ScalarT, typename AllocType>
 void PhysicsDynamicsRemapper::
 compute_view_dims (const AllocType& alloc_prop, const std::vector<int>& field_dims, Dims& view_dims)
 {
-  int num_values = alloc_prop.get_alloc_size()/sizeof(ScalarT);
+  auto num_values = alloc_prop.get_alloc_size()/sizeof(ScalarT);
   int N = field_dims.size();
 
   view_dims.size = N;

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -213,6 +213,9 @@ void scream_finalize (/* args ? */) {
 
     // Clean up the context
     scream::ScreamContext::singleton().clean_up();
+
+    // Finalize scream session
+    scream::finalize_scream_session();
   });
 }
 

--- a/components/scream/src/share/field/field.cpp
+++ b/components/scream/src/share/field/field.cpp
@@ -125,7 +125,7 @@ void Field::allocate_view ()
   alloc_prop.commit(layout);
 
   // Create the view, by quering allocation properties for the allocation size
-  const int view_dim = alloc_prop.get_alloc_size();
+  const auto view_dim = alloc_prop.get_alloc_size();
 
   m_data.d_view = decltype(m_data.d_view)(id.name(),view_dim);
   m_data.h_view = Kokkos::create_mirror_view(m_data.d_view);

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -531,7 +531,7 @@ auto Field::get_ND_view () const ->
 
   // Compute extents from FieldLayout
   const auto& alloc_prop = m_header->get_alloc_properties();
-  size_t num_values = alloc_prop.get_alloc_size() / sizeof(T);
+  auto num_values = alloc_prop.get_alloc_size() / sizeof(T);
   Kokkos::LayoutRight kl;
   for (int i=0; i<N-1; ++i) {
     kl.dimension[i] = fl.dim(i);
@@ -559,7 +559,7 @@ auto Field::get_ND_view () const ->
 
   // Compute extents from FieldLayout
   const auto& alloc_prop = m_header->get_alloc_properties();
-  size_t num_values = alloc_prop.get_alloc_size() / sizeof(T);
+  auto num_values = alloc_prop.get_alloc_size() / sizeof(T);
   Kokkos::LayoutRight kl;
   for (int i=0; i<N-1; ++i) {
     kl.dimension[i] = fl.dim(i);

--- a/components/scream/src/share/field/field_alloc_prop.cpp
+++ b/components/scream/src/share/field/field_alloc_prop.cpp
@@ -187,7 +187,7 @@ void FieldAllocProp::commit (const layout_ptr_type& layout)
   m_committed = true;
 }
 
-int FieldAllocProp::get_alloc_size () const {
+long long FieldAllocProp::get_alloc_size () const {
   EKAT_REQUIRE_MSG(is_committed(),
       "Error! You cannot query the allocation properties until they have been committed.");
   return m_alloc_size;

--- a/components/scream/src/share/field/field_alloc_prop.hpp
+++ b/components/scream/src/share/field/field_alloc_prop.hpp
@@ -120,13 +120,13 @@ public:
   bool is_dynamic_subfield () const { return m_subview_info.dynamic; }
 
   // Get the overall allocation size (in Bytes)
-  int  get_alloc_size () const;
+  long long get_alloc_size () const;
 
   // Get number of m_scalar_type_size-sized scalars in the allocation.
-  int  get_num_scalars () const { return get_alloc_size () / m_scalar_type_size; }
+  long long get_num_scalars () const { return get_alloc_size () / m_scalar_type_size; }
 
   // Get the largest pack size that this allocation was requested to accommodate
-  int  get_largest_pack_size () const;
+  int get_largest_pack_size () const;
 
   // Wether this allocation is contiguous
   bool contiguous () const { return m_contiguous; }
@@ -160,7 +160,7 @@ protected:
   int   m_last_extent;
 
   // The total size of this allocation.
-  int   m_alloc_size;
+  long long   m_alloc_size;
 
   // If this allocation is a subview of another, store info about the subview
   // process (see SubviewInfo documentation for details)

--- a/components/scream/src/share/field/field_layout.hpp
+++ b/components/scream/src/share/field/field_layout.hpp
@@ -81,7 +81,7 @@ public:
   const std::vector<int>& dims () const { return m_dims; }
   const extents_type& extents () const { return m_extents; }
 
-  int      size ()               const;
+  long long  size () const;
 
   bool is_dimension_set  (const int idim) const;
   bool are_dimensions_set () const;
@@ -132,9 +132,9 @@ inline int FieldLayout::dim (const int idim) const {
   return m_dims[idim];
 }
 
-inline int FieldLayout::size () const {
+inline long long FieldLayout::size () const {
   ekat::error::runtime_check(are_dimensions_set(), "Error! Field dimensions not yet set.\n",-1);
-  int prod = m_rank>0 ? 1 : 0;
+  long long prod = m_rank>0 ? 1 : 0;
   for (int idim=0; idim<m_rank; ++idim) {
     prod *= m_dims[idim];
   }

--- a/components/scream/src/share/tests/property_checks.cpp
+++ b/components/scream/src/share/tests/property_checks.cpp
@@ -59,7 +59,7 @@ TEST_CASE("property_checks", "") {
 
   // Check positivity.
   SECTION ("field_positivity_check") {
-    const int num_reals = f.get_header().get_alloc_properties().get_num_scalars();
+    const auto num_reals = f.get_header().get_alloc_properties().get_num_scalars();
 
     // Assign positive values to the field and make sure it passes our test for
     // positivity.
@@ -79,7 +79,7 @@ TEST_CASE("property_checks", "") {
 
   // Check positivity with repairs.
   SECTION ("field_positivity_check_with_repairs") {
-    const int num_reals = f.get_header().get_alloc_properties().get_num_scalars();
+    const auto num_reals = f.get_header().get_alloc_properties().get_num_scalars();
 
     // Assign non-positive values to the field, make sure it fails the check,
     // and then repair the field so it passes.
@@ -96,7 +96,7 @@ TEST_CASE("property_checks", "") {
 
   // Check that values are not NaN
   SECTION("field_not_nan_check") {
-    const int num_reals = f.get_header().get_alloc_properties().get_num_scalars();
+    const auto num_reals = f.get_header().get_alloc_properties().get_num_scalars();
 
     auto nan_check = std::make_shared<FieldNaNCheck>(f);
 
@@ -115,7 +115,7 @@ TEST_CASE("property_checks", "") {
 
   // Check that the values of a field lie within an interval.
   SECTION ("field_within_interval_check") {
-    const int num_reals = f.get_header().get_alloc_properties().get_num_scalars();
+    const auto num_reals = f.get_header().get_alloc_properties().get_num_scalars();
 
     auto interval_check = std::make_shared<FieldWithinIntervalCheck>(f, 0, 1);
     REQUIRE(interval_check->can_repair());
@@ -139,7 +139,7 @@ TEST_CASE("property_checks", "") {
 
   // Check that the values of a field are above a lower bound
   SECTION ("field_lower_bound_check") {
-    const int num_reals = f.get_header().get_alloc_properties().get_num_scalars();
+    const auto num_reals = f.get_header().get_alloc_properties().get_num_scalars();
 
     auto lower_bound_check = std::make_shared<FieldLowerBoundCheck>(f,-1.0);
     REQUIRE(lower_bound_check->can_repair());
@@ -172,7 +172,7 @@ TEST_CASE("property_checks", "") {
   SECTION ("field_upper_bound_check") {
     auto upper_bound_check = std::make_shared<FieldUpperBoundCheck>(f,1.0);
     REQUIRE(upper_bound_check->can_repair());
-    const int num_reals = f.get_header().get_alloc_properties().get_num_scalars();
+    const auto num_reals = f.get_header().get_alloc_properties().get_num_scalars();
 
     // Assign in-bound values to the field and make sure it passes the upper_bound check
     auto f_data = reinterpret_cast<Real*>(f.get_internal_view_data<Real,Host>());
@@ -199,7 +199,7 @@ TEST_CASE("property_checks", "") {
   }
 
   SECTION ("check_and_repair_wrapper") {
-    const int num_reals = f.get_header().get_alloc_properties().get_num_scalars();
+    const auto num_reals = f.get_header().get_alloc_properties().get_num_scalars();
 
     // Two separate FPC for check and for repair
     constexpr Real ub_check  = 1.0;


### PR DESCRIPTION
This avoids overflows when running very large cases on a very small number of ranks.

Close #1480 