### PR TITLE
Add error message output from property checks

### DIFF
--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -174,8 +174,8 @@ void AtmosphereProcess::run_precondition_checks () const {
   for (const auto& it : m_precondition_checks) {
     const auto& pc = it.second;
 
-    auto check = pc->check();
-    if (check) {
+    auto check_result = pc->check();
+    if (check_result.pass) {
       continue;
     }
 
@@ -189,14 +189,16 @@ void AtmosphereProcess::run_precondition_checks () const {
         "WARNING: Pre-condition property check failed.\n"
         "  - Property check name: " + pc->name() + "\n"
         "  - Atmosphere process name: " + name() + "\n"
-        "  - Atmosphere process MPI Rank: " + std::to_string(m_comm.rank()) + "\n");
+        "  - Atmosphere process MPI Rank: " + std::to_string(m_comm.rank()) + "\n"
+        "  - Message: " + check_result.msg);
     } else {
       // No hope. Crash.
       EKAT_ERROR_MSG(
           "Error! Failed pre-condition check (cannot be repaired).\n"
           "  - Atm process name: " + name() + "\n"
           "  - Property check name: " + pc->name() + "\n"
-          "  - Atmosphere process MPI Rank: " + std::to_string(m_comm.rank()) + "\n");
+          "  - Atmosphere process MPI Rank: " + std::to_string(m_comm.rank()) + "\n"
+          "  - Message: " + check_result.msg);
     }
   }
 }
@@ -206,8 +208,8 @@ void AtmosphereProcess::run_postcondition_checks () const {
   for (const auto& it : m_postcondition_checks) {
     const auto& pc = it.second;
 
-    auto check = pc->check();
-    if (check) {
+    auto check_result = pc->check();
+    if (check_result.pass) {
       continue;
     }
 
@@ -225,14 +227,16 @@ void AtmosphereProcess::run_postcondition_checks () const {
         "WARNING: Post-condition property check failed.\n"
         "  - Property check name: " + pc->name() + "\n"
         "  - Atmosphere process name: " + name() + "\n"
-        "  - Atmosphere process MPI Rank: " + std::to_string(m_comm.rank()) + "\n");
+        "  - Atmosphere process MPI Rank: " + std::to_string(m_comm.rank()) + "\n"
+        "  - Error message: " + check_result.msg);
     } else {
       // No hope. Crash.
       EKAT_ERROR_MSG(
           "Error! Failed post-condition check (cannot be repaired).\n"
           "  - Atm process name: " + name() + "\n"
           "  - Property check name: " + pc->name() + "\n"
-          "  - Atmosphere process MPI Rank: " + std::to_string(m_comm.rank()) + "\n");
+          "  - Atmosphere process MPI Rank: " + std::to_string(m_comm.rank()) + "\n"
+          "  - Error message: " + check_result.msg);
     }
   }
 }

--- a/components/scream/src/share/property_checks/check_and_repair_wrapper.hpp
+++ b/components/scream/src/share/property_checks/check_and_repair_wrapper.hpp
@@ -69,7 +69,7 @@ public:
     return n;
   }
 
-  bool check() const override {
+  CheckResult check() const override {
     return m_check->check();
   }
 

--- a/components/scream/src/share/property_checks/field_nan_check.cpp
+++ b/components/scream/src/share/property_checks/field_nan_check.cpp
@@ -24,7 +24,7 @@ FieldNaNCheck (const Field& f)
 }
 
 template<typename ST>
-bool FieldNaNCheck::check_impl() const {
+PropertyCheck::CheckResult FieldNaNCheck::check_impl() const {
   using const_ST    = typename std::add_const<ST>::type;
 
   const auto& f = fields().front();
@@ -111,10 +111,16 @@ bool FieldNaNCheck::check_impl() const {
           "You should not have reached this line. Please, contact developers.\n");
   }
 
-  return num_invalid==0;
+  PropertyCheck::CheckResult check_result;
+  check_result.pass = (num_invalid == 0);
+  check_result.msg = "";
+  if (not check_result.pass) {
+    check_result.msg = std::string("FieldNaNCheck failed; ") + std::to_string(num_invalid) + " invalid values found\n";
+  }
+  return check_result;
 }
 
-bool FieldNaNCheck::check() const {
+PropertyCheck::CheckResult FieldNaNCheck::check() const {
   const auto& f = fields().front();
 
   switch (f.data_type()) {

--- a/components/scream/src/share/property_checks/field_nan_check.hpp
+++ b/components/scream/src/share/property_checks/field_nan_check.hpp
@@ -17,14 +17,14 @@ public:
     return "NaN check for field " + fields().front().name();
   }
 
-  bool check() const override;
+  CheckResult check() const override;
 
 // CUDA requires the parent fcn of a KOKKOS_LAMBDA to have public access
 #ifndef KOKKOS_ENABLE_CUDA
 protected:
 #endif
   template<typename ST>
-  bool check_impl() const;
+  CheckResult check_impl() const;
 };
 
 } // namespace scream

--- a/components/scream/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/scream/src/share/property_checks/field_within_interval_check.cpp
@@ -30,7 +30,7 @@ FieldWithinIntervalCheck (const Field& f,
 }
 
 template<typename ST>
-bool FieldWithinIntervalCheck::check_impl () const
+PropertyCheck::CheckResult FieldWithinIntervalCheck::check_impl () const
 {
   using const_ST    = typename std::add_const<ST>::type;
   using nonconst_ST = typename std::remove_const<ST>::type;
@@ -113,10 +113,18 @@ bool FieldWithinIntervalCheck::check_impl () const
           "Internal error in FieldWithinIntervalCheck: unsupported field rank.\n"
           "You should not have reached this line. Please, contact developers.\n");
   }
-  return minmax.min_val>=m_lower_bound && minmax.max_val<=m_upper_bound;
+  PropertyCheck::CheckResult check_result;
+  check_result.pass = minmax.min_val>=m_lower_bound && minmax.max_val<=m_upper_bound;
+  check_result.msg = "";
+  if (not check_result.pass) {
+    check_result.msg = std::string("FieldWithinIntervalCheck failed")
+                     + "; min = " + std::to_string(minmax.min_val)
+                     + "; max = " + std::to_string(minmax.max_val) + "\n";
+  }
+  return check_result;
 }
 
-bool FieldWithinIntervalCheck::check() const {
+PropertyCheck::CheckResult FieldWithinIntervalCheck::check() const {
   const auto& f = fields().front();
   switch (f.data_type()) {
     case DataType::IntType:

--- a/components/scream/src/share/property_checks/field_within_interval_check.hpp
+++ b/components/scream/src/share/property_checks/field_within_interval_check.hpp
@@ -37,7 +37,7 @@ public:
     return ss.str();
   }
 
-  bool check() const override;
+  CheckResult check() const override;
 
 // CUDA requires the parent fcn of a KOKKOS_LAMBDA to have public access
 #ifndef KOKKOS_ENABLE_CUDA
@@ -45,7 +45,7 @@ protected:
 #endif
 
   template<typename ST>
-  bool check_impl () const;
+  CheckResult check_impl () const;
 
   template<typename ST>
   void repair_impl() const;

--- a/components/scream/src/share/property_checks/property_check.cpp
+++ b/components/scream/src/share/property_checks/property_check.cpp
@@ -69,7 +69,8 @@ void PropertyCheck::check_and_repair () const {
   EKAT_REQUIRE_MSG(can_repair(),
       "Error! This property check cannot repair.\n"
       "  - PropertyCheck name: " + name() + "\n");
-  if (not check()) {
+  auto check_result = check();
+  if (not check_result.pass) {
     repair();
   }
 }

--- a/components/scream/src/share/property_checks/property_check.hpp
+++ b/components/scream/src/share/property_checks/property_check.hpp
@@ -42,8 +42,13 @@ public:
   // Name of the property being checked
   virtual std::string name () const = 0;
 
+  struct CheckResult {
+    bool pass;
+    std::string msg;
+  };
+
   // Check if the property is satisfied, and return true if it is
-  virtual bool check () const = 0;
+  virtual CheckResult check () const = 0;
 
   // Set fields, and whether they can be repaired.
   void set_fields (const std::list<Field>& fields,


### PR DESCRIPTION
Add error message output from property checks. The return type for the `PropertyCheck::check()` function is changed to a `struct` containing the fields `pass` and `msg` to report both error status and error message. The pre and post-condition checks in `atmosphere_process` are correspondingly updated to report this information when a check fails. Fixes #1426.

[B4B]