### PR TITLE
Fix three diagnostic tests that were failing the cuda_mem_check test on GPU

### DIFF
--- a/components/scream/src/diagnostics/dry_static_energy.cpp
+++ b/components/scream/src/diagnostics/dry_static_energy.cpp
@@ -70,6 +70,7 @@ void DryStaticEnergyDiagnostic::run_impl(const int /* dt */)
   // Set surface geopotential for this diagnostic
   const Real surf_geopotential = 0.0;
 
+  const int num_levs = m_num_levs;
   view_1d dz("",npacks);
   view_1d z_int("",npacks_p1);
   view_1d z_mid("",npacks);
@@ -84,9 +85,9 @@ void DryStaticEnergyDiagnostic::run_impl(const int /* dt */)
       dz(jpack) = PF::calculate_dz(pseudo_density_mid(icol,jpack), p_mid(icol,jpack), T_mid(icol,jpack), qv_mid(icol,jpack));
     });
     team.team_barrier();
-    PF::calculate_z_int(team,m_num_levs,dz,surf_geopotential,z_int);
+    PF::calculate_z_int(team,num_levs,dz,surf_geopotential,z_int);
     team.team_barrier();
-    PF::calculate_z_mid(team,m_num_levs,z_int,z_mid);
+    PF::calculate_z_mid(team,num_levs,z_int,z_mid);
     team.team_barrier();
     const auto& dse_s = ekat::subview(dse,icol);
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team, npacks), [&] (const Int& jpack) {

--- a/components/scream/src/diagnostics/vertical_layer_interface.cpp
+++ b/components/scream/src/diagnostics/vertical_layer_interface.cpp
@@ -61,6 +61,7 @@ void VerticalLayerInterfaceDiagnostic::run_impl(const int /* dt */)
   // Set surface geopotential for this diagnostic
   const Real surf_geopotential = 0.0;
 
+  const int num_levs = m_num_levs;
   view_1d dz("",npacks);
   Kokkos::parallel_for("VerticalLayerInterfaceDiagnostic",
                        default_policy,
@@ -71,7 +72,7 @@ void VerticalLayerInterfaceDiagnostic::run_impl(const int /* dt */)
     });
     team.team_barrier();
     const auto& z_int_s = ekat::subview(z_int, icol);
-    PF::calculate_z_int(team,m_num_levs,dz,surf_geopotential,z_int_s);
+    PF::calculate_z_int(team,num_levs,dz,surf_geopotential,z_int_s);
   });
 
 }

--- a/components/scream/src/diagnostics/vertical_layer_midpoint.cpp
+++ b/components/scream/src/diagnostics/vertical_layer_midpoint.cpp
@@ -62,6 +62,7 @@ void VerticalLayerMidpointDiagnostic::run_impl(const int /* dt */)
   // Set surface geopotential for this diagnostic
   const Real surf_geopotential = 0.0;
 
+  const int num_levs = m_num_levs;
   view_1d dz("",npacks);
   view_1d z_int("",npacks_p1);
   Kokkos::parallel_for("VerticalLayerMidpointDiagnostic",
@@ -73,8 +74,8 @@ void VerticalLayerMidpointDiagnostic::run_impl(const int /* dt */)
     });
     team.team_barrier();
     const auto& z_mid_s = ekat::subview(z_mid, icol);
-    PF::calculate_z_int(team,m_num_levs,dz,surf_geopotential,z_int);
-    PF::calculate_z_mid(team,m_num_levs,z_int,z_mid_s);
+    PF::calculate_z_int(team,num_levs,dz,surf_geopotential,z_int);
+    PF::calculate_z_mid(team,num_levs,z_int,z_mid_s);
   });
 
 }


### PR DESCRIPTION
This commit defines a local variable `num_levs` inside the run_impl for
the dry_static_energy, vertical_layer_interface and vertical_layer_midpoint
diagnostics.  This is then used when calling the common physics functions
that need to know the number of levels in the simulation.

This bug was causing failures in the cuda_mem_check test on GPU machines,
such as weaver.

Fix #1813 