### PR TITLE
Process IOP file data

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -272,6 +272,7 @@ endif()
 
 set (SCREAM_DATA_DIR ${SCREAM_INPUT_ROOT}/atm/scream CACHE PATH "" FORCE)
 set (TOPO_DATA_DIR ${SCREAM_INPUT_ROOT}/atm/cam/topo CACHE PATH "" FORCE)
+set (IOP_DATA_DIR ${SCREAM_INPUT_ROOT}/atm/cam/scam/iop CACHE PATH "" FORCE)
 
 #
 # Handle test level

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -173,8 +173,8 @@ init_time_stamps (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0)
 void AtmosphereDriver::
 setup_intensive_observation_period ()
 {
-  // At this point, must have comm and params set.
-  check_ad_status(s_comm_set | s_params_set);
+  // At this point, must have comm, params, initialized timestamps, and grids created.
+  check_ad_status(s_comm_set | s_params_set | s_ts_inited | s_grids_created);
 
   // Check to make sure iop is not already initialized
   EKAT_REQUIRE_MSG(not m_intensive_observation_period, "Error! setup_intensive_observation_period() is "
@@ -194,7 +194,18 @@ setup_intensive_observation_period ()
                    "defined in parameters.\n");
 
   const auto iop_params = m_atm_params.sublist("intensive_observation_period_options");
-  m_intensive_observation_period = std::make_shared<IntensiveObservationPeriod>(m_atm_comm,iop_params);
+  const auto phys_grid = m_grids_manager->get_grid("Physics");
+  const auto nlevs = phys_grid->get_num_vertical_levels();
+  const auto hyam = phys_grid->get_geometry_data("hyam");
+  const auto hybm = phys_grid->get_geometry_data("hybm");
+
+  m_intensive_observation_period =
+    std::make_shared<IntensiveObservationPeriod>(m_atm_comm,
+                                                 iop_params,
+                                                 m_run_t0,
+                                                 nlevs,
+                                                 hyam,
+                                                 hybm);
 }
 
 void AtmosphereDriver::create_atm_processes()
@@ -1115,7 +1126,7 @@ void AtmosphereDriver::set_initial_conditions ()
 
   if (m_intensive_observation_period) {
     // For runs with IOP, call to setup io grids and lat
-    //and lon information needed for reading from file
+    // lon information needed for reading from file
     for (const auto& it : m_field_mgrs) {
       const auto& grid_name = it.first;
       if (ic_fields_names[grid_name].size() > 0) {
@@ -1250,6 +1261,19 @@ void AtmosphereDriver::set_initial_conditions ()
     }
 
     m_atm_params.sublist("provenance").set<std::string>("topography_file","NONE");
+  }
+
+  if (m_intensive_observation_period) {
+    // Load IOP data file data for initial time stamp
+    m_intensive_observation_period->read_iop_file_data(m_current_ts);
+
+    // Now that ICs are processed, set appropriate fields using IOP file data.
+    // Since ICs are loaded on GLL grid, we set those fields only and dynamics
+    // will take care of the rest (for PG2 case).
+    if (m_field_mgrs.count("Physics GLL") > 0) {
+      const auto& fm = m_field_mgrs.at("Physics GLL");
+      m_intensive_observation_period->set_fields_from_iop_data(fm);
+    }
   }
 
   m_atm_logger->info("  [EAMxx] set_initial_conditions ... done!");
@@ -1408,6 +1432,22 @@ void AtmosphereDriver::initialize_atm_procs ()
   // Setup SurfaceCoupling import and export (if they exist)
   if (m_surface_coupling_import_data_manager || m_surface_coupling_export_data_manager) {
     setup_surface_coupling_processes();
+  }
+
+  // For IOP runs, certain processes need to set the IOP object
+  if (m_intensive_observation_period) {
+    if (m_atm_process_group->has_process("homme")) {
+      auto homme_process = m_atm_process_group->get_process_nonconst("homme");
+      homme_process->set_intensive_observational_period(m_intensive_observation_period);
+    }
+    if (m_atm_process_group->has_process("SurfaceCouplingImporter")) {
+       auto importer = m_atm_process_group->get_process_nonconst("SurfaceCouplingImporter");
+       importer->set_intensive_observational_period(m_intensive_observation_period);
+    }
+    if (m_atm_process_group->has_process("shoc")) {
+      auto shoc_process = m_atm_process_group->get_process_nonconst("shoc");
+      shoc_process->set_intensive_observational_period(m_intensive_observation_period);
+    }
   }
 
   // Initialize the processes

--- a/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
@@ -1,6 +1,7 @@
 #include "atmosphere_surface_coupling_importer.hpp"
 
 #include "share/property_checks/field_within_interval_check.hpp"
+#include "physics/share/physics_constants.hpp"
 
 #include "ekat/ekat_assert.hpp"
 #include "ekat/util/ekat_units.hpp"
@@ -24,7 +25,7 @@ void SurfaceCouplingImporter::set_grids(const std::shared_ptr<const GridsManager
   const auto& grid_name = m_grid->name();
 
   m_num_cols = m_grid->get_num_local_dofs();      // Number of columns on this rank
- 
+
   // The units of mixing ratio Q are technically non-dimensional.
   // Nevertheless, for output reasons, we like to see 'kg/kg'.
   auto Qunit = kg/kg;
@@ -130,7 +131,7 @@ void SurfaceCouplingImporter::initialize_impl (const RunType /* run_type */)
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("sfc_alb_dif_vis"),m_grid,0.0,1.0,true);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("sfc_alb_dif_nir"),m_grid,0.0,1.0,true);
 
-  // Perform initial import (if any are marked for import during initialization) 
+  // Perform initial import (if any are marked for import during initialization)
   if (any_initial_imports) do_import(true);
 }
 // =========================================================================================
@@ -168,6 +169,68 @@ void SurfaceCouplingImporter::do_import(const bool called_during_initialization)
       info.data[offset] = cpl_imports_view_d(icol,info.cpl_indx)*info.constant_multiple;
     }
   });
+
+  // If IOP is defined, potentially overwrite imports with data from IOP file
+  if (m_intensive_observation_period) {
+    overwrite_iop_imports(called_during_initialization);
+  }
+}
+// =========================================================================================
+void SurfaceCouplingImporter::overwrite_iop_imports (const bool called_during_initialization)
+{
+  using policy_type = KokkosTypes<DefaultDevice>::RangePolicy;
+  using C = physics::Constants<Real>;
+
+  const auto has_lhflx = m_intensive_observation_period->has_iop_field("lhflx");
+  const auto has_shflx = m_intensive_observation_period->has_iop_field("shflx");
+  const auto has_Tg    = m_intensive_observation_period->has_iop_field("Tg");
+
+  static constexpr Real latvap = C::LatVap;
+  static constexpr Real stebol = C::stebol;
+
+  const auto& col_info_h = m_column_info_h;
+  const auto& col_info_d = m_column_info_d;
+
+  for (int ifield=0; ifield<m_num_scream_imports; ++ifield) {
+    const std::string fname = m_import_field_names[ifield];
+    const auto& info_h = col_info_h(ifield);
+
+    // If we are in initialization and field should not be imported, skip
+    if (called_during_initialization && not info_h.transfer_during_initialization) {
+      continue;
+    }
+
+    // Store IOP surf data into col_val
+    Real col_val(std::nan(""));
+    if (fname == "surf_evap" && has_lhflx) {
+      const auto f = m_intensive_observation_period->get_iop_field("lhflx");
+      f.sync_to_host();
+      col_val = f.get_view<Real, Host>()()/latvap;
+    } else if (fname == "surf_sens_flux" && has_shflx) {
+      const auto f = m_intensive_observation_period->get_iop_field("shflx");
+      f.sync_to_host();
+      col_val = f.get_view<Real, Host>()();
+    } else if (fname == "surf_radiative_T" && has_Tg) {
+      const auto f = m_intensive_observation_period->get_iop_field("Tg");
+      f.sync_to_host();
+      col_val = f.get_view<Real, Host>()();
+    } else if (fname == "surf_lw_flux_up" && has_Tg) {
+      const auto f = m_intensive_observation_period->get_iop_field("Tg");
+      f.sync_to_host();
+      col_val = stebol*std::pow(f.get_view<Real, Host>()(), 4);
+    } else {
+      // If import field doesn't satisify above, skip
+      continue;
+    }
+
+    // Overwrite iop imports with col_val for each column
+    auto policy = policy_type(0, m_num_cols);
+    Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int& icol) {
+      const auto& info_d = col_info_d(ifield);
+      const auto offset = icol*info_d.col_stride + info_d.col_offset;
+      info_d.data[offset] = col_val;
+    });
+  }
 }
 // =========================================================================================
 void SurfaceCouplingImporter::finalize_impl()

--- a/components/eamxx/src/control/atmosphere_surface_coupling_importer.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_importer.hpp
@@ -5,6 +5,8 @@
 #include "ekat/ekat_parameter_list.hpp"
 #include "share/atm_process/SCDataManager.hpp"
 
+#include "control/intensive_observation_period.hpp"
+
 #include "surface_coupling_utils.hpp"
 
 #include <string>
@@ -58,6 +60,15 @@ public:
   // Take and store data from SCDataManager
   void setup_surface_coupling_data(const SCDataManager &sc_data_manager);
 
+  // Setup IntensiveObservationPeriod (IOP) object for overwriting imports
+  // with data from IOP file with runs using IOP
+  void set_intensive_observational_period (const std::shared_ptr<control::IntensiveObservationPeriod>& iop) {
+    m_intensive_observation_period = iop;
+  }
+
+  // Overwrite imports for IOP cases with IOP file surface data
+  void overwrite_iop_imports (const bool called_during_initialization);
+
 protected:
 
   // The three main overrides for the subcomponent
@@ -66,7 +77,7 @@ protected:
   void finalize_impl   ();
 
   // Keep track of field dimensions
-  Int m_num_cols; 
+  Int m_num_cols;
 
   // Number of fields in cpl data
   Int m_num_cpl_imports;
@@ -97,6 +108,9 @@ protected:
   // The grid is needed for property checks
   std::shared_ptr<const AbstractGrid> m_grid;
 
+  // IOP object for setting certain imported fluxes when
+  // running EAMxx with an intensive observational period,
+  std::shared_ptr<control::IntensiveObservationPeriod> m_intensive_observation_period;
 }; // class SurfaceCouplingImporter
 
 } // namespace scream

--- a/components/eamxx/src/control/intensive_observation_period.cpp
+++ b/components/eamxx/src/control/intensive_observation_period.cpp
@@ -2,11 +2,17 @@
 
 #include "share/grid/point_grid.hpp"
 #include "share/io/scorpio_input.hpp"
+#include "share/util/scream_vertical_interpolation.hpp"
 
 #include "ekat/ekat_assert.hpp"
+#include "ekat/util/ekat_lin_interp.hpp"
 
-// Extend ekat mpi type for pair of double int, used
-// in find_closest_lat_lon_index_and_rank()
+#include "pio.h"
+
+#include <numeric>
+
+// Extend ekat mpi type for <Real,int> pairs,
+// used for reduction of type MPI_MINLOC.
 namespace ekat {
 #ifdef SCREAM_DOUBLE_PRECISION
   template<>
@@ -24,9 +30,82 @@ namespace ekat {
 namespace scream {
 namespace control {
 
+// Helper functions for reading data from .nc file to support
+// cases not currently supported in EAMxx scorpio interface.
+namespace {
+// Read the value of a dimensionless variable from file.
+template<typename T>
+void read_dimensionless_variable_from_file(const std::string& filename,
+                                           const std::string& varname,
+                                           T*                 value)
+{
+  EKAT_REQUIRE_MSG(scorpio::has_variable(filename,varname),
+                   "Error! IOP file does not have variable "+varname+".\n");
+
+  int ncid, varid, err1, err2;
+  bool was_open = scorpio::is_file_open_c2f(filename.c_str(),-1);
+  if (not was_open) {
+    scorpio::register_file(filename,scorpio::FileMode::Read);
+  }
+  ncid = scorpio::get_file_ncid_c2f (filename.c_str());
+  err1 = PIOc_inq_varid(ncid,varname.c_str(),&varid);
+  EKAT_REQUIRE_MSG(err1==PIO_NOERR,
+    "Error! Something went wrong while retrieving variable id.\n"
+    " - filename : " + filename + "\n"
+    " - varname  : " + varname + "\n"
+    " - pio error: " + std::to_string(err1) + "\n");
+
+  err2 = PIOc_get_var(ncid, varid, value);
+  EKAT_REQUIRE_MSG(err2==PIO_NOERR,
+    "Error! Something went wrong while retrieving variable.\n"
+    " - filename : " + filename + "\n"
+    " - varname  : " + varname + "\n"
+    " - pio error: " + std::to_string(err2) + "\n");
+
+  if (not was_open) {
+    scorpio::eam_pio_closefile(filename);
+  }
+}
+
+// Read variable with arbitrary number of dimensions from file.
+template<typename T>
+void read_variable_from_file(const std::string&              filename,
+                             const std::string&              varname,
+                             const std::string&              vartype,
+                             const std::vector<std::string>& dimnames,
+                             const int                       time_idx,
+                             T*                              data)
+{
+  EKAT_REQUIRE_MSG(scorpio::has_variable(filename,varname),
+                   "Error! IOP file does not have variable "+varname+".\n");
+
+  // Compute total size of data to read
+  int data_size = 1;
+  for (auto dim : dimnames) {
+    const auto dim_len = scorpio::get_dimlen(filename, dim);
+      data_size *= dim_len;
+  }
+
+  // Read into data
+  scorpio::register_file(filename, scorpio::FileMode::Read);
+  std::string io_decomp_tag = varname+","+filename;
+  scorpio::register_variable(filename, varname, varname, dimnames, vartype, io_decomp_tag);
+  std::vector<scorpio::offset_t> dof_offsets(data_size);
+  std::iota(dof_offsets.begin(), dof_offsets.end(), 0);
+  scorpio::set_dof(filename, varname, dof_offsets.size(), dof_offsets.data());
+  scorpio::set_decomp(filename);
+  scorpio::grid_read_data_array(filename, varname, time_idx, data, data_size);
+  scorpio::eam_pio_closefile(filename);
+}
+}
+
 IntensiveObservationPeriod::
 IntensiveObservationPeriod(const ekat::Comm& comm,
-	    	           const ekat::ParameterList& params)
+                           const ekat::ParameterList& params,
+                           const util::TimeStamp& run_t0,
+                           const int model_nlevs,
+                           const Field& hyam,
+                           const Field& hybm)
 {
   m_comm = comm;
   m_params = params;
@@ -44,6 +123,185 @@ IntensiveObservationPeriod(const ekat::Comm& comm,
                    "Error! IOP target_lat="+std::to_string(target_lat)+" outside of expected range [-90, 90].\n");
   EKAT_REQUIRE_MSG(0 <= target_lon and target_lon <= 360,
 	           "Error! IOP target_lat="+std::to_string(target_lon)+" outside of expected range [0, 360].\n");
+
+  // Set defaults for some parameters
+  if (not m_params.isParameter("iop_srf_prop"))         m_params.set<bool>("iop_srf_prop",         false);
+  if (not m_params.isParameter("iop_dosubsidence"))     m_params.set<bool>("iop_dosubsidence",     false);
+  if (not m_params.isParameter("iop_coriolis"))         m_params.set<bool>("iop_coriolis",         false);
+  if (not m_params.isParameter("iop_nudge_tq"))         m_params.set<bool>("iop_nudge_tq",         false);
+  if (not m_params.isParameter("iop_nudge_uv"))         m_params.set<bool>("iop_nudge_uv",         false);
+  if (not m_params.isParameter("iop_nudge_tq_low"))     m_params.set<Real>("iop_nudge_tq_low",     1050);
+  if (not m_params.isParameter("iop_nudge_tq_high"))    m_params.set<Real>("iop_nudge_tq_high",    0);
+  if (not m_params.isParameter("iop_nudge_tscale"))     m_params.set<Real>("iop_nudge_tscale",     10800);
+  if (not m_params.isParameter("iop_perturb_high"))     m_params.set<Real>("iop_perturb_high",     1050);
+  if (not m_params.isParameter("zero_non_iop_tracers")) m_params.set<bool>("zero_non_iop_tracers", false);
+
+  // Use IOP file (if it exists) to initialize parameters
+  // and timestepping information
+  if (m_params.isParameter("iop_file")) {
+    initialize_iop_file(run_t0, model_nlevs, hyam, hybm);
+  }
+}
+
+void IntensiveObservationPeriod::
+initialize_iop_file(const util::TimeStamp& run_t0,
+                    int model_nlevs,
+                    const Field& hyam,
+                    const Field& hybm)
+{
+  const auto iop_file = m_params.get<std::string>("iop_file");
+
+  // Lambda for allocating space and storing information for potential iop fields.
+  // Inputs:
+  //   - varnames:    Vector of possible variable names in the iop file.
+  //                  First entry will be the variable name used when accessing in class
+  //   - fl:          IOP field layout (acceptable ranks: 0, 1)
+  //   - srf_varname: Name of surface variable potentially in iop file associated with iop variable.
+  auto setup_iop_field = [&, this] (const vos&         varnames,
+                                    const FieldLayout& fl,
+                                    const std::string& srf_varname = "none") {
+    EKAT_REQUIRE_MSG(fl.rank() == 0 || fl.rank() == 1,
+                     "Error! IOP fields must have rank 0 or 1. "
+                     "Attempting to setup "+varnames[0]+" with rank "
+                     +std::to_string(fl.rank())+".\n");
+
+    // Check if var exists in IOP file. Some variables will
+    // need to check alternate names.
+    const auto iop_varname = varnames[0];
+    bool has_var = false;
+    std::string file_varname = "";
+    for (auto varname : varnames) {
+      if (scorpio::has_variable(iop_file, varname)) {
+        has_var = true;
+        file_varname = varname;
+        break;
+      };
+    }
+    if (has_var) {
+      // Store if iop file has a different varname than the iop field
+      if (iop_varname != file_varname) m_iop_file_varnames.insert({iop_varname, file_varname});
+      // Store if variable contains a surface value in iop file
+      if (scorpio::has_variable(iop_file, srf_varname)) {
+        m_iop_field_surface_varnames.insert({iop_varname, srf_varname});
+      }
+
+      // Allocate field for variable
+      FieldIdentifier fid(iop_varname, fl, ekat::units::Units::nondimensional(), "");
+      const auto field_rank = fl.rank();
+      EKAT_REQUIRE_MSG(field_rank <= 1,
+                       "Error! Unexpected field rank "+std::to_string(field_rank)+" for iop file fields.\n");
+      Field field(fid);
+      field.allocate_view();
+      m_iop_fields.insert({iop_varname, field});
+    }
+  };
+
+  // Check if the following variables exist in the iop file
+
+  // Scalar data
+  FieldLayout fl_scalar({}); // Zero dim fields used for iop file scalars
+  setup_iop_field({"Ps"},          fl_scalar);
+  setup_iop_field({"Tg"},          fl_scalar);
+  setup_iop_field({"lhflx", "lh"}, fl_scalar);
+  setup_iop_field({"shflx", "sh"}, fl_scalar);
+
+  // Level data
+  FieldLayout fl_vector({FieldTag::LevelMidPoint}, {model_nlevs});
+  setup_iop_field({"T"},        fl_vector, "Tsair");
+  setup_iop_field({"q"},        fl_vector, "qsrf");
+  setup_iop_field({"cld"},      fl_vector);
+  setup_iop_field({"clwp"},     fl_vector);
+  setup_iop_field({"divq"},     fl_vector, "divqsrf");
+  setup_iop_field({"vertdivq"}, fl_vector, "vertdivqsrf");
+  setup_iop_field({"NUMLIQ"},   fl_vector);
+  setup_iop_field({"CLDLIQ"},   fl_vector);
+  setup_iop_field({"CLDICE"},   fl_vector);
+  setup_iop_field({"NUMICE"},   fl_vector);
+  setup_iop_field({"divu"},     fl_vector, "divusrf");
+  setup_iop_field({"divv"},     fl_vector, "divvsrf");
+  setup_iop_field({"divT"},     fl_vector, "divtsrf");
+  setup_iop_field({"vertdivT"}, fl_vector, "vertdivTsrf");
+  setup_iop_field({"divT3d"},   fl_vector, "divT3dsrf");
+  setup_iop_field({"u"},        fl_vector, "usrf");
+  setup_iop_field({"u_ls"},     fl_vector, "usrf");
+  setup_iop_field({"v"},        fl_vector, "vsrf");
+  setup_iop_field({"v_ls"},     fl_vector, "vsrf");
+  setup_iop_field({"Q1"},       fl_vector);
+  setup_iop_field({"Q2"},       fl_vector);
+  setup_iop_field({"omega"},    fl_vector, "Ptend");
+
+  // Make sure Ps is defined if using a iop file
+  EKAT_REQUIRE_MSG(has_iop_field("Ps"),
+                   "Error! Using IOP file requires variable \"Ps\".\n");
+
+  // Initialize time information
+  int bdate;
+  std::string bdate_name;
+  if      (scorpio::has_variable(iop_file, "bdate"))    bdate_name = "bdate";
+  else if (scorpio::has_variable(iop_file, "basedate")) bdate_name = "basedate";
+  else if (scorpio::has_variable(iop_file, "nbdate"))   bdate_name = "nbdate";
+  else EKAT_ERROR_MSG("Error! No valid name for bdate in "+iop_file+".\n");
+  read_dimensionless_variable_from_file<int>(iop_file, bdate_name, &bdate);
+
+  int yr=bdate/10000;
+  int mo=(bdate/100) - yr*100;
+  int day=bdate - (yr*10000+mo*100);
+  m_time_info.iop_file_begin_time = util::TimeStamp(yr,mo,day,0,0,0);
+
+  std::string time_dimname;
+  if      (scorpio::has_dim(iop_file, "time")) time_dimname = "time";
+  else if (scorpio::has_dim(iop_file, "tsec")) time_dimname = "tsec";
+  else EKAT_ERROR_MSG("Error! No valid dimension for tsec in "+iop_file+".\n");
+  const auto ntimes = scorpio::get_dimlen(iop_file, time_dimname);
+  m_time_info.iop_file_times_in_sec =
+    decltype(m_time_info.iop_file_times_in_sec)("iop_file_times", ntimes);
+  read_variable_from_file(iop_file, "tsec", "int", {time_dimname}, -1,
+                          m_time_info.iop_file_times_in_sec.data());
+
+  // Check that lat/lon from iop file match the targets in parameters. Note that
+  // longitude may be negtive in the iop file, we convert to positive before checking.
+  const auto nlats = scorpio::get_dimlen(iop_file, "lat");
+  const auto nlons = scorpio::get_dimlen(iop_file, "lon");
+  EKAT_REQUIRE_MSG(nlats==1 and nlons==1, "Error! IOP data file requires a single lat/lon pair.\n");
+  Real iop_file_lat, iop_file_lon;
+  read_variable_from_file(iop_file, "lat", "real", {"lat"}, -1, &iop_file_lat);
+  read_variable_from_file(iop_file, "lon", "real", {"lon"}, -1, &iop_file_lon);
+  EKAT_REQUIRE_MSG(iop_file_lat == m_params.get<Real>("target_latitude"),
+                  "Error! IOP file variable \"lat\" does not match target_latitude from IOP parameters.\n");
+  EKAT_REQUIRE_MSG(std::fmod(iop_file_lon + 360, 360) == m_params.get<Real>("target_longitude"),
+                  "Error! IOP file variable \"lat\" does not match target_latitude from IOP parameters.\n");
+
+  // Store iop file pressure as helper field with dimension lev+1.
+  // Load the first lev entries from iop file, the lev+1 entry will
+  // be set when reading iop data.
+  EKAT_REQUIRE_MSG(scorpio::has_variable(iop_file, "lev"),
+                    "Error! Using IOP file requires variable \"lev\".\n");
+  const auto file_levs = scorpio::get_dimlen(iop_file, "lev");
+  FieldIdentifier fid("iop_file_pressure",
+                      FieldLayout({FieldTag::LevelMidPoint}, {file_levs+1}),
+                      ekat::units::Units::nondimensional(),
+                      "");
+  Field iop_file_pressure(fid);
+  iop_file_pressure.allocate_view();
+  Real* data = iop_file_pressure.get_view<Real*, Host>().data();
+  read_variable_from_file(iop_file, "lev", "real", {"lev"}, -1, data);
+  // Convert to pressure to milibar (file gives pressure in Pa)
+  for (int ilev=0; ilev<file_levs; ++ilev) data[ilev] /= 100;
+  iop_file_pressure.sync_to_dev();
+  m_helper_fields.insert({"iop_file_pressure", iop_file_pressure});
+
+  // Create model pressure helper field (values will be computed
+  // in read_iop_file_data())
+  FieldIdentifier model_pres_fid("model_pressure",
+                                  fl_vector,
+                                  ekat::units::Units::nondimensional(), "");
+  Field model_pressure(model_pres_fid);
+  model_pressure.allocate_view();
+  m_helper_fields.insert({"model_pressure", model_pressure});
+
+  // Store hyam and hybm in helper fields
+  m_helper_fields.insert({"hyam", hyam});
+  m_helper_fields.insert({"hybm", hybm});
 }
 
 void IntensiveObservationPeriod::
@@ -215,8 +473,8 @@ read_fields_from_file_for_iop (const std::string& file_name,
     // MPI rank with closest column index store column data
     const auto mpi_rank_with_col = m_lat_lon_info[grid_name].mpi_rank_of_closest_column;
     if (m_comm.rank() == mpi_rank_with_col) {
-      const auto col_indx_with_data = m_lat_lon_info[grid_name].local_column_index_of_closest_column;
-      col_data.deep_copy<Host>(io_field.subfield(0,col_indx_with_data));
+      const auto col_idx_with_data = m_lat_lon_info[grid_name].local_column_index_of_closest_column;
+      col_data.deep_copy<Host>(io_field.subfield(0,col_idx_with_data));
     }
 
     // Broadcast column data to all other ranks
@@ -235,6 +493,342 @@ read_fields_from_file_for_iop (const std::string& file_name,
     // Set the initial time stamp on FM fields
     fm_field.get_header().get_tracking().update_time_stamp(initial_ts);
   }
+}
+
+void IntensiveObservationPeriod::
+read_iop_file_data (const util::TimeStamp& current_ts)
+{
+  // If no iop file is given, return early
+  if (not m_params.isParameter("iop_file")) return;
+
+  const auto iop_file = m_params.get<std::string>("iop_file");
+  const auto iop_file_time_idx = m_time_info.get_iop_file_time_idx(current_ts);
+
+  // Sanity check
+  EKAT_REQUIRE_MSG(iop_file_time_idx >= m_time_info.time_idx_of_current_data,
+                   "Error! Attempting to read previous iop file data time index.\n");
+
+  // If we are still in the time interval as the previous read from iop file,
+  // there is no need to reload data. Return early
+  if (iop_file_time_idx == m_time_info.time_idx_of_current_data) return;
+
+  const auto file_levs = scorpio::get_dimlen(iop_file, "lev");
+  const auto iop_file_pressure = m_helper_fields["iop_file_pressure"];
+  const auto model_pressure = m_helper_fields["model_pressure"];
+  const auto surface_pressure = m_iop_fields["Ps"];
+
+  // Loop through iop fields, if rank 1 fields exist we need to
+  // gather information for vertically interpolating views
+  bool has_level_data = false;
+  for (auto& it : m_iop_fields) {
+    if (it.second.rank() == 1) {
+      has_level_data = true;
+      break;
+    }
+  }
+
+  // Compute values and indices associate with pressure for interpolating data (if necessary).
+  int adjusted_file_levs;
+  int iop_file_start;
+  int iop_file_end;
+  int model_start;
+  int model_end;
+  if (has_level_data) {
+    // Load surface pressure (Ps) from iop file
+    Real* ps_data = surface_pressure.get_view<Real, Host>().data();
+    read_variable_from_file(iop_file, "Ps", "real", {"lon","lat"}, iop_file_time_idx, ps_data);
+    surface_pressure.sync_to_dev();
+
+    // Pre-process file pressures, store number of file levels
+    // less than or equal to the surface pressure.
+    const auto iop_file_pres_v = iop_file_pressure.get_view<Real*>();
+    // Sanity check
+    EKAT_REQUIRE_MSG(file_levs+1 == iop_file_pres_v.extent_int(0),
+                    "Error! Unexpected size for helper field \"iop_file_pressure\"\n");
+    const auto& Ps = surface_pressure.get_view<const Real>();
+    Kokkos::parallel_reduce(file_levs+1, KOKKOS_LAMBDA (const int ilev, int& lmin) {
+      if (ilev == file_levs) {
+        // Add surface pressure to iop file pressure
+        iop_file_pres_v(ilev) = Ps()/100;
+        lmin = file_levs+1; // Initialize adjusted_file_levels
+      }
+      // Set upper bound on pressure values and set adjusted levels
+      if (iop_file_pres_v(ilev) > Ps()/100) {
+        lmin = ilev;
+        iop_file_pres_v(ilev) = Ps()/100;
+      }
+    }, Kokkos::Min<int>(adjusted_file_levs));
+
+    // Compute model pressure levels
+    const auto model_pres_v = model_pressure.get_view<Real*>();
+    const auto model_nlevs = model_pres_v.extent(0);
+    const auto hyam_v = m_helper_fields["hyam"].get_view<const Real*>();
+    const auto hybm_v = m_helper_fields["hybm"].get_view<const Real*>();
+    Kokkos::parallel_for(model_nlevs, KOKKOS_LAMBDA (const int ilev) {
+      model_pres_v(ilev) = 1000*hyam_v(ilev) + Ps()*hybm_v(ilev)/100;
+    });
+
+    // Find file pressure levels just outside the range of model pressure levels
+    Kokkos::parallel_reduce(file_levs+1, KOKKOS_LAMBDA (const int& ilev, int& lmax, int& lmin) {
+      if (iop_file_pres_v(ilev) <= model_pres_v(0) && ilev > lmax) {
+        lmax = ilev;
+      }
+      if (iop_file_pres_v(ilev) >= model_pres_v(model_nlevs-1) && ilev+1 < lmin) {
+        lmin = ilev+1;
+      }
+    },
+    Kokkos::Max<int>(iop_file_start),
+    Kokkos::Min<int>(iop_file_end));
+
+    // Find model pressure levels just inside range of file pressure levels
+    Kokkos::parallel_reduce(model_nlevs, KOKKOS_LAMBDA (const int& ilev, int& lmin, int& lmax) {
+      if (model_pres_v(ilev) >= iop_file_pres_v(iop_file_start) && ilev < lmin) {
+        lmin = ilev;
+      }
+      if (model_pres_v(ilev) <= iop_file_pres_v(iop_file_end-1) && ilev+1 > lmax) {
+        lmax = ilev+1;
+      }
+    },
+    Kokkos::Min<int>(model_start),
+    Kokkos::Max<int>(model_end));
+  }
+
+  // Loop through fields and store data from file
+  for (auto& it : m_iop_fields) {
+    auto fname = it.first;
+    auto field = it.second;
+
+    // File may use different varname than IOP class
+    auto file_varname = (m_iop_file_varnames.count(fname) > 0) ? m_iop_file_varnames[fname] : fname;
+
+    if (field.rank()==0) {
+      // For scalar data, read iop file variable directly into field data
+      Real* data = field.get_view<Real, Host>().data();
+      read_variable_from_file(iop_file, file_varname, "real", {"lon","lat"}, iop_file_time_idx, data);
+      field.sync_to_dev();
+    } else if (field.rank()==1) {
+      // Create temporary fields for reading iop file variables. We use
+      // adjusted_file_levels (computed above) which contains an unset
+      // value for surface.
+      FieldIdentifier fid(file_varname+"_iop_file",
+                          FieldLayout({FieldTag::LevelMidPoint},
+                          {adjusted_file_levs}),
+                          ekat::units::Units::nondimensional(),
+                          "");
+      Field iop_file_field(fid);
+      iop_file_field.allocate_view();
+
+      // Read data from iop file.
+      Real data[file_levs];
+      read_variable_from_file(iop_file, file_varname, "real", {"lon","lat","lev"}, iop_file_time_idx, data);
+
+      // Copy first adjusted_file_levs-1 values to field
+      auto iop_file_v_h = iop_file_field.get_view<Real*,Host>();
+      for (int ilev=0; ilev<adjusted_file_levs-1; ++ilev) iop_file_v_h(ilev) = data[ilev];
+
+      // Set or compute surface value
+      const auto has_srf = m_iop_field_surface_varnames.count(fname)>0;
+      if (has_srf) {
+        const auto srf_varname = m_iop_field_surface_varnames[fname];
+        Real srf_data;
+        read_variable_from_file(iop_file, srf_varname, "real", {"lon","lat"}, iop_file_time_idx, &srf_data);
+        iop_file_v_h(adjusted_file_levs-1) = srf_data;
+      } else {
+        // No surface value exists, compute surface value
+        const auto dx = iop_file_v_h(adjusted_file_levs-2) - iop_file_v_h(adjusted_file_levs-3);
+        if (dx == 0) iop_file_v_h(adjusted_file_levs-1) = iop_file_v_h(adjusted_file_levs-2);
+        else {
+          const auto iop_file_pres_v_h = iop_file_pressure.get_view<const Real*, Host>();
+          const auto dy = iop_file_pres_v_h(adjusted_file_levs-2) - iop_file_pres_v_h(adjusted_file_levs-3);
+          const auto scale = dy/dx;
+
+          iop_file_v_h(adjusted_file_levs-1) =
+            (iop_file_pres_v_h(adjusted_file_levs-1)-iop_file_pres_v_h(adjusted_file_levs-2))/scale
+            + iop_file_v_h(adjusted_file_levs-2);
+        }
+      }
+      iop_file_field.sync_to_dev();
+
+      // Vertically interpolate iop file data to iop fields.
+      // Note: ekat lininterp requires packs. Use 1d packs here.
+      // TODO: allow for nontrivial packsize.
+      const auto iop_file_pres_v = iop_file_pressure.get_view<const Pack1d*>();
+      const auto model_pres_v = model_pressure.get_view<const Pack1d*>();
+      const auto iop_file_v = iop_file_field.get_view<const Pack1d*>();
+      auto iop_field_v = field.get_view<Pack1d*>();
+
+      const auto nlevs_input = iop_file_end - iop_file_start;
+      const auto nlevs_output = model_end - model_start;
+      const auto total_nlevs = iop_field_v.extent_int(0);
+
+      ekat::LinInterp<Real,1> vert_interp(1, nlevs_input, nlevs_output);
+      Kokkos::parallel_for(Kokkos::TeamPolicy<KT::ExeSpace>(1, 1),
+                            KOKKOS_LAMBDA (const KT::MemberType& team) {
+        const auto x_src = Kokkos::subview(iop_file_pres_v, Kokkos::pair<int,int>(iop_file_start,iop_file_end));
+        const auto x_tgt = Kokkos::subview(model_pres_v, Kokkos::pair<int,int>(model_start,model_end));
+        const auto input = Kokkos::subview(iop_file_v, Kokkos::pair<int,int>(iop_file_start,iop_file_end));
+              auto output= Kokkos::subview(iop_field_v, Kokkos::pair<int,int>(model_start,model_end));
+
+        vert_interp.setup(team, x_src, x_tgt);
+        vert_interp.lin_interp(team, x_src, x_tgt, input, output);
+
+        // For certain fields we need to make sure to fill in the ends of
+        // the interpolated region with the value at model_start/model_end
+        if (fname == "T"    || fname == "q" || fname == "u" ||
+            fname == "u_ls" || fname == "v" || fname == "v_ls") {
+          if (model_start > 0) {
+            auto output_begin = Kokkos::subview(iop_field_v, Kokkos::pair<int,int>(0,model_start));
+            Kokkos::deep_copy(output_begin, output(model_start));
+          }
+          if (model_end < total_nlevs) {
+            auto output_end = Kokkos::subview(iop_field_v, Kokkos::pair<int,int>(model_end, total_nlevs));
+            Kokkos::deep_copy(output_end, output(model_end-1));
+          }
+        }
+      });
+    }
+  }
+
+  // Now that data is loaded, reset the index of the currently loaded data.
+  m_time_info.time_idx_of_current_data = iop_file_time_idx;
+}
+
+void IntensiveObservationPeriod::
+set_fields_from_iop_data(const field_mgr_ptr field_mgr)
+{
+  if (m_params.get<bool>("zero_non_iop_tracers") && field_mgr->has_group("tracers")) {
+    // Zero out all tracers before setting iop tracers (if requested)
+    field_mgr->get_field_group("tracers").m_bundle->deep_copy(0);
+  }
+
+  // If no iop file is given, return early
+  if (not m_params.isParameter("iop_file")) return;
+
+  EKAT_REQUIRE_MSG(field_mgr->get_grid()->name() == "Physics GLL",
+                   "Error! Attempting to set non-GLL fields using "
+                   "data from the IOP file.\n");
+
+  // Find which fields need to be written
+  const bool set_ps            = field_mgr->has_field("ps") && has_iop_field("Ps");
+  const bool set_T_mid         = field_mgr->has_field("T_mid") && has_iop_field("T");
+  const bool set_horiz_winds_u = field_mgr->has_field("horiz_winds") && has_iop_field("u");
+  const bool set_horiz_winds_v = field_mgr->has_field("horiz_winds") && has_iop_field("v");
+  const bool set_qv            = field_mgr->has_field("qv") && has_iop_field("q");
+  const bool set_nc            = field_mgr->has_field("nc") && has_iop_field("NUMLIQ");
+  const bool set_qc            = field_mgr->has_field("qc") && has_iop_field("CLDLIQ");
+  const bool set_qi            = field_mgr->has_field("qi") && has_iop_field("CLDICE");
+  const bool set_ni            = field_mgr->has_field("ni") && has_iop_field("NUMICE");
+
+  // Create views/scalars for these field's data
+  view_1d<Real> ps;
+  view_2d<Real> T_mid, qv, nc, qc, qi, ni;
+  view_3d<Real> horiz_winds;
+
+  Real ps_iop;
+  view_1d<Real> t_iop, u_iop, v_iop, qv_iop, nc_iop, qc_iop, qi_iop, ni_iop;
+
+  if (set_ps) {
+    ps = field_mgr->get_field("ps").get_view<Real*>();
+    ps_iop = get_iop_field("Ps").get_view<Real>()();
+  }
+  if (set_T_mid) {
+    T_mid = field_mgr->get_field("T_mid").get_view<Real**>();
+    t_iop = get_iop_field("T").get_view<Real*>();
+
+    // For temperature, we need to potentially correct the
+    // iop file data. We will use the first column from T_mid
+    // (all columns of T_mid should contain the same data).
+    const auto T_mid_0 = ekat::subview(T_mid, 0);
+    correct_temperature(T_mid_0);
+  }
+  if (set_horiz_winds_u || set_horiz_winds_v) {
+    horiz_winds = field_mgr->get_field("horiz_winds").get_view<Real***>();
+    if (set_horiz_winds_u) u_iop = get_iop_field("u").get_view<Real*>();
+    if (set_horiz_winds_v) v_iop = get_iop_field("v").get_view<Real*>();
+  }
+  if (set_qv) {
+    qv = field_mgr->get_field("qv").get_view<Real**>();
+    qv_iop = get_iop_field("q").get_view<Real*>();
+  }
+  if (set_nc) {
+    nc = field_mgr->get_field("nc").get_view<Real**>();
+    nc_iop = get_iop_field("NUMLIQ").get_view<Real*>();
+  }
+  if (set_qc) {
+    qc = field_mgr->get_field("qc").get_view<Real**>();
+    qc_iop = get_iop_field("CLDLIQ").get_view<Real*>();
+  }
+  if (set_qi) {
+    qi = field_mgr->get_field("qi").get_view<Real**>();
+    qi_iop = get_iop_field("CLDICE").get_view<Real*>();
+  }
+  if (set_ni) {
+    ni = field_mgr->get_field("ni").get_view<Real**>();
+    ni_iop = get_iop_field("NUMICE").get_view<Real*>();
+  }
+
+  // Loop over all columns and deep copy to FM views
+  const auto ncols = field_mgr->get_grid()->get_num_local_dofs();
+  Kokkos::parallel_for(Kokkos::RangePolicy<>(0, ncols), KOKKOS_LAMBDA(const int icol) {
+    if (set_ps) {
+      ps(icol) = ps_iop;
+    }
+    if (set_T_mid) {
+      auto T_mid_i = ekat::subview(T_mid, icol);
+      Kokkos::deep_copy(T_mid_i, t_iop);
+    }
+    if (set_horiz_winds_u) {
+      auto horiz_winds_u_i = ekat::subview(horiz_winds, icol, 0);
+      Kokkos::deep_copy(horiz_winds_u_i, u_iop);
+    }
+    if (set_horiz_winds_v) {
+      auto horiz_winds_v_i = ekat::subview(horiz_winds, icol, 1);
+      Kokkos::deep_copy(horiz_winds_v_i, v_iop);
+    }
+    if (set_qv) {
+      auto qv_i = ekat::subview(qv, icol);
+      Kokkos::deep_copy(qv_i, qv_iop);
+    }
+    if (set_nc) {
+      auto nc_i = ekat::subview(nc, icol);
+      Kokkos::deep_copy(nc_i, nc_iop);
+    }
+    if (set_qc) {
+      auto qc_i = ekat::subview(qc, icol);
+      Kokkos::deep_copy(qc_i, qc_iop);
+    }
+    if (set_qi) {
+      auto qi_i = ekat::subview(qi, icol);
+      Kokkos::deep_copy(qi_i, qi_iop);
+    }
+    if (set_ni) {
+      auto ni_i = ekat::subview(ni, icol);
+      Kokkos::deep_copy(ni_i, ni_iop);
+    }
+  });
+}
+
+void IntensiveObservationPeriod::
+correct_temperature(const view_1d<Real>& t_correction)
+{
+  EKAT_REQUIRE_MSG(has_iop_field("T"), "Error! Trying to correct IOP temperature, but no variable \"T\" exists.\n");
+
+  auto T_iop = get_iop_field("T").get_view<Real*>();
+  EKAT_REQUIRE_MSG(t_correction.extent(0) == T_iop.extent(0),
+                    "Error! t_correction has mismatched size with IOP field T. "
+                    +std::to_string(t_correction.extent(0))+" != "
+                    +std::to_string(T_iop.extent(0))+".\n");
+
+  // Find level index where T_iop is no longer 0
+  int ok_level;
+  Kokkos::parallel_reduce(T_iop.extent(0), KOKKOS_LAMBDA (const int ilev, int& lmin) {
+    if (T_iop(ilev) > 0 && ilev < lmin) lmin = ilev;
+  }, Kokkos::Min<int>(ok_level));
+
+  // Replace values of T
+  Kokkos::parallel_for(Kokkos::RangePolicy<>(0, ok_level), KOKKOS_LAMBDA (const int ilev) {
+    T_iop(ilev) = t_correction(ilev);
+  });
 }
 
 } // namespace control

--- a/components/eamxx/src/control/intensive_observation_period.hpp
+++ b/components/eamxx/src/control/intensive_observation_period.hpp
@@ -7,7 +7,9 @@
 #include "share/util/scream_time_stamp.hpp"
 
 #include "ekat/ekat_parameter_list.hpp"
+#include "ekat/ekat_pack.hpp"
 #include "ekat/mpi/ekat_comm.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 namespace scream {
 namespace control {
@@ -22,14 +24,40 @@ class IntensiveObservationPeriod
   using field_mgr_ptr = std::shared_ptr<FieldManager>;
   using grid_ptr = std::shared_ptr<const AbstractGrid>;
 
+  using KT = ekat::KokkosTypes<DefaultDevice>;
+  using ESU = ekat::ExeSpaceUtils<DefaultDevice>;
+
+  template<typename ScalarT>
+  using view_1d = KT::template view_1d<ScalarT>;
+  template<typename ScalarT>
+  using view_2d = KT::template view_2d<ScalarT>;
+  template<typename ScalarT>
+  using view_3d = KT::template view_3d<ScalarT>;
+  template<typename ScalarT>
+  using view_1d_host = typename view_1d<ScalarT>::HostMirror;
+  using Pack1d = ekat::Pack<Real, 1>;
+
 public:
 
   // Constructor
+  // Input:
+  //   - comm: MPI communicator
+  //   - params: Input yaml file needs intensive_observation_period_options sublist
+  //   - run_t0: Initial timestamp for the simulation
+  //   - model_nlevs: Number of vertical levels in the simulation. Needed since
+  //                  the iop file contains a (potentially) different number of levels
   IntensiveObservationPeriod(const ekat::Comm& comm,
-                             const ekat::ParameterList& params);
+                             const ekat::ParameterList& params,
+                             const util::TimeStamp& run_t0,
+                             const int model_nlevs,
+                             const Field& hyam,
+                             const Field& hybm);
 
   // Default destructor
   ~IntensiveObservationPeriod() = default;
+
+  // Read data from IOP file and store internally.
+  void read_iop_file_data(const util::TimeStamp& current_ts);
 
   // Setup io grids for reading data from file and determine the closest lat/lon
   // pair in a IC/topo file to the target lat/lon params for a specific grid. This
@@ -61,16 +89,37 @@ public:
 
   // Version of above, but where nc and eamxx field names are identical
   void read_fields_from_file_for_iop(const std::string& file_name,
-				     const vos& field_names,
-				     const util::TimeStamp& initial_ts,
-				     const field_mgr_ptr field_mgr)
+                                     const vos& field_names,
+                                     const util::TimeStamp& initial_ts,
+                                     const field_mgr_ptr field_mgr)
   {
     read_fields_from_file_for_iop(file_name, field_names, field_names, initial_ts, field_mgr);
   }
 
+  // Set fields using data loaded from the iop file
+  void set_fields_from_iop_data(const field_mgr_ptr field_mgr);
+
+  // Store grid spacing for use in SHOC ad interface
+  void set_grid_spacing (const Real dx_short) {
+    m_dynamics_dx_size = dx_short*1000;
+  }
+
+  Real get_dynamics_dx_size () { return m_dynamics_dx_size; }
+
+  ekat::ParameterList& get_params() { return m_params; }
+
+  bool has_iop_field(const std::string& fname) {
+    return m_iop_fields.count(fname) > 0;
+  }
+
+  Field get_iop_field(const std::string& fname) {
+    EKAT_REQUIRE_MSG(has_iop_field(fname), "Error! Requesting IOP field \""+fname+"\", but field is not stored in object.\n");
+    return m_iop_fields[fname];
+  }
+
 private:
 
-  // Helper struct for storing info related
+  // Struct for storing info related
   // to the closest lat,lon pair
   struct ClosestLatLonInfo {
     // Value for the closest lat/lon in file.
@@ -86,10 +135,66 @@ private:
     int local_column_index_of_closest_column;
   };
 
+  // Struct for storing relevant time information
+  struct TimeInfo {
+    util::TimeStamp iop_file_begin_time;
+    view_1d_host<int> iop_file_times_in_sec;
+
+    int time_idx_of_current_data = -1;
+
+    int get_iop_file_time_idx (const util::TimeStamp& current_ts)
+    {
+      // Get iop file time index that the given timestamp falls between.
+      // Note: the last time in iop file represents the non-inclusive
+      //       upper bound of acceptable model times.
+      const auto n_iop_times = iop_file_times_in_sec.extent(0);
+      int time_idx=-1;
+      for (size_t t=0; t<n_iop_times-1; ++t) {
+        if (iop_file_begin_time + iop_file_times_in_sec(t) <= current_ts &&
+            current_ts < iop_file_begin_time + iop_file_times_in_sec(t+1)) {
+          time_idx = t;
+        }
+      }
+
+      EKAT_REQUIRE_MSG(time_idx>=0,
+                       "Error! Current model time ("+current_ts.to_string()+") is not within "
+                       "IOP time period: ["+iop_file_begin_time.to_string()+", "+
+                       (iop_file_begin_time+iop_file_times_in_sec(n_iop_times-1)).to_string()+").\n");
+      return time_idx;
+    }
+  };
+
+  void initialize_iop_file(const util::TimeStamp& run_t0,
+                           int model_nlevs,
+                           const Field& hyam,
+                           const Field& hybm);
+
+  // The IOP file may contain values for T that are
+  // 0 at or above the surface. Correct these values
+  // by providing a "t_correction" view where we
+  // replace all values T_iop(k) == 0 with t_correction(k).
+  void correct_temperature(const view_1d<Real>& t_correction);
+
+  // Given vector of IC field names, and a field manager, (potentially) overwrite
+  // inputs with values from IOP data.
+  void set_ic_from_iop_data(const vos& field_names_eamxx,
+                            const field_mgr_ptr field_mgr);
+
   ekat::Comm m_comm;
   ekat::ParameterList m_params;
+
   std::map<std::string,ClosestLatLonInfo> m_lat_lon_info;
+  TimeInfo m_time_info;
+
+  Real m_dynamics_dx_size;
+
   std::map<std::string,grid_ptr> m_io_grids;
+
+  std::map<std::string, Field> m_iop_fields;
+  std::map<std::string, Field> m_helper_fields;
+
+  std::map<std::string, std::string> m_iop_file_varnames;
+  std::map<std::string, std::string> m_iop_field_surface_varnames;
 }; // class IntensiveObservationPeriod
 
 } // namespace control

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -467,6 +467,12 @@ void HommeDynamics::initialize_impl (const RunType run_type)
 
   // Initialize Rayleigh friction variables
   rayleigh_friction_init();
+
+  // If running with IOP, store grid length size
+  if (m_intensive_observation_period) {
+    const auto dx_short = get_dx_short_f90(0);
+    m_intensive_observation_period->set_grid_spacing(dx_short);
+  }
 }
 
 void HommeDynamics::run_impl (const double dt)

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
@@ -3,6 +3,7 @@
 
 #include "share/atm_process/atmosphere_process.hpp"
 #include "share/grid/remap/abstract_remapper.hpp"
+#include "control/intensive_observation_period.hpp"
 
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/ekat_pack.hpp"
@@ -89,6 +90,11 @@ protected:
   void rayleigh_friction_init ();
   void rayleigh_friction_apply (const Real dt) const;
 
+  // Set IOP object if necessary
+  void set_intensive_observational_period (const std::shared_ptr<control::IntensiveObservationPeriod>& iop) {
+    m_intensive_observation_period = iop;
+  }
+
 public:
   // Fast boolean function returning whether Physics PGN is being used.
   bool fv_phys_active() const;
@@ -151,6 +157,10 @@ protected:
                     // if set to 0, no rayleigh friction is applied
 
   int m_bfb_hash_nstep;
+
+  // IOP object
+  std::shared_ptr<control::IntensiveObservationPeriod> m_intensive_observation_period;
+
 };
 
 } // namespace scream

--- a/components/eamxx/src/dynamics/homme/interface/homme_grid_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_grid_mod.F90
@@ -227,4 +227,19 @@ contains
     nlev_out = nlev
   end function get_nlev_f90
 
+  function get_dx_short_f90 (elem_idx) result (dx_short_out) bind(c)
+    use homme_context_mod, only: elem
+    !
+    ! Input(s)
+    !
+    integer (kind=c_int), intent(in), value :: elem_idx
+    !
+    ! Local(s)
+    !
+    real (kind=c_double) :: dx_short_out
+
+    ! elem_idx is 0-based, convert to 1-based
+    dx_short_out = elem(elem_idx+1)%dx_short
+  end function get_dx_short_f90
+
 end module homme_grid_mod

--- a/components/eamxx/src/dynamics/homme/interface/scream_homme_interface.hpp
+++ b/components/eamxx/src/dynamics/homme/interface/scream_homme_interface.hpp
@@ -69,6 +69,7 @@ void get_phys_grid_data_f90 (const int& pg_type,
                              AbstractGrid::gid_type* const& gids,
                              double* const& lat, double* const& lon, double* const& area);
 int get_homme_nsplit_f90 (const int& atm_dt);
+double get_dx_short_f90 (const int elem_idx);
 
 // Parmaters getters/setters
 int get_homme_int_param_f90(const char** name);

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -451,6 +451,12 @@ void SHOCMacrophysics::run_impl (const double dt)
                        shoc_preprocess);
   Kokkos::fence();
 
+  if (m_intensive_observation_period) {
+    // For IOP case, we need to update cell length with correct
+    // spacing from planar grid.
+    Kokkos::deep_copy(shoc_preprocess.cell_length, m_intensive_observation_period->get_dynamics_dx_size());
+  }
+
   if (m_params.get<bool>("apply_tms", false)) {
     apply_turbulent_mountain_stress();
   }

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
@@ -62,6 +62,11 @@ public:
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
+  // Set IOP object if necessary
+  void set_intensive_observational_period (const std::shared_ptr<control::IntensiveObservationPeriod>& iop) {
+    m_intensive_observation_period = iop;
+  }
+
   /*--------------------------------------------------------------------------------------------*/
   // Most individual processes have a pre-processing step that constructs needed variables from
   // the set of fields stored in the field manager.  A structure like this defines those operations,
@@ -530,6 +535,8 @@ protected:
   ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr;
 
   std::shared_ptr<const AbstractGrid>   m_grid;
+
+  std::shared_ptr<control::IntensiveObservationPeriod> m_intensive_observation_period;
 }; // class SHOCMacrophysics
 
 } // namespace scream

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -1,6 +1,8 @@
 #ifndef SCREAM_ATMOSPHERE_PROCESS_HPP
 #define SCREAM_ATMOSPHERE_PROCESS_HPP
 
+#include "control/intensive_observation_period.hpp"
+
 #include "share/atm_process/atmosphere_process_utils.hpp"
 #include "share/atm_process/ATMBufferManager.hpp"
 #include "share/atm_process/SCDataManager.hpp"
@@ -98,6 +100,12 @@ public:
   // Upon return, the atm proc should have a valid and complete list
   // of in/out/inout FieldRequest and GroupRequest.
   virtual void set_grids (const std::shared_ptr<const GridsManager> grids_manager) = 0;
+
+  // If a process requires the IOP object, they can define this function for setting it
+  virtual void set_intensive_observational_period (const std::shared_ptr<control::IntensiveObservationPeriod>& iop) {
+    EKAT_ERROR_MSG("Error! "+name()+" is attempting to set an IntensiveObservationPeriod, "
+                   "but was not expecting one.\n");
+  }
 
   // These are the three main interfaces:
   //   - the initialize method sets up all the stuff the process needs in order to run,

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/CMakeLists.txt
@@ -19,7 +19,7 @@ CreateUnitTest(homme_shoc_cld_spa_p3_rrtmgp_dp "homme_shoc_cld_spa_p3_rrtmgp_dp.
 # Set AD configurable options
 set (ATM_TIME_STEP 50)
 SetVarDependingOnTestSize(NUM_STEPS 2 4 48)  # 1h 2h 24h
-set (RUN_T0 2021-10-12-45000)
+set (RUN_T0 1999-07-10-00000)
 
 # Determine num subcycles needed to keep shoc dt<=300s
 set (SHOC_MAX_DT 300)
@@ -75,6 +75,7 @@ set (TEST_INPUT_FILES
   scream/init/spa_file_unified_and_complete_ne4_20220428.nc
   scream/init/${EAMxx_tests_IC_FILE_128lev}
   cam/topo/${EAMxx_tests_TOPO_FILE}
+  cam/scam/iop/DYCOMSrf01_iopfile_4scam.nc
 )
 foreach (file IN ITEMS ${TEST_INPUT_FILES})
   GetInputFile(${file})

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/homme_shoc_cld_spa_p3_rrtmgp_dp.cpp
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/homme_shoc_cld_spa_p3_rrtmgp_dp.cpp
@@ -10,7 +10,12 @@
 #include "physics/register_physics.hpp"
 #include "diagnostics/register_diagnostics.hpp"
 
+// Surface coupling includes
+#include "control/register_surface_coupling.hpp"
+#include "control/atmosphere_surface_coupling_importer.hpp"
+
 // EKAT headers
+#include "ekat/kokkos/ekat_kokkos_types.hpp"
 
 TEST_CASE("scream_homme_physics", "scream_homme_physics") {
   using namespace scream;
@@ -36,6 +41,7 @@ TEST_CASE("scream_homme_physics", "scream_homme_physics") {
   register_dynamics();
   register_physics();
   register_diagnostics();
+  register_surface_coupling();
 
   // Create the driver
   AtmosphereDriver ad;
@@ -44,7 +50,42 @@ TEST_CASE("scream_homme_physics", "scream_homme_physics") {
   // NOTE: Kokkos is finalize in ekat_catch_main.cpp, and YAKL is finalized
   //       during RRTMGPRatiation::finalize_impl, after RRTMGP has deallocated
   //       all its arrays.
-  ad.initialize(atm_comm,ad_params,t0);
+  ad.set_comm(atm_comm);
+  ad.set_params(ad_params);
+  ad.init_scorpio ();
+  ad.init_time_stamps (t0, t0);
+  ad.create_atm_processes ();
+  ad.create_grids ();
+  ad.setup_intensive_observation_period ();
+  ad.create_fields ();
+
+  // Setup surface coupler import to be NaNs for fields IOP should overwrite
+  const int ncols = ad.get_grids_manager()->get_grid("Physics")->get_num_local_dofs();
+  static constexpr int num_imports = 4;
+  char import_names[num_imports][32];
+  std::strcpy(import_names[0], "surf_radiative_T");
+  std::strcpy(import_names[1], "surf_lw_flux_up");
+  std::strcpy(import_names[2], "surf_sens_flux");
+  std::strcpy(import_names[3], "surf_evap");
+  KokkosTypes<HostDevice>::view_2d<Real> import_data("import_data",ncols, num_imports);
+  Kokkos::deep_copy(import_data, std::nan(""));
+  KokkosTypes<HostDevice>::view_1d<int> import_cpl_indices("import_cpl_indices", num_imports);
+  std::iota(import_cpl_indices.data(), import_cpl_indices.data()+num_imports, 0);
+  KokkosTypes<HostDevice>::view_1d<int> import_vec_comps("import_vec_comps", num_imports);
+  Kokkos::deep_copy(import_vec_comps, -1);
+  KokkosTypes<HostDevice>::view_1d<Real> import_constant_multiple("import_constant_multiple", num_imports);
+  Kokkos::deep_copy(import_constant_multiple, 1);
+  KokkosTypes<HostDevice>::view_1d<bool> do_import_during_init("do_import_during_init", num_imports);
+  Kokkos::deep_copy(do_import_during_init, false);
+  do_import_during_init(2) = true; do_import_during_init(3) = true;
+
+  ad.setup_surface_coupling_data_manager(SurfaceCouplingTransferType::Import,
+                                         4, 4, ncols, import_data.data(), import_names[0], import_cpl_indices.data(),
+                                         import_vec_comps.data(), import_constant_multiple.data(), do_import_during_init.data());
+
+  ad.initialize_fields ();
+  ad.initialize_output_managers ();
+  ad.initialize_atm_procs ();
 
   if (atm_comm.am_i_root()) {
     printf("Start time stepping loop...       [  0%%]\n");

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
@@ -6,6 +6,7 @@ driver_options:
 
 intensive_observation_period_options:
   doubly_periodic_mode: true
+  iop_file: ${IOP_DATA_DIR}/DYCOMSrf01_iopfile_4scam.nc
   target_latitude: 31.5
   target_longitude: 238.5
 
@@ -23,7 +24,7 @@ initial_conditions:
   precip_ice_surf_mass: 0.0
 
 atmosphere_processes:
-  atm_procs_list: [homme,physics]
+  atm_procs_list: [sc_import,homme,physics]
   schedule_type: Sequential
   homme:
     Moisture: moist


### PR DESCRIPTION
This PR adds the ability for IOP runs to read data from an IOP file.

Basics of PR:
- Load and process data from iop file and store as iop fields
- Set iop data in appropriate GLL fields directly after ICs are processed
- Link IOP class and surface coupling importer for setting appropriate imports from IOP file
- Add importer to unit test
- Link IOP and HommeAD for setting correct grid spacing for planar
- Link IOP class and SHOC for setting the correct `input.dx`, `input.dy` variables for planar grid.

Testing: I compared ICs from an EAM DP case using the same IOP file as this test to the ICs in the unit test which are set as IOP file data, and verified that they match. Computation as a whole obviously not identical since the ICs themselves are not identical, and AD is not BFB, but I am confident that I am initializing the iop file data correctly in the FM. 