### PR TITLE
Fix test-all-scream on quartz

### DIFF
--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -690,8 +690,6 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
     def generate_ctest_config(self, cmake_config, extra_configs, test):
     ###############################################################################
         result = ""
-        if self._submit:
-            result += f"SCREAM_MACHINE={self._machine} "
 
         test_dir = self.get_test_dir(self._work_dir,test)
         num_test_res = self.create_ctest_resource_file(test,test_dir)


### PR DESCRIPTION
We can now rely on the machine cache files to set SCREAM_MACHINE (and they do it correctly when there's a hierarchical machine-file setup like quartz-intel.cmake -> quartz.cmake). There's no need for test-all-scream to set it.