### PR TITLE
Utility for applying random perturbation to IC

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1303,17 +1303,17 @@ void AtmosphereDriver::set_initial_conditions ()
     // for which the perturbation value will be randomly generated from.
     const auto perturbation_limit = ic_pl.get<Real>("perturbation_limits", 0.001);
 
-    // Define a level mask using reference pressure and the pressure_lower_bound parameter.
+    // Define a level mask using reference pressure and the perturbation_minimum_pressure parameter.
     // This mask dictates which levels we apply a perturbation.
     const auto gll_grid = m_grids_manager->get_grid("Physics GLL");
     gll_grid->get_geometry_data("hyam").sync_to_host(), gll_grid->get_geometry_data("hybm").sync_to_host();
     const auto hyam = gll_grid->get_geometry_data("hyam").get_view<const Real*, Host>();
     const auto hybm = gll_grid->get_geometry_data("hybm").get_view<const Real*, Host>();
     constexpr auto ps0 = physics::Constants<Real>::P0;
-    const auto pressure_lower_bound = ic_pl.get<Real>("perturbation_pressure_lower_bound", 1050.0);
+    const auto min_pressure = ic_pl.get<Real>("perturbation_minimum_pressure", 1050.0);
     auto pressure_mask = [&] (const int ilev) {
       const auto pref = (hyam(ilev)*ps0 + hybm(ilev)*ps0)/100; // Reference pressure ps0 is in Pa, convert to millibar
-      return pref > pressure_lower_bound;
+      return pref > min_pressure;
     };
 
     // Loop through fields and apply perturbation.

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1324,13 +1324,12 @@ void AtmosphereDriver::set_initial_conditions ()
     // Define a level mask using reference pressure and the perturbation_minimum_pressure parameter.
     // This mask dictates which levels we apply a perturbation.
     const auto gll_grid = m_grids_manager->get_grid("Physics GLL");
-    gll_grid->get_geometry_data("hyam").sync_to_host(), gll_grid->get_geometry_data("hybm").sync_to_host();
-    const auto hyam = gll_grid->get_geometry_data("hyam").get_view<const Real*, Host>();
-    const auto hybm = gll_grid->get_geometry_data("hybm").get_view<const Real*, Host>();
+    const auto hyam_h = gll_grid->get_geometry_data("hyam").get_view<const Real*, Host>();
+    const auto hybm_h = gll_grid->get_geometry_data("hybm").get_view<const Real*, Host>();
     constexpr auto ps0 = physics::Constants<Real>::P0;
     const auto min_pressure = ic_pl.get<Real>("perturbation_minimum_pressure", 1050.0);
     auto pressure_mask = [&] (const int ilev) {
-      const auto pref = (hyam(ilev)*ps0 + hybm(ilev)*ps0)/100; // Reference pressure ps0 is in Pa, convert to millibar
+      const auto pref = (hyam_h(ilev)*ps0 + hybm_h(ilev)*ps0)/100; // Reference pressure ps0 is in Pa, convert to millibar
       return pref > min_pressure;
     };
 

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -2,6 +2,8 @@
 #include "control/atmosphere_surface_coupling_importer.hpp"
 #include "control/atmosphere_surface_coupling_exporter.hpp"
 
+#include "physics/share/physics_constants.hpp"
+
 #include "share/atm_process/atmosphere_process_group.hpp"
 #include "share/atm_process/atmosphere_process_dag.hpp"
 #include "share/field/field_utils.hpp"
@@ -29,6 +31,7 @@
 #endif
 
 #include <fstream>
+#include <random>
 
 namespace scream {
 
@@ -1001,7 +1004,6 @@ void AtmosphereDriver::set_initial_conditions ()
       if (ic_pl.isType<double>(fname) or ic_pl.isType<std::vector<double>>(fname)) {
         // Initial condition is a constant
         initialize_constant_field(fid, ic_pl);
-        fields_inited[grid_name].push_back(fname);
 
         // Note: f is const, so we can't modify the tracking. So get the same field from the fm
         auto f_nonconst = m_field_mgrs.at(grid_name)->get_field(fid.name());
@@ -1009,11 +1011,11 @@ void AtmosphereDriver::set_initial_conditions ()
       } else if (ic_pl.isType<std::string>(fname)) {
         // Initial condition is a string
         ic_fields_to_copy.push_back(fid);
-        fields_inited[grid_name].push_back(fname);
       } else {
         EKAT_ERROR_MSG ("ERROR: invalid assignment for variable " + fname + ", only scalar "
                         "double or string, or vector double arguments are allowed");
       }
+      fields_inited[grid_name].push_back(fname);
     } else if (fname == "phis" or fname == "sgh30") {
       // Both phis and sgh30 need to be loaded from the topography file
       auto& this_grid_topo_file_fnames = topography_file_fields_names[grid_name];
@@ -1032,6 +1034,7 @@ void AtmosphereDriver::set_initial_conditions ()
           EKAT_ERROR_MSG ("Error! Requesting phis on an unknown grid: " + grid_name + ".\n");
         }
         this_grid_topo_eamxx_fnames.push_back(fname);
+	fields_inited[grid_name].push_back(fname);
       } else if (fname == "sgh30") {
         // The eamxx field "sgh30" is called "SGH30" in the
         // topography file and is only available on the PG2 grid.
@@ -1040,6 +1043,7 @@ void AtmosphereDriver::set_initial_conditions ()
                         " topo file only has sgh30 for Physics PG2.\n");
         topography_file_fields_names[grid_name].push_back("SGH30");
         topography_eamxx_fields_names[grid_name].push_back(fname);
+	fields_inited[grid_name].push_back(fname);
       }
     } else if (not (fvphyshack and grid_name == "Physics PG2")) {
       // The IC file is written for the GLL grid, so we only load
@@ -1051,6 +1055,7 @@ void AtmosphereDriver::set_initial_conditions ()
         // If this field is the parent of other subfields, we only read from file the subfields.
         if (not ekat::contains(this_grid_ic_fnames,fname)) {
           this_grid_ic_fnames.push_back(fname);
+	  fields_inited[grid_name].push_back(fname);
         }
       } else if (fvphyshack and grid_name == "Physics GLL") {
         // [CGLL ICs in pg2] I tried doing something like this in
@@ -1064,10 +1069,10 @@ void AtmosphereDriver::set_initial_conditions ()
           const auto& fname = fid.name();
           if (ic_pl.isParameter(fname) and ic_pl.isType<double>(fname)) {
             initialize_constant_field(fid, ic_pl);
-            fields_inited[grid_name].push_back(fname);
           } else {
             this_grid_ic_fnames.push_back(fname);
           }
+	  fields_inited[grid_name].push_back(fname);
         }
       }
     }
@@ -1274,6 +1279,56 @@ void AtmosphereDriver::set_initial_conditions ()
       const auto& fm = m_field_mgrs.at("Physics GLL");
       m_intensive_observation_period->set_fields_from_iop_data(fm);
     }
+  }
+
+  // Compute IC perturbations of GLL fields (if requested)
+  using vos = std::vector<std::string>;
+  const auto perturbed_fields = ic_pl.get<vos>("perturbed_fields", {});
+  const auto num_perturb_fields = perturbed_fields.size();
+  if (num_perturb_fields > 0) {
+    m_atm_logger->info("    [EAMxx] Adding random perturbation to ICs ...");
+
+    EKAT_REQUIRE_MSG(m_field_mgrs.count("Physics GLL") > 0,
+                     "Error! Random perturbation can only be applied to fields on "
+                     "the GLL grid, but no Physics GLL FieldManager was defined.\n");
+    const auto& fm = m_field_mgrs.at("Physics GLL");
+
+    // Setup RNG. If no random seed is requested in
+    // initial_conditions params, generate one using rand().
+    const auto seed = ic_pl.get<int>("perturbation_random_seed", rand());
+    std::mt19937_64 engine(seed);
+    m_atm_logger->info("      For IC perturbation, random seed: "+std::to_string(seed));
+
+    // Get perterbation limit. Defines a range [-perturbation_limit, perturbation_limit]
+    // for which the perturbation value will be randomly generated from.
+    const auto perturbation_limit = ic_pl.get<Real>("perturbation_limits", 0.001);
+
+    // Define a level mask using reference pressure and the pressure_lower_bound parameter.
+    // This mask dictates which levels we apply a perturbation.
+    const auto gll_grid = m_grids_manager->get_grid("Physics GLL");
+    gll_grid->get_geometry_data("hyam").sync_to_host(), gll_grid->get_geometry_data("hybm").sync_to_host();
+    const auto hyam = gll_grid->get_geometry_data("hyam").get_view<const Real*, Host>();
+    const auto hybm = gll_grid->get_geometry_data("hybm").get_view<const Real*, Host>();
+    constexpr auto ps0 = physics::Constants<Real>::P0;
+    const auto pressure_lower_bound = ic_pl.get<Real>("perturbation_pressure_lower_bound", 1050.0);
+    auto pressure_mask = [&] (const int ilev) {
+      const auto pref = (hyam(ilev)*ps0 + hybm(ilev)*ps0)/100; // Reference pressure ps0 is in Pa, convert to milibar
+      return pref > pressure_lower_bound;
+    };
+
+    // Loop through fields and apply perturbation.
+    for (size_t f=0; f<perturbed_fields.size(); ++f) {
+      const auto fname = perturbed_fields[f];
+      EKAT_REQUIRE_MSG(ekat::contains(fields_inited[fm->get_grid()->name()], fname),
+                       "Error! Attempting to apply perturbation to field not in initial_conditions.\n"
+                       "  - Field: "+fname+"\n"
+                       "  - Grid:  "+fm->get_grid()->name()+"\n");
+
+      auto field = fm->get_field(fname);
+      std::uniform_real_distribution<Real> pdf(-1.0*perturbation_limit, perturbation_limit);
+      perturb(field, engine, pdf, pressure_mask);
+    }
+    m_atm_logger->info("    [EAMxx] Adding random perturbation to ICs ... done!");
   }
 
   m_atm_logger->info("  [EAMxx] set_initial_conditions ... done!");

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1299,7 +1299,7 @@ void AtmosphereDriver::set_initial_conditions ()
     std::mt19937_64 engine(seed);
     m_atm_logger->info("      For IC perturbation, random seed: "+std::to_string(seed));
 
-    // Get perterbation limit. Defines a range [-perturbation_limit, perturbation_limit]
+    // Get perturbation limit. Defines a range [-perturbation_limit, perturbation_limit]
     // for which the perturbation value will be randomly generated from.
     const auto perturbation_limit = ic_pl.get<Real>("perturbation_limits", 0.001);
 
@@ -1312,7 +1312,7 @@ void AtmosphereDriver::set_initial_conditions ()
     constexpr auto ps0 = physics::Constants<Real>::P0;
     const auto pressure_lower_bound = ic_pl.get<Real>("perturbation_pressure_lower_bound", 1050.0);
     auto pressure_mask = [&] (const int ilev) {
-      const auto pref = (hyam(ilev)*ps0 + hybm(ilev)*ps0)/100; // Reference pressure ps0 is in Pa, convert to milibar
+      const auto pref = (hyam(ilev)*ps0 + hybm(ilev)*ps0)/100; // Reference pressure ps0 is in Pa, convert to millibar
       return pref > pressure_lower_bound;
     };
 

--- a/components/eamxx/src/control/intensive_observation_period.cpp
+++ b/components/eamxx/src/control/intensive_observation_period.cpp
@@ -133,7 +133,6 @@ IntensiveObservationPeriod(const ekat::Comm& comm,
   if (not m_params.isParameter("iop_nudge_tq_low"))     m_params.set<Real>("iop_nudge_tq_low",     1050);
   if (not m_params.isParameter("iop_nudge_tq_high"))    m_params.set<Real>("iop_nudge_tq_high",    0);
   if (not m_params.isParameter("iop_nudge_tscale"))     m_params.set<Real>("iop_nudge_tscale",     10800);
-  if (not m_params.isParameter("iop_perturb_high"))     m_params.set<Real>("iop_perturb_high",     1050);
   if (not m_params.isParameter("zero_non_iop_tracers")) m_params.set<bool>("zero_non_iop_tracers", false);
 
   // Use IOP file to initialize parameters

--- a/components/eamxx/src/control/intensive_observation_period.cpp
+++ b/components/eamxx/src/control/intensive_observation_period.cpp
@@ -289,7 +289,7 @@ initialize_iop_file(const util::TimeStamp& run_t0,
   iop_file_pressure.allocate_view();
   auto data = iop_file_pressure.get_view<Real*, Host>().data();
   read_variable_from_file(iop_file, "lev", "real", {"lev"}, -1, data);
-  // Convert to pressure to milibar (file gives pressure in Pa)
+  // Convert to pressure to millibar (file gives pressure in Pa)
   for (int ilev=0; ilev<file_levs; ++ilev) data[ilev] /= 100;
   iop_file_pressure.sync_to_dev();
   m_helper_fields.insert({"iop_file_pressure", iop_file_pressure});
@@ -565,7 +565,7 @@ read_iop_file_data (const util::TimeStamp& current_ts)
 
     EKAT_REQUIRE_MSG(adjusted_file_levs > 1,
                      "Error! Pressures in iop file "+iop_file+" is are inccorrectly set. "
-                     "Surface pressure \"Ps\" (converted to milibar) should be greater "
+                     "Surface pressure \"Ps\" (converted to millibar) should be greater "
                      "than at least the 1st entry in midpoint pressures \"lev\".\n");
 
     // Compute model pressure levels

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -126,7 +126,7 @@ public:
 
   // Like the method above, but only for rank-1 fields, returning a view with LayoutStride.
   // This is safer to use for fields that could be a subfield of another one, since a
-  // rank-1 view that is the subview of a 2d one along the 2nd index cannot have 
+  // rank-1 view that is the subview of a 2d one along the 2nd index cannot have
   // LayoutRight, and must have LayoutStride instead.
   template<typename DT, HostOrDevice HD = Device>
   get_strided_view_type<DT,HD>
@@ -175,12 +175,12 @@ public:
   // view.data ptr.
   template<typename ST, HostOrDevice HD = Device>
   ST* get_internal_view_data_unsafe () const {
-    // Check that the scalar type is correct                                                                                                   
+    // Check that the scalar type is correct
     using nonconst_ST = typename std::remove_const<ST>::type;
     EKAT_REQUIRE_MSG ((field_valid_data_types().at<nonconst_ST>()==m_header->get_identifier().data_type()
                        or std::is_same<nonconst_ST,char>::value),
           "Error! Attempt to access raw field pointere with the wrong scalar type.\n");
-    
+
     return reinterpret_cast<ST*>(get_view_impl<HD>().data());
   }
 
@@ -211,6 +211,10 @@ public:
   // Special case of update with alpha=0
   template<HostOrDevice HD = Device, typename ST = void>
   void scale (const ST beta);
+
+  // Scale a field y as y=y*x where x is also a field
+  template<HostOrDevice HD = Device>
+  void scale (const Field& x);
 
   // Returns a subview of this field, slicing at entry k along dimension idim
   // NOTES:

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -43,13 +43,26 @@ void randomize (const Field& f, Engine& engine, PDF&& pdf)
   impl::randomize<ST>(f,engine,pdf);
 }
 
-// Compute a random perturbation of a field for all view entries
-// field_view(:, k) when level_mask(k)==true. The field
-// must have level midpoint tag as last dimension, and level mask
-// should have size of last field dimension.
+// Compute a random perturbation of a field for all view entries whose
+// level index satisfies the mask.
+// Input:
+//   - f:                  Field to perturbed. Required to have level midpoint
+//                         tag as last dimension.
+//   - engine:             Random number engine.
+//   - pdf:                Random number distribution where a random value (say,
+//                         pertval) is taken s.t.
+//                           field_view(i0,...,iN) *= (1 + pertval)
+//   - base_seed:          Seed used for creating the engine input.
+//   - level_mask:         Mask (size of the level dimension of f) where f(i0,...,k) is
+//                         perturbed if level_mask(k)=true
+//   - dof_gids:           Field containing global DoF IDs for columns of f (if applicable)
 template<typename Engine, typename PDF, typename MaskType>
-void perturb (const Field& f, Engine& engine, PDF&& pdf,
-	      const MaskType& level_mask)
+void perturb (const Field& f,
+              Engine& engine,
+              PDF&& pdf,
+              const int base_seed,
+              const MaskType& level_mask,
+              const Field& dof_gids = Field())
 {
   EKAT_REQUIRE_MSG(f.is_allocated(),
        	           "Error! Cannot perturb the values of a field not yet allocated.\n");
@@ -59,23 +72,38 @@ void perturb (const Field& f, Engine& engine, PDF&& pdf,
 
   // Check compatibility between PDF and field data type
   const auto data_type = f.data_type();
-  EKAT_REQUIRE_MSG ((std::is_same_v<ST,int> && data_type==DataType::IntType) or
-		    (std::is_same_v<ST,float> && data_type==DataType::FloatType) or
-		    (std::is_same_v<ST,double> && data_type==DataType::DoubleType),
-		    "Error! Field data type incompatible with input PDF.\n");
+  EKAT_REQUIRE_MSG((std::is_same_v<ST,int> && data_type==DataType::IntType) or
+                   (std::is_same_v<ST,float> && data_type==DataType::FloatType) or
+                   (std::is_same_v<ST,double> && data_type==DataType::DoubleType),
+                   "Error! Field data type incompatible with input PDF.\n");
 
   using namespace ShortFieldTagsNames;
   const auto& fl = f.get_header().get_identifier().get_layout();
+
   // Field we are perturbing should have a level midpoint dimension,
   // and it is required to be the last dimension
   EKAT_REQUIRE_MSG(fl.has_tag(LEV),
-		   "Error! Trying to perturb field \""+f.name()+"\", but field "
-		   "has no level dimension.\n");
+                   "Error! Trying to perturb field \""+f.name()+"\", but field "
+                   "has no LEV dimension.\n");
   EKAT_REQUIRE_MSG(fl.tags().back() == LEV,
                    "Error! Trying to perturb field \""+f.name()+"\", but field "
-	           "does not have level as last dimension.\n");
+	                 "does not have LEV as last dimension.\n");
 
-  impl::perturb<ST>(f, engine, pdf, level_mask);
+  if (fl.has_tag(COL)) {
+    // If field has a column dimension, it should be the first dimension
+    EKAT_REQUIRE_MSG(fl.tag(0) == COL,
+                     "Error! Trying to perturb field \""+f.name()+"\", but field "
+	                   "does not have COL as first dimension.\n");
+
+    const auto& dof_gids_fl = dof_gids.get_header().get_identifier().get_layout();
+    EKAT_REQUIRE_MSG(dof_gids_fl.dim(0) == fl.dim(COL),
+                     "Error! Field of DoF GIDs should have the same size as "
+                     "perturbed field's column dimension.\n");
+    EKAT_REQUIRE_MSG(dof_gids.data_type() == DataType::IntType,
+                     "Error! DoF GIDs field must have \"int\" as data type.\n");
+  }
+
+  impl::perturb<ST>(f, engine, pdf, base_seed, level_mask, dof_gids);
 }
 
 template<typename ST>

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -80,25 +80,30 @@ void perturb (const Field& f,
   using namespace ShortFieldTagsNames;
   const auto& fl = f.get_header().get_identifier().get_layout();
 
-  // Field we are perturbing should have a level midpoint dimension,
+  // Field we are perturbing should have a level dimension,
   // and it is required to be the last dimension
-  EKAT_REQUIRE_MSG(fl.has_tag(LEV),
+  EKAT_REQUIRE_MSG(fl.rank()>0 &&
+                   (fl.tags().back() == LEV || fl.tags().back() == ILEV),
                    "Error! Trying to perturb field \""+f.name()+"\", but field "
-                   "has no LEV dimension.\n");
-  EKAT_REQUIRE_MSG(fl.tags().back() == LEV,
-                   "Error! Trying to perturb field \""+f.name()+"\", but field "
-	                 "does not have LEV as last dimension.\n");
+	                 "does not have LEV or ILEV as last dimension.\n"
+                   "  - field name: " + f.name() + "\n"
+                   "  - field layout: " + to_string(fl) + "\n");
 
   if (fl.has_tag(COL)) {
     // If field has a column dimension, it should be the first dimension
     EKAT_REQUIRE_MSG(fl.tag(0) == COL,
                      "Error! Trying to perturb field \""+f.name()+"\", but field "
-	                   "does not have COL as first dimension.\n");
+	                   "does not have COL as first dimension.\n"
+                     "  - field name: " + f.name() + "\n"
+                     "  - field layout: " + to_string(fl) + "\n");
 
     const auto& dof_gids_fl = dof_gids.get_header().get_identifier().get_layout();
     EKAT_REQUIRE_MSG(dof_gids_fl.dim(0) == fl.dim(COL),
                      "Error! Field of DoF GIDs should have the same size as "
-                     "perturbed field's column dimension.\n");
+                     "perturbed field's column dimension.\n"
+                     "  - dof_gids dim: " + std::to_string(dof_gids_fl.dim(0)) + "\n"
+                     "  - field name: " + f.name() + "\n"
+                     "  - field layout: " + to_string(fl) + "\n");
     EKAT_REQUIRE_MSG(dof_gids.data_type() == DataType::IntType,
                      "Error! DoF GIDs field must have \"int\" as data type.\n");
   }

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -233,7 +233,6 @@ void perturb (const Field& f,
     // RNG seed to be the same on every column so that a column will
     // have the same value no matter where it exists in an MPI rank's
     // set of local columns.
-    dof_gids.sync_to_host();
     const auto gids = dof_gids.get_view<const int*, Host>();
 
     // Create a field to store perturbation values with layout

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -250,7 +250,6 @@ void perturb (const Field& f,
 
       // Loop through levels. For each that satisfy the level_mask,
       // apply a random perturbation to f.
-      //auto f_col = f.subfield(0, icol);
       for (auto ilev=0; ilev<fl.dims().back(); ++ilev) {
         if (level_mask(ilev)) {
           randomize(perturb_f, engine, pdf);

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -831,6 +831,17 @@ TEST_CASE ("update") {
     f3.update(f_real,2,0);
     REQUIRE (views_are_equal(f3,f2));
   }
+
+  SECTION ("scale") {
+    Field f1 = f_real.clone();
+    Field f2 = f_real.clone();
+
+    // x=2, x*y = 2*y
+    f1.deep_copy(2.0);
+    f1.scale(f2);
+    f2.scale(2.0);
+    REQUIRE (views_are_equal(f1, f2));
+  }
 }
 
 

--- a/components/eamxx/src/share/tests/field_utils.cpp
+++ b/components/eamxx/src/share/tests/field_utils.cpp
@@ -184,12 +184,21 @@ TEST_CASE("utils") {
     const int nlevs = IPDF(3,9)(engine); // between 3-9 levels
 
     // Create 1d, 2d, 3d fields with a level dimension, and set all to 1
-    FieldIdentifier fid1("f_1d", FieldLayout({LEV}, {nlevs}), Units::nondimensional(), "dummy_grid");
-    FieldIdentifier fid2("f_2d", FieldLayout({COL, LEV}, {ncols, nlevs}), Units::nondimensional(), "dummy_grid");
-    FieldIdentifier fid3("f_3d", FieldLayout({COL, CMP, LEV}, {ncols, ncmps, nlevs}), Units::nondimensional(), "dummy_grid");
-    Field f1(fid1), f2(fid2), f3(fid3);
-    f1.allocate_view(), f2.allocate_view(), f3.allocate_view();
-    f1.deep_copy(1), f2.deep_copy(1), f3.deep_copy(1);
+    FieldIdentifier fid1 ("f_1d",   FieldLayout({LEV},           {nlevs}),               Units::nondimensional(), "");
+    FieldIdentifier fid2a("f_2d_a", FieldLayout({CMP, LEV},      {ncmps, nlevs}),        Units::nondimensional(), "");
+    FieldIdentifier fid2b("f_2d_b", FieldLayout({COL, LEV},      {ncols, nlevs}),        Units::nondimensional(), "");
+    FieldIdentifier fid3 ("f_3d",   FieldLayout({COL, CMP, LEV}, {ncols, ncmps, nlevs}), Units::nondimensional(), "");
+    Field f1(fid1), f2a(fid2a), f2b(fid2b), f3(fid3);
+    f1.allocate_view(), f2a.allocate_view(), f2b.allocate_view(), f3.allocate_view();
+    f1.deep_copy(1), f2a.deep_copy(1), f2b.deep_copy(1), f3.deep_copy(1);
+
+    // We need GIDs for fields with COL component. This test is not over
+    // multiple ranks, so just set as [0, ncols-1].
+    Field gids(FieldIdentifier("gids", FieldLayout({COL}, {ncols}), Units::nondimensional(), "", DataType::IntType));
+    gids.allocate_view();
+    auto gids_data = gids.get_internal_view_data<int,Host>();
+    std::iota(gids_data, gids_data+ncols, 0);
+    gids.sync_to_dev();
 
     // Create masks s.t. only last 3 levels are perturbed. For variety,
     // 1d and 2d fields will use lambda mask and 3 field will use a view.
@@ -202,17 +211,22 @@ TEST_CASE("utils") {
       if (ilev >= nlevs-3) mask_view(ilev) = true;
     }
 
-    // Compute random perturbation between [1, 2]
-    RPDF perturb_pdf(1, 2);
-    perturb(f1, engine, perturb_pdf, mask_lambda);
-    perturb(f2, engine, perturb_pdf, mask_lambda);
-    perturb(f3, engine, perturb_pdf, mask_view);
+    // Compute random perturbation between [2, 3]
+    RPDF pdf(2, 3);
+    int base_seed = 0;
+    perturb(f1,  engine, pdf, base_seed, mask_lambda);
+    perturb(f2a, engine, pdf, base_seed, mask_lambda);
+    perturb(f2b, engine, pdf, base_seed, mask_lambda, gids);
+    perturb(f3,  engine, pdf, base_seed, mask_view,   gids);
+
+    // Sync to host for checks
+    f1.sync_to_host(), f2a.sync_to_host(), f2b.sync_to_host(), f3.sync_to_host();
+    const auto v1  = f1.get_view <Real*,   Host>();
+    const auto v2a = f2a.get_view<Real**,  Host>();
+    const auto v2b = f2b.get_view<Real**,  Host>();
+    const auto v3  = f3.get_view <Real***, Host>();
 
     // Check that all field values are 1 for all but last 3 levels and between [2,3] otherwise.
-    const auto v1 = f1.get_view<Real*, Host>();
-    const auto v2 = f2.get_view<Real**, Host>();
-    const auto v3 = f3.get_view<Real***, Host>();
-
     auto check_level = [&] (const int ilev, const Real val) {
       if (ilev < nlevs-3) REQUIRE(val == 1);
       else REQUIRE((2 <= val && val <= 3));
@@ -221,9 +235,39 @@ TEST_CASE("utils") {
       for (int icmp=0; icmp<ncmps; ++icmp) {
         for (int ilev=0; ilev<nlevs; ++ilev) {
           if (icol==0 && icmp==0) check_level(ilev, v1(ilev));
-          if (icmp==0) check_level(ilev, v2(icol,ilev));
+          if (icol==0) check_level(ilev, v2a(icmp,ilev));
+          if (icmp==0) check_level(ilev, v2b(icol,ilev));
           check_level(ilev, v3(icol,icmp,ilev));
     }}}
+
+    // Check that using a different seed gives different values
+    auto f1_alt = f1.clone(); f1_alt.deep_copy(1.0);
+    auto f3_alt = f3.clone(); f3_alt.deep_copy(1.0);
+    int base_seed_alt = 100;
+    perturb(f1_alt, engine, pdf, base_seed_alt, mask_lambda);
+    perturb(f3_alt, engine, pdf, base_seed_alt, mask_lambda, gids);
+    f1_alt.sync_to_host(), f3_alt.sync_to_host();
+
+    const auto v1_alt = f1_alt.get_view<Real*,   Host>();
+    const auto v3_alt = f3_alt.get_view<Real***, Host>();
+
+    auto check_diff = [&] (const int ilev, const Real val1, const Real val2) {
+      if (ilev < nlevs-3) REQUIRE(val1==val2);
+      else                REQUIRE(val1!=val2);
+    };
+    for (int icol=0; icol<ncols; ++icol) {
+      for (int icmp=0; icmp<ncmps; ++icmp) {
+        for (int ilev=0; ilev<nlevs; ++ilev) {
+          if (icol==0 && icmp==0) check_diff(ilev, v1(ilev), v1_alt(ilev));
+          check_diff(ilev, v3(icol,icmp,ilev), v3_alt(icol,icmp,ilev));
+    }}}
+
+    // Finally check that the original seed gives same result
+    f1_alt.deep_copy(1.0), f3_alt.deep_copy(1.0);
+    perturb(f1_alt, engine, pdf, base_seed, mask_lambda);
+    perturb(f3_alt, engine, pdf, base_seed, mask_lambda, gids);
+    REQUIRE(views_are_equal(f1, f1_alt));
+    REQUIRE(views_are_equal(f3, f3_alt));
   }
 
   SECTION ("wrong_st") {

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
@@ -25,7 +25,6 @@ initial_conditions:
   perturbed_fields: [T_mid]
   perturbation_limit: 0.001
   perturbation_minimum_pressure: 900.0 # in millibar
-  perturbation_random_seed: 1805289383
 
 atmosphere_processes:
   atm_procs_list: [sc_import,homme,physics]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
@@ -24,7 +24,7 @@ initial_conditions:
   precip_ice_surf_mass: 0.0
   perturbed_fields: [T_mid]
   perturbation_limit: 0.001
-  perturbation_pressure_lower_bound: 900.0 # in millibar
+  perturbation_minimum_pressure: 900.0 # in millibar
   perturbation_random_seed: 1805289383
 
 atmosphere_processes:

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
@@ -22,6 +22,10 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0
+  perturbed_fields: [T_mid]
+  perturbation_limit: 0.001
+  perturbation_pressure_lower_bound: 900.0 # in milibar
+  perturbation_random_seed: 1805289383
 
 atmosphere_processes:
   atm_procs_list: [sc_import,homme,physics]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
@@ -24,7 +24,7 @@ initial_conditions:
   precip_ice_surf_mass: 0.0
   perturbed_fields: [T_mid]
   perturbation_limit: 0.001
-  perturbation_pressure_lower_bound: 900.0 # in milibar
+  perturbation_pressure_lower_bound: 900.0 # in millibar
   perturbation_random_seed: 1805289383
 
 atmosphere_processes:


### PR DESCRIPTION
Creates a `perturb()` in `field_utils.cpp` which applies a random perturbation
```
field_view(i0,...,k) *= (1+pertval) when level_mask(k)=true
```
The value `pertval` is randomly selected from a user defined RNG.

Uses in AD: Directly after ICs are loaded, perturb fields (if requested). Introduces some new parameters under `initial_conditions`:
  - `perturbed_fields`: set of fields to be perturbed
  - `perturbation_limit`: defines range [-perturbed_limit, perturbed_limit] for RNG
  - `perturbation_pressure_lower_bound`: lower bound s.t. perturbed field at k if `ref_pres(k)>perturbation_pressure_lower_bound`
  - `perturbation_random_seed`: seed for RNG, allows us to recreate runs


We need this for DP-SCREAM, where we perturb `T_mid`