### PR TITLE
EAMxx: allow CoarseningRemapper to handle strided subfields

### DIFF
--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -200,8 +200,10 @@ deep_copy_impl (const Field& src) {
   //       field might be a subfield of another. We need the reshaped view.
   //       Also, don't call Kokkos::deep_copy if this field and src have
   //       different pack sizes.
-  auto src_alloc = src.get_header().get_alloc_properties().get_alloc_size();
-  auto tgt_alloc =     get_header().get_alloc_properties().get_alloc_size();
+  auto src_alloc_props = src.get_header().get_alloc_properties();
+  auto tgt_alloc_props =     get_header().get_alloc_properties();
+  auto src_alloc_size  = src_alloc_props.get_alloc_size();
+  auto tgt_alloc_size  = tgt_alloc_props.get_alloc_size();
 
   // If a manual parallel_for is required (b/c of alloc sizes difference),
   // we need to create extents (rather than just using the one in layout),
@@ -217,14 +219,26 @@ deep_copy_impl (const Field& src) {
   switch (rank) {
     case 1:
       {
-        auto v     =     get_view<      ST*,HD>();
-        auto v_src = src.get_view<const ST*,HD>();
-        if (src_alloc==tgt_alloc) {
-          Kokkos::deep_copy(v,v_src);
+        if (src_alloc_props.contiguous() and tgt_alloc_props.contiguous()) {
+          auto v     =     get_view<      ST*,HD>();
+          auto v_src = src.get_view<const ST*,HD>();
+          if (src_alloc_size==tgt_alloc_size) {
+            Kokkos::deep_copy(v,v_src);
+          } else {
+            Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
+              v(idx) = v_src(idx);
+            });
+          }
         } else {
-          Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            v(idx) = v_src(idx);
-          });
+          auto v     =     get_strided_view<      ST*,HD>();
+          auto v_src = src.get_strided_view<const ST*,HD>();
+          if (src_alloc_size==tgt_alloc_size) {
+            Kokkos::deep_copy(v,v_src);
+          } else {
+            Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
+              v(idx) = v_src(idx);
+            });
+          }
         }
       }
       break;
@@ -232,7 +246,7 @@ deep_copy_impl (const Field& src) {
       {
         auto v     =     get_view<      ST**,HD>();
         auto v_src = src.get_view<const ST**,HD>();
-        if (src_alloc==tgt_alloc) {
+        if (src_alloc_size==tgt_alloc_size) {
           Kokkos::deep_copy(v,v_src);
         } else {
           Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
@@ -247,7 +261,7 @@ deep_copy_impl (const Field& src) {
       {
         auto v     =     get_view<      ST***,HD>();
         auto v_src = src.get_view<const ST***,HD>();
-        if (src_alloc==tgt_alloc) {
+        if (src_alloc_size==tgt_alloc_size) {
           Kokkos::deep_copy(v,v_src);
         } else {
           Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
@@ -262,7 +276,7 @@ deep_copy_impl (const Field& src) {
       {
         auto v     =     get_view<      ST****,HD>();
         auto v_src = src.get_view<const ST****,HD>();
-        if (src_alloc==tgt_alloc) {
+        if (src_alloc_size==tgt_alloc_size) {
           Kokkos::deep_copy(v,v_src);
         } else {
           Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
@@ -277,7 +291,7 @@ deep_copy_impl (const Field& src) {
       {
         auto v     =     get_view<      ST*****,HD>();
         auto v_src = src.get_view<const ST*****,HD>();
-        if (src_alloc==tgt_alloc) {
+        if (src_alloc_size==tgt_alloc_size) {
           Kokkos::deep_copy(v,v_src);
         } else {
           Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
@@ -305,8 +319,13 @@ void Field::deep_copy_impl (const ST value) {
   switch (rank) {
     case 1:
       {
-        auto v = get_view<ST*,HD>();
-        Kokkos::deep_copy(v,value);
+        if (m_header->get_alloc_properties().contiguous()) {
+          auto v = get_view<ST*,HD>();
+          Kokkos::deep_copy(v,value);
+        } else {
+          auto v = get_strided_view<ST*,HD>();
+          Kokkos::deep_copy(v,value);
+        }
       }
       break;
     case 2:


### PR DESCRIPTION
This PR allows to run the CoarseningRemapper on fields that are strided subfields of other fields. It also fixes an issue within the Field class impl, that caused errors with strided fields.

To confirm things work as expected, I ran an ne30 case, with two output streams (one on ne30pg2 grid, and one remapped to ne4pg2). I then ran ncremap on the ne30 output and compared it to the ne4 output. The two are not bfb, due to how accumulations are done as well as to the fact that EAMxx runs in double precision, while the nc file contain single precision fields. The diffs, however, are within roundoff:
```
23c23
< -0.06780888
---
> -0.06780889
28c28
< -0.001327516
---
> -0.001327515
67c67
< -0.0007315932
---
> -0.0007315931
...
```

One last thing to do: add a remapped output stream to one of our ne30 nightly tests.