### PR TITLE
Fix calculation of tendencies when parent atm proc is subcycled

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -825,9 +825,6 @@ initialize_fields ()
     }
   }
 
-  // Zero out accumulated fields
-  reset_accummulated_fields();
-
 #ifdef SCREAM_HAS_MEMORY_USAGE
   long long my_mem_usage = get_mem_usage(MB);
   long long max_mem_usage;
@@ -1418,6 +1415,9 @@ void AtmosphereDriver::run (const int dt) {
     "Atmosphere step = " + std::to_string(m_current_ts.get_num_steps()) + "\n" +
     "  model start-of-step time = " + m_current_ts.get_date_string() + " " + m_current_ts.get_time_string() + "\n");
 
+  // Reset accum fields
+  reset_accummulated_fields();
+
   // The class AtmosphereProcessGroup will take care of dispatching arguments to
   // the individual processes, which will be called in the correct order.
   m_atm_process_group->run(dt);
@@ -1430,10 +1430,6 @@ void AtmosphereDriver::run (const int dt) {
   for (auto& out_mgr : m_output_managers) {
     out_mgr.run(m_current_ts);
   }
-
-  // Reset accum fields right away, so that if we have t=0 output,
-  // we don't run into errors in the IO or diagnostics layers.
-  reset_accummulated_fields();
 
 #ifdef SCREAM_HAS_MEMORY_USAGE
   long long my_mem_usage = get_mem_usage(MB);

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -325,7 +325,7 @@ void AtmosphereDriver::setup_surface_coupling_processes () const
   }
 }
 
-void AtmosphereDriver::reset_accummulated_fields ()
+void AtmosphereDriver::reset_accumulated_fields ()
 {
   constexpr Real zero = 0;
   for (auto fm_it : m_field_mgrs) {
@@ -1416,7 +1416,7 @@ void AtmosphereDriver::run (const int dt) {
     "  model start-of-step time = " + m_current_ts.get_date_string() + " " + m_current_ts.get_time_string() + "\n");
 
   // Reset accum fields
-  reset_accummulated_fields();
+  reset_accumulated_fields();
 
   // The class AtmosphereProcessGroup will take care of dispatching arguments to
   // the individual processes, which will be called in the correct order.

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -91,7 +91,7 @@ public:
   void setup_surface_coupling_processes() const;
 
   // Zero out precipitation flux
-  void reset_accummulated_fields();
+  void reset_accumulated_fields();
 
   // Create and add mass and energy conservation checks
   // and pass to m_atm_process_group.

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -211,6 +211,7 @@ void AtmosphereProcess::setup_tendencies_requests () {
   // field with the requested name. If more than one is found (must be
   // that we have same field on multiple grids), error out.
   using namespace ekat::units;
+  using strlist_t = std::list<std::string>;
   for (const auto& tn : tend_list) {
     std::string grid_found = "";
     auto tokens = field_grid(tn);
@@ -240,7 +241,7 @@ void AtmosphereProcess::setup_tendencies_requests () {
 
         // Create tend FID and request field
         FieldIdentifier t_fid(tname,layout,units,gname,dtype);
-        add_field<Computed>(t_fid,"ACCUMULATED");
+        add_field<Computed>(t_fid,strlist_t{"ACCUMULATED","DIVIDE_BY_DT"});
         grid_found = gname;
       }
     }
@@ -494,8 +495,9 @@ void AtmosphereProcess::init_step_tendencies () {
 }
 
 void AtmosphereProcess::compute_step_tendencies (const double dt) {
+  using namespace ShortFieldTagsNames;
   if (m_compute_proc_tendencies) {
-    m_atm_logger->debug("[" + this->name() + "] compuiting tendencies...");
+    m_atm_logger->debug("[" + this->name() + "] computing tendencies...");
     start_timer(m_timer_prefix + this->name() + "::compute_tendencies");
     for (auto it : m_proc_tendencies) {
       // Note: f_beg is nonconst, so we can store step tendency in it
@@ -506,7 +508,7 @@ void AtmosphereProcess::compute_step_tendencies (const double dt) {
             auto& tend  = it.second;
 
       // Compute tend from this atm proc step, then sum into overall atm timestep tendency
-      f_beg.update(f,1/dt,-1/dt);
+      f_beg.update(f,1,-1);
       tend.update(f_beg,1,1);
     }
     stop_timer(m_timer_prefix + this->name() + "::compute_tendencies");

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -519,6 +519,7 @@ private:
   // Data structures necessary to compute tendencies of updated fields
   strmap_t<std::string>    m_tend_to_field;
   strmap_t<Field>          m_proc_tendencies;
+  strmap_t<Field>          m_start_of_step_fields;
 
   // These maps help to retrieve a field/group stored in the lists above. E.g.,
   //   auto ptr = m_field_in_pointers[field_name][grid_name];

--- a/components/eamxx/src/share/field/field_tracking.hpp
+++ b/components/eamxx/src/share/field/field_tracking.hpp
@@ -74,7 +74,7 @@ protected:
   // Tracking the updates of the field
   TimeStamp         m_time_stamp;
 
-  // For accummulated vars, the time where the accummulation started
+  // For accumulated vars, the time where the accumulation started
   TimeStamp         m_accum_start;
   ci_string         m_accum_type;
 

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -657,7 +657,7 @@ setup_file (      IOFileSpecs& filespecs,
     register_variable(filename,"time_bnds","time_bnds",time_units,{"dim2","time"},"double","double","time-dim2");
     
     // Make it clear how the time_bnds should be interpreted
-    set_variable_metadata(filename,"time_bnds","note","right endpoint accummulation");
+    set_variable_metadata(filename,"time_bnds","note","right endpoint accumulation");
 
     // I'm not sure what's the point of this, but CF conventions seem to require it
     set_variable_metadata (filename,"time","bounds","time_bnds");

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/CMakeLists.txt
@@ -18,6 +18,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/input_subcycled.yaml)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/output_subcycled.yaml)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output_tend.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/output_tend_subcycled.yaml)
+
 CreateUnitTestFromExec (shoc_p3_subcycled shoc_p3
       EXE_ARGS "--use-colour no --ekat-test-params ifile=input_subcycled.yaml"
       PROPERTIES FIXTURES_SETUP subcycled)
@@ -31,6 +34,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/input_monolithic.yaml)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/output_monolithic.yaml)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output_tend.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/output_tend_monolithic.yaml)
 CreateUnitTestFromExec (shoc_p3_monolithic shoc_p3
       EXE_ARGS "--use-colour no --ekat-test-params ifile=input_monolithic.yaml"
       PROPERTIES FIXTURES_SETUP monolithic)
@@ -47,3 +52,13 @@ add_test (NAME ${TEST_NAME}
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set_tests_properties(${TEST_NAME} PROPERTIES LABELS "shoc;p3"
           FIXTURES_REQUIRED "monolithic;subcycled")
+
+# Check calculation of shoc tendencies when the parent group is subcycled
+set (script ${SCREAM_BASE_DIR}/scripts/check-tendencies)
+set (fname shoc_p3_tend_subcycled.INSTANT.nsteps_x1.${RUN_T0}.nc)
+add_test (NAME ${TEST_NAME}_tend_check
+          COMMAND ${script} -f ${fname} -v tke -t shoc_tke_tend
+          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties (${TEST_NAME}_tend_check PROPERTIES
+                      FIXTURES_REQUIRED subcycled
+                      LABELS "${TEST_LABELS}")

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -27,6 +27,7 @@ atmosphere_processes:
     c_diag_3rd_mom: 7.0
     Ckh: 0.1
     Ckm: 0.1
+    compute_tendencies: [tke]
 
 grids_manager:
   Type: Mesh Free
@@ -49,5 +50,5 @@ initial_conditions:
 
 # The parameters for I/O control
 Scorpio:
-  output_yaml_files: [output_${POSTFIX}.yaml]
+  output_yaml_files: [output_${POSTFIX}.yaml, output_tend_${POSTFIX}.yaml]
 ...

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/output.yaml
@@ -2,7 +2,6 @@
 ---
 filename_prefix: shoc_p3_${POSTFIX}
 Averaging Type: Instant
-Max Snapshots Per File: 1
 Field Names:
   - T_mid
   - qv

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/output_tend.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/output_tend.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+---
+filename_prefix: shoc_p3_tend_${POSTFIX}
+Averaging Type: Instant
+Field Names:
+  - tke
+  - shoc_tke_tend
+
+output_control:
+  Frequency: ${NUM_STEPS}
+  frequency_units: nsteps
+  MPI Ranks in Filename: false
+...


### PR DESCRIPTION
The current tendency calculation assumed that, when an atm proc run method was called, it had the right to overwrite the content of the tend field with the start-of-step value of the field. However, this is wrong if the atm proc is part of a subcycled group. In that case, when the run method is called the second time, the tend field already contains a contribution from the previous subcycle iteration of the parent atm proc.

The simplest solution is to store the start-of-step value of the field in a separate object, to avoid overwriting the tend field.

Fixes #2583 