### PR TITLE
Add a few debug/trace logging calls in some infrastructure classes.

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1424,7 +1424,7 @@ void AtmosphereDriver::run (const int dt) {
   m_current_ts += dt;
 
   // Update output streams
-  m_atm_logger->log("EAMxx::run] running output managers...");
+  m_atm_logger->debug("[EAMxx::run] running output managers...");
   for (auto& out_mgr : m_output_managers) {
     out_mgr.run(m_current_ts);
   }

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1414,7 +1414,7 @@ void AtmosphereDriver::run (const int dt) {
   // Print current timestamp information
   m_atm_logger->log(ekat::logger::LogLevel::info,
     "Atmosphere step = " + std::to_string(m_current_ts.get_num_steps()) + "\n" +
-    "  model time = " + m_current_ts.get_date_string() + " " + m_current_ts.get_time_string() + "\n");
+    "  model start-of-step time = " + m_current_ts.get_date_string() + " " + m_current_ts.get_time_string() + "\n");
 
   // The class AtmosphereProcessGroup will take care of dispatching arguments to
   // the individual processes, which will be called in the correct order.
@@ -1424,6 +1424,7 @@ void AtmosphereDriver::run (const int dt) {
   m_current_ts += dt;
 
   // Update output streams
+  m_atm_logger->log("EAMxx::run] running output managers...");
   for (auto& out_mgr : m_output_managers) {
     out_mgr.run(m_current_ts);
   }
@@ -1503,6 +1504,7 @@ void AtmosphereDriver::finalize ( /* inputs? */ ) {
   m_atm_comm.all_reduce(&my_mem_usage,&max_mem_usage,1,MPI_MAX);
   m_atm_logger->debug("[EAMxx::finalize] memory usage: " + std::to_string(max_mem_usage) + "MB");
 #endif
+  m_atm_logger->flush();
 
   m_ad_status = 0;
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -78,6 +78,7 @@ void AtmosphereProcess::initialize (const TimeStamp& t0, const RunType run_type)
 }
 
 void AtmosphereProcess::run (const double dt) {
+  m_atm_logger->debug("[EAMxx::" + this->name() + "] run...");
   start_timer (m_timer_prefix + this->name() + "::run");
   if (m_params.get("enable_precondition_checks", true)) {
     // Run 'pre-condition' property checks stored in this AP
@@ -354,6 +355,7 @@ void AtmosphereProcess::set_computed_group (const FieldGroup& group) {
 void AtmosphereProcess::run_property_check (const prop_check_ptr&       property_check,
                                             const CheckFailHandling     check_fail_handling,
                                             const PropertyCheckCategory property_check_category) const {
+  m_atm_logger->trace("[" + this->name() + "] run_property_check '" + property_check->name() + "'...");
   auto res_and_msg = property_check->check();
 
   // string for output
@@ -445,6 +447,7 @@ void AtmosphereProcess::run_property_check (const prop_check_ptr&       property
 }
 
 void AtmosphereProcess::run_precondition_checks () const {
+  m_atm_logger->debug("[" + this->name() + "] run_precondition_checks...");
   // Run all pre-condition property checks
   for (const auto& it : m_precondition_checks) {
     run_property_check(it.second, it.first,
@@ -453,6 +456,7 @@ void AtmosphereProcess::run_precondition_checks () const {
 }
 
 void AtmosphereProcess::run_postcondition_checks () const {
+  m_atm_logger->debug("[" + this->name() + "] run_postcondition_checks...");
   // Run all post-condition property checks
   for (const auto& it : m_postcondition_checks) {
     run_property_check(it.second, it.first,
@@ -461,6 +465,7 @@ void AtmosphereProcess::run_postcondition_checks () const {
 }
 
 void AtmosphereProcess::run_column_conservation_check () const {
+  m_atm_logger->debug("[" + this->name() + "] run_column_conservation_check...");
   // Conservation check is run as a postcondition check
   run_property_check(m_column_conservation_check.second,
                      m_column_conservation_check.first,
@@ -484,6 +489,7 @@ void AtmosphereProcess::init_step_tendencies () {
 
 void AtmosphereProcess::compute_step_tendencies (const double dt) {
   if (m_compute_proc_tendencies) {
+    m_atm_logger->debug("[" + this->name() + "] compuiting tendencies...");
     start_timer(m_timer_prefix + this->name() + "::compute_tendencies");
     for (auto it : m_proc_tendencies) {
       const auto& tname = it.first;

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -319,6 +319,10 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     return;
   }
 
+  if (m_atm_logger) {
+    m_atm_logger->debug("[OutputManager::run] filename_prefix: " + m_filename_prefix + "\n");
+  }
+
   using namespace scorpio;
 
   std::string timer_root = m_is_model_restart_output ? "EAMxx::IO::restart" : "EAMxx::IO::standard";
@@ -415,6 +419,9 @@ void OutputManager::run(const util::TimeStamp& timestamp)
   const auto& fields_write_filename = is_output_step ? m_output_file_specs.filename : m_checkpoint_file_specs.filename;
   for (auto& it : m_output_streams) {
     // Note: filename only matters if is_output_step || is_full_checkpoint_step=true. In that case, it will definitely point to a valid file name.
+    if (m_atm_logger) {
+      m_atm_logger->debug("[OutputManager]: writing fields from grid " + it->get_io_grid()->name() + "...\n");
+    }
     it->run(fields_write_filename,is_output_step,is_full_checkpoint_step,m_output_control.nsamples_since_last_write,is_t0_output);
   }
   stop_timer(timer_root+"::run_output_streams");
@@ -432,6 +439,9 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     }
 
     auto write_global_data = [&](IOControl& control, IOFileSpecs& filespecs) {
+      if (m_atm_logger) {
+        m_atm_logger->debug("[OutputManager]: writing globals...\n");
+      }
       if (m_is_model_restart_output) {
         // Only write nsteps on model restart
         set_attribute(filespecs.filename,"nsteps",timestamp.get_num_steps());


### PR DESCRIPTION
In case of  a crash with a non-informative stack trace (e.g., an exception from something like `map::at`), one can inspect the atm.log file to help narrowing down _when_ during the timestep the crash occurs.

I encourage people to add as much logging as possible in their development. So long as the log level is debug (or less), it should not pollute the log files for normal runs.