### PR TITLE
On pm-cpu and pm-gpu, use CFS as output dir temporarily

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -169,7 +169,7 @@
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
     <!--CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-cpu</CIME_OUTPUT_ROOT-->
-    <CIME_OUTPUT_ROOT>$ENV{CFS}/e3sm/e3sm_scratch/pm-cpu</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>$ENV{CFS}/e3sm/$ENV{USER}/e3sm_scratch/pm-cpu</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>
@@ -275,7 +275,7 @@
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
     <!--CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-gpu</CIME_OUTPUT_ROOT-->
-    <CIME_OUTPUT_ROOT>$ENV{CFS}/e3sm/e3sm_scratch/pm-gpu</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>$ENV{CFS}/e3sm/$ENV{USER}/e3sm_scratch/pm-gpu</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -168,7 +168,8 @@
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
-    <CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-cpu</CIME_OUTPUT_ROOT>
+    <!--CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-cpu</CIME_OUTPUT_ROOT-->
+    <CIME_OUTPUT_ROOT>$ENV{CFS}/e3sm/e3sm_scratch/pm-cpu</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>
@@ -273,7 +274,8 @@
     <PROJECT>e3sm_g</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
-    <CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-gpu</CIME_OUTPUT_ROOT>
+    <!--CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-gpu</CIME_OUTPUT_ROOT-->
+    <CIME_OUTPUT_ROOT>$ENV{CFS}/e3sm/e3sm_scratch/pm-gpu</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>


### PR DESCRIPTION
On pm-cpu and pm-gpu, use CFS as output dir instead of scratch as a temporary fix until scratch is back on PM

[bfb]