### PR TITLE
Use 64bits integers for offsets inside scorpio interface

### DIFF
--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -382,7 +382,7 @@ void SPAFunctions<S,D>
   scorpio::get_variable(remap_file_name, "row", "row", vec_of_dims.size(), vec_of_dims, PIO_INT, i_decomp);
   scorpio::get_variable(remap_file_name, "col", "col", vec_of_dims.size(), vec_of_dims, PIO_INT, i_decomp);
   // Set the dof's to read in variables, since we will have all mpi ranks read in the full set of data the dof's are the whole array
-  std::vector<int> var_dof(spa_horiz_interp.length);
+  std::vector<scorpio::offset_t> var_dof(spa_horiz_interp.length);
   std::iota(var_dof.begin(),var_dof.end(),0);
   scorpio::set_dof(remap_file_name,"S",var_dof.size(),var_dof.data());
   scorpio::set_dof(remap_file_name,"row",var_dof.size(),var_dof.data());

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -480,10 +480,11 @@ void AtmosphereInput::set_degrees_of_freedom()
 } // set_degrees_of_freedom
 
 /* ---------------------------------------------------------- */
-std::vector<int> AtmosphereInput::
+auto AtmosphereInput::
 get_var_dof_offsets(const FieldLayout& layout)
+ -> std::vector<offset_t>
 {
-  std::vector<int> var_dof(layout.size());
+  std::vector<offset_t> var_dof(layout.size());
 
   // Gather the offsets of the dofs of this variable w.r.t. the *global* array.
   // Since we order the global array based on dof gid, and we *assume* (we actually
@@ -501,7 +502,7 @@ get_var_dof_offsets(const FieldLayout& layout)
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
-    int col_size = layout.size() / num_cols;
+    offset_t col_size = layout.size() / num_cols;
 
     auto dofs = m_io_grid->get_dofs_gids();
     auto dofs_h = Kokkos::create_mirror_view(dofs);
@@ -518,7 +519,7 @@ get_var_dof_offsets(const FieldLayout& layout)
 
       // Compute start of the column offset, then fill column adding 1 to each entry
       auto gid = dofs_h(icol);
-      auto offset = (gid-min_gid)*col_size;
+      offset_t offset = (gid-min_gid)*col_size;
       std::iota(start,end,offset);
     }
   } else if (layout.has_tag(ShortFieldTagsNames::EL)) {
@@ -529,7 +530,7 @@ get_var_dof_offsets(const FieldLayout& layout)
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
-    int col_size = layout.size() / num_cols;
+    offset_t col_size = layout.size() / num_cols;
 
     auto dofs = m_io_grid->get_dofs_gids();
     auto dofs_h = Kokkos::create_mirror_view(dofs);

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -480,11 +480,10 @@ void AtmosphereInput::set_degrees_of_freedom()
 } // set_degrees_of_freedom
 
 /* ---------------------------------------------------------- */
-auto AtmosphereInput::
-get_var_dof_offsets(const FieldLayout& layout)
- -> std::vector<offset_t>
+std::vector<scorpio::offset_t>
+AtmosphereInput::get_var_dof_offsets(const FieldLayout& layout)
 {
-  std::vector<offset_t> var_dof(layout.size());
+  std::vector<scorpio::offset_t> var_dof(layout.size());
 
   // Gather the offsets of the dofs of this variable w.r.t. the *global* array.
   // Since we order the global array based on dof gid, and we *assume* (we actually
@@ -502,7 +501,7 @@ get_var_dof_offsets(const FieldLayout& layout)
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
-    offset_t col_size = layout.size() / num_cols;
+    scorpio::offset_t col_size = layout.size() / num_cols;
 
     auto dofs = m_io_grid->get_dofs_gids();
     auto dofs_h = Kokkos::create_mirror_view(dofs);
@@ -519,7 +518,7 @@ get_var_dof_offsets(const FieldLayout& layout)
 
       // Compute start of the column offset, then fill column adding 1 to each entry
       auto gid = dofs_h(icol);
-      offset_t offset = (gid-min_gid)*col_size;
+      scorpio::offset_t offset = (gid-min_gid)*col_size;
       std::iota(start,end,offset);
     }
   } else if (layout.has_tag(ShortFieldTagsNames::EL)) {
@@ -530,7 +529,7 @@ get_var_dof_offsets(const FieldLayout& layout)
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
-    offset_t col_size = layout.size() / num_cols;
+    scorpio::offset_t col_size = layout.size() / num_cols;
 
     auto dofs = m_io_grid->get_dofs_gids();
     auto dofs_h = Kokkos::create_mirror_view(dofs);

--- a/components/scream/src/share/io/scorpio_input.hpp
+++ b/components/scream/src/share/io/scorpio_input.hpp
@@ -135,7 +135,6 @@ public:
   void finalize();
 
 protected:
-  using offset_t = std::int64_t;
 
   void set_fields_and_grid_names (const std::string& grid_name);
   void build_remapper (const std::shared_ptr<const gm_type>& grids_mgr);
@@ -153,7 +152,7 @@ protected:
 
   std::vector<std::string> get_vec_of_dims (const FieldLayout& layout);
   std::string get_io_decomp (const FieldLayout& layout);
-  std::vector<offset_t> get_var_dof_offsets (const FieldLayout& layout);
+  std::vector<scorpio::offset_t> get_var_dof_offsets (const FieldLayout& layout);
 
   // Internal variables
   ekat::Comm            m_comm;

--- a/components/scream/src/share/io/scorpio_input.hpp
+++ b/components/scream/src/share/io/scorpio_input.hpp
@@ -135,6 +135,7 @@ public:
   void finalize();
 
 protected:
+  using offset_t = std::int64_t;
 
   void set_fields_and_grid_names (const std::string& grid_name);
   void build_remapper (const std::shared_ptr<const gm_type>& grids_mgr);
@@ -152,7 +153,7 @@ protected:
 
   std::vector<std::string> get_vec_of_dims (const FieldLayout& layout);
   std::string get_io_decomp (const FieldLayout& layout);
-  std::vector<int> get_var_dof_offsets (const FieldLayout& layout);
+  std::vector<offset_t> get_var_dof_offsets (const FieldLayout& layout);
 
   // Internal variables
   ekat::Comm            m_comm;

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -494,11 +494,10 @@ void AtmosphereOutput::register_variables(const std::string& filename)
   }
 } // register_variables
 /* ---------------------------------------------------------- */
-auto AtmosphereOutput::
-get_var_dof_offsets(const FieldLayout& layout)
- -> std::vector<offset_t>
+std::vector<scorpio::offset_t>
+AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
 {
-  std::vector<offset_t> var_dof(layout.size());
+  std::vector<scorpio::offset_t> var_dof(layout.size());
 
   // Gather the offsets of the dofs of this variable w.r.t. the *global* array.
   // Since we order the global array based on dof gid, and we *assume* (we actually
@@ -519,7 +518,7 @@ get_var_dof_offsets(const FieldLayout& layout)
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
-    offset_t col_size = layout.size() / num_cols;
+    scorpio::offset_t col_size = layout.size() / num_cols;
 
     auto dofs = m_io_grid->get_dofs_gids();
     auto dofs_h = Kokkos::create_mirror_view(dofs);
@@ -547,7 +546,7 @@ get_var_dof_offsets(const FieldLayout& layout)
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
-    offset_t col_size = layout.size() / num_cols;
+    scorpio::offset_t col_size = layout.size() / num_cols;
 
     auto dofs = m_io_grid->get_dofs_gids();
     auto dofs_h = Kokkos::create_mirror_view(dofs);

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -494,9 +494,11 @@ void AtmosphereOutput::register_variables(const std::string& filename)
   }
 } // register_variables
 /* ---------------------------------------------------------- */
-std::vector<int> AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
+auto AtmosphereOutput::
+get_var_dof_offsets(const FieldLayout& layout)
+ -> std::vector<offset_t>
 {
-  std::vector<int> var_dof(layout.size());
+  std::vector<offset_t> var_dof(layout.size());
 
   // Gather the offsets of the dofs of this variable w.r.t. the *global* array.
   // Since we order the global array based on dof gid, and we *assume* (we actually
@@ -517,7 +519,7 @@ std::vector<int> AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
-    int col_size = layout.size() / num_cols;
+    offset_t col_size = layout.size() / num_cols;
 
     auto dofs = m_io_grid->get_dofs_gids();
     auto dofs_h = Kokkos::create_mirror_view(dofs);
@@ -545,7 +547,7 @@ std::vector<int> AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
-    int col_size = layout.size() / num_cols;
+    offset_t col_size = layout.size() / num_cols;
 
     auto dofs = m_io_grid->get_dofs_gids();
     auto dofs_h = Kokkos::create_mirror_view(dofs);

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -147,8 +147,6 @@ public:
 
   long long res_dep_memory_footprint () const;
 protected:
-  using offset_t = std::int64_t;
-
   // Internal functions
   void set_field_manager (const std::shared_ptr<const fm_type>& field_mgr);
   void set_grid (const std::shared_ptr<const AbstractGrid>& grid);
@@ -156,7 +154,7 @@ protected:
   void register_dimensions(const std::string& name);
   void register_variables(const std::string& filename);
   void set_degrees_of_freedom(const std::string& filename);
-  std::vector<offset_t> get_var_dof_offsets (const FieldLayout& layout);
+  std::vector<scorpio::offset_t> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
   Field get_field(const std::string& name, const bool eval_diagnostic = false);
   void set_diagnostics();

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -147,6 +147,7 @@ public:
 
   long long res_dep_memory_footprint () const;
 protected:
+  using offset_t = std::int64_t;
 
   // Internal functions
   void set_field_manager (const std::shared_ptr<const fm_type>& field_mgr);
@@ -155,7 +156,7 @@ protected:
   void register_dimensions(const std::string& name);
   void register_variables(const std::string& filename);
   void set_degrees_of_freedom(const std::string& filename);
-  std::vector<int> get_var_dof_offsets (const FieldLayout& layout);
+  std::vector<offset_t> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
   Field get_field(const std::string& name, const bool eval_diagnostic = false);
   void set_diagnostics();

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -213,7 +213,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
       }
 
       // Set degree of freedom for "time"
-      int time_dof[1] = {0};
+      std::int64_t time_dof[1] = {0};
       set_dof(filename,"time",0,time_dof);
 
       // Finish the definition phase for this file.

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -120,7 +120,7 @@ module scream_scorpio_interface
     integer          :: numdims               ! Number of dimensions in out field
     type(io_desc_t), pointer  :: iodesc       ! PIO decomp associated with this variable
     type(iodesc_list_t), pointer  :: iodesc_list ! PIO decomp list with metadata about PIO decomp
-    integer, allocatable :: compdof(:)        ! Global locations in output array for this process
+    integer(kind=pio_offset_kind), allocatable :: compdof(:)        ! Global locations in output array for this process
     integer, allocatable :: dimid(:)          ! array of PIO dimension id's for this variable
     integer, allocatable :: dimlen(:)         ! array of PIO dimension lengths for this variable
     logical              :: has_t_dim         ! true, if variable has a time dimension
@@ -791,7 +791,7 @@ contains
 !=====================================================================!
   ! Helper function to debug list of decomps 
   subroutine print_decomp()
-    type(iodesc_list_t),   pointer :: iodesc_ptr, next, prev
+    type(iodesc_list_t),   pointer :: iodesc_ptr
 
     integer :: total
     integer :: cnt 
@@ -840,7 +840,7 @@ contains
   ! taken whenever a file is closed.
   subroutine free_decomp()
     use piolib_mod, only: PIO_freedecomp
-    type(iodesc_list_t),   pointer :: iodesc_ptr, next, prev
+    type(iodesc_list_t),   pointer :: iodesc_ptr, next
 
     ! Free all decompositions from PIO
     iodesc_ptr => iodesc_list_top
@@ -946,7 +946,7 @@ contains
     character(len=*)          :: tag              ! Unique tag string describing this output grid
     integer, intent(in)       :: dtype            ! Datatype associated with the output
     integer, intent(in)       :: dimension_len(:) ! Array of the dimension lengths for this decomp
-    integer, intent(in)       :: compdof(:)       ! The degrees of freedom this rank is responsible for
+    integer(kind=pio_offset_kind), intent(in) :: compdof(:)       ! The degrees of freedom this rank is responsible for
     type(iodesc_list_t), pointer :: iodesc_list   ! The pio decomposition list that holds this iodesc 
 
     logical                     :: found            ! Whether a decomp has been found among the previously defined decompositions
@@ -1023,15 +1023,15 @@ contains
   ! Rank 2: (4,5,6)
   ! Rank 3: (7,8,9,10)
   subroutine set_dof(filename,varname,dof_len,dof_vec)
-    character(len=*), intent(in)            :: filename
-    character(len=*), intent(in)            :: varname
-    integer, intent(in)                     :: dof_len
-    integer, intent(in), dimension(dof_len) :: dof_vec
+    character(len=*), intent(in)              :: filename
+    character(len=*), intent(in)              :: varname
+    integer, intent(in)                       :: dof_len
+    integer(kind=pio_offset_kind), intent(in) :: dof_vec(dof_len)
 
-    type(pio_atm_file_t),pointer            :: pio_atm_file
-    type(hist_var_t), pointer               :: var
-    logical                                 :: found
-    integer                                 :: ii
+    type(pio_atm_file_t),pointer              :: pio_atm_file
+    type(hist_var_t), pointer                 :: var
+    logical                                   :: found
+    integer                                   :: ii
 
     call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
     call get_var(pio_atm_file,varname,var)

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -14,7 +14,7 @@ extern "C" {
 // Fortran routines to be called from C++
   void register_file_c2f(const char*&& filename, const int& mode);
   void set_decomp_c2f(const char*&& filename);
-  void set_dof_c2f(const char*&& filename,const char*&& varname,const Int dof_len,const Int *x_dof);
+  void set_dof_c2f(const char*&& filename,const char*&& varname,const Int dof_len,const std::int64_t *x_dof);
   void grid_read_data_array_c2f(const char*&& filename, const char*&& varname, const Int time_index, void *&hbuf);
 
   void grid_write_data_array_c2f_real(const char*&& filename, const char*&& varname, const Real*& hbuf);
@@ -59,7 +59,7 @@ void set_decomp(const std::string& filename) {
   set_decomp_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
-void set_dof(const std::string& filename, const std::string& varname, const Int dof_len, const Int* x_dof) {
+void set_dof(const std::string& filename, const std::string& varname, const Int dof_len, const std::int64_t* x_dof) {
 
   set_dof_c2f(filename.c_str(),varname.c_str(),dof_len,x_dof);
 }

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -40,7 +40,7 @@ namespace scorpio {
   /* Sets the IO decompostion for all variables in a particular filename.  Required after all variables have been registered.  Called once per file. */
   void set_decomp(const std::string& filename);
   /* Sets the degrees-of-freedom for a particular variable in a particular file.  Called once for each variable, for each file. */
-  void set_dof(const std::string &filename, const std::string &varname, const Int dof_len, const Int* x_dof);
+  void set_dof(const std::string &filename, const std::string &varname, const Int dof_len, const std::int64_t* x_dof);
   /* Register a dimension coordinate with a file. Called during the file setup. */
   void register_dimension(const std::string& filename,const std::string& shortname, const std::string& longname, const int length);
   /* Register a variable with a file.  Called during the file setup, for an output stream. */

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -23,6 +23,8 @@ static constexpr int PIO_INT = 4;
 namespace scream {
 namespace scorpio {
 
+  using offset_t = std::int64_t;
+
   // WARNING: these values must match the ones of file_purpose_in and file_purpose_out
   // in the scream_scorpio_interface F90 module
   enum FileMode {
@@ -40,7 +42,7 @@ namespace scorpio {
   /* Sets the IO decompostion for all variables in a particular filename.  Required after all variables have been registered.  Called once per file. */
   void set_decomp(const std::string& filename);
   /* Sets the degrees-of-freedom for a particular variable in a particular file.  Called once for each variable, for each file. */
-  void set_dof(const std::string &filename, const std::string &varname, const Int dof_len, const std::int64_t* x_dof);
+  void set_dof(const std::string &filename, const std::string &varname, const Int dof_len, const offset_t* x_dof);
   /* Register a dimension coordinate with a file. Called during the file setup. */
   void register_dimension(const std::string& filename,const std::string& shortname, const std::string& longname, const int length);
   /* Register a variable with a file.  Called during the file setup, for an output stream. */

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -1,5 +1,5 @@
 module scream_scorpio_interface_iso_c2f
-  use iso_c_binding
+  use iso_c_binding, only: c_int, c_double, c_float, c_bool, c_ptr
   implicit none
      
 #include "scream_config.f"
@@ -69,16 +69,17 @@ contains
   end subroutine set_decomp_c2f
 !=====================================================================!
   subroutine set_dof_c2f(filename_in,varname_in,dof_len,dof_vec) bind(c)
-    use scream_scorpio_interface, only : set_dof
+    use scream_scorpio_interface, only : set_dof, pio_offset_kind
+    use iso_c_binding, only: c_int64_t
     type(c_ptr), intent(in)                             :: filename_in
     type(c_ptr), intent(in)                             :: varname_in
     integer(kind=c_int), value, intent(in)              :: dof_len
-    integer(kind=c_int), intent(in), dimension(dof_len) :: dof_vec
+    integer(kind=c_int64_t), intent(in), dimension(dof_len) :: dof_vec
 
-    character(len=256)          :: filename
-    character(len=256)          :: varname
-    integer, dimension(dof_len) :: dof_vec_f90
-    integer                     :: ii
+    character(len=256)            :: filename
+    character(len=256)            :: varname
+    integer(kind=pio_offset_kind) :: dof_vec_f90(dof_len)
+    integer                       :: ii
 
     call convert_c_string(filename_in,filename)
     call convert_c_string(varname_in,varname)
@@ -246,6 +247,7 @@ contains
   end subroutine eam_pio_enddef_c2f
 !=====================================================================!
   subroutine convert_c_string(c_string_ptr,f_string)
+    use iso_c_binding, only: c_f_pointer, C_NULL_CHAR
   ! Purpose: To convert a c_string pointer to the proper fortran string format.
     type(c_ptr), intent(in) :: c_string_ptr
     character(len=256), intent(out) :: f_string
@@ -256,7 +258,6 @@ contains
     str_len = index(temp_string, C_NULL_CHAR) - 1
     f_string = trim(temp_string(1:str_len))
     
-    return
   end subroutine convert_c_string
 !=====================================================================!
   subroutine grid_write_data_array_c2f_real(filename_in,varname_in,var_data_ptr) bind(c)


### PR DESCRIPTION
With ne1024 we hit a problem with our scorpio interface, which uses integers (32 bits) for offsets in the global array. With ne1024, and 128 levels, we have more than 7B unknowns for 3d variables, which cause integer overflow.

Fixes #1846 (hopefully).