### PR TITLE
EAMxx: fix creation of diags in IO

### DIFF
--- a/components/scream/src/diagnostics/atm_density.hpp
+++ b/components/scream/src/diagnostics/atm_density.hpp
@@ -24,7 +24,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Atmosphere Density"; } 
+  std::string name () const { return "AtmosphereDensity"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -37,7 +37,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class AtmDensityDiagnostic

--- a/components/scream/src/diagnostics/dry_static_energy.hpp
+++ b/components/scream/src/diagnostics/dry_static_energy.hpp
@@ -29,7 +29,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Dry Static Energy"; } 
+  std::string name () const { return "DryStaticEnergy"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -42,7 +42,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class DryStaticEnergyDiagnostic

--- a/components/scream/src/diagnostics/exner.hpp
+++ b/components/scream/src/diagnostics/exner.hpp
@@ -24,7 +24,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Exner"; } 
+  std::string name () const { return "Exner"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -37,7 +37,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class ExnerDiagnostic

--- a/components/scream/src/diagnostics/field_at_level.hpp
+++ b/components/scream/src/diagnostics/field_at_level.hpp
@@ -19,7 +19,7 @@ public:
   FieldAtLevel (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const { return m_field_name + " @ level " + std::to_string(m_field_level); }
+  std::string name () const { return m_field_name + "@lev_" + std::to_string(m_field_level); }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/scream/src/diagnostics/ice_cloud_mask.hpp
+++ b/components/scream/src/diagnostics/ice_cloud_mask.hpp
@@ -30,7 +30,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Ice cloud mask"; } 
+  std::string name () const { return "IceCloudMask"; }
 
   // Get the required grid for the diagnostic
   std::set<std::string> get_required_grids () const {
@@ -54,7 +54,7 @@ protected:
   void finalize_impl   () { /* Nothing to do */ }
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class IceCloudMaskDiagnostic

--- a/components/scream/src/diagnostics/ice_water_path.hpp
+++ b/components/scream/src/diagnostics/ice_water_path.hpp
@@ -28,7 +28,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Ice Water Path"; } 
+  std::string name () const { return "IceWaterPath"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -41,7 +41,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class IceWaterPathDiagnostic

--- a/components/scream/src/diagnostics/liquid_water_path.hpp
+++ b/components/scream/src/diagnostics/liquid_water_path.hpp
@@ -28,7 +28,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Liquid Water Path"; } 
+  std::string name () const { return "LiquidWaterPath"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -41,7 +41,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class LiqWaterPathDiagnostic

--- a/components/scream/src/diagnostics/longwave_cloud_forcing.hpp
+++ b/components/scream/src/diagnostics/longwave_cloud_forcing.hpp
@@ -29,7 +29,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Long Wave Cloud Forcing"; } 
+  std::string name () const { return "LongWaveCloudForcing"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -42,7 +42,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class LongwaveCloudForcingDiagnostic

--- a/components/scream/src/diagnostics/meridional_vapor_flux.hpp
+++ b/components/scream/src/diagnostics/meridional_vapor_flux.hpp
@@ -28,7 +28,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Meridional Vapor Flux"; } 
+  std::string name () const { return "MeridionalVaporFlux"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -41,7 +41,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class MeridonalVapFluxDiagnostic

--- a/components/scream/src/diagnostics/potential_temperature.hpp
+++ b/components/scream/src/diagnostics/potential_temperature.hpp
@@ -24,7 +24,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Potential Temperature"; } 
+  std::string name () const { return "PotentialTemperature"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -37,7 +37,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class PotentialTemperatureDiagnostic

--- a/components/scream/src/diagnostics/rain_water_path.hpp
+++ b/components/scream/src/diagnostics/rain_water_path.hpp
@@ -28,7 +28,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Rain Water Path"; } 
+  std::string name () const { return "RainWaterPath"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -41,7 +41,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class RainWaterPathDiagnostic

--- a/components/scream/src/diagnostics/relative_humidity.hpp
+++ b/components/scream/src/diagnostics/relative_humidity.hpp
@@ -4,7 +4,7 @@
 #include "share/atm_process/atmosphere_diagnostic.hpp"
 #include "share/util/scream_common_physics_functions.hpp"
 #include "ekat/kokkos/ekat_subview_utils.hpp"
-#include "physics/share/physics_functions.hpp" 
+#include "physics/share/physics_functions.hpp"
 #include "physics/share/physics_saturation_impl.hpp"
 
 namespace scream
@@ -32,7 +32,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Relative Humidity"; } 
+  std::string name () const { return "RelativeHumidity"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -45,7 +45,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class RelativeHumidityDiagnostic

--- a/components/scream/src/diagnostics/rime_water_path.hpp
+++ b/components/scream/src/diagnostics/rime_water_path.hpp
@@ -28,7 +28,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Rime Water Path"; } 
+  std::string name () const { return "RimeWaterPath"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -41,7 +41,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class RimeWaterPathDiagnostic

--- a/components/scream/src/diagnostics/sea_level_pressure.hpp
+++ b/components/scream/src/diagnostics/sea_level_pressure.hpp
@@ -29,7 +29,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Sea Level Pressure"; } 
+  std::string name () const { return "SeaLevelPressure"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -42,7 +42,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class SeaLevelPressureDiagnostic

--- a/components/scream/src/diagnostics/shortwave_cloud_forcing.hpp
+++ b/components/scream/src/diagnostics/shortwave_cloud_forcing.hpp
@@ -29,7 +29,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Short Wave Cloud Forcing"; } 
+  std::string name () const { return "ShortWaveCloudForcing"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -42,7 +42,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class ShortwaveCloudForcingDiagnostic

--- a/components/scream/src/diagnostics/vapor_water_path.hpp
+++ b/components/scream/src/diagnostics/vapor_water_path.hpp
@@ -28,7 +28,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Vapor Water Path"; } 
+  std::string name () const { return "VaporWaterPath"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -41,7 +41,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class VapWaterPathDiagnostic

--- a/components/scream/src/diagnostics/vertical_layer_interface.hpp
+++ b/components/scream/src/diagnostics/vertical_layer_interface.hpp
@@ -29,7 +29,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Vertical Layer Interface"; } 
+  std::string name () const { return "VerticalLayerInterface"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -42,7 +42,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class VerticalLayerInterfaceDiagnostic

--- a/components/scream/src/diagnostics/vertical_layer_midpoint.hpp
+++ b/components/scream/src/diagnostics/vertical_layer_midpoint.hpp
@@ -28,7 +28,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Vertical Layer Midpoint"; } 
+  std::string name () const { return "VerticalLayerMidpoint"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -41,7 +41,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class VerticalLayerMidpointDiagnostic

--- a/components/scream/src/diagnostics/vertical_layer_thickness.hpp
+++ b/components/scream/src/diagnostics/vertical_layer_thickness.hpp
@@ -25,7 +25,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Vertical Layer Thickness"; } 
+  std::string name () const { return "VerticalLayerThickness"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -38,7 +38,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class VerticalLayerThicknessDiagnostic

--- a/components/scream/src/diagnostics/virtual_temperature.hpp
+++ b/components/scream/src/diagnostics/virtual_temperature.hpp
@@ -24,7 +24,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Virtual Temperature"; } 
+  std::string name () const { return "VirtualTemperature"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -37,7 +37,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class VirtualTemperatureDiagnostic

--- a/components/scream/src/diagnostics/zonal_vapor_flux.hpp
+++ b/components/scream/src/diagnostics/zonal_vapor_flux.hpp
@@ -28,7 +28,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "Zonal Vapor Flux"; } 
+  std::string name () const { return "ZonalVaporFlux"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -41,7 +41,7 @@ public:
 protected:
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
   Int m_num_levs;
 
 }; // class VapWaterPathDiagnostic

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -646,6 +646,9 @@ Field AtmosphereOutput::get_field(const std::string& name, const bool eval_diagn
   } else if (m_diagnostics.find(name) != m_diagnostics.end()) {
     const auto& diag = m_diagnostics.at(name);
     if (eval_diagnostic) {
+      for (const auto& dep : m_diag_depends_on_diags.at(name)) {
+        get_field(dep,eval_diagnostic);
+      }
       diag->compute_diagnostic();
     }
     return diag->get_diagnostic();
@@ -704,6 +707,9 @@ create_diagnostic (const std::string& diag_field_name) {
     if (diag_factory.has_product(fname) and
         m_diagnostics.count(fname)==0) {
       create_diagnostic(fname);
+      m_diag_depends_on_diags[diag_field_name].push_back(fname);
+    } else {
+      m_diag_depends_on_diags[diag_field_name].resize(0);
     }
     auto fid = get_field(fname).get_header().get_identifier();
     params.set("Field Name", fname);
@@ -715,6 +721,7 @@ create_diagnostic (const std::string& diag_field_name) {
     params.set("Field Level", lev_and_idx.back());
   } else {
     diag_name = diag_field_name;
+    m_diag_depends_on_diags[diag_field_name].resize(0);
   }
 
   // Create the diagnostic

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -639,12 +639,12 @@ setup_output_file(const std::string& filename,
 // manager.  If not it will next check to see if it is in the list
 // of available diagnostics.  If neither of these two options it
 // will throw an error.
-Field AtmosphereOutput::get_field(const std::string& name, const bool eval_diagnostic)
+Field AtmosphereOutput::get_field(const std::string& name, const bool eval_diagnostic) const
 {
   if (m_field_mgr->has_field(name)) {
     return m_field_mgr->get_field(name);
   } else if (m_diagnostics.find(name) != m_diagnostics.end()) {
-    const auto& diag = m_diagnostics[name];
+    const auto& diag = m_diagnostics.at(name);
     if (eval_diagnostic) {
       diag->compute_diagnostic();
     }
@@ -656,47 +656,20 @@ Field AtmosphereOutput::get_field(const std::string& name, const bool eval_diagn
 /* ---------------------------------------------------------- */
 void AtmosphereOutput::set_diagnostics()
 {
-  auto& diag_factory = AtmosphereDiagnosticFactory::instance();
+  // Create all diagnostics
   for (const auto& fname : m_fields_names) {
     if (!m_field_mgr->has_field(fname)) {
-      // Construct a diagnostic by this name
-      ekat::ParameterList params;
-
-      std::string diag_name;
-
-      // If the diagnostic is $field_lev$N/$field_bot/$field_top,
-      // then we need to set some params
-      auto tokens = ekat::split(fname,'@');
-      auto last = tokens.back();
-
-      auto lev_and_idx = ekat::split(last,'_');
-      if (last=="tom" || last=="bot" || lev_and_idx.size()==2) {
-        diag_name = "FieldAtLevel";
-        tokens.pop_back();
-        auto fname = ekat::join(tokens,"_");
-        auto fid = get_field(fname).get_header().get_identifier();
-        params.set("Field Name", fname);
-        params.set("Grid Name",fid.get_grid_name());
-        params.set("Field Layout",fid.get_layout());
-        params.set("Field Units",fid.get_units());
-
-        // If last is bot or top, will simply use that
-        params.set("Field Level", lev_and_idx.back());
-      } else {
-        diag_name = fname;
-      }
-
-      auto diag = diag_factory.create(diag_name,m_comm,params);
-      diag->set_grids(m_grids_manager);
-      m_diagnostics.emplace(fname,diag);
+      create_diagnostic(fname);
     }
   }
+
   // Set required fields for all diagnostics
+  // NOTE: do this *after* creating all diags: in case the required
+  //       field of certain diagnostics is itself a diagnostic,
+  //       we want to make sure the required ones are all built.
   for (const auto& dd : m_diagnostics) {
     const auto& diag = dd.second;
     for (const auto& req : diag->get_required_field_requests()) {
-      // Any required fields should be in the field manager, so we can gather
-      // the TimeStamp for initialization from the first of these.
       const auto& req_field = get_field(req.fid.name());
       diag->set_required_field(req_field.get_const());
     }
@@ -705,6 +678,49 @@ void AtmosphereOutput::set_diagnostics()
     //       output the diagnostic without computing it, we'll get an error.
     diag->initialize(util::TimeStamp(),RunType::Initial);
   }
+}
+
+void AtmosphereOutput::
+create_diagnostic (const std::string& diag_field_name) {
+  auto& diag_factory = AtmosphereDiagnosticFactory::instance();
+
+  // Construct a diagnostic by this name
+  ekat::ParameterList params;
+  std::string diag_name;
+
+  // If the diagnostic is $field@lev$N/$field_bot/$field_top,
+  // then we need to set some params
+  auto tokens = ekat::split(diag_field_name,'@');
+  auto last = tokens.back();
+
+  auto lev_and_idx = ekat::split(last,'_');
+  if (last=="tom" || last=="bot" || lev_and_idx.size()==2) {
+    diag_name = "FieldAtLevel";
+    tokens.pop_back();
+    auto fname = ekat::join(tokens,"_");
+    // If the field is itself a diagnostic, make sure it's built
+    std::cout << "diag_field_name: " << diag_field_name << std::endl
+              << "fname: " << fname << "\n";
+    if (diag_factory.has_product(fname) and
+        m_diagnostics.count(fname)==0) {
+      create_diagnostic(fname);
+    }
+    auto fid = get_field(fname).get_header().get_identifier();
+    params.set("Field Name", fname);
+    params.set("Grid Name",fid.get_grid_name());
+    params.set("Field Layout",fid.get_layout());
+    params.set("Field Units",fid.get_units());
+
+    // If last is bot or top, will simply use that
+    params.set("Field Level", lev_and_idx.back());
+  } else {
+    diag_name = diag_field_name;
+  }
+
+  // Create the diagnostic
+  auto diag = diag_factory.create(diag_name,m_comm,params);
+  diag->set_grids(m_grids_manager);
+  m_diagnostics.emplace(diag_field_name,diag);
 }
 
 } // namespace scream

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -178,6 +178,7 @@ protected:
   std::map<std::string,int>                             m_dofs;
   std::map<std::string,int>                             m_dims;
   std::map<std::string,std::shared_ptr<atm_diag_type>>  m_diagnostics;
+  std::map<std::string,std::vector<std::string>>        m_diag_depends_on_diags;
 
   // Local views of each field to be used for "averaging" output and writing to file.
   std::map<std::string,view_1d_host>    m_host_views_1d;

--- a/components/scream/src/share/io/scorpio_output.hpp
+++ b/components/scream/src/share/io/scorpio_output.hpp
@@ -23,7 +23,7 @@
  *
  *  At construction time ALL output instances require at least an EKAT comm group, an
  *  EKAT parameter list, and a pointer to the field manager.
- * 
+ *
  *  The EKAT parameter list contains the following options to control output behavior
  *  ------
  *  Casename:                     STRING
@@ -106,7 +106,7 @@
 namespace scream
 {
 
-class AtmosphereOutput 
+class AtmosphereOutput
 {
 public:
   using fm_type       = FieldManager;
@@ -134,7 +134,7 @@ public:
   //  - is_model_restart_output: if true, this Output is for model restart files.
   //    In this case, we have to also create an "rpointer.atm" file (which
   //    contains metadata, and is expected by the component coupled)
-  AtmosphereOutput(const ekat::Comm& comm, const ekat::ParameterList& params, 
+  AtmosphereOutput(const ekat::Comm& comm, const ekat::ParameterList& params,
                    const std::shared_ptr<const fm_type>& field_mgr,
                    const std::shared_ptr<const gm_type>& grids_mgr);
 
@@ -157,8 +157,9 @@ protected:
   void set_degrees_of_freedom(const std::string& filename);
   std::vector<scorpio::offset_t> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
-  Field get_field(const std::string& name, const bool eval_diagnostic = false);
+  Field get_field(const std::string& name, const bool eval_diagnostic = false) const;
   void set_diagnostics();
+  void create_diagnostic (const std::string& diag_name);
 
   // --- Internal variables --- //
   ekat::Comm                          m_comm;

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -56,6 +56,7 @@ Field Names:
   - rad_heating_pdel
   - sfc_flux_lw_dn
   - sfc_flux_sw_net
+  - VerticalLayerThickness@bot
  
 output_control:
   Frequency: ${NUM_STEPS}


### PR DESCRIPTION
If a diagnostic depends on another diagnostic, we need to ensure they are created/evaluated in the correct order.

Fixes #1960 