### PR TITLE
Verify input file has same dimensions as populated fields

### DIFF
--- a/components/eamxx/src/share/grid/remap/horizontal_remap_utility.hpp
+++ b/components/eamxx/src/share/grid/remap/horizontal_remap_utility.hpp
@@ -38,7 +38,7 @@ struct HorizontalMapSegment {
   HorizontalMapSegment(const gid_type dof_gid, const int length, const view_1d<const gid_type>& source_dofs, const view_1d<const Real>& weights);
 
   // Helper Functions
-  bool check() const;      // Check if this segment is valid
+  bool check() const;  // Check if this segment is valid
   void print() const;  // Useful for debugging, print the segment mapping info
 
   // Setter Functions

--- a/components/eamxx/src/share/io/scorpio_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_input.hpp
@@ -172,6 +172,7 @@ protected:
 
   bool m_inited_with_fields        = false;
   bool m_inited_with_views         = false;
+  bool m_skip_grid_chk;
 }; // Class AtmosphereInput
 
 } //namespace scream

--- a/components/eamxx/src/share/io/scorpio_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_input.hpp
@@ -149,6 +149,7 @@ protected:
 
   void register_variables();
   void set_degrees_of_freedom();
+  void check_layout_dimensions(const std::string& name,const FieldLayout& layout);
 
   std::vector<std::string> get_vec_of_dims (const FieldLayout& layout);
   std::string get_io_decomp (const FieldLayout& layout);

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -11,7 +11,7 @@ Time Stepping:
 
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc  ## WARNING!!! this test runs ne2 not ne4, so this topo file is wrong.
   surf_evap: 0.0
   surf_sens_flux: 0.0
   precip_ice_surf_mass: 0.0

--- a/components/eamxx/tests/uncoupled/homme/CMakeLists.txt
+++ b/components/eamxx/tests/uncoupled/homme/CMakeLists.txt
@@ -2,7 +2,7 @@ include (ScreamUtils)
 
 # Get or create the dynamics lib
 #                 HOMME_TARGET   NP PLEV QSIZE_D
-CreateDynamicsLib("theta-l_kokkos"  4   72   10)
+CreateDynamicsLib("theta-l_kokkos"  4   128   10)
 
 # Create the test
 set (TEST_LABELS "dynamics;driver")
@@ -49,15 +49,15 @@ set (HOMME_TEST_MOISTURE notdry)
 set (HOMME_THETA_HY_MODE .true.)
 
 # Vert coord settings
-set (HOMME_TEST_VCOORD_INT_FILE acme-72i.ascii)
-set (HOMME_TEST_VCOORD_MID_FILE acme-72m.ascii)
+set (HOMME_TEST_VCOORD_INT_FILE acme-128i.ascii)
+set (HOMME_TEST_VCOORD_MID_FILE acme-128m.ascii)
 
 # Configure the namelist into the test directory
 configure_file(${SCREAM_BASE_DIR}/src/dynamics/homme/tests/theta.nl
                ${CMAKE_CURRENT_BINARY_DIR}/namelist.nl)
 
 # Ensure test input files are present in the data dir
-GetInputFile(scream/init/${EAMxx_tests_IC_FILE_72lev})
+GetInputFile(scream/init/${EAMxx_tests_IC_FILE_128lev})
 GetInputFile(cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc)
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC

--- a/components/eamxx/tests/uncoupled/homme/input.yaml
+++ b/components/eamxx/tests/uncoupled/homme/input.yaml
@@ -10,8 +10,8 @@ Time Stepping:
   Number of Steps: ${NUM_STEPS}
 
 initial_conditions:
-  Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
+  Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc  ## WARNING!!! this test runs ne2 not ne4, so this topo file is wrong.
 
 atmosphere_processes:
   atm_procs_list: (Dynamics)

--- a/components/eamxx/tests/uncoupled/p3/input.yaml
+++ b/components/eamxx/tests/uncoupled/p3/input.yaml
@@ -16,7 +16,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  number_of_global_columns:   218
+  number_of_global_columns:   866
   number_of_vertical_levels:  72  # Will want to change to 128 when a valid unit test is available.
 
 initial_conditions:

--- a/components/eamxx/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/eamxx/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -42,7 +42,7 @@ if (NOT SCREAM_BASELINES_ONLY)
 
   ## Add a standalone test with chunked columns, and compare against non-chunked
   set (SUFFIX "_chunked")
-  math (EXPR COL_PER_RANK "218 / ${TEST_RANK_END}")
+  math (EXPR COL_PER_RANK "866 / ${TEST_RANK_END}")
   math (EXPR COL_CHUNK_SIZE "${COL_PER_RANK} / 2")
   if (COL_CHUNK_SIZE LESS 1)
     message (FATAL_ERROR "Error! Chunk size for rrtmgp unit test is less than 1.")

--- a/components/eamxx/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/eamxx/tests/uncoupled/rrtmgp/input.yaml
@@ -27,7 +27,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  number_of_global_columns: 218
+  number_of_global_columns: 866
   number_of_vertical_levels: 72
   geo_data_source: IC_FILE
 

--- a/components/eamxx/tests/uncoupled/shoc/input.yaml
+++ b/components/eamxx/tests/uncoupled/shoc/input.yaml
@@ -16,7 +16,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  number_of_global_columns:   218
+  number_of_global_columns:   866
   number_of_vertical_levels:  72  # Will want to change to 128 when a valid unit test is available.
   geo_data_source: IC_FILE
 

--- a/components/eamxx/tests/uncoupled/spa/CMakeLists.txt
+++ b/components/eamxx/tests/uncoupled/spa/CMakeLists.txt
@@ -22,7 +22,7 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/spa_standalone_output.yaml
 
 # Ensure test input files are present in the data dir
 set (TEST_INPUT_FILES
-  ${EAMxx_tests_IC_FILE_72lev}
+  ${EAMxx_tests_IC_FILE_128lev}
   map_ne4np4_to_ne2np4_mono.nc
   spa_file_unified_and_complete_ne4_20220428.nc
 )

--- a/components/eamxx/tests/uncoupled/spa/input.yaml
+++ b/components/eamxx/tests/uncoupled/spa/input.yaml
@@ -17,12 +17,12 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  number_of_global_columns:   218
-  number_of_vertical_levels:  72
+  number_of_global_columns:  218 
+  number_of_vertical_levels: 128
 
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
-  Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
+  Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/surface_coupling/input.yaml
+++ b/components/eamxx/tests/uncoupled/surface_coupling/input.yaml
@@ -13,7 +13,7 @@ atmosphere_processes:
 
 grids_manager:
   Type: Mesh Free
-  number_of_global_columns:   218
+  number_of_global_columns:   866
   number_of_vertical_levels:  72  # Will want to change to 128 when a valid unit test is available.
 
 initial_conditions:


### PR DESCRIPTION
This commit introduces a check to scorpio_input.h/cpp that checks the dimension lengths in the input file against the dimension lengths of individual fields to be populated.  If they don't match then it throws an error.

This should remove the hacky/buggy feature that allowed some tests to use an initial condition file with number of columns = X but declare the problem size to have number of columns = Y, where X != Y.

It also stops a user from accidentally using an initial condition file that does not match the problem they are running.

Lastly, this commit updates the input.yaml control files for all of the standalone tests that were doing exactly that.

Fixes #1329 