### PR TITLE
Add calendar information to time variable in output NC files

### DIFF
--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -206,6 +206,11 @@ void OutputManager::run(const util::TimeStamp& timestamp)
       // Register time as a variable.
       auto time_units="days since " + m_case_t0.get_date_string() + " " + m_case_t0.get_time_string();
       register_variable(filename,"time","time",time_units,1,{"time"},  PIO_REAL,"time");
+#ifdef SCREAM_HAS_LEAP_YEAR
+      set_variable_metadata (filename,"time","calendar","gregorian");
+#else
+      set_variable_metadata (filename,"time","calendar","noleap");
+#endif
 
       // Make all output streams register their dims/vars
       for (auto& it : m_output_streams) {

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -74,6 +74,7 @@ module scream_scorpio_interface
             eam_pio_finalize,            & ! Run any final PIO commands
             register_file,               & ! Creates/opens a pio input/output file
             register_variable,           & ! Register a variable with a particular pio output file
+            set_variable_metadata,       & ! Sets a variable metadata (always char data)
             get_variable,                & ! Register a variable with a particular pio output file
             register_dimension,          & ! Register a dimension with a particular pio output file
             set_decomp,                  & ! Set the pio decomposition for all variables in file.
@@ -566,6 +567,55 @@ contains
     endif
 
   end subroutine register_variable
+!=====================================================================!
+  subroutine set_variable_metadata(filename, varname, metaname, metaval)
+    use pionfatt_mod, only: PIO_put_att => put_att
+
+    character(len=256), intent(in) :: filename
+    character(len=256), intent(in) :: varname
+    character(len=256), intent(in) :: metaname
+    character(len=256), intent(in) :: metaval
+
+    ! Local variables
+    type(pio_atm_file_t),pointer :: pio_file
+    type(hist_var_t),    pointer :: var
+    integer                      :: ierr
+    logical                      :: found
+
+    type(hist_var_list_t), pointer :: curr
+
+    ! Find the pointer for this file
+    call lookup_pio_atm_file(trim(filename),pio_file,found)
+    if (.not.found ) then
+      call errorHandle("PIO ERROR: error setting metadata for variable "//trim(varname)//" in file "//trim(filename)//".\n PIO file not found or not open.",-999)
+    endif
+
+    ! Find the variable in the file
+    curr => pio_file%var_list_top
+
+    found = .false.
+    do while (associated(curr))
+      if (associated(curr%var)) then
+        if (trim(curr%var%name)==trim(varname) .and. curr%var%is_set) then
+          found = .true.
+          var => curr%var
+          exit
+        endif
+      endif
+      curr => curr%next
+    end do
+    if (.not.found ) then
+      call errorHandle("PIO ERROR: error setting metadata for variable "//trim(varname)//" in file "//trim(filename)//".\n Variable not found.",-999)
+    endif
+
+    ierr = PIO_put_att(pio_file%pioFileDesc, var%piovar, metaname, metaval)
+    if (ierr .ne. 0) then
+      call errorHandle("Error setting attribute '" // trim(metaname) &
+                       // "' on variable '" // trim(varname) &
+                       // "' in pio file " // trim(filename) // ".", -999)
+    endif
+
+  end subroutine set_variable_metadata
 !=====================================================================!
   ! Update the time dimension for a specific PIO file.  This is needed when
   ! reading or writing multiple time levels.  Unlimited dimensions are treated

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -24,6 +24,7 @@ extern "C" {
   void pio_update_time_c2f(const char*&& filename,const Real time);
   void register_dimension_c2f(const char*&& filename, const char*&& shortname, const char*&& longname, const int length);
   void register_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const char*&& units, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
+  void set_variable_metadata_c2f (const char*&& filename, const char*&& varname, const char*&& meta_name, const char*&& meta_val);
   void get_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
   void eam_pio_enddef_c2f(const char*&& filename);
 } // extern C
@@ -106,6 +107,9 @@ void register_variable(const std::string &filename, const std::string& shortname
 void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
 
   register_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), units.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
+}
+void set_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, const std::string& meta_val) {
+  set_variable_metadata_c2f(filename.c_str(),varname.c_str(),meta_name.c_str(),meta_val.c_str());
 }
 /* ----------------------------------------------------------------- */
 void eam_pio_enddef(const std::string &filename) {

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -48,6 +48,7 @@ namespace scorpio {
   /* Register a variable with a file.  Called during the file setup, for an output stream. */
   void register_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
   void register_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
+  void set_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, const std::string& meta_val);
   /* Register a variable with a file.  Called during the file setup, for an input stream. */
   void get_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
   void get_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag);

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -1,7 +1,7 @@
 module scream_scorpio_interface_iso_c2f
   use iso_c_binding, only: c_int, c_double, c_float, c_bool, c_ptr
   implicit none
-     
+
 #include "scream_config.f"
 #ifdef SCREAM_DOUBLE_PRECISION
 # define c_real c_double
@@ -9,7 +9,7 @@ module scream_scorpio_interface_iso_c2f
 # define c_real c_float
 #endif
 !
-! This file contains bridges from scream c++ to shoc fortran. 
+! This file contains bridges from scream c++ to shoc fortran.
 !
 contains
 !=====================================================================!
@@ -121,14 +121,14 @@ contains
     type(c_ptr), intent(in)                :: var_dimensions_in(numdims)
     integer(kind=c_int), value, intent(in) :: dtype
     type(c_ptr), intent(in)                :: pio_decomp_tag_in
-    
+
     character(len=256) :: filename
     character(len=256) :: shortname
     character(len=256) :: longname
     character(len=256) :: var_dimensions(numdims)
     character(len=256) :: pio_decomp_tag
     integer            :: ii
-    
+
     call convert_c_string(filename_in,filename)
     call convert_c_string(shortname_in,shortname)
     call convert_c_string(longname_in,longname)
@@ -136,7 +136,7 @@ contains
     do ii = 1,numdims
       call convert_c_string(var_dimensions_in(ii), var_dimensions(ii))
     end do
-   
+
     call get_variable(filename,shortname,longname,numdims,var_dimensions,dtype,pio_decomp_tag)
 
   end subroutine get_variable_c2f
@@ -181,7 +181,7 @@ contains
     type(c_ptr), intent(in)                :: var_dimensions_in(numdims)
     integer(kind=c_int), value, intent(in) :: dtype
     type(c_ptr), intent(in)                :: pio_decomp_tag_in
-    
+
     character(len=256) :: filename
     character(len=256) :: shortname
     character(len=256) :: longname
@@ -189,7 +189,7 @@ contains
     character(len=256) :: var_dimensions(numdims)
     character(len=256) :: pio_decomp_tag
     integer            :: ii
-    
+
     call convert_c_string(filename_in,filename)
     call convert_c_string(shortname_in,shortname)
     call convert_c_string(longname_in,longname)
@@ -198,10 +198,31 @@ contains
     do ii = 1,numdims
       call convert_c_string(var_dimensions_in(ii), var_dimensions(ii))
     end do
-   
+
     call register_variable(filename,shortname,longname,units,numdims,var_dimensions,dtype,pio_decomp_tag)
 
   end subroutine register_variable_c2f
+!=====================================================================!
+  subroutine set_variable_metadata_c2f(filename_in, varname_in, metaname_in, metaval_in) bind(c)
+    use scream_scorpio_interface, only : set_variable_metadata
+    type(c_ptr), intent(in)                :: filename_in
+    type(c_ptr), intent(in)                :: varname_in
+    type(c_ptr), intent(in)                :: metaname_in
+    type(c_ptr), intent(in)                :: metaval_in
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+    character(len=256) :: metaname
+    character(len=256) :: metaval
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call convert_c_string(metaname_in,metaname)
+    call convert_c_string(metaval_in,metaval)
+
+    call set_variable_metadata(filename,varname,metaname,metaval)
+
+  end subroutine set_variable_metadata_c2f
 !=====================================================================!
   subroutine register_dimension_c2f(filename_in, shortname_in, longname_in, length) bind(c)
     use scream_scorpio_interface, only : register_dimension
@@ -211,14 +232,14 @@ contains
     integer(kind=c_int), value, intent(in) :: length
 
     character(len=256) :: filename
-    character(len=256) :: shortname 
-    character(len=256) :: longname  
+    character(len=256) :: shortname
+    character(len=256) :: longname
 
     call convert_c_string(filename_in,filename)
     call convert_c_string(shortname_in,shortname)
     call convert_c_string(longname_in,longname)
     call register_dimension(filename,shortname,longname,length)
-    
+
   end subroutine register_dimension_c2f
 !=====================================================================!
   function get_dimlen_c2f(filename_in,dimname_in) result(val) bind(c)
@@ -257,7 +278,7 @@ contains
     call c_f_pointer(c_string_ptr,temp_string)
     str_len = index(temp_string, C_NULL_CHAR) - 1
     f_string = trim(temp_string(1:str_len))
-    
+
   end subroutine convert_c_string
 !=====================================================================!
   subroutine grid_write_data_array_c2f_real(filename_in,varname_in,var_data_ptr) bind(c)

--- a/components/scream/src/share/tests/utils_tests.cpp
+++ b/components/scream/src/share/tests/utils_tests.cpp
@@ -50,109 +50,128 @@ TEST_CASE ("time_stamp") {
   constexpr auto spd = constants::seconds_per_day;
 
   TS ts1 (2021,10,12,17,8,30);
-  REQUIRE (ts1.get_year()==2021);
-  REQUIRE (ts1.get_month()==10);
-  REQUIRE (ts1.get_day()==12);
-  REQUIRE (ts1.get_hours()==17);
-  REQUIRE (ts1.get_minutes()==8);
-  REQUIRE (ts1.get_seconds()==30);
 
-  // Julian day = frac_of_year_in_days.fraction_of_day, with frac_of_year_in_days=0 at Jan 1st.
-  REQUIRE (ts1.frac_of_year_in_days()==(284 + (17*3600+8*60+30)/86400.0));
-  REQUIRE (ts1.get_num_steps()==0);
+  SECTION ("ctor_check") {
+    REQUIRE (ts1.get_year()==2021);
+    REQUIRE (ts1.get_month()==10);
+    REQUIRE (ts1.get_day()==12);
+    REQUIRE (ts1.get_hours()==17);
+    REQUIRE (ts1.get_minutes()==8);
+    REQUIRE (ts1.get_seconds()==30);
+  }
 
-  REQUIRE (ts1.get_date_string()=="2021-10-12");
-  REQUIRE (ts1.get_time_string()=="17:08:30");
-  REQUIRE (ts1.to_string()=="2021-10-12-61710");
+  SECTION ("getters_checks") {
+    // Julian day = frac_of_year_in_days.fraction_of_day, with frac_of_year_in_days=0 at Jan 1st.
+    REQUIRE (ts1.frac_of_year_in_days()==(284 + (17*3600+8*60+30)/86400.0));
+    REQUIRE (ts1.get_num_steps()==0);
 
-  // Comparisons
-  TS ts2 = ts1;
-  ts2 += 10;
-  REQUIRE (ts1<ts2);
-  REQUIRE (ts2<=ts2);
-  REQUIRE (ts2==ts2);
+    REQUIRE (ts1.get_date_string()=="2021-10-12");
+    REQUIRE (ts1.get_time_string()=="17:08:30");
+    REQUIRE (ts1.to_string()=="2021-10-12-61710");
+  }
 
-  // Cannot rewind time
-  REQUIRE_THROWS (ts2+=-10);
+  SECTION ("comparisons") {
+    REQUIRE (ts1==ts1);
 
-  // Update: check carries
-  auto ts3 = ts1 + 1;
-  REQUIRE (ts3.get_seconds()==(ts1.get_seconds()+1));
-  REQUIRE (ts3.get_minutes()==ts1.get_minutes());
-  REQUIRE (ts3.get_hours()==ts1.get_hours());
-  REQUIRE (ts3.get_day()==ts1.get_day());
-  REQUIRE (ts3.get_month()==ts1.get_month());
-  REQUIRE (ts3.get_year()==ts1.get_year());
+    // Comparisons
+    REQUIRE ( TS({2021,12,31},{23,59,59}) < TS({2022,1,1},{0,0,0}));
+    REQUIRE ( TS({2022,1,1},{0,0,0}) <= TS({2022,1,1},{0,0,0}));
+    REQUIRE ( (TS({2021,12,31},{23,59,59})+1) == TS({2022,1,1},{0,0,0}));
+  }
 
-  ts3 += 60;
-  REQUIRE (ts3.get_seconds()==(ts1.get_seconds()+1));
-  REQUIRE (ts3.get_minutes()==(ts1.get_minutes()+1));
-  REQUIRE (ts3.get_hours()==ts1.get_hours());
-  REQUIRE (ts3.get_day()==ts1.get_day());
-  REQUIRE (ts3.get_month()==ts1.get_month());
-  REQUIRE (ts3.get_year()==ts1.get_year());
+  SECTION ("updates") {
+    // Cannot rewind time
+    REQUIRE_THROWS (ts1+=-10);
 
-  ts3 += 3600;
-  REQUIRE (ts3.get_seconds()==(ts1.get_seconds()+1));
-  REQUIRE (ts3.get_minutes()==(ts1.get_minutes()+1));
-  REQUIRE (ts3.get_hours()==ts1.get_hours()+1);
-  REQUIRE (ts3.get_day()==ts1.get_day());
-  REQUIRE (ts3.get_month()==ts1.get_month());
-  REQUIRE (ts3.get_year()==ts1.get_year());
+    auto ts2 = ts1 + 1;
 
-  ts3 += spd;
-  REQUIRE (ts3.get_seconds()==(ts1.get_seconds()+1));
-  REQUIRE (ts3.get_minutes()==(ts1.get_minutes()+1));
-  REQUIRE (ts3.get_hours()==(ts1.get_hours()+1));
-  REQUIRE (ts3.get_day()==(ts1.get_day()+1));
-  REQUIRE (ts3.get_month()==ts1.get_month());
-  REQUIRE (ts3.get_year()==ts1.get_year());
+    REQUIRE (ts1<ts2);
+    REQUIRE (ts2<=ts2);
 
-  ts3 += spd*20;
-  REQUIRE (ts3.get_seconds()==(ts1.get_seconds()+1));
-  REQUIRE (ts3.get_minutes()==(ts1.get_minutes()+1));
-  REQUIRE (ts3.get_hours()==(ts1.get_hours()+1));
-  REQUIRE (ts3.get_day()==(ts1.get_day()+1+20-31)); // Add 20 days, subtract Oct 31 days (carry)
-  REQUIRE (ts3.get_month()==(ts1.get_month()+1));
-  REQUIRE (ts3.get_year()==ts1.get_year());
+    // Update: check carries
+    REQUIRE (ts2.get_seconds()==(ts1.get_seconds()+1));
+    REQUIRE (ts2.get_minutes()==ts1.get_minutes());
+    REQUIRE (ts2.get_hours()==ts1.get_hours());
+    REQUIRE (ts2.get_day()==ts1.get_day());
+    REQUIRE (ts2.get_month()==ts1.get_month());
+    REQUIRE (ts2.get_year()==ts1.get_year());
 
-  ts3 += spd*365;
-  REQUIRE (ts3.get_seconds()==ts1.get_seconds()+1);
-  REQUIRE (ts3.get_minutes()==(ts1.get_minutes()+1));
-  REQUIRE (ts3.get_hours()==(ts1.get_hours()+1));
-  REQUIRE (ts3.get_day()==(ts1.get_day()+1+20-31)); // Add 20 days, subtract Oct 31 days (carry)
-  REQUIRE (ts3.get_month()==(ts1.get_month()+1));
-  REQUIRE (ts3.get_year()==(ts1.get_year()+1));
+    ts2 += 60;
+    REQUIRE (ts2.get_seconds()==(ts1.get_seconds()+1));
+    REQUIRE (ts2.get_minutes()==(ts1.get_minutes()+1));
+    REQUIRE (ts2.get_hours()==ts1.get_hours());
+    REQUIRE (ts2.get_day()==ts1.get_day());
+    REQUIRE (ts2.get_month()==ts1.get_month());
+    REQUIRE (ts2.get_year()==ts1.get_year());
 
-  REQUIRE (ts3.get_num_steps()==6);
+    ts2 += 3600;
+    REQUIRE (ts2.get_seconds()==(ts1.get_seconds()+1));
+    REQUIRE (ts2.get_minutes()==(ts1.get_minutes()+1));
+    REQUIRE (ts2.get_hours()==ts1.get_hours()+1);
+    REQUIRE (ts2.get_day()==ts1.get_day());
+    REQUIRE (ts2.get_month()==ts1.get_month());
+    REQUIRE (ts2.get_year()==ts1.get_year());
 
-  // Check update across leap date
-#ifdef EKAT_HAS_LEAP_YEAR
-  TS ts4(2024,2,28,0,0,0);
-  ts4 += spd;
-  REQUIRE (ts4.get_month()==2);
-  REQUIRE (ts4.get_day()==29);
-  ts4 += spd;
-  REQUIRE (ts4.get_month()==3);
-  REQUIRE (ts4.get_day()==1);
+    ts2 += spd;
+    REQUIRE (ts2.get_seconds()==(ts1.get_seconds()+1));
+    REQUIRE (ts2.get_minutes()==(ts1.get_minutes()+1));
+    REQUIRE (ts2.get_hours()==(ts1.get_hours()+1));
+    REQUIRE (ts2.get_day()==(ts1.get_day()+1));
+    REQUIRE (ts2.get_month()==ts1.get_month());
+    REQUIRE (ts2.get_year()==ts1.get_year());
+
+    ts2 += spd*20;
+    REQUIRE (ts2.get_seconds()==(ts1.get_seconds()+1));
+    REQUIRE (ts2.get_minutes()==(ts1.get_minutes()+1));
+    REQUIRE (ts2.get_hours()==(ts1.get_hours()+1));
+    REQUIRE (ts2.get_day()==(ts1.get_day()+1+20-31)); // Add 20 days, subtract Oct 31 days (carry)
+    REQUIRE (ts2.get_month()==(ts1.get_month()+1));
+    REQUIRE (ts2.get_year()==ts1.get_year());
+
+    ts2 += spd*365;
+    REQUIRE (ts2.get_seconds()==ts1.get_seconds()+1);
+    REQUIRE (ts2.get_minutes()==(ts1.get_minutes()+1));
+    REQUIRE (ts2.get_hours()==(ts1.get_hours()+1));
+    REQUIRE (ts2.get_day()==(ts1.get_day()+1+20-31)); // Add 20 days, subtract Oct 31 days (carry)
+    REQUIRE (ts2.get_month()==(ts1.get_month()+1));
+    REQUIRE (ts2.get_year()==(ts1.get_year()+1));
+
+    REQUIRE (ts2.get_num_steps()==6);
+  }
+
+  SECTION ("leap_years") {
+    // Check leap year correctness
+    TS ts2({2000,2,28},{23,59,59});
+    TS ts3({2012,2,28},{23,59,59});
+    TS ts4({2100,2,28},{23,59,59});
+
+    ts2 += 1;
+    ts3 += 1;
+    ts4 += 1;
+#ifdef SCREAM_HAS_LEAP_YEAR
+    REQUIRE (ts2.get_month()==2);
+    REQUIRE (ts3.get_month()==2);
+#else
+    REQUIRE (ts2.get_month()==3);
+    REQUIRE (ts3.get_month()==3);
 #endif
+    // Centennial years with first 2 digits not divisible by 4 are not leap
+    REQUIRE (ts4.get_month()==3);
+  }
 
-  // Comparisons
-  REQUIRE ( TS({2021,12,31},{23,59,59}) < TS({2022,1,1},{0,0,0}));
-  REQUIRE ( TS({2022,1,1},{0,0,0}) <= TS({2022,1,1},{0,0,0}));
-  REQUIRE ( (TS({2021,12,31},{23,59,59})+1) == TS({2022,1,1},{0,0,0}));
-
-  // Difference
-  auto ts5 = ts1 + 3600;
-  REQUIRE ( (ts5-ts1)==3600 );
-  auto ts6 = ts1 + spd;
-  REQUIRE ( (ts6-ts1)==spd );
-  auto ts7 = ts1 + spd*10;
-  REQUIRE ( (ts7-ts1)==spd*10 );
-  auto ts8 = ts1 + spd*100;
-  REQUIRE ( (ts8-ts1)==spd*100 );
-  auto ts9 = ts1 + spd*1000;
-  REQUIRE ( (ts9-ts1)==spd*1000 );
+  SECTION ("difference") {
+    // Difference
+    auto ts2 = ts1 + 3600;
+    REQUIRE ( (ts2-ts1)==3600 );
+    auto ts3 = ts1 + spd;
+    REQUIRE ( (ts3-ts1)==spd );
+    auto ts4 = ts1 + spd*10;
+    REQUIRE ( (ts4-ts1)==spd*10 );
+    auto ts5 = ts1 + spd*100;
+    REQUIRE ( (ts5-ts1)==spd*100 );
+    auto ts6 = ts1 + spd*1000;
+    REQUIRE ( (ts6-ts1)==spd*1000 );
+  }
 }
 
 TEST_CASE ("array_utils") {

--- a/components/scream/src/share/util/scream_time_stamp.cpp
+++ b/components/scream/src/share/util/scream_time_stamp.cpp
@@ -1,7 +1,8 @@
 #include "share/util/scream_time_stamp.hpp"
 
-#include "ekat/ekat_assert.hpp"
 #include "share/util/scream_universal_constants.hpp"
+#include "share/scream_config.hpp"
+#include "ekat/ekat_assert.hpp"
 
 #include <limits>
 #include <numeric>


### PR DESCRIPTION
Adds the `calendar: noleap` or `calendar: gregorian` information to the output nc file generated by eamxx. Also, fix a missing include which caused the update of a TimeStamp to never consider leap years.

I verified that generated files do contain the metadata, and that it's `gregorian` if `SCREAM_HAS_LEAP_YEAR=ON` (the default) and `noleap` if `SCREAM_HAS_LEAP_YEAR=OFF`.

Fix #1872 