### PR TITLE
HighResMIP 0.25x0.25 daily sstice for 2010 SCREAMv1 at ne120 or higher

### DIFF
--- a/components/data_comps/docn/cime_config/config_component.xml
+++ b/components/data_comps/docn/cime_config/config_component.xml
@@ -185,6 +185,7 @@
       <value compset="1850_" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
       <value compset="1950_" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_1950_clim_c20180910.nc</value>
       <value compset="2010.*_" grid=".+"					        >$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_2010_clim_c20190821.nc</value>
+      <value compset="2010_SCREAM_" grid="ne120.*|ne256.*|ne512.*|ne1024.*"	        >$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_HighResMIP_E3SM_0.25x0.25_2010_clim_c20190125_intoisst.nc</value>
       <value compset="20TR_CAM5%CMIP6" grid=".+"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_c20180213.nc</value>
       <value compset="20TR_EAM%CMIP6" grid=".+"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_c20180213.nc</value>
       <value compset="20TR_EAM%MMF.*CMIP6" grid=".+" >$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_c20180213.nc</value>
@@ -218,6 +219,7 @@
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v7"	>$DIN_LOC_ROOT/share/domains/domain.ocn.fv0.9x1.25_gx1v7.151020.nc</value>
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.47x0.63.*_oi%0.47x0.63"	>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.47x0.63_gx1v6_090408.nc</value>
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.23x0.31.*_oi%0.23x0.31"	>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.23x0.31_gx1v6_101108.nc</value>
+      <value compset="2010_SCREAM_" grid="ne120.*|ne256.*|ne512.*|ne1024.*"			>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.0.25x0.25.c20190221.nc</value>
       <value compset="1850" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.1x1.111007.nc</value>
       <value compset="1850" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.48x96_gx3v7_100114.nc</value>
       <value compset="1850" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.1.9x2.5_gx1v6_090403.nc</value>


### PR DESCRIPTION
Changes to use HighResMIP 2013 daily sstice data for SCREAMv1 F compset at
ne120, ne256, ne512 and ne1024 resolutions. The current default uses the standard
1 degree monthly climatology centered around 2010 sstice data for EAM, 
sst_ice_CMIP6_DECK_E3SM_1x1_2010_clim_c20190821.nc, which will still be used 
for lower resolution configuration after this PR.

[BFB] for SCREAMv1 tests at resolution lower than ne120.