### PR TITLE
EAMxx: better formatting for atmquery output

### DIFF
--- a/components/scream/scripts/atmquery
+++ b/components/scream/scripts/atmquery
@@ -16,7 +16,7 @@ from eamxx_buildnml_impl import check_value
 from atm_manip import expect, get_xml_node, AmbiguousName
 
 ###############################################################################
-def print_var(xml_root,var,full,dtype,value,valid_values):
+def print_var(xml_root,var,full,dtype,value,valid_values,indent="",print_style="invalid"):
 ###############################################################################
     """
     >>> xml = '''
@@ -47,14 +47,18 @@ def print_var(xml_root,var,full,dtype,value,valid_values):
         prop2: ['1', '2']
     """
 
-    # Get node
-    node = get_xml_node(xml_root,var)
+    expect (print_style in ["short","full"],
+            f"Invalid print_style '{print_style}' for print_var. Use 'full', 'compact', or 'short'.")
+
+    # Get node, along with all its parents (which might be used for 'full' print style)
+    nodes = get_xml_node(xml_root,var)
+    node = nodes[-1]
 
     # Get the shortest unique repr of the var name
     tokens = var.split("::")
     if tokens[0]=='':
         tokens.pop(0)
-    name = "::".join(tokens)
+
     while len(tokens)>1:
         new_name = "::".join(tokens[1:])
         try:
@@ -62,43 +66,51 @@ def print_var(xml_root,var,full,dtype,value,valid_values):
             tokens.pop(0)
             name = new_name
         except AmbiguousName:
+            # new_name was either "" or an ambiguous name, and get_xml_node failed
             break
+
+    if print_style=="short":
+        # Just the inner most name
+        name = tokens[-1]
+    else:
+        name = "::".join(e.tag for e in nodes)
 
     if full:
         expect ("type" in node.attrib.keys(),
                 "Error! Missing type information for {}".format(name))
-        print ("{}".format(name))
-        print ("    value: {}".format(node.text))
-        print ("    type: {}".format(node.attrib["type"]))
+        print (f"{indent}{name}")
+        print (f"{indent}    value: {node.text}")
+        print (f"{indent}    type: {node.attrib['type']}")
         if "valid_values" not in node.attrib.keys():
             valid = []
         else:
             valid = node.attrib["valid_values"].split(",")
-        print ("    valid values: {}".format(valid))
+        print (f"{indent}    valid values: {valid}")
     elif dtype:
         expect ("type" in node.attrib.keys(),
                 "Error! Missing type information for {}".format(name))
-        print ("    {}: {}".format(name,node.attrib["type"]))
+        print (f"{indent}{name}: {node.attrib['type']}")
     elif value:
-        print ("{}".format(node.text))
+        print (f"{indent}{node.text}")
     elif valid_values:
         if "valid_values" not in node.attrib.keys():
             valid = []
         else:
             valid = node.attrib["valid_values"].split(",")
-        print ("    {}: {}".format(name,valid))
+        print (f"{indent}{name}: {node.text}")
     else:
-        print ("    {}: {}".format(name,node.text))
+        print (f"{indent}{name}: {node.text}")
 
 ###############################################################################
-def print_all_vars(xml_root,xml_node,curr_namespace,full,dtype,value,valid_values):
+def print_all_vars(xml_root,xml_node,curr_namespace,full,dtype,value,valid_values,indent,print_style):
 ###############################################################################
 
     for c in xml_node:
         if len(c)>0:
-            print_all_vars(xml_root,c,curr_namespace+c.tag+"::",full,dtype,value,valid_values)
+            print (f"{indent}{c.tag}")
+            print_all_vars(xml_root,c,curr_namespace+c.tag+"::",full,dtype,value,valid_values,indent+"  ",print_style)
         else:
-            print_var(xml_root,curr_namespace+c.tag,full,dtype,value,valid_values)
+            print_var(xml_root,curr_namespace+c.tag,full,dtype,value,valid_values,indent+"  ",print_style)
 
 ###############################################################################
 def atm_query_impl(xml_root,variables,listall=False,full=False,value=False, \
@@ -128,10 +140,10 @@ def atm_query_impl(xml_root,variables,listall=False,full=False,value=False, \
     """
 
     if listall:
-        print_all_vars(xml_root,xml_root,"::",full,dtype,value,valid_values)
+        print_all_vars(xml_root,xml_root,"::",full,dtype,value,valid_values,"  ","short")
     else:
         for var in variables:
-            print_var(xml_root,var,full,dtype,value,valid_values)
+            print_var(xml_root,var,full,dtype,value,valid_values,"  ","full")
 
     return True
 


### PR DESCRIPTION
- with `--listall`, print options nested, without adding namespace at each line (but adding namespace as list name)
- add all scope resolution when printing a single parameter.

E.g.:
```
$ ./atmquery --listall
  grids_manager
      Type: Homme
      physics_grid_type: gll
      physics_grid_rebalance: None
      dynamics_namelist_file_name: ./data/namelist.nl
  initial_conditions
      Filename: /sems-data-store/ACME/inputdata/atm/scream/init/screami_ne4np4L72_20220701.nc
      restart_casename: atmquery.scream
      surf_evap: 0.0
      precip_liq_surf_mass: 0.0
      precip_ice_surf_mass: 0.0
      cldfrac_liq: 0.0
      sgs_buoy_flux: 0.0
      eddy_diff_mom: 0.0
      T_prev_micro_step: 0.0
      qv_prev_micro_step: 0.0
      qr: 0.0
      nr: 0.0
      qm: 0.0
      bm: 0.0
      ni_activated: 0.0
      nc_nuceat_tend: 0.0
      tke: 0.0
      sfc_alb_dir_vis: 0.0
      sfc_alb_dir_nir: 0.0
      sfc_alb_dif_vis: 0.0
      sfc_alb_dif_nir: 0.0
      surf_sens_flux: 0.0
      surf_lw_flux_up: 0.0
      surf_mom_flux: 0.0,0.0
  Scorpio
      output_yaml_files: /home/lbertag/workdir/scream/scream-src/branch/components/scream/data/scream_default_output.yaml
    model_restart
        Casename: ./atmquery.scream
      output_control
          Frequency: 5
          frequency_units: INVALID
          avg_type_in_filename: false
          frequency_in_filename: false
  Debug
      atmosphere_dag_verbosity_level: 0
      atm_log_level: info
  e3sm_parameters
      e3sm_casename: atmquery
  ctl_nl
      cubed_sphere_map: 0
      disable_diagnostics: False
      dt_remap_factor: 2
      dt_tracer_factor: 1
      hypervis_order: 2
      hypervis_scaling: 3.0
      hypervis_subcycle: 1
      hypervis_subcycle_tom: 1
      hypervis_subcycle_q: 1
      nu: 3.4e-08
      nu_top: 250000.0
      se_ftype: 0
      se_geometry: sphere
      se_limiter_option: 9
      se_ne: 4
      se_nsplit: -1
      se_partmethod: 4
      se_topology: cube
      se_tstep: 600
      statefreq: 9999
      theta_advect_form: 1
      theta_hydrostatic_mode: False
      tstep_type: 9
      vert_remap_q_alg: 10
      transport_alg: 0
  atmosphere_processes
      atm_procs_list: (sc_import,homme,physics,sc_export)
      Type: Group
      schedule_type: Sequential
      number_of_subcycles: 1
      enable_precondition_checks: true
      enable_postcondition_checks: true
    sc_import
        number_of_subcycles: 1
        enable_precondition_checks: true
        enable_postcondition_checks: true
    homme
        Grid: Dynamics
        vertical_coordinate_filename: /sems-data-store/ACME/inputdata/atm/scream/init/screami_ne4np4L72_20220524.nc
        Moisture: moist
        number_of_subcycles: 1
        enable_precondition_checks: true
        enable_postcondition_checks: true
    physics
        atm_procs_list: (mac_aero_mic,rrtmgp)
        Type: Group
        schedule_type: Sequential
        number_of_subcycles: 1
        enable_precondition_checks: true
        enable_postcondition_checks: true
      mac_aero_mic
          atm_procs_list: (shoc,cldFraction,spa,p3)
          number_of_subcycles: 24
          Type: Group
          schedule_type: Sequential
          enable_precondition_checks: true
          enable_postcondition_checks: true
        shoc
            number_of_subcycles: 1
            enable_precondition_checks: true
            enable_postcondition_checks: true
        cldFraction
            number_of_subcycles: 1
            enable_precondition_checks: true
            enable_postcondition_checks: true
        spa
            spa_remap_file: /sems-data-store/ACME/inputdata/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc
            spa_data_file: /sems-data-store/ACME/inputdata/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc
            number_of_subcycles: 1
            enable_precondition_checks: true
            enable_postcondition_checks: true
        p3
            do_prescribed_ccn: true
            do_predict_nc: true
            number_of_subcycles: 1
            enable_precondition_checks: true
            enable_postcondition_checks: true
      rrtmgp
          active_gases: h2o, co2, o3, n2o, co, ch4, o2, n2
          column_chunk_size: 1280
          orbital_year: -9999
          orbital_eccentricity: -9999
          orbital_obliquity: -9999
          orbital_mvelp: -9999
          rad_frequency: 1
          do_aerosol_rad: true
          number_of_subcycles: 1
          enable_precondition_checks: true
          enable_postcondition_checks: true
    sc_export
        number_of_subcycles: 1
        enable_precondition_checks: true
        enable_postcondition_checks: true
```

While
```
$ ./atmquery rad_frequency --full
  atmosphere_processes::physics::rrtmgp::rad_frequency
      value: 1
      type: integer
      valid values: []
```