### PR TITLE
Upgrade PD remapper to handle subfields

### DIFF
--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -354,14 +354,14 @@ void HommeDynamics::initialize_impl (const RunType run_type)
   create_helper_field("FT_dyn",{EL,    GP,GP,LEV},{nelem,      NGP,NGP,nlevs},dgn);
   create_helper_field("FM_dyn",{EL,CMP,GP,GP,LEV},{nelem,    3,NGP,NGP,nlevs},dgn);
   create_helper_field("Q_dyn" ,{EL,CMP,GP,GP,LEV},{nelem,qsize,NGP,NGP,nlevs},dgn);
+
   // Tendencies for temperature and momentum computed on physics grid
   create_helper_field("FT_phys",{COL,LEV},    {ncols,  nlevs},pgn);
-  create_helper_field("FM_phys",{COL,CMP,LEV},{ncols,3,nlevs},pgn);
+  create_helper_field("FM_phys",{COL,CMP,LEV},{ncols,2,nlevs},pgn);
 
   // Unfortunately, Homme *does* use FM_z even in hydrostatic mode (missing ifdef).
   // Later, it computes diags on w, so if FM_w contains NaN's, repro sum in Homme
   // will crap out. To prevent that, set FM_z=0
-  m_helper_fields.at("FM_phys").get_component(2).deep_copy<Real>(0.0);
 
   if (fv_phys_active()) {
     fv_phys_initialize_impl();
@@ -387,14 +387,19 @@ void HommeDynamics::initialize_impl (const RunType run_type)
       m_p2d_remapper->register_field(*get_group_out("Q",pgn).m_bundle,m_helper_fields.at("FQ_dyn"));
     }
     m_p2d_remapper->register_field(m_helper_fields.at("FT_phys"),m_helper_fields.at("FT_dyn"));
-    m_p2d_remapper->register_field(m_helper_fields.at("FM_phys"),m_helper_fields.at("FM_dyn"));
+
+    // FM has 3 components on dyn grid, but only 2 on phys grid
+    auto& FM_phys = m_helper_fields.at("FM_phys");
+    auto& FM_dyn  = m_helper_fields.at("FM_dyn");
+    m_p2d_remapper->register_field(FM_phys.get_component(0),FM_dyn.get_component(0));
+    m_p2d_remapper->register_field(FM_phys.get_component(1),FM_dyn.get_component(1));
 
     // NOTE: for states, if/when we can remap subfields, we can remap the corresponding internal fields,
     //       which are subviews of the corresponding helper field at time slice np1
-    m_d2p_remapper->register_field(m_helper_fields.at("vtheta_dp_dyn"),get_field_out("T_mid"));
-    m_d2p_remapper->register_field(m_helper_fields.at("v_dyn"),get_field_out("horiz_winds"));
-    m_d2p_remapper->register_field(m_helper_fields.at("dp3d_dyn"), get_field_out("pseudo_density"));
-    m_d2p_remapper->register_field(m_helper_fields.at("ps_dyn"), get_field_out("ps"));
+    m_d2p_remapper->register_field(get_internal_field("vtheta_dp_dyn"),get_field_out("T_mid"));
+    m_d2p_remapper->register_field(get_internal_field("v_dyn"),get_field_out("horiz_winds"));
+    m_d2p_remapper->register_field(get_internal_field("dp3d_dyn"), get_field_out("pseudo_density"));
+    m_d2p_remapper->register_field(get_internal_field("ps_dyn"), get_field_out("ps"));
     m_d2p_remapper->register_field(m_helper_fields.at("Q_dyn"),*get_group_out("Q",pgn).m_bundle);
     m_d2p_remapper->register_field(m_helper_fields.at("omega_dyn"), get_field_out("omega"));
 
@@ -657,6 +662,18 @@ void HommeDynamics::homme_post_process () {
   const auto& params = c.get<Homme::SimulationParams>();
   const auto& tl = c.get<Homme::TimeLevel>();
 
+  // The internal fields are dynamic subfields of the homme states.
+  // We need to update the slice they are subviewing
+  get_internal_field("v_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
+  get_internal_field("vtheta_dp_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
+  get_internal_field("dp3d_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
+  get_internal_field("phi_int_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
+  get_internal_field("ps_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
+  get_internal_field("Qdp_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.np1_qdp);
+  if (not params.theta_hydrostatic_mode) {
+    get_internal_field("w_int_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
+  }
+
   if (fv_phys_active()) {
     fv_phys_post_process();
   } else {
@@ -669,18 +686,6 @@ void HommeDynamics::homme_post_process () {
   using Pack = ekat::Pack<Real,N>;
   using ColOps = ColumnOps<DefaultDevice,Real>;
   using PF = PhysicsFunctions<DefaultDevice>;
-
-  // The internal fields are dynamic subfields of the homme states.
-  // We need to update the slice they are subviewing
-  get_internal_field("v_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
-  get_internal_field("vtheta_dp_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
-  get_internal_field("dp3d_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
-  get_internal_field("phi_int_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
-  get_internal_field("ps_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
-  get_internal_field("Qdp_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.np1_qdp);
-  if (not params.theta_hydrostatic_mode) {
-    get_internal_field("w_int_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
-  }
 
   if (fv_phys_active()) return;
   
@@ -695,9 +700,9 @@ void HommeDynamics::homme_post_process () {
   const auto Q_view   = get_group_out("Q",pgn).m_bundle->get_view<Pack***>();
 
   const auto T_view  = get_field_out("T_mid").get_view<Pack**>();
-  const auto v_view  = get_field_out("horiz_winds").get_view<Pack***>();
   const auto T_prev_view = m_helper_fields.at("FT_phys").get_view<Pack**>();
-  const auto V_prev_view = m_helper_fields.at("FM_phys").get_view<Pack***>();
+
+  m_helper_fields.at("FM_phys").deep_copy(get_field_out("horiz_winds"));
 
   const auto ncols = m_phys_grid->get_num_local_dofs();
   const auto nlevs = m_phys_grid->get_num_vertical_levels();
@@ -741,11 +746,8 @@ void HommeDynamics::homme_post_process () {
     team.team_barrier();
 
     // Convert VTheta_dp->VTheta->Theta->T
-    auto T   = ekat::subview(T_view,icol);
-    auto v   = ekat::subview(v_view,icol);
-
+    auto T      = ekat::subview(T_view,icol);
     auto T_prev = ekat::subview(T_prev_view,icol);
-    auto V_prev = ekat::subview(V_prev_view,icol);
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team,npacks),
                          [&](const int ilev) {
@@ -755,10 +757,8 @@ void HommeDynamics::homme_post_process () {
       T_val = PF::calculate_temperature_from_virtual_temperature(T_val,qv(ilev));
       T_val = PF::calculate_T_from_theta(T_val,p_mid(ilev));
 
-      // Store T, v (and possibly w) at end of the dyn timestep (to back out tendencies later)
+      // Store T at end of the dyn timestep (to back out tendencies later)
       T_prev(ilev) = T_val;
-      V_prev(0,ilev) = v(0,ilev);
-      V_prev(1,ilev) = v(1,ilev);
     });
   });
 
@@ -911,6 +911,10 @@ void HommeDynamics::init_homme_views () {
   auto fm_in = m_helper_fields.at("FM_dyn").template get_view<Homme::Scalar**[NP][NP][NVL]>();
   using fm_type = std::remove_reference<decltype(forcing.m_fm)>::type;
   forcing.m_fm = fm_type(fm_in.data(),nelem);
+
+  // Homme has 3 components for FM, but the 3d (the omega forcing) is not computed
+  // by EAMxx, so we set FM(3)=0 right away
+  m_helper_fields.at("FM_dyn").get_component(2).deep_copy(0);
 }
 
 void HommeDynamics::restart_homme_state () {
@@ -994,16 +998,11 @@ void HommeDynamics::restart_homme_state () {
     return;
   }
 
-  // TODO: if/when PD remapper supports remapping directly to/from subfields,
-  //       you could remap v_dyn into the proper slice of FM_ref,
-  //       and do away with uv_prev.
-  using namespace ShortFieldTagsNames;
-  create_helper_field("uv_prev",{COL,CMP,LEV},{ncols,2,nlevs},pgn);
-  auto qv_prev_ref = std::make_shared<Field>();
   m_ic_remapper->registration_begins();
-  m_ic_remapper->register_field(m_helper_fields.at("FT_phys"),m_helper_fields.at("vtheta_dp_dyn"));
-  m_ic_remapper->register_field(m_helper_fields.at("uv_prev"),m_helper_fields.at("v_dyn"));
-  m_ic_remapper->register_field(get_field_out("pseudo_density",pgn),m_helper_fields.at("dp3d_dyn"));
+  m_ic_remapper->register_field(m_helper_fields.at("FT_phys"),get_internal_field("vtheta_dp_dyn"));
+  m_ic_remapper->register_field(m_helper_fields.at("FM_phys"),get_internal_field("v_dyn"));
+  m_ic_remapper->register_field(get_field_out("pseudo_density",pgn),get_internal_field("dp3d_dyn"));
+  auto qv_prev_ref = std::make_shared<Field>();
   auto Q_dyn = m_helper_fields.at("Q_dyn");
   if (params.ftype==Homme::ForcingAlg::FORCING_2) {
     // Recall, we store Q_old in FQ_ref, and do FQ_ref = Q_new - FQ_ref during pre-process
@@ -1015,17 +1014,12 @@ void HommeDynamics::restart_homme_state () {
     // Grab qv_ref_old from Q_old
     *qv_prev_ref = Q_old.get_component(0);
   } else {
+    using namespace ShortFieldTagsNames;
+
     // NOTE: we need the end-of-homme-step qv on the ref grid, to do the Theta->T conversion
     //       to compute T_prev *in the same way as homme_post_process* did in the original run.
-    //       If PD remapper supported subfields, we would not need qv_prev_dyn, and could use
-    //       the proper subfield of Q_dyn instead.
     create_helper_field("qv_prev_phys",{COL,LEV},{ncols,nlevs},pgn);
-    create_helper_field("qv_prev_dyn",{EL,GP,GP,LEV},{nelem,NGP,NGP,nlevs},dgn);
-    m_ic_remapper->register_field(m_helper_fields.at("qv_prev_phys"),m_helper_fields.at("qv_prev_dyn"));
-
-    // Copy qv from the qsize-sized Q_dyn array, to the individual-tracer field qv_prev_dyn.
-    auto qv_prev_dyn = m_helper_fields.at("qv_prev_dyn");
-    qv_prev_dyn.deep_copy(Q_dyn.get_component(0));
+    m_ic_remapper->register_field(m_helper_fields.at("qv_prev_phys"),Q_dyn.get_component(0));
 
     *qv_prev_ref = m_helper_fields.at("qv_prev_phys");
   }
@@ -1036,16 +1030,11 @@ void HommeDynamics::restart_homme_state () {
   // Now that we have dp_ref, we can recompute pressure
   update_pressure(m_phys_grid);
 
-  // Copy uv_prev into FM_ref. Also, FT_ref contains vtheta_dp,
-  // so convert it to actual temperature
-  auto uv_view     = m_helper_fields.at("uv_prev").get_view<Pack***>();
-  auto V_prev_view = m_helper_fields.at("FM_phys").get_view<Pack***>();
+  // FT_ref contains vtheta_dp, so convert it to actual temperature
   auto T_prev_view = m_helper_fields.at("FT_phys").get_view<Pack**>();
   auto dp_view     = get_field_out("pseudo_density",pgn).get_view<const Pack**>();
   auto p_mid_view  = get_field_out("p_mid").get_view<Pack**>();
   auto qv_view     = qv_prev_ref->get_view<Pack**>();
-
-  // Compute dp?
 
   const auto policy = ESU::get_default_team_policy(ncols,npacks);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const KT::MemberType& team){
@@ -1056,10 +1045,6 @@ void HommeDynamics::restart_homme_state () {
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team,npacks),
                          [&](const int& ilev) {
-      // Init v_prev from uv and, possibly, w
-      V_prev_view(icol,0,ilev) = uv_view(icol,0,ilev);
-      V_prev_view(icol,1,ilev) = uv_view(icol,1,ilev);
-
       // T_prev as of now contains vtheta_dp. Convert to temperature
       auto& T_prev = T_prev_view(icol,ilev);
       T_prev /= dp_view(icol,ilev);
@@ -1069,14 +1054,8 @@ void HommeDynamics::restart_homme_state () {
   });
   Kokkos::fence();
 
-  // We can now erase the uv_prev field.
-  // Erase also qv_prev_ref/qv_prev_dyn (if we created them).
-  m_helper_fields.erase("uv_prev");
-  if (m_helper_fields.find("qv_prev_phys")!=m_helper_fields.end()) {
-    m_helper_fields.erase("qv_prev_phys");
-    m_helper_fields.erase("qv_prev_dyn");
-  }
-  qv_prev_ref = nullptr;
+  // Erase also qv_prev_phys (if we created it).
+  m_helper_fields.erase("qv_prev_phys");
 }
 
 void HommeDynamics::initialize_homme_state () {
@@ -1130,11 +1109,11 @@ void HommeDynamics::initialize_homme_state () {
   //       you can use get_internal_field (which have a single time slice) rather than
   //       the helper fields (which have NTL time slices).
   m_ic_remapper->registration_begins();
-  m_ic_remapper->register_field(get_field_in("horiz_winds",rgn),m_helper_fields.at("v_dyn"));
-  m_ic_remapper->register_field(get_field_out("pseudo_density",rgn),m_helper_fields.at("dp3d_dyn"));
-  m_ic_remapper->register_field(get_field_in("ps",rgn),m_helper_fields.at("ps_dyn"));
+  m_ic_remapper->register_field(get_field_in("horiz_winds",rgn),get_internal_field("v_dyn"));
+  m_ic_remapper->register_field(get_field_out("pseudo_density",rgn),get_internal_field("dp3d_dyn"));
+  m_ic_remapper->register_field(get_field_in("ps",rgn),get_internal_field("ps_dyn"));
   m_ic_remapper->register_field(get_field_in("phis",rgn),m_helper_fields.at("phis_dyn"));
-  m_ic_remapper->register_field(get_field_in("T_mid",rgn),m_helper_fields.at("vtheta_dp_dyn"));
+  m_ic_remapper->register_field(get_field_in("T_mid",rgn),get_internal_field("vtheta_dp_dyn"));
   m_ic_remapper->register_field(*get_group_in("tracers",rgn).m_bundle,m_helper_fields.at("Q_dyn"));
   m_ic_remapper->registration_ends();
   m_ic_remapper->remap(true);
@@ -1219,21 +1198,11 @@ void HommeDynamics::initialize_homme_state () {
     //       we cannot (11/2021) subview 2 slices of FM together, so
     //       we'd need to also subview horiz_winds. Since we
     const auto& pgn = m_phys_grid->name();
-    const auto ncols = m_phys_grid->get_num_local_dofs();
     if (params.ftype==Homme::ForcingAlg::FORCING_2) {
       m_helper_fields.at("FQ_phys").deep_copy(*get_group_out("Q",pgn).m_bundle);
     }
     m_helper_fields.at("FT_phys").deep_copy(get_field_in("T_mid",pgn));
-    auto FM_ref = m_helper_fields.at("FM_phys").get_view<Real***>();
-    auto horiz_winds = get_field_out("horiz_winds",pgn).get_view<Real***>();
-    Kokkos::parallel_for(Kokkos::RangePolicy<>(0,ncols*nlevs),
-                         KOKKOS_LAMBDA (const int idx) {
-      const int icol = idx / nlevs;
-      const int ilev = idx % nlevs;
-
-      FM_ref(icol,0,ilev) = horiz_winds(icol,0,ilev);
-      FM_ref(icol,1,ilev) = horiz_winds(icol,1,ilev);
-    });
+    m_helper_fields.at("FM_phys").deep_copy(get_field_out("horiz_winds",pgn));
   }
 
   // For initial runs, it's easier to prescribe IC for Q, and compute Qdp = Q*dp
@@ -1262,7 +1231,6 @@ void HommeDynamics::initialize_homme_state () {
 
   // Can clean up the IC remapper now.
   m_ic_remapper = nullptr;
-
 }
 // =========================================================================================
 void HommeDynamics::

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics_fv_phys.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics_fv_phys.cpp
@@ -87,7 +87,6 @@ static void copy_prev (const int ncols, const int npacks,
       FT(icol,ilev) = T(icol,ilev);
       FM(icol,0,ilev) = uv(icol,0,ilev);
       FM(icol,1,ilev) = uv(icol,1,ilev);
-      FM(icol,2,ilev) = 0;
     });
   });
   Kokkos::fence();  
@@ -198,7 +197,7 @@ void HommeDynamics::remap_fv_phys_to_dyn () const {
   assert(m_helper_fields.at("FT_phys").get_view<const Real**>().extent_int(0) == nelem*npg);
 
   const auto uv_ndim = m_helper_fields.at("FM_phys").get_view<const Real***>().extent_int(1);
-  assert(uv_ndim == 2 or uv_ndim == 3);
+  assert(uv_ndim == 2);
 
   const auto T = Homme::GllFvRemap::CPhys2T(
     m_helper_fields.at("FT_phys").get_view<const Real**>().data(),

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.cpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.cpp
@@ -390,15 +390,18 @@ void PhysicsDynamicsRemapper::
 do_remap_fwd() const
 {
   // When remapping from phys to dyn, we need to perform a BEX
-  // on the dyn fields. The BEX class cannot be updated,
-  // to point to a different slice of the dyn field. Therefore,
-  // if m_update_subfield_dyn is non-empty, we cannot perform
-  // a forward remap.
+  // on the dyn fields. The BEX is 'static', meaning that the stored
+  // views cannot be changed after it's been setup. Therefore,
+  // if subfield info has changed for some dyn fields, we're toast.
   EKAT_REQUIRE_MSG (
       not subfields_info_has_changed(m_subfield_info_dyn,m_dyn_fields),
       "Error! P->D remapping is not supported if the some of the dyn fields\n"
-      "       are 'dynamic' subfields (see Field::subfield in field.hpp for\n"
-      "       an explanation of what a 'dynamic' subfield is).\n");
+      "       are subfields whose subview info has changed since setup.\n"
+      "       Note: see field.hpp and field_alloc_prop.hpp for an explanation\n"
+      "       of what a subfield and subview info).\n");
+
+  // Check if we need to update the views for subfields on phys grid
+  update_subfields_views(m_subfield_info_phys,m_phys_repo,m_phys_fields);
 
   using TeamPolicy = typename KT::TeamTagPolicy<RemapFwdTag>;
 
@@ -425,7 +428,7 @@ do_remap_fwd() const
 void PhysicsDynamicsRemapper::
 do_remap_bwd() const
 {
-  // Check if we need to update the subfields info
+  // Check if we need to update the views for subfields
   update_subfields_views(m_subfield_info_dyn,m_dyn_repo,m_dyn_fields);
   update_subfields_views(m_subfield_info_phys,m_phys_repo,m_phys_fields);
 

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.cpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.cpp
@@ -1,28 +1,5 @@
 #include "dynamics/homme/physics_dynamics_remapper.hpp"
 
-// #include "share/scream_config.hpp"
-
-// #include "dynamics/homme/homme_dimensions.hpp"
-// #include "dynamics/homme/homme_dynamics_helpers.hpp"
-
-// #include "share/grid/remap/abstract_remapper.hpp"
-// #include "share/grid/se_grid.hpp"
-// #include "share/util/scream_utils.hpp"
-
-// #include "ekat/ekat_pack_utils.hpp"
-// #include "ekat/ekat_pack.hpp"
-// #include "ekat/ekat_assert.hpp"
-
-// // Homme includes
-// #include "Context.hpp"
-// #include "HommexxEnums.hpp"
-// #include "SimulationParams.hpp"
-// #include "TimeLevel.hpp"
-// #include "Types.hpp"
-// #include "mpi/Connectivity.hpp"
-// #include "mpi/BoundaryExchange.hpp"
-// #include "mpi/MpiBuffersManager.hpp"
-
 namespace scream
 {
 
@@ -54,6 +31,10 @@ create_src_layout (const FieldLayout& tgt_layout) const {
   auto tags = tgt_layout.tags();
   auto dims = tgt_layout.dims();
 
+  EKAT_REQUIRE_MSG (!ekat::contains(tags,FieldTag::TimeLevel),
+      "Error! Cannot remap to a Field with the TimeLevel tag.\n"
+      "       Please, provide the proper subfield instead.\n");
+
   // Note down the position of the first 'GaussPoint' tag.
   auto it_pos = ekat::find(tags,GP);
   EKAT_REQUIRE_MSG (it_pos!=tags.end(),
@@ -69,14 +50,6 @@ create_src_layout (const FieldLayout& tgt_layout) const {
   ekat::erase(tags,GP);
   dims.erase(dims.begin()+pos);
   dims.erase(dims.begin()+pos);
-
-  // If the tgt layout contains the TimeLevel tag, we slice it off.
-  auto it_tl = ekat::find(tags,TL);
-  if (it_tl!=tags.end()) {
-    pos = std::distance(tags.begin(),it_tl);
-    tags.erase(tags.begin()+pos);
-    dims.erase(dims.begin()+pos);
-  }
 
   return FieldLayout(tags,dims);
 }
@@ -128,8 +101,8 @@ create_tgt_layout (const FieldLayout& src_layout) const {
 void PhysicsDynamicsRemapper::
 do_register_field (const identifier_type& src, const identifier_type& tgt)
 {
-  m_phys.push_back(field_type(src));
-  m_dyn.push_back(field_type(tgt));
+  m_phys_fields.push_back(field_type(src));
+  m_dyn_fields.push_back(field_type(tgt));
 
   EKAT_REQUIRE_MSG (src.data_type()==field_valid_data_types().at<Real>(),
       "Error! PD remapper only works for Real data type.\n");
@@ -142,18 +115,13 @@ do_bind_field (const int ifield, const field_type& src, const field_type& tgt)
 {
   const auto& tgt_layout = tgt.get_header().get_identifier().get_layout();
   const auto& tgt_tags = tgt_layout.tags();
-  const auto& tgt_dims = tgt_layout.dims();
 
-  const bool has_time_level  = ekat::contains(tgt_tags,FieldTag::TimeLevel);
-  if (has_time_level) {
-    const bool valid_tl_dim = (tgt_dims[1]==HOMMEXX_NUM_TIME_LEVELS);
-    EKAT_REQUIRE_MSG (valid_tl_dim,
-        "Error! Field has the TimeLevel tag, but it does not appear to be 'state'.");
-  }
+  EKAT_REQUIRE_MSG (!ekat::contains(tgt_tags,FieldTag::TimeLevel),
+      "Error! Cannot remap to a Field with the TimeLevel tag.\n"
+      "       Please, provide the proper subfield instead.\n");
 
-  m_is_state_field.push_back(has_time_level);
-  m_phys[ifield] = src;
-  m_dyn[ifield] = tgt;
+  m_phys_fields[ifield] = src;
+  m_dyn_fields[ifield] = tgt;
 
   // If this was the last field to be bound, we can setup the BE and
   // precompute fields needed on device during remapper
@@ -175,144 +143,132 @@ do_registration_ends ()
   }
 }
 
-// Helper function to compute the dimensions of
-// field views.
-template<typename ScalarT, typename AllocType>
-void PhysicsDynamicsRemapper::
-compute_view_dims (const AllocType& alloc_prop, const std::vector<int>& field_dims, Dims& view_dims)
-{
-  auto num_values = alloc_prop.get_alloc_size()/sizeof(ScalarT);
-  int N = field_dims.size();
-
-  view_dims.size = N;
-  for (int i=0; i<N-1; ++i) {
-    view_dims.dims[i] = field_dims[i];
-    num_values /= field_dims[i];
-  }
-  view_dims.dims[N-1] = num_values;
-}
-
 void PhysicsDynamicsRemapper::
 initialize_device_variables()
 {
-  phys_ptrs   = decltype(phys_ptrs)      ("phys_ptrs",   this->m_num_fields);
-  phys_dims   = decltype(phys_dims)      ("phys_dims",   this->m_num_fields);
-  phys_layout = decltype(phys_layout)    ("phys_layout", this->m_num_fields);
+  m_layout              = decltype(m_layout)              ("layout", this->m_num_fields);
+  m_pack_alloc_property = decltype(m_pack_alloc_property) ("pack_alloc_property", this->m_num_fields);
+  m_num_levels          = decltype(m_num_levels)          ("num_physical_levels", this->m_num_fields);
 
-  dyn_ptrs   = decltype(dyn_ptrs)   ("dyn_ptrs",   this->m_num_fields);
-  dyn_dims   = decltype(dyn_dims)   ("dyn_dims",   this->m_num_fields);
-  dyn_layout = decltype(dyn_layout) ("dyn_layout", this->m_num_fields);
+  for (auto which : {'P','D'}) {
+    auto& repo   = which=='P' ? m_phys_repo : m_dyn_repo;
+    auto& fields = which=='P' ? m_phys_fields: m_dyn_fields;
 
-  has_parent          = decltype(has_parent)          ("has_parent",               this->m_num_fields);
-  pack_alloc_property = decltype(pack_alloc_property) ("phys_pack_alloc_property", this->m_num_fields);
-  is_state_field_dev  = decltype(is_state_field_dev)  ("is_state_field_dev",       this->m_num_fields);
-  num_levels          = decltype(num_levels)          ("num_physical_levels",      this->m_num_fields);
-  states_tl_idx       = decltype(states_tl_idx)       ("states_time_level");
+    repo.views  = ViewsRepo::views_t ("views", this->m_num_fields);
+    repo.cviews = ViewsRepo::cviews_t("cviews",this->m_num_fields);
 
-  auto h_phys_ptrs   = Kokkos::create_mirror_view(phys_ptrs);
-  auto h_phys_layout = Kokkos::create_mirror_view(phys_layout);
-  auto h_phys_dims   = Kokkos::create_mirror_view(phys_dims);
+    repo.h_views  = Kokkos::create_mirror_view(repo.views);
+    repo.h_cviews = Kokkos::create_mirror_view(repo.cviews);
 
-  auto h_dyn_ptrs   = Kokkos::create_mirror_view(dyn_ptrs);
-  auto h_dyn_layout = Kokkos::create_mirror_view(dyn_layout);
-  auto h_dyn_dims   = Kokkos::create_mirror_view(dyn_dims);
+    auto get_view = [&] (const int i, const Field& f) {
+      const auto rank = f.get_header().get_identifier().get_layout().rank();
+      switch (rank) {
+        case 1: repo.h_cviews[i].v1d = f.get_view<const Real*>();      break;
+        case 2: repo.h_cviews[i].v2d = f.get_view<const Real**>();     break;
+        case 3: repo.h_cviews[i].v3d = f.get_view<const Real***>();    break;
+        case 4: repo.h_cviews[i].v4d = f.get_view<const Real****>();   break;
+        case 5: repo.h_cviews[i].v5d = f.get_view<const Real*****>();  break;
+      }
+      if (not f.is_read_only()) {
+        switch (rank) {
+          case 1: repo.h_views[i].v1d = f.get_view<Real*>();      break;
+          case 2: repo.h_views[i].v2d = f.get_view<Real**>();     break;
+          case 3: repo.h_views[i].v3d = f.get_view<Real***>();    break;
+          case 4: repo.h_views[i].v4d = f.get_view<Real****>();   break;
+          case 5: repo.h_views[i].v5d = f.get_view<Real*****>();  break;
+        }
+      }
+    };
+    for (int i=0; i<this->m_num_fields; ++i) {
+      get_view(i,fields[i]);
+    }
+    Kokkos::deep_copy(repo.views,  repo.h_views);
+    Kokkos::deep_copy(repo.cviews, repo.h_cviews);
+  }
 
-  auto h_has_parent          = Kokkos::create_mirror_view(has_parent);
-  auto h_pack_alloc_property = Kokkos::create_mirror_view(pack_alloc_property);
-  auto h_is_state_field_dev  = Kokkos::create_mirror_view(is_state_field_dev);
-  auto h_num_levels          = Kokkos::create_mirror_view(num_levels);
+  auto h_layout              = Kokkos::create_mirror_view(m_layout);
+  auto h_pack_alloc_property = Kokkos::create_mirror_view(m_pack_alloc_property);
+  auto h_num_levels          = Kokkos::create_mirror_view(m_num_levels);
 
+  // Some info that is the same for both dyn and phys
   for (int i=0; i<this->m_num_fields; ++i) {
-    const auto& phys = m_phys[i];
-    const auto& dyn  = m_dyn[i];
+    const auto& phys = m_phys_fields[i];
+    const auto& dyn  = m_dyn_fields[i];
 
     const auto& ph = phys.get_header();
     const auto& dh = dyn.get_header();
 
-    const auto& phys_dim = ph.get_identifier().get_layout().dims();
-    const auto& dyn_dim  = dh.get_identifier().get_layout().dims();
-
-    // If field has a parent, then its view has been subviewed. We
-    // do not want to remmap subviews, only the view of the parent,
-    // so we store this and no other info for these fields, then
-    // skip these fields during the remap.
-    if (ph.get_parent().lock() != nullptr) {
-      EKAT_REQUIRE_MSG(dh.get_parent().lock() != nullptr,
-                       "Error! If physics field has parent,"
-                       "dynamics field must also have parent.");
-
-      const int ifield = this->find_field(ph.get_parent().lock()->get_identifier(), dh.get_parent().lock()->get_identifier());
-      EKAT_REQUIRE_MSG(ifield != -1,
-                       "Error! Parent must be registered for remapped subfields.");
-
-      h_has_parent(i) = true;
-      continue;
+    // A dynamic subfield will need some special treatment at runtime
+    // Namely, we'll need to re-extract the view every time,
+    // since the subview info may have changed
+    if (ph.get_parent().lock() && ph.get_alloc_properties().get_subview_info().dynamic) {
+      m_update_subfield_phys.push_back(i);
     }
-    else {
-      h_has_parent(i) = false;
+    if (dh.get_parent().lock() && dh.get_alloc_properties().get_subview_info().dynamic) {
+      m_update_subfield_dyn.push_back(i);
     }
 
-    // Store view pointers
-    h_phys_ptrs(i).cptr = phys.get_internal_view_data<const Real>();
-    h_dyn_ptrs(i).cptr  = dyn.get_internal_view_data<const Real>();
-    if (not phys.is_read_only()) {
-      h_phys_ptrs(i).ptr = phys.get_internal_view_data<Real>();
-    }
-    if (not dyn.is_read_only()) {
-      h_dyn_ptrs(i).ptr  = dyn.get_internal_view_data<Real>();
-    }
+    const auto& pl = ph.get_identifier().get_layout();
 
-    // Store phys layout
-    const auto phys_lt = get_layout_type(ph.get_identifier().get_layout().tags());
-    h_phys_layout(i) = etoi(phys_lt);
+    auto lt = get_layout_type(pl.tags());
+    h_layout(i) = etoi(lt);
 
-    // Store allocation properties. Only allow packed views for 3D physics fields.
-    const bool is_phys_field_3d = (h_phys_layout(i) == etoi(LayoutType::Scalar3D) ||
-                                   h_phys_layout(i) == etoi(LayoutType::Vector3D));
-    const auto& phys_alloc_prop = ph.get_alloc_properties();
-    const auto& dyn_alloc_prop  = dh.get_alloc_properties();
-    if (is_phys_field_3d &&
-        phys_alloc_prop.template is_compatible<pack_type>() &&
-        dyn_alloc_prop.template  is_compatible<pack_type>()) {
+    const bool is_field_3d = lt==LayoutType::Scalar3D || lt==LayoutType::Vector3D;
+    h_num_levels(i) = is_field_3d ? pl.dims().back() : -1;
+
+    const auto& pap = ph.get_alloc_properties();
+    const auto& dap = dh.get_alloc_properties();
+    if (is_field_3d &&
+        pap.template is_compatible<pack_type>() &&
+        dap.template is_compatible<pack_type>()) {
       h_pack_alloc_property(i) = AllocPropType::PackAlloc;
-
-      // Store dimensions of phys/dyn view
-      compute_view_dims<pack_type>(phys_alloc_prop, phys_dim, h_phys_dims(i));
-      compute_view_dims<pack_type>(dyn_alloc_prop,  dyn_dim,  h_dyn_dims(i));
-    } else if (is_phys_field_3d &&
-               phys_alloc_prop.template is_compatible<small_pack_type>() &&
-               dyn_alloc_prop.template  is_compatible<small_pack_type>()) {
+    } else if (is_field_3d &&
+               pap.template is_compatible<small_pack_type>() &&
+               dap.template is_compatible<small_pack_type>()) {
       h_pack_alloc_property(i) = AllocPropType::SmallPackAlloc;
-
-      // Store dimensions of phys/dyn view
-      compute_view_dims<small_pack_type>(phys_alloc_prop, phys_dim, h_phys_dims(i));
-      compute_view_dims<small_pack_type>(dyn_alloc_prop,  dyn_dim,  h_dyn_dims(i));
     } else {
       h_pack_alloc_property(i) = AllocPropType::RealAlloc;
-
-      // Store dimensions of phys/dyn view
-      compute_view_dims<Real>(phys_alloc_prop, phys_dim, h_phys_dims(i));
-      compute_view_dims<Real>(dyn_alloc_prop,  dyn_dim,  h_dyn_dims(i));
     }
-
-    h_num_levels(i) = is_phys_field_3d ? phys_dim.back() : -1;
-
-    // Store time levels
-    h_is_state_field_dev(i) = m_is_state_field[i];
   }
+  Kokkos::deep_copy(m_layout,              h_layout             );
+  Kokkos::deep_copy(m_pack_alloc_property, h_pack_alloc_property);
+  Kokkos::deep_copy(m_num_levels,          h_num_levels         );
+}
 
-  Kokkos::deep_copy(phys_ptrs,   h_phys_ptrs);
-  Kokkos::deep_copy(phys_layout, h_phys_layout);
-  Kokkos::deep_copy(phys_dims,   h_phys_dims);
+void PhysicsDynamicsRemapper::
+update_subfields_views () const
+{
+  auto update = [&](const std::vector<int>& field_idx,
+                    const ViewsRepo& repo,
+                    const std::vector<field_type>& fields) {
 
-  Kokkos::deep_copy(dyn_ptrs,   h_dyn_ptrs);
-  Kokkos::deep_copy(dyn_layout, h_dyn_layout);
-  Kokkos::deep_copy(dyn_dims,   h_dyn_dims);
-
-  Kokkos::deep_copy(has_parent,          h_has_parent);
-  Kokkos::deep_copy(pack_alloc_property, h_pack_alloc_property);
-  Kokkos::deep_copy(is_state_field_dev,  h_is_state_field_dev);
-  Kokkos::deep_copy(num_levels,          h_num_levels);
+    auto get_view = [&] (const int i, const Field& f) {
+      const auto rank = f.get_header().get_identifier().get_layout().rank();
+      switch (rank) {
+        case 1: repo.h_cviews[i].v1d = f.get_view<const Real*>();      break;
+        case 2: repo.h_cviews[i].v2d = f.get_view<const Real**>();     break;
+        case 3: repo.h_cviews[i].v3d = f.get_view<const Real***>();    break;
+        case 4: repo.h_cviews[i].v4d = f.get_view<const Real****>();   break;
+        case 5: repo.h_cviews[i].v5d = f.get_view<const Real*****>();  break;
+      }
+      if (not f.is_read_only()) {
+        switch (rank) {
+          case 1: repo.h_views[i].v1d = f.get_view<Real*>();      break;
+          case 2: repo.h_views[i].v2d = f.get_view<Real**>();     break;
+          case 3: repo.h_views[i].v3d = f.get_view<Real***>();    break;
+          case 4: repo.h_views[i].v4d = f.get_view<Real****>();   break;
+          case 5: repo.h_views[i].v5d = f.get_view<Real*****>();  break;
+        }
+      }
+    };
+    for (auto i : field_idx) {
+      get_view(i,fields[i]);
+    }
+    Kokkos::deep_copy(repo.views,  repo.h_views);
+    Kokkos::deep_copy(repo.cviews, repo.h_cviews);
+  };
+  update(m_update_subfield_dyn,m_dyn_repo,m_dyn_fields);
+  update(m_update_subfield_dyn,m_phys_repo,m_phys_fields);
 }
 
 template <typename ScalarT, typename MT>
@@ -322,123 +278,53 @@ set_dyn_to_zero(const MT& team) const
 {
   const int i = team.league_rank();
 
-  const int itl = states_tl_idx();
-  const auto& dim_d = dyn_dims(i).dims;
-
-  switch (phys_layout(i)) {
+  switch (m_layout(i)) {
     case etoi(LayoutType::Scalar2D):
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<ScalarT,4> (dyn_ptrs(i).ptr, dyn_dims(i));
-        auto v = ekat::subview_1(dyn,itl);
-
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, v.size()), [&](const int& k) {
-          int k0   = k%dim_d[0];
-          int ktmp = k/dim_d[0];
-          int k1   = ktmp%dim_d[2];
-          int k2   = ktmp/dim_d[2];
-          v(k0, k1, k2) = 0;
-        });
-      } else {
-        auto dyn = reshape<ScalarT,3> (dyn_ptrs(i).ptr, dyn_dims(i));
-
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, dyn.size()), [&](const int& k) {
-          int k0   = k%dim_d[0];
-          int ktmp = k/dim_d[0];
-          int k1   = ktmp%dim_d[1];
-          int k2   = ktmp/dim_d[1];
-          dyn(k0, k1, k2) = 0;
-        });
-      }
+    {
+      auto v = m_dyn_repo.views[i].v3d;
+      int dim1 = v.extent(1);
+      int dim2 = v.extent(2);
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, v.size()), [&](const int& k) {
+        int k0   = (k / dim2) / dim1;
+        int k1   = (k / dim2) % dim1;
+        int k2   =  k % dim2;
+        v(k0, k1, k2) = 0;
+      });
       break;
-    case etoi(LayoutType::Vector2D):
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<ScalarT,5> (dyn_ptrs(i).ptr, dyn_dims(i));
-        auto v = ekat::subview_1(dyn,itl);
-
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, v.size()), [&](const int& k) {
-          int k0   = k%dim_d[0];
-          int ktmp = k/dim_d[0];
-          int k1   = ktmp%dim_d[2];
-          ktmp     = ktmp/dim_d[2];
-          int k2   = ktmp%dim_d[3];
-          int k3   = ktmp/dim_d[3];
-          v(k0, k1, k2, k3) = 0;
-        });
-      } else {
-        auto dyn = reshape<ScalarT,4> (dyn_ptrs(i).ptr, dyn_dims(i));
-
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, dyn.size()), [&](const int& k) {
-          int k0   = k%dim_d[0];
-          int ktmp = k/dim_d[0];
-          int k1   = ktmp%dim_d[1];
-          ktmp     = ktmp/dim_d[1];
-          int k2   = ktmp%dim_d[2];
-          int k3   = ktmp/dim_d[2];
-          dyn(k0, k1, k2, k3) = 0;
-        });
-      }
-      break;
+    }
+    case etoi(LayoutType::Vector2D): // Fallthrough
     case etoi(LayoutType::Scalar3D):
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<ScalarT,5> (dyn_ptrs(i).ptr, dyn_dims(i));
-        auto v = ekat::subview_1(dyn,itl);
-
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, v.size()), [&](const int& k) {
-          int k0   = k%dim_d[0];
-          int ktmp = k/dim_d[0];
-          int k1   = ktmp%dim_d[2];
-          ktmp     = ktmp/dim_d[2];
-          int k2   = ktmp%dim_d[3];
-          int k3   = ktmp/dim_d[3];
-          v(k0, k1, k2, k3) = 0;
-        });
-
-      } else {
-        auto dyn = reshape<ScalarT,4> (dyn_ptrs(i).ptr, dyn_dims(i));
-
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, dyn.size()), [&](const int& k) {
-          int k0   = k%dim_d[0];
-          int ktmp = k/dim_d[0];
-          int k1   = ktmp%dim_d[1];
-          ktmp     = ktmp/dim_d[1];
-          int k2   = ktmp%dim_d[2];
-          int k3   = ktmp/dim_d[2];
-          dyn(k0, k1, k2, k3) = 0;
-        });
-      }
+    {
+      auto v = m_dyn_repo.views[i].v4d;
+      int dim1 = v.extent(1);
+      int dim2 = v.extent(2);
+      int dim3 = v.extent(3);
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, v.size()), [&](const int& k) {
+        int k0   = ((k / dim3) / dim2) / dim1;
+        int k1   = ((k / dim3) / dim2) % dim1;
+        int k2   =  (k / dim3) % dim2;
+        int k3   =   k % dim3;
+        v(k0, k1, k2, k3) = 0;
+      });
       break;
+    }
     case etoi(LayoutType::Vector3D):
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<ScalarT,6> (dyn_ptrs(i).ptr, dyn_dims(i));
-        auto v = ekat::subview_1(dyn,itl);
-
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, v.size()), [&](const int& k) {
-          int k0   = k%dim_d[0];
-          int ktmp = k/dim_d[0];
-          int k1   = ktmp%dim_d[2];
-          ktmp     = ktmp/dim_d[2];
-          int k2   = ktmp%dim_d[3];
-          ktmp     = ktmp/dim_d[3];
-          int k3   = ktmp%dim_d[4];
-          int k4   = ktmp/dim_d[4];
-          v(k0, k1, k2, k3, k4) = 0;
-        });
-      } else {
-        auto dyn = reshape<ScalarT,5> (dyn_ptrs(i).ptr, dyn_dims(i));
-
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, dyn.size()), [&](const int& k) {
-          int k0   = k%dim_d[0];
-          int ktmp = k/dim_d[0];
-          int k1   = ktmp%dim_d[1];
-          ktmp     = ktmp/dim_d[1];
-          int k2   = ktmp%dim_d[2];
-          ktmp     = ktmp/dim_d[2];
-          int k3   = ktmp%dim_d[3];
-          int k4   = ktmp/dim_d[3];
-          dyn(k0, k1, k2, k3, k4) = 0;
-        });
-      }
+    {
+      auto v = m_dyn_repo.views[i].v5d;
+      int dim1 = v.extent(1);
+      int dim2 = v.extent(2);
+      int dim3 = v.extent(3);
+      int dim4 = v.extent(4);
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, v.size()), [&](const int& k) {
+        int k0   = (((k / dim4) / dim3) / dim2) / dim1;
+        int k1   = (((k / dim4) / dim3) / dim2) % dim1;
+        int k2   =  ((k / dim4) / dim3) % dim2;
+        int k3   =   (k / dim4) % dim3;
+        int k4   =    k % dim4;
+        v(k0, k1, k2, k3, k4) = 0;
+      });
       break;
+    }
     default:
       EKAT_KERNEL_ERROR_MSG("Error! Unhandled case in switch statement.\n");
   }
@@ -447,11 +333,16 @@ set_dyn_to_zero(const MT& team) const
 void PhysicsDynamicsRemapper::
 do_remap_fwd() const
 {
-  // Update time slice idx for states
-  const auto& tl = Homme::Context::singleton().get<Homme::TimeLevel>();
-  Kokkos::deep_copy(states_tl_idx, tl.n0);
+  // When remapping from phys to dyn, we need to perform a BEX
+  // on the dyn fields. The BEX class cannot be updated,
+  // to point to a different slice of the dyn field. Therefore,
+  // if m_update_subfield_dyn is non-empty, we cannot perform
+  // a forward remap.
+  EKAT_REQUIRE_MSG (m_update_subfield_dyn.size()==0,
+      "Error! P->D remapping is not supported if the some of the dyn fields\n"
+      "       are 'dynamic' subfields (see Field::subfield in field.hpp for\n"
+      "       an explanation of what a 'dynamic' subfield is).\n");
 
-  using KT = KokkosTypes<DefaultDevice>;
   using TeamPolicy = typename KT::TeamTagPolicy<RemapFwdTag>;
 
   const auto concurrency = KT::ExeSpace::concurrency();
@@ -470,18 +361,16 @@ do_remap_fwd() const
   Kokkos::parallel_for(policy, *this);
   Kokkos::fence();
 
-  // Exchange only the current time levels
-  m_be[tl.n0]->exchange();
+  // Exchange element halo
+  m_be->exchange();
 }
 
 void PhysicsDynamicsRemapper::
 do_remap_bwd() const
 {
-  // Update time slice idx for states
-  const auto& tl = Homme::Context::singleton().get<Homme::TimeLevel>();
-  Kokkos::deep_copy(states_tl_idx, tl.n0);
+  // Check if we need to update the subfields info
+  update_subfields_views ();
 
-  using KT = KokkosTypes<DefaultDevice>;
   using TeamPolicy = typename KT::TeamTagPolicy<RemapBwdTag>;
 
   const auto concurrency = KT::ExeSpace::concurrency();
@@ -502,8 +391,6 @@ do_remap_bwd() const
 
 void PhysicsDynamicsRemapper::
 setup_boundary_exchange () {
-  // TODO: should we check that the BE was not already setup? I don't see this happening, but even if it does,
-  //       there should be no side effect if we re-build it. We waste some time, sure, but should yield a correct result.
 
   auto& c = Homme::Context::singleton();
 
@@ -513,29 +400,14 @@ setup_boundary_exchange () {
   int num_3d_mid = 0;
   int num_3d_int = 0;
   for (int i=0; i<this->m_num_fields; ++i) {
-    const auto& layout = m_dyn[i].get_header().get_identifier().get_layout();
+    const auto& layout = m_dyn_fields[i].get_header().get_identifier().get_layout();
     const auto lt = get_layout_type(layout.tags());
     switch (lt) {
       case LayoutType::Scalar2D:
         ++num_2d;
         break;
       case LayoutType::Vector2D:
-        if (m_is_state_field[i]) {
-          // A scalar state: we only exchange the timelevel we remapped
-          num_2d += 1;
-        } else {
-          // A vector field (not a state): remap all components
-          num_2d += layout.dim(1);
-        }
-        break;
-      case LayoutType::Tensor2D:
-        if (m_is_state_field[i]) {
-          // A vector state: we only exchange the timelevel we remapped
-          num_2d += layout.dim(2);
-        } else {
-          // A tensor field (not a state): remap all components
-          num_2d += layout.dim(1)*layout.dim(2);
-        }
+        num_2d += layout.dim(1);
         break;
       case LayoutType::Scalar3D:
         if (layout.dims().back()==HOMMEXX_NUM_PHYSICAL_LEV) {
@@ -547,50 +419,17 @@ setup_boundary_exchange () {
         }
         break;
       case LayoutType::Vector3D:
-        if (m_is_state_field[i]) {
-          // A scalar state: we only exchange the timelevel we remapped
-          if (layout.dims().back()==HOMMEXX_NUM_PHYSICAL_LEV) {
-            ++num_3d_mid;
-          } else if (layout.dims().back()==HOMMEXX_NUM_INTERFACE_LEV) {
-            ++num_3d_int;
-          } else {
-            EKAT_ERROR_MSG ("Error! Unexpected vertical level extent.\n");
-          }
+        // A vector field (not a state): remap all components
+        if (layout.dims().back()==HOMMEXX_NUM_PHYSICAL_LEV) {
+          num_3d_mid += layout.dim(1);
+        } else if (layout.dims().back()==HOMMEXX_NUM_INTERFACE_LEV) {
+          num_3d_int += layout.dim(1);
         } else {
-          // A vector field (not a state): remap all components
-          if (layout.dims().back()==HOMMEXX_NUM_PHYSICAL_LEV) {
-            num_3d_mid += layout.dim(1);
-          } else if (layout.dims().back()==HOMMEXX_NUM_INTERFACE_LEV) {
-            num_3d_int += layout.dim(1);
-          } else {
-            EKAT_ERROR_MSG ("Error! Unexpected vertical level extent.\n");
-          }
-        }
-        break;
-      case LayoutType::Tensor3D:
-        if (m_is_state_field[i]) {
-          auto num_slices = layout.dim(2);
-          // A vector state: we only exchange the timelevel we remapped
-          if (layout.dims().back()==HOMMEXX_NUM_PHYSICAL_LEV) {
-            num_3d_mid += num_slices;
-          } else if (layout.dims().back()==HOMMEXX_NUM_INTERFACE_LEV) {
-            num_3d_int += num_slices;
-          } else {
-            EKAT_ERROR_MSG ("Error! Unexpected vertical level extent.\n");
-          }
-        } else {
-          // A tensor field (not a state): remap all components
-          if (layout.dims().back()==HOMMEXX_NUM_PHYSICAL_LEV) {
-            num_3d_mid += layout.dim(1)*layout.dim(2);
-          } else if (layout.dims().back()==HOMMEXX_NUM_INTERFACE_LEV) {
-            num_3d_int += layout.dim(1)*layout.dim(2);
-          } else {
-            EKAT_ERROR_MSG ("Error! Unexpected vertical level extent.\n");
-          }
+          EKAT_ERROR_MSG ("Error! Unexpected vertical level extent.\n");
         }
         break;
     default:
-      ekat::error::runtime_abort("Error! Invalid layout. This is an internal error. Please, contact developers\n");
+      EKAT_ERROR_MSG("Error! Invalid layout. This is an internal error. Please, contact developers\n");
     }
   }
 
@@ -605,84 +444,40 @@ setup_boundary_exchange () {
 
   constexpr int NLEV = HOMMEXX_NUM_LEV;
   constexpr int NINT = HOMMEXX_NUM_LEV_P;
-  constexpr int NTL  = HOMMEXX_NUM_TIME_LEVELS;
-  for (int it=0; it<HOMMEXX_NUM_TIME_LEVELS; ++it) {
-    m_be[it]= std::make_shared<Homme::BoundaryExchange>(conn,bm);
+  m_be = std::make_shared<Homme::BoundaryExchange>(conn,bm);
+  m_be->set_num_fields(0,num_2d,num_3d_mid,num_3d_int);
 
-    auto be = m_be[it];
-    be->set_num_fields(0,num_2d,num_3d_mid,num_3d_int);
-
-    // If some fields are already bound, set them in the bd exchange
-    for (int i=0; i<this->m_num_fields; ++i) {
-      const auto& layout = m_dyn[i].get_header().get_identifier().get_layout();
-      const auto& dims = layout.dims();
-      const auto lt = get_layout_type(layout.tags());
-      switch (lt) {
-        case LayoutType::Scalar2D:
-          be->register_field(getHommeView<Real*[NP][NP]>(m_dyn[i]));
-          break;
-        case LayoutType::Vector2D:
-          if (m_is_state_field[i]) {
-            // A scalar state: exchange one time level only
-            be->register_field(getHommeView<Real**[NP][NP]>(m_dyn[i]),1,it);
-          } else {
-            // A 2d vector (not a state): exchange all slices
-            be->register_field(getHommeView<Real**[NP][NP]>(m_dyn[i]),dims[1],0);
-          }
-          break;
-        case LayoutType::Tensor2D:
-          if (m_is_state_field[i]) {
-            // A vector state: exchange one time level only
-            be->register_field(getHommeView<Real***[NP][NP]>(m_dyn[i]),it,dims[2],0);
-          } else {
-            // A 2d tensor (not a state): exchange all slices
-            for (int idim=0; idim<dims[1]; ++idim) {
-              // Homme::BoundaryExchange only exchange one slice of the outer dim at a time,
-              // so loop on the outer dim and register each slice individually.
-              be->register_field(getHommeView<Real***[NP][NP]>(m_dyn[i]),idim,dims[2],0);
-            }
-          }
-          break;
-        case LayoutType::Scalar3D:
-          if (dims.back()==HOMMEXX_NUM_PHYSICAL_LEV) {
-            be->register_field(getHommeView<Scalar*[NP][NP][NLEV]>(m_dyn[i]));
-          } else {
-            be->register_field(getHommeView<Scalar*[NP][NP][NINT]>(m_dyn[i]));
-          }
-          break;
-        case LayoutType::Vector3D:
-          if (m_is_state_field[i]) {
-            // A state: exchange one time level only
-            if (dims.back()==HOMMEXX_NUM_PHYSICAL_LEV) {
-              be->register_field(getHommeView<Scalar*[NTL][NP][NP][NLEV]>(m_dyn[i]),1,it);
-            } else {
-              be->register_field(getHommeView<Scalar*[NTL][NP][NP][NINT]>(m_dyn[i]),1,it);
-            }
-          } else {
-            // Not a state: exchange all slices
-            if (dims.back()==HOMMEXX_NUM_PHYSICAL_LEV) {
-              be->register_field(getHommeView<Scalar**[NP][NP][NLEV]>(m_dyn[i]),dims[1],0);
-            } else {
-              be->register_field(getHommeView<Scalar**[NP][NP][NINT]>(m_dyn[i]),dims[1],0);
-            }
-          }
-          break;
-        case LayoutType::Tensor3D:
-          if (m_is_state_field[i]) {
-            // This must either be v.
-            auto num_slices = layout.dim(2);
-            auto slice = it;
-            be->register_field(getHommeView<Scalar***[NP][NP][NLEV]>(m_dyn[i]),slice,num_slices,0);
-          } else {
-            EKAT_ERROR_MSG ("Error! We were not expected a rank-6 fields in homme that is not a state.\n");
-          }
-          break;
-      default:
-        ekat::error::runtime_abort("Error! Invalid layout. This is an internal error. Please, contact developers\n");
-      }
+  // If some fields are already bound, set them in the bd exchange
+  for (int i=0; i<this->m_num_fields; ++i) {
+    const auto& layout = m_dyn_fields[i].get_header().get_identifier().get_layout();
+    const auto& dims = layout.dims();
+    const auto lt = get_layout_type(layout.tags());
+    switch (lt) {
+      case LayoutType::Scalar2D:
+        m_be->register_field(getHommeView<Real*[NP][NP]>(m_dyn_fields[i]));
+        break;
+      case LayoutType::Vector2D:
+        m_be->register_field(getHommeView<Real**[NP][NP]>(m_dyn_fields[i]),dims[1],0);
+        break;
+      case LayoutType::Scalar3D:
+        if (dims.back()==HOMMEXX_NUM_PHYSICAL_LEV) {
+          m_be->register_field(getHommeView<Scalar*[NP][NP][NLEV]>(m_dyn_fields[i]));
+        } else {
+          m_be->register_field(getHommeView<Scalar*[NP][NP][NINT]>(m_dyn_fields[i]));
+        }
+        break;
+      case LayoutType::Vector3D:
+        if (dims.back()==HOMMEXX_NUM_PHYSICAL_LEV) {
+          m_be->register_field(getHommeView<Scalar**[NP][NP][NLEV]>(m_dyn_fields[i]),dims[1],0);
+        } else {
+          m_be->register_field(getHommeView<Scalar**[NP][NP][NINT]>(m_dyn_fields[i]),dims[1],0);
+        }
+        break;
+    default:
+      EKAT_ERROR_MSG("Error! Invalid layout. This is an internal error. Please, contact developers\n");
     }
-    be->registration_completed();
   }
+  m_be->registration_completed();
 }
 
 template <typename MT>
@@ -692,61 +487,35 @@ local_remap_fwd_2d (const MT& team) const
 {
   const int i = team.league_rank();
 
-  const auto& dim_p = phys_dims(i).dims;
-
-  switch (phys_layout(i)) {
+  switch (m_layout(i)) {
     case etoi(LayoutType::Scalar2D):
     {
-      auto phys = reshape<const Real,1> (phys_ptrs(i).cptr, phys_dims(i));
+      auto phys = m_phys_repo.cviews[i].v1d;
+      auto dyn  = m_dyn_repo.views[i].v3d;
 
       const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols);
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<Real,4> (dyn_ptrs(i).ptr, dyn_dims(i));
-
-        const auto f = [&] (const int icol) {
-          const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
-          dyn(elgp[0],states_tl_idx(),elgp[1],elgp[2]) = phys(icol);
-        };
-        Kokkos::parallel_for(tr, f);
-      } else {
-        auto dyn = reshape<Real,3> (dyn_ptrs(i).ptr, dyn_dims(i));
-
-        const auto f = [&] (const int icol) {
-          const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
-          dyn(elgp[0],elgp[1],elgp[2]) = phys(icol);
-        };
-        Kokkos::parallel_for(tr, f);
-      }
+      const auto f = [&] (const int icol) {
+        const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
+        dyn(elgp[0],elgp[1],elgp[2]) = phys(icol);
+      };
+      Kokkos::parallel_for(tr, f);
       break;
     }
     case etoi(LayoutType::Vector2D):
     {
-      auto phys = reshape<const Real,2> (phys_ptrs(i).cptr, phys_dims(i));
+      auto phys = m_phys_repo.cviews[i].v2d;
+      auto dyn  = m_dyn_repo.views[i].v4d;
 
-      const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols*dim_p[1]);
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<Real,5> (dyn_ptrs(i).ptr, dyn_dims(i));
+      const int vec_dim = phys.extent(1);
+      const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols*vec_dim);
+      const auto f = [&] (const int idx) {
+        const int icol = idx / vec_dim;
+        const int idim = idx % vec_dim;
 
-        const auto f = [&] (const int idx) {
-          const int icol = idx/dim_p[1];
-          const int idim = idx%dim_p[1];
-
-          const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
-          dyn(elgp[0],states_tl_idx(),idim,elgp[1],elgp[2]) = phys(icol,idim);
-        };
-        Kokkos::parallel_for(tr, f);
-      } else {
-        auto dyn = reshape<Real,4> (dyn_ptrs(i).ptr, dyn_dims(i));
-
-        const auto f = [&] (const int idx) {
-          const int icol = idx/dim_p[1];
-          const int idim = idx%dim_p[1];
-
-          const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
-          dyn(elgp[0],idim,elgp[1],elgp[2]) = phys(icol,idim);
-        };
-        Kokkos::parallel_for(tr, f);
-      }
+        const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
+        dyn(elgp[0],idim,elgp[1],elgp[2]) = phys(icol,idim);
+      };
+      Kokkos::parallel_for(tr, f);
       break;
     }
     default:
@@ -761,74 +530,43 @@ local_remap_fwd_3d (const MT& team) const
 {
   const int i = team.league_rank();
 
-  const auto& dim_p = phys_dims(i).dims;
-
   constexpr int PackSize = sizeof(ScalarT) / sizeof(Real);
   using PI = ekat::PackInfo<PackSize>;
-  const int num_packs = PI::num_packs(num_levels(i));
+  const int num_packs = PI::num_packs(m_num_levels(i));
 
-  switch (phys_layout(i)) {
+  switch (m_layout(i)) {
     case etoi(LayoutType::Scalar3D):
     {
-      auto phys = reshape<const ScalarT,2> (phys_ptrs(i).cptr, phys_dims(i));
+      auto phys = pack_view<const ScalarT>(m_phys_repo.cviews[i].v2d);
+      auto dyn  = pack_view<      ScalarT>(m_dyn_repo.views[i].v4d);
 
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<ScalarT,5> (dyn_ptrs(i).ptr, dyn_dims(i));
+      const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols*num_packs);
+      const auto f = [&] (const int idx) {
+        const int icol = idx / num_packs;
+        const int ilev = idx % num_packs;
 
-        const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols*num_packs);
-        const auto f = [&] (const int idx) {
-          const int icol = idx / num_packs;
-          const int ilev = idx % num_packs;
-
-          const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
-          dyn(elgp[0],states_tl_idx(),elgp[1],elgp[2],ilev) = phys(icol,ilev);
-        };
-        Kokkos::parallel_for(tr, f);
-      } else {
-        auto dyn = reshape<ScalarT,4> (dyn_ptrs(i).ptr, dyn_dims(i));
-
-        const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols*num_packs);
-        const auto f = [&] (const int idx) {
-          const int icol = idx / num_packs;
-          const int ilev = idx % num_packs;
-
-          const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
-          dyn(elgp[0],elgp[1],elgp[2],ilev) = phys(icol,ilev);
-        };
-        Kokkos::parallel_for(tr, f);
-      }
+        const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
+        dyn(elgp[0],elgp[1],elgp[2],ilev) = phys(icol,ilev);
+      };
+      Kokkos::parallel_for(tr, f);
       break;
     }
     case etoi(LayoutType::Vector3D):
     {
-      auto phys = reshape<const ScalarT,3> (phys_ptrs(i).cptr, phys_dims(i));
-      const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols*dim_p[1]*num_packs);
+      auto phys = pack_view<const ScalarT>(m_phys_repo.cviews[i].v3d);
+      auto dyn  = pack_view<      ScalarT>(m_dyn_repo.views[i].v5d);
+      const int vec_dim = phys.extent(1);
 
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<ScalarT,6> (dyn_ptrs(i).ptr, dyn_dims(i));
+      const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols*vec_dim*num_packs);
+      const auto f = [&] (const int idx) {
+        const int icol = (idx / num_packs) / vec_dim;
+        const int idim = (idx / num_packs) % vec_dim;
+        const int ilev =  idx % num_packs;
 
-        const auto f = [&] (const int idx) {
-          const int icol = (idx / num_packs) / dim_p[1];
-          const int idim = (idx / num_packs) % dim_p[1];
-          const int ilev =  idx % num_packs;
-
-          const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
-          dyn(elgp[0],states_tl_idx(),idim,elgp[1],elgp[2],ilev) = phys(icol,idim,ilev);
-        };
-        Kokkos::parallel_for(tr, f);
-      } else {
-        auto dyn = reshape<ScalarT,5> (dyn_ptrs(i).ptr, dyn_dims(i));
-
-        const auto f = [&] (const int idx) {
-          const int icol = (idx / num_packs) / dim_p[1];
-          const int idim = (idx / num_packs) % dim_p[1];
-          const int ilev =  idx % num_packs;
-
-          const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
-          dyn(elgp[0],idim,elgp[1],elgp[2],ilev) = phys(icol,idim,ilev);
-        };
-        Kokkos::parallel_for(tr, f);
-      }
+        const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
+        dyn(elgp[0],idim,elgp[1],elgp[2],ilev) = phys(icol,idim,ilev);
+      };
+      Kokkos::parallel_for(tr, f);
       break;
     }
     default:
@@ -844,47 +582,28 @@ local_remap_bwd_2d (const MT& team) const
   const int rank = team.league_rank();
   const int i    = rank % this->m_num_fields;
   const int icol = rank / this->m_num_fields;
-
   const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
 
-  const auto& dim_p = phys_dims(i).dims;
-
-  switch (phys_dims(i).size) {
-    case 1:
+  switch (m_layout(i)) {
+    case etoi(LayoutType::Scalar2D):
     {
-      auto phys = reshape<Real,1> (phys_ptrs(i).ptr, phys_dims(i));
+      auto phys = m_phys_repo.views[i].v1d;
+      auto dyn  = m_dyn_repo.cviews[i].v3d;
 
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<const Real,4> (dyn_ptrs(i).cptr, dyn_dims(i));
-
-        phys(icol) = dyn(elgp[0],states_tl_idx(),elgp[1],elgp[2]);
-      } else {
-        auto dyn = reshape<const Real,3> (dyn_ptrs(i).cptr, dyn_dims(i));
-
-        phys(icol) = dyn(elgp[0],elgp[1],elgp[2]);
-      }
+      phys(icol) = dyn(elgp[0],elgp[1],elgp[2]);
       break;
     }
-    case 2:
+    case etoi(LayoutType::Vector2D):
     {
-      auto phys = reshape<Real,2> (phys_ptrs(i).ptr, phys_dims(i));
+      auto phys = m_phys_repo.views[i].v2d;
+      auto dyn  = m_dyn_repo.cviews[i].v4d;
+      const int vec_dim = phys.extent(1);
 
-      const auto tr = Kokkos::TeamThreadRange(team, dim_p[1]);
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<const Real,5> (dyn_ptrs(i).cptr, dyn_dims(i));
-
-        const auto f = [&] (const int idim) {
-          phys(icol,idim) = dyn(elgp[0],states_tl_idx(),idim,elgp[1],elgp[2]);
-        };
-        Kokkos::parallel_for(tr, f);
-      } else {
-        auto dyn = reshape<const Real,4> (dyn_ptrs(i).cptr, dyn_dims(i));
-
-        const auto f = [&] (const int idim) {
-          phys(icol,idim) = dyn(elgp[0],idim,elgp[1],elgp[2]);
-        };
-        Kokkos::parallel_for(tr, f);
-      }
+      const auto tr = Kokkos::TeamThreadRange(team, vec_dim);
+      const auto f = [&] (const int idim) {
+        phys(icol,idim) = dyn(elgp[0],idim,elgp[1],elgp[2]);
+      };
+      Kokkos::parallel_for(tr, f);
       break;
     }
     default:
@@ -900,62 +619,38 @@ local_remap_bwd_3d (const MT& team) const
   const int rank = team.league_rank();
   const int i    = rank % this->m_num_fields;
   const int icol = rank / this->m_num_fields;
-
   const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
-
-  const auto& dim_p = phys_dims(i).dims;
 
   constexpr int PackSize = sizeof(ScalarT) / sizeof(Real);
   using PI = ekat::PackInfo<PackSize>;
-  const int num_packs = PI::num_packs(num_levels(i));
+  const int num_packs = PI::num_packs(m_num_levels(i));
 
-  switch (phys_dims(i).size) {
-    case 2:
+  switch (m_layout(i)) {
+    case etoi(LayoutType::Scalar3D):
     {
-      auto phys = reshape<ScalarT,2> (phys_ptrs(i).ptr, phys_dims(i));
+      auto phys = pack_view<      ScalarT>(m_phys_repo.views[i].v2d);
+      auto dyn  = pack_view<const ScalarT>(m_dyn_repo.cviews[i].v4d);
 
       const auto tr = Kokkos::TeamThreadRange(team, num_packs);
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<const ScalarT,5> (dyn_ptrs(i).cptr, dyn_dims(i));
-
-        const auto f = [&] (const int ilev) {
-          phys(icol,ilev) = dyn(elgp[0],states_tl_idx(),elgp[1],elgp[2],ilev);
-        };
-        Kokkos::parallel_for(tr, f);
-      } else {
-        auto dyn = reshape<const ScalarT,4> (dyn_ptrs(i).cptr, dyn_dims(i));
-
-        const auto f = [&] (const int ilev) {
-          phys(icol,ilev) = dyn(elgp[0],elgp[1],elgp[2],ilev);
-        };
-        Kokkos::parallel_for(tr, f);
-      }
+      const auto f = [&] (const int ilev) {
+        phys(icol,ilev) = dyn(elgp[0],elgp[1],elgp[2],ilev);
+      };
+      Kokkos::parallel_for(tr, f);
       break;
     }
-    case 3:
+    case etoi(LayoutType::Vector3D):
     {
-      auto phys = reshape<ScalarT,3> (phys_ptrs(i).ptr, phys_dims(i));
-      const auto tr = Kokkos::TeamThreadRange(team, dim_p[1]*num_packs);
+      auto phys = pack_view<      ScalarT>(m_phys_repo.views[i].v3d);
+      auto dyn  = pack_view<const ScalarT>(m_dyn_repo.cviews[i].v5d);
+      const int vec_dim = phys.extent(1);
 
-      if (is_state_field_dev(i)) {
-        auto dyn = reshape<const ScalarT,6> (dyn_ptrs(i).cptr, dyn_dims(i));
-
-        const auto f = [&] (const int idx) {
-          const int idim = idx / num_packs;
-          const int ilev = idx % num_packs;
-          phys(icol,idim,ilev) = dyn(elgp[0],states_tl_idx(),idim,elgp[1],elgp[2],ilev);
-        };
-        Kokkos::parallel_for(tr, f);
-      } else {
-        auto dyn = reshape<const ScalarT,5> (dyn_ptrs(i).cptr, dyn_dims(i));
-
-        const auto f = [&] (const int idx) {
-          const int idim = idx / num_packs;
-          const int ilev = idx % num_packs;
-          phys(icol,idim,ilev) = dyn(elgp[0],idim,elgp[1],elgp[2],ilev);
-        };
-        Kokkos::parallel_for(tr, f);
-      }
+      const auto tr = Kokkos::TeamThreadRange(team, vec_dim*num_packs);
+      const auto f = [&] (const int idx) {
+        const int idim = idx / num_packs;
+        const int ilev = idx % num_packs;
+        phys(icol,idim,ilev) = dyn(elgp[0],idim,elgp[1],elgp[2],ilev);
+      };
+      Kokkos::parallel_for(tr, f);
       break;
     }
     default:
@@ -999,9 +694,7 @@ operator()(const RemapFwdTag&, const MT& team) const
 {
   const int i = team.league_rank();
 
-  if (has_parent(i)) return;
-
-  switch (phys_layout(i)) {
+  switch (m_layout(i)) {
     case etoi(LayoutType::Scalar2D):
     case etoi(LayoutType::Vector2D):
       set_dyn_to_zero<Real>(team);
@@ -1011,12 +704,12 @@ operator()(const RemapFwdTag&, const MT& team) const
       break;
     case etoi(LayoutType::Scalar3D):
     case etoi(LayoutType::Vector3D):
-      if (pack_alloc_property(i) == AllocPropType::PackAlloc) {
+      if (m_pack_alloc_property(i) == AllocPropType::PackAlloc) {
         set_dyn_to_zero<pack_type>(team);
         team.team_barrier();
 
         local_remap_fwd_3d<pack_type>(team);
-      } else if (pack_alloc_property(i) == AllocPropType::SmallPackAlloc) {
+      } else if (m_pack_alloc_property(i) == AllocPropType::SmallPackAlloc) {
         set_dyn_to_zero<small_pack_type>(team);
         team.team_barrier();
 
@@ -1041,18 +734,16 @@ operator()(const RemapBwdTag&, const MT& team) const
   const int rank = team.league_rank();
   const int i = rank % this->m_num_fields;
 
-  if (has_parent(i)) return;
-
-  switch (phys_layout(i)) {
+  switch (m_layout(i)) {
     case etoi(LayoutType::Scalar2D):
     case etoi(LayoutType::Vector2D):
       local_remap_bwd_2d(team);
       break;
     case etoi(LayoutType::Scalar3D):
     case etoi(LayoutType::Vector3D):
-      if (pack_alloc_property(i) == AllocPropType::PackAlloc) {
+      if (m_pack_alloc_property(i) == AllocPropType::PackAlloc) {
         local_remap_bwd_3d<pack_type>(team);
-      } else if (pack_alloc_property(i) == AllocPropType::SmallPackAlloc) {
+      } else if (m_pack_alloc_property(i) == AllocPropType::SmallPackAlloc) {
         local_remap_bwd_3d<small_pack_type>(team);
       } else {
         local_remap_bwd_3d<Real>(team);

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -99,11 +99,6 @@ public:
     RealAlloc      = 2
   };
 
-  struct RemapFwdTag {};
-  struct RemapBwdTag {};
-
-protected:
-
   // A container structure to hold the physically-shaped views for the fields.
   // Notice that only one of the vNd will be set, while the others will be empty.
   template<typename T>
@@ -129,6 +124,8 @@ protected:
     hviews_t  h_views;
     hcviews_t h_cviews;
   };
+
+protected:
 
   ViewsRepo   m_phys_repo;
   ViewsRepo   m_dyn_repo;
@@ -208,6 +205,9 @@ protected:
   void local_remap_bwd_3d (const MT& team) const;
 
 public:
+  struct RemapFwdTag {};
+  struct RemapBwdTag {};
+
   template<typename MT>
   KOKKOS_INLINE_FUNCTION
   void operator()(const RemapFwdTag&, const MT &team) const;

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -157,7 +157,6 @@ protected:
     auto vm = tmp.impl_map();
     vm.m_impl_offset.m_stride = v.impl_map().stride_0() / pack_size;
     return view_Nd<NewValueT,N> (tmp.impl_track(),vm);
-
   }
 
   view_1d<Int> m_layout;
@@ -166,13 +165,20 @@ protected:
   // Only meaningful for 3d fields. Set to -1 for 2d fields, in case wrongfully used
   view_1d<Int> m_num_levels;
 
+  // List of phys/dyn fields that are subfields of other fields.
+  // For each field, we store the last value of subview info, to check if
+  // anything changed (only matters for 'dynamic' subfields).
   // Note: here "dynamic" is in the sense explained in Field::subfield
-  std::vector<int> m_update_subfield_dyn;
-  std::vector<int> m_update_subfield_phys;
+  std::map<int,SubviewInfo> m_subfield_info_dyn;
+  std::map<int,SubviewInfo> m_subfield_info_phys;
 
   void initialize_device_variables();
 
-  void update_subfields_views () const;
+  bool subfields_info_has_changed (const std::map<int,SubviewInfo>& subfield_info,
+                                   const std::vector<field_type>& fields) const;
+  void update_subfields_views (const std::map<int,SubviewInfo>& subfield_info,
+                               const ViewsRepo& repo,
+                               const std::vector<field_type>& fields) const;
 
   // Remap methods
   void do_remap_fwd () const override;

--- a/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -96,15 +96,9 @@ TEST_CASE("remap", "") {
   const int nlc = num_local_cols;
   const auto units = ekat::units::m;  // Placeholder units (we don't care about units here)
 
-  const int np1 = IPDF(0,NTL-1)(engine);
+  const int n0 = IPDF(0,NTL-1)(engine);
 
-  c.create_if_not_there<Homme::TimeLevel>();
-  auto& tl = c.get<Homme::TimeLevel>();
-  tl.np1 = np1;
-  tl.nm1 = (np1+1) % NTL;
-  tl.n0  = (np1+2) % NTL;
-
-  // Note on prefixes: s=scalar, v=vector, ss=scalar state, vs=vector_state, ts=tracer state
+  // Note on prefixes: s=scalar, v=vector, ss=scalar state, vs=vector_state, tr=tracer array
 
   // Create tags and dimensions
   std::vector<FieldTag> s_2d_dyn_tags   = {EL,          GP, GP    };
@@ -210,8 +204,8 @@ TEST_CASE("remap", "") {
   remapper->register_field(v_2d_field_phys, v_2d_field_dyn);
   remapper->register_field(s_3d_field_phys, s_3d_field_dyn);
   remapper->register_field(v_3d_field_phys, v_3d_field_dyn);
-  remapper->register_field(ss_3d_field_phys, ss_3d_field_dyn);
-  remapper->register_field(vs_3d_field_phys, vs_3d_field_dyn);
+  remapper->register_field(ss_3d_field_phys, ss_3d_field_dyn.subfield("cmp",1,n0));
+  remapper->register_field(vs_3d_field_phys, vs_3d_field_dyn.subfield("cmp",1,n0));
   remapper->register_field(tr_3d_field_phys, tr_3d_field_dyn);
   remapper->registration_ends();
 
@@ -450,7 +444,6 @@ TEST_CASE("remap", "") {
 
       {
         // 3d scalar state
-        const int n0 = tl.n0;
         ss_3d_field_phys.sync_to_host();
         ss_3d_field_dyn.sync_to_host();
         auto phys = ss_3d_field_phys.get_view<Homme::Real**,Host>();
@@ -486,7 +479,6 @@ TEST_CASE("remap", "") {
 
       {
         // 3d vector state
-        const int n0 = tl.n0;
         vs_3d_field_phys.sync_to_host();
         vs_3d_field_dyn.sync_to_host();
         auto phys = vs_3d_field_phys.get_view<Homme::Real***,Host>();
@@ -641,13 +633,9 @@ TEST_CASE("combo_remap", "") {
   const int nlc = num_local_cols;
   const auto units = ekat::units::m;  // Placeholder units (we don't care about units here)
 
-  c.create_if_not_there<Homme::TimeLevel>();
-  auto& tl = c.get<Homme::TimeLevel>();
+  const int n0 = IPDF(0,NTL-1)(engine);
 
-  const int np1 = tl.np1 = IPDF(0,NTL-1)(engine);
-  const int n0  = tl.n0  = (np1+2) % NTL;
-
-  // Note on prefixes: s=scalar, v=vector, ss=scalar state, vs=vector_state, ts=tracer state
+  // Note on prefixes: s=scalar, v=vector, ss=scalar state, vs=vector_state, tr=tracer array
 
   // Create tags and dimensions
   std::vector<FieldTag> s_2d_dyn_tags   = {EL,          GP, GP     };
@@ -755,8 +743,8 @@ TEST_CASE("combo_remap", "") {
   remapper->register_field(v_2d_field_phys, v_2d_field_dyn);
   remapper->register_field(s_3d_field_phys, s_3d_field_dyn);
   remapper->register_field(v_3d_field_phys, v_3d_field_dyn);
-  remapper->register_field(ss_3d_field_phys, ss_3d_field_dyn);
-  remapper->register_field(vs_3d_field_phys, vs_3d_field_dyn);
+  remapper->register_field(ss_3d_field_phys, ss_3d_field_dyn.subfield("cmp",1,n0));
+  remapper->register_field(vs_3d_field_phys, vs_3d_field_dyn.subfield("cmp",1,n0));
   remapper->register_field(tr_3d_field_phys, tr_3d_field_dyn);
   remapper->registration_ends();
 

--- a/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -8,6 +8,7 @@
 #include "share/util/scream_setup_random_test.hpp"
 
 #include "mpi/BoundaryExchange.hpp"
+#include "SimulationParams.hpp"
 
 #include "dynamics/homme/homme_dimensions.hpp"
 #include "dynamics/homme/dynamics_driven_grids_manager.hpp"

--- a/components/scream/src/physics/p3/p3_ice_collection_impl.hpp
+++ b/components/scream/src/physics/p3/p3_ice_collection_impl.hpp
@@ -21,9 +21,9 @@ void Functions<S,D>
   constexpr Scalar tmelt  = C::Tmelt;
 
   // set up masks
-  const auto t_is_negative        = temp < tmelt;
-  const auto qi_incld_gt_small = qi_incld > qsmall;
-  const auto qc_incld_gt_small    = qc_incld > qsmall;
+  const auto t_is_negative        = temp <= tmelt;
+  const auto qi_incld_gt_small    = qi_incld >= qsmall;
+  const auto qc_incld_gt_small    = qc_incld >= qsmall;
   const auto both_gt_small        = qi_incld_gt_small && qc_incld_gt_small && context;
   const auto both_gt_small_pos_t  = both_gt_small && !t_is_negative;
 

--- a/components/scream/src/physics/p3/p3_ice_collection_impl.hpp
+++ b/components/scream/src/physics/p3/p3_ice_collection_impl.hpp
@@ -22,24 +22,24 @@ void Functions<S,D>
 
   // set up masks
   const auto t_is_negative        = temp <= tmelt;
-  const auto qi_incld_gt_small    = qi_incld >= qsmall;
-  const auto qc_incld_gt_small    = qc_incld >= qsmall;
-  const auto both_gt_small        = qi_incld_gt_small && qc_incld_gt_small && context;
-  const auto both_gt_small_pos_t  = both_gt_small && !t_is_negative;
+  const auto qi_incld_ge_small    = qi_incld >= qsmall;
+  const auto qc_incld_ge_small    = qc_incld >= qsmall;
+  const auto both_ge_small        = qi_incld_ge_small && qc_incld_ge_small && context;
+  const auto both_ge_small_pos_t  = both_ge_small && !t_is_negative;
 
   constexpr auto eci = C::eci;
   constexpr auto inv_dropmass = C::ONE/C::dropmass;
 
-  qc2qi_collect_tend.set(both_gt_small && t_is_negative,
+  qc2qi_collect_tend.set(both_ge_small && t_is_negative,
             rhofaci*table_val_qc2qi_collect*qc_incld*eci*rho*ni_incld);
-  nc_collect_tend.set(both_gt_small, rhofaci*table_val_qc2qi_collect*nc_incld*eci*rho*ni_incld);
+  nc_collect_tend.set(both_ge_small, rhofaci*table_val_qc2qi_collect*nc_incld*eci*rho*ni_incld);
 
   // for T_atm > 273.15, assume cloud water is collected and shed as rain drops
   // sink for cloud water mass and number, note qcshed is source for rain mass
-  qc2qr_ice_shed_tend.set(both_gt_small_pos_t, rhofaci*table_val_qc2qi_collect*qc_incld*eci*rho*ni_incld);
-  nc_collect_tend.set(both_gt_small_pos_t, rhofaci*table_val_qc2qi_collect*nc_incld*eci*rho*ni_incld);
+  qc2qr_ice_shed_tend.set(both_ge_small_pos_t, rhofaci*table_val_qc2qi_collect*qc_incld*eci*rho*ni_incld);
+  nc_collect_tend.set(both_ge_small_pos_t, rhofaci*table_val_qc2qi_collect*nc_incld*eci*rho*ni_incld);
   // source for rain number, assume 1 mm drops are shed
-  ncshdc.set(both_gt_small_pos_t, qc2qr_ice_shed_tend*inv_dropmass);
+  ncshdc.set(both_ge_small_pos_t, qc2qr_ice_shed_tend*inv_dropmass);
 }
 
 template<typename S, typename D>
@@ -59,17 +59,17 @@ void Functions<S,D>
 
   // Set up masks
   const auto t_is_negative        = temp <= tmelt;
-  const auto qi_incld_ge_small = qi_incld >= qsmall;
+  const auto qi_incld_ge_small    = qi_incld >= qsmall;
   const auto qr_incld_ge_small    = qr_incld >= qsmall;
-  const auto both_gt_small        = qi_incld_ge_small && qr_incld_ge_small && context;
-  const auto both_gt_small_neg_t  = both_gt_small && t_is_negative;
+  const auto both_ge_small        = qi_incld_ge_small && qr_incld_ge_small && context;
+  const auto both_ge_small_neg_t  = both_ge_small && t_is_negative;
 
   constexpr Scalar ten = 10.0;
   constexpr auto eri = C::eri;
 
   // note: table_val_qr2qi_collect and logn0r are already calculated as log_10
-  qr2qi_collect_tend.set(both_gt_small_neg_t, pow(ten, table_val_qr2qi_collect+logn0r)*rho*rhofaci*eri*ni_incld);
-  nr_collect_tend.set(both_gt_small_neg_t, pow(ten, table_val_nr_collect+logn0r)*rho*rhofaci*eri*ni_incld);
+  qr2qi_collect_tend.set(both_ge_small_neg_t, pow(ten, table_val_qr2qi_collect+logn0r)*rho*rhofaci*eri*ni_incld);
+  nr_collect_tend.set(both_ge_small_neg_t, pow(ten, table_val_nr_collect+logn0r)*rho*rhofaci*eri*ni_incld);
 
   // rain number sink due to collection
   // for T_atm > 273.15, assume collected rain number is shed as
@@ -77,7 +77,7 @@ void Functions<S,D>
   // note that melting of ice number is scaled to the loss
   // rate of ice mass due to melting
   // collection of rain above freezing does not impact total rain mass
-  nr_collect_tend.set(both_gt_small && !t_is_negative,
+  nr_collect_tend.set(both_ge_small && !t_is_negative,
             pow(ten, table_val_nr_collect + logn0r)*rho*rhofaci*eri*ni_incld);
   // for now neglect shedding of ice collecting rain above freezing, since snow is
   // not expected to shed in these conditions (though more hevaily rimed ice would be
@@ -99,7 +99,7 @@ void Functions<S,D>
 
   // Set up masks
   const auto qm_incld_positive = qm_incld > zero && context;
-  const auto qi_incld_gt_small = qi_incld > qsmall && context;
+  const auto qi_incld_ge_small = qi_incld >= qsmall && context;
 
   Spack tmp1{0.0};
   Spack Eii_fact{0.0};
@@ -108,11 +108,11 @@ void Functions<S,D>
   Smask tmp1_lt_nine{0};
   Smask tmp1_ge_nine{0};
 
-  if (qi_incld_gt_small.any()) {
+  if (qi_incld_ge_small.any()) {
     // Determine additional collection efficiency factor to be applied to ice-ice collection.
     // The computed values of qicol and nicol are multipiled by Eii_fact to gradually shut off collection
     // if ice is highly rimed.
-    tmp1.set(qi_incld_gt_small && qm_incld_positive,
+    tmp1.set(qi_incld_ge_small && qm_incld_positive,
              qm_incld/qi_incld);   //rime mass fraction
     tmp1_lt_six  = tmp1 < sp(0.6);
     tmp1_ge_six  = tmp1 >= sp(0.6);
@@ -128,7 +128,7 @@ void Functions<S,D>
 
     Eii_fact.set(!qm_incld_positive && context, 1);
 
-    ni_selfcollect_tend.set(qi_incld_gt_small,
+    ni_selfcollect_tend.set(qi_incld_ge_small,
 	      table_val_ni_self_collect*rho*eii*Eii_fact*rhofaci*ni_incld*ni_incld );
   }
 }

--- a/components/scream/src/physics/p3/p3_ice_deposition_sublimation_impl.hpp
+++ b/components/scream/src/physics/p3/p3_ice_deposition_sublimation_impl.hpp
@@ -28,7 +28,7 @@ void Functions<S,D>
   ni_sublim_tend=0;
 
   //CAN'T HAVE DEPOSITION/SUBLIMATION IF NO ICE MASS
-  const auto qi_incld_not_small = qi_incld >= QSMALL && context;
+  const auto qi_incld_not_small = qi_incld > QSMALL && context;
 
   if (qi_incld_not_small.any()) {
   

--- a/components/scream/src/physics/p3/p3_ice_sed_impl.hpp
+++ b/components/scream/src/physics/p3/p3_ice_sed_impl.hpp
@@ -240,27 +240,27 @@ void Functions<S,D>
     const auto range_pack    = ekat::range<IntSmallPack>(pk*Spack::n);
     const auto range_mask    = range_pack >= kmin_scalar && range_pack <= kmax_scalar;
     const auto t_lt_homogf   = T_atm(pk) < T_homogfrz;
-    const auto qc_gt_small   = range_mask && t_lt_homogf && qc(pk) > qsmall;
-    const auto qr_gt_small   = range_mask && t_lt_homogf && qr(pk) > qsmall;
+    const auto qc_ge_small   = range_mask && t_lt_homogf && qc(pk) >= qsmall;
+    const auto qr_ge_small   = range_mask && t_lt_homogf && qr(pk) >= qsmall;
 
     Spack Qc_nuc(qc(pk)), Qr_nuc(qr(pk)), Nc_nuc(max(nc(pk), nsmall)), Nr_nuc(max(nr(pk), nsmall));
 
-    qm(pk).set(qc_gt_small, qm(pk) + Qc_nuc);
-    qi(pk).set(qc_gt_small, qi(pk) + Qc_nuc);
-    bm(pk).set(qc_gt_small, bm(pk) + Qc_nuc*inv_rho_rimeMax);
-    ni(pk).set(qc_gt_small, ni(pk) + Nc_nuc);
-    th_atm(pk).set   (qc_gt_small, th_atm(pk) + inv_exner(pk)*Qc_nuc*latent_heat_fusion(pk)*inv_cp);
+    qm(pk).set(qc_ge_small, qm(pk) + Qc_nuc);
+    qi(pk).set(qc_ge_small, qi(pk) + Qc_nuc);
+    bm(pk).set(qc_ge_small, bm(pk) + Qc_nuc*inv_rho_rimeMax);
+    ni(pk).set(qc_ge_small, ni(pk) + Nc_nuc);
+    th_atm(pk).set   (qc_ge_small, th_atm(pk) + inv_exner(pk)*Qc_nuc*latent_heat_fusion(pk)*inv_cp);
 
-    qm(pk).set(qr_gt_small, qm(pk) + Qr_nuc);
-    qi(pk).set(qr_gt_small, qi(pk) + Qr_nuc);
-    bm(pk).set(qr_gt_small, bm(pk) + Qr_nuc*inv_rho_rimeMax);
-    ni(pk).set(qr_gt_small, ni(pk) + Nr_nuc);
-    th_atm(pk).set   (qr_gt_small, th_atm(pk) + inv_exner(pk)*Qr_nuc*latent_heat_fusion(pk)*inv_cp);
+    qm(pk).set(qr_ge_small, qm(pk) + Qr_nuc);
+    qi(pk).set(qr_ge_small, qi(pk) + Qr_nuc);
+    bm(pk).set(qr_ge_small, bm(pk) + Qr_nuc*inv_rho_rimeMax);
+    ni(pk).set(qr_ge_small, ni(pk) + Nr_nuc);
+    th_atm(pk).set   (qr_ge_small, th_atm(pk) + inv_exner(pk)*Qr_nuc*latent_heat_fusion(pk)*inv_cp);
 
-    qc(pk).set(qc_gt_small, 0);
-    nc(pk).set(qc_gt_small, 0);
-    qr(pk).set(qr_gt_small, 0);
-    nr(pk).set(qr_gt_small, 0);
+    qc(pk).set(qc_ge_small, 0);
+    nc(pk).set(qc_ge_small, 0);
+    qr(pk).set(qr_ge_small, 0);
+    nr(pk).set(qr_ge_small, 0);
   });
 }
 

--- a/components/scream/src/physics/p3/p3_prevent_liq_supersaturation_impl.hpp
+++ b/components/scream/src/physics/p3/p3_prevent_liq_supersaturation_impl.hpp
@@ -27,7 +27,7 @@ void Functions<S,D>::prevent_liq_supersaturation(const Spack& pres, const Spack&
   Spack qv_sinks, qv_sources, qv_endstep, T_endstep, A, frac;
 
   qv_sources.set(context, qi2qv_sublim_tend + qr2qv_evap_tend);
-  const auto has_sources = (qv_sources>qsmall && context); //if nothing to rescale, no point in calculations.
+  const auto has_sources = (qv_sources>=qsmall && context); //if nothing to rescale, no point in calculations.
 
   if (not has_sources.any()) {
     return;

--- a/components/scream/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
@@ -338,10 +338,10 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit {
     auto engine = setup_random_test();
 
     UpdatePrognosticsImplicitData f90_data[] = {
-      UpdatePrognosticsImplicitData(10, 71, 72, 19, 5),
-      UpdatePrognosticsImplicitData(10, 12, 13, 7, 2.5),
-      UpdatePrognosticsImplicitData(7, 16, 17, 2, 1),
-      UpdatePrognosticsImplicitData(2, 7, 8, 1, 1)
+      UpdatePrognosticsImplicitData(10, 71, 72, 19, .5),
+      UpdatePrognosticsImplicitData(10, 12, 13, 7, .25),
+      UpdatePrognosticsImplicitData(7, 16, 17, 2, .1),
+      UpdatePrognosticsImplicitData(2, 7, 8, 1, .1)
     };
 
     // Generate random input data

--- a/components/scream/src/share/field/field.cpp
+++ b/components/scream/src/share/field/field.cpp
@@ -116,7 +116,9 @@ get_component (const int i, const bool dynamic) {
   EKAT_REQUIRE_MSG (i>=0 && i<layout.dim(idim),
       "Error! Component index out of bounds [0," + std::to_string(layout.dim(idim)) + ").\n");
 
-  return subfield (this->name()+"_"+std::to_string(i),idim,i,dynamic);
+  // Add _$idim to the field name, to avoid issues if the subfield is stored
+  // in some structure that requires unique names (e.g., a remapper)
+  return subfield (fname + "_" + std::to_string(i),idim,i,dynamic);
 }
 
 bool Field::equivalent(const Field& rhs) const

--- a/components/scream/src/share/field/field_utils_impl.hpp
+++ b/components/scream/src/share/field/field_utils_impl.hpp
@@ -3,6 +3,8 @@
 
 #include "share/field/field.hpp"
 
+#include "ekat/mpi/ekat_comm.hpp"
+
 #include <limits>
 #include <type_traits>
 
@@ -222,7 +224,7 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
     case 1:
       {
         auto v = f.template get_view<ST*,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
+        for (int i=0; i<fl.dim(0); ++i) {
           y = std::pow(v(i),2) - c;
           temp = norm + y;
           c = (temp - norm) - y;
@@ -233,8 +235,8 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
     case 2:
       {
         auto v = f.template get_view<ST**,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
             y = std::pow(v(i,j),2) - c;
             temp = norm + y;
             c = (temp - norm) - y;
@@ -245,9 +247,9 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
     case 3:
       {
         auto v = f.template get_view<ST***,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
               y = std::pow(v(i,j,k),2) - c;
               temp = norm + y;
               c = (temp - norm) - y;
@@ -258,10 +260,10 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
     case 4:
       {
         auto v = f.template get_view<ST****,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
                 y = std::pow(v(i,j,k,l),2) - c;
                 temp = norm + y;
                 c = (temp - norm) - y;
@@ -272,11 +274,11 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
     case 5:
       {
         auto v = f.template get_view<ST*****,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
-                for (int m=0; m<v.extent_int(4); ++m) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
+                for (int m=0; m<fl.dim(4); ++m) {
                   y = std::pow(v(i,j,k,l,m),2) - c;
                   temp = norm + y;
                   c = (temp - norm) - y;
@@ -287,12 +289,12 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
     case 6:
       {
         auto v = f.template get_view<ST******,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
-                for (int m=0; m<v.extent_int(4); ++m) {
-                  for (int n=0; n<v.extent_int(5); ++n) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
+                for (int m=0; m<fl.dim(4); ++m) {
+                  for (int n=0; n<fl.dim(5); ++n) {
                     y = std::pow(v(i,j,k,l,m,n),2) - c;
                     temp = norm + y;
                     c = (temp - norm) - y;
@@ -329,7 +331,7 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
     case 1:
       {
         auto v = f.template get_view<ST*,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
+        for (int i=0; i<fl.dim(0); ++i) {
           y = v(i) - c;
           temp = sum + y;
           c = (temp - sum) - y;
@@ -340,8 +342,8 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
     case 2:
       {
         auto v = f.template get_view<ST**,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
             y = v(i,j) - c;
             temp = sum + y;
             c = (temp - sum) - y;
@@ -352,9 +354,9 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
     case 3:
       {
         auto v = f.template get_view<ST***,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
               y = v(i,j,k) - c;
               temp = sum + y;
               c = (temp - sum) - y;
@@ -365,10 +367,10 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
     case 4:
       {
         auto v = f.template get_view<ST****,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
                 y = v(i,j,k,l) - c;
                 temp = sum + y;
                 c = (temp - sum) - y;
@@ -379,11 +381,11 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
     case 5:
       {
         auto v = f.template get_view<ST*****,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
-                for (int m=0; m<v.extent_int(4); ++m) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
+                for (int m=0; m<fl.dim(4); ++m) {
                   y = v(i,j,k,l,m) - c;
                   temp = sum + y;
                   c = (temp - sum) - y;
@@ -394,12 +396,12 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
     case 6:
       {
         auto v = f.template get_view<ST******,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
-                for (int m=0; m<v.extent_int(4); ++m) {
-                  for (int n=0; n<v.extent_int(5); ++n) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
+                for (int m=0; m<fl.dim(4); ++m) {
+                  for (int n=0; n<fl.dim(5); ++n) {
                     y = v(i,j,k,l,m,n) - c;
                     temp = sum + y;
                     c = (temp - sum) - y;
@@ -433,7 +435,7 @@ ST field_max(const Field& f, const ekat::Comm* comm)
     case 1:
       {
         auto v = f.template get_view<ST*,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
+        for (int i=0; i<fl.dim(0); ++i) {
           max = std::max(max,v(i));
         }
       }
@@ -441,8 +443,8 @@ ST field_max(const Field& f, const ekat::Comm* comm)
     case 2:
       {
         auto v = f.template get_view<ST**,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
             max = std::max(max,v(i,j));
         }}
       }
@@ -450,9 +452,9 @@ ST field_max(const Field& f, const ekat::Comm* comm)
     case 3:
       {
         auto v = f.template get_view<ST***,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
               max = std::max(max,v(i,j,k));
         }}}
       }
@@ -460,10 +462,10 @@ ST field_max(const Field& f, const ekat::Comm* comm)
     case 4:
       {
         auto v = f.template get_view<ST****,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
                 max = std::max(max,v(i,j,k,l));
         }}}}
       }
@@ -471,11 +473,11 @@ ST field_max(const Field& f, const ekat::Comm* comm)
     case 5:
       {
         auto v = f.template get_view<ST*****,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
-                for (int m=0; m<v.extent_int(4); ++m) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
+                for (int m=0; m<fl.dim(4); ++m) {
                   max = std::max(max,v(i,j,k,l,m));
         }}}}}
       }
@@ -483,12 +485,12 @@ ST field_max(const Field& f, const ekat::Comm* comm)
     case 6:
       {
         auto v = f.template get_view<ST******,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
-                for (int m=0; m<v.extent_int(4); ++m) {
-                  for (int n=0; n<v.extent_int(5); ++n) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
+                for (int m=0; m<fl.dim(4); ++m) {
+                  for (int n=0; n<fl.dim(5); ++n) {
                     max = std::max(max,v(i,j,k,l,m,n));
         }}}}}}
       }
@@ -519,7 +521,7 @@ ST field_min(const Field& f, const ekat::Comm* comm)
     case 1:
       {
         auto v = f.template get_view<ST*,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
+        for (int i=0; i<fl.dim(0); ++i) {
           min = std::min(min,v(i));
         }
       }
@@ -527,8 +529,8 @@ ST field_min(const Field& f, const ekat::Comm* comm)
     case 2:
       {
         auto v = f.template get_view<ST**,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
             min = std::min(min,v(i,j));
         }}
       }
@@ -536,9 +538,9 @@ ST field_min(const Field& f, const ekat::Comm* comm)
     case 3:
       {
         auto v = f.template get_view<ST***,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
               min = std::min(min,v(i,j,k));
         }}}
       }
@@ -546,10 +548,10 @@ ST field_min(const Field& f, const ekat::Comm* comm)
     case 4:
       {
         auto v = f.template get_view<ST****,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
                 min = std::min(min,v(i,j,k,l));
         }}}}
       }
@@ -557,11 +559,11 @@ ST field_min(const Field& f, const ekat::Comm* comm)
     case 5:
       {
         auto v = f.template get_view<ST*****,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
-                for (int m=0; m<v.extent_int(4); ++m) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
+                for (int m=0; m<fl.dim(4); ++m) {
                   min = std::min(min,v(i,j,k,l,m));
         }}}}}
       }
@@ -569,12 +571,12 @@ ST field_min(const Field& f, const ekat::Comm* comm)
     case 6:
       {
         auto v = f.template get_view<ST******,Host>();
-        for (int i=0; i<v.extent_int(0); ++i) {
-          for (int j=0; j<v.extent_int(1); ++j) {
-            for (int k=0; k<v.extent_int(2); ++k) {
-              for (int l=0; l<v.extent_int(3); ++l) {
-                for (int m=0; m<v.extent_int(4); ++m) {
-                  for (int n=0; n<v.extent_int(5); ++n) {
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
+                for (int m=0; m<fl.dim(4); ++m) {
+                  for (int n=0; n<fl.dim(5); ++n) {
                     min = std::min(min,v(i,j,k,l,m,n));
         }}}}}}
       }


### PR DESCRIPTION
This PR upgrades the PD remapper to handle subfields just like any other field. In doing so, it simplifies a bit the implementation (e.g., no switches based on whether a dyn field is a state; or just one BoundaryExchange object needed). Also, it removes the need of having `Homme::TimeLevel` already set up. This might be important to be able to use the PD remapper during initialization _before_ `HommeDynamics::initialize` is called (which is where homme initialization was completed).

For instance, I think we can now use a PD remapper while loading IC fields. I also would like to use a PD remapper inside another branch, where I'm changing the handling of topography (phis), from a field-manager-managed variable, to a field stored inside the grid.