### PR TITLE
fix shoc energy fixer

### DIFF
--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2703,6 +2703,11 @@ end if
     end if
 !!== KZ_WATCON 
 
+print *, 'lchnk', lchnk
+
+dlf= 0.0_r8
+rliq=0.0_r8
+
              ! =====================================================
              !    CLUBB call (PBL, shallow convection, macrophysics)
              ! =====================================================  
@@ -2723,6 +2728,14 @@ end if
                 flx_cnd(:ncol) = -1._r8*rliq(:ncol) 
                 flx_heat(:ncol) = cam_in%shf(:ncol) + det_s(:ncol)
 
+print *, 'flx_cnd(1)',flx_cnd(1)
+print *, 'flx_heat(1)',flx_heat(1)
+print *, 'det_s(1)', det_s(1)
+print *, 'det_ice(1)', det_ice(1)
+print *, 'cflx(1)', cam_in%cflx(1,1)
+print *, 'shflx(1)', cam_in%shf(1)
+
+
                 ! Unfortunately, physics_update does not know what time period
                 ! "tend" is supposed to cover, and therefore can't update it
                 ! with substeps correctly. For now, work around this by scaling
@@ -2735,8 +2748,8 @@ end if
                 call check_energy_chng(state, tend, "clubb_tend", nstep, ztodt, &
                      cam_in%cflx(:,1)/cld_macmic_num_steps, flx_cnd/cld_macmic_num_steps, &
                      det_ice/cld_macmic_num_steps, flx_heat/cld_macmic_num_steps)
-		     
-	
+!stop
+
  
           endif
 

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2735,6 +2735,8 @@ end if
                 call check_energy_chng(state, tend, "clubb_tend", nstep, ztodt, &
                      cam_in%cflx(:,1)/cld_macmic_num_steps, flx_cnd/cld_macmic_num_steps, &
                      det_ice/cld_macmic_num_steps, flx_heat/cld_macmic_num_steps)
+
+
  
           endif
 

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2703,11 +2703,6 @@ end if
     end if
 !!== KZ_WATCON 
 
-print *, 'lchnk', lchnk
-
-dlf= 0.0_r8
-rliq=0.0_r8
-
              ! =====================================================
              !    CLUBB call (PBL, shallow convection, macrophysics)
              ! =====================================================  
@@ -2728,14 +2723,6 @@ rliq=0.0_r8
                 flx_cnd(:ncol) = -1._r8*rliq(:ncol) 
                 flx_heat(:ncol) = cam_in%shf(:ncol) + det_s(:ncol)
 
-print *, 'flx_cnd(1)',flx_cnd(1)
-print *, 'flx_heat(1)',flx_heat(1)
-print *, 'det_s(1)', det_s(1)
-print *, 'det_ice(1)', det_ice(1)
-print *, 'cflx(1)', cam_in%cflx(1,1)
-print *, 'shflx(1)', cam_in%shf(1)
-
-
                 ! Unfortunately, physics_update does not know what time period
                 ! "tend" is supposed to cover, and therefore can't update it
                 ! with substeps correctly. For now, work around this by scaling
@@ -2748,8 +2735,6 @@ print *, 'shflx(1)', cam_in%shf(1)
                 call check_energy_chng(state, tend, "clubb_tend", nstep, ztodt, &
                      cam_in%cflx(:,1)/cld_macmic_num_steps, flx_cnd/cld_macmic_num_steps, &
                      det_ice/cld_macmic_num_steps, flx_heat/cld_macmic_num_steps)
-!stop
-
  
           endif
 

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -228,7 +228,6 @@ subroutine shoc_main ( &
      wthl_sfc, wqw_sfc, uw_sfc, vw_sfc, & ! Input
      wtracer_sfc,num_qtracers,w_field, &  ! Input
      inv_exner,phis, &                        ! Input
-     sens_heat,cflx, &                        ! Input
      host_dse, tke, thetal, qw, &         ! Input/Output
      u_wind, v_wind,qtracers,&            ! Input/Output
      wthv_sec,tkh,tk,&                    ! Input/Output
@@ -296,9 +295,6 @@ subroutine shoc_main ( &
   real(rtype), intent(in) :: inv_exner(shcol,nlev)
   ! Host model surface geopotential height
   real(rtype), intent(in) :: phis(shcol)
-
-  real(rtype), intent(in) :: sens_heat(shcol)
-  real(rtype), intent(in) :: cflx(shcol)
 
 ! INPUT/OUTPUT VARIABLES
   ! prognostic temp variable of host model
@@ -566,12 +562,10 @@ subroutine shoc_main ( &
   call shoc_energy_fixer(&
      shcol,nlev,nlevi,dtime,nadv,&         ! Input
      zt_grid,zi_grid,&                     ! Input
-     qw, shoc_ql,u_wind,v_wind,pdel,&
      se_b,ke_b,wv_b,wl_b,&                 ! Input
      se_a,ke_a,wv_a,wl_a,&                 ! Input
      wthl_sfc,wqw_sfc,&                    ! Input
      rho_zt,tke,presi,&                    ! Input
-     sens_heat,cflx,&
      host_dse)                             ! Input/Output
 
   ! Remaining code is to diagnose certain quantities
@@ -3864,12 +3858,10 @@ end subroutine update_host_dse
 subroutine shoc_energy_fixer(&
          shcol,nlev,nlevi,dtime,nadv,&  ! Input
          zt_grid,zi_grid,&              ! Input
-         qw,shoc_ql,u_wind,v_wind,pdel, &
          se_b,ke_b,wv_b,wl_b,&          ! Input
          se_a,ke_a,wv_a,wl_a,&          ! Input
          wthl_sfc,wqw_sfc,&             ! Input
          rho_zt,tke,pint,&              ! Input
-         sens_heat, cflx, &
          host_dse)                      ! Input/Output
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
@@ -3919,14 +3911,6 @@ subroutine shoc_energy_fixer(&
   real(rtype), intent(in) :: rho_zt(shcol,nlev)
   !turbulent kinetic energy [m^2/s^2]
   real(rtype), intent(in) :: tke(shcol,nlev)
-  real(rtype), intent(in) :: sens_heat(shcol)
-  real(rtype), intent(in) :: cflx(shcol)
-
-  real(rtype), intent(in) :: qw(shcol,nlev)
-  real(rtype), intent(in) :: shoc_ql(shcol,nlev)
-  real(rtype), intent(in) :: u_wind(shcol,nlev)
-  real(rtype), intent(in) :: v_wind(shcol,nlev)
-  real(rtype), intent(in) :: pdel(shcol,nlev)
 
   ! INPUT VARIABLES
   !host temperature [K]

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -14,7 +14,6 @@ module shoc
 
   use physics_utils, only: rtype, rtype8, itype, btype
   use scream_abortutils, only: endscreamrun
-  use physconst,     only: rair, cpair
 
 ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
@@ -4028,7 +4027,7 @@ subroutine shoc_energy_total_fixer(&
   ! call
   do i=1,shcol
     ! convert shf and lhf
-    exner_surf = (pint(i,nlevi)/p0_shoc)**(rair/cpair)
+    exner_surf = bfb_pow(pint(i,nlevi)/p0, rgas/cp)
     shf=wthl_sfc(i)*cp*rho_zi(i,nlevi)*exner_surf
 
     lhf=wqw_sfc(i)*rho_zi(i,nlevi)

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -3729,7 +3729,6 @@ end subroutine vd_shoc_solve
 subroutine shoc_energy_integrals(&
          shcol,nlev,host_dse,pdel,&     ! Input
          rtm,rcm,u_wind,v_wind,&        ! Input
-         !zt_grid, phis, &
          se_int,ke_int,wv_int,wl_int)   ! Output
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
@@ -3755,9 +3754,6 @@ subroutine shoc_energy_integrals(&
   real(rtype), intent(in) :: rtm(shcol,nlev)
   ! cloud liquid mixing ratio [kg/kg]
   real(rtype), intent(in) :: rcm(shcol,nlev)
-
-!  real(rtype), intent(in) :: zt_grid(shcol,nlev)
-!  real(rtype), intent(in) :: phis(shcol)
 
 ! OUTPUT VARIABLES
   ! integrated static energy
@@ -3937,9 +3933,8 @@ subroutine shoc_energy_fixer(&
   real(rtype), intent(inout) :: host_dse(shcol,nlev)
 
   ! LOCAL VARIABLES
-  real(rtype) :: se_dis(shcol), te_a(shcol), te_b(shcol),hdtime
-  real(rtype) :: se1(shcol), te1(shcol), ke1(shcol), wl1(shcol),wv1(shcol)
-  integer :: shoctop(shcol), i,k
+  real(rtype) :: se_dis(shcol), te_a(shcol), te_b(shcol)
+  integer :: shoctop(shcol)
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
    if (use_cxx) then
@@ -4055,7 +4050,6 @@ subroutine shoc_energy_total_fixer(&
     lhf=wqw_sfc(i)*rho_zi(i,nlevi)
     te_a(i) = se_a(i) + ke_a(i) + (lcond+lice)*wv_a(i)+lice*wl_a(i)
     te_b(i) = se_b(i) + ke_b(i) + (lcond+lice)*wv_b(i)+lice*wl_b(i)
-
     te_b(i) = te_b(i)+(shf+(lhf)*(lcond+lice))*hdtime
   enddo
 

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -31,9 +31,6 @@ logical :: use_cxx = .true.
 real(rtype), parameter, public :: largeneg = -99999999.99_rtype
 real(rtype), parameter, public :: pi = 3.14159265358979323_rtype
 
-!repeated from shoc_intr!
-real(rtype), parameter         :: p0_shoc = 100000._rtype
-
 !=========================================================
 ! Physical constants used in SHOC
 !=========================================================
@@ -49,6 +46,7 @@ real(rtype) :: lcond ! latent heat of vaporization [J/kg]
 real(rtype) :: lice  ! latent heat of fusion [J/kg]
 real(rtype) :: eps   ! rh2o/rair - 1 [-]
 real(rtype) :: vk    ! von karmann constant [-]
+real(rtype) :: p0    ! Reference pressure, Pa
 
 !=========================================================
 ! Tunable parameters used in SHOC
@@ -128,7 +126,7 @@ contains
 
 subroutine shoc_init( &
          nlev, gravit, rair, rh2o, cpair, &
-         zvir, latvap, latice, karman, &
+         zvir, latvap, latice, karman, p0_shoc, &
          pref_mid, nbot_shoc, ntop_shoc, &
          thl2tune_in, qw2tune_in, qwthl2tune_in, &
          w2tune_in, length_fac_in, c_diag_3rd_mom_in, &
@@ -151,6 +149,7 @@ subroutine shoc_init( &
   real(rtype), intent(in)  :: latvap ! latent heat of vaporization
   real(rtype), intent(in)  :: latice ! latent heat of fusion
   real(rtype), intent(in)  :: karman ! Von Karman's constant
+  real(rtype), intent(in)  :: p0_shoc! Reference pressure, Pa
 
   real(rtype), intent(in) :: pref_mid(nlev) ! reference pressures at midpoints
 
@@ -183,6 +182,7 @@ subroutine shoc_init( &
   lcond = latvap ! [J/kg]
   lice = latice  ! [J/kg]
   vk = karman    ! [-]
+  p0 = p0_shoc   ! [Pa]
 
   ! Tunable parameters, all unitless
   !  override default values if value is present
@@ -2920,8 +2920,8 @@ subroutine shoc_assumed_pdf_compute_s(&
       qn=s
     endif
   endif
-  
-  ! Prevent possibility of empty clouds or rare occurence of 
+
+  ! Prevent possibility of empty clouds or rare occurence of
   !  cloud liquid less than zero
   if (qn .le. 0._rtype) then
     C=0._rtype

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -613,7 +613,6 @@ end function shoc_implements_cnst
    real(r8) :: wv_a(pcols), wv_b(pcols), wl_b(pcols), wl_a(pcols)
    real(r8) :: se_dis(pcols), se_a(pcols), se_b(pcols), shoc_s(pcols,pver)
    real(r8) :: shoc_t(pcols,pver)
-   real(r8) :: sens_heat(pcols), cflx(pcols)
    
    ! --------------- !
    ! Pointers        !
@@ -828,9 +827,6 @@ end function shoc_implements_cnst
       wtracer_sfc(i,:) = 0._r8  ! in E3SM tracer fluxes are done elsewhere
    enddo               
    
-   sens_heat(1:ncol) = cam_in%shf(1:ncol)
-   cflx(1:ncol) = cam_in%cflx(1:ncol,1)
-
    !  Do the same for tracers 
    icnt=0
    do ixind=1,pcnst
@@ -855,7 +851,6 @@ end function shoc_implements_cnst
         wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
         wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
         inv_exner(:ncol,:),state1%phis(:ncol), & ! Input
-        sens_heat(:ncol), cflx(:ncol), &
         shoc_s(:ncol,:), tke_zt(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
         um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
         wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), & ! Input/Output

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -613,6 +613,7 @@ end function shoc_implements_cnst
    real(r8) :: wv_a(pcols), wv_b(pcols), wl_b(pcols), wl_a(pcols)
    real(r8) :: se_dis(pcols), se_a(pcols), se_b(pcols), shoc_s(pcols,pver)
    real(r8) :: shoc_t(pcols,pver)
+   real(r8) :: sens_heat(pcols), cflx(pcols)
    
    ! --------------- !
    ! Pointers        !
@@ -827,6 +828,9 @@ end function shoc_implements_cnst
       wtracer_sfc(i,:) = 0._r8  ! in E3SM tracer fluxes are done elsewhere
    enddo               
    
+   sens_heat(1:ncol) = cam_in%shf(1:ncol)
+   cflx(1:ncol) = cam_in%cflx(1:ncol,1)
+
    !  Do the same for tracers 
    icnt=0
    do ixind=1,pcnst
@@ -846,15 +850,16 @@ end function shoc_implements_cnst
 
    call shoc_main( &
         ncol, pver, pverp, dtime, nadv, & ! Input
-	host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),& ! Input
+        host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),& ! Input
         zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
-	wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
-	wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
-	inv_exner(:ncol,:),state1%phis(:ncol), & ! Input
-	shoc_s(:ncol,:), tke_zt(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
-	um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
-	wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), & ! Input/Output
-	rcm(:ncol,:),cloud_frac(:ncol,:), & ! Input/Output
+        wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
+        wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
+        inv_exner(:ncol,:),state1%phis(:ncol), & ! Input
+        sens_heat(:ncol), cflx(:ncol), &
+        shoc_s(:ncol,:), tke_zt(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
+        um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
+        wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), & ! Input/Output
+        rcm(:ncol,:),cloud_frac(:ncol,:), & ! Input/Output
         pblh(:ncol), & ! Output
         shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
         w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)   
@@ -940,6 +945,13 @@ end function shoc_implements_cnst
    !  Initialize the shallow convective detrainment rate, will always be zero
    dlf2(:,:) = 0.0_r8
 
+
+det_ice(:)=0.0
+det_s(:)=0.0
+
+
+#if 0
+
    lqice(:)        = .false.
    lqice(ixcldliq) = .true.
    lqice(ixcldice) = .true.
@@ -985,6 +997,8 @@ end function shoc_implements_cnst
     call physics_ptend_sum(ptend_loc,ptend_all,ncol)
     call physics_update(state1,ptend_loc,hdtime)
    
+#endif
+
     ! For purposes of this implementation, just set relvar and accre_enhan to 1
     relvar(:,:) = 1.0_r8
     accre_enhan(:,:) = 1._r8  

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -945,12 +945,8 @@ end function shoc_implements_cnst
    !  Initialize the shallow convective detrainment rate, will always be zero
    dlf2(:,:) = 0.0_r8
 
-
-det_ice(:)=0.0
-det_s(:)=0.0
-
-
-#if 0
+   det_ice(:)=0.0
+   det_s(:)=0.0
 
    lqice(:)        = .false.
    lqice(ixcldliq) = .true.
@@ -997,8 +993,6 @@ det_s(:)=0.0
     call physics_ptend_sum(ptend_loc,ptend_all,ncol)
     call physics_update(state1,ptend_loc,hdtime)
    
-#endif
-
     ! For purposes of this implementation, just set relvar and accre_enhan to 1
     relvar(:,:) = 1.0_r8
     accre_enhan(:,:) = 1._r8  

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -6,12 +6,12 @@ module shoc_intr
   !    by Peter Bogenschutz (Bogenschutz and Krueger 2013).            !
   !                                                                    !
   ! SHOC replaces the exisiting turbulence, shallow convection, and    !
-  !   macrophysics in E3SM                                             !  
-  !                                                                    ! 
+  !   macrophysics in E3SM                                             !
+  !                                                                    !
   !                                                                    !
   !---------------------------Code history---------------------------- !
-  ! Authors:  P. Bogenschutz                                           ! 
-  !                                                                    ! 
+  ! Authors:  P. Bogenschutz                                           !
+  !                                                                    !
   !------------------------------------------------------------------- !
 
   use shr_kind_mod,  only: r8=>shr_kind_r8
@@ -19,18 +19,18 @@ module shoc_intr
   use ppgrid,        only: pver, pverp
   use phys_control,  only: phys_getopts
   use physconst,     only: rair, cpair, gravit, latvap, latice, zvir, &
-                           rh2o, karman, tms_orocnst, tms_z0fac  
+                           rh2o, karman, tms_orocnst, tms_z0fac
   use constituents,  only: pcnst, cnst_add, stateq_names=>cnst_name
   use pbl_utils,     only: calc_ustar, calc_obklen
   use perf_mod,      only: t_startf, t_stopf
-  use cam_logfile,   only: iulog 
-  use shoc,          only: linear_interp, largeneg 
+  use cam_logfile,   only: iulog
+  use shoc,          only: linear_interp, largeneg
   use spmd_utils,    only: masterproc
   use cam_abortutils, only: endrun
- 
-  implicit none	
 
-  public :: shoc_init_cnst, shoc_implements_cnst		   
+  implicit none
+
+  public :: shoc_init_cnst, shoc_implements_cnst
 
   ! define physics buffer indicies here
   integer :: tke_idx, &     ! turbulent kinetic energy
@@ -38,7 +38,7 @@ module shoc_intr
              tk_idx, &
              wthv_idx, &       ! buoyancy flux
              cld_idx, &          ! Cloud fraction
-             tot_cloud_frac_idx, & ! Cloud fraction with higher ice threshold 
+             tot_cloud_frac_idx, & ! Cloud fraction with higher ice threshold
              concld_idx, &       ! Convective cloud fraction
              ast_idx, &          ! Stratiform cloud fraction
              alst_idx, &         ! Liquid stratiform cloud fraction
@@ -62,11 +62,11 @@ module shoc_intr
              fice_idx, &
 	     vmag_gust_idx, &
              ixq                 ! water vapor index in state%q array
-  
+
   integer :: ixtke ! SHOC_TKE index in state%q array
 
   integer :: cmfmc_sh_idx = 0
-    
+
   real(r8), parameter :: tke_tol = 0.0004_r8
 
   real(r8), parameter :: &
@@ -78,22 +78,22 @@ module shoc_intr
       shoc_liq_deep = 8.e-6, &
       shoc_liq_sh = 10.e-6, &
       shoc_ice_deep = 25.e-6, &
-      shoc_ice_sh = 50.e-6  
-         
+      shoc_ice_sh = 50.e-6
+
   logical      :: lq(pcnst)
 
   logical            :: history_budget
-  integer            :: history_budget_histfile_num  
+  integer            :: history_budget_histfile_num
   logical            :: micro_do_icesupersat
 
   character(len=16)  :: eddy_scheme      ! Default set in phys_control.F90
-  character(len=16)  :: deep_scheme      ! Default set in phys_control.F90 
-  
+  character(len=16)  :: deep_scheme      ! Default set in phys_control.F90
+
   real(r8), parameter :: unset_r8 = huge(1.0_r8)
-  
+
   real(r8) :: shoc_timestep = unset_r8  ! Default SHOC timestep set in namelist
   real(r8) :: dp1
-  
+
   real(r8) :: shoc_thl2tune = unset_r8
   real(r8) :: shoc_qw2tune = unset_r8
   real(r8) :: shoc_qwthl2tune = unset_r8
@@ -110,46 +110,46 @@ module shoc_intr
   real(r8) :: shoc_Ckm_s = unset_r8
 
   integer :: edsclr_dim
-  
+
   logical      :: prog_modal_aero
   real(r8) :: micro_mg_accre_enhan_fac = huge(1.0_r8) !Accretion enhancement factor from namelist
- 
+
   integer, parameter :: ncnst=1
   character(len=8) :: cnst_names(ncnst)
   logical :: do_cnst=.true.
- 
+
   logical :: liqcf_fix = .FALSE.  ! HW for liquid cloud fraction fix
-  logical :: relvar_fix = .FALSE. !PMA for relvar fix  
-  
+  logical :: relvar_fix = .FALSE. !PMA for relvar fix
+
   contains
-  
+
   ! =============================================================================== !
   !                                                                                 !
   ! =============================================================================== !
-  
+
   subroutine shoc_register_e3sm()
 
 #ifdef SHOC_SGS
     ! Add SHOC fields to pbuf
     use physics_buffer,  only: pbuf_add_field, dtype_r8, dyn_time_lvls
-    use ppgrid,          only: pver, pverp, pcols  
-    
+    use ppgrid,          only: pver, pverp, pcols
+
     call phys_getopts( eddy_scheme_out                 = eddy_scheme, &
-                       deep_scheme_out                 = deep_scheme, & 
+                       deep_scheme_out                 = deep_scheme, &
                        history_budget_out              = history_budget, &
                        history_budget_histfile_num_out = history_budget_histfile_num, &
                        micro_do_icesupersat_out        = micro_do_icesupersat, &
-                       micro_mg_accre_enhan_fac_out    = micro_mg_accre_enhan_fac)    
- 
-    cnst_names=(/'TKE   '/)    
- 
+                       micro_mg_accre_enhan_fac_out    = micro_mg_accre_enhan_fac)
+
+    cnst_names=(/'TKE   '/)
+
     ! TKE is prognostic in SHOC and should be advected by dynamics
     call cnst_add('SHOC_TKE',0._r8,0._r8,0._r8,ixtke,longname='turbulent kinetic energy',cam_outfld=.false.)
-  
+
     ! Fields that are not prognostic should be added to PBUF
     call pbuf_add_field('WTHV', 'global', dtype_r8, (/pcols,pver,dyn_time_lvls/), wthv_idx)
-    call pbuf_add_field('TKH', 'global', dtype_r8, (/pcols,pver,dyn_time_lvls/), tkh_idx) 
-    call pbuf_add_field('TK', 'global', dtype_r8, (/pcols,pver,dyn_time_lvls/), tk_idx) 
+    call pbuf_add_field('TKH', 'global', dtype_r8, (/pcols,pver,dyn_time_lvls/), tkh_idx)
+    call pbuf_add_field('TK', 'global', dtype_r8, (/pcols,pver,dyn_time_lvls/), tk_idx)
 
     call pbuf_add_field('pblh',       'global', dtype_r8, (/pcols/), pblh_idx)
     call pbuf_add_field('tke',        'global', dtype_r8, (/pcols, pverp/), tke_idx)
@@ -167,70 +167,70 @@ module shoc_intr
     call pbuf_add_field('FICE',       'physpkg',dtype_r8, (/pcols,pver/), fice_idx)
     call pbuf_add_field('RAD_CLUBB',  'global', dtype_r8, (/pcols,pver/), radf_idx)
     call pbuf_add_field('CMELIQ',     'physpkg',dtype_r8, (/pcols,pver/), cmeliq_idx)
-    
+
     call pbuf_add_field('vmag_gust',  'global', dtype_r8, (/pcols/),      vmag_gust_idx)
-  
+
 #endif
-  
+
   end subroutine shoc_register_e3sm
   ! =============================================================================== !
   !                                                                                 !
   ! =============================================================================== !
- 
+
 function shoc_implements_cnst(name)
 
   !--------------------------------------------------------------------
   ! Return true if specified constituent is implemented by this package
   !--------------------------------------------------------------------
 
-  character(len=*), intent(in) :: name 
+  character(len=*), intent(in) :: name
   logical :: shoc_implements_cnst
 
   shoc_implements_cnst = (do_cnst .and. any(name == cnst_names))
 
 end function shoc_implements_cnst
- 
+
   subroutine shoc_init_cnst(name, q, gcid)
-  
+
   !------------------------------------------------------------------- !
   ! Initialize the state for SHOC's prognostic variable                !
   !------------------------------------------------------------------- !
-  
+
     character(len=*), intent(in)  :: name     ! constituent name
     real(r8),         intent(out) :: q(:,:)   ! mass mixing ratio (gcol, plev)
     integer,          intent(in)  :: gcid(:)  ! global column id
-    
+
 #ifdef SHOC_SGS
     if (trim(name) == trim('SHOC_TKE')) q = tke_tol
-#endif  
+#endif
 
   end subroutine shoc_init_cnst
-  
+
   ! =============================================================================== !
   !                                                                                 !
   ! =============================================================================== !
-  
+
   subroutine shoc_readnl(nlfile)
-  
+
   !------------------------------------------------------------------- !
   ! Read in any namelist parameters here                               !
   !   (currently none)                                                 !
-  !------------------------------------------------------------------- !  
+  !------------------------------------------------------------------- !
 
     use units,           only: getunit, freeunit
     use namelist_utils,  only: find_group_name
     use mpishorthand
 
     character(len=*), intent(in) :: nlfile  ! filepath for file containing namelist input
-    
+
     integer :: iunit, read_status
-    
+
     namelist /shocpbl_diff_nl/ shoc_timestep, shoc_thl2tune, shoc_qw2tune, shoc_qwthl2tune, &
                                shoc_w2tune, shoc_length_fac, shoc_c_diag_3rd_mom, &
                                shoc_lambda_low, shoc_lambda_high, shoc_lambda_slope, &
                                shoc_lambda_thresh, shoc_Ckh, shoc_Ckm, shoc_Ckh_s, &
                                shoc_Ckm_s
-    
+
     !  Read namelist to determine if SHOC history should be called
     if (masterproc) then
       iunit = getunit()
@@ -246,8 +246,8 @@ end function shoc_implements_cnst
 
       close(unit=iunit)
       call freeunit(iunit)
-    end if    
-    
+    end if
+
 #ifdef SPMD
 ! Broadcast namelist variables
       call mpibcast(shoc_timestep,           1,   mpir8,   0, mpicom)
@@ -266,18 +266,18 @@ end function shoc_implements_cnst
       call mpibcast(shoc_Ckh_s,              1,   mpir8,   0, mpicom)
       call mpibcast(shoc_Ckm_s,              1,   mpir8,   0, mpicom)
 #endif
-  
+
   end subroutine shoc_readnl
-  
+
   ! =============================================================================== !
   !                                                                                 !
   ! =============================================================================== !
-  
+
   subroutine shoc_init_e3sm(pbuf2d, dp1_in)
 
   !------------------------------------------------------------------- !
   ! Initialize SHOC for E3SM                                           !
-  !------------------------------------------------------------------- !  
+  !------------------------------------------------------------------- !
 
     use physics_types,          only: physics_state, physics_ptend
     use ppgrid,                 only: pver, pverp, pcols
@@ -287,45 +287,45 @@ end function shoc_implements_cnst
     use physics_buffer,         only: pbuf_get_index, pbuf_set_field, &
                                       physics_buffer_desc
     use rad_constituents,       only: rad_cnst_get_info, rad_cnst_get_mode_num_idx, &
-                                      rad_cnst_get_mam_mmr_idx	
-    use constituents,           only: cnst_get_ind	
-    use shoc,                   only: shoc_init			      			      
+                                      rad_cnst_get_mam_mmr_idx
+    use constituents,           only: cnst_get_ind
+    use shoc,                   only: shoc_init
     use cam_history,            only: horiz_only, addfld, add_default
     use error_messages,         only: handle_errmsg
-    use trb_mtn_stress,         only: init_tms   
- 
+    use trb_mtn_stress,         only: init_tms
+
     implicit none
     !  Input Variables
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
-    
+
     real(r8) :: dp1_in
-    
+
     integer :: lptr
     integer :: nmodes, nspec, m, l, icnst, idw
     integer :: ixnumliq
     integer :: ntop_shoc
     integer :: nbot_shoc
-    character(len=128) :: errstring   
+    character(len=128) :: errstring
 
     logical :: history_amwg
- 
+
     lq(1:pcnst) = .true.
     edsclr_dim = pcnst
-    
+
     !----- Begin Code -----
 
     call cnst_get_ind('Q',ixq) ! get water vapor index from the state%q array
     ! ----------------------------------------------------------------- !
-    ! Determine how many constituents SHOC will transport.  Note that  
-    ! SHOC does not transport aerosol consituents.  Therefore, need to 
+    ! Determine how many constituents SHOC will transport.  Note that
+    ! SHOC does not transport aerosol consituents.  Therefore, need to
     ! determine how many aerosols constituents there are and subtract that
-    ! off of pcnst (the total consituents) 
+    ! off of pcnst (the total consituents)
     ! ----------------------------------------------------------------- !
 
     call phys_getopts(prog_modal_aero_out=prog_modal_aero, &
                       history_amwg_out = history_amwg, &
-                      liqcf_fix_out   = liqcf_fix)    
-    
+                      liqcf_fix_out   = liqcf_fix)
+
     ! Define physics buffers indexes
     cld_idx     = pbuf_get_index('CLD')         ! Cloud fraction
     tot_cloud_frac_idx     = pbuf_get_index('TOT_CLOUD_FRAC')         ! Cloud fraction
@@ -333,7 +333,7 @@ end function shoc_implements_cnst
     ast_idx     = pbuf_get_index('AST')         ! Stratiform cloud fraction
     alst_idx    = pbuf_get_index('ALST')        ! Liquid stratiform cloud fraction
     aist_idx    = pbuf_get_index('AIST')        ! Ice stratiform cloud fraction
-    qlst_idx    = pbuf_get_index('QLST')        ! Physical in-stratus LWC 
+    qlst_idx    = pbuf_get_index('QLST')        ! Physical in-stratus LWC
     qist_idx    = pbuf_get_index('QIST')        ! Physical in-stratus IWC
     dp_frac_idx = pbuf_get_index('DP_FRAC')     ! Deep convection cloud fraction
     icwmrdp_idx = pbuf_get_index('ICWMRDP')     ! In-cloud deep convective mixing ratio
@@ -343,31 +343,31 @@ end function shoc_implements_cnst
     prer_evap_idx   = pbuf_get_index('PRER_EVAP')
     qrl_idx         = pbuf_get_index('QRL')
     cmfmc_sh_idx    = pbuf_get_index('CMFMC_SH')
-    tke_idx         = pbuf_get_index('tke')   
+    tke_idx         = pbuf_get_index('tke')
     vmag_gust_idx = pbuf_get_index('vmag_gust')
- 
+
     if (is_first_step()) then
-      call pbuf_set_field(pbuf2d, wthv_idx, 0.0_r8) 
-      call pbuf_set_field(pbuf2d, tkh_idx, 0.0_r8) 
-      call pbuf_set_field(pbuf2d, tk_idx, 0.0_r8) 
+      call pbuf_set_field(pbuf2d, wthv_idx, 0.0_r8)
+      call pbuf_set_field(pbuf2d, tkh_idx, 0.0_r8)
+      call pbuf_set_field(pbuf2d, tk_idx, 0.0_r8)
       call pbuf_set_field(pbuf2d, fice_idx, 0.0_r8)
       call pbuf_set_field(pbuf2d, tke_idx, tke_tol)
       call pbuf_set_field(pbuf2d, alst_idx, 0.0_r8)
       call pbuf_set_field(pbuf2d, aist_idx, 0.0_r8)
-      
+
       call pbuf_set_field(pbuf2d, vmag_gust_idx,    1.0_r8)
-      
+
     endif
-    
+
     if (prog_modal_aero) then
        ! Turn off modal aerosols and decrement edsclr_dim accordingly
        call rad_cnst_get_info(0, nmodes=nmodes)
- 
+
        do m = 1, nmodes
           call rad_cnst_get_mode_num_idx(m, lptr)
           lq(lptr)=.false.
           edsclr_dim = edsclr_dim-1
- 
+
           call rad_cnst_get_info(0, m, nspec=nspec)
           do l = 1, nspec
              call rad_cnst_get_mam_mmr_idx(m, l, lptr)
@@ -375,14 +375,14 @@ end function shoc_implements_cnst
              edsclr_dim = edsclr_dim-1
           end do
        end do
- 
+
        !  In addition, if running with MAM, droplet number is transported
        !  in dropmixnuc, therefore we do NOT want SHOC to apply transport
        !  tendencies to avoid double counted.  Else, we apply tendencies.
        call cnst_get_ind('NUMLIQ',ixnumliq)
        lq(ixnumliq) = .false.
        edsclr_dim = edsclr_dim-1
-    endif 
+    endif
 
     ! Add SHOC fields
     call addfld('SHOC_TKE', (/'lev'/), 'A', 'm2/s2', 'TKE')
@@ -440,68 +440,68 @@ end function shoc_implements_cnst
     ! ---------------------------------------------------------------!
     ! Initialize SHOC                                                !
     ! ---------------------------------------------------------------!
- 
+
     ntop_shoc = 1    ! if >1, must be <= nbot_molec
-    nbot_shoc = pver ! currently always pver 
- 
+    nbot_shoc = pver ! currently always pver
+
     call shoc_init( &
           pver, gravit, rair, rh2o, cpair, &
-          zvir, latvap, latice, karman, &
+          zvir, latvap, latice, karman, p0_shoc, &
           pref_mid, nbot_shoc, ntop_shoc, &
           shoc_thl2tune, shoc_qw2tune, shoc_qwthl2tune, &
           shoc_w2tune, shoc_length_fac, shoc_c_diag_3rd_mom, &
           shoc_lambda_low, shoc_lambda_high, shoc_lambda_slope, &
           shoc_lambda_thresh, shoc_Ckh, shoc_Ckm, shoc_Ckh_s, &
           shoc_Ckm_s )
-    
+
     ! --------------- !
     ! End             !
     ! Initialization  !
-    ! --------------- !  
-    
-    dp1 = dp1_in  
-  
-  end subroutine shoc_init_e3sm   
-  
+    ! --------------- !
+
+    dp1 = dp1_in
+
+  end subroutine shoc_init_e3sm
+
   ! =============================================================================== !
   !                                                                                 !
   ! =============================================================================== !
-  
+
   subroutine shoc_tend_e3sm( &
                              state, ptend_all, pbuf, hdtime, &
 			     cmfmc, cam_in, sgh30, &
 			     macmic_it, cld_macmic_num_steps, &
 			     dlf, det_s, det_ice, alst_o)
-  
+
   !------------------------------------------------------------------- !
   ! Provide tendencies of shallow convection , turbulence, and         !
   !   macrophysics from SHOC to E3SM                                   !
-  !------------------------------------------------------------------- !  
-  
+  !------------------------------------------------------------------- !
+
     use physics_types,  only: physics_state, physics_ptend, &
                               physics_state_copy, physics_ptend_init, &
-                              physics_ptend_sum 
-			      
+                              physics_ptend_sum
+
     use physics_update_mod, only: physics_update
 
     use physics_buffer, only: pbuf_get_index, pbuf_old_tim_idx, pbuf_get_field, &
-                              pbuf_set_field, physics_buffer_desc	
-			      
+                              pbuf_set_field, physics_buffer_desc
+
     use ppgrid,         only: pver, pverp, pcols
     use constituents,   only: cnst_get_ind
     use camsrfexch,     only: cam_in_t
-    use ref_pres,       only: top_lev => trop_cloud_top_lev  
-    use time_manager,   only: is_first_step   
+    use ref_pres,       only: top_lev => trop_cloud_top_lev
+    use time_manager,   only: is_first_step
     use wv_saturation,  only: qsat
-    use micro_mg_cam,   only: micro_mg_version  
-    use cldfrc2m,                  only: aist_vector 
+    use micro_mg_cam,   only: micro_mg_version
+    use cldfrc2m,                  only: aist_vector
     use trb_mtn_stress,            only: compute_tms
     use shoc,           only: shoc_main
     use cam_history,    only: outfld
     use iop_data_mod,   only: single_column, dp_crm
- 
+
     implicit none
-    
+
    ! --------------- !
    ! Input Auguments !
    ! --------------- !
@@ -513,11 +513,11 @@ end function shoc_implements_cnst
    real(r8),            intent(in)    :: cmfmc(pcols,pverp)       ! convective mass flux--m sub c           [kg/m2/s]
    real(r8),            intent(in)    :: sgh30(pcols)             ! std deviation of orography              [m]
    integer,             intent(in)    :: cld_macmic_num_steps     ! number of mac-mic iterations
-   integer,             intent(in)    :: macmic_it                ! number of mac-mic iterations    		      		  
+   integer,             intent(in)    :: macmic_it                ! number of mac-mic iterations
    ! ---------------------- !
    ! Input-Output Auguments !
    ! ---------------------- !
-    
+
    type(physics_buffer_desc), pointer :: pbuf(:)
 
    ! ---------------------- !
@@ -526,18 +526,18 @@ end function shoc_implements_cnst
 
    type(physics_ptend), intent(out)   :: ptend_all                 ! package tendencies
 
-   ! These two variables are needed for energy check    
+   ! These two variables are needed for energy check
    real(r8),            intent(out)   :: det_s(pcols)              ! Integral of detrained static energy from ice
    real(r8),            intent(out)   :: det_ice(pcols)            ! Integral of detrained ice for energy check
 
-   real(r8), intent(out) :: alst_o(pcols,pver)  ! H. Wang: for old liquid status fraction 
-   
+   real(r8), intent(out) :: alst_o(pcols,pver)  ! H. Wang: for old liquid status fraction
+
    ! --------------- !
    ! Local Variables !
    ! --------------- !
 
    integer :: shoctop(pcols)
-   
+
 #ifdef SHOC_SGS
 
    type(physics_state) :: state1                ! Local copy of state variable
@@ -550,9 +550,9 @@ end function shoc_implements_cnst
    integer :: err_code                          ! Diagnostic, for if some calculation goes amiss.
    integer :: begin_height, end_height
    integer :: icnt
-   
-   real(r8) :: dtime                            ! SHOC time step                              [s]   
-   real(r8) :: edsclr_in(pcols,pver,edsclr_dim)      ! Scalars to be diffused through SHOC         [units vary]   
+
+   real(r8) :: dtime                            ! SHOC time step                              [s]
+   real(r8) :: edsclr_in(pcols,pver,edsclr_dim)      ! Scalars to be diffused through SHOC         [units vary]
    real(r8) :: edsclr_out(pcols,pver,edsclr_dim)
    real(r8) :: rcm_in(pcols,pver)
    real(r8) :: cloudfrac_shoc(pcols,pver)
@@ -575,12 +575,12 @@ end function shoc_implements_cnst
    real(r8) :: cloud_frac(pcols,pver)          ! CLUBB cloud fraction                          [fraction]
    real(r8) :: ice_cloud_frac(pcols,pver)          ! ice number aware cloud fraction, 0 or 1
    real(r8) :: precipitating_ice_frac(pcols,pver)        ! precipitating ice fraction, 0 or 1
-   real(r8) :: liq_cloud_frac(pcols,pver)     
+   real(r8) :: liq_cloud_frac(pcols,pver)
    real(r8) :: dlf2(pcols,pver)
    real(r8) :: isotropy(pcols,pver)
    real(r8) :: host_dx, host_dy
    real(r8) :: host_temp(pcols,pver)
-   real(r8) :: host_dx_in(pcols), host_dy_in(pcols)  
+   real(r8) :: host_dx_in(pcols), host_dy_in(pcols)
    real(r8) :: shoc_mix_out(pcols,pver), tk_in(pcols,pver), tkh_in(pcols,pver)
    real(r8) :: isotropy_out(pcols,pver), tke_zt(pcols,pver)
    real(r8) :: w_sec_out(pcols,pver), thl_sec_out(pcols,pverp)
@@ -597,89 +597,89 @@ end function shoc_implements_cnst
 
    real(r8) :: obklen(pcols), ustar2(pcols), kinheat(pcols), kinwat(pcols)
    real(r8) :: dummy2(pcols), dummy3(pcols), kbfs(pcols), th(pcols,pver), thv(pcols,pver)
-   real(r8) :: thv2(pcols,pver)  
- 
+   real(r8) :: thv2(pcols,pver)
+
    real(r8) :: minqn, rrho(pcols,pver), rrho_i(pcols,pverp)    ! minimum total cloud liquid + ice threshold    [kg/kg]
    real(r8) :: cldthresh, frac_limit
    real(r8) :: ic_limit, dum1
    real(r8) :: inv_exner_surf, pot_temp
- 
+
    real(r8) :: wpthlp_sfc(pcols), wprtp_sfc(pcols), upwp_sfc(pcols), vpwp_sfc(pcols)
    real(r8) :: wtracer_sfc(pcols,edsclr_dim)
 
-  
+
    ! Variables below are needed to compute energy integrals for conservation
    real(r8) :: ke_a(pcols), ke_b(pcols), te_a(pcols), te_b(pcols)
    real(r8) :: wv_a(pcols), wv_b(pcols), wl_b(pcols), wl_a(pcols)
    real(r8) :: se_dis(pcols), se_a(pcols), se_b(pcols), shoc_s(pcols,pver)
    real(r8) :: shoc_t(pcols,pver)
-   
+
    ! --------------- !
    ! Pointers        !
    ! --------------- !
-  
+
    real(r8), pointer, dimension(:,:) :: tke_zi  ! turbulent kinetic energy, interface
    real(r8), pointer, dimension(:,:) :: wthv ! buoyancy flux
-   real(r8), pointer, dimension(:,:) :: tkh 
+   real(r8), pointer, dimension(:,:) :: tkh
    real(r8), pointer, dimension(:,:) :: tk
    real(r8), pointer, dimension(:,:) :: cld      ! cloud fraction                               [fraction]
    real(r8), pointer, dimension(:,:) :: tot_cloud_frac      ! cloud fraction                               [fraction]
    real(r8), pointer, dimension(:,:) :: concld   ! convective cloud fraction                    [fraction]
    real(r8), pointer, dimension(:,:) :: ast      ! stratiform cloud fraction                    [fraction]
    real(r8), pointer, dimension(:,:) :: alst     ! liquid stratiform cloud fraction             [fraction]
-   real(r8), pointer, dimension(:,:) :: aist     ! ice stratiform cloud fraction                [fraction] 
-   real(r8), pointer, dimension(:,:) :: cmeliq 
-           
+   real(r8), pointer, dimension(:,:) :: aist     ! ice stratiform cloud fraction                [fraction]
+   real(r8), pointer, dimension(:,:) :: cmeliq
+
    real(r8), pointer, dimension(:,:) :: qlst     ! Physical in-stratus LWC                      [kg/kg]
    real(r8), pointer, dimension(:,:) :: qist     ! Physical in-stratus IWC                      [kg/kg]
    real(r8), pointer, dimension(:,:) :: deepcu   ! deep convection cloud fraction               [fraction]
-   real(r8), pointer, dimension(:,:) :: shalcu   ! shallow convection cloud fraction            [fraction]    
+   real(r8), pointer, dimension(:,:) :: shalcu   ! shallow convection cloud fraction            [fraction]
    real(r8), pointer, dimension(:,:) :: khzt     ! eddy diffusivity on thermo levels            [m^2/s]
    real(r8), pointer, dimension(:,:) :: khzm     ! eddy diffusivity on momentum levels          [m^2/s]
    real(r8), pointer, dimension(:) :: pblh     ! planetary boundary layer height                [m]
-   real(r8), pointer, dimension(:,:) :: dp_icwmr ! deep convection in cloud mixing ratio        [kg/kg] 
-   real(r8), pointer, dimension(:,:) :: cmfmc_sh ! Shallow convective mass flux--m subc (pcols,pverp) [kg/m2/s/]     
+   real(r8), pointer, dimension(:,:) :: dp_icwmr ! deep convection in cloud mixing ratio        [kg/kg]
+   real(r8), pointer, dimension(:,:) :: cmfmc_sh ! Shallow convective mass flux--m subc (pcols,pverp) [kg/m2/s/]
 
-   real(r8), pointer, dimension(:,:) :: prer_evap 
+   real(r8), pointer, dimension(:,:) :: prer_evap
    real(r8), pointer, dimension(:,:) :: accre_enhan
    real(r8), pointer, dimension(:,:) :: relvar
-   
+
    logical :: lqice(pcnst)
    real(r8) :: relvarmax
-   
+
    !------------------------------------------------------------------!
    !------------------------------------------------------------------!
    !------------------------------------------------------------------!
    !       MAIN COMPUTATION BEGINS HERE                               !
    !------------------------------------------------------------------!
    !------------------------------------------------------------------!
-   !------------------------------------------------------------------!   
-   
+   !------------------------------------------------------------------!
+
  !  Get indicees for cloud and ice mass and cloud and ice number
    ic_limit   = 1.e-12_r8
    frac_limit = 0.01_r8
-   
+
    call cnst_get_ind('CLDLIQ',ixcldliq)
    call cnst_get_ind('CLDICE',ixcldice)
    call cnst_get_ind('NUMLIQ',ixnumliq)
    call cnst_get_ind('NUMICE',ixnumice)
-   
+
    call physics_ptend_init(ptend_loc,state%psetcols, 'shoc', ls=.true., lu=.true., lv=.true., lq=lq)
-   
+
    call physics_state_copy(state,state1)
-   
+
    !  Determine number of columns and which chunk computation is to be performed on
    ncol = state%ncol
-   lchnk = state%lchnk    
-   
-   !  Determine time step of physics buffer 
-   itim_old = pbuf_old_tim_idx()     
-   
-   !  Establish associations between pointers and physics buffer fields   
+   lchnk = state%lchnk
+
+   !  Determine time step of physics buffer
+   itim_old = pbuf_old_tim_idx()
+
+   !  Establish associations between pointers and physics buffer fields
    call pbuf_get_field(pbuf, tke_idx,     tke_zi)
-   call pbuf_get_field(pbuf, wthv_idx,     wthv,     start=(/1,1,itim_old/), kount=(/pcols,pver,1/))  
-   call pbuf_get_field(pbuf, tkh_idx,      tkh,     start=(/1,1,itim_old/), kount=(/pcols,pver,1/))  
-   call pbuf_get_field(pbuf, tk_idx,       tk,     start=(/1,1,itim_old/), kount=(/pcols,pver,1/))  
+   call pbuf_get_field(pbuf, wthv_idx,     wthv,     start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
+   call pbuf_get_field(pbuf, tkh_idx,      tkh,     start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
+   call pbuf_get_field(pbuf, tk_idx,       tk,     start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
    call pbuf_get_field(pbuf, cld_idx,     cld,     start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
    call pbuf_get_field(pbuf, tot_cloud_frac_idx,     tot_cloud_frac,     start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
    call pbuf_get_field(pbuf, concld_idx,  concld,  start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
@@ -688,7 +688,7 @@ end function shoc_implements_cnst
    call pbuf_get_field(pbuf, aist_idx,    aist,    start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
    call pbuf_get_field(pbuf, qlst_idx,    qlst,    start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
    call pbuf_get_field(pbuf, qist_idx,    qist,    start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
-   
+
    call pbuf_get_field(pbuf, prer_evap_idx, prer_evap)
    call pbuf_get_field(pbuf, accre_enhan_idx, accre_enhan)
    call pbuf_get_field(pbuf, cmeliq_idx,  cmeliq)
@@ -699,40 +699,40 @@ end function shoc_implements_cnst
    call pbuf_get_field(pbuf, kvh_idx,     khzt)
    call pbuf_get_field(pbuf, pblh_idx,    pblh)
    call pbuf_get_field(pbuf, icwmrdp_idx, dp_icwmr)
-   call pbuf_get_field(pbuf, cmfmc_sh_idx, cmfmc_sh)  
-   
+   call pbuf_get_field(pbuf, cmfmc_sh_idx, cmfmc_sh)
+
    !  Determine SHOC time step.
-   
+
    dtime = shoc_timestep
-   
+
    !  If requested SHOC timestep is < 0 then set the SHOC time step
    !    equal to hdtime (the macrophysics/microphysics timestep).
-   
+
    if (dtime < 0._r8) then
      dtime = hdtime
    endif
-   
+
    !  Now perform checks to determine if the requested SHOC timestep
    !   is reasonable based on the host model time step.
-   
+
    ! Is SHOC timestep greater than the macrophysics/microphysics timestep?
    if (dtime .gt. hdtime) then
      call endrun('shoc_tend_e3sm: Requested SHOC time step is greater than the macrophysics/microphysics timestep')
    endif
-   
+
    ! Does SHOC timestep divide evenly into the macrophysics/microphyscs timestep?
    if (mod(hdtime,dtime) .ne. 0) then
      call endrun('shoc_tend_e3sm:  SHOC time step and HOST time step NOT compatible')
    endif
 
    ! If we survived this far, then the SHOC timestep is valid.
-  
-   !  determine number of timesteps SHOC core should be advanced, 
-   !  host time step divided by SHOC time step  
+
+   !  determine number of timesteps SHOC core should be advanced,
+   !  host time step divided by SHOC time step
    nadv = max(hdtime/dtime,1._r8)
 
    ! Set grid space, in meters. If SCM, set to a grid size representative
-   !  of a typical GCM.  Otherwise, compute locally.    
+   !  of a typical GCM.  Otherwise, compute locally.
    if (single_column .and. .not. dp_crm) then
      host_dx_in(:) = 100000._r8
      host_dy_in(:) = 100000._r8
@@ -743,55 +743,55 @@ end function shoc_implements_cnst
    else
      call grid_size(state1, host_dx_in, host_dy_in)
    endif
- 
+
    minqn = 0._r8
    newfice(:,:) = 0._r8
    where(state1%q(:ncol,:pver,ixcldice) .gt. minqn) &
-       newfice(:ncol,:pver) = state1%q(:ncol,:pver,ixcldice)/(state1%q(:ncol,:pver,ixcldliq)+state1%q(:ncol,:pver,ixcldice))  
-       
+       newfice(:ncol,:pver) = state1%q(:ncol,:pver,ixcldice)/(state1%q(:ncol,:pver,ixcldliq)+state1%q(:ncol,:pver,ixcldice))
+
    ! TODO: Create a general function to calculate Exner's formula - see full
    ! comment in micro_p3_interface.F90
    do k=1,pver
      do i=1,ncol
        inv_exner(i,k) = 1._r8/((state1%pmid(i,k)/p0_shoc)**(rair/cpair))
      enddo
-   enddo       
-       
-   !  At each SHOC call, initialize mean momentum  and thermo SHOC state 
+   enddo
+
+   !  At each SHOC call, initialize mean momentum  and thermo SHOC state
    !  from the E3SM state
-   
+
    do k=1,pver   ! loop over levels
      do i=1,ncol ! loop over columns
-     
+
        rvm(i,k) = state1%q(i,k,ixq)
        rcm(i,k) = state1%q(i,k,ixcldliq)
        rtm(i,k) = rvm(i,k) + rcm(i,k)
        um(i,k) = state1%u(i,k)
        vm(i,k) = state1%v(i,k)
-       
+
        pot_temp = state1%t(i,k)*inv_exner(i,k)
        thlm(i,k) = pot_temp-(pot_temp/state1%t(i,k))*(latvap/cpair)*state1%q(i,k,ixcldliq)
-       thv(i,k) = state1%t(i,k)*inv_exner(i,k)*(1.0_r8+zvir*state1%q(i,k,ixq)-state1%q(i,k,ixcldliq)) 
- 
+       thv(i,k) = state1%t(i,k)*inv_exner(i,k)*(1.0_r8+zvir*state1%q(i,k,ixq)-state1%q(i,k,ixcldliq))
+
        tke_zt(i,k) = max(tke_tol,state1%q(i,k,ixtke))
-       
-       ! Cloud fraction needs to be initialized for first 
+
+       ! Cloud fraction needs to be initialized for first
        !  PBL height calculation call
-       cloud_frac(i,k) = alst(i,k) 
-     
+       cloud_frac(i,k) = alst(i,k)
+
      enddo
-   enddo         
-   
+   enddo
+
    ! ------------------------------------------------- !
    ! Prepare inputs for SHOC call                      !
-   ! ------------------------------------------------- ! 
-   
+   ! ------------------------------------------------- !
+
    do k=1,pver
      do i=1,ncol
        dz_g(i,k) = state1%zi(i,k)-state1%zi(i,k+1)  ! compute thickness
      enddo
    enddo
-   
+
    !  Define the SHOC thermodynamic grid (in units of m)
    wm_zt(:,pver) = 0._r8
    do k=1,pver
@@ -802,7 +802,7 @@ end function shoc_implements_cnst
        shoc_s(i,k) = state1%s(i,k)
      enddo
    enddo
-     
+
    do k=1,pverp
      do i=1,ncol
        zi_g(i,k) = state1%zi(i,k)-state1%zi(i,pver+1)
@@ -823,14 +823,14 @@ end function shoc_implements_cnst
 
       wprtp_sfc(i)  = cam_in%cflx(i,1)/(rrho_i(i,pverp))      ! Latent heat flux
       upwp_sfc(i)   = cam_in%wsx(i)/rrho_i(i,pverp)               ! Surface meridional momentum flux
-      vpwp_sfc(i)   = cam_in%wsy(i)/rrho_i(i,pverp)               ! Surface zonal momentum flux  
+      vpwp_sfc(i)   = cam_in%wsy(i)/rrho_i(i,pverp)               ! Surface zonal momentum flux
       wtracer_sfc(i,:) = 0._r8  ! in E3SM tracer fluxes are done elsewhere
-   enddo               
-   
-   !  Do the same for tracers 
+   enddo
+
+   !  Do the same for tracers
    icnt=0
    do ixind=1,pcnst
-     if (lq(ixind))  then 
+     if (lq(ixind))  then
        icnt=icnt+1
        do k=1,pver
          do i=1,ncol
@@ -838,11 +838,11 @@ end function shoc_implements_cnst
          enddo
        enddo
      end if
-   enddo    
-    
+   enddo
+
    ! ------------------------------------------------- !
    ! Actually call SHOC                                !
-   ! ------------------------------------------------- !   
+   ! ------------------------------------------------- !
 
    call shoc_main( &
         ncol, pver, pverp, dtime, nadv, & ! Input
@@ -857,23 +857,23 @@ end function shoc_implements_cnst
         rcm(:ncol,:),cloud_frac(:ncol,:), & ! Input/Output
         pblh(:ncol), & ! Output
         shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
-        w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)   
+        w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)
         wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
         uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
         wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
-   
+
    ! Transfer back to pbuf variables
-   
+
    do k=1,pver
-     do i=1,ncol 
+     do i=1,ncol
        cloud_frac(i,k) = min(cloud_frac(i,k),1._r8)
       enddo
    enddo
-      
+
 !sort out edsclr_in, edsclr_out
    do ixind=1,edsclr_dim
      edsclr_out(:,:,ixind) = edsclr_in(:,:,ixind)
-   enddo 
+   enddo
 
 
    ! Eddy diffusivities and TKE are needed for aerosol activation code.
@@ -890,17 +890,17 @@ end function shoc_implements_cnst
    !  Now compute the tendencies of SHOC to E3SM
    do k=1,pver
      do i=1,ncol
-       
+
        ptend_loc%u(i,k) = (um(i,k)-state1%u(i,k))/hdtime
-       ptend_loc%v(i,k) = (vm(i,k)-state1%v(i,k))/hdtime           
+       ptend_loc%v(i,k) = (vm(i,k)-state1%v(i,k))/hdtime
        ptend_loc%q(i,k,ixq) = (rtm(i,k)-rcm(i,k)-state1%q(i,k,ixq))/hdtime ! water vapor
        ptend_loc%q(i,k,ixcldliq) = (rcm(i,k)-state1%q(i,k,ixcldliq))/hdtime   ! Tendency of liquid water
        ptend_loc%s(i,k) = (shoc_s(i,k)-state1%s(i,k))/hdtime
-       
+
        ptend_loc%q(i,k,ixtke)=(tke_zt(i,k)-state1%q(i,k,ixtke))/hdtime ! TKE
-       
+
    !  Apply tendencies to ice mixing ratio, liquid and ice number, and aerosol constituents.
-   !  Loading up this array doesn't mean the tendencies are applied.  
+   !  Loading up this array doesn't mean the tendencies are applied.
    !  edsclr_out is compressed with just the constituents being used, ptend and state are not compressed
 
        icnt=0
@@ -908,35 +908,35 @@ end function shoc_implements_cnst
          if (lq(ixind)) then
            icnt=icnt+1
            if ((ixind /= ixq) .and. (ixind /= ixcldliq) .and. (ixind /= ixtke)) then
-             ptend_loc%q(i,k,ixind) = (edsclr_out(i,k,icnt)-state1%q(i,k,ixind))/hdtime ! transported constituents 
+             ptend_loc%q(i,k,ixind) = (edsclr_out(i,k,icnt)-state1%q(i,k,ixind))/hdtime ! transported constituents
            end if
          end if
        enddo
 
      enddo
-   enddo   
-   
+   enddo
+
    cmeliq(:,:) = ptend_loc%q(:,:,ixcldliq)
-  
+
    ! Update physics tendencies
    call physics_ptend_init(ptend_all, state%psetcols, 'shoc')
    call physics_ptend_sum(ptend_loc,ptend_all,ncol)
    call physics_update(state1,ptend_loc,hdtime)
-   
+
    ! ------------------------------------------------------------ !
-   ! ------------------------------------------------------------ ! 
+   ! ------------------------------------------------------------ !
    ! ------------------------------------------------------------ !
    ! The rest of the code deals with diagnosing variables         !
    ! for microphysics/radiation computation and macrophysics      !
    ! ------------------------------------------------------------ !
    ! ------------------------------------------------------------ !
-   ! ------------------------------------------------------------ !   
-   
-   ! --------------------------------------------------------------------------------- !  
+   ! ------------------------------------------------------------ !
+
+   ! --------------------------------------------------------------------------------- !
    !  COMPUTE THE ICE CLOUD DETRAINMENT                                                !
    !  Detrainment of convective condensate into the environment or stratiform cloud    !
    ! --------------------------------------------------------------------------------- !
-   
+
    !  Initialize the shallow convective detrainment rate, will always be zero
    dlf2(:,:) = 0.0_r8
 
@@ -947,9 +947,9 @@ end function shoc_implements_cnst
    lqice(ixcldliq) = .true.
    lqice(ixcldice) = .true.
    lqice(ixnumliq) = .true.
-   lqice(ixnumice) = .true.   
-   
-   call physics_ptend_init(ptend_loc,state%psetcols, 'clubb_det', ls=.true., lq=lqice)   
+   lqice(ixnumice) = .true.
+
+   call physics_ptend_init(ptend_loc,state%psetcols, 'clubb_det', ls=.true., lq=lqice)
    do k=1,pver
       do i=1,ncol
          if( state1%t(i,k) > shoc_tk1 ) then
@@ -961,62 +961,62 @@ end function shoc_implements_cnst
             !(clubb_tk1 - clubb_tk2) is also 30.0 but it introduced a non-bfb change
             dum1 = ( shoc_tk1 - state1%t(i,k) ) /(shoc_tk1 - shoc_tk2)
          endif
-        
+
          ptend_loc%q(i,k,ixcldliq) = dlf(i,k) * ( 1._r8 - dum1 )
          ptend_loc%q(i,k,ixcldice) = dlf(i,k) * dum1
          ptend_loc%q(i,k,ixnumliq) = 3._r8 * ( max(0._r8, ( dlf(i,k) - dlf2(i,k) )) * ( 1._r8 - dum1 ) ) &
                                      / (4._r8*3.14_r8* shoc_liq_deep**3*997._r8) + & ! Deep    Convection
                                      3._r8 * (                         dlf2(i,k)    * ( 1._r8 - dum1 ) ) &
-                                     / (4._r8*3.14_r8*shoc_liq_sh**3*997._r8)     ! Shallow Convection 
+                                     / (4._r8*3.14_r8*shoc_liq_sh**3*997._r8)     ! Shallow Convection
          ptend_loc%q(i,k,ixnumice) = 3._r8 * ( max(0._r8, ( dlf(i,k) - dlf2(i,k) )) *  dum1 ) &
                                      / (4._r8*3.14_r8*shoc_ice_deep**3*500._r8) + & ! Deep    Convection
                                      3._r8 * (                         dlf2(i,k)    *  dum1 ) &
                                      / (4._r8*3.14_r8*shoc_ice_sh**3*500._r8)     ! Shallow Convection
          ptend_loc%s(i,k)          = dlf(i,k) * dum1 * latice
- 
+
          ! Only rliq is saved from deep convection, which is the reserved liquid.  We need to keep
          !   track of the integrals of ice and static energy that is effected from conversion to ice
          !   so that the energy checker doesn't complain.
          det_s(i)                  = det_s(i) + ptend_loc%s(i,k)*state1%pdel(i,k)/gravit
          det_ice(i)                = det_ice(i) - ptend_loc%q(i,k,ixcldice)*state1%pdel(i,k)/gravit
- 
+
       enddo
     enddo
 
     det_ice(:ncol) = det_ice(:ncol)/1000._r8  ! divide by density of water
-   
+
     call physics_ptend_sum(ptend_loc,ptend_all,ncol)
     call physics_update(state1,ptend_loc,hdtime)
-   
+
     ! For purposes of this implementation, just set relvar and accre_enhan to 1
     relvar(:,:) = 1.0_r8
-    accre_enhan(:,:) = 1._r8  
-   
+    accre_enhan(:,:) = 1._r8
+
 ! +++ JShpund: add relative cloud liquid variance (a vectorized version based on CLUBB)
 !     TODO: double check the hardcoded values ('relvarmax', '0.001_r8')
     relvarmax = 10.0_r8
     where (rcm(:ncol,:pver) /= 0.0 .and. rcm2(:ncol,:pver) /= 0.0) &
            relvar(:ncol,:pver) = min(relvarmax,max(0.001_r8,rcm(:ncol,:pver)**2.0/rcm2(:ncol,:pver)))
 
-    ! --------------------------------------------------------------------------------- ! 
+    ! --------------------------------------------------------------------------------- !
     !  Diagnose some quantities that are computed in macrop_tend here.                  !
     !  These are inputs required for the microphysics calculation.                      !
     !                                                                                   !
     !  FIRST PART COMPUTES THE STRATIFORM CLOUD FRACTION FROM SHOC CLOUD FRACTION       !
-    ! --------------------------------------------------------------------------------- ! 
-   
+    ! --------------------------------------------------------------------------------- !
+
     ! HW: set alst to alst_o before getting updated
     if(liqcf_fix) then
       if(.not.is_first_step()) alst_o(:ncol,:pver) = alst(:ncol,:pver)
     endif
 
-    !  initialize variables 
+    !  initialize variables
     alst(:,:) = 0.0_r8
-    qlst(:,:) = 0.0_r8 
- 
+    qlst(:,:) = 0.0_r8
+
     do k=1,pver
       do i=1,ncol
-        alst(i,k) = cloud_frac(i,k)   
+        alst(i,k) = cloud_frac(i,k)
         qlst(i,k) = rcm(i,k)/max(0.01_r8,alst(i,k))  ! Incloud stratus condensate mixing ratio
       enddo
     enddo
@@ -1024,56 +1024,56 @@ end function shoc_implements_cnst
     ! HW
     if(liqcf_fix) then
       if(is_first_step()) alst_o(:ncol,:pver) = alst(:ncol,:pver)
-    endif  
-   
-    ! --------------------------------------------------------------------------------- !  
+    endif
+
+    ! --------------------------------------------------------------------------------- !
     !  THIS PART COMPUTES CONVECTIVE AND DEEP CONVECTIVE CLOUD FRACTION                 !
-    ! --------------------------------------------------------------------------------- ! 
- 
+    ! --------------------------------------------------------------------------------- !
+
     deepcu(:,pver) = 0.0_r8
     shalcu(:,pver) = 0.0_r8
- 
+
     do k=1,pver-1
       do i=1,ncol
-        !  diagnose the deep convective cloud fraction, as done in macrophysics based on the 
-        !  deep convective mass flux, read in from pbuf.  Since shallow convection is never 
+        !  diagnose the deep convective cloud fraction, as done in macrophysics based on the
+        !  deep convective mass flux, read in from pbuf.  Since shallow convection is never
         !  called, the shallow convective mass flux will ALWAYS be zero, ensuring that this cloud
-        !  fraction is purely from deep convection scheme.  
+        !  fraction is purely from deep convection scheme.
         deepcu(i,k) = max(0.0_r8,min(dp1*log(1.0_r8+500.0_r8*(cmfmc(i,k+1)-cmfmc_sh(i,k+1))),0.6_r8))
         shalcu(i,k) = 0._r8
-       
+
         if (deepcu(i,k) <= frac_limit .or. dp_icwmr(i,k) < ic_limit) then
           deepcu(i,k) = 0._r8
         endif
-             
-        !  using the deep convective cloud fraction, and SHOC cloud fraction (variable 
+
+        !  using the deep convective cloud fraction, and SHOC cloud fraction (variable
         !  "cloud_frac"), compute the convective cloud fraction.  This follows the formulation
-        !  found in macrophysics code.  Assumes that convective cloud is all nonstratiform cloud 
+        !  found in macrophysics code.  Assumes that convective cloud is all nonstratiform cloud
         !  from SHOC plus the deep convective cloud fraction
         concld(i,k) = min(cloud_frac(i,k)-alst(i,k)+deepcu(i,k),0.80_r8)
       enddo
-    enddo   
-   
-    ! --------------------------------------------------------------------------------- !  
+    enddo
+
+    ! --------------------------------------------------------------------------------- !
     !  COMPUTE THE ICE CLOUD FRACTION PORTION                                           !
     !  use the aist_vector function to compute the ice cloud fraction                   !
     ! --------------------------------------------------------------------------------- !
-   
+
     do k=1,pver
       call aist_vector(state1%q(:,k,ixq),state1%t(:,k),state1%pmid(:,k),state1%q(:,k,ixcldice), &
            state1%q(:,k,ixnumice),cam_in%landfrac(:),cam_in%snowhland(:),aist(:,k),ncol)
     enddo
-   
-    ! --------------------------------------------------------------------------------- !  
+
+    ! --------------------------------------------------------------------------------- !
     !  THIS PART COMPUTES THE LIQUID STRATUS FRACTION                                   !
     !                                                                                   !
     !  For now leave the computation of ice stratus fraction from macrop_driver intact  !
-    !  because SHOC does nothing with ice.  Here I simply overwrite the liquid stratus ! 
+    !  because SHOC does nothing with ice.  Here I simply overwrite the liquid stratus !
     !  fraction that was coded in macrop_driver                                         !
-    ! --------------------------------------------------------------------------------- !  
- 
+    ! --------------------------------------------------------------------------------- !
+
     !  Recompute net stratus fraction using maximum over-lapping assumption, as done
-    !  in macrophysics code, using alst computed above and aist read in from physics buffer            
+    !  in macrophysics code, using alst computed above and aist read in from physics buffer
 
     cldthresh=1.e-18_r8
 
@@ -1082,27 +1082,27 @@ end function shoc_implements_cnst
 
         ast(i,k) = max(alst(i,k),aist(i,k))
 
-        qist(i,k) = state1%q(i,k,ixcldice)/max(0.01_r8,aist(i,k)) 
+        qist(i,k) = state1%q(i,k,ixcldice)/max(0.01_r8,aist(i,k))
       enddo
     enddo
-   
-    !  Probably need to add deepcu cloud fraction to the cloud fraction array, else would just 
+
+    !  Probably need to add deepcu cloud fraction to the cloud fraction array, else would just
     !  be outputting the shallow convective cloud fraction
- 
+
     !  Add liq, ice, and precipitating ice fractions here. These are purely
     !  diagnostic outputs and do not impact the rest of the code. The qi threshold for
-    !  setting ice_cloud_fraction and the qi dependent ni_threshold are tunable. 
+    !  setting ice_cloud_fraction and the qi dependent ni_threshold are tunable.
 
     liq_cloud_frac = 0.0_r8
     ice_cloud_frac = 0.0_r8
     precipitating_ice_frac = 0.0_r8
     tot_cloud_frac = 0.0_r8
- 
+
     do k=1,pver
       do i=1,ncol
         cloud_frac(i,k) = min(ast(i,k)+deepcu(i,k),1.0_r8)
         liq_cloud_frac(i,k) = alst(i,k)
-        if (state1%q(i,k,ixcldice) .ge. 1.0e-5_r8) then 
+        if (state1%q(i,k,ixcldice) .ge. 1.0e-5_r8) then
            if (state1%q(i,k,ixnumice) .ge. state1%q(i,k,ixcldice)*5.0e7_r8) then
               ice_cloud_frac(i,k) = 1.0_r8
            else
@@ -1112,8 +1112,8 @@ end function shoc_implements_cnst
         tot_cloud_frac(i,k) = min(1.0_r8, max(ice_cloud_frac(i,k),liq_cloud_frac(i,k))+deepcu(i,k))
       enddo
     enddo
-   
-    cld(:,1:pver) = cloud_frac(:,1:pver)	
+
+    cld(:,1:pver) = cloud_frac(:,1:pver)
 
     ! --------------------------------------------------------!
     ! Output fields
@@ -1122,14 +1122,14 @@ end function shoc_implements_cnst
     do k=1,pverp
       do i=1,ncol
         wthl_output(i,k) = wthl_sec_out(i,k) * rrho_i(i,k) * cpair
-        wqw_output(i,k) = wqw_sec_out(i,k) * rrho_i(i,k) * latvap 
+        wqw_output(i,k) = wqw_sec_out(i,k) * rrho_i(i,k) * latvap
       enddo
     enddo
 
     do k=1,pver
       do i=1,ncol
         wthv_output(i,k) = wthv(i,k) * rrho(i,k) * cpair
-        wql_output(i,k) = wqls_out(i,k) * rrho(i,k) * latvap 
+        wql_output(i,k) = wqls_out(i,k) * rrho(i,k) * latvap
       enddo
     enddo
 
@@ -1159,10 +1159,10 @@ end function shoc_implements_cnst
     call outfld('LIQ_CLOUD_FRAC',liq_cloud_frac,pcols,lchnk)
     call outfld('TOT_CLOUD_FRAC',tot_cloud_frac,pcols,lchnk)
 
-#endif    
-    return         
-  end subroutine shoc_tend_e3sm   
-  
+#endif
+    return
+  end subroutine shoc_tend_e3sm
+
   subroutine grid_size(state, grid_dx, grid_dy)
   ! Determine the size of the grid for each of the columns in state
 
@@ -1170,11 +1170,11 @@ end function shoc_implements_cnst
   use shr_const_mod,   only: shr_const_pi
   use physics_types,   only: physics_state
   use ppgrid,          only: pver, pverp, pcols
- 
+
   type(physics_state), intent(in) :: state
   real(r8), intent(out)           :: grid_dx(pcols), grid_dy(pcols)   ! E3SM grid [m]
 
-  real(r8), parameter :: earth_ellipsoid1 = 111132.92_r8 ! World Geodetic System 1984 (WGS84) 
+  real(r8), parameter :: earth_ellipsoid1 = 111132.92_r8 ! World Geodetic System 1984 (WGS84)
                                                          ! first coefficient, meters per degree longitude at equator
   real(r8), parameter :: earth_ellipsoid2 = 559.82_r8 ! second expansion coefficient for WGS84 ellipsoid
   real(r8), parameter :: earth_ellipsoid3 = 1.175_r8 ! third expansion coefficient for WGS84 ellipsoid
@@ -1190,29 +1190,29 @@ end function shoc_implements_cnst
 
       ! convert latitude to radians
       lat_in_rad = state%lat(i)*(shr_const_pi/180._r8)
-       
+
       ! Now find meters per degree latitude
       ! Below equation finds distance between two points on an ellipsoid, derived from expansion
-      !  taking into account ellipsoid using World Geodetic System (WGS84) reference 
+      !  taking into account ellipsoid using World Geodetic System (WGS84) reference
       mpdeglat = earth_ellipsoid1 - earth_ellipsoid2 * cos(2._r8*lat_in_rad) + earth_ellipsoid3 * cos(4._r8*lat_in_rad)
       grid_dx(i) = mpdeglat * degree
       grid_dy(i) = grid_dx(i) ! Assume these are the same
-  enddo   
+  enddo
 
-  end subroutine grid_size  
-  
+  end subroutine grid_size
+
   subroutine grid_size_planar_uniform(grid_dx, grid_dy)
-  
+
     ! Get size of grid box if in doubly period planar mode
     ! At time of implementation planar dycore only supports uniform grids.
-  
+
     use iop_data_mod,  only: dyn_dx_size
-    
+
     real(r8), intent(out) :: grid_dx, grid_dy
 
     grid_dx = dyn_dx_size
     grid_dy = grid_dx
-  
+
   end subroutine grid_size_planar_uniform
 
 end module shoc_intr

--- a/components/eamxx/src/physics/shoc/impl/shoc_energy_fixer_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_energy_fixer_impl.hpp
@@ -2,8 +2,12 @@
 #define SHOC_ENERGY_FIXER_IMPL_HPP
 
 #include "shoc_functions.hpp" // for ETI only but harmless for GPU
+#include "share/util/scream_common_physics_functions.hpp"
 
 namespace scream {
+
+using PF           = scream::PhysicsFunctions<DefaultDevice>;
+
 namespace shoc {
 
 /*
@@ -65,8 +69,10 @@ void Functions<S,D>::shoc_energy_fixer(
   const auto s_rho_zi = ekat::scalarize(rho_zi);
   const auto s_pint   = ekat::scalarize(pint);
 
+  const auto exner_int = PF::exner_function(s_pint(nlevi-1));
+
   // Compute the total energy before and after SHOC call
-  const Scalar shf = wthl_sfc*cp*s_rho_zi(nlevi-1);
+  const Scalar shf = wthl_sfc*cp*s_rho_zi(nlevi-1)*exner_int;
   const Scalar lhf = wqw_sfc*s_rho_zi(nlevi-1);
   te_a = se_a + ke_a + (lcond+lice)*wv_a + lice*wl_a;
   te_b = se_b + ke_b + (lcond+lice)*wv_b + lice*wl_b;

--- a/components/eamxx/src/physics/shoc/shoc_f90.cpp
+++ b/components/eamxx/src/physics/shoc/shoc_f90.cpp
@@ -8,7 +8,7 @@ using scream::Real;
 using scream::Int;
 extern "C" {
   void shoc_init_c(int nlev, Real gravit, Real rair, Real rh2o, Real cpair,
-                   Real zvir, Real latvap, Real latice, Real karman);
+                   Real zvir, Real latvap, Real latice, Real karman, Real p0);
   void shoc_use_cxx_c(bool use_cxx);
 }
 
@@ -119,7 +119,7 @@ void shoc_init(Int nlev, bool use_fortran, bool force_reinit) {
     using C = scream::physics::Constants<Scalar>;
 
     shoc_init_c((int)nlev, C::gravit, C::Rair, C::RH2O, C::Cpair, C::ZVIR,
-                C::LatVap, C::LatIce, C::Karman);
+                C::LatVap, C::LatIce, C::Karman, C::P0);
     is_init = true;
   }
   shoc_use_cxx_c(!use_fortran);

--- a/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
@@ -52,7 +52,7 @@ void shoc_energy_total_fixer_c(Int shcol, Int nlev, Int nlevi, Real dtime, Int n
                                Real *zt_grid, Real *zi_grid,
                                Real *se_b, Real *ke_b, Real *wv_b, Real *wl_b,
                                Real *se_a, Real *ke_a, Real *wv_a, Real *wl_a,
-                               Real *wthl_sfc, Real *wqw_sfc, Real *rho_zt,
+                               Real *wthl_sfc, Real *wqw_sfc, Real *rho_zt, Real *pint,
                                Real *te_a, Real *te_b);
 
 void shoc_energy_threshold_fixer_c(Int shcol, Int nlev, Int nlevi,
@@ -347,7 +347,10 @@ void shoc_energy_total_fixer(ShocEnergyTotalFixerData& d)
 {
   shoc_init(d.nlev, true);
   d.transpose<ekat::TransposeDirection::c2f>();
-  shoc_energy_total_fixer_c(d.shcol, d.nlev, d.nlevi, d.dtime, d.nadv, d.zt_grid, d.zi_grid, d.se_b, d.ke_b, d.wv_b, d.wl_b, d.se_a, d.ke_a, d.wv_a, d.wl_a, d.wthl_sfc, d.wqw_sfc, d.rho_zt, d.te_a, d.te_b);
+  shoc_energy_total_fixer_c(d.shcol, d.nlev, d.nlevi, d.dtime, d.nadv,
+                            d.zt_grid, d.zi_grid, d.se_b, d.ke_b, d.wv_b,
+                            d.wl_b, d.se_a, d.ke_a, d.wv_a, d.wl_a, d.wthl_sfc,
+                            d.wqw_sfc, d.rho_zt, d.pint, d.te_a, d.te_b);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 

--- a/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
@@ -22,7 +22,7 @@ extern "C" {
 
 // Special shoc_init function for shoc_main_bfb test
 void shoc_init_for_main_bfb_c(int nlev, Real gravit, Real rair, Real rh2o, Real cpair,
-                              Real zvir, Real latvap, Real latice, Real karman,
+                              Real zvir, Real latvap, Real latice, Real karman, Real p0,
                               Real* pref_mid, int nbot_shoc, int ntop_shoc);
 void shoc_use_cxx_c(bool use_cxx);
 
@@ -754,7 +754,7 @@ void shoc_main_with_init(ShocMainData& d)
   using C = scream::physics::Constants<Real>;
 
   d.transpose<ekat::TransposeDirection::c2f>();
-  shoc_init_for_main_bfb_c(d.nlev, C::gravit, C::Rair, C::RH2O, C::Cpair, C::ZVIR, C::LatVap, C::LatIce, C::Karman,
+  shoc_init_for_main_bfb_c(d.nlev, C::gravit, C::Rair, C::RH2O, C::Cpair, C::ZVIR, C::LatVap, C::LatIce, C::Karman, C::P0,
                            d.pref_mid, d.nbot_shoc, d.ntop_shoc+1);
   shoc_use_cxx_c(false);
 

--- a/components/eamxx/src/physics/shoc/shoc_functions_f90.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions_f90.hpp
@@ -141,13 +141,13 @@ struct ShocEnergyTotalFixerData : public ShocTestGridDataBase {
   // Inputs
   Int shcol, nlev, nlevi, nadv;
   Real dtime;
-  Real *se_b, *ke_b, *wv_b, *wl_b, *se_a, *ke_a, *wv_a, *wl_a, *wthl_sfc, *wqw_sfc, *rho_zt;
+  Real *se_b, *ke_b, *wv_b, *wl_b, *se_a, *ke_a, *wv_a, *wl_a, *wthl_sfc, *wqw_sfc, *rho_zt, *pint;
 
   // Outputs
   Real *te_a, *te_b;
 
   ShocEnergyTotalFixerData(Int shcol_, Int nlev_, Int nlevi_, Real dtime_, Int nadv_) :
-    ShocTestGridDataBase({{ shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_ }}, {{ &zt_grid, &rho_zt }, { &zi_grid }, { &se_b, &ke_b, &wv_b, &wl_b, &se_a, &ke_a, &wv_a, &wl_a, &wthl_sfc, &wqw_sfc, &te_a, &te_b }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_), nadv(nadv_), dtime(dtime_) {}
+    ShocTestGridDataBase({{ shcol_, nlev_ }, { shcol_, nlevi_ }, { shcol_ }}, {{ &zt_grid, &rho_zt }, { &zi_grid, &pint }, { &se_b, &ke_b, &wv_b, &wl_b, &se_a, &ke_a, &wv_a, &wl_a, &wthl_sfc, &wqw_sfc, &te_a, &te_b }}), shcol(shcol_), nlev(nlev_), nlevi(nlevi_), nadv(nadv_), dtime(dtime_) {}
 
   PTD_STD_DEF(ShocEnergyTotalFixerData, 5, shcol, nlev, nlevi, dtime, nadv);
 };

--- a/components/eamxx/src/physics/shoc/shoc_iso_c.f90
+++ b/components/eamxx/src/physics/shoc/shoc_iso_c.f90
@@ -24,7 +24,7 @@ contains
   end subroutine append_precision
 
   subroutine shoc_init_c(nlev, gravit, rair, rh2o, cpair, &
-                         zvir, latvap, latice, karman) bind(c)
+                         zvir, latvap, latice, karman, p0) bind(c)
     use shoc, only: shoc_init, npbl
 
     integer(kind=c_int), value, intent(in) :: nlev ! number of levels
@@ -37,20 +37,21 @@ contains
     real(kind=c_real), value, intent(in)  :: latvap ! latent heat of vaporization
     real(kind=c_real), value, intent(in)  :: latice ! latent heat of fusion
     real(kind=c_real), value, intent(in)  :: karman ! Von Karman's constant
+    real(kind=c_real), value, intent(in)  :: p0     ! Reference pressure
 
     real(kind=c_real) :: pref_mid(nlev) ! unused values
 
     pref_mid = 0
     call shoc_init(nlev, gravit, rair, rh2o, cpair, &
-                   zvir, latvap, latice, karman, &
+                   zvir, latvap, latice, karman, p0, &
                    pref_mid, nlev, 1)
     npbl = nlev ! set pbl layer explicitly so we don't need pref_mid.
   end subroutine shoc_init_c
 
   ! shoc_init for shoc_main_bfb testing
   subroutine shoc_init_for_main_bfb_c(nlev, gravit, rair, rh2o, cpair, &
-                                      zvir, latvap, latice, karman,pref_mid,&
-                                      nbot_shoc, ntop_shoc) bind(c)
+                                      zvir, latvap, latice, karman, p0, &
+                                      pref_mid, nbot_shoc, ntop_shoc) bind(c)
     use shoc, only: shoc_init
 
     integer(kind=c_int), value, intent(in) :: nlev ! number of levels
@@ -65,10 +66,11 @@ contains
     real(kind=c_real), value, intent(in)  :: latvap ! latent heat of vaporization
     real(kind=c_real), value, intent(in)  :: latice ! latent heat of fusion
     real(kind=c_real), value, intent(in)  :: karman ! Von Karman's constant
+    real(kind=c_real), value, intent(in)  :: p0     ! Reference pressure
 
     real(kind=c_real), intent(in), dimension(nlev) :: pref_mid ! reference pressures at midpoints
     call shoc_init(nlev, gravit, rair, rh2o, cpair, &
-                   zvir, latvap, latice, karman, &
+                   zvir, latvap, latice, karman, p0, &
                    pref_mid, nbot_shoc, ntop_shoc)
   end subroutine shoc_init_for_main_bfb_c
 

--- a/components/eamxx/src/physics/shoc/shoc_iso_c.f90
+++ b/components/eamxx/src/physics/shoc/shoc_iso_c.f90
@@ -503,7 +503,7 @@ contains
                                 zt_grid,zi_grid,&
                                 se_b,ke_b,wv_b,wl_b,&
                                 se_a,ke_a,wv_a,wl_a,&
-                                wthl_sfc,wqw_sfc,rho_zt,&
+                                wthl_sfc,wqw_sfc,rho_zt,pint,&
                                 te_a,te_b) bind (C)
     use shoc, only: shoc_energy_total_fixer
 
@@ -526,6 +526,7 @@ contains
     real(kind=c_real), intent(in) :: zt_grid(shcol,nlev)
     real(kind=c_real), intent(in) :: zi_grid(shcol,nlevi)
     real(kind=c_real), intent(in) :: rho_zt(shcol,nlev)
+    real(kind=c_real), intent(in) :: pint(shcol,nlevi)
 
     real(kind=c_real), intent(out) :: te_a(shcol)
     real(kind=c_real), intent(out) :: te_b(shcol)
@@ -534,7 +535,7 @@ contains
                                  zt_grid,zi_grid,&
                                  se_b,ke_b,wv_b,wl_b,&
                                  se_a,ke_a,wv_a,wl_a,&
-                                 wthl_sfc,wqw_sfc,rho_zt,&
+                                 wthl_sfc,wqw_sfc,rho_zt,pint,&
                                  te_a,te_b)
 
   end subroutine shoc_energy_total_fixer_c

--- a/components/eamxx/src/physics/shoc/tests/shoc_energy_total_fixer_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_energy_total_fixer_tests.cpp
@@ -55,6 +55,8 @@ struct UnitWrap::UnitTest<D>::TestShocTotEnergyFixer {
     static constexpr Real wthl_sfc = 0.5;
     // Define surface total water flux [kg/kg m/s]
     static constexpr Real wqw_sfc = 0.01;
+    //  Pressure at interface [Pa]
+    static constexpr Real pint[nlevi] = {50000, 60000, 70000, 80000, 90000, 100000};
 
     // Initialize data structure for bridging to F90
     ShocEnergyTotalFixerData SDS(shcol, nlev, nlevi, dtime, nadv);
@@ -93,6 +95,7 @@ struct UnitWrap::UnitTest<D>::TestShocTotEnergyFixer {
         const auto offset = n + s * nlevi;
 
         SDS.zi_grid[offset] = zi_grid[n];
+        SDS.pint[offset] = pint[n];
       }
     }
 


### PR DESCRIPTION
Fixing energy leaks for both F and CXX: the issue was the same in both -- instead of using raw coupler fluxes for the energy fixer, shoc recomputes them back from wpthlp_sfc (problematic) and wprtp_sfc (not an issue). The first one was missing exner factor after we transitioned to the unapproximated version of thetal. The factor was missing only in how the energy diff is computed for the fixer.

Separately, there was a SW bug in the F version, uninit-ed det_ice and det_s, which lead to false energy check errors. i don't think that issue was affecting anything besides diagnostics.

[nonbfb] for baseline tests.