### PR TITLE
Restart fixes

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -152,6 +152,7 @@ tweaking their $case/namelist_scream.xml file.
         </Dynamics__Driven>
       </Grids__Manager>
       <Initial__Conditions>
+        <Restart__Casename>${CASE}</Restart__Casename>
         <Physics__GLL>
           <Filename>${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc</Filename>
           <Filename COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc</Filename>
@@ -167,7 +168,7 @@ tweaking their $case/namelist_scream.xml file.
       <Scorpio>
         <Output__YAML__Files>data/scream_output.yaml, </Output__YAML__Files>
         <Model__Restart>
-          <Casename>eamxx_model_restart</Casename>
+          <Casename>${CASE}</Casename>
           <Output__Control>
             <Frequency>${REST_N}</Frequency>
             <Frequency__Units>INVALID</Frequency__Units>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -172,6 +172,14 @@ tweaking their $case/namelist_scream.xml file.
       </Initial__Conditions>
       <Scorpio>
         <Output__YAML__Files>data/scream_output.yaml, </Output__YAML__Files>
+        <Model__Restart>
+          <Casename>eamxx_model_restart</Casename>
+          <Output__Control>
+            <Frequency>${REST_N}</Frequency>
+            <Frequency__Units>INVALID</Frequency__Units>
+            <Frequency__Units REST_OPTION="nstep*">Steps</Frequency__Units>
+          </Output__Control>
+        </Model__Restart>
       </Scorpio>
     </Atmosphere__Driver>
     <SCREAM>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -144,12 +144,6 @@ tweaking their $case/namelist_scream.xml file.
           <Orbital__MVELP COMPSET=".*SCREAM%AQUA.*">0</Orbital__MVELP>
         </Process__5>
       </Atmosphere__Processes>
-      <Time__Stepping>
-        <Time__Step>300</Time__Step>
-        <Start__Time>12, 30, 0</Start__Time>
-        <Start__Date>2000, 2, 1</Start__Date>
-        <Number__of__Steps>288</Number__of__Steps>
-      </Time__Stepping>
       <Grids__Manager>
         <Type>Dynamics Driven</Type>
         <Reference__Grid>Physics GLL</Reference__Grid>

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -451,7 +451,8 @@ void AtmosphereDriver::restart_model ()
   // First, figure out the name of the netcdf file containing the restart data
   std::string filename, content;
   bool found = false;
-  std::string match = m_run_t0.to_string() + ".r.nc";
+  std::string head = m_atm_params.sublist("Initial Conditions").get<std::string>("Restart Casename");
+  std::string tail = m_run_t0.to_string() + ".r.nc";
 
   if (m_atm_comm.am_i_root()) {
     std::ifstream rpointer_file;
@@ -463,7 +464,7 @@ void AtmosphereDriver::restart_model ()
     //       the last one (which is the last restart file that was written).
     while (rpointer_file >> line) {
       content += line + "\n";
-      if (line.find(match) != std::string::npos) {
+      if (line.find(head) != std::string::npos && line.find(tail) != std::string::npos) {
         found = true;
         filename = line;
       }
@@ -476,7 +477,8 @@ void AtmosphereDriver::restart_model ()
     broadcast_string(content,m_atm_comm,m_atm_comm.root_rank());
     EKAT_REQUIRE_MSG (found,
         "Error! Output restart requested, but no model restart file found in 'rpointer.atm'.\n"
-        "   restart file suffix: " + match +
+        "   restart file casename: " + head + "\n"
+        "   restart file suffix: " + tail + "\n"
         "   rpointer content:\n" + content);
   }
 

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -567,7 +567,9 @@ void AtmosphereDriver::create_logger () {
   using logger_t = Logger<LogBasicFile,LogRootRank>;
   auto logger = std::make_shared<logger_t>(log_fname,log_level,m_atm_comm,"");
   logger->set_no_format();
-  logger->set_console_level(LogLevel::off);
+  if (not m_atm_params.get<bool>("Standalone",true)) {
+    logger->set_console_level(LogLevel::off);
+  }
   m_atm_logger = logger;
 }
 

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -316,8 +316,6 @@ void AtmosphereDriver::create_fields()
 void AtmosphereDriver::initialize_output_managers () {
   check_ad_status (s_comm_set | s_params_set | s_grids_created | s_fields_created);
 
-  const bool restarted_run = m_case_t0<m_run_t0;
-
   auto& io_params = m_atm_params.sublist("Scorpio");
 
   // IMPORTANT: create model restart OutputManager first! This OM will be able to
@@ -330,7 +328,7 @@ void AtmosphereDriver::initialize_output_managers () {
     // Signal that this is not a normal output, but the model restart one
     m_output_managers.emplace_back();
     auto& om = m_output_managers.back();
-    om.setup(m_atm_comm,restart_pl,m_field_mgrs,m_grids_manager,m_run_t0,true,restarted_run);
+    om.setup(m_atm_comm,restart_pl,m_field_mgrs,m_grids_manager,m_run_t0,m_case_t0,true);
   }
 
   // Build one manager per output yaml file
@@ -341,7 +339,7 @@ void AtmosphereDriver::initialize_output_managers () {
     ekat::parse_yaml_file(fname,params);
     m_output_managers.emplace_back();
     auto& om = m_output_managers.back();
-    om.setup(m_atm_comm,params,m_field_mgrs,m_grids_manager,m_run_t0,false,restarted_run,m_case_t0);
+    om.setup(m_atm_comm,params,m_field_mgrs,m_grids_manager,m_run_t0,m_case_t0,false);
   }
 
   m_ad_status |= s_output_inited;

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -78,7 +78,7 @@ public:
   void set_surface_coupling (const std::shared_ptr<SurfaceCoupling>& sc) { m_surface_coupling = sc; }
 
   // Load initial conditions for atm inputs
-  void initialize_fields (const util::TimeStamp& t0, const RunType run_type = RunType::Initial);
+  void initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0);
 
   // Initialie I/O structures for output
   void initialize_output_managers ();
@@ -92,10 +92,19 @@ public:
   // which is handy for scream standalone tests.
   //  - atm_comm: the MPI comm containing all ranks assigned to the atmosphere
   //  - params: parameter list with all atm options (organized in sublists)
-  //  - t0: the time stamp where the simulation starts
+  //  - run_t0 : the time stamp where the run starts
+  //  - case_t0: the time stamp where the original simulation started (for restarts)
   void initialize (const ekat::Comm& atm_comm,
                    const ekat::ParameterList& params,
-                   const util::TimeStamp& t0);
+                   const util::TimeStamp& run_t0,
+                   const util::TimeStamp& case_t0);
+
+  // Shortcut for tests not doing restart
+  void initialize (const ekat::Comm& atm_comm,
+                   const ekat::ParameterList& params,
+                   const util::TimeStamp& t0) {
+    initialize(atm_comm,params,t0,t0);
+  }
 
   // The run method is responsible for advancing the atmosphere component by one atm time step
   // Inside here you should find calls to the run method of each subcomponent, including parameterizations

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -78,7 +78,7 @@ public:
   void set_surface_coupling (const std::shared_ptr<SurfaceCoupling>& sc) { m_surface_coupling = sc; }
 
   // Load initial conditions for atm inputs
-  void initialize_fields (const util::TimeStamp& t0);
+  void initialize_fields (const util::TimeStamp& t0, const RunType run_type = RunType::Initial);
 
   // Initialie I/O structures for output
   void initialize_output_managers ();

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -147,8 +147,14 @@ protected:
   // Surface coupling stuff
   std::shared_ptr<SurfaceCoupling>          m_surface_coupling;
 
-  // This are the time stamps of the start and end of the time step.
+  // This is the time stamp at the beginning of the time step.
   util::TimeStamp                           m_current_ts;
+
+  // These are the time stamps of the beginning of this run and case
+  // respectively. For initial runs, they are the same, but for
+  // restarted runs, the latter is "older" than the former
+  util::TimeStamp                           m_run_t0;
+  util::TimeStamp                           m_case_t0;
 
   // This is the comm containing all (and only) the processes assigned to the atmosphere
   ekat::Comm                                m_atm_comm;

--- a/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -163,7 +163,7 @@ TEST_CASE("dyn_grid_io")
 
   OutputManager output;
   // AtmosphereOutput output(comm,io_params,fm_dyn,gm);
-  output.setup (comm, io_params, fm_dyn, gm, t0, false, false);
+  output.setup (comm, io_params, fm_dyn, gm, t0, t0, false);
   output.run(t0);
   output.finalize();
 

--- a/components/scream/src/mct_coupling/atm_comp_mct.F90
+++ b/components/scream/src/mct_coupling/atm_comp_mct.F90
@@ -3,7 +3,7 @@ module atm_comp_mct
   ! Modules used acros atm_xyz_mct routines
 
   ! shr mods
-  use shr_kind_mod,     only: IN=>SHR_KIND_IN, R8=>SHR_KIND_R8, CL=>SHR_KIND_CL!, CS=>SHR_KIND_CS
+  use shr_kind_mod,     only: IN=>SHR_KIND_IN, R8=>SHR_KIND_R8, CL=>SHR_KIND_CL, CS=>SHR_KIND_CS
 
   ! seq mods
   use seq_cdata_mod,    only: seq_cdata, seq_cdata_setptrs
@@ -46,7 +46,7 @@ CONTAINS
 
   !===============================================================================
   subroutine atm_init_mct( EClock, cdata, x2a, a2x, NLFilename )
-    use iso_c_binding,      only: c_ptr, c_loc, c_int, c_char
+    use iso_c_binding,      only: c_ptr, c_loc, c_int, c_char, c_bool
     use scream_f2c_mod,     only: scream_create_atm_instance, scream_setup_surface_coupling, &
                                   scream_init_atm
     use scream_cpl_indices, only: scream_set_cpl_indices, num_cpl_exports, &
@@ -55,12 +55,12 @@ CONTAINS
                                   can_be_exported_during_init
     use ekat_string_utils,  only: string_f2c
     use kinds,              only: homme_iulog=>iulog
-
-    use mct_mod,        only: mct_aVect_init, mct_gsMap_lsize
-    use seq_flds_mod,   only: seq_flds_a2x_fields, seq_flds_x2a_fields
-    use seq_comm_mct,   only: seq_comm_inst, seq_comm_name, seq_comm_suffix
-    use shr_file_mod,   only: shr_file_getunit, shr_file_setIO
-    use shr_sys_mod,    only: shr_sys_abort
+    use mct_mod,            only: mct_aVect_init, mct_gsMap_lsize
+    use seq_flds_mod,       only: seq_flds_a2x_fields, seq_flds_x2a_fields
+    use seq_infodata_mod,   only: seq_infodata_start_type_start, seq_infodata_start_type_cont
+    use seq_comm_mct,       only: seq_comm_inst, seq_comm_name, seq_comm_suffix
+    use shr_file_mod,       only: shr_file_getunit, shr_file_setIO
+    use shr_sys_mod,        only: shr_sys_abort
 
     ! !INPUT/OUTPUT PARAMETERS:
     type(ESMF_Clock)            , intent(inout) :: EClock
@@ -126,7 +126,7 @@ CONTAINS
       read (modelio_fid,nml=modelio,iostat=ierr)
       close(modelio_fid)
     endif
-    mpi_bcast(ierr,1,MPI_INTEGER,master_task,mpicom_atm,mpi_ierr)
+    call mpi_bcast(ierr,1,MPI_INTEGER,master_task,mpicom_atm,mpi_ierr)
     if (ierr /= 0) then
       print *,'[eamxx] ERROR reading ','atm_modelio.nml'//trim(inst_suffix),': iostat=',ierr
       call mpi_abort(mpicom_atm,ierr,mpi_ierr)

--- a/components/scream/src/mct_coupling/atm_comp_mct.F90
+++ b/components/scream/src/mct_coupling/atm_comp_mct.F90
@@ -75,7 +75,7 @@ CONTAINS
     integer(IN)                      :: phase          ! initialization phase
     integer(IN)                      :: ierr,mpi_ierr  ! error codes
     integer(IN)                      :: modelio_fid    ! file descriptor for atm_modelio.nml
-    integer(IN)                      :: start_tod, start_ymd, cur_tod, cur_ymd
+    integer(IN)                      :: case_start_tod, case_start_ymd, cur_tod, cur_ymd
     integer                          :: lsize
     character(CL)                    :: diri           ! Unused
     character(CL)                    :: diro           ! directory where ATM log file is
@@ -171,8 +171,9 @@ CONTAINS
       print *, "[eamxx] ERROR! Unsupported starttype: "//trim(run_type)
       call mpi_abort(mpicom_atm,ierr,mpi_ierr)
     endif
-    call seq_timemgr_EClockGetData(EClock, curr_ymd=cur_ymd, curr_tod=cur_tod, start_ymd=start_ymd, start_tod=start_tod)
-    call scream_init_atm (INT(start_ymd,kind=C_INT), INT(start_tod,kind=C_INT),restarted_run)
+    call seq_timemgr_EClockGetData(EClock, curr_ymd=cur_ymd, curr_tod=cur_tod, start_ymd=case_start_ymd, start_tod=case_start_tod)
+    call scream_init_atm (INT(cur_ymd,kind=C_INT),  INT(cur_tod,kind=C_INT), &
+                          INT(case_start_ymd,kind=C_INT), INT(case_start_tod,kind=C_INT))
 
     ! Init surface coupling stuff in the AD
     call scream_set_cpl_indices (x2a, a2x)

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -158,10 +158,10 @@ void scream_setup_surface_coupling (
   });
 }
 
-void scream_init_atm (const int start_ymd,
-                      const int start_tod,
-                      const int curr_ymd,
-                      const int curr_tod)
+void scream_init_atm (const int run_start_ymd,
+                      const int run_start_tod,
+                      const int case_start_ymd,
+                      const int case_start_tod)
 {
   using namespace scream;
   using namespace scream::control;
@@ -170,29 +170,22 @@ void scream_init_atm (const int start_ymd,
     // Get the ad, then complete initialization
     auto& ad = get_ad_nonconst();
 
-    // Get the ekat comm
-    auto& atm_comm = ad.get_comm();
-
     // Recall that e3sm uses the int YYYYMMDD to store a date
-    if (atm_comm.am_i_root()) {
-      std::cout << "start_ymd: " << start_ymd << "\n";
-      std::cout << "start_tod: " << start_tod << "\n";
-    }
-
     int yy,mm,dd,hr,min,sec;
-    yy  = (curr_ymd / 100) / 100;
-    mm  = (curr_ymd / 100) % 100;
-    dd  =  curr_ymd % 100;
-    hr  = (curr_tod / 60) / 60;
-    min = (curr_tod / 60) % 60;
-    sec =  curr_tod % 60;
+    yy  = (run_start_ymd / 100) / 100;
+    mm  = (run_start_ymd / 100) % 100;
+    dd  =  run_start_ymd % 100;
+    hr  = (run_start_tod / 60) / 60;
+    min = (run_start_tod / 60) % 60;
+    sec =  run_start_tod % 60;
     util::TimeStamp run_t0 (yy,mm,dd,hr,min,sec);
-    yy  = (start_ymd / 100) / 100;
-    mm  = (start_ymd / 100) % 100;
-    dd  =  start_ymd % 100;
-    hr  = (start_tod / 60) / 60;
-    min = (start_tod / 60) % 60;
-    sec =  start_tod % 60;
+
+    yy  = (case_start_ymd / 100) / 100;
+    mm  = (case_start_ymd / 100) % 100;
+    dd  =  case_start_ymd % 100;
+    hr  = (case_start_tod / 60) / 60;
+    min = (case_start_tod / 60) % 60;
+    sec =  case_start_tod % 60;
     util::TimeStamp case_t0 (yy,mm,dd,hr,min,sec);
 
     // Init and run (to finalize, wait till checks are completed,

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -157,9 +157,10 @@ void scream_setup_surface_coupling (
   });
 }
 
-void scream_init_atm (const int  start_ymd,
-                      const int  start_tod,
-                      const bool restarted_run)
+void scream_init_atm (const int start_ymd,
+                      const int start_tod,
+                      const int curr_ymd,
+                      const int curr_tod)
 {
   using namespace scream;
   using namespace scream::control;
@@ -176,18 +177,26 @@ void scream_init_atm (const int  start_ymd,
       std::cout << "start_ymd: " << start_ymd << "\n";
       std::cout << "start_tod: " << start_tod << "\n";
     }
-    const int yy  = start_ymd / 10000;
-    const int mm  = (start_ymd / 100) % 100;
-    const int dd  = start_ymd % 100;
-    const int hr  =  start_tod / 3600;
-    const int min = (start_tod % 3600) / 60;
-    const int sec = (start_tod % 3600) % 60;
-    util::TimeStamp t0 (yy,mm,dd,hr,min,sec);
+
+    int yy,mm,dd,hr,min,sec;
+    yy  = (curr_ymd / 100) / 100;
+    mm  = (curr_ymd / 100) % 100;
+    dd  =  curr_ymd % 100;
+    hr  = (curr_tod / 60) / 60;
+    min = (curr_tod / 60) % 60;
+    sec =  curr_tod % 60;
+    util::TimeStamp run_t0 (yy,mm,dd,hr,min,sec);
+    yy  = (start_ymd / 100) / 100;
+    mm  = (start_ymd / 100) % 100;
+    dd  =  start_ymd % 100;
+    hr  = (start_tod / 60) / 60;
+    min = (start_tod / 60) % 60;
+    sec =  start_tod % 60;
+    util::TimeStamp case_t0 (yy,mm,dd,hr,min,sec);
 
     // Init and run (to finalize, wait till checks are completed,
     // or you'll clear the field managers!)
-    RunType run_type = restarted_run ? RunType::Restarted : RunType::Initial;
-    ad.initialize_fields (t0,run_type);
+    ad.initialize_fields (run_t0,case_t0);
     ad.initialize_output_managers ();
     ad.initialize_atm_procs ();
   });

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -100,6 +100,7 @@ void scream_create_atm_instance (const MPI_Fint f_comm, const int atm_id,
 
     auto& ad_params = scream_params.sublist("Atmosphere Driver");
     ad_params.set<std::string>("Atm Log File",atm_log_file);
+    ad_params.set<bool>("Standalone",false);
 
     // Need to register products in the factories *before* we attempt to create any.
     // In particular, register all atm processes, and all grids managers.

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -157,8 +157,9 @@ void scream_setup_surface_coupling (
   });
 }
 
-void scream_init_atm (const int& start_ymd,
-                      const int& start_tod)
+void scream_init_atm (const int  start_ymd,
+                      const int  start_tod,
+                      const bool restarted_run)
 {
   using namespace scream;
   using namespace scream::control;
@@ -185,7 +186,8 @@ void scream_init_atm (const int& start_ymd,
 
     // Init and run (to finalize, wait till checks are completed,
     // or you'll clear the field managers!)
-    ad.initialize_fields (t0);
+    RunType run_type = restarted_run ? RunType::Restarted : RunType::Initial;
+    ad.initialize_fields (t0,run_type);
     ad.initialize_output_managers ();
     ad.initialize_atm_procs ();
   });

--- a/components/scream/src/mct_coupling/scream_f2c_mod.F90
+++ b/components/scream/src/mct_coupling/scream_f2c_mod.F90
@@ -60,12 +60,13 @@ interface
   ! During this call, all fields are initialized (i.e., initial conditions are
   ! loaded), as well as the atm procs (which might use some initial conditions
   ! to further initialize internal structures), and the output manager.
-  subroutine scream_init_atm (start_ymd,start_tod) bind(c)
-    use iso_c_binding, only: c_int
+  subroutine scream_init_atm (start_ymd,start_tod,restarted_run) bind(c)
+    use iso_c_binding, only: c_int, c_bool
     !
     ! Input(s)
     !
-    integer (kind=c_int),   intent(in) :: start_tod, start_ymd
+    integer (kind=c_int),  value, intent(in) :: start_tod, start_ymd
+    logical (kind=c_bool), value, intent(in) :: restarted_run
   end subroutine scream_init_atm
 
   ! This subroutine will run the whole atm model for one atm timestep

--- a/components/scream/src/mct_coupling/scream_f2c_mod.F90
+++ b/components/scream/src/mct_coupling/scream_f2c_mod.F90
@@ -60,13 +60,13 @@ interface
   ! During this call, all fields are initialized (i.e., initial conditions are
   ! loaded), as well as the atm procs (which might use some initial conditions
   ! to further initialize internal structures), and the output manager.
-  subroutine scream_init_atm (start_ymd,start_tod,restarted_run) bind(c)
-    use iso_c_binding, only: c_int, c_bool
+  subroutine scream_init_atm (run_start_ymd,run_start_tod,case_start_ymd,case_start_tod) bind(c)
+    use iso_c_binding, only: c_int
     !
     ! Input(s)
     !
-    integer (kind=c_int),  value, intent(in) :: start_tod, start_ymd
-    logical (kind=c_bool), value, intent(in) :: restarted_run
+    integer (kind=c_int),  value, intent(in) :: run_start_tod, run_start_ymd
+    integer (kind=c_int),  value, intent(in) :: case_start_tod, case_start_ymd
   end subroutine scream_init_atm
 
   ! This subroutine will run the whole atm model for one atm timestep

--- a/components/scream/src/share/io/scream_output_manager.hpp
+++ b/components/scream/src/share/io/scream_output_manager.hpp
@@ -67,26 +67,44 @@ public:
 
   // Set up the manager, creating all output streams. Inputs:
   //  - params: the parameter list with file/fields info, as well as method of output options
-  //  - model_restart_output: whether this output stream is to write a model restart file
+  //  - field_mgr/field_mgrs: field manager(s) storing fields to be outputed
+  //  - grids_mgr: grid manager to create remapping from field managers grids onto the IO grid.
+  //               This is needed, e.g., when outputing SEGrid fields without duplicating dofs.
+  //  - run_t0: the timestamp of the start of the current simulation
+  //  - case_t0: the timestamp of the start of the overall simulation (precedes run_r0 for
+  //             a restarted simulation. Restart logic is triggered *only* if case_t0<run_t0.
+  //  - is_model_restart_output: whether this output stream is to write a model restart file
   void setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
               const std::shared_ptr<fm_type>& field_mgr,
               const std::shared_ptr<const gm_type>& grids_mgr,
               const util::TimeStamp& run_t0,
-              const bool is_model_restart_output,
-              const bool is_restarted_run,
-              const util::TimeStamp& case_t0 = util::TimeStamp());
+              const util::TimeStamp& case_t0,
+              const bool is_model_restart_output);
+  void setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
+              const std::shared_ptr<fm_type>& field_mgr,
+              const std::shared_ptr<const gm_type>& grids_mgr,
+              const util::TimeStamp& run_t0,
+              const bool is_model_restart_output) {
+    setup (io_comm,params,field_mgr,grids_mgr,run_t0,run_t0,is_model_restart_output);
+  }
 
   void setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
               const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs,
               const std::shared_ptr<const gm_type>& grids_mgr,
               const util::TimeStamp& run_t0,
-              const bool is_model_restart_output,
-              const bool is_restarted_run,
-              const util::TimeStamp& case_t0 = util::TimeStamp());
+              const util::TimeStamp& case_t0,
+              const bool is_model_restart_output);
+
+  void setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
+              const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs,
+              const std::shared_ptr<const gm_type>& grids_mgr,
+              const util::TimeStamp& run_t0,
+              const bool is_model_restart_output) {
+    setup (io_comm,params,field_mgrs,grids_mgr,run_t0,run_t0,is_model_restart_output);
+  }
+
   void run (const util::TimeStamp& current_ts);
   void finalize();
-
-  const util::TimeStamp& get_case_t0 () const { return m_case_t0; }
 protected:
 
   std::string compute_filename_root (const IOControl& control, const IOFileSpecs& file_specs) const;

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -156,7 +156,7 @@ TEST_CASE("input_output_basic","io")
     ekat::ParameterList params;
     ekat::parse_yaml_file("io_test_" + type + ".yaml",params);
     OutputManager om;
-    om.setup(io_comm,params,field_manager,gm,t0,false,false);
+    om.setup(io_comm,params,field_manager,gm,t0,t0,false);
     io_comm.barrier();
 
     const auto& out_fields = field_manager->get_groups_info().at("output");

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -104,8 +104,8 @@ protected:
     const auto& v_A  = get_field_in("field_packed").get_view<const Real**,Host>();
     auto v_me = m_diagnostic_output.get_view<Real**,Host>();
     // Have the dummy diagnostic just manipulate the field_packed data arithmetically.  In this case (x*3 + 2)
-    for (size_t i=0; i<m_num_cols; ++i) {
-      for (size_t k=0; k<m_num_levs; ++k) {
+    for (int i=0; i<m_num_cols; ++i) {
+      for (int k=0; k<m_num_levs; ++k) {
         v_me(i,k) = v_A(i,k)*3.0 + 2.0;
       }
     }
@@ -135,7 +135,6 @@ TEST_CASE("input_output_basic","io")
   auto gm = get_test_gm(io_comm,num_gcols,num_levs);
   auto grid = gm->get_grid("Point Grid");
   int num_lcols = grid->get_num_local_dofs();
-  int num_llevs = grid->get_num_vertical_levels();
 
   // Need to register the Test Diagnostic so that IO can access it
   auto& diag_factory = AtmosphereDiagnosticFactory::instance();

--- a/components/scream/src/share/io/tests/output_restart.cpp
+++ b/components/scream/src/share/io/tests/output_restart.cpp
@@ -71,7 +71,7 @@ TEST_CASE("output_restart","io")
   ekat::ParameterList output_params;
   ekat::parse_yaml_file(param_filename,output_params);
   OutputManager output_manager;
-  output_manager.setup(io_comm,output_params,field_manager,gm,t0,false,false);
+  output_manager.setup(io_comm,output_params,field_manager,gm,t0,t0,false);
 
   // We advance the fields, by adding dt to each entry of the fields at each time step
   // The output restart data is written every 5 time steps, while the output freq is 10.
@@ -139,7 +139,7 @@ TEST_CASE("output_restart","io")
   ekat::parse_yaml_file(param_filename_res,output_params_res);
 
   OutputManager output_manager_res;
-  output_manager_res.setup(io_comm,output_params_res,fm_res,gm,time_res,false,true,t0);
+  output_manager_res.setup(io_comm,output_params_res,fm_res,gm,time_res,t0,false);
 
   // Run 5 more steps from the restart, to get to the next output step.
   // We should be generating the same output file as before.

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -5,9 +5,11 @@ Debug:
 
 Time Stepping:
   Time Step: 300
-  Start Time: [12, 00, 00]      # Hours, Minutes, Seconds
-  Start Date: [2021, 10, 12]    # Year, Month, Day
   Number of Steps: 2
+  Run Start Time: [12, 00, 00]      # Hours, Minutes, Seconds
+  Run Start Date: [2021, 10, 12]    # Year, Month, Day
+  Case Start Time: [12, 00, 00]      # Hours, Minutes, Seconds
+  Case Start Date: [2021, 10, 12]    # Year, Month, Day
 
 Initial Conditions:
   Restart Run: false

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -5,9 +5,11 @@ Debug:
 
 Time Stepping:
   Time Step: 300
-  Start Time: [12, 00, 00]      # Hours, Minutes, Seconds
-  Start Date: [2021, 10, 12]    # Year, Month, Day
   Number of Steps: 1
+  Run Start Time: [12, 00, 00]      # Hours, Minutes, Seconds
+  Run Start Date: [2021, 10, 12]    # Year, Month, Day
+  Case Start Time: [12, 00, 00]      # Hours, Minutes, Seconds
+  Case Start Date: [2021, 10, 12]    # Year, Month, Day
 
 Initial Conditions:
   Restart Run: false

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -6,12 +6,13 @@ Debug:
 Time Stepping:
   # IMPORTANT: make sure Start Time equals to the initial run start time PLUS one time step
   Time Step: 300
-  Start Time: [12, 05, 00]      # Hours, Minutes, Seconds
-  Start Date: [2021, 10, 12]    # Year, Month, Day
   Number of Steps: 1
+  Run Start Time: [12, 05, 00]      # Hours, Minutes, Seconds
+  Run Start Date: [2021, 10, 12]    # Year, Month, Day
+  Case Start Time: [12, 00, 00]      # Hours, Minutes, Seconds
+  Case Start Date: [2021, 10, 12]    # Year, Month, Day
 
 Initial Conditions:
-  Restart Run: true
   Restart Casename: model_restart
 
 Atmosphere Processes:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -12,6 +12,7 @@ Time Stepping:
 
 Initial Conditions:
   Restart Run: true
+  Restart Casename: model_restart
 
 Atmosphere Processes:
   Number of Entries: 5

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -12,7 +12,6 @@ Time Stepping:
 
 Initial Conditions:
   Restart Run: true
-  Restart Casename: model_restart
 
 Atmosphere Processes:
   Number of Entries: 5


### PR DESCRIPTION
This PR mainly tries to make initialization/restart of SCREAM as little confusing as possible. Some highlights:

- Providing a timestamp for the start of the run as well as one for the start of the case can automate some logic that detects whether this is a restarted run or an initial one. This is true in the driver as well as in the output manager.
- We now gather more info from the cpl regarding time: on top of start tod/ymd (which are the _case_ start timestamp, if I understand correctly), we gather the current tod/ymd (the start timestamp of this _run_), as well as the start type (initial vs continued)
- The "Time Stepping" section in our tests is not used in the src folder, it's just to init our tests, so can be removed from our XML file.
- Added some logging in the AD during the initialization sequence.
- Added entries to our XML defaults to handle restarts.

Edit: currently checking, but the following should be fixed by this PR.

Fixes #1530
Fixes #1544 

