### PR TITLE
Convert advance_iop_subsidence

### DIFF
--- a/components/eamxx/src/physics/dp/dp_functions.hpp
+++ b/components/eamxx/src/physics/dp/dp_functions.hpp
@@ -153,6 +153,7 @@ struct Functions
   KOKKOS_INLINE_FUNCTION
   static void do_advance_iop_subsidence_update(
     const Int& k,
+    const Int& plev,
     const Spack& fac,
     const Spack& swfldint,
     const Spack& swfldint_p1,

--- a/components/eamxx/src/physics/dp/dp_functions.hpp
+++ b/components/eamxx/src/physics/dp/dp_functions.hpp
@@ -150,8 +150,47 @@ struct Functions
   KOKKOS_FUNCTION
   static void advance_iop_nudging(const Int& plev, const Spack& scm_dt, const Spack& ps_in, const uview_1d<const Spack>& t_in, const uview_1d<const Spack>& q_in, const uview_1d<Spack>& t_update, const uview_1d<Spack>& q_update, const uview_1d<Spack>& relaxt, const uview_1d<Spack>& relaxq);
 
+  KOKKOS_INLINE_FUNCTION
+  static void do_advance_iop_subsidence_update(
+    const Int& k,
+    const Spack& fac,
+    const Spack& swfldint,
+    const Spack& swfldint_p1,
+    const uview_1d<const Spack>& in,
+    const uview_1d<const Scalar>& in_s,
+    const uview_1d<Spack>& update);
+
+  //-----------------------------------------------------------------------
+  //
+  // Purpose:
+  // Option to compute effects of large scale subsidence on T, q, u, and v.
+  // Code originated from CAM3.5/CAM5 Eulerian subsidence computation for SCM
+  // in the old forecast.f90 routine.
+  //-----------------------------------------------------------------------
   KOKKOS_FUNCTION
-  static void advance_iop_subsidence(const Int& plev, const Int& pcnst, const Spack& scm_dt, const Spack& ps_in, const uview_1d<const Spack>& u_in, const uview_1d<const Spack>& v_in, const uview_1d<const Spack>& t_in, const uview_1d<const Spack>& q_in, const uview_1d<Spack>& u_update, const uview_1d<Spack>& v_update, const uview_1d<Spack>& t_update, const uview_1d<Spack>& q_update);
+  static void advance_iop_subsidence(
+    // Input arguments
+    const Int& plev,                   // number of vertical levels
+    const Int& pcnst,                  // number of advected constituents including cloud water
+    const Scalar& scm_dt,              // model time step [s]
+    const Scalar& ps_in,               // surface pressure [Pa]
+    const uview_1d<const Spack>& u_in, // zonal wind [m/s]
+    const uview_1d<const Spack>& v_in, // meridional wind [m/s]
+    const uview_1d<const Spack>& t_in, // temperature [K]
+    const uview_2d<const Spack>& q_in, // tracer [vary]
+    const uview_1d<const Spack>& hyai, // ps0 component of hybrid coordinate - interfaces
+    const uview_1d<const Spack>& hyam, // ps0 component of hybrid coordinate - midpoints
+    const uview_1d<const Spack>& hybi, // ps component of hybrid coordinate - interfaces
+    const uview_1d<const Spack>& hybm, // ps component of hybrid coordinate - midpoints
+    const uview_1d<const Spack>& wfld, // Vertical motion (slt)
+    // Kokkos stuff
+    const MemberType& team,
+    const Workspace& workspace,
+    // Output arguments
+    const uview_1d<Spack>& u_update,   // zonal wind [m/s]
+    const uview_1d<Spack>& v_update,   // meridional wind [m/s]
+    const uview_1d<Spack>& t_update,   // temperature [m/s]
+    const uview_2d<Spack>& q_update);  // tracer [vary]
 
   KOKKOS_FUNCTION
   static void iop_setinitial(const Int& nelemd, const uview_1d<element_t>& elem);

--- a/components/eamxx/src/physics/dp/dp_functions_f90.cpp
+++ b/components/eamxx/src/physics/dp/dp_functions_f90.cpp
@@ -222,10 +222,69 @@ void advance_iop_nudging_f(Int plev, Real scm_dt, Real ps_in, Real* t_in, Real* 
 {
   // TODO
 }
-void advance_iop_subsidence_f(Int plev, Int pcnst, Real scm_dt, Real ps_in, Real* u_in, Real* v_in, Real* t_in, Real* q_in, Real* u_update, Real* v_update, Real* t_update, Real* q_update)
+
+void advance_iop_subsidence_f(Int plev, Int pcnst, Real scm_dt, Real ps_in, Real* u_in, Real* v_in, Real* t_in, Real* q_in, Real* hyai, Real* hyam, Real* hybi, Real* hybm, Real* wfld, Real* u_update, Real* v_update, Real* t_update, Real* q_update)
 {
-  // TODO
+  using DPF  = Functions<Real, DefaultDevice>;
+
+  using Spack = typename DPF::Spack;
+  using view_1d = typename DPF::view_1d<Spack>;
+  using view_2d = typename DPF::view_2d<Spack>;
+  using KT = typename DPF::KT;
+  using ExeSpace = typename KT::ExeSpace;
+  using MemberType = typename DPF::MemberType;
+
+  // Some of the workspaces need plev+1 items
+  const Int plev_pack = ekat::npack<Spack>(plev);
+  const Int plevp_pack = ekat::npack<Spack>(plev+1);
+
+  // Set up views
+  std::vector<view_1d> temp_d(AdvanceIopSubsidenceData::NUM_ARRAYS-2);
+  std::vector<view_2d> temp_2d_d(2);
+
+  ekat::host_to_device({u_in, v_in, t_in, hyai, hyam, hybi, hybm, wfld, u_update, v_update, t_update},
+                       plev, temp_d);
+
+  ekat::host_to_device({ q_in, q_update },
+                       pcnst, plev, temp_2d_d, true);
+
+  view_1d
+    u_in_d       (temp_d[0]),
+    v_in_d       (temp_d[1]),
+    t_in_d       (temp_d[2]),
+    hyai_d       (temp_d[3]),
+    hyam_d       (temp_d[4]),
+    hybi_d       (temp_d[5]),
+    hybm_d       (temp_d[6]),
+    wfld_d       (temp_d[7]),
+    u_update_d   (temp_d[8]),
+    v_update_d   (temp_d[9]),
+    t_update_d   (temp_d[10]);
+
+  view_2d
+    q_in_d    (temp_2d_d[0]),
+    q_update_d(temp_2d_d[1]);
+
+  // Call core function from kernel
+  auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, plev_pack);
+  ekat::WorkspaceManager<Spack> wsm(plevp_pack, 4, policy);
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+
+      DPF::advance_iop_subsidence(
+        plev, pcnst, scm_dt, ps_in,
+        u_in_d, v_in_d, t_in_d, q_in_d, hyai_d, hyam_d, hybi_d, hybm_d, wfld_d,
+        team, wsm.get_workspace(team),
+        u_update_d, v_update_d, t_update_d, q_update_d);
+  });
+
+  // Sync back to host
+  std::vector<view_1d> inout_views    = {t_update_d, u_update_d, v_update_d};
+  std::vector<view_2d> inout_views_2d = {q_update_d};
+
+  ekat::device_to_host({t_update, u_update, v_update}, plev, inout_views);
+  ekat::device_to_host({q_update}, pcnst, plev, inout_views_2d, true);
 }
+
 void iop_setinitial_f(Int nelemd, element_t* elem)
 {
   // TODO

--- a/components/eamxx/src/physics/dp/dp_functions_f90.hpp
+++ b/components/eamxx/src/physics/dp/dp_functions_f90.hpp
@@ -60,16 +60,24 @@ struct AdvanceIopNudgingData : public PhysicsTestData {
 };
 
 struct AdvanceIopSubsidenceData : public PhysicsTestData {
+  static constexpr size_t NUM_ARRAYS = 13;
+
   // Inputs
   Int plev, pcnst;
   Real scm_dt, ps_in;
-  Real *u_in, *v_in, *t_in, *q_in;
+  Real *u_in, *v_in, *t_in, *q_in, *hyai, *hyam, *hybi, *hybm, *wfld;
 
   // Outputs
   Real *u_update, *v_update, *t_update, *q_update;
 
   AdvanceIopSubsidenceData(Int plev_, Int pcnst_, Real scm_dt_, Real ps_in_) :
-    PhysicsTestData({{ plev_ }, { plev_, pcnst_ }}, {{ &u_in, &v_in, &t_in, &u_update, &v_update, &t_update }, { &q_in, &q_update }}), plev(plev_), pcnst(pcnst_), scm_dt(scm_dt_), ps_in(ps_in_) {}
+    PhysicsTestData(
+      {{ plev_ }, { plev_, pcnst_ }},
+      {
+        { &u_in, &v_in, &t_in, &hyai, &hyam, &hybi, &hybm, &wfld, &u_update, &v_update, &t_update },
+        { &q_in, &q_update }
+      }),
+    plev(plev_), pcnst(pcnst_), scm_dt(scm_dt_), ps_in(ps_in_) {}
 
   PTD_STD_DEF(AdvanceIopSubsidenceData, 4, plev, pcnst, scm_dt, ps_in);
 };
@@ -225,7 +233,7 @@ extern "C" { // _f function decls
 
 void advance_iop_forcing_f(Int plev, Int pcnst, Real scm_dt, Real ps_in, bool have_u, bool have_v, bool dp_crm, bool use_3dfrc, Real* u_in, Real* v_in, Real* t_in, Real* q_in, Real* t_phys_frc, Real* divt3d, Real* divq3d, Real* divt, Real* divq, Real* wfld, Real* uobs, Real* vobs, Real* hyai, Real* hyam, Real* hybi, Real* hybm, Real* u_update, Real* v_update, Real* t_update, Real* q_update);
 void advance_iop_nudging_f(Int plev, Real scm_dt, Real ps_in, Real* t_in, Real* q_in, Real* t_update, Real* q_update, Real* relaxt, Real* relaxq);
-void advance_iop_subsidence_f(Int plev, Int pcnst, Real scm_dt, Real ps_in, Real* u_in, Real* v_in, Real* t_in, Real* q_in, Real* u_update, Real* v_update, Real* t_update, Real* q_update);
+void advance_iop_subsidence_f(Int plev, Int pcnst, Real scm_dt, Real ps_in, Real* u_in, Real* v_in, Real* t_in, Real* q_in, Real* hyai, Real* hyam, Real* hybi, Real* hybm, Real* wfld, Real* u_update, Real* v_update, Real* t_update, Real* q_update);
 void iop_setinitial_f(Int nelemd, element_t* elem);
 void iop_broadcast_f();
 void apply_iop_forcing_f(Int nelemd, element_t* elem, hvcoord_t* hvcoord, hybrid_t hybrid, timelevel_t tl, Int n, bool t_before_advance, Int nets, Int nete);

--- a/components/eamxx/src/physics/dp/impl/dp_advance_iop_forcing_impl.hpp
+++ b/components/eamxx/src/physics/dp/impl/dp_advance_iop_forcing_impl.hpp
@@ -43,8 +43,10 @@ void Functions<S,D>::plevs0(
   Kokkos::parallel_for(
     Kokkos::TeamVectorRange(team, nver_pack), [&] (Int k) {
       Spack spint, spint_1;
-      IntSmallPack idx = ekat::range<IntSmallPack>(k*Spack::n);
-      ekat::index_and_shift<1>(pint_s, idx, spint, spint_1);
+      IntSmallPack range_pack1 = ekat::range<IntSmallPack>(k*Spack::n);
+      auto range_pack2_p1_safe = range_pack1;
+      range_pack2_p1_safe.set(range_pack1 > nver-1, nver-1);
+      ekat::index_and_shift<1>(pint_s, range_pack2_p1_safe, spint, spint_1);
       pdel(k) = spint_1 - spint;
   });
 }

--- a/components/eamxx/src/physics/dp/tests/dp_advance_iop_forcing_tests.cpp
+++ b/components/eamxx/src/physics/dp/tests/dp_advance_iop_forcing_tests.cpp
@@ -28,6 +28,10 @@ struct UnitWrap::UnitTest<D>::TestAdvanceIopForcing {
       AdvanceIopForcingData(27,     7,    0.1,  1000.0,   true,   true,   true, true),
       AdvanceIopForcingData(27,     7,    0.1,  1000.0,   true,   true,   true, false),
       AdvanceIopForcingData(27,     7,    0.1,  1000.0,   true,   true,  false, true),
+
+      AdvanceIopForcingData(32,     7,    0.1,  1000.0,   true,   true,   true, true),
+      AdvanceIopForcingData(32,     7,    0.1,  1000.0,   true,   true,   true, false),
+      AdvanceIopForcingData(32,     7,    0.1,  1000.0,   true,   true,  false, true),
     };
 
     static constexpr Int num_runs = sizeof(f90_data) / sizeof(AdvanceIopForcingData);
@@ -47,6 +51,9 @@ struct UnitWrap::UnitTest<D>::TestAdvanceIopForcing {
       AdvanceIopForcingData(f90_data[3]),
       AdvanceIopForcingData(f90_data[4]),
       AdvanceIopForcingData(f90_data[5]),
+      AdvanceIopForcingData(f90_data[6]),
+      AdvanceIopForcingData(f90_data[7]),
+      AdvanceIopForcingData(f90_data[8]),
     };
 
     // Assume all data is in C layout

--- a/components/eamxx/src/physics/dp/tests/dp_advance_iop_subsidence_tests.cpp
+++ b/components/eamxx/src/physics/dp/tests/dp_advance_iop_subsidence_tests.cpp
@@ -20,7 +20,13 @@ struct UnitWrap::UnitTest<D>::TestAdvanceIopSubsidence {
     auto engine = setup_random_test();
 
     AdvanceIopSubsidenceData f90_data[] = {
-      // TODO
+      //                     plev, pcnst, scm_dt, ps_in
+      AdvanceIopSubsidenceData(72,    10,    0.1, 1000.0),
+      AdvanceIopSubsidenceData(72,     7,    0.1, 1000.0),
+      AdvanceIopSubsidenceData(27,    10,    0.1, 1000.0),
+      AdvanceIopSubsidenceData(27,     7,    0.1, 1000.0),
+      AdvanceIopSubsidenceData(32,    10,    0.1, 1000.0),
+      AdvanceIopSubsidenceData(32,     7,    0.1, 1000.0),
     };
 
     static constexpr Int num_runs = sizeof(f90_data) / sizeof(AdvanceIopSubsidenceData);
@@ -33,8 +39,13 @@ struct UnitWrap::UnitTest<D>::TestAdvanceIopSubsidence {
 
     // Create copies of data for use by cxx. Needs to happen before fortran calls so that
     // inout data is in original state
-    AdvanceIopSubsidenceData cxx_data[] = {
-      // TODO
+    AdvanceIopSubsidenceData cxx_data[num_runs] = {
+      AdvanceIopSubsidenceData(f90_data[0]),
+      AdvanceIopSubsidenceData(f90_data[1]),
+      AdvanceIopSubsidenceData(f90_data[2]),
+      AdvanceIopSubsidenceData(f90_data[3]),
+      AdvanceIopSubsidenceData(f90_data[4]),
+      AdvanceIopSubsidenceData(f90_data[5]),
     };
 
     // Assume all data is in C layout
@@ -47,11 +58,14 @@ struct UnitWrap::UnitTest<D>::TestAdvanceIopSubsidence {
 
     // Get data from cxx
     for (auto& d : cxx_data) {
-      d.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
-      advance_iop_subsidence_f(d.plev, d.pcnst, d.scm_dt, d.ps_in, d.u_in, d.v_in, d.t_in, d.q_in, d.u_update, d.v_update, d.t_update, d.q_update);
-      d.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
+      d.template transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+      advance_iop_subsidence_f(d.plev, d.pcnst, d.scm_dt, d.ps_in, d.u_in, d.v_in, d.t_in, d.q_in, d.hyai, d.hyam, d.hybi, d.hybm, d.wfld, d.u_update, d.v_update, d.t_update, d.q_update);
+      d.template transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
     }
 
+    // We can't call into fortran. Due to all the dependencies it has, it's not possible
+    // to build it in standalone eamxx. Without fortran, we cannot do BFB tests.
+#if 0
     // Verify BFB results, all data should be in C layout
     if (SCREAM_BFB_TESTING) {
       for (Int i = 0; i < num_runs; ++i) {
@@ -72,6 +86,7 @@ struct UnitWrap::UnitTest<D>::TestAdvanceIopSubsidence {
 
       }
     }
+#endif
   } // run_bfb
 
 };


### PR DESCRIPTION
It's important to add tests for which the plev falls right on a pack boundary. This helps catch errors where index_and_shfit might go out of bounds and plev+1, a common array size, would also go out of bounds.