### PR TITLE
Fix FieldAtLevel diagnostic

### DIFF
--- a/components/eamxx/src/diagnostics/field_at_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_level.cpp
@@ -13,6 +13,10 @@ FieldAtLevel::FieldAtLevel (const ekat::Comm& comm, const ekat::ParameterList& p
 {
   m_field_name  = m_params.get<std::string>("Field Name");
 
+  EKAT_REQUIRE_MSG (m_field_layout.rank()>1 && m_field_layout.rank()<=6,
+      "Error! Field rank not supported by FieldAtLevel.\n"
+      " - field name: " + m_field_name + "\n"
+      " - field layout: " + to_string(m_field_layout) + "\n");
   using namespace ShortFieldTagsNames;
   EKAT_REQUIRE_MSG (ekat::contains(std::vector<FieldTag>{LEV,ILEV},m_field_layout.tags().back()),
       "Error! FieldAtLevel diagnostic expects a layout ending with 'LEV'/'ILEV' tag.\n"
@@ -21,7 +25,7 @@ FieldAtLevel::FieldAtLevel (const ekat::Comm& comm, const ekat::ParameterList& p
 }
 
 // =========================================================================================
-void FieldAtLevel::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
+void FieldAtLevel::set_grids(const std::shared_ptr<const GridsManager> /* grids_manager */)
 {
   const auto& gname  = m_params.get<std::string>("Grid Name");
 
@@ -53,17 +57,81 @@ void FieldAtLevel::set_grids(const std::shared_ptr<const GridsManager> grids_man
 void FieldAtLevel::compute_diagnostic_impl()
 {
   const auto& f = get_field_in(m_field_name);
-  auto f_data = f.get_internal_view_data<const Real>();
-  auto d_data = m_diagnostic_output.get_internal_view_data<Real>();
-  auto f_size = f.get_header().get_alloc_properties().get_num_scalars();
-  auto stride = f.get_header().get_alloc_properties().get_last_extent();
-  auto d_size = f_size/stride;
+  const int dsize = m_field_layout.size () / m_field_layout.dims().back();
+  using RangePolicy = Kokkos::RangePolicy<Field::device_t::execution_space>;
+  RangePolicy policy(0,dsize);
   auto level  = m_field_level;
-  Kokkos::parallel_for(m_diagnostic_output.name(),
-                       Kokkos::RangePolicy<>(0,d_size),
-                       KOKKOS_LAMBDA(const int& idx) {
-    d_data[idx] = f_data[idx*stride + level];
-  });
+  switch (m_field_layout.rank()) {
+    case 2:
+      {
+        auto f_view = f.get_view<const Real**>();
+        auto d_view = m_diagnostic_output.get_view<      Real*>();
+        Kokkos::parallel_for(m_diagnostic_output.name(),policy,KOKKOS_LAMBDA(const int idx) {
+            d_view(idx) = f_view(idx,level);
+        });
+      }
+      break;
+    case 3:
+      {
+        auto f_view = f.get_view<const Real***>();
+        auto d_view = m_diagnostic_output.get_view<      Real**>();
+        const int dim1 = m_field_layout.dims()[1];
+        Kokkos::parallel_for(m_diagnostic_output.name(),policy,KOKKOS_LAMBDA(const int idx) {
+            const int i = idx / dim1;
+            const int j = idx % dim1;
+            d_view(i,j) = f_view(i,j,level);
+        });
+      }
+      break;
+    case 4:
+      {
+        auto f_view = f.get_view<const Real****>();
+        auto d_view = m_diagnostic_output.get_view<      Real***>();
+        const int dim1 = m_field_layout.dims()[1];
+        const int dim2 = m_field_layout.dims()[2];
+        Kokkos::parallel_for(m_diagnostic_output.name(),policy,KOKKOS_LAMBDA(const int idx) {
+            const int i = (idx / dim2) / dim1;
+            const int j = (idx / dim2) % dim1;
+            const int k =  idx % dim2;
+            d_view(i,j,k) = f_view(i,j,k,level);
+        });
+      }
+      break;
+    case 5:
+      {
+        auto f_view = f.get_view<const Real*****>();
+        auto d_view = m_diagnostic_output.get_view<      Real****>();
+        const int dim1 = m_field_layout.dims()[1];
+        const int dim2 = m_field_layout.dims()[2];
+        const int dim3 = m_field_layout.dims()[3];
+        Kokkos::parallel_for(m_diagnostic_output.name(),policy,KOKKOS_LAMBDA(const int idx) {
+            const int i = ((idx / dim3) / dim2) / dim1;
+            const int j = ((idx / dim3) / dim2) % dim1;
+            const int k =  (idx / dim3) % dim2;
+            const int l =   idx % dim3;
+            d_view(i,j,k,l) = f_view(i,j,k,l,level);
+        });
+      }
+      break;
+    case 6:
+      {
+        auto f_view = f.get_view<const Real******>();
+        auto d_view = m_diagnostic_output.get_view<      Real*****>();
+        const int dim1 = m_field_layout.dims()[1];
+        const int dim2 = m_field_layout.dims()[2];
+        const int dim3 = m_field_layout.dims()[3];
+        const int dim4 = m_field_layout.dims()[4];
+        Kokkos::parallel_for(m_diagnostic_output.name(),policy,KOKKOS_LAMBDA(const int idx) {
+            const int i = (((idx / dim4) / dim3) / dim2) / dim1;
+            const int j = (((idx / dim4) / dim3) / dim2) % dim1;
+            const int k =  ((idx / dim4) / dim3) % dim2;
+            const int l =   (idx / dim4) % dim3;
+            const int m =    idx / dim4;
+            d_view(i,j,k,l,m) = f_view(i,j,k,l,m,level);
+        });
+      }
+      break;
+  }
   Kokkos::fence();
 }
 

--- a/components/eamxx/src/diagnostics/tests/field_at_level_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_level_tests.cpp
@@ -46,7 +46,7 @@ TEST_CASE("field_at_level")
   // Create input fields
   const auto units = ekat::units::Units::invalid();
 
-  FieldIdentifier fid_mid ("M",FL({COL,LEV},{ncols,nlevs}),units,grid->name());
+  FieldIdentifier fid_mid ("M",FL({COL,CMP,LEV},{ncols,2,nlevs}),units,grid->name());
   FieldIdentifier fid_int ("I",FL({COL,LEV},{ncols,nlevs}),units,grid->name());
 
   Field f_mid (fid_mid);
@@ -68,10 +68,12 @@ TEST_CASE("field_at_level")
   randomize(f_mid,engine,pdf);
   randomize(f_int,engine,pdf);
 
+  auto f_mid_1 = f_mid.get_component(1);
+
   ekat::ParameterList params_mid, params_int;
-  params_mid.set("Field Name",f_mid.name());
+  params_mid.set("Field Name",f_mid_1.name());
   params_mid.set("Field Units",fid_mid.get_units());
-  params_mid.set("Field Layout",fid_mid.get_layout());
+  params_mid.set("Field Layout",fid_mid.get_layout().strip_dim(CMP));
   params_mid.set("Grid Name",fid_mid.get_grid_name());
   params_int.set("Field Name",f_int.name());
   params_int.set("Field Units",fid_int.get_units());
@@ -104,7 +106,7 @@ TEST_CASE("field_at_level")
     diag_mid->set_grids(gm);
     diag_int->set_grids(gm);
 
-    diag_mid->set_required_field(f_mid);
+    diag_mid->set_required_field(f_mid_1);
     diag_int->set_required_field(f_int);
 
     diag_mid->initialize(t0,RunType::Initial);
@@ -120,7 +122,7 @@ TEST_CASE("field_at_level")
     d_mid.sync_to_host();
     d_int.sync_to_host();
 
-    auto f_mid_v = f_mid.get_view<const Real**,Host>();
+    auto f_mid_v = f_mid_1.get_view<const Real**,Host>();
     auto f_int_v = f_int.get_view<const Real**,Host>();
     auto d_mid_v = d_mid.get_view<const Real*,Host>();
     auto d_int_v = d_int.get_view<const Real*,Host>();


### PR DESCRIPTION
The previous impl was implicitly assuming the input field alloc was contiguous (which is not true for subfields).

I changed also the unit test, so that the midpoint field is a subfield of another field, and verified that in such condition the original impl was giving the wrong answer.

Fixes #2230 