### PR TITLE
SCREAM: fix jenkins test script

### DIFF
--- a/components/scream/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/scream/scripts/jenkins/jenkins_common_impl.sh
@@ -153,10 +153,10 @@ if [ $skip_testing -eq 0 ]; then
           echo "SCREAM v1 tests were skipped, since the Github label 'AT: Skip v1 Testing' was found.\n"
       fi
     fi
+  fi
 
-    if [[ $fails > 0 ]]; then
-        exit 1
-    fi
+  if [[ $fails > 0 ]]; then
+      exit 1
   fi
 
 else


### PR DESCRIPTION
The case fails>0 caused an overall fail only on mappy, due to a misplaced if statement.