### PR TITLE
Add a way to track alternate field names in output for certain diagnostics

### DIFF
--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -710,6 +710,8 @@ Field AtmosphereOutput::get_field(const std::string& name, const std::shared_ptr
   } else if (m_diagnostics.find(name) != m_diagnostics.end() && field_mgr==m_sim_field_mgr) {
     const auto& diag = m_diagnostics.at(name);
     return diag->get_diagnostic();
+  } else if (m_fields_alt_name.find(name) != m_fields_alt_name.end() && field_mgr->has_field(m_fields_alt_name.at(name))) {
+    return field_mgr->get_field(m_fields_alt_name.at(name));
   } else {
     EKAT_ERROR_MSG ("Field " + name + " not found in output field manager or diagnostics list, or requesting a diag not on the simualation field manager.");
   }
@@ -765,6 +767,7 @@ create_diagnostic (const std::string& diag_field_name) {
     diag_name = "FieldAtLevel";
     tokens.pop_back();
     auto fname = ekat::join(tokens,"_");
+    m_fields_alt_name.emplace(diag_field_name,fname);
     // If the field is itself a diagnostic, make sure it's built
     if (diag_factory.has_product(fname) and
         m_diagnostics.count(fname)==0) {
@@ -793,6 +796,7 @@ create_diagnostic (const std::string& diag_field_name) {
     }
     tokens.pop_back();
     auto fname = ekat::join(tokens,"_");
+    m_fields_alt_name.emplace(diag_field_name,fname);
     // If the field is itself a diagnostic, make sure it's built
     if (diag_factory.has_product(fname) and
         m_diagnostics.count(fname)==0) {

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -180,6 +180,7 @@ protected:
 
   // Internal maps to the output fields, how the columns are distributed, the file dimensions and the global ids.
   std::vector<std::string>                              m_fields_names;
+  std::map<std::string,std::string>                     m_fields_alt_name;
   std::map<std::string,FieldLayout>                     m_layouts;
   std::map<std::string,int>                             m_dofs;
   std::map<std::string,int>                             m_dims;

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_diagnostics.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_diagnostics.yaml
@@ -16,10 +16,10 @@ Fields:
       - AtmosphereDensity
       - Exner
       - VirtualTemperature
-#      - VerticalLayerInterface
+      - VerticalLayerInterface
       - VerticalLayerThickness
-#      - VerticalLayerMidpoint
-#      - DryStaticEnergy
+      - VerticalLayerMidpoint
+      - DryStaticEnergy
       - SeaLevelPressure
       - LiqWaterPath
       - IceWaterPath
@@ -32,6 +32,8 @@ Fields:
       - ZonalVapFlux
       - MeridionalVapFlux
       - IceCloudMask
+      - PotentialTemperature@tom
+      - PotentialTemperature@500mb
  
 output_control:
   Frequency: ${NUM_STEPS}


### PR DESCRIPTION
This commit adds a map to scorpio_output that tracks alternate names that may exist for a specific output stream.  This is useful for sliced fields which have a name like X@tom for example but would take the name X_lev_0 under-the-hood.

When using a remapper the io_fm stores the latter name for the field while the field name itself is queried in `get_field` using the former name.  We didn't catch this before because the second check would default to calculating the diagnostic as expected.  It wasn't until we added the check that we only grab diagnostics on the sim_field_mgr that this issue was found.