### PR TITLE
Add `do_aerosol_rad` as an option for SCREAMv1

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -164,8 +164,8 @@ tweaking their $case/namelist_scream.xml file.
 
     <!-- P3 microphysics -->
     <p3 inherit="physics_proc_base">
-      <do__prescribed__ccn>true</do__prescribed__ccn>
-      <do__predict__nc>true</do__predict__nc>
+      <do_prescribed_ccn>true</do_prescribed__ccn>
+      <do_predic__nc>true</do_predict__nc>
     </p3>
 
     <!-- SHOC macrophysics -->
@@ -200,7 +200,7 @@ tweaking their $case/namelist_scream.xml file.
       <rad_frequency hgrid="ne256np4">3</rad_frequency>
       <rad_frequency hgrid="ne512np4">3</rad_frequency>
       <rad_frequency hgrid="ne1024np4">3</rad_frequency>
-      <do__aerosol__rad>true</do__aerosol__rad>
+      <do_aerosol_rad>true</do_aerosol_rad>
     </rrtmgp>
 
     <mac_aero_mic inherit="atm_proc_group">

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -164,8 +164,8 @@ tweaking their $case/namelist_scream.xml file.
 
     <!-- P3 microphysics -->
     <p3 inherit="physics_proc_base">
-      <do_prescribed_ccn>true</do_prescribed__ccn>
-      <do_predic__nc>true</do_predict__nc>
+      <do_prescribed_ccn>true</do_prescribed_ccn>
+      <do_predict_nc>true</do_predict_nc>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -200,6 +200,7 @@ tweaking their $case/namelist_scream.xml file.
       <rad_frequency hgrid="ne256np4">3</rad_frequency>
       <rad_frequency hgrid="ne512np4">3</rad_frequency>
       <rad_frequency hgrid="ne1024np4">3</rad_frequency>
+      <do__aerosol__rad>true</do__aerosol__rad>
     </rrtmgp>
 
     <mac_aero_mic inherit="atm_proc_group">

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -163,7 +163,10 @@ tweaking their $case/namelist_scream.xml file.
     </homme>
 
     <!-- P3 microphysics -->
-    <p3 inherit="physics_proc_base"/>
+    <p3 inherit="physics_proc_base">
+      <do__prescribed__ccn>true</do__prescribed__ccn>
+      <do__predict__nc>true</do__predict__nc>
+    </p3>
 
     <!-- SHOC macrophysics -->
     <shoc inherit="physics_proc_base"/>

--- a/components/scream/data/scream_default_output.yaml
+++ b/components/scream/data/scream_default_output.yaml
@@ -6,45 +6,71 @@ Max Snapshots Per File: 744 # One output every 31 days
 Fields:
   Physics GLL:
     Field Names:
-      - T_mid
-      - PotentialTemperature
-      - qv
-      - qc
-      - qr
-      - qi
-      - qm
-      - nc
-      - nr
-      - ni
-      - bm
-      - precip_liq_surf
-      - precip_ice_surf
-      - eff_radius_qc
-      - eff_radius_qi
-      - nccn
-      - ni_activated
-      - nc_nuceat_tend
+      # HOMME
+      - horiz_winds
+      - ps
+      - pseudo_density
+      - omega
+      - p_int
+      - p_mid
+      # SHOC
       - cldfrac_liq
+      - eddy_diff_mom
+      - horiz_winds
+      - sgs_buoy_flux
+      - tke
+      - inv_qc_relvar
+      - pbl_height
+      # CLD
       - cldfrac_ice
       - cldfrac_tot
-      - horiz_winds
-      - tke
-      - eddy_diff_mom
-      - sgs_buoy_flux
-      - pbl_height
-      - LW_flux_up
-      - LW_flux_dn
-      - SW_flux_up
-      - SW_flux_dn
+      # SPA
+      - aero_g_sw
+      - aero_ssa_sw
+      - aero_tau_lw
+      - aero_tau_sw
+      - nccn
+      # P3
+      - bm
+      - nc
+      - ni
+      - nr
+      - qi
+      - qm
+      - qr
+      - T_prev_micro_step
+      - qv_prev_micro_step
+      - eff_radius_qc
+      - eff_radius_qi
+      - micro_liq_ice_exchange
+      - micro_vap_ice_exchange
+      - micro_vap_liq_exchange
+      - precip_ice_surf
+      - precip_liq_surf
+      # SHOC + P3
+      - qc
+      - qv
+      # SHOC + P3 + RRTMGP + HOMME
+      - T_mid
+      # RRTMGP
+      - sfc_alb_dif_nir
+      - sfc_alb_dif_vis
+      - sfc_alb_dir_nir
       - sfc_alb_dir_vis
-      - surf_lw_flux_up
-      - ps
-      - p_mid
-      - omega
-      - pseudo_density
-      - surf_latent_flux
-      - surf_sens_flux
-      - surf_mom_flux
+      - LW_flux_dn
+      - LW_flux_up
+      - SW_flux_dn
+      - SW_flux_dn_dir
+      - SW_flux_up
+      - rad_heating_pdel
+      - sfc_flux_dif_nir
+      - sfc_flux_dif_vis
+      - sfc_flux_dir_nir
+      - sfc_flux_dir_vis
+      - sfc_flux_lw_dn
+      - sfc_flux_sw_net
+      # Diagnostics
+      - PotentialTemperature
 Output Control:
   Frequency: ${HIST_N}
   Frequency Units: ${HIST_OPTION}

--- a/components/scream/data/scream_default_output.yaml
+++ b/components/scream/data/scream_default_output.yaml
@@ -42,9 +42,6 @@ Fields:
       - qv_prev_micro_step
       - eff_radius_qc
       - eff_radius_qi
-      - micro_liq_ice_exchange
-      - micro_vap_ice_exchange
-      - micro_vap_liq_exchange
       - precip_ice_surf
       - precip_liq_surf
       # SHOC + P3

--- a/components/scream/data/scream_default_output.yaml
+++ b/components/scream/data/scream_default_output.yaml
@@ -63,10 +63,6 @@ Fields:
       - SW_flux_dn_dir
       - SW_flux_up
       - rad_heating_pdel
-      - sfc_flux_dif_nir
-      - sfc_flux_dif_vis
-      - sfc_flux_dir_nir
-      - sfc_flux_dir_vis
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
       # Diagnostics

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -309,7 +309,7 @@ public:
     // 1d view scalar, size (ncol)
     static constexpr int num_1d_scalar = 0; //no 2d vars now, but keeping 1d struct for future expansion
     // 2d view packed, size (ncol, nlev_packs)
-    static constexpr int num_2d_vector = 8;
+    static constexpr int num_2d_vector = 9;
     static constexpr int num_2dp1_vector = 2;
 
     uview_2d inv_exner;
@@ -322,6 +322,7 @@ public:
     uview_2d rho_qi;
     uview_2d precip_liq_flux; //nlev+1
     uview_2d precip_ice_flux; //nlev+1
+    uview_2d unused;
 
     suview_2d col_location;
 

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -18,6 +18,7 @@ class RRTMGPRadiation : public AtmosphereProcess {
 public:
   using view_1d_real     = typename ekat::KokkosTypes<DefaultDevice>::template view_1d<Real>;
   using view_2d_real     = typename ekat::KokkosTypes<DefaultDevice>::template view_2d<Real>;
+  using view_3d_real     = typename ekat::KokkosTypes<DefaultDevice>::template view_3d<Real>;
   using ci_string        = ekat::CaseInsensitiveString;
 
   using KT               = ekat::KokkosTypes<DefaultDevice>;
@@ -55,6 +56,9 @@ public:
   int m_nlay;
   view_1d_real m_lat;
   view_1d_real m_lon;
+
+  // Whether we use aerosol forcing in radiation
+  bool m_do_aerosol_rad;
 
   // The orbital year, used for zenith angle calculations:
   // If > 0, use constant orbital year for duration of simulation

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -57,10 +57,6 @@ Fields:
       - SW_flux_dn_dir
       - SW_flux_up
       - rad_heating_pdel
-      - sfc_flux_dif_nir
-      - sfc_flux_dif_vis
-      - sfc_flux_dir_nir
-      - sfc_flux_dir_vis
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
  

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -6,56 +6,63 @@ Max Snapshots Per File: 1
 Fields:
   Physics GLL:
     Field Names:
-      - T_mid
-      - T_prev_micro_step
-      - qv
-      - qc
-      - qr
+      # HOMME
+      - horiz_winds
+      - ps
+      - pseudo_density
+      - omega
+      - p_int
+      - p_mid
+      # SHOC
+      - cldfrac_liq
+      - eddy_diff_mom
+      - horiz_winds
+      - sgs_buoy_flux
+      - tke
+      - inv_qc_relvar
+      - pbl_height
+      # CLD
+      - cldfrac_ice
+      - cldfrac_tot
+      # P3
+      - bm
+      - nc
+      - ni
+      - nr
       - qi
       - qm
-      - nc
-      - nr
-      - ni
-      - bm
+      - qr
+      - T_prev_micro_step
       - qv_prev_micro_step
       - eff_radius_qc
       - eff_radius_qi
       - micro_liq_ice_exchange
-      - micro_vap_liq_exchange
       - micro_vap_ice_exchange
-      - tke
-      - cldfrac_liq
-      - cldfrac_tot
-      - eddy_diff_mom
-      - horiz_winds
-      - sgs_buoy_flux
-      - inv_qc_relvar
-      - pbl_height
-      - LW_flux_up
-      - LW_flux_dn
-      - SW_flux_up
-      - SW_flux_dn
-      - SW_flux_dn_dir
-      - ps
-      - omega
-      - p_int
-      - p_mid
-      - phis
-      - pseudo_density
-      - surf_latent_flux
-      - surf_mom_flux
-      - surf_sens_flux
-      - cldfrac_ice
-      - nccn
-      - ni_activated
-      - nc_nuceat_tend
-      - eff_radius_qc
-      - eff_radius_qi
-      - sfc_alb_dir_nir
-      - sfc_alb_dir_vis
+      - micro_vap_liq_exchange
+      - precip_ice_surf
+      - precip_liq_surf
+      # SHOC + P3
+      - qc
+      - qv
+      # SHOC + P3 + RRTMGP + HOMME
+      - T_mid
+      # RRTMGP
       - sfc_alb_dif_nir
       - sfc_alb_dif_vis
-      - surf_lw_flux_up
+      - sfc_alb_dir_nir
+      - sfc_alb_dir_vis
+      - LW_flux_dn
+      - LW_flux_up
+      - SW_flux_dn
+      - SW_flux_dn_dir
+      - SW_flux_up
+      - rad_heating_pdel
+      - sfc_flux_dif_nir
+      - sfc_flux_dif_vis
+      - sfc_flux_dir_nir
+      - sfc_flux_dir_vis
+      - sfc_flux_lw_dn
+      - sfc_flux_sw_net
  
 Output Control:
   Frequency: ${NUM_STEPS}

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -14,10 +14,6 @@ Initial Conditions:
   Physics GLL:
     surf_latent_flux: 0.0
     surf_sens_flux: 0.0
-    aero_g_sw: 0.0
-    aero_ssa_sw: 0.0
-    aero_tau_sw: 0.0
-    aero_tau_lw: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)
@@ -41,9 +37,11 @@ atmosphere_processes:
         Grid: Physics GLL
       p3:
         Grid: Physics GLL
+        do_prescribed_ccn: false
     rrtmgp:
       Grid: Physics GLL
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
+      do_aerosol_rad: false
 
 Grids Manager:
   Type: Dynamics Driven

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -63,10 +63,6 @@ Fields:
       - SW_flux_dn_dir
       - SW_flux_up
       - rad_heating_pdel
-      - sfc_flux_dif_nir
-      - sfc_flux_dif_vis
-      - sfc_flux_dir_nir
-      - sfc_flux_dir_vis
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
  

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -6,60 +6,69 @@ Max Snapshots Per File: 1
 Fields:
   Physics GLL:
     Field Names:
-      - T_mid
-      - T_prev_micro_step
-      - qv
-      - qc
-      - qr
-      - qi
-      - qm
-      - nc
-      - nr
-      - ni
-      - bm
-      - qv_prev_micro_step
-      - eff_radius_qc
-      - eff_radius_qi
-      - micro_liq_ice_exchange
-      - micro_vap_liq_exchange
-      - micro_vap_ice_exchange
-      - tke
-      - cldfrac_liq
-      - cldfrac_tot
-      - eddy_diff_mom
+      # HOMME
       - horiz_winds
-      - sgs_buoy_flux
-      - inv_qc_relvar
-      - pbl_height
-      - LW_flux_up
-      - LW_flux_dn
-      - SW_flux_up
-      - SW_flux_dn
-      - SW_flux_dn_dir
       - ps
+      - pseudo_density
       - omega
       - p_int
       - p_mid
-      - phis
-      - pseudo_density
-      - surf_latent_flux
-      - surf_mom_flux
-      - surf_sens_flux
+      # SHOC
+      - cldfrac_liq
+      - eddy_diff_mom
+      - horiz_winds
+      - sgs_buoy_flux
+      - tke
+      - inv_qc_relvar
+      - pbl_height
+      # CLD
       - cldfrac_ice
-      - nccn
-      - ni_activated
-      - nc_nuceat_tend
-      - eff_radius_qc
-      - eff_radius_qi
-      - sfc_alb_dir_nir
-      - sfc_alb_dir_vis
-      - sfc_alb_dif_nir
-      - sfc_alb_dif_vis
-      - surf_lw_flux_up
+      - cldfrac_tot
+      # SPA
       - aero_g_sw
       - aero_ssa_sw
       - aero_tau_lw
       - aero_tau_sw
+      - nccn
+      # P3
+      - bm
+      - nc
+      - ni
+      - nr
+      - qi
+      - qm
+      - qr
+      - T_prev_micro_step
+      - qv_prev_micro_step
+      - eff_radius_qc
+      - eff_radius_qi
+      - micro_liq_ice_exchange
+      - micro_vap_ice_exchange
+      - micro_vap_liq_exchange
+      - precip_ice_surf
+      - precip_liq_surf
+      # SHOC + P3
+      - qc
+      - qv
+      # SHOC + P3 + RRTMGP + HOMME
+      - T_mid
+      # RRTMGP
+      - sfc_alb_dif_nir
+      - sfc_alb_dif_vis
+      - sfc_alb_dir_nir
+      - sfc_alb_dir_vis
+      - LW_flux_dn
+      - LW_flux_up
+      - SW_flux_dn
+      - SW_flux_dn_dir
+      - SW_flux_up
+      - rad_heating_pdel
+      - sfc_flux_dif_nir
+      - sfc_flux_dif_vis
+      - sfc_flux_dir_nir
+      - sfc_flux_dir_vis
+      - sfc_flux_lw_dn
+      - sfc_flux_sw_net
  
 Output Control:
   Frequency: ${NUM_STEPS}

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
@@ -63,10 +63,6 @@ Fields:
       - SW_flux_dn_dir
       - SW_flux_up
       - rad_heating_pdel
-      - sfc_flux_dif_nir
-      - sfc_flux_dif_vis
-      - sfc_flux_dir_nir
-      - sfc_flux_dir_vis
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
  

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
@@ -6,60 +6,69 @@ Max Snapshots Per File: 1
 Fields:
   Physics GLL:
     Field Names:
-      - T_mid
-      - T_prev_micro_step
-      - qv
-      - qc
-      - qr
-      - qi
-      - qm
-      - nc
-      - nr
-      - ni
-      - bm
-      - qv_prev_micro_step
-      - eff_radius_qc
-      - eff_radius_qi
-      - micro_liq_ice_exchange
-      - micro_vap_liq_exchange
-      - micro_vap_ice_exchange
-      - tke
-      - cldfrac_liq
-      - cldfrac_tot
-      - eddy_diff_mom
+      # HOMME
       - horiz_winds
-      - sgs_buoy_flux
-      - inv_qc_relvar
-      - pbl_height
-      - LW_flux_up
-      - LW_flux_dn
-      - SW_flux_up
-      - SW_flux_dn
-      - SW_flux_dn_dir
       - ps
+      - pseudo_density
       - omega
       - p_int
       - p_mid
-      - phis
-      - pseudo_density
-      - surf_latent_flux
-      - surf_mom_flux
-      - surf_sens_flux
+      # SHOC
+      - cldfrac_liq
+      - eddy_diff_mom
+      - horiz_winds
+      - sgs_buoy_flux
+      - tke
+      - inv_qc_relvar
+      - pbl_height
+      # CLD
       - cldfrac_ice
-      - nccn
-      - ni_activated
-      - nc_nuceat_tend
-      - eff_radius_qc
-      - eff_radius_qi
-      - sfc_alb_dir_nir
-      - sfc_alb_dir_vis
-      - sfc_alb_dif_nir
-      - sfc_alb_dif_vis
-      - surf_lw_flux_up
+      - cldfrac_tot
+      # SPA
       - aero_g_sw
       - aero_ssa_sw
       - aero_tau_lw
       - aero_tau_sw
+      - nccn
+      # P3
+      - bm
+      - nc
+      - ni
+      - nr
+      - qi
+      - qm
+      - qr
+      - T_prev_micro_step
+      - qv_prev_micro_step
+      - eff_radius_qc
+      - eff_radius_qi
+      - micro_liq_ice_exchange
+      - micro_vap_ice_exchange
+      - micro_vap_liq_exchange
+      - precip_ice_surf
+      - precip_liq_surf
+      # SHOC + P3
+      - qc
+      - qv
+      # SHOC + P3 + RRTMGP + HOMME
+      - T_mid
+      # RRTMGP
+      - sfc_alb_dif_nir
+      - sfc_alb_dif_vis
+      - sfc_alb_dir_nir
+      - sfc_alb_dir_vis
+      - LW_flux_dn
+      - LW_flux_up
+      - SW_flux_dn
+      - SW_flux_dn_dir
+      - SW_flux_up
+      - rad_heating_pdel
+      - sfc_flux_dif_nir
+      - sfc_flux_dif_vis
+      - sfc_flux_dir_nir
+      - sfc_flux_dir_vis
+      - sfc_flux_lw_dn
+      - sfc_flux_sw_net
  
 Output Control:
   Frequency: ${NUM_STEPS}

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -14,11 +14,6 @@ Time Stepping:
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   Restart Run: false
-  Physics GLL:
-    aero_g_sw: 0.0
-    aero_ssa_sw: 0.0
-    aero_tau_sw: 0.0
-    aero_tau_lw: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)
@@ -43,9 +38,11 @@ atmosphere_processes:
         Grid: Physics GLL
       p3:
         Grid: Physics GLL
+        do_prescribed_ccn: false
     rrtmgp:
       Grid: Physics GLL
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
+      do_aerosol_rad: false
 
 Grids Manager:
   Type: Dynamics Driven

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -14,11 +14,6 @@ Time Stepping:
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   Restart Run: false
-  Physics GLL:
-    aero_g_sw: 0.0
-    aero_ssa_sw: 0.0
-    aero_tau_sw: 0.0
-    aero_tau_lw: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)
@@ -43,9 +38,11 @@ atmosphere_processes:
         Grid: Physics GLL
       p3:
         Grid: Physics GLL
+        do_prescribed_ccn: false
     rrtmgp:
       Grid: Physics GLL
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
+      do_aerosol_rad: false
 
 Grids Manager:
   Type: Dynamics Driven

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -38,9 +38,11 @@ atmosphere_processes:
         Grid: Physics GLL
       p3:
         Grid: Physics GLL
+        do_prescribed_ccn: false
     rrtmgp:
       Grid: Physics GLL
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
+      do_aerosol_rad: false
 
 Grids Manager:
   Type: Dynamics Driven

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/model_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/model_output.yaml
@@ -57,10 +57,6 @@ Fields:
       - SW_flux_dn_dir
       - SW_flux_up
       - rad_heating_pdel
-      - sfc_flux_dif_nir
-      - sfc_flux_dif_vis
-      - sfc_flux_dir_nir
-      - sfc_flux_dir_vis
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
   Dynamics:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/model_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/model_output.yaml
@@ -6,26 +6,63 @@ Max Snapshots Per File: 1
 Fields:
   Physics GLL:
     Field Names:
-      - T_mid
+      # HOMME
       - horiz_winds
+      - ps
+      - pseudo_density
+      - omega
       - p_int
       - p_mid
-      - pseudo_density
-      - tke
+      # SHOC
       - cldfrac_liq
+      - eddy_diff_mom
+      - horiz_winds
+      - sgs_buoy_flux
+      - tke
+      - inv_qc_relvar
+      - pbl_height
+      # CLD
       - cldfrac_ice
-      - qv
-      - qc
-      - qr
+      - cldfrac_tot
+      # P3
+      - bm
+      - nc
+      - ni
+      - nr
       - qi
       - qm
-      - nc
-      - nr
-      - ni
+      - qr
+      - T_prev_micro_step
+      - qv_prev_micro_step
+      - eff_radius_qc
+      - eff_radius_qi
+      - micro_liq_ice_exchange
+      - micro_vap_ice_exchange
+      - micro_vap_liq_exchange
+      - precip_ice_surf
+      - precip_liq_surf
+      # SHOC + P3
+      - qc
+      - qv
+      # SHOC + P3 + RRTMGP + HOMME
+      - T_mid
+      # RRTMGP
+      - sfc_alb_dif_nir
+      - sfc_alb_dif_vis
+      - sfc_alb_dir_nir
+      - sfc_alb_dir_vis
       - LW_flux_dn
       - LW_flux_up
       - SW_flux_dn
+      - SW_flux_dn_dir
       - SW_flux_up
+      - rad_heating_pdel
+      - sfc_flux_dif_nir
+      - sfc_flux_dif_vis
+      - sfc_flux_dir_nir
+      - sfc_flux_dir_vis
+      - sfc_flux_lw_dn
+      - sfc_flux_sw_net
   Dynamics:
     Field Names:
       - Qdp_dyn

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
@@ -57,10 +57,6 @@ Fields:
       - SW_flux_dn_dir
       - SW_flux_up
       - rad_heating_pdel
-      - sfc_flux_dif_nir
-      - sfc_flux_dif_vis
-      - sfc_flux_dir_nir
-      - sfc_flux_dir_vis
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
   Dynamics:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
@@ -6,26 +6,63 @@ Max Snapshots Per File: 1
 Fields:
   Physics GLL:
     Field Names:
-      - T_mid
+      # HOMME
       - horiz_winds
+      - ps
+      - pseudo_density
+      - omega
       - p_int
       - p_mid
-      - pseudo_density
-      - tke
+      # SHOC
       - cldfrac_liq
+      - eddy_diff_mom
+      - horiz_winds
+      - sgs_buoy_flux
+      - tke
+      - inv_qc_relvar
+      - pbl_height
+      # CLD
       - cldfrac_ice
-      - qv
-      - qc
-      - qr
+      - cldfrac_tot
+      # P3
+      - bm
+      - nc
+      - ni
+      - nr
       - qi
       - qm
-      - nc
-      - nr
-      - ni
+      - qr
+      - T_prev_micro_step
+      - qv_prev_micro_step
+      - eff_radius_qc
+      - eff_radius_qi
+      - micro_liq_ice_exchange
+      - micro_vap_ice_exchange
+      - micro_vap_liq_exchange
+      - precip_ice_surf
+      - precip_liq_surf
+      # SHOC + P3
+      - qc
+      - qv
+      # SHOC + P3 + RRTMGP + HOMME
+      - T_mid
+      # RRTMGP
+      - sfc_alb_dif_nir
+      - sfc_alb_dif_vis
+      - sfc_alb_dir_nir
+      - sfc_alb_dir_vis
       - LW_flux_dn
       - LW_flux_up
       - SW_flux_dn
+      - SW_flux_dn_dir
       - SW_flux_up
+      - rad_heating_pdel
+      - sfc_flux_dif_nir
+      - sfc_flux_dif_vis
+      - sfc_flux_dir_nir
+      - sfc_flux_dir_vis
+      - sfc_flux_lw_dn
+      - sfc_flux_sw_net
   Dynamics:
     Field Names:
       - Qdp_dyn

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -23,10 +23,12 @@ atmosphere_processes:
       Grid: Point Grid
     p3:
       Grid: Point Grid
+      do_prescribed_ccn: false
   rrtmgp:
     Grid: Point Grid
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
+    do_aerosol_rad: false
 
 Grids Manager:
   Type: Mesh Free
@@ -41,10 +43,6 @@ Initial Conditions:
     Load Longitude: true
     surf_latent_flux: 0.0
     surf_sens_flux: 0.0
-    aero_g_sw: 0.0
-    aero_ssa_sw: 0.0
-    aero_tau_sw: 0.0
-    aero_tau_lw: 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
@@ -4,56 +4,56 @@ Casename: shoc_cld_p3_rrtmgp_output
 Averaging Type: Instant
 Max Snapshots Per File: 1
 Field Names:
-  - T_mid
-  - T_prev_micro_step
-  - qv
-  - qc
-  - qr
+  # SHOC
+  - cldfrac_liq
+  - eddy_diff_mom
+  - horiz_winds
+  - sgs_buoy_flux
+  - tke
+  - inv_qc_relvar
+  - pbl_height
+  # CLD
+  - cldfrac_ice
+  - cldfrac_tot
+  # P3
+  - bm
+  - nc
+  - ni
+  - nr
   - qi
   - qm
-  - nc
-  - nr
-  - ni
-  - bm
+  - qr
+  - T_prev_micro_step
   - qv_prev_micro_step
   - eff_radius_qc
   - eff_radius_qi
   - micro_liq_ice_exchange
-  - micro_vap_liq_exchange
   - micro_vap_ice_exchange
-  - tke
-  - cldfrac_liq
-  - cldfrac_tot
-  - eddy_diff_mom
-  - horiz_winds
-  - sgs_buoy_flux
-  - inv_qc_relvar
-  - pbl_height
-  - LW_flux_up
-  - LW_flux_dn
-  - SW_flux_up
-  - SW_flux_dn
-  - SW_flux_dn_dir
-  - omega
-  - p_int
-  - p_mid
-  - phis
-  - pseudo_density
-  - surf_latent_flux
-  - surf_mom_flux
-  - surf_sens_flux
-  - cldfrac_ice
-  - nccn
-  - ni_activated
-  - nc_nuceat_tend
-  - eff_radius_qc
-  - eff_radius_qi
-  - sfc_alb_dir_nir
-  - sfc_alb_dir_vis
+  - micro_vap_liq_exchange
+  - precip_ice_surf
+  - precip_liq_surf
+  # SHOC + P3
+  - qc
+  - qv
+  # SHOC + P3 + RRTMGP
+  - T_mid
+  # RRTMGP
   - sfc_alb_dif_nir
   - sfc_alb_dif_vis
-  - surf_lw_flux_up
- 
+  - sfc_alb_dir_nir
+  - sfc_alb_dir_vis
+  - LW_flux_dn
+  - LW_flux_up
+  - SW_flux_dn
+  - SW_flux_dn_dir
+  - SW_flux_up
+  - rad_heating_pdel
+  - sfc_flux_dif_nir
+  - sfc_flux_dif_vis
+  - sfc_flux_dir_nir
+  - sfc_flux_dir_vis
+  - sfc_flux_lw_dn
+  - sfc_flux_sw_net
 Output Control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
@@ -48,10 +48,6 @@ Field Names:
   - SW_flux_dn_dir
   - SW_flux_up
   - rad_heating_pdel
-  - sfc_flux_dif_nir
-  - sfc_flux_dif_vis
-  - sfc_flux_dir_nir
-  - sfc_flux_dir_vis
   - sfc_flux_lw_dn
   - sfc_flux_sw_net
 Output Control:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -4,59 +4,62 @@ Casename: shoc_cld_spa_p3_rrtmgp_output
 Averaging Type: Instant
 Max Snapshots Per File: 1
 Field Names:
-  - T_mid
-  - T_prev_micro_step
-  - qv
-  - qc
-  - qr
+  # SHOC
+  - cldfrac_liq
+  - eddy_diff_mom
+  - horiz_winds
+  - sgs_buoy_flux
+  - tke
+  - inv_qc_relvar
+  - pbl_height
+  # CLD
+  - cldfrac_ice
+  - cldfrac_tot
+  # P3
+  - bm
+  - nc
+  - ni
+  - nr
   - qi
   - qm
-  - nc
-  - nr
-  - ni
-  - bm
+  - qr
+  - T_prev_micro_step
   - qv_prev_micro_step
   - eff_radius_qc
   - eff_radius_qi
   - micro_liq_ice_exchange
-  - micro_vap_liq_exchange
   - micro_vap_ice_exchange
-  - tke
-  - cldfrac_liq
-  - cldfrac_tot
-  - eddy_diff_mom
-  - horiz_winds
-  - sgs_buoy_flux
-  - inv_qc_relvar
-  - pbl_height
-  - LW_flux_up
-  - LW_flux_dn
-  - SW_flux_up
-  - SW_flux_dn
-  - SW_flux_dn_dir
-  - omega
-  - p_int
-  - p_mid
-  - phis
-  - pseudo_density
-  - surf_latent_flux
-  - surf_mom_flux
-  - surf_sens_flux
-  - cldfrac_ice
-  - nccn
-  - ni_activated
-  - nc_nuceat_tend
-  - eff_radius_qc
-  - eff_radius_qi
-  - sfc_alb_dir_nir
-  - sfc_alb_dir_vis
-  - sfc_alb_dif_nir
-  - sfc_alb_dif_vis
-  - surf_lw_flux_up
+  - micro_vap_liq_exchange
+  - precip_ice_surf
+  - precip_liq_surf
+  # SHOC + P3
+  - qc
+  - qv
+  # SPA
   - aero_g_sw
   - aero_ssa_sw
   - aero_tau_lw
   - aero_tau_sw
+  - nccn
+  # SHOC + P3 + RRTMGP
+  - T_mid
+  # RRTMGP
+  - sfc_alb_dif_nir
+  - sfc_alb_dif_vis
+  - sfc_alb_dir_nir
+  - sfc_alb_dir_vis
+  - LW_flux_dn
+  - LW_flux_up
+  - SW_flux_dn
+  - SW_flux_dn_dir
+  - SW_flux_up
+  - rad_heating_pdel
+  - sfc_flux_dif_nir
+  - sfc_flux_dif_vis
+  - sfc_flux_dir_nir
+  - sfc_flux_dir_vis
+  - sfc_flux_lw_dn
+  - sfc_flux_sw_net
  
 Output Control:
   Frequency: ${NUM_STEPS}

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -54,10 +54,6 @@ Field Names:
   - SW_flux_dn_dir
   - SW_flux_up
   - rad_heating_pdel
-  - sfc_flux_dif_nir
-  - sfc_flux_dif_vis
-  - sfc_flux_dir_nir
-  - sfc_flux_dir_vis
   - sfc_flux_lw_dn
   - sfc_flux_sw_net
  

--- a/components/scream/tests/uncoupled/p3/input.yaml
+++ b/components/scream/tests/uncoupled/p3/input.yaml
@@ -13,6 +13,7 @@ atmosphere_processes:
   atm_procs_list: (p3)
   p3:
     Grid: Point Grid
+    do_prescribed_ccn: false
 
 Grids Manager:
   Type: Mesh Free

--- a/components/scream/tests/uncoupled/p3/p3_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/p3/p3_standalone_output.yaml
@@ -21,13 +21,6 @@ Field Names:
   - micro_liq_ice_exchange
   - micro_vap_liq_exchange
   - micro_vap_ice_exchange
-  - cldfrac_tot
-  - inv_qc_relvar
-  - nccn
-  - nc_nuceat_tend
-  - ni_activated
-  - p_mid
-  - pseudo_density
 Output Control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -18,6 +18,7 @@ atmosphere_processes:
     Orbital Year: 1990
     Can Initialize All Inputs: true
     rad_frequency: 3
+    do_aerosol_rad: false
 
 Grids Manager:
   Type: Mesh Free
@@ -31,10 +32,6 @@ Initial Conditions:
   Point Grid:
     Load Latitude:  true
     Load Longitude: true
-    aero_g_sw: 0.0
-    aero_ssa_sw: 0.0
-    aero_tau_sw: 0.0
-    aero_tau_lw: 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -14,6 +14,7 @@ atmosphere_processes:
     Orbital Obliquity: 0
     Orbital MVELP: 0
     Fixed Solar Zenith Angle: 0.86
+    do_aerosol_rad: false
 
 Grids Manager:
   Type: Mesh Free
@@ -47,8 +48,4 @@ Initial Conditions:
     ch4: 0.0
     o2: 0.0
     n2: 0.0
-    aero_g_sw: 0.0
-    aero_ssa_sw: 0.0
-    aero_tau_sw: 0.0
-    aero_tau_lw: 0.0
 ...

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
@@ -10,20 +10,13 @@ Field Names:
   - SW_flux_up
   - SW_flux_dn
   - SW_flux_dn_dir
-  - cldfrac_tot
-  - p_int
-  - p_mid
-  - pseudo_density
-  - qc
-  - qi
-  - qv
-  - eff_radius_qc
-  - eff_radius_qi
   - sfc_alb_dir_nir
   - sfc_alb_dir_vis
   - sfc_alb_dif_nir
   - sfc_alb_dif_vis
-  - surf_lw_flux_up
+  - sfc_flux_dif_vis
+  - sfc_flux_sw_net
+  - rad_heating_pdel
  
 Output Control:
   Frequency: ${NUM_STEPS}

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
@@ -14,7 +14,7 @@ Field Names:
   - sfc_alb_dir_vis
   - sfc_alb_dif_nir
   - sfc_alb_dif_vis
-  - sfc_flux_dif_vis
+  - sfc_flux_lw_dn
   - sfc_flux_sw_net
   - rad_heating_pdel
  

--- a/components/scream/tests/uncoupled/shoc/shoc_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/shoc/shoc_standalone_output.yaml
@@ -14,11 +14,6 @@ Fields:
   - tke
   - inv_qc_relvar
   - pbl_height
-  - omega
-  - p_int
-  - p_mid
-  - phis
-  - pseudo_density
 Output Control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps

--- a/components/scream/tests/uncoupled/spa/spa_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/spa/spa_standalone_output.yaml
@@ -9,7 +9,6 @@ Field Names:
   - aero_tau_lw
   - aero_tau_sw
   - nccn
-  - p_mid
 Output Control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps


### PR DESCRIPTION
This commit will add runtime parameters to P3 and RRTMGP interfaces to allow the user to turn on and off the prescribed aerosol.

For P3 the two new parameters are
`do_prescribed_ccn`
`do_predict_nc`
Which can be turned on and off.  In particular this is useful if SPA is active or not.

For RRTMGP the new parameter is
`do_aerosol_rad`
which should be turned off whenever SPA is not active to avoid passing incorrect non-zero aerosol forcing when it is not expected.

Additionally, this commit removes aerosol fields as "required" by P3 and RRTMGP if they won't be used.

Addresses #1707 