### PR TITLE
test-all-scream significant refactor

### DIFF
--- a/components/scream/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/scream/scripts/jenkins/jenkins_common_impl.sh
@@ -88,7 +88,7 @@ if [ $skip_testing -eq 0 ]; then
 
     # Add a valgrind and coverage tests for mappy for nightlies
     if [[ $is_at_run == 0 && "$SCREAM_MACHINE" == "mappy" ]]; then
-      ./scripts/gather-all-data "./scripts/test-all-scream -t dbg --valgrind ${TAS_ARGS}" -l -m $SCREAM_MACHINE
+      ./scripts/gather-all-data "./scripts/test-all-scream -t dbg --mem-check ${TAS_ARGS}" -l -m $SCREAM_MACHINE
       if [[ $? != 0 ]]; then fails=$fails+1; fi
 
       ./scripts/gather-all-data "./scripts/test-all-scream -t cov ${TAS_ARGS}" -l -m $SCREAM_MACHINE
@@ -97,7 +97,7 @@ if [ $skip_testing -eq 0 ]; then
 
     # Add a cuda-memcheck test for weaver for nightlies
     if [[ $is_at_run == 0 && "$SCREAM_MACHINE" == "weaver" ]]; then
-      ./scripts/gather-all-data "./scripts/test-all-scream -t dbg --cuda-mem-check ${TAS_ARGS}" -l -m $SCREAM_MACHINE
+      ./scripts/gather-all-data "./scripts/test-all-scream -t dbg --mem-check ${TAS_ARGS}" -l -m $SCREAM_MACHINE
       if [[ $? != 0 ]]; then fails=$fails+1; fi
     fi
   else

--- a/components/scream/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/scream/scripts/jenkins/jenkins_common_impl.sh
@@ -88,13 +88,16 @@ if [ $skip_testing -eq 0 ]; then
 
     # Add a valgrind and coverage tests for mappy for nightlies
     if [[ $is_at_run == 0 && "$SCREAM_MACHINE" == "mappy" ]]; then
-      ./scripts/gather-all-data "./scripts/test-all-scream -t valg -t cov ${TAS_ARGS}" -l -m $SCREAM_MACHINE
+      ./scripts/gather-all-data "./scripts/test-all-scream -t dbg --valgrind ${TAS_ARGS}" -l -m $SCREAM_MACHINE
+      if [[ $? != 0 ]]; then fails=$fails+1; fi
+
+      ./scripts/gather-all-data "./scripts/test-all-scream -t cov ${TAS_ARGS}" -l -m $SCREAM_MACHINE
       if [[ $? != 0 ]]; then fails=$fails+1; fi
     fi
 
     # Add a cuda-memcheck test for weaver for nightlies
     if [[ $is_at_run == 0 && "$SCREAM_MACHINE" == "weaver" ]]; then
-      ./scripts/gather-all-data "./scripts/test-all-scream -t cmc ${TAS_ARGS}" -l -m $SCREAM_MACHINE
+      ./scripts/gather-all-data "./scripts/test-all-scream -t dbg --cuda-mem-check ${TAS_ARGS}" -l -m $SCREAM_MACHINE
       if [[ $? != 0 ]]; then fails=$fails+1; fi
     fi
   else

--- a/components/scream/scripts/scripts-tests
+++ b/components/scream/scripts/scripts-tests
@@ -357,33 +357,33 @@ class TestTestAllScream(TestBaseOuter.TestBase):
 
     def test_valg_details(self):
         """
-        Test the 'valg' test in test-all-scream. It should set certain CMake values
+        Test the --valgrind flag in test-all-scream. It should set certain CMake values
         """
         if is_cuda_machine(self._machine):
             self.skipTest("Skipping Valg check on cuda")
         else:
-            options = "-b HEAD -k -t valg --config-only"
+            options = "-b HEAD -k -t dbg --valgrind --config-only"
             cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
                                 self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
-            test_cmake_cache_contents(self, "valgrind", "CMAKE_BUILD_TYPE", "Debug")
-            test_cmake_cache_contents(self, "valgrind", "EKAT_ENABLE_VALGRIND", "TRUE")
-            test_cmake_cache_contents(self, "valgrind", "SCREAM_TEST_SIZE", "SHORT")
+            test_cmake_cache_contents(self, "full_debug", "CMAKE_BUILD_TYPE", "Debug")
+            test_cmake_cache_contents(self, "full_debug", "EKAT_ENABLE_VALGRIND", "TRUE")
+            test_cmake_cache_contents(self, "full_debug", "SCREAM_TEST_SIZE", "SHORT")
 
     def test_cmc_details(self):
         """
-        Test the 'cmc' test in test-all-scream. It should set certain CMake values
+        Test the --cuda-mem-check flag in test-all-scream. It should set certain CMake values
         """
         if not is_cuda_machine(self._machine):
             self.skipTest("Skipping Cuda MemCheck check on CPU machines")
         else:
-            options = "-b HEAD -k -t cmc --config-only"
+            options = "-b HEAD -k -t dbg --cuda-mem-check --config-only"
             cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
                                 self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
-            test_cmake_cache_contents(self, "cuda_mem_check", "CMAKE_BUILD_TYPE", "Debug")
-            test_cmake_cache_contents(self, "cuda_mem_check", "EKAT_ENABLE_CUDA_MEMCHECK", "TRUE")
-            test_cmake_cache_contents(self, "cuda_mem_check", "SCREAM_TEST_SIZE", "SHORT")
+            test_cmake_cache_contents(self, "full_debug", "CMAKE_BUILD_TYPE", "Debug")
+            test_cmake_cache_contents(self, "full_debug", "EKAT_ENABLE_CUDA_MEMCHECK", "TRUE")
+            test_cmake_cache_contents(self, "full_debug", "SCREAM_TEST_SIZE", "SHORT")
 
     def test_opt_details(self):
         """

--- a/components/scream/scripts/scripts-tests
+++ b/components/scream/scripts/scripts-tests
@@ -355,35 +355,20 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             test_cmake_cache_contents(self, "debug_nopack_fpe", "SCREAM_FPE", "TRUE")
             test_cmake_cache_contents(self, "debug_nopack_fpe", "SCREAM_PACK_SIZE", "1")
 
-    def test_valg_details(self):
+    def test_mem_check_details(self):
         """
-        Test the --valgrind flag in test-all-scream. It should set certain CMake values
+        Test the --mem-check flag in test-all-scream. It should set certain CMake values
         """
+        options = "-b HEAD -k -t dbg --mem-check --config-only"
+        cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
+                            self._machine, dry_run=False)
+        run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
+        test_cmake_cache_contents(self, "full_debug", "CMAKE_BUILD_TYPE", "Debug")
+        test_cmake_cache_contents(self, "full_debug", "SCREAM_TEST_SIZE", "SHORT")
         if is_cuda_machine(self._machine):
-            self.skipTest("Skipping Valg check on cuda")
-        else:
-            options = "-b HEAD -k -t dbg --valgrind --config-only"
-            cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
-                                self._machine, dry_run=False)
-            run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
-            test_cmake_cache_contents(self, "full_debug", "CMAKE_BUILD_TYPE", "Debug")
-            test_cmake_cache_contents(self, "full_debug", "EKAT_ENABLE_VALGRIND", "TRUE")
-            test_cmake_cache_contents(self, "full_debug", "SCREAM_TEST_SIZE", "SHORT")
-
-    def test_cmc_details(self):
-        """
-        Test the --cuda-mem-check flag in test-all-scream. It should set certain CMake values
-        """
-        if not is_cuda_machine(self._machine):
-            self.skipTest("Skipping Cuda MemCheck check on CPU machines")
-        else:
-            options = "-b HEAD -k -t dbg --cuda-mem-check --config-only"
-            cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
-                                self._machine, dry_run=False)
-            run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
-            test_cmake_cache_contents(self, "full_debug", "CMAKE_BUILD_TYPE", "Debug")
             test_cmake_cache_contents(self, "full_debug", "EKAT_ENABLE_CUDA_MEMCHECK", "TRUE")
-            test_cmake_cache_contents(self, "full_debug", "SCREAM_TEST_SIZE", "SHORT")
+        else:
+            test_cmake_cache_contents(self, "full_debug", "EKAT_ENABLE_VALGRIND", "TRUE")
 
     def test_opt_details(self):
         """

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -134,9 +134,10 @@ OR
     parser.add_argument("--test-level", action="store", choices=("at", "nightly", "experimental"), default="at",
                         help="Set the testing level.")
 
-    parser.add_argument("--valgrind", action="store_true", help="Run the tests you've selected with valgrind")
-
-    parser.add_argument("--cuda-mem-check", action="store_true", help="Run the tests you've selected with cuda memcheck")
+    parser.add_argument("--mem-check", action="store_true",
+                        help="Run the tests you've selected with memory checking on. "
+                        "This will use valgrind for CPU, cuda-mem-check for GPU etc."
+                        "This will dramatically slow down tests and also disables baseline checking.")
 
     return parser.parse_args(args[1:])
 

--- a/components/scream/scripts/test-all-scream
+++ b/components/scream/scripts/test-all-scream
@@ -93,8 +93,9 @@ OR
     parser.add_argument("--preserve-env", action="store_true",
                         help="Whether to skip machine env setup, and preserve the current user env (useful to manually test new modules)")
 
+    choices_doc = ", ".join(["'{}' ({})".format(k, v) for k, v in TestAllScream.get_test_name_desc().items()])
     parser.add_argument("-t", "--test", dest="tests", action="append", default=[],
-        help="Only run specific test configurations, choices='dbg' (debug), 'sp' (single-prec), 'fpe' (floating-point exceptions), 'opt' (release), 'valg' (valgrind), 'cov' (coverage)")
+                        help=f"Only run specific test configurations, choices={choices_doc}")
 
     parser.add_argument("-i", "--integration-test", action="store_true",
                         help="Merge origin/master into this branch before testing.")
@@ -132,6 +133,10 @@ OR
 
     parser.add_argument("--test-level", action="store", choices=("at", "nightly", "experimental"), default="at",
                         help="Set the testing level.")
+
+    parser.add_argument("--valgrind", action="store_true", help="Run the tests you've selected with valgrind")
+
+    parser.add_argument("--cuda-mem-check", action="store_true", help="Run the tests you've selected with cuda memcheck")
 
     return parser.parse_args(args[1:])
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -21,8 +21,153 @@ from collections import OrderedDict
 from pathlib import Path
 
 ###############################################################################
+class TestProperty(object):
+###############################################################################
+
+    def __init__(self, longname, description, uses_baselines, cmake_args, on_by_default):
+        # What the user uses to select tests via test-all-scream CLI.
+        # Should also match the class name when converted to caps
+        self.shortname      = type(self).__name__.lower()
+
+        # A longer name used to name baseline and test directories for a test.
+        # Also used in output/error messages to refer to the test
+        self.longname       = longname
+
+        # A longer decription of the test
+        self.description    = description
+
+        # Does the test do baseline testing
+        self.uses_baselines = uses_baselines
+
+        # Cmake config args for this test
+        self.cmake_args     = cmake_args
+
+        # Should this test be run if the user did not specify tests at all?
+        self.on_by_default  = on_by_default
+
+        #
+        # Properties not set by constructor (Set by the main TestAllScream object)
+        #
+
+        # Resources used by this test.
+        self.compile_res_count = None
+        self.testing_res_count = None
+
+        # Does this test need baselines
+        self.missing_baselines = False
+
+        #
+        # Common
+        #
+
+        if not self.uses_baselines:
+            self.cmake_args += [("SCREAM_ENABLE_BASELINE_TESTS", "False")]
+
+    # Tests will generally be referred to via their longname
+    def __str__(self):
+        return self.longname
+
+###############################################################################
+class DBG(TestProperty):
+###############################################################################
+
+    CMAKE_ARGS = [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_DEFAULT_BFB", "True")]
+
+    def __init__(self):
+        TestProperty.__init__(
+            self,
+            "full_debug",
+            "debug",
+            True,
+            self.CMAKE_ARGS,
+            True
+        )
+
+###############################################################################
+class SP(TestProperty):
+###############################################################################
+
+    def __init__(self):
+        TestProperty.__init__(
+            self,
+            "full_sp_debug",
+            "debug single precision",
+            True,
+            DBG.CMAKE_ARGS + [("SCREAM_DOUBLE_PRECISION", "False")],
+            True
+        )
+
+###############################################################################
+class FPE(TestProperty):
+###############################################################################
+
+    def __init__(self):
+        TestProperty.__init__(
+            self,
+            "debug_nopack_fpe",
+            "debug pksize=1 floating point exceptions on",
+            False,
+            DBG.CMAKE_ARGS + [("SCREAM_PACK_SIZE", "1")],
+            True
+        )
+
+###############################################################################
+class OPT(TestProperty):
+###############################################################################
+
+    def __init__(self):
+        TestProperty.__init__(
+            self,
+            "release",
+            "release",
+            False,
+            [("CMAKE_BUILD_TYPE", "Release")],
+            True
+        )
+
+###############################################################################
+class COV(TestProperty):
+###############################################################################
+
+    def __init__(self):
+        TestProperty.__init__(
+            self,
+            "coverage",
+            "debug coverage",
+            False,
+            [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_ENABLE_COVERAGE", "True")],
+            False
+        )
+
+###############################################################################
+def test_factory(user_req_tests, machine):
+###############################################################################
+    testclasses = TestProperty.__subclasses__()
+    if not user_req_tests:
+        result = [testclass() for testclass in testclasses
+            if (testclass().on_by_default and not (is_cuda_machine(machine) and testclass().shortname == "fpe"))]
+    else:
+        valid_names = [testclass().shortname for testclass in testclasses]
+        for user_req_test in user_req_tests:
+            expect(user_req_test in valid_names, f"'{user_req_test}' is not a known test")
+
+        result = [testclass() for testclass in testclasses if testclass().shortname in user_req_tests]
+
+    return result
+
+###############################################################################
 class TestAllScream(object):
 ###############################################################################
+
+    ###########################################################################
+    @classmethod
+    def get_test_name_desc(cls):
+    ###########################################################################
+        """
+        Returns a dict mapping short test names to full names
+        """
+        testclasses = TestProperty.__subclasses__()
+        return OrderedDict([(testc().shortname, testc().description) for testc in testclasses])
 
     ###########################################################################
     def __init__(self, cxx_compiler=None, f90_compiler=None, c_compiler=None,
@@ -32,7 +177,8 @@ class TestAllScream(object):
                  integration_test=False, local=False, root_dir=None, work_dir=None,
                  quick_rerun=False,quick_rerun_failed=False,dry_run=False,
                  make_parallel_level=0, ctest_parallel_level=0, update_expired_baselines=False,
-                 extra_verbose=False, limit_test_regex=None, test_level="at"):
+                 extra_verbose=False, limit_test_regex=None, test_level="at",
+                 valgrind=False, cuda_mem_check=False):
     ###########################################################################
 
         # When using scripts-tests, we can't pass "-l" to test-all-scream,
@@ -58,64 +204,20 @@ class TestAllScream(object):
         self._custom_cmake_opts       = custom_cmake_opts
         self._custom_env_vars         = custom_env_vars
         self._preserve_env            = preserve_env
-        self._tests                   = tests
         self._root_dir                = root_dir
         self._work_dir                = None if work_dir is None else Path(work_dir)
         self._integration_test        = integration_test
         self._quick_rerun             = quick_rerun
         self._quick_rerun_failed      = quick_rerun_failed
         self._dry_run                 = dry_run
-        self._tests_needing_baselines = []
         self._update_expired_baselines= update_expired_baselines
         self._extra_verbose           = extra_verbose
         self._limit_test_regex        = limit_test_regex
         self._test_level              = test_level
-
-        self._test_full_names = OrderedDict([
-            ("dbg" , "full_debug"),
-            ("sp"  , "full_sp_debug"),
-            ("fpe" , "debug_nopack_fpe"),
-            ("opt" , "release"),
-            ("valg", "valgrind"),
-            ("cmc",  "cuda_mem_check"),
-            ("cov" , "coverage"),
-        ])
+        self._valgrind                = valgrind
+        self._cuda_mem_check          = cuda_mem_check
 
         # Not all builds are ment to perform comparisons against pre-built baselines
-        self._test_uses_baselines = OrderedDict([
-            ("dbg" , True),
-            ("sp"  , True),
-            ("fpe" , False),
-            ("opt" , True),
-            ("valg", False),
-            ("cmc",  False),
-            ("cov" , False),
-        ])
-
-        self._tests_cmake_args = {
-            "dbg" : [("CMAKE_BUILD_TYPE", "Debug"),
-                     ("EKAT_DEFAULT_BFB", "True")],
-            "sp"  : [("CMAKE_BUILD_TYPE", "Debug"),
-                    ("SCREAM_DOUBLE_PRECISION", "False"),
-                     ("EKAT_DEFAULT_BFB", "True")],
-            "fpe" : [("CMAKE_BUILD_TYPE", "Debug"),
-                     ("SCREAM_PACK_SIZE", "1"),
-                     ("SCREAM_SMALL_PACK_SIZE", "1"),
-                     ("SCREAM_ENABLE_BASELINE_TESTS", "False"),
-                     ("EKAT_DEFAULT_BFB", "True")],
-            "opt" : [("CMAKE_BUILD_TYPE", "Release")],
-            "valg" : [("CMAKE_BUILD_TYPE", "Debug"),
-                      ("SCREAM_TEST_SIZE", "SHORT"),
-                     ("SCREAM_ENABLE_BASELINE_TESTS", "False"),
-                      ("EKAT_ENABLE_VALGRIND", "True")],
-            "cmc"  : [("CMAKE_BUILD_TYPE", "Debug"),
-                      ("SCREAM_TEST_SIZE", "SHORT"),
-                     ("SCREAM_ENABLE_BASELINE_TESTS", "False"),
-                      ("EKAT_ENABLE_CUDA_MEMCHECK", "True")],
-            "cov" : [("CMAKE_BUILD_TYPE", "Debug"),
-                     ("SCREAM_ENABLE_BASELINE_TESTS", "False"),
-                     ("EKAT_ENABLE_COVERAGE", "True")],
-        }
 
         if self._quick_rerun_failed:
             self._quick_rerun = True
@@ -127,6 +229,10 @@ class TestAllScream(object):
         # Quick rerun skips config phase, and config-only runs only config. You can't ask for both...
         expect (not (self._quick_rerun and self._config_only),
                 "Makes no sense to ask for --quick-rerun and --config-only at the same time")
+
+        #
+        expect(not (self._valgrind and self._cuda_mem_check),
+               "Makes no sense to ask for both valgrind and cuda-mem-check")
 
         # Probe machine if none was specified
         if self._machine is None:
@@ -142,19 +248,8 @@ class TestAllScream(object):
         else:
             expect (not self._local, "Specifying a machine while passing '-l,--local' is ambiguous.")
 
-        if not self._tests:
-            # default to all test types except do not do fpe on CUDA
-            self._tests = list(self._test_full_names.keys())
-            self._tests.remove("valg") # don't want this on by default
-            self._tests.remove("cov") # don't want this on by default
-            self._tests.remove("cmc") # don't want this on by default
-            if is_cuda_machine(self._machine):
-                self._tests.remove("fpe")
-        else:
-            for t in self._tests:
-                expect(t in self._test_full_names,
-                       "Requested test '{}' is not supported by test-all-scream, please choose from: {}".\
-                           format(t, ", ".join(self._test_full_names.keys())))
+        # Make our test objects!
+        self._tests = test_factory(tests, self._machine)
 
         # Compute root dir (where repo is) and work dir (where build/test will happen)
         if not self._root_dir:
@@ -162,18 +257,18 @@ class TestAllScream(object):
         else:
             self._root_dir = Path(self._root_dir).resolve()
             expect(self._root_dir.is_dir() and self._root_dir.parts()[-2:] == ('scream', 'components'),
-                   "Bad root-dir '{}', should be: $scream_repo/components/scream".format(self._root_dir))
+                   f"Bad root-dir '{self._root_dir}', should be: $scream_repo/components/scream")
 
         if self._work_dir is not None:
             self._work_dir = Path(self._work_dir).absolute()
             expect(self._work_dir.is_dir(),
-                   "Error! Work directory '{}' does not exist.".format(self._work_dir))
+                   f"Error! Work directory '{self._work_dir}' does not exist.")
         else:
             self._work_dir = self._root_dir.absolute().joinpath("ctest-build")
             self._work_dir.mkdir(exist_ok=True)
 
         os.chdir(str(self._root_dir)) # needed, or else every git command will need repo=root_dir
-        expect(get_current_commit(), "Root dir: {}, does not appear to be a git repo".format(self._root_dir))
+        expect(get_current_commit(), f"Root dir: {self._root_dir}, does not appear to be a git repo")
 
         # Print some info on the branch
         self._original_branch = get_current_branch()
@@ -189,31 +284,32 @@ class TestAllScream(object):
         make_max_jobs = get_mach_compilation_resources()
         if make_parallel_level > 0:
             expect(make_parallel_level <= make_max_jobs,
-                   "Requested make_parallel_level {} is more than max available {}".format(make_parallel_level, make_max_jobs))
+                   f"Requested make_parallel_level {make_parallel_level} is more than max available {make_max_jobs}")
             make_max_jobs = make_parallel_level
-            print("Note: honoring requested value for make parallel level: {}".format(make_max_jobs))
+            print(f"Note: honoring requested value for make parallel level: {make_max_jobs}")
         else:
-            print("Note: no value passed for --make-parallel-level. Using the default for this machine: {}".format(make_max_jobs))
+            print(f"Note: no value passed for --make-parallel-level. Using the default for this machine: {make_max_jobs}")
 
         ctest_max_jobs = get_mach_testing_resources(self._machine)
         if ctest_parallel_level > 0:
             expect(ctest_parallel_level <= ctest_max_jobs,
-                   "Requested ctest_parallel_level {} is more than max available {}".format(ctest_parallel_level, ctest_max_jobs))
+                   f"Requested ctest_parallel_level {ctest_parallel_level} is more than max available {ctest_max_jobs}")
             ctest_max_jobs = ctest_parallel_level
-            print("Note: honoring requested value for ctest parallel level: {}".format(ctest_max_jobs))
+            print(f"Note: honoring requested value for ctest parallel level: {ctest_max_jobs}")
         elif "CTEST_PARALLEL_LEVEL" in os.environ:
             env_val = int(os.environ["CTEST_PARALLEL_LEVEL"])
             expect(env_val <= ctest_max_jobs,
-                   "CTEST_PARALLEL_LEVEL env {} is more than max available {}".format(env_val, ctest_max_jobs))
+                   f"CTEST_PARALLEL_LEVEL env {env_val} is more than max available {ctest_max_jobs}")
             ctest_max_jobs = env_val
-            print("Note: honoring environment value for ctest parallel level: {}".format(ctest_max_jobs))
+            print(f"Note: honoring environment value for ctest parallel level: {ctest_max_jobs}")
         else:
-            print("Note: no value passed for --ctest-parallel-level. Using the default for this machine: {}".format(ctest_max_jobs))
+            print(f"Note: no value passed for --ctest-parallel-level. Using the default for this machine: {ctest_max_jobs}")
 
         self._ctest_max_jobs = ctest_max_jobs
 
-        self._testing_res_count = dict(zip(self._tests, [ctest_max_jobs]*len(self._tests)))
-        self._compile_res_count = dict(zip(self._tests, [make_max_jobs ]*len(self._tests)))
+        for test in self._tests:
+            test.testing_res_count = ctest_max_jobs
+            test.compile_res_count = make_max_jobs
 
         if self._parallel:
             # We need to be aware that other builds may be running too.
@@ -234,11 +330,10 @@ class TestAllScream(object):
                 expect(False, "test-all-scream does not currently support oversubscription. "
                               "Either run fewer test types or turn off parallel testing")
 
-            self._testing_res_count = dict(zip(self._tests, [ctest_jobs_per_test]*len(self._tests)))
-            self._compile_res_count = dict(zip(self._tests, [make_jobs_per_test ]*len(self._tests)))
-
             for test in self._tests:
-                print("Test {} can use {} jobs to compile, and {} jobs for test".format(test,self._compile_res_count[test],self._testing_res_count[test]))
+                test.testing_res_count = ctest_jobs_per_test
+                test.compile_res_count = make_jobs_per_test
+                print(f"Test {test} can use {test.compile_res_count} jobs to compile, and {test.testing_res_count} jobs for test")
 
         # Unless the user claims to know what he/she is doing, we setup the env.
         # Need to happen before compiler probing
@@ -251,7 +346,7 @@ class TestAllScream(object):
         ###################################
 
         expect (not self._baseline_dir or self._work_dir != self._baseline_dir,
-                "Error! For your safety, do NOT use '{}' to store baselines. Move them to a different directory (even a subdirectory if that works).".format(self._work_dir))
+                f"Error! For your safety, do NOT use '{self._work_dir}' to store baselines. Move them to a different directory (even a subdirectory if that works).")
 
         # If no baseline ref/dir was provided, use default master baseline dir for this machine
         # NOTE: if user specifies baseline ref, baseline dir will be set later to a path within work dir
@@ -315,10 +410,15 @@ class TestAllScream(object):
             # Make sure the baseline folders exist (but do not purge content if they exist)
             self.create_tests_dirs(self._baseline_dir, False)
 
-        print ("Checking baselines directory: {}".format(self._baseline_dir))
-        self.baselines_are_present()
-        if self._update_expired_baselines:
-            self.baselines_are_expired()
+        # Do not do baseline operations if mem checking is on
+        print (f"Checking baselines directory: {self._baseline_dir}")
+        if self._valgrind or self._cuda_mem_check:
+            for test in self._tests:
+                test.uses_baselines = False
+        else:
+            self.baselines_are_present()
+            if self._update_expired_baselines:
+                self.baselines_are_expired()
 
         ############################################
         #    Deduce compilers if needed/possible   #
@@ -332,9 +432,9 @@ class TestAllScream(object):
             self._c_compiler = get_mach_c_compiler(self._machine)
 
         if not self._dry_run:
-            self._f90_compiler = run_cmd_no_fail("which {}".format(self._f90_compiler))
-            self._cxx_compiler = run_cmd_no_fail("which {}".format(self._cxx_compiler))
-            self._c_compiler   = run_cmd_no_fail("which {}".format(self._c_compiler))
+            self._f90_compiler = run_cmd_no_fail(f"which {self._f90_compiler}")
+            self._cxx_compiler = run_cmd_no_fail(f"which {self._cxx_compiler}")
+            self._c_compiler   = run_cmd_no_fail(f"which {self._c_compiler}")
 
     ###############################################################################
     def create_tests_dirs(self, root, clean):
@@ -377,35 +477,35 @@ class TestAllScream(object):
     ###############################################################################
     def get_test_dir(self, root, test):
     ###############################################################################
-        return root/self._test_full_names[test]
+        return root/str(test)
 
     ###############################################################################
     def get_preexisting_baseline(self, test):
     ###############################################################################
         expect(self._baseline_dir is not None, "Cannot supply preexisting baseline without baseline dir")
-        return self._baseline_dir/self._test_full_names[test]/"data"
+        return self._baseline_dir/str(test)/"data"
 
     ###############################################################################
-    def baselines_are_present (self):
+    def baselines_are_present(self):
     ###############################################################################
         """
         Check that all baselines are present (one subdir for all values of self._tests)
-        Note: if self._test_uses_baselines[test]=False, skip the check
+        Note: if test.uses_baselines=False, skip the check
         """
         # Sanity check
         expect(self._baseline_dir is not None,
                 "Error! Baseline directory not correctly set.")
 
         for test in self._tests:
-            if self._test_uses_baselines[test]:
+            if test.uses_baselines:
                 data_dir = self.get_preexisting_baseline(test)
                 if not data_dir.is_dir():
-                    self._tests_needing_baselines.append(test)
-                    print(" -> Test {} is missing baselines".format(test))
+                    test.missing_baselines = True
+                    print(f" -> Test {test} is missing baselines")
                 else:
-                    print(" -> Test {} appears to have baselines".format(test))
+                    print(f" -> Test {test} appears to have baselines")
             else:
-                print(" -> Test {} does not use baselines".format(test))
+                print(f" -> Test {test} does not use baselines")
 
     ###############################################################################
     def baselines_are_expired(self):
@@ -421,34 +521,34 @@ class TestAllScream(object):
         expect(self._baseline_dir is not None, "Error! This routine should only be called when testing against pre-existing baselines.")
 
         for test in self._tests:
-            if self._test_uses_baselines[test] and test not in self._tests_needing_baselines:
+            if test.uses_baselines and not test.missing_baselines:
                 # this test is not missing a baseline, but it may be expired.
 
                 baseline_file_sha = self.get_baseline_file_sha(test)
                 if baseline_file_sha is None:
-                    self._tests_needing_baselines.append(test)
-                    print(" -> Test {} has no stored sha so must be considered expired".format(test))
+                    test.missing_baselines = True
+                    print(f" -> Test {test} has no stored sha so must be considered expired")
                 else:
                     num_ref_is_behind_file, num_ref_is_ahead_file = git_refs_difference(baseline_file_sha, baseline_ref_sha)
 
                     # If the copy in our repo is behind, then we need to update the repo
                     expect (num_ref_is_behind_file==0 or not self._integration_test,
-"""Error! Your repo seems stale, since the baseline sha in your repo is behind
+f"""Error! Your repo seems stale, since the baseline sha in your repo is behind
 the one last used to generated them. We do *not* allow an integration
 test to replace baselines with older ones, for security reasons.
 If this is a legitimate case where baselines need to be 'rewound',
 e.g. b/c of a (hopefully VERY RARE) force push to master, then
 remove existing baselines first. Otherwise, please run 'git fetch $remote'.
- - baseline_ref: {}
- - repo baseline sha: {}
- - last used baseline sha: {}""".format(self._baseline_ref,baseline_ref_sha,baseline_file_sha))
+ - baseline_ref: {self._baseline_ref}
+ - repo baseline sha: {baseline_ref_sha}
+ - last used baseline sha: {baseline_file_sha}""")
 
                     # If the copy in our repo is not ahead, then baselines are not expired
                     if num_ref_is_ahead_file > 0:
-                        self._tests_needing_baselines.append(test)
-                        print(" -> Test {} baselines are expired because they were generated with an earlier commit".format(test))
+                        test.missing_baselines = True
+                        print(f" -> Test {test} baselines are expired because they were generated with an earlier commit")
                     else:
-                        print(" -> Test {} baselines are valid and do not need to be regenerated".format(test))
+                        print(f" -> Test {test} baselines are valid and do not need to be regenerated")
 
     ###############################################################################
     def get_machine_file(self):
@@ -456,41 +556,47 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         if self._local:
             return Path("~/.cime/scream_mach_file.cmake").expanduser()
         else:
-            return self._root_dir/"cmake"/"machine-files"/"{}.cmake".format(self._machine)
+            return self._root_dir/"cmake"/"machine-files"/f"{self._machine}.cmake"
 
     ###############################################################################
     def generate_cmake_config(self, extra_configs, for_ctest=False):
     ###############################################################################
 
         # Ctest only needs config options, and doesn't need the leading 'cmake '
-        result  = "{}-C {}".format("" if for_ctest else "cmake ", self.get_machine_file())
+        result  = f"{'' if for_ctest else 'cmake '}-C {self.get_machine_file()}"
 
         # Netcdf should be available. But if the user is doing a testing session
         # where all netcdf-related code is disabled, he/she should be able to run
         # even if no netcdf is available
         stat, f_path, _ = run_cmd("nf-config --prefix")
         if stat == 0:
-            result += " -DNetCDF_Fortran_PATH={}".format(f_path)
+            result += f" -DNetCDF_Fortran_PATH={f_path}"
         stat, c_path, _ = run_cmd("nc-config --prefix")
         if stat == 0:
-            result += " -DNetCDF_C_PATH={}".format(c_path)
+            result += f" -DNetCDF_C_PATH={c_path}"
 
         # Test-specific cmake options
         for key, value in extra_configs:
-            result += " -D{}={}".format(key, value)
+            result += f" -D{key}={value}"
 
         # The output coming from all tests at the same time will be a mixed-up mess
         # unless we tell test-launcher to buffer all output
         if self._extra_verbose:
-            result += " -DEKAT_TEST_LAUNCHER_BUFFER=True "
+            result += " -DEKAT_TEST_LAUNCHER_BUFFER=True"
 
         # Define test level
         if self._test_level == "at":
             pass # Nothing to do, this is the default in the cmake system
         elif self._test_level == "nightly":
-            result += " -DSCREAM_TEST_LEVEL=NIGHTLY "
+            result += " -DSCREAM_TEST_LEVEL=NIGHTLY"
         elif self._test_level == "experimental":
-            result += " -DSCREAM_TEST_LEVEL=EXPERIMENTAL "
+            result += " -DSCREAM_TEST_LEVEL=EXPERIMENTAL"
+
+        # Add configs for mem checking
+        if self._valgrind or self._cuda_mem_check:
+            # valgrind/cmc slow down things a lot, we need to run tests in short mode
+            result += " -DSCREAM_TEST_SIZE=SHORT"
+            result += f" -DEKAT_ENABLE_{'VALGRIND' if self._valgrind else 'CUDA_MEMCHECK'}=True"
 
         # User-requested config options
         custom_opts_keys = []
@@ -499,16 +605,16 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
             if "=" in custom_opt:
                 name, value = custom_opt.split("=", 1)
                 # Some effort is needed to ensure quotes are perserved
-                result += " -D{}='{}'".format(name, value)
+                result += f" -D{name}='{value}'"
                 custom_opts_keys.append(name)
 
         # Common config options (unless already specified by the user)
         if "CMAKE_CXX_COMPILER" not in custom_opts_keys:
-            result += " -DCMAKE_CXX_COMPILER={}".format(self._cxx_compiler)
+            result += f" -DCMAKE_CXX_COMPILER={self._cxx_compiler}"
         if "CMAKE_C_COMPILER" not in custom_opts_keys:
-            result += " -DCMAKE_C_COMPILER={}".format(self._c_compiler)
+            result += f" -DCMAKE_C_COMPILER={self._c_compiler}"
         if "CMAKE_Fortran_COMPILER" not in custom_opts_keys:
-            result += " -DCMAKE_Fortran_COMPILER={}".format(self._f90_compiler)
+            result += f" -DCMAKE_Fortran_COMPILER={self._f90_compiler}"
 
         if "SCREAM_DYNAMICS_DYCORE" not in custom_opts_keys:
             result += " -DSCREAM_DYNAMICS_DYCORE=HOMME"
@@ -518,7 +624,7 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
     ###############################################################################
     def get_taskset_range(self, test, for_compile=True):
     ###############################################################################
-        res_count = self._compile_res_count if for_compile else self._testing_res_count
+        res_name = "compile_res_count" if for_compile else "testing_res_count"
 
         if not for_compile and is_cuda_machine(self._machine):
             # For GPUs, the cpu affinity is irrelevant. Just assume all GPUS are open
@@ -530,8 +636,8 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         affinity_cp.sort()
 
         if self._parallel:
-            it = itertools.takewhile(lambda name: name!=test, self._tests)
-            offset = sum(res_count[prevs] for prevs in it)
+            it = itertools.takewhile(lambda item: item != test, self._tests)
+            offset = sum(getattr(prevs, res_name) for prevs in it)
         else:
             offset = 0
 
@@ -539,8 +645,8 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
                f"Offset {offset} out of bounds (max={len(affinity_cp)}) for test {test}\naffinity_cp: {affinity_cp}")
         start = affinity_cp[offset]
         end = start
-        for i in range(1, res_count[test]):
-            expect(affinity_cp[offset+i] == start+i, "Could not get contiguous range for test {}".format(test))
+        for i in range(1, getattr(test, res_name)):
+            expect(affinity_cp[offset+i] == start+i, f"Could not get contiguous range for test {test}")
             end = affinity_cp[offset+i]
 
         return start, end
@@ -551,7 +657,7 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         # Create a json file in the test build dir, which ctest will then use
         # to schedule tests in parallel.
         # In the resource file, we have N res groups with 1 slot, with N being
-        # what's in self._testing_res_count[test]. On CPU machines, res groups
+        # what's in test.testing_res_count. On CPU machines, res groups
         # are cores, on GPU machines, res groups are GPUs. In other words, a
         # res group is where we usually bind an individual MPI rank.
         # The id of the res groups on is offset so that it is unique across all builds
@@ -572,7 +678,7 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         # Add resource groups
         data['local'] = [{"devices":devices}]
 
-        with open("{}/ctest_resource_file.json".format(build_dir),'w', encoding="utf-8") as outfile:
+        with (build_dir/"ctest_resource_file.json").open('w', encoding="utf-8") as outfile:
             json.dump(data,outfile,indent=2)
 
         return (end-start)+1
@@ -580,62 +686,60 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
     ###############################################################################
     def generate_ctest_config(self, cmake_config, extra_configs, test):
     ###############################################################################
-        name = self._test_full_names[test]
         result = ""
         if self._submit:
-            result += "SCREAM_MACHINE={} ".format(self._machine)
+            result += f"SCREAM_MACHINE={self._machine} "
 
         test_dir = self.get_test_dir(self._work_dir,test)
         num_test_res = self.create_ctest_resource_file(test,test_dir)
-        cmake_config += " -DSCREAM_TEST_MAX_TOTAL_THREADS={}".format(num_test_res)
+        cmake_config += f" -DSCREAM_TEST_MAX_TOTAL_THREADS={num_test_res}"
         verbosity = "-V --output-on-failure" if not self._extra_verbose else "-VV"
 
-        result += "SCREAM_BUILD_PARALLEL_LEVEL={} CTEST_PARALLEL_LEVEL={} ctest {} ".format(self._compile_res_count[test], self._testing_res_count[test], verbosity)
-        result += "--resource-spec-file {}/ctest_resource_file.json ".format(test_dir)
+        result += f"SCREAM_BUILD_PARALLEL_LEVEL={test.compile_res_count} CTEST_PARALLEL_LEVEL={test.testing_res_count} ctest {verbosity} "
+        result += f"--resource-spec-file {test_dir}/ctest_resource_file.json "
 
-        if self._baseline_dir is not None and self._test_uses_baselines[test]:
-            cmake_config += " -DSCREAM_TEST_DATA_DIR={}".format(self.get_preexisting_baseline(test))
+        if self._baseline_dir is not None and test.uses_baselines:
+            cmake_config += f" -DSCREAM_TEST_DATA_DIR={self.get_preexisting_baseline(test)}"
 
         if not self._submit:
             result += "-DNO_SUBMIT=True "
 
-        if test == "cov":
+        if isinstance(test, COV):
             result += "-DDO_COVERAGE=True "
 
         for key, value in extra_configs:
-            result += "-D{}={} ".format(key, value)
+            result += f"-D{key}={value} "
 
-        work_dir = self._work_dir/name
-        result += "-DBUILD_WORK_DIR={} ".format(work_dir)
-        result += "-DBUILD_NAME_MOD={} ".format(name)
+        work_dir = self._work_dir/str(test)
+        result += f"-DBUILD_WORK_DIR={work_dir} "
+        result += f"-DBUILD_NAME_MOD={test} "
         if self._limit_test_regex:
-            result += "-DINCLUDE_REGEX={} ".format(self._limit_test_regex)
-        result += '-S {}/cmake/ctest_script.cmake -DCMAKE_COMMAND="{}" '.format(self._root_dir, cmake_config)
+            result += f"-DINCLUDE_REGEX={self._limit_test_regex} "
+        result += f'-S {self._root_dir}/cmake/ctest_script.cmake -DCMAKE_COMMAND="{cmake_config}" '
 
         # Ctest can only competently manage test pinning across a single instance of ctest. For
         # multiple concurrent instances of ctest, we have to help it. It's OK to use the compile_res_count
         # taskset range even though the ctest script is also running the tests
         if self._parallel:
             start, end = self.get_taskset_range(test)
-            result = "taskset -c {}-{} sh -c '{}'".format(start,end,result)
+            result = f"taskset -c {start}-{end} sh -c '{result}'"
 
         return result
 
     ###############################################################################
     def generate_baselines(self, test, commit):
     ###############################################################################
-
-        expect (self._test_uses_baselines[test],
-            "Something is off. generate_baseline should have not be called for test {}".format(test))
+        expect(test.uses_baselines,
+               f"Something is off. generate_baseline should have not be called for test {test}")
 
         test_dir = self.get_test_dir(self._baseline_dir, test)
 
-        cmake_config = self.generate_cmake_config(self._tests_cmake_args[test])
+        cmake_config = self.generate_cmake_config(test.cmake_args)
         cmake_config += " -DSCREAM_BASELINES_ONLY=ON"
-        cmake_config += " -DSCREAM_TEST_DATA_DIR={}/data".format(test_dir)
+        cmake_config += f" -DSCREAM_TEST_DATA_DIR={test_dir}/data"
 
         print("===============================================================================")
-        print("Generating baseline for test {} with config '{}'".format(self._test_full_names[test], cmake_config))
+        print(f"Generating baseline for test {test} with config '{cmake_config}'")
         print("===============================================================================")
 
         success = True
@@ -644,22 +748,22 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
             # We cannot just crash if we fail to generate baselines, since we would
             # not get a dashboard report if we did that. Instead, just ensure there is
             # no baseline file to compare against if there's a problem.
-            stat, _, err = run_cmd("{} {}".format(cmake_config, self._root_dir),
+            stat, _, err = run_cmd(f"{cmake_config} {self._root_dir}",
                                    from_dir=test_dir, verbose=True, dry_run=self._dry_run)
             if stat != 0:
-                print ("WARNING: Failed to configure baselines:\n{}".format(err))
+                print (f"WARNING: Failed to configure baselines:\n{err}")
                 success = False
 
             else:
-                cmd = "make -j{} && make -j{} baseline".format(self._compile_res_count[test], self._testing_res_count[test])
+                cmd = f"make -j{test.compile_res_count} && make -j{test.testing_res_count} baseline"
                 if self._parallel:
                     start, end = self.get_taskset_range(test)
-                    cmd = "taskset -c {}-{} sh -c '{}'".format(start,end,cmd)
+                    cmd = f"taskset -c {start}-{end} sh -c '{cmd}'"
 
                 stat, _, err = run_cmd(cmd, from_dir=test_dir, verbose=True, dry_run=self._dry_run)
 
                 if stat != 0:
-                    print("WARNING: Failed to create baselines:\n{}".format(err))
+                    print(f"WARNING: Failed to create baselines:\n{err}")
                     success = False
 
         finally:
@@ -671,6 +775,7 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         if success:
             # Store the sha used for baselines generation
             self.set_baseline_file_sha(test, commit)
+            test.missing_baselines = False
 
         return success
 
@@ -680,7 +785,7 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         git_head_ref = get_current_head()
 
         print("###############################################################################")
-        print("Generating baselines for ref {}".format(self._baseline_ref))
+        print(f"Generating baselines for ref {self._baseline_ref}")
         print("###############################################################################")
 
         commit = get_current_commit(commit=self._baseline_ref)
@@ -689,19 +794,20 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         checkout_git_ref(self._baseline_ref, verbose=True, dry_run=self._dry_run)
 
         success = True
-        num_workers = len(self._tests_needing_baselines) if self._parallel else 1
+        tests_needing_baselines = [test for test in self._tests if test.missing_baselines]
+        num_workers = len(tests_needing_baselines) if self._parallel else 1
         with threading3.ProcessPoolExecutor(max_workers=num_workers) as executor:
 
             future_to_test = {
                 executor.submit(self.generate_baselines, test, commit) : test
-                for test in self._tests_needing_baselines}
+                for test in tests_needing_baselines}
 
             for future in threading3.as_completed(future_to_test):
                 test = future_to_test[future]
                 success &= future.result()
 
                 if not success and self._fast_fail:
-                    print('Generation of baselines for build {} failed'.format(self._test_full_names[test]))
+                    print(f"Generation of baselines for test {test} failed")
                     return False
 
         # Switch back to the branch commit
@@ -715,11 +821,11 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         git_head = get_current_head()
 
         print("===============================================================================")
-        print("Testing '{}' for test '{}'".format(git_head, self._test_full_names[test]))
+        print(f"Testing '{git_head}' for test '{test}'")
         print("===============================================================================")
 
         test_dir = self.get_test_dir(self._work_dir,test)
-        cmake_config = self.generate_cmake_config(self._tests_cmake_args[test], for_ctest=True)
+        cmake_config = self.generate_cmake_config(test.cmake_args, for_ctest=True)
         ctest_config = self.generate_ctest_config(cmake_config, [], test)
 
         if self._config_only:
@@ -772,7 +878,7 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
 
         for t,s in tests_success.items():
             if not s:
-                print("Build type {} failed. Here's a list of failed tests:".format(self._test_full_names[t]))
+                print(f"Build type {t} failed. Here's a list of failed tests:")
                 test_dir = self.get_test_dir(self._work_dir,t)
                 test_results_dir = test_dir/"Testing"/"Temporary"
                 for result in test_results_dir.glob("LastTestsFailed*"):
@@ -792,7 +898,8 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         success = True
         try:
             # If needed, generate baselines first
-            if self._tests_needing_baselines:
+            tests_needing_baselines = [test for test in self._tests if test.missing_baselines]
+            if tests_needing_baselines:
                 expect(self._baseline_ref is not None, "Missing baseline ref")
 
                 success = self.generate_all_baselines()


### PR DESCRIPTION
Refactored items:
1) Tests become a proper object that can store test state
2) Valgrind and cuda-mem-check become test modifiers instead of test types
3) Use python f-strings instead of .format
4) 'opt' test no longer is set to do baseline checking. This made no sense
   since release mode is not BFB