### PR TITLE
Fix issues with GLL output for PG2 CIME cases

### DIFF
--- a/components/eamxx/data/scream_default_output.yaml
+++ b/components/eamxx/data/scream_default_output.yaml
@@ -59,6 +59,13 @@ Fields:
       - surf_sens_flux
       # Diagnostics
       - PotentialTemperature
+  # GLL output for homme states.
+  Dynamics:
+    Field Names:
+      - ps_dyn
+      - dp3d_dyn
+      - omega_dyn
+    IO Grid Name: Physics GLL
 output_control:
 # WARNING: ERS/ERP tets will override this with STOP_N/STOP_OPTION
   Frequency: ${HIST_N}

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -1214,6 +1214,13 @@ void HommeDynamics::initialize_homme_state () {
     update_pressure (m_phys_grid);
   }
 
+  // If "Instant" averaging type is used for output,
+  // an initial output is performed before AD processes
+  // are run. If omega_dyn output is requested, it will
+  // not have valid computed values for this initial
+  // output. Set to zero avoid potential FPE.
+  get_internal_field("omega_dyn").deep_copy(0);
+
   // Copy IC states on all timelevel slices
   copy_dyn_states_to_all_timelevels ();
 

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -234,6 +234,11 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
     add_internal_field (m_helper_fields.at("w_int_dyn").subfield(1,tl.n0,true));
   }
 
+  // The output manager pulls from the atm process fields. Add
+  // helper fields for the case that a user request output.
+  add_internal_field (m_helper_fields.at("omega_dyn"));
+  add_internal_field (m_helper_fields.at("phis_dyn"));
+
   if (not fv_phys_active()) {
     // Dynamics backs out tendencies from the states, and passes those to Homme.
     // After Homme completes, we remap the updated state to the ref grid.  Thus,

--- a/components/eamxx/src/share/grid/grids_manager.hpp
+++ b/components/eamxx/src/share/grid/grids_manager.hpp
@@ -21,11 +21,13 @@ namespace scream
 class GridsManager
 {
 public:
-  using grid_type         = AbstractGrid;
-  using grid_ptr_type     = std::shared_ptr<const grid_type>;
-  using grid_repo_type    = std::map<std::string, grid_ptr_type>;
-  using remapper_type     = AbstractRemapper;
-  using remapper_ptr_type = std::shared_ptr<remapper_type>;
+  using grid_type              = AbstractGrid;
+  using grid_ptr_type          = std::shared_ptr<const grid_type>;
+  using grid_repo_type         = std::map<std::string, grid_ptr_type>;
+  using nonconstgrid_ptr_type  = std::shared_ptr<grid_type>;
+  using nonconstgrid_repo_type = std::map<std::string, nonconstgrid_ptr_type>;
+  using remapper_type          = AbstractRemapper;
+  using remapper_ptr_type      = std::shared_ptr<remapper_type>;
 
   GridsManager () = default;
   virtual ~GridsManager () = default;
@@ -33,6 +35,7 @@ public:
   virtual std::string name () const = 0;
 
   grid_ptr_type get_grid (const std::string& name) const;
+  nonconstgrid_ptr_type get_grid_nonconst (const std::string& name) const;
 
   // Check if the given grid has been built
   bool has_grid (const std::string& grid_name) const;
@@ -52,12 +55,8 @@ public:
   const grid_repo_type& get_repo () const { return m_grids; }
 
 protected:
-  using nonconstgrid_ptr_type     = std::shared_ptr<grid_type>;
-  using nonconstgrid_repo_type    = std::map<std::string, nonconstgrid_ptr_type>;
 
   void add_grid (nonconstgrid_ptr_type grid);
-  nonconstgrid_ptr_type get_grid_nonconst (const std::string& name) const;
-
   void alias_grid (const std::string& grid_name, const std::string& grid_alias);
 
   virtual remapper_ptr_type

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -144,7 +144,7 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
   }
   sort_and_check(m_fields_names);
 
-  // Check if remapping and if so create the appropriate remapper 
+  // Check if remapping and if so create the appropriate remapper
   // Note: We currently support three remappers
   //   - vertical remapping from file
   //   - horizontal remapping from file
@@ -164,7 +164,7 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
   set_diagnostics();
 
   // Setup remappers - if needed
-  if (use_vertical_remap_from_file) {  
+  if (use_vertical_remap_from_file) {
     // We build a remapper, to remap fields from the fm grid to the io grid
     auto vert_remap_file   = params.get<std::string>("vertical_remap_file");
     auto f_lev = get_field("p_mid","sim");
@@ -181,7 +181,7 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
       const auto src = get_field(fname,"sim");
       const auto tgt_fid = m_vert_remapper->create_tgt_fid(src.get_header().get_identifier());
       const auto packsize = src.get_header().get_alloc_properties().get_largest_pack_size();
-      io_fm->register_field(FieldRequest(tgt_fid,packsize)); 
+      io_fm->register_field(FieldRequest(tgt_fid,packsize));
     }
     io_fm->registration_ends();
 
@@ -254,7 +254,7 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
 
     // Reset the IO field manager
     set_field_manager(io_fm,"io");
-  } 
+  }
 
   // Setup I/O structures
   init ();
@@ -571,7 +571,7 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
 
 void AtmosphereOutput::register_dimensions(const std::string& name)
 {
-/* 
+/*
  * Checks that the dimensions associated with a specific variable will be registered with IO file.
  * INPUT:
  *   field_manager: is a pointer to the field_manager for this simulation.
@@ -597,16 +597,18 @@ void AtmosphereOutput::register_dimensions(const std::string& name)
     auto is_partitioned = m_io_grid->get_partitioned_dim_tag()==tags[i];
     if (tag_loc == m_dims.end()) {
       int tag_len = 0;
-      if(tags[i] == m_io_grid->get_partitioned_dim_tag()) {
+      if(is_partitioned) {
         // This is the dimension that is partitioned across ranks.
         tag_len = m_io_grid->get_partitioned_dim_global_size();
       } else {
         tag_len = layout.dim(i);
       }
       m_dims[tag_name] = std::make_pair(tag_len,is_partitioned);
-    } else {  
+    } else {
       EKAT_REQUIRE_MSG(m_dims.at(tag_name).first==dims[i] or is_partitioned,
-        "Error! Dimension " + tag_name + " on field " + name + " has conflicting lengths");
+        "Error! Dimension " + tag_name + " on field " + name + " has conflicting lengths. "
+        "If same name applies to different dims (e.g. PhysicsGLL and PhysicsPG2 define "
+        "\"ncol\" at different lengths), reset tag name for one of the grids.\n");
     }
   }
 } // register_dimensions
@@ -829,9 +831,9 @@ AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
   } else {
     // This field is *not* defined over columns, so it is not partitioned.
     std::iota(var_dof.begin(),var_dof.end(),0);
-  } 
+  }
 
-  return var_dof; 
+  return var_dof;
 }
 /* ---------------------------------------------------------- */
 void AtmosphereOutput::set_degrees_of_freedom(const std::string& filename)
@@ -848,7 +850,7 @@ void AtmosphereOutput::set_degrees_of_freedom(const std::string& filename)
     m_dofs.emplace(std::make_pair(name,var_dof.size()));
   }
 
-  /* TODO: 
+  /* TODO:
    * Gather DOF info directly from grid manager
   */
 } // set_degrees_of_freedom
@@ -971,7 +973,7 @@ create_diagnostic (const std::string& diag_field_name) {
   auto lev_and_idx = ekat::split(last,'_');
   auto pos = lev_and_idx[0].find_first_not_of("0123456789");
   auto lev_str = lev_and_idx[0].substr(pos);
-  
+
   if (last=="tom" || last=="bot" || lev_str=="lev") {
     // Diagnostic is a horizontal slice at a specific level
     diag_name = "FieldAtLevel";

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -124,13 +124,6 @@ public:
   virtual ~AtmosphereOutput () = default;
 
   // Constructor
-  // Note on the last two inputs:
-  //  - is_restart_run: if true, this is a restarted run. This is only importand
-  //    if this output instance is *not* for writing model restart files,
-  //    and *only* for particular choices of "Averaging Type".
-  //  - is_model_restart_output: if true, this Output is for model restart files.
-  //    In this case, we have to also create an "rpointer.atm" file (which
-  //    contains metadata, and is expected by the component coupled)
   AtmosphereOutput(const ekat::Comm& comm, const ekat::ParameterList& params,
                    const std::shared_ptr<const fm_type>& field_mgr,
                    const std::shared_ptr<const gm_type>& grids_mgr);

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -62,7 +62,17 @@ Fields:
       - rad_heating_pdel
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
- 
+
+  # GLL output for homme states.
+  # Identical to ps, pseudo_density,
+  # and omega for this test.
+  Dynamics:
+    Field Names:
+      - ps_dyn
+      - dp3d_dyn
+      - omega_dyn
+    IO Grid Name: Physics GLL
+
 output_control:
   Frequency: ${NUM_STEPS}
   frequency_units: nsteps

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -62,15 +62,19 @@ Fields:
       - rad_heating_pdel
       - sfc_flux_lw_dn
       - sfc_flux_sw_net
-
-  # GLL output for homme states.
-  # Identical to ps, pseudo_density,
-  # and omega for this test.
+  # GLL output for homme states. These
+  # represent all current possible homme
+  # states available.
   Dynamics:
     Field Names:
-      - ps_dyn
+      - v_dyn
+      - vtheta_dp_dyn
       - dp3d_dyn
+      - phi_int_dyn
+      - ps_dyn
+      - phis_dyn
       - omega_dyn
+      - Qdp_dyn
     IO Grid Name: Physics GLL
 
 output_control:


### PR DESCRIPTION
- Update output manager to deal with conflicting `ncol` lengths (PG2 and GLL).
- Add homme states to internal fields so they can be int output
- Add GLL output of homme states to test/default output