### PR TITLE
EAMxx: fix valgrind error in FieldWithinIntervalCheck

### DIFF
--- a/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
@@ -198,7 +198,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
   }
   PropertyCheck::ResultAndMsg res_and_msg;
 
-  bool pass_lower, pass_upper;
+  bool pass_lower = false, pass_upper = false;
 
   if (minmaxloc.min_val>=m_lb && minmaxloc.max_val<=m_ub) {
     res_and_msg.result = CheckResult::Pass;


### PR DESCRIPTION
Fixes valgrind error `Conditional jump or move depends on uninitialised value(s)`.