### PR TITLE
Change name of surf_latent_heat to surf_evaporation to match coupler

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -238,6 +238,9 @@ tweaking their $case/namelist_scream.xml file.
     <Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220525.nc</Filename> 
     <Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20220524.nc</Filename>
     <Filename hgrid="ne30np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne30np4_L128_20211202.nc</Filename> <!-- This will need to be updated to the new nccn name -->
+    <Physics__GLL>
+      <surf_evap>0.0</surf_evap> <!-- TODO, Delete this when the IC fixes come in -->
+    </Physics__GLL>
     <Restart__Casename>${CASE}.scream</Restart__Casename>
   </Initial__Conditions>
 

--- a/components/scream/src/control/surface_coupling.cpp
+++ b/components/scream/src/control/surface_coupling.cpp
@@ -113,8 +113,8 @@ register_import(const std::string& fname,
     info.cpl_idx = cpl_idx;
 
     // For import fluxes, we must change the sign as cpl and atm interprete the direction differently.
-    if (fname == "surf_mom_flux"    || fname == "surf_sens_flux" ||
-        fname == "surf_latent_flux" || fname == "surf_lw_flux_up") {
+    if (fname == "surf_mom_flux" || fname == "surf_sens_flux" ||
+        fname == "surf_evap"     || fname == "surf_lw_flux_up") {
       m_cpl_scream_sign_change_host(m_num_scream_imports) = -1;
     } else {
       m_cpl_scream_sign_change_host(m_num_scream_imports) = 1;

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -258,14 +258,14 @@ TEST_CASE ("recreate_mct_coupling")
 
   // Create import fields
   const auto nondim = Units::nondimensional();
-  FID surf_latent_flux_id ("surf_latent_flux",   scalar2d_layout, kg/(m*m*s), grid_name);
-  FID surf_sens_flux_id   ("surf_sens_flux",     scalar2d_layout, W/(m*m), grid_name);
-  FID surf_mom_flux_id    ("surf_mom_flux",      vector2d_layout, W/(m*m), grid_name);
-  FID sfc_alb_dir_vis_id  ("sfc_alb_dir_vis",    scalar2d_layout, nondim,  grid_name);
-  FID sfc_alb_dir_nir_id  ("sfc_alb_dir_nir",    scalar2d_layout, nondim,  grid_name);
-  FID sfc_alb_dif_vis_id  ("sfc_alb_dif_vis",    scalar2d_layout, nondim,  grid_name);
-  FID sfc_alb_dif_nir_id  ("sfc_alb_dif_nir",    scalar2d_layout, nondim,  grid_name);
-  FID surf_lw_flux_up_id  ("surf_lw_flux_up",    scalar2d_layout, nondim,  grid_name);
+  FID surf_evap_id        ("surf_evap",          scalar2d_layout, kg/(m*m*s), grid_name);
+  FID surf_sens_flux_id   ("surf_sens_flux",     scalar2d_layout, W/(m*m),    grid_name);
+  FID surf_mom_flux_id    ("surf_mom_flux",      vector2d_layout, W/(m*m),    grid_name);
+  FID sfc_alb_dir_vis_id  ("sfc_alb_dir_vis",    scalar2d_layout, nondim,     grid_name);
+  FID sfc_alb_dir_nir_id  ("sfc_alb_dir_nir",    scalar2d_layout, nondim,     grid_name);
+  FID sfc_alb_dif_vis_id  ("sfc_alb_dif_vis",    scalar2d_layout, nondim,     grid_name);
+  FID sfc_alb_dif_nir_id  ("sfc_alb_dif_nir",    scalar2d_layout, nondim,     grid_name);
+  FID surf_lw_flux_up_id  ("surf_lw_flux_up",    scalar2d_layout, nondim,     grid_name);
 
   // Create necessary fields for export. Tracers qc and qr are unnecessary, but
   // are included to verify that subviewed fields (qv) are correctly handled
@@ -293,7 +293,7 @@ TEST_CASE ("recreate_mct_coupling")
   // Register fields and tracer group in a FieldManager
   auto fm = std::make_shared<FieldManager> (grid);
   fm->registration_begins();
-  fm->register_field(FR{surf_latent_flux_id});
+  fm->register_field(FR{surf_evap_id});
   fm->register_field(FR{surf_sens_flux_id});
   fm->register_field(FR{surf_mom_flux_id});
   fm->register_field(FR{sfc_alb_dir_vis_id});
@@ -321,7 +321,7 @@ TEST_CASE ("recreate_mct_coupling")
   fm->registration_ends();
 
   // Create alias to field views
-  auto surf_latent_flux_f = fm->get_field(surf_latent_flux_id);
+  auto surf_evap_f        = fm->get_field(surf_evap_id);
   auto surf_sens_flux_f   = fm->get_field(surf_sens_flux_id);
   auto surf_mom_flux_f    = fm->get_field(surf_mom_flux_id);
   auto sfc_alb_dir_vis_f  = fm->get_field(sfc_alb_dir_vis_id);
@@ -349,7 +349,7 @@ TEST_CASE ("recreate_mct_coupling")
   const auto& Q_name = group.m_bundle->get_header().get_identifier().name();
   auto Q = fm->get_field(Q_name);
 
-  auto surf_latent_flux_d = surf_latent_flux_f.get_view<Real*>();
+  auto surf_evap_d        = surf_evap_f.get_view<Real*>();
   auto surf_sens_flux_d   = surf_sens_flux_f.get_view<Real*>();
   auto surf_mom_flux_d    = surf_mom_flux_f.get_view<Real**>();
   auto sfc_alb_dir_vis_d  = sfc_alb_dir_vis_f.get_view<Real*>();
@@ -373,7 +373,7 @@ TEST_CASE ("recreate_mct_coupling")
   auto p_int_d            = p_int_f.get_view<Real**>();
   auto phis_d             = phis_f.get_view<Real*>();
 
-  auto surf_latent_flux_h = surf_latent_flux_f.get_view<Real*,Host>();
+  auto surf_evap_h        = surf_evap_f.get_view<Real*,Host>();
   auto surf_sens_flux_h   = surf_sens_flux_f.get_view<Real*,Host>();
   auto surf_mom_flux_h    = surf_mom_flux_f.get_view<Real**,Host>();
   auto sfc_alb_dir_vis_h  = sfc_alb_dir_vis_f.get_view<Real*,Host>();
@@ -428,7 +428,7 @@ TEST_CASE ("recreate_mct_coupling")
   coupler.register_import("unused",           21);
   coupler.register_import("surf_sens_flux",   22);
   coupler.register_import("surf_lw_flux_up",  23);
-  coupler.register_import("surf_latent_flux", 24);
+  coupler.register_import("surf_evap",        24);
   coupler.register_import("unused",           25);
   coupler.register_import("unused",           26);
   coupler.register_import("unused",           27);
@@ -481,7 +481,7 @@ TEST_CASE ("recreate_mct_coupling")
   for (int i=0; i<nruns; ++i) {
 
     // Set import field views to 0
-    surf_latent_flux_f.deep_copy(0.0);
+    surf_evap_f.deep_copy(0.0);
     surf_sens_flux_f.deep_copy(0.0);
     surf_mom_flux_f.deep_copy(0.0);
     sfc_alb_dir_vis_f.deep_copy(0.0);
@@ -523,7 +523,7 @@ TEST_CASE ("recreate_mct_coupling")
     coupler.do_export();
 
     // Sync host to device
-    surf_latent_flux_f.sync_to_host();
+    surf_evap_f.sync_to_host();
     surf_sens_flux_f.sync_to_host();
     surf_mom_flux_f.sync_to_host();
     sfc_alb_dir_vis_f.sync_to_host();
@@ -559,7 +559,7 @@ TEST_CASE ("recreate_mct_coupling")
       REQUIRE (surf_mom_flux_h   (icol, 1) == -import_raw_data[20 + icol*num_cpl_imports]); // 6th scream import (21st cpl import)
       REQUIRE (surf_sens_flux_h  (icol)    == -import_raw_data[22 + icol*num_cpl_imports]); // 7th scream import (23rd cpl import)
       REQUIRE (surf_lw_flux_up_h (icol)    == -import_raw_data[23 + icol*num_cpl_imports]); // 8th scream import (24th cpl import)
-      REQUIRE (surf_latent_flux_h(icol)    == -import_raw_data[24 + icol*num_cpl_imports]); // 9th scream import (24th cpl import)
+      REQUIRE (surf_evap_h(icol)           == -import_raw_data[24 + icol*num_cpl_imports]); // 9th scream import (24th cpl import)
 
       // Exports
 

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -78,7 +78,7 @@ module scream_cpl_indices
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_taux')) = 'surf_mom_flux'
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_tauy')) = 'surf_mom_flux'
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_sen'))  = 'surf_sens_flux'
-    scr_names_x2a(mct_avect_indexra(x2a,'Faxx_evap')) = 'surf_latent_flux'
+    scr_names_x2a(mct_avect_indexra(x2a,'Faxx_evap')) = 'surf_evap'
     scr_names_x2a(mct_avect_indexra(x2a,'Faxx_lwup')) = 'surf_lw_flux_up'
 
     vec_comp_x2a(mct_avect_indexra(x2a,'Faxx_taux')) = 0

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -65,11 +65,11 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
   // These variables are needed by the interface, but not actually passed to shoc_main.
   // TODO: Replace pref_mid in the FM with pref_mid read in from the grid data.
-  add_field<Required>("pref_mid",         pref_mid_layout,      Pa,   grid_name, ps);
-  add_field<Required>("omega",            scalar3d_layout_mid,  Pa/s, grid_name, ps);
-  add_field<Required>("surf_sens_flux",   scalar2d_layout_col,  W/m2, grid_name);
-  add_field<Required>("surf_latent_flux", scalar2d_layout_col,kg/m2/s, grid_name);
-  add_field<Required>("surf_mom_flux",    surf_mom_flux_layout, N/m2, grid_name);
+  add_field<Required>("pref_mid",         pref_mid_layout,      Pa,      grid_name, ps);
+  add_field<Required>("omega",            scalar3d_layout_mid,  Pa/s,    grid_name, ps);
+  add_field<Required>("surf_sens_flux",   scalar2d_layout_col,  W/m2,    grid_name);
+  add_field<Required>("surf_evap",        scalar2d_layout_col,  kg/m2/s, grid_name);
+  add_field<Required>("surf_mom_flux",    surf_mom_flux_layout, N/m2,    grid_name);
 
   add_field<Updated> ("T_mid",            scalar3d_layout_mid, K,       grid_name, ps);
   add_field<Updated> ("qv",               scalar3d_layout_mid, Qunit,   grid_name, "tracers", ps);
@@ -253,7 +253,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   const auto& pseudo_density   = get_field_in("pseudo_density").get_view<const Spack**>();
   const auto& omega            = get_field_in("omega").get_view<const Spack**>();
   const auto& surf_sens_flux   = get_field_in("surf_sens_flux").get_view<const Real*>();
-  const auto& surf_latent_flux = get_field_in("surf_latent_flux").get_view<const Real*>();
+  const auto& surf_evap        = get_field_in("surf_evap").get_view<const Real*>();
   const auto& surf_mom_flux    = get_field_in("surf_mom_flux").get_view<const Real**>();
   const auto& qc               = get_field_out("qc").get_view<Spack**>();
   const auto& qv               = get_field_out("qv").get_view<Spack**>();
@@ -300,7 +300,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   }
 
   shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,z_surf,m_cell_area,m_cell_lat,
-                                T_mid,p_mid,p_int,pseudo_density,omega,phis,surf_sens_flux,surf_latent_flux,
+                                T_mid,p_mid,p_int,pseudo_density,omega,phis,surf_sens_flux,surf_evap,
                                 surf_mom_flux,qv,qc,qc_copy,tke,tke_copy,z_mid,z_int,cell_length,
                                 dse,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
                                 wtracer_sfc,wm_zt,inv_exner,thlm,qw);

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -163,7 +163,7 @@ public:
 
       wpthlp_sfc(i) = surf_sens_flux(i)/(cpair*rrho_i(i,nlevi_v)[nlevi_p]);
       wpthlp_sfc(i) = wpthlp_sfc(i)*inv_exner_int_surf;
-      wprtp_sfc(i)  = surf_latent_flux(i)/rrho_i(i,nlevi_v)[nlevi_p];
+      wprtp_sfc(i)  = surf_evap(i)/rrho_i(i,nlevi_v)[nlevi_p];
       upwp_sfc(i)   = surf_mom_flux(i,0)/rrho_i(i,nlevi_v)[nlevi_p];
       vpwp_sfc(i)   = surf_mom_flux(i,1)/rrho_i(i,nlevi_v)[nlevi_p];
 
@@ -185,7 +185,7 @@ public:
     view_2d_const        omega;
     view_1d_const        phis;
     view_1d_const        surf_sens_flux;
-    view_1d_const        surf_latent_flux;
+    view_1d_const        surf_evap;
     sview_2d_const       surf_mom_flux;
     view_2d_const        qv;
     view_2d_const        qc;
@@ -218,7 +218,7 @@ public:
                        const view_1d_const& area_, const view_1d_const& lat_,
                        const view_2d_const& T_mid_, const view_2d_const& p_mid_, const view_2d_const& p_int_, const view_2d_const& pseudo_density_,
                        const view_2d_const& omega_,
-                       const view_1d_const& phis_, const view_1d_const& surf_sens_flux_, const view_1d_const& surf_latent_flux_,
+                       const view_1d_const& phis_, const view_1d_const& surf_sens_flux_, const view_1d_const& surf_evap_,
                        const sview_2d_const& surf_mom_flux_,
                        const view_2d_const& qv_, const view_2d_const& qc_, const view_2d& qc_copy_,
                        const view_2d& tke_, const view_2d& tke_copy_,
@@ -243,7 +243,7 @@ public:
       omega = omega_;
       phis = phis_;
       surf_sens_flux = surf_sens_flux_;
-      surf_latent_flux = surf_latent_flux_;
+      surf_evap = surf_evap_;
       surf_mom_flux = surf_mom_flux_;
       qv = qv_;
       // OUT

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   Physics GLL:
-    surf_latent_flux: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
 
 atmosphere_processes:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   Physics GLL:
-    surf_latent_flux: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
 
 atmosphere_processes:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L128_20220525.nc
   Physics GLL:
-    surf_latent_flux: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
 
 atmosphere_processes:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -14,6 +14,9 @@ Time Stepping:
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   Restart Run: false
+  Physics GLL:
+    surf_evap: 0.0
+    surf_sens_flux: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -14,6 +14,9 @@ Time Stepping:
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   Restart Run: false
+  Physics GLL:
+    surf_evap: 0.0
+    surf_sens_flux: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -29,7 +29,7 @@ Initial Conditions:
   Point Grid:
     Load Latitude:  true
     Load Longitude: true
-    surf_latent_flux: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
 
 # The parameters for I/O control

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
@@ -24,7 +24,7 @@ Field Names:
   - sgs_buoy_flux
   - inv_qc_relvar
   - pbl_height
-  - surf_latent_flux
+  - surf_evap
   - surf_mom_flux
   - surf_sens_flux
   - nccn

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -41,7 +41,7 @@ Initial Conditions:
   Point Grid:
     Load Latitude:  true
     Load Longitude: true
-    surf_latent_flux: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
 
 # The parameters for I/O control

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -43,7 +43,7 @@ Initial Conditions:
   Point Grid:
     Load Latitude:  true
     Load Longitude: true
-    surf_latent_flux: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
 
 # The parameters for I/O control

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -25,7 +25,7 @@ Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   Point Grid:
-    surf_latent_flux: 0.0
+    surf_evap: 0.0
     surf_sens_flux: 0.0
     Load Latitude: true
 


### PR DESCRIPTION
This commit change the name of the field manager variable
surf_latent_heat to be surf_evaporation. Which is what the actual
variable passed by the component coupler represents.