### PR TITLE
Fixes an inconsistency between standard IO and vertical remap files.

### DIFF
--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -54,7 +54,7 @@ VerticalRemapper (const grid_ptr_type& src_grid,
   // as the source field, but will have a different number of 
   // vertical levels.
   scorpio::register_file(map_file,scorpio::FileMode::Read);
-  m_num_remap_levs = scorpio::get_dimlen(map_file,"nlevs");
+  m_num_remap_levs = scorpio::get_dimlen(map_file,"lev");
 
   auto tgt_grid_gids = src_grid->get_unique_gids();
   const int ngids = tgt_grid_gids.size();
@@ -161,7 +161,7 @@ set_pressure_levels(const std::string& map_file) {
   std::vector<scorpio::offset_t> dofs_offsets(m_num_remap_levs);
   std::iota(dofs_offsets.begin(),dofs_offsets.end(),0);
   const std::string idx_decomp_tag = "vertical_remapper::" + std::to_string(m_num_remap_levs);
-  scorpio::register_variable(map_file, "p_levs", "p_levs", {"nlevs"}, "real", idx_decomp_tag);
+  scorpio::register_variable(map_file, "p_levs", "p_levs", {"lev"}, "real", idx_decomp_tag);
   scorpio::set_dof(map_file,"p_levs",m_num_remap_levs,dofs_offsets.data());
   scorpio::set_decomp(map_file);
   scorpio::grid_read_data_array(map_file,"p_levs",-1,remap_pres_scal.data(),remap_pres_scal.size());

--- a/components/eamxx/src/share/io/tests/io_remap_test.cpp
+++ b/components/eamxx/src/share/io/tests/io_remap_test.cpp
@@ -110,12 +110,12 @@ TEST_CASE("io_remap_test","io_remap_test")
   scorpio::register_dimension(remap_filename,"n_a",  "n_a",    ncols_src, true);
   scorpio::register_dimension(remap_filename,"n_b",  "n_b",    ncols_tgt, true);
   scorpio::register_dimension(remap_filename,"n_s",  "n_s",    ncols_src, true);
-  scorpio::register_dimension(remap_filename,"nlevs", "nlevs", nlevs_tgt, false);
+  scorpio::register_dimension(remap_filename,"lev",  "lev",    nlevs_tgt, false);
 
   scorpio::register_variable(remap_filename,"col","col","none",{"n_s"},"real","int","int-nnz");
   scorpio::register_variable(remap_filename,"row","row","none",{"n_s"},"real","int","int-nnz");
   scorpio::register_variable(remap_filename,"S","S","none",{"n_s"},"real","real","Real-nnz");
-  scorpio::register_variable(remap_filename,"p_levs","p_levs","none",{"nlevs"},"real","real","Real-nlevs");
+  scorpio::register_variable(remap_filename,"p_levs","p_levs","none",{"lev"},"real","real","Real-lev");
 
   scorpio::set_dof(remap_filename,"col",dofs_cols.size(),dofs_cols.data());
   scorpio::set_dof(remap_filename,"row",dofs_cols.size(),dofs_cols.data());

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -97,9 +97,9 @@ void create_remap_file(const std::string& filename, const int nlevs, const std::
 
   scorpio::register_file(filename, scorpio::FileMode::Write);
 
-  scorpio::register_dimension(filename,"nlevs","nlevs",nlevs, false);
+  scorpio::register_dimension(filename,"lev","lev",nlevs, false);
 
-  scorpio::register_variable(filename,"p_levs","p_levs","none",{"nlevs"},"real","real","Real-nlevs");
+  scorpio::register_variable(filename,"p_levs","p_levs","none",{"lev"},"real","real","Real-lev");
 
   scorpio::set_dof(filename,"p_levs",dofs_p.size(),dofs_p.data()); 
   


### PR DESCRIPTION
This commit fixes an inconsistency between the typical EAMxx output which uses the dimension name `lev` for levels and the vertical remapping files which uses `nlevs`.  This isn't a major bug, but the inconsistency can cause some confusion and more importantly, if someone uses EAMxx output for nudging they would have a pre-processing step of adding a dimension `levs` to the file containing `p_levs` just to work.