### PR TITLE
Ensure IO decomp tags do not clash

### DIFF
--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -28,6 +28,11 @@ AbstractGrid (const std::string& name,
 
   // This grid name is also an alias
   m_aliases.push_back(m_name);
+
+  // Ensure each grid object gets a different id
+  static int counter = 0;
+  m_unique_grid_id = counter;
+  ++counter;
 }
 
 AbstractGrid::

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -161,6 +161,8 @@ public:
   // NOTE: we'd need setter/getter for this, so we might as well make it public
   std::string m_short_name = "";
 
+  int get_unique_grid_id () const { return m_unique_grid_id; }
+
 protected:
 
   void copy_data (const AbstractGrid& src, const bool shallow = true);
@@ -174,6 +176,8 @@ private:
   // The grid name and type
   GridType     m_type;
   std::string  m_name;
+
+  int m_unique_grid_id;
 
   std::vector<std::string> m_aliases;
 

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -55,8 +55,10 @@ CoarseningRemapper (const grid_ptr_type& src_grid,
   for (int i=0; i<nlweights; ++i) {
     dofs_offsets[i] = dofs_gids_h[i];
   }
-  const std::string idx_decomp_tag = "coarsening_remapper::constructor_int_nnz" + std::to_string(nlweights);
-  const std::string val_decomp_tag = "coarsening_remapper::constructor_real_nnz" + std::to_string(nlweights);
+
+  const auto grid_idx = std::to_string(io_grid->get_unique_grid_id());
+  const std::string idx_decomp_tag = "CR::ctor,dt=int,grid-idx=" + grid_idx;
+  const std::string val_decomp_tag = "CR::ctor,dt=real,grid-idx=" + grid_idx;
 
   scorpio::register_file(map_file,scorpio::FileMode::Read);
   scorpio::register_variable(map_file, "row", "row", {"n_s"}, "int", idx_decomp_tag);
@@ -929,10 +931,14 @@ get_my_triplets_gids (const std::string& map_file,
   m_comm.scan(&offset,1,MPI_SUM);
   offset -= nlweights; // scan is inclusive, but we need exclusive
 
+  // Create a unique decomp tag, which ensures all coarsening remappers have
+  // their own decomposition
+  const std::string idx_decomp_tag = "CR::gmtg,grid-idx=" + std::to_string(io_grid_linear->get_unique_grid_id());
+
   // 2. Read a chunk of triplets col indices
   std::vector<gid_t> cols(nlweights);
   std::vector<gid_t> rows(nlweights); // Needed to calculate min_dof
-  const std::string idx_decomp_tag = "coarsening_remapper::get_my_triplet_gids_int_dim" + std::to_string(nlweights);
+
   scorpio::register_variable(map_file, "col", "col", {"n_s"}, "int", idx_decomp_tag);
   scorpio::register_variable(map_file, "row", "row", {"n_s"}, "int", idx_decomp_tag);
   std::vector<scorpio::offset_t> dofs_offsets(nlweights);

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -145,7 +145,13 @@ create_tgt_layout (const FieldLayout& src_layout) const
 }
 
 void VerticalRemapper::
-set_pressure_levels(const std::string& map_file) {
+set_pressure_levels(const std::string& map_file)
+{
+  // Ensure each map file gets a different decomp name
+  static std::map<std::string,int> file2idx;
+  if (file2idx.find(map_file)==file2idx.end()) {
+    file2idx[map_file] = file2idx.size();
+  }
 
   using namespace ShortFieldTagsNames;
   std::vector<FieldTag> tags = {LEV};
@@ -160,8 +166,8 @@ set_pressure_levels(const std::string& map_file) {
 
   std::vector<scorpio::offset_t> dofs_offsets(m_num_remap_levs);
   std::iota(dofs_offsets.begin(),dofs_offsets.end(),0);
-  const std::string idx_decomp_tag = "vertical_remapper::" + std::to_string(m_num_remap_levs);
-  scorpio::register_variable(map_file, "p_levs", "p_levs", {"lev"}, "real", idx_decomp_tag);
+  const std::string decomp_tag = "VR::spl,nlev=" + std::to_string(m_num_remap_levs) + ",file-idx=" + std::to_string(file2idx[map_file]);
+  scorpio::register_variable(map_file, "p_levs", "p_levs", {"lev"}, "real", decomp_tag);
   scorpio::set_dof(map_file,"p_levs",m_num_remap_levs,dofs_offsets.data());
   scorpio::set_decomp(map_file);
   scorpio::grid_read_data_array(map_file,"p_levs",-1,remap_pres_scal.data(),remap_pres_scal.size());

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -404,21 +404,18 @@ AtmosphereInput::get_vec_of_dims(const FieldLayout& layout)
 std::string AtmosphereInput::
 get_io_decomp(const FieldLayout& layout)
 {
-  // Given a vector of dimensions names, create a unique decomp string to register with I/O
-  // Note: We are hard-coding for only REAL input here.
-  // TODO: would be to allow for other dtypes
-  std::string io_decomp_tag = (std::string("Real-") + m_io_grid->name() + "-" +
-                               std::to_string(m_io_grid->get_num_global_dofs()));
-  auto dims_names = get_vec_of_dims(layout);
-  for (size_t i=0; i<dims_names.size(); ++i) {
-    io_decomp_tag += "-" + dims_names[i];
-    // If tag==CMP, we already attached the length to the tag name
-    if (layout.tag(i)!=ShortFieldTagsNames::CMP) {
-      io_decomp_tag += "_" + std::to_string(layout.dim(i));
-    }
-  }
+  std::string decomp_tag = "dt=real,grid-idx=" + std::to_string(m_io_grid->get_unique_grid_id()) + ",layout=";
 
-  return io_decomp_tag;
+  std::vector<int> range(layout.rank());
+  std::iota(range.begin(),range.end(),0);
+  auto tag_and_dim = [&](int i) {
+    return m_io_grid->get_dim_name(layout.tag(i)) +
+           std::to_string(layout.dim(i));
+  };
+
+  decomp_tag += ekat::join (range, tag_and_dim,"-");
+
+  return decomp_tag;
 }
 
 /* ---------------------------------------------------------- */


### PR DESCRIPTION
In current master, it was possible for two IO decomposition to have the same name on some ranks but not all. That is because we built the decomp ids with rank-local information, without considering that two decomps may have the same extents on _some_ ranks, but not all.

For instance, one decomp on CoarseningRemapper had tag
```
const std::string idx_decomp_tag = "coarsening_remapper::constructor_int_nnz" + std::to_string(nlweights);
```
where `nlweights` was the _local_ number of non-zeros to read from the map file. However, two different map files can cause some ranks to get the same `nlweights` for both, while other ranks will have two different extents. As a consequence, the ranks that had a match would not participate to the creation of the new decomp, and simply recycle the existing one. However, ranks where `nlweights` is different between the two map files would create a new decomp. Since creating the decomp is a collective operation, this would cause a hang.

This PR introduces some unique id in the tag name. In particular, if the decomp is built from a grid object, we add a unique grid id to the tag name. If it's built from a map file (without a grid object), we associate a unique id to each map filename.

@ndkeen Once this PR passes all tests, it would be nice to test it for the cases that were hanging before.