### PR TITLE
SHOC v1 buoyancy flux bug fix

### DIFF
--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -79,11 +79,11 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   add_field<Required>("p_int",          scalar3d_layout_int, Pa,    grid_name, ps);
   add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,    grid_name, ps);
   add_field<Required>("phis",           scalar2d_layout_col, m2/s2, grid_name, ps);
-  add_field<Required>("sgs_buoy_flux",  scalar3d_layout_mid, K*(m/s), grid_name, ps);
 
   // Input/Output variables
   add_field<Updated>("tke",           scalar3d_layout_mid, m2/s2,   grid_name, "tracers", ps);
   add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,     grid_name, ps);
+  add_field<Updated>("sgs_buoy_flux", scalar3d_layout_mid, K*(m/s), grid_name, ps);
   add_field<Updated>("eddy_diff_mom", scalar3d_layout_mid, m2/s,    grid_name, ps);
   add_field<Updated>("qc",            scalar3d_layout_mid, Qunit,   grid_name, "tracers", ps);
   add_field<Updated>("cldfrac_liq",   scalar3d_layout_mid, nondim,  grid_name, ps);
@@ -259,7 +259,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   const auto& qv               = get_field_out("qv").get_view<Spack**>();
   const auto& tke              = get_field_out("tke").get_view<Spack**>();
   const auto& cldfrac_liq      = get_field_out("cldfrac_liq").get_view<Spack**>();
-  const auto& sgs_buoy_flux    = get_field_in("sgs_buoy_flux").get_view<Spack**>();
+  const auto& sgs_buoy_flux    = get_field_out("sgs_buoy_flux").get_view<Spack**>();
   const auto& inv_qc_relvar    = get_field_out("inv_qc_relvar").get_view<Spack**>();
   const auto& phis             = get_field_in("phis").get_view<const Real*>();
 

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -75,18 +75,18 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   add_field<Updated> ("qv",               scalar3d_layout_mid, Qunit,   grid_name, "tracers", ps);
 
   // Input variables
-  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,      grid_name, ps);
-  add_field<Required>("p_int",          scalar3d_layout_int, Pa,      grid_name, ps);
-  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,      grid_name, ps);
-  add_field<Required>("phis",           scalar2d_layout_col, m2/s2,   grid_name, ps);
+  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,    grid_name, ps);
+  add_field<Required>("p_int",          scalar3d_layout_int, Pa,    grid_name, ps);
+  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,    grid_name, ps);
+  add_field<Required>("phis",           scalar2d_layout_col, m2/s2, grid_name, ps);
   add_field<Required>("sgs_buoy_flux",  scalar3d_layout_mid, K*(m/s), grid_name, ps);
 
   // Input/Output variables
-  add_field<Updated>("tke",           scalar3d_layout_mid, m2/s2,  grid_name, "tracers", ps);
-  add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,    grid_name, ps);
-  add_field<Updated>("eddy_diff_mom", scalar3d_layout_mid, m2/s,   grid_name, ps);
-  add_field<Updated>("qc",            scalar3d_layout_mid, Qunit,  grid_name, "tracers", ps);
-  add_field<Updated>("cldfrac_liq",   scalar3d_layout_mid, nondim, grid_name, ps);
+  add_field<Updated>("tke",           scalar3d_layout_mid, m2/s2,   grid_name, "tracers", ps);
+  add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,     grid_name, ps);
+  add_field<Updated>("eddy_diff_mom", scalar3d_layout_mid, m2/s,    grid_name, ps);
+  add_field<Updated>("qc",            scalar3d_layout_mid, Qunit,   grid_name, "tracers", ps);
+  add_field<Updated>("cldfrac_liq",   scalar3d_layout_mid, nondim,  grid_name, ps);
 
   // Output variables
   add_field<Computed>("pbl_height",    scalar2d_layout_col, m,           grid_name);

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -348,7 +348,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
 
   shoc_postprocess.set_variables(m_num_cols,m_num_levs,
                                  rrho,qv,qw,qc,qc_copy,tke,tke_copy,shoc_ql2,
-                                 cldfrac_liq,sgs_buoy_flux,inv_qc_relvar,
+                                 cldfrac_liq,inv_qc_relvar,
                                  T_mid, dse, z_mid, phis);
 
   // Set field property checks for the fields in this process

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -75,18 +75,18 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   add_field<Updated> ("qv",               scalar3d_layout_mid, Qunit,   grid_name, "tracers", ps);
 
   // Input variables
-  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,    grid_name, ps);
-  add_field<Required>("p_int",          scalar3d_layout_int, Pa,    grid_name, ps);
-  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,    grid_name, ps);
-  add_field<Required>("phis",           scalar2d_layout_col, m2/s2, grid_name, ps);
+  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,      grid_name, ps);
+  add_field<Required>("p_int",          scalar3d_layout_int, Pa,      grid_name, ps);
+  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,      grid_name, ps);
+  add_field<Required>("phis",           scalar2d_layout_col, m2/s2,   grid_name, ps);
+  add_field<Required>("sgs_buoy_flux",  scalar3d_layout_mid, K*(m/s), grid_name, ps);
 
   // Input/Output variables
-  add_field<Updated>("tke",           scalar3d_layout_mid, m2/s2,   grid_name, "tracers", ps);
-  add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,     grid_name, ps);
-  add_field<Updated>("sgs_buoy_flux", scalar3d_layout_mid, K*(m/s), grid_name, ps);
-  add_field<Updated>("eddy_diff_mom", scalar3d_layout_mid, m2/s,    grid_name, ps);
-  add_field<Updated>("qc",            scalar3d_layout_mid, Qunit,   grid_name, "tracers", ps);
-  add_field<Updated>("cldfrac_liq",   scalar3d_layout_mid, nondim,  grid_name, ps);
+  add_field<Updated>("tke",           scalar3d_layout_mid, m2/s2,  grid_name, "tracers", ps);
+  add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,    grid_name, ps);
+  add_field<Updated>("eddy_diff_mom", scalar3d_layout_mid, m2/s,   grid_name, ps);
+  add_field<Updated>("qc",            scalar3d_layout_mid, Qunit,  grid_name, "tracers", ps);
+  add_field<Updated>("cldfrac_liq",   scalar3d_layout_mid, nondim, grid_name, ps);
 
   // Output variables
   add_field<Computed>("pbl_height",    scalar2d_layout_col, m,           grid_name);
@@ -259,7 +259,7 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   const auto& qv               = get_field_out("qv").get_view<Spack**>();
   const auto& tke              = get_field_out("tke").get_view<Spack**>();
   const auto& cldfrac_liq      = get_field_out("cldfrac_liq").get_view<Spack**>();
-  const auto& sgs_buoy_flux    = get_field_out("sgs_buoy_flux").get_view<Spack**>();
+  const auto& sgs_buoy_flux    = get_field_in("sgs_buoy_flux").get_view<Spack**>();
   const auto& inv_qc_relvar    = get_field_out("inv_qc_relvar").get_view<Spack**>();
   const auto& phis             = get_field_in("phis").get_view<const Real*>();
 

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -297,7 +297,6 @@ public:
         qv(i,k) = qw(i,k) - qc(i,k);
 
         cldfrac_liq(i,k) = ekat::min(cldfrac_liq(i,k), 1);
-        sgs_buoy_flux(i,k) = sgs_buoy_flux(i,k)*rrho(i,k)*cpair;
 
         inv_qc_relvar(i,k) = 1;
         const auto condition = (qc(i,k) != 0 && qc2(i,k) != 0);
@@ -323,7 +322,6 @@ public:
     view_2d_const tke_copy, qc_copy, qw;
     view_2d_const qc2;
     view_2d cldfrac_liq;
-    view_2d sgs_buoy_flux;
     view_2d inv_qc_relvar;
     view_2d T_mid;
     view_2d_const dse,z_mid;
@@ -334,7 +332,7 @@ public:
                        const view_2d_const& rrho_,
                        const view_2d& qv_, const view_2d_const& qw_, const view_2d& qc_, const view_2d_const& qc_copy_,
                        const view_2d& tke_, const view_2d_const& tke_copy_, const view_2d_const& qc2_,
-                       const view_2d& cldfrac_liq_, const view_2d& sgs_buoy_flux_, const view_2d& inv_qc_relvar_,
+                       const view_2d& cldfrac_liq_, const view_2d& inv_qc_relvar_,
                        const view_2d& T_mid_, const view_2d_const& dse_, const view_2d_const& z_mid_, const view_1d_const phis_)
     {
       ncol = ncol_;
@@ -348,7 +346,6 @@ public:
       tke_copy = tke_copy_;
       qc2 = qc2_;
       cldfrac_liq = cldfrac_liq_;
-      sgs_buoy_flux = sgs_buoy_flux_;
       inv_qc_relvar = inv_qc_relvar_;
       T_mid = T_mid_;
       dse = dse_;


### PR DESCRIPTION
Background:  In the SHOC v0 interface we convert the buoyancy flux from units of K m/s (which are the units SHOC needs this variable in) to W/m2 for output diagnostic purposes only:

https://github.com/E3SM-Project/scream/blob/b078784a2bab4f4b0e1b2d5201248fcbe350555a/components/eam/src/physics/cam/shoc_intr.F90#L1134-L1139

Note that when this conversion was done it was stored in a special "output" array while the interactive "wthv" variable, used by SHOC, was left untouched.

In v1, this conversion is unnecessary because we are currently not saving buoyancy flux as an output variable.  But even if we were, the conversion is being done on the "interactive" buoyancy flux variable that is used by SHOC in the next time step:

https://github.com/E3SM-Project/scream/blob/b078784a2bab4f4b0e1b2d5201248fcbe350555a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp#L298-L301

Thus, the buoyancy flux is being artificially given the wrong units each time step (and hence the values inflated).  This leads to very high turbulence and eddy diffusivity values in v1.

This PR removes the "sgs_buoy_flux" from the SHOC Post Processing since we should leave this variable "untouched".  This fix should bring v1 much closer scientifically to v0. 