### PR TITLE
Prevent SHOC temperature from going negative

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -2267,7 +2267,7 @@ subroutine shoc_assumed_pdf(&
   real(rtype) s1,s2,std_s1,std_s2,C1,C2
   real(rtype) ql1,ql2
   real(rtype) thl_first,qw_first,w_first
-  real(rtype) Tl1_1,Tl1_2,pval
+  real(rtype) Tl1_1,Tl1_2,Tl1_g,pval
   real(rtype) thlsec,qwsec,qwthlsec,wqwsec,wthlsec
   real(rtype) qn1,qn2
   real(rtype) beta1, beta2, qs1, qs2
@@ -2390,21 +2390,22 @@ subroutine shoc_assumed_pdf(&
       !  BEGIN TO COMPUTE CLOUD PROPERTY STATISTICS
 
       call shoc_assumed_pdf_compute_temperature(&
+        thl_first,basepres,pval,& ! Input
+        Tl1_g)                    ! Output
+      call shoc_assumed_pdf_compute_temperature(&
         thl1_1,basepres,pval,& ! Input
         Tl1_1)                 ! Output
       call shoc_assumed_pdf_compute_temperature(&
         thl1_2,basepres,pval,& ! Input
         Tl1_2)                 ! Output
 
-      ! Check to ensure Tl1_1 and Tl1_2 are not negative. endrun otherwise
+      ! Check to ensure Tl1_1 and Tl1_2 are not negative. temporarily set to grid mean value if so.
       if (Tl1_1 .le. 0._rtype) then
-         write(err_msg,*)'ERROR: Tl1_1 is .le. 0 before shoc_assumed_pdf_compute_qs in shoc. Tl1_1 is:',Tl1_1
-         call endscreamrun(err_msg)
+         Tl1_1 = Tl1_g
       endif
 
       if (Tl1_2 .le. 0._rtype) then
-         write(err_msg,*)'ERROR: Tl1_2 is .le. 0 before shoc_assumed_pdf_compute_qs in shoc. Tl1_2 is:',Tl1_2
-         call endscreamrun(err_msg)
+         Tl1_2 = Tl1_g
       endif
 
       ! Now compute qs

--- a/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
@@ -222,17 +222,18 @@ void Functions<S,D>::shoc_assumed_pdf(
       }
 
       // Begin to compute cloud property statistics
+      const Spack Tl1_g = thl_first/(ekat::pow(basepres/pval,(rair/cp)));
       const Spack Tl1_1 = thl1_1/(ekat::pow(basepres/pval,(rair/cp)));
       const Spack Tl1_2 = thl1_2/(ekat::pow(basepres/pval,(rair/cp)));
 
       const auto index_range = ekat::range<IntSmallPack>(k*Spack::n);
       const Smask active_entries = (index_range < nlev);
 
-      // Check to ensure Tl1_1 and Tl1_2 are not negative, endrun otherwise
+      // Check to ensure Tl1_1 and Tl1_2 are not negative, temporarily set to grid mean value if so.
+      Tl1_1.set(Tl1_1<0, Tl1_g);
+      Tl1_2.set(Tl1_2<0, Tl1_g);
       const auto is_neg_Tl1_1 = (Tl1_1 <= 0) && active_entries;
       const auto is_neg_Tl1_2 = (Tl1_2 <= 0) && active_entries;
-      EKAT_KERNEL_REQUIRE_MSG(!(is_neg_Tl1_1.any()), "Error! Tl1_1 has <= 0 values.\n"); //exit with an error message
-      EKAT_KERNEL_REQUIRE_MSG(!(is_neg_Tl1_2.any()), "Error! Tl1_2 has <= 0 values.\n"); //exit with an error message
 
       // Compute qs and beta
       Spack qs1(0), qs2(0), beta1(0), beta2(0);

--- a/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
@@ -223,18 +223,17 @@ void Functions<S,D>::shoc_assumed_pdf(
 
       // Begin to compute cloud property statistics
       const Spack Tl1_g = thl_first/(ekat::pow(basepres/pval,(rair/cp)));
-      const Spack Tl1_1 = thl1_1/(ekat::pow(basepres/pval,(rair/cp)));
-      const Spack Tl1_2 = thl1_2/(ekat::pow(basepres/pval,(rair/cp)));
+            Spack Tl1_1 = thl1_1/(ekat::pow(basepres/pval,(rair/cp)));
+            Spack Tl1_2 = thl1_2/(ekat::pow(basepres/pval,(rair/cp)));
 
       const auto index_range = ekat::range<IntSmallPack>(k*Spack::n);
       const Smask active_entries = (index_range < nlev);
 
       // Check to ensure Tl1_1 and Tl1_2 are not negative, temporarily set to grid mean value if so.
-      const auto is_neg_Tl1_1 = (Tl1_1 <= 0) && active_entries;
-      const auto is_neg_Tl1_2 = (Tl1_2 <= 0) && active_entries;
-      Tl1_1.set(is_neg_Tl1_1, Tl1_g);
-      Tl1_2.set(is_neg_Tl1_2, Tl1_g);
+      const Smask is_neg_Tl1_1 = (Tl1_1 <= 0) && active_entries;
+      const Smask is_neg_Tl1_2 = (Tl1_2 <= 0) && active_entries;
       if( is_neg_Tl1_1.any() ) {
+        Tl1_1.set(is_neg_Tl1_1,Tl1_g);
         int n_mask = 0;
         for (int i=0; i<is_neg_Tl1_1.n; i++) {
           if (is_neg_Tl1_1[i]) {
@@ -244,6 +243,7 @@ void Functions<S,D>::shoc_assumed_pdf(
         printf("WARNING: Tl1_1 has %d values <= 0.  Resetting to minimum value.\n",n_mask);
       }
       if( is_neg_Tl1_2.any() ) {
+        Tl1_2.set(is_neg_Tl1_2,Tl1_g);
         int n_mask = 0;
         for (int i=0; i<is_neg_Tl1_2.n; i++) {
           if (is_neg_Tl1_2[i]) {

--- a/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_assumed_pdf_impl.hpp
@@ -230,10 +230,28 @@ void Functions<S,D>::shoc_assumed_pdf(
       const Smask active_entries = (index_range < nlev);
 
       // Check to ensure Tl1_1 and Tl1_2 are not negative, temporarily set to grid mean value if so.
-      Tl1_1.set(Tl1_1<0, Tl1_g);
-      Tl1_2.set(Tl1_2<0, Tl1_g);
       const auto is_neg_Tl1_1 = (Tl1_1 <= 0) && active_entries;
       const auto is_neg_Tl1_2 = (Tl1_2 <= 0) && active_entries;
+      Tl1_1.set(is_neg_Tl1_1, Tl1_g);
+      Tl1_2.set(is_neg_Tl1_2, Tl1_g);
+      if( is_neg_Tl1_1.any() ) {
+        int n_mask = 0;
+        for (int i=0; i<is_neg_Tl1_1.n; i++) {
+          if (is_neg_Tl1_1[i]) {
+            n_mask++;
+          }
+        }
+        printf("WARNING: Tl1_1 has %d values <= 0.  Resetting to minimum value.\n",n_mask);
+      }
+      if( is_neg_Tl1_2.any() ) {
+        int n_mask = 0;
+        for (int i=0; i<is_neg_Tl1_2.n; i++) {
+          if (is_neg_Tl1_2[i]) {
+            n_mask++;
+          }
+        }
+        printf("WARNING: Tl1_2 has %d values <= 0.  Resetting to minimum value.\n",n_mask);
+      }
 
       // Compute qs and beta
       Spack qs1(0), qs2(0), beta1(0), beta2(0);


### PR DESCRIPTION
Temporary fix to prevent individual Gaussian temperatures from going negative.  If so, replace with grid mean temperature to prevent crash.  

PR needs:  examination of cpp conversion (no confidence) and warning messages if clipping does occur.