### PR TITLE
Revert upgrade to CXX17

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -51,7 +51,12 @@ endif()
 # to be on. For now, simply ensure Kokkos Serial is enabled
 option (Kokkos_ENABLE_SERIAL "" ON)
 
-set(CMAKE_CXX_STANDARD 17)
+# MAM support requires C++17 -- hopefully SCREAM itself will get there soon
+if (SCREAM_ENABLE_MAM)
+  set(CMAKE_CXX_STANDARD 17)
+else()
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 if (NOT SCREAM_CIME_BUILD)
   project(SCREAM CXX C Fortran)


### PR DESCRIPTION
We hit some snags with regards to the CXX17 ugprade. In particular, we are getting a compilation error on crusher (for which we have a workaround), and an ICE on ascent. While we work on fixing these, it's best to revert the changes, so that we can continue testing our other development on those machines.