### PR TITLE
Print all in/out fields upon Fatal property check fail in AtmosphereProcess

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -101,8 +101,8 @@ tweaking their $case/namelist_scream.xml file.
            TODO support numeric checks (<, >, ...)??
 
         6) You can inline case values into parameter values via this syntax, e.g.:
-           <init_file>scream_init_${ATM_GRID}.nc</init_file>
-           This would result in parameter init_file' having the value 'scream_init_ne4np4.nc'
+           <init_file>scream_init_${ATM_GRID}.nc</init_file>. If ATM_GRID="ne4np4",
+           this would result in parameter init_file' having the value 'scream_init_ne4np4.nc'
 
         7) Any parameter value with a comma will be assumed to be a list.
            TODO allow this behavior to be overridden?
@@ -118,7 +118,7 @@ tweaking their $case/namelist_scream.xml file.
            for the atmosphere processes section(s).
 
        11) The attribute 'locked="true"' is to be used for entries that cannot be changed
-           via atm-config-chg. For instance, the overall list of atm procs cannot be changed,
+           via atmchange (see scripts/atmchange). For instance, the overall list of atm procs cannot be changed,
            since it would require to re-parse the defaults, to re-generate the correct
            defaults for the (possibly) new atm procs.
 
@@ -352,6 +352,7 @@ tweaking their $case/namelist_scream.xml file.
     <mass_column_conservation_error_tolerance>1e-10</mass_column_conservation_error_tolerance>
     <energy_column_conservation_error_tolerance>1e-14</energy_column_conservation_error_tolerance>
     <column_conservation_checks_fail_handling_type>Warning</column_conservation_checks_fail_handling_type>
+    <check_all_computed_fields_for_nans type="logical">true</check_all_computed_fields_for_nans >
   </driver_options>
 
   <!-- E3SM Simulation Settings -->

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -244,11 +244,11 @@ void AtmosphereDriver::create_grids()
   m_atm_logger->info("[EAMxx] create_grids ... done!");
 }
 
-  void AtmosphereDriver::setup_surface_coupling_data_manager(SurfaceCouplingTransferType transfer_type,
-                                                             const int num_cpl_fields, const int num_scream_fields,
-                                                             const int field_size, Real* data_ptr,
-                                                             char* names_ptr, int* cpl_indices_ptr, int* vec_comps_ptr,
-                                                             Real* constant_multiple_ptr, bool* do_transfer_during_init_ptr)
+void AtmosphereDriver::setup_surface_coupling_data_manager(SurfaceCouplingTransferType transfer_type,
+                                                           const int num_cpl_fields, const int num_scream_fields,
+                                                           const int field_size, Real* data_ptr,
+                                                           char* names_ptr, int* cpl_indices_ptr, int* vec_comps_ptr,
+                                                           Real* constant_multiple_ptr, bool* do_transfer_during_init_ptr)
 {
   std::shared_ptr<SCDataManager> sc_data_mgr;
 
@@ -1142,6 +1142,11 @@ void AtmosphereDriver::initialize_atm_procs ()
 
   // Create and add energy and mass conservation check to appropriate atm procs
   setup_column_conservation_checks();
+
+  // If user requests it, we set up NaN checks for all computed fields after each atm proc run
+  if (m_atm_params.sublist("driver_options").get("check_all_computed_fields_for_nans",false)) {
+    m_atm_process_group->add_postcondition_nan_checks();
+  }
 
   if (fvphyshack) {
     // [CGLL ICs in pg2] See related notes in atmosphere_dynamics.cpp.

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1144,7 +1144,7 @@ void AtmosphereDriver::initialize_atm_procs ()
   setup_column_conservation_checks();
 
   // If user requests it, we set up NaN checks for all computed fields after each atm proc run
-  if (m_atm_params.sublist("driver_options").get("check_all_computed_fields_for_nans",false)) {
+  if (m_atm_params.sublist("driver_options").get("check_all_computed_fields_for_nans",true)) {
     m_atm_process_group->add_postcondition_nan_checks();
   }
 

--- a/components/eamxx/src/diagnostics/dry_static_energy.cpp
+++ b/components/eamxx/src/diagnostics/dry_static_energy.cpp
@@ -55,7 +55,6 @@ void DryStaticEnergyDiagnostic::compute_diagnostic_impl()
 {
 
   const auto npacks     = ekat::npack<Pack>(m_num_levs);
-  const auto npacks_p1  = ekat::npack<Pack>(m_num_levs+1);
   const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(m_num_cols, npacks);
 
   const auto& dse                = m_diagnostic_output.get_view<Pack**>();

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
@@ -7,12 +7,13 @@ namespace scream
 {
 
 // =========================================================================================
-FieldAtPressureLevel::FieldAtPressureLevel (const ekat::Comm& comm, const ekat::ParameterList& params)
-  : AtmosphereDiagnostic(comm,params)
-  ,m_field_layout(m_params.get<FieldLayout>("Field Layout"))
-  ,m_field_units(m_params.get<ekat::units::Units>("Field Units"))
-  ,m_field_name(m_params.get<std::string>("Field Name"))
-  ,m_pressure_level(m_params.get<Real>("Field Target Pressure"))
+FieldAtPressureLevel::
+FieldAtPressureLevel (const ekat::Comm& comm, const ekat::ParameterList& params)
+ : AtmosphereDiagnostic(comm,params)
+ , m_field_name(m_params.get<std::string>("Field Name"))
+ , m_field_layout(m_params.get<FieldLayout>("Field Layout"))
+ , m_field_units(m_params.get<ekat::units::Units>("Field Units"))
+ , m_pressure_level(m_params.get<Real>("Field Target Pressure"))
 {
   using namespace ShortFieldTagsNames;
   EKAT_REQUIRE_MSG (ekat::contains(std::vector<FieldTag>{LEV,ILEV},m_field_layout.tags().back()),
@@ -27,15 +28,14 @@ FieldAtPressureLevel::FieldAtPressureLevel (const ekat::Comm& comm, const ekat::
 }
 
 // =========================================================================================
-void FieldAtPressureLevel::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
+void FieldAtPressureLevel::
+set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ShortFieldTagsNames;
   using namespace ekat::units;
   const auto& gname  = m_params.get<std::string>("Grid Name");
   auto m_grid = grids_manager->get_grid(gname);
-  const auto& grid_name = m_grid->name();
   m_num_cols = m_grid->get_num_local_dofs();
-  auto num_levs = m_grid->get_num_vertical_levels();
 
   add_field<Required>(m_field_name, m_field_layout, m_field_units, gname);
 

--- a/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
@@ -189,8 +189,6 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
   auto f3_host = f3.get_view<Pack**,Host>();
   auto f4_host = f4.get_view<Pack**,Host>();
 
-  Real dpres_dz = 10000;
-  Real dpres_dx = 100;
   for (int ii=0;ii<num_lcols;++ii) {
     for (int jj=0;jj<num_levs;++jj) {
       int ipack = jj / packsize;

--- a/components/eamxx/src/diagnostics/tests/vertically_remapped_field_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/vertically_remapped_field_tests.cpp
@@ -6,7 +6,6 @@
 
 #include "share/grid/mesh_free_grids_manager.hpp"
 #include "share/field/field_utils.hpp"
-#include "share/util/scream_setup_random_test.hpp"
 
 namespace scream {
 
@@ -58,8 +57,6 @@ TEST_CASE("vertically_remapped_field")
   constexpr int packsize = SCREAM_PACK_SIZE;
   std::cout<<"packsize: "<<packsize<<std::endl;
   ekat::Comm comm(MPI_COMM_WORLD);
-
-  auto engine = scream::setup_random_test(&comm);
 
   // Create a grids manager
   const int ncols = 3;

--- a/components/eamxx/src/diagnostics/vertical_layer_midpoint.cpp
+++ b/components/eamxx/src/diagnostics/vertical_layer_midpoint.cpp
@@ -4,14 +4,16 @@ namespace scream
 {
 
 // =========================================================================================
-VerticalLayerMidpointDiagnostic::VerticalLayerMidpointDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
+VerticalLayerMidpointDiagnostic::
+VerticalLayerMidpointDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
   : AtmosphereDiagnostic(comm,params)
 {
   // Nothing to do here
 }
 
 // =========================================================================================
-void VerticalLayerMidpointDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
+void VerticalLayerMidpointDiagnostic::
+set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
@@ -49,7 +51,6 @@ void VerticalLayerMidpointDiagnostic::compute_diagnostic_impl()
 {
 
   const auto npacks     = ekat::npack<Pack>(m_num_levs);
-  const auto npacks_p1  = ekat::npack<Pack>(m_num_levs+1);
   const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(m_num_cols, npacks);
   const auto& z_mid              = m_diagnostic_output.get_view<Pack**>();
   const auto& T_mid              = get_field_in("T_mid").get_view<const Pack**>();

--- a/components/eamxx/src/diagnostics/vertically_remapped_field.cpp
+++ b/components/eamxx/src/diagnostics/vertically_remapped_field.cpp
@@ -10,13 +10,14 @@ namespace scream
 {
 
 // =========================================================================================
-VerticallyRemappedField::VerticallyRemappedField (const ekat::Comm& comm, const ekat::ParameterList& params)
+VerticallyRemappedField::
+VerticallyRemappedField (const ekat::Comm& comm, const ekat::ParameterList& params)
   : AtmosphereDiagnostic(comm,params)
+  , m_field_name(m_params.get<std::string>("Field Name"))
   , m_field_layout(m_params.get<FieldLayout>("Field Layout"))
   , m_field_units(m_params.get<ekat::units::Units>("Field Units")) 
-  , m_field_name(m_params.get<std::string>("Field Name"))
-  , m_tgt_pres_levs(m_params.get<view_1d_const>("press_levels"))
   , m_tgt_num_levs(m_params.get<int>("tgt_num_levs"))
+  , m_tgt_pres_levs(m_params.get<view_1d_const>("press_levels"))
 {
   using namespace ShortFieldTagsNames;
   EKAT_REQUIRE_MSG (ekat::contains(std::vector<FieldTag>{LEV,ILEV},m_field_layout.tags().back()),
@@ -26,13 +27,13 @@ VerticallyRemappedField::VerticallyRemappedField (const ekat::Comm& comm, const 
 }
 
 // =========================================================================================
-void VerticallyRemappedField::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
+void VerticallyRemappedField::
+set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ShortFieldTagsNames;
   using namespace ekat::units;
   const auto& gname  = m_params.get<std::string>("Grid Name");
   auto m_grid = grids_manager->get_grid(gname);
-  const auto& grid_name = m_grid->name();
   m_num_cols = m_grid->get_num_local_dofs();
 
   add_field<Required>(m_field_name, m_field_layout, m_field_units, gname);

--- a/components/eamxx/src/physics/shoc/impl/shoc_energy_fixer_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_energy_fixer_impl.hpp
@@ -74,7 +74,8 @@ void Functions<S,D>::shoc_energy_fixer(
 
   // Limit the energy fixer to find highest layer where SHOC is active.
   // Find first level where tke is higher than lowest threshold.
-  static_assert(Spack::n == IntSmallPack::n, "SHOC: assumption in ||r.");
+  static_assert(static_cast<int>(Spack::n)==static_cast<int>(IntSmallPack::n),
+                "SHOC: violated assumption in parallel reduce.");
   Int shoctop = 0;
   const auto nlevm2_packs = ekat::npack<Spack>(nlev-2);
   Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, nlevm2_packs),

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -532,12 +532,12 @@ Int Functions<S,D>::shoc_main(
 #endif
                               )
 {
-  using ExeSpace = typename KT::ExeSpace;
-
   // Start timer
   auto start = std::chrono::steady_clock::now();
 
 #ifndef SCREAM_SMALL_KERNELS
+  using ExeSpace = typename KT::ExeSpace;
+
   // SHOC main loop
   const auto nlev_packs = ekat::npack<Spack>(nlev);
   const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -278,29 +278,34 @@ void AtmosphereProcess::run_property_check (const prop_check_ptr&       property
           tags.erase(itm);
           idx.erase(idx.begin()+pos);
         }
+        ss << "\n *************************** INPUT FIELDS ******************************\n";
         ss << "\n  ------- INPUT FIELDS -------\n";
         for (const auto& f : m_fields_in) {
           if (f.get_header().get_identifier().get_layout().has_tags(tags)) {
             print_field_hyperslab (f,tags,idx,ss);
+            ss << " -----------------------------------------------------------------------\n";
           }
         }
         for (const auto& g : m_groups_in) {
           for (const auto& f : g.m_fields) {
             if (f.second->get_header().get_identifier().get_layout().has_tags(tags)) {
               print_field_hyperslab (*f.second,tags,idx,ss);
+              ss << " -----------------------------------------------------------------------\n";
             }
           }
         }
-        ss << "\n  ------- OUTPUT FIELDS -------\n";
+        ss << "\n ************************** OUTPUT FIELDS ******************************\n";
         for (const auto& f : m_fields_out) {
           if (f.get_header().get_identifier().get_layout().has_tags(tags)) {
             print_field_hyperslab (f,tags,idx,ss);
+            ss << " -----------------------------------------------------------------------\n";
           }
         }
         for (const auto& g : m_groups_out) {
           for (const auto& f : g.m_fields) {
             if (f.second->get_header().get_identifier().get_layout().has_tags(tags)) {
               print_field_hyperslab (*f.second,tags,idx,ss);
+              ss << " -----------------------------------------------------------------------\n";
             }
           }
         }

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -498,6 +498,35 @@ add_precondition_check (const prop_check_ptr& pc, const CheckFailHandling cfh)
 void AtmosphereProcess::
 add_postcondition_check (const prop_check_ptr& pc, const CheckFailHandling cfh)
 {
+  auto cfh2str = [] (const CheckFailHandling cfh) -> std::string {
+    std::string s = "";
+    switch (cfh) {
+      case CheckFailHandling::Fatal:
+        s = "Fatal";
+        break;
+      case CheckFailHandling::Warning:
+        s = "Warning";
+        break;
+      default:
+        EKAT_ERROR_MSG ("Unexpected/unsupported CheckFailHandling value.\n");
+    }
+
+    return "";
+  };
+
+  // Avoid adding the *SAME* test twice
+  for (const auto& it : m_postcondition_checks) {
+    if (it.second->same_as(*pc)) {
+      EKAT_REQUIRE_MSG (it.first==cfh,
+          "Error! Duplicate property check with different CheckFailHandling.\n"
+          "  - Atmosphere process name: " + name() + "\n"
+          "  - Property check name: " + pc->name() + "\n"
+          "  - Current CFH: " + cfh2str(it.first) + "\n"
+          "  - Input CFH: " + cfh2str(cfh) + "\n");
+      return;
+    }
+  }
+
   // If a pc can repair, we need to make sure the repairable
   // fields are among the computed fields of this atm proc.
   // Otherwise, it would be possible for this AP to implicitly

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -262,8 +262,22 @@ void AtmosphereProcess::run_property_check (const prop_check_ptr&       property
             "  - Atmosphere process MPI Rank: " + std::to_string(m_comm.rank()) + "\n"
             "  - Message: " + res_and_msg.msg;
       if (res_and_msg.fail_loc_indices.size()>0) {
-        const auto& tags = res_and_msg.fail_loc_tags;
-        const auto& idx  = res_and_msg.fail_loc_indices;
+        // If the location is 3d, we not use the level index to slice the fields,
+        // but print a column worth of data for all fields.
+        using namespace ShortFieldTagsNames;
+        auto tags = res_and_msg.fail_loc_tags;
+        auto idx  = res_and_msg.fail_loc_indices;
+        auto itm = ekat::find(tags,LEV);
+        auto iti = ekat::find(tags,ILEV);
+        if (itm!=tags.end()) {
+          auto pos = std::distance(tags.begin(),itm);
+          tags.erase(itm);
+          idx.erase(idx.begin()+pos);
+        } else if (iti!=tags.end()) {
+          auto pos = std::distance(tags.begin(),iti);
+          tags.erase(itm);
+          idx.erase(idx.begin()+pos);
+        }
         ss << "\n  ------- INPUT FIELDS -------\n";
         for (const auto& f : m_fields_in) {
           if (f.get_header().get_identifier().get_layout().has_tags(tags)) {

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
@@ -87,6 +87,11 @@ public:
       const std::shared_ptr<MassAndEnergyColumnConservationCheck>& conservation_check,
       const CheckFailHandling                                      fail_handling_type) const;
 
+  // Add nan checks after each non-group process, for each computed field.
+  // If checks fail, we print all input and output fields of that process
+  // (that are on the same grid) at the location of the fail.
+  void add_postcondition_nan_checks () const;
+
 protected:
 
   // Adds fid to the list of required/computed fields of the group (as a whole).
@@ -117,6 +122,9 @@ protected:
 
   // The schedule type: Parallel vs Sequential
   ScheduleType   m_group_schedule_type;
+
+  // This is only needed to be able to access grids objects later on
+  std::shared_ptr<const GridsManager>   m_grids_mgr;
 };
 
 } // namespace scream

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -554,11 +554,14 @@ auto Field::get_ND_view () const ->
   const auto& alloc_prop = m_header->get_alloc_properties();
   auto num_values = alloc_prop.get_alloc_size() / sizeof(T);
   Kokkos::LayoutRight kl;
-  for (int i=0; i<N-1; ++i) {
-    kl.dimension[i] = fl.dim(i);
-    num_values = fl.dim(i)==0 ? 0 : num_values/fl.dim(i);
+  for (int i=0; i<N; ++i) {
+    if (i==N-1) {
+      kl.dimension[i] = num_values;
+    } else {
+      kl.dimension[i] = fl.dim(i);
+      num_values = fl.dim(i)==0 ? 0 : num_values/fl.dim(i);
+    }
   }
-  kl.dimension[N-1] = num_values;
   auto ptr = reinterpret_cast<T*>(get_view_impl<HD>().data());
 
   using ret_type = get_view_type<data_nd_t<T,N>,HD>;

--- a/components/eamxx/src/share/field/field_alloc_prop.cpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.cpp
@@ -50,16 +50,6 @@ subview (const int idim, const int k, const bool dynamic) const {
   props.m_alloc_size = m_alloc_size / m_layout->dim(idim);
   props.m_subview_info = SubviewInfo(idim,k,m_layout->dim(idim),dynamic);
 
-  // Output is contioguous if a) this->m_contiguous=true,
-  // b) idim==0, or if m_layout->dim(i)==1 for i<idim
-  props.m_contiguous = m_contiguous;
-  for (int i=0; i<idim; ++i) {
-    if (m_layout->dim(i)>0) {
-      props.m_contiguous = false;
-      break;
-    }
-  }
-
   // The output props should still store a FieldLayout, in case
   // they are further subviewed. We have all we need here to build
   // a layout from scratch, but it would duplicate what is inside
@@ -74,6 +64,18 @@ subview (const int idim, const int k, const bool dynamic) const {
   tags.erase(tags.begin()+idim);
   dims.erase(dims.begin()+idim);
   props.m_layout = std::make_shared<layout_type>(tags,dims);
+
+  // Output is contioguous if either
+  //  - this->m_contiguous=true AND idim==0
+  //  - m_layout->dim(i)==1 for all i<idim
+  //  - props.m_layout->rank()==0
+  props.m_contiguous = m_contiguous || props.m_layout->rank()==0;
+  for (int i=0; i<idim; ++i) {
+    if (m_layout->dim(i)>0) {
+      props.m_contiguous = false;
+      break;
+    }
+  }
 
   // Figure out strides
   const int rm1 = m_layout->rank()-1;

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -72,6 +72,7 @@ public:
   const std::vector<FieldTag>& tags () const { return m_tags; }
   FieldTag tag  (const int idim) const;
   bool has_tag (const FieldTag t) const { return ekat::contains(m_tags,t); }
+  bool has_tags (const std::vector<FieldTag>& tags) const;
 
   // The rank is the number of tags associated to this field.
   int     rank () const  { return m_rank; }
@@ -148,6 +149,14 @@ inline FieldTag FieldLayout::tag (const int idim) const {
   ekat::error::runtime_check(idim>=0 && idim<m_rank, "Error! Index out of bounds.", -1);
   return m_tags[idim];
 } 
+
+inline bool FieldLayout::has_tags (const std::vector<FieldTag>& tags) const {
+  bool b = true;
+  for (auto t : tags) {
+    b &= has_tag(t);
+  }
+  return b;
+}
 
 inline bool FieldLayout::is_dimension_set (const int idim) const {
   ekat::error::runtime_check(idim>=0 && idim<m_rank, "Error! Index out of bounds.", -1);

--- a/components/eamxx/src/share/field/field_tag.hpp
+++ b/components/eamxx/src/share/field/field_tag.hpp
@@ -127,6 +127,12 @@ namespace ShortFieldTagsNames {
   constexpr auto LWGPT = FieldTag::LongWaveGpoint;
 }
 
+// Allow to stream FieldTag values as strings.
+inline std::ostream& operator<< (std::ostream& out, const FieldTag t) {
+  out << e2str(t);
+  return out;
+}
+
 } // namespace scream
 
 #endif // SCREAM_FIELD_TAG_HPP

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -104,6 +104,38 @@ ST field_min(const Field& f, const ekat::Comm* comm = nullptr)
   return impl::field_min<ST>(f,comm);
 }
 
+// Prints the value of a field at a certain location, specified by tags and indices.
+// If the field layout contains all the location tags, we will slice the field along
+// those tags, and print it. E.g., f might be a <COL,LEV> field, and the tags/indices
+// refer to a single column, in which case we'll print a whole column worth of data.
+inline void
+print_field_hyperslab (const Field& f,
+                       const std::vector<FieldTag>& tags,
+                       const std::vector<int>& indices,
+                       std::ostream& out)
+{
+  const auto dt = f.data_type();
+  const auto rank = f.rank();
+
+  EKAT_REQUIRE_MSG (rank>=static_cast<int>(tags.size()),
+      "Error! Requested location incompatible with field rank.\n"
+      "  - field name: " + f.name() + "\n"
+      "  - field rank: " + std::to_string(rank) + "\n"
+      "  - requested indices: (" + ekat::join(indices,",") + "\n");
+
+  switch (dt) {
+    case DataType::IntType:
+      impl::print_field_hyperslab<int>(f,tags,indices,out,rank,0);
+      break;
+    case DataType::FloatType:
+      impl::print_field_hyperslab<float>(f,tags,indices,out,rank,0);
+      break;
+    case DataType::DoubleType:
+      impl::print_field_hyperslab<double>(f,tags,indices,out,rank,0);
+      break;
+  }
+}
+
 } // namespace scream
 
 #endif // SCREAM_FIELD_UTILS_HPP

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -636,8 +636,10 @@ void print_field_hyperslab (const Field& f,
   // slice/entry currently printed. We can already fill the entries corresponding
   // to dimensions we sliced away.
   auto get_dims_str = [&](const FieldLayout& orig_layout) -> std::vector<std::string> {
-    std::vector<std::string> dims_str (orig_layout.rank(),"");
-    for (int ii=0, jj=0; ii<orig_layout.rank(); ++ii) {
+    const int orig_rank = orig_layout.rank();
+    const int num_tags  = tags.size();
+    std::vector<std::string> dims_str (orig_rank,"");
+    for (int ii=0, jj=0; ii<orig_rank && jj<num_tags; ++ii) {
       if (orig_layout.tag(ii)==tags[jj]) {
         // Was sliced. Store slice idx as a stirng
         dims_str[ii] = std::to_string(indices[jj]);
@@ -651,9 +653,11 @@ void print_field_hyperslab (const Field& f,
   // since we'll have to loop over them. We'll use these indices to add the
   // missing info in the dims_str vector<string> as we loop and print.
   auto get_dims_left = [&](const FieldLayout& orig_layout) -> std::vector<int> {
+    const int orig_rank = orig_layout.rank();
+    const int num_tags  = tags.size();
     std::vector<int> dims_left;
-    for (int ii=0, jj=0; ii<orig_layout.rank(); ++ii) {
-      if (orig_layout.tag(ii)==tags[jj]) {
+    for (int ii=0, jj=0; ii<orig_rank; ++ii) {
+      if (jj<num_tags && orig_layout.tag(ii)==tags[jj]) {
         // Was sliced. Skip
         ++jj;
       } else {

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -677,22 +677,20 @@ void print_field_hyperslab (const Field& f,
 
     f.sync_to_host();
     const int rank = layout.rank();
-    out << " -----------------------------------------------------------------------\n";
-    out << "     " << f.name() << to_string(orig_layout) << "\n";
-    out << " -----------------------------------------------------------------------\n";
+    out << "     " << f.name() << to_string(orig_layout) << "\n\n";
     switch (rank) {
       case 0:
       {
-        out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+        out << "  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
         // NOTE: add ", " at the end, to make rank0 behave the same as other ranks,
         //       for the sake of any script trying to manipulate output
-        out << "\n    " << f.get_view<const T,Host>()() << ", ";
+        out << "\n    " << f.get_view<const T,Host>()() << ", \n";
         break;
       }
       case 1:
       {
         dims_str[dims_left[0]] = ":";
-        out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+        out << "  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
         auto v = f.get_view<const T*,Host>();
         for (int i=0; i<layout.dim(0); ++i) {
           if (i%max_per_line==0) {
@@ -700,6 +698,7 @@ void print_field_hyperslab (const Field& f,
           }
           out << v(i) << ", ";
         }
+        out << "\n";
         break;
       }
       case 2:
@@ -708,13 +707,14 @@ void print_field_hyperslab (const Field& f,
         auto v = f.get_view<const T**,Host>();
         for (int i=0; i<layout.dim(0); ++i) {
           dims_str[dims_left[0]] = std::to_string(i);
-          out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+          out << "  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
           for (int j=0; j<layout.dim(1); ++j) {
             if (j%max_per_line==0) {
               out << "\n    ";
             }
             out << v(i,j) << ", ";
           }
+          out << "\n";
         }
         break;
       }
@@ -726,13 +726,14 @@ void print_field_hyperslab (const Field& f,
           dims_str[dims_left[0]] = std::to_string(i);
           for (int j=0; j<layout.dim(1); ++j) {
             dims_str[dims_left[1]] = std::to_string(j);
-            out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+            out << "  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
             for (int k=0; k<layout.dim(2); ++k) {
               if (k%max_per_line==0) {
                 out << "\n    ";
               }
               out << v(i,j,k) << ", ";
             }
+            out << "\n";
           }
         }
         break;
@@ -747,13 +748,14 @@ void print_field_hyperslab (const Field& f,
             dims_str[dims_left[1]] = std::to_string(j);
             for (int k=0; k<layout.dim(2); ++k) {
               dims_str[dims_left[2]] = std::to_string(k);
-              out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+              out << "  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
               for (int l=0; l<layout.dim(3); ++l) {
                 if (l%max_per_line==0) {
                   out << "\n    ";
                 }
                 out << v(i,j,k,l) << ", ";
               }
+              out << "\n";
             }
           }
         }
@@ -766,7 +768,6 @@ void print_field_hyperslab (const Field& f,
             "  - field layout (upon slicing): " + to_string(layout) + "\n");
 
     }
-    out << "\n -----------------------------------------------------------------------\n";
   } else {
     auto tag = tags[curr_idx];
     auto idx = indices[curr_idx];
@@ -815,19 +816,17 @@ void print_field_hyperslab (const Field& f,
       // with a rank 1 field (if Kokkos had allowed us to take the subview)
       dims_str[dims_left[0]] = ":";
 
-      out << " -----------------------------------------------------------------------\n";
-      out << "     " << f.name() << to_string(orig_layout) << "\n";
-      out << " -----------------------------------------------------------------------\n";
+      out << "     " << f.name() << to_string(orig_layout) << "\n\n";
       f.sync_to_host();
       auto v = f.get_view<const T**,Host>();
-      out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+      out << "  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
       for (int i=0; i<layout.dim(0); ++i) {
         if (i%max_per_line==0) {
           out << "\n    ";
         }
         out << v(i,idx) << ", ";
       }
-      out << "\n -----------------------------------------------------------------------\n";
+      out << "\n";
     }
   }
 }

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -594,6 +594,240 @@ ST field_min(const Field& f, const ekat::Comm* comm)
   }
 }
 
+template<typename T>
+void print_field_hyperslab (const Field& f,
+                            std::vector<FieldTag> tags,
+                            std::vector<int> indices,
+                            std::ostream& out,
+                            const int orig_rank,
+                            const size_t curr_idx)
+{
+  // General idea: call f.subfield with the proper index, and recurse
+  // until all indices are exausted, then print the field that is left.
+  // HOWEVER. In order to keep LayoutRight in Kokkos, we can only subview
+  //   - along 1st dimension
+  //   - along 2nd dimension if rank>2
+  // So if the input field is 2d and the index to subview at is along
+  // the 2nd dim, we must stop recursion, and print the field manually
+  // extracting the last slice.
+  //
+  // We keep all the tags/indices we slice away, since we need them at
+  // the end of recursion when we print the info of the field location.
+  // E.g., if f has tags/dims <COL,CMP,LEV>/(2,3,4) and we subview at
+  // tags/indices <COL,LEV>/(0,1), we want to print something like
+  //   f(0,:,1):
+  //     0.123, 0.456, 0.789
+
+  EKAT_REQUIRE_MSG (tags.size()==indices.size(),
+      "Error! Tags vector size differs from indices vector size.\n");
+
+  const auto& layout = f.get_header().get_identifier().get_layout();
+
+  // Get layout of original field (before all the slicing happened)
+  auto get_orig_header = [&]() -> std::shared_ptr<const FieldHeader> {
+    auto fh = f.get_header_ptr();
+    while (fh->get_identifier().get_layout().rank()<orig_rank) {
+      fh = fh->get_parent().lock();
+    }
+    return fh;
+  };
+
+  // Get a vector of strings, which we'll use to print the info of the field
+  // slice/entry currently printed. We can already fill the entries corresponding
+  // to dimensions we sliced away.
+  auto get_dims_str = [&](const FieldLayout& orig_layout) -> std::vector<std::string> {
+    std::vector<std::string> dims_str (orig_layout.rank(),"");
+    for (int ii=0, jj=0; ii<orig_layout.rank(); ++ii) {
+      if (orig_layout.tag(ii)==tags[jj]) {
+        // Was sliced. Store slice idx as a stirng
+        dims_str[ii] = std::to_string(indices[jj]);
+        ++jj;
+      }
+    }
+    return dims_str;
+  };
+
+  // Get the dimensions (in the original field) that were *NOT* sliced away,
+  // since we'll have to loop over them. We'll use these indices to add the
+  // missing info in the dims_str vector<string> as we loop and print.
+  auto get_dims_left = [&](const FieldLayout& orig_layout) -> std::vector<int> {
+    std::vector<int> dims_left;
+    for (int ii=0, jj=0; ii<orig_layout.rank(); ++ii) {
+      if (orig_layout.tag(ii)==tags[jj]) {
+        // Was sliced. Skip
+        ++jj;
+      } else {
+        // Was not sliced.
+        dims_left.push_back(ii);
+      }
+    }
+    return dims_left;
+  };
+
+  constexpr int max_per_line = 5;
+  if (curr_idx==tags.size()) {
+    // All slices have been taken. Print the whole input field.
+    const auto& orig_layout = get_orig_header()->get_identifier().get_layout();
+    const auto dims_left = get_dims_left(orig_layout);
+    auto dims_str = get_dims_str(orig_layout);
+
+    f.sync_to_host();
+    const int rank = layout.rank();
+    out << " -----------------------------------------------------------------------\n";
+    out << "     " << f.name() << to_string(orig_layout) << "\n";
+    out << " -----------------------------------------------------------------------\n";
+    switch (rank) {
+      case 0:
+      {
+        out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+        // NOTE: add ", " at the end, to make rank0 behave the same as other ranks,
+        //       for the sake of any script trying to manipulate output
+        out << "\n    " << f.get_view<const T,Host>()() << ", ";
+        break;
+      }
+      case 1:
+      {
+        dims_str[dims_left[0]] = ":";
+        out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+        auto v = f.get_view<const T*,Host>();
+        for (int i=0; i<layout.dim(0); ++i) {
+          if (i%max_per_line==0) {
+            out << "\n    ";
+          }
+          out << v(i) << ", ";
+        }
+        break;
+      }
+      case 2:
+      {
+        dims_str[dims_left[1]] = ":";
+        auto v = f.get_view<const T**,Host>();
+        for (int i=0; i<layout.dim(0); ++i) {
+          dims_str[dims_left[0]] = std::to_string(i);
+          out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+          for (int j=0; j<layout.dim(1); ++j) {
+            if (j%max_per_line==0) {
+              out << "\n    ";
+            }
+            out << v(i,j) << ", ";
+          }
+        }
+        break;
+      }
+      case 3:
+      {
+        dims_str[dims_left[2]] = ":";
+        auto v = f.get_view<const T***,Host>();
+        for (int i=0; i<layout.dim(0); ++i) {
+          dims_str[dims_left[0]] = std::to_string(i);
+          for (int j=0; j<layout.dim(1); ++j) {
+            dims_str[dims_left[1]] = std::to_string(j);
+            out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+            for (int k=0; k<layout.dim(2); ++k) {
+              if (k%max_per_line==0) {
+                out << "\n    ";
+              }
+              out << v(i,j,k) << ", ";
+            }
+          }
+        }
+        break;
+      }
+      case 4:
+      {
+        dims_str[dims_left[3]] = ":";
+        auto v = f.get_view<const T****,Host>();
+        for (int i=0; i<layout.dim(0); ++i) {
+          dims_str[dims_left[0]] = std::to_string(i);
+          for (int j=0; j<layout.dim(1); ++j) {
+            dims_str[dims_left[1]] = std::to_string(j);
+            for (int k=0; k<layout.dim(2); ++k) {
+              dims_str[dims_left[2]] = std::to_string(k);
+              out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+              for (int l=0; l<layout.dim(3); ++l) {
+                if (l%max_per_line==0) {
+                  out << "\n    ";
+                }
+                out << v(i,j,k,l) << ", ";
+              }
+            }
+          }
+        }
+        break;
+      }
+      default:
+        EKAT_ERROR_MSG (
+            "Unsupported rank in print_field_hyperslab.\n"
+            "  - field name  : " + f.name() + "\n"
+            "  - field layout (upon slicing): " + to_string(layout) + "\n");
+
+    }
+    out << "\n -----------------------------------------------------------------------\n";
+  } else {
+    auto tag = tags[curr_idx];
+    auto idx = indices[curr_idx];
+
+    auto it = ekat::find(layout.tags(),tag);
+    EKAT_REQUIRE_MSG (it!=layout.tags().end(),
+        "Error! Something went wrong while slicing field.\n"
+        "  - field name  : " + f.name() + "\n"
+        "  - field layout: " + to_string(layout) + "\n"
+        "  - curr tag    : " + e2str(tag) + "\n");
+    auto idim = std::distance(layout.tags().begin(),it);
+
+    EKAT_REQUIRE_MSG (idim==0 || idim==1,
+        "Error! Cannot subview field for printing.\n"
+        "  - field name  : " + f.name() + "\n"
+        "  - field layout: " + to_string(layout) + "\n"
+        "  - loc tags    : <" + ekat::join(tags,",") + ">\n"
+        "  - loc indices : (" + ekat::join(indices,",") + ")\n");
+
+    // It's always safe to take subview along 1st dim. For 2nd dim, we can
+    // only do it if the rank is 3+
+    if (idim==0 || layout.rank()>2) {
+      // Slice field, and recurse.
+      auto sub_f = f.subfield(idim,idx);
+      return print_field_hyperslab<T>(sub_f,tags,indices,out,orig_rank,curr_idx+1);
+    } else {
+      // It must be that we have one last slicing to do,
+      // along the 2nd dimension of a rank2 field.
+      EKAT_REQUIRE_MSG (curr_idx==(tags.size()-1) && layout.rank()==2,
+          "Error! Unexpected inputs in print_field_hyperslab.\n"
+          "  - field name : " + f.name() + "\n"
+          "  - field layout: " + to_string(layout) + "\n"
+          "  - curr tag   : " + e2str(tag) + "\n"
+          "  - loc tags   : <" + ekat::join(tags,",") + ">\n"
+          "  - loc indices: (" + ekat::join(indices,",") +")\n");
+
+      const auto& orig_layout = get_orig_header()->get_identifier().get_layout();
+      const auto dims_left = get_dims_left(orig_layout);
+      auto dims_str = get_dims_str(orig_layout);
+
+      // Although the view we extract still has rank2, get_dims_[str|left] only
+      // use the original layout and the loc tags/indices, so it already filled
+      // all the dims string corresponding to the input loc tags/indices.
+      // The only dim left is the current 1st dim of the field.
+      // In other words, even though we have a rank2 field, we should have ended
+      // with a rank 1 field (if Kokkos had allowed us to take the subview)
+      dims_str[dims_left[0]] = ":";
+
+      out << " -----------------------------------------------------------------------\n";
+      out << "     " << f.name() << to_string(orig_layout) << "\n";
+      out << " -----------------------------------------------------------------------\n";
+      f.sync_to_host();
+      auto v = f.get_view<const T**,Host>();
+      out << "\n  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
+      for (int i=0; i<layout.dim(0); ++i) {
+        if (i%max_per_line==0) {
+          out << "\n    ";
+        }
+        out << v(i,idx) << ", ";
+      }
+      out << "\n -----------------------------------------------------------------------\n";
+    }
+  }
+}
+
 } // namespace impl
 
 } // namespace scream

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -343,7 +343,7 @@ get_owners (const hview_1d<const gid_type>& gids) const
       }
     }
   }
-  EKAT_REQUIRE_MSG (num_found==owners.size(),
+  EKAT_REQUIRE_MSG (num_found==static_cast<int>(owners.size()),
       "Error! Could not locate the owner of one of the input GIDs.\n"
       "  - rank: " + std::to_string(comm.rank()) + "\n"
       "  - num found: " + std::to_string(num_found) + "\n"

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -278,7 +278,6 @@ void CoarseningRemapper::do_remap_fwd ()
     // x is the src field, and y is the overlapped tgt field.
     const auto& f_src    = m_src_fields[i];
     const auto& f_ov_tgt = m_ov_tgt_fields[i];
-    const auto& tgt_layout = f_ov_tgt.get_header().get_identifier().get_layout();
 
     // Dispatch kernel with the largest possible pack size
     const auto& src_ap = f_src.get_header().get_alloc_properties();
@@ -324,10 +323,8 @@ local_mat_vec (const Field& x, const Field& y) const
   using PackInfo    = ekat::PackInfo<PackSize>;
 
   const auto& src_layout = x.get_header().get_identifier().get_layout();
-  const auto& tgt_layout = y.get_header().get_identifier().get_layout();
   const int rank = src_layout.rank();
   const int nrows = m_ov_tgt_grid->get_num_local_dofs();
-  const int nrows_src = m_src_grid->get_num_local_dofs();
   auto row_offsets = m_row_offsets;
   auto col_lids = m_col_lids;
   auto weights = m_weights;

--- a/components/eamxx/src/share/property_checks/field_nan_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_nan_check.cpp
@@ -125,7 +125,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
   res_and_msg.result = invalid_idx<0 ? CheckResult::Pass : CheckResult::Fail;
   res_and_msg.msg = "";
   if (res_and_msg.result==CheckResult::Fail) {
-    auto indices = unflatten_idx(layout.dims(),invalid_idx);
+    auto& indices = res_and_msg.fail_indices = unflatten_idx(layout.dims(),invalid_idx);
     res_and_msg.msg  = "FieldNaNCheck failed.\n";
     res_and_msg.msg += "  - field id: " + f.get_header().get_identifier().get_id_string() + "\n";
     using namespace ShortFieldTagsNames;

--- a/components/eamxx/src/share/property_checks/field_nan_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_nan_check.cpp
@@ -125,7 +125,8 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
   res_and_msg.result = invalid_idx<0 ? CheckResult::Pass : CheckResult::Fail;
   res_and_msg.msg = "";
   if (res_and_msg.result==CheckResult::Fail) {
-    auto& indices = res_and_msg.fail_indices = unflatten_idx(layout.dims(),invalid_idx);
+    auto& indices = res_and_msg.fail_loc_indices = unflatten_idx(layout.dims(),invalid_idx);
+    res_and_msg.fail_loc_tags = layout.tags();
     res_and_msg.msg  = "FieldNaNCheck failed.\n";
     res_and_msg.msg += "  - field id: " + f.get_header().get_identifier().get_id_string() + "\n";
     using namespace ShortFieldTagsNames;

--- a/components/eamxx/src/share/property_checks/field_nan_check.hpp
+++ b/components/eamxx/src/share/property_checks/field_nan_check.hpp
@@ -19,6 +19,8 @@ public:
     return "NaN check for field " + fields().front().name();
   }
 
+  PropertyType type () const override { return PropertyType::PointWise; }
+
   ResultAndMsg check() const override;
 
 // CUDA requires the parent fcn of a KOKKOS_LAMBDA to have public access

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
@@ -197,13 +197,29 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
           "You should not have reached this line. Please, contact developers.\n");
   }
   PropertyCheck::ResultAndMsg res_and_msg;
-  
+
+  bool pass_lower, pass_upper;
+
   if (minmaxloc.min_val>=m_lb && minmaxloc.max_val<=m_ub) {
     res_and_msg.result = CheckResult::Pass;
+    pass_lower = pass_upper = true;
   } else if  (minmaxloc.min_val<m_lb_repairable || minmaxloc.max_val>m_ub_repairable) {
+    if (minmaxloc.min_val<m_lb_repairable) {
+      pass_lower = false;
+    }
+    if (minmaxloc.man_val>m_ub_repairable) {
+      pass_upper = false;
+    }
+
     res_and_msg.result = CheckResult::Fail;
   } else {
     res_and_msg.result = CheckResult::Repairable;
+    if (minmaxloc.min_val<m_lb) {
+      pass_lower = false;
+    }
+    if (minmaxloc.man_val>m_ub) {
+      pass_upper = false;
+    }
   }
 
   if (res_and_msg.result == CheckResult::Pass) {
@@ -218,6 +234,12 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
 
   auto idx_min = unflatten_idx(layout.dims(),minmaxloc.min_loc);
   auto idx_max = unflatten_idx(layout.dims(),minmaxloc.max_loc);
+
+  if (not pass_lower) {
+    res_and_msg.fail_indices = idx_min;
+  } else if (not pass_upper) {
+    res_and_msg.fail_indices = idx_max;
+  }
 
   using namespace ShortFieldTagsNames;
 

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
@@ -404,4 +404,17 @@ void FieldWithinIntervalCheck::repair_impl() const {
   }
 }
 
+bool FieldWithinIntervalCheck::same_as (const PropertyCheck& pc) const {
+  auto* fwic = dynamic_cast<const FieldWithinIntervalCheck*>(&pc);
+  if (fwic==nullptr) {
+    return false;
+  }
+
+  // They are both interval checks, so check bounds and whatever the base class does
+  return PropertyCheck::same_as(pc) &&
+         m_ub==fwic->m_ub && m_lb==fwic->m_lb &&
+         m_ub_repairable==fwic->m_ub_repairable &&
+         m_lb_repairable==fwic->m_lb_repairable;
+}
+
 } // namespace scream

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
@@ -207,7 +207,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     if (minmaxloc.min_val<m_lb_repairable) {
       pass_lower = false;
     }
-    if (minmaxloc.man_val>m_ub_repairable) {
+    if (minmaxloc.max_val>m_ub_repairable) {
       pass_upper = false;
     }
 
@@ -217,7 +217,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     if (minmaxloc.min_val<m_lb) {
       pass_lower = false;
     }
-    if (minmaxloc.man_val>m_ub) {
+    if (minmaxloc.max_val>m_ub) {
       pass_upper = false;
     }
   }
@@ -236,9 +236,11 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
   auto idx_max = unflatten_idx(layout.dims(),minmaxloc.max_loc);
 
   if (not pass_lower) {
-    res_and_msg.fail_indices = idx_min;
+    res_and_msg.fail_loc_indices = idx_min;
+    res_and_msg.fail_loc_tags = layout.tags();
   } else if (not pass_upper) {
-    res_and_msg.fail_indices = idx_max;
+    res_and_msg.fail_loc_indices = idx_max;
+    res_and_msg.fail_loc_tags = layout.tags();
   }
 
   using namespace ShortFieldTagsNames;

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.hpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.hpp
@@ -50,6 +50,8 @@ protected:
   template<typename ST>
   void repair_impl() const;
 
+  bool same_as (const PropertyCheck& pc) const override;
+
 protected:
 
   void repair_impl() const override;

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.hpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.hpp
@@ -37,6 +37,8 @@ public:
   // The name of the property check
   std::string name () const override;
 
+  PropertyType type () const override { return PropertyType::PointWise; }
+
   ResultAndMsg check() const override;
 
 // CUDA requires the parent fcn of a KOKKOS_LAMBDA to have public access

--- a/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
+++ b/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
@@ -255,6 +255,8 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
     if (has_latlon) {
       msg << "    - (lat, lon): (" << lat(maxloc_mass.loc) << ", " << lon(maxloc_mass.loc) << ")\n";
     }
+    res_and_msg.fail_loc_indices.resize(1,maxloc_mass.loc);
+    res_and_msg.fail_loc_tags = m_fields.at("phis")->get_header().get_identifier().get_layout().tags();
   }
   if (not energy_below_tol) {
     msg << "  - energy error tolerance: " << m_energy_tol << "\n";
@@ -263,6 +265,8 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
     if (has_latlon) {
       msg << "    - (lat, lon): (" << lat(maxloc_energy.loc) << ", " << lon(maxloc_energy.loc) << ")\n";
     }
+    res_and_msg.fail_loc_indices.resize(1,maxloc_energy.loc);
+    res_and_msg.fail_loc_tags = m_fields.at("phis")->get_header().get_identifier().get_layout().tags();
   }
 
   res_and_msg.msg = msg.str();

--- a/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.hpp
+++ b/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.hpp
@@ -47,6 +47,8 @@ public:
   // The name of the property check
   std::string name () const override { return "Mass and energy column conservation check"; }
 
+  PropertyType type () const override { return PropertyType::ColumnWise; }
+
   // Computes mass and energy and tests against a tolerance.
   ResultAndMsg check () const override;
 

--- a/components/eamxx/src/share/property_checks/property_check.cpp
+++ b/components/eamxx/src/share/property_checks/property_check.cpp
@@ -75,4 +75,36 @@ void PropertyCheck::check_and_repair () const {
   }
 }
 
+bool PropertyCheck::same_as (const PropertyCheck& pc) const
+{
+  if (this->name()!=pc.name()) {
+    return false;
+  }
+
+  for (const auto& f : m_fields) {
+    bool found = false;
+    for (const auto& pc_f : pc.fields()) {
+      if (f.get_header().get_identifier()==pc_f.get_header().get_identifier()) {
+        found = true;
+      }
+    }
+    if (not found) {
+      return false;
+    }
+  }
+
+  for (const auto& f : m_repairable_fields) {
+    bool found = false;
+    for (const auto& pc_f : pc.repairable_fields()) {
+      if (f->get_header().get_identifier()==pc_f->get_header().get_identifier()) {
+        found = true;
+      }
+    }
+    if (not found) {
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace scream

--- a/components/eamxx/src/share/property_checks/property_check.hpp
+++ b/components/eamxx/src/share/property_checks/property_check.hpp
@@ -61,8 +61,10 @@ public:
     CheckResult       result;
     std::string       msg;
 
-    // For pointwise checks, if failing, can return indices where test failed
-    std::vector<int>  fail_indices;
+    // For pointwise/columnwise checks, if failing, can return tags/indices
+    // for the location where the test failed.
+    std::vector<int>        fail_loc_indices;
+    std::vector<FieldTag>   fail_loc_tags;
   };
 
   virtual PropertyType type () const = 0;

--- a/components/eamxx/src/share/property_checks/property_check.hpp
+++ b/components/eamxx/src/share/property_checks/property_check.hpp
@@ -43,6 +43,12 @@ enum class CheckResult {
   Repairable
 };
 
+enum class PropertyType {
+  PointWise,    // The property is computed pointwise at each entry of the field(s)
+  ColumnWise,   // The property is computed over each column of the field(s)
+  Global        // The property is computed globally
+};
+
 class PropertyCheck {
 public:
 
@@ -58,6 +64,8 @@ public:
     // For pointwise checks, if failing, can return indices where test failed
     std::vector<int>  fail_indices;
   };
+
+  virtual PropertyType type () const = 0;
 
   // Check if the property is satisfied, and return true if it is
   virtual ResultAndMsg check () const = 0;

--- a/components/eamxx/src/share/property_checks/property_check.hpp
+++ b/components/eamxx/src/share/property_checks/property_check.hpp
@@ -52,8 +52,11 @@ public:
   virtual std::string name () const = 0;
 
   struct ResultAndMsg {
-    CheckResult   result;
-    std::string   msg;
+    CheckResult       result;
+    std::string       msg;
+
+    // For pointwise checks, if failing, can return indices where test failed
+    std::vector<int>  fail_indices;
   };
 
   // Check if the property is satisfied, and return true if it is

--- a/components/eamxx/src/share/property_checks/property_check.hpp
+++ b/components/eamxx/src/share/property_checks/property_check.hpp
@@ -93,6 +93,9 @@ public:
   // override this method.
   virtual void check_and_repair () const;
 
+  // Whether the input check is the same as this class
+  virtual bool same_as (const PropertyCheck& pc) const;
+
 protected:
   virtual void repair_impl () const {
     EKAT_ERROR_MSG ("Error! The method 'repair_impl' has not been overridden.\n"

--- a/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
@@ -126,7 +126,7 @@ create_field(const std::string& name, const std::shared_ptr<const AbstractGrid>&
 }
 
 // Helper function to create a remap file
-void create_remap_file(const ekat::Comm& comm, const std::string& filename, std::vector<std::int64_t>& dofs,
+void create_remap_file(const std::string& filename, std::vector<std::int64_t>& dofs,
                        const int na, const int nb, const int ns,
                        const std::vector<Real>& col, const std::vector<Real>& row, const std::vector<Real>& S) 
 {
@@ -202,7 +202,7 @@ TEST_CASE("coarsening_remap_nnz>nsrc") {
     }
   }
 
-  create_remap_file(comm, filename, dofs, ngdofs_src, ngdofs_tgt, nnz, col, row, S);
+  create_remap_file(filename, dofs, ngdofs_src, ngdofs_tgt, nnz, col, row, S);
   print (" -> creating map file ... done!\n",comm);
 
   // -------------------------------------- //
@@ -295,9 +295,8 @@ TEST_CASE("coarsening_remap_nnz>nsrc") {
         {
           const auto v_tgt = f.get_view<const Real*,Host>();
           for (int i=0; i<ntgt_gids; ++i) {
-            const auto gid = tgt_gids(i);
             Real cmp = 0;
-            for (int j=0; j<src_gids.size(); j++) {
+            for (size_t j=0; j<src_gids.size(); j++) {
               cmp += src_gids(j);
             }
             REQUIRE ( v_tgt(i)== cmp/src_gids.size() );
@@ -359,7 +358,7 @@ TEST_CASE ("coarsening_remap") {
     S.push_back(0.75);
   }
 
-  create_remap_file(comm, filename, dofs, ngdofs_src, ngdofs_tgt, nnz, col, row, S);
+  create_remap_file(filename, dofs, ngdofs_src, ngdofs_tgt, nnz, col, row, S);
   print (" -> creating map file ... done!\n",comm);
 
   // -------------------------------------- //
@@ -407,12 +406,10 @@ TEST_CASE ("coarsening_remap") {
 
   std::vector<int> field_col_size (src_f.size());
   std::vector<int> field_col_offset (src_f.size()+1,0);
-  int sum_fields_col_sizes = 0;
   for (int i=0; i<nfields; ++i) {
     const auto& f  = src_f[i];  // Doesn't matter if src or tgt
     const auto& fl = f.get_header().get_identifier().get_layout();
     field_col_size[i] = fl.size() / fl.dim(0);
-    sum_fields_col_sizes += field_col_size[i];
     field_col_offset[i+1] = field_col_offset[i]+field_col_size[i];
   }
 

--- a/components/eamxx/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/eamxx/src/share/tests/common_physics_functions_tests.cpp
@@ -111,22 +111,21 @@ void run_scalar_valued_fns(std::mt19937_64& engine)
   RealType T_ground_tmp;
   RealType T_ground=0;
   RealType phi_ground=100;
-  RealType p_ground=100000; //can't use p0 because that is a ScalarT which could be a pack
-  PF::lapse_T_for_psl(T_ground, p_ground,  phi_ground, lapse, T_ground_tmp );
+  PF::lapse_T_for_psl(T_ground, phi_ground, lapse, T_ground_tmp );
   REQUIRE( Check::approx_equal(T_ground_tmp,0.5*255.,test_tol) );
   REQUIRE( Check::equal(lapse,0.0065) );
   T_ground=300;
-  PF::lapse_T_for_psl(T_ground, p_ground,  phi_ground, lapse, T_ground_tmp );
+  PF::lapse_T_for_psl(T_ground, phi_ground, lapse, T_ground_tmp );
   REQUIRE( Check::approx_equal(T_ground_tmp,0.5*(290.5+T_ground),test_tol) );
   REQUIRE( Check::equal(lapse,0) );
   T_ground=290;
   phi_ground=10000;
-  PF::lapse_T_for_psl(T_ground, p_ground,  phi_ground, lapse, T_ground_tmp );
+  PF::lapse_T_for_psl(T_ground, phi_ground, lapse, T_ground_tmp );
   REQUIRE( Check::equal(T_ground_tmp, T_ground) );
   REQUIRE( Check::approx_equal( T_ground_tmp+lapse*phi_ground/g, 290.5 , test_tol) );
   T_ground=280;
   phi_ground=100;
-  PF::lapse_T_for_psl(T_ground, p_ground,  phi_ground, lapse, T_ground_tmp );
+  PF::lapse_T_for_psl(T_ground, phi_ground, lapse, T_ground_tmp );
   REQUIRE( Check::equal(T_ground_tmp, T_ground) );
   REQUIRE( Check::equal(lapse,0.0065) );
   
@@ -136,6 +135,7 @@ void run_scalar_valued_fns(std::mt19937_64& engine)
   // computed value close to exact solution when lapse rate is 6.5 K/km (typical conditions)
   // PSL lower than surface pressure whenever surface height > 0 m
   // PSL greater than surface pressure whenever surface height < 0 m
+  RealType p_ground=100000; //can't use p0 because that is a ScalarT which could be a pack
   REQUIRE( Check::equal(PF::calculate_psl(310 , p_ground, 0 ), p_ground) );
   REQUIRE( Check::equal(PF::calculate_psl( 2 , 2, 0 ), 2) );
   

--- a/components/eamxx/src/share/tests/field_utils.cpp
+++ b/components/eamxx/src/share/tests/field_utils.cpp
@@ -229,22 +229,19 @@ TEST_CASE ("print_field_hyperslab") {
     print_field_hyperslab(f,loc_tags,loc_idxs,out);
 
     std::stringstream expected;
-    expected <<
-      " -----------------------------------------------------------------------\n"
-      "     f" << to_string(fid.get_layout()) << "\n"
-      " -----------------------------------------------------------------------\n";
+    expected << "     f" << to_string(fid.get_layout()) << "\n\n";
       for (int gp1=0; gp1<ngp; ++gp1) {
         for (int gp2=0; gp2<ngp; ++gp2) {
-          expected <<  "\n  f(" << iel << "," << icmp << "," << gp1 << "," << gp2 << ",:)";
+          expected <<  "  f(" << iel << "," << icmp << "," << gp1 << "," << gp2 << ",:)";
           for (int lev=0; lev<nlev; ++lev) {
             if (lev % max_per_line == 0) {
               expected << "\n    ";
             }
             expected << v(iel,icmp,gp1,gp2,lev) << ", ";
           }
+          expected << "\n";
         }
       }
-      expected << "\n -----------------------------------------------------------------------\n";
 
     REQUIRE (out.str()==expected.str());
   }
@@ -255,18 +252,15 @@ TEST_CASE ("print_field_hyperslab") {
     print_field_hyperslab(f,loc_tags,loc_idxs,out);
 
     std::stringstream expected;
-    expected <<
-      " -----------------------------------------------------------------------\n"
-      "     f" << to_string(fid.get_layout()) << "\n"
-      " -----------------------------------------------------------------------\n";
-      expected <<  "\n  f(" << iel << ",:," << igp << "," << jgp << "," << ilev << ")";
+    expected << "     f" << to_string(fid.get_layout()) << "\n\n";
+      expected <<  "  f(" << iel << ",:," << igp << "," << jgp << "," << ilev << ")";
       for (int cmp=0; cmp<ncmp; ++cmp) {
         if (cmp % max_per_line == 0) {
           expected << "\n    ";
         }
         expected << v(iel,cmp,igp,jgp,ilev) << ", ";
       }
-      expected << "\n -----------------------------------------------------------------------\n";
+      expected << "\n";
 
     REQUIRE (out.str()==expected.str());
   }
@@ -277,13 +271,9 @@ TEST_CASE ("print_field_hyperslab") {
     print_field_hyperslab(f,loc_tags,loc_idxs,out);
 
     std::stringstream expected;
-    expected <<
-      " -----------------------------------------------------------------------\n"
-      "     f" << to_string(fid.get_layout()) << "\n"
-      " -----------------------------------------------------------------------\n";
-      expected <<  "\n  f(" << ekat::join(loc_idxs,",") << ")";
-      expected << "\n    " << v(iel,icmp,igp,jgp,ilev) << ", ";
-      expected << "\n -----------------------------------------------------------------------\n";
+    expected << "     f" << to_string(fid.get_layout()) << "\n\n";
+      expected <<  "  f(" << ekat::join(loc_idxs,",") << ")\n";
+      expected << "    " << v(iel,icmp,igp,jgp,ilev) << ", \n";
 
     REQUIRE (out.str()==expected.str());
   }

--- a/components/eamxx/src/share/tests/field_utils.cpp
+++ b/components/eamxx/src/share/tests/field_utils.cpp
@@ -7,6 +7,7 @@
 #include "share/field/field.hpp"
 #include "share/field/field_manager.hpp"
 #include "share/field/field_utils.hpp"
+#include "share/util/scream_setup_random_test.hpp"
 
 #include "share/grid/point_grid.hpp"
 
@@ -83,7 +84,7 @@ TEST_CASE("utils") {
     auto dim1 = fid.get_layout().dim(1);
     auto lsize = fid.get_layout().size();
     auto gsize = lsize*comm.size();
-    auto offset = comm.rank()*lsize; 
+    auto offset = comm.rank()*lsize;
     Kokkos::parallel_for(kt::RangePolicy(0,dim0*dim1),
                          KOKKOS_LAMBDA(int idx) {
       int i = idx / dim1;
@@ -106,7 +107,7 @@ TEST_CASE("utils") {
     auto dim1 = fid.get_layout().dim(1);
     auto lsize = fid.get_layout().size();
     auto gsize = lsize*comm.size();
-    auto offset = comm.rank()*lsize; 
+    auto offset = comm.rank()*lsize;
     Kokkos::parallel_for(kt::RangePolicy(0,dim0*dim1),
                          KOKKOS_LAMBDA(int idx) {
       int i = idx / dim1;
@@ -133,7 +134,7 @@ TEST_CASE("utils") {
     auto dim1 = fid.get_layout().dim(1);
     auto lsize = fid.get_layout().size();
     auto gsize = lsize*comm.size();
-    auto offset = comm.rank()*lsize; 
+    auto offset = comm.rank()*lsize;
     Kokkos::parallel_for(kt::RangePolicy(0,dim0*dim1),
                          KOKKOS_LAMBDA(int idx) {
       int i = idx / dim1;
@@ -155,7 +156,7 @@ TEST_CASE("utils") {
     auto dim0 = fid.get_layout().dim(0);
     auto dim1 = fid.get_layout().dim(1);
     auto lsize = fid.get_layout().size();
-    auto offset = comm.rank()*lsize; 
+    auto offset = comm.rank()*lsize;
     Kokkos::parallel_for(kt::RangePolicy(0,dim0*dim1),
                          KOKKOS_LAMBDA(int idx) {
       int i = idx / dim1;
@@ -179,6 +180,112 @@ TEST_CASE("utils") {
     REQUIRE_THROWS(field_max<int>(f1));
     REQUIRE_THROWS(field_sum<wrong_real>(f1));
     REQUIRE_THROWS(frobenius_norm<wrong_real>(f1));
+  }
+}
+
+TEST_CASE ("print_field_hyperslab") {
+  using namespace scream;
+  using namespace ekat::units;
+
+  using namespace ShortFieldTagsNames;
+  using RPDF = std::uniform_real_distribution<Real>;
+  using IPDF = std::uniform_int_distribution<int>;
+
+  // Setup random number generation
+  ekat::Comm comm(MPI_COMM_WORLD);
+  auto engine = setup_random_test ();
+  RPDF pdf(0,1);
+
+  const int nel = 2;
+  const int ncmp = 2;
+  const int ngp  = 4;
+  const int nlev = 12;
+  const int iel  = IPDF(0,nel-1)(engine);
+  const int icmp = IPDF(0,ncmp-1)(engine);
+  const int igp  = IPDF(0,ngp-1)(engine);
+  const int jgp  = IPDF(0,ngp-1)(engine);
+  const int ilev = IPDF(0,nlev-1)(engine);
+
+  // WARNING: make sure this value matches the one used in print_field_hyperslab
+  constexpr int max_per_line = 5;
+
+  // Create field (if available, use packs, to ensure we don't print garbage)
+  std::vector<FieldTag> tags = {EL, CMP, GP, GP, LEV};
+  std::vector<int>      dims = {nel,ncmp,ngp,ngp,nlev};
+  int pack_size = std::min(SCREAM_PACK_SIZE,4);
+
+  FieldIdentifier fid ("f", {tags,dims}, kg, "some_grid");
+  Field f (fid);
+  f.get_header().get_alloc_properties().request_allocation(pack_size);
+  f.allocate_view();
+  randomize (f,engine,pdf);
+
+  auto v = f.get_view<const Real*****,Host>();
+
+  SECTION ("slice_0") {
+    std::vector<FieldTag> loc_tags = {EL,CMP};
+    std::vector<int>      loc_idxs = {iel,icmp};
+    std::stringstream out;
+    print_field_hyperslab(f,loc_tags,loc_idxs,out);
+
+    std::stringstream expected;
+    expected <<
+      " -----------------------------------------------------------------------\n"
+      "     f" << to_string(fid.get_layout()) << "\n"
+      " -----------------------------------------------------------------------\n";
+      for (int gp1=0; gp1<ngp; ++gp1) {
+        for (int gp2=0; gp2<ngp; ++gp2) {
+          expected <<  "\n  f(" << iel << "," << icmp << "," << gp1 << "," << gp2 << ",:)";
+          for (int lev=0; lev<nlev; ++lev) {
+            if (lev % max_per_line == 0) {
+              expected << "\n    ";
+            }
+            expected << v(iel,icmp,gp1,gp2,lev) << ", ";
+          }
+        }
+      }
+      expected << "\n -----------------------------------------------------------------------\n";
+
+    REQUIRE (out.str()==expected.str());
+  }
+  SECTION ("slice_0234") {
+    std::vector<FieldTag> loc_tags = {EL,GP,GP,LEV};
+    std::vector<int>      loc_idxs = {iel,igp,jgp,ilev};
+    std::stringstream out;
+    print_field_hyperslab(f,loc_tags,loc_idxs,out);
+
+    std::stringstream expected;
+    expected <<
+      " -----------------------------------------------------------------------\n"
+      "     f" << to_string(fid.get_layout()) << "\n"
+      " -----------------------------------------------------------------------\n";
+      expected <<  "\n  f(" << iel << ",:," << igp << "," << jgp << "," << ilev << ")";
+      for (int cmp=0; cmp<ncmp; ++cmp) {
+        if (cmp % max_per_line == 0) {
+          expected << "\n    ";
+        }
+        expected << v(iel,cmp,igp,jgp,ilev) << ", ";
+      }
+      expected << "\n -----------------------------------------------------------------------\n";
+
+    REQUIRE (out.str()==expected.str());
+  }
+  SECTION ("slice_01234") {
+    std::vector<FieldTag> loc_tags = {EL,CMP,GP,GP,LEV};
+    std::vector<int>      loc_idxs = {iel,icmp,igp,jgp,ilev};
+    std::stringstream out;
+    print_field_hyperslab(f,loc_tags,loc_idxs,out);
+
+    std::stringstream expected;
+    expected <<
+      " -----------------------------------------------------------------------\n"
+      "     f" << to_string(fid.get_layout()) << "\n"
+      " -----------------------------------------------------------------------\n";
+      expected <<  "\n  f(" << ekat::join(loc_idxs,",") << ")";
+      expected << "\n    " << v(iel,icmp,igp,jgp,ilev) << ", ";
+      expected << "\n -----------------------------------------------------------------------\n";
+
+    REQUIRE (out.str()==expected.str());
   }
 }
 

--- a/components/eamxx/src/share/tests/vertical_interp_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_interp_tests.cpp
@@ -122,7 +122,6 @@ void run(){
       const int num_vert_packs = p_tgt.extent(0);
       const auto policy = ESU::get_default_team_policy(2, num_vert_packs);
       auto loc_layers_src = n_layers_src[i];
-      auto loc_layers_tgt = n_layers_tgt[i];
       Kokkos::parallel_for("scream_vert_interp_setup_loop", policy,
          	       KOKKOS_LAMBDA(MemberType const& team) {
           const int icol = team.league_rank();
@@ -136,7 +135,6 @@ void run(){
                                                  out_1d,
                                                  msk,
                                                  loc_layers_src,
-                                                 loc_layers_tgt,
                                                  icol,
                                                  masked_val,
                                                  team,
@@ -306,7 +304,6 @@ TEST_CASE("testing_masking"){
                                              out_1d,
                                              msk,
                                              n_layers_src,
-                                             n_layers_tgt,
                                              icol,
                                              masked_val,
                                              team,

--- a/components/eamxx/src/share/util/scream_common_physics_functions.hpp
+++ b/components/eamxx/src/share/util/scream_common_physics_functions.hpp
@@ -255,7 +255,7 @@ struct PhysicsFunctions
   // psl is the sea level pressure (Pa)
   //-----------------------------------------------------------------------------------------------//
   KOKKOS_INLINE_FUNCTION
-  static void lapse_T_for_psl(const Real& T_ground, const Real& p_ground, const Real& phi_ground,
+  static void lapse_T_for_psl(const Real& T_ground, const Real& phi_ground,
 				 Real& lapse, Real& T_ground_tmp );
 
   //-----------------------------------------------------------------------------------------------//

--- a/components/eamxx/src/share/util/scream_common_physics_functions_impl.hpp
+++ b/components/eamxx/src/share/util/scream_common_physics_functions_impl.hpp
@@ -430,7 +430,7 @@ Real PhysicsFunctions<DeviceT>::calculate_surface_air_T(const Real& T_mid_bot, c
 
 template<typename DeviceT>
 KOKKOS_INLINE_FUNCTION
-void PhysicsFunctions<DeviceT>::lapse_T_for_psl(const Real& T_ground, const Real& p_ground, const Real& phi_ground,
+void PhysicsFunctions<DeviceT>::lapse_T_for_psl(const Real& T_ground, const Real& phi_ground,
 					        Real& lapse, Real& T_ground_tmp )
 {
   /* 
@@ -487,7 +487,7 @@ Real PhysicsFunctions<DeviceT>::calculate_psl(const Real& T_ground, const Real& 
   }else{
     Real lapse;
     Real T_ground_tmp;
-    lapse_T_for_psl(T_ground,p_ground,phi_ground, lapse, T_ground_tmp);
+    lapse_T_for_psl(T_ground,phi_ground, lapse, T_ground_tmp);
     Real alpha=lapse*Rair/gravit;
     Real beta=phi_ground/(Rair*T_ground_tmp);
     psl = p_ground*std::exp(beta*( 1 - alpha*beta/2 + std::pow(alpha*beta,2)/3 ) );

--- a/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
+++ b/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
@@ -74,7 +74,6 @@ void perform_vertical_interpolation_impl_2d(
 {
   const int ncols = x_src.extent(0);
   //Do a bunch of checks to make sure that Pack<T,N>s are consistent
-  auto npacks_src = ekat::PackInfo<Pack<T,N>::n>::num_packs(nlevs_src);
   auto npacks_tgt = ekat::PackInfo<Pack<T,N>::n>::num_packs(nlevs_tgt);
   EKAT_REQUIRE(x_src.extent(0)==input.extent(0));
   EKAT_REQUIRE(x_src.extent(1)==input.extent(1));
@@ -122,7 +121,6 @@ void perform_vertical_interpolation_impl_1d(
   const view_1d<Pack<T,N>>& output,
   const view_1d<Mask<N>>& mask,
   const int nlevs_src,
-  const int nlevs_tgt,
   const int icol,
   const Real msk_val,
   const MemberType& team,


### PR DESCRIPTION
This PR adds a few concepts/features:

- Allow to print a field at a particular hyperslab. E.g., print `f(1,:,2,3,:)`.
- Allow property checks to return a location where the check failed
- When a property check fail (and fail checks are fatal), if the property check provided a location, we print all input/output fields of the atm process at that location. We only print fields with a "compatible" layout (e.g., if the location of the fail has tags `<COL,LEV>`, we won't print fields with layout `<EL,GP,GP,LEV>`.
- Add the XML option `driver_options::check_all_computed_fields_for_nans`, which defaults to true, and causes the AD to add a `FieldNaNCheck` property check for _all_ computed fields after _each_ atm process.

@ambrad, @PeterCaldwell @crterai @AaronDonahue  @brhillman Question for the model experts: I did not add a feature like in Homme, where we print a whole column worth of data when EOS errors out. Right now, if there's a failed check for a field at col=A,lev=B, I print all other fields at col=A,lev=B. I could probably prune the LEV/ILEV tag/index (if present) before calling the method that prints the hyperslab. Would that be preferable? Or is the current impl ok?

As an example, I hardcoded a NaN in shoc, and ran a test. It generated the following error message.

[snippet.txt](https://github.com/E3SM-Project/scream/files/10145054/snippet.txt)

Of course, formatting is up for debate.