### PR TITLE
Remove unneeded default output for our EAMxx CIME runs.

### DIFF
--- a/components/scream/data/scream_default_output.yaml
+++ b/components/scream/data/scream_default_output.yaml
@@ -7,19 +7,18 @@ Fields:
   Physics GLL:
     Field Names:
       # HOMME
-      - horiz_winds
       - ps
       - pseudo_density
       - omega
       - p_int
       - p_mid
+      # SHOC + HOMME
+      - horiz_winds
       # SHOC
       - cldfrac_liq
       - eddy_diff_mom
-      - horiz_winds
       - sgs_buoy_flux
       - tke
-      - inv_qc_relvar
       - pbl_height
       # CLD
       - cldfrac_ice
@@ -47,7 +46,6 @@ Fields:
       - LW_flux_up
       - SW_flux_dn
       - SW_flux_up
-      - rad_heating_pdel
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
       # Diagnostics


### PR DESCRIPTION
The current set of default output for CIME runs includes everything
produced by all processes.  But many of these are not used for post
processing and analysis and thus don't need to be written by default.

A user can always include them before simulation if they are needed
for debugging.