### PR TITLE
For NERSC CPU machines (and GCP), use serial kokkos backend when no threads in CIME case

### DIFF
--- a/components/scream/cmake/machine-files/alvarez.cmake
+++ b/components/scream/cmake/machine-files/alvarez.cmake
@@ -2,9 +2,17 @@
 set (EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/cmake/machine-files)
 
 #message(STATUS "alvarez PROJECT_NAME=${PROJECT_NAME} USE_CUDA=${USE_CUDA} KOKKOS_ENABLE_CUDA=${KOKKOS_ENABLE_CUDA}")
+
 include (${EKAT_MACH_FILES_PATH}/kokkos/amd-zen3.cmake)
-include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
-#include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
+if ("${PROJECT_NAME}" STREQUAL "E3SM")
+  if (SMP_PRESENT)
+    include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+  else()
+    include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
+  endif()
+else()
+  include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+endif()
 
 set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
 

--- a/components/scream/cmake/machine-files/cori-knl.cmake
+++ b/components/scream/cmake/machine-files/cori-knl.cmake
@@ -2,12 +2,21 @@ set (EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/c
 
 # Load knl arch and openmp backend for kokkos
 include (${EKAT_MACH_FILES_PATH}/kokkos/intel-knl.cmake)
-include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+
+if ("${PROJECT_NAME}" STREQUAL "E3SM")
+  if (SMP_PRESENT)
+    include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+  else()
+    include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
+  endif()
+else()
+  include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+endif()
 
 if ("${PROJECT_NAME}" STREQUAL "E3SM")
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
-       set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch"  CACHE STRING "" FORCE) # only works with gnu v10 and above
+      set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch"  CACHE STRING "" FORCE) # only works with gnu v10 and above
     endif()
   endif()
 else()

--- a/components/scream/cmake/machine-files/gcp.cmake
+++ b/components/scream/cmake/machine-files/gcp.cmake
@@ -3,8 +3,16 @@ set (EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/c
 
 #message(STATUS "gcp PROJECT_NAME=${PROJECT_NAME} USE_CUDA=${USE_CUDA} KOKKOS_ENABLE_CUDA=${KOKKOS_ENABLE_CUDA}")
 # use default backend?
-include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
-#include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
+
+if ("${PROJECT_NAME}" STREQUAL "E3SM")
+  if (SMP_PRESENT)
+    include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+  else()
+    include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
+  endif()
+else()
+  include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+endif()
 
 set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
 

--- a/components/scream/cmake/machine-files/pm-cpu.cmake
+++ b/components/scream/cmake/machine-files/pm-cpu.cmake
@@ -2,9 +2,20 @@
 set (EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/cmake/machine-files)
 
 #message(STATUS "pm-cpu PROJECT_NAME=${PROJECT_NAME} USE_CUDA=${USE_CUDA} KOKKOS_ENABLE_CUDA=${KOKKOS_ENABLE_CUDA}")
+#message(STATUS, "pm-cpu SMP_PRESENT=${SMP_PRESENT}")
+
 include (${EKAT_MACH_FILES_PATH}/kokkos/amd-zen3.cmake)
-include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
-#include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
+if ("${PROJECT_NAME}" STREQUAL "E3SM")
+  if (SMP_PRESENT)
+    include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+    #message(STATUS, "pm-cpu openmp SMP_PRESENT=${SMP_PRESENT}")
+  else()
+    include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
+    #message(STATUS, "pm-cpu serial SMP_PRESENT=${SMP_PRESENT}")
+  endif()
+else()
+  include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+endif()
 
 set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
 


### PR DESCRIPTION
For NERSC CPU machines (and GCP), use the serial kokkos backend when the CIME build is NOT SMP (ie no threading).

Fixes https://github.com/E3SM-Project/scream/issues/1997

[bfb]