### PR TITLE
Add special "io: string attributes" field extra data, which IO will write to file

### DIFF
--- a/components/eamxx/src/diagnostics/field_at_height.cpp
+++ b/components/eamxx/src/diagnostics/field_at_height.cpp
@@ -93,6 +93,19 @@ FieldAtHeight (const ekat::Comm& comm, const ekat::ParameterList& params)
   add_field<Required>(m_z_name, layout, ekat::units::m, gname);
 }
 
+void FieldAtHeight::initialize_impl (const RunType /*run_type*/)
+{
+  using stratts_t = std::map<std::string,std::string>;
+
+  // Propagate any io string attribute from input field to diag field
+  const auto& src = get_fields_in().front();
+  const auto& src_atts = src.get_header().get_extra_data<stratts_t>("io: string attributes");
+        auto& dst_atts = m_diagnostic_output.get_header().get_extra_data<stratts_t>("io: string attributes");
+  for (const auto& [name, val] : src_atts) {
+    dst_atts[name] = val;
+  }
+}
+
 // =========================================================================================
 void FieldAtHeight::compute_diagnostic_impl()
 {

--- a/components/eamxx/src/diagnostics/field_at_height.hpp
+++ b/components/eamxx/src/diagnostics/field_at_height.hpp
@@ -29,6 +29,7 @@ public:
 #endif
   void compute_diagnostic_impl ();
 protected:
+  void initialize_impl (const RunType /*run_type*/);
 
   std::string         m_z_name;
   std::string         m_field_name;

--- a/components/eamxx/src/diagnostics/field_at_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_level.cpp
@@ -63,6 +63,19 @@ FieldAtLevel::FieldAtLevel (const ekat::Comm& comm, const ekat::ParameterList& p
   }
 }
 
+void FieldAtLevel::initialize_impl (const RunType /*run_type*/)
+{
+  using stratts_t = std::map<std::string,std::string>;
+
+  // Propagate any io string attribute from input field to diag field
+  const auto& src = get_fields_in().front();
+  const auto& src_atts = src.get_header().get_extra_data<stratts_t>("io: string attributes");
+        auto& dst_atts = m_diagnostic_output.get_header().get_extra_data<stratts_t>("io: string attributes");
+  for (const auto& [name, val] : src_atts) {
+    dst_atts[name] = val;
+  }
+}
+
 // =========================================================================================
 void FieldAtLevel::compute_diagnostic_impl()
 {

--- a/components/eamxx/src/diagnostics/field_at_level.hpp
+++ b/components/eamxx/src/diagnostics/field_at_level.hpp
@@ -32,6 +32,7 @@ public:
 #endif
   void compute_diagnostic_impl ();
 protected:
+  void initialize_impl (const RunType /*run_type*/);
 
   Field         m_field;
   int           m_field_level;

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
@@ -100,6 +100,19 @@ FieldAtPressureLevel (const ekat::Comm& comm, const ekat::ParameterList& params)
   m_mask_field.allocate_view();
 }
 
+void FieldAtPressureLevel::initialize_impl (const RunType /*run_type*/)
+{
+  using stratts_t = std::map<std::string,std::string>;
+
+  // Propagate any io string attribute from input field to diag field
+  const auto& src = get_fields_in().front();
+  const auto& src_atts = src.get_header().get_extra_data<stratts_t>("io: string attributes");
+        auto& dst_atts = m_diagnostic_output.get_header().get_extra_data<stratts_t>("io: string attributes");
+  for (const auto& [name, val] : src_atts) {
+    dst_atts[name] = val;
+  }
+}
+
 // =========================================================================================
 void FieldAtPressureLevel::compute_diagnostic_impl()
 {

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
@@ -37,6 +37,7 @@ public:
 #endif
   void compute_diagnostic_impl ();
 protected:
+  void initialize_impl (const RunType /*run_type*/);
 
   using Pack1 = ekat::Pack<Real,1>;
 

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -340,11 +340,6 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   // Setup WSM for internal local variables
   const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);
   workspace_mgr.setup(m_buffer.wsm_data, nk_pack_p1, 52, policy);
-
-
-  using stratts_t = std::map<std::string,std::string>;
-  auto& io_atts = get_field_out("T_mid").get_header().get_extra_data<stratts_t>("io: string attributes");
-  io_atts["test"] = "blah";
 }
 
 // =========================================================================================

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -340,6 +340,11 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   // Setup WSM for internal local variables
   const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);
   workspace_mgr.setup(m_buffer.wsm_data, nk_pack_p1, 52, policy);
+
+
+  using stratts_t = std::map<std::string,std::string>;
+  auto& io_atts = get_field_out("T_mid").get_header().get_extra_data<stratts_t>("io: string attributes");
+  io_atts["test"] = "blah";
 }
 
 // =========================================================================================

--- a/components/eamxx/src/share/field/field_header.cpp
+++ b/components/eamxx/src/share/field/field_header.cpp
@@ -11,6 +11,11 @@ FieldHeader::FieldHeader (const identifier_type& id)
 {
   m_alloc_prop = std::make_shared<FieldAllocProp>(get_type_size(id.data_type()));
   m_extra_data = std::make_shared<extra_data_type>();
+
+  // Let's add immediately this att, so that users don't need to check
+  // if it already exist before adding string attributes for io.
+  using stratts_t = std::map<std::string,std::string>;
+  set_extra_data("io: string attributes",stratts_t());
 }
 
 void FieldHeader::

--- a/components/eamxx/src/share/field/field_header.hpp
+++ b/components/eamxx/src/share/field/field_header.hpp
@@ -78,6 +78,8 @@ public:
   // Get the extra data
   template<typename T>
   const T& get_extra_data (const std::string& key) const;
+  template<typename T>
+        T& get_extra_data (const std::string& key);
   bool  has_extra_data (const std::string& key) const;
 
   std::shared_ptr<FieldHeader> alias (const std::string& name) const;
@@ -110,6 +112,25 @@ protected:
 template<typename T>
 inline const T& FieldHeader::
 get_extra_data (const std::string& key) const
+{
+  EKAT_REQUIRE_MSG (has_extra_data(key),
+      "Error! Extra data not found in field header.\n"
+      "  - field name: " + m_identifier.name() + "\n"
+      "  - extra data: " + key + "\n");
+  auto a = m_extra_data->at(key);
+  EKAT_REQUIRE_MSG ( a.isType<T>(),
+      "Error! Attempting to access extra data using the wrong type.\n"
+      "  - field name    : " + m_identifier.name() + "\n"
+      "  - extra data    : " + key + "\n"
+      "  - actual type   : " + std::string(a.content().type().name()) + "\n"
+      "  - requested type: " + std::string(typeid(T).name()) + ".\n");
+
+  return ekat::any_cast<T>(a);
+}
+
+template<typename T>
+inline T& FieldHeader::
+get_extra_data (const std::string& key)
 {
   EKAT_REQUIRE_MSG (has_extra_data(key),
       "Error! Extra data not found in field header.\n"

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -204,8 +204,8 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
 
   // Helper lambda, to copy io string attributes. This will be used if any
   // remapper is created, to ensure atts set by atm_procs are not lost
-  const std::string io_string_atts_key ="io: string attributes";
   auto transfer_io_str_atts = [&] (const Field& src, Field& tgt) {
+    const std::string io_string_atts_key ="io: string attributes";
     using stratts_t = std::map<std::string,std::string>;
     const auto& src_atts = src.get_header().get_extra_data<stratts_t>(io_string_atts_key);
           auto& dst_atts = tgt.get_header().get_extra_data<stratts_t>(io_string_atts_key);

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -918,41 +918,39 @@ register_variables(const std::string& filename,
     register_variable(filename, name, name, units, vec_of_dims,
                       "real",fp_precision, io_decomp_tag);
 
-    // Add FillValue as an attribute of each variable
-    // FillValue is a protected metadata, do not add it if it already existed
+    // Add any extra attributes for this variable
     if (mode != FileMode::Append ) {
-     if (fp_precision == "real") {
-       Real fill_value = m_fill_value;
-       set_variable_metadata(filename, name, "_FillValue",fill_value);
-     } else {
-       float fill_value = m_fill_value;
-       set_variable_metadata(filename, name, "_FillValue",fill_value);
-     }
-    }
-
-    // Add any extra attributes for this variable, examples include:
-    //   1. A list of subfields associated with a field group output
-    //   2. A CF longname (TODO)
-    // First check if this is a field group w/ subfields.
-    const auto& children = field.get_header().get_children();
-    if (children.size()>0) {
-      // This field is a parent to a set of subfields
-      std::string children_list;
-      children_list += "[ ";
-      for (const auto& ch_w : children) {
-        auto child = ch_w.lock();
-        children_list += child->get_identifier().name() + ", ";
+      // Add FillValue as an attribute of each variable
+      // FillValue is a protected metadata, do not add it if it already existed
+      if (fp_precision == "real") {
+        Real fill_value = m_fill_value;
+        set_variable_metadata(filename, name, "_FillValue",fill_value);
+      } else {
+        float fill_value = m_fill_value;
+        set_variable_metadata(filename, name, "_FillValue",fill_value);
       }
-      // Replace last "," with "]"
-      children_list.pop_back();
-      children_list.pop_back();
-      children_list += " ]";
-      set_variable_metadata(filename,name,"sub_fields",children_list);
-    }
-    // If tracking average count variables then add the name of the tracking variable for this variable
-    if (m_track_avg_cnt && m_add_time_dim) {
-      const auto lookup = m_field_to_avg_cnt_map.at(name);
-      set_variable_metadata(filename,name,"averaging_count_tracker",lookup);
+
+      // If this is has subfields, add list of its children
+      const auto& children = field.get_header().get_children();
+      if (children.size()>0) {
+        // This field is a parent to a set of subfields
+        std::string children_list;
+        children_list += "[ ";
+        for (const auto& ch_w : children) {
+          auto child = ch_w.lock();
+          children_list += child->get_identifier().name() + ", ";
+        }
+        // Replace last "," with "]"
+        children_list.pop_back();
+        children_list.pop_back();
+        children_list += " ]";
+        set_variable_metadata(filename,name,"sub_fields",children_list);
+      }
+      // If tracking average count variables then add the name of the tracking variable for this variable
+      if (m_track_avg_cnt && m_add_time_dim) {
+        const auto lookup = m_field_to_avg_cnt_map.at(name);
+        set_variable_metadata(filename,name,"averaging_count_tracker",lookup);
+      }
     }
   }
   // Now register the average count variables

--- a/components/eamxx/src/share/io/scream_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.cpp
@@ -39,6 +39,7 @@ extern "C" {
   void set_variable_metadata_double_c2f (const char*&& filename, const char*&& varname, const char*&& meta_name, const double meta_val);
   float get_variable_metadata_float_c2f (const char*&& filename, const char*&& varname, const char*&& meta_name);
   double get_variable_metadata_double_c2f (const char*&& filename, const char*&& varname, const char*&& meta_name);
+  void get_variable_metadata_char_c2f (const char*&& filename, const char*&& varname, const char*&& meta_name, char*&& meta_val);
   void eam_pio_redef_c2f(const char*&& filename);
   void eam_pio_enddef_c2f(const char*&& filename);
   bool is_enddef_c2f(const char*&& filename);
@@ -403,6 +404,16 @@ void get_variable_metadata (const std::string& filename, const std::string& varn
 /* ----------------------------------------------------------------- */
 void get_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, double& meta_val) {
   meta_val = get_variable_metadata_double_c2f(filename.c_str(),varname.c_str(),meta_name.c_str());
+}
+/* ----------------------------------------------------------------- */
+void get_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, std::string& meta_val) {
+  meta_val.resize(256);
+  get_variable_metadata_char_c2f(filename.c_str(),varname.c_str(),meta_name.c_str(),&meta_val[0]);
+
+  // If terminating char is not found, meta_val simply uses all 256 chars
+  if (meta_val.find('\0')!=std::string::npos) {
+    meta_val.resize(meta_val.find('\0'));
+  }
 }
 /* ----------------------------------------------------------------- */
 ekat::any get_any_attribute (const std::string& filename, const std::string& att_name) {

--- a/components/eamxx/src/share/io/scream_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.hpp
@@ -53,6 +53,7 @@ namespace scorpio {
   void set_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, const double meta_val);
   void get_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, float& meta_val);
   void get_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, double& meta_val);
+  void get_variable_metadata (const std::string& filename, const std::string& varname, const std::string& meta_name, std::string& meta_val);
   /* Register a variable with a file.  Called during the file setup, for an input stream. */
   ekat::any get_any_attribute (const std::string& filename, const std::string& att_name);
   ekat::any get_any_attribute (const std::string& filename, const std::string& var_name, const std::string& att_name);

--- a/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -275,6 +275,39 @@ contains
 
   end function get_variable_metadata_double_c2f
 !=====================================================================!
+  subroutine get_variable_metadata_char_c2f(filename_in, varname_in, metaname_in, metaval_out) bind(c)
+    use scream_scorpio_interface, only : get_variable_metadata_char
+    use iso_c_binding, only: C_NULL_CHAR, c_char, c_f_pointer
+    type(c_ptr), intent(in) :: filename_in
+    type(c_ptr), intent(in) :: varname_in
+    type(c_ptr), intent(in) :: metaname_in
+    type(c_ptr), intent(in) :: metaval_out
+
+    character(len=256) :: filename
+    character(len=256) :: varname
+    character(len=256) :: metaname
+    character(len=256) :: metaval
+    character(len=256, kind=c_char), pointer :: temp_string
+    integer :: slen
+
+    call c_f_pointer(metaval_out,temp_string)
+
+    call convert_c_string(filename_in,filename)
+    call convert_c_string(varname_in,varname)
+    call convert_c_string(metaname_in,metaname)
+
+    metaval = get_variable_metadata_char(filename,varname,metaname)
+
+    slen = len(trim(metaval))
+    ! If string is 255 or less, add terminating char. If not, it's still
+    ! ok (the C++ string will have length=max_length=256)
+    if (slen .le. 255) then
+      temp_string = trim(metaval) // C_NULL_CHAR
+    else
+      temp_string = metaval
+    endif
+  end subroutine get_variable_metadata_char_c2f
+!=====================================================================!
   subroutine register_dimension_c2f(filename_in, shortname_in, longname_in, length, partitioned) bind(c)
     use scream_scorpio_interface, only : register_dimension
 

--- a/components/eamxx/src/share/io/tests/io_basic.cpp
+++ b/components/eamxx/src/share/io/tests/io_basic.cpp
@@ -108,10 +108,13 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
   
   const auto units = ekat::units::Units::nondimensional();
   int count=0;
+  using stratts_t = std::map<std::string,std::string>;
   for (const auto& fl : layouts) {
     FID fid("f_"+std::to_string(count),fl,units,grid->name());
     Field f(fid);
     f.allocate_view();
+    auto& str_atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");
+    str_atts["test"] = f.name();
     randomize (f,engine,my_pdf);
     f.get_header().get_tracking().update_time_stamp(t0);
     fm->add_field(f);
@@ -248,11 +251,15 @@ void read (const std::string& avg_type, const std::string& freq_units,
     }
   }
 
-  // Check that the fill value gets appropriately set for each variable
+  // Check that the expected metadata was appropriately set for each variable
   Real fill_out;
+  std::string att_test;
   for (const auto& fn: fnames) {
     scorpio::get_variable_metadata(filename,fn,"_FillValue",fill_out);
     REQUIRE(fill_out==constants::DefaultFillValue<float>().value);
+
+    scorpio::get_variable_metadata(filename,fn,"test",att_test);
+    REQUIRE (att_test==fn);
   }
 }
 


### PR DESCRIPTION
- Atm procs, diagnostics, driver, or other parts of the code can add string attributes to field extra data. IO will take all of them and add them to the nc file. E.g., usage by an atm proc:
```c++
using stratts_t = std::map<std::string,std::string>;
auto& f = get_field_out("blah");
auto& atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");
atts["my_att_name"] = "some string";
```
- This extra data is preserved during output remap.
- The FieldAtXYZ diagnostics also preserve this extra data.
- Tested in `io_basic` and `io_remap_tests`. I also tested it by temporarily hacking p3, adding a dummy attribute to "T_mid", and observing it in both "T_mid" and  "T_mid_at_2m" in the output file.

@brhillman Let me know if this suits your needs or if it needs adjustment.