### PR TITLE
EAMxx: add chrysalis to machine specs, so we can run test-all-scream

### DIFF
--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -62,6 +62,10 @@ MACHINE_METADATA = {
                  ["mpicxx","mpifort","mpicc"],
                   "srun --time 02:00:00 --nodes=1 -p short --exclusive --account e3sm",
                   ""),
+    "chrysalis" : (["eval $(../../cime/CIME/Tools/get_case_env)", "export OMP_NUM_THREADS=1"],
+                  ["mpic++","mpif90","mpicc"],
+                  "srun --mpi=pmi2 -l -N 1 --kill-on-bad-exit --cpu_bind=cores",
+                  "/lcrc/group/e3sm/baselines/chrys/intel/scream"),
 
     "linux-generic" :        ([],["mpicxx","mpifort","mpicc"],"", ""),
     "linux-generic-debug" :  ([],["mpicxx","mpifort","mpicc"],"", ""),


### PR DESCRIPTION
I ran `test-all-scream  --no-test -i -p` and was able to generate p3/shoc baselines.

@oksanaguba I grabbed the config lines from your branch, adding a folder for the baselines.