### PR TITLE
Minor bugfixes for solar insolation

### DIFF
--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -2692,6 +2692,7 @@ sub write_filepath
     } elsif ($rad eq 'rrtmgp') {
         print $fh "$camsrcdir/eam/src/physics/rrtmgp\n";
         if (not defined $opts{'rrtmgpxx'} ) {
+            print $fh "$camsrcdir/eam/src/physics/rrtmgp/f90\n";
             print $fh "$camsrcdir/eam/src/physics/rrtmgp/external/rte\n";
             print $fh "$camsrcdir/eam/src/physics/rrtmgp/external/rte/kernels\n";
             print $fh "$camsrcdir/eam/src/physics/rrtmgp/external/rrtmgp\n";
@@ -2699,7 +2700,6 @@ sub write_filepath
             print $fh "$camsrcdir/eam/src/physics/rrtmgp/external/extensions\n";
             print $fh "$camsrcdir/eam/src/physics/rrtmgp/external/extensions/rng\n";
             print $fh "$camsrcdir/eam/src/physics/rrtmgp/external/examples\n";
-            print $fh "$camsrcdir/eam/src/physics/rrtmgp/f90\n";
         }
     }
 

--- a/components/eam/src/physics/rrtmgp/cpp/CMakeLists.txt
+++ b/components/eam/src/physics/rrtmgp/cpp/CMakeLists.txt
@@ -1,8 +1,8 @@
 set (F90_SRC rrtmgp_interface.F90)
 set (CXX_SRC
     rrtmgp_interface.cpp
+    mo_load_coefficients.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../external/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../external/cpp/examples/mo_load_coefficients.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../external/cpp/examples/all-sky/mo_load_cloud_coefficients.cpp
 )
 

--- a/components/eam/src/physics/rrtmgp/cpp/mo_load_coefficients.cpp
+++ b/components/eam/src/physics/rrtmgp/cpp/mo_load_coefficients.cpp
@@ -1,0 +1,123 @@
+
+#include "mo_load_coefficients.h"
+#include "YAKL_netcdf.h"
+
+// This code is part of RRTM for GCM Applications - Parallel (RRTMGP)
+//
+// Contacts: Robert Pincus and Eli Mlawer
+// email:  rrtmgp@aer.com
+//
+// Copyright 2015-2018,  Atmospheric and Environmental Research and
+// Regents of the University of Colorado.  All right reserved.
+//
+// Use and duplication is permitted under the terms of the
+//    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
+// -------------------------------------------------------------------------------------------------
+
+void load_and_init(GasOpticsRRTMGP &kdist, std::string filename, GasConcs const &available_gases) {
+  yakl::SimpleNetCDF io;
+  io.open(filename , yakl::NETCDF_MODE_READ);
+
+  // Read the many arrays
+  string1d     gas_names;
+  string1d     gas_minor;
+  string1d     identifier_minor;
+  string1d     minor_gases_lower;
+  string1d     minor_gases_upper;
+  string1d     scaling_gas_lower;
+  string1d     scaling_gas_upper;
+  intHost3d    key_species;
+  realHost2d   band_lims;
+  intHost2d    band2gpt;
+  real         press_ref_trop;
+  real         temp_ref_p;
+  real         temp_ref_t;
+  realHost1d   press_ref;
+  realHost1d   temp_ref;
+  realHost3d   vmr_ref;
+  realHost4d   kmajor;
+  intHost2d    minor_limits_gpt_lower;
+  intHost2d    minor_limits_gpt_upper;
+  boolHost1d   minor_scales_with_density_lower;
+  boolHost1d   minor_scales_with_density_upper;
+  boolHost1d   scale_by_complement_lower;
+  boolHost1d   scale_by_complement_upper;
+  intHost1d    kminor_start_lower;
+  intHost1d    kminor_start_upper;
+  realHost3d   kminor_lower;
+  realHost3d   kminor_upper;
+  realHost3d   rayl_lower;
+  realHost3d   rayl_upper;
+
+  // Read in strings
+  charHost2d tmp;
+  tmp = charHost2d();  io.read( tmp , "gas_names"         );  gas_names         = char2d_to_string1d(tmp);
+  tmp = charHost2d();  io.read( tmp , "gas_minor"         );  gas_minor         = char2d_to_string1d(tmp);
+  tmp = charHost2d();  io.read( tmp , "identifier_minor"  );  identifier_minor  = char2d_to_string1d(tmp);
+  tmp = charHost2d();  io.read( tmp , "minor_gases_lower" );  minor_gases_lower = char2d_to_string1d(tmp);
+  tmp = charHost2d();  io.read( tmp , "minor_gases_upper" );  minor_gases_upper = char2d_to_string1d(tmp);
+  tmp = charHost2d();  io.read( tmp , "scaling_gas_lower" );  scaling_gas_lower = char2d_to_string1d(tmp);
+  tmp = charHost2d();  io.read( tmp , "scaling_gas_upper" );  scaling_gas_upper = char2d_to_string1d(tmp);
+
+  io.read( key_species                     , "key_species" );
+  io.read( band_lims                       , "bnd_limits_wavenumber" );
+  io.read( band2gpt                        , "bnd_limits_gpt" );
+  io.read( press_ref                       , "press_ref" );
+  io.read( temp_ref                        , "temp_ref" );
+  io.read( temp_ref_p                      , "absorption_coefficient_ref_P" );
+  io.read( temp_ref_t                      , "absorption_coefficient_ref_T" );
+  io.read( press_ref_trop                  , "press_ref_trop" );
+  io.read( kminor_lower                    , "kminor_lower" );
+  io.read( kminor_upper                    , "kminor_upper" );
+  io.read( minor_limits_gpt_lower          , "minor_limits_gpt_lower" );
+  io.read( minor_limits_gpt_upper          , "minor_limits_gpt_upper" );
+  io.read( minor_scales_with_density_lower , "minor_scales_with_density_lower" );
+  io.read( minor_scales_with_density_upper , "minor_scales_with_density_upper" );
+  io.read( scale_by_complement_lower       , "scale_by_complement_lower" );
+  io.read( scale_by_complement_upper       , "scale_by_complement_upper" );
+  io.read( kminor_start_lower              , "kminor_start_lower" );
+  io.read( kminor_start_upper              , "kminor_start_upper" );
+  io.read( vmr_ref                         , "vmr_ref" );
+  io.read( kmajor                          , "kmajor" );
+
+  if (io.varExists("rayl_lower")) {
+    io.read( rayl_lower , "rayl_lower" );
+    io.read( rayl_upper , "rayl_upper" );
+  }
+
+  // Initialize the gas optics class with data. The calls look slightly different depending
+  //   on whether the radiation sources are internal to the atmosphere (longwave) or external (shortwave)
+  // gas_optics%load() returns a string; a non-empty string indicates an error.
+  if (io.varExists("totplnk")) {
+    // If there's a totplnk variable in the file, then it's a longwave (internal sources) type
+    realHost2d totplnk;
+    realHost4d planck_frac;
+    io.read( totplnk     , "totplnk"        );
+    io.read( planck_frac , "plank_fraction" );
+    kdist.load(available_gases, gas_names, key_species, band2gpt, band_lims, press_ref, press_ref_trop, 
+               temp_ref, temp_ref_p, temp_ref_t, vmr_ref, kmajor, kminor_lower, kminor_upper, 
+               gas_minor, identifier_minor, minor_gases_lower, minor_gases_upper, 
+               minor_limits_gpt_lower, minor_limits_gpt_upper, minor_scales_with_density_lower, 
+               minor_scales_with_density_upper, scaling_gas_lower, scaling_gas_upper, 
+               scale_by_complement_lower, scale_by_complement_upper, kminor_start_lower, 
+               kminor_start_upper, totplnk, planck_frac, rayl_lower, rayl_upper);
+  } else {
+    // Otherwise, it's a shortwave type
+    realHost1d solar_src;
+    if (io.varExists("solar_source")) {
+        io.read( solar_src , "solar_source" );
+    } else {
+        io.read( solar_src , "solar_source_quiet" );
+    }
+    kdist.load(available_gases, gas_names, key_species, band2gpt, band_lims, press_ref, press_ref_trop, 
+               temp_ref, temp_ref_p, temp_ref_t, vmr_ref, kmajor, kminor_lower, kminor_upper, 
+               gas_minor, identifier_minor, minor_gases_lower, minor_gases_upper, 
+               minor_limits_gpt_lower, minor_limits_gpt_upper, minor_scales_with_density_lower, 
+               minor_scales_with_density_upper, scaling_gas_lower, scaling_gas_upper, 
+               scale_by_complement_lower, scale_by_complement_upper, kminor_start_lower, 
+               kminor_start_upper, solar_src, rayl_lower, rayl_upper);
+  }
+  io.close();
+}
+
+

--- a/components/eam/src/physics/rrtmgp/f90/mo_load_coefficients.F90
+++ b/components/eam/src/physics/rrtmgp/f90/mo_load_coefficients.F90
@@ -1,0 +1,241 @@
+! This code is part of RRTM for GCM Applications - Parallel (RRTMGP)
+!
+! Contacts: Robert Pincus and Eli Mlawer
+! email:  rrtmgp@aer.com
+!
+! Copyright 2015-2018,  Atmospheric and Environmental Research and
+! Regents of the University of Colorado.  All right reserved.
+!
+! Use and duplication is permitted under the terms of the
+!    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
+! -------------------------------------------------------------------------------------------------
+!
+! The gas optics class used by RRMTGP needs to be initialized with data stored in a netCDF file.
+!    RRTMGP itself doesn't include methods for reading the data so we don't conflict with users'
+!    local environment. This module provides a straight-forward implementation of reading the data
+!    and calling gas_optics%load().
+!
+! -------------------------------------------------------------------------------------------------
+module mo_load_coefficients
+  !
+  ! Modules for working with rte and rrtmgp
+  !
+  use mo_rte_kind,           only: wp, wl
+  use mo_gas_concentrations, only: ty_gas_concs
+  use mo_gas_optics_rrtmgp,  only: ty_gas_optics_rrtmgp
+  ! --------------------------------------------------
+  use mo_simple_netcdf, only: read_field, read_char_vec, read_logical_vec, var_exists, get_dim_size
+  use netcdf
+  implicit none
+  private
+  public :: load_and_init
+
+contains
+  subroutine stop_on_err(msg)
+    use iso_fortran_env, only : error_unit
+    character(len=*), intent(in) :: msg
+
+    if(msg /= "") then
+      write(error_unit, *) msg
+      stop
+    end if
+  end subroutine
+  !--------------------------------------------------------------------------------------------------------------------
+  ! read optical coefficients from NetCDF file
+  subroutine load_and_init(kdist, filename, available_gases)
+    class(ty_gas_optics_rrtmgp), intent(inout) :: kdist
+    character(len=*),     intent(in   ) :: filename
+    class(ty_gas_concs),  intent(in   ) :: available_gases ! Which gases does the host model have available?
+    ! --------------------------------------------------
+    !
+    ! Variables that will be passed to gas_optics%load()
+    !
+    character(len=32), dimension(:), allocatable :: gas_names
+    integer,  dimension(:,:,:),      allocatable :: key_species
+    integer,  dimension(:,:  ),      allocatable :: band2gpt
+    real(wp), dimension(:,:  ),      allocatable :: band_lims
+    real(wp)                                     :: press_ref_trop, temp_ref_p, temp_ref_t
+    real(wp), dimension(:      ),    allocatable :: press_ref
+    real(wp), dimension(:      ),    allocatable :: temp_ref
+    real(wp), dimension(:,:,:  ),    allocatable :: vmr_ref
+    real(wp), dimension(:,:,:,:),    allocatable :: kmajor
+
+    character(len=32), dimension(:),  allocatable :: gas_minor, identifier_minor
+    character(len=32), dimension(:),  allocatable :: minor_gases_lower,               minor_gases_upper
+    integer, dimension(:,:),          allocatable :: minor_limits_gpt_lower,          minor_limits_gpt_upper
+    logical(wl), dimension(:),        allocatable :: minor_scales_with_density_lower, minor_scales_with_density_upper
+    character(len=32), dimension(:),  allocatable :: scaling_gas_lower,               scaling_gas_upper
+    logical(wl), dimension(:),        allocatable :: scale_by_complement_lower,       scale_by_complement_upper
+    integer, dimension(:),            allocatable :: kminor_start_lower,              kminor_start_upper
+    real(wp), dimension(:,:,:),       allocatable :: kminor_lower,                    kminor_upper
+
+    real(wp), dimension(:,:,:  ), allocatable :: rayl_lower, rayl_upper
+    real(wp), dimension(:      ), allocatable :: solar_src
+    real(wp), dimension(:,:    ), allocatable :: totplnk
+    real(wp), dimension(:,:,:,:), allocatable :: planck_frac
+    ! -----------------
+    !
+    ! Book-keeping variables
+    !
+    integer :: ncid
+    integer :: ntemps,          &
+               npress,          &
+               nabsorbers,      &
+               nextabsorbers,   &
+               nminorabsorbers, &
+               nmixingfracs,    &
+               nlayers,         &
+               nbnds,           &
+               ngpts,           &
+               npairs,          &
+               nminor_absorber_intervals_lower, &
+               nminor_absorber_intervals_upper, &
+               ncontributors_lower, &
+               ncontributors_upper, &
+               ninternalSourcetemps
+    ! --------------------------------------------------
+    !
+    ! How big are the various arrays?
+    !
+    if(nf90_open(trim(fileName), NF90_NOWRITE, ncid) /= NF90_NOERR) &
+      call stop_on_err("load_and_init(): can't open file " // trim(fileName))
+    ntemps            = get_dim_size(ncid,'temperature')
+    npress            = get_dim_size(ncid,'pressure')
+    nabsorbers        = get_dim_size(ncid,'absorber')
+    nminorabsorbers   = get_dim_size(ncid,'minor_absorber')
+    nextabsorbers     = get_dim_size(ncid,'absorber_ext')
+    nmixingfracs      = get_dim_size(ncid,'mixing_fraction')
+    nlayers           = get_dim_size(ncid,'atmos_layer')
+    nbnds             = get_dim_size(ncid,'bnd')
+    ngpts             = get_dim_size(ncid,'gpt')
+    npairs            = get_dim_size(ncid,'pair')
+    nminor_absorber_intervals_lower &
+                      = get_dim_size(ncid,'minor_absorber_intervals_lower')
+    nminor_absorber_intervals_upper  &
+                      = get_dim_size(ncid,'minor_absorber_intervals_upper')
+    ninternalSourcetemps &
+                      = get_dim_size(ncid,'temperature_Planck')
+    ncontributors_lower = get_dim_size(ncid,'contributors_lower')
+    ncontributors_upper = get_dim_size(ncid,'contributors_upper')
+    ! -----------------
+    !
+    ! Read the many arrays
+    !
+    gas_names         = read_char_vec(ncid, 'gas_names', nabsorbers)
+    key_species       = read_field(ncid, 'key_species',  2, nlayers, nbnds)
+    band_lims         = read_field(ncid, 'bnd_limits_wavenumber', 2, nbnds)
+    band2gpt          = int(read_field(ncid, 'bnd_limits_gpt', 2, nbnds))
+    press_ref         = read_field(ncid, 'press_ref', npress)
+    temp_ref          = read_field(ncid, 'temp_ref',  ntemps)
+    temp_ref_p        = read_field(ncid, 'absorption_coefficient_ref_P')
+    temp_ref_t        = read_field(ncid, 'absorption_coefficient_ref_T')
+    press_ref_trop    = read_field(ncid, 'press_ref_trop')
+    kminor_lower      = read_field(ncid, 'kminor_lower', &
+        ncontributors_lower, nmixingfracs, ntemps)
+    kminor_upper      = read_field(ncid, 'kminor_upper', &
+        ncontributors_upper, nmixingfracs, ntemps)
+    gas_minor = read_char_vec(ncid, 'gas_minor', nminorabsorbers)
+    identifier_minor = read_char_vec(ncid, 'identifier_minor', nminorabsorbers)
+    minor_gases_lower = read_char_vec(ncid, 'minor_gases_lower', nminor_absorber_intervals_lower)
+    minor_gases_upper = read_char_vec(ncid, 'minor_gases_upper', nminor_absorber_intervals_upper)
+    minor_limits_gpt_lower &
+                      = int(read_field(ncid, 'minor_limits_gpt_lower', npairs,nminor_absorber_intervals_lower))
+    minor_limits_gpt_upper &
+                      = int(read_field(ncid, 'minor_limits_gpt_upper', npairs,nminor_absorber_intervals_upper))
+    minor_scales_with_density_lower &
+                      = read_logical_vec(ncid, 'minor_scales_with_density_lower', nminor_absorber_intervals_lower)
+    minor_scales_with_density_upper &
+                      = read_logical_vec(ncid, 'minor_scales_with_density_upper', nminor_absorber_intervals_upper)
+    scale_by_complement_lower &
+                      = read_logical_vec(ncid, 'scale_by_complement_lower', nminor_absorber_intervals_lower)
+    scale_by_complement_upper &
+                      = read_logical_vec(ncid, 'scale_by_complement_upper', nminor_absorber_intervals_upper)
+    scaling_gas_lower &
+                      = read_char_vec(ncid, 'scaling_gas_lower', nminor_absorber_intervals_lower)
+    scaling_gas_upper &
+                      = read_char_vec(ncid, 'scaling_gas_upper', nminor_absorber_intervals_upper)
+    kminor_start_lower &
+                      = read_field(ncid, 'kminor_start_lower', nminor_absorber_intervals_lower)
+    kminor_start_upper &
+                      = read_field(ncid, 'kminor_start_upper', nminor_absorber_intervals_upper)
+    vmr_ref           = read_field(ncid, 'vmr_ref', nlayers, nextabsorbers, ntemps)
+
+    kmajor            = read_field(ncid, 'kmajor',  ngpts, nmixingfracs,  npress+1, ntemps)
+    if(var_exists(ncid, 'rayl_lower')) then
+      rayl_lower = read_field(ncid, 'rayl_lower',   ngpts, nmixingfracs,            ntemps)
+      rayl_upper = read_field(ncid, 'rayl_upper',   ngpts, nmixingfracs,            ntemps)
+    end if
+    ! --------------------------------------------------
+    !
+    ! Initialize the gas optics class with data. The calls look slightly different depending
+    !   on whether the radiation sources are internal to the atmosphere (longwave) or external (shortwave)
+    ! gas_optics%load() returns a string; a non-empty string indicates an error.
+    !
+    if(var_exists(ncid, 'totplnk')) then
+      !
+      ! If there's a totplnk variable in the file it's a longwave (internal sources) type
+      !
+      totplnk     = read_field(ncid, 'totplnk', ninternalSourcetemps, nbnds)
+      planck_frac = read_field(ncid, 'plank_fraction', ngpts, nmixingfracs, npress+1, ntemps)
+      call stop_on_err(kdist%load(available_gases, &
+                                  gas_names,   &
+                                  key_species, &
+                                  band2gpt,    &
+                                  band_lims,   &
+                                  press_ref,   &
+                                  press_ref_trop, &
+                                  temp_ref,    &
+                                  temp_ref_p, temp_ref_t,     &
+                                  vmr_ref, kmajor,            &
+                                  kminor_lower, kminor_upper, &
+                                  gas_minor,identifier_minor, &
+                                  minor_gases_lower, minor_gases_upper, &
+                                  minor_limits_gpt_lower, &
+                                  minor_limits_gpt_upper, &
+                                  minor_scales_with_density_lower, &
+                                  minor_scales_with_density_upper, &
+                                  scaling_gas_lower, scaling_gas_upper, &
+                                  scale_by_complement_lower, &
+                                  scale_by_complement_upper, &
+                                  kminor_start_lower, &
+                                  kminor_start_upper, &
+                                  totplnk, planck_frac,       &
+                                  rayl_lower, rayl_upper))
+    else
+      !
+      ! Solar source doesn't have an dependencies yet
+      !
+      if (var_exists(ncid, 'solar_source')) then
+         solar_src = read_field(ncid, 'solar_source', ngpts)
+      else
+         solar_src = read_field(ncid, 'solar_source_quiet', ngpts)
+      end if
+      call stop_on_err(kdist%load(available_gases, &
+                                  gas_names,   &
+                                  key_species, &
+                                  band2gpt,    &
+                                  band_lims,   &
+                                  press_ref,   &
+                                  press_ref_trop, &
+                                  temp_ref,    &
+                                  temp_ref_p, temp_ref_t,     &
+                                  vmr_ref, kmajor,            &
+                                  kminor_lower, kminor_upper, &
+                                  gas_minor,identifier_minor,&
+                                  minor_gases_lower, minor_gases_upper, &
+                                  minor_limits_gpt_lower, &
+                                  minor_limits_gpt_upper, &
+                                  minor_scales_with_density_lower, &
+                                  minor_scales_with_density_upper, &
+                                  scaling_gas_lower, scaling_gas_upper, &
+                                  scale_by_complement_lower, &
+                                  scale_by_complement_upper, &
+                                  kminor_start_lower, &
+                                  kminor_start_upper, &
+                                  solar_src, &
+                                  rayl_lower, rayl_upper))
+    end if
+    ! --------------------------------------------------
+    ncid = nf90_close(ncid)
+  end subroutine load_and_init
+end module

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -207,7 +207,14 @@ tweaking their $case/namelist_scream.xml file.
       <f12vmr      > 531.2820e-12 </f12vmr>
       <n2vmr       > 0.7906       </n2vmr>
       <covmr       > 1.0e-7       </covmr>
+      <!-- Orbital parameters for solar zenith angle and TSI scaling. For F2010 compsets, -->
+      <!-- we set a fixed year for these parameters, but for other compsets we set to a   -->
+      <!-- negative value to force the code to get simulated year from the timestamp.     -->
+      <!-- TODO: these should probably be set (or overridden) by CIME or cpl settings.    -->
+      <!-- In E3SM/EAM, these appear to be controlled by the orb_iyear namelist variable  -->
+      <!-- in drv_in, and we should probably switch to allowing for that in the future.   -->
       <orbital_year>-9999</orbital_year>
+      <orbital_year COMPSET="2010_.*">2010</orbital_year>
       <orbital_eccentricity>-9999</orbital_eccentricity>
       <orbital_eccentricity COMPSET=".*SCREAM%AQUA.*">0</orbital_eccentricity>
       <orbital_obliquity>-9999</orbital_obliquity>

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -144,7 +144,6 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Computed>("sfc_flux_dif_vis", scalar2d_layout, Wm2, grid_name);
   add_field<Computed>("sfc_flux_sw_net" , scalar2d_layout, Wm2, grid_name);
   add_field<Computed>("sfc_flux_lw_dn"  , scalar2d_layout, Wm2, grid_name);
-  add_field<Computed>("cosine_solar_zenith_angle",scalar2d_layout,nondim,grid_name);
 }  // RRTMGPRadiation::set_grids
 
 size_t RRTMGPRadiation::requested_buffer_size_in_bytes() const
@@ -188,6 +187,8 @@ void RRTMGPRadiation::init_buffers(const ATMBufferManager &buffer_manager)
   mem += m_buffer.sfc_flux_dif_vis.totElems();
   m_buffer.sfc_flux_dif_nir = decltype(m_buffer.sfc_flux_dif_nir)("sfc_flux_dif_nir", mem, m_col_chunk_size);
   mem += m_buffer.sfc_flux_dif_nir.totElems();
+  m_buffer.cosine_zenith = decltype(m_buffer.cosine_zenith)(mem, m_col_chunk_size);
+  mem += m_buffer.cosine_zenith.size();
 
   // 2d arrays
   m_buffer.p_lay = decltype(m_buffer.p_lay)("p_lay", mem, m_col_chunk_size, m_nlay);
@@ -408,7 +409,6 @@ void RRTMGPRadiation::run_impl (const int dt) {
   auto d_sfc_flux_dif_nir = get_field_out("sfc_flux_dif_nir").get_view<Real*>();
   auto d_sfc_flux_sw_net = get_field_out("sfc_flux_sw_net").get_view<Real*>();
   auto d_sfc_flux_lw_dn  = get_field_out("sfc_flux_lw_dn").get_view<Real*>();
-  auto d_mu0 = get_field_out("cosine_solar_zenith_angle").get_view<Real*>();
 
   constexpr auto stebol = PC::stebol;
   const auto nlay = m_nlay;
@@ -425,7 +425,7 @@ void RRTMGPRadiation::run_impl (const int dt) {
   auto obliq = m_orbital_obliq;
   auto mvelp = m_orbital_mvelp;
   if (eccen >= 0 && obliq >= 0 && mvelp >= 0) {
-    // use fixed oribal parameters; to force this, we need to set
+    // use fixed orbital parameters; to force this, we need to set
     // orbital_year to SHR_ORB_UNDEF_INT, which is exposed through
     // our c2f bridge as shr_orb_undef_int_c2f
     orbital_year = shr_orb_undef_int_c2f;
@@ -520,6 +520,7 @@ void RRTMGPRadiation::run_impl (const int dt) {
       // Determine the cosine zenith angle
       // NOTE: Since we are bridging to F90 arrays this must be done on HOST and then
       //       deep copied to a device view.
+      auto d_mu0 = m_buffer.cosine_zenith;
       auto h_mu0 = Kokkos::create_mirror_view(d_mu0);
       if (m_fixed_solar_zenith_angle > 0) {
         for (int i=0; i<ncol; i++) {

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -530,7 +530,7 @@ void RRTMGPRadiation::run_impl (const int dt) {
         for (int i=0;i<ncol;i++) {
           double lat = h_lat(i+beg)*PC::Pi/180.0;  // Convert lat/lon to radians
           double lon = h_lon(i+beg)*PC::Pi/180.0;
-          h_mu0(i) = shr_orb_cosz_c2f(calday, lat, lon, delta, dt);
+          h_mu0(i) = shr_orb_cosz_c2f(calday, lat, lon, delta, m_rad_freq_in_steps * dt);
         }
       }
       Kokkos::deep_copy(d_mu0,h_mu0);

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -100,7 +100,7 @@ public:
 
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {
-    static constexpr int num_1d_ncol        = 10;
+    static constexpr int num_1d_ncol        = 9;
     static constexpr int num_2d_nlay        = 14;
     static constexpr int num_2d_nlay_p1     = 12;
     static constexpr int num_2d_nswbands    = 2;
@@ -115,7 +115,6 @@ public:
     real1d sfc_alb_dir_nir;
     real1d sfc_alb_dif_vis;
     real1d sfc_alb_dif_nir;
-    uview_1d<Real> cosine_zenith;
     real1d sfc_flux_dir_vis;
     real1d sfc_flux_dir_nir;
     real1d sfc_flux_dif_vis;

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -100,7 +100,7 @@ public:
 
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {
-    static constexpr int num_1d_ncol        = 9;
+    static constexpr int num_1d_ncol        = 10;
     static constexpr int num_2d_nlay        = 14;
     static constexpr int num_2d_nlay_p1     = 12;
     static constexpr int num_2d_nswbands    = 2;
@@ -115,6 +115,7 @@ public:
     real1d sfc_alb_dir_nir;
     real1d sfc_alb_dif_vis;
     real1d sfc_alb_dif_nir;
+    uview_1d<Real> cosine_zenith;
     real1d sfc_flux_dir_vis;
     real1d sfc_flux_dir_nir;
     real1d sfc_flux_dif_vis;


### PR DESCRIPTION
Minor bugfixes for solar insolation inconsistencies with EAM/SCREAMv0. This includes an off-by-one bug in setting the time used by the orbital parameter routines, which expect time `calday` to be in day + fraction of day, where time 0Z on Jan 01 corresponds to `calday = 1.0` while our `ts.frac_of_year_in_days()` routine gives `0` on 0Z Jan 01. Also set orbital year to a constant value of 2010 for F2010 compsets. Before we let this be set by the simulation date, which meant by default we were setting the orbital year to be 0001 for F2010 cases. For real cases, we do probably want this to be set by the simulation timestamp, or else manually set to be consistent with the simulated year, but for cyclic forcing experiments we want to set orbital year to a constant. Also add output for `cosine_solar_zenith_angle`, and allow using reduced gpoint data with SCREAMv0 configurations for easier comparisons.