### PR TITLE
Chrysalis: Exclude chr-0512 for one test.

### DIFF
--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/small_kernels/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/small_kernels/shell_commands
@@ -1,2 +1,7 @@
 ./xmlchange --append SCREAM_CMAKE_OPTIONS='SCREAM_SMALL_KERNELS On'
 $CIMEROOT/../components/eamxx/scripts/atmchange --all internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0 -b
+
+f=$(./xmlquery --value MACH)
+if [ $f == chrysalis ]; then
+  ./xmlchange BATCH_COMMAND_FLAGS="--time 00:30:00 -p debug --account e3sm --exclude=chr-0512"
+fi


### PR DESCRIPTION
A good lead in my nondeterminism hunt on Chrysalis is that node chr-0512 produces the failure very frequently, while other nodes I have tried so far never do. Since the small_kernels test happens to fail the most, probably because of how nodes get allocated to the tests, I want to see what happens when it isn't permitted to use this node.