### PR TITLE
This commit fixes the restart_vs_monolithic unit test.

### DIFF
--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -50,9 +50,4 @@ Grids Manager:
 # List all the yaml files with the output parameters
 Scorpio:
   Output YAML Files: ["model_restart_output.yaml"]
-  Model Restart:
-    Casename: model_restart
-    Output Control:
-      Frequency:       1
-      Frequency Units: Steps
 ...


### PR DESCRIPTION
Restarted runs in the test inadvertantly overwrote the rpointer.atm
file so when tests were run in parallel they would sometimes fail.