### PR TITLE
Fix input file path

### DIFF
--- a/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
@@ -164,6 +164,8 @@ set (RRTMGP_TABLES
   scream/init/rrtmgp-allsky.nc
   scream/init/rrtmgp-cloud-optics-coeffs-sw.nc
   scream/init/rrtmgp-cloud-optics-coeffs-lw.nc
+  scream/init/rrtmgp-data-sw-g224-2018-12-04.nc
+  scream/init/rrtmgp-data-lw-g256-2018-12-04.nc
 )
 
 foreach (file IN ITEMS ${RRTMGP_TABLES})

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -64,7 +64,7 @@ configure_file(${SCREAM_SRC_DIR}/dynamics/homme/tests/theta.nl
 # Ensure test input files are present in the data dir
 set (TEST_INPUT_FILES
   scream/init/spa_init_ne2np4.nc
-  scream/init/map_ne4np4_to_ne2np4_mono.nc
+  scream/maps/map_ne4np4_to_ne2np4_mono.nc
   scream/init/spa_file_unified_and_complete_ne4_20220428.nc
   scream/init/${EAMxx_tests_IC_FILE_72lev}
   cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -32,7 +32,7 @@ atmosphere_processes:
       schedule_type: Sequential
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       spa:
-        spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
+        spa_remap_file: ${SCREAM_DATA_DIR}/maps/map_ne4np4_to_ne2np4_mono.nc
         spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
     rrtmgp:
       column_chunk_size: 123

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -33,7 +33,7 @@ atmosphere_processes:
       schedule_type: Sequential
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       spa:
-        spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
+        spa_remap_file: ${SCREAM_DATA_DIR}/maps/map_ne4np4_to_ne2np4_mono.nc
         spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
     rrtmgp:
       column_chunk_size: 123

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/CMakeLists.txt
@@ -20,7 +20,7 @@ math (EXPR MAC_MIC_SUBCYCLES "(${ATM_TIME_STEP} + ${SHOC_MAX_DT} - 1) / ${SHOC_M
 set (TEST_INPUT_FILES
   scream/init/${EAMxx_tests_IC_FILE_72lev}
   scream/init/spa_init_ne2np4.nc
-  scream/init/map_ne4np4_to_ne2np4_mono.nc
+  scream/maps/map_ne4np4_to_ne2np4_mono.nc
   scream/init/spa_file_unified_and_complete_ne4_20220428.nc
   cam/topo/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
 )

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -18,7 +18,7 @@ atmosphere_processes:
     schedule_type: Sequential
     number_of_subcycles: ${MAC_MIC_SUBCYCLES}
     spa:
-      spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
+      spa_remap_file: ${SCREAM_DATA_DIR}/maps/map_ne4np4_to_ne2np4_mono.nc
       spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
   rrtmgp:
     column_chunk_size: 123

--- a/components/eamxx/tests/uncoupled/spa/CMakeLists.txt
+++ b/components/eamxx/tests/uncoupled/spa/CMakeLists.txt
@@ -22,12 +22,12 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/spa_standalone_output.yaml
 
 # Ensure test input files are present in the data dir
 set (TEST_INPUT_FILES
-  ${EAMxx_tests_IC_FILE_72lev}
-  map_ne4np4_to_ne2np4_mono.nc
-  spa_file_unified_and_complete_ne4_20220428.nc
+  scream/init/${EAMxx_tests_IC_FILE_72lev}
+  scream/maps/map_ne4np4_to_ne2np4_mono.nc
+  scream/init/spa_file_unified_and_complete_ne4_20220428.nc
 )
 foreach (file IN ITEMS ${TEST_INPUT_FILES})
-  GetInputFile(scream/init/${file})
+  GetInputFile(${file})
 endforeach()
 
 ## Finally compare all MPI rank output files against the single rank output as a baseline, using CPRNC

--- a/components/eamxx/tests/uncoupled/spa/input.yaml
+++ b/components/eamxx/tests/uncoupled/spa/input.yaml
@@ -12,7 +12,7 @@ Time Stepping:
 atmosphere_processes:
   atm_procs_list: (spa)
   spa:
-    spa_remap_file: ${SCREAM_DATA_DIR}/init/map_ne4np4_to_ne2np4_mono.nc
+    spa_remap_file: ${SCREAM_DATA_DIR}/maps/map_ne4np4_to_ne2np4_mono.nc
     spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
 
 grids_manager:


### PR DESCRIPTION
This PR updates the location of`map_ne4np4_to_ne2np4_mono.nc`. It currently looks under the `init` directory and causes a file not found error while trying to download form ANL server if `SCREAM_INPUT_ROOT` is not specified.

Fixes #2253.