### PR TITLE
Add a new scream test suite specifically for AT

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -330,6 +330,7 @@
       <directive> --job-name={{ job_id }}</directive>
       <directive> --nodes=1</directive>
       <directive> --ntasks={{ total_tasks }}</directive>
+      <directive> --cpus-per-task={{ thread_count }}</directive>
       <directive> --output={{ job_id }}.%j </directive>
     </directives>
   </batch_system>

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -515,6 +515,14 @@ _TESTS = {
             )
     },
 
+    # Tests run on exclusively on mappy for scream AT testing. These tests
+    # should be fast, so we limit it to low res and add some thread tests
+    # specifically for mappy.
+    "e3sm_scream_v1_at" : {
+        "inherit" : ("e3sm_scream_v1_lowres"),
+        "tests"   : ("PET_Ln9_P32x2.ne4pg2_ne4pg2.F2010-SCREAMv1")
+    },
+
     "e3sm_scream_v1_medres" : {
         "time"  : "02:00:00",
         "tests" : (

--- a/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
@@ -190,7 +190,7 @@ if [ $skip_testing -eq 0 ]; then
 
       if [[ $test_v1 == 1 ]]; then
         # AT runs should be fast. => run only low resolution
-        ../../cime/scripts/create_test e3sm_scream_v1_lowres --compiler=gnu9 -c -b master --wait
+        ../../cime/scripts/create_test e3sm_scream_v1_at --compiler=gnu9 -c -b master --wait
         if [[ $? != 0 ]]; then
           fails=$fails+1;
           v1_fail=1


### PR DESCRIPTION
And add a PET_x2 test to force some thread testing. This new test is specifically designed for mappy which is why it needs to be in a new suite.

I ran this new test on mappy and it seemed to work fine once I made a fix in config_batch.xml.

Fixes #2359 