### PR TITLE
Add clear-sky fluxes

### DIFF
--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -96,7 +96,7 @@ public:
   struct Buffer {
     static constexpr int num_1d_ncol        = 10;
     static constexpr int num_2d_nlay        = 14;
-    static constexpr int num_2d_nlay_p1     = 7;
+    static constexpr int num_2d_nlay_p1     = 12;
     static constexpr int num_2d_nswbands    = 2;
     static constexpr int num_3d_nlev_nswbands = 4;
     static constexpr int num_3d_nlev_nlwbands = 2;
@@ -139,6 +139,11 @@ public:
     real2d sw_flux_dn_dir;
     real2d lw_flux_up;
     real2d lw_flux_dn;
+    real2d sw_clrsky_flux_up;
+    real2d sw_clrsky_flux_dn;
+    real2d sw_clrsky_flux_dn_dir;
+    real2d lw_clrsky_flux_up;
+    real2d lw_clrsky_flux_dn;
 
     // 3d size (ncol, nlay+1, nswbands)
     real3d sw_bnd_flux_up;

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -203,6 +203,8 @@ namespace scream {
                 real3d &aer_tau_lw,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
                 real2d &lw_flux_up, real2d &lw_flux_dn,
+                real2d &sw_clrsky_flux_up, real2d &sw_clrsky_flux_dn, real2d &sw_clrsky_flux_dn_dir,
+                real2d &lw_clrsky_flux_up, real2d &lw_clrsky_flux_dn,
                 real3d &sw_bnd_flux_up, real3d &sw_bnd_flux_dn, real3d &sw_bnd_flux_dn_dir,
                 real3d &lw_bnd_flux_up, real3d &lw_bnd_flux_dn,
                 const Real tsi_scaling,
@@ -231,6 +233,11 @@ namespace scream {
             fluxes_sw.bnd_flux_up = sw_bnd_flux_up;
             fluxes_sw.bnd_flux_dn = sw_bnd_flux_dn;
             fluxes_sw.bnd_flux_dn_dir = sw_bnd_flux_dn_dir;
+            // Clear-sky
+            FluxesByband clrsky_fluxes_sw;
+            clrsky_fluxes_sw.flux_up = sw_clrsky_flux_up;
+            clrsky_fluxes_sw.flux_dn = sw_clrsky_flux_dn;
+            clrsky_fluxes_sw.flux_dn_dir = sw_clrsky_flux_dn_dir;
 
             // Setup pointers to RRTMGP LW fluxes
             FluxesByband fluxes_lw;
@@ -238,6 +245,10 @@ namespace scream {
             fluxes_lw.flux_dn = lw_flux_dn;
             fluxes_lw.bnd_flux_up = lw_bnd_flux_up;
             fluxes_lw.bnd_flux_dn = lw_bnd_flux_dn;
+            // Clear-sky
+            FluxesByband clrsky_fluxes_lw;
+            clrsky_fluxes_lw.flux_up = lw_clrsky_flux_up;
+            clrsky_fluxes_lw.flux_dn = lw_clrsky_flux_dn;
 
             auto nswbands = k_dist_sw.get_nband();
             auto nlwbands = k_dist_lw.get_nband();
@@ -289,7 +300,8 @@ namespace scream {
             rrtmgp_sw(
                 ncol, nlay,
                 k_dist_sw, p_lay, t_lay, p_lev, t_lev, gas_concs, 
-                sfc_alb_dir, sfc_alb_dif, mu0, aerosol_sw, clouds_sw, fluxes_sw,
+                sfc_alb_dir, sfc_alb_dif, mu0, aerosol_sw, clouds_sw,
+                fluxes_sw, clrsky_fluxes_sw,
                 tsi_scaling, logger
             );
 
@@ -297,7 +309,8 @@ namespace scream {
             rrtmgp_lw(
                 ncol, nlay,
                 k_dist_lw, p_lay, t_lay, p_lev, t_lev, gas_concs,
-                aerosol_lw, clouds_lw, fluxes_lw
+                aerosol_lw, clouds_lw,
+                fluxes_lw, clrsky_fluxes_lw
             );
             
             // Calculate heating rates
@@ -364,7 +377,7 @@ namespace scream {
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0, 
                 OpticalProps2str &aerosol, OpticalProps2str &clouds,
-                FluxesByband &fluxes,
+                FluxesByband &fluxes, FluxesByband &clrsky_fluxes,
                 const Real tsi_scaling,
                 const std::shared_ptr<spdlog::logger>& logger) {
 
@@ -380,12 +393,18 @@ namespace scream {
             auto &bnd_flux_up = fluxes.bnd_flux_up;
             auto &bnd_flux_dn = fluxes.bnd_flux_dn;
             auto &bnd_flux_dn_dir = fluxes.bnd_flux_dn_dir;
+            auto &clrsky_flux_up = clrsky_fluxes.flux_up;
+            auto &clrsky_flux_dn = clrsky_fluxes.flux_dn;
+            auto &clrsky_flux_dn_dir = clrsky_fluxes.flux_dn_dir;
 
             // Reset fluxes to zero
             parallel_for(Bounds<2>(nlay+1,ncol), YAKL_LAMBDA(int ilev, int icol) {
                 flux_up    (icol,ilev) = 0;
                 flux_dn    (icol,ilev) = 0;
                 flux_dn_dir(icol,ilev) = 0;
+                clrsky_flux_up    (icol,ilev) = 0;
+                clrsky_flux_dn    (icol,ilev) = 0;
+                clrsky_flux_dn_dir(icol,ilev) = 0;
             });
             parallel_for(Bounds<3>(nbnd,nlay+1,ncol), YAKL_LAMBDA(int ibnd, int ilev, int icol) {
                 bnd_flux_up    (icol,ilev,ibnd) = 0;
@@ -479,6 +498,21 @@ namespace scream {
                 sfc_alb_dif_T(ibnd,icol) = sfc_alb_dif(dayIndices(icol),ibnd);
             });
 
+            // Temporaries we need for daytime-only fluxes
+            auto flux_up_day = real2d("flux_up_day", nday, nlay+1);
+            auto flux_dn_day = real2d("flux_dn_day", nday, nlay+1);
+            auto flux_dn_dir_day = real2d("flux_dn_dir_day", nday, nlay+1);
+            auto bnd_flux_up_day = real3d("bnd_flux_up_day", nday, nlay+1, nbnd);
+            auto bnd_flux_dn_day = real3d("bnd_flux_dn_day", nday, nlay+1, nbnd);
+            auto bnd_flux_dn_dir_day = real3d("bnd_flux_dn_dir_day", nday, nlay+1, nbnd);
+            FluxesByband fluxes_day;
+            fluxes_day.flux_up         = flux_up_day;
+            fluxes_day.flux_dn         = flux_dn_day;
+            fluxes_day.flux_dn_dir     = flux_dn_dir_day;
+            fluxes_day.bnd_flux_up     = bnd_flux_up_day;
+            fluxes_day.bnd_flux_dn     = bnd_flux_dn_day;
+            fluxes_day.bnd_flux_dn_dir = bnd_flux_dn_dir_day;
+
             // Allocate space for optical properties
             OpticalProps2str optics;
             optics.alloc_2str(nday, nlay, k_dist);
@@ -506,26 +540,23 @@ namespace scream {
             aerosol_day.delta_scale();
             aerosol_day.increment(optics);
 
+            // Compute clearsky (gas + aerosol) fluxes on daytime columns
+            rte_sw(optics, top_at_1, mu0_day, toa_flux, sfc_alb_dir_T, sfc_alb_dif_T, fluxes_day);
+            // Expand daytime fluxes to all columns
+            parallel_for(Bounds<2>(nlay+1,nday), YAKL_LAMBDA(int ilev, int iday) {
+                int icol = dayIndices(iday);
+                clrsky_flux_up    (icol,ilev) = flux_up_day    (iday,ilev);
+                clrsky_flux_dn    (icol,ilev) = flux_dn_day    (iday,ilev);
+                clrsky_flux_dn_dir(icol,ilev) = flux_dn_dir_day(iday,ilev);
+            });
+
+            // Now merge in cloud optics and do allsky calculations
+
             // Combine gas and cloud optics
             clouds_day.delta_scale();
             clouds_day.increment(optics);
-
             // Compute fluxes on daytime columns
-            auto flux_up_day = real2d("flux_up_day", nday, nlay+1);
-            auto flux_dn_day = real2d("flux_dn_day", nday, nlay+1);
-            auto flux_dn_dir_day = real2d("flux_dn_dir_day", nday, nlay+1);
-            auto bnd_flux_up_day = real3d("bnd_flux_up_day", nday, nlay+1, nbnd);
-            auto bnd_flux_dn_day = real3d("bnd_flux_dn_day", nday, nlay+1, nbnd);
-            auto bnd_flux_dn_dir_day = real3d("bnd_flux_dn_dir_day", nday, nlay+1, nbnd);
-            FluxesByband fluxes_day;
-            fluxes_day.flux_up         = flux_up_day;
-            fluxes_day.flux_dn         = flux_dn_day;
-            fluxes_day.flux_dn_dir     = flux_dn_dir_day;
-            fluxes_day.bnd_flux_up     = bnd_flux_up_day;
-            fluxes_day.bnd_flux_dn     = bnd_flux_dn_day;
-            fluxes_day.bnd_flux_dn_dir = bnd_flux_dn_dir_day;
             rte_sw(optics, top_at_1, mu0_day, toa_flux, sfc_alb_dir_T, sfc_alb_dif_T, fluxes_day);
-
             // Expand daytime fluxes to all columns
             parallel_for(Bounds<2>(nlay+1,nday), YAKL_LAMBDA(int ilev, int iday) {
                 int icol = dayIndices(iday);
@@ -548,7 +579,7 @@ namespace scream {
                 GasConcs &gas_concs,
                 OpticalProps1scl &aerosol,
                 OpticalProps1scl &clouds,
-                FluxesByband &fluxes) {
+                FluxesByband &fluxes, FluxesByband &clrsky_fluxes) {
 
             // Problem size
             int nbnd = k_dist.get_nband();
@@ -569,21 +600,7 @@ namespace scream {
             parallel_for(Bounds<1>(ncol), YAKL_LAMBDA(int icol) {
                 t_sfc(icol) = t_lev(icol, merge(nlay+1, 1, top_at_1));
             });
-            memset( emis_sfc , 0.98_wp                                   );
-
-            // Do gas optics
-            k_dist.gas_optics(ncol, nlay, top_at_1, p_lay, p_lev, t_lay, t_sfc, gas_concs, optics, lw_sources, real2d(), t_lev);
-
-#ifdef SCREAM_RRTMGP_DEBUG
-            // Check gas optics
-            check_range(optics.tau,  0, std::numeric_limits<Real>::max(), "rrtmgp_lw:optics.tau");
-#endif
-
-            // Combine gas and aerosol optics
-            aerosol.increment(optics);
-
-            // Combine gas and cloud optics
-            clouds.increment(optics);
+            memset(emis_sfc , 0.98_wp);
 
             // Get Gaussian quadrature weights
             // TODO: move this crap out of userland!
@@ -608,7 +625,25 @@ namespace scream {
             gauss_Ds_host .deep_copy_to(gauss_Ds );
             gauss_wts_host.deep_copy_to(gauss_wts);
 
-            // Compute fluxes
+
+            // Do gas optics
+            k_dist.gas_optics(ncol, nlay, top_at_1, p_lay, p_lev, t_lay, t_sfc, gas_concs, optics, lw_sources, real2d(), t_lev);
+
+#ifdef SCREAM_RRTMGP_DEBUG
+            // Check gas optics
+            check_range(optics.tau,  0, std::numeric_limits<Real>::max(), "rrtmgp_lw:optics.tau");
+#endif
+
+            // Combine gas and aerosol optics
+            aerosol.increment(optics);
+
+            // Compute clear-sky fluxes before we add in clouds
+            rte_lw(max_gauss_pts, gauss_Ds, gauss_wts, optics, top_at_1, lw_sources, emis_sfc, clrsky_fluxes);
+
+            // Combine gas and cloud optics
+            clouds.increment(optics);
+
+            // Compute allsky fluxes
             rte_lw(max_gauss_pts, gauss_Ds, gauss_wts, optics, top_at_1, lw_sources, emis_sfc, fluxes);
 
         }

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -67,6 +67,8 @@ namespace scream {
                 real3d &aer_tau_lw,
                 real2d &sw_flux_up, real2d &sw_flux_dn, real2d &sw_flux_dn_dir,
                 real2d &lw_flux_up, real2d &lw_flux_dn,
+                real2d &sw_clrsky_flux_up, real2d &sw_clrsky_flux_dn, real2d &sw_clrsky_flux_dn_dir,
+                real2d &lw_clrsky_flux_up, real2d &lw_clrsky_flux_dn,
                 real3d &sw_bnd_flux_up, real3d &sw_bnd_flux_dn, real3d &sw_bnd_flux_dn_dir,
                 real3d &lw_bnd_flux_up, real3d &lw_bnd_flux_dn,
                 const Real tsi_scaling,
@@ -84,7 +86,7 @@ namespace scream {
                 GasConcs &gas_concs,
                 real2d &sfc_alb_dir, real2d &sfc_alb_dif, real1d &mu0,
                 OpticalProps2str &aerosol, OpticalProps2str &clouds,
-                FluxesByband &fluxes, const Real tsi_scaling,
+                FluxesByband &fluxes, FluxesByband &clrsky_fluxes, const Real tsi_scaling,
                 const std::shared_ptr<spdlog::logger>& logger);
         /*
          * Longwave driver (called by rrtmgp_main)
@@ -95,7 +97,7 @@ namespace scream {
                 real2d &p_lay, real2d &t_lay, real2d &p_lev, real2d &t_lev,
                 GasConcs &gas_concs,
                 OpticalProps1scl &aerosol, OpticalProps1scl &clouds,
-                FluxesByband &fluxes);
+                FluxesByband &fluxes, FluxesByband &clrsky_fluxes);
         /* 
          * Provide a function to convert cloud (water and ice) mixing ratios to layer mass per unit area
          * (what E3SM refers to as "in-cloud water paths", a terminology we shun here to avoid confusion

--- a/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
@@ -101,6 +101,11 @@ int main (int argc, char** argv) {
     real2d sw_flux_dn_dir("sw_flux_dn_dir", ncol, nlay+1);
     real2d lw_flux_up ("lw_flux_up" , ncol, nlay+1);
     real2d lw_flux_dn ("lw_flux_dn" , ncol, nlay+1);
+    real2d sw_clrsky_flux_up ("sw_clrsky_flux_up" , ncol, nlay+1);
+    real2d sw_clrsky_flux_dn ("sw_clrsky_flux_dn" , ncol, nlay+1);
+    real2d sw_clrsky_flux_dn_dir("sw_clrsky_flux_dn_dir", ncol, nlay+1);
+    real2d lw_clrsky_flux_up ("lw_clrsky_flux_up" , ncol, nlay+1);
+    real2d lw_clrsky_flux_dn ("lw_clrsky_flux_dn" , ncol, nlay+1);
     real3d sw_bnd_flux_up ("sw_bnd_flux_up" , ncol, nlay+1, nswbands);
     real3d sw_bnd_flux_dn ("sw_bnd_flux_dn" , ncol, nlay+1, nswbands);
     real3d sw_bnd_flux_dir("sw_bnd_flux_dir", ncol, nlay+1, nswbands);
@@ -144,6 +149,8 @@ int main (int argc, char** argv) {
         aer_tau_lw,
         sw_flux_up, sw_flux_dn, sw_flux_dn_dir,
         lw_flux_up, lw_flux_dn,
+        sw_clrsky_flux_up, sw_clrsky_flux_dn, sw_clrsky_flux_dn_dir,
+        lw_clrsky_flux_up, lw_clrsky_flux_dn,
         sw_bnd_flux_up, sw_bnd_flux_dn, sw_bnd_flux_dir,
         lw_bnd_flux_up, lw_bnd_flux_dn, tsi_scaling,
         logger
@@ -191,6 +198,11 @@ int main (int argc, char** argv) {
     sw_flux_dn_dir.deallocate();
     lw_flux_up.deallocate();
     lw_flux_dn.deallocate();
+    sw_clrsky_flux_up.deallocate();
+    sw_clrsky_flux_dn.deallocate();
+    sw_clrsky_flux_dn_dir.deallocate();
+    lw_clrsky_flux_up.deallocate();
+    lw_clrsky_flux_dn.deallocate();
     sw_bnd_flux_up.deallocate();
     sw_bnd_flux_dn.deallocate();
     sw_bnd_flux_dir.deallocate();

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
@@ -135,6 +135,11 @@ int run(int argc, char** argv) {
     real2d sw_flux_dir("sw_flux_dir", ncol, nlay+1);
     real2d lw_flux_up ("lw_flux_up" , ncol, nlay+1);
     real2d lw_flux_dn ("lw_flux_dn" , ncol, nlay+1);
+    real2d sw_clrsky_flux_up ("sw_clrsky_flux_up" , ncol, nlay+1);
+    real2d sw_clrsky_flux_dn ("sw_clrsky_flux_dn" , ncol, nlay+1);
+    real2d sw_clrsky_flux_dir("sw_clrsky_flux_dir", ncol, nlay+1);
+    real2d lw_clrsky_flux_up ("lw_clrsky_flux_up" , ncol, nlay+1);
+    real2d lw_clrsky_flux_dn ("lw_clrsky_flux_dn" , ncol, nlay+1);
     real3d sw_bnd_flux_up ("sw_bnd_flux_up" , ncol, nlay+1, nswbands);
     real3d sw_bnd_flux_dn ("sw_bnd_flux_dn" , ncol, nlay+1, nswbands);
     real3d sw_bnd_flux_dir("sw_bnd_flux_dir", ncol, nlay+1, nswbands);
@@ -176,6 +181,8 @@ int run(int argc, char** argv) {
             aer_tau_lw,
             sw_flux_up, sw_flux_dn, sw_flux_dir,
             lw_flux_up, lw_flux_dn,
+            sw_clrsky_flux_up, sw_clrsky_flux_dn, sw_clrsky_flux_dir,
+            lw_clrsky_flux_up, lw_clrsky_flux_dn,
             sw_bnd_flux_up, sw_bnd_flux_dn, sw_bnd_flux_dir,
             lw_bnd_flux_up, lw_bnd_flux_dn, tsi_scaling, logger);
 
@@ -206,6 +213,11 @@ int run(int argc, char** argv) {
     sw_flux_dir.deallocate();
     lw_flux_up.deallocate();
     lw_flux_dn.deallocate();
+    sw_clrsky_flux_up.deallocate();
+    sw_clrsky_flux_dn.deallocate();
+    sw_clrsky_flux_dir.deallocate();
+    lw_clrsky_flux_up.deallocate();
+    lw_clrsky_flux_dn.deallocate();
     sw_bnd_flux_up.deallocate();
     sw_bnd_flux_dn.deallocate();
     sw_bnd_flux_dir.deallocate();


### PR DESCRIPTION
Add calculation for clear-sky radiative fluxes, and add corresponding fields to the field manager so that they can be output. Note that this will increase the cost of radiation somewhat, since the flux solvers need to be called an additional time (before cloud optical properties are merged in, and after). New fields added to FM for purposes of output are:
```
SW_clearsky_flux_up
SW_clearsky_flux_dn
SW_clearsky_flux_dn_dir
LW_clearsky_flux_up
LW_clearsky_flux_dn
```