### PR TITLE
Adjust the scream-scorpio interface freeing pio decomp memory when not needed

### DIFF
--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -498,7 +498,7 @@ initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0
   long long my_mem_usage = get_mem_usage(MB);
   long long max_mem_usage;
   m_atm_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
-  m_atm_logger->info("[EAMxx::init::initialize_fields] memory usage: " + std::to_string(max_mem_usage) + "MB");
+  m_atm_logger->debug("[EAMxx::init::initialize_fields] memory usage: " + std::to_string(max_mem_usage) + "MB");
 #endif
   stop_timer("EAMxx::initialize_fields");
   stop_timer("EAMxx::init");
@@ -1036,7 +1036,7 @@ void AtmosphereDriver::finalize ( /* inputs? */ ) {
   long long my_mem_usage = get_mem_usage(MB);
   long long max_mem_usage;
   m_atm_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
-  m_atm_logger->info("[EAMxx::finalize] memory usage: " + std::to_string(max_mem_usage) + "MB");
+  m_atm_logger->debug("[EAMxx::finalize] memory usage: " + std::to_string(max_mem_usage) + "MB");
 #endif
 
   stop_timer("EAMxx::finalize");

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -494,6 +494,12 @@ initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0
     }
   }
 
+#ifdef SCREAM_HAS_MEMORY_USAGE
+  long long my_mem_usage = get_mem_usage(MB);
+  long long max_mem_usage;
+  m_atm_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
+  m_atm_logger->info("[EAMxx::init::initialize_fields] memory usage: " + std::to_string(max_mem_usage) + "MB");
+#endif
   stop_timer("EAMxx::initialize_fields");
   stop_timer("EAMxx::init");
   m_ad_status |= s_fields_inited;
@@ -1025,6 +1031,13 @@ void AtmosphereDriver::finalize ( /* inputs? */ ) {
   }
 
   m_atm_logger->info("[EAMXX] Finalize ... done!");
+
+#ifdef SCREAM_HAS_MEMORY_USAGE
+  long long my_mem_usage = get_mem_usage(MB);
+  long long max_mem_usage;
+  m_atm_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
+  m_atm_logger->info("[EAMxx::finalize] memory usage: " + std::to_string(max_mem_usage) + "MB");
+#endif
 
   stop_timer("EAMxx::finalize");
 }

--- a/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -184,6 +184,7 @@ TEST_CASE("dyn_grid_io")
   io_params.set<std::string>("Grid",dyn_grid->name());
   AtmosphereInput input (io_params,fm_dyn, gm);
   input.read_variables();
+  input.finalize();
 
   // Remap dyn->phys, and compare against ctrl
   dyn2phys->remap(true);

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -173,6 +173,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
   //       take this information directly from the spa data file.
   scorpio::register_file(m_spa_data_file,scorpio::Read);
   const int source_data_nlevs = scorpio::get_dimlen_c2f(m_spa_data_file.c_str(),"lev")+2; // Add 2 for padding
+  scorpio::eam_pio_closefile(m_spa_data_file);
   SPAHorizInterp.m_comm = m_comm;
 
   // Initialize the size of the SPAData structures:

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -506,6 +506,7 @@ void SPAFunctions<S,D>
   // local grid to match the size of the SPA data file.
 
   // To construct the grid we need to determine the number of columns and levels in the data file.
+  scorpio::register_file(spa_data_file_name,scorpio::Read);
   Int ncol = scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"ncol");
   const int source_data_nlevs = scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"lev");
   Int num_local_cols = spa_horiz_interp.num_unique_cols;
@@ -516,6 +517,7 @@ void SPAFunctions<S,D>
   EKAT_REQUIRE_MSG(nlwbands==scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"lwband"),"ERROR update_spa_data_from_file: Number of LW bands in simulation doesn't match the SPA data file");
   EKAT_REQUIRE_MSG(ncol==spa_horiz_interp.source_grid_ncols,"ERROR update_spa_data_from_file: Number of columns in remap data (" 
                         + std::to_string(ncol) + " doesn't match the SPA data file (" + std::to_string(spa_horiz_interp.source_grid_ncols) + ").");
+  scorpio::eam_pio_closefile(spa_data_file_name);
 
   // Construct local arrays to read data into
   // Note, all of the views being created here are meant to hold the local "coarse" resolution
@@ -581,7 +583,7 @@ void SPAFunctions<S,D>
   spa_data_input.init(grid,host_views,layouts);
   spa_data_input.read_variables(time_index);
   spa_data_input.finalize();
- 
+
   // Now that we have the data we can map the data onto the target data.
   auto hyam_h       = Kokkos::create_mirror_view(spa_data.hyam);
   auto hybm_h       = Kokkos::create_mirror_view(spa_data.hybm);

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -188,7 +188,7 @@ void AtmosphereProcessGroup::initialize_impl (const RunType run_type) {
     long long my_mem_usage = get_mem_usage(MB);
     long long max_mem_usage;
     m_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
-    m_atm_logger->info("[EAMxx::initialize::"+atm_proc->name()+"] memory usage: " + std::to_string(max_mem_usage) + "MB");
+    m_atm_logger->debug("[EAMxx::initialize::"+atm_proc->name()+"] memory usage: " + std::to_string(max_mem_usage) + "MB");
 #endif
   }
 }
@@ -219,7 +219,7 @@ void AtmosphereProcessGroup::run_sequential (const Real dt) {
     long long my_mem_usage = get_mem_usage(MB);
     long long max_mem_usage;
     m_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
-    m_atm_logger->info("[EAMxx::run_sequential::"+atm_proc->name()+"] memory usage: " + std::to_string(max_mem_usage) + "MB");
+    m_atm_logger->debug("[EAMxx::run_sequential::"+atm_proc->name()+"] memory usage: " + std::to_string(max_mem_usage) + "MB");
 #endif
   }
 }
@@ -235,7 +235,7 @@ void AtmosphereProcessGroup::finalize_impl (/* what inputs? */) {
     long long my_mem_usage = get_mem_usage(MB);
     long long max_mem_usage;
     m_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
-    m_atm_logger->info("[EAMxx::finalize::"+atm_proc->name()+"] memory usage: " + std::to_string(max_mem_usage) + "MB");
+    m_atm_logger->debug("[EAMxx::finalize::"+atm_proc->name()+"] memory usage: " + std::to_string(max_mem_usage) + "MB");
 #endif
   }
 }

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -184,6 +184,12 @@ gather_internal_fields  () {
 void AtmosphereProcessGroup::initialize_impl (const RunType run_type) {
   for (auto& atm_proc : m_atm_processes) {
     atm_proc->initialize(timestamp(),run_type);
+#ifdef SCREAM_HAS_MEMORY_USAGE
+    long long my_mem_usage = get_mem_usage(MB);
+    long long max_mem_usage;
+    m_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
+    m_atm_logger->info("[EAMxx::initialize::"+atm_proc->name()+"] memory usage: " + std::to_string(max_mem_usage) + "MB");
+#endif
   }
 }
 
@@ -209,6 +215,12 @@ void AtmosphereProcessGroup::run_sequential (const Real dt) {
     atm_proc->set_update_time_stamps(do_update);
     // Run the process
     atm_proc->run(dt);
+#ifdef SCREAM_HAS_MEMORY_USAGE
+    long long my_mem_usage = get_mem_usage(MB);
+    long long max_mem_usage;
+    m_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
+    m_atm_logger->info("[EAMxx::run_sequential::"+atm_proc->name()+"] memory usage: " + std::to_string(max_mem_usage) + "MB");
+#endif
   }
 }
 
@@ -219,6 +231,12 @@ void AtmosphereProcessGroup::run_parallel (const Real /* dt */) {
 void AtmosphereProcessGroup::finalize_impl (/* what inputs? */) {
   for (auto atm_proc : m_atm_processes) {
     atm_proc->finalize(/* what inputs? */);
+#ifdef SCREAM_HAS_MEMORY_USAGE
+    long long my_mem_usage = get_mem_usage(MB);
+    long long max_mem_usage;
+    m_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
+    m_atm_logger->info("[EAMxx::finalize::"+atm_proc->name()+"] memory usage: " + std::to_string(max_mem_usage) + "MB");
+#endif
   }
 }
 

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -119,6 +119,7 @@ module scream_scorpio_interface
     integer          :: dtype                 ! data type
     integer          :: numdims               ! Number of dimensions in out field
     type(io_desc_t), pointer  :: iodesc       ! PIO decomp associated with this variable
+    type(iodesc_list_t), pointer  :: iodesc_list ! PIO decomp list with metadata about PIO decomp
     integer, allocatable :: compdof(:)        ! Global locations in output array for this process
     integer, allocatable :: dimid(:)          ! array of PIO dimension id's for this variable
     integer, allocatable :: dimlen(:)         ! array of PIO dimension lengths for this variable
@@ -133,12 +134,15 @@ module scream_scorpio_interface
   type iodesc_list_t
     character(tag_len)           :: tag              ! Unique tag associated with this decomposition
     type(io_desc_t),     pointer :: iodesc => NULL() ! PIO - decomposition
-    type(iodesc_list_t), pointer :: next => NULL()   ! Needed for recursive definition
+    type(iodesc_list_t), pointer :: next => NULL()   ! Needed for recursive definition, the next list
+    type(iodesc_list_t), pointer :: prev => NULL()   ! Needed for recursive definition, the list that points to this one
     logical                      :: iodesc_set = .false.
+    integer                      :: num_customers = 0 ! Track the number of currently active variables that use this pio decomposition
+    integer                      :: location = 0      ! where am in the recursive list
   end type iodesc_list_t
 
   ! Define the first iodesc_list_t
-  type(iodesc_list_t), target :: iodesc_list_top
+  type(iodesc_list_t), pointer :: iodesc_list_top
 !----------------------------------------------------------------------
   type hist_coord_list_t
     type(hist_coord_t),      pointer :: coord => NULL() ! Pointer to a history dimension structure
@@ -656,6 +660,9 @@ contains
     pio_file_list_back   => null()
     pio_file_list_front => null()
 
+    ! Init the iodecomp 
+    iodesc_list_top => null()
+
   end subroutine eam_init_pio_subsystem
 !=====================================================================!
   ! Query whether the pio subsystem is inited already
@@ -715,6 +722,8 @@ contains
     type(pio_atm_file_t),pointer     :: pio_atm_file
     type(pio_file_list_t), pointer   :: pio_file_list_ptr
     logical                          :: found
+    type(hist_var_list_t), pointer   :: curr_var_list
+    type(hist_var_t), pointer        :: var
 
     ! Find the pointer for this file
     call lookup_pio_atm_file(trim(fname),pio_atm_file,found,pio_file_list_ptr)
@@ -724,6 +733,19 @@ contains
           call PIO_syncfile(pio_atm_file%pioFileDesc)
         endif
         call PIO_closefile(pio_atm_file%pioFileDesc)
+        pio_atm_file%num_customers = pio_atm_file%num_customers - 1
+
+        ! Remove all variables from this file as customers for the stored pio
+        ! decompostions
+        curr_var_list => pio_atm_file%var_list_top  ! Start with the first variable in the file
+        do while (associated(curr_var_list))
+          var => curr_var_list%var  ! The actual variable pointer
+          if (associated(var)) then
+            ! Remove this variable as a customer of the associated iodesc
+            var%iodesc_list%num_customers = var%iodesc_list%num_customers - 1
+          end if ! associated(var)
+          curr_var_list => curr_var_list%next  ! Move on to the next variable
+        end do ! associated(curr_var_list)
 
         ! Adjust pointers in the pio file list
         if (associated(pio_file_list_ptr%prev)) then
@@ -738,6 +760,10 @@ contains
           ! We're deleting the last item in the lists. Update pio_file_list_back
           pio_file_list_back => pio_file_list_ptr%prev
         endif
+
+        ! Now that we have closed this pio file and purged it from the list we
+        ! can deallocate the structure.
+        deallocate(pio_atm_file)
       else if (pio_atm_file%num_customers .gt. 1) then
         pio_atm_file%num_customers = pio_atm_file%num_customers - 1
       else
@@ -747,7 +773,81 @@ contains
       call errorHandle("PIO ERROR: unable to close file: "//trim(fname)//", was not found",-999)
     end if
 
+    ! Final step, free any pio decompostion memory that is no longer needed.
+    call free_decomp()
+
   end subroutine eam_pio_closefile
+!=====================================================================!
+  ! Helper function to debug list of decomps 
+  subroutine print_decomp()
+    type(iodesc_list_t),   pointer :: iodesc_ptr, next, prev
+
+    integer :: total
+    integer :: cnt 
+    logical :: assoc
+
+    if (associated(iodesc_list_top)) then
+      total = 0
+      cnt   = 0
+      write(*,*) "            PRINT DECOMP            "
+      write(*,*) "            ------------            "
+      write(*,'(8X,A10,A15,A50,A15)') "Location", "Associated?", "IODESC TAG", "# Customers"
+    else
+      write(*,*) "No DECOMP List to print"
+      return
+    end if
+    iodesc_ptr => iodesc_list_top
+    do while(associated(iodesc_ptr))
+      total = total + 1
+      assoc = .false.
+      if (associated(iodesc_ptr%iodesc).and.iodesc_ptr%iodesc_set) then
+        cnt = cnt + 1
+        assoc = .true.
+      end if
+      write(*,'(I3,A5,I10,L15,A50,I15)') total, ": ", iodesc_ptr%location, assoc , trim(iodesc_ptr%tag), iodesc_ptr%num_customers
+      iodesc_ptr => iodesc_ptr%next
+    end do
+    write(*,*) "            total: ", total, ", cnt: ",cnt
+    write(*,*) "            ------------            "
+
+  end subroutine print_decomp
+!=====================================================================!
+!=====================================================================!
+  ! Free pio decomposition memory in PIO for any decompositions that are no
+  ! longer needed.  This is an important memory management step that should be
+  ! taken whenever a file is closed.
+  subroutine free_decomp()
+    use piolib_mod, only: PIO_freedecomp
+    type(iodesc_list_t),   pointer :: iodesc_ptr, next, prev
+
+    ! Free all decompositions from PIO
+    iodesc_ptr => iodesc_list_top
+    do while(associated(iodesc_ptr))
+      next => iodesc_ptr%next
+      if (associated(iodesc_ptr%iodesc).and.iodesc_ptr%iodesc_set) then
+        if (iodesc_ptr%num_customers .eq. 0) then
+          ! Free decomp
+          call pio_freedecomp(pio_subsystem,iodesc_ptr%iodesc)
+          ! Nullify this decomp
+          ! If we are at iodesc_list_top we need to make iodesc_ptr%next the new
+          ! iodesc_list_top:
+          if (associated(iodesc_ptr%prev)) then
+            iodesc_ptr%prev%next => iodesc_ptr%next
+          else
+            ! We are deleting the first item in the list, update
+            ! iodesc_list_front
+            iodesc_list_top => iodesc_ptr%next
+          end if
+          if (associated(iodesc_ptr%next)) then
+            iodesc_ptr%next%prev => iodesc_ptr%prev
+          end if
+          deallocate(iodesc_ptr)
+        end if
+      end if
+      iodesc_ptr => next
+    end do
+
+  end subroutine free_decomp
 !=====================================================================!
   ! Finalize a PIO session within scream.  Close all open files and deallocate
   ! the pio_subsystem session.
@@ -815,7 +915,7 @@ contains
 !=====================================================================!
  ! Determine the unique pio_decomposition for this output grid, if it hasn't
  ! been defined create a new one.
-  subroutine get_decomp(tag,dtype,dimension_len,compdof,iodesc)
+  subroutine get_decomp(tag,dtype,dimension_len,compdof,iodesc_list)
     use piolib_mod, only: pio_initdecomp
     ! TODO: CAM code creates the decomp tag for the user.  Theoretically it is
     ! unique because it is based on dimensions and datatype.  But the tag ends
@@ -826,7 +926,7 @@ contains
     integer, intent(in)       :: dtype            ! Datatype associated with the output
     integer, intent(in)       :: dimension_len(:) ! Array of the dimension lengths for this decomp
     integer, intent(in)       :: compdof(:)       ! The degrees of freedom this rank is responsible for
-    type(io_desc_t), pointer  :: iodesc           ! The pio decomposition that has been found or created
+    type(iodesc_list_t), pointer :: iodesc_list   ! The pio decomposition list that holds this iodesc 
 
     logical                     :: found            ! Whether a decomp has been found among the previously defined decompositions
     type(iodesc_list_t),pointer :: curr, prev       ! Used to toggle through the recursive list of decompositions
@@ -835,12 +935,12 @@ contains
     ! Assign a PIO decomposition to variable, if none exists, create a new one:
     found = .false.
     curr => iodesc_list_top
+    prev => iodesc_list_top
     ! Cycle through all current iodesc to see if the decomp has already been
     ! created
     do while(associated(curr) .and. (.not.found))
       if (trim(tag) == trim(curr%tag)) then
         found = .true.
-        iodesc => curr%iodesc
       else
         prev => curr
         curr => curr%next
@@ -849,14 +949,25 @@ contains
     ! If we didn't find an iodesc then we need to create one
     if (.not.found) then
       curr => prev ! Go back and allocate the new iodesc in curr%next
+      ! We may have no iodesc to begin with, so we need to associate the
+      ! beginning of the list.
+      if(.not.associated(curr)) then
+        allocate(curr)
+        curr%location = 1
+        iodesc_list_top => curr
+      end if
       if(associated(curr%iodesc)) then
         allocate(curr%next)
+        curr%next%prev => curr
         curr => curr%next
         nullify(curr%iodesc)  ! Extra step to ensure clean iodesc
         nullify(curr%next)  ! Extra step to ensure clean iodesc
       end if
       allocate(curr%iodesc)
       curr%tag = trim(tag)
+      if (associated(curr%prev)) then
+        curr%location = prev%location+1
+      end if
       loc_len = size(dimension_len)
       if ( loc_len.eq.1 .and. dimension_len(loc_len).eq.0 ) then
         allocate(curr%iodesc)
@@ -864,8 +975,8 @@ contains
         call pio_initdecomp(pio_subsystem, dtype, dimension_len, compdof, curr%iodesc, rearr=pio_rearranger)
         curr%iodesc_set = .true.
       end if
-      iodesc => curr%iodesc
     end if
+    iodesc_list => curr
 
   end subroutine get_decomp
 !=====================================================================!
@@ -937,10 +1048,12 @@ contains
         ! Assign decomp
         if (hist_var%has_t_dim) then
           loc_len = max(1,hist_var%numdims-1)
-          call get_decomp(hist_var%pio_decomp_tag,hist_var%dtype,hist_var%dimlen(:loc_len),hist_var%compdof,hist_var%iodesc)
+          call get_decomp(hist_var%pio_decomp_tag,hist_var%dtype,hist_var%dimlen(:loc_len),hist_var%compdof,hist_var%iodesc_list)
         else
-          call get_decomp(hist_var%pio_decomp_tag,hist_var%dtype,hist_var%dimlen,hist_var%compdof,hist_var%iodesc)
+          call get_decomp(hist_var%pio_decomp_tag,hist_var%dtype,hist_var%dimlen,hist_var%compdof,hist_var%iodesc_list)
         end if
+        hist_var%iodesc => hist_var%iodesc_list%iodesc
+        hist_var%iodesc_list%num_customers = hist_var%iodesc_list%num_customers + 1  ! Add this variable as a customer of this pio decomposition
       end if
       curr => curr%next
     end do

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -889,7 +889,6 @@ contains
       call eam_pio_closefile(curr_file_ptr%pio_file%filename)
       prev_file_ptr => curr_file_ptr
       curr_file_ptr => curr_file_ptr%next
-      deallocate(prev_file_ptr%pio_file)
       deallocate(prev_file_ptr)
     end do
     ! Free all decompositions from PIO


### PR DESCRIPTION
This commit adds the new subroutine in the scream_scorpio_interface.F90 code,
`free_decomp`, which will free the memory in scorpio for any pio decomposition
that is no longer needed.  This routine is called whenever a file is closed.

There is also some updates to the infrastructure in the scream scorpio interface
to keep track of which PIO decompositions are still in use, and if one is deleted
having it removed from the list of valid pio decomps.

Should address #1621 