### PR TITLE
Update ML correction unit test

### DIFF
--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -51,13 +51,16 @@ void MLCorrection::set_grids(
 }
 
 void MLCorrection::initialize_impl(const RunType /* run_type */) {
+  fpe_mask = ekat::get_enabled_fpes();
+  ekat::disable_all_fpes();  // required for importing numpy  
   if ( Py_IsInitialized() == 0 ) {
     pybind11::initialize_interpreter();
-  }  
+  }
   pybind11::module sys = pybind11::module::import("sys");
   sys.attr("path").attr("insert")(1, ML_CORRECTION_CUSTOM_PATH);
   py_correction = pybind11::module::import("ml_correction");
   ML_model = py_correction.attr("get_ML_model")(m_ML_model_path);
+  ekat::enable_fpes(fpe_mask);
 }
 
 // =========================================================================================
@@ -85,7 +88,6 @@ void MLCorrection::run_impl(const double dt) {
   Int num_tracers = tracers_info->size();
   Real qv_max_before = field_max<Real>(qv_field);
   Real qv_min_before = field_min<Real>(qv_field);
-  int fpe_mask = ekat::get_enabled_fpes();
   ekat::disable_all_fpes();  // required for importing numpy
   if ( Py_IsInitialized() == 0 ) {
     pybind11::initialize_interpreter();

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.hpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.hpp
@@ -1,7 +1,6 @@
 #ifndef SCREAM_ML_CORRECTION_HPP
 #define SCREAM_ML_CORRECTION_HPP
 
-#define PYBIND11_DETAILED_ERROR_MESSAGES
 #include <pybind11/embed.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
@@ -60,6 +59,7 @@ class MLCorrection : public AtmosphereProcess {
   std::vector<std::string> m_fields_ml_output_variables;
   pybind11::module py_correction;
   pybind11::object ML_model;
+  int fpe_mask;
 };  // class MLCorrection
 
 }  // namespace scream

--- a/components/eamxx/src/physics/ml_correction/ml_correction.py
+++ b/components/eamxx/src/physics/ml_correction/ml_correction.py
@@ -9,6 +9,8 @@ from scream_run.steppers.machine_learning import (
 )
 
 def get_ML_model(model_path):
+    if model_path == "NONE":
+        return None
     config = MachineLearningConfig(models=[model_path])
     model = open_model(config)
     return model    

--- a/components/eamxx/tests/uncoupled/ml_correction/ml_correction_standalone.cpp
+++ b/components/eamxx/tests/uncoupled/ml_correction/ml_correction_standalone.cpp
@@ -62,7 +62,9 @@ TEST_CASE("ml_correction-stand-alone", "") {
   Real reference = 1e-4;
   int fpe_mask = ekat::get_enabled_fpes();
   ekat::disable_all_fpes();  // required for importing numpy
-  py::initialize_interpreter();
+  if ( Py_IsInitialized() == 0 ) {
+    py::initialize_interpreter();
+  }  
   py::module sys = pybind11::module::import("sys");
   sys.attr("path").attr("insert")(1, CUSTOM_SYS_PATH);
   auto py_correction = py::module::import("test_correction");


### PR DESCRIPTION
ML correction unit test needs to be updated because of the change in ML correction process. Previously we only had to disable fpe check in runtime, since we now import the python module during initialization, we also need to disable that at init. Additionally, we propagate a minor change in how python interpreter is initialized from ML correction process to the unit test to avoid duplicating the interpreters.