### PR TITLE
Make one scorpio_input.cpp error message for robust, remove another check.

### DIFF
--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -191,13 +191,6 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
         "   - num global dofs: " + std::to_string(grid->get_num_global_dofs()) + "\n");
   }
 
-  EKAT_REQUIRE_MSG(grid->get_comm().size()<=grid->get_num_global_dofs(),
-      "Error! PIO interface requires the size of the IO MPI group to be\n"
-      "       no greater than the global number of columns.\n"
-      "       Consider decreasing the size of IO MPI group.\n"
-      "    - COMM SIZE: " + std::to_string(grid->get_comm().size()) + "\n"
-      "    - NUM DOFS : " + std::to_string(grid->get_num_global_dofs()) + "\n");
-
   // The grid is good. Store it.
   m_io_grid = grid;
 }

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -107,7 +107,8 @@ init (const ekat::ParameterList& params,
   for (const auto& it : m_layouts) {
     m_fields_names.push_back(it.first);
     EKAT_REQUIRE_MSG (m_host_views_1d.count(it.first)==1,
-        "Error! Input layouts and views maps do not store the same keys.\n");
+        "Error! Input layouts and views maps do not store the same keys.\n"
+	"    layout = " + it.first);
   }
 
   // Init scorpio internal structures
@@ -193,7 +194,9 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
   EKAT_REQUIRE_MSG(grid->get_comm().size()<=grid->get_num_global_dofs(),
       "Error! PIO interface requires the size of the IO MPI group to be\n"
       "       no greater than the global number of columns.\n"
-      "       Consider decreasing the size of IO MPI group.\n");
+      "       Consider decreasing the size of IO MPI group.\n"
+      "    - COMM SIZE: " + std::to_string(grid->get_comm().size()) + "\n"
+      "    - NUM DOFS : " + std::to_string(grid->get_num_global_dofs()) + "\n");
 
   // The grid is good. Store it.
   m_io_grid = grid;


### PR DESCRIPTION
Just adds more context to an error message so that when the error is thrown it is easier to decipher why.  This commit also removes a bad check that throws an error on legitimate runs.