### PR TITLE
Make initialization easier for EAMxx

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -232,7 +232,7 @@ tweaking their $case/namelist_scream.xml file.
   <!-- List of nc files for loading inputs on specified grids -->
   <Initial__Conditions>
     <Filename>UNSET</Filename>
-    <Filename hgrid="ne4np4">/sems-data-store/ACME/bhillma/scream/data/init/screami_ne4np4L72_20220701.nc</Filename>
+    <Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne4np4L72_20220701.nc</Filename>
     <Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220701.nc</Filename>
     <Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220524.nc</Filename>
     <Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220525.nc</Filename> 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -245,12 +245,24 @@ tweaking their $case/namelist_scream.xml file.
     </Physics__GLL>
     <Restart__Casename>${CASE}.scream</Restart__Casename>
     <!-- Fields that we need to initialize, but are not in an initial condition file need to be inited here -->
-    <cldfrac_liq>0.0</cldfrac_liq>
-    <sgs_buoy_flux>0.0</sgs_buoy_flux>
-    <eddy_diff_mom>0.0</eddy_diff_mom>
-    <T_prev_micro_step>0.0</T_prev_micro_step>
+    <cldfrac_liq       >0.0</cldfrac_liq>
+    <sgs_buoy_flux     >0.0</sgs_buoy_flux>
+    <eddy_diff_mom     >0.0</eddy_diff_mom>
+    <T_prev_micro_step >0.0</T_prev_micro_step>
     <qv_prev_micro_step>0.0</qv_prev_micro_step>
-
+    <sfc_alb_dir_vis   >0.0</sfc_alb_dir_vis>
+    <sfc_alb_dir_nir   >0.0</sfc_alb_dir_nir>
+    <sfc_alb_dif_vis   >0.0</sfc_alb_dif_vis>
+    <sfc_alb_dif_nir   >0.0</sfc_alb_dif_nir>
+    <surf_latent_flux  >0.0</surf_latent_flux>
+    <surf_sens_flux    >0.0</surf_sens_flux>
+    <surf_lw_flux_up   >0.0</surf_lw_flux_up>
+    <qm                >0.0</qm>
+    <bm                >0.0</bm>
+    <ni_activated      >0.0</ni_activated>
+    <nc_nuceat_tend    >0.0</nc_nuceat_tend>
+    <!-- This one needs a fix; complaints about not being able to keep the same Layout -->
+    <!--surf_mom_flux  type="array(real)">0.0,0.0</surf_mom_flux-->
   </Initial__Conditions>
 
   <!-- List of yaml files containing I/O output specs -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -232,19 +232,17 @@ tweaking their $case/namelist_scream.xml file.
   <!-- List of nc files for loading inputs on specified grids -->
   <Initial__Conditions>
     <Filename>UNSET</Filename>
-    <Filename hgrid="ne4np4">/sems-data-store/ACME/bhillma/scream/data/init/screami_ne4np4L72_stripped.nc</Filename>
-    <Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220524.nc</Filename>
+    <Filename hgrid="ne4np4">/sems-data-store/ACME/bhillma/scream/data/init/screami_ne4np4L72_20220701.nc</Filename>
+    <Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220701.nc</Filename>
     <Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220524.nc</Filename>
     <Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220525.nc</Filename> 
     <Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20220524.nc</Filename>
     <Filename hgrid="ne30np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne30np4_L128_20211202.nc</Filename> <!-- This will need to be updated to the new nccn name -->
-    <Physics__GLL>
-      <surf_evap>0.0</surf_evap> <!-- TODO, Delete this when the IC fixes come in -->
-      <precip_liq_surf_mass>0.0</precip_liq_surf_mass>
-      <precip_ice_surf_mass>0.0</precip_ice_surf_mass>
-    </Physics__GLL>
     <Restart__Casename>${CASE}.scream</Restart__Casename>
     <!-- Fields that we need to initialize, but are not in an initial condition file need to be inited here -->
+    <surf_evap>0.0</surf_evap> <!-- TODO, Delete this when the IC fixes come in -->
+    <precip_liq_surf_mass>0.0</precip_liq_surf_mass>
+    <precip_ice_surf_mass>0.0</precip_ice_surf_mass>
     <cldfrac_liq       >0.0</cldfrac_liq>
     <sgs_buoy_flux     >0.0</sgs_buoy_flux>
     <eddy_diff_mom     >0.0</eddy_diff_mom>
@@ -262,7 +260,7 @@ tweaking their $case/namelist_scream.xml file.
     <sfc_alb_dir_nir   >0.0</sfc_alb_dir_nir>
     <sfc_alb_dif_vis   >0.0</sfc_alb_dif_vis>
     <sfc_alb_dif_nir   >0.0</sfc_alb_dif_nir>
-    <surf_latent_flux  >0.0</surf_latent_flux>
+    <surf_evap         >0.0</surf_evap>
     <surf_sens_flux    >0.0</surf_sens_flux>
     <surf_lw_flux_up   >0.0</surf_lw_flux_up>
     <surf_mom_flux     >0.0,0.0</surf_mom_flux>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -261,7 +261,6 @@ tweaking their $case/namelist_scream.xml file.
     <sfc_alb_dir_nir   >0.0</sfc_alb_dir_nir>
     <sfc_alb_dif_vis   >0.0</sfc_alb_dif_vis>
     <sfc_alb_dif_nir   >0.0</sfc_alb_dif_nir>
-    <surf_evap         >0.0</surf_evap>
     <surf_sens_flux    >0.0</surf_sens_flux>
     <surf_lw_flux_up   >0.0</surf_lw_flux_up>
     <surf_mom_flux     >0.0,0.0</surf_mom_flux>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -244,6 +244,13 @@ tweaking their $case/namelist_scream.xml file.
       <precip_ice_surf_mass>0.0</precip_ice_surf_mass>
     </Physics__GLL>
     <Restart__Casename>${CASE}.scream</Restart__Casename>
+    <!-- Fields that we need to initialize, but are not in an initial condition file need to be inited here -->
+    <cldfrac_liq>0.0</cldfrac_liq>
+    <sgs_buoy_flux>0.0</sgs_buoy_flux>
+    <eddy_diff_mom>0.0</eddy_diff_mom>
+    <T_prev_micro_step>0.0</T_prev_micro_step>
+    <qv_prev_micro_step>0.0</qv_prev_micro_step>
+
   </Initial__Conditions>
 
   <!-- List of yaml files containing I/O output specs -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -232,7 +232,7 @@ tweaking their $case/namelist_scream.xml file.
   <!-- List of nc files for loading inputs on specified grids -->
   <Initial__Conditions>
     <Filename>UNSET</Filename>
-    <Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne4np4L72_20220524.nc</Filename>
+    <Filename hgrid="ne4np4">/sems-data-store/ACME/bhillma/scream/data/init/screami_ne4np4L72_stripped.nc</Filename>
     <Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220524.nc</Filename>
     <Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220524.nc</Filename>
     <Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220525.nc</Filename> 
@@ -251,6 +251,8 @@ tweaking their $case/namelist_scream.xml file.
     <T_prev_micro_step >0.0</T_prev_micro_step>
     <qv_prev_micro_step>0.0</qv_prev_micro_step>
     <!-- Initialize microphysics fields not on IC to zero; note that this is consistent with EAM init -->
+    <qr                >0.0</qr>
+    <nr                >0.0</nr>
     <qm                >0.0</qm>
     <bm                >0.0</bm>
     <ni_activated      >0.0</ni_activated>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -250,6 +250,12 @@ tweaking their $case/namelist_scream.xml file.
     <eddy_diff_mom     >0.0</eddy_diff_mom>
     <T_prev_micro_step >0.0</T_prev_micro_step>
     <qv_prev_micro_step>0.0</qv_prev_micro_step>
+    <!-- Initialize microphysics fields not on IC to zero; note that this is consistent with EAM init -->
+    <qm                >0.0</qm>
+    <bm                >0.0</bm>
+    <ni_activated      >0.0</ni_activated>
+    <nc_nuceat_tend    >0.0</nc_nuceat_tend>
+    <!-- Note: these should be provided by surface models, but we init here to keep AD from reading from file -->
     <sfc_alb_dir_vis   >0.0</sfc_alb_dir_vis>
     <sfc_alb_dir_nir   >0.0</sfc_alb_dir_nir>
     <sfc_alb_dif_vis   >0.0</sfc_alb_dif_vis>
@@ -257,12 +263,7 @@ tweaking their $case/namelist_scream.xml file.
     <surf_latent_flux  >0.0</surf_latent_flux>
     <surf_sens_flux    >0.0</surf_sens_flux>
     <surf_lw_flux_up   >0.0</surf_lw_flux_up>
-    <qm                >0.0</qm>
-    <bm                >0.0</bm>
-    <ni_activated      >0.0</ni_activated>
-    <nc_nuceat_tend    >0.0</nc_nuceat_tend>
-    <!-- This one needs a fix; complaints about not being able to keep the same Layout -->
-    <!--surf_mom_flux  type="array(real)">0.0,0.0</surf_mom_flux-->
+    <surf_mom_flux     >0.0,0.0</surf_mom_flux>
   </Initial__Conditions>
 
   <!-- List of yaml files containing I/O output specs -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -236,6 +236,7 @@ tweaking their $case/namelist_scream.xml file.
     <Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220701.nc</Filename>
     <Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220524.nc</Filename>
     <Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220525.nc</Filename> 
+    <Filename hgrid="ne1024np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_20220713.nc</Filename> 
     <Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20220524.nc</Filename>
     <Filename hgrid="ne30np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne30np4_L128_20211202.nc</Filename> <!-- This will need to be updated to the new nccn name -->
     <Restart__Casename>${CASE}.scream</Restart__Casename>

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -621,7 +621,14 @@ void AtmosphereDriver::set_initial_conditions ()
     const auto& grid_name = fid.get_grid_name();
     const auto& fname = fid.name();
 
-    const auto& ic_pl_grid = ic_pl.sublist(grid_name);
+    // TODO: initially, this used
+    //
+    //   const auto& ic_pl_grid = ic_pl.sublist(grid_name);
+    //
+    // but we appear to have done away with the grid_name heading, so the above code no longer
+    // works and we need to set ic_pl_grid to ic_pl. In the future, we should either just use
+    // ic_pl directly, or re-enable support for the sublist under the grid name heading.
+    const auto& ic_pl_grid = ic_pl;
 
     // First, check if the input file contains constant values for some of the fields
     if (ic_pl_grid.isParameter(fname)) {

--- a/components/scream/src/control/atmosphere_driver.hpp
+++ b/components/scream/src/control/atmosphere_driver.hpp
@@ -129,6 +129,11 @@ public:
 
   const std::shared_ptr<AtmosphereProcessGroup>& get_atm_processes () const { return m_atm_process_group; }
 
+#ifndef KOKKOS_ENABLE_CUDA
+  // Cuda requires methods enclosing __device__ lambda's to be public
+protected:
+#endif
+  void initialize_constant_field(const FieldIdentifier& fid, const ekat::ParameterList& ic_pl);
 protected:
 
   void report_res_dep_memory_footprint () const;
@@ -136,7 +141,6 @@ protected:
   void create_logger ();
   void set_initial_conditions ();
   void restart_model ();
-  void initialize_constant_field(const FieldIdentifier& fid, const ekat::ParameterList& ic_pl);
   void read_fields_from_file (const std::vector<std::string>& field_names,
                               const std::string& grid_name,
                               const std::string& file_name,

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -5,10 +5,9 @@ Debug:
 
 Initial Conditions:
   Filename: should_not_be_neeeded_and_code_will_throw_if_it_tries_to_open_this_nonexistent_file.nc
-  Point Grid:
-    A: 1.0
-    V: [2.0, 3.0]
-    Z: "A"
+  A: 1.0
+  V: [2.0, 3.0]
+  Z: "A"
 
 atmosphere_processes:
   atm_procs_list: (dummy1, dummy2, dummy3)

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -913,7 +913,7 @@ void HommeDynamics::restart_homme_state () {
   m_ic_remapper->registration_begins();
   m_ic_remapper->register_field(m_helper_fields.at("FT_ref"),m_helper_fields.at("vtheta_dp_dyn"));
   m_ic_remapper->register_field(m_helper_fields.at("uv_prev"),m_helper_fields.at("v_dyn"));
-  m_ic_remapper->register_field(get_internal_field("dp3d_dyn"),get_field_out("pseudo_density",rgn));
+  m_ic_remapper->register_field(get_field_out("pseudo_density",rgn),m_helper_fields.at("dp3d_dyn"));
   auto qv_prev_ref = std::make_shared<Field>();
   auto Q_dyn = m_helper_fields.at("Q_dyn");
   if (params.ftype==Homme::ForcingAlg::FORCING_2) {

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
@@ -35,6 +35,13 @@ DynamicsDrivenGridsManager (const ekat::Comm& comm,
     init_params_f90 (nlname);
   }
 
+  // Check that the global number of 2d elements is no less than the number of MPI ranks
+  EKAT_REQUIRE_MSG (get_homme_param<int>("nelem")>=comm.size(),
+      "Error! We do not yet support running EAMxx with a number of MPI ranks\n"
+      "       larger than the number of 2d elements in Homme.\n"
+      "  - num MPI ranks: " + std::to_string(comm.size()) + "\n"
+      "  - num 2d elems : " + std::to_string(get_homme_param<int>("nelem")) + "\n");
+
   // Valid names for the dyn grid
   auto& gn = m_valid_grid_names;
 

--- a/components/scream/src/dynamics/homme/interface/homme_params_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_params_mod.F90
@@ -75,7 +75,7 @@ contains
   end subroutine init_params_f90
 
   function get_homme_int_param_f90 (param_name_c) result(param_value) bind(c)
-    use dimensions_mod,    only: qsize, nlev, np
+    use dimensions_mod,    only: qsize, nlev, np, ne
     use control_mod,       only: ftype
     use homme_context_mod, only: elem
     !
@@ -95,6 +95,10 @@ contains
     select case(param_name(1:len))
       case("ftype")
         param_value = ftype
+      case("ne")
+        param_value = ne
+      case("nelem")
+        param_value = ne*ne*6
       case("qsize")
         param_value = qsize
       case("num momentum forcings")

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -297,6 +297,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
     Kokkos::deep_copy(tk,0.0);
     Kokkos::deep_copy(tke,0.0004);
     Kokkos::deep_copy(tke_copy,0.0004);
+    Kokkos::deep_copy(cldfrac_liq,0.0);
   }
 
   shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,z_surf,m_cell_area,m_cell_lat,

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -11,11 +11,15 @@ Time Stepping:
 
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
-  Physics GLL:
-    surf_evap: 0.0
-    surf_sens_flux: 0.0
-    precip_liq_surf_mass: 0.0
-    precip_ice_surf_mass: 0.0
+  surf_evap: 0.0
+  surf_latent_flux: 0.0
+  surf_sens_flux: 0.0
+  precip_liq_surf_mass: 0.0
+  precip_ice_surf_mass: 0.0
+  aero_g_sw: 0.0
+  aero_ssa_sw: 0.0
+  aero_tau_sw: 0.0
+  aero_tau_lw: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -12,7 +12,6 @@ Time Stepping:
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   surf_evap: 0.0
-  surf_latent_flux: 0.0
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -11,11 +11,10 @@ Time Stepping:
 
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
-  Physics GLL:
-    surf_evap: 0.0
-    surf_sens_flux: 0.0
-    precip_liq_surf_mass: 0.0
-    precip_ice_surf_mass: 0.0
+  surf_evap: 0.0
+  surf_sens_flux: 0.0
+  precip_liq_surf_mass: 0.0
+  precip_ice_surf_mass: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -12,7 +12,6 @@ Time Stepping:
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L128_20220525.nc
   surf_evap: 0.0
-  surf_latent_flux: 0.0
   surf_sens_flux: 0.0
 
 atmosphere_processes:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -11,9 +11,9 @@ Time Stepping:
 
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L128_20220525.nc
-  Physics GLL:
-    surf_evap: 0.0
-    surf_sens_flux: 0.0
+  surf_evap: 0.0
+  surf_latent_flux: 0.0
+  surf_sens_flux: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -13,6 +13,8 @@ Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L128_20220525.nc
   surf_evap: 0.0
   surf_sens_flux: 0.0
+  precip_ice_surf_mass: 0.0
+  precip_liq_surf_mass: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -14,11 +14,14 @@ Time Stepping:
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   Restart Run: false
-  Physics GLL:
-    surf_evap: 0.0
-    surf_sens_flux: 0.0
-    precip_liq_surf_mass: 0.0
-    precip_ice_surf_mass: 0.0
+  surf_evap: 0.0
+  surf_sens_flux: 0.0
+  precip_liq_surf_mass: 0.0
+  precip_ice_surf_mass: 0.0
+  aero_g_sw: 0.0
+  aero_ssa_sw: 0.0
+  aero_tau_sw: 0.0
+  aero_tau_lw: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -14,11 +14,14 @@ Time Stepping:
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   Restart Run: false
-  Physics GLL:
-    surf_evap: 0.0
-    surf_sens_flux: 0.0
-    precip_liq_surf_mass: 0.0
-    precip_ice_surf_mass: 0.0
+  surf_evap: 0.0
+  surf_sens_flux: 0.0
+  precip_liq_surf_mass: 0.0
+  precip_ice_surf_mass: 0.0
+  aero_g_sw: 0.0
+  aero_ssa_sw: 0.0
+  aero_tau_sw: 0.0
+  aero_tau_lw: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -27,7 +27,6 @@ Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   surf_evap: 0.0
-  surf_latent_flux: 0.0
   surf_sens_flux: 0.0
   Point Grid:
     Load Latitude:  true

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -26,11 +26,12 @@ Grids Manager:
 Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
+  surf_evap: 0.0
+  surf_latent_flux: 0.0
+  surf_sens_flux: 0.0
   Point Grid:
     Load Latitude:  true
     Load Longitude: true
-    surf_evap: 0.0
-    surf_sens_flux: 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -28,6 +28,8 @@ Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   surf_evap: 0.0
   surf_sens_flux: 0.0
+  precip_ice_surf_mass: 0.0
+  precip_liq_surf_mass: 0.0
   Point Grid:
     Load Latitude:  true
     Load Longitude: true

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -30,9 +30,8 @@ Initial Conditions:
   surf_sens_flux: 0.0
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
-  Point Grid:
-    Load Latitude:  true
-    Load Longitude: true
+  Load Latitude:  true
+  Load Longitude: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -40,6 +40,8 @@ Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   surf_sens_flux: 0.0
   surf_evap: 0.0
+  precip_ice_surf_mass: 0.0
+  precip_liq_surf_mass: 0.0
   aero_g_sw: 0.0
   aero_ssa_sw: 0.0
   aero_tau_sw: 0.0

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -38,7 +38,6 @@ Grids Manager:
 Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
-  surf_latent_flux: 0.0
   surf_sens_flux: 0.0
   surf_evap: 0.0
   aero_g_sw: 0.0

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -46,13 +46,8 @@ Initial Conditions:
   aero_ssa_sw: 0.0
   aero_tau_sw: 0.0
   aero_tau_lw: 0.0
-  Point Grid:
-    Load Latitude:  true
-    Load Longitude: true
-    surf_evap: 0.0
-    surf_sens_flux: 0.0
-    precip_liq_surf_mass: 0.0
-    precip_ice_surf_mass: 0.0
+  Load Latitude:  true
+  Load Longitude: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -38,6 +38,13 @@ Grids Manager:
 Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
+  surf_latent_flux: 0.0
+  surf_sens_flux: 0.0
+  surf_evap: 0.0
+  aero_g_sw: 0.0
+  aero_ssa_sw: 0.0
+  aero_tau_sw: 0.0
+  aero_tau_lw: 0.0
   Point Grid:
     Load Latitude:  true
     Load Longitude: true

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -40,12 +40,12 @@ Grids Manager:
 Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
-  Load Latitude:  true
-  Load Longitude: true
   surf_evap: 0.0
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0
+  Load Latitude:  true
+  Load Longitude: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -40,6 +40,9 @@ Grids Manager:
 Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
+  surf_latent_flux: 0.0
+  surf_sens_flux: 0.0
+  surf_evap: 0.0
   Point Grid:
     Load Latitude:  true
     Load Longitude: true

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -40,7 +40,6 @@ Grids Manager:
 Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
-  surf_latent_flux: 0.0
   surf_sens_flux: 0.0
   surf_evap: 0.0
   Point Grid:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -40,15 +40,12 @@ Grids Manager:
 Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
-  surf_sens_flux: 0.0
+  Load Latitude:  true
+  Load Longitude: true
   surf_evap: 0.0
-  Point Grid:
-    Load Latitude:  true
-    Load Longitude: true
-    surf_evap: 0.0
-    surf_sens_flux: 0.0
-    precip_liq_surf_mass: 0.0
-    precip_ice_surf_mass: 0.0
+  surf_sens_flux: 0.0
+  precip_liq_surf_mass: 0.0
+  precip_ice_surf_mass: 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/uncoupled/cld_fraction/input.yaml
+++ b/components/scream/tests/uncoupled/cld_fraction/input.yaml
@@ -21,7 +21,6 @@ Grids Manager:
   Number of Vertical Levels:  128
 
 Initial Conditions:
-  Point Grid:
-    cldfrac_liq: 0.0
-    qi: 0.0 
+  cldfrac_liq: 0.0
+  qi: 0.0
 ...

--- a/components/scream/tests/uncoupled/p3/input.yaml
+++ b/components/scream/tests/uncoupled/p3/input.yaml
@@ -24,9 +24,8 @@ Grids Manager:
 Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
-  Point Grid:
-    precip_liq_surf_mass: 0.0
-    precip_ice_surf_mass: 0.0
+  precip_liq_surf_mass: 0.0
+  precip_ice_surf_mass: 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -29,6 +29,10 @@ Grids Manager:
 # Specifications for setting initial conditions
 Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
+  aero_g_sw: 0.0
+  aero_ssa_sw: 0.0
+  aero_tau_sw: 0.0
+  aero_tau_lw: 0.0
   Point Grid:
     Load Latitude:  true
     Load Longitude: true

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -33,9 +33,8 @@ Initial Conditions:
   aero_ssa_sw: 0.0
   aero_tau_sw: 0.0
   aero_tau_lw: 0.0
-  Point Grid:
-    Load Latitude:  true
-    Load Longitude: true
+  Load Latitude:  true
+  Load Longitude: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -24,28 +24,31 @@ Grids Manager:
 
 # Specifications for setting initial conditions
 Initial Conditions:
-  Point Grid:
-    p_mid: 0.0
-    p_int: 0.0
-    pseudo_density: 0.0
-    T_mid: 0.0
-    surf_lw_flux_up: 0.0
-    sfc_alb_dir_vis: 0.0
-    sfc_alb_dir_nir: 0.0
-    sfc_alb_dif_vis: 0.0
-    sfc_alb_dif_nir: 0.0
-    cos_zenith: 0.0
-    qc: 0.0
-    qi: 0.0
-    cldfrac_tot: 0.0
-    eff_radius_qc: 0.0
-    eff_radius_qi: 0.0
-    qv: 0.0
-    co2: 0.0
-    o3: 0.0
-    n2o: 0.0
-    co: 0.0
-    ch4: 0.0
-    o2: 0.0
-    n2: 0.0
+  p_mid: 0.0
+  p_int: 0.0
+  pseudo_density: 0.0
+  T_mid: 0.0
+  surf_lw_flux_up: 0.0
+  sfc_alb_dir_vis: 0.0
+  sfc_alb_dir_nir: 0.0
+  sfc_alb_dif_vis: 0.0
+  sfc_alb_dif_nir: 0.0
+  cos_zenith: 0.0
+  qc: 0.0
+  qi: 0.0
+  cldfrac_tot: 0.0
+  eff_radius_qc: 0.0
+  eff_radius_qi: 0.0
+  qv: 0.0
+  co2: 0.0
+  o3: 0.0
+  n2o: 0.0
+  co: 0.0
+  ch4: 0.0
+  o2: 0.0
+  n2: 0.0
+  aero_g_sw: 0.0
+  aero_ssa_sw: 0.0
+  aero_tau_sw: 0.0
+  aero_tau_lw: 0.0
 ...

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -26,8 +26,7 @@ Initial Conditions:
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
   surf_sens_flux: 0.0
   surf_evap: 0.0
-  Point Grid:
-    Load Latitude: true
+  Load Latitude: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -24,9 +24,10 @@ Grids Manager:
 Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
+  surf_latent_flux: 0.0
+  surf_sens_flux: 0.0
+  surf_evap: 0.0
   Point Grid:
-    surf_evap: 0.0
-    surf_sens_flux: 0.0
     Load Latitude: true
 
 # The parameters for I/O control

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -24,7 +24,6 @@ Grids Manager:
 Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
-  surf_latent_flux: 0.0
   surf_sens_flux: 0.0
   surf_evap: 0.0
   Point Grid:


### PR DESCRIPTION
Make initialization and generating initial condition files for EAMxx. This adds initialization for a number of fields we do not need to read from file for initial runs, either to constants (most physics fields) or idealized profiles (for pseudo-density). This is more similar to how EAM initializes, and allows us to derive EAMxx initial conditions almost entirely from EAM/SCREAMv0 initial conditions *without* running SCREAMv0 with special outputs. Stripped down initial condition files generated from EAM “cami” style ICs will be added and used as defaults in a subsequent PR. This will be non-BFB for any test that uses HOMME, since initialization of pseudo-density is changed to be computed assuming hydrostatic initial state from hybrid coefficients instead of being read from file, and CIME tests will be non-BFB also because initialization of physics fields have changed to be set to constants initially.