### PR TITLE
Some minor fixes to the AtmosphereDriver

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -131,16 +131,9 @@ set_params(const ekat::ParameterList& atm_params)
     // To figure out whether we're using RRTMGP, we create a process group and
     // see whether RRTMGP is in it. This seems heavy-handed, but it reduceѕ code
     // duplication.
-    bool using_rrtmgp = false;
     auto& atm_proc_params = m_atm_params.sublist("atmosphere_processes");
     auto group = std::make_shared<AtmosphereProcessGroup>(m_atm_comm,atm_proc_params);
-    for (int i = 0; i < group->get_num_processes(); ++i) {
-      if (group->get_process(i)->name() == "rrtmgp") {
-        using_rrtmgp = true;
-        break;
-      }
-    }
-    if (using_rrtmgp) {
+    if (group->has_process("rrtmgp")) {
       fv_phys_rrtmgp_active_gases_init(m_atm_params);
     }
   }

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -124,8 +124,24 @@ set_params(const ekat::ParameterList& atm_params)
 
   m_ad_status |= s_params_set;
 
+  // Apply the FV-RRTMGP hack if we're using a PG2 grid and RRTMGP.
   const auto pg_type = "PG2";
-  fvphyshack = m_atm_params.sublist("grids_manager").get<std::string>("physics_grid_type", "None") == pg_type;
+  bool using_pg2 = m_atm_params.sublist("grids_manager").get<std::string>("physics_grid_type", "None") == pg_type;
+  bool using_rrtmgp = false;
+  {
+    // To figure out whether we're using RRTMGP, we create a process group and
+    // see whether RRTMGP is in it. This seems heavy-handed, but it reduceѕ code
+    // duplication.
+    auto& atm_proc_params = m_atm_params.sublist("atmosphere_processes");
+    auto group = std::make_shared<AtmosphereProcessGroup>(m_atm_comm,atm_proc_params);
+    for (int i = 0; i < group->get_num_processes(); ++i) {
+      if (group->get_process(i)->name() == "rrtmgp") {
+        using_rrtmgp = true;
+        break;
+      }
+    }
+  }
+  bool fvphyshack = using_pg2 && using_rrtmgp;
   if (fvphyshack) {
     // See the [rrtmgp active gases] note in share/util/eamxx_fv_phys_rrtmgp_active_gases_workaround.hpp
     fv_phys_rrtmgp_active_gases_init(m_atm_params);

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1353,8 +1353,10 @@ void AtmosphereDriver::finalize ( /* inputs? */ ) {
   m_output_managers.clear();
 
   // Finalize, and then destroy all atmosphere processes
-  m_atm_process_group->finalize( /* inputs ? */ );
-  m_atm_process_group = nullptr;
+  if (m_atm_process_group.get()) {
+    m_atm_process_group->finalize( /* inputs ? */ );
+    m_atm_process_group = nullptr;
+  }
 
   // Destroy the buffer manager
   m_memory_buffer = nullptr;

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -128,14 +128,7 @@ set_params(const ekat::ParameterList& atm_params)
   fvphyshack = m_atm_params.sublist("grids_manager").get<std::string>("physics_grid_type", "None") == pg_type;
   if (fvphyshack) {
     // See the [rrtmgp active gases] note in share/util/eamxx_fv_phys_rrtmgp_active_gases_workaround.hpp
-    // To figure out whether we're using RRTMGP, we create a process group and
-    // see whether RRTMGP is in it. This seems heavy-handed, but it reduceѕ code
-    // duplication.
-    auto& atm_proc_params = m_atm_params.sublist("atmosphere_processes");
-    auto group = std::make_shared<AtmosphereProcessGroup>(m_atm_comm,atm_proc_params);
-    if (group->has_process("rrtmgp")) {
-      fv_phys_rrtmgp_active_gases_init(m_atm_params);
-    }
+    fv_phys_rrtmgp_active_gases_init(m_atm_params);
   }
 }
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
@@ -149,6 +149,22 @@ AtmosphereProcessGroup (const ekat::Comm& comm, const ekat::ParameterList& param
   }
 }
 
+bool AtmosphereProcessGroup::has_process(const std::string& name) const {
+  for (auto& process: m_atm_processes) {
+    if (process->type() == AtmosphereProcessType::Group) {
+      const auto* group = dynamic_cast<const AtmosphereProcessGroup*>(process.get());
+      if (group->has_process(name)) {
+        return true;
+      }
+    } else {
+      if (process->name() == name) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 void AtmosphereProcessGroup::set_grids (const std::shared_ptr<const GridsManager> grids_manager) {
 
   // The atm process group (APG) simply 'concatenates' required/computed

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
@@ -59,6 +59,10 @@ public:
     return m_atm_processes.at(i);
   }
 
+  // returns true if this group contains the process (either directly or within
+  // a nested group), false if not
+  bool has_process(const std::string& name) const;
+
   ScheduleType get_schedule_type () const { return m_group_schedule_type; }
 
   // Computes total number of bytes needed for local variables

--- a/components/eamxx/src/share/util/eamxx_fv_phys_rrtmgp_active_gases_workaround.cpp
+++ b/components/eamxx/src/share/util/eamxx_fv_phys_rrtmgp_active_gases_workaround.cpp
@@ -5,10 +5,16 @@ namespace scream {
 bool fvphyshack;
 
 void fv_phys_rrtmgp_active_gases_init (const ekat::ParameterList& p) {
-  const auto& v = p.sublist("atmosphere_processes").sublist("physics")
-    .sublist("rrtmgp").get<std::vector<std::string>>("active_gases");
-  if (ekat::contains(v, "o3")) {
-    TraceGasesWorkaround::singleton().add_active_gas("o3_volume_mix_ratio");
+  const auto& a = p.sublist("atmosphere_processes");
+  if (a.isSublist("physics")) {
+    const auto& p = a.sublist("physics");
+    if (p.isSublist("rrtmgp")) {
+      const auto& r = p.sublist("rrtmgp");
+      const auto& v = r.get<std::vector<std::string>>("active_gases");
+      if (ekat::contains(v, "o3")) {
+        TraceGasesWorkaround::singleton().add_active_gas("o3_volume_mix_ratio");
+      }
+    }
   }
 }
 


### PR DESCRIPTION
@pbosler and I discovered a couple of things that needed adjusting in our MAM-related adventures. This PR has two minor fixes:

1. It's possible to call `finalize` on the AD before it has defined its process group, which was producing a segmentation fault by calling `finalize` on a null pointer. Now the AD checks to see whether it has a process group before attempting to finalize it.
2. <strike>The `fvphyshack`, which evidently does something special when the PG2 grid is used in tandem with RRTMGP, previously assumed that RRTMGP was enabled whenever a PG2 grid was found. Now, the AD determines whether RRTMGP is enabled and sets `fvphyshack` only if both PG2 and RRTMGP are present.</strike>The `fvphyshack`-related initialization to RRTMGP is performed only when RRTMGP is present.