### PR TITLE
Upgrades to atmquery/atmchange

### DIFF
--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -505,6 +505,9 @@ def create_raw_xml_file(case, caseroot):
         # atmchange requests.
         atmchg_buffer = case.get_value("SCREAM_ATMCHANGE_BUFFER")
         if atmchg_buffer:
+            if "--all" in atmchg_buffer:
+                atmchg_buffer = atmchg_buffer.replace("--all", "") + " --all"
+
             run_cmd_no_fail("{}/atmchange {} --no-buffer".format(caseroot, atmchg_buffer))
 
 ###############################################################################

--- a/components/eamxx/scripts/atm_manip.py
+++ b/components/eamxx/scripts/atm_manip.py
@@ -76,6 +76,9 @@ def find_node (root,name,recurse=True):
     None
     """
 
+    if root.tag==name:
+        return root, []
+
     for elem in root:
         if elem.tag==name:
             return elem, [root]
@@ -87,7 +90,7 @@ def find_node (root,name,recurse=True):
     return None, []
 
 ###############################################################################
-def get_xml_node(xml_root,name):
+def get_xml_node(xml_root,name,allow_not_found=False):
 ###############################################################################
     """
     >>> xml = '''
@@ -149,19 +152,24 @@ def get_xml_node(xml_root,name):
         node = xml_root
         parents = []
     else:
-        expect (num_nodes_with_name(xml_root,s,recurse=True)>0,
+        expect (allow_not_found or num_nodes_with_name(xml_root,s,recurse=True)>0,
             f"Error! XML entry {s} not found in section {xml_root.tag}")
-        expect (num_nodes_with_name(xml_root,s,recurse=True)==1,
+        expect (allow_not_found or num_nodes_with_name(xml_root,s,recurse=True)==1,
             f"Error! Multiple XML entries with name {s} found in section {xml_root.tag}",
             AmbiguousName)
 
         node, parents = find_node(xml_root,s,recurse=True)
 
+    if node is None:
+        expect (allow_not_found,
+                f"Error! XML entry {s} not found in section {xml_root.tag}")
+        return None, []
+
     # If user specified selectors via namespace, recurse over them
     for s in selectors[1:]:
-        expect (num_nodes_with_name(node,s,recurse=False)>0,
+        expect (allow_not_found or num_nodes_with_name(node,s,recurse=False)>0,
             f"Error! XML entry {s} not found in section {node.tag}")
-        expect (num_nodes_with_name(node,s,recurse=False)==1,
+        expect (allow_not_found or num_nodes_with_name(node,s,recurse=False)==1,
             f"Error! Multiple XML entries with name {s} found in section {node.tag}")
 
         node, parents = find_node(node,s,recurse=False)
@@ -222,7 +230,7 @@ def parse_change (change):
     return node_name,new_value,append_this
 
 ###############################################################################
-def atm_config_chg_impl(xml_root,change, all_matches=False):
+def atm_config_chg_impl(xml_parent, xml_node, change, all_matches=False):
 ###############################################################################
     """
     >>> xml = '''
@@ -242,64 +250,61 @@ def atm_config_chg_impl(xml_root,change, all_matches=False):
     >>> import xml.etree.ElementTree as ET
     >>> tree = ET.fromstring(xml)
     >>> ################ INVALID SYNTAX #######################
-    >>> atm_config_chg_impl(tree,'prop1->2')
+    >>> atm_config_chg_impl(None,tree,'prop1->2')
     Traceback (most recent call last):
     SystemExit: ERROR: Invalid change request 'prop1->2'. Valid formats are:
       - A[::B[...]=value
       - A[::B[...]+=value  (implies append for this change)
     >>> ################ INVALID TYPE #######################
-    >>> atm_config_chg_impl(tree,'prop2=two')
+    >>> atm_config_chg_impl(None,tree,'prop2=two')
     Traceback (most recent call last):
     ValueError: Could not use 'two' as type 'integer'
     >>> ################ INVALID VALUE #######################
-    >>> atm_config_chg_impl(tree,'prop2=3')
+    >>> atm_config_chg_impl(None,tree,'prop2=3')
     Traceback (most recent call last):
     CIME.utils.CIMEError: ERROR: Invalid value '3' for element 'prop2'. Value not in the valid list ('[1, 2]')
     >>> ################ VALID USAGE #######################
-    >>> atm_config_chg_impl(tree,'::prop1=two')
+    >>> atm_config_chg_impl(None,tree,'::prop1=two')
     (True, True)
-    >>> atm_config_chg_impl(tree,'::prop1=two')
+    >>> atm_config_chg_impl(None,tree,'::prop1=two')
     (True, False)
-    >>> atm_config_chg_impl(tree,'sub::prop1=one')
+    >>> atm_config_chg_impl(None,tree,'sub::prop1=one')
     (True, True)
     >>> ################ TEST APPEND += #################
-    >>> atm_config_chg_impl(tree,'a+=4')
+    >>> atm_config_chg_impl(None,tree,'a+=4')
     (True, True)
-    >>> get_xml_node(tree,'a')[0].text
+    >>> get_xml_node(None,tree,'a')[0].text
     '1,2,3, 4'
     >>> ################ ERROR, append to non-array and non-string
-    >>> atm_config_chg_impl(tree,'c+=2')
+    >>> atm_config_chg_impl(None,tree,'c+=2')
     Traceback (most recent call last):
     SystemExit: ERROR: Error! Can only append with array and string types.
         - name: c
         - type: int
     >>> ################ Append to string ##################
-    >>> atm_config_chg_impl(tree,'d+=two')
+    >>> atm_config_chg_impl(None,tree,'d+=two')
     (True, True)
-    >>> get_xml_node(tree,'d')[0].text
+    >>> get_xml_node(None,tree,'d')[0].text
     'onetwo'
     >>> ################ Append to array(string) ##################
-    >>> atm_config_chg_impl(tree,'e+=two')
+    >>> atm_config_chg_impl(None,tree,'e+=two')
     (True, True)
-    >>> get_xml_node(tree,'e')[0].text
+    >>> get_xml_node(None,tree,'e')[0].text
     'one, two'
     """
 
     any_change = False
     node_found = False
-    if all_matches and len(xml_root)>0:
+    if all_matches and len(xml_node)>0:
         # We have to go through the whole tree, since we need to apply
         # the changes to all nodes matching the node name
-        for elem in xml_root:
-            found_here, changed_here = atm_config_chg_impl(elem,change, all_matches)
+        for elem in xml_node:
+            found_here, changed_here = atm_config_chg_impl(xml_node,elem,change, all_matches)
             any_change |= changed_here
             node_found |= found_here
     else:
         node_name,new_value,append_this = parse_change(change)
-        if all_matches:
-            node = xml_root if xml_root.tag==node_name else None
-        else:
-            node, __ = get_xml_node(xml_root,node_name)
+        node, __ = get_xml_node(xml_parent,node_name,allow_not_found=all_matches)
 
         node_found = node is not None
         if node is not None:

--- a/components/eamxx/scripts/atm_manip.py
+++ b/components/eamxx/scripts/atm_manip.py
@@ -152,7 +152,7 @@ def atm_config_chg_impl(xml_root, change, all_matches=False):
     >>> ################ AMBIGUOUS CHANGE #######################
     >>> atm_config_chg_impl(tree,'prop1=three')
     Traceback (most recent call last):
-    SystemExit: ERROR: prop1 is ambiguous, matches:
+    SystemExit: ERROR: prop1 is ambiguous (use --all to change all matches), matches:
       root::prop1
       root::sub::prop1
     <BLANKLINE>
@@ -201,7 +201,7 @@ def atm_config_chg_impl(xml_root, change, all_matches=False):
             name = "::".join(e.tag for e in parents) + "::" + node.tag
             error_str += "  " + name + "\n"
 
-        expect(False, f"{node_name} is ambiguous, matches:\n{error_str}")
+        expect(False, f"{node_name} is ambiguous (use --all to change all matches), matches:\n{error_str}")
 
     any_change = False
     for node in matches:
@@ -371,6 +371,7 @@ def atm_query_impl(xml_root,variables,listall=False,full=False,value=False,
 
     elif grep:
         for regex in variables:
+            expect("::" not in regex, "query --grep does not support including parent info")
             var_re = re.compile(f'{regex}')
             if var_re.search(xml_root.tag):
                 print_all_vars(xml_root,xml_root,parent_map,"::",full,dtype,value,valid_values,"short","  ")

--- a/components/eamxx/scripts/atm_manip.py
+++ b/components/eamxx/scripts/atm_manip.py
@@ -222,7 +222,7 @@ def parse_change (change):
     return node_name,new_value,append_this
 
 ###############################################################################
-def atm_config_chg_impl(xml_root,change,all=False):
+def atm_config_chg_impl(xml_root,change, all_matches=False):
 ###############################################################################
     """
     >>> xml = '''
@@ -287,16 +287,16 @@ def atm_config_chg_impl(xml_root,change,all=False):
 
     any_change = False
     node_found = False
-    if all and len(xml_root)>0:
+    if all_matches and len(xml_root)>0:
         # We have to go through the whole tree, since we need to apply
         # the changes to all nodes matching the node name
         for elem in xml_root:
-            found_here, changed_here = atm_config_chg_impl(elem,change,all)
+            found_here, changed_here = atm_config_chg_impl(elem,change, all_matches)
             any_change |= changed_here
             node_found |= found_here
     else:
         node_name,new_value,append_this = parse_change(change)
-        if all:
+        if all_matches:
             node = xml_root if xml_root.tag==node_name else None
         else:
             node, __ = get_xml_node(xml_root,node_name)
@@ -305,7 +305,7 @@ def atm_config_chg_impl(xml_root,change,all=False):
         if node is not None:
             any_change = apply_change (node,new_value,append_this)
 
-    
+
     return node_found, any_change
 
 ###############################################################################
@@ -392,7 +392,6 @@ def print_var(xml_root,var,full,dtype,value,valid_values,print_style="invalid",i
         try:
             get_xml_node(xml_root,new_name)
             tokens.pop(0)
-            name = new_name
         except AmbiguousName:
             # new_name was either "" or an ambiguous name, and get_xml_node failed
             break

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -40,7 +40,7 @@ def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False):
 
     any_change = False
     for change in changes:
-        node_found, this_changed = atm_config_chg_impl(None, root, change, all_matches)
+        node_found, this_changed = atm_config_chg_impl(root, change, all_matches)
         expect (node_found,
                 f"Error! Change {change} did not yield any match in the XML file")
         any_change |= this_changed

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -17,7 +17,7 @@ from atm_manip import get_xml_node, atm_config_chg_impl
 from utils import run_cmd_no_fail, expect
 
 ###############################################################################
-def atm_config_chg(changes, no_buffer=False, reset=False, all=False):
+def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False):
 ###############################################################################
     expect(os.path.exists("namelist_scream.xml"),
            "No pwd/namelist_scream.xml file is present. Please run from a case dir that has been set up")
@@ -40,7 +40,7 @@ def atm_config_chg(changes, no_buffer=False, reset=False, all=False):
 
     any_change = False
     for change in changes:
-        node_found, this_changed = atm_config_chg_impl(root,change,all)
+        node_found, this_changed = atm_config_chg_impl(root, change, all_matches)
         expect (node_found,
                 f"Error! Change {change} did not yield any match in the XML file")
         any_change |= this_changed
@@ -50,6 +50,8 @@ def atm_config_chg(changes, no_buffer=False, reset=False, all=False):
 
     if not no_buffer:
         changes_str = " ".join(changes).replace(",",r"\,")
+        if all_matches:
+            changes_str += " --all"
         run_cmd_no_fail(f"./xmlchange --append SCREAM_ATMCHANGE_BUFFER='{changes_str}'")
 
     return True
@@ -77,20 +79,21 @@ OR
     )
 
     parser.add_argument(
-        "--no-buffer",
+        "-n", "--no-buffer",
         default=False,
         action="store_true",
         help="Used by buildnml to replay buffered commands",
     )
 
     parser.add_argument(
-        "--all",
+        "-a", "--all",
         default=False,
+        dest="all_matches",
         action="store_true",
         help="Apply change to all entries matching the name"
     )
     parser.add_argument(
-        "--reset",
+        "-r", "--reset",
         default=False,
         action="store_true",
         help="Forget all previous atmchanges",

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -13,7 +13,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 from eamxx_buildnml_impl import check_value, is_array_type
-from atm_manip import get_xml_node, atm_config_chg_impl
+from atm_manip import atm_config_chg_impl
 from utils import run_cmd_no_fail, expect
 
 ###############################################################################
@@ -40,9 +40,7 @@ def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False):
 
     any_change = False
     for change in changes:
-        node_found, this_changed = atm_config_chg_impl(root, change, all_matches)
-        expect (node_found,
-                f"Error! Change {change} did not yield any match in the XML file")
+        this_changed = atm_config_chg_impl(root, change, all_matches)
         any_change |= this_changed
 
     if any_change:
@@ -52,6 +50,7 @@ def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False):
         changes_str = " ".join(changes).replace(",",r"\,")
         if all_matches:
             changes_str += " --all"
+
         run_cmd_no_fail(f"./xmlchange --append SCREAM_ATMCHANGE_BUFFER='{changes_str}'")
 
     return True

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -40,7 +40,7 @@ def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False):
 
     any_change = False
     for change in changes:
-        node_found, this_changed = atm_config_chg_impl(root, change, all_matches)
+        node_found, this_changed = atm_config_chg_impl(None, root, change, all_matches)
         expect (node_found,
                 f"Error! Change {change} did not yield any match in the XML file")
         any_change |= this_changed

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -17,7 +17,7 @@ from atm_manip import get_xml_node, atm_config_chg_impl
 from utils import run_cmd_no_fail, expect
 
 ###############################################################################
-def atm_config_chg(changes, no_buffer=False, reset=False):
+def atm_config_chg(changes, no_buffer=False, reset=False, all=False):
 ###############################################################################
     expect(os.path.exists("namelist_scream.xml"),
            "No pwd/namelist_scream.xml file is present. Please run from a case dir that has been set up")
@@ -38,7 +38,12 @@ def atm_config_chg(changes, no_buffer=False, reset=False):
         tree = ET.parse(fd)
         root = tree.getroot()
 
-    any_change = atm_config_chg_impl(root,changes)
+    any_change = False
+    for change in changes:
+        node_found, this_changed = atm_config_chg_impl(root,change,all)
+        expect (node_found,
+                f"Error! Change {change} did not yield any match in the XML file")
+        any_change |= this_changed
 
     if any_change:
         tree.write("namelist_scream.xml")
@@ -78,6 +83,12 @@ OR
         help="Used by buildnml to replay buffered commands",
     )
 
+    parser.add_argument(
+        "--all",
+        default=False,
+        action="store_true",
+        help="Apply change to all entries matching the name"
+    )
     parser.add_argument(
         "--reset",
         default=False,

--- a/components/eamxx/scripts/atmquery
+++ b/components/eamxx/scripts/atmquery
@@ -37,19 +37,19 @@ OR
 {0} --help
 
 \033[1mEXAMPLES:\033[0m
-    \033[1;32m# List all settings as VAR=VALUE
+    \033[1;32m# List all settings as VAR=VALUE\033[0m
     > {0} --listall
 
-    \033[1;32m# print var1 and var2
+    \033[1;32m# print var1 and var2\033[0m
     > {0} var1 var2
 
-    \033[1;32m# print var1 and var2, with full details
+    \033[1;32m# print var1 and var2, with full details\033[0m
     > {0} var1 var2 --full
 
-    \033[1;32m# print var1 type and valid values
+    \033[1;32m# print var1 type and valid values\033[0m
     > {0} var1 --type --valid-values
 
-    \033[1;32m# print all variables whose name matches expr
+    \033[1;32m# print all variables whose name matches expr\033[0m
     > {0} --grep expr
 
 """.format(pathlib.Path(args[0]).name),
@@ -68,7 +68,7 @@ OR
         "--grep",
         default=False,
         action="store_true",
-        help="List all variables and their values.",
+        help="List all matching variables and their values.",
     )
 
     parser.add_argument(
@@ -100,6 +100,7 @@ OR
     group2.add_argument(
         "--type",
         default=False,
+        dest="dtype",
         action="store_true",
         help="Print the data type associated with each variable.",
     )
@@ -120,19 +121,9 @@ OR
         parser.error("Option --grep requires to pass a variable regex")
 
     if args.variables is not None and len(args.variables)==1:
-        variables = args.variables[0].split(",")
-    else:
-        variables = args.variables
+        args.variables = args.variables[0].split(",")
 
-    return (
-        variables,
-        args.listall,
-        args.full,
-        args.value,
-        args.type,
-        args.valid_values,
-        args.grep,
-    )
+    return args
 
 ###############################################################################
 def _main_func(description):
@@ -143,16 +134,7 @@ def _main_func(description):
         testmod()
         testmod(m=atm_manip)
     else:
-        (
-            variables,
-            listall,
-            value,
-            full,
-            dtype,
-            valid_values,
-            grep,
-        ) = parse_command_line(sys.argv, description)
-        success = atm_query(variables,listall,value,full,dtype,valid_values,grep)
+        success = atm_query(**vars(parse_command_line(sys.argv, description)))
         sys.exit(0 if success else 1)
 
 ###############################################################################

--- a/components/eamxx/scripts/atmquery
+++ b/components/eamxx/scripts/atmquery
@@ -17,7 +17,7 @@ from atm_manip import expect, get_xml_node, AmbiguousName, atm_query_impl
 
 ###############################################################################
 def atm_query(variables,listall=False,full=False,value=False, \
-              dtype=False, valid_values=False):
+              dtype=False, valid_values=False, grep=False):
 ###############################################################################
     expect(os.path.exists("namelist_scream.xml"),
            "No pwd/namelist_scream.xml file is present. Please rum from a case dir that has been setup")
@@ -26,13 +26,13 @@ def atm_query(variables,listall=False,full=False,value=False, \
         tree = ET.parse(fd)
         xml_root = tree.getroot()
 
-    return atm_query_impl(xml_root,variables,listall,full,value,dtype,valid_values)
+    return atm_query_impl(xml_root,variables,listall,full,value,dtype,valid_values,grep)
 
 ###############################################################################
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-        usage="""\n{0} [--listall] [--value] [--type] [--valid-values] [--full] [var1 [,var2 ...]
+        usage="""\n{0} [--grep] [--listall] [--value] [--type] [--valid-values] [--full] [var1 [,var2 ...]
 OR
 {0} --help
 
@@ -49,6 +49,9 @@ OR
     \033[1;32m# print var1 type and valid values
     > {0} var1 --type --valid-values
 
+    \033[1;32m# print all variables whose name matches expr
+    > {0} --grep expr
+
 """.format(pathlib.Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -62,16 +65,23 @@ OR
     )
 
     parser.add_argument(
-        "--listall",
+        "--grep",
         default=False,
         action="store_true",
         help="List all variables and their values.",
     )
 
-    # The following options are mutually exclusive
-    group = parser.add_mutually_exclusive_group()
+    parser.add_argument(
+        "--listall",
+        action="store_true",
+        help="List all variables and their values.",
+    )
 
-    group.add_argument(
+    # The following options are mutually exclusive
+    group1 = parser.add_argument_group(title="Display options")
+    group2 = parser.add_mutually_exclusive_group()
+
+    group2.add_argument(
         "--full",
         default=False,
         action="store_true",
@@ -79,7 +89,7 @@ OR
         "valid values, description and file.",
     )
 
-    group.add_argument(
+    group2.add_argument(
         "--value",
         default=False,
         action="store_true",
@@ -87,14 +97,14 @@ OR
         "If more than one has been found print first value in list.",
     )
 
-    group.add_argument(
+    group2.add_argument(
         "--type",
         default=False,
         action="store_true",
         help="Print the data type associated with each variable.",
     )
 
-    group.add_argument(
+    group2.add_argument(
         "--valid-values",
         default=False,
         action="store_true",
@@ -103,7 +113,13 @@ OR
 
     args = parser.parse_args(args[1:])
 
-    if len(args.variables) == 1:
+    if args.grep and args.listall:
+        parser.error("Cannot specify --listall and --grep at the same time")
+
+    if args.grep and args.variables is None:
+        parser.error("Option --grep requires to pass a variable regex")
+
+    if args.variables is not None and len(args.variables)==1:
         variables = args.variables[0].split(",")
     else:
         variables = args.variables
@@ -115,6 +131,7 @@ OR
         args.value,
         args.type,
         args.valid_values,
+        args.grep,
     )
 
 ###############################################################################
@@ -133,8 +150,9 @@ def _main_func(description):
             full,
             dtype,
             valid_values,
+            grep,
         ) = parse_command_line(sys.argv, description)
-        success = atm_query(variables,listall,value,full,dtype,valid_values)
+        success = atm_query(variables,listall,value,full,dtype,valid_values,grep)
         sys.exit(0 if success else 1)
 
 ###############################################################################

--- a/components/eamxx/scripts/atmquery
+++ b/components/eamxx/scripts/atmquery
@@ -13,7 +13,8 @@ sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 from eamxx_buildnml_impl import check_value
-from atm_manip import expect, get_xml_node, AmbiguousName, atm_query_impl
+from atm_manip import atm_query_impl
+from utils import expect
 
 ###############################################################################
 def atm_query(variables,listall=False,full=False,value=False, \

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -60,17 +60,44 @@ class TestBuildnml(unittest.TestCase):
         return cases[0] if len(cases) == 1 else cases
 
     ###########################################################################
-    def _chg_atmconfig(self, changes, case, buff=True, reset=False, expect_lost=False):
+    def _get_values(self, case, name, value=None, expect_equal=True, all_matches=False):
     ###########################################################################
-        buffer_opt = "" if buff else "--no-buffer"
+        """
+        Queries a name, optionally checking if the value matches or does not match the
+        argument.
+        """
+        if not all_matches:
+            orig = run_cmd_assert_result(self, f"./atmquery {name} --value", from_dir=case)
+            if value:
+                if expect_equal:
+                    self.assertEqual(orig, value)
+                else:
+                    self.assertNotEqual(orig, value)
+
+        else:
+            output = run_cmd_assert_result(self, f"./atmquery {name} --grep", from_dir=case).splitlines()
+            values = [line.rsplit(": ", maxsplit=1)[1].strip() for line in output]
+
+            if value:
+                for orig_value in values:
+                    if expect_equal:
+                        self.assertEqual(orig_value, value)
+                    else:
+                        self.assertNotEqual(orig_value, value)
+
+    ###########################################################################
+    def _chg_atmconfig(self, changes, case, buff=True, reset=False, expect_lost=None, all_matches=False):
+    ###########################################################################
+        buffer_opt      = "" if buff else "--no-buffer"
+        all_matches_opt = "-a" if all_matches else ""
+        expect_lost     = (not buff) or reset if expect_lost is None else expect_lost
 
         for name, value in changes:
-            orig = run_cmd_assert_result(self, f"./atmquery {name} --value", from_dir=case)
-            self.assertNotEqual(orig, value)
+            self._get_values(case, name, value=value, expect_equal=False, all_matches=all_matches)
 
-            run_cmd_assert_result(self, f"./atmchange {buffer_opt} {name}={value}", from_dir=case)
-            curr_value = run_cmd_assert_result(self, f"./atmquery {name} --value", from_dir=case)
-            self.assertEqual(curr_value, value)
+            run_cmd_assert_result(self, f"./atmchange {buffer_opt} {all_matches_opt} {name}={value}", from_dir=case)
+
+            self._get_values(case, name, value=value, expect_equal=True, all_matches=all_matches)
 
         if reset:
             run_cmd_assert_result(self, "./atmchange --reset", from_dir=case)
@@ -78,11 +105,7 @@ class TestBuildnml(unittest.TestCase):
         run_cmd_assert_result(self, "./case.setup", from_dir=case)
 
         for name, value in changes:
-            curr_value = run_cmd_assert_result(self, f"./atmquery {name} --value", from_dir=case)
-            if expect_lost:
-                self.assertNotEqual(curr_value, value)
-            else:
-                self.assertEqual(curr_value, value)
+            self._get_values(case, name, value=value, expect_equal=not expect_lost, all_matches=all_matches)
 
     ###########################################################################
     def setUp(self):
@@ -156,18 +179,17 @@ class TestBuildnml(unittest.TestCase):
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
 
         # An unbuffered atmchange is semantically the same as a manual edit
-        self._chg_atmconfig([("atm_log_level", "trace")], case, buff=False, expect_lost=True)
+        self._chg_atmconfig([("atm_log_level", "trace")], case, buff=False)
 
     ###########################################################################
     def test_reset_atmchanges_are_lost(self):
     ###########################################################################
         """
-        Test that manual atmchanges are lost when eamxx setup is called
+        Test that atmchanges are lost when resetting
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
 
-        # An unbuffered atmchange is semantically the same as a manual edit
-        self._chg_atmconfig([("atm_log_level", "trace")], case, reset=True, expect_lost=True)
+        self._chg_atmconfig([("atm_log_level", "trace")], case, reset=True)
 
     ###########################################################################
     def test_manual_atmchanges_are_not_lost_hack_xml(self):
@@ -178,9 +200,9 @@ class TestBuildnml(unittest.TestCase):
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
 
-        run_cmd_assert_result(self, f"./xmlchange SCREAM_HACK_XML=TRUE", from_dir=case)
+        run_cmd_assert_result(self, "./xmlchange SCREAM_HACK_XML=TRUE", from_dir=case)
 
-        self._chg_atmconfig([("atm_log_level", "trace")], case, buff=False)
+        self._chg_atmconfig([("atm_log_level", "trace")], case, buff=False, expect_lost=False)
 
     ###########################################################################
     def test_multiple_atmchanges_are_preserved(self):
@@ -214,6 +236,16 @@ class TestBuildnml(unittest.TestCase):
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
 
         self._chg_atmconfig([("surf_mom_flux", "40.0,2.0")], case)
+
+    ###########################################################################
+    def test_atmchanges_on_all_matches(self):
+    ###########################################################################
+        """
+        Test that atmchange works for all matches
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+
+        self._chg_atmconfig([("enable_precondition_checks", "false")], case, all_matches=True)
 
 ###############################################################################
 def parse_command_line(args, desc):

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -247,6 +247,16 @@ class TestBuildnml(unittest.TestCase):
 
         self._chg_atmconfig([("enable_precondition_checks", "false")], case, all_matches=True)
 
+    ###########################################################################
+    def test_atmchanges_on_all_matches_plus_spec(self):
+    ###########################################################################
+        """
+        Test that atmchange works for all matches and picking one specialization
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+
+        self._chg_atmconfig([("enable_precondition_checks", "false"), ("p3::enable_precondition_checks", "false")], case, all_matches=True)
+
 ###############################################################################
 def parse_command_line(args, desc):
 ###############################################################################

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -70,42 +70,53 @@ class TestBuildnml(unittest.TestCase):
             orig = run_cmd_assert_result(self, f"./atmquery {name} --value", from_dir=case)
             if value:
                 if expect_equal:
-                    self.assertEqual(orig, value)
+                    self.assertEqual(orig, value, msg=name)
                 else:
-                    self.assertNotEqual(orig, value)
+                    self.assertNotEqual(orig, value, msg=name)
+
+            return [name]
 
         else:
             output = run_cmd_assert_result(self, f"./atmquery {name} --grep", from_dir=case).splitlines()
+            names  = [line.rsplit(": ", maxsplit=1)[0].strip() for line in output]
             values = [line.rsplit(": ", maxsplit=1)[1].strip() for line in output]
 
             if value:
                 for orig_value in values:
                     if expect_equal:
-                        self.assertEqual(orig_value, value)
+                        self.assertEqual(orig_value, value, msg=name)
                     else:
-                        self.assertNotEqual(orig_value, value)
+                        self.assertNotEqual(orig_value, value, msg=name)
+
+            return names
 
     ###########################################################################
-    def _chg_atmconfig(self, changes, case, buff=True, reset=False, expect_lost=None, all_matches=False):
+    def _chg_atmconfig(self, changes, case, buff=True, reset=False, expect_lost=None):
     ###########################################################################
+        changes = [(item[0], item[1], False) if len(item) == 2 else item for item in changes]
+
         buffer_opt      = "" if buff else "--no-buffer"
-        all_matches_opt = "-a" if all_matches else ""
         expect_lost     = (not buff) or reset if expect_lost is None else expect_lost
 
-        for name, value in changes:
+        changes_unpacked = {}
+        for name, value, all_matches in changes:
+            all_matches_opt = "-a" if all_matches else ""
+
             self._get_values(case, name, value=value, expect_equal=False, all_matches=all_matches)
 
             run_cmd_assert_result(self, f"./atmchange {buffer_opt} {all_matches_opt} {name}={value}", from_dir=case)
 
-            self._get_values(case, name, value=value, expect_equal=True, all_matches=all_matches)
+            names = self._get_values(case, name, value=value, expect_equal=True, all_matches=all_matches)
+            for item in names:
+                changes_unpacked[item] = value
 
         if reset:
             run_cmd_assert_result(self, "./atmchange --reset", from_dir=case)
 
         run_cmd_assert_result(self, "./case.setup", from_dir=case)
 
-        for name, value in changes:
-            self._get_values(case, name, value=value, expect_equal=not expect_lost, all_matches=all_matches)
+        for name, value in changes_unpacked.items():
+            self._get_values(case, name, value=value, expect_equal=not expect_lost)
 
     ###########################################################################
     def setUp(self):
@@ -245,7 +256,7 @@ class TestBuildnml(unittest.TestCase):
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
 
-        self._chg_atmconfig([("enable_precondition_checks", "false")], case, all_matches=True)
+        self._chg_atmconfig([("enable_precondition_checks", "false", True)], case)
 
     ###########################################################################
     def test_atmchanges_on_all_matches_plus_spec(self):
@@ -255,7 +266,8 @@ class TestBuildnml(unittest.TestCase):
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
 
-        self._chg_atmconfig([("enable_precondition_checks", "false"), ("p3::enable_precondition_checks", "false")], case, all_matches=True)
+        self._chg_atmconfig([("enable_precondition_checks", "false", True),
+                             ("p3::enable_precondition_checks", "true")], case)
 
 ###############################################################################
 def parse_command_line(args, desc):

--- a/components/eamxx/scripts/scripts-tests
+++ b/components/eamxx/scripts/scripts-tests
@@ -173,7 +173,7 @@ class TestBaseOuter: # Hides the TestBase class from test scanner
 
         def test_pylint(self):
             ensure_pylint()
-            run_cmd_assert_result(self, "python3 -m pylint --disable C --disable R {}".format(self._source_file), from_dir=TEST_DIR)
+            run_cmd_assert_result(self, "python3 -m pylint --disable C --disable R {}".format(self._source_file), from_dir=TEST_DIR, verbose=True)
 
         def test_gen_baseline(self):
             if self._generate:


### PR DESCRIPTION
There are two separate upgrades:

- `atmquery --grep str`: allows to look for all the XML entries whose name (partially) matches `str`. E.g.,
```
$ ./atmquery --grep precond
    atmosphere_processes::enable_precondition_checks: false
    sc_import::enable_precondition_checks: false
    homme::enable_precondition_checks: false
    physics::enable_precondition_checks: false
    mac_aero_mic::enable_precondition_checks: false
    shoc::enable_precondition_checks: false
    cldFraction::enable_precondition_checks: false
    spa::enable_precondition_checks: false
    p3::enable_precondition_checks: false
    rrtmgp::enable_precondition_checks: false
    sc_export::enable_precondition_checks: false
```
- `atmchange --all <change-list>`: allows to apply the given changes to all matches. Eg.,
```
$ ./atmchange --all enable_precondition_checks=true --all
$ ./atmquery --grep precond
    atmosphere_processes::enable_precondition_checks: true
    sc_import::enable_precondition_checks: true
    homme::enable_precondition_checks: true
    physics::enable_precondition_checks: true
    mac_aero_mic::enable_precondition_checks: true
    shoc::enable_precondition_checks: true
    cldFraction::enable_precondition_checks: true
    spa::enable_precondition_checks: true
    p3::enable_precondition_checks: true
    rrtmgp::enable_precondition_checks: true
    sc_export::enable_precondition_checks: true
```