### PR TITLE
Minor fixes in property check classes

### DIFF
--- a/components/scream/src/share/property_checks/field_lower_bound_check.hpp
+++ b/components/scream/src/share/property_checks/field_lower_bound_check.hpp
@@ -13,12 +13,11 @@ namespace scream
 class FieldLowerBoundCheck: public FieldWithinIntervalCheck {
 public:
   // Constructor with lower bound. By default, this property check
-  // can repair fields that fail the check by overwriting nonpositive values
-  // with the given lower bound. If can_repair is false, the check cannot
-  // apply repairs to the field.
+  // can *NOT* repair fields that fail the check. If can_repair is true,
+  // this class will overwrite values out of bounds with the stored lower bound
   FieldLowerBoundCheck (const Field& field,
                         const double lower_bound,
-                        const bool can_repair = true)
+                        const bool can_repair = false)
    : FieldWithinIntervalCheck(field,
                               lower_bound,
                               std::numeric_limits<double>::max(),

--- a/components/scream/src/share/property_checks/field_positivity_check.hpp
+++ b/components/scream/src/share/property_checks/field_positivity_check.hpp
@@ -14,7 +14,7 @@ public:
 
   // Default constructor -- cannot repair fields that fail the check.
   explicit FieldPositivityCheck (const Field& f,
-                                 const bool can_repair = true)
+                                 const bool can_repair = false)
    : FieldLowerBoundCheck (f,
                            std::numeric_limits<double>::epsilon(),
                            can_repair)

--- a/components/scream/src/share/property_checks/field_upper_bound_check.hpp
+++ b/components/scream/src/share/property_checks/field_upper_bound_check.hpp
@@ -12,13 +12,12 @@ namespace scream
 // inherits from FieldWithinIntervalCheck, and sets lower bound to -infinity
 class FieldUpperBoundCheck: public FieldWithinIntervalCheck {
 public:
-  // Constructor with upper bound. By default, this property check
-  // can repair fields that fail the check by overwriting nonpositive values
-  // with the given upper bound. If can_repair is false, the check cannot
-  // apply repairs to the field.
+  // Constructor with lower bound. By default, this property check
+  // can *NOT* repair fields that fail the check. If can_repair is true,
+  // this class will overwrite values out of bounds with the stored upper bound
   FieldUpperBoundCheck (const Field& field,
                         const double upper_bound,
-                        const bool can_repair = true)
+                        const bool can_repair = false)
    : FieldWithinIntervalCheck(field,
                               -std::numeric_limits<double>::max(),
                               upper_bound,

--- a/components/scream/src/share/property_checks/field_within_interval_check.hpp
+++ b/components/scream/src/share/property_checks/field_within_interval_check.hpp
@@ -20,13 +20,13 @@ class FieldWithinIntervalCheck: public PropertyCheck {
 public:
 
   // Constructor with lower and upper bounds. By default, this property check
-  // can repair fields that fail the check by overwriting nonpositive values
-  // with the given lower bound. If can_repair is false, the check cannot
-  // apply repairs to the field.
+  // can *NOT* repair fields that fail the check. If can_repair is true,
+  // this class will overwrite values out of bounds with the proper bound
+  // (upper if v>upper_bound and lower if v<lower_bound).
   FieldWithinIntervalCheck (const Field& field,
                             const double lower_bound,
                             const double upper_bound,
-                            const bool can_repair = true);
+                            const bool can_repair = false);
 
   // The name of the property check
   std::string name () const override {

--- a/components/scream/src/share/property_checks/property_check.cpp
+++ b/components/scream/src/share/property_checks/property_check.cpp
@@ -41,11 +41,12 @@ set_fields (const std::list<Field>& fields,
   auto it_f = m_fields.begin();
   auto it_b = repairable.begin();
   for (; it_b!=repairable.end(); ++it_b, ++it_f) {
-    EKAT_REQUIRE_MSG (not it_f->is_read_only(),
-        "Error! One of the repairable fields is read only.\n"
-        "  - PropertyCheck name: " + name() + "\n"
-        "  - Field name: " + it_f->name() + "\n");
     if (*it_b) {
+      EKAT_REQUIRE_MSG (not it_f->is_read_only(),
+          "Error! One of the repairable fields is read only.\n"
+          "  - PropertyCheck name: " + name() + "\n"
+          "  - Field name: " + it_f->name() + "\n");
+
       m_repairable_fields.push_back(&(*it_f));
     }
   }

--- a/components/scream/src/share/tests/property_checks.cpp
+++ b/components/scream/src/share/tests/property_checks.cpp
@@ -31,14 +31,18 @@ TEST_CASE("property_check_base", "") {
     REQUIRE_THROWS (std::make_shared<FieldNaNCheck>(f));
   }
 
-  SECTION ("field_not_allocated") {
+  SECTION ("field_read_only") {
     Field f(fid);
     f.allocate_view();
     auto cf = f.get_const();
 
     // Field must not be read-only if repair is needed
     REQUIRE_THROWS (std::make_shared<FieldPositivityCheck>(cf,true));
+
+    // But ok if no repair is needed
+    REQUIRE_NOTHROW (std::make_shared<FieldPositivityCheck>(cf,false));
   }
+
 }
 
 TEST_CASE("property_checks", "") {

--- a/components/scream/src/share/tests/property_checks.cpp
+++ b/components/scream/src/share/tests/property_checks.cpp
@@ -87,7 +87,7 @@ TEST_CASE("property_checks", "") {
     ekat::genRandArray(f_data,num_reals,engine,neg_pdf);
     f.sync_to_dev();
 
-    auto positivity_check = std::make_shared<FieldPositivityCheck>(f,1);
+    auto positivity_check = std::make_shared<FieldPositivityCheck>(f,true);
     REQUIRE(positivity_check->can_repair());
     REQUIRE(not positivity_check->check());
     positivity_check->repair();
@@ -117,7 +117,7 @@ TEST_CASE("property_checks", "") {
   SECTION ("field_within_interval_check") {
     const auto num_reals = f.get_header().get_alloc_properties().get_num_scalars();
 
-    auto interval_check = std::make_shared<FieldWithinIntervalCheck>(f, 0, 1);
+    auto interval_check = std::make_shared<FieldWithinIntervalCheck>(f, 0, 1, true);
     REQUIRE(interval_check->can_repair());
 
     // Assign in-bound values to the field and make sure it passes the within-interval check
@@ -141,7 +141,7 @@ TEST_CASE("property_checks", "") {
   SECTION ("field_lower_bound_check") {
     const auto num_reals = f.get_header().get_alloc_properties().get_num_scalars();
 
-    auto lower_bound_check = std::make_shared<FieldLowerBoundCheck>(f,-1.0);
+    auto lower_bound_check = std::make_shared<FieldLowerBoundCheck>(f,-1.0, true);
     REQUIRE(lower_bound_check->can_repair());
 
     // Assign in-bound values to the field and make sure it passes the lower_bound check
@@ -170,7 +170,7 @@ TEST_CASE("property_checks", "") {
 
   // Check that the values of a field are above below an upper bound
   SECTION ("field_upper_bound_check") {
-    auto upper_bound_check = std::make_shared<FieldUpperBoundCheck>(f,1.0);
+    auto upper_bound_check = std::make_shared<FieldUpperBoundCheck>(f,1.0, true);
     REQUIRE(upper_bound_check->can_repair());
     const auto num_reals = f.get_header().get_alloc_properties().get_num_scalars();
 
@@ -205,7 +205,7 @@ TEST_CASE("property_checks", "") {
     constexpr Real ub_check  = 1.0;
     constexpr Real ub_repair = 0.0;
     auto check  = std::make_shared<FieldUpperBoundCheck>(f,ub_check);
-    auto repair = std::make_shared<FieldUpperBoundCheck>(f,ub_repair);
+    auto repair = std::make_shared<FieldUpperBoundCheck>(f,ub_repair,true);
 
     auto check_and_repair = std::make_shared<CheckAndRepairWrapper>(check, repair);
     REQUIRE(check_and_repair->can_repair());


### PR DESCRIPTION
Namely:
- Make `can_repair = false` the default (where repair is possible at all). Repairing is an intrusive operation, and should be explicitly requested by the user. Besides, when adding checks for inputs, fields are read-only, so repairs are not possible. The default behavior should be ok everywhere.
- Fix a check in PropertyCheck. The check should throw if input field is read-only but has to be repaired, but it was throwing for all read-only fields (regardless of whether repair was requested or not).