### PR TITLE
Remove warnings about no day columns

### DIFF
--- a/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
+++ b/components/scream/src/physics/rrtmgp/scream_rrtmgp_interface.cpp
@@ -610,8 +610,7 @@ namespace scream {
             // Copy data back to the device
             dayIndices_h.deep_copy_to(dayIndices);
             if (nday == 0) { 
-                if (logger)
-                  logger->warn("WARNING: no daytime columns found for this chunk!\n");
+                // No daytime columns in this chunk, skip the rest of this routine
                 return;
             }
 


### PR DESCRIPTION
Remove warnings about no sunlit columns in a given chunk. We are not (yet) load-balancing to pair night and day columns, so we expect some chunks to consist of all night columns, and we do not need these warnings filling up our logs (especially when running with many ranks at scale). Note that the load imbalance evident in the timers also indicates this condition is happening, so we do not lose much by taking these warnings out.

[B4B]