### PR TITLE
Crusher: Work around tcmalloc issue.

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -857,6 +857,8 @@
         <!-- See SCREAM issue #2080. -->
         <command name="load">craype-accel-amd-gfx90a</command>
         <command name="load">rocm/5.1.0</command>
+        <!-- Work around tcmalloc crash. -->
+        <command name="load">cce/14.0.3</command>
       </modules>
       <modules>
         <command name="load">cray-python/3.9.4.2</command>


### PR DESCRIPTION
cee/15.0.0 with GPU MPI buffers can crash in a system lib. Work around this by using cee/14.0.3.