### PR TITLE
Allow changing the list of atm processes in a group

### DIFF
--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -382,6 +382,9 @@ def _create_raw_xml_file_impl(case, xml):
     atm_procs.tag = "atmosphere_processes"
     xml.append(atm_procs);
 
+    # 5. Keep the atm procs defaults, so one can change atm procs via atmchange
+    xml.append(atm_procs_defaults)
+
     return xml
 
 ###############################################################################

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -129,7 +129,7 @@ tweaking their $case/namelist_scream.xml file.
       NOTE: *CANNOT* be changed.
     -->
     <!-- <atm_procs_list>(homme,((shoc,cldFraction,spa,p3),rrtmgp))</atm_procs_list> -->
-    <atm_procs_list locked="true">(homme,physics)</atm_procs_list>
+    <atm_procs_list>(homme,physics)</atm_procs_list>
 
     <!-- Basic options for each atm process -->
     <atm_proc_base>

--- a/components/scream/scripts/atmchange
+++ b/components/scream/scripts/atmchange
@@ -62,7 +62,13 @@ def atm_config_chg_impl(xml_root,changes):
 
         if node.text != new_value:
             check_value(node,new_value)
-            node.text = new_value
+            if node.tag=="atm_procs_list":
+                # Modifying the list of atm procs requires to regenerate this xml node
+                atm_procs_defaults = get_child(xml_root,"atmosphere_processes_defaults")
+                node = gen_group_processes (new_value, atm_procs_defaults):
+            else:
+                # A "normal" xml entry. Simply update the value
+                node.text = new_value
             any_change = True
 
     return any_change


### PR DESCRIPTION
@brhillman This should allow to change the list of atm processes without the need to create an ad-hoc compset.

Removing an atm proc was already possible. What this PR does is to allow to completely change the atm procs list and/or organization.

Note: I am still testing this.