### PR TITLE
SCREAM: fix valgrind error related to homme's readnl

### DIFF
--- a/components/scream/src/dynamics/homme/tests/theta.nl
+++ b/components/scream/src/dynamics/homme/tests/theta.nl
@@ -13,6 +13,7 @@ se_ftype                = ${HOMME_SE_FTYPE}
 se_geometry             = "sphere"
 se_limiter_option       = ${HOMME_TEST_LIM}
 se_ne                   = ${HOMME_TEST_NE}
+se_nsplit               = -1
 se_partmethod           = 4
 se_topology             = "cube"
 se_tstep                = ${HOMME_TEST_TIME_STEP}


### PR DESCRIPTION
It would be best to fix this issue in Homme itself, but this is not too bad.

Edit: I am currently running valg testsuite on mappy (the AT won't run it), for the 25 tests that previously failed. It's currently showing all pass (not done yet though).