### PR TITLE
Add effective radius of rain and rain precipitation fraction outputs

### DIFF
--- a/components/eam/src/physics/p3/scream/micro_p3.F90
+++ b/components/eam/src/physics/p3/scream/micro_p3.F90
@@ -960,7 +960,8 @@ contains
       inv_exner, cld_frac_l, cld_frac_r, cld_frac_i, &
       rho, inv_rho, rhofaci, qv, th_atm, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, &
       mu_c, nu, lamc, mu_r, lamr, vap_liq_exchange, &
-      ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc)
+      ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, &
+      diag_eff_radius_qc, diag_eff_radius_qr)
 
    implicit none
 
@@ -974,7 +975,8 @@ contains
         qv, th_atm, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, &
         mu_c, nu, lamc, mu_r, &
         lamr, vap_liq_exchange, &
-        ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc
+        ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, &
+        diag_eff_radius_qc, diag_eff_radius_qr
 
    ! locals
    integer :: k, dumi, dumii, dumjj, dumzz
@@ -1028,6 +1030,7 @@ contains
          ze_rain(k) = nr(k)*(mu_r(k)+6._rtype)*(mu_r(k)+5._rtype)*(mu_r(k)+4._rtype)*           &
               (mu_r(k)+3._rtype)*(mu_r(k)+2._rtype)*(mu_r(k)+1._rtype)/bfb_pow(lamr(k), 6._rtype)
          ze_rain(k) = max(ze_rain(k),1.e-22_rtype)
+         diag_eff_radius_qr(k) = 1.5_rtype/lamr(k)
       else
          qv(k) = qv(k)+qr(k)
          th_atm(k) = th_atm(k)-inv_exner(k)*qr(k)*latent_heat_vapor(k)*inv_cp
@@ -1122,7 +1125,7 @@ contains
 
   SUBROUTINE p3_main(qc,nc,qr,nr,th_atm,qv,dt,qi,qm,ni,bm,   &
        pres,dz,nc_nuceat_tend,nccn_prescribed,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_eff_radius_qc,     &
-       diag_eff_radius_qi,rho_qi,do_predict_nc, do_prescribed_CCN, &
+       diag_eff_radius_qi,diag_eff_radius_qr,rho_qi,do_predict_nc, do_prescribed_CCN, &
        dpres,inv_exner,qv2qi_depos_tend,precip_total_tend,nevapr,qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,  &
        p3_tend_out,mu_c,lamc,liq_ice_exchange,vap_liq_exchange, &
        vap_ice_exchange,qv_prev,t_prev,col_location &
@@ -1173,6 +1176,7 @@ contains
     real(rtype), intent(out),   dimension(its:ite)              :: precip_ice_surf    ! precipitation rate, solid        m s-1
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_eff_radius_qc  ! effective radius, cloud          m
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_eff_radius_qi  ! effective radius, ice            m
+    real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: diag_eff_radius_qr  ! effective radius, rain           m
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: rho_qi  ! bulk density of ice              kg m-3
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: mu_c       ! Size distribution shape parameter for radiation
     real(rtype), intent(out),   dimension(its:ite,kts:kte)      :: lamc       ! Size distribution slope parameter for radiation
@@ -1297,6 +1301,7 @@ contains
     ze_rain   = 1.e-22_rtype
     diag_eff_radius_qc = 10.e-6_rtype ! default value
     diag_eff_radius_qi = 25.e-6_rtype ! default value
+    diag_eff_radius_qr = 500.e-6_rtype ! default value
     diag_vm_qi  = 0._rtype
     diag_diam_qi   = 0._rtype
     rho_qi = 0._rtype
@@ -1452,7 +1457,8 @@ contains
             rho(i,:), inv_rho(i,:), rhofaci(i,:), qv(i,:), th_atm(i,:), qc(i,:), nc(i,:), qr(i,:), nr(i,:), qi(i,:), ni(i,:), &
             qm(i,:), bm(i,:), latent_heat_vapor(i,:), latent_heat_sublim(i,:), &
             mu_c(i,:), nu(i,:), lamc(i,:), mu_r(i,:), lamr(i,:), vap_liq_exchange(i,:), &
-            ze_rain(i,:), ze_ice(i,:), diag_vm_qi(i,:), diag_eff_radius_qi(i,:), diag_diam_qi(i,:), rho_qi(i,:), diag_equiv_reflectivity(i,:), diag_eff_radius_qc(i,:))
+            ze_rain(i,:), ze_ice(i,:), diag_vm_qi(i,:), diag_eff_radius_qi(i,:), diag_diam_qi(i,:), rho_qi(i,:), &
+            diag_equiv_reflectivity(i,:), diag_eff_radius_qc(i,:), diag_eff_radius_qr(i,:))
        !   if (debug_ON) call check_values(qv,Ti,it,debug_ABORT,800,col_location)
 
        !..............................................

--- a/components/eam/src/physics/p3/scream/micro_p3_interface.F90
+++ b/components/eam/src/physics/p3/scream/micro_p3_interface.F90
@@ -833,7 +833,6 @@ end subroutine micro_p3_readnl
     real(rtype) :: icimrst(pcols,pver) ! stratus ice mixing ratio - on grid
     real(rtype) :: icwmrst(pcols,pver) ! stratus water mixing ratio - on grid
     real(rtype) :: rho(pcols,pver)
-    real(rtype) :: drout2(pcols,pver)
     real(rtype) :: reff_rain(pcols,pver)
     real(rtype) :: col_location(pcols,3),tmp_loc(pcols)  ! Array of column lon (index 1) and lat (index 2)
     integer     :: tmpi_loc(pcols) ! Global column index temp array
@@ -1113,6 +1112,7 @@ end subroutine micro_p3_readnl
          kte,                         & ! IN     vertical index upper bound       -
          rel(its:ite,kts:kte),        & ! OUT    effective radius, cloud          m
          rei(its:ite,kts:kte),        & ! OUT    effective radius, ice            m
+         reff_rain(its:ite,kts:kte),  & ! OUT    effective radius, rain           m
          rho_qi(its:ite,kts:kte),  & ! OUT    bulk density of ice              kg m-3
          do_predict_nc,               & ! IN     .true.=prognostic Nc, .false.=specified Nc
          do_prescribed_CCN,           & ! IN
@@ -1355,23 +1355,15 @@ end subroutine micro_p3_readnl
    !!
    !! Rain/Snow effective diameter
    !!
-   drout2    = 0._rtype
-   reff_rain = 0._rtype
    aqrain    = 0._rtype
    anrain    = 0._rtype
    freqr     = 0._rtype
    ! Prognostic precipitation
    where (rain(:ncol,top_lev:) >= 1.e-7_rtype)
-      drout2(:ncol,top_lev:) = avg_diameter( &
-           rain(:ncol,top_lev:), &
-           numrain(:ncol,top_lev:) * rho(:ncol,top_lev:), &
-           rho(:ncol,top_lev:), rho_h2o)
-
       aqrain(:ncol,top_lev:) = rain(:ncol,top_lev:) * cld_frac_r(:ncol,top_lev:)
       anrain(:ncol,top_lev:) = numrain(:ncol,top_lev:) * cld_frac_r(:ncol,top_lev:)
       freqr(:ncol,top_lev:) = cld_frac_r(:ncol,top_lev:)
-      reff_rain(:ncol,top_lev:) = drout2(:ncol,top_lev:) * &
-           1.5_rtype * 1.e6_rtype
+      reff_rain(:ncol,top_lev:) = reff_rain(:ncol,top_lev:) * 1.e6_rtype
    end where
 
 !====================== COSP Specific Outputs START ======================!

--- a/components/eamxx/data/scream_default_output.yaml
+++ b/components/eamxx/data/scream_default_output.yaml
@@ -38,6 +38,7 @@ Fields:
       - eff_radius_qr
       - precip_ice_surf_mass
       - precip_liq_surf_mass
+      - rainfrac
       # SHOC + P3
       - qc
       - qv

--- a/components/eamxx/data/scream_default_output.yaml
+++ b/components/eamxx/data/scream_default_output.yaml
@@ -35,6 +35,7 @@ Fields:
       - qr
       - eff_radius_qc
       - eff_radius_qi
+      - eff_radius_qr
       - precip_ice_surf_mass
       - precip_liq_surf_mass
       # SHOC + P3

--- a/components/eamxx/data/scream_default_remap.yaml
+++ b/components/eamxx/data/scream_default_remap.yaml
@@ -38,6 +38,7 @@ Fields:
       - eff_radius_qr
       - precip_ice_surf_mass
       - precip_liq_surf_mass
+      - rainfrac
       # SHOC + P3
       - qc
       - qv

--- a/components/eamxx/data/scream_default_remap.yaml
+++ b/components/eamxx/data/scream_default_remap.yaml
@@ -35,6 +35,7 @@ Fields:
       - qr
       - eff_radius_qc
       - eff_radius_qi
+      - eff_radius_qr
       - precip_ice_surf_mass
       - precip_liq_surf_mass
       # SHOC + P3

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -19,6 +19,7 @@ void Functions<Real,DefaultDevice>
   const uview_2d<const Spack>& cld_frac_r, const uview_2d<const Spack>& inv_exner, const uview_2d<const Spack>& th_atm,
   const uview_2d<const Spack>& dz, const uview_2d<Spack>& diag_equiv_reflectivity, const uview_2d<Spack>& ze_ice,
   const uview_2d<Spack>& ze_rain, const uview_2d<Spack>& diag_eff_radius_qc, const uview_2d<Spack>& diag_eff_radius_qi,
+  const uview_2d<Spack>& diag_eff_radius_qr,
   const uview_2d<Spack>& inv_cld_frac_i, const uview_2d<Spack>& inv_cld_frac_l, const uview_2d<Spack>& inv_cld_frac_r,
   const uview_2d<Spack>& exner, const uview_2d<Spack>& T_atm, const uview_2d<Spack>& qv, const uview_2d<Spack>& inv_dz,
   const uview_1d<Scalar>& precip_liq_surf, const uview_1d<Scalar>& precip_ice_surf,
@@ -48,6 +49,7 @@ void Functions<Real,DefaultDevice>
         ze_rain(i,k)           = 1.e-22;
         diag_eff_radius_qc(i,k)         = 10.e-6;
         diag_eff_radius_qi(i,k)         = 25.e-6;
+        diag_eff_radius_qr(i,k)         = 500.e-6;
         inv_cld_frac_i(i,k)    = 1 / cld_frac_i(i,k);
         inv_cld_frac_l(i,k)    = 1 / cld_frac_l(i,k);
         inv_cld_frac_r(i,k)    = 1 / cld_frac_r(i,k);
@@ -195,6 +197,7 @@ Int Functions<Real,DefaultDevice>
   auto th                 = prognostic_state.th;
   auto diag_eff_radius_qc = diagnostic_outputs.diag_eff_radius_qc;
   auto diag_eff_radius_qi = diagnostic_outputs.diag_eff_radius_qi;
+  auto diag_eff_radius_qr = diagnostic_outputs.diag_eff_radius_qr;
   auto qv2qi_depos_tend   = diagnostic_outputs.qv2qi_depos_tend;
   auto rho_qi             = diagnostic_outputs.rho_qi;
   auto precip_liq_flux    = diagnostic_outputs.precip_liq_flux;
@@ -211,8 +214,8 @@ Int Functions<Real,DefaultDevice>
   // initialize
   p3_main_init_disp(
       nj, nk_pack, cld_frac_i, cld_frac_l, cld_frac_r, inv_exner, th, dz, diag_equiv_reflectivity,
-      ze_ice, ze_rain, diag_eff_radius_qc, diag_eff_radius_qi, inv_cld_frac_i, inv_cld_frac_l,
-      inv_cld_frac_r, exner, T_atm, qv, inv_dz,
+      ze_ice, ze_rain, diag_eff_radius_qc, diag_eff_radius_qi, diag_eff_radius_qr,
+      inv_cld_frac_i, inv_cld_frac_l, inv_cld_frac_r, exner, T_atm, qv, inv_dz,
       diagnostic_outputs.precip_liq_surf, diagnostic_outputs.precip_ice_surf,
       mu_r, lamr, logn0r, nu, cdist, cdist1, cdistr,
       qc_incld, qr_incld, qi_incld, qm_incld, nc_incld, nr_incld, ni_incld, bm_incld,
@@ -292,7 +295,7 @@ Int Functions<Real,DefaultDevice>
       rho, inv_rho, rhofaci, qv, th, qc, nc, qr, nr, qi, ni,
       qm, bm, latent_heat_vapor, latent_heat_sublim, mu_c, nu, lamc, mu_r, lamr,
       vap_liq_exchange, ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi,
-      rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc, nucleationPossible, hydrometeorsPresent);
+      rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc, diag_eff_radius_qr, nucleationPossible, hydrometeorsPresent);
 
   //
   // merge ice categories with similar properties

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part3_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part3_disp.cpp
@@ -53,6 +53,7 @@ void Functions<Real,DefaultDevice>
   const uview_2d<Spack>& rho_qi,
   const uview_2d<Spack>& diag_equiv_reflectivity,
   const uview_2d<Spack>& diag_eff_radius_qc,
+  const uview_2d<Spack>& diag_eff_radius_qr,
   const uview_1d<bool>& nucleationPossible,
   const uview_1d<bool>& hydrometeorsPresent)
 {
@@ -79,7 +80,8 @@ void Functions<Real,DefaultDevice>
       ekat::subview(ni, i), ekat::subview(qm, i), ekat::subview(bm, i), ekat::subview(latent_heat_vapor, i), ekat::subview(latent_heat_sublim, i), 
       ekat::subview(mu_c, i), ekat::subview(nu, i), ekat::subview(lamc, i), ekat::subview(mu_r, i), ekat::subview(lamr, i),
       ekat::subview(vap_liq_exchange, i), ekat::subview(ze_rain, i), ekat::subview(ze_ice, i), ekat::subview(diag_vm_qi, i), ekat::subview(diag_eff_radius_qi, i), 
-      ekat::subview(diag_diam_qi, i), ekat::subview(rho_qi, i), ekat::subview(diag_equiv_reflectivity, i), ekat::subview(diag_eff_radius_qc, i));
+      ekat::subview(diag_diam_qi, i), ekat::subview(rho_qi, i), ekat::subview(diag_equiv_reflectivity, i), ekat::subview(diag_eff_radius_qc, i),
+      ekat::subview(diag_eff_radius_qr, i));
 
   });
 }

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -99,6 +99,7 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_field<Updated>("precip_ice_surf_mass", scalar2d_layout,     kg/m2,  grid_name, "ACCUMULATED");
   add_field<Computed>("eff_radius_qc",       scalar3d_layout_mid, micron, grid_name, ps);
   add_field<Computed>("eff_radius_qi",       scalar3d_layout_mid, micron, grid_name, ps);
+  add_field<Computed>("eff_radius_qr",       scalar3d_layout_mid, micron, grid_name, ps);
 
   // History Only: (all fields are just outputs and are really only meant for I/O purposes)
   // TODO: These should be averaged over subcycle as well.  But there is no simple mechanism
@@ -220,6 +221,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   add_postcondition_check<FieldLowerBoundCheck>(get_field_out("precip_ice_surf_mass"),m_grid,0.0,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qc"),m_grid,0.0,1.0e2,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qi"),m_grid,0.0,5.0e3,false);
+  add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qr"),m_grid,0.0,5.0e3,false);
 
   // Initialize p3
   p3::p3_init(/* write_tables = */ false,
@@ -297,6 +299,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   // --Diagnostic Outputs
   diag_outputs.diag_eff_radius_qc = get_field_out("eff_radius_qc").get_view<Pack**>();
   diag_outputs.diag_eff_radius_qi = get_field_out("eff_radius_qi").get_view<Pack**>();
+  diag_outputs.diag_eff_radius_qr = get_field_out("eff_radius_qr").get_view<Pack**>();
 
   diag_outputs.precip_liq_surf  = m_buffer.precip_liq_surf_flux;
   diag_outputs.precip_ice_surf  = m_buffer.precip_ice_surf_flux;
@@ -317,6 +320,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
                             prog_state.qv, prog_state.qc, prog_state.nc, prog_state.qr,prog_state.nr,
                             prog_state.qi, prog_state.qm, prog_state.ni,prog_state.bm,qv_prev,
                             diag_outputs.diag_eff_radius_qc,diag_outputs.diag_eff_radius_qi,
+                            diag_outputs.diag_eff_radius_qr,
                             diag_outputs.precip_liq_surf,diag_outputs.precip_ice_surf,
                             precip_liq_surf_mass,precip_ice_surf_mass);
 

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -108,6 +108,7 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_field<Computed>("micro_liq_ice_exchange", scalar3d_layout_mid, Q, grid_name, ps);
   add_field<Computed>("micro_vap_liq_exchange", scalar3d_layout_mid, Q, grid_name, ps);
   add_field<Computed>("micro_vap_ice_exchange", scalar3d_layout_mid, Q, grid_name, ps);
+  add_field<Computed>("rainfrac",               scalar3d_layout_mid, nondim, grid_name, ps);
 
   // Boundary flux fields for energy and mass conservation checks
   if (has_column_conservation_check()) {
@@ -172,8 +173,6 @@ void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
   s_mem += m_buffer.cld_frac_l.size();
   m_buffer.cld_frac_i = decltype(m_buffer.cld_frac_i)(s_mem, m_num_cols, nk_pack);
   s_mem += m_buffer.cld_frac_i.size();
-  m_buffer.cld_frac_r = decltype(m_buffer.cld_frac_r)(s_mem, m_num_cols, nk_pack);
-  s_mem += m_buffer.cld_frac_r.size();
   m_buffer.dz = decltype(m_buffer.dz)(s_mem, m_num_cols, nk_pack);
   s_mem += m_buffer.dz.size();
   m_buffer.qv2qi_depos_tend = decltype(m_buffer.qv2qi_depos_tend)(s_mem, m_num_cols, nk_pack);
@@ -250,13 +249,13 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   auto qv_prev                = get_field_out("qv_prev_micro_step").get_view<Pack**>();
   const auto& precip_liq_surf_mass = get_field_out("precip_liq_surf_mass").get_view<Real*>();
   const auto& precip_ice_surf_mass = get_field_out("precip_ice_surf_mass").get_view<Real*>();
+  auto cld_frac_r             = get_field_out("rainfrac").get_view<Pack**>();
 
   // Alias local variables from temporary buffer
   auto inv_exner  = m_buffer.inv_exner;
   auto th_atm     = m_buffer.th_atm;
   auto cld_frac_l = m_buffer.cld_frac_l;
   auto cld_frac_i = m_buffer.cld_frac_i;
-  auto cld_frac_r = m_buffer.cld_frac_r;
   auto dz         = m_buffer.dz;
 
   // -- Set values for the pre-amble structure

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
@@ -239,6 +239,7 @@ public:
         // Rescale effective radius' into microns
         diag_eff_radius_qc(icol,ipack) *= 1e6;
         diag_eff_radius_qi(icol,ipack) *= 1e6;
+        diag_eff_radius_qr(icol,ipack) *= 1e6;
       } // for ipack
 
       // Microphysics can be subcycled together during a single physics timestep,
@@ -281,6 +282,7 @@ public:
     view_2d       qv_prev;
     view_2d       diag_eff_radius_qc;
     view_2d       diag_eff_radius_qi;
+    view_2d       diag_eff_radius_qr;
     view_1d_const precip_liq_surf_flux;
     view_1d_const precip_ice_surf_flux;
     view_1d       precip_liq_surf_mass;
@@ -298,7 +300,7 @@ public:
                     const view_2d& qv_, const view_2d& qc_, const view_2d& nc_, const view_2d& qr_, const view_2d& nr_,
                     const view_2d& qi_, const view_2d& qm_, const view_2d& ni_, const view_2d& bm_,
                     const view_2d& qv_prev_, const view_2d& diag_eff_radius_qc_,
-                    const view_2d& diag_eff_radius_qi_, 
+                    const view_2d& diag_eff_radius_qi_, const view_2d& diag_eff_radius_qr_,
                     const view_1d_const& precip_liq_surf_flux_, const view_1d_const& precip_ice_surf_flux_,
                     const view_1d& precip_liq_surf_mass_, const view_1d& precip_ice_surf_mass_)
     {
@@ -327,6 +329,7 @@ public:
       qv_prev              = qv_prev_;
       diag_eff_radius_qc   = diag_eff_radius_qc_;
       diag_eff_radius_qi   = diag_eff_radius_qi_;
+      diag_eff_radius_qr   = diag_eff_radius_qr_;
       precip_liq_surf_mass = precip_liq_surf_mass_;
       precip_ice_surf_mass = precip_ice_surf_mass_;
       // TODO: This is a list of variables not yet defined for post-processing, but are
@@ -335,7 +338,7 @@ public:
       // qme, vap_liq_exchange
       // ENERGY Conservation: prec_str, snow_str
       // RAD Vars: icinc, icwnc, icimrst, icwmrst
-      // COSP Vars: flxprc, flxsnw, flxprc, flxsnw, cvreffliq, cvreffice, reffrain, reffsnow
+      // COSP Vars: flxprc, flxsnw, flxprc, flxsnw, cvreffliq, cvreffice, reffsnow
     } // set_variables
 
     void set_mass_and_energy_fluxes (const view_1d& vapor_flux_, const view_1d& water_flux_,

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
@@ -358,7 +358,7 @@ public:
     // 1d view scalar, size (ncol)
     static constexpr int num_1d_scalar = 2; //no 2d vars now, but keeping 1d struct for future expansion
     // 2d view packed, size (ncol, nlev_packs)
-    static constexpr int num_2d_vector = 9;
+    static constexpr int num_2d_vector = 8;
     static constexpr int num_2dp1_vector = 2;
 
     uview_1d precip_liq_surf_flux;
@@ -367,7 +367,6 @@ public:
     uview_2d th_atm;
     uview_2d cld_frac_l;
     uview_2d cld_frac_i;
-    uview_2d cld_frac_r;
     uview_2d dz;
     uview_2d qv2qi_depos_tend;
     uview_2d rho_qi;

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -32,6 +32,7 @@ void Functions<S,D>
   const uview_1d<Spack>& ze_rain,
   const uview_1d<Spack>& diag_eff_radius_qc,
   const uview_1d<Spack>& diag_eff_radius_qi,
+  const uview_1d<Spack>& diag_eff_radius_qr,
   const uview_1d<Spack>& inv_cld_frac_i,
   const uview_1d<Spack>& inv_cld_frac_l,
   const uview_1d<Spack>& inv_cld_frac_r,
@@ -54,6 +55,7 @@ void Functions<S,D>
     ze_rain(k)           = 1.e-22;
     diag_eff_radius_qc(k)         = 10.e-6;
     diag_eff_radius_qi(k)         = 25.e-6;
+    diag_eff_radius_qr(k)         = 500.e-6;
     inv_cld_frac_i(k)    = 1 / cld_frac_i(k);
     inv_cld_frac_l(k)    = 1 / cld_frac_l(k);
     inv_cld_frac_r(k)    = 1 / cld_frac_r(k);
@@ -188,6 +190,7 @@ Int Functions<S,D>
     const auto oth                 = ekat::subview(prognostic_state.th, i);
     const auto odiag_eff_radius_qc = ekat::subview(diagnostic_outputs.diag_eff_radius_qc, i);
     const auto odiag_eff_radius_qi = ekat::subview(diagnostic_outputs.diag_eff_radius_qi, i);
+    const auto odiag_eff_radius_qr = ekat::subview(diagnostic_outputs.diag_eff_radius_qr, i);
     const auto oqv2qi_depos_tend   = ekat::subview(diagnostic_outputs.qv2qi_depos_tend, i);
     const auto orho_qi             = ekat::subview(diagnostic_outputs.rho_qi, i);
     const auto oprecip_liq_flux    = ekat::subview(diagnostic_outputs.precip_liq_flux, i);
@@ -218,8 +221,8 @@ Int Functions<S,D>
     p3_main_init(
       team, nk_pack,
       ocld_frac_i, ocld_frac_l, ocld_frac_r, oinv_exner, oth, odz, diag_equiv_reflectivity,
-      ze_ice, ze_rain, odiag_eff_radius_qc, odiag_eff_radius_qi, inv_cld_frac_i, inv_cld_frac_l,
-      inv_cld_frac_r, exner, T_atm, oqv, inv_dz,
+      ze_ice, ze_rain, odiag_eff_radius_qc, odiag_eff_radius_qi, odiag_eff_radius_qr,
+      inv_cld_frac_i, inv_cld_frac_l, inv_cld_frac_r, exner, T_atm, oqv, inv_dz,
       diagnostic_outputs.precip_liq_surf(i), diagnostic_outputs.precip_ice_surf(i), zero_init);
 
     p3_main_part1(
@@ -300,7 +303,7 @@ Int Functions<S,D>
       rho, inv_rho, rhofaci, oqv, oth, oqc, onc, oqr, onr, oqi, oni,
       oqm, obm, olatent_heat_vapor, olatent_heat_sublim, mu_c, nu, lamc, mu_r, lamr,
       ovap_liq_exchange, ze_rain, ze_ice, diag_vm_qi, odiag_eff_radius_qi, diag_diam_qi,
-      orho_qi, diag_equiv_reflectivity, odiag_eff_radius_qc);
+      orho_qi, diag_equiv_reflectivity, odiag_eff_radius_qc, odiag_eff_radius_qr);
 
     //
     // merge ice categories with similar properties

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
@@ -55,7 +55,8 @@ void Functions<S,D>
   const uview_1d<Spack>& diag_diam_qi,
   const uview_1d<Spack>& rho_qi,
   const uview_1d<Spack>& diag_equiv_reflectivity,
-  const uview_1d<Spack>& diag_eff_radius_qc)
+  const uview_1d<Spack>& diag_eff_radius_qc,
+  const uview_1d<Spack>& diag_eff_radius_qr)
 {
   constexpr Scalar qsmall       = C::QSMALL;
   constexpr Scalar inv_cp       = C::INV_CP;
@@ -116,6 +117,7 @@ void Functions<S,D>
         ze_rain(k).set(qr_gt_small, nr(k)*(mu_r(k)+6)*(mu_r(k)+5)*(mu_r(k)+4)*
                        (mu_r(k)+3)*(mu_r(k)+2)*(mu_r(k)+1)/pow(lamr(k), sp(6.0))); // once f90 is gone, 6 can be int
         ze_rain(k).set(qr_gt_small, max(ze_rain(k), sp(1.e-22)));
+        diag_eff_radius_qr(k).set(qr_gt_small, sp(1.5) / lamr(k));
       }
 
       if (qr_small.any()) {

--- a/components/eamxx/src/physics/p3/p3_f90.cpp
+++ b/components/eamxx/src/physics/p3/p3_f90.cpp
@@ -49,6 +49,7 @@ FortranData::FortranData (Int ncol_, Int nlev_)
   precip_ice_surf    = Array1("precipitation rate, solid   m/s", ncol);
   diag_eff_radius_qc = Array2("effective radius, cloud, m", ncol, nlev);
   diag_eff_radius_qi = Array2("effective radius, ice, m", ncol, nlev);
+  diag_eff_radius_qr = Array2("effective radius, rain, m", ncol, nlev);
   rho_qi             = Array2("bulk density of ice, kg/m", ncol, nlev);
   qv2qi_depos_tend   = Array2("qitend due to deposition/sublimation ", ncol, nlev);
   precip_liq_flux    = Array2("grid-box average rain flux (kg m^-2 s^-1), pverp", ncol, nlev+1);
@@ -77,7 +78,7 @@ void FortranDataIterator::init (const FortranData::Ptr& dp) {
   fdipb(dz); fdipb(nc_nuceat_tend); fdipb(nccn_prescribed); fdipb(ni_activated); fdipb(inv_qc_relvar); fdipb(qc);
   fdipb(nc); fdipb(qr); fdipb(nr); fdipb(qi); fdipb(ni);
   fdipb(qm); fdipb(bm); fdipb(precip_liq_surf); fdipb(precip_ice_surf);
-  fdipb(diag_eff_radius_qc); fdipb(diag_eff_radius_qi); fdipb(rho_qi);
+  fdipb(diag_eff_radius_qc); fdipb(diag_eff_radius_qi); fdipb(diag_eff_radius_qr); fdipb(rho_qi);
   fdipb(dpres); fdipb(inv_exner); fdipb(qv2qi_depos_tend); 
   fdipb(precip_liq_flux); fdipb(precip_ice_flux);
   fdipb(cld_frac_r); fdipb(cld_frac_l); fdipb(cld_frac_i);

--- a/components/eamxx/src/physics/p3/p3_f90.hpp
+++ b/components/eamxx/src/physics/p3/p3_f90.hpp
@@ -31,7 +31,7 @@ struct FortranData {
     ni, qm, bm, dpres, inv_exner, qv_prev, t_prev;
   // Out
   Array1 precip_liq_surf, precip_ice_surf;
-  Array2 diag_eff_radius_qc, diag_eff_radius_qi, rho_qi, qv2qi_depos_tend,
+  Array2 diag_eff_radius_qc, diag_eff_radius_qi, diag_eff_radius_qr, rho_qi, qv2qi_depos_tend,
          precip_liq_flux, precip_ice_flux, cld_frac_r, cld_frac_l, cld_frac_i;
   Array3 p3_tend_out;
   Array2 liq_ice_exchange,vap_liq_exchange,vap_ice_exchange;

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -176,6 +176,8 @@ struct Functions
     view_2d<Spack> diag_eff_radius_qc;
     // Effective ice radius [m]
     view_2d<Spack> diag_eff_radius_qi;
+    // Effective rain radius [m]
+    view_2d<Spack> diag_eff_radius_qr;
     // Bulk density of ice [kg m-3]
     view_2d<Spack> rho_qi;
     // Grid-box average rain flux [kg m^-2 s^-1] pverp
@@ -867,6 +869,7 @@ struct Functions
     const uview_1d<Spack>& ze_rain,
     const uview_1d<Spack>& diag_eff_radius_qc,
     const uview_1d<Spack>& diag_eff_radius_qi,
+    const uview_1d<Spack>& diag_eff_radius_qr,
     const uview_1d<Spack>& inv_cld_frac_i,
     const uview_1d<Spack>& inv_cld_frac_l,
     const uview_1d<Spack>& inv_cld_frac_r,
@@ -886,7 +889,7 @@ struct Functions
     const uview_2d<const Spack>& th_atm, const uview_2d<const Spack>& dz,
     const uview_2d<Spack>& diag_equiv_reflectivity, const uview_2d<Spack>& ze_ice,
     const uview_2d<Spack>& ze_rain, const uview_2d<Spack>& diag_eff_radius_qc,
-    const uview_2d<Spack>& diag_eff_radius_qi, const uview_2d<Spack>& inv_cld_frac_i,
+    const uview_2d<Spack>& diag_eff_radius_qi, const uview_2d<Spack>& diag_eff_radius_qr, const uview_2d<Spack>& inv_cld_frac_i,
     const uview_2d<Spack>& inv_cld_frac_l, const uview_2d<Spack>& inv_cld_frac_r,
     const uview_2d<Spack>& exner, const uview_2d<Spack>& T_atm, const uview_2d<Spack>& qv,
     const uview_2d<Spack>& inv_dz, const uview_1d<Scalar>& precip_liq_surf, const uview_1d<Scalar>& precip_ice_surf,
@@ -1199,7 +1202,8 @@ struct Functions
     const uview_1d<Spack>& diag_diam_qi,
     const uview_1d<Spack>& rho_qi,
     const uview_1d<Spack>& diag_equiv_reflectivity,
-    const uview_1d<Spack>& diag_eff_radius_qc);
+    const uview_1d<Spack>& diag_eff_radius_qc,
+    const uview_1d<Spack>& diag_eff_radius_qr);
 
 #ifdef SCREAM_SMALL_KERNELS
   static void p3_main_part3_disp(
@@ -1240,6 +1244,7 @@ struct Functions
     const uview_2d<Spack>& rho_qi,
     const uview_2d<Spack>& diag_equiv_reflectivity,
     const uview_2d<Spack>& diag_eff_radius_qc,
+    const uview_2d<Spack>& diag_eff_radius_qr,
     const uview_1d<bool>& is_nucleat_possible,
     const uview_1d<bool>& is_hydromet_present);
 #endif

--- a/components/eamxx/src/physics/p3/p3_functions_f90.cpp
+++ b/components/eamxx/src/physics/p3/p3_functions_f90.cpp
@@ -218,14 +218,14 @@ void p3_main_part3_c(
   Real* rho, Real* inv_rho, Real* rhofaci, Real* qv, Real* th_atm, Real* qc, Real* nc, Real* qr, Real* nr,
   Real* qi, Real* ni, Real* qm, Real* bm, Real* latent_heat_vapor, Real* latent_heat_sublim,
   Real* mu_c, Real* nu, Real* lamc, Real* mu_r, Real* lamr, Real* vap_liq_exchange,
-  Real*  ze_rain, Real* ze_ice, Real* diag_vm_qi, Real* diag_eff_radius_qi, Real* diag_diam_qi, Real* rho_qi, Real* diag_equiv_reflectivity, Real* diag_eff_radius_qc);
+  Real*  ze_rain, Real* ze_ice, Real* diag_vm_qi, Real* diag_eff_radius_qi, Real* diag_diam_qi, Real* rho_qi, Real* diag_equiv_reflectivity, Real* diag_eff_radius_qc, Real* diag_eff_radius_qr);
 
 void p3_main_c(
   Real* qc, Real* nc, Real* qr, Real* nr, Real* th_atm, Real* qv, Real dt,
   Real* qi, Real* qm, Real* ni, Real* bm, Real* pres, Real* dz,
   Real* nc_nuceat_tend, Real* nccn_prescribed, Real* ni_activated, Real* inv_qc_relvar, Int it, Real* precip_liq_surf,
   Real* precip_ice_surf, Int its, Int ite, Int kts, Int kte, Real* diag_eff_radius_qc,
-  Real* diag_eff_radius_qi, Real* rho_qi, bool do_predict_nc, bool do_prescribed, Real* dpres, Real* inv_exner,
+  Real* diag_eff_radius_qi, Real* diag_eff_radius_qr, Real* rho_qi, bool do_predict_nc, bool do_prescribed, Real* dpres, Real* inv_exner,
   Real* qv2qi_depos_tend, Real* precip_liq_flux, Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i,
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev, Real* elapsed_s);
 
@@ -782,7 +782,8 @@ P3MainPart3Data::P3MainPart3Data(
     &qv, &th_atm, &qc, &nc, &qr, &nr, &qi, &ni, &qm, &bm, &latent_heat_vapor, &latent_heat_sublim,
     &mu_c, &nu, &lamc, &mu_r,
     &lamr, &vap_liq_exchange,
-    &ze_rain, &ze_ice, &diag_vm_qi, &diag_eff_radius_qi, &diag_diam_qi, &rho_qi, &diag_equiv_reflectivity, &diag_eff_radius_qc} }),
+    &ze_rain, &ze_ice, &diag_vm_qi, &diag_eff_radius_qi, &diag_diam_qi, &rho_qi, &diag_equiv_reflectivity,
+    &diag_eff_radius_qc, &diag_eff_radius_qr} }),
   kts(kts_), kte(kte_), kbot(kbot_), ktop(ktop_), kdir(kdir_)
 {}
 
@@ -794,7 +795,7 @@ void p3_main_part3(P3MainPart3Data& d)
     d.inv_exner, d.cld_frac_l, d.cld_frac_r, d.cld_frac_i,
     d.rho, d.inv_rho, d.rhofaci, d.qv, d.th_atm, d.qc, d.nc, d.qr, d.nr, d.qi, d.ni, d.qm, d.bm, d.latent_heat_vapor, d.latent_heat_sublim,
     d.mu_c, d.nu, d.lamc, d.mu_r, d.lamr, d.vap_liq_exchange,
-    d. ze_rain, d.ze_ice, d.diag_vm_qi, d.diag_eff_radius_qi, d.diag_diam_qi, d.rho_qi, d.diag_equiv_reflectivity, d.diag_eff_radius_qc);
+    d. ze_rain, d.ze_ice, d.diag_vm_qi, d.diag_eff_radius_qi, d.diag_diam_qi, d.rho_qi, d.diag_equiv_reflectivity, d.diag_eff_radius_qc, d.diag_eff_radius_qr);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -804,7 +805,7 @@ P3MainData::P3MainData(
   PhysicsTestData( { {(ite_ - its_) + 1, (kte_ - kts_) + 1}, {(ite_ - its_) + 1, (kte_ - kts_) + 2} }, { {
     &pres, &dz, &nc_nuceat_tend, &nccn_prescribed, &ni_activated, &dpres, &inv_exner, &cld_frac_i, &cld_frac_l, &cld_frac_r,
     &inv_qc_relvar, &qc, &nc, &qr, &nr, &qi, &qm, &ni, &bm, &qv, &th_atm, &qv_prev, &t_prev,
-    &diag_eff_radius_qc, &diag_eff_radius_qi, &rho_qi, &mu_c, &lamc, &qv2qi_depos_tend, &precip_total_tend, &nevapr,
+    &diag_eff_radius_qc, &diag_eff_radius_qi, &diag_eff_radius_qr, &rho_qi, &mu_c, &lamc, &qv2qi_depos_tend, &precip_total_tend, &nevapr,
     &qr_evap_tend, &liq_ice_exchange, &vap_liq_exchange, &vap_ice_exchange, &precip_liq_flux,
     &precip_ice_flux},
     {&precip_liq_surf, &precip_ice_surf} }), // these two are (ni, nk+1)
@@ -819,7 +820,7 @@ void p3_main(P3MainData& d)
   p3_main_c(
     d.qc, d.nc, d.qr, d.nr, d.th_atm, d.qv, d.dt, d.qi, d.qm, d.ni,
     d.bm, d.pres, d.dz, d.nc_nuceat_tend, d.nccn_prescribed, d.ni_activated, d.inv_qc_relvar, d.it, d.precip_liq_surf,
-    d.precip_ice_surf, d.its, d.ite, d.kts, d.kte, d.diag_eff_radius_qc, d.diag_eff_radius_qi,
+    d.precip_ice_surf, d.its, d.ite, d.kts, d.kte, d.diag_eff_radius_qc, d.diag_eff_radius_qi, d.diag_eff_radius_qr,
     d.rho_qi, d.do_predict_nc, d.do_prescribed_CCN, d.dpres, d.inv_exner, d.qv2qi_depos_tend,
     d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i,
     d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange, d.qv_prev, d.t_prev, &d.elapsed_s);
@@ -1819,7 +1820,7 @@ void p3_main_part3_f(
   Real* bm, Real* latent_heat_vapor, Real* latent_heat_sublim, Real* mu_c, Real* nu, Real* lamc,
   Real* mu_r, Real* lamr, Real* vap_liq_exchange, Real* ze_rain, Real* ze_ice,
   Real* diag_vm_qi, Real* diag_eff_radius_qi, Real* diag_diam_qi, Real* rho_qi,
-  Real* diag_equiv_reflectivity, Real* diag_eff_radius_qc)
+  Real* diag_equiv_reflectivity, Real* diag_eff_radius_qc, Real* diag_eff_radius_qr)
 {
   using P3F  = Functions<Real, DefaultDevice>;
 
@@ -1847,7 +1848,7 @@ void p3_main_part3_f(
       inv_exner, cld_frac_l, cld_frac_r, cld_frac_i, rho, inv_rho, rhofaci, qv, th_atm, qc,
       nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, mu_c, nu, lamc, mu_r,
       lamr, vap_liq_exchange, ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi,
-      rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc},
+      rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc, diag_eff_radius_qr},
     nk, temp_d);
 
   view_1d
@@ -1883,7 +1884,8 @@ void p3_main_part3_f(
     diag_diam_qi_d             (temp_d[29]),
     rho_qi_d                   (temp_d[30]),
     diag_equiv_reflectivity_d  (temp_d[31]),
-    diag_eff_radius_qc_d          (temp_d[32]);
+    diag_eff_radius_qc_d          (temp_d[32]),
+    diag_eff_radius_qr_d          (temp_d[33]);
 
   // Call core function from kernel
   const auto dnu            = P3GlobalForFortran::dnu();
@@ -1898,7 +1900,7 @@ void p3_main_part3_f(
                        latent_heat_sublim_d, mu_c_d, nu_d, lamc_d, mu_r_d, lamr_d,
                        vap_liq_exchange_d, ze_rain_d, ze_ice_d,
                        diag_vm_qi_d, diag_eff_radius_qi_d, diag_diam_qi_d, rho_qi_d,
-                       diag_equiv_reflectivity_d, diag_eff_radius_qc_d);
+                       diag_equiv_reflectivity_d, diag_eff_radius_qc_d, diag_eff_radius_qr_d);
   });
 
   // Sync back to host
@@ -1906,13 +1908,14 @@ void p3_main_part3_f(
     rho_d, inv_rho_d, rhofaci_d, qv_d, th_atm_d, qc_d, nc_d, qr_d, nr_d, qi_d,
     ni_d, qm_d, bm_d, latent_heat_vapor_d, latent_heat_sublim_d, mu_c_d, nu_d, lamc_d, mu_r_d,
     lamr_d, vap_liq_exchange_d, ze_rain_d, ze_ice_d, diag_vm_qi_d, diag_eff_radius_qi_d,
-    diag_diam_qi_d, rho_qi_d, diag_equiv_reflectivity_d, diag_eff_radius_qc_d
+    diag_diam_qi_d, rho_qi_d, diag_equiv_reflectivity_d, diag_eff_radius_qc_d, diag_eff_radius_qr_d
   };
 
   ekat::device_to_host({
       rho, inv_rho, rhofaci, qv, th_atm, qc, nc, qr, nr, qi, ni, qm, bm,
       latent_heat_vapor, latent_heat_sublim, mu_c, nu, lamc, mu_r, lamr, vap_liq_exchange, ze_rain, ze_ice,
-      diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc
+      diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc,
+      diag_eff_radius_qr
     },
     nk, inout_views);
 }
@@ -1922,7 +1925,7 @@ Int p3_main_f(
   Real* qi, Real* qm, Real* ni, Real* bm, Real* pres, Real* dz,
   Real* nc_nuceat_tend, Real* nccn_prescribed, Real* ni_activated, Real* inv_qc_relvar, Int it, Real* precip_liq_surf,
   Real* precip_ice_surf, Int its, Int ite, Int kts, Int kte, Real* diag_eff_radius_qc,
-  Real* diag_eff_radius_qi, Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* inv_exner,
+  Real* diag_eff_radius_qi, Real* diag_eff_radius_qr, Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* inv_exner,
   Real* qv2qi_depos_tend, Real* precip_liq_flux, Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i,
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev)
 {
@@ -1958,7 +1961,7 @@ Int p3_main_f(
   std::vector<size_t> dim2_sizes(P3MainData::NUM_ARRAYS, nk);
   std::vector<const Real*> ptr_array = {
     pres, dz, nc_nuceat_tend, nccn_prescribed, ni_activated, dpres, inv_exner, cld_frac_i, cld_frac_l, cld_frac_r, inv_qc_relvar,
-    qc, nc, qr, nr, qi, qm, ni, bm, qv, th_atm, qv_prev, t_prev, diag_eff_radius_qc, diag_eff_radius_qi,
+    qc, nc, qr, nr, qi, qm, ni, bm, qv, th_atm, qv_prev, t_prev, diag_eff_radius_qc, diag_eff_radius_qi, diag_eff_radius_qr,
     rho_qi, qv2qi_depos_tend,
     liq_ice_exchange, vap_liq_exchange, vap_ice_exchange, precip_liq_flux, precip_ice_flux, precip_liq_surf, precip_ice_surf
   };
@@ -2005,15 +2008,16 @@ Int p3_main_f(
     t_prev_d               (temp_d[counter++]),
     diag_eff_radius_qc_d   (temp_d[counter++]),
     diag_eff_radius_qi_d   (temp_d[counter++]),
-    rho_qi_d               (temp_d[counter++]), //25
+    diag_eff_radius_qr_d   (temp_d[counter++]), //25
+    rho_qi_d               (temp_d[counter++]),
     qv2qi_depos_tend_d     (temp_d[counter++]),
     liq_ice_exchange_d     (temp_d[counter++]),
     vap_liq_exchange_d     (temp_d[counter++]),
-    vap_ice_exchange_d     (temp_d[counter++]),
-    precip_liq_flux_d      (temp_d[counter++]), //30
+    vap_ice_exchange_d     (temp_d[counter++]), //30
+    precip_liq_flux_d      (temp_d[counter++]),
     precip_ice_flux_d      (temp_d[counter++]),
     precip_liq_surf_temp_d (temp_d[counter++]),
-    precip_ice_surf_temp_d (temp_d[counter++]); //33
+    precip_ice_surf_temp_d (temp_d[counter++]); //34
 
   // Special cases: precip_liq_surf=1d<scalar>(ni), precip_ice_surf=1d<scalar>(ni), col_location=2d<scalar>(nj, 3)
   sview_1d precip_liq_surf_d("precip_liq_surf_d", nj), precip_ice_surf_d("precip_ice_surf_d", nj);
@@ -2041,7 +2045,7 @@ Int p3_main_f(
                                       cld_frac_l_d, cld_frac_r_d, pres_d, dz_d, dpres_d,
                                       inv_exner_d, qv_prev_d, t_prev_d};
   P3F::P3DiagnosticOutputs diag_outputs{qv2qi_depos_tend_d, precip_liq_surf_d,
-                                        precip_ice_surf_d, diag_eff_radius_qc_d, diag_eff_radius_qi_d,
+                                        precip_ice_surf_d, diag_eff_radius_qc_d, diag_eff_radius_qi_d, diag_eff_radius_qr_d,
                                         rho_qi_d,precip_liq_flux_d, precip_ice_flux_d};
   P3F::P3Infrastructure infrastructure{dt, it, its, ite, kts, kte,
                                        do_predict_nc, do_prescribed_CCN, col_location_d};
@@ -2076,7 +2080,7 @@ Int p3_main_f(
   // Sync back to host
   std::vector<view_2d> inout_views = {
     qc_d, nc_d, qr_d, nr_d, qi_d, qm_d, ni_d, bm_d, qv_d, th_atm_d,
-    diag_eff_radius_qc_d, diag_eff_radius_qi_d, rho_qi_d,
+    diag_eff_radius_qc_d, diag_eff_radius_qi_d, diag_eff_radius_qr_d, rho_qi_d,
     qv2qi_depos_tend_d,
     liq_ice_exchange_d, vap_liq_exchange_d, vap_ice_exchange_d,
     precip_liq_flux_d, precip_ice_flux_d, precip_liq_surf_temp_d, precip_ice_surf_temp_d
@@ -2090,7 +2094,7 @@ Int p3_main_f(
   dim1_sizes_out[dim_sizes_out_len-1] = 1; dim2_sizes_out[dim_sizes_out_len-1] = nj; // precip_ice_surf
 
   ekat::device_to_host({
-      qc, nc, qr, nr, qi, qm, ni, bm, qv, th_atm, diag_eff_radius_qc, diag_eff_radius_qi,
+      qc, nc, qr, nr, qi, qm, ni, bm, qv, th_atm, diag_eff_radius_qc, diag_eff_radius_qi, diag_eff_radius_qr,
       rho_qi, qv2qi_depos_tend,
       liq_ice_exchange, vap_liq_exchange, vap_ice_exchange, precip_liq_flux, precip_ice_flux, precip_liq_surf, precip_ice_surf
     },

--- a/components/eamxx/src/physics/p3/p3_functions_f90.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions_f90.hpp
@@ -723,7 +723,7 @@ struct P3MainPart2Data : public PhysicsTestData
 
 struct P3MainPart3Data : public PhysicsTestData
 {
-  static constexpr size_t NUM_ARRAYS = 33;
+  static constexpr size_t NUM_ARRAYS = 34;
 
   // Inputs
   Int kts, kte, kbot, ktop, kdir;
@@ -734,7 +734,8 @@ struct P3MainPart3Data : public PhysicsTestData
     *qv, *th_atm, *qc, *nc, *qr, *nr, *qi, *ni, *qm, *bm, *latent_heat_vapor, *latent_heat_sublim,
     *mu_c, *nu, *lamc, *mu_r,
     *lamr, *vap_liq_exchange,
-    *ze_rain, *ze_ice, *diag_vm_qi, *diag_eff_radius_qi, *diag_diam_qi, *rho_qi, *diag_equiv_reflectivity, *diag_eff_radius_qc;
+    *ze_rain, *ze_ice, *diag_vm_qi, *diag_eff_radius_qi, *diag_diam_qi, *rho_qi,
+    *diag_equiv_reflectivity, *diag_eff_radius_qc, *diag_eff_radius_qr;
 
   P3MainPart3Data(Int kts_, Int kte_, Int kbot_, Int ktop_, Int kdir_);
 
@@ -747,7 +748,7 @@ struct P3MainPart3Data : public PhysicsTestData
 
 struct P3MainData : public PhysicsTestData
 {
-  static constexpr size_t NUM_ARRAYS = 34;
+  static constexpr size_t NUM_ARRAYS = 35;
   static constexpr size_t NUM_INPUT_ARRAYS = 24;
 
   // Inputs
@@ -760,7 +761,7 @@ struct P3MainData : public PhysicsTestData
   Real* qc, *nc, *qr, *nr, *qi, *qm, *ni, *bm, *qv, *th_atm;
 
   // Out
-  Real *diag_eff_radius_qc, *diag_eff_radius_qi, *rho_qi, *mu_c, *lamc, *qv2qi_depos_tend, *precip_total_tend, *nevapr,
+  Real *diag_eff_radius_qc, *diag_eff_radius_qi, *diag_eff_radius_qr, *rho_qi, *mu_c, *lamc, *qv2qi_depos_tend, *precip_total_tend, *nevapr,
        *qr_evap_tend, *liq_ice_exchange, *vap_liq_exchange, *vap_ice_exchange,
        *precip_liq_flux, *precip_ice_flux, *precip_liq_surf, *precip_ice_surf;
   Real elapsed_s;
@@ -940,14 +941,14 @@ void p3_main_part3_f(
   Real* inv_exner, Real* cld_frac_l, Real* cld_frac_r, Real* cld_frac_i,
   Real* rho, Real* inv_rho, Real* rhofaci, Real* qv, Real* th_atm, Real* qc, Real* nc, Real* qr, Real* nr, Real* qi, Real* ni, Real* qm, Real* bm, Real* latent_heat_vapor, Real* latent_heat_sublim,
   Real* mu_c, Real* nu, Real* lamc, Real* mu_r, Real* lamr, Real* vap_liq_exchange,
-  Real*  ze_rain, Real* ze_ice, Real* diag_vm_qi, Real* diag_eff_radius_qi, Real* diag_diam_qi, Real* rho_qi, Real* diag_equiv_reflectivity, Real* diag_eff_radius_qc);
+  Real*  ze_rain, Real* ze_ice, Real* diag_vm_qi, Real* diag_eff_radius_qi, Real* diag_diam_qi, Real* rho_qi, Real* diag_equiv_reflectivity, Real* diag_eff_radius_qc, Real* diag_eff_radius_qr);
 
 Int p3_main_f(
   Real* qc, Real* nc, Real* qr, Real* nr, Real* th_atm, Real* qv, Real dt,
   Real* qi, Real* qm, Real* ni, Real* bm, Real* pres, Real* dz,
   Real* nc_nuceat_tend, Real* nccn_prescribed, Real* ni_activated, Real* inv_qc_relvar, Int it, Real* precip_liq_surf,
   Real* precip_ice_surf, Int its, Int ite, Int kts, Int kte, Real* diag_eff_radius_qc,
-  Real* diag_eff_radius_qi, Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* inv_exner,
+  Real* diag_eff_radius_qi, Real* diag_eff_radius_qr, Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* inv_exner,
   Real* qv2qi_depos_tend, Real* precip_liq_flux, Real* precip_ice_flux, Real* cld_frac_r, Real* cld_frac_l, Real* cld_frac_i,
   Real* liq_ice_exchange, Real* vap_liq_exchange, Real* vap_ice_exchange, Real* qv_prev, Real* t_prev);
 

--- a/components/eamxx/src/physics/p3/p3_iso_c.f90
+++ b/components/eamxx/src/physics/p3/p3_iso_c.f90
@@ -124,7 +124,7 @@ contains
 
   subroutine p3_main_c(qc,nc,qr,nr,th_atm,qv,dt,qi,qm,ni,bm,   &
        pres,dz,nc_nuceat_tend,nccn_prescribed,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_eff_radius_qc,     &
-       diag_eff_radius_qi,rho_qi,do_predict_nc,do_prescribed_CCN,dpres,inv_exner,qv2qi_depos_tend, &
+       diag_eff_radius_qi,diag_eff_radius_qr,rho_qi,do_predict_nc,do_prescribed_CCN,dpres,inv_exner,qv2qi_depos_tend, &
        precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,liq_ice_exchange, &
        vap_liq_exchange, vap_ice_exchange, qv_prev, t_prev, elapsed_s) bind(C)
     use micro_p3, only : p3_main
@@ -137,7 +137,9 @@ contains
     real(kind=c_real), value, intent(in) :: dt
     real(kind=c_real), intent(out), dimension(its:ite) :: precip_liq_surf, precip_ice_surf
     real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_eff_radius_qc
-    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_eff_radius_qi, rho_qi
+    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_eff_radius_qi
+    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: diag_eff_radius_qr
+    real(kind=c_real), intent(out), dimension(its:ite,kts:kte) :: rho_qi
     integer(kind=c_int), value, intent(in) :: its,ite, kts,kte, it
     logical(kind=c_bool), value, intent(in) :: do_predict_nc,do_prescribed_CCN
 
@@ -168,7 +170,7 @@ contains
 
     call p3_main(qc,nc,qr,nr,th_atm,qv,dt,qi,qm,ni,bm,   &
          pres,dz,nc_nuceat_tend,nccn_prescribed,ni_activated,inv_qc_relvar,it,precip_liq_surf,precip_ice_surf,its,ite,kts,kte,diag_eff_radius_qc, &
-         diag_eff_radius_qi,rho_qi,do_predict_nc,do_prescribed_CCN,dpres,inv_exner,qv2qi_depos_tend,precip_total_tend,nevapr, &
+         diag_eff_radius_qi,diag_eff_radius_qr, rho_qi,do_predict_nc,do_prescribed_CCN,dpres,inv_exner,qv2qi_depos_tend,precip_total_tend,nevapr, &
          qr_evap_tend,precip_liq_flux,precip_ice_flux,cld_frac_r,cld_frac_l,cld_frac_i,p3_tend_out,mu_c,lamc,liq_ice_exchange,&
          vap_liq_exchange,vap_ice_exchange,qv_prev,t_prev,col_location,elapsed_s)
   end subroutine p3_main_c
@@ -913,7 +915,7 @@ subroutine  update_prognostic_ice_c(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
       inv_exner, cld_frac_l, cld_frac_r, cld_frac_i, &
       rho, inv_rho, rhofaci, qv, th_atm, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, &
       mu_c, nu, lamc, mu_r, lamr, vap_liq_exchange, &
-      ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc) bind(C)
+      ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc, diag_eff_radius_qr) bind(C)
 
    use micro_p3, only: p3_main_part3
 
@@ -925,13 +927,14 @@ subroutine  update_prognostic_ice_c(qc2qi_hetero_freeze_tend,qc2qi_collect_tend,
         qv, th_atm, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, &
         mu_c, nu, lamc, mu_r, &
         lamr, vap_liq_exchange, &
-        ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc
+        ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, &
+        diag_equiv_reflectivity, diag_eff_radius_qc, diag_eff_radius_qr
 
    call p3_main_part3(kts, kte, kbot, ktop, kdir, &
         inv_exner, cld_frac_l, cld_frac_r, cld_frac_i, &
         rho, inv_rho, rhofaci, qv, th_atm, qc, nc, qr, nr, qi, ni, qm, bm, latent_heat_vapor, latent_heat_sublim, &
         mu_c, nu, lamc, mu_r, lamr, vap_liq_exchange, &
-        ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc)
+        ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi, rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc, diag_eff_radius_qr)
 
  end subroutine p3_main_part3_c
 

--- a/components/eamxx/src/physics/p3/p3_main_wrap.cpp
+++ b/components/eamxx/src/physics/p3/p3_main_wrap.cpp
@@ -14,7 +14,7 @@ extern "C" {
                  Real* ni, Real* bm, Real* pres,
                  Real* dz, Real* nc_nuceat_tend, Real* nccn_prescribed, Real* ni_activated, Real* inv_qc_relvar,
                  Int it, Real* precip_liq_surf, Real* precip_ice_surf, Int its,
-                 Int ite, Int kts, Int kte, Real* diag_eff_radius_qc, Real* diag_eff_radius_qi,
+                 Int ite, Int kts, Int kte, Real* diag_eff_radius_qc, Real* diag_eff_radius_qi, Real* diag_eff_radius_qr,
                  Real* rho_qi, bool do_predict_nc, bool do_prescribed_CCN, Real* dpres, Real* inv_exner,
                  Real* qv2qi_depos_tend,
                  Real* precip_liq_flux, Real* precip_ice_flux, // 1 extra column size
@@ -35,7 +35,7 @@ Int p3_main_wrap(const FortranData& d, bool use_fortran) {
               d.qm.data(), d.ni.data(), d.bm.data(),
               d.pres.data(), d.dz.data(), d.nc_nuceat_tend.data(), d.nccn_prescribed.data(), d.ni_activated.data(), d.inv_qc_relvar.data(),
               d.it, d.precip_liq_surf.data(), d.precip_ice_surf.data(), 1, d.ncol, 1, d.nlev,
-              d.diag_eff_radius_qc.data(), d.diag_eff_radius_qi.data(), d.rho_qi.data(),
+              d.diag_eff_radius_qc.data(), d.diag_eff_radius_qi.data(), d.diag_eff_radius_qr.data(), d.rho_qi.data(),
               d.do_predict_nc, d.do_prescribed_CCN, d.dpres.data(), d.inv_exner.data(), d.qv2qi_depos_tend.data(),
               d.precip_liq_flux.data(), d.precip_ice_flux.data(), d.cld_frac_r.data(), d.cld_frac_l.data(), d.cld_frac_i.data(),
               d.liq_ice_exchange.data(), d.vap_liq_exchange.data(),d.vap_ice_exchange.data(),d.qv_prev.data(),d.t_prev.data(), &elapsed_s);
@@ -47,7 +47,7 @@ Int p3_main_wrap(const FortranData& d, bool use_fortran) {
                      d.bm.data(), d.pres.data(), d.dz.data(), d.nc_nuceat_tend.data(), d.nccn_prescribed.data(),
                      d.ni_activated.data(), d.inv_qc_relvar.data(), d.it, d.precip_liq_surf.data(),
                      d.precip_ice_surf.data(), 1, d.ncol, 1, d.nlev, d.diag_eff_radius_qc.data(),
-                     d.diag_eff_radius_qi.data(), d.rho_qi.data(), d.do_predict_nc, d.do_prescribed_CCN,
+                     d.diag_eff_radius_qi.data(), d.diag_eff_radius_qr.data(), d.rho_qi.data(), d.do_predict_nc, d.do_prescribed_CCN,
                      d.dpres.data(), d.inv_exner.data(), d.qv2qi_depos_tend.data(),
                      d.precip_liq_flux.data(), d.precip_ice_flux.data(),
                      d.cld_frac_r.data(), d.cld_frac_l.data(), d.cld_frac_i.data(),

--- a/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -296,7 +296,7 @@ static void run_bfb_p3_main_part3()
       d.inv_exner, d.cld_frac_l, d.cld_frac_r, d.cld_frac_i,
       d.rho, d.inv_rho, d.rhofaci, d.qv, d.th_atm, d.qc, d.nc, d.qr, d.nr, d.qi, d.ni, d.qm, d.bm, d.latent_heat_vapor, d.latent_heat_sublim,
       d.mu_c, d.nu, d.lamc, d.mu_r, d.lamr, d.vap_liq_exchange,
-      d. ze_rain, d.ze_ice, d.diag_vm_qi, d.diag_eff_radius_qi, d.diag_diam_qi, d.rho_qi, d.diag_equiv_reflectivity, d.diag_eff_radius_qc);
+      d. ze_rain, d.ze_ice, d.diag_vm_qi, d.diag_eff_radius_qi, d.diag_diam_qi, d.rho_qi, d.diag_equiv_reflectivity, d.diag_eff_radius_qc, d.diag_eff_radius_qr);
   }
 
   if (SCREAM_BFB_TESTING) {
@@ -333,6 +333,7 @@ static void run_bfb_p3_main_part3()
         REQUIRE(isds_fortran[i].rho_qi[k]                  == isds_cxx[i].rho_qi[k]);
         REQUIRE(isds_fortran[i].diag_equiv_reflectivity[k] == isds_cxx[i].diag_equiv_reflectivity[k]);
         REQUIRE(isds_fortran[i].diag_eff_radius_qc[k]         == isds_cxx[i].diag_eff_radius_qc[k]);
+        REQUIRE(isds_fortran[i].diag_eff_radius_qr[k]         == isds_cxx[i].diag_eff_radius_qr[k]);
       }
     }
   }
@@ -396,7 +397,7 @@ static void run_bfb_p3_main()
     p3_main_f(
       d.qc, d.nc, d.qr, d.nr, d.th_atm, d.qv, d.dt, d.qi, d.qm, d.ni,
       d.bm, d.pres, d.dz, d.nc_nuceat_tend, d.nccn_prescribed, d.ni_activated, d.inv_qc_relvar, d.it, d.precip_liq_surf,
-      d.precip_ice_surf, d.its, d.ite, d.kts, d.kte, d.diag_eff_radius_qc, d.diag_eff_radius_qi,
+      d.precip_ice_surf, d.its, d.ite, d.kts, d.kte, d.diag_eff_radius_qc, d.diag_eff_radius_qi, d.diag_eff_radius_qr,
       d.rho_qi, d.do_predict_nc, d.do_prescribed_CCN, d.dpres, d.inv_exner, d.qv2qi_depos_tend,
       d.precip_liq_flux, d.precip_ice_flux, d.cld_frac_r, d.cld_frac_l, d.cld_frac_i, 
       d.liq_ice_exchange, d.vap_liq_exchange, d.vap_ice_exchange, d.qv_prev, d.t_prev);
@@ -421,6 +422,7 @@ static void run_bfb_p3_main()
         REQUIRE(df90.th_atm[t]            == dcxx.th_atm[t]);
         REQUIRE(df90.diag_eff_radius_qc[t]         == dcxx.diag_eff_radius_qc[t]);
         REQUIRE(df90.diag_eff_radius_qi[t]         == dcxx.diag_eff_radius_qi[t]);
+        REQUIRE(df90.diag_eff_radius_qr[t]         == dcxx.diag_eff_radius_qr[t]);
         REQUIRE(df90.rho_qi[t]            == dcxx.rho_qi[t]);
         REQUIRE(df90.mu_c[t]              == dcxx.mu_c[t]);
         REQUIRE(df90.lamc[t]              == dcxx.lamc[t]);

--- a/components/eamxx/src/physics/p3/tests/p3_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_tests.cpp
@@ -14,7 +14,7 @@ TEST_CASE("FortranDataIterator", "p3") {
   using scream::p3::ic::Factory;
   const auto d = Factory::create(Factory::mixed);
   scream::p3::FortranDataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 34);
+  REQUIRE(fdi.nfield() == 35);
   const auto& f = fdi.getfield(0);
   REQUIRE(f.dim == 2);
   REQUIRE(f.extent[0] == 1);

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -43,6 +43,7 @@ Fields:
       - micro_vap_liq_exchange
       - precip_ice_surf_mass
       - precip_liq_surf_mass
+      - rainfrac
       # SHOC + HOMME
       - horiz_winds
       # SHOC + P3

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/homme_shoc_cld_p3_rrtmgp_output.yaml
@@ -37,6 +37,7 @@ Fields:
       - qv_prev_micro_step
       - eff_radius_qc
       - eff_radius_qi
+      - eff_radius_qr
       - micro_liq_ice_exchange
       - micro_vap_ice_exchange
       - micro_vap_liq_exchange

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -43,6 +43,7 @@ Fields:
       - qv_prev_micro_step
       - eff_radius_qc
       - eff_radius_qi
+      - eff_radius_qr
       - micro_liq_ice_exchange
       - micro_vap_ice_exchange
       - micro_vap_liq_exchange

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/homme_shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -49,6 +49,7 @@ Fields:
       - micro_vap_liq_exchange
       - precip_ice_surf_mass
       - precip_liq_surf_mass
+      - rainfrac
       # SHOC + HOMME
       - horiz_winds
       # SHOC + P3

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
@@ -39,6 +39,7 @@ Fields:
       - qv_prev_micro_step
       - eff_radius_qc
       - eff_radius_qi
+      - eff_radius_qr
       - micro_liq_ice_exchange
       - micro_vap_ice_exchange
       - micro_vap_liq_exchange

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/homme_shoc_cld_spa_p3_rrtmgp_128levels_output.yaml
@@ -45,6 +45,7 @@ Fields:
       - micro_vap_liq_exchange
       - precip_ice_surf_mass
       - precip_liq_surf_mass
+      - rainfrac
       # SHOC + HOMME
       - horiz_winds
       # SHOC + P3

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/homme_shoc_cld_spa_p3_rrtmgp_pg2_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/homme_shoc_cld_spa_p3_rrtmgp_pg2_output.yaml
@@ -43,6 +43,7 @@ Fields:
       - qv_prev_micro_step
       - eff_radius_qc
       - eff_radius_qi
+      - eff_radius_qr
       - micro_liq_ice_exchange
       - micro_vap_ice_exchange
       - micro_vap_liq_exchange

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/homme_shoc_cld_spa_p3_rrtmgp_pg2_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/homme_shoc_cld_spa_p3_rrtmgp_pg2_output.yaml
@@ -49,6 +49,7 @@ Fields:
       - micro_vap_liq_exchange
       - precip_ice_surf_mass
       - precip_liq_surf_mass
+      - rainfrac
       # SHOC + HOMME
       - horiz_winds
       # SHOC + P3

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_output.yaml
@@ -36,6 +36,7 @@ Fields:
       - qv_prev_micro_step
       - eff_radius_qc
       - eff_radius_qi
+      - eff_radius_qr
       - micro_liq_ice_exchange
       - micro_vap_ice_exchange
       - micro_vap_liq_exchange

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_output.yaml
@@ -43,6 +43,7 @@ Fields:
       - precip_ice_surf_mass
       - precip_liq_surf_mass
       - precip_liq_surf_mass_flux
+      - rainfrac
       # SHOC + HOMME
       - horiz_winds
       # SHOC + P3

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
@@ -36,6 +36,7 @@ Fields:
       - qv_prev_micro_step
       - eff_radius_qc
       - eff_radius_qi
+      - eff_radius_qr
       - micro_liq_ice_exchange
       - micro_vap_ice_exchange
       - micro_vap_liq_exchange

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/model_restart_output.yaml
@@ -43,6 +43,7 @@ Fields:
       - precip_ice_surf_mass
       - precip_liq_surf_mass
       - precip_liq_surf_mass_flux
+      - rainfrac
       # SHOC + HOMME
       - horiz_winds
       # SHOC + P3

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
@@ -16,6 +16,7 @@ Field Names:
   - bm
   - eff_radius_qc
   - eff_radius_qi
+  - eff_radius_qr
   - micro_liq_ice_exchange
   - micro_vap_liq_exchange
   - micro_vap_ice_exchange

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
@@ -20,6 +20,7 @@ Field Names:
   - micro_liq_ice_exchange
   - micro_vap_liq_exchange
   - micro_vap_ice_exchange
+  - rainfrac
   - tke
   - eddy_diff_mom
   - sgs_buoy_flux

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
@@ -32,6 +32,7 @@ Field Names:
   - micro_vap_liq_exchange
   - precip_ice_surf_mass
   - precip_liq_surf_mass
+  - rainfrac
   # SHOC + P3
   - qc
   - qv

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/shoc_cld_p3_rrtmgp_output.yaml
@@ -26,6 +26,7 @@ Field Names:
   - qv_prev_micro_step
   - eff_radius_qc
   - eff_radius_qi
+  - eff_radius_qr
   - micro_liq_ice_exchange
   - micro_vap_ice_exchange
   - micro_vap_liq_exchange

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -27,6 +27,7 @@ Field Names:
   - qv_prev_micro_step
   - eff_radius_qc
   - eff_radius_qi
+  - eff_radius_qr
   - micro_liq_ice_exchange
   - micro_vap_ice_exchange
   - micro_vap_liq_exchange

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/shoc_cld_spa_p3_rrtmgp_output.yaml
@@ -33,6 +33,7 @@ Field Names:
   - micro_vap_liq_exchange
   - precip_ice_surf_mass
   - precip_liq_surf_mass
+  - rainfrac
   # SHOC + P3
   - qc
   - qv

--- a/components/eamxx/tests/uncoupled/p3/p3_standalone_output.yaml
+++ b/components/eamxx/tests/uncoupled/p3/p3_standalone_output.yaml
@@ -24,6 +24,7 @@ Field Names:
   - micro_liq_ice_exchange
   - micro_vap_liq_exchange
   - micro_vap_ice_exchange
+  - rainfrac
   - p3_T_mid_tend
   - p3_qc_tend
 output_control:

--- a/components/eamxx/tests/uncoupled/p3/p3_standalone_output.yaml
+++ b/components/eamxx/tests/uncoupled/p3/p3_standalone_output.yaml
@@ -18,6 +18,7 @@ Field Names:
   - qv_prev_micro_step
   - eff_radius_qc
   - eff_radius_qi
+  - eff_radius_qr
   - precip_liq_surf_mass
   - precip_ice_surf_mass
   - micro_liq_ice_exchange


### PR DESCRIPTION
This commit adds the effective radius of rain drops (`eff_radius_qr`)
and rain precipitation fraction (`rainfrac`) outputs, as calculated by
P3. Both are also added to the list of default outputs.

These outputs are not communicated to COSP or any other
parameterization that might hypothetically use these fields.
It only makes them available in the field manager.

This solves the rain part of #2471.

BFB, except for the new outputs themselves.