### PR TITLE
Add cloning capability to AbstractGrid

### DIFF
--- a/components/scream/src/share/grid/abstract_grid.cpp
+++ b/components/scream/src/share/grid/abstract_grid.cpp
@@ -239,6 +239,13 @@ AbstractGrid::get_geometry_data_names () const
   return names;
 }
 
+void AbstractGrid::reset_num_vertical_lev (const int num_vertical_lev) {
+  m_num_vert_levs = num_vertical_lev;
+
+  // TODO: when the PR storing geo data as Field goes in, you should
+  //       invalidate all geo data whose FieldLayout contains LEV/ILEV
+}
+
 void AbstractGrid::copy_views (const AbstractGrid& src, const bool shallow)
 {
   if (src.m_dofs_set) {

--- a/components/scream/src/share/grid/abstract_grid.hpp
+++ b/components/scream/src/share/grid/abstract_grid.hpp
@@ -128,6 +128,8 @@ public:
 
   std::list<std::string> get_geometry_data_names () const;
 
+  virtual std::shared_ptr<AbstractGrid> clone (const std::string& clone_name,
+                                               const bool shallow) const = 0;
 protected:
 
   // Derived classes can override these methods, which are called inside the
@@ -137,6 +139,8 @@ protected:
   // some extra consistency check.
   virtual bool valid_dofs_list (const dofs_list_type& /*dofs_gids*/)      const { return true; }
   virtual bool valid_lid_to_idx_map (const lid_to_idx_map_type& /*lid_to_idx*/) const { return true; }
+
+  void copy_views (const AbstractGrid& src, const bool shallow = true);
 
 private:
 

--- a/components/scream/src/share/grid/abstract_grid.hpp
+++ b/components/scream/src/share/grid/abstract_grid.hpp
@@ -130,6 +130,8 @@ public:
 
   virtual std::shared_ptr<AbstractGrid> clone (const std::string& clone_name,
                                                const bool shallow) const = 0;
+
+  void reset_num_vertical_lev (const int num_vertical_lev);
 protected:
 
   // Derived classes can override these methods, which are called inside the

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -63,6 +63,15 @@ PointGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag
   return FieldLayout({COL,vector_tag,VL},{get_num_local_dofs(),vector_dim,nvl});
 }
 
+std::shared_ptr<AbstractGrid>
+PointGrid::clone (const std::string& clone_name,
+                  const bool shallow) const
+{
+  auto grid = std::make_shared<PointGrid> (clone_name,get_num_local_dofs(),get_num_vertical_levels(),get_comm());
+  grid->copy_views(*this,shallow);
+  return grid;
+}
+
 std::shared_ptr<PointGrid>
 create_point_grid (const std::string& grid_name,
                    const int num_global_cols,

--- a/components/scream/src/share/grid/point_grid.hpp
+++ b/components/scream/src/share/grid/point_grid.hpp
@@ -51,6 +51,9 @@ public:
   int get_partitioned_dim_global_size () const override {
     return get_num_global_dofs();
   }
+
+  std::shared_ptr<AbstractGrid> clone (const std::string& clone_name,
+                                       const bool shallow) const override;
 };
 
 // Create a point grid, with linear range of gids, evenly partitioned

--- a/components/scream/src/share/grid/se_grid.cpp
+++ b/components/scream/src/share/grid/se_grid.cpp
@@ -73,6 +73,25 @@ void SEGrid::set_cg_dofs (const dofs_list_type& cg_dofs)
   m_cg_dofs_set = true;
 }
 
+std::shared_ptr<AbstractGrid> SEGrid::clone (const std::string& clone_name, const bool shallow) const
+{
+  auto grid = std::make_shared<SEGrid>(clone_name,m_num_local_elem,m_num_gp,get_num_vertical_levels(),get_comm());
+
+  grid->copy_views(*this,shallow);
+
+  if (m_cg_dofs_set) {
+    if (shallow) {
+      grid->set_cg_dofs(m_cg_dofs_gids);
+    } else {
+      decltype(m_cg_dofs_gids) cg_dofs ("",m_cg_dofs_gids.size());
+      Kokkos::deep_copy(cg_dofs,m_cg_dofs_gids);
+      grid->set_cg_dofs(cg_dofs);
+    }
+  }
+
+  return grid;
+}
+
 bool SEGrid::valid_dofs_list (const dofs_list_type& /*dofs_gids*/) const
 {
   return is_unique();

--- a/components/scream/src/share/grid/se_grid.hpp
+++ b/components/scream/src/share/grid/se_grid.hpp
@@ -39,6 +39,9 @@ public:
   void set_cg_dofs (const dofs_list_type& cg_dofs);
   const dofs_list_type& get_cg_dofs_gids () const;
 
+  std::shared_ptr<AbstractGrid> clone (const std::string& clone_name,
+                                       const bool shallow) const override;
+
 protected:
   bool valid_dofs_list (const dofs_list_type& dofs_gids)      const override;
   bool valid_lid_to_idx_map (const lid_to_idx_map_type& lid_to_idx) const override;

--- a/components/scream/src/share/tests/grid_tests.cpp
+++ b/components/scream/src/share/tests/grid_tests.cpp
@@ -55,6 +55,9 @@ TEST_CASE("point_grid", "") {
   for (int i=0; i<grid->get_num_local_dofs(); ++i) {
     REQUIRE (deep_copy->get_dofs_gids_host()[i]==grid->get_dofs_gids_host()[i]);
   }
+
+  shallow_copy->reset_num_vertical_lev(4);
+  REQUIRE (shallow_copy->get_num_vertical_levels()==4);
 }
 
 TEST_CASE("se_grid", "") {

--- a/components/scream/src/share/tests/grid_tests.cpp
+++ b/components/scream/src/share/tests/grid_tests.cpp
@@ -46,6 +46,15 @@ TEST_CASE("point_grid", "") {
   auto layout = grid->get_2d_scalar_layout();
   REQUIRE(layout.tags().size() == 1);
   REQUIRE(layout.tag(0) == COL);
+
+  auto shallow_copy = grid->clone("shallow",true);
+  auto deep_copy    = grid->clone("shallow",false);
+
+  REQUIRE (shallow_copy->get_dofs_gids().data()==grid->get_dofs_gids().data());
+  REQUIRE (deep_copy->get_dofs_gids().data()!=grid->get_dofs_gids().data());
+  for (int i=0; i<grid->get_num_local_dofs(); ++i) {
+    REQUIRE (deep_copy->get_dofs_gids_host()[i]==grid->get_dofs_gids_host()[i]);
+  }
 }
 
 TEST_CASE("se_grid", "") {
@@ -77,6 +86,15 @@ TEST_CASE("se_grid", "") {
   const auto max_gid = se_grid->get_global_max_dof_gid();
   const auto min_gid = se_grid->get_global_min_dof_gid();
   REQUIRE( (max_gid-min_gid+1)==se_grid->get_num_global_dofs() );
+
+  auto shallow_copy = se_grid->clone("shallow",true);
+  auto deep_copy    = se_grid->clone("shallow",false);
+
+  REQUIRE (shallow_copy->get_dofs_gids().data()==se_grid->get_dofs_gids().data());
+  REQUIRE (deep_copy->get_dofs_gids().data()!=se_grid->get_dofs_gids().data());
+  for (int i=0; i<se_grid->get_num_local_dofs(); ++i) {
+    REQUIRE (deep_copy->get_dofs_gids_host()[i]==se_grid->get_dofs_gids_host()[i]);
+  }
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Together with `reset_num_vertical_lev()`, one can use the `clone` method to create a grid object with a different number of levels (to be used, e.g., for I/O regridding).