### PR TITLE
SCREAM: allow to store special name for partitioned dim in a grid

### DIFF
--- a/components/scream/src/dynamics/homme/homme_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/homme_grids_manager.cpp
@@ -119,6 +119,14 @@ build_grids ()
 
   this->alias_grid(pg_name,"Physics");
 
+  // If pg_type is not GLL or physics uses rebalance, we need to change
+  // the name of 'ncol' dim in Physics GLL, since it would clash with
+  // the ncol dim of the physics grid.
+  if (pg_type!="GLL" || pg_rebalance!="None") {
+    auto phys_gll = get_grid_nonconst("Physics GLL");
+    phys_gll->reset_partitioned_dim_name("ncol_d");
+  }
+
   // Clean up temporaries used during grid initialization
   cleanup_grid_init_data_f90 ();
 }

--- a/components/scream/src/share/grid/abstract_grid.hpp
+++ b/components/scream/src/share/grid/abstract_grid.hpp
@@ -97,6 +97,15 @@ public:
   // When running with multiple ranks, fields are partitioned across ranks along this FieldTag
   virtual FieldTag get_partitioned_dim_tag () const = 0;
 
+  // The suffix to be appended to partitioned dim. Useful to distringuish ncols from
+  // a PG2 grid from ncols from a Physics GLL grid. The grids manager can set this to
+  // a non-trivial suffix in case multiple physics grids are present.
+  std::string get_partitioned_dim_name () const { return m_partitioned_dim_name; }
+  bool has_partitioned_dim_name () const { return m_partitioned_dim_name!=""; }
+  void reset_partitioned_dim_name (const std::string& name) {
+    m_partitioned_dim_name = name;
+  }
+
   // The extent of the partitioned dimension, locally and globally
   virtual int get_partitioned_dim_local_size () const = 0;
   virtual int get_partitioned_dim_global_size () const = 0;
@@ -201,6 +210,11 @@ private:
 
   // The MPI comm containing the ranks across which the global mesh is partitioned
   ekat::Comm            m_comm;
+
+  // The suffix to be appended to partitioned dim. Useful to distringuish ncols from
+  // a PG2 grid from ncols from a Physics GLL grid. The grids manager can set this to
+  // a non-trivial suffix in case multiple physics grids are present.
+  std::string           m_partitioned_dim_name = "";
 };
 
 } // namespace scream

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -1,7 +1,9 @@
 #include "share/io/scorpio_input.hpp"
 
-#include "ekat/ekat_parameter_list.hpp"
+#include "share/io/scream_io_utils.hpp"
 #include "share/io/scream_scorpio_interface.hpp"
+
+#include "ekat/ekat_parameter_list.hpp"
 
 #include <memory>
 #include <numeric>
@@ -449,7 +451,10 @@ AtmosphereInput::get_vec_of_dims(const FieldLayout& layout)
   // for those dimensions to be used with IO
   std::vector<std::string> dims_names(layout.rank());
   for (int i=0; i<layout.rank(); ++i) {
-    dims_names[i] = scorpio::get_nc_tag_name(layout.tag(i),layout.dim(i));
+    const auto tag = layout.tag(i);
+    const auto dim = layout.dim(i);
+
+    dims_names[i] = get_io_tag_name(m_io_grid,tag,dim);
   }
 
   return dims_names;

--- a/components/scream/src/share/io/scream_io_utils.cpp
+++ b/components/scream/src/share/io/scream_io_utils.cpp
@@ -75,4 +75,57 @@ std::string find_filename_in_rpointer (
   return filename;
 }
 
+std::string get_nc_tag_name (const FieldTag& t, const int extent) {
+  using namespace ShortFieldTagsNames;
+
+  std::string name = "";
+  switch(t) {
+    case EL:
+      name = "elem";
+      break;
+    case LEV:
+      name = "lev";
+      break;
+    case ILEV:
+      name = "ilev";
+      break;
+    case TL:
+      name = "tl";
+      break;
+    case COL:
+      name = "ncol";
+      break;
+    case GP:
+      name = "gp";
+      break;
+    case CMP:
+      name = "dim" + std::to_string(extent);
+      break;
+    // Added for rrtmgp - TODO revisit this paradigm, see comment in field_tag.hpp
+    case NGAS:
+      name = "ngas";
+      break;
+    case SWBND:
+      name = "swband";
+      break;
+    case LWBND:
+      name = "lwband";
+      break;
+    default:
+      EKAT_ERROR_MSG("Error! Field tag not supported in netcdf files.");
+  }
+
+  return name;
+}
+
+std::string get_io_tag_name (const std::shared_ptr<const AbstractGrid>& io_grid,
+                             const FieldTag tag, const int extent) {
+  // Check if this is a partitioned dim AND io_grid has a special name
+  // for it, otherwise use general utility to get the name
+  const auto is_partitioned = io_grid->get_partitioned_dim_tag()==tag;
+  return is_partitioned && io_grid->has_partitioned_dim_name()
+        ? io_grid->get_partitioned_dim_name()
+        : get_nc_tag_name(tag,extent);
+}
+
 } // namespace scream

--- a/components/scream/src/share/io/scream_io_utils.hpp
+++ b/components/scream/src/share/io/scream_io_utils.hpp
@@ -1,6 +1,7 @@
 #ifndef SCREAM_IO_UTILS_HPP
 #define SCREAM_IO_UTILS_HPP
 
+#include "share/grid/abstract_grid.hpp"
 #include "share/util/scream_time_stamp.hpp"
 #include "ekat/util/ekat_string_utils.hpp"
 #include "ekat/mpi/ekat_comm.hpp"
@@ -40,6 +41,14 @@ inline OutputAvgType str2avg (const std::string& s) {
 
   return OAT::Invalid;
 }
+
+// Given a field dimension tag/extent, returns a uniqe name that scorpio can use.
+// On one hand, the stirngs returned by e2str(const FieldTag&) are different from
+// what existing nc files are already using. On the other hand, in case of PG2
+// physics grid, we need to differentiate the COL tag in pg2 fields vs the COL
+// tag in phys GLL field.
+std::string get_io_tag_name (const std::shared_ptr<const AbstractGrid>& io_grid,
+                             const FieldTag tag, const int extent);
 
 // Mini struct to hold IO frequency info
 struct IOControl {

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -70,65 +70,6 @@ extern "C" {
   int get_dimlen_c2f(const char*&& filename, const char*&& dimname);
 } // extern "C"
 
-// The strings returned by e2str(const FieldTag&) are different from
-// what existing nc files are already using. Besides upper/lower case
-// differences, the column dimension (COL) is 'ncol' in nc files,
-// but we'd like to keep 'COL' when printing our layouts, so we
-// create this other mini helper function to get the name of a tag
-// that is compatible with nc files. Note that tags that make no
-// sense for an nc file are omitted. Namely, all those that have a
-// field-dependent extent, such as vector dimensions. Those have to
-// be "unpacked", storing a separate variable for each slice.
-
-inline std::string get_nc_tag_name (const FieldTag& t, const int extent) {
-  using namespace ShortFieldTagsNames;
-
-  std::string name = "";
-  switch(t) {
-    case EL:
-      name = "elem";
-      break;
-    case LEV:
-      name = "lev";
-      break;
-    case ILEV:
-      name = "ilev";
-      break;
-    case TL:
-      name = "tl";
-      break;
-    case COL:
-      name = "ncol";
-      break;
-    case GP:
-      name = "gp";
-      break;
-    case CMP:
-      name = "dim" + std::to_string(extent);
-      break;
-    // Added for rrtmgp - TODO revisit this paradigm, see comment in field_tag.hpp
-    case NGAS:
-      name = "ngas";
-      break;
-    case SWBND:
-      name = "swband";
-      break;
-    case LWBND:
-      name = "lwband";
-      break;
-    case SWGPT:
-      name = "swgpt";
-      break;
-    case LWGPT:
-      name = "lwgpt";
-      break;
-    default:
-      EKAT_ERROR_MSG("Error! Field tag not supported in netcdf files.");
-  }
-
-  return name;
-}
-
 } // namespace scorpio
 } // namespace scream
 


### PR DESCRIPTION
This allows to use different dim names for pgN and GLL physics grids, so that we can store both fields in the same nc file.

I manually tested this by hacking a bit the dyn_grid_io test, to spoof pg2 data (dof gids, area, lat/lon), and verified the generated nc file has ncols_d instead of ncols as dim name.

Until pg2 is actually supported, this will have little to no impact. But since I had an idea in mind of how to handle `ncols` vs `ncols_d` I decided to flesh it out now.

If AT chokes on this, we can set it to WIP.