### PR TITLE
Fix memcheck fails from new diagnostic

### DIFF
--- a/components/scream/src/diagnostics/precip_ice_surf_mass_flux.cpp
+++ b/components/scream/src/diagnostics/precip_ice_surf_mass_flux.cpp
@@ -38,11 +38,12 @@ void PrecipIceSurfMassFluxDiagnostic::compute_diagnostic_impl()
 {
   const auto& precip_ice_surf_mass      = get_field_in("precip_ice_surf_mass").get_view<const Real*>();
   const auto& precip_ice_surf_mass_flux = m_diagnostic_output.get_view<Real*>();
+  const auto dt = m_dt;
 
   Kokkos::parallel_for("PrecipIceMassFluxDiagnostic",
                        KT::RangePolicy(0,m_num_cols),
                        KOKKOS_LAMBDA(const Int& icol) {
-    precip_ice_surf_mass_flux(icol) = precip_ice_surf_mass(icol)/PC::RHO_H2O/m_dt;
+    precip_ice_surf_mass_flux(icol) = precip_ice_surf_mass(icol)/PC::RHO_H2O/dt;
   });
 }
 // =========================================================================================

--- a/components/scream/src/diagnostics/precip_liq_surf_mass_flux.cpp
+++ b/components/scream/src/diagnostics/precip_liq_surf_mass_flux.cpp
@@ -38,11 +38,12 @@ void PrecipLiqSurfMassFluxDiagnostic::compute_diagnostic_impl()
 {
   const auto& precip_liq_surf_mass      = get_field_in("precip_liq_surf_mass").get_view<const Real*>();
   const auto& precip_liq_surf_mass_flux = m_diagnostic_output.get_view<Real*>();
-
+  const auto dt = m_dt;
+  
   Kokkos::parallel_for("PrecipLiqMassFluxDiagnostic",
                        KT::RangePolicy(0,m_num_cols),
                        KOKKOS_LAMBDA(const Int& icol) {
-    precip_liq_surf_mass_flux(icol) = precip_liq_surf_mass(icol)/PC::RHO_H2O/m_dt;
+    precip_liq_surf_mass_flux(icol) = precip_liq_surf_mass(icol)/PC::RHO_H2O/dt;
   });
 }
 // =========================================================================================


### PR DESCRIPTION
Fixes memcheck fails from https://github.com/E3SM-Project/scream/pull/2037. Tested manually on weaver.