### PR TITLE
Some mods to FieldHeader interface and storage

### DIFF
--- a/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
@@ -126,9 +126,8 @@ void FieldAtPressureLevel::compute_diagnostic_impl()
     perform_vertical_interpolation<Real,1,2>(pres,m_p_tgt,f_data_src,data_tgt_tmp,m_num_levs,1,m_mask_val);
 
     // Track mask
-    auto extra_data = m_diagnostic_output.get_header().get_extra_data().at("mask_data");
-    auto d_mask     = ekat::any_cast<Field>(extra_data);
-    auto d_mask_tgt = d_mask.get_view<Pack1*>();
+    auto mask = m_diagnostic_output.get_header().get_extra_data<Field>("mask_data");
+    auto d_mask_tgt = mask.get_view<Pack1*>();
     view_Nd<Pack1,2> mask_tgt_tmp(d_mask_tgt.data(),d_mask_tgt.extent_int(0),1);  
     perform_vertical_interpolation<Real,1,2>(pres,m_p_tgt,mask_v_tmp,mask_tgt_tmp,m_num_levs,1,0);
   } else if (rank==3) {
@@ -140,9 +139,8 @@ void FieldAtPressureLevel::compute_diagnostic_impl()
     perform_vertical_interpolation<Real,1,3>(pres,m_p_tgt,f_data_src,data_tgt_tmp,m_num_levs,1,m_mask_val);
 
     // Track mask
-    auto extra_data = m_diagnostic_output.get_header().get_extra_data().at("mask_data");
-    auto d_mask     = ekat::any_cast<Field>(extra_data);
-    auto d_mask_tgt = d_mask.get_view<Pack1*>();
+    auto mask = m_diagnostic_output.get_header().get_extra_data<Field>("mask_data");
+    auto d_mask_tgt = mask.get_view<Pack1*>();
     view_Nd<Pack1,2> mask_tgt_tmp(d_mask_tgt.data(),d_mask_tgt.extent_int(0),1);  
     perform_vertical_interpolation<Real,1,2>(pres,m_p_tgt,mask_v_tmp,mask_tgt_tmp,m_num_levs,1,0);
   } else {

--- a/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
@@ -104,8 +104,7 @@ TEST_CASE("field_at_pressure_level_p2")
       diag_f.sync_to_host();
       auto test2_diag_v = diag_f.get_view<const Real*, Host>();
       // Check the mask field inside the diag_f
-      auto mask_tmp = diag_f.get_header().get_extra_data().at("mask_data");
-      auto mask_f   = ekat::any_cast<Field>(mask_tmp);
+      auto mask_f = diag_f.get_header().get_extra_data<Field>("mask_data");
       mask_f.sync_to_host();
       auto test2_mask_v = mask_f.get_view<const Real*, Host>();
       //
@@ -126,12 +125,10 @@ TEST_CASE("field_at_pressure_level_p2")
       diag_f.sync_to_host();
       auto test2_diag_v = diag_f.get_view<const Real*, Host>();
       // Check the mask field inside the diag_f
-      auto mask_tmp = diag_f.get_header().get_extra_data().at("mask_data");
-      auto mask_f   = ekat::any_cast<Field>(mask_tmp);
+      auto mask_f = diag_f.get_header().get_extra_data<Field>("mask_data");
       mask_f.sync_to_host();
       auto test2_mask_v = mask_f.get_view<const Real*, Host>();
-      auto mask_val_tmp = diag_f.get_header().get_extra_data().at("mask_value");
-      Real mask_val = ekat::any_cast<Real>(mask_val_tmp);
+      auto mask_val = diag_f.get_header().get_extra_data<Real>("mask_value");
       //
       for (int icol=0;icol<ncols;icol++) {
         REQUIRE(approx(test2_diag_v(icol),Real(mask_val)));

--- a/components/eamxx/src/share/field/field_header.cpp
+++ b/components/eamxx/src/share/field/field_header.cpp
@@ -8,9 +8,9 @@ namespace scream
 FieldHeader::FieldHeader (const identifier_type& id)
  : m_identifier (id)
  , m_tracking (create_tracking())
- , m_alloc_prop (get_type_size(id.data_type()))
 {
-  // Nothing to be done here
+  m_alloc_prop = std::make_shared<FieldAllocProp>(get_type_size(id.data_type()));
+  m_extra_data = std::make_shared<extra_data_type>();
 }
 
 void FieldHeader::
@@ -19,12 +19,12 @@ set_extra_data (const std::string& key,
                 const bool throw_if_existing)
 {
   if (throw_if_existing) {
-    EKAT_REQUIRE_MSG (m_extra_data.find(key)==m_extra_data.end(),
+    EKAT_REQUIRE_MSG (m_extra_data->find(key)==m_extra_data->end(),
                         "Error! Key '" + key + "' already existing in "
                         "the extra data map of field '" + m_identifier.get_id_string() + "'.\n");
-    m_extra_data[key] = data;
+    (*m_extra_data)[key] = data;
   } else {
-    m_extra_data[key] = data;
+    (*m_extra_data)[key] = data;
   }
 }
 
@@ -64,8 +64,8 @@ create_subfield_header (const FieldIdentifier& id,
   }
 
   // Create alloc props
-  fh->m_alloc_prop = parent->get_alloc_properties().subview(idim,k,dynamic);
-  fh->m_alloc_prop.commit(id.get_layout_ptr());
+  fh->m_alloc_prop = std::make_shared<FieldAllocProp>(parent->get_alloc_properties().subview(idim,k,dynamic));
+  fh->m_alloc_prop->commit(id.get_layout_ptr());
 
   return fh;
 }

--- a/components/eamxx/src/share/field/field_header.hpp
+++ b/components/eamxx/src/share/field/field_header.hpp
@@ -76,7 +76,9 @@ public:
         FieldAllocProp& get_alloc_properties ()       { return m_alloc_prop; }
 
   // Get the extra data
-  const extra_data_type& get_extra_data () const { return m_extra_data; }
+  template<typename T>
+  const T& get_extra_data (const std::string& key) const;
+  bool  has_extra_data (const std::string& key) const;
 
   std::shared_ptr<FieldHeader> alias (const std::string& name) const;
 
@@ -100,6 +102,31 @@ protected:
   // Extra data associated with this field
   extra_data_type                 m_extra_data;
 };
+
+template<typename T>
+inline const T& FieldHeader::
+get_extra_data (const std::string& key) const
+{
+  EKAT_REQUIRE_MSG (has_extra_data(key),
+      "Error! Extra data not found in field header.\n"
+      "  - field name: " + m_identifier.name() + "\n"
+      "  - extra data: " + key + "\n");
+  auto a = m_extra_data.at(key);
+  EKAT_REQUIRE_MSG ( a.isType<T>(),
+      "Error! Attempting to access extra data using the wrong type.\n"
+      "  - field name    : " + m_identifier.name() + "\n"
+      "  - extra data    : " + key + "\n"
+      "  - actual type   : " + std::string(a.content().type().name()) + "\n"
+      "  - requested type: " + std::string(typeid(T).name()) + ".\n");
+
+  return any_cast<T>(a);
+}
+
+inline bool FieldHeader::
+has_extra_data (const std::string& key) const
+{
+  return m_extra_data.find(key)!=m_extra_data.end();
+}
 
 // Use this free function to exploit features of enable_from_this
 template<typename... Args>

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -372,9 +372,8 @@ update (const Field& x, const ST alpha, const ST beta)
 
   // Determine if there is a FillValue that requires extra treatment.
   ST fill_val = constants::DefaultFillValue<ST>().value;
-  const auto& xtra_data = get_header().get_extra_data();
-  if (xtra_data.count("mask_value")) {
-    fill_val = ekat::any_cast<ST>(xtra_data.at("mask_value"));
+  if (get_header().has_extra_data("mask_value")) {
+    fill_val = get_header().get_extra_data<ST>("mask_value");
   }
 
   // If user passes, say, double alpha/beta for an int field, we should error out, warning about
@@ -406,9 +405,8 @@ scale (const ST beta)
 
   // Determine if there is a FillValue that requires extra treatment.
   ST fill_val = constants::DefaultFillValue<ST>().value;
-  const auto& xtra_data = get_header().get_extra_data();
-  if (xtra_data.count("mask_value")) {
-    fill_val = ekat::any_cast<ST>(xtra_data.at("mask_value"));
+  if (get_header().has_extra_data("mask_value")) {
+    fill_val = get_header().get_extra_data<ST>("mask_value");
   }
 
   // If user passes, say, double beta for an int field, we should error out, warning about

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -281,10 +281,11 @@ do_bind_field (const int ifield, const field_type& src, const field_type& tgt)
       Field           mask_tgt_fld (mask_tgt_fid);
       mask_tgt_fld.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
       mask_tgt_fld.allocate_view();
-      auto tgt_extra = tgt.get_header().get_extra_data();
-      EKAT_REQUIRE_MSG(!tgt_extra.count("mask_data"),"ERROR VerticalRemapper::do_bind_field " + src.name() + " already has mask_data assigned!");
+      EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_data"),
+          "ERROR VerticalRemapper::do_bind_field " + src.name() + " already has mask_data assigned!");
       f_tgt.get_header().set_extra_data("mask_data",mask_tgt_fld);
-      EKAT_REQUIRE_MSG(!tgt_extra.count("mask_value"),"ERROR VerticalRemapper::do_bind_field " + src.name() + " already has mask_data assigned!");
+      EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_value"),
+          "ERROR VerticalRemapper::do_bind_field " + src.name() + " already has mask_data assigned!");
       f_tgt.get_header().set_extra_data("mask_value",m_mask_val);
       m_src_masks.push_back(mask_src_fld);
       m_tgt_masks.push_back(mask_tgt_fld);
@@ -293,19 +294,19 @@ do_bind_field (const int ifield, const field_type& src, const field_type& tgt)
     // If a field does not have LEV or ILEV it may still have mask tracking assigned from somewhere else.
     // In those cases we want to copy that mask tracking to the target field.
     // Note, we still make a new field to ensure it is defined on the target grid.
-    const auto src_extra = src.get_header().get_extra_data();
-    if (src_extra.count("mask_data")) {
-      auto f_src_mask = ekat::any_cast<Field>(src_extra.at("mask_data"));
+    if (src.get_header().has_extra_data("mask_data")) {
+      auto f_src_mask = src.get_header().get_extra_data<Field>("mask_data");
       FieldIdentifier mask_tgt_fid (f_src_mask.name(), f_src_mask.get_header().get_identifier().get_layout(), nondim, m_tgt_grid->name() );
       Field           mask_tgt_fld (mask_tgt_fid);
       mask_tgt_fld.allocate_view();
       mask_tgt_fld.deep_copy(f_src_mask);
 
       auto& f_tgt    = m_tgt_fields[ifield];
-      auto tgt_extra = tgt.get_header().get_extra_data();
-      EKAT_REQUIRE_MSG(!tgt_extra.count("mask_data"),"ERROR VerticalRemapper::do_bind_field " + src.name() + " already has mask_data assigned!");
+      EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_data"),
+          "ERROR VerticalRemapper::do_bind_field " + src.name() + " already has mask_data assigned!");
       f_tgt.get_header().set_extra_data("mask_data",mask_tgt_fld);
-      EKAT_REQUIRE_MSG(!tgt_extra.count("mask_value"),"ERROR VerticalRemapper::do_bind_field " + src.name() + " already has mask_data assigned!");
+      EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_value"),
+          "ERROR VerticalRemapper::do_bind_field " + src.name() + " already has mask_data assigned!");
       f_tgt.get_header().set_extra_data("mask_value",m_mask_val);
     }
   }
@@ -349,11 +350,9 @@ void VerticalRemapper::do_remap_fwd ()
       // There is nothing to do, this field cannot be vertically interpolated,
       // so just copy it over.  Note, if this field has its own mask data make
       // sure that is copied too.
-      auto f_tgt_extra = f_tgt.get_header().get_extra_data();
-      if (f_tgt_extra.count("mask_data")) {
-        auto f_src_extra = f_src.get_header().get_extra_data();
-        auto f_tgt_mask = ekat::any_cast<Field>(f_tgt_extra.at("mask_data"));
-        auto f_src_mask = ekat::any_cast<Field>(f_src_extra.at("mask_data"));
+      if (f_tgt.get_header().has_extra_data("mask_data")) {
+        auto f_tgt_mask = f_tgt.get_header().get_extra_data<Field>("mask_data");
+        auto f_src_mask = f_src.get_header().get_extra_data<Field>("mask_data");
         f_tgt_mask.deep_copy(f_src_mask);
       }
       f_tgt.deep_copy(f_src);

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -184,6 +184,26 @@ TEST_CASE("field", "") {
     REQUIRE (field_min<Real>(f1)==3.0);
   }
 
+  SECTION ("alias") {
+    Field f1 (fid);
+    f1.allocate_view();
+
+    Field f2 = f1.alias("the_alias");
+
+    REQUIRE(f2.is_allocated());
+    REQUIRE(&f1.get_header().get_tracking()==&f2.get_header().get_tracking());
+    REQUIRE(&f1.get_header().get_alloc_properties()==&f2.get_header().get_alloc_properties());
+    REQUIRE(f1.get_header().get_identifier().get_layout()==f2.get_header().get_identifier().get_layout());
+    REQUIRE(f1.get_internal_view_data<Real>()==f2.get_internal_view_data<Real>());
+
+    // Identifiers are separate objects though
+    REQUIRE(&f1.get_header().get_identifier()!=&f2.get_header().get_identifier());
+
+    // Check extra data is also shared
+    f1.get_header().set_extra_data("foo",1);
+    REQUIRE (f2.get_header().has_extra_data("foo"));
+  }
+
   SECTION ("deep_copy") {
     std::vector<FieldTag> t1 = {COL,CMP,LEV};
     std::vector<int> d1 = {3,2,24};


### PR DESCRIPTION
- Do not expose extra data implementation, but use interfaces instead. Makes it safer as well as easier to use.
- Store alloc props and extra data via shared pointers. Allows the header of an aliased field to truly share all metadata (except the field identifier) with the original field
- Add unit tests for the field alias utility.