### PR TITLE
Fix bug in coarsening remapper

### DIFF
--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -426,6 +426,12 @@ void HommeDynamics::initialize_impl (const RunType run_type)
     restart_homme_state ();
   }
 
+  // Since we just inited them, ensure p_mid/p_int (dry and wet) timestamps are valid
+  get_field_out("p_int")    .get_header().get_tracking().update_time_stamp(timestamp());
+  get_field_out("p_mid")    .get_header().get_tracking().update_time_stamp(timestamp());
+  get_field_out("p_dry_int").get_header().get_tracking().update_time_stamp(timestamp());
+  get_field_out("p_dry_mid").get_header().get_tracking().update_time_stamp(timestamp());
+
   // Complete homme model initialization
   prim_init_model_f90 ();
 

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -223,7 +223,7 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
   switch (fl.rank()) {
     case 1:
       {
-        auto v = f.template get_view<ST*,Host>();
+        auto v = f.template get_view<const ST*,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           y = std::pow(v(i),2) - c;
           temp = norm + y;
@@ -234,7 +234,7 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
       break;
     case 2:
       {
-        auto v = f.template get_view<ST**,Host>();
+        auto v = f.template get_view<const ST**,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             y = std::pow(v(i,j),2) - c;
@@ -246,7 +246,7 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
       break;
     case 3:
       {
-        auto v = f.template get_view<ST***,Host>();
+        auto v = f.template get_view<const ST***,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -259,7 +259,7 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
       break;
     case 4:
       {
-        auto v = f.template get_view<ST****,Host>();
+        auto v = f.template get_view<const ST****,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -273,7 +273,7 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
       break;
     case 5:
       {
-        auto v = f.template get_view<ST*****,Host>();
+        auto v = f.template get_view<const ST*****,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -288,7 +288,7 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
       break;
     case 6:
       {
-        auto v = f.template get_view<ST******,Host>();
+        auto v = f.template get_view<const ST******,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -330,7 +330,7 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
   switch (fl.rank()) {
     case 1:
       {
-        auto v = f.template get_view<ST*,Host>();
+        auto v = f.template get_view<const ST*,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           y = v(i) - c;
           temp = sum + y;
@@ -341,7 +341,7 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
       break;
     case 2:
       {
-        auto v = f.template get_view<ST**,Host>();
+        auto v = f.template get_view<const ST**,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             y = v(i,j) - c;
@@ -353,7 +353,7 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
       break;
     case 3:
       {
-        auto v = f.template get_view<ST***,Host>();
+        auto v = f.template get_view<const ST***,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -366,7 +366,7 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
       break;
     case 4:
       {
-        auto v = f.template get_view<ST****,Host>();
+        auto v = f.template get_view<const ST****,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -380,7 +380,7 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
       break;
     case 5:
       {
-        auto v = f.template get_view<ST*****,Host>();
+        auto v = f.template get_view<const ST*****,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -395,7 +395,7 @@ ST field_sum(const Field& f, const ekat::Comm* comm)
       break;
     case 6:
       {
-        auto v = f.template get_view<ST******,Host>();
+        auto v = f.template get_view<const ST******,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -434,7 +434,7 @@ ST field_max(const Field& f, const ekat::Comm* comm)
   switch (fl.rank()) {
     case 1:
       {
-        auto v = f.template get_view<ST*,Host>();
+        auto v = f.template get_view<const ST*,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           max = std::max(max,v(i));
         }
@@ -442,7 +442,7 @@ ST field_max(const Field& f, const ekat::Comm* comm)
       break;
     case 2:
       {
-        auto v = f.template get_view<ST**,Host>();
+        auto v = f.template get_view<const ST**,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             max = std::max(max,v(i,j));
@@ -451,7 +451,7 @@ ST field_max(const Field& f, const ekat::Comm* comm)
       break;
     case 3:
       {
-        auto v = f.template get_view<ST***,Host>();
+        auto v = f.template get_view<const ST***,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -461,7 +461,7 @@ ST field_max(const Field& f, const ekat::Comm* comm)
       break;
     case 4:
       {
-        auto v = f.template get_view<ST****,Host>();
+        auto v = f.template get_view<const ST****,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -472,7 +472,7 @@ ST field_max(const Field& f, const ekat::Comm* comm)
       break;
     case 5:
       {
-        auto v = f.template get_view<ST*****,Host>();
+        auto v = f.template get_view<const ST*****,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -484,7 +484,7 @@ ST field_max(const Field& f, const ekat::Comm* comm)
       break;
     case 6:
       {
-        auto v = f.template get_view<ST******,Host>();
+        auto v = f.template get_view<const ST******,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -520,7 +520,7 @@ ST field_min(const Field& f, const ekat::Comm* comm)
   switch (fl.rank()) {
     case 1:
       {
-        auto v = f.template get_view<ST*,Host>();
+        auto v = f.template get_view<const ST*,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           min = std::min(min,v(i));
         }
@@ -528,7 +528,7 @@ ST field_min(const Field& f, const ekat::Comm* comm)
       break;
     case 2:
       {
-        auto v = f.template get_view<ST**,Host>();
+        auto v = f.template get_view<const ST**,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             min = std::min(min,v(i,j));
@@ -537,7 +537,7 @@ ST field_min(const Field& f, const ekat::Comm* comm)
       break;
     case 3:
       {
-        auto v = f.template get_view<ST***,Host>();
+        auto v = f.template get_view<const ST***,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -547,7 +547,7 @@ ST field_min(const Field& f, const ekat::Comm* comm)
       break;
     case 4:
       {
-        auto v = f.template get_view<ST****,Host>();
+        auto v = f.template get_view<const ST****,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -558,7 +558,7 @@ ST field_min(const Field& f, const ekat::Comm* comm)
       break;
     case 5:
       {
-        auto v = f.template get_view<ST*****,Host>();
+        auto v = f.template get_view<const ST*****,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {
@@ -570,7 +570,7 @@ ST field_min(const Field& f, const ekat::Comm* comm)
       break;
     case 6:
       {
-        auto v = f.template get_view<ST******,Host>();
+        auto v = f.template get_view<const ST******,Host>();
         for (int i=0; i<fl.dim(0); ++i) {
           for (int j=0; j<fl.dim(1); ++j) {
             for (int k=0; k<fl.dim(2); ++k) {

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -793,6 +793,9 @@ void CoarseningRemapper::pack_and_send ()
     }
   }
 
+  // Ensure all threads are done packing before firing off the sends
+  Kokkos::fence();
+
   // If MPI does not use dev pointers, we need to deep copy from dev to host
   if (not MpiOnDev) {
     Kokkos::deep_copy (m_mpi_send_buffer,m_send_buffer);


### PR DESCRIPTION
The bug was subtle, in that whether it exhibit itself or not depended heavily on machine/compiler settings, and on runtime "luck". Basically, we were firing up MPI sends without ensuring that all the packing operations had completed. Adding a fence after the packing loop ensures that we are sending the correct data.

Fixes #2439 

I also threw in fixes for a couple of bugs I ran into while debugging this.

Note: I would _not_ trust _any_ remapped output before this PR. While you may see non-zero values, I cannot guarantee that the values where correct. It is possible that the output at a certain timestep used coarsened values from the previous time step, b/c this timestep's MPI sends were fired off _before_ the packing operation completed.