### PR TITLE
Set non-exported values to 0.0 in SurfaceCoupling::do_export()

### DIFF
--- a/components/scream/src/control/surface_coupling_export.cpp
+++ b/components/scream/src/control/surface_coupling_export.cpp
@@ -102,6 +102,8 @@ void SurfaceCoupling::do_export (const bool init_phase)
     bool do_export = (!init_phase || info.do_initial_export);
     if (do_export) {
       cpl_exports_view_d(icol,info.cpl_idx) = info.data[offset];
+    } else {
+      cpl_exports_view_d(icol,info.cpl_idx) = 0.0;
     }
   });
 

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -685,12 +685,12 @@ TEST_CASE ("do_initial_export")
     // Perform export with init_phase=true
     exporter.do_export(true);
 
-    // Check that only f1 was exported
+    // Check f1 was exported, but f2 was set to 0
     f1_exp.sync_to_host();
     f2_exp.sync_to_host();
     for (int icol=0; icol<ncols; ++icol) {
       REQUIRE (raw_data[0 + icol*num_fields] == f1_exp_h(icol));
-      REQUIRE (raw_data[1 + icol*num_fields] == -1);
+      REQUIRE (raw_data[1 + icol*num_fields] == 0.0);
     }
 
     // Set all raw_data back to -1


### PR DESCRIPTION
This solves an issue on GPU CIME runs. For the exports that are skipped during the initial `do_export()` call, we were doing nothing. But it just so happens that  the `cpl_exports_ptr`on GPU contains NaNs instead of zeros. This was causing fails in other models using the exports. The `"do_initial_export"` test in `sc_tests` has been modified to catch that fields are set to 0.