### PR TITLE
Crusher: Remove -hzero from crayclang line.

### DIFF
--- a/cime_config/machines/cmake_macros/crayclang_crusher-gpu.cmake
+++ b/cime_config/machines/cmake_macros/crayclang_crusher-gpu.cmake
@@ -23,8 +23,8 @@ string(APPEND FFLAGS " -hnoacc -I${MPICH_DIR}/include -L${MPICH_DIR}/lib -lmpi -
 
 #this resolves a crash in mct in docn init
 if (NOT DEBUG)
-string(APPEND CFLAGS " -O2 -hnoacc -hzero -hfp0 -hipa0")
-string(APPEND FFLAGS " -O2 -hnoacc -hzero -hfp0 -hipa0")
+string(APPEND CFLAGS " -O2 -hnoacc -hfp0 -hipa0")
+string(APPEND FFLAGS " -O2 -hnoacc -hfp0 -hipa0")
 endif()
 
 string(APPEND CPPDEFS " -DCPRCRAY")


### PR DESCRIPTION
-hzero 0-inits stack-allocated variables, including intent(out) arguments. E3SM conventionally does not 0-init stack variables, as we want code to properly init variables explicitly.

-hzero can be useful to find bugs, however. Upstream PR 5334 fixes a bug in ELM in which intent(out) args should be intent(inout).

In our production configuration, we don't want -hzero. Remove it here.