### PR TITLE
Bugfix to re-initialize views in output after each write step

### DIFF
--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -434,23 +434,33 @@ void AtmosphereOutput::register_views()
       m_dev_views_1d.emplace(name,view_1d_dev("",size));
       m_host_views_1d.emplace(name,Kokkos::create_mirror(m_dev_views_1d[name]));
 
-      // Init dev view with an "identity" for avg_type
-      switch (m_avg_type) {
-        case OutputAvgType::Instant:
-          // No averaging
-          break;
-        case OutputAvgType::Max:
-          Kokkos::deep_copy(m_dev_views_1d[name],-std::numeric_limits<Real>::infinity());
-          break;
-        case OutputAvgType::Min:
-          Kokkos::deep_copy(m_dev_views_1d[name],std::numeric_limits<Real>::infinity());
-          break;
-        case OutputAvgType::Average:
-          Kokkos::deep_copy(m_dev_views_1d[name],0);
-          break;
-        default:
-          EKAT_ERROR_MSG ("Unrecognized averaging type.\n");
-      }
+    }
+  }
+  // Initialize the local views
+  initialize_dev_views();
+}
+/* ---------------------------------------------------------- */
+void AtmosphereOutput::
+initialize_dev_views()
+{
+  // Reset the local device views depending on the averaging type
+  // Init dev view with an "identity" for avg_type
+  for (auto const& name : m_fields_names) {
+    switch (m_avg_type) {
+      case OutputAvgType::Instant:
+        // No averaging
+        break;
+      case OutputAvgType::Max:
+        Kokkos::deep_copy(m_dev_views_1d[name],-std::numeric_limits<Real>::infinity());
+        break;
+      case OutputAvgType::Min:
+        Kokkos::deep_copy(m_dev_views_1d[name],std::numeric_limits<Real>::infinity());
+        break;
+      case OutputAvgType::Average:
+        Kokkos::deep_copy(m_dev_views_1d[name],0);
+        break;
+      default:
+        EKAT_ERROR_MSG ("Unrecognized averaging type.\n");
     }
   }
 }

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -437,11 +437,11 @@ void AtmosphereOutput::register_views()
     }
   }
   // Initialize the local views
-  initialize_dev_views();
+  reset_dev_views();
 }
 /* ---------------------------------------------------------- */
 void AtmosphereOutput::
-initialize_dev_views()
+reset_dev_views()
 {
   // Reset the local device views depending on the averaging type
   // Init dev view with an "identity" for avg_type

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -141,7 +141,7 @@ public:
   // Main Functions
   void restart (const std::string& filename);
   void init();
-  void initialize_dev_views();
+  void reset_dev_views();
   void setup_output_file (const std::string& filename, const std::string& fp_precision);
   void run (const std::string& filename, const bool write, const int nsteps_since_last_output);
   void finalize() {}

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -141,6 +141,7 @@ public:
   // Main Functions
   void restart (const std::string& filename);
   void init();
+  void initialize_dev_views();
   void setup_output_file (const std::string& filename, const std::string& fp_precision);
   void run (const std::string& filename, const bool write, const int nsteps_since_last_output);
   void finalize() {}

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -287,13 +287,13 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     // We're adding one snapshot to the file
     ++filespecs.num_snapshots_in_file;
 
-    // Since we wrote to file we need to reset the nsamples_since_last_write, the timestamp
+    // Since we wrote to file we need to reset the nsamples_since_last_write, the timestamp ...
     control.nsamples_since_last_write = 0;
     control.timestamp_of_last_write = timestamp;
-    // and the local views - unless it is a checkpoint step, then we keep local views.
+    // ... and the local views - unless it is a checkpoint step, then we keep local views.
     if (!is_checkpoint_step) {
       for (auto& it : m_output_streams) {
-        it->initialize_dev_views();
+        it->reset_dev_views();
       }
     }
 

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -287,12 +287,15 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     // We're adding one snapshot to the file
     ++filespecs.num_snapshots_in_file;
 
-    // Now that we've written output to this file we need reset the nsteps.
-    control.nsamples_since_last_write = 0;
-
-    // Since we wrote to file we need to reset the nsamples_since_last_write and the timestamp
+    // Since we wrote to file we need to reset the nsamples_since_last_write, the timestamp
     control.nsamples_since_last_write = 0;
     control.timestamp_of_last_write = timestamp;
+    // and the local views - unless it is a checkpoint step, then we keep local views.
+    if (!is_checkpoint_step) {
+      for (auto& it : m_output_streams) {
+        it->initialize_dev_views();
+      }
+    }
 
     // Check if we need to close the output file
     if (filespecs.file_is_full()) {


### PR DESCRIPTION
This commit is a bugfix that was discovered when writing output for averaging type MIN over multiple output snaps.  We were not re-init the local views so the total minimum remained the same from snap to snap.

This commit has the output manager re-initialize local views in an output stream following each write of a timesnap.