### PR TITLE
[WIP] Verify array is allocated before accessing size

### DIFF
--- a/components/eam/src/physics/cosp2/local/cosp.F90
+++ b/components/eam/src/physics/cosp2/local/cosp.F90
@@ -478,7 +478,9 @@ CONTAINS
        Lrttov_column    = .true.
 
     ! Set flag to deallocate rttov types (only done on final call to simulator)
-    if (size(cospOUT%isccp_meantb) .eq. stop_idx) lrttov_cleanUp = .true.
+    if (associated(cospOUT%isccp_meantb)) then
+       if (size(cospOUT%isccp_meantb) .eq. stop_idx) lrttov_cleanUp = .true.
+    endif
 
     ! ISCCP column
     if (associated(cospOUT%isccp_fq)                                       .or.          &


### PR DESCRIPTION
In EAMxx, if this output array is not allocated, then this resulted in a valgrind error when attempting to access `size(cospOUT%isccp_meantb)`. This is a possible solution, just asking if `cospOUT%isccp_meantb` is associated with space in memory (follows format of surrounding code).

@brhillman Does this work? 