### PR TITLE
Allow scientific notation for integers in buildnml/atmchange/atmquery scripts

### DIFF
--- a/components/scream/cime_config/eamxx_buildnml_impl.py
+++ b/components/scream/cime_config/eamxx_buildnml_impl.py
@@ -256,7 +256,9 @@ def refine_type(entry, force_type=None):
                     elem = bool(int(entry))
 
             elif elem_type == "integer":
-                elem = int(entry)
+                tmp  = float(entry)
+                expect (float(int(tmp))==tmp, "Cannot interpret {} as int".format(entry))
+                elem = int(tmp)
             elif elem_type == "real":
                 elem = float(entry)
             elif elem_type == "string":


### PR DESCRIPTION
So long as the scientific notation really represent an integer. E.g.,

```
$ ./atmchange se_tstep=1.52e2
$ ./atmchange se_tstep=1.523e2
ERROR: Cannot interpret 1.523e2 as int
```