### PR TITLE
Enhance EAMXX buildnml system

### DIFF
--- a/components/eamxx/cime_config/eamxx_buildnml_impl.py
+++ b/components/eamxx/cime_config/eamxx_buildnml_impl.py
@@ -23,7 +23,7 @@ class MockCase(object):
             return None
 
 ###############################################################################
-def parse_string_as_list (string):
+def parse_string_as_list(string):
 ###############################################################################
     """
     Takes a string representation of nested list and creates
@@ -74,7 +74,7 @@ def parse_string_as_list (string):
     return l
 
 ###############################################################################
-def is_array_type (name):
+def is_array_type(name):
 ###############################################################################
     """
     >>> is_array_type('array(T)')
@@ -87,7 +87,7 @@ def is_array_type (name):
     return name[0:6]=="array(" and name[-1]==")"
 
 ###############################################################################
-def array_elem_type (name):
+def array_elem_type(name):
 ###############################################################################
     """
     >>> print(array_elem_type('array(T)'))
@@ -510,7 +510,7 @@ def check_all_values(root):
         check_value(root,root.text)
 
 ###############################################################################
-def resolve_inheritance (root,elem):
+def resolve_inheritance(root, elem):
 ###############################################################################
     """
     If elem inherits from another node within $root, this function adds all
@@ -561,12 +561,11 @@ def resolve_inheritance (root,elem):
         resolve_inheritance(root,child)
 
 ###############################################################################
-def resolve_all_inheritances (root):
+def resolve_all_inheritances(root):
 ###############################################################################
     """
     Resolve all inheritances in the root tree
     """
-
     for elem in root:
         resolve_inheritance(root,elem)
 
@@ -623,7 +622,7 @@ def get_valid_selectors(xml_root):
     return selectors
 
 ###############################################################################
-def gen_group_processes (ap_names_str, atm_procs_defaults):
+def gen_group_processes(ap_names_str, atm_procs_defaults):
 ###############################################################################
     """
     Given a (possibly nested) string representation of an atm group,
@@ -640,7 +639,7 @@ def gen_group_processes (ap_names_str, atm_procs_defaults):
         #  - ap is declared in the XML defaults as an atm proc group (which must store
         #    the 'atm_procs_list' child, with the string representation of the group.
 
-        if ap[0]=='(':
+        if ap.startswith("("):
             # Create the atm proc group
             proc = gen_atm_proc_group(ap,atm_procs_defaults)
         else:
@@ -649,12 +648,12 @@ def gen_group_processes (ap_names_str, atm_procs_defaults):
 
             # Check if this pre-defined proc is itself a group, and, if so,
             # build all its sub-processes
-            ptype = get_child(proc,"Type",must_exist=False)
+            ptype = get_child(proc, "Type", must_exist=False)
             if ptype is not None and ptype.text=="Group":
                 # This entry of the group is itself a group, with pre-defined
                 # defaults. Let's add its entries to it
-                sub_group_procs = get_child(proc,"atm_procs_list").text
-                proc.extend(gen_group_processes(sub_group_procs,atm_procs_defaults))
+                sub_group_procs = get_child(proc, "atm_procs_list").text
+                proc.extend(gen_group_processes(sub_group_procs, atm_procs_defaults))
 
         # Append subproc to group
         group.append(proc)
@@ -702,11 +701,11 @@ def gen_atm_proc_group(atm_procs_list, atm_procs_defaults):
     # Set defaults from atm_proc_group
     group = ET.Element("__APG__")
     group.attrib["inherit"] = "atm_proc_group"
-    resolve_inheritance(atm_procs_defaults,group)
+    resolve_inheritance(atm_procs_defaults, group)
     get_child(group,"atm_procs_list").text = atm_procs_list
 
     # Create processes
-    group_procs = gen_group_processes (atm_procs_list, atm_procs_defaults)
+    group_procs = gen_group_processes(atm_procs_list, atm_procs_defaults)
 
     # Append procs and generate name for the group.
     # NOTE: the name of a 'generic' group is 'group.AP1_AP2_..._APN.'

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -209,6 +209,9 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- CLD fraction -->
     <cldFraction inherit="atm_proc_base"/>
 
+    <!-- For internal testing only -->
+    <testOnly inherit="atm_proc_base"/>
+
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="atm_proc_base">
       <spa_remap_file type="file">UNSET</spa_remap_file>

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/bfbhash/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/bfbhash/shell_commands
@@ -1,1 +1,2 @@
-./xmlchange --append SCREAM_ATMCHANGE_BUFFER='BfbHash=1'
+
+$CIMEROOT/../components/eamxx/scripts/atmchange BfbHash=1 -b

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/internal_diagnostics_level/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/internal_diagnostics_level/shell_commands
@@ -1,2 +1,2 @@
-./xmlchange --append SCREAM_ATMCHANGE_BUFFER=" --all internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0"
+$CIMEROOT/../components/eamxx/scripts/atmchange --all internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0
 ./xmlchange POSTRUN_SCRIPT="$CIMEROOT/../components/eamxx/tests/postrun/check_hashes_ers.py"

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/rad_frequency_2/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/rad_frequency_2/shell_commands
@@ -1,1 +1,1 @@
-./xmlchange SCREAM_ATMCHANGE_BUFFER='rad_frequency=2'
+$CIMEROOT/../components/eamxx/scripts/atmchange rad_frequency=2

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/scream_example_testmod_atmchange/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/scream_example_testmod_atmchange/shell_commands
@@ -1,1 +1,2 @@
-./xmlchange --append SCREAM_ATMCHANGE_BUFFER='cubed_sphere_map=42'
+
+$CIMEROOT/../components/eamxx/scripts/atmchange cubed_sphere_map=42 -b

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -13,17 +13,21 @@ sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 from eamxx_buildnml_impl import check_value, is_array_type
-from atm_manip import atm_config_chg_impl
+from atm_manip import atm_config_chg_impl, buffer_changes, reset_buffer
 from utils import run_cmd_no_fail, expect
 
 ###############################################################################
-def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False):
+def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False, buffer_only=False):
 ###############################################################################
-    expect(os.path.exists("namelist_scream.xml"),
-           "No pwd/namelist_scream.xml file is present. Please run from a case dir that has been set up")
+    if not buffer_only:
+        expect(os.path.exists("namelist_scream.xml"),
+               "No pwd/namelist_scream.xml file is present. Please run from a case dir that has been set up")
+    else:
+        expect(not no_buffer, "Makes no sense for buffer_only and no_buffer to both be on")
+        expect(not reset, "Makes no sense for buffer_only and reset to both be on")
 
     if reset:
-        run_cmd_no_fail("./xmlchange SCREAM_ATMCHANGE_BUFFER=''")
+        reset_buffer()
         print("All buffered atmchanges have been removed. A fresh namelist_scream.xml will be generated the next time buildnml (case.setup) is run.")
         hack_xml = run_cmd_no_fail("./xmlquery SCREAM_HACK_XML --value")
         if hack_xml == "TRUE":
@@ -34,24 +38,21 @@ def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False):
     else:
         expect(changes, "Missing <param>=<val> args")
 
-    with open("namelist_scream.xml", "r") as fd:
-        tree = ET.parse(fd)
-        root = tree.getroot()
+    if not buffer_only:
+        with open("namelist_scream.xml", "r") as fd:
+            tree = ET.parse(fd)
+            root = tree.getroot()
 
-    any_change = False
-    for change in changes:
-        this_changed = atm_config_chg_impl(root, change, all_matches)
-        any_change |= this_changed
+        any_change = False
+        for change in changes:
+            this_changed = atm_config_chg_impl(root, change, all_matches)
+            any_change |= this_changed
 
-    if any_change:
-        tree.write("namelist_scream.xml")
+        if any_change:
+            tree.write("namelist_scream.xml")
 
     if not no_buffer:
-        changes_str = " ".join(changes).replace(",",r"\,")
-        if all_matches:
-            changes_str += " --all"
-
-        run_cmd_no_fail(f"./xmlchange --append SCREAM_ATMCHANGE_BUFFER='{changes_str}'")
+        buffer_changes(changes, all_matches=all_matches)
 
     return True
 
@@ -96,6 +97,13 @@ OR
         default=False,
         action="store_true",
         help="Forget all previous atmchanges",
+    )
+
+    parser.add_argument(
+        "-b", "--buffer-only",
+        default=False,
+        action="store_true",
+        help="Only buffer the changes, don't actually do them. Useful for testmod scripts where the case is not setup yet",
     )
 
     parser.add_argument("changes", nargs="*", help="Values to change")

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -34,6 +34,8 @@ class TestBuildnml(unittest.TestCase):
         Convenience wrapper around create_test. Returns list of full paths to created cases. If multiple cases,
         the order of the returned list is not guaranteed to match the order of the arguments.
         """
+        extra_args = extra_args.split()
+
         test_id = f"cmd_nml_tests-{get_timestamp()}"
         extra_args.append("-t {}".format(test_id))
 
@@ -104,7 +106,7 @@ class TestBuildnml(unittest.TestCase):
 
             self._get_values(case, name, value=value, expect_equal=False, all_matches=all_matches)
 
-            run_cmd_assert_result(self, f"./atmchange {buffer_opt} {all_matches_opt} {name}={value}", from_dir=case)
+            run_cmd_assert_result(self, f"./atmchange {buffer_opt} {all_matches_opt} {name}='{value}'", from_dir=case)
 
             names = self._get_values(case, name, value=value, expect_equal=True, all_matches=all_matches)
             for item in names:
@@ -154,7 +156,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that xmlchanges impact atm config files
         """
-        case = self._create_test("ERS_Ln22.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+        case = self._create_test("ERS_Ln22.ne30_ne30.F2010-SCREAMv1 --no-build")
 
         # atm config should match case test opts
         case_rest_n = run_cmd_assert_result(self, "./xmlquery REST_N --value", from_dir=case)
@@ -177,7 +179,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that atmchanges are not lost when eamxx setup is called
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
         self._chg_atmconfig([("atm_log_level", "trace")], case)
 
@@ -187,7 +189,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that manual atmchanges are lost when eamxx setup is called
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
         # An unbuffered atmchange is semantically the same as a manual edit
         self._chg_atmconfig([("atm_log_level", "trace")], case, buff=False)
@@ -198,7 +200,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that atmchanges are lost when resetting
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
         self._chg_atmconfig([("atm_log_level", "trace")], case, reset=True)
 
@@ -209,7 +211,7 @@ class TestBuildnml(unittest.TestCase):
         Test that manual atmchanges are not lost when eamxx setup is called if
         xml hacking is enabled.
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
         run_cmd_assert_result(self, "./xmlchange SCREAM_HACK_XML=TRUE", from_dir=case)
 
@@ -221,7 +223,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that multiple atmchanges are not lost when eamxx setup is called
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
         self._chg_atmconfig([("atm_log_level", "trace"), ("output_to_screen", "true")], case)
 
@@ -234,7 +236,7 @@ class TestBuildnml(unittest.TestCase):
         """
         def_mach_comp = \
             run_cmd_assert_result(self, "../CIME/Tools/list_e3sm_tests cime_tiny", from_dir=CIME_SCRIPTS_DIR).splitlines()[-1].split(".")[-1]
-        case = self._create_test(f"SMS.ne30_ne30.F2010-SCREAMv1.{def_mach_comp}.scream-scream_example_testmod_atmchange --no-build".split())
+        case = self._create_test(f"SMS.ne30_ne30.F2010-SCREAMv1.{def_mach_comp}.scream-scream_example_testmod_atmchange --no-build")
 
         self._chg_atmconfig([("cubed_sphere_map", "84")], case)
 
@@ -244,7 +246,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that atmchange works for array data
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
         self._chg_atmconfig([("surf_mom_flux", "40.0,2.0")], case)
 
@@ -254,7 +256,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that atmchange works for all matches
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
         self._chg_atmconfig([("enable_precondition_checks", "false", True)], case)
 
@@ -264,10 +266,25 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that atmchange works for all matches and picking one specialization
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build".split())
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
         self._chg_atmconfig([("enable_precondition_checks", "false", True),
                              ("p3::enable_precondition_checks", "true")], case)
+
+    ###########################################################################
+    def test_atmchanges_for_atm_procs(self):
+    ###########################################################################
+        """
+        Test that atmchanges that add atm procs create the new proc when case.setup
+        is called.
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+
+        self._chg_atmconfig([("mac_aero_mic::atm_procs_list", "(shoc,cldFraction,spa,p3,testOnly)")], case)
+
+        # If we are able to change subcycles of testOnly then we know the atmchange
+        # above added the necessary atm proc XML block.
+        self._chg_atmconfig([("testOnly::number_of_subcycles", "42")], case)
 
 ###############################################################################
 def parse_command_line(args, desc):


### PR DESCRIPTION
1) Handle the usecase where atmchange affect XML structure (adding/removing atm procs)
2) Refactor atmchange buffer handling to be more robust
3) The /namelist_scream.xml will now have better formatting
4) Add a test for (1)
5) Add new -b/--buffer-only option to atmchange. Allows testmods to use atmchange
   instead of having to manipulate SCREAM_ATMCHANGE_BUFFER directly which exposed
   them to internal implementation details.
6) Change all testmods that were using SCREAM_ATMCHANGE_BUFFER to use
   this new approach.