### PR TITLE
Fix baseline gen on weaver

### DIFF
--- a/components/eamxx/src/physics/p3/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/p3/tests/CMakeLists.txt
@@ -98,8 +98,17 @@ if (SCREAM_ENABLE_BASELINE_TESTS)
     EXE_ARGS "-g ${BASELINE_FILE_ARG}"
     PROPERTIES DISABLED True)
 
-  get_test_property(p3_baseline_f90_fake_omp${SCREAM_TEST_MAX_THREADS} FULL_TEST_COMMAND P3_F90_GEN)
-  get_test_property(p3_baseline_cxx_fake_omp${SCREAM_TEST_MAX_THREADS} FULL_TEST_COMMAND P3_CXX_GEN)
+  if (SCREAM_TEST_MAX_THREADS GREATER 1)
+    get_test_property(p3_baseline_f90_fake_omp${SCREAM_TEST_MAX_THREADS} FULL_TEST_COMMAND P3_F90_GEN)
+    get_test_property(p3_baseline_cxx_fake_omp${SCREAM_TEST_MAX_THREADS} FULL_TEST_COMMAND P3_CXX_GEN)
+  else()
+    get_test_property(p3_baseline_f90_fake FULL_TEST_COMMAND P3_F90_GEN)
+    get_test_property(p3_baseline_cxx_fake FULL_TEST_COMMAND P3_CXX_GEN)
+  endif()
+
+  if (P3_F90_GEN STREQUAL "NOTFOUND")
+    message(FATAL_ERROR "Could not get FULL_TEST_COMMAND for p3_baseline fake test")
+  endif()
 
   separate_arguments(P3_F90_GEN_ARGS UNIX_COMMAND "${P3_F90_GEN}")
   separate_arguments(P3_CXX_GEN_ARGS UNIX_COMMAND "${P3_CXX_GEN}")

--- a/components/eamxx/src/physics/shoc/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/shoc/tests/CMakeLists.txt
@@ -109,8 +109,17 @@ if (SCREAM_ENABLE_BASELINE_TESTS)
     EXE_ARGS "-g ${BASELINE_FILE_ARG}"
     PROPERTIES DISABLED True)
 
-  get_test_property(shoc_baseline_f90_fake_omp${SCREAM_TEST_MAX_THREADS} FULL_TEST_COMMAND SHOC_F90_GEN)
-  get_test_property(shoc_baseline_cxx_fake_omp${SCREAM_TEST_MAX_THREADS} FULL_TEST_COMMAND SHOC_CXX_GEN)
+  if (SCREAM_TEST_MAX_THREADS GREATER 1)
+    get_test_property(shoc_baseline_f90_fake_omp${SCREAM_TEST_MAX_THREADS} FULL_TEST_COMMAND SHOC_F90_GEN)
+    get_test_property(shoc_baseline_cxx_fake_omp${SCREAM_TEST_MAX_THREADS} FULL_TEST_COMMAND SHOC_CXX_GEN)
+  else()
+    get_test_property(shoc_baseline_f90_fake FULL_TEST_COMMAND SHOC_F90_GEN)
+    get_test_property(shoc_baseline_cxx_fake FULL_TEST_COMMAND SHOC_CXX_GEN)
+  endif()
+
+  if (SHOC_F90_GEN STREQUAL "NOTFOUND")
+    message(FATAL_ERROR "Could not get FULL_TEST_COMMAND for shoc_baseline fake test")
+  endif()
 
   separate_arguments(SHOC_F90_GEN_ARGS UNIX_COMMAND "${SHOC_F90_GEN}")
   separate_arguments(SHOC_CXX_GEN_ARGS UNIX_COMMAND "${SHOC_CXX_GEN}")


### PR DESCRIPTION
OMP stuff is not added to test names on weaver.