### PR TITLE
Add ifdef guard around gptl init to reduce warning messages

### DIFF
--- a/components/scream/src/share/util/scream_timing.cpp
+++ b/components/scream/src/share/util/scream_timing.cpp
@@ -5,8 +5,12 @@
 namespace scream {
 
 void init_gptl (bool& was_already_inited) {
+#ifdef SCREAM_CONFIG_IS_CMAKE
+  was_already_inited = true;
+#else
   auto ierr = GPTLinitialize();
   was_already_inited = (ierr!=0);
+#endif
 }
 void finalize_gptl () {
   GPTLfinalize();

--- a/components/scream/src/share/util/scream_timing.cpp
+++ b/components/scream/src/share/util/scream_timing.cpp
@@ -1,11 +1,12 @@
 #include "share/util/scream_timing.hpp"
+#include "scream_config.h"
 
 #include <gptl.h>
 
 namespace scream {
 
 void init_gptl (bool& was_already_inited) {
-#ifdef SCREAM_CONFIG_IS_CMAKE
+#ifdef SCREAM_CIME_BUILD
   was_already_inited = true;
 #else
   auto ierr = GPTLinitialize();


### PR DESCRIPTION
Add `#ifdef SCREAM_CONFIG_IS_CMAKE` around gptl init.

Fixes #1791 