### PR TITLE
Remove ne30 aquaplanet test from medres test suite

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -463,7 +463,7 @@ _TESTS = {
     "e3sm_scream_v1_medres" : {
         "time"  : "02:00:00",
         "tests" : (
-            "SMS_D_Ln2.ne30_ne30.F2000-SCREAMv1-AQP1",
+            #  "SMS_D_Ln2.ne30_ne30.F2000-SCREAMv1-AQP1", # Uncomment once IC file for ne30 is ready
             "ERS_Ln9.ne30_ne30.F2010-SCREAMv1",
             )
     },

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -222,7 +222,8 @@ tweaking their $case/namelist_scream.xml file.
     <Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220503.nc</Filename>
     <Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220503.nc</Filename>
     <Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220505.nc</Filename>
-    <Filename COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc</Filename>
+    <Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20211202.nc</Filename>
+    <Filename hgrid="ne30np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne30np4_L128_20211202.nc</Filename>
     <Restart__Casename>${CASE}.scream</Restart__Casename>
   </Initial__Conditions>
 


### PR DESCRIPTION
IC file is only available for 128 levels, which is  still a vert res in the works. Once 128 is tested and working, we can re-enable it.