### PR TITLE
SCREAM: use same value of PI in SHOC for v1 and v0 code bases

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -29,7 +29,7 @@ public  :: shoc_init, shoc_main
 logical :: use_cxx = .true.
 
 real(rtype), parameter, public :: largeneg = -99999999.99_rtype
-real(rtype), parameter, public :: pi = 3.14159265_rtype ! Pi
+real(rtype), parameter, public :: pi = 3.14159265358979323_rtype
 
 !=========================================================
 ! Physical constants used in SHOC

--- a/components/scream/src/physics/share/physics_constants.hpp
+++ b/components/scream/src/physics/share/physics_constants.hpp
@@ -41,7 +41,7 @@ struct Constants
   static constexpr Scalar T_zerodegc    = Tmelt;
   static constexpr Scalar T_homogfrz    = Tmelt - 40;
   static constexpr Scalar T_rainfrz     = Tmelt - 4;
-  static constexpr Scalar Pi            = M_PI;  // Use the value of PI defined in cpp math.h
+  static constexpr Scalar Pi            = 3.14159265358979323;
   static constexpr long long int    iulog       = 98;
   static constexpr bool   masterproc    = true;
   static constexpr Scalar RHOW          = RHO_H2O;


### PR DESCRIPTION
The macro `M_PI` is defined in some C header, so we can't include it in Fortran. The simplest solution is to just spell out pi with enough decimal digits for double precision, and let the compiler truncate it to whatever Real/rtype are, in both C++ and Fortran.

