### PR TITLE
Crusher-GPU: Build CICE with -O0.

### DIFF
--- a/cime_config/machines/Depends.crusher-gpu.crayclang.cmake
+++ b/cime_config/machines/Depends.crusher-gpu.crayclang.cmake
@@ -1,0 +1,43 @@
+set(CICE_F90
+  ice_FY.F90
+  ice_aerosol.F90
+  ice_age.F90
+  ice_atmo.F90
+  ice_blocks.F90
+  ice_calendar.F90
+  ice_diagnostics.F90
+  ice_distribution.F90
+  ice_domain.F90
+  ice_domain_size.F90
+  ice_dyn_evp.F90
+  ice_fileunits.F90
+  ice_flux.F90
+  ice_forcing.F90
+  ice_grid.F90
+  ice_history.F90
+  ice_history_fields.F90
+  ice_init.F90
+  ice_itd.F90
+  ice_kinds_mod.F90
+  ice_lvl.F90
+  ice_mechred.F90
+  ice_meltpond.F90
+  ice_ocean.F90
+  ice_orbital.F90
+  ice_probability.F90
+  ice_probability_tools.F90
+  ice_read_write.F90
+  ice_restoring.F90
+  ice_shortwave.F90
+  ice_spacecurve.F90
+  ice_state.F90
+  ice_step_mod.F90
+  ice_therm_itd.F90
+  ice_therm_vertical.F90
+  ice_transport_driver.F90
+  ice_transport_remap.F90
+  ice_work.F90)
+
+foreach(ITEM IN LISTS CICE_F90)
+  e3sm_add_flags("cice/src/source/${ITEM}" "-O0")
+endforeach()


### PR DESCRIPTION
This fixes a source of nondeterminism on Crusher-GPU.

Fixes #2047.