### PR TITLE
Pass in smaller extent (to ncol) for certain arrays to clip_values (affecting v0)

### DIFF
--- a/components/eam/src/physics/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/rrtmgp/radiation.F90
@@ -1389,9 +1389,9 @@ contains
                end if
 
                ! Check (and possibly clip) values before passing to RRTMGP driver
-               call handle_error(clip_values(cld_tau_gpt_sw,  0._r8, huge(cld_tau_gpt_sw), trim(subname) // ' cld_tau_gpt_sw', tolerance=1e-10_r8))
-               call handle_error(clip_values(cld_ssa_gpt_sw,  0._r8,                1._r8, trim(subname) // ' cld_ssa_gpt_sw', tolerance=1e-10_r8))
-               call handle_error(clip_values(cld_asm_gpt_sw, -1._r8,                1._r8, trim(subname) // ' cld_asm_gpt_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(cld_tau_gpt_sw(1:ncol,:,:),  0._r8, huge(cld_tau_gpt_sw), trim(subname) // ' cld_tau_gpt_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(cld_ssa_gpt_sw(1:ncol,:,:),  0._r8,                1._r8, trim(subname) // ' cld_ssa_gpt_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(cld_asm_gpt_sw(1:ncol,:,:), -1._r8,                1._r8, trim(subname) // ' cld_asm_gpt_sw', tolerance=1e-10_r8))
                call handle_error(clip_values(aer_tau_bnd_sw(1:ncol,:,:),  0._r8, huge(aer_tau_bnd_sw), trim(subname) // ' aer_tau_bnd_sw', tolerance=1e-10_r8))
                call handle_error(clip_values(aer_ssa_bnd_sw(1:ncol,:,:),  0._r8,                1._r8, trim(subname) // ' aer_ssa_bnd_sw', tolerance=1e-10_r8))
                call handle_error(clip_values(aer_asm_bnd_sw(1:ncol,:,:), -1._r8,                1._r8, trim(subname) // ' aer_asm_bnd_sw', tolerance=1e-10_r8))
@@ -1482,7 +1482,7 @@ contains
                end if
 
                ! Check (and possibly clip) values before passing to RRTMGP driver
-               call handle_error(clip_values(cld_tau_gpt_lw,  0._r8, huge(cld_tau_gpt_lw), trim(subname) // ': cld_tau_gpt_lw', tolerance=1e-10_r8))
+               call handle_error(clip_values(cld_tau_gpt_lw(1:ncol,:,:),  0._r8, huge(cld_tau_gpt_lw), trim(subname) // ': cld_tau_gpt_lw', tolerance=1e-10_r8))
                call handle_error(clip_values(aer_tau_bnd_lw(1:ncol,:,:),  0._r8, huge(aer_tau_bnd_lw), trim(subname) // ': aer_tau_bnd_lw', tolerance=1e-10_r8))
 
                ! Call the longwave radiation driver to calculate fluxes and heating rates

--- a/components/eam/src/physics/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/rrtmgp/radiation.F90
@@ -1392,9 +1392,9 @@ contains
                call handle_error(clip_values(cld_tau_gpt_sw,  0._r8, huge(cld_tau_gpt_sw), trim(subname) // ' cld_tau_gpt_sw', tolerance=1e-10_r8))
                call handle_error(clip_values(cld_ssa_gpt_sw,  0._r8,                1._r8, trim(subname) // ' cld_ssa_gpt_sw', tolerance=1e-10_r8))
                call handle_error(clip_values(cld_asm_gpt_sw, -1._r8,                1._r8, trim(subname) // ' cld_asm_gpt_sw', tolerance=1e-10_r8))
-               call handle_error(clip_values(aer_tau_bnd_sw,  0._r8, huge(aer_tau_bnd_sw), trim(subname) // ' aer_tau_bnd_sw', tolerance=1e-10_r8))
-               call handle_error(clip_values(aer_ssa_bnd_sw,  0._r8,                1._r8, trim(subname) // ' aer_ssa_bnd_sw', tolerance=1e-10_r8))
-               call handle_error(clip_values(aer_asm_bnd_sw, -1._r8,                1._r8, trim(subname) // ' aer_asm_bnd_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_tau_bnd_sw(1:ncol,:,:),  0._r8, huge(aer_tau_bnd_sw), trim(subname) // ' aer_tau_bnd_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_ssa_bnd_sw(1:ncol,:,:),  0._r8,                1._r8, trim(subname) // ' aer_ssa_bnd_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_asm_bnd_sw(1:ncol,:,:), -1._r8,                1._r8, trim(subname) // ' aer_asm_bnd_sw', tolerance=1e-10_r8))
 
                ! Call the shortwave radiation driver
                call radiation_driver_sw( &
@@ -1483,7 +1483,7 @@ contains
 
                ! Check (and possibly clip) values before passing to RRTMGP driver
                call handle_error(clip_values(cld_tau_gpt_lw,  0._r8, huge(cld_tau_gpt_lw), trim(subname) // ': cld_tau_gpt_lw', tolerance=1e-10_r8))
-               call handle_error(clip_values(aer_tau_bnd_lw,  0._r8, huge(aer_tau_bnd_lw), trim(subname) // ': aer_tau_bnd_lw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_tau_bnd_lw(1:ncol,:,:),  0._r8, huge(aer_tau_bnd_lw), trim(subname) // ': aer_tau_bnd_lw', tolerance=1e-10_r8))
 
                ! Call the longwave radiation driver to calculate fluxes and heating rates
                call radiation_driver_lw( &


### PR DESCRIPTION
In a few places, for calls to clip_values, change the extent of the array sent in for clipping.

This avoid problems running v0 cases with GNU and intel/debug when presumably trying to work with uninit values.

call handle_error(clip_values(aer_tau_bnd_sw(1:ncol,:,:)...

Fixes https://github.com/E3SM-Project/scream/issues/1732

[bfb]