### PR TITLE
Increase resolution of rain fall speed lookup tables.

### DIFF
--- a/components/eamxx/src/physics/p3/impl/p3_table3_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_table3_impl.hpp
@@ -20,31 +20,15 @@ void Functions<S,D>
 {
   // find location in scaled mean size space
   const auto dum1 = (mu_r+1) / lamr;
-  const auto dum1_lt = context && (dum1 <= sp(195.e-6));
   tab.dumii = 1;
-  if (dum1_lt.any()) {
-    ekat_masked_loop(dum1_lt, s) {
-      const auto inv_dum3 = sp(0.1);
-      auto rdumii = (dum1[s] * sp(1.e6) + 5) * inv_dum3;
+  if (context.any()) {
+    ekat_masked_loop(context, s) {
+      auto rdumii = dum1[s] * sp(1.e6);
       rdumii = ekat::impl::max(rdumii, sp( 1.0));
       rdumii = ekat::impl::min(rdumii, sp(20.0));
       Int dumii = rdumii;
       dumii = ekat::impl::max(dumii,  1);
       dumii = ekat::impl::min(dumii, 20);
-      tab.rdumii[s] = rdumii;
-      tab.dumii[s] = dumii;
-    }
-  }
-  const auto dum1_gte = context && !dum1_lt;
-  if (dum1_gte.any()) {
-    ekat_masked_loop(dum1_gte, s) {
-      const auto inv_dum3 = C::THIRD * sp(0.1);
-      auto rdumii = (dum1[s] * sp(1.e+6) - 195) * inv_dum3 + 20;
-      rdumii = ekat::impl::max(rdumii,sp( 20.0));
-      rdumii = ekat::impl::min(rdumii,sp(300.0));
-      Int dumii = rdumii;
-      dumii = ekat::impl::max(dumii, 20);
-      dumii = ekat::impl::min(dumii,299);
       tab.rdumii[s] = rdumii;
       tab.dumii[s] = dumii;
     }

--- a/components/eamxx/src/physics/p3/p3_iso_c.f90
+++ b/components/eamxx/src/physics/p3/p3_iso_c.f90
@@ -26,11 +26,11 @@ contains
   subroutine init_tables_from_f90_c(vn_table_vals_c, vm_table_vals_c, revap_table_vals_c, mu_table_c) bind(C)
     use micro_p3, only: p3_get_tables
 
-    real(kind=c_real), intent(inout), dimension(300,10) :: vn_table_vals_c, vm_table_vals_c, revap_table_vals_c
+    real(kind=c_real), intent(inout), dimension(9000,10) :: vn_table_vals_c, vm_table_vals_c, revap_table_vals_c
     real(kind=c_real), intent(inout), dimension(150)    :: mu_table_c
 
     real(kind=c_real), dimension(150), target :: mu_table_f
-    real(kind=c_real), dimension(300,10), target :: vn_table_vals_f, vm_table_vals_f, revap_table_vals_f
+    real(kind=c_real), dimension(9000,10), target :: vn_table_vals_f, vm_table_vals_f, revap_table_vals_f
 
     call p3_get_tables(mu_table_f, revap_table_vals_f, vn_table_vals_f, vm_table_vals_f)
     vn_table_vals_c(:,:)    = vn_table_vals_f(:,:)
@@ -54,7 +54,7 @@ contains
     logical(kind=c_bool), intent(in) :: write_tables
 
     real(kind=c_real), dimension(150), target :: mu_r_table_vals
-    real(kind=c_real), dimension(300,10), target :: vn_table_vals, vm_table_vals, revap_table_vals
+    real(kind=c_real), dimension(9000,10), target :: vn_table_vals, vm_table_vals, revap_table_vals
 
     character(len=256), pointer :: lookup_file_dir
     character(kind=c_char, len=256) :: mu_r_filename, revap_filename, vn_filename, vm_filename
@@ -70,9 +70,9 @@ contains
     ok = .false.
 
     call append_precision(mu_r_filename, SCREAM_DATA_DIR//"/tables/mu_r_table_vals.dat")
-    call append_precision(revap_filename, SCREAM_DATA_DIR//"/tables/revap_table_vals.dat")
-    call append_precision(vn_filename, SCREAM_DATA_DIR//"/tables/vn_table_vals.dat")
-    call append_precision(vm_filename, SCREAM_DATA_DIR//"/tables/vm_table_vals.dat")
+    call append_precision(revap_filename, SCREAM_DATA_DIR//"/tables/revap_table_vals_res1micron.dat")
+    call append_precision(vn_filename, SCREAM_DATA_DIR//"/tables/vn_table_vals_res1micron.dat")
+    call append_precision(vm_filename, SCREAM_DATA_DIR//"/tables/vm_table_vals_res1micron.dat")
 
     if (write_tables) then
        call p3_init_b()

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -102,7 +102,7 @@ struct Constants
   static constexpr Scalar stebol        = 5.67e-8; // Stefan-Boltzmann's constant (W/m^2/K^4)
 
   // Table dimension constants
-  static constexpr int VTABLE_DIM0    = 300;
+  static constexpr int VTABLE_DIM0    = 9000;
   static constexpr int VTABLE_DIM1    = 10;
   static constexpr int MU_R_TABLE_DIM = 150;
 


### PR DESCRIPTION
This commit increases the resolution and range of the rain fall speed lookup tables, since the previous resolution caused significant artifacts in the vertical profile of rain. The previous tables used 10 micron resolution for small drop sizes and 30 micron resolution for larger drop sizes, covering a range between 5 and 8595 microns. The new tables have a uniform 1 micron resolution between 1 and 9000 microns, which has proven sufficient to remove the numerical artifacts in simple offline tests.

Since linear interpolation is used to extract fall speeds from the lookup tables, and since the fall speed has negative second derivative with respect to diameter over almost all of its range, this commit systematically increases rain fall speed globally. However, the climate impact of this effect is not expected to be large, since it will generally only result in a small increase in rain evaporation.

This commit will require regeneration of P3 baselines, as well as copying or regenerating the affected lookup tables to the input data directory on all machines.

[CC]