### PR TITLE
SCREAM: run medres ERS test for 9 steps, not 9 days

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -465,7 +465,7 @@ _TESTS = {
         "time"  : "02:00:00",
         "tests" : (
             "SMS_D_Ln2.ne30_ne30.F2000-SCREAMv1-AQP1",
-            "ERS.ne30_ne30.F2010-SCREAMv1",
+            "ERS_Ln9.ne30_ne30.F2010-SCREAMv1",
             )
     },
 


### PR DESCRIPTION
The latest PR made running medres tests in our nightlies a bit too expensive.

Skipping AT, since medres is not run by the AT anyways.