### PR TITLE
Remove possibility to remap fields on the fly when using AtmosphereInput

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1153,7 +1153,7 @@ read_fields_from_file (const std::vector<std::string>& field_names,
   ic_reader_params.set("Field Names",field_names);
   ic_reader_params.set("Filename",file_name);
 
-  AtmosphereInput ic_reader(ic_reader_params,field_mgr,m_grids_manager);
+  AtmosphereInput ic_reader(ic_reader_params,field_mgr);
   ic_reader.read_variables();
   ic_reader.finalize();
 

--- a/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
+++ b/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
@@ -314,8 +314,7 @@ initialize_vertical_coordinates (const nonconstgrid_ptr_type& dyn_grid) {
     { "hybm", layout_mid }
   };
 
-  AtmosphereInput vcoord_reader(m_comm,vcoord_reader_pl);
-  vcoord_reader.init(dyn_grid,host_views,layouts);
+  AtmosphereInput vcoord_reader(vcoord_reader_pl,dyn_grid,host_views,layouts);
   vcoord_reader.read_variables();
   vcoord_reader.finalize();
 

--- a/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -27,6 +27,12 @@ void cleanup_test_f90 ();
 
 namespace {
 
+/*
+ * In this test we do a dyn->physGLL remap "on the fly" during the output phase.
+ * Then, we load the generated file on a separate FieldManager, and compare the
+ * values against the ones we would get manually running the d2p remapper.
+ */
+
 TEST_CASE("dyn_grid_io")
 {
   using namespace scream;
@@ -46,17 +52,6 @@ TEST_CASE("dyn_grid_io")
     init_parallel_f90(comm_f);
   }
   init_test_params_f90 ();
-
-  // The homme context
-  auto& c = Homme::Context::singleton();
-
-  // The TimeLevel structure is needed by the PD remapper
-  // Note: we don't remap states, so doesn't matter what values we pick
-  c.create_if_not_there<Homme::TimeLevel>();
-  auto& tl = c.get<Homme::TimeLevel>();
-  tl.np1 = 0;
-  tl.nm1 = 1;
-  tl.n0  = 2;
 
   // Set parameters
   constexpr int ne = 2;
@@ -96,9 +91,14 @@ TEST_CASE("dyn_grid_io")
   FieldIdentifier fid_phys_2 ("field_2",layout_phys_2,nondim,phys_grid->name());
   FieldIdentifier fid_phys_3 ("field_3",layout_phys_3,nondim,phys_grid->name());
 
+  // The starting FM
   auto fm_dyn = std::make_shared<FieldManager> (dyn_grid);
-  auto fm_phys= std::make_shared<FieldManager> (phys_grid);
+
+  // The FM we will manually remap onto
   auto fm_ctrl= std::make_shared<FieldManager> (phys_grid);
+
+  // The FM we will read into, and compare against the previous
+  auto fm_phys= std::make_shared<FieldManager> (phys_grid);
 
   fm_dyn->registration_begins();
   fm_phys->registration_begins();
@@ -128,67 +128,54 @@ TEST_CASE("dyn_grid_io")
 
   std::vector<std::string> fnames = {"field_1", "field_2", "field_3"};
 
-  // Randomize control fields, then remap to dyn fields
+  // Randomize dyn fields, then remap to ctrl fields
   std::uniform_real_distribution<Real> pdf(0.01,100.0);
   auto engine = setup_random_test(&comm);
-  auto dyn2phys = gm->create_remapper(dyn_grid,phys_grid);
   auto dyn2ctrl = gm->create_remapper(dyn_grid,phys_grid);
-  dyn2phys->registration_begins();
   dyn2ctrl->registration_begins();
   for (const auto& fn : fnames) {
     auto fd = fm_dyn->get_field(fn);
-    auto fp = fm_phys->get_field(fn);
     auto fc = fm_ctrl->get_field(fn);
     dyn2ctrl->register_field(fd,fc);
-    dyn2phys->register_field(fd,fp);
-    randomize(fc,engine,pdf);
+    randomize(fd,engine,pdf);
 
+    // Init phys field to something obviously wrong
+    auto fp = fm_phys->get_field(fn);
+    fp.deep_copy(-1.0);
   }
-  dyn2phys->registration_ends();
   dyn2ctrl->registration_ends();
-  dyn2ctrl->remap(false); // Remap bwd to get data from ctrl to dyn
+  dyn2ctrl->remap(true);
 
   // Now try to write all fields to file from the dyn grid fm
-  // IMPORTANT! Make the file name dependent on comm size, so all tests
-  //            can run in parallel without race conditions on the nc file.
-  ekat::ParameterList io_params;
-  io_params.set<int>("Max Snapshots Per File",1);
-  io_params.set<std::string>("Averaging Type","Instant");
-  io_params.set<std::vector<std::string>>("Grids",{"Dynamics"});
-  io_params.set<std::string>("filename_prefix","dyn_grid_io_np" + std::to_string(comm.size()));
-  io_params.sublist("Fields").sublist("Dynamics").set<std::vector<std::string>>("Field Names",fnames);
-  io_params.sublist("Fields").sublist("Dynamics").set<std::string>("IO Grid Name","Physics GLL");
+  // Note: add MPI ranks to filename, to allow MPI tests to run in parallel
+  ekat::ParameterList out_params;
+  out_params.set<std::string>("Averaging Type","Instant");
+  out_params.set<std::string>("filename_prefix","dyn_grid_io");
+  out_params.sublist("Fields").sublist("Dynamics").set<std::vector<std::string>>("Field Names",fnames);
+  out_params.sublist("Fields").sublist("Dynamics").set<std::string>("IO Grid Name","Physics GLL");
 
-  io_params.sublist("output_control").set<int>("Frequency",1);
-  io_params.sublist("output_control").set<std::string>("frequency_units","nsteps");
-  io_params.set<std::string>("Floating Point Precision","real");
+  out_params.sublist("output_control").set<int>("Frequency",1);
+  out_params.sublist("output_control").set<std::string>("frequency_units","nsteps");
+  out_params.sublist("output_control").set<bool>("MPI Ranks in Filename",true);
+  out_params.set<std::string>("Floating Point Precision","real");
 
   OutputManager output;
-  // AtmosphereOutput output(comm,io_params,fm_dyn,gm);
-  output.setup (comm, io_params, fm_dyn, gm, t0, t0, false);
+  output.setup (comm, out_params, fm_dyn, gm, t0, t0, false);
   output.run(t0);
   output.finalize();
 
-  // Clear the content of the dyn fields, to avoid seeing the same numbers
-  // only b/c nothing was in fact read.
-  for (const auto& fn : fnames) {
-    auto f = fm_dyn->get_field(fn);
-    f.deep_copy(-1.0);
-  }
-
   // Next, let's load all fields from file directly into the dyn grid fm
-  std::string filename = "dyn_grid_io_np" + std::to_string(comm.size())
-                       + ".INSTANT.nsteps_x1." + t0.to_string() + ".nc";
+  std::string filename = "dyn_grid_io.INSTANT.nsteps_x1.np" + std::to_string(comm.size()) + "." + t0.to_string() + ".nc";
   filename.erase(std::remove(filename.begin(),filename.end(),':'),filename.end());
 
-  io_params.set<std::string>("Filename",filename);
-  io_params.set<std::string>("Grid",dyn_grid->name());
-  AtmosphereInput input (io_params,fm_dyn, gm);
+  ekat::ParameterList in_params;
+  in_params.set<std::string>("Filename",filename);
+  in_params.set<std::vector<std::string>>("Field Names",fnames);
+  AtmosphereInput input (in_params,fm_phys);
   input.read_variables();
   input.finalize();
 
-  // Remap dyn->phys, and compare against ctrl
-  dyn2phys->remap(true);
+  // Compare against ctrl fields
   for (const auto& fn : fnames) {
     auto fp = fm_phys->get_field(fn);
     auto fc = fm_ctrl->get_field(fn);

--- a/components/eamxx/src/physics/nudging/atmosphere_nudging.cpp
+++ b/components/eamxx/src/physics/nudging/atmosphere_nudging.cpp
@@ -91,8 +91,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
   // We need to skip grid checks because multiple ranks 
   // may want the same column of source data.
   data_in_params.set("Skip_Grid_Checks",true);  
-  data_input = std::make_shared<AtmosphereInput>(m_comm,data_in_params);
-  data_input->init(grid_l,host_views,layouts);
+  data_input.init(data_in_params,grid_l,host_views,layouts);
 
   T_mid_ext = fields_ext["T_mid"];
   p_mid_ext = fields_ext["p_mid"];
@@ -137,7 +136,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
   NudgingData_aft.time = -999;
 
   //Read in the first time step
-  data_input->read_variables(0);
+  data_input.read_variables(0);
   Kokkos::deep_copy(NudgingData_bef.T_mid,fields_ext_h["T_mid"]);
   Kokkos::deep_copy(NudgingData_bef.p_mid,fields_ext_h["p_mid"]);
   Kokkos::deep_copy(NudgingData_bef.u,fields_ext_h["u"]);
@@ -146,7 +145,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
   NudgingData_bef.time = 0.;
 
   //Read in the first time step
-  data_input->read_variables(1);
+  data_input.read_variables(1);
   Kokkos::deep_copy(NudgingData_aft.T_mid,fields_ext_h["T_mid"]);
   Kokkos::deep_copy(NudgingData_aft.p_mid,fields_ext_h["p_mid"]);
   Kokkos::deep_copy(NudgingData_aft.u,fields_ext_h["u"]);
@@ -225,7 +224,7 @@ void Nudging::update_time_step (const int time_s)
       std::swap (NudgingData_bef,NudgingData_aft);
       NudgingData_bef.time = NudgingData_aft.time;
 
-      data_input->read_variables(time_index+1);
+      data_input.read_variables(time_index+1);
       Kokkos::deep_copy(NudgingData_aft.T_mid,fields_ext_h["T_mid"]);
       Kokkos::deep_copy(NudgingData_aft.p_mid,fields_ext_h["p_mid"]);
       Kokkos::deep_copy(NudgingData_aft.u,fields_ext_h["u"]);
@@ -347,7 +346,7 @@ void Nudging::run_impl (const double dt)
 // =========================================================================================
 void Nudging::finalize_impl()
 {
-  data_input->finalize();
+  data_input.finalize();
 }
 
 } // namespace scream

--- a/components/eamxx/src/physics/nudging/atmosphere_nudging.cpp
+++ b/components/eamxx/src/physics/nudging/atmosphere_nudging.cpp
@@ -35,7 +35,7 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 
   //Now need to read in the file
   scorpio::register_file(datafile,scorpio::Read);
-  m_num_src_levs = scorpio::get_dimlen_c2f(datafile.c_str(),"lev");
+  m_num_src_levs = scorpio::get_dimlen(datafile,"lev");
   double time_value_1= scorpio::read_time_at_index_c2f(datafile.c_str(),1);
   double time_value_2= scorpio::read_time_at_index_c2f(datafile.c_str(),2);
     

--- a/components/eamxx/src/physics/nudging/atmosphere_nudging.hpp
+++ b/components/eamxx/src/physics/nudging/atmosphere_nudging.hpp
@@ -96,7 +96,7 @@ protected:
   TimeStamp ts0;
   NudgingFunc::NudgingData NudgingData_bef;
   NudgingFunc::NudgingData NudgingData_aft;
-  std::shared_ptr<AtmosphereInput> data_input;
+  AtmosphereInput data_input;
 }; // class Nudging
 
 } // namespace scream

--- a/components/eamxx/src/physics/spa/atmosphere_prescribed_aerosol.cpp
+++ b/components/eamxx/src/physics/spa/atmosphere_prescribed_aerosol.cpp
@@ -67,7 +67,7 @@ void SPA::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   //       take this information directly from the spa data file.
   m_spa_data_file = m_params.get<std::string>("spa_data_file");
   scorpio::register_file(m_spa_data_file,scorpio::Read);
-  m_num_src_levs = scorpio::get_dimlen_c2f(m_spa_data_file.c_str(),"lev");
+  m_num_src_levs = scorpio::get_dimlen(m_spa_data_file,"lev");
   scorpio::eam_pio_closefile(m_spa_data_file);
   SPAHorizInterp.m_comm = m_comm;
 

--- a/components/eamxx/src/physics/spa/spa_functions_impl.hpp
+++ b/components/eamxx/src/physics/spa/spa_functions_impl.hpp
@@ -430,7 +430,6 @@ void SPAFunctions<S,D>
   spa_data_in_params.set("Field Names",fnames);
   spa_data_in_params.set("Filename",spa_data_file_name);
   spa_data_in_params.set("Skip_Grid_Checks",true);  // We need to skip grid checks because multiple ranks may want the same column of source data.
-  AtmosphereInput spa_data_input(comm,spa_data_in_params);
   
   // Construct the grid needed for input:
   auto grid = std::make_shared<PointGrid>("grid",num_local_cols,source_data_nlevs,comm);
@@ -496,7 +495,7 @@ void SPAFunctions<S,D>
   //
   
   // Now that we have all the variables defined we can use the scorpio_input class to grab the data.
-  spa_data_input.init(grid,host_views,layouts);
+  AtmosphereInput spa_data_input(spa_data_in_params,grid,host_views,layouts);
   spa_data_input.read_variables(time_index);
   spa_data_input.finalize();
   scorpio::eam_pio_closefile(spa_data_file_name);

--- a/components/eamxx/src/physics/spa/spa_functions_impl.hpp
+++ b/components/eamxx/src/physics/spa/spa_functions_impl.hpp
@@ -414,8 +414,7 @@ void SPAFunctions<S,D>
   auto unique_src_dofs = spa_horiz_map.get_unique_source_dofs();
   const int num_local_cols = spa_horiz_map.get_num_unique_dofs();
   scorpio::register_file(spa_data_file_name,scorpio::Read);
-  const int source_data_nlevs = scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"lev");
-  scorpio::eam_pio_closefile(spa_data_file_name);
+  const int source_data_nlevs = scorpio::get_dimlen(spa_data_file_name,"lev");
 
   // Construct local arrays to read data into
   // Note, all of the views being created here are meant to hold the source resolution
@@ -440,8 +439,10 @@ void SPAFunctions<S,D>
 
   // Check that padding matches source size:
   EKAT_REQUIRE(source_data_nlevs+2 == spa_data.data.nlevs);
-  EKAT_REQUIRE_MSG(nswbands==scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"swband"),"ERROR update_spa_data_from_file: Number of SW bands in simulation doesn't match the SPA data file");
-  EKAT_REQUIRE_MSG(nlwbands==scorpio::get_dimlen_c2f(spa_data_file_name.c_str(),"lwband"),"ERROR update_spa_data_from_file: Number of LW bands in simulation doesn't match the SPA data file");
+  EKAT_REQUIRE_MSG(nswbands==scorpio::get_dimlen(spa_data_file_name,"swband"),
+      "ERROR update_spa_data_from_file: Number of SW bands in simulation doesn't match the SPA data file");
+  EKAT_REQUIRE_MSG(nlwbands==scorpio::get_dimlen(spa_data_file_name,"lwband"),
+      "ERROR update_spa_data_from_file: Number of LW bands in simulation doesn't match the SPA data file");
 
   // Constuct views to read source data in from file
   typename view_1d<Real>::HostMirror hyam_v_h("hyam",source_data_nlevs);
@@ -498,6 +499,7 @@ void SPAFunctions<S,D>
   spa_data_input.init(grid,host_views,layouts);
   spa_data_input.read_variables(time_index);
   spa_data_input.finalize();
+  scorpio::eam_pio_closefile(spa_data_file_name);
   stop_timer("EAMxx::SPA::update_spa_data_from_file::read_data");
   start_timer("EAMxx::SPA::update_spa_data_from_file::apply_remap");
   // Copy data from host back to the device views.

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
@@ -178,8 +178,7 @@ load_lat_lon (const nonconstgrid_ptr_type& grid, const std::string& filename) co
   lat_lon_reader_pl.set("Filename",filename);
   lat_lon_reader_pl.set<std::vector<std::string>>("Field Names",{"lat","lon"});
 
-  AtmosphereInput lat_lon_reader(m_comm, lat_lon_reader_pl);
-  lat_lon_reader.init(grid, host_views, layouts);
+  AtmosphereInput lat_lon_reader(lat_lon_reader_pl, grid, host_views, layouts);
   lat_lon_reader.read_variables();
   lat_lon_reader.finalize();
 
@@ -229,8 +228,7 @@ load_vertical_coordinates (const nonconstgrid_ptr_type& grid, const std::string&
   vcoord_reader_pl.set("Filename",filename);
   vcoord_reader_pl.set<std::vector<std::string>>("Field Names",{"hyam","hybm"});
 
-  AtmosphereInput vcoord_reader(m_comm,vcoord_reader_pl);
-  vcoord_reader.init(grid, host_views, layouts);
+  AtmosphereInput vcoord_reader(vcoord_reader_pl,grid, host_views, layouts);
   vcoord_reader.read_variables();
   vcoord_reader.finalize();
 

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
@@ -140,13 +140,13 @@ add_geo_data (const nonconstgrid_ptr_type& grid) const
     hybm.sync_to_dev();
   } else if (geo_data_source=="IC_FILE"){
     const auto& filename = m_params.get<std::string>("ic_filename");
-    if (scorpio::has_variable_c2f(filename.c_str(),"lat") &&
-        scorpio::has_variable_c2f(filename.c_str(),"lon")) {
+    if (scorpio::has_variable(filename,"lat") &&
+        scorpio::has_variable(filename,"lon")) {
       load_lat_lon(grid,filename);
     }
 
-    if (scorpio::has_variable_c2f(filename.c_str(),"hyam") &&
-        scorpio::has_variable_c2f(filename.c_str(),"hybm")) {
+    if (scorpio::has_variable(filename,"hyam") &&
+        scorpio::has_variable(filename,"hybm")) {
       load_vertical_coordinates(grid,filename);
     }
   }

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -904,7 +904,7 @@ get_my_triplets_gids (const std::string& map_file,
   scorpio::register_file(map_file,scorpio::FileMode::Read);
   // 1. Create a "helper" grid, with as many dofs as the number
   //    of triplets in the map file, and divided linearly across ranks
-  const int ngweights = scorpio::get_dimlen_c2f(map_file.c_str(),"n_s");
+  const int ngweights = scorpio::get_dimlen(map_file,"n_s");
   const auto io_grid_linear = create_point_grid ("helper",ngweights,1,m_comm);
   const int nlweights = io_grid_linear->get_num_local_dofs();
 

--- a/components/eamxx/src/share/grid/remap/horizontal_remap_utility.cpp
+++ b/components/eamxx/src/share/grid/remap/horizontal_remap_utility.cpp
@@ -43,7 +43,7 @@ void HorizontalMap::set_remap_segments_from_file(const std::string& remap_filena
   start_timer("EAMxx::HorizontalMap::set_remap_segments_from_file");
   // Open remap file and determine the amount of data to be read
   scorpio::register_file(remap_filename,scorpio::Read);
-  const auto remap_size = scorpio::get_dimlen_c2f(remap_filename.c_str(),"n_s"); // Note, here we assume a standard format of col, row, S
+  const auto remap_size = scorpio::get_dimlen(remap_filename,"n_s"); // Note, here we assume a standard format of col, row, S
   // Step 1: Read in the "row" data from the file to figure out which mpi ranks care about which
   //         chunk of the remap data.  This step reduces the memory footprint of reading in the
   //         map data, which can be rather large.

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -54,7 +54,7 @@ VerticalRemapper (const grid_ptr_type& src_grid,
   // as the source field, but will have a different number of 
   // vertical levels.
   scorpio::register_file(map_file,scorpio::FileMode::Read);
-  m_num_remap_levs = scorpio::get_dimlen_c2f(map_file.c_str(),"nlevs");
+  m_num_remap_levs = scorpio::get_dimlen(map_file,"nlevs");
   scorpio::eam_pio_closefile(map_file);
 
   auto tgt_grid_gids = src_grid->get_unique_gids();

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -8,33 +8,11 @@
 
 namespace scream
 {
-
-/* ---------------------------------------------------------- */
-AtmosphereInput::
-AtmosphereInput (const ekat::Comm& comm,
-                 const ekat::ParameterList& params)
- : m_comm   (comm)
- , m_params (params)
-{
-  m_filename = m_params.get<std::string>("Filename");
-
-  // This ensures that the nc file is open, even if init() doesn't
-  // get called. This allows users to read global scalar values from
-  // an nc file, by easily creating an AtmosphereInput on the fly.
-  scorpio::register_file(m_filename,scorpio::Read);
-
-  // TODO: check that comm is compatible with the pio subsystem comm?
-}
-
 AtmosphereInput::
 AtmosphereInput (const ekat::ParameterList& params,
-                 const std::shared_ptr<const fm_type>& field_mgr,
-                 const std::shared_ptr<const gm_type>& grids_mgr)
- : AtmosphereInput(field_mgr->get_grid()->get_comm(),params)
+                const std::shared_ptr<const fm_type>& field_mgr)
 {
-  // Sets the internal field mg, possibly sets up the remapper,
-  // and init scorpio internal structures
-  init (field_mgr, grids_mgr);
+  init(params,field_mgr);
 }
 
 AtmosphereInput::
@@ -42,138 +20,89 @@ AtmosphereInput (const ekat::ParameterList& params,
                  const std::shared_ptr<const grid_type>& grid,
                  const std::map<std::string,view_1d_host>& host_views_1d,
                  const std::map<std::string,FieldLayout>&  layouts)
- : AtmosphereInput(grid->get_comm(),params)
 {
-  // Sets the grid, the host views, and init scorpio internal structures
-  init (grid,host_views_1d,layouts);
+  init (params,grid,host_views_1d,layouts);
 }
 
 void AtmosphereInput::
-init (const std::shared_ptr<const fm_type>& field_mgr,
-      const std::shared_ptr<const gm_type>& grids_mgr)
+init (const ekat::ParameterList& params,
+      const std::shared_ptr<const fm_type>& field_mgr)
 {
-  // Set list of fields. Use grid name to potentially find correct sublist inside 'Fields' list.
-  set_fields_and_grid_names (field_mgr->get_grid()->aliases());
+  EKAT_REQUIRE_MSG (not m_inited_with_views,
+      "Error! Input class was already inited (with user-provided views).\n");
+  EKAT_REQUIRE_MSG (not m_inited_with_fields,
+      "Error! Input class was already inited (with fields).\n");
+
+  m_params = params;
+  m_fields_names = m_params.get<decltype(m_fields_names)>("Field Names");
+  m_filename = m_params.get<std::string>("Filename");
 
   // Sets the internal field mgr, and possibly sets up the remapper
-  set_field_manager(field_mgr,grids_mgr);
+  set_field_manager(field_mgr);
 
   // Init scorpio internal structures
   init_scorpio_structures ();
+
+  m_inited_with_fields = true;
 }
 
 void AtmosphereInput::
-init (const std::shared_ptr<const grid_type>& grid,
+init (const ekat::ParameterList& params,
+      const std::shared_ptr<const grid_type>& grid,
       const std::map<std::string,view_1d_host>& host_views_1d,
       const std::map<std::string,FieldLayout>&  layouts)
 {
-  // Set list of fields. Use grid name to potentially find correct sublist inside 'Fields' list.
-  set_fields_and_grid_names (grid->aliases());
+  EKAT_REQUIRE_MSG (not m_inited_with_views,
+      "Error! Input class was already inited (with user-provided views).\n");
+  EKAT_REQUIRE_MSG (not m_inited_with_fields,
+      "Error! Input class was already inited (with fields).\n");
+
+  m_params = params;
+  m_filename = m_params.get<std::string>("Filename");
 
   // Set the grid associated with the input views
   set_grid(grid);
+
+  EKAT_REQUIRE_MSG (host_views_1d.size()==layouts.size(),
+      "Error! Input host views and layouts maps has different sizes.\n"
+      "       Input size: " + std::to_string(host_views_1d.size()) + "\n"
+      "       Expected size: " + std::to_string(m_fields_names.size()) + "\n");
+
+  m_layouts = layouts;
+  m_host_views_1d = host_views_1d;
+
+  // Loop over one of the two maps, store key in m_fields_names,
+  // and check that the two maps have the same keys
+  for (const auto& it : m_layouts) {
+    m_fields_names.push_back(it.first);
+    EKAT_REQUIRE_MSG (m_host_views_1d.count(it.first)==1,
+        "Error! Input layouts and views maps do not store the same keys.\n");
+  }
 
   // Set the host views
   set_views(host_views_1d,layouts);
 
   // Init scorpio internal structures
   init_scorpio_structures ();
+
+  m_inited_with_views = true;
 }
 
 /* ---------------------------------------------------------- */
 
 void AtmosphereInput::
-set_fields_and_grid_names (const std::vector<std::string>& grid_aliases) {
-  // The user might just want to read some global attributes (no fields),
-  // so get the list of fields names only if present.
-  using vos_t = std::vector<std::string>;
-  if (m_params.isParameter("Field Names")) {
-    m_fields_names = m_params.get<vos_t>("Field Names");
-    if (m_params.isParameter("IO Grid Name")) {
-      m_io_grid_name = m_params.get<std::string>("IO Grid Name");
-    }
-  } else {
-    for (const auto& grid_name : grid_aliases) {
-      if (m_params.isSublist("Fields") && grid_name!="") {
-        const auto& pl = m_params.sublist("Fields").sublist(grid_name);
-        m_fields_names = pl.get<vos_t>("Field Names");
-        if (pl.isParameter("IO Grid Name")) {
-          m_io_grid_name = pl.get<std::string>("IO Grid Name");
-        }
-      }
-      break;
-    }
-  }
-}
-
-void AtmosphereInput::
-set_field_manager (const std::shared_ptr<const fm_type>& field_mgr,
-                   const std::shared_ptr<const gm_type>& grids_mgr)
+set_field_manager (const std::shared_ptr<const fm_type>& field_mgr)
 {
   // Sanity checks
   EKAT_REQUIRE_MSG (field_mgr, "Error! Invalid field manager pointer.\n");
   EKAT_REQUIRE_MSG (field_mgr->get_grid(), "Error! Field manager stores an invalid grid pointer.\n");
-  EKAT_REQUIRE_MSG (not m_inited_with_views,
-      "Error! Input class was already inited with user-provided views.\n");
-  EKAT_REQUIRE_MSG (not m_inited_with_fields,
-      "Error! Input class was already inited with fields.\n");
 
   m_field_mgr = field_mgr;
 
-  std::shared_ptr<const grid_type> fm_grid, io_grid;
-  io_grid = fm_grid = m_field_mgr->get_grid();
-
-  if (m_io_grid_name!="" && m_io_grid_name!=fm_grid->name()) {
-    // We build a remapper, to remap fields from the fm grid to the io grid
-    io_grid = grids_mgr->get_grid(m_io_grid_name);
-    m_remapper = grids_mgr->create_remapper(io_grid,fm_grid);
-
-    // Register all input fields in the remapper.
-    m_remapper->registration_begins();
-    for (const auto& fname : m_fields_names) {
-      auto f = m_field_mgr->get_field(fname);
-      const auto& tgt_fid = f.get_header().get_identifier();
-      EKAT_REQUIRE_MSG(tgt_fid.data_type()==DataType::RealType,
-          "Error! I/O supports only Real data, for now.\n");
-      m_remapper->register_field_from_tgt(tgt_fid);
-    }
-    m_remapper->registration_ends();
-
-    // Now create a new FM on io grid, and create copies of input fields from FM.
-    auto io_fm = std::make_shared<fm_type>(io_grid);
-    io_fm->registration_begins();
-    for (int i=0; i<m_remapper->get_num_fields(); ++i) {
-      const auto& src_fid = m_remapper->get_src_field_id(i);
-      io_fm->register_field(FieldRequest(src_fid));
-    }
-    io_fm->registration_ends();
-
-    // Now that fields have been allocated on the io grid, we can bind them in the remapper
-    for (const auto& fname : m_fields_names) {
-      auto src = io_fm->get_field(fname);
-      auto tgt = m_field_mgr->get_field(fname);
-      m_remapper->bind_field(src,tgt);
-    }
-
-    // This should never fail, but just in case
-    EKAT_REQUIRE_MSG (m_remapper->get_num_fields()==m_remapper->get_num_bound_fields(),
-        "Error! Something went wrong while building the scorpio input remapper.\n");
-
-    // Reset field mgr
-    m_field_mgr = io_fm;
-  }
-
   // Store grid and fm
-  set_grid(io_grid);
+  set_grid(m_field_mgr->get_grid());
 
   // Init fields specs
-  register_fields_specs();
-
-  m_inited_with_fields = true;
-}
-
-void AtmosphereInput::
-register_fields_specs() {
   for (auto const& name : m_fields_names) {
     auto f = m_field_mgr->get_field(name);
     const auto& fh  = f.get_header();
@@ -198,12 +127,12 @@ register_fields_specs() {
   }
 }
 
+
 /* ---------------------------------------------------------- */
 void AtmosphereInput::
 set_grid (const std::shared_ptr<const AbstractGrid>& grid)
 {
   // Sanity checks
-  EKAT_REQUIRE_MSG (not m_io_grid, "Error! Grid pointer was already set.\n");
   EKAT_REQUIRE_MSG (grid, "Error! Input grid pointer is invalid.\n");
   const bool skip_grid_chk = m_params.get<bool>("Skip_Grid_Checks",false);
   if (!skip_grid_chk) {
@@ -218,16 +147,13 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
         "   - num global dofs: " + std::to_string(grid->get_num_global_dofs()) + "\n");
   }
 
-  EKAT_REQUIRE_MSG(m_comm.size()<=grid->get_num_global_dofs(),
+  EKAT_REQUIRE_MSG(grid->get_comm().size()<=grid->get_num_global_dofs(),
       "Error! PIO interface requires the size of the IO MPI group to be\n"
       "       no greater than the global number of columns.\n"
       "       Consider decreasing the size of IO MPI group.\n");
 
   // The grid is good. Store it.
   m_io_grid = grid;
-
-  // Reset the comm
-  m_comm = m_io_grid->get_comm();
 }
 
 /* ---------------------------------------------------------- */
@@ -349,35 +275,26 @@ void AtmosphereInput::read_variables (const int time_index)
       f.sync_to_dev();
     }
   }
-
-  if (m_remapper) {
-    m_remapper->remap(true);
-  }
 } 
 
 void AtmosphereInput::
 set_views (const std::map<std::string,view_1d_host>& host_views_1d,
            const std::map<std::string,FieldLayout>&  layouts)
 {
-  // Sanity checks
-  EKAT_REQUIRE_MSG (not m_inited_with_views,
-      "Error! Input class was already inited with user-provided views.\n");
-  EKAT_REQUIRE_MSG (not m_inited_with_fields,
-      "Error! Input class was already inited with fields.\n");
-  EKAT_REQUIRE_MSG (host_views_1d.size()==m_fields_names.size(),
-      "Error! Input host views map has the wrong size.\n"
+  EKAT_REQUIRE_MSG (host_views_1d.size()==layouts.size(),
+      "Error! Input host views and layouts maps has different sizes.\n"
       "       Input size: " + std::to_string(host_views_1d.size()) + "\n"
       "       Expected size: " + std::to_string(m_fields_names.size()) + "\n");
-  EKAT_REQUIRE_MSG (layouts.size()==m_fields_names.size(),
-      "Error! Input layouts map has the wrong size.\n"
-      "       Input size: " + std::to_string(layouts.size()) + "\n"
-      "       Expected size: " + std::to_string(m_fields_names.size()) + "\n");
 
-  // Loop over names, rather than just set inputs map in the class.
-  // This way, if an expected name is missing, the at(..) method will throw.
-  for (auto const& name : m_fields_names) {
-    m_layouts.emplace(name,layouts.at(name));
-    m_host_views_1d[name] = host_views_1d.at(name);
+  m_layouts = layouts;
+  m_host_views_1d = host_views_1d;
+
+  // Loop over one of the two maps, store key in m_fields_names,
+  // and check that the two maps have the same keys
+  for (const auto& it : m_layouts) {
+    m_fields_names.push_back(it.first);
+    EKAT_REQUIRE_MSG (m_host_views_1d.count(it.first)==1,
+        "Error! Input layouts and views maps do not store the same keys.\n");
   }
 
   m_inited_with_views = true;
@@ -390,7 +307,6 @@ void AtmosphereInput::finalize()
 
   m_field_mgr = nullptr;
   m_io_grid   = nullptr;
-  m_remapper  = nullptr;
 
   m_host_views_1d.clear();
   m_layouts.clear();
@@ -402,6 +318,8 @@ void AtmosphereInput::finalize()
 /* ---------------------------------------------------------- */
 void AtmosphereInput::init_scorpio_structures() 
 {
+  scorpio::register_file(m_filename,scorpio::Read);
+
   // Register variables with netCDF file.
   register_variables();
   set_degrees_of_freedom();

--- a/components/eamxx/src/share/io/scorpio_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_input.hpp
@@ -7,26 +7,16 @@
 #include "share/grid/grids_manager.hpp"
 
 #include "ekat/ekat_parameter_list.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
 
 /*  The AtmosphereInput class handles all input streams to SCREAM.
  *  It is important to note that there does not exist an InputManager,
  *  like in the case of output.  So all input streams have to be managed
- *  directly by the process that requires it.
- *
- *  The typical input call will be to the outward facing routine 'pull_input'.
- *
- *  Currently, input can only handle single timesnap input files.  In other words
- *  files that will be opened, read and closed within the same timestep and only
- *  store one timesnap of data.
+ *  directly by the process that requires it. The reason is that input
+ *  operations are less convoluted than output ones (e.g., no averaging).
  *
  *  Note: the init, and finalize are separate routines that are outward facing in
  *  this class to facilitate cases where reading input over some number of simulation
  *  timesteps is possible.
- *
- *  At construction time ALL output instances require at least an EKAT comm group and
- *  an EKAT parameter list. The following arguments depend on the input class use case.
- *  See constructors documentation for more info.
  *
  *  The EKAT parameter list contains the following options to control input behavior:
  *  -----
@@ -73,45 +63,10 @@ public:
   using view_1d_host = view_Nd_host<1>;
 
   // --- Constructor(s) & Destructor --- //
-  // Creates bare input. Will require a call to one of the two 'init' methods.
-  // Constructor inputs:
-  //  - comm: the MPI comm used for I/O operations. Notice that the
-  //          associated MPI group *must* be contained in the MPI
-  //          group in the overall atm comm, but it *might* be smaller
-  //          (and likely *will* be smaller, for large scale runs).
-  //  - params: a parameter list containing info on the file/fields to load.
-  AtmosphereInput (const ekat::Comm& comm,
-                   const ekat::ParameterList& params);
-  // Creates input to read into FieldManager-owned fields.
-  // Constructor inputs:
-  //  - comm: the MPI comm used for I/O operations. Notice that the
-  //          associated MPI group *must* be contained in the MPI
-  //          group in the overall atm comm, but it *might* be smaller
-  //          (and likely *will* be smaller, for large scale runs).
-  //  - params: a parameter list containing info on the file/fields to load.
-  //  - field_mgr: the FieldManager containing the Field's where the
-  //               variables from the input filed will be read into.
-  //               Fields can be padded/strided.
-  // It calls init(field_mgr) at the end.
-  // TODO: is comm superfluous, considering we can get it from the grid in the field_mgr?
+  // NOTE: non-trivial constructors simply call the corresponding init method
+  AtmosphereInput () = default;
   AtmosphereInput (const ekat::ParameterList& params,
-                   const std::shared_ptr<const fm_type>& field_mgr,
-                   const std::shared_ptr<const gm_type>& grids_mgr = nullptr);
-
-  // Creates input to read into user-provided flattened 1d host views.
-  // Constructor inputs:
-  //  - comm: the MPI comm used for I/O operations. Notice that the
-  //          associated MPI group *must* be contained in the MPI
-  //          group in the overall atm comm, but it *might* be smaller
-  //          (and likely *will* be smaller, for large scale runs).
-  //  - params: a parameter list containing info on the file/fields to load.
-  //  - grid: the grid where the variables live
-  //  - host_views_1d: the 1d flattened views where data will be read into.
-  //                   These views must be contiguous (no padding/striding).
-  //  - layouts: the layout of the vars (used to reshape the views).
-  // It calls init(grid,host_views_1d,layouts) at the end.
-  // TODO: do not require layouts, and read them from file.
-  // TODO: is comm superfluous, considering we can get it from the grid?
+                   const std::shared_ptr<const fm_type>& field_mgr);
   AtmosphereInput (const ekat::ParameterList& params,
                    const std::shared_ptr<const grid_type>& grid,
                    const std::map<std::string,view_1d_host>& host_views_1d,
@@ -120,31 +75,38 @@ public:
   virtual ~AtmosphereInput () = default;
 
   // --- Methods --- //
-  // In case the class was constructed with the minimal ctor, these methods
-  // allow to finalize initialization later.
-  // NOTE: these two init methods are mutually exclusive
-  void init (const std::shared_ptr<const fm_type>& field_mgr,
-             const std::shared_ptr<const gm_type>& grids_mgr = nullptr);
-  void init (const std::shared_ptr<const grid_type>& grid,
+  // Initialize the class for reading into FieldManager-owned fields.
+  //  - params: input parameters (must contain at least "Filename")
+  //  - field_mgr: the FieldManager containing the Field's where the
+  //               variables from the input filed will be read into.
+  //               Fields can be padded/strided.
+  void init (const ekat::ParameterList& params,
+             const std::shared_ptr<const fm_type>& field_mgr);
+
+  // Initialize the class for reading into user-provided flattened 1d host views.
+  //  - params: input parameters (must contain at least "Filename")
+  //  - grid: the grid where the variables live
+  //  - host_views_1d: the 1d flattened views where data will be read into.
+  //                   These views must be contiguous (no padding/striding).
+  //  - layouts: the layout of the vars (used to reshape the views).
+  void init (const ekat::ParameterList& params,
+             const std::shared_ptr<const grid_type>& grid,
              const std::map<std::string,view_1d_host>& host_views_1d,
              const std::map<std::string,FieldLayout>&  layouts);
 
   // Read fields that were required via parameter list.
   void read_variables (const int time_index = -1);
+
+  // Cleans up the class
   void finalize();
 
 protected:
 
-  void set_fields_and_grid_names (const std::vector<std::string>& grid_aliases);
-  void build_remapper (const std::shared_ptr<const gm_type>& grids_mgr);
   void set_grid (const std::shared_ptr<const AbstractGrid>& grid);
-  void set_field_manager (const std::shared_ptr<const fm_type>& field_mgr,
-                          const std::shared_ptr<const gm_type>& grids_mgr);
+  void set_field_manager (const std::shared_ptr<const fm_type>& field_mgr);
   void set_views (const std::map<std::string,view_1d_host>& host_views_1d,
                   const std::map<std::string,FieldLayout>&  layouts);
   void init_scorpio_structures ();
-
-  void register_fields_specs ();
 
   void register_variables();
   void set_degrees_of_freedom();
@@ -154,18 +116,15 @@ protected:
   std::vector<scorpio::offset_t> get_var_dof_offsets (const FieldLayout& layout);
 
   // Internal variables
-  ekat::Comm            m_comm;
   ekat::ParameterList   m_params;
 
   std::shared_ptr<const fm_type>        m_field_mgr;
   std::shared_ptr<const AbstractGrid>   m_io_grid;
-  std::shared_ptr<remapper_type>        m_remapper;
 
   std::map<std::string, view_1d_host>   m_host_views_1d;
   std::map<std::string, FieldLayout>    m_layouts;
   
   std::string               m_filename;
-  std::string               m_io_grid_name;
   std::vector<std::string>  m_fields_names;
 
   bool m_inited_with_fields        = false;

--- a/components/eamxx/src/share/io/scream_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.cpp
@@ -95,6 +95,69 @@ void set_decomp(const std::string& filename) {
   set_decomp_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
+int get_dimlen(const std::string& filename, const std::string& dimname)
+{
+  int ncid, dimid, err;
+  PIO_Offset len;
+
+  bool was_open = is_file_open_c2f(filename.c_str(),-1);
+  if (not was_open) {
+    register_file(filename,Read);
+  }
+
+  ncid = get_file_ncid_c2f (filename.c_str());
+  err = PIOc_inq_dimid(ncid,dimname.c_str(),&dimid);
+  EKAT_REQUIRE_MSG (err!=PIO_EBADDIM,
+      "Error! Could not find dimension in the file.\n"
+      " - filename : " + filename + "\n"
+      " - dimname  : " + dimname + "\n"
+      " - pio error: " + std::to_string(err) + "\n");
+  EKAT_REQUIRE_MSG (err==PIO_NOERR,
+      "Error! Something went wrong while retrieving dimension id.\n"
+      " - filename : " + filename + "\n"
+      " - dimname  : " + dimname + "\n"
+      " - pio error: " + std::to_string(err) + "\n");
+
+  err = PIOc_inq_dimlen(ncid,dimid,&len);
+  EKAT_REQUIRE_MSG (err==PIO_NOERR,
+      "Error! Something went wrong while querying dimension length.\n"
+      " - filename : " + filename + "\n"
+      " - dimname  : " + dimname + "\n"
+      " - pio error: " + std::to_string(err) + "\n");
+
+  if (not was_open) {
+    eam_pio_closefile(filename);
+  }
+
+  return len;
+}
+/* ----------------------------------------------------------------- */
+bool has_variable (const std::string& filename, const std::string& varname)
+{
+  int ncid, varid, err;
+
+  bool was_open = is_file_open_c2f(filename.c_str(),-1);
+  if (not was_open) {
+    register_file(filename,Read);
+  }
+
+  ncid = get_file_ncid_c2f (filename.c_str());
+  err = PIOc_inq_varid(ncid,varname.c_str(),&varid);
+  if (err==PIO_ENOTVAR) {
+    return false;
+  }
+  EKAT_REQUIRE_MSG (err==PIO_NOERR,
+      "Error! Something went wrong while retrieving dimension id.\n"
+      " - filename : " + filename + "\n"
+      " - varname  : " + varname + "\n"
+      " - pio error: " + std::to_string(err) + "\n");
+  if (not was_open) {
+    eam_pio_closefile(filename);
+  }
+
+  return true;
+}
+/* ----------------------------------------------------------------- */
 void set_dof(const std::string& filename, const std::string& varname, const Int dof_len, const std::int64_t* x_dof) {
 
   set_dof_c2f(filename.c_str(),varname.c_str(),dof_len,x_dof);

--- a/components/eamxx/src/share/io/scream_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.hpp
@@ -33,6 +33,8 @@ namespace scorpio {
   /* Register a new file to be used for input/output with the scorpio module */
   void register_file(const std::string& filename, const FileMode mode);
   /* Sets the IO decompostion for all variables in a particular filename.  Required after all variables have been registered.  Called once per file. */
+  int get_dimlen(const std::string& filename, const std::string& dimname);
+  bool has_variable (const std::string& filename, const std::string& varname);
   void set_decomp(const std::string& filename);
   /* Sets the degrees-of-freedom for a particular variable in a particular file.  Called once for each variable, for each file. */
   void set_dof(const std::string &filename, const std::string &varname, const Int dof_len, const offset_t* x_dof);
@@ -90,9 +92,8 @@ extern "C" {
   bool is_eam_pio_subsystem_inited();
   /* Checks if a file is already open, with the given mode */
   int get_file_ncid_c2f(const char*&& filename);
+  // If mode<0, then simply checks if file is open, regardless of mode
   bool is_file_open_c2f(const char*&& filename, const int& mode);
-  int get_dimlen_c2f(const char*&& filename, const char*&& dimname);
-  bool has_variable_c2f (const char*&& filename, const char*&& varname);
   /* Query a netCDF file for the time variable */
   double read_time_at_index_c2f(const char*&& filename, const int& time_index);
   double read_curr_time_c2f(const char*&& filename);

--- a/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -52,7 +52,7 @@ contains
     call convert_c_string(filename_in,filename)
     call lookup_pio_atm_file(filename,atm_file,found)
     if (found) then
-      res = LOGICAL(atm_file%purpose .eq. purpose,kind=c_bool)
+      res = LOGICAL(purpose .eq. 0 .or. atm_file%purpose .eq. purpose,kind=c_bool)
     else
       res = .false.
     endif
@@ -228,48 +228,15 @@ contains
 
   end subroutine register_dimension_c2f
 !=====================================================================!
-  function get_dimlen_c2f(filename_in,dimname_in) result(val) bind(c)
-    use scream_scorpio_interface, only : get_dimlen
-    type(c_ptr), intent(in) :: filename_in
-    type(c_ptr), intent(in) :: dimname_in
-    integer(kind=c_int)     :: val
-
-    character(len=256) :: filename
-    character(len=256) :: dimname
-
-    call convert_c_string(filename_in,filename)
-    call convert_c_string(dimname_in,dimname)
-    val = get_dimlen(filename,dimname)
-
-  end function get_dimlen_c2f
-!=====================================================================!
-  function has_variable_c2f(filename_in,varname_in) result(has) bind(c)
-    use scream_scorpio_interface, only : has_variable
-    type(c_ptr), intent(in) :: filename_in
-    type(c_ptr), intent(in) :: varname_in
-    logical(kind=c_bool)     :: has
-
-    character(len=256) :: filename
-    character(len=256) :: varname
-
-    call convert_c_string(filename_in,filename)
-    call convert_c_string(varname_in,varname)
-    has = LOGICAL(has_variable(filename,varname),kind=c_bool)
-
-  end function has_variable_c2f
-!=====================================================================!
   function read_curr_time_c2f(filename_in) result(val) bind(c)
     use scream_scorpio_interface, only : read_time_at_index
-    use scream_scorpio_interface, only : get_dimlen
     type(c_ptr), intent(in)                :: filename_in
     real(kind=c_double)                    :: val
 
-    integer            :: time_index
     character(len=256) :: filename
 
     call convert_c_string(filename_in,filename)
-    time_index = get_dimlen(filename,trim("time"))
-    val        = read_time_at_index(filename,time_index)
+    val        = read_time_at_index(filename)
 
   end function read_curr_time_c2f
 !=====================================================================!

--- a/components/eamxx/src/share/io/tests/io_basic.cpp
+++ b/components/eamxx/src/share/io/tests/io_basic.cpp
@@ -212,7 +212,7 @@ void read (const std::string& avg_type, const std::string& freq_units,
     + ".nc";
   reader_pl.set("Filename",filename);
   reader_pl.set("Field Names",fnames);
-  AtmosphereInput reader(reader_pl,fm,gm);
+  AtmosphereInput reader(reader_pl,fm);
 
   // We added 1.0 to the input fields for each timestep
   // Hence, at output step N, we should get

--- a/components/eamxx/src/share/io/tests/io_diags.cpp
+++ b/components/eamxx/src/share/io/tests/io_diags.cpp
@@ -239,7 +239,7 @@ void read (const int seed, const ekat::Comm& comm)
     + ".nc";
   reader_pl.set("Filename",filename);
   reader_pl.set("Field Names",fnames);
-  AtmosphereInput reader(reader_pl,fm,gm);
+  AtmosphereInput reader(reader_pl,fm);
 
   reader.read_variables();
 

--- a/components/eamxx/src/share/io/tests/io_packed.cpp
+++ b/components/eamxx/src/share/io/tests/io_packed.cpp
@@ -168,7 +168,7 @@ void read (const int freq, const int seed, const int ps_write, const int ps_read
     + ".nc";
   reader_pl.set("Filename",filename);
   reader_pl.set("Field Names",fnames);
-  AtmosphereInput reader(reader_pl,fm,gm);
+  AtmosphereInput reader(reader_pl,fm);
 
   reader.read_variables();
   for (const auto& fn : fnames) {


### PR DESCRIPTION
This feature was never used, seems unlikely to be needed (one can always remap after calling the input class), and was going to complicate a bit things for work that is coming up in IO.