### PR TITLE
Add hooks to GPTL to get EAMxx timings

### DIFF
--- a/components/scream/cmake/tpls/GPTL.cmake
+++ b/components/scream/cmake/tpls/GPTL.cmake
@@ -1,22 +1,19 @@
 macro (CreateGPTLTarget)
-
-  # Some sanity checks
-  if (NOT SCREAM_CIME_BUILD)
-    message (FATAL_ERROR "Error! GPTL.cmake currently only works in a CIME build.")
-  endif ()
-
-  if (NOT DEFINED INSTALL_SHAREDPATH)
-    message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
-  endif ()
-
   # If we didn't already parse this script, proceed
   if (NOT TARGET gptl)
-    # Look for libgptl in INSTALL_SHAREDPATH/lib
-    find_library(GPTL_LIB gptl REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
+    if (SCREAM_CIME_BUILD)
+      # Some sanity checks
+      if (NOT DEFINED INSTALL_SHAREDPATH)
+        message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
+      endif ()
 
-    # Create the imported target that scream targets can link to
-    add_library(gptl UNKNOWN IMPORTED GLOBAL)
-    set_target_properties(gptl PROPERTIES IMPORTED_LOCATION ${GPTL_LIB})
-    set_target_properties(gptl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${INSTALL_SHAREDPATH}/include)
+      # Look for libgptl in INSTALL_SHAREDPATH/lib
+      find_library(GPTL_LIB gptl REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
+
+      # Create the imported target that scream targets can link to
+      add_library(gptl UNKNOWN IMPORTED GLOBAL)
+      set_target_properties(gptl PROPERTIES IMPORTED_LOCATION ${GPTL_LIB})
+      set_target_properties(gptl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${INSTALL_SHAREDPATH}/include)
+    endif ()
   endif ()
 endmacro()

--- a/components/scream/cmake/tpls/Scorpio.cmake
+++ b/components/scream/cmake/tpls/Scorpio.cmake
@@ -3,20 +3,23 @@
 set (E3SM_EXTERNALS_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../../externals CACHE INTERNAL "")
 
 set (SCREAM_TPLS_MODULE_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "")
+include (${SCREAM_TPLS_MODULE_DIR}/GPTL.cmake)
+include (${SCREAM_TPLS_MODULE_DIR}/GetNetcdfLibs.cmake)
 
 macro (CreateScorpioTargets)
 
-  if (SCREAM_CIME_BUILD)
-    # For CIME builds, we simply wrap the already built pioc/piof libs into a cmake target
-    if (NOT DEFINED INSTALL_SHAREDPATH)
-      message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
-    endif ()
+  # If we already parsed this script, then pioc/piof are already targets
+  if (NOT TARGET pioc)
+    # Sanity check
+    if (TARGET piof)
+      message (FATAL_ERROR "Something is off: pioc ws not yet created but piof was.")
+    endif()
 
-    # If we already parsed this script, then pioc/piof are already targets
-    if (NOT TARGET pioc)
-      if (TARGET piof)
-        message (FATAL_ERROR "Something is off: pioc was not yet imported but piof was.")
-      endif()
+    if (SCREAM_CIME_BUILD)
+      # For CIME builds, we simply wrap the already built pioc/piof libs into a cmake target
+      if (NOT DEFINED INSTALL_SHAREDPATH)
+        message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
+      endif ()
 
       set(SCORPIO_LIB_DIR ${INSTALL_SHAREDPATH}/lib)
       set(SCORPIO_INC_DIR ${INSTALL_SHAREDPATH}/include)
@@ -42,9 +45,7 @@ macro (CreateScorpioTargets)
 
       # Look for pioc deps, and attach them to the pioc target, so that cmake will
       # propagate them to any downstream target linking against pioc
-      include (${SCREAM_TPLS_MODULE_DIR}/GPTL.cmake)
       CreateGPTLTarget()
-      include (${SCREAM_TPLS_MODULE_DIR}/GetNetcdfLibs.cmake)
       GetNetcdfLibs()
       target_link_libraries(pioc INTERFACE "gptl;${netcdf_c_lib}")
       if (pnetcdf_lib)
@@ -66,22 +67,22 @@ macro (CreateScorpioTargets)
       # Link pioc and netcdf-fortran, so cmake will propagate them to any downstream
       # target linking against piof
       target_link_libraries(piof INTERFACE "${netcdf_f_lib};pioc")
+    else ()
+      # Not a CIME build. We'll add scorpio as a subdir
+
+      # We don't need (yet) SCORPIO tools
+      option (PIO_ENABLE_TOOLS "Enable SCORPIO tools" OFF)
+
+      # We want to use GPTL internally
+      option (PIO_ENABLE_TIMING    "Enable the use of the GPTL timing library" ON)
+
+      # This is the default, but just in case scorpio changes it
+      option (PIO_ENABLE_FORTRAN "Enable the Fortran library builds" ON)
+
+      add_subdirectory (${E3SM_EXTERNALS_DIR}/scorpio ${CMAKE_BINARY_DIR}/externals/scorpio)
+      EkatDisableAllWarning(pioc)
+      EkatDisableAllWarning(piof)
+      EkatDisableAllWarning(gptl)
     endif ()
-  elseif (NOT TARGET pioc)
-    # Not a CIME build. We'll add scorpio as a subdir
-    if (TARGET piof)
-      message (FATAL_ERROR "Something is off: pioc ws not yet created but piof was.")
-    endif()
-
-    # We don't need (yet) SCORPIO tools
-    option (PIO_ENABLE_TOOLS "Enable SCORPIO tools" OFF)
-
-    # This is the default, but just in case scorpio changes it
-    option (PIO_ENABLE_FORTRAN "Enable the Fortran library builds" ON)
-
-    add_subdirectory (${E3SM_EXTERNALS_DIR}/scorpio ${CMAKE_BINARY_DIR}/externals/scorpio)
-    EkatDisableAllWarning(pioc)
-    EkatDisableAllWarning(piof)
-    EkatDisableAllWarning(gptl)
   endif ()
 endmacro()

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -132,6 +132,8 @@ init_scorpio(const int atm_id)
 void AtmosphereDriver::create_atm_processes()
 {
   m_atm_logger->info("[EAMXX] create_atm_processes  ...");
+  start_timer("EAMxx::init");
+  start_timer("EAMxx::create_atm_processes");
 
   // At this point, must have comm and params set.
   check_ad_status(s_comm_set | s_params_set);
@@ -142,16 +144,19 @@ void AtmosphereDriver::create_atm_processes()
   auto& atm_proc_params = m_atm_params.sublist("Atmosphere Processes");
   atm_proc_params.rename("EAMxx");
   atm_proc_params.set("Logger",m_atm_logger);
-  atm_proc_params.set<std::string>("Timer Prefix","");
   m_atm_process_group = std::make_shared<AtmosphereProcessGroup>(m_atm_comm,atm_proc_params);
 
   m_ad_status |= s_procs_created;
+  stop_timer("EAMxx::create_atm_processes");
+  stop_timer("EAMxx::init");
   m_atm_logger->info("[EAMXX] create_atm_processes  ... done!");
 }
 
 void AtmosphereDriver::create_grids()
 {
   m_atm_logger->info("[EAMXX] create_grids ...");
+  start_timer("EAMxx::init");
+  start_timer("EAMxx::create_grids");
 
   // Must have procs created by now (and comm/params set)
   check_ad_status (s_procs_created | s_comm_set | s_params_set);
@@ -171,12 +176,17 @@ void AtmosphereDriver::create_grids()
 
   m_ad_status |= s_grids_created;
 
+  stop_timer("EAMxx::create_grids");
+  stop_timer("EAMxx::init");
   m_atm_logger->info("[EAMXX] create_grids ... done!");
 }
 
 void AtmosphereDriver::create_fields()
 {
   m_atm_logger->info("[EAMXX] create_fields ...");
+  start_timer("EAMxx::init");
+  start_timer("EAMxx::create_fields");
+
   // Must have grids and procs at this point
   check_ad_status (s_procs_created | s_grids_created);
 
@@ -327,11 +337,15 @@ void AtmosphereDriver::create_fields()
 
   m_ad_status |= s_fields_created;
 
+  stop_timer("EAMxx::create_fields");
+  stop_timer("EAMxx::init");
   m_atm_logger->info("[EAMXX] create_fields ... done!");
 }
 
 void AtmosphereDriver::initialize_output_managers () {
   m_atm_logger->info("[EAMXX] initialize_output_managers ...");
+  start_timer("EAMxx::init");
+  start_timer("EAMxx::initialize_output_managers");
 
   check_ad_status (s_comm_set | s_params_set | s_grids_created | s_fields_created);
 
@@ -363,6 +377,8 @@ void AtmosphereDriver::initialize_output_managers () {
 
   m_ad_status |= s_output_inited;
 
+  stop_timer("EAMxx::initialize_output_managers");
+  stop_timer("EAMxx::init");
   m_atm_logger->info("[EAMXX] initialize_output_managers ... done!");
 }
 
@@ -370,6 +386,8 @@ void AtmosphereDriver::
 initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0)
 {
   m_atm_logger->info("[EAMXX] initialize_fields ...");
+  start_timer("EAMxx::init");
+  start_timer("EAMxx::initialize_fields");
 
   m_atm_logger->info("  [EAMXX] Run  start time stamp: " + run_t0.to_string());
   m_atm_logger->info("  [EAMXX] Case start time stamp: " + case_t0.to_string());
@@ -470,6 +488,8 @@ initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0
     }
   }
 
+  stop_timer("EAMxx::initialize_fields");
+  stop_timer("EAMxx::init");
   m_ad_status |= s_fields_inited;
   m_atm_logger->info("[EAMXX] initialize_fields ... done!");
 }
@@ -841,6 +861,8 @@ initialize_constant_field(const FieldIdentifier& fid,
 void AtmosphereDriver::initialize_atm_procs ()
 {
   m_atm_logger->info("[EAMXX] initialize_atm_procs ...");
+  start_timer("EAMxx::init");
+  start_timer("EAMxx::initialize_atm_procs");
 
   // Initialize memory buffer for all atm processes
   m_memory_buffer = std::make_shared<ATMBufferManager>();
@@ -855,6 +877,8 @@ void AtmosphereDriver::initialize_atm_procs ()
 
   m_ad_status |= s_procs_inited;
 
+  stop_timer("EAMxx::initialize_atm_procs");
+  stop_timer("EAMxx::init");
   m_atm_logger->info("[EAMXX] initialize_atm_procs ... done!");
 }
 
@@ -883,6 +907,8 @@ initialize (const ekat::Comm& atm_comm,
 }
 
 void AtmosphereDriver::run (const int dt) {
+  start_timer("EAMxx::run");
+
   // Make sure the end of the time step is after the current start_time
   EKAT_REQUIRE_MSG (dt>0, "Error! Input time step must be positive.\n");
 
@@ -918,9 +944,12 @@ void AtmosphereDriver::run (const int dt) {
   // it might be several time steps before the file is updated.
   // This way, we give the user a chance to follow the log more real-time.
   m_atm_logger->flush();
+
+  stop_timer("EAMxx::run");
 }
 
 void AtmosphereDriver::finalize ( /* inputs? */ ) {
+  start_timer("EAMxx::finalize");
 
   m_atm_logger->info("[EAMXX] Finalize ...");
 
@@ -960,6 +989,8 @@ void AtmosphereDriver::finalize ( /* inputs? */ ) {
   }
 
   m_atm_logger->info("[EAMXX] Finalize ... done!");
+
+  stop_timer("EAMxx::finalize");
 }
 
 AtmosphereDriver::field_mgr_ptr

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -140,8 +140,9 @@ void AtmosphereDriver::create_atm_processes()
   // tree, storing also the information regarding parallel execution (if needed).
   // See AtmosphereProcessGroup class documentation for more details.
   auto& atm_proc_params = m_atm_params.sublist("Atmosphere Processes");
-  atm_proc_params.rename("ATM_PROC_GROUP");
+  atm_proc_params.rename("EAMxx");
   atm_proc_params.set("Logger",m_atm_logger);
+  atm_proc_params.set<std::string>("Timer Prefix","");
   m_atm_process_group = std::make_shared<AtmosphereProcessGroup>(m_atm_comm,atm_proc_params);
 
   m_ad_status |= s_procs_created;

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -190,6 +190,9 @@ protected:
   // Utility function to check the ad status
   void check_ad_status (const int flag, const bool must_be_set = true);
 
+  // Whether GPTL must be finalized by the AD (in certain standalone runs)
+  bool m_gptl_externally_handled;
+
   // Current ad initialization status
   int m_ad_status = 0;
 };

--- a/components/scream/src/share/CMakeLists.txt
+++ b/components/scream/src/share/CMakeLists.txt
@@ -1,5 +1,23 @@
 include (EkatSetCompilerFlags)
 
+# We need to link against GPTL.
+if (SCREAM_CIME_BUILD)
+  # In CIME builds, GPTL is built by CIME, during the sharedlib phase.
+  # So simply wrap the gptl lib in an imported target
+  include (GPTL)
+  CreateGPTLTarget()
+else ()
+  # In standalone builds, GPTL is built by Scorpio. Unfortunately,
+  # as of today (04/2022), there is no way to pre-build GPTL from
+  # scorpio, without scorpio trying to build it again.
+  # The only way scorpio skips GPTL is if there is an *installation*
+  # of GPTL somewhere, while we want to build it on the fly
+  # So simply process Scorpio now, so that we have GPTL available
+  # for scream_share to link against.
+  include (Scorpio)
+  CreateScorpioTargets()
+endif()
+
 set(SHARE_SRC
   scream_config.cpp
   scream_session.cpp
@@ -26,11 +44,12 @@ set(SHARE_SRC
   property_checks/field_within_interval_check.cpp
   util/scream_test_session.cpp
   util/scream_time_stamp.cpp
+  util/scream_timing.cpp
 )
 
 add_library(scream_share ${SHARE_SRC})
 target_include_directories(scream_share PUBLIC ${SCREAM_SRC_DIR} ${SCREAM_BIN_DIR}/src)
-target_link_libraries(scream_share PUBLIC ekat)
+target_link_libraries(scream_share PUBLIC ekat gptl)
 set_target_properties(scream_share PROPERTIES Fortran_MODULE_DIRECTORY ${SCREAM_F90_MODULES})
 target_compile_options(scream_share PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>)
 # We have some issues with RDC and repeated libraries in the link line.

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -30,18 +30,20 @@ AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
   EKAT_REQUIRE_MSG (m_num_subcycles>0,
       "Error! Invalid number of subcycles in param list " + m_params.name() + ".\n"
       "  - Num subcycles: " + std::to_string(m_num_subcycles) + "\n");
+
+  m_timer_prefix = m_params.get<std::string>("Timer Prefix","EAMxx::");
 }
 
 void AtmosphereProcess::initialize (const TimeStamp& t0, const RunType run_type) {
-  start_timer ("EAMXX::" + this->name() + "::init");
+  start_timer (m_timer_prefix + this->name() + "::init");
   set_fields_and_groups_pointers();
   m_time_stamp = t0;
   initialize_impl(run_type);
-  stop_timer ("EAMXX::" + this->name() + "::init");
+  stop_timer (m_timer_prefix + this->name() + "::init");
 }
 
 void AtmosphereProcess::run (const int dt) {
-  start_timer ("EAMXX::" + this->name() + "::run");
+  start_timer (m_timer_prefix + this->name() + "::run");
   if (m_params.get("Enable Precondition Checks", true)) {
     // Run 'pre-condition' property checks stored in this AP
     run_precondition_checks();
@@ -69,7 +71,7 @@ void AtmosphereProcess::run (const int dt) {
     // Update all output fields time stamps
     update_time_stamps ();
   }
-  stop_timer ("EAMXX::" + this->name() + "::run");
+  stop_timer (m_timer_prefix + this->name() + "::run");
 }
 
 void AtmosphereProcess::finalize (/* what inputs? */) {

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -35,11 +35,15 @@ AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
 }
 
 void AtmosphereProcess::initialize (const TimeStamp& t0, const RunType run_type) {
-  start_timer (m_timer_prefix + this->name() + "::init");
+  if (this->type()!=AtmosphereProcessType::Group) {
+    start_timer (m_timer_prefix + this->name() + "::init");
+  }
   set_fields_and_groups_pointers();
   m_time_stamp = t0;
   initialize_impl(run_type);
-  stop_timer (m_timer_prefix + this->name() + "::init");
+  if (this->type()!=AtmosphereProcessType::Group) {
+    stop_timer (m_timer_prefix + this->name() + "::init");
+  }
 }
 
 void AtmosphereProcess::run (const int dt) {

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -1,4 +1,5 @@
 #include "share/atm_process/atmosphere_process.hpp"
+#include "share/util/scream_timing.hpp"
 
 #include "ekat/ekat_assert.hpp"
 
@@ -32,12 +33,15 @@ AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
 }
 
 void AtmosphereProcess::initialize (const TimeStamp& t0, const RunType run_type) {
+  start_timer ("EAMXX::" + this->name() + "::init");
   set_fields_and_groups_pointers();
   m_time_stamp = t0;
   initialize_impl(run_type);
+  stop_timer ("EAMXX::" + this->name() + "::init");
 }
 
 void AtmosphereProcess::run (const int dt) {
+  start_timer ("EAMXX::" + this->name() + "::run");
   if (m_params.get("Enable Precondition Checks", true)) {
     // Run 'pre-condition' property checks stored in this AP
     run_precondition_checks();
@@ -65,6 +69,7 @@ void AtmosphereProcess::run (const int dt) {
     // Update all output fields time stamps
     update_time_stamps ();
   }
+  stop_timer ("EAMXX::" + this->name() + "::run");
 }
 
 void AtmosphereProcess::finalize (/* what inputs? */) {

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -396,6 +396,9 @@ protected:
   // Parameter list
   ekat::ParameterList m_params;
 
+  // A prefix to add to this atm proc timer
+  std::string m_timer_prefix;
+
   // The logger for the whole atmosphere
   // WARNING: this is non-const, but you should *NOT* modify its
   //          log level and/or its sinks. If you just need to log

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -31,9 +31,7 @@ AtmosphereProcessGroup (const ekat::Comm& comm, const ekat::ParameterList& param
   }
 
   // Create the individual atmosphere processes
-  m_group_name = "Group [";
-  m_group_name += m_group_schedule_type==ScheduleType::Sequential
-                ? "Sequential]:" : "Parallel]:";
+  m_group_name = params.name();
 
   auto& apf = AtmosphereProcessFactory::instance();
   apf.register_product("group",&create_atmosphere_process<AtmosphereProcessGroup>);
@@ -83,9 +81,6 @@ AtmosphereProcessGroup (const ekat::Comm& comm, const ekat::ParameterList& param
     for (const auto& name : m_atm_processes.back()->get_required_grids()) {
       m_required_grids.insert(name);
     }
-
-    m_group_name += " ";
-    m_group_name += m_atm_processes.back()->name();
   }
 }
 

--- a/components/scream/src/share/util/scream_timing.cpp
+++ b/components/scream/src/share/util/scream_timing.cpp
@@ -1,0 +1,27 @@
+#include "share/util/scream_timing.hpp"
+
+#include <gptl.h>
+
+namespace scream {
+
+void init_gptl (bool& was_already_inited) {
+  auto ierr = GPTLinitialize();
+  was_already_inited = (ierr!=0);
+}
+void finalize_gptl () {
+  GPTLfinalize();
+}
+
+void start_timer (const std::string& name) {
+  GPTLstart(name.c_str());
+}
+
+void stop_timer (const std::string& name) {
+  GPTLstop(name.c_str());
+}
+
+void write_timers_to_file (const ekat::Comm& comm, const std::string& fname) {
+  GPTLpr_summary_file (comm.mpi_comm(),fname.c_str());
+}
+
+} // namespace scream

--- a/components/scream/src/share/util/scream_timing.hpp
+++ b/components/scream/src/share/util/scream_timing.hpp
@@ -1,0 +1,22 @@
+#ifndef SCREAM_TIMING_HPP
+#define SCREAM_TIMING_HPP
+
+#include <ekat/mpi/ekat_comm.hpp>
+
+#include <string>
+
+namespace scream {
+
+// The following simply wrap GPTL calls. We encourage using
+// these (rather than raw GPTL calls), to make SCREAM insensitive
+// to any future refactor that might change how we do timing.
+void init_gptl (bool& was_already_inited);
+void finalize_gptl ();
+void start_timer (const std::string& name);
+void stop_timer (const std::string& name);
+
+void write_timers_to_file (const ekat::Comm& comm, const std::string& fname);
+
+} // namespace scream
+
+#endif // SCREAM_TIMING_HPP


### PR DESCRIPTION
Simple PR, to add wrappers to GPTL calls, and have scream generate a timing file. I have tested it in standalone mode, but I need to check that the logic is correct in CIME coupled runs (I suspect/know that I have to do a micro-change).

The timing already added produce the following "extra" timers (on top of what Homme and PIO already have):
```
EAMxx::init                                    -          4        4 2.400000e+01   2.121428e+01     5.777 (     0      0)     5.014 (     1      0)
EAMxx::create_atm_processes                    -          4        4 4.000000e+00   8.440000e-04     0.000 (     0      0)     0.000 (     3      0)
EAMxx::create_grids                            -          4        4 4.000000e+00   9.650480e-01     0.241 (     2      0)     0.241 (     0      0)
EAMxx::create_fields                           -          4        4 4.000000e+00   4.532200e-02     0.012 (     0      0)     0.011 (     2      0)
EAMxx::initialize_fields                       -          4        4 4.000000e+00   5.394096e+00     1.349 (     2      0)     1.347 (     0      0)
EAMxx::initialize_output_managers              -          4        4 4.000000e+00   1.560600e-02     0.004 (     0      0)     0.004 (     1      0)
EAMxx::initialize_atm_procs                    -          4        4 4.000000e+00   1.479325e+01     4.172 (     0      0)     3.409 (     1      0)
EAMxx::Dynamics::init                          -          4        4 4.000000e+00   8.691970e-01     0.218 (     1      0)     0.217 (     2      0)
EAMxx::Macrophysics::init                      -          4        4 4.000000e+00   1.092000e-03     0.000 (     0      0)     0.000 (     3      0)
EAMxx::CldFraction::init                       -          4        4 4.000000e+00   9.100000e-05     0.000 (     0      0)     0.000 (     2      0)
EAMxx::Simple Prescribed Aerosols (SPA)::init  -          4        4 4.000000e+00   1.278254e+01     3.667 (     0      0)     2.946 (     1      0)
EAMxx::Microphysics::init                      -          4        4 4.000000e+00   7.670880e-01     0.206 (     3      0)     0.167 (     1      0)
EAMxx::Radiation::init                         -          4        4 4.000000e+00   3.633020e-01     0.104 (     3      0)     0.076 (     1      0)
EAMxx::run                                     -          4        4 1.600000e+01   1.554241e+02    39.143 (     1      0)    38.390 (     0      0)
EAMxx::Dynamics::run                           -          4        4 8.000000e+00   1.015257e+02    27.714 (     1      0)    21.694 (     0      0)
EAMxx::Macrophysics::run                       -          4        4 8.000000e+00   8.943130e-01     0.297 (     0      0)     0.195 (     2      0)
EAMxx::CldFraction::run                        -          4        4 8.000000e+00   1.259200e-02     0.004 (     0      0)     0.003 (     2      0)
EAMxx::Simple Prescribed Aerosols (SPA)::run   -          4        4 8.000000e+00   1.293605e+00     0.389 (     0      0)     0.251 (     2      0)
EAMxx::Microphysics::run                       -          4        4 8.000000e+00   1.631595e+01     4.328 (     3      0)     3.808 (     0      0)
EAMxx::Radiation::run                          -          4        4 8.000000e+00   2.801017e+01    11.834 (     0      0)     4.083 (     1      0)
```