### PR TITLE
Change timesteps run for F2010-SCREAMv1 ERS test

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -464,7 +464,7 @@ _TESTS = {
         "time"  : "02:00:00",
         "tests" : (
             #  "SMS_D_Ln2.ne30_ne30.F2000-SCREAMv1-AQP1", # Uncomment once IC file for ne30 is ready
-            "ERS_Ln9.ne30_ne30.F2010-SCREAMv1",
+            "ERS_Ln22.ne30_ne30.F2010-SCREAMv1",
             )
     },
 


### PR DESCRIPTION
Micro-PR that changes the number of time steps run for the `ERS` test for the `ne30_ne30.F2010-SCREAMv1` configuration from `ERS_Ln9` to `ERS_Ln22`. This fixes ERS test failures seen in master. 
The previous time step led to writing the restart on a time step when the radiation was not running, leading to test failures in the `COMPARE_base_rest` step. With the new time step, restart will be written on step 12 and outputs compared at step 22, both of which are even (timesteps where radiation is run). 