### PR TITLE
EAMxx: fix fixtures logic in shoc standalone tests

### DIFF
--- a/components/eamxx/tests/uncoupled/shoc/CMakeLists.txt
+++ b/components/eamxx/tests/uncoupled/shoc/CMakeLists.txt
@@ -101,7 +101,7 @@ add_test (NAME check_U_V_slices_fail_diff
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set_tests_properties (check_U_V_slices_fail_diff PROPERTIES
           WILL_FAIL TRUE
-          FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_np1_omp1)
+          FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_np${TEST_RANK_START}_omp1)
 
 # Wrong layout
 add_test (NAME check_U_V_slices_fail_layout
@@ -110,7 +110,7 @@ add_test (NAME check_U_V_slices_fail_layout
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set_tests_properties (check_U_V_slices_fail_layout PROPERTIES
           WILL_FAIL TRUE
-          FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_np1_omp1)
+          FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_np${TEST_RANK_START}_omp1)
 
 # Missing variable(s)
 add_test (NAME check_U_V_slices_fail_missing
@@ -119,4 +119,4 @@ add_test (NAME check_U_V_slices_fail_missing
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set_tests_properties (check_U_V_slices_fail_missing PROPERTIES
           WILL_FAIL TRUE
-          FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_np1_omp1)
+          FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_np${TEST_RANK_START}_omp1)


### PR DESCRIPTION
There were a few tests that hard-coded `np1` in the name of the required fixtures. However, valgrind tests run only np4 tests (for speed reasons), so there was no fixture with `np1` in the name. Rather than giving a warning/error and maybe skip the test, cmake simply consider the test as "without deps", and runs in in parallel with the others. By shear luck, in our nightlies it must have happened that a test that should detect a diff loaded the input nc file _as it was being written_, more precisely at a moment where the file had likely zero time slices, so all vars were "the same", and no diff was detected.

Long story short, this PR fixes the fixtures names. However, I noticed another minor issue: if the file happened to not be found by the `compare-nc-files` script, the script would fail, but since we told CMake that the test would fail, cmake would mark the test as PASSED, even though the script faild _for the wrong reason_. I think it's a bit hard to cook up cmake logic to detect that a test fails as expected _for the right reason_ (we may play around with `PASS/FAIL_REGULAR_EXPRESSION` and `WILL_FAIL`, but it's not very simple. For now, I'm just going to punt on this.

This should fix our valgrind build in the nightlies.