### PR TITLE
Expose more tuning parameters for SHOC

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -216,7 +216,9 @@ be lost if SCREAM_HACK_XML is not enabled.
       <thl2tune type="real" doc="Temperature variance tuning factor">1.0</thl2tune>
       <qw2tune type="real" doc="Moisture variance tuning factor">1.0</qw2tune>
       <qwthl2tune type="real" doc="Temperature moisture covariance">1.0</qwthl2tune>
-      <w2tune type="real" doc=" Vertical velocity variance">1.0</w2tune>
+      <w2tune type="real" doc="Vertical velocity variance">1.0</w2tune>
+      <length_fac type="real" doc="Length scale factor">0.5</length_fac>
+      <c_diag_3rd_mom type="real" doc="w3 factor">7.0</c_diag_3rd_mom>
     </shoc>
 
     <!-- CLD fraction -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -213,6 +213,10 @@ be lost if SCREAM_HACK_XML is not enabled.
       <lambda_high type="real" doc="maximum value of stability correction.">0.04</lambda_high>
       <lambda_slope type="real" doc="slope of change from lambda_low to lambda_high.">2.65</lambda_slope>
       <lambda_thresh type="real" doc="stability threshold for which to apply more stability correction.">0.02</lambda_thresh>
+      <thl2tune type="real" doc="Temperature variance tuning factor">1.0</thl2tune>
+      <qw2tune type="real" doc="Moisture variance tuning factor">1.0</qw2tune>
+      <qwthl2tune type="real" doc="Temperature moisture covariance">1.0</qwthl2tune>
+      <w2tune type="real" doc=" Vertical velocity variance">1.0</w2tune>
     </shoc>
 
     <!-- CLD fraction -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -218,9 +218,9 @@ be lost if SCREAM_HACK_XML is not enabled.
       <qwthl2tune type="real" doc="Temperature moisture covariance">1.0</qwthl2tune>
       <w2tune type="real" doc="Vertical velocity variance">1.0</w2tune>
       <length_fac type="real" doc="Length scale factor">0.5</length_fac>
-      <c_diag_3rd_mom type="real" doc="w3 factor">7.0</c_diag_3rd_mom>
+      <c_diag_3rd_mom type="real" doc="Third moment vertical velocity damping factor">7.0</c_diag_3rd_mom>
       <Ckh type="real" doc="Eddy diffusivity coefficient for heat">0.1</Ckh>
-      <Ckm type="real" doc="Eddy diffusivity coefficient for heat">0.1</Ckm>
+      <Ckm type="real" doc="Eddy diffusivity coefficient for momentum">0.1</Ckm>
     </shoc>
 
     <!-- CLD fraction -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -219,6 +219,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <w2tune type="real" doc="Vertical velocity variance">1.0</w2tune>
       <length_fac type="real" doc="Length scale factor">0.5</length_fac>
       <c_diag_3rd_mom type="real" doc="w3 factor">7.0</c_diag_3rd_mom>
+      <Ckh type="real" doc="Eddy diffusivity coefficient for heat">0.1</Ckh>
+      <Ckm type="real" doc="Eddy diffusivity coefficient for heat">0.1</Ckm>
     </shoc>
 
     <!-- CLD fraction -->

--- a/components/eamxx/src/physics/shoc/disp/shoc_diag_second_shoc_moments_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_diag_second_shoc_moments_disp.cpp
@@ -9,6 +9,7 @@ template<>
 void Functions<Real,DefaultDevice>
 ::diag_second_shoc_moments_disp(
   const Int& shcol, const Int& nlev, const Int& nlevi,
+  const Real& thl2tune, const Real& qw2tune, const Real& qwthl2tune, const Real& w2tune,
   const view_2d<const Spack>& thetal,
   const view_2d<const Spack>& qw,
   const view_2d<const Spack>& u_wind,
@@ -49,6 +50,7 @@ void Functions<Real,DefaultDevice>
 
     diag_second_shoc_moments(
       team, nlev, nlevi,
+      thl2tune, qw2tune, qwthl2tune, w2tune,
       ekat::subview(thetal, i),
       ekat::subview(qw, i),
       ekat::subview(u_wind, i),

--- a/components/eamxx/src/physics/shoc/disp/shoc_diag_third_shoc_moments_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_diag_third_shoc_moments_disp.cpp
@@ -11,6 +11,7 @@ void Functions<Real,DefaultDevice>
   const Int&                  shcol,
   const Int&                  nlev,
   const Int&                  nlevi,
+  const Scalar&               c_diag_3rd_mom,
   const view_2d<const Spack>& w_sec,
   const view_2d<const Spack>& thl_sec,
   const view_2d<const Spack>& wthl_sec,
@@ -36,6 +37,7 @@ void Functions<Real,DefaultDevice>
 
     diag_third_shoc_moments(
       team, nlev, nlevi,
+      c_diag_3rd_mom,
       ekat::subview(w_sec, i),
       ekat::subview(thl_sec, i),
       ekat::subview(wthl_sec, i),

--- a/components/eamxx/src/physics/shoc/disp/shoc_length_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_length_disp.cpp
@@ -11,6 +11,7 @@ void Functions<Real,DefaultDevice>
   const Int&                   shcol,
   const Int&                   nlev,
   const Int&                   nlevi,
+  const Scalar&                length_fac,
   const view_1d<const Scalar>& dx,
   const view_1d<const Scalar>& dy,
   const view_2d<const Spack>&  zt_grid,
@@ -31,7 +32,8 @@ void Functions<Real,DefaultDevice>
 
     auto workspace       = workspace_mgr.get_workspace(team);
 
-    shoc_length(team, nlev, nlevi, dx(i), dy(i),
+    shoc_length(team, nlev, nlevi, length_fac, 
+                dx(i), dy(i),
                 ekat::subview(zt_grid, i),
                 ekat::subview(zi_grid, i),
                 ekat::subview(dz_zt, i),

--- a/components/eamxx/src/physics/shoc/disp/shoc_tke_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_tke_disp.cpp
@@ -16,6 +16,8 @@ void Functions<Real,DefaultDevice>
   const Scalar&                lambda_high,
   const Scalar&                lambda_slope,
   const Scalar&                lambda_thresh,
+  const Scalar&                Ckh,
+  const Scalar&                Ckm,
   const view_2d<const Spack>&  wthv_sec,
   const view_2d<const Spack>&  shoc_mix,
   const view_2d<const Spack>&  dz_zi,
@@ -45,6 +47,7 @@ void Functions<Real,DefaultDevice>
 
     shoc_tke(team, nlev, nlevi, dtime,
              lambda_low, lambda_high, lambda_slope, lambda_thresh,
+             Ckh, Ckm,
              ekat::subview(wthv_sec, i),
              ekat::subview(shoc_mix, i),
              ekat::subview(dz_zi, i),

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -240,6 +240,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   runtime_options.qwthl2tune    = m_params.get<double>("qwthl2tune");
   runtime_options.w2tune        = m_params.get<double>("w2tune");
   runtime_options.length_fac    = m_params.get<double>("length_fac");
+  runtime_options.c_diag_3rd_mom = m_params.get<double>("c_diag_3rd_mom");
   // Initialize all of the structures that are passed to shoc_main in run_impl.
   // Note: Some variables in the structures are not stored in the field manager.  For these
   //       variables a local view is constructed.

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -231,10 +231,14 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
 void SHOCMacrophysics::initialize_impl (const RunType run_type)
 {
   // Gather runtime options
-  runtime_options.lambda_low    = m_params.get<double>("lambda_low");
-  runtime_options.lambda_high   = m_params.get<double>("lambda_high");
-  runtime_options.lambda_slope  = m_params.get<double>("lambda_slope");
-  runtime_options.lambda_thresh = m_params.get<double>("lambda_thresh");
+  runtime_options.lambda_low    = m_params.get<Real>("lambda_low");
+  runtime_options.lambda_high   = m_params.get<Real>("lambda_high");
+  runtime_options.lambda_slope  = m_params.get<Real>("lambda_slope");
+  runtime_options.lambda_thresh = m_params.get<Real>("lambda_thresh");
+  runtime_options.thl2tune      = m_params.get<Real>("thl2tune");
+  runtime_options.qw2tune       = m_params.get<Real>("qw2tune");
+  runtime_options.qwthl2tune    = m_params.get<Real>("qwthl2tune");
+  runtime_options.w2tune        = m_params.get<Real>("w2tune");
   // Initialize all of the structures that are passed to shoc_main in run_impl.
   // Note: Some variables in the structures are not stored in the field manager.  For these
   //       variables a local view is constructed.

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -231,14 +231,14 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
 void SHOCMacrophysics::initialize_impl (const RunType run_type)
 {
   // Gather runtime options
-  runtime_options.lambda_low    = m_params.get<Real>("lambda_low");
-  runtime_options.lambda_high   = m_params.get<Real>("lambda_high");
-  runtime_options.lambda_slope  = m_params.get<Real>("lambda_slope");
-  runtime_options.lambda_thresh = m_params.get<Real>("lambda_thresh");
-  runtime_options.thl2tune      = m_params.get<Real>("thl2tune");
-  runtime_options.qw2tune       = m_params.get<Real>("qw2tune");
-  runtime_options.qwthl2tune    = m_params.get<Real>("qwthl2tune");
-  runtime_options.w2tune        = m_params.get<Real>("w2tune");
+  runtime_options.lambda_low    = m_params.get<double>("lambda_low");
+  runtime_options.lambda_high   = m_params.get<double>("lambda_high");
+  runtime_options.lambda_slope  = m_params.get<double>("lambda_slope");
+  runtime_options.lambda_thresh = m_params.get<double>("lambda_thresh");
+  runtime_options.thl2tune      = m_params.get<double>("thl2tune");
+  runtime_options.qw2tune       = m_params.get<double>("qw2tune");
+  runtime_options.qwthl2tune    = m_params.get<double>("qwthl2tune");
+  runtime_options.w2tune        = m_params.get<double>("w2tune");
   // Initialize all of the structures that are passed to shoc_main in run_impl.
   // Note: Some variables in the structures are not stored in the field manager.  For these
   //       variables a local view is constructed.

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -241,6 +241,8 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   runtime_options.w2tune        = m_params.get<double>("w2tune");
   runtime_options.length_fac    = m_params.get<double>("length_fac");
   runtime_options.c_diag_3rd_mom = m_params.get<double>("c_diag_3rd_mom");
+  runtime_options.Ckh           = m_params.get<double>("Ckh");
+  runtime_options.Ckm           = m_params.get<double>("Ckm");
   // Initialize all of the structures that are passed to shoc_main in run_impl.
   // Note: Some variables in the structures are not stored in the field manager.  For these
   //       variables a local view is constructed.

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -239,6 +239,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   runtime_options.qw2tune       = m_params.get<double>("qw2tune");
   runtime_options.qwthl2tune    = m_params.get<double>("qwthl2tune");
   runtime_options.w2tune        = m_params.get<double>("w2tune");
+  runtime_options.length_fac    = m_params.get<double>("length_fac");
   // Initialize all of the structures that are passed to shoc_main in run_impl.
   // Note: Some variables in the structures are not stored in the field manager.  For these
   //       variables a local view is constructed.

--- a/components/eamxx/src/physics/shoc/impl/shoc_compute_diag_third_shoc_moment_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_compute_diag_third_shoc_moment_impl.hpp
@@ -13,6 +13,7 @@ void Functions<S,D>
   const MemberType& team,
   const Int& nlev,
   const Int& nlevi,
+  const Scalar& c_diag_3rd_mom,
   const uview_1d<const Spack>& w_sec,
   const uview_1d<const Spack>& thl_sec,
   const uview_1d<const Spack>& wthl_sec,
@@ -44,7 +45,6 @@ void Functions<S,D>
 
   Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
     // Constants
-    const auto c_diag_3rd_mom = scream::shoc::Constants<Scalar>::c_diag_3rd_mom;
     const Scalar a0 = (sp(0.52)*(1/(c_diag_3rd_mom*c_diag_3rd_mom)))/(c_diag_3rd_mom-2);
     const Scalar a1 = sp(0.87)/(c_diag_3rd_mom*c_diag_3rd_mom);
     const Scalar a2 = sp(0.5)/c_diag_3rd_mom;

--- a/components/eamxx/src/physics/shoc/impl/shoc_compute_shoc_mix_shoc_length_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_compute_shoc_mix_shoc_length_impl.hpp
@@ -12,6 +12,7 @@ void Functions<S,D>
 ::compute_shoc_mix_shoc_length(
   const MemberType&            team,
   const Int&                   nlev,
+  const Scalar&                length_fac,
   const uview_1d<const Spack>& tke,
   const uview_1d<const Spack>& brunt,
   const uview_1d<const Spack>& zt_grid,
@@ -20,7 +21,6 @@ void Functions<S,D>
 {
   const Int nlev_pack = ekat::npack<Spack>(nlev);
   const auto maxlen = scream::shoc::Constants<Scalar>::maxlen;
-  const auto length_fac = scream::shoc::Constants<Scalar>::length_fac;
   const auto vk = C::Karman;
   
   // Eddy turnover timescale

--- a/components/eamxx/src/physics/shoc/impl/shoc_diag_second_moments_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_diag_second_moments_impl.hpp
@@ -15,6 +15,7 @@ template<typename S, typename D>
 KOKKOS_FUNCTION
 void Functions<S,D>::diag_second_moments(
   const MemberType& team, const Int& nlev, const Int& nlevi,
+  const Real& thl2tune, const Real& qw2tune, const Real& qwthl2tune, const Real& w2tune,
   const uview_1d<const Spack>& thetal, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& u_wind,
   const uview_1d<const Spack>& v_wind, const uview_1d<const Spack>& tke, const uview_1d<const Spack>& isotropy,
   const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& dz_zi,
@@ -31,16 +32,16 @@ void Functions<S,D>::diag_second_moments(
   //  u, v, TKE, and tracers are computed here as well as the
   //  correlation of qw and thetal.
 
-  const auto thl2tune = 1;
+//ASD  const auto thl2tune = 1;
 
   // moisture variance
-  const auto qw2tune = 1;
+//ASD  const auto qw2tune = 1;
 
   // temp moisture covariance
-  const auto qwthl2tune = 1;
+//ASD  const auto qwthl2tune = 1;
 
   // vertical velocity variance
-  const auto w2tune = 1;
+//ASD  const auto w2tune = 1;
 
   // Interpolate some variables from the midpoint grid to the interface grid
   linear_interp(team, zt_grid, zi_grid, isotropy, isotropy_zi, nlev, nlevi, 0);

--- a/components/eamxx/src/physics/shoc/impl/shoc_diag_second_moments_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_diag_second_moments_impl.hpp
@@ -32,17 +32,6 @@ void Functions<S,D>::diag_second_moments(
   //  u, v, TKE, and tracers are computed here as well as the
   //  correlation of qw and thetal.
 
-//ASD  const auto thl2tune = 1;
-
-  // moisture variance
-//ASD  const auto qw2tune = 1;
-
-  // temp moisture covariance
-//ASD  const auto qwthl2tune = 1;
-
-  // vertical velocity variance
-//ASD  const auto w2tune = 1;
-
   // Interpolate some variables from the midpoint grid to the interface grid
   linear_interp(team, zt_grid, zi_grid, isotropy, isotropy_zi, nlev, nlevi, 0);
   linear_interp(team, zt_grid, zi_grid, tkh,      tkh_zi,      nlev, nlevi, 0);

--- a/components/eamxx/src/physics/shoc/impl/shoc_diag_second_shoc_moments_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_diag_second_shoc_moments_impl.hpp
@@ -14,6 +14,7 @@ namespace shoc {
 template<typename S, typename D>
 KOKKOS_FUNCTION
 void Functions<S,D>::diag_second_shoc_moments(const MemberType& team, const Int& nlev, const Int& nlevi,
+       const Scalar& thl2tune, const Scalar& qw2tune, const Scalar& qwthl2tune, const Scalar& w2tune,
        const uview_1d<const Spack>& thetal, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& u_wind,
        const uview_1d<const Spack>& v_wind, const uview_1d<const Spack>& tke, const uview_1d<const Spack>& isotropy,
        const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& dz_zi,
@@ -58,6 +59,7 @@ void Functions<S,D>::diag_second_shoc_moments(const MemberType& team, const Int&
   // Diagnose the second order moments, for points away from boundaries.  this is
   //  the main computation for the second moments
   diag_second_moments(team, nlev, nlevi,
+                     thl2tune, qw2tune, qwthl2tune, w2tune,
                      thetal, qw, u_wind,v_wind, tke, isotropy,tkh, tk, dz_zi, zt_grid, zi_grid, shoc_mix,
                      isotropy_zi, tkh_zi, tk_zi, thl_sec, qw_sec, wthl_sec, wqw_sec,
                      qwthl_sec, uw_sec, vw_sec, wtke_sec, w_sec);

--- a/components/eamxx/src/physics/shoc/impl/shoc_diag_third_shoc_moments_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_diag_third_shoc_moments_impl.hpp
@@ -17,6 +17,7 @@ void Functions<S,D>::diag_third_shoc_moments(
   const MemberType&            team,
   const Int&                   nlev,
   const Int&                   nlevi,
+  const Scalar&                c_diag_3rd_mom,
   const uview_1d<const Spack>& w_sec,
   const uview_1d<const Spack>& thl_sec,
   const uview_1d<const Spack>& wthl_sec,
@@ -49,7 +50,7 @@ void Functions<S,D>::diag_third_shoc_moments(
   team.team_barrier();
 
   // Diagnose the third moment of the vertical-velocity
-  compute_diag_third_shoc_moment(team,nlev,nlevi,w_sec,thl_sec,wthl_sec,
+  compute_diag_third_shoc_moment(team,nlev,nlevi,c_diag_3rd_mom,w_sec,thl_sec,wthl_sec,
                                  tke, dz_zt, dz_zi,isotropy_zi, brunt_zi,
                                  w_sec_zi,thetal_zi,w3);
   team.team_barrier();

--- a/components/eamxx/src/physics/shoc/impl/shoc_eddy_diffusivities_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_eddy_diffusivities_impl.hpp
@@ -16,6 +16,8 @@ KOKKOS_FUNCTION
 void Functions<S,D>::eddy_diffusivities(
   const MemberType&            team,
   const Int&                   nlev,
+  const Scalar&                 Ckh,
+  const Scalar&                 Ckm,
   const Scalar&                pblh,
   const uview_1d<const Spack>& zt_grid,
   const uview_1d<const Spack>& tabs,
@@ -33,9 +35,6 @@ void Functions<S,D>::eddy_diffusivities(
   // Transition depth [m] above PBL top to allow
   // stability diffusivities
   const Int pbl_trans = 200;
-  // Turbulent coefficients
-  const Scalar Ckh = 0.1;
-  const Scalar Ckm = 0.1;
   // Dddy coefficients for stable PBL diffusivities
   const Scalar Ckh_s = 0.1;
   const Scalar Ckm_s = 0.1;

--- a/components/eamxx/src/physics/shoc/impl/shoc_length_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_length_impl.hpp
@@ -13,6 +13,7 @@ void Functions<S,D>
   const MemberType&            team,
   const Int&                   nlev,
   const Int&                   nlevi,
+  const Scalar&                length_fac,
   const Scalar&                dx,
   const Scalar&                dy,
   const uview_1d<const Spack>& zt_grid,
@@ -36,7 +37,7 @@ void Functions<S,D>
   Scalar l_inf = 0;
   compute_l_inf_shoc_length(team,nlev,zt_grid,dz_zt,tke,l_inf);
 
-  compute_shoc_mix_shoc_length(team,nlev,tke,brunt,zt_grid,l_inf,shoc_mix);
+  compute_shoc_mix_shoc_length(team,nlev,length_fac, tke,brunt,zt_grid,l_inf,shoc_mix);
   team.team_barrier();
 
   check_length_scale_shoc_length(team,nlev,dx,dy,shoc_mix);

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -221,7 +221,14 @@ void Functions<S,D>::shoc_main_internal(
                                 thetal,qw,qtracers,tke,u_wind,v_wind);   // Input/Output
 
     // Diagnose the second order moments
-    diag_second_shoc_moments(team,nlev,nlevi,thetal,qw,u_wind,v_wind,   // Input
+    // ASD
+    const Real thl2tune = 1.0;
+    const Real qw2tune = 1.0;
+    const Real qwthl2tune = 1.0;
+    const Real w2tune = 1.0;
+    diag_second_shoc_moments(team,nlev,nlevi,
+                             thl2tune, qw2tune, qwthl2tune, w2tune,     // Runtime options
+                             thetal,qw,u_wind,v_wind,                   // Input
                              tke,isotropy,tkh,tk,dz_zi,zt_grid,zi_grid, // Input
                              shoc_mix,wthl_sfc,wqw_sfc,uw_sfc,vw_sfc,   // Input
                              ustar2,wstar,                              // Input/Output
@@ -465,7 +472,14 @@ void Functions<S,D>::shoc_main_internal(
                                      thetal,qw,qtracers,tke,u_wind,v_wind);      // Input/Output
 
     // Diagnose the second order moments
-    diag_second_shoc_moments_disp(shcol,nlev,nlevi,thetal,qw,u_wind,v_wind,  // Input
+    // ASD
+    const Real thl2tune = 1.0;
+    const Real qw2tune = 1.0;
+    const Real qwthl2tune = 1.0;
+    const Real w2tune = 1.0;
+    diag_second_shoc_moments_disp(shcol,nlev,nlevi,
+                                  thl2tune, qw2tune, qwthl2tune, w2tune,     // Runtime options
+                                  thetal,qw,u_wind,v_wind,                   // Input
                                   tke,isotropy,tkh,tk,dz_zi,zt_grid,zi_grid, // Input
                                   shoc_mix,wthl_sfc,wqw_sfc,uw_sfc,vw_sfc,   // Input
                                   ustar2,wstar,                              // Input/Output

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -82,6 +82,7 @@ void Functions<S,D>::shoc_main_internal(
   const Scalar&                qwthl2tune,
   const Scalar&                w2tune,
   const Scalar&                length_fac,
+  const Scalar&                c_diag_3rd_mom,
   // Input Variables
   const Scalar&                dx,
   const Scalar&                dy,
@@ -240,7 +241,9 @@ void Functions<S,D>::shoc_main_internal(
 
     // Diagnose the third moment of vertical velocity,
     //  needed for the PDF closure
-    diag_third_shoc_moments(team,nlev,nlevi,w_sec,thl_sec,wthl_sec, // Input
+    diag_third_shoc_moments(team,nlev,nlevi,
+                            c_diag_3rd_mom,                         // Runtime options
+                            w_sec,thl_sec,wthl_sec,                 // Input
                             isotropy,brunt,thetal,tke,dz_zt,dz_zi,  // Input
                             zt_grid,zi_grid,                        // Input
                             workspace,                              // Workspace
@@ -328,6 +331,7 @@ void Functions<S,D>::shoc_main_internal(
   const Scalar&                qwthl2tune,
   const Scalar&                w2tune,
   const Scalar&                length_fac,
+  const Scalar&                c_diag_3rd_mom,
   // Input Variables
   const view_1d<const Scalar>& dx,
   const view_1d<const Scalar>& dy,
@@ -493,7 +497,9 @@ void Functions<S,D>::shoc_main_internal(
 
     // Diagnose the third moment of vertical velocity,
     //  needed for the PDF closure
-    diag_third_shoc_moments_disp(shcol,nlev,nlevi,w_sec,thl_sec,wthl_sec, // Input
+    diag_third_shoc_moments_disp(shcol,nlev,nlevi,
+                                 c_diag_3rd_mom,                         // Runtime options
+                                 w_sec,thl_sec,wthl_sec,                 // Input
                                  isotropy,brunt,thetal,tke,dz_zt,dz_zi,  // Input
                                  zt_grid,zi_grid,                        // Input
                                  workspace_mgr,                          // Workspace mgr
@@ -589,6 +595,7 @@ Int Functions<S,D>::shoc_main(
   const Scalar qwthl2tune    = shoc_runtime.qwthl2tune;
   const Scalar w2tune        = shoc_runtime.w2tune;
   const Scalar length_fac    = shoc_runtime.length_fac;
+  const Scalar c_diag_3rd_mom = 7.0; //c_diag_3rd_mom;
 
 #ifndef SCREAM_SMALL_KERNELS
   using ExeSpace = typename KT::ExeSpace;
@@ -650,6 +657,7 @@ Int Functions<S,D>::shoc_main(
     shoc_main_internal(team, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
 	               lambda_low, lambda_high, lambda_slope, lambda_thresh,  // Runtime options
                        thl2tune, qw2tune, qwthl2tune, w2tune, length_fac,     // Runtime options
+                       c_diag_3rd_mom,                                        // Runtime options
                        dx_s, dy_s, zt_grid_s, zi_grid_s,                      // Input
                        pres_s, presi_s, pdel_s, thv_s, w_field_s,             // Input
                        wthl_sfc_s, wqw_sfc_s, uw_sfc_s, vw_sfc_s,             // Input
@@ -673,6 +681,7 @@ Int Functions<S,D>::shoc_main(
   shoc_main_internal(shcol, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
     lambda_low, lambda_high, lambda_slope, lambda_thresh,  // Runtime options
     thl2tune, qw2tune, qwthl2tune, w2tune, length_fac,     // Runtime options
+    c_diag_3rd_mom,                                        // Runtime options
     shoc_input.dx, shoc_input.dy, shoc_input.zt_grid, shoc_input.zi_grid, // Input
     shoc_input.pres, shoc_input.presi, shoc_input.pdel, shoc_input.thv, shoc_input.w_field, // Input
     shoc_input.wthl_sfc, shoc_input.wqw_sfc, shoc_input.uw_sfc, shoc_input.vw_sfc, // Input

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -77,6 +77,10 @@ void Functions<S,D>::shoc_main_internal(
   const Scalar&                lambda_high,
   const Scalar&                lambda_slope,
   const Scalar&                lambda_thresh,
+  const Scalar&                thl2tune,
+  const Scalar&                qw2tune,
+  const Scalar&                qwthl2tune,
+  const Scalar&                w2tune,
   // Input Variables
   const Scalar&                dx,
   const Scalar&                dy,
@@ -221,11 +225,6 @@ void Functions<S,D>::shoc_main_internal(
                                 thetal,qw,qtracers,tke,u_wind,v_wind);   // Input/Output
 
     // Diagnose the second order moments
-    // ASD
-    const Real thl2tune = 1.0;
-    const Real qw2tune = 1.0;
-    const Real qwthl2tune = 1.0;
-    const Real w2tune = 1.0;
     diag_second_shoc_moments(team,nlev,nlevi,
                              thl2tune, qw2tune, qwthl2tune, w2tune,     // Runtime options
                              thetal,qw,u_wind,v_wind,                   // Input
@@ -321,6 +320,10 @@ void Functions<S,D>::shoc_main_internal(
   const Scalar&                lambda_high,
   const Scalar&                lambda_slope,
   const Scalar&                lambda_thresh,
+  const Scalar&                thl2tune,
+  const Scalar&                qw2tune,
+  const Scalar&                qwthl2tune,
+  const Scalar&                w2tune,
   // Input Variables
   const view_1d<const Scalar>& dx,
   const view_1d<const Scalar>& dy,
@@ -472,11 +475,6 @@ void Functions<S,D>::shoc_main_internal(
                                      thetal,qw,qtracers,tke,u_wind,v_wind);      // Input/Output
 
     // Diagnose the second order moments
-    // ASD
-    const Real thl2tune = 1.0;
-    const Real qw2tune = 1.0;
-    const Real qwthl2tune = 1.0;
-    const Real w2tune = 1.0;
     diag_second_shoc_moments_disp(shcol,nlev,nlevi,
                                   thl2tune, qw2tune, qwthl2tune, w2tune,     // Runtime options
                                   thetal,qw,u_wind,v_wind,                   // Input
@@ -580,6 +578,10 @@ Int Functions<S,D>::shoc_main(
   const Scalar lambda_high   = shoc_runtime.lambda_high;   
   const Scalar lambda_slope  = shoc_runtime.lambda_slope;  
   const Scalar lambda_thresh = shoc_runtime.lambda_thresh; 
+  const Scalar thl2tune      = shoc_runtime.thl2tune;
+  const Scalar qw2tune       = shoc_runtime.qw2tune;
+  const Scalar qwthl2tune    = shoc_runtime.qwthl2tune;
+  const Scalar w2tune        = shoc_runtime.w2tune;
 
 #ifndef SCREAM_SMALL_KERNELS
   using ExeSpace = typename KT::ExeSpace;
@@ -640,6 +642,7 @@ Int Functions<S,D>::shoc_main(
 
     shoc_main_internal(team, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
 	               lambda_low, lambda_high, lambda_slope, lambda_thresh,  // Runtime options
+                       thl2tune, qw2tune, qwthl2tune, w2tune,                 // Runtime options
                        dx_s, dy_s, zt_grid_s, zi_grid_s,                      // Input
                        pres_s, presi_s, pdel_s, thv_s, w_field_s,             // Input
                        wthl_sfc_s, wqw_sfc_s, uw_sfc_s, vw_sfc_s,             // Input
@@ -662,6 +665,7 @@ Int Functions<S,D>::shoc_main(
 
   shoc_main_internal(shcol, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
     lambda_low, lambda_high, lambda_slope, lambda_thresh,  // Runtime options
+    thl2tune, qw2tune, qwthl2tune, w2tune,                 // Runtime options
     shoc_input.dx, shoc_input.dy, shoc_input.zt_grid, shoc_input.zi_grid, // Input
     shoc_input.pres, shoc_input.presi, shoc_input.pdel, shoc_input.thv, shoc_input.w_field, // Input
     shoc_input.wthl_sfc, shoc_input.wqw_sfc, shoc_input.uw_sfc, shoc_input.vw_sfc, // Input

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -83,6 +83,8 @@ void Functions<S,D>::shoc_main_internal(
   const Scalar&                w2tune,
   const Scalar&                length_fac,
   const Scalar&                c_diag_3rd_mom,
+  const Scalar&                Ckh,
+  const Scalar&                Ckm,
   // Input Variables
   const Scalar&                dx,
   const Scalar&                dy,
@@ -210,7 +212,8 @@ void Functions<S,D>::shoc_main_internal(
 
     // Advance the SGS TKE equation
     shoc_tke(team,nlev,nlevi,dtime,              // Input
-	     lambda_low,lambda_high,lambda_slope,lambda_thresh, // Runtime options
+	     lambda_low,lambda_high,lambda_slope, // Runtime options
+	     lambda_thresh,Ckh,Ckm,              // Runtime options
 	     wthv_sec,                           // Input
              shoc_mix,dz_zi,dz_zt,pres,shoc_tabs,// Input
              u_wind,v_wind,brunt,zt_grid,        // Input
@@ -332,6 +335,8 @@ void Functions<S,D>::shoc_main_internal(
   const Scalar&                w2tune,
   const Scalar&                length_fac,
   const Scalar&                c_diag_3rd_mom,
+  const Scalar&                Ckh,
+  const Scalar&                Ckm,
   // Input Variables
   const view_1d<const Scalar>& dx,
   const view_1d<const Scalar>& dy,
@@ -467,7 +472,8 @@ void Functions<S,D>::shoc_main_internal(
 
     // Advance the SGS TKE equation
     shoc_tke_disp(shcol,nlev,nlevi,dtime,             // Input
-	          lambda_low,lambda_high,lambda_slope,lambda_thresh, // Runtime options
+	          lambda_low,lambda_high,lambda_slope, // Runtime options
+		  lambda_thresh,Ckh,Ckm,              // Runtime options
                   wthv_sec,                           // Input
                   shoc_mix,dz_zi,dz_zt,pres,shoc_tabs,// Input
                   u_wind,v_wind,brunt,zt_grid,        // Input
@@ -595,7 +601,9 @@ Int Functions<S,D>::shoc_main(
   const Scalar qwthl2tune    = shoc_runtime.qwthl2tune;
   const Scalar w2tune        = shoc_runtime.w2tune;
   const Scalar length_fac    = shoc_runtime.length_fac;
-  const Scalar c_diag_3rd_mom = 7.0; //c_diag_3rd_mom;
+  const Scalar c_diag_3rd_mom = shoc_runtime.c_diag_3rd_mom;
+  const Scalar Ckh           = shoc_runtime.Ckh;
+  const Scalar Ckm           = shoc_runtime.Ckm;
 
 #ifndef SCREAM_SMALL_KERNELS
   using ExeSpace = typename KT::ExeSpace;
@@ -657,7 +665,7 @@ Int Functions<S,D>::shoc_main(
     shoc_main_internal(team, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
 	               lambda_low, lambda_high, lambda_slope, lambda_thresh,  // Runtime options
                        thl2tune, qw2tune, qwthl2tune, w2tune, length_fac,     // Runtime options
-                       c_diag_3rd_mom,                                        // Runtime options
+                       c_diag_3rd_mom, Ckh, Ckm,                              // Runtime options
                        dx_s, dy_s, zt_grid_s, zi_grid_s,                      // Input
                        pres_s, presi_s, pdel_s, thv_s, w_field_s,             // Input
                        wthl_sfc_s, wqw_sfc_s, uw_sfc_s, vw_sfc_s,             // Input
@@ -681,7 +689,7 @@ Int Functions<S,D>::shoc_main(
   shoc_main_internal(shcol, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
     lambda_low, lambda_high, lambda_slope, lambda_thresh,  // Runtime options
     thl2tune, qw2tune, qwthl2tune, w2tune, length_fac,     // Runtime options
-    c_diag_3rd_mom,                                        // Runtime options
+    c_diag_3rd_mom, Ckh, Ckm,                              // Runtime options
     shoc_input.dx, shoc_input.dy, shoc_input.zt_grid, shoc_input.zi_grid, // Input
     shoc_input.pres, shoc_input.presi, shoc_input.pdel, shoc_input.thv, shoc_input.w_field, // Input
     shoc_input.wthl_sfc, shoc_input.wqw_sfc, shoc_input.uw_sfc, shoc_input.vw_sfc, // Input

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -81,6 +81,7 @@ void Functions<S,D>::shoc_main_internal(
   const Scalar&                qw2tune,
   const Scalar&                qwthl2tune,
   const Scalar&                w2tune,
+  const Scalar&                length_fac,
   // Input Variables
   const Scalar&                dx,
   const Scalar&                dy,
@@ -198,7 +199,9 @@ void Functions<S,D>::shoc_main_internal(
             pblh);                    // Output
 
     // Update the turbulent length scale
-    shoc_length(team,nlev,nlevi,dx,dy, // Input
+    shoc_length(team,nlev,nlevi,       // Input
+                length_fac,            // Runtime Options
+                dx,dy,                 // Input
                 zt_grid,zi_grid,dz_zt, // Input
                 tke,thv,               // Input
                 workspace,             // Workspace
@@ -324,6 +327,7 @@ void Functions<S,D>::shoc_main_internal(
   const Scalar&                qw2tune,
   const Scalar&                qwthl2tune,
   const Scalar&                w2tune,
+  const Scalar&                length_fac,
   // Input Variables
   const view_1d<const Scalar>& dx,
   const view_1d<const Scalar>& dy,
@@ -449,7 +453,9 @@ void Functions<S,D>::shoc_main_internal(
                  pblh);                    // Output
 
     // Update the turbulent length scale
-    shoc_length_disp(shcol,nlev,nlevi,dx,dy, // Input
+    shoc_length_disp(shcol,nlev,nlevi,      // Input
+                     length_fac,            // Runtime Options
+                     dx,dy,                 // Input
                      zt_grid,zi_grid,dz_zt, // Input
                      tke,thv,               // Input
                      workspace_mgr,         // Workspace mgr
@@ -582,6 +588,7 @@ Int Functions<S,D>::shoc_main(
   const Scalar qw2tune       = shoc_runtime.qw2tune;
   const Scalar qwthl2tune    = shoc_runtime.qwthl2tune;
   const Scalar w2tune        = shoc_runtime.w2tune;
+  const Scalar length_fac    = shoc_runtime.length_fac;
 
 #ifndef SCREAM_SMALL_KERNELS
   using ExeSpace = typename KT::ExeSpace;
@@ -642,7 +649,7 @@ Int Functions<S,D>::shoc_main(
 
     shoc_main_internal(team, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
 	               lambda_low, lambda_high, lambda_slope, lambda_thresh,  // Runtime options
-                       thl2tune, qw2tune, qwthl2tune, w2tune,                 // Runtime options
+                       thl2tune, qw2tune, qwthl2tune, w2tune, length_fac,     // Runtime options
                        dx_s, dy_s, zt_grid_s, zi_grid_s,                      // Input
                        pres_s, presi_s, pdel_s, thv_s, w_field_s,             // Input
                        wthl_sfc_s, wqw_sfc_s, uw_sfc_s, vw_sfc_s,             // Input
@@ -665,7 +672,7 @@ Int Functions<S,D>::shoc_main(
 
   shoc_main_internal(shcol, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
     lambda_low, lambda_high, lambda_slope, lambda_thresh,  // Runtime options
-    thl2tune, qw2tune, qwthl2tune, w2tune,                 // Runtime options
+    thl2tune, qw2tune, qwthl2tune, w2tune, length_fac,     // Runtime options
     shoc_input.dx, shoc_input.dy, shoc_input.zt_grid, shoc_input.zi_grid, // Input
     shoc_input.pres, shoc_input.presi, shoc_input.pdel, shoc_input.thv, shoc_input.w_field, // Input
     shoc_input.wthl_sfc, shoc_input.wqw_sfc, shoc_input.uw_sfc, shoc_input.vw_sfc, // Input

--- a/components/eamxx/src/physics/shoc/impl/shoc_tke_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_tke_impl.hpp
@@ -28,6 +28,8 @@ void Functions<S,D>::shoc_tke(
   const Scalar&                lambda_high,
   const Scalar&                lambda_slope,
   const Scalar&                lambda_thresh,
+  const Scalar&                Ckh,
+  const Scalar&                Ckm,
   const uview_1d<const Spack>& wthv_sec,
   const uview_1d<const Spack>& shoc_mix,
   const uview_1d<const Spack>& dz_zi,
@@ -71,7 +73,7 @@ void Functions<S,D>::shoc_tke(
   isotropic_ts(team,nlev,lambda_low,lambda_high,lambda_slope,lambda_thresh,brunt_int,tke,a_diss,brunt,isotropy);
 
   // Compute eddy diffusivity for heat and momentum
-  eddy_diffusivities(team,nlev,pblh,zt_grid,tabs,shoc_mix,sterm_zt,isotropy,tke,tkh,tk);
+  eddy_diffusivities(team,nlev,Ckh,Ckm,pblh,zt_grid,tabs,shoc_mix,sterm_zt,isotropy,tke,tkh,tk);
 
   // Release temporary variables from the workspace
   workspace.template release_many_contiguous<3>(

--- a/components/eamxx/src/physics/shoc/shoc_constants.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_constants.hpp
@@ -16,7 +16,6 @@ struct Constants
     static constexpr Scalar minlen         = 20.0;         // Lower limit for mixing length [m]
     static constexpr Scalar maxlen         = 20000.0;      // Upper limit for mixing length [m]
     static constexpr Scalar maxiso         = 20000.0;      // Upper limit for isotropy time scale [s]
-    static constexpr Scalar length_fac     = 0.5;          // Mixing length scaling parameter
     static constexpr Scalar c_diag_3rd_mom = 7.0;          // Coefficient for diag third moment parameters
     static constexpr Scalar w3clip         = 1.2;          // Third moment of vertical velocity
     static constexpr Scalar ustar_min      = 0.01;         // Minimum surface friction velocity

--- a/components/eamxx/src/physics/shoc/shoc_constants.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_constants.hpp
@@ -16,7 +16,6 @@ struct Constants
     static constexpr Scalar minlen         = 20.0;         // Lower limit for mixing length [m]
     static constexpr Scalar maxlen         = 20000.0;      // Upper limit for mixing length [m]
     static constexpr Scalar maxiso         = 20000.0;      // Upper limit for isotropy time scale [s]
-    static constexpr Scalar c_diag_3rd_mom = 7.0;          // Coefficient for diag third moment parameters
     static constexpr Scalar w3clip         = 1.2;          // Third moment of vertical velocity
     static constexpr Scalar ustar_min      = 0.01;         // Minimum surface friction velocity
     static constexpr Scalar largeneg       = -99999999.99; // Large negative value used for linear_interp threshold

--- a/components/eamxx/src/physics/shoc/shoc_functions.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions.hpp
@@ -374,6 +374,7 @@ struct Functions
 
   KOKKOS_FUNCTION
   static void diag_second_moments(const MemberType& team, const Int& nlev, const Int& nlevi,
+     const Real& thl2tune, const Real& qw2tune, const Real& qwthl2tune, const Real& w2tune,
      const uview_1d<const Spack>& thetal, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& u_wind,
      const uview_1d<const Spack>& v_wind, const uview_1d<const Spack>& tke, const uview_1d<const Spack>& isotropy,
      const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& dz_zi,
@@ -385,6 +386,7 @@ struct Functions
 
   KOKKOS_FUNCTION
   static void diag_second_shoc_moments(const MemberType& team, const Int& nlev, const Int& nlevi,
+     const Scalar& thl2tune, const Scalar& qw2tune, const Scalar& qwthl2tune, const Scalar& w2tune,
      const uview_1d<const Spack>& thetal, const uview_1d<const Spack>& qw, const uview_1d<const Spack>& u_wind,
      const uview_1d<const Spack>& v_wind, const uview_1d<const Spack>& tke, const uview_1d<const Spack>& isotropy,
      const uview_1d<const Spack>& tkh, const uview_1d<const Spack>& tk, const uview_1d<const Spack>& dz_zi,
@@ -396,6 +398,10 @@ struct Functions
 #ifdef SCREAM_SMALL_KERNELS
   static void diag_second_shoc_moments_disp(
     const Int& shcol, const Int& nlev, const Int& nlevi,
+    const Scalar& thl2tune, 
+    const Scalar& qw2tune, 
+    const Scalar& qwthl2tune, 
+    const Scalar& w2tune,
     const view_2d<const Spack>& thetal,
     const view_2d<const Spack>& qw,
     const view_2d<const Spack>& u_wind,

--- a/components/eamxx/src/physics/shoc/shoc_functions.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions.hpp
@@ -77,6 +77,10 @@ struct Functions
    Scalar lambda_high;
    Scalar lambda_slope;
    Scalar lambda_thresh;
+   Scalar thl2tune;
+   Scalar qw2tune;
+   Scalar qwthl2tune;
+   Scalar w2tune;
  };
 
   // This struct stores input views for shoc_main.
@@ -832,6 +836,10 @@ struct Functions
     const Scalar&                lambda_high,
     const Scalar&                lambda_slope,
     const Scalar&                lambda_thresh,
+    const Scalar&                thl2tune,
+    const Scalar&                qw2tune,
+    const Scalar&                qwthl2tune,
+    const Scalar&                w2tune,
     // Input Variables
     const Scalar&                host_dx,
     const Scalar&                host_dy,
@@ -895,6 +903,10 @@ struct Functions
     const Scalar&                lambda_high,
     const Scalar&                lambda_slope,
     const Scalar&                lambda_thresh,
+    const Scalar&                thl2tune,
+    const Scalar&                qw2tune,
+    const Scalar&                qwthl2tune,
+    const Scalar&                w2tune,
     // Input Variables
     const view_1d<const Scalar>& host_dx,
     const view_1d<const Scalar>& host_dy,

--- a/components/eamxx/src/physics/shoc/shoc_functions.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions.hpp
@@ -82,6 +82,7 @@ struct Functions
    Scalar qwthl2tune;
    Scalar w2tune;
    Scalar length_fac;
+   Scalar c_diag_3rd_mom;
  };
 
   // This struct stores input views for shoc_main.
@@ -282,6 +283,7 @@ struct Functions
     const MemberType& team,
     const Int& nlev,
     const Int& nlevi,
+    const Scalar& c_diag_3rd_mom,
     const uview_1d<const Spack>& w_sec,
     const uview_1d<const Spack>& thl_sec,
     const uview_1d<const Spack>& wthl_sec,
@@ -675,6 +677,7 @@ struct Functions
     const MemberType&            team,
     const Int&                   nlev,
     const Int&                   nlevi,
+    const Scalar&                c_diag_3rd_mom,
     const uview_1d<const Spack>& w_sec,
     const uview_1d<const Spack>& thl_sec,
     const uview_1d<const Spack>& wthl_sec,
@@ -693,6 +696,7 @@ struct Functions
     const Int&                  shcol,
     const Int&                  nlev,
     const Int&                  nlevi,
+    const Scalar&               c_diag_3rd_mom,
     const view_2d<const Spack>& w_sec,
     const view_2d<const Spack>& thl_sec,
     const view_2d<const Spack>& wthl_sec,
@@ -845,6 +849,7 @@ struct Functions
     const Scalar&                qwthl2tune,
     const Scalar&                w2tune,
     const Scalar&                length_fac,
+    const Scalar&                c_diag_3rd_mom,
     // Input Variables
     const Scalar&                host_dx,
     const Scalar&                host_dy,
@@ -913,6 +918,7 @@ struct Functions
     const Scalar&                qwthl2tune,
     const Scalar&                w2tune,
     const Scalar&                length_fac,
+    const Scalar&                c_diag_3rd_mom,
     // Input Variables
     const view_1d<const Scalar>& host_dx,
     const view_1d<const Scalar>& host_dy,

--- a/components/eamxx/src/physics/shoc/shoc_functions.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions.hpp
@@ -81,6 +81,7 @@ struct Functions
    Scalar qw2tune;
    Scalar qwthl2tune;
    Scalar w2tune;
+   Scalar length_fac;
  };
 
   // This struct stores input views for shoc_main.
@@ -303,6 +304,7 @@ struct Functions
   static void compute_shoc_mix_shoc_length(
     const MemberType&            team,
     const Int&                   nlev,
+    const Scalar&                length_fac,
     const uview_1d<const Spack>& tke,
     const uview_1d<const Spack>& brunt,
     const uview_1d<const Spack>& zt_grid,
@@ -501,6 +503,7 @@ struct Functions
     const MemberType&            team,
     const Int&                   nlev,
     const Int&                   nlevi,
+    const Scalar&                length_fac,
     const Scalar&                dx,
     const Scalar&                dy,
     const uview_1d<const Spack>& zt_grid,
@@ -516,6 +519,7 @@ struct Functions
     const Int&                   shcol,
     const Int&                   nlev,
     const Int&                   nlevi,
+    const Scalar&                length_fac,
     const view_1d<const Scalar>& dx,
     const view_1d<const Scalar>& dy,
     const view_2d<const Spack>&  zt_grid,
@@ -840,6 +844,7 @@ struct Functions
     const Scalar&                qw2tune,
     const Scalar&                qwthl2tune,
     const Scalar&                w2tune,
+    const Scalar&                length_fac,
     // Input Variables
     const Scalar&                host_dx,
     const Scalar&                host_dy,
@@ -907,6 +912,7 @@ struct Functions
     const Scalar&                qw2tune,
     const Scalar&                qwthl2tune,
     const Scalar&                w2tune,
+    const Scalar&                length_fac,
     // Input Variables
     const view_1d<const Scalar>& host_dx,
     const view_1d<const Scalar>& host_dy,

--- a/components/eamxx/src/physics/shoc/shoc_functions.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions.hpp
@@ -83,6 +83,8 @@ struct Functions
    Scalar w2tune;
    Scalar length_fac;
    Scalar c_diag_3rd_mom;
+   Scalar Ckh;
+   Scalar Ckm;
  };
 
   // This struct stores input views for shoc_main.
@@ -850,6 +852,8 @@ struct Functions
     const Scalar&                w2tune,
     const Scalar&                length_fac,
     const Scalar&                c_diag_3rd_mom,
+    const Scalar&                Ckh,
+    const Scalar&                Ckm,
     // Input Variables
     const Scalar&                host_dx,
     const Scalar&                host_dy,
@@ -919,6 +923,8 @@ struct Functions
     const Scalar&                w2tune,
     const Scalar&                length_fac,
     const Scalar&                c_diag_3rd_mom,
+    const Scalar&                Ckh,
+    const Scalar&                Ckm,
     // Input Variables
     const view_1d<const Scalar>& host_dx,
     const view_1d<const Scalar>& host_dy,
@@ -1125,6 +1131,8 @@ struct Functions
   static void eddy_diffusivities(
     const MemberType&            team,
     const Int&                   nlev,
+    const Scalar&                Ckh,
+    const Scalar&                Ckm,
     const Scalar&                pblh,
     const uview_1d<const Spack>& zt_grid,
     const uview_1d<const Spack>& tabs,
@@ -1145,6 +1153,8 @@ struct Functions
     const Scalar&                lambda_high,
     const Scalar&                lambda_slope,
     const Scalar&                lambda_thresh,
+    const Scalar&                Ckh,
+    const Scalar&                Ckm,
     const uview_1d<const Spack>& wthv_sec,
     const uview_1d<const Spack>& shoc_mix,
     const uview_1d<const Spack>& dz_zi,
@@ -1172,6 +1182,8 @@ struct Functions
     const Scalar&                lambda_high,
     const Scalar&                lambda_slope,
     const Scalar&                lambda_thresh,
+    const Scalar&                Ckh,
+    const Scalar&                Ckm,
     const view_2d<const Spack>&  wthv_sec,
     const view_2d<const Spack>&  shoc_mix,
     const view_2d<const Spack>&  dz_zi,

--- a/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
@@ -1132,7 +1132,9 @@ void compute_diag_third_shoc_moment_f(Int shcol, Int nlev, Int nlevi, Real* w_se
     const auto thetal_zi_s   = ekat::subview(thetal_zi_d, i);
     const auto w3_s          = ekat::subview(w3_d, i);
 
-    SHF::compute_diag_third_shoc_moment(team, nlev, nlevi, w_sec_s, thl_sec_s,
+    // Hardcode runtime options for F90 testing
+    const Real c_diag_3rd_mom = 7.0;
+    SHF::compute_diag_third_shoc_moment(team, nlev, nlevi, c_diag_3rd_mom, w_sec_s, thl_sec_s,
                                         wthl_sec_s, tke_s, dz_zt_s, dz_zi_s, isotropy_zi_s,
                                         brunt_zi_s, w_sec_zi_s, thetal_zi_s, w3_s);
   });
@@ -2325,7 +2327,9 @@ void diag_third_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* w_sec, Real
     const auto zi_grid_s = ekat::subview(zi_grid_d, i);
     const auto w3_s = ekat::subview(w3_d, i);
 
-    SHF::diag_third_shoc_moments(team, nlev, nlevi, wsec_s, thl_sec_s,
+    // Hardcode for F90 testing
+    const Real c_diag_3rd_mom = 7.0;
+    SHF::diag_third_shoc_moments(team, nlev, nlevi, c_diag_3rd_mom, wsec_s, thl_sec_s,
                                  wthl_sec_s, isotropy_s, brunt_s, thetal_s, tke_s,
                                  dz_zt_s, dz_zi_s, zt_grid_s, zi_grid_s,
                                  workspace,
@@ -2880,7 +2884,7 @@ Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, 
                                              qwthl_sec_d, wthl_sec_d, wqw_sec_d, wtke_sec_d,
                                              uw_sec_d,    vw_sec_d,   w3_d,      wqls_sec_d,
                                              brunt_d,     isotropy_d};
-  SHF::SHOCRuntime shoc_runtime_options{0.001,0.04,2.65,0.02,1.0,1.0,1.0,1.0,0.5};
+  SHF::SHOCRuntime shoc_runtime_options{0.001,0.04,2.65,0.02,1.0,1.0,1.0,1.0,0.5,7.0};
 
   const auto nlevi_packs = ekat::npack<Spack>(nlevi);
 

--- a/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
@@ -1525,6 +1525,11 @@ void diag_second_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* q
   const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
+    // Hardcode runtime options for F90
+    const Real thl2tune = 1.0;
+    const Real qw2tune = 1.0;
+    const Real qwthl2tune = 1.0;
+    const Real w2tune = 1.0;
 
     const auto thetal_1d      = ekat::subview(thetal_2d, i);
     const auto qw_1d          = ekat::subview(qw_2d, i);
@@ -1551,7 +1556,8 @@ void diag_second_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* q
     const auto tkh_zi_1d      = ekat::subview(tkh_zi_2d, i);
     const auto tk_zi_1d       = ekat::subview(tk_zi_2d, i);
 
-    SHOC::diag_second_moments(team, nlev, nlevi, thetal_1d, qw_1d, u_wind_1d, v_wind_1d, tke_1d, isotropy_1d, tkh_1d, tk_1d,
+    SHOC::diag_second_moments(team, nlev, nlevi, thl2tune, qw2tune, qwthl2tune, w2tune,
+                     thetal_1d, qw_1d, u_wind_1d, v_wind_1d, tke_1d, isotropy_1d, tkh_1d, tk_1d,
                      dz_zi_1d, zt_grid_1d, zi_grid_1d, shoc_mix_1d, isotropy_zi_1d, tkh_zi_1d, tk_zi_1d,
                      thl_sec_1d, qw_sec_1d, wthl_sec_1d, wqw_sec_1d,
                      qwthl_sec_1d, uw_sec_1d, vw_sec_1d, wtke_sec_1d, w_sec_1d);
@@ -1632,6 +1638,11 @@ void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Re
 
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
+    // Hardcode runtime options for F90
+    const Real thl2tune = 1.0;
+    const Real qw2tune = 1.0;
+    const Real qwthl2tune = 1.0;
+    const Real w2tune = 1.0;
 
     auto workspace = workspace_mgr.get_workspace(team);
 
@@ -1665,6 +1676,7 @@ void diag_second_shoc_moments_f(Int shcol, Int nlev, Int nlevi, Real* thetal, Re
     Scalar wstar_s  = wstar_1d(i);
 
     SHOC::diag_second_shoc_moments(team, nlev, nlevi,
+       thl2tune, qw2tune, qwthl2tune, w2tune,
        thetal_1d, qw_1d, u_wind_1d, v_wind_1d, tke_1d, isotropy_1d, tkh_1d, tk_1d, dz_zi_1d, zt_grid_1d, zi_grid_1d, shoc_mix_1d,
        wthl_s, wqw_s, uw_s, vw_s, ustar2_s, wstar_s,
        workspace, thl_sec_1d, qw_sec_1d, wthl_sec_1d, wqw_sec_1d, qwthl_sec_1d,

--- a/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
@@ -1222,7 +1222,8 @@ void compute_shoc_mix_shoc_length_f(Int nlev, Int shcol, Real* tke, Real* brunt,
     const auto zt_grid_s  = ekat::subview(zt_grid_d, i);
     const auto shoc_mix_s = ekat::subview(shoc_mix_d, i);
 
-    SHF::compute_shoc_mix_shoc_length(team, nlev, tke_s, brunt_s, zt_grid_s, l_inf_s,
+    const Real length_fac = 0.5;
+    SHF::compute_shoc_mix_shoc_length(team, nlev, length_fac, tke_s, brunt_s, zt_grid_s, l_inf_s,
                                       shoc_mix_s);
   });
 
@@ -1979,7 +1980,9 @@ void shoc_length_f(Int shcol, Int nlev, Int nlevi, Real* host_dx, Real* host_dy,
     const auto brunt_s = ekat::subview(brunt_d, i);
     const auto shoc_mix_s = ekat::subview(shoc_mix_d, i);
 
-    SHF::shoc_length(team,nlev,nlevi,host_dx_s,host_dy_s,
+    // Hardcode runtime option for F90 tests.
+    const Scalar length_fac = 0.5;
+    SHF::shoc_length(team,nlev,nlevi,length_fac,host_dx_s,host_dy_s,
                      zt_grid_s,zi_grid_s,dz_zt_s,tke_s,
                      thv_s,workspace,brunt_s,shoc_mix_s);
   });
@@ -2877,7 +2880,7 @@ Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, 
                                              qwthl_sec_d, wthl_sec_d, wqw_sec_d, wtke_sec_d,
                                              uw_sec_d,    vw_sec_d,   w3_d,      wqls_sec_d,
                                              brunt_d,     isotropy_d};
-  SHF::SHOCRuntime shoc_runtime_options{0.001,0.04,2.65,0.02,1.0,1.0,1.0,1.0};
+  SHF::SHOCRuntime shoc_runtime_options{0.001,0.04,2.65,0.02,1.0,1.0,1.0,1.0,0.5};
 
   const auto nlevi_packs = ekat::npack<Spack>(nlevi);
 

--- a/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
@@ -2884,7 +2884,7 @@ Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, 
                                              qwthl_sec_d, wthl_sec_d, wqw_sec_d, wtke_sec_d,
                                              uw_sec_d,    vw_sec_d,   w3_d,      wqls_sec_d,
                                              brunt_d,     isotropy_d};
-  SHF::SHOCRuntime shoc_runtime_options{0.001,0.04,2.65,0.02,1.0,1.0,1.0,1.0,0.5,7.0};
+  SHF::SHOCRuntime shoc_runtime_options{0.001,0.04,2.65,0.02,1.0,1.0,1.0,1.0,0.5,7.0,0.1,0.1};
 
   const auto nlevi_packs = ekat::npack<Spack>(nlevi);
 
@@ -3217,7 +3217,10 @@ void eddy_diffusivities_f(Int nlev, Int shcol, Real* pblh, Real* zt_grid, Real* 
     const auto tkh_s = ekat::subview(tkh_d, i);
     const auto tk_s = ekat::subview(tk_d, i);
 
-    SHF::eddy_diffusivities(team, nlev, pblh_s, zt_grid_s, tabs_s, shoc_mix_s, sterm_zt_s, isotropy_s, tke_s, tkh_s, tk_s);
+    // Hardcode runtime options for F90 testing
+    const Real Ckh = 0.1;
+    const Real Ckm = 0.1;
+    SHF::eddy_diffusivities(team, nlev, Ckh, Ckm, pblh_s, zt_grid_s, tabs_s, shoc_mix_s, sterm_zt_s, isotropy_s, tke_s, tkh_s, tk_s);
   });
 
   // Sync back to host
@@ -3477,11 +3480,16 @@ void shoc_tke_f(Int shcol, Int nlev, Int nlevi, Real dtime, Real* wthv_sec, Real
     const auto tkh_s = ekat::subview(tkh_d, i);
     const auto isotropy_s = ekat::subview(isotropy_d, i);
 
-    const Real lambda_low    = 0.001;  //ASD
+    // Hardcode for F90 testing
+    const Real lambda_low    = 0.001;  
     const Real lambda_high   = 0.04;
     const Real lambda_slope  = 2.65;
     const Real lambda_thresh = 0.02;
+    const Real Ckh           = 0.1;
+    const Real Ckm           = 0.1;
+
     SHF::shoc_tke(team,nlev,nlevi,dtime,lambda_low,lambda_high,lambda_slope,lambda_thresh,
+                  Ckh, Ckm,
 		  wthv_sec_s,shoc_mix_s,dz_zi_s,dz_zt_s,pres_s,
                   tabs_s,u_wind_s,v_wind_s,brunt_s,zt_grid_s,zi_grid_s,pblh_s,
                   workspace,

--- a/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
@@ -2660,7 +2660,8 @@ void isotropic_ts_f(Int nlev, Int shcol, Real* brunt_int, Real* tke,
       //outputs
       const auto isotropy_s = ekat::subview(isotropy_d, i); //output
 
-      const Real lambda_low = 0.001; //ASD
+      // Hard code these runtime options for F90
+      const Real lambda_low = 0.001; 
       const Real lambda_high   = 0.04;
       const Real lambda_slope  = 2.65;
       const Real lambda_thresh = 0.02;
@@ -2876,7 +2877,7 @@ Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, 
                                              qwthl_sec_d, wthl_sec_d, wqw_sec_d, wtke_sec_d,
                                              uw_sec_d,    vw_sec_d,   w3_d,      wqls_sec_d,
                                              brunt_d,     isotropy_d};
-  SHF::SHOCRuntime shoc_runtime_options{0.001,0.04,2.65,0.02};
+  SHF::SHOCRuntime shoc_runtime_options{0.001,0.04,2.65,0.02,1.0,1.0,1.0,1.0};
 
   const auto nlevi_packs = ekat::npack<Spack>(nlevi);
 

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -53,6 +53,7 @@ atmosphere_processes:
         qw2tune: 1.0
         qwthl2tune: 1.0
         w2tune: 1.0
+        length_fac: 0.5
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -55,6 +55,8 @@ atmosphere_processes:
         w2tune: 1.0
         length_fac: 0.5
         c_diag_3rd_mom: 7.0
+        Ckh: 0.1
+        Ckm: 0.1
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -49,6 +49,10 @@ atmosphere_processes:
         lambda_high: 0.04
         lambda_slope: 2.65
         lambda_thresh: 0.02
+        thl2tune: 1.0
+        qw2tune: 1.0
+        qwthl2tune: 1.0
+        w2tune: 1.0
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -54,6 +54,7 @@ atmosphere_processes:
         qwthl2tune: 1.0
         w2tune: 1.0
         length_fac: 0.5
+        c_diag_3rd_mom: 7.0
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -47,6 +47,8 @@ atmosphere_processes:
         w2tune: 1.0
         length_fac: 0.5
         c_diag_3rd_mom: 7.0
+        Ckh: 0.1
+        Ckm: 0.1
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -45,6 +45,7 @@ atmosphere_processes:
         qw2tune: 1.0
         qwthl2tune: 1.0
         w2tune: 1.0
+        length_fac: 0.5
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -46,6 +46,7 @@ atmosphere_processes:
         qwthl2tune: 1.0
         w2tune: 1.0
         length_fac: 0.5
+        c_diag_3rd_mom: 7.0
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -33,14 +33,18 @@ atmosphere_processes:
       spa:
         spa_remap_file: ${SCREAM_DATA_DIR}/maps/map_ne4np4_to_ne2np4_mono.nc
         spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
+      p3:
+        max_total_ni: 740.0e3
       shoc:
         check_flux_state_consistency: true
         lambda_low: 0.001
         lambda_high: 0.04
         lambda_slope: 2.65
         lambda_thresh: 0.02
-      p3:
-        max_total_ni: 740.0e3
+        thl2tune: 1.0
+        qw2tune: 1.0
+        qwthl2tune: 1.0
+        w2tune: 1.0
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -47,6 +47,8 @@ atmosphere_processes:
         w2tune: 1.0
         length_fac: 0.5
         c_diag_3rd_mom: 7.0
+        Ckh: 0.1
+        Ckm: 0.1
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -34,13 +34,17 @@ atmosphere_processes:
       spa:
         spa_remap_file: ${SCREAM_DATA_DIR}/maps/map_ne4np4_to_ne2np4_mono.nc
         spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
+      p3:
+        max_total_ni: 740.0e3
       shoc:
         lambda_low: 0.001
         lambda_high: 0.04
         lambda_slope: 2.65
         lambda_thresh: 0.02
-      p3:
-        max_total_ni: 740.0e3
+        thl2tune: 1.0
+        qw2tune: 1.0
+        qwthl2tune: 1.0
+        w2tune: 1.0
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -45,6 +45,7 @@ atmosphere_processes:
         qw2tune: 1.0
         qwthl2tune: 1.0
         w2tune: 1.0
+        length_fac: 0.5
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -46,6 +46,7 @@ atmosphere_processes:
         qwthl2tune: 1.0
         w2tune: 1.0
         length_fac: 0.5
+        c_diag_3rd_mom: 7.0
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
@@ -54,6 +54,8 @@ atmosphere_processes:
         w2tune: 1.0
         length_fac: 0.5
         c_diag_3rd_mom: 7.0
+        Ckh: 0.1
+        Ckm: 0.1
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
@@ -41,13 +41,17 @@ atmosphere_processes:
       spa:
         spa_remap_file: ${SCREAM_DATA_DIR}/maps/map_ne4np4_to_ne2np4_mono.nc
         spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
+      p3:
+        max_total_ni: 740.0e3
       shoc:
         lambda_low: 0.001
         lambda_high: 0.04
         lambda_slope: 2.65
         lambda_thresh: 0.02
-      p3:
-        max_total_ni: 740.0e3
+        thl2tune: 1.0
+        qw2tune: 1.0
+        qwthl2tune: 1.0
+        w2tune: 1.0
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
@@ -52,6 +52,7 @@ atmosphere_processes:
         qw2tune: 1.0
         qwthl2tune: 1.0
         w2tune: 1.0
+        length_fac: 0.5
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
@@ -53,6 +53,7 @@ atmosphere_processes:
         qwthl2tune: 1.0
         w2tune: 1.0
         length_fac: 0.5
+        c_diag_3rd_mom: 7.0
     rrtmgp:
       column_chunk_size: 123
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -48,6 +48,7 @@ atmosphere_processes:
         qw2tune: 1.0
         qwthl2tune: 1.0
         w2tune: 1.0
+        length_fac: 0.5
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -44,6 +44,10 @@ atmosphere_processes:
         lambda_high: 0.04
         lambda_slope: 2.65
         lambda_thresh: 0.02
+        thl2tune: 1.0
+        qw2tune: 1.0
+        qwthl2tune: 1.0
+        w2tune: 1.0
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -50,6 +50,8 @@ atmosphere_processes:
         w2tune: 1.0
         length_fac: 0.5
         c_diag_3rd_mom: 7.0
+        Ckh: 0.1
+        Ckm: 0.1
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -49,6 +49,7 @@ atmosphere_processes:
         qwthl2tune: 1.0
         w2tune: 1.0
         length_fac: 0.5
+        c_diag_3rd_mom: 7.0
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -48,6 +48,7 @@ atmosphere_processes:
         qw2tune: 1.0
         qwthl2tune: 1.0
         w2tune: 1.0
+        length_fac: 0.5
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -44,6 +44,10 @@ atmosphere_processes:
         lambda_high: 0.04
         lambda_slope: 2.65
         lambda_thresh: 0.02
+        thl2tune: 1.0
+        qw2tune: 1.0
+        qwthl2tune: 1.0
+        w2tune: 1.0
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -50,6 +50,8 @@ atmosphere_processes:
         w2tune: 1.0
         length_fac: 0.5
         c_diag_3rd_mom: 7.0
+        Ckh: 0.1
+        Ckm: 0.1
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -49,6 +49,7 @@ atmosphere_processes:
         qwthl2tune: 1.0
         w2tune: 1.0
         length_fac: 0.5
+        c_diag_3rd_mom: 7.0
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -40,6 +40,8 @@ atmosphere_processes:
         w2tune: 1.0
         length_fac: 0.5
         c_diag_3rd_mom: 7.0
+        Ckh: 0.1
+        Ckm: 0.1
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -39,6 +39,7 @@ atmosphere_processes:
         qwthl2tune: 1.0
         w2tune: 1.0
         length_fac: 0.5
+        c_diag_3rd_mom: 7.0
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -34,6 +34,10 @@ atmosphere_processes:
         lambda_high: 0.04
         lambda_slope: 2.65
         lambda_thresh: 0.02
+        thl2tune: 1.0
+        qw2tune: 1.0
+        qwthl2tune: 1.0
+        w2tune: 1.0
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_restarted.yaml
@@ -38,6 +38,7 @@ atmosphere_processes:
         qw2tune: 1.0
         qwthl2tune: 1.0
         w2tune: 1.0
+        length_fac: 0.5
     rrtmgp:
       active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]
       do_aerosol_rad: false

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -12,13 +12,17 @@ atmosphere_processes:
   schedule_type: Sequential
   atm_procs_list: [shoc,p3]
   number_of_subcycles: ${NUM_SUBCYCLES}
+  p3:
+    max_total_ni: 740.0e3
   shoc:
     lambda_low: 0.001
     lambda_high: 0.04
     lambda_slope: 2.65
     lambda_thresh: 0.02
-  p3:
-    max_total_ni: 740.0e3
+    thl2tune: 1.0
+    qw2tune: 1.0
+    qwthl2tune: 1.0
+    w2tune: 1.0
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -23,6 +23,7 @@ atmosphere_processes:
     qw2tune: 1.0
     qwthl2tune: 1.0
     w2tune: 1.0
+    length_fac: 0.5
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -24,6 +24,7 @@ atmosphere_processes:
     qwthl2tune: 1.0
     w2tune: 1.0
     length_fac: 0.5
+    c_diag_3rd_mom: 7.0
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -25,6 +25,8 @@ atmosphere_processes:
     w2tune: 1.0
     length_fac: 0.5
     c_diag_3rd_mom: 7.0
+    Ckh: 0.1
+    Ckm: 0.1
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -24,6 +24,10 @@ atmosphere_processes:
       lambda_high: 0.04
       lambda_slope: 2.65
       lambda_thresh: 0.02
+      thl2tune: 1.0
+      qw2tune: 1.0
+      qwthl2tune: 1.0
+      w2tune: 1.0
   rrtmgp:
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -28,6 +28,7 @@ atmosphere_processes:
       qw2tune: 1.0
       qwthl2tune: 1.0
       w2tune: 1.0
+      length_fac: 0.5
   rrtmgp:
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -29,6 +29,7 @@ atmosphere_processes:
       qwthl2tune: 1.0
       w2tune: 1.0
       length_fac: 0.5
+      c_diag_3rd_mom: 7.0
   rrtmgp:
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -30,6 +30,8 @@ atmosphere_processes:
       w2tune: 1.0
       length_fac: 0.5
       c_diag_3rd_mom: 7.0
+      Ckh: 0.1
+      Ckm: 0.1
   rrtmgp:
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -19,13 +19,17 @@ atmosphere_processes:
     spa:
       spa_remap_file: ${SCREAM_DATA_DIR}/maps/map_ne4np4_to_ne2np4_mono.nc
       spa_data_file: ${SCREAM_DATA_DIR}/init/spa_file_unified_and_complete_ne4_20220428.nc
+    p3:
+      max_total_ni: 740.0e3
     shoc:
       lambda_low: 0.001
       lambda_high: 0.04
       lambda_slope: 2.65
       lambda_thresh: 0.02
-    p3:
-      max_total_ni: 740.0e3
+      thl2tune: 1.0
+      qw2tune: 1.0
+      qwthl2tune: 1.0
+      w2tune: 1.0
   rrtmgp:
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -31,6 +31,7 @@ atmosphere_processes:
       qwthl2tune: 1.0
       w2tune: 1.0
       length_fac: 0.5
+      c_diag_3rd_mom: 7.0
   rrtmgp:
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -32,6 +32,8 @@ atmosphere_processes:
       w2tune: 1.0
       length_fac: 0.5
       c_diag_3rd_mom: 7.0
+      Ckh: 0.1
+      Ckm: 0.1
   rrtmgp:
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -30,6 +30,7 @@ atmosphere_processes:
       qw2tune: 1.0
       qwthl2tune: 1.0
       w2tune: 1.0
+      length_fac: 0.5
   rrtmgp:
     column_chunk_size: 123
     active_gases: ["h2o", "co2", "o3", "n2o", "co" , "ch4", "o2", "n2"]

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
@@ -24,6 +24,10 @@ atmosphere_processes:
     lambda_high: 0.04
     lambda_slope: 2.65
     lambda_thresh: 0.02
+    thl2tune: 1.0
+    qw2tune: 1.0
+    qwthl2tune: 1.0
+    w2tune: 1.0
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
@@ -28,6 +28,7 @@ atmosphere_processes:
     qw2tune: 1.0
     qwthl2tune: 1.0
     w2tune: 1.0
+    length_fac: 0.5
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
@@ -29,6 +29,7 @@ atmosphere_processes:
     qwthl2tune: 1.0
     w2tune: 1.0
     length_fac: 0.5
+    c_diag_3rd_mom: 7.0
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
@@ -30,6 +30,8 @@ atmosphere_processes:
     w2tune: 1.0
     length_fac: 0.5
     c_diag_3rd_mom: 7.0
+    Ckh: 0.1
+    Ckm: 0.1
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
@@ -22,6 +22,7 @@ atmosphere_processes:
     qw2tune: 1.0
     qwthl2tune: 1.0
     w2tune: 1.0
+    length_fac: 0.5
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
@@ -24,6 +24,8 @@ atmosphere_processes:
     w2tune: 1.0
     length_fac: 0.5
     c_diag_3rd_mom: 7.0
+    Ckh: 0.1
+    Ckm: 0.1
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
@@ -23,6 +23,7 @@ atmosphere_processes:
     qwthl2tune: 1.0
     w2tune: 1.0
     length_fac: 0.5
+    c_diag_3rd_mom: 7.0
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
@@ -11,13 +11,17 @@ time_stepping:
 atmosphere_processes:
   schedule_type: Sequential
   atm_procs_list: [shoc,p3]
+  p3:
+    max_total_ni: 720.0e3
   shoc:
     lambda_low: 0.001
     lambda_high: 0.04
     lambda_slope: 2.65
     lambda_thresh: 0.02
-  p3:
-    max_total_ni: 720.0e3
+    thl2tune: 1.0
+    qw2tune: 1.0
+    qwthl2tune: 1.0
+    w2tune: 1.0
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/uncoupled/shoc/input.yaml
+++ b/components/eamxx/tests/uncoupled/shoc/input.yaml
@@ -21,6 +21,7 @@ atmosphere_processes:
     qw2tune: 1.0
     qwthl2tune: 1.0
     w2tune: 1.0
+    length_fac: 0.5
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/uncoupled/shoc/input.yaml
+++ b/components/eamxx/tests/uncoupled/shoc/input.yaml
@@ -17,6 +17,10 @@ atmosphere_processes:
     lambda_high: 0.04
     lambda_slope: 2.65
     lambda_thresh: 0.02
+    thl2tune: 1.0
+    qw2tune: 1.0
+    qwthl2tune: 1.0
+    w2tune: 1.0
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/uncoupled/shoc/input.yaml
+++ b/components/eamxx/tests/uncoupled/shoc/input.yaml
@@ -22,6 +22,7 @@ atmosphere_processes:
     qwthl2tune: 1.0
     w2tune: 1.0
     length_fac: 0.5
+    c_diag_3rd_mom: 7.0
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/uncoupled/shoc/input.yaml
+++ b/components/eamxx/tests/uncoupled/shoc/input.yaml
@@ -23,6 +23,8 @@ atmosphere_processes:
     w2tune: 1.0
     length_fac: 0.5
     c_diag_3rd_mom: 7.0
+    Ckh: 0.1
+    Ckm: 0.1
 
 grids_manager:
   Type: Mesh Free


### PR DESCRIPTION
This commit exposes more shoc runtime options to the AD.  These are:
1. `thl2tune`
2. `qw2tune`
3. `qwthl2tune`
4. `w2tune`
5. `length_fac`
6. `c_diag_3rd_mom`
7. `Ckh`
8. `Ckm`