### PR TITLE
EAMxx: fix chrysalis cmake machine file for standalone testing

### DIFF
--- a/components/eamxx/cmake/machine-files/chrysalis.cmake
+++ b/components/eamxx/cmake/machine-files/chrysalis.cmake
@@ -1,4 +1,5 @@
 include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
 common_setup()
 
-set (SCREAM_INPUT_ROOT "/lcrc/group/e3sm/ccsm-data/inputdata/" CACHE STRING "" FORCE)
+set(EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/cmake/machine-files)
+include(${EKAT_MACH_FILES_PATH}/srun.cmake)


### PR DESCRIPTION
Allows to use job scheduler for tests.