### PR TITLE
EAMxx: add OpenMP/AMD settings to chrysalis mach file

### DIFF
--- a/components/eamxx/cmake/machine-files/chrysalis.cmake
+++ b/components/eamxx/cmake/machine-files/chrysalis.cmake
@@ -2,4 +2,14 @@ include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
 common_setup()
 
 set(EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/cmake/machine-files)
+
+# Get AMD arch settings
+include(${EKAT_MACH_FILES_PATH}/kokkos/amd-zen2.cmake)
+
+# Add OpenMP settings in standalone mode OR e3sm with compile_threaded=ON
+if (NOT "${PROJECT_NAME}" STREQUAL "E3SM" OR compile_threaded)
+  include(${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+endif()
+
+# Use srun for standalone testing
 include(${EKAT_MACH_FILES_PATH}/srun.cmake)


### PR DESCRIPTION
Allows to run OMP tests on chrysalis