### PR TITLE
Fix compute sanitizer tests on weaver when submitting

### DIFF
--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -213,7 +213,7 @@ class CSR(TestProperty):
             "debug with compute sanitizer racecheck",
             [("CMAKE_BUILD_TYPE", "Debug"),
              ("EKAT_ENABLE_COMPUTE_SANITIZER", "True"),
-             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "'--tool racecheck'")],
+             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "--tool=racecheck")],
             uses_baselines=False,
             on_by_default=False,
             default_test_len="short"
@@ -230,7 +230,7 @@ class CSI(TestProperty):
             "debug with compute sanitizer initcheck",
             [("CMAKE_BUILD_TYPE", "Debug"),
              ("EKAT_ENABLE_COMPUTE_SANITIZER", "True"),
-             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "'--tool initcheck'")],
+             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "--tool=initcheck")],
             uses_baselines=False,
             on_by_default=False,
             default_test_len="short"
@@ -247,7 +247,7 @@ class CSS(TestProperty):
             "debug with compute sanitizer synccheck",
             [("CMAKE_BUILD_TYPE", "Debug"),
              ("EKAT_ENABLE_COMPUTE_SANITIZER", "True"),
-             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "'--tool synccheck'")],
+             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "--tool=synccheck")],
             uses_baselines=False,
             on_by_default=False,
             default_test_len="short"


### PR DESCRIPTION
Ninja fix for compute-sanitizer tests when `-p` is provided to test-all-scream. `-p` leads to more nested quoting due to taskset which broke things due to the quotes in EKAT_COMPUTE_SANTIZER_OPTIONS. This PR changes things so the quotes aren't needed.