### PR TITLE
Only use np4pg2 topography files

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -302,23 +302,30 @@ be lost if SCREAM_HACK_XML is not enabled.
     <Filename hgrid="ne30np4" COMPSET=".*SCREAM%AQUA.*">${DIN_LOC_ROOT}/atm/scream/init/screami_aquaplanet_ne30np4L128_20220823.nc</Filename> <!-- This will need to be updated to the new nccn name -->
     <Filename hgrid="ne0np4_conus_x4v1_lowcon" nlev="72">${DIN_LOC_ROOT}/atm/scream/init/screami_conusx4v1np4L72-topo12x_013023.nc</Filename>
 
+    <!-- List of default topography files on specific grids -->
     <topography_filename type="file">UNSET</topography_filename>
-    <topography_filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc</topography_filename>
-    <topography_filename hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc</topography_filename>
-    <topography_filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne30np4_16xdel2-PFC-consistentSGH.nc</topography_filename>
-    <topography_filename hgrid="ne30np4.pg2">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne30np4pg2_16xdel2.c20200108.nc</topography_filename>
-    <topography_filename hgrid="ne30np4.pg2" COMPSET=".*X6T*">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne30np4pg2_x6t-SGH.nc</topography_filename>
-    <topography_filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc</topography_filename>
-    <topography_filename hgrid="ne120np4.pg2">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne120np4pg2_16xdel2.nc</topography_filename>
-    <topography_filename hgrid="ne256np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne256np4_16xdel2_consistentSGH_20220429.nc</topography_filename>
-    <topography_filename hgrid="ne256np4.pg2">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne256np4pg2_16xdel2_20200213.nc</topography_filename>
-    <topography_filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne512np4_16xconsistentSGH_20190212.nc</topography_filename>
-    <topography_filename hgrid="ne512np4.pg2">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne512np4pg2_16xconsistentSGH_20190212_converted.nc</topography_filename>
-    <topography_filename hgrid="ne1024np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne1024np4_16xconsistentSGH_20190528.nc</topography_filename>
-    <topography_filename hgrid="ne1024np4.pg2">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne1024np4pg2_16xconsistentSGH_20190528_converted.nc</topography_filename>
-    <topography_filename hgrid="ne1024np4.pg2" COMPSET=".*X6T*">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne1024np4pg2_x6t-SGH.nc</topography_filename>
-    <topography_filename COMPSET=".*SCREAM%AQUA.*">UNSET</topography_filename>
     <topography_filename hgrid="ne0np4_conus_x4v1_lowcon">${DIN_LOC_ROOT}/atm/cam/topo/USGS_conusx4v1pg2_12x_consistentSGH_20200609.nc</topography_filename>
+    <topography_filename hgrid="ne4np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc</topography_filename>
+    <topography_filename hgrid="ne30np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne30np4pg2_16xdel2.c20200108.nc</topography_filename>
+    <topography_filename hgrid="ne120np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne120np4pg2_16xdel2.nc</topography_filename>
+    <topography_filename hgrid="ne256np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne256np4pg2_16xdel2_20200213.nc</topography_filename>
+    <topography_filename hgrid="ne512np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne512np4pg2_16xconsistentSGH_20190212_converted.nc</topography_filename>
+    <topography_filename hgrid="ne1024np4">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne1024np4pg2_16xconsistentSGH_20190528_converted.nc</topography_filename>
+
+    <!-- In the case that *-X6T compset is requested: -->
+    <!-- The following grid have x6t topography files -->
+    <topography_filename hgrid="ne30np4" COMPSET=".*X6T*">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne30np4pg2_x6t-SGH.nc</topography_filename>
+    <topography_filename hgrid="ne256np4" COMPSET=".*X6T*">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne256np4pg2_x6t-SGH.nc</topography_filename>
+    <topography_filename hgrid="ne1024np4" COMPSET=".*X6T*">${DIN_LOC_ROOT}/atm/cam/topo/USGS-gtopo30_ne1024np4pg2_x6t-SGH.nc</topography_filename>
+    <!-- The following grids don't have x6t topography files. An error will be thrown
+         if the user attempts to run x6t compset without providing the field "phis". -->
+    <topography_filename hgrid="ne0np4_conus_x4v1_lowcon" COMPSET=".*X6T*">UNSET</topography_filename>
+    <topography_filename hgrid="ne4np4" COMPSET=".*X6T*">UNSET</topography_filename>
+    <topography_filename hgrid="ne120np4" COMPSET=".*X6T*">UNSET</topography_filename>
+    <topography_filename hgrid="ne512np4" COMPSET=".*X6T*">UNSET</topography_filename>
+
+    <!-- For aquaplanet run, unset the topography_filename and set phis=0 -->
+    <topography_filename COMPSET=".*SCREAM%AQUA.*">UNSET</topography_filename>
     <phis COMPSET=".*SCREAM%AQUA.*">0.0</phis>
 
     <restart_casename>${CASE}.scream</restart_casename>

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -877,17 +877,18 @@ void AtmosphereDriver::set_initial_conditions ()
 
       if (fname == "phis") {
         // Topography (phis) is a special case that should
-        // be loaded from the topography file, where the 
-	// eamxx field "phis" corresponds to the name 
-	// "PHIS_d" on the GLL grid and "PHIS" on the PG2 
-	// grid in the topography file.
+        // be loaded from the topography file, where the
+        // eamxx field "phis" corresponds to the name
+        // "PHIS_d" on the GLL and Point grids and "PHIS"
+        // on the PG2 grid in the topography file.
         if (grid_name == "Physics PG2") {
           this_grid_topo_file_fnames.push_back("PHIS");
-        } else if (grid_name == "Physics GLL") {
+        } else if (grid_name == "Physics GLL" ||
+                   grid_name == "Point Grid") {
           this_grid_topo_file_fnames.push_back("PHIS_d");
         } else {
           EKAT_ERROR_MSG ("Error! Requesting phis on an unknown grid: " + grid_name + ".\n");
-	}
+        }
         this_grid_topo_eamxx_fnames.push_back("phis");
       } else if (c.size()==0) {
         // If this field is the parent of other subfields, we only read from file the subfields.

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -843,8 +843,8 @@ void AtmosphereDriver::set_initial_conditions ()
   std::map<std::string,std::vector<std::string>> fields_inited;
 
   // Check which fields should be loaded from the topography file
-  std::map<std::string,std::vector<std::string>> topography_fields_names_nc;
-  std::map<std::string,std::vector<std::string>> topography_fields_names_eamxx;
+  std::map<std::string,std::vector<std::string>> topography_file_fields_names;
+  std::map<std::string,std::vector<std::string>> topography_eamxx_fields_names;
 
   // Helper lambda, to reduce code duplication
   auto process_ic_field = [&](const Field& f) {
@@ -870,22 +870,25 @@ void AtmosphereDriver::set_initial_conditions ()
       }
     } else if (not (fvphyshack and grid_name == "Physics PG2")) {
       auto& this_grid_ic_fnames = ic_fields_names[grid_name];
-      auto& this_grid_topo_fnames_nc = topography_fields_names_nc[grid_name];
-      auto& this_grid_topo_fnames_eamxx = topography_fields_names_eamxx[grid_name];
+      auto& this_grid_topo_file_fnames = topography_file_fields_names[grid_name];
+      auto& this_grid_topo_eamxx_fnames = topography_eamxx_fields_names[grid_name];
 
       auto c = f.get_header().get_children();
 
       if (fname == "phis") {
         // Topography (phis) is a special case that should
-        // be loaded from the topography file (assuming
-        // input files doesn't contain a value).
-        if (fvphyshack) {
-          this_grid_topo_fnames_nc.push_back("PHIS_d");
-          this_grid_topo_fnames_eamxx.push_back("phis");
+        // be loaded from the topography file, where the 
+	// eamxx field "phis" corresponds to the name 
+	// "PHIS_d" on the GLL grid and "PHIS" on the PG2 
+	// grid in the topography file.
+        if (grid_name == "Physics PG2") {
+          this_grid_topo_file_fnames.push_back("PHIS");
+        } else if (grid_name == "Physics GLL") {
+          this_grid_topo_file_fnames.push_back("PHIS_d");
         } else {
-          this_grid_topo_fnames_nc.push_back("PHIS");
-          this_grid_topo_fnames_eamxx.push_back("phis");
-       }
+          EKAT_ERROR_MSG ("Error! Requesting phis on an unknown grid: " + grid_name + ".\n");
+	}
+        this_grid_topo_eamxx_fnames.push_back("phis");
       } else if (c.size()==0) {
         // If this field is the parent of other subfields, we only read from file the subfields.
         if (not ekat::contains(this_grid_ic_fnames,fname)) {
@@ -1036,8 +1039,8 @@ void AtmosphereDriver::set_initial_conditions ()
     const auto& file_name = ic_pl.get<std::string>("topography_filename");
     for (const auto& it : m_field_mgrs) {
       const auto& grid_name = it.first;
-      read_fields_from_file (topography_fields_names_nc[grid_name],
-                             topography_fields_names_eamxx[grid_name],
+      read_fields_from_file (topography_file_fields_names[grid_name],
+                             topography_eamxx_fields_names[grid_name],
                              it.first,file_name,m_current_ts);
     }
     m_atm_logger->debug("    [EAMxx] Processing topography from file ... done!");
@@ -1047,7 +1050,7 @@ void AtmosphereDriver::set_initial_conditions ()
     // separate IC param entry isn't given for the field).
     for (const auto& it : m_field_mgrs) {
       const auto& grid_name = it.first;
-      EKAT_REQUIRE_MSG(topography_fields_names_nc[grid_name].size()==0,
+      EKAT_REQUIRE_MSG(topography_file_fields_names[grid_name].size()==0,
                       "Error! Topography data was requested in the FM, but no "
                       "topography_filename or entry matching the field name "
                       "was given in IC parameters.\n");

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/CMakeLists.txt
@@ -61,7 +61,7 @@ configure_file(${SCREAM_SRC_DIR}/dynamics/homme/tests/theta.nl
 
 # Ensure test input files are present in the data dir
 GetInputFile(scream/init/${EAMxx_tests_IC_FILE_72lev})
-GetInputFile(cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc)
+GetInputFile(cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc)
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if running with 2+ ranks configurations

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -14,7 +14,7 @@ Time Stepping:
 
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
   get_topo_from_file: true
   surf_evap: 0.0
   surf_sens_flux: 0.0

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -67,7 +67,7 @@ set (TEST_INPUT_FILES
   scream/init/map_ne4np4_to_ne2np4_mono.nc
   scream/init/spa_file_unified_and_complete_ne4_20220428.nc
   scream/init/${EAMxx_tests_IC_FILE_72lev}
-  cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
 )
 foreach (file IN ITEMS ${TEST_INPUT_FILES})
   GetInputFile(${file})

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -11,7 +11,7 @@ Time Stepping:
 
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
   surf_evap: 0.0
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/CMakeLists.txt
@@ -63,7 +63,7 @@ configure_file(${SCREAM_SRC_DIR}/dynamics/homme/tests/theta.nl
 set (TEST_INPUT_FILES
   scream/init/spa_file_unified_and_complete_ne4_20220428.nc
   scream/init/${EAMxx_tests_IC_FILE_128lev}
-  cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
 )
 foreach (file IN ITEMS ${TEST_INPUT_FILES})
   GetInputFile(${file})

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -11,7 +11,7 @@ Time Stepping:
 
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
   surf_evap: 0.0
   surf_sens_flux: 0.0
   precip_ice_surf_mass: 0.0

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/CMakeLists.txt
@@ -118,4 +118,4 @@ configure_file(${SCREAM_SRC_DIR}/dynamics/homme/tests/theta.nl
 
 # Ensure test input files are present in the data dir
 GetInputFile(scream/init/${EAMxx_tests_IC_FILE_72lev})
-GetInputFile(cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc)
+GetInputFile(cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc)

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -13,7 +13,7 @@ Time Stepping:
 
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
   Restart Run: false
   surf_evap: 0.0
   surf_sens_flux: 0.0

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -13,7 +13,7 @@ Time Stepping:
 
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
   Restart Run: false
   surf_evap: 0.0
   surf_sens_flux: 0.0

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/CMakeLists.txt
@@ -5,7 +5,7 @@ CreateUnitTestExec (shoc_p3 shoc_p3.cpp "shoc;p3;scream_control;diagnostics")
 
 # Ensure test input files are present in the data dir
 GetInputFile(scream/init/${EAMxx_tests_IC_FILE_72lev})
-GetInputFile(cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc)
+GetInputFile(cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc)
 
 # Run a test with subcycling
 set (NUM_SUBCYCLES 3)

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -23,7 +23,7 @@ grids_manager:
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
   surf_evap: 0.0
   surf_sens_flux: 0.0
   precip_ice_surf_mass: 0.0

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/CMakeLists.txt
@@ -18,7 +18,7 @@ math (EXPR MAC_MIC_SUBCYCLES "(${ATM_TIME_STEP} + ${SHOC_MAX_DT} - 1) / ${SHOC_M
 
 # Ensure test input files are present in the data dir
 GetInputFile(scream/init/${EAMxx_tests_IC_FILE_72lev})
-GetInputFile(cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc)
+GetInputFile(cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc)
 
 ## Copy (and configure) yaml files needed by tests
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -38,7 +38,7 @@ grids_manager:
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
   surf_sens_flux: 0.0
   surf_evap: 0.0
   precip_ice_surf_mass: 0.0

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -22,7 +22,7 @@ set (TEST_INPUT_FILES
   scream/init/spa_init_ne2np4.nc
   scream/init/map_ne4np4_to_ne2np4_mono.nc
   scream/init/spa_file_unified_and_complete_ne4_20220428.nc
-  cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
 )
 foreach (file IN ITEMS ${TEST_INPUT_FILES})
   GetInputFile(${file})

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -38,7 +38,7 @@ grids_manager:
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
   surf_evap: 0.0
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0

--- a/components/eamxx/tests/uncoupled/homme/CMakeLists.txt
+++ b/components/eamxx/tests/uncoupled/homme/CMakeLists.txt
@@ -58,7 +58,7 @@ configure_file(${SCREAM_BASE_DIR}/src/dynamics/homme/tests/theta.nl
 
 # Ensure test input files are present in the data dir
 GetInputFile(scream/init/${EAMxx_tests_IC_FILE_72lev})
-GetInputFile(cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc)
+GetInputFile(cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc)
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC
 ## Only if running with 2+ ranks configurations

--- a/components/eamxx/tests/uncoupled/homme/input.yaml
+++ b/components/eamxx/tests/uncoupled/homme/input.yaml
@@ -11,7 +11,7 @@ Time Stepping:
 
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
 
 atmosphere_processes:
   atm_procs_list: (Dynamics)

--- a/components/eamxx/tests/uncoupled/shoc/CMakeLists.txt
+++ b/components/eamxx/tests/uncoupled/shoc/CMakeLists.txt
@@ -18,7 +18,7 @@ math (EXPR NUM_SUBCYCLES "(${ATM_TIME_STEP} + ${SHOC_MAX_DT} - 1) / ${SHOC_MAX_D
 
 # Ensure test input files are present in the data dir
 GetInputFile(scream/init/${EAMxx_tests_IC_FILE_72lev})
-GetInputFile(cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc)
+GetInputFile(cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)

--- a/components/eamxx/tests/uncoupled/shoc/input.yaml
+++ b/components/eamxx/tests/uncoupled/shoc/input.yaml
@@ -23,7 +23,7 @@ grids_manager:
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
   surf_sens_flux: 0.0
   surf_evap: 0.0
 

--- a/components/eamxx/tests/uncoupled/surface_coupling/CMakeLists.txt
+++ b/components/eamxx/tests/uncoupled/surface_coupling/CMakeLists.txt
@@ -10,7 +10,7 @@ CreateUnitTest(surface_coupling surface_coupling.cpp "${NEED_LIBS}" LABELS ${TES
 
 # Ensure test input files are present in the data dir
 GetInputFile(scream/init/${EAMxx_tests_IC_FILE_72lev})
-GetInputFile(cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc)
+GetInputFile(cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc)
 
 ## Copy (and configure) yaml files needed by tests
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml

--- a/components/eamxx/tests/uncoupled/surface_coupling/input.yaml
+++ b/components/eamxx/tests/uncoupled/surface_coupling/input.yaml
@@ -19,7 +19,7 @@ grids_manager:
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4_16x.c20160612.nc
+  topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
   # Some fields needed for the exports (not in ic file)
   precip_ice_surf_mass: 1.0
   precip_liq_surf_mass: 2.0


### PR DESCRIPTION
Previously, topography files of type `*np4_*` and `*np4pg2_*` were being used in `namelist_defaults_scream.yaml`, although the `*np4pg2_*` files contain both `PHIS` (PG2 nodes) and `PHIS_d` (GLL nodes). This is not ideal as, rough topography files only exist for `*np4pg2_*` type files in https://web.lcrc.anl.gov/public/e3sm/inputdata/atm/cam/topo/ collection. This caused a silent bug documented in issue https://github.com/E3SM-Project/scream/issues/2222 (fixed here).

Additionally, unset `topography_filename` if user request `*-X6T` compset, but on a grid which no rough topography file exists. This will throw an error if the user does not provide `phis`.

I tested on summit: 
- `ERS_Ln22.ne30_ne30.F2010-SCREAMv1` (fail, diffs)
- `ERS_Ln22.ne30pg2_ne30pg2.F2010-SCREAMv1-X6T` (pass)
 
The reason for the `ERS_Ln22.ne30_ne30.F2010-SCREAMv1` diffs is that the topo files change and `PHIS` in the np4-only file (used on master) does not match `PHIS_d` in the np4pg2 file (used in this PR). The ne4 tests in the AT should pass since I've verified `PHIS` in the np4-only file matches `PHIS_d` in the np4pg2 file for ne4. 