### PR TITLE
Add radiation super-stepping

### DIFF
--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -1,6 +1,6 @@
 #include "physics/rrtmgp/scream_rrtmgp_interface.hpp"
 #include "physics/rrtmgp/atmosphere_radiation.hpp"
-#include "physics/rrtmgp/rrtmgp_heating_rate.hpp"
+#include "physics/rrtmgp/rrtmgp_utils.hpp"
 #include "physics/rrtmgp/share/shr_orb_mod_c2f.hpp"
 #include "share/util/scream_common_physics_functions.hpp"
 #include "share/util/scream_column_ops.hpp"

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -624,7 +624,6 @@ void RRTMGPRadiation::run_impl (const int dt) {
 
   // Copy output data back to FieldManager
   if (update_rad) {
-    std::cout << "Update rad fluxes in FM...\n";
     {
       const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
       Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -241,6 +241,9 @@ void RRTMGPRadiation::init_buffers(const ATMBufferManager &buffer_manager)
 void RRTMGPRadiation::initialize_impl(const RunType /* run_type */) {
   using PC = scream::physics::Constants<Real>;
 
+  // Determine rad timestep, specified as number of atm steps
+  m_rad_freq_in_steps = m_params.get<Int>("rad_frequency", 1);
+
   // Determine orbital year. If Orbital Year is negative, use current year
   // from timestamp for orbital year; if positive, use provided orbital year
   // for duration of simulation.

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -82,6 +82,9 @@ public:
   view_1d_real             m_gas_mol_weights;
   GasConcs gas_concs;
 
+  // Rad frequency in number of steps
+  int m_rad_freq_in_steps;
+
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {
     static constexpr int num_1d_ncol        = 10;

--- a/components/scream/src/physics/rrtmgp/rrtmgp_utils.hpp
+++ b/components/scream/src/physics/rrtmgp/rrtmgp_utils.hpp
@@ -1,5 +1,5 @@
-#ifndef RRTMGP_HEATING_RATE_HPP
-#define RRTMGP_HEATING_RATE_HPP
+#ifndef RRTMGP_UTILS_HPP
+#define RRTMGP_UTILS_HPP
 
 #include "physics/share/physics_constants.hpp"
 #include "cpp/rrtmgp_const.h"
@@ -30,6 +30,18 @@ namespace scream {
                     flux_dn(icol,ilay+1) + flux_dn(icol,ilay)
                 ) * physconst::gravit / (physconst::Cpair * pdel(icol,ilay));
             });
+        }
+
+        bool radiation_do(const int irad, const int nstep) {
+            // If irad == 0, then never do radiation;
+            // Otherwise, we always call radiation at the first step,
+            // and afterwards we do radiation if the timestep is divisible
+            // by irad
+            if (irad == 0) {
+                return false;
+            } else {
+                return ( (nstep == 0) || (nstep % irad == 0) );
+            }
         }
     }
 }

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
@@ -1,5 +1,5 @@
 #include "catch2/catch.hpp"
-#include "physics/rrtmgp/rrtmgp_heating_rate.hpp"
+#include "physics/rrtmgp/rrtmgp_utils.hpp"
 #include "physics/rrtmgp/scream_rrtmgp_interface.hpp"
 #include "YAKL.h"
 #include "physics/share/physics_constants.hpp"
@@ -402,4 +402,19 @@ TEST_CASE("rrtmgp_test_compute_broadband_surface_flux") {
     sfc_flux_dif_nir.deallocate();
     sfc_flux_dif_vis.deallocate();
     if (yakl::isInitialized()) { yakl::finalize(); }
+}
+
+TEST_CASE("rrtmgp_test_radiation_do") {
+
+    //
+    REQUIRE(scream::rrtmgp::radiation_do(2, 0) == true);
+    REQUIRE(scream::rrtmgp::radiation_do(2, 1) == false);
+    REQUIRE(scream::rrtmgp::radiation_do(2, 2) == true);
+    REQUIRE(scream::rrtmgp::radiation_do(2, 3) == false);
+
+    REQUIRE(scream::rrtmgp::radiation_do(3, 0) == true);
+    REQUIRE(scream::rrtmgp::radiation_do(3, 1) == false);
+    REQUIRE(scream::rrtmgp::radiation_do(3, 2) == false);
+    REQUIRE(scream::rrtmgp::radiation_do(3, 3) == true);
+    REQUIRE(scream::rrtmgp::radiation_do(3, 4) == false);
 }

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
@@ -405,16 +405,23 @@ TEST_CASE("rrtmgp_test_compute_broadband_surface_flux") {
 }
 
 TEST_CASE("rrtmgp_test_radiation_do") {
+    // If we specify rad every step, radiation_do should always be true
+    REQUIRE(scream::rrtmgp::radiation_do(1, 0) == true);
+    REQUIRE(scream::rrtmgp::radiation_do(1, 1) == true);
+    REQUIRE(scream::rrtmgp::radiation_do(1, 2) == true);
 
-    //
+    // Test cases where we want rad called every other step
     REQUIRE(scream::rrtmgp::radiation_do(2, 0) == true);
     REQUIRE(scream::rrtmgp::radiation_do(2, 1) == false);
     REQUIRE(scream::rrtmgp::radiation_do(2, 2) == true);
     REQUIRE(scream::rrtmgp::radiation_do(2, 3) == false);
 
+    // Test cases where we want rad every third step
     REQUIRE(scream::rrtmgp::radiation_do(3, 0) == true);
     REQUIRE(scream::rrtmgp::radiation_do(3, 1) == false);
     REQUIRE(scream::rrtmgp::radiation_do(3, 2) == false);
     REQUIRE(scream::rrtmgp::radiation_do(3, 3) == true);
     REQUIRE(scream::rrtmgp::radiation_do(3, 4) == false);
+    REQUIRE(scream::rrtmgp::radiation_do(3, 5) == false);
+    REQUIRE(scream::rrtmgp::radiation_do(3, 6) == true);
 }

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -19,6 +19,7 @@ Atmosphere Processes:
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
     Can Initialize All Inputs: true
+    rad_frequency: 3
 
 Grids Manager:
   Type: Mesh Free

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone.cpp
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone.cpp
@@ -79,17 +79,16 @@ TEST_CASE("rrtmgp-stand-alone", "") {
     sw_flux_up_old.deep_copy(sw_flux_up);
 
     ad.run(dt);
-
-    // compare before and after
-    auto d_sw_flux_up_new = sw_flux_up.get_view<Real**,Host>();
-    auto d_sw_flux_up_old = sw_flux_up_old.get_view<Real**,Host>();
     if (atm_comm.am_i_root()) {
       std::cout << "  - Iteration " << std::setfill(' ') << std::setw(3) << i+1 << " completed";
       std::cout << "       [" << std::setfill(' ') << std::setw(3) << 100*(i+1)/nsteps << "%]\n";
     }
+
     // Test that in between rad steps, we maintain the same values of fluxes and heating rates
     // get rad fluxes and heating rates before; we set rad_requency to 3 in the input.yaml, so
     // the first two steps should look the same
+    auto d_sw_flux_up_new = sw_flux_up.get_view<Real**,Host>();
+    auto d_sw_flux_up_old = sw_flux_up_old.get_view<Real**,Host>();
     if (i == 0) {
         REQUIRE(!views_are_equal(sw_flux_up_old, sw_flux_up));
     } else if (i == 1) {
@@ -99,6 +98,7 @@ TEST_CASE("rrtmgp-stand-alone", "") {
     } else if (i == 3) {
         REQUIRE(!views_are_equal(sw_flux_up_old, sw_flux_up));
     }
+
   }
 
   // TODO: get the field repo from the driver, and go get (one of)

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone.cpp
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone.cpp
@@ -49,14 +49,49 @@ TEST_CASE("rrtmgp-stand-alone", "") {
   // Init and run
   ad.initialize(atm_comm,ad_params,t0);
 
+  // Get a pointer to the field manager so we can query fields
+  const auto& grid = ad.get_grids_manager()->get_grid("Point Grid");
+  const auto& field_mgr = *ad.get_field_mgr(grid->name());
+
+
+  // Make copies of field managed variables
+  auto d_sw_flux_up = field_mgr.get_field("sw_flux_up").get_view<Real**,Host>();
+  auto dims = field_mgr.get_field("sw_flux_up").get_header().get_identifier().get_layout().dims();
+
+  // Start stepping
   if (atm_comm.am_i_root()) {
     printf("Start time stepping loop...       [  0%%]\n");
   }
   for (int i=0; i<nsteps; ++i) {
+
+    // Test that in between rad steps, we maintain the same values of fluxes and heating rates
+    // get rad fluxes and heating rates before; we set rad_requency to 3 in the input.yaml, so
+    // the first three steps should look the same
+    auto d_sw_data = d_sw_flux_up.data();
+    scream::RRTMGPRadiation::view_2d_real::HostMirror d_sw_flux_up_before(d_sw_data,dims[0],dims[1]);
+    //Kokkos::deep_copy(d_sw_flux_up_before, d_sw_flux_up);
+
     ad.run(dt);
+
+    // compare before and after
+    //auto d_sw_flux_dn_after = field_mgr.get_field("sw_flux_dn").get_view<Real**>();
+    //auto d_sw_flux_dn_dir_after = field_mgr.get_field("sw_flux_dn_dir").get_view<Real**>();
+    //auto d_lw_flux_up_after = field_mgr.get_field("lw_flux_up").get_view<Real**>();
+    //auto d_lw_flux_dn_after = field_mgr.get_field("lw_flux_dn").get_view<Real**>();
+    // First step (i = 0) should be different
+    if (i == 0) {
+        REQUIRE(d_sw_flux_up_before(2,2) != d_sw_flux_up(2,2));
+    } else if (i == 1) {
+        REQUIRE(d_sw_flux_up_before(2,2) == d_sw_flux_up(2,2));
+    } else if (i == 2) {
+        REQUIRE(d_sw_flux_up_before(2,2) == d_sw_flux_up(2,2));
+    } else if (i == 3) {
+        REQUIRE(d_sw_flux_up_before(2,2) != d_sw_flux_up(2,2));
+    }
     if (atm_comm.am_i_root()) {
       std::cout << "  - Iteration " << std::setfill(' ') << std::setw(3) << i+1 << " completed";
       std::cout << "       [" << std::setfill(' ') << std::setw(3) << 100*(i+1)/nsteps << "%]\n";
+      std::cout << "flux_up: " << d_sw_flux_up(2,2) << "; flux_up_before: " << d_sw_flux_up_before(2,2) << std::endl;
     }
   }
 


### PR DESCRIPTION
Add option for radiation super-stepping (only running radiation every N steps as opposed to every step). This is enabled by setting `rad_frequency` (units of number of steps) to a value greater than 1 in the RRTMGP section of `input.yaml`. This is done by default for the `rrtmgp_standalone` test to test this functionality, where `rad_frequency = 3`. 