### PR TITLE
EAMxx: Fix imported piof target for CIME builds

### DIFF
--- a/components/eamxx/cmake/tpls/Scorpio.cmake
+++ b/components/eamxx/cmake/tpls/Scorpio.cmake
@@ -58,12 +58,12 @@ macro (CreateScorpioTargets)
     ######################
 
     # Look for piof lib in INSTALL_SHAREDPATH/lib
-    find_library(SCORPIO_F_LIB piof REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
+    find_library(SCORPIO_F_LIB piof REQUIRED PATHS ${SCORPIO_LIB_DIR})
 
     # Create the interface library, and set target properties
     add_library(piof INTERFACE)
-    target_link_libraries (pioc INTERFACE ${SCORPIO_F_LIB} ${netcdf_f_lib} pioc)
-    target_include_directories (pioc INTERFACE ${SCORPIO_INC_DIR} ${netcdf_f_incdir} )
+    target_link_libraries (piof INTERFACE ${SCORPIO_F_LIB} ${netcdf_f_lib} pioc)
+    target_include_directories (piof INTERFACE ${SCORPIO_INC_DIR} ${netcdf_f_incdir} )
 
   else ()
     # Not a CIME build. We'll add scorpio as a subdir


### PR DESCRIPTION
Fixes a cmake bug that prevented the imported piof target in CIME build from having the correct upstream dependencies added to the target. Namely, the piof target contained nothing. Since scream_io linked both pioc and piof, this was "ok" so long as netcdf C and Fortran installation were in the same include/lib folders, which is often (but not always!) the case on HPC platforms.

This PR fixes the setup of piof, so that it is a well-formed CMake target, containing all the needed include/lib dependencies (e.g., netcdf-f).

Edit: actually, things were OK regardless of netcf C/F installation folders. In fact, we were adding scorpio's flib as a dependency of pioc. Hence, linking pioc we were linking both flib and clib from scorpio, with their deps. The imported target piof was in fact _empty_. If we had had linked _just_ piof (which, in theory, should also link pioc indirectly) we would have noticed the error at build time.