### PR TITLE
SHOC: Use another team_barrier based on view_reduction pattern.

### DIFF
--- a/components/scream/src/physics/shoc/shoc_compute_l_inf_shoc_length_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_l_inf_shoc_length_impl.hpp
@@ -25,6 +25,7 @@ void Functions<S,D>
                                 [&] (const int k) -> Spack {
     return ekat::sqrt(tke(k))*zt_grid(k)*dz_zt(k);
   }, numer);
+  team.team_barrier(); // see comment in shoc_energy_integrals_impl.hpp
 
   // Compute denominator
   Scalar denom = 0;


### PR DESCRIPTION
This one is based just on grepping. We know there is still a failure somewhere. I've isolated it again to SHOC on ascent but haven't yet gotten direct evidence of the detailed source. But grepping the text showed these adjacent reductions, which I identified in #1921 as a problem.

Associated with #1917.