### PR TITLE
Create local temp variables for device code

### DIFF
--- a/components/scream/src/share/property_checks/mass_and_energy_column_conservation_check.hpp
+++ b/components/scream/src/share/property_checks/mass_and_energy_column_conservation_check.hpp
@@ -76,6 +76,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION
   Real compute_total_mass_on_column (const KT::MemberType&       team,
+                                     const int                   nlevs,
                                      const uview_1d<const Real>& pseudo_density,
                                      const uview_1d<const Real>& qv,
                                      const uview_1d<const Real>& qc,
@@ -88,6 +89,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION
   Real compute_total_energy_on_column (const KT::MemberType&       team,
+                                       const int                   nlevs,
                                        const uview_1d<const Real>& pseudo_density,
                                        const uview_1d<const Real>& T_mid,
                                        const uview_2d<const Real>& horiz_winds,


### PR DESCRIPTION
Fixes the cuda mem check fails on Weaver. Only needed for nlev dimension, but I create them for ncols as well so that both dims are treated the same. 