### PR TITLE
Updates to TimeInterpolation structure

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -172,7 +172,9 @@ be lost if SCREAM_HACK_XML is not enabled.
       </prescribed_constants>
       <prescribed_from_file>
         <fields type="array(string)">NONE</fields>
-        <files type="array(string)">NONE</files>
+	<files type="array(string)">NONE</files>
+	<!-- Optional argument if fields have a different name in the source data files, set to NONE if not used -->
+        <fields_alt_name type="array(string)">NONE</fields_alt_name>
       </prescribed_from_file>
     </sc_export>
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -232,7 +232,7 @@ void SurfaceCouplingExporter::initialize_impl (const RunType /* run_type */)
     bool do_export_from_file = are_fields_present and are_files_present;
     if (do_export_from_file) {
       // Construct a time interpolation object
-      auto time_interp = util::TimeInterpolation(m_grid,export_from_file_names);
+      m_time_interp = util::TimeInterpolation(m_grid,export_from_file_names);
       for (auto fname : export_from_file_fields) {
         // Find the index for this field in the list of export fields.
 	auto v_loc = std::find(m_export_field_names_vector.begin(),m_export_field_names_vector.end(),fname);
@@ -244,10 +244,9 @@ void SurfaceCouplingExporter::initialize_impl (const RunType /* run_type */)
         --m_num_from_model_exports;
         auto& f_helper = m_helper_fields.at(fname);
 	// We want to add the field as a deep copy so that the helper_fields are automatically updated.
-        time_interp.add_field(f_helper, true);
+        m_time_interp.add_field(f_helper, true);
         m_export_from_file_field_names.push_back(fname);
       }
-      m_time_interp = time_interp;
       m_time_interp.initialize_data_from_files();
     }
   }

--- a/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
@@ -82,14 +82,19 @@ void TimeInterpolation::perform_time_interpolation(const TimeStamp& time_in)
  */
 void TimeInterpolation::add_field(const Field& field_in, const bool store_shallow_copy)
 {
+  // Typical case, name of field matches the name in the data files.
+  add_field(field_in,"",store_shallow_copy);
+}
+void TimeInterpolation::add_field(const Field& field_in, const std::string& alt_name, const bool store_shallow_copy)
+{
   // First check that we haven't already added a field with the same name.
-  const auto name = field_in.name();
+  const std::string name = alt_name == "" ? field_in.name() : alt_name;
   EKAT_REQUIRE_MSG(!m_fm_time0->has_field(name) and !m_fm_time1->has_field(name),
 		  "Error!! TimeInterpolation:add_field, field + " << name << " has already been added." << "\n");
 
   // Clone the field for each field manager to get all the metadata correct.
-  auto field0 = field_in.clone();
-  auto field1 = field_in.clone();
+  auto field0 = field_in.clone(name);
+  auto field1 = field_in.clone(name);
   m_fm_time0->add_field(field0);
   m_fm_time1->add_field(field1);
   if (store_shallow_copy) {
@@ -97,7 +102,7 @@ void TimeInterpolation::add_field(const Field& field_in, const bool store_shallo
     m_interp_fields.emplace(name,field_in);
   } else {
     // We want to store a copy of the field but not ovveride
-    auto field_out = field_in.clone();
+    auto field_out = field_in.clone(name);
     m_interp_fields.emplace(name,field_out);
   }
   m_field_names.push_back(name);

--- a/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
@@ -155,17 +155,18 @@ void TimeInterpolation::initialize_data_from_field(const Field& field_in)
  */
 void TimeInterpolation::initialize_data_from_files()
 {
+  auto triplet_curr = m_file_data_triplets[m_triplet_idx];
   // Initialize the AtmosphereInput object that will be used to gather data
   ekat::ParameterList input_params;
   input_params.set("Field Names",m_field_names);
-  input_params.set("Filename",m_triplet_iterator->filename);
+  input_params.set("Filename",triplet_curr.filename);
   m_file_data_atm_input = AtmosphereInput(input_params,m_fm_time1);
   // Read first snap of data and shift to time0
   read_data();
   shift_data();
-  update_timestamp(m_triplet_iterator->timestamp);
+  update_timestamp(triplet_curr.timestamp);
   // Advance the iterator and read the next set of data for time1
-  ++m_triplet_iterator;
+  ++m_triplet_idx;
   read_data();
 }
 /*-----------------------------------------------------------------------------------------------*/
@@ -290,7 +291,7 @@ void TimeInterpolation::set_file_data_triplets(const vos_type& list_of_files) {
     m_file_data_triplets.push_back(my_trip);
   }
   // Finally set the iterator to point to the first triplet.
-  m_triplet_iterator = m_file_data_triplets.begin();
+  m_triplet_idx = 0;
 }	
 /*-----------------------------------------------------------------------------------------------*/
 /* Function to read a new set of data from file using the current iterator pointing to the current
@@ -298,16 +299,17 @@ void TimeInterpolation::set_file_data_triplets(const vos_type& list_of_files) {
  */
 void TimeInterpolation::read_data()
 {
-  if (m_triplet_iterator->filename != m_file_data_atm_input.get_filename()) {
+  const auto triplet_curr = m_file_data_triplets[m_triplet_idx];
+  if (triplet_curr.filename != m_file_data_atm_input.get_filename()) {
     // Then we need to close this input stream and open a new one
     m_file_data_atm_input.finalize();
     ekat::ParameterList input_params;
     input_params.set("Field Names",m_field_names);
-    input_params.set("Filename",m_triplet_iterator->filename);
+    input_params.set("Filename",triplet_curr.filename);
     m_file_data_atm_input = AtmosphereInput(input_params,m_fm_time1);
   }
-  m_file_data_atm_input.read_variables(m_triplet_iterator->time_idx);
-  m_time1 = m_triplet_iterator->timestamp;
+  m_file_data_atm_input.read_variables(triplet_curr.time_idx);
+  m_time1 = triplet_curr.timestamp;
 }
 /*-----------------------------------------------------------------------------------------------*/
 /* Function to check the current set of interpolation data against a timestamp and, if needed,
@@ -326,10 +328,10 @@ void TimeInterpolation::check_and_update_data(const TimeStamp& ts_in)
     // First cycle through the DataFromFileTriplet's to find a timestamp that is greater than this one.
     bool found = false;
     int step_cnt = 0; // Track how many triplets we passed to find one that worked. 
-    while (m_triplet_iterator != m_file_data_triplets.end()) {
-      ++m_triplet_iterator;
+    while (m_triplet_idx < m_file_data_triplets.size()) {
+      ++m_triplet_idx;
       ++step_cnt;
-      auto ts_tmp = m_triplet_iterator->timestamp;
+      auto ts_tmp = m_file_data_triplets[m_triplet_idx].timestamp;
       if (ts_tmp.seconds_from(ts_in) >= 0) {
         // This timestamp is greater than the input timestamp, we can use it
 	found = true;
@@ -343,13 +345,13 @@ void TimeInterpolation::check_and_update_data(const TimeStamp& ts_in)
     // incorrect.
     if (step_cnt>1) {
       // Then we need to populate data for time1 as the previous triplet before shifting data to time0
-      --m_triplet_iterator;
+      --m_triplet_idx;
       read_data();
-      ++m_triplet_iterator;
+      ++m_triplet_idx;
     }
     // We shift the time1 data to time0 and read the new data.
     shift_data();
-    update_timestamp(m_triplet_iterator->timestamp);
+    update_timestamp(m_file_data_triplets[m_triplet_idx].timestamp);
     read_data();
     // Sanity Check
     bool current_data_check = (ts_in.seconds_from(m_time0) >= 0) and (m_time1.seconds_from(ts_in) >= 0);

--- a/components/eamxx/src/share/util/eamxx_time_interpolation.hpp
+++ b/components/eamxx/src/share/util/eamxx_time_interpolation.hpp
@@ -81,7 +81,7 @@ protected:
 
   // Variables related to the case where we use data from file
   std::vector<DataFromFileTriplet>           m_file_data_triplets;
-  std::vector<DataFromFileTriplet>::iterator m_triplet_iterator;
+  int                                        m_triplet_idx;
   AtmosphereInput                            m_file_data_atm_input;
   bool                                       m_is_data_from_file=false;
 

--- a/components/eamxx/src/share/util/eamxx_time_interpolation.hpp
+++ b/components/eamxx/src/share/util/eamxx_time_interpolation.hpp
@@ -36,6 +36,7 @@ public:
 
   // Build interpolator
   void add_field(const Field& field_in, const bool store_shallow_copy=false);
+  void add_field(const Field& field_in, const std::string& alt_name, const bool store_shallow_copy=false);
 
   // Getters
   Field get_field(const std::string& name) {

--- a/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
+++ b/components/eamxx/tests/uncoupled/surface_coupling/surface_coupling.cpp
@@ -65,7 +65,7 @@ std::vector<std::string> create_from_file_test_data(const ekat::Comm& comm, cons
   const auto grid = gm->get_grid("Physics");
   const int nlcols = grid->get_num_local_dofs();
   const auto dofs_gids = grid->get_dofs_gids().get_view<const int*,Host>();
-  std::vector<std::string> fnames = {"Faxa_lwdn"};
+  std::vector<std::string> fnames = {"lwdn"};
   FieldLayout layout({COL},{nlcols});
   auto fm = std::make_shared<FieldManager>(grid);
   fm->registration_begins();
@@ -481,8 +481,11 @@ TEST_CASE("surface-coupling", "") {
   // Set up forcing to data interpolated from file
   const auto exp_file_files = create_from_file_test_data(atm_comm, t0, ncol_in);
   const vos_type exp_file_fields = {"Faxa_lwdn"};
+  // Test the use of an alternative name as stored in the data file(s).
+  const vos_type exp_file_fields_alt_name = {"lwdn"};
   auto& exp_file_params = sc_exp_params.sublist("prescribed_from_file");
   exp_file_params.set<vos_type>("fields",exp_file_fields);
+  exp_file_params.set<vos_type>("fields_alt_name",exp_file_fields_alt_name);
   exp_file_params.set<vos_type>("files",exp_file_files);
 
   // Need to register products in the factory *before* we create any atm process or grids manager.


### PR DESCRIPTION
This commit updates the TimeInterpolation structure to facilitate more use cases.

In particular,
1. The capability to specify an "alternative name" at registration of a field to be interpolated provides a way to use source data that has a different variable name then the internal name expected in EAMxx.
2. Fixes a design choice that was causing some data within the structure to be destroyed prematurely - which led to errors in some applications.