### PR TITLE
In buildnml, split apply_buffer in two parts

### DIFF
--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -16,7 +16,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__f
 # SCREAM imports
 from eamxx_buildnml_impl import get_valid_selectors, get_child, refine_type, \
         resolve_all_inheritances, gen_atm_proc_group, check_all_values
-from atm_manip import apply_buffer
+from atm_manip import apply_atm_procs_list_changes_from_buffer, apply_non_atm_procs_list_changes_from_buffer
 
 from utils import ensure_yaml # pylint: disable=no-name-in-module
 ensure_yaml()
@@ -480,8 +480,9 @@ def _create_raw_xml_file_impl(case, xml):
     # 1. Evaluate all selectors
     evaluate_selectors(xml, case, selectors)
 
-    # 2. If there are changes in the SCREAM_ATMCHANGE_BUFFER, apply them
-    apply_buffer(case,xml)
+    # 2. Apply all changes in the SCREAM_ATMCHANGE_BUFFER that may alter
+    #    which atm processes are used
+    apply_atm_procs_list_changes_from_buffer (case,xml)
 
     # 3. Resolve all inheritances
     resolve_all_inheritances(xml)
@@ -495,11 +496,14 @@ def _create_raw_xml_file_impl(case, xml):
     # 6. Get atm procs list
     atm_procs_list = get_child(atm_procs_defaults,"atm_procs_list",remove=True)
 
-
     # 7. Form the nested list of atm procs needed, append to atmosphere_driver section
     atm_procs = gen_atm_proc_group(atm_procs_list.text, atm_procs_defaults)
     atm_procs.tag = "atmosphere_processes"
     xml.append(atm_procs)
+
+    # 8. Apply all changes in the SCREAM_ATMCHANGE_BUFFER that do not alter
+    #    which atm processes are used
+    apply_non_atm_procs_list_changes_from_buffer (case,xml)
 
     return xml
 

--- a/components/eamxx/scripts/atm_manip.py
+++ b/components/eamxx/scripts/atm_manip.py
@@ -18,6 +18,31 @@ ATMCHANGE_ALL = "__ALL__"
 ATMCHANGE_BUFF_XML_NAME = "SCREAM_ATMCHANGE_BUFFER"
 
 ###############################################################################
+def apply_atm_procs_list_changes_from_buffer(case, xml):
+###############################################################################
+    atmchg_buffer = case.get_value(ATMCHANGE_BUFF_XML_NAME)
+    if atmchg_buffer:
+        atmchgs, atmchgs_all = unbuffer_changes(case)
+
+        expect (len(atmchgs)==len(atmchgs_all),"Failed to unbuffer changes from SCREAM_ATMCHANGE_BUFFER")
+        for chg, to_all in zip(atmchgs,atmchgs_all):
+            if "atm_procs_list" in chg:
+                expect (not to_all, "Makes no sense to change 'atm_procs_list' for all groups")
+                atm_config_chg_impl(xml, chg, all_matches=false)
+
+###############################################################################
+def apply_non_atm_procs_list_changes_from_buffer(case, xml):
+###############################################################################
+    atmchg_buffer = case.get_value(ATMCHANGE_BUFF_XML_NAME)
+    if atmchg_buffer:
+        atmchgs, atmchgs_all = unbuffer_changes(case)
+
+        expect (len(atmchgs)==len(atmchgs_all),"Failed to unbuffer changes from SCREAM_ATMCHANGE_BUFFER")
+        for chg, to_all in zip(atmchgs,atmchgs_all):
+            if "atm_procs_list" not in chg:
+                atm_config_chg_impl(xml, chg, all_matches=to_all)
+
+###############################################################################
 def buffer_changes(changes, all_matches=False):
 ###############################################################################
     """
@@ -50,23 +75,6 @@ def unbuffer_changes(case):
 
     return atmchgs, atmchgs_all
 
-###############################################################################
-def apply_buffer(case,xml_root):
-###############################################################################
-    """
-    From a case, retrieve the buffered changes and re-apply them via atmchange
-    """
-    atmchg_buffer = case.get_value(ATMCHANGE_BUFF_XML_NAME)
-    if atmchg_buffer:
-        atmchgs, atmchgs_all = unbuffer_changes(case)
-
-        expect (len(atmchgs)==len(atmchgs_all),"Failed to unbuffer changes from SCREAM_ATMCHANGE_BUFFER")
-        for chg, to_all in zip(atmchgs,atmchgs_all):
-            atm_config_chg_impl(xml_root, chg, all_matches=to_all)
-            # Annoying as it may be, we must resolve all inheritances.
-            # E.g., the user *may* have added an atm proc, which requires
-            # to get all the atm_proc_base defaults
-            resolve_all_inheritances(xml_root)
 
 ###############################################################################
 def reset_buffer():

--- a/components/eamxx/scripts/atm_manip.py
+++ b/components/eamxx/scripts/atm_manip.py
@@ -10,7 +10,7 @@ import xml.etree.ElementTree as ET # pylint: disable=unused-import
 # Add path to cime_config folder
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "cime_config"))
 from eamxx_buildnml_impl import check_value, is_array_type, get_child, find_node
-from eamxx_buildnml_impl import gen_atm_proc_group, resolve_all_inheritances
+from eamxx_buildnml_impl import gen_atm_proc_group
 from utils import expect, run_cmd_no_fail
 
 ATMCHANGE_SEP = "-ATMCHANGE_SEP-"
@@ -28,7 +28,7 @@ def apply_atm_procs_list_changes_from_buffer(case, xml):
         for chg, to_all in zip(atmchgs,atmchgs_all):
             if "atm_procs_list" in chg:
                 expect (not to_all, "Makes no sense to change 'atm_procs_list' for all groups")
-                atm_config_chg_impl(xml, chg, all_matches=false)
+                atm_config_chg_impl(xml, chg, all_matches=False)
 
 ###############################################################################
 def apply_non_atm_procs_list_changes_from_buffer(case, xml):

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -14,7 +14,7 @@ sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 from eamxx_buildnml_impl import check_value, is_array_type
 from eamxx_buildnml import create_raw_xml_file
-from atm_manip import atm_config_chg_impl, buffer_changes, reset_buffer, get_xml_nodes
+from atm_manip import atm_config_chg_impl, buffer_changes, reset_buffer, get_xml_nodes, parse_change
 from utils import run_cmd_no_fail, expect
 
 # Add path to cime
@@ -52,6 +52,12 @@ def atm_config_chg(changes, reset=False, all_matches=False, buffer_only=False):
     else:
         expect(changes, "Missing <param>=<val> args")
 
+    # Before applying/buffering changes, at the very least check the syntax
+    for c in changes:
+        # This will throw if the syntax is bad
+        _, _, _ = parse_change(c)
+
+    any_change = True
     if not buffer_only:
         with open("namelist_scream.xml", "r") as fd:
             tree = ET.parse(fd)
@@ -62,10 +68,15 @@ def atm_config_chg(changes, reset=False, all_matches=False, buffer_only=False):
             this_changed = atm_config_chg_impl(root, change, all_matches)
             any_change |= this_changed
 
-    buffer_changes(changes, all_matches=all_matches)
 
-    if not buffer_only:
-        recreate_raw_xml_file()
+    if any_change:
+        # NOTE: if a change is wrong (e.g., typo in param name), we are still buffering it.
+        #       We have no way of checking this, unfortunately. If you get an error that is
+        #       not just syntax, your best course of action is to run atmchange --reset.
+        buffer_changes(changes, all_matches=all_matches)
+
+        if not buffer_only:
+            recreate_raw_xml_file()
 
     return True
 

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -57,13 +57,14 @@ def atm_config_chg(changes, reset=False, all_matches=False, buffer_only=False):
         # This will throw if the syntax is bad
         _, _, _ = parse_change(c)
 
-    any_change = True
+    # If buffer_only=True, we must assume there were changes (we can't check).
+    # Otherwise, we'll assume no changes, and if we find one, we'll adjust
+    any_change = buffer_only
     if not buffer_only:
         with open("namelist_scream.xml", "r") as fd:
             tree = ET.parse(fd)
             root = tree.getroot()
 
-        any_change = False
         for change in changes:
             this_changed = atm_config_chg_impl(root, change, all_matches)
             any_change |= this_changed

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -244,6 +244,16 @@ class TestBuildnml(unittest.TestCase):
         self._chg_atmconfig([("cubed_sphere_map", "84")], case)
 
     ###########################################################################
+    def test_atmchanges_with_namespace(self):
+    ###########################################################################
+        """
+        Test that atmchange works when using :: syntax
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+
+        self._chg_atmconfig([("p3::enable_precondition_checks", "false", True)], case)
+
+    ###########################################################################
     def test_atmchanges_on_arrays(self):
     ###########################################################################
         """
@@ -278,8 +288,7 @@ class TestBuildnml(unittest.TestCase):
     def test_atmchanges_for_atm_procs(self):
     ###########################################################################
         """
-        Test that atmchanges that add atm procs create the new proc when case.setup
-        is called.
+        Test that atmchanges that add atm procs create the new proc
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
@@ -288,21 +297,6 @@ class TestBuildnml(unittest.TestCase):
         # If we are able to change subcycles of testOnly then we know the atmchange
         # above added the necessary atm proc XML block.
         self._chg_atmconfig([("testOnly::number_of_subcycles", "42")], case)
-
-        # Now remove the testOnly proc. Things should still work even though
-        # the buffer will have changes that cannot be applied.
-        self._chg_atmconfig([("mac_aero_mic::atm_procs_list", "shoc,cldFraction,spa,p3")], case)
-
-    ###########################################################################
-    def test_atmchanges_for_atm_procs_no_setup(self):
-    ###########################################################################
-        """
-        Test that you can set atm proc fields for an atm proc added by
-        atmchange without having to run case.setup.
-        """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
-
-        self._chg_atmconfig([("mac_aero_mic::atm_procs_list", "shoc,cldFraction,spa,p3,testOnly"), ("testOnly::number_of_subcycles", "42")], case)
 
 ###############################################################################
 def parse_command_line(args, desc):

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -113,7 +113,7 @@ class TestBuildnml(unittest.TestCase):
         if reset:
             run_cmd_assert_result(self, "./atmchange --reset", from_dir=case)
 
-        run_cmd_assert_result(self, "./case.setup", from_dir=case)
+        #  run_cmd_assert_result(self, "./case.setup", from_dir=case)
 
         for name, value in changes_unpacked.items():
             self._get_values(case, name, value=value, expect_equal=not expect_lost)

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -5,7 +5,8 @@ Script containing python test suite for SCREAM's CIME
 namelist-related infrastructure.
 """
 
-from utils import check_minimum_python_version, expect, ensure_pylint, run_cmd_assert_result, get_timestamp, run_cmd_no_fail
+from utils import check_minimum_python_version, expect, ensure_pylint, get_timestamp, \
+                  run_cmd_assert_result, run_cmd_no_fail, run_cmd
 
 check_minimum_python_version(3, 6)
 
@@ -179,7 +180,15 @@ class TestBuildnml(unittest.TestCase):
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
-        self._chg_atmconfig([("atm_log_level", "trace")], case)
+        self._chg_atmconfig([("atm_log_level", "trace"), ("output_to_screen", "true")], case)
+
+        run_cmd_no_fail ("./case.setup", from_dir=case)
+
+        out1 = run_cmd_no_fail("./atmquery --value atm_log_level", from_dir=case)
+        out2 = run_cmd_no_fail("./atmquery --value output_to_screen", from_dir=case)
+
+        expect (out1=="trace", "An atm change appears to have been lost during case.setup")
+        expect (out2=="true",  "An atm change appears to have been lost during case.setup")
 
     ###########################################################################
     def test_append(self):
@@ -208,11 +217,10 @@ class TestBuildnml(unittest.TestCase):
         self._chg_atmconfig([("atm_log_level", "trace")], case, reset=True)
 
     ###########################################################################
-    def test_manual_atmchanges_are_not_lost_hack_xml(self):
+    def test_atmchanges_are_lost_with_hack_xml(self):
     ###########################################################################
         """
-        Test that manual atmchanges are not lost when eamxx setup is called if
-        xml hacking is enabled.
+        Test that atmchanges are lost if SCREAM_HACK_XML=TRUE
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
@@ -221,37 +229,28 @@ class TestBuildnml(unittest.TestCase):
         self._chg_atmconfig([("atm_log_level", "trace")], case, expect_lost=True)
 
     ###########################################################################
-    def test_multiple_atmchanges_are_preserved(self):
-    ###########################################################################
-        """
-        Test that multiple atmchanges are not lost when eamxx setup is called
-        """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
-
-        self._chg_atmconfig([("atm_log_level", "trace"), ("output_to_screen", "true")], case)
-
-    ###########################################################################
     def test_atmchanges_are_preserved_testmod(self):
     ###########################################################################
         """
-        Test that atmchanges are not lost when eamxx setup is called when that
-        parameter is impacted by an active testmod
+        Test that atmchanges via testmod are preserved
         """
         def_mach_comp = \
             run_cmd_assert_result(self, "../CIME/Tools/list_e3sm_tests cime_tiny", from_dir=CIME_SCRIPTS_DIR).splitlines()[-1].split(".")[-1]
         case = self._create_test(f"SMS.ne30_ne30.F2010-SCREAMv1.{def_mach_comp}.scream-scream_example_testmod_atmchange --no-build")
 
-        self._chg_atmconfig([("cubed_sphere_map", "84")], case)
+        # Check that the value match what's in the testmod
+        out = run_cmd_no_fail("./atmquery --value cubed_sphere_map", from_dir=case)
+        expect (out=="42", "An atm change appears to have been lost during case.setup")
 
     ###########################################################################
     def test_atmchanges_with_namespace(self):
     ###########################################################################
         """
-        Test that atmchange works when using :: syntax
+        Test that atmchange works when using 'namespace' syntax foo::bar
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
-        self._chg_atmconfig([("p3::enable_precondition_checks", "false", True)], case)
+        self._chg_atmconfig([("p3::enable_precondition_checks", "false")], case)
 
     ###########################################################################
     def test_atmchanges_on_arrays(self):
@@ -267,7 +266,7 @@ class TestBuildnml(unittest.TestCase):
     def test_atmchanges_on_all_matches(self):
     ###########################################################################
         """
-        Test that atmchange works for all matches
+        Test that atmchange --all works
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
@@ -277,7 +276,7 @@ class TestBuildnml(unittest.TestCase):
     def test_atmchanges_on_all_matches_plus_spec(self):
     ###########################################################################
         """
-        Test that atmchange works for all matches and picking one specialization
+        Test atmchange --all followed by an atmchange of one of them
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
@@ -285,10 +284,10 @@ class TestBuildnml(unittest.TestCase):
                              ("p3::enable_precondition_checks", "true")], case)
 
     ###########################################################################
-    def test_atmchanges_for_atm_procs(self):
+    def test_atmchanges_for_atm_procs_add(self):
     ###########################################################################
         """
-        Test that atmchanges that add atm procs create the new proc
+        Test atmchanges that add atm procs
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
@@ -297,6 +296,77 @@ class TestBuildnml(unittest.TestCase):
         # If we are able to change subcycles of testOnly then we know the atmchange
         # above added the necessary atm proc XML block.
         self._chg_atmconfig([("testOnly::number_of_subcycles", "42")], case)
+
+    ###########################################################################
+    def test_atmchanges_for_atm_procs_add_invalid(self):
+    ###########################################################################
+        """
+        Test atmchanges that add atm procs
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+
+        # modifying a procs list requires known processes or "_" pre/post suffixes
+        stat, out, err = run_cmd ("./atmchange mac_aero_mic::atm_procs_list=shoc,cldfraction,spa,p3,spiderman",
+                                  from_dir=case)
+
+        expect (stat!=0,"Command './atmchange mac_aero_mic::atm_procs_list=shoc,cldFraction,spa,p3,spiderman' should have failed")
+
+    ###########################################################################
+    def test_buffer_unchanged_with_bad_change_syntax(self):
+    ###########################################################################
+        """
+        Test atmchange does not change buffer if syntax was wrong
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+
+        # Attempting a bad change should not alter the content of SCREAM_ATMCHANGE_BUFFER
+        old = run_cmd_no_fail ("./xmlquery --value SCREAM_ATMCHANGE_BUFFER",from_dir=case)
+        stat, out, err = run_cmd ("./atmchange foo",from_dir=case)
+        expect (stat!=0,"Command './atmchange foo' should have failed")
+
+        new = run_cmd_no_fail ("./xmlquery --value SCREAM_ATMCHANGE_BUFFER",from_dir=case)
+
+        expect (new==old, "A bad atmchange should have not modified SCREAM_ATMCHANGE_BUFFER")
+
+    ###########################################################################
+    def test_invalid_xml_option(self):
+    ###########################################################################
+        """
+        Test atmchange errors out with invalid param names
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+
+        stat, out, err = run_cmd ("./atmchange p3::non_existent=3",from_dir=case)
+        expect (stat!=0,"Command './atmchange p3::non_existent=3' should have failed")
+
+    ###########################################################################
+    def test_atmchanges_for_atm_procs_add_group(self):
+    ###########################################################################
+        """
+        Test atmchanges that add atm proc groups
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+
+        out = run_cmd_no_fail ("./atmchange mac_aero_mic::atm_procs_list=shoc,_my_group_",from_dir=case)
+
+        self._chg_atmconfig([("_my_group_::atm_procs_list", "testOnly")], case)
+
+        # If we are able to change subcycles of testOnly then we know the atmchange
+        # above added the necessary atm proc XML block.
+        self._chg_atmconfig([("testOnly::number_of_subcycles", "42")], case)
+
+    ###########################################################################
+    def test_atmchanges_for_atm_procs_remove(self):
+    ###########################################################################
+        """
+        Test atmchanges that remove atm procs
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+
+        self._chg_atmconfig([("mac_aero_mic::atm_procs_list", "shoc,cldFraction,spa")], case)
+
+        stat, output, error = run_cmd("./atmquery --grep p3",from_dir=case)
+        expect (output=="", "There is still a trace of the removed process")
 
 ###############################################################################
 def parse_command_line(args, desc):


### PR DESCRIPTION
Namely

- The first call is done at the beginning of the xml file generation. It runs on the xml tree of the defaults, and only applies changes that alter the atm procs used. We need this early on, since below we build the atm proc group, so we need to have the correct list of atm procs.
-  The second call is done at the end, when the xml has been fully created. In this pass, we will skip all changes that alter the atm procs used, since we already took care of those in the first call.

Note: this pr prevents us from doing something like this:
```
$ ./atmchange mac_aero_mic::atm_procs_list=shoc,spa,p3,blah
$ ./atmchange blah:foo=bar
$ ./atmchange mac_aero_mic::atm_procs_list=shoc,spa,p3
```
That's b/c the 1st and 3rd line will be done in the first call, while the 2nd line is done in the second call. By the time the 2nd atmchange is issues, there is no longer a "blah" node in the XML. This is a mild limitation: if you do something like the above, you may as well issue `./atmchange --reset` and start over...

This PR should fix all the fails we are currently seeing with atmchange. The reason for the fails is that the buffer was unpacked before resolving inheritances.

Note: wip while I test the scripts locally.