### PR TITLE
Remove ML correction from coupler CMakelist

### DIFF
--- a/components/eamxx/src/mct_coupling/CMakeLists.txt
+++ b/components/eamxx/src/mct_coupling/CMakeLists.txt
@@ -40,7 +40,6 @@ set (SCREAM_LIBS
      spa
      nudging
      diagnostics
-     ml_correction
 )
 if (SCREAM_ENABLE_MAM)
   set(SCREAM_LIBS ${SCREAM_LIBS} mam)


### PR DESCRIPTION
PR #2442 broke nightly tests since it was not tested properly on all machines. This PR temporary disable ML correction from being compiled and should allow nightly tests to run normally.

We will re-enable this once all machines can build ML correction properly.