### PR TITLE
Add vertically integrated low, mid, and high-level cloud area

### DIFF
--- a/components/scream/data/scream_default_output.yaml
+++ b/components/scream/data/scream_default_output.yaml
@@ -48,6 +48,10 @@ Fields:
       - SW_flux_up
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
+      - cldtot
+      - cldlow
+      - cldmed
+      - cldhgh
       # Surface Fluxes
       - surf_evap
       - surf_sens_flux

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -839,22 +839,27 @@ namespace scream {
 
         }
 
-        void compute_cloud_area(int ncol, int nlay, int ngpt, const real3d& cld_tau_gpt, real1d& cldtot) {
-            // Subcolumn binary cld mask; if any layers are cloudy, 2d subcol mask is 1
+        void compute_cloud_area(
+                int ncol, int nlay, int ngpt, const Real pmin, const Real pmax, 
+                const real2d& pmid, const real3d& cld_tau_gpt, real1d& cld_area) {
+            // Subcolumn binary cld mask; if any layers with pressure between pmin and pmax are cloudy
+            // then 2d subcol mask is 1, otherwise it is 0
             auto subcol_mask = real2d("subcol_mask", ncol, ngpt);
             memset(subcol_mask, 0);
             yakl::fortran::parallel_for(Bounds<3>(ngpt, nlay, ncol), YAKL_LAMBDA(int igpt, int ilay, int icol) {
-                if (cld_tau_gpt(icol,ilay,igpt) > 0) {
+                // NOTE: using plev would need to assume level ordering (top to bottom or bottom to top), but
+                // using play/pmid does not
+                if (cld_tau_gpt(icol,ilay,igpt) > 0 && pmid(icol,ilay) >= pmin && pmid(icol,ilay) < pmax) {
                     subcol_mask(icol,igpt) = 1;
                 }
             });
-            // Compute average over subcols
+            // Compute average over subcols to get cloud area
             auto ngpt_inv = 1.0 / ngpt;
-            memset(cldtot, 0);
+            memset(cld_area, 0);
             yakl::fortran::parallel_for(Bounds<1>(ncol), YAKL_LAMBDA(int icol) {
                 // This loop needs to be serial because of the atomic reduction
                 for (int igpt = 1; igpt <= ngpt; ++igpt) {
-                    cldtot(icol) += subcol_mask(icol,igpt) * ngpt_inv;
+                    cld_area(icol) += subcol_mask(icol,igpt) * ngpt_inv;
                 }
             });
         }

--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -107,7 +107,9 @@ namespace scream {
         /*
          * Compute cloud area from 3d subcol cloud property
          */
-        void compute_cloud_area(int ncol, int nlay, int ngpt, const real3d& cld_tau_gpt, real1d& cldtot);
+        void compute_cloud_area(
+                int ncol, int nlay, int ngpt, Real pmin, Real pmax,
+                const real2d& pmid, const real3d& cld_tau_gpt, real1d& cld_area);
 
         /* 
          * Provide a function to convert cloud (water and ice) mixing ratios to layer mass per unit area


### PR DESCRIPTION
Add vertically integrated low (cldlow), mid (cldmed) and high-level (cldhgh) cloud area. This also adds these fields (along with cldtot) to the default output yaml file so that these diagnostics will be output by default for EAMxx runs. This should be BFB other than the addition of the three extra default output fields.