### PR TITLE
This commit adds a compset that for running SCREAM physics without SPA

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2250,7 +2250,7 @@
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>cbronze</PROJECT>
-    <CIME_OUTPUT_ROOT>/p/lustre2/$USER/e3sm_scratch/syrah</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>/p/lustre1/$USER/e3sm_scratch/syrah</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/usr/gdata/climdat/ccsm3data/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/usr/gdata/climdat/ccsm3data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT> $CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
@@ -2301,7 +2301,7 @@
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>cbronze</PROJECT>
-    <CIME_OUTPUT_ROOT>/p/lustre2/$USER/e3sm_scratch/quartz</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>/p/lustre1/$USER/e3sm_scratch/quartz</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/usr/gdata/climdat/ccsm3data/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/usr/gdata/climdat/ccsm3data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT> $CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -457,6 +457,7 @@ _TESTS = {
         "tests" : (
             "ERP_D_Ln9.ne4_ne4.F2010-SCREAMv1",
             "ERS_Ln9.ne4_ne4.F2000-SCREAMv1-AQP1",
+            "SMS_D_Ln9.ne4_ne4.F2010-SCREAMv1-noAero",
             )
     },
 

--- a/components/scream/cime_config/config_compsets.xml
+++ b/components/scream/cime_config/config_compsets.xml
@@ -41,7 +41,7 @@
 
   <compset>
       <alias>F2000-SCREAMv1-AQP1-noAero</alias> <!-- atm aquaplanet compset (using SCREAMv1), 2000 initial conditions, turn of Aerosol forcing -->
-      <lname>2000_SCREAM%no_Aero%AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
+      <lname>2000_SCREAM%noAero%AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
       <support_level>Experimental, under development</support_level>
   </compset>
 

--- a/components/scream/cime_config/config_compsets.xml
+++ b/components/scream/cime_config/config_compsets.xml
@@ -35,13 +35,13 @@
 
   <compset>
       <alias>F2010-SCREAMv1-noAero</alias> <!-- Coupled land-atm compset (using SCREAMv1), 2010 initial conditions, turn off Aerosol forcing -->
-      <lname>2010_SCREAM_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP</lname>
+      <lname>2010_SCREAM%noAero_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP</lname>
       <support_level>Experimental, under development</support_level>
   </compset>
 
   <compset>
       <alias>F2000-SCREAMv1-AQP1-noAero</alias> <!-- atm aquaplanet compset (using SCREAMv1), 2000 initial conditions, turn of Aerosol forcing -->
-      <lname>2000_SCREAM%AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
+      <lname>2000_SCREAM%no_Aero%AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
       <support_level>Experimental, under development</support_level>
   </compset>
 

--- a/components/scream/cime_config/config_compsets.xml
+++ b/components/scream/cime_config/config_compsets.xml
@@ -33,4 +33,16 @@
       <support_level>Experimental, under development</support_level>
   </compset>
 
+  <compset>
+      <alias>F2010-SCREAMv1-noSPA</alias> <!-- Coupled land-atm compset (using SCREAMv1), 2010 initial conditions -->
+      <lname>2010_SCREAM_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP%noSPA</lname>
+      <support_level>Experimental, under development</support_level>
+  </compset>
+
+  <compset>
+      <alias>F2000-SCREAMv1-AQP1-noSPA</alias> <!-- atm aquaplanet compset (using SCREAMv1), 2000 initial conditions -->
+      <lname>2000_SCREAM%AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV%noSPA</lname>
+      <support_level>Experimental, under development</support_level>
+  </compset>
+
 </compsets>

--- a/components/scream/cime_config/config_compsets.xml
+++ b/components/scream/cime_config/config_compsets.xml
@@ -41,7 +41,7 @@
 
   <compset>
       <alias>F2000-SCREAMv1-AQP1-noAero</alias> <!-- atm aquaplanet compset (using SCREAMv1), 2000 initial conditions, turn of Aerosol forcing -->
-      <lname>2000_SCREAM%noAero%AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
+      <lname>2000_SCREAM%AQUA-noAero_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
       <support_level>Experimental, under development</support_level>
   </compset>
 

--- a/components/scream/cime_config/config_compsets.xml
+++ b/components/scream/cime_config/config_compsets.xml
@@ -34,14 +34,14 @@
   </compset>
 
   <compset>
-      <alias>F2010-SCREAMv1-noSPA</alias> <!-- Coupled land-atm compset (using SCREAMv1), 2010 initial conditions -->
-      <lname>2010_SCREAM_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP%noSPA</lname>
+      <alias>F2010-SCREAMv1-noAero</alias> <!-- Coupled land-atm compset (using SCREAMv1), 2010 initial conditions, turn off Aerosol forcing -->
+      <lname>2010_SCREAM_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP</lname>
       <support_level>Experimental, under development</support_level>
   </compset>
 
   <compset>
-      <alias>F2000-SCREAMv1-AQP1-noSPA</alias> <!-- atm aquaplanet compset (using SCREAMv1), 2000 initial conditions -->
-      <lname>2000_SCREAM%AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV%noSPA</lname>
+      <alias>F2000-SCREAMv1-AQP1-noAero</alias> <!-- atm aquaplanet compset (using SCREAMv1), 2000 initial conditions, turn of Aerosol forcing -->
+      <lname>2000_SCREAM%AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
       <support_level>Experimental, under development</support_level>
   </compset>
 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -165,9 +165,9 @@ tweaking their $case/namelist_scream.xml file.
     <!-- P3 microphysics -->
     <p3 inherit="physics_proc_base">
       <do_prescribed_ccn>true</do_prescribed_ccn>
-      <do_prescribed_ccn COMPSET=".*noAero*">false</do_prescribed_ccn>
+      <do_prescribed_ccn COMPSET=".*SCREAM.*noAero">false</do_prescribed_ccn>
       <do_predict_nc>true</do_predict_nc>
-      <do_predict_nc COMPSET=".*noAero*">false</do_predict_nc>
+      <do_predict_nc COMPSET=".*SCREAM.*noAero">false</do_predict_nc>
     </p3>
 
     <!-- SHOC macrophysics -->
@@ -203,12 +203,12 @@ tweaking their $case/namelist_scream.xml file.
       <rad_frequency hgrid="ne512np4">3</rad_frequency>
       <rad_frequency hgrid="ne1024np4">3</rad_frequency>
       <do_aerosol_rad>true</do_aerosol_rad>
-      <do_aerosol_rad COMPSET="*noAero*">false</do_aerosol_rad>
+      <do_aerosol_rad COMPSET=".*SCREAM.*noAero">false</do_aerosol_rad>
     </rrtmgp>
 
     <mac_aero_mic inherit="atm_proc_group">
       <atm_procs_list>(shoc,cldFraction,spa,p3)</atm_procs_list>
-      <atm_procs_list COMPSET="*noAero*">(shoc,cldFraction,p3)</atm_procs_list>
+      <atm_procs_list COMPSET=".*SCREAM.*noAero">(shoc,cldFraction,p3)</atm_procs_list>
       <Number__of__Subcycles hgrid="ne4np4">24</Number__of__Subcycles>
       <Number__of__Subcycles hgrid="ne30np4">6</Number__of__Subcycles>
       <Number__of__Subcycles hgrid="ne120np4">3</Number__of__Subcycles>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -165,7 +165,9 @@ tweaking their $case/namelist_scream.xml file.
     <!-- P3 microphysics -->
     <p3 inherit="physics_proc_base">
       <do_prescribed_ccn>true</do_prescribed_ccn>
+      <do_prescribed_ccn COMPSET=".*SCREAM*noSPA*">false</do_prescribed_ccn>
       <do_predict_nc>true</do_predict_nc>
+      <do_predict_nc COMPSET=".*SCREAM*noSPA*">false</do_predict_nc>
     </p3>
 
     <!-- SHOC macrophysics -->
@@ -201,10 +203,12 @@ tweaking their $case/namelist_scream.xml file.
       <rad_frequency hgrid="ne512np4">3</rad_frequency>
       <rad_frequency hgrid="ne1024np4">3</rad_frequency>
       <do_aerosol_rad>true</do_aerosol_rad>
+      <do_aerosol_rad COMPSET=".*SCREAM*noSPA*">false</do_aerosol_rad>
     </rrtmgp>
 
     <mac_aero_mic inherit="atm_proc_group">
       <atm_procs_list>(shoc,cldFraction,spa,p3)</atm_procs_list>
+      <atm_procs_list COMPSET=".*SCREAM*noSPA*">(shoc,cldFraction,p3)</atm_procs_list>
       <Number__of__Subcycles hgrid="ne4np4">24</Number__of__Subcycles>
       <Number__of__Subcycles hgrid="ne30np4">6</Number__of__Subcycles>
       <Number__of__Subcycles hgrid="ne120np4">3</Number__of__Subcycles>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -165,9 +165,9 @@ tweaking their $case/namelist_scream.xml file.
     <!-- P3 microphysics -->
     <p3 inherit="physics_proc_base">
       <do_prescribed_ccn>true</do_prescribed_ccn>
-      <do_prescribed_ccn COMPSET=".*SCREAM*noSPA*">false</do_prescribed_ccn>
+      <do_prescribed_ccn COMPSET=".*noAero*">false</do_prescribed_ccn>
       <do_predict_nc>true</do_predict_nc>
-      <do_predict_nc COMPSET=".*SCREAM*noSPA*">false</do_predict_nc>
+      <do_predict_nc COMPSET=".*noAero*">false</do_predict_nc>
     </p3>
 
     <!-- SHOC macrophysics -->
@@ -203,12 +203,12 @@ tweaking their $case/namelist_scream.xml file.
       <rad_frequency hgrid="ne512np4">3</rad_frequency>
       <rad_frequency hgrid="ne1024np4">3</rad_frequency>
       <do_aerosol_rad>true</do_aerosol_rad>
-      <do_aerosol_rad COMPSET=".*SCREAM*noSPA*">false</do_aerosol_rad>
+      <do_aerosol_rad COMPSET="*noAero*">false</do_aerosol_rad>
     </rrtmgp>
 
     <mac_aero_mic inherit="atm_proc_group">
       <atm_procs_list>(shoc,cldFraction,spa,p3)</atm_procs_list>
-      <atm_procs_list COMPSET=".*SCREAM*noSPA*">(shoc,cldFraction,p3)</atm_procs_list>
+      <atm_procs_list COMPSET="*noAero*">(shoc,cldFraction,p3)</atm_procs_list>
       <Number__of__Subcycles hgrid="ne4np4">24</Number__of__Subcycles>
       <Number__of__Subcycles hgrid="ne30np4">6</Number__of__Subcycles>
       <Number__of__Subcycles hgrid="ne120np4">3</Number__of__Subcycles>


### PR DESCRIPTION
The noSPA option for the compsets triggers all of the runtime options
needed to run EAMxx without SPA.