### PR TITLE
Fix ML correction unit test

### DIFF
--- a/components/eamxx/cmake/machine-files/quartz-intel.cmake
+++ b/components/eamxx/cmake/machine-files/quartz-intel.cmake
@@ -1,3 +1,5 @@
 include(${CMAKE_CURRENT_LIST_DIR}/quartz.cmake)
 set(CMAKE_EXE_LINKER_FLAGS "-L/usr/tce/packages/gcc/gcc-10.3.1-magic/lib/gcc/x86_64-redhat-linux/10/ -qmkl" CACHE STRING "" FORCE)
+set(PYTHON_EXECUTABLE "/usr/tce/packages/python/python-3.9.12/bin/python3" CACHE STRING "" FORCE)
+set(PYTHON_LIBRARIES "/usr/lib64/libpython3.9.so.1.0" CACHE STRING "" FORCE)
 set(RUN_ML_CORRECTION_TEST TRUE CACHE BOOL "")

--- a/components/eamxx/tests/uncoupled/ml_correction/ml_correction_standalone.cpp
+++ b/components/eamxx/tests/uncoupled/ml_correction/ml_correction_standalone.cpp
@@ -21,11 +21,11 @@ TEST_CASE("ml_correction-stand-alone", "") {
   ekat::ParameterList ad_params("Atmosphere Driver");
   parse_yaml_file(fname, ad_params);
 
-  const auto& ts     = ad_params.sublist("time_stepping");
-  const auto  dt     = ts.get<int>("time_step");
-  const auto  nsteps = ts.get<int>("number_of_steps");
-  const auto  t0_str = ts.get<std::string>("run_t0");
-  const auto  t0     = util::str_to_time_stamp(t0_str);
+  const auto &ts    = ad_params.sublist("time_stepping");
+  const auto dt     = ts.get<int>("time_step");
+  const auto nsteps = ts.get<int>("number_of_steps");
+  const auto t0_str = ts.get<std::string>("run_t0");
+  const auto t0     = util::str_to_time_stamp(t0_str);
 
   EKAT_ASSERT_MSG(dt > 0, "Error! Time step must be positive.\n");
 
@@ -62,6 +62,7 @@ TEST_CASE("ml_correction-stand-alone", "") {
   reference += 0.1;
   Real reference2 = qv(1, 30);
   reference2 += 0.1;
+  ekat::disable_all_fpes();  // required for importing numpy
   pybind11::scoped_interpreter guard{};
   pybind11::module sys = pybind11::module::import("sys");
   sys.attr("path").attr("insert")(1, CUSTOM_SYS_PATH);

--- a/components/eamxx/tests/uncoupled/ml_correction/ml_correction_standalone.cpp
+++ b/components/eamxx/tests/uncoupled/ml_correction/ml_correction_standalone.cpp
@@ -21,11 +21,11 @@ TEST_CASE("ml_correction-stand-alone", "") {
   ekat::ParameterList ad_params("Atmosphere Driver");
   parse_yaml_file(fname, ad_params);
 
-  const auto &ts    = ad_params.sublist("time_stepping");
-  const auto dt     = ts.get<int>("time_step");
-  const auto nsteps = ts.get<int>("number_of_steps");
-  const auto t0_str = ts.get<std::string>("run_t0");
-  const auto t0     = util::str_to_time_stamp(t0_str);
+  const auto& ts     = ad_params.sublist("time_stepping");
+  const auto  dt     = ts.get<int>("time_step");
+  const auto  nsteps = ts.get<int>("number_of_steps");
+  const auto  t0_str = ts.get<std::string>("run_t0");
+  const auto  t0     = util::str_to_time_stamp(t0_str);
 
   EKAT_ASSERT_MSG(dt > 0, "Error! Time step must be positive.\n");
 


### PR DESCRIPTION
When `SCREAM_FPE=True`, importing numpy causes FPE. For the unit test, we can just disable it. In the production ML correction, we would want to enable fpes after python calls are done.