### PR TITLE
Fix homme restart of nstep

### DIFF
--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -133,7 +133,7 @@ init_scorpio(const int atm_id)
 
 void AtmosphereDriver::create_atm_processes()
 {
-  m_atm_logger->info("[EAMXX] create_atm_processes  ...");
+  m_atm_logger->info("[EAMxx] create_atm_processes  ...");
   start_timer("EAMxx::init");
   start_timer("EAMxx::create_atm_processes");
 
@@ -151,12 +151,12 @@ void AtmosphereDriver::create_atm_processes()
   m_ad_status |= s_procs_created;
   stop_timer("EAMxx::create_atm_processes");
   stop_timer("EAMxx::init");
-  m_atm_logger->info("[EAMXX] create_atm_processes  ... done!");
+  m_atm_logger->info("[EAMxx] create_atm_processes  ... done!");
 }
 
 void AtmosphereDriver::create_grids()
 {
-  m_atm_logger->info("[EAMXX] create_grids ...");
+  m_atm_logger->info("[EAMxx] create_grids ...");
   start_timer("EAMxx::init");
   start_timer("EAMxx::create_grids");
 
@@ -166,16 +166,16 @@ void AtmosphereDriver::create_grids()
   // Create the grids manager
   auto& gm_params = m_atm_params.sublist("Grids Manager");
   const std::string& gm_type = gm_params.get<std::string>("Type");
-  m_atm_logger->debug("  [EAMXX] Creating grid manager '" + gm_type + "' ...");
+  m_atm_logger->debug("  [EAMxx] Creating grid manager '" + gm_type + "' ...");
   m_grids_manager = GridsManagerFactory::instance().create(gm_type,m_atm_comm,gm_params);
 
-  m_atm_logger->debug("  [EAMXX] Creating grid manager '" + gm_type + "' ... done!");
+  m_atm_logger->debug("  [EAMxx] Creating grid manager '" + gm_type + "' ... done!");
 
   // Tell the grid manager to build all the grids required
   // by the atm processes, as well as the reference grid
   m_grids_manager->build_grids(m_atm_process_group->get_required_grids());
 
-  m_atm_logger->debug("  [EAMXX] Grids created.");
+  m_atm_logger->debug("  [EAMxx] Grids created.");
 
   // Set the grids in the processes. Do this by passing the grids manager.
   // Each process will grab what they need
@@ -185,12 +185,12 @@ void AtmosphereDriver::create_grids()
 
   stop_timer("EAMxx::create_grids");
   stop_timer("EAMxx::init");
-  m_atm_logger->info("[EAMXX] create_grids ... done!");
+  m_atm_logger->info("[EAMxx] create_grids ... done!");
 }
 
 void AtmosphereDriver::create_fields()
 {
-  m_atm_logger->info("[EAMXX] create_fields ...");
+  m_atm_logger->info("[EAMxx] create_fields ...");
   start_timer("EAMxx::init");
   start_timer("EAMxx::create_fields");
 
@@ -346,11 +346,11 @@ void AtmosphereDriver::create_fields()
 
   stop_timer("EAMxx::create_fields");
   stop_timer("EAMxx::init");
-  m_atm_logger->info("[EAMXX] create_fields ... done!");
+  m_atm_logger->info("[EAMxx] create_fields ... done!");
 }
 
 void AtmosphereDriver::initialize_output_managers () {
-  m_atm_logger->info("[EAMXX] initialize_output_managers ...");
+  m_atm_logger->info("[EAMxx] initialize_output_managers ...");
   start_timer("EAMxx::init");
   start_timer("EAMxx::initialize_output_managers");
 
@@ -393,18 +393,18 @@ void AtmosphereDriver::initialize_output_managers () {
 
   stop_timer("EAMxx::initialize_output_managers");
   stop_timer("EAMxx::init");
-  m_atm_logger->info("[EAMXX] initialize_output_managers ... done!");
+  m_atm_logger->info("[EAMxx] initialize_output_managers ... done!");
 }
 
 void AtmosphereDriver::
 initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0)
 {
-  m_atm_logger->info("[EAMXX] initialize_fields ...");
+  m_atm_logger->info("[EAMxx] initialize_fields ...");
   start_timer("EAMxx::init");
   start_timer("EAMxx::initialize_fields");
 
-  m_atm_logger->info("  [EAMXX] Run  start time stamp: " + run_t0.to_string());
-  m_atm_logger->info("  [EAMXX] Case start time stamp: " + case_t0.to_string());
+  m_atm_logger->info("  [EAMxx] Run  start time stamp: " + run_t0.to_string());
+  m_atm_logger->info("  [EAMxx] Case start time stamp: " + case_t0.to_string());
 
 
   // See if we need to print a DAG. We do this first, cause if any input
@@ -511,12 +511,12 @@ initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0
   stop_timer("EAMxx::initialize_fields");
   stop_timer("EAMxx::init");
   m_ad_status |= s_fields_inited;
-  m_atm_logger->info("[EAMXX] initialize_fields ... done!");
+  m_atm_logger->info("[EAMxx] initialize_fields ... done!");
 }
 
 void AtmosphereDriver::restart_model ()
 {
-  m_atm_logger->info("  [EAMXX] restart_model ...");
+  m_atm_logger->info("  [EAMxx] restart_model ...");
 
   // First, figure out the name of the netcdf file containing the restart data
   const auto& casename = m_atm_params.sublist("Initial Conditions").get<std::string>("Restart Casename");
@@ -549,7 +549,7 @@ void AtmosphereDriver::restart_model ()
   // Close files and finalize all pio data structs
   model_restart.finalize();
 
-  m_atm_logger->info("  [EAMXX] restart_model ... done!");
+  m_atm_logger->info("  [EAMxx] restart_model ... done!");
 }
 
 void AtmosphereDriver::create_logger () {
@@ -599,7 +599,7 @@ void AtmosphereDriver::create_logger () {
 
 void AtmosphereDriver::set_initial_conditions ()
 {
-  m_atm_logger->info("  [EAMXX] set_initial_conditions ...");
+  m_atm_logger->info("  [EAMxx] set_initial_conditions ...");
 
   auto& ic_pl = m_atm_params.sublist("Initial Conditions");
 
@@ -652,14 +652,14 @@ void AtmosphereDriver::set_initial_conditions ()
   };
 
   // First the individual input fields...
-  m_atm_logger->debug("    [EAMXX] Processing input fields ...");
+  m_atm_logger->debug("    [EAMxx] Processing input fields ...");
   for (const auto& f : m_atm_process_group->get_fields_in()) {
     process_ic_field (f);
   }
-  m_atm_logger->debug("    [EAMXX] Processing input fields ... done!");
+  m_atm_logger->debug("    [EAMxx] Processing input fields ... done!");
 
   // ...then the input groups
-  m_atm_logger->debug("    [EAMXX] Processing input groups ...");
+  m_atm_logger->debug("    [EAMxx] Processing input groups ...");
   for (const auto& g : m_atm_process_group->get_groups_in()) {
     if (g.m_bundle) {
       process_ic_field(*g.m_bundle);
@@ -668,7 +668,7 @@ void AtmosphereDriver::set_initial_conditions ()
       process_ic_field(*it.second);
     }
   }
-  m_atm_logger->debug("    [EAMXX] Processing input groups ... done!");
+  m_atm_logger->debug("    [EAMxx] Processing input groups ... done!");
 
   // Some fields might be the subfield of a group's bundled field. In that case,
   // we only need to init one: either the bundled field, or all the individual subfields.
@@ -706,17 +706,17 @@ void AtmosphereDriver::set_initial_conditions ()
   // If a filename is specified, use it to load inputs on all grids
   if (ic_pl.isParameter("Filename")) {
     // Now loop over all grids, and load from file the needed fields on each grid (if any).
-    m_atm_logger->debug("    [EAMXX] Reading fields from file ...");
+    m_atm_logger->debug("    [EAMxx] Reading fields from file ...");
     const auto& file_name = ic_pl.get<std::string>("Filename");
     for (const auto& it : m_field_mgrs) {
       const auto& grid_name = it.first;
       read_fields_from_file (ic_fields_names[grid_name],it.first,file_name,m_current_ts);
     }
-    m_atm_logger->debug("    [EAMXX] Reading fields from file ... done!");
+    m_atm_logger->debug("    [EAMxx] Reading fields from file ... done!");
   }
 
   // If there were any fields that needed to be copied per the input yaml file, now we copy them.
-  m_atm_logger->debug("    [EAMXX] Processing fields to copy ...");
+  m_atm_logger->debug("    [EAMxx] Processing fields to copy ...");
   for (const auto& tgt_fid : ic_fields_to_copy) {
     const auto& tgt_fname = tgt_fid.name();
     const auto& tgt_gname = tgt_fid.get_grid_name();
@@ -770,13 +770,13 @@ void AtmosphereDriver::set_initial_conditions ()
     // Set the initial time stamp
     f_tgt.get_header().get_tracking().update_time_stamp(m_current_ts);
   }
-  m_atm_logger->debug("    [EAMXX] Processing fields to copy ... done!");
+  m_atm_logger->debug("    [EAMxx] Processing fields to copy ... done!");
 
   // Final step: it is possible to have a bundled group G1=(f1,f2,f3),
   // where the IC are read from file for f1, f2, and f3. In that case,
   // the time stamp for the bundled G1 has not be inited, but the data
   // is valid (all entries have been inited). Let's fix that.
-  m_atm_logger->debug("    [EAMXX] Processing subfields ...");
+  m_atm_logger->debug("    [EAMxx] Processing subfields ...");
   for (const auto& g : m_atm_process_group->get_groups_in()) {
     if (g.m_bundle) {
       auto& track = g.m_bundle->get_header().get_tracking();
@@ -798,9 +798,9 @@ void AtmosphereDriver::set_initial_conditions ()
       }
     }
   }
-  m_atm_logger->debug("    [EAMXX] Processing subfields ... done!");
+  m_atm_logger->debug("    [EAMxx] Processing subfields ... done!");
 
-  m_atm_logger->info("  [EAMXX] set_initial_conditions ... done!");
+  m_atm_logger->info("  [EAMxx] set_initial_conditions ... done!");
 }
 
 void AtmosphereDriver::
@@ -871,7 +871,7 @@ initialize_constant_field(const FieldIdentifier& fid,
 
 void AtmosphereDriver::initialize_atm_procs ()
 {
-  m_atm_logger->info("[EAMXX] initialize_atm_procs ...");
+  m_atm_logger->info("[EAMxx] initialize_atm_procs ...");
   start_timer("EAMxx::init");
   start_timer("EAMxx::initialize_atm_procs");
 
@@ -890,7 +890,7 @@ void AtmosphereDriver::initialize_atm_procs ()
 
   stop_timer("EAMxx::initialize_atm_procs");
   stop_timer("EAMxx::init");
-  m_atm_logger->info("[EAMXX] initialize_atm_procs ... done!");
+  m_atm_logger->info("[EAMxx] initialize_atm_procs ... done!");
 
   report_res_dep_memory_footprint ();
 }
@@ -971,7 +971,7 @@ void AtmosphereDriver::run (const int dt) {
 void AtmosphereDriver::finalize ( /* inputs? */ ) {
   start_timer("EAMxx::finalize");
 
-  m_atm_logger->info("[EAMXX] Finalize ...");
+  m_atm_logger->info("[EAMxx] Finalize ...");
 
   // Finalize and destroy output streams, make sure files are closed
   for (auto& out_mgr : m_output_managers) {
@@ -1008,7 +1008,7 @@ void AtmosphereDriver::finalize ( /* inputs? */ ) {
     scorpio::eam_pio_finalize();
   }
 
-  m_atm_logger->info("[EAMXX] Finalize ... done!");
+  m_atm_logger->info("[EAMxx] Finalize ... done!");
 
 #ifdef SCREAM_HAS_MEMORY_USAGE
   long long my_mem_usage = get_mem_usage(MB);

--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -237,7 +237,6 @@ TEST_CASE ("recreate_mct_coupling")
   using GR     = GroupRequest;
   using RPDF   = std::uniform_real_distribution<Real>;
   using IPDF = std::uniform_int_distribution<int>;
-  using C = scream::physics::Constants<Real>;
 
   // Some constants
   constexpr int ncols = 4;

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -53,6 +53,10 @@ HommeDynamics::HommeDynamics (const ekat::Comm& comm, const ekat::ParameterList&
 {
   // This class needs Homme's context, so register as a user
   HommeContextUser::singleton().add_user();
+
+  ekat::any homme_nsteps;
+  homme_nsteps.reset<int>(-1);
+  m_restart_extra_data["homme_nsteps"] = std::make_pair(std::string("int"),homme_nsteps);
 }
 
 HommeDynamics::~HommeDynamics ()
@@ -369,11 +373,6 @@ void HommeDynamics::initialize_impl (const RunType run_type)
     restart_homme_state ();
   }
 
-  // For BFB restarts, set nstep counter in Homme's TimeLevel to match
-  // what's in the timestamp (which, for restarted runs, is read from restart file)
-  set_homme_param("num_steps",timestamp().get_num_steps());
-  Homme::Context::singleton().get<Homme::TimeLevel>().nstep = timestamp().get_num_steps();
-
   // Complete homme model initialization
   prim_init_model_f90 ();
 
@@ -410,7 +409,8 @@ void HommeDynamics::run_impl (const int dt)
     //       Now we can compute the actual nsplit, and need to update its value
     //       in Hommexx's data structures
     const int nsplit = get_homme_nsplit_f90(dt);
-    auto& params = Homme::Context::singleton().get<Homme::SimulationParams>();
+    const auto& c = Homme::Context::singleton();
+    auto& params = c.get<Homme::SimulationParams>();
     params.nsplit = nsplit;
 
     Kokkos::fence();
@@ -420,6 +420,11 @@ void HommeDynamics::run_impl (const int dt)
       Kokkos::fence();
       prim_run_f90 ();
     }
+
+    // Update nstep in the restart extra data, so it can be written to restart if needed.
+    const auto& tl = c.get<Homme::TimeLevel>();
+    auto& nstep = ekat::any_cast<int>(m_restart_extra_data["homme_nsteps"].second);
+    nstep = tl.nstep;
 
     // Post process Homme's output, to produce what the rest of Atm expects
     Kokkos::fence();
@@ -859,7 +864,13 @@ void HommeDynamics::restart_homme_state () {
   // TODO: p2d remapper does not support subfields, so we need to create temps
   //       to remap v_dyn and w_dyn separately, then copy into v3d_prev.
   const auto& c = Homme::Context::singleton();
-  auto& params = c.get<Homme::SimulationParams>();
+        auto& params = c.get<Homme::SimulationParams>();
+        auto& tl = c.get<Homme::TimeLevel>();
+
+  // For BFB restarts, set nstep counter in Homme's TimeLevel to match the restarted value.
+  const auto& nstep = ekat::any_cast<int>(m_restart_extra_data["homme_nsteps"].second);
+  tl.nstep = nstep;
+  set_homme_param("num_steps",nstep);
 
   constexpr int NGP = HOMMEXX_NP;
   const int nlevs = m_ref_grid->get_num_vertical_levels();
@@ -1032,8 +1043,11 @@ void HommeDynamics::initialize_homme_state () {
   const auto Q_view   = m_helper_fields.at("Q_dyn").get_view<Pack*****>();
 
   // State time slices
-  const int n0  = c.get<Homme::TimeLevel>().n0;
-  const int n0_qdp  = c.get<Homme::TimeLevel>().n0_qdp;
+  const auto& tl = c.get<Homme::TimeLevel>();
+  const int n0  = tl.n0;
+  const int n0_qdp  = tl.n0_qdp;
+
+  ekat::any_cast<int>(m_restart_extra_data["homme_nsteps"].second) = tl.nstep;
 
   // ps0 is the TOM boundary condition when we compute p_int(z)=integral_top^z dp(s)ds
   const auto& hvcoord = c.get<Homme::HybridVCoord>();

--- a/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -237,7 +237,7 @@ contains
   end subroutine prim_run_f90
 
   subroutine prim_finalize_f90 () bind(c)
-    use homme_context_mod,    only: is_model_inited, elem, dom_mt, par
+    use homme_context_mod,    only: is_model_inited, elem, dom_mt
     use prim_cxx_driver_base, only: prim_finalize
 
     if (.not. is_model_inited) then

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -284,7 +284,6 @@ public:
     void operator()(const Kokkos::TeamPolicy<KT::ExeSpace>::member_type& team) const {
       const int i = team.league_rank();
 
-      const Real cpair = C::Cpair;
       const Real inv_qc_relvar_max = 10;
       const Real inv_qc_relvar_min = 0.001;
 

--- a/components/scream/src/share/io/scream_output_manager.hpp
+++ b/components/scream/src/share/io/scream_output_manager.hpp
@@ -60,6 +60,8 @@ class OutputManager
 public:
   using fm_type = FieldManager;
   using gm_type = GridsManager;
+  using str_any_pair_t = std::pair<std::string,ekat::any>;
+  using globals_map_t = std::map<std::string,str_any_pair_t>;
 
   // Constructor(s) & Destructor
   OutputManager () = default;
@@ -103,6 +105,7 @@ public:
     setup (io_comm,params,field_mgrs,grids_mgr,run_t0,run_t0,is_model_restart_output);
   }
 
+  void setup_globals_map (const globals_map_t& globals);
   void run (const util::TimeStamp& current_ts);
   void finalize();
 
@@ -122,6 +125,8 @@ protected:
   using output_ptr_type = std::shared_ptr<output_type>;
 
   std::vector<output_ptr_type>   m_output_streams;
+  globals_map_t                  m_globals;
+
   ekat::Comm                     m_io_comm;
   ekat::ParameterList            m_params;
 


### PR DESCRIPTION
The main goal of this PR is to fix the restart of Homme's internal step counter 'nstep'. This is different from the atm counter nstep, in case anyone of `nsplit`, `dt_remap_factor`, `dt_tracers_factor` is larger than 1.

In the process, I made a couple of small additions to the atm proc class and to the output manager class:
- atm proc: expose a list of "extra restart data". This is a map `data_name -> (data_type,data_value)`, where the data is supposed to be "simple", like a builtin type. The data value is stored in an `ekat::any` container, so it has pointer semantic. Note: names are supposed to be unique: if 2 atm proc have the same name for some restart data, the AD will crap out.
- output manager: allow to set a list of global attributes to save. This is the same map structure as above. The map is set at setup time (though it can in principle be set in the middle of a run), and the manager will internally loop over it whenever it hits a write step.

This feature(s) are used to restart Homme's nstep counter correctly. I manually ran `ERS_Ln9.ne4_ne4.F2010-SCREAMv1` on mappy, and verified in the log of the restarted test that nstep is 30 (correct) rather than 5 (current master incorrect value).

That said, I _think_ that the internal counter is only useful for Homme to determine if it's time to copy some data back to host, in view of diagnostics output (meaning the internal diagnostic output to screen performed by Homme). I don't think that the incorrect value of nstep had any real consequence on the correctness of the data.

Fix #1785 