### PR TITLE
Autogenerate markdown documentation file for all the atmchange-able parameters of EAMxx

### DIFF
--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -43,7 +43,7 @@ CIME_VAR_RE = re.compile(r'[$][{](\w+)[}]')
 #    Examples:
 #      - constraints="ge 0; lt 4" means the value V must satisfy V>=0 && V<4.
 #      - constraints="mod 2 eq 0" means the value V must be a multiple of 2.
-METADATA_ATTRIBS = ("type", "valid_values", "locked", "constraints", "inherit")
+METADATA_ATTRIBS = ("type", "valid_values", "locked", "constraints", "inherit", "doc")
 
 ###############################################################################
 def do_cime_vars(entry, case, refine=False, extra=None):

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -381,7 +381,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <output_yaml_files type="array(string)">${SRCROOT}/components/eamxx/data/scream_default_output.yaml</output_yaml_files>
     <model_restart>
       <filename_prefix>./${CASE}.scream</filename_prefix>
-      <output_control>
+      <output_control locked="true">
         <Frequency>${REST_N}</Frequency>
         <frequency_units>${REST_OPTION}</frequency_units>
       </output_control>

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -159,7 +159,6 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- Basic options for each atm process group -->
     <atm_proc_group inherit="atm_proc_base">
       <atm_procs_list>ERROR_NO_ATM_PROCS</atm_procs_list>
-      <Type>Group</Type>
       <schedule_type>Sequential</schedule_type>
     </atm_proc_group>
 
@@ -178,7 +177,6 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <!-- Homme dynamics -->
     <homme inherit="atm_proc_base">
-      <Grid>Dynamics</Grid>
       <Moisture>moist</Moisture>
       <!-- Frequency in physics steps to output a global hash over the dycore's
            in-fields. <= 0 disables hashing. -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -146,20 +146,26 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <!-- Basic options for each atm process -->
     <atm_proc_base>
-      <number_of_subcycles constraints="gt 0">1</number_of_subcycles>
+      <number_of_subcycles constraints="gt 0"
+        doc="how many times to subcycle this atm process">
+        1
+      </number_of_subcycles>
       <enable_precondition_checks type="logical">true</enable_precondition_checks>
       <enable_postcondition_checks type="logical">true</enable_postcondition_checks>
       <repair_log_level type="string" valid_values="trace,debug,info,warn">trace</repair_log_level>
       <!-- Run internal checks on code correctness.
            <= 0: off; >= 1: global hashes over state -->
       <internal_diagnostics_level type="integer">0</internal_diagnostics_level>
-      <compute_tendencies type="array(string)">NONE</compute_tendencies>
+      <compute_tendencies type="array(string)"
+        doc="list of computed fields for which this process will back out tendencies">
+        NONE
+      </compute_tendencies>
     </atm_proc_base>
 
     <!-- Basic options for each atm process group -->
     <atm_proc_group inherit="atm_proc_base">
       <atm_procs_list>ERROR_NO_ATM_PROCS</atm_procs_list>
-      <schedule_type>Sequential</schedule_type>
+      <schedule_type valid_values="Sequential">Sequential</schedule_type>
     </atm_proc_group>
 
     <!-- Surface coupling (import and export) -->

--- a/components/eamxx/scripts/eamxx-params-docs-autogen
+++ b/components/eamxx/scripts/eamxx-params-docs-autogen
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 
 """
-Generate a markdown file with explanation of all EAMxx namelist defaults parameters
+This script parses the file `cime_config/namelist_defaults_scream.xml'
+and generates the markdown file `docs/mkdocs/docs/common/eamxx_params.md`,
+containing all the runtime parameters that can be configured via calls
+to `atmchange` (in the case folder). For each parameter, we also report
+a doc string and its type, as well as, if present, constraints and valid values.
 """
 
-import sys, os
+import argparse, sys, os, pathlib
 
-from pathlib import Path
 from utils import _ensure_pylib_impl
 
 _ensure_pylib_impl("mdutils")
@@ -17,46 +20,18 @@ from mdutils import Html
 
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "cime_config"))
 from eamxx_buildnml_impl import resolve_all_inheritances, get_valid_selectors
-#  import os, sys, re
 
-#  import xml.etree.ElementTree as ET
-#  import xml.dom.minidom as md
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""{0}
+""".format(pathlib.Path(args[0]).name),
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
 
-#  _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","cime")
-#  sys.path.append(os.path.join(_CIMEROOT, "CIME", "Tools"))
-
-#  # Add path to scream libs
-#  sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"))
-
-#  # Cime imports
-#  from standard_script_setup import * # pylint: disable=wildcard-import
-#  from CIME.utils import expect, safe_copy, SharedArea
-
-#  # SCREAM imports
-#  from eamxx_buildnml_impl import get_valid_selectors, get_child, refine_type, \
-#          resolve_all_inheritances, gen_atm_proc_group, check_all_values
-#  from atm_manip import atm_config_chg_impl, unbuffer_changes, apply_buffer
-
-#  from utils import ensure_yaml
-#  ensure_yaml()
-#  import yaml
-
-#  logger = logging.getLogger(__name__) # pylint: disable=undefined-variable
-
-#  CIME_VAR_RE = re.compile(r'[$][{](\w+)[}]')
-
-# These are special attributes used by buildnml and other scripts to
-# perform some checks. In particular:
-#  - type: allows to verify compatibility (e.g., can't assing 3.2 to an integer)
-#  - valid_values: allows to specify a set of valid values
-#  - locked: if set to true, the parameter cannot be modified (via atmchange)
-#  - constraints: allows to specify constraints on values. Valid constraints
-#    are lt, le, ne, gt, ge, and mod. Multiple constrained are separated by ';'.
-#    Examples:
-#      - constraints="ge 0; lt 4" means the value V must satisfy V>=0 && V<4.
-#      - constraints="mod 2 eq 0" means the value V must be a multiple of 2.
-METADATA_ATTRIBS = ("type", "valid_values", "locked", "constraints", "inherit")
-
+    return parser.parse_args(args[1:])
 
 ###########################################################################
 def add_param(docs,scope,item):
@@ -109,7 +84,7 @@ def add_children(docs,xml,scope=""):
 def generate_params_docs():
 ###########################################################################
 
-    eamxx = Path(__file__).parent.parent.resolve()
+    eamxx = pathlib.Path(__file__).parent.parent.resolve()
     xml_defaults_file = eamxx / "cime_config" / "namelist_defaults_scream.xml"
     output_file = eamxx / "docs" / "mkdocs" / "docs" / "common" / "eamxx_params.md"
 
@@ -157,8 +132,7 @@ def generate_params_docs():
 def _main_func(description):
 ###############################################################################
 
-    success = generate_params_docs()
-    #  success = generate_params_docs(**vars(parse_command_line(sys.argv, description)))
+    success = generate_params_docs(**vars(parse_command_line(sys.argv, description)))
 
     sys.exit(0 if success else 1)
 

--- a/components/eamxx/scripts/eamxx-params-docs-autogen
+++ b/components/eamxx/scripts/eamxx-params-docs-autogen
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+"""
+Generate a markdown file with explanation of all EAMxx namelist defaults parameters
+"""
+
+import sys, os
+
+from pathlib import Path
+from utils import _ensure_pylib_impl
+
+_ensure_pylib_impl("mdutils")
+
+import xml.etree.ElementTree as ET
+from mdutils.mdutils import MdUtils
+from mdutils import Html
+
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "cime_config"))
+from eamxx_buildnml_impl import resolve_all_inheritances, get_valid_selectors
+#  import os, sys, re
+
+#  import xml.etree.ElementTree as ET
+#  import xml.dom.minidom as md
+
+#  _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","cime")
+#  sys.path.append(os.path.join(_CIMEROOT, "CIME", "Tools"))
+
+#  # Add path to scream libs
+#  sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"))
+
+#  # Cime imports
+#  from standard_script_setup import * # pylint: disable=wildcard-import
+#  from CIME.utils import expect, safe_copy, SharedArea
+
+#  # SCREAM imports
+#  from eamxx_buildnml_impl import get_valid_selectors, get_child, refine_type, \
+#          resolve_all_inheritances, gen_atm_proc_group, check_all_values
+#  from atm_manip import atm_config_chg_impl, unbuffer_changes, apply_buffer
+
+#  from utils import ensure_yaml
+#  ensure_yaml()
+#  import yaml
+
+#  logger = logging.getLogger(__name__) # pylint: disable=undefined-variable
+
+#  CIME_VAR_RE = re.compile(r'[$][{](\w+)[}]')
+
+# These are special attributes used by buildnml and other scripts to
+# perform some checks. In particular:
+#  - type: allows to verify compatibility (e.g., can't assing 3.2 to an integer)
+#  - valid_values: allows to specify a set of valid values
+#  - locked: if set to true, the parameter cannot be modified (via atmchange)
+#  - constraints: allows to specify constraints on values. Valid constraints
+#    are lt, le, ne, gt, ge, and mod. Multiple constrained are separated by ';'.
+#    Examples:
+#      - constraints="ge 0; lt 4" means the value V must satisfy V>=0 && V<4.
+#      - constraints="mod 2 eq 0" means the value V must be a multiple of 2.
+METADATA_ATTRIBS = ("type", "valid_values", "locked", "constraints", "inherit")
+
+
+###########################################################################
+def add_param(docs,scope,item):
+###########################################################################
+    # Locked parameters are not to be configured at runtime, so don't even bother
+    # E.g, a locked param is something we need to get in the input file, like
+    # the restart write frequency, but we don't want the user to modify it
+    # via atmchange
+    if "locked" in item.attrib.keys():
+        return
+    docs.new_line(f"* {scope}{item.tag}:")
+
+    pdoc = item.attrib['doc'] if 'doc' in item.attrib.keys() else "**MISSING**"
+    docs.new_line(f"    - description: {pdoc}")
+
+    ptype = item.attrib['type'] if 'type' in item.attrib.keys() else "**MISSING**"
+    docs.new_line(f"    - type: {ptype}")
+
+    pvalid = item.attrib['valid_values'] if 'valid_values' in item.attrib.keys() else None
+    if pvalid is not None:
+        docs.new_line(f"    - valid values: {pvalid}")
+    pconstr = item.attrib['constraints'] if 'constraints' in item.attrib.keys() else None
+    if pconstr is not None:
+        docs.new_line(f"    - constraints: {pconstr}")
+
+###########################################################################
+def add_children(docs,xml,scope=""):
+###########################################################################
+    done = []
+    # Locked parameters are not to be configured at runtime, so don't even bother
+    # E.g, a locked param is something we need to get in the input file, like
+    # the restart write frequency, but we don't want the user to modify it
+    # via atmchange
+    if "locked" in xml.attrib.keys():
+        return
+    for item in xml:
+        # The same entry may appear multiple times in the XML defaults file,
+        # each time with different selectors. We don't want to generate the
+        # same documentation twice.
+        if item.tag in done:
+            continue
+        done.append(item.tag)
+        if len(item)>0:
+            add_children (docs,item,f"{scope}{xml.tag}::")
+        else:
+            add_param(docs,f"{scope}{xml.tag}::",item)
+    docs.new_line()
+
+###########################################################################
+def generate_params_docs():
+###########################################################################
+
+    eamxx = Path(__file__).parent.parent.resolve()
+    xml_defaults_file = eamxx / "cime_config" / "namelist_defaults_scream.xml"
+    output_file = eamxx / "docs" / "mkdocs" / "docs" / "common" / "eamxx_params.md"
+
+    print("Generating eamxx params documentation...")
+    print(f"  output file: {output_file}")
+
+    with open(xml_defaults_file, "r") as fd:
+        tree = ET.parse(fd)
+        xml_defaults = tree.getroot()
+
+    selectors = get_valid_selectors(xml_defaults)
+    resolve_all_inheritances(xml_defaults)
+
+    docs = MdUtils(file_name=str(output_file),title='EAMxx runtime configurable parameters')
+    with open (output_file, "w") as fd:
+        docs.new_header(level=1,title='Atmosphere Processes Parameters')
+        aps = xml_defaults.find('atmosphere_processes_defaults')
+        for ap in aps:
+            if ap.tag.startswith('atm_proc'):
+                continue
+            docs.new_header(level=2,title=ap.tag)
+            add_children(docs,ap)
+                
+        ic = xml_defaults.find('initial_conditions')
+        docs.new_header(level=1,title="Initial Conditions Parameters")
+        add_children(docs,ic)
+
+        ad = xml_defaults.find('driver_options')
+        docs.new_header(level=1,title='Atmosphere Driver Parameters')
+        add_children(docs,ad)
+
+        scorpio = xml_defaults.find('Scorpio')
+        docs.new_header(level=1,title='Scorpio Parameters')
+        add_children(docs,scorpio)
+
+        homme = xml_defaults.find('ctl_nl')
+        docs.new_header(level=1,title='Homme namelist')
+        add_children(docs,homme)
+    docs.create_md_file()
+
+    print("Generating eamxx params documentation ... SUCCESS!")
+    return True
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+
+    success = generate_params_docs()
+    #  success = generate_params_docs(**vars(parse_command_line(sys.argv, description)))
+
+    sys.exit(0 if success else 1)
+
+###############################################################################
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)


### PR DESCRIPTION
This script parses our `namelist_defaults_scream.xml` file, and produces a markdown file in the folder `components/eamxx/docs/mkdocs/common` (which will exist as soon as #2454 is merged). The generated file contains all (and only) the parameters that are atmchange-able, listing the name, type, description, and, if present, valid values and/or constraints.

The generated file (see attached) clearly shows that we have some work to do in adding more metadata to our XML defaults file.

Ideally, when someone adds a new configurable parameters, they should  run the script in their branch, and commit also the changed newly generated markdown file. Then, upon PR merge, deploy the new documentation via
```
$ cd components/eamxx/docs/mkdocs
$ mkdocs build
$ mkdocs gh-deploy
```
Note: the above folder does not yet exist in master, it will be created only when #2454 is merged.

If you don't have mkdocs, simply run `$ pip install mkdocs pymdown-extensions mkdocs-material`. That should be enough (as of today) to run mkdocs.

[eamxx_params.md](https://github.com/E3SM-Project/scream/files/12353778/eamxx_params.md)
