### PR TITLE
Fix v1 mac mic subcycles parameter

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -195,7 +195,7 @@ tweaking their $case/namelist_scream.xml file.
 
     <mac_aero_mic inherit="atm_proc_group">
       <atm_procs_list>(shoc,cldFraction,spa,p3)</atm_procs_list>
-      <Number__of__Subcycles hgrid="ne4np4">6</Number__of__Subcycles>
+      <Number__of__Subcycles hgrid="ne4np4">24</Number__of__Subcycles>
       <Number__of__Subcycles hgrid="ne30np4">6</Number__of__Subcycles>
       <Number__of__Subcycles hgrid="ne120np4">3</Number__of__Subcycles>
       <Number__of__Subcycles hgrid="ne256np4">3</Number__of__Subcycles>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -133,7 +133,7 @@ tweaking their $case/namelist_scream.xml file.
 
     <!-- Basic options for each atm process -->
     <atm_proc_base>
-      <Num__Subcycle__Iterations constraints="gt 0">1</Num__Subcycle__Iterations>
+      <Number__of__Subcycles constraints="gt 0">1</Number__of__Subcycles>
       <Enable__Precondition__Checks type="logical">true</Enable__Precondition__Checks>
       <Enable__Postcondition__Checks type="logical">true</Enable__Postcondition__Checks>
     </atm_proc_base>
@@ -195,7 +195,12 @@ tweaking their $case/namelist_scream.xml file.
 
     <mac_aero_mic inherit="atm_proc_group">
       <atm_procs_list>(shoc,cldFraction,spa,p3)</atm_procs_list>
-      <Num__Subcycle__Iterations>6</Num__Subcycle__Iterations>
+      <Number__of__Subcycles hgrid="ne4np4">6</Number__of__Subcycles>
+      <Number__of__Subcycles hgrid="ne30np4">6</Number__of__Subcycles>
+      <Number__of__Subcycles hgrid="ne120np4">3</Number__of__Subcycles>
+      <Number__of__Subcycles hgrid="ne256np4">3</Number__of__Subcycles>
+      <Number__of__Subcycles hgrid="ne512np4">1</Number__of__Subcycles>
+      <Number__of__Subcycles hgrid="ne1024np4">1</Number__of__Subcycles>
     </mac_aero_mic>
 
     <physics inherit="atm_proc_group">

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -387,6 +387,10 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
 // =========================================================================================
 void SHOCMacrophysics::run_impl (const int dt)
 {
+  EKAT_REQUIRE_MSG (dt<=300,
+      "Error! SHOC is intended to run with a timestep no longer than 5 minutes.\n"
+      "       Please, reduce timestep (perhaps increasing subcycling iteratinos).\n")
+
   const auto nlev_packs  = ekat::npack<Spack>(m_num_levs);
   const auto scan_policy    = ekat::ExeSpaceUtils<KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(m_num_cols, nlev_packs);
   const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -389,7 +389,7 @@ void SHOCMacrophysics::run_impl (const int dt)
 {
   EKAT_REQUIRE_MSG (dt<=300,
       "Error! SHOC is intended to run with a timestep no longer than 5 minutes.\n"
-      "       Please, reduce timestep (perhaps increasing subcycling iteratinos).\n")
+      "       Please, reduce timestep (perhaps increasing subcycling iteratinos).\n");
 
   const auto nlev_packs  = ekat::npack<Spack>(m_num_levs);
   const auto scan_policy    = ekat::ExeSpaceUtils<KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(m_num_cols, nlev_packs);

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/CMakeLists.txt
@@ -17,6 +17,10 @@ CreateUnitTest(homme_shoc_cld_p3_rrtmgp "homme_shoc_cld_p3_rrtmgp.cpp" "${NEED_L
 set (ATM_TIME_STEP 1800)
 SetVarDependingOnTestProfile(NUM_STEPS 2 4 48)  # 1h 2h 24h
 
+# Determine num subcycles needed to keep shoc dt<=300s
+set (SHOC_MAX_DT 300)
+math (EXPR MAC_MIC_SUBCYCLES "(${ATM_TIME_STEP} + ${SHOC_MAX_DT} - 1) / ${SHOC_MAX_DT}")
+
 ## Copy (and configure) yaml files needed by tests
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -20,21 +20,30 @@ Initial Conditions:
     aero_tau_lw: 0.0
 
 atmosphere_processes:
-  atm_procs_list: (homme,shoc,CldFraction,p3,rrtmgp)
+  atm_procs_list: (homme,physics)
   Schedule Type: Sequential
   homme:
     Enable Precondition Checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/homme_shoc_cld_p3_rrtmgp_init_ne2np4.nc
     Moisture: moist
-  shoc:
-    Grid: Physics GLL
-  CldFraction:
-    Grid: Physics GLL
-  p3:
-    Grid: Physics GLL
-  rrtmgp:
-    Grid: Physics GLL
-    active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
+  physics:
+    atm_procs_list: (mac_mic,rrtmgp)
+    Schedule Type: Sequential
+    Type: Group
+    mac_mic:
+      atm_procs_list: (shoc,CldFraction,p3)
+      Schedule Type: Sequential
+      Type: Group
+      Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+      shoc:
+        Grid: Physics GLL
+      CldFraction:
+        Grid: Physics GLL
+      p3:
+        Grid: Physics GLL
+    rrtmgp:
+      Grid: Physics GLL
+      active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 Grids Manager:
   Type: Dynamics Driven

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -17,6 +17,10 @@ CreateUnitTest(homme_shoc_cld_spa_p3_rrtmgp "homme_shoc_cld_spa_p3_rrtmgp.cpp" "
 set (ATM_TIME_STEP 1800)
 SetVarDependingOnTestProfile(NUM_STEPS 2 4 48)  # 1h 2h 24h
 
+# Determine num subcycles needed to keep shoc dt<=300s
+set (SHOC_MAX_DT 300)
+math (EXPR MAC_MIC_SUBCYCLES "(${ATM_TIME_STEP} + ${SHOC_MAX_DT} - 1) / ${SHOC_MAX_DT}")
+
 ## Copy (and configure) yaml files needed by tests
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -16,26 +16,35 @@ Initial Conditions:
     surf_sens_flux: 0.0
 
 atmosphere_processes:
-  atm_procs_list: (homme,shoc,CldFraction,spa,p3,rrtmgp)
+  atm_procs_list: (homme,physics)
   Schedule Type: Sequential
   homme:
     Process Name: Homme
     Enable Precondition Checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/homme_shoc_cld_spa_p3_rrtmgp_init_ne2np4.nc
     Moisture: moist
-  shoc:
-    Grid: Physics GLL
-  CldFraction:
-    Grid: Physics GLL
-  spa:
-    Grid: Physics GLL
-    SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
-  p3:
-    Grid: Physics GLL
-  rrtmgp:
-    Grid: Physics GLL
-    active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
+  physics:
+    atm_procs_list: (mac_aero_mic,rrtmgp)
+    Schedule Type: Sequential
+    Type: Group
+    mac_aero_mic:
+      atm_procs_list: (shoc,CldFraction,spa,p3)
+      Type: Group
+      Schedule Type: Sequential
+      Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+      shoc:
+        Grid: Physics GLL
+      CldFraction:
+        Grid: Physics GLL
+      spa:
+        Grid: Physics GLL
+        SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
+        SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
+      p3:
+        Grid: Physics GLL
+    rrtmgp:
+      Grid: Physics GLL
+      active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 Grids Manager:
   Type: Dynamics Driven

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
@@ -67,6 +67,10 @@ endforeach()
 # Set AD configurable options
 set (ATM_TIME_STEP 300)
 
+# Determine num subcycles needed to keep shoc dt<=300s
+set (SHOC_MAX_DT 300)
+math (EXPR MAC_MIC_SUBCYCLES "(${ATM_TIME_STEP} + ${SHOC_MAX_DT} - 1) / ${SHOC_MAX_DT}")
+
 # Configure yaml input file to run directory
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_baseline.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/input_baseline.yaml)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -21,22 +21,31 @@ Initial Conditions:
     aero_tau_lw: 0.0
 
 atmosphere_processes:
-  atm_procs_list: (homme,shoc,CldFraction,p3,rrtmgp)
+  atm_procs_list: (homme,physics)
   Schedule Type: Sequential
   homme:
     Process Name: Homme
     Enable Precondition Checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/homme_physics_ne2np4.nc
     Moisture: moist
-  shoc:
-    Grid: Physics GLL
-  CldFraction:
-    Grid: Physics GLL
-  p3:
-    Grid: Physics GLL
-  rrtmgp:
-    Grid: Physics GLL
-    active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
+  physics:
+    atm_procs_list: (mac_aero_mic,rrtmgp)
+    Type: Group
+    Schedule Type: Sequential
+    mac_aero_mic:
+      atm_procs_list: (shoc,CldFraction,p3)
+      Type: Group
+      Schedule Type: Sequential
+      Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+      shoc:
+        Grid: Physics GLL
+      CldFraction:
+        Grid: Physics GLL
+      p3:
+        Grid: Physics GLL
+    rrtmgp:
+      Grid: Physics GLL
+      active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 Grids Manager:
   Type: Dynamics Driven

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -21,22 +21,31 @@ Initial Conditions:
     aero_tau_lw: 0.0
 
 atmosphere_processes:
-  atm_procs_list: (homme,shoc,CldFraction,p3,rrtmgp)
+  atm_procs_list: (homme,physics)
   Schedule Type: Sequential
   homme:
     Process Name: Homme
     Enable Precondition Checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/homme_physics_ne2np4.nc
     Moisture: moist
-  shoc:
-    Grid: Physics GLL
-  CldFraction:
-    Grid: Physics GLL
-  p3:
-    Grid: Physics GLL
-  rrtmgp:
-    Grid: Physics GLL
-    active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
+  physics:
+    atm_procs_list: (mac_aero_mic,rrtmgp)
+    Type: Group
+    Schedule Type: Sequential
+    mac_aero_mic:
+      atm_procs_list: (shoc,CldFraction,p3)
+      Type: Group
+      Schedule Type: Sequential
+      Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+      shoc:
+        Grid: Physics GLL
+      CldFraction:
+        Grid: Physics GLL
+      p3:
+        Grid: Physics GLL
+    rrtmgp:
+      Grid: Physics GLL
+      active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 Grids Manager:
   Type: Dynamics Driven

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -16,22 +16,31 @@ Initial Conditions:
   Restart Casename: model_restart
 
 atmosphere_processes:
-  atm_procs_list: (homme,shoc,CldFraction,p3,rrtmgp)
+  atm_procs_list: (homme,physics)
   Schedule Type: Sequential
   homme:
     Process Name: Homme
     Enable Precondition Checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/homme_physics_ne2np4.nc
     Moisture: moist
-  shoc:
-    Grid: Physics GLL
-  CldFraction:
-    Grid: Physics GLL
-  p3:
-    Grid: Physics GLL
-  rrtmgp:
-    Grid: Physics GLL
-    active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
+  physics:
+    atm_procs_list: (mac_aero_mic,rrtmgp)
+    Type: Group
+    Schedule Type: Sequential
+    mac_aero_mic:
+      atm_procs_list: (shoc,CldFraction,p3)
+      Type: Group
+      Schedule Type: Sequential
+      Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+      shoc:
+        Grid: Physics GLL
+      CldFraction:
+        Grid: Physics GLL
+      p3:
+        Grid: Physics GLL
+    rrtmgp:
+      Grid: Physics GLL
+      active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 Grids Manager:
   Type: Dynamics Driven

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/CMakeLists.txt
@@ -12,6 +12,10 @@ CreateUnitTest(shoc_cld_p3_rrtmgp shoc_cld_p3_rrtmgp.cpp "${NEED_LIBS}" LABELS $
 set (ATM_TIME_STEP 1800)
 SetVarDependingOnTestProfile(NUM_STEPS 2 5 48)  # 1h 4h 24h
 
+# Determine num subcycles needed to keep shoc dt<=300s
+set (SHOC_MAX_DT 300)
+math (EXPR MAC_MIC_SUBCYCLES "(${ATM_TIME_STEP} + ${SHOC_MAX_DT} - 1) / ${SHOC_MAX_DT}")
+
 # Ensure test input files are present in the data dir
 GetInputFile(init/shoc_cld_p3_rrtmgp_init_ne2np4.nc)
 

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -10,14 +10,19 @@ Time Stepping:
   Number of Steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (shoc,CldFraction,p3,rrtmgp)
+  atm_procs_list: (mac_mic,rrtmgp)
   Schedule Type: Sequential
-  shoc:
-    Grid: Point Grid
-  CldFraction:
-    Grid: Point Grid
-  p3:
-    Grid: Point Grid
+  mac_mic:
+    atm_procs_list: (shoc,CldFraction,p3)
+    Type: Group
+    Schedule Type: Sequential
+    Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+    shoc:
+      Grid: Point Grid
+    CldFraction:
+      Grid: Point Grid
+    p3:
+      Grid: Point Grid
   rrtmgp:
     Grid: Point Grid
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -12,6 +12,10 @@ CreateUnitTest(shoc_cld_spa_p3_rrtmgp shoc_cld_spa_p3_rrtmgp.cpp "${NEED_LIBS}" 
 set (ATM_TIME_STEP 1800)
 SetVarDependingOnTestProfile(NUM_STEPS 2 5 48)  # 1h 4h 24h
 
+# Determine num subcycles needed to keep shoc dt<=300s
+set (SHOC_MAX_DT 300)
+math (EXPR MAC_MIC_SUBCYCLES "(${ATM_TIME_STEP} + ${SHOC_MAX_DT} - 1) / ${SHOC_MAX_DT}")
+
 # Ensure test input files are present in the data dir
 set (TEST_INPUT_FILES
   init/shoc_cld_spa_p3_rrtmgp_init_ne2np4.nc

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -10,18 +10,23 @@ Time Stepping:
   Number of Steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (shoc,CldFraction,spa,p3,rrtmgp)
+  atm_procs_list: (mac_mic,rrtmgp)
   Schedule Type: Sequential
-  shoc:
-    Grid: Point Grid
-  CldFraction:
-    Grid: Point Grid
-  p3:
-    Grid: Point Grid
-  spa:
-    Grid: Point Grid
-    SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
+  mac_mic:
+    atm_procs_list: (shoc,CldFraction,spa,p3)
+    Type: Group
+    Schedule Type: Sequential
+    Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+    shoc:
+      Grid: Point Grid
+    CldFraction:
+      Grid: Point Grid
+    p3:
+      Grid: Point Grid
+    spa:
+      Grid: Point Grid
+      SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
+      SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
   rrtmgp:
     Grid: Point Grid
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/scream/tests/uncoupled/shoc/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/shoc/CMakeLists.txt
@@ -12,6 +12,10 @@ CreateUnitTest(shoc_standalone "shoc_standalone.cpp" "${NEED_LIBS}" LABELS ${TES
 SetVarDependingOnTestProfile(NUM_STEPS 2 5 48)
 set (ATM_TIME_STEP 1800)
 
+# Determine num subcycles needed to keep shoc dt<=300s
+set (SHOC_MAX_DT 300)
+math (EXPR NUM_SUBCYCLES "(${ATM_TIME_STEP} + ${SHOC_MAX_DT} - 1) / ${SHOC_MAX_DT}")
+
 # Ensure test input files are present in the data dir
 GetInputFile(init/shoc_init_ne2np4.nc)
 

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -12,6 +12,7 @@ Time Stepping:
 atmosphere_processes:
   atm_procs_list: (shoc)
   shoc:
+    Number of Subcycles: ${NUM_SUBCYCLES}
     Grid: Point Grid
 
 Grids Manager:


### PR DESCRIPTION
Namely:

* Make parameter default value resolution dependent
* Fix name of parameter, matching what's used in the C++ code.

I took the resolution dependent values from `components/eam/namelist_files/use_cases/2010_scream_hr.xml`. Please, double check that they are indeed the right ones.

Fix #1657 
Fix #1663 