### PR TITLE
EAMxx: Use type annotation in mesh_file entry.

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -444,7 +444,7 @@ tweaking their $case/namelist_scream.xml file.
     <transport_alg hgrid=".*pg2">12</transport_alg>
     <!-- Other settings that we'll trigger based on pg2 for convenience -->
     <se_ftype valid_values="0,2" hgrid=".*pg2">2</se_ftype>
-    <mesh_file>none</mesh_file>
+    <mesh_file type="file">none</mesh_file>
     <mesh_file hgrid="ne0np4_conus_x4v1_lowcon">${DIN_LOC_ROOT}/atm/cam/inic/homme/conusx4v1.g</mesh_file>
   </ctl_nl>
 


### PR DESCRIPTION
This should make the grid auto-download through CIME.