### PR TITLE
restore pbl_height postcondition check

### DIFF
--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -357,7 +357,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("qv"),1e-13,0.2,true);  // This is a quick fix to make sure qv doesn't go negative.  TODO item is to take care of this in a more clever way.
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("qc"),0.0,0.1,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("horiz_winds"),-400.0,400.0,false);
-//  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("pbl_height"),0.0,3000.0,false); //TODO: Uncomment this check when we figure out what is wrong with PBL
+  add_postcondition_check<FieldPositivityCheck>(get_field_out("pbl_height"));
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("cldfrac_liq"),0.0,1.0,false);
   add_postcondition_check<FieldPositivityCheck>(get_field_out("tke"));
 


### PR DESCRIPTION
Decided to only check that pbl_height >0 because first few steps can have arbitrarily large pbl_height as the model adjusts and we don't want people to get surprised with pbl_height failures that they might not understand. 