### PR TITLE
EAMxx: rename cxx_blah wrapper to avoid conflict with Homme

### DIFF
--- a/components/eam/src/physics/cam/bfb_math.inc
+++ b/components/eam/src/physics/cam/bfb_math.inc
@@ -6,8 +6,8 @@
 ! Make sure to place the following lines at the top of any modules
 ! that use these macros:
 !
-! use physics_share_f2c, only: cxx_pow, cxx_sqrt, cxx_cbrt, cxx_gamma, cxx_log, &
-!                              cxx_log10, cxx_exp, cxx_tanh, cxx_erf
+! use physics_share_f2c, only: scream_pow, scream_sqrt, scream_cbrt, scream_gamma, scream_log, &
+!                              scream_log10, scream_exp, scream_tanh, scream_erf
 
 #ifndef SCREAM_BFB_MATH_INC
 #define SCREAM_BFB_MATH_INC
@@ -30,16 +30,16 @@
 #  define bfb_tanh(val) tanh(val)
 #  define bfb_erf(val) erf(val)
 #else
-#  define bfb_pow(base, exp) cxx_pow(base, exp)
-#  define bfb_sqrt(base) cxx_sqrt(base)
-#  define bfb_cbrt(base) cxx_cbrt(base)
-#  define bfb_gamma(val) cxx_gamma(val)
-#  define bfb_log(val) cxx_log(val)
-#  define bfb_log10(val) cxx_log10(val)
-#  define bfb_exp(val) cxx_exp(val)
-#  define bfb_expm1(val) cxx_expm1(val)
-#  define bfb_tanh(val) cxx_tanh(val)
-#  define bfb_erf(val) cxx_erf(val)
+#  define bfb_pow(base, exp) scream_pow(base, exp)
+#  define bfb_sqrt(base) scream_sqrt(base)
+#  define bfb_cbrt(base) scream_cbrt(base)
+#  define bfb_gamma(val) scream_gamma(val)
+#  define bfb_log(val) scream_log(val)
+#  define bfb_log10(val) scream_log10(val)
+#  define bfb_exp(val) scream_exp(val)
+#  define bfb_expm1(val) scream_expm1(val)
+#  define bfb_tanh(val) scream_tanh(val)
+#  define bfb_erf(val) scream_erf(val)
 #endif
 
 #endif

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -17,8 +17,8 @@ module shoc
 
 ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
-  use physics_share_f2c, only: cxx_pow, cxx_sqrt, cxx_cbrt, cxx_gamma, cxx_log, &
-                               cxx_log10, cxx_exp, cxx_erf
+  use physics_share_f2c, only: scream_pow, scream_sqrt, scream_cbrt, scream_gamma, scream_log, &
+                               scream_log10, scream_exp, scream_erf
 #endif
 
 implicit none

--- a/components/eam/src/physics/cam/trb_mtn_stress.F90
+++ b/components/eam/src/physics/cam/trb_mtn_stress.F90
@@ -5,8 +5,8 @@ module trb_mtn_stress
 
   ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
-  use physics_share_f2c, only: cxx_pow, cxx_sqrt, cxx_cbrt, cxx_gamma, cxx_log, &
-                               cxx_log10, cxx_exp, cxx_erf
+  use physics_share_f2c, only: scream_pow, scream_sqrt, scream_cbrt, scream_gamma, scream_log, &
+                               scream_log10, scream_exp, scream_erf
 #endif
 
   implicit none

--- a/components/eam/src/physics/cam/wv_sat_scream.F90
+++ b/components/eam/src/physics/cam/wv_sat_scream.F90
@@ -14,8 +14,8 @@ module wv_sat_scream
   use physics_utils,  only: rtype
   use micro_p3_utils, only: T_zerodegc
 #ifdef SCREAM_CONFIG_IS_CMAKE
-  use physics_share_f2c, only: cxx_pow, cxx_sqrt, cxx_cbrt, cxx_gamma, cxx_log, &
-                                 cxx_log10, cxx_exp, cxx_tanh
+  use physics_share_f2c, only: scream_pow, scream_sqrt, scream_cbrt, scream_gamma, scream_log, &
+                               scream_log10, scream_exp, scream_tanh
 #endif
 
 

--- a/components/eam/src/physics/p3/eam/micro_p3.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3.F90
@@ -72,8 +72,8 @@ module micro_p3
 
   ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
-  use physics_share_f2c, only: cxx_pow, cxx_sqrt, cxx_cbrt, cxx_gamma, cxx_log, &
-                                 cxx_log10, cxx_exp, cxx_expm1, cxx_tanh
+  use physics_share_f2c, only: scream_pow, scream_sqrt, scream_cbrt, scream_gamma, scream_log, &
+                               scream_log10, scream_exp, scream_expm1, scream_tanh
 #endif
 
   implicit none

--- a/components/eam/src/physics/p3/scream/micro_p3.F90
+++ b/components/eam/src/physics/p3/scream/micro_p3.F90
@@ -60,8 +60,8 @@ module micro_p3
 
   ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
-  use physics_share_f2c, only: cxx_pow, cxx_sqrt, cxx_cbrt, cxx_gamma, cxx_log, &
-                                 cxx_log10, cxx_exp, cxx_expm1, cxx_tanh
+  use physics_share_f2c, only: scream_pow, scream_sqrt, scream_cbrt, scream_gamma, scream_log, &
+                               scream_log10, scream_exp, scream_expm1, scream_tanh
 #endif
 
   implicit none

--- a/components/eamxx/src/physics/share/physics_share.cpp
+++ b/components/eamxx/src/physics/share/physics_share.cpp
@@ -22,7 +22,7 @@ struct CudaWrap
   using Scalar = ScalarT;
   using RangePolicy = typename ekat::KokkosTypes<DeviceT>::RangePolicy;
 
-  static Scalar cxx_pow(Scalar base, Scalar exp)
+  static Scalar pow(Scalar base, Scalar exp)
   {
     Scalar result;
     RangePolicy policy(0,1);
@@ -43,106 +43,106 @@ static Scalar wrap_name(Scalar input) {                                       \
   return result;                                                              \
 }
 
-  cuda_wrap_single_arg(cxx_gamma, std::tgamma)
-  cuda_wrap_single_arg(cxx_sqrt, std::sqrt)
-  cuda_wrap_single_arg(cxx_cbrt, std::cbrt)
-  cuda_wrap_single_arg(cxx_log, std::log)
-  cuda_wrap_single_arg(cxx_log10, std::log10)
-  cuda_wrap_single_arg(cxx_exp, std::exp)
-  cuda_wrap_single_arg(cxx_expm1, std::expm1)
-  cuda_wrap_single_arg(cxx_tanh, std::tanh)
-  cuda_wrap_single_arg(cxx_erf, std::erf)
+  cuda_wrap_single_arg(gamma, std::tgamma)
+  cuda_wrap_single_arg(sqrt, std::sqrt)
+  cuda_wrap_single_arg(cbrt, std::cbrt)
+  cuda_wrap_single_arg(log, std::log)
+  cuda_wrap_single_arg(log10, std::log10)
+  cuda_wrap_single_arg(exp, std::exp)
+  cuda_wrap_single_arg(expm1, std::expm1)
+  cuda_wrap_single_arg(tanh, std::tanh)
+  cuda_wrap_single_arg(erf, std::erf)
 
 #undef cuda_wrap_single_arg
 };
 
 extern "C" {
 
-Real cxx_pow(Real base, Real exp)
+Real scream_pow(Real base, Real exp)
 {
 #ifdef EAMXX_ENABLE_GPU
-  return CudaWrap<Real, DefaultDevice>::cxx_pow(base, exp);
+  return CudaWrap<Real, DefaultDevice>::pow(base, exp);
 #else
   return std::pow(base, exp);
 #endif
 }
 
-Real cxx_gamma(Real input)
+Real scream_gamma(Real input)
 {
 #ifdef EAMXX_ENABLE_GPU
-  return CudaWrap<Real, DefaultDevice>::cxx_gamma(input);
+  return CudaWrap<Real, DefaultDevice>::gamma(input);
 #else
   return std::tgamma(input);
 #endif
 }
 
-Real cxx_cbrt(Real input)
+Real scream_cbrt(Real input)
 {
 #ifdef EAMXX_ENABLE_GPU
-  return CudaWrap<Real, DefaultDevice>::cxx_cbrt(input);
+  return CudaWrap<Real, DefaultDevice>::cbrt(input);
 #else
   return std::cbrt(input);
 #endif
 }
 
-Real cxx_sqrt(Real input)
+Real scream_sqrt(Real input)
 {
 #ifdef EAMXX_ENABLE_GPU
-  return CudaWrap<Real, DefaultDevice>::cxx_sqrt(input);
+  return CudaWrap<Real, DefaultDevice>::sqrt(input);
 #else
   return std::sqrt(input);
 #endif
 }
 
-Real cxx_log(Real input)
+Real scream_log(Real input)
 {
 #ifdef EAMXX_ENABLE_GPU
-  return CudaWrap<Real, DefaultDevice>::cxx_log(input);
+  return CudaWrap<Real, DefaultDevice>::log(input);
 #else
   return std::log(input);
 #endif
 }
 
-Real cxx_log10(Real input)
+Real scream_log10(Real input)
 {
 #ifdef EAMXX_ENABLE_GPU
-  return CudaWrap<Real, DefaultDevice>::cxx_log10(input);
+  return CudaWrap<Real, DefaultDevice>::log10(input);
 #else
   return std::log10(input);
 #endif
 }
 
-Real cxx_exp(Real input)
+Real scream_exp(Real input)
 {
 #ifdef EAMXX_ENABLE_GPU
-  return CudaWrap<Real, DefaultDevice>::cxx_exp(input);
+  return CudaWrap<Real, DefaultDevice>::exp(input);
 #else
   return std::exp(input);
 #endif
 }
 
-Real cxx_expm1(Real input)
+Real scream_expm1(Real input)
 {
 #ifdef EAMXX_ENABLE_GPU
-  return CudaWrap<Real, DefaultDevice>::cxx_expm1(input);
+  return CudaWrap<Real, DefaultDevice>::expm1(input);
 #else
   return std::expm1(input);
 #endif
 }
   
-Real cxx_tanh(Real input)
+Real scream_tanh(Real input)
 {
 #ifdef EAMXX_ENABLE_GPU
-  return CudaWrap<Real, DefaultDevice>::cxx_tanh(input);
+  return CudaWrap<Real, DefaultDevice>::tanh(input);
 #else
   return std::tanh(input);
 #endif
 }
 
-Real cxx_erf(Real input)
+Real scream_erf(Real input)
 {
 #ifdef EAMXX_ENABLE_GPU
-  return CudaWrap<Real, DefaultDevice>::cxx_erf(input);
+  return CudaWrap<Real, DefaultDevice>::erf(input);
 #else
   return std::erf(input);
 #endif

--- a/components/eamxx/src/physics/share/physics_share.hpp
+++ b/components/eamxx/src/physics/share/physics_share.hpp
@@ -7,16 +7,16 @@ namespace scream {
 
 extern "C" {
 
-Real cxx_pow(Real base, Real exp);
-Real cxx_sqrt(Real base);
-Real cxx_cbrt(Real base);
-Real cxx_gamma(Real input);
-Real cxx_log(Real input);
-Real cxx_log10(Real input);
-Real cxx_exp(Real input);
-Real cxx_expm1(Real input);
-Real cxx_tanh(Real input);
-Real cxx_erf(Real input);
+Real scream_pow(Real base, Real exp);
+Real scream_sqrt(Real base);
+Real scream_cbrt(Real base);
+Real scream_gamma(Real input);
+Real scream_log(Real input);
+Real scream_log10(Real input);
+Real scream_exp(Real input);
+Real scream_expm1(Real input);
+Real scream_tanh(Real input);
+Real scream_erf(Real input);
 
 }
 

--- a/components/eamxx/src/physics/share/physics_share_f2c.F90
+++ b/components/eamxx/src/physics/share/physics_share_f2c.F90
@@ -21,7 +21,7 @@ interface
   ! the C++ versions in order to stay BFB.
   !
 
-  function cxx_pow(base, exp) bind(C)
+  function scream_pow(base, exp) bind(C)
     use iso_c_binding
 
     !arguments:
@@ -29,98 +29,98 @@ interface
     real(kind=c_real), value, intent(in)  :: exp
 
     ! return
-    real(kind=c_real)               :: cxx_pow
-  end function cxx_pow
+    real(kind=c_real)               :: scream_pow
+  end function scream_pow
 
-  function cxx_sqrt(base) bind(C)
+  function scream_sqrt(base) bind(C)
     use iso_c_binding
 
     !arguments:
     real(kind=c_real), value, intent(in)  :: base
 
     ! return
-    real(kind=c_real)               :: cxx_sqrt
-  end function cxx_sqrt
+    real(kind=c_real)               :: scream_sqrt
+  end function scream_sqrt
 
-  function cxx_cbrt(base) bind(C)
+  function scream_cbrt(base) bind(C)
     use iso_c_binding
 
     !arguments:
     real(kind=c_real), value, intent(in)  :: base
 
     ! return
-    real(kind=c_real)               :: cxx_cbrt
-  end function cxx_cbrt
+    real(kind=c_real)               :: scream_cbrt
+  end function scream_cbrt
 
-  function cxx_gamma(input) bind(C)
+  function scream_gamma(input) bind(C)
     use iso_c_binding
 
     !arguments:
     real(kind=c_real), value, intent(in) :: input
 
     ! return
-    real(kind=c_real)            :: cxx_gamma
-  end function cxx_gamma
+    real(kind=c_real)            :: scream_gamma
+  end function scream_gamma
 
-  function cxx_log(input) bind(C)
+  function scream_log(input) bind(C)
     use iso_c_binding
 
     !arguments:
     real(kind=c_real), value, intent(in) :: input
 
     ! return
-    real(kind=c_real)            :: cxx_log
-  end function cxx_log
+    real(kind=c_real)            :: scream_log
+  end function scream_log
 
-  function cxx_log10(input) bind(C)
+  function scream_log10(input) bind(C)
     use iso_c_binding
 
     !arguments:
     real(kind=c_real), value, intent(in) :: input
 
     ! return
-    real(kind=c_real)            :: cxx_log10
-  end function cxx_log10
+    real(kind=c_real)            :: scream_log10
+  end function scream_log10
 
-  function cxx_exp(input) bind(C)
+  function scream_exp(input) bind(C)
     use iso_c_binding
 
     !arguments:
     real(kind=c_real), value, intent(in) :: input
 
     ! return
-    real(kind=c_real)            :: cxx_exp
-  end function cxx_exp
+    real(kind=c_real)            :: scream_exp
+  end function scream_exp
 
-  function cxx_expm1(input) bind(C)
+  function scream_expm1(input) bind(C)
     use iso_c_binding
 
     !arguments:
     real(kind=c_real), value, intent(in) :: input
 
     ! return
-    real(kind=c_real)            :: cxx_expm1
-  end function cxx_expm1
+    real(kind=c_real)            :: scream_expm1
+  end function scream_expm1
   
-  function cxx_tanh(input) bind(C)
+  function scream_tanh(input) bind(C)
     use iso_c_binding
 
     !arguments:
     real(kind=c_real), value, intent(in) :: input
 
     ! return
-    real(kind=c_real)            :: cxx_tanh
-  end function cxx_tanh
+    real(kind=c_real)            :: scream_tanh
+  end function scream_tanh
 
-  function cxx_erf(input) bind(C)
+  function scream_erf(input) bind(C)
     use iso_c_binding
 
     !arguments:
     real(kind=c_real), value, intent(in)  :: input
 
     ! return
-    real(kind=c_real) :: cxx_erf
-  end function cxx_erf
+    real(kind=c_real) :: scream_erf
+  end function scream_erf
 
 end interface
 


### PR DESCRIPTION
This solves a link error that for some reason does not always appear. Both homme and scream define a function with C linkage with the same name.

We could change the name of the fcn in Homme, but that requires lengthier process (due to PR workflow in E3SM)

Fixes #2604 