### PR TITLE
Fix input file for standalone driver tests

### DIFF
--- a/components/eamxx/tests/coupled/dynamics_physics/homme_mam4xx_pg2/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_mam4xx_pg2/input.yaml
@@ -15,12 +15,12 @@ initial_conditions:
   pbl_height : 1000.0
 
 atmosphere_processes:
-  atm_procs_list: (homme,physics)
+  atm_procs_list: [homme,physics]
   schedule_type: Sequential
   homme:
     Moisture: moist
   physics:
-    atm_procs_list: (mam4_micro,mam4_optics)
+    atm_procs_list: [mam4_micro,mam4_optics]
     schedule_type: Sequential
     Type: Group
     mam4_micro:

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -26,16 +26,16 @@ initial_conditions:
   aero_tau_lw: 0.0
 
 atmosphere_processes:
-  atm_procs_list: (homme,physics)
+  atm_procs_list: [homme,physics]
   schedule_type: Sequential
   homme:
     Moisture: moist
   physics:
-    atm_procs_list: (mac_mic,rrtmgp)
+    atm_procs_list: [mac_mic,rrtmgp]
     schedule_type: Sequential
     Type: Group
     mac_mic:
-      atm_procs_list: (shoc,CldFraction,p3)
+      atm_procs_list: [shoc,CldFraction,p3]
       schedule_type: Sequential
       Type: Group
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -17,16 +17,16 @@ initial_conditions:
   precip_ice_surf_mass: 0.0
 
 atmosphere_processes:
-  atm_procs_list: (homme,physics)
+  atm_procs_list: [homme,physics]
   schedule_type: Sequential
   homme:
     Moisture: moist
   physics:
-    atm_procs_list: (mac_aero_mic,rrtmgp)
+    atm_procs_list: [mac_aero_mic,rrtmgp]
     schedule_type: Sequential
     Type: Group
     mac_aero_mic:
-      atm_procs_list: (shoc,CldFraction,spa,p3)
+      atm_procs_list: [shoc,CldFraction,spa,p3]
       Type: Group
       schedule_type: Sequential
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -17,17 +17,17 @@ initial_conditions:
   precip_liq_surf_mass: 0.0
 
 atmosphere_processes:
-  atm_procs_list: (homme,physics)
+  atm_procs_list: [homme,physics]
   schedule_type: Sequential
   compute_tendencies: [T_mid, qv]
   homme:
     Moisture: moist
   physics:
-    atm_procs_list: (mac_aero_mic,rrtmgp)
+    atm_procs_list: [mac_aero_mic,rrtmgp]
     schedule_type: Sequential
     Type: Group
     mac_aero_mic:
-      atm_procs_list: (shoc,CldFraction,spa,p3)
+      atm_procs_list: [shoc,CldFraction,spa,p3]
       Type: Group
       schedule_type: Sequential
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
@@ -25,16 +25,16 @@ initial_conditions:
   landfrac: 0.5
 
 atmosphere_processes:
-  atm_procs_list: (homme,physics)
+  atm_procs_list: [homme,physics]
   schedule_type: Sequential
   homme:
     Moisture: moist
   physics:
-    atm_procs_list: (mac_aero_mic,rrtmgp)
+    atm_procs_list: [mac_aero_mic,rrtmgp]
     schedule_type: Sequential
     Type: Group
     mac_aero_mic:
-      atm_procs_list: (tms,shoc,CldFraction,spa,p3)
+      atm_procs_list: [tms,shoc,CldFraction,spa,p3]
       Type: Group
       schedule_type: Sequential
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -23,16 +23,16 @@ initial_conditions:
   aero_tau_lw: 0.0
 
 atmosphere_processes:
-  atm_procs_list: (homme,physics)
+  atm_procs_list: [homme,physics]
   schedule_type: Sequential
   homme:
     Moisture: moist
   physics:
-    atm_procs_list: (mac_aero_mic,rrtmgp)
+    atm_procs_list: [mac_aero_mic,rrtmgp]
     Type: Group
     schedule_type: Sequential
     mac_aero_mic:
-      atm_procs_list: (shoc,CldFraction,p3)
+      atm_procs_list: [shoc,CldFraction,p3]
       Type: Group
       schedule_type: Sequential
       number_of_subcycles: 1

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -23,16 +23,16 @@ initial_conditions:
   aero_tau_lw: 0.0
 
 atmosphere_processes:
-  atm_procs_list: (homme,physics)
+  atm_procs_list: [homme,physics]
   schedule_type: Sequential
   homme:
     Moisture: moist
   physics:
-    atm_procs_list: (mac_aero_mic,rrtmgp)
+    atm_procs_list: [mac_aero_mic,rrtmgp]
     Type: Group
     schedule_type: Sequential
     mac_aero_mic:
-      atm_procs_list: (shoc,CldFraction,p3)
+      atm_procs_list: [shoc,CldFraction,p3]
       Type: Group
       schedule_type: Sequential
       number_of_subcycles: 1

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -13,16 +13,16 @@ initial_conditions:
   restart_casename: model_restart
 
 atmosphere_processes:
-  atm_procs_list: (homme,physics)
+  atm_procs_list: [homme,physics]
   schedule_type: Sequential
   homme:
     Moisture: moist
   physics:
-    atm_procs_list: (mac_aero_mic,rrtmgp)
+    atm_procs_list: [mac_aero_mic,rrtmgp]
     Type: Group
     schedule_type: Sequential
     mac_aero_mic:
-      atm_procs_list: (shoc,CldFraction,p3)
+      atm_procs_list: [shoc,CldFraction,p3]
       Type: Group
       schedule_type: Sequential
       number_of_subcycles: 1

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -10,7 +10,7 @@ time_stepping:
 
 atmosphere_processes:
   schedule_type: Sequential
-  atm_procs_list: (shoc,p3)
+  atm_procs_list: [shoc,p3]
   number_of_subcycles: ${NUM_SUBCYCLES}
 
 grids_manager:

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -9,10 +9,10 @@ time_stepping:
   number_of_steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (mac_mic,rrtmgp)
+  atm_procs_list: [mac_mic,rrtmgp]
   schedule_type: Sequential
   mac_mic:
-    atm_procs_list: (shoc,CldFraction,p3)
+    atm_procs_list: [shoc,CldFraction,p3]
     Type: Group
     schedule_type: Sequential
     number_of_subcycles: ${MAC_MIC_SUBCYCLES}

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -9,10 +9,10 @@ time_stepping:
   number_of_steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (mac_mic,rrtmgp)
+  atm_procs_list: [mac_mic,rrtmgp]
   schedule_type: Sequential
   mac_mic:
-    atm_procs_list: (shoc,CldFraction,spa,p3)
+    atm_procs_list: [shoc,CldFraction,spa,p3]
     Type: Group
     schedule_type: Sequential
     number_of_subcycles: ${MAC_MIC_SUBCYCLES}

--- a/components/eamxx/tests/uncoupled/cld_fraction/input.yaml
+++ b/components/eamxx/tests/uncoupled/cld_fraction/input.yaml
@@ -9,7 +9,7 @@ time_stepping:
   number_of_steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (CldFraction)
+  atm_procs_list: [CldFraction]
   CldFraction:
     ice_cloud_threshold: 1e-12
     ice_cloud_for_analysis_threshold: 1e-5

--- a/components/eamxx/tests/uncoupled/cosp/input.yaml
+++ b/components/eamxx/tests/uncoupled/cosp/input.yaml
@@ -9,7 +9,7 @@ time_stepping:
   number_of_steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (cosp)
+  atm_procs_list: [cosp]
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/uncoupled/homme/input.yaml
+++ b/components/eamxx/tests/uncoupled/homme/input.yaml
@@ -13,7 +13,7 @@ initial_conditions:
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
 
 atmosphere_processes:
-  atm_procs_list: (Dynamics)
+  atm_procs_list: [Dynamics]
   Dynamics:
     Type: Homme
     Moisture: moist

--- a/components/eamxx/tests/uncoupled/mam4/input.yaml
+++ b/components/eamxx/tests/uncoupled/mam4/input.yaml
@@ -9,7 +9,7 @@ time_stepping:
   number_of_steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (mam4_micro)
+  atm_procs_list: [mam4_micro]
   mam4_micro:
     compute_tendencies: [q_aitken_so4, n_aitken, q_h2so4]
 

--- a/components/eamxx/tests/uncoupled/ml_correction/input.yaml
+++ b/components/eamxx/tests/uncoupled/ml_correction/input.yaml
@@ -9,7 +9,7 @@ time_stepping:
   number_of_steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (MLCorrection)
+  atm_procs_list: [MLCorrection]
   MLCorrection:
     ML_model_path: NONE
     ML_output_fields: ["qv","T_mid"]

--- a/components/eamxx/tests/uncoupled/p3/input.yaml
+++ b/components/eamxx/tests/uncoupled/p3/input.yaml
@@ -9,7 +9,7 @@ time_stepping:
   number_of_steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (p3)
+  atm_procs_list: [p3]
   p3:
     compute_tendencies: [T_mid,qc]
     do_prescribed_ccn: false

--- a/components/eamxx/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/eamxx/tests/uncoupled/rrtmgp/input.yaml
@@ -11,7 +11,7 @@ time_stepping:
   number_of_steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (rrtmgp)
+  atm_procs_list: [rrtmgp]
   rrtmgp:
     column_chunk_size: ${COL_CHUNK_SIZE}
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/eamxx/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -4,7 +4,7 @@ driver_options:
   atmosphere_dag_verbosity_level: 5
 
 atmosphere_processes:
-  atm_procs_list: (rrtmgp)
+  atm_procs_list: [rrtmgp]
   rrtmgp:
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/uncoupled/shoc/input.yaml
+++ b/components/eamxx/tests/uncoupled/shoc/input.yaml
@@ -9,7 +9,7 @@ time_stepping:
   number_of_steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (shoc)
+  atm_procs_list: [shoc]
   shoc:
     number_of_subcycles: ${NUM_SUBCYCLES}
     compute_tendencies: [all]

--- a/components/eamxx/tests/uncoupled/spa/input.yaml
+++ b/components/eamxx/tests/uncoupled/spa/input.yaml
@@ -9,7 +9,7 @@ time_stepping:
   number_of_steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (spa)
+  atm_procs_list: [spa]
   spa:
     spa_remap_file: ${SCREAM_DATA_DIR}/maps/map_ne4np4_to_ne2np4_mono.nc
     spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc

--- a/components/eamxx/tests/uncoupled/surface_coupling/input.yaml
+++ b/components/eamxx/tests/uncoupled/surface_coupling/input.yaml
@@ -7,7 +7,7 @@ time_stepping:
   run_t0: ${RUN_T0}  # YYYY-MM-DD-XXXXX
 
 atmosphere_processes:
-  atm_procs_list: (SurfaceCouplingImporter,SurfaceCouplingExporter)
+  atm_procs_list: [SurfaceCouplingImporter,SurfaceCouplingExporter]
   schedule_type: Sequential
 
 grids_manager:

--- a/components/eamxx/tests/uncoupled/zm/input.yaml
+++ b/components/eamxx/tests/uncoupled/zm/input.yaml
@@ -9,7 +9,7 @@ time_stepping:
   number_of_steps: ${NUM_STEPS}
 
 atmosphere_processes:
-  atm_procs_list: (zm)
+  atm_procs_list: [zm]
 
 grids_manager:
   Type: Mesh Free


### PR DESCRIPTION
PR #2510 changed how we specify an atm procs list. I mistakenly added the label to skip v1 tests, so tests got broken without me noticing. Sorry about that.