### PR TITLE
Aarondonahue/fix bug in prepost cond output

### DIFF
--- a/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
@@ -198,15 +198,16 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
   }
   PropertyCheck::ResultAndMsg res_and_msg;
 
-  bool pass_lower = false, pass_upper = false;
+  bool pass_lower = true, pass_upper = true;
 
   if (minmaxloc.min_val>=m_lb && minmaxloc.max_val<=m_ub) {
     res_and_msg.result = CheckResult::Pass;
-    pass_lower = pass_upper = true;
   } else if  (minmaxloc.min_val<m_lb_repairable || minmaxloc.max_val>m_ub_repairable) {
+    // Check if the min_val fails test
     if (minmaxloc.min_val<m_lb_repairable) {
       pass_lower = false;
     }
+    // Check if the max_val fails test
     if (minmaxloc.max_val>m_ub_repairable) {
       pass_upper = false;
     }
@@ -214,9 +215,11 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     res_and_msg.result = CheckResult::Fail;
   } else {
     res_and_msg.result = CheckResult::Repairable;
+    // Check if the min_val fails test
     if (minmaxloc.min_val<m_lb) {
       pass_lower = false;
     }
+    // Check if the max_val fails test
     if (minmaxloc.max_val>m_ub) {
       pass_upper = false;
     }

--- a/components/eamxx/src/share/tests/property_checks.cpp
+++ b/components/eamxx/src/share/tests/property_checks.cpp
@@ -205,6 +205,27 @@ TEST_CASE("property_checks", "") {
     interval_check->repair();
     res_and_msg = interval_check->check();
     REQUIRE(res_and_msg.result==CheckResult::Pass);
+
+    // Re-assign an out-of-bounds value to the field, but only in the upper-bound.  Check if it
+    // fails and reports just the max fail.
+    std::vector<int> exp_fail_loc = {0,0,1};
+    f_data[1] = -2;
+    f.sync_to_dev();
+    res_and_msg = interval_check->check();
+    REQUIRE(res_and_msg.result==CheckResult::Fail);
+    REQUIRE(res_and_msg.fail_loc_indices == exp_fail_loc);
+    // Repair for next check.
+    interval_check->repair();
+
+    // Re-assign an out-of-bounds value to the field, but only in the upper-bound.  Check if it
+    // fails and reports just the max fail.
+    exp_fail_loc = {1,2,11};
+    f_data[num_reals-1] = 4;
+    f.sync_to_dev();
+    res_and_msg = interval_check->check();
+    REQUIRE(res_and_msg.result==CheckResult::Fail);
+    REQUIRE(res_and_msg.fail_loc_indices == exp_fail_loc);
+    
   }
 
   // Check that the values of a field are above a lower bound


### PR DESCRIPTION
Fix bug in the within_interval_check for property checks where if the maximum was violated the failed column
index still took the location of the minimum value.

This commit also adds a unit test to ensure that the column index matches the expectation.

Addresses #2114 