### PR TITLE
EAMxx: fix bug in scorpio output

### DIFF
--- a/components/eamxx/src/diagnostics/liquid_water_path.hpp
+++ b/components/eamxx/src/diagnostics/liquid_water_path.hpp
@@ -28,7 +28,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "LiquidWaterPath"; }
+  std::string name () const { return "LiqWaterPath"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/precip_surf_mass_flux.cpp
+++ b/components/eamxx/src/diagnostics/precip_surf_mass_flux.cpp
@@ -13,16 +13,14 @@ PrecipSurfMassFlux (const ekat::Comm& comm, const ekat::ParameterList& params)
   ci_string type = m_params.get<std::string>("precip_type");
   if (type=="ice") {
     m_type = s_ice;
-    m_name = "precip_ice_surf_mass_flux";
-  } else if (type=="liquid") {
+  } else if (type=="liq") {
     m_type = s_liq;
-    m_name = "precip_liq_surf_mass_flux";
   } else if (type=="total") {
     m_type = s_ice + s_liq;
-    m_name = "precip_total_surf_mass_flux";
   } else {
     EKAT_ERROR_MSG ("Error! Invalid choice for 'precip_type': " + type + "\n");
   }
+  m_name = "precip_" + type + "_surf_mass_flux";
 }
 
 // ==============================================================================

--- a/components/eamxx/src/diagnostics/tests/precip_liq_surf_mass_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/precip_liq_surf_mass_flux_tests.cpp
@@ -63,7 +63,7 @@ void run(std::mt19937_64& engine)
   // Construct the Diagnostic
   register_diagnostics();
   ekat::ParameterList params;
-  params.set<std::string>("precip_type","liquid");
+  params.set<std::string>("precip_type","liq");
   auto& diag_factory = AtmosphereDiagnosticFactory::instance();
   auto diag = diag_factory.create("precip_surf_mass_flux",comm,params);
   diag->set_grids(gm);

--- a/components/eamxx/src/diagnostics/tests/precip_total_surf_mass_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/precip_total_surf_mass_flux_tests.cpp
@@ -66,7 +66,7 @@ void run(std::mt19937_64& engine)
   auto diag_total = diag_factory.create("precip_surf_mass_flux", comm, params);
   params.set<std::string>("precip_type","ice");
   auto diag_ice   = diag_factory.create("precip_surf_mass_flux"  , comm, params);
-  params.set<std::string>("precip_type","liquid");
+  params.set<std::string>("precip_type","liq");
   auto diag_liq   = diag_factory.create("precip_surf_mass_flux"  , comm, params);
   diag_total->set_grids(gm);
   diag_ice->set_grids(gm);

--- a/components/eamxx/src/diagnostics/vapor_water_path.hpp
+++ b/components/eamxx/src/diagnostics/vapor_water_path.hpp
@@ -28,7 +28,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
-  std::string name () const { return "VaporWaterPath"; }
+  std::string name () const { return "VapWaterPath"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -424,7 +424,7 @@ run (const std::string& filename,
   for (auto const& name : m_fields_names) {
     // Get all the info for this field.
           auto  field = get_field(name,"io");
-    const auto& layout = m_layouts.at(name);
+    const auto& layout = m_layouts.at(field.name());
     const auto& dims = layout.dims();
     const auto  rank = layout.rank();
 
@@ -729,7 +729,7 @@ void AtmosphereOutput::register_dimensions(const std::string& name)
   // Store the field layout
   const auto& fid = get_field(name,"io").get_header().get_identifier();
   const auto& layout = fid.get_layout();
-  m_layouts.emplace(name,layout);
+  m_layouts.emplace(fid.name(),layout);
 
   // Now check taht all the dims of this field are already set to be registered.
   for (int i=0; i<layout.rank(); ++i) {
@@ -784,8 +784,8 @@ void AtmosphereOutput::register_views()
         field.get_header().get_parent().expired() &&
         not is_diagnostic;
 
-    const auto layout = m_layouts.at(name);
-    const auto size = m_layouts.at(name).size();
+    const auto layout = m_layouts.at(field.name());
+    const auto size = layout.size();
     if (can_alias_field_view) {
       // Alias field's data, to save storage.
       m_dev_views_1d.emplace(name,view_1d_dev(field.get_internal_view_data<Real,Device>(),size));

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1240,18 +1240,13 @@ create_diagnostic (const std::string& diag_field_name) {
     } else {
       diag_name = "FieldAtLevel";
     }
-  } else if (diag_field_name=="PrecipLiqSurfMassFlux" or
-             diag_field_name=="precip_liq_surf_mass_flux") {
-    diag_name = "precip_surf_mass_flux";
-    params.set<std::string>("precip_type","liquid");
-  } else if (diag_field_name=="PrecipIceSurfMassFlux" or
-             diag_field_name=="precip_ice_surf_mass_flux") {
-    diag_name = "precip_surf_mass_flux";
-    params.set<std::string>("precip_type","ice");
-  } else if (diag_field_name=="PrecipTotalSurfMassFlux" or
+  } else if (diag_field_name=="precip_liq_surf_mass_flux" or
+             diag_field_name=="precip_ice_surf_mass_flux" or
              diag_field_name=="precip_total_surf_mass_flux") {
     diag_name = "precip_surf_mass_flux";
-    params.set<std::string>("precip_type","total");
+    // split will return [X, ''], with X being whatever is before '_surf_mass_flux'
+    auto type = ekat::split(diag_field_name.substr(7),"_surf_mass_flux").front();
+    params.set<std::string>("precip_type",type);
   } else {
     diag_name = diag_field_name;
   }

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_output.yaml
@@ -41,7 +41,7 @@ Fields:
       - micro_vap_liq_exchange
       - precip_ice_surf_mass
       - precip_liq_surf_mass
-      - PrecipLiqSurfMassFlux
+      - precip_liq_surf_mass_flux
       # SHOC + HOMME
       - horiz_winds
       # SHOC + P3

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
@@ -41,7 +41,7 @@ Fields:
       - micro_vap_liq_exchange
       - precip_ice_surf_mass
       - precip_liq_surf_mass
-      - PrecipLiqSurfMassFlux
+      - precip_liq_surf_mass_flux
       # SHOC + HOMME
       - horiz_winds
       # SHOC + P3


### PR DESCRIPTION
Always use the field name from the field object as key in maps. That's b/c field.name() may differ from the string we received in the input file if the field is a diagnostic.