### PR TITLE
Add intbilin maps for SPA

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -176,13 +176,16 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="atm_proc_base">
       <spa_remap_file>UNSET</spa_remap_file>
-      <spa_remap_file hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc</spa_remap_file>
-      <spa_remap_file hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne4pg2_mono.20220714.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30_to_ne4_mono_20220502.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne4pg2_mono.20220714.nc</spa_remap_file>
       <spa_remap_file hgrid="ne30np4">none</spa_remap_file>
-      <spa_remap_file hgrid="ne30np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne30pg2_mono.20220714.nc</spa_remap_file>
-      <spa_remap_file hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc</spa_remap_file>
-      <spa_remap_file hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne512np4_mono_20220506.nc</spa_remap_file>
-      <spa_remap_file hgrid="ne1024np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne1024pg2_nco_idw.c20220910.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne30np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne30pg2_mono.20220714.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne120np4_mono_20220502.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne512np4_mono_20220506.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne120np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne120pg2_intbilin_20221012.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne256np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne256pg2_intbilin_20221011.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne512np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne512pg2_intbilin_20221012.nc</spa_remap_file>
+      <spa_remap_file hgrid="ne1024np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne1024pg2_intbilin_20221012.nc</spa_remap_file>
       <spa_data_file>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</spa_data_file>
     </spa>
 
@@ -343,16 +346,16 @@ tweaking their $case/namelist_scream.xml file.
     ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
     ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/map_ne30_to_ne4_mono_20220502.nc,
-    <!-- ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne120np4_mono_20220502.nc, -->
-    <!-- ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne512np4_mono_20220506.nc, -->
+    ${DIN_LOC_ROOT}/atm/scream/maps/map_ne30_to_ne4_mono_20220502.nc,
+    <!-- ${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne120np4_mono_20220502.nc, -->
+    <!-- ${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne512np4_mono_20220506.nc, -->
     ${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220701.nc,
     ${DIN_LOC_ROOT}/atm/scream/init/screami_ne4np4L72_20220524.nc,
     <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220524.nc, -->
     <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220525.nc, -->
     ${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20220524.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne4pg2_mono.20220714.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/map_ne30np4_to_ne30pg2_mono.20220714.nc
+    ${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne4pg2_mono.20220714.nc,
+    ${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne30pg2_mono.20220714.nc
   </input_files>
 
   <!-- Homme control namelist -->


### PR DESCRIPTION
Add intbilin maps for SPA. Also move all SPA remap files into new inputdata location at `${DIN_LOC_ROOT}/atm/scream/maps` to clean up the `${DIN_LOC_ROOT}/atm/scream/init` directory.

[B4B]