### PR TITLE
Revives two previously broken MPASSI tests

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -538,15 +538,13 @@ _TESTS = {
     "e3sm_scream_v1_mpassi" : {
         "time"  : "01:00:00",
         "tests" : (
-         #  "ERP_D_Ln9.ne4_oQU240.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
-         #  "SMS_D_Ln9.ne4_oQU240.F2010-SCREAMv1-MPASSI-noAero",
-         # Disable the two 111422-commented tests b/c they fail on pm-gpu and
-         # we're not using MPASSI right now.
-         #111422 "ERP_Ln22.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
-         "ERS_D_Ln22.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
-         #  "ERS_Ln22.ne30_oECv3.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
-         #111422 "PEM_Ln90.ne30pg2_EC30to60E2r2.F2010-SCREAMv1-MPASSI",
-         #  "ERS_Ln22.ne30pg2_EC30to60E2r2.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+            #  "ERP_D_Ln9.ne4_oQU240.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+            #  "SMS_D_Ln9.ne4_oQU240.F2010-SCREAMv1-MPASSI-noAero",
+            "ERP_Ln22.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+            "ERS_D_Ln22.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+            #  "ERS_Ln22.ne30_oECv3.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
+            "PEM_Ln90.ne30pg2_EC30to60E2r2.F2010-SCREAMv1-MPASSI",
+            #  "ERS_Ln22.ne30pg2_EC30to60E2r2.F2010-SCREAMv1-MPASSI.atmlndactive-rtm_off",
             )
     },
 


### PR DESCRIPTION
Revives two MPASSI tests that were previously broken on GPUs in hopes that more recent code changes might have fixed these. I have tested them on a CPU machine (Compy) to ensure that they work on a CPU machine. Due to the missing partition files for the default Compy configurations, I ran the following equivalent tests:
```
./cs.status.mpassi_tests3 -s
mpassi_tests3: 3 tests
  PASS ERP_Ln22_P64x1.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.compy_intel.atmlndactive-rtm_off
  PASS ERS_D_Ln22_P40x1.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.compy_intel.atmlndactive-rtm_off
  PASS PEM_Ln90_P128x1.ne30pg2_EC30to60E2r2.F2010-SCREAMv1-MPASSI.compy_intel

```