### PR TITLE
Add ability to write diagnostic to file.

### DIFF
--- a/components/scream/data/scream_output.yaml
+++ b/components/scream/data/scream_output.yaml
@@ -63,6 +63,7 @@ Fields:
       - aero_tau_sw
       - nc_activated
       - p_mid
+      - PotentialTemperature
 
 Output Control:
   Frequency: 2

--- a/components/scream/src/diagnostics/potential_temperature.cpp
+++ b/components/scream/src/diagnostics/potential_temperature.cpp
@@ -47,7 +47,7 @@ void PotentialTemperatureDiagnostic::initialize_impl(const RunType /* run_type *
 
   const auto& output         = m_diagnostic_output.get_view<Pack**>();
 
-  auto ts = timestamp();  // TODO - how confident are we with how this timestamp is being handled?
+  auto ts = timestamp(); 
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 
   const auto nk_pack  = ekat::npack<Spack>(m_num_levs);

--- a/components/scream/src/diagnostics/potential_temperature.cpp
+++ b/components/scream/src/diagnostics/potential_temperature.cpp
@@ -34,6 +34,8 @@ void PotentialTemperatureDiagnostic::set_grids(const std::shared_ptr<const Grids
   // Construct and allocate the diagnostic field
   FieldIdentifier fid (name(), scalar3d_layout_mid, K, grid_name);
   m_diagnostic_output = Field(fid);
+  auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
+  C_ap.request_allocation(ps);
   m_diagnostic_output.allocate_view();
 
 }
@@ -44,6 +46,9 @@ void PotentialTemperatureDiagnostic::initialize_impl(const RunType /* run_type *
   const auto& p_mid          = get_field_in("p_mid").get_view<const Pack**>();
 
   const auto& output         = m_diagnostic_output.get_view<Pack**>();
+
+  auto ts = timestamp();  // TODO - how confident are we with how this timestamp is being handled?
+  m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 
   const auto nk_pack  = ekat::npack<Spack>(m_num_levs);
 

--- a/components/scream/src/diagnostics/register_diagnostics.hpp
+++ b/components/scream/src/diagnostics/register_diagnostics.hpp
@@ -1,0 +1,16 @@
+#ifndef SCREAM_REGISTER_DIAGNOSTICS_HPP
+#define SCREAM_REGISTER_DIAGNOSTICS_HPP
+
+#include "share/atm_process/atmosphere_diagnostic.hpp"
+// Include all diagnostics
+#include "diagnostics/potential_temperature.hpp"
+
+namespace scream {
+
+inline void register_diagnostics () {
+  auto& diag_factory = AtmosphereDiagnosticFactory::instance();
+  diag_factory.register_product("PotentialTemperature",&create_atmosphere_diagnostic<PotentialTemperatureDiagnostic>);
+}
+
+} // namespace scream
+#endif // SCREAM_REGISTER_DIAGNOSTICS_HPP

--- a/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
@@ -2,6 +2,7 @@
 
 #include "share/grid/mesh_free_grids_manager.hpp"
 #include "diagnostics/potential_temperature.hpp"
+#include "diagnostics/register_diagnostics.hpp"
 
 #include "physics/share/physics_constants.hpp"
 
@@ -152,8 +153,11 @@ void run(std::mt19937_64& engine)
   ekat::ParameterList params;
   params.set<std::string>("Diagnostic Name", "Potential Temperature");
   params.set<std::string>("Grid", "Point Grid");
-  auto diag = std::make_shared<PotentialTemperatureDiagnostic>(comm,params);
+  register_diagnostics();
+  auto& diag_factory = AtmosphereDiagnosticFactory::instance();
+  auto diag = diag_factory.create("PotentialTemperature",comm,params);
   diag->set_grids(gm);
+
 
   // Set the required fields for the diagnostic.
   std::map<std::string,Field> input_fields;

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
@@ -13,6 +13,8 @@ AtmosphereDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
 // Function to retrieve the diagnostic output which is stored in m_diagnostic_output
 Field AtmosphereDiagnostic::get_diagnostic (const Real dt) {
   run(dt);
+  auto ts = timestamp(); //TODO We need to find a way to make sure the diagnostic timestamp always matches the run timestamp
+  m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
   return m_diagnostic_output.get_const();
 }
 

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
@@ -13,7 +13,7 @@ AtmosphereDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
 // Function to retrieve the diagnostic output which is stored in m_diagnostic_output
 Field AtmosphereDiagnostic::get_diagnostic (const Real dt) {
   run(dt);
-  auto ts = timestamp(); //TODO We need to find a way to make sure the diagnostic timestamp always matches the run timestamp
+  auto ts = timestamp();
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
   return m_diagnostic_output.get_const();
 }

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -50,6 +50,27 @@ protected:
 
 };
 
+// A short name for the factory for atmosphere diagnostics
+// WARNING: you do not need to write your own creator function to register your atmosphere diagnostic in the factory.
+//          You could, but there's no need. You can simply register the common one right below, using your
+//          atmosphere diagnostic subclass name as templated argument. If you roll your own creator function, you
+//          *MUST* ensure that it correctly sets up the self pointer after creating the shared_ptr.
+//          This is *necessary* until we can safely switch to std::enable_shared_from_this.
+//          For more details, see the comments at the top of ekat_std_enable_shared_from_this.hpp.
+using AtmosphereDiagnosticFactory =
+    ekat::Factory<AtmosphereDiagnostic,
+                  ekat::CaseInsensitiveString,
+                  std::shared_ptr<AtmosphereDiagnostic>,
+                  const ekat::Comm&,const ekat::ParameterList&>;
+
+// Create an atmosphere process, and correctly set up the (weak) pointer to self.
+template <typename AtmDiagType>
+inline std::shared_ptr<AtmosphereDiagnostic>
+create_atmosphere_diagnostic (const ekat::Comm& comm, const ekat::ParameterList& p) {
+  auto ptr = std::make_shared<AtmDiagType>(comm,p);
+  ptr->setSelfPointer(ptr);
+  return ptr;
+}
 } //namespace scream
 
 #endif // SCREAM_ATMOSPHERE_DIAGNOSTIC_HPP

--- a/components/scream/src/share/io/CMakeLists.txt
+++ b/components/scream/src/share/io/CMakeLists.txt
@@ -19,7 +19,7 @@ set (SCREAM_CIME_LIBS
 # Create io lib
 add_library(scream_io ${SCREAM_SCORPIO_SRCS})
 set_target_properties(scream_io PROPERTIES Fortran_MODULE_DIRECTORY ${SCREAM_F90_MODULES})
-target_link_libraries(scream_io PUBLIC scream_share ${SCREAM_CIME_LIBS})
+target_link_libraries(scream_io PUBLIC scream_share diagnostics ${SCREAM_CIME_LIBS})
 target_compile_options(scream_io PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>)
 
 if (NOT SCREAM_LIB_ONLY)

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -592,6 +592,7 @@ void AtmosphereOutput::set_diagnostics()
       const auto& req_field = get_field(req.fid.name());
       if (!t0_set) {
         t0 = req_field.get_header().get_tracking().get_time_stamp();
+        t0_set = true;
       }
       diag->set_required_field(req_field.get_const());
     }

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -193,10 +193,12 @@ void AtmosphereOutput::run (const std::string& filename, const bool is_write_ste
     EKAT_REQUIRE_MSG (field.get_header().get_tracking().get_time_stamp().is_valid(),
         "Error! Output field '" + name + "' has not been initialized yet\n.");
 
+    const bool is_diagnostic = (m_diagnostics.find(name) != m_diagnostics.end());
     const bool is_aliasing_field_view =
         m_avg_type==OutputAvgType::Instant &&
         field.get_header().get_alloc_properties().get_padding()==0 &&
-        field.get_header().get_parent().expired();
+        field.get_header().get_parent().expired() &&
+        not is_diagnostic;
 
     // Manually update the 'running-tally' views with data from the field,
     // by combining new data with current avg values.

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -154,6 +154,7 @@ protected:
   void set_degrees_of_freedom(const std::string& filename);
   std::vector<int> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
+  Field get_field(const std::string& name);
 
   // --- Internal variables --- //
   ekat::Comm                          m_comm;

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -7,6 +7,7 @@
 #include "share/grid/abstract_grid.hpp"
 #include "share/grid/grids_manager.hpp"
 #include "share/util//scream_time_stamp.hpp"
+#include "share/atm_process/atmosphere_diagnostic.hpp"
 
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/mpi/ekat_comm.hpp"
@@ -112,6 +113,7 @@ public:
   using grid_type     = AbstractGrid;
   using gm_type       = GridsManager;
   using remapper_type = AbstractRemapper;
+  using atm_diag_type = AtmosphereDiagnostic;
 
   using KT = KokkosTypes<DefaultDevice>;
   template<int N>
@@ -155,6 +157,7 @@ protected:
   std::vector<int> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
   Field get_field(const std::string& name);
+  void set_diagnostics();
 
   // --- Internal variables --- //
   ekat::Comm                          m_comm;
@@ -162,15 +165,17 @@ protected:
   std::shared_ptr<const fm_type>      m_field_mgr;
   std::shared_ptr<const grid_type>    m_io_grid;
   std::shared_ptr<remapper_type>      m_remapper;
+  std::shared_ptr<const gm_type>      m_grids_manager;
 
   // How to combine multiple snapshots in the output: Instant, Max, Min, Average
   OutputAvgType     m_avg_type;
 
   // Internal maps to the output fields, how the columns are distributed, the file dimensions and the global ids.
-  std::vector<std::string>            m_fields_names;
-  std::map<std::string,FieldLayout>   m_layouts;
-  std::map<std::string,int>           m_dofs;
-  std::map<std::string,int>           m_dims;
+  std::vector<std::string>                              m_fields_names;
+  std::map<std::string,FieldLayout>                     m_layouts;
+  std::map<std::string,int>                             m_dofs;
+  std::map<std::string,int>                             m_dims;
+  std::map<std::string,std::shared_ptr<atm_diag_type>>  m_diagnostics;
 
   // Local views of each field to be used for "averaging" output and writing to file.
   std::map<std::string,view_1d_host>    m_host_views_1d;

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -3,6 +3,8 @@
 #include "share/io/scorpio_input.hpp"
 #include "share/io/scream_scorpio_interface.hpp"
 
+#include "diagnostics/register_diagnostics.hpp"
+
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/mpi/ekat_comm.hpp"
 #include "ekat/util/ekat_string_utils.hpp"
@@ -41,6 +43,9 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
   m_run_t0 = m_case_t0 = run_t0;
   m_is_restarted_run = is_restarted_run;
   m_is_model_restart_output = is_model_restart_output;
+
+  // Register all potential diagnostics
+  register_diagnostics();
 
   // Check for model restart output
   set_params(params,field_mgrs);

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -113,6 +113,7 @@ protected:
         v_me(i,k) = v_A(i,k)*3.0 + 2.0;
       }
     }
+    m_diagnostic_output.sync_to_dev();
   }
 
   // Clean up

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -404,8 +404,10 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
 
   // Make sure that field 4 is in fact a packed field
   auto field4 = fm->get_field(fid4);
-  auto fid4_padding = field4.get_header().get_alloc_properties().get_padding();
-  REQUIRE(fid4_padding > 0);
+  if (SCREAM_SMALL_PACK_SIZE > 1) {
+    auto fid4_padding = field4.get_header().get_alloc_properties().get_padding();
+    REQUIRE(fid4_padding > 0);
+  }
 
   // Initialize these fields
   auto f1 = fm->get_field(fid1);
@@ -416,6 +418,7 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
   auto f2_host = f2.get_view<Real*,Host>(); 
   auto f3_host = f3.get_view<Real**,Host>();
   auto f4_host = f4.get_view<Pack**,Host>(); 
+
   for (int ii=0;ii<num_lcols;++ii) {
     f1_host(ii) = ii;
     for (int jj=0;jj<num_levs;++jj) {

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -34,6 +34,12 @@ using input_type = AtmosphereInput;
 const int packsize = SCREAM_SMALL_PACK_SIZE; //2;
 using Pack         = ekat::Pack<Real,packsize>;
 
+using KT = KokkosTypes<DefaultDevice>;
+template <typename S>
+using view_1d = typename KT::template view_1d<S>;
+template <typename S>
+using view_2d = typename KT::template view_2d<S>;
+
 std::shared_ptr<FieldManager>
 get_test_fm(std::shared_ptr<const AbstractGrid> grid);
 
@@ -44,6 +50,78 @@ ekat::ParameterList get_in_params(const std::string& type,
                                   const ekat::Comm& comm,
                                   const util::TimeStamp& t0,
                                   const int dt, const int max_steps);
+
+view_2d<Real>::HostMirror get_diagnostic_input(const ekat::Comm& comm, const std::shared_ptr<GridsManager>& gm, const int time_index, const std::string& filename);
+
+class DiagTest : public AtmosphereDiagnostic
+{
+public:
+  DiagTest (const ekat::Comm& comm, const ekat::ParameterList&params)
+    : AtmosphereDiagnostic(comm,params)
+  {
+    //Do nothing
+  }
+
+  std::string name() const { return "DiagnosticTest"; }
+
+  // Get the required grid for the diagnostic
+  std::set<std::string> get_required_grids () const {
+    static std::set<std::string> s;
+    s.insert(m_params.get<std::string>("Grid"));
+    return s;
+  }
+
+  void set_grids (const std::shared_ptr<const GridsManager> gm) {
+    using namespace ekat::units;
+    using namespace ShortFieldTagsNames;
+    using FL = FieldLayout;
+
+    const auto& grid_name = m_params.get<std::string>("Grid");
+    const auto grid = gm->get_grid(grid_name);
+    m_num_cols  = grid->get_num_local_dofs(); // Number of columns on this rank
+    m_num_levs  = grid->get_num_vertical_levels();  // Number of levels per column
+
+    std::vector<FieldTag> tag_2d = {COL,LEV};
+    std::vector<Int>     dims_2d = {m_num_cols,m_num_levs};
+    FL lt( tag_2d, dims_2d );
+
+    constexpr int ps = Pack::n;
+    add_field<Required>("field_packed",lt,kg/m,grid_name,ps);
+
+    // We have to initialize the m_diagnostic_output:
+    FieldIdentifier fid (name(), lt, K, grid_name);
+    m_diagnostic_output = Field(fid);
+    auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
+    C_ap.request_allocation(ps);
+    m_diagnostic_output.allocate_view();
+  }
+
+protected:
+
+  // The initialization method should prepare all stuff needed to import/export from/to
+  // f90 structures.
+  void initialize_impl (const RunType /* run_type */ ) {}
+
+  // The run method is responsible for exporting atm states to the e3sm coupler, and
+  // import surface states from the e3sm coupler.
+  void run_impl (const int /* dt */) {
+    const auto& v_A  = get_field_in("field_packed").get_view<const Real**,Host>();
+    auto v_me = m_diagnostic_output.get_view<Real**,Host>();
+    // Have the dummy diagnostic just manipulate the field_packed data arithmetically.  In this case (x*3 + 2)
+    for (size_t i=0; i<m_num_cols; ++i) {
+      for (size_t k=0; k<m_num_levs; ++k) {
+        v_me(i,k) = v_A(i,k)*3.0 + 2.0;
+      }
+    }
+  }
+
+  // Clean up
+  void finalize_impl ( /* inputs */ ) {}
+
+  // Internal variables
+  int m_num_cols, m_num_levs;
+
+};
 
 TEST_CASE("input_output_basic","io")
 {
@@ -60,6 +138,11 @@ TEST_CASE("input_output_basic","io")
   auto gm = get_test_gm(io_comm,num_gcols,num_levs);
   auto grid = gm->get_grid("Point Grid");
   int num_lcols = grid->get_num_local_dofs();
+  int num_llevs = grid->get_num_vertical_levels();
+
+  // Need to register the Test Diagnostic so that IO can access it
+  auto& diag_factory = AtmosphereDiagnosticFactory::instance();
+  diag_factory.register_product("DummyDiagnostic",&create_atmosphere_diagnostic<DiagTest>);
 
   // Construct a timestamp
   util::TimeStamp t0 ({2000,1,1},{0,0,0});
@@ -169,6 +252,7 @@ TEST_CASE("input_output_basic","io")
   auto f3_host = f3.get_view<Real**,Host>();
   auto f4_host = f4.get_view<Real**,Host>();
 
+
   // Check instant output
   input_type ins_input(ins_params,field_manager);
   ins_input.read_variables();
@@ -177,11 +261,16 @@ TEST_CASE("input_output_basic","io")
   f3.sync_to_host();
   f4.sync_to_host();
 
+  // The diagnostic is not present in the field manager.  So we can't use the scorpio_input class
+  // to read in the data.  Here we use raw IO routines to gather the data for testing.
+  auto f_diag_ins_h = get_diagnostic_input(io_comm, gm, 1, ins_params.get<std::string>("Filename"));
+
   for (int ii=0;ii<num_lcols;++ii) {
     REQUIRE(std::abs(f1_host(ii)-(max_steps*dt+ii))<tol);
     for (int jj=0;jj<num_levs;++jj) {
       REQUIRE(std::abs(f3_host(ii,jj)-(ii+max_steps*dt + (jj+1)/10.))<tol);
       REQUIRE(std::abs(f4_host(ii,jj)-(ii+max_steps*dt + (jj+1)/10.))<tol);
+      REQUIRE(std::abs(f_diag_ins_h(ii,jj)-(3.0*f4_host(ii,jj)+2.0))<tol);
     }
   }
   for (int jj=0;jj<num_levs;++jj) {
@@ -303,8 +392,6 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
   FieldIdentifier fid2("field_2",FL{tag_v,dims_v},kg,gn);
   FieldIdentifier fid3("field_3",FL{tag_2d,dims_2d},kg/m,gn);
   FieldIdentifier fid4("field_packed",FL{tag_2d,dims_2d},kg/m,gn);
-  FieldIdentifier fidT("T_mid",FL{tag_2d,dims_2d},K,gn);
-  FieldIdentifier fidP("p_mid",FL{tag_2d,dims_2d},Pa,gn);
 
   // Register fields with fm
   // Make sure packsize isn't bigger than the packsize for this machine, but not so big that we end up with only 1 pack.
@@ -313,8 +400,6 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
   fm->register_field(FR{fid2,"output"});
   fm->register_field(FR{fid3,"output"});
   fm->register_field(FR{fid4,"output",Pack::n}); // Register field as packed
-  fm->register_field(FR{fidT,"T_mid",Pack::n}); // Register field as packed
-  fm->register_field(FR{fidP,"p_mid",Pack::n}); // Register field as packed
   fm->registration_ends();
 
   // Make sure that field 4 is in fact a packed field
@@ -327,14 +412,10 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
   auto f2 = fm->get_field(fid2);
   auto f3 = fm->get_field(fid3);
   auto f4 = fm->get_field(fid4);
-  auto fT = fm->get_field(fidT);
-  auto fP = fm->get_field(fidP);
   auto f1_host = f1.get_view<Real*,Host>(); 
   auto f2_host = f2.get_view<Real*,Host>(); 
   auto f3_host = f3.get_view<Real**,Host>();
   auto f4_host = f4.get_view<Pack**,Host>(); 
-  auto fT_host = fT.get_view<Pack**,Host>(); 
-  auto fP_host = fP.get_view<Pack**,Host>(); 
   for (int ii=0;ii<num_lcols;++ii) {
     f1_host(ii) = ii;
     for (int jj=0;jj<num_levs;++jj) {
@@ -343,8 +424,6 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
       int ipack = jj / packsize;
       int ivec  = jj % packsize;
       f4_host(ii,ipack)[ivec] = (ii) + (jj+1)/10.0;
-      fT_host(ii,ipack)[ivec] = 0.0;
-      fP_host(ii,ipack)[ivec] = 100000.0; //TODO grab this from physics_constants.
     }
   }
   // Update timestamp
@@ -355,8 +434,6 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
   f2.sync_to_dev();
   f3.sync_to_dev();
   f4.sync_to_dev();
-  fT.sync_to_dev();
-  fP.sync_to_dev();
 
   return fm;
 }
@@ -392,6 +469,35 @@ ekat::ParameterList get_in_params(const std::string& type,
   in_params.set<std::string>("Filename",filename);
   in_params.set<vos_type>("Field Names",{"field_1", "field_2", "field_3", "field_packed"});
   return in_params;
+}
+/*===================================================================================================================*/
+view_2d<Real>::HostMirror get_diagnostic_input(const ekat::Comm& comm, const std::shared_ptr<GridsManager>& gm, const int time_index, const std::string& filename) {
+
+  using namespace ShortFieldTagsNames;
+
+  auto grid = gm->get_grid("Point Grid");
+  int ncols = grid->get_num_local_dofs();
+  int nlevs = grid->get_num_vertical_levels();
+
+  view_2d<Real> f_diag("DummyDiag",ncols,nlevs);
+  auto f_diag_h = Kokkos::create_mirror_view(f_diag);
+
+  std::vector<std::string> fnames = {"DummyDiagnostic"};
+  std::map<std::string,view_1d<Real>::HostMirror> host_views;
+  std::map<std::string,FieldLayout>  layouts;
+  host_views["DummyDiagnostic"] = view_1d<Real>::HostMirror(f_diag_h.data(),f_diag_h.size());
+  layouts.emplace("DummyDiagnostic",FieldLayout( {COL,LEV}, {ncols,nlevs} ) );
+
+  ekat::ParameterList in_params;
+  in_params.set("Field Names",fnames);
+  in_params.set("Filename",filename);
+  AtmosphereInput input(comm,in_params);
+  input.init(grid,host_views,layouts);
+  input.read_variables(time_index);
+  input.finalize();
+
+  return f_diag_h;
+  
 }
 /*===================================================================================================================*/
 } // undefined namespace

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -31,7 +31,7 @@ using namespace scream;
 using namespace ekat::units;
 using input_type = AtmosphereInput;
 // Make sure packsize isn't bigger than the packsize for this machine, but not so big that we end up with only 1 pack.
-const int packsize = SCREAM_SMALL_PACK_SIZE; //2;
+const int packsize = SCREAM_SMALL_PACK_SIZE;
 using Pack         = ekat::Pack<Real,packsize>;
 
 using KT = KokkosTypes<DefaultDevice>;
@@ -98,12 +98,8 @@ public:
 
 protected:
 
-  // The initialization method should prepare all stuff needed to import/export from/to
-  // f90 structures.
   void initialize_impl (const RunType /* run_type */ ) {}
 
-  // The run method is responsible for exporting atm states to the e3sm coupler, and
-  // import surface states from the e3sm coupler.
   void run_impl (const int /* dt */) {
     const auto& v_A  = get_field_in("field_packed").get_view<const Real**,Host>();
     auto v_me = m_diagnostic_output.get_view<Real**,Host>();

--- a/components/scream/src/share/io/tests/io_test_instant.yaml
+++ b/components/scream/src/share/io/tests/io_test_instant.yaml
@@ -3,7 +3,7 @@
 Casename: io_output_test
 Averaging Type: Instant
 Max Snapshots Per File: 1
-Field Names: [field_1, field_2, field_3, field_packed]
+Field Names: [field_1, field_2, field_3, field_packed, DummyDiagnostic]
 Output Control:
   MPI Ranks in Filename: true
   Frequency: 10


### PR DESCRIPTION
This commit will make it possible to request a diagnostic as output to file.  Each new diagnostic needs to be added to the register_diagnostics routine in order to be available to the scorpio_output class.  Requesting a diagnostic as output is as simple as adding the name that the diagnostic was registered under in the scorpio output YAML file.

An example can be found in the io_test which has been changed to also test for diagnostic output.