### PR TITLE
A few mods related to IO

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -778,7 +778,7 @@ void AtmosphereDriver::restart_model ()
     for (const auto& fn : restart_group->m_fields_names) {
       fnames.push_back(fn);
     }
-    read_fields_from_file (fnames,it.first,filename,m_current_ts);
+    read_fields_from_file (fnames,it.second->get_grid(),filename,m_current_ts);
   }
 
   // Restart the num steps counter in the atm time stamp
@@ -997,7 +997,7 @@ void AtmosphereDriver::set_initial_conditions ()
     m_atm_logger->info("    [EAMxx] IC filename: " + file_name);
     for (const auto& it : m_field_mgrs) {
       const auto& grid_name = it.first;
-      read_fields_from_file (ic_fields_names[grid_name],it.first,file_name,m_current_ts);
+      read_fields_from_file (ic_fields_names[grid_name],it.second->get_grid(),file_name,m_current_ts);
     }
   }
 
@@ -1063,9 +1063,19 @@ void AtmosphereDriver::set_initial_conditions ()
     m_atm_logger->info("        filename: " + file_name);
     for (const auto& it : m_field_mgrs) {
       const auto& grid_name = it.first;
+      // Topography files always use "ncol_d" for the GLL grid value of ncol.
+      // To ensure we read in the correct value, we must change the name for that dimension
+      auto io_grid = it.second->get_grid();
+      if (grid_name=="Physics GLL") {
+        using namespace ShortFieldTagsNames;
+        auto grid = io_grid->clone(io_grid->name(),true);
+        grid->reset_field_tag_name(COL,"ncol_d");
+        io_grid = grid;
+      }
+
       read_fields_from_file (topography_file_fields_names[grid_name],
                              topography_eamxx_fields_names[grid_name],
-                             it.first,file_name,m_current_ts);
+                             io_grid,file_name,m_current_ts);
     }
     m_atm_logger->debug("    [EAMxx] Processing topography from file ... done!");
   } else {
@@ -1087,7 +1097,7 @@ void AtmosphereDriver::set_initial_conditions ()
 void AtmosphereDriver::
 read_fields_from_file (const std::vector<std::string>& field_names_nc,
                        const std::vector<std::string>& field_names_eamxx,
-                       const std::string& grid_name,
+                       const std::shared_ptr<const AbstractGrid>& grid,
                        const std::string& file_name,
                        const util::TimeStamp& t0)
 {
@@ -1098,35 +1108,26 @@ read_fields_from_file (const std::vector<std::string>& field_names_nc,
     return;
   }
 
-  ekat::ParameterList ic_reader_params;
-  ic_reader_params.set("Field Names",field_names_nc);
-  ic_reader_params.set("Filename",file_name);
-
-  using view_1d_host = AtmosphereInput::view_1d_host;
-
-  const auto& field_mgr = m_field_mgrs.at(grid_name);
-  std::map<std::string, view_1d_host> hosts_views;
-  std::map<std::string, FieldLayout> layouts;
-  for (int i=0; i<int(field_names_nc.size()); ++i) {
-    const auto fname_nc = field_names_nc[i];
-    const auto fname_eamxx = field_names_eamxx[i];
-
-    hosts_views[fname_nc] =
-      field_mgr->get_field(fname_eamxx).get_view<Real*, Host>();
-    layouts.emplace(fname_nc,
-      field_mgr->get_field(fname_eamxx).get_header().get_identifier().get_layout());
+  // NOTE: we cannot pass the field_mgr and m_grids_mgr, since the input
+  //       grid may not be in the grids_manager and may not be the grid
+  //       of the field mgr. This sounds weird, but there is a precise
+  //       use case: when grid is a shallow clone of the fm grid, where
+  //       we changed the name of some field tags (e.g., we set the name
+  //       of COL to ncol_d). This is used when reading the topography,
+  //       since the topo file *always* uses ncol_d for GLL points data,
+  //       while a non-PG2 run would have the tag name be "ncol".
+  const auto& field_mgr = m_field_mgrs.at(grid->name());
+  std::map<std::string,Field> fields;
+  for (size_t i=0; i<field_names_nc.size(); ++i) {
+    fields[field_names_nc[i]] = field_mgr->get_field(field_names_eamxx[i]);
   }
 
-  AtmosphereInput ic_reader(ic_reader_params,
-                            m_grids_manager->get_grid(grid_name),
-                            hosts_views, layouts);
+  AtmosphereInput ic_reader(file_name,grid,fields);
   ic_reader.read_variables();
   ic_reader.finalize();
 
-  for (const auto& fname : field_names_eamxx) {
-    auto f = field_mgr->get_field(fname);
-    // Sync fields to device
-    f.sync_to_dev();
+  for (auto& it : fields) {
+    auto f = it.second;
     // Set the initial time stamp
     f.get_header().get_tracking().update_time_stamp(t0);
   }
@@ -1134,7 +1135,7 @@ read_fields_from_file (const std::vector<std::string>& field_names_nc,
 
 void AtmosphereDriver::
 read_fields_from_file (const std::vector<std::string>& field_names,
-                       const std::string& grid_name,
+                       const std::shared_ptr<const AbstractGrid>& grid,
                        const std::string& file_name,
                        const util::TimeStamp& t0)
 {
@@ -1142,18 +1143,21 @@ read_fields_from_file (const std::vector<std::string>& field_names,
     return;
   }
 
-  // Loop over all grids, setup and run an AtmosphereInput object,
-  // loading all fields in the RESTART group on that grid from
-  // the nc file stored in the rpointer file
-  // for (const auto& it : m_field_mgrs) {
-  const auto& field_mgr = m_field_mgrs.at(grid_name);
+  // NOTE: we cannot pass the field_mgr and m_grids_mgr, since the input
+  //       grid may not be in the grids_manager and may not be the grid
+  //       of the field mgr. This sounds weird, but there is a precise
+  //       use case: when grid is a shallow clone of the fm grid, where
+  //       we changed the name of some field tags (e.g., we set the name
+  //       of COL to ncol_d). This is used when reading the topography,
+  //       since the topo file *always* uses ncol_d for GLL points data,
+  //       while a non-PG2 run would have the tag name be "ncol".
+  const auto& field_mgr = m_field_mgrs.at(grid->name());
+  std::map<std::string,Field> fields;
+  for (const auto& fn : field_names) {
+    fields[fn] = field_mgr->get_field(fn);
+  }
 
-  // There are fields to read from the nc file. We must have a valid nc file then.
-  ekat::ParameterList ic_reader_params;
-  ic_reader_params.set("Field Names",field_names);
-  ic_reader_params.set("Filename",file_name);
-
-  AtmosphereInput ic_reader(ic_reader_params,field_mgr);
+  AtmosphereInput ic_reader(file_name,grid,fields);
   ic_reader.read_variables();
   ic_reader.finalize();
 

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -167,13 +167,13 @@ protected:
   // different naming conventions for phis.
   void read_fields_from_file (const std::vector<std::string>& field_names_nc,
                               const std::vector<std::string>& field_names_eamxx,
-                              const std::string& grid_name,
+                              const std::shared_ptr<const AbstractGrid>& grid,
                               const std::string& file_name,
                               const util::TimeStamp& t0);
   // Read fields from a file when the names of the fields in
   // EAMxx match with the .nc file.
   void read_fields_from_file (const std::vector<std::string>& field_names,
-                              const std::string& grid_name,
+                              const std::shared_ptr<const AbstractGrid>& grid,
                               const std::string& file_name,
                               const util::TimeStamp& t0);
   void register_groups ();

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -792,7 +792,7 @@ void HommeDynamics::init_homme_views () {
   // Print homme's parameters, so user can see whether something wasn't set right.
   // TODO: make Homme::SimulationParams::print accept an ostream.
   std::stringstream msg;
-  msg << "\n************** CXX SimulationParams **********************\n\n";
+  msg << "\n************** HOMMEXX SimulationParams **********************\n\n";
   msg << "   time_step_type: " << Homme::etoi(params.time_step_type) << "\n";
   msg << "   moisture: " << (params.moisture==Homme::MoistDry::DRY ? "dry" : "moist") << "\n";
   msg << "   remap_alg: " << Homme::etoi(params.remap_alg) << "\n";

--- a/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
+++ b/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
@@ -181,7 +181,7 @@ void HommeGridsManager::build_dynamics_grid () {
 
   initialize_vertical_coordinates(dyn_grid);
 
-  dyn_grid->m_short_name = "_dyn";
+  dyn_grid->m_short_name = "dyn";
   add_grid(dyn_grid);
 }
 

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -24,6 +24,15 @@ Field::clone() const {
 }
 
 Field
+Field::alias (const std::string& name) const {
+  Field f;
+  f.m_header = get_header().alias(name);
+  f.m_data = m_data;
+  f.m_is_read_only = m_is_read_only;
+  return f;
+}
+
+Field
 Field::clone(const std::string& name) const {
   // Create new field
   const auto& my_fid = get_header().get_identifier();

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -114,6 +114,7 @@ public:
   // It is created with a pristine header (no providers/customers)
   Field clone () const;
   Field clone (const std::string& name) const;
+  Field alias (const std::string& name) const;
 
   // Allows to get the underlying view, reshaped for a different data type.
   // The class will check that the requested data type is compatible with the

--- a/components/eamxx/src/share/field/field_header.cpp
+++ b/components/eamxx/src/share/field/field_header.cpp
@@ -28,6 +28,17 @@ set_extra_data (const std::string& key,
   }
 }
 
+std::shared_ptr<FieldHeader>
+FieldHeader::
+alias (const std::string& name) const
+{
+  auto fh = create_header(get_identifier().alias(name));
+  fh->m_tracking = m_tracking;
+  fh->m_alloc_prop = m_alloc_prop;
+  fh->m_extra_data = m_extra_data;
+  return fh;
+}
+
 // ---------------- Free function -------------------- //
 
 std::shared_ptr<FieldHeader>

--- a/components/eamxx/src/share/field/field_header.hpp
+++ b/components/eamxx/src/share/field/field_header.hpp
@@ -47,8 +47,6 @@ public:
   // Assignment deleted, to prevent sneaky overwrites.
   FieldHeader& operator= (const FieldHeader&) = delete;
 
-  std::shared_ptr<FieldHeader> alias (const std::string& name) const;
-
   // Set extra data
   void set_extra_data (const std::string& key,
                        const ekat::any& data,
@@ -80,6 +78,8 @@ public:
   // Get the extra data
   const extra_data_type& get_extra_data () const { return m_extra_data; }
 
+  std::shared_ptr<FieldHeader> alias (const std::string& name) const;
+
 protected:
 
   // Friend this function, so it can set up a subfield header
@@ -87,10 +87,6 @@ protected:
   create_subfield_header (const FieldIdentifier&,
                           std::shared_ptr<FieldHeader>,
                           const int, const int, const bool);
-
-  friend std::shared_ptr<FieldHeader>
-  create_alias (const FieldHeader&,
-                const std::string&);
 
   // Static information about the field: name, rank, tags
   identifier_type                 m_identifier;

--- a/components/eamxx/src/share/field/field_identifier.cpp
+++ b/components/eamxx/src/share/field/field_identifier.cpp
@@ -28,6 +28,15 @@ FieldIdentifier (const std::string& name,
   set_layout (layout);
 }
 
+FieldIdentifier
+FieldIdentifier::
+alias (const std::string& name) const
+{
+  auto fid = *this;
+  fid.m_name = name;
+  return fid;
+}
+
 void FieldIdentifier::set_layout (const layout_type& layout) {
   set_layout(std::make_shared<layout_type>(layout));
 }

--- a/components/eamxx/src/share/field/field_identifier.hpp
+++ b/components/eamxx/src/share/field/field_identifier.hpp
@@ -70,7 +70,10 @@ public:
   const layout_ptr_type&  get_layout_ptr () const { return m_layout;    }
   const Units&            get_units      () const { return m_units;     }
   const std::string&      get_grid_name  () const { return m_grid_name; }
-  DataType           data_type      () const { return m_data_type; }
+  DataType                data_type      () const { return m_data_type; }
+
+  // Returns a copy of this identifier, but with a different name
+  FieldIdentifier alias (const std::string& name) const;
 
   // The identifier string
   const std::string& get_id_string () const { return m_identifier; }

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -51,10 +51,8 @@ int FieldLayout::get_vector_dim () const {
   } else {
     EKAT_ERROR_MSG ("Error! Unrecognized layout for a '" + e2str(get_layout_type(m_tags)) + "' quantity.\n");
   }
-
   return idim;
 }
-
 
 FieldLayout FieldLayout::strip_dim (const FieldTag tag) const {
   auto it = ekat::find(m_tags,tag);
@@ -145,26 +143,21 @@ LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
       }
       break;
     case 2:
-      // Possible scenarios:
+      // Possible supported scenarios:
       //  1) <CMP|TL,LEV|ILEV>
       //  2) <TL,CMP>
-      //  3) <CMP1,CMP2>
       if ( (tags[1]==LEV || tags[1]==ILEV) && (tags[0]==CMP || tags[0]==TL)) {
         result = LayoutType::Vector3D;
-      } else if ((tags[0]==CMP1 && tags[1]==CMP2) ||
-                 (tags[0]==TL   && tags[1]==CMP )) {
+      } else if (tags[0]==TL && tags[1]==CMP ) {
         result = LayoutType::Tensor2D;
       }
       break;
     case 3:
-      // The only scenarios are:
-      //  1) <CMP1, CMP2, LEV|ILEV>
-      //  2) <TL,  CMP, LEV|ILEV>
-      if (tags[2]==LEV || tags[2]==ILEV) {
-        if ((tags[0]==CMP1 && tags[1]==CMP2) ||
-            (tags[0]==TL && tags[1]==CMP)) {
-          result = LayoutType::Tensor3D;
-        }
+      // The only supported scenario is:
+      //  1) <TL,  CMP, LEV|ILEV>
+      if ( tags[0]==TL && tags[1]==CMP &&
+          (tags[2]==LEV || tags[2]==ILEV)) {
+        result = LayoutType::Tensor3D;
       }
   }
 

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -722,8 +722,13 @@ void FieldManager::add_field (const Field& f) {
   EKAT_REQUIRE_MSG (not has_field(f.get_header().get_identifier().name()),
       "Error! The method 'add_field' requires the input field to not be already existing.\n"
       "  - field name: " + f.get_header().get_identifier().name() + "\n");
-  EKAT_REQUIRE_MSG (f.get_header().get_tracking().get_groups_info().size()==0,
-      "Error! The method 'add_field' requires the input field to not be part of any group.\n");
+  EKAT_REQUIRE_MSG (f.get_header().get_tracking().get_groups_info().size()==0 ||
+                    m_group_requests.size()==0,
+      "Error! When calling 'add_field', one of the following must be true:\n"
+      "  - the input field is not be part of any group,\n"
+      "  - there were no group requests for this field manager.\n"
+      "The reason for this is that otherwise we *might* have missed some inclusion dependency\n"
+      "when we allocated the fields for one of those groups.\n");
 
   // All good, add the field to the repo
   m_fields[f.get_header().get_identifier().name()] = std::make_shared<Field>(f);

--- a/components/eamxx/src/share/field/field_tag.hpp
+++ b/components/eamxx/src/share/field/field_tag.hpp
@@ -88,7 +88,7 @@ inline std::string e2str (const FieldTag ft) {
       name = "gp";
       break;
     case FieldTag::Component:
-      name = "cmp";
+      name = "dim";
       break;
     // Added for rrtmgp - see TODO item above
     case FieldTag::Gases:

--- a/components/eamxx/src/share/field/field_tag.hpp
+++ b/components/eamxx/src/share/field/field_tag.hpp
@@ -41,56 +41,6 @@ enum class FieldTag {
   LongWaveGpoint
 };
 
-inline std::string e2str (const FieldTag ft) {
-  std::string name = "";
-  switch(ft) {
-    case FieldTag::Invalid:
-      name = "Invalid";
-      break;
-    case FieldTag::Element:
-      name = "EL";
-      break;
-    case FieldTag::LevelMidPoint:
-      name = "LEV";
-      break;
-    case FieldTag::LevelInterface:
-      name = "ILEV";
-      break;
-    case FieldTag::TimeLevel:
-      name = "TL";
-      break;
-    case FieldTag::Column:
-      name = "COL";
-      break;
-    case FieldTag::GaussPoint:
-      name = "GP";
-      break;
-    case FieldTag::Component:
-      name = "CMP";
-      break;
-    // Added for rrtmgp - see TODO item above
-    case FieldTag::Gases:
-      name = "NGAS";
-      break;
-    case FieldTag::ShortWaveBand:
-      name = "SWBND";
-      break;
-    case FieldTag::ShortWaveGpoint:
-      name = "SWGPT";
-      break;
-    case FieldTag::LongWaveBand:
-      name = "LWBND";
-      break;
-    case FieldTag::LongWaveGpoint:
-      name = "LWGPT";
-      break;
-    default:
-      EKAT_ERROR_MSG("Error! Unrecognized field tag.");
-  }
-
-  return name;
-}
-
 // If using tags a lot, consider adding 'using namespace ShortFieldTagsNames'
 // locally to your function or cpp file.
 // TODO: if/when we require std=c++20, this can be removed, and user can do
@@ -110,6 +60,56 @@ namespace ShortFieldTagsNames {
   constexpr auto LWBND = FieldTag::LongWaveBand;
   constexpr auto SWGPT = FieldTag::ShortWaveGpoint;
   constexpr auto LWGPT = FieldTag::LongWaveGpoint;
+}
+
+inline std::string e2str (const FieldTag ft) {
+  using namespace ShortFieldTagsNames;
+  std::string name = "";
+  switch(ft) {
+    case FieldTag::Invalid:
+      name = "Invalid";
+      break;
+    case EL:
+      name = "elem";
+      break;
+    case LEV:
+      name = "lev";
+      break;
+    case ILEV:
+      name = "ilev";
+      break;
+    case FieldTag::TimeLevel:
+      name = "tl";
+      break;
+    case FieldTag::Column:
+      name = "ncol";
+      break;
+    case FieldTag::GaussPoint:
+      name = "gp";
+      break;
+    case FieldTag::Component:
+      name = "cmp";
+      break;
+    // Added for rrtmgp - see TODO item above
+    case FieldTag::Gases:
+      name = "ngas";
+      break;
+    case FieldTag::ShortWaveBand:
+      name = "swband";
+      break;
+    case FieldTag::ShortWaveGpoint:
+      name = "swgpt";
+      break;
+    case FieldTag::LongWaveBand:
+      name = "lwband";
+      break;
+    case FieldTag::LongWaveGpoint:
+      name = "lwgpt";
+      break;
+    default:
+      EKAT_ERROR_MSG("Error! Unrecognized field tag.");
+  }
+  return name;
 }
 
 // Allow to stream FieldTag values as strings.

--- a/components/eamxx/src/share/field/field_tag.hpp
+++ b/components/eamxx/src/share/field/field_tag.hpp
@@ -32,9 +32,6 @@ enum class FieldTag {
   Column,
   GaussPoint,
   Component,
-  Component1,
-  Component2,
-  Component3,
   TimeLevel,
   // Added for RRTMGP, TODO: Revisit this approach, is there a better way than adding more field tags?
   Gases,
@@ -70,15 +67,6 @@ inline std::string e2str (const FieldTag ft) {
       break;
     case FieldTag::Component:
       name = "CMP";
-      break;
-    case FieldTag::Component1:
-      name = "CMP1";
-      break;
-    case FieldTag::Component2:
-      name = "CMP2";
-      break;
-    case FieldTag::Component3:
-      name = "CMP3";
       break;
     // Added for rrtmgp - see TODO item above
     case FieldTag::Gases:
@@ -116,9 +104,6 @@ namespace ShortFieldTagsNames {
   constexpr auto LEV  = FieldTag::LevelMidPoint;
   constexpr auto ILEV = FieldTag::LevelInterface;
   constexpr auto CMP  = FieldTag::Component;
-  constexpr auto CMP1 = FieldTag::Component1;
-  constexpr auto CMP2 = FieldTag::Component2;
-  constexpr auto CMP3 = FieldTag::Component3;
   // Added for rrtmgp - see TODO item above
   constexpr auto NGAS = FieldTag::Gases;
   constexpr auto SWBND = FieldTag::ShortWaveBand;

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -143,6 +143,11 @@ public:
   virtual bool check_valid_dofs()        const { return true; }
   virtual bool check_valid_lid_to_idx () const { return true; }
 
+  void reset_field_tag_name (const FieldTag t, const std::string& s) { m_special_tag_names[t] = s; }
+  std::string get_dim_name (const FieldTag t) const {
+    return m_special_tag_names.count(t)==1 ? m_special_tag_names.at(t) : e2str(t);
+  }
+
   // This member is used mostly by IO: if a field exists on multiple grids
   // with the same name, IO can use this as a suffix to diambiguate the fields in
   // the IO file, by appending each grid's suffix to the fields names.
@@ -164,6 +169,8 @@ private:
   std::string  m_name;
 
   std::vector<std::string> m_aliases;
+
+  std::map<FieldTag, std::string> m_special_tag_names;
 
   // Counters
   int m_num_local_dofs;

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -8,6 +8,7 @@
 
 namespace scream
 {
+
 AtmosphereInput::
 AtmosphereInput (const ekat::ParameterList& params,
                 const std::shared_ptr<const fm_type>& field_mgr)
@@ -22,6 +23,26 @@ AtmosphereInput (const ekat::ParameterList& params,
                  const std::map<std::string,FieldLayout>&  layouts)
 {
   init (params,grid,host_views_1d,layouts);
+}
+
+AtmosphereInput::
+AtmosphereInput (const std::string& filename,
+                 const std::shared_ptr<const grid_type>& grid,
+                 const std::map<std::string,Field>& fields)
+{
+  // Create param list and field manager on the fly
+  ekat::ParameterList params;
+  params.set("Filename",filename);
+  auto& names = params.get<std::vector<std::string>>("Field Names",{});
+
+  auto fm = std::make_shared<fm_type>(grid);
+  fm->registration_begins();
+  fm->registration_ends();
+  for (auto& it : fields) {
+    fm->add_field(it.second);
+    names.push_back(it.first);
+  }
+  init(params,fm);
 }
 
 void AtmosphereInput::

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -362,9 +362,15 @@ AtmosphereInput::get_vec_of_dims(const FieldLayout& layout)
 {
   // Given a set of dimensions in field tags, extract a vector of strings
   // for those dimensions to be used with IO
-  std::vector<std::string> dims_names(layout.rank());
+  using namespace ShortFieldTagsNames;
+  std::vector<std::string> dims_names;
+  dims_names.reserve(layout.rank());
   for (int i=0; i<layout.rank(); ++i) {
-    dims_names[i] = scorpio::get_nc_tag_name(layout.tag(i),layout.dim(i));
+    const FieldTag t = layout.tag(i);
+    dims_names.push_back(m_io_grid->get_dim_name(t));
+    if (t==CMP) {
+      dims_names.back() += std::to_string(layout.dim(i));
+    }
   }
 
   return dims_names;

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -28,7 +28,7 @@ AtmosphereInput (const ekat::ParameterList& params,
 AtmosphereInput::
 AtmosphereInput (const std::string& filename,
                  const std::shared_ptr<const grid_type>& grid,
-                 const std::map<std::string,Field>& fields)
+                 const std::vector<Field>& fields)
 {
   // Create param list and field manager on the fly
   ekat::ParameterList params;
@@ -38,9 +38,9 @@ AtmosphereInput (const std::string& filename,
   auto fm = std::make_shared<fm_type>(grid);
   fm->registration_begins();
   fm->registration_ends();
-  for (auto& it : fields) {
-    fm->add_field(it.second);
-    names.push_back(it.first);
+  for (auto& f : fields) {
+    fm->add_field(f);
+    names.push_back(f.name());
   }
   init(params,fm);
 }

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -388,9 +388,10 @@ AtmosphereInput::get_vec_of_dims(const FieldLayout& layout)
   dims_names.reserve(layout.rank());
   for (int i=0; i<layout.rank(); ++i) {
     const FieldTag t = layout.tag(i);
-    dims_names.push_back(m_io_grid->get_dim_name(t));
     if (t==CMP) {
-      dims_names.back() += std::to_string(layout.dim(i));
+      dims_names.push_back("dim" + std::to_string(layout.dim(i)));
+    } else {
+      dims_names.push_back(m_io_grid->get_dim_name(t));
     }
   }
 

--- a/components/eamxx/src/share/io/scorpio_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_input.hpp
@@ -71,6 +71,9 @@ public:
                    const std::shared_ptr<const grid_type>& grid,
                    const std::map<std::string,view_1d_host>& host_views_1d,
                    const std::map<std::string,FieldLayout>&  layouts);
+  AtmosphereInput (const std::string& filename,
+                   const std::shared_ptr<const grid_type>& grid,
+                   const std::map<std::string,Field>& fields);
 
   virtual ~AtmosphereInput () = default;
 

--- a/components/eamxx/src/share/io/scorpio_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_input.hpp
@@ -73,7 +73,7 @@ public:
                    const std::map<std::string,FieldLayout>&  layouts);
   AtmosphereInput (const std::string& filename,
                    const std::shared_ptr<const grid_type>& grid,
-                   const std::map<std::string,Field>& fields);
+                   const std::vector<Field>& fields);
 
   virtual ~AtmosphereInput () = default;
 

--- a/components/eamxx/src/share/io/scream_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.hpp
@@ -109,55 +109,6 @@ extern "C" {
 // field-dependent extent, such as vector dimensions. Those have to
 // be "unpacked", storing a separate variable for each slice.
 
-inline std::string get_nc_tag_name (const FieldTag& t, const int extent) {
-  using namespace ShortFieldTagsNames;
-
-  std::string name = "";
-  switch(t) {
-    case EL:
-      name = "elem";
-      break;
-    case LEV:
-      name = "lev";
-      break;
-    case ILEV:
-      name = "ilev";
-      break;
-    case TL:
-      name = "tl";
-      break;
-    case COL:
-      name = "ncol";
-      break;
-    case GP:
-      name = "gp";
-      break;
-    case CMP:
-      name = "dim" + std::to_string(extent);
-      break;
-    // Added for rrtmgp - TODO revisit this paradigm, see comment in field_tag.hpp
-    case NGAS:
-      name = "ngas";
-      break;
-    case SWBND:
-      name = "swband";
-      break;
-    case LWBND:
-      name = "lwband";
-      break;
-    case SWGPT:
-      name = "swgpt";
-      break;
-    case LWGPT:
-      name = "lwgpt";
-      break;
-    default:
-      EKAT_ERROR_MSG("Error! Field tag not supported in netcdf files.");
-  }
-
-  return name;
-}
-
 } // namespace scorpio
 } // namespace scream
 


### PR DESCRIPTION
- Make the `e2str(FieldTag)` utility return the same strings that `get_nc_tag_name` returned, and remove the latter.
- Allow to query a grid for the string name of a tag. Defaults to `e2str(FieldTag)`, but a grid can store 'special' names for some tags. This helps when checking number of GLL columns in topo file when PG2 is not enabled.
- Add convenience constructor for AtmosphereInput accepting a list of Fields. Use this in grids managers as well as to read topo file.
