### PR TITLE
Update MLcorrection unit test

### DIFF
--- a/components/eamxx/tests/uncoupled/ml_correction/input.yaml
+++ b/components/eamxx/tests/uncoupled/ml_correction/input.yaml
@@ -13,6 +13,7 @@ atmosphere_processes:
   MLCorrection:
     ML_model_path_tq: NONE
     ML_model_path_uv: NONE
+    ML_model_path_sfc_fluxes: NONE
     ML_output_fields: ["qv","T_mid"]
     ML_correction_unit_test: True
 grids_manager:


### PR DESCRIPTION
`ML_model_path_sfc_fluxes` was missing from the unit test input yaml causing the test to fail. This PR fixed that.