### PR TITLE
Add a vertical remapper to EAMxx IO

### DIFF
--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SHARE_SRC
   grid/point_grid.cpp
   grid/remap/abstract_remapper.cpp
   grid/remap/coarsening_remapper.cpp
+  grid/remap/vertical_remapper.cpp
   grid/remap/horizontal_remap_utility.cpp
   property_checks/property_check.cpp
   property_checks/field_nan_check.cpp

--- a/components/eamxx/src/share/grid/grids_manager.hpp
+++ b/components/eamxx/src/share/grid/grids_manager.hpp
@@ -51,6 +51,12 @@ public:
 
   const grid_repo_type& get_repo () const { return m_grids; }
 
+  void print() const {
+    auto avail_grids = print_available_grids();
+    printf("List of available grids in grids manager:\n");
+    printf("   - %s\n",avail_grids.c_str());
+  }
+
 protected:
   using nonconstgrid_ptr_type     = std::shared_ptr<grid_type>;
   using nonconstgrid_repo_type    = std::map<std::string, nonconstgrid_ptr_type>;

--- a/components/eamxx/src/share/grid/grids_manager.hpp
+++ b/components/eamxx/src/share/grid/grids_manager.hpp
@@ -51,12 +51,6 @@ public:
 
   const grid_repo_type& get_repo () const { return m_grids; }
 
-  void print() const {
-    auto avail_grids = print_available_grids();
-    printf("List of available grids in grids manager:\n");
-    printf("   - %s\n",avail_grids.c_str());
-  }
-
 protected:
   using nonconstgrid_ptr_type     = std::shared_ptr<grid_type>;
   using nonconstgrid_repo_type    = std::map<std::string, nonconstgrid_ptr_type>;

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -814,7 +814,7 @@ void CoarseningRemapper::create_ov_tgt_fields ()
   m_ov_tgt_fields.reserve(m_num_fields);
   const int num_ov_cols = m_ov_tgt_grid->get_num_local_dofs();
   const auto ov_gn = m_ov_tgt_grid->name();
-  // for (const auto& f : m_tgt_fields) {
+  // for (const auto& f : m_tgt_fields) { //TODO should we delete this line?
   for (int i=0; i<m_num_fields; ++i) {
     const auto& f_src = m_src_fields[i];
     const auto& f_tgt = m_tgt_fields[i];

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -814,7 +814,6 @@ void CoarseningRemapper::create_ov_tgt_fields ()
   m_ov_tgt_fields.reserve(m_num_fields);
   const int num_ov_cols = m_ov_tgt_grid->get_num_local_dofs();
   const auto ov_gn = m_ov_tgt_grid->name();
-  // for (const auto& f : m_tgt_fields) { //TODO should we delete this line?
   for (int i=0; i<m_num_fields; ++i) {
     const auto& f_src = m_src_fields[i];
     const auto& f_tgt = m_tgt_fields[i];

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -1,0 +1,265 @@
+#include "vertical_remapper.hpp"
+
+#include "share/grid/point_grid.hpp"
+#include "share/util/scream_vertical_interpolation.hpp"
+#include "share/io/scorpio_input.hpp"
+
+#include <ekat/kokkos/ekat_kokkos_utils.hpp>
+#include <ekat/ekat_pack_utils.hpp>
+#include <ekat/ekat_pack_kokkos.hpp>
+
+#include <numeric>
+
+namespace scream
+{
+
+VerticalRemapper::
+VerticalRemapper (const grid_ptr_type& src_grid,
+                    const std::string& map_file)
+ : AbstractRemapper()
+ , m_comm (src_grid->get_comm())
+{
+  using namespace ShortFieldTagsNames;
+
+  // Sanity checks
+  EKAT_REQUIRE_MSG (src_grid->type()==GridType::Point,
+      "Error! VerticalRemapper only works on PointGrid grids.\n"
+      "  - src grid name: " + src_grid->name() + "\n"
+      "  - src_grid_type: " + e2str(src_grid->type()) + "\n");
+  EKAT_REQUIRE_MSG (src_grid->is_unique(),
+      "Error! VerticalRemapper requires a unique source grid.\n");
+
+  // This is a vertical remapper. We only go in one direction
+  m_bwd_allowed = false;
+
+  // Gather the pressure level data for vertical remapping
+  set_pressure_levels(map_file);
+
+  // Create tgt_grid that is a clone of the src grid but with
+  // the correct number of level
+  auto tgt_grid = src_grid->clone("vertical_remapped_grid",false);
+  this->set_grids(src_grid,tgt_grid);
+}
+
+VerticalRemapper::
+~VerticalRemapper ()
+{
+  // Nothing to do
+}
+
+FieldLayout VerticalRemapper::
+create_src_layout (const FieldLayout& tgt_layout) const
+{
+  using namespace ShortFieldTagsNames;
+  const auto lt = get_layout_type(tgt_layout.tags());
+  auto src = FieldLayout::invalid();
+  const bool midpoints = tgt_layout.has_tag(LEV);
+  const int vec_dim = tgt_layout.is_vector_layout() ? tgt_layout.dim(CMP) : -1;
+  switch (lt) {
+    case LayoutType::Scalar2D:
+      src = m_src_grid->get_2d_scalar_layout();
+      break;
+    case LayoutType::Vector2D:
+      src = m_src_grid->get_2d_vector_layout(CMP,vec_dim);
+      break;
+    case LayoutType::Scalar3D:
+      src = m_src_grid->get_3d_scalar_layout(midpoints);
+      break;
+    case LayoutType::Vector3D:
+      src = m_src_grid->get_3d_vector_layout(midpoints,CMP,vec_dim);
+      break;
+    default:
+      EKAT_ERROR_MSG ("Layout not supported by VerticalRemapper: " + e2str(lt) + "\n");
+  }
+  return src;
+}
+FieldLayout VerticalRemapper::
+create_tgt_layout (const FieldLayout& src_layout) const
+{
+  using namespace ShortFieldTagsNames;
+  const auto lt = get_layout_type(src_layout.tags());
+  auto tgt = FieldLayout::invalid();
+  const bool midpoints = src_layout.has_tag(LEV);
+  const int vec_dim = src_layout.is_vector_layout() ? src_layout.dim(CMP) : -1;
+  switch (lt) {
+    case LayoutType::Scalar2D:
+      tgt = m_tgt_grid->get_2d_scalar_layout();
+      break;
+    case LayoutType::Vector2D:
+      tgt = m_tgt_grid->get_2d_vector_layout(CMP,vec_dim);
+      break;
+    case LayoutType::Scalar3D:
+      tgt = m_tgt_grid->get_3d_scalar_layout(midpoints);
+      break;
+    case LayoutType::Vector3D:
+      tgt = m_tgt_grid->get_3d_vector_layout(midpoints,CMP,vec_dim);
+      break;
+    default:
+      EKAT_ERROR_MSG ("Layout not supported by VerticalRemapper: " + e2str(lt) + "\n");
+  }
+  return tgt;
+}
+
+void VerticalRemapper::
+set_pressure_levels(const std::string& map_file) {
+  scorpio::register_file(map_file,scorpio::FileMode::Read);
+  m_num_remap_levs = scorpio::get_dimlen_c2f(map_file.c_str(),"nlevs");
+  std::vector<Real> remap_pres_levs(m_num_remap_levs);
+  std::vector<scorpio::offset_t> dofs_offsets(m_num_remap_levs);
+  std::iota(dofs_offsets.begin(),dofs_offsets.end(),0);
+  const std::string idx_decomp_tag = "vertical_remapper::" + std::to_string(m_num_remap_levs);
+  scorpio::get_variable(map_file, "p_levs", "p_levs", {"nlevs"}, "real", idx_decomp_tag);
+  scorpio::set_dof(map_file,"p_levs",m_num_remap_levs,dofs_offsets.data());
+  scorpio::set_decomp(map_file);
+  scorpio::grid_read_data_array(map_file,"p_levs",-1,remap_pres_levs.data(),remap_pres_levs.size());
+  scorpio::eam_pio_closefile(map_file);
+
+  auto npacks = ekat::PackInfo<SCREAM_PACK_SIZE>::num_packs(m_num_remap_levs);
+  m_remap_pres_view = view_1d<Pack>("",npacks);
+  auto remap_pres_host = Kokkos::create_mirror_view(m_remap_pres_view);
+  auto remap_pres_scal = ekat::scalarize(remap_pres_host);
+  for (int ii=0;ii<m_num_remap_levs;ii++) {
+    remap_pres_scal(ii) = remap_pres_levs[ii];
+  }
+  Kokkos::deep_copy(m_remap_pres_view,remap_pres_host);  
+}
+
+void VerticalRemapper::
+register_vertical_source_field(const identifier_type& src, const std::string& mode)
+{
+  using namespace ShortFieldTagsNames;
+  EKAT_REQUIRE_MSG(mode=="mid" || mode=="int","Error: VerticalRemapper::register_vertical_source_field,"
+    "mode arg must be 'mid' or 'int'\n");
+  if (mode=="mid") {
+    auto layout = src.get_layout();
+    auto name   = src.name();
+    EKAT_REQUIRE_MSG(ekat::contains(std::vector<FieldTag>{LEV},layout.tags().back()),
+      "Error::VerticalRemapper::register_vertical_source_field,\n"
+      "mode = 'mid' expects a layour ending with LEV tag.\n"
+      " - field name  : " + name + "\n"
+      " - field layout: " + to_string(layout) + "\n");
+    src_mid = field_type(src);
+    mid_set = true; 
+   } else {  // mode=="int"
+    auto layout = src.get_layout();
+    auto name   = src.name();
+    EKAT_REQUIRE_MSG(ekat::contains(std::vector<FieldTag>{ILEV},layout.tags().back()),
+      "Error::VerticalRemapper::register_vertical_source_field,\n"
+      "mode = 'int' expects a layour ending with ILEV tag.\n"
+      " - field name  : " + name + "\n"
+      " - field layout: " + to_string(layout) + "\n");
+    src_int = field_type(src);
+    int_set = true; 
+  }
+}
+
+void VerticalRemapper::
+do_register_field (const identifier_type& src, const identifier_type& tgt)
+{
+  m_src_fields.push_back(field_type(src));
+  m_tgt_fields.push_back(field_type(tgt));
+}
+
+void VerticalRemapper::
+do_bind_field (const int ifield, const field_type& src, const field_type& tgt)
+{
+  EKAT_REQUIRE_MSG (
+      src.get_header().get_identifier().get_layout().rank()>1 ||
+      src.get_header().get_alloc_properties().get_padding()==0,
+      "Error! We don't support 2d scalar fields that are padded.\n");
+  EKAT_REQUIRE_MSG (
+      tgt.get_header().get_identifier().get_layout().rank()>1 ||
+      tgt.get_header().get_alloc_properties().get_padding()==0,
+      "Error! We don't support 2d scalar fields that are padded.\n");
+  m_src_fields[ifield] = src;
+  m_tgt_fields[ifield] = tgt;
+}
+
+void VerticalRemapper::do_registration_ends ()
+{
+  // Check that the vertical profiles for the source data have been set
+  EKAT_REQUIRE_MSG(mid_set,"Error::VerticalRemapper:registration_ends,\n"
+    "Field for vertical profile of the source data for layout LEV has not been set.\n");
+  EKAT_REQUIRE_MSG(int_set,"Error::VerticalRemapper:registration_ends,\n"
+    "Field for vertical profile of the source data for layout ILEV has not been set.\n");
+}
+
+void VerticalRemapper::do_remap_fwd ()
+{
+
+  using namespace ShortFieldTagsNames;
+  using namespace scream::vinterp;
+  FieldTag src_tag;
+  Field    src_lev_f;
+  int      src_num_levs;
+  // Loop over each field
+  for (int i=0; i<m_num_fields; ++i) {
+    const auto& f_src  = m_src_fields[i];
+          auto  f_tgt  = m_tgt_fields[i];
+    const auto& layout = f_src.get_header().get_identifier().get_layout();
+    const auto  rank   = f_src.rank();
+    src_tag = layout.tags().back();
+    src_num_levs = layout.dim(src_tag);
+    const bool do_remap = ekat::contains(std::vector<FieldTag>{ILEV,LEV},src_tag);
+    if (src_tag == ILEV) {
+      src_lev_f = src_int;
+    } else {
+      src_lev_f = src_mid;
+    }
+    auto src_lev  = src_lev_f.get_view<const Pack**>();
+    if (do_remap) { 
+      switch(rank) {
+        case 1:
+        {
+          // This must be a single vertical profile
+          break;
+        }
+        case 2:
+        {
+          auto src_view = f_src.get_view<const Pack**>();
+          auto tgt_view = f_src.get_view<      Pack**>();
+          perform_vertical_interpolation(src_lev,m_remap_pres_view,src_view,tgt_view,src_num_levs,m_num_remap_levs);
+          break;
+        }
+//ASD TODO; perform vertical interpolation needs to be extended to views of size >2
+//ASD        case 3:
+//ASD        {
+//ASD          auto src_view = f_src.get_view<const Pack***>();
+//ASD          auto tgt_view = f_src.get_view<      Pack***>();
+//ASD          perform_vertical_interpolation(src_lev,m_remap_pres_view,src_view,tgt_view,src_num_levs,m_num_remap_levs);
+//ASD          break;
+//ASD        }
+//ASD        case 4:
+//ASD        {
+//ASD          auto src_view = f_src.get_view<const Pack****>();
+//ASD          auto tgt_view = f_src.get_view<      Pack****>();
+//ASD          perform_vertical_interpolation(src_lev,m_remap_pres_view,src_view,tgt_view,src_num_levs,m_num_remap_levs);
+//ASD          break;
+//ASD        }
+//ASD        case 5:
+//ASD        {
+//ASD          auto src_view = f_src.get_view<const Pack*****>();
+//ASD          auto tgt_view = f_src.get_view<      Pack*****>();
+//ASD          perform_vertical_interpolation(src_lev,m_remap_pres_view,src_view,tgt_view,src_num_levs,m_num_remap_levs);
+//ASD          break;
+//ASD        }
+//ASD        case 6:
+//ASD        {
+//ASD          auto src_view = f_src.get_view<const Pack******>();
+//ASD          auto tgt_view = f_src.get_view<      Pack******>();
+//ASD          perform_vertical_interpolation(src_lev,m_remap_pres_view,src_view,tgt_view,src_num_levs,m_num_remap_levs);
+//ASD          break;
+//ASD        }
+        default:
+          EKAT_ERROR_MSG ("Error! Field rank (" + std::to_string(rank) + ") not supported by VerticalRemapper.\n");
+      }
+    } else {
+      // There is nothing to do, this field cannot be vertically interpolated,
+      // so just copy it over.
+      f_tgt.deep_copy(f_src);
+    }
+  }
+
+}
+
+} // namespace scream

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -231,6 +231,7 @@ void VerticalRemapper::do_remap_fwd ()
   using namespace ShortFieldTagsNames;
   // Loop over each field
   constexpr auto can_pack = SCREAM_PACK_SIZE>1;
+  const auto& tgt_pres_ap = m_remap_pres.get_header().get_alloc_properties();
   for (int i=0; i<m_num_fields; ++i) {
     const auto& f_src    = m_src_fields[i];
           auto  f_tgt    = m_tgt_fields[i];
@@ -241,17 +242,26 @@ void VerticalRemapper::do_remap_fwd ()
       // Dispatch kernel with the largest possible pack size
       const auto& src_ap = f_src.get_header().get_alloc_properties();
       const auto& tgt_ap = f_tgt.get_header().get_alloc_properties();
+      const auto& src_pres_ap = src_tag == LEV ? m_src_mid.get_header().get_alloc_properties() : m_src_int.get_header().get_alloc_properties();
       if (can_pack && src_ap.is_compatible<RPack<16>>() &&
-                      tgt_ap.is_compatible<RPack<16>>()) {
+                      tgt_ap.is_compatible<RPack<16>>() &&
+                      src_pres_ap.is_compatible<RPack<16>>() &&
+                      tgt_pres_ap.is_compatible<RPack<16>>()) {
         apply_vertical_interpolation<16>(f_src,f_tgt); 
       } else if (can_pack && src_ap.is_compatible<RPack<8>>() &&
-                             tgt_ap.is_compatible<RPack<8>>()) {
+                             tgt_ap.is_compatible<RPack<8>>() &&
+                             src_pres_ap.is_compatible<RPack<8>>() &&
+                             tgt_pres_ap.is_compatible<RPack<8>>()) {
         apply_vertical_interpolation<8>(f_src,f_tgt); 
       } else if (can_pack && src_ap.is_compatible<RPack<4>>() &&
-                             tgt_ap.is_compatible<RPack<4>>()) {
+                             tgt_ap.is_compatible<RPack<4>>() &&
+                             src_pres_ap.is_compatible<RPack<4>>() &&
+                             tgt_pres_ap.is_compatible<RPack<4>>()) {
         apply_vertical_interpolation<4>(f_src,f_tgt); 
       } else if (can_pack && src_ap.is_compatible<RPack<2>>() &&
-                             tgt_ap.is_compatible<RPack<2>>()) {
+                             tgt_ap.is_compatible<RPack<2>>() &&
+                             src_pres_ap.is_compatible<RPack<2>>() &&
+                             tgt_pres_ap.is_compatible<RPack<2>>()) {
         apply_vertical_interpolation<2>(f_src,f_tgt); 
       } else {
         apply_vertical_interpolation<1>(f_src,f_tgt); 
@@ -268,6 +278,7 @@ template<int Packsize>
 void VerticalRemapper::
 apply_vertical_interpolation(const Field& f_src, const Field& f_tgt) const
 {
+    
     using Pack = ekat::Pack<Real,Packsize>;
     using namespace ShortFieldTagsNames;
     using namespace scream::vinterp;

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -235,8 +235,6 @@ void VerticalRemapper::do_registration_ends ()
     "Field for vertical profile of the source data for layout LEV has not been set.\n");
   EKAT_REQUIRE_MSG(int_set,"Error::VerticalRemapper:registration_ends,\n"
     "Field for vertical profile of the source data for layout ILEV has not been set.\n");
-
-  do_print();
 }
 
 void VerticalRemapper::do_remap_fwd ()

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -179,7 +179,10 @@ void VerticalRemapper::
 do_bind_field (const int ifield, const field_type& src, const field_type& tgt)
 {
   auto name = src.name();
-  EKAT_REQUIRE_MSG(src.get_header().get_identifier().get_layout()==tgt.get_header().get_identifier().get_layout(),"ERROR! vert_remap:do_bind_field:" + name + ", tgt and src do not have the same layout");
+  EKAT_REQUIRE_MSG(src.get_header().get_identifier().get_layout().rank()==tgt.get_header().get_identifier().get_layout().rank(),
+      "ERROR! vert_remap:do_bind_field:" + name + ", tgt and src do not have the same rank");
+  EKAT_REQUIRE_MSG(src.get_header().get_identifier().get_layout().tags()==tgt.get_header().get_identifier().get_layout().tags(),
+      "ERROR! vert_remap:do_bind_field:" + name + ", tgt and src do not have the same set of field tags");
   EKAT_REQUIRE_MSG (
       src.get_header().get_identifier().get_layout().rank()>1 ||
       src.get_header().get_alloc_properties().get_padding()==0,

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -65,6 +65,7 @@ public:
            src_col_size == tgt_col_size;
   }
 
+
 protected:
 
   void register_vertical_source_field(const Field& src, const std::string& mode);
@@ -99,12 +100,20 @@ protected:
   void set_pressure_levels (const std::string& map_file);
   void do_print();
 
+#ifdef KOKKOS_ENABLE_CUDA
+public:
+#endif
+  template<int N>
+  void apply_vertical_interpolation (const Field& f_src, const Field& f_tgt) const;
 protected:
 
   using KT = KokkosTypes<DefaultDevice>;
   using gid_t = AbstractGrid::gid_type;
 
-  using Pack = ekat::Pack<Real,SCREAM_PACK_SIZE>;
+  template<int N>
+  using RPack = ekat::Pack<Real,N>;
+
+  using mPack = RPack<SCREAM_PACK_SIZE>;
 
   template<typename T>
   using view_1d = typename KT::template view_1d<T>;
@@ -119,8 +128,8 @@ protected:
 
   // Vertical profile fields, both for source and target
   int                   m_num_remap_levs;
-  view_1d<Pack>         m_remap_pres_view;
   Real                  m_mask_val;
+  Field                 m_remap_pres;
   Field                 m_src_mid;  // Src vertical profile for LEV layouts
   Field                 m_src_int;  // Src vertical profile for ILEV layouts
   bool                  m_mid_set = false;

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -1,0 +1,109 @@
+#ifndef EAMXX_VERTICAL_REMAPPER_HPP
+#define EAMXX_VERTICAL_REMAPPER_HPP
+
+#include "share/grid/remap/abstract_remapper.hpp"
+#include "share/util/scream_vertical_interpolation.hpp"
+
+#include "scream_config.h"
+
+#include <mpi.h>
+
+namespace scream
+{
+
+/*
+ * A remapper to interpolate fields on a separate vertical grid
+ */
+
+class VerticalRemapper : public AbstractRemapper
+{
+public:
+
+  VerticalRemapper (const grid_ptr_type& src_grid,
+                      const std::string& map_file);
+
+  ~VerticalRemapper ();
+
+  FieldLayout create_src_layout (const FieldLayout& tgt_layout) const override;
+  FieldLayout create_tgt_layout (const FieldLayout& src_layout) const override;
+
+  bool compatible_layouts (const layout_type& src,
+                           const layout_type& tgt) const override {
+    // Same type of layout, and same sizes except for possibly the first one
+    // Note: we can't do tgt.size()/tgt.dim(0), since there may be 0 tgt gids
+    //       on some ranks, which means tgt.dim(0)=0.
+    int src_col_size = 1;
+    for (int i=1; i<src.rank(); ++i) {
+      src_col_size *= src.dim(i);
+    }
+    int tgt_col_size = 1;
+    for (int i=1; i<tgt.rank(); ++i) {
+      tgt_col_size *= tgt.dim(i);
+    }
+    return get_layout_type(src.tags())==get_layout_type(tgt.tags()) &&
+           src_col_size == tgt_col_size;
+  }
+
+  void register_vertical_source_field(const identifier_type& src, const std::string& mode);
+
+protected:
+
+  const identifier_type& do_get_src_field_id (const int ifield) const override {
+    return m_src_fields[ifield].get_header().get_identifier();
+  }
+  const identifier_type& do_get_tgt_field_id (const int ifield) const override {
+    return m_tgt_fields[ifield].get_header().get_identifier();
+  }
+  const field_type& do_get_src_field (const int ifield) const override {
+    return m_src_fields[ifield];
+  }
+  const field_type& do_get_tgt_field (const int ifield) const override {
+    return m_tgt_fields[ifield];
+  }
+
+  void do_registration_begins () override { /* Nothing to do here */ }
+
+  void do_register_field (const identifier_type& src, const identifier_type& tgt) override;
+
+  void do_bind_field (const int ifield, const field_type& src, const field_type& tgt) override;
+
+  void do_registration_ends () override;
+
+  void do_remap_fwd () override;
+
+  void do_remap_bwd () override {
+    EKAT_ERROR_MSG ("VerticalRemapper only supports fwd remapping.\n");
+  }
+
+  void set_pressure_levels (const std::string& map_file);
+
+protected:
+
+  using KT = KokkosTypes<DefaultDevice>;
+  using gid_t = AbstractGrid::gid_type;
+
+  using Pack = ekat::Pack<Real,SCREAM_PACK_SIZE>;
+
+  template<typename T>
+  using view_1d = typename KT::template view_1d<T>;
+  template<typename T>
+  using view_2d = typename KT::template view_2d<T>;
+
+  ekat::Comm            m_comm;
+
+  // Source and target fields
+  std::vector<Field>    m_src_fields;
+  std::vector<Field>    m_tgt_fields;
+
+  // Vertical profile fields, both for source and target
+  int                   m_num_remap_levs;
+  view_1d<Pack>         m_remap_pres_view;
+  Field                 src_mid;  // Src vertical profile for LEV layouts
+  Field                 src_int;  // Src vertical profile for ILEV layouts
+  bool                  mid_set = false;
+  bool                  int_set = false;
+};
+
+} // namespace scream
+
+#endif // EAMXX_VERTICAL_REMAPPER_HPP

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -3,11 +3,6 @@
 
 #include "share/field/field_tag.hpp"
 #include "share/grid/remap/abstract_remapper.hpp"
-#include "share/util/scream_vertical_interpolation.hpp"
-
-#include "scream_config.h"
-
-#include <mpi.h>
 
 namespace scream
 {
@@ -31,7 +26,7 @@ public:
                     const Field& lev_prof,
                     const Field& ilev_prof);
 
-  ~VerticalRemapper ();
+  ~VerticalRemapper () = default;
 
   FieldLayout create_src_layout (const FieldLayout& tgt_layout) const override;
   FieldLayout create_tgt_layout (const FieldLayout& src_layout) const override;
@@ -126,10 +121,10 @@ protected:
   int                   m_num_remap_levs;
   view_1d<Pack>         m_remap_pres_view;
   Real                  m_mask_val;
-  Field                 src_mid;  // Src vertical profile for LEV layouts
-  Field                 src_int;  // Src vertical profile for ILEV layouts
-  bool                  mid_set = false;
-  bool                  int_set = false;
+  Field                 m_src_mid;  // Src vertical profile for LEV layouts
+  Field                 m_src_int;  // Src vertical profile for ILEV layouts
+  bool                  m_mid_set = false;
+  bool                  m_int_set = false;
 };
 
 } // namespace scream

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -20,7 +20,15 @@ class VerticalRemapper : public AbstractRemapper
 public:
 
   VerticalRemapper (const grid_ptr_type& src_grid,
-                      const std::string& map_file);
+                    const std::string& map_file,
+                    const Field& lev_prof,
+                    const Field& ilev_prof,
+                    const Real mask_val);
+
+  VerticalRemapper (const grid_ptr_type& src_grid,
+                    const std::string& map_file,
+                    const Field& lev_prof,
+                    const Field& ilev_prof);
 
   ~VerticalRemapper ();
 
@@ -32,21 +40,23 @@ public:
     // Same type of layout, and same sizes except for possibly the first one
     // Note: we can't do tgt.size()/tgt.dim(0), since there may be 0 tgt gids
     //       on some ranks, which means tgt.dim(0)=0.
-    int src_col_size = 1;
-    for (int i=1; i<src.rank(); ++i) {
-      src_col_size *= src.dim(i);
-    }
-    int tgt_col_size = 1;
-    for (int i=1; i<tgt.rank(); ++i) {
-      tgt_col_size *= tgt.dim(i);
-    }
-    return get_layout_type(src.tags())==get_layout_type(tgt.tags()) &&
-           src_col_size == tgt_col_size;
+    return true;
+    // TODO: Set this up as appropriate
+//ASD    int src_col_size = 1;
+//ASD    for (int i=1; i<src.rank(); ++i) {
+//ASD      src_col_size *= src.dim(i);
+//ASD    }
+//ASD    int tgt_col_size = 1;
+//ASD    for (int i=1; i<tgt.rank(); ++i) {
+//ASD      tgt_col_size *= tgt.dim(i);
+//ASD    }
+//ASD    return get_layout_type(src.tags())==get_layout_type(tgt.tags()) &&
+//ASD           src_col_size == tgt_col_size;
   }
 
-  void register_vertical_source_field(const identifier_type& src, const std::string& mode);
-
 protected:
+
+  void register_vertical_source_field(const Field& src, const std::string& mode);
 
   const identifier_type& do_get_src_field_id (const int ifield) const override {
     return m_src_fields[ifield].get_header().get_identifier();
@@ -76,6 +86,7 @@ protected:
   }
 
   void set_pressure_levels (const std::string& map_file);
+  void do_print();
 
 protected:
 
@@ -98,6 +109,7 @@ protected:
   // Vertical profile fields, both for source and target
   int                   m_num_remap_levs;
   view_1d<Pack>         m_remap_pres_view;
+  Real                  m_mask_val;
   Field                 src_mid;  // Src vertical profile for LEV layouts
   Field                 src_int;  // Src vertical profile for ILEV layouts
   bool                  mid_set = false;

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -89,22 +89,22 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
         "Error! Bad formatting of output yaml file. Missing 'Fields->$grid_name` sublist.\n");
   }
 
+  // Check if remapping and if so create the appropriate remapper 
+  bool m_vert_remap_from_file = params.isParameter("vertical_remap_file");
+  bool m_horiz_remap_from_file = params.isParameter("horiz_remap_file");
+  if (m_vert_remap_from_file && m_horiz_remap_from_file) {
+    // TODO - support both horizontal and vertical remapping together.
+    EKAT_ERROR_MSG("Error! scorpio_output:: We currently do not support both vertical and horizontal remapping.");
+  }
+
   // Try to set the IO grid (checks will be performed)
   set_grid (io_grid);
 
   // Register any diagnostics needed by this output stream
   set_diagnostics();
 
-  // Check if remapping and if so create the appropriate remapper 
-  bool vert_remap_from_file = params.isParameter("vertical_remap_file");
-  bool horiz_remap_from_file = params.isParameter("horiz_remap_file");
-  if (vert_remap_from_file && horiz_remap_from_file) {
-    // TODO - support both horizontal and vertical remapping together.
-    EKAT_ERROR_MSG("Error! scorpio_output:: We currently do not support both vertical and horizontal remapping.");
-  }
-
   // Setup remappers - if needed
-  if (vert_remap_from_file) {  
+  if (m_vert_remap_from_file) {  
     using namespace ShortFieldTagsNames;
     // We build a remapper, to remap fields from the fm grid to the io grid
     auto vert_remap_file   = params.get<std::string>("vertical_remap_file");
@@ -154,9 +154,9 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
     set_field_manager(io_fm,"io");
   }
 
-  if (io_grid->name()!=fm_grid->name() || horiz_remap_from_file) {
+  if (io_grid->name()!=fm_grid->name() || m_horiz_remap_from_file) {
     // We build a remapper, to remap fields from the fm grid to the io grid
-    if (horiz_remap_from_file) {
+    if (m_horiz_remap_from_file) {
       auto horiz_remap_file   = params.get<std::string>("horiz_remap_file");
       m_horiz_remapper = std::make_shared<CoarseningRemapper>(io_grid,horiz_remap_file);
       io_grid = m_horiz_remapper->get_tgt_grid();
@@ -854,7 +854,7 @@ create_diagnostic (const std::string& diag_field_name) {
     // If last is bot or top, will simply use that
     params.set("Field Level", lev_and_idx.back());
   } else if (lev_str=="mb" || lev_str=="hPa" || lev_str=="Pa") {
-    EKAT_REQUIRE_MSG(!m_horiz_remapper,"Error! scorpio_output:" + diag_field_name + ", horizontal remapping of pressure level slices not supported.");
+    EKAT_REQUIRE_MSG(!m_horiz_remap_from_file,"Error! scorpio_output:" + diag_field_name + ", horizontal remapping of pressure level slices not supported.");
     // Diagnostic is a horizontal slice at a specific pressure level
     diag_name = "FieldAtPressureLevel";
     auto pres_str = lev_and_idx[0].substr(0,pos);

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -400,7 +400,7 @@ void AtmosphereOutput::run (const std::string& filename, const bool is_write_ste
 long long AtmosphereOutput::
 res_dep_memory_footprint () const {
   long long rdmf = 0;
-  if (m_horiz_remapper) {
+  if (m_io_field_mgr != m_sim_field_mgr) {
     // The IO is done on a different grid. The FM stored here is
     // not shared with anyone else, so we can safely add its footprint
     for (const auto& it : *m_io_field_mgr) {

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -854,6 +854,7 @@ create_diagnostic (const std::string& diag_field_name) {
     // If last is bot or top, will simply use that
     params.set("Field Level", lev_and_idx.back());
   } else if (lev_str=="mb" || lev_str=="hPa" || lev_str=="Pa") {
+    EKAT_REQUIRE_MSG(!m_horiz_remapper,"Error! scorpio_output:" + diag_field_name + ", horizontal remapping of pressure level slices not supported.");
     // Diagnostic is a horizontal slice at a specific pressure level
     diag_name = "FieldAtPressureLevel";
     auto pres_str = lev_and_idx[0].substr(0,pos);

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -91,6 +91,15 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
   // Register any diagnostics needed by this output stream
   set_diagnostics();
 
+  // Check if remapping vertically and if so create a VerticalRemapper and initialize it.
+//ASD  if (true) {  //TODO trigger true if output_control.yaml requests it.
+//ASD    m_verti_remapper = VerticalRemapper("test.nc");
+//ASD    for (const auto& fname : m_fields_names) { 
+//ASD      auto fid = get_field(fname,m_sim_field_mgr).get_header().get_identifier();
+//ASD    }
+//ASD  }
+  
+
   bool remap_from_file = params.isParameter("remap_file");
 
   if (io_grid->name()!=fm_grid->name() || remap_from_file) {

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -11,10 +11,6 @@
 
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/ekat_pack_utils.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
-
-#include <numeric>
 /*  The AtmosphereOutput class handles an output stream in SCREAM.
  *  Typical usage is to register an AtmosphereOutput object with the OutputManager (see scream_output_manager.hpp
  *

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -172,7 +172,7 @@ protected:
   std::shared_ptr<const fm_type>      m_io_field_mgr;
   std::shared_ptr<const fm_type>      m_sim_field_mgr;
   std::shared_ptr<const grid_type>    m_io_grid;
-  std::shared_ptr<remapper_type>      m_remapper;
+  std::shared_ptr<remapper_type>      m_horiz_remapper;
   std::shared_ptr<const gm_type>      m_grids_manager;
 
   // How to combine multiple snapshots in the output: Instant, Max, Min, Average
@@ -191,6 +191,7 @@ protected:
   // Local views of each field to be used for "averaging" output and writing to file.
   std::map<std::string,view_1d_host>    m_host_views_1d;
   std::map<std::string,view_1d_dev>     m_dev_views_1d;
+
 };
 
 } //namespace scream

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -174,6 +174,8 @@ protected:
   std::shared_ptr<remapper_type>      m_horiz_remapper;
   std::shared_ptr<remapper_type>      m_vert_remapper;
   std::shared_ptr<const gm_type>      m_grids_manager;
+  bool                                m_horiz_remap_from_file = false;
+  bool                                m_vert_remap_from_file = false;
 
   // How to combine multiple snapshots in the output: Instant, Max, Min, Average
   OutputAvgType     m_avg_type;

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -176,6 +176,7 @@ protected:
   std::shared_ptr<const fm_type>      m_sim_field_mgr;
   std::shared_ptr<const grid_type>    m_io_grid;
   std::shared_ptr<remapper_type>      m_horiz_remapper;
+  std::shared_ptr<remapper_type>      m_vert_remapper;
   std::shared_ptr<const gm_type>      m_grids_manager;
 
   // How to combine multiple snapshots in the output: Instant, Max, Min, Average
@@ -194,63 +195,6 @@ protected:
   // Local views of each field to be used for "averaging" output and writing to file.
   std::map<std::string,view_1d_host>    m_host_views_1d;
   std::map<std::string,view_1d_dev>     m_dev_views_1d;
-
-//ASD  // A structure that will be used to handle vertical remapping
-//ASD  struct VerticalRemapper {
-//ASD    using fid_t = FieldIdentifier;
-//ASD    using Pack = ekat::Pack<Real,SCREAM_PACK_SIZE>;
-//ASD    using KT = KokkosTypes<DefaultDevice>;
-//ASD    using view_1d_const = typename KT::template view_1d<const Pack>;
-//ASD    using view_1d = typename KT::template view_1d<Pack>;
-//ASD
-//ASD    VerticalRemapper() = default;
-//ASD    VerticalRemapper(const std::string remap_filename)
-//ASD    {
-//ASD      // Add code to read pressure levs from file.
-//ASD      scorpio::register_file(remap_filename,scorpio::FileMode::Read);
-//ASD      m_tgt_levs = scorpio::get_dimlen_c2f(remap_filename.c_str(),"nlevs");
-//ASD      std::vector<Real> remap_pres_levs(m_tgt_levs);
-//ASD      std::vector<scorpio::offset_t> dofs_offsets(m_tgt_levs);
-//ASD      std::iota(dofs_offsets.begin(),dofs_offsets.end(),0);
-//ASD      const std::string idx_decomp_tag = "vertical_remapper::" + std::to_string(m_tgt_levs);
-//ASD      scorpio::get_variable(remap_filename, "p_levs", "p_levs", {"nlevs"}, "real", idx_decomp_tag);
-//ASD      scorpio::set_dof(remap_filename,"p_levs",m_tgt_levs,dofs_offsets.data());
-//ASD      scorpio::set_decomp(remap_filename);
-//ASD      scorpio::grid_read_data_array(remap_filename,"p_levs",-1,remap_pres_levs.data(),remap_pres_levs.size());
-//ASD      scorpio::eam_pio_closefile(remap_filename);
-//ASD
-//ASD      auto npacks = ekat::PackInfo<SCREAM_PACK_SIZE>::num_packs(m_tgt_levs);
-//ASD      m_plevs = view_1d("",npacks);
-//ASD      auto remap_pres_host = Kokkos::create_mirror_view(m_plevs);
-//ASD      auto remap_pres_scal = ekat::scalarize(remap_pres_host);
-//ASD      for (int ii=0;ii<m_tgt_levs;ii++) {
-//ASD        remap_pres_scal(ii) = remap_pres_levs[ii];
-//ASD      }
-//ASD      Kokkos::deep_copy(m_plevs,remap_pres_host);
-//ASD    }
-//ASD
-//ASD    int m_tgt_levs;
-//ASD    view_1d m_plevs;
-//ASD    std::map<std::string,std::shared_ptr<atm_diag_type>>  m_fields;
-//ASD
-//ASD    void register_field(const ekat::Comm comm, const fid_t& fid, std::shared_ptr<const gm_type> grids_manager) {
-//ASD      auto& diag_factory = AtmosphereDiagnosticFactory::instance();
-//ASD 
-//ASD      ekat::ParameterList params;
-//ASD      params.set("Field Name",fid.name());
-//ASD      params.set("Grid Name",fid.get_grid_name());
-//ASD      params.set("Field Layout",fid.get_layout());
-//ASD      params.set("Field Units",fid.get_units());
-//ASD      params.set<view_1d_const>("press_levels",m_plevs);
-//ASD      params.set<int>("tgt_num_levs",m_tgt_levs);
-//ASD      // Create the diagnostic
-//ASD      auto diag = diag_factory.create("VerticallyRemappedField",comm,params);
-//ASD      diag->set_grids(grids_manager);
-//ASD      m_fields.emplace(fid.name(),diag);
-//ASD    }
-//ASD    
-//ASD  }; // VerticalRemapper
-//ASD  VerticalRemapper                    m_verti_remapper;
 };
 
 } //namespace scream

--- a/components/eamxx/src/share/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/tests/CMakeLists.txt
@@ -29,6 +29,10 @@ if (NOT ${SCREAM_BASELINES_ONLY})
   CreateUnitTest(coarsening_remapper "coarsening_remapper_tests.cpp" "scream_share;scream_io"
     MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
 
+  # Test coarsening remap
+  CreateUnitTest(vertical_remapper "vertical_remapper_tests.cpp" "scream_share;scream_io"
+    MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
+
   # Test common physics functions
   CreateUnitTest(common_physics "common_physics_functions_tests.cpp" scream_share)
 

--- a/components/eamxx/src/share/tests/vertical_interp_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_interp_tests.cpp
@@ -122,6 +122,7 @@ void run(){
       const int num_vert_packs = p_tgt.extent(0);
       const auto policy = ESU::get_default_team_policy(2, num_vert_packs);
       auto loc_layers_src = n_layers_src[i];
+      auto loc_layers_tgt = n_layers_tgt[i];
       Kokkos::parallel_for("scream_vert_interp_setup_loop", policy,
          	       KOKKOS_LAMBDA(MemberType const& team) {
           const int icol = team.league_rank();
@@ -135,6 +136,7 @@ void run(){
                                               out_1d,
                                               msk,
                                               loc_layers_src,
+                                              loc_layers_tgt,
                                               icol,
                                               masked_val,
                                               team,
@@ -304,6 +306,7 @@ TEST_CASE("testing_masking"){
                                           out_1d,
                                           msk,
                                           n_layers_src,
+                                          n_layers_tgt,
                                           icol,
                                           masked_val,
                                           team,

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -51,14 +51,12 @@ void print (const std::string& msg, const ekat::Comm& comm) {
 std::shared_ptr<AbstractGrid>
 build_src_grid(const ekat::Comm& comm, const int nldofs_src, const int nlevs_src) 
 {
-
-  AbstractGrid::dofs_list_type src_dofs("",nldofs_src);
-  auto src_dofs_h = cmvc(src_dofs);
-  std::iota(src_dofs_h.data(),src_dofs_h.data()+nldofs_src,nldofs_src*comm.rank());
-  Kokkos::deep_copy(src_dofs,src_dofs_h);
-
   auto src_grid = std::make_shared<PointGrid>("src",nldofs_src,nlevs_src,comm);
-  src_grid->set_dofs(src_dofs);
+
+  auto src_dofs = src_grid->get_dofs_gids();
+  auto src_dofs_h = src_dofs.get_view<gid_t*,Host>();
+  std::iota(src_dofs_h.data(),src_dofs_h.data()+nldofs_src,nldofs_src*comm.rank());
+  src_dofs.sync_to_dev();
 
   return src_grid;
 }
@@ -99,7 +97,7 @@ void create_remap_file(const std::string& filename, const int nlevs, const std::
 
   scorpio::register_file(filename, scorpio::FileMode::Write);
 
-  scorpio::register_dimension(filename,"nlevs","nlevs",nlevs);
+  scorpio::register_dimension(filename,"nlevs","nlevs",nlevs, true);
 
   scorpio::register_variable(filename,"p_levs","p_levs","none",{"nlevs"},"real","real","Real-nlevs");
 
@@ -266,7 +264,7 @@ TEST_CASE ("vertical_remap") {
   // values was, even if that data was off rank.
   auto pmid_v = pmid_src.get_view<Real**,Host>();
   auto pint_v = pint_src.get_view<Real**,Host>();
-  auto src_gids    = remap->get_src_grid()->get_dofs_gids_host();
+  auto src_gids    = remap->get_src_grid()->get_dofs_gids().get_view<const gid_t*,Host>();
   for (const auto& f : src_f) {
     const auto& l = f.get_header().get_identifier().get_layout();
     switch (get_layout_type(l.tags())) {
@@ -326,7 +324,7 @@ TEST_CASE ("vertical_remap") {
     // -------------------------------------- //
 
     print (" -> check tgt fields ...\n",comm);
-    const auto tgt_gids = tgt_grid->get_dofs_gids_host();
+    const auto tgt_gids = tgt_grid->get_dofs_gids().get_view<const gid_t*,Host>();
     const int ntgt_gids = tgt_gids.size();
     for (size_t ifield=0; ifield<tgt_f.size(); ++ifield) {
       const auto& f     = tgt_f[ifield];

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -210,17 +210,17 @@ TEST_CASE ("vertical_remap") {
   // For now we can only support PS = SCREAM_PACK_SIZE because the source and target pressure levels will assume that packsize.
   // If we use a smaller packsize we throw an error in the property check step of the vertical interpolation scheme.
   // TODO: Fix that.
-  auto src_s3d_m = create_field("s3d_m",src_grid,false,false,true, SCREAM_PACK_SIZE); //1);
-  auto src_s3d_i = create_field("s3d_i",src_grid,false,false,false,SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,4));
-  auto src_v3d_m = create_field("v3d_m",src_grid,false,true ,true, SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,8));
-  auto src_v3d_i = create_field("v3d_i",src_grid,false,true ,false,SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,16));
+  auto src_s3d_m = create_field("s3d_m",src_grid,false,false,true, 1);
+  auto src_s3d_i = create_field("s3d_i",src_grid,false,false,false,std::min(SCREAM_PACK_SIZE,4));
+  auto src_v3d_m = create_field("v3d_m",src_grid,false,true ,true, std::min(SCREAM_PACK_SIZE,8));
+  auto src_v3d_i = create_field("v3d_i",src_grid,false,true ,false,std::min(SCREAM_PACK_SIZE,16));
 
   auto tgt_s2d   = create_field("s2d",  tgt_grid,true,false);
   auto tgt_v2d   = create_field("v2d",  tgt_grid,true,true);
-  auto tgt_s3d_m = create_field("s3d_m",tgt_grid,false,false,true, SCREAM_PACK_SIZE); //1);
-  auto tgt_s3d_i = create_field("s3d_i",tgt_grid,false,false,true, SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,4));
-  auto tgt_v3d_m = create_field("v3d_m",tgt_grid,false,true ,true, SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,8));
-  auto tgt_v3d_i = create_field("v3d_i",tgt_grid,false,true ,true, SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,16));
+  auto tgt_s3d_m = create_field("s3d_m",tgt_grid,false,false,true, 1);
+  auto tgt_s3d_i = create_field("s3d_i",tgt_grid,false,false,true, std::min(SCREAM_PACK_SIZE,4));
+  auto tgt_v3d_m = create_field("v3d_m",tgt_grid,false,true ,true, std::min(SCREAM_PACK_SIZE,8));
+  auto tgt_v3d_i = create_field("v3d_i",tgt_grid,false,true ,true, std::min(SCREAM_PACK_SIZE,16));
 
   std::vector<Field> src_f = {src_s2d,src_v2d,src_s3d_m,src_s3d_i,src_v3d_m,src_v3d_i};
   std::vector<Field> tgt_f = {tgt_s2d,tgt_v2d,tgt_s3d_m,tgt_s3d_i,tgt_v3d_m,tgt_v3d_i};
@@ -312,7 +312,7 @@ TEST_CASE ("vertical_remap") {
   print (" -> generate src fields data ... done!\n",comm);
 
   // No bwd remap
-//ASD why doesn't this work?  REQUIRE_THROWS(remap->remap(false));
+  REQUIRE_THROWS(remap->remap(false));
 
   for (int irun=0; irun<5; ++irun) {
     print (" -> run remap ...\n",comm);

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -189,6 +189,8 @@ TEST_CASE ("vertical_remap") {
       }
     }
   }
+  pmid_src.sync_to_dev();
+  pint_src.sync_to_dev();
   auto remap = std::make_shared<VerticalRemapperTester>(src_grid,filename,pmid_src,pint_src,mask_val);
   print (" -> creating grid and remapper ... done!\n",comm);
 

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -97,7 +97,7 @@ void create_remap_file(const std::string& filename, const int nlevs, const std::
 
   scorpio::register_file(filename, scorpio::FileMode::Write);
 
-  scorpio::register_dimension(filename,"nlevs","nlevs",nlevs, true);
+  scorpio::register_dimension(filename,"nlevs","nlevs",nlevs, false);
 
   scorpio::register_variable(filename,"p_levs","p_levs","none",{"nlevs"},"real","real","Real-nlevs");
 

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -1,0 +1,404 @@
+#include <catch2/catch.hpp>
+
+#include "share/grid/remap/vertical_remapper.hpp"
+#include "share/grid/remap/coarsening_remapper.hpp"
+#include "share/grid/point_grid.hpp"
+#include "share/io/scream_scorpio_interface.hpp"
+
+namespace scream {
+
+template<typename ViewT>
+typename ViewT::HostMirror
+cmvc (const ViewT& v) {
+  auto vh = Kokkos::create_mirror_view(v);
+  Kokkos::deep_copy(vh,v);
+  return vh;
+}
+
+class VerticalRemapperTester : public VerticalRemapper {
+public:
+  VerticalRemapperTester (const grid_ptr_type& src_grid,
+                          const std::string&   map_file,
+                          const Field&         lev_prof,
+                          const Field&         ilev_prof,
+                          const Real           mask_val)
+   : VerticalRemapper(src_grid, map_file, lev_prof, ilev_prof, mask_val)
+  {
+    // Nothing to do
+  }
+};
+
+template<typename ViewT>
+bool contains (const ViewT& v, const typename ViewT::traits::value_type& entry) {
+  const auto vh = cmvc (v);
+  const auto beg = vh.data();
+  const auto end = vh.data() + vh.size();
+  for (auto it=beg; it!=end; ++it) {
+    if (*it == entry) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void print (const std::string& msg, const ekat::Comm& comm) {
+  if (comm.am_i_root()) {
+    printf("%s",msg.c_str());
+  }
+}
+
+// Helper function to create a grid given the number of dof's and a comm group.
+std::shared_ptr<AbstractGrid>
+build_src_grid(const ekat::Comm& comm, const int nldofs_src, const int nlevs_src) 
+{
+
+  AbstractGrid::dofs_list_type src_dofs("",nldofs_src);
+  auto src_dofs_h = cmvc(src_dofs);
+  std::iota(src_dofs_h.data(),src_dofs_h.data()+nldofs_src,nldofs_src*comm.rank());
+  Kokkos::deep_copy(src_dofs,src_dofs_h);
+
+  auto src_grid = std::make_shared<PointGrid>("src",nldofs_src,nlevs_src,comm);
+  src_grid->set_dofs(src_dofs);
+
+  return src_grid;
+}
+
+// Helper function to create fields
+Field
+create_field(const std::string& name, const std::shared_ptr<const AbstractGrid>& grid, const bool twod, const bool vec, const bool mid = false, const int ps = 1)
+{
+  constexpr int vec_dim = 3;
+  constexpr auto CMP = FieldTag::Component;
+  constexpr auto units = ekat::units::Units::nondimensional();
+  auto fl = twod
+          ? (vec ? grid->get_2d_vector_layout (CMP,vec_dim)
+                 : grid->get_2d_scalar_layout ())
+          : (vec ? grid->get_3d_vector_layout (mid,CMP,vec_dim)
+                 : grid->get_3d_scalar_layout (mid));
+  FieldIdentifier fid(name,fl,units,grid->name());
+  Field f(fid);
+  f.get_header().get_alloc_properties().request_allocation(ps);
+  f.allocate_view();
+  return f;
+}
+
+// Helper function to set variable data
+Real data_func(const int col, const int vec, const Real pres) {
+  // Using a linear function dependent on 
+  //   - col, the horizontal column,
+  //   - vec, the vector dimension, and
+  //   - pres, the current pressure
+  // Should ensure that the interpolated values match exactly, since vertical interp is also a linear interpolator.
+  // Note, we don't use the level, because here the vertical interpolation is over pressure, so it represents the level.
+  return col*pres + vec*100.0;
+}
+
+// Helper function to create a remap file
+void create_remap_file(const std::string& filename, const int nlevs, const std::vector<std::int64_t>& dofs_p, const std::vector<Real>& p_tgt) 
+{
+
+  scorpio::register_file(filename, scorpio::FileMode::Write);
+
+  scorpio::register_dimension(filename,"nlevs","nlevs",nlevs);
+
+  scorpio::register_variable(filename,"p_levs","p_levs","none",{"nlevs"},"real","real","Real-nlevs");
+
+  scorpio::set_dof(filename,"p_levs",dofs_p.size(),dofs_p.data()); 
+  
+  scorpio::eam_pio_enddef(filename);
+
+  scorpio::grid_write_data_array(filename,"p_levs",p_tgt.data(),nlevs);
+
+  scorpio::eam_pio_closefile(filename);
+}
+
+TEST_CASE ("vertical_remap") {
+
+  // -------------------------------------- //
+  //           Init MPI and PIO             //
+  // -------------------------------------- //
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  MPI_Fint fcomm = MPI_Comm_c2f(comm.mpi_comm());
+  scorpio::eam_init_pio_subsystem(fcomm);
+
+  // -------------------------------------- //
+  //           Set grid/map sizes           //
+  // -------------------------------------- //
+
+  const int nlevs_src  = 2*SCREAM_PACK_SIZE + 2;  // Make sure we check what happens when the vertical extent is a little larger than the max PACK SIZE
+  const int nlevs_tgt  = nlevs_src/2;
+  const int nldofs_src = 10;
+  const int nldofs_tgt =  5;
+  const int ngdofs_src = nldofs_src*comm.size();
+  const int ngdofs_tgt = nldofs_tgt*comm.size();
+  const int nnz_local  = nldofs_src;
+  const int nnz        = nnz_local*comm.size();
+
+  // -------------------------------------- //
+  //           Create a map file            //
+  // -------------------------------------- //
+
+  print (" -> creating map file ...\n",comm);
+
+
+  std::string filename = "vertical_map_file_np" + std::to_string(comm.size()) + ".nc";
+
+  // Create target pressure levels to be remapped onto
+  const Real ptop_tgt = 1;
+  const Real pbot_tgt = nlevs_src-2;
+  const Real dp_tgt   = (pbot_tgt-ptop_tgt)/(nlevs_tgt-1);
+  std::vector<std::int64_t> dofs_p(nlevs_tgt);
+  std::iota(dofs_p.begin(),dofs_p.end(),0);
+  std::vector<Real> p_tgt;
+  for (int ii=0; ii<nlevs_tgt; ++ii) {
+    p_tgt.push_back(ptop_tgt + dp_tgt*ii);
+  }
+
+  create_remap_file(filename, nlevs_tgt, dofs_p, p_tgt);
+  print (" -> creating map file ... done!\n",comm);
+
+  // -------------------------------------- //
+  //      Build src grid and remapper       //
+  // -------------------------------------- //
+
+  print (" -> creating grid and remapper ...\n",comm);
+
+  const Real mask_val = -99999.0;
+
+  auto src_grid = build_src_grid(comm, nldofs_src, nlevs_src);
+
+  // We need the source pressure level fields for both p_mid and p_int
+  auto pmid_src   = create_field("p_mid",  src_grid, false, false, true,  SCREAM_PACK_SIZE);
+  auto pint_src   = create_field("p_int",  src_grid, false, false, false, SCREAM_PACK_SIZE);
+  // Set the source pressures
+  {
+    // By adding 1 to the pbot_tgt and subtrating 1 from ptop_tgt we ensure some masking, which 
+    // we also want to check.
+    const Real ptop_src = ptop_tgt-1;
+    const Real pbot_src = pbot_tgt+1;
+    const Real dp_src = (pbot_src-ptop_src)/(nlevs_src-1);
+    auto pmid_v = pmid_src.get_view<Real**,Host>();
+    auto pint_v = pint_src.get_view<Real**,Host>();
+    for (int ii=0; ii<pmid_v.extent_int(0); ++ii) {
+      pint_v(ii,0) = ptop_src;
+      for (int kk=0; kk<nlevs_src; ++kk) {
+        pint_v(ii,kk+1) = pint_v(ii,kk) + dp_src;
+        pmid_v(ii,kk)   = 0.5*(pint_v(ii,kk) + pint_v(ii,kk+1));
+      }
+    }
+  }
+  auto remap = std::make_shared<VerticalRemapperTester>(src_grid,filename,pmid_src,pint_src,mask_val);
+  print (" -> creating grid and remapper ... done!\n",comm);
+
+  // -------------------------------------- //
+  //      Create src/tgt grid fields        //
+  // -------------------------------------- //
+
+  print (" -> creating fields ...\n",comm);
+  constexpr int vec_dim = 3;
+
+  auto tgt_grid = remap->get_tgt_grid();
+  // Check that the target grid made by the remapper has the same number of columns as the source grid.
+  // Also check that the number of levels matches the expectation.
+  REQUIRE(tgt_grid->get_num_vertical_levels()==nlevs_tgt);
+  REQUIRE(tgt_grid->get_num_global_dofs()==src_grid->get_num_global_dofs());
+
+  auto src_s2d   = create_field("s2d",  src_grid,true,false);
+  auto src_v2d   = create_field("v2d",  src_grid,true,true);
+  // For now we can only support PS = SCREAM_PACK_SIZE because the source and target pressure levels will assume that packsize.
+  // If we use a smaller packsize we throw an error in the property check step of the vertical interpolation scheme.
+  // TODO: Fix that.
+  auto src_s3d_m = create_field("s3d_m",src_grid,false,false,true, SCREAM_PACK_SIZE); //1);
+  auto src_s3d_i = create_field("s3d_i",src_grid,false,false,false,SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,4));
+  auto src_v3d_m = create_field("v3d_m",src_grid,false,true ,true, SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,8));
+  auto src_v3d_i = create_field("v3d_i",src_grid,false,true ,false,SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,16));
+
+  auto tgt_s2d   = create_field("s2d",  tgt_grid,true,false);
+  auto tgt_v2d   = create_field("v2d",  tgt_grid,true,true);
+  auto tgt_s3d_m = create_field("s3d_m",tgt_grid,false,false,true, SCREAM_PACK_SIZE); //1);
+  auto tgt_s3d_i = create_field("s3d_i",tgt_grid,false,false,true, SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,4));
+  auto tgt_v3d_m = create_field("v3d_m",tgt_grid,false,true ,true, SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,8));
+  auto tgt_v3d_i = create_field("v3d_i",tgt_grid,false,true ,true, SCREAM_PACK_SIZE); //std::min(SCREAM_PACK_SIZE,16));
+
+  std::vector<Field> src_f = {src_s2d,src_v2d,src_s3d_m,src_s3d_i,src_v3d_m,src_v3d_i};
+  std::vector<Field> tgt_f = {tgt_s2d,tgt_v2d,tgt_s3d_m,tgt_s3d_i,tgt_v3d_m,tgt_v3d_i};
+
+  const int nfields = src_f.size();
+
+  print (" -> creating fields ... done!\n",comm);
+
+  // -------------------------------------- //
+  //     Register fields in the remapper    //
+  // -------------------------------------- //
+
+  print (" -> registering fields ...\n",comm);
+  remap->registration_begins();
+  remap->register_field(src_s2d,  tgt_s2d);
+  remap->register_field(src_v2d,  tgt_v2d);
+  remap->register_field(src_s3d_m,tgt_s3d_m);
+  remap->register_field(src_s3d_i,tgt_s3d_i);
+  remap->register_field(src_v3d_m,tgt_v3d_m);
+  remap->register_field(src_v3d_i,tgt_v3d_i);
+  remap->registration_ends();
+  print (" -> registering fields ... done!\n",comm);
+
+  // -------------------------------------- //
+  //        Check remapper internals        //
+  // -------------------------------------- //
+
+  print (" -> Checking remapper internal state ...\n",comm);
+
+
+  // Check the pressure levels read from map file
+
+  // -------------------------------------- //
+  //       Generate data for src fields     //
+  // -------------------------------------- //
+
+  print (" -> generate src fields data ...\n",comm);
+  using namespace ShortFieldTagsNames;
+  // Generate data in a deterministic way, so that when we check results,
+  // we know a priori what the input data that generated the tgt field's
+  // values was, even if that data was off rank.
+  auto pmid_v = pmid_src.get_view<Real**,Host>();
+  auto pint_v = pint_src.get_view<Real**,Host>();
+  auto src_gids    = remap->get_src_grid()->get_dofs_gids_host();
+  for (const auto& f : src_f) {
+    const auto& l = f.get_header().get_identifier().get_layout();
+    switch (get_layout_type(l.tags())) {
+      case LayoutType::Scalar2D:
+      {
+        const auto v_src = f.get_view<Real*,Host>();
+        for (int i=0; i<nldofs_src; ++i) {
+          v_src(i) = data_func(i,0,pmid_v(i,0));
+        }
+      } break;
+      case LayoutType::Vector2D:
+      {
+        const auto v_src = f.get_view<Real**,Host>();
+        for (int i=0; i<nldofs_src; ++i) {
+          for (int j=0; j<vec_dim; ++j) {
+            v_src(i,j) = data_func(i,j+1,pmid_v(i,0));
+        }}
+      } break;
+      case LayoutType::Scalar3D:
+      {
+        const int  nlevs = l.dims().back();
+        const auto p_v   = l.has_tag(LEV) ? pmid_v : pint_v;
+        const auto v_src = f.get_view<Real**,Host>();
+        for (int i=0; i<nldofs_src; ++i) {
+          for (int j=0; j<nlevs; ++j) {
+            v_src(i,j) = data_func(i,0,p_v(i,j));
+        }}
+      } break;
+      case LayoutType::Vector3D:
+      {
+        const int nlevs  = l.dims().back();
+        const auto p_v   = l.has_tag(LEV) ? pmid_v : pint_v;
+        const auto v_src = f.get_view<Real***,Host>();
+        for (int i=0; i<nldofs_src; ++i) {
+          for (int j=0; j<vec_dim; ++j) {
+            for (int k=0; k<nlevs; ++k) {
+              v_src(i,j,k) = data_func(i,j+1,p_v(i,k));
+        }}}
+      } break;
+      default:
+        EKAT_ERROR_MSG ("Unexpected layout.\n");
+    }
+    f.sync_to_dev();
+  }
+  print (" -> generate src fields data ... done!\n",comm);
+
+  // No bwd remap
+//ASD why doesn't this work?  REQUIRE_THROWS(remap->remap(false));
+
+  for (int irun=0; irun<5; ++irun) {
+    print (" -> run remap ...\n",comm);
+    remap->remap(true);
+    print (" -> run remap ... done!\n",comm);
+
+    // -------------------------------------- //
+    //          Check remapped fields         //
+    // -------------------------------------- //
+
+    print (" -> check tgt fields ...\n",comm);
+    const auto tgt_gids = tgt_grid->get_dofs_gids_host();
+    const int ntgt_gids = tgt_gids.size();
+    for (size_t ifield=0; ifield<tgt_f.size(); ++ifield) {
+      const auto& f     = tgt_f[ifield];
+      const auto& fsrc  = src_f[ifield];
+      const auto& lsrc  = fsrc.get_header().get_identifier().get_layout();
+      const auto p_v    = lsrc.has_tag(LEV) ? pmid_v : pint_v;
+      const int nlevs_p = lsrc.has_tag(LEV) ? nlevs_src : nlevs_src+1;
+      const auto ls     = to_string(lsrc);
+      std::string dots (25-ls.size(),'.');
+      print ("   -> Checking field with source layout " + to_string(lsrc) +" " + dots + "\n",comm);
+
+      f.sync_to_host();
+
+      switch (get_layout_type(lsrc.tags())) {
+        case LayoutType::Scalar2D:
+        {
+          // This is a flat array w/ no LEV tag so the interpolated value for source and target should match.
+          const auto v_src = fsrc.get_view<const Real*,Host>();
+          const auto v_tgt = f.get_view<const Real*,Host>();
+          for (int i=0; i<ntgt_gids; ++i) {
+            REQUIRE ( v_tgt(i) == v_src(i) );
+          }
+        } break;
+        case LayoutType::Vector2D:
+        {
+          // This is a flat array w/ no LEV tag so the interpolated value for source and target should match.
+          const auto v_tgt = f.get_view<const Real**,Host>();
+          const auto v_src = fsrc.get_view<const Real**,Host>();
+          for (int i=0; i<ntgt_gids; ++i) {
+            const auto gid = tgt_gids(i);
+            for (int j=0; j<vec_dim; ++j) {
+              REQUIRE ( v_tgt(i,j) == v_src(i,j) );
+          }}
+        } break;
+        case LayoutType::Scalar3D:
+        {
+          const auto v_tgt = f.get_view<const Real**,Host>();
+          for (int i=0; i<ntgt_gids; ++i) {
+            const auto gid = tgt_gids(i);
+            for (int j=0; j<nlevs_tgt; ++j) {
+              if (p_tgt[j]>p_v(i,nlevs_p-1) || p_tgt[j]<p_v(i,0)) {
+                REQUIRE ( v_tgt(i,j) == mask_val );
+              } else {
+                REQUIRE ( v_tgt(i,j) == data_func(i,0,p_tgt[j]) );
+              }
+          }}
+        } break;
+        case LayoutType::Vector3D:
+        {
+          const auto v_tgt = f.get_view<const Real***,Host>();
+          for (int i=0; i<ntgt_gids; ++i) {
+            const auto gid = tgt_gids(i);
+            for (int j=0; j<vec_dim; ++j) {
+              for (int k=0; k<nlevs_tgt; ++k) {
+                const auto term1 = gid*vec_dim*nlevs_tgt+j*nlevs_tgt+k;
+                const auto term2 = (gid+ngdofs_tgt)*vec_dim*nlevs_tgt+j*nlevs_tgt+k;
+                if (p_tgt[k]>p_v(i,nlevs_p-1) || p_tgt[k]<p_v(i,0)) {
+                  REQUIRE ( v_tgt(i,j,k) == mask_val );
+                } else {
+                  REQUIRE ( v_tgt(i,j,k)== data_func(i,j+1,p_tgt[k]) );
+                }
+          }}}
+        } break;
+        default:
+          EKAT_ERROR_MSG ("Unexpected layout.\n");
+      }
+
+      print ("   -> Checking field with source layout " + to_string(lsrc) + " " + dots + " OK!\n",comm);
+    }
+    print ("check tgt fields ... done!\n",comm);
+  }
+
+  // Clean up scorpio stuff
+  scorpio::eam_pio_finalize();
+}
+
+} // namespace scream

--- a/components/eamxx/src/share/util/scream_vertical_interpolation.hpp
+++ b/components/eamxx/src/share/util/scream_vertical_interpolation.hpp
@@ -117,6 +117,7 @@ void apply_interpolation_impl_1d(
   const view_1d<      Pack<T,P>>& output,
   const view_1d<      Mask<P>>&   mask,
   const int nlevs_src,
+  const int nlevs_tgt,
   const int icol,
   const T msk_val,
   const MemberType& team,
@@ -136,7 +137,8 @@ void perform_checks(
 
 template<typename T, int P> 
 void apply_interpolation(
-  const                      int  num_levs,
+  const                      int  num_levs_src,
+  const                      int  num_levs_tgt,
   const                        T  mask_val,
   const                 LIV<T,P>& vert_interp,
   const view_2d<const Pack<T,P>>& x_src,
@@ -147,7 +149,8 @@ void apply_interpolation(
 
 template<typename T, int P> 
 void apply_interpolation(
-  const                      int  num_levs,
+  const                      int  num_levs_src,
+  const                      int  num_levs_tgt,
   const                        T  mask_val,
   const                 LIV<T,P>& vert_interp,
   const view_2d<const Pack<T,P>>& x_src,
@@ -170,7 +173,8 @@ void perform_checks(
 
 template<typename T, int P> 
 void apply_interpolation(
-  const                      int  num_levs,
+  const                      int  num_levs_src,
+  const                      int  num_levs_tgt,
   const                        T  mask_val,
   const                 LIV<T,P>& vert_interp,
   const view_2d<const Pack<T,P>>& x_src,
@@ -181,7 +185,8 @@ void apply_interpolation(
 
 template<typename T, int P> 
 void apply_interpolation(
-  const                      int  num_levs,
+  const                      int  num_levs_src,
+  const                      int  num_levs_tgt,
   const                        T  mask_val,
   const                 LIV<T,P>& vert_interp,
   const view_2d<const Pack<T,P>>& x_src,

--- a/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
+++ b/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
@@ -209,7 +209,7 @@ void perform_checks(
 
   // The input data and x_src data should match in the appropriate size
   EKAT_REQUIRE(x_src.extent_int(0) == input.extent_int(0));
-  EKAT_REQUIRE(x_src.extent_int(1) == input.extent_int(input.rank-1));
+  EKAT_REQUIRE_MSG(x_src.extent_int(1) == input.extent_int(input.rank-1),"Error! vertical_interpolation::perform_checks " + std::to_string(x_src.extent_int(1)) + " != " + std::to_string(input.extent_int(input.rank-1)) + ".");
   // The output data and x_tgt data should match in the appropriate size
   EKAT_REQUIRE_MSG(x_tgt.extent_int(0) == output.extent_int(input.rank-1),"Error! vertical_interpolation::perform_checks " + std::to_string(x_tgt.extent_int(0)) + " != " + std::to_string(output.extent_int(input.rank-1)) + ".");
 

--- a/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
+++ b/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
@@ -46,8 +46,8 @@ void apply_interpolation_impl_1d(
   auto mask   = Kokkos::subview(mask_col,  Kokkos::pair<int,int>(0,num_tgt_packs));
 
   // The input/output data and x_src/x_tgt data should match in the appropriate size, respectively.
-  EKAT_REQUIRE_MSG(x_tgt.size() == output.size(),"Error! vertical_interpolation::perform_checks " + std::to_string(x_tgt.size()) + " != " + std::to_string(output.size()) + ".");
-  EKAT_REQUIRE_MSG(x_src.size() == input.size(), "Error! vertical_interpolation::perform_checks " + std::to_string(x_src.size()) + " != " + std::to_string(input.size()) + ".");
+  EKAT_KERNEL_REQUIRE_MSG(x_tgt.size() == output.size(),"Error! vertical_interpolation::perform_checks " + std::to_string(x_tgt.size()) + " != " + std::to_string(output.size()) + ".");
+  EKAT_KERNEL_REQUIRE_MSG(x_src.size() == input.size(), "Error! vertical_interpolation::perform_checks " + std::to_string(x_src.size()) + " != " + std::to_string(input.size()) + ".");
 
   //Setup linear interpolation
   vert_interp.setup(team, x_src, x_tgt);

--- a/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
+++ b/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
@@ -46,8 +46,8 @@ void apply_interpolation_impl_1d(
   auto mask   = Kokkos::subview(mask_col,  Kokkos::pair<int,int>(0,num_tgt_packs));
 
   // The input/output data and x_src/x_tgt data should match in the appropriate size, respectively.
-  EKAT_KERNEL_REQUIRE_MSG(x_tgt.size() == output.size(),"Error! vertical_interpolation::perform_checks " + std::to_string(x_tgt.size()) + " != " + std::to_string(output.size()) + ".");
-  EKAT_KERNEL_REQUIRE_MSG(x_src.size() == input.size(), "Error! vertical_interpolation::perform_checks " + std::to_string(x_src.size()) + " != " + std::to_string(input.size()) + ".");
+  EKAT_KERNEL_REQUIRE(x_tgt.size() == output.size());
+  EKAT_KERNEL_REQUIRE(x_src.size() == input.size());
 
   //Setup linear interpolation
   vert_interp.setup(team, x_src, x_tgt);

--- a/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
+++ b/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
@@ -46,8 +46,8 @@ void apply_interpolation_impl_1d(
   auto mask   = Kokkos::subview(mask_col,  Kokkos::pair<int,int>(0,num_tgt_packs));
 
   // The input/output data and x_src/x_tgt data should match in the appropriate size, respectively.
-  EKAT_KERNEL_REQUIRE(x_tgt.size() == output.size());
-  EKAT_KERNEL_REQUIRE(x_src.size() == input.size());
+  EKAT_KERNEL_REQUIRE_MSG(x_tgt.size() == output.size(), "Error! vertical_interpolation::apply_interpolation_imple_1d - target pressure level size does not match the size of the target data output.");
+  EKAT_KERNEL_REQUIRE_MSG(x_src.size() == input.size() , "Error! vertical_interpolation::apply_interpolation_imple_1d - source pressure level size does not match the size of the source data input.");
 
   //Setup linear interpolation
   vert_interp.setup(team, x_src, x_tgt);


### PR DESCRIPTION
This commit introduces a vertical remapper to `scorpio_output.cpp/hpp` similar to the current coarsening remapper.

The purpose of the new remapper is to allow users to output simulation data on a different vertical mesh.  This is controlled by passing a vertical_remap file within the output YAML file, which triggers vertical remapping.

There is support to also output fields with no vertical extent, in that case the vertical remapping step will be skipped and the regular field will be in the output.

Note, with this commit there is not yet support for both vertical and horizontal remapping.  That feature will be added in a subsequent PR.