### PR TITLE
Bartgol/add p3 tables files to xml defaults input list

### DIFF
--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -523,7 +523,7 @@ def refine_type(entry, force_type=None):
     Try to convert the text entry to the appropriate type based on its contents.
     """
     if "," in entry:
-        result = [refine_type(item, force_type=force_type) for item in entry.split(", ") if item.strip() != ""]
+        result = [refine_type(item, force_type=force_type) for item in entry.split(",") if item.strip() != ""]
         expected_type = type(result[0])
         for item in result[1:]:
             expect(isinstance(item, expected_type), "List '{}' has inconsistent types inside".format(entry))

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -176,7 +176,18 @@ tweaking their $case/namelist_scream.xml file.
     </Atmosphere__Driver>
     <SCREAM>
       <Start__Date>${RUN_STARTDATE}</Start__Date>
-      <Input__Files>${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-sw-g224-2018-12-04.nc, ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-lw-g256-2018-12-04.nc, ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-sw.nc, ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-lw.nc, ${DIN_LOC_ROOT}/atm/scream/tables/p3_lookup_table_1.dat-v4.1.1, ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc</Input__Files>
+      <Input__Files>
+        ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-sw-g224-2018-12-04.nc,
+        ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-lw-g256-2018-12-04.nc,
+        ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-sw.nc,
+        ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-lw.nc,
+        ${DIN_LOC_ROOT}/atm/scream/tables/p3_lookup_table_1.dat-v4.1.1,
+        ${DIN_LOC_ROOT}/atm/scream/tables/mu_r_table_vals.dat8,
+        ${DIN_LOC_ROOT}/atm/scream/tables/revap_table_vals.dat8,
+        ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
+        ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
+        ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc
+    </Input__Files>
     </SCREAM>
   </file>
 


### PR DESCRIPTION
Fix to allow new p3 tables files to be automatically downloaded by CIME along with other input files.