### PR TITLE
Compute pref_mid 

### DIFF
--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -1355,8 +1355,8 @@ void HommeDynamics::init_homme_vcoord () {
                          host_views["hybm"].data());
 
   // Store hybrid coords in phys grid
-  Kokkos::deep_copy(m_ref_grid->get_geometry_data("hyam"), host_views["hyam"]);
-  Kokkos::deep_copy(m_ref_grid->get_geometry_data("hybm"), host_views["hybm"]);
+  Kokkos::deep_copy(m_phys_grid->get_geometry_data("hyam"), host_views["hyam"]);
+  Kokkos::deep_copy(m_phys_grid->get_geometry_data("hybm"), host_views["hybm"]);
 }
 
 // =========================================================================================

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -1353,6 +1353,10 @@ void HommeDynamics::init_homme_vcoord () {
                          host_views["hybi"].data(),
                          host_views["hyam"].data(),
                          host_views["hybm"].data());
+
+  // Store hybrid coords in phys grid
+  Kokkos::deep_copy(m_ref_grid->get_geometry_data("hyam"), host_views["hyam"]);
+  Kokkos::deep_copy(m_ref_grid->get_geometry_data("hybm"), host_views["hybm"]);
 }
 
 // =========================================================================================

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
@@ -227,10 +227,17 @@ build_physics_grid (const std::string& name) {
     AbstractGrid::geo_view_type  lat("lat",nlcols);
     AbstractGrid::geo_view_type  lon("lon",nlcols);
     AbstractGrid::geo_view_type  area("area",nlcols);
+    AbstractGrid::geo_view_type  hyam("hyam",nlev);
+    AbstractGrid::geo_view_type  hybm("hybm",nlev);
     auto h_dofs = Kokkos::create_mirror_view(dofs);
     auto h_lat  = Kokkos::create_mirror_view(lat);
     auto h_lon  = Kokkos::create_mirror_view(lon);
     auto h_area = Kokkos::create_mirror_view(area);
+
+    // For the following, set to NaN. They will need to be grabbed
+    // from input files later.
+    Kokkos::deep_copy(hyam, std::nan(""));
+    Kokkos::deep_copy(hybm, std::nan(""));
 
     // Get all specs of phys grid cols (gids, coords, area)
     get_phys_grid_data_f90 (pg_type, h_dofs.data(), h_lat.data(), h_lon.data(), h_area.data());
@@ -258,6 +265,8 @@ build_physics_grid (const std::string& name) {
     phys_grid->set_geometry_data("lat",lat);
     phys_grid->set_geometry_data("lon",lon);
     phys_grid->set_geometry_data("area",area);
+    phys_grid->set_geometry_data("hyam",hyam);
+    phys_grid->set_geometry_data("hybm",hybm);
 
     m_grids[name] = phys_grid;
   }

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -5,9 +5,6 @@
 #include "share/property_checks/field_within_interval_check.hpp"
 
 #include "scream_config.h" // for SCREAM_CIME_BUILD
-#ifdef SCREAM_CIME_BUILD
-# include "control/fvphyshack.hpp"
-#endif
 
 namespace scream
 {
@@ -44,9 +41,6 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   // Define the different field layouts that will be used for this process
   using namespace ShortFieldTagsNames;
 
-  // Layout for pref_mid_field
-  FieldLayout pref_mid_layout{ {LEV}, {m_num_levs} };
-
   // Layout for 2D (1d horiz X 1d vertical) variable
   FieldLayout scalar2d_layout_col{ {COL}, {m_num_cols} };
 
@@ -70,20 +64,6 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   const auto s2 = s*s;
 
   // These variables are needed by the interface, but not actually passed to shoc_main.
-  
-  // TODO: Replace pref_mid in the FM with pref_mid read in from the grid data
-  // or, better, an analog to EAM's dyn_grid_get_pref.
-  add_field<Required>("pref_mid",         pref_mid_layout,      Pa,
-#ifdef SCREAM_CIME_BUILD
-                      // If pg2, read from the "Dynamics" grid b/c "Physics GLL"
-                      // fields are temporary and not written to the restart
-                      // file and reading "Physics PG2" data from the IC is not
-                      // and should not be supported.
-                      fvphyshack ? "Dynamics" :
-#endif
-                      grid_name,
-                      ps);
-
   add_field<Required>("omega",            scalar3d_layout_mid,  Pa/s,    grid_name, ps);
   add_field<Required>("surf_sens_flux",   scalar2d_layout_col,  W/m2,    grid_name);
   add_field<Required>("surf_evap",        scalar2d_layout_col,  kg/m2/s, grid_name);
@@ -141,7 +121,8 @@ size_t SHOCMacrophysics::requested_buffer_size_in_bytes() const
   const int num_tracer_packs = ekat::npack<Spack>(m_num_tracers);
 
   // Number of Reals needed by local views in the interface
-  const size_t interface_request = Buffer::num_1d_scalar*m_num_cols*sizeof(Real) +
+  const size_t interface_request = Buffer::num_1d_scalar_ncol*m_num_cols*sizeof(Real) +
+                                   Buffer::num_1d_scalar_nlev*nlev_packs*sizeof(Spack) +
                                    Buffer::num_2d_vector_mid*m_num_cols*nlev_packs*sizeof(Spack) +
                                    Buffer::num_2d_vector_int*m_num_cols*nlevi_packs*sizeof(Spack) +
                                    Buffer::num_2d_vector_tr*m_num_cols*num_tracer_packs*sizeof(Spack);
@@ -180,6 +161,9 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
   const int nlev_packs       = ekat::npack<Spack>(m_num_levs);
   const int nlevi_packs      = ekat::npack<Spack>(m_num_levs+1);
   const int num_tracer_packs = ekat::npack<Spack>(m_num_tracers);
+
+  m_buffer.pref_mid = decltype(m_buffer.pref_mid)(s_mem, nlev_packs);
+  s_mem += m_buffer.pref_mid.size();
 
   m_buffer.z_mid = decltype(m_buffer.z_mid)(s_mem, m_num_cols, nlev_packs);
   s_mem += m_buffer.z_mid.size();
@@ -396,11 +380,22 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
   workspace_mgr.setup(m_buffer.wsm_data, nlevi_packs, 13+(n_wind_slots+n_trac_slots), default_policy);
 
-  // Calculate maximum number of levels in pbl from surface
-  const auto pref_mid = get_field_in("pref_mid").get_view<const Spack*>();
+  // Calculate pref_mid, and use that to calculate
+  // maximum number of levels in pbl from surface
+  const auto pref_mid = m_buffer.pref_mid;
+  const auto s_pref_mid = ekat::scalarize(pref_mid);
+  const auto hyam = m_grid->get_geometry_data("hyam");
+  const auto hybm = m_grid->get_geometry_data("hybm");
+  const auto ps0 = C::P0;
+  const auto psref = ps0;
+  Kokkos::parallel_for(Kokkos::RangePolicy<>(0, m_num_levs), KOKKOS_LAMBDA (const int lev) {
+    s_pref_mid(lev) = ps0*hyam(lev) + psref*hybm(lev);
+  });
+  Kokkos::fence();
+
   const int ntop_shoc = 0;
   const int nbot_shoc = m_num_levs;
-  m_npbl = SHF::shoc_init(nbot_shoc,ntop_shoc,pref_mid);
+  m_npbl = SHF::shoc_init(nbot_shoc, ntop_shoc, pref_mid);
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -405,11 +405,15 @@ public:
     Spack* wsm_data;
   };
 
+#ifndef KOKKOS_ENABLE_CUDA
+  // Cuda requires methods enclosing __device__ lambda's to be public
+protected:
+#endif
+
+  void initialize_impl (const RunType run_type);
 
 protected:
 
-  // The three main interfaces for the subcomponent
-  void initialize_impl (const RunType run_type);
   void run_impl        (const int dt);
   void finalize_impl   ();
 

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -356,16 +356,19 @@ public:
 
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {
-    static constexpr int num_1d_scalar     = 5;
-    static constexpr int num_2d_vector_mid = 18;
-    static constexpr int num_2d_vector_int = 12;
-    static constexpr int num_2d_vector_tr  = 1;
+    static constexpr int num_1d_scalar_ncol = 5;
+    static constexpr int num_1d_scalar_nlev = 1;
+    static constexpr int num_2d_vector_mid  = 18;
+    static constexpr int num_2d_vector_int  = 12;
+    static constexpr int num_2d_vector_tr   = 1;
 
     uview_1d<Real> cell_length;
     uview_1d<Real> wpthlp_sfc;
     uview_1d<Real> wprtp_sfc;
     uview_1d<Real> upwp_sfc;
     uview_1d<Real> vpwp_sfc;
+
+    uview_1d<Spack> pref_mid;
 
     uview_2d<Spack> z_mid;
     uview_2d<Spack> z_int;

--- a/components/scream/src/share/grid/abstract_grid.cpp
+++ b/components/scream/src/share/grid/abstract_grid.cpp
@@ -160,7 +160,7 @@ AbstractGrid::get_lid_to_idx_map () const {
 void AbstractGrid::
 set_geometry_data (const std::string& name, const geo_view_type& data) {
   // Sanity checks
-  EKAT_REQUIRE_MSG (data.extent_int(0)==m_num_local_dofs,
+  EKAT_REQUIRE_MSG (data.extent_int(0)==m_num_local_dofs || data.extent_int(0)==m_num_vert_levs,
                     "Error! Input geometry data has wrong dimensions.\n");
 
 #ifndef NDEBUG

--- a/components/scream/src/share/grid/abstract_grid.cpp
+++ b/components/scream/src/share/grid/abstract_grid.cpp
@@ -159,14 +159,6 @@ AbstractGrid::get_lid_to_idx_map () const {
 
 void AbstractGrid::
 set_geometry_data (const std::string& name, const geo_view_type& data) {
-  // Sanity checks
-  EKAT_REQUIRE_MSG (data.extent_int(0)==m_num_local_dofs || data.extent_int(0)==m_num_vert_levs,
-                    "Error! Input geometry data has wrong dimensions.\n");
-
-#ifndef NDEBUG
-  EKAT_REQUIRE_MSG(this->valid_geo_data(name,data), "Error! Invalid geo data.\n");
-#endif
-
   m_geo_views[name] = data;
   m_geo_views_host[name] = Kokkos::create_mirror_view(data);
   Kokkos::deep_copy(m_geo_views_host[name],data);

--- a/components/scream/src/share/grid/abstract_grid.hpp
+++ b/components/scream/src/share/grid/abstract_grid.hpp
@@ -116,8 +116,6 @@ public:
   const lid_to_idx_map_type& get_lid_to_idx_map () const;
 
   // Set/get geometric views.
-  // NOTE: this method calls valid_geo_data, which may contain collective
-  //       operations over the stored communicator.
   void set_geometry_data (const std::string& name, const geo_view_type& data);
   const geo_view_type& get_geometry_data (const std::string& name) const;
   const geo_view_h_type& get_geometry_data_host (const std::string& name) const;
@@ -137,7 +135,6 @@ protected:
   // some extra consistency check.
   virtual bool valid_dofs_list (const dofs_list_type& /*dofs_gids*/)      const { return true; }
   virtual bool valid_lid_to_idx_map (const lid_to_idx_map_type& /*lid_to_idx*/) const { return true; }
-  virtual bool valid_geo_data (const std::string& /*name*/, const geo_view_type& /*data*/) const { return true; }
 
 private:
 

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -66,7 +66,7 @@ PointGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag
 bool PointGrid::
 valid_geo_data (const std::string& name, const geo_view_type& /* data */) const {
   // Sanity checks
-  return name=="lat" || name=="lon" || name=="area";
+  return name=="lat" || name=="lon" || name=="area" || name=="hyam" || name=="hybm";
 }
 
 std::shared_ptr<const PointGrid>
@@ -101,15 +101,16 @@ create_point_grid (const std::string& grid_name,
   using device_type       = DefaultDevice;
   using kokkos_types      = KokkosTypes<device_type>;
   using geo_view_type     = kokkos_types::view_1d<Real>;
-  using KT                = KokkosTypes<DefaultDevice>;
   using C                 = scream::physics::Constants<Real>;
 
-  // Store cell area, longitude, and latitude in geometry data.
-  // For  longitude and latitude, set values to NaN since they
-  // are currently not required from any application using PointGrid
+  // Store cell area, longitude, latitude and reference/surface pressure fractions
+  // in geometry data. For  longitude, latitude and pressure fractions, set values
+  // to NaN since they are not necessarily required from all application using PointGrid
   geo_view_type area("area", num_my_cols);
   geo_view_type lon ("lon",  num_my_cols);
   geo_view_type lat ("lat",  num_my_cols);
+  geo_view_type hyam("hyam", num_vertical_lev);
+  geo_view_type hybm("hybm", num_vertical_lev);
 
   // Estimate cell area for a uniform grid by taking the surface area
   // of the earth divided by the number of columns.  Note we do this in
@@ -117,16 +118,17 @@ create_point_grid (const std::string& grid_name,
   const Real pi        = C::Pi;
   const Real cell_area = 4.0*pi/num_my_cols;
 
-  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(num_my_cols, num_vertical_lev);
-  Kokkos::parallel_for("area_loop", policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
-    const int i = team.league_rank();
-    area(i) = cell_area;
-    lon(i) = std::nan("");
-    lat(i) = std::nan("");
-  });
+  Kokkos::deep_copy(area, cell_area);
+  Kokkos::deep_copy(lon,  std::nan(""));
+  Kokkos::deep_copy(lat,  std::nan(""));
+  Kokkos::deep_copy(hyam, std::nan(""));
+  Kokkos::deep_copy(hybm, std::nan(""));
+
   grid->set_geometry_data("area", area);
   grid->set_geometry_data("lon",  lon);
   grid->set_geometry_data("lat",  lat);
+  grid->set_geometry_data("hyam", hyam);
+  grid->set_geometry_data("hybm", hybm);
 
   return grid;
 }

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -63,12 +63,6 @@ PointGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag
   return FieldLayout({COL,vector_tag,VL},{get_num_local_dofs(),vector_dim,nvl});
 }
 
-bool PointGrid::
-valid_geo_data (const std::string& name, const geo_view_type& /* data */) const {
-  // Sanity checks
-  return name=="lat" || name=="lon" || name=="area" || name=="hyam" || name=="hybm";
-}
-
 std::shared_ptr<const PointGrid>
 create_point_grid (const std::string& grid_name,
                    const int num_global_cols,

--- a/components/scream/src/share/grid/point_grid.hpp
+++ b/components/scream/src/share/grid/point_grid.hpp
@@ -51,9 +51,6 @@ public:
   int get_partitioned_dim_global_size () const override {
     return get_num_global_dofs();
   }
-
-protected:
-  bool valid_geo_data (const std::string& name, const geo_view_type& data) const override;
 };
 
 // Create a point grid, with linear range of gids, evenly partitioned

--- a/components/scream/src/share/grid/se_grid.cpp
+++ b/components/scream/src/share/grid/se_grid.cpp
@@ -96,12 +96,4 @@ bool SEGrid::valid_lid_to_idx_map (const lid_to_idx_map_type& /*lid_to_idx*/) co
   return true;
 }
 
-bool SEGrid::
-valid_geo_data (const std::string& name, const geo_view_type& /* data */) const {
-  // Sanity checks
-  return name=="lat" || name=="lon" || name=="area";
-
-  // TODO: check actual values?
-}
-
 } // namespace scream

--- a/components/scream/src/share/grid/se_grid.hpp
+++ b/components/scream/src/share/grid/se_grid.hpp
@@ -42,7 +42,6 @@ public:
 protected:
   bool valid_dofs_list (const dofs_list_type& dofs_gids)      const override;
   bool valid_lid_to_idx_map (const lid_to_idx_map_type& lid_to_idx) const override;
-  bool valid_geo_data (const std::string& name, const geo_view_type& data) const override;
 
   // SE dims
   int       m_num_local_elem;

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -32,6 +32,7 @@ Initial Conditions:
   precip_liq_surf_mass: 0.0
   Load Latitude:  true
   Load Longitude: true
+  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -48,6 +48,7 @@ Initial Conditions:
   aero_tau_lw: 0.0
   Load Latitude:  true
   Load Longitude: true
+  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -46,6 +46,7 @@ Initial Conditions:
   precip_ice_surf_mass: 0.0
   Load Latitude:  true
   Load Longitude: true
+  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -27,6 +27,7 @@ Initial Conditions:
   surf_sens_flux: 0.0
   surf_evap: 0.0
   Load Latitude: true
+  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:


### PR DESCRIPTION
No longer grab `pref_mid` from IC files, instead compute it in `SHOCMacrophysics::initialize_impl()`. 

This requires us to grab and store `hyam,hybm` from file. This is already done inside `HommeDynamics::init_homme_vcoord ()`, so there we store into grid geometry data. For standalone tests that do not include dynamics, we add `Load Hybrid Coefficients` parameter where the AD queries, and then manually loads the `hyam/hybm`, much like latitude/longitude.

From https://github.com/E3SM-Project/scream/issues/1806, this was actually bugged and `npbl=1` for all runs. Now, for the dynamics_physics tests, `npbl=29`, and pref_mid looks like:
```
12.3825 18.2829 26.9949 39.8582 
58.8509 86.8939 128.299 189.435 
279.703 412.983 596.845 837.74 
1147.38 1533.39 1999.63 2544.47 
3159.33 3836.63 4567.12 5330.96 
6101.52 6847.64 7535.53 8194.63 
8891.05 9646.67 10466.5 11356 
12321.1 13368.2 14504.3 15737 
17074.4 18525.5 20099.9 21808.1 
23661.5 25672.4 27854.2 30221.4 
32789.8 35576.4 38599.9 41880.3 
45439.6 49246.9 53164 57062.5 
60864.4 64532 68049.8 71370.5 
74447.5 77236.3 79695.3 81786.9 
83509.5 84966.1 86317.6 87637.1 
88922.3 90171.2 91381.8 92552 
93679.9 94763.6 95801.3 96791.1 
97731.4 98620.5 99375.7 99849.6 

```