### PR TITLE
Change default ne30 macmic to 12 (from 6)

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -288,7 +288,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <atm_procs_list>(shoc,cldFraction,spa,p3)</atm_procs_list>
       <atm_procs_list COMPSET=".*SCREAM.*noAero">(shoc,cldFraction,p3)</atm_procs_list>
       <number_of_subcycles hgrid="ne4np4">24</number_of_subcycles>
-      <number_of_subcycles hgrid="ne30np4">6</number_of_subcycles>
+      <number_of_subcycles hgrid="ne30np4">12</number_of_subcycles>
       <number_of_subcycles hgrid="ne120np4">3</number_of_subcycles>
       <number_of_subcycles hgrid="ne256np4">3</number_of_subcycles>
       <number_of_subcycles hgrid="ne512np4">1</number_of_subcycles>


### PR DESCRIPTION
For ne30, we found that using macmic=12 allowed long-running cases to avoid high T error.

NBFB at ne30

Fixes https://github.com/E3SM-Project/scream/issues/2381