### PR TITLE
rework the github actions logic with some improvements

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,30 +1,55 @@
 # This workflow aims to automatically rebuild eamxx documentation
-# every time the master branch is updated on github
-name: Build and deploy gh-pages branch with Mkdocs
+# every time the master branch is updated on github and within every PR
+
+name: EAMxx Docs
 
 on:
   # Runs every time master branch is updated
   push:
-    branches: ["master"]
+    branches: [ master ]
+  # Runs every time master a PR is open against master
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:
-  Build-and-Deploy-docs:
+
+  emaxx-docs:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out the repository
+        uses: actions/checkout@v3
         with:
-          repository: e3sm-project/scream
-          ref: master
           fetch-depth: 0 # Needed, or else gh-pages won't be fetched, and push rejected
           submodules: recursive
+  
       - name: Show action trigger
-        run: echo "= The job was automatically triggered by a ${{github.event_name}} event."
-      - name: Install python deps
-        run: python3 -m pip install mkdocs pymdown-extensions mkdocs-material
-      - name: Generate eamxx params docs
-        run: ./eamxx-params-docs-autogen
+        run: |
+          echo "= The job was automatically triggered by a ${{github.event_name}} event."
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4.7.0
+        with:
+          python-version: "3.10"
+
+      - name: Install Python deps
+        run: |
+          pip install mkdocs pymdown-extensions mkdocs-material mdutils
+  
+      - name: Generate EAMxx params docs
         working-directory: components/eamxx/scripts
-      - name: Build and deploy
+        run: |
+          ./eamxx-params-docs-autogen
+
+      - name: Build docs
         working-directory: components/eamxx
-        run: mkdocs build && mkdocs gh-deploy
+        run: |
+          mkdocs build 
+
+      # only deploy when there is a push to master
+      - if: ${{ github.event_name == 'push' }}
+        name: Deploy docs
+        working-directory: components/eamxx
+        run: |
+          mkdocs gh-deploy

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -45,11 +45,11 @@ jobs:
       - name: Build docs
         working-directory: components/eamxx
         run: |
-          mkdocs build 
+          mkdocs build --strict --verbose
 
       # only deploy when there is a push to master
       - if: ${{ github.event_name == 'push' }}
         name: Deploy docs
         working-directory: components/eamxx
         run: |
-          mkdocs gh-deploy
+          mkdocs gh-deploy --verbose

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
   # Runs every time master branch is updated
   push:
     branches: [ master ]
-  # Runs every time master a PR is open against master
+  # Runs every time a PR is open against master
   pull_request:
     branches: [ master ]
   workflow_dispatch:

--- a/components/eamxx/docs/index.md
+++ b/components/eamxx/docs/index.md
@@ -1,8 +1,8 @@
 # The C++ E3SM Atmosphere Model (EAMxx)
 
-Some nice introductory text goes here! Maybe some figures, too. Who knows?
+Some nice introductory text goes here! Maybe some figures, too. Who knows?!
 
 * The [User Guide](user/index.md) guide explains how to run EAMxx, both in
   its standalone configuration and within E3SM.
-* The [Developer Guide](dev/index.md) guide contains all the information needed
+* The [Developer Guide](developer/index.md) guide contains all the information needed
   to contribute to the development of EAMxx.

--- a/components/eamxx/scripts/eamxx-params-docs-autogen
+++ b/components/eamxx/scripts/eamxx-params-docs-autogen
@@ -2,7 +2,7 @@
 
 """
 This script parses the file `cime_config/namelist_defaults_scream.xml'
-and generates the markdown file `docs/mkdocs/docs/common/eamxx_params.md`,
+and generates the markdown file `docs/common/eamxx_params.md`,
 containing all the runtime parameters that can be configured via calls
 to `atmchange` (in the case folder). For each parameter, we also report
 a doc string and its type, as well as, if present, constraints and valid values.
@@ -86,7 +86,7 @@ def generate_params_docs():
 
     eamxx = pathlib.Path(__file__).parent.parent.resolve()
     xml_defaults_file = eamxx / "cime_config" / "namelist_defaults_scream.xml"
-    output_file = eamxx / "docs" / "mkdocs" / "docs" / "common" / "eamxx_params.md"
+    output_file = eamxx / "docs" / "common" / "eamxx_params.md"
 
     print("Generating eamxx params documentation...")
     print(f"  output file: {output_file}")


### PR DESCRIPTION
Minor improvements and ensuring CI passes.

- explicitly specify python version
- run both on PRs and pushes to main (if guard on deploy)
- use action to fetch (don't fetch remote repo, but repo where the runner is starting from, e.g. in PR)
- separate python setup and python deps (explicitly ask for mdutils which was missing)
- actually ensure the action is passing as it was failing for a bit: https://github.com/E3SM-Project/scream/actions

<details><summary>still todo later</summary>
<p>

- [ ] add dependabot for managing all these random actions 
- [ ] think about making this more interactive
- [ ] use a more streamline pusher rather than manual  
- [ ] rename gh-pages.yml to something eamxx specific as this will likely need to go into other e3sm repos

</p>
</details> 