### PR TITLE
EAMxx: fix driver options sublist name in f90-cxx interface

### DIFF
--- a/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/scream/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -94,7 +94,7 @@ void scream_create_atm_instance (const MPI_Fint f_comm, const int atm_id,
     ekat::ParameterList scream_params("Scream Parameters");
     parse_yaml_file (input_yaml_file, scream_params);
 
-    scream_params.sublist("Debug").set<std::string>("Atm Log File",atm_log_file);
+    scream_params.sublist("driver_options").set<std::string>("Atm Log File",atm_log_file);
 
     // Need to register products in the factories *before* we attempt to create any.
     // In particular, register all atm processes, and all grids managers.


### PR DESCRIPTION
The name of a parameter list has recently changed, but we forgot to update its name in one place. This caused atm log filename to not be correctly forwarded to the atm driver.

Fix #2008 