### PR TITLE
Add logic to control the reference for writing output and restarts.

### DIFF
--- a/components/eamxx/src/share/io/scream_io_utils.hpp
+++ b/components/eamxx/src/share/io/scream_io_utils.hpp
@@ -80,6 +80,8 @@ struct IOControl {
       } else if (frequency_units == "nmonths" || frequency_units == "nyears") {
         // For months and years we need to be careful, can't just divide ts_diff by a set value.
         // First we make sure that if we are the same day of the month and at the same time of day.
+        // TODO: Potential bug, if the day of last write >=29 there is a chance that we won't write
+        //       in some subset of months, think Feb (28 days) and all of the months with only 30 days.
         if (ts.get_day() == timestamp_of_last_write.get_day() &&
             ts.sec_of_day() == timestamp_of_last_write.sec_of_day()) {
           auto diff = 0;


### PR DESCRIPTION
This commit adds a parameter list argument to output controls that allows the user to designate one of two different reference points when calculating the time elapsed against the output frequency.

Those options are
  1) use_case_as_start_reference: TRUE
        This option will use the overall CASE start timestamp as a
        reference.  So even if this is a restarted run, the CASE
        start will correspond to the absolute start date/time for
        the overall simulation.
  2) use_case_as_start_reference: FALSE
        This opeion will use the RUN start timestamp, which is based
        on the timestamp for this particular simulation.  This is
        essential to sync EAMxx restarts with the rest of the model
        components, which start calculating whether it is time to
        write a restart file based on how much time has elapsed in
        the simulation, indepndent of the CASE start timestamp.

This commit sets the new parameter to FALSE by default if an output stream is meant for restart writes.  Otherwise it is set to TRUE by default.  That being said, a user could change this at runtime if they wanted to by adding the parameter argument to the control YAML file.

Fixes #2110 