### PR TITLE
EAMxx: Run small_kernels nightly with internal diagnostics.

### DIFF
--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/small_kernels/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/small_kernels/shell_commands
@@ -1,1 +1,2 @@
 ./xmlchange --append SCREAM_CMAKE_OPTIONS='SCREAM_SMALL_KERNELS On'
+$CIMEROOT/../components/eamxx/scripts/atmchange --all internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0 -b


### PR DESCRIPTION
Repetition testing has so far failed to reproduce the nondeterministic diff against the baseline exhibited by the test ERS_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1.chrysalis_intel.scream-small_kernels. In particular, I'm getting the same step-72 bfbhash line as the baseline. This is true with and without internal diagnostics on, so internal diagnostics are not the reason I can't reproduce the failure.

In this PR, I turn internal diagnostics on. That way, the next time there is a diff against the baseline, I can download the log files and compare the full hash stream against an instance that passes against the baseline.

[BFB]