### PR TITLE
Switch to C++17 from C++14(!)

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -51,12 +51,7 @@ endif()
 # to be on. For now, simply ensure Kokkos Serial is enabled
 option (Kokkos_ENABLE_SERIAL "" ON)
 
-# MAM support requires C++17 -- hopefully SCREAM itself will get there soon
-if (SCREAM_ENABLE_MAM)
-  set(CMAKE_CXX_STANDARD 17)
-else()
-  set(CMAKE_CXX_STANDARD 14)
-endif()
+set(CMAKE_CXX_STANDARD 17)
 
 if (NOT SCREAM_CIME_BUILD)
   project(SCREAM CXX C Fortran)


### PR DESCRIPTION
This is a single-character-change PR, tied for the smallest in this repository's history.

This single character switches to C++17, which brings (checks notes) improved support for lambdas, which I believe our EAGLES-related work happens to need. But also, Kokkos is switching over to C++17, so this change is in our future even if it's a bit too early yet.

Let's see what the testing system has to say.

Closes #2233