### PR TITLE
SCREAM: fix some input yaml files for tests involving P3

### DIFF
--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -14,6 +14,8 @@ Initial Conditions:
   Physics GLL:
     surf_evap: 0.0
     surf_sens_flux: 0.0
+    precip_liq_surf_mass: 0.0
+    precip_ice_surf_mass: 0.0
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -31,6 +31,8 @@ Initial Conditions:
     Load Longitude: true
     surf_evap: 0.0
     surf_sens_flux: 0.0
+    precip_liq_surf_mass: 0.0
+    precip_ice_surf_mass: 0.0
 
 # The parameters for I/O control
 Scorpio:


### PR DESCRIPTION
The recent change in the handling of water precip variable required some extra lines that were not propagated to all the input yaml files.