### PR TITLE
Make "all or nothing" ice cloud fraction default in SCREAMv0 compsets

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1144,7 +1144,7 @@
 <cldfrc_iceopt  phys="default"                > 5 </cldfrc_iceopt>
 
 <cldfrc_minice                             > 1.0e-12 </cldfrc_minice>
-<cldfrc_minice  phys="cam5",iceopt="7"     > 1.0e-5  </cldfrc_minice>
+<cldfrc_minice iceopt="7"  > 1.0e-5        </cldfrc_minice>
 
 <cldfrc_icecrit                            > 0.95D0 </cldfrc_icecrit>
 <cldfrc_icecrit phys="default"                > 0.93D0 </cldfrc_icecrit>

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -69,6 +69,9 @@
 <!-- Parameters specific to deep convection (default off for HR compset) -->
 <deep_scheme             > 'off'  </deep_scheme>
 
+<!-- Use all or nothing ice cloud fraction scheme -->
+<cldfrc_iceopt> 7 </cldfrc_iceopt>
+
 <!-- Macrophysics/microphysics coupling -->
 <cld_macmic_num_steps hgrid="ne4np4"   > 6 </cld_macmic_num_steps>
 <cld_macmic_num_steps hgrid="ne30np4"  > 6 </cld_macmic_num_steps>

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_hr_dyamond2.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_hr_dyamond2.xml
@@ -75,6 +75,9 @@
 <!-- Parameters specific to deep convection (default off for HR compset) -->
 <deep_scheme             > 'off'  </deep_scheme>
 
+<!-- Use all or nothing ice cloud fraction scheme -->
+<cldfrc_iceopt> 7 </cldfrc_iceopt>
+
 <!-- Macrophysics/microphysics coupling -->
 <cld_macmic_num_steps hgrid="ne4np4"   > 6 </cld_macmic_num_steps>
 <cld_macmic_num_steps hgrid="ne30np4"  > 6 </cld_macmic_num_steps>

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -79,6 +79,9 @@
 <zmconv_cape_cin         > 1      </zmconv_cape_cin>
 <zmconv_mx_bot_lyr_adj   > 2      </zmconv_mx_bot_lyr_adj>
 
+<!-- Use all or nothing ice cloud fraction scheme -->
+<cldfrc_iceopt> 7 </cldfrc_iceopt>
+
 <!-- Macrophysics/microphysics coupling -->
 <cld_macmic_num_steps hgrid="ne4np4"   > 6 </cld_macmic_num_steps>
 <cld_macmic_num_steps hgrid="ne30np4"  > 6 </cld_macmic_num_steps>

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_lr_dyamond2.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_lr_dyamond2.xml
@@ -81,6 +81,9 @@
 <zmconv_cape_cin         > 1      </zmconv_cape_cin>
 <zmconv_mx_bot_lyr_adj   > 2      </zmconv_mx_bot_lyr_adj>
 
+<!-- Use all or nothing ice cloud fraction scheme -->
+<cldfrc_iceopt> 7 </cldfrc_iceopt>
+
 <!-- Macrophysics/microphysics coupling -->
 <cld_macmic_num_steps hgrid="ne4np4"   > 6 </cld_macmic_num_steps>
 <cld_macmic_num_steps hgrid="ne30np4"  > 6 </cld_macmic_num_steps>

--- a/components/eam/bld/namelist_files/use_cases/dpscream_arm97.xml
+++ b/components/eam/bld/namelist_files/use_cases/dpscream_arm97.xml
@@ -75,6 +75,9 @@
 <se_lx>50000</se_lx>
 <se_ly>50000</se_ly>
 
+<!-- Use all or nothing ice cloud fraction scheme -->
+<cldfrc_iceopt> 7 </cldfrc_iceopt>
+
 <!-- Prescribed aerosol options -->
 <use_hetfrz_classnuc>.false.</use_hetfrz_classnuc>
 <aerodep_flx_type>'CYCLICAL'</aerodep_flx_type>


### PR DESCRIPTION
PR #944 added an "all or nothing" ice cloud fraction scheme to v0/v1 SCREAM codes.  In SCREAMv1 this is used by default.  In SCREAMv0 this was never set as the default ice cloud fraction scheme, which makes it very easy to unintentionally use the unwanted relative humidity based definition when running v0.  This PR sets the default to the all or nothing ice cloud fraction scheme in the SCREAMv0 compsets.