### PR TITLE
Work-around for slurm settings on perlmutter

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -374,18 +374,23 @@
     <directives>
       <directive> --constraint=gpu</directive>
     </directives>
-    <directives compiler="nvidiagpu">
-      <directive> --gpus-per-task=1</directive>
-      <directive> --gpu-bind=map_gpu:0,1,2,3</directive>
-    </directives>
-    <directives compiler="nvidia">
-      <directive> -G 0</directive>
-    </directives>
     <directives compiler="gnugpu">
       <directive> --gpus-per-task=1</directive>
+    </directives>
+    <directives COMPSET="!.*%MMF.*" compiler="gnugpu">
+      <directive> --gpu-bind=none</directive>
+    </directives>
+    <directives COMPSET=".*%MMF.*" compiler="gnugpu">
       <directive> --gpu-bind=map_gpu:0,1,2,3</directive>
     </directives>
+    <directives compiler="nvidiagpu">
+      <directive> --gpus-per-task=1</directive>
+      <directive> --gpu-bind=none</directive>
+    </directives>
     <directives compiler="gnu">
+      <directive> -G 0</directive>
+    </directives>
+    <directives compiler="nvidia">
       <directive> -G 0</directive>
     </directives>
     <queues>

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -164,7 +164,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
   using ci_string = ekat::CaseInsensitiveString;
   ci_string no_filename = "none";
   if (m_spa_remap_file == no_filename) {
-    printf("WARNING: SPA Remap File has been set to 'NONE', assuming that SPA data and simulation are on the same grid - skipping horizontal interpolation");
+    printf("WARNING: SPA Remap File has been set to 'NONE', assuming that SPA data and simulation are on the same grid - skipping horizontal interpolation\n");
     SPAFunc::set_remap_weights_one_to_one(m_total_global_dofs,m_min_global_dof,m_dofs_gids,SPAHorizInterp);
   } else {
     SPAFunc::get_remap_weights_from_file(m_spa_remap_file,m_total_global_dofs,m_min_global_dof,m_dofs_gids,SPAHorizInterp);


### PR DESCRIPTION
For perlmutter, and only for compiler=gnugpu, we need a different `gpu_bind` settings for MMF and non-MMF runs. We think this might be a system issue and NERSC is aware, but for now, this works.

Also added a newline for a print statement.

Fixes https://github.com/E3SM-Project/E3SM/issues/4834