### PR TITLE
Fix subcycling logic for AtmosphereProcess

### DIFF
--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -752,7 +752,9 @@ void AtmosphereDriver::initialize_atm_procs ()
 {
   // Initialize memory buffer for all atm processes
   m_memory_buffer = std::make_shared<ATMBufferManager>();
-  m_atm_process_group->initialize_atm_memory_buffer(*m_memory_buffer);
+  m_memory_buffer->request_bytes(m_atm_process_group->requested_buffer_size_in_bytes());
+  m_memory_buffer->allocate();
+  m_atm_process_group->init_buffers(*m_memory_buffer);
 
   const bool restarted_run = m_atm_params.sublist("Initial Conditions").get<bool>("Restart Run",false);
 

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -132,7 +132,7 @@ void SPA::init_buffers(const ATMBufferManager &buffer_manager)
   m_buffer.spa_temp.PS = decltype(m_buffer.spa_temp.PS)(r_mem,ncols);
   r_mem += m_buffer.spa_temp.PS.size();
 
-  int used_mem = (r_mem - buffer_manager.get_memory())*sizeof(Real);
+  size_t used_mem = (r_mem - buffer_manager.get_memory())*sizeof(Real);
   EKAT_REQUIRE_MSG(used_mem==requested_buffer_size_in_bytes(),
       "Error! Used memory != requested memory for SPA.\n"
       "   - used mem     : " + std::to_string(used_mem) + "\n"

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -41,7 +41,7 @@ void AtmosphereProcess::run (const int dt) {
 
   // Let the derived class do the actual run
   auto dt_sub = dt / m_num_subcycles;
-  for (int isub=0; isub<m_num_subcycles; ++isub) {
+  for (m_subcycle_iter=0; m_subcycle_iter<m_num_subcycles; ++m_subcycle_iter) {
     run_impl(dt_sub);
   }
 
@@ -50,9 +50,11 @@ void AtmosphereProcess::run (const int dt) {
     run_postcondition_checks();
   }
 
-  // Update all output fields time stamps
   m_time_stamp += dt;
-  update_time_stamps ();
+  if (m_update_time_stamps) {
+    // Update all output fields time stamps
+    update_time_stamps ();
+  }
 }
 
 void AtmosphereProcess::finalize (/* what inputs? */) {
@@ -157,7 +159,7 @@ void AtmosphereProcess::set_computed_group (const FieldGroup& group) {
   set_computed_group_impl(group);
 }
 
-void AtmosphereProcess::run_precondition_checks () const { 
+void AtmosphereProcess::run_precondition_checks () const {
   // Run all pre-condition property checks
   for (const auto& it : m_precondition_checks) {
     const auto& pc = it.second;
@@ -253,6 +255,10 @@ bool AtmosphereProcess::has_computed_group (const std::string& name, const std::
     }
   }
   return false;
+}
+
+void AtmosphereProcess::set_update_time_stamps (const bool do_update) {
+  m_update_time_stamps = do_update;
 }
 
 void AtmosphereProcess::update_time_stamps () {

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -12,20 +12,19 @@ namespace scream
 AtmosphereProcess::AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
   : m_comm  (comm)
   , m_params(params)
-{}
+{
+  if (m_params.isParameter("Number of Subcycles")) {
+    m_num_subcycles = m_params.get<int>("Number of Subcycles");
+  }
+  EKAT_REQUIRE_MSG (m_num_subcycles>0,
+      "Error! Invalid number of subcycles in param list " + m_params.name() + ".\n"
+      "  - Num subcycles: " + std::to_string(m_num_subcycles) + "\n");
+}
 
 void AtmosphereProcess::initialize (const TimeStamp& t0, const RunType run_type) {
   set_fields_and_groups_pointers();
   m_time_stamp = t0;
   initialize_impl(run_type);
-
-  if (m_params.isParameter("Number of Subcycles")) {
-    m_num_subcycles = m_params.get<int>("Number of Subcycles");
-  }
-  EKAT_REQUIRE_MSG (m_num_subcycles>0,
-      "Error! Invalid number of subcycles.\n"
-      "  - Atm proc name: " + this->name() + "\n"
-      "  - Num subcycles: " + std::to_string(m_num_subcycles) + "\n");
 }
 
 void AtmosphereProcess::run (const int dt) {

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -172,7 +172,12 @@ public:
 
   // Set local variables using memory provided by
   // the ATMBufferManager
-  virtual void init_buffers(const ATMBufferManager& /*buffer_manager*/) {}
+  virtual void init_buffers(const ATMBufferManager& /* buffer_manager */) {
+    EKAT_REQUIRE_MSG (requested_buffer_size_in_bytes()==0,
+        "Error! This Atm Process requested a non-zero buffer size,\n"
+        "       but does not override 'init_buffers'. Please, fix this.\n"
+        "   - Atm proc name: " + this->name() + "\n");
+  }
 
   // Convenience function to retrieve input/output fields from the field/group (and grid) name.
   // Note: the version without grid name only works if there is only one copy of the field/group.

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -115,6 +115,11 @@ public:
   // Return the parameter list
   const ekat::ParameterList& get_params () const { return m_params; }
 
+  // Note: if we are being subcycled from the outside, the host will set
+  //       do_update=false, and we will not update the timestamp of the AP
+  //       or that of the output fields.
+  void set_update_time_stamps (const bool do_update);
+
   // These methods set fields/groups in the atm process. The fields/groups are stored
   // in a list (with some helpers maps that can be used to quickly retrieve them).
   // If derived class need additional bookkeping/checks, they can override the
@@ -224,6 +229,10 @@ public:
   void add_invariant_check (const Args... args);
 
 protected:
+
+  int get_num_subcycles () const { return m_num_subcycles; }
+  int get_subcycle_iter () const { return m_subcycle_iter; }
+  bool do_update_time_stamp () const { return m_update_time_stamps; }
 
   // Derived classes can used these method, so that if we change how fields/groups
   // requirement are stored (e.g., change the std container), they don't need to change
@@ -436,6 +445,13 @@ private:
 
   // The number of times this process needs to be subcycled
   int m_num_subcycles = 1;
+
+  // This can be queried by derived classes, in case they need to know which
+  // iteration of the subcycle this is
+  int m_subcycle_iter;
+
+  // Whether we need to update time stamps at the end of the run method
+  bool m_update_time_stamps = true;
 };
 
 // ================= IMPLEMENTATION ================== //

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -34,6 +34,8 @@ AtmosphereProcessGroup (const ekat::Comm& comm, const ekat::ParameterList& param
   m_group_name = "Group [";
   m_group_name += m_group_schedule_type==ScheduleType::Sequential
                 ? "Sequential]:" : "Parallel]:";
+  auto& apf = AtmosphereProcessFactory::instance();
+  apf.register_product("group",&create_atmosphere_process<AtmosphereProcessGroup>);
   for (int i=0; i<m_group_size; ++i) {
     // The comm to be passed to the processes construction is
     //  - the same as the input comm if num_entries=1 or sched_type=Sequential
@@ -57,7 +59,7 @@ AtmosphereProcessGroup (const ekat::Comm& comm, const ekat::ParameterList& param
 
     const auto& params_i = m_params.sublist(ekat::strint("Process",i));
     const std::string& process_name = params_i.get<std::string>("Process Name");
-    m_atm_processes.emplace_back(AtmosphereProcessFactory::instance().create(process_name,proc_comm,params_i));
+    m_atm_processes.emplace_back(apf.create(process_name,proc_comm,params_i));
 
     // NOTE: the shared_ptr of the new atmosphere process *MUST* have been created correctly.
     //       Namely, the creation process must have set up enable_shared_from_this's status correctly.

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -410,13 +410,20 @@ process_required_field (const FieldRequest& req) {
   }
 }
 
-void AtmosphereProcessGroup::initialize_atm_memory_buffer(ATMBufferManager &memory_buffer) {
-  for (auto& atm_proc : m_atm_processes) {
-    memory_buffer.request_bytes(atm_proc->requested_buffer_size_in_bytes());
+size_t AtmosphereProcessGroup::requested_buffer_size_in_bytes () const
+{
+  size_t buf_size = 0;
+  for (const auto& proc : m_atm_processes) {
+    buf_size = std::max(buf_size,proc->requested_buffer_size_in_bytes());
   }
-  memory_buffer.allocate();
+
+  return buf_size;
+}
+
+void AtmosphereProcessGroup::
+init_buffers(const ATMBufferManager& buffer_manager) {
   for (auto& atm_proc : m_atm_processes) {
-    atm_proc->init_buffers(memory_buffer);
+    atm_proc->init_buffers(buffer_manager);
   }
 }
 

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -155,7 +155,13 @@ void AtmosphereProcessGroup::run_sequential (const Real dt) {
   auto ts = timestamp();
   ts += dt;
 
+  // The stored atm procs should update the timestamp if both
+  //  - this is the last subcycle iteration
+  //  - nobody from outside told this APG to not update timestamps
+  const bool do_update = do_update_time_stamp() &&
+                      (get_subcycle_iter()==get_num_subcycles()-1);
   for (auto atm_proc : m_atm_processes) {
+    atm_proc->set_update_time_stamps(do_update);
     // Run the process
     atm_proc->run(dt);
   }

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -46,8 +46,6 @@ public:
   // Grab the proper grid from the grids manager
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
-  void final_setup ();
-
   // --- Methods specific to AtmosphereProcessGroup --- //
   int get_num_processes () const { return m_atm_processes.size(); }
 

--- a/components/scream/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.hpp
@@ -57,8 +57,12 @@ public:
 
   ScheduleType get_schedule_type () const { return m_group_schedule_type; }
 
-  // Initialize memory buffer for each process
-  void initialize_atm_memory_buffer (ATMBufferManager& memory_buffer);
+  // Computes total number of bytes needed for local variables
+  size_t requested_buffer_size_in_bytes () const;
+
+  // Set local variables using memory provided by
+  // the ATMBufferManager
+  void init_buffers(const ATMBufferManager& buffer_manager);
 
   // The APG class needs to perform special checks before establishing whether
   // a required group/field is indeed a required group for this APG

--- a/components/scream/tests/coupled/physics_only/CMakeLists.txt
+++ b/components/scream/tests/coupled/physics_only/CMakeLists.txt
@@ -4,3 +4,4 @@ if (SCREAM_DOUBLE_PRECISION)
   add_subdirectory(shoc_cld_spa_p3_rrtmgp)
 endif()
 
+add_subdirectory (atm_proc_subcycling)

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/CMakeLists.txt
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/CMakeLists.txt
@@ -1,0 +1,52 @@
+INCLUDE (ScreamUtils)
+
+# Create the exec
+CreateUnitTestExec (shoc_p3 shoc_p3.cpp "shoc;p3;scream_control")
+
+## Copy input files to run directory
+file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
+
+GetInputFile(init/shoc_cld_p3_rrtmgp_init_ne2np4.nc
+             ${CMAKE_CURRENT_BINARY_DIR}/shoc_cld_p3_rrtmgp_init_ne2np4.nc)
+
+GetInputFile(tables/p3_lookup_table_1.dat-v4.1.1 ${CMAKE_CURRENT_BINARY_DIR}/data)
+GetInputFile(tables/p3_lookup_table_2.dat-v4.1.1 ${CMAKE_CURRENT_BINARY_DIR}/data)
+
+# Run a test with subcycling
+set (NUM_SUBCYCLES 3)
+set (NUM_STEPS  1)
+set (POSTFIX subcycled)
+set (ATM_TIME_STEP 900)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input_subcycled.yaml)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/output_subcycled.yaml)
+CreateUnitTestFromExec (shoc_p3_subcycled shoc_p3
+      EXE_ARGS "--use-colour no --ekat-test-params ifile=input_subcycled.yaml"
+      PROPERTIES FIXTURES_SETUP subcycled)
+
+# Run a test without subcycling and more steps
+set (NUM_SUBCYCLES 1)
+set (NUM_STEPS  3)
+set (ATM_TIME_STEP 300)
+set (POSTFIX monolithic)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input_monolithic.yaml)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/output_monolithic.yaml)
+CreateUnitTestFromExec (shoc_p3_monolithic shoc_p3
+      EXE_ARGS "--use-colour no --ekat-test-params ifile=input_monolithic.yaml"
+      PROPERTIES FIXTURES_SETUP monolithic)
+
+# Finally, compare output of the two tests
+include (BuildCprnc)
+BuildCprnc()
+
+set (SRC_FILE "shoc_p3_monolithic.INSTANT.Steps_x3.nc")
+set (TGT_FILE "shoc_p3_subcycled.INSTANT.Steps_x1.nc")
+set (TEST_NAME check_subcycling)
+add_test (NAME ${TEST_NAME}
+          COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
+          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(${TEST_NAME} PROPERTIES LABELS "shoc;p3"
+          FIXTURES_REQUIRED "monolithic;subcycled")

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -1,0 +1,42 @@
+%YAML 1.1
+---
+Debug:
+  Atmosphere DAG Verbosity Level: 5
+
+Time Stepping:
+  Time Step: ${ATM_TIME_STEP}
+  Start Time: [12, 30, 00]      # Hours, Minutes, Seconds
+  Start Date: [2021, 10, 12]    # Year, Month, Day
+  Number of Steps: ${NUM_STEPS}
+
+Atmosphere Processes:
+  Number of Entries: 2
+  Schedule Type: Sequential
+  Number of Subcycles: ${NUM_SUBCYCLES}
+  Process 0:
+    Process Name: SHOC
+    Grid: Point Grid
+  Process 1:
+    Process Name: P3
+    Grid: Point Grid
+
+Grids Manager:
+  Type: Mesh Free
+  Mesh Free:
+    Number of Global Columns:   218
+    Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.
+
+# The name of the file containing the initial conditions for this test.
+Initial Conditions:
+  Point Grid:
+    Filename: shoc_cld_p3_rrtmgp_init_ne2np4.nc
+    Load Latitude:  true
+    Load Longitude: true
+    surf_latent_flux: 0.0
+    surf_sens_flux: 0.0
+
+
+# The parameters for I/O control
+Scorpio:
+  Output YAML Files: [output_${POSTFIX}.yaml]
+...

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
@@ -1,0 +1,41 @@
+%YAML 1.1
+---
+Casename: shoc_p3_${POSTFIX}
+Averaging Type: Instant
+Max Snapshots Per File: 1
+Field Names:
+  - T_mid
+  - qv
+  - qc
+  - qr
+  - qi
+  - qm
+  - nc
+  - nr
+  - ni
+  - bm
+  - eff_radius_qc
+  - eff_radius_qi
+  - micro_liq_ice_exchange
+  - micro_vap_liq_exchange
+  - micro_vap_ice_exchange
+  - tke
+  - eddy_diff_mom
+  - sgs_buoy_flux
+  - inv_qc_relvar
+  - pbl_height
+  - surf_latent_flux
+  - surf_mom_flux
+  - surf_sens_flux
+  - nc_activated
+  - ni_activated
+  - nc_nuceat_tend
+  - eff_radius_qc
+  - eff_radius_qi
+ 
+Output Control:
+  Frequency: ${NUM_STEPS}
+  Frequency Units: Steps
+  Timestamp in Filename: false
+  MPI Ranks in Filename: false
+...

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/shoc_p3.cpp
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/shoc_p3.cpp
@@ -1,0 +1,71 @@
+#include <catch2/catch.hpp>
+
+// Boiler plate, needed for all runs
+#include "control/atmosphere_driver.hpp"
+#include "share/atm_process/atmosphere_process.hpp"
+
+#include "share/grid/mesh_free_grids_manager.hpp"
+
+// Physics headers
+#include "physics/p3/atmosphere_microphysics.hpp"
+#include "physics/shoc/atmosphere_macrophysics.hpp"
+
+// EKAT headers
+#include "ekat/ekat_pack.hpp"
+#include "ekat/ekat_parse_yaml_file.hpp"
+#include "ekat/util/ekat_test_utils.hpp"
+
+namespace scream {
+
+TEST_CASE("shoc-p3", "") {
+  using namespace scream;
+  using namespace scream::control;
+
+  // Create a comm
+  ekat::Comm atm_comm (MPI_COMM_WORLD);
+
+  // Load ad parameter list
+  const auto& session = ekat::TestSession::get();
+  std::string fname = session.params.at("ifile");
+  ekat::ParameterList ad_params("Atmosphere Driver");
+  REQUIRE_NOTHROW ( parse_yaml_file(fname,ad_params) );
+
+  // Time stepping parameters
+  auto& ts = ad_params.sublist("Time Stepping");
+  const auto dt = ts.get<int>("Time Step");
+  const auto start_date = ts.get<std::vector<int>>("Start Date");
+  const auto start_time = ts.get<std::vector<int>>("Start Time");
+  const auto nsteps     = ts.get<int>("Number of Steps");
+
+  util::TimeStamp t0 (start_date, start_time);
+  EKAT_ASSERT_MSG (t0.is_valid(), "Error! Invalid start date.\n");
+
+  // Need to register products in the factory *before* we create any atm process or grids manager.
+  auto& proc_factory = AtmosphereProcessFactory::instance();
+  proc_factory.register_product("p3",&create_atmosphere_process<P3Microphysics>);
+  proc_factory.register_product("SHOC",&create_atmosphere_process<SHOCMacrophysics>);
+  register_mesh_free_grids_manager();
+
+  // Create the driver
+  AtmosphereDriver ad;
+
+  // Init, run, and finalize
+  ad.initialize(atm_comm,ad_params,t0);
+
+  if (atm_comm.am_i_root()) {
+    printf("Start time stepping loop...       [  0%%]\n");
+  }
+  for (int i=0; i<nsteps; ++i) {
+    ad.run(dt);
+    if (atm_comm.am_i_root()) {
+      std::cout << "  - Iteration " << std::setfill(' ') << std::setw(3) << i+1 << " completed";
+      std::cout << "       [" << std::setfill(' ') << std::setw(3) << 100*(i+1)/nsteps << "%]\n";
+    }
+  }
+  ad.finalize();
+
+  // If we got here, we were able to run shoc
+  REQUIRE(true);
+}
+
+} // empty namespace


### PR DESCRIPTION
This PR fixes the last few issues with subcycling an atmosphere process. I manually verified it works, by hacking the input.yaml file for the full homme+physics test, subcycling SHOC+Cld+SPA+P3 3 times, and printing out the dt inside Homme, P3, and SHOC. I got:

```
Run HOMME with dt = 1800
Run SHOC with dt = 600
Run P3 with dt = 600
Run SHOC with dt = 600
Run P3 with dt = 600
Run SHOC with dt = 600
Run P3 with dt = 600
```

I haven't added a specific test, since I wanted to ask first: should I add a dummy test (subcycling some dummy procs) or should we modify one of our coupled tests, so that 1+ (but not all) atm procs are subcycled?

@PeterCaldwell @AaronDonahue thoughts?