### PR TITLE
Fix issue where some restart configurations were failing.

### DIFF
--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -162,7 +162,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
       // NOTE: if you change the output frequency when you restart, this could lead to wonky behavior
       m_output_control.nsamples_since_last_write = m_run_t0.get_num_steps() % m_output_control.frequency; 
 
-      if (has_restart_data) {
+      if (has_restart_data && m_output_control.nsamples_since_last_write>0) {
         using namespace scorpio;
         auto fn = find_filename_in_rpointer(hist_restart_casename,false,m_io_comm,m_run_t0);
         register_file(fn.c_str(),FileMode::Read);


### PR DESCRIPTION
This commit fixes an issue where restarts that involved history files with frequency and frequency units that didn't match the simulation frequency and units would go looking for a restart history file even if it was needed.  For example if we restart a monthly run with an output stream that took average output every 3 hours then no restart history file is needed but EAMxx would still go look for one in the rpointer.atm file and throw an error.