### PR TITLE
Allow using non-integer timestep inside atmosphere processes

### DIFF
--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -202,12 +202,12 @@ void SurfaceCouplingExporter::initialize_impl (const RunType /* run_type */)
   if (any_initial_exports) do_export(0, true);
 }
 // =========================================================================================
-void SurfaceCouplingExporter::run_impl (const int dt)
+void SurfaceCouplingExporter::run_impl (const double dt)
 {
   do_export(dt);
 }
 // =========================================================================================
-void SurfaceCouplingExporter::do_export(const Int dt, const bool called_during_initialization)
+void SurfaceCouplingExporter::do_export(const double dt, const bool called_during_initialization)
 {
   using policy_type = KT::RangePolicy;
   using PC = physics::Constants<Real>;

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
@@ -69,7 +69,7 @@ public:
   // If calling in initialize_impl(), set
   // called_during_initialization=true to avoid exporting fields
   // which do not have valid entries.
-  void do_export(const Int dt, const bool called_during_initialization=false);
+  void do_export(const double dt, const bool called_during_initialization=false);
 
   // Take and store data from SCDataManager
   void setup_surface_coupling_data(const SCDataManager &sc_data_manager);
@@ -78,7 +78,7 @@ protected:
 
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
-  void run_impl        (const int dt);
+  void run_impl        (const double dt);
   void finalize_impl   ();
 
   // Creates an helper field, not to be shared with the AD's FieldManager

--- a/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
@@ -132,7 +132,7 @@ void SurfaceCouplingImporter::initialize_impl (const RunType /* run_type */)
   if (any_initial_imports) do_import(true);
 }
 // =========================================================================================
-void SurfaceCouplingImporter::run_impl (const int /* dt */)
+void SurfaceCouplingImporter::run_impl (const double /* dt */)
 {
   do_import();
 }

--- a/components/eamxx/src/control/atmosphere_surface_coupling_importer.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_importer.hpp
@@ -62,7 +62,7 @@ protected:
 
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
-  void run_impl        (const int dt);
+  void run_impl        (const double dt);
   void finalize_impl   ();
 
   // Keep track of field dimensions

--- a/components/eamxx/src/control/tests/dummy_atm_proc.hpp
+++ b/components/eamxx/src/control/tests/dummy_atm_proc.hpp
@@ -74,7 +74,7 @@ protected:
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
-  void run_impl (const int /* dt */) {
+  void run_impl (const double /* dt */) {
     const int ncols = m_grid->get_num_local_dofs();
     const int nlevs = m_grid->get_num_vertical_levels();
     auto policy = KokkosTypes<exec_space>::RangePolicy(0,ncols*nlevs);

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -452,7 +452,7 @@ void HommeDynamics::initialize_impl (const RunType run_type)
   rayleigh_friction_init();
 }
 
-void HommeDynamics::run_impl (const int dt)
+void HommeDynamics::run_impl (const double dt)
 {
   try {
 

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -100,7 +100,7 @@ public:
   void remap_fv_phys_to_dyn() const;
   
 protected:
-  void run_impl        (const int dt);
+  void run_impl        (const double dt);
   void finalize_impl   ();
 
   // We need to store the size of the tracers group as soon as it is available.

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -21,11 +21,6 @@ namespace scream
  */
 class HommeDynamics : public AtmosphereProcess
 {
-  using Pack = ekat::Pack<Real,SCREAM_PACK_SIZE>;
-  using KT = KokkosTypes<DefaultDevice>;
-  template<typename ScalarT>
-  using view_1d = typename KT::template view_1d<ScalarT>;
-
 public:
 
   // Constructor(s) and Destructor
@@ -137,8 +132,15 @@ protected:
   std::shared_ptr<const AbstractGrid> m_phys_grid; // Column parameterizations grid
   std::shared_ptr<const AbstractGrid> m_cgll_grid; // Unique CGLL
 
+  template<int N>
+  using RPack = ekat::Pack<Real,N>;
+
+  using KT = KokkosTypes<DefaultDevice>;
+  template<typename ScalarT>
+  using view_1d = typename KT::template view_1d<ScalarT>;
+
   // Rayleigh friction decay rate profile
-  view_1d<Pack> m_otau;
+  view_1d<RPack<SCREAM_PACK_SIZE>> m_otau;
 
   // Rayleigh friction paramaters
   int m_rayk0;      // Vertical level at which rayleigh friction term is centered.

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -45,8 +45,8 @@ public:
   // Cuda requires methods enclosing __device__ lambda's to be public
 protected:
 #endif
-  void homme_pre_process (const int dt);
-  void homme_post_process (const int dt);
+  void homme_pre_process (const double dt);
+  void homme_post_process (const double dt);
 
 #ifndef KOKKOS_ENABLE_CUDA
   // Cuda requires methods enclosing __device__ lambda's to be public

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics_rayleigh_friction.cpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics_rayleigh_friction.cpp
@@ -10,10 +10,6 @@ namespace scream {
 
 void HommeDynamics::rayleigh_friction_init()
 {
-  constexpr int N = HOMMEXX_PACK_SIZE;
-  using KT = KokkosTypes<DefaultDevice>;
-  using Pack = ekat::Pack<Real,N>;
-
   // Rayleigh friction paramaters
   m_rayk0     = m_params.get<int>("rayleigh_friction_vertical_level", 2);
   m_raykrange = m_params.get<Real>("rayleigh_friction_range", 0.0);
@@ -26,9 +22,12 @@ void HommeDynamics::rayleigh_friction_init()
   // to 0-based for computations
   m_rayk0 -= 1;
 
+  constexpr int N = SCREAM_PACK_SIZE;
+  using Pack = RPack<N>;
+
   // Calculate decay rate profile, otau.
   const int nlevs = m_dyn_grid->get_num_vertical_levels();
-  const auto npacks= ekat::PackInfo<Pack::n>::num_packs(nlevs);
+  const auto npacks= ekat::PackInfo<N>::num_packs(nlevs);
   m_otau = decltype(m_otau)("otau", npacks);
 
   // Local paramters
@@ -49,7 +48,7 @@ void HommeDynamics::rayleigh_friction_init()
     
   Kokkos::parallel_for(KT::RangePolicy(0, npacks),
                        KOKKOS_LAMBDA (const int ilev) {
-    const auto range_pack = ekat::range<Pack>(ilev*Pack::n);
+    const auto range_pack = ekat::range<Pack>(ilev*N);
     const Pack x = (rayk0 - range_pack)/krange;
     otau(ilev) = otau0*(1.0 + ekat::tanh(x))/2.0;
   });
@@ -59,8 +58,7 @@ void HommeDynamics::rayleigh_friction_apply(const Real dt) const
 {
   constexpr int N = HOMMEXX_PACK_SIZE;
   using PF = PhysicsFunctions<DefaultDevice>;
-  using KT = KokkosTypes<DefaultDevice>;
-  using Pack = ekat::Pack<Real,N>;
+  using Pack = RPack<N>;
   using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
 
   // If m_raytau0==0, then no Rayleigh friction is applied. Return.

--- a/components/eamxx/src/physics/cld_fraction/atmosphere_cld_fraction.cpp
+++ b/components/eamxx/src/physics/cld_fraction/atmosphere_cld_fraction.cpp
@@ -61,7 +61,7 @@ void CldFraction::initialize_impl (const RunType /* run_type */)
 }
 
 // =========================================================================================
-void CldFraction::run_impl (const int /* dt */)
+void CldFraction::run_impl (const double /* dt */)
 {
   // Calculate ice cloud fraction and total cloud fraction given the liquid cloud fraction
   // and the ice mass mixing ratio. 

--- a/components/eamxx/src/physics/cld_fraction/atmosphere_cld_fraction.hpp
+++ b/components/eamxx/src/physics/cld_fraction/atmosphere_cld_fraction.hpp
@@ -41,7 +41,7 @@ protected:
 
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
-  void run_impl        (const int dt);
+  void run_impl        (const double dt);
   void finalize_impl   ();
 
   // Keep track of field dimensions and the iteration count

--- a/components/eamxx/src/physics/p3/atmosphere_microphysics.hpp
+++ b/components/eamxx/src/physics/p3/atmosphere_microphysics.hpp
@@ -56,7 +56,7 @@ public:
   /*--------------------------------------------------------------------------------------------*/
   // Most individual processes have a pre-processing step that constructs needed variables from
   // the set of fields stored in the field manager.  A structure like this defines those operations,
-  // which can then be called during run_imple in the main .cpp code.
+  // which can then be called during run_impl in the main .cpp code.
   // NOTE: the use of the ekat command "set" to copy local values into the variables of interest.
   // This is an important step to avoid having those variables just share pointers to memory.
   // Structure to handle the local generation of data needed by p3_main in run_impl
@@ -259,7 +259,8 @@ public:
       }
     } // operator
     // Local variables
-    int m_ncol, m_npack, m_dt;
+    int m_ncol, m_npack;
+    double m_dt;
     view_2d       T_atm;
     view_2d_const pmid;
     view_2d       th_atm;
@@ -286,12 +287,6 @@ public:
     view_1d       ice_flux;
     view_1d       heat_flux;
 
-    // Assigning local values
-    void set_dt(const int dt)
-    {
-      // Allow dt to be set every run_impl, in case variable timestepping is ever used.
-      m_dt = dt;
-    }
     void set_variables(const int ncol, const int npack,
                     const view_2d& th_atm_, const view_2d_const& pmid_, const view_2d& T_atm_, const view_2d& T_prev_,
                     const view_2d& qv_, const view_2d& qc_, const view_2d& nc_, const view_2d& qr_, const view_2d& nr_,
@@ -377,7 +372,7 @@ protected:
 
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
-  void run_impl        (const int dt);
+  void run_impl        (const double dt);
   void finalize_impl   ();
 
   // Computes total number of bytes needed for local variables

--- a/components/eamxx/src/physics/p3/atmosphere_microphysics_run.cpp
+++ b/components/eamxx/src/physics/p3/atmosphere_microphysics_run.cpp
@@ -2,10 +2,10 @@
 
 namespace scream {
 
-void P3Microphysics::run_impl (const int dt)
+void P3Microphysics::run_impl (const double dt)
 {
   // Set the dt for p3 postprocessing
-  p3_postproc.set_dt(dt);
+  p3_postproc.m_dt = dt;
 
   // Assign values to local arrays used by P3, these are now stored in p3_loc.
   Kokkos::parallel_for(

--- a/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -366,7 +366,7 @@ void RRTMGPRadiation::initialize_impl(const RunType /* run_type */) {
 
 // =========================================================================================
 
-void RRTMGPRadiation::run_impl (const int dt) {
+void RRTMGPRadiation::run_impl (const double dt) {
   using PF = scream::PhysicsFunctions<DefaultDevice>;
   using PC = scream::physics::Constants<Real>;
   using CO = scream::ColumnOps<DefaultDevice,Real>;

--- a/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.hpp
+++ b/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.hpp
@@ -42,7 +42,7 @@ public:
 public:
   // The three main interfaces for the subcomponent
   void initialize_impl (const RunType run_type);
-  void run_impl        (const int dt);
+  void run_impl        (const double dt);
   void finalize_impl   ();
 
   // Keep track of number of columns and levels

--- a/components/eamxx/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/eamxx/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -440,7 +440,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
 }
 
 // =========================================================================================
-void SHOCMacrophysics::run_impl (const int dt)
+void SHOCMacrophysics::run_impl (const double dt)
 {
   EKAT_REQUIRE_MSG (dt<=300,
       "Error! SHOC is intended to run with a timestep no longer than 5 minutes.\n"
@@ -461,7 +461,7 @@ void SHOCMacrophysics::run_impl (const int dt)
   // number of SHOC timesteps (nadv) to be 1.
   // TODO: input parameter?
   hdtime = dt;
-  m_nadv = std::max(hdtime/dt,1);
+  m_nadv = std::max(static_cast<int>(hdtime/dt),1);
 
   // Reset internal WSM variables.
   workspace_mgr.reset_internals();

--- a/components/eamxx/src/physics/shoc/atmosphere_macrophysics.cpp
+++ b/components/eamxx/src/physics/shoc/atmosphere_macrophysics.cpp
@@ -461,7 +461,7 @@ void SHOCMacrophysics::run_impl (const double dt)
   // number of SHOC timesteps (nadv) to be 1.
   // TODO: input parameter?
   hdtime = dt;
-  m_nadv = std::max(static_cast<int>(hdtime/dt),1);
+  m_nadv = std::max(static_cast<int>(round(hdtime/dt)),1);
 
   // Reset internal WSM variables.
   workspace_mgr.reset_internals();

--- a/components/eamxx/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/eamxx/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -526,7 +526,7 @@ protected:
 
 protected:
 
-  void run_impl        (const int dt);
+  void run_impl        (const double dt);
   void finalize_impl   ();
 
   // SHOC updates the 'tracers' group.

--- a/components/eamxx/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/eamxx/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -201,7 +201,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
 }
 
 // =========================================================================================
-void SPA::run_impl (const int dt)
+void SPA::run_impl (const double dt)
 {
   /* Gather time and state information for interpolation */
   auto ts = timestamp()+dt;

--- a/components/eamxx/src/physics/spa/atmosphere_prescribed_aerosol.hpp
+++ b/components/eamxx/src/physics/spa/atmosphere_prescribed_aerosol.hpp
@@ -63,7 +63,7 @@ protected:
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
   void initialize_spa_impl ();
-  void run_impl        (const int dt);
+  void run_impl        (const double dt);
   void finalize_impl   ();
 
   // Computes total number of bytes needed for local variables

--- a/components/eamxx/src/physics/spa/tests/spa_main_test.cpp
+++ b/components/eamxx/src/physics/spa/tests/spa_main_test.cpp
@@ -194,7 +194,7 @@ TEST_CASE("spa_main")
   RPDF pdf(0.001,0.999);
   auto dt = (t_end-t_beg) * pdf(engine);
 
-  auto t_mid = t_beg + static_cast<int>(dt);
+  auto t_mid = t_beg + static_cast<int>(round(dt));
   spa_time_state.t_now = t_mid.frac_of_year_in_days();
   SPAFunc::perform_time_interpolation(spa_time_state,spa_beg,spa_end,spa_tmp);
   data_tmp_h.copy_from_dev(spa_tmp.data);

--- a/components/eamxx/src/physics/spa/tests/spa_main_test.cpp
+++ b/components/eamxx/src/physics/spa/tests/spa_main_test.cpp
@@ -192,9 +192,9 @@ TEST_CASE("spa_main")
   std::cout << "  -> time interp, t_beg<t<t_end\n";
 
   RPDF pdf(0.001,0.999);
-  auto dt = int ( (t_end-t_beg) * pdf(engine) );
+  auto dt = (t_end-t_beg) * pdf(engine);
 
-  auto t_mid = t_beg + dt;
+  auto t_mid = t_beg + static_cast<int>(dt);
   spa_time_state.t_now = t_mid.frac_of_year_in_days();
   SPAFunc::perform_time_interpolation(spa_time_state,spa_beg,spa_end,spa_tmp);
   data_tmp_h.copy_from_dev(spa_tmp.data);

--- a/components/eamxx/src/physics/zm/atmosphere_deep_convection.cpp
+++ b/components/eamxx/src/physics/zm/atmosphere_deep_convection.cpp
@@ -71,7 +71,7 @@ void ZMDeepConvection::initialize_impl (const RunType /* run_type */)
   zm_init_f90 (*m_raw_ptrs_in["limcnv_in"], m_raw_ptrs_in["no_deep_pbl_in"]);
 }
 // =========================================================================================
-void ZMDeepConvection::run_impl (const int dt)
+void ZMDeepConvection::run_impl (const double dt)
 {
   std::vector<const Real*> in;
   std::vector<Real*> out;

--- a/components/eamxx/src/physics/zm/atmosphere_deep_convection.hpp
+++ b/components/eamxx/src/physics/zm/atmosphere_deep_convection.hpp
@@ -37,7 +37,7 @@ public:
 
   // The three main interfaces for the subcomponent
   void initialize_impl (const RunType run_type);
-  void run_impl        (const int dt);
+  void run_impl        (const double dt);
   void finalize_impl   ();
 
   // Register all fields in the proper field manager(s).

--- a/components/eamxx/src/share/atm_process/atmosphere_diagnostic.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_diagnostic.cpp
@@ -18,7 +18,7 @@ Field AtmosphereDiagnostic::get_diagnostic () const {
   return m_diagnostic_output.get_const();
 }
 
-void AtmosphereDiagnostic::compute_diagnostic (const int dt) {
+void AtmosphereDiagnostic::compute_diagnostic (const double dt) {
   // Some diagnostics need the timestep, store in case.
   m_dt = dt;
 
@@ -44,7 +44,7 @@ void AtmosphereDiagnostic::compute_diagnostic (const int dt) {
 }
 
 
-void AtmosphereDiagnostic::run_impl (const int dt) {
+void AtmosphereDiagnostic::run_impl (const double dt) {
   compute_diagnostic(dt);
 }
 void AtmosphereDiagnostic::set_computed_field (const Field& /* f */) {

--- a/components/eamxx/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -54,7 +54,7 @@ public:
   void set_computed_field (const Field& f) final;
   void set_computed_group (const FieldGroup& group) final;
 
-  void compute_diagnostic (const int dt=0);
+  void compute_diagnostic (const double dt = 0);
 protected:
 
   virtual void compute_diagnostic_impl () = 0;
@@ -62,11 +62,11 @@ protected:
   // By default, diagnostic don't do any initialization/finalization stuff.
   // Derived classes can override, of course
   void initialize_impl (const RunType /*run_type*/) { /* Nothing to do */ }
-  void run_impl (const int dt);
+  void run_impl (const double dt);
   void finalize_impl   () { /* Nothing to do */ }
 
   // Some diagnostics will need the timestep, store here.
-  int m_dt;
+  double m_dt;
 
   // Diagnostics are meant to return a field
   Field m_diagnostic_output;

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -75,18 +75,12 @@ void AtmosphereProcess::initialize (const TimeStamp& t0, const RunType run_type)
   }
 }
 
-void AtmosphereProcess::run (const int dt) {
+void AtmosphereProcess::run (const double dt) {
   start_timer (m_timer_prefix + this->name() + "::run");
   if (m_params.get("enable_precondition_checks", true)) {
     // Run 'pre-condition' property checks stored in this AP
     run_precondition_checks();
   }
-
-  EKAT_REQUIRE_MSG ( (dt % m_num_subcycles)==0,
-      "Error! The number of subcycle iterations does not exactly divide the time step.\n"
-      "  - Atm proc name: " + this->name() + "\n"
-      "  - Num subcycles: " + std::to_string(m_num_subcycles) + "\n"
-      "  - Time step    : " + std::to_string(dt) + "\n");
 
   // Let the derived class do the actual run
   auto dt_sub = dt / m_num_subcycles;

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -110,7 +110,7 @@ public:
   //       Whether it's a needed check depends on what resources we init/free, and how.
   // TODO: should we check that initialize has been called, when calling run/finalize?
   void initialize (const TimeStamp& t0, const RunType run_type);
-  void run (const int dt);
+  void run (const double dt);
   void finalize   (/* what inputs? */);
 
   // Return the MPI communicator
@@ -363,7 +363,7 @@ protected:
 
   // Override this method to define how the derived runs forward one step
   // (of size dt). This method is called before the timestamp is updated.
-  virtual void run_impl(const int dt) = 0;
+  virtual void run_impl(const double dt) = 0;
 
   // Override this method to finalize the derived class
   virtual void finalize_impl(/* what inputs? */) = 0;

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
@@ -331,7 +331,7 @@ void AtmosphereProcessGroup::initialize_impl (const RunType run_type) {
   }
 }
 
-void AtmosphereProcessGroup::run_impl (const int dt) {
+void AtmosphereProcessGroup::run_impl (const double dt) {
   if (m_group_schedule_type==ScheduleType::Sequential) {
     run_sequential(dt);
   } else {
@@ -339,7 +339,7 @@ void AtmosphereProcessGroup::run_impl (const int dt) {
   }
 }
 
-void AtmosphereProcessGroup::run_sequential (const Real dt) {
+void AtmosphereProcessGroup::run_sequential (const double dt) {
   // Get the timestamp at the beginning of the step and advance it.
   auto ts = timestamp();
   ts += dt;
@@ -362,7 +362,7 @@ void AtmosphereProcessGroup::run_sequential (const Real dt) {
   }
 }
 
-void AtmosphereProcessGroup::run_parallel (const Real /* dt */) {
+void AtmosphereProcessGroup::run_parallel (const double /* dt */) {
   EKAT_REQUIRE_MSG (false,"Error! Parallel splitting not yet implemented.\n");
 }
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
@@ -101,11 +101,11 @@ protected:
   // The initialization, run, and finalization methods
   void initialize_impl(const RunType run_type);
   void initialize_impl ();
-  void run_impl        (const int dt);
+  void run_impl        (const double dt);
   void finalize_impl   (/* what inputs? */);
 
-  void run_sequential (const Real dt);
-  void run_parallel   (const Real dt);
+  void run_sequential (const double dt);
+  void run_parallel   (const double dt);
 
   // The methods to set the fields/groups in the right processes of the group
   void set_required_field_impl (const Field& f);

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -129,7 +129,6 @@ set_pressure_levels(const std::string& map_file) {
   m_remap_pres.get_header().get_alloc_properties().request_allocation(mPack::n);
   m_remap_pres.allocate_view();
 
-  auto npacks = ekat::PackInfo<mPack::n>::num_packs(m_num_remap_levs);
   auto remap_pres_scal = m_remap_pres.get_view<Real*>();
 
   std::vector<scorpio::offset_t> dofs_offsets(m_num_remap_levs);
@@ -286,7 +285,6 @@ apply_vertical_interpolation(const Field& f_src, const Field& f_tgt) const
     const auto  rank   = f_src.rank();
     auto src_tag = layout.tags().back();
     auto src_num_levs = layout.dim(src_tag);
-    const bool do_remap = ekat::contains(std::vector<FieldTag>{ILEV,LEV},src_tag);
 
     Field    src_lev_f;
     if (src_tag == ILEV) {

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -182,7 +182,6 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
     for (const auto& fname : m_fields_names) {
       auto src = get_field(fname,m_sim_field_mgr);
       auto tgt = io_fm->get_field(src.name());
-      const auto& src_fid = src.get_header().get_identifier();
       m_vert_remapper->bind_field(src,tgt);
     }
 

--- a/components/eamxx/src/share/tests/atm_process_tests.cpp
+++ b/components/eamxx/src/share/tests/atm_process_tests.cpp
@@ -227,7 +227,7 @@ protected:
 
   // The run method is responsible for exporting atm states to the e3sm coupler, and
   // import surface states from the e3sm coupler.
-  void run_impl (const int /* dt */) {}
+  void run_impl (const double /* dt */) {}
 
   // Clean up
   void finalize_impl ( /* inputs */ ) {}
@@ -329,7 +329,7 @@ public:
     add_field<Updated>("Field A",lt,K,m_grid_name);
   }
 protected:
-    void run_impl (const int /* dt */) {
+    void run_impl (const double /* dt */) {
     auto v = get_field_out("Field A", m_grid_name).get_view<Real*,Host>();
 
     for (int i=0; i<v.extent_int(0); ++i) {

--- a/components/eamxx/src/share/util/scream_time_stamp.cpp
+++ b/components/eamxx/src/share/util/scream_time_stamp.cpp
@@ -144,7 +144,14 @@ void TimeStamp::set_num_steps (const int num_steps) {
   m_num_steps = num_steps;
 }
 
-TimeStamp& TimeStamp::operator+=(const int seconds) {
+TimeStamp& TimeStamp::operator+=(const double seconds) {
+  // Sanity checks
+  // Note: (x-int(x)) only works for x small enough that can be stored in an int,
+  //       but that should be the case here, for use cases in EAMxx.
+  EKAT_REQUIRE_MSG (seconds>0, "Error! Time must move forward.\n");
+  EKAT_REQUIRE_MSG ((seconds-static_cast<int>(seconds))<std::numeric_limits<double>::epsilon()*10,
+      "Error! Cannot update TimeStamp with non-integral number of seconds " << seconds << "\n");
+
   EKAT_REQUIRE_MSG(is_valid(),
       "Error! The time stamp contains uninitialized values.\n"
       "       To use this object, use operator= with a valid rhs first.\n");
@@ -156,7 +163,6 @@ TimeStamp& TimeStamp::operator+=(const int seconds) {
   auto& mm = m_date[1];
   auto& yy = m_date[0];
 
-  EKAT_REQUIRE_MSG (seconds>0, "Error! Time must move forward.\n");
   ++m_num_steps;
   sec += seconds;
 

--- a/components/eamxx/src/share/util/scream_time_stamp.cpp
+++ b/components/eamxx/src/share/util/scream_time_stamp.cpp
@@ -149,7 +149,7 @@ TimeStamp& TimeStamp::operator+=(const double seconds) {
   // Note: (x-int(x)) only works for x small enough that can be stored in an int,
   //       but that should be the case here, for use cases in EAMxx.
   EKAT_REQUIRE_MSG (seconds>0, "Error! Time must move forward.\n");
-  EKAT_REQUIRE_MSG ((seconds-static_cast<int>(seconds))<std::numeric_limits<double>::epsilon()*10,
+  EKAT_REQUIRE_MSG ((seconds-round(seconds))<std::numeric_limits<double>::epsilon()*10,
       "Error! Cannot update TimeStamp with non-integral number of seconds " << seconds << "\n");
 
   EKAT_REQUIRE_MSG(is_valid(),

--- a/components/eamxx/src/share/util/scream_time_stamp.hpp
+++ b/components/eamxx/src/share/util/scream_time_stamp.hpp
@@ -53,7 +53,7 @@ public:
   TimeStamp& operator= (const TimeStamp&) = default;
 
   // This method checks that time shifts forward (i.e. that seconds is positive)
-  TimeStamp& operator+= (const int seconds);
+  TimeStamp& operator+= (const double seconds);
 
 protected:
 

--- a/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
+++ b/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
@@ -223,7 +223,7 @@ void perform_checks(
   const int                         nlevs_src,
   const int                         nlevs_tgt)
 {
-  auto rank = input.rank;
+  constexpr int rank = input.rank;
   EKAT_REQUIRE_MSG (rank>1 &&rank<=3,"Error::scream_vertical_interpolation, passed view of rank (" + std::to_string(rank) +"), only support ranks 2 or 3\n");
 
   // The input data and x_src data should match in the appropriate size
@@ -231,7 +231,7 @@ void perform_checks(
 
 
   // The output and input data should match in rank
-  EKAT_REQUIRE(input.rank == output.rank);
+  EKAT_REQUIRE(static_cast<int>(output.rank)==rank);
   // The output data and the input data should match in all sizes except the last one
   for (int ii=0;ii<rank-1;ii++) {
     EKAT_REQUIRE(input.extent_int(ii)==output.extent_int(ii));


### PR DESCRIPTION
There are only two places where we need an integer dt: when we interface to the component coupler, and when we update a timestamp. All other places in the code, can use a non-integer value.

With this mod, atmosphere processes can use a number of subcycles that yields non-integer dt. Notice that, if we're in the middle of a subcyle, the atm proc class will not attempt to update the computed fields' timestamps, so the non-integer dt is not a problem. The TimeStamp class checks that the input dt is "close to be integer" when updating the time; if it's not, it throws, otherwise it rounds dt to an int, and then updates the time. When all the subcycles are completed, we should be back to an integer dt (modulo some roundoffs), so updating time is again ok.