### PR TITLE
Set the year values for DYAMOND-1 SSTICE data stream

### DIFF
--- a/components/data_comps/docn/cime_config/config_component.xml
+++ b/components/data_comps/docn/cime_config/config_component.xml
@@ -251,6 +251,7 @@
       <value compset="20TR_CAM5%CMIP6">1869</value>
       <value compset="20TR_EAM%CMIP6">1869</value>
       <value compset="20TR_EAM%MMF.*CMIP6">1869</value>
+      <value compset="2010_SCREAM%DYAMOND-1">2016</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -277,6 +278,7 @@
       <value compset="20TR_CAM5%CMIP6">1869</value>
       <value compset="20TR_EAM%CMIP6">1869</value>
       <value compset="20TR_EAM%MMF.*CMIP6">1869</value>
+      <value compset="2010_SCREAM%DYAMOND-1">2016</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -297,6 +299,7 @@
       <value compset="20TR_CAM5%CMIP6">2016</value>
       <value compset="20TR_EAM%CMIP6">2016</value>
       <value compset="20TR_EAM%MMF.*CMIP6">2016</value>
+      <value compset="2010_SCREAM%DYAMOND-1">2016</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
This is to match both the year values in the SSTICE data and the model year to use for DYAMOND-1 simulation, which is 2016.

Fix issue #2004.

[BFB]