### PR TITLE
Fix TMS race condition and remove packs form TMSFunctions

### DIFF
--- a/components/eamxx/src/physics/share/CMakeLists.txt
+++ b/components/eamxx/src/physics/share/CMakeLists.txt
@@ -21,6 +21,7 @@ set_target_properties(physics_share PROPERTIES
   Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules
 )
 target_include_directories(physics_share PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}/modules
 )
 target_link_libraries(physics_share scream_share)

--- a/components/eamxx/src/physics/tms/CMakeLists.txt
+++ b/components/eamxx/src/physics/tms/CMakeLists.txt
@@ -1,43 +1,30 @@
-set(TMS_SRCS
-  tms_iso_c.f90
-  ${SCREAM_BASE_DIR}/../eam/src/physics/cam/trb_mtn_stress.F90
-  eamxx_tms_process_interface.cpp
-)
-
-if (NOT SCREAM_LIB_ONLY)
-  list(APPEND TMS_SRCS
-    tms_functions_f90.cpp
-    )
-endif()
-
-set(TMS_HEADERS
-  eamxx_tms_process_interface.hpp
+# Create tms library
+add_library(tms eamxx_tms_process_interface.cpp)
+target_link_libraries(tms physics_share scream_share)
+target_compile_definitions(tms PUBLIC EAMXX_HAS_TMS)
+target_include_directories(tms PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/impl
 )
 
 # Add ETI source files if not on CUDA/HIP
 if (NOT EAMXX_ENABLE_GPU)
-  list(APPEND TMS_SRCS
-    eti/compute_tms.cpp
-  ) # TMS ETI SRCS
+  target_sources(tms PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/eti/compute_tms.cpp
+  )
 endif()
 
-set(TMS_LIBS "tms")
-add_library(tms ${TMS_SRCS})
-target_compile_definitions(tms PUBLIC EAMXX_HAS_TMS)
-
-foreach (TMS_LIB IN LISTS TMS_LIBS)
-  set_target_properties(${TMS_LIB} PROPERTIES
-    Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TMS_LIB}_modules
-  )
-  target_include_directories(${TMS_LIB} PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/../share
-    ${CMAKE_CURRENT_BINARY_DIR}/${TMS_LIB}_modules
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/impl
-  )
-  target_link_libraries(${TMS_LIB} physics_share scream_share)
-endforeach()
-
 if (NOT SCREAM_LIB_ONLY)
+  # For testing, add some more sources and modules directory
+  target_sources (tms PUBLIC
+    ${SCREAM_BASE_DIR}/../eam/src/physics/cam/trb_mtn_stress.F90
+    ${CMAKE_CURRENT_SOURCE_DIR}/tms_iso_c.f90
+    ${CMAKE_CURRENT_SOURCE_DIR}/tms_functions_f90.cpp
+  )
+  set_target_properties(tms PROPERTIES
+    Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tms_modules
+  )
+  target_include_directories (tms PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/tms_modules)
+
   add_subdirectory(tests)
 endif()

--- a/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
+++ b/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
@@ -115,8 +115,13 @@ void TurbulentMountainStress::run_impl (const double /* dt */)
   });
 
   // Compute TMS
-  TMSFunctions::compute_tms(ncols, nlevs, horiz_winds, T_mid, p_mid,
-                            exner, z_mid, sgh30, landfrac,
+  TMSFunctions::compute_tms(ncols, nlevs,
+                            ekat::scalarize(horiz_winds),
+                            ekat::scalarize(T_mid),
+                            ekat::scalarize(p_mid),
+                            ekat::scalarize(exner),
+                            ekat::scalarize(z_mid),
+                            sgh30, landfrac,
                             surf_drag_coeff_tms, wind_stress_tms);
 }
 

--- a/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
+++ b/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
@@ -108,6 +108,7 @@ void TurbulentMountainStress::run_impl (const double /* dt */)
     // Calculate z_mid
     PF::calculate_dz(team, pseudo_density_i, p_mid_i, T_mid_i, qv_i, dz_i);
     const Real z_surf = 0.0; // For now, set z_int(i,nlevs) = z_surf = 0
+    team.team_barrier();
     PF::calculate_z_int(team, nlevs, dz_i, z_surf, z_int_i);
     team.team_barrier();
     PF::calculate_z_mid(team, nlevs, z_int_i, z_mid_i);

--- a/components/eamxx/src/physics/tms/eamxx_tms_process_interface.hpp
+++ b/components/eamxx/src/physics/tms/eamxx_tms_process_interface.hpp
@@ -23,7 +23,7 @@ class TurbulentMountainStress : public AtmosphereProcess
 {
   using PF           = scream::PhysicsFunctions<DefaultDevice>;
   using TMSFunctions = tms::Functions<Real, DefaultDevice>;
-  using Spack        = TMSFunctions::Spack;
+  using Spack        = ekat::Pack<Real,SCREAM_PACK_SIZE>;
   using view_2d      = TMSFunctions::view_2d<Spack>;
   using uview_2d     = ekat::Unmanaged<view_2d>;
 

--- a/components/eamxx/src/physics/tms/tests/tms_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/tms/tests/tms_unit_tests_common.hpp
@@ -42,14 +42,7 @@ struct UnitWrap {
 
     using Functions          = scream::tms::Functions<Real, Device>;
     using Scalar             = typename Functions::Scalar;
-    using Spack              = typename Functions::Spack;
-    using Pack               = typename Functions::Pack;
-    using IntSmallPack       = typename Functions::IntSmallPack;
-    using Smask              = typename Functions::Smask;
-    using C                  = typename Functions::C;
-
-    static constexpr int max_pack_size = 16;
-    static constexpr int num_test_itrs = max_pack_size / Spack::n;
+    using Spack              = ekat::Pack<Scalar,SCREAM_PACK_SIZE>;
 
     // Put struct decls here
     struct TestComputeTMS;

--- a/components/eamxx/src/physics/tms/tms_functions.hpp
+++ b/components/eamxx/src/physics/tms/tms_functions.hpp
@@ -28,21 +28,7 @@ struct Functions
   using Scalar = ScalarT;
   using Device = DeviceT;
 
-  template <typename S>
-  using BigPack = ekat::Pack<S,SCREAM_PACK_SIZE>;
-  template <typename S>
-  using SmallPack = ekat::Pack<S,SCREAM_SMALL_PACK_SIZE>;
-
-  using IntSmallPack = SmallPack<Int>;
-  using Pack = BigPack<Scalar>;
-  using Spack = SmallPack<Scalar>;
-
-  using Mask  = ekat::Mask<Pack::n>;
-  using Smask = ekat::Mask<Spack::n>;
-
   using KT = ekat::KokkosTypes<Device>;
-
-  using C  = physics::Constants<Scalar>;
 
   template <typename S>
   using view_1d = typename KT::template view_1d<S>;
@@ -51,20 +37,17 @@ struct Functions
   template <typename S>
   using view_3d = typename KT::template view_3d<S>;
 
-  using MemberType = typename KT::MemberType;
-
-
   //
   // --------- Functions ---------
   //
   static void compute_tms(
     const int&                   ncols,
     const int&                   nlevs,
-    const view_3d<const Spack>&  horiz_wind,
-    const view_2d<const Spack>&  t_mid,
-    const view_2d<const Spack>&  p_mid,
-    const view_2d<const Spack>&  exner,
-    const view_2d<const Spack>&  z_mid,
+    const view_3d<const Scalar>& horiz_wind,
+    const view_2d<const Scalar>& t_mid,
+    const view_2d<const Scalar>& p_mid,
+    const view_2d<const Scalar>& exner,
+    const view_2d<const Scalar>& z_mid,
     const view_1d<const Scalar>& sgh,
     const view_1d<const Scalar>& landfrac,
     const view_1d<Scalar>&       ksrf,

--- a/components/eamxx/src/physics/tms/tms_functions_f90.cpp
+++ b/components/eamxx/src/physics/tms/tms_functions_f90.cpp
@@ -44,13 +44,13 @@ void compute_tms_f(int ncols, int nlevs,
   using TMSFunc  = Functions<Real, DefaultDevice>;
 
   using Scalar     = typename TMSFunc::Scalar;
-  using Spack      = typename TMSFunc::Spack;
+  using Spack      = ekat::Pack<Scalar,SCREAM_PACK_SIZE>;
   using view_1d    = typename TMSFunc::view_1d<Scalar>;
   using view_2d    = typename TMSFunc::view_2d<Spack>;
   using view_2d_s  = typename TMSFunc::view_2d<Scalar>;
   using view_3d    = typename TMSFunc::view_3d<Spack>;
   using ExeSpace   = typename TMSFunc::KT::ExeSpace;
-  using MemberType = typename TMSFunc::MemberType;
+  using MemberType = typename TMSFunc::KT::MemberType;
 
   // Initialize Kokkos views, sync to device
   std::vector<view_1d> temp_d_1d(2);
@@ -90,7 +90,12 @@ void compute_tms_f(int ncols, int nlevs,
   });
 
   // C++ compute_tms function implementation
-  TMSFunc::compute_tms(ncols, nlevs, horiz_wind_d, t_mid_d, p_mid_d, exner_d, z_mid_d,
+  TMSFunc::compute_tms(ncols, nlevs,
+                       ekat::scalarize(horiz_wind_d),
+                       ekat::scalarize(t_mid_d),
+                       ekat::scalarize(p_mid_d),
+                       ekat::scalarize(exner_d),
+                       ekat::scalarize(z_mid_d),
                        sgh_d, landfrac_d, ksrf_d, tau_d);
 
   // Transfer data back to individual arrays (only for output variables)


### PR DESCRIPTION
Jury is still out on whether this fixes #2534 , but I'm feeling confident it will. 

List of changes:

- add missing team barrier: there were two team-level pfor's with dependencies one after the other.
- remove use of Pack from TMSFunctions: the only fcn doesn't use packs at all, so no point in using them just to call `ekat::scalarize` inside (for every col, btw)
- change policy to a range policy: the team was not really used; in fact, all threads in the team were re-doing the same calculations, resulting in a (benign) race condition.