### PR TITLE
Crusher: Use -c 7 to work around issue #2112.

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -2286,7 +2286,7 @@
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>8</nthrds_lnd>
+          <nthrds_lnd>7</nthrds_lnd>
           <nthrds_rof>1</nthrds_rof>
           <nthrds_ice>1</nthrds_ice>
           <nthrds_ocn>1</nthrds_ocn>


### PR DESCRIPTION
I'm keeping the node count at 1 from the previous commit because there's no point in testing on multiple nodes if the node-level configuration isn't right.