### PR TITLE
Add property check ability to output column data from fields

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -394,7 +394,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <energy_column_conservation_error_tolerance>1e-14</energy_column_conservation_error_tolerance>
     <column_conservation_checks_fail_handling_type>Warning</column_conservation_checks_fail_handling_type>
     <check_all_computed_fields_for_nans type="logical">true</check_all_computed_fields_for_nans >
-    <property_check_data_fields type="array(string)" doc="list of additional data fields to output in property checks">phis,landfrac</property_check_data_fields>
+    <property_check_data_fields type="array(string)" doc="list of additional data fields to output in property checks (only for physics grid)">phis,landfrac</property_check_data_fields>
   </driver_options>
 
   <!-- E3SM Simulation Settings -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -394,6 +394,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <energy_column_conservation_error_tolerance>1e-14</energy_column_conservation_error_tolerance>
     <column_conservation_checks_fail_handling_type>Warning</column_conservation_checks_fail_handling_type>
     <check_all_computed_fields_for_nans type="logical">true</check_all_computed_fields_for_nans >
+    <property_check_data_fields type="array(string)" doc="list of computed fields for which this process will back out tendencies">phis,landfrac</property_check_data_fields>
   </driver_options>
 
   <!-- E3SM Simulation Settings -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -394,7 +394,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <energy_column_conservation_error_tolerance>1e-14</energy_column_conservation_error_tolerance>
     <column_conservation_checks_fail_handling_type>Warning</column_conservation_checks_fail_handling_type>
     <check_all_computed_fields_for_nans type="logical">true</check_all_computed_fields_for_nans >
-    <property_check_data_fields type="array(string)" doc="list of computed fields for which this process will back out tendencies">phis,landfrac</property_check_data_fields>
+    <property_check_data_fields type="array(string)" doc="list of additional data fields to output in property checks">phis,landfrac</property_check_data_fields>
   </driver_options>
 
   <!-- E3SM Simulation Settings -->

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -414,6 +414,16 @@ void AtmosphereDriver::setup_column_conservation_checks ()
   m_atm_process_group->setup_column_conservation_checks(conservation_check, fail_handling_type);
 }
 
+void AtmosphereDriver::add_additional_column_data_to_property_checks () {
+  auto phys_field_mgr = m_field_mgrs[m_grids_manager->get_grid("Physics")->name()];
+  if (phys_field_mgr->has_field("landfrac")) {
+    m_atm_process_group->add_additional_data_fields_to_property_checks(phys_field_mgr->get_field("landfrac"));
+  }
+  if (phys_field_mgr->has_field("phis")) {
+    m_atm_process_group->add_additional_data_fields_to_property_checks(phys_field_mgr->get_field("phis"));
+  }
+}
+
 void AtmosphereDriver::create_fields()
 {
   m_atm_logger->info("[EAMxx] create_fields ...");
@@ -1305,6 +1315,9 @@ void AtmosphereDriver::initialize_atm_procs ()
   if (m_atm_params.sublist("driver_options").get("check_all_computed_fields_for_nans",true)) {
     m_atm_process_group->add_postcondition_nan_checks();
   }
+
+  // Add additional column data fields to pre/postcondition checks (if they exist)
+  add_additional_column_data_to_property_checks();
 
   if (fvphyshack) {
     // [CGLL ICs in pg2] See related notes in atmosphere_dynamics.cpp.

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -415,12 +415,20 @@ void AtmosphereDriver::setup_column_conservation_checks ()
 }
 
 void AtmosphereDriver::add_additional_column_data_to_property_checks () {
+  // Get list of additional data fields from driver_options parameters.
+  // If no fields given, return.
+  using vos_t = std::vector<std::string>;
+  auto additional_data_fields = m_atm_params.sublist("driver_options").get<vos_t>("property_check_data_fields",
+                                                                                  {"NONE"});
+  if (additional_data_fields == vos_t{"NONE"}) return;
+
+  // Add requested fields to property checks
   auto phys_field_mgr = m_field_mgrs[m_grids_manager->get_grid("Physics")->name()];
-  if (phys_field_mgr->has_field("landfrac")) {
-    m_atm_process_group->add_additional_data_fields_to_property_checks(phys_field_mgr->get_field("landfrac"));
-  }
-  if (phys_field_mgr->has_field("phis")) {
-    m_atm_process_group->add_additional_data_fields_to_property_checks(phys_field_mgr->get_field("phis"));
+  for (auto fname : additional_data_fields) {
+    EKAT_REQUIRE_MSG(phys_field_mgr->has_field(fname), "Error! The field "+fname+" is requested for property check output "
+                                                       "but does not exist in the physics field manager.\n");
+    
+    m_atm_process_group->add_additional_data_fields_to_property_checks(phys_field_mgr->get_field(fname));
   }
 }
 

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -97,6 +97,10 @@ public:
   // and pass to m_atm_process_group.
   void setup_column_conservation_checks ();
 
+  // Add column data to all pre/postcondition property checks
+  // for use in output.
+  void add_additional_column_data_to_property_checks ();
+
   void set_provenance_data (std::string caseid = "",
                             std::string hostname = "",
                             std::string username = "");

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -153,6 +153,20 @@ public:
   void run_postcondition_checks () const;
   void run_column_conservation_check () const;
 
+  // Returns pre/postcondition checks
+  std::list<std::pair<CheckFailHandling,prop_check_ptr>>
+  get_precondition_checks () {
+    return m_precondition_checks;
+  }
+  std::list<std::pair<CheckFailHandling,prop_check_ptr>>
+  get_postcondition_checks() {
+    return m_postcondition_checks;
+  }
+  std::pair<CheckFailHandling,prop_check_ptr>
+  get_column_conservation_check() {
+    return m_column_conservation_check;
+  }
+
 
   void init_step_tendencies ();
   void compute_step_tendencies (const double dt);
@@ -261,7 +275,7 @@ public:
                                const bool out = true, const bool internal = true) const;
   // For BFB tracking in production simulations.
   void print_fast_global_state_hash(const std::string& label) const;
-  
+
 protected:
 
   // Sends a message to the atm log

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
@@ -304,7 +304,7 @@ setup_column_conservation_checks (const std::shared_ptr<MassAndEnergyColumnConse
                      "for non-physics process \"" + atm_proc->name() + "\". "
                      "This check is column local and therefore can only be run "
                      "on physics processes.\n");
- 
+
     // Query the computed fields for this atm process and see if either the mass or energy computation
     // might be changed after the process has run. If no field used in the mass or energy calculate
     // is updated by this process, there is no need to run the check.
@@ -359,6 +359,25 @@ void AtmosphereProcessGroup::add_postcondition_nan_checks () const {
           auto nan_check = std::make_shared<FieldNaNCheck>(*f.second,grid);
           proc->add_postcondition_check(nan_check, CheckFailHandling::Fatal);
         }
+      }
+    }
+  }
+}
+
+void AtmosphereProcessGroup::add_additional_data_fields_to_property_checks (const Field& data_field) {
+  for (auto proc : m_atm_processes) {
+    auto group = std::dynamic_pointer_cast<AtmosphereProcessGroup>(proc);
+    if (group) {
+      group->add_additional_data_fields_to_property_checks(data_field);
+    } else {
+      for (auto& prop_check : proc->get_precondition_checks()) {
+        prop_check.second->set_additional_data_field(data_field);
+      }
+      for (auto& prop_check : proc->get_postcondition_checks()) {
+        prop_check.second->set_additional_data_field(data_field);
+      }
+      if (proc->has_column_conservation_check()) {
+        proc->get_column_conservation_check().second->set_additional_data_field(data_field);
       }
     }
   }

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
@@ -99,6 +99,9 @@ public:
   // (that are on the same grid) at the location of the fail.
   void add_postcondition_nan_checks () const;
 
+  // Add additional data fields to all property checks in the group
+  void add_additional_data_fields_to_property_checks (const Field& data_field);
+
 protected:
 
   // Adds fid to the list of required/computed fields of the group (as a whole).

--- a/components/eamxx/src/share/property_checks/field_nan_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_nan_check.cpp
@@ -151,12 +151,15 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
       }
       bool has_additional_col_info = not additional_data_fields().empty();
       if (has_additional_col_info) {
+        std::stringstream msg;
+        msg << "  - additional data:\n";
         for (auto& f : additional_data_fields()) {
           f.sync_to_host();
-          res_and_msg.msg += "  - "+ f.name() + ": "+
-                             std::to_string(f.get_internal_view_data<const Real, Host>()[col_lid]) +
-                             "\n";
+          msg << "\n";
+          print_field_hyperslab(f, {COL}, {col_lid}, msg);
         }
+        msg << "\n  END OF ADDITIONAL DATA\n";
+        res_and_msg.msg += msg.str();
       }
     }
 

--- a/components/eamxx/src/share/property_checks/field_nan_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_nan_check.cpp
@@ -149,7 +149,17 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
         auto lon = m_grid->get_geometry_data("lon").get_internal_view_data<const Real,Host>();
         res_and_msg.msg += "  - lat/lon: (" + std::to_string(lat[col_lid]) + ", " + std::to_string(lon[col_lid]) + ")\n";
       }
+      bool has_additional_col_info = not additional_data_fields().empty();
+      if (has_additional_col_info) {
+        for (auto& f : additional_data_fields()) {
+          f.sync_to_host();
+          res_and_msg.msg += "  - "+ f.name() + ": "+
+                             std::to_string(f.get_internal_view_data<const Real, Host>()[col_lid]) +
+                             "\n";
+        }
+      }
     }
+
   } else {
     res_and_msg.msg = "FieldNaNCheck passed.\n";
   }

--- a/components/eamxx/src/share/property_checks/field_nan_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_nan_check.cpp
@@ -138,7 +138,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
       col_lid = indices[0];
       auto gids = m_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
 
-      res_and_msg.msg += "  - entry (" + std::to_string(gids(col_lid));;
+      res_and_msg.msg += "  - indices (w/ global column index): (" + std::to_string(gids(col_lid));
       for (size_t i=1; i<indices.size(); ++i) {
         res_and_msg.msg += "," + std::to_string(indices[i]);
       }
@@ -152,7 +152,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
       bool has_additional_col_info = not additional_data_fields().empty();
       if (has_additional_col_info) {
         std::stringstream msg;
-        msg << "  - additional data:\n";
+        msg << "  - additional data (w/ local column index):\n";
         for (auto& f : additional_data_fields()) {
           f.sync_to_host();
           msg << "\n";

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
@@ -1,5 +1,6 @@
 #include "share/property_checks/field_within_interval_check.hpp"
 #include "share/util/scream_array_utils.hpp"
+#include "share/field/field_utils.hpp"
 
 #include <ekat/util/ekat_math_utils.hpp>
 
@@ -281,12 +282,13 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     }
   }
   if (has_additional_col_info) {
+    msg << "    - additional data:\n";
     for (auto& f : additional_data_fields()) {
       f.sync_to_host();
-      msg << "    - " << f.name() << ": "
-          << f.get_internal_view_data<const Real, Host>()[min_col_lid]
-          << "\n";
+      msg << "\n";
+      print_field_hyperslab(f, {COL}, {min_col_lid}, msg);
     }
+    msg << "\n    END OF ADDITIONAL DATA\n";
   }
 
   msg << "  - maximum:\n";
@@ -303,12 +305,13 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     }
   }
   if (has_additional_col_info) {
+    msg << "    - additional data:\n";
     for (auto& f : additional_data_fields()) {
       f.sync_to_host();
-      msg << "    - " << f.name() << ": "
-          << f.get_internal_view_data<const Real, Host>()[max_col_lid]
-          << "\n";
+      msg << "\n";
+      print_field_hyperslab(f, {COL}, {max_col_lid}, msg);
     }
+    msg << "\n    END OF ADDITIONAL DATA\n";
   }
 
   res_and_msg.msg += msg.str();

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
@@ -249,12 +249,12 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
 
   using namespace ShortFieldTagsNames;
 
-  int min_col_lid, max_col_lid;
-  bool has_latlon;
+  int min_col_lid = -1, max_col_lid = -1;
+  bool has_latlon = false;
   bool has_col_info = m_grid and layout.tag(0)==COL;
   bool has_additional_col_info = not additional_data_fields().empty();
-  const Real* lat;
-  const Real* lon;
+  const Real* lat = nullptr;
+  const Real* lon = nullptr;
 
   if (has_col_info) {
     // We are storing grid info, and the field is over columns. Get col id and coords.
@@ -272,7 +272,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
   msg << "    - value: " << minmaxloc.min_val << "\n";
   if (has_col_info) {
     auto gids = m_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
-    msg << "    - entry: (" << gids(min_col_lid);
+    msg << "    - indices (w/ global column index): (" << gids(min_col_lid);
     for (size_t i=1; i<idx_min.size(); ++i) {
       msg << "," << idx_min[i];
     }
@@ -282,20 +282,20 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     }
   }
   if (has_additional_col_info) {
-    msg << "    - additional data:\n";
+    msg << "    - additional data (w/ local column index):\n";
     for (auto& f : additional_data_fields()) {
       f.sync_to_host();
       msg << "\n";
       print_field_hyperslab(f, {COL}, {min_col_lid}, msg);
     }
-    msg << "\n    END OF ADDITIONAL DATA\n";
+    msg << "\n    END OF ADDITIONAL DATA\n\n";
   }
 
   msg << "  - maximum:\n";
   msg << "    - value: " << minmaxloc.max_val << "\n";
   if (has_col_info) {
     auto gids = m_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
-    msg << "    - entry: (" << gids(max_col_lid);
+    msg << "    - indices (w/ global column index): (" << gids(max_col_lid);
     for (size_t i=1; i<idx_max.size(); ++i) {
       msg << "," << idx_max[i];
     }
@@ -305,7 +305,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     }
   }
   if (has_additional_col_info) {
-    msg << "    - additional data:\n";
+    msg << "    - additional data (w/ local column index):\n";
     for (auto& f : additional_data_fields()) {
       f.sync_to_host();
       msg << "\n";

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
@@ -251,6 +251,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
   int min_col_lid, max_col_lid;
   bool has_latlon;
   bool has_col_info = m_grid and layout.tag(0)==COL;
+  bool has_additional_col_info = not additional_data_fields().empty();
   const Real* lat;
   const Real* lon;
 
@@ -279,6 +280,14 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
       msg << "    - lat/lon: (" << lat[min_col_lid] << ", " << lon[min_col_lid] << ")\n";
     }
   }
+  if (has_additional_col_info) {
+    for (auto& f : additional_data_fields()) {
+      f.sync_to_host();
+      msg << "    - " << f.name() << ": "
+          << f.get_internal_view_data<const Real, Host>()[min_col_lid]
+          << "\n";
+    }
+  }
 
   msg << "  - maximum:\n";
   msg << "    - value: " << minmaxloc.max_val << "\n";
@@ -291,6 +300,14 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     msg << ")\n";
     if (has_latlon) {
       msg << "    - lat/lon: (" << lat[max_col_lid] << ", " << lon[max_col_lid] << ")\n";
+    }
+  }
+  if (has_additional_col_info) {
+    for (auto& f : additional_data_fields()) {
+      f.sync_to_host();
+      msg << "    - " << f.name() << ": "
+          << f.get_internal_view_data<const Real, Host>()[max_col_lid]
+          << "\n";
     }
   }
 

--- a/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
+++ b/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
@@ -225,6 +225,7 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
     lat = m_grid->get_geometry_data("lat").get_view<const Real*, Host>();
     lon = m_grid->get_geometry_data("lon").get_view<const Real*, Host>();
   }
+  const bool has_additional_col_info = not additional_data_fields().empty();
 
   std::stringstream msg;
   msg << "Check failed.\n"
@@ -236,6 +237,14 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
     if (has_latlon) {
       msg << "    - (lat, lon): (" << lat(maxloc_mass.loc) << ", " << lon(maxloc_mass.loc) << ")\n";
     }
+    if (has_additional_col_info) {
+      for (auto& f : additional_data_fields()) {
+        f.sync_to_host();
+        msg << "    - " << f.name() << ": "
+            << f.get_internal_view_data<const Real, Host>()[maxloc_mass.loc]
+            << "\n";
+      }
+    }
     res_and_msg.fail_loc_indices.resize(1,maxloc_mass.loc);
     res_and_msg.fail_loc_tags = m_fields.at("phis").get_header().get_identifier().get_layout().tags();
   }
@@ -245,6 +254,14 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
         << "    - global dof: " << gids(maxloc_energy.loc) << "\n";
     if (has_latlon) {
       msg << "    - (lat, lon): (" << lat(maxloc_energy.loc) << ", " << lon(maxloc_energy.loc) << ")\n";
+    }
+    if (has_additional_col_info) {
+      for (auto& f : additional_data_fields()) {
+        f.sync_to_host();
+        msg << "    - " << f.name() << ": "
+            << f.get_internal_view_data<const Real, Host>()[maxloc_energy.loc]
+            << "\n";
+      }
     }
     res_and_msg.fail_loc_indices.resize(1,maxloc_energy.loc);
     res_and_msg.fail_loc_tags = m_fields.at("phis").get_header().get_identifier().get_layout().tags();

--- a/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
+++ b/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
@@ -241,7 +241,7 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
       msg << "    - (lat, lon): (" << lat(maxloc_mass.loc) << ", " << lon(maxloc_mass.loc) << ")\n";
     }
     if (has_additional_col_info) {
-      msg << "    - additional data:\n";
+      msg << "    - additional data (w/ local column index):\n";
       for (auto& f : additional_data_fields()) {
         f.sync_to_host();
         msg << "\n";
@@ -260,7 +260,7 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
       msg << "    - (lat, lon): (" << lat(maxloc_energy.loc) << ", " << lon(maxloc_energy.loc) << ")\n";
     }
     if (has_additional_col_info) {
-      msg << "    - additional data:\n";
+      msg << "    - additional data (w/ local column index):\n";
       for (auto& f : additional_data_fields()) {
         f.sync_to_host();
         msg << "\n";

--- a/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
+++ b/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
@@ -1,5 +1,7 @@
 #include "share/property_checks/mass_and_energy_column_conservation_check.hpp"
 #include "physics/share/physics_constants.hpp"
+#include "share/field/field_utils.hpp"
+
 #include <iomanip>
 
 namespace scream
@@ -226,6 +228,7 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
     lon = m_grid->get_geometry_data("lon").get_view<const Real*, Host>();
   }
   const bool has_additional_col_info = not additional_data_fields().empty();
+  using namespace ShortFieldTagsNames;
 
   std::stringstream msg;
   msg << "Check failed.\n"
@@ -238,12 +241,13 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
       msg << "    - (lat, lon): (" << lat(maxloc_mass.loc) << ", " << lon(maxloc_mass.loc) << ")\n";
     }
     if (has_additional_col_info) {
+      msg << "    - additional data:\n";
       for (auto& f : additional_data_fields()) {
         f.sync_to_host();
-        msg << "    - " << f.name() << ": "
-            << f.get_internal_view_data<const Real, Host>()[maxloc_mass.loc]
-            << "\n";
+        msg << "\n";
+        print_field_hyperslab(f, {COL}, {maxloc_mass.loc}, msg);
       }
+      msg << "\n    END OF ADDITIONAL DATA\n";
     }
     res_and_msg.fail_loc_indices.resize(1,maxloc_mass.loc);
     res_and_msg.fail_loc_tags = m_fields.at("phis").get_header().get_identifier().get_layout().tags();
@@ -256,12 +260,13 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
       msg << "    - (lat, lon): (" << lat(maxloc_energy.loc) << ", " << lon(maxloc_energy.loc) << ")\n";
     }
     if (has_additional_col_info) {
+      msg << "    - additional data:\n";
       for (auto& f : additional_data_fields()) {
         f.sync_to_host();
-        msg << "    - " << f.name() << ": "
-            << f.get_internal_view_data<const Real, Host>()[maxloc_energy.loc]
-            << "\n";
+        msg << "\n";
+        print_field_hyperslab(f, {COL}, {maxloc_energy.loc}, msg);
       }
+      msg << "\n    END OF ADDITIONAL DATA\n";
     }
     res_and_msg.fail_loc_indices.resize(1,maxloc_energy.loc);
     res_and_msg.fail_loc_tags = m_fields.at("phis").get_header().get_identifier().get_layout().tags();

--- a/components/eamxx/src/share/property_checks/property_check.cpp
+++ b/components/eamxx/src/share/property_checks/property_check.cpp
@@ -52,6 +52,23 @@ set_fields (const std::list<Field>& fields,
   }
 }
 
+void PropertyCheck::
+set_additional_data_field (const Field& data_field)
+{
+  EKAT_REQUIRE_MSG(data_field.rank() == 1 &&
+                   data_field.get_header().get_identifier().get_layout().has_tag(FieldTag::Column),
+                   "Error! Additional data field \""+data_field.name()+"\" for property check \""
+                   +name()+"\" must be a column-only field.\n");
+
+  // Only add field if it currently does not exist in additional fields list.
+  const bool found_field_in_list = std::find(m_additional_data_fields.begin(),
+                                             m_additional_data_fields.end(),
+                                             data_field) != m_additional_data_fields.end();
+  if (not found_field_in_list) {
+    m_additional_data_fields.push_back(data_field);
+  }
+}
+
 // If a check fails, attempt to repair things. Default is to throw.
 void PropertyCheck::repair () const {
   EKAT_REQUIRE_MSG (can_repair(),

--- a/components/eamxx/src/share/property_checks/property_check.cpp
+++ b/components/eamxx/src/share/property_checks/property_check.cpp
@@ -55,10 +55,9 @@ set_fields (const std::list<Field>& fields,
 void PropertyCheck::
 set_additional_data_field (const Field& data_field)
 {
-  EKAT_REQUIRE_MSG(data_field.rank() == 1 &&
-                   data_field.get_header().get_identifier().get_layout().has_tag(FieldTag::Column),
+  EKAT_REQUIRE_MSG(data_field.get_header().get_identifier().get_layout().has_tag(FieldTag::Column),
                    "Error! Additional data field \""+data_field.name()+"\" for property check \""
-                   +name()+"\" must be a column-only field.\n");
+                   +name()+"\" must be defined on columns.\n");
 
   // Only add field if it currently does not exist in additional fields list.
   const bool found_field_in_list = std::find(m_additional_data_fields.begin(),

--- a/components/eamxx/src/share/property_checks/property_check.hpp
+++ b/components/eamxx/src/share/property_checks/property_check.hpp
@@ -13,7 +13,7 @@ namespace scream
 
 /*
  * Abstract interface for property checks
- * 
+ *
  * A property check (PC) object is responsible to check that
  * a certain property holds. The class can (but does not have to)
  * also implement a way to 'repair' the simulation if
@@ -21,13 +21,13 @@ namespace scream
  *
  * PC's are stored in an AtmosphereProcess (AP), and can be
  * run before and/or after the process is executed.
- * 
+ *
  * The typical class deriving from this interface will implement
  * some checks on one or more Field objects, verifying that they
  * satisfy the properties. For instance, we can check that a
  * Field does not contain NaN values, or that it is always within
  * certain bounds.
- * 
+ *
  * More complicate checks can verify that 2+ fields together verify
  * a certain property. For instance, we might want to verify that
  * the sum of certain quantities stay the same (like an energy or
@@ -76,6 +76,10 @@ public:
   void set_fields (const std::list<Field>& fields,
                    const std::list<bool>& repairable);
 
+  // Additional column data fields can be added to output
+  // stream of any property check. 
+  void set_additional_data_field (const Field& data_field);
+
   // Whether this PC is capable of fixing things if the check fails.
   // Defaults to false.
   bool can_repair() const {
@@ -95,6 +99,11 @@ public:
   // returns an empty list.
   const std::list<Field*>& repairable_fields () const {
     return m_repairable_fields;
+  }
+
+  // Return additional data fields used in this property check
+  const std::list<Field>& additional_data_fields () const {
+    return m_additional_data_fields;
   }
 
   // If a check fails, attempt to repair things. Default is to throw.
@@ -117,6 +126,8 @@ protected:
 
   std::list<Field>    m_fields;
   std::list<Field*>   m_repairable_fields;
+
+  std::list<Field> m_additional_data_fields;
 };
 
 } // namespace scream

--- a/components/eamxx/src/share/tests/property_checks.cpp
+++ b/components/eamxx/src/share/tests/property_checks.cpp
@@ -83,15 +83,24 @@ TEST_CASE("property_checks", "") {
   // Create a field
   std::vector<FieldTag> tags = {COL, CMP, LEV};
   std::vector<int> dims = {num_lcols, 3, nlevs};
-  FieldIdentifier fid ("field_1",{tags,dims}, m/s,"some_grid");
+  FieldIdentifier fid ("field_1", {tags,dims}, m/s,"some_grid");
   Field f(fid);
   f.allocate_view();
+
+  // Create additional data
+  std::vector<FieldTag> tags_data = {COL};
+  std::vector<int> dims_data = {num_lcols};
+  FieldIdentifier data_fid("data", {tags_data, dims_data}, m/s, "some_grid");
+  Field data(data_fid);
+  data.allocate_view();
+  data.deep_copy(1.0);
 
   // Check that values are not NaN
   SECTION("field_not_nan_check") {
     const auto num_reals = f.get_header().get_alloc_properties().get_num_scalars();
 
     auto nan_check = std::make_shared<FieldNaNCheck>(f,grid);
+    nan_check->set_additional_data_field(data);
 
     // Assign  values to the field and make sure it passes our test for NaNs.
     auto f_data = reinterpret_cast<Real*>(f.get_internal_view_data<Real,Host>());
@@ -106,11 +115,18 @@ TEST_CASE("property_checks", "") {
     f.sync_to_dev();
     res_and_msg = nan_check->check();
     REQUIRE(res_and_msg.result==CheckResult::Fail);
+    
     std::string expected_msg =
       "FieldNaNCheck failed.\n"
       "  - field id: " + fid.get_id_string() + "\n"
-      "  - entry (1,2,3)\n"
-      "  - lat/lon: (1.000000, -1.000000)\n";
+      "  - indices (w/ global column index): (1,2,3)\n"
+      "  - lat/lon: (1.000000, -1.000000)\n"
+      "  - additional data (w/ local column index):\n\n"
+      "     data<ncol>(2)\n\n"+
+      "  data(1)\n"+
+      "    1, \n\n"+
+      "  END OF ADDITIONAL DATA\n";
+
     REQUIRE( res_and_msg.msg == expected_msg );
   }
 
@@ -120,6 +136,8 @@ TEST_CASE("property_checks", "") {
 
     auto interval_check = std::make_shared<FieldWithinIntervalCheck>(f, grid, 0, 1, true);
     REQUIRE(interval_check->can_repair());
+
+    interval_check->set_additional_data_field(data);
 
     // Assign in-bound values to the field and make sure it passes the within-interval check
     auto f_data = reinterpret_cast<Real*>(f.get_internal_view_data<Real,Host>());
@@ -143,12 +161,22 @@ TEST_CASE("property_checks", "") {
       "  - field id: " + fid.get_id_string() + "\n"
       "  - minimum:\n"
       "    - value: 0\n"
-      "    - entry: (0,1,2)\n"
+      "    - indices (w/ global column index): (0,1,2)\n"
       "    - lat/lon: (0, 0)\n"
+      "    - additional data (w/ local column index):\n\n"
+      "     data<ncol>(2)\n\n"
+      "  data(0)\n"
+      "    1, \n\n"
+      "    END OF ADDITIONAL DATA\n\n"
       "  - maximum:\n"
       "    - value: 2\n"
-      "    - entry: (1,2,3)\n"
-      "    - lat/lon: (1, -1)\n";
+      "    - indices (w/ global column index): (1,2,3)\n"
+      "    - lat/lon: (1, -1)\n"
+      "    - additional data (w/ local column index):\n\n"
+      "     data<ncol>(2)\n\n"
+      "  data(1)\n"
+      "    1, \n\n"
+      "    END OF ADDITIONAL DATA\n";
 
     REQUIRE(res_and_msg.msg == expected_msg);
 
@@ -191,11 +219,11 @@ TEST_CASE("property_checks", "") {
       "  - field id: " + fid.get_id_string() + "\n"
       "  - minimum:\n"
       "    - value: -2\n"
-      "    - entry: (0,0,0)\n"
+      "    - indices (w/ global column index): (0,0,0)\n"
       "    - lat/lon: (0, 0)\n"
       "  - maximum:\n"
       "    - value: 3\n"
-      "    - entry: (1,2,11)\n"
+      "    - indices (w/ global column index): (1,2,11)\n"
       "    - lat/lon: (1, -1)\n";
 
     REQUIRE(res_and_msg.msg == expected_msg);

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -5,6 +5,7 @@ driver_options:
   mass_column_conservation_error_tolerance: 1e-3
   energy_column_conservation_error_tolerance: 1e-4
   column_conservation_checks_fail_handling_type: Warning
+  property_check_data_fields: [phis]
 
 time_stepping:
   time_step: ${ATM_TIME_STEP}


### PR DESCRIPTION
@oksanaguba asked for `landfrac` and `phis` to be output at failing indices of property checks. This PR lets the driver query if either field exists and then adds then to an internal list in the property check class, where the fail/warning message includes the value alongside lat/lon.

If interested, this could be even more general, adding a driver option in the input.yaml to include field names the user is requesting, instead of hardcoding phis/landfrac.