### PR TITLE
fpe_guard_wrapper() now prints any exception it encounters.

### DIFF
--- a/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -51,7 +51,8 @@ void fpe_guard_wrapper (const Lambda& f) {
   // Execute wrapped function
   try {
     f();
-  } catch (...) {
+  } catch (std::exception &e) {
+    fprintf(stderr, "%s\n", e.what());
     auto& c = ScreamContext::singleton();
     c.clean_up();
     throw;


### PR DESCRIPTION
In the current master branch, any exception emitted by a function invoked using `fpe_guard_wrapper` gets swallowed, making it hard to understand what went wrong. This PR just catches the exception and sends its string representation to `stderr`. It seems like you'd want this (or something like it!) if you're trying to debug a new case.