### PR TITLE
EAMxx: revamped some mkdocs stuff, moved into eamxx folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ buildlib_cmakec
 
 # Ignore emacs backup files
 *~
+
+# Ignore mkdocs site-generated files in eamxx
+components/eamxx/docs/mkdocs/site/*

--- a/components/eamxx/docs/mkdocs/docs/common/installation.md
+++ b/components/eamxx/docs/mkdocs/docs/common/installation.md
@@ -1,0 +1,9 @@
+# Installation
+
+## Prerequisites
+
+## Setting Up Your Environment
+
+## Configuring and Building Scream
+
+## Running Tests

--- a/components/eamxx/docs/mkdocs/docs/dev/ci_nightly.md
+++ b/components/eamxx/docs/mkdocs/docs/dev/ci_nightly.md
@@ -1,0 +1,4 @@
+# Continuous Integration and Nightly Testing
+
+* Autotester quick overview
+* Nightly overview, CDash

--- a/components/eamxx/docs/mkdocs/docs/dev/cime_testing.md
+++ b/components/eamxx/docs/mkdocs/docs/dev/cime_testing.md
@@ -1,0 +1,7 @@
+# Full Model Testing
+
+Quickly review CIME test infrastructure and how EAMxx uses it
+
+* test types, specifiers (`_LnX`,`_D`,`_PMxN`,..), grids, compsets, test-mods
+* available grids/compsets for EAMxx, and where to find them
+* how to add atmchange in `shell_commands` test mods

--- a/components/eamxx/docs/mkdocs/docs/dev/field.md
+++ b/components/eamxx/docs/mkdocs/docs/dev/field.md
@@ -1,0 +1,46 @@
+## Field
+
+In EAMxx, a `Field` is a data structure holding two things: pointers to the data and pointers to metadata.
+Both the data and metadata are stored in `std::shared_ptr` instances, to ensure consistency across all copies
+of the field. This allows for fast shallow copy semantic for this class.
+
+The data is stored on both CPU and device memory (these may be the same, depending on the Kokkos
+backend). In EAMxx, we always assume and guarantee that the device data is up to date. That implies that the data
+be explicitly synced to host before using it on host, and explicitly synced to device after host manipulation,
+in order to ensure correctness. In order to access the data, users must use the `get_view` method, which takes
+two template arguments: the data type, and an enum specifying whether CPU or device data is needed. The data
+type is used to reinterpret the generic pointer stored inside to a view of the correct scalar type and layout.
+It is a possibly const-qualified type, and if the field was marked as "read-only", the method ensures that the
+provided data type is const. A read-only field can be created via the `getConst` method, which returns an
+identical copy of the field, but marked as read-only. The enum specifying host or device data is optional,
+with device being the default.
+
+The metadata is a collection of information on the field, such as name, layout, units, allocation size, and more.
+Part of the metadata is immutable after creation (e.g., name, units, or layout), while some metadata can be
+partially or completely modified. The metadata is contained in the `FieldHeader` data structure, which contains
+four parts:
+
+* `FieldIdentifier`: stores the field's name, layout, units, data type, and name of the grid where it's defined.
+  These information are condensed in a single string, that can be used to uniquely identify a field,
+  allowing to distinguish between different version of the same field. The layout is stored in the `FieldLayout`
+  data structure, which includes:
+    * the field tags: stored as a `std::vector<FieldTag>`, they give context to the field's extents.
+    * the field dims: stored both as a `std::vector<int>`, as well as a 1d `Kokkos::View`.
+* `FieldTracking`: stores information on the usage of the field, as well as its possible connections to other
+  fields. In particular, the tracked items are:
+    * the field time stamp: the time stamp when the field was last updated.
+    * the field accumulation start time: used for fields that are accumulated over several time steps
+      (or time step subcycles). For instance, it allows to reconstruct fluxes from raw accumulations.
+    * the providers/customers: lists of atmosphere processes (see below) that respectively require/compute
+      the field in their calculations.
+    * the field groups: a list of field groups that this field belongs too. Field groups are used to access
+      a group of fields without explicit prior knowledge about the number and/or names of the fields.
+* `FieldAllocProp`: stores information about the allocation. While the field is not yet allocated, users can
+  request special allocations for the field, for instance to accommodate packing (for SIMD), which may
+  require padding. Upon allocation, this information is then used by the Field structure to extract the
+  actual data, wrapped in a properly shaped `Kokkos::View`. The alloc props are also responsible of tracking
+  additional information in case the field is a "slice" of a higher-dimensional one, a fact that can affect
+  how the data is accessed.
+* Extra data: stored as a `std::map<std::string,ekat::any>`, allows to catch any metadata that does not fit
+  in the above structures. This is a last resort structure, intended to accommodate the most peculiar
+  corner cases, and should be used sparingly.

--- a/components/eamxx/docs/mkdocs/docs/dev/grid.md
+++ b/components/eamxx/docs/mkdocs/docs/dev/grid.md
@@ -1,0 +1,22 @@
+## Grids and Remappers
+
+In EAMxx, the `AbstractGrid` is an interface used to access information regarding the horizontal and vertical
+discretization. The most important information that the grid stores is:
+
+* the number of local/global DOFs: these are the degrees of freedom of the horizontal grid only. Here,
+  local/global refers to the MPI partitioning.
+* the DOFs global IDs (GIDs): a list of GIDs of the DOFs on the current MPI rank, stored as a Field
+* the local IDs (LIDs) to index list: this list maps the LID of a DOF (that is, the position of the DOF
+  in the GID list) to a "native" indexing system for that DOF. For instance, a `PointGrid` (a class derived from
+  `AbstractGrid`) is a simple collection of points, so the "native" indexing system coincides with the LIDs.
+  However, for a `SEGrid` (a derived class, for spectral element grids), the "native" indexing is a triplet
+  `(ielem,igp,jgp)`, specifying the element index, and the two indices of the Gauss point within the element.
+* geometry data: stored as a `std::map<std::string,Field>`, this represent any data that is intrinsically
+  linked to the grid (either along the horizontal or vertical direction), such as lat/lon coordinates,
+  vertical coordinates, area associated with the DOF.
+
+Grids can also be used to retrieve the layout of a 2d/3d scalar/vector field, which allows certain downstream
+classes to perform certain operations without assuming anything on the horizontal grid.
+
+In general, grid objects are passed around the different parts of EAMxx as const objects (read-only).
+The internal data can only be modified during construction, which usually is handled by a `GridsManager` object.

--- a/components/eamxx/docs/mkdocs/docs/dev/index.md
+++ b/components/eamxx/docs/mkdocs/docs/dev/index.md
@@ -1,0 +1,1 @@
+# SCREAM Developer Guide

--- a/components/eamxx/docs/mkdocs/docs/dev/io.md
+++ b/components/eamxx/docs/mkdocs/docs/dev/io.md
@@ -1,0 +1,5 @@
+# Input-Output
+
+In EAMxx, I/O is handled through the SCORPIO library, currently a submodule of E3SM.
+The `scream_io` library within eamxx allows to interface the EAMxx infrastructure classes
+with the SCORPIO library.

--- a/components/eamxx/docs/mkdocs/docs/dev/kokkos_ekat.md
+++ b/components/eamxx/docs/mkdocs/docs/dev/kokkos_ekat.md
@@ -1,0 +1,12 @@
+# Building Blocks
+
+Here we can discuss EKAT, Kokkos, and all of the highly-technical non-scientific
+stuff that makes our heads hurt.
+
+## Kokkos Views
+
+## Vectorization: Packs
+
+## Fields and the Field Manager
+
+### Preconditions, Postconditions, and Invariants

--- a/components/eamxx/docs/mkdocs/docs/dev/managers.md
+++ b/components/eamxx/docs/mkdocs/docs/dev/managers.md
@@ -1,0 +1,1 @@
+## FieldManager and GridsManager

--- a/components/eamxx/docs/mkdocs/docs/dev/processes.md
+++ b/components/eamxx/docs/mkdocs/docs/dev/processes.md
@@ -1,0 +1,17 @@
+# Atmospheric Processes
+
+In EAMxx, the `AtmosphereProcess` (AP) is a class representing a portion of the atmosphere timestep algorithm.
+In simple terms, an AP is an object that given certain input fields performs some calculations to compute
+some output fields.
+
+TODO: describe init sequcene (e.g., the process of requesting fields), base class main
+      interfaces/capabilities (e.g., subcycling), class expectations (e.g., must update fields on physics grid)
+
+Here is a list of currently implemented atmosphere processes.
+TODO: add links to papers/github-repos, and a SMALL description
+* p3: Microphysics, blah blah
+* SHOC: Macrophysics/Turbulence, blah
+* rrtmgp: Radiation, blah
+* spa: prescribed aerosols, blah blah
+* surface coupling: blah
+* mam: prognostic aerosols, blah blah

--- a/components/eamxx/docs/mkdocs/docs/dev/standalone_testing.md
+++ b/components/eamxx/docs/mkdocs/docs/dev/standalone_testing.md
@@ -1,0 +1,8 @@
+# Standalone EAMxx Testing
+
+Here we describe our testing methodology. Describe:
+
+* Unit tests (Catch2)
+* Property (verification) tests
+* F90-CXX bfb tests (for code porting)
+* test-all-scream

--- a/components/eamxx/docs/mkdocs/docs/dev/style_guide.md
+++ b/components/eamxx/docs/mkdocs/docs/dev/style_guide.md
@@ -1,0 +1,10 @@
+# SCREAM C++ Style Guide
+
+Here's our style guide. Let the holy wars begin!
+
+## Types
+
+## Functions and Methods
+
+## Variables
+

--- a/components/eamxx/docs/mkdocs/docs/index.md
+++ b/components/eamxx/docs/mkdocs/docs/index.md
@@ -1,0 +1,8 @@
+# The C++ E3SM Atmosphere Model (EAMxx)
+
+Some nice introductory text goes here! Maybe some figures, too. Who knows?
+
+* The [User Guide](user/index.md) guide explains how to run EAMxx, both in
+  its standalone configuration and within E3SM.
+* The [Developer Guide](dev/index.md) guide contains all the information needed
+  to contribute to the development of EAMxx.

--- a/components/eamxx/docs/mkdocs/docs/user/index.md
+++ b/components/eamxx/docs/mkdocs/docs/user/index.md
@@ -1,0 +1,2 @@
+# SCREAM User Guide
+

--- a/components/eamxx/docs/mkdocs/docs/user/index.md
+++ b/components/eamxx/docs/mkdocs/docs/user/index.md
@@ -1,2 +1,3 @@
 # SCREAM User Guide
 
+For the time being, see our [public confluence EAMxx user guide](https://acme-climate.atlassian.net/wiki/spaces/DOC/pages/3858890786/EAMxx+User+s+Guide)

--- a/components/eamxx/docs/mkdocs/mkdocs.yml
+++ b/components/eamxx/docs/mkdocs/mkdocs.yml
@@ -1,0 +1,59 @@
+site_name: The C++ E3SM Atmosphere Model (EAMxx)
+
+nav:
+  - 'Home': 'index.md'
+  - 'User Guide':
+    - 'Overview': 'user/index.md'
+    - 'Installation': 'common/installation.md'
+  - 'Developer Guide':
+    - 'Overview': 'dev/index.md'
+    - 'Installation': 'common/installation.md'
+    - 'Style Guide': 'dev/style_guide.md'
+    - 'Kokkos and EKAT': 'dev/kokkos_ekat.md'
+    - 'Important Data Structures':
+      - 'Fields': 'dev/field.md'
+      - 'Grids and Remappers': 'dev/grid.md'
+      - 'Atmosphere Processes': 'dev/processes.md'
+      - 'Managers': 'dev/managers.md'
+    - 'I/O': 'dev/io.md'
+    - 'Testing':
+      - 'Standalone': 'dev/standalone_testing.md'
+      - 'Full model': 'dev/cime_testing.md'
+      - 'CI and Nightly Testing': 'dev/ci_nightly.md'
+
+edit_uri: ""
+
+theme:
+  name: material
+  palette:
+  - media: "(prefers-color-scheme: light)"
+    scheme: default
+    toggle:
+      icon: material/weather-sunny
+      name: Switch to dark mode
+  - media: "(prefers-color-scheme: dark)"
+    scheme: slate
+    toggle:
+      icon: material/weather-night
+      name: Switch to light mode
+  features:
+    - navigation.indices
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+#    - navigation.tabs
+
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.arithmatex:
+      generic: true
+
+extra_javascript:
+  # - javascript/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
+repo_url: https://github.com/E3SM-Project/scream


### PR DESCRIPTION
I thought if we start to bring the mkdocs stuff in our master branch, people are epsilon-more likely to eventually write some documentation. I started to write some documentation for some of the main data structures. I think my next stab will be the testing infrastructure.

I verified that even if the docs is confined to `components/eamxx`, it gets correctly deployed to the gh-pages branch, which is visualized [here](https://e3sm-project.github.io/scream/). I am not sure how we can deal with this once we merge back to E3SM, since there is only one gh page for each repo. Perhaps we can get E3SM to use mkdocs, and we will simply be one of the pages? Otherwise, mkdocs is basically markdown, so we can export it elsewhere (e.g., confluence). But having it in the repo, we can at least "force" people to add some documentation when they add/remove/change major things.