### PR TITLE
EAMxx: Try again to reuse PIO decomps across files.

### DIFF
--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -462,7 +462,8 @@ get_io_decomp(const FieldLayout& layout)
   // Given a vector of dimensions names, create a unique decomp string to register with I/O
   // Note: We are hard-coding for only REAL input here.
   // TODO: would be to allow for other dtypes
-  std::string io_decomp_tag = "Real";
+  std::string io_decomp_tag = (std::string("Real-") + m_io_grid->name() + "-" +
+                               std::to_string(m_io_grid->get_num_global_dofs()));
   auto dims_names = get_vec_of_dims(layout);
   for (size_t i=0; i<dims_names.size(); ++i) {
     io_decomp_tag += "-" + dims_names[i];

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -482,8 +482,12 @@ register_variables(const std::string& filename,
   for (auto const& name : m_fields_names) {
     auto field = get_field(name);
     auto& fid  = field.get_header().get_identifier();
-    // Determine the IO-decomp and construct a vector of dimension ids for this variable:
-    std::string io_decomp_tag = fp_precision;
+    // Make a unique tag for each decomposition. To reuse decomps successfully,
+    // we must be careful to make the tags 1-1 with the intended decomp. Here we
+    // use the I/O grid name and its global #DOFs, then append the local
+    // dimension data.
+    std::string io_decomp_tag = (fp_precision + "-" + m_io_grid->name() + "-" +
+                                 std::to_string(m_io_grid->get_num_global_dofs()));
     std::vector<std::string> vec_of_dims;
     const auto& layout = fid.get_layout();
     std::string units = to_string(fid.get_units());

--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -843,9 +843,7 @@ contains
     ! Final step, free any pio decompostion memory that is no longer needed.
     !   Update: We are trying to reuse decompostions maximally, so we're
     ! skipping this step.
-    !   Update to the update: For now, we're keeping this. We need to fix all
-    ! the tag nonuniqueness issues in the driver before this will work robustly.
-    call free_decomp()
+    !call free_decomp()
 
   end subroutine eam_pio_closefile
 !=====================================================================!


### PR DESCRIPTION
Make the tag unique by including more information: I/O grid and global #DOFs.

[BFB]