### PR TITLE
Make default timestep 5min for SCREAMv1 CIME cases

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -447,8 +447,8 @@ _TESTS = {
     "e3sm_scream_v1" : {
         "time"  : "03:00:00",
         "tests" : (
-            "SMS_D_Ln2_P24x1.ne4_ne4.F2000SCREAMv1.scream-30min_ts",
-            "SMS_D_Ln2_P24x1.ne4_ne4.F2000-SCREAMv1-AQP1.scream-30min_ts",
+            "SMS_D_Ln2_P24x1.ne4_ne4.F2000SCREAMv1",
+            "SMS_D_Ln2_P24x1.ne4_ne4.F2000-SCREAMv1-AQP1",
             )
     },
 

--- a/components/scream/cime_config/testdefs/testmods_dirs/scream/30min_ts/shell_commands
+++ b/components/scream/cime_config/testdefs/testmods_dirs/scream/30min_ts/shell_commands
@@ -1,1 +1,0 @@
-./xmlchange ATM_NCPL=48

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -408,6 +408,8 @@
       <!-- a shorter timestep is needed for stability in MMF  -->
       <!-- Use for all "low res" grids (i.e. ne4, ne30, ne45) -->
       <value compset="_EAM%MMF">72</value>
+      <!-- Shorter timestep needed for SCREAMv1 because we are not substepping SHOC and P3 yet -->
+      <value compset="_SCREAM.*">288</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Change the default timestep for SCREAMv1 CIME cases to 5 minutes for all resolutions. This is currently required because SHOC and P3 assume a 5 min timestep, and we do not yet have the ability to substep these processes in EAMxx. This will be non-BFB for the SCREAMv1 CIME cases because it changes the timestep for those tests, and also renames the tests to remove the testmod that was used to force the timestep to 30 minutes (which we know was not quite optimal for SHOC and P3).