### PR TITLE
EAMxx: workaround to make testing work on weaver

### DIFF
--- a/components/eamxx/scripts/jenkins/weaver_setup
+++ b/components/eamxx/scripts/jenkins/weaver_setup
@@ -1,3 +1,5 @@
+source /etc/profile.d/modules.sh
+
 module load python/3.10.8
 
 SCREAM_MACHINE=weaver


### PR DESCRIPTION
IT folks are examining why the module command is not found from within a script on weaver. Meanwhile, they suggested this reasonable workaround.