### PR TITLE
Use non-hydrostatic mode by default for SCREAMv1

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -321,8 +321,8 @@ tweaking their $case/namelist_scream.xml file.
     <se_tstep hgrid="ne1024np4" constraints="gt 0">8.3333333333333</se_tstep>
     <statefreq>9999</statefreq>
     <theta_advect_form>1</theta_advect_form>
-    <theta_hydrostatic_mode>True</theta_hydrostatic_mode>
-    <tstep_type>5</tstep_type>
+    <theta_hydrostatic_mode>False</theta_hydrostatic_mode>
+    <tstep_type>9</tstep_type>
     <vert_remap_q_alg>10</vert_remap_q_alg>
     <transport_alg>0</transport_alg>
   </ctl_nl>


### PR DESCRIPTION
Use non-hydrostatic mode by default for SCREAMv1. As SCREAMv1 is meant to target higher (cloud-permitting) resolutions, and does not yet have a deep convective parameterization, it makes the most sense to use non-hydrostatic mode for these simulations by default. We might condition this on either compset or resolution in the future once we have a deep convective parameterization available for the lower resolutions.

[non-B4B] (for CIME cases).