### PR TITLE
Add a getter to IO interface to grab the timestamp of a file.

### DIFF
--- a/components/eamxx/src/share/io/scream_scorpio_interface.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.F90
@@ -1374,14 +1374,21 @@ contains
     
     type(pio_atm_file_t), pointer :: pio_atm_file
     logical                       :: found
-    integer                       :: ierr
+    integer                       :: dim_id, time_len, ierr
     type(var_desc_t)              :: varid ! netCDF variable ID
     integer                       :: strt(1), cnt(1)
 
     call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
-    if (.not.found) call errorHandle("pio_inq_dimlen ERROR: File "//trim(filename)//" not found",-999)
+    if (.not.found) call errorHandle("read_time_at_index ERROR: File "//trim(filename)//" not found",-999)
     ierr = PIO_inq_varid(pio_atm_file%pioFileDesc,"time",varid)
     call errorHandle('read_time_at_index: Error finding variable ID for "time" in file '//trim(filename)//'.',ierr);
+
+    ierr = pio_inq_dimid(pio_atm_file%pioFileDesc,trim("time"),dim_id)
+    call errorHandle("read_time_at_index ERROR: dimension 'time' not found in file "//trim(filename)//".",ierr)
+    ierr = pio_inq_dimlen(pio_atm_file%pioFileDesc,dim_id,time_len)
+    if (time_index .gt. time_len) then
+      call errorHandle("read_time_at_index ERROR: time_index arg larger than length of time dimension",-999)
+    end if
 
     if (time_index .gt. 0) then
       strt(1) = time_index

--- a/components/eamxx/src/share/io/scream_scorpio_interface.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.F90
@@ -77,6 +77,7 @@ module scream_scorpio_interface
             get_int_attribute,           & ! Retrieves an integer global attribute from the nc file
             set_int_attribute,           & ! Writes an integer global attribute to the nc file
             get_dimlen,                  & ! Returns the length of a specific dimension in a file
+            read_time_at_index,          & ! Returns the time stamp for a specific time index
             has_variable                   ! Checks if given file contains a certain variable
 
   private :: errorHandle, get_coord
@@ -649,10 +650,10 @@ contains
     use pionfput_mod, only: PIO_put_var   => put_var
 
     character(len=*), intent(in) :: filename       ! PIO filename
-    real(c_double), intent(in)      :: time
+    real(c_double), intent(in)   :: time
 
     type(hist_var_t), pointer    :: var
-    type(pio_atm_file_t),pointer   :: pio_atm_file
+    type(pio_atm_file_t),pointer :: pio_atm_file
     integer                      :: ierr
     logical                      :: found
 
@@ -1359,6 +1360,40 @@ contains
       endif
     endif
   end subroutine get_pio_atm_file
+!=====================================================================!
+  ! Retrieve the time value for a specific time_index
+  ! If the input arg time_index is <= 0 then it is assumed the user wants
+  ! the last time entry.
+  function read_time_at_index(filename,time_index) result(val)
+    use pio,          only: PIO_get_var
+    use pio_nf,       only: PIO_inq_varid
+    character(len=*), intent(in) :: filename
+    integer, intent(in)          :: time_index
+    real(c_double)               :: val
+    real(c_double)               :: val_buf(1)
+    
+    type(pio_atm_file_t), pointer :: pio_atm_file
+    logical                       :: found
+    integer                       :: ierr
+    type(var_desc_t)              :: varid ! netCDF variable ID
+    integer                       :: strt(1), cnt(1)
+
+    call lookup_pio_atm_file(trim(filename),pio_atm_file,found)
+    if (.not.found) call errorHandle("pio_inq_dimlen ERROR: File "//trim(filename)//" not found",-999)
+    ierr = PIO_inq_varid(pio_atm_file%pioFileDesc,"time",varid)
+    call errorHandle('read_time_at_index: Error finding variable ID for "time" in file '//trim(filename)//'.',ierr);
+
+    if (time_index .gt. 0) then
+      strt(1) = time_index
+    else
+      strt(1) = int(pio_atm_file%numRecs,kind=pio_offset_kind)
+    end if
+
+    cnt(1)  = 1
+    ierr = PIO_get_var(pio_atm_file%pioFileDesc,varid,strt,cnt,val_buf)
+    call errorHandle('read_time_at_index: Error reading variable "time" in file '//trim(filename)//'.',ierr);
+    val  = val_buf(1)
+  end function read_time_at_index
 !=====================================================================!
   ! Retrieve the dimension length for a file.
   function get_dimlen(filename,dimname) result(val)

--- a/components/eamxx/src/share/io/scream_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.hpp
@@ -70,7 +70,8 @@ extern "C" {
   int get_dimlen_c2f(const char*&& filename, const char*&& dimname);
   bool has_variable_c2f (const char*&& filename, const char*&& varname);
   /* Query a netCDF file for the time variable */
-  double read_time_at_index_c2f(const char*&& filename, const int& time_index = -1);
+  double read_time_at_index_c2f(const char*&& filename, const int& time_index);
+  double read_curr_time_c2f(const char*&& filename);
 } // extern "C"
 
 // The strings returned by e2str(const FieldTag&) are different from

--- a/components/eamxx/src/share/io/scream_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.hpp
@@ -69,6 +69,8 @@ extern "C" {
   void set_int_attribute_c2f (const char*&& filename, const char*&& attr_name, const int& value);
   int get_dimlen_c2f(const char*&& filename, const char*&& dimname);
   bool has_variable_c2f (const char*&& filename, const char*&& varname);
+  /* Query a netCDF file for the time variable */
+  double read_time_at_index_c2f(const char*&& filename, const int& time_index = -1);
 } // extern "C"
 
 // The strings returned by e2str(const FieldTag&) are different from

--- a/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -270,6 +270,21 @@ contains
 
   end function has_variable_c2f
 !=====================================================================!
+  function read_curr_time_c2f(filename_in) result(val) bind(c)
+    use scream_scorpio_interface, only : read_time_at_index
+    use scream_scorpio_interface, only : get_dimlen
+    type(c_ptr), intent(in)                :: filename_in
+    real(kind=c_double)                    :: val
+
+    integer            :: time_index
+    character(len=256) :: filename
+
+    call convert_c_string(filename_in,filename)
+    time_index = get_dimlen(filename,trim("time"))
+    val        = read_time_at_index(filename,time_index)
+
+  end function read_curr_time_c2f
+!=====================================================================!
   function read_time_at_index_c2f(filename_in,time_index) result(val) bind(c)
     use scream_scorpio_interface, only : read_time_at_index
     type(c_ptr), intent(in)                :: filename_in
@@ -279,7 +294,7 @@ contains
     character(len=256) :: filename
 
     call convert_c_string(filename_in,filename)
-    val =  read_time_at_index(filename,time_index)
+    val = read_time_at_index(filename,time_index)
 
   end function read_time_at_index_c2f
 !=====================================================================!

--- a/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -270,6 +270,19 @@ contains
 
   end function has_variable_c2f
 !=====================================================================!
+  function read_time_at_index_c2f(filename_in,time_index) result(val) bind(c)
+    use scream_scorpio_interface, only : read_time_at_index
+    type(c_ptr), intent(in)                :: filename_in
+    integer(kind=c_int), intent(in)        :: time_index ! zero-based
+    real(kind=c_double)                    :: val
+
+    character(len=256) :: filename
+
+    call convert_c_string(filename_in,filename)
+    val =  read_time_at_index(filename,time_index)
+
+  end function read_time_at_index_c2f
+!=====================================================================!
   subroutine eam_pio_enddef_c2f(filename_in) bind(c)
     use scream_scorpio_interface, only : eam_pio_enddef
     type(c_ptr), intent(in) :: filename_in

--- a/components/eamxx/src/share/io/tests/io.cpp
+++ b/components/eamxx/src/share/io/tests/io.cpp
@@ -301,6 +301,15 @@ void run_multisnap(const std::string& output_freq_units) {
     int tt1 = tt + 1;
     // Here tt1 is the snap, we need to figure out what time that is in seconds given the frequency units
     const int current_t = get_current_t(tt1,dt,io_control.frequency,output_freq_units);
+    // Check timestamp, note, with multisnap we also verify that we can grab the timestamp at location tt1
+    {
+      auto test_filename = input_params.get<std::string>("Filename");
+      scorpio::register_file(test_filename,scorpio::Read);
+      Real time_val = scorpio::read_time_at_index_c2f(test_filename.c_str(),tt1);
+      scorpio::eam_pio_closefile(test_filename);
+      Real time_in_days = current_t/86400.; // current_t is in seconds, need to convert to days.
+      REQUIRE(time_val==time_in_days);
+    }
     for (int ii=0;ii<num_lcols;++ii) {
       REQUIRE(std::abs(f1_host(ii)-check_data_xy(current_t,dt,ii,0,"instant"))<tol);
       for (int jj=0;jj<num_levs;++jj) {
@@ -504,6 +513,16 @@ void run(const std::string& output_type,const std::string& output_freq_units) {
     }
   }
   Int current_t = max_steps*dt;
+  // Check timestamp
+  {
+    auto test_filename = input_params.get<std::string>("Filename");
+    scorpio::register_file(test_filename,scorpio::Read);
+    Real time_val = scorpio::read_time_at_index_c2f(test_filename.c_str());
+    scorpio::eam_pio_closefile(test_filename);
+    Real time_in_days = current_t/86400.; // current_t is in seconds, need to convert to days.
+    REQUIRE(time_val==time_in_days);
+  }
+  // Check values
   for (int ii=0;ii<num_lcols;++ii) {
     REQUIRE(std::abs(f1_host(ii)-check_data_xy(current_t,dt,ii,0,output_type))<tol);
     for (int jj=0;jj<num_levs;++jj) {

--- a/components/eamxx/src/share/io/tests/io.cpp
+++ b/components/eamxx/src/share/io/tests/io.cpp
@@ -517,7 +517,7 @@ void run(const std::string& output_type,const std::string& output_freq_units) {
   {
     auto test_filename = input_params.get<std::string>("Filename");
     scorpio::register_file(test_filename,scorpio::Read);
-    Real time_val = scorpio::read_time_at_index_c2f(test_filename.c_str());
+    Real time_val = scorpio::read_curr_time_c2f(test_filename.c_str());
     scorpio::eam_pio_closefile(test_filename);
     Real time_in_days = current_t/86400.; // current_t is in seconds, need to convert to days.
     REQUIRE(time_val==time_in_days);

--- a/components/eamxx/src/share/io/tests/io.cpp
+++ b/components/eamxx/src/share/io/tests/io.cpp
@@ -304,9 +304,7 @@ void run_multisnap(const std::string& output_freq_units) {
     // Check timestamp, note, with multisnap we also verify that we can grab the timestamp at location tt1
     {
       auto test_filename = input_params.get<std::string>("Filename");
-      scorpio::register_file(test_filename,scorpio::Read);
       Real time_val = scorpio::read_time_at_index_c2f(test_filename.c_str(),tt1);
-      scorpio::eam_pio_closefile(test_filename);
       Real time_in_days = current_t/86400.; // current_t is in seconds, need to convert to days.
       REQUIRE(time_val==time_in_days);
     }


### PR DESCRIPTION
This commit introduces the function read_time_at_index to the IO interface for EAMxx.  The purpose of this routine is to read the specific "time" variable to get the timestamp from a file.

This commit also adds the read_time_at_index calls to the io_test unit test which verifies that the output variables store the correct timestamp and verifies that the read_time_at_index routine is working correctly.