### PR TITLE
Summit machine configuration and jsrun fixes

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -561,8 +561,9 @@
        <directive>-alloc_flags "gpumps smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}"</directive>
      </directives>
      <queues>
-       <queue walltimemax="24:00" nodemin="1" nodemax="4608" strict="true" default="true">batch</queue>
-       <queue walltimemax="24:00" nodemin="1" nodemax="54" strict="true" default="false">batch-hm</queue>
+       <queue walltimemax="02:00" nodemin="1" nodemax="4608" strict="true" default="true">batch</queue>
+       <queue walltimemax="02:00" nodemin="1" nodemax="54" strict="true" default="false">batch-hm</queue>
+       <queue walltimemax="02:00" nodemin="1" nodemax="91" strict="true" default="false">killable</queue>
        <queue walltimemax="02:00" nodemin="1" nodemax="4608" strict="true" default="false">debug</queue>
      </queues>
    </batch_system>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3490,11 +3490,11 @@
     <SUPPORTED_BY>e3sm</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>84</MAX_TASKS_PER_NODE>
     <MAX_TASKS_PER_NODE compiler="pgigpu">18</MAX_TASKS_PER_NODE>
-    <MAX_TASKS_PER_NODE compiler="gnugpu">42</MAX_TASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE compiler="gnugpu">6</MAX_TASKS_PER_NODE>
     <MAX_TASKS_PER_NODE compiler="ibmgpu">42</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>84</MAX_MPITASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE compiler="pgigpu">18</MAX_MPITASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE compiler="gnugpu">42</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE compiler="gnugpu">6</MAX_MPITASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE compiler="ibmgpu">42</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="spectrum-mpi">
@@ -3539,7 +3539,7 @@
         <command name="load">cuda/10.1.243</command>
       </modules>
       <modules compiler="gnugpu">
-        <command name="load">cuda/11.5.2</command>
+	   <command name="load">cuda/10.1.168</command>
       </modules>
       <modules compiler="ibm.*">
         <command name="load">xl/16.1.1-10</command>
@@ -3548,7 +3548,7 @@
         <command name="load">cuda/10.1.243</command>
       </modules>
       <modules compiler="gnu.*">
-        <command name="load">gcc/9.3.0</command>
+        <command name="load">gcc/7.5.0</command>
       </modules>
       <modules>
         <command name="load">spectrum-mpi/10.4.0.3-20210112</command>
@@ -3614,11 +3614,11 @@
       <env name="NUM_RS">$SHELL{echo "6*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
     </environment_variables>
     <environment_variables compiler="gnugpu">
-      <env name="RS_PER_NODE">6</env>
-      <env name="CPU_PER_RS">7</env>
+      <env name="RS_PER_NODE">$SHELL{if [  `./xmlquery --value TOTAL_TASKS` -le 6 ];then echo  `./xmlquery --value  TOTAL_TASKS`; else echo 6; fi} </env>
+      <env name="CPU_PER_RS">1</env>
       <env name="GPU_PER_RS">1</env>
       <env name="LTC_PRT">gpu-cpu</env>
-      <env name="NUM_RS">$SHELL{echo "6*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
+	  <env name="NUM_RS">$SHELL{ if [ `./xmlquery --value TOTAL_TASKS` -le 6 ];then echo `./xmlquery --value TOTAL_TASKS`; else echo "6*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc; fi}</env>
     </environment_variables>
   </machine>
 


### PR DESCRIPTION
This PR fixes jsrun arguments (--nrs etc.) for small number of tasks. Previously, jsrun always tried to use 6 resource sets per node even when NTASKS<6. This is an immediate fix that helps debugging at smaller scale. 
I would plan for a more robust fix (other edge cases - non-multiples of 6) in the future.

This PR also includes the best known modules (gcc and cuda) and customizes various CIME settings specifically for SCREAM workloads. Specifically, we use 1 process per GPU (so CPU_PER_RS=GPU_PER_RS=1)

Testing:
I was able to get the latest master to build and run a ne30 case successfully on 32 nodes (192 tasks).

Following timers are `wallmax` from `HommeTime_stats` file.
```
Timer name   : seconds
CPL:ATM_RUN  : 64.616
CPL:RUN_LOOP : 73.535
```

jsrun:
```
jsrun -X 1 --nrs 192 --rs_per_host 6 --tasks_per_rs 1 -d plane:1 --cpu_per_rs 1 --gpu_per_rs 1 --bind packed:smt:1 --latency_priority gpu-cpu --stdio_mode prepended   --smpiargs="-gpu" /gpfs/alpine/cli115/proj-shared/sarat/e3sm_scratch/n1/bld/e3sm.exe   >> e3sm.log.$LID 2>&1
 
 ```
 
cc @PeterCaldwell @mt5555 