### PR TITLE
Use grid-mean condensate for cloud optics

### DIFF
--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -85,6 +85,9 @@ public:
   // Rad frequency in number of steps
   int m_rad_freq_in_steps;
 
+  // Whether or not to do subcolumn sampling of cloud state for MCICA
+  bool m_do_subcol_sampling;
+
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {
     static constexpr int num_1d_ncol        = 10;

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -115,9 +115,13 @@ namespace scream {
                 // NOTE: these thresholds (from E3SM) seem arbitrary, but included here for consistency
                 // This limits in-cloud mixing ratio to 0.005 kg/kg. According to note in cloud_diagnostics
                 // in EAM, this is consistent with limits in MG2. Is this true for P3?
-                auto incloud_mixing_ratio = std::min(mixing_ratio(icol,ilay) / std::max(0.0001, cloud_fraction(icol,ilay)), 0.005);
-                // Compute layer-integrated cloud mass (per unit area)
-                cloud_mass(icol,ilay) = incloud_mixing_ratio * dp(icol,ilay) / physconst::gravit;
+                if (cloud_fraction(icol,ilay) > 0) {
+                    // Compute layer-integrated cloud mass (per unit area)
+                    auto incloud_mixing_ratio = std::min(mixing_ratio(icol,ilay) / std::max(0.0001, cloud_fraction(icol,ilay)), 0.005);
+                    cloud_mass(icol,ilay) = incloud_mixing_ratio * dp(icol,ilay) / physconst::gravit;
+                } else {
+                    cloud_mass(icol,ilay) = 0;
+                }
             });
         }
 


### PR DESCRIPTION
Use grid-mean condensate for cloud optics when not doing subcolumn sampling of cloud state. This adds a new yaml option to RRTMGP, `do_subcol_sampling`, to enable future support for implementing subcolumn sampling and to control whether or not we want to use grid-mean or in-cloud condensate amount to compute cloud optics. When not doing subcolumn sampling, we assume that each column is either entirely cloudy or entirely clear at a given level (i.e., layer cloud fraction is 0 or 1), and thus we want to use the grid-mean (total) cloud condensate amount to compute cloud optical properties. When doing subcolumn sampling of cloud state (not currently supported), we would want to use in-cloud values to compute cloud optical properties before assigning to subcolumns (i.e., using qc / cldfrac). The default for `do_subcol_sampling` is set to `false` for now, since subcolumn sampling is not yet implemented, and the code will throw an error if the user tries to select `do_subcol_sampling = true`. This change is non-BFB, since cloud properties are scaled differently for the computation of cloud optics.

[Non-B4B]