### PR TITLE
Adjust default SPA data files to reflect the new set of data files.

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -162,7 +162,7 @@ tweaking their $case/namelist_scream.xml file.
 
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="physics_proc_base">
-      <SPA__Remap__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4.nc</SPA__Remap__File>
+      <SPA__Remap__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc</SPA__Remap__File>
       <SPA__Remap__File hgrid="ne30np4">none</SPA__Remap__File>
       <SPA__Data__File>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
     </spa>
@@ -238,6 +238,7 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc
+    ${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc
   </input_files>
 
   <!-- Homme control namelist -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -163,8 +163,8 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="physics_proc_base">
       <SPA__Remap__File>none</SPA__Remap__File>
-      <SPA__Data__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc</SPA__Data__File>
-      <SPA__Data__File hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_scream.nc</SPA__Data__File>
+      <SPA__Data__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_20220428.nc</SPA__Data__File>
+      <SPA__Data__File hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
     </spa>
 
     <!-- Radiation -->
@@ -237,8 +237,8 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/revap_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
-    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_scream.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_scream.nc
+    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_20220428.nc,
+    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc
   </input_files>
 
   <!-- Homme control namelist -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -237,7 +237,7 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/revap_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
-    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc
+    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc,
     ${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc
   </input_files>
 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -162,9 +162,9 @@ tweaking their $case/namelist_scream.xml file.
 
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="physics_proc_base">
-      <SPA__Remap__File>none</SPA__Remap__File>
-      <SPA__Data__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_20220428.nc</SPA__Data__File>
-      <SPA__Data__File hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
+      <SPA__Remap__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4.nc</SPA__Remap__File>
+      <SPA__Remap__File hgrid="ne30np4">none</SPA__Remap__File>
+      <SPA__Data__File>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
     </spa>
 
     <!-- Radiation -->
@@ -237,7 +237,6 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/revap_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
-    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_20220428.nc,
     ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc
   </input_files>
 

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -175,7 +175,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
 {
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),140.0,500.0,false);
-  add_invariant_check<FieldWithinIntervalCheck>(get_field_out("qv"),1e-13,0.2,false);
+  add_invariant_check<FieldWithinIntervalCheck>(get_field_out("qv"),1e-13,0.2,true);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("qc"),0.0,0.1,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("qi"),0.0,0.1,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("qr"),0.0,0.1,false);

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -1,5 +1,4 @@
 #include "physics/p3/atmosphere_microphysics.hpp"
-// #include "share/property_checks/field_positivity_check.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
 // Needed for p3_init, the only F90 code still used.
 #include "physics/p3/p3_functions.hpp"
@@ -181,7 +180,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("qi"),0.0,0.1,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("qr"),0.0,0.1,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("qm"),0.0,0.1,false);
-  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nc"),0.0,1.e9,false);
+  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nc"),0.0,1.e11,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nr"),0.0,1.e9,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("ni"),0.0,1.e9,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("bm"),0.0,1.0,false);

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -193,7 +193,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
   m_buffer.spa_temp.hybm = SPAData_start.hybm;
 
   // Set property checks for fields in this process
-  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nc_activated"),0.0,1.0e6,false);
+  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nc_activated"),0.0,1.0e11,false);
   // upper bound set to 1.01 as max(g_sw)=1.00757 in current ne4 data assumingly due to remapping
   // add an epslon to max possible upper bound of aero_ssa_sw
 

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -59,7 +59,7 @@ configure_file(${SCREAM_SRC_DIR}/dynamics/homme/tests/theta.nl
 set (TEST_INPUT_FILES
   init/spa_init_ne2np4.nc
   init/map_ne4np4_to_ne2np4_mono.nc
-  init/spa_file_unified_and_complete_ne4_scream.nc
+  init/spa_file_unified_and_complete_ne4_20220428.nc
   init/homme_shoc_cld_spa_p3_rrtmgp_init_ne2np4.nc
 )
 foreach (file IN ITEMS ${TEST_INPUT_FILES})

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -30,7 +30,7 @@ atmosphere_processes:
   spa:
     Grid: Physics GLL
     SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_scream.nc
+    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
   p3:
     Grid: Physics GLL
   rrtmgp:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -17,7 +17,7 @@ set (TEST_INPUT_FILES
   init/shoc_cld_spa_p3_rrtmgp_init_ne2np4.nc
   init/spa_init_ne2np4.nc
   init/map_ne4np4_to_ne2np4_mono.nc
-  init/spa_file_unified_and_complete_ne4_scream.nc
+  init/spa_file_unified_and_complete_ne4_20220428.nc
 )
 foreach (file IN ITEMS ${TEST_INPUT_FILES})
   GetInputFile(${file})

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -21,7 +21,7 @@ atmosphere_processes:
   spa:
     Grid: Point Grid
     SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_scream.nc
+    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
   rrtmgp:
     Grid: Point Grid
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/scream/tests/uncoupled/spa/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/spa/CMakeLists.txt
@@ -24,7 +24,7 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/spa_standalone_output.yaml
 set (TEST_INPUT_FILES
   spa_init_ne2np4.nc
   map_ne4np4_to_ne2np4_mono.nc
-  spa_file_unified_and_complete_ne4_scream.nc
+  spa_file_unified_and_complete_ne4_20220428.nc
 )
 foreach (file IN ITEMS ${TEST_INPUT_FILES})
   GetInputFile(init/${file})

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -14,7 +14,7 @@ atmosphere_processes:
   spa:
     Grid: Point Grid
     SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_scream.nc
+    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
 
 Grids Manager:
   Type: Mesh Free

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -379,7 +379,9 @@
       <value compset=".+" grid="a%0.23x0.31">96</value>
       <value compset=".+" grid="a%ne4np4">12</value>
       <value compset=".+" grid="a%ne4np4.pg2">24</value>
+      <value compset="_SCREAM.*" grid="a%ne4np4">24</value>
       <value compset=".+" grid="a%ne11np4">12</value>
+      <value compset="_SCREAM.*" grid="a%ne11np4">24</value>
       <value compset=".+" grid="a%ne45np4">72</value>
       <value compset=".+" grid="a%ne60np4">96</value>
       <value compset=".+" grid="a%ne120np4">96</value>


### PR DESCRIPTION
The old SPA data files had the wrong units for CCN3. which led to a
model with little or no clouds.  This commit adopts updated SPA data
files with the correct units.

This commit also adjusts the bounds for property checks for `nc` in
`P3` and for `nccn_activated` in `SPA` taking into account that with
the correct units these values are expected to be higher.