### PR TITLE
EAMxx: fix buggy logic in npX vs np1 tests

### DIFF
--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/CMakeLists.txt
@@ -65,7 +65,7 @@ GetInputFile(init/${EAMxx_tests_IC_FILE_72lev})
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (TEST_RANK_START GREATER TEST_RANK_END)
+if (TEST_RANK_END GREATER TEST_RANK_START)
   include (BuildCprnc)
   BuildCprnc()
 

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -74,7 +74,7 @@ endforeach()
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (TEST_RANK_START GREATER TEST_RANK_END)
+if (TEST_RANK_END GREATER TEST_RANK_START)
   include (BuildCprnc)
   BuildCprnc()
 

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/CMakeLists.txt
@@ -72,7 +72,7 @@ endforeach()
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (TEST_RANK_START GREATER TEST_RANK_END)
+if (TEST_RANK_END GREATER TEST_RANK_START)
   include (BuildCprnc)
   BuildCprnc()
 

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
@@ -20,7 +20,7 @@ set (NEED_LIBS cld_fraction shoc p3 scream_rrtmgp rrtmgp ${NETCDF_C} ${dynLibNam
 
 # Add _np1 only if we're running also with more than one rank. Otherwise, add nothing
 set (TEST_NRANKS ${TEST_RANK_START})
-if (TEST_RANK_START GREATER TEST_RANK_END)
+if (TEST_RANK_END GREATER TEST_RANK_START)
   list (APPEND TEST_NRANKS ${TEST_RANK_END})
 endif()
 

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/CMakeLists.txt
@@ -28,7 +28,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/shoc_cld_p3_rrtmgp_output.yaml
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (TEST_RANK_START GREATER TEST_RANK_END)
+if (TEST_RANK_END GREATER TEST_RANK_START)
   include (BuildCprnc)
   BuildCprnc()
 

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -36,7 +36,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/shoc_cld_spa_p3_rrtmgp_output.yaml
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (TEST_RANK_START GREATER TEST_RANK_END)
+if (TEST_RANK_END GREATER TEST_RANK_START)
   include (BuildCprnc)
   BuildCprnc()
 

--- a/components/scream/tests/uncoupled/homme/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/homme/CMakeLists.txt
@@ -62,7 +62,7 @@ GetInputFile(init/${EAMxx_tests_IC_FILE_72lev})
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (TEST_RANK_START GREATER TEST_RANK_END)
+if (TEST_RANK_END GREATER TEST_RANK_START)
   include (BuildCprnc)
   BuildCprnc()
   set (BASE_TEST_NAME "homme")

--- a/components/scream/tests/uncoupled/p3/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/p3/CMakeLists.txt
@@ -23,7 +23,7 @@ GetInputFile(init/${EAMxx_tests_IC_FILE_72lev})
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (TEST_RANK_START GREATER TEST_RANK_END)
+if (TEST_RANK_END GREATER TEST_RANK_START)
   include (BuildCprnc)
   BuildCprnc()
   SET (BASE_TEST_NAME "p3")

--- a/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -75,7 +75,7 @@ if (NOT SCREAM_BASELINES_ONLY)
   ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
   ## Only if running with 2+ ranks configurations
   # This test requires CPRNC
-  if (TEST_RANK_START GREATER TEST_RANK_END)
+  if (TEST_RANK_END GREATER TEST_RANK_START)
     foreach (MPI_RANKS RANGE ${TEST_RANK_START} ${TEST_RANK_END})
       set (SRC_FILE "rrtmgp_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${MPI_RANKS}.nc")
       set (TGT_FILE "rrtmgp_standalone_output.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_START}.nc")

--- a/components/scream/tests/uncoupled/shoc/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/shoc/CMakeLists.txt
@@ -26,7 +26,7 @@ configure_file(shoc_standalone_output.yaml shoc_standalone_output.yaml)
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (TEST_RANK_START GREATER TEST_RANK_END)
+if (TEST_RANK_END GREATER TEST_RANK_START)
   include (BuildCprnc)
   BuildCprnc()
   SET (BASE_TEST_NAME "shoc")

--- a/components/scream/tests/uncoupled/spa/CMakeLists.txt
+++ b/components/scream/tests/uncoupled/spa/CMakeLists.txt
@@ -33,7 +33,7 @@ endforeach()
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if running with 2+ ranks configurations
 # This test requires CPRNC
-if (TEST_RANK_START GREATER TEST_RANK_END)
+if (TEST_RANK_END GREATER TEST_RANK_START)
   include (BuildCprnc)
   BuildCprnc()
   SET (BASE_TEST_NAME "spa")


### PR DESCRIPTION
We were not testing npX vs np1 at all, due to a backward comparison in our cmake logic.