### PR TITLE
EAMxx: State hasher to track BFBness in production simulations.

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -522,7 +522,7 @@ _TESTS = {
             "ERS_Ln22.ne30_ne30.F2010-SCREAMv1",
             "PEM_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1",
             "ERS_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1.scream-small_kernels",
-            "ERP_Ln22.conusx4v1pg2_r05_oECv3.F2010-SCREAMv1-noAero",
+            "ERP_Ln22.conusx4v1pg2_r05_oECv3.F2010-SCREAMv1-noAero.scream-bfbhash",
             )
     },
 

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -173,6 +173,9 @@ be lost if SCREAM_HACK_XML is not enabled.
     <homme inherit="atm_proc_base">
       <Grid>Dynamics</Grid>
       <Moisture>moist</Moisture>
+      <!-- Frequency in physics steps to output a global hash over the dycore's
+           in fields. <= 0 disables hashing. -->
+      <BfbHash>0</BfbHash>
     </homme>
 
     <!-- P3 microphysics -->

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/bfbhash/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/bfbhash/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange --append SCREAM_ATMCHANGE_BUFFER='BfbHash=6'

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -65,7 +65,9 @@ HommeDynamics::HommeDynamics (const ekat::Comm& comm, const ekat::ParameterList&
   const char* logname = m_atm_logger->get_logfile_name().c_str();
   set_homme_log_file_name_f90 (&logname);
 
-  m_bfb_hash_nstep = std::max(0, params.get<int>("BfbHash"));
+  m_bfb_hash_nstep = 0;
+  if (params.isParameter("BfbHash"))
+    m_bfb_hash_nstep = std::max(0, params.get<int>("BfbHash"));
 }
 
 HommeDynamics::~HommeDynamics ()

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics.cpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics.cpp
@@ -64,6 +64,8 @@ HommeDynamics::HommeDynamics (const ekat::Comm& comm, const ekat::ParameterList&
   // Set the log filename in the F90 interface
   const char* logname = m_atm_logger->get_logfile_name().c_str();
   set_homme_log_file_name_f90 (&logname);
+
+  m_bfb_hash_nstep = std::max(0, params.get<int>("BfbHash"));
 }
 
 HommeDynamics::~HommeDynamics ()
@@ -468,6 +470,9 @@ void HommeDynamics::run_impl (const double dt)
         "[HommeDynamics] Error! Input timestep departure from integer above tolerance.\n"
         "  - input dt : " << dt << "\n"
         "  - tolerance: " << std::numeric_limits<double>::epsilon()*10 << "\n");
+
+    if (m_bfb_hash_nstep > 0 && timestamp().get_num_steps() % m_bfb_hash_nstep == 0)
+      print_fast_global_state_hash("Hommexx");
 
     const int dt_int = static_cast<int>(std::round(dt));
 

--- a/components/eamxx/src/dynamics/homme/atmosphere_dynamics.hpp
+++ b/components/eamxx/src/dynamics/homme/atmosphere_dynamics.hpp
@@ -149,6 +149,8 @@ protected:
   Real m_raykrange; // Range of rayleigh friction profile.
   Real m_raytau0;   // Approximate value of decay time at model top (days)
                     // if set to 0, no rayleigh friction is applied
+
+  int m_bfb_hash_nstep;
 };
 
 } // namespace scream

--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SHARE_SRC
   scream_config.cpp
   scream_session.cpp
   atm_process/atmosphere_process.cpp
+  atm_process/atmosphere_process_hash.cpp
   atm_process/atmosphere_process_group.cpp
   atm_process/atmosphere_process_dag.cpp
   atm_process/atmosphere_diagnostic.cpp

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -256,6 +256,11 @@ public:
   // Boolean that dictates whether or not the conservation checks are run for this process
   bool has_column_conservation_check () { return m_column_conservation_check_data.has_check; }
 
+  // For internal diagnostics and debugging.
+  void print_global_state_hash(const std::string& label) const;
+  // For BFB tracking in production simulations.
+  void print_fast_global_state_hash(const std::string& label) const;
+  
 protected:
 
   // Sends a message to the atm log

--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -1,0 +1,187 @@
+#include "share/atm_process/atmosphere_process.hpp"
+#include "share/field/field_utils.hpp"
+#include "share/util/scream_array_utils.hpp"
+#include "ekat/ekat_assert.hpp"
+
+#include <cstdint>
+
+namespace scream {
+
+namespace {
+typedef std::uint64_t HashType;
+
+KOKKOS_INLINE_FUNCTION void hash (const HashType v, HashType& accum) {
+  constexpr auto first_bit = 1ULL << 63;
+  accum += ~first_bit & v; // no overflow
+  accum ^=  first_bit & v; // handle most significant bit  
+}
+
+KOKKOS_INLINE_FUNCTION void hash (const double v_, HashType& accum) {
+  static_assert(sizeof(double) == sizeof(HashType),
+                "HashType must have size sizeof(double).");
+  HashType v;
+  std::memcpy(&v, &v_, sizeof(HashType));
+  hash(v, accum);
+}
+
+// For Kokkos::parallel_reduce.
+template <typename ExecSpace = Kokkos::HostSpace>
+struct HashReducer {
+  typedef HashReducer reducer;
+  typedef HashType value_type;
+  typedef Kokkos::View<value_type*, ExecSpace, Kokkos::MemoryUnmanaged> result_view_type;
+
+  KOKKOS_INLINE_FUNCTION HashReducer (value_type& value_) : value(value_) {}
+  KOKKOS_INLINE_FUNCTION void join (value_type& dest, const value_type& src) const { hash(src, dest); }
+  KOKKOS_INLINE_FUNCTION void init (value_type& val) const { val = 0; }
+  KOKKOS_INLINE_FUNCTION value_type& reference () const { return value; }
+  KOKKOS_INLINE_FUNCTION bool references_scalar () const { return true; }
+  KOKKOS_INLINE_FUNCTION result_view_type view () const { return result_view_type(&value, 1); }
+
+private:
+  value_type& value;
+};
+
+void reduce_hash (void* invec, void* inoutvec, int* len, MPI_Datatype* /* datatype */) {
+  const int n = *len;
+  const auto* s = reinterpret_cast<const HashType*>(invec);
+  auto* d = reinterpret_cast<HashType*>(inoutvec);
+  for (int i = 0; i < n; ++i) hash(s[i], d[i]);
+}
+
+int all_reduce_HashType (MPI_Comm comm, const HashType* sendbuf, HashType* rcvbuf,
+                         int count) {
+  static_assert(sizeof(long long int) == sizeof(HashType),
+                "HashType must have size sizeof(long long int).");
+  MPI_Op op;
+  MPI_Op_create(reduce_hash, true, &op);
+  const auto stat = MPI_Allreduce(sendbuf, rcvbuf, count, MPI_LONG_LONG_INT, op, comm);
+  MPI_Op_free(&op);
+  return stat;
+}
+
+using ExeSpace = KokkosTypes<DefaultDevice>::ExeSpace;
+
+void hash (const Field::view_dev_t<const Real*>& v,
+           const FieldLayout& lo, HashType& accum_out) {
+  HashType accum = 0;
+  Kokkos::parallel_reduce(
+    Kokkos::RangePolicy<ExeSpace>(0, lo.size()),
+    KOKKOS_LAMBDA(const int idx, HashType& accum) {
+      hash(v(idx), accum);
+    }, HashReducer<>(accum));
+  Kokkos::fence();
+  hash(accum, accum_out);  
+}
+
+void hash (const Field::view_dev_t<const Real**>& v,
+           const FieldLayout& lo, HashType& accum_out) {
+  HashType accum = 0;
+  const auto& dims = lo.extents();
+  Kokkos::parallel_reduce(
+    Kokkos::RangePolicy<ExeSpace>(0, lo.size()),
+    KOKKOS_LAMBDA(const int idx, HashType& accum) {
+      int i, j;
+      unflatten_idx(idx, dims, i, j);
+      hash(v(i,j), accum);
+    }, HashReducer<>(accum));
+  Kokkos::fence();
+  hash(accum, accum_out);
+}
+
+void hash (const Field::view_dev_t<const Real***>& v,
+           const FieldLayout& lo, HashType& accum_out) {
+  HashType accum = 0;
+  const auto& dims = lo.extents();
+  Kokkos::parallel_reduce(
+    Kokkos::RangePolicy<ExeSpace>(0, lo.size()),
+    KOKKOS_LAMBDA(const int idx, HashType& accum) {
+      int i, j, k;
+      unflatten_idx(idx, dims, i, j, k);
+      hash(v(i,j,k), accum);
+    }, HashReducer<>(accum));
+  Kokkos::fence();
+  hash(accum, accum_out);
+}
+
+void hash (const Field::view_dev_t<const Real****>& v,
+           const FieldLayout& lo, HashType& accum_out) {
+  HashType accum = 0;
+  const auto& dims = lo.extents();
+  Kokkos::parallel_reduce(
+    Kokkos::RangePolicy<ExeSpace>(0, lo.size()),
+    KOKKOS_LAMBDA(const int idx, HashType& accum) {
+      int i, j, k, m;
+      unflatten_idx(idx, dims, i, j, k, m);
+      hash(v(i,j,k,m), accum);
+    }, HashReducer<>(accum));
+  Kokkos::fence();
+  hash(accum, accum_out);
+}
+
+void hash (const Field::view_dev_t<const Real*****>& v,
+           const FieldLayout& lo, HashType& accum_out) {
+  HashType accum = 0;
+  const auto& dims = lo.extents();
+  Kokkos::parallel_reduce(
+    Kokkos::RangePolicy<ExeSpace>(0, lo.size()),
+    KOKKOS_LAMBDA(const int idx, HashType& accum) {
+      int i, j, k, m, n;
+      unflatten_idx(idx, dims, i, j, k, m, n);
+      hash(v(i,j,k,m,n), accum);
+    }, HashReducer<>(accum));
+  Kokkos::fence();
+  hash(accum, accum_out);
+}
+
+void hash (const std::list<FieldGroup>& fgs, HashType& accum_out) {
+  
+}
+
+void hash (const std::list<Field>& fs, HashType& accum) {
+  for (const auto& f : fs) {
+    const auto& hd = f.get_header();
+    const auto& id = hd.get_identifier();
+    if (id.data_type() != DataType::DoubleType) continue;
+    const auto& lo = id.get_layout();
+    const auto rank = lo.rank();
+    switch (rank) {
+    case 1: hash(f.get_view<const Real*    >(), lo, accum); break;
+    case 2: hash(f.get_view<const Real**   >(), lo, accum); break;
+    case 3: hash(f.get_view<const Real***  >(), lo, accum); break;
+    case 4: hash(f.get_view<const Real**** >(), lo, accum); break;
+    case 5: hash(f.get_view<const Real*****>(), lo, accum); break;
+    default: continue;
+    }
+  }
+}
+} // namespace anon
+
+void AtmosphereProcess::print_global_state_hash (const std::string& label) const {
+  static constexpr int nslot = 3;
+  HashType laccum[nslot] = {0};
+  hash(m_fields_in, laccum[0]);
+  hash(m_groups_in, laccum[0]);
+  hash(m_fields_out, laccum[1]);
+  hash(m_groups_out, laccum[1]);
+  hash(m_internal_fields, laccum[2]);
+  HashType gaccum[nslot];
+  all_reduce_HashType(m_comm.mpi_comm(), laccum, gaccum, nslot);
+  if (m_comm.am_i_root())
+    for (int i = 0; i < nslot; ++i)
+      fprintf(stderr, "exxhash> %4d-%9.5f %1d %16lx (%s)\n",
+              timestamp().get_year(), timestamp().frac_of_year_in_days(),
+              i, gaccum[i], label.c_str());
+}
+
+void AtmosphereProcess::print_fast_global_state_hash (const std::string& label) const {
+  HashType laccum = 0;
+  hash(m_fields_in, laccum);
+  HashType gaccum;
+  all_reduce_HashType(m_comm.mpi_comm(), &laccum, &gaccum, 1);
+  if (m_comm.am_i_root())
+    fprintf(stderr, "bfbhash> %14d %16lx (%s)\n",
+            timestamp().get_num_steps(), gaccum, label.c_str());
+}
+
+} // namespace scream


### PR DESCRIPTION
Default is off (BfbHash = 0). A number N > 0 means that a hash is printed every N physics time steps.

The hash line appears in e3sm.log for the root rank and looks like this:
```
0: bfbhash>             14 81f1508e28e52796 (Hommexx)
```
Here, "14" is the physics time step. The hasher is called in homme_dynamics.cpp at the start of the run.

A testmod used in the RRM test exercises the hasher. In the future I might add a python POSTRUN_SCRIPT to check the hash values, but for now I don't.

Two future PRs will add an internal diagnostics capability to the EAMxx AD and Hommexx for debugging purposes.