### PR TITLE
Add default rad_frequency to v1 and updates to v0 scream nml

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -113,8 +113,12 @@
 <prescribed_aero_cycle_yr>01</prescribed_aero_cycle_yr>
 
 <!-- Do radiation every five minutes for ne1024 -->
-<iradsw hgrid="ne1024np4"> 4 </iradsw>
-<iradlw hgrid="ne1024np4"> 4 </iradlw>
+<iradsw hgrid="ne256np4"> 3 </iradsw>
+<iradlw hgrid="ne256np4"> 3 </iradlw>
+<iradsw hgrid="ne512np4"> 3 </iradsw>
+<iradlw hgrid="ne512np4"> 3 </iradlw>
+<iradsw hgrid="ne1024np4"> 3 </iradsw>
+<iradlw hgrid="ne1024np4"> 3 </iradlw>
 
 <!-- Settings related to the SCREAM NH dycore -->
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
@@ -123,6 +127,11 @@
 <se_tstep hgrid="ne256np4"> 37.5 </se_tstep>
 <dt_tracer_factor hgrid="ne256np4"> 8 </dt_tracer_factor>
 <hypervis_subcycle_q hgrid="ne256np4"> 8 </hypervis_subcycle_q>
+<!-- Settings specific for ne1024 configuration -->
+<se_tstep hgrid="ne1024np4"> 8.333333333333333d0 </se_tstep>
+<dt_remap_factor hgrid="ne1024np4"> 6 </dt_remap_factor>
+<dt_tracer_factor hgrid="ne1024np4"> 6 </dt_tracer_factor>
+<hypervis_subcycle_q hgrid="ne1024np4"> 6 </hypervis_subcycle_q>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_hr_dyamond2.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_hr_dyamond2.xml
@@ -119,8 +119,12 @@
 <prescribed_aero_cycle_yr>01</prescribed_aero_cycle_yr>
 
 <!-- Do radiation every five minutes for ne1024 -->
-<iradsw hgrid="ne1024np4"> 4 </iradsw>
-<iradlw hgrid="ne1024np4"> 4 </iradlw>
+<iradsw hgrid="ne256np4"> 3 </iradsw>
+<iradlw hgrid="ne256np4"> 3 </iradlw>
+<iradsw hgrid="ne512np4"> 3 </iradsw>
+<iradlw hgrid="ne512np4"> 3 </iradlw>
+<iradsw hgrid="ne1024np4"> 3 </iradsw>
+<iradlw hgrid="ne1024np4"> 3 </iradlw>
 
 <!-- Settings related to the SCREAM NH dycore -->
 <theta_hydrostatic_mode>.false.</theta_hydrostatic_mode>
@@ -129,6 +133,11 @@
 <se_tstep hgrid="ne256np4"> 37.5 </se_tstep>
 <dt_tracer_factor hgrid="ne256np4"> 8 </dt_tracer_factor>
 <hypervis_subcycle_q hgrid="ne256np4"> 8 </hypervis_subcycle_q>
+<!-- Settings specific for ne1024 configuration -->
+<se_tstep hgrid="ne1024np4"> 8.333333333333333d0 </se_tstep>
+<dt_remap_factor hgrid="ne1024np4"> 6 </dt_remap_factor>
+<dt_tracer_factor hgrid="ne1024np4"> 6 </dt_tracer_factor>
+<hypervis_subcycle_q hgrid="ne1024np4"> 6 </hypervis_subcycle_q>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -125,8 +125,12 @@
 <prescribed_aero_cycle_yr>01</prescribed_aero_cycle_yr>
 
 <!-- Do radiation every five minutes for ne1024 -->
-<iradsw hgrid="ne1024np4"> 4 </iradsw>
-<iradlw hgrid="ne1024np4"> 4 </iradlw>
+<iradsw hgrid="ne256np4"> 3 </iradsw>
+<iradlw hgrid="ne256np4"> 3 </iradlw>
+<iradsw hgrid="ne512np4"> 3 </iradsw>
+<iradlw hgrid="ne512np4"> 3 </iradlw>
+<iradsw hgrid="ne1024np4"> 3 </iradsw>
+<iradlw hgrid="ne1024np4"> 3 </iradlw>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_lr_dyamond2.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_lr_dyamond2.xml
@@ -127,8 +127,12 @@
 <prescribed_aero_cycle_yr>01</prescribed_aero_cycle_yr>
 
 <!-- Do radiation every five minutes for ne1024 -->
-<iradsw hgrid="ne1024np4"> 4 </iradsw>
-<iradlw hgrid="ne1024np4"> 4 </iradlw>
+<iradsw hgrid="ne256np4"> 3 </iradsw>
+<iradlw hgrid="ne256np4"> 3 </iradlw>
+<iradsw hgrid="ne512np4"> 3 </iradsw>
+<iradlw hgrid="ne512np4"> 3 </iradlw>
+<iradsw hgrid="ne1024np4"> 3 </iradsw>
+<iradlw hgrid="ne1024np4"> 3 </iradlw>
 
 <!-- Use the less sensitive advection scheme -->
 <semi_lagrange_cdr_alg>3</semi_lagrange_cdr_alg>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -191,6 +191,12 @@ tweaking their $case/namelist_scream.xml file.
       <Orbital__Obliquity COMPSET=".*SCREAM%AQUA.*">0</Orbital__Obliquity>
       <Orbital__MVELP>-9999</Orbital__MVELP>
       <Orbital__MVELP COMPSET=".*SCREAM%AQUA.*">0</Orbital__MVELP>
+      <rad_frequency hgrid="ne4np4">1</rad_frequency>
+      <rad_frequency hgrid="ne30np4">2</rad_frequency>
+      <rad_frequency hgrid="ne120np4">4</rad_frequency>
+      <rad_frequency hgrid="ne256np4">3</rad_frequency>
+      <rad_frequency hgrid="ne512np4">3</rad_frequency>
+      <rad_frequency hgrid="ne1024np4">3</rad_frequency>
     </rrtmgp>
 
     <mac_aero_mic inherit="atm_proc_group">


### PR DESCRIPTION
This PR 
* adds `rrtmgp::rad_frequency` to `namelist_defaults_scream.xml` and provides default values for ne4, ne30, ne120, ne256, ne512, and ne1024 simulations. 
* makes consistent changes to scream v0 compsets (at least for higher rez sims)
* makes the se_tstep changes consistent with updated NCPL for ne1024.