### PR TITLE
EAMxx: minor mod to random test setup, to enhance reproducibility

### DIFF
--- a/components/scream/src/share/util/scream_setup_random_test.hpp
+++ b/components/scream/src/share/util/scream_setup_random_test.hpp
@@ -18,8 +18,8 @@ Engine setup_random_test(const ekat::Comm* comm=nullptr)
   const auto& test_name = Catch::getResultCapture().getCurrentTestName();
 
   std::random_device rdev;
-  const unsigned int catchRngSeed = Catch::rngSeed();
-  const unsigned int seed = catchRngSeed==0 ? rdev() : catchRngSeed;
+  const int catchRngSeed = Catch::rngSeed();
+  int seed = catchRngSeed==0 ? rdev() : catchRngSeed;
 
   if (comm == nullptr || comm->am_i_root()) {
     // Print seed to screen to trace tests that fail.
@@ -28,6 +28,15 @@ Engine setup_random_test(const ekat::Comm* comm=nullptr)
       std::cout << "    Note: catch rng seed was 0 (default). We interpret that as a request to pick a random seed.\n"
         "    To reproduce a previous run, use --rng-seed N to provide the rng seed.\n\n";
     }
+
+  }
+
+  // Ensure all ranks use different seeds, but in a reproducible way
+  if (comm) {
+    comm->broadcast(&seed,1,comm->root_rank());
+    // We don't really expect root_rank to ever change from 0,
+    // but it doesn't cost anything...
+    seed += comm->rank()-comm->root_rank();
   }
   Engine engine(seed);
   return engine;


### PR DESCRIPTION
When trying to re-run a test with 2+ ranks, we can only pass the random seed used by rank 0 (which was printed by the test setup), but that will make all ranks use what rank 0 used in the first run, which is not what they originally used.

This PR makes the rng seed for ranks>0 dependent on the rng seed of rank 0 _always_. They will still use different seeds, to increase randomization, but this way we can fully reproduce an MPI run.

Note: in order to take advantage of this feature, we should always pass a comm to `setup_random_test`. @jgfouca I wonder if we should make the comm arg mandatory...