### PR TITLE
Changes needed for creating, allocating, and deepcpoying rank-0 fields

### DIFF
--- a/components/eamxx/src/physics/p3/CMakeLists.txt
+++ b/components/eamxx/src/physics/p3/CMakeLists.txt
@@ -93,7 +93,7 @@ foreach (P3_LIB IN LISTS P3_LIBS)
     Fortran_MODULE_DIRECTORY ${P3_LIB}/modules
   )
   target_include_directories(${P3_LIB} PUBLIC
-    ${CMAKE_CURRENT_BINARY_DIR}/modules
+    ${CMAKE_CURRENT_BINARY_DIR}/${P3_LIB}/modules
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/impl
     ${SCREAM_BASE_DIR}/../eam/src/physics/cam

--- a/components/eamxx/src/physics/p3/impl/p3_get_latent_heat_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_get_latent_heat_impl.hpp
@@ -10,8 +10,6 @@ template<typename S, typename D>
 void Functions<S,D>
 ::get_latent_heat(const Int& nj, const Int& nk, view_2d<Spack>& v, view_2d<Spack>& s, view_2d<Spack>& f)
 {
-  using ExeSpace = typename KT::ExeSpace;
-
   constexpr Scalar latvap  = C::LatVap;
   constexpr Scalar latice  = C::LatIce;
 

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -150,12 +150,8 @@ void Field::allocate_view ()
 
   // Short names
   const auto& id     = m_header->get_identifier();
-  const auto& layout = id.get_layout_ptr();
+  const auto& layout = id.get_layout();
   auto& alloc_prop   = m_header->get_alloc_properties();
-
-  // Check the identifier has all the dimensions set
-  EKAT_REQUIRE_MSG(layout->are_dimensions_set(),
-      "Error! Cannot allocate the view until all the field's dimensions are set.\n");
 
   // Commit the allocation properties
   alloc_prop.commit(layout);

--- a/components/eamxx/src/share/field/field_alloc_prop.cpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.cpp
@@ -162,8 +162,12 @@ void FieldAllocProp::commit (const layout_type& layout)
       m_last_extent = std::max(m_last_extent, num_st);
     }
 
-    m_alloc_size = m_layout.size() / last_phys_extent  // All except the last dimension
-                 * m_last_extent * m_scalar_type_size; // Last dimension must account for padding (if any)
+    if (m_layout.size()>0) {
+      m_alloc_size = m_layout.size() / last_phys_extent  // All except the last dimension
+                   * m_last_extent * m_scalar_type_size; // Last dimension must account for padding (if any)
+    } else {
+      m_alloc_size = 0;
+    }
   }
 
   m_contiguous = true;

--- a/components/eamxx/src/share/field/field_alloc_prop.cpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.cpp
@@ -37,9 +37,9 @@ subview (const int idim, const int k, const bool dynamic) const {
       "Error! Subview requires alloc properties to be committed.\n");
   EKAT_REQUIRE_MSG (idim==0 || idim==1,
       "Error! Subviewing is only allowed along first or second dimension.\n");
-  EKAT_REQUIRE_MSG (idim<m_layout->rank(),
+  EKAT_REQUIRE_MSG (idim<m_layout.rank(),
       "Error! Dimension index out of bounds.\n");
-  EKAT_REQUIRE_MSG (k>=0 && k<m_layout->dim(idim),
+  EKAT_REQUIRE_MSG (k>=0 && k<m_layout.dim(idim),
       "Error! Index along the dimension is out of bounds.\n");
 
   // Set new layout basic stuff
@@ -47,8 +47,8 @@ subview (const int idim, const int k, const bool dynamic) const {
   props.m_committed = false;
   props.m_scalar_type_size = m_scalar_type_size;
   props.m_pack_size_max = m_pack_size_max;
-  props.m_alloc_size = m_alloc_size / m_layout->dim(idim);
-  props.m_subview_info = SubviewInfo(idim,k,m_layout->dim(idim),dynamic);
+  props.m_alloc_size = m_alloc_size / m_layout.dim(idim);
+  props.m_subview_info = SubviewInfo(idim,k,m_layout.dim(idim),dynamic);
 
   // The output props should still store a FieldLayout, in case
   // they are further subviewed. We have all we need here to build
@@ -59,29 +59,25 @@ subview (const int idim, const int k, const bool dynamic) const {
   // HOWEVER, this may cause bugs, cause the user might make a mistake,
   // and pass the wrong layout. Therefore, we build a "temporary" one,
   // which will be replaced during the call to 'commit'.
-  std::vector<FieldTag> tags = m_layout->tags();
-  std::vector<int> dims = m_layout->dims();
-  tags.erase(tags.begin()+idim);
-  dims.erase(dims.begin()+idim);
-  props.m_layout = std::make_shared<layout_type>(tags,dims);
+  props.m_layout = m_layout.strip_dim(idim);
 
   // Output is contioguous if either
   //  - this->m_contiguous=true AND idim==0
-  //  - m_layout->dim(i)==1 for all i<idim
-  //  - props.m_layout->rank()==0
-  props.m_contiguous = m_contiguous || props.m_layout->rank()==0;
+  //  - m_layout.dim(i)==1 for all i<idim
+  //  - props.m_layout.rank()==0
+  props.m_contiguous = m_contiguous || props.m_layout.rank()==0;
   for (int i=0; i<idim; ++i) {
-    if (m_layout->dim(i)>0) {
+    if (m_layout.dim(i)>0) {
       props.m_contiguous = false;
       break;
     }
   }
 
   // Figure out strides
-  const int rm1 = m_layout->rank()-1;
+  const int rm1 = m_layout.rank()-1;
   if (idim==rm1) {
     // We're slicing the possibly padded dim, so everything else is as in the layout
-    props.m_last_extent = m_layout->dim(idim);
+    props.m_last_extent = m_layout.dim(idim);
   } else {
     // We are keeping the last dim, so same last extent
     props.m_last_extent = m_last_extent;
@@ -113,7 +109,7 @@ void FieldAllocProp::request_allocation (const FieldAllocProp& src)
 int FieldAllocProp::get_padding () const {
   EKAT_REQUIRE_MSG(is_committed(),
       "Error! You cannot query the allocation padding until after calling commit().");
-  int padding = m_last_extent - m_layout->dims().back();
+  int padding = m_last_extent - m_layout.dims().back();
   return padding;
 }
 
@@ -131,23 +127,19 @@ void FieldAllocProp::reset_subview_idx (const int idx) {
   m_subview_info.slice_idx = idx;
 }
 
-void FieldAllocProp::commit (const layout_ptr_type& layout)
+void FieldAllocProp::commit (const layout_type& layout)
 {
   if (is_committed()) {
     // TODO: should we issue a warning? Error? For now, I simply do nothing
     return;
   }
 
-  EKAT_REQUIRE_MSG (layout,
-      "Error! Invalid input layout pointer.\n");
-
   if (m_alloc_size>0) {
     // This obj was created as a subview of another alloc props obj.
-    // Check that input layout matches the stored one, then replace the ptr.
-    EKAT_REQUIRE_MSG (*layout==*m_layout,
+    // Check that input layout matches the stored one
+    EKAT_REQUIRE_MSG (layout==m_layout,
         "Error! The input field layout does not match the stored one.\n");
 
-    m_layout = layout;
     m_committed = true;
     return;
   }
@@ -155,13 +147,13 @@ void FieldAllocProp::commit (const layout_ptr_type& layout)
   // Sanity checks: we must have requested at least one value type, and the identifier needs all dimensions set by now.
   EKAT_REQUIRE_MSG(m_value_type_sizes.size()>0,
       "Error! No value types requested for the allocation.\n");
-  EKAT_REQUIRE_MSG(layout->are_dimensions_set(),
+  EKAT_REQUIRE_MSG(layout.are_dimensions_set(),
       "Error! You need all field dimensions set before committing the allocation properties.\n");
 
-  // Store pointer to layout for future use (in case subview is called)
+  // Store layout for future use (in case subview is called)
   m_layout = layout;
 
-  if (m_layout->rank()==0) {
+  if (m_layout.size()==0) {
     // Zero-dimensional fields are supported. In this case allocate a single
     // scalar, but set the last extent to 0 since we have no dimension.
     m_alloc_size = m_scalar_type_size;
@@ -169,7 +161,7 @@ void FieldAllocProp::commit (const layout_ptr_type& layout)
   } else {
     // Loop on all value type sizes.
     m_last_extent = 0;
-    int last_phys_extent = m_layout->dims().back();
+    int last_phys_extent = m_layout.dims().back();
     for (auto vts : m_value_type_sizes) {
       // The number of scalar_type in a value_type
       const int vt_len = vts / m_scalar_type_size;
@@ -187,7 +179,7 @@ void FieldAllocProp::commit (const layout_ptr_type& layout)
       m_last_extent = std::max(m_last_extent, num_st);
     }
 
-    m_alloc_size = (m_layout->size() / last_phys_extent) // All except the last dimension
+    m_alloc_size = (m_layout.size() / last_phys_extent) // All except the last dimension
                    * m_last_extent * m_scalar_type_size;
   }
 

--- a/components/eamxx/src/share/field/field_alloc_prop.cpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.cpp
@@ -135,7 +135,7 @@ void FieldAllocProp::commit (const layout_type& layout)
   // Store layout for future use (in case subview is called)
   m_layout = layout;
 
-  if (m_layout.size()==0) {
+  if (m_layout.rank()==0) {
     // Zero-dimensional fields are supported. In this case allocate a single
     // scalar, but set the last extent to 0 since we have no dimension.
     m_alloc_size = m_scalar_type_size;

--- a/components/eamxx/src/share/field/field_alloc_prop.cpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.cpp
@@ -101,7 +101,7 @@ void FieldAllocProp::request_allocation (const FieldAllocProp& src)
 int FieldAllocProp::get_padding () const {
   EKAT_REQUIRE_MSG(is_committed(),
       "Error! You cannot query the allocation padding until after calling commit().");
-  int padding = m_last_extent - m_layout.dims().back();
+  int padding = m_layout.rank()==0 ? 0 : m_last_extent - m_layout.dims().back();
   return padding;
 }
 

--- a/components/eamxx/src/share/field/field_alloc_prop.cpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.cpp
@@ -3,7 +3,8 @@
 namespace scream {
 
 FieldAllocProp::FieldAllocProp (const int scalar_size)
- : m_value_type_sizes (1,scalar_size)
+ : m_layout           (FieldLayout::invalid())
+ , m_value_type_sizes (1,scalar_size)
  , m_scalar_type_size (scalar_size)
  , m_pack_size_max    (1)
  , m_alloc_size       (0)
@@ -44,43 +45,34 @@ subview (const int idim, const int k, const bool dynamic) const {
 
   // Set new layout basic stuff
   FieldAllocProp props(m_scalar_type_size);
-  props.m_committed = false;
+  props.m_committed = true;
   props.m_scalar_type_size = m_scalar_type_size;
-  props.m_pack_size_max = m_pack_size_max;
-  props.m_alloc_size = m_alloc_size / m_layout.dim(idim);
-  props.m_subview_info = SubviewInfo(idim,k,m_layout.dim(idim),dynamic);
-
-  // The output props should still store a FieldLayout, in case
-  // they are further subviewed. We have all we need here to build
-  // a layout from scratch, but it would duplicate what is inside
-  // the FieldIdentifier that will be built for the corresponding
-  // field. Therefore, we'll require the user to still call 'commit',
-  // passing the layout from the field id.
-  // HOWEVER, this may cause bugs, cause the user might make a mistake,
-  // and pass the wrong layout. Therefore, we build a "temporary" one,
-  // which will be replaced during the call to 'commit'.
   props.m_layout = m_layout.strip_dim(idim);
 
   // Output is contioguous if either
   //  - this->m_contiguous=true AND idim==0
   //  - m_layout.dim(i)==1 for all i<idim
-  //  - props.m_layout.rank()==0
-  props.m_contiguous = m_contiguous || props.m_layout.rank()==0;
-  for (int i=0; i<idim; ++i) {
-    if (m_layout.dim(i)>0) {
-      props.m_contiguous = false;
-      break;
-    }
-  }
+  //  - m_layout.rank()==1 (we end up with a rank-0 subview)
+  auto is_one = [](int i) { return i==1; };
+  props.m_contiguous = (m_contiguous and idim==0)
+                       || m_layout.rank()==1
+                       || std::all_of(m_layout.dims().begin(),m_layout.dims().begin()+idim,is_one);
 
-  // Figure out strides
+  props.m_subview_info = SubviewInfo(idim,k,m_layout.dim(idim),dynamic);
+
+  // Figure out strides/packs
   const int rm1 = m_layout.rank()-1;
   if (idim==rm1) {
-    // We're slicing the possibly padded dim, so everything else is as in the layout
+    // We're slicing the possibly padded dim, so everything else is as in the layout,
+    // and there is no packing
     props.m_last_extent = m_layout.dim(idim);
+    props.m_pack_size_max = 1;
+    props.m_alloc_size = m_alloc_size / m_last_extent;
   } else {
-    // We are keeping the last dim, so same last extent
+    // We are keeping the last dim, so same last extent and max pack size
     props.m_last_extent = m_last_extent;
+    props.m_pack_size_max = m_pack_size_max;
+    props.m_alloc_size = m_alloc_size / m_layout.dim(idim);
   }
   return props;
 }
@@ -134,16 +126,6 @@ void FieldAllocProp::commit (const layout_type& layout)
     return;
   }
 
-  if (m_alloc_size>0) {
-    // This obj was created as a subview of another alloc props obj.
-    // Check that input layout matches the stored one
-    EKAT_REQUIRE_MSG (layout==m_layout,
-        "Error! The input field layout does not match the stored one.\n");
-
-    m_committed = true;
-    return;
-  }
-
   // Sanity checks: we must have requested at least one value type, and the identifier needs all dimensions set by now.
   EKAT_REQUIRE_MSG(m_value_type_sizes.size()>0,
       "Error! No value types requested for the allocation.\n");
@@ -157,6 +139,7 @@ void FieldAllocProp::commit (const layout_type& layout)
     // Zero-dimensional fields are supported. In this case allocate a single
     // scalar, but set the last extent to 0 since we have no dimension.
     m_alloc_size = m_scalar_type_size;
+    m_pack_size_max = 1;
     m_last_extent = 0;
   } else {
     // Loop on all value type sizes.
@@ -179,8 +162,8 @@ void FieldAllocProp::commit (const layout_type& layout)
       m_last_extent = std::max(m_last_extent, num_st);
     }
 
-    m_alloc_size = (m_layout.size() / last_phys_extent) // All except the last dimension
-                   * m_last_extent * m_scalar_type_size;
+    m_alloc_size = m_layout.size() / last_phys_extent  // All except the last dimension
+                 * m_last_extent * m_scalar_type_size; // Last dimension must account for padding (if any)
   }
 
   m_contiguous = true;

--- a/components/eamxx/src/share/field/field_alloc_prop.cpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.cpp
@@ -161,10 +161,9 @@ void FieldAllocProp::commit (const layout_ptr_type& layout)
   // Store pointer to layout for future use (in case subview is called)
   m_layout = layout;
 
-  if (m_layout->size()==0) {
-    // Zero-dimensional fields are supported, so we may end up with a
-    // layout of size 0. In this case allocate a single scalar, but
-    // set the last extent to 0 since we have no dimension.
+  if (m_layout->rank()==0) {
+    // Zero-dimensional fields are supported. In this case allocate a single
+    // scalar, but set the last extent to 0 since we have no dimension.
     m_alloc_size = m_scalar_type_size;
     m_last_extent = 0;
   } else {

--- a/components/eamxx/src/share/field/field_alloc_prop.hpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.hpp
@@ -103,7 +103,7 @@ public:
   void request_allocation (const FieldAllocProp& src);
 
   // Locks the allocation properties, preventing furter value types requests
-  void commit (const layout_ptr_type& layout);
+  void commit (const layout_type& layout);
 
   // For dynamic subfield, reset the slice index
   void reset_subview_idx (const int idx);
@@ -145,7 +145,7 @@ public:
 protected:
 
   // The FieldLayout associated to this allocation
-  layout_ptr_type     m_layout;
+  layout_type     m_layout;
 
   // The list of requested value types for this allocation
   std::vector<int>    m_value_type_sizes;

--- a/components/eamxx/src/share/field/field_header.cpp
+++ b/components/eamxx/src/share/field/field_header.cpp
@@ -68,7 +68,6 @@ create_subfield_header (const FieldIdentifier& id,
 
   // Create alloc props
   fh->m_alloc_prop = std::make_shared<FieldAllocProp>(parent->get_alloc_properties().subview(idim,k,dynamic));
-  fh->m_alloc_prop->commit(id.get_layout());
 
   return fh;
 }

--- a/components/eamxx/src/share/field/field_header.cpp
+++ b/components/eamxx/src/share/field/field_header.cpp
@@ -54,8 +54,6 @@ create_subfield_header (const FieldIdentifier& id,
   // Sanity checks
   EKAT_REQUIRE_MSG (parent!=nullptr,
       "Error! Invalid pointer for parent header.\n");
-  EKAT_REQUIRE_MSG (id.get_layout_ptr()!=nullptr,
-      "Error! Input field identifier has an invalid layout pointer.\n");
 
   // Create header, and set up parent/child
   auto fh = create_header(id);
@@ -70,7 +68,7 @@ create_subfield_header (const FieldIdentifier& id,
 
   // Create alloc props
   fh->m_alloc_prop = std::make_shared<FieldAllocProp>(parent->get_alloc_properties().subview(idim,k,dynamic));
-  fh->m_alloc_prop->commit(id.get_layout_ptr());
+  fh->m_alloc_prop->commit(id.get_layout());
 
   return fh;
 }

--- a/components/eamxx/src/share/field/field_identifier.cpp
+++ b/components/eamxx/src/share/field/field_identifier.cpp
@@ -21,11 +21,12 @@ FieldIdentifier (const std::string& name,
                  const std::string& grid_name,
                  const DataType data_type)
  : m_name      (name)
+ , m_layout    (layout)
  , m_units     (units)
  , m_grid_name (grid_name)
  , m_data_type (data_type)
 {
-  set_layout (layout);
+  update_identifier();
 }
 
 FieldIdentifier
@@ -37,38 +38,15 @@ alias (const std::string& name) const
   return fid;
 }
 
-void FieldIdentifier::set_layout (const layout_type& layout) {
-  set_layout(std::make_shared<layout_type>(layout));
-}
-
-void FieldIdentifier::set_layout (const layout_ptr_type& layout) {
-  EKAT_REQUIRE_MSG (!m_layout,
-      "Error! You cannot reset the layout once it's set.\n");
-  EKAT_REQUIRE_MSG (layout,
-      "Error! Invalid input layout pointer.\n");
-  EKAT_REQUIRE_MSG (layout->are_dimensions_set(),
-      "Error! Input layout must have dimensions set.\n");
-
-  m_layout = layout;
-  update_identifier ();
-}
-
 void FieldIdentifier::update_identifier () {
   // Create a verbose identifier string.
   m_identifier = m_name + "[" + m_grid_name + "] <" + e2str(m_data_type);
-  if (m_layout->rank()>0) {
-    m_identifier += ":" + e2str(m_layout->tags()[0]);
-    for (int dim=1; dim<m_layout->rank(); ++dim) {
-      m_identifier += "," + e2str(m_layout->tags()[dim]);
-    }
-    m_identifier += ">(" + std::to_string(m_layout->dims()[0]);
-    for (int dim=1; dim<m_layout->rank(); ++dim) {
-      m_identifier += "," + std::to_string(m_layout->dims()[dim]);
-    }
-    m_identifier += ")";
-  } else {
-    m_identifier += ">";
+  auto print_tag = [](FieldTag t) {return e2str(t); };
+  if (m_layout.rank()>0) {
+    m_identifier += ":" + ekat::join(m_layout.tags(),print_tag,",");
   }
+  m_identifier += ">";
+  m_identifier += "(" + ekat::join(m_layout.dims(),",") + ")";
 
   m_identifier += " [" + m_units.get_string() + "]";
 }

--- a/components/eamxx/src/share/field/field_identifier.hpp
+++ b/components/eamxx/src/share/field/field_identifier.hpp
@@ -40,7 +40,6 @@ field_valid_data_types ()
 class FieldIdentifier {
 public:
   using layout_type     = FieldLayout;
-  using layout_ptr_type = std::shared_ptr<const layout_type>;
   using ci_string       = ekat::CaseInsensitiveString;
   using Units           = ekat::units::Units;
 
@@ -66,8 +65,7 @@ public:
 
   // Name and layout informations
   const std::string&      name           () const { return m_name;      }
-  const layout_type&      get_layout     () const { return *m_layout;   }
-  const layout_ptr_type&  get_layout_ptr () const { return m_layout;    }
+  const layout_type&      get_layout     () const { return m_layout;   }
   const Units&            get_units      () const { return m_units;     }
   const std::string&      get_grid_name  () const { return m_grid_name; }
   DataType                data_type      () const { return m_data_type; }
@@ -80,10 +78,6 @@ public:
 
   // ----- Setters ----- //
 
-  // Note: as soon as the layout is set, it cannot be changed.
-  void set_layout (const layout_type& layout);
-  void set_layout (const layout_ptr_type& layout);
-
   // We reimplement the equality operator for identifiers comparison (needed for some std container)
   friend bool operator== (const FieldIdentifier&, const FieldIdentifier&);
   friend bool operator<  (const FieldIdentifier&, const FieldIdentifier&);
@@ -94,7 +88,7 @@ protected:
 
   ci_string       m_name;
 
-  layout_ptr_type m_layout;
+  layout_type     m_layout;
 
   Units           m_units;
 

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -194,7 +194,7 @@ deep_copy_impl (const Field& src) {
   const auto& layout     =     get_header().get_identifier().get_layout();
   const auto& layout_src = src.get_header().get_identifier().get_layout();
   EKAT_REQUIRE_MSG(layout==layout_src,
-       "ERROR: Unable to copy field " + src.get_header().get_identifier().name() + 
+       "ERROR: Unable to copy field " + src.get_header().get_identifier().name() +
           " to field " + get_header().get_identifier().name() + ".  Layouts don't match.");
   const auto  rank = layout.rank();
   // Note: we can't just do a deep copy on get_view_impl<HD>(), since this
@@ -218,6 +218,13 @@ deep_copy_impl (const Field& src) {
   auto policy = RangePolicy(0,layout.size());
 
   switch (rank) {
+    case 0:
+      {
+        auto v     =     get_view<      ST,HD>();
+        auto v_src = src.get_view<const ST,HD>();
+        v() = v_src();
+      }
+      break;
     case 1:
       {
         if (src_alloc_props.contiguous() and tgt_alloc_props.contiguous()) {
@@ -318,6 +325,12 @@ void Field::deep_copy_impl (const ST value) {
   const auto& layout = get_header().get_identifier().get_layout();
   const auto  rank   = layout.rank();
   switch (rank) {
+    case 0:
+      {
+        auto v = get_view<ST,HD>();
+        v() = value;
+      }
+      break;
     case 1:
       {
         if (m_header->get_alloc_properties().contiguous()) {

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -96,6 +96,8 @@ LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
   const int n_element = count(tags,EL);
   const int n_column  = count(tags,COL);
   const int ngp       = count(tags,GP);
+  const int nvlevs    = count(tags,LEV) + count(tags,ILEV);
+  const int ncomps    = count(tags,CMP);
 
   // Start from undefined/invalid
   LayoutType result = LayoutType::Invalid;
@@ -112,6 +114,14 @@ LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
 
     // Remove the column tag
     erase(tags,COL);
+  } else if (tags.size()==0) {
+    return LayoutType::Scalar0D;
+  } else if (tags.size()==1 and tags[0]==CMP) {
+    return LayoutType::Vector0D;
+  } else if (tags.size()==1 and nvlevs==1) {
+    return LayoutType::Scalar1D;
+  } else if (tags.size()==2 and ncomps==1 and nvlevs==1) {
+    return LayoutType::Vector1D;
   } else {
     // Not a supported layout.
     return result;

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -6,21 +6,15 @@ namespace scream
 {
 
 FieldLayout::FieldLayout (const std::initializer_list<FieldTag>& tags)
- : m_rank(tags.size())
- , m_tags(tags)
+ : FieldLayout(std::vector<FieldTag>(tags))
 {
-  m_dims.resize(m_rank,-1);
-  m_extents = decltype(m_extents)("",m_rank);
-  Kokkos::deep_copy(m_extents,-1);
+  // Nothing to do here
 }
 
 FieldLayout::FieldLayout (const std::vector<FieldTag>& tags)
- : m_rank(tags.size())
- , m_tags(tags)
+ : FieldLayout(tags,std::vector<int>(tags.size(),-1))
 {
-  m_dims.resize(m_rank,-1);
-  m_extents = decltype(m_extents)("",m_rank);
-  Kokkos::deep_copy(m_extents,-1);
+  // Nothing to do here
 }
 
 FieldLayout::FieldLayout (const std::vector<FieldTag>& tags,
@@ -30,8 +24,9 @@ FieldLayout::FieldLayout (const std::vector<FieldTag>& tags,
 {
   m_dims.resize(m_rank,-1);
   m_extents = decltype(m_extents)("",m_rank);
-  Kokkos::deep_copy(m_extents,-1);
-  set_dimensions(dims);
+  for (int idim=0; idim<m_rank; ++idim) {
+    set_dimension(idim,dims[idim]);
+  }
 }
 
 bool FieldLayout::is_vector_layout () const {
@@ -69,6 +64,10 @@ FieldLayout FieldLayout::strip_dim (const FieldTag tag) const {
 }
 
 FieldLayout FieldLayout::strip_dim (const int idim) const {
+  EKAT_REQUIRE_MSG (idim>=0 and idim<m_rank,
+      "Error! Cannot strip dimension, because it is out of bounds.\n"
+      "  - input dim index: " + std::to_string(idim) + "\n"
+      "  - layout rank    : " + std::to_string(m_rank) + "\n");
   std::vector<FieldTag> t = tags();
   std::vector<int>      d = dims();
   t.erase(t.begin()+idim);
@@ -81,20 +80,10 @@ void FieldLayout::set_dimension (const int idim, const int dimension) {
   EKAT_REQUIRE_MSG(dimension>=0, "Error! Dimensions must be non-negative.");
   m_dims[idim] = dimension;
 
-  // Recompute extents
-  auto extents = Kokkos::create_mirror_view(m_extents);
-  Kokkos::deep_copy(extents,m_extents);
-  extents(idim) = dimension;
-  Kokkos::deep_copy(m_extents,extents);
-}
-
-void FieldLayout::set_dimensions (const std::vector<int>& dims) {
-  // Check, then set dims
-  EKAT_REQUIRE_MSG(dims.size()==static_cast<size_t>(m_rank),
-                     "Error! Input dimensions vector not properly sized.");
-  for (int idim=0; idim<m_rank; ++idim) {
-    set_dimension(idim,dims[idim]);
-  }
+  // Recompute device extents
+  auto extents_h = Kokkos::create_mirror_view(m_extents);
+  std::copy_n(m_dims.begin(),m_rank,extents_h.data());
+  Kokkos::deep_copy(m_extents,extents_h);
 }
 
 LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -16,6 +16,10 @@ namespace scream
 // The type of the layout, that is, the kind of field it represent.
 enum class LayoutType {
   Invalid,
+  Scalar0D,
+  Vector0D,
+  Scalar1D,
+  Vector1D,
   Scalar2D,
   Vector2D,
   Tensor2D,
@@ -27,6 +31,10 @@ enum class LayoutType {
 inline std::string e2str (const LayoutType lt) {
   std::string name;
   switch (lt) {
+    case LayoutType::Scalar0D: name = "Scalar0D"; break;
+    case LayoutType::Vector0D: name = "Vector0D"; break;
+    case LayoutType::Scalar1D: name = "Scalar1D"; break;
+    case LayoutType::Vector1D: name = "Vector1D"; break;
     case LayoutType::Scalar2D: name = "Scalar2D"; break;
     case LayoutType::Vector2D: name = "Vector2D"; break;
     case LayoutType::Tensor2D: name = "Tensor2D"; break;

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -136,9 +136,6 @@ inline int FieldLayout::dim (const int idim) const {
 }
 
 inline long long FieldLayout::size () const {
-  // A rank-0 field should have size 0.
-  if (m_rank == 0) return 0;
-
   EKAT_REQUIRE_MSG(are_dimensions_set(),
       "Error! Field dimensions not yet set.\n");
   long long prod = 1;

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -136,6 +136,9 @@ inline int FieldLayout::dim (const int idim) const {
 }
 
 inline long long FieldLayout::size () const {
+  // A rank-0 field should have size 0.
+  if (m_rank == 0) return 0;
+
   EKAT_REQUIRE_MSG(are_dimensions_set(),
       "Error! Field dimensions not yet set.\n");
   long long prod = 1;

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -98,9 +98,7 @@ public:
 
   // ----- Setters ----- //
 
-  // Note: as soon as a dimension is set, it cannot be changed.
   void set_dimension  (const int idim, const int dimension);
-  void set_dimensions (const std::vector<int>& dims);
 
 protected:
 

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -519,13 +519,13 @@ void FieldManager::registration_ends ()
       // Figure out the layout of the fields in this cluster,
       // and make sure they all have the same layout
       LayoutType lt = LayoutType::Invalid;
-      std::shared_ptr<const FieldLayout> f_layout;
+      FieldLayout f_layout = FieldLayout::invalid();
       for (const auto& fname : cluster_ordered_fields) {
         const auto& f = m_fields.at(fname);
         const auto& id = f->get_header().get_identifier();
         if (lt==LayoutType::Invalid) {
-         f_layout = id.get_layout_ptr();
-         lt = get_layout_type(f_layout->tags());
+         f_layout = id.get_layout();
+         lt = get_layout_type(f_layout.tags());
         } else {
           EKAT_REQUIRE_MSG (lt==get_layout_type(id.get_layout().tags()),
               "Error! Found a group to bundle containing fields with different layouts.\n"
@@ -542,7 +542,7 @@ void FieldManager::registration_ends ()
       if (lt==LayoutType::Scalar2D) {
         c_layout = m_grid->get_2d_vector_layout(CMP,cluster_ordered_fields.size());
       } else {
-        c_layout = m_grid->get_3d_vector_layout(f_layout->tags().back()==LEV,CMP,cluster_ordered_fields.size());
+        c_layout = m_grid->get_3d_vector_layout(f_layout.tags().back()==LEV,CMP,cluster_ordered_fields.size());
       }
 
       // The units for the bundled field are nondimensional, cause checking whether

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -137,6 +137,12 @@ void randomize (const Field& f, Engine& engine, PDF&& pdf)
 {
   const auto& fl = f.get_header().get_identifier().get_layout();
   switch (fl.rank()) {
+    case 0:
+      {
+        auto v = f.template get_view<ST,Host>();
+        v() = pdf(engine);
+      }
+      break;
     case 1:
       {
         auto v = f.template get_view<ST*,Host>();

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -379,8 +379,6 @@ TEST_CASE("field", "") {
       f1.subfield(0, i).deep_copy(f0);
       REQUIRE(v1(i) == v0());
     }
-
-    printf("DONE\n");
   }
 }
 

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -17,18 +17,6 @@
 
 namespace {
 
-TEST_CASE("field_layout") {
-  using namespace scream;
-  using namespace ShortFieldTagsNames;
-
-  FieldLayout l({EL,GP,GP});
-
-  // Should not be able to set a dimensions vector of wrong rank
-  REQUIRE_THROWS(l.set_dimensions({1,2}));
-
-  l.set_dimensions({1,2,3});
-}
-
 TEST_CASE("field_identifier", "") {
   using namespace scream;
   using namespace ekat::units;

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -347,6 +347,41 @@ TEST_CASE("field", "") {
       }
     }
   }
+
+  SECTION ("rank0_field") {
+    // Create 0d field
+    FieldIdentifier fid0("f_0d", FieldLayout({}), Units::nondimensional(), "dummy_grid");
+    Field f0(fid0);
+    f0.allocate_view();
+
+    // Create 1d field
+    FieldIdentifier fid1("f_1d", FieldLayout({COL}, {5}), Units::nondimensional(), "dummy_grid");
+    Field f1(fid1);
+    f1.allocate_view();
+
+    // Randomize 1d field
+    randomize(f1,engine,pdf);
+
+    auto v0 = f0.get_view<Real, Host>();
+    auto v1 = f1.get_view<Real*, Host>();
+
+    // Deep copy subfield of 1d field -> 0d field and check result
+    for (size_t i=0; i<v1.extent(0); ++i) {
+      f0.deep_copy(f1.subfield(0, i));
+      REQUIRE(v0() == v1(i));
+    }
+
+    // Randomize 0d field
+    randomize(f0,engine,pdf);
+
+    // Deep copy 0d field -> subfield of 1d field and check result
+    for (size_t i=0; i<v1.extent(0); ++i) {
+      f1.subfield(0, i).deep_copy(f0);
+      REQUIRE(v1(i) == v0());
+    }
+
+    printf("DONE\n");
+  }
 }
 
 TEST_CASE("field_group") {

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -355,7 +355,7 @@ TEST_CASE("field", "") {
 
     // Deep copy subfield of 1d field -> 0d field and check result
     for (size_t i=0; i<v1.extent(0); ++i) {
-      f0.deep_copy(f1.subfield(0, i));
+      f0.deep_copy<Host>(f1.subfield(0, i));
       REQUIRE(v0() == v1(i));
     }
 
@@ -364,7 +364,7 @@ TEST_CASE("field", "") {
 
     // Deep copy 0d field -> subfield of 1d field and check result
     for (size_t i=0; i<v1.extent(0); ++i) {
-      f1.subfield(0, i).deep_copy(f0);
+      f1.subfield(0, i).deep_copy<Host>(f0);
       REQUIRE(v1(i) == v0());
     }
   }


### PR DESCRIPTION
Two issues I've run into when using rank-0 fields in https://github.com/E3SM-Project/scream/pull/2587:
1. When running `Field::allocate_view()`, in `FieldAllocProp::commit()` we ask for `m_layout->dims().back()`, but no dims exist, so we error out. My solution here is to set `m_last_extent=0` (there is no "last dimension"), and `m_alloc_size=m_scalar_type_size` (field will contain a single value)
2. `Field::deep_copy()` (and `randomize(field,...)` which is needed in the test) need a `case 0:` implementation.

@bartgol These are the issues I ran into, maybe others exist.