### PR TITLE
EAMxx: switch to CXX17

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -55,12 +55,8 @@ endif()
 # to be on. For now, simply ensure Kokkos Serial is enabled
 option (Kokkos_ENABLE_SERIAL "" ON)
 
-# MAM support requires C++17 -- hopefully SCREAM itself will get there soon
-if (SCREAM_ENABLE_MAM)
-  set(CMAKE_CXX_STANDARD 17)
-else()
-  set(CMAKE_CXX_STANDARD 14)
-endif()
+# We want to use C++17 in EAMxx
+set(CMAKE_CXX_STANDARD 17)
 
 if (NOT SCREAM_CIME_BUILD)
   project(SCREAM CXX C Fortran)


### PR DESCRIPTION
C++17 seems to give no problem on mappy and weaver. It compiles fine on frontier (test pending). Now I'm going to run v1 tests on chrysalis and pm-gpu. I do not have access to ascent, but given that Summit will be decommissioned soon, I don't know if it's _that_ important.

Note: this upgrade is needed by other E3SM project. In particular, MALI: it links to "recent" Trilinos, which uses Kokkos 4.0, which in turn requires C++17. So even if we (as SCREAM) could punt on C++17 for a bit, it's a good idea to do it sooner than later, so that other projects can move forward.