### PR TITLE
EAMxx: fix shoc standalone output yaml file

### DIFF
--- a/components/scream/tests/uncoupled/shoc/shoc_standalone_output.yaml
+++ b/components/scream/tests/uncoupled/shoc/shoc_standalone_output.yaml
@@ -4,16 +4,19 @@ Casename: shoc_standalone_output
 Averaging Type: Instant
 Max Snapshots Per File: 1
 Fields:
-  - T_mid
-  - cldfrac_liq
-  - eddy_diff_mom
-  - horiz_winds
-  - qv
-  - qc
-  - sgs_buoy_flux
-  - tke
-  - inv_qc_relvar
-  - pbl_height
+  Physics GLL:
+    Field Names:
+      - T_mid
+      - cldfrac_liq
+      - eddy_diff_mom
+      - horiz_winds
+      - qv
+      - qc
+      - sgs_buoy_flux
+      - tke
+      - inv_qc_relvar
+      - pbl_height
+
 output_control:
   Frequency: ${NUM_STEPS}
   frequency_units: nsteps


### PR DESCRIPTION
The file was using some old syntax, which caused no field to be saved.