### PR TITLE
Fix valgrind error in scream_scorpio_interface.F90

### DIFF
--- a/components/eamxx/src/share/io/scream_scorpio_interface.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.F90
@@ -966,6 +966,7 @@ contains
       prev_file_ptr => curr_file_ptr
       curr_file_ptr => curr_file_ptr%next
       deallocate(prev_file_ptr)
+      pio_file_list_front => curr_file_ptr ! be sure not to iterate over deallocated item
     end do
     ! Free all decompositions from PIO
     iodesc_ptr => iodesc_list_top


### PR DESCRIPTION
During finalize, lookups were iterating over deallocated items.

Details, this callstack:
```
JGF closing all files BEGIN
   JGF closing all files loop io_packed_ps1.INSTANT.nsteps_x5.np1.2023-02-17-00000.nc
       JGF Deleting list item io_packed_ps1.INSTANT.nsteps_x5.np1.2023-02-17-00000.nc
          JGF lookup_pio_atm_file
              JGF lookup_pio_atm_file loop io_packed_ps1.INSTANT.nsteps_x5.np1.2023-02-17-00000.nc
          JGF while deleting io_packed_ps1.INSTANT.nsteps_x5.np1.2023-02-17-00000.nc num customers=4
       JGF deallocating io_packed_ps1.INSTANT.nsteps_x5.np1.2023-02-17-00000.nc
   JGF closing all files loop io_packed_ps2.INSTANT.nsteps_x5.np1.2023-02-17-00000.nc
       JGF Deleting list item io_packed_ps2.INSTANT.nsteps_x5.np1.2023-02-17-00000.nc   
          JGF lookup_pio_atm_file
          JGF lookup_pio_atm_file loop io_packed_ps1.INSTANT.nsteps_x5.np1.2023-02-17-00000.nc <-- VALGRIND ERR
```

In English, the loop in `eam_pio_finalize` calls `eam_pio_closefile` but closefile does not deallocate the file because num_customers > 1 (it's 4 in this case). Because it did not deallocate, the `pio_file_list_front` is not changed. `eam_pio_finalize` later forces deallocation but does not update `pio_file_list_front`, so subsequent calls to `lookup_pio_atm_file` iterate over the deallocated items.

This PR changes the `eam_pio_finalize` loop to ensure `pio_file_list_front` does not point to a deallocated item. I'm not 100% sure the code is bug free because in the opposite case, where num_customers=1, I think the file will be deallocated twice.