### PR TITLE
Fix crusher-scream to use new filesystem

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -661,7 +661,7 @@
    </batch_system>
 
    <batch_system MACH="crusher-scream-gpu" type="slurm">
-     <batch_submit>/gpfs/alpine/cli133/world-shared/e3sm/tools/sbatch/throttle</batch_submit>
+     <batch_submit>/lustre/orion/cli133/world-shared/e3sm/tools/sbatch/throttle</batch_submit>
      <directives>
        <directive> -S 0</directive>
      </directives>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -713,11 +713,11 @@
     <COMPILERS>crayclang-scream</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>CLI133_crusher</PROJECT>
-    <CIME_OUTPUT_ROOT>/gpfs/alpine/cli133/proj-shared/$ENV{USER}/e3sm_scratch/crusher</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>/lustre/orion/cli133/proj-shared/$ENV{USER}/e3sm_scratch/crusher</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/gpfs/alpine/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/gpfs/alpine/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-       <CCSM_CPRNC>/gpfs/alpine/cli133/world-shared/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
+       <CCSM_CPRNC>/lustre/orion/cli133/world-shared/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <NTEST_PARALLEL_JOBS>1</NTEST_PARALLEL_JOBS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -801,7 +801,7 @@
       <env name="OMP_PLACES">threads</env>
     </environment_variables>
     <environment_variables compiler="crayclang-scream" mpilib="mpich">
-      <env name="ADIOS2_DIR">/gpfs/alpine/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
+      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
     </environment_variables>
   </machine>
 
@@ -816,11 +816,11 @@
     <COMPILERS>crayclang-scream</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>CLI133_crusher</PROJECT>
-    <CIME_OUTPUT_ROOT>/gpfs/alpine/cli133/proj-shared/$ENV{USER}/e3sm_scratch/crusher</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>/lustre/orion/cli133/proj-shared/$ENV{USER}/e3sm_scratch/crusher</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/gpfs/alpine/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/gpfs/alpine/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-    <CCSM_CPRNC>/gpfs/alpine/cli133/world-shared/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>/lustre/orion/cli133/world-shared/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <NTEST_PARALLEL_JOBS>1</NTEST_PARALLEL_JOBS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -889,7 +889,7 @@
       <env name="OMP_PLACES">threads</env>
     </environment_variables>
     <environment_variables compiler="crayclang-scream" mpilib="mpich">
-      <env name="ADIOS2_DIR">/gpfs/alpine/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
+      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
     </environment_variables>
   </machine>
 

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -714,8 +714,8 @@
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>CLI133_crusher</PROJECT>
     <CIME_OUTPUT_ROOT>/lustre/orion/cli133/proj-shared/$ENV{USER}/e3sm_scratch/crusher</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/gpfs/alpine/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/gpfs/alpine/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT>/lustre/orion/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lustre/orion/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
        <CCSM_CPRNC>/lustre/orion/cli133/world-shared/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
@@ -817,8 +817,8 @@
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>CLI133_crusher</PROJECT>
     <CIME_OUTPUT_ROOT>/lustre/orion/cli133/proj-shared/$ENV{USER}/e3sm_scratch/crusher</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/gpfs/alpine/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/gpfs/alpine/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT>/lustre/orion/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lustre/orion/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <CCSM_CPRNC>/lustre/orion/cli133/world-shared/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>


### PR DESCRIPTION
The CI pipeline stuff has also been updated to the new filesystem, `/lustre/orion`.

`ERS_D_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.crusher-scream-cpu_crayclang-scream` appears to work now.

`ERS_D_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.crusher-scream-gpu_crayclang-scream` does not build but it doesn't appear to be related to the filesystem change:

```
-- Check for working HIP compiler: /opt/rocm-5.1.0/llvm/bin/clang++ - broken
The HIP compiler

    "/opt/rocm-5.1.0/llvm/bin/clang++"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /lustre/orion/cli133/proj-shared/acmetest/e3sm_scratch/crusher/ERS_D_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.crusher-scream-gpu_crayclang-scream.20230424_130940_eu9jrl/bld/cmake-bld/CMakeFiles/CMakeTmp
    
    Run Build Command(s):/usr/bin/gmake -f Makefile cmTC_19985/fast && /usr/bin/gmake  -f CMakeFiles/cmTC_19985.dir/build.make CMakeFiles/cmTC_19985.dir/build
    gmake[1]: Entering directory '/lustre/orion/cli133/proj-shared/acmetest/e3sm_scratch/crusher/ERS_D_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.crusher-scream-gpu_crayclang-scream.20230424_130940_eu9jrl/bld/cmake-bld/CMakeFiles/CMakeTmp'
    Building HIP object CMakeFiles/cmTC_19985.dir/testHIPCompiler.hip.o
    /opt/rocm-5.1.0/llvm/bin/clang++ -D__HIP_ROCclr__=1 -I/opt/rocm-5.1.0/hip/include -I/opt/rocm-5.1.0/include -I/opt/rocm-5.1.0/hip/../include -I/opt/rocm-5.1.0/llvm/lib/clang/14.0.0 --cuda-host-only  --offload-arch=gfx90a --offload-arch=gfx90a -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -o CMakeFiles/cmTC_19985.dir/testHIPCompiler.hip.o  -c /lustre/orion/cli133/proj-shared/acmetest/e3sm_scratch/crusher/ERS_D_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.crusher-scream-gpu_crayclang-scream.20230424_130940_eu9jrl/bld/cmake-bld/CMakeFiles/CMakeTmp/testHIPCompiler.hip
    Linking HIP executable cmTC_19985
    /autofs/nccs-svm1_sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/cmake-3.21.3-rsmsjp6nq5d3ah55w4wrzjjcqgdzqmed/bin/cmake -E cmake_link_script CMakeFiles/cmTC_19985.dir/link.txt --verbose=1
    /opt/rocm-5.1.0/llvm/bin/clang++ --cuda-host-only  --offload-arch=gfx90a --offload-arch=gfx90a -L/opt/cray/pe/mpich/8.1.16/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.16/gtl/lib -lmpi_gtl_hsa  --hip-link CMakeFiles/cmTC_19985.dir/testHIPCompiler.hip.o -o cmTC_19985  /opt/rocm-5.1.0/lib/libamdhip64.so.5.1.50100 /opt/rocm-5.1.0/llvm/lib/clang/14.0.0/lib/linux/libclang_rt.builtins-x86_64.a 
    terminate called after throwing an instance of 'std::system_error'
      what():  Resource temporarily unavailable
    PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.
     #0 0x00000000008a998f PrintStackTraceSignalHandler(void*) Signals.cpp:0:0
     #1 0x00000000008a73a9 SignalHandler(int) Signals.cpp:0:0
     #2 0x00007f63e6eff8c0 __restore_rt (/lib64/libpthread.so.0+0x168c0)
     #3 0x00007f63e5960cbb raise (/lib64/libc.so.6+0x4acbb)
     #4 0x00007f63e5962355 abort (/lib64/libc.so.6+0x4c355)
     #5 0x00007f63e631a5b9 __gnu_cxx::__verbose_terminate_handler() (.cold) /home/jenkins/BUILD/snos_objdir/x86_64-suse-linux/libstdc++-v3/libsupc++/../../../../cpe-gcc-12.2.0-202211182106.97b1815c41a72/libstdc++-v3/libsupc++/vterminate.cc:75:10
     #6 0x00007f63e6325bea __cxxabiv1::__terminate(void (*)()) /home/jenkins/BUILD/snos_objdir/x86_64-suse-linux/libstdc++-v3/libsupc++/../../../../cpe-gcc-12.2.0-202211182106.97b1815c41a72/libstdc++-v3/libsupc++/eh_terminate.cc:48:15
     #7 0x00007f63e6325c55 (/opt/cray/pe/gcc-libs/libstdc++.so.6+0xb0c55)
     #8 0x00007f63e6325ea7 (/opt/cray/pe/gcc-libs/libstdc++.so.6+0xb0ea7)
     #9 0x00007f63e631d244 std::__throw_system_error(int) /home/jenkins/BUILD/snos_objdir/x86_64-suse-linux/libstdc++-v3/src/c++11/../../../../../cpe-gcc-12.2.0-202211182106.97b1815c41a72/libstdc++-v3/src/c++11/system_error.cc:524:5
    #10 0x00007f63e63518c5 (/opt/cray/pe/gcc-libs/libstdc++.so.6+0xdc8c5)
    #11 0x0000000002ec74d3 std::thread::_State_impl<std::thread::_Invoker<std::tuple<llvm::parallel::detail::(anonymous namespace)::ThreadPoolExecutor::ThreadPoolExecutor(llvm::ThreadPoolStrategy)::'lambda'()> > >::_M_run() Parallel.cpp:0:0
    #12 0x00007f63e63515a3 std::default_delete<std::thread::_State>::operator()(std::thread::_State*) const /home/jenkins/BUILD/snos_objdir/x86_64-suse-linux/libstdc++-v3/include/bits/unique_ptr.h:95:2
    #13 0x00007f63e63515a3 std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >::~unique_ptr() /home/jenkins/BUILD/snos_objdir/x86_64-suse-linux/libstdc++-v3/include/bits/unique_ptr.h:396:17
    #14 0x00007f63e63515a3 execute_native_thread_routine /home/jenkins/BUILD/snos_objdir/x86_64-suse-linux/libstdc++-v3/src/c++11/../../../../../cpe-gcc-12.2.0-202211182106.97b1815c41a72/libstdc++-v3/src/c++11/thread.cc:84:5
    #15 0x00007f63e6ef36ea start_thread (/lib64/libpthread.so.0+0xa6ea)
    #16 0x00007f63e5a2da6f clone (/lib64/libc.so.6+0x117a6f)
    clang-14: error: unable to execute command: Aborted (core dumped)
    clang-14: error: linker command failed due to signal (use -v to see invocation)
    gmake[1]: *** [CMakeFiles/cmTC_19985.dir/build.make:93: cmTC_19985] Error 254
    gmake[1]: Leaving directory '/lustre/orion/cli133/proj-shared/acmetest/e3sm_scratch/crusher/ERS_D_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.crusher-scream-gpu_crayclang-scream.20230424_130940_eu9jrl/bld/cmake-bld/CMakeFiles/CMakeTmp'
    gmake: *** [Makefile:127: cmTC_19985/fast] Error 2
```

So, HIP linking of an executable failed with:
```
Resource temporarily unavailable
```

I was able to confirm this error on the command line with HIP test program:
```
#ifndef __HIP__
# error "The CMAKE_HIP_COMPILER is set to a C/CXX compiler"
#endif
int main(){return 0;}
```

Compiling with:
```
/opt/rocm-5.1.0/llvm/bin/clang++ -D__HIP_ROCclr__=1 -I/opt/rocm-5.1.0/hip/include -I/opt/rocm-5.1.0/include -I/opt/rocm-5.1.0/hip/../include -I/opt/rocm-5.1.0/llvm/lib/clang/14.0.0 --cuda-host-only  --offload-arch=gfx90a --offload-arch=gfx90a -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -o CMakeFiles/cmTC_1d02e.dir/testHIPCompiler.hip.o  -c /lustre/orion/cli133/proj-shared/acmetest/e3sm_scratch/crusher/ERS_D_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.crusher-scream-gpu_crayclang-scream.20230424_132522_yr2yun/bld/cmake-bld/CMakeFiles/CMakeTmp/testHIPCompiler.hip
```

Linking with:
```
/opt/rocm-5.1.0/llvm/bin/clang++ --cuda-host-only  --offload-arch=gfx90a --offload-arch=gfx90a -L/opt/cray/pe/mpich/8.1.16/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.16/gtl/lib -lmpi_gtl_hsa -v --hip-link CMakeFiles/cmTC_1d02e.dir/testHIPCompiler.hip.o -o cmTC_1d02e  /opt/rocm-5.1.0/lib/libamdhip64.so.5.1.50100 /opt/rocm-5.1.0/llvm/lib/clang/14.0.0/lib/linux/libclang_rt.builtins-x86_64.a
```

I don't see any references to the old filesystem in flags or my environment, so I don't understand this fail.