### PR TITLE
Link YAKL against MPI if HAVE_MPI is defined

### DIFF
--- a/components/cmake/build_scream.cmake
+++ b/components/cmake/build_scream.cmake
@@ -12,7 +12,16 @@ function(build_scream)
     set (CMAKE_C_FLAGS ${CFLAGS})
     set (CMAKE_CXX_FLAGS ${CXXFLAGS})
     set (CMAKE_Fortran_FLAGS ${FFLAGS})
-    add_compile_definitions (${CPPDEFS})
+
+    # Strip leading space, or else add_compile_definitions will add
+    # an empty definition '-D `, which will cause compiler errors
+    # string (REGEX REPLACE "^ " "" CPPDEFS "${CPPDEFS}")
+    # add_compile_definitions expects a list of definitinos, each
+    # one provided without -D. So 1) replace ' ' with ';', and
+    # 2) strip '-D'/
+    string (REPLACE " " ";" CPPDEFS "${CPPDEFS}")
+    string (REPLACE "-D" "" CPPDEFS "${CPPDEFS}")
+    add_compile_definitions ("${CPPDEFS}")
 
     # Include machine file here
     include(${CMAKE_SOURCE_DIR}/scream/cmake/machine-files/${MACH}.cmake)

--- a/components/cmake/build_scream.cmake
+++ b/components/cmake/build_scream.cmake
@@ -12,7 +12,7 @@ function(build_scream)
     set (CMAKE_C_FLAGS ${CFLAGS})
     set (CMAKE_CXX_FLAGS ${CXXFLAGS})
     set (CMAKE_Fortran_FLAGS ${FFLAGS})
-    add_definitions (${CPPDEFS})
+    add_compile_definitions (${CPPDEFS})
 
     # Include machine file here
     include(${CMAKE_SOURCE_DIR}/scream/cmake/machine-files/${MACH}.cmake)

--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -23,6 +23,12 @@ if ("${DIR_DEFS} ${DIR_FLAGS} ${YAKL_DEFS} ${YAKL_FLAGS} ${CMAKE_CXX_FLAGS}" MAT
   cmake_policy (SET CMP0079 NEW)
   find_package(MPI REQUIRED COMPONENTS C)
   target_link_libraries (yakl PUBLIC MPI::MPI_C)
+  if (MPI_C_INCLUDE_DIRS)
+    target_include_directories (yakl PUBLIC ${MPI_C_INCLUDE_DIRS})
+  endif()
+  if (MPI_C_COMPILER_INCLUDE_DIRS)
+    target_include_directories (yakl PUBLIC ${MPI_C_COMPILER_INCLUDE_DIRS})
+  endif()
 endif()
 EkatDisableAllWarning(yakl)
 

--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -12,6 +12,18 @@ endif()
 # RRTMGP++ requires YAKL
 add_subdirectory(${SCREAM_BASE_DIR}/../../externals/YAKL ${CMAKE_BINARY_DIR}/externals/YAKL)
 target_compile_options(yakl PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${YAKL_CXX_FLAGS}>)
+
+# If HAVE_MPI is defined, yakl needs to link against MPI. To be safe, we check
+# any CMake property that could make yakl see that CPP macro
+get_directory_property (DIR_DEFS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMPILE_DEFINITIONS )
+get_directory_property (DIR_FLAGS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMPILE_FLAGS )
+get_target_property(YAKL_FLAGS yakl COMPILE_FLAGS)
+get_target_property(YAKL_DEFS yakl COMPILE_DEFINITIONS)
+if ("${DIR_DEFS} ${DIR_FLAGS} ${YAKL_DEFS} ${YAKL_FLAGS} ${CMAKE_CXX_FLAGS}" MATCHES "HAVE_MPI")
+  cmake_policy (SET CMP0079 NEW)
+  find_package(MPI REQUIRED COMPONENTS C)
+  target_link_libraries (yakl PUBLIC MPI::MPI_C)
+endif()
 EkatDisableAllWarning(yakl)
 
 # For debug builds, set -DYAKL_DEBUG


### PR DESCRIPTION
If HAVE_MPI is defined, YAKL uses mpi.h, but does not link against it. Therefore, if that macro is available to YAKL, we must ensure we provide MPI include/link stuff to the yakl target.

Fix #1905 .

@ndkeen this fixes it for me on pm-gpu. 