### PR TITLE
EAMxx: Use simulation data type rather than I/O data type in decomp tag.

### DIFF
--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -486,7 +486,9 @@ register_variables(const std::string& filename,
     // we must be careful to make the tags 1-1 with the intended decomp. Here we
     // use the I/O grid name and its global #DOFs, then append the local
     // dimension data.
-    std::string io_decomp_tag = (fp_precision + "-" + m_io_grid->name() + "-" +
+    //   We use real here because the data type for the decomp is the one used
+    // in the simulation and not the one used in the output file.
+    std::string io_decomp_tag = (std::string("Real-") + m_io_grid->name() + "-" +
                                  std::to_string(m_io_grid->get_num_global_dofs()));
     std::vector<std::string> vec_of_dims;
     const auto& layout = fid.get_layout();


### PR DESCRIPTION
Consistent with the resolution to issue #1982, the decomp tag is the simulation data type, not the I/O data type. Thus, the same decomp can be used for both double and float outputs of a field of the same dimension.

[BFB]