### PR TITLE
This commit fixes the zonal and meridonal vapor flux diagnostics.

### DIFF
--- a/components/scream/src/diagnostics/zonal_vapor_flux.cpp
+++ b/components/scream/src/diagnostics/zonal_vapor_flux.cpp
@@ -29,12 +29,14 @@ void ZonalVapFluxDiagnostic::set_grids(const std::shared_ptr<const GridsManager>
 
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
   FieldLayout scalar2d_layout_mid { {COL},     {m_num_cols}            };
+  FieldLayout horiz_wind_layout { {COL,CMP,LEV}, {m_num_cols,2,m_num_levs} };
   constexpr int ps = Pack::n;
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa, grid_name, ps);
-  add_field<Required>("qv",             scalar3d_layout_mid, Q,  grid_name, "tracers", ps);
-  add_field<Required>("u",             scalar3d_layout_mid, m/s,  grid_name, ps);
+  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,  grid_name, ps);
+  add_field<Required>("qv",             scalar3d_layout_mid, Q,   grid_name, "tracers", ps);
+  // Note both u and v are packaged into the single field horiz_winds.
+  add_field<Required>("horiz_winds",    horiz_wind_layout,   m/s, grid_name, ps);
 
 
   // Construct and allocate the diagnostic field
@@ -52,10 +54,10 @@ void ZonalVapFluxDiagnostic::compute_diagnostic_impl()
   constexpr Real gravit = PC::gravit;
   const auto npacks         = ekat::npack<Pack>(m_num_levs);
   const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, npacks);
-  const auto& qv_vert_integrated_flux_u                = m_diagnostic_output.get_view<Real*>();
+  const auto& qv_vert_integrated_flux_u = m_diagnostic_output.get_view<Real*>();
   const auto& qv_mid             = get_field_in("qv").get_view<const Pack**>();
   const auto& pseudo_density_mid = get_field_in("pseudo_density").get_view<const Pack**>();
-  const auto& u_mid = get_field_in("u").get_view<const Pack**>();
+  const auto& horiz_winds        = get_field_in("horiz_winds").get_view<const Pack***>();
 
   const auto num_levs = m_num_levs;
   Kokkos::parallel_for("ZonalVapFluxDiagnostic",
@@ -65,7 +67,8 @@ void ZonalVapFluxDiagnostic::compute_diagnostic_impl()
     Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
       const int jpack = idx / Pack::n;
       const int klev  = idx % Pack::n;
-      lsum += u_mid(icol,jpack)[klev] * qv_mid(icol,jpack)[klev] * pseudo_density_mid(icol,jpack)[klev]/gravit;
+      // Note, horiz_winds contains u (index 0) and v (index 1).  Here we want u
+      lsum += horiz_winds(icol,0,jpack)[klev] * qv_mid(icol,jpack)[klev] * pseudo_density_mid(icol,jpack)[klev]/gravit;
     },qv_vert_integrated_flux_u(icol));
     team.team_barrier();
   });


### PR DESCRIPTION
In the original implementation the u and v wind profile were specifically defined as a required field from the field manager.  In EAMxx these two fields are packed inside the `horiz_winds` field.  This commit switches the diagnostics to require `horiz_winds` and then uses the specfic velocity component associated with the diagnostic.

This commit also updates the tests to reflect the change in the diagnostics themselves.

Tested that this fix allows a typical EAMxx run to use these diagnostics as output.