### PR TITLE
Allow user to prescribe atmosphere surface forcing to other components

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -165,7 +165,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <sc_export inherit="atm_proc_base">
       <prescribed_constants>
         <fields type="array(string)">NONE</fields>
-        <values type="array(double)">NONE</values>
+        <values type="array(real)">0</values>
       </prescribed_constants>
     </sc_export>
 

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -162,7 +162,9 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <!-- Surface coupling (import and export) -->
     <sc_import inherit="atm_proc_base"/>
-    <sc_export inherit="atm_proc_base"/>
+    <sc_export inherit="atm_proc_base">
+      <prescribed_export_control_file type="string">NONE</prescribed_export_control_file>
+    </sc_export>
 
     <!-- Homme dynamics -->
     <homme inherit="atm_proc_base">

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -163,7 +163,10 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- Surface coupling (import and export) -->
     <sc_import inherit="atm_proc_base"/>
     <sc_export inherit="atm_proc_base">
-      <prescribed_export_control_file type="string">NONE</prescribed_export_control_file>
+      <prescribed_constants>
+        <fields type="array(string)">NONE</fields>
+        <values type="array(double)">NONE</values>
+      </prescribed_constants>
     </sc_export>
 
     <!-- Homme dynamics -->

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -250,17 +250,17 @@ void SurfaceCouplingExporter::run_impl (const double dt)
 void SurfaceCouplingExporter::do_export(const double dt, const bool called_during_initialization)
 {
   if (m_num_const_exports>0) {
-    do_export_constant(dt,called_during_initialization);
+    set_constant_exports(dt,called_during_initialization);
   }
   if (m_num_eamxx_exports>0) {
-    do_export_from_eamxx(dt,called_during_initialization);
+    compute_eamxx_exports(dt,called_during_initialization);
   }
 
   // Finish up exporting vars
   do_export_to_cpl(called_during_initialization);
 }
 // =========================================================================================
-void SurfaceCouplingExporter::do_export_constant(const double dt, const bool called_during_initialization)
+void SurfaceCouplingExporter::set_constant_exports(const double dt, const bool called_during_initialization)
 {
   // Cycle through those fields that will be set to a constant value:
   auto export_source_h = Kokkos::create_mirror_view(m_export_source);
@@ -275,13 +275,13 @@ void SurfaceCouplingExporter::do_export_constant(const double dt, const bool cal
   
 }
 // =========================================================================================
-// This do_export handles all export variables that are derived from the EAMxx state.
+// This compute_eamxx_exports routine  handles all export variables that are derived from the EAMxx state.
 // Important! This setup assumes the numerical order of export_cpl_indices as listed in
 // /src/mct_coupling/scream_cpl_indices.F90
 //
 // If this order is changed or a new variable is added it is important to update the corresponding
 // index query in the below.
-void SurfaceCouplingExporter::do_export_from_eamxx(const double dt, const bool called_during_initialization)
+void SurfaceCouplingExporter::compute_eamxx_exports(const double dt, const bool called_during_initialization)
 {
   using PC = physics::Constants<Real>;
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -225,8 +225,8 @@ void SurfaceCouplingExporter::initialize_impl (const RunType /* run_type */)
         if (loc != export_constant_fields.end()) {
           const auto pos = loc-export_constant_fields.begin();
           export_source_h(i) = CONSTANT;
-          m_num_const_exports += 1;
-          m_num_eamxx_exports -= 1;
+          ++m_num_const_exports;
+          --m_num_eamxx_exports;
           m_export_constants.emplace(fname,export_constant_values[pos]);
         }
       }
@@ -400,7 +400,7 @@ void SurfaceCouplingExporter::compute_eamxx_exports(const double dt, const bool 
       Sa_v(i)             = v_wind_i(num_levs-1);
     }
 
-    if (m_export_source(idx_Sa_tbot)==EAMXX) {  /// HERE
+    if (m_export_source(idx_Sa_tbot)==EAMXX) {
       Sa_tbot(i) = s_T_mid_i(num_levs-1);
     }
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -202,12 +202,12 @@ void SurfaceCouplingExporter::initialize_impl (const RunType /* run_type */)
   // Copy data to device for use in do_export()
   Kokkos::deep_copy(m_column_info_d, m_column_info_h);
 
-  // Set the number of exports from eamxx or set to a constant, default type = EAMXX
+  // Set the number of exports from eamxx or set to a constant, default type = FROM_MODEL
   using vos_type = std::vector<std::string>;
   using vor_type = std::vector<Real>;
   m_export_source     = view_1d<DefaultDevice,ExportType>("",m_num_scream_exports);
   auto export_source_h = Kokkos::create_mirror_view(m_export_source);
-  Kokkos::deep_copy(m_export_source,EAMXX);  // The default is that all export variables will be derived from the EAMxx state.
+  Kokkos::deep_copy(m_export_source,FROM_MODEL);  // The default is that all export variables will be derived from the EAMxx state.
   m_num_eamxx_exports = m_num_scream_exports;
  
   if (m_params.isSublist("prescribed_constants")) {
@@ -369,9 +369,9 @@ void SurfaceCouplingExporter::compute_eamxx_exports(const double dt, const bool 
     // Compute vertical layer heights (relative to ground surface rather than from sea level).
     // Use z_int(nlevs) = z_surf = 0.0.
     // Currently only needed for Sa_z, Sa_dens and Sa_pslv
-    const bool calculate_z_vars = m_export_source(idx_Sa_z)==EAMXX
-                               || m_export_source(idx_Sa_dens)==EAMXX
-                               || m_export_source(idx_Sa_pslv)==EAMXX; 
+    const bool calculate_z_vars = m_export_source(idx_Sa_z)==FROM_MODEL
+                               || m_export_source(idx_Sa_dens)==FROM_MODEL
+                               || m_export_source(idx_Sa_pslv)==FROM_MODEL; 
     if (calculate_z_vars) {
       PF::calculate_dz(team, pseudo_density_i, p_mid_i, T_mid_i, qv_i, dz_i);
       team.team_barrier();
@@ -384,46 +384,46 @@ void SurfaceCouplingExporter::compute_eamxx_exports(const double dt, const bool 
 
     // Set the values in the helper fields which correspond to the exported variables
 
-    if (m_export_source(idx_Sa_z)==EAMXX) { 
+    if (m_export_source(idx_Sa_z)==FROM_MODEL) { 
       // Assugb to Sa_z
       const auto s_z_mid_i = ekat::scalarize(z_mid_i);
       Sa_z(i)    = s_z_mid_i(num_levs-1); 
     }
 
-    if (m_export_source(idx_Sa_u)==EAMXX) {
+    if (m_export_source(idx_Sa_u)==FROM_MODEL) {
       const auto u_wind_i = ekat::subview(horiz_winds, i, 0); // TODO, when U and V work switch to using here instead of horiz_winds.
       Sa_u(i)             = u_wind_i(num_levs-1);
     }
 
-    if (m_export_source(idx_Sa_v)==EAMXX) {
+    if (m_export_source(idx_Sa_v)==FROM_MODEL) {
       const auto v_wind_i = ekat::subview(horiz_winds, i, 1);
       Sa_v(i)             = v_wind_i(num_levs-1);
     }
 
-    if (m_export_source(idx_Sa_tbot)==EAMXX) {
+    if (m_export_source(idx_Sa_tbot)==FROM_MODEL) {
       Sa_tbot(i) = s_T_mid_i(num_levs-1);
     }
 
-    if (m_export_source(idx_Sa_ptem)==EAMXX) {
+    if (m_export_source(idx_Sa_ptem)==FROM_MODEL) {
       Sa_ptem(i) = PF::calculate_theta_from_T(s_T_mid_i(num_levs-1), s_p_mid_i(num_levs-1));
     }
 
-    if (m_export_source(idx_Sa_pbot)==EAMXX) {
+    if (m_export_source(idx_Sa_pbot)==FROM_MODEL) {
       Sa_pbot(i) = s_p_mid_i(num_levs-1);
     }
 
-    if (m_export_source(idx_Sa_shum)==EAMXX) { 
+    if (m_export_source(idx_Sa_shum)==FROM_MODEL) { 
       const auto s_qv_i = ekat::scalarize(qv_i);
       Sa_shum(i) = s_qv_i(num_levs-1); 
     }
 
-    if (m_export_source(idx_Sa_dens)==EAMXX) {
+    if (m_export_source(idx_Sa_dens)==FROM_MODEL) {
       const auto s_dz_i = ekat::scalarize(dz_i);
       const auto s_pseudo_density_i = ekat::scalarize(pseudo_density_i);
       Sa_dens(i) = PF::calculate_density(s_pseudo_density_i(num_levs-1), s_dz_i(num_levs-1));
     }
 
-    if (m_export_source(idx_Sa_pslv)==EAMXX) {
+    if (m_export_source(idx_Sa_pslv)==FROM_MODEL) {
       const auto p_int_i   = ekat::subview(p_int, i);
       const auto s_z_mid_i = ekat::scalarize(z_mid_i);
       // Calculate air temperature at bottom of cell closest to the ground for PSL
@@ -436,19 +436,19 @@ void SurfaceCouplingExporter::compute_eamxx_exports(const double dt, const bool 
       // Precipitation has units of kg/m2, and Faxa_rainl/snowl
       // need units mm/s. Here, 1000 converts m->mm, dt has units s, and
       // rho_h2o has units kg/m3.
-      if (m_export_source(idx_Faxa_rainl)==EAMXX) { Faxa_rainl(i) = precip_liq_surf_mass(i)/dt*(1000.0/PC::RHO_H2O); }
-      if (m_export_source(idx_Faxa_snowl)==EAMXX) { Faxa_snowl(i) = precip_ice_surf_mass(i)/dt*(1000.0/PC::RHO_H2O); }
+      if (m_export_source(idx_Faxa_rainl)==FROM_MODEL) { Faxa_rainl(i) = precip_liq_surf_mass(i)/dt*(1000.0/PC::RHO_H2O); }
+      if (m_export_source(idx_Faxa_snowl)==FROM_MODEL) { Faxa_snowl(i) = precip_ice_surf_mass(i)/dt*(1000.0/PC::RHO_H2O); }
     }
   });
   // Variables that are already surface vars in the ATM can just be copied directly.
   auto export_source_h = Kokkos::create_mirror_view(m_export_source);
   Kokkos::deep_copy(export_source_h,m_export_source);
-  if (export_source_h(idx_Faxa_swndr)==EAMXX) { Kokkos::deep_copy(Faxa_swndr, sfc_flux_dir_nir); }
-  if (export_source_h(idx_Faxa_swvdr)==EAMXX) { Kokkos::deep_copy(Faxa_swvdr, sfc_flux_dir_vis); }
-  if (export_source_h(idx_Faxa_swndf)==EAMXX) { Kokkos::deep_copy(Faxa_swndf, sfc_flux_dif_nir); }
-  if (export_source_h(idx_Faxa_swvdf)==EAMXX) { Kokkos::deep_copy(Faxa_swvdf, sfc_flux_dif_vis); }
-  if (export_source_h(idx_Faxa_swnet)==EAMXX) { Kokkos::deep_copy(Faxa_swnet, sfc_flux_sw_net); }
-  if (export_source_h(idx_Faxa_lwdn )==EAMXX) { Kokkos::deep_copy(Faxa_lwdn,  sfc_flux_lw_dn); }
+  if (export_source_h(idx_Faxa_swndr)==FROM_MODEL) { Kokkos::deep_copy(Faxa_swndr, sfc_flux_dir_nir); }
+  if (export_source_h(idx_Faxa_swvdr)==FROM_MODEL) { Kokkos::deep_copy(Faxa_swvdr, sfc_flux_dir_vis); }
+  if (export_source_h(idx_Faxa_swndf)==FROM_MODEL) { Kokkos::deep_copy(Faxa_swndf, sfc_flux_dif_nir); }
+  if (export_source_h(idx_Faxa_swvdf)==FROM_MODEL) { Kokkos::deep_copy(Faxa_swvdf, sfc_flux_dif_vis); }
+  if (export_source_h(idx_Faxa_swnet)==FROM_MODEL) { Kokkos::deep_copy(Faxa_swnet, sfc_flux_sw_net); }
+  if (export_source_h(idx_Faxa_lwdn )==FROM_MODEL) { Kokkos::deep_copy(Faxa_lwdn,  sfc_flux_lw_dn); }
 }
 // =========================================================================================
 void SurfaceCouplingExporter::do_export_to_cpl(const bool called_during_initialization)

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
@@ -125,8 +125,7 @@ protected:
   // Number of exports from EAMxx and how they will be handled
   Int                               m_num_scream_exports;
   view_1d<DefaultDevice,ExportType> m_export_source;
-  view_1d<DefaultDevice,Real>       m_export_constants;
-  std::map<std::string,int>         m_export_indices;
+  view_1d<HostDevice,Real>          m_export_constants;
   int                               m_num_eamxx_exports=0;
   int                               m_num_const_exports=0;
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
@@ -80,6 +80,7 @@ public:
   void do_export(const double dt, const bool called_during_initialization=false);             // Main export routine
   void do_export_from_eamxx(const double dt, const bool called_during_initialization=false);  // Export vars are derived from eamxx state
   void do_export_constant(const double dt, const bool called_during_initialization=false);    // Export vars are set to a constant
+  void do_export_to_cpl(const bool called_during_initialization=false);                       // Finish export by copying data to cpl structures.
 
   // Take and store data from SCDataManager
   void setup_surface_coupling_data(const SCDataManager &sc_data_manager);
@@ -125,6 +126,7 @@ protected:
   Int                               m_num_scream_exports;
   view_1d<DefaultDevice,ExportType> m_export_source;
   view_1d<DefaultDevice,Real>       m_export_constants;
+  std::map<std::string,int>         m_export_indices;
   int                               m_num_eamxx_exports=0;
   int                               m_num_const_exports=0;
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
@@ -125,7 +125,7 @@ protected:
   // Number of exports from EAMxx and how they will be handled
   Int                               m_num_scream_exports;
   view_1d<DefaultDevice,ExportType> m_export_source;
-  view_1d<HostDevice,Real>          m_export_constants;
+  std::map<std::string,Real>        m_export_constants;
   int                               m_num_eamxx_exports=0;
   int                               m_num_const_exports=0;
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
@@ -78,8 +78,8 @@ public:
   // called_during_initialization=true to avoid exporting fields
   // which do not have valid entries.
   void do_export(const double dt, const bool called_during_initialization=false);             // Main export routine
-  void do_export_from_eamxx(const double dt, const bool called_during_initialization=false);  // Export vars are derived from eamxx state
-  void do_export_constant(const double dt, const bool called_during_initialization=false);    // Export vars are set to a constant
+  void compute_eamxx_exports(const double dt, const bool called_during_initialization=false); // Export vars are derived from eamxx state
+  void set_constant_exports(const double dt, const bool called_during_initialization=false);  // Export vars are set to a constant
   void do_export_to_cpl(const bool called_during_initialization=false);                       // Finish export by copying data to cpl structures.
 
   // Take and store data from SCDataManager

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
@@ -21,6 +21,14 @@ namespace scream
  * in its list of subcomponents (the AD should make sure of this).
 */
 
+// enum to track how exported fields will be set.
+enum ExportType {
+  EAMXX      =  0,  // Variable will be derived from EAMxx state
+  PRESCRIBED =  1,  // Variable will be set given data from a file
+  CONSTANT   =  2   // Set variable to a constant value
+};
+
+
 class SurfaceCouplingExporter : public AtmosphereProcess
 {
 public:
@@ -69,7 +77,9 @@ public:
   // If calling in initialize_impl(), set
   // called_during_initialization=true to avoid exporting fields
   // which do not have valid entries.
-  void do_export(const double dt, const bool called_during_initialization=false);
+  void do_export(const double dt, const bool called_during_initialization=false);             // Main export routine
+  void do_export_from_eamxx(const double dt, const bool called_during_initialization=false);  // Export vars are derived from eamxx state
+  void do_export_constant(const double dt, const bool called_during_initialization=false);    // Export vars are set to a constant
 
   // Take and store data from SCDataManager
   void setup_surface_coupling_data(const SCDataManager &sc_data_manager);
@@ -111,8 +121,12 @@ protected:
   // Number of fields in cpl data
   Int m_num_cpl_exports;
 
-  // Number of exports from SCREAM
-  Int m_num_scream_exports;
+  // Number of exports from EAMxx and how they will be handled
+  Int                               m_num_scream_exports;
+  view_1d<DefaultDevice,ExportType> m_export_source;
+  view_1d<DefaultDevice,Real>       m_export_constants;
+  int                               m_num_eamxx_exports=0;
+  int                               m_num_const_exports=0;
 
   // Views storing a 2d array with dims (num_cols,num_fields) for cpl export data.
   // The field idx strides faster, since that's what mct does (so we can "view" the

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
@@ -126,7 +126,7 @@ protected:
   Int                               m_num_scream_exports;
   view_1d<DefaultDevice,ExportType> m_export_source;
   std::map<std::string,Real>        m_export_constants;
-  int                               m_num_eamxx_exports=0;
+  int                               m_num_from_model_exports=0;
   int                               m_num_const_exports=0;
 
   // Views storing a 2d array with dims (num_cols,num_fields) for cpl export data.

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
@@ -23,9 +23,9 @@ namespace scream
 
 // enum to track how exported fields will be set.
 enum ExportType {
-  EAMXX     =  0,  // Variable will be derived from EAMxx state
-  FROM_FILE =  1,  // Variable will be set given data from a file
-  CONSTANT  =  2   // Set variable to a constant value
+  FROM_MODEL =  0,  // Variable will be derived from atmosphere model state
+  FROM_FILE  =  1,  // Variable will be set given data from a file
+  CONSTANT   =  2   // Set variable to a constant value
 };
 
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
@@ -23,9 +23,9 @@ namespace scream
 
 // enum to track how exported fields will be set.
 enum ExportType {
-  EAMXX      =  0,  // Variable will be derived from EAMxx state
-  PRESCRIBED =  1,  // Variable will be set given data from a file
-  CONSTANT   =  2   // Set variable to a constant value
+  EAMXX     =  0,  // Variable will be derived from EAMxx state
+  FROM_FILE =  1,  // Variable will be set given data from a file
+  CONSTANT  =  2   // Set variable to a constant value
 };
 
 

--- a/components/eamxx/src/mct_coupling/scream_cpl_indices.F90
+++ b/components/eamxx/src/mct_coupling/scream_cpl_indices.F90
@@ -139,22 +139,22 @@ module scream_cpl_indices
 
     ! SCREAM names
     export_field_names(1)  = 'Sa_z'
-    export_field_names(2)  = 'horiz_winds'
-    export_field_names(3)  = 'horiz_winds'
-    export_field_names(4)  = 'T_mid'
+    export_field_names(2)  = 'Sa_u'
+    export_field_names(3)  = 'Sa_v'
+    export_field_names(4)  = 'Sa_tbot' 
     export_field_names(5)  = 'Sa_ptem'
-    export_field_names(6)  = 'p_mid'
-    export_field_names(7)  = 'qv'
+    export_field_names(6)  = 'Sa_pbot'
+    export_field_names(7)  = 'Sa_shum'
     export_field_names(8)  = 'Sa_dens'
     export_field_names(9)  = 'Sa_pslv'
     export_field_names(10) = 'Faxa_rainl'
     export_field_names(11) = 'Faxa_snowl'
-    export_field_names(12) = 'sfc_flux_dir_nir'
-    export_field_names(13) = 'sfc_flux_dir_vis'
-    export_field_names(14) = 'sfc_flux_dif_nir'
-    export_field_names(15) = 'sfc_flux_dif_vis'
-    export_field_names(16) = 'sfc_flux_sw_net'
-    export_field_names(17) = 'sfc_flux_lw_dn'
+    export_field_names(12) = 'Faxa_swndr' 
+    export_field_names(13) = 'Faxa_swvdr' 
+    export_field_names(14) = 'Faxa_swndf' 
+    export_field_names(15) = 'Faxa_swvdf' 
+    export_field_names(16) = 'Faxa_swnet' 
+    export_field_names(17) = 'Faxa_lwdn'  
 
     ! CPL indices
     export_cpl_indices(1)  = mct_avect_indexra(a2x,'Sa_z')
@@ -174,10 +174,6 @@ module scream_cpl_indices
     export_cpl_indices(15) = mct_avect_indexra(a2x,'Faxa_swvdf')
     export_cpl_indices(16) = mct_avect_indexra(a2x,'Faxa_swnet')
     export_cpl_indices(17) = mct_avect_indexra(a2x,'Faxa_lwdn')
-
-    ! Vector components
-    export_vector_components(2) = 0
-    export_vector_components(3) = 1
 
     ! Does this field need to be imported during intialization
     do_export_during_init(1) = .true.

--- a/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
+++ b/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
@@ -175,6 +175,7 @@ void test_exports(const FieldManager& fm,
                   const KokkosTypes<HostDevice>::view_2d<Real> export_data_view,
                   const KokkosTypes<HostDevice>::view_1d<int>  export_cpl_indices_view,
                   const KokkosTypes<HostDevice>::view_1d<Real> export_constant_multiple_view,
+                  const std::string& export_control_filename,
                   const int dt,
                   const bool called_directly_after_init = false)
 {
@@ -274,6 +275,14 @@ void test_exports(const FieldManager& fm,
   const auto Faxa_rainl_h = Kokkos::create_mirror_view_and_copy(HostDevice(), Faxa_rainl);
   const auto Faxa_snowl_h = Kokkos::create_mirror_view_and_copy(HostDevice(), Faxa_snowl);
 
+  // Recall that two fields have been set to export to a constant value, so we load those constants from the parameter list here:
+  ekat::ParameterList exp_control_params("export control");
+  REQUIRE_NOTHROW ( parse_yaml_file(export_control_filename,exp_control_params) );
+  auto exp_const_params       = exp_control_params.sublist("set_export_to_constant");
+  const Real Faxa_swndf_const = exp_const_params.get<Real>("Faxa_swndf"); 
+  const Real Faxa_swndv_const = exp_const_params.get<Real>("Faxa_swvdf"); 
+
+
   // Check cpl data to scream fields
   for (int i=0; i<ncols; ++i) {
 
@@ -304,8 +313,8 @@ void test_exports(const FieldManager& fm,
       EKAT_REQUIRE(export_constant_multiple_view(10)*Faxa_snowl_h(i)       == export_data_view(i, export_cpl_indices_view(10)));
       EKAT_REQUIRE(export_constant_multiple_view(11)*sfc_flux_dir_nir_h(i) == export_data_view(i, export_cpl_indices_view(11)));
       EKAT_REQUIRE(export_constant_multiple_view(12)*sfc_flux_dir_vis_h(i) == export_data_view(i, export_cpl_indices_view(12)));
-      EKAT_REQUIRE(export_constant_multiple_view(13)*sfc_flux_dif_nir_h(i) == export_data_view(i, export_cpl_indices_view(13)));
-      EKAT_REQUIRE(export_constant_multiple_view(14)*sfc_flux_dif_vis_h(i) == export_data_view(i, export_cpl_indices_view(14)));
+      EKAT_REQUIRE(Faxa_swndf_const                                        == export_data_view(i, export_cpl_indices_view(13)));
+      EKAT_REQUIRE(Faxa_swndv_const                                        == export_data_view(i, export_cpl_indices_view(14)));
       EKAT_REQUIRE(export_constant_multiple_view(15)*sfc_flux_sw_net_h(i)  == export_data_view(i, export_cpl_indices_view(15)));
       EKAT_REQUIRE(export_constant_multiple_view(16)*sfc_flux_lw_dn_h(i)   == export_data_view(i, export_cpl_indices_view(16)));
     }
@@ -318,6 +327,7 @@ TEST_CASE("surface-coupling", "") {
 
   // Create a comm
   ekat::Comm atm_comm (MPI_COMM_WORLD);
+  auto engine = setup_random_test(&atm_comm);
 
   // Load ad parameter list
   std::string fname = "input.yaml";
@@ -328,6 +338,22 @@ TEST_CASE("surface-coupling", "") {
   auto& ts          = ad_params.sublist("time_stepping");
   const auto t0_str = ts.get<std::string>("run_t0");
   const auto t0     = util::str_to_time_stamp(t0_str);
+
+  // Set one export field to be randomly set to a constant
+  // This requires us to add a sublist to the parsed AD params yaml list.
+  // We also write the random values out so they can be checked later.
+  std::uniform_real_distribution<Real> pdf_real_constant_data(0.0,1.0);
+  ekat::ParameterList exp_control_params("export control");
+  auto& exp_const_params = exp_control_params.sublist("set_export_to_constant");
+  const Real Faxa_swndf_const = pdf_real_constant_data(engine);
+  const Real Faxa_swndv_const = pdf_real_constant_data(engine);
+  exp_const_params.set<Real>("Faxa_swndf",Faxa_swndf_const); 
+  exp_const_params.set<Real>("Faxa_swvdf",Faxa_swndv_const);
+  const std::string export_control_filename = "export_control_np"+std::to_string(atm_comm.size())+".yaml";
+  write_yaml_file(export_control_filename,exp_control_params);
+  auto& ap_params     = ad_params.sublist("atmosphere_processes");
+  auto& sc_exp_params = ap_params.sublist("SurfaceCouplingExporter");
+  sc_exp_params.set<std::string>("prescribed_export_control_file",export_control_filename);
 
   // Need to register products in the factory *before* we create any atm process or grids manager.
   auto& proc_factory = AtmosphereProcessFactory::instance();
@@ -352,7 +378,6 @@ TEST_CASE("surface-coupling", "") {
   // Create test data for SurfaceCouplingDataManager
 
   // Create engine and pdfs for random test data
-  auto engine = setup_random_test(&atm_comm);
   std::uniform_int_distribution<int> pdf_int_additional_fields(0,10);
   std::uniform_int_distribution<int> pdf_int_dt(1,1800);
   std::uniform_real_distribution<Real> pdf_real_import_data(0.0,1.0);
@@ -462,7 +487,7 @@ TEST_CASE("surface-coupling", "") {
   test_imports(*fm, import_data_view, import_cpl_indices_view,
                import_constant_multiple_view, true);
   test_exports(*fm, export_data_view, export_cpl_indices_view,
-               export_constant_multiple_view, dt, true);
+               export_constant_multiple_view, export_control_filename, dt, true);
 
   // Run the AD
   ad.run(dt);
@@ -471,7 +496,7 @@ TEST_CASE("surface-coupling", "") {
   test_imports(*fm, import_data_view, import_cpl_indices_view,
                import_constant_multiple_view);
   test_exports(*fm, export_data_view, export_cpl_indices_view,
-               export_constant_multiple_view, dt);
+               export_constant_multiple_view, export_control_filename, dt);
 
   // Finalize  the AD
   ad.finalize();

--- a/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
+++ b/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
@@ -175,7 +175,7 @@ void test_exports(const FieldManager& fm,
                   const KokkosTypes<HostDevice>::view_2d<Real> export_data_view,
                   const KokkosTypes<HostDevice>::view_1d<int>  export_cpl_indices_view,
                   const KokkosTypes<HostDevice>::view_1d<Real> export_constant_multiple_view,
-                  const std::string& export_control_filename,
+                  const ekat::ParameterList prescribed_constants,
                   const int dt,
                   const bool called_directly_after_init = false)
 {
@@ -276,11 +276,10 @@ void test_exports(const FieldManager& fm,
   const auto Faxa_snowl_h = Kokkos::create_mirror_view_and_copy(HostDevice(), Faxa_snowl);
 
   // Recall that two fields have been set to export to a constant value, so we load those constants from the parameter list here:
-  ekat::ParameterList exp_control_params("export control");
-  REQUIRE_NOTHROW ( parse_yaml_file(export_control_filename,exp_control_params) );
-  auto exp_const_params       = exp_control_params.sublist("set_export_to_constant");
-  const Real Faxa_swndf_const = exp_const_params.get<Real>("Faxa_swndf"); 
-  const Real Faxa_swndv_const = exp_const_params.get<Real>("Faxa_swvdf"); 
+  using vor_type = std::vector<Real>;
+  const auto prescribed_const_values = prescribed_constants.get<vor_type>("values");
+  const Real Faxa_swndf_const = prescribed_const_values[0]; 
+  const Real Faxa_swndv_const = prescribed_const_values[1]; 
 
 
   // Check cpl data to scream fields
@@ -339,21 +338,21 @@ TEST_CASE("surface-coupling", "") {
   const auto t0_str = ts.get<std::string>("run_t0");
   const auto t0     = util::str_to_time_stamp(t0_str);
 
-  // Set one export field to be randomly set to a constant
+  // Set two export fields to be randomly set to a constant
   // This requires us to add a sublist to the parsed AD params yaml list.
-  // We also write the random values out so they can be checked later.
+  using vos_type = std::vector<std::string>;
+  using vor_type = std::vector<Real>;
   std::uniform_real_distribution<Real> pdf_real_constant_data(0.0,1.0);
-  ekat::ParameterList exp_control_params("export control");
-  auto& exp_const_params = exp_control_params.sublist("set_export_to_constant");
   const Real Faxa_swndf_const = pdf_real_constant_data(engine);
-  const Real Faxa_swndv_const = pdf_real_constant_data(engine);
-  exp_const_params.set<Real>("Faxa_swndf",Faxa_swndf_const); 
-  exp_const_params.set<Real>("Faxa_swvdf",Faxa_swndv_const);
-  const std::string export_control_filename = "export_control_np"+std::to_string(atm_comm.size())+".yaml";
-  write_yaml_file(export_control_filename,exp_control_params);
+  const Real Faxa_swvdf_const = pdf_real_constant_data(engine);
+  const vos_type exp_const_fields = {"Faxa_swndf","Faxa_swvdf"};
+  const vor_type exp_const_values = {Faxa_swndf_const,Faxa_swvdf_const};
   auto& ap_params     = ad_params.sublist("atmosphere_processes");
   auto& sc_exp_params = ap_params.sublist("SurfaceCouplingExporter");
   sc_exp_params.set<std::string>("prescribed_export_control_file",export_control_filename);
+  auto& exp_const_params = sc_exp_params.sublist("prescribed_constants");
+  exp_const_params.set<vos_type>("fields",exp_const_fields);
+  exp_const_params.set<vor_type>("values",exp_const_values);
 
   // Need to register products in the factory *before* we create any atm process or grids manager.
   auto& proc_factory = AtmosphereProcessFactory::instance();
@@ -487,7 +486,7 @@ TEST_CASE("surface-coupling", "") {
   test_imports(*fm, import_data_view, import_cpl_indices_view,
                import_constant_multiple_view, true);
   test_exports(*fm, export_data_view, export_cpl_indices_view,
-               export_constant_multiple_view, export_control_filename, dt, true);
+               export_constant_multiple_view,  exp_const_params, dt, true);
 
   // Run the AD
   ad.run(dt);
@@ -496,7 +495,7 @@ TEST_CASE("surface-coupling", "") {
   test_imports(*fm, import_data_view, import_cpl_indices_view,
                import_constant_multiple_view);
   test_exports(*fm, export_data_view, export_cpl_indices_view,
-               export_constant_multiple_view, export_control_filename, dt);
+               export_constant_multiple_view, exp_const_params, dt);
 
   // Finalize  the AD
   ad.finalize();

--- a/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
+++ b/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
@@ -85,10 +85,6 @@ void setup_import_and_export_data(
     }
   }
 
-  // Set vector components
-  export_vec_comps_view(1) = 0;
-  export_vec_comps_view(2) = 1;
-
   // Set boolean for exporting during intialization
   do_export_during_init_view(0) = true;
   do_export_during_init_view(1) = true;
@@ -418,23 +414,23 @@ TEST_CASE("surface-coupling", "") {
   Kokkos::deep_copy(export_data_view, -1.0);
   // Set names. For all non-scream exports, set to 0.
   char export_names[num_scream_exports][32];
-  std::strcpy(export_names[0],  "Sa_z");
-  std::strcpy(export_names[1],  "horiz_winds");
-  std::strcpy(export_names[2],  "horiz_winds");
-  std::strcpy(export_names[3],  "T_mid");
-  std::strcpy(export_names[4],  "Sa_ptem");
-  std::strcpy(export_names[5],  "p_mid");
-  std::strcpy(export_names[6],  "qv");
-  std::strcpy(export_names[7],  "Sa_dens");
-  std::strcpy(export_names[8],  "Sa_pslv");
-  std::strcpy(export_names[9],  "Faxa_rainl");
-  std::strcpy(export_names[10], "Faxa_snowl");
-  std::strcpy(export_names[11], "sfc_flux_dir_nir");
-  std::strcpy(export_names[12], "sfc_flux_dir_vis");
-  std::strcpy(export_names[13], "sfc_flux_dif_nir");
-  std::strcpy(export_names[14], "sfc_flux_dif_vis");
-  std::strcpy(export_names[15], "sfc_flux_sw_net");
-  std::strcpy(export_names[16], "sfc_flux_lw_dn");
+  std::strcpy(export_names[0],  "Sa_z"       );
+  std::strcpy(export_names[1],  "Sa_u"       );
+  std::strcpy(export_names[2],  "Sa_v"       );
+  std::strcpy(export_names[3],  "Sa_tbot"    );
+  std::strcpy(export_names[4],  "Sa_ptem"    );
+  std::strcpy(export_names[5],  "Sa_pbot"    );
+  std::strcpy(export_names[6],  "Sa_shum"    );
+  std::strcpy(export_names[7],  "Sa_dens"    );
+  std::strcpy(export_names[8],  "Sa_pslv"    );
+  std::strcpy(export_names[9],  "Faxa_rainl" );
+  std::strcpy(export_names[10], "Faxa_snowl" );
+  std::strcpy(export_names[11], "Faxa_swndr" );
+  std::strcpy(export_names[12], "Faxa_swvdr" );
+  std::strcpy(export_names[13], "Faxa_swndf" );
+  std::strcpy(export_names[14], "Faxa_swvdf" );
+  std::strcpy(export_names[15], "Faxa_swnet" );
+  std::strcpy(export_names[16], "Faxa_lwdn"  );
 
   // Setup the import/export data. This is meant to replicate the structures coming
   // from mct_coupling/scream_cpl_indices.F90

--- a/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
+++ b/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
@@ -349,7 +349,6 @@ TEST_CASE("surface-coupling", "") {
   const vor_type exp_const_values = {Faxa_swndf_const,Faxa_swvdf_const};
   auto& ap_params     = ad_params.sublist("atmosphere_processes");
   auto& sc_exp_params = ap_params.sublist("SurfaceCouplingExporter");
-  sc_exp_params.set<std::string>("prescribed_export_control_file",export_control_filename);
   auto& exp_const_params = sc_exp_params.sublist("prescribed_constants");
   exp_const_params.set<vos_type>("fields",exp_const_fields);
   exp_const_params.set<vor_type>("values",exp_const_values);


### PR DESCRIPTION
This PR introduces an option to override the exported surface fluxes from the ATM to CPL with constant values.

This is a first step to prescribing exported values using data from a file.  A task that will be tackled in a subsequent PR.

This is a functionality that has been requested by the ML nudging effort.  A part of that workflow will require the surface
to be forced by values taken from a file.

This functionality may be generally useful for any case where we want to explicitly force some or all of the ATM
surface fluxes to be a specific value.