### PR TITLE
More improvements to gh-pages docs workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,6 +10,7 @@ on:
   # Runs every time a PR is open against master
   pull_request:
     branches: [ master ]
+
   workflow_dispatch:
 
 jobs:
@@ -21,7 +22,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # Needed, or else gh-pages won't be fetched, and push rejected
+          # TODO: git rid of dependency on CIME
           submodules: recursive
   
       - name: Show action trigger
@@ -47,9 +48,10 @@ jobs:
         run: |
           mkdocs build --strict --verbose
 
-      # only deploy when there is a push to master
       - if: ${{ github.event_name == 'push' }}
-        name: Deploy docs
-        working-directory: components/eamxx
-        run: |
-          mkdocs gh-deploy --verbose
+        name: GitHub Pages action
+        uses: peaceiris/actions-gh-pages@v3.9.3
+        with:
+          # information about GITHUB_TOKEN are in settings
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./components/eamxx/site

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
 
-  emaxx-docs:
+  eamxx-docs:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,6 +23,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           # TODO: git rid of dependency on CIME
+          # TODO: another option to investigate is a sparse checkout. 
+          # In the scream repo, all other components do not need to be checked out. 
+          # And even in the upstream, we mainly need only components/xyz/docs (and a few more places).
           submodules: true
   
       - name: Show action trigger

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           # TODO: git rid of dependency on CIME
-          submodules: recursive
+          submodules: true
   
       - name: Show action trigger
         run: |
@@ -48,6 +48,7 @@ jobs:
         run: |
           mkdocs build --strict --verbose
 
+      # only deploy when there is a push to master
       - if: ${{ github.event_name == 'push' }}
         name: GitHub Pages action
         uses: peaceiris/actions-gh-pages@v3.9.3


### PR DESCRIPTION
Motivation: There was still a failure after merging the ml_correction PR (perhaps due to lack of sync? see https://github.com/E3SM-Project/scream/actions/runs/6019310104/job/16328947146) and this workflow adjustment should hopefully be more robust in the future. 

- reduces fetch-depth (slightly quicker); we still need to get rid of CIME dependency in the doc generation logic, but that will wait for later
- use more standard and automated action to push generated docs: https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#readme (instead of previous manual pushing via mkdocs deploy)

⚠️ before we merge, @bartgol, we need to go over the `secrets.GITHUB_TOKEN` to 1) set the permissions correctly and 2)  see if it is okay with hierarchy to enable it (it is relatively safe and automated, but we can fine-grain it). More info: https://docs.github.com/en/actions/security-guides/automatic-token-authentication

