### PR TITLE
Re-instate single precision model output

### DIFF
--- a/components/scream/cmake/tpls/Scorpio.cmake
+++ b/components/scream/cmake/tpls/Scorpio.cmake
@@ -40,6 +40,15 @@ macro (CreateScorpioTargets)
     add_library (pioc INTERFACE)
     target_link_libraries (pioc INTERFACE ${SCORPIO_C_LIB} gptl ${netcdf_c_lib})
     target_include_directories (pioc INTERFACE ${SCORPIO_INC_DIR} ${CSM_SHR_INCLUDE})
+
+    # HACK: CIME only copies headers from the bld dir to the CSM_SHR_INCLUDE dir
+    #       This means all the pioc headers in the src folder are not copied.
+    #       It would be nice if CIME used the cmake-generated makefile, and
+    #       ran 'make install' rather than copy files. Alas, we don't control
+    #       that, so we need another way. Including the src tree folder works.
+    target_include_directories (pioc INTERFACE ${SCREAM_BASE_DIR}/../../externals/scorpio/src/clib)
+    get_target_property (pioc_inc_dirs pioc INTERFACE_INCLUDE_DIRECTORIES)
+    message ("pioc includes: ${pioc_inc_dirs}")
     if (pnetcdf_lib)
       target_link_libraries(pioc INTERFACE "${pnetcdf_lib}")
     endif ()

--- a/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/scream/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -157,8 +157,10 @@ TEST_CASE("dyn_grid_io")
   io_params.set<std::string>("Casename","dyn_grid_io_np" + std::to_string(comm.size()));
   io_params.sublist("Fields").sublist("Dynamics").set<std::vector<std::string>>("Field Names",fnames);
   io_params.sublist("Fields").sublist("Dynamics").set<std::string>("IO Grid Name","Physics GLL");
+
   io_params.sublist("output_control").set<int>("Frequency",1);
   io_params.sublist("output_control").set<std::string>("frequency_units","nsteps");
+  io_params.set<std::string>("Floating Point Precision","real");
 
   OutputManager output;
   // AtmosphereOutput output(comm,io_params,fm_dyn,gm);

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -384,9 +384,9 @@ void SPAFunctions<S,D>
   std::vector<std::string> vec_of_dims = {"n_s"};
   std::string r_decomp = "Real-n_s";
   std::string i_decomp = "Int-n_s";
-  scorpio::get_variable(remap_file_name, "S", "S", vec_of_dims, scorpio::nctype("real"), r_decomp);
-  scorpio::get_variable(remap_file_name, "row", "row", vec_of_dims, scorpio::nctype("int"), i_decomp);
-  scorpio::get_variable(remap_file_name, "col", "col", vec_of_dims, scorpio::nctype("int"), i_decomp);
+  scorpio::get_variable(remap_file_name, "S", "S", vec_of_dims, "real", r_decomp);
+  scorpio::get_variable(remap_file_name, "row", "row", vec_of_dims, "int", i_decomp);
+  scorpio::get_variable(remap_file_name, "col", "col", vec_of_dims, "int", i_decomp);
   // Set the dof's to read in variables, since we will have all mpi ranks read in the full set of data the dof's are the whole array
   std::vector<scorpio::offset_t> var_dof(spa_horiz_interp.length);
   std::iota(var_dof.begin(),var_dof.end(),0);

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -384,9 +384,9 @@ void SPAFunctions<S,D>
   std::vector<std::string> vec_of_dims = {"n_s"};
   std::string r_decomp = "Real-n_s";
   std::string i_decomp = "Int-n_s";
-  scorpio::get_variable(remap_file_name, "S", "S", vec_of_dims.size(), vec_of_dims, PIO_REAL, r_decomp);
-  scorpio::get_variable(remap_file_name, "row", "row", vec_of_dims.size(), vec_of_dims, PIO_INT, i_decomp);
-  scorpio::get_variable(remap_file_name, "col", "col", vec_of_dims.size(), vec_of_dims, PIO_INT, i_decomp);
+  scorpio::get_variable(remap_file_name, "S", "S", vec_of_dims.size(), vec_of_dims, scorpio::nctype("real"), r_decomp);
+  scorpio::get_variable(remap_file_name, "row", "row", vec_of_dims.size(), vec_of_dims, scorpio::nctype("int"), i_decomp);
+  scorpio::get_variable(remap_file_name, "col", "col", vec_of_dims.size(), vec_of_dims, scorpio::nctype("int"), i_decomp);
   // Set the dof's to read in variables, since we will have all mpi ranks read in the full set of data the dof's are the whole array
   std::vector<scorpio::offset_t> var_dof(spa_horiz_interp.length);
   std::iota(var_dof.begin(),var_dof.end(),0);
@@ -396,9 +396,9 @@ void SPAFunctions<S,D>
   scorpio::set_decomp(remap_file_name);
   
   // Now read all of the input
-  scorpio::grid_read_data_array(remap_file_name,"S",-1,S_global_h.data()); 
-  scorpio::grid_read_data_array(remap_file_name,"row",-1,row_global_h.data()); 
-  scorpio::grid_read_data_array(remap_file_name,"col",-1,col_global_h.data()); 
+  scorpio::grid_read_data_array(remap_file_name,"S",  -1,S_global_h.data(),S_global_h.size()); 
+  scorpio::grid_read_data_array(remap_file_name,"row",-1,row_global_h.data(),row_global_h.size()); 
+  scorpio::grid_read_data_array(remap_file_name,"col",-1,col_global_h.data(),col_global_h.size()); 
 
   // Finished, close the file
   scorpio::eam_pio_closefile(remap_file_name);

--- a/components/scream/src/physics/spa/spa_functions_impl.hpp
+++ b/components/scream/src/physics/spa/spa_functions_impl.hpp
@@ -384,9 +384,9 @@ void SPAFunctions<S,D>
   std::vector<std::string> vec_of_dims = {"n_s"};
   std::string r_decomp = "Real-n_s";
   std::string i_decomp = "Int-n_s";
-  scorpio::get_variable(remap_file_name, "S", "S", vec_of_dims.size(), vec_of_dims, scorpio::nctype("real"), r_decomp);
-  scorpio::get_variable(remap_file_name, "row", "row", vec_of_dims.size(), vec_of_dims, scorpio::nctype("int"), i_decomp);
-  scorpio::get_variable(remap_file_name, "col", "col", vec_of_dims.size(), vec_of_dims, scorpio::nctype("int"), i_decomp);
+  scorpio::get_variable(remap_file_name, "S", "S", vec_of_dims, scorpio::nctype("real"), r_decomp);
+  scorpio::get_variable(remap_file_name, "row", "row", vec_of_dims, scorpio::nctype("int"), i_decomp);
+  scorpio::get_variable(remap_file_name, "col", "col", vec_of_dims, scorpio::nctype("int"), i_decomp);
   // Set the dof's to read in variables, since we will have all mpi ranks read in the full set of data the dof's are the whole array
   std::vector<scorpio::offset_t> var_dof(spa_horiz_interp.length);
   std::iota(var_dof.begin(),var_dof.end(),0);

--- a/components/scream/src/share/io/CMakeLists.txt
+++ b/components/scream/src/share/io/CMakeLists.txt
@@ -11,7 +11,7 @@ set(SCREAM_SCORPIO_SRCS
 # Create io lib
 add_library(scream_io ${SCREAM_SCORPIO_SRCS})
 set_target_properties(scream_io PROPERTIES Fortran_MODULE_DIRECTORY ${SCREAM_F90_MODULES})
-target_link_libraries(scream_io PUBLIC scream_share diagnostics piof)
+target_link_libraries(scream_io PUBLIC scream_share diagnostics piof pioc)
 target_compile_options(scream_io PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>)
 
 if (SCREAM_CIME_BUILD)

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -235,7 +235,8 @@ void AtmosphereInput::read_variables (const int time_index)
   for (auto const& name : m_fields_names) {
 
     // Read the data
-    scorpio::grid_read_data_array(m_filename,name,time_index,m_host_views_1d.at(name).data());
+    auto v1d = m_host_views_1d.at(name);
+    scorpio::grid_read_data_array(m_filename,name,time_index,v1d.data(),v1d.size());
 
     // If we have a field manager, make sure the data is correctly
     // synced to both host and device views of the field.
@@ -415,6 +416,7 @@ void AtmosphereInput::register_variables()
   // dof decomposition across different ranks.
 
   // Cycle through all fields
+  const auto& fp_precision = "real";
   for (auto const& name : m_fields_names) {
     // Determine the IO-decomp and construct a vector of dimension ids for this variable:
     auto vec_of_dims   = get_vec_of_dims(m_layouts.at(name));
@@ -430,7 +432,7 @@ void AtmosphereInput::register_variables()
     //  but in the future if non-Real variables are added we will want to accomodate that.
     //TODO: Should be able to simply inquire from the netCDF the dimensions for each variable.
     scorpio::get_variable(m_filename, name, name, vec_of_dims.size(),
-                          vec_of_dims, PIO_REAL, io_decomp_tag);
+                          vec_of_dims, scorpio::nctype(fp_precision), io_decomp_tag);
   }
 }
 

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -431,7 +431,7 @@ void AtmosphereInput::register_variables()
     //  Currently the field_manager only stores Real variables so it is not an issue,
     //  but in the future if non-Real variables are added we will want to accomodate that.
     //TODO: Should be able to simply inquire from the netCDF the dimensions for each variable.
-    scorpio::get_variable(m_filename, name, name, vec_of_dims.size(),
+    scorpio::get_variable(m_filename, name, name,
                           vec_of_dims, scorpio::nctype(fp_precision), io_decomp_tag);
   }
 }

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -432,7 +432,7 @@ void AtmosphereInput::register_variables()
     //  but in the future if non-Real variables are added we will want to accomodate that.
     //TODO: Should be able to simply inquire from the netCDF the dimensions for each variable.
     scorpio::get_variable(m_filename, name, name,
-                          vec_of_dims, scorpio::nctype(fp_precision), io_decomp_tag);
+                          vec_of_dims, fp_precision, io_decomp_tag);
   }
 }
 

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -493,7 +493,7 @@ register_variables(const std::string& filename,
     // Currently the field_manager only stores Real variables so it is not an issue,
     // but in the future if non-Real variables are added we will want to accomodate that.
     register_variable(filename, name, name, units, vec_of_dims,
-                      fp_precision, io_decomp_tag);
+                      "real",fp_precision, io_decomp_tag);
   }
 } // register_variables
 /* ---------------------------------------------------------- */

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -493,7 +493,7 @@ register_variables(const std::string& filename,
     // Currently the field_manager only stores Real variables so it is not an issue,
     // but in the future if non-Real variables are added we will want to accomodate that.
     register_variable(filename, name, name, units, vec_of_dims,
-                      scorpio::nctype(fp_precision), io_decomp_tag);
+                      fp_precision, io_decomp_tag);
   }
 } // register_variables
 /* ---------------------------------------------------------- */

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -292,7 +292,7 @@ void AtmosphereOutput::run (const std::string& filename, const bool is_write_ste
       // Bring data to host
       auto view_host = m_host_views_1d.at(name);
       Kokkos::deep_copy (view_host,view_dev);
-      grid_write_data_array(filename,name,view_host.data());
+      grid_write_data_array(filename,name,view_host.data(),view_host.size());
     }
   }
 } // run
@@ -455,7 +455,9 @@ void AtmosphereOutput::register_views()
   }
 }
 /* ---------------------------------------------------------- */
-void AtmosphereOutput::register_variables(const std::string& filename)
+void AtmosphereOutput::
+register_variables(const std::string& filename,
+                   const std::string& fp_precision)
 {
   using namespace scorpio;
 
@@ -490,7 +492,8 @@ void AtmosphereOutput::register_variables(const std::string& filename)
      // TODO  Need to change dtype to allow for other variables.
     // Currently the field_manager only stores Real variables so it is not an issue,
     // but in the future if non-Real variables are added we will want to accomodate that.
-    register_variable(filename, name, name, units, vec_of_dims.size(), vec_of_dims, PIO_REAL, io_decomp_tag);
+    register_variable(filename, name, name, units, vec_of_dims.size(),
+                      vec_of_dims, scorpio::nctype(fp_precision), io_decomp_tag);
   }
 } // register_variables
 /* ---------------------------------------------------------- */
@@ -595,7 +598,9 @@ void AtmosphereOutput::set_degrees_of_freedom(const std::string& filename)
   */
 } // set_degrees_of_freedom
 /* ---------------------------------------------------------- */
-void AtmosphereOutput::setup_output_file(const std::string& filename)
+void AtmosphereOutput::
+setup_output_file(const std::string& filename,
+                  const std::string& fp_precision)
 {
   using namespace scream::scorpio;
 
@@ -605,7 +610,7 @@ void AtmosphereOutput::setup_output_file(const std::string& filename)
   }
 
   // Register variables with netCDF file.  Must come after dimensions are registered.
-  register_variables(filename);
+  register_variables(filename,fp_precision);
 
   // Set the offsets of the local dofs in the global vector.
   set_degrees_of_freedom(filename);

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -492,8 +492,8 @@ register_variables(const std::string& filename,
      // TODO  Need to change dtype to allow for other variables.
     // Currently the field_manager only stores Real variables so it is not an issue,
     // but in the future if non-Real variables are added we will want to accomodate that.
-    register_variable(filename, name, name, units, vec_of_dims.size(),
-                      vec_of_dims, scorpio::nctype(fp_precision), io_decomp_tag);
+    register_variable(filename, name, name, units, vec_of_dims,
+                      scorpio::nctype(fp_precision), io_decomp_tag);
   }
 } // register_variables
 /* ---------------------------------------------------------- */

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -141,7 +141,7 @@ public:
   // Main Functions
   void restart (const std::string& filename);
   void init();
-  void setup_output_file (const std::string& filename);
+  void setup_output_file (const std::string& filename, const std::string& fp_precision);
   void run (const std::string& filename, const bool write, const int nsteps_since_last_output);
   void finalize() {}
 
@@ -152,7 +152,7 @@ protected:
   void set_grid (const std::shared_ptr<const AbstractGrid>& grid);
 
   void register_dimensions(const std::string& name);
-  void register_variables(const std::string& filename);
+  void register_variables(const std::string& filename, const std::string& fp_precision);
   void set_degrees_of_freedom(const std::string& filename);
   std::vector<scorpio::offset_t> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -209,7 +209,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
 
       // Register time as a variable.
       auto time_units="days since " + m_case_t0.get_date_string() + " " + m_case_t0.get_time_string();
-      register_variable(filename,"time","time",time_units,1,{"time"}, scorpio::nctype("double"),"time");
+      register_variable(filename,"time","time",time_units,{"time"}, "double","time");
 #ifdef SCREAM_HAS_LEAP_YEAR
       set_variable_metadata (filename,"time","calendar","gregorian");
 #else

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -209,7 +209,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
 
       // Register time as a variable.
       auto time_units="days since " + m_case_t0.get_date_string() + " " + m_case_t0.get_time_string();
-      register_variable(filename,"time","time",time_units,{"time"}, "double","time");
+      register_variable(filename,"time","time",time_units,{"time"}, "double", "double","time");
 #ifdef SCREAM_HAS_LEAP_YEAR
       set_variable_metadata (filename,"time","calendar","gregorian");
 #else

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -45,25 +45,16 @@ module scream_scorpio_interface
   !------------
   use pio_types,    only: iosystem_desc_t, file_desc_t, var_desc_t, io_desc_t, &
                           pio_noerr, pio_global, &
-                          PIO_int, PIO_real, PIO_double
+                          PIO_int, PIO_real, PIO_double, PIO_float=>PIO_real
   use pio_kinds,    only: PIO_OFFSET_KIND
   use pio_nf,       only: PIO_enddef, PIO_inq_dimid, PIO_inq_dimlen, PIO_inq_varid
   use pionfatt_mod, only: PIO_put_att   => put_att
 
-  use mpi
+  use mpi, only: mpi_abort, mpi_comm_size, mpi_comm_rank
 
-  use iso_c_binding
+  use iso_c_binding, only: c_float, c_double, c_int
   implicit none
   save
-
-#include "scream_config.f"
-#ifdef SCREAM_DOUBLE_PRECISION
-# define pio_rtype PIO_double
-# define rtype c_double
-#else
-# define pio_rtype PIO_real
-# define rtype c_float
-#endif
 
   public :: &
             lookup_pio_atm_file,         & ! Checks if a pio file is present
@@ -179,11 +170,15 @@ module scream_scorpio_interface
 
 !----------------------------------------------------------------------
   interface grid_read_data_array
-    module procedure grid_read_darray_1d
+    module procedure grid_read_darray_double
+    module procedure grid_read_darray_float
+    module procedure grid_read_darray_int
   end interface grid_read_data_array
 !----------------------------------------------------------------------
   interface grid_write_data_array
-    module procedure grid_write_darray_1d
+    module procedure grid_write_darray_float
+    module procedure grid_write_darray_double
+    module procedure grid_write_darray_int
   end interface
 !----------------------------------------------------------------------
 
@@ -627,7 +622,7 @@ contains
     use pionfput_mod, only: PIO_put_var   => put_var
 
     character(len=*), intent(in) :: filename       ! PIO filename
-    real(rtype), intent(in)      :: time
+    real(c_double), intent(in)      :: time
 
     type(hist_var_t), pointer    :: var
     type(pio_atm_file_t),pointer   :: pio_atm_file
@@ -725,6 +720,7 @@ contains
   ! Query whether the pio subsystem is inited already
   ! This can be useful to avoid double-init or double-finalize calls.
   function is_eam_pio_subsystem_inited() result(is_it) bind(c)
+    use iso_c_binding, only: c_bool
 
     logical(kind=c_bool) :: is_it
 
@@ -1359,22 +1355,22 @@ contains
   !  grid_write_darray_1d: Write a variable defined on this grid
   !
   !---------------------------------------------------------------------------
-  subroutine grid_write_darray_1d(filename, varname, var_data_ptr)
+  subroutine grid_write_darray_float(filename, varname, buf, buf_size)
     use piolib_mod, only: PIO_setframe
     use piodarray,  only: PIO_write_darray
 
     ! Dummy arguments
-    character(len=*),   intent(in) :: filename       ! PIO filename
-    character(len=*),   intent(in) :: varname
-    type (c_ptr),       intent(in) :: var_data_ptr
+    character(len=*),    intent(in) :: filename       ! PIO filename
+    character(len=*),    intent(in) :: varname
+    integer(kind=c_int), intent(in) :: buf_size
+    real(kind=c_float),  intent(in) :: buf(buf_size)
 
     ! Local variables
-    real(rtype), dimension(:), pointer         :: var_data_real
-    integer(kind=c_int), dimension(:), pointer :: var_data_int
-    type(pio_atm_file_t), pointer      :: pio_atm_file
-    type(hist_var_t), pointer          :: var
-    integer                            :: ierr,var_size
-    logical                            :: found
+
+    type(pio_atm_file_t), pointer :: pio_atm_file
+    type(hist_var_t), pointer     :: var
+    integer                       :: ierr,var_size
+    logical                       :: found
 
     call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
     call get_var(pio_atm_file,varname,var)
@@ -1386,18 +1382,75 @@ contains
     var_size = SIZE(var%compdof)
 
     ! Now we know the exact size of the array, and can shape the f90 pointer
-    if (var%dtype .eq. pio_rtype) then
-      call c_f_pointer (var_data_ptr, var_data_real, [var_size])
-      call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, var_data_real, ierr)
-      call errorHandle( 'eam_grid_write_darray_1d: Error writing variable '//trim(varname),ierr)
-    else if (var%dtype .eq. PIO_INT) then
-      call c_f_pointer (var_data_ptr, var_data_int, [var_size])
-      call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, var_data_int, ierr)
-      call errorHandle( 'eam_grid_write_darray_1d: Error writing variable '//trim(varname),ierr)
+    call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
+    call errorHandle( 'eam_grid_write_darray_float: Error writing variable '//trim(varname),ierr)
+  end subroutine grid_write_darray_float
+  subroutine grid_write_darray_double(filename, varname, buf, buf_size)
+    use piolib_mod, only: PIO_setframe
+    use piodarray,  only: PIO_write_darray
+
+    ! Dummy arguments
+    character(len=*),    intent(in) :: filename       ! PIO filename
+    character(len=*),    intent(in) :: varname
+    integer(kind=c_int), intent(in) :: buf_size
+    real(kind=c_double), intent(in) :: buf(buf_size)
+
+    ! Local variables
+
+    real(kind=c_float) :: sbuf(buf_size)
+    type(pio_atm_file_t), pointer :: pio_atm_file
+    type(hist_var_t), pointer     :: var
+    integer                       :: ierr,var_size
+    logical                       :: found
+
+    call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
+    call get_var(pio_atm_file,varname,var)
+
+    ! Set the timesnap we are reading
+    call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
+
+    ! We don't want the extent along the 'time' dimension
+    var_size = SIZE(var%compdof)
+
+    ! Now we know the exact size of the array, and can shape the f90 pointer
+    if (var%dtype .eq. PIO_FLOAT) then
+      sbuf = real(buf,c_float)
+      call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, sbuf, ierr)
     else
-      call errorHandle( "eam_grid_write_darray_1d: Error writing variable "//trim(varname)//" unsupported dtype", -999)
-    end if
-  end subroutine grid_write_darray_1d
+      call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
+    endif
+    call errorHandle( 'eam_grid_write_darray_double: Error writing variable '//trim(varname),ierr)
+  end subroutine grid_write_darray_double
+  subroutine grid_write_darray_int(filename, varname, buf, buf_size)
+    use piolib_mod, only: PIO_setframe
+    use piodarray,  only: PIO_write_darray
+
+    ! Dummy arguments
+    character(len=*),    intent(in) :: filename       ! PIO filename
+    character(len=*),    intent(in) :: varname
+    integer(kind=c_int), intent(in) :: buf_size
+    integer(kind=c_int), intent(in) :: buf(buf_size)
+
+    ! Local variables
+
+    type(pio_atm_file_t), pointer :: pio_atm_file
+    type(hist_var_t), pointer     :: var
+    integer                       :: ierr,var_size
+    logical                       :: found
+
+    call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
+    call get_var(pio_atm_file,varname,var)
+
+    ! Set the timesnap we are reading
+    call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
+
+    ! We don't want the extent along the 'time' dimension
+    var_size = SIZE(var%compdof)
+
+    ! Now we know the exact size of the array, and can shape the f90 pointer
+    call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
+    call errorHandle( 'eam_grid_write_darray_int: Error writing variable '//trim(varname),ierr)
+  end subroutine grid_write_darray_int
 !=====================================================================!
   ! Read output from file based on type (int or real)
   ! --Note-- that any dimensionality could be read if it is flattened to 1D
@@ -1415,14 +1468,15 @@ contains
   !  grid_read_darray_1d: Read a variable defined on this grid
   !
   !---------------------------------------------------------------------------
-  subroutine grid_read_darray_1d(filename, varname, var_data_ptr, time_index)
+  subroutine grid_read_darray_double(filename, varname, buf, buf_size, time_index)
     use piolib_mod, only: PIO_setframe
     use piodarray,  only: PIO_read_darray
 
     ! Dummy arguments
-    character(len=*), intent(in) :: filename       ! PIO filename
-    character(len=*), intent(in) :: varname
-    type (c_ptr),     intent(in) :: var_data_ptr
+    character(len=*),     intent(in) :: filename       ! PIO filename
+    character(len=*),     intent(in) :: varname
+    integer (kind=c_int), intent(in) :: buf_size
+    real(kind=c_double),  intent(out) :: buf(buf_size)
     integer, intent(in)          :: time_index
 
     ! Local variables
@@ -1430,8 +1484,6 @@ contains
     type(hist_var_t), pointer          :: var
     integer                            :: ierr, var_size
     logical                            :: found
-    real(rtype), dimension(:), pointer         :: var_data_real
-    integer(kind=c_int), dimension(:), pointer :: var_data_int
 
     call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
     call get_var(pio_atm_file,varname,var)
@@ -1449,20 +1501,81 @@ contains
     var_size = SIZE(var%compdof)
 
     ! Now we know the exact size of the array, and can shape the f90 pointer
-    if (var%dtype .eq. pio_rtype) then
-      call c_f_pointer (var_data_ptr, var_data_real, [var_size])
-      call pio_read_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, var_data_real, ierr)
-      call errorHandle( 'eam_grid_read_darray_1d: Error reading variable '//trim(varname),ierr)
-    else if (var%dtype .eq. PIO_INT) then
-      call c_f_pointer (var_data_ptr, var_data_int, [var_size])
-      call pio_read_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, var_data_int, ierr)
-      call errorHandle( 'eam_grid_read_darray_1d: Error reading variable '//trim(varname),ierr)
+    call pio_read_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
+    call errorHandle( 'eam_grid_read_darray_double: Error reading variable '//trim(varname),ierr)
+  end subroutine grid_read_darray_double
+  subroutine grid_read_darray_float(filename, varname, buf, buf_size, time_index)
+    use piolib_mod, only: PIO_setframe
+    use piodarray,  only: PIO_read_darray
+
+    ! Dummy arguments
+    character(len=*),     intent(in) :: filename       ! PIO filename
+    character(len=*),     intent(in) :: varname
+    integer (kind=c_int), intent(in) :: buf_size
+    real(kind=c_float),  intent(out) :: buf(buf_size)
+    integer, intent(in)          :: time_index
+
+    ! Local variables
+    type(pio_atm_file_t),pointer       :: pio_atm_file
+    type(hist_var_t), pointer          :: var
+    integer                            :: ierr, var_size
+    logical                            :: found
+
+    call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
+    call get_var(pio_atm_file,varname,var)
+
+    ! Set the timesnap we are reading
+    if (time_index .gt. 0) then
+      ! The user has set a valid time index to read from
+      call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(time_index,kind=pio_offset_kind))
     else
-      call errorHandle( "eam_grid_read_darra_1d: Error reading variable "//trim(varname)//" unsupported dtype", -999)
+      ! Otherwise default to the last time_index in the file
+      call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(pio_atm_file%numRecs,kind=pio_offset_kind))
     end if
+    
+    ! We don't want the extent along the 'time' dimension
+    var_size = SIZE(var%compdof)
 
+    ! Now we know the exact size of the array, and can shape the f90 pointer
+    call pio_read_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
+    call errorHandle( 'eam_grid_read_darray_float: Error reading variable '//trim(varname),ierr)
+  end subroutine grid_read_darray_float
+  subroutine grid_read_darray_int(filename, varname, buf, buf_size, time_index)
+    use piolib_mod, only: PIO_setframe
+    use piodarray,  only: PIO_read_darray
 
-  end subroutine grid_read_darray_1d
+    ! Dummy arguments
+    character(len=*),     intent(in) :: filename       ! PIO filename
+    character(len=*),     intent(in) :: varname
+    integer (kind=c_int), intent(in) :: buf_size
+    integer (kind=c_int), intent(out) :: buf(buf_size)
+    integer, intent(in)          :: time_index
+
+    ! Local variables
+    type(pio_atm_file_t),pointer       :: pio_atm_file
+    type(hist_var_t), pointer          :: var
+    integer                            :: ierr, var_size
+    logical                            :: found
+
+    call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
+    call get_var(pio_atm_file,varname,var)
+
+    ! Set the timesnap we are reading
+    if (time_index .gt. 0) then
+      ! The user has set a valid time index to read from
+      call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(time_index,kind=pio_offset_kind))
+    else
+      ! Otherwise default to the last time_index in the file
+      call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(pio_atm_file%numRecs,kind=pio_offset_kind))
+    end if
+    
+    ! We don't want the extent along the 'time' dimension
+    var_size = SIZE(var%compdof)
+
+    ! Now we know the exact size of the array, and can shape the f90 pointer
+    call pio_read_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
+    call errorHandle( 'eam_grid_read_darray_int: Error reading variable '//trim(varname),ierr)
+  end subroutine grid_read_darray_int
 !=====================================================================!
   subroutine convert_int_2_str(int_in,str_out)
     integer, intent(in)           :: int_in

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -100,28 +100,35 @@ void register_dimension(const std::string &filename, const std::string& shortnam
   register_dimension_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), length);
 }
 /* ----------------------------------------------------------------- */
-void get_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
+void get_variable(const std::string &filename, const std::string& shortname, const std::string& longname,
+                  const std::vector<std::string>& var_dimensions,
+                  const int dtype, const std::string& pio_decomp_tag) {
 
   /* Convert the vector of strings that contains the variable dimensions to a char array */
-  const char** var_dimensions_c = new const char*[numdims];
+  const int numdims = var_dimensions.size();
+  std::vector<const char*> var_dimensions_c(numdims);
   for (int ii = 0;ii<numdims;++ii) 
   {
     var_dimensions_c[ii] = var_dimensions[ii].c_str();
   }
-  get_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), numdims, var_dimensions_c, dtype, pio_decomp_tag.c_str());
-  delete[] var_dimensions_c;
+  get_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(),
+                   numdims, var_dimensions_c.data(), dtype, pio_decomp_tag.c_str());
 }
 /* ----------------------------------------------------------------- */
-void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
+void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname,
+                       const std::string& units, const std::vector<std::string>& var_dimensions,
+                       const int dtype, const std::string& pio_decomp_tag) {
 
   /* Convert the vector of strings that contains the variable dimensions to a char array */
-  const char** var_dimensions_c = new const char*[numdims];
+  const int numdims = var_dimensions.size();
+  std::vector<const char*> var_dimensions_c(numdims);
   for (int ii = 0;ii<numdims;++ii) 
   {
     var_dimensions_c[ii] = var_dimensions[ii].c_str();
   }
-  register_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), units.c_str(), numdims, var_dimensions_c, dtype, pio_decomp_tag.c_str());
-  delete[] var_dimensions_c;
+  register_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(),
+                        units.c_str(), numdims, var_dimensions_c.data(),
+                        dtype, pio_decomp_tag.c_str());
 }
 /* ----------------------------------------------------------------- */
 void set_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, const std::string& meta_val) {

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -112,11 +112,6 @@ void get_variable(const std::string &filename, const std::string& shortname, con
   delete[] var_dimensions_c;
 }
 /* ----------------------------------------------------------------- */
-void get_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
-
-  get_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
-}
-/* ----------------------------------------------------------------- */
 void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
 
   /* Convert the vector of strings that contains the variable dimensions to a char array */
@@ -129,10 +124,6 @@ void register_variable(const std::string &filename, const std::string& shortname
   delete[] var_dimensions_c;
 }
 /* ----------------------------------------------------------------- */
-void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag) {
-
-  register_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), units.c_str(), numdims, var_dimensions, dtype, pio_decomp_tag.c_str());
-}
 void set_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, const std::string& meta_val) {
   set_variable_metadata_c2f(filename.c_str(),varname.c_str(),meta_name.c_str(),meta_val.c_str());
 }

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -30,9 +30,13 @@ extern "C" {
   void eam_pio_closefile_c2f(const char*&& filename);
   void pio_update_time_c2f(const char*&& filename,const double time);
   void register_dimension_c2f(const char*&& filename, const char*&& shortname, const char*&& longname, const int length);
-  void register_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const char*&& units, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
+  void register_variable_c2f(const char*&& filename, const char*&& shortname, const char*&& longname,
+                             const char*&& units, const int numdims, const char** var_dimensions,
+                             const int dtype, const int nc_dtype, const char*&& pio_decomp_tag);
   void set_variable_metadata_c2f (const char*&& filename, const char*&& varname, const char*&& meta_name, const char*&& meta_val);
-  void get_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
+  void get_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname,
+                        const int numdims, const char** var_dimensions,
+                        const int dtype, const char*&& pio_decomp_tag);
   void eam_pio_enddef_c2f(const char*&& filename);
 } // extern C
 
@@ -118,7 +122,7 @@ void get_variable(const std::string &filename, const std::string& shortname, con
 /* ----------------------------------------------------------------- */
 void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname,
                        const std::string& units, const std::vector<std::string>& var_dimensions,
-                       const std::string& dtype, const std::string& pio_decomp_tag) {
+                       const std::string& dtype, const std::string& nc_dtype, const std::string& pio_decomp_tag) {
 
   /* Convert the vector of strings that contains the variable dimensions to a char array */
   const int numdims = var_dimensions.size();
@@ -129,7 +133,7 @@ void register_variable(const std::string &filename, const std::string& shortname
   }
   register_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(),
                         units.c_str(), numdims, var_dimensions_c.data(),
-                        nctype(dtype), pio_decomp_tag.c_str());
+                        nctype(dtype), nctype(nc_dtype), pio_decomp_tag.c_str());
 }
 /* ----------------------------------------------------------------- */
 void set_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, const std::string& meta_val) {

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -39,6 +39,7 @@ extern "C" {
 namespace scream {
 namespace scorpio {
 
+// Retrieve the int codes PIO uses to specify data types
 int nctype (const std::string& type) {
   if (type=="int") {
     return PIO_INT;
@@ -102,7 +103,7 @@ void register_dimension(const std::string &filename, const std::string& shortnam
 /* ----------------------------------------------------------------- */
 void get_variable(const std::string &filename, const std::string& shortname, const std::string& longname,
                   const std::vector<std::string>& var_dimensions,
-                  const int dtype, const std::string& pio_decomp_tag) {
+                  const std::string& dtype, const std::string& pio_decomp_tag) {
 
   /* Convert the vector of strings that contains the variable dimensions to a char array */
   const int numdims = var_dimensions.size();
@@ -112,12 +113,12 @@ void get_variable(const std::string &filename, const std::string& shortname, con
     var_dimensions_c[ii] = var_dimensions[ii].c_str();
   }
   get_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(),
-                   numdims, var_dimensions_c.data(), dtype, pio_decomp_tag.c_str());
+                   numdims, var_dimensions_c.data(), nctype(dtype), pio_decomp_tag.c_str());
 }
 /* ----------------------------------------------------------------- */
 void register_variable(const std::string &filename, const std::string& shortname, const std::string& longname,
                        const std::string& units, const std::vector<std::string>& var_dimensions,
-                       const int dtype, const std::string& pio_decomp_tag) {
+                       const std::string& dtype, const std::string& pio_decomp_tag) {
 
   /* Convert the vector of strings that contains the variable dimensions to a char array */
   const int numdims = var_dimensions.size();
@@ -128,7 +129,7 @@ void register_variable(const std::string &filename, const std::string& shortname
   }
   register_variable_c2f(filename.c_str(), shortname.c_str(), longname.c_str(),
                         units.c_str(), numdims, var_dimensions_c.data(),
-                        dtype, pio_decomp_tag.c_str());
+                        nctype(dtype), pio_decomp_tag.c_str());
 }
 /* ----------------------------------------------------------------- */
 void set_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, const std::string& meta_val) {

--- a/components/scream/src/share/io/scream_scorpio_interface.cpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.cpp
@@ -5,7 +5,10 @@
 #include "ekat/ekat_assert.hpp"
 #include "share/scream_types.hpp"
 
+#include <pio.h>
+
 #include <string>
+
 
 using scream::Real;
 using scream::Int;
@@ -15,13 +18,17 @@ extern "C" {
   void register_file_c2f(const char*&& filename, const int& mode);
   void set_decomp_c2f(const char*&& filename);
   void set_dof_c2f(const char*&& filename,const char*&& varname,const Int dof_len,const std::int64_t *x_dof);
-  void grid_read_data_array_c2f(const char*&& filename, const char*&& varname, const Int time_index, void *&hbuf);
+  void grid_read_data_array_c2f_int(const char*&& filename, const char*&& varname, const Int time_index, int *buf, const int buf_size);
+  void grid_read_data_array_c2f_float(const char*&& filename, const char*&& varname, const Int time_index, float *buf, const int buf_size);
+  void grid_read_data_array_c2f_double(const char*&& filename, const char*&& varname, const Int time_index, double *buf, const int buf_size);
 
-  void grid_write_data_array_c2f_real(const char*&& filename, const char*&& varname, const Real*& hbuf);
+  void grid_write_data_array_c2f_int(const char*&& filename, const char*&& varname, const int* buf, const int buf_size);
+  void grid_write_data_array_c2f_float(const char*&& filename, const char*&& varname, const float* buf, const int buf_size);
+  void grid_write_data_array_c2f_double(const char*&& filename, const char*&& varname, const double* buf, const int buf_size);
   void eam_init_pio_subsystem_c2f(const int mpicom, const int atm_id);
   void eam_pio_finalize_c2f();
   void eam_pio_closefile_c2f(const char*&& filename);
-  void pio_update_time_c2f(const char*&& filename,const Real time);
+  void pio_update_time_c2f(const char*&& filename,const double time);
   void register_dimension_c2f(const char*&& filename, const char*&& shortname, const char*&& longname, const int length);
   void register_variable_c2f(const char*&& filename,const char*&& shortname, const char*&& longname, const char*&& units, const int numdims, const char** var_dimensions, const int dtype, const char*&& pio_decomp_tag);
   void set_variable_metadata_c2f (const char*&& filename, const char*&& varname, const char*&& meta_name, const char*&& meta_val);
@@ -31,6 +38,24 @@ extern "C" {
 
 namespace scream {
 namespace scorpio {
+
+int nctype (const std::string& type) {
+  if (type=="int") {
+    return PIO_INT;
+  } else if (type=="float" || type=="single") {
+    return PIO_FLOAT;
+  } else if (type=="double") {
+    return PIO_DOUBLE;
+  } else if (type=="real") {
+#if defined(SCREAM_DOUBLE_PRECISION)
+    return PIO_DOUBLE;
+#else
+    return PIO_FLOAT;
+#endif
+  } else {
+    EKAT_ERROR_MSG ("Error! Unrecognized/unsupported data type '" + type + "'.\n");
+  }
+}
 /* ----------------------------------------------------------------- */
 
 void eam_init_pio_subsystem(const int mpicom, const int atm_id) {
@@ -65,7 +90,7 @@ void set_dof(const std::string& filename, const std::string& varname, const Int 
   set_dof_c2f(filename.c_str(),varname.c_str(),dof_len,x_dof);
 }
 /* ----------------------------------------------------------------- */
-void pio_update_time(const std::string& filename, const Real time) {
+void pio_update_time(const std::string& filename, const double time) {
 
   pio_update_time_c2f(filename.c_str(),time);
 }
@@ -116,13 +141,33 @@ void eam_pio_enddef(const std::string &filename) {
   eam_pio_enddef_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
-void grid_read_data_array(const std::string &filename, const std::string &varname,
-                          const int time_index, void *hbuf) {
-  grid_read_data_array_c2f(filename.c_str(),varname.c_str(),time_index,hbuf);
+template<>
+void grid_read_data_array<int>(const std::string &filename, const std::string &varname,
+                          const int time_index, int *hbuf, const int buf_size) {
+  grid_read_data_array_c2f_int(filename.c_str(),varname.c_str(),time_index,hbuf,buf_size);
+}
+template<>
+void grid_read_data_array<float>(const std::string &filename, const std::string &varname,
+                                const int time_index, float *hbuf, const int buf_size) {
+  grid_read_data_array_c2f_float(filename.c_str(),varname.c_str(),time_index,hbuf,buf_size);
+}
+template<>
+void grid_read_data_array<double>(const std::string &filename, const std::string &varname,
+                                  const int time_index, double *hbuf, const int buf_size) {
+  grid_read_data_array_c2f_double(filename.c_str(),varname.c_str(),time_index,hbuf,buf_size);
 }
 /* ----------------------------------------------------------------- */
-void grid_write_data_array(const std::string &filename, const std::string &varname, const Real* hbuf) {
-  grid_write_data_array_c2f_real(filename.c_str(),varname.c_str(),hbuf);
+template<>
+void grid_write_data_array<int>(const std::string &filename, const std::string &varname, const int* hbuf, const int buf_size) {
+  grid_write_data_array_c2f_int(filename.c_str(),varname.c_str(),hbuf,buf_size);
+}
+template<>
+void grid_write_data_array<float>(const std::string &filename, const std::string &varname, const float* hbuf, const int buf_size) {
+  grid_write_data_array_c2f_float(filename.c_str(),varname.c_str(),hbuf,buf_size);
+}
+template<>
+void grid_write_data_array<double>(const std::string &filename, const std::string &varname, const double* hbuf, const int buf_size) {
+  grid_write_data_array_c2f_double(filename.c_str(),varname.c_str(),hbuf,buf_size);
 }
 /* ----------------------------------------------------------------- */
 } // namespace scorpio

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -38,11 +38,9 @@ namespace scorpio {
   /* Register a dimension coordinate with a file. Called during the file setup. */
   void register_dimension(const std::string& filename,const std::string& shortname, const std::string& longname, const int length);
   /* Register a variable with a file.  Called during the file setup, for an output stream. */
-  void register_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
   void register_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
   void set_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, const std::string& meta_val);
   /* Register a variable with a file.  Called during the file setup, for an input stream. */
-  void get_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const char**&& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
   void get_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
   /* End the definition phase for a scorpio file.  Last thing called after all dimensions, variables, dof's and decomps have been set.  Called once per file.
    * Mandatory before writing or reading can happend on file. */

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -4,26 +4,18 @@
 #include "ekat/util/ekat_string_utils.hpp"
 #include "share/field/field_tag.hpp"
 #include "share/scream_types.hpp"
+
 #include <vector>
 
 /* C++/F90 bridge to F90 SCORPIO routines */
-
-// TODO, figure out a better way to define netCDF output type for fields
-#ifdef SCREAM_CONFIG_IS_CMAKE
-#  ifdef SCREAM_DOUBLE_PRECISION
-  static constexpr int PIO_REAL = 6;
-#  else
-  static constexpr int PIO_REAL = 5;
-#  endif // SCREAM_DOUBLE_PRECISION
-#else // SCREAM_CONFIG_IS_CMAKE
-  static constexpr int PIO_REAL = 6;
-#endif // SCREAM_CONFIG_IS_CMAKE
-static constexpr int PIO_INT = 4;
 
 namespace scream {
 namespace scorpio {
 
   using offset_t = std::int64_t;
+
+  // Retrieve the int codes PIO uses to specify data types
+  int nctype (const std::string& type);
 
   // WARNING: these values must match the ones of file_purpose_in and file_purpose_out
   // in the scream_scorpio_interface F90 module
@@ -56,16 +48,18 @@ namespace scorpio {
    * Mandatory before writing or reading can happend on file. */
   void eam_pio_enddef(const std::string &filename);
   /* Called each timestep to update the timesnap for the last written output. */
-  void pio_update_time(const std::string &filename, const Real time);
+  void pio_update_time(const std::string &filename, const double time);
 
   // Read data for a specific variable from a specific file. To read data that
   // isn't associated with a time index, or to read data at the most recent
   // time, set time_index to -1. Otherwise use the proper zero-based time index.
+  template<typename T>
   void grid_read_data_array (const std::string &filename, const std::string &varname,
-                             const int time_index, void* hbuf);
+                             const int time_index, T* hbuf, const int buf_size);
   /* Write data for a specific variable to a specific file. */
+  template<typename T>
   void grid_write_data_array(const std::string &filename, const std::string &varname,
-                             const Real* hbuf);
+                             const T* hbuf, const int buf_size);
 
 extern "C" {
   /* Query whether the pio subsystem is inited or not */

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -37,7 +37,7 @@ namespace scorpio {
   /* Register a variable with a file.  Called during the file setup, for an output stream. */
   void register_variable(const std::string& filename, const std::string& shortname, const std::string& longname,
                          const std::string& units, const std::vector<std::string>& var_dimensions,
-                         const std::string& dtype, const std::string& pio_decomp_tag);
+                         const std::string& dtype, const std::string& nc_dtype, const std::string& pio_decomp_tag);
   void set_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, const std::string& meta_val);
   /* Register a variable with a file.  Called during the file setup, for an input stream. */
   void get_variable(const std::string& filename,const std::string& shortname, const std::string& longname,

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -38,10 +38,14 @@ namespace scorpio {
   /* Register a dimension coordinate with a file. Called during the file setup. */
   void register_dimension(const std::string& filename,const std::string& shortname, const std::string& longname, const int length);
   /* Register a variable with a file.  Called during the file setup, for an output stream. */
-  void register_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const std::string& units, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
+  void register_variable(const std::string& filename, const std::string& shortname, const std::string& longname,
+                         const std::string& units, const std::vector<std::string>& var_dimensions,
+                         const int dtype, const std::string& pio_decomp_tag);
   void set_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, const std::string& meta_val);
   /* Register a variable with a file.  Called during the file setup, for an input stream. */
-  void get_variable(const std::string& filename,const std::string& shortname, const std::string& longname, const int numdims, const std::vector<std::string>& var_dimensions, const int dtype, const std::string& pio_decomp_tag);
+  void get_variable(const std::string& filename,const std::string& shortname, const std::string& longname,
+                    const std::vector<std::string>& var_dimensions,
+                    const int dtype, const std::string& pio_decomp_tag);
   /* End the definition phase for a scorpio file.  Last thing called after all dimensions, variables, dof's and decomps have been set.  Called once per file.
    * Mandatory before writing or reading can happend on file. */
   void eam_pio_enddef(const std::string &filename);

--- a/components/scream/src/share/io/scream_scorpio_interface.hpp
+++ b/components/scream/src/share/io/scream_scorpio_interface.hpp
@@ -14,9 +14,6 @@ namespace scorpio {
 
   using offset_t = std::int64_t;
 
-  // Retrieve the int codes PIO uses to specify data types
-  int nctype (const std::string& type);
-
   // WARNING: these values must match the ones of file_purpose_in and file_purpose_out
   // in the scream_scorpio_interface F90 module
   enum FileMode {
@@ -40,12 +37,12 @@ namespace scorpio {
   /* Register a variable with a file.  Called during the file setup, for an output stream. */
   void register_variable(const std::string& filename, const std::string& shortname, const std::string& longname,
                          const std::string& units, const std::vector<std::string>& var_dimensions,
-                         const int dtype, const std::string& pio_decomp_tag);
+                         const std::string& dtype, const std::string& pio_decomp_tag);
   void set_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, const std::string& meta_val);
   /* Register a variable with a file.  Called during the file setup, for an input stream. */
   void get_variable(const std::string& filename,const std::string& shortname, const std::string& longname,
                     const std::vector<std::string>& var_dimensions,
-                    const int dtype, const std::string& pio_decomp_tag);
+                    const std::string& dtype, const std::string& pio_decomp_tag);
   /* End the definition phase for a scorpio file.  Last thing called after all dimensions, variables, dof's and decomps have been set.  Called once per file.
    * Mandatory before writing or reading can happend on file. */
   void eam_pio_enddef(const std::string &filename);

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -171,7 +171,9 @@ contains
     call set_int_attribute(file_name,attr_name,val)
   end subroutine set_int_attribute_c2f
 !=====================================================================!
-  subroutine register_variable_c2f(filename_in, shortname_in, longname_in, units_in, numdims, var_dimensions_in, dtype, pio_decomp_tag_in) bind(c)
+  subroutine register_variable_c2f(filename_in, shortname_in, longname_in, &
+                                   units_in, numdims, var_dimensions_in,   &
+                                   dtype, nc_dtype, pio_decomp_tag_in) bind(c)
     use scream_scorpio_interface, only : register_variable
     type(c_ptr), intent(in)                :: filename_in
     type(c_ptr), intent(in)                :: shortname_in
@@ -179,7 +181,7 @@ contains
     type(c_ptr), intent(in)                :: units_in
     integer(kind=c_int), value, intent(in) :: numdims
     type(c_ptr), intent(in)                :: var_dimensions_in(numdims)
-    integer(kind=c_int), value, intent(in) :: dtype
+    integer(kind=c_int), value, intent(in) :: dtype, nc_dtype
     type(c_ptr), intent(in)                :: pio_decomp_tag_in
 
     character(len=256) :: filename
@@ -199,7 +201,7 @@ contains
       call convert_c_string(var_dimensions_in(ii), var_dimensions(ii))
     end do
 
-    call register_variable(filename,shortname,longname,units,numdims,var_dimensions,dtype,pio_decomp_tag)
+    call register_variable(filename,shortname,longname,units,numdims,var_dimensions,dtype,nc_dtype,pio_decomp_tag)
 
   end subroutine register_variable_c2f
 !=====================================================================!

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -103,7 +103,7 @@ contains
   subroutine pio_update_time_c2f(filename_in,time) bind(c)
     use scream_scorpio_interface, only : eam_update_time
     type(c_ptr), intent(in) :: filename_in
-    real(kind=c_real), value, intent(in) :: time
+    real(kind=c_double), value, intent(in) :: time
 
     character(len=256)       :: filename
 
@@ -281,37 +281,107 @@ contains
 
   end subroutine convert_c_string
 !=====================================================================!
-  subroutine grid_write_data_array_c2f_real(filename_in,varname_in,var_data_ptr) bind(c)
+  subroutine grid_write_data_array_c2f_int(filename_in,varname_in,buf,buf_size) bind(c)
     use scream_scorpio_interface, only: grid_write_data_array
 
     type(c_ptr), intent(in) :: filename_in
     type(c_ptr), intent(in) :: varname_in
-    type(c_ptr), intent(in) :: var_data_ptr
+    integer(kind=c_int), intent(in), value :: buf_size
+    integer(kind=c_int), intent(in) :: buf(buf_size)
 
     character(len=256) :: filename
     character(len=256) :: varname
 
     call convert_c_string(filename_in,filename)
     call convert_c_string(varname_in,varname)
-    call grid_write_data_array(filename,varname,var_data_ptr)
+    call grid_write_data_array(filename,varname,buf,buf_size)
 
-  end subroutine grid_write_data_array_c2f_real
+  end subroutine grid_write_data_array_c2f_int
+  subroutine grid_write_data_array_c2f_float(filename_in,varname_in,buf,buf_size) bind(c)
+    use scream_scorpio_interface, only: grid_write_data_array
+
+    type(c_ptr), intent(in) :: filename_in
+    type(c_ptr), intent(in) :: varname_in
+    integer(kind=c_int), intent(in), value :: buf_size
+    real(kind=c_float), intent(in) :: buf(buf_size)
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_write_data_array(filename,varname,buf,buf_size)
+
+  end subroutine grid_write_data_array_c2f_float
+  subroutine grid_write_data_array_c2f_double(filename_in,varname_in,buf,buf_size) bind(c)
+    use scream_scorpio_interface, only: grid_write_data_array
+
+    type(c_ptr), intent(in) :: filename_in
+    type(c_ptr), intent(in) :: varname_in
+    integer(kind=c_int), intent(in), value :: buf_size
+    real(kind=c_double), intent(in) :: buf(buf_size)
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_write_data_array(filename,varname,buf,buf_size)
+
+  end subroutine grid_write_data_array_c2f_double
 !=====================================================================!
-  subroutine grid_read_data_array_c2f(filename_in,varname_in,time_index,var_data_ptr) bind(c)
+  subroutine grid_read_data_array_c2f_int(filename_in,varname_in,time_index,buf,buf_size) bind(c)
     use scream_scorpio_interface, only: grid_read_data_array
 
     type(c_ptr), intent(in) :: filename_in
     type(c_ptr), intent(in) :: varname_in
     integer(kind=c_int), value, intent(in) :: time_index ! zero-based
-    type(c_ptr), intent(in) :: var_data_ptr
+    integer(kind=c_int), intent(in), value :: buf_size
+    integer(kind=c_int), intent(out) :: buf(buf_size)
 
     character(len=256) :: filename
     character(len=256) :: varname
 
     call convert_c_string(filename_in,filename)
     call convert_c_string(varname_in,varname)
-    call grid_read_data_array(filename,varname,var_data_ptr,time_index+1)
+    call grid_read_data_array(filename,varname,buf,buf_size,time_index+1)
 
-  end subroutine grid_read_data_array_c2f
+  end subroutine grid_read_data_array_c2f_int
+!=====================================================================!
+  subroutine grid_read_data_array_c2f_float(filename_in,varname_in,time_index,buf,buf_size) bind(c)
+    use scream_scorpio_interface, only: grid_read_data_array
+
+    type(c_ptr), intent(in) :: filename_in
+    type(c_ptr), intent(in) :: varname_in
+    integer(kind=c_int), value, intent(in) :: time_index ! zero-based
+    integer(kind=c_int), intent(in), value :: buf_size
+    real(kind=c_float), intent(out) :: buf(buf_size)
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_read_data_array(filename,varname,buf,buf_size,time_index+1)
+
+  end subroutine grid_read_data_array_c2f_float
+!=====================================================================!
+  subroutine grid_read_data_array_c2f_double(filename_in,varname_in,time_index,buf,buf_size) bind(c)
+    use scream_scorpio_interface, only: grid_read_data_array
+
+    type(c_ptr), intent(in) :: filename_in
+    type(c_ptr), intent(in) :: varname_in
+    integer(kind=c_int), value, intent(in) :: time_index ! zero-based
+    integer(kind=c_int), intent(in), value :: buf_size
+    real(kind=c_double), intent(out) :: buf(buf_size)
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call grid_read_data_array(filename,varname,buf,buf_size,time_index+1)
+
+  end subroutine grid_read_data_array_c2f_double
 !=====================================================================!
 end module scream_scorpio_interface_iso_c2f

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -161,12 +161,15 @@ void run_multisnap(const std::string& output_freq_units) {
     // Re-create the fm anew, so the fields are re-inited for each output type
     auto field_manager = get_test_fm(grid);
     field_manager->init_fields_time_stamp(t0);
+
     // Set up parameter list control for output
     ekat::ParameterList params;
     ekat::parse_yaml_file("io_test_" + output_type + ".yaml",params);
+    params.set<std::string>("Floating Point Precision","real");
     auto& params_sub = params.sublist("output_control");
     params_sub.set<std::string>("frequency_units",output_freq_units);
     io_control.frequency = params_sub.get<int>("Frequency");
+
     // Set up output manager.
     OutputManager om;
     om.setup(io_comm,params,field_manager,gm,t0,t0,false);
@@ -604,6 +607,8 @@ ekat::ParameterList get_in_params(const std::string& type,
 
   in_params.set<std::string>("Filename",filename);
   in_params.set<vos_type>("Field Names",{"field_1", "field_2", "field_3", "field_packed"});
+  in_params.set<std::string>("Floating Point Precision","real");
+
   return in_params;
 }
 /*========================================================================================================*/
@@ -630,6 +635,7 @@ get_diagnostic_input(const ekat::Comm& comm, const std::shared_ptr<GridsManager>
   ekat::ParameterList in_params;
   in_params.set("Field Names",fnames);
   in_params.set("Filename",filename);
+  in_params.set<std::string>("Floating Point Precision","real");
   AtmosphereInput input(comm,in_params);
   input.init(grid,host_views,layouts);
   input.read_variables(time_index);

--- a/components/scream/src/share/io/tests/io_se_grid.cpp
+++ b/components/scream/src/share/io/tests/io_se_grid.cpp
@@ -58,6 +58,7 @@ TEST_CASE("se_grid_io")
   auto fm0 = get_test_fm(grid,t0,true);
   ekat::ParameterList params;
   ekat::parse_yaml_file("io_test_se_grid.yaml",params);
+  params.set<std::string>("Floating Point Precision","real");
 
   OutputManager om;
   om.setup(io_comm,params,fm0,gm,t0,t0,false);
@@ -173,6 +174,7 @@ ekat::ParameterList get_in_params(const ekat::Comm& comm,
 
   in_params.set<std::string>("Filename",filename);
   in_params.set<vos_type>("Field Names",{"field_1", "field_2", "field_3", "field_packed"});
+  in_params.set<std::string>("Floating Point Precision","real");
   return in_params;
 }
 

--- a/components/scream/src/share/io/tests/output_restart.cpp
+++ b/components/scream/src/share/io/tests/output_restart.cpp
@@ -70,6 +70,7 @@ TEST_CASE("output_restart","io")
   std::string param_filename = "io_test_restart.yaml";
   ekat::ParameterList output_params;
   ekat::parse_yaml_file(param_filename,output_params);
+  output_params.set<std::string>("Floating Point Precision","real");
   OutputManager output_manager;
   output_manager.setup(io_comm,output_params,field_manager,gm,t0,t0,false);
 
@@ -137,6 +138,7 @@ TEST_CASE("output_restart","io")
 
   ekat::ParameterList output_params_res;
   ekat::parse_yaml_file(param_filename_res,output_params_res);
+  output_params_res.set<std::string>("Floating Point Precision","real");
 
   OutputManager output_manager_res;
   output_manager_res.setup(io_comm,output_params_res,fm_res,gm,time_res,t0,false);

--- a/components/scream/src/share/util/scream_time_stamp.cpp
+++ b/components/scream/src/share/util/scream_time_stamp.cpp
@@ -92,7 +92,7 @@ bool TimeStamp::is_valid () const {
   return !(*this==TimeStamp());
 }
 
-int TimeStamp::seconds_from (const TimeStamp& ts) const {
+std::int64_t TimeStamp::seconds_from (const TimeStamp& ts) const {
   return *this-ts;
 }
 
@@ -224,12 +224,12 @@ TimeStamp operator+ (const TimeStamp& ts, const int dt) {
   return sum;
 }
 
-long long operator- (const TimeStamp& ts1, const TimeStamp& ts2) {
+std::int64_t operator- (const TimeStamp& ts1, const TimeStamp& ts2) {
   if (ts1<ts2) {
     return -(ts2-ts1);
   }
 
-  long long diff = 0;
+  std::int64_t diff = 0;
   const auto y1 = ts1.get_year();
   const auto y2 = ts2.get_year();
   const auto m1 = ts1.get_month();

--- a/components/scream/src/share/util/scream_time_stamp.hpp
+++ b/components/scream/src/share/util/scream_time_stamp.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace scream {
 namespace util {
@@ -35,7 +36,7 @@ public:
   bool is_valid    () const;
 
   int sec_of_day () const { return m_time[0]*3600 + m_time[1]*60 + m_time[2]; }
-  int seconds_from (const TimeStamp& ts) const;
+  std::int64_t seconds_from (const TimeStamp& ts) const;
   double days_from (const TimeStamp& ts) const;
 
   std::string to_string () const;
@@ -69,7 +70,7 @@ bool operator<= (const TimeStamp& ts1, const TimeStamp& ts2);
 TimeStamp operator+ (const TimeStamp& ts, const int dt);
 
 // Difference (in seconds) between two timestamps
-long long operator- (const TimeStamp& ts1, const TimeStamp& ts2);
+std::int64_t operator- (const TimeStamp& ts1, const TimeStamp& ts2);
 
 // Time-related free-functions
 int days_in_month (const int year, const int month);


### PR DESCRIPTION
I reverted the revert of the single precision PR, and added fixes that remove the temporary arrays copies.