### PR TITLE
Update nudging atm process member variables

### DIFF
--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -7,9 +7,8 @@ namespace scream
 // =========================================================================================
 Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
   : AtmosphereProcess(comm, params)
-{
-  datafile=m_params.get<std::string>("Nudging_Filename");
-}
+  , m_datafile(params.get<std::string>("Nudging_Filename"))
+{}
 
 // =========================================================================================
 void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
@@ -30,121 +29,120 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>("p_mid", scalar3d_layout_mid, Pa, grid_name, ps);
   add_field<Updated>("T_mid", scalar3d_layout_mid, K, grid_name, ps);
   add_field<Updated>("qv", scalar3d_layout_mid, Q, grid_name, "tracers", ps);
-  add_field<Updated>("u", scalar3d_layout_mid, m/s, grid_name, ps);  
-  add_field<Updated>("v", scalar3d_layout_mid, m/s, grid_name, ps);  
+  add_field<Updated>("u", scalar3d_layout_mid, m/s, grid_name, ps);
+  add_field<Updated>("v", scalar3d_layout_mid, m/s, grid_name, ps);
 
   //Now need to read in the file
-  scorpio::register_file(datafile,scorpio::Read);
-  m_num_src_levs = scorpio::get_dimlen(datafile,"lev");
-  double time_value_1= scorpio::read_time_at_index_c2f(datafile.c_str(),1);
-  double time_value_2= scorpio::read_time_at_index_c2f(datafile.c_str(),2);
-    
-  //Here we are assuming that the time in the netcdf file is in days
-  //Internally we want this in seconds so need to convert
-  //Only consider integer time steps in seconds to resolve any roundoff error
-  time_step_file=int((time_value_2-time_value_1)*86400);
-  scorpio::eam_pio_closefile(datafile);
+  scorpio::register_file(m_datafile,scorpio::Read);
+  m_num_src_levs = scorpio::get_dimlen(m_datafile,"lev");
+  double time_value_1= scorpio::read_time_at_index_c2f(m_datafile.c_str(),1);
+  double time_value_2= scorpio::read_time_at_index_c2f(m_datafile.c_str(),2);
+
+  // Here we are assuming that the time in the netcdf file is in days
+  // Internally we want this in seconds so need to convert
+  // Only consider integer time steps in seconds to resolve any roundoff error
+  m_time_step_file=int((time_value_2-time_value_1)*86400);
+  scorpio::eam_pio_closefile(m_datafile);
 }
 
 // =========================================================================================
 void Nudging::initialize_impl (const RunType /* run_type */)
 {
   using namespace ShortFieldTagsNames;
+
+  std::map<std::string,view_1d_host<Real>> host_views;
+  std::map<std::string,FieldLayout>  layouts;
+
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols, m_num_src_levs} };
   FieldLayout horiz_wind_layout { {COL,CMP,LEV}, {m_num_cols,2,m_num_src_levs} };
-  fields_ext["T_mid"] = view_2d<Real>("T_mid",m_num_cols,m_num_src_levs);
-  fields_ext_h["T_mid"]       = Kokkos::create_mirror_view(fields_ext["T_mid"]);
-  auto T_mid_h=fields_ext_h["T_mid"];
+  m_fields_ext["T_mid"] = view_2d<Real>("T_mid",m_num_cols,m_num_src_levs);
+  m_fields_ext_h["T_mid"]       = Kokkos::create_mirror_view(m_fields_ext["T_mid"]);
+  auto T_mid_h=m_fields_ext_h["T_mid"];
   host_views["T_mid"] = view_1d_host<Real>(T_mid_h.data(),T_mid_h.size());
   layouts.emplace("T_mid", scalar3d_layout_mid);
 
-  fields_ext["p_mid"] = view_2d<Real>("p_mid",m_num_cols,m_num_src_levs);
-  fields_ext_h["p_mid"]       = Kokkos::create_mirror_view(fields_ext["p_mid"]);
-  auto p_mid_h=fields_ext_h["p_mid"];
+  m_fields_ext["p_mid"] = view_2d<Real>("p_mid",m_num_cols,m_num_src_levs);
+  m_fields_ext_h["p_mid"]       = Kokkos::create_mirror_view(m_fields_ext["p_mid"]);
+  auto p_mid_h=m_fields_ext_h["p_mid"];
   host_views["p_mid"] = view_1d_host<Real>(p_mid_h.data(),p_mid_h.size());
   layouts.emplace("p_mid", scalar3d_layout_mid);
-  
-  fields_ext["qv"] = view_2d<Real>("qv",m_num_cols,m_num_src_levs);
-  fields_ext_h["qv"]       = Kokkos::create_mirror_view(fields_ext["qv"]);
-  auto qv_h=fields_ext_h["qv"];
+
+  m_fields_ext["qv"] = view_2d<Real>("qv",m_num_cols,m_num_src_levs);
+  m_fields_ext_h["qv"]       = Kokkos::create_mirror_view(m_fields_ext["qv"]);
+  auto qv_h=m_fields_ext_h["qv"];
   host_views["qv"] = view_1d_host<Real>(qv_h.data(),qv_h.size());
   layouts.emplace("qv", scalar3d_layout_mid);
 
-  fields_ext["u"] = view_2d<Real>("u",m_num_cols,m_num_src_levs);
-  fields_ext_h["u"]       = Kokkos::create_mirror_view(fields_ext["u"]);
-  auto u_h=fields_ext_h["u"];
+  m_fields_ext["u"] = view_2d<Real>("u",m_num_cols,m_num_src_levs);
+  m_fields_ext_h["u"]       = Kokkos::create_mirror_view(m_fields_ext["u"]);
+  auto u_h=m_fields_ext_h["u"];
   host_views["u"] = view_1d_host<Real>(u_h.data(),u_h.size());
   layouts.emplace("u", scalar3d_layout_mid);
 
-  fields_ext["v"] = view_2d<Real>("v",m_num_cols,m_num_src_levs);
-  fields_ext_h["v"]       = Kokkos::create_mirror_view(fields_ext["v"]);
-  auto v_h=fields_ext_h["v"];
+  m_fields_ext["v"] = view_2d<Real>("v",m_num_cols,m_num_src_levs);
+  m_fields_ext_h["v"]       = Kokkos::create_mirror_view(m_fields_ext["v"]);
+  auto v_h=m_fields_ext_h["v"];
   host_views["v"] = view_1d_host<Real>(v_h.data(),v_h.size());
   layouts.emplace("v", scalar3d_layout_mid);
 
   auto grid_l = m_grid->clone("Point Grid", false);
   grid_l->reset_num_vertical_lev(m_num_src_levs);
   ekat::ParameterList data_in_params;
-  m_fnames = {"T_mid","p_mid","qv","u","v"};
-  data_in_params.set("Field Names",m_fnames);
-  data_in_params.set("Filename",datafile);
-  // We need to skip grid checks because multiple ranks 
+  std::vector<std::string> fnames = {"T_mid","p_mid","qv","u","v"};
+  data_in_params.set("Field Names",fnames);
+  data_in_params.set("Filename",m_datafile);
+  // We need to skip grid checks because multiple ranks
   // may want the same column of source data.
-  data_in_params.set("Skip_Grid_Checks",true);  
-  data_input.init(data_in_params,grid_l,host_views,layouts);
+  data_in_params.set("Skip_Grid_Checks",true);
+  m_data_input.init(data_in_params,grid_l,host_views,layouts);
 
-  T_mid_ext = fields_ext["T_mid"];
-  p_mid_ext = fields_ext["p_mid"];
-  qv_ext = fields_ext["qv"];
-  u_ext = fields_ext["u"];
-  v_ext = fields_ext["v"];
-  ts0=timestamp();
+  m_ts0=timestamp();
 
   //Check that internal timestamp starts at same point as time in external file
-  auto case_t0 = scorpio::read_timestamp(datafile,"case_t0");
+  auto case_t0 = scorpio::read_timestamp(m_datafile,"case_t0");
 
-  EKAT_REQUIRE_MSG(case_t0.get_year()==ts0.get_year(),
+  EKAT_REQUIRE_MSG(case_t0.get_year()==m_ts0.get_year(),
 		   "ERROR: The start year from the nudging file is "\
 		   "different than the internal simulation start year\n");
-  EKAT_REQUIRE_MSG(case_t0.get_month()==ts0.get_month(),
+  EKAT_REQUIRE_MSG(case_t0.get_month()==m_ts0.get_month(),
 		   "ERROR: The start month from the nudging file is "\
 		   "different than the internal simulation start month\n");
-  EKAT_REQUIRE_MSG(case_t0.get_day()==ts0.get_day(),
+  EKAT_REQUIRE_MSG(case_t0.get_day()==m_ts0.get_day(),
 		   "ERROR: The start day from the nudging file is "\
 		   "different than the internal simulation start day\n");
-  EKAT_REQUIRE_MSG(case_t0.get_hours()==ts0.get_hours(),
+  EKAT_REQUIRE_MSG(case_t0.get_hours()==m_ts0.get_hours(),
 		   "ERROR: The start hour from the nudging file is "\
 		   "different than the internal simulation start hour\n");
-  EKAT_REQUIRE_MSG(case_t0.get_minutes()==ts0.get_minutes(),
+  EKAT_REQUIRE_MSG(case_t0.get_minutes()==m_ts0.get_minutes(),
 		   "ERROR: The start minute from the nudging file is "\
 		   "different than the internal simulation start minute\n");
-  EKAT_REQUIRE_MSG(case_t0.get_seconds()==ts0.get_seconds(),
+  EKAT_REQUIRE_MSG(case_t0.get_seconds()==m_ts0.get_seconds(),
 		   "ERROR: The start second from the nudging file is "\
 		   "different than the internal simulation start second\n");
-		   
+
   //Initialize before and after data
-  NudgingData_bef.init(m_num_cols,m_num_src_levs,true);
-  NudgingData_bef.time = -999;
-  NudgingData_aft.init(m_num_cols,m_num_src_levs,true);
-  NudgingData_aft.time = -999;
+  m_NudgingData_bef.init(m_num_cols,m_num_src_levs,true);
+  m_NudgingData_bef.time = -999;
+  m_NudgingData_aft.init(m_num_cols,m_num_src_levs,true);
+  m_NudgingData_aft.time = -999;
 
   //Read in the first time step
-  data_input.read_variables(0);
-  Kokkos::deep_copy(NudgingData_bef.T_mid,fields_ext_h["T_mid"]);
-  Kokkos::deep_copy(NudgingData_bef.p_mid,fields_ext_h["p_mid"]);
-  Kokkos::deep_copy(NudgingData_bef.u,fields_ext_h["u"]);
-  Kokkos::deep_copy(NudgingData_bef.v,fields_ext_h["v"]);
-  Kokkos::deep_copy(NudgingData_bef.qv,fields_ext_h["qv"]);
-  NudgingData_bef.time = 0.;
+  m_data_input.read_variables(0);
+  Kokkos::deep_copy(m_NudgingData_bef.T_mid,m_fields_ext_h["T_mid"]);
+  Kokkos::deep_copy(m_NudgingData_bef.p_mid,m_fields_ext_h["p_mid"]);
+  Kokkos::deep_copy(m_NudgingData_bef.u,m_fields_ext_h["u"]);
+  Kokkos::deep_copy(m_NudgingData_bef.v,m_fields_ext_h["v"]);
+  Kokkos::deep_copy(m_NudgingData_bef.qv,m_fields_ext_h["qv"]);
+  m_NudgingData_bef.time = 0.;
 
   //Read in the first time step
-  data_input.read_variables(1);
-  Kokkos::deep_copy(NudgingData_aft.T_mid,fields_ext_h["T_mid"]);
-  Kokkos::deep_copy(NudgingData_aft.p_mid,fields_ext_h["p_mid"]);
-  Kokkos::deep_copy(NudgingData_aft.u,fields_ext_h["u"]);
-  Kokkos::deep_copy(NudgingData_aft.v,fields_ext_h["v"]);
-  Kokkos::deep_copy(NudgingData_aft.qv,fields_ext_h["qv"]);
-  NudgingData_aft.time = time_step_file;
+  m_data_input.read_variables(1);
+  Kokkos::deep_copy(m_NudgingData_aft.T_mid,m_fields_ext_h["T_mid"]);
+  Kokkos::deep_copy(m_NudgingData_aft.p_mid,m_fields_ext_h["p_mid"]);
+  Kokkos::deep_copy(m_NudgingData_aft.u,m_fields_ext_h["u"]);
+  Kokkos::deep_copy(m_NudgingData_aft.v,m_fields_ext_h["v"]);
+  Kokkos::deep_copy(m_NudgingData_aft.qv,m_fields_ext_h["qv"]);
+  m_NudgingData_aft.time = m_time_step_file;
 
 }
 
@@ -154,30 +152,36 @@ void Nudging::time_interpolation (const int time_s) {
   using ExeSpace = typename KT::ExeSpace;
   using ESU = ekat::ExeSpaceUtils<ExeSpace>;
   using MemberType = typename KT::MemberType;
-  
-  const int time_index = time_s/time_step_file;
-  double time_step_file_d = time_step_file;
-  double w_bef = ((time_index+1)*time_step_file-time_s) / time_step_file_d;
-  double w_aft = (time_s-(time_index)*time_step_file) / time_step_file_d;
-  const int num_cols = NudgingData_aft.T_mid.extent(0);
-  const int num_vert_packs = NudgingData_aft.T_mid.extent(1);
+
+  const int time_index = time_s/m_time_step_file;
+  double time_step_file_d = m_time_step_file;
+  double w_bef = ((time_index+1)*m_time_step_file-time_s) / time_step_file_d;
+  double w_aft = (time_s-(time_index)*m_time_step_file) / time_step_file_d;
+  const int num_cols = m_NudgingData_aft.T_mid.extent(0);
+  const int num_vert_packs = m_NudgingData_aft.T_mid.extent(1);
   const auto policy = ESU::get_default_team_policy(num_cols, num_vert_packs);
 
-  auto T_mid_bef = NudgingData_bef.T_mid;
-  auto T_mid_aft = NudgingData_aft.T_mid;
-  auto u_bef = NudgingData_bef.u;
-  auto u_aft = NudgingData_aft.u;
-  auto v_bef = NudgingData_bef.v;
-  auto v_aft = NudgingData_aft.v;
-  auto p_mid_bef = NudgingData_bef.p_mid;
-  auto p_mid_aft = NudgingData_aft.p_mid;
-  auto qv_bef = NudgingData_bef.qv;
-  auto qv_aft = NudgingData_aft.qv;
+  auto T_mid_ext = m_fields_ext["T_mid"];
+  auto p_mid_ext = m_fields_ext["p_mid"];
+  auto qv_ext = m_fields_ext["qv"];
+  auto u_ext = m_fields_ext["u"];
+  auto v_ext = m_fields_ext["v"];
+
+  auto T_mid_bef = m_NudgingData_bef.T_mid;
+  auto T_mid_aft = m_NudgingData_aft.T_mid;
+  auto u_bef = m_NudgingData_bef.u;
+  auto u_aft = m_NudgingData_aft.u;
+  auto v_bef = m_NudgingData_bef.v;
+  auto v_aft = m_NudgingData_aft.v;
+  auto p_mid_bef = m_NudgingData_bef.p_mid;
+  auto p_mid_aft = m_NudgingData_aft.p_mid;
+  auto qv_bef = m_NudgingData_bef.qv;
+  auto qv_aft = m_NudgingData_aft.qv;
 
   Kokkos::parallel_for("nudging_time_interpolation", policy,
      	       KOKKOS_LAMBDA(MemberType const& team) {
-
       const int icol = team.league_rank();
+
       auto T_mid_1d = ekat::subview(T_mid_ext,icol);
       auto T_mid_bef_1d = ekat::subview(T_mid_bef,icol);
       auto T_mid_aft_1d = ekat::subview(T_mid_aft,icol);
@@ -196,49 +200,49 @@ void Nudging::time_interpolation (const int time_s) {
 
       const auto range = Kokkos::TeamThreadRange(team, num_vert_packs);
       Kokkos::parallel_for(range, [&] (const Int & k) {
-	  T_mid_1d(k)=w_bef*T_mid_bef_1d(k) + w_aft*T_mid_aft_1d(k);
-	  p_mid_1d(k)=w_bef*p_mid_bef_1d(k) + w_aft*p_mid_aft_1d(k);
-	  u_1d(k)=w_bef*u_bef_1d(k) + w_aft*u_aft_1d(k);
-	  v_1d(k)=w_bef*v_bef_1d(k) + w_aft*v_aft_1d(k);
-	  qv_1d(k)=w_bef*qv_bef_1d(k) + w_aft*qv_aft_1d(k);
+        T_mid_1d(k)=w_bef*T_mid_bef_1d(k) + w_aft*T_mid_aft_1d(k);
+        p_mid_1d(k)=w_bef*p_mid_bef_1d(k) + w_aft*p_mid_aft_1d(k);
+        u_1d(k)=w_bef*u_bef_1d(k) + w_aft*u_aft_1d(k);
+        v_1d(k)=w_bef*v_bef_1d(k) + w_aft*v_aft_1d(k);
+        qv_1d(k)=w_bef*qv_bef_1d(k) + w_aft*qv_aft_1d(k);
       });
       team.team_barrier();
   });
-  Kokkos::fence();   
+  Kokkos::fence();
 }
 
 // =========================================================================================
 void Nudging::update_time_step (const int time_s)
 {
   //Check to see in time state needs to be updated
-  if (time_s >= NudgingData_aft.time)
+  if (time_s >= m_NudgingData_aft.time)
     {
-      const int time_index = time_s/time_step_file;
-      std::swap (NudgingData_bef,NudgingData_aft);
-      NudgingData_bef.time = NudgingData_aft.time;
+      const int time_index = time_s/m_time_step_file;
+      std::swap (m_NudgingData_bef,m_NudgingData_aft);
+      m_NudgingData_bef.time = m_NudgingData_aft.time;
 
-      data_input.read_variables(time_index+1);
-      Kokkos::deep_copy(NudgingData_aft.T_mid,fields_ext_h["T_mid"]);
-      Kokkos::deep_copy(NudgingData_aft.p_mid,fields_ext_h["p_mid"]);
-      Kokkos::deep_copy(NudgingData_aft.u,fields_ext_h["u"]);
-      Kokkos::deep_copy(NudgingData_aft.v,fields_ext_h["v"]);
-      Kokkos::deep_copy(NudgingData_aft.qv,fields_ext_h["qv"]);
-      NudgingData_aft.time = time_step_file*(time_index+1);
+      m_data_input.read_variables(time_index+1);
+      Kokkos::deep_copy(m_NudgingData_aft.T_mid,m_fields_ext_h["T_mid"]);
+      Kokkos::deep_copy(m_NudgingData_aft.p_mid,m_fields_ext_h["p_mid"]);
+      Kokkos::deep_copy(m_NudgingData_aft.u,m_fields_ext_h["u"]);
+      Kokkos::deep_copy(m_NudgingData_aft.v,m_fields_ext_h["v"]);
+      Kokkos::deep_copy(m_NudgingData_aft.qv,m_fields_ext_h["qv"]);
+      m_NudgingData_aft.time = m_time_step_file*(time_index+1);
     }
-  
+
 }
 
-  
+
 // =========================================================================================
 void Nudging::run_impl (const double dt)
 {
   using namespace scream::vinterp;
 
-  //Have to add dt because first time iteration is at 0 seconds where you will 
-  //not have any data from the field. The timestamp is only iterated at the 
+  //Have to add dt because first time iteration is at 0 seconds where you will
+  //not have any data from the field. The timestamp is only iterated at the
   //end of the full step in scream.
   auto ts = timestamp()+dt;
-  auto time_since_zero = ts.seconds_from(ts0);
+  auto time_since_zero = ts.seconds_from(m_ts0);
 
   //update time state information and check whether need to update data
   update_time_step(time_since_zero);
@@ -253,15 +257,15 @@ void Nudging::run_impl (const double dt)
 
   const auto& p_mid    = get_field_in("p_mid").get_view<const mPack**>();
 
-  const view_Nd<mPack,2> T_mid_ext_p(reinterpret_cast<mPack*>(fields_ext["T_mid"].data()),
-				     m_num_cols,m_num_src_levs); 
-  const view_Nd<mPack,2> p_mid_ext_p(reinterpret_cast<mPack*>(fields_ext["p_mid"].data()),
+  const view_Nd<mPack,2> T_mid_ext_p(reinterpret_cast<mPack*>(m_fields_ext["T_mid"].data()),
 				     m_num_cols,m_num_src_levs);
-  const view_Nd<mPack,2> qv_ext_p(reinterpret_cast<mPack*>(fields_ext["qv"].data()),
+  const view_Nd<mPack,2> p_mid_ext_p(reinterpret_cast<mPack*>(m_fields_ext["p_mid"].data()),
+				     m_num_cols,m_num_src_levs);
+  const view_Nd<mPack,2> qv_ext_p(reinterpret_cast<mPack*>(m_fields_ext["qv"].data()),
 				  m_num_cols,m_num_src_levs);
-  const view_Nd<mPack,2> u_ext_p(reinterpret_cast<mPack*>(fields_ext["u"].data()),
+  const view_Nd<mPack,2> u_ext_p(reinterpret_cast<mPack*>(m_fields_ext["u"].data()),
 				  m_num_cols,m_num_src_levs);
-  const view_Nd<mPack,2> v_ext_p(reinterpret_cast<mPack*>(fields_ext["v"].data()),
+  const view_Nd<mPack,2> v_ext_p(reinterpret_cast<mPack*>(m_fields_ext["v"].data()),
 				  m_num_cols,m_num_src_levs);
 
   //Now perform the vertical interpolation from the external file to the internal
@@ -296,6 +300,12 @@ void Nudging::run_impl (const double dt)
 
   //This code removes any masked values and sets them to the corresponding
   //values at the lowest/highest pressure levels from the external file
+  auto T_mid_ext = m_fields_ext["T_mid"];
+  auto p_mid_ext = m_fields_ext["p_mid"];
+  auto qv_ext = m_fields_ext["qv"];
+  auto u_ext = m_fields_ext["u"];
+  auto v_ext = m_fields_ext["v"];
+
   const int num_cols = T_mid.extent(0);
   const int num_vert_packs = T_mid.extent(1);
   const int num_vert_packs_ext = T_mid_ext.extent(1);
@@ -333,13 +343,13 @@ void Nudging::run_impl (const double dt)
       });
       team.team_barrier();
   });
-  Kokkos::fence();   
+  Kokkos::fence();
 }
 
 // =========================================================================================
 void Nudging::finalize_impl()
 {
-  data_input.finalize();
+  m_data_input.finalize();
 }
 
 } // namespace scream

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -29,10 +29,10 @@ public:
   using NudgingFunc = nudging::NudgingFunctions;
   using mPack = ekat::Pack<Real,1>;
   using KT = KokkosTypes<DefaultDevice>;
-  
+
   template <typename S>
   using view_1d = typename KT::template view_1d<S>;
-  
+
   template <typename S>
   using view_2d = typename KT::template view_2d<S>;
 
@@ -59,7 +59,7 @@ public:
 
   //Update the time step
   void update_time_step(const int time_s);
-  
+
   //Time interpolation function
   void time_interpolation(const int time_s);
 
@@ -69,7 +69,7 @@ protected:
 #endif
 
   void run_impl        (const double dt);
-  
+
 protected:
 
   // The three main overrides for the subcomponent
@@ -78,25 +78,19 @@ protected:
 
   std::shared_ptr<const AbstractGrid>   m_grid;
   // Keep track of field dimensions and the iteration count
-  int m_num_cols; 
+  int m_num_cols;
   int m_num_levs;
   int m_num_src_levs;
-  int time_step_file;
-  std::string datafile;
-  std::map<std::string,view_1d_host<Real>> host_views;
-  std::map<std::string,FieldLayout>  layouts;
-  std::vector<std::string> m_fnames;
-  std::map<std::string,view_2d<Real>> fields_ext;
-  std::map<std::string,view_2d_host<Real>> fields_ext_h;
-  view_2d<Real> T_mid_ext;
-  view_2d<Real> p_mid_ext;
-  view_2d<Real> qv_ext;
-  view_2d<Real> u_ext;
-  view_2d<Real> v_ext;
-  TimeStamp ts0;
-  NudgingFunc::NudgingData NudgingData_bef;
-  NudgingFunc::NudgingData NudgingData_aft;
-  AtmosphereInput data_input;
+  int m_time_step_file;
+  std::string m_datafile;
+
+  std::map<std::string,view_2d<Real>> m_fields_ext;
+  std::map<std::string,view_2d_host<Real>> m_fields_ext_h;
+
+  TimeStamp m_ts0;
+  NudgingFunc::NudgingData m_NudgingData_bef;
+  NudgingFunc::NudgingData m_NudgingData_aft;
+  AtmosphereInput m_data_input;
 }; // class Nudging
 
 } // namespace scream


### PR DESCRIPTION
Fixes [scream_unit_tests_cuda_mem_check ](https://my.cdash.org/build/2348064) fails for the nudging test. Issue was member variables were being directly used inside `parallel_for()` functors, instead of local copies. 

Changed the following
- Use `m_*` naming for all member variables (naming made the error hard to detect)
- Removed some member variables that were only used locally inside a single function
- Remove member views, only keeping map of views that then local copies are made directly before parallel_fors.