### PR TITLE
Remove redundant hyam and hybm variables from SPA interface.

### DIFF
--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -52,8 +52,6 @@ void SPA::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   // Set of fields used strictly as input
   constexpr int ps = Pack::n;
   add_field<Required>("p_mid"      , scalar3d_layout_mid, Pa,     grid_name, ps);
-  add_field<Required>("hyam"       , scalar1d_layout_mid, nondim, grid_name, ps); // TODO: These fields should  be loaded from file and not registered with the field manager.
-  add_field<Required>("hybm"       , scalar1d_layout_mid, nondim, grid_name, ps); // TODO: These fields should  be loaded from file and not registered with the field manager.
 
   // Set of fields used strictly as output
   add_field<Computed>("nccn",   scalar3d_layout_mid,    1/kg,   grid_name,ps);
@@ -187,13 +185,6 @@ void SPA::initialize_impl (const RunType /* run_type */)
   SPATimeState.inited = false;
   SPATimeState.current_month = ts.get_month();
   SPAFunc::update_spa_timestate(m_spa_data_file,m_nswbands,m_nlwbands,ts,SPAHorizInterp,SPATimeState,SPAData_start,SPAData_end);
-
-  // NOTE: we *assume* hybrid v coordinates don't change with time.
-  //       IF this ever ceases to be the case, you need to remove these
-  //       lines, and have spa_main interpolate those during the call
-  //       to performe_time_interpolation.
-  m_buffer.spa_temp.hyam = SPAData_start.hyam;
-  m_buffer.spa_temp.hybm = SPAData_start.hybm;
 
   // Set property checks for fields in this process
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nccn"),m_grid,0.0,1.0e11,false);


### PR DESCRIPTION
There was left over code from an earlier version of SPA which read
the hybrid pressure coordinates from the input file by setting them
as "required" variables.  This was replaced by gathering this data
directly from the SPA data file, but the call to the field manager
was never removed.

This commit fixes this by removing the code.