### PR TITLE
This commit will fix the units for water path diagnostics.

### DIFF
--- a/components/eamxx/src/diagnostics/ice_water_path.cpp
+++ b/components/eamxx/src/diagnostics/ice_water_path.cpp
@@ -33,7 +33,8 @@ void IceWaterPathDiagnostic::set_grids(const std::shared_ptr<const GridsManager>
   add_field<Required>("qi",             scalar3d_layout_mid, Q,  grid_name, "tracers", ps);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d_layout_mid, m, grid_name);
+  const auto m2 = m*m;
+  FieldIdentifier fid (name(), scalar2d_layout_mid, kg/m2, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation();

--- a/components/eamxx/src/diagnostics/liquid_water_path.cpp
+++ b/components/eamxx/src/diagnostics/liquid_water_path.cpp
@@ -33,7 +33,8 @@ void LiqWaterPathDiagnostic::set_grids(const std::shared_ptr<const GridsManager>
   add_field<Required>("qc",             scalar3d_layout_mid, Q,  grid_name, "tracers", ps);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d_layout_mid, m, grid_name);
+  const auto m2 = m*m;
+  FieldIdentifier fid (name(), scalar2d_layout_mid, kg/m2, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation();

--- a/components/eamxx/src/diagnostics/meridional_vapor_flux.cpp
+++ b/components/eamxx/src/diagnostics/meridional_vapor_flux.cpp
@@ -40,7 +40,7 @@ void MeridionalVapFluxDiagnostic::set_grids(const std::shared_ptr<const GridsMan
 
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d_layout_mid, m, grid_name);
+  FieldIdentifier fid (name(), scalar2d_layout_mid, kg/m/s, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation();

--- a/components/eamxx/src/diagnostics/rain_water_path.cpp
+++ b/components/eamxx/src/diagnostics/rain_water_path.cpp
@@ -33,7 +33,8 @@ void RainWaterPathDiagnostic::set_grids(const std::shared_ptr<const GridsManager
   add_field<Required>("qr",             scalar3d_layout_mid, Q,  grid_name, "tracers", ps);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d_layout_mid, m, grid_name);
+  const auto m2 = m*m;
+  FieldIdentifier fid (name(), scalar2d_layout_mid, kg/m2, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation();

--- a/components/eamxx/src/diagnostics/rime_water_path.cpp
+++ b/components/eamxx/src/diagnostics/rime_water_path.cpp
@@ -33,7 +33,8 @@ void RimeWaterPathDiagnostic::set_grids(const std::shared_ptr<const GridsManager
   add_field<Required>("qm",             scalar3d_layout_mid, Q,  grid_name, "tracers", ps);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d_layout_mid, m, grid_name);
+  const auto m2 = m*m;
+  FieldIdentifier fid (name(), scalar2d_layout_mid, kg/m2, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation();

--- a/components/eamxx/src/diagnostics/vapor_water_path.cpp
+++ b/components/eamxx/src/diagnostics/vapor_water_path.cpp
@@ -33,7 +33,8 @@ void VapWaterPathDiagnostic::set_grids(const std::shared_ptr<const GridsManager>
   add_field<Required>("qv",             scalar3d_layout_mid, Q,  grid_name, "tracers", ps);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d_layout_mid, m, grid_name);
+  const auto m2 = m*m;
+  FieldIdentifier fid (name(), scalar2d_layout_mid, kg/m2, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation();

--- a/components/eamxx/src/diagnostics/zonal_vapor_flux.cpp
+++ b/components/eamxx/src/diagnostics/zonal_vapor_flux.cpp
@@ -40,7 +40,7 @@ void ZonalVapFluxDiagnostic::set_grids(const std::shared_ptr<const GridsManager>
 
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d_layout_mid, m, grid_name);
+  FieldIdentifier fid (name(), scalar2d_layout_mid, kg/m/s, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation();


### PR DESCRIPTION
The units for `ICE` `LIQ` `RAIN` `RIME` and `VAP` water path were incorrect.  This commit fixes that.

Additionally, the flux for `meridional` and `zonal` vapor flux were incorrect and have been fixed.

Addresses #2014 