### PR TITLE
Bug fix in v0 P3 interface (remove gravit constant in dz calculation)

### DIFF
--- a/components/eam/src/physics/p3/scream/micro_p3_interface.F90
+++ b/components/eam/src/physics/p3/scream/micro_p3_interface.F90
@@ -1019,7 +1019,7 @@ end subroutine micro_p3_readnl
           ! P3 is using dry MMR we instead calculated dz using virtual
           ! temperature and pressure.
 
-          dz(icol,k) = (state%zi(icol,k) - state%zi(icol,k+1))/gravit
+          dz(icol,k) = state%zi(icol,k) - state%zi(icol,k+1)
           th(icol,k) = state%t(icol,k)*inv_exner(icol,k) 
        end do
     end do


### PR DESCRIPTION
I noticed recently that DP-SCREAM simulations using master were highly degraded.  All of them do not look physical.  I traced it back to PR #2193.  When digging further I found an oddity in the P3 interface when dz was calculated as it included a gravitational acceleration factor.  It appears that P3 needs dz in units of [m].  When I removed this factor then the DP-SCREAM simulations looked as expected again.  

See attached figure displaying a DYCOMS-RF01 simulation (marine stratocumulus). The red curve is the current master and represents a very poor solution for this case.  The blue curve represents the SCREAM master just prior to when PR #2193 was merged (this is the expected solution for this case).  The green curve represents results produced by this branch (which retains the expected solution).  This is just an example from one case.  All cases tested are very degraded with current master.

I consider this a very high priority because DP-SCREAM (and v0 RRM) is essentially broken with this bug present.

Note that it does NOT appear this bug is in the v1 code, but I'm hoping someone else will verify this.
![CLDLIQ](https://github.com/E3SM-Project/scream/assets/25110300/9a24a27f-6c7a-46c9-bb0e-738d2b6773bf)
