### PR TITLE
Lower the T_mid minimum cutoff to 100 from 130

### DIFF
--- a/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/scream/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -449,7 +449,7 @@ void HommeDynamics::initialize_impl (const RunType run_type)
   using LowerBound = FieldLowerBoundCheck;
 
   add_postcondition_check<LowerBound>(*get_group_out("Q",pgn).m_bundle,m_phys_grid,0,true);
-  add_postcondition_check<Interval>(get_field_out("T_mid",pgn),m_phys_grid,130.0, 500.0,false);
+  add_postcondition_check<Interval>(get_field_out("T_mid",pgn),m_phys_grid,100.0, 500.0,false);
   add_postcondition_check<Interval>(get_field_out("horiz_winds",pgn),m_phys_grid,-400.0, 400.0,false);
   add_postcondition_check<Interval>(get_field_out("ps"),m_phys_grid,40000.0, 120000.0,false);
 

--- a/components/scream/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/scream/src/physics/p3/atmosphere_microphysics.cpp
@@ -199,7 +199,7 @@ void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
 void P3Microphysics::initialize_impl (const RunType /* run_type */)
 {
   // Set property checks for fields in this process
-  add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,130.0,500.0,false);
+  add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0,500.0,false);
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("qv"),m_grid,1e-13,0.2,true);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("qc"),m_grid,0.0,0.1,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("qi"),m_grid,0.0,0.1,false);

--- a/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/scream/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -363,7 +363,7 @@ void RRTMGPRadiation::initialize_impl(const RunType /* run_type */) {
   );
 
   // Set property checks for fields in this process
-  add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,130.0, 500.0,false);
+  add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0, 500.0,false);
 }
 
 // =========================================================================================

--- a/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/scream/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -403,7 +403,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   // Set field property checks for the fields in this process
   using Interval = FieldWithinIntervalCheck;
   using LowerBound = FieldLowerBoundCheck;
-  add_postcondition_check<Interval>(get_field_out("T_mid"),m_grid,130.0,500.0,false);
+  add_postcondition_check<Interval>(get_field_out("T_mid"),m_grid,100.0,500.0,false);
   add_postcondition_check<Interval>(get_field_out("qc"),m_grid,0.0,0.1,false);
   add_postcondition_check<Interval>(get_field_out("horiz_winds"),m_grid,-400.0,400.0,false);
   add_postcondition_check<LowerBound>(get_field_out("pbl_height"),m_grid,0);


### PR DESCRIPTION
Lower the T_mid minimum cutoff to 100 from 130
Allows cases to continue running if T is under 130 (but over 100)
[bfb]
