### PR TITLE
Change to use mosart and mpassi for F2010-SCREAMv1 and update the tests

### DIFF
--- a/cime_config/testmods_dirs/atmlndactive/rtm_off/README
+++ b/cime_config/testmods_dirs/atmlndactive/rtm_off/README
@@ -1,0 +1,9 @@
+Modifications (in shell_commands) to enable a hybrid run for SSP compsets
+(e.g., SSp370 or SSP585), starting from 2015-01-01 of v2.LR.historical_0101
+
+Other modifications (same as for wcprod) should result in a case that has the 
+same namelist settings as the water cycle production sims
+
+Run these for at least 1 day to see all output.
+Also use the CMIP6 compsets.
+If running longer, change the nhtfrq for the first history file.

--- a/cime_config/testmods_dirs/atmlndactive/rtm_off/README
+++ b/cime_config/testmods_dirs/atmlndactive/rtm_off/README
@@ -1,9 +1,4 @@
-Modifications (in shell_commands) to enable a hybrid run for SSP compsets
-(e.g., SSp370 or SSP585), starting from 2015-01-01 of v2.LR.historical_0101
-
-Other modifications (same as for wcprod) should result in a case that has the 
-same namelist settings as the water cycle production sims
-
-Run these for at least 1 day to see all output.
-Also use the CMIP6 compsets.
-If running longer, change the nhtfrq for the first history file.
+This test mod ican be used to disable river model mosart during runtime
+for compsets that use mosart as river model. In practice, this is used 
+for ERS and ERP tests with F2010-SCREAMv1 after it was changed to use 
+mosart in place of srof. 

--- a/cime_config/testmods_dirs/atmlndactive/rtm_off/README
+++ b/cime_config/testmods_dirs/atmlndactive/rtm_off/README
@@ -1,4 +1,5 @@
-This test mod ican be used to disable river model mosart during runtime
+This test mod can be used to disable river model mosart during runtime
 for compsets that use mosart as river model. In practice, this is used 
 for ERS and ERP tests with F2010-SCREAMv1 after it was changed to use 
 mosart in place of srof. 
+

--- a/cime_config/testmods_dirs/atmlndactive/rtm_off/user_nl_mosart
+++ b/cime_config/testmods_dirs/atmlndactive/rtm_off/user_nl_mosart
@@ -1,0 +1,6 @@
+! disable rtm to allow short ERS and ERP run to complete. 
+! If rtm active, due to large rtm time step, restart pointer for ROF
+! is always ahead of that for atm at the end of the first run. And in 
+! restart run, the restart point for ROF becomes later than the run stop time
+
+ do_rtm =.false.

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -461,6 +461,7 @@ _TESTS = {
     "e3sm_scream_v1_lowres" : {
         "time"  : "01:00:00",
         "tests" : (
+            "ERP_D_Ln9.ne4_ne4.F2010-SCREAMv1-CICE",
             "ERP_D_Ln9.ne4_oQU240.F2010-SCREAMv1.atmlndactive-rtm_off",
             "ERS_Ln9.ne4_ne4.F2000-SCREAMv1-AQP1",
             "SMS_D_Ln9.ne4_oQU240.F2010-SCREAMv1-noAero",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -461,11 +461,11 @@ _TESTS = {
     "e3sm_scream_v1_lowres" : {
         "time"  : "01:00:00",
         "tests" : (
-            "ERP_D_Ln9.ne4_ne4.F2010-SCREAMv1",
+            "ERP_D_Ln9.ne4_oQU240.F2010-SCREAMv1.atmlndactive-rtm_off",
             "ERS_Ln9.ne4_ne4.F2000-SCREAMv1-AQP1",
-            "SMS_D_Ln9.ne4_ne4.F2010-SCREAMv1-noAero",
-            "ERP_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1",
-            "ERS_D_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1",
+            "SMS_D_Ln9.ne4_oQU240.F2010-SCREAMv1-noAero",
+            "ERP_Ln22.ne4pg2_oQU480.F2010-SCREAMv1.atmlndactive-rtm_off",
+            "ERS_D_Ln22.ne4pg2_oQU480.F2010-SCREAMv1.atmlndactive-rtm_off",
             )
     },
 
@@ -473,9 +473,9 @@ _TESTS = {
         "time"  : "02:00:00",
         "tests" : (
             #  "SMS_D_Ln2.ne30_ne30.F2000-SCREAMv1-AQP1", # Uncomment once IC file for ne30 is ready
-            "ERS_Ln22.ne30_ne30.F2010-SCREAMv1",
-            "PEM_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1",
-            "ERS_Ln22.ne30pg2_ne30pg2.F2010-SCREAMv1",
+            "ERS_Ln22.ne30_oECv3.F2010-SCREAMv1.atmlndactive-rtm_off",
+            "PEM_Ln90.ne30pg2_EC30to60E2r2.F2010-SCREAMv1",
+            "ERS_Ln22.ne30pg2_EC30to60E2r2.F2010-SCREAMv1.atmlndactive-rtm_off",
             )
     },
 

--- a/components/scream/cime_config/config_compsets.xml
+++ b/components/scream/cime_config/config_compsets.xml
@@ -23,7 +23,7 @@
 
   <compset>
       <alias>F2010-SCREAMv1</alias> <!-- Coupled land-atm compset (using SCREAMv1), 2010 initial conditions -->
-      <lname>2010_SCREAM_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP</lname>
+      <lname>2010_SCREAM_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP</lname>
       <support_level>Experimental, under development</support_level>
   </compset>
 
@@ -35,7 +35,7 @@
 
   <compset>
       <alias>F2010-SCREAMv1-noAero</alias> <!-- Coupled land-atm compset (using SCREAMv1), 2010 initial conditions, turn off Aerosol forcing -->
-      <lname>2010_SCREAM%noAero_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP</lname>
+      <lname>2010_SCREAM%noAero_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP</lname>
       <support_level>Experimental, under development</support_level>
   </compset>
 

--- a/components/scream/cime_config/config_compsets.xml
+++ b/components/scream/cime_config/config_compsets.xml
@@ -28,6 +28,12 @@
   </compset>
 
   <compset>
+      <alias>F2010-SCREAMv1-CICE</alias> <!-- Coupled land-atm compset (using SCREAMv1), 2010 initial conditions -->
+      <lname>2010_SCREAM_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP</lname>
+      <support_level>Experimental, under development</support_level>
+  </compset>
+
+  <compset>
       <alias>F2000-SCREAMv1-AQP1</alias> <!-- atm aquaplanet compset (using SCREAMv1), 2000 initial conditions -->
       <lname>2000_SCREAM%AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
       <support_level>Experimental, under development</support_level>


### PR DESCRIPTION
This PR changes to use MOSART for river and replaces CICE with MPASSI
 for compsets F2010-SCREAMv1 and F2010-SCREAMv1-noAero. The tests
for F2010-SCREAMv1 lowres and medres are updated accordingly. The 
original compset is retained as F2010-SCREAMv1-CICE along with a test.

With mpassi for F2010-SCREAMv1, the grids used for the tests
must be replaced because mpassi can not run on atm se grid.
With mosart as river model for the compset and because of its
much larger time stepping, ERS_Ln# and ERP_Ln# tests would always
end up having mosart restart point being ahead of the stop time of
the restart run, which would fail to proceed. Changes to ERS_Ld3
and ERP_Ld3 could work, but it would take longer time. Furthermore
with _Ld3, REST_N=2days is being treated as 2 steps, leading to
much frequent writing of scream.r and mismatched atm restart time stamp
for ERP test's case2run.

To overcome these restart issue with the updated F2010-SCREAMv1, given
river model does not impact the atm results, a new test mod,
atmlndactive-rtm_off, is introduced to turn off the river model. This mode
is used for the updated ERS and ERP tests.

[non-BFB] for all tests using F2010-SCREAMv1 and F2010-SCREAMv1-noAero
                because of the grid changes and the use of the new testmod,
                the updated F2010-SCREAMv1 lowres and medres tests will become
                new tests and the original ones become missing.