### PR TITLE
Fix passage of views to parallel Kokkos loops in horizontal_remap_utility.

### DIFF
--- a/components/scream/src/share/grid/remap/horizontal_remap_utility.cpp
+++ b/components/scream/src/share/grid/remap/horizontal_remap_utility.cpp
@@ -187,12 +187,11 @@ void HorizontalMap::set_dof_gids(const view_1d<const gid_type>& dofs_gids, const
   start_timer("EAMxx::HorizontalMap::set_dof_gids");
   EKAT_REQUIRE(dofs_gids.size()>0);
   m_dofs_gids = view_1d<gid_type>("",dofs_gids.size());
-  view_1d<gid_type> l_dofs_gids("",dofs_gids.size());
+  const auto l_dofs_gids = m_dofs_gids;
   m_num_dofs = m_dofs_gids.extent(0);
   Kokkos::parallel_for("", m_num_dofs, KOKKOS_LAMBDA (const int& ii) {
     l_dofs_gids(ii) = dofs_gids(ii)-min_dof;
   });
-  Kokkos::deep_copy(m_dofs_gids,l_dofs_gids);
   m_dofs_set = true;
   stop_timer("EAMxx::HorizontalMap::set_dof_gids");
 }

--- a/components/scream/src/share/grid/remap/horizontal_remap_utility.cpp
+++ b/components/scream/src/share/grid/remap/horizontal_remap_utility.cpp
@@ -187,10 +187,12 @@ void HorizontalMap::set_dof_gids(const view_1d<const gid_type>& dofs_gids, const
   start_timer("EAMxx::HorizontalMap::set_dof_gids");
   EKAT_REQUIRE(dofs_gids.size()>0);
   m_dofs_gids = view_1d<gid_type>("",dofs_gids.size());
+  view_1d<gid_type> l_dofs_gids("",dofs_gids.size());
   m_num_dofs = m_dofs_gids.extent(0);
   Kokkos::parallel_for("", m_num_dofs, KOKKOS_LAMBDA (const int& ii) {
-    m_dofs_gids(ii) = dofs_gids(ii)-min_dof;
+    l_dofs_gids(ii) = dofs_gids(ii)-min_dof;
   });
+  Kokkos::deep_copy(m_dofs_gids,l_dofs_gids);
   m_dofs_set = true;
   stop_timer("EAMxx::HorizontalMap::set_dof_gids");
 }
@@ -504,8 +506,9 @@ bool HorizontalMapSegment::check() const
   EKAT_REQUIRE_MSG(m_source_idx.extent(0)==m_length,"Error remap segment for DOF: " + std::to_string(m_dof) + ", source_idx view not the correct length");
   // Check that the segment weight adds up to 1.0 
   Real wgt = 0.0;
+  const auto weights = m_weights;
   Kokkos::parallel_reduce("", m_length, KOKKOS_LAMBDA (const int& ii, Real& lsum) {
-    lsum += m_weights(ii);
+    lsum += weights(ii);
   },wgt);
   Real tol = std::numeric_limits<Real>::epsilon() * 100.0;
   if (std::abs(wgt-1.0)>=tol) {


### PR DESCRIPTION
This commit fixes a bug in how views that existed within a structure were handled within Kokkos for loops.  Should fix errors we are seeing in cuda-mem-check fails on weaver.