### PR TITLE
Crusher: Disable OpenACC in all builds to work around compile errors …

### DIFF
--- a/cime_config/machines/cmake_macros/crayclang-scream_crusher-scream-gpu.cmake
+++ b/cime_config/machines/cmake_macros/crayclang-scream_crusher-scream-gpu.cmake
@@ -24,11 +24,12 @@ string(APPEND LDFLAGS " -L${MPICH_DIR}/lib -lmpi -L/opt/cray/pe/mpich/8.1.16/gtl
 # For YAKL's -lroctx64 -lrocfft; the rocm module doesn't set this.
 string(APPEND LDFLAGS " -L$ENV{ROCM_PATH}/lib")
 
-#this resolves a crash in mct in docn init
-if (NOT DEBUG)
+# 'NOT DEBUG': this resolves a crash in mct in docn init
+# 'DEBUG' casee, too: resolves a build error in elm/src/main/elm_varctl.F90 due to several OpenACC syntax errors
+#if (NOT DEBUG)
   string(APPEND CFLAGS " -O2 -hnoacc -hfp0 -hipa0")
   string(APPEND FFLAGS " -O2 -hnoacc -hfp0 -hipa0")
-endif()
+#endif()
 
 string(APPEND CPPDEFS " -DCPRCRAY")
 


### PR DESCRIPTION
…in ELM.