### PR TITLE
Adds pami lib to jsrun for the summit machine file

### DIFF
--- a/components/scream/cmake/machine-files/summit.cmake
+++ b/components/scream/cmake/machine-files/summit.cmake
@@ -9,6 +9,6 @@ else()
   set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
 endif()
 
-set(SCREAM_MPIRUN_EXE "jsrun" CACHE STRING "")
+set(SCREAM_MPIRUN_EXE "jsrun -E LD_PRELOAD=/opt/ibm/spectrum_mpi/lib/pami_490/libpami.so" CACHE STRING "")
 set(SCREAM_MPI_NP_FLAG "-n" CACHE STRING "")
 set(SCREAM_MACHINE "summit" CACHE STRING "")


### PR DESCRIPTION
Running scream standalone tests on Summit were causing the following errors/warnings:
`CUDA Hook Library: Failed to find symbol mem_find_dreg_entries, exe: undefined symbol: __PAMI_Invalidate_region`

Adding the path to the pami lib in the jsrun command fixes it.