### PR TITLE
Add more robust log entries for IO

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1226,6 +1226,7 @@ read_fields_from_file (const std::vector<std::string>& field_names_nc,
   }
 
   AtmosphereInput ic_reader(file_name,grid,fields);
+  ic_reader.set_logger(m_atm_logger);
   ic_reader.read_variables();
   ic_reader.finalize();
 
@@ -1264,6 +1265,7 @@ read_fields_from_file (const std::vector<std::string>& field_names,
   }
 
   AtmosphereInput ic_reader(file_name,grid,fields);
+  ic_reader.set_logger(m_atm_logger);
   ic_reader.read_variables();
   ic_reader.finalize();
 

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -202,6 +202,10 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
 //       running eam_update_timesnap.
 void AtmosphereInput::read_variables (const int time_index)
 {
+  auto func_start = std::chrono::steady_clock::now();
+  if (m_atm_logger) {
+    m_atm_logger->info("[EAMxx::scorpio_input] Reading variables from file:\n\t " + m_filename + " ...\n");
+  }
   EKAT_REQUIRE_MSG (m_inited_with_views || m_inited_with_fields,
       "Error! Scorpio structures not inited yet. Did you forget to call 'init(..)'?\n");
 
@@ -313,6 +317,11 @@ void AtmosphereInput::read_variables (const int time_index)
       // Sync to device
       f.sync_to_dev();
     }
+  }
+  auto func_finish = std::chrono::steady_clock::now();
+  if (m_atm_logger) {
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(func_finish - func_start);
+    m_atm_logger->info("[EAMxx::scorpio_input] Reading variables from file:\n\t " + m_filename + " ... done! (Elapsed time = " + std::to_string(duration.count()) +" ms)\n");
   }
 } 
 

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -320,8 +320,8 @@ void AtmosphereInput::read_variables (const int time_index)
   }
   auto func_finish = std::chrono::steady_clock::now();
   if (m_atm_logger) {
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(func_finish - func_start);
-    m_atm_logger->info("[EAMxx::scorpio_input] Reading variables from file:\n\t " + m_filename + " ... done! (Elapsed time = " + std::to_string(duration.count()) +" ms)\n");
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(func_finish - func_start)/1000.0;
+    m_atm_logger->info("[EAMxx::scorpio_input] Reading variables from file:\n\t " + m_filename + " ... done! (Elapsed time = " + std::to_string(duration.count()) +" seconds)\n");
   }
 } 
 

--- a/components/eamxx/src/share/io/scorpio_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_input.hpp
@@ -7,6 +7,7 @@
 #include "share/grid/grids_manager.hpp"
 
 #include "ekat/ekat_parameter_list.hpp"
+#include "ekat/logging/ekat_logger.hpp"
 
 /*  The AtmosphereInput class handles all input streams to SCREAM.
  *  It is important to note that there does not exist an InputManager,
@@ -109,6 +110,11 @@ public:
   // Expose the ability to set field manager for cases like time_interpolation where we swap fields
   // between field managers to avoid deep_copy.
   void set_field_manager (const std::shared_ptr<const fm_type>& field_mgr);
+
+  // Option to add a logger
+  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger) {
+      m_atm_logger = atm_logger;
+  }
 protected:
 
   void set_grid (const std::shared_ptr<const AbstractGrid>& grid);
@@ -137,6 +143,9 @@ protected:
 
   bool m_inited_with_fields        = false;
   bool m_inited_with_views         = false;
+
+  // The logger to be used throughout the ATM to log message
+  std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger;
 }; // Class AtmosphereInput
 
 } //namespace scream

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -366,6 +366,12 @@ run (const std::string& filename,
   if (not is_write_step and m_avg_type==OutputAvgType::Instant) {
     return;
   }
+  auto func_start = std::chrono::steady_clock::now();
+  if (is_write_step) {
+    if (m_atm_logger) {
+      m_atm_logger->info("[EAMxx::scorpio_output] Writing variables to file:\n\t " + filename + " ...\n");
+    }
+  }
 
   using namespace scream::scorpio;
 
@@ -636,6 +642,13 @@ run (const std::string& filename,
       auto view_host = m_host_views_1d.at(name);
       Kokkos::deep_copy (view_host,view_dev);
       grid_write_data_array(filename,name,view_host.data(),view_host.size());
+    }
+  }
+  auto func_finish = std::chrono::steady_clock::now();
+  if (is_write_step) {
+    if (m_atm_logger) {
+      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(func_finish - func_start)/1000.0;
+      m_atm_logger->info("[EAMxx::scorpio_output] Writing variables to file:\n\t " + filename + " ...done! (Elapsed time = " + std::to_string(duration.count()) +" seconds)\n");
     }
   }
 } // run

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -366,7 +366,7 @@ run (const std::string& filename,
   if (not is_write_step and m_avg_type==OutputAvgType::Instant) {
     return;
   }
-  auto func_start = std::chrono::steady_clock::now();
+  Real duration_write = 0.0;  // Record of time spent writing output
   if (is_write_step) {
     if (m_atm_logger) {
       m_atm_logger->info("[EAMxx::scorpio_output] Writing variables to file:\n\t " + filename + " ...\n");
@@ -631,7 +631,11 @@ run (const std::string& filename,
       // Bring data to host
       auto view_host = m_host_views_1d.at(name);
       Kokkos::deep_copy (view_host,view_dev);
+      auto func_start = std::chrono::steady_clock::now();
       grid_write_data_array(filename,name,view_host.data(),view_host.size());
+      auto func_finish = std::chrono::steady_clock::now();
+      auto duration_loc = std::chrono::duration_cast<std::chrono::milliseconds>(func_finish - func_start);
+      duration_write += duration_loc.count();
     }
   }
   // Handle writing the average count variables to file
@@ -641,14 +645,16 @@ run (const std::string& filename,
       // Bring data to host
       auto view_host = m_host_views_1d.at(name);
       Kokkos::deep_copy (view_host,view_dev);
+      auto func_start = std::chrono::steady_clock::now();
       grid_write_data_array(filename,name,view_host.data(),view_host.size());
+      auto func_finish = std::chrono::steady_clock::now();
+      auto duration_loc = std::chrono::duration_cast<std::chrono::milliseconds>(func_finish - func_start);
+      duration_write += duration_loc.count();
     }
   }
-  auto func_finish = std::chrono::steady_clock::now();
   if (is_write_step) {
     if (m_atm_logger) {
-      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(func_finish - func_start)/1000.0;
-      m_atm_logger->info("[EAMxx::scorpio_output] Writing variables to file:\n\t " + filename + " ...done! (Elapsed time = " + std::to_string(duration.count()) +" seconds)\n");
+      m_atm_logger->info("[EAMxx::scorpio_output] Writing variables to file:\n\t " + filename + " ...done! (Elapsed time = " + std::to_string(duration_write/1000.0) +" seconds)\n");
     }
   }
 } // run

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -150,6 +150,11 @@ public:
     return m_io_grid;
   }
 
+  // Option to add a logger
+  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger) {
+      m_atm_logger = atm_logger;
+  }
+
 protected:
   // Internal functions
   void set_grid (const std::shared_ptr<const AbstractGrid>& grid);
@@ -212,6 +217,9 @@ protected:
 
   bool m_add_time_dim;
   bool m_track_avg_cnt = false;
+
+  // The logger to be used throughout the ATM to log message
+  std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger;
 };
 
 } //namespace scream

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -96,6 +96,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
   // For each grid, create a separate output stream.
   if (field_mgrs.size()==1) {
     auto output = std::make_shared<output_type>(m_io_comm,m_params,field_mgrs.begin()->second,grids_mgr);
+    output->set_logger(m_atm_logger);
     m_output_streams.push_back(output);
   } else {
     for (auto it=fields_pl.sublists_names_cbegin(); it!=fields_pl.sublists_names_cend(); ++it) {
@@ -128,6 +129,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
           "Error! Output requested on grid '" + gname + "', but no field manager is available for such grid.\n");
 
       auto output = std::make_shared<output_type>(m_io_comm,m_params,field_mgrs.at(gname),grids_mgr);
+      output->set_logger(m_atm_logger);
       m_output_streams.push_back(output);
     }
   }


### PR DESCRIPTION
This commit adds atmosphere log capability to the AtmosphereInput and AtmosphereOutput classes.  This should allow for more robust logging of IO in the atmosphere log.  This commit adds log messages for both of the "run" routines for Input and Output respectively, including timers to record how long the run routines have taken.

[BFB]