### PR TITLE
Update weaver mach file and mach specs to adapt to new system modules

### DIFF
--- a/components/eamxx/cmake/machine-files/weaver.cmake
+++ b/components/eamxx/cmake/machine-files/weaver.cmake
@@ -1,8 +1,9 @@
 include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
 common_setup()
 
-set (BLAS_LIBRARIES /ascldap/users/projects/e3sm/scream/libs/openblas/install/weaver/gcc/8.5.0/lib/libopenblas.so CACHE STRING "")
-set (LAPACK_LIBRARIES /ascldap/users/projects/e3sm/scream/libs/openblas/install/weaver/gcc/8.5.0/lib/libopenblas.so CACHE STRING "")
+set (BLAS_LIBRARIES $ENV{NETLIB_LAPACK_ROOT}/lib64/libblas.so CACHE STRING "")
+set (LAPACK_LIBRARIES $ENV{NETLIB_LAPACK_ROOT}/lib64/liblapack.so CACHE STRING "")
 set(SCREAM_INPUT_ROOT "/home/projects/e3sm/scream/data" CACHE STRING "")
-set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
+#set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
+set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch"  CACHE STRING "" FORCE)
 set(HOMMEXX_CUDA_MAX_WARP_PER_TEAM 8 CACHE STRING "")

--- a/components/eamxx/scripts/jenkins/weaver_setup
+++ b/components/eamxx/scripts/jenkins/weaver_setup
@@ -1,3 +1,3 @@
-module load python/3.7.3
+module load python/3.10.8
 
 SCREAM_MACHINE=weaver

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -21,7 +21,7 @@ MACHINE_METADATA = {
                  ["mpicxx","mpifort","mpicc"],
                   "salloc -N 1 srun -n1 --preserve-env",
                   "/home/projects/e3sm/scream/pr-autotester/master-baselines/blake/"),
-    "weaver"   : (["source /etc/profile.d/modules.sh", "module purge", "module load git/2.10.1 python/3.7.3 cmake/3.23.1 cuda/11.2.2/gcc/8.3.1 openmpi/4.1.1/gcc/8.3.1/cuda/11.2.2 netcdf-c/4.8.1/gcc/8.3.1/openmpi/4.1.1 netcdf-cxx/4.2/gcc/8.3.1/openmpi/4.1.1 netcdf-fortran/4.5.4/gcc/8.3.1/openmpi/4.1.1 parallel-netcdf/1.12.2/gcc/8.3.1/openmpi/4.1.1",
+    "weaver"   : (["source /etc/profile.d/modules.sh", "module purge", "module load cmake/3.25.1 git/2.39.1 python/3.10.8 gcc/11.3.0 cuda/11.8.0 openmpi netcdf-c netcdf-fortran parallel-netcdf netlib-lapack",
                  ],
                  ["mpicxx","mpifort","mpicc"],
                   "bsub -I -q rhel8 -n 4",

--- a/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -392,7 +392,7 @@ static void run_bfb_p3_main()
 
   // Get data from cxx
   for (auto& d : isds_cxx) {
-    d.transpose<ekat::TransposeDirection::c2f>();
+    d.template transpose<ekat::TransposeDirection::c2f>();
     p3_main_f(
       d.qc, d.nc, d.qr, d.nr, d.th_atm, d.qv, d.dt, d.qi, d.qm, d.ni,
       d.bm, d.pres, d.dz, d.nc_nuceat_tend, d.nccn_prescribed, d.ni_activated, d.inv_qc_relvar, d.it, d.precip_liq_surf,
@@ -400,7 +400,7 @@ static void run_bfb_p3_main()
       d.rho_qi, d.do_predict_nc, d.do_prescribed_CCN, d.dpres, d.inv_exner, d.qv2qi_depos_tend,
       d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i, 
       d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange, d.qv_prev, d.t_prev);
-    d.transpose<ekat::TransposeDirection::f2c>();
+    d.template transpose<ekat::TransposeDirection::f2c>();
   }
 
   if (SCREAM_BFB_TESTING) {


### PR DESCRIPTION
I also had to do a minor C++ fix, to accommodate a finicky compiler. With these mods, I can compile scream (with test-all), but I cannot yet run the tests, since there are still issues with propagating modules on the compute nodes