### PR TITLE
Allow unexpected resolutions and add ne120 defaults in XML

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -153,9 +153,11 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Homme dynamics -->
     <homme inherit="atm_proc_base">
       <Grid>Dynamics</Grid>
+      <Vertical__Coordinate__Filename>UNSET</Vertical__Coordinate__Filename>
       <Vertical__Coordinate__Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc</Vertical__Coordinate__Filename>
       <Vertical__Coordinate__Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220503.nc</Vertical__Coordinate__Filename>
       <Vertical__Coordinate__Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220503.nc</Vertical__Coordinate__Filename>
+      <Vertical__Coordinate__Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220505.nc</Vertical__Coordinate__Filename>
       <Vertical__Coordinate__Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc</Vertical__Coordinate__Filename>
       <Moisture>moist</Moisture>
     </homme>
@@ -171,9 +173,11 @@ tweaking their $case/namelist_scream.xml file.
 
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="physics_proc_base">
+      <SPA__Remap__File>UNSET</SPA__Remap__File>
       <SPA__Remap__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc</SPA__Remap__File>
       <SPA__Remap__File hgrid="ne30np4">none</SPA__Remap__File>
       <SPA__Remap__File hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc</SPA__Remap__File>
+      <SPA__Remap__File hgrid="ne512np4">UNSET</SPA__Remap__File>
       <SPA__Data__File>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
     </spa>
 
@@ -208,9 +212,11 @@ tweaking their $case/namelist_scream.xml file.
 
   <!-- List of nc files for loading inputs on specified grids -->
   <Initial__Conditions>
+    <Filename>UNSET</Filename>
     <Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc</Filename>
     <Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220503.nc</Filename>
     <Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220503.nc</Filename>
+    <Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220505.nc</Filename>
     <Filename COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc</Filename>
     <Restart__Casename>${CASE}</Restart__Casename>
   </Initial__Conditions>
@@ -265,19 +271,33 @@ tweaking their $case/namelist_scream.xml file.
     <hypervis_subcycle_tom>1</hypervis_subcycle_tom>
     <hypervis_subcycle_q>1</hypervis_subcycle_q>
     <nu>3.4e-08</nu>
-    <nu_top>250000.0</nu_top>
+    <nu_top>UNSET</nu_top>
+    <nu_top hgrid="ne4np4">250000.0</nu_top>
+    <nu_top hgrid="ne30np4">250000.0</nu_top>
+    <nu_top hgrid="ne120np4">100000.0</nu_top>
+    <nu_top hgrid="ne256np4">4.0e4</nu_top>
+    <nu_top hgrid="ne512np4">2.0e4</nu_top>
+    <nu_top hgrid="ne1024np4">1.0e4</nu_top>
     <se_ftype valid_values="0,2">0</se_ftype>
     <se_geometry>sphere</se_geometry>
     <se_limiter_option>9</se_limiter_option>
+    <se_ne>UNSET</se_ne>
     <se_ne hgrid="ne4np4" constraints="ge 2">4</se_ne>
     <se_ne hgrid="ne30np4" constraints="ge 2">30</se_ne>
     <se_ne hgrid="ne120np4" constraints="ge 2">120</se_ne>
+    <se_ne hgrid="ne256np4" constraints="ge 2">256</se_ne>
+    <se_ne hgrid="ne512np4" constraints="ge 2">512</se_ne>
+    <se_ne hgrid="ne1024np4" constraints="ge 2">1024</se_ne>
     <se_nsplit>-1</se_nsplit>
     <se_partmethod>4</se_partmethod>
     <se_topology>cube</se_topology>
+    <se_tstep>UNSET</se_tstep>
     <se_tstep hgrid="ne4np4" constraints="gt 0">600</se_tstep>
     <se_tstep hgrid="ne30np4" constraints="gt 0">300</se_tstep>
     <se_tstep hgrid="ne120np4" constraints="gt 0">75</se_tstep>
+    <se_tstep hgrid="ne256np4" constraints="gt 0">33.33333333333</se_tstep>
+    <se_tstep hgrid="ne512np4" constraints="gt 0">16.6666666666666</se_tstep>
+    <se_tstep hgrid="ne1024np4" constraints="gt 0">8.3333333333333</se_tstep>
     <statefreq>9999</statefreq>
     <theta_advect_form>1</theta_advect_form>
     <theta_hydrostatic_mode>True</theta_hydrostatic_mode>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -177,7 +177,7 @@ tweaking their $case/namelist_scream.xml file.
       <SPA__Remap__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc</SPA__Remap__File>
       <SPA__Remap__File hgrid="ne30np4">none</SPA__Remap__File>
       <SPA__Remap__File hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc</SPA__Remap__File>
-      <SPA__Remap__File hgrid="ne512np4">UNSET</SPA__Remap__File>
+      <SPA__Remap__File hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne512np4_mono_20220506.nc</SPA__Remap__File>
       <SPA__Data__File>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
     </spa>
 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -154,7 +154,8 @@ tweaking their $case/namelist_scream.xml file.
     <homme inherit="atm_proc_base">
       <Grid>Dynamics</Grid>
       <Vertical__Coordinate__Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc</Vertical__Coordinate__Filename>
-      <Vertical__Coordinate__Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220413.nc</Vertical__Coordinate__Filename>
+      <Vertical__Coordinate__Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220503.nc</Vertical__Coordinate__Filename>
+      <Vertical__Coordinate__Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220503.nc</Vertical__Coordinate__Filename>
       <Vertical__Coordinate__Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc</Vertical__Coordinate__Filename>
       <Moisture>moist</Moisture>
     </homme>
@@ -172,6 +173,7 @@ tweaking their $case/namelist_scream.xml file.
     <spa inherit="physics_proc_base">
       <SPA__Remap__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc</SPA__Remap__File>
       <SPA__Remap__File hgrid="ne30np4">none</SPA__Remap__File>
+      <SPA__Remap__File hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc</SPA__Remap__File>
       <SPA__Data__File>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
     </spa>
 
@@ -207,7 +209,8 @@ tweaking their $case/namelist_scream.xml file.
   <!-- List of nc files for loading inputs on specified grids -->
   <Initial__Conditions>
     <Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc</Filename>
-    <Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220413.nc</Filename>
+    <Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220503.nc</Filename>
+    <Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220503.nc</Filename>
     <Filename COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc</Filename>
     <Restart__Casename>${CASE}</Restart__Casename>
   </Initial__Conditions>
@@ -247,6 +250,7 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc,
     ${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc
+    ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc
   </input_files>
 
   <!-- Homme control namelist -->
@@ -267,11 +271,13 @@ tweaking their $case/namelist_scream.xml file.
     <se_limiter_option>9</se_limiter_option>
     <se_ne hgrid="ne4np4" constraints="ge 2">4</se_ne>
     <se_ne hgrid="ne30np4" constraints="ge 2">30</se_ne>
+    <se_ne hgrid="ne120np4" constraints="ge 2">120</se_ne>
     <se_nsplit>-1</se_nsplit>
     <se_partmethod>4</se_partmethod>
     <se_topology>cube</se_topology>
-    <se_tstep hgrid="ne4np4">600</se_tstep>
-    <se_tstep hgrid="ne30np4">300</se_tstep>
+    <se_tstep hgrid="ne4np4" constraints="gt 0">600</se_tstep>
+    <se_tstep hgrid="ne30np4" constraints="gt 0">300</se_tstep>
+    <se_tstep hgrid="ne120np4" constraints="gt 0">75</se_tstep>
     <statefreq>9999</statefreq>
     <theta_advect_form>1</theta_advect_form>
     <theta_hydrostatic_mode>True</theta_hydrostatic_mode>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -256,7 +256,12 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc,
     ${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc
+    <!-- ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc -->
+    <!-- ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne512np4_mono_20220506.nc -->
+    ${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc
+    ${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220503.nc
+    <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220503.nc -->
+    <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220505.nc -->
   </input_files>
 
   <!-- Homme control namelist -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -249,7 +249,7 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc
+    ${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc,
     ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc
   </input_files>
 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -256,12 +256,12 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc,
     ${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc,
-    <!-- ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc -->
-    <!-- ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne512np4_mono_20220506.nc -->
-    ${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220503.nc
-    <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220503.nc -->
-    <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220505.nc -->
+    <!-- ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc, -->
+    <!-- ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne512np4_mono_20220506.nc, -->
+    <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220505.nc, -->
+    <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220503.nc, -->
+    ${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220503.nc,
+    ${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc
   </input_files>
 
   <!-- Homme control namelist -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -258,7 +258,7 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc,
     <!-- ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc -->
     <!-- ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne512np4_mono_20220506.nc -->
-    ${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc
+    ${DIN_LOC_ROOT}/atm/scream/init/init_ne4np4.nc,
     ${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220503.nc
     <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220503.nc -->
     <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220505.nc -->


### PR DESCRIPTION
This commit adds the default settings for running an ne120np4 CIME based SCREAMv1 case.

It also updates the filename for the initial condition file for ne30.