### PR TITLE
Use reduced spectral resolution for RRTMGP

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -191,6 +191,10 @@ tweaking their $case/namelist_scream.xml file.
 
     <!-- Radiation -->
     <rrtmgp inherit="atm_proc_base">
+      <rrtmgp_coefficients_file_sw>${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-sw-g112-210809.nc</rrtmgp_coefficients_file_sw>
+      <rrtmgp_coefficients_file_lw>${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-lw-g128-210809.nc</rrtmgp_coefficients_file_lw>
+      <rrtmgp_cloud_optics_file_sw>${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-sw.nc</rrtmgp_cloud_optics_file_sw>
+      <rrtmgp_cloud_optics_file_lw>${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-lw.nc</rrtmgp_cloud_optics_file_lw>
       <column_chunk_size>1280</column_chunk_size>
       <!-- Radiatively active gases; surface values set to F2010 settings taken from EAM  -->
       <!-- Note that h2o concentrations are just taken from qv, o3 is prescribed for now, -->

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -322,8 +322,8 @@ tweaking their $case/namelist_scream.xml file.
     CIME will automatically download them from the E3SM data server.
   -->
   <input_files>
-    ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-sw-g224-2018-12-04.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-lw-g256-2018-12-04.nc,
+    ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-sw-g112-210809.nc,
+    ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-lw-g128-210809.nc,
     ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-sw.nc,
     ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-lw.nc,
     ${DIN_LOC_ROOT}/atm/scream/tables/p3_lookup_table_1.dat-v4.1.1,

--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -94,8 +94,8 @@ target_include_directories(scream_rrtmgp SYSTEM PUBLIC
 
 # Ensure RRTMGP lookup tables are present in the data dir
 set (RRTMGP_TABLES
-  init/rrtmgp-data-sw-g224-2018-12-04.nc
-  init/rrtmgp-data-lw-g256-2018-12-04.nc
+  init/rrtmgp-data-sw-g112-210809.nc #rrtmgp-data-sw-g224-2018-12-04.nc
+  init/rrtmgp-data-lw-g128-210809.nc #rrtmgp-data-lw-g256-2018-12-04.nc
   init/rrtmgp-allsky.nc
   init/rrtmgp-cloud-optics-coeffs-sw.nc
   init/rrtmgp-cloud-optics-coeffs-lw.nc

--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -94,8 +94,8 @@ target_include_directories(scream_rrtmgp SYSTEM PUBLIC
 
 # Ensure RRTMGP lookup tables are present in the data dir
 set (RRTMGP_TABLES
-  init/rrtmgp-data-sw-g112-210809.nc #rrtmgp-data-sw-g224-2018-12-04.nc
-  init/rrtmgp-data-lw-g128-210809.nc #rrtmgp-data-lw-g256-2018-12-04.nc
+  init/rrtmgp-data-sw-g112-210809.nc
+  init/rrtmgp-data-lw-g128-210809.nc
   init/rrtmgp-allsky.nc
   init/rrtmgp-cloud-optics-coeffs-sw.nc
   init/rrtmgp-cloud-optics-coeffs-lw.nc

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -328,8 +328,17 @@ void RRTMGPRadiation::initialize_impl(const RunType /* run_type */) {
   Kokkos::deep_copy(m_gas_mol_weights,gas_mol_w_host);
 
   // Initialize GasConcs object to pass to RRTMGP initializer;
+  std::string coefficients_file_sw = m_params.get<std::string>("rrtmgp_coefficients_file_sw");
+  std::string coefficients_file_lw = m_params.get<std::string>("rrtmgp_coefficients_file_lw");
+  std::string cloud_optics_file_sw = m_params.get<std::string>("rrtmgp_cloud_optics_file_sw");
+  std::string cloud_optics_file_lw = m_params.get<std::string>("rrtmgp_cloud_optics_file_lw");
   m_gas_concs.init(gas_names_yakl_offset,m_col_chunk_size,m_nlay);
-  rrtmgp::rrtmgp_initialize(m_gas_concs, m_atm_logger);
+  rrtmgp::rrtmgp_initialize(
+          m_gas_concs,
+          coefficients_file_sw, coefficients_file_lw, 
+          cloud_optics_file_sw, cloud_optics_file_lw,
+          m_atm_logger
+  );
 
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,130.0, 500.0,false);

--- a/components/scream/src/physics/rrtmgp/mo_load_coefficients.cpp
+++ b/components/scream/src/physics/rrtmgp/mo_load_coefficients.cpp
@@ -103,7 +103,20 @@ void load_and_init(GasOpticsRRTMGP &kdist, std::string filename, GasConcs const 
   } else {
     // Otherwise, it's a shortwave type
     realHost1d solar_src;
-    io.read( solar_src , "solar_source" );
+    try {
+      if (io.varExists("solar_source")) {
+        io.read( solar_src , "solar_source" );
+      } else if (io.varExists("solar_source_quiet")) {
+        // Newer RRTMGP input data files include components of solar source function sufficient to
+        // compute solar variability; ignore this for now, and simply read in the baseline solar source.
+        // TODO: Ultimately, we probably want to use solar source data consistent with EAM.
+        io.read( solar_src , "solar_source_quiet" );
+      } else {
+        throw 1;
+      }
+    } catch (int err) {
+      std::cout << "ERROR: no solar_source variable found in input data.\n";
+    }
     kdist.load(available_gases, gas_names, key_species, band2gpt, band_lims, press_ref, press_ref_trop, 
                temp_ref, temp_ref_p, temp_ref_t, vmr_ref, kmajor, kminor_lower, kminor_upper, 
                gas_minor, identifier_minor, minor_gases_lower, minor_gases_upper, 

--- a/components/scream/src/physics/rrtmgp/mo_load_coefficients.cpp
+++ b/components/scream/src/physics/rrtmgp/mo_load_coefficients.cpp
@@ -109,26 +109,32 @@ void load_and_init(GasOpticsRRTMGP &kdist, std::string filename, GasConcs const 
       } else if (io.varExists("solar_source_quiet")) {
         // Newer RRTMGP input data files include components of solar source function sufficient to
         // compute solar variability; ignore this for now, and simply read in the baseline solar source.
-        // TODO: Ultimately, we probably want to use solar source data consistent with EAM.
-        realHost1d solar_source_quiet;
-        realHost1d solar_source_facular;
-        realHost1d solar_source_sunspot;
-        real mg_index;
-        real sb_index;
-        //io.read( solar_src , "solar_source_quiet" );
-        io.read( solar_source_quiet   , "solar_source_quiet" );
-        io.read( solar_source_facular , "solar_source_facular" );
-        io.read( solar_source_sunspot , "solar_source_sunspot" );
-        io.read( mg_index, "mg_default");
-        io.read( sb_index, "sb_default");
-        const real a_offset = 0.1495954;
-        const real b_offset = 0.00066696;
-        auto ngpt = solar_source_quiet.totElems();
-        parallel_for(Bounds<1>(ngpt), YAKL_LAMBDA(int igpt) {
-            solar_src(igpt) = solar_source_quiet(igpt) 
-                + (mg_index - a_offset) * solar_source_facular(igpt) 
-                + (sb_index - b_offset) * solar_source_sunspot(igpt);
-        });
+        // This seems to get us closer to the original average insolation from
+        // the full spectral resolution data, but there is disagreement between
+        // this and EAM RRTMG for some reason.
+        // TODO: Ultimately, we need to be able to use solar source data consistent with EAM (i.e., the
+        // input4MIPS data); this will require implementing a separate function
+        // here to read that data in and integrate the solar source over each
+        // wavelength/gpoint band
+        io.read( solar_src            , "solar_source_quiet" );
+        if (false) {
+          realHost1d solar_source_facular;
+          realHost1d solar_source_sunspot;
+          real mg_index;
+          real sb_index;
+          io.read( solar_source_facular , "solar_source_facular" );
+          io.read( solar_source_sunspot , "solar_source_sunspot" );
+          io.read( mg_index, "mg_default");
+          io.read( sb_index, "sb_default");
+          const real a_offset = 0.1495954;
+          const real b_offset = 0.00066696;
+          auto ngpt = solar_src.totElems();
+          parallel_for(Bounds<1>(ngpt), YAKL_LAMBDA(int igpt) {
+              solar_src(igpt) = solar_src(igpt)
+                  + (mg_index - a_offset) * solar_source_facular(igpt)
+                  + (sb_index - b_offset) * solar_source_sunspot(igpt);
+          });
+        }
       } else {
         throw 1;
       }

--- a/components/scream/src/physics/rrtmgp/mo_load_coefficients.cpp
+++ b/components/scream/src/physics/rrtmgp/mo_load_coefficients.cpp
@@ -110,7 +110,25 @@ void load_and_init(GasOpticsRRTMGP &kdist, std::string filename, GasConcs const 
         // Newer RRTMGP input data files include components of solar source function sufficient to
         // compute solar variability; ignore this for now, and simply read in the baseline solar source.
         // TODO: Ultimately, we probably want to use solar source data consistent with EAM.
-        io.read( solar_src , "solar_source_quiet" );
+        realHost1d solar_source_quiet;
+        realHost1d solar_source_facular;
+        realHost1d solar_source_sunspot;
+        real mg_index;
+        real sb_index;
+        //io.read( solar_src , "solar_source_quiet" );
+        io.read( solar_source_quiet   , "solar_source_quiet" );
+        io.read( solar_source_facular , "solar_source_facular" );
+        io.read( solar_source_sunspot , "solar_source_sunspot" );
+        io.read( mg_index, "mg_default");
+        io.read( sb_index, "sb_default");
+        const real a_offset = 0.1495954;
+        const real b_offset = 0.00066696;
+        auto ngpt = solar_source_quiet.totElems();
+        parallel_for(Bounds<1>(ngpt), YAKL_LAMBDA(int igpt) {
+            solar_src(igpt) = solar_source_quiet(igpt) 
+                + (mg_index - a_offset) * solar_source_facular(igpt) 
+                + (sb_index - b_offset) * solar_source_sunspot(igpt);
+        });
       } else {
         throw 1;
       }

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -15,15 +15,6 @@ namespace scream {
         OpticalProps2str get_cloud_optics_sw(const int ncol, const int nlay, CloudOptics &cloud_optics, GasOpticsRRTMGP &kdist, real2d &lwp, real2d &iwp, real2d &rel, real2d &rei);
         OpticalProps1scl get_cloud_optics_lw(const int ncol, const int nlay, CloudOptics &cloud_optics, GasOpticsRRTMGP &kdist, real2d &lwp, real2d &iwp, real2d &rel, real2d &rei);
 
-        /*
-         * Names of input files we will need.
-         * TODO: these should be passed as parameters to init, not hard-coded
-         */
-        std::string coefficients_file_sw = SCREAM_DATA_DIR "/init/rrtmgp-data-sw-g112-210809.nc";
-        std::string coefficients_file_lw = SCREAM_DATA_DIR "/init/rrtmgp-data-lw-g128-210809.nc";
-        std::string cloud_optics_file_sw = SCREAM_DATA_DIR "/init/rrtmgp-cloud-optics-coeffs-sw.nc";
-        std::string cloud_optics_file_lw = SCREAM_DATA_DIR "/init/rrtmgp-cloud-optics-coeffs-lw.nc";
-
         /* 
          * Objects containing k-distribution information need to be initialized
          * once and then persist throughout the life of the program, so we
@@ -56,6 +47,8 @@ namespace scream {
          * interface to radiation.
          */
         void rrtmgp_initialize(GasConcs &gas_concs,
+                               const std::string coefficients_file_sw, const std::string coefficients_file_lw,
+                               const std::string cloud_optics_file_sw, const std::string cloud_optics_file_lw,
                                const std::shared_ptr<spdlog::logger>& logger) {
 
             // If we've already initialized, just exit

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -17,9 +17,10 @@ namespace scream {
 
         /*
          * Names of input files we will need.
+         * TODO: these should be passed as parameters to init, not hard-coded
          */
-        std::string coefficients_file_sw = SCREAM_DATA_DIR "/init/rrtmgp-data-sw-g224-2018-12-04.nc";
-        std::string coefficients_file_lw = SCREAM_DATA_DIR "/init/rrtmgp-data-lw-g256-2018-12-04.nc";
+        std::string coefficients_file_sw = SCREAM_DATA_DIR "/init/rrtmgp-data-sw-g112-210809.nc";
+        std::string coefficients_file_lw = SCREAM_DATA_DIR "/init/rrtmgp-data-lw-g128-210809.nc";
         std::string cloud_optics_file_sw = SCREAM_DATA_DIR "/init/rrtmgp-cloud-optics-coeffs-sw.nc";
         std::string cloud_optics_file_lw = SCREAM_DATA_DIR "/init/rrtmgp-cloud-optics-coeffs-lw.nc";
 

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -35,6 +35,8 @@ namespace scream {
          * Initialize data for RRTMGP driver
          */
         extern void rrtmgp_initialize(GasConcs &gas_concs,
+                                      const std::string coefficients_file_sw, const std::string coefficients_file_lw,
+                                      const std::string cloud_optics_file_sw, const std::string cloud_optics_file_lw,
                                       const std::shared_ptr<spdlog::logger>& logger);
         /*
          * Compute band-by-band surface albedos from broadband albedos.

--- a/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/generate_baseline.cpp
@@ -15,6 +15,13 @@
 
 using namespace scream;
 
+// Names of input files we will need.
+// NOTE: use full spectral resolution absorption data for consistency with reference problem
+std::string coefficients_file_sw = SCREAM_DATA_DIR "/init/rrtmgp-data-sw-g224-2018-12-04.nc";
+std::string coefficients_file_lw = SCREAM_DATA_DIR "/init/rrtmgp-data-lw-g256-2018-12-04.nc";
+std::string cloud_optics_file_sw = SCREAM_DATA_DIR "/init/rrtmgp-cloud-optics-coeffs-sw.nc";
+std::string cloud_optics_file_lw = SCREAM_DATA_DIR "/init/rrtmgp-cloud-optics-coeffs-lw.nc";
+
 int main (int argc, char** argv) {
     MPI_Init(&argc,&argv);
 
@@ -69,7 +76,7 @@ int main (int argc, char** argv) {
     // Initialize the RRTMGP interface; this will read in the k-distribution
     // data that contains information about absorption coefficients for gases
     logger->info("rrtmgp_initialize...");
-    rrtmgp::rrtmgp_initialize(gas_concs,logger);
+    rrtmgp::rrtmgp_initialize(gas_concs, coefficients_file_sw, coefficients_file_lw, cloud_optics_file_sw, cloud_optics_file_lw, logger);
 
     // Setup dummy all-sky problem
     real1d sfc_alb_dir_vis ("sfc_alb_dir_vis", ncol);

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_tests.cpp
@@ -15,6 +15,13 @@
 
 using namespace scream;
 
+// Names of input files we will need.
+// NOTE: using old (full gpoint resolution) coefficient data for consistency with reference problem
+std::string coefficients_file_sw = SCREAM_DATA_DIR "/init/rrtmgp-data-sw-g224-2018-12-04.nc";
+std::string coefficients_file_lw = SCREAM_DATA_DIR "/init/rrtmgp-data-lw-g256-2018-12-04.nc";
+std::string cloud_optics_file_sw = SCREAM_DATA_DIR "/init/rrtmgp-cloud-optics-coeffs-sw.nc";
+std::string cloud_optics_file_lw = SCREAM_DATA_DIR "/init/rrtmgp-cloud-optics-coeffs-lw.nc";
+
 void expect_another_arg (int i, int argc) {
   EKAT_REQUIRE_MSG(i != argc-1, "Expected another cmd-line arg.");
 }
@@ -101,7 +108,7 @@ int run(int argc, char** argv) {
 
     // Initialize absorption coefficients
     logger->info("Initialize RRTMGP...\n");
-    scream::rrtmgp::rrtmgp_initialize(gas_concs,logger);
+    scream::rrtmgp::rrtmgp_initialize(gas_concs, coefficients_file_sw, coefficients_file_lw, cloud_optics_file_sw, cloud_optics_file_lw, logger);
 
     // Setup our dummy atmosphere based on the input data we read in
     logger->info("Setup dummy atmos...\n");

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
@@ -5,6 +5,12 @@
 #include "physics/share/physics_constants.hpp"
 #include "physics/rrtmgp/shr_orb_mod_c2f.hpp"
 
+// Names of input files we will need.
+std::string coefficients_file_sw = SCREAM_DATA_DIR "/init/rrtmgp-data-sw-g112-210809.nc";
+std::string coefficients_file_lw = SCREAM_DATA_DIR "/init/rrtmgp-data-lw-g128-210809.nc";
+std::string cloud_optics_file_sw = SCREAM_DATA_DIR "/init/rrtmgp-cloud-optics-coeffs-sw.nc";
+std::string cloud_optics_file_lw = SCREAM_DATA_DIR "/init/rrtmgp-cloud-optics-coeffs-lw.nc";
+
 TEST_CASE("rrtmgp_test_heating") {
     // Initialize YAKL
     if (!yakl::isInitialized()) { yakl::init(); }
@@ -254,7 +260,7 @@ TEST_CASE("rrtmgp_test_compute_broadband_surface_flux") {
     gas_names(8) = std::string("n2" );
     gas_concs.init(gas_names,ncol,nlay);
     logger->info("Init RRTMGP...\n");
-    scream::rrtmgp::rrtmgp_initialize(gas_concs,logger);
+    scream::rrtmgp::rrtmgp_initialize(gas_concs, coefficients_file_sw, coefficients_file_lw, cloud_optics_file_sw, cloud_optics_file_lw, logger);
 
     // Create simple test cases; We expect, given the input data, that band 10
     // will straddle the NIR and VIS, bands 1-9 will be purely NIR, and bands 11-14

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -42,6 +42,10 @@ atmosphere_processes:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false
+      rrtmgp_coefficients_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-sw-g112-210809.nc
+      rrtmgp_coefficients_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-lw-g128-210809.nc
+      rrtmgp_cloud_optics_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-sw.nc
+      rrtmgp_cloud_optics_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-lw.nc
 
 grids_manager:
   Type: Homme

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -39,6 +39,10 @@ atmosphere_processes:
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
+      rrtmgp_coefficients_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-sw-g112-210809.nc
+      rrtmgp_coefficients_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-lw-g128-210809.nc
+      rrtmgp_cloud_optics_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-sw.nc
+      rrtmgp_cloud_optics_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-lw.nc
 
 grids_manager:
   Type: Homme

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -39,6 +39,10 @@ atmosphere_processes:
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
+      rrtmgp_coefficients_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-sw-g112-210809.nc
+      rrtmgp_coefficients_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-lw-g128-210809.nc
+      rrtmgp_cloud_optics_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-sw.nc
+      rrtmgp_cloud_optics_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-lw.nc
 
 grids_manager:
   Type: Homme

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -45,6 +45,10 @@ atmosphere_processes:
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false
+      rrtmgp_coefficients_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-sw-g112-210809.nc
+      rrtmgp_coefficients_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-lw-g128-210809.nc
+      rrtmgp_cloud_optics_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-sw.nc
+      rrtmgp_cloud_optics_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-lw.nc
 
 grids_manager:
   Type: Homme

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -45,6 +45,10 @@ atmosphere_processes:
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false
+      rrtmgp_coefficients_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-sw-g112-210809.nc
+      rrtmgp_coefficients_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-lw-g128-210809.nc
+      rrtmgp_cloud_optics_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-sw.nc
+      rrtmgp_cloud_optics_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-lw.nc
 
 grids_manager:
   Type: Homme

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -37,6 +37,10 @@ atmosphere_processes:
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false
+      rrtmgp_coefficients_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-sw-g112-210809.nc
+      rrtmgp_coefficients_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-lw-g128-210809.nc
+      rrtmgp_cloud_optics_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-sw.nc
+      rrtmgp_cloud_optics_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-lw.nc
 
 grids_manager:
   Type: Homme

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -24,6 +24,10 @@ atmosphere_processes:
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     orbital_year: 1990
     do_aerosol_rad: false
+    rrtmgp_coefficients_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-sw-g112-210809.nc
+    rrtmgp_coefficients_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-lw-g128-210809.nc
+    rrtmgp_cloud_optics_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-sw.nc
+    rrtmgp_cloud_optics_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-lw.nc
 
 grids_manager:
   Type: Mesh Free

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -24,6 +24,10 @@ atmosphere_processes:
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
     orbital_year: 1990
+    rrtmgp_coefficients_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-sw-g112-210809.nc
+    rrtmgp_coefficients_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-lw-g128-210809.nc
+    rrtmgp_cloud_optics_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-sw.nc
+    rrtmgp_cloud_optics_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-lw.nc
 
 grids_manager:
   Type: Mesh Free

--- a/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -25,7 +25,7 @@ if (NOT SCREAM_BASELINES_ONLY)
 
   # Copy yaml input file to run directory
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_unit.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/input_unit.yaml COPYONLY)
+                 ${CMAKE_CURRENT_BINARY_DIR}/input_unit.yaml)
 
   # Ensure test input files are present in the data dir
   GetInputFile(init/${EAMxx_tests_IC_FILE_72lev})

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -20,6 +20,10 @@ atmosphere_processes:
     Can Initialize All Inputs: true
     rad_frequency: 3
     do_aerosol_rad: false
+    rrtmgp_coefficients_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-sw-g112-210809.nc
+    rrtmgp_coefficients_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-lw-g128-210809.nc
+    rrtmgp_cloud_optics_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-sw.nc
+    rrtmgp_cloud_optics_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-lw.nc
 
 grids_manager:
   Type: Mesh Free

--- a/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -15,6 +15,10 @@ atmosphere_processes:
     orbital_mvelp: 0
     Fixed Solar Zenith Angle: 0.86
     do_aerosol_rad: false
+    rrtmgp_coefficients_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-sw-g224-2018-12-04.nc
+    rrtmgp_coefficients_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-lw-g256-2018-12-04.nc
+    rrtmgp_cloud_optics_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-sw.nc
+    rrtmgp_cloud_optics_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-lw.nc
 
 grids_manager:
   Type: Mesh Free


### PR DESCRIPTION
Use reduced spectral resolution for RRTMGP. This uses the reduced spectral resolution absorption data developed externally by RRTMGP developers, which uses half the number of "g-points". This is consistent with the spectral resolution used in the RRTMG (no P) implementation in EAMv2, and should speed up the execution and reduce the memory footprint of RRTMGP in EAMxx by about a factor of two, with minimal impact to the solution accuracy. This also adds the capability to configure the spectral resolution by specifying the input file to use for radiation in the case directory via `atmchange`, rather   than hard-coding the path in the RRTMGP interface. This will be non-BFB for CIME cases that now use the reduced spectral resolution by default, but BFB for standalone tests, which use a mix of the full and reduced resolution depending on the test. This is done both for additional test coverage (to make sure the actual code is agnostic to input data size), but also because the `rrtmgp_tests` and `rrtmgp_standalone_unit` tests evaluate a solution against a reference problem that use the full spectral resolution.