### PR TITLE
Update compute-sanitizer tests

### DIFF
--- a/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
@@ -116,7 +116,7 @@ if [ $skip_testing -eq 0 ]; then
       fi
 
       if [[ "$SCREAM_MACHINE" == "weaver" ]]; then
-        ./scripts/gather-all-data "./scripts/test-all-scream -t cmc -t csr -t csi -t css ${TAS_ARGS}" -l -m $SCREAM_MACHINE
+        ./scripts/gather-all-data "./scripts/test-all-scream -t csm -t csr -t csi -t css ${TAS_ARGS}" -l -m $SCREAM_MACHINE
         if [[ $? != 0 ]]; then
           fails=$fails+1;
           memcheck_fail=1

--- a/components/eamxx/scripts/scripts-tests
+++ b/components/eamxx/scripts/scripts-tests
@@ -349,11 +349,12 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
                                 self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
-            builddir = "cuda_mem_check" if is_cuda_machine(self._machine) else "valgrind"
+            builddir = "compute_sanitizer_memcheck" if is_cuda_machine(self._machine) else "valgrind"
             test_cmake_cache_contents(self, builddir, "CMAKE_BUILD_TYPE", "Debug")
             test_cmake_cache_contents(self, builddir, "SCREAM_TEST_SIZE", "SHORT")
             if is_cuda_machine(self._machine):
-                test_cmake_cache_contents(self, builddir, "EKAT_ENABLE_CUDA_MEMCHECK", "TRUE")
+                test_cmake_cache_contents(self, builddir, "EKAT_ENABLE_COMPUTE_SANITIZER", "TRUE")
+                test_cmake_cache_contents(self, builddir, "EKAT_COMPUTE_SANITIZER_OPTIONS", "--tool=memcheck")
             else:
                 test_cmake_cache_contents(self, builddir, "EKAT_ENABLE_VALGRIND", "TRUE")
         else:

--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -173,30 +173,17 @@ class VALG(TestProperty):
                 self.cmake_args.append( ("EKAT_VALGRIND_SUPPRESSION_FILE", str(persistent_supp_file)) )
 
 ###############################################################################
-class CMC(TestProperty):
-###############################################################################
-
-    def __init__(self, _):
-        TestProperty.__init__(
-            self,
-            "cuda_mem_check",
-            "debug with cuda memcheck",
-            [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_ENABLE_CUDA_MEMCHECK", "True")],
-            uses_baselines=False,
-            on_by_default=False,
-            default_test_len="short"
-        )
-
-###############################################################################
 class CSM(TestProperty):
 ###############################################################################
 
     def __init__(self, _):
         TestProperty.__init__(
             self,
-            "compute_santizer_memcheck",
+            "compute_sanitizer_memcheck",
             "debug with compute sanitizer memcheck",
-            [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_ENABLE_COMPUTE_SANITIZER", "True")],
+            [("CMAKE_BUILD_TYPE", "Debug"),
+             ("EKAT_ENABLE_COMPUTE_SANITIZER", "True"),
+             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "--tool=memcheck")],
             uses_baselines=False,
             on_by_default=False,
             default_test_len="short"
@@ -209,11 +196,11 @@ class CSR(TestProperty):
     def __init__(self, _):
         TestProperty.__init__(
             self,
-            "compute_santizer_racecheck",
+            "compute_sanitizer_racecheck",
             "debug with compute sanitizer racecheck",
             [("CMAKE_BUILD_TYPE", "Debug"),
              ("EKAT_ENABLE_COMPUTE_SANITIZER", "True"),
-             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "--tool=racecheck")],
+             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "'--tool=racecheck --racecheck-detect-level=error'")],
             uses_baselines=False,
             on_by_default=False,
             default_test_len="short"
@@ -226,7 +213,7 @@ class CSI(TestProperty):
     def __init__(self, _):
         TestProperty.__init__(
             self,
-            "compute_santizer_initcheck",
+            "compute_sanitizer_initcheck",
             "debug with compute sanitizer initcheck",
             [("CMAKE_BUILD_TYPE", "Debug"),
              ("EKAT_ENABLE_COMPUTE_SANITIZER", "True"),
@@ -243,7 +230,7 @@ class CSS(TestProperty):
     def __init__(self, _):
         TestProperty.__init__(
             self,
-            "compute_santizer_synccheck",
+            "compute_sanitizer_synccheck",
             "debug with compute sanitizer synccheck",
             [("CMAKE_BUILD_TYPE", "Debug"),
              ("EKAT_ENABLE_COMPUTE_SANITIZER", "True"),
@@ -368,7 +355,7 @@ class TestAllScream(object):
 
         # Make our test objects! Change mem to default mem-check test for current platform
         if "mem" in tests:
-            tests[tests.index("mem")] = "cmc" if self.on_cuda() else "valg"
+            tests[tests.index("mem")] = "csm" if self.on_cuda() else "valg"
         self._tests = test_factory(tests, self)
 
         if self._work_dir is not None:


### PR DESCRIPTION
A few changes: 
- use `compute-sanitizer --tool=memcheck ./exe` instead of `cuda-memcheck ./exe`. Reason: when running `cuda-memcheck`...
```
========= CUDA-MEMCHECK
========= This tool is deprecated and will be removed in a future release of the CUDA toolkit
========= Please use the compute-sanitizer tool as a drop-in replacement
```
- Add `--racecheck-detect-level=error` for racecheck. I've tested manually, and when using the default (`=warn`) you get many many many "hazards" which cause the tester to fail. Every instance of these hazards I've looked at revolve around `Kokkos::parallel_reduce` and appear to be internal to Kokkos. The most basic reduce gives these hazards:
```
CODE:

double result;
Kokkos::parallel_reduce("simple_reduce", 1, KOKKOS_LAMBDA(int i, double& lsum) {
  lsum += i;
}, result);

OUTPUT:

========= COMPUTE-SANITIZER
========= Warning: Race reported between Read access at 0x570 in void Kokkos::Impl::cuda_parallel_launch_local_memory<Kokkos::Impl::ParallelReduce<Kokkos::Impl::CombinedFunctorReducer<main::[lambda(int, double &) (instance 1)], Kokkos::Impl::FunctorAnalysis<Kokkos::Impl::FunctorPatternInterface::REDUCE, Kokkos::RangePolicy<Kokkos::Cuda>, main::[lambda(int, double &) (instance 1)], double>::Reducer, void>, Kokkos::RangePolicy<Kokkos::Cuda>, Kokkos::Cuda, Kokkos::Cuda>>(T1)
=========     and Write access at 0x5a0 in void Kokkos::Impl::cuda_parallel_launch_local_memory<Kokkos::Impl::ParallelReduce<Kokkos::Impl::CombinedFunctorReducer<main::[lambda(int, double &) (instance 1)], Kokkos::Impl::FunctorAnalysis<Kokkos::Impl::FunctorPatternInterface::REDUCE, Kokkos::RangePolicy<Kokkos::Cuda>, main::[lambda(int, double &) (instance 1)], double>::Reducer, void>, Kokkos::RangePolicy<Kokkos::Cuda>, Kokkos::Cuda, Kokkos::Cuda>>(T1) [6272 hazards]
========= ....more lines of the same warning....
...
========= RACECHECK SUMMARY: 8 hazards displayed (0 errors, 8 warnings)
```
Adding `--racecheck-detect-level=error` removes these and the test cases pass.
```
========= COMPUTE-SANITIZER
...
========= RACECHECK SUMMARY: 0 hazards displayed (0 errors, 0 warnings)
```
Not sure if racecheck is going to turn out to be useful. These warning I don't think are useful, but maybe the errors are? 
- typo in test name: `santizer -> sanitizer`