### PR TITLE
MPAS-SEAICE fixes for fully coupled compset and some grid configurations

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1416,6 +1416,16 @@
       <mask>oEC60to30v3</mask>
     </model_grid>
 
+    <model_grid alias="ne120pg2_EC30to60E2r2">
+      <grid name="atm">ne120np4.pg2</grid>
+      <grid name="lnd">ne120np4.pg2</grid>
+      <grid name="ocnice">EC30to60E2r2</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>EC30to60E2r2</mask>
+    </model_grid>
+
     <model_grid alias="ne120pg2_r05_EC30to60E2r2">
       <grid name="atm">ne120np4.pg2</grid>
       <grid name="lnd">r05</grid>
@@ -1439,6 +1449,16 @@
     <model_grid alias="ne256np4_oRRS18to6v3">
       <grid name="atm">ne256np4</grid>
       <grid name="lnd">ne256np4</grid>
+      <grid name="ocnice">oRRS18to6v3</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6v3</mask>
+    </model_grid>
+
+    <model_grid alias="ne256pg2_oRRS18to6v3">
+      <grid name="atm">ne256np4.pg2</grid>
+      <grid name="lnd">ne256np4.pg2</grid>
       <grid name="ocnice">oRRS18to6v3</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>

--- a/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
@@ -4689,7 +4689,7 @@ contains
          cxxx,  cxxy,  cxyy,  cyyy,   &
          cxxxx, cxxxy, cxxyy, cxyyy, cyyyy
 
-    real(kind=RKIND) :: reciprocal, massTracerProd
+    real(kind=RKIND) ::  massTracerProd
 
     ! compute the barycenter coordinates, depending on how many tracer types were passed in
     ! Note: These formulas become more complex as the tracer hierarchy deepens.  See the model documentation for details.
@@ -4706,18 +4706,18 @@ contains
        c0 = center0
        cx = xGrad0
        cy = yGrad0
-       if (abs(mean0) > 0.0_RKIND) then
-          reciprocal = 1.0_RKIND / mean0
-       else
-          reciprocal = 0.0_RKIND
-       endif
 
+       xBarycenter = 0.0_RKIND
+       yBarycenter = 0.0_RKIND
+       if (abs(mean0) > 0.0_RKIND) then
        xBarycenter = (c0 * geomAvgCell % x (iCell)  &
                     + cx * geomAvgCell % xx(iCell)  + cy * geomAvgCell % xy(iCell))  &
-                    * reciprocal
+                       / mean0
        yBarycenter = (c0 * geomAvgCell % y (iCell)  &
                     + cx * geomAvgCell % xy(iCell)  + cy * geomAvgCell % yy(iCell))  &
-                    * reciprocal
+                       / mean0
+       endif
+
 
     elseif (.not.present(mean2)) then
 
@@ -4730,21 +4730,19 @@ contains
        cxy = xGrad0  * yGrad1  + yGrad0  * xGrad1
        cyy = yGrad0  * yGrad1
 
+       xBarycenter = 0.0_RKIND
+       yBarycenter = 0.0_RKIND
        massTracerProd = mean0 * mean1
        if (abs(massTracerProd) > 0.0_RKIND) then
-          reciprocal = 1.0_RKIND / massTracerProd
-       else
-          reciprocal = 0.0_RKIND
-       endif
-
        xBarycenter = (c0  * geomAvgCell % x  (iCell) &
                     + cx  * geomAvgCell % xx (iCell) + cy  * geomAvgCell % xy (iCell)  &
                     + cxx * geomAvgCell % xxx(iCell) + cxy * geomAvgCell % xxy(iCell) + cyy * geomAvgCell % xyy(iCell)) &
-                    * reciprocal
+                       / massTracerProd
        yBarycenter = (c0  * geomAvgCell % y  (iCell) &
                     + cx  * geomAvgCell % xy (iCell) + cy  * geomAvgCell % yy (iCell)  &
                     + cxx * geomAvgCell % xxy(iCell) + cxy * geomAvgCell % xyy(iCell) + cyy * geomAvgCell % yyy(iCell)) &
-                    * reciprocal
+                       / massTracerProd
+       endif
 
     else  ! mass field, tracer1 and tracer2 are all present
 
@@ -4762,25 +4760,23 @@ contains
        cxyy  = yGrad0  * yGrad1  * xGrad2   + yGrad0  * xGrad1  * yGrad2  + xGrad0  * yGrad1  * yGrad2
        cyyy  = yGrad0  * yGrad1  * yGrad2
 
+       xBarycenter = 0.0_RKIND
+       yBarycenter = 0.0_RKIND
        massTracerProd = mean0 * mean1 * mean2
        if (abs(massTracerProd) > 0.0_RKIND) then
-          reciprocal = 1.0_RKIND / massTracerProd
-       else
-          reciprocal = 0.0_RKIND
-       endif
-
        xBarycenter = (c0   * geomAvgCell % x   (iCell) &
                     + cx   * geomAvgCell % xx  (iCell) + cy   * geomAvgCell % xy  (iCell) &
                     + cxx  * geomAvgCell % xxx (iCell) + cxy  * geomAvgCell % xxy (iCell) + cyy  * geomAvgCell % xyy (iCell) &
                     + cxxx * geomAvgCell % xxxx(iCell) + cxxy * geomAvgCell % xxxy(iCell) + cxyy * geomAvgCell % xxyy(iCell) &
                                                                                           + cyyy * geomAvgCell % xyyy(iCell)) &
-                    * reciprocal
+                       / massTracerProd
        yBarycenter = (c0   * geomAvgCell % y   (iCell) &
                     + cx   * geomAvgCell % xy  (iCell) + cy   * geomAvgCell % yy  (iCell) &
                     + cxx  * geomAvgCell % xxy (iCell) + cxy  * geomAvgCell % xyy (iCell) + cyy  * geomAvgCell % yyy (iCell) &
                     + cxxx * geomAvgCell % xxxy(iCell) + cxxy * geomAvgCell % xxyy(iCell) + cxyy * geomAvgCell % xyyy(iCell) &
                                                                                           + cyyy * geomAvgCell % yyyy(iCell)) &
-                    * reciprocal
+                       / massTracerProd
+       endif
 
     endif
 


### PR DESCRIPTION
Fixes for MPAS-SEAICE provided by @jonbob in his [PR #5252](https://github.com/E3SM-Project/E3SM/pull/5252) for E3SM. These fixes resolved the crash I got earlier (see issue #2470). The fully coupled compset can now run for 5 days on PM-GPU.

Also adds bi-grid configurations for ne256 and ne120 with appropriate ocean grids.

Fixes #2470 