### PR TITLE
Revert "For NERSC CPU machines (and GCP), use the serial kokkos backe…

### DIFF
--- a/components/eamxx/cmake/machine-files/alvarez.cmake
+++ b/components/eamxx/cmake/machine-files/alvarez.cmake
@@ -1,18 +1,8 @@
 include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
 common_setup()
 
-#message(STATUS "alvarez PROJECT_NAME=${PROJECT_NAME} USE_CUDA=${USE_CUDA} KOKKOS_ENABLE_CUDA=${KOKKOS_ENABLE_CUDA}")
-
 include (${EKAT_MACH_FILES_PATH}/kokkos/amd-zen3.cmake)
-if ("${PROJECT_NAME}" STREQUAL "E3SM")
-  if (SMP_PRESENT)
-    include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
-  else()
-    include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
-  endif()
-else()
-  include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
-endif()
+include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
 
 include (${EKAT_MACH_FILES_PATH}/mpi/srun.cmake)
 

--- a/components/eamxx/cmake/machine-files/cori-knl.cmake
+++ b/components/eamxx/cmake/machine-files/cori-knl.cmake
@@ -3,23 +3,14 @@ common_setup()
 
 # Load knl arch and openmp backend for kokkos
 include (${EKAT_MACH_FILES_PATH}/kokkos/intel-knl.cmake)
-
-if ("${PROJECT_NAME}" STREQUAL "E3SM")
-  if (SMP_PRESENT)
-    include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
-  else()
-    include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
-  endif()
-else()
-  include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
-endif()
+include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
 
 include (${EKAT_MACH_FILES_PATH}/mpi/srun.cmake)
 
 if ("${PROJECT_NAME}" STREQUAL "E3SM")
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
-      set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch"  CACHE STRING "" FORCE) # only works with gnu v10 and above
+       set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch"  CACHE STRING "" FORCE) # only works with gnu v10 and above
     endif()
   endif()
 else()

--- a/components/eamxx/cmake/machine-files/crusher-scream-gpu.cmake
+++ b/components/eamxx/cmake/machine-files/crusher-scream-gpu.cmake
@@ -2,7 +2,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
 common_setup()
 
 #serial is needed, but maybe it is always on?
-#include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
 include (${EKAT_MACH_FILES_PATH}/kokkos/mi250.cmake)
 include (${EKAT_MACH_FILES_PATH}/kokkos/hip.cmake)
 include (${EKAT_MACH_FILES_PATH}/mpi/srun.cmake)

--- a/components/eamxx/cmake/machine-files/gcp.cmake
+++ b/components/eamxx/cmake/machine-files/gcp.cmake
@@ -1,19 +1,8 @@
 include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
 common_setup()
 
-#message(STATUS "gcp PROJECT_NAME=${PROJECT_NAME} USE_CUDA=${USE_CUDA} KOKKOS_ENABLE_CUDA=${KOKKOS_ENABLE_CUDA}")
 # use default backend?
-
-if ("${PROJECT_NAME}" STREQUAL "E3SM")
-  if (SMP_PRESENT)
-    include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
-  else()
-    include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
-  endif()
-else()
-  include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
-endif()
-
+include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
 include (${EKAT_MACH_FILES_PATH}/mpi/srun.cmake)
 
 set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)

--- a/components/eamxx/cmake/machine-files/pm-cpu.cmake
+++ b/components/eamxx/cmake/machine-files/pm-cpu.cmake
@@ -1,17 +1,8 @@
 include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
 common_setup()
 
-if ("${PROJECT_NAME}" STREQUAL "E3SM")
-  if (SMP_PRESENT)
-    include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
-    #message(STATUS, "pm-cpu openmp SMP_PRESENT=${SMP_PRESENT}")
-  else()
-    include (${EKAT_MACH_FILES_PATH}/kokkos/serial.cmake)
-    #message(STATUS, "pm-cpu serial SMP_PRESENT=${SMP_PRESENT}")
-  endif()
-else()
-  include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
-endif()
+include (${EKAT_MACH_FILES_PATH}/kokkos/amd-zen3.cmake)
+include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
 
 set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
 


### PR DESCRIPTION
…nd when"

This reverts commit 4f54aa472260057284ea8f646c99e385e4cfd1ae.

With the recent changes to the cmake system, turning off the openmp execution space for serial cases is now handled globally in `scream/components/cmake/build_eamxx.cmake` :

```
    # The machine files may enable kokkos stuff we don't want                                                                                                                                                                   
    if (NOT compile_threaded)
      set(Kokkos_ENABLE_OPENMP FALSE)
    endif()
```