### PR TITLE
EAMxx/SHOC: Fix new nondeterminism.

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -509,6 +509,15 @@ _TESTS = {
             )
     },
 
+    "e3sm_scream_v1_long" : {
+        "time"  : "01:00:00",
+        "tests" : (
+            "ERP_D_Lh182.ne4pg2_ne4pg2.F2010-SCREAMv1",
+            "ERS_D_Ln182.ne4_ne4.F2010-SCREAMv1",
+            "ERS_Ln362.ne30pg2_ne30pg2.F2010-SCREAMv1"
+            )
+    },
+
     "e3sm_gpuacc" : {
         "tests"    : (
                  "SMS_Ld1.T62_oEC60to30v3.CMPASO-NYF",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -513,7 +513,6 @@ _TESTS = {
         "time"  : "01:00:00",
         "tests" : (
             "ERP_D_Lh182.ne4pg2_ne4pg2.F2010-SCREAMv1",
-            "ERS_D_Ln182.ne4_ne4.F2010-SCREAMv1",
             "ERS_Ln362.ne30pg2_ne30pg2.F2010-SCREAMv1"
             )
     },


### PR DESCRIPTION
We started seeing new nondeterministic FAILs in debug-build tests on ascent after a recent PR. I believe the PR itself, though it had a bug that was fixed in a subsequent PR, was not in fact responsible; I think it just revealed latent issues.

I traced the new nondeterminism to the calculation of wpthlp_sfc in SHOC's preprocess phase.

In this commit, I've cleaned up SHOC's preprocess phase. I've removed multiple spurious references. I've also combined parallel_for's that were needlessly separate loops. The spurious refs seemed to be the issue, as repeat testing of a reproducer switched to passing after those changes.

I've also added a new category of v1 tests to run only on GPU machines in our nightlies. These run three tests for many steps, increasing the probability we'll get nondeterministic FAILs to show up more quickly.

[BFB]