### PR TITLE
Add vertically-projected cloud area output from radiation

### DIFF
--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -851,7 +851,7 @@ void RRTMGPRadiation::run_impl (const int dt) {
 
     // Compute diagnostic total cloud area (vertically-projected cloud cover)
     auto cldtot = real1d("cldtot", ncol);
-    rrtmgp::compute_cloud_area(ncol, nlay, nswgpts, cld_tau_sw_gpt, cldtot);
+    rrtmgp::compute_cloud_area(ncol, nlay, nlwgpts, cld_tau_lw_gpt, cldtot);
 
     // Copy output data back to FieldManager
     if (update_rad) {

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -133,6 +133,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   // Cloud optical properties added as computed fields for diagnostic purposes
   add_field<Computed>("cld_tau_sw_gpt", scalar3d_swgpts_layout, nondim, grid_name, ps);
   add_field<Computed>("cld_tau_lw_gpt", scalar3d_lwgpts_layout, nondim, grid_name, ps);
+  add_field<Computed>("cldtot"        , scalar2d_layout, nondim, grid_name);
 
   // Translation of variables from EAM
   // --------------------------------------------------------------
@@ -424,6 +425,7 @@ void RRTMGPRadiation::run_impl (const int dt) {
   auto d_sfc_flux_dif_nir = get_field_out("sfc_flux_dif_nir").get_view<Real*>();
   auto d_sfc_flux_sw_net = get_field_out("sfc_flux_sw_net").get_view<Real*>();
   auto d_sfc_flux_lw_dn  = get_field_out("sfc_flux_lw_dn").get_view<Real*>();
+  auto d_cldtot = get_field_out("cldtot").get_view<Real*>();
 
   constexpr auto stebol = PC::stebol;
   const auto nlay = m_nlay;
@@ -847,6 +849,10 @@ void RRTMGPRadiation::run_impl (const int dt) {
         sfc_flux_dif_vis, sfc_flux_dif_nir
     );
 
+    // Compute diagnostic total cloud area (vertically-projected cloud cover)
+    auto cldtot = real1d("cldtot", ncol);
+    rrtmgp::compute_cloud_area(ncol, nlay, nswgpts, cld_tau_sw_gpt, cldtot);
+
     // Copy output data back to FieldManager
     if (update_rad) {
       {
@@ -860,6 +866,7 @@ void RRTMGPRadiation::run_impl (const int dt) {
           d_sfc_flux_dif_vis(icol) = sfc_flux_dif_vis(i+1);
           d_sfc_flux_sw_net(icol)  = sw_flux_dn(i+1,kbot) - sw_flux_up(i+1,kbot);
           d_sfc_flux_lw_dn(icol)   = lw_flux_dn(i+1,kbot);
+          d_cldtot(icol) = cldtot(i+1);
           Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay+1), [&] (const int& k) {
             d_sw_flux_up(icol,k)            = sw_flux_up(i+1,k+1);
             d_sw_flux_dn(icol,k)            = sw_flux_dn(i+1,k+1);

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -841,6 +841,7 @@ namespace scream {
             });
             // Compute average over subcols
             auto ngpt_inv = 1.0 / ngpt;
+            memset(cldtot, 0);
             yakl::fortran::parallel_for(Bounds<1>(ncol), YAKL_LAMBDA(int icol) {
                 // This loop needs to be serial because of the atomic reduction
                 for (int igpt = 1; igpt <= ngpt; ++igpt) {

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -830,6 +830,24 @@ namespace scream {
 
         }
 
+        void compute_cloud_area(int ncol, int nlay, int ngpt, const real3d& cld_tau_gpt, real1d& cldtot) {
+            // Subcolumn binary cld mask; if any layers are cloudy, 2d subcol mask is 1
+            auto subcol_mask = real2d("subcol_mask", ncol, ngpt);
+            memset(subcol_mask, 0);
+            yakl::fortran::parallel_for(Bounds<3>(ngpt, nlay, ncol), YAKL_LAMBDA(int igpt, int ilay, int icol) {
+                if (cld_tau_gpt(icol,ilay,igpt) > 0) {
+                    subcol_mask(icol,igpt) = 1;
+                }
+            });
+            // Compute average over subcols
+            auto ngpt_inv = 1.0 / ngpt;
+            yakl::fortran::parallel_for(Bounds<1>(ncol), YAKL_LAMBDA(int icol) {
+                // This loop needs to be serial because of the atomic reduction
+                for (int igpt = 1; igpt <= ngpt; ++igpt) {
+                    cldtot(icol) += subcol_mask(icol,igpt) * ngpt_inv;
+                }
+            });
+        }
 
     }  // namespace rrtmgp
 }  // namespace scream

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -104,6 +104,10 @@ namespace scream {
          * Return a subcolumn mask consistent with a specified overlap assumption
          */
         int3d get_subcolumn_mask(const int ncol, const int nlay, const int ngpt, real2d &cldf, const int overlap_option, int1d &seeds);
+        /*
+         * Compute cloud area from 3d subcol cloud property
+         */
+        void compute_cloud_area(int ncol, int nlay, int ngpt, const real3d& cld_tau_gpt, real1d& cldtot);
 
         /* 
          * Provide a function to convert cloud (water and ice) mixing ratios to layer mass per unit area

--- a/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
+++ b/components/scream/src/physics/rrtmgp/tests/rrtmgp_unit_tests.cpp
@@ -599,4 +599,7 @@ TEST_CASE("rrtmgp_cloud_area") {
     });
     scream::rrtmgp::compute_cloud_area(ncol, nlay, ngpt, cldtau, cldtot);
     REQUIRE(cldtot.createHostCopy()(1) == 2.0 / 3.0);
+    cldtau.deallocate();
+    cldtot.deallocate();
+    yakl::finalize();
 }


### PR DESCRIPTION
Add a new output for vertically-projected cloud area (`cldtot`) computed from the subcolumn cloud optical depth used in the actual radiation computation. This provides a 2D cloud area fraction that is guaranteed to be consistent with the overlap assumption used in the radiation.

[B4B]