### PR TITLE
atmchange: do not fail on missing entry when not buffering

### DIFF
--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -10,25 +10,25 @@ from collections import OrderedDict
 import xml.etree.ElementTree as ET
 import xml.dom.minidom as md
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","cime")
-sys.path.append(os.path.join(_CIMEROOT, "CIME", "Tools"))
-
 # Add path to scream libs
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"))
-
-# Cime imports
-from standard_script_setup import * # pylint: disable=wildcard-import
-from CIME.utils import expect, safe_copy, SharedArea
 
 # SCREAM imports
 from eamxx_buildnml_impl import get_valid_selectors, get_child, refine_type, \
         resolve_all_inheritances, gen_atm_proc_group, check_all_values
 from atm_manip import atm_config_chg_impl, unbuffer_changes, apply_buffer
 
-from utils import ensure_yaml
+from utils import ensure_yaml # pylint: disable=no-name-in-module
 ensure_yaml()
 import yaml
 from yaml_utils import Bools,Ints,Floats,Strings,array_representer
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","cime")
+sys.path.append(os.path.join(_CIMEROOT, "CIME", "Tools"))
+
+# Cime imports
+from standard_script_setup import * # pylint: disable=wildcard-import
+from CIME.utils import expect, safe_copy, SharedArea
 
 logger = logging.getLogger(__name__) # pylint: disable=undefined-variable
 

--- a/components/eamxx/cime_config/eamxx_buildnml_impl.py
+++ b/components/eamxx/cime_config/eamxx_buildnml_impl.py
@@ -246,13 +246,22 @@ def refine_type(entry, force_type=None):
             expect (force_type is None or is_array_type(force_type),
                     "Error! Invalid type '{}' for an array.".format(force_type))
 
-            elem_type = force_type if force_type is None else array_elem_type(force_type)
-            result = [refine_type(item.strip(), force_type=elem_type) for item in entry.split(",") if item.strip() != ""]
-            result = make_array(result,'string' if elem_type is None else elem_type)
+            if force_type is None:
+                # Try to derive type from first element
+                elem_type = derive_type([item.strip() for item in entry.split(",")][0])
+            else:
+                elem_type = force_type if force_type is None else array_elem_type(force_type)
+
+            try:
+                result = [refine_type(item.strip(), force_type=elem_type) for item in entry.split(",") if item.strip() != ""]
+            except ValueError:
+                expect(False, "List '{}' has inconsistent types inside".format(entry))
+
+            result = make_array(result, "string" if elem_type is None else elem_type)
             expected_type = type(result[0])
             for item in result[1:]:
                 expect(isinstance(item, expected_type),
-                      "List '{}' has inconsistent types inside".format(entry))
+                       "List '{}' has inconsistent types inside".format(entry))
 
             return result
 

--- a/components/eamxx/cime_config/eamxx_buildnml_impl.py
+++ b/components/eamxx/cime_config/eamxx_buildnml_impl.py
@@ -250,7 +250,7 @@ def refine_type(entry, force_type=None):
                 # Try to derive type from first element
                 elem_type = derive_type([item.strip() for item in entry.split(",")][0])
             else:
-                elem_type = force_type if force_type is None else array_elem_type(force_type)
+                elem_type = array_elem_type(force_type)
 
             try:
                 result = [refine_type(item.strip(), force_type=elem_type) for item in entry.split(",") if item.strip() != ""]

--- a/components/eamxx/cime_config/yaml_utils.py
+++ b/components/eamxx/cime_config/yaml_utils.py
@@ -2,7 +2,7 @@
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"))
 
-from utils import ensure_yaml
+from utils import ensure_yaml # pylint: disable=no-name-in-module
 ensure_yaml()
 import yaml
 

--- a/components/eamxx/cime_config/yaml_utils.py
+++ b/components/eamxx/cime_config/yaml_utils.py
@@ -1,3 +1,7 @@
+# Add path to scream libs
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"))
+
 from utils import ensure_yaml
 ensure_yaml()
 import yaml
@@ -26,9 +30,9 @@ class Strings(Array):
 ###############################################################################
 def make_array (vals,etype):
 ###############################################################################
-    if etype=="bool":
+    if etype=="bool" or etype=="logical":
         return Bools(vals)
-    elif etype=="int":
+    elif etype=="int" or etype=="integer":
         return Ints(vals)
     elif etype=="float" or etype=="real":
         return Floats(vals)

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -45,7 +45,7 @@ def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False, buf
 
         any_change = False
         for change in changes:
-            this_changed = atm_config_chg_impl(root, change, all_matches)
+            this_changed = atm_config_chg_impl(root, change, all_matches, missing_ok=no_buffer)
             any_change |= this_changed
 
         if any_change:

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -13,8 +13,22 @@ sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 from eamxx_buildnml_impl import check_value, is_array_type
+from eamxx_buildnml import create_raw_xml_file
 from atm_manip import atm_config_chg_impl, buffer_changes, reset_buffer
 from utils import run_cmd_no_fail, expect
+
+# Add path to cime
+_CIMEROOT = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..","..","..","cime")
+sys.path.append(os.path.join(_CIMEROOT, "CIME", "Tools"))
+from standard_script_setup import * # pylint: disable=wildcard-import
+from CIME.case import Case
+
+###############################################################################
+def recreate_raw_xml_file():
+###############################################################################
+    caseroot = os.getcwd()
+    with Case(caseroot) as case:
+        create_raw_xml_file(case, caseroot)
 
 ###############################################################################
 def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False, buffer_only=False):
@@ -28,12 +42,13 @@ def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False, buf
 
     if reset:
         reset_buffer()
-        print("All buffered atmchanges have been removed. A fresh namelist_scream.xml will be generated the next time buildnml (case.setup) is run.")
+        print("All buffered atmchanges have been removed.")
         hack_xml = run_cmd_no_fail("./xmlquery SCREAM_HACK_XML --value")
         if hack_xml == "TRUE":
             print("SCREAM_HACK_XML is on. Removing namelist_scream.xml to force regen")
             os.remove("namelist_scream.xml")
 
+        recreate_raw_xml_file()
         return True
     else:
         expect(changes, "Missing <param>=<val> args")
@@ -53,6 +68,9 @@ def atm_config_chg(changes, no_buffer=False, reset=False, all_matches=False, buf
 
     if not no_buffer:
         buffer_changes(changes, all_matches=all_matches)
+
+    if not no_buffer and not buffer_only:
+        recreate_raw_xml_file()
 
     return True
 

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -294,8 +294,8 @@ class TestBuildnml(unittest.TestCase):
     def test_atmchanges_for_atm_procs_no_setup(self):
     ###########################################################################
         """
-        Test that atmchanges that add atm procs create the new proc when case.setup
-        is called.
+        Test that you can set atm proc fields for an atm proc added by
+        atmchange without having to run case.setup.
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -290,6 +290,17 @@ class TestBuildnml(unittest.TestCase):
         # the buffer will have changes that cannot be applied.
         self._chg_atmconfig([("mac_aero_mic::atm_procs_list", "(shoc,cldFraction,spa,p3)")], case)
 
+    ###########################################################################
+    def test_atmchanges_for_atm_procs_no_setup(self):
+    ###########################################################################
+        """
+        Test that atmchanges that add atm procs create the new proc when case.setup
+        is called.
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+
+        self._chg_atmconfig([("mac_aero_mic::atm_procs_list", "(shoc,cldFraction,spa,p3,testOnly)"), ("testOnly::number_of_subcycles", "42")], case)
+
 ###############################################################################
 def parse_command_line(args, desc):
 ###############################################################################

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -286,6 +286,10 @@ class TestBuildnml(unittest.TestCase):
         # above added the necessary atm proc XML block.
         self._chg_atmconfig([("testOnly::number_of_subcycles", "42")], case)
 
+        # Now remove the testOnly proc. Things should still work even though
+        # the buffer will have changes that cannot be applied.
+        self._chg_atmconfig([("mac_aero_mic::atm_procs_list", "(shoc,cldFraction,spa,p3)")], case)
+
 ###############################################################################
 def parse_command_line(args, desc):
 ###############################################################################


### PR DESCRIPTION
If the user changed fields of an atm_proc, then removed the atm_proc, we don't want buffer applies to fail, so turn on missing_ok when no_buffer is on.

Always regenerate namelist.xml file after atmchange is run (unless it's buffer-only or no-buffer).

I also had to fix a number of doctests which appear to have been broken in previous PRs. We need to remember to run `cime-buildnml-tests` when we change these scripts.

Fixes #2427 