### PR TITLE
Set default macmic=6 for ne256 and macmic=2 for ne512

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -304,8 +304,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <number_of_subcycles hgrid="ne4np4">24</number_of_subcycles>
       <number_of_subcycles hgrid="ne30np4">12</number_of_subcycles>
       <number_of_subcycles hgrid="ne120np4">6</number_of_subcycles>
-      <number_of_subcycles hgrid="ne256np4">3</number_of_subcycles>
-      <number_of_subcycles hgrid="ne512np4">1</number_of_subcycles>
+      <number_of_subcycles hgrid="ne256np4">6</number_of_subcycles>
+      <number_of_subcycles hgrid="ne512np4">2</number_of_subcycles>
       <number_of_subcycles hgrid="ne1024np4">1</number_of_subcycles>
       <number_of_subcycles hgrid="ne0np4_conus_x4v1_lowcon">5</number_of_subcycles>
     </mac_aero_mic>


### PR DESCRIPTION
Changing default values of macmic for ne256 and ne512.
We encountered crashes at ne256 with macmic=3, and using 6 seems to resolve.
