### PR TITLE
nudging from coarse data

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -240,7 +240,6 @@ be lost if SCREAM_HACK_XML is not enabled.
     STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
       <source_pressure_file type="string" doc="If STATIC_1D_VERTICAL_PROFILE, this is an optional arg to point to a file with the source pressure levels defined.  
     Default is to look for p_levs in the first nudging_filename file"/>
-      <do_nudging_refine_remap type="logical" doc="Flag for whether to remap nudging fields to the physics grid">false</do_nudging_refine_remap>
       <nudging_refine_remap_mapfile type="string" doc="File containing the remapping weights for nudging fields to the physics grid">"no-file-given"</nudging_refine_remap_mapfile>
     </nudging>
 

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -231,7 +231,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <nudging_filename type="array(string)"/>
       <nudging_fields type="array(string)" doc="List of fields to be nudged.  Note, syntax of 'A:B' represents nudging field A with data from field B in files, syntax of 'A' assumes that nudging file has the same variables name as EAMxx"/>
       <nudging_timescale type="integer" doc="Timescale to apply nudging tendencies, 0: full replacement, >0: actual timescale">0</nudging_timescale>
-      <use_nudging_weights type="logical" doc="Flag for nudging weights option"/>
+      <use_nudging_weights type="logical" doc="Flag for nudging weights option">false</use_nudging_weights>
       <nudging_weights_file type="string" doc="weights that relax the nudging fields update"/>
       <source_pressure_type type="string" 
 	                    valid_values="TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE"

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -240,7 +240,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
       <source_pressure_file type="string" doc="If STATIC_1D_VERTICAL_PROFILE, this is an optional arg to point to a file with the source pressure levels defined.  
     Default is to look for p_levs in the first nudging_filename file"/>
-      <nudging_refine_remap_mapfile type="string" doc="File containing the remapping weights for nudging fields to the physics grid">"no-file-given"</nudging_refine_remap_mapfile>
+      <nudging_refine_remap_mapfile type="string" doc="Refine-remapping mapfile from the source nudging dataset to the physics grid">"no-file-given"</nudging_refine_remap_mapfile>
     </nudging>
 
     <!-- ML correction -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -240,6 +240,8 @@ be lost if SCREAM_HACK_XML is not enabled.
     STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
       <source_pressure_file type="string" doc="If STATIC_1D_VERTICAL_PROFILE, this is an optional arg to point to a file with the source pressure levels defined.  
     Default is to look for p_levs in the first nudging_filename file"/>
+      <do_nudging_refine_remap type="logical" doc="Flag for whether to remap nudging fields to the physics grid">false</do_nudging_refine_remap>
+      <nudging_refine_remap_mapfile type="string" doc="File containing the remapping weights for nudging fields to the physics grid">"no-file-given"</nudging_refine_remap_mapfile>
     </nudging>
 
     <!-- ML correction -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -244,13 +244,13 @@ be lost if SCREAM_HACK_XML is not enabled.
         type="string"
         doc="Refine-remapping mapfile from the source nudging dataset to the physics grid"
       >
-      "no-file-given"
+        "no-file-given"
       </nudging_refine_remap_mapfile>
       <nudging_refine_remap_vert_cutoff
         type="real"
         doc="A vertical cutoff to go with refine-remap logic (in units of p_mid) where the nudging is turned off above it (closer to the surface)"
       >
-      0.0
+        0.0
       </nudging_refine_remap_vert_cutoff>
     </nudging>
 

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -240,7 +240,18 @@ be lost if SCREAM_HACK_XML is not enabled.
     STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
       <source_pressure_file type="string" doc="If STATIC_1D_VERTICAL_PROFILE, this is an optional arg to point to a file with the source pressure levels defined.  
     Default is to look for p_levs in the first nudging_filename file"/>
-      <nudging_refine_remap_mapfile type="string" doc="Refine-remapping mapfile from the source nudging dataset to the physics grid">"no-file-given"</nudging_refine_remap_mapfile>
+      <nudging_refine_remap_mapfile
+        type="string"
+        doc="Refine-remapping mapfile from the source nudging dataset to the physics grid"
+      >
+      "no-file-given"
+      </nudging_refine_remap_mapfile>
+      <nudging_refine_remap_vert_cutoff
+        type="real"
+        doc="A vertical cutoff to go with refine-remap logic (in units of p_mid) where the nudging is turned off above it (closer to the surface)"
+      >
+      0.0
+      </nudging_refine_remap_vert_cutoff>
     </nudging>
 
     <!-- ML correction -->

--- a/components/eamxx/docs/user/coarse_nudging.md
+++ b/components/eamxx/docs/user/coarse_nudging.md
@@ -1,6 +1,6 @@
 # Nudging from coarse data
 
-Because EAMxx is designed to run at ultra high resolution, it is not feasible to produce nudging data at the same resolution.
+Because EAMxx is designed to support ultra-high resolutions (in fact, that was the initial reason for its inception), it is not feasible to produce nudging data at the same resolution.
 Instead, in EAMxx, it is possible to nudge from coarse data.
 This is done by remapping the coarse data provided by the user to the runtime physics grid of EAMxx.
 In order to enable nudging from coarse data, the user must provide nudging data at the coarse resolution desired and an appropriate     ncremap-compatible mapping file.
@@ -13,7 +13,7 @@ A limitation for now is that the nudging data must be provided explicitly, eithe
 This can be problematic for long list of files, but we are working on a solution to this problem.
 
 Let's say that the nudging data is provided as one file in the following path: `/path/to/nudging_data_ne4pg2_L72.nc`.
-Then, a mapping file is provided as `/path/to/mapping_file_ne4pg2_to_ne120pg2.nc`.
+Then, a mapping file is provided as `/another/path/to/mapping_file_ne4pg2_to_ne120pg2.nc`.
 Then if the physics grid is ne120pg2, the user must enable the nudging process, specify the nudging files, and provide the specifies the nudging data and a remap file.
 In other words, the following options are needed:
 
@@ -21,5 +21,5 @@ In other words, the following options are needed:
 ./atmchange atm_procs_list=(sc_import,nudging,homme,physics,sc_export)
 ./atmchange nudging_fields=U,V
 ./atmchange nudging_filename=/path/to/nudging_data_ne4pg2_L72.nc
-./atmchange nudging_refine_remap_mapfile=/path/to/mapping_file_ne4pg2_to_ne120pg2.nc
+./atmchange nudging_refine_remap_mapfile=/another/path/to/mapping_file_ne4pg2_to_ne120pg2.nc
 ```

--- a/components/eamxx/docs/user/coarse_nudging.md
+++ b/components/eamxx/docs/user/coarse_nudging.md
@@ -1,0 +1,25 @@
+# Nudging from coarse data
+
+Because EAMxx is designed to run at ultra high resolution, it is not feasible to produce nudging data at the same resolution.
+Instead, in EAMxx, it is possible to nudge from coarse data.
+This is done by remapping the coarse data provided by the user to the runtime physics grid of EAMxx.
+In order to enable nudging from coarse data, the user must provide nudging data at the coarse resolution desired and an appropriate     ncremap-compatible mapping file.
+
+## Example setup
+
+A user can produce coarse nudging data from running EAMxx or EAM at a ne30pg2 or any other applicable resolution.
+Additionally, several users in the E3SM projects have produced nudging data at the ne30pg2 resolution from the MERRA2 and ERA5 datasets.
+A limitation for now is that the nudging data must be provided explicitly, either as one file or as a list of files.
+This can be problematic for long list of files, but we are working on a solution to this problem.
+
+Let's say that the nudging data is provided as one file in the following path: `/path/to/nudging_data_ne4pg2_L72.nc`.
+Then, a mapping file is provided as `/path/to/mapping_file_ne4pg2_to_ne120pg2.nc`.
+Then if the physics grid is ne120pg2, the user must enable the nudging process, specify the nudging files, and provide the specifies the nudging data and a remap file.
+In other words, the following options are needed:
+
+```shell
+./atmchange atm_procs_list=(sc_import,nudging,homme,physics,sc_export)
+./atmchange nudging_fields=U,V
+./atmchange nudging_filename=/path/to/nudging_data_ne4pg2_L72.nc
+./atmchange nudging_refine_remap_mapfile=/path/to/mapping_file_ne4pg2_to_ne120pg2.nc
+```

--- a/components/eamxx/mkdocs.yml
+++ b/components/eamxx/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
     - 'Model output': 'user/model_output.md'
     - 'Model input': 'user/model_input.md'
     - 'Runtime parameters': 'common/eamxx_params.md'
+    - 'Coarse nudging': 'user/coarse_nudging.md'
   - 'Developer Guide':
     - 'Overview': 'developer/index.md'
     - 'Installation': 'common/installation.md'

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -522,6 +522,10 @@ void Nudging::run_impl (const double dt)
         // appply the nudging tendencies to the ATM states
         apply_weighted_tendency(atm_state_field, int_state_field, nudging_weights_field, dt);
       } else if (m_refine_remap_vert_cutoff > 0.0) {
+        // If we have a cutoff, we apply the tendency with p_mid cutoff
+        // First, get p_mid the field in the "atm" (i.e., "int") state
+        auto p_mid_field = get_field_in("p_mid")
+        // Then, call the tendency with a Heaviside-like cutoff
         apply_vert_cutoff_tendency(atm_state_field, int_state_field,
                                    p_mid_field, m_refine_remap_vert_cutoff, dt);
       } else {

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -1,7 +1,7 @@
 #include "eamxx_nudging_process_interface.hpp"
 #include "share/util/scream_universal_constants.hpp"
 #include "share/grid/remap/refining_remapper_p2p.hpp"
-#include "share/grid/remap/abstract_remapper.hpp"
+#include "share/grid/remap/do_nothing_remapper.hpp"
 
 namespace scream
 {

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -416,8 +416,9 @@ void Nudging::run_impl (const double dt)
 
   }
 
-  // Refine-remap onto target atmosphere state horiz grid ("int")
-  // Note that we are going from hxt to int here
+  // Refine-remap onto target atmosphere state horiz grid ("int");
+  // note that if the nudging data comes from the same grid as the model,
+  // this remap step is a no-op; otherwise, we refine-remap from hxt to int
   m_refine_remapper->remap(true);
 
   for (auto name : m_fields_nudge) {

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -211,7 +211,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
 
   // Get the number of external cols on current rank
   auto m_num_cols_ext = grid_ext->get_num_local_dofs();
-  // Declare the layouts for the helper fields (tmp: temporay))
+  // Declare the layouts for the helper fields (tmp: temporary))
   FieldLayout scalar2d_layout_mid_tmp { {LEV}, {m_num_levs}};
   FieldLayout scalar3d_layout_mid_tmp { {COL,LEV}, {m_num_cols_ext, m_num_levs} };
   // Declare the layouts for the helper fields (ext: external)

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -245,6 +245,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
   // do the interpolation.
   if (m_use_weights)
   {
+    auto grid_name = m_grid->name();
     FieldLayout scalar3d_layout_grid { {COL,LEV}, {m_num_cols, m_num_levs} };	  
     create_helper_field("nudging_weights", scalar3d_layout_grid, grid_name, ps);
     std::vector<Field> fields;

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -145,14 +145,12 @@ void Nudging::initialize_impl (const RunType /* run_type */)
   // For now, we are doing the horizontal interpolation last,
   // so we use the m_grid (model physics) as the target grid
   grid_int = m_grid->clone(m_grid->name(), true);
-  // We also need a temporary grid for the external grid
-  std::shared_ptr<const scream::AbstractGrid> grid_ext_const;
   if(m_refine_remap) {
     // P2P remapper
     m_refine_remapper =
         std::make_shared<RefiningRemapperP2P>(grid_int, m_refine_remap_file);
     // If we are refine-remapping, then get grid from remapper
-    grid_ext_const = m_refine_remapper->get_src_grid();
+    auto grid_ext_const = m_refine_remapper->get_src_grid();
     // Deep clone it though to get rid of "const" stuff
     grid_ext = grid_ext_const->clone(grid_ext_const->name(), true);
     // The first grid is grid_ext (external grid, i.e., files),
@@ -456,8 +454,10 @@ void Nudging::finalize_impl()
 }
 // =========================================================================================
 Field Nudging::create_helper_field(const std::string &name,
-                                   const FieldLayout &layout,
-                                   const std::string &grid_name, const int ps) {
+                                             const FieldLayout &layout,
+                                             const std::string &grid_name,
+                                             const int ps)
+{
   using namespace ekat::units;
   // For helper fields we don't bother w/ units, so we set them to non-dimensional
   FieldIdentifier id(name,layout,Units::nondimensional(),grid_name);

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -109,10 +109,10 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
                      << "mapfile " << std::to_string(num_cols_remap_a) << ".  Please check the "
                      << "nudging data file and/or the mapfile.");
     EKAT_REQUIRE_MSG(num_cols_remap_b == m_num_cols_global,
-                      "Error! Nudging::set_grids - the number of columns in the model grid "
-                      << std::to_string(m_num_cols_global) << " does not match the number of columns in the "
-                      << "mapfile " << std::to_string(num_cols_remap_b) << ".  Please check the "
-                      << "model grid and/or the mapfile.");
+                     "Error! Nudging::set_grids - the number of columns in the model grid "
+                     << std::to_string(m_num_cols_global) << " does not match the number of columns in the "
+                     << "mapfile " << std::to_string(num_cols_remap_b) << ".  Please check the "
+                    << "model grid and/or the mapfile.");
     // If we get here, we are good to go!
     m_refine_remap = true;
   } else {

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -16,7 +16,7 @@ Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
   m_use_weights   = m_params.get<bool>("use_nudging_weights",false);
   // Whether or not to do horizontal refine remap
   m_refine_remap = m_params.get<bool>("do_nudging_refine_remap", false);
-  if(m_refine_remap) {
+  if (m_refine_remap) {
     // If we are doing horizontal refine remap, we need to get the map file
     m_refine_remap_file = m_params.get<std::string>(
         "nudging_refine_remap_mapfile", "no-file-given");
@@ -145,7 +145,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
   // For now, we are doing the horizontal interpolation last,
   // so we use the m_grid (model physics) as the target grid
   grid_int = m_grid->clone(m_grid->name(), true);
-  if(m_refine_remap) {
+  if (m_refine_remap) {
     // P2P remapper
     m_refine_remapper =
         std::make_shared<RefiningRemapperP2P>(grid_int, m_refine_remap_file);
@@ -225,7 +225,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
     auto field_ext = create_helper_field(name_ext, scalar3d_layout_mid, grid_ext_name, ps);
     auto field_hxt = create_helper_field(name_hxt, scalar3d_layout_hid, grid_hxt_name, ps);
     Field field_int;
-    if(m_refine_remap) {
+    if (m_refine_remap) {
       field_int = create_helper_field(name, layout, grid_int_name, ps);
     } else {
       field_int             = field_hxt.alias(name);
@@ -451,7 +451,7 @@ void Nudging::finalize_impl()
   m_time_interp.finalize();
 }
 // =========================================================================================
-Field Nudging::create_helper_field(const std::string& name,
+Field Nudging::create_helper_field (const std::string& name,
                                              const FieldLayout& layout,
                                              const std::string& grid_name,
                                              const int ps)

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -1,5 +1,7 @@
 #include "eamxx_nudging_process_interface.hpp"
 #include "share/util/scream_universal_constants.hpp"
+#include "share/grid/remap/refining_remapper_p2p.hpp"
+#include "share/grid/remap/abstract_remapper.hpp"
 
 namespace scream
 {

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -205,7 +205,7 @@ void Nudging::apply_vert_cutoff_tendency(Field &base, const Field &next,
                                              {num_cols, num_vert_packs}),
       KOKKOS_LAMBDA(int i, int j) {
         // If the pressure is above the cutoff, then we are closer to the surface
-        if (pmid_view(i, j) > cutoff_view(i, j)) {
+        if (pmid_view(i, j) > cutoff) {
           // Don't apply the tendency closer to the surface
           tend_view(i, j) = 0.0;
         } else {
@@ -523,8 +523,8 @@ void Nudging::run_impl (const double dt)
         apply_weighted_tendency(atm_state_field, int_state_field, nudging_weights_field, dt);
       } else if (m_refine_remap_vert_cutoff > 0.0) {
         // If we have a cutoff, we apply the tendency with p_mid cutoff
-        // First, get p_mid the field in the "atm" (i.e., "int") state
-        auto p_mid_field = get_field_in("p_mid")
+        // First, get p_mid the field in the atm (i.e., int) state
+        auto p_mid_field = get_field_in("p_mid");
         // Then, call the tendency with a Heaviside-like cutoff
         apply_vert_cutoff_tendency(atm_state_field, int_state_field,
                                    p_mid_field, m_refine_remap_vert_cutoff, dt);

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -112,7 +112,7 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
                      "Error! Nudging::set_grids - the number of columns in the model grid "
                      << std::to_string(m_num_cols_global) << " does not match the number of columns in the "
                      << "mapfile " << std::to_string(num_cols_remap_b) << ".  Please check the "
-                    << "model grid and/or the mapfile.");
+                     << "model grid and/or the mapfile.");
     // If we get here, we are good to go!
     m_refine_remap = true;
   } else {

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -1,5 +1,6 @@
 #include "eamxx_nudging_process_interface.hpp"
 #include "share/util/scream_universal_constants.hpp"
+#include "share/field/field_utils.hpp"
 
 namespace scream
 {
@@ -293,10 +294,6 @@ void Nudging::run_impl (const double dt)
       auto int_state_field = get_helper_field(name);        // int horiz, int vert
       auto ext_state_field = get_helper_field(name+"_ext"); // ext horiz, ext vert
       auto hxt_state_field = get_helper_field(name+"_hxt"); // ext horiz, int vert
-      auto ext_state_view  = ext_state_field.get_view<mPack**>();
-      auto hxt_state_view  = hxt_state_field.get_view<mPack**>();
-      auto atm_state_view  = atm_state_field.get_view<mPack**>();  // TODO: Right now assume whatever field is defined on COLxLEV
-      auto int_state_view  = int_state_field.get_view<mPack**>();
       refine_remapper->register_field(hxt_state_field, int_state_field);
     }
   }
@@ -307,6 +304,14 @@ void Nudging::run_impl (const double dt)
 
   // Loop over the nudged fields
   for (auto name : m_fields_nudge) {
+    auto atm_state_field = get_field_out_wrap(name);      // int horiz, int vert
+    auto int_state_field = get_helper_field(name);        // int horiz, int vert
+    auto ext_state_field = get_helper_field(name+"_ext"); // ext horiz, ext vert
+    auto hxt_state_field = get_helper_field(name+"_hxt"); // ext horiz, int vert
+    auto ext_state_view  = ext_state_field.get_view<mPack**>();
+    auto hxt_state_view  = hxt_state_field.get_view<mPack**>();
+    auto atm_state_view  = atm_state_field.get_view<mPack**>();  // TODO: Right now assume whatever field is defined on COLxLEV
+    auto int_state_view  = int_state_field.get_view<mPack**>();
     auto int_mask_view = m_buffer.int_mask_view;
     // Masked values in the source data can lead to strange behavior in the vertical interpolation.
     // We pre-process the data and map any masked values (sometimes called "filled" values) to the
@@ -382,6 +387,9 @@ void Nudging::run_impl (const double dt)
     // Note that we are going from hxt to int here
     if(m_refine_remap) {
       // Call the remapper
+      print_field_hyperslab (ext_state_field);
+      print_field_hyperslab (hxt_state_field);
+      print_field_hyperslab (int_state_field);
       refine_remapper->remap(true);
     } else {
       // No horizontal interpolation, just copy the data

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -204,9 +204,12 @@ void Nudging::apply_vert_cutoff_tendency(Field &base, const Field &next,
       Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0},
                                              {num_cols, num_vert_packs}),
       KOKKOS_LAMBDA(int i, int j) {
-        if(pmid_view(i, j) > cutoff_view(i, j)) {
+        // If the pressure is above the cutoff, then we are closer to the surface
+        if (pmid_view(i, j) > cutoff_view(i, j)) {
+          // Don't apply the tendency closer to the surface
           tend_view(i, j) = 0.0;
         } else {
+          // Apply the tendency farther up from the surface
           tend_view(i, j) = next_view(i, j) - base_view(i, j);
         }
       });

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -144,7 +144,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
   // because we need to know the grid information.
   // For now, we are doing the horizontal interpolation last,
   // so we use the m_grid (model physics) as the target grid
-  grid_int = m_grid->clone(m_grid->name(), false);
+  grid_int = m_grid->clone(m_grid->name(), true);
   // We also need a temporary grid for the external grid
   std::shared_ptr<const scream::AbstractGrid> grid_ext_const;
   if(m_refine_remap) {
@@ -154,25 +154,25 @@ void Nudging::initialize_impl (const RunType /* run_type */)
     // If we are refine-remapping, then get grid from remapper
     grid_ext_const = m_refine_remapper->get_src_grid();
     // Deep clone it though to get rid of "const" stuff
-    grid_ext = grid_ext_const->clone(grid_ext_const->name(), false);
+    grid_ext = grid_ext_const->clone(grid_ext_const->name(), true);
     // The first grid is grid_ext (external grid, i.e., files),
     // so, grid_ext can potentially have different levels
     grid_ext->reset_num_vertical_lev(m_num_src_levs);
     // The second grid is grid_hxt (external horiz grid, but model physics
     // vert grid, so potentially a bit of a mess)
-    grid_hxt = grid_ext->clone(grid_ext->name(), false);
+    grid_hxt = grid_ext->clone(grid_ext->name(), true);
     grid_hxt->reset_num_vertical_lev(m_num_levs);
   } else {
     // DoNothingRemapper
     // If not refine-remapping, then use whatever was used before,
     // i.e., deep clone the physics grid
-    grid_ext = m_grid->clone(m_grid->name(), false);
+    grid_ext = m_grid->clone(m_grid->name(), true);
     // The first grid is grid_ext (external grid, i.e., files),
     // so, grid_ext can potentially have different levels
     grid_ext->reset_num_vertical_lev(m_num_src_levs);
     // The second grid is grid_hxt (external horiz grid, but model physics
     // vert grid, so potentially a bit of a mess)
-    grid_hxt = grid_ext->clone(grid_ext->name(), false);
+    grid_hxt = grid_ext->clone(grid_ext->name(), true);
     grid_hxt->reset_num_vertical_lev(m_num_levs);
     m_refine_remapper = std::make_shared<DoNothingRemapper>(grid_hxt, grid_int);
   }

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -116,6 +116,16 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
     // If we get here, we are good to go!
     m_refine_remap = true;
   } else {
+    // If the number of columns is the same, we don't need to do any remapping,
+    // but print a warning if the user provided a mapfile
+    if (m_refine_remap_file != "no-file-given") {
+      std::cout << "Warning! Nudging::set_grids - the number of columns in the nudging data file "
+                << std::to_string(num_cols_src) << " matches the number of columns in the "
+                << "model grid " << std::to_string(m_num_cols_global) << ".  The mapfile "
+                << m_refine_remap_file << " will NOT be used.  Please check the "
+                << "nudging data file and/or the model grid." << std::endl;
+    }
+    // Set m_refine_remap to false
     m_refine_remap = false;
   }
 }

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -78,13 +78,9 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 
   //Now need to read in the file
   if (m_src_pres_type == TIME_DEPENDENT_3D_PROFILE) {
-    scorpio::register_file(m_datafiles[0],scorpio::Read);
     m_num_src_levs = scorpio::get_dimlen(m_datafiles[0],"lev");
-    scorpio::eam_pio_closefile(m_datafiles[0]);
   } else {
-    scorpio::register_file(m_static_vertical_pressure_file,scorpio::Read);
     m_num_src_levs = scorpio::get_dimlen(m_static_vertical_pressure_file,"lev");
-    scorpio::eam_pio_closefile(m_static_vertical_pressure_file);
   }
 
   /* Check for consistency between nudging files, map file, and remapper */
@@ -93,9 +89,7 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   auto m_num_cols_global = m_grid->get_num_global_dofs(); 
 
   // Get the information from the first nudging data file
-  scorpio::register_file(m_datafiles[0],scorpio::Read);
   int num_cols_src = scorpio::get_dimlen(m_datafiles[0],"ncol");
-  scorpio::eam_pio_closefile(m_datafiles[0]);
 
   if (num_cols_src != m_num_cols_global) {
     // If differing cols, check if remap file is provided
@@ -106,10 +100,8 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
                      << "nudging data file and/or the model grid.");
     // If remap file is provided, check if it is consistent with the nudging data file
     // First get the data from the mapfile
-    scorpio::register_file(m_refine_remap_file,scorpio::Read);
     int num_cols_remap_a = scorpio::get_dimlen(m_refine_remap_file,"n_a");
     int num_cols_remap_b = scorpio::get_dimlen(m_refine_remap_file,"n_b");
-    scorpio::eam_pio_closefile(m_refine_remap_file);
     // Then, check if n_a (source) and n_b (target) are consistent
     EKAT_REQUIRE_MSG(num_cols_remap_a == num_cols_src,
                      "Error! Nudging::set_grids - the number of columns in the nudging data file "

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -222,10 +222,8 @@ void Nudging::initialize_impl (const RunType /* run_type */)
     auto grid_hxt_name = grid_hxt->name();
     auto field  = get_field_out_wrap(name);
     auto layout = field.get_header().get_identifier().get_layout();
-    auto field_ext =
-        create_helper_field(name_ext, scalar3d_layout_mid, grid_ext_name, ps);
-    auto field_hxt =
-        create_helper_field(name_hxt, scalar3d_layout_hid, grid_hxt_name, ps);
+    auto field_ext = create_helper_field(name_ext, scalar3d_layout_mid, grid_ext_name, ps);
+    auto field_hxt = create_helper_field(name_hxt, scalar3d_layout_hid, grid_hxt_name, ps);
     Field field_int;
     if(m_refine_remap) {
       field_int = create_helper_field(name, layout, grid_int_name, ps);
@@ -251,8 +249,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
   {
     auto grid_name = m_grid->name();
     FieldLayout scalar3d_layout_grid { {COL,LEV}, {m_num_cols, m_num_levs} };
-    auto nudging_weights = create_helper_field(
-        "nudging_weights", scalar3d_layout_grid, grid_name, ps);
+    auto nudging_weights = create_helper_field("nudging_weights", scalar3d_layout_grid, grid_name, ps);
     std::vector<Field> fields;
     fields.push_back(nudging_weights);
     AtmosphereInput src_weights_input(m_weights_file, grid_ext, fields);
@@ -454,9 +451,9 @@ void Nudging::finalize_impl()
   m_time_interp.finalize();
 }
 // =========================================================================================
-Field Nudging::create_helper_field(const std::string &name,
-                                             const FieldLayout &layout,
-                                             const std::string &grid_name,
+Field Nudging::create_helper_field(const std::string& name,
+                                             const FieldLayout& layout,
+                                             const std::string& grid_name,
                                              const int ps)
 {
   using namespace ekat::units;

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -265,7 +265,6 @@ void Nudging::initialize_impl (const RunType /* run_type */)
   // do the interpolation.
   if (m_use_weights)
   {
-    auto grid_name = m_grid->name();
     auto nudging_weights = create_helper_field("nudging_weights", scalar3d_layout_mid, grid_name, ps);
     std::vector<Field> fields;
     fields.push_back(nudging_weights);

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -140,12 +140,6 @@ protected:
   std::string m_refine_remap_file;
   // (refining) remapper object
   std::shared_ptr<scream::AbstractRemapper> m_refine_remapper;
-  // grid for coarse data
-  std::shared_ptr<scream::AbstractGrid> grid_ext;
-  // grid after vertical interpolation
-  std::shared_ptr<scream::AbstractGrid> grid_hxt;
-  // grid after horizontal interpolation
-  std::shared_ptr<scream::AbstractGrid> grid_int;
 
   util::TimeInterpolation m_time_interp;
 

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -140,6 +140,12 @@ protected:
   std::string m_refine_remap_file;
   // (refining) remapper object
   std::shared_ptr<scream::AbstractRemapper> m_refine_remapper;
+  // (refining) remapper vertical cutoff
+  Real m_refine_remap_vert_cutoff;
+  // (refining) remapper vertically-weighted tendency application
+  void apply_vert_cutoff_tendency(Field &base, const Field &next,
+                                  const Field &p_mid, const Real cutoff,
+                                  const Real dt);
 
   util::TimeInterpolation m_time_interp;
 

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -149,10 +149,6 @@ protected:
   std::shared_ptr<scream::AbstractRemapper> m_refine_remapper;
   // (refining) remapper vertical cutoff
   Real m_refine_remap_vert_cutoff;
-  // (refining) remapper vertically-weighted tendency application
-  void apply_vert_cutoff_tendency(Field &base, const Field &next,
-                                  const Field &p_mid, const Real cutoff,
-                                  const Real dt);
 
   util::TimeInterpolation m_time_interp;
 

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -13,7 +13,6 @@
 #include "share/grid/point_grid.hpp"
 #include "share/util/scream_vertical_interpolation.hpp"
 #include "share/util/scream_time_stamp.hpp"
-#include "share/grid/remap/refining_remapper_p2p.hpp"
 #include "share/grid/remap/do_nothing_remapper.hpp"
 
 #include <string>

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -13,6 +13,7 @@
 #include "share/grid/point_grid.hpp"
 #include "share/util/scream_vertical_interpolation.hpp"
 #include "share/util/scream_time_stamp.hpp"
+#include "share/grid/remap/refining_remapper_p2p.hpp"
 
 #include <string>
 
@@ -131,6 +132,14 @@ protected:
   std::map<std::string,Field> m_helper_fields;
 
   std::vector<std::string> m_fields_nudge;
+
+  /* Nudge from coarse data */
+  // if true, remap coarse data to fine grid
+  bool m_refine_remap;
+  // file containing coarse data mapping
+  std::string m_refine_remap_file;
+  // (refining) remapper object
+  std::shared_ptr<scream::RefiningRemapperP2P> refine_remapper;
 
   util::TimeInterpolation m_time_interp;
 

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -14,6 +14,7 @@
 #include "share/util/scream_vertical_interpolation.hpp"
 #include "share/util/scream_time_stamp.hpp"
 #include "share/grid/remap/refining_remapper_p2p.hpp"
+#include "share/grid/remap/do_nothing_remapper.hpp"
 
 #include <string>
 
@@ -101,10 +102,8 @@ protected:
   void init_buffers(const ATMBufferManager &buffer_manager);
 
   // Creates an helper field, not to be shared with the AD's FieldManager
-  void create_helper_field (const std::string& name,
-                            const FieldLayout& layout,
-                            const std::string& grid_name,
-                            const int ps=0);
+  Field create_helper_field(const std::string &name, const FieldLayout &layout,
+                            const std::string &grid_name, const int ps = 0);
 
   // Query if a local field exists
   bool has_helper_field (const std::string& name) const { return m_helper_fields.find(name)!=m_helper_fields.end(); }
@@ -139,7 +138,13 @@ protected:
   // file containing coarse data mapping
   std::string m_refine_remap_file;
   // (refining) remapper object
-  std::shared_ptr<scream::RefiningRemapperP2P> refine_remapper;
+  std::shared_ptr<scream::AbstractRemapper> m_refine_remapper;
+  // grid for coarse data
+  std::shared_ptr<scream::AbstractGrid> grid_ext;
+  // grid after vertical interpolation
+  std::shared_ptr<scream::AbstractGrid> grid_hxt;
+  // grid after horizontal interpolation
+  std::shared_ptr<scream::AbstractGrid> grid_int;
 
   util::TimeInterpolation m_time_interp;
 

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -101,8 +101,10 @@ protected:
   void init_buffers(const ATMBufferManager &buffer_manager);
 
   // Creates an helper field, not to be shared with the AD's FieldManager
-  Field create_helper_field(const std::string &name, const FieldLayout &layout,
-                            const std::string &grid_name, const int ps = 0);
+  Field create_helper_field(const std::string &name,
+                            const FieldLayout &layout,
+                            const std::string &grid_name,
+                            const int ps = 0);
 
   // Query if a local field exists
   bool has_helper_field (const std::string& name) const { return m_helper_fields.find(name)!=m_helper_fields.end(); }

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -101,7 +101,7 @@ protected:
   void init_buffers(const ATMBufferManager &buffer_manager);
 
   // Creates an helper field, not to be shared with the AD's FieldManager
-  Field create_helper_field(const std::string& name,
+  Field create_helper_field (const std::string& name,
                             const FieldLayout& layout,
                             const std::string& grid_name,
                             const int ps=0);

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -101,10 +101,10 @@ protected:
   void init_buffers(const ATMBufferManager &buffer_manager);
 
   // Creates an helper field, not to be shared with the AD's FieldManager
-  Field create_helper_field(const std::string &name,
-                            const FieldLayout &layout,
-                            const std::string &grid_name,
-                            const int ps = 0);
+  Field create_helper_field(const std::string& name,
+                            const FieldLayout& layout,
+                            const std::string& grid_name,
+                            const int ps=0);
 
   // Query if a local field exists
   bool has_helper_field (const std::string& name) const { return m_helper_fields.find(name)!=m_helper_fields.end(); }

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -85,6 +85,13 @@ protected:
 
   void run_impl        (const double dt);
 
+  /* Nudge from coarse data */
+  // See more details later in this file
+  // Must add this here to make it public for CUDA
+  // (refining) remapper vertically-weighted tendency application
+  void apply_vert_cutoff_tendency(Field &base, const Field &next,
+                                  const Field &p_mid, const Real cutoff,
+                                  const Real dt);
 protected:
 
   Field get_field_out_wrap(const std::string& field_name);

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -13,7 +13,7 @@
 #include "share/grid/point_grid.hpp"
 #include "share/util/scream_vertical_interpolation.hpp"
 #include "share/util/scream_time_stamp.hpp"
-#include "share/grid/remap/do_nothing_remapper.hpp"
+#include "share/grid/remap/abstract_remapper.hpp"
 
 #include <string>
 


### PR DESCRIPTION
adds the ability to nudge from coarse data. Both the vertical interpolation and regional nudging (weighting) should be unaffected. However, I did have to make edits in code related to vertical interp and regional nudging, so please take a look. The tests pass on chrysalis. The vertical and horizontal interpolation should work well together. The weighting should also work well with both, but only if applied at the model grid (in the future, we could contemplate applying it to the external grid if we need to).

Ultimately, I think we will need to rewrite this whole interface soon to make it easier to maintain. Currently, there are areas of the code that code be improved.

A current limitation is the need to provide an explicit list of data files. In my testing, this didn't work quite well (it was not possible to provide a list of more than ~5 files).

