### PR TITLE
EAMxx: add possibility to control atm procs log level in standalone test

### DIFF
--- a/components/scream/src/share/atm_process/atmosphere_process.cpp
+++ b/components/scream/src/share/atm_process/atmosphere_process.cpp
@@ -10,6 +10,26 @@
 namespace scream
 {
 
+ekat::logger::LogLevel str2LogLevel (const std::string& s) {
+  using namespace ekat::logger;
+
+  ekat::logger::LogLevel log_level;
+  if (s=="off") {
+    log_level = LogLevel::off;
+  } else if (s=="trace") {
+    log_level = LogLevel::trace;
+  } else if (s=="debug") {
+    log_level = LogLevel::debug;
+  } else if (s=="info") {
+    log_level = LogLevel::info;
+  } else if (s=="warn") {
+    log_level = LogLevel::warn;
+  } else {
+    EKAT_ERROR_MSG ("Invalid string value for log level: " + s + "\n");
+  }
+  return log_level;
+}
+
 AtmosphereProcess::
 AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
   : m_comm       (comm)
@@ -21,7 +41,8 @@ AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
     // Create a console-only logger, that logs all ranks
     using namespace ekat::logger;
     using logger_impl_t = Logger<LogNoFile,LogAllRanks>;
-    m_atm_logger = std::make_shared<logger_impl_t>("",LogLevel::trace,m_comm);
+    auto log_level = m_params.get<std::string>("log_level","trace");
+    m_atm_logger = std::make_shared<logger_impl_t>("",str2LogLevel(log_level),m_comm);
   }
 
   if (m_params.isParameter("number_of_subcycles")) {
@@ -33,20 +54,7 @@ AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
 
   m_timer_prefix = m_params.get<std::string>("Timer Prefix","EAMxx::");
 
-  const auto& repair_log_level = m_params.get<std::string>("repair_log_level","warn");
-  if (repair_log_level=="off") {
-    m_repair_log_level = LogLevel::off;
-  } else if (repair_log_level=="trace") {
-    m_repair_log_level = LogLevel::trace;
-  } else if (repair_log_level=="debug") {
-    m_repair_log_level = LogLevel::debug;
-  } else if (repair_log_level=="info") {
-    m_repair_log_level = LogLevel::info;
-  } else if (repair_log_level=="warn") {
-    m_repair_log_level = LogLevel::warn;
-  } else {
-    EKAT_ERROR_MSG ("Invalid value for 'repair_log_level': " + repair_log_level + "\n");
-  }
+  m_repair_log_level = str2LogLevel(m_params.get<std::string>("repair_log_level","warn"));
 }
 
 void AtmosphereProcess::initialize (const TimeStamp& t0, const RunType run_type) {

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -24,7 +24,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    enable_precondition_checks: false
     vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -20,8 +20,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    Process Name: Homme
-    enable_precondition_checks: false
     vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -21,7 +21,6 @@ atmosphere_processes:
   schedule_type: Sequential
   homme:
     Process Name: Homme
-    enable_precondition_checks: false
     vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -27,8 +27,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    Process Name: Homme
-    enable_precondition_checks: false
     vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -27,8 +27,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    Process Name: Homme
-    enable_precondition_checks: false
     vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -19,8 +19,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    Process Name: Homme
-    enable_precondition_checks: false
     vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:


### PR DESCRIPTION
Allows to limit output to screen due to property checks repair calls.