### PR TITLE
Fix env setup in machine_specs.py

### DIFF
--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -219,7 +219,7 @@ def setup_mach_env(machine, ctest_j=None):
         # But we can return the resulting PATH, and update current env with that
 
         # Get the whole env string after running the env_setup command
-        curr_env = run_cmd_no_fail("{{ {};  }} > /dev/null && env | sort".format(";".join(env_setup)))
+        curr_env = run_cmd_no_fail("{{ {};  }} > /dev/null && env | sort".format(" && ".join(env_setup)),verbose=True)
 
         # Split by line. We are assuming that each env variable is *exactly* on one line
         curr_env_list = curr_env.split("\n")


### PR DESCRIPTION
I was getting odd behavior on my workstation, where I have a custom mach specs file. Basically, the env setup command contained some invalid commands (*), but since we were chaining setup as "cmd1; cmd2; ...; cmdN", the overall result of the mach setup was ok, so long as the last env setting was returning 0. Not only this was not loading the env for me, but it might have hidden some bad env setup on any machine.

This PR changes the chaining to "cmd1 && cmd2 && .. && cmdN", so that it immediately craps out if something is off in the env setup.

(*) The invalid commands were aliases I defined in some scripts I load in my `.bashrc`. Why doesn't the subprocess pick up the aliases? Our `run_cmd` function has `shell=True`, so it _should_ get all the stuff that I do/load in my `.bashrc`, no?

Edit: subprocess.call, even if run with `shell=True`, and even if `executable='/usr/bin/bash'`, does not run in interactive mode, so the `.profile` and `.bashrc` scripts are _not_ sourced. So one has to add `source ~/.bashrc` to its env setup cmd list.