### PR TITLE
Allow to reduce size of e3sm log, by optionally suppressing pre/post condition checks warnings

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -136,6 +136,7 @@ tweaking their $case/namelist_scream.xml file.
       <number_of_subcycles constraints="gt 0">1</number_of_subcycles>
       <enable_precondition_checks type="logical">true</enable_precondition_checks>
       <enable_postcondition_checks type="logical">true</enable_postcondition_checks>
+      <repair_log_level type="string" valid_values="trace,debug,info,warn">trace</repair_log_level>
     </atm_proc_base>
 
     <!-- Basic options for each atm process group -->

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -488,9 +488,9 @@ add_precondition_check (const prop_check_ptr& pc, const CheckFailHandling cfh)
         has_computed_field(fid) || has_computed_group(fid.name(),fid.get_grid_name()),
         "Error! Input property check can repair a non-computed field.\n"
         "  - Atmosphere process name: " + name() + "\n"
-        "  - Property check name: " + name() + "\n");
+        "  - Property check name: " + pc->name() + "\n");
   }
-  m_precondition_checks.push_back(std::make_pair(pc,cfh));
+  m_precondition_checks.push_back(std::make_pair(cfh,pc));
 }
 
 void AtmosphereProcess::
@@ -506,9 +506,9 @@ add_postcondition_check (const prop_check_ptr& pc, const CheckFailHandling cfh)
         has_computed_field(fid) || has_computed_group(fid.name(),fid.get_grid_name()),
         "Error! Input property check can repair a non-computed field.\n"
         "  - Atmosphere process name: " + name() + "\n"
-        "  - Property check name: " + name() + "\n");
+        "  - Property check name: " + pc->name() + "\n");
   }
-  m_postcondition_checks.push_back(std::make_pair(pc,cfh));
+  m_postcondition_checks.push_back(std::make_pair(cfh,pc));
 }
 
 void AtmosphereProcess::set_fields_and_groups_pointers () {

--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -468,6 +468,49 @@ get_internal_field(const std::string& field_name) const {
   return get_internal_field_impl(field_name);
 }
 
+void AtmosphereProcess::
+add_invariant_check (const prop_check_ptr& pc, const CheckFailHandling cfh)
+{
+  add_precondition_check (pc,cfh);
+  add_postcondition_check (pc,cfh);
+}
+
+void AtmosphereProcess::
+add_precondition_check (const prop_check_ptr& pc, const CheckFailHandling cfh)
+{
+  // If a pc can repair, we need to make sure the repairable
+  // fields are among the computed fields of this atm proc.
+  // Otherwise, it would be possible for this AP to implicitly
+  // update a field, without that appearing in the dag.
+  for (const auto& ptr : pc->repairable_fields()) {
+    const auto& fid = ptr->get_header().get_identifier();
+    EKAT_REQUIRE_MSG (
+        has_computed_field(fid) || has_computed_group(fid.name(),fid.get_grid_name()),
+        "Error! Input property check can repair a non-computed field.\n"
+        "  - Atmosphere process name: " + name() + "\n"
+        "  - Property check name: " + name() + "\n");
+  }
+  m_precondition_checks.push_back(std::make_pair(pc,cfh));
+}
+
+void AtmosphereProcess::
+add_postcondition_check (const prop_check_ptr& pc, const CheckFailHandling cfh)
+{
+  // If a pc can repair, we need to make sure the repairable
+  // fields are among the computed fields of this atm proc.
+  // Otherwise, it would be possible for this AP to implicitly
+  // update a field, without that appearing in the dag.
+  for (const auto& ptr : pc->repairable_fields()) {
+    const auto& fid = ptr->get_header().get_identifier();
+    EKAT_REQUIRE_MSG (
+        has_computed_field(fid) || has_computed_group(fid.name(),fid.get_grid_name()),
+        "Error! Input property check can repair a non-computed field.\n"
+        "  - Atmosphere process name: " + name() + "\n"
+        "  - Property check name: " + name() + "\n");
+  }
+  m_postcondition_checks.push_back(std::make_pair(pc,cfh));
+}
+
 void AtmosphereProcess::set_fields_and_groups_pointers () {
   for (auto& f : m_fields_in) {
     const auto& fid = f.get_header().get_identifier();

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -496,6 +496,9 @@ private:
 
   // Whether we need to update time stamps at the end of the run method
   bool m_update_time_stamps = true;
+
+  // Log level for when property checks perform a repair
+  ekat::logger::LogLevel  m_repair_log_level;
 };
 
 // ================= IMPLEMENTATION ================== //

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -220,20 +220,21 @@ public:
         Field& get_internal_field(const std::string& field_name);
 
   // Add a pre-built property check (PC) for precondition, postcondition, or invariant (i.e., pre+post) check.
-  template<CheckFailHandling CFH = CheckFailHandling::Fatal>
-  void add_precondition_check (const prop_check_ptr& prop_check);
-  template<CheckFailHandling CFH = CheckFailHandling::Fatal>
-  void add_postcondition_check (const prop_check_ptr& prop_check);
-  template<CheckFailHandling CFH = CheckFailHandling::Fatal>
-  void add_invariant_check (const prop_check_ptr& prop_check);
+  void add_precondition_check  (const prop_check_ptr& prop_check,
+                                const CheckFailHandling cfh = CheckFailHandling::Fatal);
+  void add_postcondition_check (const prop_check_ptr& prop_check,
+                                const CheckFailHandling cfh = CheckFailHandling::Fatal);
+  void add_invariant_check     (const prop_check_ptr& prop_check,
+                                const CheckFailHandling cfh = CheckFailHandling::Fatal);
 
   // Build a property check on the fly, then call the methods above
-  template<typename FPC, CheckFailHandling CFH = CheckFailHandling::Fatal, typename... Args>
+  template<typename FPC, typename... Args>
   void add_precondition_check (const Args... args);
-  template<typename FPC, CheckFailHandling CFH = CheckFailHandling::Fatal, typename... Args>
+  template<typename FPC, typename... Args>
   void add_postcondition_check (const Args... args);
-  template<typename FPC, CheckFailHandling CFH = CheckFailHandling::Fatal, typename... Args>
+  template<typename FPC, typename... Args>
   void add_invariant_check (const Args... args);
+  template<typename FPC, typename... Args>
 
   // For restarts, it is possible that some atm proc need to write/read some ad-hoc data.
   // E.g., some atm proc might need to read/write certain scalar values.
@@ -503,69 +504,24 @@ private:
 
 // ================= IMPLEMENTATION ================== //
 
-template<typename FPC, CheckFailHandling CFH, typename... Args>
+template<typename FPC, typename... Args>
 void AtmosphereProcess::
 add_precondition_check (const Args... args) {
   auto fpc = std::make_shared<FPC>(args...);
-  add_precondition_check<CFH>(fpc);
+  add_precondition_check(fpc);
 }
-template<typename FPC, CheckFailHandling CFH, typename... Args>
+template<typename FPC, typename... Args>
 void AtmosphereProcess::
 add_postcondition_check (const Args... args) {
   auto fpc = std::make_shared<FPC>(args...);
-  add_postcondition_check<CFH>(fpc);
+  add_postcondition_check(fpc);
 }
-template<typename FPC, CheckFailHandling CFH, typename... Args>
+template<typename FPC, typename... Args>
 void AtmosphereProcess::
 add_invariant_check (const Args... args) {
   auto fpc = std::make_shared<FPC>(args...);
-  add_invariant_check<CFH>(fpc);
+  add_invariant_check(fpc);
 }
-
-template<CheckFailHandling CFH>
-void AtmosphereProcess::
-add_invariant_check (const prop_check_ptr& pc)
-{
-  add_precondition_check<CFH> (pc);
-  add_postcondition_check<CFH> (pc);
-}
-template<CheckFailHandling CFH>
-void AtmosphereProcess::
-add_precondition_check (const prop_check_ptr& pc)
-{
-  // If a pc can repair, we need to make sure the repairable
-  // fields are among the computed fields of this atm proc.
-  // Otherwise, it would be possible for this AP to implicitly
-  // update a field, without that appearing in the dag.
-  for (const auto& ptr : pc->repairable_fields()) {
-    const auto& fid = ptr->get_header().get_identifier();
-    EKAT_REQUIRE_MSG (
-        has_computed_field(fid) || has_computed_group(fid.name(),fid.get_grid_name()),
-        "Error! Input property check can repair a non-computed field.\n"
-        "  - Atmosphere process name: " + name() + "\n"
-        "  - Property check name: " + name() + "\n");
-  }
-  m_precondition_checks.push_back(std::make_pair(CFH,pc));
-}
-template<CheckFailHandling CFH>
-void AtmosphereProcess::
-add_postcondition_check (const prop_check_ptr& pc)
-{
-  // If a pc can repair, we need to make sure the repairable
-  // fields are among the computed fields of this atm proc.
-  // Otherwise, it would be possible for this AP to implicitly
-  // update a field, without that appearing in the dag.
-  for (const auto& ptr : pc->repairable_fields()) {
-    const auto& fid = ptr->get_header().get_identifier();
-    EKAT_REQUIRE_MSG (
-        has_computed_field(fid) || has_computed_group(fid.name(),fid.get_grid_name()),
-        "Error! Input property check can repair a non-computed field.\n"
-        "  - Atmosphere process name: " + name() + "\n"
-        "  - Property check name: " + name() + "\n");
-  }
-  m_postcondition_checks.push_back(std::make_pair(CFH,pc));
-}
-
 
 // A short name for the factory for atmosphere processes
 // WARNING: you do not need to write your own creator function to register your atmosphere process in the factory.

--- a/components/scream/src/share/atm_process/atmosphere_process.hpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.hpp
@@ -234,7 +234,6 @@ public:
   void add_postcondition_check (const Args... args);
   template<typename FPC, typename... Args>
   void add_invariant_check (const Args... args);
-  template<typename FPC, typename... Args>
 
   // For restarts, it is possible that some atm proc need to write/read some ad-hoc data.
   // E.g., some atm proc might need to read/write certain scalar values.

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -518,7 +518,6 @@ TEST_CASE("field_checks", "") {
   util::TimeStamp t0(1,1,1,1,1,1);
 
   constexpr auto Warning = CheckFailHandling::Warning;
-  constexpr auto Fatal   = CheckFailHandling::Fatal;
   auto pos_check_pre = std::make_shared<FieldLowerBoundCheck>(T_tend,grid,0,false);
   auto pos_check_post = std::make_shared<FieldLowerBoundCheck>(T,grid,0,false);
   for (bool allow_failure : {true,false}) {
@@ -537,11 +536,12 @@ TEST_CASE("field_checks", "") {
         foo->initialize(t0,RunType::Initial);
 
         if (allow_failure) {
-          foo->add_precondition_check<Warning>(pos_check_pre);
-          foo->add_postcondition_check<Warning>(pos_check_post);
+          foo->add_precondition_check(pos_check_pre,Warning);
+          foo->add_postcondition_check(pos_check_post,Warning);
         } else {
-          foo->add_precondition_check<Fatal>(pos_check_pre);
-          foo->add_postcondition_check<Fatal>(pos_check_post);
+          // Default CheckFailHandling is Fatal
+          foo->add_precondition_check(pos_check_pre);
+          foo->add_postcondition_check(pos_check_post);
         }
 
         if (not allow_failure && (check_pre || check_post)) {


### PR DESCRIPTION
A couple of mods:

- Change construction of pre/post condition checks: do not pass CheckFailHandling as template arg. It's pointless, it can be a runtime arg.
- Each atm proc can receive the parameter `repair_log_level`, which establishes the level of logging for when the pre/post condition checks fail, and are repaired. Default is 'warn' for standalone, and 'trace' for v1 runs. This means that, with likely choices of atm log level, standalone will print the warnings, while v1 will not, keeping logs sizes under control.