### PR TITLE
Crusher: Simplify modules.

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -805,21 +805,16 @@
       <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
       <modules compiler="crayclang">
         <command name="reset"></command>
-        <command name="switch">PrgEnv-cray PrgEnv-cray/8.3.3</command>
-        <command name="switch">cce cce/14.0.0</command>
-
+        <command name="load">PrgEnv-cray</command>
         <command name="load">craype-accel-amd-gfx90a</command>
         <command name="load">rocm/5.1.0</command>
       </modules>
-
       <modules>
-        <command name="load">cray-mpich/8.1.16</command>
         <command name="load">cray-python/3.9.4.2</command>
         <command name="load">subversion/1.14.0</command>
         <command name="load">git/2.31.1</command>
         <command name="load">cmake/3.21.3</command>
         <command name="load">zlib/1.2.11</command>
-        <command name="load">cray-libsci/21.08.1.2</command>
         <command name="load">cray-hdf5-parallel/1.12.1.1</command>
         <command name="load">cray-netcdf-hdf5parallel/4.8.1.1</command>
         <command name="load">cray-parallel-netcdf/1.12.1.7</command>


### PR DESCRIPTION
Use default PrgEnv-cray rather than hardcoded version. Remove non-default libsci and cray-mpich; the defaults are loaded with PrgEnv-cray.