### PR TITLE
Fix how precipitation is handled so that it is still correct with subcycling.

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -240,6 +240,8 @@ tweaking their $case/namelist_scream.xml file.
     <Filename hgrid="ne30np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne30np4_L128_20211202.nc</Filename> <!-- This will need to be updated to the new nccn name -->
     <Physics__GLL>
       <surf_evap>0.0</surf_evap> <!-- TODO, Delete this when the IC fixes come in -->
+      <precip_liq_surf_mass>0.0</precip_liq_surf_mass>
+      <precip_ice_surf_mass>0.0</precip_ice_surf_mass>
     </Physics__GLL>
     <Restart__Casename>${CASE}.scream</Restart__Casename>
   </Initial__Conditions>

--- a/components/scream/data/scream_default_output.yaml
+++ b/components/scream/data/scream_default_output.yaml
@@ -33,8 +33,8 @@ Fields:
       - qr
       - eff_radius_qc
       - eff_radius_qi
-      - precip_ice_surf
-      - precip_liq_surf
+      - precip_ice_surf_mass
+      - precip_liq_surf_mass
       # SHOC + P3
       - qc
       - qv

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -949,7 +949,7 @@ void AtmosphereDriver::run (const int dt) {
 
   if (m_surface_coupling) {
     // Export fluxes from the component coupler (if any)
-    m_surface_coupling->do_export();
+    m_surface_coupling->do_export(dt);
   }
 
 #ifdef SCREAM_HAS_MEMORY_USAGE

--- a/components/scream/src/control/surface_coupling.cpp
+++ b/components/scream/src/control/surface_coupling.cpp
@@ -164,7 +164,7 @@ register_export (const std::string& fname,
   //      a. fname == set_zero, which indicates that this field is not used in SCREAM.
   //      c. fname corresponeds to a field which is a combination of SCREAM fields.
   //      For these special cases, we have member variable 1d views which we will store the correct
-  //      values at the surface for each field during do_export(). Here, just set the data
+  //      values at the surface for each field during do_export(dt). Here, just set the data
   //      to point to these views, and fill in stride/offset info using a field setup in
   //      the constructor of the class
   if (m_field_mgr->has_field(fname)) {

--- a/components/scream/src/control/surface_coupling.hpp
+++ b/components/scream/src/control/surface_coupling.hpp
@@ -70,7 +70,7 @@ public:
   // Export device fields from the AD to host fields in the component coupler.
   // If this export is called during the init phase, set init_phase=true
   // so that fields which are computed inside SCREAM during the run phase are skipped.
-  void do_export (const bool init_phase = false);
+  void do_export (const int dt, const bool init_phase = false);
 
   // Getters
   RepoState get_repo_state () const { return m_state; }

--- a/components/scream/src/control/surface_coupling_export.cpp
+++ b/components/scream/src/control/surface_coupling_export.cpp
@@ -22,27 +22,27 @@ void SurfaceCoupling::do_export (const int dt, const bool init_phase)
   const bool scream_ad_run =
       (m_field_mgr->has_field("qv") && m_field_mgr->has_field("T_mid") &&
        m_field_mgr->has_field("p_mid") && m_field_mgr->has_field("pseudo_density") &&
-       m_field_mgr->has_field("precip_liq_surf") && m_field_mgr->has_field("precip_ice_surf") &&
+       m_field_mgr->has_field("precip_liq_surf_mass") && m_field_mgr->has_field("precip_ice_surf_mass") &&
        m_field_mgr->has_field("p_int") && m_field_mgr->has_field("phis") );
   if (scream_ad_run) {
     const int last_entry = m_num_levs-1;
-    const auto& qv              = m_field_mgr->get_field("qv").get_view<const Real**>();
-    const auto& T_mid           = m_field_mgr->get_field("T_mid").get_view<const Real**>();
-    const auto& p_mid           = m_field_mgr->get_field("p_mid").get_view<const Real**>();
-    const auto& p_int           = m_field_mgr->get_field("p_int").get_view<const Real**>();
-    const auto& pseudo_density  = m_field_mgr->get_field("pseudo_density").get_view<const Real**>();
-    const auto& precip_liq_surf = m_field_mgr->get_field("precip_liq_surf").get_view<Real*>(); // TODO: go back to const when AD takes care of zeroing out precip fluxes.
-    const auto& precip_ice_surf = m_field_mgr->get_field("precip_ice_surf").get_view<Real*>();
-    const auto& phis            = m_field_mgr->get_field("phis").get_view<const Real*>();
-    const auto l_dz             = dz;
-    const auto l_z_int          = z_int;
-    const auto l_z_mid          = z_mid;
-    const auto l_Sa_z           = Sa_z;
-    const auto l_Sa_ptem        = Sa_ptem;
-    const auto l_Sa_dens        = Sa_dens;
-    const auto l_Sa_pslv        = Sa_pslv;
-    const auto l_Faxa_rainl     = Faxa_rainl;
-    const auto l_Faxa_snowl     = Faxa_snowl;
+    const auto& qv                   = m_field_mgr->get_field("qv").get_view<const Real**>();
+    const auto& T_mid                = m_field_mgr->get_field("T_mid").get_view<const Real**>();
+    const auto& p_mid                = m_field_mgr->get_field("p_mid").get_view<const Real**>();
+    const auto& p_int                = m_field_mgr->get_field("p_int").get_view<const Real**>();
+    const auto& pseudo_density       = m_field_mgr->get_field("pseudo_density").get_view<const Real**>();
+    const auto& precip_liq_surf_mass = m_field_mgr->get_field("precip_liq_surf_mass").get_view<Real*>(); // TODO: go back to const when AD takes care of zeroing out precip fluxes.
+    const auto& precip_ice_surf_mass = m_field_mgr->get_field("precip_ice_surf_mass").get_view<Real*>();
+    const auto& phis                 = m_field_mgr->get_field("phis").get_view<const Real*>();
+    const auto l_dz                  = dz;
+    const auto l_z_int               = z_int;
+    const auto l_z_mid               = z_mid;
+    const auto l_Sa_z                = Sa_z;
+    const auto l_Sa_ptem             = Sa_ptem;
+    const auto l_Sa_dens             = Sa_dens;
+    const auto l_Sa_pslv             = Sa_pslv;
+    const auto l_Faxa_rainl          = Faxa_rainl;
+    const auto l_Faxa_snowl          = Faxa_snowl;
 
     // Local copy, to deal with CUDA's handling of *this.
     const int num_levs = m_num_levs;
@@ -80,15 +80,15 @@ void SurfaceCoupling::do_export (const int dt, const bool init_phase)
       l_Sa_dens(i)    = PF::calculate_density(pseudo_density_i(last_entry), dz_i(last_entry));
       l_Sa_pslv(i)    = PF::calculate_psl(T_int_bot, p_int_i(num_levs), phis(i) );
       // Precipitation has units of kg, so we need to convert to a flux with units of kg/s
-      l_Faxa_rainl(i) = precip_liq_surf(i) / dt;
-      l_Faxa_snowl(i) = precip_ice_surf(i) / dt;
+      l_Faxa_rainl(i) = precip_liq_surf_mass(i) / dt;
+      l_Faxa_snowl(i) = precip_ice_surf_mass(i) / dt;
     });
     Kokkos::fence();
     // It is the responsibility of the surface coupling to zero out the precipitation flux
     // now that it has been assigned to the coupling variable.  TODO: Have the atmosphere
     // driver actually do this in a consistent way - see Issue #1767
-    Kokkos::deep_copy(precip_liq_surf,0.0);
-    Kokkos::deep_copy(precip_ice_surf,0.0);
+    Kokkos::deep_copy(precip_liq_surf_mass,0.0);
+    Kokkos::deep_copy(precip_ice_surf_mass,0.0);
   }
 
   // Local copies, to deal with CUDA's handling of *this.

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -284,8 +284,8 @@ TEST_CASE ("recreate_mct_coupling")
   FID horiz_winds_id     ("horiz_winds",     vector3d_layout, m/s,    grid_name);
   FID pseudo_density_id  ("pseudo_density",  scalar3d_layout, Pa,     grid_name);
   FID qv_id              ("qv",              scalar3d_layout, nondim, grid_name);
-  FID precip_liq_surf_id ("precip_liq_surf", scalar2d_layout, m/s,    grid_name);
-  FID precip_ice_surf_id ("precip_ice_surf", scalar2d_layout, m/s,    grid_name);
+  FID precip_liq_surf_id ("precip_liq_surf_mass", scalar2d_layout, kg,    grid_name);
+  FID precip_ice_surf_id ("precip_ice_surf_mass", scalar2d_layout, kg,    grid_name);
   FID sfc_flux_dir_nir_id("sfc_flux_dir_nir", scalar2d_layout, W/(m*m), grid_name);
   FID sfc_flux_dir_vis_id("sfc_flux_dir_vis", scalar2d_layout, W/(m*m), grid_name);
   FID sfc_flux_dif_nir_id("sfc_flux_dif_nir", scalar2d_layout, W/(m*m), grid_name);

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -26,6 +26,7 @@ TEST_CASE ("surface_coupling")
   using FR = FieldRequest;
   using GR = GroupRequest;
   using RPDF = std::uniform_real_distribution<Real>;
+  using IPDF = std::uniform_int_distribution<int>;
 
   // Some constants
   constexpr int ncols = 4;
@@ -38,6 +39,10 @@ TEST_CASE ("surface_coupling")
   // The random numbers generator
   auto engine = setup_random_test(&comm);
   RPDF pdf(0.0,1.0);
+  IPDF dt_pdf(1,1800);
+
+  // Set dt for test
+  const int dt = dt_pdf(engine);
 
   // Create a grid
   auto grid = create_point_grid("my grid",ncols*comm.size(), nlevs, comm);
@@ -180,7 +185,7 @@ TEST_CASE ("surface_coupling")
     std::fill_n(raw_data,ncols*num_fields,-1);
 
     // Perform export
-    exporter.do_export();
+    exporter.do_export(dt);
 
     // Perform import
     importer.do_import();
@@ -221,7 +226,7 @@ TEST_CASE ("recreate_mct_coupling")
    * This test aims to recreate the import/export of fields inside the mct-coupling
    * for CIME runs. Much of the code inside surface coupling is hard-coded for these runs.
    */
-
+  
   // Some namespaces/aliases
   using namespace scream;
   using namespace ShortFieldTagsNames;
@@ -231,6 +236,7 @@ TEST_CASE ("recreate_mct_coupling")
   using FR     = FieldRequest;
   using GR     = GroupRequest;
   using RPDF   = std::uniform_real_distribution<Real>;
+  using IPDF = std::uniform_int_distribution<int>;
   using C = scream::physics::Constants<Real>;
 
   // Some constants
@@ -244,6 +250,10 @@ TEST_CASE ("recreate_mct_coupling")
   // The random numbers generator
   auto engine = setup_random_test(&comm);
   RPDF pdf(0.0,1.0);
+  IPDF dt_pdf(1,1800);
+
+  // Set dt for test
+  const int dt = dt_pdf(engine);
 
   // Create a grid
   auto grid = create_point_grid("my_grid",ncols*comm.size(), nlevs, comm);
@@ -397,6 +407,15 @@ TEST_CASE ("recreate_mct_coupling")
   auto p_int_h            = p_int_f.get_view<Real**,Host>();
   auto phis_h             = phis_f.get_view<Real*,Host>();
 
+  // We need a copy of precip to check export is correct, since precip will be zeroed out after do_export is called.
+  // TODO: This step can be undone once we have the AD take care of resetting precip fluxes.
+  auto precip_liq_surf_copy_f = precip_liq_surf_f.clone(); 
+  auto precip_ice_surf_copy_f = precip_ice_surf_f.clone(); 
+  auto precip_liq_surf_copy_d = precip_liq_surf_copy_f.get_view<Real*>();
+  auto precip_ice_surf_copy_d = precip_ice_surf_copy_f.get_view<Real*>();
+  auto precip_liq_surf_copy_h = precip_liq_surf_copy_f.get_view<Real*,Host>();
+  auto precip_ice_surf_copy_h = precip_ice_surf_copy_f.get_view<Real*,Host>();
+
   // Create SC object and set number of import/export fields
   control::SurfaceCoupling coupler(fm);
   coupler.set_num_fields(num_cpl_imports, num_scream_imports, num_cpl_exports);
@@ -497,6 +516,10 @@ TEST_CASE ("recreate_mct_coupling")
     ekat::genRandArray(pseudo_density_d,engine,pdf);
     ekat::genRandArray(precip_liq_surf_d,engine,pdf);
     ekat::genRandArray(precip_ice_surf_d,engine,pdf);
+    // Copy precip_liq/ice_surf to the copy we need for comparison
+    Kokkos::deep_copy(precip_liq_surf_copy_d,precip_liq_surf_d);
+    Kokkos::deep_copy(precip_ice_surf_copy_d,precip_ice_surf_d);
+    // TODO: These deep copies won't be needed when the AD handles resetting precip
     ekat::genRandArray(sfc_flux_lw_dn_d,engine,pdf);
     ekat::genRandArray(sfc_flux_dir_nir_d,engine,pdf);
     ekat::genRandArray(sfc_flux_dir_vis_d,engine,pdf);
@@ -520,7 +543,7 @@ TEST_CASE ("recreate_mct_coupling")
     coupler.do_import();
 
     // Perform export
-    coupler.do_export();
+    coupler.do_export(dt);
 
     // Sync host to device
     surf_evap_f.sync_to_host();
@@ -569,8 +592,8 @@ TEST_CASE ("recreate_mct_coupling")
       REQUIRE (export_raw_data[4 + icol*num_cpl_exports]  == T_mid_h          (icol,    nlevs-1)); // 5th export
       REQUIRE (export_raw_data[6 + icol*num_cpl_exports]  == qv_h             (icol,    nlevs-1)); // 7th export
       REQUIRE (export_raw_data[7 + icol*num_cpl_exports]  == p_mid_h          (icol,    nlevs-1)); // 8th export
-      REQUIRE (export_raw_data[15 + icol*num_cpl_exports] == C::RHO_H2O*precip_liq_surf_h(icol));  // 16th export
-      REQUIRE (export_raw_data[16 + icol*num_cpl_exports] == C::RHO_H2O*precip_ice_surf_h(icol));  // 17th export
+      REQUIRE (export_raw_data[15 + icol*num_cpl_exports] == precip_liq_surf_copy_h(icol) / dt  ); // 16th export
+      REQUIRE (export_raw_data[16 + icol*num_cpl_exports] == precip_ice_surf_copy_h(icol) / dt  ); // 17th export
       REQUIRE (export_raw_data[17 + icol*num_cpl_exports] == sfc_flux_lw_dn_h(icol));              // 18th export
       REQUIRE (export_raw_data[18 + icol*num_cpl_exports] == sfc_flux_dir_nir_h(icol));            // 19th export
       REQUIRE (export_raw_data[19 + icol*num_cpl_exports] == sfc_flux_dir_vis_h(icol));            // 20th export
@@ -598,6 +621,10 @@ TEST_CASE ("recreate_mct_coupling")
       REQUIRE (export_raw_data[33 + icol*num_cpl_exports] == 0);
       REQUIRE (export_raw_data[34 + icol*num_cpl_exports] == 0);
       REQUIRE (export_raw_data[35 + icol*num_cpl_exports] == 0); // 35th export
+
+      // precipitation should be set to zero.  TODO: Won't be needed when AD handles resetting precipitation.
+      REQUIRE (precip_liq_surf_h(icol) == 0 ); 
+      REQUIRE (precip_ice_surf_h(icol) == 0 ); 
     }
   }
 
@@ -621,6 +648,7 @@ TEST_CASE ("do_initial_export")
   using FL = FieldLayout;
   using FID = FieldIdentifier;
   using RPDF = std::uniform_real_distribution<Real>;
+  using IPDF = std::uniform_int_distribution<int>;
 
   // Some constants
   constexpr int ncols = 4;
@@ -633,6 +661,10 @@ TEST_CASE ("do_initial_export")
   // The random numbers generator
   auto engine = setup_random_test(&comm);
   RPDF pdf(0.0,1.0);
+  IPDF dt_pdf(1,1800);
+
+  // Set dt for test
+  const int dt = dt_pdf(engine);
 
   // Create a grid
   auto grid = create_point_grid("my grid",ncols*comm.size(), nlevs, comm);
@@ -683,7 +715,7 @@ TEST_CASE ("do_initial_export")
     ekat::genRandArray(f2_exp_d,engine,pdf);
 
     // Perform export with init_phase=true
-    exporter.do_export(true);
+    exporter.do_export(dt,true);
 
     // Check f1 was exported, but f2 was set to 0
     f1_exp.sync_to_host();
@@ -697,7 +729,7 @@ TEST_CASE ("do_initial_export")
     std::fill_n(raw_data,ncols*num_fields,-1);
 
     // Perform export with init_phase=false (default)
-    exporter.do_export();
+    exporter.do_export(dt);
 
     // Check that both f1 and f2 were exported
     f1_exp.sync_to_host();

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -149,7 +149,7 @@ void scream_setup_surface_coupling (
 
     // After registration we need to export all fields (except those that require scream computations)
     // as other models will need these values.
-    sc->do_export(true);
+    sc->do_export(0.0,true);
   });
 }
 

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -149,7 +149,7 @@ void scream_setup_surface_coupling (
 
     // After registration we need to export all fields (except those that require scream computations)
     // as other models will need these values.
-    sc->do_export(0.0,true);
+    sc->do_export(0.0,true);  // Using dt=0.0 here since do_export(true) shouldn't use variables not yet defined by physics.  If it does a dt=0.0 will likely throw an error.
   });
 }
 

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -97,10 +97,10 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_field<Updated> ("T_prev_micro_step",  scalar3d_layout_mid, K,        grid_name, ps);
 
   // Diagnostic Outputs: (all fields are just outputs w.r.t. P3)
-  add_field<Computed>("precip_liq_surf",    scalar2d_layout,     kg,     grid_name);
-  add_field<Computed>("precip_ice_surf",    scalar2d_layout,     kg,     grid_name);
-  add_field<Computed>("eff_radius_qc",      scalar3d_layout_mid, micron, grid_name, ps);
-  add_field<Computed>("eff_radius_qi",      scalar3d_layout_mid, micron, grid_name, ps);
+  add_field<Updated>("precip_liq_surf_mass", scalar2d_layout,     kg,     grid_name);
+  add_field<Updated>("precip_ice_surf_mass", scalar2d_layout,     kg,     grid_name);
+  add_field<Computed>("eff_radius_qc",       scalar3d_layout_mid, micron, grid_name, ps);
+  add_field<Computed>("eff_radius_qi",       scalar3d_layout_mid, micron, grid_name, ps);
 
   // History Only: (all fields are just outputs and are really only meant for I/O purposes)
   // TODO: These should be averaged over subcycle as well.  But there is no simple mechanism
@@ -208,8 +208,8 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nr"),m_grid,0.0,1.e9,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("ni"),m_grid,0.0,1.e9,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("bm"),m_grid,0.0,1.0,false);
-  add_postcondition_check<FieldLowerBoundCheck>(get_field_out("precip_liq_surf"),m_grid,0.0,false);
-  add_postcondition_check<FieldLowerBoundCheck>(get_field_out("precip_ice_surf"),m_grid,0.0,false);
+  add_postcondition_check<FieldLowerBoundCheck>(get_field_out("precip_liq_surf_mass"),m_grid,0.0,false);
+  add_postcondition_check<FieldLowerBoundCheck>(get_field_out("precip_ice_surf_mass"),m_grid,0.0,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qc"),m_grid,0.0,1.0e2,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qi"),m_grid,0.0,5.0e3,false);
 
@@ -235,8 +235,8 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   const  auto& ni             = get_field_out("ni").get_view<Pack**>();
   const  auto& bm             = get_field_out("bm").get_view<Pack**>();
   auto qv_prev                = get_field_out("qv_prev_micro_step").get_view<Pack**>();
-  const auto& precip_liq_surf_mass = get_field_out("precip_liq_surf").get_view<Real*>();
-  const auto& precip_ice_surf_mass = get_field_out("precip_ice_surf").get_view<Real*>();
+  const auto& precip_liq_surf_mass = get_field_out("precip_liq_surf_mass").get_view<Real*>();
+  const auto& precip_ice_surf_mass = get_field_out("precip_ice_surf_mass").get_view<Real*>();
 
   // Alias local variables from temporary buffer
   auto inv_exner  = m_buffer.inv_exner;

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -208,6 +208,9 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nr"),m_grid,0.0,1.e9,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("ni"),m_grid,0.0,1.e9,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("bm"),m_grid,0.0,1.0,false);
+  // The following checks on precip have been changed to lower bound checks, from an interval check.
+  // TODO: Change back to interval check when it is possible to pass dt_atm for the check.  Because
+  //       precip is now an accumulated mass, the upper bound is dependent on the timestep.
   add_postcondition_check<FieldLowerBoundCheck>(get_field_out("precip_liq_surf_mass"),m_grid,0.0,false);
   add_postcondition_check<FieldLowerBoundCheck>(get_field_out("precip_ice_surf_mass"),m_grid,0.0,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qc"),m_grid,0.0,1.0e2,false);

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -96,8 +96,8 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_field<Updated> ("T_prev_micro_step",  scalar3d_layout_mid, K,        grid_name, ps);
 
   // Diagnostic Outputs: (all fields are just outputs w.r.t. P3)
-  add_field<Computed>("precip_liq_surf",    scalar2d_layout,     m/s,    grid_name);
-  add_field<Computed>("precip_ice_surf",    scalar2d_layout,     m/s,    grid_name);
+  add_field<Computed>("precip_liq_surf",    scalar2d_layout,     kg,     grid_name);
+  add_field<Computed>("precip_ice_surf",    scalar2d_layout,     kg,     grid_name);
   add_field<Computed>("eff_radius_qc",      scalar3d_layout_mid, micron, grid_name, ps);
   add_field<Computed>("eff_radius_qi",      scalar3d_layout_mid, micron, grid_name, ps);
 
@@ -205,8 +205,8 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nr"),m_grid,0.0,1.e9,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("ni"),m_grid,0.0,1.e9,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("bm"),m_grid,0.0,1.0,false);
-  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("precip_liq_surf"),m_grid,0.0,0.001,false);
-  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("precip_ice_surf"),m_grid,0.0,0.001,false);
+  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("precip_liq_surf"),m_grid,0.0,100.0,false);
+  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("precip_ice_surf"),m_grid,0.0,100.0,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qc"),m_grid,0.0,1.0e2,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qi"),m_grid,0.0,5.0e3,false);
 

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -1,5 +1,6 @@
 #include "physics/p3/atmosphere_microphysics.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
+#include "share/property_checks/field_lower_bound_check.hpp"
 // Needed for p3_init, the only F90 code still used.
 #include "physics/p3/p3_functions.hpp"
 #include "physics/p3/p3_f90.hpp"
@@ -205,8 +206,8 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nr"),m_grid,0.0,1.e9,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("ni"),m_grid,0.0,1.e9,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("bm"),m_grid,0.0,1.0,false);
-  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("precip_liq_surf"),m_grid,0.0,100.0,false);
-  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("precip_ice_surf"),m_grid,0.0,100.0,false);
+  add_postcondition_check<FieldLowerBoundCheck>(get_field_out("precip_liq_surf"),m_grid,0.0,false);
+  add_postcondition_check<FieldLowerBoundCheck>(get_field_out("precip_ice_surf"),m_grid,0.0,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qc"),m_grid,0.0,1.0e2,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qi"),m_grid,0.0,5.0e3,false);
 

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -103,7 +103,9 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_field<Computed>("eff_radius_qi",      scalar3d_layout_mid, micron, grid_name, ps);
 
   // History Only: (all fields are just outputs and are really only meant for I/O purposes)
-  // TODO: question - should these be averaged over subcycle as well?
+  // TODO: These should be averaged over subcycle as well.  But there is no simple mechanism
+  //       yet to reset these values at the beginning of the atmosphere timestep.  When this
+  //       mechanism is developed we should add these variables to the accumulated variables.
   add_field<Computed>("micro_liq_ice_exchange", scalar3d_layout_mid, Q, grid_name, ps);
   add_field<Computed>("micro_vap_liq_exchange", scalar3d_layout_mid, Q, grid_name, ps);
   add_field<Computed>("micro_vap_ice_exchange", scalar3d_layout_mid, Q, grid_name, ps);
@@ -141,10 +143,10 @@ void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
   Real* mem = reinterpret_cast<Real*>(buffer_manager.get_memory());
 
   // 1d scalar views
-  m_buffer.precip_liq_surf = decltype(m_buffer.precip_liq_surf)(mem, m_num_cols);
-  mem += m_buffer.precip_liq_surf.size();
-  m_buffer.precip_ice_surf = decltype(m_buffer.precip_ice_surf)(mem, m_num_cols);
-  mem += m_buffer.precip_ice_surf.size();
+  m_buffer.precip_liq_surf_flux = decltype(m_buffer.precip_liq_surf_flux)(mem, m_num_cols);
+  mem += m_buffer.precip_liq_surf_flux.size();
+  m_buffer.precip_ice_surf_flux = decltype(m_buffer.precip_ice_surf_flux)(mem, m_num_cols);
+  mem += m_buffer.precip_ice_surf_flux.size();
 
   // 2d scalar views
   m_buffer.col_location = decltype(m_buffer.col_location)(mem, m_num_cols, 3);
@@ -233,8 +235,8 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   const  auto& ni             = get_field_out("ni").get_view<Pack**>();
   const  auto& bm             = get_field_out("bm").get_view<Pack**>();
   auto qv_prev                = get_field_out("qv_prev_micro_step").get_view<Pack**>();
-  const auto& precip_liq_surf = get_field_out("precip_liq_surf").get_view<Real*>();
-  const auto& precip_ice_surf = get_field_out("precip_ice_surf").get_view<Real*>();
+  const auto& precip_liq_surf_mass = get_field_out("precip_liq_surf").get_view<Real*>();
+  const auto& precip_ice_surf_mass = get_field_out("precip_ice_surf").get_view<Real*>();
 
   // Alias local variables from temporary buffer
   auto inv_exner  = m_buffer.inv_exner;
@@ -282,8 +284,8 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   diag_outputs.diag_eff_radius_qc = get_field_out("eff_radius_qc").get_view<Pack**>();
   diag_outputs.diag_eff_radius_qi = get_field_out("eff_radius_qi").get_view<Pack**>();
 
-  diag_outputs.precip_liq_surf  = m_buffer.precip_liq_surf;
-  diag_outputs.precip_ice_surf  = m_buffer.precip_ice_surf;
+  diag_outputs.precip_liq_surf  = m_buffer.precip_liq_surf_flux;
+  diag_outputs.precip_ice_surf  = m_buffer.precip_ice_surf_flux;
   diag_outputs.qv2qi_depos_tend = m_buffer.qv2qi_depos_tend;
   diag_outputs.rho_qi           = m_buffer.rho_qi;
   diag_outputs.precip_liq_flux  = m_buffer.precip_liq_flux;
@@ -299,7 +301,8 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
       prog_state.qv, prog_state.qc, prog_state.nc, prog_state.qr,prog_state.nr,
       prog_state.qi, prog_state.qm, prog_state.ni,prog_state.bm,qv_prev,
       diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi,
-      diag_outputs.precip_liq_surf,diag_outputs.precip_ice_surf,precip_liq_surf,precip_ice_surf);
+      diag_outputs.precip_liq_surf,diag_outputs.precip_ice_surf,
+      precip_liq_surf_mass,precip_ice_surf_mass);
 
   // Load tables
   P3F::init_kokkos_ice_lookup_tables(lookup_tables.ice_table_vals, lookup_tables.collect_table_vals);

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -31,6 +31,7 @@ namespace scream
   using WSM          = ekat::WorkspaceManager<Spack, KT::Device>;
 
   using view_1d  = typename P3F::view_1d<Real>;
+  using view_1d_const  = typename P3F::view_1d<const Real>;
   using view_2d  = typename P3F::view_2d<Spack>;
   using view_2d_const  = typename P3F::view_2d<const Spack>;
   using sview_2d = typename KokkosTypes<DefaultDevice>::template view_2d<Real>;
@@ -268,8 +269,8 @@ public:
     view_2d       qv_prev;
     view_2d       diag_eff_radius_qc;
     view_2d       diag_eff_radius_qi;
-    view_1d       precip_liq_surf_local;
-    view_1d       precip_ice_surf_local;
+    view_1d_const precip_liq_surf_local;
+    view_1d_const precip_ice_surf_local;
     view_1d       precip_liq_surf;
     view_1d       precip_ice_surf;
     // Assigning local values
@@ -284,7 +285,7 @@ public:
                     const view_2d& qi_, const view_2d& qm_, const view_2d& ni_, const view_2d& bm_,
                     const view_2d& qv_prev_, const view_2d& diag_eff_radius_qc_,
                     const view_2d& diag_eff_radius_qi_, 
-                    const view_1d& precip_liq_surf_local_, const view_1d& precip_ice_surf_local_,
+                    const view_1d_const& precip_liq_surf_local_, const view_1d_const& precip_ice_surf_local_,
                     const view_1d& precip_liq_surf_, const view_1d& precip_ice_surf_)
     {
       m_ncol  = ncol;

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -248,8 +248,8 @@ public:
         diag_eff_radius_qc(icol,ipack) *= 1e6;
         diag_eff_radius_qi(icol,ipack) *= 1e6;
       } // for ipack
-      precip_liq_surf(icol) += precip_liq_surf_local(icol) * PC::RHO_H2O * m_dt;
-      precip_ice_surf(icol) += precip_ice_surf_local(icol) * PC::RHO_H2O * m_dt;
+      precip_liq_surf_mass(icol) += precip_liq_surf_flux(icol) * PC::RHO_H2O * m_dt;
+      precip_ice_surf_mass(icol) += precip_ice_surf_flux(icol) * PC::RHO_H2O * m_dt;
     } // operator
     // Local variables
     int m_ncol, m_npack, m_dt;
@@ -269,10 +269,10 @@ public:
     view_2d       qv_prev;
     view_2d       diag_eff_radius_qc;
     view_2d       diag_eff_radius_qi;
-    view_1d_const precip_liq_surf_local;
-    view_1d_const precip_ice_surf_local;
-    view_1d       precip_liq_surf;
-    view_1d       precip_ice_surf;
+    view_1d_const precip_liq_surf_flux;
+    view_1d_const precip_ice_surf_flux;
+    view_1d       precip_liq_surf_mass;
+    view_1d       precip_ice_surf_mass;
     // Assigning local values
     void set_dt(const int dt)
     {
@@ -285,33 +285,33 @@ public:
                     const view_2d& qi_, const view_2d& qm_, const view_2d& ni_, const view_2d& bm_,
                     const view_2d& qv_prev_, const view_2d& diag_eff_radius_qc_,
                     const view_2d& diag_eff_radius_qi_, 
-                    const view_1d_const& precip_liq_surf_local_, const view_1d_const& precip_ice_surf_local_,
-                    const view_1d& precip_liq_surf_, const view_1d& precip_ice_surf_)
+                    const view_1d_const& precip_liq_surf_flux_, const view_1d_const& precip_ice_surf_flux_,
+                    const view_1d& precip_liq_surf_mass_, const view_1d& precip_ice_surf_mass_)
     {
       m_ncol  = ncol;
       m_npack = npack;
       // IN
-      th_atm      = th_atm_;
-      pmid        = pmid_;
-      qv          = qv_;
-      qc          = qc_;
-      nc          = nc_;
-      qr          = qr_;
-      nr          = nr_;
-      qi          = qi_;
-      qm          = qm_;
-      ni          = ni_;
-      bm          = bm_;
-      precip_liq_surf_local = precip_liq_surf_local_;
-      precip_ice_surf_local = precip_ice_surf_local_;
+      th_atm               = th_atm_;
+      pmid                 = pmid_;
+      qv                   = qv_;
+      qc                   = qc_;
+      nc                   = nc_;
+      qr                   = qr_;
+      nr                   = nr_;
+      qi                   = qi_;
+      qm                   = qm_;
+      ni                   = ni_;
+      bm                   = bm_;
+      precip_liq_surf_flux = precip_liq_surf_flux_;
+      precip_ice_surf_flux = precip_ice_surf_flux_;
       // OUT
-      T_atm              = T_atm_;
-      T_prev             = T_prev_;
-      qv_prev            = qv_prev_;
-      diag_eff_radius_qc = diag_eff_radius_qc_;
-      diag_eff_radius_qi = diag_eff_radius_qi_;
-      precip_liq_surf    = precip_liq_surf_;
-      precip_ice_surf    = precip_ice_surf_;
+      T_atm                = T_atm_;
+      T_prev               = T_prev_;
+      qv_prev              = qv_prev_;
+      diag_eff_radius_qc   = diag_eff_radius_qc_;
+      diag_eff_radius_qi   = diag_eff_radius_qi_;
+      precip_liq_surf_mass = precip_liq_surf_mass_;
+      precip_ice_surf_mass = precip_ice_surf_mass_;
       // TODO: This is a list of variables not yet defined for post-processing, but are
       // defined in the F90 p3 interface code.  So this list will need to be checked as
       // new processes come online to make sure their requirements from p3 are being met.
@@ -331,8 +331,8 @@ public:
     static constexpr int num_2d_vector = 9;
     static constexpr int num_2dp1_vector = 2;
 
-    uview_1d precip_liq_surf;
-    uview_1d precip_ice_surf;
+    uview_1d precip_liq_surf_flux;
+    uview_1d precip_ice_surf_flux;
     uview_2d inv_exner;
     uview_2d th_atm;
     uview_2d cld_frac_l;

--- a/components/scream/src/physics/p3/atmosphere_microphysics_run.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics_run.cpp
@@ -2,8 +2,22 @@
 
 namespace scream {
 
-void P3Microphysics::run_impl (const int dt)
+void P3Microphysics::run_impl (const int dt_proc)
 {
+
+  // TODO: Need to check if this is the first timestep of a subcycling, this will be taken care of
+  // in a separate PR and then these lines can be updated.
+  // We also need to have the dt_atm be explicitly passed to P3 somehow.  Will be taken care of in a separate PR.
+  const auto& precip_liq_surf = get_field_out("precip_liq_surf").get_view<Real*>();
+  const auto& precip_ice_surf = get_field_out("precip_ice_surf").get_view<Real*>();
+  Real dt_atm = m_params.get<Real>("dt_atm",1800);
+  Int  num_subcycles = m_params.get<Int>("dt_subcycle",6);
+  if (m_subcycle_step%num_subcycles==0) {
+    Kokkos::deep_copy(precip_liq_surf,0.0);
+    Kokkos::deep_copy(precip_ice_surf,0.0);
+    m_subcycle_step = 0;
+  }
+  m_subcycle_step += 1;
   // Assign values to local arrays used by P3, these are now stored in p3_loc.
   Kokkos::parallel_for(
     "p3_main_local_vals",
@@ -14,7 +28,7 @@ void P3Microphysics::run_impl (const int dt)
 
   // Update the variables in the p3 input structures with local values.
 
-  infrastructure.dt = dt;
+  infrastructure.dt = dt_proc;
   infrastructure.it++;
 
   // Reset internal WSM variables.
@@ -23,6 +37,13 @@ void P3Microphysics::run_impl (const int dt)
   // Run p3 main
   P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
                history_only, lookup_tables, workspace_mgr, m_num_cols, m_num_levs);
+
+  // Rescale precip fluxes from P3 for the atmosphere timestep in case
+  // there is subcycling.
+  Kokkos::parallel_for("",m_num_cols, [&] (const int& icol) {
+    diag_outputs.precip_liq_surf(icol) *= dt_proc/dt_atm;
+    diag_outputs.precip_ice_surf(icol) *= dt_proc/dt_atm;
+  });
 
   // Conduct the post-processing of the p3_main output.
   Kokkos::parallel_for(

--- a/components/scream/src/physics/p3/atmosphere_microphysics_run.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics_run.cpp
@@ -2,22 +2,11 @@
 
 namespace scream {
 
-void P3Microphysics::run_impl (const int dt_proc)
+void P3Microphysics::run_impl (const int dt)
 {
+  // Set the dt for p3 postprocessing
+  p3_postproc.set_dt(dt);
 
-  // TODO: Need to check if this is the first timestep of a subcycling, this will be taken care of
-  // in a separate PR and then these lines can be updated.
-  // We also need to have the dt_atm be explicitly passed to P3 somehow.  Will be taken care of in a separate PR.
-  const auto& precip_liq_surf = get_field_out("precip_liq_surf").get_view<Real*>();
-  const auto& precip_ice_surf = get_field_out("precip_ice_surf").get_view<Real*>();
-  Real dt_atm = m_params.get<Real>("dt_atm",1800);
-  Int  num_subcycles = m_params.get<Int>("dt_subcycle",6);
-  if (m_subcycle_step%num_subcycles==0) {
-    Kokkos::deep_copy(precip_liq_surf,0.0);
-    Kokkos::deep_copy(precip_ice_surf,0.0);
-    m_subcycle_step = 0;
-  }
-  m_subcycle_step += 1;
   // Assign values to local arrays used by P3, these are now stored in p3_loc.
   Kokkos::parallel_for(
     "p3_main_local_vals",
@@ -28,7 +17,7 @@ void P3Microphysics::run_impl (const int dt_proc)
 
   // Update the variables in the p3 input structures with local values.
 
-  infrastructure.dt = dt_proc;
+  infrastructure.dt = dt;
   infrastructure.it++;
 
   // Reset internal WSM variables.
@@ -37,13 +26,6 @@ void P3Microphysics::run_impl (const int dt_proc)
   // Run p3 main
   P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
                history_only, lookup_tables, workspace_mgr, m_num_cols, m_num_levs);
-
-  // Rescale precip fluxes from P3 for the atmosphere timestep in case
-  // there is subcycling.
-  Kokkos::parallel_for("",m_num_cols, [&] (const int& icol) {
-    diag_outputs.precip_liq_surf(icol) *= dt_proc/dt_atm;
-    diag_outputs.precip_ice_surf(icol) *= dt_proc/dt_atm;
-  });
 
   // Conduct the post-processing of the p3_main output.
   Kokkos::parallel_for(

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -39,8 +39,8 @@ Fields:
       - micro_liq_ice_exchange
       - micro_vap_ice_exchange
       - micro_vap_liq_exchange
-      - precip_ice_surf
-      - precip_liq_surf
+      - precip_ice_surf_mass
+      - precip_liq_surf_mass
       # SHOC + P3
       - qc
       - qv

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -14,6 +14,8 @@ Initial Conditions:
   Physics GLL:
     surf_evap: 0.0
     surf_sens_flux: 0.0
+    precip_liq_surf_mass: 0.0
+    precip_ice_surf_mass: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -45,8 +45,8 @@ Fields:
       - micro_liq_ice_exchange
       - micro_vap_ice_exchange
       - micro_vap_liq_exchange
-      - precip_ice_surf
-      - precip_liq_surf
+      - precip_ice_surf_mass
+      - precip_liq_surf_mass
       # SHOC + P3
       - qc
       - qv

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -14,6 +14,8 @@ Initial Conditions:
   Physics GLL:
     surf_evap: 0.0
     surf_sens_flux: 0.0
+    precip_liq_surf_mass: 0.0
+    precip_ice_surf_mass: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
@@ -45,8 +45,8 @@ Fields:
       - micro_liq_ice_exchange
       - micro_vap_ice_exchange
       - micro_vap_liq_exchange
-      - precip_ice_surf
-      - precip_liq_surf
+      - precip_ice_surf_mass
+      - precip_liq_surf_mass
       # SHOC + P3
       - qc
       - qv

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -17,6 +17,8 @@ Initial Conditions:
   Physics GLL:
     surf_evap: 0.0
     surf_sens_flux: 0.0
+    precip_liq_surf_mass: 0.0
+    precip_ice_surf_mass: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -17,6 +17,8 @@ Initial Conditions:
   Physics GLL:
     surf_evap: 0.0
     surf_sens_flux: 0.0
+    precip_liq_surf_mass: 0.0
+    precip_ice_surf_mass: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/model_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/model_output.yaml
@@ -39,8 +39,8 @@ Fields:
       - micro_liq_ice_exchange
       - micro_vap_ice_exchange
       - micro_vap_liq_exchange
-      - precip_ice_surf
-      - precip_liq_surf
+      - precip_ice_surf_mass
+      - precip_liq_surf_mass
       # SHOC + P3
       - qc
       - qv

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
@@ -39,8 +39,8 @@ Fields:
       - micro_liq_ice_exchange
       - micro_vap_ice_exchange
       - micro_vap_liq_exchange
-      - precip_ice_surf
-      - precip_liq_surf
+      - precip_ice_surf_mass
+      - precip_liq_surf_mass
       # SHOC + P3
       - qc
       - qv

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -43,6 +43,8 @@ Initial Conditions:
     Load Longitude: true
     surf_evap: 0.0
     surf_sens_flux: 0.0
+    precip_liq_surf_mass: 0.0
+    precip_ice_surf_mass: 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
@@ -30,8 +30,8 @@ Field Names:
   - micro_liq_ice_exchange
   - micro_vap_ice_exchange
   - micro_vap_liq_exchange
-  - precip_ice_surf
-  - precip_liq_surf
+  - precip_ice_surf_mass
+  - precip_liq_surf_mass
   # SHOC + P3
   - qc
   - qv

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -45,6 +45,8 @@ Initial Conditions:
     Load Longitude: true
     surf_evap: 0.0
     surf_sens_flux: 0.0
+    precip_liq_surf_mass: 0.0
+    precip_ice_surf_mass: 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -30,8 +30,8 @@ Field Names:
   - micro_liq_ice_exchange
   - micro_vap_ice_exchange
   - micro_vap_liq_exchange
-  - precip_ice_surf
-  - precip_liq_surf
+  - precip_ice_surf_mass
+  - precip_liq_surf_mass
   # SHOC + P3
   - qc
   - qv

--- a/components/scream/tests/uncoupled/p3/input.yaml
+++ b/components/scream/tests/uncoupled/p3/input.yaml
@@ -24,6 +24,9 @@ Grids Manager:
 Initial Conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/screami_ne2np4L72_20220524.nc
+  Point Grid:
+    precip_liq_surf_mass: 0.0
+    precip_ice_surf_mass: 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/uncoupled/p3/p3_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/p3/p3_standalone_output.yaml
@@ -18,6 +18,8 @@ Field Names:
   - qv_prev_micro_step
   - eff_radius_qc
   - eff_radius_qi
+  - precip_liq_surf_mass
+  - precip_ice_surf_mass
   - micro_liq_ice_exchange
   - micro_vap_liq_exchange
   - micro_vap_ice_exchange


### PR DESCRIPTION
This commit adjusts how precip_liq_surf and precip_ice_surf is handled in EAMxx to accommodate subcycling.

Now, the precipitation flux provided by P3 is converted into a total precipitation mass (units=kg), and the precipitation mass
is accumulated every p3 run step.

In the surface coupling export, where precipitation is used, the total mass is converted to a mass flux for use by the component coupler.  After the precipitation is exported it is no longer needed this time step, so surface coupling is responsible for resetting the accumulated precipitation to 0.0.

This commit is non-BFB in that precipitation output variables will now be in units of kg rather than m/s.

Addresses issue #1755 
Will be improved when issue #1767 is eventually addressed.