### PR TITLE
This PR ensures that SCORPIO time indices are 0-based in C++ and 1-based in Fortran.

### DIFF
--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -390,9 +390,9 @@ void SPAFunctions<S,D>
   scorpio::set_decomp(remap_file_name);
   
   // Now read all of the input
-  scorpio::grid_read_data_array(remap_file_name,"S",0,S_global_h.data()); 
-  scorpio::grid_read_data_array(remap_file_name,"row",0,row_global_h.data()); 
-  scorpio::grid_read_data_array(remap_file_name,"col",0,col_global_h.data()); 
+  scorpio::grid_read_data_array(remap_file_name,"S",-1,S_global_h.data()); 
+  scorpio::grid_read_data_array(remap_file_name,"row",-1,row_global_h.data()); 
+  scorpio::grid_read_data_array(remap_file_name,"col",-1,col_global_h.data()); 
 
   // Finished, close the file
   scorpio::eam_pio_closefile(remap_file_name);
@@ -484,7 +484,7 @@ template<typename S, typename D>
 void SPAFunctions<S,D>
 ::update_spa_data_from_file(
     const std::string&          spa_data_file_name,
-    const Int                   time_index,
+    const Int                   time_index, // zero-based
     const Int                   nswbands,
     const Int                   nlwbands,
           SPAHorizInterp&       spa_horiz_interp,
@@ -701,9 +701,10 @@ void SPAFunctions<S,D>
     // NOTE: If the timestep is bigger than monthly this could cause the wrong values
     //       to be assigned.  A timestep greater than a month is very unlikely so we
     //       will proceed.
-    update_spa_data_from_file(spa_data_file_name,time_state.current_month,nswbands,nlwbands,spa_horiz_interp,spa_beg);
+    // NOTE: we use zero-based time indexing here.
+    update_spa_data_from_file(spa_data_file_name,time_state.current_month-1,nswbands,nlwbands,spa_horiz_interp,spa_beg);
     Int next_month = time_state.current_month==12 ? 1 : time_state.current_month+1;
-    update_spa_data_from_file(spa_data_file_name,next_month,nswbands,nlwbands,spa_horiz_interp,spa_end);
+    update_spa_data_from_file(spa_data_file_name,next_month-1,nswbands,nlwbands,spa_horiz_interp,spa_end);
     // If time state was not initialized it is now:
     time_state.inited = true;
   }

--- a/components/scream/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
@@ -77,7 +77,7 @@ TEST_CASE("spa_one_to_one_remap","spa")
   });
 
   // Verify that the interpolated values match the algorithm for the data and the weights.
-  //       weights(i) = 1.0 
+  //       weights(i) = 1.0
   //       FOR t=1,2,3; i=0,1,2; b=1,2 or 1,2,3 and k=0,1,2,3
   //       p(t,i) = (t+1) * (i+1)*100
   //       ccn3(t,i,k) = (i+1)*100 + t*10 + k
@@ -92,7 +92,7 @@ TEST_CASE("spa_one_to_one_remap","spa")
   auto aer_tau_sw_h = Kokkos::create_mirror_view(spa_data.data.AER_TAU_SW);
   auto aer_tau_lw_h = Kokkos::create_mirror_view(spa_data.data.AER_TAU_LW);
   for (int time_index = 0;time_index<max_time; time_index++) {
-    SPAFunc::update_spa_data_from_file(spa_data_file, time_index+1, nswbands, nlwbands,
+    SPAFunc::update_spa_data_from_file(spa_data_file, time_index, nswbands, nlwbands,
                                        spa_horiz_interp, spa_data);
     Kokkos::deep_copy(ps_h,spa_data.PS);
     Kokkos::deep_copy(ccn3_h,spa_data.data.CCN3);
@@ -119,8 +119,8 @@ TEST_CASE("spa_one_to_one_remap","spa")
       }
     }
   }
-  
-  // All Done 
+
+  // All Done
   scorpio::eam_pio_finalize();
 } // run_property
 

--- a/components/scream/src/physics/spa/tests/spa_read_data_from_file_test.cpp
+++ b/components/scream/src/physics/spa/tests/spa_read_data_from_file_test.cpp
@@ -83,7 +83,7 @@ TEST_CASE("spa_read_data","spa")
   auto dofs_gids_h = Kokkos::create_mirror_view(dofs_gids);
   Kokkos::deep_copy(dofs_gids_h,dofs_gids);
   for (int time_index = 0;time_index<max_time; time_index++) {
-    SPAFunc::update_spa_data_from_file(spa_data_file, time_index+1, nswbands, nlwbands,
+    SPAFunc::update_spa_data_from_file(spa_data_file, time_index, nswbands, nlwbands,
                                        spa_horiz_interp, spa_data);
     Kokkos::deep_copy(ps_h,spa_data.PS);
     Kokkos::deep_copy(ccn3_h,spa_data.data.CCN3);

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -223,10 +223,10 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
 }
 
 /* ---------------------------------------------------------- */
-// Note: The time_index argument provides a way to control which
-//       time snap to read input from in the file.  If a negative
-//       number is provided the routine will read input at the
-//       last time level set by running eam_update_timesnap.
+// Note: The (zero-based) time_index argument provides a way to control which
+//       time step to read input from in the file.  If a negative number is
+//       provided the routine will read input at the last time level set by
+//       running eam_update_timesnap.
 void AtmosphereInput::read_variables (const int time_index)
 {
   EKAT_REQUIRE_MSG (m_inited_with_views || m_inited_with_fields,

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -1359,6 +1359,7 @@ contains
   !               If PIO MPI ranks > 1, var_data_ptr should be the subset of the global array
   !               which includes only those degrees of freedom that have been
   !               assigned to this rank.  See set_dof above.
+  ! time_index:   The 1-based time index for this variable (0 is ignored).
   !---------------------------------------------------------------------------
   !
   !  grid_read_darray_1d: Read a variable defined on this grid

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -112,7 +112,8 @@ void eam_pio_enddef(const std::string &filename) {
   eam_pio_enddef_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname, const int time_index, void *hbuf) {
+void grid_read_data_array(const std::string &filename, const std::string &varname,
+                          const int time_index, void *hbuf) {
   grid_read_data_array_c2f(filename.c_str(),varname.c_str(),time_index,hbuf);
 }
 /* ----------------------------------------------------------------- */

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -56,8 +56,8 @@ namespace scorpio {
   void pio_update_time(const std::string &filename, const Real time);
 
   // Read data for a specific variable from a specific file. To read data that
-  // isn't associated with a time index, set time_index to -1. Otherwise use
-  // the proper zero-based time index.
+  // isn't associated with a time index, or to read data at the most recent
+  // time, set time_index to -1. Otherwise use the proper zero-based time index.
   void grid_read_data_array (const std::string &filename, const std::string &varname,
                              const int time_index, void* hbuf);
   /* Write data for a specific variable to a specific file. */

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -55,10 +55,14 @@ namespace scorpio {
   /* Called each timestep to update the timesnap for the last written output. */
   void pio_update_time(const std::string &filename, const Real time);
 
-  /* Read data for a specific variable from a specific file. */
-  void grid_read_data_array (const std::string &filename, const std::string &varname, const int time_index, void* hbuf);
+  // Read data for a specific variable from a specific file. To read data that
+  // isn't associated with a time index, set time_index to -1. Otherwise use
+  // the proper zero-based time index.
+  void grid_read_data_array (const std::string &filename, const std::string &varname,
+                             const int time_index, void* hbuf);
   /* Write data for a specific variable to a specific file. */
-  void grid_write_data_array(const std::string &filename, const std::string &varname, const Real* hbuf);
+  void grid_write_data_array(const std::string &filename, const std::string &varname,
+                             const Real* hbuf);
 
 extern "C" {
   /* Query whether the pio subsystem is inited or not */

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -280,7 +280,7 @@ contains
 
     type(c_ptr), intent(in) :: filename_in
     type(c_ptr), intent(in) :: varname_in
-    integer(kind=c_int), value, intent(in) :: time_index
+    integer(kind=c_int), value, intent(in) :: time_index ! zero-based
     type(c_ptr), intent(in) :: var_data_ptr
 
     character(len=256) :: filename
@@ -288,7 +288,7 @@ contains
 
     call convert_c_string(filename_in,filename)
     call convert_c_string(varname_in,varname)
-    call grid_read_data_array(filename,varname,var_data_ptr,time_index)
+    call grid_read_data_array(filename,varname,var_data_ptr,time_index+1)
 
   end subroutine grid_read_data_array_c2f
 !=====================================================================!

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -261,7 +261,7 @@ TEST_CASE("input_output_basic","io")
 
   // The diagnostic is not present in the field manager.  So we can't use the scorpio_input class
   // to read in the data.  Here we use raw IO routines to gather the data for testing.
-  auto f_diag_ins_h = get_diagnostic_input(io_comm, gm, 1, ins_params.get<std::string>("Filename"));
+  auto f_diag_ins_h = get_diagnostic_input(io_comm, gm, 0, ins_params.get<std::string>("Filename"));
 
   for (int ii=0;ii<num_lcols;++ii) {
     REQUIRE(std::abs(f1_host(ii)-(max_steps*dt+ii))<tol);
@@ -337,7 +337,7 @@ TEST_CASE("input_output_basic","io")
 
   // Check multisnap output; note, tt starts at 1 instead of 0 to follow netcdf time dimension indexing.
   AtmosphereInput multi_input(multi_params,field_manager);
-  for (int tt = 1; tt<=std::min(max_steps,10); tt++) {
+  for (int tt = 0; tt<std::min(max_steps,10); tt++) {
     multi_input.read_variables(tt);
     f1.sync_to_host();
     f2.sync_to_host();

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -344,20 +344,21 @@ TEST_CASE("input_output_basic","io")
     f3.sync_to_host();
     f4.sync_to_host();
 
+    int tt1 = tt + 1;
     for (int ii=0;ii<num_lcols;++ii) {
-      REQUIRE(std::abs(f1_host(ii)-(tt*dt+ii))<tol);
+      REQUIRE(std::abs(f1_host(ii)-(tt1*dt+ii))<tol);
       for (int jj=0;jj<num_levs;++jj) {
-        REQUIRE(std::abs(f3_host(ii,jj)-(ii+tt*dt + (jj+1)/10.))<tol);
-        REQUIRE(std::abs(f4_host(ii,jj)-(ii+tt*dt + (jj+1)/10.))<tol);
+        REQUIRE(std::abs(f3_host(ii,jj)-(ii+tt1*dt + (jj+1)/10.))<tol);
+        REQUIRE(std::abs(f4_host(ii,jj)-(ii+tt1*dt + (jj+1)/10.))<tol);
       }
     }
     for (int jj=0;jj<num_levs;++jj) {
-      REQUIRE(std::abs(f2_host(jj)-(tt*dt + (jj+1)/10.))<tol);
+      REQUIRE(std::abs(f2_host(jj)-(tt1*dt + (jj+1)/10.))<tol);
     }
   }
   multi_input.finalize();
 
-  // All Done 
+  // All Done
   scorpio::eam_pio_finalize();
 }
 
@@ -411,10 +412,10 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
   auto f2 = fm->get_field(fid2);
   auto f3 = fm->get_field(fid3);
   auto f4 = fm->get_field(fid4);
-  auto f1_host = f1.get_view<Real*,Host>(); 
-  auto f2_host = f2.get_view<Real*,Host>(); 
+  auto f1_host = f1.get_view<Real*,Host>();
+  auto f2_host = f2.get_view<Real*,Host>();
   auto f3_host = f3.get_view<Real**,Host>();
-  auto f4_host = f4.get_view<Pack**,Host>(); 
+  auto f4_host = f4.get_view<Pack**,Host>();
 
   for (int ii=0;ii<num_lcols;++ii) {
     f1_host(ii) = ii;

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -335,7 +335,7 @@ TEST_CASE("input_output_basic","io")
   min_input.finalize();
   reset_fields();
 
-  // Check multisnap output; note, tt starts at 1 instead of 0 to follow netcdf time dimension indexing.
+  // Check multisnap output
   AtmosphereInput multi_input(multi_params,field_manager);
   for (int tt = 0; tt<std::min(max_steps,10); tt++) {
     multi_input.read_variables(tt);


### PR DESCRIPTION
Fixes #1815