### PR TITLE
Add missing metadata to eamxx output files

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -66,17 +66,18 @@ if (NOT SCREAM_CIME_BUILD)
     list(REMOVE_ITEM CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "ifport")
   endif()
 
-  # Print the sha of the last commit (useful to double check which version was tested on CDash)
-  execute_process (COMMAND git rev-parse HEAD
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    OUTPUT_VARIABLE LAST_GIT_COMMIT_SHA
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  set(LAST_GIT_COMMIT_SHA ${LAST_GIT_COMMIT_SHA} CACHE STRING "The sha of the last git commit.")
-  message(STATUS "The sha of the last commit is ${LAST_GIT_COMMIT_SHA}")
 else()
   # Ensure our languages are all enabled
   enable_language(C CXX Fortran)
 endif()
+
+# Print the sha of the last commit (useful to double check which version was tested on CDash)
+execute_process (COMMAND git rev-parse HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE LAST_GIT_COMMIT_SHA
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(EAMXX_GIT_VERSION ${LAST_GIT_COMMIT_SHA} CACHE STRING "The sha of the last git commit.")
+message(STATUS "The sha of the last commit is ${EAMXX_GIT_VERSION}")
 
 set(SCREAM_DOUBLE_PRECISION TRUE CACHE BOOL "Set to double precision (default True)")
 

--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -12,6 +12,10 @@ if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
   cmake_policy(SET CMP0074 NEW)
 endif()
 
+set (EAMXX_VERSION_MAJOR 1)
+set (EAMXX_VERSION_MINOR 0)
+set (EAMXX_VERSION_PATCH 0)
+
 if ($ENV{SCREAM_FORCE_CONFIG_FAIL})
   message(FATAL_ERROR "Failed, as instructed by environment")
 endif()

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -97,6 +97,10 @@ public:
   // and pass to m_atm_process_group.
   void setup_column_conservation_checks ();
 
+  void set_provenance_data (std::string caseid = "",
+                            std::string hostname = "",
+                            std::string username = "");
+
   // Load initial conditions for atm inputs
   void initialize_fields ();
 

--- a/components/eamxx/src/mct_coupling/atm_comp_mct.F90
+++ b/components/eamxx/src/mct_coupling/atm_comp_mct.F90
@@ -90,6 +90,8 @@ CONTAINS
     ! TODO: read this from the namelist?
     character(len=256)                :: yaml_fname = "./data/scream_input.yaml"
     character(kind=c_char,len=256), target :: yaml_fname_c, atm_log_fname_c
+    character(len=256) :: caseid, username, hostname
+    character(kind=c_char,len=256), target :: caseid_c, username_c, hostname_c
     logical (kind=c_bool) :: restarted_run
 
     !-------------------------------------------------------------------------------
@@ -101,7 +103,8 @@ CONTAINS
          gsMap=gsmap_atm, &
          dom=dom_atm, &
          infodata=infodata)
-    call seq_infodata_getData(infodata, atm_phase=phase, start_type=run_type)
+    call seq_infodata_getData(infodata, atm_phase=phase, start_type=run_type, &
+                              username=username, case_name=caseid, hostname=hostname)
     call seq_infodata_PutData(infodata, atm_aero=.true.)
     call seq_infodata_PutData(infodata, atm_prognostic=.true.)
 
@@ -183,7 +186,10 @@ CONTAINS
                                         c_loc(export_constant_multiple), c_loc(do_export_during_init), &
                                         num_cpl_exports, num_scream_exports, export_field_size)
 
-    call scream_init_atm ()
+    call string_f2c(trim(caseid),caseid_c)
+    call string_f2c(trim(username),username_c)
+    call string_f2c(trim(hostname),hostname_c)
+    call scream_init_atm (caseid_c,hostname_c,username_c)
 
   end subroutine atm_init_mct
 

--- a/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -188,10 +188,9 @@ void scream_setup_surface_coupling (const char*& import_field_names, int*& impor
   });
 }
 
-void scream_init_atm (const int run_start_ymd,
-                      const int run_start_tod,
-                      const int case_start_ymd,
-                      const int case_start_tod)
+void scream_init_atm (const char* caseid,
+                      const char* hostname,
+                      const char* username)
 {
   using namespace scream;
   using namespace scream::control;
@@ -199,6 +198,9 @@ void scream_init_atm (const int run_start_ymd,
   fpe_guard_wrapper([&](){
     // Get the ad, then complete initialization
     auto& ad = get_ad_nonconst();
+
+    // Set provenance info in the driver (will be added to the output files)
+    ad.set_provenance_data (caseid,hostname,username);
 
     // Init all fields, atm processes, and output streams
     ad.initialize_fields ();

--- a/components/eamxx/src/mct_coupling/scream_f2c_mod.F90
+++ b/components/eamxx/src/mct_coupling/scream_f2c_mod.F90
@@ -74,7 +74,9 @@ interface
   ! During this call, all fields are initialized (i.e., initial conditions are
   ! loaded), as well as the atm procs (which might use some initial conditions
   ! to further initialize internal structures), and the output manager.
-  subroutine scream_init_atm () bind(c)
+  subroutine scream_init_atm (caseid,hostname,username) bind(c)
+    use iso_c_binding, only: c_char
+    character(kind=c_char), target, intent(in) :: caseid(*), hostname(*), username(*)
   end subroutine scream_init_atm
 
   ! This subroutine will run the whole atm model for one atm timestep

--- a/components/eamxx/src/scream_config.h.in
+++ b/components/eamxx/src/scream_config.h.in
@@ -51,4 +51,7 @@
 // The sha of the last commit
 #define EAMXX_GIT_VERSION "${EAMXX_GIT_VERSION}"
 
+// The version of EAMxx
+#define EAMXX_VERSION "${EAMXX_VERSION_MAJOR}.${EAMXX_VERSION_MINOR}.${EAMXX_VERSION_PATCH}"
+
 #endif

--- a/components/eamxx/src/scream_config.h.in
+++ b/components/eamxx/src/scream_config.h.in
@@ -48,4 +48,7 @@
 // Whether monolithic kernels are on
 #cmakedefine SCREAM_SMALL_KERNELS
 
+// The sha of the last commit
+#define EAMXX_GIT_VERSION "${EAMXX_GIT_VERSION}"
+
 #endif

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -711,6 +711,7 @@ void OutputManager::set_file_header(const std::string& filename)
   set_attribute<std::string>(filename,"source","E3SM Atmosphere Model Version 4 (EAMxx)");  // TODO: probably want to make sure that new versions are reflected here.
   set_attribute<std::string>(filename,"case",p.get<std::string>("caseid","NONE"));  // TODO
   set_attribute<std::string>(filename,"title","EAMxx History File");
+  set_attribute<std::string>(filename,"source","E3SM Atmosphere Model (EAMxx)");
   set_attribute<std::string>(filename,"eamxx_version",EAMXX_VERSION);
   set_attribute<std::string>(filename,"git_version",p.get<std::string>("git_version",EAMXX_GIT_VERSION));
   set_attribute<std::string>(filename,"hostname",p.get<std::string>("hostname","UNKNOWN"));
@@ -720,7 +721,7 @@ void OutputManager::set_file_header(const std::string& filename)
   set_attribute<std::string>(filename,"contact","e3sm-data-support@listserv.llnl.gov");
   set_attribute<std::string>(filename,"institution_id","E3SM-Projet");
   set_attribute<std::string>(filename,"product",(m_is_model_restart_output ? "model-restart" : "model-output"));  // TODO
-  set_attribute<std::string>(filename,"component","ATM");
+  set_attribute<std::string>(filename,"realm","atmos");
   set_attribute<std::string>(filename,"history",ts_str);
   set_attribute<std::string>(filename,"Conventions","CF-1.8");  // TODO: In the future we may be able to have this be set at runtime.  We hard-code for now, because post-processing needs something in this global attribute. 2023-04-12
 }

--- a/components/eamxx/src/share/io/scream_output_manager.hpp
+++ b/components/eamxx/src/share/io/scream_output_manager.hpp
@@ -120,6 +120,8 @@ protected:
                                 const IOFileSpecs& file_specs,
                                 const util::TimeStamp& timestamp) const;
 
+  void set_file_header(const std::string& filename);
+
   // Craft the restart parameter list
   void set_params (const ekat::ParameterList& params,
                    const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs);

--- a/components/eamxx/src/share/io/scream_output_manager.hpp
+++ b/components/eamxx/src/share/io/scream_output_manager.hpp
@@ -120,7 +120,7 @@ protected:
                                 const IOFileSpecs& file_specs,
                                 const util::TimeStamp& timestamp) const;
 
-  void set_file_header(const std::string& filename);
+  void set_file_header(const IOFileSpecs& file_specs);
 
   // Craft the restart parameter list
   void set_params (const ekat::ParameterList& params,


### PR DESCRIPTION
Metadata that was missing included IC/topo file names, user/host names, git/model version, creation date, and case id.

This should complete the [list of IO tasks](https://acme-climate.atlassian.net/wiki/spaces/NGDNA/pages/3290497244/SCREAMv1+Output+Netcdf+Cleanup) we had on confluence. We still have the PR for scorpio clib open, but that's not a priority, so it wasn't on that list.