### PR TITLE
Fix utility str_to_time_stamp

### DIFF
--- a/components/eamxx/src/share/io/scream_scorpio_interface.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.F90
@@ -678,15 +678,15 @@ contains
     ! TODO: revise the set_str_attribute code to allow the
     ! scream_output_manager.cpp to handle institutions too.
     ! NOTE: The use of //char(10)// causes each institution to be written on it's own line, makes it easier to read.
-    retval=pio_put_att (File, PIO_GLOBAL, 'institutions', 'LLNL (Lawrence Livermore National Laboratory, Livermore, CA 94550, USA); &
-      '//char(10)//'ANL (Argonne National Laboratory, Argonne, IL 60439, USA);  &
-      '//char(10)//'BNL (Brookhaven National Laboratory, Upton, NY 11973, USA); &
-      '//char(10)//'LANL (Los Alamos National Laboratory, Los Alamos, NM 87545, USA); &
-      '//char(10)//'LBNL (Lawrence Berkeley National Laboratory, Berkeley, CA 94720, USA); &
-      '//char(10)//'ORNL (Oak Ridge National Laboratory, Oak Ridge, TN 37831, USA); &
-      '//char(10)//'PNNL (Pacific Northwest National Laboratory, Richland, WA 99352, USA); &
-      '//char(10)//'SNL (Sandia National Laboratories, Albuquerque, NM 87185, USA). &
-      '//char(10)//'Mailing address: LLNL Climate Program, c/o David C. Bader, Principal Investigator, L-103, 7000 East Avenue, Livermore, CA 94550, USA')
+    retval=pio_put_att (File, PIO_GLOBAL, 'institutions', 'LLNL (Lawrence Livermore National Laboratory, Livermore, CA 94550, USA);'  &
+      //char(10)//'ANL (Argonne National Laboratory, Argonne, IL 60439, USA); '  &
+      //char(10)//'BNL (Brookhaven National Laboratory, Upton, NY 11973, USA);'  &
+      //char(10)//'LANL (Los Alamos National Laboratory, Los Alamos, NM 87545, USA);'  &
+      //char(10)//'LBNL (Lawrence Berkeley National Laboratory, Berkeley, CA 94720, USA);'  &
+      //char(10)//'ORNL (Oak Ridge National Laboratory, Oak Ridge, TN 37831, USA);'  &
+      //char(10)//'PNNL (Pacific Northwest National Laboratory, Richland, WA 99352, USA);'  &
+      //char(10)//'SNL (Sandia National Laboratories, Albuquerque, NM 87185, USA).'  &
+      //char(10)//'Mailing address: LLNL Climate Program, c/o David C. Bader, Principal Investigator, L-103, 7000 East Avenue, Livermore, CA 94550, USA')
 
   end subroutine eam_pio_createHeader
 !=====================================================================!

--- a/components/eamxx/src/share/tests/utils_tests.cpp
+++ b/components/eamxx/src/share/tests/utils_tests.cpp
@@ -64,10 +64,13 @@ TEST_CASE ("time_stamp") {
     // Julian day = frac_of_year_in_days.fraction_of_day, with frac_of_year_in_days=0 at Jan 1st.
     REQUIRE (ts1.frac_of_year_in_days()==(284 + (17*3600+8*60+30)/86400.0));
     REQUIRE (ts1.get_num_steps()==0);
+  }
 
+  SECTION ("formatting") {
     REQUIRE (ts1.get_date_string()=="2021-10-12");
     REQUIRE (ts1.get_time_string()=="17:08:30");
     REQUIRE (ts1.to_string()=="2021-10-12-61710");
+    REQUIRE (util::str_to_time_stamp("2021-10-12-61710")==ts1);
   }
 
   SECTION ("comparisons") {

--- a/components/eamxx/src/share/util/scream_time_stamp.cpp
+++ b/components/eamxx/src/share/util/scream_time_stamp.cpp
@@ -362,7 +362,11 @@ TimeStamp str_to_time_stamp (const std::string& s)
     return util::TimeStamp();
   }
   std::vector<int> date{std::stoi(YY),std::stoi(MM),std::stoi(DD)};
-  std::vector<int> time{std::stoi(tod)/10000,(std::stoi(tod)/100)%100,(std::stoi(tod))%100};
+  auto sec_of_day = std::stoi(tod);
+  auto hh = (sec_of_day / 60) / 60;
+  auto mm = (sec_of_day / 60) % 60;
+  auto ss =  sec_of_day % 60;
+  std::vector<int> time{hh,mm,ss};
 
   try {
     return util::TimeStamp(date,time);


### PR DESCRIPTION
The utility `str_to_time_stamp`, which creates a TimeStamp from a string, was using a different convention for the string representation than that used by TimeStamp::to_string. In particular, the latter uses YYYY-MM-DD-XXXXX, with XXXXX=sec_of_day, while the former was assuming YYYY-MM-DD-HHMMSS. The discrepancy in conventions caused the utility to parse the string 43200 as 4h32m00s, rather than 12h00m00s.

This utility was used in `find_filename_in_rpointer`, a routine called during restarts, so it _could_ impact restarts. That said, I think it's not that likely that this fixes any of our restarts issue, unless our restarts happened to be written in the middle of the day; that can certainly happen, but I don't think any of our runs that exhibited odd behaviors in restart fell in that category.

Still, this is a clear bug, and easy to fix.