### PR TITLE
For perlmutter (pm-cpu and pm-gpu) use scratch instead of CFS for cases.

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -168,8 +168,7 @@
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
-    <!--CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-cpu</CIME_OUTPUT_ROOT-->
-    <CIME_OUTPUT_ROOT>$ENV{CFS}/e3sm/$ENV{USER}/e3sm_scratch/pm-cpu</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-cpu</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>
@@ -274,8 +273,7 @@
     <PROJECT>e3sm_g</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
-    <!--CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-gpu</CIME_OUTPUT_ROOT-->
-    <CIME_OUTPUT_ROOT>$ENV{CFS}/e3sm/$ENV{USER}/e3sm_scratch/pm-gpu</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-gpu</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>


### PR DESCRIPTION
For perlmutter (pm-cpu and pm-gpu) use scratch instead of CFS for cases.
Reverting the temporary change made while scratch was in maintenance 
[bfb]