### PR TITLE
Fix all instances of .get<Real> to be .get<double>

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -369,8 +369,8 @@ void AtmosphereDriver::setup_column_conservation_checks ()
 
   // Get tolerances for mass and energy checks from driver_option parameters.
   auto& driver_options_pl = m_atm_params.sublist("driver_options");
-  const Real mass_error_tol   = driver_options_pl.get<Real>("mass_column_conservation_error_tolerance",   1e-10);
-  const Real energy_error_tol = driver_options_pl.get<Real>("energy_column_conservation_error_tolerance", 1e-14);
+  const Real mass_error_tol   = driver_options_pl.get<double>("mass_column_conservation_error_tolerance",   1e-10);
+  const Real energy_error_tol = driver_options_pl.get<double>("energy_column_conservation_error_tolerance", 1e-14);
 
   // Create energy checker
   auto conservation_check =

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
@@ -13,7 +13,7 @@ FieldAtPressureLevel (const ekat::Comm& comm, const ekat::ParameterList& params)
  , m_field_name(m_params.get<std::string>("Field Name"))
  , m_field_layout(m_params.get<FieldLayout>("Field Layout"))
  , m_field_units(m_params.get<ekat::units::Units>("Field Units"))
- , m_pressure_level(m_params.get<Real>("Field Target Pressure"))
+ , m_pressure_level(m_params.get<double>("Field Target Pressure"))
 {
   using namespace ShortFieldTagsNames;
   EKAT_REQUIRE_MSG (ekat::contains(std::vector<FieldTag>{LEV,ILEV},m_field_layout.tags().back()),
@@ -24,7 +24,7 @@ FieldAtPressureLevel (const ekat::Comm& comm, const ekat::ParameterList& params)
   m_p_tgt = view_1d<mPack>("",1);
   Kokkos::deep_copy(m_p_tgt, m_pressure_level);
 
-  m_mask_val = m_params.get<Real>("mask_value",Real(std::numeric_limits<float>::max()/10.0));
+  m_mask_val = m_params.get<double>("mask_value",Real(std::numeric_limits<float>::max()/10.0));
 }
 
 // =========================================================================================

--- a/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
@@ -246,7 +246,7 @@ get_test_diag(const ekat::Comm& comm, std::shared_ptr<const FieldManager> fm, st
     params.set("Field Units",fid.get_units());
     params.set("Field Layout",fid.get_layout());
     params.set("Grid Name",fid.get_grid_name());
-    params.set<Real>("Field Target Pressure",plevel);
+    params.set<double>("Field Target Pressure",plevel);
     auto diag = std::make_shared<FieldAtPressureLevel>(comm,params);
     diag->set_grids(gm);
     diag->set_required_field(field);

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics_rayleigh_friction.cpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics_rayleigh_friction.cpp
@@ -12,8 +12,8 @@ void HommeDynamics::rayleigh_friction_init()
 {
   // Rayleigh friction paramaters
   m_rayk0     = m_params.get<int>("rayleigh_friction_vertical_level", 2);
-  m_raykrange = m_params.get<Real>("rayleigh_friction_range", 0.0);
-  m_raytau0   = m_params.get<Real>("rayleigh_friction_decay_time", 5.0);
+  m_raykrange = m_params.get<double>("rayleigh_friction_range", 0.0);
+  m_raytau0   = m_params.get<double>("rayleigh_friction_decay_time", 5.0);
 
   // If m_raytau0==0, then no Rayleigh friction is applied. Return.
   if (m_raytau0 == 0) return;

--- a/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -315,16 +315,16 @@ void RRTMGPRadiation::initialize_impl(const RunType /* run_type */) {
   m_orbital_mvelp = m_params.get<Int>("orbital_mvelp"       ,-9999);
 
   // Determine whether or not we are using a fixed solar zenith angle (positive value)
-  m_fixed_solar_zenith_angle = m_params.get<Real>("Fixed Solar Zenith Angle", -9999);
+  m_fixed_solar_zenith_angle = m_params.get<double>("Fixed Solar Zenith Angle", -9999);
 
   // Get prescribed surface values of greenhouse gases
-  m_co2vmr     = m_params.get<Real>("co2vmr", 388.717e-6);
-  m_n2ovmr     = m_params.get<Real>("n2ovmr", 323.141e-9);
-  m_ch4vmr     = m_params.get<Real>("ch4vmr", 1807.851e-9);
-  m_f11vmr     = m_params.get<Real>("f11vmr", 768.7644e-12);
-  m_f12vmr     = m_params.get<Real>("f12vmr", 531.2820e-12);
-  m_n2vmr      = m_params.get<Real>("n2vmr", 0.7906);
-  m_covmr      = m_params.get<Real>("covmr", 1.0e-7);
+  m_co2vmr     = m_params.get<double>("co2vmr", 388.717e-6);
+  m_n2ovmr     = m_params.get<double>("n2ovmr", 323.141e-9);
+  m_ch4vmr     = m_params.get<double>("ch4vmr", 1807.851e-9);
+  m_f11vmr     = m_params.get<double>("f11vmr", 768.7644e-12);
+  m_f12vmr     = m_params.get<double>("f12vmr", 531.2820e-12);
+  m_n2vmr      = m_params.get<double>("n2vmr", 0.7906);
+  m_covmr      = m_params.get<double>("covmr", 1.0e-7);
 
   // Whether or not to do MCICA subcolumn sampling
   m_do_subcol_sampling = m_params.get<bool>("do_subcol_sampling",true);
@@ -669,10 +669,10 @@ void RRTMGPRadiation::run_impl (const double dt) {
           // We read o3 in as a vmr already
         } else if (name == "n2") {
           // n2 prescribed as a constant value
-          Kokkos::deep_copy(d_vmr, m_params.get<Real>("n2vmr", 0.7906));
+          Kokkos::deep_copy(d_vmr, m_params.get<double>("n2vmr", 0.7906));
         } else if (name == "co") {
           // co prescribed as a constant value
-          Kokkos::deep_copy(d_vmr, m_params.get<Real>("covmr", 1.0e-7));
+          Kokkos::deep_copy(d_vmr, m_params.get<double>("covmr", 1.0e-7));
         } else {
           // This gives (dry) mass mixing ratios
           scream::physics::trcmix(

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -142,6 +142,16 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
     EKAT_REQUIRE_MSG (grid_found,
         "Error! Bad formatting of output yaml file. Missing 'Fields->$grid_name` sublist.\n");
   }
+  if (std::find(m_fields_names.begin(),m_fields_names.end(),"All")!=m_fields_names.end()) {
+    EKAT_REQUIRE_MSG(m_fields_names.size()==1,"Error!! scorpio_output - `All` is listed as output among other fields.  Please either use `All` for all fields or remove this entry.");
+    m_fields_names.clear();
+    const auto fm_sim = get_field_manager("sim");
+    for (auto it = fm_sim->begin();it!=fm_sim->end();it++) {
+      auto it_pair = *it;
+      m_fields_names.push_back(it_pair.second->name());
+    }
+    
+  }
   sort_and_check(m_fields_names);
 
   // Check if remapping and if so create the appropriate remapper 

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -142,16 +142,6 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
     EKAT_REQUIRE_MSG (grid_found,
         "Error! Bad formatting of output yaml file. Missing 'Fields->$grid_name` sublist.\n");
   }
-  if (std::find(m_fields_names.begin(),m_fields_names.end(),"All")!=m_fields_names.end()) {
-    EKAT_REQUIRE_MSG(m_fields_names.size()==1,"Error!! scorpio_output - `All` is listed as output among other fields.  Please either use `All` for all fields or remove this entry.");
-    m_fields_names.clear();
-    const auto fm_sim = get_field_manager("sim");
-    for (auto it = fm_sim->begin();it!=fm_sim->end();it++) {
-      auto it_pair = *it;
-      m_fields_names.push_back(it_pair.second->name());
-    }
-    
-  }
   sort_and_check(m_fields_names);
 
   // Check if remapping and if so create the appropriate remapper 

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1013,8 +1013,8 @@ create_diagnostic (const std::string& diag_field_name) {
     params.set("Grid Name",fid.get_grid_name());
     params.set("Field Layout",fid.get_layout());
     params.set("Field Units",fid.get_units());
-    params.set<Real>("Field Target Pressure", pres_level);
-    params.set<Real>("mask_value",m_fill_value);
+    params.set<double>("Field Target Pressure", pres_level);
+    params.set<double>("mask_value",m_fill_value);
   } else {
     diag_name = diag_field_name;
     m_diag_depends_on_diags[diag_field_name].resize(0);


### PR DESCRIPTION
This commit fixes an anticipated bug if we move to support single precision w/ dynamics, radiation and rayleigh_friction.  It changes any use of the parameter list getter .get<Real> with .get<double>.

Note, although we cast the getter as double, because the variable being defined is cast as Real we retain single precision.

Fixes #2234