### PR TITLE
Adds the XML defaults to run an ne30 case for CIME

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -163,8 +163,8 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="physics_proc_base">
       <SPA__Remap__File>none</SPA__Remap__File>
-      <SPA__Data__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_20220428.nc</SPA__Data__File>
-      <SPA__Data__File hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
+      <SPA__Data__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc</SPA__Data__File>
+      <SPA__Data__File hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_scream.nc</SPA__Data__File>
     </spa>
 
     <!-- Radiation -->
@@ -237,23 +237,21 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/revap_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
-    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_20220428.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc
+    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc,
+    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_scream.nc
   </input_files>
 
   <!-- Homme control namelist -->
   <ctl_nl>
-    <cubed_sphere_map>2</cubed_sphere_map>
+    <cubed_sphere_map>0</cubed_sphere_map>
     <disable_diagnostics>False</disable_diagnostics>
     <dt_remap_factor>2</dt_remap_factor>
-    <dt_tracer_factor hgrid="ne4np4">6</dt_tracer_factor>
-    <dt_tracer_factor hgrid="ne30np4">6</dt_tracer_factor>
+    <dt_tracer_factor>1</dt_tracer_factor>
     <hypervis_order>2</hypervis_order>
     <hypervis_scaling>3.0</hypervis_scaling>
     <hypervis_subcycle>1</hypervis_subcycle>
     <hypervis_subcycle_tom>1</hypervis_subcycle_tom>
-    <hypervis_subcycle_q hgrid="ne4np4">6</hypervis_subcycle_q>
-    <hypervis_subcycle_q hgrid="ne30np4">6</hypervis_subcycle_q>
+    <hypervis_subcycle_q>1</hypervis_subcycle_q>
     <nu>3.4e-08</nu>
     <nu_top>250000.0</nu_top>
     <se_ftype valid_values="0,2">0</se_ftype>
@@ -271,7 +269,7 @@ tweaking their $case/namelist_scream.xml file.
     <theta_hydrostatic_mode>True</theta_hydrostatic_mode>
     <tstep_type>5</tstep_type>
     <vert_remap_q_alg>10</vert_remap_q_alg>
-    <transport_alg>12</transport_alg>
+    <transport_alg>0</transport_alg>
   </ctl_nl>
 
 </namelist_defaults>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -163,8 +163,8 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="physics_proc_base">
       <SPA__Remap__File>none</SPA__Remap__File>
-      <SPA__Data__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc</SPA__Data__File>
-      <SPA__Data__File hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_scream.nc</SPA__Data__File>
+      <SPA__Data__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_20220428.nc</SPA__Data__File>
+      <SPA__Data__File hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
     </spa>
 
     <!-- Radiation -->
@@ -237,20 +237,23 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/revap_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
-    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_scream.nc
+    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_20220428.nc,
+    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc
   </input_files>
 
   <!-- Homme control namelist -->
   <ctl_nl>
-    <cubed_sphere_map>0</cubed_sphere_map>
+    <cubed_sphere_map>2</cubed_sphere_map>
     <disable_diagnostics>False</disable_diagnostics>
     <dt_remap_factor>2</dt_remap_factor>
-    <dt_tracer_factor>1</dt_tracer_factor>
+    <dt_tracer_factor hgrid="ne4np4">6</dt_tracer_factor>
+    <dt_tracer_factor hgrid="ne30np4">6</dt_tracer_factor>
     <hypervis_order>2</hypervis_order>
     <hypervis_scaling>3.0</hypervis_scaling>
     <hypervis_subcycle>1</hypervis_subcycle>
     <hypervis_subcycle_tom>1</hypervis_subcycle_tom>
+    <hypervis_subcycle_q hgrid="ne4np4">6</hypervis_subcycle_q>
+    <hypervis_subcycle_q hgrid="ne30np4">6</hypervis_subcycle_q>
     <nu>3.4e-08</nu>
     <nu_top>250000.0</nu_top>
     <se_ftype valid_values="0,2">0</se_ftype>
@@ -261,12 +264,14 @@ tweaking their $case/namelist_scream.xml file.
     <se_nsplit>-1</se_nsplit>
     <se_partmethod>4</se_partmethod>
     <se_topology>cube</se_topology>
-    <se_tstep>300</se_tstep>
+    <se_tstep hgrid="ne4np4">600</se_tstep>
+    <se_tstep hgrid="ne30np4">300</se_tstep>
     <statefreq>9999</statefreq>
     <theta_advect_form>1</theta_advect_form>
     <theta_hydrostatic_mode>True</theta_hydrostatic_mode>
     <tstep_type>5</tstep_type>
     <vert_remap_q_alg>10</vert_remap_q_alg>
+    <transport_alg>12</transport_alg>
   </ctl_nl>
 
 </namelist_defaults>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -145,8 +145,9 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Homme dynamics -->
     <homme inherit="atm_proc_base">
       <Grid>Dynamics</Grid>
-      <Vertical__Coordinate__Filename>${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc</Vertical__Coordinate__Filename>
-      <Vertical__Coordinate__Filename COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc</Vertical__Coordinate__Filename>
+      <Vertical__Coordinate__Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc</Vertical__Coordinate__Filename>
+      <Vertical__Coordinate__Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc</Vertical__Coordinate__Filename>
+      <Vertical__Coordinate__Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc</Vertical__Coordinate__Filename>
       <Moisture>moist</Moisture>
     </homme>
 
@@ -162,7 +163,8 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="physics_proc_base">
       <SPA__Remap__File>none</SPA__Remap__File>
-      <SPA__Data__File>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc</SPA__Data__File>
+      <SPA__Data__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc</SPA__Data__File>
+      <SPA__Data__File hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_scream.nc</SPA__Data__File>
     </spa>
 
     <!-- Radiation -->
@@ -179,6 +181,7 @@ tweaking their $case/namelist_scream.xml file.
 
     <mac_aero_mic inherit="atm_proc_group">
       <atm_procs_list>(shoc,cldFraction,spa,p3)</atm_procs_list>
+      <Num__Subcycle__Iterations>6</Num__Subcycle__Iterations>
     </mac_aero_mic>
 
     <physics inherit="atm_proc_group">
@@ -195,7 +198,8 @@ tweaking their $case/namelist_scream.xml file.
 
   <!-- List of nc files for loading inputs on specified grids -->
   <Initial__Conditions>
-    <Filename>${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc</Filename>
+    <Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc</Filename>
+    <Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220329.nc</Filename>
     <Filename COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc</Filename>
     <Restart__Casename>${CASE}</Restart__Casename>
   </Initial__Conditions>
@@ -233,14 +237,15 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/revap_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
-    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc
+    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc,
+    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_scream.nc
   </input_files>
 
   <!-- Homme control namelist -->
   <ctl_nl>
     <cubed_sphere_map>0</cubed_sphere_map>
     <disable_diagnostics>False</disable_diagnostics>
-    <dt_remap_factor>1</dt_remap_factor>
+    <dt_remap_factor>2</dt_remap_factor>
     <dt_tracer_factor>1</dt_tracer_factor>
     <hypervis_order>2</hypervis_order>
     <hypervis_scaling>3.0</hypervis_scaling>
@@ -251,7 +256,8 @@ tweaking their $case/namelist_scream.xml file.
     <se_ftype valid_values="0,2">0</se_ftype>
     <se_geometry>sphere</se_geometry>
     <se_limiter_option>9</se_limiter_option>
-    <se_ne>4</se_ne>
+    <se_ne hgrid="ne4np4">4</se_ne>
+    <se_ne hgrid="ne30np4">30</se_ne>
     <se_nsplit>-1</se_nsplit>
     <se_partmethod>4</se_partmethod>
     <se_topology>cube</se_topology>

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -208,6 +208,8 @@ void SPA::run_impl (const int /* dt */)
 {
   /* Gather time and state information for interpolation */
   auto ts = timestamp();
+  /* Update the SPATimeState to reflect the current time, note the addition of dt */
+  SPATimeState.t_now = ts.frac_of_year_in_days() + dt/86400.;
   /* Update time state and if the month has changed, update the data.*/
   SPAFunc::update_spa_timestate(m_spa_data_file,m_nswbands,m_nlwbands,ts,SPAHorizInterp,SPATimeState,SPAData_start,SPAData_end);
 

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -204,7 +204,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
 }
 
 // =========================================================================================
-void SPA::run_impl (const int /* dt */)
+void SPA::run_impl (const int dt)
 {
   /* Gather time and state information for interpolation */
   auto ts = timestamp();

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -685,8 +685,6 @@ void SPAFunctions<S,D>
         SPAInput&        spa_end)
 {
 
-  // We always want to update the current time in the time_state.
-  time_state.t_now = ts.frac_of_year_in_days();
   // Now we check if we have to update the data that changes monthly
   // NOTE:  This means that SPA assumes monthly data to update.  Not
   //        any other frequency.

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -30,7 +30,7 @@ atmosphere_processes:
   spa:
     Grid: Physics GLL
     SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_scream.nc
+    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
   p3:
     Grid: Physics GLL
   rrtmgp:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -21,7 +21,7 @@ atmosphere_processes:
   spa:
     Grid: Point Grid
     SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_scream.nc
+    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
   rrtmgp:
     Grid: Point Grid
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -14,7 +14,7 @@ atmosphere_processes:
   spa:
     Grid: Point Grid
     SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_scream.nc
+    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
 
 Grids Manager:
   Type: Mesh Free

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -408,8 +408,6 @@
       <!-- a shorter timestep is needed for stability in MMF  -->
       <!-- Use for all "low res" grids (i.e. ne4, ne30, ne45) -->
       <value compset="_EAM%MMF">72</value>
-      <!-- Shorter timestep needed for SCREAMv1 because we are not substepping SHOC and P3 yet -->
-      <value compset="_SCREAM.*">288</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
This commit will make it possible to build an ne30 testcase for
SCREAMv1 and run out-of-the-box.

It does this by adding the `hgrid` conditional to some of the XML
entries.