### PR TITLE
Fix bug in SHOC with calculation of cell grid length

### DIFF
--- a/components/scream/src/physics/share/physics_constants.hpp
+++ b/components/scream/src/physics/share/physics_constants.hpp
@@ -116,6 +116,12 @@ struct Constants
 
   // Gases
   static Scalar get_gas_mol_weight(ci_string gas_name);
+
+  // For use in converting area to length for a column cell
+  // World Geodetic System 1984 (WGS84) 
+  static constexpr Scalar earth_ellipsoid1 = 111132.92; // first coefficient, meters per degree longitude at equator 
+  static constexpr Scalar earth_ellipsoid2 = 559.82;    // second expansion coefficient for WGS84 ellipsoid 
+  static constexpr Scalar earth_ellipsoid3 = 1.175;     // third expansion coefficient for WGS84 ellipsoid 
 };
 
 // Gases

--- a/components/scream/src/physics/share/physics_constants.hpp
+++ b/components/scream/src/physics/share/physics_constants.hpp
@@ -41,7 +41,7 @@ struct Constants
   static constexpr Scalar T_zerodegc    = Tmelt;
   static constexpr Scalar T_homogfrz    = Tmelt - 40;
   static constexpr Scalar T_rainfrz     = Tmelt - 4;
-  static constexpr Scalar Pi            = 3.14159265;
+  static constexpr Scalar Pi            = M_PI;  // Use the value of PI defined in cpp math.h
   static constexpr long long int    iulog       = 98;
   static constexpr bool   masterproc    = true;
   static constexpr Scalar RHOW          = RHO_H2O;

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -32,9 +32,8 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
 
-  // TODO: In preprocessing, we assume area is in meters. This may not
-  //       always be the case.
   m_cell_area = grid->get_geometry_data("area"); // area of each cell
+  m_cell_lat  = grid->get_geometry_data("lat"); // area of each cell
 
   // Define the different field layouts that will be used for this process
   using namespace ShortFieldTagsNames;
@@ -291,7 +290,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   // For now, set z_int(i,nlevs) = z_surf = 0
   const Real z_surf = 0.0;
 
-  shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,z_surf,m_cell_area,
+  shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,z_surf,m_cell_area,m_cell_lat,
                                 T_mid,p_mid,p_int,pseudo_density,omega,phis,surf_sens_flux,surf_latent_flux,
                                 surf_mom_flux,qv,qc,qc_copy,tke,tke_copy,z_mid,z_int,cell_length,
                                 dse,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -156,7 +156,7 @@ public:
       // For now, we are considering dy=dx. Here, we
       // will need to compute dx/dy instead of cell_length
       // if we have dy!=dx.
-      cell_length(i) = sqrt(area(i));
+      cell_length(i) = PF::calculate_dx_from_area(area(i),lat(i));
 
       const auto& exner_int = PF::exner_function(p_int(i,nlevi_v)[nlevi_p]);
       const auto& inv_exner_int_surf = 1/exner_int;
@@ -177,6 +177,7 @@ public:
     int ncol, nlev, num_qtracers;
     Real z_surf;
     view_1d_const        area;
+    view_1d_const        lat;
     view_2d_const        T_mid;
     view_2d_const        p_mid;
     view_2d_const        p_int;
@@ -214,7 +215,7 @@ public:
 
     // Assigning local variables
     void set_variables(const int ncol_, const int nlev_, const int num_qtracers_, const Real z_surf_,
-                       const view_1d_const& area_,
+                       const view_1d_const& area_, const view_1d_const& lat_,
                        const view_2d_const& T_mid_, const view_2d_const& p_mid_, const view_2d_const& p_int_, const view_2d_const& pseudo_density_,
                        const view_2d_const& omega_,
                        const view_1d_const& phis_, const view_1d_const& surf_sens_flux_, const view_1d_const& surf_latent_flux_,
@@ -234,6 +235,7 @@ public:
       z_surf = z_surf_;
       // IN
       area = area_;
+      lat  = lat_;
       T_mid = T_mid_;
       p_mid = p_mid_;
       p_int = p_int_;
@@ -432,6 +434,7 @@ protected:
   Int hdtime;
 
   KokkosTypes<DefaultDevice>::view_1d<Real> m_cell_area;
+  KokkosTypes<DefaultDevice>::view_1d<Real> m_cell_lat;
 
   // Struct which contains local variables
   Buffer m_buffer;

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -112,10 +112,10 @@ create_point_grid (const std::string& grid_name,
   geo_view_type lat ("lat",  num_my_cols);
 
   // Estimate cell area for a uniform grid by taking the surface area
-  // of the earth divided by the number of columns
-  const Real rearth    = C::r_earth;
+  // of the earth divided by the number of columns.  Note we do this in
+  // units of radians-squared.
   const Real pi        = C::Pi;
-  const Real cell_area = 4*pi*rearth*rearth/num_my_cols;
+  const Real cell_area = 4*pi/num_my_cols;
 
   const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(num_my_cols, num_vertical_lev);
   Kokkos::parallel_for("area_loop", policy, KOKKOS_LAMBDA (const KT::MemberType& team) {

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -115,7 +115,7 @@ create_point_grid (const std::string& grid_name,
   // of the earth divided by the number of columns.  Note we do this in
   // units of radians-squared.
   const Real pi        = C::Pi;
-  const Real cell_area = 4*pi/num_my_cols;
+  const Real cell_area = 4.0*pi/num_my_cols;
 
   const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(num_my_cols, num_vertical_lev);
   Kokkos::parallel_for("area_loop", policy, KOKKOS_LAMBDA (const KT::MemberType& team) {

--- a/components/scream/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/scream/src/share/tests/common_physics_functions_tests.cpp
@@ -156,10 +156,12 @@ void run_scalar_valued_fns(std::mt19937_64& engine)
 
   // Get dx from grid cell area property tests:
   RealType area, lat, grid_dx;
-  REQUIRE( Check::equal(PF::calculate_dx_from_area(0.0,1.0),0.0) );
-  area = (pi/180.0)*(pi/180.0);
-  REQUIRE( Check::equal(PF::calculate_dx_from_area(area,0.0), coeff_1-coeff_2+coeff_3) );
-  REQUIRE( Check::equal(PF::calculate_dx_from_area(area,pi/2.0), coeff_1+coeff_2+coeff_3) );
+  area = 0.0; lat = 1.0;
+  REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat),0.0) );
+  area = (pi/180.0)*(pi/180.0); lat = 0.0;
+  REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat), coeff_1-coeff_2+coeff_3) );
+  lat = pi/2.0;
+  REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat), coeff_1+coeff_2+coeff_3) );
   
   lat     = pdf_lat(engine);
   area    = pdf_area(engine);

--- a/components/scream/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/scream/src/share/tests/common_physics_functions_tests.cpp
@@ -164,16 +164,9 @@ void run_scalar_valued_fns(std::mt19937_64& engine)
   lat = pi/2.0;
   REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat), coeff_1+coeff_2+coeff_3) );
   lat = pi/4.0;
-  // Note, pi is not defined up to double precision, so in order to compare with output from
-  // calculate_dx_from_area we need to define the following variables to approximate the output
-  // expected from the use of cosine in the function.  In other words this provides finite
-  // precision values to use in the test.
-  auto cos_pi_4 = std::cos(pi/4.0);
-  auto cos_pi_2 = std::cos(pi/2.0);
-  auto cos_pi   = std::cos(pi);
-  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,lat), coeff_1-coeff_2*cos_pi_2 + coeff_3*cos_pi, test_tol) );
+  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,lat), coeff_1 - coeff_3, test_tol) );
   lat = pi/8.0;
-  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,lat), coeff_1-cos_pi_4*coeff_2 + coeff_3*cos_pi_2, test_tol) );
+  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,lat), coeff_1-std::sqrt(2.0)/2.0*coeff_2, test_tol) );
   lat     = pdf_lat(engine);
   area    = pdf_area(engine);
   REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat),PF::calculate_dx_from_area(area,-lat)) );

--- a/components/scream/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/scream/src/share/tests/common_physics_functions_tests.cpp
@@ -164,9 +164,16 @@ void run_scalar_valued_fns(std::mt19937_64& engine)
   lat = pi/2.0;
   REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat), coeff_1+coeff_2+coeff_3) );
   lat = pi/4.0;
-  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,lat), coeff_1-coeff_3, test_tol) );
+  // Note, pi is not defined up to double precision, so in order to compare with output from
+  // calculate_dx_from_area we need to define the following variables to approximate the output
+  // expected from the use of cosine in the function.  In other words this provides finite
+  // precision values to use in the test.
+  auto cos_pi_4 = std::cos(pi/4.0);
+  auto cos_pi_2 = std::cos(pi/2.0);
+  auto cos_pi   = std::cos(pi);
+  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,lat), coeff_1-coeff_2*cos_pi_2 + coeff_3*cos_pi, test_tol) );
   lat = pi/8.0;
-  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,lat), coeff_1-std::sqrt(2)/2*coeff_2, test_tol) );
+  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,lat), coeff_1-cos_pi_4*coeff_2 + coeff_3*cos_pi_2, test_tol) );
   lat     = pdf_lat(engine);
   area    = pdf_area(engine);
   REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat),PF::calculate_dx_from_area(area,-lat)) );

--- a/components/scream/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/scream/src/share/tests/common_physics_functions_tests.cpp
@@ -159,7 +159,7 @@ void run_scalar_valued_fns(std::mt19937_64& engine)
   REQUIRE( Check::equal(PF::calculate_dx_from_area(0.0,1.0),0.0) );
   area = (pi/180.0)*(pi/180.0);
   REQUIRE( Check::equal(PF::calculate_dx_from_area(area,0.0), coeff_1-coeff_2+coeff_3) );
-  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,pi/2.0), coeff_1+coeff_2+coeff_3, test_tol) );
+  REQUIRE( Check::equal(PF::calculate_dx_from_area(area,pi/2.0), coeff_1+coeff_2+coeff_3) );
   
   lat     = pdf_lat(engine);
   area    = pdf_area(engine);

--- a/components/scream/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/scream/src/share/tests/common_physics_functions_tests.cpp
@@ -65,7 +65,7 @@ auto cmvdc (const ViewT& v_d) -> typename ViewT::HostMirror {
 }
 
 template<typename DeviceT>
-void run_scalar_valued_fns()
+void run_scalar_valued_fns(std::mt19937_64& engine)
 {
   /*
   Most of the common physics functions are templated to operate on scalars or on packs of vertical indices. 
@@ -79,9 +79,18 @@ void run_scalar_valued_fns()
   using PC         = scream::physics::Constants<RealType>;
   using Check = ChecksHelpers<RealType,1>; //1 is for number of levels.
 
+  static constexpr auto pi       = PC::Pi;
   static constexpr auto Rd       = PC::RD;
   static constexpr auto g        = PC::gravit;
   static constexpr auto test_tol = PC::macheps*1e3;
+  static constexpr auto coeff_1  = PC::earth_ellipsoid1;
+  static constexpr auto coeff_2  = PC::earth_ellipsoid2;
+  static constexpr auto coeff_3  = PC::earth_ellipsoid3;
+
+  // Construct random input data
+  using RPDF = std::uniform_real_distribution<RealType>;
+  RPDF pdf_lat(-pi/2.0,pi/2.0),
+       pdf_area(1e-8,pi*pi);
 
   //calculate_surface_air_T property tests:
   // If z_mid_bot==0, output should equal T_mid_bot
@@ -144,7 +153,20 @@ void run_scalar_valued_fns()
   psl=PF::calculate_psl( T_ground , p_ground, phi_ground );
   REQUIRE( Check::approx_equal( psl_exact, psl, test_tol) );
   REQUIRE( psl<p_ground );
-} 
+
+  // Get dx from grid cell area property tests:
+  RealType area, lat, grid_dx;
+  REQUIRE( Check::equal(PF::calculate_dx_from_area(0.0,1.0),0.0) );
+  area = (pi/180.0)*(pi/180.0);
+  REQUIRE( Check::equal(PF::calculate_dx_from_area(area,0.0), coeff_1-coeff_2+coeff_3) );
+  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,pi/2.0), coeff_1+coeff_2+coeff_3, test_tol) );
+  
+  lat     = pdf_lat(engine);
+  area    = pdf_area(engine);
+  grid_dx = (coeff_1 - coeff_2 * std::cos(2.0*lat) + coeff_3 * std::cos(4.0*lat)) * std::sqrt(area)*(180.0/pi);
+  REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat),grid_dx) ); 
+}
+
 
 //-----------------------------------------------------------------------------------------------//
 template<typename ScalarT, typename DeviceT>
@@ -500,15 +522,6 @@ void run(std::mt19937_64& engine)
 //===============================================================================
 TEST_CASE("common_physics_functions_test", "[common_physics_functions_test]"){
 
-// Run tests of functions only defined for a scalar (e.g. a particular column
-//of a variable only defined at the surface)
-   using Device = scream::DefaultDevice;
-   printf("\n -> Testing scalar-valued functions...");
-   run_scalar_valued_fns<Device>();
-   printf("ok!\n\n");
-
-// Run tests of vertically dimensioned-functions for both Real and Pack,
-// and for (potentially) different pack sizes
   using scream::Real;
   using Device = scream::DefaultDevice;
 
@@ -516,11 +529,15 @@ TEST_CASE("common_physics_functions_test", "[common_physics_functions_test]"){
 
   auto engine = scream::setup_random_test();
 
+// Run tests of vertically dimensioned-functions for both Real and Pack,
+// and for (potentially) different pack sizes
+
   printf(" -> Number of randomized runs: %d\n\n", num_runs);
 
   printf(" -> Testing Real scalar type...");
   for (int irun=0; irun<num_runs; ++irun) {
     run<Real,Device>(engine);
+    run_scalar_valued_fns<Device>(engine);
   }
   printf("ok!\n");
 

--- a/components/scream/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/scream/src/share/tests/common_physics_functions_tests.cpp
@@ -158,15 +158,19 @@ void run_scalar_valued_fns(std::mt19937_64& engine)
   RealType area, lat, grid_dx;
   area = 0.0; lat = 1.0;
   REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat),0.0) );
-  area = (pi/180.0)*(pi/180.0); lat = 0.0;
+  area = (pi/180.0)*(pi/180.0);
+  lat = 0.0;
   REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat), coeff_1-coeff_2+coeff_3) );
   lat = pi/2.0;
   REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat), coeff_1+coeff_2+coeff_3) );
-  
+  lat = pi/4.0;
+  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,lat), coeff_1-coeff_3, test_tol) );
+  lat = pi/8.0;
+  REQUIRE( Check::approx_equal(PF::calculate_dx_from_area(area,lat), coeff_1-std::sqrt(2)/2*coeff_2, test_tol) );
   lat     = pdf_lat(engine);
   area    = pdf_area(engine);
-  grid_dx = (coeff_1 - coeff_2 * std::cos(2.0*lat) + coeff_3 * std::cos(4.0*lat)) * std::sqrt(area)*(180.0/pi);
-  REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat),grid_dx) ); 
+  REQUIRE( Check::equal(PF::calculate_dx_from_area(area,lat),PF::calculate_dx_from_area(area,-lat)) );
+
 }
 
 

--- a/components/scream/src/share/util/scream_common_physics_functions.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions.hpp
@@ -25,6 +25,20 @@ struct PhysicsFunctions
   // ---------------------------------------------------------------- //
 
   //-----------------------------------------------------------------------------------------------//
+  // Determine the length of a square column cell at a specifc latitude given the area in radians
+  //   grid_dx = mpdeglat * area
+  // where,
+  //   mpdeglat is the distance between two points on an ellipsoid
+  //   area     is the area of the column cell in radians. 
+  //   lat      is the latitude of the grid column in radians.
+  // NOTE - Here we assume that the column area is a SQUARE so dx=dy.  We will need a different
+  //        routine for a rectangular (or other shape) area.
+  //-----------------------------------------------------------------------------------------------//
+  template<typename ScalarT>
+  KOKKOS_INLINE_FUNCTION
+  static ScalarT calculate_dx_from_area(const ScalarT& area, const ScalarT& lat);
+
+  //-----------------------------------------------------------------------------------------------//
   // Determines the density given the definition of pseudo_density passed by the dycore
   //   rho = pseudo_density/dz/g
   // where,

--- a/components/scream/src/share/util/scream_common_physics_functions_impl.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions_impl.hpp
@@ -18,9 +18,12 @@ ScalarT PhysicsFunctions<DeviceT>::calculate_dx_from_area(const ScalarT& area, c
   static constexpr auto coeff_3 = C::earth_ellipsoid3;
   static constexpr auto pi      = C::Pi; 
 
-  auto mpdeglat = coeff_1 - coeff_2 * std::cos(2.0*lat) + coeff_3 * std::cos(4.0*lat);
+  // Now find meters per degree latitude
+  // Below equation finds distance between two points on an ellipsoid, derived from expansion
+  // taking into account ellipsoid using World Geodetic System (WGS84) reference 
+  auto m_per_degree_lat = coeff_1 - coeff_2 * std::cos(2.0*lat) + coeff_3 * std::cos(4.0*lat);
   // Note, for the formula we need to convert area from radians to degrees.
-  return mpdeglat * std::sqrt(area)*(180.0/pi);
+  return m_per_degree_lat * std::sqrt(area)*(180.0/pi);
 
 }
 

--- a/components/scream/src/share/util/scream_common_physics_functions_impl.hpp
+++ b/components/scream/src/share/util/scream_common_physics_functions_impl.hpp
@@ -9,6 +9,24 @@ namespace scream {
 template<typename DeviceT>
 template<typename ScalarT>
 KOKKOS_INLINE_FUNCTION
+ScalarT PhysicsFunctions<DeviceT>::calculate_dx_from_area(const ScalarT& area, const ScalarT& lat)
+{
+  using C = scream::physics::Constants<Real>;
+
+  static constexpr auto coeff_1 = C::earth_ellipsoid1;
+  static constexpr auto coeff_2 = C::earth_ellipsoid2;
+  static constexpr auto coeff_3 = C::earth_ellipsoid3;
+  static constexpr auto pi      = C::Pi; 
+
+  auto mpdeglat = coeff_1 - coeff_2 * std::cos(2.0*lat) + coeff_3 * std::cos(4.0*lat);
+  // Note, for the formula we need to convert area from radians to degrees.
+  return mpdeglat * std::sqrt(area)*(180.0/pi);
+
+}
+
+template<typename DeviceT>
+template<typename ScalarT>
+KOKKOS_INLINE_FUNCTION
 ScalarT PhysicsFunctions<DeviceT>::calculate_density(const ScalarT& pseudo_density, const ScalarT& dz)
 {
   using C = scream::physics::Constants<Real>;

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -26,6 +26,7 @@ Initial Conditions:
   Point Grid:
     surf_latent_flux: 0.0
     surf_sens_flux: 0.0
+    Load Latitude: true
 
 # The parameters for I/O control
 Scorpio:


### PR DESCRIPTION
This commit will update the calculation of a physics grid cell area from HOMME to be in the units of meters-squared rather than radians-squared when used by EAMxx.  Note that the area reported by HOMME is also scaled to the unit-sphere, so the function used here also rescales the area using the radius of Earth.

This commit will introduce a new common physics function which calculates the cell length of a physics column given the area in radians^2 and the latitude of that cell.  New tests are introduced to unit test this function.

This will fix a bug described in #1588 .