### PR TITLE
Switch the pressure coordinate in P3 to be dry instead of wet.

### DIFF
--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -160,6 +160,10 @@ void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
   s_mem += m_buffer.cld_frac_r.size();
   m_buffer.dz = decltype(m_buffer.dz)(s_mem, m_num_cols, nk_pack);
   s_mem += m_buffer.dz.size();
+  m_buffer.pdel_dry = decltype(m_buffer.pdel_dry)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.pdel_dry.size();
+  m_buffer.pmid_dry = decltype(m_buffer.pmid_dry)(s_mem, m_num_cols, nk_pack);
+  s_mem += m_buffer.pmid_dry.size();
   m_buffer.qv2qi_depos_tend = decltype(m_buffer.qv2qi_depos_tend)(s_mem, m_num_cols, nk_pack);
   s_mem += m_buffer.qv2qi_depos_tend.size();
   m_buffer.rho_qi = decltype(m_buffer.rho_qi)(s_mem, m_num_cols, nk_pack);
@@ -233,11 +237,13 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   auto cld_frac_i = m_buffer.cld_frac_i;
   auto cld_frac_r = m_buffer.cld_frac_r;
   auto dz         = m_buffer.dz;
+  auto pdel_dry   = m_buffer.pdel_dry;
+  auto pmid_dry   = m_buffer.pmid_dry;
 
   // -- Set values for the pre-amble structure
   p3_preproc.set_variables(m_num_cols,nk_pack,pmid,pseudo_density,T_atm,cld_frac_t,
                         qv, qc, nc, qr, nr, qi, qm, ni, bm, qv_prev,
-                        inv_exner, th_atm, cld_frac_l, cld_frac_i, cld_frac_r, dz);
+                        inv_exner, th_atm, cld_frac_l, cld_frac_i, cld_frac_r, dz, pdel_dry, pmid_dry);
   // --Prognostic State Variables:
   prog_state.qc     = p3_preproc.qc;
   prog_state.nc     = p3_preproc.nc;
@@ -258,8 +264,8 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   }
   diag_inputs.ni_activated    = get_field_in("ni_activated").get_view<const Pack**>();
   diag_inputs.inv_qc_relvar   = get_field_in("inv_qc_relvar").get_view<const Pack**>();
-  diag_inputs.pres            = get_field_in("p_mid").get_view<const Pack**>();
-  diag_inputs.dpres           = p3_preproc.pseudo_density;
+  diag_inputs.pres            = p3_preproc.pmid_dry;
+  diag_inputs.dpres           = p3_preproc.pdel_dry;
   diag_inputs.qv_prev         = p3_preproc.qv_prev;
   auto t_prev                 = get_field_out("T_prev_micro_step").get_view<Pack**>();
   diag_inputs.t_prev          = t_prev;

--- a/components/scream/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.hpp
@@ -77,13 +77,16 @@ public:
         const Spack& pmid_pack(pmid(icol,ipack));
         const Spack& T_atm_pack(T_atm(icol,ipack));
         const Spack& cld_frac_t_pack(cld_frac_t(icol,ipack));
+        // Ensure that the pseudo_density and pmid used by P3 is dry
+        pdel_dry(icol,ipack) = pseudo_density(icol,ipack) * (1-qv(icol,ipack));
+        pmid_dry(icol,ipack) = pmid_pack * (1-qv(icol,ipack));
         // Exner
-        const auto& exner = PF::exner_function(pmid_pack);
+        const auto& exner = PF::exner_function(pmid_dry(icol,ipack));
         inv_exner(icol,ipack) = 1.0/exner;
         // Potential temperature
-        th_atm(icol,ipack) = PF::calculate_theta_from_T(T_atm_pack,pmid_pack);
+        th_atm(icol,ipack) = PF::calculate_theta_from_T(T_atm_pack,pmid_dry(icol,ipack));
         // DZ
-        dz(icol,ipack) = PF::calculate_dz(pseudo_density(icol,ipack), pmid_pack, T_atm_pack, qv(icol,ipack));
+        dz(icol,ipack) = PF::calculate_dz(pdel_dry(icol,ipack), pmid_dry(icol,ipack), T_atm_pack, qv(icol,ipack));
         // Cloud fraction
         // Set minimum cloud fraction - avoids division by zero
         cld_frac_l(icol,ipack) = ekat::max(cld_frac_t_pack,mincld);
@@ -120,6 +123,7 @@ public:
         // ^^ Ensure that qv is "wet mmr" till this point ^^
         //NOTE: Convert "qv" to dry mmr in the end after converting all other constituents to dry mmr
         qv(icol, ipack)      = PF::calculate_drymmr_from_wetmmr(qv(icol,ipack),qv(icol,ipack));
+
 
         // update rain cloud fraction given neighboring levels using max-overlap approach.
         for (int ivec=0;ivec<Spack::n;ivec++)
@@ -162,6 +166,8 @@ public:
     view_2d       cld_frac_i;
     view_2d       cld_frac_r;
     view_2d       dz;
+    view_2d       pdel_dry;
+    view_2d       pmid_dry;
     // Assigning local variables
     void set_variables(const int ncol, const int npack,
            const view_2d_const& pmid_, const view_2d_const& pseudo_density_, const view_2d& T_atm_,
@@ -169,7 +175,7 @@ public:
            const view_2d& nc_, const view_2d& qr_, const view_2d& nr_, const view_2d& qi_,
            const view_2d& qm_, const view_2d& ni_, const view_2d& bm_, const view_2d& qv_prev_,
            const view_2d& inv_exner_, const view_2d& th_atm_, const view_2d& cld_frac_l_,
-           const view_2d& cld_frac_i_, const view_2d& cld_frac_r_, const view_2d& dz_
+           const view_2d& cld_frac_i_, const view_2d& cld_frac_r_, const view_2d& dz_, const view_2d& pdel_dry_, const view_2d& pmid_dry_
            )
     {
       m_ncol = ncol;
@@ -196,6 +202,8 @@ public:
       cld_frac_i = cld_frac_i_;
       cld_frac_r = cld_frac_r_;
       dz = dz_;
+      pdel_dry = pdel_dry_;
+      pmid_dry = pmid_dry_;
     } // set_variables
   }; // p3_preamble
   /* --------------------------------------------------------------------------------------------*/
@@ -309,7 +317,7 @@ public:
     // 1d view scalar, size (ncol)
     static constexpr int num_1d_scalar = 0; //no 2d vars now, but keeping 1d struct for future expansion
     // 2d view packed, size (ncol, nlev_packs)
-    static constexpr int num_2d_vector = 9;
+    static constexpr int num_2d_vector = 11;
     static constexpr int num_2dp1_vector = 2;
 
     uview_2d inv_exner;
@@ -318,6 +326,8 @@ public:
     uview_2d cld_frac_i;
     uview_2d cld_frac_r;
     uview_2d dz;
+    uview_2d pdel_dry;
+    uview_2d pmid_dry;
     uview_2d qv2qi_depos_tend;
     uview_2d rho_qi;
     uview_2d precip_liq_flux; //nlev+1

--- a/components/scream/src/share/util/standalone_helper_functions.hpp
+++ b/components/scream/src/share/util/standalone_helper_functions.hpp
@@ -1,0 +1,96 @@
+#ifndef SCREAM_STANDALONE_TEST_UTILS_HPP
+#define SCREAM_STANDALONE_TEST_UTILS_HPP
+
+#include "share/field/field_manager.hpp"
+#include "share/grid/mesh_free_grids_manager.hpp"
+
+namespace scream {
+
+// Helper function to check the total water mass
+Real calculate_water_mass(const std::shared_ptr<const GridsManager>& grids_mgr,const std::shared_ptr<FieldManager>& field_mgr, const Real dt, const bool use_precip) {
+  
+  using PC = scream::physics::Constants<Real>;
+  constexpr Real gravit = PC::gravit;
+  constexpr Real rho_h2o = PC::RHO_H2O;
+
+  const auto& grid = grids_mgr->get_grid("Point Grid");
+
+  int ncol  = grid->get_num_local_dofs();
+  int nlay  = grid->get_num_vertical_levels();
+  int dof   = ncol*nlay;
+  REQUIRE(field_mgr->has_field("pseudo_density"));
+  auto d_pdel       = field_mgr->get_field("pseudo_density").get_view<Real**>();
+
+  // Start adding water species to mass calculation
+  Real total_mass = 0.0;
+  if (field_mgr->has_field("qv")) {
+    auto d_tmp         = field_mgr->get_field("qv").get_view<Real**>();
+    Real result;
+    Kokkos::parallel_reduce("",dof,KOKKOS_LAMBDA(const int& i,Real& lsum) {
+      int icol = i / nlay;
+      int klev = i % nlay;
+      lsum += d_tmp(icol,klev) * d_pdel(icol,klev) / gravit;
+    },result);
+    total_mass += result;
+  }
+  if (field_mgr->has_field("qr")) {
+    auto d_tmp         = field_mgr->get_field("qr").get_view<Real**>();
+    Real result;
+    Kokkos::parallel_reduce("",dof,KOKKOS_LAMBDA(const int& i,Real& lsum) {
+      int icol = i / nlay;
+      int klev = i % nlay;
+      lsum += d_tmp(icol,klev) * d_pdel(icol,klev) / gravit;
+    },result);
+    total_mass += result;
+  }
+  if (field_mgr->has_field("qc")) {
+    auto d_tmp         = field_mgr->get_field("qc").get_view<Real**>();
+    Real result;
+    Kokkos::parallel_reduce("",dof,KOKKOS_LAMBDA(const int& i,Real& lsum) {
+      int icol = i / nlay;
+      int klev = i % nlay;
+      lsum += d_tmp(icol,klev) * d_pdel(icol,klev) / gravit;
+    },result);
+    total_mass += result;
+  }
+  if (field_mgr->has_field("qi")) {
+    auto d_tmp         = field_mgr->get_field("qi").get_view<Real**>();
+    Real result;
+    Kokkos::parallel_reduce("",dof,KOKKOS_LAMBDA(const int& i,Real& lsum) {
+      int icol = i / nlay;
+      int klev = i % nlay;
+      lsum += d_tmp(icol,klev) * d_pdel(icol,klev) / gravit;
+    },result);
+    total_mass += result;
+  }
+  if (field_mgr->has_field("qs")) {
+    auto d_tmp         = field_mgr->get_field("qs").get_view<Real**>();
+    Real result;
+    Kokkos::parallel_reduce("",dof,KOKKOS_LAMBDA(const int& i,Real& lsum) {
+      int icol = i / nlay;
+      int klev = i % nlay;
+      lsum += d_tmp(icol,klev) * d_pdel(icol,klev) / gravit;
+    },result);
+    total_mass += result;
+  }
+
+  if (use_precip) {
+    auto d_tmp_liq = field_mgr->get_field("precip_liq_surf").get_view<Real*>();
+    auto d_tmp_ice = field_mgr->get_field("precip_ice_surf").get_view<Real*>();
+    Real result;
+    Kokkos::parallel_reduce("",ncol, KOKKOS_LAMBDA(const int& icol,Real& lsum) {
+      lsum += (d_tmp_liq(icol) + d_tmp_ice(icol) ) * rho_h2o * dt;
+    },result);
+    total_mass += result;
+    printf("precip this step: %e\n",result);
+  }
+
+  return total_mass;
+}
+
+Real calculate_water_mass(const std::shared_ptr<const GridsManager>& grids_mgr,const std::shared_ptr<FieldManager>& field_mgr, const Real dt) {
+  return calculate_water_mass(grids_mgr,field_mgr,dt,false);
+}
+
+} //namespace scream
+#endif //SCREAM_STANDALONE_TEST_UTILS_HPP

--- a/components/scream/tests/uncoupled/p3/p3_standalone.cpp
+++ b/components/scream/tests/uncoupled/p3/p3_standalone.cpp
@@ -6,6 +6,7 @@
 
 #include "share/grid/mesh_free_grids_manager.hpp"
 #include "share/atm_process/atmosphere_process.hpp"
+#include "share/util/standalone_helper_functions.hpp"
 
 #include "ekat/ekat_parse_yaml_file.hpp"
 
@@ -46,11 +47,26 @@ TEST_CASE("p3-stand-alone", "") {
 
   // Init and run
   ad.initialize(atm_comm,ad_params,t0);
+
+  // Grab the grid and field manager ptrs 
+  const auto& grids_mgr = ad.get_grids_manager();
+  const auto& grid = grids_mgr->get_grid("Point Grid");
+  const auto& field_mgr = ad.get_field_mgr(grid->name());
+  Real wm_prev = calculate_water_mass(grids_mgr,field_mgr,dt);
+  Real wm_after;
+
   if (atm_comm.am_i_root()) {
     printf("Start time stepping loop...       [  0%%]\n");
   }
   for (int i=0; i<nsteps; ++i) {
     ad.run(dt);
+    const auto& wm_after = calculate_water_mass(grids_mgr,field_mgr,dt,true);
+    EKAT_REQUIRE_MSG(std::abs(wm_after - wm_prev) < 1.e-12, 
+       "Error in water mass change: " + std::to_string(wm_after) + " != "
+       + std::to_string(wm_prev) + ", diff = " + std::to_string((wm_after-wm_prev)/(std::abs(wm_after)+std::abs(wm_prev))*200.0) + "%"
+       + " or " + std::to_string(wm_after-wm_prev));
+    wm_prev = wm_after;
+
     if (atm_comm.am_i_root()) {
       std::cout << "  - Iteration " << std::setfill(' ') << std::setw(3) << i+1 << " completed";
       std::cout << "       [" << std::setfill(' ') << std::setw(3) << 100*(i+1)/nsteps << "%]\n";


### PR DESCRIPTION
Because the mass-mixing-ratios in P3 are dry, the pressure coordinates
are inconsistent, which leads to a mass leak during sedimentation in P3.

This commit introduces the pdel_dry and pmid_dry variables which are passed
to p3_main which represent the conversion of the wet pressure coordinates to
a dry set.

This commit also introduces a helper function for standalone tests that will
allow the user to calculate the total global water mass.  This can be used to
ensure that any mass leaks are sufficiently small, as shown in the application
of this new function in the p3_standalone test.