### PR TITLE
Add logic to write output progress to atm.log file

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -606,10 +606,13 @@ void AtmosphereDriver::initialize_output_managers () {
         if (it.first == "Physics GLL") continue;
         fms[it.first] = it.second;
       }
+      om.set_logger(m_atm_logger);
       om.setup(m_atm_comm,restart_pl,         fms,m_grids_manager,m_run_t0,m_case_t0,true);
     } else {
+      om.set_logger(m_atm_logger);
       om.setup(m_atm_comm,restart_pl,m_field_mgrs,m_grids_manager,m_run_t0,m_case_t0,true);
     }
+    om.set_logger(m_atm_logger);
     om.setup_globals_map(m_atm_process_group->get_restart_extra_data());
   }
 
@@ -628,6 +631,7 @@ void AtmosphereDriver::initialize_output_managers () {
     // Add a new output manager
     m_output_managers.emplace_back();
     auto& om = m_output_managers.back();
+    om.set_logger(m_atm_logger);
     om.setup(m_atm_comm,params,m_field_mgrs,m_grids_manager,m_run_t0,m_case_t0,false);
   }
 

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -270,7 +270,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
   stop_timer(timer_root+"::get_new_file"); 
 
   // Log if we write output this step:
-  if (m_atm_logger_set && is_write_step) {
+  if (m_atm_logger && is_write_step) {
     m_atm_logger->info("[EAMxx::output_manager] - Writing output:");
     m_atm_logger->info("[EAMxx::output_manager]      CASE: " + m_casename); 
     m_atm_logger->info("[EAMxx::output_manager]      FILE: " + filename); 
@@ -572,7 +572,7 @@ void OutputManager::
 push_to_logger()
 {
   // If no atm logger set then don't do anything
-  if (!m_atm_logger_set) return;
+  if (!m_atm_logger) return;
 
   auto bool_to_string = [](const bool x) {
     std::string y = x ? "YES" : "NO";

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -198,6 +198,9 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
   } else if (m_output_control.output_enabled() && m_run_t0==m_case_t0 && !m_is_model_restart_output) {
     this->run(m_run_t0);
   }
+
+  // Log this output stream
+  push_to_logger();
 }
 
 void OutputManager::setup_globals_map (const globals_map_t& globals) {
@@ -265,6 +268,13 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     }
   }
   stop_timer(timer_root+"::get_new_file"); 
+
+  // Log if we write output this step:
+  if (m_atm_logger_set && is_write_step) {
+    m_atm_logger->info("[EAMxx::output_manager] - Writing output:");
+    m_atm_logger->info("[EAMxx::output_manager]      CASE: " + m_casename); 
+    m_atm_logger->info("[EAMxx::output_manager]      FILE: " + filename); 
+  }
 
   // Run the output streams
   start_timer(timer_root+"::run_output_streams"); 
@@ -556,6 +566,35 @@ void set_file_header(const std::string& filename)
   set_str_attribute_c2f(filename.c_str(),"component","ATM");
   set_str_attribute_c2f(filename.c_str(),"conventions","");  // TODO
 
+}
+/*===============================================================================================*/
+void OutputManager::
+push_to_logger()
+{
+  // If no atm logger set then don't do anything
+  if (!m_atm_logger_set) return;
+
+  auto bool_to_string = [](const bool x) {
+    std::string y = x ? "YES" : "NO";
+    return y;
+  };
+
+  m_atm_logger->info("[EAMxx::output_manager] - New Output stream");
+  m_atm_logger->info("                      Case: " + m_casename);
+  m_atm_logger->info("                    Run t0: " + m_run_t0.to_string());
+  m_atm_logger->info("                   Case t0: " + m_case_t0.to_string());
+  m_atm_logger->info("              Reference t0: " + m_output_control.timestamp_of_last_write.to_string());
+  m_atm_logger->info("         Is Restart File ?: " + bool_to_string(m_is_model_restart_output));
+  m_atm_logger->info("        Is Restarted Run ?: " + bool_to_string(m_is_restarted_run));
+  m_atm_logger->info("            Averaging Type: " + e2str(m_avg_type));
+  m_atm_logger->info("          Output Frequency: " + std::to_string(m_output_control.frequency) + " " + m_output_control.frequency_units);
+  m_atm_logger->info("         Max snaps in file: " + std::to_string(m_output_file_specs.max_snapshots_in_file));  // TODO: add "not set" if the value is -1
+  m_atm_logger->info("      Includes Grid Data ?: " + bool_to_string(m_output_file_specs.save_grid_data));
+  // List each GRID - TODO
+  // List all FIELDS - TODO
+
+
+  
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/io/scream_output_manager.hpp
+++ b/components/eamxx/src/share/io/scream_output_manager.hpp
@@ -111,7 +111,6 @@ public:
   void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger)
     {
       m_atm_logger = atm_logger;
-      m_atm_logger_set = true;
     }
   void run (const util::TimeStamp& current_ts);
   void finalize();
@@ -179,7 +178,6 @@ protected:
 
   // The logger to be used throughout the ATM to log message
   std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger;
-  bool m_atm_logger_set = false;
 };
 
 } // namespace scream

--- a/components/eamxx/src/share/io/scream_output_manager.hpp
+++ b/components/eamxx/src/share/io/scream_output_manager.hpp
@@ -9,6 +9,7 @@
 #include "share/grid/grids_manager.hpp"
 #include "share/util/scream_time_stamp.hpp"
 
+#include "ekat/logging/ekat_logger.hpp"
 #include "ekat/mpi/ekat_comm.hpp"
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/ekat_parse_yaml_file.hpp"
@@ -107,6 +108,11 @@ public:
   }
 
   void setup_globals_map (const globals_map_t& globals);
+  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger)
+    {
+      m_atm_logger = atm_logger;
+      m_atm_logger_set = true;
+    }
   void run (const util::TimeStamp& current_ts);
   void finalize();
 
@@ -125,6 +131,9 @@ protected:
   void setup_file (      IOFileSpecs& filespecs,
                    const IOControl& control,
                    const util::TimeStamp& timestamp);
+
+  // Manage logging of info to atm.log
+  void push_to_logger();
 
   using output_type     = AtmosphereOutput;
   using output_ptr_type = std::shared_ptr<output_type>;
@@ -167,6 +176,10 @@ protected:
   // restart happens, and the latter being the start time of the *original* run.
   util::TimeStamp   m_case_t0;
   util::TimeStamp   m_run_t0;
+
+  // The logger to be used throughout the ATM to log message
+  std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger;
+  bool m_atm_logger_set = false;
 };
 
 } // namespace scream


### PR DESCRIPTION
This commit passes the atm_logger to all instances of the output_manager class so that basic information about output writing can be posted to the atm.log file.