### PR TITLE
EAMxx: Integrate pg2 and SL transport into SCREAMv1.

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -464,6 +464,8 @@ _TESTS = {
             "ERP_D_Ln9.ne4_ne4.F2010-SCREAMv1",
             "ERS_Ln9.ne4_ne4.F2000-SCREAMv1-AQP1",
             "SMS_D_Ln9.ne4_ne4.F2010-SCREAMv1-noAero",
+            "ERP_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1",
+            "ERS_D_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1",
             )
     },
 
@@ -472,7 +474,8 @@ _TESTS = {
         "tests" : (
             #  "SMS_D_Ln2.ne30_ne30.F2000-SCREAMv1-AQP1", # Uncomment once IC file for ne30 is ready
             "ERS_Ln22.ne30_ne30.F2010-SCREAMv1",
-            "PEM_Ln9.ne30_ne30.F2010-SCREAMv1"
+            "PEM_Ln9.ne30_ne30.F2010-SCREAMv1",
+            "ERS_Ln22.ne30pg2_ne30pg2.F2010-SCREAMv1",
             )
     },
 

--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -60,7 +60,7 @@ CIME_VAR_RE = re.compile(r'[$][{](\w+)[}]')
 METADATA_ATTRIBS = ("type", "valid_values", "locked", "constraints", "inherit")
 
 ###############################################################################
-def do_cime_vars(entry, case, refine=False):
+def do_cime_vars(entry, case, refine=False, extra=None):
 ###############################################################################
     """
     For a parameter value, process any references to case values ("${CASEVAR}")
@@ -87,13 +87,26 @@ def do_cime_vars(entry, case, refine=False):
     {'foo': '1', 'subdict': {'bar': 'foo', 'baz': '1'}}
     """
     if type(entry) is dict:
+        changed_keys = []
         for k,v in entry.items():
-            entry[k] = do_cime_vars(v,case,refine)
+            # Apply replacement to the key.
+            k1 = do_cime_vars(k,case,refine,extra)
+            if (k1 != k): changed_keys.append((k,k1))
+            # Apply replacement to the value.
+            entry[k] = do_cime_vars(v,case,refine,extra)
+        # Handle changed keys outside the original loop since keys can't change
+        # in an items loop.
+        for e in changed_keys:
+            entry[e[1]] = entry[e[0]]
+            del entry[e[0]]
     elif type(entry) is str:
         m = CIME_VAR_RE.search(entry)
         while m:
             cime_var = m.groups()[0]
-            value = case.get_value(cime_var)
+            if type(extra) is dict and cime_var in extra:
+                value = extra[cime_var]
+            else:
+                value = case.get_value(cime_var)
             expect(value is not None,
                    "Cannot resolve XML entry '{}', CIME has no value for '{}'".format(entry, cime_var))
             entry = entry.replace("${{{}}}".format(cime_var), str(value))
@@ -752,6 +765,12 @@ def do_cime_vars_on_yaml_output_files(case,caseroot):
             if not os.path.exists(dst_yaml):
                 safe_copy(src_yaml,dst_yaml)
 
+    # Determine the physics grid type for use in CIME-var substitution.
+    pgt = 'GLL'
+    atm_grid = case.get_value('ATM_GRID')
+    if '.pg' in atm_grid:
+        pgt = 'PG' + atm_grid[-1]
+
     # Now loop over all output yaml files, and process any CIME var present (if any)
     for fn in out_files:
         # Get full name
@@ -759,9 +778,10 @@ def do_cime_vars_on_yaml_output_files(case,caseroot):
 
         # Load yaml file
         content = yaml.safe_load(open(fn_full,"r"))
-
+            
         # Replace possible CIME vars
-        do_cime_vars(content,case,refine=True)
+        do_cime_vars(content,case,refine=True,
+                     extra={'PHYSICS_GRID_TYPE': pgt})
 
         # Save YAML file
         ordered_dump(content, open(fn_full, "w"))

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -148,6 +148,7 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Basic options for each "physics" atm process -->
     <physics_proc_base inherit="atm_proc_base">
       <Grid>Physics GLL</Grid>
+      <Grid hgrid=".*pg2">Physics PG2</Grid>
     </physics_proc_base>
 
     <!-- Homme dynamics -->
@@ -180,7 +181,9 @@ tweaking their $case/namelist_scream.xml file.
     <spa inherit="physics_proc_base">
       <SPA__Remap__File>UNSET</SPA__Remap__File>
       <SPA__Remap__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc</SPA__Remap__File>
+      <SPA__Remap__File hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne4pg2_mono.20220714.nc</SPA__Remap__File>
       <SPA__Remap__File hgrid="ne30np4">none</SPA__Remap__File>
+      <SPA__Remap__File hgrid="ne30np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne30pg2_mono.20220714.nc</SPA__Remap__File>
       <SPA__Remap__File hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc</SPA__Remap__File>
       <SPA__Remap__File hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne512np4_mono_20220506.nc</SPA__Remap__File>
       <SPA__Data__File>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
@@ -226,6 +229,7 @@ tweaking their $case/namelist_scream.xml file.
   <Grids__Manager>
     <Type>Dynamics Driven</Type>
     <Reference__Grid>Physics GLL</Reference__Grid>
+    <Reference__Grid hgrid=".*pg2">Physics PG2</Reference__Grid>
     <Dynamics__Namelist__File__Name>./data/namelist.nl</Dynamics__Namelist__File__Name>
   </Grids__Manager>
 
@@ -256,6 +260,8 @@ tweaking their $case/namelist_scream.xml file.
     <bm                >0.0</bm>
     <ni_activated      >0.0</ni_activated>
     <nc_nuceat_tend    >0.0</nc_nuceat_tend>
+    <!-- SHOC internally inits TKE; just set to 0 here to signal it's not in the IC file -->
+    <tke               >0.0</tke>
     <!-- Note: these should be provided by surface models, but we init here to keep AD from reading from file -->
     <sfc_alb_dir_vis   >0.0</sfc_alb_dir_vis>
     <sfc_alb_dir_nir   >0.0</sfc_alb_dir_nir>
@@ -285,7 +291,7 @@ tweaking their $case/namelist_scream.xml file.
   <!-- Debug options for scream -->
   <Debug>
     <Atmosphere__DAG__Verbosity__Level>0</Atmosphere__DAG__Verbosity__Level>
-    <Atm__Log__Level valid_values="trace,debug,info,warn,error">info</Atm__Log__Level>
+    <Atm__Log__Level valid_values="trace,debug,info,warn,error">trace</Atm__Log__Level>
   </Debug>
 
   <!-- E3SM Simulation Settings -->
@@ -315,7 +321,9 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/init/screami_ne4np4L72_20220524.nc,
     <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220524.nc, -->
     <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220525.nc, -->
-    ${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20220524.nc
+    ${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20220524.nc,
+    ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne4pg2_mono.20220714.nc,
+    ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne30pg2_mono.20220714.nc
   </input_files>
 
   <!-- Homme control namelist -->
@@ -363,6 +371,12 @@ tweaking their $case/namelist_scream.xml file.
     <tstep_type>9</tstep_type>
     <vert_remap_q_alg>10</vert_remap_q_alg>
     <transport_alg>0</transport_alg>
+    <!-- pg2 settings -->
+    <cubed_sphere_map hgrid=".*pg2">2</cubed_sphere_map>
+    <!-- SL transport settings. SL defaults to on for pg2 configs. -->
+    <dt_tracer_factor constraints="ge 1" hgrid=".*pg2">6</dt_tracer_factor>
+    <hypervis_subcycle_q hgrid=".*pg2">6</hypervis_subcycle_q>
+    <transport_alg hgrid=".*pg2">12</transport_alg>  
   </ctl_nl>
 
 </namelist_defaults>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -291,7 +291,7 @@ tweaking their $case/namelist_scream.xml file.
   <!-- Debug options for scream -->
   <Debug>
     <Atmosphere__DAG__Verbosity__Level>0</Atmosphere__DAG__Verbosity__Level>
-    <Atm__Log__Level valid_values="trace,debug,info,warn,error">trace</Atm__Log__Level>
+    <Atm__Log__Level valid_values="trace,debug,info,warn,error">info</Atm__Log__Level>
   </Debug>
 
   <!-- E3SM Simulation Settings -->

--- a/components/scream/data/scream_default_output.yaml
+++ b/components/scream/data/scream_default_output.yaml
@@ -4,7 +4,7 @@ Casename: ${CASE}.scream.hi
 Averaging Type: Instant
 Max Snapshots Per File: 744 # One output every 31 days
 Fields:
-  Physics GLL:
+  Physics ${PHYSICS_GRID_TYPE}:
     Field Names:
       # HOMME
       - ps

--- a/components/scream/src/control/CMakeLists.txt
+++ b/components/scream/src/control/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SCREAM_CONTROL_SOURCES
   atmosphere_driver.cpp
   surface_coupling.cpp
   surface_coupling_export.cpp
+  fvphyshack.cpp
 )
 
 set(SCREAM_CONTROL_HEADERS

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -14,6 +14,8 @@
 #include "ekat/ekat_parse_yaml_file.hpp"
 #include "ekat/std_meta/ekat_std_utils.hpp"
 
+#include "control/fvphyshack.hpp"
+
 #include <fstream>
 
 namespace scream {
@@ -108,6 +110,13 @@ set_params(const ekat::ParameterList& atm_params)
   create_logger ();
 
   m_ad_status |= s_params_set;
+
+  const auto hgn = "Physics PG2";
+  fvphyshack = m_atm_params.sublist("Grids Manager").get<std::string>("Reference Grid") == hgn;
+  if (fvphyshack) {
+    // See the [rrtmgp active gases] note in dynamics/homme/atmosphere_dynamics_fv_phys.cpp.
+    fv_phys_rrtmgp_active_gases_init(m_atm_params);
+  }
 }
 
 void AtmosphereDriver::
@@ -236,13 +245,14 @@ void AtmosphereDriver::create_fields()
             "   grid name: " + req.grid + "\n");
         // Given request for group A on grid g1 to be an Import of
         // group B on grid g2, register each field in group B in the
-
         // field manager on grid g1.
         const auto& fm = m_field_mgrs.at(req.grid);
         const auto& rel_fm   = m_field_mgrs.at(req.src_grid);
         const auto& rel_info = rel_fm->get_groups_info().at(req.src_name);
 
-        auto r = m_grids_manager->create_remapper(req.src_grid,req.grid);
+        // In the case of pg2, can't use create_remapper. But the remapper is
+        // used only for a convenience function, anyway, create_tgt_fid.
+        auto r = fvphyshack ? nullptr : m_grids_manager->create_remapper(req.src_grid,req.grid);
         // Loop over all fields in group src_name on grid src_grid.
         for (const auto& fname : rel_info->m_fields_names) {
           // Get field on src_grid
@@ -250,9 +260,19 @@ void AtmosphereDriver::create_fields()
 
           // Build a FieldRequest for the same field on greq's grid,
           // and add it to the group of this request
-          auto fid = r->create_tgt_fid(f->get_header().get_identifier());
-          FieldRequest freq(fid,req.name,req.pack_size);
-          fm->register_field(freq);
+          if (fvphyshack) {
+            const auto& sfid = f->get_header().get_identifier();
+            auto dims = sfid.get_layout().dims();
+            dims[0] = fm->get_grid()->get_num_local_dofs();
+            FieldLayout fl(sfid.get_layout().tags(), dims);
+            FieldIdentifier fid(sfid.name(), fl, sfid.get_units(), req.grid);
+            FieldRequest freq(fid,req.name,req.pack_size);
+            fm->register_field(freq);
+          } else {
+            const auto fid = r->create_tgt_fid(f->get_header().get_identifier());
+            FieldRequest freq(fid,req.name,req.pack_size);
+            fm->register_field(freq);
+          }
         }
 
         // Now that the fields have been imported on this grid's GM,
@@ -323,11 +343,18 @@ void AtmosphereDriver::create_fields()
   // the internal fields/groups, and mark them as part of the RESTART group.
   for (const auto& f : m_atm_process_group->get_fields_in()) {
     const auto& fid = f.get_header().get_identifier();
-    auto fm = get_field_mgr(fid.get_grid_name());
+    const auto& gn = fid.get_grid_name();
+    if (fvphyshack and gn == "Physics CGLL") {
+      // CGLL is used only in the IC field for Homme.
+      continue;
+    }
+    auto fm = get_field_mgr(gn);
     fm->add_to_group(fid.name(),"RESTART");
   }
   for (const auto& g : m_atm_process_group->get_groups_in()) {
-    auto fm = get_field_mgr(g.grid_name());
+    const auto& gn = g.grid_name();
+    auto fm = get_field_mgr(gn);
+    if (fvphyshack and gn == "Physics CGLL") continue; // see above
     if (g.m_bundle) {
       fm->add_to_group(g.m_bundle->get_header().get_identifier().name(),"RESTART");
     } else {
@@ -338,7 +365,9 @@ void AtmosphereDriver::create_fields()
   }
   for (const auto& f : m_atm_process_group->get_internal_fields()) {
     const auto& fid = f.get_header().get_identifier();
-    auto fm = get_field_mgr(fid.get_grid_name());
+    const auto& gn = fid.get_grid_name();
+    if (fvphyshack and gn == "Physics CGLL") continue; // see above
+    auto fm = get_field_mgr(gn);
     fm->add_to_group(fid.name(),"RESTART");
   }
 
@@ -368,10 +397,20 @@ void AtmosphereDriver::initialize_output_managers () {
     // Signal that this is not a normal output, but the model restart one
     m_output_managers.emplace_back();
     auto& om = m_output_managers.back();
-    om.setup(m_atm_comm,restart_pl,m_field_mgrs,m_grids_manager,m_run_t0,m_case_t0,true);
+    if (fvphyshack) {
+      // Don't save CGLL fields from ICs to the restart file.
+      std::map<std::string,field_mgr_ptr> fms;
+      for (auto& it : m_field_mgrs) {
+        if (it.first == "Physics GLL") continue;
+        fms[it.first] = it.second;
+      }
+      om.setup(m_atm_comm,restart_pl,         fms,m_grids_manager,m_run_t0,m_case_t0,true);
+    } else {
+      om.setup(m_atm_comm,restart_pl,m_field_mgrs,m_grids_manager,m_run_t0,m_case_t0,true);
+    }
     om.setup_globals_map(m_atm_process_group->get_restart_extra_data());
   }
-
+  
   // Build one manager per output yaml file
   using vos_t = std::vector<std::string>;
   const auto& output_yaml_files = io_params.get<vos_t>("Output YAML Files",vos_t{});
@@ -407,6 +446,8 @@ initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0
   m_atm_logger->info("  [EAMxx] Run  start time stamp: " + run_t0.to_string());
   m_atm_logger->info("  [EAMxx] Case start time stamp: " + case_t0.to_string());
 
+  // See the [rrtmgp active gases] note in dynamics/homme/atmosphere_dynamics_fv_phys.cpp.
+  if (fvphyshack) fv_phys_rrtmgp_active_gases_set_restart(case_t0 < run_t0);
 
   // See if we need to print a DAG. We do this first, cause if any input
   // field is missing from the initial condition file, an error will be thrown.
@@ -517,6 +558,7 @@ void AtmosphereDriver::restart_model ()
   AtmosphereInput model_restart(m_atm_comm,rest_pl);
 
   for (auto& it : m_field_mgrs) {
+    if (fvphyshack and it.second->get_grid()->name() == "Physics GLL") continue;
     if (not it.second->has_group("RESTART")) {
       // No field needs to be restarted on this grid.
       continue;
@@ -633,13 +675,31 @@ void AtmosphereDriver::set_initial_conditions ()
       } else {
         EKAT_REQUIRE_MSG (false, "ERROR: invalid assignment for variable " + fname + ", only scalar double or string, or vector double arguments are allowed");
       }
-    } else {
+    } else if (not (fvphyshack and grid_name == "Physics PG2")) {
       // If this field is the parent of other subfields, we only read from file the subfields.
       auto c = f.get_header().get_children();
       if (c.size()==0) {
-        auto& this_grid_ic_fnames = ic_fields_names[fid.get_grid_name()];
+        auto& this_grid_ic_fnames = ic_fields_names[grid_name];
         if (not ekat::contains(this_grid_ic_fnames,fname)) {
           this_grid_ic_fnames.push_back(fname);
+        }
+      } else if (fvphyshack and grid_name == "Physics GLL") {
+        // [CGLL ICs in pg2] I tried doing something like this in
+        // HommeDynamics::set_grids, but I couldn't find the means to get the
+        // list of fields. I think the issue is that you can't access group
+        // objects until some registration period ends. So instead do it here,
+        // where the list is definitely available.
+        auto& this_grid_ic_fnames = ic_fields_names[grid_name];
+        for (const auto& e : c) {
+          const auto f = e.lock();
+          const auto& fid = f->get_identifier();
+          const auto& fname = fid.name();
+          if (ic_pl.isParameter(fname) and ic_pl.isType<double>(fname)) {
+            initialize_constant_field(fid, ic_pl);
+            fields_inited[grid_name].push_back(fname);
+          } else {
+            this_grid_ic_fnames.push_back(fname);
+          }
         }
       }
     }
@@ -692,7 +752,6 @@ void AtmosphereDriver::set_initial_conditions ()
             break;
           }
         }
-
       }
     }
   }
@@ -871,6 +930,13 @@ void AtmosphereDriver::initialize_atm_procs ()
 
   // Initialize the processes
   m_atm_process_group->initialize(m_current_ts, restarted_run ? RunType::Restarted : RunType::Initial);
+
+  if (fvphyshack) {
+    // [CGLL ICs in pg2] See related notes in atmosphere_dynamics.cpp.
+    const auto gn = "Physics GLL";
+    m_field_mgrs[gn]->clean_up();
+    m_field_mgrs.erase(gn);
+  }
 
   m_ad_status |= s_procs_inited;
 

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -14,6 +14,7 @@
 #include "ekat/ekat_parse_yaml_file.hpp"
 #include "ekat/std_meta/ekat_std_utils.hpp"
 
+#include "scream_config.h" // for SCREAM_CIME_BUILD
 #include "control/fvphyshack.hpp"
 
 #include <fstream>
@@ -113,10 +114,12 @@ set_params(const ekat::ParameterList& atm_params)
 
   const auto hgn = "Physics PG2";
   fvphyshack = m_atm_params.sublist("Grids Manager").get<std::string>("Reference Grid") == hgn;
+#ifdef SCREAM_CIME_BUILD
   if (fvphyshack) {
     // See the [rrtmgp active gases] note in dynamics/homme/atmosphere_dynamics_fv_phys.cpp.
     fv_phys_rrtmgp_active_gases_init(m_atm_params);
   }
+#endif
 }
 
 void AtmosphereDriver::
@@ -446,8 +449,10 @@ initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0
   m_atm_logger->info("  [EAMxx] Run  start time stamp: " + run_t0.to_string());
   m_atm_logger->info("  [EAMxx] Case start time stamp: " + case_t0.to_string());
 
+#ifdef SCREAM_CIME_BUILD
   // See the [rrtmgp active gases] note in dynamics/homme/atmosphere_dynamics_fv_phys.cpp.
   if (fvphyshack) fv_phys_rrtmgp_active_gases_set_restart(case_t0 < run_t0);
+#endif
 
   // See if we need to print a DAG. We do this first, cause if any input
   // field is missing from the initial condition file, an error will be thrown.

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -349,17 +349,12 @@ void AtmosphereDriver::create_fields()
   for (const auto& f : m_atm_process_group->get_fields_in()) {
     const auto& fid = f.get_header().get_identifier();
     const auto& gn = fid.get_grid_name();
-    if (fvphyshack and gn == "Physics CGLL") {
-      // CGLL is used only in the IC field for Homme.
-      continue;
-    }
     auto fm = get_field_mgr(gn);
     fm->add_to_group(fid.name(),"RESTART");
   }
   for (const auto& g : m_atm_process_group->get_groups_in()) {
     const auto& gn = g.grid_name();
     auto fm = get_field_mgr(gn);
-    if (fvphyshack and gn == "Physics CGLL") continue; // see above
     if (g.m_bundle) {
       fm->add_to_group(g.m_bundle->get_header().get_identifier().name(),"RESTART");
     } else {
@@ -371,7 +366,6 @@ void AtmosphereDriver::create_fields()
   for (const auto& f : m_atm_process_group->get_internal_fields()) {
     const auto& fid = f.get_header().get_identifier();
     const auto& gn = fid.get_grid_name();
-    if (fvphyshack and gn == "Physics CGLL") continue; // see above
     auto fm = get_field_mgr(gn);
     fm->add_to_group(fid.name(),"RESTART");
   }

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -112,13 +112,15 @@ set_params(const ekat::ParameterList& atm_params)
 
   m_ad_status |= s_params_set;
 
+#ifdef SCREAM_CIME_BUILD
   const auto hgn = "Physics PG2";
   fvphyshack = m_atm_params.sublist("Grids Manager").get<std::string>("Reference Grid") == hgn;
-#ifdef SCREAM_CIME_BUILD
   if (fvphyshack) {
     // See the [rrtmgp active gases] note in dynamics/homme/atmosphere_dynamics_fv_phys.cpp.
     fv_phys_rrtmgp_active_gases_init(m_atm_params);
   }
+#else
+  fvphyshack = false;
 #endif
 }
 

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -14,6 +14,11 @@
 #include "ekat/ekat_parse_yaml_file.hpp"
 #include "ekat/std_meta/ekat_std_utils.hpp"
 
+// The global variable fvphyshack is used to help the initial pgN implementation
+// work around some current AD constraints. Search the code for "fvphyshack" to
+// find blocks that eventually should be removed in favor of a design that
+// accounts for pg2. Some blocks may turn out to be unnecessary, and I simply
+// didn't realize I could do without the workaround.
 #include "scream_config.h" // for SCREAM_CIME_BUILD
 #include "control/fvphyshack.hpp"
 

--- a/components/scream/src/control/fvphyshack.cpp
+++ b/components/scream/src/control/fvphyshack.cpp
@@ -1,0 +1,3 @@
+namespace scream {
+bool fvphyshack;
+}

--- a/components/scream/src/control/fvphyshack.hpp
+++ b/components/scream/src/control/fvphyshack.hpp
@@ -1,0 +1,7 @@
+#include "ekat/ekat_parameter_list.hpp"
+
+namespace scream {
+extern bool fvphyshack;
+void fv_phys_rrtmgp_active_gases_init(const ekat::ParameterList& p);
+void fv_phys_rrtmgp_active_gases_set_restart(const bool restart);
+}

--- a/components/scream/src/dynamics/homme/CMakeLists.txt
+++ b/components/scream/src/dynamics/homme/CMakeLists.txt
@@ -186,6 +186,7 @@ macro (CreateDynamicsLib HOMME_TARGET NP PLEV QSIZE)
 
     set (SCREAM_DYNAMICS_SOURCES
       ${SCREAM_DYNAMICS_SRC_DIR}/atmosphere_dynamics.cpp
+      ${SCREAM_DYNAMICS_SRC_DIR}/atmosphere_dynamics_fv_phys.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/physics_dynamics_remapper.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/dynamics_driven_grids_manager.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/interface/homme_context_mod.F90

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -274,7 +274,7 @@ size_t HommeDynamics::requested_buffer_size_in_bytes() const
   fbm.request_size(diag.requested_buffer_size());
   fbm.request_size(ff.requested_buffer_size());
   fbm.request_size(vrm.requested_buffer_size());
-  // Functors that whose creation depends on the Homme namelist.
+  // Functors whose creation depends on the Homme namelist.
   if (params.transport_alg == 0) {
     auto& esf = c.create_if_not_there<EulerStepFunctor>(num_elems);
     fbm.request_size(esf.requested_buffer_size());

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -8,6 +8,7 @@
 #include "SimulationParams.hpp"
 #include "ElementsForcing.hpp"
 #include "EulerStepFunctor.hpp"
+#include "ComposeTransport.hpp"
 #include "Diagnostics.hpp"
 #include "DirkFunctor.hpp"
 #include "ForcingFunctor.hpp"
@@ -49,7 +50,7 @@ namespace scream
 {
 
 HommeDynamics::HommeDynamics (const ekat::Comm& comm, const ekat::ParameterList& params)
-  : AtmosphereProcess(comm, params)
+  : AtmosphereProcess(comm, params), m_phys_grid_pgN(-1)
 {
   // This class needs Homme's context, so register as a user
   HommeContextUser::singleton().add_user();
@@ -70,8 +71,10 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
   // Grab dynamics and reference grid
   const auto dgn = "Dynamics";
   m_dyn_grid = grids_manager->get_grid(dgn);
-  m_ref_grid = grids_manager->get_reference_grid();
-  const auto& rgn = m_ref_grid->name();
+  m_phys_grid = grids_manager->get_reference_grid();
+  m_cgll_grid = grids_manager->get_grid("Physics GLL");
+
+  fv_phys_set_grids();
 
   // Init prim structures
   // TODO: they should not be inited yet; should we error out if they are?
@@ -112,7 +115,7 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
   auto Q = kg/kg;
   Q.set_string("kg/kg");
 
-  const int ncols = m_ref_grid->get_num_local_dofs();
+  const int ncols = m_phys_grid->get_num_local_dofs();
   const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
   const int nlev_mid = m_dyn_grid->get_num_vertical_levels();
   const int nlev_int = nlev_mid+1;
@@ -162,19 +165,38 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
   const auto s2 = s*s;
 
   // Note: qv is needed to transform T<->Theta
-  add_field<Updated> ("horiz_winds",   FL({COL,CMP, LEV},{ncols,2,nlev_mid}),m/s,   rgn,N);
-  add_field<Updated> ("T_mid",         FL({COL,     LEV},{ncols,  nlev_mid}),K,     rgn,N);
-  add_field<Computed>("pseudo_density",FL({COL,     LEV},{ncols,  nlev_mid}),Pa,    rgn,N);
-  add_field<Computed>("pseudo_density_dry",FL({COL, LEV},{ncols,  nlev_mid}),Pa,    rgn,N);
-  add_field<Updated> ("ps",            FL({COL         },{ncols           }),Pa,    rgn);
-  add_field<Required>("qv",            FL({COL,     LEV},{ncols,  nlev_mid}),Q,     rgn,"tracers",N);
-  add_field<Required>("phis",          FL({COL         },{ncols           }),m2/s2, rgn);
-  add_field<Computed>("p_int",         FL({COL,    ILEV},{ncols,  nlev_int}),Pa,    rgn,N);
-  add_field<Computed>("p_mid",         FL({COL,     LEV},{ncols,  nlev_mid}),Pa,    rgn,N);
-  add_field<Computed>("p_dry_int",     FL({COL,    ILEV},{ncols,  nlev_int}),Pa,    rgn,N);
-  add_field<Computed>("p_dry_mid",     FL({COL,     LEV},{ncols,  nlev_mid}),Pa,    rgn,N);
-  add_field<Computed>("omega",         FL({COL,     LEV},{ncols,  nlev_mid}),Pa/s,  rgn,N);
-  add_group<Updated>("tracers",rgn,N, Bundling::Required);
+
+  const auto& pgn = m_phys_grid->name();
+  add_field<Updated> ("horiz_winds",   FL({COL,CMP, LEV},{ncols,2,nlev_mid}),m/s,   pgn,N);
+  add_field<Updated> ("T_mid",         FL({COL,     LEV},{ncols,  nlev_mid}),K,     pgn,N);
+  add_field<Computed>("pseudo_density",FL({COL,     LEV},{ncols,  nlev_mid}),Pa,    pgn,N);
+  add_field<Computed>("pseudo_density_dry",FL({COL, LEV},{ncols,  nlev_mid}),Pa,    pgn,N);
+  add_field<Updated> ("ps",            FL({COL         },{ncols           }),Pa,    pgn);
+  add_field<Updated >("qv",            FL({COL,     LEV},{ncols,  nlev_mid}),Q,     pgn,"tracers",N);
+  add_field<Updated >("phis",          FL({COL         },{ncols           }),m2/s2, pgn);
+  add_field<Computed>("p_int",         FL({COL,    ILEV},{ncols,  nlev_int}),Pa,    pgn,N);
+  add_field<Computed>("p_mid",         FL({COL,     LEV},{ncols,  nlev_mid}),Pa,    pgn,N);
+  add_field<Computed>("p_dry_int",     FL({COL,    ILEV},{ncols,  nlev_int}),Pa,    pgn,N);
+  add_field<Computed>("p_dry_mid",     FL({COL,     LEV},{ncols,  nlev_mid}),Pa,    pgn,N);
+  add_field<Computed>("omega",         FL({COL,     LEV},{ncols,  nlev_mid}),Pa/s,  pgn,N);
+  add_group<Updated>("tracers",pgn,N, Bundling::Required);
+
+  if (fv_phys_active()) {
+    // [CGLL ICs in pg2] Read CGLL IC data even though our in/out format is
+    // pgN. I don't want to read these directly from the netcdf file because
+    // doing so may conflict with additional IC mechanisms in the AD, e.g.,
+    // init'ing a field to a constant.
+    const auto& rgn = m_cgll_grid->name();
+    const auto nc = m_cgll_grid->get_num_local_dofs();
+    add_field<Required>("horiz_winds",   FL({COL,CMP, LEV},{nc,2,nlev_mid}),m/s,   rgn,N);
+    add_field<Required>("T_mid",         FL({COL,     LEV},{nc,  nlev_mid}),K,     rgn,N);
+    add_field<Required>("ps",            FL({COL         },{nc           }),Pa,    rgn);
+    add_field<Required>("phis",          FL({COL         },{nc           }),m2/s2, rgn);
+    add_group<Required>("tracers",rgn,N, Bundling::Required, DerivationType::Import, "tracers", pgn);
+    fv_phys_rrtmgp_active_gases_init(grids_manager);
+    // This is needed for the dp_ref init in initialize_homme_state.
+    add_field<Computed>("pseudo_density",FL({COL,     LEV},{nc,  nlev_mid}),Pa,    rgn,N);
+  }
 
   // Dynamics grid states
   create_helper_field("v_dyn",        {EL,TL,CMP,GP,GP,LEV}, {nelem,NTL,2,NP,NP,nlev_mid}, dgn);
@@ -211,16 +233,18 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
     add_internal_field (m_helper_fields.at("w_int_dyn").subfield(1,tl.n0,true));
   }
 
-  // Dynamics backs out tendencies from the states, and passes those to Homme.
-  // After Homme completes, we remap the updated state to the ref grid.
-  // Thus, is more convenient to use two different remappers: the pd remapper
-  // will remap into Homme's forcing views, while the dp remapper will remap
-  // from Homme's states.
-  m_p2d_remapper = grids_manager->create_remapper(m_ref_grid,m_dyn_grid);
-  m_d2p_remapper = grids_manager->create_remapper(m_dyn_grid,m_ref_grid);
-
+  if (not fv_phys_active()) {
+    // Dynamics backs out tendencies from the states, and passes those to Homme.
+    // After Homme completes, we remap the updated state to the ref grid.  Thus,
+    // is more convenient to use two different remappers: the pd remapper will
+    // remap into Homme's forcing views, while the dp remapper will remap from
+    // Homme's states.
+    m_p2d_remapper = grids_manager->create_remapper(m_phys_grid,m_dyn_grid);
+    m_d2p_remapper = grids_manager->create_remapper(m_dyn_grid,m_phys_grid);
+  }
+  
   // Create separate remapper for Initial Conditions
-  m_ic_remapper = grids_manager->create_remapper(m_ref_grid,m_dyn_grid);
+  m_ic_remapper = grids_manager->create_remapper(m_cgll_grid,m_dyn_grid);
 }
 
 size_t HommeDynamics::requested_buffer_size_in_bytes() const
@@ -233,7 +257,6 @@ size_t HommeDynamics::requested_buffer_size_in_bytes() const
   const auto num_elems = c.get<Elements>().num_elems();
 
   auto& caar = c.create_if_not_there<CaarFunctor>(num_elems,params);
-  auto& esf  = c.create_if_not_there<EulerStepFunctor>(num_elems);
   auto& hvf  = c.create_if_not_there<HyperviscosityFunctor>(num_elems, params);
   auto& ff   = c.create_if_not_there<ForcingFunctor>(num_elems, num_elems, params.qsize);
   auto& diag = c.create_if_not_there<Diagnostics> (num_elems,params.theta_hydrostatic_mode);
@@ -247,16 +270,24 @@ size_t HommeDynamics::requested_buffer_size_in_bytes() const
   // return the total bytes using the calculated buffer size.
   auto& fbm  = c.create_if_not_there<FunctorsBuffersManager>();
   fbm.request_size(caar.requested_buffer_size());
-  fbm.request_size(esf.requested_buffer_size());
   fbm.request_size(hvf.requested_buffer_size());
   fbm.request_size(diag.requested_buffer_size());
   fbm.request_size(ff.requested_buffer_size());
   fbm.request_size(vrm.requested_buffer_size());
+  // Functors that whose creation depends on the Homme namelist.
+  if (params.transport_alg == 0) {
+    auto& esf = c.create_if_not_there<EulerStepFunctor>(num_elems);
+    fbm.request_size(esf.requested_buffer_size());
+  } else {
+    auto& ct = c.create_if_not_there<ComposeTransport>(num_elems);
+    fbm.request_size(ct.requested_buffer_size());
+  }
   if (need_dirk) {
     // Create dirk functor only if needed
     auto& dirk = c.create_if_not_there<DirkFunctor>(num_elems);
     fbm.request_size(dirk.requested_buffer_size());
   }
+  fv_phys_requested_buffer_size_in_bytes();
 
   return fbm.allocated_size()*sizeof(Real);
 }
@@ -279,11 +310,11 @@ void HommeDynamics::init_buffers(const ATMBufferManager &buffer_manager)
 void HommeDynamics::initialize_impl (const RunType run_type)
 {
   const auto& dgn = m_dyn_grid->name();
-  const auto& rgn = m_ref_grid->name();
+  const auto& pgn = m_phys_grid->name();
 
   // Use common/shorter names for tracers.
-  alias_group_in  ("tracers",rgn,"Q");
-  alias_group_out ("tracers",rgn,"Q");
+  alias_group_in  ("tracers",pgn,"Q");
+  alias_group_out ("tracers",pgn,"Q");
 
   // Grab handles of some Homme data structure
   const auto& c       = Homme::Context::singleton();
@@ -303,18 +334,21 @@ void HommeDynamics::initialize_impl (const RunType run_type)
   //          p_mid by first remapping the restarted dp3d_dyn back to ref grid, and using
   //          that value to compute p_mid. Or, perhaps easier, write p_mid to restart file.
   EKAT_REQUIRE_MSG (
-      get_field_out("pseudo_density").get_header().get_tracking().get_providers().size()==1,
+      get_field_out("pseudo_density",pgn).get_header().get_tracking().get_providers().size()==1,
       "Error! Someone other than Dynamics is trying to update the pseudo_density.\n");
 
   // The groups 'tracers' and 'tracers_mass_dyn' should contain the same fields
-  EKAT_REQUIRE_MSG(not get_group_out("Q",rgn).m_info->empty(),
+  EKAT_REQUIRE_MSG(not get_group_out("Q",pgn).m_info->empty(),
     "Error! There should be at least one tracer (qv) in the tracers group.\n");
 
   // Create remaining internal fields
   constexpr int NGP  = HOMMEXX_NP;
   const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
-  const int ncols = m_ref_grid->get_num_local_dofs();
+  const int ncols = m_phys_grid->get_num_local_dofs();
   const int nlevs = m_dyn_grid->get_num_vertical_levels();
+  assert(nlevs == m_dyn_grid->get_num_vertical_levels());
+  assert(nlevs == m_cgll_grid->get_num_vertical_levels());
+  assert(nlevs == m_phys_grid->get_num_vertical_levels());
   const int qsize = params.qsize;
 
   using namespace ShortFieldTagsNames;
@@ -322,49 +356,53 @@ void HommeDynamics::initialize_impl (const RunType run_type)
   create_helper_field("FT_dyn",{EL,    GP,GP,LEV},{nelem,      NGP,NGP,nlevs},dgn);
   create_helper_field("FM_dyn",{EL,CMP,GP,GP,LEV},{nelem,    3,NGP,NGP,nlevs},dgn);
   create_helper_field("Q_dyn" ,{EL,CMP,GP,GP,LEV},{nelem,qsize,NGP,NGP,nlevs},dgn);
-  // Tendencies for temperature and momentum computed on ref grid
-  create_helper_field("FT_ref",{COL,LEV},    {ncols,  nlevs},rgn);
-  create_helper_field("FM_ref",{COL,CMP,LEV},{ncols,3,nlevs},rgn);
+  // Tendencies for temperature and momentum computed on physics grid
+  create_helper_field("FT_phys",{COL,LEV},    {ncols,  nlevs},pgn);
+  create_helper_field("FM_phys",{COL,CMP,LEV},{ncols,3,nlevs},pgn);
 
   // Unfortunately, Homme *does* use FM_z even in hydrostatic mode (missing ifdef).
   // Later, it computes diags on w, so if FM_w contains NaN's, repro sum in Homme
   // will crap out. To prevent that, set FM_z=0
-  m_helper_fields.at("FM_ref").get_component(2).deep_copy<Real>(0.0);
+  m_helper_fields.at("FM_phys").get_component(2).deep_copy<Real>(0.0);
 
-  // Setup the p2d and d2p remappers
-  m_p2d_remapper->registration_begins();
-  m_d2p_remapper->registration_begins();
-
-  // ftype==FORCING_0:
-  //  1) remap Q_rgn->Q_dyn
-  //  2) compute FQ_dyn=(Q_dyn-Q_dyn_old)/dt
-  // ftype!=FORCING_0:
-  //  1) compute FQ_rgn=Q_rgn-Q_rgn_old
-  //  2) remap FQ_rgn->FQ_dyn
-  //  3) Q_dyn=Q_dyn_old+FQ_dyn
-  if (params.ftype==Homme::ForcingAlg::FORCING_2) {
-    // Need a tmp for dQ_rgn
-    using namespace ShortFieldTagsNames;
-    create_helper_field("FQ_ref",{COL,CMP,LEV},{ncols,qsize,nlevs},rgn);
-    m_p2d_remapper->register_field(m_helper_fields.at("FQ_ref"),m_helper_fields.at("FQ_dyn"));
+  if (fv_phys_active()) {
+    fv_phys_initialize_impl();
   } else {
-    // Can remap Q directly into FQ, tendency computed in pre_process step
-    m_p2d_remapper->register_field(*get_group_out("Q",rgn).m_bundle,m_helper_fields.at("FQ_dyn"));
+    // Setup the p2d and d2p remappers
+    m_p2d_remapper->registration_begins();
+    m_d2p_remapper->registration_begins();
+
+    // ftype==FORCING_0:
+    //  1) remap Q_rgn->Q_dyn
+    //  2) compute FQ_dyn=(Q_dyn-Q_dyn_old)/dt
+    // ftype!=FORCING_0:
+    //  1) compute FQ_rgn=Q_rgn-Q_rgn_old
+    //  2) remap FQ_rgn->FQ_dyn
+    //  3) Q_dyn=Q_dyn_old+FQ_dyn
+    if (params.ftype==Homme::ForcingAlg::FORCING_2) {
+      // Need a tmp for dQ_phys
+      using namespace ShortFieldTagsNames;
+      create_helper_field("FQ_phys",{COL,CMP,LEV},{ncols,qsize,nlevs},pgn);
+      m_p2d_remapper->register_field(m_helper_fields.at("FQ_phys"),m_helper_fields.at("FQ_dyn"));
+    } else {
+      // Can remap Q directly into FQ, tendency computed in pre_process step
+      m_p2d_remapper->register_field(*get_group_out("Q",pgn).m_bundle,m_helper_fields.at("FQ_dyn"));
+    }
+    m_p2d_remapper->register_field(m_helper_fields.at("FT_phys"),m_helper_fields.at("FT_dyn"));
+    m_p2d_remapper->register_field(m_helper_fields.at("FM_phys"),m_helper_fields.at("FM_dyn"));
+
+    // NOTE: for states, if/when we can remap subfields, we can remap the corresponding internal fields,
+    //       which are subviews of the corresponding helper field at time slice np1
+    m_d2p_remapper->register_field(m_helper_fields.at("vtheta_dp_dyn"),get_field_out("T_mid"));
+    m_d2p_remapper->register_field(m_helper_fields.at("v_dyn"),get_field_out("horiz_winds"));
+    m_d2p_remapper->register_field(m_helper_fields.at("dp3d_dyn"), get_field_out("pseudo_density"));
+    m_d2p_remapper->register_field(m_helper_fields.at("ps_dyn"), get_field_out("ps"));
+    m_d2p_remapper->register_field(m_helper_fields.at("Q_dyn"),*get_group_out("Q",pgn).m_bundle);
+    m_d2p_remapper->register_field(m_helper_fields.at("omega_dyn"), get_field_out("omega"));
+
+    m_p2d_remapper->registration_ends();
+    m_d2p_remapper->registration_ends();
   }
-  m_p2d_remapper->register_field(m_helper_fields.at("FT_ref"),m_helper_fields.at("FT_dyn"));
-  m_p2d_remapper->register_field(m_helper_fields.at("FM_ref"),m_helper_fields.at("FM_dyn"));
-
-  // NOTE: for states, if/when we can remap subfields, we can remap the corresponding internal fields,
-  //       which are subviews of the corresponding helper field at time slice np1
-  m_d2p_remapper->register_field(m_helper_fields.at("vtheta_dp_dyn"),get_field_out("T_mid"));
-  m_d2p_remapper->register_field(m_helper_fields.at("v_dyn"),get_field_out("horiz_winds"));
-  m_d2p_remapper->register_field(m_helper_fields.at("dp3d_dyn"), get_field_out("pseudo_density"));
-  m_d2p_remapper->register_field(m_helper_fields.at("ps_dyn"), get_field_out("ps"));
-  m_d2p_remapper->register_field(m_helper_fields.at("Q_dyn"),*get_group_out("Q",rgn).m_bundle);
-  m_d2p_remapper->register_field(m_helper_fields.at("omega_dyn"), get_field_out("omega"));
-
-  m_p2d_remapper->registration_ends();
-  m_d2p_remapper->registration_ends();
 
   // Sets the scream views into the hommexx internal data structures
   init_homme_views ();
@@ -379,6 +417,23 @@ void HommeDynamics::initialize_impl (const RunType run_type)
   // Complete homme model initialization
   prim_init_model_f90 ();
 
+  if (fv_phys_active()) {
+    fv_phys_dyn_to_fv_phys(run_type != RunType::Initial);
+    // [CGLL ICs in pg2] Remove the CGLL fields from the process. The AD has a
+    // separate fvphyshack-based line to remove the whole CGLL FM. The intention
+    // is to clear the view memory on the device, but I don't know if these two
+    // steps are enough.
+    //   We might end up needing these fields, anyway, for dynamics
+    // output. Alternatively, it might be more efficient to make some of the
+    // dynamics helper fields Computed and output on the dynamics grid. Worse
+    // for I/O but better for device memory.
+    const auto& rgn = m_cgll_grid->name();
+    for (const auto& f : {"horiz_winds", "T_mid", "ps", "phis"})
+      remove_field(f, rgn);
+    remove_group("tracers", rgn);
+    fv_phys_rrtmgp_active_gases_remap();
+  }
+
   // Set up field property checks
   // Note: We are seeing near epsilon negative values in a handful of places,
   // The strategy is to
@@ -392,13 +447,13 @@ void HommeDynamics::initialize_impl (const RunType run_type)
   //       are added here. To avoid this assumption, we need a more flexible lower bound
   //       check, which has one LB for check and one LB for repair.
   const Real tol = -1e-17;
-  const auto& Q = *get_group_out("Q",rgn).m_bundle;
-  auto lb_check = std::make_shared<FieldLowerBoundCheck>(Q,m_ref_grid,tol,false);
-  auto lb_repair = std::make_shared<FieldPositivityCheck>(Q,m_ref_grid,true);
+  const auto& Q = *get_group_out("Q",pgn).m_bundle;
+  auto lb_check = std::make_shared<FieldLowerBoundCheck>(Q,m_phys_grid,tol,false);
+  auto lb_repair = std::make_shared<FieldPositivityCheck>(Q,m_phys_grid,true);
   add_postcondition_check<CheckAndRepairWrapper>(lb_check,lb_repair);
-  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_ref_grid,140.0, 500.0,false);
-  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("horiz_winds"),m_ref_grid,-400.0, 400.0,false);
-  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("ps"),m_ref_grid,40000.0, 110000.0,false);
+  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("T_mid",pgn),m_phys_grid,140.0, 500.0,false);
+  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("horiz_winds",pgn),m_phys_grid,-400.0, 400.0,false);
+  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("ps"),m_phys_grid,40000.0, 110000.0,false);
 }
 
 void HommeDynamics::run_impl (const int dt)
@@ -475,19 +530,19 @@ void HommeDynamics::homme_pre_process (const int dt) {
   const auto& c = Context::singleton();
   const auto& params = c.get<SimulationParams>();
 
-  const int ncols = m_ref_grid->get_num_local_dofs();
-  const int nlevs = m_ref_grid->get_num_vertical_levels();
+  const int ncols = m_phys_grid->get_num_local_dofs();
+  const int nlevs = m_phys_grid->get_num_vertical_levels();
   const int npacks = ekat::PackInfo<N>::num_packs(nlevs);
 
-  const auto& rgn = m_ref_grid->name();
+  const auto& pgn = m_phys_grid->name();
 
   // At the beginning of the step, FT and FM store T_prev and V_prev,
   // the temperature and (3d) velocity at the end of the previous
   // Homme step
-  auto T  = get_field_in("T_mid").get_view<const Pack**>();
-  auto v  = get_field_in("horiz_winds").get_view<const Pack***>();
-  auto FT = m_helper_fields.at("FT_ref").get_view<Pack**>();
-  auto FM = m_helper_fields.at("FM_ref").get_view<Pack***>();
+  auto T  = get_field_in("T_mid",pgn).get_view<const Pack**>();
+  auto v  = get_field_in("horiz_winds",pgn).get_view<const Pack***>();
+  auto FT = m_helper_fields.at("FT_phys").get_view<Pack**>();
+  auto FM = m_helper_fields.at("FM_phys").get_view<Pack***>();
 
   // If there are other atm procs updating the vertical velocity,
   // then we need to compute forcing for w as well
@@ -516,22 +571,26 @@ void HommeDynamics::homme_pre_process (const int dt) {
   });
 
   const auto ftype = params.ftype;
-  if (ftype==Homme::ForcingAlg::FORCING_2) {
-    const auto Q  = get_group_in("Q",rgn).m_bundle->get_view<const Pack***>();
-    const auto FQ = m_helper_fields.at("FQ_ref").get_view<Pack***>();
-    const int qsize = Q.extent(1);
-    Kokkos::parallel_for(Kokkos::RangePolicy<>(0,ncols*qsize*npacks),
-                         KOKKOS_LAMBDA (const int idx) {
-      const int icol =  idx / (qsize*npacks);
-      const int iq   = (idx / (npacks)) % qsize;
-      const int ilev = idx % npacks;
-      // Recall: at this point FQ stores Q_ref at the end of previous homme step
-      FQ(icol,iq,ilev) = Q(icol,iq,ilev) - FQ(icol,iq,ilev);
-    });
-  }
 
-  // Remap FT, FM, and Q (or FQ, depending on ftype)
-  m_p2d_remapper->remap(true);
+  if (fv_phys_active()) {
+    fv_phys_pre_process();
+  } else {
+    if (ftype==Homme::ForcingAlg::FORCING_2) {
+      const auto Q  = get_group_in("Q",pgn).m_bundle->get_view<const Pack***>();
+      const auto FQ = m_helper_fields.at("FQ_phys").get_view<Pack***>();
+      const int qsize = params.qsize;
+      Kokkos::parallel_for(Kokkos::RangePolicy<>(0,ncols*qsize*npacks),
+                           KOKKOS_LAMBDA (const int idx) {
+        const int icol =  idx / (qsize*npacks);
+        const int iq   = (idx / (npacks)) % qsize;
+        const int ilev = idx % npacks;
+        // Recall: at this point FQ stores Q_ref at the end of previous homme step
+        FQ(icol,iq,ilev) = Q(icol,iq,ilev) - FQ(icol,iq,ilev);
+      });
+    }
+    // Remap FT, FM, and Q (or FQ, depending on ftype)
+    m_p2d_remapper->remap(true);
+  }
 
   auto& tl = c.get<TimeLevel>();
   auto& ff = c.get<ForcingFunctor>();
@@ -581,17 +640,18 @@ void HommeDynamics::homme_pre_process (const int dt) {
       Kokkos::fence();
       break;
     case ForcingAlg::FORCING_2:
-      Kokkos::parallel_for(Kokkos::RangePolicy<>(0,Q.size()),KOKKOS_LAMBDA(const int idx) {
-        const int ie = idx / (qsize*NP*NP*NVL);
-        const int iq = (idx / (NP*NP*NVL)) % qsize;
-        const int ip = (idx / (NP*NVL)) % NP;
-        const int jp = (idx / NVL) % NP;
-        const int k  =  idx % NVL;
+      if (not fv_phys_active()) {
+        Kokkos::parallel_for(Kokkos::RangePolicy<>(0,Q.size()),KOKKOS_LAMBDA(const int idx) {
+          const int ie = idx / (qsize*NP*NP*NVL);
+          const int iq = (idx / (NP*NP*NVL)) % qsize;
+          const int ip = (idx / (NP*NVL)) % NP;
+          const int jp = (idx / NVL) % NP;
+          const int k  =  idx % NVL;
 
-        // So far, FQ contains the remap of Q_ref_new - Q_ref_old. Add Q_dyn_old to get new state.
-        FQ(ie,iq,ip,jp,k) += Q_dyn(ie,iq,ip,jp,k);
-      });
-
+          // So far, FQ contains the remap of Q_ref_new - Q_ref_old. Add Q_dyn_old to get new state.
+          FQ(ie,iq,ip,jp,k) += Q_dyn(ie,iq,ip,jp,k);
+        });
+      }
       // Hard adjustment of qdp
       ff.tracers_forcing(dt,n0,n0_qdp,true,params.moisture);
       break;
@@ -602,13 +662,17 @@ void HommeDynamics::homme_pre_process (const int dt) {
 }
 
 void HommeDynamics::homme_post_process () {
-  const auto& rgn = m_ref_grid->name();
+  const auto& pgn = m_phys_grid->name();
   const auto& c = Homme::Context::singleton();
   const auto& params = c.get<Homme::SimulationParams>();
   const auto& tl = c.get<Homme::TimeLevel>();
 
-  // Remap outputs to ref grid
-  m_d2p_remapper->remap(true);
+  if (fv_phys_active()) {
+    fv_phys_post_process();
+  } else {
+    // Remap outputs to ref grid
+    m_d2p_remapper->remap(true);
+  }
 
   constexpr int N = HOMMEXX_PACK_SIZE;
   using KT = KokkosTypes<DefaultDevice>;
@@ -628,6 +692,8 @@ void HommeDynamics::homme_post_process () {
     get_internal_field("w_int_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
   }
 
+  if (fv_phys_active()) return;
+  
   // Convert VTheta_dp->T, store T,uv, and possibly w in FT, FM,
   // compute p_int on ref grid.
   const auto dp_view = get_field_out("pseudo_density").get_view<Pack**>();
@@ -636,15 +702,15 @@ void HommeDynamics::homme_post_process () {
   const auto dp_dry_view    = get_field_out("pseudo_density_dry").get_view<Pack**>();
   const auto p_dry_int_view = get_field_out("p_dry_int").get_view<Pack**>();
   const auto p_dry_mid_view = get_field_out("p_dry_mid").get_view<Pack**>();
-  const auto Q_view   = get_group_out("Q",rgn).m_bundle->get_view<Pack***>();
+  const auto Q_view   = get_group_out("Q",pgn).m_bundle->get_view<Pack***>();
 
   const auto T_view  = get_field_out("T_mid").get_view<Pack**>();
   const auto v_view  = get_field_out("horiz_winds").get_view<Pack***>();
-  const auto T_prev_view = m_helper_fields.at("FT_ref").get_view<Pack**>();
-  const auto V_prev_view = m_helper_fields.at("FM_ref").get_view<Pack***>();
+  const auto T_prev_view = m_helper_fields.at("FT_phys").get_view<Pack**>();
+  const auto V_prev_view = m_helper_fields.at("FM_phys").get_view<Pack***>();
 
-  const auto ncols = m_ref_grid->get_num_local_dofs();
-  const auto nlevs = m_ref_grid->get_num_vertical_levels();
+  const auto ncols = m_phys_grid->get_num_local_dofs();
+  const auto nlevs = m_phys_grid->get_num_vertical_levels();
   const auto npacks= ekat::PackInfo<N>::num_packs(nlevs);
 
   using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
@@ -706,15 +772,11 @@ void HommeDynamics::homme_post_process () {
     });
   });
 
-  auto s = Homme::Context::singleton().get<Homme::ElementsState>();
-  auto tr = Homme::Context::singleton().get<Homme::Tracers>();
-  auto vdyn = m_helper_fields.at("v_dyn");
-  
-  // If ftype==FORCING_2, also set FQ_ref=Q_ref. Next step's Q_dyn will be set
-  // as Q_dyn = Q_dyn_old + PD_remap(Q_ref-Q_ref_old)
+  // If ftype==FORCING_2, also set FQ_phys=Q_phys. Next step's Q_dyn will be set
+  // as Q_dyn = Q_dyn_old + PD_remap(Q_phys-Q_phys_old)
   const auto ftype = params.ftype;
   if (ftype==Homme::ForcingAlg::FORCING_2) {
-    m_helper_fields.at("FQ_ref").deep_copy(*get_group_out("Q",rgn).m_bundle);
+    m_helper_fields.at("FQ_phys").deep_copy(*get_group_out("Q",pgn).m_bundle);
   }
 }
 
@@ -877,10 +939,10 @@ void HommeDynamics::restart_homme_state () {
   using PF = PhysicsFunctions<DefaultDevice>;
 
   const auto& dgn = m_dyn_grid->name();
-  const auto& rgn = m_ref_grid->name();
+  const auto& pgn = m_phys_grid->name();
 
   // All internal fields should have been read from restart file.
-  // We need to remap Q_dyn, v_dyn, w_dyn, T_dyn back to ref grid,
+  // We need to remap Q_dyn, v_dyn, w_dyn, T_dyn back to phys grid,
   // to handle the backing out of the tendencies
   // Note: Q_ref only in case of ftype!=FORCING_0.
   // TODO: p2d remapper does not support subfields, so we need to create temps
@@ -895,8 +957,8 @@ void HommeDynamics::restart_homme_state () {
   set_homme_param("num_steps",nstep);
 
   constexpr int NGP = HOMMEXX_NP;
-  const int nlevs = m_ref_grid->get_num_vertical_levels();
-  const int ncols = m_ref_grid->get_num_local_dofs();
+  const int nlevs = m_phys_grid->get_num_vertical_levels();
+  const int ncols = m_phys_grid->get_num_local_dofs();
   const int nelem = m_dyn_grid->get_num_local_dofs() / (NGP*NGP);
   const int npacks = ekat::PackInfo<N>::num_packs(nlevs);
   const int qsize = params.qsize;
@@ -937,23 +999,27 @@ void HommeDynamics::restart_homme_state () {
     Q_dyn_view(ie,iq,ip,jp,k) = Qdp_dyn_view(ie,iq,ip,jp,k) / dp_dyn_view(ie,ip,jp,k);
   });
 
+  if (fv_phys_active()) {
+    m_ic_remapper = nullptr;
+    return;
+  }
+
   // TODO: if/when PD remapper supports remapping directly to/from subfields,
   //       you could remap v_dyn into the proper slice of FM_ref,
   //       and do away with uv_prev.
   using namespace ShortFieldTagsNames;
-  create_helper_field("uv_prev",{COL,CMP,LEV},{ncols,2,nlevs},rgn);
-
-  m_ic_remapper->registration_begins();
-  m_ic_remapper->register_field(m_helper_fields.at("FT_ref"),m_helper_fields.at("vtheta_dp_dyn"));
-  m_ic_remapper->register_field(m_helper_fields.at("uv_prev"),m_helper_fields.at("v_dyn"));
-  m_ic_remapper->register_field(get_field_out("pseudo_density",rgn),m_helper_fields.at("dp3d_dyn"));
+  create_helper_field("uv_prev",{COL,CMP,LEV},{ncols,2,nlevs},pgn);
   auto qv_prev_ref = std::make_shared<Field>();
+  m_ic_remapper->registration_begins();
+  m_ic_remapper->register_field(m_helper_fields.at("FT_phys"),m_helper_fields.at("vtheta_dp_dyn"));
+  m_ic_remapper->register_field(m_helper_fields.at("uv_prev"),m_helper_fields.at("v_dyn"));
+  m_ic_remapper->register_field(get_field_out("pseudo_density",pgn),m_helper_fields.at("dp3d_dyn"));
   auto Q_dyn = m_helper_fields.at("Q_dyn");
   if (params.ftype==Homme::ForcingAlg::FORCING_2) {
     // Recall, we store Q_old in FQ_ref, and do FQ_ref = Q_new - FQ_ref during pre-process
     // Q_old is the tracers at the end of last dyn step, which we can recompute by remapping
     // Q_dyn (which was part of the restart file) to the ref grid.
-    auto Q_old = m_helper_fields.at("FQ_ref");  
+    auto Q_old = m_helper_fields.at("FQ_phys");  
     m_ic_remapper->register_field(Q_old,Q_dyn);
 
     // Grab qv_ref_old from Q_old
@@ -963,29 +1029,29 @@ void HommeDynamics::restart_homme_state () {
     //       to compute T_prev *in the same way as homme_post_process* did in the original run.
     //       If PD remapper supported subfields, we would not need qv_prev_dyn, and could use
     //       the proper subfield of Q_dyn instead.
-    create_helper_field("qv_prev_ref",{COL,LEV},{ncols,nlevs},rgn);
+    create_helper_field("qv_prev_phys",{COL,LEV},{ncols,nlevs},pgn);
     create_helper_field("qv_prev_dyn",{EL,GP,GP,LEV},{nelem,NGP,NGP,nlevs},dgn);
-    m_ic_remapper->register_field(m_helper_fields.at("qv_prev_ref"),m_helper_fields.at("qv_prev_dyn"));
+    m_ic_remapper->register_field(m_helper_fields.at("qv_prev_phys"),m_helper_fields.at("qv_prev_dyn"));
 
     // Copy qv from the qsize-sized Q_dyn array, to the individual-tracer field qv_prev_dyn.
     auto qv_prev_dyn = m_helper_fields.at("qv_prev_dyn");
     qv_prev_dyn.deep_copy(Q_dyn.get_component(0));
 
-    *qv_prev_ref = m_helper_fields.at("qv_prev_ref");
+    *qv_prev_ref = m_helper_fields.at("qv_prev_phys");
   }
   m_ic_remapper->registration_ends();
   m_ic_remapper->remap(/*forward = */false);
   m_ic_remapper = nullptr; // Can clean up the IC remapper now.
 
   // Now that we have dp_ref, we can recompute pressure
-  update_pressure();
+  update_pressure(m_phys_grid);
 
   // Copy uv_prev into FM_ref. Also, FT_ref contains vtheta_dp,
   // so convert it to actual temperature
   auto uv_view     = m_helper_fields.at("uv_prev").get_view<Pack***>();
-  auto V_prev_view = m_helper_fields.at("FM_ref").get_view<Pack***>();
-  auto T_prev_view = m_helper_fields.at("FT_ref").get_view<Pack**>();
-  auto dp_view     = get_field_out("pseudo_density",rgn).get_view<const Pack**>();
+  auto V_prev_view = m_helper_fields.at("FM_phys").get_view<Pack***>();
+  auto T_prev_view = m_helper_fields.at("FT_phys").get_view<Pack**>();
+  auto dp_view     = get_field_out("pseudo_density",pgn).get_view<const Pack**>();
   auto p_mid_view  = get_field_out("p_mid").get_view<Pack**>();
   auto qv_view     = qv_prev_ref->get_view<Pack**>();
 
@@ -1016,8 +1082,8 @@ void HommeDynamics::restart_homme_state () {
   // We can now erase the uv_prev field.
   // Erase also qv_prev_ref/qv_prev_dyn (if we created them).
   m_helper_fields.erase("uv_prev");
-  if (m_helper_fields.find("qv_prev_ref")!=m_helper_fields.end()) {
-    m_helper_fields.erase("qv_prev_ref");
+  if (m_helper_fields.find("qv_prev_phys")!=m_helper_fields.end()) {
+    m_helper_fields.erase("qv_prev_phys");
     m_helper_fields.erase("qv_prev_dyn");
   }
   qv_prev_ref = nullptr;
@@ -1033,7 +1099,7 @@ void HommeDynamics::initialize_homme_state () {
   using EOS = Homme::EquationOfState;
   using WS = ekat::WorkspaceManager<Pack,DefaultDevice>;
 
-  const auto& rgn = m_ref_grid->name();
+  const auto& rgn = m_cgll_grid->name();
 
   // Some Homme structures
   const auto& c = Homme::Context::singleton();
@@ -1041,9 +1107,9 @@ void HommeDynamics::initialize_homme_state () {
   const auto& hvcoord = c.get<Homme::HybridVCoord>();
 
   // Some extents
-  const auto ncols = m_ref_grid->get_num_local_dofs();
-  const auto nlevs = m_ref_grid->get_num_vertical_levels();
-  constexpr int NGP  = HOMMEXX_NP;
+  const auto ncols = m_cgll_grid->get_num_local_dofs();
+  const auto nlevs = m_cgll_grid->get_num_vertical_levels();
+  constexpr int NGP = HOMMEXX_NP;
   const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
   const int qsize = params.qsize;
   const int npacks_mid = ekat::PackInfo<HOMMEXX_PACK_SIZE>::num_packs(nlevs);
@@ -1054,7 +1120,7 @@ void HommeDynamics::initialize_homme_state () {
   //       but it used KokkosKernels packs, which are incompatible with ekat::Pack.
   //       If Homme switched to ekat::Pack, you could do the loop below with packs.
   const auto ps0 = hvcoord.ps0;
-  const auto dp_ref = get_field_out("pseudo_density").get_view<Real**>();
+  const auto dp_ref = get_field_out("pseudo_density",rgn).get_view<Real**>();
   const auto ps_ref = get_field_in("ps",rgn).get_view<const Real*>();
   const auto hyai = hvcoord.hybrid_ai;
   const auto hybi = hvcoord.hybrid_bi;
@@ -1079,7 +1145,7 @@ void HommeDynamics::initialize_homme_state () {
   m_ic_remapper->register_field(get_field_in("ps",rgn),m_helper_fields.at("ps_dyn"));
   m_ic_remapper->register_field(get_field_in("phis",rgn),m_helper_fields.at("phis_dyn"));
   m_ic_remapper->register_field(get_field_in("T_mid",rgn),m_helper_fields.at("vtheta_dp_dyn"));
-  m_ic_remapper->register_field(*get_group_in("Q",rgn).m_bundle,m_helper_fields.at("Q_dyn"));
+  m_ic_remapper->register_field(*get_group_in("tracers",rgn).m_bundle,m_helper_fields.at("Q_dyn"));
   m_ic_remapper->registration_ends();
   m_ic_remapper->remap(true);
 
@@ -1153,28 +1219,32 @@ void HommeDynamics::initialize_homme_state () {
     f.get_header().get_tracking().update_time_stamp(timestamp());
   }
 
-  // Forcings are computed as some version of "value coming in from AD
-  // minus value at the end of last HommeDynamics run".
-  // At the first time step, we don't have a value at the end of last
-  // HommeDynamics run, so init with the initial conditions.
-  // NOTE: for FM, we can't deep copy w_int, since w_int and FM_w
-  //       have different number of levels. For u,v, we could, but
-  //       we cannot (11/2021) subview 2 slices of FM together, so
-  //       we'd need to also subview horiz_winds. Since we
-  if (params.ftype==Homme::ForcingAlg::FORCING_2) {
-    m_helper_fields.at("FQ_ref").deep_copy(*get_group_out("Q",rgn).m_bundle);
-  }
-  m_helper_fields.at("FT_ref").deep_copy(get_field_in("T_mid",rgn));
-  auto FM_ref = m_helper_fields.at("FM_ref").get_view<Real***>();
-  auto horiz_winds = get_field_out("horiz_winds",rgn).get_view<Real***>();
-  Kokkos::parallel_for(Kokkos::RangePolicy<>(0,ncols*nlevs),
-                       KOKKOS_LAMBDA (const int idx) {
-    const int icol = idx / nlevs;
-    const int ilev = idx % nlevs;
+  if (not fv_phys_active()) {
+    // Forcings are computed as some version of "value coming in from AD
+    // minus value at the end of last HommeDynamics run".
+    // At the first time step, we don't have a value at the end of last
+    // HommeDynamics run, so init with the initial conditions.
+    // NOTE: for FM, we can't deep copy w_int, since w_int and FM_w
+    //       have different number of levels. For u,v, we could, but
+    //       we cannot (11/2021) subview 2 slices of FM together, so
+    //       we'd need to also subview horiz_winds. Since we
+    const auto& pgn = m_phys_grid->name();
+    const auto ncols = m_phys_grid->get_num_local_dofs();
+    if (params.ftype==Homme::ForcingAlg::FORCING_2) {
+      m_helper_fields.at("FQ_phys").deep_copy(*get_group_out("Q",pgn).m_bundle);
+    }
+    m_helper_fields.at("FT_phys").deep_copy(get_field_in("T_mid",pgn));
+    auto FM_ref = m_helper_fields.at("FM_phys").get_view<Real***>();
+    auto horiz_winds = get_field_out("horiz_winds",pgn).get_view<Real***>();
+    Kokkos::parallel_for(Kokkos::RangePolicy<>(0,ncols*nlevs),
+                         KOKKOS_LAMBDA (const int idx) {
+      const int icol = idx / nlevs;
+      const int ilev = idx % nlevs;
 
-    FM_ref(icol,0,ilev) = horiz_winds(icol,0,ilev);
-    FM_ref(icol,1,ilev) = horiz_winds(icol,1,ilev);
-  });
+      FM_ref(icol,0,ilev) = horiz_winds(icol,0,ilev);
+      FM_ref(icol,1,ilev) = horiz_winds(icol,1,ilev);
+    });
+  }
 
   // For initial runs, it's easier to prescribe IC for Q, and compute Qdp = Q*dp
   auto& tracers = c.get<Homme::Tracers>();
@@ -1192,8 +1262,10 @@ void HommeDynamics::initialize_homme_state () {
     qdp(ie,n0_qdp,iq,ip,jp,k) = q(ie,iq,ip,jp,k) * dp(ie,n0,ip,jp,k);
   });
 
-  // Initialize p_mid/p_int
-  update_pressure ();
+  if (not fv_phys_active()) {
+    // Initialize p_mid/p_int
+    update_pressure (m_phys_grid);
+  }
 
   // Copy IC states on all timelevel slices
   copy_dyn_states_to_all_timelevels ();
@@ -1288,22 +1360,23 @@ void HommeDynamics::init_homme_vcoord () {
 //       routine, which is responsible for updating the pressure every timestep.  There is a
 //       TODO item to consolidate how we update the pressure during initialization and run, but
 //       for now we have two locations where we do this.
-void HommeDynamics::update_pressure() {
+void HommeDynamics::update_pressure(const std::shared_ptr<const AbstractGrid>& grid) {
   using KT = KokkosTypes<DefaultDevice>;
   using Pack = ekat::Pack<Real,HOMMEXX_PACK_SIZE>;
   using ColOps = ColumnOps<DefaultDevice,Real>;
 
-  const auto ncols = m_ref_grid->get_num_local_dofs();
-  const auto nlevs = m_ref_grid->get_num_vertical_levels();
+  const auto ncols = grid->get_num_local_dofs();
+  const auto nlevs = grid->get_num_vertical_levels();
   const auto npacks= ekat::PackInfo<HOMMEXX_PACK_SIZE>::num_packs(nlevs);
 
   const auto& c = Homme::Context::singleton();
   const auto& hvcoord = c.get<Homme::HybridVCoord>();
   const auto ps0 = hvcoord.ps0 * hvcoord.hybrid_ai0;
 
-  const auto dp_view    = get_field_out("pseudo_density").get_view<Pack**>();
-  const auto p_int_view = get_field_out("p_int").get_view<Pack**>();
-  const auto p_mid_view = get_field_out("p_mid").get_view<Pack**>();
+  const auto& gn = grid->name();
+  const auto dp_view    = get_field_out("pseudo_density",gn).get_view<Pack**>();
+  const auto p_int_view = get_field_out("p_int",gn).get_view<Pack**>();
+  const auto p_mid_view = get_field_out("p_mid",gn).get_view<Pack**>();
 
   const auto qv_view        = get_field_in("qv").get_view<const Pack**>();
   const auto dp_dry_view    = get_field_out("pseudo_density_dry").get_view<Pack**>();

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -10,6 +10,8 @@
 namespace scream
 {
 
+class FieldManager;
+
 /*
  *  The class responsible to handle the atmosphere dynamics
  *
@@ -31,7 +33,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Dynamics; }
 
   std::set<std::string> get_required_grids () const {
-    return std::set<std::string>{"Dynamics"};
+    return std::set<std::string>{"Dynamics", "Physics GLL"};
   }
 
   // The name of the subcomponent
@@ -63,12 +65,39 @@ protected:
   void init_homme_vcoord ();
 
   // Updates p_mid
-  void update_pressure ();
+  void update_pressure (const std::shared_ptr<const AbstractGrid>& grid);
 
   // Copy initial states from n0 timelevel to other timelevels
   void copy_dyn_states_to_all_timelevels ();
 
   void initialize_impl (const RunType run_type);
+
+  // fv_phys refers to the horizontal finite volume (FV) grid for column
+  // parameterizations nested inside the horizontal element grid. The grid names
+  // are "Physics PGN", where N in practice is 2. The name of each routine is
+  // fv_phys_X, where X is the name of an existing HommeDynamics routine. If
+  // fv_phys is not being used, each of these routines does an immediate exit,
+  // so it's OK to always call the routine.
+  //   For the finite volume (FV) physics grid, sometimes referred to as
+  // "physgrid", we use the remapper that Homme provides. Store N in pgN; if the
+  // grid is not FV, then this variable is set to -1.
+  int m_phys_grid_pgN;
+  void fv_phys_set_grids();
+  void fv_phys_requested_buffer_size_in_bytes() const;
+  void fv_phys_initialize_impl();
+  void fv_phys_dyn_to_fv_phys(const bool restart = false);
+  void fv_phys_pre_process();
+  void fv_phys_post_process();
+  // See [rrtmgp active gases] in atmosphere_dynamics_fv_phys.cpp.
+  void fv_phys_rrtmgp_active_gases_init(const std::shared_ptr<const GridsManager>& gm);
+  void fv_phys_rrtmgp_active_gases_remap();
+public:
+  // Fast boolean function returning whether Physics PGN is being used.
+  bool fv_phys_active() const;
+  struct GllFvRemapTmp;
+  void remap_dyn_to_fv_phys(GllFvRemapTmp* t = nullptr) const;
+  void remap_fv_phys_to_dyn() const;
+  
 protected:
   void run_impl        (const int dt);
   void finalize_impl   ();
@@ -96,14 +125,17 @@ protected:
   // Some helper fields.
   std::map<std::string,Field>  m_helper_fields;
 
-  // Remapper for inputs and outputs, plus a special one for initial conditions
+  // Remapper for inputs and outputs, plus a special one for initial
+  // conditions. These are used when the physics grid is the continuous GLL
+  // point grid.
   std::shared_ptr<AbstractRemapper>   m_p2d_remapper;
   std::shared_ptr<AbstractRemapper>   m_d2p_remapper;
   std::shared_ptr<AbstractRemapper>   m_ic_remapper;
 
   // The dynamics and reference grids
-  std::shared_ptr<const AbstractGrid>  m_dyn_grid;
-  std::shared_ptr<const AbstractGrid>  m_ref_grid;
+  std::shared_ptr<const AbstractGrid> m_dyn_grid;  // Dynamics DGLL
+  std::shared_ptr<const AbstractGrid> m_phys_grid; // Column parameterizations grid
+  std::shared_ptr<const AbstractGrid> m_cgll_grid; // Unique CGLL
 };
 
 } // namespace scream

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -10,8 +10,6 @@
 namespace scream
 {
 
-class FieldManager;
-
 /*
  *  The class responsible to handle the atmosphere dynamics
  *

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics_fv_phys.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics_fv_phys.cpp
@@ -216,9 +216,9 @@ void HommeDynamics::remap_fv_phys_to_dyn () const {
   Kokkos::fence();
 }
 
-// [rrtmgp active gases] This is to address issue #1782. It supports option 1 in
-// that issue. These fv_phys_rrtmgp_active_gases_* routines can be removed once
-// rrtmgp active_gases initialization is treated properly.
+// TODO [rrtmgp active gases] This is to address issue #1782. It supports option
+// 1 in that issue. These fv_phys_rrtmgp_active_gases_* routines can be removed
+// once rrtmgp active_gases initialization is treated properly.
 
 struct TraceGasesWorkaround {
   bool restart{false};
@@ -255,7 +255,8 @@ void HommeDynamics
   constexpr int ps = SCREAM_SMALL_PACK_SIZE;
   for (const auto& e : s_tgw.active_gases) {
     add_field<Required>(e, FieldLayout({COL,LEV},{rnc,nlev}), kgkg, rgn, ps);
-    // 'Updated' so that it gets written to the restart file.
+    // 'Updated' rather than just 'Computed' so that it gets written to the
+    // restart file.
     add_field<Updated >(e, FieldLayout({COL,LEV},{pnc,nlev}), kgkg, pgn, ps);
   }
   s_tgw.remapper = gm->create_remapper(m_cgll_grid, m_dyn_grid);

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics_fv_phys.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics_fv_phys.cpp
@@ -1,0 +1,320 @@
+#include "atmosphere_dynamics.hpp"
+
+// HOMMEXX Includes
+#include "Context.hpp"
+#include "FunctorsBuffersManager.hpp"
+#include "SimulationParams.hpp"
+#include "TimeLevel.hpp"
+#include "ElementsForcing.hpp"
+#include "GllFvRemap.hpp"
+
+// Scream includes
+#include "share/field/field_manager.hpp"
+#include "dynamics/homme/homme_dimensions.hpp"
+
+// Ekat includes
+#include "ekat/ekat_assert.hpp"
+#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include "ekat/ekat_pack.hpp"
+#include "ekat/ekat_pack_kokkos.hpp"
+#include "ekat/ekat_pack_utils.hpp"
+
+extern "C" void gfr_init_hxx();
+
+// Parse a name of the form "Physics PGN". Return -1 if not an FV physics grid
+// name, otherwise N in pgN.
+static int get_phys_grid_fv_param (const std::string& grid_name) {
+  if (grid_name.size() < 11) return -1;
+  if (grid_name.substr(0, 10) != "Physics PG") return -1;
+  const auto param = grid_name.substr(10, std::string::npos);
+  int N;
+  std::istringstream ss(param);
+  try {
+    ss >> N;
+  } catch (...) {
+    N = -1;
+  }
+  return N;
+}
+
+namespace scream {
+
+bool HommeDynamics::fv_phys_active () const {
+  return m_phys_grid_pgN > 0;
+}
+
+void HommeDynamics::fv_phys_set_grids () {
+  m_phys_grid_pgN = get_phys_grid_fv_param(m_phys_grid->name());
+}
+
+void HommeDynamics::fv_phys_requested_buffer_size_in_bytes () const {
+  if (not fv_phys_active()) return;
+  using namespace Homme;
+  auto& c = Context::singleton();
+  auto& gfr = c.create_if_not_there<GllFvRemap>();
+  auto& fbm = c.create_if_not_there<FunctorsBuffersManager>();
+  fbm.request_size(gfr.requested_buffer_size());
+}
+
+void HommeDynamics::fv_phys_initialize_impl () {
+  if (not fv_phys_active()) return;
+  using namespace Homme;
+  auto& c = Context::singleton();
+  auto& gfr = c.get<GllFvRemap>();
+  gfr.reset(c.get<SimulationParams>());
+  gfr_init_hxx();
+}
+
+// During restart, we can't overwrite T_mid, horiz_winds, and tracers, as these
+// contain data used in homme_pre_process to compute tendencies.
+struct HommeDynamics::GllFvRemapTmp {
+  Homme::ExecView<Real***> T_mid;
+  Homme::ExecView<Real****> horiz_winds, tracers;
+};
+
+// Copy physics T,uv state to FT,M to form tendencies in next dynamics step.
+template <typename T_t, typename uv_t, typename FT_t, typename FM_t>
+static void copy_prev (const int ncols, const int npacks,
+                       const T_t& T, const uv_t& uv,
+                       const FT_t& FT, const FM_t& FM) {
+  using KT = KokkosTypes<DefaultDevice>;
+  using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
+  const auto policy = ESU::get_default_team_policy(ncols, npacks);
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
+    const int& icol = team.league_rank();
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, npacks),
+                         [&] (const int ilev) {
+      FT(icol,ilev) = T(icol,ilev);
+      FM(icol,0,ilev) = uv(icol,0,ilev);
+      FM(icol,1,ilev) = uv(icol,1,ilev);
+      FM(icol,2,ilev) = 0;
+    });
+  });
+  Kokkos::fence();  
+}
+
+void HommeDynamics::fv_phys_dyn_to_fv_phys (const bool restart) {
+  if (not fv_phys_active()) return;
+  constexpr int N = HOMMEXX_PACK_SIZE;
+  using Pack = ekat::Pack<Real,N>;
+  const auto nlevs = m_phys_grid->get_num_vertical_levels();
+  const auto npacks = ekat::PackInfo<N>::num_packs(nlevs);
+  const auto& pgn = m_phys_grid->name();
+  const auto ncols = m_phys_grid->get_num_local_dofs();
+  const auto FT = m_helper_fields.at("FT_phys").get_view<Pack**>();
+  const auto FM = m_helper_fields.at("FM_phys").get_view<Pack***>();
+  if (restart) {
+    constexpr int NGP = HOMMEXX_NP;
+    const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
+    const auto npg = m_phys_grid_pgN*m_phys_grid_pgN;
+    GllFvRemapTmp t;    
+    t.T_mid = Homme::ExecView<Real***>("T_mid_tmp", nelem, npg, npacks*N);
+    t.horiz_winds = Homme::ExecView<Real****>("horiz_winds_tmp", nelem, npg, 2, npacks*N);
+    // Really need just the first tracer.
+    const auto qsize = get_group_out("tracers", pgn).m_bundle->get_view<Real***>().extent_int(1);
+    t.tracers = Homme::ExecView<Real****>("tracers_tmp", nelem, npg, qsize, npacks*N);
+    remap_dyn_to_fv_phys(&t);
+    assert(ncols == nelem*npg);
+    Homme::ExecViewUnmanaged<Pack**> T(reinterpret_cast<Pack*>(t.T_mid.data()),
+                                        ncols, npacks);
+    Homme::ExecViewUnmanaged<Pack***> uv(reinterpret_cast<Pack*>(t.horiz_winds.data()),
+                                         ncols, 2, npacks);
+    copy_prev(ncols, npacks, T, uv, FT, FM);
+  } else {
+    remap_dyn_to_fv_phys();
+    const auto T  = get_field_out("T_mid",pgn).get_view<const Pack**>();
+    const auto uv = get_field_out("horiz_winds",pgn).get_view<const Pack***>();
+    copy_prev(ncols, npacks, T, uv, FT, FM);
+  }
+  update_pressure(m_phys_grid);
+}
+
+// Q state: Map get_group_in("tracers", gn) to Homme's FQ.
+// T,uv tendencies: Map F(T,M)_phys to Homme's F(T,M) tendency arrays.
+void HommeDynamics::fv_phys_pre_process () {
+  if (not fv_phys_active()) return;
+  remap_fv_phys_to_dyn();
+}
+
+// Remap Homme state to get_field_out("x", m_phys_grid->name()) for x in (ps,
+// phis, T_mid, omega, horiz_winds, tracers, pseudo_density). Then call
+// update_pressure to update p_mid,int.
+void HommeDynamics::fv_phys_post_process () {
+  if (not fv_phys_active()) return;
+  fv_phys_dyn_to_fv_phys();
+}
+
+void HommeDynamics::remap_dyn_to_fv_phys (GllFvRemapTmp* t) const {
+  if (not fv_phys_active()) return;
+  const auto& c = Homme::Context::singleton();
+  auto& gfr = c.get<Homme::GllFvRemap>();
+  const auto time_idx = c.get<Homme::TimeLevel>().n0;
+  constexpr int NGP = HOMMEXX_NP;
+  const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
+  const auto npg = m_phys_grid_pgN*m_phys_grid_pgN;
+  const auto& gn = m_phys_grid->name();
+  const auto nlev = get_field_out("T_mid", gn).get_view<Real**>().extent_int(1);
+  const auto nq = get_group_out("tracers").m_bundle->get_view<Real***>().extent_int(1);
+  assert(get_field_out("T_mid", gn).get_view<Real**>().extent_int(0) == nelem*npg);
+  assert(get_field_out("horiz_winds", gn).get_view<Real***>().extent_int(1) == 2);
+  
+  const auto ps = Homme::GllFvRemap::Phys1T(
+    get_field_out("ps", gn).get_view<Real*>().data(),
+    nelem, npg);
+  const auto phis = Homme::GllFvRemap::Phys1T(
+    get_field_out("phis", gn).get_view<Real*>().data(),
+    nelem, npg);
+  const auto T = Homme::GllFvRemap::Phys2T(
+    t ? t->T_mid.data() : get_field_out("T_mid", gn).get_view<Real**>().data(),
+    nelem, npg, nlev);
+  const auto omega = Homme::GllFvRemap::Phys2T(
+    get_field_out("omega", gn).get_view<Real**>().data(),
+    nelem, npg, nlev);
+  const auto uv = Homme::GllFvRemap::Phys3T(
+    t ? t->horiz_winds.data() : get_field_out("horiz_winds", gn).get_view<Real***>().data(),
+    nelem, npg, 2, nlev);
+  const auto q = Homme::GllFvRemap::Phys3T(
+    t ? t->tracers.data() : get_group_out("tracers", gn).m_bundle->get_view<Real***>().data(),
+    nelem, npg, nq, nlev);
+  const auto dp = Homme::GllFvRemap::Phys2T(
+    get_field_out("pseudo_density", gn).get_view<Real**>().data(),
+    nelem, npg, nlev);
+
+  gfr.run_dyn_to_fv_phys(time_idx, ps, phis, T, omega, uv, q, &dp);
+  Kokkos::fence();
+}
+
+void HommeDynamics::remap_fv_phys_to_dyn () const {
+  if (not fv_phys_active()) return;
+  const auto& c = Homme::Context::singleton();
+  auto& gfr = c.get<Homme::GllFvRemap>();
+  const auto time_idx = c.get<Homme::TimeLevel>().n0;
+  constexpr int NGP = HOMMEXX_NP;
+  const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
+  const auto npg = m_phys_grid_pgN*m_phys_grid_pgN;
+  const auto& gn = m_phys_grid->name();
+  const auto nlev = m_helper_fields.at("FT_phys").get_view<const Real**>().extent_int(1);
+  const auto nq = get_group_in("tracers", gn).m_bundle->get_view<const Real***>().extent_int(1);
+  assert(m_helper_fields.at("FT_phys").get_view<const Real**>().extent_int(0) == nelem*npg);
+
+  const auto uv_ndim = m_helper_fields.at("FM_phys").get_view<const Real***>().extent_int(1);
+  assert(uv_ndim == 2 or uv_ndim == 3);
+
+  const auto T = Homme::GllFvRemap::CPhys2T(
+    m_helper_fields.at("FT_phys").get_view<const Real**>().data(),
+    nelem, npg, nlev);
+  const auto uv = Homme::GllFvRemap::CPhys3T(
+    m_helper_fields.at("FM_phys").get_view<const Real***>().data(),
+    nelem, npg, uv_ndim, nlev);
+  const auto q = Homme::GllFvRemap::CPhys3T(
+    get_group_in("tracers", gn).m_bundle->get_view<const Real***>().data(),
+    nelem, npg, nq, nlev);
+  
+  gfr.run_fv_phys_to_dyn(time_idx, T, uv, q);
+  Kokkos::fence();
+  gfr.run_fv_phys_to_dyn_dss();
+  Kokkos::fence();
+}
+
+// [rrtmgp active gases] This is to address issue #1782. It supports option 1 in
+// that issue. These fv_phys_rrtmgp_active_gases_* routines can be removed once
+// rrtmgp active_gases initialization is treated properly.
+
+struct TraceGasesWorkaround {
+  bool restart{false};
+  std::shared_ptr<AbstractRemapper> remapper;
+  std::vector<std::string> active_gases; // other than h2o
+};
+
+static TraceGasesWorkaround s_tgw;
+
+void fv_phys_rrtmgp_active_gases_init (const ekat::ParameterList& p) {
+  const auto& v = p.sublist("atmosphere_processes").sublist("physics")
+    .sublist("rrtmgp").get<std::vector<std::string>>("active_gases");
+  for (const auto& e : v)
+    if (e != "h2o")
+      s_tgw.active_gases.push_back(e);
+}
+
+void fv_phys_rrtmgp_active_gases_set_restart (const bool restart) {
+  s_tgw.restart = restart;
+}
+
+void HommeDynamics
+::fv_phys_rrtmgp_active_gases_init (const std::shared_ptr<const GridsManager>& gm) {
+  if (s_tgw.restart) return; // always false b/c it hasn't been set yet
+  using namespace ekat::units;
+  using namespace ShortFieldTagsNames;
+  auto kgkg = kg/kg;
+  kgkg.set_string("kg/kg");
+  const auto& rgn = m_cgll_grid->name();
+  const auto& pgn = m_phys_grid->name();
+  const auto rnc = m_cgll_grid->get_num_local_dofs();
+  const auto pnc = m_phys_grid->get_num_local_dofs();
+  const auto nlev = m_cgll_grid->get_num_vertical_levels();
+  constexpr int ps = SCREAM_SMALL_PACK_SIZE;
+  for (const auto& e : s_tgw.active_gases) {
+    add_field<Required>(e, FieldLayout({COL,LEV},{rnc,nlev}), kgkg, rgn, ps);
+    // 'Updated' so that it gets written to the restart file.
+    add_field<Updated >(e, FieldLayout({COL,LEV},{pnc,nlev}), kgkg, pgn, ps);
+  }
+  s_tgw.remapper = gm->create_remapper(m_cgll_grid, m_dyn_grid);
+}
+
+void HommeDynamics::fv_phys_rrtmgp_active_gases_remap () {
+  // Note re: restart: Ideally, we'd know if we're restarting before having to
+  // call add_field above. However, we only find out after. Because the pg2
+  // field was declared Updated, it will read the restart data. But we don't
+  // actually want to remap from CGLL to pg2 now. So if restarting, just do the
+  // cleanup part at the end.
+  const auto& rgn = m_cgll_grid->name();
+  if (not s_tgw.restart) {
+    using namespace ShortFieldTagsNames;
+    const auto& dgn = m_dyn_grid ->name();
+    const auto& pgn = m_phys_grid->name();
+    constexpr int NGP = HOMMEXX_NP;
+    const int ngll = NGP*NGP;
+    const int npg = m_phys_grid_pgN*m_phys_grid_pgN;
+    const int nelem = m_dyn_grid->get_num_local_dofs()/ngll;
+    { // CGLL -> DGLL
+      const auto nlev = m_dyn_grid->get_num_vertical_levels();
+      for (const auto& e : s_tgw.active_gases)
+        create_helper_field(e, {EL,GP,GP,LEV}, {nelem,NGP,NGP,nlev}, dgn);
+      auto& r = s_tgw.remapper;
+      r->registration_begins();
+      for (const auto& e : s_tgw.active_gases)
+        r->register_field(get_field_in(e, rgn), m_helper_fields.at(e));
+      r->registration_ends();
+      r->remap(true);
+      s_tgw.remapper = nullptr;
+    }
+    { // DGLL -> PGN
+      const auto& c = Homme::Context::singleton();
+      auto& gfr = c.get<Homme::GllFvRemap>();
+      const auto time_idx = c.get<Homme::TimeLevel>().n0;
+      for (const auto& e : s_tgw.active_gases) {
+        const auto& f_dgll = m_helper_fields.at(e);
+        const auto& f_phys = get_field_out(e, pgn);
+        const auto& v_dgll = f_dgll.get_view<const Real****>();
+        const auto& v_phys = f_phys.get_view<Real**>();
+        assert(v_dgll.extent_int(0) == nelem and
+               v_dgll.extent_int(1)*v_dgll.extent_int(2) == ngll);
+        const auto in_dgll = Homme::GllFvRemap::CPhys3T(
+          v_dgll.data(), nelem, 1, ngll, v_dgll.extent_int(3));
+        assert(nelem*npg == v_phys.extent_int(0));
+        const auto out_phys = Homme::GllFvRemap::Phys3T(
+          v_phys.data(), nelem, npg, 1, v_phys.extent_int(1));
+        gfr.remap_tracer_dyn_to_fv_phys(time_idx, 1, in_dgll, out_phys);
+        Kokkos::fence();
+      }
+    }
+  }
+  // Done with all of these, so remove them.
+  s_tgw.remapper = nullptr;
+  for (const auto& e : s_tgw.active_gases)
+    m_helper_fields.erase(e);
+  for (const auto& e : s_tgw.active_gases)
+    remove_field(e, rgn);
+}
+
+} // namespace scream

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
@@ -125,10 +125,11 @@ build_grids (const std::set<std::string>& grid_names)
       pg_codes.push_back(code);
     }
   }
+
   pg_codes.push_back(m_grid_codes.at(m_ref_grid_name));
   const int* codes_ptr = pg_codes.data();
   init_grids_f90 (codes_ptr,pg_codes.size());
-
+  
   // We know we need the dyn grid, so build it
   build_dynamics_grid ();
 
@@ -142,12 +143,15 @@ build_grids (const std::set<std::string>& grid_names)
     build_physics_grid(m_ref_grid_name);
   }
 
+  if (m_grids.find("Physics GLL")==m_grids.end()) {
+    build_physics_grid("Physics GLL");
+  }
+
   // Clean up temporaries used during grid initialization
   cleanup_grid_init_data_f90 ();
 }
 
 void DynamicsDrivenGridsManager::build_dynamics_grid () {
-
   const std::string name = "Dynamics";
   if (m_grids.find(name)==m_grids.end()) {
     // Get dimensions and create "empty" grid
@@ -205,7 +209,6 @@ void DynamicsDrivenGridsManager::build_dynamics_grid () {
 
 void DynamicsDrivenGridsManager::
 build_physics_grid (const std::string& name) {
-
   // Build only if not built yet
   if (m_grids.find(name)==m_grids.end()) {
 
@@ -236,7 +239,7 @@ build_physics_grid (const std::string& name) {
     Kokkos::deep_copy(lat, h_lat);
     Kokkos::deep_copy(lon, h_lon);
     Kokkos::deep_copy(area,h_area);
-
+    
 #ifndef NDEBUG
     // Check that latitude, longitude, and area are valid
     using KT = KokkosTypes<DefaultDevice>;

--- a/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -65,7 +65,8 @@ contains
     use prim_driver_base,  only: prim_init1_buffers, prim_init1_compose, prim_init1_cleanup
     use homme_context_mod, only: par, elem
     use compose_mod,       only: compose_control_kokkos_init_and_fin
-
+    use prim_driver_mod,   only: prim_init_grid_views
+    
     ! Compose is not in charge of init/finalize kokkos
     call compose_control_kokkos_init_and_fin(.false.)
 
@@ -79,6 +80,8 @@ contains
 
     ! Cleanup the tmp stuff used in prim_init1_geometry
     call prim_init1_cleanup()
+
+    call prim_init_grid_views (elem)
 
   end subroutine prim_complete_init1_phase_f90
 
@@ -123,6 +126,7 @@ contains
                                    elem_state_phinh_i, elem_state_dp3d, elem_state_ps_v, &
                                    elem_state_Qdp, elem_state_Q, elem_derived_omega_p,   &
                                    elem_state_phis
+    
     !
     ! Inputs
     !
@@ -172,7 +176,7 @@ contains
   end subroutine prim_copy_cxx_to_f90
 
   subroutine prim_init_model_f90 () bind(c)
-    use prim_driver_mod,   only: prim_init_grid_views, prim_init_ref_states_views, &
+    use prim_driver_mod,   only: prim_init_ref_states_views, &
                                  prim_init_diags_views, prim_init_kokkos_functors, &
                                  prim_init_state_views
     use prim_state_mod,    only: prim_printstate
@@ -203,8 +207,7 @@ contains
     ! single buffer.
     call prim_init_kokkos_functors (allocate_buffer)
 
-    ! Init grid views, ref_states views, and diags views
-    call prim_init_grid_views (elem)
+    ! Init ref_states views, and diags views
     call prim_init_ref_states_views (elem)
     call prim_init_diags_views (elem)
 

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -4,7 +4,10 @@
 #include "share/property_checks/field_positivity_check.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
 
-#include "control/fvphyshack.hpp"
+#include "scream_config.h" // for SCREAM_CIME_BUILD
+#ifdef SCREAM_CIME_BUILD
+# include "control/fvphyshack.hpp"
+#endif
 
 namespace scream
 {
@@ -71,11 +74,14 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   // TODO: Replace pref_mid in the FM with pref_mid read in from the grid data
   // or, better, an analog to EAM's dyn_grid_get_pref.
   add_field<Required>("pref_mid",         pref_mid_layout,      Pa,
+#ifdef SCREAM_CIME_BUILD
                       // If pg2, read from the "Dynamics" grid b/c "Physics GLL"
                       // fields are temporary and not written to the restart
                       // file and reading "Physics PG2" data from the IC is not
                       // and should not be supported.
-                      fvphyshack ? "Dynamics" : grid_name,
+                      fvphyshack ? "Dynamics" :
+#endif
+                      grid_name,
                       ps);
 
   add_field<Required>("omega",            scalar3d_layout_mid,  Pa/s,    grid_name, ps);

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -3,6 +3,9 @@
 
 #include "share/property_checks/field_positivity_check.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
+
+#include "control/fvphyshack.hpp"
+
 namespace scream
 {
 
@@ -64,8 +67,17 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   const auto s2 = s*s;
 
   // These variables are needed by the interface, but not actually passed to shoc_main.
-  // TODO: Replace pref_mid in the FM with pref_mid read in from the grid data.
-  add_field<Required>("pref_mid",         pref_mid_layout,      Pa,      grid_name, ps);
+  
+  // TODO: Replace pref_mid in the FM with pref_mid read in from the grid data
+  // or, better, an analog to EAM's dyn_grid_get_pref.
+  add_field<Required>("pref_mid",         pref_mid_layout,      Pa,
+                      // If pg2, read from the "Dynamics" grid b/c "Physics GLL"
+                      // fields are temporary and not written to the restart
+                      // file and reading "Physics PG2" data from the IC is not
+                      // and should not be supported.
+                      fvphyshack ? "Dynamics" : grid_name,
+                      ps);
+
   add_field<Required>("omega",            scalar3d_layout_mid,  Pa/s,    grid_name, ps);
   add_field<Required>("surf_sens_flux",   scalar2d_layout_col,  W/m2,    grid_name);
   add_field<Required>("surf_evap",        scalar2d_layout_col,  kg/m2/s, grid_name);

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -3,6 +3,8 @@
 #include "share/util/scream_time_stamp.hpp"
 #include "share/io/scream_scorpio_interface.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
+#include "share/property_checks/field_lower_bound_check.hpp"
+#include "share/property_checks/check_and_repair_wrapper.hpp"
 
 #include "ekat/ekat_assert.hpp"
 #include "ekat/util/ekat_units.hpp"
@@ -187,7 +189,16 @@ void SPA::initialize_impl (const RunType /* run_type */)
   SPAFunc::update_spa_timestate(m_spa_data_file,m_nswbands,m_nlwbands,ts,SPAHorizInterp,SPATimeState,SPAData_start,SPAData_end);
 
   // Set property checks for fields in this process
+#if 0
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nccn"),m_grid,0.0,1.0e11,false);
+#else
+  {
+    const auto& f = get_field_out("nccn");
+    const auto check = std::make_shared<FieldWithinIntervalCheck>(f, m_grid, -1e-16, 1.0e11, false);
+    const auto repair = std::make_shared<FieldLowerBoundCheck>(f, m_grid, 0.0, true);
+    add_postcondition_check<CheckAndRepairWrapper>(check, repair);
+  }
+#endif
   // upper bound set to 1.01 as max(g_sw)=1.00757 in current ne4 data assumingly due to remapping
   // add an epslon to max possible upper bound of aero_ssa_sw
 

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -189,16 +189,12 @@ void SPA::initialize_impl (const RunType /* run_type */)
   SPAFunc::update_spa_timestate(m_spa_data_file,m_nswbands,m_nlwbands,ts,SPAHorizInterp,SPATimeState,SPAData_start,SPAData_end);
 
   // Set property checks for fields in this process
-#if 0
-  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("nccn"),m_grid,0.0,1.0e11,false);
-#else
   {
     const auto& f = get_field_out("nccn");
     const auto check = std::make_shared<FieldWithinIntervalCheck>(f, m_grid, -1e-16, 1.0e11, false);
     const auto repair = std::make_shared<FieldLowerBoundCheck>(f, m_grid, 0.0, true);
     add_postcondition_check<CheckAndRepairWrapper>(check, repair);
   }
-#endif
   // upper bound set to 1.01 as max(g_sw)=1.00757 in current ne4 data assumingly due to remapping
   // add an epslon to max possible upper bound of aero_ssa_sw
 

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -699,4 +699,42 @@ get_internal_field_impl(const std::string& field_name) const {
   }
 }
 
+void AtmosphereProcess
+::remove_field (const std::string& field_name, const std::string& grid_name) {
+  typedef std::list<Field>::iterator It;
+  const auto rmf = [&] (std::list<Field>& fields, str_map<str_map<Field*>>& ptrs) {
+    std::vector<It> rm_its;
+    for (It it = fields.begin(); it != fields.end(); ++it) {
+      const auto& fid = it->get_header().get_identifier();
+      if (fid.name() == field_name and fid.get_grid_name() == grid_name) {
+        rm_its.push_back(it);
+        ptrs[field_name][grid_name] = nullptr;
+      }
+    }
+    for (auto& it : rm_its) fields.erase(it);
+  };
+  rmf(m_fields_in, m_fields_in_pointers);
+  rmf(m_fields_out, m_fields_out_pointers);
+  rmf(m_internal_fields, m_internal_fields_pointers);
+}
+
+void AtmosphereProcess
+::remove_group (const std::string& group_name, const std::string& grid_name) {
+  typedef std::list<FieldGroup>::iterator It;
+  const auto rmg = [&] (std::list<FieldGroup>& fields, str_map<str_map<FieldGroup*>>& ptrs) {
+    std::vector<It> rm_its;
+    for (It it = fields.begin(); it != fields.end(); ++it) {
+      if (it->m_info->m_group_name == group_name and it->grid_name() == grid_name) {
+        rm_its.push_back(it);
+        ptrs[group_name][grid_name] = nullptr;
+        for (auto& kv : it->m_fields)
+          remove_field(kv.first, grid_name);
+      }
+    }
+    for (auto& it : rm_its) fields.erase(it);
+  };
+  rmg(m_groups_in, m_groups_in_pointers);
+  rmg(m_groups_out, m_groups_out_pointers);
+}
+
 } // namespace scream

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -427,6 +427,13 @@ protected:
   // Extra data needed for restart
   strmap_t<str_any_pair_t>  m_restart_extra_data;
 
+  // Use at your own risk. Motivation: Free up device memory for a field that is
+  // no longer used, such as a field read in the ICs used only to initialize
+  // other fields.
+  void remove_field(const std::string& field_name, const std::string& grid_name);
+  // Calls remove_field on each field in the group.
+  void remove_group(const std::string& group_name, const std::string& grid_name);
+
 private:
   // Called from initialize, this method creates the m_[fields|groups]_[in|out]_pointers
   // maps, which are used inside the get_[field|group]_[in|out] methods.


### PR DESCRIPTION
The core operations (files ComposeTransport*, GllFvRemap*) are in Hommexx and
were brought in through upstream merges. This PR makes EAMxx-side interface
changes to enable these capabilities in SCREAMv1.

Grid selectors in namelist_defaults_scream.xml make it so that any compset
specification with pg2 in the grid alias also triggers SL transport.

This PR adds three new ERS/P v1 tests.

A number of things still need to be done:

1. fvphyshack is a global variable that works around some initialization issues:
   1a. active_gases for rrtmgp,
   1b. some grid/field manager stuff in the AD.
1a can be backed out when the active_gases are fully initialized separately from
the IC file. 1b will require some discussion and bits of AD redesign or
correction of what I missed.

2. I've noticed qv min in the Homme state output can be <0, unlike in
E3SMv2. I've traced this preliminarily to Hommexx's vertical remap (but perhaps
only indirectly) but need to do more analysis and work out a fix. Eventually we
should be able to remove the lower-bound check in dynamics when using SL.

3. There seems to be a PE sensitivity somewhere in (very preliminary diagnosis)
postcondition checking on the GPU, I think unrelated to this PR. The new ERP
tests this PR includes should pass, but others I've tried do not.

[BFB] except for new ERS/P v1 tests