### PR TITLE
Fix find_filename_in_rpointer on Perlmutter.

### DIFF
--- a/components/scream/src/share/io/scream_io_utils.cpp
+++ b/components/scream/src/share/io/scream_io_utils.cpp
@@ -52,7 +52,9 @@ std::string find_filename_in_rpointer (
       }
     }
   }
-  comm.broadcast(&found,1,0);
+  int ifound = int(found);
+  comm.broadcast(&ifound,1,0);
+  found = bool(ifound);
   broadcast_string(content,comm,comm.root_rank());
 
   // If the history restart file is not found, it must be because the last


### PR DESCRIPTION
comm.broadcast of a boolean doesn't work on Perlmutter. Work
around this by broadcasting an integer instead.

Fixes #1661.

[BFB]