### PR TITLE
EAMxx: some changes to where/how the tpl targets are created

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -20,7 +20,6 @@ endif()
 set (EKAT_CMAKE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../externals/ekat/cmake)
 list(APPEND CMAKE_MODULE_PATH
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake
-     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/tpls
      ${EKAT_CMAKE_PATH}
      ${EKAT_CMAKE_PATH}/pkg_build
 )
@@ -451,6 +450,7 @@ add_custom_target(baseline_cxx)
 # scripts work correctly. We are not really interested in building/testing SCREAM.
 if (NOT DEFINED ENV{SCREAM_FAKE_ONLY})
 
+  add_subdirectory(tpls)
   add_subdirectory(src)
 
   if (NOT SCREAM_LIB_ONLY)

--- a/components/scream/cmake/tpls/CsmShare.cmake
+++ b/components/scream/cmake/tpls/CsmShare.cmake
@@ -1,9 +1,10 @@
-set (SCREAM_TPLS_MODULE_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "")
-
 macro (CreateCsmShareTarget)
+  if (TARGET csm_share)
+    message (FATAL_ERROR "Error! The target csm_share already exists!")
+  endif()
 
-  # Some sanity checks
   if (SCREAM_CIME_BUILD)
+    # Some sanity checks
     if (NOT DEFINED INSTALL_SHAREDPATH)
       message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
     endif ()
@@ -33,10 +34,7 @@ macro (CreateCsmShareTarget)
       target_link_libraries (csm_share INTERFACE ${CSM_SHARE_LIB})
       target_include_directories(csm_share INTERFACE ${CSM_SHARE})
 
-      # Create the piof interface target, and link it to csm_share, so that cmake will correctly
-      # attach it to any downstream target linking against csm_share
-      include(${SCREAM_TPLS_MODULE_DIR}/Scorpio.cmake)
-      CreateScorpioTargets()
+      # Link against piof
       target_link_libraries(csm_share INTERFACE piof)
     endif ()
   else()
@@ -89,5 +87,11 @@ macro (CreateCsmShareTarget)
       $<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CXX_COMPILER_ID:GNU>>:CPRGNU>
       $<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CXX_COMPILER_ID:Intel>>:CPRINTEL>)
 
+    if (${CMAKE_SYSTEM} MATCHES "Linux")
+      target_compile_definitions(csm_share PUBLIC LINUX)
+    endif()
+    set_target_properties(csm_share PROPERTIES
+      Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules)
+    target_include_directories(csm_share PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/modules)
   endif ()
 endmacro()

--- a/components/scream/cmake/tpls/GPTL.cmake
+++ b/components/scream/cmake/tpls/GPTL.cmake
@@ -1,22 +1,25 @@
 macro (CreateGPTLTarget)
-  # If we didn't already parse this script, proceed
-  if (NOT TARGET gptl)
-    if (SCREAM_CIME_BUILD)
-      # Some sanity checks
-      if (NOT DEFINED INSTALL_SHAREDPATH)
-        message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
-      endif ()
+  # Sanity check
+  if (TARGET gptl)
+    # We should not call this macro twice
+    message (FATAL_ERROR "The GPTL target was already created!")
+  endif()
 
-      # Look for libgptl in INSTALL_SHAREDPATH/lib
-      find_library(GPTL_LIB gptl REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
-
-      # Create the imported target that scream targets can link to
-      add_library (gptl INTERFACE)
-      target_link_libraries (gptl INTERFACE ${GPTL_LIB})
-      target_include_directories (gptl INTERFACE ${INSTALL_SHAREDPATH}/include)
-      if (NOT MPILIB STREQUAL "mpi-serial")
-        target_compile_definitions (gptl INTERFACE HAVE_MPI)
-      endif()
+  if (SCREAM_CIME_BUILD)
+    # Some sanity checks
+    if (NOT DEFINED INSTALL_SHAREDPATH)
+      message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
     endif ()
+
+    # Look for libgptl in INSTALL_SHAREDPATH/lib
+    find_library(GPTL_LIB gptl REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
+
+    # Create the imported target that scream targets can link to
+    add_library (gptl INTERFACE)
+    target_link_libraries (gptl INTERFACE ${GPTL_LIB})
+    target_include_directories (gptl INTERFACE ${INSTALL_SHAREDPATH}/include)
+    if (NOT MPILIB STREQUAL "mpi-serial")
+      target_compile_definitions (gptl INTERFACE HAVE_MPI)
+    endif()
   endif ()
 endmacro()

--- a/components/scream/cmake/tpls/Mct.cmake
+++ b/components/scream/cmake/tpls/Mct.cmake
@@ -4,26 +4,25 @@ macro (CreateMctTarget)
 
   # Some sanity checks
   if (NOT SCREAM_CIME_BUILD)
-    message (FATAL_ERROR "Error! Mct.cmake currently only works in a CIME build.")
+    message (FATAL_ERROR "Error! You should need the mct target only in CIME builds")
   endif ()
   if (NOT DEFINED INSTALL_SHAREDPATH)
     message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
   endif ()
 
-  # If we didn't already parse this script, proceed
-  if (NOT TARGET mct)
-    # Look for libmct in INSTALL_SHAREDPATH/lib
-    find_library(MCT_LIB mct REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
+  if (TARGET mct)
+    # We should not call this macro twice
+    message (FATAL_ERROR "The mct target was already created!")
+  endif()
 
-    # Create the interface library, and set target properties
-    add_library(mct INTERFACE)
-    target_link_libraries(mct INTERFACE ${MCT_LIB})
-    target_include_directories(mct INTERFACE ${INSTALL_SHAREDPATH}/include)
+  # Look for libmct in INSTALL_SHAREDPATH/lib
+  find_library(MCT_LIB mct REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
 
-    # Create the csm_share interface target, and link it to mct, so that cmake will correctly
-    # attach it to any downstream target linking against mct
-    include(${SCREAM_TPLS_MODULE_DIR}/CsmShare.cmake)
-    CreateCsmShareTarget()
-    target_link_libraries(mct INTERFACE csm_share)
-  endif ()
+  # Create the interface library, and set target properties
+  add_library(mct INTERFACE)
+  target_link_libraries(mct INTERFACE ${MCT_LIB})
+  target_include_directories(mct INTERFACE ${INSTALL_SHAREDPATH}/include)
+
+  # Link against csm_share
+  target_link_libraries(mct INTERFACE csm_share)
 endmacro()

--- a/components/scream/cmake/tpls/Scorpio.cmake
+++ b/components/scream/cmake/tpls/Scorpio.cmake
@@ -8,71 +8,69 @@ include (${SCREAM_TPLS_MODULE_DIR}/GetNetcdfLibs.cmake)
 
 macro (CreateScorpioTargets)
 
-  # If we already parsed this script, then pioc/piof are already targets
-  if (NOT TARGET pioc)
-    # Sanity check
-    if (TARGET piof)
-      message (FATAL_ERROR "Something is off: pioc ws not yet created but piof was.")
-    endif()
+  # Sanity check
+  if (TARGET pioc OR TARGET piof)
+    # We should not call this macro twice
+    message (FATAL_ERROR "The Scorpio targets were already created!")
+  endif()
 
-    if (SCREAM_CIME_BUILD)
-      # For CIME builds, we simply wrap the already built pioc/piof libs into a cmake target
-      if (NOT DEFINED INSTALL_SHAREDPATH)
-        message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
-      endif ()
-
-      set(SCORPIO_LIB_DIR ${INSTALL_SHAREDPATH}/lib)
-      set(SCORPIO_INC_DIR ${INSTALL_SHAREDPATH}/include)
-      set(CSM_SHR_INCLUDE ${INSTALL_SHAREDPATH}/${COMP_INTERFACE}/noesmf/${NINST_VALUE}/include)
-
-      # Look for pioc deps. We will have to link them to the pioc target, so that cmake will
-      # propagate them to any downstream target linking against pioc
-      CreateGPTLTarget()
-      GetNetcdfLibs()
-
-      ######################
-      #        PIOc        #
-      ######################
-
-      # Look for pioc in INSTALL_SHAREDPATH/lib
-      find_library(SCORPIO_C_LIB pioc REQUIRED PATHS ${SCORPIO_LIB_DIR})
-
-      # Create the interface library, and set target properties
-      add_library (pioc INTERFACE)
-      target_link_libraries (pioc INTERFACE ${SCORPIO_C_LIB} gptl ${netcdf_c_lib})
-      target_include_directories (pioc INTERFACE ${SCORPIO_INC_DIR} ${CSM_SHR_INCLUDE})
-      if (pnetcdf_lib)
-        target_link_libraries(pioc INTERFACE "${pnetcdf_lib}")
-      endif ()
-
-      ######################
-      #        PIOf        #
-      ######################
-
-      # Look for piof lib in INSTALL_SHAREDPATH/lib
-      find_library(SCORPIO_F_LIB piof REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
-
-      # Create the interface library, and set target properties
-      add_library(piof INTERFACE)
-      target_link_libraries (pioc INTERFACE ${SCORPIO_F_LIB} ${netcdf_f_lib} pioc)
-      target_include_directories (pioc INTERFACE ${SCORPIO_INC_DIR})
-
-    else ()
-      # Not a CIME build. We'll add scorpio as a subdir
-
-      # We don't need (yet) SCORPIO tools
-      option (PIO_ENABLE_TOOLS "Enable SCORPIO tools" OFF)
-
-      # We want to use GPTL internally
-      option (PIO_ENABLE_TIMING    "Enable the use of the GPTL timing library" ON)
-
-      # This is the default, but just in case scorpio changes it
-      option (PIO_ENABLE_FORTRAN "Enable the Fortran library builds" ON)
-
-      add_subdirectory (${E3SM_EXTERNALS_DIR}/scorpio ${CMAKE_BINARY_DIR}/externals/scorpio)
-      EkatDisableAllWarning(pioc)
-      EkatDisableAllWarning(piof)
-      EkatDisableAllWarning(gptl)
+  if (SCREAM_CIME_BUILD)
+    # For CIME builds, we simply wrap the already built pioc/piof libs into a cmake target
+    if (NOT DEFINED INSTALL_SHAREDPATH)
+      message (FATAL_ERROR "Error! The cmake variable 'INSTALL_SHAREDPATH' is not defined.")
     endif ()
+
+    set(SCORPIO_LIB_DIR ${INSTALL_SHAREDPATH}/lib)
+    set(SCORPIO_INC_DIR ${INSTALL_SHAREDPATH}/include)
+    set(CSM_SHR_INCLUDE ${INSTALL_SHAREDPATH}/${COMP_INTERFACE}/noesmf/${NINST_VALUE}/include)
+
+    # Look for pioc deps. We will have to link them to the pioc target, so that cmake will
+    # propagate them to any downstream target linking against pioc
+    CreateGPTLTarget()
+    GetNetcdfLibs()
+
+    ######################
+    #        PIOc        #
+    ######################
+
+    # Look for pioc in INSTALL_SHAREDPATH/lib
+    find_library(SCORPIO_C_LIB pioc REQUIRED PATHS ${SCORPIO_LIB_DIR})
+
+    # Create the interface library, and set target properties
+    add_library (pioc INTERFACE)
+    target_link_libraries (pioc INTERFACE ${SCORPIO_C_LIB} gptl ${netcdf_c_lib})
+    target_include_directories (pioc INTERFACE ${SCORPIO_INC_DIR} ${CSM_SHR_INCLUDE})
+    if (pnetcdf_lib)
+      target_link_libraries(pioc INTERFACE "${pnetcdf_lib}")
+    endif ()
+
+    ######################
+    #        PIOf        #
+    ######################
+
+    # Look for piof lib in INSTALL_SHAREDPATH/lib
+    find_library(SCORPIO_F_LIB piof REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
+
+    # Create the interface library, and set target properties
+    add_library(piof INTERFACE)
+    target_link_libraries (pioc INTERFACE ${SCORPIO_F_LIB} ${netcdf_f_lib} pioc)
+    target_include_directories (pioc INTERFACE ${SCORPIO_INC_DIR})
+
+  else ()
+    # Not a CIME build. We'll add scorpio as a subdir
+
+    # We don't need (yet) SCORPIO tools
+    option (PIO_ENABLE_TOOLS "Enable SCORPIO tools" OFF)
+
+    # We want to use GPTL internally
+    option (PIO_ENABLE_TIMING    "Enable the use of the GPTL timing library" ON)
+
+    # This is the default, but just in case scorpio changes it
+    option (PIO_ENABLE_FORTRAN "Enable the Fortran library builds" ON)
+
+    add_subdirectory (${E3SM_EXTERNALS_DIR}/scorpio ${CMAKE_BINARY_DIR}/externals/scorpio)
+    EkatDisableAllWarning(pioc)
+    EkatDisableAllWarning(piof)
+    EkatDisableAllWarning(gptl)
   endif ()
 endmacro()

--- a/components/scream/src/CMakeLists.txt
+++ b/components/scream/src/CMakeLists.txt
@@ -1,11 +1,5 @@
 add_subdirectory(share)
 
-# Also handle csm_share. If this is a CIME build,
-# it will wrap the lib in a cmake target, otherwise
-# it will build a small lib (same name in both cases).
-include(${SCREAM_TPLS_MODULE_DIR}/CsmShare.cmake)
-CreateCsmShareTarget()
-
 add_subdirectory(dynamics)
 add_subdirectory(physics)
 add_subdirectory(diagnostics)

--- a/components/scream/src/mct_coupling/CMakeLists.txt
+++ b/components/scream/src/mct_coupling/CMakeLists.txt
@@ -39,9 +39,6 @@ set (SCREAM_LIBS
      spa
 )
 
-include (tpls/Mct)
-CreateMctTarget()
-
 # Create atm lib
 add_library(atm ${ATM_SRC})
 

--- a/components/scream/src/share/CMakeLists.txt
+++ b/components/scream/src/share/CMakeLists.txt
@@ -1,23 +1,5 @@
 include (EkatSetCompilerFlags)
 
-# We need to link against GPTL.
-if (SCREAM_CIME_BUILD)
-  # In CIME builds, GPTL is built by CIME, during the sharedlib phase.
-  # So simply wrap the gptl lib in an imported target
-  include (GPTL)
-  CreateGPTLTarget()
-else ()
-  # In standalone builds, GPTL is built by Scorpio. Unfortunately,
-  # as of today (04/2022), there is no way to pre-build GPTL from
-  # scorpio, without scorpio trying to build it again.
-  # The only way scorpio skips GPTL is if there is an *installation*
-  # of GPTL somewhere, while we want to build it on the fly
-  # So simply process Scorpio now, so that we have GPTL available
-  # for scream_share to link against.
-  include (Scorpio)
-  CreateScorpioTargets()
-endif()
-
 set(SHARE_SRC
   scream_config.cpp
   scream_session.cpp

--- a/components/scream/src/share/io/CMakeLists.txt
+++ b/components/scream/src/share/io/CMakeLists.txt
@@ -14,6 +14,10 @@ set_target_properties(scream_io PROPERTIES Fortran_MODULE_DIRECTORY ${SCREAM_F90
 target_link_libraries(scream_io PUBLIC scream_share diagnostics piof)
 target_compile_options(scream_io PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>)
 
+if (SCREAM_CIME_BUILD)
+  target_link_libraries(scream_io PUBLIC csm_share)
+endif()
+
 if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)
 endif()

--- a/components/scream/src/share/io/CMakeLists.txt
+++ b/components/scream/src/share/io/CMakeLists.txt
@@ -8,19 +8,10 @@ set(SCREAM_SCORPIO_SRCS
   scream_io_utils.cpp
 )
 
-# Create or import scorpio targets
-include (${SCREAM_BASE_DIR}/cmake/tpls/Scorpio.cmake)
-CreateScorpioTargets()
-
-set (SCREAM_CIME_LIBS
-     pioc
-     piof
-)
-
 # Create io lib
 add_library(scream_io ${SCREAM_SCORPIO_SRCS})
 set_target_properties(scream_io PROPERTIES Fortran_MODULE_DIRECTORY ${SCREAM_F90_MODULES})
-target_link_libraries(scream_io PUBLIC scream_share diagnostics ${SCREAM_CIME_LIBS})
+target_link_libraries(scream_io PUBLIC scream_share diagnostics piof)
 target_compile_options(scream_io PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>)
 
 if (NOT SCREAM_LIB_ONLY)

--- a/components/scream/tpls/CMakeLists.txt
+++ b/components/scream/tpls/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Here, we process a few shared libraries shipped with e3sm.
+# For each of them, we either
+#   - build the library (standalone build) or
+#   - wrap pre-built library in a CMake target (CIME build)
+
+# First pioc/piof, since we link against it in csm_share (at least in CIME build)
+include (${SCREAM_BASE_DIR}/cmake/tpls/Scorpio.cmake)
+CreateScorpioTargets()
+
+# Then csm_share
+include (${SCREAM_BASE_DIR}/cmake/tpls/CsmShare.cmake)
+CreateCsmShareTarget()
+
+if (SCREAM_CIME_BUILD)
+  # For CIME runs, wrap mct in a target too
+  include (${SCREAM_BASE_DIR}/cmake/tpls/Mct.cmake)
+  CreateMctTarget()
+endif()


### PR DESCRIPTION
PR #1850 caused the bld tree to contain spurious files in the main scream folder. This PR reorganizes a bit tpls, to keep bld tree clean, and centralize a bit the handling of all sharedlib tpls dependencies, in both CIME and STANDALONE builds.

Namely:
 - Handle all shared libs config once, before parsing any scream src folder.
 - Handle them inside a "tpls" subdir, to hide any potential src/obj/lib file created in the process.
 - In standalone, when appropriate, add `LINUX` macro to csm_share target, to more accurately mimic what CIME would do.
 