### PR TITLE
This commit fixes a bug in the team policy declaration for diagnostics.

### DIFF
--- a/components/scream/src/diagnostics/dry_static_energy.hpp
+++ b/components/scream/src/diagnostics/dry_static_energy.hpp
@@ -46,9 +46,8 @@ protected:
   Int m_num_levs;
 
   // Temporary view to set dz in compute diagnostic
-  view_2d m_dz;
-  view_2d m_z_int;
-  view_2d m_z_mid;
+  view_2d m_tmp_mid;
+  view_2d m_tmp_int;
 
 }; // class DryStaticEnergyDiagnostic
 

--- a/components/scream/src/diagnostics/dry_static_energy.hpp
+++ b/components/scream/src/diagnostics/dry_static_energy.hpp
@@ -20,7 +20,7 @@ public:
 
   using KT            = KokkosTypes<DefaultDevice>;
   using MemberType    = typename KT::MemberType;
-  using view_1d       = typename KT::template view_1d<Pack>;
+  using view_2d       = typename KT::template view_2d<Pack>;
 
   // Constructors
   DryStaticEnergyDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
@@ -44,6 +44,11 @@ protected:
   // Keep track of field dimensions
   Int m_num_cols;
   Int m_num_levs;
+
+  // Temporary view to set dz in compute diagnostic
+  view_2d m_dz;
+  view_2d m_z_int;
+  view_2d m_z_mid;
 
 }; // class DryStaticEnergyDiagnostic
 

--- a/components/scream/src/diagnostics/vertical_layer_interface.hpp
+++ b/components/scream/src/diagnostics/vertical_layer_interface.hpp
@@ -20,7 +20,7 @@ public:
   using KT            = KokkosTypes<DefaultDevice>;
   using MemberType    = typename KT::MemberType;
 
-  using view_1d       = typename KT::template view_1d<Pack>;
+  using view_2d       = typename KT::template view_2d<Pack>;
 
   // Constructors
   VerticalLayerInterfaceDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
@@ -44,6 +44,9 @@ protected:
   // Keep track of field dimensions
   Int m_num_cols;
   Int m_num_levs;
+
+  // Temporary view to set dz in compute diagnostic
+  view_2d m_dz;
 
 }; // class VerticalLayerInterfaceDiagnostic
 

--- a/components/scream/src/diagnostics/vertical_layer_midpoint.cpp
+++ b/components/scream/src/diagnostics/vertical_layer_midpoint.cpp
@@ -39,6 +39,12 @@ void VerticalLayerMidpointDiagnostic::set_grids(const std::shared_ptr<const Grid
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation(ps);
   m_diagnostic_output.allocate_view();
+
+  // Initialize 2d view of dz to be used in compute_diagnostic
+  const auto npacks     = ekat::npack<Pack>(m_num_levs);
+  const auto npacks_p1  = ekat::npack<Pack>(m_num_levs+1);
+  m_dz    = view_2d("",m_num_cols,npacks);
+  m_z_int = view_2d("",m_num_cols,npacks_p1);
 }
 // =========================================================================================
 void VerticalLayerMidpointDiagnostic::compute_diagnostic_impl()
@@ -46,7 +52,7 @@ void VerticalLayerMidpointDiagnostic::compute_diagnostic_impl()
 
   const auto npacks     = ekat::npack<Pack>(m_num_levs);
   const auto npacks_p1  = ekat::npack<Pack>(m_num_levs+1);
-  const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, npacks);
+  const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(m_num_cols, npacks);
   const auto& z_mid              = m_diagnostic_output.get_view<Pack**>();
   const auto& T_mid              = get_field_in("T_mid").get_view<const Pack**>();
   const auto& p_mid              = get_field_in("p_mid").get_view<const Pack**>();
@@ -57,19 +63,21 @@ void VerticalLayerMidpointDiagnostic::compute_diagnostic_impl()
   const Real surf_geopotential = 0.0;
 
   const int num_levs = m_num_levs;
-  view_1d dz("",npacks);
-  view_1d z_int("",npacks_p1);
+  auto dz    = m_dz;
+  auto z_int = m_z_int;
   Kokkos::parallel_for("VerticalLayerMidpointDiagnostic",
                        default_policy,
                        KOKKOS_LAMBDA(const MemberType& team) {
     const int icol = team.league_rank();
+    const auto& dz_s    = ekat::subview(dz, icol);
+    const auto& z_int_s = ekat::subview(z_int, icol);
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team, npacks), [&] (const Int& jpack) {
-      dz(jpack) = PF::calculate_dz(pseudo_density_mid(icol,jpack), p_mid(icol,jpack), T_mid(icol,jpack), qv_mid(icol,jpack));
+      dz_s(jpack) = PF::calculate_dz(pseudo_density_mid(icol,jpack), p_mid(icol,jpack), T_mid(icol,jpack), qv_mid(icol,jpack));
     });
     team.team_barrier();
     const auto& z_mid_s = ekat::subview(z_mid, icol);
-    PF::calculate_z_int(team,num_levs,dz,surf_geopotential,z_int);
-    PF::calculate_z_mid(team,num_levs,z_int,z_mid_s);
+    PF::calculate_z_int(team,num_levs,dz_s,surf_geopotential,z_int_s);
+    PF::calculate_z_mid(team,num_levs,z_int_s,z_mid_s);
   });
 
   const auto ts = get_field_in("qv").get_header().get_tracking().get_time_stamp();

--- a/components/scream/src/diagnostics/vertical_layer_midpoint.cpp
+++ b/components/scream/src/diagnostics/vertical_layer_midpoint.cpp
@@ -41,9 +41,7 @@ void VerticalLayerMidpointDiagnostic::set_grids(const std::shared_ptr<const Grid
   m_diagnostic_output.allocate_view();
 
   // Initialize 2d view of dz to be used in compute_diagnostic
-  const auto npacks     = ekat::npack<Pack>(m_num_levs);
   const auto npacks_p1  = ekat::npack<Pack>(m_num_levs+1);
-  m_dz    = view_2d("",m_num_cols,npacks);
   m_z_int = view_2d("",m_num_cols,npacks_p1);
 }
 // =========================================================================================
@@ -63,19 +61,18 @@ void VerticalLayerMidpointDiagnostic::compute_diagnostic_impl()
   const Real surf_geopotential = 0.0;
 
   const int num_levs = m_num_levs;
-  auto dz    = m_dz;
   auto z_int = m_z_int;
   Kokkos::parallel_for("VerticalLayerMidpointDiagnostic",
                        default_policy,
                        KOKKOS_LAMBDA(const MemberType& team) {
     const int icol = team.league_rank();
-    const auto& dz_s    = ekat::subview(dz, icol);
+    const auto& z_mid_s = ekat::subview(z_mid, icol);
+    const auto& dz_s    = z_mid_s; // Use the memory in z_mid for dz, since we don't set z_mid until after dz is no longer needed.
     const auto& z_int_s = ekat::subview(z_int, icol);
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team, npacks), [&] (const Int& jpack) {
       dz_s(jpack) = PF::calculate_dz(pseudo_density_mid(icol,jpack), p_mid(icol,jpack), T_mid(icol,jpack), qv_mid(icol,jpack));
     });
     team.team_barrier();
-    const auto& z_mid_s = ekat::subview(z_mid, icol);
     PF::calculate_z_int(team,num_levs,dz_s,surf_geopotential,z_int_s);
     PF::calculate_z_mid(team,num_levs,z_int_s,z_mid_s);
   });

--- a/components/scream/src/diagnostics/vertical_layer_midpoint.hpp
+++ b/components/scream/src/diagnostics/vertical_layer_midpoint.hpp
@@ -45,7 +45,6 @@ protected:
   Int m_num_levs;
 
   // Temporary view to set dz in compute diagnostic
-  view_2d m_dz;
   view_2d m_z_int;
 
 }; // class VerticalLayerMidpointDiagnostic

--- a/components/scream/src/diagnostics/vertical_layer_midpoint.hpp
+++ b/components/scream/src/diagnostics/vertical_layer_midpoint.hpp
@@ -19,7 +19,7 @@ public:
   using PF            = scream::PhysicsFunctions<DefaultDevice>;
   using KT            = KokkosTypes<DefaultDevice>;
   using MemberType    = typename KT::MemberType;
-  using view_1d       = typename KT::template view_1d<Pack>;
+  using view_2d       = typename KT::template view_2d<Pack>;
 
   // Constructors
   VerticalLayerMidpointDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
@@ -43,6 +43,10 @@ protected:
   // Keep track of field dimensions
   Int m_num_cols;
   Int m_num_levs;
+
+  // Temporary view to set dz in compute diagnostic
+  view_2d m_dz;
+  view_2d m_z_int;
 
 }; // class VerticalLayerMidpointDiagnostic
 


### PR DESCRIPTION
There are three diagnostics that failed when run in a typical AD case on a GPU machine.  These three diagnostics;
 - DryStaticEnergy
 - VerticalLayerInterface
 - VerticalLayerMidpoint all shared one thing in common, under-the-hood they used a Kokkos parallel scan.  The way the Kokkos policy was set up didn't guarantee a team size of a power of 2 which caused fails in certain cases.  This commit solves that by using the appropriate team policy setup.

This commit also solves a separate bug which was discovered where temporary variables were not being handled properly in the diagnostics which could lead to non-BFB behavior.

Solves #2015 

[BFB] - in general, does solve a potential race condition.