### PR TITLE
Fix bug in how we parse rpointer file

### DIFF
--- a/components/eamxx/src/share/io/scream_io_utils.cpp
+++ b/components/eamxx/src/share/io/scream_io_utils.cpp
@@ -6,7 +6,7 @@
 namespace scream {
 
 std::string find_filename_in_rpointer (
-    const std::string& casename,
+    const std::string& filename_prefix,
     const bool model_restart,
     const ekat::Comm& comm,
     const util::TimeStamp& run_t0)
@@ -37,8 +37,7 @@ std::string find_filename_in_rpointer (
     while ((rpointer_file >> line) and not found) {
       content += line + "\n";
 
-      found = line.find(casename) != std::string::npos &&
-              line.find(suffix) != std::string::npos &&
+      found = line.find(filename_prefix+suffix) != std::string::npos &&
               extract_ts(line)==run_t0;
       filename = line;
     }
@@ -59,7 +58,7 @@ std::string find_filename_in_rpointer (
     // in the input parameter list
     EKAT_ERROR_MSG (
         "Error! Restart requested, but no restart file found in 'rpointer.atm'.\n"
-        "   restart case name: " + casename + "\n"
+        "   restart filename prefix: " + filename_prefix + "\n"
         "   restart file type: " + std::string(model_restart ? "model restart" : "history restart") + "\n"
         "   run t0           : " + run_t0.to_string() + "\n"
         "   rpointer content:\n" + content);

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -60,7 +60,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
 
   // Output control
   EKAT_REQUIRE_MSG(m_params.isSublist("output_control"),
-      "Error! The output control YAML file for " + m_casename + " is missing the sublist 'output_control'");
+      "Error! The output control YAML file for " + m_filename_prefix + " is missing the sublist 'output_control'");
   auto& out_control_pl = m_params.sublist("output_control");
   // Determine which timestamp to use a reference for output frequency.  Two options:
   // 	1. use_case_as_start_reference: TRUE  - implies we want to calculate frequency from the beginning of the whole simulation, even if this is a restarted run.
@@ -199,7 +199,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
     // that is different from the filename_prefix of the current output.
     auto& restart_pl = m_params.sublist("Restart");
     bool perform_history_restart = restart_pl.get("Perform Restart",true);
-    auto hist_restart_casename = restart_pl.get("filename_prefix",m_casename);
+    auto hist_restart_filename_prefix = restart_pl.get("filename_prefix",m_filename_prefix);
 
     if (m_is_model_restart_output) {
       // For model restart output, the restart time (which is the start time of this run) is precisely
@@ -208,7 +208,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
       m_output_control.nsamples_since_last_write = 0;
     } else if (perform_history_restart) {
       using namespace scorpio;
-      auto rhist_file = find_filename_in_rpointer(hist_restart_casename,false,m_io_comm,m_run_t0);
+      auto rhist_file = find_filename_in_rpointer(hist_restart_filename_prefix,false,m_io_comm,m_run_t0);
 
       // From restart file, get the time of last write, as well as the current size of the avg sample
       m_output_control.timestamp_of_last_write = read_timestamp(rhist_file,"last_write");
@@ -390,7 +390,6 @@ void OutputManager::run(const util::TimeStamp& timestamp)
 
     if (m_atm_logger) {
       m_atm_logger->info("[EAMxx::output_manager] - Writing " + file_type + ":");
-      m_atm_logger->info("[EAMxx::output_manager]      CASE: " + m_casename);
       m_atm_logger->info("[EAMxx::output_manager]      FILE: " + filespecs.filename);
     }
   };
@@ -530,7 +529,7 @@ compute_filename (const IOControl& control,
   std::string suffix =
     file_specs.hist_restart_file ? ".rhist"
                        : (m_is_model_restart_output ? ".r" : "");
-  auto filename = m_casename + suffix;
+  auto filename = m_filename_prefix + suffix;
 
   // Always add avg type and frequency info
   filename += "." + e2str(m_avg_type);
@@ -586,7 +585,7 @@ set_params (const ekat::ParameterList& params,
       }
       fields_pl.sublist(it.first).set("Field Names",fnames);
     }
-    m_casename = m_params.get<std::string>("filename_prefix");
+    m_filename_prefix = m_params.get<std::string>("filename_prefix");
     // Match precision of Fields
     m_params.set<std::string>("Floating Point Precision","real");
   } else {
@@ -598,7 +597,7 @@ set_params (const ekat::ParameterList& params,
 
     constexpr auto large_int = 1000000;
     m_output_file_specs.max_snapshots_in_file = m_params.get<int>("Max Snapshots Per File",large_int);
-    m_casename = m_params.get<std::string>("filename_prefix");
+    m_filename_prefix = m_params.get<std::string>("filename_prefix");
 
     // Allow user to ask for higher precision for normal model output,
     // but default to single to save on storage
@@ -753,7 +752,7 @@ push_to_logger()
   };
 
   m_atm_logger->info("[EAMxx::output_manager] - New Output stream");
-  m_atm_logger->info("                      Case: " + m_casename);
+  m_atm_logger->info("           Filename prefix: " + m_filename_prefix);
   m_atm_logger->info("                    Run t0: " + m_run_t0.to_string());
   m_atm_logger->info("                   Case t0: " + m_case_t0.to_string());
   m_atm_logger->info("              Reference t0: " + m_output_control.timestamp_of_last_write.to_string());

--- a/components/eamxx/src/share/io/scream_output_manager.hpp
+++ b/components/eamxx/src/share/io/scream_output_manager.hpp
@@ -144,7 +144,7 @@ protected:
   ekat::ParameterList            m_params;
 
   // The output filename root
-  std::string       m_casename;
+  std::string       m_filename_prefix;
 
   std::vector<double> m_time_bnds;
 

--- a/components/eamxx/src/share/io/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/io/tests/CMakeLists.txt
@@ -5,6 +5,11 @@ include(ScreamUtils)
 include (BuildCprnc)
 BuildCprnc()
 
+## Test io utils
+CreateUnitTest(io_utils "io_utils.cpp" "scream_io" LABELS "io"
+  PROPERTIES RESOURCE_LOCK rpointer_file
+)
+
 ## Test basic output (no packs, no diags, all avg types, all freq units)
 CreateUnitTest(io_basic "io_basic.cpp" "scream_io" LABELS "io"
   MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}

--- a/components/eamxx/src/share/io/tests/io_utils.cpp
+++ b/components/eamxx/src/share/io/tests/io_utils.cpp
@@ -1,0 +1,123 @@
+#include <catch2/catch.hpp>
+
+#include <share/io/scream_io_utils.hpp>
+#include <share/util/scream_time_stamp.hpp>
+
+#include <fstream>
+
+TEST_CASE ("find_filename_in_rpointer") {
+  using namespace scream;
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  util::TimeStamp t0({2023,9,7},{12,0,0});
+  util::TimeStamp t1({2023,9,7},{13,0,0});
+
+  // Create a dummy rpointer
+  std::ofstream rpointer ("rpointer.atm");
+
+  rpointer << "foo.r." + t0.to_string() + ".nc\n";
+  rpointer << "bar2.rhist." + t0.to_string() + ".nc\n";
+  rpointer << "bar.rhist." + t0.to_string() + ".nc\n";
+  rpointer.close();
+
+  // Now test find_filename_in_rpointer with different inputs
+
+  REQUIRE_THROWS (find_filename_in_rpointer("baz",false,comm,t0)); // wrong prefix
+  REQUIRE_THROWS (find_filename_in_rpointer("bar",false,comm,t1)); // wrong timestamp
+  REQUIRE_THROWS (find_filename_in_rpointer("bar",true, comm,t0)); // bar is not model restart
+  REQUIRE_THROWS (find_filename_in_rpointer("foo",false,comm,t0)); // foo is model restart
+
+  REQUIRE (find_filename_in_rpointer("bar", false,comm,t0)==("bar.rhist."+t0.to_string()+".nc"));
+  REQUIRE (find_filename_in_rpointer("bar2",false,comm,t0)==("bar2.rhist."+t0.to_string()+".nc"));
+  REQUIRE (find_filename_in_rpointer("foo", true, comm,t0)==("foo.r."+t0.to_string()+".nc"));
+}
+
+TEST_CASE ("io_control") {
+  using namespace scream;
+
+  util::TimeStamp t0({2023,9,7},{12,0,0});
+
+  IOControl control;
+  control.frequency = 2;
+  control.timestamp_of_last_write = t0;
+
+  SECTION ("none") {
+    control.frequency_units = "none";
+    REQUIRE (not control.output_enabled());
+    REQUIRE (not control.is_write_step(t0));
+  }
+
+  SECTION ("never") {
+    control.frequency_units = "never";
+    REQUIRE (not control.output_enabled());
+    REQUIRE (not control.is_write_step(t0));
+  }
+
+  SECTION ("nsteps") {
+    control.frequency_units = "nsteps";
+    auto t1 = t0 + 1;
+    auto t2 = t1 + 1;
+    REQUIRE (control.output_enabled());
+    REQUIRE (not control.is_write_step(t1));
+    REQUIRE (control.is_write_step(t2));
+  }
+
+  SECTION ("nsecs") {
+    control.frequency_units = "nsecs";
+    auto t1 = t0 + 1;
+    auto t2 = t1 + 1;
+    REQUIRE (control.output_enabled());
+    REQUIRE (not control.is_write_step(t1));
+    REQUIRE (control.is_write_step(t2));
+  }
+
+  SECTION ("nmins") {
+    control.frequency_units = "nmins";
+    auto t1 = t0 + 60;
+    auto t2 = t1 + 60;
+    REQUIRE (control.output_enabled());
+    REQUIRE (not control.is_write_step(t1));
+    REQUIRE (control.is_write_step(t2));
+  }
+
+  SECTION ("nhours") {
+    control.frequency_units = "nhours";
+    auto t1 = t0 + 3600;
+    auto t2 = t1 + 3600;
+    REQUIRE (control.output_enabled());
+    REQUIRE (not control.is_write_step(t1));
+    REQUIRE (control.is_write_step(t2));
+  }
+
+  SECTION ("ndays") {
+    control.frequency_units = "ndays";
+    auto t1 = t0 + 86400;
+    auto t2 = t1 + 86400;
+    REQUIRE (control.output_enabled());
+    REQUIRE (not control.is_write_step(t1));
+    REQUIRE (control.is_write_step(t2));
+  }
+
+  SECTION ("nmonths") {
+    control.frequency_units = "nmonths";
+    util::TimeStamp t1({2023,10,7},{12,0,0});
+    util::TimeStamp t2({2023,11,7},{12,0,0});
+    util::TimeStamp t3({2023,11,7},{13,0,0});
+    REQUIRE (control.output_enabled());
+    REQUIRE (not control.is_write_step(t1));
+    REQUIRE (control.is_write_step(t2));
+    REQUIRE (not control.is_write_step(t3));
+  }
+
+  SECTION ("nyears") {
+    control.frequency_units = "nyears";
+    util::TimeStamp t1({2024,9,7},{12,0,0});
+    util::TimeStamp t2({2025,9,7},{12,0,0});
+    util::TimeStamp t3({2025,9,7},{13,0,0});
+    REQUIRE (control.output_enabled());
+    REQUIRE (not control.is_write_step(t1));
+    REQUIRE (control.is_write_step(t2));
+    REQUIRE (not control.is_write_step(t3));
+  }
+}

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -287,7 +287,6 @@ void time_advance (const FieldManager& fm,
 		if (fname == "field_5") {
 		  // field_5 is used to test restarts w/ filled values, so
 		  // we cycle between filled and unfilled states.
-		  const auto tmp = v(i,j,k);
 		  v(i,j,k) = (v(i,j,k)==FillValue) ? dt :
 			  ( (v(i,j,k)==1.0) ? 2.0*dt : FillValue );
 		} else {


### PR DESCRIPTION
@ndkeen uncovered a subtle bug in how we parse the rpointer file. Basically, we were lookinf for a line containing the filename prefix, the filename suffix, and the timestamp. But consider the following rpointer file

```
bar2.rhist.2023-01-01-00000.nc
bar.rhist.2023-01-01-00000.nc
```
If we look for prefix="bar" and suffix=".rhist." _separately_, both lines would match. Instead, we should look for `bar.rhist.`, which would give a unique match. This PR addresses that, and adds some unit tests to the stuff in `scream_io_utils.*pp`. I manually verified that the unit tests would not pass without the mod in this PR.

Thanks Noel for always uncovering all our corner-case bugs! :)