### PR TITLE
Make the AT test v1 by default

### DIFF
--- a/components/scream/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/scream/scripts/jenkins/jenkins_common_impl.sh
@@ -7,7 +7,7 @@ IFS=';' read -r -a labels <<< "$PR_LABELS";
 skip_testing=0
 test_scripts=0
 test_v0=0
-test_v1=0
+test_v1=1
 test_SA=1
 skip_mappy=0
 skip_weaver=0
@@ -20,15 +20,12 @@ if [ ${#labels[@]} -gt 0 ]; then
       skip_testing=1
     elif [ "$label" == "AT: Skip Stand-Alone Testing" ]; then
       test_SA=0
+    elif [ "$label" == "AT: Skip v1 Testing" ]; then
+      test_v1=0
     elif [ "$label" == "scripts" ]; then
       test_scripts=1
-    elif [ "$label" == "SCREAMv1" ]; then
-      test_v1=1
     elif [ "$label" == "SCREAMv0" ]; then
       test_v0=1
-    elif [ "$label" == "CIME" ]; then
-      test_v0=1
-      test_v1=1
     elif [ "$label" == "AT: Skip mappy" ]; then
       skip_mappy=1
     elif [ "$label" == "AT: Skip weaver" ]; then

--- a/components/scream/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/scream/scripts/jenkins/jenkins_common_impl.sh
@@ -127,16 +127,18 @@ if [ $skip_testing -eq 0 ]; then
             exit 1
         fi
       fi
+    fi
 
-      if [[ $test_v0 == 1 ]]; then
-        ../../cime/scripts/create_test e3sm_scream -c -b master
-        if [[ $? != 0 ]]; then fails=$fails+1; fi
-      fi
+    if [[ $test_v0 == 1 ]]; then
+      ../../cime/scripts/create_test e3sm_scream -c -b master
+      if [[ $? != 0 ]]; then fails=$fails+1; fi
+    fi
 
-      if [[ $test_v1 == 1 ]]; then
-        ../../cime/scripts/create_test e3sm_scream_v1 --compiler=gnu9 -c -b master
-        if [[ $? != 0 ]]; then fails=$fails+1; fi
-      fi
+    if [[ $test_v1 == 1 ]]; then
+      ../../cime/scripts/create_test e3sm_scream_v1 --compiler=gnu9 -c -b master
+      if [[ $? != 0 ]]; then fails=$fails+1; fi
+    else
+      echo "SCREAM v1 tests were skipped, since the Github label 'AT: Skip v1 Testing' was found.\n"
     fi
   fi
 


### PR DESCRIPTION
We don't want to accidentally mess up v1 just because we forget to tell the AT to run v1 tests. So run them by default. Users can still skip them with the proper label.

Fix #1583 .

Note: DO not merge until we verify the labels work as expected.