### PR TITLE
Change lower bound of FieldPositivityCheck to zero

### DIFF
--- a/components/scream/src/share/property_checks/field_positivity_check.hpp
+++ b/components/scream/src/share/property_checks/field_positivity_check.hpp
@@ -16,9 +16,7 @@ public:
   FieldPositivityCheck (const Field& f,
                         const std::shared_ptr<const AbstractGrid>& grid,
                         const bool can_repair = false)
-   : FieldLowerBoundCheck (f,grid,
-                           std::numeric_limits<double>::epsilon(),
-                           can_repair)
+   : FieldLowerBoundCheck (f,grid,0,can_repair)
   {
     // Nothing to do here
   }


### PR DESCRIPTION
I believe this is the single piece of non-BFBness that #1837 introduced. I'm turning it into its own PR, to make non-BFB changes as isolated as possible.