### PR TITLE
Miscellanea scorpio fixes

### DIFF
--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -62,6 +62,9 @@ public:
   // Set AD params
   void set_params (const ekat::ParameterList& params);
 
+  // Set AD params
+  void init_scorpio (const int atm_id = 0);
+
   // Create atm processes, without initializing them
   void create_atm_processes ();
 
@@ -156,13 +159,14 @@ protected:
   // Some status flags, used to make sure we call the init functions in the right order
   static constexpr int s_comm_set       =   1;
   static constexpr int s_params_set     =   2;
-  static constexpr int s_procs_created  =   4;
-  static constexpr int s_grids_created  =   8;
-  static constexpr int s_fields_created =  16;
-  static constexpr int s_sc_set         =  32;
-  static constexpr int s_output_inited  =  64;
-  static constexpr int s_fields_inited  = 128;
-  static constexpr int s_procs_inited   = 256;
+  static constexpr int s_scorpio_inited =   4;
+  static constexpr int s_procs_created  =   8;
+  static constexpr int s_grids_created  =  16;
+  static constexpr int s_fields_created =  32;
+  static constexpr int s_sc_set         =  64;
+  static constexpr int s_output_inited  = 128;
+  static constexpr int s_fields_inited  = 256;
+  static constexpr int s_procs_inited   = 512;
 
   // Lazy version to ensure s_atm_inited & flag is true for every flag,
   // even if someone adds new flags later on

--- a/components/scream/src/mct_coupling/atm_comp_mct.F90
+++ b/components/scream/src/mct_coupling/atm_comp_mct.F90
@@ -187,7 +187,6 @@ CONTAINS
     type(mct_gGrid)        , pointer :: ggrid
     real(R8)                         :: nextsw_cday    ! calendar of next atm sw
     integer                          :: dt_scream
-    real(kind=c_double)              :: dt_scream_r
 
     !-------------------------------------------------------------------------------
 
@@ -200,8 +199,7 @@ CONTAINS
     call seq_timemgr_EClockGetData (EClock, next_cday=nextsw_cday, dtime=dt_scream)
 
     ! Run scream
-    dt_scream_r = dt_scream
-    call scream_run( dt_scream_r )
+    call scream_run( dt_scream )
 
     ! Set time of next radiadtion computation
     call seq_infodata_PutData(infodata, nextsw_cday=nextsw_cday)

--- a/components/scream/src/mct_coupling/atm_comp_mct.F90
+++ b/components/scream/src/mct_coupling/atm_comp_mct.F90
@@ -147,7 +147,7 @@ CONTAINS
     call seq_timemgr_EClockGetData(EClock, start_ymd=start_ymd, start_tod=start_tod)
     call string_f2c(yaml_fname,yaml_fname_c)
     call string_f2c(trim(diro)//"/"//trim(logfile),atm_log_fname_c)
-    call scream_create_atm_instance (mpicom_atm, yaml_fname_c, atm_log_fname_c)
+    call scream_create_atm_instance (mpicom_atm, ATM_ID, yaml_fname_c, atm_log_fname_c)
 
     ! Init MCT gsMap
     call atm_Set_gsMap_mct (mpicom_atm, ATM_ID, gsMap_atm)

--- a/components/scream/src/mct_coupling/atm_comp_mct.F90
+++ b/components/scream/src/mct_coupling/atm_comp_mct.F90
@@ -38,7 +38,6 @@ module atm_comp_mct
   character(len=16)      :: inst_name           ! fullname of current instance (ie. "lnd_0001")
   character(len=16)      :: inst_suffix = ""    ! char string associated with instance (ie. "_0001" or "")
   integer(IN)            :: ATM_ID              ! mct comp id
-  real(r8) ,  pointer    :: gbuf(:,:)           ! model grid
   integer(IN),parameter  :: master_task=0       ! task number of master task
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -73,8 +72,6 @@ CONTAINS
     type(seq_infodata_type), pointer :: infodata
     type(mct_gsMap)        , pointer :: gsMap_atm
     type(mct_gGrid)        , pointer :: dom_atm
-    integer(IN)                      :: nxg            ! global dim i-direction
-    integer(IN)                      :: nyg            ! global dim j-direction
     integer(IN)                      :: phase          ! initialization phase
     integer(IN)                      :: ierr           ! error code
     integer(IN)                      :: modelio_fid    ! file descriptor for atm_modelio.nml
@@ -170,14 +167,6 @@ CONTAINS
                                         c_loc(scr_names_a2x), c_loc(index_a2x), c_loc(a2x%rAttr), c_loc(vec_comp_a2x), &
                                         c_loc(can_be_exported_during_init), num_cpl_exports)
 
-    !----------------------------------------------------------------------------
-    ! Reset shr logging to my log file
-    !----------------------------------------------------------------------------
-
-    ! call shr_file_getLogUnit (shrlogunit)
-    ! call shr_file_getLogLevel(shrloglev)
-    ! call shr_file_setLogUnit (logunit)
-
   end subroutine atm_init_mct
 
   !===============================================================================
@@ -196,8 +185,6 @@ CONTAINS
     type(seq_infodata_type), pointer :: infodata
     type(mct_gsMap)        , pointer :: gsMap
     type(mct_gGrid)        , pointer :: ggrid
-    integer(IN)                      :: shrlogunit     ! original log unit
-    integer(IN)                      :: shrloglev      ! original log level
     real(R8)                         :: nextsw_cday    ! calendar of next atm sw
     integer                          :: dt_scream
     real(kind=c_double)              :: dt_scream_r
@@ -302,7 +289,6 @@ CONTAINS
     !
     ! Local Variables
     !
-    integer  :: n,i,c,ncols           ! indices	
     real(r8), pointer :: data1(:)
     real(r8), pointer :: data2(:)     ! temporary
     integer , pointer :: idata(:)     ! temporary

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -72,7 +72,7 @@ extern "C"
 
 /*===============================================================================================*/
 // WARNING: make sure input_yaml_file is a null-terminated string!
-void scream_create_atm_instance (const MPI_Fint& f_comm, const int atm_id,
+void scream_create_atm_instance (const MPI_Fint f_comm, const int atm_id,
                                  const char* input_yaml_file,
                                  const char* atm_log_file) {
   using namespace scream;

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -72,10 +72,9 @@ extern "C"
 
 /*===============================================================================================*/
 // WARNING: make sure input_yaml_file is a null-terminated string!
-void scream_create_atm_instance (const MPI_Fint& f_comm,
+void scream_create_atm_instance (const MPI_Fint& f_comm, const int atm_id,
                                  const char* input_yaml_file,
                                  const char* atm_log_file) {
-                  // const int& compid) {
   using namespace scream;
   using namespace scream::control;
 
@@ -112,6 +111,7 @@ void scream_create_atm_instance (const MPI_Fint& f_comm,
 
     ad.set_comm(atm_comm);
     ad.set_params(ad_params);
+    ad.init_scorpio(atm_id);
     ad.create_atm_processes ();
     ad.create_grids ();
     ad.create_fields ();

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -192,7 +192,7 @@ void scream_init_atm (const int& start_ymd,
 }
 
 /*===============================================================================================*/
-void scream_run (const scream::Real& dt) {
+void scream_run (const int dt) {
   // TODO: uncomment once you have valid inputs. I fear AD may crash with no inputs.
   fpe_guard_wrapper([&](){
     // Get the AD, and run it

--- a/components/scream/src/mct_coupling/scream_f2c_mod.F90
+++ b/components/scream/src/mct_coupling/scream_f2c_mod.F90
@@ -13,12 +13,12 @@ interface
   ! It does *NOT* initialize the fields and the atm processes, nor it initializes
   ! any structure related to the component coupler. Other subroutines
   ! will have to be called *after* this one, to achieve that.
-  subroutine scream_create_atm_instance (f_comm,yaml_fname,atm_log_fname) bind(c)
+  subroutine scream_create_atm_instance (f_comm,atm_id,yaml_fname,atm_log_fname) bind(c)
     use iso_c_binding, only: c_int, c_char
     !
     ! Input(s)
     !
-    integer (kind=c_int),   intent(in) :: f_comm
+    integer (kind=c_int),   intent(in) :: f_comm, atm_id
     character(kind=c_char), target, intent(in) :: yaml_fname(*), atm_log_fname(*)
   end subroutine scream_create_atm_instance
 

--- a/components/scream/src/mct_coupling/scream_f2c_mod.F90
+++ b/components/scream/src/mct_coupling/scream_f2c_mod.F90
@@ -70,11 +70,11 @@ interface
 
   ! This subroutine will run the whole atm model for one atm timestep
   subroutine scream_run (dt) bind(c)
-    use iso_c_binding, only: c_double
+    use iso_c_binding, only: c_int
     !
     ! arguments
     !
-    real(kind=c_double), intent(in) :: dt
+    integer(kind=c_int), value, intent(in) :: dt
   end subroutine scream_run
 
   subroutine scream_finalize () bind(c)

--- a/components/scream/src/mct_coupling/scream_f2c_mod.F90
+++ b/components/scream/src/mct_coupling/scream_f2c_mod.F90
@@ -18,7 +18,7 @@ interface
     !
     ! Input(s)
     !
-    integer (kind=c_int),   intent(in) :: f_comm, atm_id
+    integer (kind=c_int), value, intent(in) :: f_comm, atm_id
     character(kind=c_char), target, intent(in) :: yaml_fname(*), atm_log_fname(*)
   end subroutine scream_create_atm_instance
 

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -268,9 +268,6 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     // We're adding one snapshot to the file
     ++filespecs.num_snapshots_in_file;
 
-    // Finish up any updates to output file
-    sync_outfile(filename);
-
     // Now that we've written output to this file we need reset the nsteps.
     control.nsteps_since_last_write = 0;
 

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -755,7 +755,9 @@ contains
     use piolib_mod, only: PIO_finalize, pio_freedecomp
     ! May not be needed, possibly handled by PIO directly.
 
+#if !defined(SCREAM_CIME_BUILD)
     integer :: ierr
+#endif
     type(pio_file_list_t), pointer :: curr_file_ptr, prev_file_ptr
     type(iodesc_list_t),   pointer :: iodesc_ptr
 
@@ -777,8 +779,10 @@ contains
       iodesc_ptr => iodesc_ptr%next
     end do
 
+#if !defined(SCREAM_CIME_BUILD)
     call PIO_finalize(pio_subsystem, ierr)
     nullify(pio_subsystem)
+#endif
 
   end subroutine eam_pio_finalize
 !=====================================================================!

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -85,7 +85,6 @@ module scream_scorpio_interface
             set_dof,                     & ! Set the pio dof decomposition for specific variable in file.
             grid_write_data_array,       & ! Write gridded data to a pio managed netCDF file
             grid_read_data_array,        & ! Read gridded data from a pio managed netCDF file
-            eam_sync_piofile,            & ! Syncronize the piofile, to be done after all output is written during a single timestep
             eam_update_time,             & ! Update the timestamp (i.e. time variable) for a given pio netCDF file
             get_int_attribute,           & ! Retrieves an integer global attribute from the nc file
             set_int_attribute,           & ! Writes an integer global attribute to the nc file
@@ -613,18 +612,6 @@ contains
     ! Only update time on the file if a valid time is provided
     if (time>=0) ierr = pio_put_var(pio_atm_file%pioFileDesc,var%piovar,(/ pio_atm_file%numRecs /), (/ 1 /), (/ time /))
   end subroutine eam_update_time
-!=====================================================================!
-  ! Synchronize a pio file after updating the unlimited dimensions and accessing
-  ! all desired variables.
-  subroutine eam_sync_piofile(filename)
-    character(len=*),          intent(in)    :: filename       ! PIO filename
-
-    type(pio_atm_file_t),pointer             :: pio_atm_file
-    logical                      :: found
-
-    call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
-    call PIO_syncfile(pio_atm_file%pioFileDesc)
-  end subroutine eam_sync_piofile
 !=====================================================================!
   ! Assign header metadata to a specific pio output file.  TODO: Fix this to be
   ! more general.  Right now it is all dummy boiler plate.  Would make the most

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -5,8 +5,6 @@
 #include "ekat/ekat_assert.hpp"
 #include "share/scream_types.hpp"
 
-#include "gptl.h"
-
 #include <string>
 
 using scream::Real;
@@ -40,13 +38,11 @@ void eam_init_pio_subsystem(const int mpicom, const int atm_id) {
   // When surface coupling is established we will need to refactor this
   // routine to pass the appropriate values depending on if we are running
   // the full model or a unit test.
-  GPTLinitialize();
   eam_init_pio_subsystem_c2f(mpicom,atm_id);
 }
 /* ----------------------------------------------------------------- */
 void eam_pio_finalize() {
   eam_pio_finalize_c2f();
-  GPTLfinalize();
 }
 /* ----------------------------------------------------------------- */
 void register_file(const std::string& filename, const FileMode mode) {

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -29,8 +29,6 @@ extern "C" {
   void register_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const char*&& units, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
   void get_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
   void eam_pio_enddef_c2f(const char*&& filename);
-
-  int count_pio_atm_file_c2f();
 } // extern C
 
 namespace scream {
@@ -121,12 +119,6 @@ void register_variable(const std::string &filename, const std::string& shortname
 /* ----------------------------------------------------------------- */
 void eam_pio_enddef(const std::string &filename) {
   eam_pio_enddef_c2f(filename.c_str());
-}
-/* ----------------------------------------------------------------- */
-int count_pio_atm_file() {
-
-  return count_pio_atm_file_c2f();
-
 }
 /* ----------------------------------------------------------------- */
 void grid_read_data_array(const std::string &filename, const std::string &varname, const int time_index, void *hbuf) {

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -22,7 +22,6 @@ extern "C" {
   void grid_write_data_array_c2f_real(const char*&& filename, const char*&& varname, const Real*& hbuf);
   void eam_init_pio_subsystem_c2f(const int mpicom, const int compid, const bool local);
   void eam_pio_finalize_c2f();
-  void sync_outfile_c2f(const char*&& filename);
   void eam_pio_closefile_c2f(const char*&& filename);
   void pio_update_time_c2f(const char*&& filename,const Real time);
   void register_dimension_c2f(const char*&& filename, const char*&& shortname, const char*&& longname, const int length);
@@ -56,11 +55,6 @@ void register_file(const std::string& filename, const FileMode mode) {
 void eam_pio_closefile(const std::string& filename) {
 
   eam_pio_closefile_c2f(filename.c_str());
-}
-/* ----------------------------------------------------------------- */
-void sync_outfile(const std::string& filename) {
-
-  sync_outfile_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
 void set_decomp(const std::string& filename) {

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -20,7 +20,7 @@ extern "C" {
   void grid_read_data_array_c2f(const char*&& filename, const char*&& varname, const Int time_index, void *&hbuf);
 
   void grid_write_data_array_c2f_real(const char*&& filename, const char*&& varname, const Real*& hbuf);
-  void eam_init_pio_subsystem_c2f(const int mpicom, const int compid, const bool local);
+  void eam_init_pio_subsystem_c2f(const int mpicom, const int atm_id);
   void eam_pio_finalize_c2f();
   void eam_pio_closefile_c2f(const char*&& filename);
   void pio_update_time_c2f(const char*&& filename,const Real time);
@@ -33,14 +33,15 @@ extern "C" {
 namespace scream {
 namespace scorpio {
 /* ----------------------------------------------------------------- */
-void eam_init_pio_subsystem(const int mpicom) {
+
+void eam_init_pio_subsystem(const int mpicom, const int atm_id) {
   // TODO: Right now the compid has been hardcoded to 0 and the flag
   // to create a init a subsystem in SCREAM is hardcoded to true.
   // When surface coupling is established we will need to refactor this
   // routine to pass the appropriate values depending on if we are running
   // the full model or a unit test.
   GPTLinitialize();
-  eam_init_pio_subsystem_c2f(mpicom,0,true);
+  eam_init_pio_subsystem_c2f(mpicom,atm_id);
 }
 /* ----------------------------------------------------------------- */
 void eam_pio_finalize() {

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -62,13 +62,9 @@ namespace scorpio {
   /* Write data for a specific variable to a specific file. */
   void grid_write_data_array(const std::string &filename, const std::string &varname, const Real* hbuf);
 
-  /* Helper functions */
-  int count_pio_atm_file();
-
 extern "C" {
   /* Query whether the pio subsystem is inited or not */
   bool is_eam_pio_subsystem_inited();
-  int  eam_pio_subsystem_comm ();
   /* Checks if a file is already open, with the given mode */
   bool is_file_open_c2f(const char*&& filename, const int& mode);
   int get_int_attribute_c2f (const char*&& filename, const char*&& attr_name);

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -37,8 +37,6 @@ namespace scorpio {
   void eam_pio_closefile(const std::string& filename);
   /* Register a new file to be used for input/output with the scorpio module */
   void register_file(const std::string& filename, const FileMode mode);
-  /* Every timestep each output file needs to be synced, call once per timestep, per file */
-  void sync_outfile(const std::string& filename);
   /* Sets the IO decompostion for all variables in a particular filename.  Required after all variables have been registered.  Called once per file. */
   void set_decomp(const std::string& filename);
   /* Sets the degrees-of-freedom for a particular variable in a particular file.  Called once for each variable, for each file. */

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -30,7 +30,7 @@ namespace scorpio {
     Write = 2
   };
   /* All scorpio usage requires that the pio_subsystem is initialized. Happens only once per simulation */
-  void eam_init_pio_subsystem(const int mpicom);
+  void eam_init_pio_subsystem(const int mpicom, const int atm_id = 0);
   /* Cleanup scorpio with pio_finalize */
   void eam_pio_finalize();
   /* Close a file currently open in scorpio */

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -258,13 +258,6 @@ contains
     call eam_pio_enddef(filename)
   end subroutine eam_pio_enddef_c2f
 !=====================================================================!
-  function count_pio_atm_file_c2f() bind(c) result(file_count)
-    use scream_scorpio_interface, only : count_pio_atm_file
-    integer(kind=c_int) :: file_count
-
-    file_count = count_pio_atm_file()
-  end function count_pio_atm_file_c2f
-!=====================================================================!
   subroutine convert_c_string(c_string_ptr,f_string)
   ! Purpose: To convert a c_string pointer to the proper fortran string format.
     type(c_ptr), intent(in) :: c_string_ptr

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -13,13 +13,11 @@ module scream_scorpio_interface_iso_c2f
 !
 contains
 !=====================================================================!
-  subroutine eam_init_pio_subsystem_c2f(mpicom,compid,local) bind(c)
+  subroutine eam_init_pio_subsystem_c2f(mpicom,compid) bind(c)
     use scream_scorpio_interface, only : eam_init_pio_subsystem
-    integer(kind=c_int), value, intent(in) :: mpicom
-    integer(kind=c_int), value, intent(in) :: compid
-    logical(kind=c_bool),value, intent(in) :: local
+    integer(kind=c_int), value, intent(in) :: mpicom,compid
 
-    call eam_init_pio_subsystem(mpicom,compid,LOGICAL(local))
+    call eam_init_pio_subsystem(mpicom,compid)
   end subroutine eam_init_pio_subsystem_c2f
 !=====================================================================!
   subroutine eam_pio_finalize_c2f() bind(c)

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -60,17 +60,6 @@ contains
 
   end subroutine register_file_c2f
 !=====================================================================!
-  subroutine sync_outfile_c2f(filename_in) bind(c)
-    use scream_scorpio_interface, only : eam_sync_piofile
-    type(c_ptr), intent(in) :: filename_in
-
-    character(len=256)       :: filename
-
-    call convert_c_string(filename_in,filename)
-    call eam_sync_piofile(trim(filename))
-
-  end subroutine sync_outfile_c2f
-!=====================================================================!
   subroutine set_decomp_c2f(filename_in) bind(c)
     use scream_scorpio_interface, only : set_decomp
     type(c_ptr), intent(in) :: filename_in


### PR DESCRIPTION
With a lot of effort from @ndkeen and some help from scorpio wizards, we identified a few issues with IO. This branch fixes some of them (but should not yet give us a IO as fast as we want/need/expect).

Main changes:
- In CIME builds, we were still allocating a PIO system manually, as we do for standalone runs, without using the one created for atm by MCT. Fixing this, incidentally, allows to use the pio stride set by cime configuration system.
- Calling "sync" on output files is expensive, and should only be done when needed (e.g., when closing a file). This PR removes the possibility of explcitly calling sync, which is now called only before closing the file.