### PR TITLE
No scream restarts should happen when REST_OPTION is none

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -228,6 +228,7 @@ tweaking their $case/namelist_scream.xml file.
       <Casename>${CASE}</Casename>
       <Output__Control>
         <Frequency>${REST_N}</Frequency>
+        <Frequency REST_OPTION="none">0</Frequency>
         <Frequency__Units>INVALID</Frequency__Units>
         <Frequency__Units REST_OPTION="nstep*">Steps</Frequency__Units>
       </Output__Control>


### PR DESCRIPTION
I noticed this issue when trying to run on summit. Summit cases fail when doing restarts, but then I realized SMS cases should not be trying to do restarts in the first place because they default to setting `REST_OPTION` to none. I did some digging and it seems like SCREAM is not handling the REST_OPTION correctly.

The block in question is:
```
	<Frequency>${REST_N}</Frequency>
        <Frequency REST_OPTION="none">0</Frequency>
        <Frequency__Units>INVALID</Frequency__Units>
        <Frequency__Units REST_OPTION="nstep*">Steps</Frequency__Units>
```

So, frequency units is set to `INVALID`, but that just results in a restart file with this name:
`SMS_D_Ln2_P24x1.ne4_ne4.F2000-SCREAMv1-AQP1.mappy_gnu9.20220512_103430_rux6oi.INSTANT.INVALID_x2.0001-01-01.020000.r.nc`

So `INVALID` seems to be treated the same as `Steps`. There are also other units like days that we don't seem to handle. Those are separate issues not handled by this PR. @bartgol , if you agree, please make a GitHub issue that describes this problem.

I did notice that the scream_output_manager does seem to skip restarts when frequency is 0, so we can at least do that when `REST_OPTION` is none which is what we do in this PR.