### PR TITLE
Add clone method to Field class

### DIFF
--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
@@ -16,11 +16,11 @@ Field AtmosphereDiagnostic::get_diagnostic (const Real dt) {
   return m_diagnostic_output.get_const();
 }
 
-void AtmosphereDiagnostic::set_computed_field (const Field& f) {
+void AtmosphereDiagnostic::set_computed_field (const Field& /* f */) {
   EKAT_ERROR_MSG("Error! Diagnostics are not allowed to compute fields. See " + name() + ".\n");
 }
 
-void AtmosphereDiagnostic::set_computed_group (const FieldGroup& group) {
+void AtmosphereDiagnostic::set_computed_group (const FieldGroup& /* group */) {
   EKAT_ERROR_MSG("Error! Diagnostics are not allowed to compute field groups. See " + name() + ".\n");
 }
 

--- a/components/scream/src/share/field/field.cpp
+++ b/components/scream/src/share/field/field.cpp
@@ -20,6 +20,30 @@ Field::get_const() const {
   return f;
 }
 
+Field
+Field::clone() const {
+
+  // Create new field
+  Field f(get_header().get_identifier());
+
+  // Ensure alloc props match
+  const auto&  ap = get_header().get_alloc_properties();
+        auto& fap = f.get_header().get_alloc_properties();
+  fap.request_allocation(ap.get_largest_pack_size());
+
+  // Allocate
+  f.allocate_view();
+
+  // Set correct time stamp
+  const auto& ts = get_header().get_tracking().get_time_stamp();
+  f.get_header().get_tracking().update_time_stamp(ts);
+
+  // Deep copy
+  f.deep_copy(*this);
+
+  return f;
+}
+
 void Field::
 sync_to_host () const {
   // Sanity check

--- a/components/scream/src/share/field/field.hpp
+++ b/components/scream/src/share/field/field.hpp
@@ -105,6 +105,10 @@ public:
 
   bool is_read_only () const { return m_is_read_only; }
 
+  // Creates a deep copy version of this field.
+  // It is created with a pristine header (no providers/customers)
+  Field clone () const;
+
   // Allows to get the underlying view, reshaped for a different data type.
   // The class will check that the requested data type is compatible with the
   // allocation. This allows each field to be stored as a 1d array, but then

--- a/components/scream/src/share/field/field_utils_impl.hpp
+++ b/components/scream/src/share/field/field_utils_impl.hpp
@@ -42,8 +42,6 @@ bool views_are_equal(const Field& f1, const Field& f2) {
       break;
     case 2:
       {
-        std::cout << "calling get_view with ST=" << typeid(ST).name() << ", which "
-                  << (std::is_const<ST>::value ? "is" : "is NOT") << " const.\n";
         auto v1 = f1.template get_view<ST**,Host>();
         auto v2 = f2.template get_view<ST**,Host>();
         for (int i=0; i<dims[0]; ++i) {
@@ -406,7 +404,7 @@ ST field_max(const Field& f)
   // TODO: compute directly on device
   f.sync_to_host();
 
-  ST max = std::numeric_limits<ST>::min();
+  ST max = -std::numeric_limits<ST>::max();
   switch (fl.rank()) {
     case 1:
       {

--- a/components/scream/src/share/field/field_utils_impl.hpp
+++ b/components/scream/src/share/field/field_utils_impl.hpp
@@ -404,7 +404,7 @@ ST field_max(const Field& f)
   // TODO: compute directly on device
   f.sync_to_host();
 
-  ST max = -std::numeric_limits<ST>::max();
+  ST max = std::numeric_limits<ST>::lowest();
   switch (fl.rank()) {
     case 1:
       {

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -199,6 +199,13 @@ TEST_CASE("field", "") {
     REQUIRE(f2.is_allocated());
     REQUIRE(fap2.get_alloc_size()==fap1.get_alloc_size());
     REQUIRE(views_are_equal(f1,f2));
+
+    // Changing f2 should leave f1 unchanged
+    f2.deep_copy<Real>(0.0);
+    REQUIRE (field_max<Real>(f2)==0.0);
+    REQUIRE (field_min<Real>(f2)==0.0);
+    REQUIRE (field_max<Real>(f1)==3.0);
+    REQUIRE (field_min<Real>(f1)==3.0);
   }
 
   SECTION ("deep_copy") {

--- a/components/scream/src/share/tests/field_tests.cpp
+++ b/components/scream/src/share/tests/field_tests.cpp
@@ -186,6 +186,21 @@ TEST_CASE("field", "") {
     REQUIRE(views_are_equal(f1,f2));
   }
 
+  SECTION ("clone") {
+    Field f1 (fid);
+    auto& fap1 = f1.get_header().get_alloc_properties();
+
+    fap1.request_allocation(16);
+    f1.allocate_view();
+    f1.deep_copy(3.0);
+
+    Field f2 = f1.clone();
+    auto& fap2 = f2.get_header().get_alloc_properties();
+    REQUIRE(f2.is_allocated());
+    REQUIRE(fap2.get_alloc_size()==fap1.get_alloc_size());
+    REQUIRE(views_are_equal(f1,f2));
+  }
+
   SECTION ("deep_copy") {
     std::vector<FieldTag> t1 = {COL,CMP,LEV};
     std::vector<int> d1 = {3,2,24};

--- a/components/scream/src/share/util/scream_utils.hpp
+++ b/components/scream/src/share/util/scream_utils.hpp
@@ -44,7 +44,7 @@ void sort (std::list<T>& l) {
     return;
   }
   l.sort();
-};
+}
 
 // This routine tries to find an arrangment of elements that allow each
 // of the input groups to be a contiguous subarray of the global arrangement.


### PR DESCRIPTION
Makes it way easier to create temporary copies of a field (e.g., when checking if/how a field changes before/after a function call).

Fixes #1510 