### PR TITLE
Fixes a segfault in the finalization of F90 SCORPIO system in certain cases

### DIFF
--- a/components/eamxx/src/share/io/scream_scorpio_interface.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.F90
@@ -890,11 +890,11 @@ contains
             if (associated(var%iodesc_list)) then
               ! Remove this variable as a customer of the associated iodesc
               var%iodesc_list%num_customers = var%iodesc_list%num_customers - 1
-              ! Dellocate select memory from this variable.  Note we can't just
-              ! deallocate the whole var structure because this would also
-              ! deallocate the iodesc_list.
-              call deallocate_hist_var_t(var)
             end if ! associated(var%iodesc_list)
+            ! Dellocate select memory from this variable.  Note we can't just
+            ! deallocate the whole var structure because this would also
+            ! deallocate the iodesc_list.
+            call deallocate_hist_var_t(var)
           end if ! associated(var)
           curr_var_list => curr_var_list%next  ! Move on to the next variable
         end do ! associated(curr_var_list)

--- a/components/eamxx/src/share/io/scream_scorpio_interface.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.F90
@@ -887,12 +887,14 @@ contains
         do while (associated(curr_var_list))
           var => curr_var_list%var  ! The actual variable pointer
           if (associated(var)) then
-            ! Remove this variable as a customer of the associated iodesc
-            var%iodesc_list%num_customers = var%iodesc_list%num_customers - 1
-            ! Dellocate select memory from this variable.  Note we can't just
-            ! deallocate the whole var structure because this would also
-            ! deallocate the iodesc_list.
-            call deallocate_hist_var_t(var)
+            if (associated(var%iodesc_list)) then
+              ! Remove this variable as a customer of the associated iodesc
+              var%iodesc_list%num_customers = var%iodesc_list%num_customers - 1
+              ! Dellocate select memory from this variable.  Note we can't just
+              ! deallocate the whole var structure because this would also
+              ! deallocate the iodesc_list.
+              call deallocate_hist_var_t(var)
+            end if ! associated(var%iodesc_list)
           end if ! associated(var)
           curr_var_list => curr_var_list%next  ! Move on to the next variable
         end do ! associated(curr_var_list)


### PR DESCRIPTION
**EDIT: Only the second bullet still applies for this PR. See discussion below.**

These changes prevent exceptions from being swallowed in cases where the model has not been completely initialized. Specifically:

* AtmosphereProcess objects now only run their finalization if they have been initialized
* The SCREAM SCORPIO interface is a bit more careful about how it finalizes itself (as a result of the first refinement).

I've been trying to debug a standalone coupled HOMME-MAM4xx test that needs some extra fields in its initial conditions, and these changes have made it much easier to figure out which fields are needed, so I hope this can help others stand up new AtmosphereProcess subclasses.