### PR TITLE
Fix config_archive.xml

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -26,12 +26,9 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="scream" compclass="atm">
-    <rest_file_extension>[ri]</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_file_extension>rhist</rest_file_extension>
-    <rest_file_extension>rs</rest_file_extension>
-    <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
-    <hist_file_extension>e</hist_file_extension>
-    <rest_history_varname>nhfil</rest_history_varname>
+    <hist_file_extension>hi</hist_file_extension>
   </comp_archive_spec>
 
   <comp_archive_spec compname="elm" compclass="lnd">


### PR DESCRIPTION
We were not listing the extension of our typical history file. Also, some of the entries for scream were not used, probably copy-pasted from EAM.