### PR TITLE
Use TeamVectorRange for flat-loops

### DIFF
--- a/components/eamxx/src/diagnostics/dry_static_energy.cpp
+++ b/components/eamxx/src/diagnostics/dry_static_energy.cpp
@@ -79,7 +79,7 @@ void DryStaticEnergyDiagnostic::compute_diagnostic_impl()
     const auto& dz_s    = ekat::subview(tmp_mid,icol);
     const auto& z_int_s = ekat::subview(tmp_int,icol);
     const auto& z_mid_s = dz_s; // Reuse the memory for z_mid, but set a new variable for code readability.
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, npacks), [&] (const Int& jpack) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, npacks), [&] (const Int& jpack) {
       dz_s(jpack) = PF::calculate_dz(pseudo_density_mid(icol,jpack), p_mid(icol,jpack), T_mid(icol,jpack), qv_mid(icol,jpack));
     });
     team.team_barrier();
@@ -88,7 +88,7 @@ void DryStaticEnergyDiagnostic::compute_diagnostic_impl()
     PF::calculate_z_mid(team,num_levs,z_int_s,z_mid_s);
     team.team_barrier();
     const auto& dse_s = ekat::subview(dse,icol);
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, npacks), [&] (const Int& jpack) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, npacks), [&] (const Int& jpack) {
       dse_s(jpack) = PF::calculate_dse(T_mid(icol,jpack),z_mid_s(jpack),phis(icol));
     });
     team.team_barrier();

--- a/components/eamxx/src/diagnostics/ice_water_path.cpp
+++ b/components/eamxx/src/diagnostics/ice_water_path.cpp
@@ -57,7 +57,7 @@ void IceWaterPathDiagnostic::compute_diagnostic_impl()
                        default_policy,
                        KOKKOS_LAMBDA(const MemberType& team) {
     const int icol = team.league_rank();
-    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
+    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
       const int jpack = idx / Pack::n;
       const int klev  = idx % Pack::n;
       lsum += qi_mid(icol,jpack)[klev] * pseudo_density_mid(icol,jpack)[klev]/gravit;

--- a/components/eamxx/src/diagnostics/liquid_water_path.cpp
+++ b/components/eamxx/src/diagnostics/liquid_water_path.cpp
@@ -57,7 +57,7 @@ void LiqWaterPathDiagnostic::compute_diagnostic_impl()
                        default_policy,
                        KOKKOS_LAMBDA(const MemberType& team) {
     const int icol = team.league_rank();
-    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
+    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
       const int jpack = idx / Pack::n;
       const int klev  = idx % Pack::n;
       lsum += qc_mid(icol,jpack)[klev] * pseudo_density_mid(icol,jpack)[klev]/gravit;

--- a/components/eamxx/src/diagnostics/meridional_vapor_flux.cpp
+++ b/components/eamxx/src/diagnostics/meridional_vapor_flux.cpp
@@ -64,7 +64,7 @@ void MeridionalVapFluxDiagnostic::compute_diagnostic_impl()
                        default_policy,
                        KOKKOS_LAMBDA(const MemberType& team) {
     const int icol = team.league_rank();
-    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
+    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
       const int jpack = idx / Pack::n;
       const int klev  = idx % Pack::n;
       // Note, horiz_winds contains u (index 0) and v (index 1).  Here we want v

--- a/components/eamxx/src/diagnostics/rain_water_path.cpp
+++ b/components/eamxx/src/diagnostics/rain_water_path.cpp
@@ -57,7 +57,7 @@ void RainWaterPathDiagnostic::compute_diagnostic_impl()
                        default_policy,
                        KOKKOS_LAMBDA(const MemberType& team) {
     const int icol = team.league_rank();
-    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
+    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
       const int jpack = idx / Pack::n;
       const int klev  = idx % Pack::n;
       lsum += qr_mid(icol,jpack)[klev] * pseudo_density_mid(icol,jpack)[klev]/gravit;

--- a/components/eamxx/src/diagnostics/rime_water_path.cpp
+++ b/components/eamxx/src/diagnostics/rime_water_path.cpp
@@ -57,7 +57,7 @@ void RimeWaterPathDiagnostic::compute_diagnostic_impl()
                        default_policy,
                        KOKKOS_LAMBDA(const MemberType& team) {
     const int icol = team.league_rank();
-    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
+    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
       const int jpack = idx / Pack::n;
       const int klev  = idx % Pack::n;
       lsum += qm_mid(icol,jpack)[klev] * pseudo_density_mid(icol,jpack)[klev]/gravit;

--- a/components/eamxx/src/diagnostics/tests/atm_density_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/atm_density_test.cpp
@@ -145,7 +145,7 @@ void run(std::mt19937_64& engine)
     const auto& atm_density_v = atm_density_f.get_view<Pack**>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& jpack) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
         auto dz = PF::calculate_dz(pseudo_dens_v(icol,jpack),p_mid_v(icol,jpack),T_mid_v(icol,jpack),qv_mid_v(icol,jpack));
         atm_density_v(icol,jpack) = PF::calculate_density(pseudo_dens_v(icol,jpack),dz);
       });

--- a/components/eamxx/src/diagnostics/tests/dry_static_energy_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/dry_static_energy_test.cpp
@@ -154,7 +154,7 @@ void run(std::mt19937_64& engine)
     const auto& z_mid_v = view_1d("",num_mid_packs);
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& jpack) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
         dz_v(jpack) = PF::calculate_dz(pseudo_dens_v(icol,jpack),p_mid_v(icol,jpack),T_mid_v(icol,jpack),qv_mid_v(icol,jpack));
       });
       team.team_barrier();
@@ -163,7 +163,7 @@ void run(std::mt19937_64& engine)
       team.team_barrier();
       PF::calculate_z_mid(team,num_levs,z_int_v,z_mid_v);
       team.team_barrier();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& jpack) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
         dse_sub(jpack) = PF::calculate_dse(T_mid_v(icol,jpack),z_mid_v(jpack),phis_v(icol));
       });
       team.team_barrier();

--- a/components/eamxx/src/diagnostics/tests/exner_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/exner_test.cpp
@@ -125,7 +125,7 @@ void run(std::mt19937_64& engine)
     const auto& exner_v = exner_f.get_view<Pack**>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& jpack) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
         exner_v(icol,jpack) = PF::exner_function(p_mid_v(icol,jpack));
       });
       team.team_barrier();

--- a/components/eamxx/src/diagnostics/tests/ice_cloud_mask_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/ice_cloud_mask_tests.cpp
@@ -126,7 +126,7 @@ void run(std::mt19937_64& engine)
     const auto& ice_cld_mask_v = ice_cld_mask_f.get_view<Pack**>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& jpack) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
         const Real ice_frac_threshold = 1e-5;
         auto icecld = qi_v(icol,jpack) > ice_frac_threshold;
         ice_cld_mask_v(icol,jpack) = 0.0;

--- a/components/eamxx/src/diagnostics/tests/meridional_vapor_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/meridional_vapor_flux_tests.cpp
@@ -146,7 +146,7 @@ void run(std::mt19937_64& engine)
     constexpr Real gravit = PC::gravit;
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-         Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
+         Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
       const int jpack = idx / Pack::n;
       const int klev  = idx % Pack::n;
       lsum += horiz_winds_v(icol,1,jpack)[klev] * qv_v(icol,jpack)[klev] * pseudo_density_v(icol,jpack)[klev]/gravit;

--- a/components/eamxx/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/potential_temperature_test.cpp
@@ -131,7 +131,7 @@ void run(std::mt19937_64& engine)
     const auto& theta_v = theta_f.get_view<Pack**>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& jpack) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
         theta_v(icol,jpack) = PF::calculate_theta_from_T(T_mid_v(icol,jpack),p_mid_v(icol,jpack));
       });
       team.team_barrier();

--- a/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
@@ -143,7 +143,7 @@ void run(std::mt19937_64& engine)
     Smask range_mask(true);
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& jpack) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
       auto qv_sat_l = physics::qv_sat(T_mid_v(icol,jpack), p_mid_v(icol,jpack), false, range_mask);
         rh_v(icol,jpack) = qv_v(icol,jpack)/qv_sat_l;
       });

--- a/components/eamxx/src/diagnostics/tests/vertical_layer_interface_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/vertical_layer_interface_test.cpp
@@ -146,7 +146,7 @@ void run(std::mt19937_64& engine)
     view_1d dz_v("",num_mid_packs);
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& jpack) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
         dz_v(jpack) = PF::calculate_dz(pseudo_dens_v(icol,jpack),p_mid_v(icol,jpack),T_mid_v(icol,jpack),qv_mid_v(icol,jpack));
       });
       team.team_barrier();

--- a/components/eamxx/src/diagnostics/tests/vertical_layer_midpoint_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/vertical_layer_midpoint_test.cpp
@@ -148,7 +148,7 @@ void run(std::mt19937_64& engine)
     const auto& dz_v = view_1d("",num_mid_packs);
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& jpack) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
         dz_v(jpack) = PF::calculate_dz(pseudo_dens_v(icol,jpack),p_mid_v(icol,jpack),T_mid_v(icol,jpack),qv_mid_v(icol,jpack));
       });
       team.team_barrier();

--- a/components/eamxx/src/diagnostics/tests/vertical_layer_thickness_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/vertical_layer_thickness_test.cpp
@@ -144,7 +144,7 @@ void run(std::mt19937_64& engine)
     const auto& dz_v = dz_f.get_view<Pack**>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& jpack) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
         dz_v(icol,jpack) = PF::calculate_dz(pseudo_dens_v(icol,jpack),p_mid_v(icol,jpack),T_mid_v(icol,jpack),qv_mid_v(icol,jpack));
       });
       team.team_barrier();

--- a/components/eamxx/src/diagnostics/tests/virtual_temperature_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/virtual_temperature_test.cpp
@@ -130,7 +130,7 @@ void run(std::mt19937_64& engine)
     const auto& virtualT_v = virtualT_f.get_view<Pack**>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_mid_packs), [&] (const Int& jpack) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
         virtualT_v(icol,jpack) = PF::calculate_virtual_temperature(T_mid_v(icol,jpack),qv_mid_v(icol,jpack));
       });
       team.team_barrier();

--- a/components/eamxx/src/diagnostics/tests/water_path_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/water_path_tests.cpp
@@ -220,7 +220,7 @@ void run(std::mt19937_64& engine)
         Real qv_mass_max=0.0;
         auto qv_s = ekat::scalarize(ekat::subview(qv_v, icol));
         Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team,num_levs), [&] (Int idx, Real& lmax) {
+          Kokkos::TeamVectorRange(team,num_levs), [&] (Int idx, Real& lmax) {
             if (qv_s(idx)*dp_s(idx)/gravit > lmax) {
               lmax = qv_s(idx)*dp_s(idx)/gravit;
             }
@@ -230,7 +230,7 @@ void run(std::mt19937_64& engine)
         Real qc_mass_max=0.0;
         auto qc_s = ekat::scalarize(ekat::subview(qc_v, icol));
         Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team,num_levs), [&] (Int idx, Real& lmax) {
+          Kokkos::TeamVectorRange(team,num_levs), [&] (Int idx, Real& lmax) {
             if (qc_s(idx)*dp_s(idx)/gravit > lmax) {
               lmax = qc_s(idx)*dp_s(idx)/gravit;
             }
@@ -240,7 +240,7 @@ void run(std::mt19937_64& engine)
         Real qi_mass_max=0.0;
         auto qi_s = ekat::scalarize(ekat::subview(qi_v, icol));
         Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team,num_levs), [&] (Int idx, Real& lmax) {
+          Kokkos::TeamVectorRange(team,num_levs), [&] (Int idx, Real& lmax) {
             if (qi_s(idx)*dp_s(idx)/gravit > lmax) {
               lmax = qi_s(idx)*dp_s(idx)/gravit;
             }
@@ -250,7 +250,7 @@ void run(std::mt19937_64& engine)
         Real qm_mass_max=0.0;
         auto qm_s = ekat::scalarize(ekat::subview(qm_v, icol));
         Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team,num_levs), [&] (Int idx, Real& lmax) {
+          Kokkos::TeamVectorRange(team,num_levs), [&] (Int idx, Real& lmax) {
             if (qm_s(idx)*dp_s(idx)/gravit > lmax) {
               lmax = qm_s(idx)*dp_s(idx)/gravit;
             }
@@ -261,7 +261,7 @@ void run(std::mt19937_64& engine)
         Real qr_mass_max=0.0;
         auto qr_s = ekat::scalarize(ekat::subview(qr_v, icol));
         Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team,num_levs), [&] (Int idx, Real& lmax) {
+          Kokkos::TeamVectorRange(team,num_levs), [&] (Int idx, Real& lmax) {
             if (qr_s(idx)*dp_s(idx)/gravit > lmax) {
               lmax = qr_s(idx)*dp_s(idx)/gravit;
             }

--- a/components/eamxx/src/diagnostics/tests/zonal_vapor_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/zonal_vapor_flux_tests.cpp
@@ -144,7 +144,7 @@ void run(std::mt19937_64& engine)
     constexpr Real gravit = PC::gravit;
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-         Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
+         Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
       const int jpack = idx / Pack::n;
       const int klev  = idx % Pack::n;
       lsum += horiz_winds_v(icol,0,jpack)[klev] * qv_v(icol,jpack)[klev] * pseudo_density_v(icol,jpack)[klev]/gravit;

--- a/components/eamxx/src/diagnostics/vapor_water_path.cpp
+++ b/components/eamxx/src/diagnostics/vapor_water_path.cpp
@@ -57,7 +57,7 @@ void VapWaterPathDiagnostic::compute_diagnostic_impl()
                        default_policy,
                        KOKKOS_LAMBDA(const MemberType& team) {
     const int icol = team.league_rank();
-    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
+    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
       const int jpack = idx / Pack::n;
       const int klev  = idx % Pack::n;
       lsum += qv_mid(icol,jpack)[klev] * pseudo_density_mid(icol,jpack)[klev]/gravit;

--- a/components/eamxx/src/diagnostics/vertical_layer_interface.cpp
+++ b/components/eamxx/src/diagnostics/vertical_layer_interface.cpp
@@ -66,7 +66,7 @@ void VerticalLayerInterfaceDiagnostic::compute_diagnostic_impl()
                        KOKKOS_LAMBDA(const MemberType& team) {
     const int icol = team.league_rank();
     const auto& dz_s = ekat::subview(dz, icol);
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, npacks), [&] (const Int& jpack) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, npacks), [&] (const Int& jpack) {
       dz_s(jpack) = PF::calculate_dz(pseudo_density_mid(icol,jpack), p_mid(icol,jpack), T_mid(icol,jpack), qv_mid(icol,jpack));
     });
     team.team_barrier();

--- a/components/eamxx/src/diagnostics/vertical_layer_midpoint.cpp
+++ b/components/eamxx/src/diagnostics/vertical_layer_midpoint.cpp
@@ -70,7 +70,7 @@ void VerticalLayerMidpointDiagnostic::compute_diagnostic_impl()
     const auto& z_mid_s = ekat::subview(z_mid, icol);
     const auto& dz_s    = z_mid_s; // Use the memory in z_mid for dz, since we don't set z_mid until after dz is no longer needed.
     const auto& z_int_s = ekat::subview(z_int, icol);
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, npacks), [&] (const Int& jpack) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, npacks), [&] (const Int& jpack) {
       dz_s(jpack) = PF::calculate_dz(pseudo_density_mid(icol,jpack), p_mid(icol,jpack), T_mid(icol,jpack), qv_mid(icol,jpack));
     });
     team.team_barrier();

--- a/components/eamxx/src/diagnostics/zonal_vapor_flux.cpp
+++ b/components/eamxx/src/diagnostics/zonal_vapor_flux.cpp
@@ -64,7 +64,7 @@ void ZonalVapFluxDiagnostic::compute_diagnostic_impl()
                        default_policy,
                        KOKKOS_LAMBDA(const MemberType& team) {
     const int icol = team.league_rank();
-    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
+    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, num_levs), [&] (const Int& idx, Real& lsum) {
       const int jpack = idx / Pack::n;
       const int klev  = idx % Pack::n;
       // Note, horiz_winds contains u (index 0) and v (index 1).  Here we want u

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -708,7 +708,7 @@ void HommeDynamics::homme_post_process (const double dt) {
     auto p_dry_mid = ekat::subview(p_dry_mid_view,icol);
     auto p_dry_int = ekat::subview(p_dry_int_view,icol);
 
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,npacks), [&](const int& jpack) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team,npacks), [&](const int& jpack) {
       dp_dry(jpack) = dp(jpack) * (1.0 - qv(jpack));
     });
     ColOps::column_scan<true>(team,nlevs,dp_dry,p_dry_int,ps0);
@@ -720,7 +720,7 @@ void HommeDynamics::homme_post_process (const double dt) {
     auto T      = ekat::subview(T_view,icol);
     auto T_prev = ekat::subview(T_prev_view,icol);
 
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,npacks),
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team,npacks),
                          [&](const int ilev) {
       // VTheta_dp->VTheta->Theta->T
       auto& T_val = T(ilev);
@@ -1005,7 +1005,7 @@ void HommeDynamics::restart_homme_state () {
     auto p_mid = ekat::subview(p_mid_view,icol);
     auto qv    = ekat::subview(qv_view,icol);
 
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,npacks),
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team,npacks),
                          [&](const int& ilev) {
       // T_prev as of now contains vtheta_dp. Convert to temperature
       auto& T_prev = T_prev_view(icol,ilev);
@@ -1057,7 +1057,7 @@ void HommeDynamics::initialize_homme_state () {
   const auto policy_dp = ESU::get_default_team_policy(ncols, nlevs);
   Kokkos::parallel_for(policy_dp, KOKKOS_LAMBDA (const KT::MemberType& team) {
     const int icol = team.league_rank();
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,nlevs),
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team,nlevs),
                         [&](const int ilev) {
        dp_ref(icol,ilev) = (hyai(ilev+1)-hyai(ilev))*ps0
                          + (hybi(ilev+1)-hybi(ilev))*ps_ref(icol);
@@ -1123,7 +1123,7 @@ void HommeDynamics::initialize_homme_state () {
     auto T      = ekat::subview(vth_view,ie,n0,igp,jgp);
     auto vTh_dp = ekat::subview(vth_view,ie,n0,igp,jgp);
     auto qv     = ekat::subview(Q_view,ie,0,igp,jgp);
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,npacks_mid),
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team,npacks_mid),
                          [&](const int ilev) {
       const auto th = PF::calculate_theta_from_T(T(ilev),p_mid(ilev));
       vTh_dp(ilev) = PF::calculate_virtual_temperature(th,qv(ilev))*dp(ilev);
@@ -1271,7 +1271,7 @@ void HommeDynamics::update_pressure(const std::shared_ptr<const AbstractGrid>& g
     auto p_dry_mid = ekat::subview(p_dry_mid_view,icol);
     auto p_dry_int = ekat::subview(p_dry_int_view,icol);
 
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,npacks), [&](const int& jpack) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team,npacks), [&](const int& jpack) {
       dp_dry(jpack) = dp(jpack) * (1.0 - qv(jpack));
     });
 

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics_fv_phys.cpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics_fv_phys.cpp
@@ -82,7 +82,7 @@ static void copy_prev (const int ncols, const int npacks,
   const auto policy = ESU::get_default_team_policy(ncols, npacks);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
     const int& icol = team.league_rank();
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, npacks),
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, npacks),
                          [&] (const int ilev) {
       FT(icol,ilev) = T(icol,ilev);
       FM(icol,0,ilev) = uv(icol,0,ilev);

--- a/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
+++ b/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
@@ -340,7 +340,7 @@ set_dyn_to_zero(const MT& team) const
       auto v = m_dyn_repo.views[i].v3d;
       int dim1 = v.extent(1);
       int dim2 = v.extent(2);
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, v.size()), [&](const int& k) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, v.size()), [&](const int& k) {
         int k0   = (k / dim2) / dim1;
         int k1   = (k / dim2) % dim1;
         int k2   =  k % dim2;
@@ -355,7 +355,7 @@ set_dyn_to_zero(const MT& team) const
       int dim1 = v.extent(1);
       int dim2 = v.extent(2);
       int dim3 = v.extent(3);
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, v.size()), [&](const int& k) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, v.size()), [&](const int& k) {
         int k0   = ((k / dim3) / dim2) / dim1;
         int k1   = ((k / dim3) / dim2) % dim1;
         int k2   =  (k / dim3) % dim2;
@@ -371,7 +371,7 @@ set_dyn_to_zero(const MT& team) const
       int dim2 = v.extent(2);
       int dim3 = v.extent(3);
       int dim4 = v.extent(4);
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, v.size()), [&](const int& k) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, v.size()), [&](const int& k) {
         int k0   = (((k / dim4) / dim3) / dim2) / dim1;
         int k1   = (((k / dim4) / dim3) / dim2) % dim1;
         int k2   =  ((k / dim4) / dim3) % dim2;
@@ -562,7 +562,7 @@ local_remap_fwd_2d (const MT& team) const
       auto phys = m_phys_repo.cviews[i].v1d;
       auto dyn  = m_dyn_repo.views[i].v3d;
 
-      const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols);
+      const auto tr = Kokkos::TeamVectorRange(team, m_num_phys_cols);
       const auto f = [&] (const int icol) {
         const auto& elgp = Kokkos::subview(m_lid2elgp,m_p2d(icol),Kokkos::ALL());
         dyn(elgp[0],elgp[1],elgp[2]) = phys(icol);
@@ -576,7 +576,7 @@ local_remap_fwd_2d (const MT& team) const
       auto dyn  = m_dyn_repo.views[i].v4d;
 
       const int vec_dim = phys.extent(1);
-      const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols*vec_dim);
+      const auto tr = Kokkos::TeamVectorRange(team, m_num_phys_cols*vec_dim);
       const auto f = [&] (const int idx) {
         const int icol = idx / vec_dim;
         const int idim = idx % vec_dim;
@@ -609,7 +609,7 @@ local_remap_fwd_3d (const MT& team) const
       auto phys = pack_view<const ScalarT>(m_phys_repo.cviews[i].v2d);
       auto dyn  = pack_view<      ScalarT>(m_dyn_repo.views[i].v4d);
 
-      const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols*num_packs);
+      const auto tr = Kokkos::TeamVectorRange(team, m_num_phys_cols*num_packs);
       const auto f = [&] (const int idx) {
         const int icol = idx / num_packs;
         const int ilev = idx % num_packs;
@@ -626,7 +626,7 @@ local_remap_fwd_3d (const MT& team) const
       auto dyn  = pack_view<      ScalarT>(m_dyn_repo.views[i].v5d);
       const int vec_dim = phys.extent(1);
 
-      const auto tr = Kokkos::TeamThreadRange(team, m_num_phys_cols*vec_dim*num_packs);
+      const auto tr = Kokkos::TeamVectorRange(team, m_num_phys_cols*vec_dim*num_packs);
       const auto f = [&] (const int idx) {
         const int icol = (idx / num_packs) / vec_dim;
         const int idim = (idx / num_packs) % vec_dim;
@@ -668,7 +668,7 @@ local_remap_bwd_2d (const MT& team) const
       auto dyn  = m_dyn_repo.cviews[i].v4d;
       const int vec_dim = phys.extent(1);
 
-      const auto tr = Kokkos::TeamThreadRange(team, vec_dim);
+      const auto tr = Kokkos::TeamVectorRange(team, vec_dim);
       const auto f = [&] (const int idim) {
         phys(icol,idim) = dyn(elgp[0],idim,elgp[1],elgp[2]);
       };
@@ -700,7 +700,7 @@ local_remap_bwd_3d (const MT& team) const
       auto phys = pack_view<      ScalarT>(m_phys_repo.views[i].v2d);
       auto dyn  = pack_view<const ScalarT>(m_dyn_repo.cviews[i].v4d);
 
-      const auto tr = Kokkos::TeamThreadRange(team, num_packs);
+      const auto tr = Kokkos::TeamVectorRange(team, num_packs);
       const auto f = [&] (const int ilev) {
         phys(icol,ilev) = dyn(elgp[0],elgp[1],elgp[2],ilev);
       };
@@ -713,7 +713,7 @@ local_remap_bwd_3d (const MT& team) const
       auto dyn  = pack_view<const ScalarT>(m_dyn_repo.cviews[i].v5d);
       const int vec_dim = phys.extent(1);
 
-      const auto tr = Kokkos::TeamThreadRange(team, vec_dim*num_packs);
+      const auto tr = Kokkos::TeamVectorRange(team, vec_dim*num_packs);
       const auto f = [&] (const int idx) {
         const int idim = idx / num_packs;
         const int ilev = idx % num_packs;

--- a/components/eamxx/src/physics/cld_fraction/cld_fraction_main_impl.hpp
+++ b/components/eamxx/src/physics/cld_fraction/cld_fraction_main_impl.hpp
@@ -52,7 +52,7 @@ void CldFractionFunctions<S,D>
   team.team_barrier();
   const Int nk_pack = ekat::npack<Spack>(nk);
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, nk_pack), [&] (Int k) {
+    Kokkos::TeamVectorRange(team, nk_pack), [&] (Int k) {
       const Real ice_frac_threshold = 1e-12;
       auto icecld = qi(k) > ice_frac_threshold;
       ice_cld_frac(k) = 0.0;
@@ -74,7 +74,7 @@ void CldFractionFunctions<S,D>
   team.team_barrier();
   const Int nk_pack = ekat::npack<Spack>(nk);
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, nk_pack), [&] (Int k) {
+    Kokkos::TeamVectorRange(team, nk_pack), [&] (Int k) {
       tot_cld_frac(k) = max(ice_cld_frac(k),liq_cld_frac(k));
   }); // Kokkos_parallel_for nk_pack
   team.team_barrier();

--- a/components/eamxx/src/physics/p3/impl/p3_check_values_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_check_values_impl.hpp
@@ -38,7 +38,7 @@ void Functions<S,D>
   ekat::impl::set_min_max(ktop, kbot, kmin, kmax, Spack::n);
 
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, kmax-kmin+1), [&] (int pk_) {
+    Kokkos::TeamVectorRange(team, kmax-kmin+1), [&] (int pk_) {
 
     bool trap{false};
 

--- a/components/eamxx/src/physics/p3/impl/p3_cloud_sed_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_cloud_sed_impl.hpp
@@ -71,7 +71,7 @@ void Functions<S,D>
       const Int kmax_scalar = ( kdir == 1 ? k_qxtop : k_qxbot);
 
       Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, V_qc.extent(0)), [&] (Int k) {
+        Kokkos::TeamVectorRange(team, V_qc.extent(0)), [&] (Int k) {
           V_qc(k) = 0;
           if (do_predict_nc) {
             V_nc(k) = 0;
@@ -83,7 +83,7 @@ void Functions<S,D>
       ekat::impl::set_min_max(k_qxbot, k_qxtop, kmin, kmax, Spack::n);
 
       Kokkos::parallel_reduce(
-        Kokkos::TeamThreadRange(team, kmax-kmin+1), [&] (int pk_, Scalar& lmax) {
+        Kokkos::TeamVectorRange(team, kmax-kmin+1), [&] (int pk_, Scalar& lmax) {
           const int pk = kmin + pk_;
           const auto range_pack = ekat::range<IntSmallPack>(pk*Spack::n);
           const auto range_mask = range_pack >= kmin_scalar && range_pack <= kmax_scalar;
@@ -122,7 +122,7 @@ void Functions<S,D>
       //Update _incld values with end-of-step cell-ave values
       //No prob w/ div by cld_frac_l because set to min of 1e-4 in interface.
       Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, qc.extent(0)), [&] (int pk) {
+        Kokkos::TeamVectorRange(team, qc.extent(0)), [&] (int pk) {
 	  qc_incld(pk)=qc(pk)/cld_frac_l(pk);
 	  nc_incld(pk)=nc(pk)/cld_frac_l(pk);
 	});
@@ -137,7 +137,7 @@ void Functions<S,D>
 
   const Int nk_pack = ekat::npack<Spack>(nk);
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, nk_pack), [&] (int pk) {
+    Kokkos::TeamVectorRange(team, nk_pack), [&] (int pk) {
       qc_tend(pk) = (qc(pk) - qc_tend(pk)) * inv_dt; // Liq. sedimentation tendency, measure
       nc_tend(pk) = (nc(pk) - nc_tend(pk)) * inv_dt; // Liq. # sedimentation tendency, measure
   });

--- a/components/eamxx/src/physics/p3/impl/p3_find_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_find_impl.hpp
@@ -32,7 +32,7 @@ Int Functions<S,D>
   } else {
     if (kdir == -1) {
       Kokkos::parallel_reduce(
-        Kokkos::TeamThreadRange(team, kbot - ktop + 1), [&] (Int k_, int& lmax) {
+        Kokkos::TeamVectorRange(team, kbot - ktop + 1), [&] (Int k_, int& lmax) {
           const Int k = ktop + k_;
           if (v(k) >= small && k > lmax)
             lmax = k;
@@ -40,7 +40,7 @@ Int Functions<S,D>
       log_present = k_xbot >= ktop;
     } else {
       Kokkos::parallel_reduce(
-        Kokkos::TeamThreadRange(team, ktop - kbot + 1), [&] (Int k_, int& lmin) {
+        Kokkos::TeamVectorRange(team, ktop - kbot + 1), [&] (Int k_, int& lmin) {
           const Int k = kbot + k_;
           if (v(k) >= small && k < lmin)
             lmin = k;
@@ -72,7 +72,7 @@ Int Functions<S,D>
   } else {
     if (kdir == -1) {
       Kokkos::parallel_reduce(
-        Kokkos::TeamThreadRange(team, kbot - ktop + 1), [&] (Int k_, int& lmin) {
+        Kokkos::TeamVectorRange(team, kbot - ktop + 1), [&] (Int k_, int& lmin) {
           const Int k = ktop + k_;
           if (v(k) >= small && k < lmin)
             lmin = k;
@@ -80,7 +80,7 @@ Int Functions<S,D>
       log_present = k_xtop <= kbot;
     } else {
       Kokkos::parallel_reduce(
-        Kokkos::TeamThreadRange(team, ktop - kbot + 1), [&] (Int k_, int& lmax) {
+        Kokkos::TeamVectorRange(team, ktop - kbot + 1), [&] (Int k_, int& lmax) {
           const Int k = kbot + k_;
           if (v(k) >= small && k > lmax)
             lmax = k;

--- a/components/eamxx/src/physics/p3/impl/p3_get_latent_heat_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_get_latent_heat_impl.hpp
@@ -18,7 +18,7 @@ void Functions<S,D>
   auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk);
   Kokkos::parallel_for("get_latent_heat", policy, KOKKOS_LAMBDA(const MemberType& team) {
     int i = team.league_rank();
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nk), [&] (const int& k) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nk), [&] (const int& k) {
       v(i,k) = lapvap;
       s(i,k) = lapvap + latice;
       f(i,k) = latice;

--- a/components/eamxx/src/physics/p3/impl/p3_ice_sed_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_ice_sed_impl.hpp
@@ -119,7 +119,7 @@ void Functions<S,D>
       const Int kmax_scalar = ( kdir == 1 ? k_qxtop : k_qxbot);
 
       Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, V_qit.extent(0)), [&] (Int k) {
+        Kokkos::TeamVectorRange(team, V_qit.extent(0)), [&] (Int k) {
           V_qit(k) = 0;
           V_nit(k) = 0;
       });
@@ -130,7 +130,7 @@ void Functions<S,D>
 
       // compute Vq, Vn (get values from lookup table)
       Kokkos::parallel_reduce(
-        Kokkos::TeamThreadRange(team, kmax-kmin+1), [&] (int pk_, Scalar& lmax) {
+        Kokkos::TeamVectorRange(team, kmax-kmin+1), [&] (int pk_, Scalar& lmax) {
 
         const int pk = kmin + pk_;
         const auto range_pack = ekat::range<IntSmallPack>(pk*Spack::n);
@@ -172,7 +172,7 @@ void Functions<S,D>
       //Update _incld values with end-of-step cell-ave values
       //No prob w/ div by cld_frac_i because set to min of 1e-4 in interface.
       Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, qi.extent(0)), [&] (int pk) {
+        Kokkos::TeamVectorRange(team, qi.extent(0)), [&] (int pk) {
 	  qi_incld(pk)=qi(pk)/cld_frac_i(pk);
 	  ni_incld(pk)=ni(pk)/cld_frac_i(pk);
 	  qm_incld(pk)=qm(pk)/cld_frac_i(pk);
@@ -190,7 +190,7 @@ void Functions<S,D>
 
   const Int nk_pack = ekat::npack<Spack>(nk);
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, nk_pack), [&] (int pk) {
+    Kokkos::TeamVectorRange(team, nk_pack), [&] (int pk) {
       qi_tend(pk) = (qi(pk) - qi_tend(pk)) * inv_dt; // Liq. sedimentation tendency, measure
       ni_tend(pk) = (ni(pk) - ni_tend(pk)) * inv_dt; // Liq. # sedimentation tendency, measure
   });
@@ -232,7 +232,7 @@ void Functions<S,D>
   ekat::impl::set_min_max(kbot, ktop, kmin, kmax, Spack::n);
 
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, kmax-kmin+1), [&] (int pk_) {
+    Kokkos::TeamVectorRange(team, kmax-kmin+1), [&] (int pk_) {
 
     const int pk = kmin + pk_;
 

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -47,7 +47,7 @@ void Functions<S,D>
   precip_ice_surf = 0;
 
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, nk_pack), [&] (Int k) {
+    Kokkos::TeamVectorRange(team, nk_pack), [&] (Int k) {
 
     diag_equiv_reflectivity(k)           = -99;
     ze_ice(k)            = 1.e-22;
@@ -312,7 +312,7 @@ Int Functions<S,D>
 
 #ifndef NDEBUG
     Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nk_pack), [&] (Int k) {
+      Kokkos::TeamVectorRange(team, nk_pack), [&] (Int k) {
         tmparr1(k) = oth(k) * exner(k);
     });
 

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part1.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part1.hpp
@@ -95,7 +95,7 @@ void Functions<S,D>
   // can be made consistent with E3SM definition of latent heat
   //
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, nk_pack), [&] (Int k) {
+    Kokkos::TeamVectorRange(team, nk_pack), [&] (Int k) {
 
     const auto range_pack = ekat::range<IntSmallPack>(k*Spack::n);
     const auto range_mask = range_pack < nk;

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -109,7 +109,7 @@ void Functions<S,D>
   team.team_barrier();
 
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, nk_pack), [&] (Int k) {
+    Kokkos::TeamVectorRange(team, nk_pack), [&] (Int k) {
 
     //compute mask to identify padded values in packs, which shouldn't be used in calculations
     const auto range_pack = ekat::range<IntSmallPack>(k*Spack::n);

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
@@ -63,7 +63,7 @@ void Functions<S,D>
   constexpr Scalar nsmall       = C::NSMALL;
 
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, nk_pack), [&] (Int k) {
+    Kokkos::TeamVectorRange(team, nk_pack), [&] (Int k) {
 
     Spack
       ignore1  (0),

--- a/components/eamxx/src/physics/p3/impl/p3_rain_sed_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_rain_sed_impl.hpp
@@ -90,7 +90,7 @@ void Functions<S,D>
       Int kmax_scalar = ( kdir == 1 ? k_qxtop : k_qxbot);
 
       Kokkos::parallel_for(
-       Kokkos::TeamThreadRange(team, V_qr.extent(0)), [&] (Int k) {
+       Kokkos::TeamVectorRange(team, V_qr.extent(0)), [&] (Int k) {
         V_qr(k) = 0;
         V_nr(k) = 0;
       });
@@ -101,7 +101,7 @@ void Functions<S,D>
 
       // compute Vq, Vn (get values from lookup table)
       Kokkos::parallel_reduce(
-       Kokkos::TeamThreadRange(team, kmax-kmin+1), [&] (int pk_, Scalar& lmax) {
+       Kokkos::TeamVectorRange(team, kmax-kmin+1), [&] (int pk_, Scalar& lmax) {
 
         const int pk = kmin + pk_;
         const auto range_pack = ekat::range<IntSmallPack>(pk*Spack::n);
@@ -130,7 +130,7 @@ void Functions<S,D>
       //Update _incld values with end-of-step cell-ave values
       //No prob w/ div by cld_frac_r because set to min of 1e-4 in interface.
       Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, qr.extent(0)), [&] (int pk) {
+        Kokkos::TeamVectorRange(team, qr.extent(0)), [&] (int pk) {
 	  qr_incld(pk)=qr(pk)/cld_frac_r(pk);
 	  nr_incld(pk)=nr(pk)/cld_frac_r(pk);
 	});
@@ -140,7 +140,7 @@ void Functions<S,D>
       kmax_scalar = ( kdir == 1 ? k_qxtop+1 : k_qxbot+1);
       ekat::impl::set_min_max(kmin_scalar, kmax_scalar, kmin, kmax, Spack::n);
       Kokkos::parallel_for(
-       Kokkos::TeamThreadRange(team, kmax-kmin+1), [&] (int pk_) {
+       Kokkos::TeamVectorRange(team, kmax-kmin+1), [&] (int pk_) {
         const int pk = kmin + pk_;
         const auto range_pack = ekat::range<IntSmallPack>(pk*Spack::n);
         const auto range_mask = range_pack >= kmin_scalar && range_pack <= kmax_scalar;
@@ -159,7 +159,7 @@ void Functions<S,D>
 
   const Int nk_pack = ekat::npack<Spack>(nk);
   Kokkos::parallel_for(
-   Kokkos::TeamThreadRange(team, nk_pack), [&] (int pk) {
+   Kokkos::TeamVectorRange(team, nk_pack), [&] (int pk) {
     qr_tend(pk) = (qr(pk) - qr_tend(pk)) * inv_dt; // Rain sedimentation tendency, measure
     nr_tend(pk) = (nr(pk) - nr_tend(pk)) * inv_dt; // Rain # sedimentation tendency, measure
   });

--- a/components/eamxx/src/physics/p3/impl/p3_upwind_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_upwind_impl.hpp
@@ -39,7 +39,7 @@ void Functions<S,D>
 
   // calculate fluxes
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, kmax - kmin), [&] (Int k_) {
+    Kokkos::TeamVectorRange(team, kmax - kmin), [&] (Int k_) {
       const Int k = kmin + k_;
       for (int f = 0; f < nfield; ++f)
         (*flux[f])(k) = (*V[f])(k) * (*r[f])(k) * rho(k);
@@ -76,7 +76,7 @@ void Functions<S,D>
     ++kmin;
 
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, kmax - kmin), [&] (Int k_) {
+    Kokkos::TeamVectorRange(team, kmax - kmin), [&] (Int k_) {
       const Int k = kmin + k_;
       for (int f = 0; f < nfield; ++f) {
         // compute flux divergence

--- a/components/eamxx/src/physics/p3/tests/p3_ice_tables_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_tables_unit_tests.cpp
@@ -304,7 +304,7 @@ struct UnitWrap::UnitTest<D>::TestTableIce {
     TeamPolicy policy(ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ice_table_vals.extent(0), ice_table_vals.extent(1)));
     Kokkos::parallel_reduce("TestTableIce::run", policy, KOKKOS_LAMBDA(const MemberType& team, int& errors) {
       //int i = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, ice_table_vals.extent(1)), [&] (const int& j) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, ice_table_vals.extent(1)), [&] (const int& j) {
 
         for (size_t k = 0; k < ice_table_vals.extent(2); ++k) {
           for (size_t l = 0; l < ice_table_vals.extent(3); ++l) {

--- a/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
@@ -94,7 +94,7 @@ static void run_phys()
           }
           EKAT_KERNEL_ASSERT((V[0](k) == V[1](k)).all());
         };
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, npack), set_fields);
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(team, npack), set_fields);
         team.team_barrier();
       };
       Kokkos::parallel_for(ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, npack),
@@ -113,7 +113,7 @@ static void run_phys()
             const auto sum_mass = [&] (const Int& k, Scalar& mass) {
               mass += srho(k)*sr(k)/sinv_dz(k);
             };
-            Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, nk), sum_mass, mass);
+            Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, nk), sum_mass, mass);
 
             const auto find_max_r = [&] (const Int& k, Scalar& r_max) {
               // The background rho is is not advected in P3. Thus, here we
@@ -135,14 +135,14 @@ static void run_phys()
               const auto mixing_ratio_true = sr(k)/sr0(k);
               r_max = ekat::impl::max(mixing_ratio_true, r_max);
             };
-            Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, nk), find_max_r,
+            Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, nk), find_max_r,
                                     Kokkos::Max<Scalar>(r_max));
 
             const auto find_min_r = [&] (const Int& k, Scalar& r_min) {
               const auto mixing_ratio_true = sr(k)/sr0(k);
               r_min = ekat::impl::min(mixing_ratio_true, r_min);
             };
-            Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, nk), find_min_r,
+            Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, nk), find_min_r,
                                     Kokkos::Min<Scalar>(r_min));
           };
 

--- a/components/eamxx/src/physics/share/scream_trcmix.cpp
+++ b/components/eamxx/src/physics/share/scream_trcmix.cpp
@@ -59,7 +59,7 @@ void trcmix(
     const auto val = name == "o2" ? C::o2mmr : rmwco2 * co2vmr;
     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
       const Int i = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlevs), [&] (const Int& k) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlevs), [&] (const Int& k) {
         q(i, k) = val;
       });
     });
@@ -76,7 +76,7 @@ void trcmix(
 
     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
       const Int i = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlevs), [&] (const Int& k) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlevs), [&] (const Int& k) {
         // set stratospheric scale height factor for gases. Need to convert
         // clat to radians
         const auto clat_r = clat(i) * C::Pi/180.0;

--- a/components/eamxx/src/physics/shoc/atmosphere_macrophysics.hpp
+++ b/components/eamxx/src/physics/shoc/atmosphere_macrophysics.hpp
@@ -82,7 +82,7 @@ public:
 
       const int nlev_packs = ekat::npack<Spack>(nlev);
 
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_packs), [&] (const Int& k) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_packs), [&] (const Int& k) {
       /*---------------------------------------------------------------------------------
        *Wet to dry mixing ratios:
        *-------------------------
@@ -152,7 +152,7 @@ public:
 
       const int nlevi_v = nlev/Spack::n;
       const int nlevi_p = nlev%Spack::n;
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_packs), [&] (const Int& k) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_packs), [&] (const Int& k) {
         zt_grid(i,k) = z_mid(i,k) - z_int(i, nlevi_v)[nlevi_p];
         zi_grid(i,k) = z_int(i,k) - z_int(i, nlevi_v)[nlevi_p];
 
@@ -183,7 +183,7 @@ public:
       vpwp_sfc(i)   = surf_mom_flux(i,1)/rrho_i(i,nlevi_v)[nlevi_p];
 
       const int num_qtracer_packs = ekat::npack<Spack>(num_qtracers);
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, num_qtracer_packs), [&] (const Int& q) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, num_qtracer_packs), [&] (const Int& q) {
         wtracer_sfc(i,q) = 0;
       });
     } // operator
@@ -313,7 +313,7 @@ public:
       //After these updates, all tracers (except TKE) in the qtarcers array will be converted
       //from dry mmr to wet mmr
       const int nlev_packs = ekat::npack<Spack>(nlev);
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_packs), [&] (const Int& k) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_packs), [&] (const Int& k) {
         // See comment in SHOCPreprocess::operator() about the necessity of *_copy views
         tke(i,k) = tke_copy(i,k);
         qc(i,k)  = qc_copy(i,k);

--- a/components/eamxx/src/physics/shoc/impl/shoc_adv_sgs_tke_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_adv_sgs_tke_impl.hpp
@@ -41,7 +41,7 @@ void Functions<S,D>
   static constexpr Scalar Cee = Ce1 + Ce2;
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
 
     // Compute buoyant production term
     const Spack a_prod_bu = (ggr/basetemp)*wthv_sec(k);

--- a/components/eamxx/src/physics/shoc/impl/shoc_assumed_pdf_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_assumed_pdf_impl.hpp
@@ -85,7 +85,7 @@ void Functions<S,D>::shoc_assumed_pdf(
   // The following is morally a const var, but there are issues with
   // gnu and std=c++14. The macro ConstExceptGnu is defined in ekat_kokkos_types.hpp.
   ConstExceptGnu Int nlev_pack = ekat::npack<Spack>(nlev);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     // Initialize cloud variables to zero
     shoc_cldfrac(k) = 0;
     if (k==0) { shoc_ql(k)[0] = 0; }

--- a/components/eamxx/src/physics/shoc/impl/shoc_calc_shoc_varorcovar_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_calc_shoc_varorcovar_impl.hpp
@@ -24,7 +24,7 @@ void Functions<S,D>
   const auto sinvar1 = scalarize(invar1);
   const auto sinvar2 = scalarize(invar2);
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     // Calculate shift
     Spack invar1_s, invar1_sm1, invar2_s, invar2_sm1;
     auto range_pack1 = ekat::range<IntSmallPack>(k*Spack::n);

--- a/components/eamxx/src/physics/shoc/impl/shoc_calc_shoc_vertflux_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_calc_shoc_vertflux_impl.hpp
@@ -19,7 +19,7 @@ void Functions<S,D>
 {
   const Int nlev_pack = ekat::npack<Spack>(nlev);
   const auto sinvar = scalarize(invar);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     auto range_pack1 = ekat::range<IntSmallPack>(k*Spack::n);
     auto range_pack2 = range_pack1;
     range_pack2.set(range_pack1 < 1, 1); // don't want the shift to go below zero. we mask out that result anyway

--- a/components/eamxx/src/physics/shoc/impl/shoc_check_length_scale_shoc_length_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_check_length_scale_shoc_length_impl.hpp
@@ -18,7 +18,7 @@ void Functions<S,D>::check_length_scale_shoc_length(
   const auto minlen = scream::shoc::Constants<Real>::minlen;
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     // Ensure shoc_mix is in the interval [minval, sqrt(host_dx*host_dy)]
     shoc_mix(k) = ekat::min(std::sqrt(dx*dy),
                             ekat::max(minlen, shoc_mix(k)));

--- a/components/eamxx/src/physics/shoc/impl/shoc_check_tke_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_check_tke_impl.hpp
@@ -18,7 +18,7 @@ void Functions<S,D>
   static constexpr auto mintke   = SC::mintke; // units:m2/s2
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
 
       //take max(mintke,tke(k))
       tke(k).set(tke(k) < mintke, mintke);

--- a/components/eamxx/src/physics/shoc/impl/shoc_clipping_diag_third_shoc_moments_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_clipping_diag_third_shoc_moments_impl.hpp
@@ -17,7 +17,7 @@ void Functions<S,D>
 {
   const Int nlevi_pack = ekat::npack<Spack>(nlevi);
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlevi_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlevi_pack), [&] (const Int& k) {
     const auto w3clip = scream::shoc::Constants<Scalar>::w3clip;
     Spack tsign(1);
 

--- a/components/eamxx/src/physics/shoc/impl/shoc_compute_brunt_shoc_length_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_compute_brunt_shoc_length_impl.hpp
@@ -21,7 +21,7 @@ void Functions<S,D>::compute_brunt_shoc_length(
   const auto s_thv_zi = scalarize(thv_zi);
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     // Calculate thv_zi shift
     Spack thv_zi_k, thv_zi_kp1;
     auto range_pack1 = ekat::range<IntSmallPack>(k*Spack::n);

--- a/components/eamxx/src/physics/shoc/impl/shoc_compute_diag_third_shoc_moment_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_compute_diag_third_shoc_moment_impl.hpp
@@ -42,7 +42,7 @@ void Functions<S,D>
   // Set lower condition: w3(i,nlevi) = 0
   s_w3(nlevi-1) = 0;
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     // Constants
     const auto c_diag_3rd_mom = scream::shoc::Constants<Scalar>::c_diag_3rd_mom;
     const Scalar a0 = (sp(0.52)*(1/(c_diag_3rd_mom*c_diag_3rd_mom)))/(c_diag_3rd_mom-2);

--- a/components/eamxx/src/physics/shoc/impl/shoc_compute_shoc_mix_shoc_length_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_compute_shoc_mix_shoc_length_impl.hpp
@@ -26,7 +26,7 @@ void Functions<S,D>
   // Eddy turnover timescale
   const Scalar tscale = 400;
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     const Spack tkes = ekat::sqrt(tke(k));
     const Spack brunt2 = ekat::max(0, brunt(k));
 

--- a/components/eamxx/src/physics/shoc/impl/shoc_compute_shoc_vapor_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_compute_shoc_vapor_impl.hpp
@@ -25,7 +25,7 @@ void Functions<S,D>::compute_shoc_vapor(
   const uview_1d<Spack>&       qv)
 {
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     qv(k) = qw(k) - ql(k);
   });
 }

--- a/components/eamxx/src/physics/shoc/impl/shoc_compute_shr_prod_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_compute_shr_prod_impl.hpp
@@ -33,7 +33,7 @@ void Functions<S,D>
   const auto sclr_vwind = scalarize(v_wind); //for v_wind
 
   //compute shear production term
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
 
     auto range_pack1 = ekat::range<IntSmallPack>(k*Spack::n);
     const auto active_range = range_pack1 > 0 && range_pack1 < nlev;

--- a/components/eamxx/src/physics/shoc/impl/shoc_compute_tmpi_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_compute_tmpi_impl.hpp
@@ -22,7 +22,7 @@ void Functions<S,D>
   tmpi(0)[0] = 0;
 
   const Int nlev_pack = ekat::npack<Spack>(nlevi);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     const auto mask  = ekat::range<IntSmallPack>(k*Spack::n) > 0;
     if (mask.any()) {
       tmpi(k).set(mask, dtime*(ggr*rho_zi(k))/dz_zi(k));

--- a/components/eamxx/src/physics/shoc/impl/shoc_diag_second_moments_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_diag_second_moments_impl.hpp
@@ -50,7 +50,7 @@ void Functions<S,D>::diag_second_moments(
 
   // Vertical velocity variance is assumed to be propotional to the TKE
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     w_sec(k) = w2tune*(sp(2.)/sp(3.))*tke(k);
   });
 

--- a/components/eamxx/src/physics/shoc/impl/shoc_dp_inverse_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_dp_inverse_impl.hpp
@@ -19,7 +19,7 @@ void Functions<S,D>
   const auto ggr = C::gravit;
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     rdp_zt(k) = 1/(ggr*rho_zt(k)*dz_zt(k));
   });
 }

--- a/components/eamxx/src/physics/shoc/impl/shoc_eddy_diffusivities_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_eddy_diffusivities_impl.hpp
@@ -47,7 +47,7 @@ void Functions<S,D>::eddy_diffusivities(
   const auto s_zt_grid = ekat::scalarize(zt_grid);
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     // Dimensionless Okukhov length considering only
     // the lowest model grid layer height to scale
     const auto z_over_L = s_zt_grid(nlev-1)/obklen;

--- a/components/eamxx/src/physics/shoc/impl/shoc_energy_fixer_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_energy_fixer_impl.hpp
@@ -78,7 +78,7 @@ void Functions<S,D>::shoc_energy_fixer(
                 "SHOC: violated assumption in parallel reduce.");
   Int shoctop = 0;
   const auto nlevm2_packs = ekat::npack<Spack>(nlev-2);
-  Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, nlevm2_packs),
+  Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, nlevm2_packs),
                           [&] (Int k, Int& local_shoctop) {
     // Find the minimum index corresponding to mintke!=tke(indx).
     // Here we set all indices s.t. tke==mintke to nlev-2 since
@@ -98,7 +98,7 @@ void Functions<S,D>::shoc_energy_fixer(
   // Update host_dse
   const int shoctop_pack = shoctop/Spack::n;
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, shoctop_pack, nlev_packs), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, shoctop_pack, nlev_packs), [&] (const Int& k) {
     auto range_pack = ekat::range<IntSmallPack>(k*Spack::n);
 
     host_dse(k).set(range_pack >= shoctop && range_pack < nlev, host_dse(k)-se_dis*ggr);

--- a/components/eamxx/src/physics/shoc/impl/shoc_grid_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_grid_impl.hpp
@@ -37,7 +37,7 @@ void Functions<S,D>::shoc_grid(
   const auto s_dz_zi   = ekat::scalarize(dz_zi);
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
 
     // Compute shifts
     Spack zi_grid_k, zi_grid_kp1, zt_grid_k, zt_grid_km1;

--- a/components/eamxx/src/physics/shoc/impl/shoc_isotropic_ts_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_isotropic_ts_impl.hpp
@@ -36,7 +36,7 @@ void Functions<S,D>
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
 
       // define the time scale
       const Spack tscale = 2*tke(k)/a_diss(k);

--- a/components/eamxx/src/physics/shoc/impl/shoc_linear_interp_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_linear_interp_impl.hpp
@@ -28,7 +28,7 @@ void Functions<S,D>::linear_interp(
   const Int km2_pack = ekat::npack<Spack>(km2);
 
   if (km1 == km2+1) {
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, km2_pack), [&] (const Int& k2) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, km2_pack), [&] (const Int& k2) {
       Spack x1, x1s, y1, y1s; // s->-1 shift
       auto indx_pack = ekat::range<IntSmallPack>(k2*Spack::n + 1);
 
@@ -48,7 +48,7 @@ void Functions<S,D>::linear_interp(
     // a Kokkos::single block so that all conditionals can be removed from the ||4.
     // Keep thread0 unoccupied so it can process the Kokkos::single while other threads
     // are doing the ||4.
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, km2_pack), [&] (const Int& k2) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, km2_pack), [&] (const Int& k2) {
       Spack x1, x1s, y1, y1s; // s->-1 shift
       auto indx_pack = ekat::range<IntSmallPack>(k2*Spack::n);
       indx_pack.set(indx_pack < 1, 1); // special shift for 0 boundary case
@@ -64,7 +64,7 @@ void Functions<S,D>::linear_interp(
   }
   team.team_barrier();
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, km2_pack), [&] (const Int& k2) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, km2_pack), [&] (const Int& k2) {
     y2(k2).set(y2(k2) < minthresh, minthresh);
   });
 }

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -36,7 +36,7 @@ Int Functions<S,D>::shoc_init(
 
     const int begin_pack_indx = ntop_shoc/Spack::n;
     const int end_pack_indx   = nbot_shoc/Spack::n+1;
-    Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, begin_pack_indx, end_pack_indx),
+    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, begin_pack_indx, end_pack_indx),
                                                     [&] (const Int& k, Int& local_max) {
       auto range = ekat::range<IntSmallPack>(k*Spack::n);
       auto condition = (range >= ntop_shoc && range < nbot_shoc);

--- a/components/eamxx/src/physics/shoc/impl/shoc_pblintd_height_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_pblintd_height_impl.hpp
@@ -57,7 +57,7 @@ void Functions<S,D>::pblintd_height(
 
   // Compute rino values and find max index k s.t. rino(k) >= ricr
   Int max_indx = Kokkos::reduction_identity<Int>::max();
-  Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, lower_pack_indx, upper_pack_indx+1),
+  Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, lower_pack_indx, upper_pack_indx+1),
                           [&] (const Int& k, Int& local_max) {
     auto indices_pack = ekat::range<IntSmallPack>(k*Spack::n);
     const auto in_range = (indices_pack < nlev-1 && indices_pack >= nlev-npbl);

--- a/components/eamxx/src/physics/shoc/impl/shoc_pblintd_init_pot_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_pblintd_init_pot_impl.hpp
@@ -24,7 +24,7 @@ void Functions<S,D>
 
    const Int nlev_pack = ekat::npack<Spack>(nlev);
 
-   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const int& k) {
+   Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const int& k) {
      const auto th = thl(k) + (lcond/cp)*ql(k);
      thv(k) = th * (one + eps*q(k) - ql(k));
    });

--- a/components/eamxx/src/physics/shoc/impl/shoc_tridiag_solver_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_tridiag_solver_impl.hpp
@@ -29,7 +29,7 @@ void Functions<S,D>::vd_shoc_decomp(
   const Int nlev_pack = ekat::npack<Spack>(nlev);
 
   // Compute entries of the tridiagonal system
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
 
     // Compute local diagonals
     Spack du_k, dl_k, d_k;

--- a/components/eamxx/src/physics/shoc/impl/shoc_update_host_dse_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_update_host_dse_impl.hpp
@@ -26,7 +26,7 @@ void Functions<S,D>
   const auto cp = C::CP;
   const auto ggr = C::gravit;
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_pack), [&] (const Int& k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
       Spack temp = (thlm(k)/inv_exner(k))+(lcond/cp)*shoc_ql(k);
       host_dse(k) = cp*temp+ggr*zt_grid(k)+phis;
   });

--- a/components/eamxx/src/physics/shoc/impl/shoc_update_prognostics_implicit_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_update_prognostics_implicit_impl.hpp
@@ -140,7 +140,7 @@ void Functions<S,D>::update_prognostics_implicit(
       tke_s(nlev-1)    += cmnfac*wtke_sfc;
     });
 
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, num_qtracers), [&] (const Int& q) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, num_qtracers), [&] (const Int& q) {
       qtracers_s(q, nlev-1) += cmnfac*wtracer_sfc_s(q);
     });
   }

--- a/components/eamxx/src/physics/spa/spa_functions_impl.hpp
+++ b/components/eamxx/src/physics/spa/spa_functions_impl.hpp
@@ -197,7 +197,7 @@ void SPAFunctions<S,D>
     auto var_end = get_var_column (data_end.data,icol,ivar);
     auto var_out = get_var_column (data_out.data,icol,ivar);
 
-    Kokkos::parallel_for (Kokkos::TeamThreadRange(team,num_vert_packs),
+    Kokkos::parallel_for (Kokkos::TeamVectorRange(team,num_vert_packs),
                           [&] (const int& k) {
       var_out(k) = linear_interp(var_beg(k),var_end(k),delta_t_fraction);
     });
@@ -226,7 +226,7 @@ compute_source_pressure_levels(
   Kokkos::parallel_for("spa_compute_p_src_loop", policy,
     KOKKOS_LAMBDA (const MemberType& team) {
     const int icol = team.league_rank();
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,num_vert_packs),
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_vert_packs),
                          [&](const int k) {
       p_src(icol,k) = ps_src(icol) * hybm(k)  + P0 * hyam(k);
     });

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -322,7 +322,7 @@ void CoarseningRemapper::do_registration_ends ()
     }
     // Update the number of fields.
     // NOTE: We need to do this again because the `registration_ends()` call in the abstract
-    //       remapper base class set the `m_num_fields` value before calling 
+    //       remapper base class set the `m_num_fields` value before calling
     //       `do_registration_ends()`.
     m_num_fields = m_num_registered_fields;
 
@@ -340,7 +340,7 @@ void CoarseningRemapper::do_registration_ends ()
         auto m_idx = m_mask_map_src.at(name);
         if (m_idx >-1) {
         auto m_fld = m_mask_fields_src[m_idx];
-        auto m_lt = m_fld.get_header().get_identifier().get_layout(); 
+        auto m_lt = m_fld.get_header().get_identifier().get_layout();
         auto f_lt = f.get_header().get_identifier().get_layout();
         EKAT_REQUIRE(f_lt.has_tag(COL) == m_lt.has_tag(COL));
         EKAT_REQUIRE(f_lt.has_tag(LEV) == m_lt.has_tag(LEV));
@@ -458,7 +458,7 @@ rescale_masked_fields (const Field& x, const Field& mask) const
   const auto x_extra  = x.get_header().get_extra_data();
   Real mask_val = std::numeric_limits<float>::max()/10.0;
   if (x_extra.count("mask_value")) {
-    mask_val = ekat::any_cast<Real>(x_extra.at("mask_value")); 
+    mask_val = ekat::any_cast<Real>(x_extra.at("mask_value"));
   }
   const Real mask_threshold = std::numeric_limits<Real>::epsilon();  // TODO: Should we not hardcode the threshold for simply masking out the column.
   switch (rank) {
@@ -487,7 +487,7 @@ rescale_masked_fields (const Field& x, const Field& mask) const
         const auto icol = team.league_rank();
         auto x_sub = ekat::subview(x_view,icol);
         auto m_sub = ekat::subview(m_view,icol);
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team,dim1),
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dim1),
                             [&](const int j){
           auto masked = m_sub(j) > mask_threshold;
           if (masked.any()) {
@@ -510,7 +510,7 @@ rescale_masked_fields (const Field& x, const Field& mask) const
         const auto icol = team.league_rank();
         auto m_sub      = ekat::subview(m_view,icol);
 
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team,dim1*dim2),
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dim1*dim2),
                             [&](const int idx){
           const int j = idx / dim2;
           const int k = idx % dim2;
@@ -526,7 +526,7 @@ rescale_masked_fields (const Field& x, const Field& mask) const
       break;
     }
   }
-  
+
 
 }
 

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -592,7 +592,7 @@ local_mat_vec (const Field& x, const Field& y, const Field* mask) const
 
         const auto beg = row_offsets(row);
         const auto end = row_offsets(row+1);
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team,dim1),
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dim1),
                             [&](const int j){
           if (mask != nullptr) {
             y_view(row,j) = weights(beg)*x_view(col_lids(beg),j)*mask_view(col_lids(beg),j);
@@ -627,7 +627,7 @@ local_mat_vec (const Field& x, const Field& y, const Field* mask) const
 
         const auto beg = row_offsets(row);
         const auto end = row_offsets(row+1);
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team,dim1*dim2),
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dim1*dim2),
                             [&](const int idx){
           const int j = idx / dim2;
           const int k = idx % dim2;
@@ -697,7 +697,7 @@ void CoarseningRemapper::pack_and_send ()
           const int lidpos = i - pid_lid_start(pid);
           const int offset = f_pid_offsets(pid);
 
-          Kokkos::parallel_for(Kokkos::TeamThreadRange(team,ndims),
+          Kokkos::parallel_for(Kokkos::TeamVectorRange(team,ndims),
                                [&](const int idim) {
             buf(offset + lidpos*ndims + idim) = v(lid,idim);
           });
@@ -716,7 +716,7 @@ void CoarseningRemapper::pack_and_send ()
           const int lidpos = i - pid_lid_start(pid);
           const int offset = f_pid_offsets(pid);
 
-          Kokkos::parallel_for(Kokkos::TeamThreadRange(team,nlevs),
+          Kokkos::parallel_for(Kokkos::TeamVectorRange(team,nlevs),
                                [&](const int ilev) {
             buf(offset + lidpos*nlevs + ilev) = v(lid,ilev);
           });
@@ -736,7 +736,7 @@ void CoarseningRemapper::pack_and_send ()
           const int lidpos = i - pid_lid_start(pid);
           const int offset = f_pid_offsets(pid);
 
-          Kokkos::parallel_for(Kokkos::TeamThreadRange(team,ndims*nlevs),
+          Kokkos::parallel_for(Kokkos::TeamVectorRange(team,ndims*nlevs),
                                [&](const int idx) {
             const int idim = idx / nlevs;
             const int ilev = idx % nlevs;
@@ -826,7 +826,7 @@ void CoarseningRemapper::recv_and_unpack ()
             const int pid = recv_lids_pidpos(irecv,0);
             const int lidpos = recv_lids_pidpos(irecv,1);
             const int offset = f_pid_offsets(pid)+lidpos*ndims;
-            Kokkos::parallel_for(Kokkos::TeamThreadRange(team,ndims),
+            Kokkos::parallel_for(Kokkos::TeamVectorRange(team,ndims),
                                  [&](const int idim) {
               v(lid,idim) += buf (offset + idim);
             });
@@ -848,7 +848,7 @@ void CoarseningRemapper::recv_and_unpack ()
             const int lidpos = recv_lids_pidpos(irecv,1);
             const int offset = f_pid_offsets(pid) + lidpos*nlevs;
 
-            Kokkos::parallel_for(Kokkos::TeamThreadRange(team,nlevs),
+            Kokkos::parallel_for(Kokkos::TeamVectorRange(team,nlevs),
                                  [&](const int ilev) {
               v(lid,ilev) += buf (offset + ilev);
             });
@@ -871,7 +871,7 @@ void CoarseningRemapper::recv_and_unpack ()
             const int lidpos = recv_lids_pidpos(irecv,1);
             const int offset = f_pid_offsets(pid) + lidpos*ndims*nlevs;
 
-            Kokkos::parallel_for(Kokkos::TeamThreadRange(team,nlevs*ndims),
+            Kokkos::parallel_for(Kokkos::TeamVectorRange(team,nlevs*ndims),
                                  [&](const int idx) {
               const int idim = idx / nlevs;
               const int ilev = idx % nlevs;

--- a/components/eamxx/src/share/util/scream_column_ops.hpp
+++ b/components/eamxx/src/share/util/scream_column_ops.hpp
@@ -27,7 +27,7 @@ namespace scream {
  *  quantities (which will be defined at midpoints).
  *  The kernels are meant to be launched from within a parallel region, with
  *  team policy. More precisely, they are meant to be called from the outer most
- *  parallel region. In other words, you should *not* be inside a TeamThreadRange
+ *  parallel region. In other words, you should *not* be inside a TeamVectorRange
  *  parallel loop when calling these kernels, since these kernels will attempt
  *  to create such loops. Furthermore, these kernels *assume* that the team policy
  *  vector length (on CUDA) is 1. We have no way of checking this (the vector length
@@ -741,27 +741,27 @@ protected:
   // |        Kokkos::parallel_X wrappers         |
   // +--------------------------------------------+
 
-  // Runs the input lambda with a TeamThreadRange parallel for over [0,count) range
+  // Runs the input lambda with a TeamVectorRange parallel for over [0,count) range
   template<typename Lambda>
   KOKKOS_INLINE_FUNCTION
   static void team_parallel_for (const TeamMember& team,
                                  const int count,
                                  const Lambda& f)
   {
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,count),f);
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team,count),f);
   }
 
-  // Runs the input lambda with a TeamThreadRange parallel for over [start,end) range
+  // Runs the input lambda with a TeamVectorRange parallel for over [start,end) range
   template<typename Lambda>
   KOKKOS_INLINE_FUNCTION
   static void team_parallel_for (const TeamMember& team,
                                  const int start, const int end,
                                  const Lambda& f)
   {
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,start,end),f);
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team,start,end),f);
   }
 
-  // Runs the input lambda with a TeamThreadRange parallel scan over [0,count) range
+  // Runs the input lambda with a TeamVectorRange parallel scan over [0,count) range
   template<typename Lambda>
   KOKKOS_INLINE_FUNCTION
   static void team_parallel_scan (const TeamMember& team,
@@ -771,7 +771,7 @@ protected:
     team_parallel_scan(team,0,count,f);
   }
 
-  // Runs the input lambda with a TeamThreadRange parallel scan over [start,end) range
+  // Runs the input lambda with a TeamVectorRange parallel scan over [start,end) range
   template<typename Lambda>
   KOKKOS_INLINE_FUNCTION
   static void team_parallel_scan (const TeamMember& team,

--- a/components/eamxx/src/share/util/scream_common_physics_functions.hpp
+++ b/components/eamxx/src/share/util/scream_common_physics_functions.hpp
@@ -300,9 +300,8 @@ struct PhysicsFunctions
   // region; more precisely, they should be called from within the    //
   // outermost parallel_for, which should have been dispatched with a //
   // TeamPolicy. In other words, these routines will dispatch a       //
-  // parallel_for using a TeamVectorRange policy. No third layer of   //
-  // parallelism will be used (no ThreadVectorRange for loop), so the //
-  // team policy on GPU should be built with vector_length=1.         //
+  // parallel_for using a TeamVectorRange policy with no third layer  //
+  // of parallelism (no ThreadVectorRange for loop).                  //
   // The routines are templated on the type of their inputs, so that  //
   // these can be 1d views as well as other routines (e.g. lambdas).  //
   // The only requirement is that the provider supports op()(int k),  //

--- a/components/eamxx/src/share/util/scream_common_physics_functions.hpp
+++ b/components/eamxx/src/share/util/scream_common_physics_functions.hpp
@@ -300,7 +300,7 @@ struct PhysicsFunctions
   // region; more precisely, they should be called from within the    //
   // outermost parallel_for, which should have been dispatched with a //
   // TeamPolicy. In other words, these routines will dispatch a       //
-  // parallel_for using a TeamThreadRange policy. No third layer of   //
+  // parallel_for using a TeamVectorRange policy. No third layer of   //
   // parallelism will be used (no ThreadVectorRange for loop), so the //
   // team policy on GPU should be built with vector_length=1.         //
   // The routines are templated on the type of their inputs, so that  //

--- a/components/eamxx/src/share/util/scream_common_physics_functions_impl.hpp
+++ b/components/eamxx/src/share/util/scream_common_physics_functions_impl.hpp
@@ -16,14 +16,14 @@ ScalarT PhysicsFunctions<DeviceT>::calculate_dx_from_area(const ScalarT& area, c
   static constexpr auto coeff_1 = C::earth_ellipsoid1;
   static constexpr auto coeff_2 = C::earth_ellipsoid2;
   static constexpr auto coeff_3 = C::earth_ellipsoid3;
-  static constexpr auto pi      = C::Pi; 
+  static constexpr auto pi      = C::Pi;
 
   // Compute latitude in radians
   auto lat_in_rad = lat*(pi/180.0);
 
   // Now find meters per degree latitude
   // Below equation finds distance between two points on an ellipsoid, derived from expansion
-  // taking into account ellipsoid using World Geodetic System (WGS84) reference 
+  // taking into account ellipsoid using World Geodetic System (WGS84) reference
   auto m_per_degree_lat = coeff_1 - coeff_2 * std::cos(2.0*lat_in_rad) + coeff_3 * std::cos(4.0*lat_in_rad);
   // Note, for the formula we need to convert area from radians to degrees.
   return m_per_degree_lat * std::sqrt(area)*(180.0/pi);
@@ -50,7 +50,7 @@ void PhysicsFunctions<DeviceT>::calculate_density(const MemberType& team,
                                                   const InputProviderZ& dz,
                                                   const view_1d<ScalarT>& density)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,density.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,density.extent(0)),
                        [&] (const int k) {
     density(k) = calculate_density(pseudo_density(k),dz(k));
   });
@@ -77,7 +77,7 @@ void PhysicsFunctions<DeviceT>::exner_function(const MemberType& team,
                                                const InputProviderP& pressure,
                                                const view_1d<ScalarT>& exner)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,exner.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,exner.extent(0)),
                        [&] (const int k) {
     exner(k) = exner_function(pressure(k));
   });
@@ -99,7 +99,7 @@ void PhysicsFunctions<DeviceT>::calculate_theta_from_T(const MemberType& team,
                                                        const InputProviderP& pressure,
                                                        const view_1d<ScalarT>& theta)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,theta.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,theta.extent(0)),
                        [&] (const int k) {
     theta(k) = calculate_theta_from_T(temperature(k),pressure(k));
   });
@@ -121,7 +121,7 @@ void PhysicsFunctions<DeviceT>::calculate_T_from_theta(const MemberType& team,
                                                        const InputProviderP& pressure,
                                                        const view_1d<ScalarT>& temperature)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,temperature.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,temperature.extent(0)),
                        [&] (const int k) {
     temperature(k) = calculate_T_from_theta(theta(k),pressure(k));
   });
@@ -151,7 +151,7 @@ calculate_temperature_from_virtual_temperature(const MemberType& team,
                                                const InputProviderQ& qv,
                                                const view_1d<ScalarT>& temperature)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,temperature.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,temperature.extent(0)),
                        [&] (const int k) {
     temperature(k) = calculate_temperature_from_virtual_temperature(T_virtual(k),qv(k));
   });
@@ -180,7 +180,7 @@ calculate_virtual_temperature(const MemberType& team,
                               const InputProviderQ& qv,
                               const view_1d<ScalarT>& T_virtual)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,T_virtual.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,T_virtual.extent(0)),
                        [&] (const int k) {
     T_virtual(k) = calculate_virtual_temperature(temperature(k),qv(k));
   });
@@ -209,7 +209,7 @@ void PhysicsFunctions<DeviceT>::calculate_dse(const MemberType& team,
                                               const Real surf_geopotential,
                                               const view_1d<ScalarT>& dse)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,dse.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dse.extent(0)),
                        [&] (const int k) {
     dse(k) = calculate_dse(temperature(k),z(k),surf_geopotential);
   });
@@ -240,7 +240,7 @@ calculate_temperature_from_dse(const MemberType& team,
                                const Real surf_geopotential,
                                const view_1d<ScalarT>& temperature)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,dse.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dse.extent(0)),
                        [&] (const int k) {
     temperature(k) = calculate_temperature_from_dse(dse(k),z(k),surf_geopotential);
   });
@@ -263,7 +263,7 @@ void PhysicsFunctions<DeviceT>::calculate_wetmmr_from_drymmr(const MemberType& t
                                                              const InputProviderQ& qv_dry,
                                                              const view_1d<ScalarT>& wetmmr)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,wetmmr.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,wetmmr.extent(0)),
                        [&] (const int k) {
                          wetmmr(k) = calculate_wetmmr_from_drymmr(drymmr(k),qv_dry(k));
                        });
@@ -286,7 +286,7 @@ void PhysicsFunctions<DeviceT>::calculate_drymmr_from_wetmmr(const MemberType& t
                                                              const InputProviderQ& qv_wet,
                                                              const view_1d<ScalarT>& drymmr)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,drymmr.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,drymmr.extent(0)),
                        [&] (const int k) {
                          drymmr(k) = calculate_drymmr_from_wetmmr(wetmmr(k),qv_wet(k));
                        });
@@ -320,7 +320,7 @@ void PhysicsFunctions<DeviceT>::calculate_dz(const MemberType& team,
                                              const InputProviderQ& qv,
                                              const view_1d<ScalarT, MT>& dz)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,dz.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dz.extent(0)),
                        [&] (const int k) {
     dz(k) = calculate_dz(pseudo_density(k),p_mid(k),T_mid(k),qv(k));
   });
@@ -374,7 +374,7 @@ void PhysicsFunctions<DeviceT>::calculate_vmr_from_mmr(const MemberType& team,
                                                        const InputProviderX& mmr,
                                                        const view_1d<ScalarT>& vmr)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,vmr.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,vmr.extent(0)),
                        [&] (const int k) {
     vmr(k) = calculate_vmr_from_mmr(gas_mol_weight,qv(k),mmr(k));
   });
@@ -389,7 +389,7 @@ ScalarT PhysicsFunctions<DeviceT>::calculate_mmr_from_vmr(const Real& gas_mol_we
   constexpr Real air_mol_weight   = C::MWdry;
   const Real mol_weight_ratio = gas_mol_weight/air_mol_weight;
 
-  return mol_weight_ratio * vmr * (1.0 - qv); 
+  return mol_weight_ratio * vmr * (1.0 - qv);
 
 }
 
@@ -402,7 +402,7 @@ void PhysicsFunctions<DeviceT>::calculate_mmr_from_vmr(const MemberType& team,
                                                        const InputProviderX& vmr,
                                                        const view_1d<ScalarT>& mmr)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,mmr.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team,mmr.extent(0)),
                        [&] (const int k) {
     mmr(k) = calculate_mmr_from_vmr(gas_mol_weight,qv(k),vmr(k));
   });
@@ -414,7 +414,7 @@ Real PhysicsFunctions<DeviceT>::calculate_surface_air_T(const Real& T_mid_bot, c
 {
   /*Compute temperature at the bottom of the gridcell closest to the ground. The implementation here
     is really clunky and is meant to provide calculate_psl with the values used by CESM... Think
-    twice before using it for anything else. Inputs are T at midpoint of layer closest to the surface (K) and 
+    twice before using it for anything else. Inputs are T at midpoint of layer closest to the surface (K) and
     the geometric height at that point (m). Note that z_mid_bot is distance from the surface rather than from
     sea level!
   */
@@ -423,7 +423,7 @@ Real PhysicsFunctions<DeviceT>::calculate_surface_air_T(const Real& T_mid_bot, c
   //Ditching this version for fear that weird lowest layer T relationships could yield strange surface values.
   //const Real T_weighting = ( p_int_i(num_levs) - p_mid_i(last_entry))/(p_mid_i(last_entry - 1) - p_mid_i(last_entry) );
   //return T_mid_i(last_entry - 1)*T_weighting + T_mid_i(last_entry)*(1-T_weighting);
-  
+
   //Assume 6.5 K/km lapse rate between cell's midpoint and its bottom edge
   return T_mid_bot + sp(0.0065)*z_mid_bot;
 }
@@ -433,9 +433,9 @@ KOKKOS_INLINE_FUNCTION
 void PhysicsFunctions<DeviceT>::lapse_T_for_psl(const Real& T_ground, const Real& phi_ground,
 					        Real& lapse, Real& T_ground_tmp )
 {
-  /* 
+  /*
     Choose lapse rate and effective ground temperature to use for sea-level pressure calculation.
-    This function should only be used by calculate_psl and is separated from that function solely 
+    This function should only be used by calculate_psl and is separated from that function solely
     to improve specificity of unit testing.
  */
 
@@ -467,10 +467,10 @@ template<typename DeviceT>
 KOKKOS_INLINE_FUNCTION
 Real PhysicsFunctions<DeviceT>::calculate_psl(const Real& T_ground, const Real& p_ground, const Real& phi_ground)
 {
-  /* 
-     Compute sea level pressure (psl) assuming atmosphere below the land surface is dry and has a lapse 
+  /*
+     Compute sea level pressure (psl) assuming atmosphere below the land surface is dry and has a lapse
      rate of 6.5K/km unless conditions are very warm. See components/eamxx/docs/tech_doc/physics/psl/
-     for a description. Note that all input/out variables are only defined at the surface rather than 
+     for a description. Note that all input/out variables are only defined at the surface rather than
      being 3d variables so no need to template on InputProvider.
  */
 
@@ -479,7 +479,7 @@ Real PhysicsFunctions<DeviceT>::calculate_psl(const Real& T_ground, const Real& 
   constexpr Real gravit = C::gravit;
   constexpr Real Rair = C::Rair;
   Real psl;
-  
+
   // if phi_ground is very close to sea level already, set psl to existing p_ground
   if (std::abs(phi_ground/gravit) < 1e-4){
     psl = p_ground;
@@ -492,7 +492,7 @@ Real PhysicsFunctions<DeviceT>::calculate_psl(const Real& T_ground, const Real& 
     Real beta=phi_ground/(Rair*T_ground_tmp);
     psl = p_ground*std::exp(beta*( 1 - alpha*beta/2 + std::pow(alpha*beta,2)/3 ) );
   }
-  
+
   return psl;
 }
 
@@ -529,7 +529,7 @@ void PhysicsFunctions<DeviceT>::apply_rayleigh_friction (const MemberType& team,
                                                          const view_1d<ScalarT, MT>& v_wind,
                                                          const view_1d<ScalarT, MT>& T_mid)
 {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, T_mid.extent(0)),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, T_mid.extent(0)),
                        [&] (const int k) {
     apply_rayleigh_friction(dt, otau(k), u_wind(k), v_wind(k), T_mid(k));
   });

--- a/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
+++ b/components/eamxx/src/share/util/scream_vertical_interpolation_impl.hpp
@@ -55,7 +55,7 @@ void apply_interpolation_impl_1d(
   vert_interp.lin_interp(team, x_src, x_tgt, input, output, icol);
   const auto x_src_s = ekat::scalarize(x_src);
   const auto x_tgt_s = ekat::scalarize(x_tgt);
-  const auto range = Kokkos::TeamThreadRange(team, x_tgt.extent(0));
+  const auto range = Kokkos::TeamVectorRange(team, x_tgt.extent(0));
   //Mask out values above (below) maximum (minimum) source grid
   Kokkos::parallel_for(range, [&] (const Int & k) {
     const auto above_max = x_tgt[k] > x_src_s[nlevs_src-1];

--- a/components/eamxx/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
+++ b/components/eamxx/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
@@ -279,7 +279,7 @@ namespace scream {
             d_sfc_alb_dir_nir(i) = sfc_alb_dir_nir(i+1);
             d_sfc_alb_dif_vis(i) = sfc_alb_dif_vis(i+1);
             d_sfc_alb_dif_nir(i) = sfc_alb_dif_nir(i+1);
-            Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay), [&] (const int& k) {
+            Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlay), [&] (const int& k) {
               d_pmid(i,k) = p_lay(i+1,k+1);
               d_tmid(i,k) = t_lay(i+1,k+1);
               d_pdel(i,k) = p_del(i+1,k+1);
@@ -332,7 +332,7 @@ namespace scream {
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
             const int i = team.league_rank();
 
-            Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlay+1), [&] (const int& k) {
+            Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlay+1), [&] (const int& k) {
               if (k < nlay) t_lay(i+1,k+1) = d_tmid(i,k);
 
               sw_flux_up_test(i+1,k+1)     = d_sw_flux_up(i,k);


### PR DESCRIPTION
Use `TeamVectorRange` when no nested parallelism is needed. Updates EKAT to include similar updates. Continuation of https://github.com/E3SM-Project/scream/issues/2070.

Sanity performance test `F2010-SCREAMv1.ne30pg2_ne30pg2` on 4 summit nodes:
**Old (TeamThreadRange)**
```
name                     processes          count      walltotal  wallmax  wallmin
"a:EAMxx::physics::run"         24   1.152000e+03   1.821062e+02    8.160    7.076 
```
**New (TeamVectorRange)**
```
name                     processes          count      walltotal  wallmax  wallmin
"a:EAMxx::physics::run"         24   1.152000e+03   1.751569e+02    7.738    6.878 
```
From `wallmax`, we see a 5% decrease in runtime using `TeamVectorRange`. Maybe this is just coincidence/negligible, but they match 2 of the same simulations I did a couple of days ago, so slight performance gain in physics.