### PR TITLE
Fixes the sc_ut test which was failing on GPU's

### DIFF
--- a/components/scream/src/control/tests/sc_tests.cpp
+++ b/components/scream/src/control/tests/sc_tests.cpp
@@ -519,6 +519,8 @@ TEST_CASE ("recreate_mct_coupling")
     // Copy precip_liq/ice_surf to the copy we need for comparison
     Kokkos::deep_copy(precip_liq_surf_copy_d,precip_liq_surf_d);
     Kokkos::deep_copy(precip_ice_surf_copy_d,precip_ice_surf_d);
+    precip_liq_surf_copy_f.sync_to_host();
+    precip_ice_surf_copy_f.sync_to_host();
     // TODO: These deep copies won't be needed when the AD handles resetting precip
     ekat::genRandArray(sfc_flux_lw_dn_d,engine,pdf);
     ekat::genRandArray(sfc_flux_dir_nir_d,engine,pdf);


### PR DESCRIPTION
This commit adds a sync to host for the precipitation field copies
that are used in the sc_ut tests.  Without the sync to host this test
was failing on GPU.  Note that the failures are from changes made previously
in how precipitation is being handled in EAMxx.