### PR TITLE
EAMxx: make radiation process columns in chunks

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -193,6 +193,7 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Radiation -->
     <rrtmgp inherit="physics_proc_base">
       <active_gases>h2o, co2, o3, n2o, co, ch4, o2, n2</active_gases>
+      <Max__Column__Chunk__Size>1280</Max__Column__Chunk__Size>
       <Orbital__Year>-9999</Orbital__Year>
       <Orbital__Eccentricity>-9999</Orbital__Eccentricity>
       <Orbital__Eccentricity COMPSET=".*SCREAM%AQUA.*">0</Orbital__Eccentricity>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -193,7 +193,7 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Radiation -->
     <rrtmgp inherit="physics_proc_base">
       <active_gases>h2o, co2, o3, n2o, co, ch4, o2, n2</active_gases>
-      <Max__Column__Chunk__Size>1280</Max__Column__Chunk__Size>
+      <Column__Chunk__Size>1280</Column__Chunk__Size>
       <Orbital__Year>-9999</Orbital__Year>
       <Orbital__Eccentricity>-9999</Orbital__Eccentricity>
       <Orbital__Eccentricity COMPSET=".*SCREAM%AQUA.*">0</Orbital__Eccentricity>

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -55,6 +55,14 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   m_lat  = m_grid->get_geometry_data("lat");
   m_lon  = m_grid->get_geometry_data("lon");
 
+  // Figure out radiation column chunks stats
+  m_col_chunk_size = std::min(m_params.get("Max Column Chunk Size", m_ncol),m_ncol);
+  m_num_col_chunks = (m_ncol+m_col_chunk_size-1) / m_col_chunk_size;
+  m_col_chunk_beg.resize(m_num_col_chunks+1,0);
+  for (int i=0; i<m_num_col_chunks; ++i) {
+    m_col_chunk_beg[i+1] = std::min(m_ncol,m_col_chunk_beg[i] + m_col_chunk_size);
+  }
+
   // Set up dimension layouts
   FieldLayout scalar2d_layout     { {COL   }, {m_ncol    } };
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_ncol,m_nlay} };
@@ -135,16 +143,17 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
 
 size_t RRTMGPRadiation::requested_buffer_size_in_bytes() const
 {
-  const size_t interface_request = Buffer::num_1d_ncol*m_ncol*sizeof(Real) +
-                                   Buffer::num_2d_nlay*m_ncol*m_nlay*sizeof(Real) +
-                                   Buffer::num_2d_nlay_p1*m_ncol*(m_nlay+1)*sizeof(Real) +
-                                   Buffer::num_2d_nswbands*m_ncol*m_nswbands*sizeof(Real) +
-                                   Buffer::num_3d_nlev_nswbands*m_ncol*(m_nlay+1)*m_nswbands*sizeof(Real) +
-                                   Buffer::num_3d_nlev_nlwbands*m_ncol*(m_nlay+1)*m_nlwbands*sizeof(Real) +
-                                   Buffer::num_3d_nlay_nswbands*m_ncol*(m_nlay)*m_nswbands*sizeof(Real) +
-                                   Buffer::num_3d_nlay_nlwbands*m_ncol*(m_nlay)*m_nlwbands*sizeof(Real);
+  const size_t interface_request =
+    Buffer::num_1d_ncol*m_col_chunk_size +
+    Buffer::num_2d_nlay*m_col_chunk_size*m_nlay +
+    Buffer::num_2d_nlay_p1*m_col_chunk_size*(m_nlay+1) +
+    Buffer::num_2d_nswbands*m_col_chunk_size*m_nswbands +
+    Buffer::num_3d_nlev_nswbands*m_col_chunk_size*(m_nlay+1)*m_nswbands +
+    Buffer::num_3d_nlev_nlwbands*m_col_chunk_size*(m_nlay+1)*m_nlwbands +
+    Buffer::num_3d_nlay_nswbands*m_col_chunk_size*(m_nlay)*m_nswbands +
+    Buffer::num_3d_nlay_nlwbands*m_col_chunk_size*(m_nlay)*m_nlwbands;
 
-  return interface_request;
+  return interface_request * sizeof(Real);
 } // RRTMGPRadiation::requested_buffer_size
 // =========================================================================================
 
@@ -155,108 +164,108 @@ void RRTMGPRadiation::init_buffers(const ATMBufferManager &buffer_manager)
   Real* mem = reinterpret_cast<Real*>(buffer_manager.get_memory());
 
   // 1d array
-  m_buffer.mu0 = decltype(m_buffer.mu0)("mu0", mem, m_ncol);
+  m_buffer.mu0 = decltype(m_buffer.mu0)("mu0", mem, m_col_chunk_size);
   mem += m_buffer.mu0.totElems();
-  m_buffer.sfc_alb_dir_vis = decltype(m_buffer.sfc_alb_dir_vis)("sfc_alb_dir_vis", mem, m_ncol);
+  m_buffer.sfc_alb_dir_vis = decltype(m_buffer.sfc_alb_dir_vis)("sfc_alb_dir_vis", mem, m_col_chunk_size);
   mem += m_buffer.sfc_alb_dir_vis.totElems();
-  m_buffer.sfc_alb_dir_nir = decltype(m_buffer.sfc_alb_dir_nir)("sfc_alb_dir_nir", mem, m_ncol);
+  m_buffer.sfc_alb_dir_nir = decltype(m_buffer.sfc_alb_dir_nir)("sfc_alb_dir_nir", mem, m_col_chunk_size);
   mem += m_buffer.sfc_alb_dir_nir.totElems();
-  m_buffer.sfc_alb_dif_vis = decltype(m_buffer.sfc_alb_dif_vis)("sfc_alb_dif_vis", mem, m_ncol);
+  m_buffer.sfc_alb_dif_vis = decltype(m_buffer.sfc_alb_dif_vis)("sfc_alb_dif_vis", mem, m_col_chunk_size);
   mem += m_buffer.sfc_alb_dif_vis.totElems();
-  m_buffer.sfc_alb_dif_nir = decltype(m_buffer.sfc_alb_dif_nir)("sfc_alb_dif_nir", mem, m_ncol);
+  m_buffer.sfc_alb_dif_nir = decltype(m_buffer.sfc_alb_dif_nir)("sfc_alb_dif_nir", mem, m_col_chunk_size);
   mem += m_buffer.sfc_alb_dif_nir.totElems();
-  m_buffer.cosine_zenith = decltype(m_buffer.cosine_zenith)(mem, m_ncol);
+  m_buffer.cosine_zenith = decltype(m_buffer.cosine_zenith)(mem, m_col_chunk_size);
   mem += m_buffer.cosine_zenith.size();
-  m_buffer.sfc_flux_dir_vis = decltype(m_buffer.sfc_flux_dir_vis)("sfc_flux_dir_vis", mem, m_ncol);
+  m_buffer.sfc_flux_dir_vis = decltype(m_buffer.sfc_flux_dir_vis)("sfc_flux_dir_vis", mem, m_col_chunk_size);
   mem += m_buffer.sfc_flux_dir_vis.totElems();
-  m_buffer.sfc_flux_dir_nir = decltype(m_buffer.sfc_flux_dir_nir)("sfc_flux_dir_nir", mem, m_ncol);
+  m_buffer.sfc_flux_dir_nir = decltype(m_buffer.sfc_flux_dir_nir)("sfc_flux_dir_nir", mem, m_col_chunk_size);
   mem += m_buffer.sfc_flux_dir_nir.totElems();
-  m_buffer.sfc_flux_dif_vis = decltype(m_buffer.sfc_flux_dif_vis)("sfc_flux_dif_vis", mem, m_ncol);
+  m_buffer.sfc_flux_dif_vis = decltype(m_buffer.sfc_flux_dif_vis)("sfc_flux_dif_vis", mem, m_col_chunk_size);
   mem += m_buffer.sfc_flux_dif_vis.totElems();
-  m_buffer.sfc_flux_dif_nir = decltype(m_buffer.sfc_flux_dif_nir)("sfc_flux_dif_nir", mem, m_ncol);
+  m_buffer.sfc_flux_dif_nir = decltype(m_buffer.sfc_flux_dif_nir)("sfc_flux_dif_nir", mem, m_col_chunk_size);
   mem += m_buffer.sfc_flux_dif_nir.totElems();
 
   // 2d arrays
-  m_buffer.p_lay = decltype(m_buffer.p_lay)("p_lay", mem, m_ncol, m_nlay);
+  m_buffer.p_lay = decltype(m_buffer.p_lay)("p_lay", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.p_lay.totElems();
-  m_buffer.t_lay = decltype(m_buffer.t_lay)("t_lay", mem, m_ncol, m_nlay);
+  m_buffer.t_lay = decltype(m_buffer.t_lay)("t_lay", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.t_lay.totElems();
-  m_buffer.p_del = decltype(m_buffer.p_del)("p_del", mem, m_ncol, m_nlay);
+  m_buffer.p_del = decltype(m_buffer.p_del)("p_del", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.p_del.totElems();
-  m_buffer.qc = decltype(m_buffer.qc)("qc", mem, m_ncol, m_nlay);
+  m_buffer.qc = decltype(m_buffer.qc)("qc", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.qc.totElems();
-  m_buffer.qi = decltype(m_buffer.qi)("qi", mem, m_ncol, m_nlay);
+  m_buffer.qi = decltype(m_buffer.qi)("qi", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.qi.totElems();
-  m_buffer.cldfrac_tot = decltype(m_buffer.cldfrac_tot)("cldfrac_tot", mem, m_ncol, m_nlay);
+  m_buffer.cldfrac_tot = decltype(m_buffer.cldfrac_tot)("cldfrac_tot", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.cldfrac_tot.totElems();
-  m_buffer.eff_radius_qc = decltype(m_buffer.eff_radius_qc)("eff_radius_qc", mem, m_ncol, m_nlay);
+  m_buffer.eff_radius_qc = decltype(m_buffer.eff_radius_qc)("eff_radius_qc", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.eff_radius_qc.totElems();
-  m_buffer.eff_radius_qi = decltype(m_buffer.eff_radius_qi)("eff_radius_qi", mem, m_ncol, m_nlay);
+  m_buffer.eff_radius_qi = decltype(m_buffer.eff_radius_qi)("eff_radius_qi", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.eff_radius_qi.totElems();
-  m_buffer.tmp2d = decltype(m_buffer.tmp2d)("tmp2d", mem, m_ncol, m_nlay);
+  m_buffer.tmp2d = decltype(m_buffer.tmp2d)("tmp2d", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.tmp2d.totElems();
-  m_buffer.lwp = decltype(m_buffer.lwp)("lwp", mem, m_ncol, m_nlay);
+  m_buffer.lwp = decltype(m_buffer.lwp)("lwp", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.lwp.totElems();
-  m_buffer.iwp = decltype(m_buffer.iwp)("iwp", mem, m_ncol, m_nlay);
+  m_buffer.iwp = decltype(m_buffer.iwp)("iwp", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.iwp.totElems();
-  m_buffer.sw_heating = decltype(m_buffer.sw_heating)("sw_heating", mem, m_ncol, m_nlay);
+  m_buffer.sw_heating = decltype(m_buffer.sw_heating)("sw_heating", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.sw_heating.totElems();
-  m_buffer.lw_heating = decltype(m_buffer.lw_heating)("lw_heating", mem, m_ncol, m_nlay);
+  m_buffer.lw_heating = decltype(m_buffer.lw_heating)("lw_heating", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.lw_heating.totElems();
-  m_buffer.rad_heating = decltype(m_buffer.rad_heating)("rad_heating", mem, m_ncol, m_nlay);
+  m_buffer.rad_heating = decltype(m_buffer.rad_heating)("rad_heating", mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.rad_heating.totElems();
   // 3d arrays
-  m_buffer.p_lev = decltype(m_buffer.p_lev)("p_lev", mem, m_ncol, m_nlay+1);
+  m_buffer.p_lev = decltype(m_buffer.p_lev)("p_lev", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.p_lev.totElems();
-  m_buffer.t_lev = decltype(m_buffer.t_lev)("t_lev", mem, m_ncol, m_nlay+1);
+  m_buffer.t_lev = decltype(m_buffer.t_lev)("t_lev", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.t_lev.totElems();
-  m_buffer.sw_flux_up = decltype(m_buffer.sw_flux_up)("sw_flux_up", mem, m_ncol, m_nlay+1);
+  m_buffer.sw_flux_up = decltype(m_buffer.sw_flux_up)("sw_flux_up", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.sw_flux_up.totElems();
-  m_buffer.sw_flux_dn = decltype(m_buffer.sw_flux_dn)("sw_flux_dn", mem, m_ncol, m_nlay+1);
+  m_buffer.sw_flux_dn = decltype(m_buffer.sw_flux_dn)("sw_flux_dn", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.sw_flux_dn.totElems();
-  m_buffer.sw_flux_dn_dir = decltype(m_buffer.sw_flux_dn_dir)("sw_flux_dn_dir", mem, m_ncol, m_nlay+1);
+  m_buffer.sw_flux_dn_dir = decltype(m_buffer.sw_flux_dn_dir)("sw_flux_dn_dir", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.sw_flux_dn_dir.totElems();
-  m_buffer.lw_flux_up = decltype(m_buffer.lw_flux_up)("lw_flux_up", mem, m_ncol, m_nlay+1);
+  m_buffer.lw_flux_up = decltype(m_buffer.lw_flux_up)("lw_flux_up", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.lw_flux_up.totElems();
-  m_buffer.lw_flux_dn = decltype(m_buffer.lw_flux_dn)("lw_flux_dn", mem, m_ncol, m_nlay+1);
+  m_buffer.lw_flux_dn = decltype(m_buffer.lw_flux_dn)("lw_flux_dn", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.lw_flux_dn.totElems();
-  m_buffer.sw_clrsky_flux_up = decltype(m_buffer.sw_clrsky_flux_up)("sw_clrsky_flux_up", mem, m_ncol, m_nlay+1);
+  m_buffer.sw_clrsky_flux_up = decltype(m_buffer.sw_clrsky_flux_up)("sw_clrsky_flux_up", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.sw_clrsky_flux_up.totElems();
-  m_buffer.sw_clrsky_flux_dn = decltype(m_buffer.sw_clrsky_flux_dn)("sw_clrsky_flux_dn", mem, m_ncol, m_nlay+1);
+  m_buffer.sw_clrsky_flux_dn = decltype(m_buffer.sw_clrsky_flux_dn)("sw_clrsky_flux_dn", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.sw_clrsky_flux_dn.totElems();
-  m_buffer.sw_clrsky_flux_dn_dir = decltype(m_buffer.sw_clrsky_flux_dn_dir)("sw_clrsky_flux_dn_dir", mem, m_ncol, m_nlay+1);
+  m_buffer.sw_clrsky_flux_dn_dir = decltype(m_buffer.sw_clrsky_flux_dn_dir)("sw_clrsky_flux_dn_dir", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.sw_clrsky_flux_dn_dir.totElems();
-  m_buffer.lw_clrsky_flux_up = decltype(m_buffer.lw_clrsky_flux_up)("lw_clrsky_flux_up", mem, m_ncol, m_nlay+1);
+  m_buffer.lw_clrsky_flux_up = decltype(m_buffer.lw_clrsky_flux_up)("lw_clrsky_flux_up", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.lw_clrsky_flux_up.totElems();
-  m_buffer.lw_clrsky_flux_dn = decltype(m_buffer.lw_clrsky_flux_dn)("lw_clrsky_flux_dn", mem, m_ncol, m_nlay+1);
+  m_buffer.lw_clrsky_flux_dn = decltype(m_buffer.lw_clrsky_flux_dn)("lw_clrsky_flux_dn", mem, m_col_chunk_size, m_nlay+1);
   mem += m_buffer.lw_clrsky_flux_dn.totElems();
   // 3d nswbands
-  m_buffer.sw_bnd_flux_up = decltype(m_buffer.sw_bnd_flux_up)("sw_bnd_flux_up", mem, m_ncol, m_nlay+1, m_nswbands);
+  m_buffer.sw_bnd_flux_up = decltype(m_buffer.sw_bnd_flux_up)("sw_bnd_flux_up", mem, m_col_chunk_size, m_nlay+1, m_nswbands);
   mem += m_buffer.sw_bnd_flux_up.totElems();
-  m_buffer.sw_bnd_flux_dn = decltype(m_buffer.sw_bnd_flux_dn)("sw_bnd_flux_dn", mem, m_ncol, m_nlay+1, m_nswbands);
+  m_buffer.sw_bnd_flux_dn = decltype(m_buffer.sw_bnd_flux_dn)("sw_bnd_flux_dn", mem, m_col_chunk_size, m_nlay+1, m_nswbands);
   mem += m_buffer.sw_bnd_flux_dn.totElems();
-  m_buffer.sw_bnd_flux_dir = decltype(m_buffer.sw_bnd_flux_dir)("sw_bnd_flux_dir", mem, m_ncol, m_nlay+1, m_nswbands);
+  m_buffer.sw_bnd_flux_dir = decltype(m_buffer.sw_bnd_flux_dir)("sw_bnd_flux_dir", mem, m_col_chunk_size, m_nlay+1, m_nswbands);
   mem += m_buffer.sw_bnd_flux_dir.totElems();
-  m_buffer.sw_bnd_flux_dif = decltype(m_buffer.sw_bnd_flux_dif)("sw_bnd_flux_dif", mem, m_ncol, m_nlay+1, m_nswbands);
+  m_buffer.sw_bnd_flux_dif = decltype(m_buffer.sw_bnd_flux_dif)("sw_bnd_flux_dif", mem, m_col_chunk_size, m_nlay+1, m_nswbands);
   mem += m_buffer.sw_bnd_flux_dif.totElems();
   // 3d nlwbands
-  m_buffer.lw_bnd_flux_up = decltype(m_buffer.lw_bnd_flux_up)("lw_bnd_flux_up", mem, m_ncol, m_nlay+1, m_nlwbands);
+  m_buffer.lw_bnd_flux_up = decltype(m_buffer.lw_bnd_flux_up)("lw_bnd_flux_up", mem, m_col_chunk_size, m_nlay+1, m_nlwbands);
   mem += m_buffer.lw_bnd_flux_up.totElems();
-  m_buffer.lw_bnd_flux_dn = decltype(m_buffer.lw_bnd_flux_dn)("lw_bnd_flux_dn", mem, m_ncol, m_nlay+1, m_nlwbands);
+  m_buffer.lw_bnd_flux_dn = decltype(m_buffer.lw_bnd_flux_dn)("lw_bnd_flux_dn", mem, m_col_chunk_size, m_nlay+1, m_nlwbands);
   mem += m_buffer.lw_bnd_flux_dn.totElems();
   // Surface albedos
-  m_buffer.sfc_alb_dir = decltype(m_buffer.sfc_alb_dir)("sfc_alb_dir", mem, m_ncol, m_nswbands);
+  m_buffer.sfc_alb_dir = decltype(m_buffer.sfc_alb_dir)("sfc_alb_dir", mem, m_col_chunk_size, m_nswbands);
   mem += m_buffer.sfc_alb_dir.totElems();
-  m_buffer.sfc_alb_dif = decltype(m_buffer.sfc_alb_dif)("sfc_alb_dif", mem, m_ncol, m_nswbands);
+  m_buffer.sfc_alb_dif = decltype(m_buffer.sfc_alb_dif)("sfc_alb_dif", mem, m_col_chunk_size, m_nswbands);
   mem += m_buffer.sfc_alb_dif.totElems();
 
-  m_buffer.aero_tau_sw = decltype(m_buffer.aero_tau_sw)("aero_tau_sw", mem, m_ncol, m_nlay, m_nswbands);
+  m_buffer.aero_tau_sw = decltype(m_buffer.aero_tau_sw)("aero_tau_sw", mem, m_col_chunk_size, m_nlay, m_nswbands);
   mem += m_buffer.aero_tau_sw.totElems();
-  m_buffer.aero_ssa_sw = decltype(m_buffer.aero_ssa_sw)("aero_ssa_sw", mem, m_ncol, m_nlay, m_nswbands);
+  m_buffer.aero_ssa_sw = decltype(m_buffer.aero_ssa_sw)("aero_ssa_sw", mem, m_col_chunk_size, m_nlay, m_nswbands);
   mem += m_buffer.aero_ssa_sw.totElems();
-  m_buffer.aero_g_sw   = decltype(m_buffer.aero_g_sw  )("aero_g_sw"  , mem, m_ncol, m_nlay, m_nswbands);
+  m_buffer.aero_g_sw   = decltype(m_buffer.aero_g_sw  )("aero_g_sw"  , mem, m_col_chunk_size, m_nlay, m_nswbands);
   mem += m_buffer.aero_g_sw.totElems();
-  m_buffer.aero_tau_lw = decltype(m_buffer.aero_tau_lw)("aero_tau_lw", mem, m_ncol, m_nlay, m_nlwbands);
+  m_buffer.aero_tau_lw = decltype(m_buffer.aero_tau_lw)("aero_tau_lw", mem, m_col_chunk_size, m_nlay, m_nlwbands);
   mem += m_buffer.aero_tau_lw.totElems();
 
   size_t used_mem = (reinterpret_cast<Real*>(mem) - buffer_manager.get_memory())*sizeof(Real);
@@ -301,8 +310,14 @@ void RRTMGPRadiation::initialize_impl(const RunType /* run_type */) {
   Kokkos::deep_copy(m_gas_mol_weights,gas_mol_w_host);
 
   // Initialize GasConcs object to pass to RRTMGP initializer;
-  gas_concs.init(gas_names_yakl_offset,m_ncol,m_nlay);
-  rrtmgp::rrtmgp_initialize(gas_concs, m_atm_logger);
+  gas_concs.resize(m_num_col_chunks);
+  for (int ic=0; ic<m_num_col_chunks; ++ic) {
+    const int chunk_size = m_col_chunk_beg[ic+1] - m_col_chunk_beg[ic];
+    gas_concs[ic].init(gas_names_yakl_offset,chunk_size,m_nlay);
+  }
+
+  // This really doesn't need gas_concs, only the gas names, so pass the 1st entry
+  rrtmgp::rrtmgp_initialize(gas_concs[0], m_atm_logger);
 
   // Set property checks for fields in this process
 
@@ -379,52 +394,7 @@ void RRTMGPRadiation::run_impl (const int dt) {
   auto d_sfc_flux_sw_net = get_field_out("sfc_flux_sw_net").get_view<Real*>();
   auto d_sfc_flux_lw_dn  = get_field_out("sfc_flux_lw_dn").get_view<Real*>();
 
-  // Create YAKL arrays. RRTMGP expects YAKL arrays with styleFortran, i.e., data has ncol
-  // as the fastest index. For this reason we must copy the data.
-  auto p_lay           = m_buffer.p_lay;
-  auto t_lay           = m_buffer.t_lay;
-  auto p_lev           = m_buffer.p_lev;
-  auto p_del           = m_buffer.p_del;
-  auto t_lev           = m_buffer.t_lev;
-  auto mu0             = m_buffer.mu0;
-  auto sfc_alb_dir     = m_buffer.sfc_alb_dir;
-  auto sfc_alb_dif     = m_buffer.sfc_alb_dif;
-  auto sfc_alb_dir_vis = m_buffer.sfc_alb_dir_vis;
-  auto sfc_alb_dir_nir = m_buffer.sfc_alb_dir_nir;
-  auto sfc_alb_dif_vis = m_buffer.sfc_alb_dif_vis;
-  auto sfc_alb_dif_nir = m_buffer.sfc_alb_dif_nir;
-  auto qc              = m_buffer.qc;
-  auto qi              = m_buffer.qi;
-  auto cldfrac_tot     = m_buffer.cldfrac_tot;
-  auto rel             = m_buffer.eff_radius_qc;
-  auto rei             = m_buffer.eff_radius_qi;
-  auto sw_flux_up      = m_buffer.sw_flux_up;
-  auto sw_flux_dn      = m_buffer.sw_flux_dn;
-  auto sw_flux_dn_dir  = m_buffer.sw_flux_dn_dir;
-  auto lw_flux_up      = m_buffer.lw_flux_up;
-  auto lw_flux_dn      = m_buffer.lw_flux_dn;
-  auto sw_clrsky_flux_up      = m_buffer.sw_clrsky_flux_up;
-  auto sw_clrsky_flux_dn      = m_buffer.sw_clrsky_flux_dn;
-  auto sw_clrsky_flux_dn_dir  = m_buffer.sw_clrsky_flux_dn_dir;
-  auto lw_clrsky_flux_up      = m_buffer.lw_clrsky_flux_up;
-  auto lw_clrsky_flux_dn      = m_buffer.lw_clrsky_flux_dn;
-  auto sw_bnd_flux_up  = m_buffer.sw_bnd_flux_up;
-  auto sw_bnd_flux_dn  = m_buffer.sw_bnd_flux_dn;
-  auto sw_bnd_flux_dir = m_buffer.sw_bnd_flux_dir;
-  auto sw_bnd_flux_dif = m_buffer.sw_bnd_flux_dif;
-  auto lw_bnd_flux_up  = m_buffer.lw_bnd_flux_up;
-  auto lw_bnd_flux_dn  = m_buffer.lw_bnd_flux_dn;
-  auto sfc_flux_dir_vis = m_buffer.sfc_flux_dir_vis;
-  auto sfc_flux_dir_nir = m_buffer.sfc_flux_dir_nir;
-  auto sfc_flux_dif_vis = m_buffer.sfc_flux_dif_vis;
-  auto sfc_flux_dif_nir = m_buffer.sfc_flux_dif_nir;
-  auto aero_tau_sw     = m_buffer.aero_tau_sw;
-  auto aero_ssa_sw     = m_buffer.aero_ssa_sw;
-  auto aero_g_sw       = m_buffer.aero_g_sw;
-  auto aero_tau_lw     = m_buffer.aero_tau_lw;
-
   constexpr auto stebol = PC::stebol;
-  const auto ncol = m_ncol;
   const auto nlay = m_nlay;
   const auto nlwbands = m_nlwbands;
   const auto nswbands = m_nswbands;
@@ -458,308 +428,377 @@ void RRTMGPRadiation::run_impl (const int dt) {
   // Are we going to update fluxes and heating this step?
   auto update_rad = scream::rrtmgp::radiation_do(m_rad_freq_in_steps, ts.get_num_steps());
 
-  // Copy data from the FieldManager to the YAKL arrays
-  {
-    // Determine the cosine zenith angle
-    // NOTE: Since we are bridging to F90 arrays this must be done on HOST and then
-    //       deep copied to a device view.
-    auto d_mu0 = m_buffer.cosine_zenith;
-    auto h_mu0 = Kokkos::create_mirror_view(d_mu0);
-    if (m_fixed_solar_zenith_angle > 0) {
-      for (int i=0; i<m_ncol; i++) {
-        h_mu0(i) = m_fixed_solar_zenith_angle;
-      }
-    } else {
-      // Now use solar declination to calculate zenith angle for all points
-      for (int i=0;i<m_ncol;i++) {
-        double lat = h_lat(i)*PC::Pi/180.0;  // Convert lat/lon to radians
-        double lon = h_lon(i)*PC::Pi/180.0;
-        h_mu0(i) = shr_orb_cosz_c2f(calday, lat, lon, delta, dt);
-      }
-    }
-    Kokkos::deep_copy(d_mu0,h_mu0);
+  // Loop over each chunk of columns
+  for (int ic=0; ic<m_num_col_chunks; ++ic) {
+    const int beg  = m_col_chunk_beg[ic];
+    const int ncol = m_col_chunk_beg[ic+1] - beg;
 
-    // dz and T_int will need to be computed
-    view_2d_real d_tint("T_int", m_ncol, m_nlay+1);
-    view_2d_real d_dz  ("dz",    m_ncol, m_nlay);
+    // Create YAKL arrays. RRTMGP expects YAKL arrays with styleFortran, i.e., data has ncol
+    // as the fastest index. For this reason we must copy the data.
+    auto subview_1d = [&](const real1d v) -> real1d {
+      return real1d(v.label(),v.myData,ncol);
+    };
+    auto subview_2d = [&](const real2d v) -> real2d {
+      return real2d(v.label(),v.myData,ncol,v.dimension[1]);
+    };
+    auto subview_3d = [&](const real3d v) -> real3d {
+      return real3d(v.label(),v.myData,ncol,v.dimension[1],v.dimension[2]);
+    };
 
-    const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
-    Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
-      const int i = team.league_rank();
-
-      // Calculate dz
-      const auto pseudo_density = ekat::subview(d_pdel, i);
-      const auto p_mid          = ekat::subview(d_pmid, i);
-      const auto T_mid          = ekat::subview(d_tmid, i);
-      const auto qv             = ekat::subview(d_qv,   i);
-      const auto dz             = ekat::subview(d_dz,   i);
-      PF::calculate_dz<Real>(team, pseudo_density, p_mid, T_mid, qv, dz);
-      team.team_barrier();
-
-      // Calculate T_int from longwave flux up from the surface, assuming
-      // blackbody emission with emissivity of 1.
-      // TODO: Does land model assume something other than emissivity of 1? If so
-      // we should use that here rather than assuming perfect blackbody emission.
-      // NOTE: RRTMGP can accept vertical ordering surface to toa, or toa to
-      // surface. The input data for the standalone test is ordered surface to
-      // toa, but SCREAM in general assumes data is toa to surface. We account
-      // for this here by swapping bc_top and bc_bot in the case that the input
-      // data is ordered surface to toa.
-      const auto T_int = ekat::subview(d_tint, i);
-      const auto P_mid = ekat::subview(d_pmid, i);
-      const int itop = (P_mid(0) < P_mid(nlay-1)) ? 0 : nlay-1;
-      const Real bc_top = T_mid(itop);
-      const Real bc_bot = sqrt(sqrt(d_surf_lw_flux_up(i)/stebol));
-      if (itop == 0) {
-          CO::compute_interface_values_linear(team, nlay, T_mid, dz, bc_top, bc_bot, T_int);
-      } else {
-          CO::compute_interface_values_linear(team, nlay, T_mid, dz, bc_bot, bc_top, T_int);
-      }
-      team.team_barrier();
-
-      mu0(i+1) = d_mu0(i);
-      sfc_alb_dir_vis(i+1) = d_sfc_alb_dir_vis(i);
-      sfc_alb_dir_nir(i+1) = d_sfc_alb_dir_nir(i);
-      sfc_alb_dif_vis(i+1) = d_sfc_alb_dif_vis(i);
-      sfc_alb_dif_nir(i+1) = d_sfc_alb_dif_nir(i);
-
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
-        p_lay(i+1,k+1)       = d_pmid(i,k);
-        t_lay(i+1,k+1)       = d_tmid(i,k);
-        p_del(i+1,k+1)       = d_pdel(i,k);
-        qc(i+1,k+1)          = d_qc(i,k);
-        qi(i+1,k+1)          = d_qi(i,k);
-        rel(i+1,k+1)         = d_rel(i,k);
-        rei(i+1,k+1)         = d_rei(i,k);
-        p_lev(i+1,k+1)       = d_pint(i,k);
-        t_lev(i+1,k+1)       = d_tint(i,k);
-      });
-
-      p_lev(i+1,nlay+1) = d_pint(i,nlay);
-      t_lev(i+1,nlay+1) = d_tint(i,nlay);
-
-      // Note that RRTMGP expects ordering (col,lay,bnd) but the FM keeps things in (col,bnd,lay) order
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nswbands*nlay), [&] (const int&idx) {
-          auto b = idx / nlay;
-          auto k = idx % nlay;
-          aero_tau_sw(i+1,k+1,b+1) = d_aero_tau_sw(i,b,k);
-          aero_ssa_sw(i+1,k+1,b+1) = d_aero_ssa_sw(i,b,k);
-          aero_g_sw  (i+1,k+1,b+1) = d_aero_g_sw  (i,b,k);
-      });
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlwbands*nlay), [&] (const int&idx) {
-          auto b = idx / nlay;
-          auto k = idx % nlay;
-          aero_tau_lw(i+1,k+1,b+1) = d_aero_tau_lw(i,b,k);
-      });
-    });
-  }
-  Kokkos::fence();
-
-  // Populate GasConcs object to pass to RRTMGP driver
-  auto tmp2d = m_buffer.tmp2d;
-  for (int igas = 0; igas < m_ngas; igas++) {
-    auto name = m_gas_names[igas];
-    auto fm_name = name=="h2o" ? "qv" : name;
-    auto d_temp  = get_field_in(fm_name).get_view<const Real**>();
-    const auto gas_mol_weights = m_gas_mol_weights;
-
-    const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
-    Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
-      const int i = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
-        tmp2d(i+1,k+1) = PF::calculate_vmr_from_mmr(gas_mol_weights[igas],d_qv(i,k),d_temp(i,k)); // Note that for YAKL arrays i and k start with index 1
-      });
-    });
-    Kokkos::fence();
-
-    gas_concs.set_vmr(name, tmp2d);
-  }
-
-  // Set layer cloud fraction.
-  //
-  // If not doing subcolumn sampling for mcica, we want to make sure we use grid-mean
-  // condensate for computing cloud optical properties, because we are assuming the
-  // entire column is completely clear or cloudy. Thus, in this case we want to set
-  // cloud fraction to 0 or 1. Note that we could choose an alternative threshold
-  // criteria here, like qc + qi > 1e-5 or something.
-  //
-  // If we *are* doing subcolumn sampling for MCICA, then keep cloud fraction as input
-  // from cloud fraction parameterization, wherever that is computed.
-  auto do_subcol_sampling = m_do_subcol_sampling;
-  if (not do_subcol_sampling) {
-    const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
-    Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
-      const int i = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
-        if (d_cldfrac_tot(i,k) > 0) {
-          cldfrac_tot(i+1,k+1) = 1;
-        } else {
-          cldfrac_tot(i+1,k+1) = 0;
+    auto p_lay           = subview_2d(m_buffer.p_lay);
+    auto t_lay           = subview_2d(m_buffer.t_lay);
+    auto p_lev           = subview_2d(m_buffer.p_lev);
+    auto p_del           = subview_2d(m_buffer.p_del);
+    auto t_lev           = subview_2d(m_buffer.t_lev);
+    auto mu0             = subview_1d(m_buffer.mu0);
+    auto sfc_alb_dir     = subview_2d(m_buffer.sfc_alb_dir);
+    auto sfc_alb_dif     = subview_2d(m_buffer.sfc_alb_dif);
+    auto sfc_alb_dir_vis = subview_1d(m_buffer.sfc_alb_dir_vis);
+    auto sfc_alb_dir_nir = subview_1d(m_buffer.sfc_alb_dir_nir);
+    auto sfc_alb_dif_vis = subview_1d(m_buffer.sfc_alb_dif_vis);
+    auto sfc_alb_dif_nir = subview_1d(m_buffer.sfc_alb_dif_nir);
+    auto qc              = subview_2d(m_buffer.qc);
+    auto qi              = subview_2d(m_buffer.qi);
+    auto cldfrac_tot     = subview_2d(m_buffer.cldfrac_tot);
+    auto rel             = subview_2d(m_buffer.eff_radius_qc);
+    auto rei             = subview_2d(m_buffer.eff_radius_qi);
+    auto sw_flux_up      = subview_2d(m_buffer.sw_flux_up);
+    auto sw_flux_dn      = subview_2d(m_buffer.sw_flux_dn);
+    auto sw_flux_dn_dir  = subview_2d(m_buffer.sw_flux_dn_dir);
+    auto lw_flux_up      = subview_2d(m_buffer.lw_flux_up);
+    auto lw_flux_dn      = subview_2d(m_buffer.lw_flux_dn);
+    auto sw_clrsky_flux_up      = subview_2d(m_buffer.sw_clrsky_flux_up);
+    auto sw_clrsky_flux_dn      = subview_2d(m_buffer.sw_clrsky_flux_dn);
+    auto sw_clrsky_flux_dn_dir  = subview_2d(m_buffer.sw_clrsky_flux_dn_dir);
+    auto lw_clrsky_flux_up      = subview_2d(m_buffer.lw_clrsky_flux_up);
+    auto lw_clrsky_flux_dn      = subview_2d(m_buffer.lw_clrsky_flux_dn);
+    auto sw_bnd_flux_up  = subview_3d(m_buffer.sw_bnd_flux_up);
+    auto sw_bnd_flux_dn  = subview_3d(m_buffer.sw_bnd_flux_dn);
+    auto sw_bnd_flux_dir = subview_3d(m_buffer.sw_bnd_flux_dir);
+    auto sw_bnd_flux_dif = subview_3d(m_buffer.sw_bnd_flux_dif);
+    auto lw_bnd_flux_up  = subview_3d(m_buffer.lw_bnd_flux_up);
+    auto lw_bnd_flux_dn  = subview_3d(m_buffer.lw_bnd_flux_dn);
+    auto sfc_flux_dir_vis = subview_1d(m_buffer.sfc_flux_dir_vis);
+    auto sfc_flux_dir_nir = subview_1d(m_buffer.sfc_flux_dir_nir);
+    auto sfc_flux_dif_vis = subview_1d(m_buffer.sfc_flux_dif_vis);
+    auto sfc_flux_dif_nir = subview_1d(m_buffer.sfc_flux_dif_nir);
+    auto aero_tau_sw     = subview_3d(m_buffer.aero_tau_sw);
+    auto aero_ssa_sw     = subview_3d(m_buffer.aero_ssa_sw);
+    auto aero_g_sw       = subview_3d(m_buffer.aero_g_sw);
+    auto aero_tau_lw     = subview_3d(m_buffer.aero_tau_lw);
+    // Copy data from the FieldManager to the YAKL arrays
+    {
+      // Determine the cosine zenith angle
+      // NOTE: Since we are bridging to F90 arrays this must be done on HOST and then
+      //       deep copied to a device view.
+      auto d_mu0 = m_buffer.cosine_zenith;
+      auto h_mu0 = Kokkos::create_mirror_view(d_mu0);
+      if (m_fixed_solar_zenith_angle > 0) {
+        for (int i=0; i<ncol; i++) {
+          h_mu0(i) = m_fixed_solar_zenith_angle;
         }
-      });
-    });
-  } else {
-    const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
-    Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
-      const int i = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
-        cldfrac_tot(i+1,k+1) = d_cldfrac_tot(i,k);
-      });
-    });
-  }
-  Kokkos::fence();
+      } else {
+        // Now use solar declination to calculate zenith angle for all points
+        for (int i=0;i<ncol;i++) {
+          double lat = h_lat(i+beg)*PC::Pi/180.0;  // Convert lat/lon to radians
+          double lon = h_lon(i+beg)*PC::Pi/180.0;
+          h_mu0(i) = shr_orb_cosz_c2f(calday, lat, lon, delta, dt);
+        }
+      }
+      Kokkos::deep_copy(d_mu0,h_mu0);
 
-  // Compute layer cloud mass (per unit area)
-  auto lwp = m_buffer.lwp;
-  auto iwp = m_buffer.iwp;
-  scream::rrtmgp::mixing_ratio_to_cloud_mass(qc, cldfrac_tot, p_del, lwp);
-  scream::rrtmgp::mixing_ratio_to_cloud_mass(qi, cldfrac_tot, p_del, iwp);
-  // Convert to g/m2 (needed by RRTMGP)
-  {
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
-  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
-    const int i = team.league_rank();
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
-      // Note that for YAKL arrays i and k start with index 1
-      lwp(i+1,k+1) *= 1e3;
-      iwp(i+1,k+1) *= 1e3;
-    });
-  });
-  }
-  Kokkos::fence();
+      // dz and T_int will need to be computed
+      view_2d_real d_tint("T_int", ncol, m_nlay+1);
+      view_2d_real d_dz  ("dz",    ncol, m_nlay);
 
-  // Compute band-by-band surface_albedos. This is needed since
-  // the AD passes broadband albedos, but rrtmgp require band-by-band.
-  rrtmgp::compute_band_by_band_surface_albedos(
-    m_ncol, m_nswbands,
-    sfc_alb_dir_vis, sfc_alb_dir_nir,
-    sfc_alb_dif_vis, sfc_alb_dif_nir,
-    sfc_alb_dir, sfc_alb_dif);
-
-  // Run RRTMGP driver
-  if (update_rad) {
-    rrtmgp::rrtmgp_main(
-      m_ncol, m_nlay,
-      p_lay, t_lay, p_lev, t_lev,
-      gas_concs,
-      sfc_alb_dir, sfc_alb_dif, mu0,
-      lwp, iwp, rel, rei,
-      aero_tau_sw, aero_ssa_sw, aero_g_sw, aero_tau_lw,
-      sw_flux_up       , sw_flux_dn       , sw_flux_dn_dir       , lw_flux_up       , lw_flux_dn, 
-      sw_clrsky_flux_up, sw_clrsky_flux_dn, sw_clrsky_flux_dn_dir, lw_clrsky_flux_up, lw_clrsky_flux_dn, 
-      sw_bnd_flux_up   , sw_bnd_flux_dn   , sw_bnd_flux_dir      , lw_bnd_flux_up   , lw_bnd_flux_dn, 
-      eccf, m_atm_logger
-    );
-  }
-
-  // Compute and apply heating tendency
-  auto sw_heating  = m_buffer.sw_heating;
-  auto lw_heating  = m_buffer.lw_heating;
-  auto rad_heating = m_buffer.rad_heating;
-  if (update_rad) {
-    rrtmgp::compute_heating_rate(
-      sw_flux_up, sw_flux_dn, p_del, sw_heating
-    );
-    rrtmgp::compute_heating_rate(
-      lw_flux_up, lw_flux_dn, p_del, lw_heating
-    );
-    {
-      const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
-      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
-        const int icol = team.league_rank();
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& ilay) {
-          // Note that for YAKL arrays i and k start with index 1
-          int i = icol + 1;
-          int k = ilay + 1;
-          // Combine SW and LW heating into a net heating tendency
-          rad_heating(i,k) = sw_heating(i,k) + lw_heating(i,k);
-          // Apply heating tendency to temperature
-          t_lay(i,k) = t_lay(i,k) + rad_heating(i,k) * dt;
-          // Compute pdel * rad_heating to conserve energy across timesteps in case
-          // levels change before next heating update.
-          d_rad_heating_pdel(icol,k-1) = d_pdel(icol,k-1) * rad_heating(i,k);
-        });
-      });
-    }
-    Kokkos::fence();
-  } else {
-    {
-      const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
-      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
-        const int icol = team.league_rank();
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& ilay) {
-          // Note that for YAKL arrays i and k start with index 1
-          int i = icol + 1;
-          int k = ilay + 1;
-          // Back out net heating tendency from the pdel weighted quantity we keep in the FM
-          rad_heating(i,k) = d_rad_heating_pdel(icol,k-1) / d_pdel(icol,k-1);
-          // Apply heating tendency to temperature
-          t_lay(i,k) = t_lay(i,k) + rad_heating(i,k) * dt;
-        });
-      });
-    }
-    Kokkos::fence();
-  }
-
-  // Index to surface (bottom of model); used to get surface fluxes below
-  const int kbot = nlay+1;
-
-  // Compute diffuse flux as difference between total and direct; use YAKL parallel_for here because these are YAKL objects
-  parallel_for(Bounds<3>(m_nswbands,m_nlay+1,m_ncol), YAKL_LAMBDA(int ibnd, int ilev, int icol) {
-    sw_bnd_flux_dif(icol,ilev,ibnd) = sw_bnd_flux_dn(icol,ilev,ibnd) - sw_bnd_flux_dir(icol,ilev,ibnd);
-  });
-
-  // Compute surface fluxes
-  rrtmgp::compute_broadband_surface_fluxes(
-      m_ncol, kbot, m_nswbands,
-      sw_bnd_flux_dir, sw_bnd_flux_dif, 
-      sfc_flux_dir_vis, sfc_flux_dir_nir, 
-      sfc_flux_dif_vis, sfc_flux_dif_nir
-  );
-
-  // Copy output data back to FieldManager
-  if (update_rad) {
-    {
-      const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
+      const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
       Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
         const int i = team.league_rank();
-        d_sfc_flux_dir_nir(i) = sfc_flux_dir_nir(i+1);
-        d_sfc_flux_dir_vis(i) = sfc_flux_dir_vis(i+1);
-        d_sfc_flux_dif_nir(i) = sfc_flux_dif_nir(i+1);
-        d_sfc_flux_dif_vis(i) = sfc_flux_dif_vis(i+1);
-        d_sfc_flux_sw_net(i)  = sw_flux_dn(i+1,kbot) - sw_flux_up(i+1,kbot);
-        d_sfc_flux_lw_dn(i)   = lw_flux_dn(i+1,kbot);
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay+1), [&] (const int& k) {
-          d_sw_flux_up(i,k)            = sw_flux_up(i+1,k+1);
-          d_sw_flux_dn(i,k)            = sw_flux_dn(i+1,k+1);
-          d_sw_flux_dn_dir(i,k)        = sw_flux_dn_dir(i+1,k+1);
-          d_lw_flux_up(i,k)            = lw_flux_up(i+1,k+1);
-          d_lw_flux_dn(i,k)            = lw_flux_dn(i+1,k+1);
-          d_sw_clrsky_flux_up(i,k)     = sw_clrsky_flux_up(i+1,k+1);
-          d_sw_clrsky_flux_dn(i,k)     = sw_clrsky_flux_dn(i+1,k+1);
-          d_sw_clrsky_flux_dn_dir(i,k) = sw_clrsky_flux_dn_dir(i+1,k+1);
-          d_lw_clrsky_flux_up(i,k)     = lw_clrsky_flux_up(i+1,k+1);
-          d_lw_clrsky_flux_dn(i,k)     = lw_clrsky_flux_dn(i+1,k+1);
+        const int icol = i+beg;
+
+        // Calculate dz
+        const auto pseudo_density = ekat::subview(d_pdel, icol);
+        const auto p_mid          = ekat::subview(d_pmid, icol);
+        const auto T_mid          = ekat::subview(d_tmid, icol);
+        const auto qv             = ekat::subview(d_qv,   icol);
+        const auto dz             = ekat::subview(d_dz,   i);
+        PF::calculate_dz<Real>(team, pseudo_density, p_mid, T_mid, qv, dz);
+        team.team_barrier();
+
+        // Calculate T_int from longwave flux up from the surface, assuming
+        // blackbody emission with emissivity of 1.
+        // TODO: Does land model assume something other than emissivity of 1? If so
+        // we should use that here rather than assuming perfect blackbody emission.
+        // NOTE: RRTMGP can accept vertical ordering surface to toa, or toa to
+        // surface. The input data for the standalone test is ordered surface to
+        // toa, but SCREAM in general assumes data is toa to surface. We account
+        // for this here by swapping bc_top and bc_bot in the case that the input
+        // data is ordered surface to toa.
+        const auto T_int = ekat::subview(d_tint, i);
+        const auto P_mid = ekat::subview(d_pmid, icol);
+        const int itop = (P_mid(0) < P_mid(nlay-1)) ? 0 : nlay-1;
+        const Real bc_top = T_mid(itop);
+        const Real bc_bot = sqrt(sqrt(d_surf_lw_flux_up(icol)/stebol));
+        if (itop == 0) {
+            CO::compute_interface_values_linear(team, nlay, T_mid, dz, bc_top, bc_bot, T_int);
+        } else {
+            CO::compute_interface_values_linear(team, nlay, T_mid, dz, bc_bot, bc_top, T_int);
+        }
+        team.team_barrier();
+
+        mu0(i+1) = d_mu0(i);
+        sfc_alb_dir_vis(i+1) = d_sfc_alb_dir_vis(icol);
+        sfc_alb_dir_nir(i+1) = d_sfc_alb_dir_nir(icol);
+        sfc_alb_dif_vis(i+1) = d_sfc_alb_dif_vis(icol);
+        sfc_alb_dif_nir(i+1) = d_sfc_alb_dif_nir(icol);
+
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
+          p_lay(i+1,k+1)       = d_pmid(icol,k);
+          t_lay(i+1,k+1)       = d_tmid(icol,k);
+          p_del(i+1,k+1)       = d_pdel(icol,k);
+          qc(i+1,k+1)          = d_qc(icol,k);
+          qi(i+1,k+1)          = d_qi(icol,k);
+          rel(i+1,k+1)         = d_rel(icol,k);
+          rei(i+1,k+1)         = d_rei(icol,k);
+          p_lev(i+1,k+1)       = d_pint(icol,k);
+          t_lev(i+1,k+1)       = d_tint(i,k);
+        });
+
+        p_lev(i+1,nlay+1) = d_pint(icol,nlay);
+        t_lev(i+1,nlay+1) = d_tint(i,nlay);
+
+        // Note that RRTMGP expects ordering (col,lay,bnd) but the FM keeps things in (col,bnd,lay) order
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nswbands*nlay), [&] (const int&idx) {
+            auto b = idx / nlay;
+            auto k = idx % nlay;
+            aero_tau_sw(i+1,k+1,b+1) = d_aero_tau_sw(icol,b,k);
+            aero_ssa_sw(i+1,k+1,b+1) = d_aero_ssa_sw(icol,b,k);
+            aero_g_sw  (i+1,k+1,b+1) = d_aero_g_sw  (icol,b,k);
+        });
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlwbands*nlay), [&] (const int&idx) {
+            auto b = idx / nlay;
+            auto k = idx % nlay;
+            aero_tau_lw(i+1,k+1,b+1) = d_aero_tau_lw(icol,b,k);
         });
       });
     }
-  }
-  // Temperature is always updated
-  {
-    const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
+    Kokkos::fence();
+
+    // Populate GasConcs object to pass to RRTMGP driver
+    // set_vmr requires the input array size to have the correct size,
+    // and the last chunk may have less columns, so create a temp of
+    // correct size that uses m_buffer.tmp2d's pointer
+    real2d tmp2d = subview_2d(m_buffer.tmp2d);
+    for (int igas = 0; igas < m_ngas; igas++) {
+      auto name = m_gas_names[igas];
+      auto fm_name = name=="h2o" ? "qv" : name;
+      auto d_temp  = get_field_in(fm_name).get_view<const Real**>();
+      const auto gas_mol_weights = m_gas_mol_weights;
+
+      const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+        const int i = team.league_rank();
+        const int icol = i + beg;
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
+          tmp2d(i+1,k+1) = PF::calculate_vmr_from_mmr(gas_mol_weights[igas],d_qv(icol,k),d_temp(icol,k)); // Note that for YAKL arrays i and k start with index 1
+        });
+      });
+      Kokkos::fence();
+
+      gas_concs[ic].set_vmr(name, tmp2d);
+    }
+
+    // Set layer cloud fraction.
+    //
+    // If not doing subcolumn sampling for mcica, we want to make sure we use grid-mean
+    // condensate for computing cloud optical properties, because we are assuming the
+    // entire column is completely clear or cloudy. Thus, in this case we want to set
+    // cloud fraction to 0 or 1. Note that we could choose an alternative threshold
+    // criteria here, like qc + qi > 1e-5 or something.
+    //
+    // If we *are* doing subcolumn sampling for MCICA, then keep cloud fraction as input
+    // from cloud fraction parameterization, wherever that is computed.
+    auto do_subcol_sampling = m_do_subcol_sampling;
+    if (not do_subcol_sampling) {
+      const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+        const int i = team.league_rank();
+        const int icol = i + beg;
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
+          if (d_cldfrac_tot(icol,k) > 0) {
+            cldfrac_tot(i+1,k+1) = 1;
+          } else {
+            cldfrac_tot(i+1,k+1) = 0;
+          }
+        });
+      });
+    } else {
+      const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+        const int i = team.league_rank();
+        const int icol = i + beg;
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
+          cldfrac_tot(i+1,k+1) = d_cldfrac_tot(icol,k);
+        });
+      });
+    }
+    Kokkos::fence();
+
+    // Compute layer cloud mass (per unit area)
+    auto lwp = m_buffer.lwp;
+    auto iwp = m_buffer.iwp;
+    scream::rrtmgp::mixing_ratio_to_cloud_mass(qc, cldfrac_tot, p_del, lwp);
+    scream::rrtmgp::mixing_ratio_to_cloud_mass(qi, cldfrac_tot, p_del, iwp);
+    // Convert to g/m2 (needed by RRTMGP)
+    {
+    const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int i = team.league_rank();
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
-        d_tmid(i,k) = t_lay(i+1,k+1);
+        // Note that for YAKL arrays i and k start with index 1
+        lwp(i+1,k+1) *= 1e3;
+        iwp(i+1,k+1) *= 1e3;
       });
     });
-  }
-   
+    }
+    Kokkos::fence();
+
+    // Compute band-by-band surface_albedos. This is needed since
+    // the AD passes broadband albedos, but rrtmgp require band-by-band.
+    rrtmgp::compute_band_by_band_surface_albedos(
+      ncol, m_nswbands,
+      sfc_alb_dir_vis, sfc_alb_dir_nir,
+      sfc_alb_dif_vis, sfc_alb_dif_nir,
+      sfc_alb_dir, sfc_alb_dif);
+
+    // Run RRTMGP driver
+    if (update_rad) {
+      rrtmgp::rrtmgp_main(
+        ncol, m_nlay,
+        p_lay, t_lay, p_lev, t_lev,
+        gas_concs[ic],
+        sfc_alb_dir, sfc_alb_dif, mu0,
+        lwp, iwp, rel, rei,
+        aero_tau_sw, aero_ssa_sw, aero_g_sw, aero_tau_lw,
+        sw_flux_up       , sw_flux_dn       , sw_flux_dn_dir       , lw_flux_up       , lw_flux_dn, 
+        sw_clrsky_flux_up, sw_clrsky_flux_dn, sw_clrsky_flux_dn_dir, lw_clrsky_flux_up, lw_clrsky_flux_dn, 
+        sw_bnd_flux_up   , sw_bnd_flux_dn   , sw_bnd_flux_dir      , lw_bnd_flux_up   , lw_bnd_flux_dn, 
+        eccf, m_atm_logger
+      );
+    }
+
+    // Compute and apply heating tendency
+    auto sw_heating  = m_buffer.sw_heating;
+    auto lw_heating  = m_buffer.lw_heating;
+    auto rad_heating = m_buffer.rad_heating;
+    if (update_rad) {
+      rrtmgp::compute_heating_rate(
+        sw_flux_up, sw_flux_dn, p_del, sw_heating
+      );
+      rrtmgp::compute_heating_rate(
+        lw_flux_up, lw_flux_dn, p_del, lw_heating
+      );
+      {
+        const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+        Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+          const int idx = team.league_rank();
+          const int icol = idx+beg;
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& ilay) {
+            // Note that for YAKL arrays i and k start with index 1
+            int i = idx + 1;
+            int k = ilay + 1;
+            // Combine SW and LW heating into a net heating tendency
+            rad_heating(i,k) = sw_heating(i,k) + lw_heating(i,k);
+            // Apply heating tendency to temperature
+            t_lay(i,k) = t_lay(i,k) + rad_heating(i,k) * dt;
+            // Compute pdel * rad_heating to conserve energy across timesteps in case
+            // levels change before next heating update.
+            d_rad_heating_pdel(icol,k-1) = d_pdel(icol,k-1) * rad_heating(i,k);
+          });
+        });
+      }
+      Kokkos::fence();
+    } else {
+      {
+        const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+        Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+          const int idx = team.league_rank();
+          const int icol = idx+beg;
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& ilay) {
+            // Note that for YAKL arrays i and k start with index 1
+            int i = idx + 1;
+            int k = ilay + 1;
+            // Back out net heating tendency from the pdel weighted quantity we keep in the FM
+            rad_heating(i,k) = d_rad_heating_pdel(icol,k-1) / d_pdel(icol,k-1);
+            // Apply heating tendency to temperature
+            t_lay(i,k) = t_lay(i,k) + rad_heating(i,k) * dt;
+          });
+        });
+      }
+      Kokkos::fence();
+    }
+
+    // Index to surface (bottom of model); used to get surface fluxes below
+    const int kbot = nlay+1;
+
+    // Compute diffuse flux as difference between total and direct; use YAKL parallel_for here because these are YAKL objects
+    parallel_for(Bounds<3>(m_nswbands,m_nlay+1,ncol), YAKL_LAMBDA(int ibnd, int ilev, int icol) {
+      sw_bnd_flux_dif(icol,ilev,ibnd) = sw_bnd_flux_dn(icol,ilev,ibnd) - sw_bnd_flux_dir(icol,ilev,ibnd);
+    });
+
+    // Compute surface fluxes
+    rrtmgp::compute_broadband_surface_fluxes(
+        ncol, kbot, m_nswbands,
+        sw_bnd_flux_dir, sw_bnd_flux_dif, 
+        sfc_flux_dir_vis, sfc_flux_dir_nir, 
+        sfc_flux_dif_vis, sfc_flux_dif_nir
+    );
+
+    // Copy output data back to FieldManager
+    if (update_rad) {
+      {
+        const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+        Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+          const int i = team.league_rank();
+          const int icol = i + beg;
+          d_sfc_flux_dir_nir(icol) = sfc_flux_dir_nir(i+1);
+          d_sfc_flux_dir_vis(icol) = sfc_flux_dir_vis(i+1);
+          d_sfc_flux_dif_nir(icol) = sfc_flux_dif_nir(i+1);
+          d_sfc_flux_dif_vis(icol) = sfc_flux_dif_vis(i+1);
+          d_sfc_flux_sw_net(icol)  = sw_flux_dn(i+1,kbot) - sw_flux_up(i+1,kbot);
+          d_sfc_flux_lw_dn(icol)   = lw_flux_dn(i+1,kbot);
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay+1), [&] (const int& k) {
+            d_sw_flux_up(icol,k)            = sw_flux_up(i+1,k+1);
+            d_sw_flux_dn(icol,k)            = sw_flux_dn(i+1,k+1);
+            d_sw_flux_dn_dir(icol,k)        = sw_flux_dn_dir(i+1,k+1);
+            d_lw_flux_up(icol,k)            = lw_flux_up(i+1,k+1);
+            d_lw_flux_dn(icol,k)            = lw_flux_dn(i+1,k+1);
+            d_sw_clrsky_flux_up(icol,k)     = sw_clrsky_flux_up(i+1,k+1);
+            d_sw_clrsky_flux_dn(icol,k)     = sw_clrsky_flux_dn(i+1,k+1);
+            d_sw_clrsky_flux_dn_dir(icol,k) = sw_clrsky_flux_dn_dir(i+1,k+1);
+            d_lw_clrsky_flux_up(icol,k)     = lw_clrsky_flux_up(i+1,k+1);
+            d_lw_clrsky_flux_dn(icol,k)     = lw_clrsky_flux_dn(i+1,k+1);
+          });
+        });
+      }
+    }
+    // Temperature is always updated
+    {
+      const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+        const int i = team.league_rank();
+        const int icol = i + beg;
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
+          d_tmid(icol,k) = t_lay(i+1,k+1);
+        });
+      });
+    }
+  }  
 }
 // =========================================================================================
 
 void RRTMGPRadiation::finalize_impl  () {
-  gas_concs.reset();
+  gas_concs.clear();
   rrtmgp::rrtmgp_finalize();
 
   // Finalize YAKL

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -56,7 +56,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   m_lon  = m_grid->get_geometry_data("lon");
 
   // Figure out radiation column chunks stats
-  m_col_chunk_size = std::min(m_params.get("Max Column Chunk Size", m_ncol),m_ncol);
+  m_col_chunk_size = std::min(m_params.get("Column Chunk Size", m_ncol),m_ncol);
   m_num_col_chunks = (m_ncol+m_col_chunk_size-1) / m_col_chunk_size;
   m_col_chunk_beg.resize(m_num_col_chunks+1,0);
   for (int i=0; i<m_num_col_chunks; ++i) {

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -62,6 +62,10 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   for (int i=0; i<m_num_col_chunks; ++i) {
     m_col_chunk_beg[i+1] = std::min(m_ncol,m_col_chunk_beg[i] + m_col_chunk_size);
   }
+  this->log(LogLevel::debug,
+            "[RRTMGP::set_grids] Col chunking stats:\n"
+            "  - Chunk size: " + std::to_string(m_col_chunk_size) + "\n"
+            "  - Number of chunks: " + std::to_string(m_num_col_chunks) + "\n");
 
   // Set up dimension layouts
   FieldLayout scalar2d_layout     { {COL   }, {m_ncol    } };
@@ -432,6 +436,9 @@ void RRTMGPRadiation::run_impl (const int dt) {
   for (int ic=0; ic<m_num_col_chunks; ++ic) {
     const int beg  = m_col_chunk_beg[ic];
     const int ncol = m_col_chunk_beg[ic+1] - beg;
+    this->log(LogLevel::debug,
+              "[RRTMGP::run_impl] Col chunk beg,end: " + std::to_string(beg) + ", " + std::to_string(beg+ncol) + "\n");
+
 
     // Create YAKL arrays. RRTMGP expects YAKL arrays with styleFortran, i.e., data has ncol
     // as the fastest index. For this reason we must copy the data.

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -53,6 +53,9 @@ public:
 
   // Keep track of number of columns and levels
   int m_ncol;
+  int m_num_col_chunks;
+  int m_col_chunk_size;
+  std::vector<int> m_col_chunk_beg;
   int m_nlay;
   view_1d_real m_lat;
   view_1d_real m_lon;
@@ -84,7 +87,7 @@ public:
   int m_ngas;
   std::vector<ci_string>   m_gas_names;
   view_1d_real             m_gas_mol_weights;
-  GasConcs gas_concs;
+  std::vector<GasConcs> gas_concs;
 
   // Rad frequency in number of steps
   int m_rad_freq_in_steps;

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -45,6 +45,7 @@ atmosphere_processes:
         do_prescribed_ccn: false
     rrtmgp:
       Grid: Physics GLL
+      Max Column Chunk Size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false
 

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -45,7 +45,7 @@ atmosphere_processes:
         do_prescribed_ccn: false
     rrtmgp:
       Grid: Physics GLL
-      Max Column Chunk Size: 123
+      Column Chunk Size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false
 

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -45,6 +45,7 @@ atmosphere_processes:
         Grid: Physics GLL
     rrtmgp:
       Grid: Physics GLL
+      Max Column Chunk Size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 Grids Manager:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -45,7 +45,7 @@ atmosphere_processes:
         Grid: Physics GLL
     rrtmgp:
       Grid: Physics GLL
-      Max Column Chunk Size: 123
+      Column Chunk Size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 Grids Manager:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -45,6 +45,7 @@ atmosphere_processes:
         Grid: Physics GLL
     rrtmgp:
       Grid: Physics GLL
+      Max Column Chunk Size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 Grids Manager:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -45,7 +45,7 @@ atmosphere_processes:
         Grid: Physics GLL
     rrtmgp:
       Grid: Physics GLL
-      Max Column Chunk Size: 123
+      Column Chunk Size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 Grids Manager:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -26,6 +26,7 @@ atmosphere_processes:
       do_prescribed_ccn: false
   rrtmgp:
     Grid: Point Grid
+    Max Column Chunk Size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
     do_aerosol_rad: false

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -26,7 +26,7 @@ atmosphere_processes:
       do_prescribed_ccn: false
   rrtmgp:
     Grid: Point Grid
-    Max Column Chunk Size: 123
+    Column Chunk Size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
     do_aerosol_rad: false

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -29,6 +29,7 @@ atmosphere_processes:
       SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
   rrtmgp:
     Grid: Point Grid
+    Max Column Chunk Size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
 

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -29,7 +29,7 @@ atmosphere_processes:
       SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
   rrtmgp:
     Grid: Point Grid
-    Max Column Chunk Size: 123
+    Column Chunk Size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
 

--- a/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -19,6 +19,7 @@ if (NOT SCREAM_BASELINES_ONLY)
   CreateUnitTest(
       rrtmgp_standalone "rrtmgp_standalone.cpp" "${NEED_LIBS}" LABELS ${TEST_LABELS}
       MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+      EXE_ARGS "--ekat-test-params inputfile=input.yaml"
       PROPERTIES FIXTURES_SETUP rrtmgp_generate_output_nc_files
   )
 
@@ -35,26 +36,47 @@ if (NOT SCREAM_BASELINES_ONLY)
   set (ATM_TIME_STEP 1800)
 
   ## Copy (and configure) yaml files needed by tests
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
-  configure_file(rrtmgp_standalone_output.yaml rrtmgp_standalone_output.yaml)
+  configure_file (rrtmgp_standalone_output.yaml rrtmgp_standalone_output.yaml)
+  set (COL_CHUNK_SIZE 1000)
+  configure_file (input.yaml input.yaml)
+
+  ## Add a standalone test with chunked columns, and compare against non-chunked
+  set (SUFFIX "_chunked")
+  set (COL_CHUNK_SIZE 50)
+  configure_file (input.yaml input_chunked.yaml)
+  configure_file (rrtmgp_standalone_output.yaml rrtmgp_standalone_output_chunked.yaml)
+  CreateUnitTestFromExec(
+      rrtmgp_standalone_chunked rrtmgp_standalone
+      LABELS ${TEST_LABELS}
+      EXE_ARGS "--ekat-test-params inputfile=input_chunked.yaml"
+      PROPERTIES FIXTURES_SETUP rrtmgp_chunked_generate_output
+      PASS_REGULAR_EXPRESSION "(beg.end: 50, 100)"
+  )
+
+  # Compare chunked vs non-chunked radiation
+  include (BuildCprnc)
+  BuildCprnc()
+  set (SRC_FILE "rrtmgp_standalone_output_chunked.INSTANT.Steps_x${NUM_STEPS}.np1.nc")
+  set (TGT_FILE "rrtmgp_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np1.nc")
+  set (TEST_NAME "rrtmgp_chunked_vs_monolithic_bfb")
+  add_test (NAME ${TEST_NAME}
+            COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}"
+            FIXTURES_REQUIRED "rrtmgp_generate_output_nc_files;rrtmgp_chunked_generate_output")
 
   ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
   ## Only if max mpi ranks is >1
   # This test requires CPRNC
   if (SCREAM_TEST_MAX_RANKS GREATER 1)
-    include (BuildCprnc)
-    BuildCprnc()
-    SET (BASE_TEST_NAME "rrtmgp")
     foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
-      set (SRC_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
-      set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np1.nc")
-      set (TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+      set (SRC_FILE "rrtmgp_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
+      set (TGT_FILE "rrtmgp_standalone_output.INSTANT.Steps_x${NUM_STEPS}.np1.nc")
+      set (TEST_NAME "rrtmgp_np1_vs_np${MPI_RANKS}_bfb")
       add_test (NAME ${TEST_NAME}
                 COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
       set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${TEST_LABELS}"
-                RESOURCE_LOCK ${BASE_TEST_NAME}
                 FIXTURES_REQUIRED rrtmgp_generate_output_nc_files)
     endforeach()
   endif()

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -14,6 +14,7 @@ atmosphere_processes:
   atm_procs_list: (rrtmgp)
   rrtmgp:
     Grid: Point Grid
+    Max Column Chunk Size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
     Can Initialize All Inputs: true

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -3,6 +3,7 @@
 # This input file is for a free-standing rrtmgp test that runs using initial conditions read from a SCREAMv0 run
 Debug:
   Atmosphere DAG Verbosity Level: 5
+  Atm Log Level: debug
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}
@@ -14,7 +15,7 @@ atmosphere_processes:
   atm_procs_list: (rrtmgp)
   rrtmgp:
     Grid: Point Grid
-    Max Column Chunk Size: 123
+    Column Chunk Size: ${COL_CHUNK_SIZE}
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
     Can Initialize All Inputs: true
@@ -39,5 +40,5 @@ Initial Conditions:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["rrtmgp_standalone_output.yaml"]
+  Output YAML Files: ["rrtmgp_standalone_output${SUFFIX}.yaml"]
 ...

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -7,6 +7,7 @@ atmosphere_processes:
   atm_procs_list: (rrtmgp)
   rrtmgp:
     Grid: Point Grid
+    Max Column Chunk Size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
     # Set orbital parameters to constants for consistency with RRTMGP test problem

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone.cpp
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone.cpp
@@ -9,6 +9,7 @@
 #include "share/field/field_utils.hpp"
 
 #include "ekat/ekat_parse_yaml_file.hpp"
+#include "ekat/util/ekat_test_utils.hpp"
 
 #include <iomanip>
 
@@ -22,9 +23,9 @@ TEST_CASE("rrtmgp-stand-alone", "") {
   ekat::Comm atm_comm (MPI_COMM_WORLD);
 
   // Load ad parameter list
-  std::string fname = "input.yaml";
+  std::string inputfile = ekat::TestSession::get().params.at("inputfile");
   ekat::ParameterList ad_params("Atmosphere Driver");
-  REQUIRE_NOTHROW ( parse_yaml_file(fname,ad_params) );
+  REQUIRE_NOTHROW ( parse_yaml_file(inputfile,ad_params) );
 
   // Time stepping parameters
   auto& ts = ad_params.sublist("Time Stepping");

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-Casename: rrtmgp_standalone_output
+Casename: rrtmgp_standalone_output${SUFFIX}
 Averaging Type: Instant
 Max Snapshots Per File: 1
 Field Names:


### PR DESCRIPTION
Allows to reduce (YAKL) memory footprint in RRTMGP. The size of column chunks is configurable via yaml/xml file.

Passes standalone testing on my laptop. I will let the AT run v1 testing (or do it myself in the morning if AT times out on mappy, as it often happens at night). I will also run memcheck tests in the morning.