### PR TITLE
Allow locally-empty layouts in AtmosphereInput

### DIFF
--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -436,6 +436,11 @@ void AtmosphereInput::set_degrees_of_freedom()
 std::vector<scorpio::offset_t>
 AtmosphereInput::get_var_dof_offsets(const FieldLayout& layout)
 {
+  // It may be that this MPI ranks owns no chunk of the field
+  if (layout.size()==0) {
+    return {};
+  }
+
   std::vector<scorpio::offset_t> var_dof(layout.size());
 
   // Gather the offsets of the dofs of this variable w.r.t. the *global* array.

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -973,6 +973,11 @@ register_variables(const std::string& filename,
 std::vector<scorpio::offset_t>
 AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
 {
+  // It may be that this MPI rank owns no chunk of the field
+  if (layout.size()==0) {
+    return {};
+  }
+
   std::vector<scorpio::offset_t> var_dof(layout.size());
 
   // Gather the offsets of the dofs of this variable w.r.t. the *global* array.
@@ -994,9 +999,6 @@ AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
   auto dofs_h = m_io_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
   if (layout.has_tag(ShortFieldTagsNames::COL)) {
     const int num_cols = m_io_grid->get_num_local_dofs();
-    if (num_cols==0) {
-      return var_dof;
-    }
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
@@ -1021,9 +1023,6 @@ AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
     const int num_my_elems = layout2d.dim(0);
     const int ngp = layout2d.dim(1);
     const int num_cols = num_my_elems*ngp*ngp;
-    if (num_cols==0) {
-      return var_dof;
-    }
 
     // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
     //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -47,10 +47,11 @@ void time_advance (const FieldManager& fm,
 
 TEST_CASE("output_restart","io")
 {
-  // Note to AaronDonahue:  You are trying to figure out why you can't change the number of cols and levs for this test.  
-  // Something having to do with freeing up and then resetting the io_decompositions.
   ekat::Comm comm(MPI_COMM_WORLD);
-  int num_gcols = 2*comm.size();
+
+  // If running with 2+ ranks, this will check that restart works correctly
+  // even if some ranks own no dofs
+  int num_gcols = std::max(comm.size()-1,1);
   int num_levs = 3;
   int dt = 1;
 


### PR DESCRIPTION
This was already done for writing, but the lack of fix in the read part caused restart crashes.

Note: this bug only shows up when one requests output coarsened to the point where there are less columns than ranks in the coarsened output.