### PR TITLE
Fix usage of parallel reduce in field property checks

### DIFF
--- a/components/scream/src/share/property_checks/field_nan_check.cpp
+++ b/components/scream/src/share/property_checks/field_nan_check.cpp
@@ -43,8 +43,7 @@ PropertyCheck::CheckResult FieldNaNCheck::check_impl() const {
   const auto size = layout.size();
 
   int invalid_idx = -1;
-  using space_t = Field::device_t::execution_space;
-  using max_t = Kokkos::Max<int,space_t>;
+  using max_t = Kokkos::Max<int>;
   switch (layout.rank()) {
     case 1:
       {

--- a/components/scream/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/scream/src/share/property_checks/field_within_interval_check.cpp
@@ -59,8 +59,7 @@ PropertyCheck::CheckResult FieldWithinIntervalCheck::check_impl () const
   const auto extents = layout.extents();
   const auto size = layout.size();
 
-  using space_t = typename Field::device_t::execution_space;
-  using minmaxloc_t = Kokkos::MinMaxLoc<nonconst_ST,int,space_t>;
+  using minmaxloc_t = Kokkos::MinMaxLoc<nonconst_ST,int>;
   using minmaxloc_value_t = typename minmaxloc_t::value_type;
   minmaxloc_value_t minmaxloc;
   switch (layout.rank()) {

--- a/components/scream/src/share/tests/field_utils.cpp
+++ b/components/scream/src/share/tests/field_utils.cpp
@@ -45,6 +45,7 @@ TEST_CASE("utils") {
     auto v2 = f2.get_view<Real**>();
     auto dim0 = fid.get_layout().dim(0);
     auto dim1 = fid.get_layout().dim(1);
+    auto am_i_root = comm.am_i_root();
     Kokkos::parallel_for(kt::RangePolicy(0,dim0*dim1),
                          KOKKOS_LAMBDA(int idx) {
       int i = idx / dim1;
@@ -54,7 +55,7 @@ TEST_CASE("utils") {
       int jpack = j / P8::n;
       int jvec = j % P8::n;
       v1(i,jpack)[jvec] = i*dim1+j;
-      if (parallel_test and not comm.am_i_root()) {
+      if (parallel_test and not am_i_root) {
         v1(i,jpack)[jvec] *= -1;
       }
     });


### PR DESCRIPTION
The reducers were templated on the wrong space (device instead of host).