### PR TITLE
Changing naming convention of scream parameters

### DIFF
--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -751,10 +751,10 @@ def do_cime_vars_on_yaml_output_files(case,caseroot):
         eamxx_xml = ET.parse(fd).getroot()
 
     scorpio = get_child(eamxx_xml,'Scorpio')
-    out_files_xml = get_child(scorpio,"Output__YAML__Files",must_exist=False)
+    out_files_xml = get_child(scorpio,"output_yaml_files",must_exist=False)
     out_files = out_files_xml.text.split(",") if out_files_xml is not None else []
 
-    # We will also change the 'Output YAML Files' entry in scream_input.yaml,
+    # We will also change the 'output_yaml_files' entry in scream_input.yaml,
     # to point to the copied files in $rundir/data
     output_yaml_files = []
     scream_input_file = os.path.join(rundir,'data','scream_input.yaml')
@@ -783,12 +783,12 @@ def do_cime_vars_on_yaml_output_files(case,caseroot):
                      extra={'PHYSICS_GRID_TYPE': pgt})
         ordered_dump(content, open(dst_yaml, "w"))
 
-        output_yaml_files.append (dst_yaml)
+        output_yaml_files.append(dst_yaml)
 
     # Now update the output yaml files entry, and dump the new content
     # of the scream input to YAML file
     print ("out list: {}".format(",".join(output_yaml_files)))
-    scream_input["Scorpio"]["Output YAML Files"] = refine_type(",".join(output_yaml_files),"array(string)")
+    scream_input["Scorpio"]["output_yaml_files"] = refine_type(",".join(output_yaml_files),"array(string)")
     with open(scream_input_file, "w") as fd:
         fd.write(
 """################################################################

--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -835,7 +835,7 @@ def buildnml(case, caseroot, compname):
     # to ensure are present on the machine (possibly downloading them)
     #
     scream_input = files_as_dicts["data/scream_input.yaml"]
-    ic_section = scream_input["Initial Conditions"]
+    ic_section = scream_input["initial_conditions"]
     create_input_data_list_file(case,caseroot,screamroot,ic_section)
 
     # For all YAML files listed in the XML for model output, expand CIME vars (if any)

--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -454,18 +454,18 @@ def _create_raw_xml_file_impl(case, xml):
     OrderedDict([   ('atm_procs_list', '(P1,P2)'),
                     ('prop2', 'one'),
                     ('number_of_subcycles', 1),
-                    ('Enable Precondition Checks', True),
+                    ('enable_precondition_checks', True),
                     ('Enable Postcondition Checks', True),
                     (   'P1',
                         OrderedDict([   ('prop1', 'hi'),
                                         ('Grid', 'Physics PG2'),
                                         ('number_of_subcycles', 1),
-                                        ('Enable Precondition Checks', True),
+                                        ('enable_precondition_checks', True),
                                         ('Enable Postcondition Checks', True)])),
                     (   'P2',
                         OrderedDict([   ('prop1', 'there'),
                                         ('number_of_subcycles', 1),
-                                        ('Enable Precondition Checks', True),
+                                        ('enable_precondition_checks', True),
                                         ('Enable Postcondition Checks', True)]))])
 
     """

--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -453,18 +453,18 @@ def _create_raw_xml_file_impl(case, xml):
     >>> pp.pprint(d)
     OrderedDict([   ('atm_procs_list', '(P1,P2)'),
                     ('prop2', 'one'),
-                    ('Number of Subcycles', 1),
+                    ('number_of_subcycles', 1),
                     ('Enable Precondition Checks', True),
                     ('Enable Postcondition Checks', True),
                     (   'P1',
                         OrderedDict([   ('prop1', 'hi'),
                                         ('Grid', 'Physics PG2'),
-                                        ('Number of Subcycles', 1),
+                                        ('number_of_subcycles', 1),
                                         ('Enable Precondition Checks', True),
                                         ('Enable Postcondition Checks', True)])),
                     (   'P2',
                         OrderedDict([   ('prop1', 'there'),
-                                        ('Number of Subcycles', 1),
+                                        ('number_of_subcycles', 1),
                                         ('Enable Precondition Checks', True),
                                         ('Enable Postcondition Checks', True)]))])
 

--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -455,18 +455,18 @@ def _create_raw_xml_file_impl(case, xml):
                     ('prop2', 'one'),
                     ('number_of_subcycles', 1),
                     ('enable_precondition_checks', True),
-                    ('Enable Postcondition Checks', True),
+                    ('enable_postcondition_checks', True),
                     (   'P1',
                         OrderedDict([   ('prop1', 'hi'),
                                         ('Grid', 'Physics PG2'),
                                         ('number_of_subcycles', 1),
                                         ('enable_precondition_checks', True),
-                                        ('Enable Postcondition Checks', True)])),
+                                        ('enable_postcondition_checks', True)])),
                     (   'P2',
                         OrderedDict([   ('prop1', 'there'),
                                         ('number_of_subcycles', 1),
                                         ('enable_precondition_checks', True),
-                                        ('Enable Postcondition Checks', True)]))])
+                                        ('enable_postcondition_checks', True)]))])
 
     """
 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -290,7 +290,7 @@ tweaking their $case/namelist_scream.xml file.
   <!-- List of yaml files containing I/O output specs -->
   <Scorpio>
     <output_yaml_files type="array(string)">${SRCROOT}/components/scream/data/scream_default_output.yaml</output_yaml_files>
-    <Model__Restart>
+    <model_restart>
       <Casename>./${CASE}.scream</Casename>
       <Output__Control>
         <Frequency>${REST_N}</Frequency>
@@ -300,7 +300,7 @@ tweaking their $case/namelist_scream.xml file.
         <AVG__Type__in__Filename>false</AVG__Type__in__Filename>
         <Frequency__in__Filename>false</Frequency__in__Filename>
       </Output__Control>
-    </Model__Restart>
+    </model_restart>
   </Scorpio>
 
   <!-- Debug options for scream -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -135,7 +135,7 @@ tweaking their $case/namelist_scream.xml file.
     <atm_proc_base>
       <number_of_subcycles constraints="gt 0">1</number_of_subcycles>
       <enable_precondition_checks type="logical">true</enable_precondition_checks>
-      <Enable__Postcondition__Checks type="logical">true</Enable__Postcondition__Checks>
+      <enable_postcondition_checks type="logical">true</enable_postcondition_checks>
     </atm_proc_base>
 
     <!-- Basic options for each atm process group -->
@@ -155,7 +155,7 @@ tweaking their $case/namelist_scream.xml file.
     <sc_import>
       <Grid>Physics GLL</Grid>
       <Grid hgrid=".*pg2">Physics PG2</Grid>
-      <Enable__Postcondition__Checks type="logical">true</Enable__Postcondition__Checks>
+      <enable_postcondition_checks type="logical">true</enable_postcondition_checks>
     </sc_import>
 
     <!-- SC Export -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -133,7 +133,7 @@ tweaking their $case/namelist_scream.xml file.
 
     <!-- Basic options for each atm process -->
     <atm_proc_base>
-      <Number__of__Subcycles constraints="gt 0">1</Number__of__Subcycles>
+      <number_of_subcycles constraints="gt 0">1</number_of_subcycles>
       <Enable__Precondition__Checks type="logical">true</Enable__Precondition__Checks>
       <Enable__Postcondition__Checks type="logical">true</Enable__Postcondition__Checks>
     </atm_proc_base>
@@ -227,12 +227,12 @@ tweaking their $case/namelist_scream.xml file.
     <mac_aero_mic inherit="atm_proc_group">
       <atm_procs_list>(shoc,cldFraction,spa,p3)</atm_procs_list>
       <atm_procs_list COMPSET=".*SCREAM.*noAero">(shoc,cldFraction,p3)</atm_procs_list>
-      <Number__of__Subcycles hgrid="ne4np4">24</Number__of__Subcycles>
-      <Number__of__Subcycles hgrid="ne30np4">6</Number__of__Subcycles>
-      <Number__of__Subcycles hgrid="ne120np4">3</Number__of__Subcycles>
-      <Number__of__Subcycles hgrid="ne256np4">3</Number__of__Subcycles>
-      <Number__of__Subcycles hgrid="ne512np4">1</Number__of__Subcycles>
-      <Number__of__Subcycles hgrid="ne1024np4">1</Number__of__Subcycles>
+      <number_of_subcycles hgrid="ne4np4">24</number_of_subcycles>
+      <number_of_subcycles hgrid="ne30np4">6</number_of_subcycles>
+      <number_of_subcycles hgrid="ne120np4">3</number_of_subcycles>
+      <number_of_subcycles hgrid="ne256np4">3</number_of_subcycles>
+      <number_of_subcycles hgrid="ne512np4">1</number_of_subcycles>
+      <number_of_subcycles hgrid="ne1024np4">1</number_of_subcycles>
     </mac_aero_mic>
 
     <physics inherit="atm_proc_group">

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -206,7 +206,7 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Radiation -->
     <rrtmgp inherit="physics_proc_base">
       <active_gases>h2o, co2, o3, n2o, co, ch4, o2, n2</active_gases>
-      <Column__Chunk__Size>1280</Column__Chunk__Size>
+      <column_chunk_size>1280</column_chunk_size>
       <Orbital__Year>-9999</Orbital__Year>
       <Orbital__Eccentricity>-9999</Orbital__Eccentricity>
       <Orbital__Eccentricity COMPSET=".*SCREAM%AQUA.*">0</Orbital__Eccentricity>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -200,7 +200,7 @@ tweaking their $case/namelist_scream.xml file.
       <spa_remap_file hgrid="ne30np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne30pg2_mono.20220714.nc</spa_remap_file>
       <spa_remap_file hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc</spa_remap_file>
       <spa_remap_file hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne512np4_mono_20220506.nc</spa_remap_file>
-      <SPA__Data__File>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
+      <spa_data_file>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</spa_data_file>
     </spa>
 
     <!-- Radiation -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -212,8 +212,8 @@ tweaking their $case/namelist_scream.xml file.
       <orbital_eccentricity COMPSET=".*SCREAM%AQUA.*">0</orbital_eccentricity>
       <orbital_obliquity>-9999</orbital_obliquity>
       <orbital_obliquity COMPSET=".*SCREAM%AQUA.*">0</orbital_obliquity>
-      <Orbital__MVELP>-9999</Orbital__MVELP>
-      <Orbital__MVELP COMPSET=".*SCREAM%AQUA.*">0</Orbital__MVELP>
+      <orbital_mvelp>-9999</orbital_mvelp>
+      <orbital_mvelp COMPSET=".*SCREAM%AQUA.*">0</orbital_mvelp>
       <rad_frequency hgrid="ne4np4">1</rad_frequency>
       <rad_frequency hgrid="ne30np4">2</rad_frequency>
       <rad_frequency hgrid="ne120np4">4</rad_frequency>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -47,7 +47,7 @@ tweaking their $case/namelist_scream.xml file.
       <sections>ctl_nl</sections>
     </file>
     <file name="data/scream_input.yaml" format="yaml">
-      <sections>Debug,atmosphere_processes,Grids__Manager,Initial__Conditions,Scorpio,E3SM__Parameters</sections>
+      <sections>Debug,atmosphere_processes,grids_manager,Initial__Conditions,Scorpio,E3SM__Parameters</sections>
     </file>
   </generated_files>
 
@@ -241,12 +241,12 @@ tweaking their $case/namelist_scream.xml file.
   </atmosphere_processes_defaults>
 
   <!-- Grids manager specs -->
-  <Grids__Manager>
+  <grids_manager>
     <Type>Dynamics Driven</Type>
     <Reference__Grid>Physics GLL</Reference__Grid>
     <Reference__Grid hgrid=".*pg2">Physics PG2</Reference__Grid>
     <Dynamics__Namelist__File__Name>./data/namelist.nl</Dynamics__Namelist__File__Name>
-  </Grids__Manager>
+  </grids_manager>
 
   <!-- List of nc files for loading inputs on specified grids -->
   <Initial__Conditions>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -311,7 +311,7 @@ tweaking their $case/namelist_scream.xml file.
 
   <!-- E3SM Simulation Settings -->
   <e3sm_parameters>
-    <E3SM__Casename>${CASE}</E3SM__Casename>
+    <e3sm_casename>${CASE}</e3sm_casename>
   </e3sm_parameters>
 
   <!--

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -210,8 +210,8 @@ tweaking their $case/namelist_scream.xml file.
       <orbital_year>-9999</orbital_year>
       <orbital_eccentricity>-9999</orbital_eccentricity>
       <orbital_eccentricity COMPSET=".*SCREAM%AQUA.*">0</orbital_eccentricity>
-      <Orbital__Obliquity>-9999</Orbital__Obliquity>
-      <Orbital__Obliquity COMPSET=".*SCREAM%AQUA.*">0</Orbital__Obliquity>
+      <orbital_obliquity>-9999</orbital_obliquity>
+      <orbital_obliquity COMPSET=".*SCREAM%AQUA.*">0</orbital_obliquity>
       <Orbital__MVELP>-9999</Orbital__MVELP>
       <Orbital__MVELP COMPSET=".*SCREAM%AQUA.*">0</Orbital__MVELP>
       <rad_frequency hgrid="ne4np4">1</rad_frequency>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -292,14 +292,14 @@ tweaking their $case/namelist_scream.xml file.
     <output_yaml_files type="array(string)">${SRCROOT}/components/scream/data/scream_default_output.yaml</output_yaml_files>
     <model_restart>
       <Casename>./${CASE}.scream</Casename>
-      <Output__Control>
+      <output_control>
         <Frequency>${REST_N}</Frequency>
         <Frequency REST_OPTION="none">0</Frequency>
         <Frequency__Units>INVALID</Frequency__Units>
         <Frequency__Units REST_OPTION="nstep*">Steps</Frequency__Units>
         <AVG__Type__in__Filename>false</AVG__Type__in__Filename>
         <Frequency__in__Filename>false</Frequency__in__Filename>
-      </Output__Control>
+      </output_control>
     </model_restart>
   </Scorpio>
 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -207,7 +207,7 @@ tweaking their $case/namelist_scream.xml file.
     <rrtmgp inherit="physics_proc_base">
       <active_gases>h2o, co2, o3, n2o, co, ch4, o2, n2</active_gases>
       <column_chunk_size>1280</column_chunk_size>
-      <Orbital__Year>-9999</Orbital__Year>
+      <orbital_year>-9999</orbital_year>
       <Orbital__Eccentricity>-9999</Orbital__Eccentricity>
       <Orbital__Eccentricity COMPSET=".*SCREAM%AQUA.*">0</Orbital__Eccentricity>
       <Orbital__Obliquity>-9999</Orbital__Obliquity>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -47,7 +47,7 @@ tweaking their $case/namelist_scream.xml file.
       <sections>ctl_nl</sections>
     </file>
     <file name="data/scream_input.yaml" format="yaml">
-      <sections>Debug,atmosphere_processes,grids_manager,Initial__Conditions,Scorpio,E3SM__Parameters</sections>
+      <sections>Debug,atmosphere_processes,grids_manager,initial_conditions,Scorpio,E3SM__Parameters</sections>
     </file>
   </generated_files>
 
@@ -249,7 +249,7 @@ tweaking their $case/namelist_scream.xml file.
   </grids_manager>
 
   <!-- List of nc files for loading inputs on specified grids -->
-  <Initial__Conditions>
+  <initial_conditions>
     <Filename>UNSET</Filename>
     <Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne4np4L72_20220701.nc</Filename>
     <Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220701.nc</Filename>
@@ -285,7 +285,7 @@ tweaking their $case/namelist_scream.xml file.
     <surf_sens_flux    >0.0</surf_sens_flux>
     <surf_lw_flux_up   >0.0</surf_lw_flux_up>
     <surf_mom_flux     >0.0,0.0</surf_mom_flux>
-  </Initial__Conditions>
+  </initial_conditions>
 
   <!-- List of yaml files containing I/O output specs -->
   <Scorpio>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -142,7 +142,7 @@ tweaking their $case/namelist_scream.xml file.
     <atm_proc_group inherit="atm_proc_base">
       <atm_procs_list>ERROR_NO_ATM_PROCS</atm_procs_list>
       <Type>Group</Type>
-      <Schedule__Type>Sequential</Schedule__Type>
+      <schedule_type>Sequential</schedule_type>
     </atm_proc_group>
 
     <!-- Basic options for each "physics" atm process -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -297,7 +297,7 @@ tweaking their $case/namelist_scream.xml file.
         <Frequency REST_OPTION="none">0</Frequency>
         <frequency_units>INVALID</frequency_units>
         <frequency_units REST_OPTION="nstep*">Steps</frequency_units>
-        <AVG__Type__in__Filename>false</AVG__Type__in__Filename>
+        <avg_type_in_filename>false</avg_type_in_filename>
         <Frequency__in__Filename>false</Frequency__in__Filename>
       </output_control>
     </model_restart>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -295,8 +295,8 @@ tweaking their $case/namelist_scream.xml file.
       <output_control>
         <Frequency>${REST_N}</Frequency>
         <Frequency REST_OPTION="none">0</Frequency>
-        <Frequency__Units>INVALID</Frequency__Units>
-        <Frequency__Units REST_OPTION="nstep*">Steps</Frequency__Units>
+        <frequency_units>INVALID</frequency_units>
+        <frequency_units REST_OPTION="nstep*">Steps</frequency_units>
         <AVG__Type__in__Filename>false</AVG__Type__in__Filename>
         <Frequency__in__Filename>false</Frequency__in__Filename>
       </output_control>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -305,7 +305,7 @@ tweaking their $case/namelist_scream.xml file.
 
   <!-- Debug options for scream -->
   <Debug>
-    <Atmosphere__DAG__Verbosity__Level>0</Atmosphere__DAG__Verbosity__Level>
+    <atmosphere_dag_verbosity_level>0</atmosphere_dag_verbosity_level>
     <Atm__Log__Level valid_values="trace,debug,info,warn,error">info</Atm__Log__Level>
   </Debug>
 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -289,7 +289,7 @@ tweaking their $case/namelist_scream.xml file.
 
   <!-- List of yaml files containing I/O output specs -->
   <Scorpio>
-    <Output__YAML__Files type="array(string)">${SRCROOT}/components/scream/data/scream_default_output.yaml</Output__YAML__Files>
+    <output_yaml_files type="array(string)">${SRCROOT}/components/scream/data/scream_default_output.yaml</output_yaml_files>
     <Model__Restart>
       <Casename>./${CASE}.scream</Casename>
       <Output__Control>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -47,7 +47,7 @@ tweaking their $case/namelist_scream.xml file.
       <sections>ctl_nl</sections>
     </file>
     <file name="data/scream_input.yaml" format="yaml">
-      <sections>Debug,atmosphere_processes,grids_manager,initial_conditions,Scorpio,E3SM__Parameters</sections>
+      <sections>Debug,atmosphere_processes,grids_manager,initial_conditions,Scorpio,e3sm_parameters</sections>
     </file>
   </generated_files>
 
@@ -310,9 +310,9 @@ tweaking their $case/namelist_scream.xml file.
   </Debug>
 
   <!-- E3SM Simulation Settings -->
-  <E3SM__Parameters>
+  <e3sm_parameters>
     <E3SM__Casename>${CASE}</E3SM__Casename>
-  </E3SM__Parameters>
+  </e3sm_parameters>
 
   <!--
     List of input files that CIME needs to ensure to be present. If not present,

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -208,8 +208,8 @@ tweaking their $case/namelist_scream.xml file.
       <active_gases>h2o, co2, o3, n2o, co, ch4, o2, n2</active_gases>
       <column_chunk_size>1280</column_chunk_size>
       <orbital_year>-9999</orbital_year>
-      <Orbital__Eccentricity>-9999</Orbital__Eccentricity>
-      <Orbital__Eccentricity COMPSET=".*SCREAM%AQUA.*">0</Orbital__Eccentricity>
+      <orbital_eccentricity>-9999</orbital_eccentricity>
+      <orbital_eccentricity COMPSET=".*SCREAM%AQUA.*">0</orbital_eccentricity>
       <Orbital__Obliquity>-9999</Orbital__Obliquity>
       <Orbital__Obliquity COMPSET=".*SCREAM%AQUA.*">0</Orbital__Obliquity>
       <Orbital__MVELP>-9999</Orbital__MVELP>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -243,8 +243,8 @@ tweaking their $case/namelist_scream.xml file.
   <!-- Grids manager specs -->
   <grids_manager>
     <Type>Dynamics Driven</Type>
-    <Reference__Grid>Physics GLL</Reference__Grid>
-    <Reference__Grid hgrid=".*pg2">Physics PG2</Reference__Grid>
+    <reference_grid>Physics GLL</reference_grid>
+    <reference_grid hgrid=".*pg2">Physics PG2</reference_grid>
     <Dynamics__Namelist__File__Name>./data/namelist.nl</Dynamics__Namelist__File__Name>
   </grids_manager>
 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -193,13 +193,13 @@ tweaking their $case/namelist_scream.xml file.
 
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="physics_proc_base">
-      <SPA__Remap__File>UNSET</SPA__Remap__File>
-      <SPA__Remap__File hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc</SPA__Remap__File>
-      <SPA__Remap__File hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne4pg2_mono.20220714.nc</SPA__Remap__File>
-      <SPA__Remap__File hgrid="ne30np4">none</SPA__Remap__File>
-      <SPA__Remap__File hgrid="ne30np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne30pg2_mono.20220714.nc</SPA__Remap__File>
-      <SPA__Remap__File hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc</SPA__Remap__File>
-      <SPA__Remap__File hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne512np4_mono_20220506.nc</SPA__Remap__File>
+      <spa_remap_file>UNSET</spa_remap_file>
+      <spa_remap_file hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne4pg2_mono.20220714.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne30np4">none</spa_remap_file>
+      <spa_remap_file hgrid="ne30np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne30pg2_mono.20220714.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne512np4_mono_20220506.nc</spa_remap_file>
       <SPA__Data__File>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</SPA__Data__File>
     </spa>
 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -167,13 +167,13 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Homme dynamics -->
     <homme inherit="atm_proc_base">
       <Grid>Dynamics</Grid>
-      <Vertical__Coordinate__Filename>UNSET</Vertical__Coordinate__Filename>
-      <Vertical__Coordinate__Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne4np4L72_20220524.nc</Vertical__Coordinate__Filename>
-      <Vertical__Coordinate__Filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220524.nc</Vertical__Coordinate__Filename>
-      <Vertical__Coordinate__Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220524.nc</Vertical__Coordinate__Filename>
-      <Vertical__Coordinate__Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220525.nc</Vertical__Coordinate__Filename>
-      <Vertical__Coordinate__Filename hgrid="ne1024np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_20220713.nc</Vertical__Coordinate__Filename>
-      <Vertical__Coordinate__Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20220524.nc</Vertical__Coordinate__Filename>
+      <vertical_coordinate_filename>UNSET</vertical_coordinate_filename>
+      <vertical_coordinate_filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne4np4L72_20220524.nc</vertical_coordinate_filename>
+      <vertical_coordinate_filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220524.nc</vertical_coordinate_filename>
+      <vertical_coordinate_filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220524.nc</vertical_coordinate_filename>
+      <vertical_coordinate_filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220525.nc</vertical_coordinate_filename>
+      <vertical_coordinate_filename hgrid="ne1024np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_20220713.nc</vertical_coordinate_filename>
+      <vertical_coordinate_filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20220524.nc</vertical_coordinate_filename>
       <Moisture>moist</Moisture>
     </homme>
 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -134,7 +134,7 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Basic options for each atm process -->
     <atm_proc_base>
       <number_of_subcycles constraints="gt 0">1</number_of_subcycles>
-      <Enable__Precondition__Checks type="logical">true</Enable__Precondition__Checks>
+      <enable_precondition_checks type="logical">true</enable_precondition_checks>
       <Enable__Postcondition__Checks type="logical">true</Enable__Postcondition__Checks>
     </atm_proc_base>
 

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -298,7 +298,7 @@ tweaking their $case/namelist_scream.xml file.
         <frequency_units>INVALID</frequency_units>
         <frequency_units REST_OPTION="nstep*">Steps</frequency_units>
         <avg_type_in_filename>false</avg_type_in_filename>
-        <Frequency__in__Filename>false</Frequency__in__Filename>
+        <frequency_in_filename>false</frequency_in_filename>
       </output_control>
     </model_restart>
   </Scorpio>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -306,7 +306,7 @@ tweaking their $case/namelist_scream.xml file.
   <!-- Debug options for scream -->
   <Debug>
     <atmosphere_dag_verbosity_level>0</atmosphere_dag_verbosity_level>
-    <Atm__Log__Level valid_values="trace,debug,info,warn,error">info</Atm__Log__Level>
+    <atm_log_level valid_values="trace,debug,info,warn,error">info</atm_log_level>
   </Debug>
 
   <!-- E3SM Simulation Settings -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -258,7 +258,7 @@ tweaking their $case/namelist_scream.xml file.
     <Filename hgrid="ne1024np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_20220713.nc</Filename> 
     <Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20220524.nc</Filename>
     <Filename hgrid="ne30np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne30np4_L128_20211202.nc</Filename> <!-- This will need to be updated to the new nccn name -->
-    <Restart__Casename>${CASE}.scream</Restart__Casename>
+    <restart_casename>${CASE}.scream</restart_casename>
     <!-- Fields that we need to initialize, but are not in an initial condition file need to be inited here -->
     <surf_evap>0.0</surf_evap> <!-- TODO, Delete this when the IC fixes come in -->
     <precip_liq_surf_mass>0.0</precip_liq_surf_mass>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -245,7 +245,7 @@ tweaking their $case/namelist_scream.xml file.
     <Type>Dynamics Driven</Type>
     <reference_grid>Physics GLL</reference_grid>
     <reference_grid hgrid=".*pg2">Physics PG2</reference_grid>
-    <Dynamics__Namelist__File__Name>./data/namelist.nl</Dynamics__Namelist__File__Name>
+    <dynamics_namelist_file_name>./data/namelist.nl</dynamics_namelist_file_name>
   </grids_manager>
 
   <!-- List of nc files for loading inputs on specified grids -->

--- a/components/scream/data/scream_default_output.yaml
+++ b/components/scream/data/scream_default_output.yaml
@@ -53,7 +53,7 @@ Fields:
       - surf_sens_flux
       # Diagnostics
       - PotentialTemperature
-Output Control:
+output_control:
   Frequency: ${HIST_N}
   Frequency Units: ${HIST_OPTION}
   MPI Ranks in Filename: false

--- a/components/scream/data/scream_default_output.yaml
+++ b/components/scream/data/scream_default_output.yaml
@@ -59,5 +59,5 @@ output_control:
   MPI Ranks in Filename: false
   Timestamp in Filename: true
   avg_type_in_filename: false
-  Frequency in Filename: false
+  frequency_in_filename: false
 ...

--- a/components/scream/data/scream_default_output.yaml
+++ b/components/scream/data/scream_default_output.yaml
@@ -58,6 +58,6 @@ output_control:
   frequency_units: ${HIST_OPTION}
   MPI Ranks in Filename: false
   Timestamp in Filename: true
-  AVG Type in Filename: false
+  avg_type_in_filename: false
   Frequency in Filename: false
 ...

--- a/components/scream/data/scream_default_output.yaml
+++ b/components/scream/data/scream_default_output.yaml
@@ -55,7 +55,7 @@ Fields:
       - PotentialTemperature
 output_control:
   Frequency: ${HIST_N}
-  Frequency Units: ${HIST_OPTION}
+  frequency_units: ${HIST_OPTION}
   MPI Ranks in Filename: false
   Timestamp in Filename: true
   AVG Type in Filename: false

--- a/components/scream/scripts/change-param-pattern
+++ b/components/scream/scripts/change-param-pattern
@@ -1,0 +1,38 @@
+#! /usr/bin/env python3
+
+"""
+A quick-and-dirty script for changing naming patterns of
+items in namelist_defaults_scream.xml.
+
+Run from root scream directory on mappy
+"""
+
+from utils import run_cmd_no_fail
+import re
+
+result = run_cmd_no_fail("echo hi")
+print(result)
+
+# Hardcoded things
+bad_pattern = "__"
+name_re = re.compile(r'([A-Za-z0-9]+__)([A-Za-z0-9]+__)?([A-Za-z0-9]+__)?([A-Za-z0-9]+__)?([A-Za-z0-9]+__)?([A-Za-z0-9]+)')
+
+raw_dbl_un = run_cmd_no_fail(f"git grep {bad_pattern} cime_config/namelist_defaults_scream.xml")
+bad_name_unders = []
+for m in name_re.finditer(raw_dbl_un):
+    name = "".join([item for item in m.groups() if item is not None])
+    if name not in bad_name_unders:
+        bad_name_unders.append(name)
+
+print("Found these:")
+print(bad_name_unders)
+
+for bad_name_under in bad_name_unders:
+    bad_name_ws = bad_name_under.replace("__", " ")
+    good_name = bad_name_ws.replace(" ", "_").lower()
+    print(f"  Replacing {bad_name_under} with {good_name}")
+    run_cmd_no_fail(f"sed -i -e 's/{bad_name_under}/{good_name}/g' $(git grep -l '{bad_name_under}')")
+    run_cmd_no_fail(f"sed -i -e 's/{bad_name_ws}/{good_name}/g'    $(git grep -l '{bad_name_ws}')")
+    run_cmd_no_fail(f"git commit -a -m '{bad_name_ws} -> {good_name}'")
+    print("  Testing")
+    run_cmd_no_fail("./create_test ERS_D_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1 --compiler=gnu9", from_dir="../../cime/scripts")

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -727,7 +727,7 @@ void AtmosphereDriver::create_logger () {
   auto& deb_pl = m_atm_params.sublist("Debug");
 
   ci_string log_fname = deb_pl.get<std::string>("Atm Log File","atm.log");
-  ci_string log_level_str = deb_pl.get<std::string>("Atm Log Level","info");
+  ci_string log_level_str = deb_pl.get<std::string>("atm_log_level","info");
   EKAT_REQUIRE_MSG (log_fname!="",
       "Invalid string for 'Atm Log File': '" + log_fname + "'.\n");
 
@@ -745,7 +745,7 @@ void AtmosphereDriver::create_logger () {
   } else if (log_level_str=="off") {
     log_level = LogLevel::off;
   } else {
-    EKAT_ERROR_MSG ("Invalid choice for 'Atm Log Level': " + log_level_str + "\n");
+    EKAT_ERROR_MSG ("Invalid choice for 'atm_log_level': " + log_level_str + "\n");
   }
 
   using logger_t = Logger<LogBasicFile,LogRootRank>;

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -514,8 +514,8 @@ void AtmosphereDriver::initialize_output_managers () {
   // OM of all the requested outputs.
 
   // Check for model restart output
-  if (io_params.isSublist("Model Restart")) {
-    auto restart_pl = io_params.sublist("Model Restart");
+  if (io_params.isSublist("model_restart")) {
+    auto restart_pl = io_params.sublist("model_restart");
     // Signal that this is not a normal output, but the model restart one
     m_output_managers.emplace_back();
     auto& om = m_output_managers.back();

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -583,7 +583,7 @@ initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0
   //       the IC file, and throw an error when the dag is created.
 
   auto& deb_pl = m_atm_params.sublist("Debug");
-  const int verb_lvl = deb_pl.get<int>("Atmosphere DAG Verbosity Level",-1);
+  const int verb_lvl = deb_pl.get<int>("atmosphere_dag_verbosity_level",-1);
   if (verb_lvl>0) {
     // Check the atm DAG for missing stuff
     AtmProcDAG dag;

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -535,7 +535,7 @@ void AtmosphereDriver::initialize_output_managers () {
   
   // Build one manager per output yaml file
   using vos_t = std::vector<std::string>;
-  const auto& output_yaml_files = io_params.get<vos_t>("Output YAML Files",vos_t{});
+  const auto& output_yaml_files = io_params.get<vos_t>("output_yaml_files",vos_t{});
   int om_tally = 0;
   for (const auto& fname : output_yaml_files) {
     ekat::ParameterList params;

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -121,7 +121,7 @@ set_params(const ekat::ParameterList& atm_params)
 
 #ifdef SCREAM_CIME_BUILD
   const auto hgn = "Physics PG2";
-  fvphyshack = m_atm_params.sublist("grids_manager").get<std::string>("Reference Grid") == hgn;
+  fvphyshack = m_atm_params.sublist("grids_manager").get<std::string>("reference_grid") == hgn;
   if (fvphyshack) {
     // See the [rrtmgp active gases] note in dynamics/homme/atmosphere_dynamics_fv_phys.cpp.
     fv_phys_rrtmgp_active_gases_init(m_atm_params);

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -759,7 +759,7 @@ void AtmosphereDriver::create_logger () {
   // Record the CASENAME for this run, set default to EAMxx
   if (m_atm_params.isSublist("e3sm_parameters")) {
     auto e3sm_params = m_atm_params.sublist("e3sm_parameters");
-    m_casename = e3sm_params.get<std::string>("E3SM Casename","EAMxx");
+    m_casename = e3sm_params.get<std::string>("e3sm_casename","EAMxx");
   } else {
     m_casename = "EAMxx";
   }

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -121,7 +121,7 @@ set_params(const ekat::ParameterList& atm_params)
 
 #ifdef SCREAM_CIME_BUILD
   const auto hgn = "Physics PG2";
-  fvphyshack = m_atm_params.sublist("Grids Manager").get<std::string>("Reference Grid") == hgn;
+  fvphyshack = m_atm_params.sublist("grids_manager").get<std::string>("Reference Grid") == hgn;
   if (fvphyshack) {
     // See the [rrtmgp active gases] note in dynamics/homme/atmosphere_dynamics_fv_phys.cpp.
     fv_phys_rrtmgp_active_gases_init(m_atm_params);
@@ -185,7 +185,7 @@ void AtmosphereDriver::create_grids()
   check_ad_status (s_procs_created | s_comm_set | s_params_set);
 
   // Create the grids manager
-  auto& gm_params = m_atm_params.sublist("Grids Manager");
+  auto& gm_params = m_atm_params.sublist("grids_manager");
   const std::string& gm_type = gm_params.get<std::string>("Type");
   m_atm_logger->debug("  [EAMxx] Creating grid manager '" + gm_type + "' ...");
   m_grids_manager = GridsManagerFactory::instance().create(gm_type,m_atm_comm,gm_params);

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -757,8 +757,8 @@ void AtmosphereDriver::create_logger () {
   m_atm_logger = logger;
 
   // Record the CASENAME for this run, set default to EAMxx
-  if (m_atm_params.isSublist("E3SM Parameters")) {
-    auto e3sm_params = m_atm_params.sublist("E3SM Parameters");
+  if (m_atm_params.isSublist("e3sm_parameters")) {
+    auto e3sm_params = m_atm_params.sublist("e3sm_parameters");
     m_casename = e3sm_params.get<std::string>("E3SM Casename","EAMxx");
   } else {
     m_casename = "EAMxx";

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -205,7 +205,7 @@ void AtmosphereDriver::create_grids()
   // Load reference/surface pressure fractions if needed. This
   // is done inside dynamics, however, for standalone runs
   // without dynamics, these values could be needed.
-  auto& ic_pl = m_atm_params.sublist("Initial Conditions");
+  auto& ic_pl = m_atm_params.sublist("initial_conditions");
   const bool load_hybrid_coeffs = ic_pl.get<bool>("Load Hybrid Coefficients",false);
   if (load_hybrid_coeffs) {
     using view_1d_host = AtmosphereInput::view_1d_host;
@@ -610,7 +610,7 @@ initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0
   // Check whether we need to load latitude/longitude of reference grid dofs.
   // This option allows the user to set lat or lon in their own
   // test or run setup code rather than by file.
-  auto& ic_pl = m_atm_params.sublist("Initial Conditions");
+  auto& ic_pl = m_atm_params.sublist("initial_conditions");
   bool load_latitude  = ic_pl.get<bool>("Load Latitude",false);
   bool load_longitude = ic_pl.get<bool>("Load Longitude",false);
 
@@ -667,7 +667,7 @@ void AtmosphereDriver::restart_model ()
   m_atm_logger->info("  [EAMxx] restart_model ...");
 
   // First, figure out the name of the netcdf file containing the restart data
-  const auto& casename = m_atm_params.sublist("Initial Conditions").get<std::string>("Restart Casename");
+  const auto& casename = m_atm_params.sublist("initial_conditions").get<std::string>("Restart Casename");
   auto filename = find_filename_in_rpointer (casename,true,m_atm_comm,m_run_t0);
 
   // Restart the num steps counter in the atm time stamp
@@ -769,7 +769,7 @@ void AtmosphereDriver::set_initial_conditions ()
 {
   m_atm_logger->info("  [EAMxx] set_initial_conditions ...");
 
-  auto& ic_pl = m_atm_params.sublist("Initial Conditions");
+  auto& ic_pl = m_atm_params.sublist("initial_conditions");
 
   // Check which fields need to have an initial condition.
   std::map<std::string,std::vector<std::string>> ic_fields_names;

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -667,7 +667,7 @@ void AtmosphereDriver::restart_model ()
   m_atm_logger->info("  [EAMxx] restart_model ...");
 
   // First, figure out the name of the netcdf file containing the restart data
-  const auto& casename = m_atm_params.sublist("initial_conditions").get<std::string>("Restart Casename");
+  const auto& casename = m_atm_params.sublist("initial_conditions").get<std::string>("restart_casename");
   auto filename = find_filename_in_rpointer (casename,true,m_atm_comm,m_run_t0);
 
   // Restart the num steps counter in the atm time stamp

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -28,5 +28,5 @@ atmosphere_processes:
 
 grids_manager:
   Type: User Provided
-  Reference Grid: Point Grid
+  reference_grid: Point Grid
 ...

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -11,7 +11,7 @@ initial_conditions:
 
 atmosphere_processes:
   atm_procs_list: (dummy1, dummy2, dummy3)
-  Schedule Type: Sequential
+  schedule_type: Sequential
 
   dummy1:
     Type: Dummy

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -3,7 +3,7 @@
 Debug:
   Atmosphere DAG Verbosity Level: 5
 
-Initial Conditions:
+initial_conditions:
   Filename: should_not_be_neeeded_and_code_will_throw_if_it_tries_to_open_this_nonexistent_file.nc
   A: 1.0
   V: [2.0, 3.0]

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 initial_conditions:
   Filename: should_not_be_neeeded_and_code_will_throw_if_it_tries_to_open_this_nonexistent_file.nc

--- a/components/scream/src/control/tests/ad_tests.yaml
+++ b/components/scream/src/control/tests/ad_tests.yaml
@@ -26,7 +26,7 @@ atmosphere_processes:
     Sub Name: Group to A
     Grid Name: Point Grid
 
-Grids Manager:
+grids_manager:
   Type: User Provided
   Reference Grid: Point Grid
 ...

--- a/components/scream/src/diagnostics/tests/atm_density_test.cpp
+++ b/components/scream/src/diagnostics/tests/atm_density_test.cpp
@@ -26,7 +26,7 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
   const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/diagnostics/tests/diagnostic_test_util.hpp
+++ b/components/scream/src/diagnostics/tests/diagnostic_test_util.hpp
@@ -12,7 +12,7 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
   const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/diagnostics/tests/dry_static_energy_test.cpp
+++ b/components/scream/src/diagnostics/tests/dry_static_energy_test.cpp
@@ -26,7 +26,7 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
   const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/diagnostics/tests/exner_test.cpp
+++ b/components/scream/src/diagnostics/tests/exner_test.cpp
@@ -26,7 +26,7 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
   const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/scream/src/diagnostics/tests/potential_temperature_test.cpp
@@ -26,7 +26,7 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
   const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/diagnostics/tests/sea_level_pressure_test.cpp
+++ b/components/scream/src/diagnostics/tests/sea_level_pressure_test.cpp
@@ -26,7 +26,7 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
   const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/diagnostics/tests/vertical_layer_interface_test.cpp
+++ b/components/scream/src/diagnostics/tests/vertical_layer_interface_test.cpp
@@ -26,7 +26,7 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
   const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/diagnostics/tests/vertical_layer_midpoint_test.cpp
+++ b/components/scream/src/diagnostics/tests/vertical_layer_midpoint_test.cpp
@@ -26,7 +26,7 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
   const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/diagnostics/tests/vertical_layer_thickness_test.cpp
+++ b/components/scream/src/diagnostics/tests/vertical_layer_thickness_test.cpp
@@ -26,7 +26,7 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
   const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/diagnostics/tests/virtual_temperature_test.cpp
+++ b/components/scream/src/diagnostics/tests/virtual_temperature_test.cpp
@@ -26,7 +26,7 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
   const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/diagnostics/tests/water_path_tests.cpp
+++ b/components/scream/src/diagnostics/tests/water_path_tests.cpp
@@ -26,7 +26,7 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
   const int num_global_cols = ncols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -241,7 +241,7 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
     m_d2p_remapper = grids_manager->create_remapper(m_dyn_grid,m_phys_grid);
   }
   
-  // Create separate remapper for Initial Conditions
+  // Create separate remapper for initial_conditions
   m_ic_remapper = grids_manager->create_remapper(m_cgll_grid,m_dyn_grid);
 }
 

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -1314,7 +1314,7 @@ void HommeDynamics::init_homme_vcoord () {
 
   // Read vcoords into host views
   ekat::ParameterList vcoord_reader_pl;
-  vcoord_reader_pl.set("Filename",m_params.get<std::string>("Vertical Coordinate Filename"));
+  vcoord_reader_pl.set("Filename",m_params.get<std::string>("vertical_coordinate_filename"));
   vcoord_reader_pl.set<vos_t>("Field Names",{"hyai","hybi","hyam","hybm"});
   std::map<std::string,view_1d_host> host_views = {
     { "hyai", view_1d_host("hyai",nlev_int) },

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
@@ -63,7 +63,7 @@ DynamicsDrivenGridsManager (const ekat::Comm& comm,
   // TODO: add other rebalancing?
 
   // Get the ref grid name
-  m_ref_grid_name = p.get<std::string>("Reference Grid");
+  m_ref_grid_name = p.get<std::string>("reference_grid");
   EKAT_REQUIRE_MSG (ekat::contains(gn,m_ref_grid_name),
       "Error! Invalid reference grid name: " + m_ref_grid_name + "\n");
 

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.cpp
@@ -31,7 +31,7 @@ DynamicsDrivenGridsManager (const ekat::Comm& comm,
 
   if (!is_params_inited_f90()) {
     // While we're here, we can init homme's parameters
-    auto nlname = p.get<std::string>("Dynamics Namelist File Name").c_str();
+    auto nlname = p.get<std::string>("dynamics_namelist_file_name").c_str();
     init_params_f90 (nlname);
   }
 

--- a/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.hpp
+++ b/components/scream/src/dynamics/homme/dynamics_driven_grids_manager.hpp
@@ -18,7 +18,7 @@ public:
 
   ~DynamicsDrivenGridsManager ();
 
-  std::string name () const { return "Dynamics Driven Grids Manager"; }
+  std::string name () const { return "Dynamics Driven grids_manager"; }
 
   void build_grids (const std::set<std::string>& grid_names);
 

--- a/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -158,8 +158,8 @@ TEST_CASE("dyn_grid_io")
   io_params.set<std::string>("Casename","dyn_grid_io_np" + std::to_string(comm.size()));
   io_params.sublist("Fields").sublist("Dynamics").set<std::vector<std::string>>("Field Names",fnames);
   io_params.sublist("Fields").sublist("Dynamics").set<std::string>("IO Grid Name","Physics GLL");
-  io_params.sublist("Output Control").set<int>("Frequency",1);
-  io_params.sublist("Output Control").set<std::string>("Frequency Units","Steps");
+  io_params.sublist("output_control").set<int>("Frequency",1);
+  io_params.sublist("output_control").set<std::string>("Frequency Units","Steps");
 
   OutputManager output;
   // AtmosphereOutput output(comm,io_params,fm_dyn,gm);

--- a/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -64,7 +64,7 @@ TEST_CASE("dyn_grid_io")
 
   // Create the grids
   ekat::ParameterList params;
-  params.set<std::string>("Reference Grid","Physics GLL");
+  params.set<std::string>("reference_grid","Physics GLL");
   auto gm = std::make_shared<DynamicsDrivenGridsManager>(comm,params);
   std::set<std::string> grids_names = {"Physics GLL","Dynamics"};
   gm->build_grids(grids_names);

--- a/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -159,7 +159,7 @@ TEST_CASE("dyn_grid_io")
   io_params.sublist("Fields").sublist("Dynamics").set<std::vector<std::string>>("Field Names",fnames);
   io_params.sublist("Fields").sublist("Dynamics").set<std::string>("IO Grid Name","Physics GLL");
   io_params.sublist("output_control").set<int>("Frequency",1);
-  io_params.sublist("output_control").set<std::string>("Frequency Units","Steps");
+  io_params.sublist("output_control").set<std::string>("frequency_units","Steps");
 
   OutputManager output;
   // AtmosphereOutput output(comm,io_params,fm_dyn,gm);

--- a/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -67,7 +67,7 @@ TEST_CASE("remap", "") {
 
   // Create the grids
   ekat::ParameterList params;
-  params.set<std::string>("Reference Grid","Physics GLL");
+  params.set<std::string>("reference_grid","Physics GLL");
   DynamicsDrivenGridsManager gm(comm,params);
   std::set<std::string> grids_names = {"Physics GLL","Dynamics"};
   gm.build_grids(grids_names);
@@ -612,7 +612,7 @@ TEST_CASE("combo_remap", "") {
 
   // Create the grids
   ekat::ParameterList params;
-  params.set<std::string>("Reference Grid","Physics GLL");
+  params.set<std::string>("reference_grid","Physics GLL");
   DynamicsDrivenGridsManager gm(comm,params);
   std::set<std::string> grids_names = {"Physics GLL","Dynamics"};
   gm.build_grids(grids_names);

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -283,7 +283,7 @@ void RRTMGPRadiation::initialize_impl(const RunType /* run_type */) {
   m_orbital_year = m_params.get<Int>("orbital_year",-9999);
   // Get orbital parameters from yaml file
   m_orbital_eccen = m_params.get<Int>("orbital_eccentricity",-9999);
-  m_orbital_obliq = m_params.get<Int>("Orbital Obliquity"   ,-9999);
+  m_orbital_obliq = m_params.get<Int>("orbital_obliquity"   ,-9999);
   m_orbital_mvelp = m_params.get<Int>("Orbital MVELP"       ,-9999);
 
   // Determine whether or not we are using a fixed solar zenith angle (positive value)

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -282,7 +282,7 @@ void RRTMGPRadiation::initialize_impl(const RunType /* run_type */) {
   // for duration of simulation.
   m_orbital_year = m_params.get<Int>("orbital_year",-9999);
   // Get orbital parameters from yaml file
-  m_orbital_eccen = m_params.get<Int>("Orbital Eccentricity",-9999);
+  m_orbital_eccen = m_params.get<Int>("orbital_eccentricity",-9999);
   m_orbital_obliq = m_params.get<Int>("Orbital Obliquity"   ,-9999);
   m_orbital_mvelp = m_params.get<Int>("Orbital MVELP"       ,-9999);
 

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -56,7 +56,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   m_lon  = m_grid->get_geometry_data("lon");
 
   // Figure out radiation column chunks stats
-  m_col_chunk_size = std::min(m_params.get("Column Chunk Size", m_ncol),m_ncol);
+  m_col_chunk_size = std::min(m_params.get("column_chunk_size", m_ncol),m_ncol);
   m_num_col_chunks = (m_ncol+m_col_chunk_size-1) / m_col_chunk_size;
   m_col_chunk_beg.resize(m_num_col_chunks+1,0);
   for (int i=0; i<m_num_col_chunks; ++i) {

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -277,10 +277,10 @@ void RRTMGPRadiation::initialize_impl(const RunType /* run_type */) {
   // Determine rad timestep, specified as number of atm steps
   m_rad_freq_in_steps = m_params.get<Int>("rad_frequency", 1);
 
-  // Determine orbital year. If Orbital Year is negative, use current year
+  // Determine orbital year. If orbital_year is negative, use current year
   // from timestamp for orbital year; if positive, use provided orbital year
   // for duration of simulation.
-  m_orbital_year = m_params.get<Int>("Orbital Year",-9999);
+  m_orbital_year = m_params.get<Int>("orbital_year",-9999);
   // Get orbital parameters from yaml file
   m_orbital_eccen = m_params.get<Int>("Orbital Eccentricity",-9999);
   m_orbital_obliq = m_params.get<Int>("Orbital Obliquity"   ,-9999);

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -284,7 +284,7 @@ void RRTMGPRadiation::initialize_impl(const RunType /* run_type */) {
   // Get orbital parameters from yaml file
   m_orbital_eccen = m_params.get<Int>("orbital_eccentricity",-9999);
   m_orbital_obliq = m_params.get<Int>("orbital_obliquity"   ,-9999);
-  m_orbital_mvelp = m_params.get<Int>("Orbital MVELP"       ,-9999);
+  m_orbital_mvelp = m_params.get<Int>("orbital_mvelp"       ,-9999);
 
   // Determine whether or not we are using a fixed solar zenith angle (positive value)
   m_fixed_solar_zenith_angle = m_params.get<Real>("Fixed Solar Zenith Angle", -9999);

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -160,9 +160,9 @@ void SPA::initialize_impl (const RunType /* run_type */)
   SPAData_out.AER_TAU_LW         = get_field_out("aero_tau_lw").get_view<Pack***>();
 
   // Retrieve the remap and data file locations from the parameter list:
-  EKAT_REQUIRE_MSG(m_params.isParameter("SPA Remap File"),"ERROR: SPA Remap File is missing from SPA parameter list.");
+  EKAT_REQUIRE_MSG(m_params.isParameter("spa_remap_file"),"ERROR: spa_remap_file is missing from SPA parameter list.");
   EKAT_REQUIRE_MSG(m_params.isParameter("SPA Data File"),"ERROR: SPA Data File is missing from SPA parameter list.");
-  m_spa_remap_file = m_params.get<std::string>("SPA Remap File");
+  m_spa_remap_file = m_params.get<std::string>("spa_remap_file");
 
   // Set the SPA remap weights.  
   // TODO: We may want to provide an option to calculate weights on-the-fly. 
@@ -171,7 +171,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
   using ci_string = ekat::CaseInsensitiveString;
   ci_string no_filename = "none";
   if (m_spa_remap_file == no_filename) {
-    printf("WARNING: SPA Remap File has been set to 'NONE', assuming that SPA data and simulation are on the same grid - skipping horizontal interpolation\n");
+    printf("WARNING: spa_remap_file has been set to 'NONE', assuming that SPA data and simulation are on the same grid - skipping horizontal interpolation\n");
     SPAFunc::set_remap_weights_one_to_one(m_total_global_dofs,m_min_global_dof,m_dofs_gids,SPAHorizInterp);
   } else {
     SPAFunc::get_remap_weights_from_file(m_spa_remap_file,m_total_global_dofs,m_min_global_dof,m_dofs_gids,SPAHorizInterp);

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -66,7 +66,7 @@ void SPA::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 
   // Note: only the number of levels associated with this data haven't been set.  We can
   //       take this information directly from the spa data file.
-  m_spa_data_file = m_params.get<std::string>("SPA Data File");
+  m_spa_data_file = m_params.get<std::string>("spa_data_file");
   scorpio::register_file(m_spa_data_file,scorpio::Read);
   m_num_src_levs = scorpio::get_dimlen_c2f(m_spa_data_file.c_str(),"lev");
   scorpio::eam_pio_closefile(m_spa_data_file);
@@ -161,7 +161,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
 
   // Retrieve the remap and data file locations from the parameter list:
   EKAT_REQUIRE_MSG(m_params.isParameter("spa_remap_file"),"ERROR: spa_remap_file is missing from SPA parameter list.");
-  EKAT_REQUIRE_MSG(m_params.isParameter("SPA Data File"),"ERROR: SPA Data File is missing from SPA parameter list.");
+  EKAT_REQUIRE_MSG(m_params.isParameter("spa_data_file"),"ERROR: spa_data_file is missing from SPA parameter list.");
   m_spa_remap_file = m_params.get<std::string>("spa_remap_file");
 
   // Set the SPA remap weights.  

--- a/components/scream/src/physics/spa/tests/spa_main.yaml
+++ b/components/scream/src/physics/spa/tests/spa_main.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_scream.nc
+spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_scream.nc
 ncols: 866
 nlevs: 72
 nswbands: 14

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -24,8 +24,8 @@ AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
     m_atm_logger = std::make_shared<logger_impl_t>("",LogLevel::trace,m_comm);
   }
 
-  if (m_params.isParameter("Number of Subcycles")) {
-    m_num_subcycles = m_params.get<int>("Number of Subcycles");
+  if (m_params.isParameter("number_of_subcycles")) {
+    m_num_subcycles = m_params.get<int>("number_of_subcycles");
   }
   EKAT_REQUIRE_MSG (m_num_subcycles>0,
       "Error! Invalid number of subcycles in param list " + m_params.name() + ".\n"

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -65,7 +65,7 @@ void AtmosphereProcess::run (const int dt) {
     run_impl(dt_sub);
   }
 
-  if (m_params.get("Enable Postcondition Checks", true)) {
+  if (m_params.get("enable_postcondition_checks", true)) {
     // Run 'post-condition' property checks stored in this AP
     run_postcondition_checks();
   }

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -48,7 +48,7 @@ void AtmosphereProcess::initialize (const TimeStamp& t0, const RunType run_type)
 
 void AtmosphereProcess::run (const int dt) {
   start_timer (m_timer_prefix + this->name() + "::run");
-  if (m_params.get("Enable Precondition Checks", true)) {
+  if (m_params.get("enable_precondition_checks", true)) {
     // Run 'pre-condition' property checks stored in this AP
     run_precondition_checks();
   }

--- a/components/scream/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process_group.cpp
@@ -21,13 +21,13 @@ AtmosphereProcessGroup (const ekat::Comm& comm, const ekat::ParameterList& param
   EKAT_REQUIRE_MSG (m_group_size>0, "Error! Invalid group size.\n");
 
   if (m_group_size>1) {
-    if (m_params.get<std::string>("Schedule Type") == "Sequential") {
+    if (m_params.get<std::string>("schedule_type") == "Sequential") {
       m_group_schedule_type = ScheduleType::Sequential;
-    } else if (m_params.get<std::string>("Schedule Type") == "Parallel") {
+    } else if (m_params.get<std::string>("schedule_type") == "Parallel") {
       m_group_schedule_type = ScheduleType::Parallel;
       ekat::error::runtime_abort("Error! Parallel schedule not yet implemented.\n");
     } else {
-      ekat::error::runtime_abort("Error! Invalid 'Schedule Type'. Available choices are 'Parallel' and 'Sequential'.\n");
+      ekat::error::runtime_abort("Error! Invalid 'schedule_type'. Available choices are 'Parallel' and 'Sequential'.\n");
     }
   } else {
     // Pointless to handle this group as parallel, if only one process is in it

--- a/components/scream/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/scream/src/share/grid/mesh_free_grids_manager.cpp
@@ -38,15 +38,15 @@ build_grids (const std::set<std::string>& grid_names)
         "       Requested grid: " + gn + "\n");
   }
 
-  if (not m_params.isParameter("Reference Grid")) {
+  if (not m_params.isParameter("reference_grid")) {
     // Set a reference grid.
     if (ekat::contains(grid_names,"Point Grid")) {
-      m_params.set<std::string>("Reference Grid","Point Grid");
+      m_params.set<std::string>("reference_grid","Point Grid");
     } else {
-      m_params.set<std::string>("Reference Grid","SE Grid");
+      m_params.set<std::string>("reference_grid","SE Grid");
     }
   }
-  std::string ref_grid = m_params.get<std::string>("Reference Grid");
+  std::string ref_grid = m_params.get<std::string>("reference_grid");
 
   const bool build_pt = ekat::contains(grid_names,"Point Grid") || ref_grid=="Point Grid";
   const bool build_se = ekat::contains(grid_names,"SE Grid") || ref_grid=="SE Grid";

--- a/components/scream/src/share/grid/mesh_free_grids_manager.hpp
+++ b/components/scream/src/share/grid/mesh_free_grids_manager.hpp
@@ -25,7 +25,7 @@ public:
 
   virtual ~MeshFreeGridsManager () = default;
 
-  std::string name () const { return "Mesh-Free Grids Manager"; }
+  std::string name () const { return "Mesh-Free grids_manager"; }
 
   std::set<std::string> supported_grids () const {
     std::set<std::string> gnames;

--- a/components/scream/src/share/grid/mesh_free_grids_manager.hpp
+++ b/components/scream/src/share/grid/mesh_free_grids_manager.hpp
@@ -43,7 +43,7 @@ public:
 protected:
 
   std::string get_reference_grid_name () const {
-    return m_params.get<std::string>("Reference Grid");
+    return m_params.get<std::string>("reference_grid");
   }
 
   remapper_ptr_type

--- a/components/scream/src/share/grid/user_provided_grids_manager.hpp
+++ b/components/scream/src/share/grid/user_provided_grids_manager.hpp
@@ -20,7 +20,7 @@ public:
 
   virtual ~UserProvidedGridsManager () = default;
 
-  std::string name () const { return "User Provided Grids Manager"; }
+  std::string name () const { return "User Provided grids_manager"; }
 
   std::set<std::string> supported_grids () const {
     std::set<std::string> gnames;

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -40,7 +40,7 @@
  *     GRID_NAME_N:
  *        Field Names:            ARRAY OF STRINGS
  *        IO Grid Name:           STRING                (optional)
- *  Output Control:
+ *  output_control:
  *    Frequency:                  INT
  *    Frequency Units:            STRING                (default: Steps)
  *  Checkpoint Control:

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -42,10 +42,10 @@
  *        IO Grid Name:           STRING                (optional)
  *  output_control:
  *    Frequency:                  INT
- *    Frequency Units:            STRING                (default: Steps)
+ *    frequency_units:            STRING                (default: Steps)
  *  Checkpoint Control:
  *    Frequency:                  INT                   (default: 0)
- *    Frequency Units:            STRING                (default: ${Output->Frequency Units})
+ *    frequency_units:            STRING                (default: ${Output->frequency_units})
  *  Restart:
  *    Casename:                   STRING                (default: ${Casename})
  *    Perform Restart:            BOOL                  (default: true)
@@ -57,8 +57,8 @@
  *      average - average of the field over some interval.
  *      min     - minimum value of the field over time interval.
  *      max     - maximum value of the field over time interval.
- *    Here, 'time interval' is described by ${Output Frequency} and ${Output Frequency Units}.
- *    E.g., with 'Output Frequency'=10 and 'Output Frequency Units'="Days", the time interval is 10 days.
+ *    Here, 'time interval' is described by ${Output Frequency} and ${Output frequency_units}.
+ *    E.g., with 'Output Frequency'=10 and 'Output frequency_units'="Days", the time interval is 10 days.
  *  - Fields: parameters specifying fields to output
  *     - GRID_NAME: parameters specifyign fields to output from grid $GRID_NAME
  *        - Field Names: names of fields defined on grid $grid_name that need to be outputed
@@ -66,13 +66,13 @@
  *                        SEGrid fields to PointGrid fields on the fly, to save on output size)
  *  - Max Snapshots Per File: the maximum number of snapshots saved per file. After this many
  *  - Output: parameters for output control
- *    - Frequency: the frequency of output writes (in the units specified by ${Output Frequency Units})
- *    - Frequency Units: the units of output frequency (Steps, Months, Years, Hours, Days,...)
+ *    - Frequency: the frequency of output writes (in the units specified by ${Output frequency_units})
+ *    - frequency_units: the units of output frequency (Steps, Months, Years, Hours, Days,...)
  *      snapshots have been written on a single nc file, the class will close the file, and open a new one
  *  - Checkpointing: parameters for checkpointing control
  *    - Frequency: the frequenct of checkpoints writes. This option is used/matters only if
  *      if Averaging Type is *not* Instant. A value of 0 is interpreted as 'no checkpointing'.
- *    - Frequency Units: the units of restart history output.
+ *    - frequency_units: the units of restart history output.
  *  - Restart: parameters for history restart
  *    - Casename: the history restart filename root.
  *    - Perform Restart: if this is a restarted run, and Averaging Type is not Instant, this flag

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -70,7 +70,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
   m_output_file_specs.num_snapshots_in_file = 0;
   m_output_file_specs.filename_with_time_string = out_control_pl.get("Timestamp in Filename",true);
   m_output_file_specs.filename_with_mpiranks    = out_control_pl.get("MPI Ranks in Filename",false);
-  m_output_file_specs.filename_with_avg_type    = out_control_pl.get("AVG Type in Filename",true);
+  m_output_file_specs.filename_with_avg_type    = out_control_pl.get("avg_type_in_filename",true);
   m_output_file_specs.filename_with_frequency   = out_control_pl.get("Frequency in Filename",true);
 
   // For each grid, create a separate output stream.
@@ -106,7 +106,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
       m_checkpoint_file_specs.num_snapshots_in_file = 0;
       m_checkpoint_file_specs.filename_with_time_string = pl.get("Timestamp in Filename",true);
       m_checkpoint_file_specs.filename_with_mpiranks    = pl.get("MPI Ranks in Filename",false);
-      m_checkpoint_file_specs.filename_with_avg_type    = pl.get("AVG Type in Filename",true);
+      m_checkpoint_file_specs.filename_with_avg_type    = pl.get("avg_type_in_filename",true);
       m_checkpoint_file_specs.filename_with_frequency   = pl.get("Frequency in Filename",true);
     }
   }

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -71,7 +71,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
   m_output_file_specs.filename_with_time_string = out_control_pl.get("Timestamp in Filename",true);
   m_output_file_specs.filename_with_mpiranks    = out_control_pl.get("MPI Ranks in Filename",false);
   m_output_file_specs.filename_with_avg_type    = out_control_pl.get("avg_type_in_filename",true);
-  m_output_file_specs.filename_with_frequency   = out_control_pl.get("Frequency in Filename",true);
+  m_output_file_specs.filename_with_frequency   = out_control_pl.get("frequency_in_filename",true);
 
   // For each grid, create a separate output stream.
   if (field_mgrs.size()==1) {
@@ -107,7 +107,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
       m_checkpoint_file_specs.filename_with_time_string = pl.get("Timestamp in Filename",true);
       m_checkpoint_file_specs.filename_with_mpiranks    = pl.get("MPI Ranks in Filename",false);
       m_checkpoint_file_specs.filename_with_avg_type    = pl.get("avg_type_in_filename",true);
-      m_checkpoint_file_specs.filename_with_frequency   = pl.get("Frequency in Filename",true);
+      m_checkpoint_file_specs.filename_with_frequency   = pl.get("frequency_in_filename",true);
     }
   }
 

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -60,7 +60,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
   set_params(params,field_mgrs);
 
   // Output control
-  auto& out_control_pl = m_params.sublist("Output Control");
+  auto& out_control_pl = m_params.sublist("output_control");
   m_output_control.frequency  = out_control_pl.get<int>("Frequency");
   m_output_control.frequency_units = out_control_pl.get<std::string>("Frequency Units");
   m_output_control.nsteps_since_last_write = 0;

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -62,7 +62,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
   // Output control
   auto& out_control_pl = m_params.sublist("output_control");
   m_output_control.frequency  = out_control_pl.get<int>("Frequency");
-  m_output_control.frequency_units = out_control_pl.get<std::string>("Frequency Units");
+  m_output_control.frequency_units = out_control_pl.get<std::string>("frequency_units");
   m_output_control.nsteps_since_last_write = 0;
 
   // File specs
@@ -98,7 +98,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
       // Output control
       auto& pl = m_params.sublist("Checkpoint Control");
       m_checkpoint_control.frequency  = pl.get<int>("Frequency");
-      m_checkpoint_control.frequency_units = pl.get<std::string>("Frequency Units");
+      m_checkpoint_control.frequency_units = pl.get<std::string>("frequency_units");
       m_checkpoint_control.nsteps_since_last_write = 0;
 
       // File specs

--- a/components/scream/src/share/io/tests/io_test_average.yaml
+++ b/components/scream/src/share/io/tests/io_test_average.yaml
@@ -4,7 +4,7 @@ Casename: io_output_test
 Averaging Type: Average
 Max Snapshots Per File: 1
 Field Names: [field_1, field_2, field_3, field_packed]
-Output Control:
+output_control:
   MPI Ranks in Filename: true
   Frequency: 10
   Frequency Units: Steps

--- a/components/scream/src/share/io/tests/io_test_average.yaml
+++ b/components/scream/src/share/io/tests/io_test_average.yaml
@@ -7,5 +7,5 @@ Field Names: [field_1, field_2, field_3, field_packed]
 output_control:
   MPI Ranks in Filename: true
   Frequency: 10
-  Frequency Units: Steps
+  frequency_units: Steps
 ...

--- a/components/scream/src/share/io/tests/io_test_instant.yaml
+++ b/components/scream/src/share/io/tests/io_test_instant.yaml
@@ -4,7 +4,7 @@ Casename: io_output_test
 Averaging Type: Instant
 Max Snapshots Per File: 1
 Field Names: [field_1, field_2, field_3, field_packed, DummyDiagnostic]
-Output Control:
+output_control:
   MPI Ranks in Filename: true
   Frequency: 10
   Frequency Units: Steps

--- a/components/scream/src/share/io/tests/io_test_instant.yaml
+++ b/components/scream/src/share/io/tests/io_test_instant.yaml
@@ -7,5 +7,5 @@ Field Names: [field_1, field_2, field_3, field_packed, DummyDiagnostic]
 output_control:
   MPI Ranks in Filename: true
   Frequency: 10
-  Frequency Units: Steps
+  frequency_units: Steps
 ...

--- a/components/scream/src/share/io/tests/io_test_max.yaml
+++ b/components/scream/src/share/io/tests/io_test_max.yaml
@@ -4,7 +4,7 @@ Casename: io_output_test
 Averaging Type: Max
 Max Snapshots Per File: 1
 Field Names: [field_1, field_2, field_3, field_packed]
-Output Control:
+output_control:
   MPI Ranks in Filename: true
   Frequency: 10
   Frequency Units: Steps

--- a/components/scream/src/share/io/tests/io_test_max.yaml
+++ b/components/scream/src/share/io/tests/io_test_max.yaml
@@ -7,5 +7,5 @@ Field Names: [field_1, field_2, field_3, field_packed]
 output_control:
   MPI Ranks in Filename: true
   Frequency: 10
-  Frequency Units: Steps
+  frequency_units: Steps
 ...

--- a/components/scream/src/share/io/tests/io_test_min.yaml
+++ b/components/scream/src/share/io/tests/io_test_min.yaml
@@ -7,5 +7,5 @@ Field Names: [field_1, field_2, field_3, field_packed]
 output_control:
   MPI Ranks in Filename: true
   Frequency: 10
-  Frequency Units: Steps
+  frequency_units: Steps
 ...

--- a/components/scream/src/share/io/tests/io_test_min.yaml
+++ b/components/scream/src/share/io/tests/io_test_min.yaml
@@ -4,7 +4,7 @@ Casename: io_output_test
 Averaging Type: Min
 Max Snapshots Per File: 1
 Field Names: [field_1, field_2, field_3, field_packed]
-Output Control:
+output_control:
   MPI Ranks in Filename: true
   Frequency: 10
   Frequency Units: Steps

--- a/components/scream/src/share/io/tests/io_test_multisnap.yaml
+++ b/components/scream/src/share/io/tests/io_test_multisnap.yaml
@@ -7,5 +7,5 @@ Field Names: [field_1, field_2, field_3, field_packed]
 output_control:
   MPI Ranks in Filename: true
   Frequency: 1
-  Frequency Units: Steps
+  frequency_units: Steps
 ...

--- a/components/scream/src/share/io/tests/io_test_multisnap.yaml
+++ b/components/scream/src/share/io/tests/io_test_multisnap.yaml
@@ -4,7 +4,7 @@ Casename: io_multisnap_test
 Averaging Type: Instant
 Max Snapshots Per File: 10
 Field Names: [field_1, field_2, field_3, field_packed]
-Output Control:
+output_control:
   MPI Ranks in Filename: true
   Frequency: 1
   Frequency Units: Steps

--- a/components/scream/src/share/io/tests/io_test_restart.yaml
+++ b/components/scream/src/share/io/tests/io_test_restart.yaml
@@ -7,9 +7,9 @@ Field Names: [field_1, field_2, field_3, field_4]
 output_control:
   MPI Ranks in Filename: true
   Frequency: 10
-  Frequency Units: Steps
+  frequency_units: Steps
 Checkpoint Control:
   MPI Ranks in Filename: true
   Frequency: 5
-  Frequency Units: Steps
+  frequency_units: Steps
 ...

--- a/components/scream/src/share/io/tests/io_test_restart.yaml
+++ b/components/scream/src/share/io/tests/io_test_restart.yaml
@@ -4,7 +4,7 @@ Casename: io_output_restart
 Averaging Type: Average
 Max Snapshots Per File: 1
 Field Names: [field_1, field_2, field_3, field_4]
-Output Control:
+output_control:
   MPI Ranks in Filename: true
   Frequency: 10
   Frequency Units: Steps

--- a/components/scream/src/share/io/tests/io_test_restart_check.yaml
+++ b/components/scream/src/share/io/tests/io_test_restart_check.yaml
@@ -7,7 +7,7 @@ Field Names: [field_1, field_2, field_3, field_4]
 output_control:
   MPI Ranks in Filename: true
   Frequency: 10
-  Frequency Units: Steps
+  frequency_units: Steps
 Restart:
   MPI Ranks in Filename: true
   Casename: io_output_restart

--- a/components/scream/src/share/io/tests/io_test_restart_check.yaml
+++ b/components/scream/src/share/io/tests/io_test_restart_check.yaml
@@ -4,7 +4,7 @@ Casename: io_output_restart_check
 Averaging Type: Average
 Max Snapshots Per File: 1
 Field Names: [field_1, field_2, field_3, field_4]
-Output Control:
+output_control:
   MPI Ranks in Filename: true
   Frequency: 10
   Frequency Units: Steps

--- a/components/scream/src/share/io/tests/io_test_se_grid.yaml
+++ b/components/scream/src/share/io/tests/io_test_se_grid.yaml
@@ -4,7 +4,7 @@ Casename: io_test_se_grid
 Averaging Type: Instant
 Max Snapshots Per File: 1
 Field Names: [field_1, field_2, field_3, field_packed]
-Output Control:
+output_control:
   MPI Ranks in Filename: true
   Frequency: 1
   Frequency Units: Steps

--- a/components/scream/src/share/io/tests/io_test_se_grid.yaml
+++ b/components/scream/src/share/io/tests/io_test_se_grid.yaml
@@ -7,5 +7,5 @@ Field Names: [field_1, field_2, field_3, field_packed]
 output_control:
   MPI Ranks in Filename: true
   Frequency: 1
-  Frequency Units: Steps
+  frequency_units: Steps
 ...

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -25,7 +25,7 @@ ekat::ParameterList create_test_params ()
   // Create a parameter list for inputs
   ekat::ParameterList params ("Atmosphere Processes");
 
-  params.set<std::string>("Schedule Type","Sequential");
+  params.set<std::string>("schedule_type","Sequential");
   params.set<std::string>("atm_procs_list","(Foo,BarBaz)");
 
   auto& p0 = params.sublist("Foo");
@@ -35,7 +35,7 @@ ekat::ParameterList create_test_params ()
   auto& p1 = params.sublist("BarBaz");
   p1.set<std::string>("atm_procs_list","(Bar,Baz)");
   p1.set<std::string>("Type", "Group");
-  p1.set<std::string>("Schedule Type","Sequential");
+  p1.set<std::string>("schedule_type","Sequential");
 
   auto& p1_0 = p1.sublist("Bar");
   p1_0.set<std::string>("Type", "Bar");

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -547,7 +547,7 @@ TEST_CASE("field_checks", "") {
     for (bool check_pre : {true, false}) {
       for (bool check_post : {true, false}) {
 
-        params.set("Enable Precondition Checks",check_pre);
+        params.set("enable_precondition_checks",check_pre);
         params.set("Enable Postcondition Checks",check_post);
 
         // Create the process

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -548,7 +548,7 @@ TEST_CASE("field_checks", "") {
       for (bool check_post : {true, false}) {
 
         params.set("enable_precondition_checks",check_pre);
-        params.set("Enable Postcondition Checks",check_post);
+        params.set("enable_postcondition_checks",check_post);
 
         // Create the process
         auto foo = create_atmosphere_process<Foo>(comm,params);

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -58,7 +58,7 @@ create_gm (const ekat::Comm& comm) {
   const int num_global_cols = num_local_cols*comm.size();
 
   ekat::ParameterList gm_params;
-  gm_params.set<std::string>("Reference Grid", "Point Grid");
+  gm_params.set<std::string>("reference_grid", "Point Grid");
   gm_params.set<int>("Number of Global Columns", num_global_cols);
   gm_params.set<int>("Number of Local Elements", num_local_elems);
   gm_params.set<int>("Number of Vertical Levels", nlevs);

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -593,7 +593,7 @@ TEST_CASE ("subcycling") {
   params.set<std::string>("Grid Name", "Point Grid");
   params_sub.set<std::string>("Process Name", "AddOne");
   params_sub.set<std::string>("Grid Name", "Point Grid");
-  params_sub.set<int>("Number of Subcycles", 5);
+  params_sub.set<int>("number_of_subcycles", 5);
 
   // Create and init two atm procs, one subcycled and one not subcycled
   auto ap     = std::make_shared<AddOne>(comm,params);

--- a/components/scream/src/share/tests/atm_process_tests_named_procs.yaml
+++ b/components/scream/src/share/tests/atm_process_tests_named_procs.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 atm_procs_list: (MyFoo,BarBaz)
-Schedule Type: Sequential
+schedule_type: Sequential
 Type: Group
 
 MyFoo:
@@ -9,7 +9,7 @@ MyFoo:
   Grid Name: Point Grid
 BarBaz:
   Type: Group
-  Schedule Type: Sequential
+  schedule_type: Sequential
   atm_procs_list: (MyBar,MyBaz)
 
   MyBar:

--- a/components/scream/src/share/tests/atm_process_tests_parse_list.yaml
+++ b/components/scream/src/share/tests/atm_process_tests_parse_list.yaml
@@ -1,14 +1,14 @@
 %YAML 1.1
 ---
 atm_procs_list: (MyFoo,(MyBar,MyBaz))
-Schedule Type: Sequential
+schedule_type: Sequential
 Type: Group
 
 MyFoo:
   Type: Foo
   Grid Name: Point Grid
 group.MyBar_MyBaz.:
-  Schedule Type: Sequential
+  schedule_type: Sequential
   atm_procs_list: (MyBar,MyBaz)
 
   MyBar:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -63,7 +63,7 @@ Fields:
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
  
-Output Control:
+output_control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -65,7 +65,7 @@ Fields:
  
 output_control:
   Frequency: ${NUM_STEPS}
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -52,7 +52,7 @@ atmosphere_processes:
 grids_manager:
   Type: Dynamics Driven
   reference_grid: Physics GLL
-  Dynamics Namelist File Name: namelist.nl
+  dynamics_namelist_file_name: namelist.nl
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -24,7 +24,7 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   Schedule Type: Sequential
   homme:
-    Enable Precondition Checks: false
+    enable_precondition_checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -9,7 +9,7 @@ Time Stepping:
   Start Date: [2021, 10, 12]    # Year, Month, Day
   Number of Steps: ${NUM_STEPS}
 
-Initial Conditions:
+initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   surf_evap: 0.0
   surf_sens_flux: 0.0

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -35,7 +35,7 @@ atmosphere_processes:
       atm_procs_list: (shoc,CldFraction,p3)
       Schedule Type: Sequential
       Type: Group
-      Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+      number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:
         Grid: Physics GLL
       CldFraction:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -45,7 +45,7 @@ atmosphere_processes:
         do_prescribed_ccn: false
     rrtmgp:
       Grid: Physics GLL
-      Column Chunk Size: 123
+      column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false
 

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -22,18 +22,18 @@ initial_conditions:
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)
-  Schedule Type: Sequential
+  schedule_type: Sequential
   homme:
     enable_precondition_checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_mic,rrtmgp)
-    Schedule Type: Sequential
+    schedule_type: Sequential
     Type: Group
     mac_mic:
       atm_procs_list: (shoc,CldFraction,p3)
-      Schedule Type: Sequential
+      schedule_type: Sequential
       Type: Group
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -25,7 +25,7 @@ atmosphere_processes:
   schedule_type: Sequential
   homme:
     enable_precondition_checks: false
-    Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_mic,rrtmgp)

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -49,7 +49,7 @@ atmosphere_processes:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false
 
-Grids Manager:
+grids_manager:
   Type: Dynamics Driven
   Reference Grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -51,7 +51,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Dynamics Driven
-  Reference Grid: Physics GLL
+  reference_grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl
 
 # The parameters for I/O control

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -56,5 +56,5 @@ grids_manager:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["homme_shoc_cld_p3_rrtmgp_output.yaml"]
+  output_yaml_files: ["homme_shoc_cld_p3_rrtmgp_output.yaml"]
 ...

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -69,7 +69,7 @@ Fields:
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
  
-Output Control:
+output_control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -71,7 +71,7 @@ Fields:
  
 output_control:
   Frequency: ${NUM_STEPS}
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -18,7 +18,7 @@ initial_conditions:
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)
-  Schedule Type: Sequential
+  schedule_type: Sequential
   homme:
     Process Name: Homme
     enable_precondition_checks: false
@@ -26,12 +26,12 @@ atmosphere_processes:
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
-    Schedule Type: Sequential
+    schedule_type: Sequential
     Type: Group
     mac_aero_mic:
       atm_procs_list: (shoc,CldFraction,spa,p3)
       Type: Group
-      Schedule Type: Sequential
+      schedule_type: Sequential
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:
         Grid: Physics GLL

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -32,7 +32,7 @@ atmosphere_processes:
       atm_procs_list: (shoc,CldFraction,spa,p3)
       Type: Group
       Schedule Type: Sequential
-      Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+      number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:
         Grid: Physics GLL
       CldFraction:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -21,7 +21,7 @@ atmosphere_processes:
   Schedule Type: Sequential
   homme:
     Process Name: Homme
-    Enable Precondition Checks: false
+    enable_precondition_checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -9,7 +9,7 @@ Time Stepping:
   Start Date: [2021, 10, 12]    # Year, Month, Day
   Number of Steps: ${NUM_STEPS}
 
-Initial Conditions:
+initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   surf_evap: 0.0
   surf_sens_flux: 0.0

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -55,5 +55,5 @@ grids_manager:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["homme_shoc_cld_spa_p3_rrtmgp_output.yaml"]
+  output_yaml_files: ["homme_shoc_cld_spa_p3_rrtmgp_output.yaml"]
 ...

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -22,7 +22,7 @@ atmosphere_processes:
   homme:
     Process Name: Homme
     enable_precondition_checks: false
-    Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -50,7 +50,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Dynamics Driven
-  Reference Grid: Physics GLL
+  reference_grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl
 
 # The parameters for I/O control

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -45,7 +45,7 @@ atmosphere_processes:
         Grid: Physics GLL
     rrtmgp:
       Grid: Physics GLL
-      Column Chunk Size: 123
+      column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 grids_manager:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -51,7 +51,7 @@ atmosphere_processes:
 grids_manager:
   Type: Dynamics Driven
   reference_grid: Physics GLL
-  Dynamics Namelist File Name: namelist.nl
+  dynamics_namelist_file_name: namelist.nl
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -48,7 +48,7 @@ atmosphere_processes:
       Column Chunk Size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
-Grids Manager:
+grids_manager:
   Type: Dynamics Driven
   Reference Grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -39,7 +39,7 @@ atmosphere_processes:
         Grid: Physics GLL
       spa:
         Grid: Physics GLL
-        SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
+        spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
         SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
       p3:
         Grid: Physics GLL

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -40,7 +40,7 @@ atmosphere_processes:
       spa:
         Grid: Physics GLL
         spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-        SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
+        spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
       p3:
         Grid: Physics GLL
     rrtmgp:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
@@ -68,7 +68,7 @@ Fields:
  
 output_control:
   Frequency: ${NUM_STEPS}
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
@@ -66,7 +66,7 @@ Fields:
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
  
-Output Control:
+output_control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -55,5 +55,5 @@ grids_manager:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml"]
+  output_yaml_files: ["homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml"]
 ...

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -21,7 +21,7 @@ atmosphere_processes:
   Schedule Type: Sequential
   homme:
     Process Name: Homme
-    Enable Precondition Checks: false
+    enable_precondition_checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -18,7 +18,7 @@ initial_conditions:
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)
-  Schedule Type: Sequential
+  schedule_type: Sequential
   homme:
     Process Name: Homme
     enable_precondition_checks: false
@@ -26,12 +26,12 @@ atmosphere_processes:
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
-    Schedule Type: Sequential
+    schedule_type: Sequential
     Type: Group
     mac_aero_mic:
       atm_procs_list: (shoc,CldFraction,spa,p3)
       Type: Group
-      Schedule Type: Sequential
+      schedule_type: Sequential
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:
         Grid: Physics GLL

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -32,7 +32,7 @@ atmosphere_processes:
       atm_procs_list: (shoc,CldFraction,spa,p3)
       Type: Group
       Schedule Type: Sequential
-      Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+      number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:
         Grid: Physics GLL
       CldFraction:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -22,7 +22,7 @@ atmosphere_processes:
   homme:
     Process Name: Homme
     enable_precondition_checks: false
-    Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
+    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -9,7 +9,7 @@ Time Stepping:
   Start Date: [2021, 10, 12]    # Year, Month, Day
   Number of Steps: ${NUM_STEPS}
 
-Initial Conditions:
+initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
   surf_evap: 0.0
   surf_sens_flux: 0.0

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -50,7 +50,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Dynamics Driven
-  Reference Grid: Physics GLL
+  reference_grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl
 
 # The parameters for I/O control

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -45,7 +45,7 @@ atmosphere_processes:
         Grid: Physics GLL
     rrtmgp:
       Grid: Physics GLL
-      Column Chunk Size: 123
+      column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
 grids_manager:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -51,7 +51,7 @@ atmosphere_processes:
 grids_manager:
   Type: Dynamics Driven
   reference_grid: Physics GLL
-  Dynamics Namelist File Name: namelist.nl
+  dynamics_namelist_file_name: namelist.nl
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -48,7 +48,7 @@ atmosphere_processes:
       Column Chunk Size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
 
-Grids Manager:
+grids_manager:
   Type: Dynamics Driven
   Reference Grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -39,7 +39,7 @@ atmosphere_processes:
         Grid: Physics GLL
       spa:
         Grid: Physics GLL
-        SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
+        spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
         SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
       p3:
         Grid: Physics GLL

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -40,7 +40,7 @@ atmosphere_processes:
       spa:
         Grid: Physics GLL
         spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-        SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
+        spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
       p3:
         Grid: Physics GLL
     rrtmgp:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -59,5 +59,5 @@ grids_manager:
 
 # List all the yaml files with the output parameters
 Scorpio:
-  Output YAML Files: ["model_output.yaml"]
+  output_yaml_files: ["model_output.yaml"]
 ...

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -25,7 +25,7 @@ initial_conditions:
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)
-  Schedule Type: Sequential
+  schedule_type: Sequential
   homme:
     Process Name: Homme
     enable_precondition_checks: false
@@ -34,11 +34,11 @@ atmosphere_processes:
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
     Type: Group
-    Schedule Type: Sequential
+    schedule_type: Sequential
     mac_aero_mic:
       atm_procs_list: (shoc,CldFraction,p3)
       Type: Group
-      Schedule Type: Sequential
+      schedule_type: Sequential
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:
         Grid: Physics GLL

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -29,7 +29,7 @@ atmosphere_processes:
   homme:
     Process Name: Homme
     enable_precondition_checks: false
-    Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -54,7 +54,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Dynamics Driven
-  Reference Grid: Physics GLL
+  reference_grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl
 
 # List all the yaml files with the output parameters

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -11,7 +11,7 @@ Time Stepping:
   Case Start Time: [12, 00, 00]      # Hours, Minutes, Seconds
   Case Start Date: [2021, 10, 12]    # Year, Month, Day
 
-Initial Conditions:
+initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   Restart Run: false
   surf_evap: 0.0

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -52,7 +52,7 @@ atmosphere_processes:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false
 
-Grids Manager:
+grids_manager:
   Type: Dynamics Driven
   Reference Grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -55,7 +55,7 @@ atmosphere_processes:
 grids_manager:
   Type: Dynamics Driven
   reference_grid: Physics GLL
-  Dynamics Namelist File Name: namelist.nl
+  dynamics_namelist_file_name: namelist.nl
 
 # List all the yaml files with the output parameters
 Scorpio:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: 300

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -39,7 +39,7 @@ atmosphere_processes:
       atm_procs_list: (shoc,CldFraction,p3)
       Type: Group
       Schedule Type: Sequential
-      Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+      number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:
         Grid: Physics GLL
       CldFraction:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -28,7 +28,7 @@ atmosphere_processes:
   Schedule Type: Sequential
   homme:
     Process Name: Homme
-    Enable Precondition Checks: false
+    enable_precondition_checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -25,7 +25,7 @@ initial_conditions:
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)
-  Schedule Type: Sequential
+  schedule_type: Sequential
   homme:
     Process Name: Homme
     enable_precondition_checks: false
@@ -34,11 +34,11 @@ atmosphere_processes:
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
     Type: Group
-    Schedule Type: Sequential
+    schedule_type: Sequential
     mac_aero_mic:
       atm_procs_list: (shoc,CldFraction,p3)
       Type: Group
-      Schedule Type: Sequential
+      schedule_type: Sequential
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:
         Grid: Physics GLL

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -29,7 +29,7 @@ atmosphere_processes:
   homme:
     Process Name: Homme
     enable_precondition_checks: false
-    Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -54,7 +54,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Dynamics Driven
-  Reference Grid: Physics GLL
+  reference_grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl
 
 # List all the yaml files with the output parameters

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -59,7 +59,7 @@ grids_manager:
 
 # List all the yaml files with the output parameters
 Scorpio:
-  Model Restart:
+  model_restart:
     Casename: model_restart
     Output Control:
       Frequency:       1

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -63,6 +63,6 @@ Scorpio:
     Casename: model_restart
     output_control:
       Frequency:       1
-      Frequency Units: Steps
+      frequency_units: Steps
   output_yaml_files: ["model_restart_output.yaml"]
 ...

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -11,7 +11,7 @@ Time Stepping:
   Case Start Time: [12, 00, 00]      # Hours, Minutes, Seconds
   Case Start Date: [2021, 10, 12]    # Year, Month, Day
 
-Initial Conditions:
+initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   Restart Run: false
   surf_evap: 0.0

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -64,5 +64,5 @@ Scorpio:
     Output Control:
       Frequency:       1
       Frequency Units: Steps
-  Output YAML Files: ["model_restart_output.yaml"]
+  output_yaml_files: ["model_restart_output.yaml"]
 ...

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -52,7 +52,7 @@ atmosphere_processes:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false
 
-Grids Manager:
+grids_manager:
   Type: Dynamics Driven
   Reference Grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -55,7 +55,7 @@ atmosphere_processes:
 grids_manager:
   Type: Dynamics Driven
   reference_grid: Physics GLL
-  Dynamics Namelist File Name: namelist.nl
+  dynamics_namelist_file_name: namelist.nl
 
 # List all the yaml files with the output parameters
 Scorpio:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: 300

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -39,7 +39,7 @@ atmosphere_processes:
       atm_procs_list: (shoc,CldFraction,p3)
       Type: Group
       Schedule Type: Sequential
-      Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+      number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:
         Grid: Physics GLL
       CldFraction:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -61,7 +61,7 @@ grids_manager:
 Scorpio:
   model_restart:
     Casename: model_restart
-    Output Control:
+    output_control:
       Frequency:       1
       Frequency Units: Steps
   output_yaml_files: ["model_restart_output.yaml"]

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -28,7 +28,7 @@ atmosphere_processes:
   Schedule Type: Sequential
   homme:
     Process Name: Homme
-    Enable Precondition Checks: false
+    enable_precondition_checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -20,7 +20,7 @@ atmosphere_processes:
   Schedule Type: Sequential
   homme:
     Process Name: Homme
-    Enable Precondition Checks: false
+    enable_precondition_checks: false
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -31,7 +31,7 @@ atmosphere_processes:
       atm_procs_list: (shoc,CldFraction,p3)
       Type: Group
       Schedule Type: Sequential
-      Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+      number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:
         Grid: Physics GLL
       CldFraction:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -12,7 +12,7 @@ Time Stepping:
   Case Start Time: [12, 00, 00]      # Hours, Minutes, Seconds
   Case Start Date: [2021, 10, 12]    # Year, Month, Day
 
-Initial Conditions:
+initial_conditions:
   Restart Casename: model_restart
 
 atmosphere_processes:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -47,7 +47,7 @@ atmosphere_processes:
 grids_manager:
   Type: Dynamics Driven
   reference_grid: Physics GLL
-  Dynamics Namelist File Name: namelist.nl
+  dynamics_namelist_file_name: namelist.nl
 
 # List all the yaml files with the output parameters
 Scorpio:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -17,7 +17,7 @@ initial_conditions:
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)
-  Schedule Type: Sequential
+  schedule_type: Sequential
   homme:
     Process Name: Homme
     enable_precondition_checks: false
@@ -26,11 +26,11 @@ atmosphere_processes:
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
     Type: Group
-    Schedule Type: Sequential
+    schedule_type: Sequential
     mac_aero_mic:
       atm_procs_list: (shoc,CldFraction,p3)
       Type: Group
-      Schedule Type: Sequential
+      schedule_type: Sequential
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       shoc:
         Grid: Physics GLL

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -51,5 +51,5 @@ grids_manager:
 
 # List all the yaml files with the output parameters
 Scorpio:
-  Output YAML Files: ["model_restart_output.yaml"]
+  output_yaml_files: ["model_restart_output.yaml"]
 ...

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -13,7 +13,7 @@ Time Stepping:
   Case Start Date: [2021, 10, 12]    # Year, Month, Day
 
 initial_conditions:
-  Restart Casename: model_restart
+  restart_casename: model_restart
 
 atmosphere_processes:
   atm_procs_list: (homme,physics)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -21,7 +21,7 @@ atmosphere_processes:
   homme:
     Process Name: Homme
     enable_precondition_checks: false
-    Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -46,7 +46,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Dynamics Driven
-  Reference Grid: Physics GLL
+  reference_grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl
 
 # List all the yaml files with the output parameters

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -44,7 +44,7 @@ atmosphere_processes:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false
 
-Grids Manager:
+grids_manager:
   Type: Dynamics Driven
   Reference Grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   # IMPORTANT: make sure Start Time equals to the initial run start time PLUS one time step

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/model_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/model_output.yaml
@@ -68,7 +68,7 @@ Fields:
       - v_dyn
       - vtheta_dp_dyn
       - dp3d_dyn
-Output Control:
+output_control:
   MPI Ranks in Filename: true
   Frequency: 2
   Frequency Units: Steps

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/model_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/model_output.yaml
@@ -71,5 +71,5 @@ Fields:
 output_control:
   MPI Ranks in Filename: true
   Frequency: 2
-  Frequency Units: Steps
+  frequency_units: Steps
 ...

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
@@ -68,7 +68,7 @@ Fields:
       - v_dyn
       - vtheta_dp_dyn
       - dp3d_dyn
-Output Control:
+output_control:
   MPI Ranks in Filename: true
   Frequency: 2
   Frequency Units: Steps

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
@@ -71,9 +71,9 @@ Fields:
 output_control:
   MPI Ranks in Filename: true
   Frequency: 2
-  Frequency Units: Steps
+  frequency_units: Steps
 Checkpoint Control:
   MPI Ranks in Filename: true
   Frequency: 1
-  Frequency Units: Steps
+  frequency_units: Steps
 ...

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -23,7 +23,7 @@ grids_manager:
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.
 
-Initial Conditions:
+initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   surf_evap: 0.0

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -10,7 +10,7 @@ Time Stepping:
   Number of Steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  Schedule Type: Sequential
+  schedule_type: Sequential
   atm_procs_list: (shoc,p3)
   number_of_subcycles: ${NUM_SUBCYCLES}
   shoc:

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -18,7 +18,7 @@ atmosphere_processes:
   p3:
     Grid: Point Grid
 
-Grids Manager:
+grids_manager:
   Type: Mesh Free
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 atmosphere_processes:
   Schedule Type: Sequential
   atm_procs_list: (shoc,p3)
-  Number of Subcycles: ${NUM_SUBCYCLES}
+  number_of_subcycles: ${NUM_SUBCYCLES}
   shoc:
     Grid: Point Grid
   p3:

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -36,5 +36,5 @@ initial_conditions:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: [output_${POSTFIX}.yaml]
+  output_yaml_files: [output_${POSTFIX}.yaml]
 ...

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
@@ -35,7 +35,7 @@ Field Names:
  
 output_control:
   Frequency: ${NUM_STEPS}
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: false
 ...

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
@@ -33,7 +33,7 @@ Field Names:
   - eff_radius_qc
   - eff_radius_qi
  
-Output Control:
+output_control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -11,11 +11,11 @@ Time Stepping:
 
 atmosphere_processes:
   atm_procs_list: (mac_mic,rrtmgp)
-  Schedule Type: Sequential
+  schedule_type: Sequential
   mac_mic:
     atm_procs_list: (shoc,CldFraction,p3)
     Type: Group
-    Schedule Type: Sequential
+    schedule_type: Sequential
     number_of_subcycles: ${MAC_MIC_SUBCYCLES}
     shoc:
       Grid: Point Grid

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -36,7 +36,7 @@ grids_manager:
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.
 
-Initial Conditions:
+initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   surf_sens_flux: 0.0

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -28,7 +28,7 @@ atmosphere_processes:
     Grid: Point Grid
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
-    Orbital Year: 1990
+    orbital_year: 1990
     do_aerosol_rad: false
 
 grids_manager:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -53,5 +53,5 @@ initial_conditions:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["shoc_cld_p3_rrtmgp_output.yaml"]
+  output_yaml_files: ["shoc_cld_p3_rrtmgp_output.yaml"]
 ...

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -26,7 +26,7 @@ atmosphere_processes:
       do_prescribed_ccn: false
   rrtmgp:
     Grid: Point Grid
-    Column Chunk Size: 123
+    column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
     do_aerosol_rad: false

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -16,7 +16,7 @@ atmosphere_processes:
     atm_procs_list: (shoc,CldFraction,p3)
     Type: Group
     Schedule Type: Sequential
-    Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+    number_of_subcycles: ${MAC_MIC_SUBCYCLES}
     shoc:
       Grid: Point Grid
     CldFraction:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -31,7 +31,7 @@ atmosphere_processes:
     Orbital Year: 1990
     do_aerosol_rad: false
 
-Grids Manager:
+grids_manager:
   Type: Mesh Free
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
@@ -52,7 +52,7 @@ Field Names:
   - sfc_flux_sw_net
 output_control:
   Frequency: ${NUM_STEPS}
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
@@ -50,7 +50,7 @@ Field Names:
   - rad_heating_pdel
   - sfc_flux_lw_dn
   - sfc_flux_sw_net
-Output Control:
+output_control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -38,7 +38,7 @@ grids_manager:
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.
 
-Initial Conditions:
+initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   surf_evap: 0.0

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -26,7 +26,7 @@ atmosphere_processes:
     spa:
       Grid: Point Grid
       spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-      SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
+      spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
   rrtmgp:
     Grid: Point Grid
     Column Chunk Size: 123

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -31,7 +31,7 @@ atmosphere_processes:
     Grid: Point Grid
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
-    Orbital Year: 1990
+    orbital_year: 1990
 
 grids_manager:
   Type: Mesh Free

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -29,7 +29,7 @@ atmosphere_processes:
       spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
   rrtmgp:
     Grid: Point Grid
-    Column Chunk Size: 123
+    column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
 

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -51,5 +51,5 @@ initial_conditions:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["shoc_cld_spa_p3_rrtmgp_output.yaml"]
+  output_yaml_files: ["shoc_cld_spa_p3_rrtmgp_output.yaml"]
 ...

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -33,7 +33,7 @@ atmosphere_processes:
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
 
-Grids Manager:
+grids_manager:
   Type: Mesh Free
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -11,11 +11,11 @@ Time Stepping:
 
 atmosphere_processes:
   atm_procs_list: (mac_mic,rrtmgp)
-  Schedule Type: Sequential
+  schedule_type: Sequential
   mac_mic:
     atm_procs_list: (shoc,CldFraction,spa,p3)
     Type: Group
-    Schedule Type: Sequential
+    schedule_type: Sequential
     number_of_subcycles: ${MAC_MIC_SUBCYCLES}
     shoc:
       Grid: Point Grid

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -16,7 +16,7 @@ atmosphere_processes:
     atm_procs_list: (shoc,CldFraction,spa,p3)
     Type: Group
     Schedule Type: Sequential
-    Number of Subcycles: ${MAC_MIC_SUBCYCLES}
+    number_of_subcycles: ${MAC_MIC_SUBCYCLES}
     shoc:
       Grid: Point Grid
     CldFraction:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -25,7 +25,7 @@ atmosphere_processes:
       Grid: Point Grid
     spa:
       Grid: Point Grid
-      SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
+      spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
       SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
   rrtmgp:
     Grid: Point Grid

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -59,7 +59,7 @@ Field Names:
  
 output_control:
   Frequency: ${NUM_STEPS}
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -57,7 +57,7 @@ Field Names:
   - sfc_flux_lw_dn
   - sfc_flux_sw_net
  
-Output Control:
+output_control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/coupled/surface_coupling_only/input.yaml
+++ b/components/scream/tests/coupled/surface_coupling_only/input.yaml
@@ -15,7 +15,7 @@ atmosphere_processes:
   SurfaceCouplingExporter:
     Grid: Point Grid
 
-Grids Manager:
+grids_manager:
   Type: Mesh Free
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.

--- a/components/scream/tests/coupled/surface_coupling_only/input.yaml
+++ b/components/scream/tests/coupled/surface_coupling_only/input.yaml
@@ -9,7 +9,7 @@ Time Stepping:
 
 atmosphere_processes:
   atm_procs_list: (SurfaceCouplingImporter,SurfaceCouplingExporter)
-  Schedule Type: Sequential
+  schedule_type: Sequential
   SurfaceCouplingImporter:
     Grid: Point Grid
   SurfaceCouplingExporter:

--- a/components/scream/tests/coupled/surface_coupling_only/input.yaml
+++ b/components/scream/tests/coupled/surface_coupling_only/input.yaml
@@ -37,5 +37,5 @@ initial_conditions:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["surface_coupling_output.yaml"]
+  output_yaml_files: ["surface_coupling_output.yaml"]
 ...

--- a/components/scream/tests/coupled/surface_coupling_only/input.yaml
+++ b/components/scream/tests/coupled/surface_coupling_only/input.yaml
@@ -20,7 +20,7 @@ grids_manager:
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.
 
-Initial Conditions:
+initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   # Some fields needed for the exports (not in ic file)

--- a/components/scream/tests/coupled/surface_coupling_only/input.yaml
+++ b/components/scream/tests/coupled/surface_coupling_only/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Start Time: [12, 30, 00]      # Hours, Minutes, Seconds

--- a/components/scream/tests/coupled/surface_coupling_only/surface_coupling_output.yaml
+++ b/components/scream/tests/coupled/surface_coupling_only/surface_coupling_output.yaml
@@ -16,7 +16,7 @@ Field Names:
   # EXPORTER
   - precip_liq_surf_mass
   - precip_ice_surf_mass
-Output Control:
+output_control:
   Frequency: 1
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/coupled/surface_coupling_only/surface_coupling_output.yaml
+++ b/components/scream/tests/coupled/surface_coupling_only/surface_coupling_output.yaml
@@ -18,7 +18,7 @@ Field Names:
   - precip_ice_surf_mass
 output_control:
   Frequency: 1
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...

--- a/components/scream/tests/uncoupled/cld_fraction/input.yaml
+++ b/components/scream/tests/uncoupled/cld_fraction/input.yaml
@@ -14,7 +14,7 @@ atmosphere_processes:
   CldFraction:
     Grid: Point Grid
 
-Grids Manager:
+grids_manager:
   Type: Mesh Free
   Reference Grid: Point Grid
   Number of Global Columns:   3

--- a/components/scream/tests/uncoupled/cld_fraction/input.yaml
+++ b/components/scream/tests/uncoupled/cld_fraction/input.yaml
@@ -16,7 +16,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  Reference Grid: Point Grid
+  reference_grid: Point Grid
   Number of Global Columns:   3
   Number of Vertical Levels:  128
 

--- a/components/scream/tests/uncoupled/cld_fraction/input.yaml
+++ b/components/scream/tests/uncoupled/cld_fraction/input.yaml
@@ -20,7 +20,7 @@ grids_manager:
   Number of Global Columns:   3
   Number of Vertical Levels:  128
 
-Initial Conditions:
+initial_conditions:
   cldfrac_liq: 0.0
   qi: 0.0
 ...

--- a/components/scream/tests/uncoupled/cld_fraction/input.yaml
+++ b/components/scream/tests/uncoupled/cld_fraction/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/uncoupled/homme/homme_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/homme/homme_standalone_output.yaml
@@ -17,7 +17,7 @@ Fields:
       - p_dry_int
       - p_dry_mid
  
-Output Control:
+output_control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/uncoupled/homme/homme_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/homme/homme_standalone_output.yaml
@@ -19,7 +19,7 @@ Fields:
  
 output_control:
   Frequency: ${NUM_STEPS}
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -22,7 +22,7 @@ atmosphere_processes:
 grids_manager:
   Type: Dynamics Driven
   reference_grid: Physics GLL
-  Dynamics Namelist File Name: namelist.nl
+  dynamics_namelist_file_name: namelist.nl
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -21,7 +21,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Dynamics Driven
-  Reference Grid: Physics GLL
+  reference_grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl
 
 # The parameters for I/O control

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -26,5 +26,5 @@ grids_manager:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["homme_standalone_output.yaml"]
+  output_yaml_files: ["homme_standalone_output.yaml"]
 ...

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -9,7 +9,7 @@ Time Stepping:
   Start Date: [2021, 10, 12]    # Year, Month, Day
   Number of Steps: ${NUM_STEPS}
 
-Initial Conditions:
+initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 atmosphere_processes:

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -19,7 +19,7 @@ atmosphere_processes:
     Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
 
-Grids Manager:
+grids_manager:
   Type: Dynamics Driven
   Reference Grid: Physics GLL
   Dynamics Namelist File Name: namelist.nl

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -16,7 +16,7 @@ atmosphere_processes:
   atm_procs_list: (Dynamics)
   Dynamics:
     Type: Homme
-    Vertical Coordinate Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
 
 grids_manager:

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/uncoupled/p3/input.yaml
+++ b/components/scream/tests/uncoupled/p3/input.yaml
@@ -21,7 +21,7 @@ grids_manager:
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.
 
-Initial Conditions:
+initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   precip_liq_surf_mass: 0.0

--- a/components/scream/tests/uncoupled/p3/input.yaml
+++ b/components/scream/tests/uncoupled/p3/input.yaml
@@ -15,7 +15,7 @@ atmosphere_processes:
     Grid: Point Grid
     do_prescribed_ccn: false
 
-Grids Manager:
+grids_manager:
   Type: Mesh Free
   Reference Grid: Point Grid
   Number of Global Columns:   218

--- a/components/scream/tests/uncoupled/p3/input.yaml
+++ b/components/scream/tests/uncoupled/p3/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/uncoupled/p3/input.yaml
+++ b/components/scream/tests/uncoupled/p3/input.yaml
@@ -17,7 +17,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  Reference Grid: Point Grid
+  reference_grid: Point Grid
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.
 

--- a/components/scream/tests/uncoupled/p3/input.yaml
+++ b/components/scream/tests/uncoupled/p3/input.yaml
@@ -29,5 +29,5 @@ initial_conditions:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["p3_standalone_output.yaml"]
+  output_yaml_files: ["p3_standalone_output.yaml"]
 ...

--- a/components/scream/tests/uncoupled/p3/p3_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/p3/p3_standalone_output.yaml
@@ -23,7 +23,7 @@ Field Names:
   - micro_liq_ice_exchange
   - micro_vap_liq_exchange
   - micro_vap_ice_exchange
-Output Control:
+output_control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/uncoupled/p3/p3_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/p3/p3_standalone_output.yaml
@@ -25,7 +25,7 @@ Field Names:
   - micro_vap_ice_exchange
 output_control:
   Frequency: ${NUM_STEPS}
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -40,5 +40,5 @@ initial_conditions:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["rrtmgp_standalone_output${SUFFIX}.yaml"]
+  output_yaml_files: ["rrtmgp_standalone_output${SUFFIX}.yaml"]
 ...

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -17,7 +17,7 @@ atmosphere_processes:
     Grid: Point Grid
     column_chunk_size: ${COL_CHUNK_SIZE}
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
-    Orbital Year: 1990
+    orbital_year: 1990
     Can Initialize All Inputs: true
     rad_frequency: 3
     do_aerosol_rad: false

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -15,7 +15,7 @@ atmosphere_processes:
   atm_procs_list: (rrtmgp)
   rrtmgp:
     Grid: Point Grid
-    Column Chunk Size: ${COL_CHUNK_SIZE}
+    column_chunk_size: ${COL_CHUNK_SIZE}
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
     Can Initialize All Inputs: true

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -29,7 +29,7 @@ grids_manager:
   Number of Vertical Levels: 72
 
 # Specifications for setting initial conditions
-Initial Conditions:
+initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   aero_g_sw: 0.0
   aero_ssa_sw: 0.0

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -2,7 +2,7 @@
 ---
 # This input file is for a free-standing rrtmgp test that runs using initial conditions read from a SCREAMv0 run
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
   Atm Log Level: debug
 
 Time Stepping:

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -3,7 +3,7 @@
 # This input file is for a free-standing rrtmgp test that runs using initial conditions read from a SCREAMv0 run
 Debug:
   atmosphere_dag_verbosity_level: 5
-  Atm Log Level: debug
+  atm_log_level: debug
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -24,7 +24,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  Reference Grid: Point Grid
+  reference_grid: Point Grid
   Number of Global Columns: 218
   Number of Vertical Levels: 72
 

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -22,7 +22,7 @@ atmosphere_processes:
     rad_frequency: 3
     do_aerosol_rad: false
 
-Grids Manager:
+grids_manager:
   Type: Mesh Free
   Reference Grid: Point Grid
   Number of Global Columns: 218

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -13,7 +13,7 @@ atmosphere_processes:
     # Set orbital parameters to constants for consistency with RRTMGP test problem
     orbital_eccentricity: 0
     orbital_obliquity: 0
-    Orbital MVELP: 0
+    orbital_mvelp: 0
     Fixed Solar Zenith Angle: 0.86
     do_aerosol_rad: false
 

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -17,7 +17,7 @@ atmosphere_processes:
     Fixed Solar Zenith Angle: 0.86
     do_aerosol_rad: false
 
-Grids Manager:
+grids_manager:
   Type: Mesh Free
   Reference Grid: Point Grid
   Number of Global Columns: 128

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 atmosphere_processes:
   atm_procs_list: (rrtmgp)

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -11,7 +11,7 @@ atmosphere_processes:
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     orbital_year: 1990
     # Set orbital parameters to constants for consistency with RRTMGP test problem
-    Orbital Eccentricity: 0
+    orbital_eccentricity: 0
     Orbital Obliquity: 0
     Orbital MVELP: 0
     Fixed Solar Zenith Angle: 0.86

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -12,7 +12,7 @@ atmosphere_processes:
     orbital_year: 1990
     # Set orbital parameters to constants for consistency with RRTMGP test problem
     orbital_eccentricity: 0
-    Orbital Obliquity: 0
+    orbital_obliquity: 0
     Orbital MVELP: 0
     Fixed Solar Zenith Angle: 0.86
     do_aerosol_rad: false

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -7,7 +7,7 @@ atmosphere_processes:
   atm_procs_list: (rrtmgp)
   rrtmgp:
     Grid: Point Grid
-    Max Column Chunk Size: 123
+    Max column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     Orbital Year: 1990
     # Set orbital parameters to constants for consistency with RRTMGP test problem

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -19,7 +19,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  Reference Grid: Point Grid
+  reference_grid: Point Grid
   Number of Global Columns: 128
   Number of Vertical Levels: 42
 

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -24,7 +24,7 @@ grids_manager:
   Number of Vertical Levels: 42
 
 # Specifications for setting initial conditions
-Initial Conditions:
+initial_conditions:
   p_mid: 0.0
   p_int: 0.0
   pseudo_density: 0.0

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -9,7 +9,7 @@ atmosphere_processes:
     Grid: Point Grid
     Max column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
-    Orbital Year: 1990
+    orbital_year: 1990
     # Set orbital parameters to constants for consistency with RRTMGP test problem
     Orbital Eccentricity: 0
     Orbital Obliquity: 0

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
@@ -18,7 +18,7 @@ Field Names:
   - sfc_flux_sw_net
   - rad_heating_pdel
  
-Output Control:
+output_control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_output.yaml
@@ -20,7 +20,7 @@ Field Names:
  
 output_control:
   Frequency: ${NUM_STEPS}
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -21,7 +21,7 @@ grids_manager:
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.
 
-Initial Conditions:
+initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   surf_sens_flux: 0.0

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 atmosphere_processes:
   atm_procs_list: (shoc)
   shoc:
-    Number of Subcycles: ${NUM_SUBCYCLES}
+    number_of_subcycles: ${NUM_SUBCYCLES}
     Grid: Point Grid
 
 grids_manager:

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -15,7 +15,7 @@ atmosphere_processes:
     Number of Subcycles: ${NUM_SUBCYCLES}
     Grid: Point Grid
 
-Grids Manager:
+grids_manager:
   Type: Mesh Free
   Reference Grid: Point Grid
   Number of Global Columns:   218

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -17,7 +17,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  Reference Grid: Point Grid
+  reference_grid: Point Grid
   Number of Global Columns:   218
   Number of Vertical Levels:  72  # Will want to change to 128 when a valid unit test is available.
 

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -31,5 +31,5 @@ initial_conditions:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["shoc_standalone_output.yaml"]
+  output_yaml_files: ["shoc_standalone_output.yaml"]
 ...

--- a/components/scream/tests/uncoupled/shoc/shoc_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/shoc/shoc_standalone_output.yaml
@@ -14,7 +14,7 @@ Fields:
   - tke
   - inv_qc_relvar
   - pbl_height
-Output Control:
+output_control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/uncoupled/shoc/shoc_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/shoc/shoc_standalone_output.yaml
@@ -16,7 +16,7 @@ Fields:
   - pbl_height
 output_control:
   Frequency: ${NUM_STEPS}
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -28,5 +28,5 @@ initial_conditions:
 
 # The parameters for I/O control
 Scorpio:
-  Output YAML Files: ["spa_standalone_output.yaml"]
+  output_yaml_files: ["spa_standalone_output.yaml"]
 ...

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -14,7 +14,7 @@ atmosphere_processes:
   spa:
     Grid: Point Grid
     spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
-    SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
+    spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
 
 grids_manager:
   Type: Mesh Free

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -16,7 +16,7 @@ atmosphere_processes:
     SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
     SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
 
-Grids Manager:
+grids_manager:
   Type: Mesh Free
   Reference Grid: Point Grid
   Number of Global Columns:   218

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -22,7 +22,7 @@ grids_manager:
   Number of Global Columns:   218
   Number of Vertical Levels:  72
 
-Initial Conditions:
+initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -18,7 +18,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  Reference Grid: Point Grid
+  reference_grid: Point Grid
   Number of Global Columns:   218
   Number of Vertical Levels:  72
 

--- a/components/scream/tests/uncoupled/spa/input.yaml
+++ b/components/scream/tests/uncoupled/spa/input.yaml
@@ -13,7 +13,7 @@ atmosphere_processes:
   atm_procs_list: (spa)
   spa:
     Grid: Point Grid
-    SPA Remap File: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
+    spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
     SPA Data File: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
 
 grids_manager:

--- a/components/scream/tests/uncoupled/spa/spa_stand_alone.cpp
+++ b/components/scream/tests/uncoupled/spa/spa_stand_alone.cpp
@@ -45,7 +45,7 @@ TEST_CASE("spa-stand-alone", "") {
   gm_factory.register_product("Mesh Free",&create_mesh_free_grids_manager);
 
   // Create the grids manager
-  auto& gm_params = ad_params.sublist("Grids Manager");
+  auto& gm_params = ad_params.sublist("grids_manager");
   const std::string& gm_type = gm_params.get<std::string>("Type");
   auto gm = GridsManagerFactory::instance().create(gm_type,atm_comm,gm_params);
 

--- a/components/scream/tests/uncoupled/spa/spa_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/spa/spa_standalone_output.yaml
@@ -11,7 +11,7 @@ Field Names:
   - nccn
 output_control:
   Frequency: ${NUM_STEPS}
-  Frequency Units: Steps
+  frequency_units: Steps
   Timestamp in Filename: false
   MPI Ranks in Filename: true
 ...

--- a/components/scream/tests/uncoupled/spa/spa_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/spa/spa_standalone_output.yaml
@@ -9,7 +9,7 @@ Field Names:
   - aero_tau_lw
   - aero_tau_sw
   - nccn
-Output Control:
+output_control:
   Frequency: ${NUM_STEPS}
   Frequency Units: Steps
   Timestamp in Filename: false

--- a/components/scream/tests/uncoupled/zm/input.yaml
+++ b/components/scream/tests/uncoupled/zm/input.yaml
@@ -16,7 +16,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  Reference Grid: Point Grid
+  reference_grid: Point Grid
   Number of Global Columns:   32
   Number of Vertical Levels: 128
 ...

--- a/components/scream/tests/uncoupled/zm/input.yaml
+++ b/components/scream/tests/uncoupled/zm/input.yaml
@@ -14,7 +14,7 @@ atmosphere_processes:
   zm:
     Grid: Point Grid
 
-Grids Manager:
+grids_manager:
   Type: Mesh Free
   Reference Grid: Point Grid
   Number of Global Columns:   32

--- a/components/scream/tests/uncoupled/zm/input.yaml
+++ b/components/scream/tests/uncoupled/zm/input.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 Debug:
-  Atmosphere DAG Verbosity Level: 5
+  atmosphere_dag_verbosity_level: 5
 
 Time Stepping:
   Time Step: ${ATM_TIME_STEP}


### PR DESCRIPTION
No more whitespaces or double underscores. All impacted items were also converted into lowercase.

I included the script I used since it could be useful in the future if we decide to systematically rename things again.