### PR TITLE
EAMxx: Make iodesc_list_t%tag have length max_chars (256).

### DIFF
--- a/components/scream/src/share/io/scream_scorpio_interface.F90
+++ b/components/scream/src/share/io/scream_scorpio_interface.F90
@@ -124,9 +124,8 @@ module scream_scorpio_interface
   ! The tag needs the dim lengths, the dtype and map id (+ optional permutation)
   ! Define a recursive structure because we do not know ahead of time how many
   ! decompositions will be require
-  integer, parameter      :: tag_len           = 48
   type iodesc_list_t
-    character(tag_len)           :: tag              ! Unique tag associated with this decomposition
+    character(max_chars)         :: tag              ! Unique tag associated with this decomposition
     type(io_desc_t),     pointer :: iodesc => NULL() ! PIO - decomposition
     type(iodesc_list_t), pointer :: next => NULL()   ! Needed for recursive definition, the next list
     type(iodesc_list_t), pointer :: prev => NULL()   ! Needed for recursive definition, the list that points to this one


### PR DESCRIPTION
This is consistent with hist_var%pio_decomp_tag's length. In addition, longer unique tags need more space so we don't accidentally lose uniqueness when the tag string is truncated to 48.