### PR TITLE
Remove RMA dependency from coarsening remapper

### DIFF
--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -338,7 +338,7 @@ get_owners (const hview_1d<const gid_type>& gids) const
       }
     }
   }
-  EKAT_REQUIRE_MSG (num_found==num_gids_in,
+  EKAT_REQUIRE_MSG (num_found==owners.size(),
       "Error! Could not locate the owner of one of the input GIDs.\n"
       "  - rank: " + std::to_string(comm.rank()) + "\n"
       "  - num found: " + std::to_string(num_found) + "\n"
@@ -346,7 +346,7 @@ get_owners (const hview_1d<const gid_type>& gids) const
 
 
   // Now create and fill output view
-  hview_1d<int> result("",num_found);
+  hview_1d<int> result("",num_gids_in);
   for (int i=0; i<num_gids_in; ++i) {
     result[i] = owners.at(gids[i]);
   }

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -295,154 +295,59 @@ get_owners (const hview_1d<const gid_type>& gids) const
 {
   EKAT_REQUIRE_MSG (m_dofs_set,
       "Error! Cannot retrieve gids owners until dofs gids have been set.\n");
-  // In order to ship information around across ranks, it is easier to use
-  // an auxiliary grid, where dofs are partitioned across ranks linearly
-  // NOTE: we actually don't need the grid itself. We only need to know
-  //       what the local number of dofs would be on this rank.
-  const int ngdofs = get_num_global_dofs();
+
   const auto& comm = get_comm();
-  int nldofs_linear = ngdofs / comm.size();
-  if (comm.rank()<(ngdofs % comm.size())) {
-    ++ nldofs_linear;
-  }
 
-  // For each pid, compute offsets in the global gids array.
-  std::vector<int> offsets(comm.size()+1,0);
-  const int ndofs_per_rank = ngdofs / comm.size();
-  const int remainder = ngdofs % comm.size();
-  for (int pid=1; pid<=comm.size(); ++pid) {
-    offsets[pid] = offsets[pid-1] + ndofs_per_rank;
-    if ( (pid-1)<remainder ){
-      ++offsets[pid];
+  // Init owners to in
+  std::map<gid_type,int> owners;
+  int num_gids_in = gids.size();
+  for (int i=0; i<num_gids_in; ++i) {
+    owners[gids[i]] = -1;
+  }
+  int num_found = 0;
+
+  // Let each rank bcast its owned gids, so that other procs can
+  // check against their input list
+  auto my_gids_h = m_dofs_gids_host;
+  gid_type* data;
+  std::vector<gid_type> pid_gids;
+  for (int pid=0; pid<comm.size(); ++pid) {
+    // Bcast gids count for this pid
+    int num_gids_pid = my_gids_h.size();
+    comm.broadcast(&num_gids_pid,1,pid);
+
+    // Bcast gids
+    if (pid==comm.rank()) {
+      data = my_gids_h.data();
+    } else {
+      pid_gids.resize(num_gids_pid);
+      data = pid_gids.data();
+    }
+    comm.broadcast(data,num_gids_pid,pid);
+
+    // Checks if any of the input pids is in this list
+    for (int i=0; i<num_gids_pid && num_found<num_gids_in; ++i) {
+      auto it = owners.find(data[i]);
+      if (it!=owners.end()) {
+        EKAT_REQUIRE_MSG (it->second==-1,
+            "Error! Found a GID with multiple owners.\n"
+            "  - owner 1: " + std::to_string(it->second) + "\n"
+            "  - owner 2: " + std::to_string(pid) + "\n");
+        it->second = pid;
+        ++num_found;
+      }
     }
   }
-  EKAT_REQUIRE_MSG (offsets.back()==ngdofs,
-      "Error! Something went wrong while calling get_gids_owners.\n"
-      "  - grid name: " + this->name() + "\n");
+  EKAT_REQUIRE_MSG (num_found==num_gids_in,
+      "Error! Could not locate the owner of one of the input GIDs.\n");
 
-  // Utility lambda: given a GID, retrieve the PID that would own it in a
-  // linearly distributed grid, as well as the corresponding LID it would
-  // have in that grid on that rank. This is doable without any communication
-  // since the gids are partitioned linearly
-  auto pid_and_lid = [&] (const gid_type gid) -> std::pair<int,int> {
-    auto it = std::upper_bound (offsets.begin(),offsets.end(),gid);
-    int pid = std::distance(offsets.begin(),it) - 1;
-    int lid = gid - offsets[pid];
-    EKAT_REQUIRE_MSG (pid>=0 && pid<comm.size(),
-        "Error! Failed to retrieve owner of GID in the linear grid.\n");
-    return std::make_pair(pid,lid);
-  };
-
-  // The idea is to create a "global" array (partitioned across ranks) of the
-  // gids in the linear map, use it to store the owner of each dofs (in the original grid),
-  // and finally read that global array for all the input gids.
-  struct PidLid {
-    int pid;
-    int lid;
-  };
-  std::map<int,std::vector<PidLid>> rma_data;
-  std::map<int,std::vector<int>> rma_offsets;
-  std::map<int,MPI_Datatype> rma_dtypes;
-
-  auto clear_dtypes = [&] () {
-    for (auto& it : rma_dtypes) {
-      MPI_Type_free(&it.second);
-    }
-    rma_dtypes.clear();
-  };
-
-  MPI_Win win;
-  PidLid* pids_lids_linear;
-  MPI_Win_allocate (nldofs_linear*sizeof(MPI_2INT),sizeof(MPI_2INT),
-                    MPI_INFO_NULL,comm.mpi_comm(),&pids_lids_linear,&win);
-  MPI_Win_fence(0,win);
-
-  // Step 1: each rank loops through its grid gids, and sets owners_linear=rank
-  // for all its gids in the grid.
-  MPI_Win_fence(0,win);
-
-  //  - 1.a Figure where each local dof specs will be written in the linearly
-  //        distributed global array
-  for (int i=0; i<get_num_local_dofs(); ++i) {
-    const auto gid = m_dofs_gids_host[i];
-    const auto pidlid = pid_and_lid (gid);
-    const auto pid = pidlid.first;
-    const auto lid = pidlid.second;
-    rma_data[pid].push_back({comm.rank(),i});
-    rma_offsets[pid].push_back(lid);
+  // Now create and fill output view
+  hview_1d<int> result("",num_found);
+  for (int i=0; i<num_gids_in; ++i) {
+    result[i] = owners.at(gids[i]);
   }
 
-  //  - 1.b: build data types for writing all the data on each tgt rank at once
-  for (const auto& it : rma_offsets) {
-    auto& dtype = rma_dtypes[it.first];
-    std::vector<int> ones(it.second.size(),1);
-    MPI_Type_indexed (it.second.size(),ones.data(),it.second.data(),MPI_2INT,&dtype);
-    MPI_Type_commit (&dtype);
-  }
-
-  //  - 1.c: write on the window
-  for (const auto& it : rma_data) {
-    const auto pid = it.first;
-    const auto dtype = rma_dtypes.at(pid);
-    // Note: the dtype already encodes offsets in the remote window, so tgt_disp=0
-    MPI_Put (it.second.data(),it.second.size(),MPI_2INT,pid,
-             0,1,dtype,win);
-  }
-  clear_dtypes();
-  rma_data.clear();
-  rma_offsets.clear();
-  MPI_Win_fence(0,win);
-
-  // Step 2: each rank loops over its input gids, and retrieves the owner from the window
-
-  //  - 1.a: Figure out what needs to be read from each rank
-  for (int i=0; i<gids.extent_int(0); ++i) {
-    const auto gid = gids[i];
-    const auto pidlid = pid_and_lid (gid);
-    const auto pid = pidlid.first;
-    const auto lid = pidlid.second;
-    rma_offsets[pid].push_back(lid);
-    rma_data[pid].push_back({-1,-1});
-  }
-
-  //  - 1.b: build data types for reading all the data from each tgt rank at once
-  for (const auto& it : rma_offsets) {
-    auto& dtype = rma_dtypes[it.first];
-    std::vector<int> ones(it.second.size(),1);
-    MPI_Type_indexed (it.second.size(),ones.data(),it.second.data(),MPI_2INT,&dtype);
-    MPI_Type_commit (&dtype);
-  }
-
-  //  - 1.c: read from the window
-  for (auto& it : rma_data) {
-    const auto pid = it.first;
-    const auto dtype = rma_dtypes.at(pid);
-    // Note: the dtype already encodes offsets in the remote window, so tgt_disp=0
-    MPI_Get (it.second.data(),it.second.size(),MPI_2INT,pid,
-             0,1,dtype,win);
-  }
-  clear_dtypes();
-  rma_offsets.clear();
-  MPI_Win_fence(0,win);
-
-  // Step 3: copy data in rma types into output view, making sure we keep correct order
-  hview_1d<int> owners("",gids.size());
-  std::map<int,int> curr_data_index;
-  for (int i=0; i<gids.extent_int(0); ++i) {
-    const auto gid = gids[i];
-    const auto pidlid = pid_and_lid (gid);
-    const auto pid = pidlid.first;
-    auto it_bool = curr_data_index.emplace(pid,0);
-    auto& idx = it_bool.first->second;
-    owners(i) = rma_data[pid][idx].pid;
-    ++idx;
-  }
-  rma_data.clear();
-
-  // Clean up
-  MPI_Win_free(&win);
-
-  return owners;
+  return result;
 }
 
 void AbstractGrid::copy_views (const AbstractGrid& src, const bool shallow)

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -339,7 +339,11 @@ get_owners (const hview_1d<const gid_type>& gids) const
     }
   }
   EKAT_REQUIRE_MSG (num_found==num_gids_in,
-      "Error! Could not locate the owner of one of the input GIDs.\n");
+      "Error! Could not locate the owner of one of the input GIDs.\n"
+      "  - rank: " + std::to_string(comm.rank()) + "\n"
+      "  - num found: " + std::to_string(num_found) + "\n"
+      "  - num gids in: " + std::to_string(num_gids_in) + "\n");
+
 
   // Now create and fill output view
   hview_1d<int> result("",num_found);

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -118,6 +118,9 @@ set_dofs (const dofs_list_type& dofs)
 
   m_dofs_gids_host = Kokkos::create_mirror_view(m_dofs_gids);
   Kokkos::deep_copy(m_dofs_gids_host,m_dofs_gids);
+
+  set_global_min_dof_gid();
+  set_global_max_dof_gid();
 }
 
 const AbstractGrid::dofs_list_type&
@@ -186,8 +189,8 @@ AbstractGrid::get_geometry_data_host (const std::string& name) const {
   return m_geo_views_host.at(name);
 }
 
-AbstractGrid::gid_type
-AbstractGrid::get_global_min_dof_gid () const
+void
+AbstractGrid::set_global_min_dof_gid ()
 {
   EKAT_REQUIRE_MSG (m_dofs_set,
       "Error! You need to set dofs gids before you can compute the global min dof.\n");
@@ -205,11 +208,11 @@ AbstractGrid::get_global_min_dof_gid () const
 
   m_comm.all_reduce(&local_min,&global_min,1,MPI_MIN);
 
-  return global_min;
+  m_global_min_dof_gid = global_min;
 }
 
-AbstractGrid::gid_type
-AbstractGrid::get_global_max_dof_gid () const
+void
+AbstractGrid::set_global_max_dof_gid ()
 {
   EKAT_REQUIRE_MSG (m_dofs_set,
       "Error! You need to set dofs gids before you can compute the global max dof.\n");
@@ -227,7 +230,7 @@ AbstractGrid::get_global_max_dof_gid () const
 
   m_comm.all_reduce(&local_max,&global_max,1,MPI_MAX);
 
-  return global_max;
+  m_global_max_dof_gid = global_max;
 }
 
 std::list<std::string>

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -104,13 +104,15 @@ public:
   // The number of dofs on this MPI rank
   int get_num_local_dofs  () const { return m_num_local_dofs;  }
   gid_type get_num_global_dofs () const { return m_num_global_dofs; }
-  gid_type get_global_min_dof_gid () const;
-  gid_type get_global_max_dof_gid () const;
+  gid_type get_global_min_dof_gid () const { return m_global_min_dof_gid; }
+  gid_type get_global_max_dof_gid () const { return m_global_max_dof_gid; }
 
   // Set the dofs list
   // NOTE: this method calls valid_dofs_list, which may contain collective
   //       operations over the stored communicator.
   void set_dofs (const dofs_list_type& dofs);
+  void set_global_min_dof_gid ();
+  void set_global_max_dof_gid ();
 
   // Get a 1d view containing the dof gids
   const dofs_list_type& get_dofs_gids () const;
@@ -192,6 +194,8 @@ private:
   // The global ID of each dof
   dofs_list_type        m_dofs_gids;
   dofs_list_h_type      m_dofs_gids_host;
+  gid_type              m_global_min_dof_gid;
+  gid_type              m_global_max_dof_gid;
 
   // The map lid->idx
   lid_to_idx_map_type   m_lid_to_idx;

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -68,6 +68,20 @@ CoarseningRemapper (const grid_ptr_type& src_grid,
   scorpio::grid_read_data_array(map_file,"S",  -1,S_h.data(),       nlweights);
   scorpio::eam_pio_closefile(map_file);
 
+  // Offset the cols ids to match the source grid.
+  // Determine the min id among the cols array, we
+  // also add the min_dof for the grid.
+  int remap_min_dof = col_gids_h[0];
+  for (int id=1; id<nlweights; id++) {
+    remap_min_dof = std::min(col_gids_h[id],remap_min_dof);
+  }
+  int global_remap_min_dof;
+  m_comm.all_reduce(&remap_min_dof,&global_remap_min_dof,1,MPI_MIN);
+
+  for (int ii=0; ii<nlweights; ii++) {
+    col_gids_h(ii) = col_gids_h(ii) - global_remap_min_dof + src_grid->get_global_min_dof_gid();
+  }
+
   // Create an "overlapped" tgt grid, that is, a grid where each rank
   // owns all tgt rows that are affected by at least one of the cols
   // in its src_grid
@@ -110,7 +124,7 @@ CoarseningRemapper (const grid_ptr_type& src_grid,
   auto weights_h     = Kokkos::create_mirror_view(m_weights);
 
   for (int i=0; i<nlweights; ++i) {
-    col_lids_h(i) = gid2lid(col_gids_h(id[i])-1,src_grid);
+    col_lids_h(i) = gid2lid(col_gids_h(id[i]),src_grid);
     weights_h(i)  = S_h(id[i]);
   }
 
@@ -158,7 +172,7 @@ create_src_layout (const FieldLayout& tgt_layout) const
   const auto lt = get_layout_type(tgt_layout.tags());
   auto src = FieldLayout::invalid();
   const bool midpoints = tgt_layout.has_tag(LEV);
-  const int vec_dim = tgt_layout.is_vector_layout() ? tgt_layout.get_vector_dim() : -1;
+  const int vec_dim = tgt_layout.is_vector_layout() ? tgt_layout.dim(CMP) : -1;
   switch (lt) {
     case LayoutType::Scalar2D:
       src = m_src_grid->get_2d_scalar_layout();
@@ -184,7 +198,7 @@ create_tgt_layout (const FieldLayout& src_layout) const
   const auto lt = get_layout_type(src_layout.tags());
   auto tgt = FieldLayout::invalid();
   const bool midpoints = src_layout.has_tag(LEV);
-  const int vec_dim = src_layout.is_vector_layout() ? src_layout.get_vector_dim() : -1;
+  const int vec_dim = src_layout.is_vector_layout() ? src_layout.dim(CMP) : -1;
   switch (lt) {
     case LayoutType::Scalar2D:
       tgt = m_tgt_grid->get_2d_scalar_layout();
@@ -259,6 +273,8 @@ void CoarseningRemapper::do_remap_fwd ()
     // x is the src field, and y is the overlapped tgt field.
     const auto& f_src    = m_src_fields[i];
     const auto& f_ov_tgt = m_ov_tgt_fields[i];
+    const auto& src_layout = f_src.get_header().get_identifier().get_layout();
+    const auto& tgt_layout = f_ov_tgt.get_header().get_identifier().get_layout();
 
     // Dispatch kernel with the largest possible pack size
     const auto& src_ap = f_src.get_header().get_alloc_properties();
@@ -304,8 +320,10 @@ local_mat_vec (const Field& x, const Field& y) const
   using PackInfo    = ekat::PackInfo<PackSize>;
 
   const auto& src_layout = x.get_header().get_identifier().get_layout();
+  const auto& tgt_layout = y.get_header().get_identifier().get_layout();
   const int rank = src_layout.rank();
   const int nrows = m_ov_tgt_grid->get_num_local_dofs();
+  const int nrows_src = m_src_grid->get_num_local_dofs();
   auto row_offsets = m_row_offsets;
   auto col_lids = m_col_lids;
   auto weights = m_weights;
@@ -645,8 +663,19 @@ get_my_triplets_gids (const std::string& map_file,
   scorpio::set_decomp(map_file);
   scorpio::grid_read_data_array(map_file,"col",-1,cols.data(),cols.size());
   scorpio::eam_pio_closefile(map_file);
+
+  // Offset the cols ids to match the source grid.
+  // Determine the min id among the cols array, we
+  // also add the min_dof for the grid.
+  int remap_min_dof = cols[0];
+  for (int id=1; id<nlweights; id++) {
+    remap_min_dof = std::min(cols[id],remap_min_dof);
+  }
+  int global_remap_min_dof;
+  m_comm.all_reduce(&remap_min_dof,&global_remap_min_dof,1,MPI_MIN);
+
   for (auto& id : cols) {
-    --id; // Subtract 1 to get 0-based indices
+    id = id - global_remap_min_dof + src_grid->get_global_min_dof_gid(); 
   }
 
   // 3. Get the owners of the cols gids we read in, according to the src grid

--- a/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
@@ -209,12 +209,13 @@ TEST_CASE("coarsening_remap_nnz>nsrc") {
   //      Build src grid and remapper       //
   // -------------------------------------- //
 
-  print (" -> creating grid and remapper ...\n",comm);
-
+  print (" -> creating grid ...\n",comm);
   auto src_grid = build_src_grid(comm, nldofs_src);
+  print (" -> creating grid ... done\n",comm);
 
+  print (" -> creating remapper ...\n",comm);
   auto remap = std::make_shared<CoarseningRemapperTester>(src_grid,filename);
-  print (" -> creating grid and remapper ... done!\n",comm);
+  print (" -> creating remapper ... done!\n",comm);
 
   // -------------------------------------- //
   //      Create src/tgt grid fields        //


### PR DESCRIPTION
This commit fixes a number of issues with the implementation of the coarsening remapper
that were discovered after more extensive testing.  In particular, a few of the machines that
support scream don't support RMA operations in MPI.  The main body of this commit is to
revert the use of RMA to more basic MPI functions.

Over the course of developing this commit a handful of bugs were also discovered which have
been fixed.  In particular, the treatment of global id's in both the remap triplets and the source/
target grid.

This commit will allow us to develop the regionally refined output capability which will be in a
subsequent PR.