### PR TITLE
Make the handling of the diagnostic timestamp more robust.

### DIFF
--- a/components/scream/src/diagnostics/atm_density.cpp
+++ b/components/scream/src/diagnostics/atm_density.cpp
@@ -49,7 +49,7 @@ void AtmDensityDiagnostic::initialize_impl(const RunType /* run_type */)
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void AtmDensityDiagnostic::run_impl(const int /* dt */)
+void AtmDensityDiagnostic::compute_diagnostic_impl()
 {
 
   const auto npacks  = ekat::npack<Pack>(m_num_levs);

--- a/components/scream/src/diagnostics/atm_density.hpp
+++ b/components/scream/src/diagnostics/atm_density.hpp
@@ -37,14 +37,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/dry_static_energy.cpp
+++ b/components/scream/src/diagnostics/dry_static_energy.cpp
@@ -53,7 +53,7 @@ void DryStaticEnergyDiagnostic::initialize_impl(const RunType /* run_type */)
 
 }
 // =========================================================================================
-void DryStaticEnergyDiagnostic::run_impl(const int /* dt */)
+void DryStaticEnergyDiagnostic::compute_diagnostic_impl()
 {
 
   const auto npacks     = ekat::npack<Pack>(m_num_levs);

--- a/components/scream/src/diagnostics/dry_static_energy.hpp
+++ b/components/scream/src/diagnostics/dry_static_energy.hpp
@@ -42,14 +42,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/exner.cpp
+++ b/components/scream/src/diagnostics/exner.cpp
@@ -43,7 +43,7 @@ void ExnerDiagnostic::initialize_impl(const RunType /* run_type */)
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void ExnerDiagnostic::run_impl(const int /* dt */)
+void ExnerDiagnostic::compute_diagnostic_impl()
 {
 
   const auto npacks  = ekat::npack<Pack>(m_num_levs);

--- a/components/scream/src/diagnostics/exner.hpp
+++ b/components/scream/src/diagnostics/exner.hpp
@@ -37,14 +37,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/ice_water_path.cpp
+++ b/components/scream/src/diagnostics/ice_water_path.cpp
@@ -46,7 +46,7 @@ void IceWaterPathDiagnostic::initialize_impl(const RunType /* run_type */)
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void IceWaterPathDiagnostic::run_impl(const int /* dt */)
+void IceWaterPathDiagnostic::compute_diagnostic_impl()
 {
 
   using PC         = scream::physics::Constants<Real>;

--- a/components/scream/src/diagnostics/ice_water_path.hpp
+++ b/components/scream/src/diagnostics/ice_water_path.hpp
@@ -41,14 +41,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/liquid_water_path.cpp
+++ b/components/scream/src/diagnostics/liquid_water_path.cpp
@@ -46,7 +46,7 @@ void LiqWaterPathDiagnostic::initialize_impl(const RunType /* run_type */)
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void LiqWaterPathDiagnostic::run_impl(const int /* dt */)
+void LiqWaterPathDiagnostic::compute_diagnostic_impl()
 {
 
   using PC         = scream::physics::Constants<Real>;

--- a/components/scream/src/diagnostics/liquid_water_path.hpp
+++ b/components/scream/src/diagnostics/liquid_water_path.hpp
@@ -41,14 +41,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/potential_temperature.cpp
+++ b/components/scream/src/diagnostics/potential_temperature.cpp
@@ -45,7 +45,7 @@ void PotentialTemperatureDiagnostic::initialize_impl(const RunType /* run_type *
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void PotentialTemperatureDiagnostic::run_impl(const int /* dt */)
+void PotentialTemperatureDiagnostic::compute_diagnostic_impl()
 {
 
   const auto npacks  = ekat::npack<Pack>(m_num_levs);

--- a/components/scream/src/diagnostics/potential_temperature.hpp
+++ b/components/scream/src/diagnostics/potential_temperature.hpp
@@ -37,14 +37,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/rain_water_path.cpp
+++ b/components/scream/src/diagnostics/rain_water_path.cpp
@@ -46,7 +46,7 @@ void RainWaterPathDiagnostic::initialize_impl(const RunType /* run_type */)
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void RainWaterPathDiagnostic::run_impl(const int /* dt */)
+void RainWaterPathDiagnostic::compute_diagnostic_impl()
 {
 
   using PC         = scream::physics::Constants<Real>;

--- a/components/scream/src/diagnostics/rain_water_path.hpp
+++ b/components/scream/src/diagnostics/rain_water_path.hpp
@@ -41,14 +41,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/sea_level_pressure.cpp
+++ b/components/scream/src/diagnostics/sea_level_pressure.cpp
@@ -51,7 +51,7 @@ void SeaLevelPressureDiagnostic::initialize_impl(const RunType /* run_type */)
 
 }
 // =========================================================================================
-void SeaLevelPressureDiagnostic::run_impl(const int /* dt */)
+void SeaLevelPressureDiagnostic::compute_diagnostic_impl()
 {
 
   const auto npacks     = ekat::npack<Pack>(m_num_levs);

--- a/components/scream/src/diagnostics/sea_level_pressure.hpp
+++ b/components/scream/src/diagnostics/sea_level_pressure.hpp
@@ -42,14 +42,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/tests/atm_density_test.cpp
+++ b/components/scream/src/diagnostics/tests/atm_density_test.cpp
@@ -140,7 +140,7 @@ void run(std::mt19937_64& engine)
     } 
 
     // Run diagnostic and compare with manual calculation
-    diag->run();
+    diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field atm_density_f = diag_out.clone();
     atm_density_f.deep_copy<double,Host>(0.0);

--- a/components/scream/src/diagnostics/tests/dry_static_energy_test.cpp
+++ b/components/scream/src/diagnostics/tests/dry_static_energy_test.cpp
@@ -145,7 +145,7 @@ void run(std::mt19937_64& engine)
     ekat::genRandArray(phis_v, engine, pdf_surface);
 
     // Run diagnostic and compare with manual calculation
-    diag->run();
+    diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field dse_f = diag_out.clone();
     dse_f.deep_copy<double,Host>(0.0);

--- a/components/scream/src/diagnostics/tests/exner_test.cpp
+++ b/components/scream/src/diagnostics/tests/exner_test.cpp
@@ -120,7 +120,7 @@ void run(std::mt19937_64& engine)
     }
 
     // Run diagnostic and compare with manual calculation
-    diag->run();
+    diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field exner_f = diag_out.clone();
     exner_f.deep_copy<double,Host>(0.0);

--- a/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
@@ -126,7 +126,7 @@ void run(std::mt19937_64& engine)
     }
 
     // Run diagnostic and compare with manual calculation
-    diag->run();
+    diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field theta_f = diag_out.clone();
     theta_f.deep_copy<double,Host>(0.0);

--- a/components/scream/src/diagnostics/tests/sea_level_pressure_test.cpp
+++ b/components/scream/src/diagnostics/tests/sea_level_pressure_test.cpp
@@ -130,7 +130,7 @@ void run(std::mt19937_64& engine)
     ekat::genRandArray(phis_v, engine, pdf_surface);
 
     // Run diagnostic and compare with manual calculation
-    diag->run();
+    diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field p_sealevel_f = diag_out.clone();
     p_sealevel_f.deep_copy<double,Host>(0.0);

--- a/components/scream/src/diagnostics/tests/vertical_layer_interface_test.cpp
+++ b/components/scream/src/diagnostics/tests/vertical_layer_interface_test.cpp
@@ -140,7 +140,7 @@ void run(std::mt19937_64& engine)
     }
 
     // Run diagnostic and compare with manual calculation
-    diag->run();
+    diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field zint_f = diag_out.clone();
     zint_f.deep_copy<double,Host>(0.0);

--- a/components/scream/src/diagnostics/tests/vertical_layer_midpoint_test.cpp
+++ b/components/scream/src/diagnostics/tests/vertical_layer_midpoint_test.cpp
@@ -141,7 +141,7 @@ void run(std::mt19937_64& engine)
     }
 
     // Run diagnostic and compare with manual calculation
-    diag->run();
+    diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field zmid_f = diag_out.clone();
     zmid_f.deep_copy<double,Host>(0.0);

--- a/components/scream/src/diagnostics/tests/vertical_layer_thickness_test.cpp
+++ b/components/scream/src/diagnostics/tests/vertical_layer_thickness_test.cpp
@@ -140,7 +140,7 @@ void run(std::mt19937_64& engine)
     }
 
     // Run diagnostic and compare with manual calculation
-    diag->run();
+    diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field dz_f = diag_out.clone();
     dz_f.deep_copy<double,Host>(0.0);

--- a/components/scream/src/diagnostics/tests/virtual_temperature_test.cpp
+++ b/components/scream/src/diagnostics/tests/virtual_temperature_test.cpp
@@ -126,7 +126,7 @@ void run(std::mt19937_64& engine)
     }
 
     // Run diagnostic and compare with manual calculation
-    diag->run();
+    diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field virtualT_f = diag_out.clone();
     virtualT_f.deep_copy<double,Host>(0.0);

--- a/components/scream/src/diagnostics/tests/virtual_temperature_test.cpp
+++ b/components/scream/src/diagnostics/tests/virtual_temperature_test.cpp
@@ -43,7 +43,6 @@ template<typename DeviceT>
 void run(std::mt19937_64& engine)
 {
   using PF         = scream::PhysicsFunctions<DeviceT>;
-  using PC         = scream::physics::Constants<Real>;
   using Pack       = ekat::Pack<Real,SCREAM_PACK_SIZE>;
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;

--- a/components/scream/src/diagnostics/tests/water_path_tests.cpp
+++ b/components/scream/src/diagnostics/tests/water_path_tests.cpp
@@ -50,7 +50,6 @@ cmvdc (const VT& v) {
 template<typename DeviceT>
 void run(std::mt19937_64& engine)
 {
-  using PF         = scream::PhysicsFunctions<DeviceT>;
   using PC         = scream::physics::Constants<Real>;
   using Pack       = ekat::Pack<Real,SCREAM_PACK_SIZE>;
   using KT         = ekat::KokkosTypes<DeviceT>;

--- a/components/scream/src/diagnostics/tests/water_path_tests.cpp
+++ b/components/scream/src/diagnostics/tests/water_path_tests.cpp
@@ -202,7 +202,7 @@ void run(std::mt19937_64& engine)
     const auto& rwp_h = rwp.get_view<const Real*,Host>();
 
     for (const auto& dd : diags) {
-      dd.second->run();
+      dd.second->compute_diagnostic();
     }
     // Test 1: The water path should be >= the maximum cell level mass per column
     {
@@ -289,7 +289,7 @@ void run(std::mt19937_64& engine)
       });
       Kokkos::fence();
       for (const auto& dd : diags) {
-        dd.second->run();
+        dd.second->compute_diagnostic();
       }
       vwp_copy_f.sync_to_host();
       lwp_copy_f.sync_to_host();
@@ -341,7 +341,7 @@ void run(std::mt19937_64& engine)
       });
       Kokkos::fence();
       for (const auto& dd : diags) {
-        dd.second->run();
+        dd.second->compute_diagnostic();
       }
       auto total_mass_h = cmvdc(total_mass);
       vwp.sync_to_host();
@@ -386,7 +386,7 @@ void run(std::mt19937_64& engine)
       });
       Kokkos::fence();
       for (const auto& dd : diags) {
-        dd.second->run();
+        dd.second->compute_diagnostic();
       }
       auto total_mass_h = cmvdc(total_mass);
       auto delta_mass_h = cmvdc(delta_mass);
@@ -417,7 +417,7 @@ void run(std::mt19937_64& engine)
       });
       Kokkos::fence();
       for (const auto& dd : diags) {
-        dd.second->run();
+        dd.second->compute_diagnostic();
       }
       vwp.sync_to_host();
       lwp.sync_to_host();

--- a/components/scream/src/diagnostics/vapor_water_path.cpp
+++ b/components/scream/src/diagnostics/vapor_water_path.cpp
@@ -46,7 +46,7 @@ void VapWaterPathDiagnostic::initialize_impl(const RunType /* run_type */)
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void VapWaterPathDiagnostic::run_impl(const int /* dt */)
+void VapWaterPathDiagnostic::compute_diagnostic_impl()
 {
 
   using PC         = scream::physics::Constants<Real>;

--- a/components/scream/src/diagnostics/vapor_water_path.hpp
+++ b/components/scream/src/diagnostics/vapor_water_path.hpp
@@ -41,14 +41,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/vertical_layer_interface.cpp
+++ b/components/scream/src/diagnostics/vertical_layer_interface.cpp
@@ -48,7 +48,7 @@ void VerticalLayerInterfaceDiagnostic::initialize_impl(const RunType /* run_type
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void VerticalLayerInterfaceDiagnostic::run_impl(const int /* dt */)
+void VerticalLayerInterfaceDiagnostic::compute_diagnostic_impl()
 {
   const auto npacks     = ekat::npack<Pack>(m_num_levs);
   const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, npacks);

--- a/components/scream/src/diagnostics/vertical_layer_interface.hpp
+++ b/components/scream/src/diagnostics/vertical_layer_interface.hpp
@@ -42,14 +42,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/vertical_layer_midpoint.cpp
+++ b/components/scream/src/diagnostics/vertical_layer_midpoint.cpp
@@ -47,7 +47,7 @@ void VerticalLayerMidpointDiagnostic::initialize_impl(const RunType /* run_type 
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void VerticalLayerMidpointDiagnostic::run_impl(const int /* dt */)
+void VerticalLayerMidpointDiagnostic::compute_diagnostic_impl()
 {
 
   const auto npacks     = ekat::npack<Pack>(m_num_levs);

--- a/components/scream/src/diagnostics/vertical_layer_midpoint.hpp
+++ b/components/scream/src/diagnostics/vertical_layer_midpoint.hpp
@@ -41,14 +41,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/vertical_layer_thickness.cpp
+++ b/components/scream/src/diagnostics/vertical_layer_thickness.cpp
@@ -47,7 +47,7 @@ void VerticalLayerThicknessDiagnostic::initialize_impl(const RunType /* run_type
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void VerticalLayerThicknessDiagnostic::run_impl(const int /* dt */)
+void VerticalLayerThicknessDiagnostic::compute_diagnostic_impl()
 {
 
   const auto npacks  = ekat::npack<Pack>(m_num_levs);

--- a/components/scream/src/diagnostics/vertical_layer_thickness.hpp
+++ b/components/scream/src/diagnostics/vertical_layer_thickness.hpp
@@ -38,14 +38,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/diagnostics/virtual_temperature.cpp
+++ b/components/scream/src/diagnostics/virtual_temperature.cpp
@@ -45,7 +45,7 @@ void VirtualTemperatureDiagnostic::initialize_impl(const RunType /* run_type */)
   m_diagnostic_output.get_header().get_tracking().update_time_stamp(ts);
 }
 // =========================================================================================
-void VirtualTemperatureDiagnostic::run_impl(const int /* dt */)
+void VirtualTemperatureDiagnostic::compute_diagnostic_impl()
 {
 
   const auto npacks  = ekat::npack<Pack>(m_num_levs);

--- a/components/scream/src/diagnostics/virtual_temperature.hpp
+++ b/components/scream/src/diagnostics/virtual_temperature.hpp
@@ -37,14 +37,14 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
 protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl        (const int dt);
+  void compute_diagnostic_impl ();
 protected:
+
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions

--- a/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -43,13 +43,15 @@ public:
   // Getting the diagnostic output
   Field get_diagnostic () const;
 
-  // Avoid shadowing the base class method, but allow calling without passing a dummy dt
-  using AtmosphereProcess::run;
-  void run () { this->run_impl(0); } // Pass null dt, but should not be used anyways.
-
   void set_computed_field (const Field& f) final;
   void set_computed_group (const FieldGroup& group) final;
+
+  void compute_diagnostic ();
 protected:
+
+  virtual void compute_diagnostic_impl () = 0;
+
+  void run_impl (const int /* dt */);
 
   // Diagnostics are meant to return a field
   Field m_diagnostic_output;

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -97,11 +97,7 @@ public:
 
 protected:
 
-  void initialize_impl (const RunType /* run_type */ ) {
-    m_diagnostic_output.get_header().get_tracking().update_time_stamp(timestamp());
-  }
-
-  void run_impl (const int /* dt */) {
+  void compute_diagnostic_impl () {
     const auto& v_A  = get_field_in("field_packed").get_view<const Real**,Host>();
     auto v_me = m_diagnostic_output.get_view<Real**,Host>();
     // Have the dummy diagnostic just manipulate the field_packed data arithmetically.  In this case (x*3 + 2)
@@ -111,6 +107,10 @@ protected:
       }
     }
     m_diagnostic_output.sync_to_dev();
+  }
+
+  void initialize_impl (const RunType /* run_type */ ) {
+    m_diagnostic_output.get_header().get_tracking().update_time_stamp(timestamp());
   }
 
   // Clean up
@@ -154,6 +154,7 @@ TEST_CASE("input_output_basic","io")
 
     // Re-create the fm anew, so the fields are re-inited for each output type
     auto field_manager = get_test_fm(grid);
+    field_manager->init_fields_time_stamp(t0);
     ekat::ParameterList params;
     ekat::parse_yaml_file("io_test_" + type + ".yaml",params);
     OutputManager om;

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -93,13 +93,11 @@ public:
 
 protected:
 
+  void compute_diagnostic_impl () {}
+
   // The initialization method should prepare all stuff needed to import/export from/to
   // f90 structures.
   void initialize_impl (const RunType /* run_type */ ) {}
-
-  // The run method is responsible for exporting atm states to the e3sm coupler, and
-  // import surface states from the e3sm coupler.
-  void run_impl (const int /* dt */) {}
 
   // Clean up
   void finalize_impl ( /* inputs */ ) {}
@@ -135,9 +133,9 @@ public:
     m_diagnostic_output.allocate_view();
   }
 protected:
-    void run_impl (const int /* dt */) {
-      // Do nothing, this diagnostic should fail.
-    }
+  void compute_diagnostic_impl () {
+    // Do nothing, this diagnostic should fail.
+  }
 };
 
 class DiagIdentity : public DummyDiag
@@ -165,14 +163,14 @@ public:
     m_diagnostic_output.allocate_view();
   }
 protected:
-    void run_impl (const int /* dt */) {
-      auto f = get_field_in("Field A", m_grid_name);
-      auto v_A = f.get_view<const Real*,Host>();
-      auto v_me = m_diagnostic_output.get_view<Real*,Host>();
-      for (size_t i=0; i<v_me.size(); ++i) {
-        v_me[i] = v_A[i];
-      }
+  void compute_diagnostic_impl () {
+    auto f = get_field_in("Field A", m_grid_name);
+    auto v_A = f.get_view<const Real*,Host>();
+    auto v_me = m_diagnostic_output.get_view<Real*,Host>();
+    for (size_t i=0; i<v_me.size(); ++i) {
+      v_me[i] = v_A[i];
     }
+  }
 };
 
 class DiagSum : public DummyDiag
@@ -202,16 +200,16 @@ public:
   }
 
 protected:
-    void run_impl (const int /* dt */) {
-      auto f_A = get_field_in("Field A", m_grid_name);
-      auto f_B = get_field_in("Field B", m_grid_name);
-      auto v_A = f_A.get_view<const Real*,Host>();
-      auto v_B = f_B.get_view<const Real*,Host>();
-      auto v_me = m_diagnostic_output.get_view<Real*,Host>();
-      for (size_t i=0; i<v_me.size(); ++i) {
-        v_me[i] = v_A[i]+v_B[i];
-      }
+  void compute_diagnostic_impl () {
+    auto f_A = get_field_in("Field A", m_grid_name);
+    auto f_B = get_field_in("Field B", m_grid_name);
+    auto v_A = f_A.get_view<const Real*,Host>();
+    auto v_B = f_B.get_view<const Real*,Host>();
+    auto v_me = m_diagnostic_output.get_view<Real*,Host>();
+    for (size_t i=0; i<v_me.size(); ++i) {
+      v_me[i] = v_A[i]+v_B[i];
     }
+  }
 };
 // =============================== Processes ========================== //
 // A dummy atm proc
@@ -666,8 +664,8 @@ TEST_CASE ("diagnostics") {
   diag_sum->initialize(t0,RunType::Initial);
 
   // Run the diagnostics
-  diag_identity->run();
-  diag_sum->run();
+  diag_identity->compute_diagnostic();
+  diag_sum->compute_diagnostic();
 
   // Get diagnostics outputs
   const auto& f_identity = diag_identity->get_diagnostic();


### PR DESCRIPTION
Before, we were setting the diag timestamp in `scorpio_output.cpp`, as soon as we created it, by grabbing the timestamp of one of the diagnostic required fields. However, we never checked that the timestamp was valid. In certain cases, additionally, all the required fields might have an invalid timestamp. This can happen if all the required fields are _computed_ in the ATM, so that none of them has a valid timestamp when the IO class is created at init time.

Fix #1810 