### PR TITLE
Switch PEM test from ne30 to ne30pg2.

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -474,7 +474,7 @@ _TESTS = {
         "tests" : (
             #  "SMS_D_Ln2.ne30_ne30.F2000-SCREAMv1-AQP1", # Uncomment once IC file for ne30 is ready
             "ERS_Ln22.ne30_ne30.F2010-SCREAMv1",
-            "PEM_Ln9.ne30_ne30.F2010-SCREAMv1",
+            "PEM_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1",
             "ERS_Ln22.ne30pg2_ne30pg2.F2010-SCREAMv1",
             )
     },


### PR DESCRIPTION
This fits within the allocated nodes on ascent (based on testing on summit).

I've also lengthened the test to 90 steps, which runs in ~200s. I think a longer
PEM test is useful.