### PR TITLE
EAMxx: process rrtmgp sources with YAKL's macros to select compile language

### DIFF
--- a/components/scream/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/scream/src/physics/rrtmgp/CMakeLists.txt
@@ -57,6 +57,12 @@ set(EXTERNAL_SRC
   ${EAM_RRTMGP_DIR}/external/cpp/rte/kernels/mo_rte_solver_kernels.cpp
   ${EAM_RRTMGP_DIR}/external/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.cpp
 )
+list(APPEND CMAKE_MODULE_PATH
+  ${SCREAM_BASE_DIR}/../../externals/YAKL)
+
+include(yakl_utils)
+yakl_process_cxx_source_files("${EXTERNAL_SRC}")
+
 add_library(rrtmgp ${EXTERNAL_SRC})
 EkatDisableAllWarning(rrtmgp)
 SetCudaFlags(rrtmgp)


### PR DESCRIPTION
In particular, this sets the compile language of rrtmgp sources to match whatever compile language was set for YAKL's c++ sources. This ensures that the flags of target rrtmgp inherit the same flags used to compile the yakl target.

Fix #2020 