### PR TITLE
Do less rad work

### DIFF
--- a/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -873,10 +873,12 @@ void RRTMGPRadiation::run_impl (const int dt) {
     // does not matter in practice, as clouds probably should not be produced above 50 hPa and we
     // should not be encountering surface pressure above 1200 hPa, but in the event that things go off
     // the rails we might want to look at these still.
-    rrtmgp::compute_cloud_area(ncol, nlay, nlwgpts, 700e2, std::numeric_limits<Real>::max(), p_lay, cld_tau_lw_gpt, cldlow);
-    rrtmgp::compute_cloud_area(ncol, nlay, nlwgpts, 400e2,                            700e2, p_lay, cld_tau_lw_gpt, cldmed);
-    rrtmgp::compute_cloud_area(ncol, nlay, nlwgpts,     0,                            400e2, p_lay, cld_tau_lw_gpt, cldhgh);
-    rrtmgp::compute_cloud_area(ncol, nlay, nlwgpts,     0, std::numeric_limits<Real>::max(), p_lay, cld_tau_lw_gpt, cldtot);
+    if (update_rad) {
+      rrtmgp::compute_cloud_area(ncol, nlay, nlwgpts, 700e2, std::numeric_limits<Real>::max(), p_lay, cld_tau_lw_gpt, cldlow);
+      rrtmgp::compute_cloud_area(ncol, nlay, nlwgpts, 400e2,                            700e2, p_lay, cld_tau_lw_gpt, cldmed);
+      rrtmgp::compute_cloud_area(ncol, nlay, nlwgpts,     0,                            400e2, p_lay, cld_tau_lw_gpt, cldhgh);
+      rrtmgp::compute_cloud_area(ncol, nlay, nlwgpts,     0, std::numeric_limits<Real>::max(), p_lay, cld_tau_lw_gpt, cldtot);
+    }
 
     // Copy output data back to FieldManager
     if (update_rad) {

--- a/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -765,11 +765,13 @@ void RRTMGPRadiation::run_impl (const int dt) {
 
     // Compute band-by-band surface_albedos. This is needed since
     // the AD passes broadband albedos, but rrtmgp require band-by-band.
-    rrtmgp::compute_band_by_band_surface_albedos(
-      ncol, nswbands,
-      sfc_alb_dir_vis, sfc_alb_dir_nir,
-      sfc_alb_dif_vis, sfc_alb_dif_nir,
-      sfc_alb_dir, sfc_alb_dif);
+    if (update_rad) {
+      rrtmgp::compute_band_by_band_surface_albedos(
+        ncol, nswbands,
+        sfc_alb_dir_vis, sfc_alb_dir_nir,
+        sfc_alb_dif_vis, sfc_alb_dif_nir,
+        sfc_alb_dir, sfc_alb_dif);
+    }
 
     // Compute cloud optical properties here?
 
@@ -791,10 +793,10 @@ void RRTMGPRadiation::run_impl (const int dt) {
     }
 
     // Compute and apply heating tendency
-    auto sw_heating  = m_buffer.sw_heating;
-    auto lw_heating  = m_buffer.lw_heating;
     auto rad_heating = m_buffer.rad_heating;
     if (update_rad) {
+      auto sw_heating  = m_buffer.sw_heating;
+      auto lw_heating  = m_buffer.lw_heating;
       rrtmgp::compute_heating_rate(
         sw_flux_up, sw_flux_dn, p_del, sw_heating
       );

--- a/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -103,7 +103,7 @@ public:
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {
     static constexpr int num_1d_ncol        = 10;
-    static constexpr int num_2d_nlay        = 14;
+    static constexpr int num_2d_nlay        = 13;
     static constexpr int num_2d_nlay_p1     = 12;
     static constexpr int num_2d_nswbands    = 2;
     static constexpr int num_3d_nlev_nswbands = 4;
@@ -139,7 +139,6 @@ public:
     real2d iwp;
     real2d sw_heating;
     real2d lw_heating;
-    real2d rad_heating;
 
     // 2d size (ncol, nlay+1)
     real2d p_lev;


### PR DESCRIPTION
Do less rad work on timesteps where rad heating is not updated. This bypasses the entire chunk loop and all rad calls (like cloud optics and gas concentrations) when fluxes and heating rates are not updated. Previously there was still a non-trivial amount of data wrangling and computation on each timestep.