### PR TITLE
DP: convert advance_iop_forcing

### DIFF
--- a/components/eamxx/src/physics/dp/dp_functions.hpp
+++ b/components/eamxx/src/physics/dp/dp_functions.hpp
@@ -85,10 +85,12 @@ struct Functions
   KOKKOS_FUNCTION
   static void plevs0(
     // Input arguments
-    const Int& ncol,                 // Longitude dimension
-    const Int& ncold,                // Declared longitude dimension
-    const Int& nver,                 // vertical dimension
-    const Spack& ps,                 // Surface pressure (pascals)
+    const Int& nver,                   // vertical dimension
+    const Scalar& ps,                  // Surface pressure (pascals)
+    const uview_1d<const Spack>& hyai, // ps0 component of hybrid coordinate - interfaces
+    const uview_1d<const Spack>& hyam, // ps0 component of hybrid coordinate - midpoints
+    const uview_1d<const Spack>& hybi, // ps component of hybrid coordinate - interfaces
+    const uview_1d<const Spack>& hybm, // ps component of hybrid coordinate - midpoints
     // Kokkos stuff
     const MemberType& team,
     // Output arguments
@@ -113,11 +115,13 @@ struct Functions
   static void advance_iop_forcing(
     // Input arguments
     const Int& plev,                         // number of vertical levels
-    const Int& plon,                         // number of longitudes
     const Int& pcnst,                        // number of advected constituents including cloud water
+    const bool& have_u,                      // dataset contains u
+    const bool& have_v,                      // dataset contains v
+    const bool& dp_crm,                      // use 3d forcing
     const bool& use_3dfrc,                   // use 3d forcing
-    const Spack& scm_dt,                     // model time step [s]
-    const Spack& ps_in,                      // surface pressure [Pa]
+    const Scalar& scm_dt,                    // model time step [s]
+    const Scalar& ps_in,                     // surface pressure [Pa]
     const uview_1d<const Spack>& u_in,       // zonal wind [m/s]
     const uview_1d<const Spack>& v_in,       // meridional wind [m/s]
     const uview_1d<const Spack>& t_in,       // temperature [K]
@@ -128,6 +132,12 @@ struct Functions
     const uview_1d<const Spack>& divt,       // Divergence of temperature
     const uview_2d<const Spack>& divq,       // Divergence of moisture
     const uview_1d<const Spack>& wfld,       // Vertical motion (slt)
+    const uview_1d<const Spack>& uobs,       // actual u wind
+    const uview_1d<const Spack>& vobs,       // actual v wind
+    const uview_1d<const Spack>& hyai,       // ps0 component of hybrid coordinate - interfaces
+    const uview_1d<const Spack>& hyam,       // ps0 component of hybrid coordinate - midpoints
+    const uview_1d<const Spack>& hybi,       // ps component of hybrid coordinate - interfaces
+    const uview_1d<const Spack>& hybm,       // ps component of hybrid coordinate - midpoints
     // Kokkos stuff
     const MemberType& team,
     const Workspace& workspace,

--- a/components/eamxx/src/physics/dp/dp_functions.hpp
+++ b/components/eamxx/src/physics/dp/dp_functions.hpp
@@ -78,30 +78,99 @@ struct Functions
   // --------- Functions ---------
   //
 
+  // ---------------------------------------------------------------------
+  // Define the pressures of the interfaces and midpoints from the
+  // coordinate definitions and the surface pressure.
+  // ---------------------------------------------------------------------
   KOKKOS_FUNCTION
-  static void advance_iop_forcing(const Int& plev, const Int& pcnst, const Spack& scm_dt, const Spack& ps_in, const uview_1d<const Spack>& u_in, const uview_1d<const Spack>& v_in, const uview_1d<const Spack>& t_in, const uview_1d<const Spack>& q_in, const uview_1d<const Spack>& t_phys_frc, const uview_1d<Spack>& u_update, const uview_1d<Spack>& v_update, const uview_1d<Spack>& t_update, const uview_1d<Spack>& q_update);
+  static void plevs0(
+    // Input arguments
+    const Int& ncol,                 // Longitude dimension
+    const Int& ncold,                // Declared longitude dimension
+    const Int& nver,                 // vertical dimension
+    const Spack& ps,                 // Surface pressure (pascals)
+    // Kokkos stuff
+    const MemberType& team,
+    // Output arguments
+    const uview_1d<Spack>& pint,     // Pressure at model interfaces
+    const uview_1d<Spack>& pmid,     // Pressure at model levels
+    const uview_1d<Spack>& pdel);    // Layer thickness (pint(k+1) - pint(k))
+
+  //-----------------------------------------------------------------------
+  // advance_iop_forcing
+  // Purpose:
+  // Apply large scale forcing for t, q, u, and v as provided by the
+  //   case IOP forcing file.
+  //
+  // Author:
+  // Original version: Adopted from CAM3.5/CAM5
+  // Updated version for E3SM: Peter Bogenschutz (bogenschutz1@llnl.gov)
+  //  and replaces the forecast.F90 routine in CAM3.5/CAM5/CAM6/E3SMv1/E3SMv2
+  // CXX version: James Foucar (jgfouca@sandia.gov)
+  //
+  //-----------------------------------------------------------------------
+  KOKKOS_FUNCTION
+  static void advance_iop_forcing(
+    // Input arguments
+    const Int& plev,                         // number of vertical levels
+    const Int& plon,                         // number of longitudes
+    const Int& pcnst,                        // number of advected constituents including cloud water
+    const bool& use_3dfrc,                   // use 3d forcing
+    const Spack& scm_dt,                     // model time step [s]
+    const Spack& ps_in,                      // surface pressure [Pa]
+    const uview_1d<const Spack>& u_in,       // zonal wind [m/s]
+    const uview_1d<const Spack>& v_in,       // meridional wind [m/s]
+    const uview_1d<const Spack>& t_in,       // temperature [K]
+    const uview_2d<const Spack>& q_in,       // q tracer array [units vary]
+    const uview_1d<const Spack>& t_phys_frc, // temperature forcing from physics [K/s]
+    const uview_1d<const Spack>& divt3d,     // 3D T advection
+    const uview_2d<const Spack>& divq3d,     // 3D q advection
+    const uview_1d<const Spack>& divt,       // Divergence of temperature
+    const uview_2d<const Spack>& divq,       // Divergence of moisture
+    const uview_1d<const Spack>& wfld,       // Vertical motion (slt)
+    // Kokkos stuff
+    const MemberType& team,
+    const Workspace& workspace,
+    // Output arguments
+    const uview_1d<Spack>& u_update,         // updated temperature [K]
+    const uview_1d<Spack>& v_update,         // updated q tracer array [units vary]
+    const uview_1d<Spack>& t_update,         // updated zonal wind [m/s]
+    const uview_2d<Spack>& q_update);        // updated meridional wind [m/s]
+
   KOKKOS_FUNCTION
   static void advance_iop_nudging(const Int& plev, const Spack& scm_dt, const Spack& ps_in, const uview_1d<const Spack>& t_in, const uview_1d<const Spack>& q_in, const uview_1d<Spack>& t_update, const uview_1d<Spack>& q_update, const uview_1d<Spack>& relaxt, const uview_1d<Spack>& relaxq);
+
   KOKKOS_FUNCTION
   static void advance_iop_subsidence(const Int& plev, const Int& pcnst, const Spack& scm_dt, const Spack& ps_in, const uview_1d<const Spack>& u_in, const uview_1d<const Spack>& v_in, const uview_1d<const Spack>& t_in, const uview_1d<const Spack>& q_in, const uview_1d<Spack>& u_update, const uview_1d<Spack>& v_update, const uview_1d<Spack>& t_update, const uview_1d<Spack>& q_update);
+
   KOKKOS_FUNCTION
   static void iop_setinitial(const Int& nelemd, const uview_1d<element_t>& elem);
+
   KOKKOS_FUNCTION
   static void iop_broadcast();
+
   KOKKOS_FUNCTION
   static void apply_iop_forcing(const Int& nelemd, const uview_1d<element_t>& elem, hvcoord_t& hvcoord, const hybrid_t& hybrid, const timelevel_t& tl, const Int& n, const bool& t_before_advance, const Int& nets, const Int& nete);
+
   KOKKOS_FUNCTION
   static void iop_domain_relaxation(const Int& nelemd, const Int& np, const Int& nlev, const uview_1d<element_t>& elem, const hvcoord_t& hvcoord, const hybrid_t& hybrid, const Int& t1, const uview_1d<Spack>& dp, const Int& nelemd_todo, const Int& np_todo, const Spack& dt);
+
   KOKKOS_FUNCTION
   static void crm_resolved_turb(const Int& nelemd, const uview_1d<element_t>& elem, const hvcoord_t& hvcoord, const hybrid_t& hybrid, const Int& t1, const Int& nelemd_todo, const Int& np_todo);
+
   static void iop_default_opts(Spack& scmlat_out, Spack& scmlon_out, std::string& iopfile_out, bool& single_column_out, bool& scm_iop_srf_prop_out, bool& iop_nudge_tq_out, bool& iop_nudge_uv_out, Spack& iop_nudge_tq_low_out, Spack& iop_nudge_tq_high_out, Spack& iop_nudge_tscale_out, bool& scm_observed_aero_out, bool& iop_dosubsidence_out, bool& scm_multcols_out, bool& dp_crm_out, Spack& iop_perturb_high_out, bool& precip_off_out, bool& scm_zero_non_iop_tracers_out);
+
   static void iop_setopts(const Spack& scmlat_in, const Spack& scmlon_in, const std::string& iopfile_in, const bool& single_column_in, const bool& scm_iop_srf_prop_in, const bool& iop_nudge_tq_in, const bool& iop_nudge_uv_in, const Spack& iop_nudge_tq_low_in, const Spack& iop_nudge_tq_high_in, const Spack& iop_nudge_tscale_in, const bool& scm_observed_aero_in, const bool& iop_dosubsidence_in, const bool& scm_multcols_in, const bool& dp_crm_in, const Spack& iop_perturb_high_in, const bool& precip_off_in, const bool& scm_zero_non_iop_tracers_in);
+
   KOKKOS_FUNCTION
   static void setiopupdate_init();
+
   KOKKOS_FUNCTION
   static void setiopupdate();
+
   KOKKOS_FUNCTION
   static void readiopdata(const Int& plev, const bool& iop_update_phase1, const uview_1d<const Spack>& hyam, const uview_1d<const Spack>& hybm);
+
   KOKKOS_FUNCTION
   static void iop_intht();
 }; // struct Functions

--- a/components/eamxx/src/physics/dp/dp_functions_f90.hpp
+++ b/components/eamxx/src/physics/dp/dp_functions_f90.hpp
@@ -19,18 +19,28 @@ namespace scream {
 namespace dp {
 
 struct AdvanceIopForcingData : public PhysicsTestData {
+  static constexpr size_t NUM_ARRAYS = 20;
+
   // Inputs
   Int plev, pcnst;
   Real scm_dt, ps_in;
-  Real *u_in, *v_in, *t_in, *q_in, *t_phys_frc;
+  bool have_u, have_v, dp_crm, use_3dfrc;
+  Real *u_in, *v_in, *t_in, *q_in, *t_phys_frc, *divt3d, *divq3d, *divt,
+    *divq, *wfld, *uobs, *vobs, *hyai, *hyam, *hybi, *hybm;
 
   // Outputs
   Real *u_update, *v_update, *t_update, *q_update;
 
-  AdvanceIopForcingData(Int plev_, Int pcnst_, Real scm_dt_, Real ps_in_) :
-    PhysicsTestData({{ plev_ }, { plev_, pcnst_ }}, {{ &u_in, &v_in, &t_in, &t_phys_frc, &u_update, &v_update, &t_update }, { &q_in, &q_update }}), plev(plev_), pcnst(pcnst_), scm_dt(scm_dt_), ps_in(ps_in_) {}
+  AdvanceIopForcingData(Int plev_, Int pcnst_, Real scm_dt_, Real ps_in_, bool have_u_, bool have_v_, bool dp_crm_, bool use_3dfrc_) :
+    PhysicsTestData(
+      {{ plev_ }, { pcnst_, plev_ }},
+      {
+        { &u_in, &v_in, &t_in, &t_phys_frc, &divt3d, &divt, &divq, &wfld, &uobs, &vobs, &hyai, &hyam, &hybi, &hybm, &u_update, &v_update, &t_update },
+        { &q_in, &divq3d, &divq, &q_update }
+      }),
+    plev(plev_), pcnst(pcnst_), scm_dt(scm_dt_), ps_in(ps_in_), have_u(have_u_), have_v(have_v_), dp_crm(dp_crm_), use_3dfrc(use_3dfrc_) {}
 
-  PTD_STD_DEF(AdvanceIopForcingData, 4, plev, pcnst, scm_dt, ps_in);
+  PTD_STD_DEF(AdvanceIopForcingData, 8, plev, pcnst, scm_dt, ps_in, have_u, have_v, dp_crm, use_3dfrc);
 };
 
 
@@ -213,7 +223,7 @@ void readiopdata(ReadiopdataData& d);
 void iop_intht(IopInthtData& d);
 extern "C" { // _f function decls
 
-void advance_iop_forcing_f(Int plev, Int pcnst, Real scm_dt, Real ps_in, Real* u_in, Real* v_in, Real* t_in, Real* q_in, Real* t_phys_frc, Real* u_update, Real* v_update, Real* t_update, Real* q_update);
+void advance_iop_forcing_f(Int plev, Int pcnst, Real scm_dt, Real ps_in, bool have_u, bool have_v, bool dp_crm, bool use_3dfrc, Real* u_in, Real* v_in, Real* t_in, Real* q_in, Real* t_phys_frc, Real* divt3d, Real* divq3d, Real* divt, Real* divq, Real* wfld, Real* uobs, Real* vobs, Real* hyai, Real* hyam, Real* hybi, Real* hybm, Real* u_update, Real* v_update, Real* t_update, Real* q_update);
 void advance_iop_nudging_f(Int plev, Real scm_dt, Real ps_in, Real* t_in, Real* q_in, Real* t_update, Real* q_update, Real* relaxt, Real* relaxq);
 void advance_iop_subsidence_f(Int plev, Int pcnst, Real scm_dt, Real ps_in, Real* u_in, Real* v_in, Real* t_in, Real* q_in, Real* u_update, Real* v_update, Real* t_update, Real* q_update);
 void iop_setinitial_f(Int nelemd, element_t* elem);

--- a/components/eamxx/src/physics/dp/impl/dp_advance_iop_forcing_impl.hpp
+++ b/components/eamxx/src/physics/dp/impl/dp_advance_iop_forcing_impl.hpp
@@ -121,13 +121,6 @@ void Functions<S,D>::advance_iop_forcing(
       //  considered if using the preq-x dycore and if three dimensional
       //  forcing is not provided by IOP forcing file.
       Spack t_expan = 0;
-#ifndef MODEL_THETA_L
-      // this term is already taken into account through
-      //  LS vertical advection in theta-l dycore
-      if (!use_3dfrc) {
-        t_expan = scm_dt*wfld(k)*t_in(k)*rair/(cpair*pmidm1(k));
-      }
-#endif
       t_update(k) = t_in(k) + t_expan + scm_dt*(t_phys_frc(k) + t_lsf(k));
       for (Int m = 0; m < pcnst; ++m) {
         q_update(m, k) = q_in(m, k) + scm_dt*q_lsf(m, k);

--- a/components/eamxx/src/physics/dp/impl/dp_advance_iop_forcing_impl.hpp
+++ b/components/eamxx/src/physics/dp/impl/dp_advance_iop_forcing_impl.hpp
@@ -137,14 +137,22 @@ void Functions<S,D>::advance_iop_forcing(
   ////////////////////////////////////////////////////////////
   //  Set U and V fields
 
+  uview_1d<const Spack> u_src, v_src;
+
   if (have_v && have_u && !dp_crm) {
-    Kokkos::deep_copy(u_update, uobs);
-    Kokkos::deep_copy(v_update, vobs);
+    u_src = uobs;
+    v_src = vobs;
   }
   else {
-    Kokkos::deep_copy(u_update, u_in);
-    Kokkos::deep_copy(v_update, v_in);
+    u_src = u_in;
+    v_src = v_in;
   }
+
+  Kokkos::parallel_for(
+    Kokkos::TeamVectorRange(team, plev_pack), [&] (Int k) {
+      u_update(k) = u_src(k);
+      v_update(k) = v_src(k);
+  });
 
   workspace.template release_many_contiguous<3>(
     {&pmidm1, &pintm1, &pdelm1});

--- a/components/eamxx/src/physics/dp/impl/dp_advance_iop_forcing_impl.hpp
+++ b/components/eamxx/src/physics/dp/impl/dp_advance_iop_forcing_impl.hpp
@@ -15,10 +15,12 @@ template<typename S, typename D>
 KOKKOS_FUNCTION
 void Functions<S,D>::plevs0(
   // Input arguments
-  const Int& ncol,
-  const Int& ncold,
   const Int& nver,
-  const Spack& ps,
+  const Scalar& ps,
+  const uview_1d<const Spack>& hyai,
+  const uview_1d<const Spack>& hyam,
+  const uview_1d<const Spack>& hybi,
+  const uview_1d<const Spack>& hybm,
   // Kokkos stuff
   const MemberType& team,
   // Output arguments
@@ -26,38 +28,23 @@ void Functions<S,D>::plevs0(
   const uview_1d<Spack>& pmid,
   const uview_1d<Spack>& pdel)
 {
-// !-----------------------------------------------------------------------
-//   integer , intent(in)  :: ncol               ! Longitude dimension
-//   integer , intent(in)  :: ncold              ! Declared longitude dimension
-//   integer , intent(in)  :: nver               ! vertical dimension
-//   real(r8), intent(in)  :: ps(ncold)          ! Surface pressure (pascals)
-//   real(r8), intent(out) :: pint(ncold,nver+1) ! Pressure at model interfaces
-//   real(r8), intent(out) :: pmid(ncold,nver)   ! Pressure at model levels
-//   real(r8), intent(out) :: pdel(ncold,nver)   ! Layer thickness (pint(k+1) - pint(k))
-// !-----------------------------------------------------------------------
+  const auto ps0 = C::P0;
+  const Int nver_pack = ekat::npack<Spack>(nver);
 
-// !---------------------------Local workspace-----------------------------
-//   integer i,k             ! Longitude, level indices
-// !-----------------------------------------------------------------------
-// !
-// ! Set interface pressures
-// !
-//   !$OMP PARALLEL DO PRIVATE (K, I)
-//   do k=1,nver+1
-//        do i=1,ncol
-//             pint(i,k) = hyai(k)*ps0 + hybi(k)*ps(i)
-//      end do
-//   end do
-// !
-// ! Set midpoint pressures and layer thicknesses
-// !
-//   !$OMP PARALLEL DO PRIVATE (K, I)
-//   do k=1,nver
-//        do i=1,ncol
-//             pmid(i,k) = hyam(k)*ps0 + hybm(k)*ps(i)
-//             pdel(i,k) = pint(i,k+1) - pint(i,k)
-//      end do
-//   end do
+  // Set interface pressures
+  Kokkos::parallel_for(
+    Kokkos::TeamVectorRange(team, nver_pack), [&] (Int k) {
+      pint(k) = hyai(k)*ps0 + hybi(k)*ps;
+      pmid(k) = hyam(k)*ps0 + hybm(k)*ps;
+  });
+
+  // Set midpoint pressures and layer thicknesses
+  const auto pdel_s = scalarize(pdel);
+  const auto pint_s = scalarize(pint);
+  Kokkos::parallel_for(
+    Kokkos::TeamVectorRange(team, nver), [&] (Int k) {
+      pdel_s(k) = pint_s(k+1) - pint_s(k);
+  });
 }
 
 template<typename S, typename D>
@@ -65,11 +52,13 @@ KOKKOS_FUNCTION
 void Functions<S,D>::advance_iop_forcing(
   // Input arguments
   const Int& plev,
-  const Int& plon,
   const Int& pcnst,
+  const bool& have_u,
+  const bool& have_v,
+  const bool& dp_crm,
   const bool& use_3dfrc,
-  const Spack& scm_dt,
-  const Spack& ps_in,
+  const Scalar& scm_dt,
+  const Scalar& ps_in,
   const uview_1d<const Spack>& u_in,
   const uview_1d<const Spack>& v_in,
   const uview_1d<const Spack>& t_in,
@@ -80,6 +69,12 @@ void Functions<S,D>::advance_iop_forcing(
   const uview_1d<const Spack>& divt,
   const uview_2d<const Spack>& divq,
   const uview_1d<const Spack>& wfld,
+  const uview_1d<const Spack>& uobs,
+  const uview_1d<const Spack>& vobs,
+  const uview_1d<const Spack>& hyai,
+  const uview_1d<const Spack>& hyam,
+  const uview_1d<const Spack>& hybi,
+  const uview_1d<const Spack>& hybm,
   // Kokkos stuff
   const MemberType& team,
   const Workspace& workspace,
@@ -90,24 +85,16 @@ void Functions<S,D>::advance_iop_forcing(
   const uview_2d<Spack>& q_update)
 {
   // Local variables
-  uview_1d<Spack> pmidm1, pintm1, pdelm1, t_lsf;
-  uview_2d<Spack> q_lsf;
+  uview_1d<Spack>
+    pmidm1, // pressure at model levels
+    pintm1, // pressure at model interfaces (dim=plev+1)
+    pdelm1; // pdel(k)   = pint  (k+1)-pint  (k)
   workspace.template take_many_contiguous_unsafe<3>(
     {"pmidm1", "pintm1", "pdelm1"},
     {&pmidm1, &pintm1, &pdelm1});
 
-  // real(r8) pmidm1(plev)  ! pressure at model levels
-  // real(r8) pintm1(plevp) ! pressure at model interfaces
-  // real(r8) pdelm1(plev)  ! pdel(k)   = pint  (k+1)-pint  (k)
-  // real(r8) t_lsf(plev)       ! storage for temperature large scale forcing
-  // real(r8) q_lsf(plev,pcnst) ! storage for moisture large scale forcing
-  // real(r8) fac, t_expan
-
-  // integer k,m           ! longitude, level, constituent indices
-
   // Get vertical level profiles
-  const Int nlon = 1; // number of columns for plevs0 routine
-  plevs0(nlon, plon, plev, ps_in, team, pintm1, pmidm1, pdelm1);
+  plevs0(plev, ps_in, hyai, hyam, hybi, hybm, team, pintm1, pmidm1, pdelm1);
 
   constexpr Scalar rair = C::Rair;
   constexpr Scalar cpair = C::Cpair;
@@ -115,17 +102,21 @@ void Functions<S,D>::advance_iop_forcing(
   ////////////////////////////////////////////////////////////
   //  Advance T and Q due to large scale forcing
 
-  // if (use_3dfrc) {
-  //   t_lsf = divt3d;
-  //   q_lsf = divq3d;
-  // }
-  // else {
-  //   t_lsf = divt;
-  //   q_lsf = divq;
-  // }
+  uview_1d<const Spack> t_lsf; // storage for temperature large scale forcing
+  uview_2d<const Spack> q_lsf; // storage for moisture large scale forcing
 
+  if (use_3dfrc) {
+    t_lsf = divt3d;
+    q_lsf = divq3d;
+  }
+  else {
+    t_lsf = divt;
+    q_lsf = divq;
+  }
+
+  const Int plev_pack = ekat::npack<Spack>(plev);
   Kokkos::parallel_for(
-    Kokkos::TeamVectorRange(team, plev), [&] (Int k) {
+    Kokkos::TeamVectorRange(team, plev_pack), [&] (Int k) {
       // Initialize thermal expansion term to zero.  This term is only
       //  considered if using the preq-x dycore and if three dimensional
       //  forcing is not provided by IOP forcing file.
@@ -139,15 +130,21 @@ void Functions<S,D>::advance_iop_forcing(
 #endif
       t_update(k) = t_in(k) + t_expan + scm_dt*(t_phys_frc(k) + t_lsf(k));
       for (Int m = 0; m < pcnst; ++m) {
-        q_update(k,m) = q_in(k,m) + scm_dt*q_lsf(k,m);
+        q_update(m, k) = q_in(m, k) + scm_dt*q_lsf(m, k);
       }
   });
 
   ////////////////////////////////////////////////////////////
   //  Set U and V fields
 
-  Kokkos::deep_copy(u_update, u_in);
-  Kokkos::deep_copy(v_update, v_in);
+  if (have_v && have_u && !dp_crm) {
+    Kokkos::deep_copy(u_update, uobs);
+    Kokkos::deep_copy(v_update, vobs);
+  }
+  else {
+    Kokkos::deep_copy(u_update, u_in);
+    Kokkos::deep_copy(v_update, v_in);
+  }
 
   workspace.template release_many_contiguous<3>(
     {&pmidm1, &pintm1, &pdelm1});

--- a/components/eamxx/src/physics/dp/impl/dp_advance_iop_forcing_impl.hpp
+++ b/components/eamxx/src/physics/dp/impl/dp_advance_iop_forcing_impl.hpp
@@ -13,10 +13,144 @@ namespace dp {
 
 template<typename S, typename D>
 KOKKOS_FUNCTION
-void Functions<S,D>::advance_iop_forcing(const Int& plev, const Int& pcnst, const Spack& scm_dt, const Spack& ps_in, const uview_1d<const Spack>& u_in, const uview_1d<const Spack>& v_in, const uview_1d<const Spack>& t_in, const uview_1d<const Spack>& q_in, const uview_1d<const Spack>& t_phys_frc, const uview_1d<Spack>& u_update, const uview_1d<Spack>& v_update, const uview_1d<Spack>& t_update, const uview_1d<Spack>& q_update)
+void Functions<S,D>::plevs0(
+  // Input arguments
+  const Int& ncol,
+  const Int& ncold,
+  const Int& nver,
+  const Spack& ps,
+  // Kokkos stuff
+  const MemberType& team,
+  // Output arguments
+  const uview_1d<Spack>& pint,
+  const uview_1d<Spack>& pmid,
+  const uview_1d<Spack>& pdel)
 {
-  // TODO
-  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+// !-----------------------------------------------------------------------
+//   integer , intent(in)  :: ncol               ! Longitude dimension
+//   integer , intent(in)  :: ncold              ! Declared longitude dimension
+//   integer , intent(in)  :: nver               ! vertical dimension
+//   real(r8), intent(in)  :: ps(ncold)          ! Surface pressure (pascals)
+//   real(r8), intent(out) :: pint(ncold,nver+1) ! Pressure at model interfaces
+//   real(r8), intent(out) :: pmid(ncold,nver)   ! Pressure at model levels
+//   real(r8), intent(out) :: pdel(ncold,nver)   ! Layer thickness (pint(k+1) - pint(k))
+// !-----------------------------------------------------------------------
+
+// !---------------------------Local workspace-----------------------------
+//   integer i,k             ! Longitude, level indices
+// !-----------------------------------------------------------------------
+// !
+// ! Set interface pressures
+// !
+//   !$OMP PARALLEL DO PRIVATE (K, I)
+//   do k=1,nver+1
+//        do i=1,ncol
+//             pint(i,k) = hyai(k)*ps0 + hybi(k)*ps(i)
+//      end do
+//   end do
+// !
+// ! Set midpoint pressures and layer thicknesses
+// !
+//   !$OMP PARALLEL DO PRIVATE (K, I)
+//   do k=1,nver
+//        do i=1,ncol
+//             pmid(i,k) = hyam(k)*ps0 + hybm(k)*ps(i)
+//             pdel(i,k) = pint(i,k+1) - pint(i,k)
+//      end do
+//   end do
+}
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::advance_iop_forcing(
+  // Input arguments
+  const Int& plev,
+  const Int& plon,
+  const Int& pcnst,
+  const bool& use_3dfrc,
+  const Spack& scm_dt,
+  const Spack& ps_in,
+  const uview_1d<const Spack>& u_in,
+  const uview_1d<const Spack>& v_in,
+  const uview_1d<const Spack>& t_in,
+  const uview_2d<const Spack>& q_in,
+  const uview_1d<const Spack>& t_phys_frc,
+  const uview_1d<const Spack>& divt3d,
+  const uview_2d<const Spack>& divq3d,
+  const uview_1d<const Spack>& divt,
+  const uview_2d<const Spack>& divq,
+  const uview_1d<const Spack>& wfld,
+  // Kokkos stuff
+  const MemberType& team,
+  const Workspace& workspace,
+  // Output arguments
+  const uview_1d<Spack>& u_update,
+  const uview_1d<Spack>& v_update,
+  const uview_1d<Spack>& t_update,
+  const uview_2d<Spack>& q_update)
+{
+  // Local variables
+  uview_1d<Spack> pmidm1, pintm1, pdelm1, t_lsf;
+  uview_2d<Spack> q_lsf;
+  workspace.template take_many_contiguous_unsafe<3>(
+    {"pmidm1", "pintm1", "pdelm1"},
+    {&pmidm1, &pintm1, &pdelm1});
+
+  // real(r8) pmidm1(plev)  ! pressure at model levels
+  // real(r8) pintm1(plevp) ! pressure at model interfaces
+  // real(r8) pdelm1(plev)  ! pdel(k)   = pint  (k+1)-pint  (k)
+  // real(r8) t_lsf(plev)       ! storage for temperature large scale forcing
+  // real(r8) q_lsf(plev,pcnst) ! storage for moisture large scale forcing
+  // real(r8) fac, t_expan
+
+  // integer k,m           ! longitude, level, constituent indices
+
+  // Get vertical level profiles
+  const Int nlon = 1; // number of columns for plevs0 routine
+  plevs0(nlon, plon, plev, ps_in, team, pintm1, pmidm1, pdelm1);
+
+  constexpr Scalar rair = C::Rair;
+  constexpr Scalar cpair = C::Cpair;
+
+  ////////////////////////////////////////////////////////////
+  //  Advance T and Q due to large scale forcing
+
+  // if (use_3dfrc) {
+  //   t_lsf = divt3d;
+  //   q_lsf = divq3d;
+  // }
+  // else {
+  //   t_lsf = divt;
+  //   q_lsf = divq;
+  // }
+
+  Kokkos::parallel_for(
+    Kokkos::TeamVectorRange(team, plev), [&] (Int k) {
+      // Initialize thermal expansion term to zero.  This term is only
+      //  considered if using the preq-x dycore and if three dimensional
+      //  forcing is not provided by IOP forcing file.
+      Spack t_expan = 0;
+#ifndef MODEL_THETA_L
+      // this term is already taken into account through
+      //  LS vertical advection in theta-l dycore
+      if (!use_3dfrc) {
+        t_expan = scm_dt*wfld(k)*t_in(k)*rair/(cpair*pmidm1(k));
+      }
+#endif
+      t_update(k) = t_in(k) + t_expan + scm_dt*(t_phys_frc(k) + t_lsf(k));
+      for (Int m = 0; m < pcnst; ++m) {
+        q_update(k,m) = q_in(k,m) + scm_dt*q_lsf(k,m);
+      }
+  });
+
+  ////////////////////////////////////////////////////////////
+  //  Set U and V fields
+
+  Kokkos::deep_copy(u_update, u_in);
+  Kokkos::deep_copy(v_update, v_in);
+
+  workspace.template release_many_contiguous<3>(
+    {&pmidm1, &pintm1, &pdelm1});
 }
 
 } // namespace dp

--- a/components/eamxx/src/physics/dp/tests/dp_advance_iop_forcing_tests.cpp
+++ b/components/eamxx/src/physics/dp/tests/dp_advance_iop_forcing_tests.cpp
@@ -20,7 +20,14 @@ struct UnitWrap::UnitTest<D>::TestAdvanceIopForcing {
     auto engine = setup_random_test();
 
     AdvanceIopForcingData f90_data[] = {
-      // TODO
+      //                  plev, pcnst, scm_dt,   ps_in, have_u, have_v, dp_crm, use_3dfrc
+      AdvanceIopForcingData(72,    10,    0.1,  1000.0,   true,   true,   true, true),
+      AdvanceIopForcingData(72,    10,    0.1,  1000.0,   true,   true,   true, false),
+      AdvanceIopForcingData(72,    10,    0.1,  1000.0,   true,   true,  false, true),
+
+      AdvanceIopForcingData(27,     7,    0.1,  1000.0,   true,   true,   true, true),
+      AdvanceIopForcingData(27,     7,    0.1,  1000.0,   true,   true,   true, false),
+      AdvanceIopForcingData(27,     7,    0.1,  1000.0,   true,   true,  false, true),
     };
 
     static constexpr Int num_runs = sizeof(f90_data) / sizeof(AdvanceIopForcingData);
@@ -33,8 +40,13 @@ struct UnitWrap::UnitTest<D>::TestAdvanceIopForcing {
 
     // Create copies of data for use by cxx. Needs to happen before fortran calls so that
     // inout data is in original state
-    AdvanceIopForcingData cxx_data[] = {
-      // TODO
+    AdvanceIopForcingData cxx_data[num_runs] = {
+      AdvanceIopForcingData(f90_data[0]),
+      AdvanceIopForcingData(f90_data[1]),
+      AdvanceIopForcingData(f90_data[2]),
+      AdvanceIopForcingData(f90_data[3]),
+      AdvanceIopForcingData(f90_data[4]),
+      AdvanceIopForcingData(f90_data[5]),
     };
 
     // Assume all data is in C layout
@@ -48,10 +60,13 @@ struct UnitWrap::UnitTest<D>::TestAdvanceIopForcing {
     // Get data from cxx
     for (auto& d : cxx_data) {
       d.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
-      advance_iop_forcing_f(d.plev, d.pcnst, d.scm_dt, d.ps_in, d.u_in, d.v_in, d.t_in, d.q_in, d.t_phys_frc, d.u_update, d.v_update, d.t_update, d.q_update);
+      advance_iop_forcing_f(d.plev, d.pcnst, d.scm_dt, d.ps_in, d.have_u, d.have_v, d.dp_crm, d.use_3dfrc, d.u_in, d.v_in, d.t_in, d.q_in, d.t_phys_frc, d.divt3d, d.divq3d, d.divt, d.divq, d.wfld, d.uobs, d.vobs, d.hyai, d.hyam, d.hybi, d.hybm, d.u_update, d.v_update, d.t_update, d.q_update);
       d.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
     }
 
+    // We can't call into fortran. Due to all the dependencies it has, it's not possible
+    // to build it in standalone eamxx. Without fortran, we cannot do BFB tests.
+#if 0
     // Verify BFB results, all data should be in C layout
     if (SCREAM_BFB_TESTING) {
       for (Int i = 0; i < num_runs; ++i) {
@@ -72,6 +87,8 @@ struct UnitWrap::UnitTest<D>::TestAdvanceIopForcing {
 
       }
     }
+#endif
+
   } // run_bfb
 
 };

--- a/components/eamxx/src/physics/dp/tests/dp_advance_iop_forcing_tests.cpp
+++ b/components/eamxx/src/physics/dp/tests/dp_advance_iop_forcing_tests.cpp
@@ -59,9 +59,9 @@ struct UnitWrap::UnitTest<D>::TestAdvanceIopForcing {
 
     // Get data from cxx
     for (auto& d : cxx_data) {
-      d.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+      d.template transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
       advance_iop_forcing_f(d.plev, d.pcnst, d.scm_dt, d.ps_in, d.have_u, d.have_v, d.dp_crm, d.use_3dfrc, d.u_in, d.v_in, d.t_in, d.q_in, d.t_phys_frc, d.divt3d, d.divq3d, d.divt, d.divq, d.wfld, d.uobs, d.vobs, d.hyai, d.hyam, d.hybi, d.hybm, d.u_update, d.v_update, d.t_update, d.q_update);
-      d.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
+      d.template transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
     }
 
     // We can't call into fortran. Due to all the dependencies it has, it's not possible


### PR DESCRIPTION
Issues:
1) A couple of the fortran arrays have dims `(plev, pcnst)`. I wasn't sure which dimension to pack and which index should be the fast index. I think, in fortran for the above dims, plev is the fast index. But the fortran code using these arrays had the pcnst loop as the inner loop. I decide to pack on the plev dimension and keep plev indexing as the fast index.
2) Other than running the code and seeing that it doesn't crash or have memory problems, there's no way to test these conversions.