### PR TITLE
Fix treatment of diagnostics in IO

### DIFF
--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -184,6 +184,12 @@ void AtmosphereOutput::run (const std::string& filename, const bool is_write_ste
 
   using namespace scream::scorpio;
 
+  // Update all diagnostics, we need to do this before applying the remapper
+  // to make sure that the remapped fields are the most up to date.
+  for (auto const& name : m_fields_names) {
+    update_field(name); // Note, if the field is a diagnostic this will update it.
+  }
+
   // If needed, remap fields from their grid to the unique grid, for I/O
   if (m_remapper) {
     start_timer("EAMxx::IO::remap");
@@ -204,7 +210,6 @@ void AtmosphereOutput::run (const std::string& filename, const bool is_write_ste
   // Take care of updating and possibly writing fields.
   for (auto const& name : m_fields_names) {
     // Get all the info for this field.
-    update_field(name); // If diagnostic, must evaluate it
     const auto  field = get_field(name);
     const auto& layout = m_layouts.at(name);
     const auto& dims = layout.dims();
@@ -685,7 +690,7 @@ void AtmosphereOutput::update_field(const std::string& name) const
 // manager.  If not it will next check to see if it is in the list
 // of available diagnostics.  If neither of these two options it
 // will throw an error.
-Field AtmosphereOutput::get_field(const std::string& name, const bool eval_diagnostic) const
+Field AtmosphereOutput::get_field(const std::string& name) const
 {
   if (m_field_mgr->has_field(name)) {
     return m_field_mgr->get_field(name);

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -707,11 +707,11 @@ Field AtmosphereOutput::get_field(const std::string& name, const std::shared_ptr
 {
   if (field_mgr->has_field(name)) {
     return field_mgr->get_field(name);
-  } else if (m_diagnostics.find(name) != m_diagnostics.end()) {
+  } else if (m_diagnostics.find(name) != m_diagnostics.end() && field_mgr==m_sim_field_mgr) {
     const auto& diag = m_diagnostics.at(name);
     return diag->get_diagnostic();
   } else {
-    EKAT_ERROR_MSG ("Field " + name + " not found in output field manager or diagnostics list");
+    EKAT_ERROR_MSG ("Field " + name + " not found in output field manager or diagnostics list, or requesting a diag not on the simualation field manager.");
   }
 }
 /* ---------------------------------------------------------- */

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -191,11 +191,8 @@ void AtmosphereOutput::run (const std::string& filename, const bool is_write_ste
   // to make sure that the remapped fields are the most up to date.
   // First we reset the diag computed map so that all diags are recomputed.
   m_diag_computed.clear();
-  for (auto const& name : m_fields_names) {
-    auto it = m_diagnostics.find(name);
-    if (it != m_diagnostics.end()) {
-      compute_diagnostic(name); 
-    }
+  for (auto& it : m_diagnostics) {
+    compute_diagnostic(it.first);
   }
 
   // If needed, remap fields from their grid to the unique grid, for I/O

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -157,7 +157,8 @@ protected:
   void set_degrees_of_freedom(const std::string& filename);
   std::vector<scorpio::offset_t> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
-  Field get_field(const std::string& name, const bool eval_diagnostic = false) const;
+  Field get_field(const std::string& name) const;
+  void update_field(const std::string& name) const;
   void set_diagnostics();
   void create_diagnostic (const std::string& diag_name);
 

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -149,7 +149,7 @@ public:
   long long res_dep_memory_footprint () const;
 protected:
   // Internal functions
-  void set_field_manager (const std::shared_ptr<const fm_type>& field_mgr);
+  void set_field_manager (const std::shared_ptr<const fm_type>& field_mgr, const std::string& mode);
   void set_grid (const std::shared_ptr<const AbstractGrid>& grid);
 
   void register_dimensions(const std::string& name);
@@ -157,7 +157,7 @@ protected:
   void set_degrees_of_freedom(const std::string& filename);
   std::vector<scorpio::offset_t> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
-  Field get_field(const std::string& name) const;
+  Field get_field(const std::string& name, const std::shared_ptr<const fm_type>& field_mgr) const;
   void update_field(const std::string& name) const;
   void set_diagnostics();
   void create_diagnostic (const std::string& diag_name);
@@ -165,7 +165,12 @@ protected:
   // --- Internal variables --- //
   ekat::Comm                          m_comm;
 
-  std::shared_ptr<const fm_type>      m_field_mgr;
+  // We store two shared pointers for field managers:
+  // io_field_manager stores the fields in the layout for output
+  // sim_field_manager points to the simulation field manager
+  // when remapping horizontally these two field managers may be different.
+  std::shared_ptr<const fm_type>      m_io_field_mgr;
+  std::shared_ptr<const fm_type>      m_sim_field_mgr;
   std::shared_ptr<const grid_type>    m_io_grid;
   std::shared_ptr<remapper_type>      m_remapper;
   std::shared_ptr<const gm_type>      m_grids_manager;

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -158,7 +158,7 @@ protected:
   std::vector<scorpio::offset_t> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
   Field get_field(const std::string& name, const std::shared_ptr<const fm_type>& field_mgr) const;
-  void update_field(const std::string& name) const;
+  void compute_diagnostic(const std::string& name);
   void set_diagnostics();
   void create_diagnostic (const std::string& diag_name);
 
@@ -185,6 +185,7 @@ protected:
   std::map<std::string,int>                             m_dims;
   std::map<std::string,std::shared_ptr<atm_diag_type>>  m_diagnostics;
   std::map<std::string,std::vector<std::string>>        m_diag_depends_on_diags;
+  std::map<std::string,bool>                            m_diag_computed;
 
   // Local views of each field to be used for "averaging" output and writing to file.
   std::map<std::string,view_1d_host>    m_host_views_1d;


### PR DESCRIPTION
This commit fixes an issue where the treatment of diagnostics in IO led to errors when writing diagnostics as regional output.  This redefines the `get_field` function in `scorpio_output` to accomodate multiple field managers (simulation and IO) which we get when doing regional output.

Note, diagnostics are a special case because they must be calculated on the simulation grid using field managed variables from the simulation, before they are remapped.

With this commit in it should be possible to do regional output for all available variables.