### PR TITLE
Ensure output is always flushed when program terminates

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -94,6 +94,11 @@ AtmosphereDriver(const ekat::Comm& atm_comm,
   set_params(params);
 }
 
+AtmosphereDriver::~AtmosphereDriver ()
+{
+  finalize();
+}
+
 void AtmosphereDriver::
 set_comm(const ekat::Comm& atm_comm)
 {

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1327,6 +1327,10 @@ void AtmosphereDriver::run (const int dt) {
 void AtmosphereDriver::finalize ( /* inputs? */ ) {
   start_timer("EAMxx::finalize");
 
+  if (m_ad_status==0) {
+    return;
+  }
+
   m_atm_logger->info("[EAMxx] Finalize ...");
 
   // Finalize and destroy output streams, make sure files are closed
@@ -1373,6 +1377,8 @@ void AtmosphereDriver::finalize ( /* inputs? */ ) {
   m_atm_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
   m_atm_logger->debug("[EAMxx::finalize] memory usage: " + std::to_string(max_mem_usage) + "MB");
 #endif
+
+  m_ad_status = 0;
 
   stop_timer("EAMxx::finalize");
 }

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -132,8 +132,9 @@ public:
   // Note: dt is assumed to be in seconds
   void run (const int dt);
 
-  // Clean up the driver (includes cleaning up the parameterizations and the fm's);
-  void finalize ( /* inputs */ );
+  // Clean up the driver (finalizes and cleans up all internals)
+  // NOTE: if already finalized, this is a no-op
+  void finalize ();
 
   field_mgr_ptr get_ref_grid_field_mgr () const;
   field_mgr_ptr get_field_mgr (const std::string& grid_name) const;

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -48,8 +48,10 @@ public:
   AtmosphereDriver (const ekat::Comm& atm_comm,
                     const ekat::ParameterList& params);
 
-  // The default dtor is fine.
-  ~AtmosphereDriver () = default;
+  // Must call finalize, so that, if AD is destroyed as part of uncaught
+  // exception stack unwinding, we will still perform some cleanup ops,
+  // among which, for instance, closing any open output file.
+  ~AtmosphereDriver ();
 
   // ---- Begin initialization methods ---- //
 

--- a/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -49,7 +49,13 @@ void fpe_guard_wrapper (const Lambda& f) {
   ekat::enable_fpes(get_default_fpes());
 
   // Execute wrapped function
-  f();
+  try {
+    f();
+  } catch (...) {
+    auto& c = ScreamContext::singleton();
+    c.clean_up();
+    throw;
+  }
 
   // Restore the FPE flag as it was when control was handed to us.
   ekat::disable_all_fpes();


### PR DESCRIPTION
In case of abnormal termination (e.g., exception thrown), the driver was not finalized, causing output streams to not be flushed.

The fix was trivial for standalone runs:. replace the default dtor of the driver with one that calls the finalize method. The dtor is guaranteed to be called for all automatic (i.e., stack) variables.

For CIME runs, not so much. The issue is that the AD is no longer a stack var, but it's held by the `ScreamContext` object. My first take was "well, let's register a cleanup function with `atexit`". That sounds reasonable, but the fortran execution does not call `exit` like a C/C++ program would, and the fcn registered with atexit never gets called, and Fortran does not have an equivalent of atexit.

My current solution is to handle the exception inside our F90<->C++ interface layer, by catching the exception, and doing the cleanup:
```
  try {
    scream_blah
  } catch (...) {
    finalize_singleton
    throw; // <- this will be were all our stacktraces will point to
  }
```
The downside is that the exception that kills the run is now originating from that `throw` statement. So the backtrace of our runs will not be very informative, as it will always point to that line.

I am open to different strategies. If anyone knows of a way to intercept the termination of the program in fortran (similar to the `atexit` way in C/C++), I'm all ears. Meanwhile, I think this is the best we can do to guarantee our output streams are flushed.

Well, that's not the whole truth: we do not have the ability to flush streams if the error does not originate in our C/C++ code. E.g., we do not intercept errors originating in other components, so if CICE crashes, we will not have a chance to flush our output. That said, I think this is still a good improvement, in that we can flush output if EAMxx generates an error (e.g., a field property check fails).

I verified (by injecting a `EKAT_ERROR_MSG("whoops!")` call in the code) that current master did not properly flush files, while this branch does, both for standalone and CIME runs.

@PeterCaldwell I would like you to weigh in on the limitations and drawback(s) of the approach I implemented. To summarize, the limitations/drawbacks are
- limitation: won't work if crash originates outside of EAMxx or in EAMxx's F90 code
- drawback: stacktrace of all EAMxx errors will point to the same line in `scream_cxx_f90_interface.cpp`.

Fixes #2185 