### PR TITLE
Use 10 tracers and field checking by default

### DIFF
--- a/components/scream/cime_config/config_component.xml
+++ b/components/scream/cime_config/config_component.xml
@@ -27,7 +27,7 @@
     <valid_values></valid_values>
     <default_value></default_value>
     <values modifier='additive'>
-      <value compset="_SCREAM">SCREAM_NP 4 SCREAM_NUM_VERTICAL_LEV 72 SCREAM_NUM_TRACERS 35</value>
+      <value compset="_SCREAM">SCREAM_NP 4 SCREAM_NUM_VERTICAL_LEV 72 SCREAM_NUM_TRACERS 10</value>
     </values>
     <group>build_component_scream</group>
     <file>env_build.xml</file>

--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -7,38 +7,40 @@ Atmosphere Driver:
     Schedule Type: Sequential
     Process 0:
       Process Name: Homme
-      Enable Output Fields Checks: true
-      Enable Input Fields Checks: true
+      Enable Postcondition Checks: true
+      Enable Precondition Checks: true
       Grid: Dynamics
-      Vertical Coordinate Filename: "<${COMPSET} : .*SCREAM%AQUA.* => ${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc : ${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc>"
+      Vertical Coordinate Filename: "<${COMPSET} : .*SCREAM%AQUA.* =>
+      ${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc
+      : ${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc>"
       Moisture: moist
     Process 1:
       Process Name: SHOC
-      Enable Output Fields Checks: true
-      Enable Input Fields Checks: true
+      Enable Postcondition Checks: true
+      Enable Precondition Checks: true
       Grid: Physics GLL
     Process 2:
       Process Name: CldFraction
-      Enable Output Fields Checks: true
-      Enable Input Fields Checks: true
+      Enable Postcondition Checks: true
+      Enable Precondition Checks: true
       Grid: Physics GLL
     Process 3:
       Process Name: SPA
-      Enable Output Fields Checks: true
-      Enable Input Fields Checks: true
+      Enable Postcondition Checks: true
+      Enable Precondition Checks: true
       Grid: Physics GLL
       SPA Remap File: none
       SPA Data File: ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc
       # TODO: Fix the SPA remap file and data file to be dependent on the grid resolution.  For now we hardcode the ne4 case.
     Process 4:
       Process Name: P3
-      Enable Output Fields Checks: true
-      Enable Input Fields Checks: true
+      Enable Postcondition Checks: true
+      Enable Precondition Checks: true
       Grid: Physics GLL
     Process 5:
       Process Name: RRTMGP
-      Enable Output Fields Checks: true
-      Enable Input Fields Checks: true
+      Enable Postcondition Checks: true
+      Enable Precondition Checks: true
       Grid: Physics GLL
       active_gases:
       - h2o

--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -7,38 +7,38 @@ Atmosphere Driver:
     Schedule Type: Sequential
     Process 0:
       Process Name: Homme
-      Enable Output Fields Checks: false
-      Enable Input Fields Checks: false
+      Enable Output Fields Checks: true
+      Enable Input Fields Checks: true
       Grid: Dynamics
       Vertical Coordinate Filename: "<${COMPSET} : .*SCREAM%AQUA.* => ${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc : ${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc>"
       Moisture: moist
     Process 1:
       Process Name: SHOC
-      Enable Output Fields Checks: false
-      Enable Input Fields Checks: false
+      Enable Output Fields Checks: true
+      Enable Input Fields Checks: true
       Grid: Physics GLL
     Process 2:
       Process Name: CldFraction
-      Enable Output Fields Checks: false
-      Enable Input Fields Checks: false
+      Enable Output Fields Checks: true
+      Enable Input Fields Checks: true
       Grid: Physics GLL
     Process 3:
       Process Name: SPA
-      Enable Output Fields Checks: false
-      Enable Input Fields Checks: false
+      Enable Output Fields Checks: true
+      Enable Input Fields Checks: true
       Grid: Physics GLL
       SPA Remap File: none
       SPA Data File: ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc
       # TODO: Fix the SPA remap file and data file to be dependent on the grid resolution.  For now we hardcode the ne4 case.
     Process 4:
       Process Name: P3
-      Enable Output Fields Checks: false
-      Enable Input Fields Checks: false
+      Enable Output Fields Checks: true
+      Enable Input Fields Checks: true
       Grid: Physics GLL
     Process 5:
       Process Name: RRTMGP
-      Enable Output Fields Checks: false
-      Enable Input Fields Checks: false
+      Enable Output Fields Checks: true
+      Enable Input Fields Checks: true
       Grid: Physics GLL
       active_gases:
       - h2o

--- a/components/scream/data/scream_input.yaml
+++ b/components/scream/data/scream_input.yaml
@@ -7,8 +7,8 @@ Atmosphere Driver:
     Schedule Type: Sequential
     Process 0:
       Process Name: Homme
-      Enable Postcondition Checks: true
-      Enable Precondition Checks: true
+      Enable Postcondition Checks: 1
+      Enable Precondition Checks: 1
       Grid: Dynamics
       Vertical Coordinate Filename: "<${COMPSET} : .*SCREAM%AQUA.* =>
       ${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc
@@ -16,31 +16,31 @@ Atmosphere Driver:
       Moisture: moist
     Process 1:
       Process Name: SHOC
-      Enable Postcondition Checks: true
-      Enable Precondition Checks: true
+      Enable Postcondition Checks: 1
+      Enable Precondition Checks: 1
       Grid: Physics GLL
     Process 2:
       Process Name: CldFraction
-      Enable Postcondition Checks: true
-      Enable Precondition Checks: true
+      Enable Postcondition Checks: 1
+      Enable Precondition Checks: 1
       Grid: Physics GLL
     Process 3:
       Process Name: SPA
-      Enable Postcondition Checks: true
-      Enable Precondition Checks: true
+      Enable Postcondition Checks: 1
+      Enable Precondition Checks: 1
       Grid: Physics GLL
       SPA Remap File: none
       SPA Data File: ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc
       # TODO: Fix the SPA remap file and data file to be dependent on the grid resolution.  For now we hardcode the ne4 case.
     Process 4:
       Process Name: P3
-      Enable Postcondition Checks: true
-      Enable Precondition Checks: true
+      Enable Postcondition Checks: 1
+      Enable Precondition Checks: 1
       Grid: Physics GLL
     Process 5:
       Process Name: RRTMGP
-      Enable Postcondition Checks: true
-      Enable Precondition Checks: true
+      Enable Postcondition Checks: 1
+      Enable Precondition Checks: 1
       Grid: Physics GLL
       active_gases:
       - h2o


### PR DESCRIPTION
Since SCREAMv1 only supports prescribed aerosol, it only has 10 tracers. We were initializing space for 35 of them. This PR fixes that. Also, scream_input.yaml has an option for checking that each process doesn't return bad data (e.g. concentrations <0). We had turned this off for a while because of some overly sensitive value, but I think that's fixed. So turning it back on. I'm not positive that field checking won't cause test fails... using the AT to confirm that.