### PR TITLE
Add SCREAMv1 DYAMOND-2 compsets and support files

### DIFF
--- a/components/data_comps/docn/cime_config/config_component.xml
+++ b/components/data_comps/docn/cime_config/config_component.xml
@@ -187,6 +187,7 @@
       <value compset="2010.*_" grid=".+"					        >$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_2010_clim_c20190821.nc</value>
       <value compset="2010_SCREAM_" grid="ne120.*|ne256.*|ne512.*|ne1024.*"	        >$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_HighResMIP_E3SM_0.25x0.25_2010_clim_c20190125_intoisst.nc</value>
       <value compset="2010_SCREAM%DYAMOND-1"       	                                >$DIN_LOC_ROOT/atm/cam/sst/sst_ifs_2560x5136_20160725_20160916_c201013.nc</value>
+      <value compset="2010_SCREAM%DYAMOND-2"       	                                >$DIN_LOC_ROOT/atm/cam/sst/sst_ifs_360x720_20200110_20200305_c201013.nc</value>
       <value compset="20TR_CAM5%CMIP6" grid=".+"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_c20180213.nc</value>
       <value compset="20TR_EAM%CMIP6" grid=".+"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_c20180213.nc</value>
       <value compset="20TR_EAM%MMF.*CMIP6" grid=".+" >$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_c20180213.nc</value>
@@ -222,6 +223,7 @@
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.23x0.31.*_oi%0.23x0.31"	>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.23x0.31_gx1v6_101108.nc</value>
       <value compset="2010_SCREAM_" grid="ne120.*|ne256.*|ne512.*|ne1024.*"			>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.0.25x0.25.c20190221.nc</value>
       <value compset="2010_SCREAM%DYAMOND-1"     			                        >$DIN_LOC_ROOT/ocn/docn7/domain.ocn.2560x5136.201027.nc</value>
+      <value compset="2010_SCREAM%DYAMOND-2"     			                        >$DIN_LOC_ROOT/ocn/docn7/domain.ocn.360x720.201027.nc</value>
       <value compset="1850" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.1x1.111007.nc</value>
       <value compset="1850" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.48x96_gx3v7_100114.nc</value>
       <value compset="1850" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.1.9x2.5_gx1v6_090403.nc</value>
@@ -252,6 +254,7 @@
       <value compset="20TR_EAM%CMIP6">1869</value>
       <value compset="20TR_EAM%MMF.*CMIP6">1869</value>
       <value compset="2010_SCREAM%DYAMOND-1">2016</value>
+      <value compset="2010_SCREAM%DYAMOND-2">2020</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -279,6 +282,7 @@
       <value compset="20TR_EAM%CMIP6">1869</value>
       <value compset="20TR_EAM%MMF.*CMIP6">1869</value>
       <value compset="2010_SCREAM%DYAMOND-1">2016</value>
+      <value compset="2010_SCREAM%DYAMOND-2">2020</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -300,6 +304,7 @@
       <value compset="20TR_EAM%CMIP6">2016</value>
       <value compset="20TR_EAM%MMF.*CMIP6">2016</value>
       <value compset="2010_SCREAM%DYAMOND-1">2016</value>
+      <value compset="2010_SCREAM%DYAMOND-2">2020</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>

--- a/components/eamxx/cime_config/config_compsets.xml
+++ b/components/eamxx/cime_config/config_compsets.xml
@@ -40,6 +40,18 @@
   </compset>
 
   <compset>
+      <alias>F2010-SCREAMv1-DYAMOND2</alias> <!-- Coupled land-atm compset (using SCREAMv1), DYAMOND-2 initial conditions with 16x smoothed topography-->
+      <lname>2010_SCREAM%DYAMOND-2_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP</lname>
+      <support_level>Experimental, under development</support_level>
+  </compset>
+
+  <compset>
+      <alias>F2010-SCREAMv1-DYAMOND2-X6T</alias> <!-- Coupled land-atm compset (using SCREAMv1), DYAMOND-2 initial conditions with X6T topography-->
+      <lname>2010_SCREAM%DYAMOND-2-X6T_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP</lname>
+      <support_level>Experimental, under development</support_level>
+  </compset>
+
+  <compset>
       <alias>F2010-SCREAMv1-MPASSI</alias> <!-- Coupled land-atm compset (using SCREAMv1), 2010 initial conditions -->
       <lname>2010_SCREAM_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP</lname>
       <support_level>Experimental, under development</support_level>

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -292,6 +292,8 @@ tweaking their $case/namelist_scream.xml file.
     <Filename hgrid="ne1024np4">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_era5-20131001-topoadj-16x_20220914.nc</Filename>
     <Filename hgrid="ne1024np4" COMPSET=".*SCREAM%DYAMOND-1_ELM">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_ifs-20160801-topoadj16x_20221011.nc</Filename>
     <Filename hgrid="ne1024np4" COMPSET=".*SCREAM%DYAMOND-1-X6T_ELM">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_ifs-20160801-topoadjx6t_20221011.nc</Filename>
+    <Filename hgrid="ne1024np4" COMPSET=".*SCREAM%DYAMOND-2_ELM">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_ifs-20200120-topoadj16x_20221012.nc</Filename>
+    <Filename hgrid="ne1024np4" COMPSET=".*SCREAM%DYAMOND-2-X6T_ELM">${DIN_LOC_ROOT}/atm/scream/init/screami_ne1024np4L128_ifs-20200120-topoadjx6t_20221011.nc</Filename>
     <Filename hgrid="ne4np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/screami_aquaplanet_ne4np4L72_20220823.nc</Filename>
     <Filename hgrid="ne30np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/screami_aquaplanet_ne30np4L128_20220823.nc</Filename> <!-- This will need to be updated to the new nccn name -->
 

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -262,8 +262,9 @@ ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".true." irrigate=".true." nu_co
 <finidat hgrid="ne0np4_enax4v1" sim_year="2000">lnd/clm2/initdata_map/clmi.ICRUCLM45SP.2000-01-01.enax4v1_oRRS18to6_simyr2000_c180430.nc</finidat>
 <finidat hgrid="ne0np4_twpx4v1" ic_ymd="101" sim_year="2000">lnd/clm2/initdata_map/clmi.ICRUCLM45SP.2000-01-01.twpx4v1_oRRS18to6v3_simyr2000_c180430.nc</finidat>
 
-<!-- Initial conditions for DYAMOND1 -->
+<!-- Initial conditions for DYAMOND1, DYAMOND2 and for seasons of ENSO neutral year 2013 -->
 <finidat hgrid="ne1024np4.pg2" mask="ICOS10" ic_ymd="20160801">lnd/clm2/initdata/20220928.I2010CRUELM.ne1024pg2_ICOS10.elm.r.2016-08-01-00000.nc</finidat>
+<finidat hgrid="ne1024np4.pg2" mask="ICOS10" ic_ymd="20200120">lnd/clm2/initdata/20221218.F2010-CICE.ne30pg2_ne1024pg2.elm.r.2020-01-20-00000.nc</finidat>
 <finidat hgrid="ne1024np4.pg2" mask="ICOS10" ic_ymd="101">lnd/clm2/initdata/20220717.I2010CRUELM.ne1024pg2_ICOS10.elm.r.2013-01-01-00000.nc</finidat>
 <finidat hgrid="ne1024np4.pg2" mask="ICOS10" ic_ymd="401">lnd/clm2/initdata/20220717.I2010CRUELM.ne1024pg2_ICOS10.elm.r.2013-04-01-00000.nc</finidat>
 <finidat hgrid="ne1024np4.pg2" mask="ICOS10" ic_ymd="701">lnd/clm2/initdata/20220717.I2010CRUELM.ne1024pg2_ICOS10.elm.r.2013-07-01-00000.nc</finidat>


### PR DESCRIPTION
Two compsets are added: F2010-SCREAMv1-DYAMOND2 and F2010-SCREAMv1-DYAMOND2-X6T
with the distinction in using 16x (smoother) or x6t topography. 

The following are automatically set for cases created with either DYAMOND2 compset
atm IC, lnd IC, prescribed sst/seaice data, and RUN_STARTDATE (2020-01-20).

[BFB] 