### PR TITLE
Default energy fixer to off

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -204,7 +204,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- SHOC macrophysics -->
     <shoc inherit="atm_proc_base">
       <enable_column_conservation_checks>false</enable_column_conservation_checks>
-      <check_flux_state_consistency>true</check_flux_state_consistency>
+      <check_flux_state_consistency>false</check_flux_state_consistency>
     </shoc>
 
     <!-- CLD fraction -->


### PR DESCRIPTION
Some issues were raised by @ambrad and @oksanaguba about the PR https://github.com/E3SM-Project/scream/pull/2418 that need to be investigated. For now, easiest to just default off for CIME runs until we are confident in the computation.