### PR TITLE
Crusher: Work around SCORPIO threading issue.

### DIFF
--- a/cime_config/machines/cmake_macros/crayclang.cmake
+++ b/cime_config/machines/cmake_macros/crayclang.cmake
@@ -1,4 +1,4 @@
-if (compile_threaded)
+if (compile_threaded AND NOT COMP_NAME STREQUAL pio2)
   string(APPEND CFLAGS " -h omp")
   string(APPEND FFLAGS " -h omp")
   string(APPEND LDFLAGS " -h omp")

--- a/cime_config/machines/cmake_macros/crayclang_crusher-gpu.cmake
+++ b/cime_config/machines/cmake_macros/crayclang_crusher-gpu.cmake
@@ -1,7 +1,9 @@
 if (compile_threaded)
-  string(APPEND CFLAGS " -fopenmp")
-  string(APPEND FFLAGS " -fopenmp")
-  string(APPEND CXXFLAGS " -fopenmp")
+  if (NOT COMP_NAME STREQUAL pio2)
+    string(APPEND CFLAGS " -fopenmp")
+    string(APPEND FFLAGS " -fopenmp")
+    string(APPEND CXXFLAGS " -fopenmp")
+  endif ()
   string(APPEND LDFLAGS " -fopenmp")
 endif()
 
@@ -23,8 +25,8 @@ string(APPEND FFLAGS " -hnoacc -I${MPICH_DIR}/include -L${MPICH_DIR}/lib -lmpi -
 
 #this resolves a crash in mct in docn init
 if (NOT DEBUG)
-string(APPEND CFLAGS " -O2 -hnoacc -hfp0 -hipa0")
-string(APPEND FFLAGS " -O2 -hnoacc -hfp0 -hipa0")
+  string(APPEND CFLAGS " -O2 -hnoacc -hfp0 -hipa0")
+  string(APPEND FFLAGS " -O2 -hnoacc -hfp0 -hipa0")
 endif()
 
 string(APPEND CPPDEFS " -DCPRCRAY")


### PR DESCRIPTION
SCORPIO needs only the link line; avoiding threading flags in the compile lines works around the SCORPIO bool and extern "C" issues.