### PR TITLE
EAMxx: fix setting of FillValue based on fp precision

### DIFF
--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -896,9 +896,14 @@ register_variables(const std::string& filename,
                    const std::string& fp_precision,
                    const scorpio::FileMode mode)
 {
-
   using namespace scorpio;
   using namespace ShortFieldTagsNames;
+  using strvec_t = std::vector<std::string>;
+
+  EKAT_REQUIRE_MSG (ekat::contains(strvec_t{"float","single","double","real"},fp_precision),
+      "Error! Invalid/unsupported value for fp_precision.\n"
+      "  - input value: " + fp_precision + "\n"
+      "  - supported values: float, single, double, real\n");
 
   // Helper lambdas
   auto set_decomp_tag = [&](const FieldLayout& layout) {
@@ -963,8 +968,9 @@ register_variables(const std::string& filename,
     if (mode != FileMode::Append ) {
       // Add FillValue as an attribute of each variable
       // FillValue is a protected metadata, do not add it if it already existed
-      if (fp_precision == "real") {
-        Real fill_value = m_fill_value;
+      if (fp_precision=="double" or
+          (fp_precision=="real" and std::is_same<Real,double>::value)) {
+        double fill_value = m_fill_value;
         set_variable_metadata(filename, name, "_FillValue",fill_value);
       } else {
         float fill_value = m_fill_value;

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -566,10 +566,11 @@ void OutputManager::
 set_params (const ekat::ParameterList& params,
             const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs)
 {
-  m_params = params;
-  if (m_is_model_restart_output) {
-    using vos_t = std::vector<std::string>;
+  using vos_t = std::vector<std::string>;
 
+  m_params = params;
+
+  if (m_is_model_restart_output) {
     // We build some restart parameters internally
     auto avg_type = m_params.get<std::string>("Averaging Type","INSTANT");
     m_avg_type = str2avg(avg_type);
@@ -614,8 +615,11 @@ set_params (const ekat::ParameterList& params,
     // Allow user to ask for higher precision for normal model output,
     // but default to single to save on storage
     const auto& prec = m_params.get<std::string>("Floating Point Precision", "single");
-    EKAT_REQUIRE_MSG (prec=="single" || prec=="double" || prec=="real",
-        "Error! Invalid floating point precision '" + prec + "'.\n");
+    vos_t valid_prec = {"single", "float", "double", "real"};
+    EKAT_REQUIRE_MSG (ekat::contains(valid_prec,prec),
+        "Error! Invalid/unsupported value for 'Floating Point Precision'.\n"
+        "  - input value: " + prec + "\n"
+        "  - supported values: float, single, double, real\n");
   }
 }
 /*===============================================================================================*/

--- a/components/eamxx/src/share/io/tests/io_basic.cpp
+++ b/components/eamxx/src/share/io/tests/io_basic.cpp
@@ -157,6 +157,11 @@ void write (const std::string& avg_type, const std::string& freq_units,
 
   // Create Output manager
   OutputManager om;
+
+  // Attempt to use invalid fp precision string
+  om_pl.set("Floating Point Precision",std::string("triple"));
+  REQUIRE_THROWS (om.setup(comm,om_pl,fm,gm,t0,t0,false));
+  om_pl.set("Floating Point Precision",std::string("single"));
   om.setup(comm,om_pl,fm,gm,t0,t0,false);
 
   // Time loop: ensure we always hit 3 output steps


### PR DESCRIPTION
If the precision string was not "real", we were assuming single precision. However, asking for "double" should be perfectly ok. This PR fixes that.