### PR TITLE
Speed up `get_rain_dsd2` calculations.

### DIFF
--- a/components/eamxx/src/physics/p3/impl/p3_dsd2_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_dsd2_impl.hpp
@@ -76,7 +76,7 @@ KOKKOS_FUNCTION
 void Functions<S,D>::
 get_rain_dsd2 (
   const Spack& qr, Spack& nr, Spack& mu_r,
-  Spack& lamr, Spack& cdistr, Spack& logn0r, 
+  Spack& lamr,
   const physics::P3_Constants<S> & p3constants,
   const Smask& context)
 {
@@ -85,8 +85,6 @@ get_rain_dsd2 (
   constexpr auto cons1  = C::CONS1;
 
   lamr.set(context  , 0);
-  cdistr.set(context, 0);
-  logn0r.set(context, 0);
 
   const auto qr_gt_small = qr >= qsmall && context;
 
@@ -99,14 +97,12 @@ get_rain_dsd2 (
     // find spot in lookup table
     // (scaled N/q for lookup table parameter space)
     const auto nr_lim = max(nr, nsmall);
-    Spack inv_dum(0);
-    inv_dum.set(qr_gt_small, cbrt(qr / (cons1 * nr_lim * 6)));
 
     // Apply constant mu_r:  Recall the switch to v4 tables means constant mu_r
     mu_r.set(qr_gt_small, mu_r_const);
     // recalculate slope based on mu_r
-    lamr.set(qr_gt_small, cbrt(cons1 * nr_lim * (mu_r + 3) *
-                                     (mu_r + 2) * (mu_r + 1)/qr));
+    const auto mass_to_d3_factor = cons1 * (mu_r + 3) * (mu_r + 2) * (mu_r + 1);
+    lamr.set(qr_gt_small, cbrt(mass_to_d3_factor * nr_lim / qr));
 
     // check for slope
     const auto lammax = (mu_r+1.)*sp(1.e+5);
@@ -123,15 +119,31 @@ get_rain_dsd2 (
       lamr.set(lt, lammin);
       lamr.set(gt, lammax);
       ekat_masked_loop(either, s) {
-        nr[s] = std::exp(3*std::log(lamr[s]) + std::log(qr[s]) +
-                         std::log(std::tgamma(mu_r[s] + 1)) - std::log(std::tgamma(mu_r[s] + 4)))
-          / cons1;
+        nr[s] = lamr[s]*lamr[s]*lamr[s] * qr[s] / mass_to_d3_factor[s];
       }
     }
+  }
+}
 
+template <typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::
+get_cdistr_logn0r (
+  const Spack& qr, const Spack& nr, const Spack& mu_r,
+  const Spack& lamr, Spack& cdistr, Spack& logn0r,
+  const Smask& context)
+{
+  constexpr auto qsmall = C::QSMALL;
+
+  cdistr.set(context, 0);
+  logn0r.set(context, 0);
+
+  const auto qr_gt_small = qr >= qsmall && context;
+
+  if (qr_gt_small.any()) {
     cdistr.set(qr_gt_small, nr/tgamma(mu_r + 1));
     // note: logn0r is calculated as log10(n0r)
-    logn0r.set(qr_gt_small, log10(nr) + (mu_r + 1) * log10(lamr) - log10(tgamma(mu_r+1)));
+    logn0r.set(qr_gt_small, log10(cdistr) + (mu_r + 1) * log10(lamr));
   }
 }
 

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -216,7 +216,8 @@ void Functions<S,D>
                      lamc(k), cdist(k), cdist1(k), not_skip_micro);
       nc(k).set(not_skip_micro, nc_incld(k) * cld_frac_l(k));
 
-      get_rain_dsd2(qr_incld(k), nr_incld(k), mu_r(k), lamr(k), cdistr(k), logn0r(k), p3constants, not_skip_micro);
+      get_rain_dsd2(qr_incld(k), nr_incld(k), mu_r(k), lamr(k), p3constants, not_skip_micro);
+      get_cdistr_logn0r(qr_incld(k), nr_incld(k), mu_r(k), lamr(k), cdistr(k), logn0r(k), not_skip_micro);
       nr(k).set(not_skip_micro, nr_incld(k) * cld_frac_r(k));
 
       impose_max_total_ni(ni_incld(k), max_total_ni, inv_rho(k), not_skip_micro);

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
@@ -108,7 +108,7 @@ void Functions<S,D>
       auto nr_incld = nr(k)/cld_frac_r(k); //nr_incld is updated in get_rain_dsd2 but isn't used again
 
       get_rain_dsd2(
-        qr_incld, nr_incld, mu_r(k), lamr(k), ignore1, ignore2, p3constants, qr_gt_small);
+        qr_incld, nr_incld, mu_r(k), lamr(k), p3constants, qr_gt_small);
 
       //Note that integrating over the drop-size PDF as done here should only be done to in-cloud
       //quantities but radar reflectivity is likely meant to be a cell ave. Thus nr in the next line

--- a/components/eamxx/src/physics/p3/impl/p3_rain_sed_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_rain_sed_impl.hpp
@@ -22,8 +22,7 @@ void Functions<S,D>
   const Smask& context)
 {
   Table3 table;
-  Spack tmp1, tmp2; //ignore
-  get_rain_dsd2(qr_incld, nr_incld, mu_r, lamr, tmp1, tmp2, p3constants, context);
+  get_rain_dsd2(qr_incld, nr_incld, mu_r, lamr, p3constants, context);
 
   if (context.any()) {
     lookup(mu_r, lamr, table, context);

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -625,8 +625,15 @@ struct Functions
   KOKKOS_FUNCTION
   static void get_rain_dsd2 (
     const Spack& qr, Spack& nr, Spack& mu_r,
-    Spack& lamr, Spack& cdistr, Spack& logn0r,
+    Spack& lamr,
     const physics::P3_Constants<ScalarT> & p3constants,
+    const Smask& context = Smask(true) );
+
+  // Computes and returns additional rain size distribution parameters
+  KOKKOS_FUNCTION
+  static void get_cdistr_logn0r (
+    const Spack& qr, const Spack& nr, const Spack& mu_r,
+    const Spack& lamr, Spack& cdistr, Spack& logn0r,
     const Smask& context = Smask(true) );
 
   // Calculates rime density

--- a/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
@@ -161,7 +161,8 @@ struct UnitWrap::UnitTest<D>::TestDsd2 {
       }
 
       Spack mu_r(0.0), lamr(0.0), cdistr(0.0), logn0r(0.0);
-      Functions::get_rain_dsd2(qr, nr, mu_r, lamr, cdistr, logn0r, physics::P3_Constants<Real>());
+      Functions::get_rain_dsd2(qr, nr, mu_r, lamr, physics::P3_Constants<Real>());
+      Functions::get_cdistr_logn0r(qr, nr, mu_r, lamr, cdistr, logn0r);
 
       // Copy results back into views
       for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {


### PR DESCRIPTION
Fixes #2565. This commit makes a set of changes to the Fortran and C++ versions of P3 used by SCREAM, all of which are intended to avoid redundant calculations and/or minimize special function evaluations. These changes are limited to `get_rain_dsd2` and its callers, and made due to the belief that `get_rain_dsd2` is relatively performance- critical code, since it is evaluated at each rain sedimentation time step (often much smaller than the overall physics time step).

The changes are:
 1. Remove calculation of `inv_dum`, since it is not used.
 2. Simplify the conversions between `lamr` and `nr`. In particular, all special function calls can be removed from the calculation of the "adjusted" `nr` produced when `lamr` is limited.
 3. Remove extra `log10` and `tgamma` calls when calculating `logn0r`, since it can be calculated more simply from the value of `cdistr` on the line above.

The C++ version also has an additional change, which is separating the calculation of `cdistr` and `logn0r` into a separate function from `get_rain_dsd2`. This is done because these two values require a `tgamma` call and two `log10` calls to calculate, but they are only needed in a few places in the code. Thus it is better to only calculate them in the one place where they are actually needed, rather than in every `get_rain_dsd2` call. In particular, they are not needed in the rain sedimentation loop.

These changes cause roundoff-level changes in P3.

[non-BFB]