### PR TITLE
Fixes to get SHOC's small kernels option working reliably.

### DIFF
--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -181,6 +181,9 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
     &m_buffer.z_mid, &m_buffer.rrho, &m_buffer.thv, &m_buffer.dz, &m_buffer.zt_grid, &m_buffer.wm_zt,
     &m_buffer.inv_exner, &m_buffer.thlm, &m_buffer.qw, &m_buffer.dse, &m_buffer.tke_copy, &m_buffer.qc_copy,
     &m_buffer.shoc_ql2, &m_buffer.shoc_mix, &m_buffer.isotropy, &m_buffer.w_sec, &m_buffer.wqls_sec, &m_buffer.brunt
+#ifdef SCREAM_SMALL_KERNELS
+    , &m_buffer.rho_zt, &m_buffer.shoc_qv, &m_buffer.dz_zt, &m_buffer.tkh
+#endif
   };
 
   spack_2d_view_t* _2d_spack_int_view_ptrs[Buffer::num_2d_vector_int] = {
@@ -188,7 +191,7 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
     &m_buffer.qwthl_sec, &m_buffer.wthl_sec, &m_buffer.wqw_sec, &m_buffer.wtke_sec, &m_buffer.uw_sec,
     &m_buffer.vw_sec, &m_buffer.w3
 #ifdef SCREAM_SMALL_KERNELS
-    , &m_buffer.rho_zt, &m_buffer.shoc_qv, &m_buffer.dz_zt, &m_buffer.dz_zi, &m_buffer.tkh
+    , &m_buffer.dz_zi
 #endif
   };
 

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -443,11 +443,12 @@ public:
     static constexpr int num_1d_scalar_ncol = 18;
 #endif
     static constexpr int num_1d_scalar_nlev = 1;
-    static constexpr int num_2d_vector_mid  = 18;
 #ifndef SCREAM_SMALL_KERNELS
+    static constexpr int num_2d_vector_mid  = 18;
     static constexpr int num_2d_vector_int  = 12;
 #else
-    static constexpr int num_2d_vector_int  = 17;
+    static constexpr int num_2d_vector_mid  = 22;
+    static constexpr int num_2d_vector_int  = 13;
 #endif
     static constexpr int num_2d_vector_tr   = 1;
 

--- a/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_compute_diag_third_shoc_moment_impl.hpp
@@ -37,7 +37,7 @@ void Functions<S,D>
   const auto s_tke = scalarize(tke);
   const auto s_w3 = scalarize(w3);
 
-  const Int max_safe_shift1_idx = s_wthl_sec.extent(0) - 2;
+  const Int max_safe_shift1_idx = nlevi - 2;
 
   // Set lower condition: w3(i,nlevi) = 0
   s_w3(nlevi-1) = 0;
@@ -76,9 +76,9 @@ void Functions<S,D>
     ekat::index_and_shift<-1>(s_w_sec, range_pack_m1, w_sec_k, w_sec_km1);
     ekat::index_and_shift<-1>(s_tke, range_pack_m1, tke_k, tke_km1);
 
-    // Compute inputs for computing f0 to f5 terms
     const auto active_range = range_pack > 0 && range_pack < nlev;
     if (active_range.any()) {
+      // Compute inputs for computing f0 to f5 terms
       const auto thedz  = 1/dz_zi(k);
       const auto thedz2 = 1/(dz_zt_k+dz_zt_km1);
 

--- a/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_diag_third_shoc_moments_impl.hpp
@@ -48,7 +48,7 @@ void Functions<S,D>::diag_third_shoc_moments(
   linear_interp(team,zt_grid,zi_grid,thetal,thetal_zi,nlev,nlevi,0);
   team.team_barrier();
 
-  //Diagnose the third moment of the vertical-velocity
+  // Diagnose the third moment of the vertical-velocity
   compute_diag_third_shoc_moment(team,nlev,nlevi,w_sec,thl_sec,wthl_sec,
                                  tke, dz_zt, dz_zi,isotropy_zi, brunt_zi,
                                  w_sec_zi,thetal_zi,w3);

--- a/components/scream/src/physics/shoc/shoc_energy_fixer_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_energy_fixer_impl.hpp
@@ -68,12 +68,13 @@ void Functions<S,D>::shoc_energy_fixer(
   // Compute the total energy before and after SHOC call
   const Scalar shf = wthl_sfc*cp*s_rho_zi(nlevi-1);
   const Scalar lhf = wqw_sfc*s_rho_zi(nlevi-1);
-  te_a = se_a + ke_a + (lcond+lice)*wv_a +lice*wl_a;
+  te_a = se_a + ke_a + (lcond+lice)*wv_a + lice*wl_a;
   te_b = se_b + ke_b + (lcond+lice)*wv_b + lice*wl_b;
   te_b += (shf+lhf*(lcond+lice))*hdtime;
 
   // Limit the energy fixer to find highest layer where SHOC is active.
   // Find first level where tke is higher than lowest threshold.
+  static_assert(Spack::n == IntSmallPack::n, "SHOC: assumption in ||r.");
   Int shoctop = 0;
   const auto nlevm2_packs = ekat::npack<Spack>(nlev-2);
   Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, nlevm2_packs),

--- a/components/scream/src/physics/shoc/shoc_grid_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_grid_impl.hpp
@@ -57,13 +57,14 @@ void Functions<S,D>::shoc_grid(
 
     // Define thickness of the interface grid points
     dz_zi(k) = zt_grid_km1 - zt_grid_k;
-    dz_zi(k).set(range_pack == 0, 0);
 
     // Define the air density on the thermo grid
     rho_zt(k) = (1/ggr)*(pdel(k)/dz_zt(k));
   });
 
+  team.team_barrier();
   // Set lower condition for dz_zi
+  s_dz_zi(0) = 0;
   s_dz_zi(nlevi-1) = s_zt_grid(nlev-1);
 }
 

--- a/components/scream/src/physics/shoc/shoc_main_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_main_impl.hpp
@@ -366,8 +366,6 @@ void Functions<S,D>::shoc_main_internal(
   const view_2d<Spack>& dz_zi,
   const view_2d<Spack>& tkh)
 {
-  workspace_mgr.reset_internals();
-
   // Scalarize some views for single entry access
   const auto s_thetal  = ekat::scalarize(thetal);
   const auto s_shoc_ql = ekat::scalarize(shoc_ql);

--- a/components/scream/src/physics/shoc/shoc_pblintd_cldcheck_impl.hpp
+++ b/components/scream/src/physics/shoc/shoc_pblintd_cldcheck_impl.hpp
@@ -27,9 +27,7 @@ void Functions<S,D>
     // higher than top interface of lowest level
     //
 
-    auto cldcheck = false;
-    if (cldn >= 0) cldcheck = true;
-    if (cldcheck) pblh = ekat::impl::max<Scalar>(pblh, zi + sp(50));
+    if (cldn >= 0) pblh = ekat::impl::max<Scalar>(pblh, zi + sp(50));
 }
 } // namespace shoc
 } // namespace scream

--- a/components/scream/src/physics/shoc/shoc_pblintd_disp.cpp
+++ b/components/scream/src/physics/shoc/shoc_pblintd_disp.cpp
@@ -35,6 +35,7 @@ void Functions<Real,DefaultDevice>
 
     auto workspace       = workspace_mgr.get_workspace(team);
 
+    Scalar pblh_;
     pblintd(team, nlev, nlevi, npbl,
             ekat::subview(z, i),
             ekat::subview(zi, i),
@@ -48,7 +49,8 @@ void Functions<Real,DefaultDevice>
             kbfs(i),
             ekat::subview(cldn, i),
             workspace,
-            pblh(i));
+            pblh_);
+    pblh(i) = pblh_;
   });
 }
 


### PR DESCRIPTION
1. Fix treatment of pblh in shoc_pblintd_disp/impl.
2. kbfs was fixed in 2017 but was part of fixing 1992.
3. Update EKAT with the memory_fence fixes to the workspace acquisition/release process.
4. Improve nlev vs nlevi distinction in SK variables.
5. Improve some miscellaneous little things I noticed.

Fixes https://github.com/E3SM-Project/scream/issues/1992.