### PR TITLE
EAMxx: remove runtime parameter from phisics constants

### DIFF
--- a/components/eamxx/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/eamxx/src/physics/p3/atmosphere_microphysics.cpp
@@ -218,7 +218,8 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qi"),m_grid,0.0,5.0e3,false);
 
   // Initialize p3
-  p3::p3_init();
+  p3::p3_init(/* write_tables = */ false,
+              this->get_comm().am_i_root());
 
   // Initialize all of the structures that are passed to p3_main in run_impl.
   // Note: Some variables in the structures are not stored in the field manager.  For these

--- a/components/eamxx/src/physics/p3/p3_f90.cpp
+++ b/components/eamxx/src/physics/p3/p3_f90.cpp
@@ -9,7 +9,7 @@ using scream::Int;
 extern "C" {
   void micro_p3_utils_init_c(Real Cpair, Real Rair, Real RH2O, Real RHO_H2O,
                  Real MWH2O, Real MWdry, Real gravit, Real LatVap, Real LatIce,
-                 Real CpLiq, Real Tmelt, Real Pi, Int iulog, bool masterproc);
+                 Real CpLiq, Real Tmelt, Real Pi, bool masterproc);
   void p3_init_c(const char** lookup_file_dir, int* info, const bool& write_tables);
 }
 
@@ -92,17 +92,17 @@ FortranDataIterator::getfield (Int i) const {
   return fields_[i];
 }
 
-void micro_p3_utils_init () {
+void micro_p3_utils_init (const bool masterproc) {
   using c = scream::physics::Constants<Real>;
   micro_p3_utils_init_c(c::Cpair, c::Rair, c::RH2O, c::RHO_H2O,
                  c::MWH2O, c::MWdry, c::gravit, c::LatVap, c::LatIce,
-                 c::CpLiq, c::Tmelt, c::Pi, c::iulog, c::masterproc);
+                 c::CpLiq, c::Tmelt, c::Pi, masterproc);
 }
 
-void p3_init (const bool write_tables) {
+void p3_init (const bool write_tables, const bool masterproc) {
   static bool is_init = false;
   if (!is_init) {
-    micro_p3_utils_init();
+    micro_p3_utils_init(masterproc);
     static const char* dir = SCREAM_DATA_DIR "/tables";
     Int info;
     p3_init_c(&dir, &info, write_tables);

--- a/components/eamxx/src/physics/p3/p3_f90.hpp
+++ b/components/eamxx/src/physics/p3/p3_f90.hpp
@@ -61,7 +61,8 @@ private:
   void init(const FortranData::Ptr& d);
 };
 
-void p3_init(const bool write_tables = false);
+void p3_init(const bool write_tables = false,
+             const bool masterproc = false);
 
 // We will likely want to remove these checks in the future, as we're not tied
 // to the exact implementation or arithmetic in P3. For now, these checks are

--- a/components/eamxx/src/physics/p3/p3_iso_c.f90
+++ b/components/eamxx/src/physics/p3/p3_iso_c.f90
@@ -175,9 +175,10 @@ contains
 
   subroutine micro_p3_utils_init_c(Cpair, Rair, RH2O, RHO_H2O, &
                  MWH2O, MWdry, gravit, LatVap, LatIce,        &
-                 CpLiq, Tmelt, Pi, iulog_in, masterproc) bind(C)
+                 CpLiq, Tmelt, Pi, masterproc) bind(C)
 
     use micro_p3_utils, only: micro_p3_utils_init
+    use iso_fortran_env, only: OUTPUT_UNIT
     real(kind=c_real), value, intent(in) :: Cpair
     real(kind=c_real), value, intent(in) :: Rair
     real(kind=c_real), value, intent(in) :: RH2O
@@ -190,14 +191,10 @@ contains
     real(kind=c_real), value, intent(in) :: CpLiq
     real(kind=c_real), value, intent(in) :: Tmelt
     real(kind=c_real), value, intent(in) :: Pi
-    integer(kind=c_int), value, intent(in)   :: iulog_in
     logical(kind=c_bool), value, intent(in)  :: masterproc
 
-    integer :: iulog
-    iulog = iulog_in
-
     call micro_p3_utils_init(Cpair,Rair,RH2O,RHO_H2O,MWH2O,MWdry,gravit,LatVap,LatIce, &
-                   CpLiq,Tmelt,Pi,iulog,masterproc)
+                   CpLiq,Tmelt,Pi,OUTPUT_UNIT,masterproc)
   end subroutine micro_p3_utils_init_c
 
   subroutine p3_init_a_c(ice_table_vals_c, collect_table_vals_c) bind(C)

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -43,8 +43,6 @@ struct Constants
   static constexpr Scalar T_homogfrz    = Tmelt - 40;
   static constexpr Scalar T_rainfrz     = Tmelt - 4;
   static constexpr Scalar Pi            = 3.14159265358979323;
-  static constexpr long long int    iulog       = 98;
-  static constexpr bool   masterproc    = true;
   static constexpr Scalar RHOW          = RHO_H2O;
   static constexpr Scalar INV_RHOW      = 1.0/RHOW;
   static constexpr Scalar RHO_RIMEMIN   =  50.0;  //Min limit for rime density [kg m-3]


### PR DESCRIPTION
The iulog and masterproc entries should be determined based on runtime values. P3 was the only user of these entries, which were passed to micro p3 utils initialization. We replaced them with queries on the comm and stdout. I thought about using the atm log filename, but writing to a buffer from both C/C++ and Fortran is dangerous. Since the iulog in micro_p3 was only used for printing one line at init time, I thought it was ok to just write to screen.

This is not really important, but it was confusing (because wrong) to see runtime options as constexpr. Besides, it was also a quick fix.

Note: this issue was why we had the `fort.98` file in our run directory: we were always using iulog=98 for the write statements in micro_p3.