### PR TITLE
Make grids store data inside Field objects rather than bare views

### DIFF
--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -153,9 +153,6 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Homme dynamics -->
     <homme inherit="atm_proc_base">
       <Grid>Dynamics</Grid>
-      <vertical_coordinate_filename>UNSET</vertical_coordinate_filename>
-      <vertical_coordinate_filename nlev="72">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L72_20220927.nc</vertical_coordinate_filename>
-      <vertical_coordinate_filename nlev="128">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L128_20220927.nc</vertical_coordinate_filename>
       <Moisture>moist</Moisture>
     </homme>
 
@@ -258,6 +255,9 @@ tweaking their $case/namelist_scream.xml file.
     <physics_grid_type hgrid=".*pg2">PG2</physics_grid_type>
     <physics_grid_rebalance>None</physics_grid_rebalance>
     <dynamics_namelist_file_name>./data/namelist.nl</dynamics_namelist_file_name>
+    <vertical_coordinate_filename>UNSET</vertical_coordinate_filename>
+    <vertical_coordinate_filename nlev="72">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L72_20220927.nc</vertical_coordinate_filename>
+    <vertical_coordinate_filename nlev="128">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L128_20220927.nc</vertical_coordinate_filename>
   </grids_manager>
 
   <!-- List of nc files for loading inputs on specified grids -->

--- a/components/scream/cmake/ScreamUtils.cmake
+++ b/components/scream/cmake/ScreamUtils.cmake
@@ -66,7 +66,7 @@ function(CreateUnitTestExec exec_name test_srcs scream_libs)
     ${CMAKE_CURRENT_BINARY_DIR}
   )
 
-  set(test_libs "${scream_libs}")
+  set(test_libs "${scream_libs};scream_test_support")
   list(APPEND test_libs "${SCREAM_TPL_LIBRARIES}")
 
   if (SCREAM_Fortran_FLAGS)

--- a/components/scream/src/control/atmosphere_driver.cpp
+++ b/components/scream/src/control/atmosphere_driver.cpp
@@ -203,40 +203,6 @@ void AtmosphereDriver::create_grids()
   // Each process will grab what they need
   m_atm_process_group->set_grids(m_grids_manager);
 
-  // Load reference/surface pressure fractions if needed. This
-  // is done inside dynamics, however, for standalone runs
-  // without dynamics, these values could be needed.
-  auto& ic_pl = m_atm_params.sublist("initial_conditions");
-  const bool load_hybrid_coeffs = ic_pl.get<bool>("Load Hybrid Coefficients",false);
-  if (load_hybrid_coeffs) {
-    using view_1d_host = AtmosphereInput::view_1d_host;
-    using vos_t = std::vector<std::string>;
-    using namespace ShortFieldTagsNames;
-
-    auto phys_grid = m_grids_manager->get_grid("Physics");
-    const auto nlev = phys_grid->get_num_vertical_levels();
-
-    // Read vcoords into host views
-    ekat::ParameterList vcoord_reader_pl;
-    vcoord_reader_pl.set("Filename",ic_pl.get<std::string>("Filename"));
-    vcoord_reader_pl.set<vos_t>("Field Names",{"hyam","hybm"});
-    std::map<std::string,view_1d_host> host_views = {
-      { "hyam", view_1d_host("hyam",nlev) },
-      { "hybm", view_1d_host("hybm",nlev) }
-    };
-    std::map<std::string,FieldLayout> layouts = {
-      { "hyam", FieldLayout({LEV}, {nlev}) },
-      { "hybm", FieldLayout({LEV}, {nlev}) }
-    };
-
-    AtmosphereInput vcoord_reader(vcoord_reader_pl, phys_grid, host_views, layouts);
-    vcoord_reader.read_variables();
-    vcoord_reader.finalize();
-
-    Kokkos::deep_copy(phys_grid->get_geometry_data("hyam"), host_views["hyam"]);
-    Kokkos::deep_copy(phys_grid->get_geometry_data("hybm"), host_views["hybm"]);
-  }
-
   m_ad_status |= s_grids_created;
 
   stop_timer("EAMxx::create_grids");
@@ -684,50 +650,6 @@ initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0
     restart_model ();
   } else {
     set_initial_conditions ();
-  }
-
-  // Check if lat/lon needs to be loaded
-  // Check whether we need to load latitude/longitude of physics grid dofs.
-  // This option allows the user to set lat or lon in their own
-  // test or run setup code rather than by file.
-  auto& ic_pl = m_atm_params.sublist("initial_conditions");
-  bool load_latitude  = ic_pl.get<bool>("Load Latitude",false);
-  bool load_longitude = ic_pl.get<bool>("Load Longitude",false);
-
-  if (load_longitude || load_latitude) {
-    using namespace ShortFieldTagsNames;
-    using view_d = AbstractGrid::geo_view_type;
-    using view_h = view_d::HostMirror;
-    auto grid = m_grids_manager->get_grid("Physics");
-    auto layout = grid->get_2d_scalar_layout();
-
-    std::vector<std::string> fnames;
-    std::map<std::string,FieldLayout> layouts;
-    std::map<std::string,view_h> host_views;
-    std::map<std::string,view_d> dev_views;
-    if (load_latitude) {
-      dev_views["lat"] = grid->get_geometry_data("lat");
-      host_views["lat"] = Kokkos::create_mirror_view(dev_views["lat"]);
-      layouts.emplace("lat",layout);
-      fnames.push_back("lat");
-    }
-    if (load_longitude) {
-      dev_views["lon"] = grid->get_geometry_data("lon");
-      host_views["lon"] = Kokkos::create_mirror_view(dev_views["lon"]);
-      layouts.emplace("lon",layout);
-      fnames.push_back("lon");
-    }
-
-    ekat::ParameterList lat_lon_params;
-    lat_lon_params.set("Field Names",fnames);
-    lat_lon_params.set("Filename",ic_pl.get<std::string>("Filename"));
-
-    AtmosphereInput lat_lon_reader(lat_lon_params,grid,host_views,layouts);
-    lat_lon_reader.read_variables();
-    lat_lon_reader.finalize();
-    for (auto& fname : fnames) {
-      Kokkos::deep_copy(dev_views[fname],host_views[fname]);
-    }
   }
 
 #ifdef SCREAM_HAS_MEMORY_USAGE
@@ -1339,7 +1261,7 @@ void AtmosphereDriver::report_res_dep_memory_footprint () const {
 
     my_dev_mem_usage += sizeof(AbstractGrid::gid_type)*nldofs;
 
-    my_dev_mem_usage += sizeof(int)*nldofs*grid->get_lid_to_idx_map().extent(1);
+    my_dev_mem_usage += sizeof(int)*grid->get_lid_to_idx_map().get_header().get_identifier().get_layout().size();
 
     const auto& geo_names = grid->get_geometry_data_names();
     my_dev_mem_usage += sizeof(Real)*geo_names.size()*nldofs;

--- a/components/scream/src/dynamics/homme/CMakeLists.txt
+++ b/components/scream/src/dynamics/homme/CMakeLists.txt
@@ -137,7 +137,7 @@ macro (CreateDynamicsLib HOMME_TARGET NP PLEV QSIZE)
     # Create library
     set (dynLibName scream_${hommeLibName})
     add_library(${dynLibName} ${SCREAM_DYNAMICS_SOURCES})
-    target_link_libraries(${dynLibName} scream_share ${hommeLibName})
+    target_link_libraries(${dynLibName} scream_share scream_io ${hommeLibName})
     get_target_property(modulesDir ${hommeLibName} Fortran_MODULE_DIRECTORY)
     set_target_properties(${dynLibName} PROPERTIES Fortran_MODULE_DIRECTORY ${modulesDir})
     target_include_directories(${dynLibName} PUBLIC ${modulesDir})

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -29,9 +29,8 @@
 #include "dynamics/homme/homme_dynamics_helpers.hpp"
 #include "dynamics/homme/interface/scream_homme_interface.hpp"
 #include "physics/share/physics_constants.hpp"
-#include "share/io/scorpio_input.hpp"
 #include "share/util/scream_common_physics_functions.hpp"
-#include "share/util//scream_column_ops.hpp"
+#include "share/util/scream_column_ops.hpp"
 #include "share/property_checks/field_lower_bound_check.hpp"
 
 // Ekat includes
@@ -91,10 +90,6 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
     // Set moisture in homme base on input file:
     const auto& moisture = m_params.get<std::string>("Moisture");
     set_homme_param("moisture",ekat::upper_case(moisture)!="DRY");
-
-    // Read vertical coordinates, before initing the data structures,
-    // so that Homme::HybridVCoords will be valid when stored in all the functors.
-    init_homme_vcoord ();
 
     prim_init_data_structures_f90 ();
   }
@@ -1231,51 +1226,6 @@ copy_dyn_states_to_all_timelevels () {
   vtheta_dp.subfield(1,nm1).deep_copy(vtheta_dp.subfield(1,n0));
   vtheta_dp.subfield(1,np1).deep_copy(vtheta_dp.subfield(1,n0));
   qdp.subfield(1,np1_qdp).deep_copy(qdp.subfield(1,n0_qdp));
-}
-
-void HommeDynamics::init_homme_vcoord () {
-  using view_1d_host = AtmosphereInput::view_1d_host; 
-  using vos_t = std::vector<std::string>;
-  using namespace ShortFieldTagsNames;
-
-  const int nlev_int = HOMMEXX_NUM_INTERFACE_LEV;
-  const int nlev_mid = HOMMEXX_NUM_PHYSICAL_LEV;
-
-  // Read vcoords into host views
-  ekat::ParameterList vcoord_reader_pl;
-  vcoord_reader_pl.set("Filename",m_params.get<std::string>("vertical_coordinate_filename"));
-  vcoord_reader_pl.set<vos_t>("Field Names",{"hyai","hybi","hyam","hybm"});
-  std::map<std::string,view_1d_host> host_views = {
-    { "hyai", view_1d_host("hyai",nlev_int) },
-    { "hybi", view_1d_host("hybi",nlev_int) },
-    { "hyam", view_1d_host("hyam",nlev_mid) },
-    { "hybm", view_1d_host("hybm",nlev_mid) }
-  };
-  std::map<std::string,FieldLayout> layouts = {
-    { "hyai", FieldLayout({ILEV},{nlev_int}) },
-    { "hybi", FieldLayout({ILEV},{nlev_int}) },
-    { "hyam", FieldLayout({LEV}, {nlev_mid}) },
-    { "hybm", FieldLayout({LEV}, {nlev_mid}) }
-  };
-
-  AtmosphereInput vcoord_reader(m_comm,vcoord_reader_pl);
-  vcoord_reader.init(m_dyn_grid,host_views,layouts);
-  vcoord_reader.read_variables();
-  vcoord_reader.finalize();
-  
-  // Pass host views data to hvcoord init function
-  const auto ps0 = Homme::PhysicalConstants::p0;
-
-  // Set vcoords in f90
-  prim_set_hvcoords_f90 (ps0,
-                         host_views["hyai"].data(),
-                         host_views["hybi"].data(),
-                         host_views["hyam"].data(),
-                         host_views["hybm"].data());
-
-  // Store hybrid coords in phys grid
-  Kokkos::deep_copy(m_phys_grid->get_geometry_data("hyam"), host_views["hyam"]);
-  Kokkos::deep_copy(m_phys_grid->get_geometry_data("hybm"), host_views["hybm"]);
 }
 
 // =========================================================================================

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -118,8 +118,6 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
   constexpr int N   = HOMMEXX_PACK_SIZE;
 
   // Some units
-  const auto nondim = Units::nondimensional();
-  const auto rho = kg/(m*m*m);
   auto Q = kg/kg;
   Q.set_string("kg/kg");
 

--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -60,9 +60,6 @@ protected:
   // Restart homme
   void restart_homme_state ();
 
-  // Read vertical coordinates and set them in hommexx's structures
-  void init_homme_vcoord ();
-
   // Updates p_mid
   void update_pressure (const std::shared_ptr<const AbstractGrid>& grid);
 

--- a/components/scream/src/dynamics/homme/homme_grids_manager.cpp
+++ b/components/scream/src/dynamics/homme/homme_grids_manager.cpp
@@ -3,12 +3,18 @@
 #include "dynamics/homme/physics_dynamics_remapper.hpp"
 #include "dynamics/homme/homme_dynamics_helpers.hpp"
 
+#ifndef NDEBUG
+#include "share/property_checks/field_nan_check.hpp"
+#endif
+
+#include "share/io/scorpio_input.hpp"
 #include "share/grid/se_grid.hpp"
 #include "share/grid/point_grid.hpp"
 #include "share/grid/remap/inverse_remapper.hpp"
 
-// Get all Homme's compile-time dims
+// Get all Homme's compile-time dims and constants
 #include "homme_dimensions.hpp"
+#include "PhysicalConstants.hpp"
 
 #include "ekat/std_meta/ekat_std_utils.hpp"
 
@@ -129,6 +135,8 @@ void HommeGridsManager::build_dynamics_grid () {
     return;
   }
 
+  using gid_t = AbstractGrid::gid_type;
+
   // Get dimensions and create "empty" grid
   const int nlelem = get_num_local_elems_f90();
   const int nlev   = get_nlev_f90();
@@ -136,47 +144,41 @@ void HommeGridsManager::build_dynamics_grid () {
   auto dyn_grid = std::make_shared<SEGrid>("Dynamics",nlelem,HOMMEXX_NP,nlev,m_comm);
   dyn_grid->setSelfPointer(dyn_grid);
 
-  const int ndofs = nlelem*HOMMEXX_NP*HOMMEXX_NP;
+  const auto layout2d = dyn_grid->get_2d_scalar_layout();
+  const auto rad = ekat::units::Units::nondimensional();
 
-  // Create the gids, elgpgp, coords, area views
-  AbstractGrid::dofs_list_type      dg_dofs("dyn dofs",ndofs);
-  AbstractGrid::dofs_list_type      cg_dofs("dyn dofs",ndofs);
-  AbstractGrid::lid_to_idx_map_type elgpgp("dof idx",ndofs,3);
-  AbstractGrid::geo_view_type       lat("lat",ndofs);
-  AbstractGrid::geo_view_type       lon("lon",ndofs);
-  auto h_cg_dofs   = Kokkos::create_mirror_view(cg_dofs);
-  auto h_dg_dofs   = Kokkos::create_mirror_view(dg_dofs);
-  auto h_elgpgp = Kokkos::create_mirror_view(elgpgp);
-  auto h_lat    = Kokkos::create_mirror_view(lat);
-  auto h_lon    = Kokkos::create_mirror_view(lon);
+  // Filling the cg/dg gids, elgpgp, coords, lat/lon views
+  auto dg_dofs = dyn_grid->get_dofs_gids();
+  auto cg_dofs = dyn_grid->get_cg_dofs_gids();
+  auto elgpgp  = dyn_grid->get_lid_to_idx_map();
+  auto lat     = dyn_grid->create_geometry_data("lat",layout2d,rad);
+  auto lon     = dyn_grid->create_geometry_data("lon",layout2d,rad);
+
+  auto dg_dofs_h = dg_dofs.get_view<gid_t*,Host>();
+  auto cg_dofs_h = cg_dofs.get_view<gid_t*,Host>();
+  auto elgpgp_h  = elgpgp.get_view<int**,Host>();
+  auto lat_h     = lat.get_view<Real***,Host>();
+  auto lon_h     = lon.get_view<Real***,Host>();
 
   // Get (ie,igp,jgp,gid) data for each dof
-  get_dyn_grid_data_f90 (h_dg_dofs.data(),h_cg_dofs.data(),h_elgpgp.data(), h_lat.data(), h_lon.data());
+  get_dyn_grid_data_f90 (dg_dofs_h.data(),cg_dofs_h.data(),elgpgp_h.data(), lat_h.data(), lon_h.data());
 
-  Kokkos::deep_copy(dg_dofs,h_dg_dofs);
-  Kokkos::deep_copy(cg_dofs,h_cg_dofs);
-  Kokkos::deep_copy(elgpgp,h_elgpgp);
-  Kokkos::deep_copy(lat,h_lat);
-  Kokkos::deep_copy(lon,h_lon);
+  dg_dofs.sync_to_dev();
+  cg_dofs.sync_to_dev();
+  elgpgp.sync_to_dev();
+  lat.sync_to_dev();
+  lon.sync_to_dev();
 
 #ifndef NDEBUG
-  // Check that latitude and longitude are valid
-  using KT = KokkosTypes<DefaultDevice>;
-  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(ndofs,nlev);
-  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const KT::MemberType& team) {
-    const Int i = team.league_rank();
-
-    EKAT_KERNEL_ASSERT_MSG(!ekat::impl::is_nan(lat(i)), "Error! NaN values detected for latitude.");
-    EKAT_KERNEL_ASSERT_MSG(!ekat::impl::is_nan(lon(i)), "Error! NaN values detected for longitude.");
-  });
+  auto lat_check = std::make_shared<FieldNaNCheck>(lat,dyn_grid)->check();
+  EKAT_REQUIRE_MSG (lat_check.result==CheckResult::Pass,
+      "ERROR! NaN values detected in latitude field.\n" + lat_check.msg);
+  auto lon_check = std::make_shared<FieldNaNCheck>(lon,dyn_grid)->check();
+  EKAT_REQUIRE_MSG (lon_check.result==CheckResult::Pass,
+      "ERROR! NaN values detected in longitude field.\n" + lon_check.msg);
 #endif
 
-  // Set dofs and geo data in the grid
-  dyn_grid->set_dofs (dg_dofs);
-  dyn_grid->set_cg_dofs (cg_dofs);
-  dyn_grid->set_lid_to_idx_map(elgpgp);
-  dyn_grid->set_geometry_data ("lat", lat);
-  dyn_grid->set_geometry_data ("lon", lon);
+  init_homme_vcoord(dyn_grid);
 
   add_grid(dyn_grid);
 }
@@ -204,52 +206,110 @@ build_physics_grid (const ci_string& type, const ci_string& rebalance) {
   phys_grid->setSelfPointer(phys_grid);
 
   // Create the gids, coords, area views
-  AbstractGrid::dofs_list_type dofs("phys dofs",nlcols);
-  AbstractGrid::geo_view_type  lat("lat",nlcols);
-  AbstractGrid::geo_view_type  lon("lon",nlcols);
-  AbstractGrid::geo_view_type  area("area",nlcols);
-  AbstractGrid::geo_view_type  hyam("hyam",nlev);
-  AbstractGrid::geo_view_type  hybm("hybm",nlev);
-  auto h_dofs = Kokkos::create_mirror_view(dofs);
-  auto h_lat  = Kokkos::create_mirror_view(lat);
-  auto h_lon  = Kokkos::create_mirror_view(lon);
-  auto h_area = Kokkos::create_mirror_view(area);
+  using namespace ShortFieldTagsNames;
+  const auto layout2d = phys_grid->get_2d_scalar_layout();
+  const auto nondim = ekat::units::Units::nondimensional();
 
-  // For the following, set to NaN. They will need to be grabbed
-  // from input files later.
-  Kokkos::deep_copy(hyam, std::nan(""));
-  Kokkos::deep_copy(hybm, std::nan(""));
+  auto dofs = phys_grid->get_dofs_gids();
+  auto lat  = phys_grid->create_geometry_data("lat",layout2d,nondim);
+  auto lon  = phys_grid->create_geometry_data("lon",layout2d,nondim);
+  auto area = phys_grid->create_geometry_data("area",layout2d,nondim);
+
+  using gid_t = AbstractGrid::gid_type;
+
+  auto dofs_h = dofs.get_view<gid_t*,Host>();
+  auto lat_h  = lat.get_view<Real*,Host>();
+  auto lon_h  = lon.get_view<Real*,Host>();
+  auto area_h = lon.get_view<Real*,Host>();
 
   // Get all specs of phys grid cols (gids, coords, area)
-  get_phys_grid_data_f90 (pg_code, h_dofs.data(), h_lat.data(), h_lon.data(), h_area.data());
+  get_phys_grid_data_f90 (pg_code, dofs_h.data(), lat_h.data(), lon_h.data(), area_h.data());
 
-  Kokkos::deep_copy(dofs,h_dofs);
-  Kokkos::deep_copy(lat, h_lat);
-  Kokkos::deep_copy(lon, h_lon);
-  Kokkos::deep_copy(area,h_area);
-  
+  dofs.sync_to_dev();
+  lat.sync_to_dev();
+  lon.sync_to_dev();
+  area.sync_to_dev();
+
 #ifndef NDEBUG
-  // Check that latitude, longitude, and area are valid
-  using KT = KokkosTypes<DefaultDevice>;
-  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(nlcols,nlev);
-  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const KT::MemberType& team) {
-    const Int i = team.league_rank();
-
-    EKAT_KERNEL_ASSERT_MSG(!ekat::impl::is_nan(lat(i)),                   "Error! NaN values detected for latitude.");
-    EKAT_KERNEL_ASSERT_MSG(!ekat::impl::is_nan(lon(i)),                   "Error! NaN values detected for longitude.");
-    EKAT_KERNEL_ASSERT_MSG(area(i) >  0  && !ekat::impl::is_nan(area(i)), "Error! Non-positve or NaN values detected for area.");
-  });
+  auto lat_check = std::make_shared<FieldNaNCheck>(lat,phys_grid)->check();
+  EKAT_REQUIRE_MSG (lat_check.result==CheckResult::Pass,
+      "ERROR! NaN values detected in latitude field.\n" + lat_check.msg);
+  auto lon_check = std::make_shared<FieldNaNCheck>(lon,phys_grid)->check();
+  EKAT_REQUIRE_MSG (lon_check.result==CheckResult::Pass,
+      "ERROR! NaN values detected in longitude field.\n" + lon_check.msg);
+  auto area_check = std::make_shared<FieldNaNCheck>(area,phys_grid)->check();
+  EKAT_REQUIRE_MSG (area_check.result==CheckResult::Pass,
+      "ERROR! NaN values detected in area field.\n" + area_check.msg);
 #endif
 
-  // Set dofs and geo data in the grid
-  phys_grid->set_dofs(dofs);
-  phys_grid->set_geometry_data("lat",lat);
-  phys_grid->set_geometry_data("lon",lon);
-  phys_grid->set_geometry_data("area",area);
-  phys_grid->set_geometry_data("hyam",hyam);
-  phys_grid->set_geometry_data("hybm",hybm);
+  // Copy hybrid coords from dyn grid into phys grid
+  auto hyai = get_grid("Dynamics")->get_geometry_data("hyai");
+  auto hybi = get_grid("Dynamics")->get_geometry_data("hybi");
+  auto hyam = get_grid("Dynamics")->get_geometry_data("hyam");
+  auto hybm = get_grid("Dynamics")->get_geometry_data("hybm");
+  phys_grid->set_geometry_data(hyai);
+  phys_grid->set_geometry_data(hybi);
+  phys_grid->set_geometry_data(hyam);
+  phys_grid->set_geometry_data(hybm);
 
   add_grid(phys_grid);
+}
+
+void HommeGridsManager::init_homme_vcoord (const nonconstgrid_ptr_type& dyn_grid) {
+  using view_1d_host = AtmosphereInput::view_1d_host; 
+  using vos_t = std::vector<std::string>;
+  using namespace ShortFieldTagsNames;
+
+  const int nlev_int = HOMMEXX_NUM_INTERFACE_LEV;
+  const int nlev_mid = HOMMEXX_NUM_PHYSICAL_LEV;
+
+  // Read vcoords into host views
+  ekat::ParameterList vcoord_reader_pl;
+  vcoord_reader_pl.set("Filename",m_params.get<std::string>("vertical_coordinate_filename"));
+  vcoord_reader_pl.set<vos_t>("Field Names",{"hyai","hybi","hyam","hybm"});
+
+  FieldLayout layout_mid ({ LEV},{nlev_mid});
+  FieldLayout layout_int ({ILEV},{nlev_int});
+  constexpr auto nondim = ekat::units::Units::nondimensional();
+
+  auto hyai = dyn_grid->create_geometry_data("hyai",layout_int,nondim);
+  auto hybi = dyn_grid->create_geometry_data("hybi",layout_int,nondim);
+  auto hyam = dyn_grid->create_geometry_data("hyam",layout_mid,nondim);
+  auto hybm = dyn_grid->create_geometry_data("hybm",layout_mid,nondim);
+
+  std::map<std::string,view_1d_host> host_views = {
+    { "hyai", hyai.get_view<Real*,Host>() },
+    { "hybi", hybi.get_view<Real*,Host>() },
+    { "hyam", hyam.get_view<Real*,Host>() },
+    { "hybm", hybm.get_view<Real*,Host>() }
+  };
+  std::map<std::string,FieldLayout> layouts = {
+    { "hyai", layout_int },
+    { "hybi", layout_int },
+    { "hyam", layout_mid },
+    { "hybm", layout_mid }
+  };
+
+  AtmosphereInput vcoord_reader(m_comm,vcoord_reader_pl);
+  vcoord_reader.init(dyn_grid,host_views,layouts);
+  vcoord_reader.read_variables();
+  vcoord_reader.finalize();
+
+  // Sync to device
+  hyai.sync_to_dev();
+  hybi.sync_to_dev();
+  hyam.sync_to_dev();
+  hybm.sync_to_dev();
+  
+  // Pass host views data to hvcoord init function
+  const auto ps0 = Homme::PhysicalConstants::p0;
+
+  // Set vcoords in f90
+  prim_set_hvcoords_f90 (ps0,
+                         host_views["hyai"].data(),
+                         host_views["hybi"].data(),
+                         host_views["hyam"].data(),
+                         host_views["hybm"].data());
 }
 
 void HommeGridsManager::

--- a/components/scream/src/dynamics/homme/homme_grids_manager.hpp
+++ b/components/scream/src/dynamics/homme/homme_grids_manager.hpp
@@ -33,6 +33,9 @@ protected:
 
 protected:
 
+  // Read vertical coordinates and set them in hommexx's structures
+  void init_homme_vcoord (const nonconstgrid_ptr_type& dyn_grid);
+
   remapper_ptr_type
   do_create_remapper (const grid_ptr_type from_grid,
                       const grid_ptr_type to_grid) const;

--- a/components/scream/src/dynamics/homme/interface/dyn_grid_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/dyn_grid_mod.F90
@@ -54,7 +54,7 @@ contains
     !
     ! Inputs
     !
-    real(kind=c_double), intent(out) :: lat (:), lon(:)
+    real(kind=c_double), intent(out) :: lat (:,:,:), lon(:,:,:)
     integer(kind=c_int), intent(out) :: cg_gids (:), dg_gids(:), elgpgp(:,:)
     !
     ! Local(s)
@@ -85,8 +85,8 @@ contains
           idof = (ie-1)*16+(jp-1)*4+ip
           cg_gids(idof) = INT(el_cg_gids(ip,jp,ie),kind=c_int)
           dg_gids(idof) = INT(el_dg_gids(ip,jp,ie),kind=c_int)
-          lat(idof)  = elem(ie)%spherep(ip,jp)%lat * 180.0_c_double/pi
-          lon(idof)  = elem(ie)%spherep(ip,jp)%lon * 180.0_c_double/pi
+          lat(ip,jp,ie)  = elem(ie)%spherep(ip,jp)%lat * 180.0_c_double/pi
+          lon(ip,jp,ie)  = elem(ie)%spherep(ip,jp)%lon * 180.0_c_double/pi
           elgpgp(1,idof) = ie-1
           elgpgp(2,idof) = jp-1
           elgpgp(3,idof) = ip-1

--- a/components/scream/src/dynamics/homme/interface/homme_grid_mod.F90
+++ b/components/scream/src/dynamics/homme/interface/homme_grid_mod.F90
@@ -103,7 +103,7 @@ contains
     !
     ! Local(s)
     !
-    real(kind=c_double), pointer :: lat (:), lon(:)
+    real(kind=c_double), pointer :: lat (:,:,:), lon(:,:,:)
     integer(kind=c_int), pointer :: cg_gids (:), dg_gids(:), elgpgp(:,:)
 
     ! Sanity check
@@ -112,8 +112,8 @@ contains
     call c_f_pointer (dg_gids_ptr, dg_gids, [nelemd*np*np])
     call c_f_pointer (cg_gids_ptr, cg_gids, [nelemd*np*np])
     call c_f_pointer (elgpgp_ptr,  elgpgp,  [3,nelemd*np*np])
-    call c_f_pointer (lat_ptr,     lat,     [nelemd*np*np])
-    call c_f_pointer (lon_ptr,     lon,     [nelemd*np*np])
+    call c_f_pointer (lat_ptr,     lat,     [np,np,nelemd])
+    call c_f_pointer (lon_ptr,     lon,     [np,np,nelemd])
 
     call get_my_dyn_data (dg_gids, cg_gids, elgpgp, lat, lon)
   end subroutine get_dyn_grid_data_f90

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.cpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.cpp
@@ -53,7 +53,7 @@ PhysicsDynamicsRemapper (const grid_ptr_type& phys_grid,
   m_phys_grid = phys_grid;
 
   m_num_phys_cols = phys_grid->get_num_local_dofs();
-  m_lid2elgp      = m_dyn_grid->get_lid_to_idx_map();
+  m_lid2elgp      = m_dyn_grid->get_lid_to_idx_map().get_view<const int**>();
 
   // For each phys dofs, we find a corresponding dof in the dyn grid.
   // Notice that such dyn dof may not be unique (if phys dof is on an edge
@@ -726,8 +726,10 @@ create_p2d_map () {
 
   auto se_dyn = std::dynamic_pointer_cast<const SEGrid>(m_dyn_grid);
   EKAT_REQUIRE_MSG(se_dyn, "Error! Something went wrong casting dyn grid to a SEGrid.\n");
-  auto dyn_gids  = se_dyn->get_cg_dofs_gids();
-  auto phys_gids = m_phys_grid->get_dofs_gids();
+
+  using gid_t = AbstractGrid::gid_type;
+  auto dyn_gids  = se_dyn->get_cg_dofs_gids().get_view<const gid_t*>();
+  auto phys_gids = m_phys_grid->get_dofs_gids().get_view<const gid_t*>();
 
   auto policy = KokkosTypes<DefaultDevice>::RangePolicy(0,num_phys_dofs);
   m_p2d = decltype(m_p2d) ("",num_phys_dofs);

--- a/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/scream/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -80,7 +80,7 @@ protected:
   grid_ptr_type     m_phys_grid;
 
   int m_num_phys_cols;
-  typename grid_type::lid_to_idx_map_type    m_lid2elgp;
+  typename Field::view_dev_t<const int**>  m_lid2elgp;
 
   std::shared_ptr<Homme::BoundaryExchange>  m_be;
 

--- a/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/scream/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -80,12 +80,9 @@ TEST_CASE("remap", "") {
   // Get physics and dynamics grids, and their dofs
   auto phys_grid = gm.get_grid("Physics GLL");
   auto dyn_grid  = std::dynamic_pointer_cast<const SEGrid>(gm.get_grid("Dynamics"));
-  auto h_p_dofs = Kokkos::create_mirror_view(phys_grid->get_dofs_gids());
-  auto h_d_dofs = Kokkos::create_mirror_view(dyn_grid->get_cg_dofs_gids());
-  auto h_d_lid2idx = Kokkos::create_mirror_view(dyn_grid->get_lid_to_idx_map());
-  Kokkos::deep_copy(h_p_dofs,phys_grid->get_dofs_gids());
-  Kokkos::deep_copy(h_d_dofs,dyn_grid->get_cg_dofs_gids());
-  Kokkos::deep_copy(h_d_lid2idx,dyn_grid->get_lid_to_idx_map());
+  auto h_p_dofs = phys_grid->get_dofs_gids().get_view<const gid_t*,Host>();
+  auto h_d_dofs = dyn_grid->get_cg_dofs_gids().get_view<const gid_t*,Host>();
+  auto h_d_lid2idx = dyn_grid->get_lid_to_idx_map().get_view<const int**,Host>();
 
   // Get some dimensions for Homme
   constexpr int np  = HOMMEXX_NP;
@@ -616,12 +613,9 @@ TEST_CASE("combo_remap", "") {
   // Get physics and dynamics grids, and their dofs
   auto phys_grid = gm.get_grid("Physics GLL");
   auto dyn_grid  = std::dynamic_pointer_cast<const SEGrid>(gm.get_grid("Dynamics"));
-  auto h_p_dofs = Kokkos::create_mirror_view(phys_grid->get_dofs_gids());
-  auto h_d_dofs = Kokkos::create_mirror_view(dyn_grid->get_cg_dofs_gids());
-  auto h_d_lid2idx = Kokkos::create_mirror_view(dyn_grid->get_lid_to_idx_map());
-  Kokkos::deep_copy(h_p_dofs,phys_grid->get_dofs_gids());
-  Kokkos::deep_copy(h_d_dofs,dyn_grid->get_cg_dofs_gids());
-  Kokkos::deep_copy(h_d_lid2idx,dyn_grid->get_lid_to_idx_map());
+  auto h_p_dofs = phys_grid->get_dofs_gids().get_view<const gid_t*,Host>();
+  auto h_d_dofs = dyn_grid->get_cg_dofs_gids().get_view<const gid_t*,Host>();
+  auto h_d_lid2idx = dyn_grid->get_lid_to_idx_map().get_view<const int**,Host>();
 
   // Get some dimensions for Homme
   constexpr int np  = HOMMEXX_NP;

--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -6,6 +6,7 @@
 
 #include "dynamics/register_dynamics.hpp"
 #include "physics/register_physics.hpp"
+#include "diagnostics/register_diagnostics.hpp"
 #include "control/register_surface_coupling.hpp"
 
 #include "mct_coupling/ScreamContext.hpp"
@@ -97,9 +98,10 @@ void scream_create_atm_instance (const MPI_Fint f_comm, const int atm_id,
     scream_params.sublist("Debug").set<std::string>("Atm Log File",atm_log_file);
 
     // Need to register products in the factories *before* we attempt to create any.
-    // In particular, register all atm processes, and all grids managers.
+    // In particular, register all atm processes, grids managers, and diagnostics.
     register_dynamics();
     register_physics();
+    register_diagnostics();
     register_surface_coupling();
 
     // Create the bare ad, then start the initialization sequence

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -374,10 +374,8 @@ void RRTMGPRadiation::run_impl (const int dt) {
   using CO = scream::ColumnOps<DefaultDevice,Real>;
 
   // get a host copy of lat/lon
-  auto h_lat  = Kokkos::create_mirror_view(m_lat);
-  auto h_lon  = Kokkos::create_mirror_view(m_lon);
-  Kokkos::deep_copy(h_lat,m_lat);
-  Kokkos::deep_copy(h_lon,m_lon);
+  auto h_lat  = m_lat.get_view<const Real*,Host>();
+  auto h_lon  = m_lon.get_view<const Real*,Host>();
 
   // Get data from the FieldManager
   auto d_pmid = get_field_in("p_mid").get_view<const Real**>();
@@ -679,7 +677,7 @@ void RRTMGPRadiation::run_impl (const int dt) {
       } else {
         // This gives (dry) mass mixing ratios
         scream::physics::trcmix(
-          name, m_lat, d_pmid, d_vmr,
+          name, m_lat.get_view<const Real*>(), d_pmid, d_vmr,
           m_co2vmr, m_n2ovmr, m_ch4vmr, m_f11vmr, m_f12vmr
         );
         // Back out volume mixing ratios

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -51,8 +51,8 @@ public:
   int m_col_chunk_size;
   std::vector<int> m_col_chunk_beg;
   int m_nlay;
-  view_1d_real m_lat;
-  view_1d_real m_lon;
+  Field m_lat;
+  Field m_lon;
 
   // Whether we use aerosol forcing in radiation
   bool m_do_aerosol_rad;

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -35,8 +35,8 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   m_num_cols = m_grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = m_grid->get_num_vertical_levels();  // Number of levels per column
 
-  m_cell_area = m_grid->get_geometry_data("area"); // area of each cell
-  m_cell_lat  = m_grid->get_geometry_data("lat"); // area of each cell
+  m_cell_area = m_grid->get_geometry_data("area").get_view<const Real*>(); // area of each cell
+  m_cell_lat  = m_grid->get_geometry_data("lat").get_view<const Real*>(); // area of each cell
 
   // Define the different field layouts that will be used for this process
   using namespace ShortFieldTagsNames;
@@ -422,8 +422,8 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   // maximum number of levels in pbl from surface
   const auto pref_mid = m_buffer.pref_mid;
   const auto s_pref_mid = ekat::scalarize(pref_mid);
-  const auto hyam = m_grid->get_geometry_data("hyam");
-  const auto hybm = m_grid->get_geometry_data("hybm");
+  const auto hyam = m_grid->get_geometry_data("hyam").get_view<const Real*>();
+  const auto hybm = m_grid->get_geometry_data("hybm").get_view<const Real*>();
   const auto ps0 = C::P0;
   const auto psref = ps0;
   Kokkos::parallel_for(Kokkos::RangePolicy<>(0, m_num_levs), KOKKOS_LAMBDA (const int lev) {

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -547,8 +547,8 @@ protected:
   Int m_num_tracers;
   Int hdtime;
 
-  KokkosTypes<DefaultDevice>::view_1d<Real> m_cell_area;
-  KokkosTypes<DefaultDevice>::view_1d<Real> m_cell_lat;
+  KokkosTypes<DefaultDevice>::view_1d<const Real> m_cell_area;
+  KokkosTypes<DefaultDevice>::view_1d<const Real> m_cell_lat;
 
   // Struct which contains local variables
   Buffer m_buffer;

--- a/components/scream/src/physics/shoc/tests/shoc_tests.cpp
+++ b/components/scream/src/physics/shoc/tests/shoc_tests.cpp
@@ -23,7 +23,7 @@ TEST_CASE("FortranDataIterator", "shoc") {
   REQUIRE(f.extent[1] == 1);
   REQUIRE(f.extent[2] == 1);
   REQUIRE(f.data == d->host_dx.data());
-  REQUIRE(f.size == d->shcol);
+  REQUIRE(static_cast<int>(f.size) == d->shcol);
 }
 
 TEST_CASE("shoc_init_f", "shoc") {

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -36,7 +36,7 @@ void SPA::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   const auto& grid_name = m_grid->name();
   m_num_cols = m_grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = m_grid->get_num_vertical_levels();  // Number of levels per column
-  m_dofs_gids = m_grid->get_dofs_gids();
+  m_dofs_gids = m_grid->get_dofs_gids().get_view<const gid_type*>();
   m_min_global_dof    = m_grid->get_global_min_dof_gid();
 
   // Define the different field layouts that will be used for this process

--- a/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.hpp
+++ b/components/scream/src/physics/spa/atmosphere_prescribed_aerosol.hpp
@@ -31,7 +31,7 @@ public:
   using view_1d         = typename SPAFunc::view_1d<Spack>;
   using view_2d         = typename SPAFunc::view_2d<Spack>;
   using view_3d         = typename SPAFunc::view_3d<Spack>;
-  using view_1d_dof     = typename SPAFunc::view_1d<gid_type>;
+  using view_1d_dof     = typename SPAFunc::view_1d<const gid_type>;
 
   template<typename ScalarT>
   using uview_1d = Unmanaged<typename KT::template view_1d<ScalarT>>;

--- a/components/scream/src/physics/spa/spa_functions.hpp
+++ b/components/scream/src/physics/spa/spa_functions.hpp
@@ -172,15 +172,15 @@ struct SPAFunctions
     const SPAOutput&  data_out);
 
   static void get_remap_weights_from_file(
-    const std::string&       remap_file_name,
-    gid_type                 min_dof,
-    const view_1d<gid_type>& dofs_gids,
-          SPAHorizInterp&    spa_horiz_interp);
+    const std::string&             remap_file_name,
+    const gid_type                 min_dof,
+    const view_1d<const gid_type>& dofs_gids,
+          SPAHorizInterp&          spa_horiz_interp);
 
   static void set_remap_weights_one_to_one(
-    gid_type                 min_dof,
-    const view_1d<gid_type>& dofs_gids,
-          SPAHorizInterp&    spa_horiz_interp);
+    gid_type                       min_dof,
+    const view_1d<const gid_type>& dofs_gids,
+          SPAHorizInterp&          spa_horiz_interp);
 
   static void update_spa_data_from_file(
     const std::string&    spa_data_file_name,

--- a/components/scream/src/share/CMakeLists.txt
+++ b/components/scream/src/share/CMakeLists.txt
@@ -17,7 +17,6 @@ set(SHARE_SRC
   field/field_manager.cpp
   grid/abstract_grid.cpp
   grid/grids_manager.cpp
-  grid/mesh_free_grids_manager.cpp
   grid/se_grid.cpp
   grid/point_grid.cpp
   grid/remap/abstract_remapper.cpp
@@ -27,7 +26,6 @@ set(SHARE_SRC
   property_checks/field_nan_check.cpp
   property_checks/field_within_interval_check.cpp
   property_checks/mass_and_energy_column_conservation_check.cpp
-  util/scream_test_session.cpp
   util/scream_time_stamp.cpp
   util/scream_timing.cpp
   util/scream_utils.cpp
@@ -80,8 +78,16 @@ if (NOT WGET STREQUAL "WGET-NOTFOUND")
     COMMENT "Downloading CF conventions XML file and building YAML dictionary...")
 endif()
 
+# IO library
+add_subdirectory(io)
+
 if (NOT SCREAM_LIB_ONLY)
+  # Create test_support lib
+  add_library(scream_test_support
+    grid/mesh_free_grids_manager.cpp
+    util/scream_test_session.cpp
+  )
+  target_link_libraries(scream_test_support PUBLIC scream_share scream_io)
+
   add_subdirectory(tests)
 endif()
-
-add_subdirectory(io)

--- a/components/scream/src/share/grid/abstract_grid.cpp
+++ b/components/scream/src/share/grid/abstract_grid.cpp
@@ -125,7 +125,7 @@ AbstractGrid::get_geometry_data (const std::string& name) const {
 }
 
 Field
-AbstractGrid::get_geometry_data (const std::string& name) {
+AbstractGrid::get_geometry_data_nonconst (const std::string& name) const {
   EKAT_REQUIRE_MSG (has_geometry_data(name),
       "Error! Geometry data '" + name + "' not found.\n");
 

--- a/components/scream/src/share/grid/abstract_grid.hpp
+++ b/components/scream/src/share/grid/abstract_grid.hpp
@@ -4,7 +4,7 @@
 #include "ekat/std_meta/ekat_std_enable_shared_from_this.hpp"
 #include "share/grid/grid_utils.hpp"
 #include "share/field/field_layout.hpp"
-#include "share/scream_types.hpp"
+#include "share/field/field.hpp"
 
 #include "ekat/mpi//ekat_comm.hpp"
 
@@ -22,12 +22,12 @@ namespace scream
  * to provide the following information:
  *   - number of local degrees of freedom (dofs) along the horizontal direction
  *   - number of vertical levels
- *   - gids for all local (2d) dofs
+ *   - gids for all local 2d dofs
  *   - type and name of the grid (see grid_utils.hpp for types)
- *   - the layout of a (2d) dof on this grid (see field_layout.hpp)
- *   - the gid of a (2d) dof given indices (i_1,...,i_N), with N being the
+ *   - the layout of a 2d/3d field on this grid (see field_layout.hpp)
+ *   - the mapping of dof lid to a set of indices (i_1,...,i_N), with N being the
  *     rank of the scalar field layout, and i_k less than the i-th dimension
- *     in the scalar field layout
+ *     in the scalar field layout. This is how a dof is 'naturally' indexed on this grid.
  *
  * The methods get_Xd_Y_layout, with X=2,3, and Y=scalar,vector, will return the
  * FieldLayout of a 2d/3d scalar/vector field on this grid.
@@ -40,30 +40,10 @@ namespace scream
 class AbstractGrid : public ekat::enable_shared_from_this<AbstractGrid>
 {
 public:
-  using gid_type            = int;           // TODO: use int64_t? int? template class on gid_type?
-  using device_type         = DefaultDevice; // TODO: template class on device type
-  using kokkos_types        = KokkosTypes<device_type>;
-  using kokkos_types_host   = KokkosTypes<HostDevice>;
-
-  template<typename T>
-  using view_1d = kokkos_types::view_1d<T>;
-  template<typename T>
-  using hview_1d = kokkos_types_host::view_1d<T>;
-  template<typename T>
-  using view_2d = kokkos_types::view_2d<T>;
-
-  using geo_view_type       = view_1d<Real>;
-  using geo_view_h_type     = hview_1d<Real>;
-  using geo_view_map_type   = std::map<std::string,geo_view_type>;
-  using geo_view_h_map_type = std::map<std::string,geo_view_h_type>;
-
-  // The list of all dofs' gids
-  using dofs_list_type   = view_1d<gid_type>;
-  using dofs_list_h_type = hview_1d<gid_type>;
-
-  // Row i of this 2d view gives the indices of the ith local dof
-  // in the native 2d layout
-  using lid_to_idx_map_type = view_2d<int>;
+  // TODO: use int64_t? int? template class on gid_type?
+  // So far, 32 bits seem enough for 2d dofs numbering
+  using gid_type = int;
+  using gid_view_h = Field::view_host_t<const gid_type*>;
 
   // Constructor(s) & Destructor
   AbstractGrid (const std::string& name,
@@ -107,32 +87,29 @@ public:
   gid_type get_global_min_dof_gid () const;
   gid_type get_global_max_dof_gid () const;
 
-  // Set the dofs list
-  // NOTE: this method calls valid_dofs_list, which may contain collective
-  //       operations over the stored communicator.
-  void set_dofs (const dofs_list_type& dofs);
+  // Get a Field storing 1d data (the dof gids)
+  Field get_dofs_gids () const;
+  Field get_dofs_gids ();
 
-  // Get a 1d view containing the dof gids
-  const dofs_list_type& get_dofs_gids () const;
-  const dofs_list_h_type& get_dofs_gids_host () const;
+  // Get a Field storing 2d data, where (i,j) entry contains the j-th coordinate of
+  // the i-th dof in the native dof layout. Const verison returns a read-only field
+  Field get_lid_to_idx_map () const;
+  Field get_lid_to_idx_map ();
 
-  // Set the the map dof_lid->dof_indices, where the indices are the ones used
-  // to access the dof in the layout returned by get_2d_scalar_layout().
-  // NOTE: this method calls valid_lid_to_idx_map, which may contain collective
-  //       operations over the stored communicator.
-  void set_lid_to_idx_map (const lid_to_idx_map_type& lid_to_idx);
+  // Get geometry-related fields. Const version returns a read-only field
+  Field get_geometry_data (const std::string& name) const;
+  Field get_geometry_data (const std::string& name);
 
-  // Get a 2d view, where (i,j) entry contains the j-th coordinate of
-  // the i-th dof in the native dof layout.
-  const lid_to_idx_map_type& get_lid_to_idx_map () const;
+  // Create geometry data, throws if already existing. Returns writable field
+  Field create_geometry_data (const std::string& name, const FieldLayout& layout,
+                              const ekat::units::Units& units = ekat::units::Units::invalid(),
+                              const DataType data_type = DataType::RealType);
 
-  // Set/get geometric views.
-  void set_geometry_data (const std::string& name, const geo_view_type& data);
-  const geo_view_type& get_geometry_data (const std::string& name) const;
-  const geo_view_h_type& get_geometry_data_host (const std::string& name) const;
+  // Sets pre-existing field as geometry data.
+  void set_geometry_data (const Field& f);
 
   bool has_geometry_data (const std::string& name) const {
-    return m_geo_views.find(name)!=m_geo_views.end();
+    return m_geo_fields.find(name)!=m_geo_fields.end();
   }
 
   // Get list of currently stored geometry data views
@@ -158,17 +135,17 @@ public:
     return get_owners(gids_v);
   }
 
+  // Derived classes can override these methods to verify that the
+  // dofs have been set to something that satisfies any requirement of the grid type.
+  virtual bool check_valid_dofs()        const { return true; }
+  virtual bool check_valid_lid_to_idx () const { return true; }
 protected:
 
-  // Derived classes can override these methods, which are called inside the
-  // set_dofs, set_lid_to_idx_map, and set_geometry_data methods respectively, to verify that the
-  // views have been set to something that satisfies any requirement of the grid type.
-  // This class already checks the extents of the view, but derived classes can add
-  // some extra consistency check.
-  virtual bool valid_dofs_list (const dofs_list_type& /*dofs_gids*/)      const { return true; }
-  virtual bool valid_lid_to_idx_map (const lid_to_idx_map_type& /*lid_to_idx*/) const { return true; }
+  void copy_data (const AbstractGrid& src, const bool shallow = true);
 
-  void copy_views (const AbstractGrid& src, const bool shallow = true);
+  // Note: this method must be called from the derived classes,
+  //       since it calls get_2d_scalar_layout.
+  void create_dof_fields (const int scalar2d_layout_rank);
 
 private:
 
@@ -183,20 +160,14 @@ private:
   int m_num_global_dofs;
   int m_num_vert_levs;
 
-  // Whether the dofs have been set
-  bool m_dofs_set = false;
-  // Whether the lid->idx map has been set
-  bool m_lid_to_idx_set = false;
 
   // The global ID of each dof
-  dofs_list_type        m_dofs_gids;
-  dofs_list_h_type      m_dofs_gids_host;
+  Field     m_dofs_gids;
 
   // The map lid->idx
-  lid_to_idx_map_type   m_lid_to_idx;
+  Field     m_lid_to_idx;
 
-  geo_view_map_type     m_geo_views;
-  geo_view_h_map_type   m_geo_views_host;
+  std::map<std::string,Field>  m_geo_fields;
 
   // The MPI comm containing the ranks across which the global mesh is partitioned
   ekat::Comm            m_comm;

--- a/components/scream/src/share/grid/abstract_grid.hpp
+++ b/components/scream/src/share/grid/abstract_grid.hpp
@@ -149,16 +149,15 @@ public:
   // Get a list of GIDs that are unique across all ranks in the grid comm. That is,
   // if a dof is present on 2+ ranks, it will (globally) appear just once in the
   // view returned by this method.
-  dofs_list_type get_unique_gids () const;
+  std::vector<gid_type> get_unique_gids () const;
 
   // For each entry in the input list of GIDs, retrieve the process id that owns it
-  hview_1d<int> get_owners (const hview_1d<const gid_type>& gids) const;
-
-  // Handy version of the above method, to allow passing a std::vector
-  hview_1d<int> get_owners (const std::vector<gid_type>& gids) const {
-    hview_1d<const gid_type> gids_v(gids.data(),gids.size());
+  std::vector<int> get_owners (const gid_view_h& gids) const;
+  std::vector<int> get_owners (const std::vector<gid_type>& gids) const {
+    gid_view_h gids_v(gids.data(),gids.size());
     return get_owners(gids_v);
   }
+
 protected:
 
   // Derived classes can override these methods, which are called inside the

--- a/components/scream/src/share/grid/abstract_grid.hpp
+++ b/components/scream/src/share/grid/abstract_grid.hpp
@@ -96,9 +96,11 @@ public:
   Field get_lid_to_idx_map () const;
   Field get_lid_to_idx_map ();
 
-  // Get geometry-related fields. Const version returns a read-only field
+  // Get geometry-related fields. Returns a read-only field
   Field get_geometry_data (const std::string& name) const;
-  Field get_geometry_data (const std::string& name);
+
+  // Same as the above one, but the field data is writable
+  Field get_geometry_data_nonconst (const std::string& name) const;
 
   // Create geometry data, throws if already existing. Returns writable field
   Field create_geometry_data (const std::string& name, const FieldLayout& layout,

--- a/components/scream/src/share/grid/mesh_free_grids_manager.hpp
+++ b/components/scream/src/share/grid/mesh_free_grids_manager.hpp
@@ -31,6 +31,9 @@ public:
 
 protected:
 
+  void load_lat_lon (const nonconstgrid_ptr_type& grid) const;
+  void load_hybrid_coeffs (const nonconstgrid_ptr_type& grid) const;
+
   std::string get_reference_grid_name () const {
     return m_params.get<std::string>("reference_grid");
   }

--- a/components/scream/src/share/grid/point_grid.cpp
+++ b/components/scream/src/share/grid/point_grid.cpp
@@ -13,17 +13,17 @@ PointGrid (const std::string& grid_name,
            const ekat::Comm&  comm)
  : AbstractGrid(grid_name,GridType::Point,num_my_cols,num_vertical_levels,comm)
 {
+  using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
+
+  create_dof_fields (get_2d_scalar_layout().rank());
+
   // The lid->idx map is the identity map.
-  lid_to_idx_map_type lid_to_idx("lid to idx",get_num_local_dofs(),1);
-  auto h_lid_to_idx = Kokkos::create_mirror_view(lid_to_idx);
+  auto lid2idx = get_lid_to_idx_map();
+  auto h_lid_to_idx = lid2idx.get_view<int**,Host>();
   std::iota(h_lid_to_idx.data(),h_lid_to_idx.data()+get_num_local_dofs(),0);
-  Kokkos::deep_copy(lid_to_idx,h_lid_to_idx);
-
-  // Note: we use the base class set method, rather than directly using m_lid_to_idx,
-  //       so that we can perform sanity checks on inputs consistency.
-  set_lid_to_idx_map(lid_to_idx);
+  lid2idx.sync_to_dev();
 }
-
 
 FieldLayout
 PointGrid::get_2d_scalar_layout () const
@@ -68,7 +68,7 @@ PointGrid::clone (const std::string& clone_name,
                   const bool shallow) const
 {
   auto grid = std::make_shared<PointGrid> (clone_name,get_num_local_dofs(),get_num_vertical_levels(),get_comm());
-  grid->copy_views(*this,shallow);
+  grid->copy_data(*this,shallow);
   return grid;
 }
 
@@ -94,44 +94,10 @@ create_point_grid (const std::string& grid_name,
   auto grid = std::make_shared<PointGrid>(grid_name,num_my_cols,num_vertical_lev,comm);
   grid->setSelfPointer(grid);
 
-  PointGrid::dofs_list_type dofs_gids ("phys dofs",num_my_cols);
-  auto h_dofs_gids = Kokkos::create_mirror_view(dofs_gids);
+  auto dofs_gids = grid->get_dofs_gids();
+  auto h_dofs_gids = dofs_gids.get_view<AbstractGrid::gid_type*,Host>();
   std::iota(h_dofs_gids.data(),h_dofs_gids.data()+num_my_cols,dof_offset);
-  Kokkos::deep_copy(dofs_gids,h_dofs_gids);
-
-  grid->set_dofs(dofs_gids);
-
-  using device_type       = DefaultDevice;
-  using kokkos_types      = KokkosTypes<device_type>;
-  using geo_view_type     = kokkos_types::view_1d<Real>;
-  using C                 = scream::physics::Constants<Real>;
-
-  // Store cell area, longitude, latitude and reference/surface pressure fractions
-  // in geometry data. For  longitude, latitude and pressure fractions, set values
-  // to NaN since they are not necessarily required from all application using PointGrid
-  geo_view_type area("area", num_my_cols);
-  geo_view_type lon ("lon",  num_my_cols);
-  geo_view_type lat ("lat",  num_my_cols);
-  geo_view_type hyam("hyam", num_vertical_lev);
-  geo_view_type hybm("hybm", num_vertical_lev);
-
-  // Estimate cell area for a uniform grid by taking the surface area
-  // of the earth divided by the number of columns.  Note we do this in
-  // units of radians-squared.
-  const Real pi        = C::Pi;
-  const Real cell_area = 4.0*pi/num_my_cols;
-
-  Kokkos::deep_copy(area, cell_area);
-  Kokkos::deep_copy(lon,  std::nan(""));
-  Kokkos::deep_copy(lat,  std::nan(""));
-  Kokkos::deep_copy(hyam, std::nan(""));
-  Kokkos::deep_copy(hybm, std::nan(""));
-
-  grid->set_geometry_data("area", area);
-  grid->set_geometry_data("lon",  lon);
-  grid->set_geometry_data("lat",  lat);
-  grid->set_geometry_data("hyam", hyam);
-  grid->set_geometry_data("hybm", hybm);
+  dofs_gids.sync_to_dev();
 
   return grid;
 }

--- a/components/scream/src/share/grid/remap/coarsening_remapper.hpp
+++ b/components/scream/src/share/grid/remap/coarsening_remapper.hpp
@@ -117,14 +117,14 @@ protected:
   void setup_mpi_data_structures ();
 
   int gid2lid (const gid_t gid, const grid_ptr_type& grid) const {
-    const auto gids = grid->get_dofs_gids_host();
+    const auto gids = grid->get_dofs_gids().get_view<const gid_t*,Host>();
     const auto beg = gids.data();
     const auto end = gids.data()+grid->get_num_local_dofs();
     const auto it = std::find(beg,end,gid);
     return it==end ? -1 : std::distance(beg,it);
   }
 
-  view_1d<gid_t>::HostMirror
+  std::vector<gid_t>
   get_my_triplets_gids (const std::string& map_file,
                         const grid_ptr_type& src_grid) const;
 

--- a/components/scream/src/share/grid/remap/horizontal_remap_utility.cpp
+++ b/components/scream/src/share/grid/remap/horizontal_remap_utility.cpp
@@ -17,7 +17,7 @@ HorizontalMap::HorizontalMap(const ekat::Comm& comm, const std::string& map_name
   m_dofs_set = false;
 }
 /*-----------------------------------------------------------------------------------------------*/
-HorizontalMap::HorizontalMap(const ekat::Comm& comm, const std::string& map_name, const view_1d<gid_type>& dofs_gids, const gid_type min_dof)
+HorizontalMap::HorizontalMap(const ekat::Comm& comm, const std::string& map_name, const view_1d<const gid_type>& dofs_gids, const gid_type min_dof)
   : m_name (map_name)
   , m_comm (comm)
 {

--- a/components/scream/src/share/grid/remap/horizontal_remap_utility.hpp
+++ b/components/scream/src/share/grid/remap/horizontal_remap_utility.hpp
@@ -110,7 +110,7 @@ public:
   HorizontalMap() {};
   explicit HorizontalMap(const ekat::Comm& comm);
   HorizontalMap(const ekat::Comm& comm, const std::string& map_name);
-  HorizontalMap(const ekat::Comm& comm, const std::string& map_name, const view_1d<gid_type>& dofs_gids, const gid_type min_dof);
+  HorizontalMap(const ekat::Comm& comm, const std::string& map_name, const view_1d<const gid_type>& dofs_gids, const gid_type min_dof);
  
   // Main remap functions
   void apply_remap(const view_1d<const Real>& source_data, const view_1d<Real>& remapped_data);

--- a/components/scream/src/share/grid/se_grid.hpp
+++ b/components/scream/src/share/grid/se_grid.hpp
@@ -35,16 +35,17 @@ public:
     return m_num_global_elem;
   }
 
-  // Set/retrieve the CG grid dofs
-  void set_cg_dofs (const dofs_list_type& cg_dofs);
-  const dofs_list_type& get_cg_dofs_gids () const;
+  // Set/retrieve the CG grid dofs. Const version returns a read-only field
+  Field get_cg_dofs_gids ();
+  Field get_cg_dofs_gids () const;
 
   std::shared_ptr<AbstractGrid> clone (const std::string& clone_name,
                                        const bool shallow) const override;
 
+  bool check_valid_dofs()        const override;
+  bool check_valid_lid_to_idx () const override;
+
 protected:
-  bool valid_dofs_list (const dofs_list_type& dofs_gids)      const override;
-  bool valid_lid_to_idx_map (const lid_to_idx_map_type& lid_to_idx) const override;
 
   // SE dims
   int       m_num_local_elem;
@@ -52,8 +53,7 @@ protected:
   int       m_num_gp;
 
   // The dofs gids for a CG version of this grid
-  dofs_list_type m_cg_dofs_gids;
-  bool m_cg_dofs_set = false;
+  Field m_cg_dofs_gids;
 };
 
 } // namespace scream

--- a/components/scream/src/share/io/CMakeLists.txt
+++ b/components/scream/src/share/io/CMakeLists.txt
@@ -14,7 +14,7 @@ set_target_properties(scream_io PROPERTIES
   Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules
 )
 target_include_directories(scream_io PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/modules)
-target_link_libraries(scream_io PUBLIC scream_share diagnostics piof pioc)
+target_link_libraries(scream_io PUBLIC scream_share piof pioc)
 
 if (SCREAM_CIME_BUILD)
   target_link_libraries(scream_io PUBLIC csm_share)

--- a/components/scream/src/share/io/scorpio_input.cpp
+++ b/components/scream/src/share/io/scorpio_input.cpp
@@ -504,16 +504,13 @@ AtmosphereInput::get_var_dof_offsets(const FieldLayout& layout)
   //       All we need to do in this routine is to compute the offset of all the entries
   //       of the MPI-local array w.r.t. the global array. So long as the offsets are in
   //       the same order as the corresponding entry in the data to be read/written, we're good.
+  auto dofs_h = m_io_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
   if (layout.has_tag(ShortFieldTagsNames::COL)) {
     const int num_cols = m_io_grid->get_num_local_dofs();
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
     scorpio::offset_t col_size = layout.size() / num_cols;
-
-    auto dofs = m_io_grid->get_dofs_gids();
-    auto dofs_h = Kokkos::create_mirror_view(dofs);
-    Kokkos::deep_copy(dofs_h,dofs);
 
     // Precompute this *before* the loop, since it involves expensive collectives.
     // Besides, the loop might have different length on different ranks, so
@@ -538,10 +535,6 @@ AtmosphereInput::get_var_dof_offsets(const FieldLayout& layout)
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
     scorpio::offset_t col_size = layout.size() / num_cols;
-
-    auto dofs = m_io_grid->get_dofs_gids();
-    auto dofs_h = Kokkos::create_mirror_view(dofs);
-    Kokkos::deep_copy(dofs_h,dofs);
 
     // Precompute this *before* the loop, since it involves expensive collectives.
     // Besides, the loop might have different length on different ranks, so

--- a/components/scream/src/share/io/scorpio_output.cpp
+++ b/components/scream/src/share/io/scorpio_output.cpp
@@ -540,16 +540,13 @@ AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
   //       All we need to do in this routine is to compute the offset of all the entries
   //       of the MPI-local array w.r.t. the global array. So long as the offsets are in
   //       the same order as the corresponding entry in the data to be read/written, we're good.
+  auto dofs_h = m_io_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
   if (layout.has_tag(ShortFieldTagsNames::COL)) {
     const int num_cols = m_io_grid->get_num_local_dofs();
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
     scorpio::offset_t col_size = layout.size() / num_cols;
-
-    auto dofs = m_io_grid->get_dofs_gids();
-    auto dofs_h = Kokkos::create_mirror_view(dofs);
-    Kokkos::deep_copy(dofs_h,dofs);
 
     // Precompute this *before* the loop, since it involves expensive collectives.
     // Besides, the loop might have different length on different ranks, so
@@ -574,10 +571,6 @@ AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
     scorpio::offset_t col_size = layout.size() / num_cols;
-
-    auto dofs = m_io_grid->get_dofs_gids();
-    auto dofs_h = Kokkos::create_mirror_view(dofs);
-    Kokkos::deep_copy(dofs_h,dofs);
 
     // Precompute this *before* the loop, since it involves expensive collectives.
     // Besides, the loop might have different length on different ranks, so

--- a/components/scream/src/share/io/scream_output_manager.cpp
+++ b/components/scream/src/share/io/scream_output_manager.cpp
@@ -3,8 +3,6 @@
 #include "share/io/scorpio_input.hpp"
 #include "share/io/scream_scorpio_interface.hpp"
 
-#include "diagnostics/register_diagnostics.hpp"
-
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/mpi/ekat_comm.hpp"
 #include "ekat/util/ekat_string_utils.hpp"
@@ -52,9 +50,6 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
   m_case_t0 = case_t0;
   m_is_restarted_run = (case_t0<run_t0);
   m_is_model_restart_output = is_model_restart_output;
-
-  // Register all potential diagnostics
-  register_diagnostics();
 
   // Check for model restart output
   set_params(params,field_mgrs);

--- a/components/scream/src/share/io/tests/CMakeLists.txt
+++ b/components/scream/src/share/io/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ configure_file(io_test_multisnap.yaml io_test_multisnap.yaml)
 configure_file(io_test_template.yaml io_test_template.yaml)
 configure_file(io_test_control.yaml io_test_control.yaml)
 
-CreateUnitTest(io_test "io.cpp" scream_io LABELS "io"
+CreateUnitTest(io_test "io.cpp" "scream_io;diagnostics" LABELS "io"
   MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
 )
 

--- a/components/scream/src/share/io/tests/io.cpp
+++ b/components/scream/src/share/io/tests/io.cpp
@@ -1,12 +1,12 @@
 #include <catch2/catch.hpp>
 #include <memory>
 
-#include "ekat/ekat_parse_yaml_file.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
 #include "share/io/scream_output_manager.hpp"
 #include "share/io/scorpio_output.hpp"
 #include "share/io/scorpio_input.hpp"
 #include "share/io/scream_scorpio_interface.hpp"
+
+#include "diagnostics/register_diagnostics.hpp"
 
 #include "share/grid/mesh_free_grids_manager.hpp"
 #include "share/grid/point_grid.hpp"
@@ -24,6 +24,8 @@
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/ekat_scalar_traits.hpp"
 #include "ekat/ekat_assert.hpp"
+#include "ekat/ekat_parse_yaml_file.hpp"
+#include "ekat/util/ekat_string_utils.hpp"
 
 namespace {
 
@@ -723,6 +725,10 @@ int get_current_t(const int tt, const int dt, const int freq, const std::string&
 TEST_CASE("input_output_basic","io")
 {
   ekat::Comm comm (MPI_COMM_WORLD);
+
+  // Register all potential diagnostics
+  register_diagnostics();
+
   std::vector<std::string> output_types =
     { "instant","average", "max", "min"};
   std::vector<std::string> output_freq =

--- a/components/scream/src/share/property_checks/field_nan_check.cpp
+++ b/components/scream/src/share/property_checks/field_nan_check.cpp
@@ -131,28 +131,22 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
     using namespace ShortFieldTagsNames;
 
     int col_lid;
-    AbstractGrid::dofs_list_h_type gids;
-    AbstractGrid::geo_view_h_type lat, lon;
-    bool has_latlon;
-    bool has_col_info = m_grid and layout.tag(0)==COL;
 
-    if (has_col_info) {
+    if (m_grid) {
       // We are storing grid info, and the field is over columns. Get col id and coords.
       col_lid = indices[0];
-      gids = m_grid->get_dofs_gids_host();
-      has_latlon = m_grid->has_geometry_data("lat") && m_grid->has_geometry_data("lon");
-      if (has_latlon) {
-        lat = m_grid->get_geometry_data_host("lat");
-        lon = m_grid->get_geometry_data_host("lon");
-      }
+      auto gids = m_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
 
       res_and_msg.msg += "  - entry (" + std::to_string(gids(col_lid));;
       for (size_t i=1; i<indices.size(); ++i) {
         res_and_msg.msg += "," + std::to_string(indices[i]);
       }
       res_and_msg.msg += ")\n";
+      const bool has_latlon = m_grid->has_geometry_data("lat") && m_grid->has_geometry_data("lon");
       if (has_latlon) {
-        res_and_msg.msg += "  - lat/lon: (" + std::to_string(lat(col_lid)) + ", " + std::to_string(lon(col_lid)) + ")\n";
+        auto lat = m_grid->get_geometry_data("lat").get_internal_view_data<const Real,Host>();
+        auto lon = m_grid->get_geometry_data("lon").get_internal_view_data<const Real,Host>();
+        res_and_msg.msg += "  - lat/lon: (" + std::to_string(lat[col_lid]) + ", " + std::to_string(lon[col_lid]) + ")\n";
       }
     }
   } else {

--- a/components/scream/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/scream/src/share/property_checks/field_within_interval_check.cpp
@@ -222,20 +222,19 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
   using namespace ShortFieldTagsNames;
 
   int min_col_lid, max_col_lid;
-  AbstractGrid::dofs_list_h_type gids;
-  AbstractGrid::geo_view_h_type lat, lon;
   bool has_latlon;
   bool has_col_info = m_grid and layout.tag(0)==COL;
+  const Real* lat;
+  const Real* lon;
 
   if (has_col_info) {
     // We are storing grid info, and the field is over columns. Get col id and coords.
     min_col_lid = idx_min[0];
     max_col_lid = idx_max[0];
-    gids = m_grid->get_dofs_gids_host();
     has_latlon = m_grid->has_geometry_data("lat") && m_grid->has_geometry_data("lon");
     if (has_latlon) {
-      lat = m_grid->get_geometry_data_host("lat");
-      lon = m_grid->get_geometry_data_host("lon");
+      lat = m_grid->get_geometry_data("lat").get_internal_view_data<const Real,Host>();
+      lon = m_grid->get_geometry_data("lon").get_internal_view_data<const Real,Host>();
     }
   }
 
@@ -243,26 +242,28 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
   msg << "  - minimum:\n";
   msg << "    - value: " << minmaxloc.min_val << "\n";
   if (has_col_info) {
+    auto gids = m_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
     msg << "    - entry: (" << gids(min_col_lid);
     for (size_t i=1; i<idx_min.size(); ++i) {
       msg << "," << idx_min[i];
     }
     msg << ")\n";
     if (has_latlon) {
-      msg << "    - lat/lon: (" << lat(min_col_lid) << ", " << lon(min_col_lid) << ")\n";
+      msg << "    - lat/lon: (" << lat[min_col_lid] << ", " << lon[min_col_lid] << ")\n";
     }
   }
 
   msg << "  - maximum:\n";
   msg << "    - value: " << minmaxloc.max_val << "\n";
   if (has_col_info) {
+    auto gids = m_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
     msg << "    - entry: (" << gids(max_col_lid);
     for (size_t i=1; i<idx_max.size(); ++i) {
       msg << "," << idx_max[i];
     }
     msg << ")\n";
     if (has_latlon) {
-      msg << "    - lat/lon: (" << lat(max_col_lid) << ", " << lon(max_col_lid) << ")\n";
+      msg << "    - lat/lon: (" << lat[max_col_lid] << ", " << lon[max_col_lid] << ")\n";
     }
   }
 

--- a/components/scream/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
+++ b/components/scream/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
@@ -232,12 +232,13 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
   res_and_msg.result = CheckResult::Fail;
 
   // We output relative errors with lat/lon information (if available)
-  AbstractGrid::dofs_list_h_type gids = m_grid->get_dofs_gids_host();
-  AbstractGrid::geo_view_h_type lat, lon;
+  using gid_t = AbstractGrid::gid_type;
+  auto gids = m_grid->get_dofs_gids().get_view<const gid_t*,Host>();
+  typename Field::view_host_t<const Real*> lat, lon;
   const bool has_latlon = m_grid->has_geometry_data("lat") && m_grid->has_geometry_data("lon");
   if (has_latlon) {
-    lat = m_grid->get_geometry_data_host("lat");
-    lon = m_grid->get_geometry_data_host("lon");
+    lat = m_grid->get_geometry_data("lat").get_view<const Real*, Host>();
+    lon = m_grid->get_geometry_data("lon").get_view<const Real*, Host>();
   }
 
   std::stringstream msg;

--- a/components/scream/src/share/tests/CMakeLists.txt
+++ b/components/scream/src/share/tests/CMakeLists.txt
@@ -44,7 +44,4 @@ if (NOT ${SCREAM_BASELINES_ONLY})
     LABELS "horiz_remap"
     MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
   )
- 
-
-
 endif()

--- a/components/scream/src/share/tests/atm_process_tests.cpp
+++ b/components/scream/src/share/tests/atm_process_tests.cpp
@@ -504,7 +504,6 @@ TEST_CASE("field_checks", "") {
 
   // Create a parameter list
   ekat::ParameterList params ("Atmosphere Processes");
-  params.set<std::string>("Process Name", "Foo");
   params.set<std::string>("Grid Name", "Point Grid");
 
   const auto lt = grid->get_3d_scalar_layout(true);
@@ -567,9 +566,7 @@ TEST_CASE ("subcycling") {
   auto gm = create_gm(comm);
 
   ekat::ParameterList params, params_sub;
-  params.set<std::string>("Process Name", "AddOne");
   params.set<std::string>("Grid Name", "Point Grid");
-  params_sub.set<std::string>("Process Name", "AddOne");
   params_sub.set<std::string>("Grid Name", "Point Grid");
   params_sub.set<int>("number_of_subcycles", 5);
 

--- a/components/scream/src/share/tests/coarsening_remapper_tests.cpp
+++ b/components/scream/src/share/tests/coarsening_remapper_tests.cpp
@@ -22,7 +22,7 @@ public:
   {
     // Nothing to do
   }
-  view_1d<gid_t>::HostMirror
+  std::vector<gid_t>
   test_triplet_gids (const std::string& map_file) const {
     return CoarseningRemapper::get_my_triplets_gids (map_file,m_src_grid);
   }
@@ -72,7 +72,7 @@ public:
 };
 
 template<typename ViewT>
-bool contains (const ViewT& v, const typename ViewT::traits::value_type& entry) {
+bool view_contains (const ViewT& v, const typename ViewT::traits::value_type& entry) {
   const auto vh = cmvc (v);
   const auto beg = vh.data();
   const auto end = vh.data() + vh.size();
@@ -91,6 +91,7 @@ void print (const std::string& msg, const ekat::Comm& comm) {
 }
 
 TEST_CASE ("coarsening_remap") {
+  using gid_t = AbstractGrid::gid_type;
 
   // -------------------------------------- //
   //           Init MPI and PIO             //
@@ -162,13 +163,12 @@ TEST_CASE ("coarsening_remap") {
 
   print (" -> creating grid and remapper ...\n",comm);
 
-  AbstractGrid::dofs_list_type src_dofs("",nldofs_src);
-  auto src_dofs_h = cmvc(src_dofs);
-  std::iota(src_dofs_h.data(),src_dofs_h.data()+nldofs_src,nldofs_src*comm.rank());
-  Kokkos::deep_copy(src_dofs,src_dofs_h);
-
   auto src_grid = std::make_shared<PointGrid>("src",nldofs_src,20,comm);
-  src_grid->set_dofs(src_dofs);
+
+  auto src_dofs = src_grid->get_dofs_gids();
+  auto src_dofs_h = src_dofs.get_view<gid_t*,Host>();
+  std::iota(src_dofs_h.data(),src_dofs_h.data()+nldofs_src,nldofs_src*comm.rank());
+  src_dofs.sync_to_dev();
 
   auto remap = std::make_shared<CoarseningRemapperTester>(src_grid,filename);
   print (" -> creating grid and remapper ... done!\n",comm);
@@ -263,7 +263,7 @@ TEST_CASE ("coarsening_remap") {
     const auto src_gid = src_dofs_h(i);
     const auto tgt_gid = src_gid % ngdofs_tgt;
 
-    REQUIRE (contains(my_triplets, 2*tgt_gid + src_gid/ngdofs_tgt));
+    REQUIRE (ekat::contains(my_triplets, 2*tgt_gid + src_gid/ngdofs_tgt));
   }
 
   // Check overlapped tgt grid
@@ -274,13 +274,13 @@ TEST_CASE ("coarsening_remap") {
   const int num_loc_ov_tgt_gids = ov_tgt_grid->get_num_local_dofs();
   const int expected_num_loc_ov_tgt_gids = ngdofs_tgt>=nldofs_src ? nldofs_src : ngdofs_tgt;
   REQUIRE (num_loc_ov_tgt_gids==expected_num_loc_ov_tgt_gids);
-  auto ov_gids = ov_tgt_grid->get_dofs_gids_host();
+  const auto ov_gids = ov_tgt_grid->get_dofs_gids().get_view<const gid_t*,Host>();
   for (int i=0; i<num_loc_ov_tgt_gids; ++i) {
     if (comm.size()==1) {
       REQUIRE(ov_gids[i]==i);
     } else {
       const auto src_gid = src_dofs_h[i];
-      REQUIRE (contains(ov_gids, src_gid % ngdofs_tgt));
+      REQUIRE (view_contains(ov_gids, src_gid % ngdofs_tgt));
     }
   }
 
@@ -288,8 +288,8 @@ TEST_CASE ("coarsening_remap") {
   auto row_offsets_h = cmvc(remap->get_row_offsets());
   auto col_lids_h    = cmvc(remap->get_col_lids());
   auto weights_h = cmvc(remap->get_weights());
-  auto ov_tgt_gids = ov_tgt_grid->get_dofs_gids_host();
-  auto src_gids    = remap->get_src_grid()->get_dofs_gids_host();
+  auto ov_tgt_gids = ov_tgt_grid->get_dofs_gids().get_view<const gid_t*,Host>();
+  auto src_gids    = remap->get_src_grid()->get_dofs_gids().get_view<const gid_t*,Host>();
 
   REQUIRE (col_lids_h.extent_int(0)==nldofs_src);
   REQUIRE (row_offsets_h.extent_int(0)==(num_loc_ov_tgt_gids+1));
@@ -317,7 +317,7 @@ TEST_CASE ("coarsening_remap") {
 
   // Check internal MPI structures
   const int num_loc_tgt_gids = tgt_grid->get_num_local_dofs();
-  const auto tgt_gids = tgt_grid->get_dofs_gids_host();
+  const auto tgt_gids = tgt_grid->get_dofs_gids().get_view<const gid_t*,Host>();
   const auto recv_lids_beg = remap->get_recv_lids_beg();
   const auto recv_lids_end = remap->get_recv_lids_end();
   const auto recv_lids_pidpos = remap->get_recv_lids_pidpos();

--- a/components/scream/src/share/tests/horizontal_remap_test.cpp
+++ b/components/scream/src/share/tests/horizontal_remap_test.cpp
@@ -78,9 +78,8 @@ void run(std::mt19937_64& engine, const ekat::Comm& comm, const gid_type src_min
   auto grid_tgt         = gm_tgt->get_grid("Point Grid");     // Retrieve the actual grid from the grids manager.
   auto num_loc_tgt_cols = grid_tgt->get_num_local_dofs();     // Number of columns (dofs) on this rank.
   auto tgt_min_dof      = grid_tgt->get_global_min_dof_gid(); // The starting index of the EAMxx grid.
-  auto dofs_gids        = grid_tgt->get_dofs_gids();          // A view of the dofs on this rank with their global id.
-  auto dofs_gids_h      = Kokkos::create_mirror_view(dofs_gids);
-  Kokkos::deep_copy(dofs_gids_h,dofs_gids);
+  auto dofs_gids        = grid_tgt->get_dofs_gids().get_view<const gid_type*>();          // A view of the dofs on this rank with their global id.
+  auto dofs_gids_h      = grid_tgt->get_dofs_gids().get_view<const gid_type*,Host>();
 
 //----------------------
 // Step 1: Generate a random remapping (source col, target col, weight) and random source data.

--- a/components/scream/src/share/tests/property_checks.cpp
+++ b/components/scream/src/share/tests/property_checks.cpp
@@ -50,6 +50,7 @@ TEST_CASE("property_checks", "") {
   using namespace scream;
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
+  using gid_type = AbstractGrid::gid_type;
 
   auto engine = setup_random_test();
   using RPDF = std::uniform_real_distribution<Real>;
@@ -62,25 +63,19 @@ TEST_CASE("property_checks", "") {
   const int nlevs = 12;
 
   // Create a point grid
-  std::shared_ptr<AbstractGrid> grid;
-  grid = std::make_shared<PointGrid>("some_grid",num_lcols,nlevs,comm);
-  AbstractGrid::dofs_list_type dofs("dogs",grid->get_num_local_dofs());
-  AbstractGrid::geo_view_type lat("lat",grid->get_num_local_dofs());
-  AbstractGrid::geo_view_type lon("lon",grid->get_num_local_dofs());
-  auto lat_h = Kokkos::create_mirror_view(lat);
-  auto lon_h = Kokkos::create_mirror_view(lon);
-  auto dofs_h = Kokkos::create_mirror_view(dofs);
+  auto grid = create_point_grid("some_grid",num_lcols*comm.size(),nlevs,comm);
+  const auto& lat = grid->get_geometry_data("lat");
+  const auto& lon = grid->get_geometry_data("lon");
+  auto lat_h = lat.get_view<Real*,Host>();
+  auto lon_h = lon.get_view<Real*,Host>();
+  auto dofs = grid->get_dofs_gids();
+  auto dofs_h = dofs.get_view<gid_type*,Host>();
   for (int i=0; i<grid->get_num_local_dofs(); ++i) {
-    dofs_h(i) = num_lcols*comm.rank() + i;
     lat_h(i) = i;
     lon_h(i) = -i;
   }
-  Kokkos::deep_copy(dofs,dofs_h);
-  Kokkos::deep_copy(lat,lat_h);
-  Kokkos::deep_copy(lon,lon_h);
-  grid->set_dofs(dofs);
-  grid->set_geometry_data("lat",lat);
-  grid->set_geometry_data("lon",lon);
+  lat.sync_to_dev();
+  lon.sync_to_dev();
 
   // Create a field
   std::vector<FieldTag> tags = {COL, CMP, LEV};

--- a/components/scream/src/share/util/scream_vertical_interpolation_impl.hpp
+++ b/components/scream/src/share/util/scream_vertical_interpolation_impl.hpp
@@ -63,10 +63,10 @@ void perform_vertical_interpolation_impl_2d(
   auto npacks_tgt = ekat::PackInfo<Pack<T,N>::n>::num_packs(nlevs_tgt);
   EKAT_REQUIRE(x_src.extent(0)==input.extent(0));
   EKAT_REQUIRE(x_src.extent(1)==input.extent(1));
-  EKAT_REQUIRE(x_src.extent(1)==npacks_src);
-  EKAT_REQUIRE(input.extent(1)==npacks_src);
+  EKAT_REQUIRE(x_src.extent_int(1)==npacks_src);
+  EKAT_REQUIRE(input.extent_int(1)==npacks_src);
   EKAT_REQUIRE(x_tgt.extent(0)==output.extent(1));
-  EKAT_REQUIRE(x_tgt.extent(0)==npacks_tgt); 
+  EKAT_REQUIRE(x_tgt.extent_int(0)==npacks_tgt);
   
   LIV<T,N> vert_interp(ncols,nlevs_src,nlevs_tgt);
 

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -27,7 +27,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_mic,rrtmgp)
@@ -57,6 +56,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -20,7 +20,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
@@ -46,6 +45,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -20,7 +20,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    Process Name: Homme
     vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
     Moisture: moist
   physics:

--- a/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -20,7 +20,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
@@ -46,6 +45,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -27,7 +27,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
@@ -52,6 +51,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # List all the yaml files with the output parameters
 Scorpio:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -27,7 +27,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
@@ -52,6 +51,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # List all the yaml files with the output parameters
 Scorpio:

--- a/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/scream/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -19,7 +19,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
@@ -44,6 +43,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # List all the yaml files with the output parameters
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/scream/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -18,6 +18,8 @@ grids_manager:
   Type: Mesh Free
   number_of_global_columns:   218
   number_of_vertical_levels:  72  # Will want to change to 128 when a valid unit test is available.
+  latlon_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+  hybrid_coefficients_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
@@ -26,9 +28,6 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
-  Load Latitude:  true
-  Load Longitude: true
-  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -33,6 +33,8 @@ grids_manager:
   Type: Mesh Free
   number_of_global_columns:   218
   number_of_vertical_levels:  72  # Will want to change to 128 when a valid unit test is available.
+  latlon_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+  hybrid_coefficients_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
@@ -45,9 +47,6 @@ initial_conditions:
   aero_ssa_sw: 0.0
   aero_tau_sw: 0.0
   aero_tau_lw: 0.0
-  Load Latitude:  true
-  Load Longitude: true
-  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -2,7 +2,7 @@ include (ScreamUtils)
 
 # Create the test
 set (TEST_LABELS "shoc;cld;spa;p3;rrtmgp;physics;driver")
-set (NEED_LIBS shoc cld_fraction spa p3 scream_rrtmgp scream_control scream_share physics_share)
+set (NEED_LIBS shoc cld_fraction spa p3 scream_rrtmgp scream_control scream_share diagnostics physics_share)
 CreateUnitTest(shoc_cld_spa_p3_rrtmgp shoc_cld_spa_p3_rrtmgp.cpp "${NEED_LIBS}" LABELS ${TEST_LABELS}
   MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
   PROPERTIES FIXTURES_SETUP shoc_cld_spa_p3_rrtmgp_generate_output_nc_files

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -33,6 +33,8 @@ grids_manager:
   Type: Mesh Free
   number_of_global_columns:   218
   number_of_vertical_levels:  72  # Will want to change to 128 when a valid unit test is available.
+  latlon_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+  hybrid_coefficients_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
@@ -41,9 +43,6 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0
-  Load Latitude:  true
-  Load Longitude: true
-  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp.cpp
+++ b/components/scream/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp.cpp
@@ -3,6 +3,7 @@
 // Boiler plate, needed for all runs
 #include "control/atmosphere_driver.hpp"
 
+#include "diagnostics/register_diagnostics.hpp"
 #include "physics/register_physics.hpp"
 #include "share/grid/mesh_free_grids_manager.hpp"
 
@@ -35,6 +36,7 @@ TEST_CASE("shoc-stand-alone", "") {
 
   // Need to register products in the factory *before* we create any atm process or grids manager.
   register_physics();
+  register_diagnostics();
   register_mesh_free_grids_manager();
 
   // Create the driver

--- a/components/scream/tests/uncoupled/homme/input.yaml
+++ b/components/scream/tests/uncoupled/homme/input.yaml
@@ -16,13 +16,13 @@ atmosphere_processes:
   atm_procs_list: (Dynamics)
   Dynamics:
     Type: Homme
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
 
 grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/scream/tests/uncoupled/rrtmgp/input.yaml
@@ -29,6 +29,7 @@ grids_manager:
   Type: Mesh Free
   number_of_global_columns: 218
   number_of_vertical_levels: 72
+  latlon_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # Specifications for setting initial conditions
 initial_conditions:
@@ -37,8 +38,6 @@ initial_conditions:
   aero_ssa_sw: 0.0
   aero_tau_sw: 0.0
   aero_tau_lw: 0.0
-  Load Latitude:  true
-  Load Longitude: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
@@ -43,7 +43,6 @@ namespace scream {
     TEST_CASE("rrtmgp_scream_standalone", "") {
         using namespace scream;
         using namespace scream::control;
-        using PF = scream::PhysicsFunctions<DefaultDevice>;
         using PC = scream::physics::Constants<Real>;
 
         // Get baseline name (needs to be passed as an arg)
@@ -256,13 +255,6 @@ namespace scream {
 
         // Gather molecular weights of all the active gases in the test for conversion
         // to mass-mixing-ratio.
-        auto co2_mol = PC::get_gas_mol_weight("co2");
-        auto o3_mol  = PC::get_gas_mol_weight("o3");
-        auto n2o_mol = PC::get_gas_mol_weight("n2o");
-        auto co_mol  = PC::get_gas_mol_weight("co");
-        auto ch4_mol = PC::get_gas_mol_weight("ch4");
-        auto o2_mol  = PC::get_gas_mol_weight("o2");
-        auto n2_mol  = PC::get_gas_mol_weight("n2");
         {
           const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, nlay);
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {

--- a/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
+++ b/components/scream/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
@@ -95,8 +95,14 @@ namespace scream {
         const auto& field_mgr = *ad.get_field_mgr(grid->name());
         int ncol  = grid->get_num_local_dofs();
         int nlay  = grid->get_num_vertical_levels();
-        auto& lat = grid->get_geometry_data("lat");
-        auto& lon = grid->get_geometry_data("lon");
+
+        // In this test, we need to hack lat/lon. But the fields we get
+        // from the grid are read-only. Therefore, hack a bit, and cast
+        // away constness. It's bad, but it's only for this unit test
+        auto clat = grid->get_geometry_data("lat").get_view<const Real*>();
+        auto clon = grid->get_geometry_data("lon").get_view<const Real*>();
+        auto lat = const_cast<Real*>(clat.data());
+        auto lon = const_cast<Real*>(clon.data());
 
         // Get number of shortwave bands and number of gases from RRTMGP
         int ngas     =   8;  // TODO: get this intelligently
@@ -264,8 +270,8 @@ namespace scream {
             // Note, these values will ensure that the cosine zenith
             // angle will end up matching the constant velue meant for
             // the test, which is 0.86
-            lat(i) = 5.224000000000;
-            lon(i) = 167.282000000000; 
+            lat[i] = 5.224000000000;
+            lon[i] = 167.282000000000;
 
             d_sfc_alb_dir_vis(i) = sfc_alb_dir_vis(i+1);
             d_sfc_alb_dir_nir(i) = sfc_alb_dir_nir(i+1);

--- a/components/scream/tests/uncoupled/shoc/input.yaml
+++ b/components/scream/tests/uncoupled/shoc/input.yaml
@@ -18,14 +18,14 @@ grids_manager:
   Type: Mesh Free
   number_of_global_columns:   218
   number_of_vertical_levels:  72  # Will want to change to 128 when a valid unit test is available.
+  latlon_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+  hybrid_coefficients_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   surf_sens_flux: 0.0
   surf_evap: 0.0
-  Load Latitude: true
-  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:


### PR DESCRIPTION
This has a couple of advantages: will allow to remap geometric fields from one grid to another, and also makes dealing with host/dev copies of gids/geo_data easier.

A list of changes:
- Remove dependency of `scream_io` lib on `diagnostics` lib. The IO does not need to know the details about specific diagnostics, it only needs to know what a diagnostic is, which is provided by the `atmosphere_diagnostic.hpp` header. The diags registration in the factory can be done like the registration of atm procs and grids managers, namely before creating an AD instance in tests or mct interface.
- Make grids store gids, lid2idx, and geometric data as Field. The instances of Field returned by getters are const if the grid is const. This means that all Fields need to be populated at grid construction time (or else we need to cast away const).
- B/c of the above point, I moved the loading of lat/lon and hybrid coeffs inside the grids manager, removing it from the AD as well as HommeDynamics.
- Since grids managers now need to use `scream_io`, I moved `mesh_free_grids_manager.*pp` out of `scream_share`, and into its own library `scream_test_support` (which also contains `scream_test_session.cpp`). This lib is built only if `SCREAM_LIB_ONLY=FALSE` (i.e., not a CIME run), and is automatically linked to all our unit tests.