### PR TITLE
EAMxx: fix timestamp of FV fields for Initial run in HommeDynamics

### DIFF
--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics_fv_phys.cpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics_fv_phys.cpp
@@ -124,6 +124,21 @@ void HommeDynamics::fv_phys_dyn_to_fv_phys (const bool restart) {
     const auto T  = get_field_out("T_mid",pgn).get_view<const Pack**>();
     const auto uv = get_field_out("horiz_winds",pgn).get_view<const Pack***>();
     copy_prev(ncols, npacks, T, uv, FT, FM);
+
+    // In an initial run, the AD only reads IC for the Physics GLL fields,
+    // and this class has just taken care of remapping them to the FV grid.
+    // Therefore, the timestamp of the FV fields has *not* been set yet,
+    // which can cause serious issues downstream. For details, see
+    //   https://github.com/E3SM-Project/scream/issues/2250
+    // To avoid any problem, we simply set the timestamp of FV state fields here.
+    // NOTE: even if the init sequence *ever* changed, and the AD *did* read
+    // IC for FV fields, this step remains safe (we're setting the same t0)
+    for (auto n : {"T_mid","horiz_winds","ps","phis","omega","pseudo_density"}) {
+      auto f = get_field_out(n,pgn);
+      f.get_header().get_tracking().update_time_stamp(timestamp());
+    }
+    auto Q = get_group_out("tracers",pgn).m_bundle;
+    Q->get_header().get_tracking().update_time_stamp(timestamp());
   }
   update_pressure(m_phys_grid);
 }

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -207,9 +207,6 @@ void AtmosphereProcess::setup_tendencies_requests () {
         const auto& gname  = fid.get_grid_name();
         const auto& dtype  = fid.data_type();
 
-        std::cout << "found match for " << tn << ": " << it.fid.get_id_string() << ", g=("
-                 << ekat::join(it.groups,",") << "), ps=" << it.pack_size << ", pn=" << it.parent_name << "\n";
-
         // Check we did not process another field with same name
         if (grid_found!="" && gname!=grid_found) {
           multiple_matches_error(tn);

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -360,8 +360,6 @@ update (const Field& x, const ST alpha, const ST beta)
       " - x/y data type  : " + e2str(dt) + "\n"
       " - coeff data type: " + e2str(dt_st) + "\n");
 
-  std::cout << "going from " + e2str(dt_st) + " to " + e2str(dt) + " does not cause narrowing.\n";
-  std::cout << " alpha=" << alpha << ", beta=" << beta << std::endl;
   if (dt==DataType::IntType) {
     return update_impl<CombineMode::ScaleUpdate,HD,int>(x,alpha,beta);
   } else if (dt==DataType::FloatType) {
@@ -388,8 +386,6 @@ scale (const ST beta)
       "Error! Coefficients alpha/beta may be narrowed when converted to x/y data type.\n"
       " - x/y data type  : " + e2str(dt) + "\n"
       " - coeff data type: " + e2str(dt_st) + "\n");
-  std::cout << "going from " + e2str(dt_st) + " to " + e2str(dt) + " does not cause narrowing.\n";
-  std::cout << " beta=" << beta << std::endl;
 
   if (dt==DataType::IntType) {
     return update_impl<CombineMode::Rescale,HD,int>(*this,ST(0),beta);

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -258,8 +258,6 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
 
   // Setup I/O structures
   init ();
-
-  std::cout << "stream inited, fill value: " << m_fill_value << "\n";
 }
 
 /* ---------------------------------------------------------- */


### PR DESCRIPTION
The tendencies PR introduced a bug by doing something seemingly innocuous (in [this](https://github.com/E3SM-Project/scream/pull/2216/commits/b1485a4e64f6c08210003c950a3f35751b080745) commit). This PR fixes the exposed inconsistency. I verified the fix works by running SMS_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1 on mappy.

What happened is summarized in the following points.

- For PG2 runs, AD reads state on a physics GLL grid, rather than on PG2 grid.
- HommeDynamics takes care of initing FV state fields, but was not initializing the timestamp of those fields.
- This used to be innocuous, since the timesamp would have been updated at the very first timestep.
- The linked commit changed the order of Output Mgr (OM) init and Atm Procs (AP) init, so that OM init would happen after AP init.
- INSTANT output always outputs fields at t=0, and if it finds an uninited field, it _assumes_ it's just something not yet computed (e.g. some fields computed by physics, like `tke`), and proceeds to set the field equal to `m_fill_value`.
- Result: when OM ran after Homme init, it would see FV copies of state as un-inited, and set them to `m_fill_value`, wreacking havoc.

Fixes #2250 