### PR TITLE
Initialize SHOC v1 turbulence consistent with v0

### DIFF
--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -335,7 +335,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   
   // Some SHOC variables should be initialized uniformly if an Initial run
   if (run_type==RunType::Initial){
-//    Kokkos::deep_copy(sgs_buoy_flux,0.0);
+//    Kokkos::deep_copy(input_output.wthv_sec,0.0); // or could do it like this to be consistent with below?
     Kokkos::deep_copy(input_output.tke,0.0004); //not sure what to do here, should be set to 0.0004
     Kokkos::deep_copy(input_output.tk,0.0); //not sure what to do here, should be set to 0.0
   }  

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -242,7 +242,7 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
 }
 
 // =========================================================================================
-void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
+void SHOCMacrophysics::initialize_impl (const RunType run_type)
 {
   // Initialize all of the structures that are passed to shoc_main in run_impl.
   // Note: Some variables in the structures are not stored in the field manager.  For these
@@ -296,6 +296,13 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
                                 dse,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
                                 wtracer_sfc,wm_zt,inv_exner,thlm,qw);
 
+  // Some SHOC variables should be initialized uniformly if an Initial run
+  if (run_type==RunType::Initial){
+    Kokkos::deep_copy(sgs_buoy_flux,0.0);
+//    Kokkos::deep_copy(eddy_diff_mom,0.0); not sure what to do here, should be set to 0.0
+//    Kokkos::deep_copy(tke_copy,0.0); not sure what to do here, should be set to 0.0004
+  }
+
   // Input Variables:
   input.dx          = shoc_preprocess.cell_length;
   input.dy          = shoc_preprocess.cell_length;
@@ -325,6 +332,13 @@ void SHOCMacrophysics::initialize_impl (const RunType /* run_type */)
   input_output.tk           = get_field_out("eddy_diff_mom").get_view<Spack**>();
   input_output.shoc_cldfrac = cldfrac_liq;
   input_output.shoc_ql      = qc_copy;
+  
+  // Some SHOC variables should be initialized uniformly if an Initial run
+  if (run_type==RunType::Initial){
+//    Kokkos::deep_copy(sgs_buoy_flux,0.0);
+    Kokkos::deep_copy(input_output.tke,0.0004); //not sure what to do here, should be set to 0.0004
+    Kokkos::deep_copy(input_output.tk,0.0); //not sure what to do here, should be set to 0.0
+  }  
 
   // Output Variables
   output.pblh     = get_field_out("pbl_height").get_view<Real*>();

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -333,7 +333,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   input_output.qtracers     = get_group_out("tracers").m_bundle->get_view<Spack***>();
   input_output.tk           = tk;
   input_output.shoc_cldfrac = cldfrac_liq;
-  input_output.shoc_ql      = qc_copy;  
+  input_output.shoc_ql      = qc_copy;
 
   // Output Variables
   output.pblh     = get_field_out("pbl_height").get_view<Real*>();


### PR DESCRIPTION
In SHOC v0 various input turbulence quantities are initialized uniformly (TKE, eddy diffusivity, SGS buoyancy flux) with either 0 or the minimum tolerance value (TKE).  

Currently, v1 initializes these quantities via initialization file with values from a spun-up simulation.  While there is nothing technically wrong with this, it is an inconsistency with v0 which makes doing apples-to-apples comparison between v0 and v1 difficult (especially diagnosing v1 crashes that occur during spin up period).  In addition, I am more comfortable allowing SHOC turbulence to spin-up in conjunction with the rest of the model since I'm not 100% sure of the impacts of doing it the v1 way.

Confirmed that changes in this PR perform scientifically as expected in ne30 SCREAMv1.