### PR TITLE
Add extra RRTMGP bounds checks and debug info

### DIFF
--- a/components/scream/src/physics/rrtmgp/rrtmgp_utils.hpp
+++ b/components/scream/src/physics/rrtmgp/rrtmgp_utils.hpp
@@ -5,6 +5,9 @@
 #include "cpp/rrtmgp_const.h"
 #include "YAKL.h"
 
+using yakl::intrinsics::maxval;
+using yakl::intrinsics::minval;
+
 namespace scream {
     namespace rrtmgp {
         // Provide a routine to compute heating due to radiative fluxes. This is
@@ -32,7 +35,7 @@ namespace scream {
             });
         }
 
-        bool radiation_do(const int irad, const int nstep) {
+        inline bool radiation_do(const int irad, const int nstep) {
             // If irad == 0, then never do radiation;
             // Otherwise, we always call radiation at the first step,
             // and afterwards we do radiation if the timestep is divisible
@@ -43,6 +46,26 @@ namespace scream {
                 return ( (nstep == 0) || (nstep % irad == 0) );
             }
         }
+
+
+        // Verify that array only contains values within valid range, and if not
+        // report min and max of array
+        template <class T> bool check_range(T x, Real xmin, Real xmax, std::string msg) {
+            bool pass = true;
+            auto _xmin = minval(x);
+            auto _xmax = maxval(x);
+            if (_xmin < xmin or _xmax > xmax) {
+                pass = false;
+                std::cout 
+                    << std::string(msg) 
+                    << ": one or more values outside range"
+                    << "; minval = " << _xmin 
+                    << "; maxval = " << _xmax << "\n";
+            }
+            return pass;
+        }
+
     }
+
 }
 #endif

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -1,4 +1,5 @@
 #include "scream_rrtmgp_interface.hpp"
+#include "rrtmgp_utils.hpp"
 
 #include "mo_load_coefficients.h"
 #include "mo_load_cloud_coefficients.h"
@@ -245,6 +246,18 @@ namespace scream {
             // Convert cloud physical properties to optical properties for input to RRTMGP
             OpticalProps2str clouds_sw = get_cloud_optics_sw(ncol, nlay, cloud_optics_sw, k_dist_sw, lwp, iwp, rel, rei);
             OpticalProps1scl clouds_lw = get_cloud_optics_lw(ncol, nlay, cloud_optics_lw, k_dist_lw, lwp, iwp, rel, rei);        
+
+            // Perform checks on optics; these would be caught by RRTMGP_EXPENSIVE_CHECKS in the RRTMGP code,
+            // but we might want to provide additional debug info here. NOTE: we may actually want to move this
+            // up higher in the code, I think optical props should go up higher since optical props are kind of
+            // a parameterization of their own, and we might want to swap different choices. These checks go here
+            // only because we need to run them on computed optical props, so if the optical props themselves get
+            // computed up higher, then perform these checks higher as well
+            //check_range(clouds_sw.tau,  0, std::numeric_limits<Real>::max(), "cloud_optics_sw.tau");
+            check_range(clouds_sw.tau,  0,                              1e3, "cloud_optics_sw.tau");
+            check_range(clouds_sw.ssa,  0,                                1, "cloud_optics_sw.ssa"); //, "cloud_optics_sw.ssa");
+            check_range(clouds_sw.g  , -1,                                1, "cloud_optics_sw.g  "); //, "cloud_optics_sw.g"  );
+            check_range(clouds_lw.tau,  0,                              1e3, "cloud_optics_lw.tau");
 
             // Do shortwave
             rrtmgp_sw(

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
@@ -425,3 +425,19 @@ TEST_CASE("rrtmgp_test_radiation_do") {
     REQUIRE(scream::rrtmgp::radiation_do(3, 5) == false);
     REQUIRE(scream::rrtmgp::radiation_do(3, 6) == true);
 }
+
+TEST_CASE("rrtmgp_test_check_range") {
+    // Initialize YAKL
+    if (!yakl::isInitialized()) { yakl::init(); }
+    // Create some dummy data and test with both values inside valid range and outside
+    auto dummy = real2d("dummy", 2, 1);
+    // All values within range
+    memset(dummy, 0.1);
+    REQUIRE(scream::rrtmgp::check_range(dummy, 0.0, 1.0, "dummy") == true);
+    // At least one value below lower bound
+    parallel_for(1, YAKL_LAMBDA (int i) {dummy(i, 1) = -0.1;});
+    REQUIRE(scream::rrtmgp::check_range(dummy, 0.0, 1.0, "dummy") == false);
+    // At least one value above upper bound
+    parallel_for(1, YAKL_LAMBDA (int i) {dummy(i, 1) = 1.1;});
+    REQUIRE(scream::rrtmgp::check_range(dummy, 0.0, 1.0, "dummy") == false);
+}


### PR DESCRIPTION
Add extra RRTMGP bounds checks and debug info, so that min/max values are reported when cloud or aerosol optics go outside expected ranges.

[B4B]