### PR TITLE
EAMxx: fix time handling in SPA

### DIFF
--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -203,9 +203,9 @@ void SPA::initialize_impl (const RunType /* run_type */)
 void SPA::run_impl (const int dt)
 {
   /* Gather time and state information for interpolation */
-  auto ts = timestamp();
+  auto ts = timestamp()+dt;
   /* Update the SPATimeState to reflect the current time, note the addition of dt */
-  SPATimeState.t_now = ts.frac_of_year_in_days() + dt/86400.;
+  SPATimeState.t_now = ts.frac_of_year_in_days();
   /* Update time state and if the month has changed, update the data.*/
   SPAFunc::update_spa_timestate(m_spa_data_file,m_nswbands,m_nlwbands,ts,SPAHorizInterp,SPATimeState,SPAData_start,SPAData_end);
 

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -698,9 +698,10 @@ void SPAFunctions<S,D>
   //        any other frequency.
   const auto month = ts.get_month();
   if (month != time_state.current_month or !time_state.inited) {
+
     // Update the SPA time state information
     time_state.current_month = month;
-    time_state.t_beg_month = util::TimeStamp({0,month,1}, {0,0,0}).frac_of_year_in_days();
+    time_state.t_beg_month = util::TimeStamp({ts.get_year(),month,1}, {0,0,0}).frac_of_year_in_days();
     time_state.days_this_month = util::days_in_month(ts.get_year(),month);
     // Update the SPA forcing data for this month and next month
     // Start by copying next months data to this months data structure.  

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -170,6 +170,12 @@ void SPAFunctions<S,D>
 
   auto delta_t_fraction = (t_now-t_beg) / delta_t;
 
+  EKAT_REQUIRE_MSG (delta_t_fraction>=0 && delta_t_fraction<=1,
+      "Error! Convex interpolation with coefficient out of [0,1].\n"
+      "  t_now  : " + std::to_string(t_now) + "\n"
+      "  t_beg  : " + std::to_string(t_beg) + "\n"
+      "  delta_t: " + std::to_string(delta_t) + "\n");
+
   Kokkos::parallel_for("spa_time_interp_loop", policy,
     KOKKOS_LAMBDA(const MemberType& team) {
 


### PR DESCRIPTION
Spa was correctly computing the current time as `ts.frac_of_year_in_days()+dt`. However, it was passing `ts` rather than `ts+dt` to the main routine. In the case where `dt` takes you to the next month, SPA was using beg/end from the previous month. This was especially bad when the next month has more days, since we'd get `t_now-t_beg>days_in_month`, leading to a non-convex interpolation.

However, this should have caused a problem _only if_ the start date/time and ATM_NCPL are such that we have a timestep that crosses midnight. E.g., if start time is XX:15 and we use a timestep of 30 minutes.