### PR TITLE
For utility function, change len=256 to len=* for incoming fortran string

### DIFF
--- a/components/scream/src/mct_coupling/ekat_string_utils.F90
+++ b/components/scream/src/mct_coupling/ekat_string_utils.F90
@@ -28,7 +28,7 @@ contains
     !
     ! Input(s)
     !
-    character(len=256),             intent(in)  :: f_str
+    character(len=*),               intent(in)  :: f_str
     character(kind=C_CHAR,len=256), intent(out) :: c_str
 
     c_str = TRIM(f_str)//C_NULL_CHAR


### PR DESCRIPTION
Without this, was seeing ugly chars in filename:

``` 
 ndk trim(diro)/trim(logfile)=(/pscratch/sd/n/ndk/e3sm_scratch/perlmutter/bio-apr11/f30.F2000SCREAMv1.ne30_ne30.bio-apr11.gnugpu.12s.n002a4x16.Hremap512.K00.RECe.N576.ts150.s8b/run/atm.log.1739914.220412-110504)
 ndk atm_log_fname_c=(/pscratch/sd/n/ndk/e3sm_scratch/perlmutter/bio-apr11/f30.F2000SCREAMv1.ne30_ne30.bio-apr11.gnugpu.12s.n002a4x16.Hremap512.K00.RECe.N576.ts150.s8b/run/atm.log.1739914.220412-110504bot::Q^@^@^@^@^@^@^@^@^@^@^@^B^@^@^@^@^@ ^@^D^@^@^@^A^@^@^@^@^@^@^@^@^@^@^@^B^@^@^$
```
