### PR TITLE
Add various fields to import fields

### DIFF
--- a/components/scream/src/control/atmosphere_surface_coupling_importer.cpp
+++ b/components/scream/src/control/atmosphere_surface_coupling_importer.cpp
@@ -40,14 +40,15 @@ void SurfaceCouplingImporter::set_grids(const std::shared_ptr<const GridsManager
   FieldLayout scalar2d_layout { {COL     }, {m_num_cols   } };
   FieldLayout vector2d_layout { {COL, CMP}, {m_num_cols, 2} };
 
-  add_field<Computed>("sfc_alb_dir_vis", scalar2d_layout, nondim,  grid_name);
-  add_field<Computed>("sfc_alb_dir_nir", scalar2d_layout, nondim,  grid_name);
-  add_field<Computed>("sfc_alb_dif_vis", scalar2d_layout, nondim,  grid_name);
-  add_field<Computed>("sfc_alb_dif_nir", scalar2d_layout, nondim,  grid_name);
-  add_field<Computed>("surf_lw_flux_up", scalar2d_layout, W/m2,    grid_name);
-  add_field<Computed>("surf_sens_flux",  scalar2d_layout, W/m2,    grid_name);
-  add_field<Computed>("surf_evap",       scalar2d_layout, kg/m2/s, grid_name);
-  add_field<Computed>("surf_mom_flux",   vector2d_layout, N/m2,    grid_name);
+  add_field<Computed>("sfc_alb_dir_vis",  scalar2d_layout, nondim,  grid_name);
+  add_field<Computed>("sfc_alb_dir_nir",  scalar2d_layout, nondim,  grid_name);
+  add_field<Computed>("sfc_alb_dif_vis",  scalar2d_layout, nondim,  grid_name);
+  add_field<Computed>("sfc_alb_dif_nir",  scalar2d_layout, nondim,  grid_name);
+  add_field<Computed>("surf_lw_flux_up",  scalar2d_layout, W/m2,    grid_name);
+  add_field<Computed>("surf_sens_flux",   scalar2d_layout, W/m2,    grid_name);
+  add_field<Computed>("surf_evap",        scalar2d_layout, kg/m2/s, grid_name);
+  add_field<Computed>("surf_mom_flux",    vector2d_layout, N/m2,    grid_name);
+  add_field<Computed>("surf_radiative_T", scalar2d_layout, K,       grid_name);
 }
 // =========================================================================================
   void SurfaceCouplingImporter::setup_surface_coupling_data(const SCDataManager &sc_data_manager)

--- a/components/scream/src/control/atmosphere_surface_coupling_importer.cpp
+++ b/components/scream/src/control/atmosphere_surface_coupling_importer.cpp
@@ -49,6 +49,10 @@ void SurfaceCouplingImporter::set_grids(const std::shared_ptr<const GridsManager
   add_field<Computed>("surf_evap",        scalar2d_layout, kg/m2/s, grid_name);
   add_field<Computed>("surf_mom_flux",    vector2d_layout, N/m2,    grid_name);
   add_field<Computed>("surf_radiative_T", scalar2d_layout, K,       grid_name);
+  add_field<Computed>("T_2m",             scalar2d_layout, K,       grid_name);
+  add_field<Computed>("qv_2m",            scalar2d_layout, Qunit,   grid_name);
+  add_field<Computed>("wind_speed_10m",   scalar2d_layout, m/s,     grid_name);
+  add_field<Computed>("snow_depth_land",  scalar2d_layout, m,       grid_name);
 }
 // =========================================================================================
   void SurfaceCouplingImporter::setup_surface_coupling_data(const SCDataManager &sc_data_manager)

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -6,7 +6,7 @@ module scream_cpl_indices
   private
 
   ! Focus only on the ones that scream imports/exports (subsets of x2a and a2x)
-  integer, parameter, public :: num_scream_imports = 9
+  integer, parameter, public :: num_scream_imports = 10
   integer, parameter, public :: num_scream_exports = 17
   integer, public :: num_cpl_imports, num_cpl_exports, import_field_size, export_field_size
 
@@ -73,26 +73,28 @@ module scream_cpl_indices
     enddo
 
     ! SCREAM names
-    import_field_names(1) = 'sfc_alb_dir_vis'
-    import_field_names(2) = 'sfc_alb_dir_nir'
-    import_field_names(3) = 'sfc_alb_dif_vis'
-    import_field_names(4) = 'sfc_alb_dif_nir'
-    import_field_names(5) = 'surf_lw_flux_up'
-    import_field_names(6) = 'surf_mom_flux'
-    import_field_names(7) = 'surf_mom_flux'
-    import_field_names(8) = 'surf_sens_flux'
-    import_field_names(9) = 'surf_evap'
+    import_field_names(1)  = 'sfc_alb_dir_vis'
+    import_field_names(2)  = 'sfc_alb_dir_nir'
+    import_field_names(3)  = 'sfc_alb_dif_vis'
+    import_field_names(4)  = 'sfc_alb_dif_nir'
+    import_field_names(5)  = 'surf_lw_flux_up'
+    import_field_names(6)  = 'surf_mom_flux'
+    import_field_names(7)  = 'surf_mom_flux'
+    import_field_names(8)  = 'surf_sens_flux'
+    import_field_names(9)  = 'surf_evap'
+    import_field_names(10) = 'surf_radiative_T'
 
     ! CPL indices
-    import_cpl_indices(1) = mct_avect_indexra(x2a,'Sx_avsdr')
-    import_cpl_indices(2) = mct_avect_indexra(x2a,'Sx_anidr')
-    import_cpl_indices(3) = mct_avect_indexra(x2a,'Sx_avsdf')
-    import_cpl_indices(4) = mct_avect_indexra(x2a,'Sx_anidf')
-    import_cpl_indices(5) = mct_avect_indexra(x2a,'Faxx_lwup')
-    import_cpl_indices(6) = mct_avect_indexra(x2a,'Faxx_taux')
-    import_cpl_indices(7) = mct_avect_indexra(x2a,'Faxx_tauy')
-    import_cpl_indices(8) = mct_avect_indexra(x2a,'Faxx_sen')
-    import_cpl_indices(9) = mct_avect_indexra(x2a,'Faxx_evap')
+    import_cpl_indices(1)  = mct_avect_indexra(x2a,'Sx_avsdr')
+    import_cpl_indices(2)  = mct_avect_indexra(x2a,'Sx_anidr')
+    import_cpl_indices(3)  = mct_avect_indexra(x2a,'Sx_avsdf')
+    import_cpl_indices(4)  = mct_avect_indexra(x2a,'Sx_anidf')
+    import_cpl_indices(5)  = mct_avect_indexra(x2a,'Faxx_lwup')
+    import_cpl_indices(6)  = mct_avect_indexra(x2a,'Faxx_taux')
+    import_cpl_indices(7)  = mct_avect_indexra(x2a,'Faxx_tauy')
+    import_cpl_indices(8)  = mct_avect_indexra(x2a,'Faxx_sen')
+    import_cpl_indices(9)  = mct_avect_indexra(x2a,'Faxx_evap')
+    import_cpl_indices(10) = mct_avect_indexra(x2a,'Sx_t')
 
     ! Vector components
     import_vector_components(6) = 0

--- a/components/scream/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/scream/src/mct_coupling/scream_cpl_indices.F90
@@ -6,7 +6,7 @@ module scream_cpl_indices
   private
 
   ! Focus only on the ones that scream imports/exports (subsets of x2a and a2x)
-  integer, parameter, public :: num_scream_imports = 10
+  integer, parameter, public :: num_scream_imports = 14
   integer, parameter, public :: num_scream_exports = 17
   integer, public :: num_cpl_imports, num_cpl_exports, import_field_size, export_field_size
 
@@ -69,7 +69,7 @@ module scream_cpl_indices
     do i=1,num_scream_imports
       import_vector_components(i) = -1
       import_constant_multiple(i) = 1
-      do_import_during_init(i) = .true.
+      do_import_during_init(i) = .false.
     enddo
 
     ! SCREAM names
@@ -77,42 +77,49 @@ module scream_cpl_indices
     import_field_names(2)  = 'sfc_alb_dir_nir'
     import_field_names(3)  = 'sfc_alb_dif_vis'
     import_field_names(4)  = 'sfc_alb_dif_nir'
-    import_field_names(5)  = 'surf_lw_flux_up'
-    import_field_names(6)  = 'surf_mom_flux'
-    import_field_names(7)  = 'surf_mom_flux'
-    import_field_names(8)  = 'surf_sens_flux'
-    import_field_names(9)  = 'surf_evap'
-    import_field_names(10) = 'surf_radiative_T'
+    import_field_names(5)  = 'surf_radiative_T'
+    import_field_names(6)  = 'T_2m'
+    import_field_names(7)  = 'qv_2m'
+    import_field_names(8)  = 'wind_speed_10m'
+    import_field_names(9)  = 'snow_depth_land'
+    import_field_names(10) = 'surf_lw_flux_up'
+    import_field_names(11) = 'surf_mom_flux'
+    import_field_names(12) = 'surf_mom_flux'
+    import_field_names(13) = 'surf_sens_flux'
+    import_field_names(14) = 'surf_evap'
 
     ! CPL indices
     import_cpl_indices(1)  = mct_avect_indexra(x2a,'Sx_avsdr')
     import_cpl_indices(2)  = mct_avect_indexra(x2a,'Sx_anidr')
     import_cpl_indices(3)  = mct_avect_indexra(x2a,'Sx_avsdf')
     import_cpl_indices(4)  = mct_avect_indexra(x2a,'Sx_anidf')
-    import_cpl_indices(5)  = mct_avect_indexra(x2a,'Faxx_lwup')
-    import_cpl_indices(6)  = mct_avect_indexra(x2a,'Faxx_taux')
-    import_cpl_indices(7)  = mct_avect_indexra(x2a,'Faxx_tauy')
-    import_cpl_indices(8)  = mct_avect_indexra(x2a,'Faxx_sen')
-    import_cpl_indices(9)  = mct_avect_indexra(x2a,'Faxx_evap')
-    import_cpl_indices(10) = mct_avect_indexra(x2a,'Sx_t')
+    import_cpl_indices(5)  = mct_avect_indexra(x2a,'Sx_t')
+    import_cpl_indices(6)  = mct_avect_indexra(x2a,'Sx_tref')
+    import_cpl_indices(7)  = mct_avect_indexra(x2a,'Sx_qref')
+    import_cpl_indices(8)  = mct_avect_indexra(x2a,'Sx_u10')
+    import_cpl_indices(9)  = mct_avect_indexra(x2a,'Sl_snowh')
+    import_cpl_indices(10) = mct_avect_indexra(x2a,'Faxx_lwup')
+    import_cpl_indices(11) = mct_avect_indexra(x2a,'Faxx_taux')
+    import_cpl_indices(12) = mct_avect_indexra(x2a,'Faxx_tauy')
+    import_cpl_indices(13) = mct_avect_indexra(x2a,'Faxx_sen')
+    import_cpl_indices(14) = mct_avect_indexra(x2a,'Faxx_evap')
 
     ! Vector components
-    import_vector_components(6) = 0
-    import_vector_components(7) = 1
+    import_vector_components(11) = 0
+    import_vector_components(12) = 1
 
     ! Constant multiples
-    import_constant_multiple(5) = -1
-    import_constant_multiple(6) = -1
-    import_constant_multiple(7) = -1
-    import_constant_multiple(8) = -1
-    import_constant_multiple(9) = -1
+    import_constant_multiple(10) = -1
+    import_constant_multiple(11) = -1
+    import_constant_multiple(12) = -1
+    import_constant_multiple(13) = -1
+    import_constant_multiple(14) = -1
 
     ! Does this field need to be imported during intialization
-    do_import_during_init(1) = .false.
-    do_import_during_init(2) = .false.
-    do_import_during_init(3) = .false.
-    do_import_during_init(4) = .false.
-    do_import_during_init(5) = .false.
+    do_import_during_init(11) = .true.
+    do_import_during_init(12) = .true.
+    do_import_during_init(13) = .true.
+    do_import_during_init(14) = .true.
 
     ! EXPORT
 
@@ -127,7 +134,7 @@ module scream_cpl_indices
     do i=1,num_scream_exports
       export_vector_components(i) = -1
       export_constant_multiple(i) = 1
-      do_export_during_init(i) = .true.
+      do_export_during_init(i) = .false.
     enddo
 
     ! SCREAM names
@@ -173,14 +180,15 @@ module scream_cpl_indices
     export_vector_components(3) = 1
 
     ! Does this field need to be imported during intialization
-    do_export_during_init(10) = .false.
-    do_export_during_init(11) = .false.
-    do_export_during_init(12) = .false.
-    do_export_during_init(13) = .false.
-    do_export_during_init(14) = .false.
-    do_export_during_init(15) = .false.
-    do_export_during_init(16) = .false.
-    do_export_during_init(17) = .false.
+    do_export_during_init(1) = .true.
+    do_export_during_init(2) = .true.
+    do_export_during_init(3) = .true.
+    do_export_during_init(4) = .true.
+    do_export_during_init(5) = .true.
+    do_export_during_init(6) = .true.
+    do_export_during_init(7) = .true.
+    do_export_during_init(8) = .true.
+    do_export_during_init(9) = .true.
 
     ! Trim names
     do i=1,num_scream_imports

--- a/components/scream/tests/uncoupled/surface_coupling/surface_coupling.cpp
+++ b/components/scream/tests/uncoupled/surface_coupling/surface_coupling.cpp
@@ -115,6 +115,7 @@ void test_imports(const FieldManager& fm,
   fm.get_field("surf_mom_flux"   ).sync_to_host();
   fm.get_field("surf_sens_flux"  ).sync_to_host();
   fm.get_field("surf_evap"       ).sync_to_host();
+  fm.get_field("surf_radiative_T").sync_to_host();
   const auto sfc_alb_dir_vis  = fm.get_field("sfc_alb_dir_vis" ).get_view<const Real*,  Host>();
   const auto sfc_alb_dir_nir  = fm.get_field("sfc_alb_dir_nir" ).get_view<const Real*,  Host>();
   const auto sfc_alb_dif_vis  = fm.get_field("sfc_alb_dif_vis" ).get_view<const Real*,  Host>();
@@ -122,7 +123,8 @@ void test_imports(const FieldManager& fm,
   const auto surf_lw_flux_up  = fm.get_field("surf_lw_flux_up" ).get_view<const Real*,  Host>();
   const auto surf_mom_flux    = fm.get_field("surf_mom_flux"   ).get_view<const Real**, Host>();
   const auto surf_sens_flux   = fm.get_field("surf_sens_flux"  ).get_view<const Real*,  Host>();
-  const auto surf_evap        = fm.get_field("surf_evap").get_view<const Real*,  Host>();
+  const auto surf_evap        = fm.get_field("surf_evap"       ).get_view<const Real*,  Host>();
+  const auto ts               = fm.get_field("surf_radiative_T").get_view<const Real*,  Host>();
 
   const int ncols = surf_evap.extent(0);
 
@@ -135,6 +137,8 @@ void test_imports(const FieldManager& fm,
     EKAT_REQUIRE(surf_mom_flux(i,1) == import_constant_multiple_view(6)*import_data_view(i, import_cpl_indices_view(6)));
     EKAT_REQUIRE(surf_sens_flux(i)  == import_constant_multiple_view(7)*import_data_view(i, import_cpl_indices_view(7)));
     EKAT_REQUIRE(surf_evap(i)       == import_constant_multiple_view(8)*import_data_view(i, import_cpl_indices_view(8)));
+    EKAT_REQUIRE(ts(i)              == import_constant_multiple_view(9)*import_data_view(i, import_cpl_indices_view(9)));
+
 
     // The following are only imported during run phase. If this test is called
     // during initialization, all values should still be 0.
@@ -344,7 +348,7 @@ TEST_CASE("surface-coupling", "") {
   // Setup views to test import/export. For this test we consider a random number of non-imported/exported
   // cpl fields (in addition to the required scream imports/exports), then assign a random, non-repeating
   // cpl index for each field in [0, num_cpl_fields).
-  const int num_scream_imports = 9;
+  const int num_scream_imports = 10;
   const int num_scream_exports = 17;
   KokkosTypes<HostDevice>::view_1d<int> additional_import_exports("additional_import_exports", 2);
   ekat::genRandArray(additional_import_exports, engine, pdf_int_additional_fields);
@@ -376,6 +380,8 @@ TEST_CASE("surface-coupling", "") {
   std::strcpy(import_names[6], "surf_mom_flux");
   std::strcpy(import_names[7], "surf_sens_flux");
   std::strcpy(import_names[8], "surf_evap");
+  std::strcpy(import_names[9], "surf_radiative_T");
+
   // Export data is of size num_cpl_exports, the rest of the views are size num_scream_exports.
   KokkosTypes<HostDevice>::view_2d<Real> export_data_view             ("export_data",
                                                                        ncols, num_cpl_exports);
@@ -408,6 +414,7 @@ TEST_CASE("surface-coupling", "") {
   std::strcpy(export_names[14], "sfc_flux_dif_vis");
   std::strcpy(export_names[15], "sfc_flux_sw_net");
   std::strcpy(export_names[16], "sfc_flux_lw_dn");
+
   // Setup the import/export data. This is meant to replicate the structures coming
   // from mct_coupling/scream_cpl_indices.F90
   setup_import_and_export_data(num_cpl_imports, num_scream_imports,

--- a/components/scream/tests/uncoupled/surface_coupling/surface_coupling.cpp
+++ b/components/scream/tests/uncoupled/surface_coupling/surface_coupling.cpp
@@ -34,7 +34,7 @@ void setup_import_and_export_data(
   // Default values
   Kokkos::deep_copy(import_vec_comps_view,         -1);
   Kokkos::deep_copy(import_constant_multiple_view,  1);
-  Kokkos::deep_copy(do_import_during_init_view,     true);
+  Kokkos::deep_copy(do_import_during_init_view,     false);
 
   // Set cpl indices. We do a random shuffle of [0, num_cpl_imports),
   // then assign the scream imports to the first num_scream_imports
@@ -49,29 +49,28 @@ void setup_import_and_export_data(
   }
 
   // Set vector components
-  import_vec_comps_view(5) = 0;
-  import_vec_comps_view(6) = 1;
+  import_vec_comps_view(10) = 0;
+  import_vec_comps_view(11) = 1;
 
   // Set constant multiples
-  import_constant_multiple_view(4) = -1;
-  import_constant_multiple_view(5) = -1;
-  import_constant_multiple_view(6) = -1;
-  import_constant_multiple_view(7) = -1;
-  import_constant_multiple_view(8) = -1;
+  import_constant_multiple_view(9)  = -1;
+  import_constant_multiple_view(10) = -1;
+  import_constant_multiple_view(11) = -1;
+  import_constant_multiple_view(12) = -1;
+  import_constant_multiple_view(13) = -1;
 
   // Set boolean for importing during intialization
-  do_import_during_init_view(0) = false;
-  do_import_during_init_view(1) = false;
-  do_import_during_init_view(2) = false;
-  do_import_during_init_view(3) = false;
-  do_import_during_init_view(4) = false;
+  do_import_during_init_view(10) = true;
+  do_import_during_init_view(11) = true;
+  do_import_during_init_view(12) = true;
+  do_import_during_init_view(13) = true;
 
   // EXPORTS
 
   // Default values
   Kokkos::deep_copy(export_vec_comps_view,         -1);
   Kokkos::deep_copy(export_constant_multiple_view,  1);
-  Kokkos::deep_copy(do_export_during_init_view,     true);
+  Kokkos::deep_copy(do_export_during_init_view,     false);
 
   // Set cpl indices. We do a random shuffle of [0, num_cpl_exports),
   // then assign the scream exports to the first num_scream_exports
@@ -90,14 +89,15 @@ void setup_import_and_export_data(
   export_vec_comps_view(2) = 1;
 
   // Set boolean for exporting during intialization
-  do_export_during_init_view(9 ) = false;
-  do_export_during_init_view(10) = false;
-  do_export_during_init_view(11) = false;
-  do_export_during_init_view(12) = false;
-  do_export_during_init_view(13) = false;
-  do_export_during_init_view(14) = false;
-  do_export_during_init_view(15) = false;
-  do_export_during_init_view(16) = false;
+  do_export_during_init_view(0) = true;
+  do_export_during_init_view(1) = true;
+  do_export_during_init_view(2) = true;
+  do_export_during_init_view(3) = true;
+  do_export_during_init_view(4) = true;
+  do_export_during_init_view(5) = true;
+  do_export_during_init_view(6) = true;
+  do_export_during_init_view(7) = true;
+  do_export_during_init_view(8) = true;
 }
 
 void test_imports(const FieldManager& fm,
@@ -111,20 +111,28 @@ void test_imports(const FieldManager& fm,
   fm.get_field("sfc_alb_dir_nir" ).sync_to_host();
   fm.get_field("sfc_alb_dif_vis" ).sync_to_host();
   fm.get_field("sfc_alb_dif_nir" ).sync_to_host();
+  fm.get_field("surf_radiative_T").sync_to_host();
+  fm.get_field("T_2m"            ).sync_to_host();
+  fm.get_field("qv_2m"           ).sync_to_host();
+  fm.get_field("wind_speed_10m"  ).sync_to_host();
+  fm.get_field("snow_depth_land" ).sync_to_host();
   fm.get_field("surf_lw_flux_up" ).sync_to_host();
   fm.get_field("surf_mom_flux"   ).sync_to_host();
   fm.get_field("surf_sens_flux"  ).sync_to_host();
   fm.get_field("surf_evap"       ).sync_to_host();
-  fm.get_field("surf_radiative_T").sync_to_host();
   const auto sfc_alb_dir_vis  = fm.get_field("sfc_alb_dir_vis" ).get_view<const Real*,  Host>();
   const auto sfc_alb_dir_nir  = fm.get_field("sfc_alb_dir_nir" ).get_view<const Real*,  Host>();
   const auto sfc_alb_dif_vis  = fm.get_field("sfc_alb_dif_vis" ).get_view<const Real*,  Host>();
   const auto sfc_alb_dif_nir  = fm.get_field("sfc_alb_dif_nir" ).get_view<const Real*,  Host>();
+  const auto surf_radiative_T = fm.get_field("surf_radiative_T").get_view<const Real*,  Host>();
+  const auto T_2m             = fm.get_field("T_2m"            ).get_view<const Real*,  Host>();
+  const auto qv_2m            = fm.get_field("qv_2m"           ).get_view<const Real*,  Host>();
+  const auto wind_speed_10m   = fm.get_field("wind_speed_10m"  ).get_view<const Real*,  Host>();
+  const auto snow_depth_land  = fm.get_field("snow_depth_land" ).get_view<const Real*,  Host>();
   const auto surf_lw_flux_up  = fm.get_field("surf_lw_flux_up" ).get_view<const Real*,  Host>();
   const auto surf_mom_flux    = fm.get_field("surf_mom_flux"   ).get_view<const Real**, Host>();
   const auto surf_sens_flux   = fm.get_field("surf_sens_flux"  ).get_view<const Real*,  Host>();
   const auto surf_evap        = fm.get_field("surf_evap"       ).get_view<const Real*,  Host>();
-  const auto ts               = fm.get_field("surf_radiative_T").get_view<const Real*,  Host>();
 
   const int ncols = surf_evap.extent(0);
 
@@ -133,27 +141,35 @@ void test_imports(const FieldManager& fm,
     // Check cpl data to scream fields
 
     // The following are imported both during initialization and run phase
-    EKAT_REQUIRE(surf_mom_flux(i,0) == import_constant_multiple_view(5)*import_data_view(i, import_cpl_indices_view(5)));
-    EKAT_REQUIRE(surf_mom_flux(i,1) == import_constant_multiple_view(6)*import_data_view(i, import_cpl_indices_view(6)));
-    EKAT_REQUIRE(surf_sens_flux(i)  == import_constant_multiple_view(7)*import_data_view(i, import_cpl_indices_view(7)));
-    EKAT_REQUIRE(surf_evap(i)       == import_constant_multiple_view(8)*import_data_view(i, import_cpl_indices_view(8)));
-    EKAT_REQUIRE(ts(i)              == import_constant_multiple_view(9)*import_data_view(i, import_cpl_indices_view(9)));
-
+    EKAT_REQUIRE(surf_mom_flux(i,0) == import_constant_multiple_view(10)*import_data_view(i, import_cpl_indices_view(10)));
+    EKAT_REQUIRE(surf_mom_flux(i,1) == import_constant_multiple_view(11)*import_data_view(i, import_cpl_indices_view(11)));
+    EKAT_REQUIRE(surf_sens_flux(i)  == import_constant_multiple_view(12)*import_data_view(i, import_cpl_indices_view(12)));
+    EKAT_REQUIRE(surf_evap(i)       == import_constant_multiple_view(13)*import_data_view(i, import_cpl_indices_view(13)));
 
     // The following are only imported during run phase. If this test is called
     // during initialization, all values should still be 0.
     if (called_directly_after_init) {
-      EKAT_REQUIRE(sfc_alb_dir_vis(i) == 0.0);
-      EKAT_REQUIRE(sfc_alb_dir_nir(i) == 0.0);
-      EKAT_REQUIRE(sfc_alb_dif_vis(i) == 0.0);
-      EKAT_REQUIRE(sfc_alb_dif_nir(i) == 0.0);
-      EKAT_REQUIRE(surf_lw_flux_up(i) == 0.0);
+      EKAT_REQUIRE(sfc_alb_dir_vis(i)  == 0.0);
+      EKAT_REQUIRE(sfc_alb_dir_nir(i)  == 0.0);
+      EKAT_REQUIRE(sfc_alb_dif_vis(i)  == 0.0);
+      EKAT_REQUIRE(sfc_alb_dif_nir(i)  == 0.0);
+      EKAT_REQUIRE(surf_radiative_T(i) == 0.0);
+      EKAT_REQUIRE(T_2m(i)             == 0.0);
+      EKAT_REQUIRE(qv_2m(i)            == 0.0);
+      EKAT_REQUIRE(wind_speed_10m(i)   == 0.0);
+      EKAT_REQUIRE(snow_depth_land(i)  == 0.0);
+      EKAT_REQUIRE(surf_lw_flux_up(i)  == 0.0);
     } else {
-      EKAT_REQUIRE(sfc_alb_dir_vis(i) == import_constant_multiple_view(0)*import_data_view(i, import_cpl_indices_view(0)));
-      EKAT_REQUIRE(sfc_alb_dir_nir(i) == import_constant_multiple_view(1)*import_data_view(i, import_cpl_indices_view(1)));
-      EKAT_REQUIRE(sfc_alb_dif_vis(i) == import_constant_multiple_view(2)*import_data_view(i, import_cpl_indices_view(2)));
-      EKAT_REQUIRE(sfc_alb_dif_nir(i) == import_constant_multiple_view(3)*import_data_view(i, import_cpl_indices_view(3)));
-      EKAT_REQUIRE(surf_lw_flux_up(i) == import_constant_multiple_view(4)*import_data_view(i, import_cpl_indices_view(4)));
+      EKAT_REQUIRE(sfc_alb_dir_vis(i)  == import_constant_multiple_view(0)*import_data_view(i, import_cpl_indices_view(0)));
+      EKAT_REQUIRE(sfc_alb_dir_nir(i)  == import_constant_multiple_view(1)*import_data_view(i, import_cpl_indices_view(1)));
+      EKAT_REQUIRE(sfc_alb_dif_vis(i)  == import_constant_multiple_view(2)*import_data_view(i, import_cpl_indices_view(2)));
+      EKAT_REQUIRE(sfc_alb_dif_nir(i)  == import_constant_multiple_view(3)*import_data_view(i, import_cpl_indices_view(3)));
+      EKAT_REQUIRE(surf_radiative_T(i) == import_constant_multiple_view(4)*import_data_view(i, import_cpl_indices_view(4)));
+      EKAT_REQUIRE(T_2m(i)             == import_constant_multiple_view(5)*import_data_view(i, import_cpl_indices_view(5)));
+      EKAT_REQUIRE(qv_2m(i)            == import_constant_multiple_view(6)*import_data_view(i, import_cpl_indices_view(6)));
+      EKAT_REQUIRE(wind_speed_10m(i)   == import_constant_multiple_view(7)*import_data_view(i, import_cpl_indices_view(7)));
+      EKAT_REQUIRE(snow_depth_land(i)  == import_constant_multiple_view(8)*import_data_view(i, import_cpl_indices_view(8)));
+      EKAT_REQUIRE(surf_lw_flux_up(i)  == import_constant_multiple_view(9)*import_data_view(i, import_cpl_indices_view(9)));
     }
   }
 }
@@ -348,7 +364,7 @@ TEST_CASE("surface-coupling", "") {
   // Setup views to test import/export. For this test we consider a random number of non-imported/exported
   // cpl fields (in addition to the required scream imports/exports), then assign a random, non-repeating
   // cpl index for each field in [0, num_cpl_fields).
-  const int num_scream_imports = 10;
+  const int num_scream_imports = 14;
   const int num_scream_exports = 17;
   KokkosTypes<HostDevice>::view_1d<int> additional_import_exports("additional_import_exports", 2);
   ekat::genRandArray(additional_import_exports, engine, pdf_int_additional_fields);
@@ -371,16 +387,20 @@ TEST_CASE("surface-coupling", "") {
   ekat::genRandArray(import_data_view, engine, pdf_real_import_data);
   // Set import names
   char import_names[num_scream_imports][32];
-  std::strcpy(import_names[0], "sfc_alb_dir_vis");
-  std::strcpy(import_names[1], "sfc_alb_dir_nir");
-  std::strcpy(import_names[2], "sfc_alb_dif_vis");
-  std::strcpy(import_names[3], "sfc_alb_dif_nir");
-  std::strcpy(import_names[4], "surf_lw_flux_up");
-  std::strcpy(import_names[5], "surf_mom_flux");
-  std::strcpy(import_names[6], "surf_mom_flux");
-  std::strcpy(import_names[7], "surf_sens_flux");
-  std::strcpy(import_names[8], "surf_evap");
-  std::strcpy(import_names[9], "surf_radiative_T");
+  std::strcpy(import_names[0],  "sfc_alb_dir_vis");
+  std::strcpy(import_names[1],  "sfc_alb_dir_nir");
+  std::strcpy(import_names[2],  "sfc_alb_dif_vis");
+  std::strcpy(import_names[3],  "sfc_alb_dif_nir");
+  std::strcpy(import_names[4],  "surf_radiative_T");
+  std::strcpy(import_names[5],  "T_2m");
+  std::strcpy(import_names[6],  "qv_2m");
+  std::strcpy(import_names[7],  "wind_speed_10m");
+  std::strcpy(import_names[8],  "snow_depth_land");
+  std::strcpy(import_names[9],  "surf_lw_flux_up");
+  std::strcpy(import_names[10], "surf_mom_flux");
+  std::strcpy(import_names[11], "surf_mom_flux");
+  std::strcpy(import_names[12], "surf_sens_flux");
+  std::strcpy(import_names[13], "surf_evap");
 
   // Export data is of size num_cpl_exports, the rest of the views are size num_scream_exports.
   KokkosTypes<HostDevice>::view_2d<Real> export_data_view             ("export_data",


### PR DESCRIPTION
In case the user would like to output `ts`, `tref`, `qref`, `u10`, or `snowhland` at runtime, adds to import fields. These are given EAMxx names `surf_radiative_T`, `T_2m`, `qv_2m`, `wind_speed_10m`, and `snow_depth_land`.

@PeterCaldwell requested this.