### PR TITLE
Add check_flux_state_consistency to shoc interface

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -204,7 +204,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- SHOC macrophysics -->
     <shoc inherit="atm_proc_base">
       <enable_column_conservation_checks>false</enable_column_conservation_checks>
-      <check_flux_state_consistency>false</check_flux_state_consistency>
+      <check_flux_state_consistency>true</check_flux_state_consistency>
     </shoc>
 
     <!-- CLD fraction -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -204,6 +204,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- SHOC macrophysics -->
     <shoc inherit="atm_proc_base">
       <enable_column_conservation_checks>false</enable_column_conservation_checks>
+      <check_flux_state_consistency>false</check_flux_state_consistency>
     </shoc>
 
     <!-- CLD fraction -->

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
@@ -102,7 +102,7 @@ public:
         // to tracer group in postprocessing.
         // TODO: remove *_copy views once SHOC can request a subset of tracers.
         tke_copy(i,k) = tke(i,k);
-        qc_copy(i,k)  = qc(i,k); 
+        qc_copy(i,k)  = qc(i,k);
 
         qw(i,k) = qv(i,k) + qc(i,k);
 
@@ -294,7 +294,7 @@ public:
 
         cldfrac_liq(i,k) = ekat::min(cldfrac_liq(i,k), 1);
 
-        //P3 uses inv_qc_relvar, P3 is using dry mmrs, but 
+        //P3 uses inv_qc_relvar, P3 is using dry mmrs, but
         //wet<->dry conversion is a constant factor that cancels out in mean(qc)^2/mean(qc'*qc').
         inv_qc_relvar(i,k) = 1;
         const auto condition = (qc(i,k) != 0 && qc2(i,k) != 0);
@@ -474,6 +474,9 @@ protected:
 #endif
 
   void initialize_impl (const RunType run_type);
+
+  // Update flux (if necessary)
+  void check_flux_state_consistency(const double dt);
 
 protected:
 

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -33,6 +33,8 @@ atmosphere_processes:
       spa:
         spa_remap_file: ${SCREAM_DATA_DIR}/maps/map_ne4np4_to_ne2np4_mono.nc
         spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
+      shoc:
+        check_flux_state_consistency: true
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]


### PR DESCRIPTION
New `check_flux_state_consistency()` from @oksanaguba suggestion https://github.com/E3SM-Project/scream/issues/2372#issuecomment-1583832926. Called directly before `shoc_main()`.