### PR TITLE
Add rough topo compset and test for ne30

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -486,6 +486,7 @@ _TESTS = {
             "PEM_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1",
             "ERS_Ln22.ne30pg2_ne30pg2.F2010-SCREAMv1",
             "ERS_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1.scream-small_kernels",
+            "ERS_Ln22.ne30pg2_ne30pg2.F2010-SCREAMv1-X6T",
             )
     },
 

--- a/components/eamxx/cime_config/config_compsets.xml
+++ b/components/eamxx/cime_config/config_compsets.xml
@@ -81,6 +81,13 @@
       <support_level>Experimental, under development</support_level>
   </compset>
 
+  <compset>
+      <alias>F2010-SCREAMv1-X6T</alias> <!-- Coupled land-atm compset (using SCREAMv1), with X6T topography-->
+      <lname>2010_SCREAM%X6T_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP</lname>
+      <support_level>Experimental, under development</support_level>
+  </compset>
+
+
   <entries>
 
     <entry id="RUN_STARTDATE">

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -302,6 +302,7 @@ tweaking their $case/namelist_scream.xml file.
     <topography_filename hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc</topography_filename>
     <topography_filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne30np4_16xdel2-PFC-consistentSGH.nc</topography_filename>
     <topography_filename hgrid="ne30np4.pg2">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne30np4pg2_16xdel2.c20200108.nc</topography_filename>
+    <topography_filename hgrid="ne30np4.pg2" COMPSET=".*X6T*">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne30np4pg2_x6t-SGH.nc</topography_filename>
     <topography_filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc</topography_filename>
     <topography_filename hgrid="ne120np4.pg2">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne120np4pg2_16xdel2.nc</topography_filename>
     <topography_filename hgrid="ne256np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne256np4_16xdel2_consistentSGH_20220429.nc</topography_filename>
@@ -310,6 +311,7 @@ tweaking their $case/namelist_scream.xml file.
     <topography_filename hgrid="ne512np4.pg2">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne512np4pg2_16xconsistentSGH_20190212_converted.nc</topography_filename>
     <topography_filename hgrid="ne1024np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne1024np4_16xconsistentSGH_20190528.nc</topography_filename>
     <topography_filename hgrid="ne1024np4.pg2">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne1024np4pg2_16xconsistentSGH_20190528_converted.nc</topography_filename>
+    <topography_filename hgrid="ne1024np4.pg2" COMPSET=".*X6T*">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne1024np4pg2_x6t-SGH.nc</topography_filename>
     <topography_filename COMPSET=".*SCREAM%AQUA.*">UNSET</topography_filename>
     <phis COMPSET=".*SCREAM%AQUA.*">0.0</phis>
 
@@ -397,6 +399,7 @@ tweaking their $case/namelist_scream.xml file.
     <nu_top hgrid="ne256np4">4.0e4</nu_top>
     <nu_top hgrid="ne512np4">2.0e4</nu_top>
     <nu_top hgrid="ne1024np4">1.0e4</nu_top>
+    <pgrad_correction COMPSET=".*X6T*">1</pgrad_correction>
     <se_ftype valid_values="0,2">0</se_ftype>
     <se_geometry>sphere</se_geometry>
     <se_limiter_option>9</se_limiter_option>


### PR DESCRIPTION
What this PR currently does:
- Adds rough topo compset for ne30 screamv1, with `USGS-gtopo30_ne30np4pg2_x6t-SGH.nc` topo file and `pgrad_correction=1` set in the input yaml.
- Adds midres test `ERS_Ln22.ne30pg2_ne30pg2.F2010-SCREAMv1-X6T`.
- Fixes ne1024 namelist defaults, so that `*X6T_ELM*` compsets get `USGS-gtopo30_ne1024np4pg2_x6t-SGH.nc` topo file and `pgrad_correction=1`.

What I've verified is that `ERS_Ln22.ne30pg2_ne30pg2.F2010-SCREAMv1-X6T` runs to completion and includes the correct topo file in the input yaml and `pgrad_correction=1` in the namelist file.

Should anything else be tested? Or output files be looked at?

Closes https://github.com/E3SM-Project/scream/issues/2120