### PR TITLE
Better memory management for SPA data read

### DIFF
--- a/components/scream/src/physics/spa/spa_functions.hpp
+++ b/components/scream/src/physics/spa/spa_functions.hpp
@@ -169,14 +169,14 @@ struct SPAFunctions
     // 1D index of target grid column.
     view_1d<Int> target_grid_loc;
     // Organize unique source grid columns
-    Int              num_unique_cols;
-    std::vector<Int> source_grid_unique_cols; 
+    Int               num_unique_cols;
+    std::map<Int,Int> source_local_col_map;
 
     //  Helper function to organize the set of unique source data columns
     void set_unique_cols()
     {
       auto source_grid_loc_h = Kokkos::create_mirror_view(source_grid_loc);
-      Kokkos::deep_copy(source_grid_loc_h,source_grid_loc);
+      std::vector<Int>  source_grid_unique_cols; 
       for (int ii=0; ii<length; ii++) {
         Int src_col = source_grid_loc_h(ii);
         if (find(source_grid_unique_cols.begin(),source_grid_unique_cols.end(),src_col) == source_grid_unique_cols.end()) {
@@ -184,7 +184,9 @@ struct SPAFunctions
         } // if find
       } // for ii
       num_unique_cols = source_grid_unique_cols.size();
-      // TODO: Not sure if we should also sort the source_grid_unqiue_cols vector.
+      for (int ii=0; ii<num_unique_cols; ii++) {
+        source_local_col_map[source_grid_unique_cols[ii]] = ii;
+      } // for ii
     }
 
   }; // SPAHorizInterp

--- a/components/scream/src/physics/spa/spa_functions.hpp
+++ b/components/scream/src/physics/spa/spa_functions.hpp
@@ -168,6 +168,24 @@ struct SPAFunctions
     view_1d<Int> source_grid_loc;
     // 1D index of target grid column.
     view_1d<Int> target_grid_loc;
+    // Organize unique source grid columns
+    Int              num_unique_cols;
+    std::vector<Int> source_grid_unique_cols; 
+
+    //  Helper function to organize the set of unique source data columns
+    void set_unique_cols()
+    {
+      auto source_grid_loc_h = Kokkos::create_mirror_view(source_grid_loc);
+      Kokkos::deep_copy(source_grid_loc_h,source_grid_loc);
+      for (int ii=0; ii<length; ii++) {
+        Int src_col = source_grid_loc_h(ii);
+        if (find(source_grid_unique_cols.begin(),source_grid_unique_cols.end(),src_col) == source_grid_unique_cols.end()) {
+          source_grid_unique_cols.push_back(src_col);
+        } // if find
+      } // for ii
+      num_unique_cols = source_grid_unique_cols.size();
+      // TODO: Not sure if we should also sort the source_grid_unqiue_cols vector.
+    }
 
   }; // SPAHorizInterp
   /* ------------------------------------------------------------------------------------------- */

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -491,14 +491,15 @@ void SPAFunctions<S,D>
           SPAInput&             spa_data)
 {
   // Ensure all ranks are operating independently when reading the file, so there's a copy on all ranks
-  ekat::Comm self_comm(MPI_COMM_SELF);
+  auto comm = spa_horiz_interp.m_comm;
 
   // We have enough info to start opening the file
   std::vector<std::string> fnames = {"hyam","hybm","PS","CCN3","AER_G_SW","AER_SSA_SW","AER_TAU_SW","AER_TAU_LW"};
   ekat::ParameterList spa_data_in_params;
   spa_data_in_params.set("Field Names",fnames);
   spa_data_in_params.set("Filename",spa_data_file_name);
-  AtmosphereInput spa_data_input(self_comm,spa_data_in_params);
+  spa_data_in_params.set("Skip_Grid_Checks",true);  // We need to skip grid checks because multiple ranks may want the same column of source data.
+  AtmosphereInput spa_data_input(comm,spa_data_in_params);
 
   // Note that the SPA data follows a conventional GLL grid format, albeit at a different resolution than
   // the simulation.  For simplicity we can use the scorpio_input object class but we must construct a
@@ -507,12 +508,14 @@ void SPAFunctions<S,D>
   // To construct the grid we need to determine the number of columns and levels in the data file.
   Int ncol = scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"ncol");
   const int source_data_nlevs = scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"lev");
+  Int num_local_cols = spa_horiz_interp.num_unique_cols;
   // Check that padding matches source size:
   EKAT_REQUIRE(source_data_nlevs+2 == spa_data.data.nlevs);
   // while we have the file open, check that the dimensions map the simulation and the horizontal interpolation structure
   EKAT_REQUIRE_MSG(nswbands==scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"swband"),"ERROR update_spa_data_from_file: Number of SW bands in simulation doesn't match the SPA data file");
   EKAT_REQUIRE_MSG(nlwbands==scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"lwband"),"ERROR update_spa_data_from_file: Number of LW bands in simulation doesn't match the SPA data file");
-  EKAT_REQUIRE_MSG(ncol==spa_horiz_interp.source_grid_ncols,"ERROR update_spa_data_from_file: Number of columns in remap data doesn't match the SPA data file");
+  EKAT_REQUIRE_MSG(ncol==spa_horiz_interp.source_grid_ncols,"ERROR update_spa_data_from_file: Number of columns in remap data (" 
+                        + std::to_string(ncol) + " doesn't match the SPA data file (" + std::to_string(spa_horiz_interp.source_grid_ncols) + ").");
 
   // Construct local arrays to read data into
   // Note, all of the views being created here are meant to hold the local "coarse" resolution
@@ -524,27 +527,29 @@ void SPAFunctions<S,D>
   //   and so on for the other variables.
   typename view_1d<Real>::HostMirror hyam_v_h("hyam",source_data_nlevs);
   typename view_1d<Real>::HostMirror hybm_v_h("hybm",source_data_nlevs);
-  typename view_1d<Real>::HostMirror PS_v_h("PS",spa_horiz_interp.source_grid_ncols);
-  typename view_2d<Real>::HostMirror CCN3_v_h("CCN3",spa_horiz_interp.source_grid_ncols,source_data_nlevs);
-  typename view_3d<Real>::HostMirror AER_G_SW_v_h("AER_G_SW",spa_horiz_interp.source_grid_ncols,nswbands,source_data_nlevs);
-  typename view_3d<Real>::HostMirror AER_SSA_SW_v_h("AER_SSA_SW",spa_horiz_interp.source_grid_ncols,nswbands,source_data_nlevs);
-  typename view_3d<Real>::HostMirror AER_TAU_SW_v_h("AER_TAU_SW",spa_horiz_interp.source_grid_ncols,nswbands,source_data_nlevs);
-  typename view_3d<Real>::HostMirror AER_TAU_LW_v_h("AER_TAU_LW",spa_horiz_interp.source_grid_ncols,nlwbands,source_data_nlevs);
+  typename view_1d<Real>::HostMirror PS_v_h("PS",num_local_cols);
+  typename view_2d<Real>::HostMirror CCN3_v_h("CCN3",num_local_cols,source_data_nlevs);
+  typename view_3d<Real>::HostMirror AER_G_SW_v_h("AER_G_SW",num_local_cols,nswbands,source_data_nlevs);
+  typename view_3d<Real>::HostMirror AER_SSA_SW_v_h("AER_SSA_SW",num_local_cols,nswbands,source_data_nlevs);
+  typename view_3d<Real>::HostMirror AER_TAU_SW_v_h("AER_TAU_SW",num_local_cols,nswbands,source_data_nlevs);
+  typename view_3d<Real>::HostMirror AER_TAU_LW_v_h("AER_TAU_LW",num_local_cols,nlwbands,source_data_nlevs);
 
   // Construct the grid needed for input:
-  auto grid = std::make_shared<PointGrid>("grid",spa_horiz_interp.source_grid_ncols,source_data_nlevs,self_comm);
-  PointGrid::dofs_list_type dof_gids("",spa_horiz_interp.source_grid_ncols);
-  Kokkos::parallel_for("", spa_horiz_interp.source_grid_ncols, KOKKOS_LAMBDA (const int& ii) {
-    dof_gids(ii) = ii;
-  });
+  auto grid = std::make_shared<PointGrid>("grid",num_local_cols,source_data_nlevs,comm);
+  PointGrid::dofs_list_type dof_gids("",num_local_cols);
+  auto dof_gids_h = Kokkos::create_mirror_view(dof_gids);
+  for (const auto& nn : spa_horiz_interp.source_local_col_map) {
+    dof_gids_h(nn.second) = nn.first;
+  }
+  Kokkos::deep_copy(dof_gids,dof_gids_h);
   grid->set_dofs(dof_gids);
 
   using namespace ShortFieldTagsNames;
   FieldLayout scalar1d_layout { {LEV}, {source_data_nlevs} };
-  FieldLayout scalar2d_layout_mid { {COL}, {spa_horiz_interp.source_grid_ncols} };
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {spa_horiz_interp.source_grid_ncols, source_data_nlevs} };
-  FieldLayout scalar3d_swband_layout { {COL,SWBND, LEV}, {spa_horiz_interp.source_grid_ncols, nswbands, source_data_nlevs} }; 
-  FieldLayout scalar3d_lwband_layout { {COL,LWBND, LEV}, {spa_horiz_interp.source_grid_ncols, nlwbands, source_data_nlevs} };
+  FieldLayout scalar2d_layout_mid { {COL}, {num_local_cols} };
+  FieldLayout scalar3d_layout_mid { {COL,LEV}, {num_local_cols, source_data_nlevs} };
+  FieldLayout scalar3d_swband_layout { {COL,SWBND, LEV}, {num_local_cols, nswbands, source_data_nlevs} }; 
+  FieldLayout scalar3d_lwband_layout { {COL,LWBND, LEV}, {num_local_cols, nlwbands, source_data_nlevs} };
   std::map<std::string,view_1d_host> host_views;
   std::map<std::string,FieldLayout>  layouts;
   // Define each input variable we need
@@ -603,7 +608,7 @@ void SPAFunctions<S,D>
   Kokkos::deep_copy(target_grid_loc_h, spa_horiz_interp.target_grid_loc);
   for (int idx=0;idx<spa_horiz_interp.length;idx++) {
     auto src_wgt = weights_h(idx);
-    int  src_col = source_grid_loc_h(idx);
+    int  src_col = spa_horiz_interp.source_local_col_map[source_grid_loc_h(idx)];
     int  tgt_col = target_grid_loc_h(idx);
     // PS is defined only over columns
     ps_h(tgt_col) += PS_v_h(src_col)*src_wgt;

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -550,30 +550,30 @@ void SPAFunctions<S,D>
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {num_local_cols, source_data_nlevs} };
   FieldLayout scalar3d_swband_layout { {COL,SWBND, LEV}, {num_local_cols, nswbands, source_data_nlevs} }; 
   FieldLayout scalar3d_lwband_layout { {COL,LWBND, LEV}, {num_local_cols, nlwbands, source_data_nlevs} };
-  std::map<std::string,view_1d_host> host_views;
+  std::map<std::string,view_1d_host<Real>> host_views;
   std::map<std::string,FieldLayout>  layouts;
   // Define each input variable we need
-  host_views["hyam"] = view_1d_host(hyam_v_h.data(),hyam_v_h.size());
+  host_views["hyam"] = view_1d_host<Real>(hyam_v_h.data(),hyam_v_h.size());
   layouts.emplace("hyam", scalar1d_layout);
-  host_views["hybm"] = view_1d_host(hybm_v_h.data(),hybm_v_h.size());
+  host_views["hybm"] = view_1d_host<Real>(hybm_v_h.data(),hybm_v_h.size());
   layouts.emplace("hybm", scalar1d_layout);
   //
-  host_views["PS"] = view_1d_host(PS_v_h.data(),PS_v_h.size());
+  host_views["PS"] = view_1d_host<Real>(PS_v_h.data(),PS_v_h.size());
   layouts.emplace("PS", scalar2d_layout_mid);
   //
-  host_views["CCN3"] = view_1d_host(CCN3_v_h.data(),CCN3_v_h.size());
+  host_views["CCN3"] = view_1d_host<Real>(CCN3_v_h.data(),CCN3_v_h.size());
   layouts.emplace("CCN3",scalar3d_layout_mid);
   //
-  host_views["AER_G_SW"] = view_1d_host(AER_G_SW_v_h.data(),AER_G_SW_v_h.size());
+  host_views["AER_G_SW"] = view_1d_host<Real>(AER_G_SW_v_h.data(),AER_G_SW_v_h.size());
   layouts.emplace("AER_G_SW",scalar3d_swband_layout);
   //
-  host_views["AER_SSA_SW"] = view_1d_host(AER_SSA_SW_v_h.data(),AER_SSA_SW_v_h.size());
+  host_views["AER_SSA_SW"] = view_1d_host<Real>(AER_SSA_SW_v_h.data(),AER_SSA_SW_v_h.size());
   layouts.emplace("AER_SSA_SW",scalar3d_swband_layout);
   //
-  host_views["AER_TAU_SW"] = view_1d_host(AER_TAU_SW_v_h.data(),AER_TAU_SW_v_h.size());
+  host_views["AER_TAU_SW"] = view_1d_host<Real>(AER_TAU_SW_v_h.data(),AER_TAU_SW_v_h.size());
   layouts.emplace("AER_TAU_SW",scalar3d_swband_layout);
   //
-  host_views["AER_TAU_LW"] = view_1d_host(AER_TAU_LW_v_h.data(),AER_TAU_LW_v_h.size());
+  host_views["AER_TAU_LW"] = view_1d_host<Real>(AER_TAU_LW_v_h.data(),AER_TAU_LW_v_h.size());
   layouts.emplace("AER_TAU_LW",scalar3d_lwband_layout);
   //
   

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -318,6 +318,8 @@ void SPAFunctions<S,D>
     // That way the first global-id will map to the 0th entry in the source grid data.
     spa_horiz_interp.source_grid_loc(ii) = dofs_gids(ii) - min_dof;
   });
+  // Determine the set of unique columns in this remapping
+  spa_horiz_interp.set_unique_cols();
 } // END set_remap_weights_one_to_one
 /*-----------------------------------------------------------------*/
 // Function to read the weights for conducting horizontal remapping
@@ -431,6 +433,8 @@ void SPAFunctions<S,D>
   Kokkos::deep_copy(spa_horiz_interp.weights        , weights_h        );
   Kokkos::deep_copy(spa_horiz_interp.source_grid_loc, source_grid_loc_h);
   Kokkos::deep_copy(spa_horiz_interp.target_grid_loc, target_grid_loc_h);
+  // Determine the set of unique columns in this remapping
+  spa_horiz_interp.set_unique_cols();
 }  // END get_remap_weights_from_file
 /*-----------------------------------------------------------------*/
 /* Note: In this routine the SPA source data is padded in the vertical

--- a/components/scream/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
@@ -68,7 +68,7 @@ TEST_CASE("spa_one_to_one_remap","spa")
   REQUIRE(spa_horiz_interp.num_unique_cols==my_ncols);
   for (int ii=0;ii<spa_horiz_interp.num_unique_cols;ii++) {
     // Also check that each entry is uniquely placed in the vector
-    REQUIRE(std::count(spa_horiz_interp.source_grid_unique_cols.begin(),spa_horiz_interp.source_grid_unique_cols.end(),dofs_gids_h(ii))==1);
+    REQUIRE(spa_horiz_interp.source_local_col_map.count(dofs_gids_h(ii))==1);
   }
   // Recall, SPA data is padded, so we initialize with 2 more levels than the source data file.
   SPAFunc::SPAInput spa_data(dofs_gids.size(), nlevs+2, nswbands, nlwbands);

--- a/components/scream/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
@@ -66,10 +66,6 @@ TEST_CASE("spa_one_to_one_remap","spa")
   SPAFunc::set_remap_weights_one_to_one(ncols,min_dof,dofs_gids,spa_horiz_interp);
   // Make sure one_to_one remap has the correct unique columns
   REQUIRE(spa_horiz_interp.num_unique_cols==my_ncols);
-  for (int ii=0;ii<spa_horiz_interp.num_unique_cols;ii++) {
-    // Also check that each entry is uniquely placed in the vector
-    REQUIRE(spa_horiz_interp.source_local_col_map.count(dofs_gids_h(ii))==1);
-  }
   // Recall, SPA data is padded, so we initialize with 2 more levels than the source data file.
   SPAFunc::SPAInput spa_data(dofs_gids.size(), nlevs+2, nswbands, nlwbands);
 

--- a/components/scream/src/physics/spa/tests/spa_read_remap_from_file_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_read_remap_from_file_test.cpp
@@ -56,10 +56,6 @@ TEST_CASE("spa_read_remap_data","spa")
   SPAFunc::get_remap_weights_from_file(remap_file_name,tgt_grid_ncols_total,0,dofs_gids,spa_horiz_interp);
   // Make sure one_to_one remap has the correct unique columns
   REQUIRE(spa_horiz_interp.num_unique_cols==src_grid_ncols);
-  for (int ii=0;ii<src_grid_ncols;ii++) {
-    // Also check that each entry is uniquely placed in the vector
-    REQUIRE(spa_horiz_interp.source_local_col_map.count(ii)==1);
-  }
 
   REQUIRE(spa_horiz_interp.length==tgt_grid_ncols*src_grid_ncols);
   REQUIRE(spa_horiz_interp.source_grid_ncols==src_grid_ncols);

--- a/components/scream/src/physics/spa/tests/spa_read_remap_from_file_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_read_remap_from_file_test.cpp
@@ -54,6 +54,12 @@ TEST_CASE("spa_read_remap_data","spa")
   REQUIRE(test_total_ncols == tgt_grid_ncols_total);
 
   SPAFunc::get_remap_weights_from_file(remap_file_name,tgt_grid_ncols_total,0,dofs_gids,spa_horiz_interp);
+  // Make sure one_to_one remap has the correct unique columns
+  REQUIRE(spa_horiz_interp.num_unique_cols==src_grid_ncols);
+  for (int ii=0;ii<src_grid_ncols;ii++) {
+    // Also check that each entry is uniquely placed in the vector
+    REQUIRE(std::count(spa_horiz_interp.source_grid_unique_cols.begin(),spa_horiz_interp.source_grid_unique_cols.end(),ii)==1);
+  }
 
   REQUIRE(spa_horiz_interp.length==tgt_grid_ncols*src_grid_ncols);
   REQUIRE(spa_horiz_interp.source_grid_ncols==src_grid_ncols);

--- a/components/scream/src/physics/spa/tests/spa_read_remap_from_file_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_read_remap_from_file_test.cpp
@@ -58,7 +58,7 @@ TEST_CASE("spa_read_remap_data","spa")
   REQUIRE(spa_horiz_interp.num_unique_cols==src_grid_ncols);
   for (int ii=0;ii<src_grid_ncols;ii++) {
     // Also check that each entry is uniquely placed in the vector
-    REQUIRE(std::count(spa_horiz_interp.source_grid_unique_cols.begin(),spa_horiz_interp.source_grid_unique_cols.end(),ii)==1);
+    REQUIRE(spa_horiz_interp.source_local_col_map.count(ii)==1);
   }
 
   REQUIRE(spa_horiz_interp.length==tgt_grid_ncols*src_grid_ncols);

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -200,12 +200,15 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
   // Sanity checks
   EKAT_REQUIRE_MSG (not m_io_grid, "Error! Grid pointer was already set.\n");
   EKAT_REQUIRE_MSG (grid, "Error! Input grid pointer is invalid.\n");
-  EKAT_REQUIRE_MSG (grid->is_unique(),
-      "Error! I/O only supports grids which are 'unique', meaning that the\n"
-      "       map dof_gid->proc_id is well defined.\n");
-  EKAT_REQUIRE_MSG (
-      (grid->get_global_max_dof_gid()-grid->get_global_min_dof_gid()+1)==grid->get_num_global_dofs(),
-      "Error! In order for IO to work, the grid must (globally) have dof gids in interval [gid_0,gid_0+num_global_dofs).\n");
+  const bool skip_grid_chk = m_params.get<bool>("Skip_Grid_Checks",false);
+  if (!skip_grid_chk) {
+    EKAT_REQUIRE_MSG (grid->is_unique(),
+        "Error! I/O only supports grids which are 'unique', meaning that the\n"
+        "       map dof_gid->proc_id is well defined.\n");
+    EKAT_REQUIRE_MSG (
+        (grid->get_global_max_dof_gid()-grid->get_global_min_dof_gid()+1)==grid->get_num_global_dofs(),
+        "Error! In order for IO to work, the grid must (globally) have dof gids in interval [gid_0,gid_0+num_global_dofs).\n");
+  }
 
   EKAT_REQUIRE_MSG(m_comm.size()<=grid->get_num_global_dofs(),
       "Error! PIO interface requires the size of the IO MPI group to be\n"


### PR DESCRIPTION
This commit improves the infrastructure for pulling SPA data from a file which will solve an issue we have been seeing with out-of-memory errors on certain machines, in particular `quartz` and `cori`.

This commit changes the data read to just pull spa data for the columns that a particular rank is interested in.  Before this change each rank would pull all of the data, which was an issue for the ne30 dataset.