### PR TITLE
Fix units on surf_latent_flux

### DIFF
--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -258,7 +258,7 @@ TEST_CASE ("recreate_mct_coupling")
 
   // Create import fields
   const auto nondim = Units::nondimensional();
-  FID surf_latent_flux_id ("surf_latent_flux",   scalar2d_layout, W/(m*m), grid_name);
+  FID surf_latent_flux_id ("surf_latent_flux",   scalar2d_layout, kg/(m*m*s), grid_name);
   FID surf_sens_flux_id   ("surf_sens_flux",     scalar2d_layout, W/(m*m), grid_name);
   FID surf_mom_flux_id    ("surf_mom_flux",      vector2d_layout, W/(m*m), grid_name);
   FID sfc_alb_dir_vis_id  ("sfc_alb_dir_vis",    scalar2d_layout, nondim,  grid_name);

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -69,7 +69,7 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   add_field<Required>("pref_mid",         pref_mid_layout,      Pa,   grid_name, ps);
   add_field<Required>("omega",            scalar3d_layout_mid,  Pa/s, grid_name, ps);
   add_field<Required>("surf_sens_flux",   scalar2d_layout_col,  W/m2, grid_name);
-  add_field<Required>("surf_latent_flux", scalar2d_layout_col,  W/m2, grid_name);
+  add_field<Required>("surf_latent_flux", scalar2d_layout_col,kg/m2/s, grid_name);
   add_field<Required>("surf_mom_flux",    surf_mom_flux_layout, N/m2, grid_name);
 
   add_field<Updated> ("T_mid",            scalar3d_layout_mid, K,       grid_name, ps);


### PR DESCRIPTION
Several months ago we figured out that latent heat flux was expected to be in flux units (kg/m2/s) but its units label was energy units (W/m2). This 2-line PR just changes the units to the correct value.

The only thing I want to triple check is that SHOC is actually expecting LHF in flux units.