### PR TITLE
SCREAM: do not build diagnostics tests in CIME builds

### DIFF
--- a/components/scream/src/diagnostics/CMakeLists.txt
+++ b/components/scream/src/diagnostics/CMakeLists.txt
@@ -6,4 +6,6 @@ add_library(diagnostics ${DIAGNOSTIC_SRCS})
 target_include_directories(diagnostics PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../share)
 target_link_libraries(diagnostics PUBLIC scream_share)
 
-add_subdirectory(tests)
+if (NOT SCREAM_LIB_ONLY)
+  add_subdirectory(tests)
+endif()


### PR DESCRIPTION
@whannah1 got some link errors because of this. We don't need that folder anyways it in CIME builds, so skip it.