### PR TITLE
Improve ML correction performance

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -216,8 +216,8 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <!-- ML correction -->
     <mlcorrection inherit="atm_proc_base">
-      <ML_model_path type="string">NONE</ML_model_path>
-      <ML_output_fields type="array(string)">NONE</ML_output_fields>
+      <ML_model_path type="string" doc="Path to pre-trained ML model"/>
+      <ML_output_fields type="array(string)" doc="ML correction output variables, the following variables are supported: T_mid,qv,u,v"/>
     </mlcorrection>
 
     <!-- For internal testing only -->

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -1,9 +1,3 @@
-#define PYBIND11_DETAILED_ERROR_MESSAGES
-#include <pybind11/embed.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <array>
-
 #include "eamxx_ml_correction_process_interface.hpp"
 #include "ekat/ekat_assert.hpp"
 #include "ekat/util/ekat_units.hpp"
@@ -58,12 +52,17 @@ void MLCorrection::set_grids(
 }
 
 void MLCorrection::initialize_impl(const RunType /* run_type */) {
-  // Do nothing
+  if ( Py_IsInitialized() == 0 ) {
+    pybind11::initialize_interpreter();
+  }  
+  pybind11::module sys = pybind11::module::import("sys");
+  sys.attr("path").attr("insert")(1, ML_CORRECTION_CUSTOM_PATH);
+  py_correction = pybind11::module::import("ml_correction");
+  ML_model = py_correction.attr("get_ML_model")(m_ML_model_path);
 }
 
 // =========================================================================================
 void MLCorrection::run_impl(const double dt) {
-  namespace py      = pybind11;
   // use model time to infer solar zenith angle for the ML prediction
   auto current_ts = timestamp();
   std::string datetime_str = current_ts.get_date_string() + " " + current_ts.get_time_string();
@@ -91,28 +90,24 @@ void MLCorrection::run_impl(const double dt) {
   ekat::disable_all_fpes();  // required for importing numpy
   start_timer("EAMxx::ml_correction::python");
   if ( Py_IsInitialized() == 0 ) {
-    py::initialize_interpreter();
+    pybind11::initialize_interpreter();
   }
-  py::module sys = pybind11::module::import("sys");
-  sys.attr("path").attr("insert")(1, ML_CORRECTION_CUSTOM_PATH);
-  auto py_correction = py::module::import("ml_correction");
-
   // for qv, we need to stride across number of tracers
-  py::object ob1     = py_correction.attr("update_fields")(
-      py::array_t<Real, py::array::c_style | py::array::forcecast>(
-          m_num_cols * m_num_levs, T_mid.data(), py::str{}),
-      py::array_t<Real, py::array::c_style | py::array::forcecast>(
-          m_num_cols * m_num_levs * num_tracers, qv.data(), py::str{}),          
-      py::array_t<Real, py::array::c_style | py::array::forcecast>(
-          m_num_cols * m_num_levs, u.data(), py::str{}),        
-      py::array_t<Real, py::array::c_style | py::array::forcecast>(
-          m_num_cols * m_num_levs, v.data(), py::str{}),       
-      py::array_t<Real, py::array::c_style | py::array::forcecast>(
-          m_num_cols, h_lat.data(), py::str{}),       
-      py::array_t<Real, py::array::c_style | py::array::forcecast>(
-          m_num_cols, h_lon.data(), py::str{}),                                                
-      m_num_cols, m_num_levs, num_tracers, dt, m_ML_model_path, datetime_str);
-  py::gil_scoped_release no_gil;  
+  pybind11::object ob1     = py_correction.attr("update_fields")(
+      pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
+          m_num_cols * m_num_levs, T_mid.data(), pybind11::str{}),
+      pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
+          m_num_cols * m_num_levs * num_tracers, qv.data(), pybind11::str{}),          
+      pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
+          m_num_cols * m_num_levs, u.data(), pybind11::str{}),        
+      pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
+          m_num_cols * m_num_levs, v.data(), pybind11::str{}),       
+      pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
+          m_num_cols, h_lat.data(), pybind11::str{}),       
+      pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
+          m_num_cols, h_lon.data(), pybind11::str{}),                                                
+      m_num_cols, m_num_levs, num_tracers, dt, ML_model, datetime_str);
+  pybind11::gil_scoped_release no_gil;  
   stop_timer("EAMxx::ml_correction::python");
   ekat::enable_fpes(fpe_mask);
   Real qv_max_after = field_max<Real>(qv_field);

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -8,6 +8,7 @@
 #include "ekat/ekat_assert.hpp"
 #include "ekat/util/ekat_units.hpp"
 #include "share/field/field_utils.hpp"
+#include "share/util/scream_timing.hpp"
 
 namespace scream {
 // =========================================================================================
@@ -88,6 +89,7 @@ void MLCorrection::run_impl(const double dt) {
   Real qv_min_before = field_min<Real>(qv_field);
   int fpe_mask = ekat::get_enabled_fpes();
   ekat::disable_all_fpes();  // required for importing numpy
+  start_timer("EAMxx::ml_correction::python");
   if ( Py_IsInitialized() == 0 ) {
     py::initialize_interpreter();
   }
@@ -111,6 +113,7 @@ void MLCorrection::run_impl(const double dt) {
           m_num_cols, h_lon.data(), py::str{}),                                                
       m_num_cols, m_num_levs, num_tracers, dt, m_ML_model_path, datetime_str);
   py::gil_scoped_release no_gil;  
+  stop_timer("EAMxx::ml_correction::python");
   ekat::enable_fpes(fpe_mask);
   Real qv_max_after = field_max<Real>(qv_field);
   Real qv_min_after = field_min<Real>(qv_field);        

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -2,7 +2,6 @@
 #include "ekat/ekat_assert.hpp"
 #include "ekat/util/ekat_units.hpp"
 #include "share/field/field_utils.hpp"
-#include "share/util/scream_timing.hpp"
 
 namespace scream {
 // =========================================================================================
@@ -88,7 +87,6 @@ void MLCorrection::run_impl(const double dt) {
   Real qv_min_before = field_min<Real>(qv_field);
   int fpe_mask = ekat::get_enabled_fpes();
   ekat::disable_all_fpes();  // required for importing numpy
-  start_timer("EAMxx::ml_correction::python");
   if ( Py_IsInitialized() == 0 ) {
     pybind11::initialize_interpreter();
   }
@@ -108,7 +106,6 @@ void MLCorrection::run_impl(const double dt) {
           m_num_cols, h_lon.data(), pybind11::str{}),                                                
       m_num_cols, m_num_levs, num_tracers, dt, ML_model, datetime_str);
   pybind11::gil_scoped_release no_gil;  
-  stop_timer("EAMxx::ml_correction::python");
   ekat::enable_fpes(fpe_mask);
   Real qv_max_after = field_max<Real>(qv_field);
   Real qv_min_after = field_min<Real>(qv_field);        

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.hpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.hpp
@@ -1,6 +1,11 @@
 #ifndef SCREAM_ML_CORRECTION_HPP
 #define SCREAM_ML_CORRECTION_HPP
 
+#define PYBIND11_DETAILED_ERROR_MESSAGES
+#include <pybind11/embed.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <array>
 #include <string>
 #include "share/atm_process/atmosphere_process.hpp"
 #include "ekat/ekat_parameter_list.hpp"
@@ -53,6 +58,8 @@ class MLCorrection : public AtmosphereProcess {
   Field m_lon;
   std::string m_ML_model_path;
   std::vector<std::string> m_fields_ml_output_variables;
+  pybind11::module py_correction;
+  pybind11::object ML_model;
 };  // class MLCorrection
 
 }  // namespace scream

--- a/components/eamxx/src/physics/ml_correction/ml_correction.py
+++ b/components/eamxx/src/physics/ml_correction/ml_correction.py
@@ -8,10 +8,12 @@ from scream_run.steppers.machine_learning import (
     predict,
 )
 
-
-def get_ML_correction(model_path, T_mid, qv, cos_zenith, dt):
+def get_ML_model(model_path):
     config = MachineLearningConfig(models=[model_path])
     model = open_model(config)
+    return model    
+
+def get_ML_correction(model, T_mid, qv, cos_zenith, dt):
     ds = xr.Dataset(
         data_vars=dict(
             T_mid=(["ncol", "z"], T_mid),
@@ -33,7 +35,7 @@ def update_fields(
     Nlev,
     num_tracers,
     dt,
-    model_path,
+    model,
     current_time,
 ):
     T_mid = np.reshape(T_mid, (-1, Nlev))
@@ -46,6 +48,6 @@ def update_fields(
         lon,
         lat,
     )
-    correction = get_ML_correction(model_path, T_mid, qv[:, 0, :], cos_zenith, dt)
+    correction = get_ML_correction(model, T_mid, qv[:, 0, :], cos_zenith, dt)
     T_mid[:, :] += correction["dQ1"].values * dt
     qv[:, 0, :] += correction["dQ2"].values * dt


### PR DESCRIPTION
In this PR, we moved reading the ML model and importing python modules to initialization. This move resulted in significant speedup for MLCorrection's runtime, now taking up around 3% of the total `EAMxx::run` time. A constant overhead with loading and importing in python is now pushed to initialization, and `EAMxx::MLCorrection::init` is about a third of `EAMxx::init`.