### PR TITLE
Add default layouts for pm-cpu,pm-gpu,cori-knl on ne30np4 resolutions

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1961,6 +1961,69 @@
       </pes>
     </mach>
   </grid>
+  <grid name="a%ne30np4_">
+    <mach name="pm-gpu">
+      <pes compset="any" pesize="any">
+        <comment>"pm-gpu ne30np4 2 nodes"</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_cpl>-2</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="pm-cpu">
+      <pes compset="any" pesize="any">
+        <comment>"pm-gpu ne30np4 2 nodes 2 threads"</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_cpl>-2</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_cpl>2</nthrds_cpl>
+        </nthrds>        
+      </pes>
+    </mach>
+    <mach name="cori-knl">
+      <pes compset="any" pesize="any">
+        <comment>"cori-knl ne30np4 4 nodes 2 threads"</comment>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_cpl>2</nthrds_cpl>
+        </nthrds>        
+      </pes>
+    </mach>
+  </grid>  
   <grid name="a%ne0np4_northamericax4v1.pg2_l%.+_oi%WC14to60E2r3">
     <mach name="compy">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="S">


### PR DESCRIPTION
For any ne30np4 resolution:
On Perlmutter, use 2 nodes
On cori-knl, use 4 nodes.

Tried the following tests to verify it uses expected nodes (and does not run out of memory):
```
SMS_D_Ln12.ne30_ne30.F2010-SCREAMv1.pm-cpu_gnu
ERS_Ln9.ne30_ne30.F2010-SCREAMv1.pm-cpu_gnu

SMS_D_Ln12.ne30_ne30.F2010-SCREAMv1.pm-gpu_gnugpu

SMS_D_Ln12.ne30_ne30.F2010-SCREAMv1.cori-knl_intel
ERS_Ln9.ne30_ne30.F2010-SCREAMv1.cori-knl_intel
```