### PR TITLE
atmchange: Add support for empty lists, reset option

### DIFF
--- a/components/eamxx/cime_config/buildnml
+++ b/components/eamxx/cime_config/buildnml
@@ -20,13 +20,13 @@ Some import errors are expected and can be ignored
 
 It is encouraged that any changes to this system be tested with
 eamxx/cime-nml-tests
-
 """
 
-import os
+import os, sys
 
 from CIME.case import Case
 from CIME.utils import expect, safe_copy, SharedArea, run_cmd_no_fail
+from CIME.buildlib import parse_input
 
 from eamxx_buildnml import create_raw_xml_file, create_input_files, create_input_data_list_file, \
     do_cime_vars_on_yaml_output_files

--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -742,7 +742,7 @@ def do_cime_vars_on_yaml_output_files(case,caseroot):
 
     scorpio = get_child(eamxx_xml,'Scorpio')
     out_files_xml = get_child(scorpio,"output_yaml_files",must_exist=False)
-    out_files = out_files_xml.text.split(",") if out_files_xml is not None else []
+    out_files = out_files_xml.text.split(",") if (out_files_xml is not None and out_files_xml.text is not None) else []
 
     # We will also change the 'output_yaml_files' entry in scream_input.yaml,
     # to point to the copied files in $rundir/data

--- a/components/eamxx/cime_config/eamxx_buildnml_impl.py
+++ b/components/eamxx/cime_config/eamxx_buildnml_impl.py
@@ -192,6 +192,7 @@ def refine_type(entry, force_type=None):
 ###############################################################################
     """
     Try to convert the text entry to the appropriate type based on its contents.
+
     >>> e = '(a,b)'
     >>> refine_type(e)==e
     True
@@ -221,27 +222,40 @@ def refine_type(entry, force_type=None):
     CIME.utils.CIMEError: ERROR: Error! Invalid type 'logical' for an array.
     >>> refine_type(e,'array(logical)')
     [True, False]
+    >>> refine_type('', 'array(string)')
+    []
+    >>> refine_type('', 'array(float)')
+    []
+    >>> refine_type(None, 'array(float)')
+    []
     """
     # We want to preserve strings representing lists
-    if (entry[0]=="(" and entry[-1]==")") or \
-       (entry[0]=="[" and entry[-1]=="]") :
-        expect (force_type is None or force_type == "string",
-                "Error! Invalid force type '{}' for a string representing a list"
-                .format(force_type))
-        return entry
 
-    if "," in entry:
-        expect (force_type is None or is_array_type(force_type),
-                "Error! Invalid type '{}' for an array.".format(force_type))
+    if entry:
 
-        elem_type = force_type if force_type is None else array_elem_type(force_type)
-        result = [refine_type(item.strip(), force_type=elem_type) for item in entry.split(",") if item.strip() != ""]
-        expected_type = type(result[0])
-        for item in result[1:]:
-            expect(isinstance(item, expected_type),
-                  "List '{}' has inconsistent types inside".format(entry))
+        if (entry[0]=="(" and entry[-1]==")") or \
+           (entry[0]=="[" and entry[-1]=="]") :
+            expect (force_type is None or force_type == "string",
+                    "Error! Invalid force type '{}' for a string representing a list"
+                    .format(force_type))
+            return entry
 
-        return result
+        if "," in entry:
+            expect (force_type is None or is_array_type(force_type),
+                    "Error! Invalid type '{}' for an array.".format(force_type))
+
+            elem_type = force_type if force_type is None else array_elem_type(force_type)
+            result = [refine_type(item.strip(), force_type=elem_type) for item in entry.split(",") if item.strip() != ""]
+            expected_type = type(result[0])
+            for item in result[1:]:
+                expect(isinstance(item, expected_type),
+                      "List '{}' has inconsistent types inside".format(entry))
+
+            return result
+
+    elif force_type is not None and is_array_type(force_type):
+
+        return []
 
     if force_type:
         try:

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -17,10 +17,17 @@ from atm_manip import get_xml_node, atm_config_chg_impl
 from utils import run_cmd_no_fail, expect
 
 ###############################################################################
-def atm_config_chg(changes, no_buffer=False):
+def atm_config_chg(changes, no_buffer=False, reset=False):
 ###############################################################################
     expect(os.path.exists("namelist_scream.xml"),
-           "No pwd/namelist_scream.xml file is present. Please rum from a case dir that has been setup")
+           "No pwd/namelist_scream.xml file is present. Please run from a case dir that has been set up")
+
+    if reset:
+        run_cmd_no_fail(f"./xmlchange SCREAM_ATMCHANGE_BUFFER=''")
+        print("All buffered atmchanges have been removed. A fresh namelist_scream.xml will be generated the next time buildnml (case.setup) is run.")
+        return True
+    else:
+        expect(changes, "Missing <param>=<val> args")
 
     with open("namelist_scream.xml", "r") as fd:
         tree = ET.parse(fd)
@@ -66,7 +73,14 @@ OR
         help="Used by buildnml to replay buffered commands",
     )
 
-    parser.add_argument("changes", nargs="+", help="Values to change")
+    parser.add_argument(
+        "--reset",
+        default=False,
+        action="store_true",
+        help="Forget all previous atmchanges",
+    )
+
+    parser.add_argument("changes", nargs="*", help="Values to change")
 
     return parser.parse_args(args[1:])
 

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -23,8 +23,13 @@ def atm_config_chg(changes, no_buffer=False, reset=False):
            "No pwd/namelist_scream.xml file is present. Please run from a case dir that has been set up")
 
     if reset:
-        run_cmd_no_fail(f"./xmlchange SCREAM_ATMCHANGE_BUFFER=''")
+        run_cmd_no_fail("./xmlchange SCREAM_ATMCHANGE_BUFFER=''")
         print("All buffered atmchanges have been removed. A fresh namelist_scream.xml will be generated the next time buildnml (case.setup) is run.")
+        hack_xml = run_cmd_no_fail("./xmlquery SCREAM_HACK_XML --value")
+        if hack_xml == "TRUE":
+            print("SCREAM_HACK_XML is on. Removing namelist_scream.xml to force regen")
+            os.remove("namelist_scream.xml")
+
         return True
     else:
         expect(changes, "Missing <param>=<val> args")

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -60,7 +60,7 @@ class TestBuildnml(unittest.TestCase):
         return cases[0] if len(cases) == 1 else cases
 
     ###########################################################################
-    def _chg_atmconfig(self, changes, case, buff=True, expect_lost=False):
+    def _chg_atmconfig(self, changes, case, buff=True, reset=False, expect_lost=False):
     ###########################################################################
         buffer_opt = "" if buff else "--no-buffer"
 
@@ -71,6 +71,9 @@ class TestBuildnml(unittest.TestCase):
             run_cmd_assert_result(self, f"./atmchange {buffer_opt} {name}={value}", from_dir=case)
             curr_value = run_cmd_assert_result(self, f"./atmquery {name} --value", from_dir=case)
             self.assertEqual(curr_value, value)
+
+        if reset:
+            run_cmd_assert_result(self, "./atmchange --reset", from_dir=case)
 
         run_cmd_assert_result(self, "./case.setup", from_dir=case)
 
@@ -154,6 +157,17 @@ class TestBuildnml(unittest.TestCase):
 
         # An unbuffered atmchange is semantically the same as a manual edit
         self._chg_atmconfig([("atm_log_level", "trace")], case, buff=False, expect_lost=True)
+
+    ###########################################################################
+    def test_reset_atmchanges_are_lost(self):
+    ###########################################################################
+        """
+        Test that manual atmchanges are lost when eamxx setup is called
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+
+        # An unbuffered atmchange is semantically the same as a manual edit
+        self._chg_atmconfig([("atm_log_level", "trace")], case, reset=True, expect_lost=True)
 
     ###########################################################################
     def test_manual_atmchanges_are_not_lost_hack_xml(self):


### PR DESCRIPTION
You can set a list/array variable to empty via:
`./atmchange varname=''`

