### PR TITLE
Remove compute-sanitizer --tool=synccheck from AT

### DIFF
--- a/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
@@ -121,7 +121,7 @@ if [ $skip_testing -eq 0 ]; then
       fi
 
       if [[ "$SCREAM_MACHINE" == "weaver" ]]; then
-        ./scripts/gather-all-data "./scripts/test-all-scream -t csm -t csr -t csi -t css ${TAS_ARGS}" -l -m $SCREAM_MACHINE
+        ./scripts/gather-all-data "./scripts/test-all-scream -t csm -t csr -t csi ${TAS_ARGS}" -l -m $SCREAM_MACHINE
         if [[ $? != 0 ]]; then
           fails=$fails+1;
           memcheck_fail=1


### PR DESCRIPTION
The `synccheck` tool tests the use of CUDA synchronization primitives `__syncwarp()` and `__syncthreads()`, which we do not use directly in EAMxx code. Kokkos' CUDA back end obviously makes extensive use of these, but in the AT we are pretty much exclusively getting false and/or non-reproducible fails with this specific `compute-sanitizer` test. So I propose removing from the AT. This PR would leave it as a test def in `test_all_scream` so we could easily add back or run manually (`-t css`) if we wanted to.

Thoughts? Objections?