### PR TITLE
Crusher: Specialize v1_long test group to Crusher.

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -521,6 +521,15 @@ _TESTS = {
             )
     },
 
+    "e3sm_scream_v1_long_crusher" : {
+        # _D builds take a long longer on crusher than ascent or pm-gpu, so
+        # don't run the long _D test.
+        "time"  : "01:00:00",
+        "tests" : (
+            "ERS_Ln362.ne30pg2_ne30pg2.F2010-SCREAMv1"
+            )
+    },
+
     "e3sm_gpuacc" : {
         "tests"    : (
                  "SMS_Ld1.T62_oEC60to30v3.CMPASO-NYF",


### PR DESCRIPTION
On ascent and pm-gpu, ERP_D_Lh182.ne4pg2_ne4pg2.F2010-SCREAMv1 takes < 8 min to run, but on crusher-gpu, it takes hours. Thus, make a special v1_long group for Crusher.