### PR TITLE
Add EKAT standalone tests to nightly test-all-scream runs

### DIFF
--- a/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
@@ -83,7 +83,8 @@ if [ $skip_testing -eq 0 ]; then
       TAS_ARGS="${TAS_ARGS} --test-level nightly"
       # We never want to submit a fake run to the dashboard
       if [ -z "$SCREAM_FAKE_ONLY" ]; then
-          TAS_ARGS="${TAS_ARGS} --submit"
+          # Run EKAT tests for real nightly runs
+          TAS_ARGS="${TAS_ARGS} --submit -c EKAT_ENABLE_TESTS=ON"
       fi
   fi
 

--- a/components/eamxx/tests/generic/fail_check/CMakeLists.txt
+++ b/components/eamxx/tests/generic/fail_check/CMakeLists.txt
@@ -18,9 +18,9 @@ if (EKAT_ENABLE_VALGRIND)
 endif()
 
 # Ensure that FPE *do* throw when we expect them to
-CreateUnitTestExec (fpe_check "fpe_check.cpp" "scream_share")
+CreateUnitTestExec (scream_fpe_check "fpe_check.cpp" "scream_share")
 if (SCREAM_FPE)
-  CreateUnitTestFromExec (fpe_check fpe_check PROPERTIES WILL_FAIL TRUE LABELS "check")
+  CreateUnitTestFromExec (scream_fpe_check scream_fpe_check PROPERTIES WILL_FAIL TRUE LABELS "check")
 else()
-  CreateUnitTestFromExec (fpe_check fpe_check LABELS "check")
+  CreateUnitTestFromExec (scream_fpe_check scream_fpe_check LABELS "check")
 endif()


### PR DESCRIPTION
EKAT AT runs these same tests but they are very inexpensive to run so we may as well run them alongside the scream standalone tests.

This change will run EKAT ctests on mappy, Blake, and weaver nightly with the same build types that are currently used for scream.

Change test names to not conflict with EKAT tests.

Fixes #2028 