### PR TITLE
EAMxx: fix detection of CIME build in scorpio F90 interface

### DIFF
--- a/components/scream/src/scream_config.h.in
+++ b/components/scream/src/scream_config.h.in
@@ -1,9 +1,6 @@
 #ifndef SCREAM_CONFIG_H
 #define SCREAM_CONFIG_H
 
-// Whether scream is built as a standalone project or as the atm component of E3SM
-#cmakedefine SCREAM_CIME_BUILD
-
 // If defined, Real is double; if not, Real is float.
 #cmakedefine SCREAM_DOUBLE_PRECISION
 

--- a/components/scream/src/share/CMakeLists.txt
+++ b/components/scream/src/share/CMakeLists.txt
@@ -35,6 +35,14 @@ target_include_directories(scream_share PUBLIC ${SCREAM_SRC_DIR} ${SCREAM_BIN_DI
 target_link_libraries(scream_share PUBLIC ekat gptl)
 set_target_properties(scream_share PROPERTIES Fortran_MODULE_DIRECTORY ${SCREAM_F90_MODULES})
 target_compile_options(scream_share PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>)
+
+# This used to be in `scream_config.h/scream_config.f`, but we did accidentally remove
+# the includes at least twice. To avoid this from happening again, we add this crucial
+# macro as a compile definition of the scream_share, which is linked to all other
+# scream libraries.
+if (SCREAM_CIME_BUILD)
+  target_compile_definitions (scream_share PUBLIC SCREAM_CIME_BUILD)
+endif()
 # We have some issues with RDC and repeated libraries in the link line.
 # It's a known issue, and nvcc_wrapper has a flag for handling this.
 if (Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE)

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -42,6 +42,7 @@ module scream_scorpio_interface
 ! Finalization:
 !==============================================================================!
 
+#include "scream_config.f"
   !------------
   use pio_types,    only: iosystem_desc_t, file_desc_t, var_desc_t, io_desc_t, &
                           pio_noerr, pio_global, &

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -42,7 +42,6 @@ module scream_scorpio_interface
 ! Finalization:
 !==============================================================================!
 
-#include "scream_config.f"
   !------------
   use pio_types,    only: iosystem_desc_t, file_desc_t, var_desc_t, io_desc_t, &
                           pio_noerr, pio_global, &

--- a/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -2,12 +2,6 @@ module scream_scorpio_interface_iso_c2f
   use iso_c_binding, only: c_int, c_double, c_float, c_bool, c_ptr
   implicit none
 
-#include "scream_config.f"
-#ifdef SCREAM_DOUBLE_PRECISION
-# define c_real c_double
-#else
-# define c_real c_float
-#endif
 !
 ! This file contains bridges from scream c++ to shoc fortran.
 !

--- a/components/scream/src/share/util/scream_timing.cpp
+++ b/components/scream/src/share/util/scream_timing.cpp
@@ -1,5 +1,4 @@
 #include "share/util/scream_timing.hpp"
-#include "scream_config.h"
 
 #include <gptl.h>
 


### PR DESCRIPTION
While removing some unused code I accidentally removed the scream config file inclusion, so the `SCREAM_CIME_BUILD` macro was not picked up.