### PR TITLE
EAMxx: Add namelist entry for Hxx's internal_diagnostics_level.

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -462,6 +462,9 @@ be lost if SCREAM_HACK_XML is not enabled.
     <vert_remap_q_alg>10</vert_remap_q_alg>
     <transport_alg>0</transport_alg>
     <vtheta_thresh>100.0</vtheta_thresh>
+    <!-- Run internal checks on code correctness.
+         <= 0: off; >= 1: global hashes over state -->
+    <internal_diagnostics_level type="integer">0</internal_diagnostics_level>
     <!-- pg2 settings -->
     <cubed_sphere_map hgrid=".*pg2">2</cubed_sphere_map>
     <!-- SL transport settings. SL defaults to on for pg2 configs. -->


### PR DESCRIPTION
The nightly test with testmod scream-internal_diagnostics_level will run Hommexx with internal_diagnostics_level=1 in addition to the AD's equivalent.