### PR TITLE
Fix 2 bugs in how IO (output) handles AVG pressure sliced vars

### DIFF
--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -846,7 +846,7 @@ void AtmosphereOutput::register_views()
   reset_dev_views();
 }
 /* ---------------------------------------------------------- */
-void AtmosphereOutput::set_avg_cnt_tracking(const std::string& name, const std::string& name_ext, const FieldLayout& layout)
+void AtmosphereOutput::set_avg_cnt_tracking(const std::string& name, const std::string& avg_cnt_suffix, const FieldLayout& layout)
 {
     // Make sure this field "name" hasn't already been regsitered with avg_cnt tracking.
     // Note, we check this because some diagnostics need to have their own tracking which
@@ -860,7 +860,7 @@ void AtmosphereOutput::set_avg_cnt_tracking(const std::string& name, const std::
     const auto tags = layout.tags();
     auto lt = get_layout_type(tags);
     if (m_add_time_dim && m_track_avg_cnt) {
-      std::string avg_cnt_name = "avg_count_" + e2str(lt) + "_" + name_ext;
+      std::string avg_cnt_name = "avg_count" + avg_cnt_suffix;
       for (int ii=0; ii<layout.rank(); ++ii) {
         auto tag_name = m_io_grid->get_dim_name(layout.tag(ii));
         avg_cnt_name += "_" + tag_name;
@@ -1283,7 +1283,7 @@ AtmosphereOutput::create_diagnostic (const std::string& diag_field_name) {
         diag_name = "FieldAtHeight";
       } else if (units=="mb" or units=="Pa" or units=="hPa") {
         diag_name = "FieldAtPressureLevel";
-	diag_avg_cnt_name = tokens[1]; // Set avg_cnt tracking for this specific slice
+	diag_avg_cnt_name = "_" + tokens[1]; // Set avg_cnt tracking for this specific slice
         m_track_avg_cnt = true; // If we have pressure slices we need to be tracking the average count.
       } else {
         EKAT_ERROR_MSG ("Error! Invalid units x for 'field_at_Nx' diagnostic.\n");

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -175,7 +175,7 @@ protected:
   create_diagnostic (const std::string& diag_name);
 
   // Tracking the averaging of any filled values:
-  void set_avg_cnt_tracking(const std::string& name, const std::string& name_ext, const FieldLayout& layout);
+  void set_avg_cnt_tracking(const std::string& name, const std::string& avg_cnt_suffix, const FieldLayout& layout);
 
   // --- Internal variables --- //
   ekat::Comm                          m_comm;


### PR DESCRIPTION
    Fix two bugs in IO regarding average tracking and sliced output.
    
    This commit fixes two bugs in how we handle average snap tracking
    in cases where sliced output is one of the fields.
    
      1. We were not automatically tracking the number of filled values
         in cases where fields where output on a set pressure level.
         This would result in some columns being the average of the Fill
         Value and real values.
    
      2. When tracking the fill values we were using a single tracking
         field for all outputs on the same layout.  This would result
         in sliced outputs causing other 2D fields (ncol) to also be
         masked, even when they shouldn't have been.  The most direct
         example would be surface pressure.
    