### PR TITLE
SCREAM: fix prim_init1 sequence for Homme

### DIFF
--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -55,6 +55,12 @@ HommeDynamics::HommeDynamics (const ekat::Comm& comm, const ekat::ParameterList&
   HommeContextUser::singleton().add_user();
 }
 
+HommeDynamics::~HommeDynamics ()
+{
+  // This class is done with Homme. Remove from its users list
+  HommeContextUser::singleton().remove_user();
+}
+
 void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_manager)
 {
   // Grab dynamics and reference grid

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -72,10 +72,6 @@ protected:
   void run_impl        (const int dt);
   void finalize_impl   ();
 
-  // For simplicity, it's best to store the size of the tracers as soon as it is available.
-  // We can do it the first time that the 'tracers' group is set
-  void set_computed_group_impl (const FieldGroup& group);
-
   // Computes total number of bytes needed for local variables
   size_t requested_buffer_size_in_bytes() const;
 

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -23,8 +23,9 @@ class HommeDynamics : public AtmosphereProcess
 {
 public:
 
-  // Constructor(s)
+  // Constructor(s) and Destructor
   HommeDynamics (const ekat::Comm& comm, const ekat::ParameterList& params);
+  ~HommeDynamics ();
 
   // The type of the subcomponent (dynamics or physics)
   AtmosphereProcessType type () const { return AtmosphereProcessType::Dynamics; }

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -73,6 +73,13 @@ protected:
   void run_impl        (const int dt);
   void finalize_impl   ();
 
+  // We need to store the size of the tracers group as soon as it is available.
+  // In particular, we absolutely need to store it *before* the call to
+  // requested_buffer_size_in_bytes, where Homme::ForcingFunctor queries
+  // Homme::Tracers for qsize.
+  void set_computed_group_impl (const FieldGroup& group);
+
+
   // Computes total number of bytes needed for local variables
   size_t requested_buffer_size_in_bytes() const;
 

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
@@ -136,7 +136,7 @@ build_grids (const std::set<std::string>& grid_names)
     build_physics_grid(m_ref_grid_name);
   }
 
-  // Now we can cleanup all the grid stuff in f90
+  // Clean up temporaries used during grid initialization
   cleanup_grid_init_data_f90 ();
 }
 

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
@@ -20,14 +20,14 @@ DynamicsDrivenGridsManager (const ekat::Comm& comm,
                             const ekat::ParameterList& p)
  : m_comm (comm)
 {
-  // This class needs Homme's context, so register as a user
-  HommeContextUser::singleton().add_user();
-
   if (!is_parallel_inited_f90()) {
     // While we're here, we can init homme's parallel session
     auto fcomm = MPI_Comm_c2f(comm.mpi_comm());
     init_parallel_f90 (fcomm);
   }
+
+  // This class needs Homme's context, so register as a user
+  HommeContextUser::singleton().add_user();
 
   if (!is_params_inited_f90()) {
     // While we're here, we can init homme's parameters
@@ -70,8 +70,8 @@ DynamicsDrivenGridsManager::
   // Cleanup the grids stuff
   finalize_geometry_f90 ();
 
-  // This class is done needing Homme's context, so remove myself as customer
-  Homme::Context::singleton().finalize_singleton();
+  // This class is done with Homme. Remove from its users list
+  HommeContextUser::singleton().remove_user();
 }
 
 DynamicsDrivenGridsManager::remapper_ptr_type

--- a/components/scream/src/dynamics/homme/interface/dyn_grid_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/dyn_grid_mod.F90
@@ -96,13 +96,11 @@ contains
   end subroutine get_my_dyn_data
 
   subroutine cleanup_grid_init_data ()
-    use prim_driver_base, only: prim_init1_cleanup
     use edge_mod_base,    only: FreeEdgeBuffer
 
-    ! Cleanup the tmp stuff used in prim_init1_geometry
-    call prim_init1_cleanup()
-
     ! Cleanup edge used in get_my_dyn_data
+    ! NOTE: do not call prim_init1_cleanup, since compose,
+    ! which has not been inited yet, needs some grid connectivity info
     call FreeEdgeBuffer(edge)
   end subroutine cleanup_grid_init_data
 

--- a/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -63,8 +63,9 @@ contains
   end subroutine prim_init_data_structures_f90
 
   subroutine prim_complete_init1_phase_f90 () bind(c)
-    use prim_driver_base, only: prim_init1_buffers, prim_init1_compose, prim_init1_cleanup
-    use compose_mod, only: compose_control_kokkos_init_and_fin
+    use prim_driver_base,  only: prim_init1_buffers, prim_init1_compose, prim_init1_cleanup
+    use homme_context_mod, only: par, elem
+    use compose_mod,       only: compose_control_kokkos_init_and_fin
 
     ! Compose is not in charge of init/finalize kokkos
     call compose_control_kokkos_init_and_fin(.false.)

--- a/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -1,3 +1,4 @@
+! Include Homme's config settings
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -12,6 +13,7 @@ module homme_driver_mod
   private 
 
   public :: prim_init_data_structures_f90
+  public :: prim_complete_init1_phase_f90
   public :: prim_set_hvcoords_f90
   public :: prim_init_model_f90
   public :: prim_run_f90
@@ -20,14 +22,13 @@ module homme_driver_mod
 contains
 
   subroutine prim_init_data_structures_f90 () bind(c)
-    use prim_driver_mod,      only: prim_create_c_data_structures, prim_init_kokkos_functors
-    use prim_driver_base,     only: prim_init1_geometry, prim_init1_elem_arrays, &
-                                    prim_init1_cleanup, prim_init1_buffers
+    use prim_driver_mod,      only: prim_create_c_data_structures
+    use prim_driver_base,     only: prim_init1_elem_arrays
     use prim_cxx_driver_base, only: setup_element_pointers
     use derivative_mod_base,  only: derivinit
     use time_mod,             only: TimeLevel_init
     use homme_context_mod,    only: is_geometry_inited, is_data_structures_inited, &
-                                    par, elem, tl, deriv, hvcoord, init_parallel_f90
+                                    par, elem, tl, deriv, hvcoord
 
     if (is_data_structures_inited) then
       call abortmp ("Error! prim_init_data_structures_f90 was already called.\n")
@@ -41,11 +42,6 @@ contains
     ! Initialize derivative structure
     ! ==================================
     call derivinit(deriv)
-
-    ! ==================================
-    ! Initialize the buffers for exchanges
-    ! ==================================
-    call prim_init1_buffers(elem,par)
 
     ! ==================================
     ! Initialize element pointers
@@ -65,6 +61,27 @@ contains
 
     is_data_structures_inited = .true.
   end subroutine prim_init_data_structures_f90
+
+  subroutine prim_complete_init1_phase_f90 () bind(c)
+    use prim_driver_base, only: prim_init1_buffers, prim_init1_compose, prim_init1_cleanup
+    use compose_mod, only: compose_control_kokkos_init_and_fin
+
+    ! Compose is not in charge of init/finalize kokkos
+    call compose_control_kokkos_init_and_fin(.false.)
+
+    ! Init compose
+    call prim_init1_compose(par,elem)
+
+    ! ==================================
+    ! Initialize the buffers for exchanges
+    ! ==================================
+    call prim_init1_buffers(elem,par)
+
+    ! Cleanup the tmp stuff used in prim_init1_geometry
+    call prim_init1_cleanup()
+
+  end subroutine prim_complete_init1_phase_f90
+
 
   subroutine prim_set_hvcoords_f90 (ps0, hyai_ptr, hybi_ptr, hyam_ptr, hybm_ptr) bind(c)
     use iso_c_binding,     only: c_f_pointer

--- a/components/scream/src/dynamics/homme/interface/scream_homme_interface.hpp
+++ b/components/scream/src/dynamics/homme/interface/scream_homme_interface.hpp
@@ -44,6 +44,7 @@ void finalize_geometry_f90 ();
 
 // Prim init/run/finalize
 void prim_init_data_structures_f90 ();
+void prim_complete_init1_phase_f90 ();
 void prim_set_hvcoords_f90 (const double& ps0,
                             Homme::CF90Ptr& hyai_ptr,
                             Homme::CF90Ptr& hybi_ptr,

--- a/components/scream/src/dynamics/homme/tests/test_helper_mod.F90
+++ b/components/scream/src/dynamics/homme/tests/test_helper_mod.F90
@@ -28,6 +28,7 @@ contains
     use schedtype_mod,     only: schedule
     use parallel_mod,      only: rrequest, srequest, global_shared_buf, status
     use homme_context_mod, only: is_parallel_inited
+    use prim_driver_base,  only: prim_init1_cleanup
 
     ! Cleanup the schedule structure
     deallocate(Schedule(1)%SendCycle)
@@ -42,6 +43,8 @@ contains
     deallocate(srequest)
     deallocate(status)
     deallocate(global_shared_buf)
+
+    call prim_init1_cleanup()
 
     is_parallel_inited = .false.
   end subroutine cleanup_test_f90


### PR DESCRIPTION
The subroutine `prim_init1_buffers` requires `qsize` (the number of tracers). Up to now, this routine was called during the call to `prim_init_data_structures_f90`, inside HommeDynamics constructor. At that moment, `qsize` is not yet known. Since Homme initializes `qsize=qsize_d` (compile time upper bound), everything works. Nevertheless, it might waste space.

This commit fixes this, by removing the call to `prim_init1_buffers` from `prim_init_data_structures_f90`. Instead, a new interoperable routine `prim_complete_init1_phase_f90` is called at the beginning of `Homme::::initialize_impl`, which, as the name suggests, completes the "init1" phase in Homme.

This new routine also takes care of calling compose initialization, which we never did before.