### PR TITLE
Bug Fix - Fix ml_correction standalone test header declaration

### DIFF
--- a/components/eamxx/tests/uncoupled/ml_correction/ml_correction_standalone.cpp
+++ b/components/eamxx/tests/uncoupled/ml_correction/ml_correction_standalone.cpp
@@ -8,7 +8,7 @@
 #include "control/atmosphere_driver.hpp"
 #include "ekat/ekat_pack.hpp"
 #include "ekat/ekat_parse_yaml_file.hpp"
-#include "physics/ml_correction/atmosphere_ml_correction.hpp"
+#include "physics/ml_correction/eamxx_ml_correction_process_interface.hpp"
 #include "share/atm_process/atmosphere_process.hpp"
 #include "share/grid/mesh_free_grids_manager.hpp"
 


### PR DESCRIPTION
Fix to ml_correction standalone test to changes introduced in #2324 

This is a quick fix to a header file name change that was introduced in a previous commit, but missed because the ml_correction test is only run on a few machines for testing.