### PR TITLE
Add configuration for ne256np4_oRRS18to6v3 v0 grid

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1427,6 +1427,16 @@
       <mask>tx0.1v2</mask>
     </model_grid>
 
+    <model_grid alias="ne256np4_oRRS18to6v3">
+      <grid name="atm">ne256np4</grid>
+      <grid name="lnd">ne256np4</grid>
+      <grid name="ocnice">oRRS18to6v3</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6v3</mask>
+    </model_grid>
+
     <model_grid alias="ne256pg2_r0125_oRRS18to6v3">
       <grid name="atm">ne256np4.pg2</grid>
       <grid name="lnd">r0125</grid>
@@ -2476,6 +2486,14 @@
       <desc>ne1024np4 is Spectral Elem 3km grid:</desc>
     </domain>
 
+    <domain name="ne256np4">
+      <nx>3538946</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne256np4_oRRS18to6v3.220524.nc</file>
+      <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne256np4_oRRS18to6v3.220524.nc</file>
+      <desc>ne256np4 is Spectral Elem 12km grid:</desc>
+    </domain>
+
     <domain name="ne256np4.pg2">
       <nx>1572864</nx>
       <ny>1</ny>
@@ -3366,6 +3384,15 @@
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_360x720cru_mono.190508.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_mono.190508.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_mono.190508.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne256np4" ocn_grid="oRRS18to6v3">
+      <!-- 13km atm /  18to6 ocean, so use bilin for state -->
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne256np4/map_ne256np4_to_oRRS18to6v3_mono.20220523.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne256np4/map_ne256np4_to_oRRS18to6v3_intbilin.20220503.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne256np4/map_ne256np4_to_oRRS18to6v3_intbilin.20220503.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne256np4/map_oRRS18to6v3_to_ne256np4_monotr.20220523.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne256np4/map_oRRS18to6v3_to_ne256np4_monotr.20220523.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne256np4.pg2" ocn_grid="oRRS18to6v3">

--- a/components/eam/bld/config_files/horiz_grid.xml
+++ b/components/eam/bld/config_files/horiz_grid.xml
@@ -59,6 +59,7 @@
 <horiz_grid dyn="se"    hgrid="ne120np4"     ncol="777602"  csne="120" csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne120np4.pg2" ncol="345600"  csne="120" csnp="4" npg="2" />
 <horiz_grid dyn="se"    hgrid="ne240np4"     ncol="3110402" csne="240" csnp="4" npg="0" />
+<horiz_grid dyn="se"    hgrid="ne256np4"     ncol="3538946" csne="256" csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne512np4"     ncol="14155778" csne="512"  csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne1024np4"    ncol="56623106" csne="1024" csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne256np4.pg2" ncol="1572864"  csne="256"  csnp="4" npg="2" />

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1322,8 +1322,8 @@
 <cubed_sphere_map npg="0"> 0 </cubed_sphere_map>
 
 <!-- scream -->
+<cubed_sphere_map hgrid="ne256np4"  npg="0"> 2 </cubed_sphere_map>
 <cubed_sphere_map hgrid="ne512np4"  npg="0"> 2 </cubed_sphere_map>
-<!-- scream -->
 <cubed_sphere_map hgrid="ne1024np4" npg="0"> 2 </cubed_sphere_map>
 
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -152,6 +152,7 @@
 <bnd_topo hgrid="ne240np4" npg="0">atm/cam/topo/USGS-gtopo30_ne240np4_16xconsistentSGH.c20130724.nc</bnd_topo>
 <bnd_topo hgrid="ne512np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne512np4_16xconsistentSGH_20190212.nc</bnd_topo>
 <bnd_topo hgrid="ne1024np4" npg="0">atm/cam/topo/USGS-gtopo30_ne1024np4_16xconsistentSGH_20190528.nc</bnd_topo>
+<bnd_topo hgrid="ne256np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne256np4_16xdel2_consistentSGH_20220429.nc</bnd_topo>
 <bnd_topo hgrid="ne256np4"  npg="2">atm/cam/topo/USGS-gtopo30_ne256np4pg2_16xdel2_20200213.nc</bnd_topo>
 <bnd_topo hgrid="ne512np4"  npg="2">atm/cam/topo/USGS-gtopo30_ne512np4pg2_16xconsistentSGH_20190212_converted.nc</bnd_topo>
 <bnd_topo hgrid="ne1024np4" npg="2">atm/cam/topo/USGS-gtopo30_ne1024np4pg2_16xconsistentSGH_20190528_converted.nc</bnd_topo>

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -119,10 +119,6 @@
 <!-- Settings related to the SCREAM NH dycore -->
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
 <tstep_type> 9 </tstep_type>
-<!-- Settings specific for ne256 configuration -->
-<se_tstep hgrid="ne256np4"> 37.5 </se_tstep>
-<dt_tracer_factor hgrid="ne256np4"> 8 </dt_tracer_factor>
-<hypervis_subcycle_q hgrid="ne256np4"> 8 </hypervis_subcycle_q>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_hr_dyamond2.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_hr_dyamond2.xml
@@ -125,10 +125,6 @@
 <!-- Settings related to the SCREAM NH dycore -->
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
 <tstep_type> 9 </tstep_type>
-<!-- Settings specific for ne256 configuration -->
-<se_tstep hgrid="ne256np4"> 37.5 </se_tstep>
-<dt_tracer_factor hgrid="ne256np4"> 8 </dt_tracer_factor>
-<hypervis_subcycle_q hgrid="ne256np4"> 8 </hypervis_subcycle_q>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/eam/bld/namelist_files/use_cases/aquaplanet_SCREAM-HR.xml
+++ b/components/eam/bld/namelist_files/use_cases/aquaplanet_SCREAM-HR.xml
@@ -122,10 +122,6 @@
 <!-- Settings related to the SCREAM NH dycore -->
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
 <tstep_type> 9 </tstep_type>
-<!-- Settings specific for ne256 configuration -->
-<se_tstep hgrid="ne256np4"> 37.5 </se_tstep>
-<dt_tracer_factor hgrid="ne256np4"> 8 </dt_tracer_factor>
-<hypervis_subcycle_q hgrid="ne256np4"> 8 </hypervis_subcycle_q>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -317,6 +317,10 @@ lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr2000_c190620.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr2000_c190620.nc</fsurdat>
 <fsurdat hgrid="ne240np4"      sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne240np4_simyr2000_c170821.nc</fsurdat>
+<fsurdat hgrid="ne256np4"      sim_year="2000" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_ne256np4_simyr2010_c220518.nc</fsurdat>
+<fsurdat hgrid="ne256np4"      sim_year="2010" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_ne256np4_simyr2010_c220518.nc</fsurdat>
 <fsurdat hgrid="r05"         sim_year="2000" >
 lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr2000_c200624.nc</fsurdat>
 <fsurdat hgrid="r0125"       sim_year="2000" use_crop=".false." >

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1283,7 +1283,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,ne1024np4.pg2,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r2,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2,ne0np4_arcticx4v1.pg2">
+"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,ne256np4,ne1024np4.pg2,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r2,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2,ne0np4_arcticx4v1.pg2">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry>


### PR DESCRIPTION
Add configuration for ne256np4 bigrid with oRRS16to6v3 ocean/ice grid for SCREAMv0. Note that this currently needs an increase on the tolerance of `EPS_AGRID=1e-9`.

[B4B]