### PR TITLE
Some small simplifications to FieldManager

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -346,32 +346,20 @@ void AtmosphereDriver::setup_column_conservation_checks ()
 
   // Get fields needed to run the mass and energy conservation checks. Require that
   // all fields exist.
-  const auto pseudo_density_ptr = phys_field_mgr->get_field_ptr("pseudo_density");
-  const auto ps_ptr             = phys_field_mgr->get_field_ptr("ps");
-  const auto phis_ptr           = phys_field_mgr->get_field_ptr("phis");
-  const auto horiz_winds_ptr    = phys_field_mgr->get_field_ptr("horiz_winds");
-  const auto T_mid_ptr          = phys_field_mgr->get_field_ptr("T_mid");
-  const auto qv_ptr             = phys_field_mgr->get_field_ptr("qv");
-  const auto qc_ptr             = phys_field_mgr->get_field_ptr("qc");
-  const auto qr_ptr             = phys_field_mgr->get_field_ptr("qr");
-  const auto qi_ptr             = phys_field_mgr->get_field_ptr("qi");
-  const auto vapor_flux_ptr     = phys_field_mgr->get_field_ptr("vapor_flux");
-  const auto water_flux_ptr     = phys_field_mgr->get_field_ptr("water_flux");
-  const auto ice_flux_ptr       = phys_field_mgr->get_field_ptr("ice_flux");
-  const auto heat_flux_ptr      = phys_field_mgr->get_field_ptr("heat_flux");
-  EKAT_REQUIRE_MSG(pseudo_density_ptr != nullptr &&
-                   ps_ptr             != nullptr &&
-                   phis_ptr           != nullptr &&
-                   horiz_winds_ptr    != nullptr &&
-                   T_mid_ptr          != nullptr &&
-                   qv_ptr             != nullptr &&
-                   qc_ptr             != nullptr &&
-                   qr_ptr             != nullptr &&
-                   qi_ptr             != nullptr &&
-                   vapor_flux_ptr     != nullptr &&
-                   water_flux_ptr     != nullptr &&
-                   ice_flux_ptr       != nullptr &&
-                   heat_flux_ptr      != nullptr,
+  EKAT_REQUIRE_MSG (
+    phys_field_mgr->has_field("pseudo_density") and
+    phys_field_mgr->has_field("ps") and
+    phys_field_mgr->has_field("phis") and
+    phys_field_mgr->has_field("horiz_winds") and
+    phys_field_mgr->has_field("T_mid") and
+    phys_field_mgr->has_field("qv") and
+    phys_field_mgr->has_field("qc") and
+    phys_field_mgr->has_field("qr") and
+    phys_field_mgr->has_field("qi") and
+    phys_field_mgr->has_field("vapor_flux") and
+    phys_field_mgr->has_field("water_flux") and
+    phys_field_mgr->has_field("ice_flux") and
+    phys_field_mgr->has_field("heat_flux"),
                    "Error! enable_column_conservation_checks=true for some atm process, "
                    "but not all fields needed for this check exist in the FieldManager.\n");
 
@@ -381,14 +369,28 @@ void AtmosphereDriver::setup_column_conservation_checks ()
   const Real energy_error_tol = driver_options_pl.get<double>("energy_column_conservation_error_tolerance", 1e-14);
 
   // Create energy checker
+  const auto pseudo_density = phys_field_mgr->get_field("pseudo_density");
+  const auto ps             = phys_field_mgr->get_field("ps");
+  const auto phis           = phys_field_mgr->get_field("phis");
+  const auto horiz_winds    = phys_field_mgr->get_field("horiz_winds");
+  const auto T_mid          = phys_field_mgr->get_field("T_mid");
+  const auto qv             = phys_field_mgr->get_field("qv");
+  const auto qc             = phys_field_mgr->get_field("qc");
+  const auto qr             = phys_field_mgr->get_field("qr");
+  const auto qi             = phys_field_mgr->get_field("qi");
+  const auto vapor_flux     = phys_field_mgr->get_field("vapor_flux");
+  const auto water_flux     = phys_field_mgr->get_field("water_flux");
+  const auto ice_flux       = phys_field_mgr->get_field("ice_flux");
+  const auto heat_flux      = phys_field_mgr->get_field("heat_flux");
+
   auto conservation_check =
     std::make_shared<MassAndEnergyColumnConservationCheck>(phys_grid,
                                                            mass_error_tol, energy_error_tol,
-                                                           pseudo_density_ptr, ps_ptr, phis_ptr,
-                                                           horiz_winds_ptr, T_mid_ptr, qv_ptr,
-                                                           qc_ptr, qr_ptr, qi_ptr,
-                                                           vapor_flux_ptr, water_flux_ptr,
-                                                           ice_flux_ptr, heat_flux_ptr);
+                                                           pseudo_density, ps, phis,
+                                                           horiz_winds, T_mid, qv,
+                                                           qc, qr, qi,
+                                                           vapor_flux, water_flux,
+                                                           ice_flux, heat_flux);
 
   //Get fail handling type from driver_option parameters.
   const std::string fail_handling_type_str =

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -470,20 +470,19 @@ void AtmosphereDriver::create_fields()
         // Loop over all fields in group src_name on grid src_grid.
         for (const auto& fname : rel_info->m_fields_names) {
           // Get field on src_grid
-          auto f = rel_fm->get_field(fname);
+          const auto& rel_fid = rel_fm->get_field_id(fname);
 
           // Build a FieldRequest for the same field on greq's grid,
           // and add it to the group of this request
           if (fvphyshack) {
-            const auto& sfid = f.get_header().get_identifier();
-            auto dims = sfid.get_layout().dims();
+            auto dims = rel_fid.get_layout().dims();
             dims[0] = fm->get_grid()->get_num_local_dofs();
-            FieldLayout fl(sfid.get_layout().tags(), dims);
-            FieldIdentifier fid(sfid.name(), fl, sfid.get_units(), req.grid);
+            FieldLayout fl(rel_fid.get_layout().tags(), dims);
+            FieldIdentifier fid(rel_fid.name(), fl, rel_fid.get_units(), req.grid);
             FieldRequest freq(fid,req.name,req.pack_size);
             fm->register_field(freq);
           } else {
-            const auto fid = r->create_tgt_fid(f.get_header().get_identifier());
+            const auto fid = r->create_tgt_fid(rel_fid);
             FieldRequest freq(fid,req.name,req.pack_size);
             fm->register_field(freq);
           }

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -470,12 +470,12 @@ void AtmosphereDriver::create_fields()
         // Loop over all fields in group src_name on grid src_grid.
         for (const auto& fname : rel_info->m_fields_names) {
           // Get field on src_grid
-          auto f = rel_fm->get_field_ptr(fname);
+          auto f = rel_fm->get_field(fname);
 
           // Build a FieldRequest for the same field on greq's grid,
           // and add it to the group of this request
           if (fvphyshack) {
-            const auto& sfid = f->get_header().get_identifier();
+            const auto& sfid = f.get_header().get_identifier();
             auto dims = sfid.get_layout().dims();
             dims[0] = fm->get_grid()->get_num_local_dofs();
             FieldLayout fl(sfid.get_layout().tags(), dims);
@@ -483,7 +483,7 @@ void AtmosphereDriver::create_fields()
             FieldRequest freq(fid,req.name,req.pack_size);
             fm->register_field(freq);
           } else {
-            const auto fid = r->create_tgt_fid(f->get_header().get_identifier());
+            const auto fid = r->create_tgt_fid(f.get_header().get_identifier());
             FieldRequest freq(fid,req.name,req.pack_size);
             fm->register_field(freq);
           }

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -129,13 +129,11 @@ bool FieldManager::has_field (const identifier_type& id) const
   return has_field(id.name()) && m_fields.at(id.name())->get_header().get_identifier()==id;
 }
 
-Field FieldManager::get_field (const identifier_type& id) const {
-  EKAT_REQUIRE_MSG(m_repo_state==RepoState::Closed,
-      "Error! Cannot get fields from the repo while registration has not yet completed.\n");
-  auto ptr = get_field_ptr(id);
+const FieldIdentifier& FieldManager::get_field_id (const std::string& name) const {
+  auto ptr = get_field_ptr(name);
   EKAT_REQUIRE_MSG(ptr!=nullptr,
-      "Error! Field identifier '" + id.get_id_string() + "' not found.\n");
-  return *ptr;
+      "Error! Field '" + name + "' not found.\n");
+  return ptr->get_header().get_identifier();
 }
 
 Field FieldManager::get_field (const std::string& name) const {
@@ -144,15 +142,6 @@ Field FieldManager::get_field (const std::string& name) const {
       "Error! Cannot get fields from the repo while registration has not yet completed.\n");
   auto ptr = get_field_ptr(name);
   EKAT_REQUIRE_MSG(ptr!=nullptr, "Error! Field " + name + " not found.\n");
-  return *ptr;
-}
-
-Field& FieldManager::get_field (const identifier_type& id) {
-  EKAT_REQUIRE_MSG(m_repo_state==RepoState::Closed,
-      "Error! Cannot get fields from the repo while registration has not yet completed.\n");
-  auto ptr = get_field_ptr(id);
-  EKAT_REQUIRE_MSG(ptr!=nullptr,
-      "Error! Field identifier '" + id.get_id_string() + "' not found.\n");
   return *ptr;
 }
 

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -711,7 +711,7 @@ void FieldManager::clean_up() {
 
 void FieldManager::add_field (const Field& f) {
   // This method has a few restrictions on the input field.
-  EKAT_REQUIRE_MSG (m_repo_state==RepoState::Closed,
+  EKAT_REQUIRE_MSG (m_repo_state==RepoState::Closed or m_repo_state==RepoState::Clean,
       "Error! The method 'add_field' can only be called on a closed repo.\n");
   EKAT_REQUIRE_MSG (f.is_allocated(),
       "Error! The method 'add_field' requires the input field to be already allocated.\n");
@@ -732,6 +732,8 @@ void FieldManager::add_field (const Field& f) {
 
   // All good, add the field to the repo
   m_fields[f.get_header().get_identifier().name()] = std::make_shared<Field>(f);
+
+  m_repo_state = RepoState::Closed;
 }
 
 std::shared_ptr<Field>

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -147,6 +147,24 @@ Field FieldManager::get_field (const std::string& name) const {
   return *ptr;
 }
 
+Field& FieldManager::get_field (const identifier_type& id) {
+  EKAT_REQUIRE_MSG(m_repo_state==RepoState::Closed,
+      "Error! Cannot get fields from the repo while registration has not yet completed.\n");
+  auto ptr = get_field_ptr(id);
+  EKAT_REQUIRE_MSG(ptr!=nullptr,
+      "Error! Field identifier '" + id.get_id_string() + "' not found.\n");
+  return *ptr;
+}
+
+Field& FieldManager::get_field (const std::string& name) {
+
+  EKAT_REQUIRE_MSG(m_repo_state==RepoState::Closed,
+      "Error! Cannot get fields from the repo while registration has not yet completed.\n");
+  auto ptr = get_field_ptr(name);
+  EKAT_REQUIRE_MSG(ptr!=nullptr, "Error! Field " + name + " not found.\n");
+  return *ptr;
+}
+
 FieldGroup FieldManager::
 get_field_group (const std::string& group_name) const
 {

--- a/components/eamxx/src/share/field/field_manager.hpp
+++ b/components/eamxx/src/share/field/field_manager.hpp
@@ -87,10 +87,8 @@ public:
 
   Field get_field (const std::string& name) const;
   Field get_field (const identifier_type& id) const;
-
-  // Unlike the previous two, these are allowed even if registration is ongoing
-  std::shared_ptr<Field> get_field_ptr(const std::string& name) const;
-  std::shared_ptr<Field> get_field_ptr(const identifier_type& id) const;
+  Field& get_field (const std::string& name);
+  Field& get_field (const identifier_type& id);
 
   FieldGroup get_field_group (const std::string& name) const;
 

--- a/components/eamxx/src/share/field/field_manager.hpp
+++ b/components/eamxx/src/share/field/field_manager.hpp
@@ -105,6 +105,10 @@ public:
 
 protected:
 
+  // These are allowed even if registration is ongoing
+  std::shared_ptr<Field> get_field_ptr(const std::string& name) const;
+  std::shared_ptr<Field> get_field_ptr(const identifier_type& id) const;
+
   void pre_process_group_requests ();
 
   // The state of the repository

--- a/components/eamxx/src/share/field/field_manager.hpp
+++ b/components/eamxx/src/share/field/field_manager.hpp
@@ -85,10 +85,11 @@ public:
   bool has_field (const identifier_type& id) const;
   bool has_group (const std::string& name) const { return m_field_groups.find(name)!=m_field_groups.end(); }
 
+  const FieldIdentifier& get_field_id (const std::string& name) const;
   Field get_field (const std::string& name) const;
-  Field get_field (const identifier_type& id) const;
+  Field get_field (const identifier_type& id) const { return get_field(id.name()); }
   Field& get_field (const std::string& name);
-  Field& get_field (const identifier_type& id);
+  Field& get_field (const identifier_type& id) { return get_field(id.name()); }
 
   FieldGroup get_field_group (const std::string& name) const;
 

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -36,8 +36,6 @@ AtmosphereInput (const std::string& filename,
   auto& names = params.get<std::vector<std::string>>("Field Names",{});
 
   auto fm = std::make_shared<fm_type>(grid);
-  fm->registration_begins();
-  fm->registration_ends();
   for (auto& f : fields) {
     fm->add_field(f);
     names.push_back(f.name());

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -60,8 +60,6 @@ AtmosphereOutput (const ekat::Comm& comm,
 
   // Create a FieldManager with the input fields
   auto fm = std::make_shared<FieldManager> (grid);
-  fm->registration_begins();
-  fm->registration_ends();
   for (auto f : fields) {
     fm->add_field(f);
   }

--- a/components/eamxx/src/share/io/tests/io_basic.cpp
+++ b/components/eamxx/src/share/io/tests/io_basic.cpp
@@ -105,8 +105,6 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
   };
 
   auto fm = std::make_shared<FieldManager>(grid);
-  fm->registration_begins();
-  fm->registration_ends();
   
   const auto units = ekat::units::Units::nondimensional();
   for (const auto& fl : layouts) {

--- a/components/eamxx/src/share/io/tests/io_diags.cpp
+++ b/components/eamxx/src/share/io/tests/io_diags.cpp
@@ -139,8 +139,6 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
   const int nlevs  = grid->get_num_vertical_levels();
 
   auto fm = std::make_shared<FieldManager>(grid);
-  fm->registration_begins();
-  fm->registration_ends();
   
   const auto units = ekat::units::Units::nondimensional();
   FL fl ({COL,LEV}, {nlcols,nlevs});

--- a/components/eamxx/src/share/io/tests/io_packed.cpp
+++ b/components/eamxx/src/share/io/tests/io_packed.cpp
@@ -82,8 +82,6 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
   };
 
   auto fm = std::make_shared<FieldManager>(grid);
-  fm->registration_begins();
-  fm->registration_ends();
   
   const auto units = ekat::units::Units::nondimensional();
   for (const auto& fl : layouts) {

--- a/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
+++ b/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
@@ -7,21 +7,21 @@ namespace scream
 
 MassAndEnergyColumnConservationCheck::
 MassAndEnergyColumnConservationCheck (const std::shared_ptr<const AbstractGrid>& grid,
-                                      const Real                                 mass_error_tolerance,
-                                      const Real                                 energy_error_tolerance,
-                                      const std::shared_ptr<const Field>&        pseudo_density_ptr,
-                                      const std::shared_ptr<const Field>&        ps_ptr,
-                                      const std::shared_ptr<const Field>&        phis_ptr,
-                                      const std::shared_ptr<const Field>&        horiz_winds_ptr,
-                                      const std::shared_ptr<const Field>&        T_mid_ptr,
-                                      const std::shared_ptr<const Field>&        qv_ptr,
-                                      const std::shared_ptr<const Field>&        qc_ptr,
-                                      const std::shared_ptr<const Field>&        qr_ptr,
-                                      const std::shared_ptr<const Field>&        qi_ptr,
-                                      const std::shared_ptr<const Field>&        vapor_flux_ptr,
-                                      const std::shared_ptr<const Field>&        water_flux_ptr,
-                                      const std::shared_ptr<const Field>&        ice_flux_ptr,
-                                      const std::shared_ptr<const Field>&        heat_flux_ptr)
+                                      const Real          mass_error_tolerance,
+                                      const Real          energy_error_tolerance,
+                                      const Field&        pseudo_density,
+                                      const Field&        ps,
+                                      const Field&        phis,
+                                      const Field&        horiz_winds,
+                                      const Field&        T_mid,
+                                      const Field&        qv,
+                                      const Field&        qc,
+                                      const Field&        qr,
+                                      const Field&        qi,
+                                      const Field&        vapor_flux,
+                                      const Field&        water_flux,
+                                      const Field&        ice_flux,
+                                      const Field&        heat_flux)
   : m_grid (grid)
   , m_dt (std::nan(""))
   , m_mass_tol (mass_error_tolerance)
@@ -33,39 +33,19 @@ MassAndEnergyColumnConservationCheck (const std::shared_ptr<const AbstractGrid>&
   m_current_mass   = view_1d<Real> ("current_total_water",  m_num_cols);
   m_current_energy = view_1d<Real> ("current_total_energy", m_num_cols);
 
-  m_fields["pseudo_density"] = pseudo_density_ptr;
-  m_fields["ps"]             = ps_ptr;
-  m_fields["phis"]           = phis_ptr;
-  m_fields["horiz_winds"]    = horiz_winds_ptr;
-  m_fields["T_mid"]          = T_mid_ptr;
-  m_fields["qv"]             = qv_ptr;
-  m_fields["qc"]             = qc_ptr;
-  m_fields["qr"]             = qr_ptr;
-  m_fields["qi"]             = qi_ptr;
-  m_fields["vapor_flux"]     = vapor_flux_ptr;
-  m_fields["water_flux"]     = water_flux_ptr;
-  m_fields["ice_flux"]       = ice_flux_ptr;
-  m_fields["heat_flux"]      = heat_flux_ptr;
-
-  // Require that all fields needed for mass and energy computation are not null.
-  const bool all_computation_fields_exist =
-      pseudo_density_ptr && ps_ptr          &&
-      phis_ptr           && horiz_winds_ptr &&
-      T_mid_ptr          && qv_ptr          &&
-      qc_ptr             && qr_ptr          &&
-      qi_ptr;
-  EKAT_REQUIRE_MSG(all_computation_fields_exist,
-                   "Error! Currently we require mass and energy conservation "
-                   "check to contain all fields related to the mass and energy "
-                   "computation.\n");
-
-  // Require any process that add this checker to define all fluxes.
-  // Fluxes which are not relevant to a certain process should be set to 0.
-  EKAT_REQUIRE_MSG(vapor_flux_ptr && water_flux_ptr &&
-                   ice_flux_ptr   && heat_flux_ptr,
-                   "Error! If a process adds this check, it must define all "
-                   "boundary fluxes. Fluxes which are not relevant to a "
-                   "certain process should be set to 0.\n");
+  m_fields["pseudo_density"] = pseudo_density;
+  m_fields["ps"]             = ps;
+  m_fields["phis"]           = phis;
+  m_fields["horiz_winds"]    = horiz_winds;
+  m_fields["T_mid"]          = T_mid;
+  m_fields["qv"]             = qv;
+  m_fields["qc"]             = qc;
+  m_fields["qr"]             = qr;
+  m_fields["qi"]             = qi;
+  m_fields["vapor_flux"]     = vapor_flux;
+  m_fields["water_flux"]     = water_flux;
+  m_fields["ice_flux"]       = ice_flux;
+  m_fields["heat_flux"]      = heat_flux;
 }
 
 void MassAndEnergyColumnConservationCheck::compute_current_mass ()
@@ -74,11 +54,11 @@ void MassAndEnergyColumnConservationCheck::compute_current_mass ()
   const auto ncols = m_num_cols;
   const auto nlevs = m_num_levs;
 
-  const auto pseudo_density = m_fields.at("pseudo_density")->get_view<const Real**>();
-  const auto qv = m_fields.at("qv")->get_view<const Real**>();
-  const auto qc = m_fields.at("qc")->get_view<const Real**>();
-  const auto qi = m_fields.at("qi")->get_view<const Real**>();
-  const auto qr = m_fields.at("qr")->get_view<const Real**>();
+  const auto pseudo_density = m_fields.at("pseudo_density").get_view<const Real**>();
+  const auto qv = m_fields.at("qv").get_view<const Real**>();
+  const auto qc = m_fields.at("qc").get_view<const Real**>();
+  const auto qi = m_fields.at("qi").get_view<const Real**>();
+  const auto qr = m_fields.at("qr").get_view<const Real**>();
 
   const auto policy = ExeSpaceUtils::get_default_team_policy(ncols, nlevs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
@@ -100,14 +80,14 @@ void MassAndEnergyColumnConservationCheck::compute_current_energy ()
   const auto ncols = m_num_cols;
   const auto nlevs = m_num_levs;
 
-  const auto pseudo_density = m_fields.at("pseudo_density")->get_view<const Real**>();
-  const auto T_mid = m_fields.at("T_mid")->get_view<const Real**>();
-  const auto horiz_winds = m_fields.at("horiz_winds")->get_view<const Real***>();
-  const auto qv = m_fields.at("qv")->get_view<const Real**>();
-  const auto qc = m_fields.at("qc")->get_view<const Real**>();
-  const auto qr = m_fields.at("qr")->get_view<const Real**>();
-  const auto ps = m_fields.at("ps")->get_view<const Real*>();
-  const auto phis = m_fields.at("phis")->get_view<const Real*>();
+  const auto pseudo_density = m_fields.at("pseudo_density").get_view<const Real**>();
+  const auto T_mid = m_fields.at("T_mid").get_view<const Real**>();
+  const auto horiz_winds = m_fields.at("horiz_winds").get_view<const Real***>();
+  const auto qv = m_fields.at("qv").get_view<const Real**>();
+  const auto qc = m_fields.at("qc").get_view<const Real**>();
+  const auto qr = m_fields.at("qr").get_view<const Real**>();
+  const auto ps = m_fields.at("ps").get_view<const Real*>();
+  const auto phis = m_fields.at("phis").get_view<const Real*>();
 
   const auto policy = ExeSpaceUtils::get_default_team_policy(ncols, nlevs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
@@ -136,20 +116,20 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
                                       "before running check().");
   auto dt = m_dt;
 
-  const auto pseudo_density = m_fields.at("pseudo_density")->get_view<const Real**> ();
-  const auto T_mid          = m_fields.at("T_mid"         )->get_view<const Real**> ();
-  const auto horiz_winds    = m_fields.at("horiz_winds"   )->get_view<const Real***>();
-  const auto qv             = m_fields.at("qv"            )->get_view<const Real**> ();
-  const auto qc             = m_fields.at("qc"            )->get_view<const Real**> ();
-  const auto qi             = m_fields.at("qi"            )->get_view<const Real**> ();
-  const auto qr             = m_fields.at("qr"            )->get_view<const Real**> ();
-  const auto ps             = m_fields.at("ps"            )->get_view<const Real*>  ();
-  const auto phis           = m_fields.at("phis"          )->get_view<const Real*>  ();
+  const auto pseudo_density = m_fields.at("pseudo_density").get_view<const Real**> ();
+  const auto T_mid          = m_fields.at("T_mid"         ).get_view<const Real**> ();
+  const auto horiz_winds    = m_fields.at("horiz_winds"   ).get_view<const Real***>();
+  const auto qv             = m_fields.at("qv"            ).get_view<const Real**> ();
+  const auto qc             = m_fields.at("qc"            ).get_view<const Real**> ();
+  const auto qi             = m_fields.at("qi"            ).get_view<const Real**> ();
+  const auto qr             = m_fields.at("qr"            ).get_view<const Real**> ();
+  const auto ps             = m_fields.at("ps"            ).get_view<const Real*>  ();
+  const auto phis           = m_fields.at("phis"          ).get_view<const Real*>  ();
 
-  const auto vapor_flux = m_fields.at("vapor_flux")->get_view<const Real*>();
-  const auto water_flux = m_fields.at("water_flux")->get_view<const Real*>();
-  const auto ice_flux   = m_fields.at("ice_flux"  )->get_view<const Real*>();
-  const auto heat_flux  = m_fields.at("heat_flux" )->get_view<const Real*>();
+  const auto vapor_flux = m_fields.at("vapor_flux").get_view<const Real*>();
+  const auto water_flux = m_fields.at("water_flux").get_view<const Real*>();
+  const auto ice_flux   = m_fields.at("ice_flux"  ).get_view<const Real*>();
+  const auto heat_flux  = m_fields.at("heat_flux" ).get_view<const Real*>();
 
   // Use Kokkos::MaxLoc to find the largest error for both mass and energy
   using maxloc_t = Kokkos::MaxLoc<Real, int>;
@@ -257,7 +237,7 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
       msg << "    - (lat, lon): (" << lat(maxloc_mass.loc) << ", " << lon(maxloc_mass.loc) << ")\n";
     }
     res_and_msg.fail_loc_indices.resize(1,maxloc_mass.loc);
-    res_and_msg.fail_loc_tags = m_fields.at("phis")->get_header().get_identifier().get_layout().tags();
+    res_and_msg.fail_loc_tags = m_fields.at("phis").get_header().get_identifier().get_layout().tags();
   }
   if (not energy_below_tol) {
     msg << "  - energy error tolerance: " << m_energy_tol << "\n";
@@ -267,7 +247,7 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
       msg << "    - (lat, lon): (" << lat(maxloc_energy.loc) << ", " << lon(maxloc_energy.loc) << ")\n";
     }
     res_and_msg.fail_loc_indices.resize(1,maxloc_energy.loc);
-    res_and_msg.fail_loc_tags = m_fields.at("phis")->get_header().get_identifier().get_layout().tags();
+    res_and_msg.fail_loc_tags = m_fields.at("phis").get_header().get_identifier().get_layout().tags();
   }
 
   res_and_msg.msg = msg.str();

--- a/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.hpp
+++ b/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.hpp
@@ -30,21 +30,21 @@ public:
 
   // Constructor
   MassAndEnergyColumnConservationCheck (const std::shared_ptr<const AbstractGrid>& grid,
-                                        const Real                                 mass_error_tolerance,
-                                        const Real                                 energy_error_tolerance,
-                                        const std::shared_ptr<const Field>&        pseudo_density_ptr,
-                                        const std::shared_ptr<const Field>&        ps_ptr,
-                                        const std::shared_ptr<const Field>&        phis_ptr,
-                                        const std::shared_ptr<const Field>&        horiz_winds_ptr,
-                                        const std::shared_ptr<const Field>&        T_mid_ptr,
-                                        const std::shared_ptr<const Field>&        qv_ptr,
-                                        const std::shared_ptr<const Field>&        qc_ptr,
-                                        const std::shared_ptr<const Field>&        qr_ptr,
-                                        const std::shared_ptr<const Field>&        qi_ptr,
-                                        const std::shared_ptr<const Field>&        vapor_flux_ptr,
-                                        const std::shared_ptr<const Field>&        water_flux_ptr,
-                                        const std::shared_ptr<const Field>&        ice_flux_ptr,
-                                        const std::shared_ptr<const Field>&        heat_flux_ptr);
+                                        const Real    mass_error_tolerance,
+                                        const Real    energy_error_tolerance,
+                                        const Field&  pseudo_density_ptr,
+                                        const Field&  ps_ptr,
+                                        const Field&  phis_ptr,
+                                        const Field&  horiz_winds_ptr,
+                                        const Field&  T_mid_ptr,
+                                        const Field&  qv_ptr,
+                                        const Field&  qc_ptr,
+                                        const Field&  qr_ptr,
+                                        const Field&  qi_ptr,
+                                        const Field&  vapor_flux_ptr,
+                                        const Field&  water_flux_ptr,
+                                        const Field&  ice_flux_ptr,
+                                        const Field&  heat_flux_ptr);
 
   // The name of the property check
   std::string name () const override { return "Mass and energy column conservation check"; }
@@ -111,8 +111,8 @@ public:
 
 protected:
 
-  std::shared_ptr<const AbstractGrid>                 m_grid;
-  std::map<std::string, std::shared_ptr<const Field>> m_fields;
+  std::shared_ptr<const AbstractGrid> m_grid;
+  std::map<std::string, Field>  m_fields;
 
   int m_num_cols;
   int m_num_levs;


### PR DESCRIPTION
In particular:

* Allow to call `add_field` without having to call `registration_begins/ends` back to back. If repo is Clean when `add_field` is called, it will be immediately set to Closed (cannot "register" fields anymore, only add pre-built ones). This simplifies things in a few places that only need a FM with pre-build fields.
* Move `get_field_ptr` to protected section. The only outside customer of this method was the mass/energy check, which did not need pointers anyways.
* Add non-const `get_field` returning a reference to the Field. This can be useful with "local" field managers (which are non-const), so we can modify fields on the fly.

@AaronDonahue I think point 3 may make swapping fields between two FM's easier for you.