### PR TITLE
quick fix to ensure the proper units are added to netCDF metadata

### DIFF
--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -909,7 +909,7 @@ register_variables(const std::string& filename,
     const auto& layout = fid.get_layout();
     const auto& io_decomp_tag = set_decomp_tag(layout);
     auto vec_of_dims   = set_vec_of_dims(layout);
-    std::string units = to_string(fid.get_units());
+    std::string units = fid.get_units().get_string();
 
     // TODO  Need to change dtype to allow for other variables.
     // Currently the field_manager only stores Real variables so it is not an issue,


### PR DESCRIPTION
Quick fix because qv, qc, qr, qi, qm did not show the proper string of `kg/kg` in the netCDF metadata.