### PR TITLE
ML correction for `u` and `v`

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -242,8 +242,10 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <!-- ML correction -->
     <mlcorrection inherit="atm_proc_base">
-      <ML_model_path type="string" doc="Path to pre-trained ML model"/>
+      <ML_model_path_tq type="string" doc="Path to pre-trained ML model for temperature and specific humidity"/>
+      <ML_model_path_uv type="string" doc="Path to pre-trained ML model for wind fields"/>
       <ML_output_fields type="array(string)" doc="ML correction output variables, the following variables are supported: T_mid,qv,u,v"/>
+      <ML_correction_unit_test type="logical">false</ML_correction_unit_test>
     </mlcorrection>
 
     <!-- For internal testing only -->

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -33,6 +33,8 @@ void MLCorrection::set_grids(
   // Layout for 3D (2d horiz X 1d vertical) variable defined at mid-level and
   // interfaces
   FieldLayout scalar3d_layout_mid{{COL, LEV}, {m_num_cols, m_num_levs}};
+  FieldLayout horiz_wind_layout { {COL,CMP,LEV}, {m_num_cols,2,m_num_levs} };
+
   
   /* ----------------------- WARNING --------------------------------*/
   /* The following is a HACK to get things moving, we don't want to
@@ -42,8 +44,7 @@ void MLCorrection::set_grids(
    */
   add_field<Updated>("T_mid", scalar3d_layout_mid, K, grid_name, ps);
   add_field<Updated>("qv",    scalar3d_layout_mid, Q, grid_name, "tracers", ps);
-  add_field<Updated>("U",     scalar3d_layout_mid, m/s, grid_name, ps);
-  add_field<Updated>("V",     scalar3d_layout_mid, m/s, grid_name, ps);
+  add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,     grid_name, ps);
   /* ----------------------- WARNING --------------------------------*/
   add_group<Updated>("tracers", grid_name, 1, Bundling::Required);
 }
@@ -70,9 +71,9 @@ void MLCorrection::run_impl(const double dt) {
   const auto &qv       = qv_field.get_view<Real **, Host>();
   const auto &T_mid_field = get_field_out("T_mid");
   const auto &T_mid       = T_mid_field.get_view<Real **, Host>();
-  const auto &u_field = get_field_out("U");
+  const auto &u_field = get_field_out("horiz_winds").get_component(0);
   const auto &u       = u_field.get_view<Real **, Host>();
-  const auto &v_field = get_field_out("V");
+  const auto &v_field = get_field_out("horiz_winds").get_component(1);
   const auto &v       = v_field.get_view<Real **, Host>();
 
   // having m_lat and m_lon in set_grids breaks the standalone unit test

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -8,8 +8,10 @@ namespace scream {
 MLCorrection::MLCorrection(const ekat::Comm &comm,
                            const ekat::ParameterList &params)
     : AtmosphereProcess(comm, params) {
-  m_ML_model_path = m_params.get<std::string>("ML_model_path");
+  m_ML_model_path_tq = m_params.get<std::string>("ML_model_path_tq");
+  m_ML_model_path_uv = m_params.get<std::string>("ML_model_path_uv");
   m_fields_ml_output_variables = m_params.get<std::vector<std::string>>("ML_output_fields");
+  m_ML_correction_unit_test = m_params.get<bool>("ML_correction_unit_test");
 }
 
 // =========================================================================================
@@ -32,10 +34,17 @@ void MLCorrection::set_grids(
 
   // Layout for 3D (2d horiz X 1d vertical) variable defined at mid-level and
   // interfaces
+  FieldLayout scalar2d_layout{ {COL}, {m_num_cols}};
   FieldLayout scalar3d_layout_mid{{COL, LEV}, {m_num_cols, m_num_levs}};
   FieldLayout horiz_wind_layout { {COL,CMP,LEV}, {m_num_cols,2,m_num_levs} };
+  if (not m_ML_correction_unit_test) {
+    const auto m2 = m*m;
+    const auto s2 = s*s;
+    add_field<Required>("phis", scalar2d_layout, m2/s2, grid_name, ps);
+    m_lat  = m_grid->get_geometry_data("lat");
+    m_lon  = m_grid->get_geometry_data("lon");      
+  }
 
-  
   /* ----------------------- WARNING --------------------------------*/
   /* The following is a HACK to get things moving, we don't want to
    * add all fields as "updated" long-term.  A separate stream of work
@@ -58,7 +67,8 @@ void MLCorrection::initialize_impl(const RunType /* run_type */) {
   pybind11::module sys = pybind11::module::import("sys");
   sys.attr("path").attr("insert")(1, ML_CORRECTION_CUSTOM_PATH);
   py_correction = pybind11::module::import("ml_correction");
-  ML_model = py_correction.attr("get_ML_model")(m_ML_model_path);
+  ML_model_tq = py_correction.attr("get_ML_model")(m_ML_model_path_tq);
+  ML_model_uv = py_correction.attr("get_ML_model")(m_ML_model_path_uv);
   ekat::enable_fpes(fpe_mask);
 }
 
@@ -71,14 +81,13 @@ void MLCorrection::run_impl(const double dt) {
   const auto &qv       = qv_field.get_view<Real **, Host>();
   const auto &T_mid_field = get_field_out("T_mid");
   const auto &T_mid       = T_mid_field.get_view<Real **, Host>();
+  const auto &phis_field  = get_field_in("phis");
+  const auto &phis        = phis_field.get_view<const Real *, Host>();
   const auto &u_field = get_field_out("horiz_winds").get_component(0);
   const auto &u       = u_field.get_view<Real **, Host>();
   const auto &v_field = get_field_out("horiz_winds").get_component(1);
   const auto &v       = v_field.get_view<Real **, Host>();
 
-  // having m_lat and m_lon in set_grids breaks the standalone unit test
-  m_lat  = m_grid->get_geometry_data("lat");
-  m_lon  = m_grid->get_geometry_data("lon");
   auto h_lat  = m_lat.get_view<const Real*,Host>();
   auto h_lon  = m_lon.get_view<const Real*,Host>();
 
@@ -104,8 +113,10 @@ void MLCorrection::run_impl(const double dt) {
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
           m_num_cols, h_lat.data(), pybind11::str{}),       
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
-          m_num_cols, h_lon.data(), pybind11::str{}),                                                
-      m_num_cols, m_num_levs, num_tracers, dt, ML_model, datetime_str);
+          m_num_cols, h_lon.data(), pybind11::str{}),
+      pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
+          m_num_cols, phis.data(), pybind11::str{}),                                                           
+      m_num_cols, m_num_levs, num_tracers, dt, ML_model_tq, ML_model_uv, datetime_str);
   pybind11::gil_scoped_release no_gil;  
   ekat::enable_fpes(fpe_mask);
   Real qv_max_after = field_max<Real>(qv_field);

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.hpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.hpp
@@ -55,10 +55,13 @@ class MLCorrection : public AtmosphereProcess {
   Int m_num_levs;
   Field m_lat;
   Field m_lon;
-  std::string m_ML_model_path;
+  std::string m_ML_model_path_tq;
+  std::string m_ML_model_path_uv;
   std::vector<std::string> m_fields_ml_output_variables;
+  bool m_ML_correction_unit_test;
   pybind11::module py_correction;
-  pybind11::object ML_model;
+  pybind11::object ML_model_tq;
+  pybind11::object ML_model_uv;
   int fpe_mask;
 };  // class MLCorrection
 

--- a/components/eamxx/src/physics/ml_correction/ml_correction.py
+++ b/components/eamxx/src/physics/ml_correction/ml_correction.py
@@ -23,7 +23,7 @@ def ensure_correction_ordering(correction):
     return correction
 
 
-def get_ML_correction(model, T_mid, qv, cos_zenith, dt):
+def get_ML_correction_dQ1_dQ2(model, T_mid, qv, cos_zenith, dt):
     ds = xr.Dataset(
         data_vars=dict(
             T_mid=(["ncol", "z"], T_mid),
@@ -33,6 +33,26 @@ def get_ML_correction(model, T_mid, qv, cos_zenith, dt):
     )
     return ensure_correction_ordering(predict(model, ds, dt))
 
+def get_ML_correction_dQu_dQv(model, T_mid, qv, cos_zenith, lat, phis, u, v, dt):
+    ds = xr.Dataset(
+        data_vars=dict(
+            T_mid=(["ncol", "z"], T_mid),
+            qv=(["ncol", "z"], qv),
+            U=(["ncol", "z"], u),
+            V=(["ncol", "z"], v),
+            lat=(["ncol"], lat),
+            surface_geopotential=(["ncol"], phis),
+            cos_zenith_angle=(["ncol"], cos_zenith),
+        )
+    )
+    output = ensure_correction_ordering(predict(model, ds, dt))
+    # rename dQxwind and dQywind to dQu and dQv if needed
+    if "dQxwind" in output.keys():
+        output["dQu"] = output.pop("dQxwind")
+    if "dQywind" in output.keys():
+        output["dQv"] = output.pop("dQywind")
+            
+    return output
 
 def update_fields(
     T_mid,
@@ -41,14 +61,34 @@ def update_fields(
     v,
     lat,
     lon,
+    phis,
     Ncol,
     Nlev,
     num_tracers,
     dt,
-    model,
+    model_tq,
+    model_uv,
     current_time,
 ):
+    """
+    T_mid: temperature
+    qv: specific humidity
+    u: x-component of wind
+    v: y-component of wind
+    lat: latitude
+    lon: longitude
+    phis: surface geopotential
+    Ncol: number of columns
+    Nlev: number of levels
+    num_tracers: number of tracers
+    dt: time step (s)
+    model_tq: path to the ML model for temperature and specific humidity
+    model_uv: path to the ML model for u and v
+    current_time: current time in the format "YYYY-MM-DD HH:MM:SS"
+    """
     T_mid = np.reshape(T_mid, (-1, Nlev))
+    u = np.reshape(u, (-1, Nlev))
+    v = np.reshape(v, (-1, Nlev))
     # qv is a 3D array of shape (Ncol, num_tracers, Nlev)
     # by default, qv is the frist tracer variable
     qv = np.reshape(qv, (-1, num_tracers, Nlev))
@@ -58,6 +98,11 @@ def update_fields(
         lon,
         lat,
     )
-    correction = get_ML_correction(model, T_mid, qv[:, 0, :], cos_zenith, dt)
-    T_mid[:, :] += correction["dQ1"].values * dt
-    qv[:, 0, :] += correction["dQ2"].values * dt
+    if model_tq is not None:
+        correction_tq = get_ML_correction_dQ1_dQ2(model_tq, T_mid, qv[:, 0, :], cos_zenith, dt)
+        T_mid[:, :] += correction_tq["dQ1"].values * dt
+        qv[:, 0, :] += correction_tq["dQ2"].values * dt
+    if model_uv is not None:
+        correction_uv = get_ML_correction_dQu_dQv(model_uv, T_mid, qv[:, 0, :], cos_zenith, lat, phis, u, v, dt)
+        u[:, :] += correction_uv["dQu"].values * dt
+        v[:, :] += correction_uv["dQv"].values * dt        

--- a/components/eamxx/src/physics/ml_correction/ml_correction.py
+++ b/components/eamxx/src/physics/ml_correction/ml_correction.py
@@ -8,12 +8,20 @@ from scream_run.steppers.machine_learning import (
     predict,
 )
 
+
 def get_ML_model(model_path):
     if model_path == "NONE":
         return None
     config = MachineLearningConfig(models=[model_path])
     model = open_model(config)
-    return model    
+    return model
+
+
+def ensure_correction_ordering(correction):
+    for key in correction:
+        correction[key] = correction[key].transpose("ncol", "z")
+    return correction
+
 
 def get_ML_correction(model, T_mid, qv, cos_zenith, dt):
     ds = xr.Dataset(
@@ -23,7 +31,7 @@ def get_ML_correction(model, T_mid, qv, cos_zenith, dt):
             cos_zenith_angle=(["ncol"], cos_zenith),
         )
     )
-    return predict(model, ds, dt)
+    return ensure_correction_ordering(predict(model, ds, dt))
 
 
 def update_fields(

--- a/components/eamxx/tests/uncoupled/ml_correction/input.yaml
+++ b/components/eamxx/tests/uncoupled/ml_correction/input.yaml
@@ -11,8 +11,10 @@ time_stepping:
 atmosphere_processes:
   atm_procs_list: [MLCorrection]
   MLCorrection:
-    ML_model_path: NONE
+    ML_model_path_tq: NONE
+    ML_model_path_uv: NONE
     ML_output_fields: ["qv","T_mid"]
+    ML_correction_unit_test: True
 grids_manager:
   Type: Mesh Free
   grids_names: [Physics]

--- a/components/eamxx/tests/uncoupled/ml_correction/test_correction.py
+++ b/components/eamxx/tests/uncoupled/ml_correction/test_correction.py
@@ -8,7 +8,17 @@ from scream_run.steppers.machine_learning import (
 )
 
 
-def sample_ML_prediction(nz: int, input_data: np.ndarray):
+def get_ML_model(model_path):
+    if model_path == "NONE":
+        return None
+    config = MachineLearningConfig(models=[model_path])
+    model = open_model(config)
+    return model
+
+
+def sample_ML_prediction(
+    nz: int, input_data: np.ndarray, ML_model_tq: str, ML_model_uv: str
+):
     """
     This function is used to generate a sample ML prediction for the given input data.
     We use a constant output predictor to generate the prediction.
@@ -30,7 +40,7 @@ def sample_ML_prediction(nz: int, input_data: np.ndarray):
     return output["qv"].values
 
 
-def modify_view(data, Ncol, Nlev):
+def modify_view(data, Ncol, Nlev, model_tq, model_uv):
     data = np.reshape(data, (-1, Nlev))
-    prediction = sample_ML_prediction(Nlev, data[1, :])
+    prediction = sample_ML_prediction(Nlev, data[1, :], model_tq, model_uv)
     data[1, :] = prediction


### PR DESCRIPTION
In this PR, we add the capability of ML correction for `u` and `v`. Currently, this is done in a separate ML model, one for temperature and specific humidity, and the other for winds. Additional input fields are needed (`phis`) and will be passed to python regardless of whether `ML_model_path_uv` is specified. 

We also added `ML_correction_unit_test` in the namelist to accommodate the unit test that does not have access to lat/lon and surface geopotential. This allows us to move get lat/lon and phis to `set_grids`.