### PR TITLE
Remove hard-coded disabling of prescribed aero perturbation

### DIFF
--- a/components/eam/src/chemistry/utils/prescribed_aero.F90
+++ b/components/eam/src/chemistry/utils/prescribed_aero.F90
@@ -481,11 +481,8 @@ end subroutine spec_c_to_a
     ! random sampling is off (randn=0) in single column model setting. 
     if (single_column) then
       randn = 0._r8
-   endif
+    endif
 
-   ! turn off random sampling for scream simulations
-   randn = 0._r8
-    
     do i = 1, aero_cnt
        !Species with '_a' are updated using random sampling.
        !Cloud borne species (ends with _c1,_c2, etc.) have to be skipped


### PR DESCRIPTION
Remove hard-coded disabling of prescribed aerosol perturbation that was added for SCREAMv0. This would cause an unintended DIFF in MMF tests when the scream repo is merged upstream to E3SM, and does not appear to actually be used by SCREAMv0 tests (tests appear to be BFB).

[B4B]