### PR TITLE
Crusher: Use -S 0 to solve -c 8 issue.

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -2275,18 +2275,18 @@
       <pes compset="any" pesize="any">
         <comment>"crusher-gpu ne30np4 and ne30np4.pg2"</comment>
         <ntasks>
-          <ntasks_atm>-1</ntasks_atm>
-          <ntasks_lnd>-1</ntasks_lnd>
-          <ntasks_rof>-1</ntasks_rof>
-          <ntasks_ice>-1</ntasks_ice>
-          <ntasks_ocn>-1</ntasks_ocn>
-          <ntasks_glc>-1</ntasks_glc>
-          <ntasks_wav>-1</ntasks_wav>
-          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_cpl>-2</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>7</nthrds_lnd>
+          <nthrds_lnd>8</nthrds_lnd>
           <nthrds_rof>1</nthrds_rof>
           <nthrds_ice>1</nthrds_ice>
           <nthrds_ocn>1</nthrds_ocn>

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -56,43 +56,6 @@
     </directives>
   </batch_system>
 
-   <batch_system MACH="spock" type="slurm">
-     <queues>
-       <queue strict="true" nodemin="1" nodemax="4" walltimemax="03:00:00" default="true">ecp</queue>
-       <queue strict="true" nodemin="1" nodemax="4" walltimemax="03:00:00">caar</queue>
-       <queue strict="true" nodemin="5" nodemax="16" walltimemax="01:00:00">caar</queue>
-     </queues>
-   </batch_system>
-
-   <batch_system MACH="crusher" type="slurm">
-     <batch_submit>/gpfs/alpine/cli133/world-shared/e3sm/tools/sbatch/throttle</batch_submit>
-     <queues>
-       <queue strict="true" nodemin="1" nodemax="8" walltimemax="01:00:00" default="true">batch</queue>
-       <queue strict="true" nodemin="9" nodemax="64" walltimemax="01:00:00">batch</queue>
-       <queue strict="true" nodemin="65" nodemax="160" walltimemax="01:00:00">batch</queue>
-     </queues>
-   </batch_system>
-
-
-   <batch_system MACH="crusher-cpu" type="slurm">
-     <queues>
-       <queue strict="true" nodemin="1" nodemax="8" walltimemax="08:00:00" default="true">batch</queue>
-       <queue strict="true" nodemin="9" nodemax="64" walltimemax="04:00:00">batch</queue>
-       <queue strict="true" nodemin="65" nodemax="160" walltimemax="02:00:00">batch</queue>
-     </queues>
-   </batch_system>
-
-
-   <batch_system MACH="crusher-gpu" type="slurm">
-     <batch_submit>/gpfs/alpine/cli133/world-shared/e3sm/tools/sbatch/throttle</batch_submit>
-     <queues>
-       <queue strict="true" nodemin="1" nodemax="8" walltimemax="01:00:00" default="true">batch</queue>
-       <queue strict="true" nodemin="9" nodemax="64" walltimemax="01:00:00">batch</queue>
-       <queue strict="true" nodemin="65" nodemax="160" walltimemax="01:00:00">batch</queue>
-     </queues>
-   </batch_system>
-
-
   <batch_system type="cobalt" >
     <batch_query>qstat</batch_query>
     <batch_submit>qsub</batch_submit>
@@ -630,6 +593,43 @@
      <queues>
        <queue walltimemax="02:00" default="true" strict="true" nodemin="1" nodemax="2">batch</queue>
        <queue walltimemax="01:00" strict="true" nodemin="3" nodemax="16">batch</queue>
+     </queues>
+   </batch_system>
+
+   <batch_system MACH="spock" type="slurm">
+     <queues>
+       <queue strict="true" nodemin="1" nodemax="4" walltimemax="03:00:00" default="true">ecp</queue>
+       <queue strict="true" nodemin="1" nodemax="4" walltimemax="03:00:00">caar</queue>
+       <queue strict="true" nodemin="5" nodemax="16" walltimemax="01:00:00">caar</queue>
+     </queues>
+   </batch_system>
+
+   <batch_system MACH="crusher" type="slurm">
+     <batch_submit>/gpfs/alpine/cli133/world-shared/e3sm/tools/sbatch/throttle</batch_submit>
+     <queues>
+       <queue strict="true" nodemin="1" nodemax="8" walltimemax="01:00:00" default="true">batch</queue>
+       <queue strict="true" nodemin="9" nodemax="64" walltimemax="01:00:00">batch</queue>
+       <queue strict="true" nodemin="65" nodemax="160" walltimemax="01:00:00">batch</queue>
+     </queues>
+   </batch_system>
+
+   <batch_system MACH="crusher-cpu" type="slurm">
+     <queues>
+       <queue strict="true" nodemin="1" nodemax="8" walltimemax="08:00:00" default="true">batch</queue>
+       <queue strict="true" nodemin="9" nodemax="64" walltimemax="04:00:00">batch</queue>
+       <queue strict="true" nodemin="65" nodemax="160" walltimemax="02:00:00">batch</queue>
+     </queues>
+   </batch_system>
+
+   <batch_system MACH="crusher-gpu" type="slurm">
+     <batch_submit>/gpfs/alpine/cli133/world-shared/e3sm/tools/sbatch/throttle</batch_submit>
+     <directives>
+       <directive> -S 0</directive>
+     </directives>
+     <queues>
+       <queue strict="true" nodemin="1" nodemax="8" walltimemax="01:00:00" default="true">batch</queue>
+       <queue strict="true" nodemin="9" nodemax="64" walltimemax="01:00:00">batch</queue>
+       <queue strict="true" nodemin="65" nodemax="160" walltimemax="01:00:00">batch</queue>
      </queues>
    </batch_system>
 


### PR DESCRIPTION
Also move crusher-related entries in XML file to OLCF area and revert the PE-layout workaround.

Fixes #2112.