### PR TITLE
Fix issue w/ U and V in nudging process

### DIFF
--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -54,14 +54,13 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
    * vector, if it is we register it.  For now we are limited to just T_mid, qv,
    * U and V
    */
-  if (std::find(m_fields_nudge.begin(),m_fields_nudge.end(),"T_mid") != m_fields_nudge.end()) {
+  if (ekat::contains(m_fields_nudge,"T_mid")) {
     add_field<Updated>("T_mid", scalar3d_layout_mid, K, grid_name, ps);
   }
-  if (std::find(m_fields_nudge.begin(),m_fields_nudge.end(),"qv") != m_fields_nudge.end()) {
+  if (ekat::contains(m_fields_nudge,"qv")) {
     add_field<Updated>("qv",    scalar3d_layout_mid, Q, grid_name, "tracers", ps);
   }
-  if (std::find(m_fields_nudge.begin(),m_fields_nudge.end(),"U") != m_fields_nudge.end() or
-      std::find(m_fields_nudge.begin(),m_fields_nudge.end(),"V") != m_fields_nudge.end()) {
+  if (ekat::contains(m_fields_nudge,"U") or ekat::contains(m_fields_nudge,"V")) {
     add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,     grid_name, ps);
   }
   /* ----------------------- WARNING --------------------------------*/
@@ -355,9 +354,9 @@ Field Nudging::get_field_out_wrap(const std::string& field_name) {
     const int vec_dim = layout.get_vector_dim();
     const auto& units = fid.get_units();
     if (field_name == "U") {
-      return hw.subfield("U",units,vec_dim,0);
+      return hw.get_component(0);
     } else {
-      return hw.subfield("V",units,vec_dim,1);
+      return hw.get_component(1);
     }
   } else {
     return get_field_out(field_name);

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -349,10 +349,6 @@ void Nudging::init_buffers(const ATMBufferManager& buffer_manager) {
 Field Nudging::get_field_out_wrap(const std::string& field_name) {
   if (field_name == "U" or field_name == "V") {
     auto hw = get_field_out("horiz_winds");
-    const auto& fid = hw.get_header().get_identifier();
-    const auto& layout = fid.get_layout();
-    const int vec_dim = layout.get_vector_dim();
-    const auto& units = fid.get_units();
     if (field_name == "U") {
       return hw.get_component(0);
     } else {

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -83,6 +83,8 @@ protected:
 
 protected:
 
+  Field get_field_out_wrap(const std::string& field_name);
+
   // The two other main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
   void finalize_impl   ();


### PR DESCRIPTION
In the current setup, the fields U and V are added to the field manager as subfields of horiz_winds *after* the field manager has already registerd all field requests from atmospheric processes.  As a result, nudging, which may register U and V disrupts the assumptions about horiz_winds currently hard-coded.  When U and V are used in nudging they are added as independent fields and are no longer tied to horiz_winds.

This commit is a quick fix to address the immediate issue in nudging.  A longer term fix will be require a bit more work and will be added in a subsequent PR.