### PR TITLE
Remove host copy of uninitialized device memory

### DIFF
--- a/components/eamxx/src/physics/rrtmgp/simple_netcdf.hpp
+++ b/components/eamxx/src/physics/rrtmgp/simple_netcdf.hpp
@@ -81,7 +81,7 @@ namespace simple_netcdf {
                 std::vector<int> dimSizes(ndims);
                 size_t dimsize;
                 for (int i = 0; i < ndims; i++) {
-                    handle_error(nc_inq_dimlen(ncid, dimids[i], &dimsize), __FILE__, __LINE__); 
+                    handle_error(nc_inq_dimlen(ncid, dimids[i], &dimsize), __FILE__, __LINE__);
                     dimSizes[i] = dimsize;
                 }
 
@@ -95,7 +95,7 @@ namespace simple_netcdf {
 
                 // Read variable data
                 if (myMem == memDevice) {
-                    auto arrHost = arr.createHostCopy();
+                    auto arrHost = arr.createHostObject();
                     if (std::is_same<T,bool>::value) {
                         // Create boolean array from integer arrays
                         Array<int,rank,memHost,myStyle> tmp("tmp",dimSizes);
@@ -222,7 +222,7 @@ namespace simple_netcdf {
                 handle_error(nc_put_var(ncid, varid, arr), __FILE__, __LINE__);
             }
 
-            template <class T, int rank, int myMem, int myStyle> 
+            template <class T, int rank, int myMem, int myStyle>
             void write(Array<T,rank,myMem,myStyle> const &arr, std::string varName, std::vector<std::string> dimNames) {
 
                 // Make sure length of dimension names is equal to rank of array

--- a/components/eamxx/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
+++ b/components/eamxx/tests/uncoupled/rrtmgp/rrtmgp_standalone_unit.cpp
@@ -134,7 +134,6 @@ namespace scream {
         auto ncol_all = grid->get_num_global_dofs();
         auto p_lay_all = real2d("p_lay", ncol_all, nlay);
         auto t_lay_all = real2d("t_lay", ncol_all, nlay);
-        auto p_del_all = real2d("p_del", ncol_all, nlay);
         auto p_lev_all = real2d("p_lev", ncol_all, nlay+1);
         auto t_lev_all = real2d("t_lev", ncol_all, nlay+1);
         auto sfc_alb_dir_vis_all = real1d("sfc_alb_dir_vis", ncol_all);
@@ -178,7 +177,6 @@ namespace scream {
             auto icol_all = ncol * irank + icol;
             p_lay(icol,ilay) = p_lay_all(icol_all,ilay);
             t_lay(icol,ilay) = t_lay_all(icol_all,ilay);
-            p_del(icol,ilay) = p_del_all(icol_all,ilay);
             lwp(icol,ilay) = lwp_all(icol_all,ilay);
             iwp(icol,ilay) = iwp_all(icol_all,ilay);
             rel(icol,ilay) = rel_all(icol_all,ilay);
@@ -193,7 +191,6 @@ namespace scream {
         // Free temporary variables
         p_lay_all.deallocate();
         t_lay_all.deallocate();
-        p_del_all.deallocate();
         p_lev_all.deallocate();
         t_lev_all.deallocate();
         sfc_alb_dir_vis_all.deallocate();


### PR DESCRIPTION
Should fix [scream_unit_tests_compute_santizer_initcheck](https://my.cdash.org/build/2347016) fails. Two issue:
1. We were requesting host copy of uninitialized device array in YAKL. We only need the host object, that we read values into from netcdf file, and then we deep copy back to device.
2. `rrtmgp_standalone_unit` test allocated an array that was unset. Uninitialized memory read occurred when copying to new array.