### PR TITLE
Add append feature to atmchange

### DIFF
--- a/components/scream/scripts/atm_manip.py
+++ b/components/scream/scripts/atm_manip.py
@@ -95,7 +95,7 @@ def expect(condition, error_msg, exc_type=SystemExit, error_prefix="ERROR:"):
         raise exc_type(msg)
 
 ###############################################################################
-def get_xml_node(xml_root,name,return_hierarchy=False):
+def get_xml_node(xml_root,name):
 ###############################################################################
     """
     >>> xml = '''

--- a/components/scream/scripts/atmchange
+++ b/components/scream/scripts/atmchange
@@ -16,12 +16,17 @@ from eamxx_buildnml_impl import check_value, is_array_type
 from atm_manip import expect, get_xml_node
 
 ###############################################################################
-def atm_config_chg_impl(xml_root,append,changes):
+def atm_config_chg_impl(xml_root,changes,append=False):
 ###############################################################################
     """
 
     >>> xml = '''
     ... <root>
+    ...     <a type="array(int)">1,2,3</a>
+    ...     <b type="array(int)">1</b>
+    ...     <c type="int">1</c>
+    ...     <d type="string">one</d>
+    ...     <e type="array(string)">one</e>
     ...     <prop1>one</prop1>
     ...     <sub>
     ...         <prop1>two</prop1>
@@ -34,7 +39,9 @@ def atm_config_chg_impl(xml_root,append,changes):
     >>> ################ INVALID SYNTAX #######################
     >>> atm_config_chg_impl(tree,['prop1->2'])
     Traceback (most recent call last):
-    SystemExit: ERROR: Invalid change format. Expected A[::B[...]=value, got' prop1->2'
+    SystemExit: ERROR: Invalid change request 'prop1->2'. Valid formats are:
+      - A[::B[...]=value
+      - A[::B[...]+=value  (implies append for this change)
     >>> ################ INVALID TYPE #######################
     >>> atm_config_chg_impl(tree,['prop2=two'])
     Traceback (most recent call last):
@@ -50,6 +57,32 @@ def atm_config_chg_impl(xml_root,append,changes):
     False
     >>> atm_config_chg_impl(tree,['sub::prop1=one'])
     True
+    >>> ################ TEST APPEND += #################
+    >>> atm_config_chg_impl(tree,['a+=4'])
+    True
+    >>> get_xml_node(tree,'a')[0].text
+    '1,2,3, 4'
+    >>> ################ TEST APPEND = and --append #################
+    >>> atm_config_chg_impl(tree,['b=5'],append=True)
+    True
+    >>> get_xml_node(tree,'b')[0].text
+    '1, 5'
+    >>> ################ ERROR, append to non-array and non-string
+    >>> atm_config_chg_impl(tree,['c+=2'])
+    Traceback (most recent call last):
+    SystemExit: ERROR: Error! Can only append with array and string types.
+        - name: c
+        - type: int
+    >>> ################ Append to string ##################
+    >>> atm_config_chg_impl(tree,['d+=two'])
+    True
+    >>> get_xml_node(tree,'d')[0].text
+    'onetwo'
+    >>> ################ Append to array(string) ##################
+    >>> atm_config_chg_impl(tree,['e+=two'])
+    True
+    >>> get_xml_node(tree,'e')[0].text
+    'one, two'
     """
 
     any_change = False
@@ -63,7 +96,7 @@ def atm_config_chg_impl(xml_root,append,changes):
             tokens = change.split('=')
             
         expect (len(tokens)==2,
-            f"Invalid change format '{change}'. Valid formats are:\n"
+            f"Invalid change request '{change}'. Valid formats are:\n"
             f"  - A[::B[...]=value\n"
             f"  - A[::B[...]+=value  (implies append for this change)")
         node, __ = get_xml_node(xml_root,tokens[0])
@@ -74,7 +107,7 @@ def atm_config_chg_impl(xml_root,append,changes):
                     "Error! Missing type information for {}".format(tokens[0]))
             type = node.attrib["type"];
             expect (is_array_type(type) or type=="string",
-                    "Error! Can only use '--append' with array and string types.\n"
+                    "Error! Can only append with array and string types.\n"
                     f"    - name: {tokens[0]}\n"
                     f"    - type: {type}")
             if is_array_type(type):
@@ -92,7 +125,7 @@ def atm_config_chg_impl(xml_root,append,changes):
     return any_change
 
 ###############################################################################
-def atm_config_chg(append,changes):
+def atm_config_chg(changes,append):
 ###############################################################################
     expect(os.path.exists("namelist_scream.xml"),
            "No pwd/namelist_scream.xml file is present. Please rum from a case dir that has been setup")
@@ -101,7 +134,7 @@ def atm_config_chg(append,changes):
         tree = ET.parse(fd)
         root = tree.getroot()
 
-    any_change = atm_config_chg_impl(root,append,changes)
+    any_change = atm_config_chg_impl(root,changes,append)
 
     if any_change:
         tree.write("namelist_scream.xml")

--- a/components/scream/scripts/atmchange
+++ b/components/scream/scripts/atmchange
@@ -12,11 +12,11 @@ import xml.etree.ElementTree as ET
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "cime_config"))
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
-from eamxx_buildnml_impl import check_value
+from eamxx_buildnml_impl import check_value, is_array_type
 from atm_manip import expect, get_xml_node
 
 ###############################################################################
-def atm_config_chg_impl(xml_root,changes):
+def atm_config_chg_impl(xml_root,append,changes):
 ###############################################################################
     """
 
@@ -60,7 +60,22 @@ def atm_config_chg_impl(xml_root,changes):
         node, __ = get_xml_node(xml_root,tokens[0])
         new_value = tokens[1]
 
-        if node.text != new_value:
+        if append:
+            expect ("type" in node.attrib.keys(),
+                    "Error! Missing type information for {}".format(tokens[0]))
+            type = node.attrib["type"];
+            expect (is_array_type(type) or type=="string",
+                    "Error! Can only use '--append' with array and string types.\n"
+                    f"    - name: {tokens[0]}\n"
+                    f"    - type: {type}")
+            if is_array_type(type):
+                node.text += ", " + new_value
+            else:
+                node.text += new_value
+
+            any_change = True
+
+        elif node.text != new_value:
             check_value(node,new_value)
             node.text = new_value
             any_change = True
@@ -68,7 +83,7 @@ def atm_config_chg_impl(xml_root,changes):
     return any_change
 
 ###############################################################################
-def atm_config_chg(changes):
+def atm_config_chg(append,changes):
 ###############################################################################
     expect(os.path.exists("namelist_scream.xml"),
            "No pwd/namelist_scream.xml file is present. Please rum from a case dir that has been setup")
@@ -77,7 +92,7 @@ def atm_config_chg(changes):
         tree = ET.parse(fd)
         root = tree.getroot()
 
-    any_change = atm_config_chg_impl(root,changes)
+    any_change = atm_config_chg_impl(root,append,changes)
 
     if any_change:
         tree.write("namelist_scream.xml")
@@ -104,6 +119,13 @@ OR
 """.format(pathlib.Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--append",
+        default=False,
+        action="store_true",
+        help="Append to atm var, rather than replace its value.",
     )
 
     parser.add_argument("changes", nargs="+", help="Values to change")

--- a/components/scream/scripts/atmchange
+++ b/components/scream/scripts/atmchange
@@ -55,12 +55,21 @@ def atm_config_chg_impl(xml_root,append,changes):
     any_change = False
     for change in changes:
 
-        tokens = change.split('=')
-        expect (len(tokens)==2, "Invalid change format. Expected A[::B[...]=value, got' {}'".format(change))
+        tokens = change.split('+=')
+        if len(tokens)==2:
+            append_this = True
+        else:
+            append_this = append
+            tokens = change.split('=')
+            
+        expect (len(tokens)==2,
+            f"Invalid change format '{change}'. Valid formats are:\n"
+            f"  - A[::B[...]=value\n"
+            f"  - A[::B[...]+=value  (implies append for this change)")
         node, __ = get_xml_node(xml_root,tokens[0])
         new_value = tokens[1]
 
-        if append:
+        if append_this:
             expect ("type" in node.attrib.keys(),
                     "Error! Missing type information for {}".format(tokens[0]))
             type = node.attrib["type"];


### PR DESCRIPTION
This PR allows to do
```
atmchange --append var2=value
atmchange var2+=value
```
as syntax to append to an XML variable. The XML entry must have type `string` or `array(T)` (for some type T compatible with value). In the first case, strings are concatenated, while in the second case, an entry is appended to the array.

Notice that, if `var` is of type `array(int)`, `atmchange var=3`  will reset `var` to an array of length, contaiining just `3`.