### PR TITLE
EAMxx/IO: Reinstate free_decomp for now.

### DIFF
--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -843,7 +843,9 @@ contains
     ! Final step, free any pio decompostion memory that is no longer needed.
     !   Update: We are trying to reuse decompostions maximally, so we're
     ! skipping this step.
-    !call free_decomp()
+    !   Update to the update: For now, we're keeping this. We need to fix all
+    ! the tag nonuniqueness issues in the driver before this will work robustly.
+    call free_decomp()
 
   end subroutine eam_pio_closefile
 !=====================================================================!


### PR DESCRIPTION
I was too ambitious in PR #1969. For now, call free_decomp. I'm not doing a revert because 1969 has a memory-leak fix we want to keep plus some tag uniqueness work that will be needed later and is fine to have now.