### PR TITLE
Refactor how input files are handling in namelist_scream.xml

### DIFF
--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -725,7 +725,7 @@ def get_file_parameters(caseroot):
     for item in raw_xml.findall('.//*[@type="array(file)"]'):
         result.extend(refine_type(item.text, force_type="array(file)"))
 
-    # Remove duplicates. Note sure if an error would be warranted if dupes exist
+    # Remove duplicates. Not sure if an error would be warranted if dupes exist
     return list(OrderedDict.fromkeys(result))
 
 ###############################################################################
@@ -747,12 +747,6 @@ def create_input_data_list_file(case, caseroot):
     with open(input_data_list_file, "w") as fd:
         for idx, file_path in enumerate(files_to_download):
             fd.write("scream_dl_input_{} = {}\n".format(idx, file_path))
-
-            # SCREAM is currently hardcoded to expect many inputs to be in $rundir/data
-            file_name = os.path.basename(file_path)
-            tgt_file = os.path.join(target, file_name)
-            if not os.path.exists(tgt_file) and not os.path.islink(tgt_file):
-                os.symlink(file_path, tgt_file)
 
 ###############################################################################
 def do_cime_vars_on_yaml_output_files(case,caseroot):

--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -37,7 +37,7 @@ from CIME.buildnml import parse_input
 
 # SCREAM imports
 from eamxx_buildnml_impl import get_valid_selectors, get_child, refine_type, \
-        resolve_all_inheritances, gen_atm_proc_group, find_node, check_all_values
+        resolve_all_inheritances, gen_atm_proc_group, check_all_values
 
 from utils import ensure_yaml
 ensure_yaml()
@@ -57,7 +57,7 @@ CIME_VAR_RE = re.compile(r'[$][{](\w+)[}]')
 #    Examples:
 #      - constraints="ge 0; lt 4" means the value V must satisfy V>=0 && V<4.
 #      - constraints="mod 2 eq 0" means the value V must be a multiple of 2.
-METADATA_ATTRIBS = ("type", "valid_values", "locked", "constraints", "inherit")
+METADATA_ATTRIBS = ("type", "valid_values", "locked", "constraints", "inherit", "file")
 
 ###############################################################################
 def do_cime_vars(entry, case, refine=False, extra=None):
@@ -341,7 +341,6 @@ def _create_raw_xml_file_impl(case, xml):
     >>> xml = '''
     ... <namelist_defaults>
     ...     <selectors/>
-    ...     <input_files/>
     ...     <generated_files/>
     ...     <atmosphere_processes_defaults>
     ...         <atm_procs_list>(P1,P2)</atm_procs_list>
@@ -379,7 +378,6 @@ def _create_raw_xml_file_impl(case, xml):
     ...     <selectors>
     ...       <selector name="grid" case_env="ATM_GRID"/>
     ...     </selectors>
-    ...     <input_files/>
     ...     <generated_files/>
     ...     <atmosphere_processes_defaults>
     ...         <atm_procs_list>(P1,P2)</atm_procs_list>
@@ -418,7 +416,6 @@ def _create_raw_xml_file_impl(case, xml):
     ...     <selectors>
     ...       <selector name='grid' case_env='ATM_GRID'/>
     ...     </selectors>
-    ...     <input_files/>
     ...     <generated_files/>
     ...     <atmosphere_processes_defaults>
     ...       <atm_procs_list locked="true">(P1,P2)</atm_procs_list>
@@ -473,7 +470,6 @@ def _create_raw_xml_file_impl(case, xml):
     # 0. Remove internal sections, that are not to appear in the
     #    processed xml file.
     #    Note: get_valid_selectors also removes the section
-    get_child(xml,"input_files",remove=True)
     get_child(xml,"generated_files",remove=True)
     selectors = get_valid_selectors(xml)
 
@@ -490,7 +486,7 @@ def _create_raw_xml_file_impl(case, xml):
     # 4. Form the nested list of atm procs needed, append to atmosphere_driver section
     atm_procs = gen_atm_proc_group (atm_procs_list.text, atm_procs_defaults)
     atm_procs.tag = "atmosphere_processes"
-    xml.append(atm_procs);
+    xml.append(atm_procs)
 
     return xml
 
@@ -507,7 +503,7 @@ def create_raw_xml_file(case, caseroot):
     raw_xml_file = os.path.join(caseroot, "namelist_scream.xml")
     with open(src, "r") as fd:
         defaults = ET.parse(fd)
-        raw_xml = _create_raw_xml_file_impl(case,defaults.getroot())
+        raw_xml = _create_raw_xml_file_impl(case, defaults.getroot())
 
     if os.path.exists(raw_xml_file):
         print("{} already exists, will not overwrite. Remove to regenerate".format(raw_xml_file))
@@ -675,13 +671,13 @@ def create_input_files(caseroot, screamroot, rundir):
         generated_files = get_child(tree.getroot(),"generated_files")
 
     result = {}
-    for file in generated_files:
-        expect("name" in file.attrib, "file element missing required 'name' attribute")
-        expect("format" in file.attrib, "file element missing required 'format' attribute")
-        filename    = os.path.join(rundir, file.attrib["name"])
-        file_format = file.attrib["format"]
+    for file_ in generated_files:
+        expect("name" in file_.attrib, "file element missing required 'name' attribute")
+        expect("format" in file_.attrib, "file element missing required 'format' attribute")
+        filename    = os.path.join(rundir, file_.attrib["name"])
+        file_format = file_.attrib["format"]
 
-        xml_sections = get_child(file,"sections").text.split(",")
+        xml_sections = get_child(file_,"sections").text.split(",")
 
         dict_contents = {}
         for section_name in xml_sections:
@@ -706,40 +702,53 @@ def create_input_files(caseroot, screamroot, rundir):
         else:
             expect(False, "Unknown input file format '{}'".format(file_format))
 
-        result[file.attrib["name"]] = dict_contents
+        result[file_.attrib["name"]] = dict_contents
 
     return result
 
 ###############################################################################
-def create_input_data_list_file(case,caseroot,screamroot,ic_section):
+def get_file_parameters(caseroot):
 ###############################################################################
+    """
+    Find all XML elements with file="true" attribute. Returns a list
+    of file paths.
+    """
+    raw_xml_file = os.path.join(caseroot, "namelist_scream.xml")
+    with open(raw_xml_file, "r") as fd:
+        tree    = ET.parse(fd)
+        raw_xml = tree.getroot()
 
+    result = []
+    for item in raw_xml.findall('.//*[@file="true"]'):
+        result.append(item.text.strip())
+
+    return result
+
+###############################################################################
+def create_input_data_list_file(case, caseroot):
+###############################################################################
+    """
+    Create the scream.input_data_list file for this case. This will tell CIME
+    what to download.
+    """
     rundir   = case.get_value("RUNDIR")
     target   = os.path.join(rundir, "data")
+
+    files_to_download = get_file_parameters(caseroot)
 
     input_data_list_file = "{}/Buildconf/scream.input_data_list".format(caseroot)
     if os.path.exists(input_data_list_file):
         os.remove(input_data_list_file)
 
-    def_xml_file = os.path.join(screamroot, "cime_config/namelist_defaults_scream.xml")
-    with open(def_xml_file, "r") as fd:
-        tree = ET.parse(fd)
-        root = tree.getroot()
-        tables = get_child(root,"input_files").text.split(',')
-
     with open(input_data_list_file, "w") as fd:
-        fd.write("ic_file_0 = {}\n".format(ic_section["Filename"]))
-        for idx, table in enumerate(tables):
-            fd.write("table_{} = {}\n".format(idx, table.strip()))
+        for idx, file_path in enumerate(files_to_download):
+            fd.write("scream_dl_input_{} = {}\n".format(idx, file_path))
 
-    # SCREAM is currently hardcoded to expect tables to be in $rundir/data
-    for table in tables:
-        src_table = do_cime_vars(table.strip(),case)
-        table_name = os.path.basename(src_table)
-        tgt_table = os.path.join(target, table_name)
-        if not os.path.exists(tgt_table) and not os.path.islink(tgt_table):
-            os.symlink(src_table, tgt_table)
-
+            # SCREAM is currently hardcoded to expect many inputs to be in $rundir/data
+            file_name = os.path.basename(file_path)
+            tgt_file = os.path.join(target, file_name)
+            if not os.path.exists(tgt_file) and not os.path.islink(tgt_file):
+                os.symlink(file_path, tgt_file)
 
 ###############################################################################
 def do_cime_vars_on_yaml_output_files(case,caseroot):
@@ -828,15 +837,13 @@ def buildnml(case, caseroot, compname):
     # from it.
     #
     create_raw_xml_file(case, caseroot)
-    files_as_dicts = create_input_files(caseroot, screamroot, rundir)
+    create_input_files(caseroot, screamroot, rundir)
 
     #
     # Create input data list. This is the list of files that CIME needs
     # to ensure are present on the machine (possibly downloading them)
     #
-    scream_input = files_as_dicts["data/scream_input.yaml"]
-    ic_section = scream_input["initial_conditions"]
-    create_input_data_list_file(case,caseroot,screamroot,ic_section)
+    create_input_data_list_file(case, caseroot)
 
     # For all YAML files listed in the XML for model output, expand CIME vars (if any)
     do_cime_vars_on_yaml_output_files(case,caseroot)

--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -729,15 +729,12 @@ def get_file_parameters(caseroot):
     return list(OrderedDict.fromkeys(result))
 
 ###############################################################################
-def create_input_data_list_file(case, caseroot):
+def create_input_data_list_file(caseroot):
 ###############################################################################
     """
     Create the scream.input_data_list file for this case. This will tell CIME
     what to download.
     """
-    rundir   = case.get_value("RUNDIR")
-    target   = os.path.join(rundir, "data")
-
     files_to_download = get_file_parameters(caseroot)
 
     input_data_list_file = "{}/Buildconf/scream.input_data_list".format(caseroot)
@@ -841,7 +838,7 @@ def buildnml(case, caseroot, compname):
     # Create input data list. This is the list of files that CIME needs
     # to ensure are present on the machine (possibly downloading them)
     #
-    create_input_data_list_file(case, caseroot)
+    create_input_data_list_file(caseroot)
 
     # For all YAML files listed in the XML for model output, expand CIME vars (if any)
     do_cime_vars_on_yaml_output_files(case,caseroot)

--- a/components/scream/cime_config/buildnml
+++ b/components/scream/cime_config/buildnml
@@ -57,7 +57,7 @@ CIME_VAR_RE = re.compile(r'[$][{](\w+)[}]')
 #    Examples:
 #      - constraints="ge 0; lt 4" means the value V must satisfy V>=0 && V<4.
 #      - constraints="mod 2 eq 0" means the value V must be a multiple of 2.
-METADATA_ATTRIBS = ("type", "valid_values", "locked", "constraints", "inherit", "file")
+METADATA_ATTRIBS = ("type", "valid_values", "locked", "constraints", "inherit")
 
 ###############################################################################
 def do_cime_vars(entry, case, refine=False, extra=None):
@@ -719,10 +719,14 @@ def get_file_parameters(caseroot):
         raw_xml = tree.getroot()
 
     result = []
-    for item in raw_xml.findall('.//*[@file="true"]'):
+    for item in raw_xml.findall('.//*[@type="file"]'):
         result.append(item.text.strip())
 
-    return result
+    for item in raw_xml.findall('.//*[@type="array(file)"]'):
+        result.extend(refine_type(item.text, force_type="array(file)"))
+
+    # Remove duplicates. Note sure if an error would be warranted if dupes exist
+    return list(OrderedDict.fromkeys(result))
 
 ###############################################################################
 def create_input_data_list_file(case, caseroot):

--- a/components/scream/cime_config/eamxx_buildnml_impl.py
+++ b/components/scream/cime_config/eamxx_buildnml_impl.py
@@ -225,7 +225,7 @@ def refine_type(entry, force_type=None):
     # We want to preserve strings representing lists
     if (entry[0]=="(" and entry[-1]==")") or \
        (entry[0]=="[" and entry[-1]=="]") :
-        expect (force_type is None or force_type=="string",
+        expect (force_type is None or force_type == "string",
                 "Error! Invalid force type '{}' for a string representing a list"
                 .format(force_type))
         return entry
@@ -261,7 +261,7 @@ def refine_type(entry, force_type=None):
                 elem = int(tmp)
             elif elem_type == "real":
                 elem = float(entry)
-            elif elem_type == "string":
+            elif elem_type in ["string", "file"]:
                 elem = str(entry)
             else:
                 raise NameError ("Bad force_type: {}".format(force_type))

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -74,29 +74,41 @@ tweaking their $case/namelist_scream.xml file.
            set of selectors. A parameter element with no selectors, which means it controls the default param value, must
            come before parameter elements with selectors. If multiple parameter elements
            are matched, then the match the occurs last takes precendence.
+
         2) The first matched parameter element encountered for a parameter will define the default metadata
            for that parameter. All subsequent parameter elements will assume the same
            metadata as the first unless an explicit override occurs.
            User changes to the case XML file must be compatible with the metadata.
+
         3) For a parameter whose elements all have selectors, if none of the selectors
            are matched, then the parameter will be omitted from the case XML
            file ($case/namelist_scream.xml).
+
         4) Parameter types will be inferred. You can override the inferred type
            via the 'type' metadata attribute. Types are:
              logical: will be inferred from any case of true/false
              integer: will be inferred from any sequence of 0-9
              real   : will be inferred from any numeric expression with a decimal point or scientific notation
+             file   : A string that denotes a file path that CIME should download
+                      NOTE: All file parameters will be symlinked to ${RUNDIR}/data from the download area.
              string : everything else
+
+             array(one of the above): An array of one of the above types
+
         5) A parameter can be set to any value of the correct type unless
            the 'valid_values' metadata attribute is set. If desired, valid_values
            should be set up as a comma-separated list of values, e.g. 'valid_values="1,2,3"'
            TODO support numeric checks (<, >, ...)??
+
         6) You can inline case values into parameter values via this syntax, e.g.:
            <init_file>scream_init_${ATM_GRID}.nc</init_file>
            This would result in parameter init_file' having the value 'scream_init_ne4np4.nc'
+
         7) Any parameter value with a comma will be assumed to be a list.
            TODO allow this behavior to be overridden?
+
         8) Every value in a list should be of the same type
+
         9) All local changes made to $case/namelist_scream.xml must conform
            to the structure and metadata derived from this file.
 
@@ -117,11 +129,6 @@ tweaking their $case/namelist_scream.xml file.
              - constraints="ge 0; ne 4" means the value V must satisfy V>=0 && V!=4.
              - constraints="ge 0; lt 4" means the value V must satisfy V>=0 && V<4.
              - constraints="mod 2 eq 0" means the value V must be a multiple of 2.
-
-       13) The attribute 'file' denotes that the parameter should be added to the list of files
-           that need to be downloaded by CIME. Example
-           <init_file file="true">scream_init_${ATM_GRID}.nc</init_file>
-           NOTE: All file parameters will be symlinked to ${RUNDIR}/data from the download area.
   -->
 
   <atmosphere_processes_defaults>
@@ -158,7 +165,7 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Homme dynamics -->
     <homme inherit="atm_proc_base">
       <Grid>Dynamics</Grid>
-      <vertical_coordinate_filename file="true">UNSET</vertical_coordinate_filename>
+      <vertical_coordinate_filename type="file">UNSET</vertical_coordinate_filename>
       <vertical_coordinate_filename nlev="72">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L72_20220927.nc</vertical_coordinate_filename>
       <vertical_coordinate_filename nlev="128">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L128_20220927.nc</vertical_coordinate_filename>
       <Moisture>moist</Moisture>
@@ -171,11 +178,13 @@ tweaking their $case/namelist_scream.xml file.
       <do_predict_nc>true</do_predict_nc>
       <do_predict_nc COMPSET=".*SCREAM.*noAero">false</do_predict_nc>
       <enable_column_conservation_checks>false</enable_column_conservation_checks>
-      <p3_lookup_table file="true">${DIN_LOC_ROOT}/atm/scream/tables/p3_lookup_table_1.dat-v4.1.1</p3_lookup_table>
-      <mu_r_table file="true">${DIN_LOC_ROOT}/atm/scream/tables/mu_r_table_vals.dat8</mu_r_table>
-      <revap_table file="true">${DIN_LOC_ROOT}/atm/scream/tables/revap_table_vals.dat8</revap_table>
-      <vn_table file="true">${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8</vn_table>
-      <vm_table file="true">${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8</vm_table>
+      <tables type="array(file)">
+        ${DIN_LOC_ROOT}/atm/scream/tables/p3_lookup_table_1.dat-v4.1.1,
+        ${DIN_LOC_ROOT}/atm/scream/tables/mu_r_table_vals.dat8,
+        ${DIN_LOC_ROOT}/atm/scream/tables/revap_table_vals.dat8,
+        ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
+        ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8
+      </tables>
     </p3>
 
     <!-- SHOC macrophysics -->
@@ -188,7 +197,7 @@ tweaking their $case/namelist_scream.xml file.
 
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="atm_proc_base">
-      <spa_remap_file file="true">UNSET</spa_remap_file>
+      <spa_remap_file type="file">UNSET</spa_remap_file>
       <spa_remap_file hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30_to_ne4_mono_20220502.nc</spa_remap_file>
       <spa_remap_file hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne4pg2_mono.20220714.nc</spa_remap_file>
       <spa_remap_file hgrid="ne30np4">none</spa_remap_file>
@@ -200,15 +209,15 @@ tweaking their $case/namelist_scream.xml file.
       <spa_remap_file hgrid="ne512np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne512pg2_intbilin_20221012.nc</spa_remap_file>
       <spa_remap_file hgrid="ne1024np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne1024pg2_intbilin_20221012.nc</spa_remap_file>
 
-      <spa_data_file file="true">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</spa_data_file>
+      <spa_data_file type="file">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</spa_data_file>
     </spa>
 
     <!-- Radiation -->
     <rrtmgp inherit="atm_proc_base">
-      <rrtmgp_coefficients_file_sw file="true">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-sw-g112-210809.nc</rrtmgp_coefficients_file_sw>
-      <rrtmgp_coefficients_file_lw file="true">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-lw-g128-210809.nc</rrtmgp_coefficients_file_lw>
-      <rrtmgp_cloud_optics_file_sw file="true">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-sw.nc</rrtmgp_cloud_optics_file_sw>
-      <rrtmgp_cloud_optics_file_lw file="true">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-lw.nc</rrtmgp_cloud_optics_file_lw>
+      <rrtmgp_coefficients_file_sw type="file">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-sw-g112-210809.nc</rrtmgp_coefficients_file_sw>
+      <rrtmgp_coefficients_file_lw type="file">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-lw-g128-210809.nc</rrtmgp_coefficients_file_lw>
+      <rrtmgp_cloud_optics_file_sw type="file">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-sw.nc</rrtmgp_cloud_optics_file_sw>
+      <rrtmgp_cloud_optics_file_lw type="file">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-lw.nc</rrtmgp_cloud_optics_file_lw>
       <column_chunk_size>1280</column_chunk_size>
       <!-- Radiatively active gases; surface values set to F2010 settings taken from EAM  -->
       <!-- Note that h2o concentrations are just taken from qv, o3 is prescribed for now, -->
@@ -273,7 +282,7 @@ tweaking their $case/namelist_scream.xml file.
 
   <!-- List of nc files for loading inputs on specified grids -->
   <initial_conditions>
-    <Filename file="true">UNSET</Filename>
+    <Filename type="file">UNSET</Filename>
     <Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne4np4L72_20220823.nc</Filename>
     <Filename hgrid="ne30np4" nlev="72">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220823.nc</Filename>
     <Filename hgrid="ne30np4" nlev="128">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L128_20221004.nc</Filename>

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -92,7 +92,8 @@ tweaking their $case/namelist_scream.xml file.
              file   : A string that denotes a file path that CIME should download
              string : everything else
 
-             array(one of the above): An array of one of the above types
+             array(one of the above): An array of one of the above types. The array type will be inferred
+                                      if the value is of the form (v1, v2, ...) or [v1, v2, ...]
 
         5) A parameter can be set to any value of the correct type unless
            the 'valid_values' metadata attribute is set. If desired, valid_values

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -90,7 +90,6 @@ tweaking their $case/namelist_scream.xml file.
              integer: will be inferred from any sequence of 0-9
              real   : will be inferred from any numeric expression with a decimal point or scientific notation
              file   : A string that denotes a file path that CIME should download
-                      NOTE: All file parameters will be symlinked to ${RUNDIR}/data from the download area.
              string : everything else
 
              array(one of the above): An array of one of the above types

--- a/components/scream/cime_config/namelist_defaults_scream.xml
+++ b/components/scream/cime_config/namelist_defaults_scream.xml
@@ -117,6 +117,11 @@ tweaking their $case/namelist_scream.xml file.
              - constraints="ge 0; ne 4" means the value V must satisfy V>=0 && V!=4.
              - constraints="ge 0; lt 4" means the value V must satisfy V>=0 && V<4.
              - constraints="mod 2 eq 0" means the value V must be a multiple of 2.
+
+       13) The attribute 'file' denotes that the parameter should be added to the list of files
+           that need to be downloaded by CIME. Example
+           <init_file file="true">scream_init_${ATM_GRID}.nc</init_file>
+           NOTE: All file parameters will be symlinked to ${RUNDIR}/data from the download area.
   -->
 
   <atmosphere_processes_defaults>
@@ -153,7 +158,7 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Homme dynamics -->
     <homme inherit="atm_proc_base">
       <Grid>Dynamics</Grid>
-      <vertical_coordinate_filename>UNSET</vertical_coordinate_filename>
+      <vertical_coordinate_filename file="true">UNSET</vertical_coordinate_filename>
       <vertical_coordinate_filename nlev="72">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L72_20220927.nc</vertical_coordinate_filename>
       <vertical_coordinate_filename nlev="128">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L128_20220927.nc</vertical_coordinate_filename>
       <Moisture>moist</Moisture>
@@ -166,6 +171,11 @@ tweaking their $case/namelist_scream.xml file.
       <do_predict_nc>true</do_predict_nc>
       <do_predict_nc COMPSET=".*SCREAM.*noAero">false</do_predict_nc>
       <enable_column_conservation_checks>false</enable_column_conservation_checks>
+      <p3_lookup_table file="true">${DIN_LOC_ROOT}/atm/scream/tables/p3_lookup_table_1.dat-v4.1.1</p3_lookup_table>
+      <mu_r_table file="true">${DIN_LOC_ROOT}/atm/scream/tables/mu_r_table_vals.dat8</mu_r_table>
+      <revap_table file="true">${DIN_LOC_ROOT}/atm/scream/tables/revap_table_vals.dat8</revap_table>
+      <vn_table file="true">${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8</vn_table>
+      <vm_table file="true">${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8</vm_table>
     </p3>
 
     <!-- SHOC macrophysics -->
@@ -178,7 +188,7 @@ tweaking their $case/namelist_scream.xml file.
 
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="atm_proc_base">
-      <spa_remap_file>UNSET</spa_remap_file>
+      <spa_remap_file file="true">UNSET</spa_remap_file>
       <spa_remap_file hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30_to_ne4_mono_20220502.nc</spa_remap_file>
       <spa_remap_file hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne4pg2_mono.20220714.nc</spa_remap_file>
       <spa_remap_file hgrid="ne30np4">none</spa_remap_file>
@@ -189,15 +199,16 @@ tweaking their $case/namelist_scream.xml file.
       <spa_remap_file hgrid="ne256np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne256pg2_intbilin_20221011.nc</spa_remap_file>
       <spa_remap_file hgrid="ne512np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne512pg2_intbilin_20221012.nc</spa_remap_file>
       <spa_remap_file hgrid="ne1024np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne1024pg2_intbilin_20221012.nc</spa_remap_file>
-      <spa_data_file>${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</spa_data_file>
+
+      <spa_data_file file="true">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</spa_data_file>
     </spa>
 
     <!-- Radiation -->
     <rrtmgp inherit="atm_proc_base">
-      <rrtmgp_coefficients_file_sw>${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-sw-g112-210809.nc</rrtmgp_coefficients_file_sw>
-      <rrtmgp_coefficients_file_lw>${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-lw-g128-210809.nc</rrtmgp_coefficients_file_lw>
-      <rrtmgp_cloud_optics_file_sw>${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-sw.nc</rrtmgp_cloud_optics_file_sw>
-      <rrtmgp_cloud_optics_file_lw>${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-lw.nc</rrtmgp_cloud_optics_file_lw>
+      <rrtmgp_coefficients_file_sw file="true">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-sw-g112-210809.nc</rrtmgp_coefficients_file_sw>
+      <rrtmgp_coefficients_file_lw file="true">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-lw-g128-210809.nc</rrtmgp_coefficients_file_lw>
+      <rrtmgp_cloud_optics_file_sw file="true">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-sw.nc</rrtmgp_cloud_optics_file_sw>
+      <rrtmgp_cloud_optics_file_lw file="true">${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-lw.nc</rrtmgp_cloud_optics_file_lw>
       <column_chunk_size>1280</column_chunk_size>
       <!-- Radiatively active gases; surface values set to F2010 settings taken from EAM  -->
       <!-- Note that h2o concentrations are just taken from qv, o3 is prescribed for now, -->
@@ -262,18 +273,19 @@ tweaking their $case/namelist_scream.xml file.
 
   <!-- List of nc files for loading inputs on specified grids -->
   <initial_conditions>
-    <Filename>UNSET</Filename>
+    <Filename file="true">UNSET</Filename>
     <Filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne4np4L72_20220823.nc</Filename>
     <Filename hgrid="ne30np4" nlev="72">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220823.nc</Filename>
     <Filename hgrid="ne30np4" nlev="128">${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L128_20221004.nc</Filename>
     <Filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220823.nc</Filename>
     <Filename hgrid="ne256np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne256np4L128_ifs-20200120_20220914.nc</Filename>
-    <Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220823.nc</Filename> 
+    <Filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220823.nc</Filename>
     <Filename hgrid="ne1024np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_era5-20131001-topoadj-16x_20220914.nc</Filename>
     <Filename hgrid="ne1024np4" COMPSET=".*SCREAM%DYAMOND-1_ELM">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_ifs-20160801-topoadj16x_20221011.nc</Filename>
     <Filename hgrid="ne1024np4" COMPSET=".*SCREAM%DYAMOND-1-X6T_ELM">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_ifs-20160801-topoadjx6t_20221011.nc</Filename>
     <Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/screami_aquaplanet_ne4np4L72_20220823.nc</Filename>
     <Filename hgrid="ne30np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/screami_aquaplanet_ne30np4L128_20220823.nc</Filename> <!-- This will need to be updated to the new nccn name -->
+
     <restart_casename>${CASE}.scream</restart_casename>
     <!-- Fields that we need to initialize, but are not in an initial condition file need to be inited here -->
     <surf_evap>0.0</surf_evap> <!-- TODO, Delete this when the IC fixes come in -->
@@ -337,35 +349,6 @@ tweaking their $case/namelist_scream.xml file.
   <e3sm_parameters>
     <e3sm_casename>${CASE}</e3sm_casename>
   </e3sm_parameters>
-
-  <!--
-    List of input files that CIME needs to ensure to be present. If not present,
-    CIME will automatically download them from the E3SM data server.
-  -->
-  <input_files>
-    ${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L72_20220927.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L128_20220927.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-sw-g112-210809.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-data-lw-g128-210809.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-sw.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/rrtmgp-cloud-optics-coeffs-lw.nc,
-    ${DIN_LOC_ROOT}/atm/scream/tables/p3_lookup_table_1.dat-v4.1.1,
-    ${DIN_LOC_ROOT}/atm/scream/tables/mu_r_table_vals.dat8,
-    ${DIN_LOC_ROOT}/atm/scream/tables/revap_table_vals.dat8,
-    ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
-    ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8,
-    ${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc,
-    ${DIN_LOC_ROOT}/atm/scream/maps/map_ne30_to_ne4_mono_20220502.nc,
-    <!-- ${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne120np4_mono_20220502.nc, -->
-    <!-- ${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne512np4_mono_20220506.nc, -->
-    ${DIN_LOC_ROOT}/atm/scream/init/screami_ne30np4L72_20220701.nc,
-    ${DIN_LOC_ROOT}/atm/scream/init/screami_ne4np4L72_20220524.nc,
-    <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne120np4L72_20220524.nc, -->
-    <!-- ${DIN_LOC_ROOT}/atm/scream/init/screami_ne512np4L128_20220525.nc, -->
-    ${DIN_LOC_ROOT}/atm/scream/init/scream-aquaplanet_init_ne4np4_L72_20220524.nc,
-    ${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne4pg2_mono.20220714.nc,
-    ${DIN_LOC_ROOT}/atm/scream/maps/map_ne30np4_to_ne30pg2_mono.20220714.nc
-  </input_files>
 
   <!-- Homme control namelist -->
   <ctl_nl>


### PR DESCRIPTION
Remove special input_files element and instead add file attribute to parameters that specify input files. This eliminates duplication and allows selectors to filter-out unneeded files.

Fixes #1955 