### PR TITLE
Add memory usage information to atm log

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -295,6 +295,10 @@ endif()
 set(SCREAM_TEST_PROFILE MEDIUM CACHE STRING "The kind of testing to perform: SHORT, MEDIUM, LONG")
 set(SCREAM_TEST_VALID_PROFILES "SHORT;MEDIUM;LONG" CACHE INTERNAL "List of valid values for SCREAM_TEST_PROFILE")
 
+# Whether to use XYZ as a method to detect memory usage.
+option (SCREAM_ENABLE_GETRUSAGE "Whether getrusage can be used to get memory usage." ON)
+option (SCREAM_ENABLE_STATM "Whether /proc/self/statm can be used to get memory usage." ON)
+
 # Whether to disable warnings from tpls.
 set (SCREAM_DISABLE_TPL_WARNINGS ON CACHE BOOL "")
 

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -296,8 +296,8 @@ set(SCREAM_TEST_PROFILE MEDIUM CACHE STRING "The kind of testing to perform: SHO
 set(SCREAM_TEST_VALID_PROFILES "SHORT;MEDIUM;LONG" CACHE INTERNAL "List of valid values for SCREAM_TEST_PROFILE")
 
 # Whether to use XYZ as a method to detect memory usage.
-option (SCREAM_ENABLE_GETRUSAGE "Whether getrusage can be used to get memory usage." ON)
-option (SCREAM_ENABLE_STATM "Whether /proc/self/statm can be used to get memory usage." ON)
+option (SCREAM_ENABLE_GETRUSAGE "Whether getrusage can be used to get memory usage." OFF)
+option (SCREAM_ENABLE_STATM "Whether /proc/self/statm can be used to get memory usage." OFF)
 
 # Whether to disable warnings from tpls.
 set (SCREAM_DISABLE_TPL_WARNINGS ON CACHE BOOL "")

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -8,6 +8,7 @@
 #include "share/field/field_utils.hpp"
 #include "share/util/scream_time_stamp.hpp"
 #include "share/util/scream_timing.hpp"
+#include "share/util/scream_utils.hpp"
 
 #include "ekat/ekat_assert.hpp"
 #include "ekat/util/ekat_string_utils.hpp"
@@ -880,6 +881,11 @@ void AtmosphereDriver::initialize_atm_procs ()
   stop_timer("EAMxx::initialize_atm_procs");
   stop_timer("EAMxx::init");
   m_atm_logger->info("[EAMXX] initialize_atm_procs ... done!");
+
+  long long my_mem_usage = get_mem_usage(MB);
+  long long max_mem_usage;
+  m_atm_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
+  m_atm_logger->info("[EAMxx::init] memory usage: " + std::to_string(max_mem_usage) + "MB");
 }
 
 void AtmosphereDriver::
@@ -938,6 +944,11 @@ void AtmosphereDriver::run (const int dt) {
     // Export fluxes from the component coupler (if any)
     m_surface_coupling->do_export();
   }
+
+  long long my_mem_usage = get_mem_usage(MB);
+  long long max_mem_usage;
+  m_atm_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
+  m_atm_logger->info("[EAMxx::run] memory usage: " + std::to_string(max_mem_usage) + "MB");
 
   // Flush the logger at least once per time step.
   // Without this flush, depending on how much output we are loggin,

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -882,10 +882,12 @@ void AtmosphereDriver::initialize_atm_procs ()
   stop_timer("EAMxx::init");
   m_atm_logger->info("[EAMXX] initialize_atm_procs ... done!");
 
+#ifdef SCREAM_HAS_MEMORY_USAGE
   long long my_mem_usage = get_mem_usage(MB);
   long long max_mem_usage;
   m_atm_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
   m_atm_logger->info("[EAMxx::init] memory usage: " + std::to_string(max_mem_usage) + "MB");
+#endif
 }
 
 void AtmosphereDriver::
@@ -945,10 +947,12 @@ void AtmosphereDriver::run (const int dt) {
     m_surface_coupling->do_export();
   }
 
+#ifdef SCREAM_HAS_MEMORY_USAGE
   long long my_mem_usage = get_mem_usage(MB);
   long long max_mem_usage;
   m_atm_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
   m_atm_logger->info("[EAMxx::run] memory usage: " + std::to_string(max_mem_usage) + "MB");
+#endif
 
   // Flush the logger at least once per time step.
   // Without this flush, depending on how much output we are loggin,

--- a/components/scream/src/scream_config.h.in
+++ b/components/scream/src/scream_config.h.in
@@ -39,6 +39,11 @@
 // Whether /proc/self/statm can be used to get memory usage
 #cmakedefine SCREAM_ENABLE_STATM
 
+#if defined(SCREAM_ENABLE_STATM) || defined(SCREAM_ENABLE_GETRUSAGE)
+#define SCREAM_HAS_MEMORY_USAGE
+#endif
+
+
 // Data directory for the scream project
 #define SCREAM_DATA_DIR "${SCREAM_DATA_DIR}"
 

--- a/components/scream/src/scream_config.h.in
+++ b/components/scream/src/scream_config.h.in
@@ -34,6 +34,11 @@
 // Whether experimental code should be enabled
 #cmakedefine SCREAM_ENABLE_EXPERIMENTAL
 
+// Whether getrusage can be used to get memory usage
+#cmakedefine SCREAM_ENABLE_GETRUSAGE
+// Whether /proc/self/statm can be used to get memory usage
+#cmakedefine SCREAM_ENABLE_STATM
+
 // Data directory for the scream project
 #define SCREAM_DATA_DIR "${SCREAM_DATA_DIR}"
 

--- a/components/scream/src/share/CMakeLists.txt
+++ b/components/scream/src/share/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SHARE_SRC
   util/scream_test_session.cpp
   util/scream_time_stamp.cpp
   util/scream_timing.cpp
+  util/scream_utils.cpp
 )
 
 add_library(scream_share ${SHARE_SRC})

--- a/components/scream/src/share/util/scream_utils.cpp
+++ b/components/scream/src/share/util/scream_utils.cpp
@@ -1,0 +1,28 @@
+#include "share/util/scream_utils.hpp"
+
+#include <sys/resource.h>
+
+namespace scream {
+
+long long get_mem_usage (const MemoryUnits u) {
+  struct rusage r_usage;
+  getrusage(RUSAGE_SELF,&r_usage);
+
+  long long mem = r_usage.ru_maxrss;
+
+  switch (u) {
+    case B  : mem *= 1000;              break;
+    case KB :                           break;
+    case MB : mem /= 1000;              break;
+    case GB : mem /= 1000*1000;         break;
+    case GiB: mem /= 1024;              // Fallthrough
+    case MiB: mem /= 1024;              // Fallthrough
+    case KiB: mem *= 1000; mem /= 1024; break;
+    default:
+      EKAT_ERROR_MSG ("Invalid choice for memory units: " + std::to_string(u) + "\n");
+  }
+
+  return mem;
+}
+
+} // namespace scream

--- a/components/scream/src/share/util/scream_utils.hpp
+++ b/components/scream/src/share/util/scream_utils.hpp
@@ -24,6 +24,7 @@ enum MemoryUnits {
   GiB
 };
 
+// Gets current memory (RAM) usage by current process.
 long long get_mem_usage (const MemoryUnits u);
 
 // Micro-utility, that given an enum returns the underlying int.

--- a/components/scream/src/share/util/scream_utils.hpp
+++ b/components/scream/src/share/util/scream_utils.hpp
@@ -14,6 +14,18 @@
 
 namespace scream {
 
+enum MemoryUnits {
+  B = 1,
+  KB,
+  MB,
+  GB,
+  KiB,
+  MiB,
+  GiB
+};
+
+long long get_mem_usage (const MemoryUnits u);
+
 // Micro-utility, that given an enum returns the underlying int.
 // The only use of this is if you need to sort scoped enums.
 template<typename EnumT>


### PR DESCRIPTION
With some suggestion from @ndkeen I put together a super small, very minimal, memory usage utility function, and use it in the driver, to report mem usage at the end of each time step. It can use either the `getrusage` function or check `/proc/self/statm` for the information. The two methods seem to produce _very_ different answers (like 180MB vs 900MB), but they can both be used to determine if the memory usage is increasing.

NOTE: CIME already has this feature, but this PR allows us to get this info also for standalone runs, which might be easier to debug.