### PR TITLE
Remove duplicate spock and crusher xml tags

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -648,23 +648,6 @@
      </queues>
    </batch_system>
 
-   <batch_system MACH="spock" type="slurm">
-     <queues>
-       <queue strict="true" nodemin="1" nodemax="4" walltimemax="03:00:00" default="true">ecp</queue>
-       <queue strict="true" nodemin="1" nodemax="4" walltimemax="03:00:00">caar</queue>
-       <queue strict="true" nodemin="5" nodemax="16" walltimemax="01:00:00">caar</queue>
-     </queues>
-   </batch_system>
-
-   <batch_system MACH="crusher" type="slurm">
-     <batch_submit>/gpfs/alpine/cli133/world-shared/e3sm/tools/sbatch/throttle</batch_submit>
-     <queues>
-       <queue strict="true" nodemin="1" nodemax="8" walltimemax="01:00:00" default="true">batch</queue>
-       <queue strict="true" nodemin="9" nodemax="64" walltimemax="01:00:00">batch</queue>
-       <queue strict="true" nodemin="65" nodemax="160" walltimemax="01:00:00">batch</queue>
-     </queues>
-   </batch_system>
-
    <batch_system MACH="crusher-scream-cpu" type="slurm">
      <queues>
        <queue strict="true" nodemin="1" nodemax="8" walltimemax="08:00:00" default="true">batch</queue>


### PR DESCRIPTION
Remove duplicate spock and crusher xml tags in config_batch.xml. Needed for consistency with E3SM upstream. Should be B4B.

[B4B]