### PR TITLE
Crusher: Temporarily run nightlies with netcdf.

### DIFF
--- a/cime_config/machines/config_pio.xml
+++ b/cime_config/machines/config_pio.xml
@@ -52,6 +52,7 @@
       <value mach="melvin">netcdf</value>
       <value mach="mappy">netcdf</value>
       <value mach="weaver">netcdf</value>
+      <value mach="crusher-gpu">netcdf</value>
       <value mach="eastwind">netcdf</value>
       <value mach="constance">netcdf</value>
       <value mach="cascade">netcdf</value>


### PR DESCRIPTION
The trace
  SCORPIO -> PnetCDF -> pio_darray_int.c -> flush_output_buffer -> ncmpi_wait_all
is seg faulting randomly and so far has defeated every attempted workaround.

I want to see if our crusher-gpu nightlies are solidly green except for this. Thus, temporarily set the PIO type to netcdf.