### PR TITLE
Add a default output filename that matches the E3SM casename

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -47,7 +47,7 @@ tweaking their $case/namelist_scream.xml file.
       <sections>ctl_nl</sections>
     </file>
     <file name="data/scream_input.yaml" format="yaml">
-      <sections>Debug,atmosphere_processes,Grids__Manager,Initial__Conditions,Scorpio</sections>
+      <sections>Debug,atmosphere_processes,Grids__Manager,Initial__Conditions,Scorpio,E3SM__Parameters</sections>
     </file>
   </generated_files>
 
@@ -263,8 +263,10 @@ tweaking their $case/namelist_scream.xml file.
     <Atm__Log__Level valid_values="trace,debug,info,warn,error">info</Atm__Log__Level>
   </Debug>
 
-  <!-- Casename options -->
-  <Casename>${CASE}</Casename> 
+  <!-- E3SM Simulation Settings -->
+  <E3SM__Parameters>
+    <E3SM__Casename>${CASE}</E3SM__Casename>
+  </E3SM__Parameters>
 
   <!--
     List of input files that CIME needs to ensure to be present. If not present,

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -263,6 +263,9 @@ tweaking their $case/namelist_scream.xml file.
     <Atm__Log__Level valid_values="trace,debug,info,warn,error">info</Atm__Log__Level>
   </Debug>
 
+  <!-- Casename options -->
+  <Casename>${CASE}</Casename> 
+
   <!--
     List of input files that CIME needs to ensure to be present. If not present,
     CIME will automatically download them from the E3SM data server.

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -580,6 +580,9 @@ void AtmosphereDriver::create_logger () {
     logger->set_console_level(LogLevel::off);
   }
   m_atm_logger = logger;
+
+  // Record the CASENAME for this run, set default to EAMxx
+  m_casename = m_atm_params.get<std::string>("Casename","EAMxx");
 }
 
 void AtmosphereDriver::set_initial_conditions ()

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -197,6 +197,9 @@ protected:
 
   // Current ad initialization status
   int m_ad_status = 0;
+
+  // Current simulation casename
+  std::string m_casename;
 };
 
 }  // namespace control


### PR DESCRIPTION
This commit will provide for a default output filename if one is not provided in the output control YAML file.  For typical CIME based runs the E3SM case name, ${CASE}, will be gathered by the AD and used as the default output file name.  If no case name can be found the default is "EAMxx".  

In cases where there are more than one output stream that will use the default file name there is a running tally, `h0`, `h1`, `h2`, etc. to keep track of each unique file.

If an output control file provides a case name already, as with our default output and all unit tests, then that case name will be used for the filename instead of the E3SM case name.  In other words, this PR shouldn't change any of the current output file names.