### PR TITLE
Fix restart with radiation super-stepping

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -493,7 +493,7 @@ _TESTS = {
             "ERS_Ln9.ne4_ne4.F2000-SCREAMv1-AQP1",
             "SMS_D_Ln9.ne4_ne4.F2010-SCREAMv1-noAero",
             "ERP_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1",
-            "ERS_D_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1",
+            "ERS_D_Ln21.ne4pg2_ne4pg2.F2010-SCREAMv1.scream-rad_frequency_2",
             )
     },
 

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/rad_frequency_2/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/rad_frequency_2/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange SCREAM_ATMCHANGE_BUFFER='rad_frequency=2'

--- a/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -129,7 +129,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Computed>("SW_clrsky_flux_dn_dir", scalar3d_layout_int, Wm2, grid_name, ps);
   add_field<Computed>("LW_clrsky_flux_up", scalar3d_layout_int, Wm2, grid_name, ps);
   add_field<Computed>("LW_clrsky_flux_dn", scalar3d_layout_int, Wm2, grid_name, ps);
-  add_field<Computed>("rad_heating_pdel", scalar3d_layout_mid, Pa*K/s, grid_name, ps);
+  add_field<Updated>("rad_heating_pdel", scalar3d_layout_mid, Pa*K/s, grid_name, ps);
   // Cloud properties added as computed fields for diagnostic purposes
   add_field<Computed>("cldlow"        , scalar2d_layout, nondim, grid_name);
   add_field<Computed>("cldmed"        , scalar2d_layout, nondim, grid_name);
@@ -147,12 +147,13 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   // netsw      sfc_flux_sw_net    net (down - up) SW flux at surface
   // flwds      sfc_flux_lw_dn     downwelling LW flux at surface
   // --------------------------------------------------------------
-  add_field<Computed>("sfc_flux_dir_nir", scalar2d_layout, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_dir_vis", scalar2d_layout, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_dif_nir", scalar2d_layout, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_dif_vis", scalar2d_layout, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_sw_net" , scalar2d_layout, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_lw_dn"  , scalar2d_layout, Wm2, grid_name);
+  // These need to be added to restarts in the case of super-stepping
+  add_field<Updated>("sfc_flux_dir_nir", scalar2d_layout, Wm2, grid_name);
+  add_field<Updated>("sfc_flux_dir_vis", scalar2d_layout, Wm2, grid_name);
+  add_field<Updated>("sfc_flux_dif_nir", scalar2d_layout, Wm2, grid_name);
+  add_field<Updated>("sfc_flux_dif_vis", scalar2d_layout, Wm2, grid_name);
+  add_field<Updated>("sfc_flux_sw_net" , scalar2d_layout, Wm2, grid_name);
+  add_field<Updated>("sfc_flux_lw_dn"  , scalar2d_layout, Wm2, grid_name);
 
   // Boundary flux fields for energy and mass conservation checks
   if (has_column_conservation_check()) {

--- a/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
+++ b/components/eamxx/src/physics/rrtmgp/atmosphere_radiation.cpp
@@ -129,7 +129,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Computed>("SW_clrsky_flux_dn_dir", scalar3d_layout_int, Wm2, grid_name, ps);
   add_field<Computed>("LW_clrsky_flux_up", scalar3d_layout_int, Wm2, grid_name, ps);
   add_field<Computed>("LW_clrsky_flux_dn", scalar3d_layout_int, Wm2, grid_name, ps);
-  add_field<Updated>("rad_heating_pdel", scalar3d_layout_mid, Pa*K/s, grid_name, ps);
+  add_field<Computed>("rad_heating_pdel", scalar3d_layout_mid, Pa*K/s, grid_name, "RESTART", ps);
   // Cloud properties added as computed fields for diagnostic purposes
   add_field<Computed>("cldlow"        , scalar2d_layout, nondim, grid_name);
   add_field<Computed>("cldmed"        , scalar2d_layout, nondim, grid_name);
@@ -148,12 +148,12 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   // flwds      sfc_flux_lw_dn     downwelling LW flux at surface
   // --------------------------------------------------------------
   // These need to be added to restarts in the case of super-stepping
-  add_field<Updated>("sfc_flux_dir_nir", scalar2d_layout, Wm2, grid_name);
-  add_field<Updated>("sfc_flux_dir_vis", scalar2d_layout, Wm2, grid_name);
-  add_field<Updated>("sfc_flux_dif_nir", scalar2d_layout, Wm2, grid_name);
-  add_field<Updated>("sfc_flux_dif_vis", scalar2d_layout, Wm2, grid_name);
-  add_field<Updated>("sfc_flux_sw_net" , scalar2d_layout, Wm2, grid_name);
-  add_field<Updated>("sfc_flux_lw_dn"  , scalar2d_layout, Wm2, grid_name);
+  add_field<Computed>("sfc_flux_dir_nir", scalar2d_layout, Wm2, grid_name, "RESTART");
+  add_field<Computed>("sfc_flux_dir_vis", scalar2d_layout, Wm2, grid_name, "RESTART");
+  add_field<Computed>("sfc_flux_dif_nir", scalar2d_layout, Wm2, grid_name, "RESTART");
+  add_field<Computed>("sfc_flux_dif_vis", scalar2d_layout, Wm2, grid_name, "RESTART");
+  add_field<Computed>("sfc_flux_sw_net" , scalar2d_layout, Wm2, grid_name, "RESTART");
+  add_field<Computed>("sfc_flux_lw_dn"  , scalar2d_layout, Wm2, grid_name, "RESTART");
 
   // Boundary flux fields for energy and mass conservation checks
   if (has_column_conservation_check()) {


### PR DESCRIPTION
Fix restart with radiation super-stepping. Previously, restarts would be non-bfb if super-stepping radiation and trying to restart on a step in which radiation is not computed. This was due to the heating and surface fluxes not being written to restart files, since they were tagged as computed rather than updated fields. These fields are added to the list of updated fields here so that they will automatically be restarted. A testmod is also added to change the radiation frequency, and a corresponding test modified in the v1 low-res test suite to catch this case. This also changes the values of the fields that were changed to updated on the zeroth step (because they are initialized to zero instead of fill values), so tests that include output on the zeroth step will show DIFFs. These changes should otherwise be BFB. Fixes #2201 

[Non-B4B]