### PR TITLE
Some upgrades to the XML defaults syntax

### DIFF
--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -807,7 +807,7 @@ def do_cime_vars_on_yaml_output_files(case, caseroot):
         # Hence, change default output settings to perform a single AVERAGE step at the end of the run
         if case.get_value("TESTCASE") in ["ERP", "ERS"]:
             test_env = case.get_env('test')
-            stop_n = test_env.get_value("STOP_N")
+            stop_n = int(test_env.get_value("STOP_N"))
             stop_opt = test_env.get_value("STOP_OPTION")
             content['output_control']['Frequency'] = stop_n
             content['output_control']['frequency_units'] = stop_opt

--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -238,15 +238,16 @@ def evaluate_selectors(element, case, ez_selectors):
     child_values = {} # elem_name -> evaluated XML element
     children_to_remove = []
     for child in element:
-        child_name = child.tag
-        child_val = child.text
-
         # Note: in our system, an XML element is either a "node" (has children)
         # or a "leaf" (has a value).
         has_children = len(child) > 0
         if has_children:
             evaluate_selectors(child, case, ez_selectors)
         else:
+            child_name = child.tag
+            child.text = str(child.text).strip(' \n')
+            child_val = child.text
+
             selectors = child.attrib
             if selectors:
                 all_match = True

--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -245,7 +245,7 @@ def evaluate_selectors(element, case, ez_selectors):
             evaluate_selectors(child, case, ez_selectors)
         else:
             child_name = child.tag
-            child.text = str(child.text).strip(' \n')
+            child.text = None if child.text is None else child.text.strip(' \n')
             child_val = child.text
 
             selectors = child.attrib

--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -28,6 +28,7 @@ from atm_manip import atm_config_chg_impl, unbuffer_changes, apply_buffer
 from utils import ensure_yaml
 ensure_yaml()
 import yaml
+from yaml_utils import Bools,Ints,Floats,Strings,array_representer
 
 logger = logging.getLogger(__name__) # pylint: disable=undefined-variable
 
@@ -110,7 +111,6 @@ def ordered_dump(data, item, Dumper=yaml.SafeDumper, **kwds):
     Copied from: https://stackoverflow.com/a/21912744
     Added ability to pass filename
     """
-    from yaml_utils import Bools,Ints,Floats,Strings,array_representer
 
     class OrderedDumper(Dumper):
         pass

--- a/components/eamxx/cime_config/eamxx_buildnml_impl.py
+++ b/components/eamxx/cime_config/eamxx_buildnml_impl.py
@@ -5,6 +5,8 @@ _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","
 sys.path.append(_CIMEROOT)
 
 from CIME.utils import expect
+from yaml_utils import make_array
+
 
 ###############################################################################
 class MockCase(object):
@@ -190,8 +192,6 @@ def has_child (root,name):
 ###############################################################################
 def refine_type(entry, force_type=None):
 ###############################################################################
-    from yaml_utils import make_array
-
     """
     Try to convert the text entry to the appropriate type based on its contents.
 

--- a/components/eamxx/cime_config/eamxx_buildnml_impl.py
+++ b/components/eamxx/cime_config/eamxx_buildnml_impl.py
@@ -190,6 +190,8 @@ def has_child (root,name):
 ###############################################################################
 def refine_type(entry, force_type=None):
 ###############################################################################
+    from yaml_utils import make_array
+
     """
     Try to convert the text entry to the appropriate type based on its contents.
 
@@ -246,6 +248,7 @@ def refine_type(entry, force_type=None):
 
             elem_type = force_type if force_type is None else array_elem_type(force_type)
             result = [refine_type(item.strip(), force_type=elem_type) for item in entry.split(",") if item.strip() != ""]
+            result = make_array(result,'string' if elem_type is None else elem_type)
             expected_type = type(result[0])
             for item in result[1:]:
                 expect(isinstance(item, expected_type),
@@ -254,8 +257,8 @@ def refine_type(entry, force_type=None):
             return result
 
     elif force_type is not None and is_array_type(force_type):
-
-        return []
+        etype = array_elem_type(force_type)
+        return make_array([],etype)
 
     if force_type:
         try:

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -176,8 +176,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <prescribed_from_file>
         <fields type="array(string)"/>
         <files type="array(string)"/>
-	<!-- Optional argument if fields have a different name in the source data files, set to NONE if not used -->
-        <fields_alt_name type="array(string)">NONE</fields_alt_name>
+        <!-- Optional argument if fields have a different name in the source data files -->
+        <fields_alt_name type="array(string)"/>
       </prescribed_from_file>
     </sc_export>
 

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -153,7 +153,10 @@ be lost if SCREAM_HACK_XML is not enabled.
       <!-- Run internal checks on code correctness.
            <= 0: off; >= 1: global hashes over state -->
       <internal_diagnostics_level type="integer">0</internal_diagnostics_level>
-      <compute_tendencies type="array(string)" doc="list of computed fields for which this process will back out tendencies">NONE</compute_tendencies>
+      <compute_tendencies
+        type="array(string)"
+        doc="list of computed fields for which this process will back out tendencies"
+        />
     </atm_proc_base>
 
     <!-- Basic options for each atm process group -->
@@ -167,12 +170,12 @@ be lost if SCREAM_HACK_XML is not enabled.
     <sc_import inherit="atm_proc_base"/>
     <sc_export inherit="atm_proc_base">
       <prescribed_constants>
-        <fields type="array(string)">NONE</fields>
-        <values type="array(real)">0</values>
+        <fields type="array(string)"/>
+        <values type="array(real)"/>
       </prescribed_constants>
       <prescribed_from_file>
-        <fields type="array(string)">NONE</fields>
-	<files type="array(string)">NONE</files>
+        <fields type="array(string)"/>
+        <files type="array(string)"/>
 	<!-- Optional argument if fields have a different name in the source data files, set to NONE if not used -->
         <fields_alt_name type="array(string)">NONE</fields_alt_name>
       </prescribed_from_file>
@@ -363,7 +366,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <sfc_alb_dif_nir   >0.0</sfc_alb_dif_nir>
     <surf_sens_flux    >0.0</surf_sens_flux>
     <surf_lw_flux_up   >0.0</surf_lw_flux_up>
-    <surf_mom_flux     >0.0,0.0</surf_mom_flux>
+    <surf_mom_flux     type="array(real)">0.0,0.0</surf_mom_flux>
     <!-- default ne1024 initial condition files do not have these, so init to zero here -->
     <!-- TODO: delete this once we can tell the AD that some fields can be inited by procs -->
     <qc hgrid="ne256np4|ne1024np4">0.0</qc>

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -388,7 +388,11 @@ be lost if SCREAM_HACK_XML is not enabled.
   <!-- driver_options options for scream -->
   <driver_options>
     <atmosphere_dag_verbosity_level>0</atmosphere_dag_verbosity_level>
-    <atm_log_level valid_values="trace,debug,info,warn,error">info</atm_log_level>
+    <atm_log_level type="string"
+                   valid_values="trace,debug,info,warn,error"
+                   doc="Verbosity level for the atm logger">
+      info
+    </atm_log_level>
     <output_to_screen type="logical">false</output_to_screen>
     <mass_column_conservation_error_tolerance>1e-10</mass_column_conservation_error_tolerance>
     <energy_column_conservation_error_tolerance>1e-14</energy_column_conservation_error_tolerance>

--- a/components/eamxx/cime_config/yaml_utils.py
+++ b/components/eamxx/cime_config/yaml_utils.py
@@ -1,0 +1,68 @@
+from utils import ensure_yaml
+ensure_yaml()
+import yaml
+
+###############################################################################
+# These are types that we use to differentiate lists of ints,bools,floats,strings
+# We can use these types to tell YAML how to write them to file, which ultimately
+# means to simply add the proper tag to the yaml file
+###############################################################################
+class Array(list):
+    def __init__ (self, vals, t):
+        super().__init__(t(v) for v in vals)
+class Bools(Array):
+    def __init__ (self,vals):
+        Array.__init__(self,vals,bool)
+class Ints(Array):
+    def __init__ (self,vals):
+        Array.__init__(self,vals,int)
+class Floats(Array):
+    def __init__ (self,vals):
+        Array.__init__(self,vals,float)
+class Strings(Array):
+    def __init__ (self,vals):
+        Array.__init__(self,vals,str)
+
+###############################################################################
+def make_array (vals,etype):
+    if etype=="bool":
+        return Bools(vals)
+    elif etype=="int":
+        return Ints(vals)
+    elif etype=="float" or etype=="real":
+        return Floats(vals)
+    elif etype=="string" or etype=="file":
+        return Strings(vals)
+    else:
+        raise ValueError (f"Unsupported element type '{etype}' for arrays.")
+###############################################################################
+
+###############################################################################
+def array_constructor(loader: yaml.SafeLoader, node: yaml.nodes.SequenceNode) -> list:
+###############################################################################
+    entries = loader.construct_sequence(node)
+    if node.tag=="!bools":
+        return Bools(entries)
+    elif node.tag=="!ints":
+        return Ints(entries)
+    elif node.tag=="!floats":
+        return Floats(entries)
+    elif node.tag=="!strings":
+        return Strings(entries)
+    else:
+        raise ValueError(f"Invalid node tag={node.tag} for array constructor.")
+
+###############################################################################
+def array_representer(dumper,array) -> yaml.nodes.SequenceNode:
+###############################################################################
+    if isinstance(array,Bools):
+        return dumper.represent_sequence('!bools',array)
+    elif isinstance(array,Ints):
+        return dumper.represent_sequence('!ints',array)
+    elif isinstance(array,Floats):
+        return dumper.represent_sequence('!floats',array)
+    elif isinstance(array,Strings):
+        return dumper.represent_sequence('!strings',array)
+    else:
+        raise ValueError (f"Unsupported array type: {type(array)}")
+

--- a/components/eamxx/cime_config/yaml_utils.py
+++ b/components/eamxx/cime_config/yaml_utils.py
@@ -25,6 +25,7 @@ class Strings(Array):
 
 ###############################################################################
 def make_array (vals,etype):
+###############################################################################
     if etype=="bool":
         return Bools(vals)
     elif etype=="int":
@@ -35,7 +36,6 @@ def make_array (vals,etype):
         return Strings(vals)
     else:
         raise ValueError (f"Unsupported element type '{etype}' for arrays.")
-###############################################################################
 
 ###############################################################################
 def array_constructor(loader: yaml.SafeLoader, node: yaml.nodes.SequenceNode) -> list:

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -64,12 +64,12 @@ void SurfaceCouplingExporter::set_grids(const std::shared_ptr<const GridsManager
   add_field<Required>("precip_ice_surf_mass", scalar2d_layout,      kg/m2,  grid_name);
 
   create_helper_field("Sa_z",       scalar2d_layout, grid_name);
-  create_helper_field("Sa_u",       scalar2d_layout, grid_name); 
-  create_helper_field("Sa_v",       scalar2d_layout, grid_name); 
-  create_helper_field("Sa_tbot",    scalar2d_layout, grid_name); 
+  create_helper_field("Sa_u",       scalar2d_layout, grid_name);
+  create_helper_field("Sa_v",       scalar2d_layout, grid_name);
+  create_helper_field("Sa_tbot",    scalar2d_layout, grid_name);
   create_helper_field("Sa_ptem",    scalar2d_layout, grid_name);
-  create_helper_field("Sa_pbot",    scalar2d_layout, grid_name); 
-  create_helper_field("Sa_shum",    scalar2d_layout, grid_name); 
+  create_helper_field("Sa_pbot",    scalar2d_layout, grid_name);
+  create_helper_field("Sa_shum",    scalar2d_layout, grid_name);
   create_helper_field("Sa_dens",    scalar2d_layout, grid_name);
   create_helper_field("Sa_pslv",    scalar2d_layout, grid_name);
   create_helper_field("Faxa_rainl", scalar2d_layout, grid_name);
@@ -157,7 +157,7 @@ void SurfaceCouplingExporter::setup_surface_coupling_data(const SCDataManager &s
   m_constant_multiple_view =
       decltype(m_constant_multiple_view)  (sc_data_manager.get_field_constant_multiple_ptr(),
                                            m_num_scream_exports);
-  m_do_export_during_init_view = 
+  m_do_export_during_init_view =
     decltype(m_do_export_during_init_view)(sc_data_manager.get_field_transfer_during_init_ptr(),
                                            m_num_scream_exports);
 
@@ -234,27 +234,25 @@ void SurfaceCouplingExporter::initialize_impl (const RunType /* run_type */)
       export_from_file_reg_names = export_from_file_fields;
       // Check if alternative names have been provided.  This is useful for source data files
       // that don't use the conventional EAMxx ATM->SRFC variable names.
-      if (export_from_file_params.isParameter("fields_alt_name")) {
-        // The parameter may exist but not be set, so check that it really exists
-        auto alt_names = export_from_file_params.get<vos_type>("fields_alt_name");
-        for (auto entry : alt_names) {
-          ekat::strip(entry, ' '); // remove empty spaces in case user did `a : b`
-          auto tokens = ekat::split(entry,':');
-          EKAT_REQUIRE_MSG(tokens.size()==2,"Error! surface_coupling_exporter::init - expected 'EAMxx_var_name:FILE_var_name' entry in fields_alt_names, got '" + entry + "' instead.\n");
-          auto it = ekat::find(export_from_file_fields,tokens[0]);
-          EKAT_REQUIRE_MSG(it!=export_from_file_fields.end(),
-                         "Error! surface_coupling_exporter::init - LHS of entry '" + entry + "' in field_alt_names does not match a valid EAMxx field.\n");
-          // Make sure that a user hasn't accidentally copy/pasted 
-          auto chk = ekat::find(export_from_file_reg_names,tokens[1]);
-          EKAT_REQUIRE_MSG(chk==export_from_file_reg_names.end(),
-                	  "Error! surface_coupling_exporter::init - RHS of entry '" + entry + "' in field_alt_names has already been used for a different field.\n");
-          auto idx = std::distance(export_from_file_fields.begin(),it);
-          export_from_file_reg_names[idx] = tokens[1];
-        }
+      auto alt_names = export_from_file_params.get<vos_type>("fields_alt_name",{});
+      for (auto entry : alt_names) {
+        ekat::strip(entry, ' '); // remove empty spaces in case user did `a : b`
+        auto tokens = ekat::split(entry,':');
+        EKAT_REQUIRE_MSG(tokens.size()==2,
+            "Error! surface_coupling_exporter::init - expected 'EAMxx_var_name:FILE_var_name' entry in fields_alt_names, got '" + entry + "' instead.\n");
+        auto it = ekat::find(export_from_file_fields,tokens[0]);
+        EKAT_REQUIRE_MSG(it!=export_from_file_fields.end(),
+                       "Error! surface_coupling_exporter::init - LHS of entry '" + entry + "' in field_alt_names does not match a valid EAMxx field.\n");
+        // Make sure that a user hasn't accidentally copy/pasted
+        auto chk = ekat::find(export_from_file_reg_names,tokens[1]);
+        EKAT_REQUIRE_MSG(chk==export_from_file_reg_names.end(),
+                  "Error! surface_coupling_exporter::init - RHS of entry '" + entry + "' in field_alt_names has already been used for a different field.\n");
+        auto idx = std::distance(export_from_file_fields.begin(),it);
+        export_from_file_reg_names[idx] = tokens[1];
       }
       // Construct a time interpolation object
       m_time_interp = util::TimeInterpolation(m_grid,export_from_file_names);
-      for (int ii=0; ii<export_from_file_fields.size(); ++ii) {
+      for (size_t ii=0; ii<export_from_file_fields.size(); ++ii) {
         auto fname = export_from_file_fields[ii];
         auto rname = export_from_file_reg_names[ii];
         // Find the index for this field in the list of export fields.
@@ -276,7 +274,7 @@ void SurfaceCouplingExporter::initialize_impl (const RunType /* run_type */)
     }
   }
 
-  // Parse all fields that will be set to a constant value: 
+  // Parse all fields that will be set to a constant value:
   if (m_params.isSublist("prescribed_constants")) {
     auto export_constant_params = m_params.sublist("prescribed_constants");
     EKAT_REQUIRE_MSG(export_constant_params.isParameter("fields"),"Error! surface_coupling_exporter::init - prescribed_constants does not have 'fields' parameter.");
@@ -349,7 +347,7 @@ void SurfaceCouplingExporter::set_constant_exports()
   }
   // Gotta catch em all
   EKAT_REQUIRE_MSG(num_set==m_num_const_exports,"ERROR! SurfaceCouplingExporter::set_constant_exports() - Number of fields set to a constant (" + std::to_string(num_set) +") doesn't match the number recorded at initialization (" + std::to_string(m_num_const_exports) +").  Something went wrong.");
-  
+
 }
 // =========================================================================================
 void SurfaceCouplingExporter::set_from_file_exports(const int dt)
@@ -460,7 +458,7 @@ void SurfaceCouplingExporter::compute_eamxx_exports(const double dt, const bool 
     // Currently only needed for Sa_z, Sa_dens and Sa_pslv
     const bool calculate_z_vars = export_source(idx_Sa_z)==FROM_MODEL
                                || export_source(idx_Sa_dens)==FROM_MODEL
-                               || export_source(idx_Sa_pslv)==FROM_MODEL; 
+                               || export_source(idx_Sa_pslv)==FROM_MODEL;
     if (calculate_z_vars) {
       PF::calculate_dz(team, pseudo_density_i, p_mid_i, T_mid_i, qv_i, dz_i);
       team.team_barrier();
@@ -473,10 +471,10 @@ void SurfaceCouplingExporter::compute_eamxx_exports(const double dt, const bool 
 
     // Set the values in the helper fields which correspond to the exported variables
 
-    if (export_source(idx_Sa_z)==FROM_MODEL) { 
+    if (export_source(idx_Sa_z)==FROM_MODEL) {
       // Assugb to Sa_z
       const auto s_z_mid_i = ekat::scalarize(z_mid_i);
-      Sa_z(i)    = s_z_mid_i(num_levs-1); 
+      Sa_z(i)    = s_z_mid_i(num_levs-1);
     }
 
     if (export_source(idx_Sa_u)==FROM_MODEL) {
@@ -501,9 +499,9 @@ void SurfaceCouplingExporter::compute_eamxx_exports(const double dt, const bool 
       Sa_pbot(i) = s_p_mid_i(num_levs-1);
     }
 
-    if (export_source(idx_Sa_shum)==FROM_MODEL) { 
+    if (export_source(idx_Sa_shum)==FROM_MODEL) {
       const auto s_qv_i = ekat::scalarize(qv_i);
-      Sa_shum(i) = s_qv_i(num_levs-1); 
+      Sa_shum(i) = s_qv_i(num_levs-1);
     }
 
     if (export_source(idx_Sa_dens)==FROM_MODEL) {

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -216,20 +216,18 @@ void SurfaceCouplingExporter::initialize_impl (const RunType /* run_type */)
   if (m_params.isSublist("prescribed_from_file")) {
     // Retrieve the parameters for prescribed from file
     auto export_from_file_params = m_params.sublist("prescribed_from_file");
-    EKAT_REQUIRE_MSG(export_from_file_params.isParameter("fields"),"Error! surface_coupling_exporter::init - prescribed_from_file does not have 'fields' parameter.");
+    EKAT_REQUIRE_MSG(export_from_file_params.isParameter("fields"),
+        "Error! surface_coupling_exporter::init - prescribed_from_file does not have 'fields' parameter.");
     auto export_from_file_fields = export_from_file_params.get<vos_type>("fields");
 
-    EKAT_REQUIRE_MSG(export_from_file_params.isParameter("files"),"Error! surface_coupling_exporter::init - prescribed_from_file does not have 'files' parameter.");
+    EKAT_REQUIRE_MSG(export_from_file_params.isParameter("files"),
+        "Error! surface_coupling_exporter::init - prescribed_from_file does not have 'files' parameter.");
     auto export_from_file_names = export_from_file_params.get<vos_type>("files");
 
-    bool are_fields_present = (std::find(export_from_file_fields.begin(),export_from_file_fields.end(),"NONE") == export_from_file_fields.end()) and (export_from_file_fields.size() > 0);
-    bool are_files_present  = (std::find(export_from_file_names.begin(),export_from_file_names.end(),"NONE") == export_from_file_names.end()) and (export_from_file_names.size() > 0);
-    if (are_fields_present) {
-      EKAT_REQUIRE_MSG(are_files_present,"ERROR!! surface_coupling_exporter::init - prescribed_from_file has fields but no files.");
-    }
-    if (are_files_present) {
-      EKAT_REQUIRE_MSG(are_fields_present,"ERROR!! surface_coupling_exporter::init - prescribed_from_file has files but no fields.");
-    }
+    bool are_fields_present = export_from_file_fields.size() > 0;
+    bool are_files_present  = export_from_file_names.size() > 0;
+    EKAT_REQUIRE_MSG(are_files_present==are_fields_present,
+        "ERROR!! When prescribing export fields from file, you must provide both fields names and file name(s).\n");
     bool do_export_from_file = are_fields_present and are_files_present;
     if (do_export_from_file) {
       vos_type export_from_file_reg_names;
@@ -257,14 +255,16 @@ void SurfaceCouplingExporter::initialize_impl (const RunType /* run_type */)
       // Construct a time interpolation object
       m_time_interp = util::TimeInterpolation(m_grid,export_from_file_names);
       for (int ii=0; ii<export_from_file_fields.size(); ++ii) {
-	auto fname = export_from_file_fields[ii];
-	auto rname = export_from_file_reg_names[ii];
+        auto fname = export_from_file_fields[ii];
+        auto rname = export_from_file_reg_names[ii];
         // Find the index for this field in the list of export fields.
-	auto v_loc = std::find(m_export_field_names_vector.begin(),m_export_field_names_vector.end(),fname);
-	EKAT_REQUIRE_MSG(v_loc != m_export_field_names_vector.end(), "ERROR!! surface_coupling_exporter::init - prescribed_from_file has field with name " << fname << " which can't be found in set of exported fields\n.");
-	auto idx = v_loc - m_export_field_names_vector.begin();
-	EKAT_REQUIRE_MSG(m_export_source_h(idx)==FROM_MODEL,"Error! surface_coupling_exporter::init - attempting to set field " << fname << " export type, which has already been set. Please check namelist options");
-	m_export_source_h(idx) = FROM_FILE;
+        auto v_loc = std::find(m_export_field_names_vector.begin(),m_export_field_names_vector.end(),fname);
+        EKAT_REQUIRE_MSG(v_loc != m_export_field_names_vector.end(),
+            "ERROR!! surface_coupling_exporter::init - prescribed_from_file has field with name " << fname << " which can't be found in set of exported fields\n.");
+        auto idx = v_loc - m_export_field_names_vector.begin();
+        EKAT_REQUIRE_MSG(m_export_source_h(idx)==FROM_MODEL,
+            "Error! surface_coupling_exporter::init - attempting to set field " << fname << " export type, which has already been set. Please check namelist options");
+        m_export_source_h(idx) = FROM_FILE;
         ++m_num_from_file_exports;
         --m_num_from_model_exports;
         auto& f_helper = m_helper_fields.at(fname);
@@ -284,7 +284,7 @@ void SurfaceCouplingExporter::initialize_impl (const RunType /* run_type */)
     auto export_constant_fields = export_constant_params.get<vos_type>("fields");
     auto export_constant_values = export_constant_params.get<vor_type>("values");
     EKAT_REQUIRE_MSG(export_constant_fields.size()==export_constant_values.size(),"Error! surface_coupling_exporter::init - prescribed_constants 'fields' and 'values' are not the same size");
-    bool are_fields_present = (std::find(export_constant_fields.begin(),export_constant_fields.end(),"NONE") == export_constant_fields.end()) and (export_constant_fields.size() > 0);
+    bool are_fields_present = export_constant_fields.size() > 0;
     if (are_fields_present) {
       // Determine which fields need constants
       for (size_t ii=0; ii<export_constant_fields.size(); ii++) {

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -138,8 +138,8 @@ void AtmosphereProcess::finalize (/* what inputs? */) {
 
 void AtmosphereProcess::setup_tendencies_requests () {
   using vos_t = std::vector<std::string>;
-  auto tend_vec = m_params.get<vos_t>("compute_tendencies",{"NONE"});
-  if (tend_vec == vos_t{"NONE"}) {
+  auto tend_vec = m_params.get<vos_t>("compute_tendencies",{});
+  if (tend_vec.size()==0) {
     return;
   }
 


### PR DESCRIPTION
After #2458 , we will (hopefully!) start to add documentation to our parameters. Since putting all on one line may be hard to visualize on some text editors, splitting the XML defaults file on multiple lines is probably a good idea. For instance, we may do something like

```
    <atm_log_level type="string"
                   valid_values="trace,debug,info,warn,error"
                   doc="Verbosity level for the atm logger">
      info
    </atm_log_level>
```
However, the current XML parsing would consider as parameter value the whole string between `>` and `</`, including spaces and newlines. Hence, it would cause an error of the form
```
ERROR: Invalid value '
      info
    ' for element 'atm_log_level'. Value not in the valid list ('['trace', 'debug', 'info', 'warn', 'error']')
```
This PR fixes this, by stripping space/newline chars inside the param values.