### PR TITLE
Make the implementation of spa_main more modular, to improve testing granularity

### DIFF
--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -129,6 +129,10 @@ void SPA::initialize_impl (const RunType /* run_type */)
   SPAData_out.AER_SSA_SW         = get_field_out("aero_ssa_sw").get_view<Pack***>();
   SPAData_out.AER_TAU_SW         = get_field_out("aero_tau_sw").get_view<Pack***>();
   SPAData_out.AER_TAU_LW         = get_field_out("aero_tau_lw").get_view<Pack***>();
+  SPAData_out.ncols = m_num_cols;
+  SPAData_out.nlevs = m_num_levs;
+  SPAData_out.nswbands = m_nswbands;
+  SPAData_out.nswbands = m_nlwbands;
 
   // Retrieve the remap and data file locations from the parameter list:
   EKAT_REQUIRE_MSG(m_params.isParameter("SPA Remap File"),"ERROR: SPA Remap File is missing from SPA parameter list.");
@@ -175,7 +179,7 @@ void SPA::run_impl (const int /* dt */)
 
   // Call the main SPA routine to get interpolated aerosol forcings.
   const auto& pmid_tgt = get_field_in("p_mid").get_view<const Pack**>();
-  SPAFunc::spa_main(SPATimeState, pmid_tgt,SPAData_start,SPAData_end,SPAData_out,m_num_cols,m_num_levs,m_nswbands,m_nlwbands);
+  SPAFunc::spa_main(SPATimeState, pmid_tgt,SPAData_start,SPAData_end,SPAData_out);
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.hpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.hpp
@@ -27,8 +27,6 @@ public:
   using Spack           = SPAFunc::Spack;
   using Pack            = ekat::Pack<Real,Spack::n>;
   using KT              = ekat::KokkosTypes<DefaultDevice>;
-  using WSM             = ekat::WorkspaceManager<Spack, KT::Device>;
-  using LIV             = ekat::LinInterp<Real,Spack::n>;
 
   using view_1d         = typename SPAFunc::view_1d<Spack>;
   using view_2d         = typename SPAFunc::view_2d<Spack>;
@@ -61,17 +59,11 @@ public:
 
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {
-    // 1d view scalar, size (ncol)
-    static constexpr int num_1d_scalar = 1;
-    // 2d view packed, size (ncol, nlev_packs)
-    static constexpr int num_2d_vector = 2;
-    static constexpr int num_2dp1_vector = 0;
+    // Used to store temporary data during spa_main
+    SPAFunc::SPAInput spa_temp;
 
-    uview_1d<Real>  ps_src;
+    // Temporary to use
     uview_2d<Spack> p_mid_src;
-    uview_2d<Spack> ccn3_src;
-
-    Spack* wsm_data;
   };
 protected:
 
@@ -100,7 +92,7 @@ protected:
   Int         m_total_global_dofs; // Needed to make sure that remap data matches grid.
   gid_type    m_min_global_dof;
 
-  // Struct which contains local variables
+  // Struct which contains temporary variables used during spa_main
   Buffer m_buffer;
 
   // SPA specific files
@@ -109,9 +101,9 @@ protected:
 
   // Structures to store the data used for interpolation
   SPAFunc::SPATimeState     SPATimeState;
-  SPAFunc::SPAData          SPAData_start;
-  SPAFunc::SPAData          SPAData_end;
   SPAFunc::SPAHorizInterp   SPAHorizInterp;
+  SPAFunc::SPAInput         SPAData_start;
+  SPAFunc::SPAInput         SPAData_end;
   SPAFunc::SPAOutput        SPAData_out;
 
 }; // class SPA 

--- a/components/scream/src/physics/spa/spa_functions.hpp
+++ b/components/scream/src/physics/spa/spa_functions.hpp
@@ -4,16 +4,16 @@
 #include "share/grid/abstract_grid.hpp"
 #include "share/scream_types.hpp"
 #include "share/util/scream_time_stamp.hpp"
+
 #include "ekat/ekat_pack_kokkos.hpp"
+#include "ekat/ekat_pack_utils.hpp"
 #include "ekat/ekat_workspace.hpp"
 #include "ekat/mpi/ekat_comm.hpp"
-
-#include <numeric>
 
 namespace scream {
 namespace spa {
 
-template <typename ScalarT, typename DeviceT>
+template <typename ScalarType, typename DeviceType>
 struct SPAFunctions
 {
 
@@ -21,8 +21,8 @@ struct SPAFunctions
   // ------- Types --------
   //
 
-  using Scalar = ScalarT;
-  using Device = DeviceT;
+  using Scalar = ScalarType;
+  using Device = DeviceType;
 
   template <typename S>
   using BigPack = ekat::Pack<S,SCREAM_PACK_SIZE>;
@@ -75,74 +75,68 @@ struct SPAFunctions
 
   struct SPAData {
     SPAData() = default;
-    SPAData(const int ncol_, const int nlev_, const int nswbands_, const int nlwbands_) :
-      ncols(ncol_)
-      ,nlevs(nlev_)
-      ,nswbands(nswbands_)
-      ,nlwbands(nlwbands_)
+    SPAData(const int ncol_, const int nlev_, const int nswbands_, const int nlwbands_)
     {
-      hyam       = view_1d<Spack>("",nlevs);
-      hybm       = view_1d<Spack>("",nlevs);
-      PS         = view_1d<Real>("",ncols);
-      CCN3       = view_2d<Spack>("",ncols,nlevs);
-      AER_G_SW   = view_3d<Spack>("",ncols,nswbands,nlevs); 
-      AER_SSA_SW = view_3d<Spack>("",ncols,nswbands,nlevs); 
-      AER_TAU_SW = view_3d<Spack>("",ncols,nswbands,nlevs); 
-      AER_TAU_LW = view_3d<Spack>("",ncols,nlwbands,nlevs); 
+      init (ncol_,nlev_,nswbands_,nlwbands_,true);
     }
+
+    void init(const int ncol_, const int nlev_, const int nswbands_, const int nlwbands_, const bool allocate)
+    {
+      ncols = ncol_;
+      nlevs = nlev_;
+      nswbands = nswbands_;
+      nlwbands = nlwbands_;
+
+      if (allocate) {
+        const int npacks = ekat::PackInfo<Spack::n>::num_packs(nlevs);
+
+        CCN3       = view_2d<Spack>("",ncols,npacks);
+        AER_G_SW   = view_3d<Spack>("",ncols,nswbands,npacks);
+        AER_SSA_SW = view_3d<Spack>("",ncols,nswbands,npacks);
+        AER_TAU_SW = view_3d<Spack>("",ncols,nswbands,npacks);
+        AER_TAU_LW = view_3d<Spack>("",ncols,nlwbands,npacks);
+      }
+    }
+
     // Basic spatial dimensions of the data
     Int ncols;
     Int nlevs;
     Int nswbands;
     Int nlwbands;
-    // Hybrid Coordinates
-    view_1d<Spack> hyam, hybm;
-    // PS unit = Pa: Surface pressure
-    view_1d<Real> PS;
-    // CCN3: CCN concentration at S=0.1%, units = #/cm3, dimensions = (ncol,nlev)
-    view_2d<Spack> CCN3;
-    // AER_G_SW unit = #/cm3, dimensions = (ncol,nswband=14,nlev)
-    view_3d<Spack> AER_G_SW;
-    // AER_SSA_SW unit = #/cm3, dimensions = (ncol,nswband=14,nlev)
-    view_3d<Spack> AER_SSA_SW;
-    // AER_TAU_SW unit = #/cm3, dimensions = (ncol,nswband=14,nlev)
-    view_3d<Spack> AER_TAU_SW;
-    // AER_TAU_LW unit = #/cm3, dimensions = (ncol,nswband=16,nlev)
-    view_3d<Spack> AER_TAU_LW;
 
-  }; // SPAPrescribedAerosolData
+    view_2d<Spack> CCN3;        // CCN concentration at S=0.1: units = #/cm3, dimensions = (ncols,nlevs)
+    view_3d<Spack> AER_G_SW;    // AER_G_SW:   units = #/cm3, dimensions = (ncols,nswbands,nlevs)
+    view_3d<Spack> AER_SSA_SW;  // AER_SSA_SW: units = #/cm3, dimensions = (ncols,nswbands,nlevs)
+    view_3d<Spack> AER_TAU_SW;  // AER_TAU_SW: units = #/cm3, dimensions = (ncols,nswbands,nlevs)
+    view_3d<Spack> AER_TAU_LW;  // AER_TAU_LW: units = #/cm3, dimensions = (ncols,nlwbands,nlevs)
+  }; // SPAData
 
-  struct SPAOutput {
-    SPAOutput() = default;
-    SPAOutput(const int ncol_, const int nlev_, const int nswbands_, const int nlwbands_) :
-      ncols(ncol_)
-      ,nlevs(nlev_)
-      ,nswbands(nswbands_)
-      ,nlwbands(nlwbands_)
+  struct SPAInput {
+    SPAInput() = default;
+    SPAInput(const int ncols_, const int nlevs_, const int nswbands_, const int nlwbands_)
     {
-      CCN3       = view_2d<Spack>("",ncols,nlevs);
-      AER_G_SW   = view_3d<Spack>("",ncols,nswbands,nlevs); 
-      AER_SSA_SW = view_3d<Spack>("",ncols,nswbands,nlevs); 
-      AER_TAU_SW = view_3d<Spack>("",ncols,nswbands,nlevs); 
-      AER_TAU_LW = view_3d<Spack>("",ncols,nlwbands,nlevs); 
+      init(ncols_,nlevs_,nswbands_,nlwbands_);
     }
-    // Basic spatial dimensions of the data
-    Int ncols;
-    Int nlevs;
-    Int nswbands;
-    Int nlwbands;
-    // CCN3: CCN concentration at S=0.1%, units = #/cm3, dimensions = (ncol,nlev)
-    view_2d<Spack> CCN3;
-    // AER_G_SW - 14 bands
-    // AER_G_SW: unit = #/cm3, dimensions = (ncol,nswband=14,nlev)
-    view_3d<Spack> AER_G_SW;
-    // AER_SSA_SW: unit = #/cm3, dimensions = (ncol,nswband=14,nlev)
-    view_3d<Spack> AER_SSA_SW;
-    // AER_TAU_SW: unit = #/cm3, dimensions = (ncol,nswband=14,nlev)
-    view_3d<Spack> AER_TAU_SW;
-    // AER_TAU_LW: unit = #/cm3, dimensions = (ncol,nswband=16,nlev)
-    view_3d<Spack> AER_TAU_LW;
-  }; // SPAPrescribedAerosolData
+
+    void init(const int ncols_, const int nlevs_, const int nswbands_, const int nlwbands_)
+    {
+      const int npacks = ekat::PackInfo<Spack::n>::num_packs(nlevs_);
+
+      data.init(ncols_,nlevs_,nswbands_,nlwbands_,true);
+      PS  = view_1d<Real>("", ncols_);
+      hyam = view_1d<Spack>("", npacks);
+      hybm = view_1d<Spack>("", npacks);
+    }
+
+    view_1d<Spack>  hyam, hybm;   // Hybrid Coordinates
+    view_1d<Real>   PS;           // PS unit = Pa: Surface pressure
+
+    SPAData         data;         // All spa fields
+  }; // SPAInput
+
+  // The output is really just SPAData, but for clarity it might
+  // help to see a SPAOutput along a SPAInput in functions signatures
+  using SPAOutput = SPAData;
 
   struct SPAHorizInterp {
     // This structure stores the information need by SPA to conduct horizontal
@@ -181,10 +175,11 @@ struct SPAFunctions
   static void spa_main(
     const SPATimeState& time_state,
     const view_2d<const Spack>& p_tgt,
-    const SPAData&   data_beg,
-    const SPAData&   data_end,
-    const SPAOutput& data_out,
-    const SPAOutput& data_out);
+    const view_2d<      Spack>& p_src,  // Temporary
+    const SPAInput&   data_beg,
+    const SPAInput&   data_end,
+    const SPAInput&   data_tmp,         // Temporary
+    const SPAOutput&  data_out);
 
   static void get_remap_weights_from_file(
     const std::string&       remap_file_name,
@@ -205,7 +200,7 @@ struct SPAFunctions
     const Int             nswbands,
     const Int             nlwbands,
           SPAHorizInterp& spa_horiz_interp,
-          SPAData&        spa_data);
+          SPAInput&       spa_data);
 
   static void update_spa_timestate(
     const std::string&     spa_data_file_name,
@@ -213,20 +208,54 @@ struct SPAFunctions
     const Int              nlwbands,
     const util::TimeStamp& ts,
           SPAHorizInterp&  spa_horiz_interp,
-          SPATimeState&    time_state, 
-          SPAData&         spa_beg,
-          SPAData&         spa_end);
-    
+          SPATimeState&    time_state,
+          SPAInput&        spa_beg,
+          SPAInput&        spa_end);
+
+  // The following three are called during spa_main
+  static void perform_time_interpolation (
+      const SPATimeState& time_state,
+      const SPAInput&  data_beg,
+      const SPAInput&  data_end,
+      const SPAInput&  data_out);
+
+  static void compute_source_pressure_levels (
+      const view_1d<const Real>& ps_src,
+      const view_2d<      Spack>& p_src,
+      const view_1d<const Spack>& hyam,
+      const view_1d<const Spack>& hybm);
+
+  static void perform_vertical_interpolation (
+      const view_2d<const Spack>& p_src,
+      const view_2d<const Spack>& p_tgt,
+      const SPAData&  data_in,
+      const SPAData&  data_out);
+
+  // Return the subcolumn of the proper variable, where ivar
+  // is a condensed idx for var and possibly band. In particular:
+  //  - ivar=0: return CCN
+  //  - else, jvar = ivar-1, and
+  //     - jvar=[0...nswbands): return aer_g_sw
+  //     - jvar=[nswbands...2*nswbands): return aer_ssa_sw
+  //     - jvar=[2*nswbands...3*nswbands): return aer_tau_sw
+  //     - jvar=[3*nswbands...3*nswbands+nlbands): return aer_tau_lw
+  KOKKOS_INLINE_FUNCTION
+  static view_1d<Spack> get_var_column (const SPAData& data, const int icol, const int ivar);
+
+  // Performs convex interpolation of x0 and x1 at point t
+  template<typename ScalarX,typename ScalarT>
+  KOKKOS_INLINE_FUNCTION
+  static ScalarX linear_interp(const ScalarX& x0, const ScalarX& x1, const ScalarT& t);
 
 }; // struct Functions
 
-} // namespace spa 
+} // namespace spa
 } // namespace scream
 
 #endif // SPA_FUNCTIONS_HPP
 
 // We don't do ETI, since we don't know some of the concrete types.
-// E.g., we don't know InputProvider, or ScalarT (although we could
+// E.g., we don't know InputProvider, or ScalarType (although we could
 // ETI the "common" cases, where the provider is a view_1d, and
 // Scalar=Real or Scalar=Pack<Real,SCREAM_PACK_SIZE>).
 # include "spa_functions_impl.hpp"

--- a/components/scream/src/physics/spa/spa_functions.hpp
+++ b/components/scream/src/physics/spa/spa_functions.hpp
@@ -184,10 +184,7 @@ struct SPAFunctions
     const SPAData&   data_beg,
     const SPAData&   data_end,
     const SPAOutput& data_out,
-    Int ncols_scream,
-    Int nlevs_scream,
-    Int nswbands,
-    Int nlwbands);
+    const SPAOutput& data_out);
 
   static void get_remap_weights_from_file(
     const std::string&       remap_file_name,

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -92,11 +92,7 @@ void SPAFunctions<S,D>
   const view_2d<const Spack>& p_tgt,
   const SPAData&   data_beg,
   const SPAData&   data_end,
-  const SPAOutput& data_out,
-  Int ncols_tgt,
-  Int nlevs_tgt,
-  Int nswbands,
-  Int nlwbands)
+  const SPAOutput& data_out)
 {
   // Gather time stamp info
   auto& t_now = time_state.t_now;
@@ -104,6 +100,8 @@ void SPAFunctions<S,D>
   auto& t_len = time_state.days_this_month;
 
   const int nlevs_src = data_beg.nlevs;
+  const int ncols_tgt = data_out.ncols;
+  const int nlevs_tgt = data_out.nlevs;
 
   // For now we require that the Data in and the Data out have the same number of columns.
   EKAT_REQUIRE(ncols_tgt==data_beg.ncols);

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -6,9 +6,13 @@
 #include "share/io/scorpio_input.hpp"
 #include "share/grid/point_grid.hpp"
 #include "physics/share/physics_constants.hpp"
+
 #include "ekat/kokkos/ekat_subview_utils.hpp"
 #include "ekat/util/ekat_lin_interp.hpp"
+#include "ekat/ekat_pack_utils.hpp"
 #include "ekat/ekat_parse_yaml_file.hpp"
+
+#include <numeric>
 
 /*-----------------------------------------------------------------
  * The main SPA routines used to convert SPA data into a format that
@@ -62,10 +66,6 @@
 namespace scream {
 namespace spa {
 
-// Helper function
-template<typename ScalarT,typename ScalarS>
-KOKKOS_INLINE_FUNCTION
-ScalarT linear_interp(const ScalarT& x0, const ScalarT& x1, const ScalarS& t_norm);
 /*-----------------------------------------------------------------*/
 // The main SPA routine which handles projecting SPA data onto the
 // horizontal columns and vertical pressure profiles of the atmospheric
@@ -90,193 +90,187 @@ void SPAFunctions<S,D>
 ::spa_main(
   const SPATimeState& time_state,
   const view_2d<const Spack>& p_tgt,
-  const SPAData&   data_beg,
-  const SPAData&   data_end,
-  const SPAOutput& data_out)
+  const view_2d<      Spack>& p_src,
+  const SPAInput&   data_beg,
+  const SPAInput&   data_end,
+  const SPAInput&   data_tmp,
+  const SPAOutput&  data_out)
 {
+  // Number of bands must match.
+  EKAT_REQUIRE(data_end.data.nswbands==data_beg.data.nswbands);
+  EKAT_REQUIRE(data_end.data.nlwbands==data_beg.data.nlwbands);
+
+  // For now we require input and output to have same geometric sizes
+  EKAT_REQUIRE(data_end.data.ncols==data_beg.data.ncols);
+  EKAT_REQUIRE(data_end.data.nlevs==data_beg.data.nlevs);
+
+  // Step 1. Perform horizontal interpolation (todo)
+
+  // Step 2. Perform time interpolation
+  perform_time_interpolation(time_state,data_beg,data_end,data_tmp);
+
+  // Step 3. Compute source pressure levels
+  // NOTE: we assume data_beg and data_end have the *same* hybrid v coords.
+  //       IF this ever ceases to be the case, you can interp those too,
+  //       and stored them in data_tmp.
+  compute_source_pressure_levels(data_tmp.PS, p_src, data_beg.hyam, data_beg.hybm);
+
+  // Step 4. Perform vertical interpolation
+  perform_vertical_interpolation(p_src, p_tgt, data_tmp.data, data_out);
+}
+
+/*-----------------------------------------------------------------*/
+template <typename S, typename D>
+void SPAFunctions<S,D>
+::perform_time_interpolation(
+  const SPATimeState& time_state,
+  const SPAInput&  data_beg,
+  const SPAInput&  data_end,
+  const SPAInput&  data_out)
+{
+  using ExeSpace = typename KT::ExeSpace;
+  using ESU = ekat::ExeSpaceUtils<ExeSpace>;
+
   // Gather time stamp info
   auto& t_now = time_state.t_now;
   auto& t_beg = time_state.t_beg_month;
-  auto& t_len = time_state.days_this_month;
+  auto& delta_t = time_state.days_this_month;
 
-  const int nlevs_src = data_beg.nlevs;
-  const int ncols_tgt = data_out.ncols;
-  const int nlevs_tgt = data_out.nlevs;
+  // Makes no sense to have different number of bands
+  EKAT_REQUIRE(data_end.data.nswbands==data_beg.data.nswbands);
+  EKAT_REQUIRE(data_end.data.nlwbands==data_beg.data.nlwbands);
 
-  // For now we require that the Data in and the Data out have the same number of columns.
-  EKAT_REQUIRE(ncols_tgt==data_beg.ncols);
-  EKAT_REQUIRE(data_end.ncols==data_beg.ncols);
-  EKAT_REQUIRE(data_end.nlevs==data_beg.nlevs);
+  // At this stage, begin/end must have the same dimensions
+  EKAT_REQUIRE(data_end.data.ncols==data_beg.data.ncols);
+  EKAT_REQUIRE(data_end.data.nlevs==data_beg.data.nlevs);
 
-  // Set up temporary arrays that will be used for the spa interpolation.
-  view_2d<Spack> p_src("p_mid_src",ncols_tgt,nlevs_src), 
-                 ccn3_src("ccn3_src",ncols_tgt,nlevs_src);
-  view_3d<Spack> aer_g_sw_src("aer_g_sw_src",ncols_tgt,nswbands,nlevs_src),
-                 aer_ssa_sw_src("aer_ssa_sw_src",ncols_tgt,nswbands,nlevs_src),
-                 aer_tau_sw_src("aer_tau_sw_src",ncols_tgt,nswbands,nlevs_src),
-                 aer_tau_lw_src("aer_tau_lw_src",ncols_tgt,nlwbands,nlevs_src);
+  // We can ||ize over columns as well as over variables and bands
+  const int num_vars = 1+data_beg.data.nswbands*3+data_beg.data.nlwbands;
+  const int outer_iters = data_beg.data.ncols*num_vars;
+  const int num_vert_packs = ekat::PackInfo<Spack::n>::num_packs(data_beg.data.nlevs);
+  const auto policy = ESU::get_default_team_policy(outer_iters, num_vert_packs);
 
-  using ExeSpace = typename KT::ExeSpace;
-  const Int nk_pack = ekat::npack<Spack>(nlevs_tgt);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncols_tgt, nk_pack);
-  auto t_norm = (t_now-t_beg)/t_len;
-  // SPA Main loop
-  // Parallel loop order:
-  // 1. Loop over all horizontal columns (i index)
-  // 2. Loop over all aerosol bands (n index) - where applicable
-  // 3. Loop over all vertical packs (k index)
-  Kokkos::parallel_for(
-    "spa main loop",
-    policy,
+  auto delta_t_fraction = (t_now-t_beg) / delta_t;
+
+  Kokkos::parallel_for("spa_time_interp_loop", policy,
     KOKKOS_LAMBDA(const MemberType& team) {
 
-    const Int i = team.league_rank();  // SCREAM column index
+    // The policy is over ncols*num_vars, so retrieve icol/ivar
+    const int icol = team.league_rank() / num_vars;
+    const int ivar = team.league_rank() % num_vars;
 
-    // Get single-column subviews of all 2D inputs, i.e. those that don't have aerosol bands
-    const auto& ps_beg_sub   = data_beg.PS(i);
-    const auto& ps_end_sub   = data_end.PS(i);
-    const auto& pmid_sub     = ekat::subview(p_tgt, i);
-    const auto& p_src_sub    = ekat::subview(p_src, i);
-
-    const auto& ccn3_beg_sub = ekat::subview(data_beg.CCN3, i);
-    const auto& ccn3_end_sub = ekat::subview(data_end.CCN3, i);
-    const auto& ccn3_src_sub = ekat::subview(ccn3_src, i);
-
-    // First Step: Horizontal Interpolation if needed - Skip for Now
-  
-    // Second Step: Temporal Interpolation
-    // Use basic linear interpolation function y = b + mx
-    /* Determine PS for the source data at this time */
-    auto ps_src = linear_interp(ps_beg_sub,ps_end_sub,t_norm);
-    /* Reconstruct the vertical pressure profile for the data and time interpolation
-     * of the data.
-     * Note: CCN3 has the same dimensions as pressure so we handle that time interpolation
-     *       in this loop as well.  */
-    using C = scream::physics::Constants<Real>;
-    static constexpr auto P0 = C::P0;
-    const Int nk_pack = ekat::npack<Spack>(nlevs_src);
-    Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nk_pack), [&] (Int k) {
-        // Reconstruct vertical temperature profile using the hybrid coordinate system.
-        p_src_sub(k)    = ps_src * data_beg.hybm(k)  + P0 * data_beg.hyam(k);
-        // Time interpolation for CCN3
-        ccn3_src_sub(k) = linear_interp(ccn3_beg_sub(k),ccn3_end_sub(k),t_norm);
-    });
-    team.team_barrier();
-    /* Loop over all SW variables with nswbands */
-    Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nswbands), [&] (int n) {
-      const auto& aer_g_sw_beg_sub           = ekat::subview(data_beg.AER_G_SW, i, n);
-      const auto& aer_g_sw_end_sub           = ekat::subview(data_end.AER_G_SW, i, n);
-      const auto& aer_g_sw_src_sub           = ekat::subview(aer_g_sw_src, i, n);
-
-      const auto& aer_ssa_sw_beg_sub         = ekat::subview(data_beg.AER_SSA_SW, i, n);
-      const auto& aer_ssa_sw_end_sub         = ekat::subview(data_end.AER_SSA_SW, i, n);
-      const auto& aer_ssa_sw_src_sub         = ekat::subview(aer_ssa_sw_src, i, n);
-  
-      const auto& aer_tau_sw_beg_sub         = ekat::subview(data_beg.AER_TAU_SW, i, n);
-      const auto& aer_tau_sw_end_sub         = ekat::subview(data_end.AER_TAU_SW, i, n);
-      const auto& aer_tau_sw_src_sub         = ekat::subview(aer_tau_sw_src, i, n);
-
-      /* Now loop over fastest index, the number of vertical packs */
-      Kokkos::parallel_for(
-        Kokkos::ThreadVectorRange(team, nk_pack), [&] (Int k) {
-        aer_g_sw_src_sub(k)   = linear_interp(aer_g_sw_beg_sub(k),   aer_g_sw_end_sub(k),   t_norm);
-        aer_ssa_sw_src_sub(k) = linear_interp(aer_ssa_sw_beg_sub(k), aer_ssa_sw_end_sub(k), t_norm);
-        aer_tau_sw_src_sub(k) = linear_interp(aer_tau_sw_beg_sub(k), aer_tau_sw_end_sub(k), t_norm);
+    // Compute ps out only once
+    if (ivar==0) {
+      // PS is a 2d var, so we need to make one team member handle it.
+      Kokkos::single(Kokkos::PerTeam(team),[&]{
+          data_out.PS(icol) = linear_interp(data_beg.PS(icol),data_end.PS(icol),delta_t_fraction);
       });
-    });
-    team.team_barrier();
-    /* Loop over all LW variables with nlwbands */
-    Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nlwbands), [&] (int n) {
-      const auto& aer_tau_lw_beg_sub         = ekat::subview(data_beg.AER_TAU_LW, i, n);
-      const auto& aer_tau_lw_end_sub         = ekat::subview(data_end.AER_TAU_LW, i, n);
-      const auto& aer_tau_lw_src_sub         = ekat::subview(aer_tau_lw_src, i, n);
+    }
 
-      /* Now loop over fastest index, the number of vertical packs */
-      Kokkos::parallel_for(
-        Kokkos::ThreadVectorRange(team, nk_pack), [&] (Int k) {
-        aer_tau_lw_src_sub(k) = linear_interp(aer_tau_lw_beg_sub(k), aer_tau_lw_end_sub(k), t_norm);
-      });
+    // Get column of beg/end/out variable
+    auto var_beg = get_var_column (data_beg.data,icol,ivar);
+    auto var_end = get_var_column (data_end.data,icol,ivar);
+    auto var_out = get_var_column (data_out.data,icol,ivar);
+
+    Kokkos::parallel_for (Kokkos::TeamThreadRange(team,num_vert_packs),
+                          [&] (const int& k) {
+      var_out(k) = linear_interp(var_beg(k),var_end(k),delta_t_fraction);
     });
-    team.team_barrier();
   });
   Kokkos::fence();
+}
 
-  // Third Step: Vertical interpolation, project the SPA data onto the pressure profile for this simulation.
-  // This is done using the EKAT linear interpolation routine, see /externals/ekat/util/ekat_lin_interp.hpp
-  // for more details. 
+template<typename S, typename D>
+void SPAFunctions<S,D>::
+compute_source_pressure_levels(
+  const view_1d<const Real>& ps_src,
+  const view_2d<      Spack>& p_src,
+  const view_1d<const Spack>& hyam,
+  const view_1d<const Spack>& hybm)
+{
+  using ExeSpace = typename KT::ExeSpace;
+  using ESU = ekat::ExeSpaceUtils<ExeSpace>;
+  using C = scream::physics::Constants<Real>;
+
+  constexpr auto P0 = C::P0;
+
+  const int ncols = ps_src.extent(0);
+  const int nlevs = p_src.extent(1);
+  const int num_vert_packs = ekat::PackInfo<Spack::n>::num_packs(nlevs);
+  const auto policy = ESU::get_default_team_policy(ncols, num_vert_packs);
+
+  Kokkos::parallel_for("spa_compute_p_src_loop", policy,
+    KOKKOS_LAMBDA (const MemberType& team) {
+    const int icol = team.league_rank();
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_vert_packs),
+                         [&](const int k) {
+      p_src(icol,k) = ps_src(icol) * hybm(k)  + P0 * hyam(k);
+    });
+  });
+}
+
+template<typename S, typename D>
+void SPAFunctions<S,D>::
+perform_vertical_interpolation(
+  const view_2d<const Spack>& p_src,
+  const view_2d<const Spack>& p_tgt,
+  const SPAData& input,
+  const SPAData& output)
+{
+  using ExeSpace = typename KT::ExeSpace;
+  using ESU = ekat::ExeSpaceUtils<ExeSpace>;
   using LIV = ekat::LinInterp<Real,Spack::n>;
 
-  LIV VertInterp(ncols_tgt,nlevs_src,nlevs_tgt);
-  /* Parallel loop strategy:
-   * 1. Loop over all simulation columns (i index)
-   * 2. Where applicable, loop over all aerosol bands (n index)
-   */
-  const Int most_bands = std::max(nlwbands, nswbands);
-  typename LIV::TeamPolicy band_policy(ncols_tgt, ekat::OnGpu<typename LIV::ExeSpace>::value ? most_bands : 1, VertInterp.km2_pack());
-  Kokkos::parallel_for("vertical-interp-spa",
-    band_policy,
+  // Makes no sense to have different number of bands
+  EKAT_REQUIRE(input.nswbands==output.nswbands);
+  EKAT_REQUIRE(input.nlwbands==output.nlwbands);
+
+  // At this stage, begin/end must have the same horiz dimensions
+  EKAT_REQUIRE(input.ncols==output.ncols);
+
+  const int ncols     = input.ncols;
+  const int nlevs_src = input.nlevs;
+  const int nlevs_tgt = output.nlevs;
+
+  LIV vert_interp(ncols,nlevs_src,nlevs_tgt);
+
+  // We can ||ize over columns as well as over variables and bands
+  const int num_vars = 1+input.nswbands*3+input.nlwbands;
+  const int num_vert_packs = ekat::PackInfo<Spack::n>::num_packs(nlevs_tgt);
+  const auto policy_setup = ESU::get_default_team_policy(ncols, num_vert_packs);
+
+  // Setup the linear interpolation object
+  Kokkos::parallel_for("spa_vert_interp_setup_loop", policy_setup,
     KOKKOS_LAMBDA(typename LIV::MemberType const& team) {
-    const int i = team.league_rank();
-    /* Setup the linear interpolater for this column. */
-    if (team.team_rank()==0) {
-      const auto tvr = Kokkos::ThreadVectorRange(team, VertInterp.km2_pack());
-    
-      VertInterp.setup(team,tvr,
-                       ekat::subview(p_src,i),
-                       ekat::subview(p_tgt,i));
-    }
-    team.team_barrier();
-    /* Conduct vertical interpolation for the 2D variable CCN3 */
-    if (team.team_rank()==0) {
-      const auto tvr = Kokkos::ThreadVectorRange(team, VertInterp.km2_pack());
-    
-      VertInterp.lin_interp(team,tvr,
-                            ekat::subview(p_src,i),
-                            ekat::subview(p_tgt,i),
-                            ekat::subview(ccn3_src,i),
-                            ekat::subview(data_out.CCN3,i));
-    }
-    /* Conduct vertical interpolation for the LW banded data - nlwbands (n index) */
-    Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nlwbands), [&] (int n) {
-      const auto& tvr = Kokkos::ThreadVectorRange(team, VertInterp.km2_pack());
-      VertInterp.lin_interp(team,
-                            tvr,
-                            ekat::subview(p_src,i),
-                            ekat::subview(p_tgt,i),
-                            ekat::subview(aer_tau_lw_src,i,n),
-                            ekat::subview(data_out.AER_TAU_LW,i,n));
-    });
-    /* Conduct vertical interpolation for the SW banded data - nswbands (n index) */
-    Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nswbands), [&] (int n) {
-      const auto& tvr = Kokkos::ThreadVectorRange(team, VertInterp.km2_pack());
-      VertInterp.lin_interp(team,
-                            tvr,
-                            ekat::subview(p_src,i),
-                            ekat::subview(p_tgt,i),
-                            ekat::subview(aer_g_sw_src,i,n),
-                            ekat::subview(data_out.AER_G_SW,i,n));
-      VertInterp.lin_interp(team,
-                            tvr,
-                            ekat::subview(p_src,i),
-                            ekat::subview(p_tgt,i),
-                            ekat::subview(aer_ssa_sw_src,i,n),
-                            ekat::subview(data_out.AER_SSA_SW,i,n));
-      VertInterp.lin_interp(team,
-                            tvr,
-                            ekat::subview(p_src,i),
-                            ekat::subview(p_tgt,i),
-                            ekat::subview(aer_tau_sw_src,i,n),
-                            ekat::subview(data_out.AER_TAU_SW,i,n));
-    });
+
+    const int icol = team.league_rank();
+  
+    // Setup
+    vert_interp.setup(team, ekat::subview(p_src,icol),
+                            ekat::subview(p_tgt,icol));
   });
   Kokkos::fence();
 
-}  // END spa_main
+  // Now use the interpolation object in || over all variables.
+  const int outer_iters = ncols*num_vars;
+  const auto policy_interp = ESU::get_default_team_policy(outer_iters, num_vert_packs);
+  Kokkos::parallel_for("spa_vert_interp_loop", policy_interp,
+    KOKKOS_LAMBDA(typename LIV::MemberType const& team) {
+
+    const int icol = team.league_rank() / num_vars;
+    const int ivar = team.league_rank() % num_vars;
+
+    const auto x1 = ekat::subview(p_src,icol);
+    const auto x2 = ekat::subview(p_tgt,icol);
+
+    const auto y1 = get_var_column(input, icol,ivar);
+    const auto y2 = get_var_column(output,icol,ivar);
+
+    vert_interp.lin_interp(team, x1, x2, y1, y2, icol);
+  });
+  Kokkos::fence();
+}
+
 /*-----------------------------------------------------------------*/
 // Function to read the weights for conducting horizontal remapping
 // from a file.
@@ -468,12 +462,12 @@ void SPAFunctions<S,D>
 template<typename S, typename D>
 void SPAFunctions<S,D>
 ::update_spa_data_from_file(
-    const std::string&    spa_data_file_name,
-    const Int             time_index,
-    const Int             nswbands,
-    const Int             nlwbands,
-          SPAHorizInterp& spa_horiz_interp,
-          SPAData&        spa_data)
+    const std::string&          spa_data_file_name,
+    const Int                   time_index,
+    const Int                   nswbands,
+    const Int                   nlwbands,
+          SPAHorizInterp&       spa_horiz_interp,
+          SPAInput&             spa_data)
 {
   // Ensure all ranks are operating independently when reading the file, so there's a copy on all ranks
   ekat::Comm self_comm(MPI_COMM_SELF);
@@ -493,7 +487,7 @@ void SPAFunctions<S,D>
   Int ncol = scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"ncol");
   const int source_data_nlevs = scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"lev");
   // Check that padding matches source size:
-  EKAT_REQUIRE(source_data_nlevs+2 == spa_data.nlevs);
+  EKAT_REQUIRE(source_data_nlevs+2 == spa_data.data.nlevs);
   // while we have the file open, check that the dimensions map the simulation and the horizontal interpolation structure
   EKAT_REQUIRE_MSG(nswbands==scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"swband"),"ERROR update_spa_data_from_file: Number of SW bands in simulation doesn't match the SPA data file");
   EKAT_REQUIRE_MSG(nlwbands==scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"lwband"),"ERROR update_spa_data_from_file: Number of LW bands in simulation doesn't match the SPA data file");
@@ -507,30 +501,15 @@ void SPAFunctions<S,D>
   //   then we will use the horizontal interpolation structure, spa_horiz_interp, to
   //   interpolate PS_v onto the simulation grid: PS_v -> spa_data.PS
   //   and so on for the other variables.
-  view_1d<Real> hyam_v("hyam",source_data_nlevs);
-  view_1d<Real> hybm_v("hybm",source_data_nlevs);
-  view_1d<Real> PS_v("PS",spa_horiz_interp.source_grid_ncols);
-  view_2d<Real> CCN3_v("CCN3",spa_horiz_interp.source_grid_ncols,source_data_nlevs);
-  view_3d<Real> AER_G_SW_v("AER_G_SW",spa_horiz_interp.source_grid_ncols,nswbands,source_data_nlevs);
-  view_3d<Real> AER_SSA_SW_v("AER_SSA_SW",spa_horiz_interp.source_grid_ncols,nswbands,source_data_nlevs);
-  view_3d<Real> AER_TAU_SW_v("AER_TAU_SW",spa_horiz_interp.source_grid_ncols,nswbands,source_data_nlevs);
-  view_3d<Real> AER_TAU_LW_v("AER_TAU_LW",spa_horiz_interp.source_grid_ncols,nlwbands,source_data_nlevs);
-  auto hyam_v_h          = Kokkos::create_mirror_view(hyam_v);
-  auto hybm_v_h          = Kokkos::create_mirror_view(hybm_v);
-  auto PS_v_h            = Kokkos::create_mirror_view(PS_v);
-  auto CCN3_v_h          = Kokkos::create_mirror_view(CCN3_v);
-  auto AER_G_SW_v_h      = Kokkos::create_mirror_view(AER_G_SW_v);
-  auto AER_SSA_SW_v_h    = Kokkos::create_mirror_view(AER_SSA_SW_v);
-  auto AER_TAU_SW_v_h    = Kokkos::create_mirror_view(AER_TAU_SW_v);
-  auto AER_TAU_LW_v_h    = Kokkos::create_mirror_view(AER_TAU_LW_v);
-  Kokkos::deep_copy(hyam_v_h,          hyam_v);                     
-  Kokkos::deep_copy(hybm_v_h,          hybm_v);                     
-  Kokkos::deep_copy(PS_v_h,            PS_v);                     
-  Kokkos::deep_copy(CCN3_v_h,          CCN3_v);                   
-  Kokkos::deep_copy(AER_G_SW_v_h,      AER_G_SW_v);               
-  Kokkos::deep_copy(AER_SSA_SW_v_h,    AER_SSA_SW_v);             
-  Kokkos::deep_copy(AER_TAU_SW_v_h,    AER_TAU_SW_v);             
-  Kokkos::deep_copy(AER_TAU_LW_v_h,    AER_TAU_LW_v);             
+  typename view_1d<Real>::HostMirror hyam_v_h("hyam",source_data_nlevs);
+  typename view_1d<Real>::HostMirror hybm_v_h("hybm",source_data_nlevs);
+  typename view_1d<Real>::HostMirror PS_v_h("PS",spa_horiz_interp.source_grid_ncols);
+  typename view_2d<Real>::HostMirror CCN3_v_h("CCN3",spa_horiz_interp.source_grid_ncols,source_data_nlevs);
+  typename view_3d<Real>::HostMirror AER_G_SW_v_h("AER_G_SW",spa_horiz_interp.source_grid_ncols,nswbands,source_data_nlevs);
+  typename view_3d<Real>::HostMirror AER_SSA_SW_v_h("AER_SSA_SW",spa_horiz_interp.source_grid_ncols,nswbands,source_data_nlevs);
+  typename view_3d<Real>::HostMirror AER_TAU_SW_v_h("AER_TAU_SW",spa_horiz_interp.source_grid_ncols,nswbands,source_data_nlevs);
+  typename view_3d<Real>::HostMirror AER_TAU_LW_v_h("AER_TAU_LW",spa_horiz_interp.source_grid_ncols,nlwbands,source_data_nlevs);
+
   // Construct the grid needed for input:
   auto grid = std::make_shared<PointGrid>("grid",spa_horiz_interp.source_grid_ncols,source_data_nlevs,self_comm);
   PointGrid::dofs_list_type dof_gids("",spa_horiz_interp.source_grid_ncols);
@@ -581,11 +560,11 @@ void SPAFunctions<S,D>
   auto hyam_h       = Kokkos::create_mirror_view(spa_data.hyam);
   auto hybm_h       = Kokkos::create_mirror_view(spa_data.hybm);
   auto ps_h         = Kokkos::create_mirror_view(spa_data.PS);
-  auto ccn3_h       = Kokkos::create_mirror_view(spa_data.CCN3);
-  auto aer_g_sw_h   = Kokkos::create_mirror_view(spa_data.AER_G_SW);
-  auto aer_ssa_sw_h = Kokkos::create_mirror_view(spa_data.AER_SSA_SW);
-  auto aer_tau_sw_h = Kokkos::create_mirror_view(spa_data.AER_TAU_SW);
-  auto aer_tau_lw_h = Kokkos::create_mirror_view(spa_data.AER_TAU_LW);
+  auto ccn3_h       = Kokkos::create_mirror_view(spa_data.data.CCN3);
+  auto aer_g_sw_h   = Kokkos::create_mirror_view(spa_data.data.AER_G_SW);
+  auto aer_ssa_sw_h = Kokkos::create_mirror_view(spa_data.data.AER_SSA_SW);
+  auto aer_tau_sw_h = Kokkos::create_mirror_view(spa_data.data.AER_TAU_SW);
+  auto aer_tau_lw_h = Kokkos::create_mirror_view(spa_data.data.AER_TAU_LW);
   Kokkos::deep_copy(hyam_h,0.0);
   Kokkos::deep_copy(hybm_h,0.0);
   Kokkos::deep_copy(ps_h,0.0);
@@ -658,13 +637,14 @@ void SPAFunctions<S,D>
   Kokkos::deep_copy(spa_data.hyam,hyam_h);
   Kokkos::deep_copy(spa_data.hybm,hybm_h);
   Kokkos::deep_copy(spa_data.PS,ps_h);
-  Kokkos::deep_copy(spa_data.CCN3,ccn3_h);
-  Kokkos::deep_copy(spa_data.AER_G_SW,aer_g_sw_h);
-  Kokkos::deep_copy(spa_data.AER_SSA_SW,aer_ssa_sw_h);
-  Kokkos::deep_copy(spa_data.AER_TAU_SW,aer_tau_sw_h);
-  Kokkos::deep_copy(spa_data.AER_TAU_LW,aer_tau_lw_h);
+  Kokkos::deep_copy(spa_data.data.CCN3,ccn3_h);
+  Kokkos::deep_copy(spa_data.data.AER_G_SW,aer_g_sw_h);
+  Kokkos::deep_copy(spa_data.data.AER_SSA_SW,aer_ssa_sw_h);
+  Kokkos::deep_copy(spa_data.data.AER_TAU_SW,aer_tau_sw_h);
+  Kokkos::deep_copy(spa_data.data.AER_TAU_LW,aer_tau_lw_h);
 
 } // END update_spa_data_from_file
+
 /*-----------------------------------------------------------------*/
 template<typename S, typename D>
 void SPAFunctions<S,D>
@@ -675,8 +655,8 @@ void SPAFunctions<S,D>
   const util::TimeStamp& ts,
         SPAHorizInterp&  spa_horiz_interp,
         SPATimeState&    time_state, 
-        SPAData&         spa_beg,
-        SPAData&         spa_end)
+        SPAInput&        spa_beg,
+        SPAInput&        spa_end)
 {
 
   // We always want to update the current time in the time_state.
@@ -703,19 +683,39 @@ void SPAFunctions<S,D>
   }
 
 } // END updata_spa_timestate
-/*-----------------------------------------------------------------*/
-// A helper function to manage basic linear interpolation in time.
-// The inputs of x0 and x1 represent the data to interpolate from at
-// times t0 and t1, respectively.  To keep the signature of the function 
-// simple we use
-//    t_norm = (t-t0)/(t1-t0).
-template<typename ScalarT, typename ScalarS>
-inline ScalarT linear_interp(
-  const ScalarT& x0,
-  const ScalarT& x1,
-  const ScalarS& t_norm)
+
+template<typename S,typename D>
+KOKKOS_INLINE_FUNCTION
+auto SPAFunctions<S,D>::
+get_var_column (const SPAData& data, const int icol, const int ivar)
+  -> view_1d<Spack> 
 {
-  return (1.0 - t_norm) * x0 + t_norm * x1;
+  if (ivar==0) {
+    return ekat::subview(data.CCN3,icol);
+  } else {
+    // NOTE: if we ever get 2+ long-wave vars, you will have to do 
+    //       something like
+    //    if (jvar<num_sw_vars) {..} else { // compute lw var index }
+    int jvar   = (ivar-1) / data.nswbands;
+    int swband = (ivar-1) % data.nswbands;
+    int lwband = (ivar-1) - 3*data.nswbands;
+    switch (jvar) {
+      case 0: return ekat::subview(data.AER_G_SW,icol,swband);
+      case 1: return ekat::subview(data.AER_SSA_SW,icol,swband); 
+      case 2: return ekat::subview(data.AER_TAU_SW,icol,swband); 
+      default: return ekat::subview(data.AER_TAU_LW,icol,lwband); 
+
+    }
+  }
+}
+
+template<typename S,typename D>
+template<typename ScalarX,typename ScalarT>
+KOKKOS_INLINE_FUNCTION
+ScalarX SPAFunctions<S,D>::
+linear_interp(const ScalarX& x0, const ScalarX& x1, const ScalarT& t)
+{
+  return (1 - t)*x0 + t*x1;
 }
 /*-----------------------------------------------------------------*/
 

--- a/components/scream/src/physics/spa/tests/spa_main_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_main_test.cpp
@@ -2,17 +2,15 @@
 
 #include "share/io/scream_scorpio_interface.hpp"
 #include "physics/spa/spa_functions.hpp"
+#include "share/util/scream_setup_random_test.hpp"
 #include "share/util/scream_time_stamp.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/ekat_parse_yaml_file.hpp"
+#include "ekat/util/ekat_arch.hpp"
+#include "ekat/util/ekat_test_utils.hpp"
+#include "ekat/ekat_pack.hpp"
 
-#include <algorithm>
-#include <array>
 #include <random>
-#include <thread>
 
 namespace {
 
@@ -29,371 +27,381 @@ using view_3d = typename KokkosTypes<DefaultDevice>::template view_3d<S>;
 using SPAFunc = spa::SPAFunctions<Real, DefaultDevice>;
 using Spack = SPAFunc::Spack;
 
-// Helper Functions
-std::pair<Real,Real> compute_max_min(const view_1d<Real>::HostMirror& input, const int start, const int end);
+using RPDF = std::uniform_real_distribution<Real>;
+using IPDF = std::uniform_int_distribution<int>;
 
-TEST_CASE("spa_read_data","spa")
+// Helper Functions
+std::pair<Real,Real> compute_min_max(const view_1d<Real>::HostMirror& input, const int start, const int end);
+
+template<typename Engine, typename PDF>
+void randomize (SPAFunc::SPAData& data, Engine& engine, PDF&& pdf);
+
+struct SPADataHost {
+  using view_2d_host = typename view_2d<Real>::HostMirror;
+  using view_3d_host = typename view_3d<Real>::HostMirror;
+
+  view_2d_host   ccn3;
+  view_3d_host   aer_g_sw;
+  view_3d_host   aer_ssa_sw;
+  view_3d_host   aer_tau_sw;
+  view_3d_host   aer_tau_lw;
+
+  SPADataHost (const SPAFunc::SPAData& spa_out) {
+    ccn3       = ekat::scalarize(Kokkos::create_mirror_view (spa_out.CCN3));
+    aer_g_sw   = ekat::scalarize(Kokkos::create_mirror_view (spa_out.AER_G_SW));
+    aer_ssa_sw = ekat::scalarize(Kokkos::create_mirror_view (spa_out.AER_SSA_SW));
+    aer_tau_sw = ekat::scalarize(Kokkos::create_mirror_view (spa_out.AER_TAU_SW));
+    aer_tau_lw = ekat::scalarize(Kokkos::create_mirror_view (spa_out.AER_TAU_LW));
+  }
+
+  void copy_from_dev (const SPAFunc::SPAData& spa_out) {
+    Kokkos::deep_copy (ccn3, ekat::scalarize(spa_out.CCN3));
+    Kokkos::deep_copy (aer_g_sw, ekat::scalarize(spa_out.AER_G_SW));
+    Kokkos::deep_copy (aer_ssa_sw, ekat::scalarize(spa_out.AER_SSA_SW));
+    Kokkos::deep_copy (aer_tau_sw, ekat::scalarize(spa_out.AER_TAU_SW));
+    Kokkos::deep_copy (aer_tau_lw, ekat::scalarize(spa_out.AER_TAU_LW));
+  }
+};
+
+TEST_CASE("spa_main")
 {
-  using C = scream::physics::Constants<Real>;
-  static constexpr auto P0 = C::P0;
+  auto engine = setup_random_test ();
 
  /* ====================================================================
   *                  Test Setup, create structures, etc.
   * ====================================================================*/
 
-  // Set up the mpi communicator and init the pio subsystem
-  ekat::Comm spa_comm(MPI_COMM_WORLD);  // MPI communicator group used for I/O set as ekat object.
-  MPI_Fint fcomm = MPI_Comm_c2f(spa_comm.mpi_comm());  // MPI communicator group used for I/O.  In our simple test we use MPI_COMM_WORLD, however a subset could be used.
-  scorpio::eam_init_pio_subsystem(fcomm);   // Gather the initial PIO subsystem data creater by component coupler
+  int ncols    = IPDF(1,10)(engine);
+  int nlevs    = 3;//IPDF(30,70)(engine);
+  int nswbands = IPDF(10,20)(engine);
+  int nlwbands = IPDF(10,20)(engine);
 
-  // Establish the SPA function object
-  using SPAFunc = spa::SPAFunctions<Real, DefaultDevice>;
-  using Spack = SPAFunc::Spack;
-  using gid_type = SPAFunc::gid_type;
-
-  std::string fname = "spa_main.yaml";
-  ekat::ParameterList test_params("Atmosphere Driver");
-  REQUIRE_NOTHROW ( parse_yaml_file(fname,test_params) );
-  test_params.print();
-
-  std::string spa_data_file = test_params.get<std::string>("SPA Data File");
-  Int ncols    = test_params.get<Int>("ncols");
-  Int nlevs    = test_params.get<Int>("nlevs");
-  Int nswbands = test_params.get<Int>("nswbands");
-  Int nlwbands = test_params.get<Int>("nlwbands");
-
-  // Break the test set of columns into local degrees of freedom per mpi rank
-  auto comm_size = spa_comm.size();
-  auto comm_rank = spa_comm.rank();
-
-  int my_ncols = ncols/comm_size + (comm_rank < ncols%comm_size ? 1 : 0);
-  view_1d<gid_type> dofs_gids("",my_ncols);
-  gid_type min_dof = 1; // Start global-ids from 1
-  Kokkos::parallel_for("", my_ncols, KOKKOS_LAMBDA(const int& ii) {
-    dofs_gids(ii) = min_dof + static_cast<gid_type>(comm_rank + ii*comm_size);
-  });
-  // Make sure that the total set of columns has been completely broken up.
-  Int test_total_ncols = 0;
-  spa_comm.all_reduce(&my_ncols,&test_total_ncols,1,MPI_SUM);
-  REQUIRE(test_total_ncols == ncols);
+  std::cout << " +---------------------------+\n";
+  std::cout << " |  SPA Interpolation sizes  |\n";
+  std::cout << " +---------------------------+\n";
+  std::cout << "    ncols   : " << ncols << "\n";
+  std::cout << "    nlevs   : " << nlevs << "\n";
+  std::cout << "    nswbands: " << nswbands << "\n";
+  std::cout << "    nlwbands: " << nlwbands << "\n";
+  std::cout << " +---------------------------+\n\n";
 
   // Set up the set of SPA structures needed to run the test
-  SPAFunc::SPAHorizInterp spa_horiz_interp;
-  spa_horiz_interp.m_comm = spa_comm;
-  SPAFunc::set_remap_weights_one_to_one(ncols,min_dof,dofs_gids,spa_horiz_interp);
-  SPAFunc::SPATimeState     spa_time_state;
-  SPAFunc::SPAData          spa_data_beg(dofs_gids.size(), nlevs+2, nswbands, nlwbands);
-  SPAFunc::SPAData          spa_data_end(dofs_gids.size(), nlevs+2, nswbands, nlwbands);
-  SPAFunc::SPAOutput        spa_data_out(dofs_gids.size(), nlevs,   nswbands, nlwbands);
-  auto pmid_tgt = view_2d<Spack>("",dofs_gids.size(),nlevs);
+  // Recall: SPAInput has padded values (for stable vertical interpolation)
+  SPAFunc::SPATimeState spa_time_state;
+  SPAFunc::SPAInput     spa_beg(ncols, nlevs+2, nswbands, nlwbands);
+  SPAFunc::SPAInput     spa_end(ncols, nlevs+2, nswbands, nlwbands);
+  SPAFunc::SPAInput     spa_tmp(ncols, nlevs+2, nswbands, nlwbands);
+  SPAFunc::SPAOutput    spa_out(ncols, nlevs,   nswbands, nlwbands);
 
-  // Verify that the interpolated values match the data, since no temporal or vertical interpolation
-  // should be done at this point.
-  
-  // Create local host views of all relevant data:
-  auto hyam_h         = Kokkos::create_mirror_view(spa_data_beg.hyam);
-  auto hybm_h         = Kokkos::create_mirror_view(spa_data_beg.hybm);
-  // Beg data for time interpolation
-  auto ps_beg         = Kokkos::create_mirror_view(spa_data_beg.PS);
-  auto ccn3_beg       = Kokkos::create_mirror_view(spa_data_beg.CCN3);
-  auto aer_g_sw_beg   = Kokkos::create_mirror_view(spa_data_beg.AER_G_SW);
-  auto aer_ssa_sw_beg = Kokkos::create_mirror_view(spa_data_beg.AER_SSA_SW);
-  auto aer_tau_sw_beg = Kokkos::create_mirror_view(spa_data_beg.AER_TAU_SW);
-  auto aer_tau_lw_beg = Kokkos::create_mirror_view(spa_data_beg.AER_TAU_LW);
-  // End data for time interpolation
-  auto ps_end         = Kokkos::create_mirror_view(spa_data_end.PS);
-  auto ccn3_end       = Kokkos::create_mirror_view(spa_data_end.CCN3);
-  auto aer_g_sw_end   = Kokkos::create_mirror_view(spa_data_end.AER_G_SW);
-  auto aer_ssa_sw_end = Kokkos::create_mirror_view(spa_data_end.AER_SSA_SW);
-  auto aer_tau_sw_end = Kokkos::create_mirror_view(spa_data_end.AER_TAU_SW);
-  auto aer_tau_lw_end = Kokkos::create_mirror_view(spa_data_end.AER_TAU_LW);
-  // Output
-  auto ccn3_h       = Kokkos::create_mirror_view(spa_data_out.CCN3);
-  auto aer_g_sw_h   = Kokkos::create_mirror_view(spa_data_out.AER_G_SW);
-  auto aer_ssa_sw_h = Kokkos::create_mirror_view(spa_data_out.AER_SSA_SW);
-  auto aer_tau_sw_h = Kokkos::create_mirror_view(spa_data_out.AER_TAU_SW);
-  auto aer_tau_lw_h = Kokkos::create_mirror_view(spa_data_out.AER_TAU_LW);
-  
-  // First initialize the start and end month data:  Set for January
-  util::TimeStamp ts(1900,1,1,0,0,0);
-  SPAFunc::update_spa_timestate(spa_data_file,nswbands,nlwbands,ts,spa_horiz_interp,spa_time_state,spa_data_beg,spa_data_end);
+  // Create local host copies of all relevant data:
+  SPADataHost data_beg_h(spa_beg.data);
+  SPADataHost data_end_h(spa_end.data);
+  SPADataHost data_tmp_h(spa_tmp.data);
+  SPADataHost data_out_h(spa_out);
+  auto ps_beg_h = Kokkos::create_mirror_view(spa_beg.PS);
+  auto ps_end_h = Kokkos::create_mirror_view(spa_end.PS);
+  auto ps_tmp_h = Kokkos::create_mirror_view(spa_tmp.PS);
 
-  Kokkos::deep_copy(hyam_h        ,spa_data_beg.hyam);
-  Kokkos::deep_copy(hybm_h        ,spa_data_beg.hybm);
-  Kokkos::deep_copy(ps_beg        ,spa_data_beg.PS);
-  Kokkos::deep_copy(ccn3_beg      ,spa_data_beg.CCN3);
-  Kokkos::deep_copy(aer_g_sw_beg  ,spa_data_beg.AER_G_SW);
-  Kokkos::deep_copy(aer_ssa_sw_beg,spa_data_beg.AER_SSA_SW);
-  Kokkos::deep_copy(aer_tau_sw_beg,spa_data_beg.AER_TAU_SW);
-  Kokkos::deep_copy(aer_tau_lw_beg,spa_data_beg.AER_TAU_LW);
-  Kokkos::deep_copy(ps_end        ,spa_data_end.PS);
-  Kokkos::deep_copy(ccn3_end      ,spa_data_end.CCN3);
-  Kokkos::deep_copy(aer_g_sw_end  ,spa_data_end.AER_G_SW);
-  Kokkos::deep_copy(aer_ssa_sw_end,spa_data_end.AER_SSA_SW);
-  Kokkos::deep_copy(aer_tau_sw_end,spa_data_end.AER_TAU_SW);
-  Kokkos::deep_copy(aer_tau_lw_end,spa_data_end.AER_TAU_LW);
+  // First initialize the time_state: set for January run
+  util::TimeStamp t_beg(1900,1,1,0,0,0);
+  util::TimeStamp t_end(1900,2,1,0,0,0);
+  spa_time_state.current_month = t_beg.get_month();
+  spa_time_state.t_beg_month = t_beg.frac_of_year_in_days();
+  spa_time_state.days_this_month = util::days_in_month(t_beg.get_year(),t_beg.get_month());
+  spa_time_state.inited = true;
 
- /* ====================================================================
-  * Test that spa_main is the identity when no time interpolation and
-  * matching pressure profiles.
-  *
-  * In this section we set the target pressure profile to match the
-  * expected source pressure profile that will be calculate in spa_main.
-  * We test when the time stamp is both at the beginning of the month and
-  * the end of the month, which should be the identity for data_out matching
-  * data_beg and data_end, respectively.
-  * ====================================================================*/
-  // Create the pressure state.  Note, we need to create the pmid values for the actual data.  We will build it based on the PS and hya/bm
-  // coordinates in the beginning data.
-  auto dofs_gids_h = Kokkos::create_mirror_view(dofs_gids);
-  Kokkos::deep_copy(dofs_gids_h,dofs_gids);
+  // Generate random beg/end data
+  randomize(spa_beg.data,engine,RPDF(1.0,10.0));
+  randomize(spa_end.data,engine,RPDF(1.0,10.0));
+  ekat::genRandArray(spa_beg.PS,engine,RPDF(9e4,1.1e5));
+  ekat::genRandArray(spa_end.PS,engine,RPDF(9e4,1.1e5));
 
-  auto pmid_tgt_h = Kokkos::create_mirror_view(pmid_tgt);
+  // These won't change between tests, so deep copy to host right away.
+  data_beg_h.copy_from_dev(spa_beg.data);
+  data_end_h.copy_from_dev(spa_end.data);
+  Kokkos::deep_copy(ps_beg_h,spa_beg.PS);
+  Kokkos::deep_copy(ps_end_h,spa_end.PS);
 
-  // Note, hyam and hybm are padded
-  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
-    for (int kk=0;kk<nlevs;kk++) {
-      int kpack = kk / Spack::n;
-      int kidx  = kk % Spack::n;
-      int kpack_pad = (kk+1) / Spack::n;
-      int kidx_pad  = (kk+1) % Spack::n;
-      pmid_tgt_h(dof_i,kpack)[kidx] = ps_beg(dof_i)*hybm_h(kpack_pad)[kidx_pad] + P0*hyam_h(kpack_pad)[kidx_pad];
-    }
-  }
-  Kokkos::deep_copy(pmid_tgt,pmid_tgt_h);
+  // ======================================================== //
+  //                Test elemental interpolation              //
+  // ======================================================== //
 
-  // Run SPA main
-  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_end,spa_data_out)
+  std::cout << "  -> elemental linear interp\n";
+  Spack x0, x1;
+  ekat::genRandArray(&x0,1,engine,RPDF(-10.0,10.0));
+  ekat::genRandArray(&x1,1,engine,RPDF(-10.0,10.0));
 
-  Kokkos::deep_copy(ccn3_h      , spa_data_out.CCN3);
-  Kokkos::deep_copy(aer_g_sw_h  , spa_data_out.AER_G_SW);
-  Kokkos::deep_copy(aer_ssa_sw_h, spa_data_out.AER_SSA_SW);
-  Kokkos::deep_copy(aer_tau_sw_h, spa_data_out.AER_TAU_SW);
-  Kokkos::deep_copy(aer_tau_lw_h, spa_data_out.AER_TAU_LW);
+  REQUIRE ( (SPAFunc::linear_interp(x0,x1,0)==x0).all() );
+  REQUIRE ( (SPAFunc::linear_interp(x0,x1,1.0)==x1).all() );
 
-  // The output data should match the input data exactly since there is no time interpolation
-  // and the pmid profile should match the constructed profile within spa_main.
-  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
-    for (int kk=0;kk<nlevs;kk++) {
-      int kpack = kk / Spack::n;
-      int kidx  = kk % Spack::n;
-      int kpack_pad = (kk+1) / Spack::n;
-      int kidx_pad  = (kk+1) % Spack::n;
-      REQUIRE(ccn3_h(dof_i,kpack)[kidx] == ccn3_beg(dof_i,kpack_pad)[kidx_pad] );
-      for (int n=0;n<nswbands;n++) {
-        REQUIRE(aer_g_sw_h(dof_i,n,kpack)[kidx]   == aer_g_sw_beg(dof_i,n,kpack_pad)[kidx_pad]);
-        REQUIRE(aer_ssa_sw_h(dof_i,n,kpack)[kidx] == aer_ssa_sw_beg(dof_i,n,kpack_pad)[kidx_pad] );
-        REQUIRE(aer_tau_sw_h(dof_i,n,kpack)[kidx] == aer_tau_sw_beg(dof_i,n,kpack_pad)[kidx_pad] );
+  std::cout << "  -> elemental linear interp .............................. OK!\n";
+
+  // ======================================================== //
+  //                Test time interpolation                   //
+  // ======================================================== //
+
+  // 1. If t=t_beg, we should get back spa_beg
+  std::cout << "  -> time interp, t=t_beg\n";
+
+  spa_time_state.t_now = t_beg.frac_of_year_in_days();
+  SPAFunc::perform_time_interpolation(spa_time_state,spa_beg,spa_end,spa_tmp);
+  data_tmp_h.copy_from_dev(spa_tmp.data);
+  Kokkos::deep_copy(ps_tmp_h,spa_tmp.PS);
+
+  for (int i=0; i<ncols; ++i) {
+    REQUIRE (ps_tmp_h(i) == ps_beg_h(i));
+    for (int k=0; k<nlevs+2; ++k) {
+      REQUIRE (data_tmp_h.ccn3(i,k) == data_beg_h.ccn3(i,k));
+      for (int n=0; n<nswbands; ++n) {
+        REQUIRE (data_tmp_h.aer_g_sw(i,n,k) == data_beg_h.aer_g_sw(i,n,k));
+        REQUIRE (data_tmp_h.aer_ssa_sw(i,n,k) == data_beg_h.aer_ssa_sw(i,n,k));
+        REQUIRE (data_tmp_h.aer_tau_sw(i,n,k) == data_beg_h.aer_tau_sw(i,n,k));
       }
-      for (int n=0;n<nlwbands;n++) {
-        REQUIRE(aer_tau_lw_h(dof_i,n,kpack)[kidx] == aer_tau_lw_beg(dof_i,n,kpack_pad)[kidx_pad] );
+      for (int n=0; n<nlwbands; ++n) {
+        REQUIRE (data_tmp_h.aer_tau_lw(i,n,k) == data_beg_h.aer_tau_lw(i,n,k));
       }
     }
   }
+  std::cout << "  -> time interp, t=t_beg ................................. OK!\n";
 
-  /* Here we test the end of the month */
-  // Add a month and recalculate.  Should now match the end of the month data.
-  ts += util::days_in_month(ts.get_year(),ts.get_month())*86400;
-  spa_time_state.t_now = ts.frac_of_year_in_days();
+  // 2. If t=t_end, we should get back spa_end
+  std::cout << "  -> time interp, t=t_end\n";
 
-  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
-    for (int kk=0;kk<nlevs;kk++) {
-      int kpack = kk / Spack::n;
-      int kidx  = kk % Spack::n;
-      int kpack_pad = (kk+1) / Spack::n;
-      int kidx_pad  = (kk+1) % Spack::n;
-      pmid_tgt_h(dof_i,kpack)[kidx] = ps_end(dof_i)*hybm_h(kpack_pad)[kidx_pad] + P0*hyam_h(kpack_pad)[kidx_pad];
-    }
-  }
-  Kokkos::deep_copy(pmid_tgt,pmid_tgt_h);
-  
-  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_end,spa_data_out);
-  Kokkos::deep_copy(ccn3_h      , spa_data_out.CCN3);
-  Kokkos::deep_copy(aer_g_sw_h  , spa_data_out.AER_G_SW);
-  Kokkos::deep_copy(aer_ssa_sw_h, spa_data_out.AER_SSA_SW);
-  Kokkos::deep_copy(aer_tau_sw_h, spa_data_out.AER_TAU_SW);
-  Kokkos::deep_copy(aer_tau_lw_h, spa_data_out.AER_TAU_LW);
+  spa_time_state.t_now = t_end.frac_of_year_in_days();
+  SPAFunc::perform_time_interpolation(spa_time_state,spa_beg,spa_end,spa_tmp);
+  data_tmp_h.copy_from_dev(spa_tmp.data);
+  Kokkos::deep_copy(ps_tmp_h,spa_tmp.PS);
 
-  // The output data should match the input data exactly since there is no time interpolation
-  // and the pmid profile should match the constructed profile within spa_main.
-  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
-    for (int kk=0;kk<nlevs;kk++) {
-      int kpack     = kk / Spack::n;
-      int kidx      = kk % Spack::n;
-      int kpack_pad = (kk+1) / Spack::n;
-      int kidx_pad  = (kk+1) % Spack::n;
-      REQUIRE(ccn3_h(dof_i,kpack)[kidx] == ccn3_end(dof_i,kpack_pad)[kidx_pad] );
-      for (int n=0;n<nswbands;n++) {
-        REQUIRE(aer_g_sw_h(dof_i,n,kpack)[kidx]   == aer_g_sw_end(dof_i,n,kpack_pad)[kidx_pad]   );
-        REQUIRE(aer_ssa_sw_h(dof_i,n,kpack)[kidx] == aer_ssa_sw_end(dof_i,n,kpack_pad)[kidx_pad] );
-        REQUIRE(aer_tau_sw_h(dof_i,n,kpack)[kidx] == aer_tau_sw_end(dof_i,n,kpack_pad)[kidx_pad] );
+  for (int i=0; i<ncols; ++i) {
+    REQUIRE (ps_tmp_h(i) == ps_end_h(i));
+    for (int k=0; k<nlevs+2; ++k) {
+      REQUIRE (data_tmp_h.ccn3(i,k) == data_end_h.ccn3(i,k));
+      for (int n=0; n<nswbands; ++n) {
+        REQUIRE (data_tmp_h.aer_g_sw(i,n,k) == data_end_h.aer_g_sw(i,n,k));
+        REQUIRE (data_tmp_h.aer_ssa_sw(i,n,k) == data_end_h.aer_ssa_sw(i,n,k));
+        REQUIRE (data_tmp_h.aer_tau_sw(i,n,k) == data_end_h.aer_tau_sw(i,n,k));
       }
-      for (int n=0;n<nlwbands;n++) {
-        REQUIRE(aer_tau_lw_h(dof_i,n,kpack)[kidx] == aer_tau_lw_end(dof_i,n,kpack_pad)[kidx_pad] );
+      for (int n=0; n<nlwbands; ++n) {
+        REQUIRE (data_tmp_h.aer_tau_lw(i,n,k) == data_end_h.aer_tau_lw(i,n,k));
       }
     }
   }
- /* ====================================================================
-  * Test that the time interpolation is bounded by the data:
-  *
-  * In the above tests we established that when the pressure profile for
-  * source and data match and there is no time interpolation the output
-  * data and input data match.
-  *
-  * Here we introduce time interpolation by picking the middle of the month
-  * between beginning and ending months of data.  We set the target pressure profile
-  * to match the profile expected for the source data in spa_main so that
-  * only time interpolation is tested and check that all output values are
-  * bounded by the min/max of the beggining/ending data.
-  * ====================================================================*/
-  // Add a few days and update spa data.  Make sure that the output values are not outside of the bounds
-  // of the actual SPA data 
-  ts += (int)(util::days_in_month(ts.get_year(),ts.get_month())*0.5)*86400;
-  SPAFunc::update_spa_timestate(spa_data_file,nswbands,nlwbands,ts,spa_horiz_interp,spa_time_state,spa_data_beg,spa_data_end);
-  Kokkos::deep_copy(ps_beg        ,spa_data_beg.PS);
-  Kokkos::deep_copy(ccn3_beg      ,spa_data_beg.CCN3);
-  Kokkos::deep_copy(aer_g_sw_beg  ,spa_data_beg.AER_G_SW);
-  Kokkos::deep_copy(aer_ssa_sw_beg,spa_data_beg.AER_SSA_SW);
-  Kokkos::deep_copy(aer_tau_sw_beg,spa_data_beg.AER_TAU_SW);
-  Kokkos::deep_copy(aer_tau_lw_beg,spa_data_beg.AER_TAU_LW);
-  Kokkos::deep_copy(ps_end        ,spa_data_end.PS);
-  Kokkos::deep_copy(ccn3_end      ,spa_data_end.CCN3);
-  Kokkos::deep_copy(aer_g_sw_end  ,spa_data_end.AER_G_SW);
-  Kokkos::deep_copy(aer_ssa_sw_end,spa_data_end.AER_SSA_SW);
-  Kokkos::deep_copy(aer_tau_sw_end,spa_data_end.AER_TAU_SW);
-  Kokkos::deep_copy(aer_tau_lw_end,spa_data_end.AER_TAU_LW);
-  // Create a target pressure profile to interpolate onto that matches what spa_main will compute for the source data 
-  auto& t_now = spa_time_state.t_now;
-  auto& t_beg = spa_time_state.t_beg_month;
-  auto& t_len = spa_time_state.days_this_month;
-  auto t_norm = (t_now-t_beg)/t_len;
-  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
-    for (int kk=0;kk<nlevs;kk++) {
-      int kpack     = kk / Spack::n;
-      int kidx      = kk % Spack::n;
-      int kpack_pad = (kk+1) / Spack::n;
-      int kidx_pad  = (kk+1) % Spack::n;
-      Real ps = (1.0 - t_norm) * ps_beg(dof_i) + t_norm * ps_end(dof_i);
-      pmid_tgt_h(dof_i,kpack)[kidx] = ps*hybm_h(kpack_pad)[kidx_pad] + P0*hyam_h(kpack_pad)[kidx_pad];
-    }
-  }
-  Kokkos::deep_copy(pmid_tgt,pmid_tgt_h);
+  std::cout << "  -> time interp, t=t_end ................................. OK!\n";
 
-  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_end,spa_data_out);
-  Kokkos::deep_copy(ccn3_h      , spa_data_out.CCN3);
-  Kokkos::deep_copy(aer_g_sw_h  , spa_data_out.AER_G_SW);
-  Kokkos::deep_copy(aer_ssa_sw_h, spa_data_out.AER_SSA_SW);
-  Kokkos::deep_copy(aer_tau_sw_h, spa_data_out.AER_TAU_SW);
-  Kokkos::deep_copy(aer_tau_lw_h, spa_data_out.AER_TAU_LW);
+  // 3. Since time interpolation is convex, the output is bounded by the input
+  std::cout << "  -> time interp, t_beg<t<t_end\n";
 
-  // Make sure the output data is within the same bounds as the input data.  We check bounds in each column and level.
-  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
-    for (int kk=0;kk<nlevs;kk++) {
-      int kpack = kk / Spack::n;
-      int kidx  = kk % Spack::n;
-      int kpack_pad = (kk+1) / Spack::n;
-      int kidx_pad  = (kk+1) % Spack::n;
-      REQUIRE(ccn3_h(dof_i,kpack)[kidx]>=std::min(ccn3_beg(dof_i,kpack_pad)[kidx_pad],ccn3_end(dof_i,kpack_pad)[kidx_pad]));
-      REQUIRE(ccn3_h(dof_i,kpack)[kidx]<=std::max(ccn3_beg(dof_i,kpack_pad)[kidx_pad],ccn3_end(dof_i,kpack_pad)[kidx_pad]));
-      for (int n=0;n<nswbands;n++) {
-        REQUIRE(aer_g_sw_h(dof_i,n,kpack)[kidx]   >= std::min(aer_g_sw_beg(dof_i,n,kpack_pad)[kidx_pad],aer_g_sw_end(dof_i,n,kpack_pad)[kidx_pad]) );
-        REQUIRE(aer_g_sw_h(dof_i,n,kpack)[kidx]   <= std::max(aer_g_sw_beg(dof_i,n,kpack_pad)[kidx_pad],aer_g_sw_end(dof_i,n,kpack_pad)[kidx_pad]) );
+  RPDF pdf(0.001,0.999);
+  auto dt = int ( (t_end-t_beg) * pdf(engine) );
 
-        REQUIRE(aer_ssa_sw_h(dof_i,n,kpack)[kidx] >= std::min(aer_ssa_sw_beg(dof_i,n,kpack_pad)[kidx_pad],aer_ssa_sw_end(dof_i,n,kpack_pad)[kidx_pad]) );
-        REQUIRE(aer_ssa_sw_h(dof_i,n,kpack)[kidx] <= std::max(aer_ssa_sw_beg(dof_i,n,kpack_pad)[kidx_pad],aer_ssa_sw_end(dof_i,n,kpack_pad)[kidx_pad]) );
+  auto t_mid = t_beg + dt;
+  spa_time_state.t_now = t_mid.frac_of_year_in_days();
+  SPAFunc::perform_time_interpolation(spa_time_state,spa_beg,spa_end,spa_tmp);
+  data_tmp_h.copy_from_dev(spa_tmp.data);
+  Kokkos::deep_copy(ps_tmp_h,spa_tmp.PS);
 
-        REQUIRE(aer_tau_sw_h(dof_i,n,kpack)[kidx] >= std::min(aer_tau_sw_beg(dof_i,n,kpack_pad)[kidx_pad],aer_tau_sw_end(dof_i,n,kpack_pad)[kidx_pad]) );
-        REQUIRE(aer_tau_sw_h(dof_i,n,kpack)[kidx] <= std::max(aer_tau_sw_beg(dof_i,n,kpack_pad)[kidx_pad],aer_tau_sw_end(dof_i,n,kpack_pad)[kidx_pad]) );
+  auto max_min = [&] (const Real v0, const Real v1) -> std::pair<Real,Real> {
+    using pair_t = std::pair<Real,Real>;
+    return (v0>v1 ? pair_t{v0,v1} : pair_t{v1,v0});
+  };
+  auto check_time_bounds = [&] (const Real v, const std::pair<Real,Real>& bounds) {
+    REQUIRE ( v <= bounds.first  );
+    REQUIRE ( v >= bounds.second );
+  };
+  for (int i=0; i<ncols; ++i) {
+    REQUIRE (ps_tmp_h(i) >= std::min(ps_beg_h(i),ps_end_h(i)));
+    REQUIRE (ps_tmp_h(i) <= std::max(ps_beg_h(i),ps_end_h(i)));
+    for (int k=0; k<nlevs+2; ++k) {
+      auto ccn3_bounds = max_min (data_end_h.ccn3(i,k),data_beg_h.ccn3(i,k));
+      check_time_bounds (data_tmp_h.ccn3(i,k),ccn3_bounds);
+
+      for (int n=0; n<nswbands; ++n) {
+        auto aer_g_sw_bounds = max_min(data_end_h.aer_g_sw(i,n,k),
+                                       data_beg_h.aer_g_sw(i,n,k));
+        check_time_bounds (data_tmp_h.aer_g_sw(i,n,k), aer_g_sw_bounds);
+
+        auto aer_ssa_sw_bounds = max_min(data_end_h.aer_ssa_sw(i,n,k),
+                                         data_beg_h.aer_ssa_sw(i,n,k));
+        check_time_bounds (data_tmp_h.aer_ssa_sw(i,n,k), aer_ssa_sw_bounds);
+
+        auto aer_tau_sw_bounds = max_min(data_end_h.aer_tau_sw(i,n,k),
+                                         data_beg_h.aer_tau_sw(i,n,k));
+        check_time_bounds (data_tmp_h.aer_tau_sw(i,n,k), aer_tau_sw_bounds);
       }
-      for (int n=0;n<nlwbands;n++) {
-        REQUIRE(aer_tau_lw_h(dof_i,n,kpack)[kidx] >= std::min(aer_tau_lw_beg(dof_i,n,kpack_pad)[kidx_pad],aer_tau_lw_end(dof_i,n,kpack_pad)[kidx_pad]) );
-        REQUIRE(aer_tau_lw_h(dof_i,n,kpack)[kidx] <= std::max(aer_tau_lw_beg(dof_i,n,kpack_pad)[kidx_pad],aer_tau_lw_end(dof_i,n,kpack_pad)[kidx_pad]) );
+      for (int n=0; n<nlwbands; ++n) {
+        auto aer_tau_lw_bounds = max_min(data_end_h.aer_tau_lw(i,n,k),
+                                         data_beg_h.aer_tau_lw(i,n,k));
+        check_time_bounds (data_tmp_h.aer_tau_lw(i,n,k), aer_tau_lw_bounds);
       }
     }
   }
-
- /* ====================================================================
-  * Test that the vertical interpolation is witin the bounds of the source data
-  * on a per column basis.
-  *
-  * For simplicity we set data_beg = data_end which will ensure that no the
-  * time interpolation returns the identity.
-  *
-  * We set the target pressure level to be outside of the source pressure level
-  * that we expect spa_main to calculate.  We do this by bumping the surface pressure
-  * for the target pressure up by 5% and halve the top-of-model pressure.
-  *
-  * This will require the vertical interpolation to apply the boundary conditions, which
-  * should be still bounded by the max/min of the total column.
-  * ====================================================================*/
-  // Create a target pressure profile to interpolate onto that has a slightly higher surface pressure that the bounds.
-  // This will force extrapolation.
-  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
-    for (int kk=0;kk<nlevs;kk++) {
-      int kpack     = kk / Spack::n;
-      int kidx      = kk % Spack::n;
-      int kpack_pad = (kk+1) / Spack::n;
-      int kidx_pad  = (kk+1) % Spack::n;
-      // If kk=0 then we are top-of-model, so we decrease the pressure.  Otherwise go with bigger pressure.
-      Real ps   = kk==0 ? ps_beg(dof_i) : 1.05*ps_beg(dof_i);
-      Real mult = kk==0 ? 0.5 : 1.0;
-      pmid_tgt_h(dof_i,kpack)[kidx] = mult*(ps*hybm_h(kpack_pad)[kidx_pad] + P0*hyam_h(kpack_pad)[kidx_pad]);
-    }
-  }
-  Kokkos::deep_copy(pmid_tgt,pmid_tgt_h);
-
-  // Note, here we pass spa_data_beg twice, as both bounds of the input data.
-  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_beg,spa_data_out);
-  Kokkos::deep_copy(ccn3_h      , spa_data_out.CCN3);
-  Kokkos::deep_copy(aer_g_sw_h  , spa_data_out.AER_G_SW);
-  Kokkos::deep_copy(aer_ssa_sw_h, spa_data_out.AER_SSA_SW);
-  Kokkos::deep_copy(aer_tau_sw_h, spa_data_out.AER_TAU_SW);
-  Kokkos::deep_copy(aer_tau_lw_h, spa_data_out.AER_TAU_LW);
+  std::cout << "  -> time interp, t_beg<t<t_end ........................... OK!\n";
 
   using col_type = view_1d<Real>::HostMirror;
+
+  // ======================================================== //
+  //                Test vert interpolation                   //
+  // ======================================================== //
+
+  // Create a target pressure profile to interpolate onto.
+  // NOTE: set a slightly higher surface pressure than the p_src,
+  //       to ensure spa vert interpolation extrapolates correctly.
+  auto npacks_src = ekat::PackInfo<Spack::n>::num_packs(nlevs+2);
+  auto npacks_tgt = ekat::PackInfo<Spack::n>::num_packs(nlevs);
+  auto p_src = view_2d<Spack>("",ncols,npacks_src);
+  auto p_tgt = view_2d<Spack>("",ncols,npacks_tgt);
+  auto p_tgt_h = Kokkos::create_mirror_view(ekat::scalarize(p_tgt));
+  auto p_src_h = Kokkos::create_mirror_view(ekat::scalarize(p_src));
+
+  // Make a monotonic tgt pressure profile
+  ekat::genRandArray(p_tgt,engine,RPDF(1e3,1e5));
+  for (int i=0; i<ncols; ++i) {
+    auto col = ekat::subview(p_tgt_h,i);
+    std::sort(col.data(),col.data()+nlevs);
+  }
+  Kokkos::deep_copy(ekat::scalarize(p_tgt),p_tgt_h);
+
+  // 1. If p_src==p_tgt, we should get back the input data
+  std::cout << "  -> vert interp, p_tgt = p_src\n";
+
+  for (int i=0; i<ncols; ++i) {
+    p_src_h(i,0) = 0;
+    for (int k=0; k<nlevs; ++k) {
+      if (k<nlevs/2) {
+        p_src_h(i,k+1) = p_tgt_h(i,k);
+      } else {
+        p_src_h(i,k+1) = p_tgt_h(i,k);
+      }
+    }
+    p_src_h(i,nlevs+1) = 10*p_src_h(i,nlevs);
+  }
+  Kokkos::deep_copy(ekat::scalarize(p_src),p_src_h);
+
+  // Run vertical interpolation
+  SPAFunc::perform_vertical_interpolation(p_src,p_tgt,spa_beg.data,spa_out);
+  data_out_h.copy_from_dev(spa_out);
+
+  for (int i=0; i<ncols; ++i) {
+    for (int k=0; k<nlevs; ++k) {
+      REQUIRE (data_out_h.ccn3(i,k) == data_beg_h.ccn3(i,k+1));
+      for (int n=0; n<nswbands; ++n) {
+        REQUIRE (data_out_h.aer_g_sw(i,n,k) == data_beg_h.aer_g_sw(i,n,k+1));
+        REQUIRE (data_out_h.aer_ssa_sw(i,n,k) == data_beg_h.aer_ssa_sw(i,n,k+1));
+        REQUIRE (data_out_h.aer_tau_sw(i,n,k) == data_beg_h.aer_tau_sw(i,n,k+1));
+      }
+      for (int n=0; n<nlwbands; ++n) {
+        REQUIRE (data_out_h.aer_tau_lw(i,n,k) == data_beg_h.aer_tau_lw(i,n,k+1));
+      }
+    }
+  }
+  std::cout << "  -> vert interp, p_tgt = p_src ........................... OK!\n";
+
+  // 2. If p_src!=p_tgt, for each column verify that each level of output
+  //    is bounded by max/min of input over column.
+  //    Note: make p_tgt<p_src toward TOM, and p_tgt>p_src toward surface
+  std::cout << "  -> vert interp, p_tgt!=p_src and extrapolation needed\n";
+
+  for (int i=0; i<ncols; ++i) {
+    p_src_h(i,0) = 0;
+    for (int k=1; k<=nlevs; ++k) {
+      if (k<nlevs/2) {
+        p_src_h(i,k) = 0.9*p_tgt_h(i,k-1);
+      } else {
+        p_src_h(i,k) = 1.1*p_tgt_h(i,k-1);
+      }
+    }
+    p_src_h(i,nlevs+1) = 10*p_src_h(i,nlevs);
+  }
+  Kokkos::deep_copy(ekat::scalarize(p_src),p_src_h);
+
+  // Run vertical interpolation
+  SPAFunc::perform_vertical_interpolation(p_src,p_tgt,spa_beg.data,spa_out);
+  data_out_h.copy_from_dev(spa_out);
+
+  // Helper lambda: verify max/min of output bounded by max/min of data
   auto check_bounds = [&](const col_type& data,const col_type& output) {
-    auto data_minmax   = compute_max_min(data,0,nlevs+1);
-    auto output_minmax = compute_max_min(output,0,nlevs-1);
+    auto data_minmax   = compute_min_max(data,0,nlevs+2); // Recall: data is padded
+    auto output_minmax = compute_min_max(output,0,nlevs);
     REQUIRE( data_minmax.first  <= output_minmax.first );
     REQUIRE( data_minmax.second >= output_minmax.second );
   };
+  auto sv = [&](const view_3d<Real>::HostMirror& v, const int col, const int band) -> col_type {
+    return ekat::subview(v,col,band);
+  };
 
-  for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
-    auto ssv = [&](const view_3d<Spack>::HostMirror& v, const int col, const int band) -> col_type {
-      return ekat::subview(ekat::scalarize(v),col,band);
-    };
-    const auto& ccn3_in  = ekat::subview(ekat::scalarize(ccn3_beg),dof_i);
-    const auto& ccn3_out = ekat::subview(ekat::scalarize(ccn3_h),dof_i);
+  for (int i=0; i<ncols; ++i) {
+    const auto& ccn3_in  = ekat::subview(data_beg_h.ccn3,i);
+    const auto& ccn3_out = ekat::subview(data_out_h.ccn3,i);
     check_bounds( ccn3_in, ccn3_out );
     for (int n=0;n<nswbands;n++) {
-      check_bounds (ssv(aer_g_sw_beg,dof_i,n),ssv(aer_g_sw_h,dof_i,n));
-      check_bounds (ssv(aer_ssa_sw_beg,dof_i,n),ssv(aer_ssa_sw_h,dof_i,n));
-      check_bounds (ssv(aer_tau_sw_beg,dof_i,n),ssv(aer_tau_sw_h,dof_i,n));
+      check_bounds (sv(data_beg_h.aer_g_sw,i,n),  sv(data_out_h.aer_g_sw,i,n));
+      check_bounds (sv(data_beg_h.aer_ssa_sw,i,n),sv(data_out_h.aer_ssa_sw,i,n));
+      check_bounds (sv(data_beg_h.aer_tau_sw,i,n),sv(data_out_h.aer_tau_sw,i,n));
     }
     for (int n=0;n<nlwbands;n++) {
-      check_bounds (ssv(aer_tau_lw_beg,dof_i,n),ssv(aer_tau_lw_h,dof_i,n));
+      check_bounds (sv(data_beg_h.aer_tau_lw,i,n),sv(data_out_h.aer_tau_lw,i,n));
     }
   }
- /* ====================================================================
-  *                         DONE WITH TESTS
-  * ====================================================================*/
-  // All Done 
-  scorpio::eam_pio_finalize();
-} // run_property
+  std::cout << "  -> vert interp, p_tgt!=p_src and extrapolation needed ... OK!\n\n";
+}
 
-// Helper function
-std::pair<Real,Real> compute_max_min(const view_1d<Real>::HostMirror& input, const int start, const int end)
+// Compute min/max of input over [start,end) indices
+std::pair<Real,Real> compute_min_max(const view_1d<Real>::HostMirror& input, const int start, const int end)
 {
   std::pair<Real,Real> result;
   // Initialize min and max with first entry in input
   result.first = input[start];
   result.second = input[start];
   // Now go through the rest of the view
-  for (int kk = start+1; kk<=end; kk++) {
-    result.first  = std::min(result.first,input[kk]);
-    result.second = std::max(result.second,input[kk]);
+  for (int k = start+1; k<end; k++) {
+    result.first  = std::min(result.first,input[k]);
+    result.second = std::max(result.second,input[k]);
   }
   return result;
+}
+
+template<typename Engine,typename PDF>
+void randomize (SPAFunc::SPAData& data, Engine& engine, PDF&& pdf) {
+
+  // Need to make sure padding is set correctly in each column:
+  //   col(0) = 0
+  //   col(end) = col(end-1)
+  auto ccn3 = Kokkos::create_mirror_view(ekat::scalarize(data.CCN3));
+  auto aer_g_sw = Kokkos::create_mirror_view(ekat::scalarize(data.AER_G_SW));
+  auto aer_ssa_sw = Kokkos::create_mirror_view(ekat::scalarize(data.AER_SSA_SW));
+  auto aer_tau_sw = Kokkos::create_mirror_view(ekat::scalarize(data.AER_TAU_SW));
+  auto aer_tau_lw = Kokkos::create_mirror_view(ekat::scalarize(data.AER_TAU_LW));
+
+  // NOTE: the deep_copy calls in 'genRandArray' are no-ops for host views
+  ekat::genRandArray(ccn3,engine,pdf);
+  ekat::genRandArray(aer_g_sw,engine,pdf);
+  ekat::genRandArray(aer_ssa_sw,engine,pdf);
+  ekat::genRandArray(aer_tau_sw,engine,pdf);
+  ekat::genRandArray(aer_tau_lw,engine,pdf);
+
+  const int nlevs = data.nlevs-2;
+  for (int i=0; i<data.ncols; ++i) {
+    ccn3(i,0) = 0;
+    ccn3(i,nlevs+1) = ccn3(i,nlevs);
+    for (int n=0; n<data.nswbands; ++n) {
+      aer_g_sw(i,n,0) = 0;
+      aer_g_sw(i,n,nlevs+1) = aer_g_sw(i,n,nlevs);
+      aer_ssa_sw(i,n,0) = 0;
+      aer_ssa_sw(i,n,nlevs+1) = aer_ssa_sw(i,n,nlevs);
+      aer_tau_sw(i,n,0) = 0;
+      aer_tau_sw(i,n,nlevs+1) = aer_tau_sw(i,n,nlevs);
+    }
+    for (int n=0; n<data.nlwbands; ++n) {
+      aer_tau_lw(i,n,0) = 0;
+      aer_tau_lw(i,n,nlevs+1) = aer_tau_lw(i,n,nlevs);
+    }
+  }
+
+  Kokkos::deep_copy(ekat::scalarize(data.CCN3),ccn3);
+  Kokkos::deep_copy(ekat::scalarize(data.AER_G_SW),aer_g_sw);
+  Kokkos::deep_copy(ekat::scalarize(data.AER_SSA_SW),aer_ssa_sw);
+  Kokkos::deep_copy(ekat::scalarize(data.AER_TAU_SW),aer_tau_sw);
+  Kokkos::deep_copy(ekat::scalarize(data.AER_TAU_LW),aer_tau_lw);
 }
 
 } // namespace

--- a/components/scream/src/physics/spa/tests/spa_main_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_main_test.cpp
@@ -163,7 +163,7 @@ TEST_CASE("spa_read_data","spa")
   Kokkos::deep_copy(pmid_tgt,pmid_tgt_h);
 
   // Run SPA main
-  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_end,spa_data_out,dofs_gids.size(),nlevs,nswbands,nlwbands);
+  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_end,spa_data_out)
 
   Kokkos::deep_copy(ccn3_h      , spa_data_out.CCN3);
   Kokkos::deep_copy(aer_g_sw_h  , spa_data_out.AER_G_SW);
@@ -207,7 +207,7 @@ TEST_CASE("spa_read_data","spa")
   }
   Kokkos::deep_copy(pmid_tgt,pmid_tgt_h);
   
-  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_end,spa_data_out,dofs_gids.size(),nlevs,nswbands,nlwbands);
+  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_end,spa_data_out);
   Kokkos::deep_copy(ccn3_h      , spa_data_out.CCN3);
   Kokkos::deep_copy(aer_g_sw_h  , spa_data_out.AER_G_SW);
   Kokkos::deep_copy(aer_ssa_sw_h, spa_data_out.AER_SSA_SW);
@@ -279,7 +279,7 @@ TEST_CASE("spa_read_data","spa")
   }
   Kokkos::deep_copy(pmid_tgt,pmid_tgt_h);
 
-  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_end,spa_data_out,dofs_gids.size(),nlevs,nswbands,nlwbands);
+  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_end,spa_data_out);
   Kokkos::deep_copy(ccn3_h      , spa_data_out.CCN3);
   Kokkos::deep_copy(aer_g_sw_h  , spa_data_out.AER_G_SW);
   Kokkos::deep_copy(aer_ssa_sw_h, spa_data_out.AER_SSA_SW);
@@ -343,7 +343,7 @@ TEST_CASE("spa_read_data","spa")
   Kokkos::deep_copy(pmid_tgt,pmid_tgt_h);
 
   // Note, here we pass spa_data_beg twice, as both bounds of the input data.
-  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_beg,spa_data_out,dofs_gids.size(),nlevs,nswbands,nlwbands);
+  SPAFunc::spa_main(spa_time_state,pmid_tgt,spa_data_beg,spa_data_beg,spa_data_out);
   Kokkos::deep_copy(ccn3_h      , spa_data_out.CCN3);
   Kokkos::deep_copy(aer_g_sw_h  , spa_data_out.AER_G_SW);
   Kokkos::deep_copy(aer_ssa_sw_h, spa_data_out.AER_SSA_SW);

--- a/components/scream/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
@@ -63,7 +63,7 @@ TEST_CASE("spa_one_to_one_remap","spa")
   spa_horiz_interp.m_comm = spa_comm;
   SPAFunc::set_remap_weights_one_to_one(ncols,min_dof,dofs_gids,spa_horiz_interp);
   // Recall, SPA data is padded, so we initialize with 2 more levels than the source data file.
-  SPAFunc::SPAData spa_data(dofs_gids.size(), nlevs+2, nswbands, nlwbands);
+  SPAFunc::SPAInput spa_data(dofs_gids.size(), nlevs+2, nswbands, nlwbands);
 
   // Check that the horizontal interpolation data is in fact a 1-1 mapping
   Kokkos::parallel_for("", spa_horiz_interp.length, KOKKOS_LAMBDA(const int& ii) {
@@ -82,22 +82,22 @@ TEST_CASE("spa_one_to_one_remap","spa")
   //       aer_tau_sw(t,i,b,k) = b
   //       aer_tau_lw(t,i,b,k) = k
   auto ps_h         = Kokkos::create_mirror_view(spa_data.PS);
-  auto ccn3_h       = Kokkos::create_mirror_view(spa_data.CCN3);
-  auto aer_g_sw_h   = Kokkos::create_mirror_view(spa_data.AER_G_SW);
-  auto aer_ssa_sw_h = Kokkos::create_mirror_view(spa_data.AER_SSA_SW);
-  auto aer_tau_sw_h = Kokkos::create_mirror_view(spa_data.AER_TAU_SW);
-  auto aer_tau_lw_h = Kokkos::create_mirror_view(spa_data.AER_TAU_LW);
+  auto ccn3_h       = Kokkos::create_mirror_view(spa_data.data.CCN3);
+  auto aer_g_sw_h   = Kokkos::create_mirror_view(spa_data.data.AER_G_SW);
+  auto aer_ssa_sw_h = Kokkos::create_mirror_view(spa_data.data.AER_SSA_SW);
+  auto aer_tau_sw_h = Kokkos::create_mirror_view(spa_data.data.AER_TAU_SW);
+  auto aer_tau_lw_h = Kokkos::create_mirror_view(spa_data.data.AER_TAU_LW);
   auto dofs_gids_h = Kokkos::create_mirror_view(dofs_gids);
   Kokkos::deep_copy(dofs_gids_h,dofs_gids);
   for (int time_index = 0;time_index<max_time; time_index++) {
     SPAFunc::update_spa_data_from_file(spa_data_file, time_index+1, nswbands, nlwbands,
                                        spa_horiz_interp, spa_data);
     Kokkos::deep_copy(ps_h,spa_data.PS);
-    Kokkos::deep_copy(ccn3_h,spa_data.CCN3);
-    Kokkos::deep_copy(aer_g_sw_h,spa_data.AER_G_SW);
-    Kokkos::deep_copy(aer_ssa_sw_h,spa_data.AER_SSA_SW);
-    Kokkos::deep_copy(aer_tau_sw_h,spa_data.AER_TAU_SW);
-    Kokkos::deep_copy(aer_tau_lw_h,spa_data.AER_TAU_LW);
+    Kokkos::deep_copy(ccn3_h,spa_data.data.CCN3);
+    Kokkos::deep_copy(aer_g_sw_h,spa_data.data.AER_G_SW);
+    Kokkos::deep_copy(aer_ssa_sw_h,spa_data.data.AER_SSA_SW);
+    Kokkos::deep_copy(aer_tau_sw_h,spa_data.data.AER_TAU_SW);
+    Kokkos::deep_copy(aer_tau_lw_h,spa_data.data.AER_TAU_LW);
     for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
       gid_type glob_i = dofs_gids_h(dof_i);
       REQUIRE(ps_h(dof_i) == ps_func(time_index,glob_i));

--- a/components/scream/src/physics/spa/tests/spa_read_data_from_file_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_read_data_from_file_test.cpp
@@ -63,7 +63,7 @@ TEST_CASE("spa_read_data","spa")
   spa_horiz_interp.m_comm = spa_comm;
   SPAFunc::get_remap_weights_from_file(spa_remap_file,ncols,min_dof,dofs_gids,spa_horiz_interp);
   // Recall, SPA data is padded, so we initialize with 2 more levels than the source data file.
-  SPAFunc::SPAData spa_data(dofs_gids.size(), nlevs+2, nswbands, nlwbands);
+  SPAFunc::SPAInput spa_data(dofs_gids.size(), nlevs+2, nswbands, nlwbands);
 
   // Verify that the interpolated values match the algorithm for the data and the weights.
   //       weights(i) = 1 / (2**i), weights(-1) = 1 / (2**(ncols-1)) such that sum(weights) = 1., for i=0,1,2
@@ -75,22 +75,22 @@ TEST_CASE("spa_read_data","spa")
   //       aer_tau_sw(t,i,b,k) = b
   //       aer_tau_lw(t,i,b,k) = k
   auto ps_h         = Kokkos::create_mirror_view(spa_data.PS);
-  auto ccn3_h       = Kokkos::create_mirror_view(spa_data.CCN3);
-  auto aer_g_sw_h   = Kokkos::create_mirror_view(spa_data.AER_G_SW);
-  auto aer_ssa_sw_h = Kokkos::create_mirror_view(spa_data.AER_SSA_SW);
-  auto aer_tau_sw_h = Kokkos::create_mirror_view(spa_data.AER_TAU_SW);
-  auto aer_tau_lw_h = Kokkos::create_mirror_view(spa_data.AER_TAU_LW);
+  auto ccn3_h       = Kokkos::create_mirror_view(spa_data.data.CCN3);
+  auto aer_g_sw_h   = Kokkos::create_mirror_view(spa_data.data.AER_G_SW);
+  auto aer_ssa_sw_h = Kokkos::create_mirror_view(spa_data.data.AER_SSA_SW);
+  auto aer_tau_sw_h = Kokkos::create_mirror_view(spa_data.data.AER_TAU_SW);
+  auto aer_tau_lw_h = Kokkos::create_mirror_view(spa_data.data.AER_TAU_LW);
   auto dofs_gids_h = Kokkos::create_mirror_view(dofs_gids);
   Kokkos::deep_copy(dofs_gids_h,dofs_gids);
   for (int time_index = 0;time_index<max_time; time_index++) {
     SPAFunc::update_spa_data_from_file(spa_data_file, time_index+1, nswbands, nlwbands,
                                        spa_horiz_interp, spa_data);
     Kokkos::deep_copy(ps_h,spa_data.PS);
-    Kokkos::deep_copy(ccn3_h,spa_data.CCN3);
-    Kokkos::deep_copy(aer_g_sw_h,spa_data.AER_G_SW);
-    Kokkos::deep_copy(aer_ssa_sw_h,spa_data.AER_SSA_SW);
-    Kokkos::deep_copy(aer_tau_sw_h,spa_data.AER_TAU_SW);
-    Kokkos::deep_copy(aer_tau_lw_h,spa_data.AER_TAU_LW);
+    Kokkos::deep_copy(ccn3_h,spa_data.data.CCN3);
+    Kokkos::deep_copy(aer_g_sw_h,spa_data.data.AER_G_SW);
+    Kokkos::deep_copy(aer_ssa_sw_h,spa_data.data.AER_SSA_SW);
+    Kokkos::deep_copy(aer_tau_sw_h,spa_data.data.AER_TAU_SW);
+    Kokkos::deep_copy(aer_tau_lw_h,spa_data.data.AER_TAU_LW);
     for (size_t dof_i=0;dof_i<dofs_gids_h.size();dof_i++) {
       REQUIRE(ps_h(dof_i) == ps_func(time_index,spa_horiz_interp.source_grid_ncols));
       for (int kk=0;kk<nlevs;kk++) {


### PR DESCRIPTION
This PR modifies a tiny bit the SPAXyz structures, and splits `spa_main` into separate function calls (and separate kernels). The testing for the individual sub-functions is done on completely random data, to increase robustness. The only subroutine not tested is `compute_source_pressure_levels`, since I have no idea how to test it without copy-pasting the code itself (which is not really a test). However, it's small enough that I'm confident we can live with it.

Fixes #1469 
Fixes #1463 
Closes #1465 