### PR TITLE
For Cori, add flag to allow building with gnuv10 and above.

### DIFF
--- a/components/scream/cmake/machine-files/cori-knl.cmake
+++ b/components/scream/cmake/machine-files/cori-knl.cmake
@@ -4,6 +4,16 @@ set (EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/c
 include (${EKAT_MACH_FILES_PATH}/kokkos/intel-knl.cmake)
 include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
 
+if ("${PROJECT_NAME}" STREQUAL "E3SM")
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+       set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch"  CACHE STRING "" FORCE) # only works with gnu v10 and above
+    endif()
+  endif()
+else()
+  set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch"  CACHE STRING "" FORCE) # only works with gnu v10 and above
+endif()
+
 # Fixes some openmpi link problems we observed on cori. This hack is
 # not necessary if CRAYPE_LINK_TYPE=dynamic is in the environment.
 set(SCREAM_CORI_HACK True CACHE BOOL "")


### PR DESCRIPTION
Only affects Cori and only for GNU compiling.
Add the `-fallow-argument-mismatch` flag only for gnu v10 and above (same as was done on Perlmutter).
With last upstream merge, the gnu compiler was bumped to v10.3 on Cori.

I tested with DEBUG build, but cannot test out-of-the-box with OPT due to https://github.com/E3SM-Project/scream/issues/1540 (but I did test with work-around).
