### PR TITLE
Added F2010-SCREAMv1-MPASSI and tests

### DIFF
--- a/cime_config/testmods_dirs/atmlndactive/rtm_off/README
+++ b/cime_config/testmods_dirs/atmlndactive/rtm_off/README
@@ -1,0 +1,5 @@
+This test mod can be used to disable river model mosart during runtime
+for compsets that use mosart as river model. In practice, this is used 
+for ERS and ERP tests with F2010-SCREAMv1 after it was changed to use 
+mosart in place of srof. 
+

--- a/cime_config/testmods_dirs/atmlndactive/rtm_off/user_nl_mosart
+++ b/cime_config/testmods_dirs/atmlndactive/rtm_off/user_nl_mosart
@@ -1,0 +1,6 @@
+! disable rtm to allow short ERS and ERP run to complete. 
+! If rtm active, due to large rtm time step, restart pointer for ROF
+! is always ahead of that for atm at the end of the first run. And in 
+! restart run, the restart point for ROF becomes later than the run stop time
+
+ do_rtm =.false.

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -454,7 +454,7 @@ _TESTS = {
 
     "e3sm_scream_v1" : {
         "time"    : "03:00:00",
-        "inherit" : ("e3sm_scream_v1_lowres", "e3sm_scream_v1_medres"),
+        "inherit" : ("e3sm_scream_v1_lowres", "e3sm_scream_v1_medres","e3sm_scream_v1_mpassi"),
     },
 
 
@@ -485,6 +485,19 @@ _TESTS = {
             "SMS_D_Ln12.ne120_r0125_oRRS18to6v3.F2010-SCREAMv1",
             "SMS_Ln12.ne120_ne120.F2010-SCREAMv1",
 #            "SMS_Ln12.ne120_r0125_oRRS18to6v3.F2000-SCREAMv1-AQP1", add when aquap 120 inputs available
+            )
+    },
+
+    "e3sm_scream_v1_mpassi" : {
+        "time"  : "01:00:00",
+        "tests" : (
+            "ERP_D_Ln9.ne4_oQU240.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+            "SMS_D_Ln9.ne4_oQU240.F2010-SCREAMv1-MPASSI-noAero",
+            "ERP_Ln22.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+            "ERS_D_Ln22.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+            "ERS_Ln22.ne30_oECv3.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+            "PEM_Ln90.ne30pg2_EC30to60E2r2.F2010-SCREAMv1-MPASSI",
+            "ERS_Ln22.ne30pg2_EC30to60E2r2.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
             )
     },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -491,13 +491,13 @@ _TESTS = {
     "e3sm_scream_v1_mpassi" : {
         "time"  : "01:00:00",
         "tests" : (
-            "ERP_D_Ln9.ne4_oQU240.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
-            "SMS_D_Ln9.ne4_oQU240.F2010-SCREAMv1-MPASSI-noAero",
+         #  "ERP_D_Ln9.ne4_oQU240.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+         #  "SMS_D_Ln9.ne4_oQU240.F2010-SCREAMv1-MPASSI-noAero",
             "ERP_Ln22.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
             "ERS_D_Ln22.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
-            "ERS_Ln22.ne30_oECv3.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+         #  "ERS_Ln22.ne30_oECv3.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
             "PEM_Ln90.ne30pg2_EC30to60E2r2.F2010-SCREAMv1-MPASSI",
-            "ERS_Ln22.ne30pg2_EC30to60E2r2.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+         #  "ERS_Ln22.ne30pg2_EC30to60E2r2.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
             )
     },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -454,7 +454,7 @@ _TESTS = {
 
     "e3sm_scream_v1" : {
         "time"    : "03:00:00",
-        "inherit" : ("e3sm_scream_v1_lowres", "e3sm_scream_v1_medres","e3sm_scream_v1_mpassi"),
+        "inherit" : ("e3sm_scream_v1_lowres", "e3sm_scream_v1_medres", "e3sm_scream_v1_mpassi"),
     },
 
 

--- a/components/scream/cime_config/config_component.xml
+++ b/components/scream/cime_config/config_component.xml
@@ -26,8 +26,9 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value></default_value>
-    <values modifier='additive'>
+    <values match='last'>
       <value compset="_SCREAM">SCREAM_NP 4 SCREAM_NUM_VERTICAL_LEV 72 SCREAM_NUM_TRACERS 10</value>
+      <value compset="_SCREAM" grid="ne256.*|ne512.*|ne1024.*">SCREAM_NP 4 SCREAM_NUM_VERTICAL_LEV 128 SCREAM_NUM_TRACERS 10</value>
     </values>
     <group>build_component_scream</group>
     <file>env_build.xml</file>

--- a/components/scream/cime_config/config_compsets.xml
+++ b/components/scream/cime_config/config_compsets.xml
@@ -28,6 +28,12 @@
   </compset>
 
   <compset>
+      <alias>F2010-SCREAMv1-MPASSI</alias> <!-- Coupled land-atm compset (using SCREAMv1), 2010 initial conditions -->
+      <lname>2010_SCREAM_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP</lname>
+      <support_level>Experimental, under development</support_level>
+  </compset>
+
+  <compset>
       <alias>F2000-SCREAMv1-AQP1</alias> <!-- atm aquaplanet compset (using SCREAMv1), 2000 initial conditions -->
       <lname>2000_SCREAM%AQUA_SLND_SICE_DOCN%AQP1_SROF_SGLC_SWAV</lname>
       <support_level>Experimental, under development</support_level>
@@ -36,6 +42,12 @@
   <compset>
       <alias>F2010-SCREAMv1-noAero</alias> <!-- Coupled land-atm compset (using SCREAMv1), 2010 initial conditions, turn off Aerosol forcing -->
       <lname>2010_SCREAM%noAero_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP</lname>
+      <support_level>Experimental, under development</support_level>
+  </compset>
+
+  <compset>
+      <alias>F2010-SCREAMv1-MPASSI-noAero</alias> <!-- Coupled land-atm compset (using SCREAMv1), 2010 initial conditions, turn off Aerosol forcing -->
+      <lname>2010_SCREAM%noAero_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP</lname>
       <support_level>Experimental, under development</support_level>
   </compset>
 


### PR DESCRIPTION
Added compset F2010-SCREAMv1-MPASSI to use mpassi for
prescribed sea-ice mode and mosart for river model.  A test suite
e3sm_scream_v1_mpassi is added for testing the new compset.

Also Made 128 level default for high resolution (ne256,ne512, ne1024).

[BFB] for existing tests. new tests (scream_v1_mpassi) added.