### PR TITLE
Save grid geometric data in output files

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -165,9 +165,6 @@ tweaking their $case/namelist_scream.xml file.
     <!-- Homme dynamics -->
     <homme inherit="atm_proc_base">
       <Grid>Dynamics</Grid>
-      <vertical_coordinate_filename type="file">UNSET</vertical_coordinate_filename>
-      <vertical_coordinate_filename nlev="72">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L72_20220927.nc</vertical_coordinate_filename>
-      <vertical_coordinate_filename nlev="128">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L128_20220927.nc</vertical_coordinate_filename>
       <Moisture>moist</Moisture>
     </homme>
 
@@ -278,6 +275,9 @@ tweaking their $case/namelist_scream.xml file.
     <physics_grid_type hgrid=".*pg2">PG2</physics_grid_type>
     <physics_grid_rebalance>None</physics_grid_rebalance>
     <dynamics_namelist_file_name>./data/namelist.nl</dynamics_namelist_file_name>
+    <vertical_coordinate_filename type="file">UNSET</vertical_coordinate_filename>
+    <vertical_coordinate_filename nlev="72">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L72_20220927.nc</vertical_coordinate_filename>
+    <vertical_coordinate_filename nlev="128">${DIN_LOC_ROOT}/atm/scream/init/vertical_coordinates_L128_20220927.nc</vertical_coordinate_filename>
   </grids_manager>
 
   <!-- List of nc files for loading inputs on specified grids -->

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -62,6 +62,9 @@ public:
   // Set AD params
   void set_params (const ekat::ParameterList& params);
 
+  // Init time stamps
+  void init_time_stamps (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0);
+
   // Set AD params
   void init_scorpio (const int atm_id = 0);
 
@@ -93,7 +96,7 @@ public:
   void setup_column_conservation_checks ();
 
   // Load initial conditions for atm inputs
-  void initialize_fields (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0);
+  void initialize_fields ();
 
   // Initialie I/O structures for output
   void initialize_output_managers ();
@@ -202,16 +205,17 @@ protected:
   std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger;
 
   // Some status flags, used to make sure we call the init functions in the right order
-  static constexpr int s_comm_set       =   1;
-  static constexpr int s_params_set     =   2;
-  static constexpr int s_scorpio_inited =   4;
-  static constexpr int s_procs_created  =   8;
-  static constexpr int s_grids_created  =  16;
-  static constexpr int s_fields_created =  32;
-  static constexpr int s_sc_set         =  64;
-  static constexpr int s_output_inited  = 128;
-  static constexpr int s_fields_inited  = 256;
-  static constexpr int s_procs_inited   = 512;
+  static constexpr int s_comm_set       =    1;
+  static constexpr int s_params_set     =    2;
+  static constexpr int s_scorpio_inited =    4;
+  static constexpr int s_procs_created  =    8;
+  static constexpr int s_grids_created  =   16;
+  static constexpr int s_fields_created =   32;
+  static constexpr int s_sc_set         =   64;
+  static constexpr int s_output_inited  =  128;
+  static constexpr int s_fields_inited  =  256;
+  static constexpr int s_procs_inited   =  512;
+  static constexpr int s_ts_inited      = 1024;
 
   // Lazy version to ensure s_atm_inited & flag is true for every flag,
   // even if someone adds new flags later on

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -209,9 +209,7 @@ void SurfaceCouplingExporter::run_impl (const int dt)
 // =========================================================================================
 void SurfaceCouplingExporter::do_export(const Int dt, const bool called_during_initialization)
 {
-  using KT = KokkosTypes<DefaultDevice>;
   using policy_type = KT::RangePolicy;
-  using PF = PhysicsFunctions<DefaultDevice>;
   using PC = physics::Constants<Real>;
 
   const auto& p_int                = get_field_in("p_int").get_view<const Real**>();

--- a/components/eamxx/src/dynamics/homme/CMakeLists.txt
+++ b/components/eamxx/src/dynamics/homme/CMakeLists.txt
@@ -137,7 +137,7 @@ macro (CreateDynamicsLib HOMME_TARGET NP PLEV QSIZE)
     # Create library
     set (dynLibName scream_${hommeLibName})
     add_library(${dynLibName} ${SCREAM_DYNAMICS_SOURCES})
-    target_link_libraries(${dynLibName} scream_share ${hommeLibName})
+    target_link_libraries(${dynLibName} scream_share scream_io ${hommeLibName})
     get_target_property(modulesDir ${hommeLibName} Fortran_MODULE_DIRECTORY)
     set_target_properties(${dynLibName} PROPERTIES Fortran_MODULE_DIRECTORY ${modulesDir})
     target_include_directories(${dynLibName} PUBLIC ${modulesDir})

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -60,9 +60,6 @@ protected:
   // Restart homme
   void restart_homme_state ();
 
-  // Read vertical coordinates and set them in hommexx's structures
-  void init_homme_vcoord ();
-
   // Updates p_mid
   void update_pressure (const std::shared_ptr<const AbstractGrid>& grid);
 

--- a/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
+++ b/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
@@ -181,6 +181,7 @@ void HommeGridsManager::build_dynamics_grid () {
 
   initialize_vertical_coordinates(dyn_grid);
 
+  dyn_grid->m_short_name = "_dyn";
   add_grid(dyn_grid);
 }
 
@@ -259,6 +260,7 @@ build_physics_grid (const ci_string& type, const ci_string& rebalance) {
     phys_grid->set_geometry_data(hybm);
   }
 
+  phys_grid->m_short_name = type;
   add_grid(phys_grid);
 }
 

--- a/components/eamxx/src/dynamics/homme/homme_grids_manager.hpp
+++ b/components/eamxx/src/dynamics/homme/homme_grids_manager.hpp
@@ -39,6 +39,9 @@ protected:
 
   void build_pg_codes ();
 
+  // Read vertical coordinates and set them in hommexx's structures
+  void initialize_vertical_coordinates (const nonconstgrid_ptr_type& dyn_grid);
+
   ekat::Comm            m_comm;
 
   ekat::ParameterList   m_params;

--- a/components/eamxx/src/dynamics/homme/interface/dyn_grid_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/dyn_grid_mod.F90
@@ -54,7 +54,7 @@ contains
     !
     ! Inputs
     !
-    real(kind=c_double), intent(out) :: lat (:), lon(:)
+    real(kind=c_double), intent(out) :: lat (:,:,:), lon(:,:,:)
     integer(kind=c_int), intent(out) :: cg_gids (:), dg_gids(:), elgpgp(:,:)
     !
     ! Local(s)
@@ -85,8 +85,8 @@ contains
           idof = (ie-1)*16+(jp-1)*4+ip
           cg_gids(idof) = INT(el_cg_gids(ip,jp,ie),kind=c_int)
           dg_gids(idof) = INT(el_dg_gids(ip,jp,ie),kind=c_int)
-          lat(idof)  = elem(ie)%spherep(ip,jp)%lat * 180.0_c_double/pi
-          lon(idof)  = elem(ie)%spherep(ip,jp)%lon * 180.0_c_double/pi
+          lat(ip,jp,ie)  = elem(ie)%spherep(ip,jp)%lat * 180.0_c_double/pi
+          lon(ip,jp,ie)  = elem(ie)%spherep(ip,jp)%lon * 180.0_c_double/pi
           elgpgp(1,idof) = ie-1
           elgpgp(2,idof) = jp-1
           elgpgp(3,idof) = ip-1

--- a/components/eamxx/src/dynamics/homme/interface/homme_grid_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_grid_mod.F90
@@ -103,7 +103,7 @@ contains
     !
     ! Local(s)
     !
-    real(kind=c_double), pointer :: lat (:), lon(:)
+    real(kind=c_double), pointer :: lat (:,:,:), lon(:,:,:)
     integer(kind=c_int), pointer :: cg_gids (:), dg_gids(:), elgpgp(:,:)
 
     ! Sanity check
@@ -112,8 +112,8 @@ contains
     call c_f_pointer (dg_gids_ptr, dg_gids, [nelemd*np*np])
     call c_f_pointer (cg_gids_ptr, cg_gids, [nelemd*np*np])
     call c_f_pointer (elgpgp_ptr,  elgpgp,  [3,nelemd*np*np])
-    call c_f_pointer (lat_ptr,     lat,     [nelemd*np*np])
-    call c_f_pointer (lon_ptr,     lon,     [nelemd*np*np])
+    call c_f_pointer (lat_ptr,     lat,     [np,np,nelemd])
+    call c_f_pointer (lon_ptr,     lon,     [np,np,nelemd])
 
     call get_my_dyn_data (dg_gids, cg_gids, elgpgp, lat, lon)
   end subroutine get_dyn_grid_data_f90

--- a/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
+++ b/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
@@ -53,7 +53,7 @@ PhysicsDynamicsRemapper (const grid_ptr_type& phys_grid,
   m_phys_grid = phys_grid;
 
   m_num_phys_cols = phys_grid->get_num_local_dofs();
-  m_lid2elgp      = m_dyn_grid->get_lid_to_idx_map();
+  m_lid2elgp      = m_dyn_grid->get_lid_to_idx_map().get_view<const int**>();
 
   // For each phys dofs, we find a corresponding dof in the dyn grid.
   // Notice that such dyn dof may not be unique (if phys dof is on an edge
@@ -734,8 +734,10 @@ create_p2d_map () {
 
   auto se_dyn = std::dynamic_pointer_cast<const SEGrid>(m_dyn_grid);
   EKAT_REQUIRE_MSG(se_dyn, "Error! Something went wrong casting dyn grid to a SEGrid.\n");
-  auto dyn_gids  = se_dyn->get_cg_dofs_gids();
-  auto phys_gids = m_phys_grid->get_dofs_gids();
+
+  using gid_t = AbstractGrid::gid_type;
+  auto dyn_gids  = se_dyn->get_cg_dofs_gids().get_view<const gid_t*>();
+  auto phys_gids = m_phys_grid->get_dofs_gids().get_view<const gid_t*>();
 
   auto policy = KokkosTypes<DefaultDevice>::RangePolicy(0,num_phys_dofs);
   m_p2d = decltype(m_p2d) ("",num_phys_dofs);

--- a/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -80,7 +80,7 @@ protected:
   grid_ptr_type     m_phys_grid;
 
   int m_num_phys_cols;
-  typename grid_type::lid_to_idx_map_type    m_lid2elgp;
+  typename Field::view_dev_t<const int**>  m_lid2elgp;
 
   std::shared_ptr<Homme::BoundaryExchange>  m_be;
 

--- a/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -65,6 +65,7 @@ TEST_CASE("dyn_grid_io")
   // Create the grids
   ekat::ParameterList params;
   params.set<std::string>("physics_grid_type","GLL");
+  params.set<std::string>("vertical_coordinate_filename","NONE");
   auto gm = std::make_shared<HommeGridsManager>(comm,params);
   gm->build_grids();
 

--- a/components/eamxx/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/eamxx/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -80,12 +80,9 @@ TEST_CASE("remap", "") {
   // Get physics and dynamics grids, and their dofs
   auto phys_grid = gm.get_grid("Physics GLL");
   auto dyn_grid  = std::dynamic_pointer_cast<const SEGrid>(gm.get_grid("Dynamics"));
-  auto h_p_dofs = Kokkos::create_mirror_view(phys_grid->get_dofs_gids());
-  auto h_d_dofs = Kokkos::create_mirror_view(dyn_grid->get_cg_dofs_gids());
-  auto h_d_lid2idx = Kokkos::create_mirror_view(dyn_grid->get_lid_to_idx_map());
-  Kokkos::deep_copy(h_p_dofs,phys_grid->get_dofs_gids());
-  Kokkos::deep_copy(h_d_dofs,dyn_grid->get_cg_dofs_gids());
-  Kokkos::deep_copy(h_d_lid2idx,dyn_grid->get_lid_to_idx_map());
+  auto h_p_dofs = phys_grid->get_dofs_gids().get_view<const gid_t*,Host>();
+  auto h_d_dofs = dyn_grid->get_cg_dofs_gids().get_view<const gid_t*,Host>();
+  auto h_d_lid2idx = dyn_grid->get_lid_to_idx_map().get_view<const int**,Host>();
 
   // Get some dimensions for Homme
   constexpr int np  = HOMMEXX_NP;
@@ -616,12 +613,9 @@ TEST_CASE("combo_remap", "") {
   // Get physics and dynamics grids, and their dofs
   auto phys_grid = gm.get_grid("Physics GLL");
   auto dyn_grid  = std::dynamic_pointer_cast<const SEGrid>(gm.get_grid("Dynamics"));
-  auto h_p_dofs = Kokkos::create_mirror_view(phys_grid->get_dofs_gids());
-  auto h_d_dofs = Kokkos::create_mirror_view(dyn_grid->get_cg_dofs_gids());
-  auto h_d_lid2idx = Kokkos::create_mirror_view(dyn_grid->get_lid_to_idx_map());
-  Kokkos::deep_copy(h_p_dofs,phys_grid->get_dofs_gids());
-  Kokkos::deep_copy(h_d_dofs,dyn_grid->get_cg_dofs_gids());
-  Kokkos::deep_copy(h_d_lid2idx,dyn_grid->get_lid_to_idx_map());
+  auto h_p_dofs = phys_grid->get_dofs_gids().get_view<const gid_t*,Host>();
+  auto h_d_dofs = dyn_grid->get_cg_dofs_gids().get_view<const gid_t*,Host>();
+  auto h_d_lid2idx = dyn_grid->get_lid_to_idx_map().get_view<const int**,Host>();
 
   // Get some dimensions for Homme
   constexpr int np  = HOMMEXX_NP;

--- a/components/eamxx/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/eamxx/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -69,6 +69,7 @@ TEST_CASE("remap", "") {
   // Create the grids
   ekat::ParameterList params;
   params.set<std::string>("physics_grid_type","GLL");
+  params.set<std::string>("vertical_coordinate_filename","NONE");
   HommeGridsManager gm(comm,params);
   gm.build_grids();
 
@@ -602,6 +603,7 @@ TEST_CASE("combo_remap", "") {
   // Create the grids
   ekat::ParameterList params;
   params.set<std::string>("physics_grid_type","GLL");
+  params.set<std::string>("vertical_coordinate_filename","NONE");
   HommeGridsManager gm(comm,params);
   gm.build_grids();
 

--- a/components/eamxx/src/mct_coupling/atm_comp_mct.F90
+++ b/components/eamxx/src/mct_coupling/atm_comp_mct.F90
@@ -142,9 +142,13 @@ CONTAINS
     !----------------------------------------------------------------------------
 
     ! Init the AD
+    call seq_timemgr_EClockGetData(EClock, curr_ymd=cur_ymd, curr_tod=cur_tod, start_ymd=case_start_ymd, start_tod=case_start_tod)
     call string_f2c(yaml_fname,yaml_fname_c)
     call string_f2c(trim(atm_log_fname),atm_log_fname_c)
-    call scream_create_atm_instance (mpicom_atm, ATM_ID, yaml_fname_c, atm_log_fname_c)
+    call scream_create_atm_instance (mpicom_atm, ATM_ID, yaml_fname_c, atm_log_fname_c, &
+                          INT(cur_ymd,kind=C_INT),  INT(cur_tod,kind=C_INT), &
+                          INT(case_start_ymd,kind=C_INT), INT(case_start_tod,kind=C_INT))
+
 
     ! Init MCT gsMap
     call atm_Set_gsMap_mct (mpicom_atm, ATM_ID, gsMap_atm)
@@ -166,7 +170,6 @@ CONTAINS
       print *, "[eamxx] ERROR! Unsupported starttype: "//trim(run_type)
       call mpi_abort(mpicom_atm,ierr,mpi_ierr)
     endif
-    call seq_timemgr_EClockGetData(EClock, curr_ymd=cur_ymd, curr_tod=cur_tod, start_ymd=case_start_ymd, start_tod=case_start_tod)
 
     ! Init surface coupling stuff in the AD
     call scream_set_cpl_indices (x2a, a2x)
@@ -180,8 +183,7 @@ CONTAINS
                                         c_loc(export_constant_multiple), c_loc(do_export_during_init), &
                                         num_cpl_exports, num_scream_exports, export_field_size)
 
-    call scream_init_atm (INT(cur_ymd,kind=C_INT),  INT(cur_tod,kind=C_INT), &
-                          INT(case_start_ymd,kind=C_INT), INT(case_start_tod,kind=C_INT))
+    call scream_init_atm ()
 
   end subroutine atm_init_mct
 

--- a/components/eamxx/src/mct_coupling/scream_f2c_mod.F90
+++ b/components/eamxx/src/mct_coupling/scream_f2c_mod.F90
@@ -13,12 +13,16 @@ interface
   ! It does *NOT* initialize the fields and the atm processes, nor it initializes
   ! any structure related to the component coupler. Other subroutines
   ! will have to be called *after* this one, to achieve that.
-  subroutine scream_create_atm_instance (f_comm,atm_id,yaml_fname,atm_log_fname) bind(c)
+  subroutine scream_create_atm_instance (f_comm,atm_id,yaml_fname,atm_log_fname, &
+                                         run_start_ymd,run_start_tod, &
+                                         case_start_ymd,case_start_tod) bind(c)
     use iso_c_binding, only: c_int, c_char
     !
     ! Input(s)
     !
     integer (kind=c_int), value, intent(in) :: f_comm, atm_id
+    integer (kind=c_int),  value, intent(in) :: run_start_tod, run_start_ymd
+    integer (kind=c_int),  value, intent(in) :: case_start_tod, case_start_ymd
     character(kind=c_char), target, intent(in) :: yaml_fname(*), atm_log_fname(*)
   end subroutine scream_create_atm_instance
 
@@ -70,13 +74,7 @@ interface
   ! During this call, all fields are initialized (i.e., initial conditions are
   ! loaded), as well as the atm procs (which might use some initial conditions
   ! to further initialize internal structures), and the output manager.
-  subroutine scream_init_atm (run_start_ymd,run_start_tod,case_start_ymd,case_start_tod) bind(c)
-    use iso_c_binding, only: c_int
-    !
-    ! Input(s)
-    !
-    integer (kind=c_int),  value, intent(in) :: run_start_tod, run_start_ymd
-    integer (kind=c_int),  value, intent(in) :: case_start_tod, case_start_ymd
+  subroutine scream_init_atm () bind(c)
   end subroutine scream_init_atm
 
   ! This subroutine will run the whole atm model for one atm timestep

--- a/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -372,10 +372,8 @@ void RRTMGPRadiation::run_impl (const int dt) {
   using CO = scream::ColumnOps<DefaultDevice,Real>;
 
   // get a host copy of lat/lon
-  auto h_lat  = Kokkos::create_mirror_view(m_lat);
-  auto h_lon  = Kokkos::create_mirror_view(m_lon);
-  Kokkos::deep_copy(h_lat,m_lat);
-  Kokkos::deep_copy(h_lon,m_lon);
+  auto h_lat  = m_lat.get_view<const Real*,Host>();
+  auto h_lon  = m_lon.get_view<const Real*,Host>();
 
   // Get data from the FieldManager
   auto d_pmid = get_field_in("p_mid").get_view<const Real**>();
@@ -678,7 +676,7 @@ void RRTMGPRadiation::run_impl (const int dt) {
         } else {
           // This gives (dry) mass mixing ratios
           scream::physics::trcmix(
-            name, m_lat, d_pmid, d_vmr,
+            name, m_lat.get_view<const Real*>(), d_pmid, d_vmr,
             m_co2vmr, m_n2ovmr, m_ch4vmr, m_f11vmr, m_f12vmr
           );
           // Back out volume mixing ratios

--- a/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -51,8 +51,8 @@ public:
   int m_col_chunk_size;
   std::vector<int> m_col_chunk_beg;
   int m_nlay;
-  view_1d_real m_lat;
-  view_1d_real m_lon;
+  Field m_lat;
+  Field m_lon;
 
   // Whether we use aerosol forcing in radiation
   bool m_do_aerosol_rad;

--- a/components/eamxx/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/eamxx/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -35,8 +35,8 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   m_num_cols = m_grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = m_grid->get_num_vertical_levels();  // Number of levels per column
 
-  m_cell_area = m_grid->get_geometry_data("area"); // area of each cell
-  m_cell_lat  = m_grid->get_geometry_data("lat"); // area of each cell
+  m_cell_area = m_grid->get_geometry_data("area").get_view<const Real*>(); // area of each cell
+  m_cell_lat  = m_grid->get_geometry_data("lat").get_view<const Real*>(); // area of each cell
 
   // Define the different field layouts that will be used for this process
   using namespace ShortFieldTagsNames;
@@ -425,8 +425,8 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   // maximum number of levels in pbl from surface
   const auto pref_mid = m_buffer.pref_mid;
   const auto s_pref_mid = ekat::scalarize(pref_mid);
-  const auto hyam = m_grid->get_geometry_data("hyam");
-  const auto hybm = m_grid->get_geometry_data("hybm");
+  const auto hyam = m_grid->get_geometry_data("hyam").get_view<const Real*>();
+  const auto hybm = m_grid->get_geometry_data("hybm").get_view<const Real*>();
   const auto ps0 = C::P0;
   const auto psref = ps0;
   Kokkos::parallel_for(Kokkos::RangePolicy<>(0, m_num_levs), KOKKOS_LAMBDA (const int lev) {

--- a/components/eamxx/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/eamxx/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -548,8 +548,8 @@ protected:
   Int m_num_tracers;
   Int hdtime;
 
-  KokkosTypes<DefaultDevice>::view_1d<Real> m_cell_area;
-  KokkosTypes<DefaultDevice>::view_1d<Real> m_cell_lat;
+  KokkosTypes<DefaultDevice>::view_1d<const Real> m_cell_area;
+  KokkosTypes<DefaultDevice>::view_1d<const Real> m_cell_lat;
 
   // Struct which contains local variables
   Buffer m_buffer;

--- a/components/eamxx/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/eamxx/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -36,7 +36,7 @@ void SPA::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   const auto& grid_name = m_grid->name();
   m_num_cols = m_grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = m_grid->get_num_vertical_levels();  // Number of levels per column
-  m_dofs_gids = m_grid->get_dofs_gids();
+  m_dofs_gids = m_grid->get_dofs_gids().get_view<const gid_type*>();
   m_min_global_dof    = m_grid->get_global_min_dof_gid();
 
   // Define the different field layouts that will be used for this process

--- a/components/eamxx/src/physics/spa/atmosphere_prescribed_aerosol.hpp
+++ b/components/eamxx/src/physics/spa/atmosphere_prescribed_aerosol.hpp
@@ -31,7 +31,7 @@ public:
   using view_1d         = typename SPAFunc::view_1d<Spack>;
   using view_2d         = typename SPAFunc::view_2d<Spack>;
   using view_3d         = typename SPAFunc::view_3d<Spack>;
-  using view_1d_dof     = typename SPAFunc::view_1d<gid_type>;
+  using view_1d_dof     = typename SPAFunc::view_1d<const gid_type>;
 
   template<typename ScalarT>
   using uview_1d = Unmanaged<typename KT::template view_1d<ScalarT>>;

--- a/components/eamxx/src/physics/spa/spa_functions.hpp
+++ b/components/eamxx/src/physics/spa/spa_functions.hpp
@@ -172,15 +172,15 @@ struct SPAFunctions
     const SPAOutput&  data_out);
 
   static void get_remap_weights_from_file(
-    const std::string&       remap_file_name,
-    gid_type                 min_dof,
-    const view_1d<gid_type>& dofs_gids,
-          SPAHorizInterp&    spa_horiz_interp);
+    const std::string&             remap_file_name,
+    const gid_type                 min_dof,
+    const view_1d<const gid_type>& dofs_gids,
+          SPAHorizInterp&          spa_horiz_interp);
 
   static void set_remap_weights_one_to_one(
-    gid_type                 min_dof,
-    const view_1d<gid_type>& dofs_gids,
-          SPAHorizInterp&    spa_horiz_interp);
+    gid_type                       min_dof,
+    const view_1d<const gid_type>& dofs_gids,
+          SPAHorizInterp&          spa_horiz_interp);
 
   static void update_spa_data_from_file(
     const std::string&    spa_data_file_name,

--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -87,7 +87,7 @@ if (NOT SCREAM_LIB_ONLY)
     grid/mesh_free_grids_manager.cpp
     util/scream_test_session.cpp
   )
-  target_link_libraries(scream_test_support PUBLIC scream_share)
+  target_link_libraries(scream_test_support PUBLIC scream_share scream_io)
 
   add_subdirectory(tests)
 endif()

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -275,7 +275,7 @@ void AtmosphereProcess::run_property_check (const prop_check_ptr&       property
           idx.erase(idx.begin()+pos);
         } else if (iti!=tags.end()) {
           auto pos = std::distance(tags.begin(),iti);
-          tags.erase(itm);
+          tags.erase(iti);
           idx.erase(idx.begin()+pos);
         }
         ss << "\n *************************** INPUT FIELDS ******************************\n";

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -46,7 +46,8 @@ Field::clone(const std::string& name) const {
   f.get_header().get_tracking().update_time_stamp(ts);
 
   // Deep copy
-  f.deep_copy(*this);
+  f.deep_copy<Device>(*this);
+  f.deep_copy<Host>(*this);
 
   return f;
 }

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -22,9 +22,16 @@ Field::get_const() const {
 
 Field
 Field::clone() const {
+  return clone(name());
+}
 
+Field
+Field::clone(const std::string& name) const {
   // Create new field
-  Field f(get_header().get_identifier());
+  const auto& my_fid = get_header().get_identifier();
+  FieldIdentifier fid(name,my_fid.get_layout(),my_fid.get_units(),
+                      my_fid.get_grid_name(),my_fid.data_type());
+  Field f(fid);
 
   // Ensure alloc props match
   const auto&  ap = get_header().get_alloc_properties();

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -107,6 +107,7 @@ public:
   // Creates a deep copy version of this field.
   // It is created with a pristine header (no providers/customers)
   Field clone () const;
+  Field clone (const std::string& name) const;
 
   // Allows to get the underlying view, reshaped for a different data type.
   // The class will check that the requested data type is compatible with the

--- a/components/eamxx/src/share/field/field_header.hpp
+++ b/components/eamxx/src/share/field/field_header.hpp
@@ -47,6 +47,8 @@ public:
   // Assignment deleted, to prevent sneaky overwrites.
   FieldHeader& operator= (const FieldHeader&) = delete;
 
+  std::shared_ptr<FieldHeader> alias (const std::string& name) const;
+
   // Set extra data
   void set_extra_data (const std::string& key,
                        const ekat::any& data,
@@ -85,6 +87,10 @@ protected:
   create_subfield_header (const FieldIdentifier&,
                           std::shared_ptr<FieldHeader>,
                           const int, const int, const bool);
+
+  friend std::shared_ptr<FieldHeader>
+  create_alias (const FieldHeader&,
+                const std::string&);
 
   // Static information about the field: name, rank, tags
   identifier_type                 m_identifier;

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -146,14 +146,6 @@ AbstractGrid::get_geometry_data (const std::string& name) const {
 }
 
 Field
-AbstractGrid::get_geometry_data_nonconst (const std::string& name) const {
-  EKAT_REQUIRE_MSG (has_geometry_data(name),
-      "Error! Geometry data '" + name + "' not found.\n");
-
-  return m_geo_fields.at(name);
-}
-
-Field
 AbstractGrid::create_geometry_data (const FieldIdentifier& fid)
 {
   const auto& name = fid.name();

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -1,5 +1,7 @@
 #include "share/grid/abstract_grid.hpp"
 
+#include "share/field/field_utils.hpp"
+
 #include <algorithm>
 #include <cstring>
 #include <string>
@@ -36,14 +38,11 @@ void AbstractGrid::add_alias (const std::string& alias)
 }
 
 bool AbstractGrid::is_unique () const {
-  EKAT_REQUIRE_MSG (m_dofs_set,
-      "Error! We cannot establish if this grid is unique before the dofs GIDs are set.\n");
-
-  // Get a copy of gids on host. CAREFUL: do not use create_mirror_view,
-  // since it would create a shallow copy on CPU devices, but we need a
-  // deep copy, to prevent altering order of gids.
-  decltype(m_dofs_gids)::HostMirror dofs_h("",m_dofs_gids.size());
-  Kokkos::deep_copy(dofs_h,m_dofs_gids);
+  // Get a copy of gids on host. CAREFUL: do not use the stored dofs,
+  // since we need to sort dofs in order to call unique, and we don't
+  // want to alter the order of gids in this grid.
+  auto dofs = m_dofs_gids.clone();
+  auto dofs_h = dofs.get_view<gid_type*,Host>();
 
   std::sort(dofs_h.data(),dofs_h.data()+m_num_local_dofs);
   auto unique_end = std::unique(dofs_h.data(),dofs_h.data()+m_num_local_dofs);
@@ -58,7 +57,7 @@ bool AbstractGrid::is_unique () const {
   // Each rank has unique gids locally. Now it's time to verify if they are also globally unique.
   int max_dofs;
   m_comm.all_reduce(&m_num_local_dofs,&max_dofs,1,MPI_MAX);
-  std::vector<int> gids(max_dofs);
+  std::vector<gid_type> gids(max_dofs,-1);
   int unique_gids = 1;
 
   for (int pid=0; pid<m_comm.size(); ++pid) {
@@ -98,148 +97,96 @@ bool AbstractGrid::is_unique () const {
   return unique_gids;
 }
 
-void AbstractGrid::
-set_dofs (const dofs_list_type& dofs)
+auto AbstractGrid::
+get_global_min_dof_gid () const ->gid_type
 {
-  // Sanity checks
-  EKAT_REQUIRE_MSG (not m_dofs_set, "Error! Dofs cannot be re-set, once set.\n");
-
-  EKAT_REQUIRE_MSG (dofs.extent_int(0)==m_num_local_dofs,
-      "Error! Wrong size for the input dofs list. It should match the number of local dofs stored in the mesh.\n"
-      "       Expected gids list size: " + std::to_string(m_num_local_dofs) + "\n"
-      "       Input gids list size   : " + std::to_string(dofs.size()) + "\n");
-
-  m_dofs_gids  = dofs;
-  m_dofs_set = true;
-
-#ifndef NDEBUG
-  EKAT_REQUIRE_MSG(this->valid_dofs_list(dofs), "Error! Invalid list of dofs gids.\n");
-#endif
-
-  m_dofs_gids_host = Kokkos::create_mirror_view(m_dofs_gids);
-  Kokkos::deep_copy(m_dofs_gids_host,m_dofs_gids);
-
-  set_global_min_dof_gid();
-  set_global_max_dof_gid();
+  // Lazy calculation
+  if (m_global_min_dof_gid==std::numeric_limits<gid_type>::max()) {
+    m_global_min_dof_gid = field_min<gid_type>(m_dofs_gids,&get_comm());
+  }
+  return m_global_min_dof_gid;
 }
 
-const AbstractGrid::dofs_list_type&
-AbstractGrid::get_dofs_gids () const {
-  // Sanity check
-  EKAT_REQUIRE_MSG (m_dofs_set, "Error! You must call 'set_dofs' first.\n");
+auto AbstractGrid::
+get_global_max_dof_gid () const ->gid_type
+{
+  // Lazy calculation
+  if (m_global_max_dof_gid==-std::numeric_limits<gid_type>::max()) {
+    m_global_max_dof_gid = field_max<gid_type>(m_dofs_gids,&get_comm());
+  }
+  return m_global_max_dof_gid;
+}
 
+Field
+AbstractGrid::get_dofs_gids () const {
+  return m_dofs_gids.get_const();
+}
+
+Field
+AbstractGrid::get_dofs_gids () {
   return m_dofs_gids;
 }
 
-const AbstractGrid::dofs_list_h_type&
-AbstractGrid::get_dofs_gids_host () const {
-  // Sanity check
-  EKAT_REQUIRE_MSG (m_dofs_set, "Error! You must call 'set_dofs' first.\n");
-
-  return m_dofs_gids_host;
-}
-
-
-void AbstractGrid::
-set_lid_to_idx_map (const lid_to_idx_map_type& lid_to_idx)
-{
-  // Sanity checks
-  EKAT_REQUIRE_MSG (not m_lid_to_idx_set, "Error! The lid->idx map cannot be re-set, once set.\n");
-
-  EKAT_REQUIRE_MSG (lid_to_idx.extent_int(0)==m_num_local_dofs &&
-                    lid_to_idx.extent_int(1)==get_2d_scalar_layout().rank(),
-      "Error! Wrong size(s) for the input lid_to_idx map. They should match (num_local_dofs, 2d layout rank).\n"
-      "       Expected sizes: (" + std::to_string(m_num_local_dofs) + "," + std::to_string(get_2d_scalar_layout().rank()) + ")\n"
-      "       Input map sizes: (" + std::to_string(lid_to_idx.extent(0)) + "," + std::to_string(lid_to_idx.extent(1)) + ")\n");
-
-#ifndef NDEBUG
-  EKAT_REQUIRE_MSG(this->valid_lid_to_idx_map(lid_to_idx), "Error! Invalid lid->idx map.\n");
-#endif
-
-  m_lid_to_idx = lid_to_idx;
-  m_lid_to_idx_set = true;
-}
-
-const AbstractGrid::lid_to_idx_map_type&
+Field
 AbstractGrid::get_lid_to_idx_map () const {
-  // Sanity check
-  EKAT_REQUIRE_MSG (m_dofs_gids.size()>0, "Error! You must call 'set_dofs' first.\n");
+  return m_lid_to_idx.get_const();
+}
 
+Field
+AbstractGrid::get_lid_to_idx_map () {
   return m_lid_to_idx;
 }
 
-void AbstractGrid::
-set_geometry_data (const std::string& name, const geo_view_type& data) {
-  m_geo_views[name] = data;
-  m_geo_views_host[name] = Kokkos::create_mirror_view(data);
-  Kokkos::deep_copy(m_geo_views_host[name],data);
-}
-
-const AbstractGrid::geo_view_type&
+Field
 AbstractGrid::get_geometry_data (const std::string& name) const {
-  EKAT_REQUIRE_MSG (m_geo_views.find(name)!=m_geo_views.end(),
-                    "Error! Grid '" + m_name + "' does not store geometric data '" + name + "'.\n");
-  return m_geo_views.at(name);
+  EKAT_REQUIRE_MSG (has_geometry_data(name),
+      "Error! Geometry data '" + name + "' not found.\n");
+
+  return m_geo_fields.at(name).get_const();
 }
 
-const AbstractGrid::geo_view_h_type&
-AbstractGrid::get_geometry_data_host (const std::string& name) const {
-  EKAT_REQUIRE_MSG (m_geo_views_host.find(name)!=m_geo_views_host.end(),
-                    "Error! Grid '" + m_name + "' does not store geometric data '" + name + "'.\n");
-  return m_geo_views_host.at(name);
+Field
+AbstractGrid::get_geometry_data_nonconst (const std::string& name) const {
+  EKAT_REQUIRE_MSG (has_geometry_data(name),
+      "Error! Geometry data '" + name + "' not found.\n");
+
+  return m_geo_fields.at(name);
+}
+
+Field
+AbstractGrid::create_geometry_data (const FieldIdentifier& fid)
+{
+  const auto& name = fid.name();
+
+  EKAT_REQUIRE_MSG (not has_geometry_data(name),
+      "Error! Cannot create geometry data, since it already exists.\n"
+      "  - grid name: " + this->name() + "\n"
+      "  - geo data name: " + name + "\n"
+      "  - geo data layout: " + to_string(m_geo_fields.at(name).get_header().get_identifier().get_layout()) + "\n"
+      "  - input layout: " + to_string(fid.get_layout()) + "\n");
+
+  // Create field and the read only copy as well
+  auto& f = m_geo_fields[name] = Field(fid);
+  f.allocate_view();
+  return f;
 }
 
 void
-AbstractGrid::set_global_min_dof_gid ()
+AbstractGrid::set_geometry_data (const Field& f)
 {
-  EKAT_REQUIRE_MSG (m_dofs_set,
-      "Error! You need to set dofs gids before you can compute the global min dof.\n");
-  gid_type local_min = get_num_global_dofs(); // the local min should be <= than the size of the grid.
-  gid_type global_min;
-  if (get_num_local_dofs()>0) {
-    auto dofs = get_dofs_gids();
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,get_num_local_dofs()),
-        KOKKOS_LAMBDA (const int& i, gid_type& lmin) {
-          if (dofs(i) < lmin) {
-            lmin = dofs(i);
-          }
-        },Kokkos::Min<gid_type>(local_min));
-    Kokkos::fence();
-  }
+  EKAT_REQUIRE_MSG (not has_geometry_data(f.name()),
+      "Error! Cannot set geometry data, since it already exists.\n"
+      "  - grid name: " + this->name() + "\n"
+      "  - geo data name: " + f.name() + "\n");
 
-  m_comm.all_reduce(&local_min,&global_min,1,MPI_MIN);
-
-  m_global_min_dof_gid = global_min;
-}
-
-void
-AbstractGrid::set_global_max_dof_gid ()
-{
-  EKAT_REQUIRE_MSG (m_dofs_set,
-      "Error! You need to set dofs gids before you can compute the global max dof.\n");
-  gid_type local_max = -1;
-  gid_type global_max;
-  if (get_num_local_dofs()>0) {
-    auto dofs = get_dofs_gids();
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<>(0,get_num_local_dofs()),
-        KOKKOS_LAMBDA (const int& i, gid_type& lmax) {
-          if (dofs(i) > lmax) {
-            lmax = dofs(i);
-          }
-        },Kokkos::Max<gid_type>(local_max));
-    Kokkos::fence();
-  }
-
-  m_comm.all_reduce(&local_max,&global_max,1,MPI_MAX);
-
-  m_global_max_dof_gid = global_max;
+  m_geo_fields[f.name()] = f;
 }
 
 std::list<std::string>
 AbstractGrid::get_geometry_data_names () const
 {
   std::list<std::string> names;
-  for (const auto& it : m_geo_views) {
+  for (const auto& it : m_geo_fields) {
     names.push_back(it.first);
   }
   return names;
@@ -270,7 +217,8 @@ AbstractGrid::get_unique_gids () const
   // Gather all dofs
   const auto mpi_gid_t = ekat::get_mpi_type<gid_type>();
   std::vector<gid_type> all_gids (m_num_global_dofs);
-  MPI_Allgatherv (m_dofs_gids_host.data(),m_num_local_dofs,mpi_gid_t,
+  auto dofs_gids_h = m_dofs_gids.get_view<const gid_type*,Host>();
+  MPI_Allgatherv (dofs_gids_h.data(),m_num_local_dofs,mpi_gid_t,
                   all_gids.data(),ngids.data(),offsets.data(),
                   mpi_gid_t,m_comm.mpi_comm());
 
@@ -278,8 +226,8 @@ AbstractGrid::get_unique_gids () const
   std::vector<gid_type> unique_dofs;
   const auto all_gids_beg = all_gids.begin();
   const auto all_gids_end = all_gids.begin() + offsets[m_comm.rank()];
-  const auto my_gids_beg = m_dofs_gids_host.data();
-  const auto my_gids_end = m_dofs_gids_host.data() + m_num_local_dofs;
+  const auto my_gids_beg = dofs_gids_h.data();
+  const auto my_gids_end = dofs_gids_h.data() + m_num_local_dofs;
   for (auto it=my_gids_beg; it!=my_gids_end; ++it) {
     if (std::find(all_gids_beg,all_gids_end,*it)==all_gids_end) {
       unique_dofs.push_back(*it);
@@ -290,11 +238,8 @@ AbstractGrid::get_unique_gids () const
 }
 
 std::vector<int> AbstractGrid::
-get_owners (const hview_1d<const gid_type>& gids) const
+get_owners (const gid_view_h& gids) const
 {
-  EKAT_REQUIRE_MSG (m_dofs_set,
-      "Error! Cannot retrieve gids owners until dofs gids have been set.\n");
-
   const auto& comm = get_comm();
 
   // Init owners to in
@@ -307,7 +252,11 @@ get_owners (const hview_1d<const gid_type>& gids) const
 
   // Let each rank bcast its owned gids, so that other procs can
   // check against their input list
-  auto my_gids_h = m_dofs_gids_host;
+  // Note: we can't use a view of const, since the view ptr needs to be passed
+  //       to MPI bcast routines, which expect pointer to nonconst. It's an
+  //       innocuous issue though, since only the send rank will use the ptr
+  //       from the view, and it's not writing in it.
+  auto my_gids_h = m_dofs_gids.get_view<gid_type*,Host>();
   gid_type* data;
   std::vector<gid_type> pid_gids;
   for (int pid=0; pid<comm.size(); ++pid) {
@@ -353,49 +302,42 @@ get_owners (const hview_1d<const gid_type>& gids) const
   return result;
 }
 
-void AbstractGrid::copy_views (const AbstractGrid& src, const bool shallow)
+void AbstractGrid::create_dof_fields (const int scalar2d_layout_rank)
 {
-  if (src.m_dofs_set) {
-    m_dofs_set = false;
-    if (shallow) {
-      set_dofs (src.m_dofs_gids);
-      // set_dof created a new host mirror, so assing that too
-      m_dofs_gids_host = src.m_dofs_gids_host;
-    } else {
-      decltype (src.m_dofs_gids) dofs ("",m_num_local_dofs);
-      Kokkos::deep_copy (dofs,src.get_dofs_gids());
-      set_dofs (dofs);
-    }
+  using namespace ShortFieldTagsNames;
+  const auto units = ekat::units::Units::nondimensional();
+
+  // The dof gids field is a 1d field, while lid2idx has rank 2.
+  // For both, the 1st dim is the num of local dofs. The 2nd dime of
+  // lid2idx is the rank of a 2d scalar layout.
+  FieldLayout dof_layout({COL},{get_num_local_dofs()});
+  FieldLayout lid2idx_layout({COL,CMP},{get_num_local_dofs(),scalar2d_layout_rank});
+  m_dofs_gids = Field(FieldIdentifier("gids",dof_layout,units,m_name,DataType::IntType));
+  m_lid_to_idx = Field(FieldIdentifier("lid2idx",lid2idx_layout,units,m_name,DataType::IntType));
+
+  m_dofs_gids.allocate_view();
+  m_lid_to_idx.allocate_view();
+}
+
+void AbstractGrid::copy_data (const AbstractGrid& src, const bool shallow)
+{
+  if (shallow) {
+    m_dofs_gids = src.m_dofs_gids;
+  } else {
+    m_dofs_gids = src.m_dofs_gids.clone();
   }
 
-  if (src.m_lid_to_idx_set) {
-    m_lid_to_idx_set = false;
-    if (shallow) {
-      set_lid_to_idx_map (src.get_lid_to_idx_map());
-    } else {
-      decltype (src.m_lid_to_idx) lid2idx ("",m_num_local_dofs,get_2d_scalar_layout().rank());
-      Kokkos::deep_copy (lid2idx,src.m_lid_to_idx);
-      set_lid_to_idx_map (lid2idx);
-    }
+  if (shallow) {
+    m_lid_to_idx = src.m_lid_to_idx;
+  } else {
+    m_lid_to_idx = src.m_lid_to_idx.clone();
   }
 
-  for (const auto& it : src.m_geo_views) {
-    const auto& name = it.first;
+  for (const auto& name : src.get_geometry_data_names()) {
     if (shallow) {
-      m_geo_views[name] = it.second;
+      m_geo_fields[name] = src.m_geo_fields.at(name);
     } else {
-      m_geo_views[name] = geo_view_type("",it.second.size());
-      Kokkos::deep_copy (m_geo_views[name],it.second);
-    }
-  }
-
-  for (const auto& it : src.m_geo_views_host) {
-    const auto& name = it.first;
-    if (shallow) {
-      m_geo_views_host[name] = it.second;
-    } else {
-      m_geo_views_host[name] = geo_view_h_type("",it.second.size());
-      Kokkos::deep_copy (m_geo_views_host[name],it.second);
+      m_geo_fields[name] = src.m_geo_fields.at(name).clone();
     }
   }
 }

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -252,9 +252,8 @@ void AbstractGrid::reset_num_vertical_lev (const int num_vertical_lev) {
   //       invalidate all geo data whose FieldLayout contains LEV/ILEV
 }
 
-auto
+std::vector<AbstractGrid::gid_type>
 AbstractGrid::get_unique_gids () const
- -> dofs_list_type
 {
   // Gather local sizes across all ranks
   std::vector<int> ngids (m_comm.size());
@@ -287,16 +286,11 @@ AbstractGrid::get_unique_gids () const
     }
   }
 
-  dofs_list_type unique_gids_d("",unique_dofs.size());
-  auto unique_gids_h = Kokkos::create_mirror_view(unique_gids_d);
-  std::memcpy(unique_gids_h.data(),unique_dofs.data(),sizeof(gid_type)*unique_dofs.size());
-  Kokkos::deep_copy(unique_gids_d,unique_gids_h);
-  return unique_gids_d;
+  return unique_dofs;
 }
 
-auto AbstractGrid::
+std::vector<int> AbstractGrid::
 get_owners (const hview_1d<const gid_type>& gids) const
- -> hview_1d<int>
 {
   EKAT_REQUIRE_MSG (m_dofs_set,
       "Error! Cannot retrieve gids owners until dofs gids have been set.\n");
@@ -351,7 +345,7 @@ get_owners (const hview_1d<const gid_type>& gids) const
 
 
   // Now create and fill output view
-  hview_1d<int> result("",num_gids_in);
+  std::vector<int> result(num_gids_in);
   for (int i=0; i<num_gids_in; ++i) {
     result[i] = owners.at(gids[i]);
   }

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -37,6 +37,15 @@ void AbstractGrid::add_alias (const std::string& alias)
   }
 }
 
+FieldLayout AbstractGrid::
+get_vertical_layout (const bool midpoints) const
+{
+  using namespace ShortFieldTagsNames;
+  return midpoints ? FieldLayout ({ LEV},{m_num_vert_levs})
+                   : FieldLayout ({ILEV},{m_num_vert_levs+1});
+
+}
+
 bool AbstractGrid::is_unique () const {
   // Get a copy of gids on host. CAREFUL: do not use the stored dofs,
   // since we need to sort dofs in order to call unique, and we don't

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -151,16 +151,15 @@ public:
   // Get a list of GIDs that are unique across all ranks in the grid comm. That is,
   // if a dof is present on 2+ ranks, it will (globally) appear just once in the
   // view returned by this method.
-  dofs_list_type get_unique_gids () const;
+  std::vector<gid_type> get_unique_gids () const;
 
   // For each entry in the input list of GIDs, retrieve the process id that owns it
-  hview_1d<int> get_owners (const hview_1d<const gid_type>& gids) const;
-
-  // Handy version of the above method, to allow passing a std::vector
-  hview_1d<int> get_owners (const std::vector<gid_type>& gids) const {
+  std::vector<int> get_owners (const hview_1d<const gid_type>& gids) const;
+  std::vector<int> get_owners (const std::vector<gid_type>& gids) const {
     hview_1d<const gid_type> gids_v(gids.data(),gids.size());
     return get_owners(gids_v);
   }
+
 protected:
 
   // Derived classes can override these methods, which are called inside the

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -141,6 +141,13 @@ public:
   // dofs have been set to something that satisfies any requirement of the grid type.
   virtual bool check_valid_dofs()        const { return true; }
   virtual bool check_valid_lid_to_idx () const { return true; }
+
+  // This member is used mostly by IO: if a field exists on multiple grids
+  // with the same name, IO can use this as a suffix to diambiguate the fields in
+  // the IO file, by appending each grid's suffix to the fields names.
+  // NOTE: we'd need setter/getter for this, so we might as well make it public
+  std::string m_short_name = "";
+
 protected:
 
   void copy_data (const AbstractGrid& src, const bool shallow = true);

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -98,7 +98,6 @@ public:
 
   // Get geometry-related fields
   Field get_geometry_data (const std::string& name) const;
-  Field get_geometry_data_nonconst (const std::string& name) const;
 
   // Create geometry data, throws if already existing. Returns writable field
   Field create_geometry_data (const FieldIdentifier& fid);

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -64,6 +64,7 @@ public:
   // Native layout of a dof. This is the natural way to index a dof in the grid.
   // E.g., for a scalar 2d field on a SE grid, this will be (nelem,np,np),
   //       for a vector 3d field on a Point grid it will be (ncols,vector_dim,nlevs)
+  FieldLayout get_vertical_layout (const bool midpoints) const;
   virtual FieldLayout get_2d_scalar_layout () const = 0;
   virtual FieldLayout get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const = 0;
   virtual FieldLayout get_3d_scalar_layout (const bool midpoints) const = 0;

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -4,7 +4,7 @@
 #include "ekat/std_meta/ekat_std_enable_shared_from_this.hpp"
 #include "share/grid/grid_utils.hpp"
 #include "share/field/field_layout.hpp"
-#include "share/scream_types.hpp"
+#include "share/field/field.hpp"
 
 #include "ekat/mpi//ekat_comm.hpp"
 
@@ -22,12 +22,12 @@ namespace scream
  * to provide the following information:
  *   - number of local degrees of freedom (dofs) along the horizontal direction
  *   - number of vertical levels
- *   - gids for all local (2d) dofs
+ *   - gids for all local 2d dofs
  *   - type and name of the grid (see grid_utils.hpp for types)
- *   - the layout of a (2d) dof on this grid (see field_layout.hpp)
- *   - the gid of a (2d) dof given indices (i_1,...,i_N), with N being the
+ *   - the layout of a 2d/3d field on this grid (see field_layout.hpp)
+ *   - the mapping of dof lid to a set of indices (i_1,...,i_N), with N being the
  *     rank of the scalar field layout, and i_k less than the i-th dimension
- *     in the scalar field layout
+ *     in the scalar field layout. This is how a dof is 'naturally' indexed on this grid.
  *
  * The methods get_Xd_Y_layout, with X=2,3, and Y=scalar,vector, will return the
  * FieldLayout of a 2d/3d scalar/vector field on this grid.
@@ -40,30 +40,10 @@ namespace scream
 class AbstractGrid : public ekat::enable_shared_from_this<AbstractGrid>
 {
 public:
-  using gid_type            = int;           // TODO: use int64_t? int? template class on gid_type?
-  using device_type         = DefaultDevice; // TODO: template class on device type
-  using kokkos_types        = KokkosTypes<device_type>;
-  using kokkos_types_host   = KokkosTypes<HostDevice>;
-
-  template<typename T>
-  using view_1d = kokkos_types::view_1d<T>;
-  template<typename T>
-  using hview_1d = kokkos_types_host::view_1d<T>;
-  template<typename T>
-  using view_2d = kokkos_types::view_2d<T>;
-
-  using geo_view_type       = view_1d<Real>;
-  using geo_view_h_type     = hview_1d<Real>;
-  using geo_view_map_type   = std::map<std::string,geo_view_type>;
-  using geo_view_h_map_type = std::map<std::string,geo_view_h_type>;
-
-  // The list of all dofs' gids
-  using dofs_list_type   = view_1d<gid_type>;
-  using dofs_list_h_type = hview_1d<gid_type>;
-
-  // Row i of this 2d view gives the indices of the ith local dof
-  // in the native 2d layout
-  using lid_to_idx_map_type = view_2d<int>;
+  // TODO: use int64_t? int? template class on gid_type?
+  // So far, 32 bits seem enough for 2d dofs numbering
+  using gid_type = int;
+  using gid_view_h = Field::view_host_t<const gid_type*>;
 
   // Constructor(s) & Destructor
   AbstractGrid (const std::string& name,
@@ -104,37 +84,35 @@ public:
   // The number of dofs on this MPI rank
   int get_num_local_dofs  () const { return m_num_local_dofs;  }
   gid_type get_num_global_dofs () const { return m_num_global_dofs; }
-  gid_type get_global_min_dof_gid () const { return m_global_min_dof_gid; }
-  gid_type get_global_max_dof_gid () const { return m_global_max_dof_gid; }
+  gid_type get_global_min_dof_gid () const;
+  gid_type get_global_max_dof_gid () const;
 
-  // Set the dofs list
-  // NOTE: this method calls valid_dofs_list, which may contain collective
-  //       operations over the stored communicator.
-  void set_dofs (const dofs_list_type& dofs);
-  void set_global_min_dof_gid ();
-  void set_global_max_dof_gid ();
+  // Get a Field storing 1d data (the dof gids)
+  Field get_dofs_gids () const;
+  Field get_dofs_gids ();
 
-  // Get a 1d view containing the dof gids
-  const dofs_list_type& get_dofs_gids () const;
-  const dofs_list_h_type& get_dofs_gids_host () const;
+  // Get a Field storing 2d data, where (i,j) entry contains the j-th coordinate of
+  // the i-th dof in the native dof layout. Const verison returns a read-only field
+  Field get_lid_to_idx_map () const;
+  Field get_lid_to_idx_map ();
 
-  // Set the the map dof_lid->dof_indices, where the indices are the ones used
-  // to access the dof in the layout returned by get_2d_scalar_layout().
-  // NOTE: this method calls valid_lid_to_idx_map, which may contain collective
-  //       operations over the stored communicator.
-  void set_lid_to_idx_map (const lid_to_idx_map_type& lid_to_idx);
+  // Get geometry-related fields
+  Field get_geometry_data (const std::string& name) const;
+  Field get_geometry_data_nonconst (const std::string& name) const;
 
-  // Get a 2d view, where (i,j) entry contains the j-th coordinate of
-  // the i-th dof in the native dof layout.
-  const lid_to_idx_map_type& get_lid_to_idx_map () const;
+  // Create geometry data, throws if already existing. Returns writable field
+  Field create_geometry_data (const FieldIdentifier& fid);
+  Field create_geometry_data (const std::string& name, const FieldLayout& layout,
+                              const ekat::units::Units& units = ekat::units::Units::invalid(),
+                              const DataType data_type = DataType::RealType) {
+    return create_geometry_data(FieldIdentifier(name,layout,units,this->name(),data_type));
+  }
 
-  // Set/get geometric views.
-  void set_geometry_data (const std::string& name, const geo_view_type& data);
-  const geo_view_type& get_geometry_data (const std::string& name) const;
-  const geo_view_h_type& get_geometry_data_host (const std::string& name) const;
+  // Sets pre-existing field as geometry data.
+  void set_geometry_data (const Field& f);
 
   bool has_geometry_data (const std::string& name) const {
-    return m_geo_views.find(name)!=m_geo_views.end();
+    return m_geo_fields.find(name)!=m_geo_fields.end();
   }
 
   // Get list of currently stored geometry data views
@@ -154,23 +132,23 @@ public:
   std::vector<gid_type> get_unique_gids () const;
 
   // For each entry in the input list of GIDs, retrieve the process id that owns it
-  std::vector<int> get_owners (const hview_1d<const gid_type>& gids) const;
+  std::vector<int> get_owners (const gid_view_h& gids) const;
   std::vector<int> get_owners (const std::vector<gid_type>& gids) const {
-    hview_1d<const gid_type> gids_v(gids.data(),gids.size());
+    gid_view_h gids_v(gids.data(),gids.size());
     return get_owners(gids_v);
   }
 
+  // Derived classes can override these methods to verify that the
+  // dofs have been set to something that satisfies any requirement of the grid type.
+  virtual bool check_valid_dofs()        const { return true; }
+  virtual bool check_valid_lid_to_idx () const { return true; }
 protected:
 
-  // Derived classes can override these methods, which are called inside the
-  // set_dofs, set_lid_to_idx_map, and set_geometry_data methods respectively, to verify that the
-  // views have been set to something that satisfies any requirement of the grid type.
-  // This class already checks the extents of the view, but derived classes can add
-  // some extra consistency check.
-  virtual bool valid_dofs_list (const dofs_list_type& /*dofs_gids*/)      const { return true; }
-  virtual bool valid_lid_to_idx_map (const lid_to_idx_map_type& /*lid_to_idx*/) const { return true; }
+  void copy_data (const AbstractGrid& src, const bool shallow = true);
 
-  void copy_views (const AbstractGrid& src, const bool shallow = true);
+  // Note: this method must be called from the derived classes,
+  //       since it calls get_2d_scalar_layout.
+  void create_dof_fields (const int scalar2d_layout_rank);
 
 private:
 
@@ -185,22 +163,17 @@ private:
   int m_num_global_dofs;
   int m_num_vert_levs;
 
-  // Whether the dofs have been set
-  bool m_dofs_set = false;
-  // Whether the lid->idx map has been set
-  bool m_lid_to_idx_set = false;
-
   // The global ID of each dof
-  dofs_list_type        m_dofs_gids;
-  dofs_list_h_type      m_dofs_gids_host;
-  gid_type              m_global_min_dof_gid;
-  gid_type              m_global_max_dof_gid;
+  Field     m_dofs_gids;
+
+  // The max/min dof GID across all ranks. Mutable, to allow for lazy calculation
+  mutable gid_type  m_global_min_dof_gid =  std::numeric_limits<gid_type>::max();
+  mutable gid_type  m_global_max_dof_gid = -std::numeric_limits<gid_type>::max();
 
   // The map lid->idx
-  lid_to_idx_map_type   m_lid_to_idx;
+  Field     m_lid_to_idx;
 
-  geo_view_map_type     m_geo_views;
-  geo_view_h_map_type   m_geo_views_host;
+  std::map<std::string,Field>  m_geo_fields;
 
   // The MPI comm containing the ranks across which the global mesh is partitioned
   ekat::Comm            m_comm;

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
@@ -81,6 +81,7 @@ build_grids ()
     dof_gids.sync_to_dev();
     lid2idx.sync_to_dev();
 
+    se_grid->m_short_name = "se";
     add_geo_data(se_grid);
 
     add_grid(se_grid);
@@ -103,6 +104,7 @@ build_grids ()
     area.sync_to_host();
 
     add_geo_data(pt_grid);
+    pt_grid->m_short_name = "pt";
 
     add_grid(pt_grid);
     this->alias_grid("Point Grid", "Physics");

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
@@ -2,6 +2,9 @@
 #include "share/grid/point_grid.hpp"
 #include "share/grid/se_grid.hpp"
 #include "share/grid/remap/do_nothing_remapper.hpp"
+#include "share/io/scorpio_input.hpp"
+
+#include "physics/share/physics_constants.hpp"
 
 #include "ekat/std_meta/ekat_std_utils.hpp"
 
@@ -42,12 +45,17 @@ build_grids ()
     const int num_local_elems  = m_params.get<int>("number_of_local_elements");
     const int num_gp           = m_params.get<int>("number_of_gauss_points");
 
-    // Set up the degrees of freedom.
-    SEGrid::dofs_list_type dofs("", num_local_elems*num_gp*num_gp);
-    SEGrid::lid_to_idx_map_type dofs_map("", num_local_elems*num_gp*num_gp, 3);
+    // Create the grid
+    std::shared_ptr<SEGrid> se_grid;
+    se_grid = std::make_shared<SEGrid>("SE Grid",num_local_elems,num_gp,num_vertical_levels,m_comm);
+    se_grid->setSelfPointer(se_grid);
 
-    auto host_dofs = Kokkos::create_mirror_view(dofs);
-    auto host_dofs_map = Kokkos::create_mirror_view(dofs_map);
+    // Set up the degrees of freedom.
+    auto dof_gids = se_grid->get_dofs_gids();
+    auto lid2idx  = se_grid->get_lid_to_idx_map();
+
+    auto host_dofs    = dof_gids.template get_view<AbstractGrid::gid_type*,Host>();
+    auto host_lid2idx = lid2idx.template get_view<int**,Host>();
 
     // Count unique local dofs. On all elems except the very last one (on rank N),
     // we have num_gp*(num_gp-1) unique dofs;
@@ -60,33 +68,137 @@ build_grids ()
           int idof = ie*num_gp*num_gp + igp*num_gp + jgp;
           int gid = offset + idof;
           host_dofs(idof) = gid;
-          host_dofs_map(idof, 0) = ie;
-          host_dofs_map(idof, 1) = igp;
-          host_dofs_map(idof, 2) = jgp;
+          host_lid2idx(idof, 0) = ie;
+          host_lid2idx(idof, 1) = igp;
+          host_lid2idx(idof, 2) = jgp;
         }
       }
     }
 
-    // Move the data to the device and set the DOFs.
-    Kokkos::deep_copy(dofs, host_dofs);
-    Kokkos::deep_copy(dofs_map, host_dofs_map);
-
-    // Create the grid, and set the dofs
-    std::shared_ptr<SEGrid> se_grid;
-    se_grid = std::make_shared<SEGrid>("SE Grid",num_local_elems,num_gp,num_vertical_levels,m_comm);
-    se_grid->setSelfPointer(se_grid);
-
-    se_grid->set_dofs(dofs);
-    se_grid->set_lid_to_idx_map(dofs_map);
+    // Sync to device
+    dof_gids.sync_to_dev();
+    lid2idx.sync_to_dev();
 
     add_grid(se_grid);
   }
   if (build_pt) {
     const int num_global_cols  = m_params.get<int>("number_of_global_columns");
     auto pt_grid = create_point_grid("Point Grid",num_global_cols,num_vertical_levels,m_comm);
+
+    using namespace ShortFieldTagsNames;
+    const auto units = ekat::units::Units::nondimensional();
+    FieldLayout layout_mid ({LEV},{num_vertical_levels});
+
+    auto area = pt_grid->create_geometry_data("area", pt_grid->get_2d_scalar_layout(), units);
+    auto lat  = pt_grid->create_geometry_data("lat" , pt_grid->get_2d_scalar_layout(), units);
+    auto lon  = pt_grid->create_geometry_data("lon" , pt_grid->get_2d_scalar_layout(), units);
+    auto hyam = pt_grid->create_geometry_data("hyam", layout_mid, units);
+    auto hybm = pt_grid->create_geometry_data("hybm", layout_mid, units);
+
+    // Estimate cell area for a uniform grid by taking the surface area
+    // of the earth divided by the number of columns.  Note we do this in
+    // units of radians-squared.
+    using PC             = scream::physics::Constants<Real>;
+    const Real pi        = PC::Pi;
+    const Real cell_area = 4.0*pi/num_global_cols;
+    area.deep_copy(cell_area);
+    area.sync_to_host();
+
+    const auto nan = ekat::ScalarTraits<Real>::invalid();
+
+    // Load lat/lon if latlon_filename param is given.
+    if (m_params.isParameter("latlon_filename")) {
+      load_lat_lon(pt_grid);
+    } else {
+      lat.deep_copy(nan);
+      lon.deep_copy(nan);
+      lat.sync_to_host();
+      lon.sync_to_host();
+    }
+
+    // Load hyam/hybm if hybrid_coefficients_filename param is given.
+    if (m_params.isParameter("vertical_coordinate_filename")) {
+      load_vertical_coordinates(pt_grid);
+    } else {
+      hyam.deep_copy(nan);
+      hybm.deep_copy(nan);
+      hyam.sync_to_host();
+      hybm.sync_to_host();
+    }
     add_grid(pt_grid);
     this->alias_grid("Point Grid", "Physics");
   }
+}
+
+void MeshFreeGridsManager::
+load_lat_lon (const nonconstgrid_ptr_type& grid) const
+{
+  using geo_view_host = AtmosphereInput::view_1d_host;
+
+  auto lat = grid->get_geometry_data_nonconst("lat");
+  auto lon = grid->get_geometry_data_nonconst("lon");
+
+  // Create host mirrors for reading in data
+  std::map<std::string,geo_view_host> host_views = {
+    { "lat", lat.get_view<Real*,Host>() },
+    { "lon", lon.get_view<Real*,Host>() }
+  };
+
+  // Store view layouts
+  std::map<std::string,FieldLayout> layouts = {
+    { "lat", lat.get_header().get_identifier().get_layout() },
+    { "lon", lon.get_header().get_identifier().get_layout() }
+  };
+
+  // Read lat/lon into host views
+  ekat::ParameterList lat_lon_reader_pl;
+  lat_lon_reader_pl.set("Filename",m_params.get<std::string>("latlon_filename"));
+  lat_lon_reader_pl.set<std::vector<std::string>>("Field Names",{"lat","lon"});
+
+  AtmosphereInput lat_lon_reader(m_comm, lat_lon_reader_pl);
+  lat_lon_reader.init(grid, host_views, layouts);
+  lat_lon_reader.read_variables();
+  lat_lon_reader.finalize();
+
+  // Sync to dev
+  lat.sync_to_dev();
+  lon.sync_to_dev();
+}
+
+void MeshFreeGridsManager::
+load_vertical_coordinates (const nonconstgrid_ptr_type& grid) const
+{
+  using geo_view_host = AtmosphereInput::view_1d_host;
+
+  auto hyam = grid->get_geometry_data_nonconst("hyam");
+  auto hybm = grid->get_geometry_data_nonconst("hybm");
+
+  // Create host mirrors for reading in data
+  std::map<std::string,geo_view_host> host_views = {
+    { "hyam", hyam.get_view<Real*,Host>() },
+    { "hybm", hybm.get_view<Real*,Host>() }
+  };
+
+  // Store view layouts
+  using namespace ShortFieldTagsNames;
+  std::map<std::string,FieldLayout> layouts = {
+    { "hyam", hyam.get_header().get_identifier().get_layout() },
+    { "hybm", hybm.get_header().get_identifier().get_layout() }
+  };
+
+  // Read hyam/hybm into host views
+  ekat::ParameterList vcoord_reader_pl;
+  vcoord_reader_pl.set("Filename",m_params.get<std::string>("vertical_coordinate_filename"));
+  vcoord_reader_pl.set<std::vector<std::string>>("Field Names",{"hyam","hybm"});
+
+  AtmosphereInput vcoord_reader(m_comm,vcoord_reader_pl);
+  vcoord_reader.init(grid, host_views, layouts);
+  vcoord_reader.read_variables();
+  vcoord_reader.finalize();
+
+  // Sync to dev
+  hyam.sync_to_dev();
+  hybm.sync_to_dev();
 }
 
 std::shared_ptr<GridsManager>

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.hpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.hpp
@@ -39,6 +39,8 @@ protected:
   do_create_remapper (const grid_ptr_type from_grid,
                       const grid_ptr_type to_grid) const;
 
+  void load_lat_lon (const nonconstgrid_ptr_type& grid) const;
+  void load_vertical_coordinates (const nonconstgrid_ptr_type& grid) const;
   remap_repo_type     m_remappers;
 
   ekat::ParameterList m_params;

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.hpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.hpp
@@ -31,6 +31,8 @@ public:
 
 protected:
 
+  void add_geo_data (const nonconstgrid_ptr_type& grid) const;
+
   std::string get_reference_grid_name () const {
     return m_params.get<std::string>("reference_grid");
   }
@@ -39,8 +41,8 @@ protected:
   do_create_remapper (const grid_ptr_type from_grid,
                       const grid_ptr_type to_grid) const;
 
-  void load_lat_lon (const nonconstgrid_ptr_type& grid) const;
-  void load_vertical_coordinates (const nonconstgrid_ptr_type& grid) const;
+  void load_lat_lon (const nonconstgrid_ptr_type& grid, const std::string& filename) const;
+  void load_vertical_coordinates (const nonconstgrid_ptr_type& grid, const std::string& filename) const;
   remap_repo_type     m_remappers;
 
   ekat::ParameterList m_params;

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
@@ -252,7 +252,9 @@ protected:
   // and bind the actual field later.
   // NOTE: vector<bool> is a strange beast, and doesn't necessarily behave as
   // expected. Use caution when manipulating this member, and don't rely on the
-  // usual assumptions about how the boolean elements are stored.
+  // usual assumptions about how the boolean elements are stored. In particular,
+  // avoid range for loops and iterators. Instead, use op[] when you need to
+  // access its entries.
   std::vector<bool>   m_fields_are_bound;
   int                 m_num_bound_fields = 0;
 };

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.hpp
@@ -124,7 +124,7 @@ protected:
     return it==end ? -1 : std::distance(beg,it);
   }
 
-  view_1d<gid_t>::HostMirror
+  std::vector<gid_t>
   get_my_triplets_gids (const std::string& map_file,
                         const grid_ptr_type& src_grid) const;
 

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.hpp
@@ -117,7 +117,7 @@ protected:
   void setup_mpi_data_structures ();
 
   int gid2lid (const gid_t gid, const grid_ptr_type& grid) const {
-    const auto gids = grid->get_dofs_gids_host();
+    const auto gids = grid->get_dofs_gids().get_view<const gid_t*,Host>();
     const auto beg = gids.data();
     const auto end = gids.data()+grid->get_num_local_dofs();
     const auto it = std::find(beg,end,gid);
@@ -132,6 +132,11 @@ protected:
 
   std::map<int,std::vector<int>>
   recv_gids_from_pids (const std::map<int,std::vector<int>>& pid2gids_send) const;
+
+  // This class uses itself to remap src grid geo data to the tgt grid. But in order
+  // to not pollute the remapper for later use, we must be able to clean it up after
+  // remapping all the geo data.
+  void clean_up ();
 
 #ifdef KOKKOS_ENABLE_CUDA
 public:

--- a/components/eamxx/src/share/grid/remap/horizontal_remap_utility.cpp
+++ b/components/eamxx/src/share/grid/remap/horizontal_remap_utility.cpp
@@ -17,7 +17,7 @@ HorizontalMap::HorizontalMap(const ekat::Comm& comm, const std::string& map_name
   m_dofs_set = false;
 }
 /*-----------------------------------------------------------------------------------------------*/
-HorizontalMap::HorizontalMap(const ekat::Comm& comm, const std::string& map_name, const view_1d<gid_type>& dofs_gids, const gid_type min_dof)
+HorizontalMap::HorizontalMap(const ekat::Comm& comm, const std::string& map_name, const view_1d<const gid_type>& dofs_gids, const gid_type min_dof)
   : m_name (map_name)
   , m_comm (comm)
 {

--- a/components/eamxx/src/share/grid/remap/horizontal_remap_utility.hpp
+++ b/components/eamxx/src/share/grid/remap/horizontal_remap_utility.hpp
@@ -110,7 +110,7 @@ public:
   HorizontalMap() {};
   explicit HorizontalMap(const ekat::Comm& comm);
   HorizontalMap(const ekat::Comm& comm, const std::string& map_name);
-  HorizontalMap(const ekat::Comm& comm, const std::string& map_name, const view_1d<gid_type>& dofs_gids, const gid_type min_dof);
+  HorizontalMap(const ekat::Comm& comm, const std::string& map_name, const view_1d<const gid_type>& dofs_gids, const gid_type min_dof);
  
   // Main remap functions
   void apply_remap(const view_1d<const Real>& source_data, const view_1d<Real>& remapped_data);

--- a/components/eamxx/src/share/grid/se_grid.hpp
+++ b/components/eamxx/src/share/grid/se_grid.hpp
@@ -35,16 +35,17 @@ public:
     return m_num_global_elem;
   }
 
-  // Set/retrieve the CG grid dofs
-  void set_cg_dofs (const dofs_list_type& cg_dofs);
-  const dofs_list_type& get_cg_dofs_gids () const;
+  // Retrieve list of the CG grid dofs. Const version returns a read-only field
+  Field get_cg_dofs_gids ();
+  Field get_cg_dofs_gids () const;
 
   std::shared_ptr<AbstractGrid> clone (const std::string& clone_name,
                                        const bool shallow) const override;
 
+  bool check_valid_dofs()        const override;
+  bool check_valid_lid_to_idx () const override;
+
 protected:
-  bool valid_dofs_list (const dofs_list_type& dofs_gids)      const override;
-  bool valid_lid_to_idx_map (const lid_to_idx_map_type& lid_to_idx) const override;
 
   // SE dims
   int       m_num_local_elem;
@@ -52,8 +53,7 @@ protected:
   int       m_num_gp;
 
   // The dofs gids for a CG version of this grid
-  dofs_list_type m_cg_dofs_gids;
-  bool m_cg_dofs_set = false;
+  Field m_cg_dofs_gids;
 };
 
 } // namespace scream

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -48,7 +48,13 @@ AtmosphereOutput (const ekat::Comm& comm,
   m_avg_type = OutputAvgType::Instant;
   m_add_time_dim = false;
 
+  // Create a FieldManager with the input fields
   auto fm = std::make_shared<FieldManager> (grid);
+  fm->registration_begins();
+  fm->registration_ends();
+  for (auto f : fields) {
+    fm->add_field(f);
+  }
 
   set_field_manager (fm,"sim");
 

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -254,7 +254,7 @@ void AtmosphereOutput::run (const std::string& filename, const bool is_write_ste
     const auto  rank = layout.rank();
 
     // Safety check: make sure that the field was written at least once before using it.
-    EKAT_REQUIRE_MSG (field.get_header().get_tracking().get_time_stamp().is_valid(),
+    EKAT_REQUIRE_MSG (!m_add_time_dim || field.get_header().get_tracking().get_time_stamp().is_valid(),
         "Error! Output field '" + name + "' has not been initialized yet\n.");
 
     const bool is_diagnostic = (m_diagnostics.find(name) != m_diagnostics.end());

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -262,7 +262,7 @@ void AtmosphereOutput::run (const std::string& filename, const bool is_write_ste
 
     // Safety check: make sure that the field was written at least once before using it.
     EKAT_REQUIRE_MSG (!m_add_time_dim || field.get_header().get_tracking().get_time_stamp().is_valid(),
-        "Error! Output field '" + name + "' has not been initialized yet\n.");
+        "Error! Time-dependent output field '" + name + "' has not been initialized yet\n.");
 
     const bool is_diagnostic = (m_diagnostics.find(name) != m_diagnostics.end());
     const bool is_aliasing_field_view =
@@ -580,6 +580,8 @@ register_variables(const std::string& filename,
     if (m_add_time_dim) {
       io_decomp_tag += "-time";
       vec_of_dims.push_back("time");  //TODO: See the above comment on time.
+    } else {
+      io_decomp_tag += "-notime";
     }
 
     // TODO  Need to change dtype to allow for other variables.

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -462,9 +462,9 @@ void AtmosphereOutput::register_dimensions(const std::string& name)
       } else {
         tag_len = layout.dim(i);
       }
-      m_dims.emplace(std::make_pair(get_nc_tag_name(tags[i],dims[i]),tag_len));
+      m_dims[get_nc_tag_name(tags[i],dims[i])] = std::make_pair(tag_len,is_partitioned);
     } else {  
-      EKAT_REQUIRE_MSG(m_dims.at(tag_name)==dims[i] or is_partitioned,
+      EKAT_REQUIRE_MSG(m_dims.at(tag_name).first==dims[i] or is_partitioned,
         "Error! Dimension " + tag_name + " on field " + name + " has conflicting lengths");
     }
   }
@@ -694,7 +694,7 @@ setup_output_file(const std::string& filename,
 
   // Register dimensions with netCDF file.
   for (auto it : m_dims) {
-    register_dimension(filename,it.first,it.first,it.second);
+    register_dimension(filename,it.first,it.first,it.second.first,it.second.second);
   }
 
   // Register variables with netCDF file.  Must come after dimensions are registered.

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -572,6 +572,7 @@ AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
   //       the same order as the corresponding entry in the data to be read/written, we're good.
   // NOTE: In the case of regional output this rank may have 0 columns to write, thus, var_dof
   //       should be empty, we check for this special case and return an empty var_dof.
+  auto dofs_h = m_io_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
   if (layout.has_tag(ShortFieldTagsNames::COL)) {
     const int num_cols = m_io_grid->get_num_local_dofs();
     if (num_cols==0) {
@@ -581,10 +582,6 @@ AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
     scorpio::offset_t col_size = layout.size() / num_cols;
-
-    auto dofs = m_io_grid->get_dofs_gids();
-    auto dofs_h = Kokkos::create_mirror_view(dofs);
-    Kokkos::deep_copy(dofs_h,dofs);
 
     // Precompute this *before* the loop, since it involves expensive collectives.
     // Besides, the loop might have different length on different ranks, so
@@ -612,10 +609,6 @@ AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
     scorpio::offset_t col_size = layout.size() / num_cols;
-
-    auto dofs = m_io_grid->get_dofs_gids();
-    auto dofs_h = Kokkos::create_mirror_view(dofs);
-    Kokkos::deep_copy(dofs_h,dofs);
 
     // Precompute this *before* the loop, since it involves expensive collectives.
     // Besides, the loop might have different length on different ranks, so

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -138,6 +138,11 @@ public:
                    const std::shared_ptr<const fm_type>& field_mgr,
                    const std::shared_ptr<const gm_type>& grids_mgr);
 
+  // Short version for outputing a list of fields (no remapping supported)
+  AtmosphereOutput(const ekat::Comm& comm,
+                   const std::vector<Field>& fields,
+                   const std::shared_ptr<const grid_type>& grid);
+
   // Main Functions
   void restart (const std::string& filename);
   void init();
@@ -195,6 +200,8 @@ protected:
   // Local views of each field to be used for "averaging" output and writing to file.
   std::map<std::string,view_1d_host>    m_host_views_1d;
   std::map<std::string,view_1d_dev>     m_dev_views_1d;
+
+  bool m_add_time_dim;
 };
 
 } //namespace scream

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -192,7 +192,7 @@ protected:
   std::map<std::string,std::string>                     m_fields_alt_name;
   std::map<std::string,FieldLayout>                     m_layouts;
   std::map<std::string,int>                             m_dofs;
-  std::map<std::string,int>                             m_dims;
+  std::map<std::string,std::pair<int,bool>>             m_dims;
   std::map<std::string,std::shared_ptr<atm_diag_type>>  m_diagnostics;
   std::map<std::string,std::vector<std::string>>        m_diag_depends_on_diags;
   std::map<std::string,bool>                            m_diag_computed;

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -147,6 +147,10 @@ public:
   void finalize() {}
 
   long long res_dep_memory_footprint () const;
+
+  std::shared_ptr<const AbstractGrid> get_io_grid () const {
+    return m_io_grid;
+  }
 protected:
   // Internal functions
   void set_field_manager (const std::shared_ptr<const fm_type>& field_mgr, const std::string& mode);

--- a/components/eamxx/src/share/io/scream_io_utils.hpp
+++ b/components/eamxx/src/share/io/scream_io_utils.hpp
@@ -114,6 +114,7 @@ struct IOFileSpecs {
   bool filename_with_mpiranks    = false;
   bool filename_with_avg_type    = true;
   bool filename_with_frequency   = true;
+  bool save_grid_data            = true;
 };
 
 std::string find_filename_in_rpointer (

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -415,7 +415,7 @@ setup_file (      IOFileSpecs& filespecs, const IOControl& control,
   // Note: time has an unknown length. Setting its "length" to 0 tells the scorpio to
   // set this dimension as having an 'unlimited' length, thus allowing us to write
   // as many timesnaps to file as we desire.
-  register_dimension(filename,"time","time",0);
+  register_dimension(filename,"time","time",0,false);
 
   // Register time as a variable.
   auto time_units="days since " + m_case_t0.get_date_string() + " " + m_case_t0.get_time_string();

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -70,6 +70,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
   m_output_file_specs.filename_with_mpiranks    = out_control_pl.get("MPI Ranks in Filename",false);
   m_output_file_specs.filename_with_avg_type    = out_control_pl.get("avg_type_in_filename",true);
   m_output_file_specs.filename_with_frequency   = out_control_pl.get("frequency_in_filename",true);
+  m_output_file_specs.save_grid_data            = out_control_pl.get("save_grid_data",!m_is_model_restart_output);
 
   // For each grid, create a separate output stream.
   if (field_mgrs.size()==1) {
@@ -92,7 +93,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
 
   // For normal output, setup the geometry data streams, which we used to write the
   // geo data in the output file when we create it.
-  if (!m_is_model_restart_output) {
+  if (m_output_file_specs.save_grid_data) {
     std::set<std::shared_ptr<const AbstractGrid>> grids;
     for (auto& it : m_output_streams) {
       grids.insert(it->get_io_grid());
@@ -435,7 +436,7 @@ setup_file (      IOFileSpecs& filespecs, const IOControl& control,
     it->setup_output_file(filename,fp_precision);
   }
 
-  if (!m_is_model_restart_output && !is_checkpoint_step) {
+  if (filespecs.save_grid_data) {
     // If not a restart file, also register geo data fields.
     for (auto& it : m_geo_data_streams) {
       it->setup_output_file(filename,fp_precision);
@@ -453,7 +454,7 @@ setup_file (      IOFileSpecs& filespecs, const IOControl& control,
   set_int_attribute_c2f(filename.c_str(),"start_date",t0_date);
   set_int_attribute_c2f(filename.c_str(),"start_time",t0_time);
 
-  if (!m_is_model_restart_output && !is_checkpoint_step) {
+  if (filespecs.save_grid_data) {
     // Immediately run the geo data streams
     for (const auto& it : m_geo_data_streams) {
       it->run(filename,true,0);

--- a/components/eamxx/src/share/io/scream_output_manager.hpp
+++ b/components/eamxx/src/share/io/scream_output_manager.hpp
@@ -122,6 +122,10 @@ protected:
   void set_params (const ekat::ParameterList& params,
                    const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs);
 
+  void setup_file (      IOFileSpecs& filespecs,
+                   const IOControl& control,
+                   const util::TimeStamp& timestamp);
+
   using output_type     = AtmosphereOutput;
   using output_ptr_type = std::shared_ptr<output_type>;
 

--- a/components/eamxx/src/share/io/scream_output_manager.hpp
+++ b/components/eamxx/src/share/io/scream_output_manager.hpp
@@ -130,6 +130,8 @@ protected:
   using output_ptr_type = std::shared_ptr<output_type>;
 
   std::vector<output_ptr_type>   m_output_streams;
+  std::vector<output_ptr_type>   m_geo_data_streams;
+
   globals_map_t                  m_globals;
 
   ekat::Comm                     m_io_comm;

--- a/components/eamxx/src/share/io/scream_scorpio_interface.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.F90
@@ -1432,7 +1432,7 @@ contains
 
     type(pio_atm_file_t), pointer :: pio_atm_file
     type(hist_var_t), pointer     :: var
-    integer                       :: ierr,var_size
+    integer                       :: ierr
     logical                       :: found
 
     call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
@@ -1441,10 +1441,7 @@ contains
     ! Set the timesnap we are reading
     call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
 
-    ! We don't want the extent along the 'time' dimension
-    var_size = SIZE(var%compdof)
 
-    ! Now we know the exact size of the array, and can shape the f90 pointer
     call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
     call errorHandle( 'eam_grid_write_darray_float: Error writing variable '//trim(varname),ierr)
   end subroutine grid_write_darray_float
@@ -1462,7 +1459,7 @@ contains
 
     type(pio_atm_file_t), pointer :: pio_atm_file
     type(hist_var_t), pointer     :: var
-    integer                       :: ierr,var_size
+    integer                       :: ierr
     logical                       :: found
 
     call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
@@ -1471,10 +1468,7 @@ contains
     ! Set the timesnap we are reading
     call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
 
-    ! We don't want the extent along the 'time' dimension
-    var_size = SIZE(var%compdof)
 
-    ! Now we know the exact size of the array, and can shape the f90 pointer
     call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
     call errorHandle( 'eam_grid_write_darray_double: Error writing variable '//trim(varname),ierr)
   end subroutine grid_write_darray_double
@@ -1492,7 +1486,7 @@ contains
 
     type(pio_atm_file_t), pointer :: pio_atm_file
     type(hist_var_t), pointer     :: var
-    integer                       :: ierr,var_size
+    integer                       :: ierr
     logical                       :: found
 
     call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
@@ -1501,10 +1495,7 @@ contains
     ! Set the timesnap we are reading
     call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
 
-    ! We don't want the extent along the 'time' dimension
-    var_size = SIZE(var%compdof)
 
-    ! Now we know the exact size of the array, and can shape the f90 pointer
     call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
     call errorHandle( 'eam_grid_write_darray_int: Error writing variable '//trim(varname),ierr)
   end subroutine grid_write_darray_int

--- a/components/eamxx/src/share/io/scream_scorpio_interface.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.F90
@@ -1419,6 +1419,7 @@ contains
   !
   !---------------------------------------------------------------------------
   subroutine grid_write_darray_float(filename, varname, buf, buf_size)
+    use pionfput_mod, only: PIO_put_var   => put_var
     use piolib_mod, only: PIO_setframe
     use piodarray,  only: PIO_write_darray
 
@@ -1438,14 +1439,21 @@ contains
     call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
     call get_var(pio_atm_file,varname,var)
 
-    ! Set the timesnap we are reading
-    call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
+    if (var%has_t_dim) then
+      ! Set the time index we are writing
+      call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
+    endif
 
+    if (var%is_partitioned) then
+      call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
+    else
+      ierr = pio_put_var(pio_atm_file%pioFileDesc,var%piovar,buf)
+    endif
 
-    call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
     call errorHandle( 'eam_grid_write_darray_float: Error writing variable '//trim(varname),ierr)
   end subroutine grid_write_darray_float
   subroutine grid_write_darray_double(filename, varname, buf, buf_size)
+    use pionfput_mod, only: PIO_put_var   => put_var
     use piolib_mod, only: PIO_setframe
     use piodarray,  only: PIO_write_darray
 
@@ -1465,14 +1473,21 @@ contains
     call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
     call get_var(pio_atm_file,varname,var)
 
-    ! Set the timesnap we are reading
-    call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
+    if (var%has_t_dim) then
+      ! Set the time index we are writing
+      call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
+    endif
 
+    if (var%is_partitioned) then
+      call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
+    else
+      ierr = pio_put_var(pio_atm_file%pioFileDesc,var%piovar,buf)
+    endif
 
-    call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
     call errorHandle( 'eam_grid_write_darray_double: Error writing variable '//trim(varname),ierr)
   end subroutine grid_write_darray_double
   subroutine grid_write_darray_int(filename, varname, buf, buf_size)
+    use pionfput_mod, only: PIO_put_var   => put_var
     use piolib_mod, only: PIO_setframe
     use piodarray,  only: PIO_write_darray
 
@@ -1492,11 +1507,17 @@ contains
     call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
     call get_var(pio_atm_file,varname,var)
 
-    ! Set the timesnap we are reading
-    call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
+    if (var%has_t_dim) then
+      ! Set the time index we are writing
+      call PIO_setframe(pio_atm_file%pioFileDesc,var%piovar,int(max(1,pio_atm_file%numRecs),kind=pio_offset_kind))
+    endif
 
+    if (var%is_partitioned) then
+      call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
+    else
+      ierr = pio_put_var(pio_atm_file%pioFileDesc,var%piovar,buf)
+    endif
 
-    call pio_write_darray(pio_atm_file%pioFileDesc, var%piovar, var%iodesc, buf, ierr)
     call errorHandle( 'eam_grid_write_darray_int: Error writing variable '//trim(varname),ierr)
   end subroutine grid_write_darray_int
 !=====================================================================!

--- a/components/eamxx/src/share/io/scream_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.cpp
@@ -29,7 +29,7 @@ extern "C" {
   void eam_pio_finalize_c2f();
   void eam_pio_closefile_c2f(const char*&& filename);
   void pio_update_time_c2f(const char*&& filename,const double time);
-  void register_dimension_c2f(const char*&& filename, const char*&& shortname, const char*&& longname, const int length);
+  void register_dimension_c2f(const char*&& filename, const char*&& shortname, const char*&& longname, const int global_length, const bool partitioned);
   void register_variable_c2f(const char*&& filename, const char*&& shortname, const char*&& longname,
                              const char*&& units, const int numdims, const char** var_dimensions,
                              const int dtype, const int nc_dtype, const char*&& pio_decomp_tag);
@@ -100,9 +100,9 @@ void pio_update_time(const std::string& filename, const double time) {
   pio_update_time_c2f(filename.c_str(),time);
 }
 /* ----------------------------------------------------------------- */
-void register_dimension(const std::string &filename, const std::string& shortname, const std::string& longname, const int length) {
+void register_dimension(const std::string &filename, const std::string& shortname, const std::string& longname, const int length, const bool partitioned) {
 
-  register_dimension_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), length);
+  register_dimension_c2f(filename.c_str(), shortname.c_str(), longname.c_str(), length, partitioned);
 }
 /* ----------------------------------------------------------------- */
 void get_variable(const std::string &filename, const std::string& shortname, const std::string& longname,

--- a/components/eamxx/src/share/io/scream_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.hpp
@@ -33,7 +33,7 @@ namespace scorpio {
   /* Sets the degrees-of-freedom for a particular variable in a particular file.  Called once for each variable, for each file. */
   void set_dof(const std::string &filename, const std::string &varname, const Int dof_len, const offset_t* x_dof);
   /* Register a dimension coordinate with a file. Called during the file setup. */
-  void register_dimension(const std::string& filename,const std::string& shortname, const std::string& longname, const int length);
+  void register_dimension(const std::string& filename,const std::string& shortname, const std::string& longname, const int length, const bool partitioned);
   /* Register a variable with a file.  Called during the file setup, for an output stream. */
   void register_variable(const std::string& filename, const std::string& shortname, const std::string& longname,
                          const std::string& units, const std::vector<std::string>& var_dimensions,

--- a/components/eamxx/src/share/io/scream_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.hpp
@@ -68,6 +68,7 @@ extern "C" {
   int get_int_attribute_c2f (const char*&& filename, const char*&& attr_name);
   void set_int_attribute_c2f (const char*&& filename, const char*&& attr_name, const int& value);
   int get_dimlen_c2f(const char*&& filename, const char*&& dimname);
+  bool has_variable_c2f (const char*&& filename, const char*&& varname);
 } // extern "C"
 
 // The strings returned by e2str(const FieldTag&) are different from

--- a/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -220,12 +220,14 @@ contains
 
   end subroutine set_variable_metadata_c2f
 !=====================================================================!
-  subroutine register_dimension_c2f(filename_in, shortname_in, longname_in, length) bind(c)
+  subroutine register_dimension_c2f(filename_in, shortname_in, longname_in, length, partitioned) bind(c)
     use scream_scorpio_interface, only : register_dimension
-    type(c_ptr), intent(in)                :: filename_in
-    type(c_ptr), intent(in)                :: shortname_in
-    type(c_ptr), intent(in)                :: longname_in
-    integer(kind=c_int), value, intent(in) :: length
+
+    type(c_ptr), intent(in)                 :: filename_in
+    type(c_ptr), intent(in)                 :: shortname_in
+    type(c_ptr), intent(in)                 :: longname_in
+    integer(kind=c_int), value, intent(in)  :: length
+    logical(kind=c_bool), value, intent(in) :: partitioned
 
     character(len=256) :: filename
     character(len=256) :: shortname
@@ -234,7 +236,7 @@ contains
     call convert_c_string(filename_in,filename)
     call convert_c_string(shortname_in,shortname)
     call convert_c_string(longname_in,longname)
-    call register_dimension(filename,shortname,longname,length)
+    call register_dimension(filename,shortname,longname,length,LOGICAL(partitioned))
 
   end subroutine register_dimension_c2f
 !=====================================================================!

--- a/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -253,6 +253,21 @@ contains
 
   end function get_dimlen_c2f
 !=====================================================================!
+  function has_variable_c2f(filename_in,varname_in) result(has) bind(c)
+    use scream_scorpio_interface, only : has_variable
+    type(c_ptr), intent(in) :: filename_in
+    type(c_ptr), intent(in) :: varname_in
+    logical(kind=c_bool)     :: has
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    has = LOGICAL(has_variable(filename,varname),kind=c_bool)
+
+  end function has_variable_c2f
+!=====================================================================!
   subroutine eam_pio_enddef_c2f(filename_in) bind(c)
     use scream_scorpio_interface, only : eam_pio_enddef
     type(c_ptr), intent(in) :: filename_in

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
@@ -249,20 +249,19 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
   using namespace ShortFieldTagsNames;
 
   int min_col_lid, max_col_lid;
-  AbstractGrid::dofs_list_h_type gids;
-  AbstractGrid::geo_view_h_type lat, lon;
   bool has_latlon;
   bool has_col_info = m_grid and layout.tag(0)==COL;
+  const Real* lat;
+  const Real* lon;
 
   if (has_col_info) {
     // We are storing grid info, and the field is over columns. Get col id and coords.
     min_col_lid = idx_min[0];
     max_col_lid = idx_max[0];
-    gids = m_grid->get_dofs_gids_host();
     has_latlon = m_grid->has_geometry_data("lat") && m_grid->has_geometry_data("lon");
     if (has_latlon) {
-      lat = m_grid->get_geometry_data_host("lat");
-      lon = m_grid->get_geometry_data_host("lon");
+      lat = m_grid->get_geometry_data("lat").get_internal_view_data<const Real,Host>();
+      lon = m_grid->get_geometry_data("lon").get_internal_view_data<const Real,Host>();
     }
   }
 
@@ -270,26 +269,28 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
   msg << "  - minimum:\n";
   msg << "    - value: " << minmaxloc.min_val << "\n";
   if (has_col_info) {
+    auto gids = m_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
     msg << "    - entry: (" << gids(min_col_lid);
     for (size_t i=1; i<idx_min.size(); ++i) {
       msg << "," << idx_min[i];
     }
     msg << ")\n";
     if (has_latlon) {
-      msg << "    - lat/lon: (" << lat(min_col_lid) << ", " << lon(min_col_lid) << ")\n";
+      msg << "    - lat/lon: (" << lat[min_col_lid] << ", " << lon[min_col_lid] << ")\n";
     }
   }
 
   msg << "  - maximum:\n";
   msg << "    - value: " << minmaxloc.max_val << "\n";
   if (has_col_info) {
+    auto gids = m_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
     msg << "    - entry: (" << gids(max_col_lid);
     for (size_t i=1; i<idx_max.size(); ++i) {
       msg << "," << idx_max[i];
     }
     msg << ")\n";
     if (has_latlon) {
-      msg << "    - lat/lon: (" << lat(max_col_lid) << ", " << lon(max_col_lid) << ")\n";
+      msg << "    - lat/lon: (" << lat[max_col_lid] << ", " << lon[max_col_lid] << ")\n";
     }
   }
 

--- a/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
+++ b/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
@@ -237,12 +237,13 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
   res_and_msg.result = CheckResult::Fail;
 
   // We output relative errors with lat/lon information (if available)
-  AbstractGrid::dofs_list_h_type gids = m_grid->get_dofs_gids_host();
-  AbstractGrid::geo_view_h_type lat, lon;
+  using gid_t = AbstractGrid::gid_type;
+  auto gids = m_grid->get_dofs_gids().get_view<const gid_t*,Host>();
+  typename Field::view_host_t<const Real*> lat, lon;
   const bool has_latlon = m_grid->has_geometry_data("lat") && m_grid->has_geometry_data("lon");
   if (has_latlon) {
-    lat = m_grid->get_geometry_data_host("lat");
-    lon = m_grid->get_geometry_data_host("lon");
+    lat = m_grid->get_geometry_data("lat").get_view<const Real*, Host>();
+    lon = m_grid->get_geometry_data("lon").get_view<const Real*, Host>();
   }
 
   std::stringstream msg;

--- a/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
@@ -72,7 +72,7 @@ public:
 };
 
 template<typename ViewT>
-bool contains (const ViewT& v, const typename ViewT::traits::value_type& entry) {
+bool view_contains (const ViewT& v, const typename ViewT::traits::value_type& entry) {
   const auto vh = cmvc (v);
   const auto beg = vh.data();
   const auto end = vh.data() + vh.size();
@@ -94,14 +94,12 @@ void print (const std::string& msg, const ekat::Comm& comm) {
 std::shared_ptr<AbstractGrid>
 build_src_grid(const ekat::Comm& comm, const int nldofs_src) 
 {
-
-  AbstractGrid::dofs_list_type src_dofs("",nldofs_src);
-  auto src_dofs_h = cmvc(src_dofs);
-  std::iota(src_dofs_h.data(),src_dofs_h.data()+nldofs_src,nldofs_src*comm.rank());
-  Kokkos::deep_copy(src_dofs,src_dofs_h);
-
   auto src_grid = std::make_shared<PointGrid>("src",nldofs_src,20,comm);
-  src_grid->set_dofs(src_dofs);
+
+  auto src_dofs = src_grid->get_dofs_gids();
+  auto src_dofs_h = src_dofs.get_view<gid_t*,Host>();
+  std::iota(src_dofs_h.data(),src_dofs_h.data()+nldofs_src,nldofs_src*comm.rank());
+  src_dofs.sync_to_dev();
 
   return src_grid;
 }
@@ -250,7 +248,7 @@ TEST_CASE("coarsening_remap_nnz>nsrc") {
   // Generate data in a deterministic way, so that when we check results,
   // we know a priori what the input data that generated the tgt field's
   // values was, even if that data was off rank.
-  auto src_gids    = remap->get_src_grid()->get_dofs_gids_host();
+  auto src_gids = remap->get_src_grid()->get_dofs_gids().get_view<const gid_t*,Host>();
   for (const auto& f : src_f) {
     const auto& l = f.get_header().get_identifier().get_layout();
     switch (get_layout_type(l.tags())) {
@@ -272,7 +270,7 @@ TEST_CASE("coarsening_remap_nnz>nsrc") {
   // -------------------------------------- //
   //          Check remapped fields         //
   // -------------------------------------- //
-  const auto tgt_gids = tgt_grid->get_dofs_gids_host();
+  const auto tgt_gids = tgt_grid->get_dofs_gids().get_view<const gid_t*,Host>();
   for (int irun=0; irun<5; ++irun) {
     print (" -> run remap ...\n",comm);
     remap->remap(true);
@@ -314,6 +312,7 @@ TEST_CASE("coarsening_remap_nnz>nsrc") {
 }
 
 TEST_CASE ("coarsening_remap") {
+  using gid_t = AbstractGrid::gid_type;
 
   // -------------------------------------- //
   //           Init MPI and PIO             //
@@ -440,7 +439,7 @@ TEST_CASE ("coarsening_remap") {
   REQUIRE (tgt_grid->get_num_global_dofs()==ngdofs_tgt);
 
   // Check which triplets are read from map file
-  auto src_dofs_h = src_grid->get_dofs_gids_host();
+  auto src_dofs_h = src_grid->get_dofs_gids().get_view<const gid_t*,Host>();
   auto my_triplets = remap->test_triplet_gids (filename);
   const int num_triplets = my_triplets.size();
   REQUIRE (num_triplets==nnz_local);
@@ -448,7 +447,7 @@ TEST_CASE ("coarsening_remap") {
     const auto src_gid = src_dofs_h(i);
     const auto tgt_gid = src_gid % ngdofs_tgt;
 
-    REQUIRE (contains(my_triplets, 2*tgt_gid + src_gid/ngdofs_tgt));
+    REQUIRE (ekat::contains(my_triplets, 2*tgt_gid + src_gid/ngdofs_tgt));
   }
 
   // Check overlapped tgt grid
@@ -459,13 +458,13 @@ TEST_CASE ("coarsening_remap") {
   const int num_loc_ov_tgt_gids = ov_tgt_grid->get_num_local_dofs();
   const int expected_num_loc_ov_tgt_gids = ngdofs_tgt>=nldofs_src ? nldofs_src : ngdofs_tgt;
   REQUIRE (num_loc_ov_tgt_gids==expected_num_loc_ov_tgt_gids);
-  auto ov_gids = ov_tgt_grid->get_dofs_gids_host();
+  const auto ov_gids = ov_tgt_grid->get_dofs_gids().get_view<const gid_t*,Host>();
   for (int i=0; i<num_loc_ov_tgt_gids; ++i) {
     if (comm.size()==1) {
       REQUIRE(ov_gids[i]==i);
     } else {
       const auto src_gid = src_dofs_h[i];
-      REQUIRE (contains(ov_gids, src_gid % ngdofs_tgt));
+      REQUIRE (view_contains(ov_gids, src_gid % ngdofs_tgt));
     }
   }
 
@@ -473,8 +472,8 @@ TEST_CASE ("coarsening_remap") {
   auto row_offsets_h = cmvc(remap->get_row_offsets());
   auto col_lids_h    = cmvc(remap->get_col_lids());
   auto weights_h = cmvc(remap->get_weights());
-  auto ov_tgt_gids = ov_tgt_grid->get_dofs_gids_host();
-  auto src_gids    = remap->get_src_grid()->get_dofs_gids_host();
+  auto ov_tgt_gids = ov_tgt_grid->get_dofs_gids().get_view<const gid_t*,Host>();
+  auto src_gids    = remap->get_src_grid()->get_dofs_gids().get_view<const gid_t*,Host>();
 
   REQUIRE (col_lids_h.extent_int(0)==nldofs_src);
   REQUIRE (row_offsets_h.extent_int(0)==(num_loc_ov_tgt_gids+1));
@@ -502,7 +501,7 @@ TEST_CASE ("coarsening_remap") {
 
   // Check internal MPI structures
   const int num_loc_tgt_gids = tgt_grid->get_num_local_dofs();
-  const auto tgt_gids = tgt_grid->get_dofs_gids_host();
+  const auto tgt_gids = tgt_grid->get_dofs_gids().get_view<const gid_t*,Host>();
   const auto recv_lids_beg = remap->get_recv_lids_beg();
   const auto recv_lids_end = remap->get_recv_lids_end();
   const auto recv_lids_pidpos = remap->get_recv_lids_pidpos();

--- a/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
@@ -131,9 +131,9 @@ void create_remap_file(const std::string& filename, std::vector<std::int64_t>& d
 
   scorpio::register_file(filename, scorpio::FileMode::Write);
 
-  scorpio::register_dimension(filename,"n_a", "n_a", na);
-  scorpio::register_dimension(filename,"n_b", "n_b", nb);
-  scorpio::register_dimension(filename,"n_s", "n_s", ns);
+  scorpio::register_dimension(filename,"n_a", "n_a", na, true);
+  scorpio::register_dimension(filename,"n_b", "n_b", nb, true);
+  scorpio::register_dimension(filename,"n_s", "n_s", ns, true);
 
   scorpio::register_variable(filename,"col","col","none",{"n_s"},"real","int","int-nnz");
   scorpio::register_variable(filename,"row","row","none",{"n_s"},"real","int","int-nnz");

--- a/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
@@ -22,7 +22,7 @@ public:
   {
     // Nothing to do
   }
-  view_1d<gid_t>::HostMirror
+  std::vector<gid_t>
   test_triplet_gids (const std::string& map_file) const {
     return CoarseningRemapper::get_my_triplets_gids (map_file,m_src_grid);
   }

--- a/components/eamxx/src/share/tests/horizontal_remap_test.cpp
+++ b/components/eamxx/src/share/tests/horizontal_remap_test.cpp
@@ -78,9 +78,8 @@ void run(std::mt19937_64& engine, const ekat::Comm& comm, const gid_type src_min
   auto grid_tgt         = gm_tgt->get_grid("Point Grid");     // Retrieve the actual grid from the grids manager.
   auto num_loc_tgt_cols = grid_tgt->get_num_local_dofs();     // Number of columns (dofs) on this rank.
   auto tgt_min_dof      = grid_tgt->get_global_min_dof_gid(); // The starting index of the EAMxx grid.
-  auto dofs_gids        = grid_tgt->get_dofs_gids();          // A view of the dofs on this rank with their global id.
-  auto dofs_gids_h      = Kokkos::create_mirror_view(dofs_gids);
-  Kokkos::deep_copy(dofs_gids_h,dofs_gids);
+  auto dofs_gids        = grid_tgt->get_dofs_gids().get_view<const gid_type*>();          // A view of the dofs on this rank with their global id.
+  auto dofs_gids_h      = grid_tgt->get_dofs_gids().get_view<const gid_type*,Host>();
 
 //----------------------
 // Step 1: Generate a random remapping (source col, target col, weight) and random source data.

--- a/components/eamxx/src/share/tests/horizontal_remap_test.cpp
+++ b/components/eamxx/src/share/tests/horizontal_remap_test.cpp
@@ -225,10 +225,10 @@ void run(std::mt19937_64& engine, const ekat::Comm& comm, const gid_type src_min
   // Register the output file
   scorpio::register_file(filename,scorpio::Write);
   //   - Dimensions
-  scorpio::register_dimension(filename,"n_s","n_s",n_s);
-  scorpio::register_dimension(filename,"n_a","n_a",num_src_cols);
-  scorpio::register_dimension(filename,"n_b","n_b",num_tgt_cols);
-  scorpio::register_dimension(filename,"ncol","ncol",num_src_cols);
+  scorpio::register_dimension(filename,"n_s","n_s",n_s,true);
+  scorpio::register_dimension(filename,"n_a","n_a",num_src_cols,false);
+  scorpio::register_dimension(filename,"n_b","n_b",num_tgt_cols,false);
+  scorpio::register_dimension(filename,"ncol","ncol",num_src_cols,true);
   //   - Variables
   std::string remap_decomp_tag_r = "n_s_real";
   std::string data_decomp_tag_r  = "data_real";

--- a/components/eamxx/src/share/util/scream_common_physics_functions.hpp
+++ b/components/eamxx/src/share/util/scream_common_physics_functions.hpp
@@ -249,7 +249,6 @@ struct PhysicsFunctions
   // rate of 6.5K/km except in very warm conditions. See docs/tech_doc/physics/psl/psl_doc.tex for details
   // INPUTS:
   // T_ground is the air temperature at the bottom of the cell closest to the surface (aka T_int[nlev+1]; K)
-  // p_ground is the pressure at the bottom of the cell closest to the surface (Pa)
   // phi_ground is the geopotential at surface (aka surf_geopotential; m2/s2)
   // OUTPUTS:
   // psl is the sea level pressure (Pa)

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -58,7 +58,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
-  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+  vertical_coordinate_filename: IC_FILE
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -29,7 +29,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_mic,rrtmgp)
@@ -59,6 +58,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -46,7 +46,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
-  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+  vertical_coordinate_filename: IC_FILE
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -21,7 +21,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
@@ -47,6 +46,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -46,7 +46,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
-  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
+  vertical_coordinate_filename: IC_FILE
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -21,7 +21,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
@@ -47,6 +46,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -28,7 +28,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
@@ -53,6 +52,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # List all the yaml files with the output parameters
 Scorpio:

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -52,7 +52,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
-  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+  vertical_coordinate_filename: IC_FILE
 
 # List all the yaml files with the output parameters
 Scorpio:

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -28,7 +28,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
@@ -53,6 +52,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # List all the yaml files with the output parameters
 Scorpio:

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -52,7 +52,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
-  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+  vertical_coordinate_filename: IC_FILE
 
 # List all the yaml files with the output parameters
 Scorpio:

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -19,7 +19,6 @@ atmosphere_processes:
   atm_procs_list: (homme,physics)
   schedule_type: Sequential
   homme:
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
   physics:
     atm_procs_list: (mac_aero_mic,rrtmgp)
@@ -44,6 +43,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # List all the yaml files with the output parameters
 Scorpio:

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -18,6 +18,7 @@ grids_manager:
   Type: Mesh Free
   number_of_global_columns:   218
   number_of_vertical_levels:  72  # Will want to change to 128 when a valid unit test is available.
+  geo_data_source: IC_FILE
 
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
@@ -27,9 +28,6 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
-  Load Latitude:  true
-  Load Longitude: true
-  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -33,6 +33,7 @@ grids_manager:
   Type: Mesh Free
   number_of_global_columns:   218
   number_of_vertical_levels:  72  # Will want to change to 128 when a valid unit test is available.
+  geo_data_source: IC_FILE
 
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
@@ -46,9 +47,6 @@ initial_conditions:
   aero_ssa_sw: 0.0
   aero_tau_sw: 0.0
   aero_tau_lw: 0.0
-  Load Latitude:  true
-  Load Longitude: true
-  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -2,7 +2,7 @@ include (ScreamUtils)
 
 # Create the test
 set (TEST_LABELS "shoc;cld;spa;p3;rrtmgp;physics;driver")
-set (NEED_LIBS shoc cld_fraction spa p3 scream_rrtmgp scream_control scream_share diagnostics physics_share diagnostics)
+set (NEED_LIBS shoc cld_fraction spa p3 scream_rrtmgp scream_control scream_share diagnostics physics_share)
 CreateUnitTest(shoc_cld_spa_p3_rrtmgp shoc_cld_spa_p3_rrtmgp.cpp "${NEED_LIBS}" LABELS ${TEST_LABELS}
   MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
   PROPERTIES FIXTURES_SETUP shoc_cld_spa_p3_rrtmgp_generate_output_nc_files

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -33,6 +33,7 @@ grids_manager:
   Type: Mesh Free
   number_of_global_columns:   218
   number_of_vertical_levels:  72  # Will want to change to 128 when a valid unit test is available.
+  geo_data_source: IC_FILE
 
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
@@ -42,9 +43,6 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0
-  Load Latitude:  true
-  Load Longitude: true
-  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/homme/input.yaml
+++ b/components/eamxx/tests/uncoupled/homme/input.yaml
@@ -23,7 +23,7 @@ grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
-  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+  vertical_coordinate_filename: IC_FILE
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/homme/input.yaml
+++ b/components/eamxx/tests/uncoupled/homme/input.yaml
@@ -17,13 +17,13 @@ atmosphere_processes:
   atm_procs_list: (Dynamics)
   Dynamics:
     Type: Homme
-    vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
     Moisture: moist
 
 grids_manager:
   Type: Homme
   physics_grid_type: GLL
   dynamics_namelist_file_name: namelist.nl
+  vertical_coordinate_filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/eamxx/tests/uncoupled/rrtmgp/input.yaml
@@ -29,6 +29,7 @@ grids_manager:
   Type: Mesh Free
   number_of_global_columns: 218
   number_of_vertical_levels: 72
+  geo_data_source: IC_FILE
 
 # Specifications for setting initial conditions
 initial_conditions:
@@ -37,8 +38,6 @@ initial_conditions:
   aero_ssa_sw: 0.0
   aero_tau_sw: 0.0
   aero_tau_lw: 0.0
-  Load Latitude:  true
-  Load Longitude: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/eamxx/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -26,6 +26,7 @@ grids_manager:
   Type: Mesh Free
   number_of_global_columns: 128
   number_of_vertical_levels: 42
+  geo_data_source: CREATE_EMPTY_DATA
 
 # Specifications for setting initial conditions
 initial_conditions:

--- a/components/eamxx/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
+++ b/components/eamxx/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
@@ -37,8 +37,8 @@ namespace scream {
   using KT = KokkosTypes<DefaultDevice>;
   using ExeSpace = KT::ExeSpace;
   using MemberType = KT::MemberType;
-       
-    /* 
+
+    /*
      * Run standalone test through SCREAM driver this time
      */
     TEST_CASE("rrtmgp_scream_standalone", "") {
@@ -101,8 +101,10 @@ namespace scream {
         // In this test, we need to hack lat/lon. But the fields we get
         // from the grid are read-only. Therefore, hack a bit, and cast
         // away constness. It's bad, but it's only for this unit test
-        auto lat = grid->get_geometry_data_nonconst("lat").get_view<Real*>();
-        auto lon = grid->get_geometry_data_nonconst("lon").get_view<Real*>();
+        auto clat = grid->get_geometry_data("lat").get_view<const Real*>();
+        auto clon = grid->get_geometry_data("lon").get_view<const Real*>();
+        auto lat = const_cast<Real*>(clat.data());
+        auto lon = const_cast<Real*>(clon.data());
 
         // Get number of shortwave bands and number of gases from RRTMGP
         int ngas     =   8;  // TODO: get this intelligently
@@ -268,10 +270,10 @@ namespace scream {
 
             // Set lat and lon to single value for just this test:
             // Note, these values will ensure that the cosine zenith
-            // angle will end up matching the constant velue meant for
+            // angle will end up matching the constant value meant for
             // the test, which is 0.86
-            lat(i) = 5.224000000000;
-            lon(i) = 167.282000000000; 
+            lat[i] = 5.224000000000;
+            lon[i] = 167.282000000000;
 
             d_sfc_alb_dir_vis(i) = sfc_alb_dir_vis(i+1);
             d_sfc_alb_dir_nir(i) = sfc_alb_dir_nir(i+1);

--- a/components/eamxx/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
+++ b/components/eamxx/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
@@ -97,8 +97,12 @@ namespace scream {
         const auto& field_mgr = *ad.get_field_mgr(grid->name());
         int ncol  = grid->get_num_local_dofs();
         int nlay  = grid->get_num_vertical_levels();
-        auto& lat = grid->get_geometry_data("lat");
-        auto& lon = grid->get_geometry_data("lon");
+
+        // In this test, we need to hack lat/lon. But the fields we get
+        // from the grid are read-only. Therefore, hack a bit, and cast
+        // away constness. It's bad, but it's only for this unit test
+        auto lat = grid->get_geometry_data_nonconst("lat").get_view<Real*>();
+        auto lon = grid->get_geometry_data_nonconst("lon").get_view<Real*>();
 
         // Get number of shortwave bands and number of gases from RRTMGP
         int ngas     =   8;  // TODO: get this intelligently

--- a/components/eamxx/tests/uncoupled/shoc/input.yaml
+++ b/components/eamxx/tests/uncoupled/shoc/input.yaml
@@ -18,6 +18,7 @@ grids_manager:
   Type: Mesh Free
   number_of_global_columns:   218
   number_of_vertical_levels:  72  # Will want to change to 128 when a valid unit test is available.
+  geo_data_source: IC_FILE
 
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
@@ -25,8 +26,6 @@ initial_conditions:
   topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
   surf_sens_flux: 0.0
   surf_evap: 0.0
-  Load Latitude: true
-  Load Hybrid Coefficients: true
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
+++ b/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
@@ -349,6 +349,7 @@ TEST_CASE("surface-coupling", "") {
   ad.set_comm(atm_comm);
   ad.set_params(ad_params);
   ad.init_scorpio ();
+  ad.init_time_stamps (t0, t0);
   ad.create_atm_processes ();
   ad.create_grids ();
   ad.create_fields ();
@@ -458,7 +459,7 @@ TEST_CASE("surface-coupling", "") {
                                          export_constant_multiple_view.data(), do_export_during_init_view.data());
 
   // Initialize the AD
-  ad.initialize_fields (t0, t0);
+  ad.initialize_fields ();
   ad.initialize_output_managers ();
   ad.initialize_atm_procs ();
 


### PR DESCRIPTION
This PR does two things:

1. It makes grid object store spatially-dependent data as Field objects: makes part 2 easier, and simplifies some code in the grids/grids manager classes.
2. Allows to save grid's geometry data in the output files: on by default, but only for model output streams. Required some changes in the scorpio interface, to deal with non-time dependent variables.

This PR is non-BFB, in that it adds variables to our v1 output files, but other than that v1 tests should pass on mappy. Standalone tests also pass on mappy. 

I have to take off, so I will wait for AT result to debug possible v1 and/or GPU bugs.