### PR TITLE
Fix atmosphere diagnostic class

### DIFF
--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.cpp
@@ -11,10 +11,10 @@ AtmosphereDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
 }
 
 // Function to retrieve the diagnostic output which is stored in m_diagnostic_output
-Field AtmosphereDiagnostic::get_diagnostic (const Real dt) {
-  run(dt);
-  auto ts = timestamp();
-  m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
+Field AtmosphereDiagnostic::get_diagnostic () const {
+  EKAT_REQUIRE_MSG (m_diagnostic_output.is_allocated(),
+      "Error! Getting a diagnostic field before it is allocated is suspicious at best.\n"
+      "       We chose to throw an error, but if this is a legit use, please, contact developers.\n");
   return m_diagnostic_output.get_const();
 }
 

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -38,16 +38,17 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // Getting the diagnostic output
-  Field get_diagnostic (const Real dt);
+  Field get_diagnostic () const;
 
+  // Note: this should *hide* base class method, which is fine, since
+  //       it makes no sense to pass dt to a diagnostic.
+  void run () { this->run_impl(0); } // Pass null dt, but should not be used anyways.
   void set_computed_field (const Field& f) final;
   void set_computed_group (const FieldGroup& group) final;
 protected:
 
   // Diagnostics are meant to return a field
   Field m_diagnostic_output;
-
-
 };
 
 // A short name for the factory for atmosphere diagnostics

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -25,6 +25,9 @@ namespace scream
  *    A diagnostic output is meant to be used for OUTPUT or a PROPERTY CHECK.
  */
 
+// TODO: inheriting from AtmosphereProcess is conceptually wrong. It was done
+//       out of convenience, but we should revisit that choice.
+
 class AtmosphereDiagnostic : public AtmosphereProcess
 {
 public:
@@ -40,9 +43,10 @@ public:
   // Getting the diagnostic output
   Field get_diagnostic () const;
 
-  // Note: this should *hide* base class method, which is fine, since
-  //       it makes no sense to pass dt to a diagnostic.
+  // Avoid shadowing the base class method, but allow calling without passing a dummy dt
+  using AtmosphereProcess::run;
   void run () { this->run_impl(0); } // Pass null dt, but should not be used anyways.
+
   void set_computed_field (const Field& f) final;
   void set_computed_group (const FieldGroup& group) final;
 protected:

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -184,7 +184,7 @@ void AtmosphereOutput::run (const std::string& filename, const bool is_write_ste
   // Take care of updating and possibly writing fields.
   for (auto const& name : m_fields_names) {
     // Get all the info for this field.
-    const auto  field = get_field(name);
+    const auto  field = get_field(name,true); // If diagnostic, must evaluate it
     const auto& layout = m_layouts.at(name);
     const auto& dims = layout.dims();
     const auto  rank = layout.rank();
@@ -615,13 +615,16 @@ void AtmosphereOutput::setup_output_file(const std::string& filename)
 // manager.  If not it will next check to see if it is in the list
 // of available diagnostics.  If neither of these two options it
 // will throw an error.
-Field AtmosphereOutput::get_field(const std::string& name)
+Field AtmosphereOutput::get_field(const std::string& name, const bool eval_diagnostic)
 {
   if (m_field_mgr->has_field(name)) {
     return m_field_mgr->get_field(name);
   } else if (m_diagnostics.find(name) != m_diagnostics.end()) {
     const auto& diag = m_diagnostics[name];
-    return diag->get_diagnostic(100.0);
+    if (eval_diagnostic) {
+      diag->run();
+    }
+    return diag->get_diagnostic();
   } else {
     EKAT_ERROR_MSG ("Field " + name + " not found in output field manager or diagnostics list");
   }

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -157,7 +157,7 @@ protected:
   void set_degrees_of_freedom(const std::string& filename);
   std::vector<int> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
-  Field get_field(const std::string& name);
+  Field get_field(const std::string& name, const bool eval_diagnostic = false);
   void set_diagnostics();
 
   // --- Internal variables --- //

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -97,7 +97,9 @@ public:
 
 protected:
 
-  void initialize_impl (const RunType /* run_type */ ) {}
+  void initialize_impl (const RunType /* run_type */ ) {
+    m_diagnostic_output.get_header().get_tracking().update_time_stamp(timestamp());
+  }
 
   void run_impl (const int /* dt */) {
     const auto& v_A  = get_field_in("field_packed").get_view<const Real**,Host>();

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -665,12 +665,13 @@ TEST_CASE ("diagnostics") {
   diag_identity->initialize(t0,RunType::Initial);
   diag_sum->initialize(t0,RunType::Initial);
 
-  // Run the AddOne process for one timestep
-  const int dt = 5;  // Note, none of the diagnostics actually use dt so really can be any value.
-
   // Run the diagnostics
-  const auto& f_identity = diag_identity->get_diagnostic(dt);
-  const auto& f_sum      = diag_sum->get_diagnostic(dt);
+  diag_identity->run();
+  diag_sum->run();
+
+  // Get diagnostics outputs
+  const auto& f_identity = diag_identity->get_diagnostic();
+  const auto& f_sum      = diag_sum->get_diagnostic();
 
   // For the identity diagnostic check that the fields match
   auto v_identity = f_identity.get_view<const Real*,Host>();


### PR DESCRIPTION
The main change of this PR is to allow calling `get_diagnostic` without computing the diagnostic. The get method should only return a handle to the Field computed. If the user needs to compute the diagnostic, they can call `run`.

Another minor mod is to remove the dt argument from `run`, since it's pointless and never used. Technically, the new method `void run()` is simply _shadowing_ the base class one. If one access a diagnostic via pointer to the base class, the base class method will be available. But for the main practical purpose of diagnostics (i.e., I/O), the user will have a pointer to an AtmosphereDiagnostic, which is fine.