### PR TITLE
EAMxx: fix test-all-scream report of failed tests

### DIFF
--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -888,7 +888,7 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
 
         for t,s in tests_success.items():
             if not s:
-                last_test = self.get_last_ctest_file(t,"Tests")
+                last_test = self.get_last_ctest_file(t,"TestsFailed")
                 last_build  = self.get_last_ctest_file(t,"Build")
                 last_config = self.get_last_ctest_file(t,"Configure")
                 if last_test is not None:


### PR DESCRIPTION
In case of failed tests, `test-all-scream` is supposed to print to screen a list of failed tests. However, it was looking at the wrong file, namely `LastTestsDisabled_XYZ.log` rather than `LastTestsFailed_XYZ.log`. This cause puzzling AT reports on PR pages, where standalone testing failed, but the only reported failed tests were the fake tests that were disabled.

I tested this PR by introducing an error in `field_tests.cpp` (which should cause a failure of that test), and checking the output in master vs this branch.

master:
```
Build type full_sp_debug failed at testing time. Here's a list of failed tests:
107:p3_baseline_f90_fake_omp16
108:p3_baseline_cxx_fake_omp16
143:shoc_baseline_f90_fake_omp16
144:shoc_baseline_cxx_fake_omp16
```
branch:
```
Build type full_sp_debug failed at testing time. Here's a list of failed tests:
32:field
```

Note: once this PR is integrated, unless you merge master in your branch, you will still see the fake tests reported as "failed" (rather than the ones that _actually_ failed).