### PR TITLE
Add max_total_ni as a runtime option in P3

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -196,6 +196,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <do_predict_nc>true</do_predict_nc>
       <do_predict_nc COMPSET=".*SCREAM.*noAero">false</do_predict_nc>
       <enable_column_conservation_checks>false</enable_column_conservation_checks>
+      <max_total_ni type="real" doc="maximum total ice concentration (sum of all categories) (m)">740.0e3</max_total_ni>
       <tables type="array(file)">
         ${DIN_LOC_ROOT}/atm/scream/tables/p3_lookup_table_1.dat-v4.1.1,
         ${DIN_LOC_ROOT}/atm/scream/tables/mu_r_table_vals.dat8,

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -196,7 +196,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <do_predict_nc>true</do_predict_nc>
       <do_predict_nc COMPSET=".*SCREAM.*noAero">false</do_predict_nc>
       <enable_column_conservation_checks>false</enable_column_conservation_checks>
-      <max_total_ni type="real" doc="maximum total ice concentration (sum of all categories) (m)">740.0e3</max_total_ni>
+      <max_total_ni type="real" doc="maximum total ice concentration (sum of all categories)" constraints="gt 0">740.0e3</max_total_ni>
       <tables type="array(file)">
         ${DIN_LOC_ROOT}/atm/scream/tables/p3_lookup_table_1.dat-v4.1.1,
         ${DIN_LOC_ROOT}/atm/scream/tables/mu_r_table_vals.dat8,

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -237,7 +237,7 @@ Int Functions<Real,DefaultDevice>
   // main k-loop (for processes):
 
   p3_main_part2_disp(
-      nj, nk, infrastructure.predictNc, infrastructure.prescribedCCN, infrastructure.dt, inv_dt,
+      nj, nk, runtime_options.max_total_ni, infrastructure.predictNc, infrastructure.prescribedCCN, infrastructure.dt, inv_dt,
       lookup_tables.dnu_table_vals, lookup_tables.ice_table_vals, lookup_tables.collect_table_vals, 
       lookup_tables.revap_table_vals, pres, dpres, dz, nc_nuceat_tend, inv_exner,
       exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, ni_activated, inv_qc_relvar, cld_frac_i,
@@ -292,7 +292,7 @@ Int Functions<Real,DefaultDevice>
   // and compute diagnostic fields for output
   //
   p3_main_part3_disp(
-      nj, nk_pack, lookup_tables.dnu_table_vals, lookup_tables.ice_table_vals, inv_exner, cld_frac_l, cld_frac_r, cld_frac_i,
+      nj, nk_pack, runtime_options.max_total_ni, lookup_tables.dnu_table_vals, lookup_tables.ice_table_vals, inv_exner, cld_frac_l, cld_frac_r, cld_frac_i,
       rho, inv_rho, rhofaci, qv, th, qc, nc, qr, nr, qi, ni,
       qm, bm, latent_heat_vapor, latent_heat_sublim, mu_c, nu, lamc, mu_r, lamr,
       vap_liq_exchange, ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi,

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -99,6 +99,7 @@ void Functions<Real,DefaultDevice>
 template <>
 Int Functions<Real,DefaultDevice>
 ::p3_main_internal_disp(
+  const P3Runtime& runtime_options,
   const P3PrognosticState& prognostic_state,
   const P3DiagnosticInputs& diagnostic_inputs,
   const P3DiagnosticOutputs& diagnostic_outputs,

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
@@ -107,7 +107,7 @@ void Functions<Real,DefaultDevice>
     // ------------------------------------------------------------------------------------------
     // main k-loop (for processes):
     p3_main_part2(
-      team, nk_pack, predictNc, do_prescribed_CCN, dt, inv_dt,
+      team, nk_pack, max_total_ni, predictNc, do_prescribed_CCN, dt, inv_dt,
       dnu_table_vals, ice_table_vals, collect_table_vals, revap_table_vals, 
       ekat::subview(pres, i), ekat::subview(dpres, i), ekat::subview(dz, i), ekat::subview(nc_nuceat_tend, i), ekat::subview(inv_exner, i),
       ekat::subview(exner, i), ekat::subview(inv_cld_frac_l, i), ekat::subview(inv_cld_frac_i, i), ekat::subview(inv_cld_frac_r, i), 

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
@@ -15,6 +15,7 @@ void Functions<Real,DefaultDevice>
 ::p3_main_part2_disp(
   const Int& nj,
   const Int& nk,
+  const Scalar& max_total_ni,
   const bool& predictNc,
   const bool& do_prescribed_CCN,
   const Scalar& dt,

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part3_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part3_disp.cpp
@@ -18,6 +18,7 @@ void Functions<Real,DefaultDevice>
 ::p3_main_part3_disp(
   const Int& nj,
   const Int& nk_pack,
+  const Scalar& max_total_ni,
   const view_dnu_table& dnu_table_vals,
   const view_ice_table& ice_table_vals,
   const uview_2d<const Spack>& inv_exner,
@@ -74,7 +75,7 @@ void Functions<Real,DefaultDevice>
     // and compute diagnostic fields for output
     //
     p3_main_part3(
-      team, nk_pack, dnu_table_vals, ice_table_vals, ekat::subview(inv_exner, i), ekat::subview(cld_frac_l, i), ekat::subview(cld_frac_r, i),
+      team, nk_pack, max_total_ni, dnu_table_vals, ice_table_vals, ekat::subview(inv_exner, i), ekat::subview(cld_frac_l, i), ekat::subview(cld_frac_r, i),
       ekat::subview(cld_frac_i, i), ekat::subview(rho, i), ekat::subview(inv_rho, i), ekat::subview(rhofaci, i), ekat::subview(qv, i), 
       ekat::subview(th_atm, i), ekat::subview(qc, i), ekat::subview(nc, i), ekat::subview(qr, i), ekat::subview(nr, i), ekat::subview(qi, i), 
       ekat::subview(ni, i), ekat::subview(qm, i), ekat::subview(bm, i), ekat::subview(latent_heat_vapor, i), ekat::subview(latent_heat_sublim, i), 

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -203,7 +203,7 @@ void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
 void P3Microphysics::initialize_impl (const RunType /* run_type */)
 {
   // Gather runtime options
-  runtime_options.max_total_ni = m_params.get<Real>("max_total_ni");
+  runtime_options.max_total_ni = m_params.get<double>("max_total_ni");
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0,500.0,false);
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("qv"),m_grid,1e-13,0.2,true);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -202,6 +202,8 @@ void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
 // =========================================================================================
 void P3Microphysics::initialize_impl (const RunType /* run_type */)
 {
+  // Gather runtime options
+  runtime_options.max_total_ni = m_params.get<Real>("max_total_ni");
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0,500.0,false);
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("qv"),m_grid,1e-13,0.2,true);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
@@ -408,6 +408,7 @@ protected:
   P3F::P3HistoryOnly       history_only;
   P3F::P3LookupTables      lookup_tables;
   P3F::P3Infrastructure    infrastructure;
+  P3F::P3Runtime           runtime_options;
   p3_preamble              p3_preproc;
   p3_postamble             p3_postproc;
 

--- a/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
@@ -28,7 +28,7 @@ void P3Microphysics::run_impl (const double dt)
   get_field_out("micro_vap_liq_exchange").deep_copy(0.0);
   get_field_out("micro_vap_ice_exchange").deep_copy(0.0);
 
-  P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
+  P3F::p3_main(runtime_options, prog_state, diag_inputs, diag_outputs, infrastructure,
                history_only, lookup_tables, workspace_mgr, m_num_cols, m_num_levs);
 
   // Conduct the post-processing of the p3_main output.

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -244,7 +244,7 @@ Int Functions<S,D>
     // main k-loop (for processes):
 
     p3_main_part2(
-      team, nk_pack, infrastructure.predictNc, infrastructure.prescribedCCN, infrastructure.dt, inv_dt,
+      team, nk_pack, runtime_options.max_total_ni, infrastructure.predictNc, infrastructure.prescribedCCN, infrastructure.dt, inv_dt,
       lookup_tables.dnu_table_vals, lookup_tables.ice_table_vals, lookup_tables.collect_table_vals, lookup_tables.revap_table_vals, opres, odpres, odz, onc_nuceat_tend, oinv_exner,
       exner, inv_cld_frac_l, inv_cld_frac_i, inv_cld_frac_r, oni_activated, oinv_qc_relvar, ocld_frac_i,
       ocld_frac_l, ocld_frac_r, oqv_prev, ot_prev, T_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr, rhofaci, acn,
@@ -300,7 +300,7 @@ Int Functions<S,D>
     // and compute diagnostic fields for output
     //
     p3_main_part3(
-      team, nk_pack, lookup_tables.dnu_table_vals, lookup_tables.ice_table_vals, oinv_exner, ocld_frac_l, ocld_frac_r, ocld_frac_i,
+      team, nk_pack, runtime_options.max_total_ni, lookup_tables.dnu_table_vals, lookup_tables.ice_table_vals, oinv_exner, ocld_frac_l, ocld_frac_r, ocld_frac_i,
       rho, inv_rho, rhofaci, oqv, oth, oqc, onc, oqr, onr, oqi, oni,
       oqm, obm, olatent_heat_vapor, olatent_heat_sublim, mu_c, nu, lamc, mu_r, lamr,
       ovap_liq_exchange, ze_rain, ze_ice, diag_vm_qi, odiag_eff_radius_qi, diag_diam_qi,
@@ -347,7 +347,7 @@ Int Functions<S,D>
 {
 #ifndef SCREAM_SMALL_KERNELS
   return p3_main_internal(runtime_options,
-		         prognostic_state,
+                         prognostic_state,
                          diagnostic_inputs,
                          diagnostic_outputs,
                          infrastructure,
@@ -357,7 +357,7 @@ Int Functions<S,D>
                          nj, nk);
 #else 
   return p3_main_internal_disp(runtime_options,
-		               prognostic_state,
+                               prognostic_state,
                                diagnostic_inputs,
                                diagnostic_outputs,
                                infrastructure,

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -74,6 +74,7 @@ void Functions<S,D>
 template <typename S, typename D>
 Int Functions<S,D>
 ::p3_main_internal(
+  const P3Runtime& runtime_options,
   const P3PrognosticState& prognostic_state,
   const P3DiagnosticInputs& diagnostic_inputs,
   const P3DiagnosticOutputs& diagnostic_outputs,
@@ -345,7 +346,8 @@ Int Functions<S,D>
   Int nk)
 {
 #ifndef SCREAM_SMALL_KERNELS
-  return p3_main_internal(prognostic_state,
+  return p3_main_internal(runtime_options,
+		         prognostic_state,
                          diagnostic_inputs,
                          diagnostic_outputs,
                          infrastructure,
@@ -354,7 +356,8 @@ Int Functions<S,D>
                          workspace_mgr,
                          nj, nk);
 #else 
-  return p3_main_internal_disp(prognostic_state,
+  return p3_main_internal_disp(runtime_options,
+		               prognostic_state,
                                diagnostic_inputs,
                                diagnostic_outputs,
                                infrastructure,

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -333,6 +333,7 @@ Int Functions<S,D>
 template <typename S, typename D>
 Int Functions<S,D>
 ::p3_main(
+  const P3Runtime& runtime_options,
   const P3PrognosticState& prognostic_state,
   const P3DiagnosticInputs& diagnostic_inputs,
   const P3DiagnosticOutputs& diagnostic_outputs,

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -21,6 +21,7 @@ void Functions<S,D>
 ::p3_main_part2(
   const MemberType& team,
   const Int& nk_pack,
+  const Scalar& max_total_ni,
   const bool& predictNc,
   const bool& do_prescribed_CCN,
   const Scalar& dt,
@@ -98,7 +99,6 @@ void Functions<S,D>
   constexpr Scalar qsmall       = C::QSMALL;
   constexpr Scalar nsmall       = C::NSMALL;
   constexpr Scalar T_zerodegc   = C::T_zerodegc;
-  constexpr Scalar max_total_ni = C::max_total_ni;
   constexpr Scalar f1r          = C::f1r;
   constexpr Scalar f2r          = C::f2r;
   constexpr Scalar nmltratio    = C::nmltratio;

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
@@ -21,6 +21,7 @@ void Functions<S,D>
 ::p3_main_part3(
   const MemberType& team,
   const Int& nk_pack,
+  const Scalar& max_total_ni,
   const view_dnu_table& dnu,
   const view_ice_table& ice_table_vals,
   const uview_1d<const Spack>& inv_exner,
@@ -60,7 +61,6 @@ void Functions<S,D>
 {
   constexpr Scalar qsmall       = C::QSMALL;
   constexpr Scalar inv_cp       = C::INV_CP;
-  constexpr Scalar max_total_ni = C::max_total_ni;
   constexpr Scalar nsmall       = C::NSMALL;
 
   Kokkos::parallel_for(

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -1016,6 +1016,7 @@ struct Functions
   static void p3_main_part2(
     const MemberType& team,
     const Int& nk_pack,
+    const Scalar& max_total_ni,
     const bool& do_predict_nc,
     const bool& do_prescribed_CCN,
     const Scalar& dt,
@@ -1095,6 +1096,7 @@ struct Functions
   static void p3_main_part2_disp(
     const Int& nj,
     const Int& nk,
+    const Scalar& max_total_ni,
     const bool& do_predict_nc,
     const bool& do_prescribed_CCN,
     const Scalar& dt,
@@ -1175,6 +1177,7 @@ struct Functions
   static void p3_main_part3(
     const MemberType& team,
     const Int& nk_pack,
+    const Scalar& max_total_ni,
     const view_dnu_table& dnu,
     const view_ice_table& ice_table_vals,
     const uview_1d<const Spack>& inv_exner,
@@ -1216,6 +1219,7 @@ struct Functions
   static void p3_main_part3_disp(
     const Int& nj,
     const Int& nk_pack,
+    const Scalar& max_total_ni,
     const view_dnu_table& dnu,
     const view_ice_table& ice_table_vals,
     const uview_2d<const Spack>& inv_exner,

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -109,7 +109,6 @@ struct Functions
 
   // Structure to store p3 runtime options
   struct P3Runtime {
-    P3Runtime() = default;
     // maximum total ice concentration (sum of all categories) (m)
     Scalar max_total_ni;
   };

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -1258,6 +1258,7 @@ struct Functions
 
   // Return microseconds elapsed
   static Int p3_main(
+    const P3Runtime& runtime_options,
     const P3PrognosticState& prognostic_state,
     const P3DiagnosticInputs& diagnostic_inputs,
     const P3DiagnosticOutputs& diagnostic_outputs,

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -107,6 +107,13 @@ struct Functions
   using WorkspaceManager = typename ekat::WorkspaceManager<Spack, Device>;
   using Workspace        = typename WorkspaceManager::Workspace;
 
+  // Structure to store p3 runtime options
+  struct P3Runtime {
+    P3Runtime() = default;
+    // maximum total ice concentration (sum of all categories) (m)
+    Scalar max_total_ni;
+  };
+
   // This struct stores prognostic variables evolved by P3.
   struct P3PrognosticState {
     P3PrognosticState() = default;

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -1270,6 +1270,7 @@ struct Functions
     Int nk); // number of vertical cells per column
 
   static Int p3_main_internal(
+    const P3Runtime& runtime_options,
     const P3PrognosticState& prognostic_state,
     const P3DiagnosticInputs& diagnostic_inputs,
     const P3DiagnosticOutputs& diagnostic_outputs,
@@ -1282,6 +1283,7 @@ struct Functions
 
 #ifdef SCREAM_SMALL_KERNELS
   static Int p3_main_internal_disp(
+    const P3Runtime& runtime_options,
     const P3PrognosticState& prognostic_state,
     const P3DiagnosticInputs& diagnostic_inputs,
     const P3DiagnosticOutputs& diagnostic_outputs,

--- a/components/eamxx/src/physics/p3/p3_functions_f90.cpp
+++ b/components/eamxx/src/physics/p3/p3_functions_f90.cpp
@@ -2063,13 +2063,14 @@ Int p3_main_f(
 
   P3F::P3LookupTables lookup_tables{mu_r_table_vals, vn_table_vals, vm_table_vals, revap_table_vals,
                                     ice_table_vals, collect_table_vals, dnu_table_vals};
+  P3F::P3Runtime runtime_options{740.0e3};
 
   // Create local workspace
   const Int nk_pack = ekat::npack<Spack>(nk);
   const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(nj, nk_pack);
   ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(nk_pack, 52, policy);
 
-  auto elapsed_microsec = P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
+  auto elapsed_microsec = P3F::p3_main(runtime_options, prog_state, diag_inputs, diag_outputs, infrastructure,
                                        history_only, lookup_tables, workspace_mgr, nj, nk);
 
   Kokkos::parallel_for(nj, KOKKOS_LAMBDA(const Int& i) {

--- a/components/eamxx/src/physics/p3/p3_functions_f90.cpp
+++ b/components/eamxx/src/physics/p3/p3_functions_f90.cpp
@@ -1685,6 +1685,7 @@ void p3_main_part2_f(
 
   const Int nk = (kte - kts) + 1;
   const Int nk_pack = ekat::npack<Spack>(nk);
+  const Real max_total_ni = 740.0e3;
 
   // Set up views
   std::vector<view_1d> temp_d(P3MainPart2Data::NUM_ARRAYS);
@@ -1774,7 +1775,7 @@ void p3_main_part2_f(
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
 
     P3F::p3_main_part2(
-      team, nk_pack, do_predict_nc, do_prescribed_CCN, dt, inv_dt, dnu, ice_table_vals, collect_table_vals, revap_table_vals,
+      team, nk_pack, max_total_ni, do_predict_nc, do_prescribed_CCN, dt, inv_dt, dnu, ice_table_vals, collect_table_vals, revap_table_vals,
       pres_d, dpres_d, dz_d, nc_nuceat_tend_d, inv_exner_d, exner_d, inv_cld_frac_l_d,
       inv_cld_frac_i_d, inv_cld_frac_r_d, ni_activated_d, inv_qc_relvar_d, cld_frac_i_d, cld_frac_l_d, cld_frac_r_d,
       qv_prev_d, t_prev_d, t_d, rho_d, inv_rho_d, qv_sat_l_d, qv_sat_i_d, qv_supersat_i_d, rhofacr_d, rhofaci_d, acn_d,
@@ -1840,6 +1841,7 @@ void p3_main_part3_f(
 
   const Int nk = (kte - kts) + 1;
   const Int nk_pack = ekat::npack<Spack>(nk);
+  const Real max_total_ni = 740.0e3;
 
   // Set up views
   std::vector<view_1d> temp_d(P3MainPart3Data::NUM_ARRAYS);
@@ -1893,7 +1895,7 @@ void p3_main_part3_f(
   auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
 
-    P3F::p3_main_part3(team, nk_pack, dnu, ice_table_vals,
+    P3F::p3_main_part3(team, nk_pack, max_total_ni, dnu, ice_table_vals,
                        inv_exner_d, cld_frac_l_d, cld_frac_r_d, cld_frac_i_d, rho_d, inv_rho_d,
                        rhofaci_d, qv_d, th_atm_d, qc_d, nc_d, qr_d, nr_d,
                        qi_d, ni_d, qm_d, bm_d, latent_heat_vapor_d,

--- a/components/eamxx/src/physics/p3/p3_functions_f90.cpp
+++ b/components/eamxx/src/physics/p3/p3_functions_f90.cpp
@@ -1685,7 +1685,7 @@ void p3_main_part2_f(
 
   const Int nk = (kte - kts) + 1;
   const Int nk_pack = ekat::npack<Spack>(nk);
-  const Real max_total_ni = 740.0e3;
+  const Real max_total_ni = 740.0e3;  // Hard-code this value for F90 comparison
 
   // Set up views
   std::vector<view_1d> temp_d(P3MainPart2Data::NUM_ARRAYS);
@@ -1841,7 +1841,7 @@ void p3_main_part3_f(
 
   const Int nk = (kte - kts) + 1;
   const Int nk_pack = ekat::npack<Spack>(nk);
-  const Real max_total_ni = 740.0e3;
+  const Real max_total_ni = 740.0e3;  // Hard-code this value for F90 comparison
 
   // Set up views
   std::vector<view_1d> temp_d(P3MainPart3Data::NUM_ARRAYS);

--- a/components/eamxx/src/physics/p3/tests/p3_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_unit_tests.cpp
@@ -996,7 +996,7 @@ template <typename D>
 struct UnitWrap::UnitTest<D>::TestP3FunctionsImposeMaxTotalNi
 {
   static void impose_max_total_ni_bfb_test(){
-    constexpr Scalar max_total_ni = C::max_total_ni;
+    constexpr Scalar max_total_ni = 740.0e3;
 
     ImposeMaxTotalNiData dc[max_pack_size]= {
       // ni_local, max_total_ni, inv_rho_local

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -94,7 +94,6 @@ struct Constants
   static constexpr Scalar MWWV          = MWH2O;
   static constexpr Scalar RWV           = Rgas / MWWV;
   static constexpr Scalar ZVIR          = (RWV / Rair) - 1.0;
-  static constexpr Scalar max_total_ni  = 740.e+3;  // maximum total ice concentration (sum of all categories) (m)
   static constexpr Scalar f1r           = 0.78;
   static constexpr Scalar f2r           = 0.32;
   static constexpr Scalar nmltratio     = 1.0; // ratio of rain number produced to ice number loss from melting

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -42,6 +42,7 @@ atmosphere_processes:
       p3:
         do_prescribed_ccn: false
         enable_column_conservation_checks: true
+        max_total_ni: 740.0e3
       shoc:
         enable_column_conservation_checks: true
         lambda_low: 0.001

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -39,6 +39,8 @@ atmosphere_processes:
         lambda_high: 0.04
         lambda_slope: 2.65
         lambda_thresh: 0.02
+      p3:
+        max_total_ni: 740.0e3
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -39,6 +39,8 @@ atmosphere_processes:
         lambda_high: 0.04
         lambda_slope: 2.65
         lambda_thresh: 0.02
+      p3:
+        max_total_ni: 740.0e3
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
@@ -46,6 +46,8 @@ atmosphere_processes:
         lambda_high: 0.04
         lambda_slope: 2.65
         lambda_thresh: 0.02
+      p3:
+        max_total_ni: 740.0e3
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -38,6 +38,7 @@ atmosphere_processes:
       number_of_subcycles: 1
       p3:
         do_prescribed_ccn: false
+        max_total_ni: 740.0e3
       shoc:
         lambda_low: 0.001
         lambda_high: 0.04

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -37,6 +37,7 @@ atmosphere_processes:
       schedule_type: Sequential
       number_of_subcycles: 1
       p3:
+        max_total_ni: 740.0e3
         do_prescribed_ccn: false
       shoc:
         lambda_low: 0.001

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -27,6 +27,7 @@ atmosphere_processes:
       schedule_type: Sequential
       number_of_subcycles: 1
       p3:
+        max_total_ni: 740.0e3
         do_prescribed_ccn: false
       shoc:
         lambda_low: 0.001

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -17,6 +17,8 @@ atmosphere_processes:
     lambda_high: 0.04
     lambda_slope: 2.65
     lambda_thresh: 0.02
+  p3:
+    max_total_ni: 740.0e3
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -17,6 +17,7 @@ atmosphere_processes:
     schedule_type: Sequential
     number_of_subcycles: ${MAC_MIC_SUBCYCLES}
     p3:
+      max_total_ni: 740.0e3
       do_prescribed_ccn: false
     shoc:
       lambda_low: 0.001

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -24,6 +24,8 @@ atmosphere_processes:
       lambda_high: 0.04
       lambda_slope: 2.65
       lambda_thresh: 0.02
+    p3:
+      max_total_ni: 740.0e3
   rrtmgp:
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
@@ -11,6 +11,8 @@ time_stepping:
 atmosphere_processes:
   schedule_type: Sequential
   atm_procs_list: [shoc,p3,nudging]
+  p3:
+    max_total_ni: 740.0e3
   nudging:
     nudging_filename: [shoc_p3_source_data_${POSTFIX}.INSTANT.nsteps_x${NUM_STEPS}.${RUN_T0}.nc]
     nudging_fields: ["T_mid", "qv"]

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
@@ -12,7 +12,7 @@ atmosphere_processes:
   schedule_type: Sequential
   atm_procs_list: [shoc,p3,nudging]
   p3:
-    max_total_ni: 740.0e3
+    max_total_ni: 720.0e3
   nudging:
     nudging_filename: [shoc_p3_source_data_${POSTFIX}.INSTANT.nsteps_x${NUM_STEPS}.${RUN_T0}.nc]
     nudging_fields: ["T_mid", "qv"]

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
@@ -16,6 +16,8 @@ atmosphere_processes:
     lambda_high: 0.04
     lambda_slope: 2.65
     lambda_thresh: 0.02
+  p3:
+    max_total_ni: 740.0e3
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
@@ -17,7 +17,7 @@ atmosphere_processes:
     lambda_slope: 2.65
     lambda_thresh: 0.02
   p3:
-    max_total_ni: 740.0e3
+    max_total_ni: 720.0e3
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/uncoupled/p3/input.yaml
+++ b/components/eamxx/tests/uncoupled/p3/input.yaml
@@ -11,6 +11,7 @@ time_stepping:
 atmosphere_processes:
   atm_procs_list: [p3]
   p3:
+    max_total_ni: 740.0e3
     compute_tendencies: [T_mid,qc]
     do_prescribed_ccn: false
 


### PR DESCRIPTION
Similar to #2554 , this commit adds a new runtime option to a physics process, in this case P3.  The new option is for `max_total_ni`.  This commit establishes a structure in the P3 interface with the AD that can handle additional runtime options as they become needed.

Note: Similar to the work of #2554 this PR assumes that we will eventually drop support for the F90 version of SCREAM so there are no changes to the P3 F90 <-> C++ bridges.  It is still, however, BFB as long as the user sets max_total_ni to the default value.