### PR TITLE
EAMxx: reduce cost of memcheck build

### DIFF
--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -353,7 +353,13 @@ endif()
 # This is a meta-variable, which individual tests can use to set *different* degrees
 # of testing, in terms of resolutions. E.g., for SHORT use 3 timesteps, for MEDIUM use 10,
 # for LONG use 100. It is *completely* up to the test to decide what short, medium, and long mean.
-set(SCREAM_TEST_SIZE MEDIUM CACHE STRING "The kind of testing to perform: SHORT, MEDIUM, LONG. Only applies to certain tests and is generally used to reduce test length when valgrind/cuda-memcheck are on.")
+if (EKAT_ENABLE_COVERAGE OR EKAT_ENABLE_CUDA_MEMCHECK OR EKAT_ENABLE_VALGRIND)
+  set (SCREAM_TEST_SIZE_DEFAULT SHORT)
+else()
+  set (SCREAM_TEST_SIZE_DEFAULT MEDIUM)
+endif()
+
+set(SCREAM_TEST_SIZE ${SCREAM_TEST_SIZE_DEFAULT} CACHE STRING "The kind of testing to perform: SHORT, MEDIUM, LONG. Only applies to certain tests and is generally used to reduce test length when valgrind/cuda-memcheck are on.")
 set(SCREAM_TEST_VALID_SIZES "SHORT;MEDIUM;LONG" CACHE INTERNAL "List of valid values for SCREAM_TEST_SIZE")
 
 # Whether to use XYZ as a method to detect memory usage.

--- a/components/scream/CMakeLists.txt
+++ b/components/scream/CMakeLists.txt
@@ -355,6 +355,10 @@ endif()
 # for LONG use 100. It is *completely* up to the test to decide what short, medium, and long mean.
 if (EKAT_ENABLE_COVERAGE OR EKAT_ENABLE_CUDA_MEMCHECK OR EKAT_ENABLE_VALGRIND)
   set (SCREAM_TEST_SIZE_DEFAULT SHORT)
+  # also set thread_ing=$max_thread - 1, so we test at most 2 threading configurations
+  if (SCREAM_TEST_MAX_THREADS GREATER 1)
+    math (EXPR SCREAM_TEST_THREAD_INC ${SCREAM_TEST_MAX_THREADS}-1)
+  endif()
 else()
   set (SCREAM_TEST_SIZE_DEFAULT MEDIUM)
 endif()
@@ -406,6 +410,9 @@ print_var(SCREAM_FPMODEL)
 print_var(SCREAM_MPIRUN_EXE)
 print_var(SCREAM_LIB_ONLY)
 print_var(SCREAM_TPL_LIBRARIES)
+print_var(SCREAM_TEST_MAX_THREADS)
+print_var(SCREAM_TEST_THREAD_INC)
+print_var(SCREAM_TEST_MAX_RANKS)
 
 # This must be done using add_definitions because it is used to determine
 # whether to include scream_config.h.

--- a/components/scream/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/scream/scripts/jenkins/jenkins_common_impl.sh
@@ -98,7 +98,7 @@ if [ $skip_testing -eq 0 ]; then
     # Add a valgrind and coverage tests for mappy for nightlies
     if [[ $is_at_run == 0 ]]; then
       if [[ "$SCREAM_MACHINE" == "mappy" ]]; then
-        ./scripts/gather-all-data "./scripts/test-all-scream -t cov ${TAS_ARGS}" -l -m $SCREAM_MACHINE
+        ./scripts/gather-all-data "./scripts/test-all-scream -t cov ${TAS_ARGS} -c SCREAM_TEST_SIZE=SHORT" -l -m $SCREAM_MACHINE
         if [[ $? != 0 ]]; then
           fails=$fails+1;
           cov_fail=1
@@ -107,7 +107,7 @@ if [ $skip_testing -eq 0 ]; then
 
       # Add a memcheck test for mappy/weaver for nightlies
       if [[ "$SCREAM_MACHINE" == "mappy" || "$SCREAM_MACHINE" == "weaver" ]]; then
-        ./scripts/gather-all-data "./scripts/test-all-scream -t dbg --mem-check ${TAS_ARGS}" -l -m $SCREAM_MACHINE
+        ./scripts/gather-all-data "./scripts/test-all-scream -t dbg --mem-check ${TAS_ARGS} -c SCREAM_TEST_SIZE=SHORT" -l -m $SCREAM_MACHINE
         if [[ $? != 0 ]]; then
           fails=$fails+1;
           memcheck_fail=1

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -155,8 +155,6 @@ def test_factory(user_req_tests, machine, mem_check):
     if mem_check:
         for test in result:
             test.longname += "_cuda_mem_check" if is_cuda_machine(machine) else "_valgrind"
-            test.uses_baselines = False
-
 
     return result
 

--- a/components/scream/scripts/test_all_scream.py
+++ b/components/scream/scripts/test_all_scream.py
@@ -155,6 +155,8 @@ def test_factory(user_req_tests, machine, mem_check):
     if mem_check:
         for test in result:
             test.longname += "_cuda_mem_check" if is_cuda_machine(machine) else "_valgrind"
+            test.uses_baselines = False
+
 
     return result
 

--- a/components/scream/tests/CMakeLists.txt
+++ b/components/scream/tests/CMakeLists.txt
@@ -5,6 +5,17 @@ set(EAMxx_tests_IC_FILE_128lev "screami_unit_tests_ne2np4L128_20220718.nc")
 add_subdirectory(generic)
 
 if (NOT DEFINED ENV{SCREAM_FAKE_ONLY})
+  # memcheck builds (and also coverage ones) can just run the max ranks, since they
+  # do only need to perform checks on the code itself, rather than the model it represents
+  if (EKAT_ENABLE_VALGRIND OR EKAT_ENABLE_CUDA_MEMCHECK OR EKAT_ENABLE_COVERAGE)
+    set (TEST_RANK_START ${SCREAM_TEST_MAX_RANKS})
+    set (TEST_RANK_END   ${SCREAM_TEST_MAX_RANKS})
+  else()
+    set (TEST_RANK_START 1)
+    set (TEST_RANK_END   ${SCREAM_TEST_MAX_RANKS})
+  endif()
+
+  message ("test ranks [start,end] = [${TEST_RANK_START}, ${TEST_RANK_END}]")
   # Testing individual atm processes
   add_subdirectory(uncoupled)
 

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/CMakeLists.txt
@@ -8,9 +8,9 @@ CreateDynamicsLib("theta-l_kokkos"  4   72   10)
 set (TEST_LABELS "dynamics;driver;shoc;cld;p3;rrtmgp;physics")
 set (NEED_LIBS cld_fraction shoc p3 scream_rrtmgp ${dynLibName} scream_control scream_share physics_share)
 CreateUnitTest(homme_shoc_cld_p3_rrtmgp "homme_shoc_cld_p3_rrtmgp.cpp" "${NEED_LIBS}"
-               LABELS ${TEST_LABELS} 
-               MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-               PROPERTIES FIXTURES_SETUP homme_shoc_cld_p3_rrtmgp_generate_output_nc_files
+  LABELS ${TEST_LABELS} 
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
+  PROPERTIES FIXTURES_SETUP homme_shoc_cld_p3_rrtmgp_generate_output_nc_files
 )
 
 # Set AD configurable options
@@ -63,17 +63,17 @@ configure_file(${SCREAM_SRC_DIR}/dynamics/homme/tests/theta.nl
 GetInputFile(init/${EAMxx_tests_IC_FILE_72lev})
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
-## Only if max mpi ranks is >1
+## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (SCREAM_TEST_MAX_RANKS GREATER 1)
+if (TEST_RANK_START GREATER TEST_RANK_END)
   include (BuildCprnc)
   BuildCprnc()
 
   set (BASE_TEST_NAME "homme_shoc_cld_p3_rrtmgp")
-  foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+  foreach (MPI_RANKS RANGE ${TEST_RANK_START} ${TEST_RANK_END})
     set (SRC_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
-    set (TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
+    set (TEST_NAME "${BASE_TEST_NAME}_np${TEST_RANK_START}_vs_np${MPI_RANKS}_bfb")
     add_test (NAME ${TEST_NAME} 
               COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -8,9 +8,9 @@ CreateDynamicsLib("theta-l_kokkos"  4   72   10)
 set (TEST_LABELS "dynamics;driver;shoc;cld;p3;rrtmgp;physics")
 set (NEED_LIBS cld_fraction shoc spa p3 scream_rrtmgp ${dynLibName} scream_control scream_share physics_share)
 CreateUnitTest(homme_shoc_cld_spa_p3_rrtmgp "homme_shoc_cld_spa_p3_rrtmgp.cpp" "${NEED_LIBS}"
-    LABELS ${TEST_LABELS}
-    MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-    PROPERTIES FIXTURES_SETUP homme_shoc_cld_spa_p3_rrtmgp_generate_output_nc_files
+  LABELS ${TEST_LABELS}
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
+  PROPERTIES FIXTURES_SETUP homme_shoc_cld_spa_p3_rrtmgp_generate_output_nc_files
 )
 
 # Set AD configurable options
@@ -72,17 +72,17 @@ endforeach()
 
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
-## Only if max mpi ranks is >1
+## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (SCREAM_TEST_MAX_RANKS GREATER 1)
+if (TEST_RANK_START GREATER TEST_RANK_END)
   include (BuildCprnc)
   BuildCprnc()
 
   set (BASE_TEST_NAME "homme_shoc_cld_spa_p3_rrtmgp")
-  foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+  foreach (MPI_RANKS RANGE ${TEST_RANK_START} ${TEST_RANK_END})
     set (SRC_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
-    set (TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
+    set (TEST_NAME "${BASE_TEST_NAME}_np${TEST_RANK_START}_vs_np${MPI_RANKS}_bfb")
     add_test (NAME ${TEST_NAME} 
               COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/CMakeLists.txt
@@ -8,9 +8,9 @@ CreateDynamicsLib("theta-l_kokkos"  4   128   10)
 set (TEST_LABELS "dynamics;driver;shoc;cld;p3;rrtmgp;physics")
 set (NEED_LIBS cld_fraction shoc spa p3 scream_rrtmgp ${dynLibName} scream_control scream_share physics_share)
 CreateUnitTest(homme_shoc_cld_spa_p3_rrtmgp_128levels "homme_shoc_cld_spa_p3_rrtmgp_128levels.cpp" "${NEED_LIBS}"
-    LABELS ${TEST_LABELS}
-    MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-    PROPERTIES FIXTURES_SETUP homme_shoc_cld_spa_p3_rrtmgp_128levels_generate_output_nc_files
+  LABELS ${TEST_LABELS}
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
+  PROPERTIES FIXTURES_SETUP homme_shoc_cld_spa_p3_rrtmgp_128levels_generate_output_nc_files
 )
 
 # Set AD configurable options
@@ -23,7 +23,7 @@ math (EXPR MAC_MIC_SUBCYCLES "(${ATM_TIME_STEP} + ${SHOC_MAX_DT} - 1) / ${SHOC_M
 
 ## Copy (and configure) yaml files needed by tests
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-               ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
+             ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml)
 
@@ -70,17 +70,17 @@ endforeach()
 
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
-## Only if max mpi ranks is >1
+## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (SCREAM_TEST_MAX_RANKS GREATER 1)
+if (TEST_RANK_START GREATER TEST_RANK_END)
   include (BuildCprnc)
   BuildCprnc()
 
   set (BASE_TEST_NAME "homme_shoc_cld_spa_p3_rrtmgp_128levels")
-  foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+  foreach (MPI_RANKS RANGE ${TEST_RANK_START} ${TEST_RANK_END})
     set (SRC_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
-    set (TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
+    set (TEST_NAME "${BASE_TEST_NAME}_np${TEST_RANK_START}_vs_np${MPI_RANKS}_bfb")
     add_test (NAME ${TEST_NAME} 
               COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
@@ -19,10 +19,9 @@ set (NEED_LIBS cld_fraction shoc p3 scream_rrtmgp rrtmgp ${NETCDF_C} ${dynLibNam
 # We can use the same namelist for all tests, using 3 different input yaml files
 
 # Add _np1 only if we're running also with more than one rank. Otherwise, add nothing
-if (SCREAM_TEST_MAX_RANKS GREATER 1)
-  set (TEST_NRANKS 1 ${SCREAM_TEST_MAX_RANKS})
-else()
-  set (TEST_NRANKS 1)
+set (TEST_NRANKS ${TEST_RANK_START})
+if (TEST_RANK_START GREATER TEST_RANK_END)
+  list (APPEND TEST_NRANKS ${TEST_RANK_END})
 endif()
 
 # Create a single executable for all the 3 runs

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/CMakeLists.txt
@@ -4,7 +4,7 @@ INCLUDE (ScreamUtils)
 set (TEST_LABELS "shoc;cld;p3;rrtmgp;physics;driver")
 set (NEED_LIBS shoc cld_fraction p3 scream_rrtmgp scream_control scream_share physics_share)
 CreateUnitTest(shoc_cld_p3_rrtmgp shoc_cld_p3_rrtmgp.cpp "${NEED_LIBS}" LABELS ${TEST_LABELS}
-  MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
   PROPERTIES FIXTURES_SETUP shoc_cld_p3_rrtmgp_generate_output_nc_files
 )
 
@@ -26,17 +26,17 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/shoc_cld_p3_rrtmgp_output.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/shoc_cld_p3_rrtmgp_output.yaml)
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
-## Only if max mpi ranks is >1
+## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (SCREAM_TEST_MAX_RANKS GREATER 1)
+if (TEST_RANK_START GREATER TEST_RANK_END)
   include (BuildCprnc)
   BuildCprnc()
 
   set (BASE_TEST_NAME "shoc_cld_p3_rrtmgp")
-  foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+  foreach (MPI_RANKS RANGE ${TEST_RANK_START} ${TEST_RANK_END})
     set (SRC_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
-    set (TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
+    set (TEST_NAME "${BASE_TEST_NAME}_np${TEST_RANK_START}_vs_np${MPI_RANKS}_bfb")
     add_test (NAME ${TEST_NAME}
               COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -4,7 +4,7 @@ include (ScreamUtils)
 set (TEST_LABELS "shoc;cld;spa;p3;rrtmgp;physics;driver")
 set (NEED_LIBS shoc cld_fraction spa p3 scream_rrtmgp scream_control scream_share physics_share)
 CreateUnitTest(shoc_cld_spa_p3_rrtmgp shoc_cld_spa_p3_rrtmgp.cpp "${NEED_LIBS}" LABELS ${TEST_LABELS}
-  MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
   PROPERTIES FIXTURES_SETUP shoc_cld_spa_p3_rrtmgp_generate_output_nc_files
 )
 
@@ -34,17 +34,17 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/shoc_cld_spa_p3_rrtmgp_output.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/shoc_cld_spa_p3_rrtmgp_output.yaml)
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
-## Only if max mpi ranks is >1
+## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (SCREAM_TEST_MAX_RANKS GREATER 1)
+if (TEST_RANK_START GREATER TEST_RANK_END)
   include (BuildCprnc)
   BuildCprnc()
 
   set (BASE_TEST_NAME "shoc_cld_spa_p3_rrtmgp")
-  foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+  foreach (MPI_RANKS RANGE ${TEST_RANK_START} ${TEST_RANK_END})
     set (SRC_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
-    set (TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+    set (TGT_FILE "${BASE_TEST_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
+    set (TEST_NAME "${BASE_TEST_NAME}_np${TEST_RANK_START}_vs_np${MPI_RANKS}_bfb")
     add_test (NAME ${TEST_NAME}
               COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/components/scream/tests/uncoupled/homme/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/homme/CMakeLists.txt
@@ -9,9 +9,9 @@ set (TEST_LABELS "dynamics;driver")
 set (NEED_LIBS ${dynLibName} scream_control scream_share)
 
 CreateUnitTest(homme_standalone "homme_standalone.cpp" "${NEED_LIBS}"
-               LABELS ${TEST_LABELS} 
-               MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
-               PROPERTIES FIXTURES_SETUP homme_generate_output_nc_files
+  LABELS ${TEST_LABELS} 
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
+  PROPERTIES FIXTURES_SETUP homme_generate_output_nc_files
 )
 
 # Set AD configurable options
@@ -60,16 +60,16 @@ configure_file(${SCREAM_BASE_DIR}/src/dynamics/homme/tests/theta.nl
 GetInputFile(init/${EAMxx_tests_IC_FILE_72lev})
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
-## Only if max mpi ranks is >1
+## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (SCREAM_TEST_MAX_RANKS GREATER 1)
+if (TEST_RANK_START GREATER TEST_RANK_END)
   include (BuildCprnc)
   BuildCprnc()
   set (BASE_TEST_NAME "homme")
-  foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+  foreach (MPI_RANKS RANGE ${TEST_RANK_START} ${TEST_RANK_END})
     set (SRC_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
-    set (TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
+    set (TEST_NAME "${BASE_TEST_NAME}_np${TEST_RANK_START}_vs_np${MPI_RANKS}_bfb")
     add_test (NAME ${TEST_NAME} 
               COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/components/scream/tests/uncoupled/p3/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/p3/CMakeLists.txt
@@ -4,7 +4,7 @@ include (ScreamUtils)
 SET (TEST_LABELS "p3;physics;driver")
 set (NEED_LIBS p3 scream_control scream_share)
 CreateUnitTest(p3_standalone "p3_standalone.cpp" "${NEED_LIBS}" LABELS ${TEST_LABELS}
-  MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
   PROPERTIES FIXTURES_SETUP p3_generate_output_nc_files
 )
 
@@ -21,16 +21,16 @@ configure_file(p3_standalone_output.yaml p3_standalone_output.yaml)
 GetInputFile(init/${EAMxx_tests_IC_FILE_72lev})
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
-## Only if max mpi ranks is >1
+## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (SCREAM_TEST_MAX_RANKS GREATER 1)
+if (TEST_RANK_START GREATER TEST_RANK_END)
   include (BuildCprnc)
   BuildCprnc()
   SET (BASE_TEST_NAME "p3")
-  foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+  foreach (MPI_RANKS RANGE ${TEST_RANK_START} ${TEST_RANK_END})
     set (SRC_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
-    set (TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
+    set (TEST_NAME "${BASE_TEST_NAME}_np${TEST_RANK_START}_vs_np${MPI_RANKS}_bfb")
     add_test (NAME ${TEST_NAME}
               COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -18,7 +18,7 @@ if (NOT SCREAM_BASELINES_ONLY)
   ## Create free running rrtmgp stand alone test that runs from an initial condition file.
   CreateUnitTest(
       rrtmgp_standalone "rrtmgp_standalone.cpp" "${NEED_LIBS}" LABELS ${TEST_LABELS}
-      MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+      MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
       EXE_ARGS "--ekat-test-params inputfile=input.yaml"
       PROPERTIES FIXTURES_SETUP rrtmgp_generate_output_nc_files
   )
@@ -56,8 +56,8 @@ if (NOT SCREAM_BASELINES_ONLY)
   # Compare chunked vs non-chunked radiation
   include (BuildCprnc)
   BuildCprnc()
-  set (SRC_FILE "rrtmgp_standalone_output_chunked.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
-  set (TGT_FILE "rrtmgp_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
+  set (SRC_FILE "rrtmgp_standalone_output_chunked.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
+  set (TGT_FILE "rrtmgp_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
   set (TEST_NAME "rrtmgp_chunked_vs_monolithic_bfb")
   add_test (NAME ${TEST_NAME}
             COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
@@ -66,13 +66,13 @@ if (NOT SCREAM_BASELINES_ONLY)
             FIXTURES_REQUIRED "rrtmgp_generate_output_nc_files;rrtmgp_chunked_generate_output")
 
   ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
-  ## Only if max mpi ranks is >1
+  ## Only if running with 2+ ranks configurations
   # This test requires CPRNC
-  if (SCREAM_TEST_MAX_RANKS GREATER 1)
-    foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+  if (TEST_RANK_START GREATER TEST_RANK_END)
+    foreach (MPI_RANKS RANGE ${TEST_RANK_START} ${TEST_RANK_END})
       set (SRC_FILE "rrtmgp_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
-      set (TGT_FILE "rrtmgp_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
-      set (TEST_NAME "rrtmgp_np1_vs_np${MPI_RANKS}_bfb")
+      set (TGT_FILE "rrtmgp_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
+      set (TEST_NAME "rrtmgp_np${TEST_RANK_START}_vs_np${MPI_RANKS}_bfb")
       add_test (NAME ${TEST_NAME}
                 COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/components/scream/tests/uncoupled/shoc/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/shoc/CMakeLists.txt
@@ -4,7 +4,7 @@ include (ScreamUtils)
 SET (TEST_LABELS "shoc;physics;driver")
 set (NEED_LIBS shoc scream_control scream_share)
 CreateUnitTest(shoc_standalone "shoc_standalone.cpp" "${NEED_LIBS}" LABELS ${TEST_LABELS}
-  MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
   PROPERTIES FIXTURES_SETUP shoc_generate_output_nc_files
 )
 
@@ -24,16 +24,16 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
 configure_file(shoc_standalone_output.yaml shoc_standalone_output.yaml)
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
-## Only if max mpi ranks is >1
+## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (SCREAM_TEST_MAX_RANKS GREATER 1)
+if (TEST_RANK_START GREATER TEST_RANK_END)
   include (BuildCprnc)
   BuildCprnc()
   SET (BASE_TEST_NAME "shoc")
-  foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+  foreach (MPI_RANKS RANGE ${TEST_RANK_START} ${TEST_RANK_END})
     set (SRC_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
-    set (TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
+    set (TEST_NAME "${BASE_TEST_NAME}_np${TEST_RANK_START}_vs_np${MPI_RANKS}_bfb")
     add_test (NAME ${TEST_NAME} 
               COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/components/scream/tests/uncoupled/spa/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/spa/CMakeLists.txt
@@ -6,7 +6,7 @@ set (NEED_LIBS spa scream_control scream_share)
 
 # Test atmosphere processes
 CreateUnitTest(spa_stand_alone "spa_stand_alone.cpp" "${NEED_LIBS}" LABELS ${TEST_LABELS}
-  MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
   PROPERTIES FIXTURES_SETUP spa_generate_output_nc_files
 )
 
@@ -31,16 +31,16 @@ foreach (file IN ITEMS ${TEST_INPUT_FILES})
 endforeach()
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
-## Only if max mpi ranks is >1
+## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (SCREAM_TEST_MAX_RANKS GREATER 1)
+if (TEST_RANK_START GREATER TEST_RANK_END)
   include (BuildCprnc)
   BuildCprnc()
   SET (BASE_TEST_NAME "spa")
-  foreach (MPI_RANKS RANGE 2 ${SCREAM_TEST_MAX_RANKS})
+  foreach (MPI_RANKS RANGE ${TEST_RANK_START} ${TEST_RANK_END})
     set (SRC_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
-    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np1.nc")
-    set (TEST_NAME "${BASE_TEST_NAME}_np1_vs_np${MPI_RANKS}_bfb")
+    set (TGT_FILE "${BASE_TEST_NAME}_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")
+    set (TEST_NAME "${BASE_TEST_NAME}_np${TEST_RANK_START}_vs_np${MPI_RANKS}_bfb")
     add_test (NAME ${TEST_NAME}
               COMMAND cmake -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/components/scream/tests/uncoupled/surface_coupling/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/surface_coupling/CMakeLists.txt
@@ -4,7 +4,7 @@ INCLUDE (ScreamUtils)
 set (TEST_LABELS "surface_coupling;driver")
 set (NEED_LIBS scream_control scream_share)
 CreateUnitTest(surface_coupling surface_coupling.cpp "${NEED_LIBS}" LABELS ${TEST_LABELS}
-  MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
   PROPERTIES FIXTURES_SETUP surface_coupling_generate_output_nc_files
 )
 


### PR DESCRIPTION
For multi-rank system tests, only build the test with most ranks. Also, for memchek/coverage builds, set the test size (which most coupled tests use to determine the number of time steps) to short.