### PR TITLE
Allow to flush output files before they are closed

### DIFF
--- a/components/eamxx/src/share/io/scream_io_utils.hpp
+++ b/components/eamxx/src/share/io/scream_io_utils.hpp
@@ -111,7 +111,13 @@ struct IOFileSpecs {
   std::string filename;
   int num_snapshots_in_file = 0;
   int max_snapshots_in_file;
+
+  // If positive, flush the output file every these many snapshots
+  int flush_frequency = -1;
+
   bool file_is_full () const { return num_snapshots_in_file>=max_snapshots_in_file; }
+  bool file_needs_flush () const { return flush_frequency>0 and num_snapshots_in_file%flush_frequency==0; }
+
   // Adding number of MPI ranks to the filenamea is useful in testing, since we can run
   // multiple instances of the same test in parallel (with different number of ranks),
   // without the risk of them overwriting each other output.
@@ -122,6 +128,7 @@ struct IOFileSpecs {
 
   // Whether this struct refers to a history restart file
   bool hist_restart_file         = false;
+
 };
 
 std::string find_filename_in_rpointer (

--- a/components/eamxx/src/share/io/scream_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.cpp
@@ -29,6 +29,7 @@ extern "C" {
   void eam_init_pio_subsystem_c2f(const int mpicom, const int atm_id);
   void eam_pio_finalize_c2f();
   void eam_pio_closefile_c2f(const char*&& filename);
+  void eam_pio_flush_file_c2f(const char*&& filename);
   void pio_update_time_c2f(const char*&& filename,const double time);
   void register_dimension_c2f(const char*&& filename, const char*&& shortname, const char*&& longname, const int global_length, const bool partitioned);
   void register_variable_c2f(const char*&& filename, const char*&& shortname, const char*&& longname,
@@ -100,6 +101,9 @@ void register_file(const std::string& filename, const FileMode mode) {
 void eam_pio_closefile(const std::string& filename) {
 
   eam_pio_closefile_c2f(filename.c_str());
+}
+void eam_flush_file(const std::string& filename) {
+  eam_pio_flush_file_c2f(filename.c_str());
 }
 /* ----------------------------------------------------------------- */
 void set_decomp(const std::string& filename) {

--- a/components/eamxx/src/share/io/scream_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.hpp
@@ -31,6 +31,7 @@ namespace scorpio {
   void eam_pio_finalize();
   /* Close a file currently open in scorpio */
   void eam_pio_closefile(const std::string& filename);
+  void eam_flush_file(const std::string& filename);
   /* Register a new file to be used for input/output with the scorpio module */
   void register_file(const std::string& filename, const FileMode mode);
   /* Sets the IO decompostion for all variables in a particular filename.  Required after all variables have been registered.  Called once per file. */

--- a/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface_iso_c2f.F90
@@ -132,6 +132,16 @@ contains
 
   end subroutine eam_pio_closefile_c2f
 !=====================================================================!
+  subroutine eam_pio_flush_file_c2f(filename_in) bind(c)
+    use scream_scorpio_interface, only : eam_pio_flush_file
+    type(c_ptr), intent(in) :: filename_in
+    character(len=256)      :: filename
+
+    call convert_c_string(filename_in,filename)
+    call eam_pio_flush_file(trim(filename))
+
+  end subroutine eam_pio_flush_file_c2f
+!=====================================================================!
   subroutine pio_update_time_c2f(filename_in,time) bind(c)
     use scream_scorpio_interface, only : eam_update_time
     type(c_ptr), intent(in) :: filename_in


### PR DESCRIPTION
Usually, if EAMxx crashes, we should intercept the crash, and flush any open file. However, it is possible that this doesn't work (e.g., crash inside another component, or an exception is thrown during stack unwinding). In this case, it can help to have EAMxx flush output files more frequently.

This PR adds this capability. By default, we only flush when we close the file, but the user can request a different frequency by setting the `flush_frequency` paraeter in the output yaml file.