### PR TITLE
Update summit env to GCC 9.3

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3433,7 +3433,7 @@
         <command name="load">cuda/10.1.243</command>
       </modules>
       <modules compiler="gnugpu">
-        <command name="load">cuda/10.1.168</command>
+        <command name="load">cuda/11.5.2</command>
       </modules>
       <modules compiler="ibm.*">
         <command name="load">xl/16.1.1-10</command>
@@ -3442,7 +3442,7 @@
         <command name="load">cuda/10.1.243</command>
       </modules>
       <modules compiler="gnu.*">
-        <command name="load">gcc/7.5.0</command>
+        <command name="load">gcc/9.3.0</command>
       </modules>
       <modules>
         <command name="load">spectrum-mpi/10.4.0.3-20210112</command>

--- a/components/scream/cmake/machine-files/summit.cmake
+++ b/components/scream/cmake/machine-files/summit.cmake
@@ -3,6 +3,8 @@ set (EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/c
 include (${EKAT_MACH_FILES_PATH}/kokkos/nvidia-v100.cmake)
 include (${EKAT_MACH_FILES_PATH}/kokkos/cuda.cmake)
 
+set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
+
 set(SCREAM_MPIRUN_EXE "jsrun" CACHE STRING "")
 set(SCREAM_MPI_NP_FLAG "-n" CACHE STRING "")
 set(SCREAM_MACHINE "summit" CACHE STRING "")

--- a/components/scream/scripts/machines_specs.py
+++ b/components/scream/scripts/machines_specs.py
@@ -52,7 +52,7 @@ MACHINE_METADATA = {
                  ["mpicxx","mpifort","mpicc"],
                   "salloc --partition=pbatch --time=60",
                   ""),
-    "summit" : (["module purge", "module load cmake/3.18.4 gcc/7.5.0 spectrum-mpi/10.4.0.3-20210112 cuda/10.1.168 python/3.7-anaconda3 netcdf-c/4.8.0 netcdf-fortran/4.4.5 openblas/0.3.5","unset OMPI_CXX", "export OMPI_COMM_WORLD_RANK=0"],
+    "summit" : (["module purge", "module load cmake/3.18.4 gcc/9.3.0 spectrum-mpi/10.4.0.3-20210112 cuda/11.5.2 python/3.7-anaconda3 netcdf-c/4.8.0 netcdf-fortran/4.4.5 openblas/0.3.5","unset OMPI_CXX", "export OMPI_COMM_WORLD_RANK=0"],
                 ["mpicxx","mpifort","mpicc"],
                 "bsub -I -q batch -W 0:30 -P cli115 -nnodes 1",
                 "/gpfs/alpine/cli115/proj-shared/scream/master-baselines"),


### PR DESCRIPTION
GCC was old (7.5) which and we were seeing internal compiler failures
in some debug builds.