### PR TITLE
Better handle accumulated fields

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -89,7 +89,7 @@ public:
   void setup_surface_coupling_processes() const;
 
   // Zero out precipitation flux
-  void set_precipitation_fields_to_zero();
+  void reset_accummulated_fields();
 
   // Create and add mass and energy conservation checks
   // and pass to m_atm_process_group.

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -59,10 +59,8 @@ void SurfaceCouplingExporter::set_grids(const std::shared_ptr<const GridsManager
   add_field<Required>("sfc_flux_dif_vis",     scalar2d_layout,      Wm2,   grid_name);
   add_field<Required>("sfc_flux_sw_net" ,     scalar2d_layout,      Wm2,   grid_name);
   add_field<Required>("sfc_flux_lw_dn"  ,     scalar2d_layout,      Wm2,   grid_name);
-
-  // These fields are required for computations, and are set to zero after the export
-  add_field<Updated>("precip_liq_surf_mass", scalar2d_layout,      kg/m2,  grid_name);
-  add_field<Updated>("precip_ice_surf_mass", scalar2d_layout,      kg/m2,  grid_name);
+  add_field<Required>("precip_liq_surf_mass", scalar2d_layout,      kg/m2,  grid_name);
+  add_field<Required>("precip_ice_surf_mass", scalar2d_layout,      kg/m2,  grid_name);
 
   create_helper_field("Sa_z",       scalar2d_layout, grid_name);
   create_helper_field("Sa_ptem",    scalar2d_layout, grid_name);

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -217,8 +217,8 @@ void SurfaceCouplingExporter::do_export(const double dt, const bool called_durin
   const auto& p_mid                = get_field_in("p_mid").get_view<const Spack**>();
   const auto& phis                 = get_field_in("phis").get_view<const Real*>();
 
-  const auto& precip_liq_surf_mass = get_field_out("precip_liq_surf_mass").get_view<Real*>();
-  const auto& precip_ice_surf_mass = get_field_out("precip_ice_surf_mass").get_view<Real*>();
+  const auto& precip_liq_surf_mass = get_field_in("precip_liq_surf_mass").get_view<const Real*>();
+  const auto& precip_ice_surf_mass = get_field_in("precip_ice_surf_mass").get_view<const Real*>();
 
   const auto Sa_z       = m_helper_fields.at("Sa_z").get_view<Real*>();
   const auto Sa_ptem    = m_helper_fields.at("Sa_ptem").get_view<Real*>();

--- a/components/eamxx/src/diagnostics/precip_ice_surf_mass_flux.cpp
+++ b/components/eamxx/src/diagnostics/precip_ice_surf_mass_flux.cpp
@@ -36,14 +36,21 @@ void PrecipIceSurfMassFluxDiagnostic::set_grids(const std::shared_ptr<const Grid
 // =========================================================================================
 void PrecipIceSurfMassFluxDiagnostic::compute_diagnostic_impl()
 {
-  const auto& precip_ice_surf_mass      = get_field_in("precip_ice_surf_mass").get_view<const Real*>();
-  const auto& precip_ice_surf_mass_flux = m_diagnostic_output.get_view<Real*>();
-  const auto dt = m_dt;
+  const auto& mass_field = get_field_in("precip_ice_surf_mass");
+  const auto& mass_view  = mass_field.get_view<const Real*>();
+  const auto& flux_view  = m_diagnostic_output.get_view<Real*>();
 
+  const auto& mass_track = mass_field.get_header().get_tracking();
+
+  const auto& t_start = mass_track.get_accum_start_time ();
+  const auto& t_now   = mass_track.get_time_stamp ();
+  const auto dt = t_now - t_start;
+
+  auto rhodt = PC::RHO_H2O*dt;
   Kokkos::parallel_for("PrecipIceMassFluxDiagnostic",
                        KT::RangePolicy(0,m_num_cols),
                        KOKKOS_LAMBDA(const Int& icol) {
-    precip_ice_surf_mass_flux(icol) = precip_ice_surf_mass(icol)/PC::RHO_H2O/dt;
+    flux_view(icol) = mass_view(icol) / rhodt;
   });
 }
 // =========================================================================================

--- a/components/eamxx/src/diagnostics/precip_liq_surf_mass_flux.cpp
+++ b/components/eamxx/src/diagnostics/precip_liq_surf_mass_flux.cpp
@@ -36,14 +36,21 @@ void PrecipLiqSurfMassFluxDiagnostic::set_grids(const std::shared_ptr<const Grid
 // =========================================================================================
 void PrecipLiqSurfMassFluxDiagnostic::compute_diagnostic_impl()
 {
-  const auto& precip_liq_surf_mass      = get_field_in("precip_liq_surf_mass").get_view<const Real*>();
-  const auto& precip_liq_surf_mass_flux = m_diagnostic_output.get_view<Real*>();
-  const auto dt = m_dt;
-  
+  const auto& mass_field = get_field_in("precip_liq_surf_mass");
+  const auto& mass_view  = mass_field.get_view<const Real*>();
+  const auto& flux_view  = m_diagnostic_output.get_view<Real*>();
+
+  const auto& mass_track = mass_field.get_header().get_tracking();
+
+  const auto& t_start = mass_track.get_accum_start_time ();
+  const auto& t_now   = mass_track.get_time_stamp ();
+  const auto dt = t_now - t_start;
+
+  auto rhodt = PC::RHO_H2O*dt;
   Kokkos::parallel_for("PrecipLiqMassFluxDiagnostic",
                        KT::RangePolicy(0,m_num_cols),
                        KOKKOS_LAMBDA(const Int& icol) {
-    precip_liq_surf_mass_flux(icol) = precip_liq_surf_mass(icol)/PC::RHO_H2O/dt;
+    flux_view(icol) = mass_view(icol) / rhodt;
   });
 }
 // =========================================================================================

--- a/components/eamxx/src/diagnostics/tests/precip_ice_surf_mass_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/precip_ice_surf_mass_flux_tests.cpp
@@ -52,7 +52,7 @@ void run(std::mt19937_64& engine)
   using RPDF = std::uniform_real_distribution<Real>;
   RPDF pdf_mass(0.0,1.0);
 
-  // A time stamp
+  // Initial time stamp
   util::TimeStamp t0 ({2022,1,1},{0,0,0});
 
   // Construct the Diagnostic
@@ -71,6 +71,7 @@ void run(std::mt19937_64& engine)
     f.allocate_view();
     const auto name = f.name();
     f.get_header().get_tracking().update_time_stamp(t0);
+    f.get_header().get_tracking().set_accum_start_time(t0);
     diag->set_required_field(f.get_const());
     REQUIRE_THROWS(diag->set_computed_field(f));
     input_fields.emplace(name,f);
@@ -81,26 +82,29 @@ void run(std::mt19937_64& engine)
 
   // Run tests
   {
+    util::TimeStamp t = t0 + dt;
+
     // Construct random data to use for test
     // Get views of input data and set to random values
-    const auto& precip_ice_surf_mass_f = input_fields["precip_ice_surf_mass"];
+    auto precip_ice_surf_mass_f = input_fields["precip_ice_surf_mass"];
     const auto& precip_ice_surf_mass_v = precip_ice_surf_mass_f.get_view<Real*>();
     for (int icol=0;icol<ncols;icol++) {
       ekat::genRandArray(precip_ice_surf_mass_v, engine, pdf_mass);
     }
+    precip_ice_surf_mass_f.get_header().get_tracking().update_time_stamp(t);
 
     // Run diagnostic and compare with manual calculation
-    diag->compute_diagnostic(dt);
+    diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field theta_f = diag_out.clone();
     theta_f.deep_copy<double,Host>(0.0);
     theta_f.sync_to_dev();
     const auto& theta_v = theta_f.get_view<Real*>();
-    const auto rho_h2o = PC::RHO_H2O;
+    const auto rhodt = PC::RHO_H2O*dt;
     Kokkos::parallel_for("precip_ice_surf_mass_flux_test",
                          typename KT::RangePolicy(0,ncols),
                          KOKKOS_LAMBDA(const int& icol) {
-      theta_v(icol) = precip_ice_surf_mass_v(icol)/rho_h2o/dt;
+      theta_v(icol) = precip_ice_surf_mass_v(icol) / rhodt;
     });
     Kokkos::fence();
     REQUIRE(views_are_equal(diag_out,theta_f));

--- a/components/eamxx/src/physics/p3/atmosphere_microphysics.cpp
+++ b/components/eamxx/src/physics/p3/atmosphere_microphysics.cpp
@@ -91,8 +91,8 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_field<Updated> ("T_prev_micro_step",  scalar3d_layout_mid, K,        grid_name, ps);
 
   // Diagnostic Outputs: (all fields are just outputs w.r.t. P3)
-  add_field<Updated>("precip_liq_surf_mass", scalar2d_layout,     kg/m2,  grid_name);
-  add_field<Updated>("precip_ice_surf_mass", scalar2d_layout,     kg/m2,  grid_name);
+  add_field<Updated>("precip_liq_surf_mass", scalar2d_layout,     kg/m2,  grid_name, "ACCUMULATED");
+  add_field<Updated>("precip_ice_surf_mass", scalar2d_layout,     kg/m2,  grid_name, "ACCUMULATED");
   add_field<Computed>("eff_radius_qc",       scalar3d_layout_mid, micron, grid_name, ps);
   add_field<Computed>("eff_radius_qi",       scalar3d_layout_mid, micron, grid_name, ps);
 

--- a/components/eamxx/src/share/field/field_tracking.cpp
+++ b/components/eamxx/src/share/field/field_tracking.cpp
@@ -31,4 +31,10 @@ void FieldTracking::update_time_stamp (const TimeStamp& ts) {
   }
 }
 
+void FieldTracking::set_accum_start_time (const TimeStamp& t_start) {
+  EKAT_REQUIRE_MSG (not m_time_stamp.is_valid() || m_time_stamp<=t_start,
+      "Error! Accumulation start time is older than current timestamp of the field.\n");
+  m_accum_start = t_start;
+}
+
 } // namespace scream

--- a/components/eamxx/src/share/field/field_tracking.hpp
+++ b/components/eamxx/src/share/field/field_tracking.hpp
@@ -61,6 +61,10 @@ public:
   //       However, if the field has a 'parent' (see FamilyTracking), the parent's ts will not be updated.
   void update_time_stamp (const TimeStamp& ts);
 
+  // Set/get accumulation interval start
+  void set_accum_start_time (const TimeStamp& ts);
+  const TimeStamp& get_accum_start_time () const { return m_accum_start; }
+
 protected:
 
   // We keep the field name just to make debugging messages more helpful
@@ -68,6 +72,10 @@ protected:
 
   // Tracking the updates of the field
   TimeStamp         m_time_stamp;
+
+  // For accummulated vars, the time where the accummulation started
+  TimeStamp         m_accum_start;
+  ci_string         m_accum_type;
 
   // List of provider/customer processes. A provider is an atm process that computes/updates the field.
   // A customer is an atm process that uses the field just as an input.

--- a/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
+++ b/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
@@ -304,8 +304,8 @@ void test_exports(const FieldManager& fm,
       EKAT_REQUIRE(0 == export_data_view(i, export_cpl_indices_view(15)));
       EKAT_REQUIRE(0 == export_data_view(i, export_cpl_indices_view(16)));
     } else {
-      EKAT_REQUIRE(export_constant_multiple_view(9 )*Faxa_rainl_h(i)       == 0.0); // These are set to 0 in do_export() so the values can't be
-      EKAT_REQUIRE(export_constant_multiple_view(10)*Faxa_snowl_h(i)       == 0.0); // checked here. It will be tested in the V1 CIME tests.
+      EKAT_REQUIRE(export_constant_multiple_view(9 )*Faxa_rainl_h(i)       == export_data_view(i, export_cpl_indices_view(9 )));
+      EKAT_REQUIRE(export_constant_multiple_view(10)*Faxa_snowl_h(i)       == export_data_view(i, export_cpl_indices_view(10)));
       EKAT_REQUIRE(export_constant_multiple_view(11)*sfc_flux_dir_nir_h(i) == export_data_view(i, export_cpl_indices_view(11)));
       EKAT_REQUIRE(export_constant_multiple_view(12)*sfc_flux_dir_vis_h(i) == export_data_view(i, export_cpl_indices_view(12)));
       EKAT_REQUIRE(export_constant_multiple_view(13)*sfc_flux_dif_nir_h(i) == export_data_view(i, export_cpl_indices_view(13)));


### PR DESCRIPTION
This PR adds some metadata to FieldTracking, namely the timestamp where accumulation started. Customers of the field can use this info to deduce how much time has passed, like

```
  auto t_start = tracking.get_accum_start_time();
  auto t_now = tracking.get_time_stamp();
  auto dt = t_now - t_start;
```
The driver queries the field managers for field group "ACCUMULATED", and resets them to 0 at the beginning of each time step, (setting their timestamp as well).

So far, the driver assumes the accumulation is a SUM. I thought about adding MAX/MIN, but a) I didn't know if it was useful, and b) it was not as immediate to add.



Fixes #1767 
Fixes part of #2160 