### PR TITLE
Fix regex for ELM use cases for SCREAM compsets

### DIFF
--- a/components/elm/cime_config/config_component.xml
+++ b/components/elm/cime_config/config_component.xml
@@ -83,12 +83,10 @@
       <value compset="SSP370(?:SOI)?_EAM%CMIP6_ELM">2015-2100_SSP370_transient</value>
       <value compset="2010(?:SOI)?_EAM%CMIP6-LR_ELM">2010_CMIP6LR_control</value>
       <value compset="2010(?:SOI)?_EAM%CMIP6-HR_ELM">2010_CMIP6HR_control</value>
-      <value compset="2010(?:SOI)?_EAM.*SCREAM-LR" >2010_defscream_control</value>
-      <value compset="2010(?:SOI)?_EAM.*SCREAM-HR" >2010_defscream_control</value>
-      <value compset="2010(?:SOI)?_EAM.*SCREAM-LR-DYAMOND2" >2010_dy2scream_control</value>
-      <value compset="2010(?:SOI)?_EAM.*SCREAM-HR-DYAMOND2" >2010_dy2scream_control</value>
-      <value compset="2000(?:SOI)?_EAM.*SCREAM-LR" >2000_control</value>
-      <value compset="2000(?:SOI)?_EAM.*SCREAM-HR" >2000_control</value>
+      <!-- Use cases for SCREAM compsets -->
+      <value compset="2010(?:SOI)?_.*SCREAM"                    >2010_defscream_control</value>
+      <value compset="2010(?:SOI)?_EAM.*SCREAM-[L,H]R-DYAMOND2" >2010_dy2scream_control</value>
+      <value compset="2000(?:SOI)?_EAM.*SCREAM"                 >2000_control</value>
       <!-- superfast chemistry compsets (use CMIP6 land configuration)-->
       <value compset="1850(?:SOI)?_EAM%AR5sf_ELM">1850_CMIP6_control</value>
       <value compset="20TR(?:SOI)?_EAM%AR5sf_ELM">20thC_CMIP6_transient</value>

--- a/components/elm/cime_config/config_component.xml
+++ b/components/elm/cime_config/config_component.xml
@@ -85,7 +85,7 @@
       <value compset="2010(?:SOI)?_EAM%CMIP6-HR_ELM">2010_CMIP6HR_control</value>
       <!-- Use cases for SCREAM compsets -->
       <value compset="2010(?:SOI)?_.*SCREAM"                    >2010_defscream_control</value>
-      <value compset="2010(?:SOI)?_EAM.*SCREAM-[L,H]R-DYAMOND2" >2010_dy2scream_control</value>
+      <value compset="2010(?:SOI)?_EAM.*SCREAM-[LH]R-DYAMOND2" >2010_dy2scream_control</value>
       <value compset="2000(?:SOI)?_EAM.*SCREAM"                 >2000_control</value>
       <!-- superfast chemistry compsets (use CMIP6 land configuration)-->
       <value compset="1850(?:SOI)?_EAM%AR5sf_ELM">1850_CMIP6_control</value>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -158,6 +158,7 @@ tweaking their $case/namelist_scream.xml file.
       <Vertical__Coordinate__Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220524.nc</Vertical__Coordinate__Filename>
       <Vertical__Coordinate__Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220524.nc</Vertical__Coordinate__Filename>
       <Vertical__Coordinate__Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220525.nc</Vertical__Coordinate__Filename>
+      <Vertical__Coordinate__Filename hgrid="ne1024np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_20220713.nc</Vertical__Coordinate__Filename>
       <Vertical__Coordinate__Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20220524.nc</Vertical__Coordinate__Filename>
       <Moisture>moist</Moisture>
     </homme>


### PR DESCRIPTION
Fix bigrid configuration for ne1024. Two fixes needed: first, fix a regular expression for ELM use cases for SCREAM compsets. This previously would not match the SCREAMv1 compsets because the regex had EAM in the compset name. This would leave fsurdat unset for resolutions that do not have defaults (i.e., ne1024np4). Also cleans up the setting of use cases for the rest of the SCREAM compsets. Second, we neglected to set the vertical coordinate file for ne1024 in `namelist_defaults_scream.xml`. This is non-BFB because previously the SCREAMv1 compsets would not match any ELM use cases, leaving the ELM use case UNSET.