### PR TITLE
Overhaul of the initial conditions (Initial run type)

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -421,38 +421,90 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <restart_casename>${CASE}.scream</restart_casename>
     <!-- Fields that we need to initialize, but are not in an initial condition file need to be inited here -->
-    <surf_evap>0.0</surf_evap> <!-- TODO, Delete this when the IC fixes come in -->
-    <precip_liq_surf_mass>0.0</precip_liq_surf_mass>
-    <precip_ice_surf_mass>0.0</precip_ice_surf_mass>
-    <cldfrac_liq       >0.0</cldfrac_liq>
-    <sgs_buoy_flux     >0.0</sgs_buoy_flux>
-    <eddy_diff_mom     >0.0</eddy_diff_mom>
-    <T_prev_micro_step >0.0</T_prev_micro_step>
-    <qv_prev_micro_step>0.0</qv_prev_micro_step>
-    <!-- Initialize microphysics fields not on IC to zero; note that this is consistent with EAM init -->
-    <qr                >0.0</qr>
-    <nr                >0.0</nr>
-    <qm                >0.0</qm>
-    <bm                >0.0</bm>
-    <ni_activated      >0.0</ni_activated>
-    <nc_nuceat_tend    >0.0</nc_nuceat_tend>
-    <!-- SHOC internally inits TKE; just set to 0 here to signal it's not in the IC file -->
-    <tke               >0.0</tke>
-    <!-- Note: these should be provided by surface models, but we init here to keep AD from reading from file -->
-    <sfc_alb_dir_vis   >0.0</sfc_alb_dir_vis>
-    <sfc_alb_dir_nir   >0.0</sfc_alb_dir_nir>
-    <sfc_alb_dif_vis   >0.0</sfc_alb_dif_vis>
-    <sfc_alb_dif_nir   >0.0</sfc_alb_dif_nir>
-    <surf_sens_flux    >0.0</surf_sens_flux>
-    <surf_lw_flux_up   >0.0</surf_lw_flux_up>
-    <surf_mom_flux     type="array(real)">0.0,0.0</surf_mom_flux>
-    <!-- default ne1024 initial condition files do not have these, so init to zero here -->
+    <!-- NOTE: SHOC internally inits TKE; just set to 0 here to signal it's not in the IC file -->
+    <!-- NOTE: sfc_alb_XYZ and surf_XYZ should be provided by surface models, but we init here to keep AD from reading from file -->
+    <constant_fields
+      type="array(string)"
+      doc="List of fields to be inited to constant value. The syntax for each field is 'field_name=field_value'"
+    >
+      surf_evap            = 0.0,
+      precip_liq_surf_mass = 0.0,
+      precip_ice_surf_mass = 0.0,
+      cldfrac_liq          = 0.0,
+      sgs_buoy_flux        = 0.0,
+      eddy_diff_mom        = 0.0,
+      T_prev_micro_step    = 0.0,
+      qv_prev_micro_step   = 0.0,
+      qr                   = 0.0,
+      nr                   = 0.0,
+      qm                   = 0.0,
+      bm                   = 0.0,
+      ni_activated         = 0.0,
+      nc_nuceat_tend       = 0.0,
+      tke                  = 0.0,
+      sfc_alb_dir_vis      = 0.0,
+      sfc_alb_dir_nir      = 0.0,
+      sfc_alb_dif_vis      = 0.0,
+      sfc_alb_dif_nir      = 0.0,
+      surf_sens_flux       = 0.0,
+      surf_lw_flux_up      = 0.0,
+      surf_mom_flux        = 0.0
+    </constant_fields>
+    <!-- NOTE: default ne1024 initial condition files do not have qc,qi,nc,ni, so init to zero here -->
     <!-- TODO: delete this once we can tell the AD that some fields can be inited by procs -->
-    <qc hgrid="ne256np4|ne1024np4">0.0</qc>
-    <qi hgrid="ne256np4|ne1024np4">0.0</qi>
-    <nc hgrid="ne256np4|ne1024np4">0.0</nc>
-    <ni hgrid="ne256np4|ne1024np4">0.0</ni>
-    <o3_volume_mix_ratio hgrid="ne0np4_conus_x4v1_lowcon">0.0</o3_volume_mix_ratio>
+    <constant_fields hgrid="ne256np4|ne1024np4">
+      surf_evap            = 0.0,
+      precip_liq_surf_mass = 0.0,
+      precip_ice_surf_mass = 0.0,
+      cldfrac_liq          = 0.0,
+      sgs_buoy_flux        = 0.0,
+      eddy_diff_mom        = 0.0,
+      T_prev_micro_step    = 0.0,
+      qv_prev_micro_step   = 0.0,
+      qr                   = 0.0,
+      nr                   = 0.0,
+      qm                   = 0.0,
+      bm                   = 0.0,
+      ni_activated         = 0.0,
+      nc_nuceat_tend       = 0.0,
+      tke                  = 0.0,
+      sfc_alb_dir_vis      = 0.0,
+      sfc_alb_dir_nir      = 0.0,
+      sfc_alb_dif_vis      = 0.0,
+      sfc_alb_dif_nir      = 0.0,
+      surf_sens_flux       = 0.0,
+      surf_lw_flux_up      = 0.0,
+      surf_mom_flux        = 0.0,
+      qc                   = 0.0,
+      qi                   = 0.0,
+      nc                   = 0.0,
+      ni                   = 0.0
+    </constant_fields>
+    <constant_fields hgrid="ne0np4_conus_x4v1_lowcon">
+      surf_evap            = 0.0,
+      precip_liq_surf_mass = 0.0,
+      precip_ice_surf_mass = 0.0,
+      cldfrac_liq          = 0.0,
+      sgs_buoy_flux        = 0.0,
+      eddy_diff_mom        = 0.0,
+      T_prev_micro_step    = 0.0,
+      qv_prev_micro_step   = 0.0,
+      qr                   = 0.0,
+      nr                   = 0.0,
+      qm                   = 0.0,
+      bm                   = 0.0,
+      ni_activated         = 0.0,
+      nc_nuceat_tend       = 0.0,
+      tke                  = 0.0,
+      sfc_alb_dir_vis      = 0.0,
+      sfc_alb_dir_nir      = 0.0,
+      sfc_alb_dif_vis      = 0.0,
+      sfc_alb_dif_nir      = 0.0,
+      surf_sens_flux       = 0.0,
+      surf_lw_flux_up      = 0.0,
+      surf_mom_flux        = 0.0,
+      o3_volume_mix_ratio  = 0.0
+    </constant_fields>
   </initial_conditions>
 
   <!-- List of yaml files containing I/O output specs -->

--- a/components/eamxx/src/control/CMakeLists.txt
+++ b/components/eamxx/src/control/CMakeLists.txt
@@ -2,15 +2,9 @@ set(SCREAM_CONTROL_SOURCES
   atmosphere_driver.cpp
   atmosphere_surface_coupling_importer.cpp
   atmosphere_surface_coupling_exporter.cpp
+  eamxx_default_model_init.cpp
   intensive_observation_period.cpp
   surface_coupling_utils.cpp
-)
-
-set(SCREAM_CONTROL_HEADERS
-  atmosphere_driver.hpp
-  atmosphere_surface_coupling.hpp
-  intensive_observation_period.hpp
-  surface_coupling_utils.hpp
 )
 
 add_library(scream_control ${SCREAM_CONTROL_SOURCES})

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -622,6 +622,9 @@ void AtmosphereDriver::create_fields()
     m_atm_process_group->set_required_field(fm->get_field(fid).get_const());
   }
 
+  // Tell all atm procs that we are done setting fields from the FieldManager's
+  m_atm_process_group->all_fields_set();
+
   // Now that all processes have all the required/computed fields/groups, they
   // have also created any possible internal field (if needed). Notice that some
   // atm proc might have created internal fields already during the set_grids

--- a/components/eamxx/src/control/eamxx_default_model_init.cpp
+++ b/components/eamxx/src/control/eamxx_default_model_init.cpp
@@ -1,4 +1,5 @@
 #include "eamxx_default_model_init.hpp"
+#include "intensive_observation_period.hpp"
 
 #include "share/io/scorpio_input.hpp"
 
@@ -42,10 +43,26 @@ read_ic_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
   }
   auto grid = m_gm->get_grid("Physics");
 
-  AtmosphereInput ic_reader (filename,grid,ic_fields);
-  ic_reader.set_logger(logger);
-  ic_reader.read_variables();
-  ic_reader.finalize();
+  auto iop = m_params.get<std::shared_ptr<control::IntensiveObservationPeriod>>("iop");
+
+  if (iop==nullptr) {
+    AtmosphereInput ic_reader (filename,grid,ic_fields);
+    ic_reader.set_logger(logger);
+    ic_reader.read_variables();
+    ic_reader.finalize();
+  } else {
+    // Setup io grid
+    iop->setup_io_info(filename,grid);
+
+    // Copy data to the closest lat/lon col in the io data to every other col
+    iop->read_fields_from_file_for_iop (filename,
+                                          ic_fields,
+                                          m_run_t0);
+
+    // Overwrite IC data with data from iop file
+    iop->read_iop_file_data(m_run_t0);
+    iop->set_fields_from_iop_data(m_eamxx_inputs);
+  }
 
   // Update time stamp of ic fields
   for (auto& f : ic_fields) {
@@ -62,13 +79,6 @@ read_topo_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
   const auto& filename = m_params.get<std::string>("topography_filename");
   logger->info("    [EAMxx] Reading topography file ...");
   logger->info("        filename: " + filename);
-
-  auto phys_grid = m_gm->get_grid("Physics");
-  auto ic_grid   = phys_grid->clone("Physics",true);
-  ic_grid->reset_field_tag_name(COL,"ncol_d");
-  for (auto n : phys_grid->aliases()) {
-    ic_grid->add_alias(n);
-  }
 
   // Store topo fields as std::vector. Alias name, to match what's in the file
   std::vector<Field> fields;
@@ -87,12 +97,26 @@ read_topo_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
     }
   }
 
-  // Load fields
-  const auto& filename = m_params.get<std::string>("topography_filename");
-  AtmosphereInput ic_reader (filename,ic_grid,fields);
-  ic_reader.set_logger(logger);
-  ic_reader.read_variables();
-  ic_reader.finalize();
+  auto phys_grid = m_gm->get_grid("Physics");
+  auto iop = m_params.get<std::shared_ptr<control::IntensiveObservationPeriod>>("iop");
+  if (iop==nullptr) {
+    // The topo file stores colum dim as ncol for PG2 and ncol_d for GLL.
+    // So create a shallow clone of the gll grid, with different name for COL tag
+    auto io_grid   = phys_grid->clone("Physics",true);
+    io_grid->reset_field_tag_name(COL,"ncol_d");
+    for (auto n : phys_grid->aliases()) {
+      io_grid->add_alias(n);
+    }
+
+    // Load fields
+    AtmosphereInput ic_reader (filename,io_grid,fields);
+    ic_reader.set_logger(logger);
+    ic_reader.read_variables();
+    ic_reader.finalize();
+  } else {
+    iop->setup_io_info(filename,phys_grid);
+    iop->read_fields_from_file_for_iop (filename,fields,m_run_t0);
+  }
 
   // Update time stamp of ic fields
   for (auto& f : fields) {

--- a/components/eamxx/src/control/eamxx_default_model_init.cpp
+++ b/components/eamxx/src/control/eamxx_default_model_init.cpp
@@ -19,6 +19,12 @@ DefaultModelInit (const strmap_t<Field>& eamxx_inputs,
 void DefaultModelInit::
 set_initial_conditions (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
 {
+  // For the tracers, we read in individual fields, rather than the field 'tracers'
+  // NOTE: this is an ad-hoc fix for the tracers. PG2 requires to get the tracers
+  //       group when setting the IC, so we had to add it to the eamxx inputs.
+  //       But non-PG2 runs do not need this (and, in fact, won't find it in the file)
+  m_eamxx_inputs.erase("tracers");
+
   set_constant_fields (logger);
   if (m_params.isParameter("Filename") and m_ic_fields.size()>0) {
     read_ic_file (logger);

--- a/components/eamxx/src/control/eamxx_default_model_init.cpp
+++ b/components/eamxx/src/control/eamxx_default_model_init.cpp
@@ -1,0 +1,104 @@
+#include "eamxx_default_model_init.hpp"
+
+#include "share/io/scorpio_input.hpp"
+
+namespace scream
+{
+
+DefaultModelInit::
+DefaultModelInit (const strmap_t<Field>& eamxx_inputs,
+                  const std::shared_ptr<const GridsManager>& gm,
+                  const ekat::ParameterList& ic_pl,
+                  const util::TimeStamp& run_t0)
+ : ModelInit (eamxx_inputs,gm,ic_pl,run_t0)
+{
+  // Nothing to do here
+}
+
+void DefaultModelInit::
+set_initial_conditions (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
+{
+  set_constant_fields (logger);
+  if (m_params.isParameter("Filename") and m_ic_fields.size()>0) {
+    read_ic_file (logger);
+  }
+  if (m_params.isParameter("topography_filename") and m_topo_fields.size()>0) {
+    read_topo_file (logger);
+  }
+}
+
+void DefaultModelInit::
+read_ic_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
+{
+  const auto& filename = m_params.get<std::string>("Filename");
+
+  logger->info("    [EAMxx] Reading initial conditions file ...");
+  logger->info("        filename: " + filename);
+
+  // Use convert std::set to a std::vector
+  std::vector<Field> ic_fields;
+  for (const auto& f : m_ic_fields) {
+    ic_fields.push_back(f);
+  }
+  auto grid = m_gm->get_grid("Physics");
+
+  AtmosphereInput ic_reader (filename,grid,ic_fields);
+  ic_reader.set_logger(logger);
+  ic_reader.read_variables();
+  ic_reader.finalize();
+
+  // Update time stamp of ic fields
+  for (auto& f : ic_fields) {
+    f.get_header().get_tracking().update_time_stamp(m_run_t0);
+  }
+
+  logger->info("    [EAMxx] Reading initial conditions file ... done!");
+}
+
+void DefaultModelInit::
+read_topo_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
+{
+  using namespace ShortFieldTagsNames;
+  const auto& filename = m_params.get<std::string>("topography_filename");
+  logger->info("    [EAMxx] Reading topography file ...");
+  logger->info("        filename: " + filename);
+
+  auto phys_grid = m_gm->get_grid("Physics");
+  auto ic_grid   = phys_grid->clone("Physics",true);
+  ic_grid->reset_field_tag_name(COL,"ncol_d");
+  for (auto n : phys_grid->aliases()) {
+    ic_grid->add_alias(n);
+  }
+
+  // Store topo fields as std::vector. Alias name, to match what's in the file
+  std::vector<Field> fields;
+  for (const auto& f : m_topo_fields) {
+    if (f.name()=="phis") {
+      fields.push_back(f.alias("PHIS_d"));
+    } else if (f.name()=="sgh30") {
+      EKAT_ERROR_MSG(
+        "[DefaultModelInit] Error! Requesting sgh30 field from topo file.\n"
+        "  The DefaultModelInit class does not handle Physics PG2 grid,\n"
+        "  but sgh30 should only be needed for Physics PG2 grid.\n");
+    } else {
+      EKAT_ERROR_MSG(
+        "[DefaultModelInit] Error! Unexpected/unrecognized topo field name.\n"
+        " - field name: " + f.name() + "\n");
+    }
+  }
+
+  // Load fields
+  const auto& filename = m_params.get<std::string>("topography_filename");
+  AtmosphereInput ic_reader (filename,ic_grid,fields);
+  ic_reader.set_logger(logger);
+  ic_reader.read_variables();
+  ic_reader.finalize();
+
+  // Update time stamp of ic fields
+  for (auto& f : fields) {
+    f.get_header().get_tracking().update_time_stamp(m_run_t0);
+  }
+  logger->info("    [EAMxx] Reading topography file ... done!");
+}
+
+} // namespace scream

--- a/components/eamxx/src/control/eamxx_default_model_init.hpp
+++ b/components/eamxx/src/control/eamxx_default_model_init.hpp
@@ -1,0 +1,44 @@
+#ifndef EAMXX_DEFAULT_MODEL_INIT_HPP
+#define EAMXX_DEFAULT_MODEL_INIT_HPP
+
+#include "share/eamxx_model_init.hpp"
+
+namespace scream
+{
+
+// Concrete implementation of ModelInit where we simply read in
+// the eamxx input fields from input file, using the 'Physics'
+// grid from the grids manager.
+class DefaultModelInit : public ModelInit {
+public:
+
+  DefaultModelInit (const strmap_t<Field>& eamxx_inputs,
+                    const std::shared_ptr<const GridsManager>& gm,
+                    const ekat::ParameterList& ic_pl,
+                    const util::TimeStamp& run_t0);
+
+  ~DefaultModelInit () = default;
+
+  void set_initial_conditions (const std::shared_ptr<ekat::logger::LoggerBase>& logger);
+
+protected:
+  void read_ic_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger) override;
+  void read_topo_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger) override;
+};
+
+inline std::shared_ptr<ModelInit>
+create_default_model_init (const std::map<std::string,Field>& eamxx_inputs,
+                           const std::shared_ptr<const GridsManager>& gm,
+                           const ekat::ParameterList& params,
+                           const util::TimeStamp& run_t0)
+{
+  return std::make_shared<DefaultModelInit>(eamxx_inputs,gm,params,run_t0);
+}
+
+inline void register_default_model_init () {
+  ModelInitFactory::instance().register_product("default",&create_default_model_init);
+}
+
+} // namespace scream
+
+#endif // EAMXX_DEFAULT_MODEL_INIT_HPP

--- a/components/eamxx/src/control/intensive_observation_period.hpp
+++ b/components/eamxx/src/control/intensive_observation_period.hpp
@@ -76,28 +76,14 @@ public:
   // this function can be called.
   // Input:
   //  - file_name: Name of the file used to load field data (IC or topo file)
-  //  - field_names_nc: Field names used by the input file
-  //  - field_names_eamxx: Field names used by eamxx
+  //  - fields: fields to read in
   //  - initial_ts: Inital timestamp
-  // Input/output
-  //  - field_mgr: Field manager containing fields that need data read from files
   void read_fields_from_file_for_iop(const std::string& file_name,
-                                     const vos& field_names_nc,
-                                     const vos& field_names_eamxx,
-                                     const util::TimeStamp& initial_ts,
-                                     const field_mgr_ptr field_mgr);
-
-  // Version of above, but where nc and eamxx field names are identical
-  void read_fields_from_file_for_iop(const std::string& file_name,
-                                     const vos& field_names,
-                                     const util::TimeStamp& initial_ts,
-                                     const field_mgr_ptr field_mgr)
-  {
-    read_fields_from_file_for_iop(file_name, field_names, field_names, initial_ts, field_mgr);
-  }
+                                     const std::vector<Field>& fields,
+                                     const util::TimeStamp& initial_ts);
 
   // Set fields using data loaded from the iop file
-  void set_fields_from_iop_data(const field_mgr_ptr field_mgr);
+  void set_fields_from_iop_data(std::map<std::string,Field>& eamxx_inputs);
 
   // The IOP file may contain temperature values that are
   // 0 at or above the surface. Correct these values using
@@ -108,7 +94,7 @@ public:
   // Note: We only need to use the first column because during
   //       the loading of ICs, every columns will have the same
   //       data.
-  void correct_temperature_and_water_vapor(const field_mgr_ptr field_mgr);
+  void correct_temperature_and_water_vapor(const Field& T_mid, const Field& qv);
 
   // Store grid spacing for use in SHOC ad interface
   void set_grid_spacing (const Real dx_short) {

--- a/components/eamxx/src/control/tests/ad_tests.yaml
+++ b/components/eamxx/src/control/tests/ad_tests.yaml
@@ -5,9 +5,10 @@ driver_options:
 
 initial_conditions:
   Filename: should_not_be_neeeded_and_code_will_throw_if_it_tries_to_open_this_nonexistent_file.nc
-  A: 1.0
-  V: [2.0, 3.0]
-  Z: "A"
+  constant_fields:
+    - A = 1
+    - V = (2,3)
+    - Z = 1.0
 
 atmosphere_processes:
   atm_procs_list: [dummy1, dummy2, dummy3]
@@ -16,20 +17,20 @@ atmosphere_processes:
   dummy1:
     Type: Dummy
     Sub Name: A to Group
-    Grid Name: Point Grid
+    Grid Name: Physics
   dummy2:
     Type: Dummy
     Sub Name: Group to Group
-    Grid Name: Point Grid
+    Grid Name: Physics
   dummy3:
     Type: Dummy
     Sub Name: Group to A
-    Grid Name: Point Grid
+    Grid Name: Physics
 
 grids_manager:
   Type: Mesh Free
-  grids_names: ["Point Grid"]
-  Point Grid:
+  grids_names: ["Physics"]
+  Physics:
     type: point_grid
     number_of_global_columns: 24
     number_of_vertical_levels: 3

--- a/components/eamxx/src/dynamics/homme/CMakeLists.txt
+++ b/components/eamxx/src/dynamics/homme/CMakeLists.txt
@@ -144,8 +144,10 @@ macro (CreateDynamicsLib HOMME_TARGET NP PLEV QSIZE)
 
     set (SCREAM_DYNAMICS_SOURCES
       ${SCREAM_DYNAMICS_SRC_DIR}/eamxx_homme_process_interface.cpp
-      ${SCREAM_DYNAMICS_SRC_DIR}/eamxx_homme_fv_phys.cpp
+      ${SCREAM_DYNAMICS_SRC_DIR}/eamxx_homme_fv_phys_helper.cpp
+      ${SCREAM_DYNAMICS_SRC_DIR}/eamxx_homme_fv_phys_active_gases.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/eamxx_homme_rayleigh_friction.cpp
+      ${SCREAM_DYNAMICS_SRC_DIR}/eamxx_fvphys_model_init.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/physics_dynamics_remapper.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/homme_grids_manager.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/interface/homme_context_mod.F90

--- a/components/eamxx/src/dynamics/homme/eamxx_fvphys_model_init.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_fvphys_model_init.cpp
@@ -1,0 +1,233 @@
+#include "eamxx_fvphys_model_init.hpp"
+
+#include "eamxx_homme_fv_phys_helper.hpp"
+#include "physics_dynamics_remapper.hpp"
+#include "share/io/scorpio_input.hpp"
+
+// Homme includes
+#include "Context.hpp"
+#include "Tracers.hpp"
+#include "ElementsState.hpp"
+
+namespace scream
+{
+
+FvPhysModelInit::
+FvPhysModelInit (const strmap_t<Field>& eamxx_inputs,
+                 const std::shared_ptr<const GridsManager>& gm,
+                 const ekat::ParameterList& ic_pl,
+                 const util::TimeStamp& run_t0)
+ : ModelInit (eamxx_inputs,gm,ic_pl,run_t0)
+{
+  // FvPhys requires certain fields to be present
+  for (const std::string& n : {"T_mid","horiz_winds","ps","phis","pseudo_density","tracers"}) {
+    EKAT_REQUIRE_MSG (m_eamxx_inputs.count(n)==1,
+        "Error! Using FvPhysModelInit but '" + n + "' is not a model input.\n");
+  }
+}
+
+void FvPhysModelInit::
+set_initial_conditions (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
+{
+  set_constant_fields (logger);
+  if (m_params.isParameter("Filename") and m_ic_fields.size()>0) {
+    read_ic_file (logger);
+  }
+  if (m_params.isParameter("topography_filename") and m_topo_fields.size()>0) {
+    read_topo_file (logger);
+  }
+
+  remap_fields ();
+}
+
+void FvPhysModelInit::
+read_ic_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
+{
+  const auto& filename = m_params.get<std::string>("Filename");
+
+  logger->info("    [EAMxx] Reading initial conditions file ...");
+  logger->info("        filename: " + filename);
+
+  using namespace ShortFieldTagsNames;
+
+  std::vector<Field> nc_fields;
+  const auto cgll_grid = HommeFvPhysHelper::instance().m_cgll_grid;
+  std::cout << "fvphys, reading with grid " << cgll_grid->name() << "\n";
+  for (const auto& f : m_ic_fields) {
+
+    const auto& fid = f.get_header().get_identifier();
+    const auto& layout = fid.get_layout();
+    const auto lt = get_layout_type(layout.tags());
+          auto gll_layout = FieldLayout::invalid();
+    const bool midpoints = layout.tags().back()==LEV;
+    const int vec_dim = layout.is_vector_layout() ? layout.get_vector_dim() : -1;
+    const int vec_extent = vec_dim>=0 ? layout.dims()[vec_dim] : 0;
+    switch (lt) {
+      case LayoutType::Scalar2D:
+        gll_layout = cgll_grid->get_2d_scalar_layout();
+        break;
+      case LayoutType::Vector2D:
+        gll_layout = cgll_grid->get_2d_vector_layout(CMP,vec_extent);
+        break;
+      case LayoutType::Scalar3D:
+        gll_layout = cgll_grid->get_3d_scalar_layout(midpoints);
+        break;
+      case LayoutType::Vector3D:
+        gll_layout = cgll_grid->get_3d_vector_layout(midpoints,CMP,vec_extent);
+        break;
+      default:
+        EKAT_ERROR_MSG ("Unexpected/unsupported layout for EAMxx input.\n"
+                        " - field name: " + fid.name() + "\n"
+                        " - layout    : " + to_string(layout) + "\n");
+    }
+
+    FieldIdentifier gll_fid(fid.name(),gll_layout,fid.get_units(),cgll_grid->name());
+    Field gll_f (gll_fid);
+    const int pack_size = f.get_header().get_alloc_properties().get_largest_pack_size();
+    gll_f.get_header().get_alloc_properties().request_allocation(pack_size);
+    gll_f.allocate_view();
+    m_gll_fields[f.name()] = gll_f;
+
+    if (f.name()=="tracers") {
+      // We do need to pass the tracers to the fvphys remapper, but we won't
+      // find them in the IC file. So don't add it to nc_fields.
+      continue;
+    }
+
+    // Also check whether this field was already init-ed to a constant.
+    // If yes, simply copy the constant in the gll field, otherwise add
+    // the gll field to the vector of fields to read in
+    if (m_const_fields_values.count(f.name())==1) {
+      const auto& fl = f.get_header().get_identifier().get_layout();
+      const auto& val_str = m_const_fields_values.at(f.name());
+      const bool vector_values = val_str.front()=='(' and val_str.back()==')';
+      if (vector_values) {
+        const auto vals_str = ekat::split(val_str.substr(0,val_str.size()-1),",");
+        const int ncmp = vals_str.size();
+        const int vec_dim = fl.get_vector_dim();
+        for (int icmp=0; icmp<ncmp; ++icmp) {
+          auto comp = f.subfield(vec_dim,icmp);
+          comp.deep_copy(std::stod(vals_str[icmp]));
+        }
+      } else {
+        gll_f.deep_copy(std::stod(val_str));
+      }
+    } else {
+      nc_fields.push_back(gll_f);
+    }
+  }
+
+  AtmosphereInput ic_reader (filename,cgll_grid,nc_fields);
+  ic_reader.set_logger(logger);
+  ic_reader.read_variables();
+  ic_reader.finalize();
+
+  logger->info("    [EAMxx] Reading initial conditions file ... done!");
+}
+
+void FvPhysModelInit::
+read_topo_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
+{
+  using namespace ShortFieldTagsNames;
+
+  const auto& filename = m_params.get<std::string>("topography_filename");
+  logger->info("    [EAMxx] Reading topography file ...");
+  logger->info("        filename: " + filename);
+
+  using namespace ShortFieldTagsNames;
+
+  const auto cgll_grid = HommeFvPhysHelper::instance().m_cgll_grid;
+  const auto phys_grid = HommeFvPhysHelper::instance().m_phys_grid;
+
+  for (const auto& f : m_topo_fields) {
+    if (f.name()=="phis") {
+      // We only read phis on GLL grid. But the ncol dim for gll is 'ncol_d'
+      // in the topo file, so we need to create a soft copy of cgll grid,
+      // with a new name for the COL dim.
+      auto io_grid = cgll_grid->clone(cgll_grid->name(),true);
+      io_grid->reset_field_tag_name(COL,"ncol_d");
+      const auto& fid = f.get_header().get_identifier();
+      const auto layout = io_grid->get_2d_scalar_layout();
+      FieldIdentifier phis_fid("PHIS_d",layout,fid.get_units(),io_grid->name());
+      Field phis (phis_fid);
+      phis.allocate_view();
+      m_gll_fields["phis"] = phis;
+
+      // Also check whether phis was already init-ed to a constant.
+      // If yes, simply copy the constant in the gll field, otherwise
+      // proceed to read from file
+      if (m_const_fields_values.count(f.name())==1) {
+        const auto& val_str = m_const_fields_values.at(f.name());
+        phis.deep_copy(std::stod(val_str));
+      } else {
+        std::vector<Field> nc_fields = {phis};
+        AtmosphereInput topo_reader (filename,io_grid,nc_fields);
+        topo_reader.set_logger(logger);
+        topo_reader.read_variables();
+        topo_reader.finalize();
+      }
+    } else if (f.name()=="sgh30") {
+      // Only read sgh30 on FV grid
+      EKAT_REQUIRE_MSG (f.get_header().get_identifier().get_grid_name()==phys_grid->name(),
+          "Error! Somehow, the field 'sgh30' is required on non-PG2 grid.\n");
+
+      // If someone inits sgh30 to a constant, skip this part
+      if (m_const_fields_names.count(f.name())==0) {
+        std::vector<Field> nc_fields = {f.alias("SGH30") };
+
+        AtmosphereInput topo_reader (filename,phys_grid,nc_fields);
+        topo_reader.set_logger(logger);
+        topo_reader.read_variables();
+        topo_reader.finalize();
+      }
+    } else {
+      EKAT_ERROR_MSG ("Unexpected topology-related field.\n"
+          " - field name : " + f.name() + "\n"
+          " - valid names: phis, sgh30\n");
+    }
+  }
+
+  logger->info("    [EAMxx] Reading topography file ... done!");
+}
+
+void FvPhysModelInit::
+remap_fields ()
+{
+  using kt = KokkosTypes<DefaultDevice>;
+  using view_1d = typename kt::view_ND<Real,1>;
+  using view_2d = typename kt::view_ND<Real,2>;
+  using view_3d = typename kt::view_ND<Real,3>;
+  using view_4d = typename kt::view_ND<Real,4>;
+  using view_5d = typename kt::view_ND<Real,5>;
+  using view_6d = typename kt::view_ND<Real,6>;
+
+  auto as_real = [] (Homme::Scalar* p) {
+    return reinterpret_cast<Real*>(p);
+  };
+
+  auto& fv_phys = HommeFvPhysHelper::instance();
+  auto& c = Homme::Context::singleton();
+  auto& state = c.get<Homme::ElementsState>();
+  auto& tracers = c.get<Homme::Tracers>();
+
+  const int np = HOMMEXX_NGP;
+  const int nelem = m_dyn_grid->get_num_local_dofs() / (np*np);
+  const int homme_num_lev  = HOMMEXX_PACK_SIZE * HOMMEXX_NUM_LEV;
+  const int homme_num_ilev = HOMMEXX_PACK_SIZE * HOMMEXX_NUM_LEV_P;
+
+  // Create dyn grid fields from Homme's views
+  auto vTheta = view_5d(as_real(state.m_vtheta_dp.data()),
+
+  // First, remap the fields from cgll to dyn grid
+  PhysicsDynamicsRemapper gll2dyn(fv_phys.m_cgll_grid,fv_phys.m_dyn_grid);
+  gll2dyn.registration_begins();
+  for (const std::string& n : {"T_mid","horiz_winds","ps","phis","pseudo_density","tracers"}) {
+    gll2dyn.register_field(m_gll_fields.at(n),fv_phys.m_dyn_fields.at(n));
+  }
+  gll2dyn.registration_ends();
+  gll2dyn.remap(/*forward = */ true);
+
+  // Second, use FvPhysHelper to remap dyn->phys
+}
+
+} // namespace scream

--- a/components/eamxx/src/dynamics/homme/eamxx_fvphys_model_init.hpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_fvphys_model_init.hpp
@@ -1,0 +1,42 @@
+#ifndef EAMXX_FVPHYS_MODEL_INIT_HPP
+#define EAMXX_FVPHYS_MODEL_INIT_HPP
+
+#include "share/eamxx_model_init.hpp"
+
+namespace scream
+{
+
+class FvPhysModelInit : public ModelInit
+{
+public:
+  FvPhysModelInit (const strmap_t<Field>& eamxx_inputs,
+                   const std::shared_ptr<const GridsManager>& gm,
+                   const ekat::ParameterList& ic_pl,
+                   const util::TimeStamp& run_t0);
+
+  ~FvPhysModelInit () = default;
+
+  void set_initial_conditions (const std::shared_ptr<ekat::logger::LoggerBase>& logger);
+
+protected:
+
+  void read_ic_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger) override;
+  void read_topo_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger) override;
+
+  void remap_fields ();
+
+  strmap_t<Field>   m_gll_fields;
+};
+
+inline std::shared_ptr<ModelInit>
+create_fvphys_model_init (const std::map<std::string,Field>& eamxx_inputs,
+                          const std::shared_ptr<const GridsManager>& gm,
+                          const ekat::ParameterList& params,
+                          const util::TimeStamp& run_t0)
+{
+  return std::make_shared<FvPhysModelInit>(eamxx_inputs,gm,params,run_t0);
+}
+
+} // namespace scream
+
+#endif // EAMXX_FVPHYS_MODEL_INIT_HPP

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys_active_gases.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys_active_gases.cpp
@@ -1,0 +1,97 @@
+#include "eamxx_homme_process_interface.hpp"
+
+// HOMMEXX Includes
+#include "Context.hpp"
+#include "SimulationParams.hpp"
+#include "TimeLevel.hpp"
+#include "GllFvRemap.hpp"
+
+// Scream includes
+#include "share/util/eamxx_fv_phys_rrtmgp_active_gases_workaround.hpp"
+#include "dynamics/homme/homme_dimensions.hpp"
+
+namespace scream {
+
+// See the [rrtmgp active gases] note in share/util/eamxx_fv_phys_rrtmgp_active_gases_workaround.hpp
+void HommeDynamics
+::fv_phys_rrtmgp_active_gases_init (const std::shared_ptr<const GridsManager>& gm) {
+  auto& trace_gases_workaround = TraceGasesWorkaround::singleton();
+  if (trace_gases_workaround.is_restart()) return; // always false b/c it hasn't been set yet
+  using namespace ekat::units;
+  using namespace ShortFieldTagsNames;
+  auto molmol = mol/mol;
+  molmol.set_string("mol/mol");
+  const auto& rgn = m_cgll_grid->name();
+  const auto& pgn = m_phys_grid->name();
+  const auto rnc = m_cgll_grid->get_num_local_dofs();
+  const auto pnc = m_phys_grid->get_num_local_dofs();
+  const auto nlev = m_cgll_grid->get_num_vertical_levels();
+  for (const auto& e : trace_gases_workaround.get_active_gases()) {
+    add_field<Required>(e, FieldLayout({COL,LEV},{rnc,nlev}), molmol, rgn);
+    // 'Updated' rather than just 'Computed' so that it gets written to the
+    // restart file.
+    add_field<Updated >(e, FieldLayout({COL,LEV},{pnc,nlev}), molmol, pgn);
+  }
+  trace_gases_workaround.set_remapper(gm->create_remapper(m_cgll_grid, m_dyn_grid));
+}
+
+// See the [rrtmgp active gases] note in share/util/eamxx_fv_phys_rrtmgp_active_gases_workaround.hpp
+void HommeDynamics::fv_phys_rrtmgp_active_gases_remap (const int pgN) {
+  // Note re: restart: Ideally, we'd know if we're restarting before having to
+  // call add_field above. However, we only find out after. Because the pg2
+  // field was declared Updated, it will read the restart data. But we don't
+  // actually want to remap from CGLL to pg2 now. So if restarting, just do the
+  // cleanup part at the end.
+
+  auto& trace_gases_workaround = TraceGasesWorkaround::singleton();
+  const auto& rgn = m_cgll_grid->name();
+  if (not trace_gases_workaround.is_restart()) {
+    using namespace ShortFieldTagsNames;
+    const auto& dgn = m_dyn_grid ->name();
+    const auto& pgn = m_phys_grid->name();
+    constexpr int NGP = HOMMEXX_NP;
+    const int ngll = NGP*NGP;
+    const int npg = pgN*pgN;
+    const int nelem = m_dyn_grid->get_num_local_dofs()/ngll;
+    { // CGLL -> DGLL
+      const auto nlev = m_dyn_grid->get_num_vertical_levels();
+      for (const auto& e : trace_gases_workaround.get_active_gases())
+        create_helper_field(e, {EL,GP,GP,LEV}, {nelem,NGP,NGP,nlev}, dgn);
+      auto r = trace_gases_workaround.get_remapper();
+      r->registration_begins();
+      for (const auto& e : trace_gases_workaround.get_active_gases())
+        r->register_field(get_field_in(e, rgn), m_helper_fields.at(e));
+      r->registration_ends();
+      r->remap(true);
+      trace_gases_workaround.erase_remapper();
+    }
+    { // DGLL -> PGN
+      const auto& c = Homme::Context::singleton();
+      auto& gfr = c.get<Homme::GllFvRemap>();
+      const auto time_idx = c.get<Homme::TimeLevel>().n0;
+      for (const auto& e : trace_gases_workaround.get_active_gases()) {
+        const auto& f_dgll = m_helper_fields.at(e);
+        const auto& f_phys = get_field_out(e, pgn);
+        const auto& v_dgll = f_dgll.get_view<const Real****>();
+        const auto& v_phys = f_phys.get_view<Real**>();
+        assert(v_dgll.extent_int(0) == nelem and
+               v_dgll.extent_int(1)*v_dgll.extent_int(2) == ngll);
+        const auto in_dgll = Homme::GllFvRemap::CPhys3T(
+          v_dgll.data(), nelem, 1, ngll, v_dgll.extent_int(3));
+        assert(nelem*npg == v_phys.extent_int(0));
+        const auto out_phys = Homme::GllFvRemap::Phys3T(
+          v_phys.data(), nelem, npg, 1, v_phys.extent_int(1));
+        gfr.remap_tracer_dyn_to_fv_phys(time_idx, 1, in_dgll, out_phys);
+        Kokkos::fence();
+      }
+    }
+  }
+  // Done with all of these, so remove them.
+  trace_gases_workaround.erase_remapper();
+  for (const auto& e : trace_gases_workaround.get_active_gases())
+    m_helper_fields.erase(e);
+  for (const auto& e : trace_gases_workaround.get_active_gases())
+    remove_field(e, rgn);
+}
+
+} // namespace scream

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys_helper.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys_helper.cpp
@@ -1,0 +1,241 @@
+#include "eamxx_homme_fv_phys_helper.hpp"
+
+#include "share/util/eamxx_fv_phys_rrtmgp_active_gases_workaround.hpp"
+#include "share/grid/abstract_grid.hpp"
+#include "share/field/field.hpp"
+#include "dynamics/homme/homme_dimensions.hpp"
+
+// HOMMEXX Includes
+#include "Context.hpp"
+#include "FunctorsBuffersManager.hpp"
+#include "SimulationParams.hpp"
+#include "TimeLevel.hpp"
+#include "GllFvRemap.hpp"
+
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "ekat/ekat_pack_utils.hpp"
+
+// Defined in homme's gllfvremap_mod.F90
+extern "C" void gfr_init_hxx();
+
+namespace scream {
+
+void HommeFvPhysHelper::
+set_grids (const std::shared_ptr<const AbstractGrid>& dyn_grid,
+           const std::shared_ptr<const AbstractGrid>& cgll_grid,
+           const std::shared_ptr<const AbstractGrid>& phys_grid)
+{
+  m_dyn_grid = dyn_grid;
+  m_cgll_grid = cgll_grid;
+  m_phys_grid = phys_grid;
+
+  const auto phys_grid_name = phys_grid->name();
+
+  // Check the name of the physics grid, to find out if FvPhys is used
+  if (phys_grid_name.size() >= 11 and
+      phys_grid_name.substr(0, 10) == "Physics PG")
+  {
+    const auto pgN_str = phys_grid_name.substr(10, std::string::npos);
+    std::istringstream ss(pgN_str);
+    try {
+      ss >> pgN;
+    } catch (...) {
+      pgN = -1;
+    }
+    fv_phys_active = true;
+  }
+}
+
+void HommeFvPhysHelper::
+requested_buffer_size_in_bytes () {
+  if (not fv_phys_active) return;
+
+  // Init FV<->GLL remap, since we'll need its
+  using namespace Homme;
+  auto& c = Context::singleton();
+  EKAT_REQUIRE_MSG (c.has<SimulationParams>(),
+      "Error! SimulationParams was not yet created in the Homme context.\n");
+
+  auto& gfr = c.create_if_not_there<GllFvRemap>();
+  gfr.reset(c.get<SimulationParams>());
+  gfr_init_hxx();
+
+  auto& fbm = c.create_if_not_there<FunctorsBuffersManager>();
+  fbm.request_size(gfr.requested_buffer_size());
+}
+
+void HommeFvPhysHelper::
+dyn_to_fv_phys_init (const bool restart, const util::TimeStamp& t0) {
+  if (not fv_phys_active) return;
+
+  constexpr int N = HOMMEXX_PACK_SIZE;
+  using Pack = ekat::Pack<Real,N>;
+  const auto nlevs = m_phys_grid->get_num_vertical_levels();
+  const auto npacks = ekat::PackInfo<N>::num_packs(nlevs);
+  const auto ncols = m_phys_grid->get_num_local_dofs();
+  const auto qsize = m_Q_phys.get_view<const Real***>().extent(1);
+  const auto FT = m_FT_phys.get_view<Pack**>();
+  const auto FM = m_FM_phys.get_view<Pack***>();
+
+  view_ND<Real,2> T;
+  view_ND<Real,3> uv;
+  view_ND<Real,3> q;
+  if (restart) {
+    constexpr int NGP = HOMMEXX_NP;
+    const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
+    const auto npg = pgN*pgN;
+
+    T = view_ND<Real,2>("T_mid_tmp",nelem*npg,npacks*N);
+    uv = view_ND<Real,3>("horiz_winds_tmp",nelem*npg,2,npacks*N);
+    // Really need just the first tracer.
+    q = view_ND<Real,3>("tracers_tmp",nelem*npg,qsize,npacks*N);
+
+    remap_dyn_to_fv_phys(T,uv,q);
+    assert(ncols == nelem*npg);
+
+    view_ND<PackT,2> T_packed (reinterpret_cast<Pack*>(T.data()),  ncols,    npacks);
+    view_ND<PackT,3> uv_packed(reinterpret_cast<Pack*>(uv.data()), ncols, 2, npacks);
+    copy_prev(ncols,nlevs,T_packed,uv_packed,FT,FM);
+  } else {
+    T  = m_T_phys.get_view<Real**>();
+    uv = m_uv_phys.get_view<Real***>();
+    q  = m_Q_phys.get_view<Real***>();
+    remap_dyn_to_fv_phys(T,uv,q);
+
+    view_ND<PackT,2> T_packed (reinterpret_cast<Pack*>(T.data()),  ncols,    npacks);
+    view_ND<PackT,3> uv_packed(reinterpret_cast<Pack*>(uv.data()), ncols, 2, npacks);
+    copy_prev(ncols, npacks, T_packed, uv_packed, FT, FM);
+
+    // In an initial run, the AD only reads IC for the Physics GLL fields,
+    // and this class has just taken care of remapping them to the FV grid.
+    // Therefore, the timestamp of the FV fields has *not* been set yet,
+    // which can cause serious issues downstream. For details, see
+    //   https://github.com/E3SM-Project/scream/issues/2250
+    // To avoid any problem, we simply set the timestamp of FV state fields here.
+    // NOTE: even if the init sequence *ever* changed, and the AD *did* read
+    // IC for FV fields, this step remains safe (we're setting the same t0)
+    for (auto f : {m_T_phys,m_uv_phys,m_ps_phys,m_phis_phys,m_omega_phys,m_dp_phys,m_Q_phys}) {
+      f.get_header().get_tracking().update_time_stamp(t0);
+    }
+  }
+}
+
+void HommeFvPhysHelper::
+remap_dyn_to_fv_phys () const
+{
+  auto T  = m_T_phys.get_view<Real**>();
+  auto uv = m_uv_phys.get_view<Real***>();
+  auto q  = m_Q_phys.get_view<Real***>();
+  remap_dyn_to_fv_phys(T,uv,q);
+}
+
+void HommeFvPhysHelper::
+remap_dyn_to_fv_phys (const view_ND<Real,2>& T_out, const view_ND<Real,3>& uv_out, const view_ND<Real,3>& Q_out) const
+{
+  if (not fv_phys_active) return;
+
+  using GFR = Homme::GllFvRemap;
+
+  const auto& c = Homme::Context::singleton();
+  auto& gfr = c.get<Homme::GllFvRemap>();
+  const auto time_idx = c.get<Homme::TimeLevel>().n0;
+  constexpr int NGP = HOMMEXX_NP;
+  const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
+  const auto npg = pgN*pgN;
+  const auto nlev = T_out.extent_int(1);
+  const auto nq = Q_out.extent_int(1);
+  assert(T_out.extent_int(0) == nelem*npg);
+  assert(uv_out.extent_int(1) == 2);
+
+  const auto ps    = GFR::Phys1T(m_ps_phys.get_view<Real*>().data(), nelem, npg);
+  const auto phis  = GFR::Phys1T(m_phis_phys.get_view<Real*>().data(), nelem, npg);
+  const auto T     = GFR::Phys2T(T_out.data(), nelem, npg, nlev);
+  const auto omega = GFR::Phys2T(m_omega_phys.get_view<Real**>().data(),nelem, npg, nlev);
+  const auto uv    = GFR::Phys3T(uv_out.data(),nelem, npg, 2, nlev);
+  const auto q     = GFR::Phys3T(Q_out.data(),nelem, npg, nq, nlev);
+  const auto dp    = GFR::Phys2T(m_dp_phys.get_view<Real**>().data(),nelem, npg, nlev);
+
+  gfr.run_dyn_to_fv_phys(time_idx, ps, phis, T, omega, uv, q, &dp);
+  Kokkos::fence();
+}
+
+void HommeFvPhysHelper::
+remap_fv_phys_to_dyn () const {
+  if (not fv_phys_active) return;
+
+  using GFR = Homme::GllFvRemap;
+
+  const auto& c = Homme::Context::singleton();
+  auto& gfr = c.get<Homme::GllFvRemap>();
+  const auto time_idx = c.get<Homme::TimeLevel>().n0;
+  constexpr int NGP = HOMMEXX_NP;
+  const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
+  const auto npg = pgN*pgN;
+
+  const auto FT = m_FT_phys.get_view<const Real**>();
+  const auto FM = m_FM_phys.get_view<const Real***>();
+  const auto tracers = m_Q_phys.get_view<const Real***>();
+
+  const auto nlev    = FT.extent_int(1);
+  const auto nq      = tracers.extent_int(1);
+  const auto uv_ndim = FM.extent_int(1);
+
+  assert(FT.extent_int(0) == nelem*npg);
+  assert(uv_ndim == 2);
+
+  const auto T  = GFR::CPhys2T(FT.data(), nelem, npg, nlev);
+  const auto uv = GFR::CPhys3T(FM.data(), nelem, npg, uv_ndim, nlev);
+  const auto q  = GFR::CPhys3T(tracers.data(), nelem, npg, nq, nlev);
+
+  gfr.run_fv_phys_to_dyn(time_idx, T, uv, q);
+  Kokkos::fence();
+  gfr.run_fv_phys_to_dyn_dss();
+  Kokkos::fence();
+}
+
+void HommeFvPhysHelper::
+copy_prev (const int ncols, const int nlevs,
+           const view_ND<PackT,2>& T,  const view_ND<PackT,3>& uv,
+           const view_ND<PackT,2>& FT, const view_ND<PackT,3>& FM)
+{
+  using KT = KokkosTypes<DefaultDevice>;
+  using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
+
+  const auto npacks = ekat::PackInfo<N>::num_packs(nlevs);
+  const auto policy = ESU::get_default_team_policy(ncols, npacks);
+
+  // Copy physics T,uv state to FT,M to form tendencies in next dynamics step.
+  auto f = KOKKOS_LAMBDA (const KT::MemberType& team) {
+    const int& icol = team.league_rank();
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, npacks),
+                         [&] (const int ilev) {
+      FT(icol,ilev)   = T(icol,ilev);
+      FM(icol,0,ilev) = uv(icol,0,ilev);
+      FM(icol,1,ilev) = uv(icol,1,ilev);
+    });
+  };
+
+  Kokkos::parallel_for(policy, f);
+
+  Kokkos::fence();
+}
+
+void HommeFvPhysHelper::
+clean_up ()
+{
+  m_phys_grid = m_cgll_grid = m_dyn_grid = nullptr;
+
+  Field empty;
+
+  m_FT_phys    = empty;
+  m_FM_phys    = empty;
+  m_T_phys     = empty;
+  m_uv_phys    = empty;
+  m_ps_phys    = empty;
+  m_phis_phys  = empty;
+  m_omega_phys = empty;
+  m_dp_phys    = empty;
+  m_Q_phys     = empty;
+}
+
+} // namespace scream

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys_helper.hpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys_helper.hpp
@@ -1,0 +1,76 @@
+#ifndef EAMXX_HOMME_FV_PHYS_HELPER_HPP
+#define EAMXX_HOMME_FV_PHYS_HELPER_HPP
+
+#include "dynamics/homme/homme_dimensions.hpp"
+
+#include "share/grid/grids_manager.hpp"
+#include "share/grid/abstract_grid.hpp"
+#include "share/field/field.hpp"
+
+#include <ekat/kokkos/ekat_kokkos_types.hpp>
+#include <ekat/ekat_pack.hpp>
+
+namespace scream {
+
+struct HommeFvPhysHelper {
+public:
+  using KT = KokkosTypes<DefaultDevice>;
+  template<typename T,int N>
+  using view_ND = typename KT::view_ND<T,N>;
+
+  static constexpr int N = HOMMEXX_PACK_SIZE;
+  using PackT = ekat::Pack<Real,N>;
+
+  static HommeFvPhysHelper& instance () {
+    static HommeFvPhysHelper dph;
+    return dph;
+  }
+
+  void set_grids (const std::shared_ptr<const AbstractGrid>& dyn_grid,
+                  const std::shared_ptr<const AbstractGrid>& cgll_grid,
+                  const std::shared_ptr<const AbstractGrid>& phys_grid);
+
+  void requested_buffer_size_in_bytes ();
+
+  void dyn_to_fv_phys_init (const bool restart, const util::TimeStamp& t0);
+
+  void remap_dyn_to_fv_phys () const;
+  void remap_dyn_to_fv_phys (const view_ND<Real,2>& T_out, const view_ND<Real,3>& uv_out, const view_ND<Real,3>& Q_out) const;
+  void remap_fv_phys_to_dyn () const;
+
+  void clean_up ();
+
+  bool fv_phys_active = false;
+  int  pgN            = -1;
+
+  // Copy physics T,uv state to FT,M to form tendencies in next dynamics step.
+  static void copy_prev (const int ncols, const int nlevs,
+                         const view_ND<PackT,2>& T,  const view_ND<PackT,3>& uv,
+                         const view_ND<PackT,2>& FT, const view_ND<PackT,3>& FM);
+
+  // Physics forcing
+  Field m_FT_phys;
+  Field m_FM_phys;
+
+  // Dynamics state on physics grid
+  Field m_T_phys;
+  Field m_uv_phys;
+  Field m_ps_phys;
+  Field m_phis_phys;
+  Field m_omega_phys;
+  Field m_dp_phys;
+  Field m_Q_phys;
+
+  // During restart, we can't overwrite T_mid, horiz_winds, and tracers, as these
+  // contain data used in homme_pre_process to compute tendencies.
+
+  std::shared_ptr<const AbstractGrid> m_dyn_grid;
+  std::shared_ptr<const AbstractGrid> m_cgll_grid;
+  std::shared_ptr<const AbstractGrid> m_phys_grid;
+
+  HommeFvPhysHelper () = default;
+};
+
+} // namespace scream
+
+#endif  // EAMXX_HOMME_FV_PHYS_HELPER_HPP

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
@@ -38,6 +38,8 @@ public:
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
+  void all_fields_set_impl () override;
+
 #ifndef KOKKOS_ENABLE_CUDA
   // Cuda requires methods enclosing __device__ lambda's to be public
 protected:

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
@@ -30,13 +30,13 @@ public:
   ~HommeDynamics ();
 
   // The type of the subcomponent (dynamics or physics)
-  AtmosphereProcessType type () const { return AtmosphereProcessType::Dynamics; }
+  AtmosphereProcessType type () const override { return AtmosphereProcessType::Dynamics; }
 
   // The name of the subcomponent
-  std::string name () const { return "homme"; }
+  std::string name () const override { return "homme"; }
 
   // Set the grid
-  void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
+  void set_grids (const std::shared_ptr<const GridsManager> grids_manager) override;
 
   void all_fields_set_impl () override;
 
@@ -65,55 +65,35 @@ protected:
   // Copy initial states from n0 timelevel to other timelevels
   void copy_dyn_states_to_all_timelevels ();
 
-  void initialize_impl (const RunType run_type);
-
   // fv_phys refers to the horizontal finite volume (FV) grid for column
   // parameterizations nested inside the horizontal element grid. The grid names
-  // are "Physics PGN", where N in practice is 2. The name of each routine is
-  // fv_phys_X, where X is the name of an existing HommeDynamics routine. If
-  // fv_phys is not being used, each of these routines does an immediate exit,
-  // so it's OK to always call the routine.
-  //   For the finite volume (FV) physics grid, sometimes referred to as
-  // "physgrid", we use the remapper that Homme provides. Store N in pgN; if the
-  // grid is not FV, then this variable is set to -1.
-  int m_phys_grid_pgN;
-  void fv_phys_set_grids();
-  void fv_phys_requested_buffer_size_in_bytes() const;
-  void fv_phys_initialize_impl();
-  void fv_phys_dyn_to_fv_phys(const bool restart = false);
-  void fv_phys_pre_process();
-  void fv_phys_post_process();
-  // See [rrtmgp active gases] in eamxx_homme_fv_phys.cpp.
+  // are "Physics PGN", where N in practice is 2.
+  // These two routines are needed for reading active gases from IC/restart file
+  // with PG2.
   void fv_phys_rrtmgp_active_gases_init(const std::shared_ptr<const GridsManager>& gm);
-  void fv_phys_rrtmgp_active_gases_remap();
+  void fv_phys_rrtmgp_active_gases_remap(const int pgN);
 
   // Rayleigh friction functions
   void rayleigh_friction_init ();
   void rayleigh_friction_apply (const Real dt) const;
 
-public:
-  // Fast boolean function returning whether Physics PGN is being used.
-  bool fv_phys_active() const;
-  struct GllFvRemapTmp;
-  void remap_dyn_to_fv_phys(GllFvRemapTmp* t = nullptr) const;
-  void remap_fv_phys_to_dyn() const;
-
 protected:
-  void run_impl        (const double dt);
-  void finalize_impl   ();
+  void initialize_impl (const RunType run_type) override;
+  void run_impl        (const double dt) override;
+  void finalize_impl   () override;
 
   // We need to store the size of the tracers group as soon as it is available.
   // In particular, we absolutely need to store it *before* the call to
   // requested_buffer_size_in_bytes, where Homme::ForcingFunctor queries
   // Homme::Tracers for qsize.
-  void set_computed_group_impl (const FieldGroup& group);
+  void set_computed_group_impl (const FieldGroup& group) override;
 
   // Computes total number of bytes needed for local variables
-  size_t requested_buffer_size_in_bytes() const;
+  size_t requested_buffer_size_in_bytes() const override;
 
   // Set local variables using memory provided by
   // the ATMBufferManager
-  void init_buffers(const ATMBufferManager &buffer_manager);
+  void init_buffers(const ATMBufferManager &buffer_manager) override;
 
   // Creates an helper field, not to be shared with the AD's FieldManager
   void create_helper_field (const std::string& name,

--- a/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -182,8 +182,7 @@ contains
 
   subroutine prim_init_model_f90 () bind(c)
     use prim_driver_mod,   only: prim_init_ref_states_views, &
-                                 prim_init_diags_views, prim_init_kokkos_functors, &
-                                 prim_init_state_views
+                                 prim_init_diags_views, prim_init_kokkos_functors
     use prim_state_mod,    only: prim_printstate
     use model_init_mod,    only: model_init2
     use control_mod,       only: disable_diagnostics

--- a/components/eamxx/src/dynamics/homme/interface/phys_grid_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/phys_grid_mod.F90
@@ -85,7 +85,6 @@ contains
   end subroutine check_phys_grid_inited
 
   subroutine phys_grids_init (pg_types)
-    use gllfvremap_mod,    only: gfr_init
     use homme_context_mod, only: elem, par
     use dimensions_mod,    only: nelem, nelemd
     !
@@ -155,78 +154,6 @@ contains
       call phys_grid_init (fvN)
     endif
   end subroutine phys_grids_init
-
-  !   integer :: ldofs, ierr, proc, ngcols, ie, gid, offset
-  !   integer, allocatable :: dofs_per_elem (:)
-
-  !   ! Note: in the following, we often use MPI_IN_PLACE,0,MPI_DATATYPE_NULL
-  !   !       for the src array specs in Allgatherv calls. These special values 
-  !   !       inform MPI that src array is aliasing the dst one, so MPI will
-  !   !       grab the src data from the dst array, using the offsets info
-
-  !   if (pgN>0) then
-  !     fv_nphys = pgN
-  !     call gfr_init(par, elem, fv_nphys)
-  !   endif
-
-  !   ! Set this right away, so calls to get_num_[local|global]_columns doesn't crap out
-  !   is_phys_grid_inited = .true.
-
-  !   ! Gather num elems on each rank
-  !   allocate(g_elem_per_rank(par%nprocs))
-  !   call MPI_Allgather(nelemd, 1, MPIinteger_t, g_elem_per_rank, 1, MPIinteger_t, par%comm, ierr)
-
-  !   ! Compute offset of each rank in the g_elem_per_rank array
-  !   ! This allows each rank to know where to fill arrays of size num_global_elements
-  !   allocate(g_elem_offsets(par%nprocs))
-  !   g_elem_offsets = 0
-  !   do proc=2,par%nprocs
-  !     g_elem_offsets(proc) = g_elem_offsets(proc-1) + g_elem_per_rank(proc-1)
-  !   enddo
-
-  !   ! Gather elem GIDs on each rank
-  !   allocate(g_elem_gids(nelem))
-  !   do ie=1,nelemd
-  !     g_elem_gids(g_elem_offsets(par%rank+1)+ie) = elem(ie)%globalID
-  !   enddo
-  !   call MPI_Allgatherv( MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
-  !                        g_elem_gids, g_elem_per_rank, g_elem_offsets, MPIinteger_t, par%comm, ierr)
-
-  !   ! Gather the number of unique cols on each rank
-  !   allocate(g_dofs_per_rank(par%nprocs))
-  !   call MPI_Allgather(get_num_local_columns(), 1, MPIinteger_t, g_dofs_per_rank, 1, MPIinteger_t, par%comm, ierr)
-
-  !   ! Gather the number of unique cols on each element
-  !   ! NOTE: we use a temp (dofs_per_elem) rather than g_dofs, since in g_dofs we order by
-  !   !       elem GID. But elem GIDs may not be distributed linearly across ranks
-  !   !       (e.g., proc0 may own [1-20,41-60],and proc1 may owns [21-40]), while in order
-  !   !       to use Allgatherv, we need the send buffer to be contiguous. So in dofs_per_elem
-  !   !       we order the data *by rank*. Once the gather is complete, we copy the data from
-  !   !       dofs_per_elem into g_dofs_per_elem, ordering by elem GID instead.
-  !   !
-  !   allocate(dofs_per_elem(nelem))
-  !   do ie=1,nelemd
-  !     dofs_per_elem(g_elem_offsets(par%rank+1)+ie) = elem(ie)%idxP%NumUniquePts
-  !   enddo
-  !   call MPI_Allgatherv( MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, &
-  !                        dofs_per_elem, g_elem_per_rank, g_elem_offsets, MPIinteger_t, par%comm, ierr)
-
-  !   allocate(g_dofs_per_elem(nelem))
-  !   do proc=1,par%nprocs
-  !     offset = g_elem_offsets(proc)
-  !     do ie=1,g_elem_per_rank(proc)
-  !       g_dofs_per_elem(g_elem_gids(offset+ie)) = dofs_per_elem(offset+ie)
-  !     enddo
-  !   enddo
-
-  !   ! Compute global dofs
-  !   call compute_global_dofs ()
-
-  !   ! Compute area and lat/lon coords
-  !   call compute_global_coords ()
-  !   call compute_global_area ()
-
-  ! end subroutine phys_grid_init
 
   subroutine cleanup_grid_init_data ()
     !

--- a/components/eamxx/src/dynamics/register_dynamics.hpp
+++ b/components/eamxx/src/dynamics/register_dynamics.hpp
@@ -2,10 +2,12 @@
 #define SCREAM_REGISTER_DYNAMICS_PROCESS_HPP
 
 #include "share/atm_process/atmosphere_process.hpp"
+#include "share/eamxx_model_init.hpp"
 
 #ifdef EAMXX_HAS_HOMME
 #include "homme/eamxx_homme_process_interface.hpp"
 #include "homme/homme_grids_manager.hpp"
+#include "homme/eamxx_fvphys_model_init.hpp"
 #endif
 
 namespace scream {
@@ -13,14 +15,17 @@ namespace scream {
 inline void register_dynamics () {
   auto& proc_factory = AtmosphereProcessFactory::instance();
   auto& gm_factory   = GridsManagerFactory::instance();
+  auto& init_factory = ModelInitFactory::instance();
 
 #ifdef EAMXX_HAS_HOMME
   proc_factory.register_product("Homme",&create_atmosphere_process<HommeDynamics>);
-
   gm_factory.register_product("Homme",&create_homme_grids_manager);
+  init_factory.register_product("fvphys",&create_fvphys_model_init);
 #endif
+
   (void) proc_factory;
   (void) gm_factory;
+  (void) init_factory;
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -3,6 +3,7 @@ include (EkatSetCompilerFlags)
 set(SHARE_SRC
   scream_config.cpp
   scream_session.cpp
+  eamxx_model_init.cpp
   atm_process/atmosphere_process.cpp
   atm_process/atmosphere_process_hash.cpp
   atm_process/atmosphere_process_group.cpp

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -401,7 +401,7 @@ void AtmosphereProcess::run_property_check (const prop_check_ptr&       property
       "  - Atmosphere process name: " + name() + "\n"
       "  - Property check name: " + property_check->name() + "\n"
       "  - Atmosphere process MPI Rank: " + std::to_string(m_comm.rank()) + "\n"
-      "  - Message: " + res_and_msg.msg + "\n");
+      "  - Message: " + res_and_msg.msg);
   } else {
     // Ugh, the test failed badly, with no chance to repair it.
     if (check_fail_handling==CheckFailHandling::Warning) {

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -141,6 +141,12 @@ public:
   virtual void set_required_group (const FieldGroup& group);
   virtual void set_computed_group (const FieldGroup& group);
 
+  // Signal to the atm proc that we're done setting fields in it.
+  // Derived classes *can* use this info to start setting up some
+  // infrastructure. Default behavior is a no-op
+  void all_fields_set ();
+  virtual void all_fields_set_impl () {}
+
   // These methods check that some properties are satisfied before/after
   // the run_impl method is called.
   // For more info on what a property check can be, see content of the
@@ -529,6 +535,7 @@ private:
   strmap_t<strmap_t<Field*>> m_fields_in_pointers;
   strmap_t<strmap_t<Field*>> m_fields_out_pointers;
   strmap_t<strmap_t<Field*>> m_internal_fields_pointers;
+  bool m_all_fields_set = false;
 
   // The list of in/out field/group requests.
   std::set<FieldRequest>   m_required_field_requests;

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
@@ -570,6 +570,14 @@ endloop:
 }
 
 void AtmosphereProcessGroup::
+all_fields_set_impl ()
+{
+  for (auto atm_proc : m_atm_processes) {
+    atm_proc->all_fields_set();
+  }
+}
+
+void AtmosphereProcessGroup::
 set_required_group_impl (const FieldGroup& group)
 {
   for (auto atm_proc : m_atm_processes) {

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
@@ -80,6 +80,9 @@ public:
   void set_required_field (const Field& field);
   void set_required_group (const FieldGroup& group);
 
+  // Propagate the call to stored atm procs
+  void all_fields_set_impl ();
+
   // Gather internal fields from all processes in the group
   // NOTE: this method *must* be called before any attempt to query this atm proc group
   //       for its internal fields, otherwise it will appear as if this atm proc group

--- a/components/eamxx/src/share/eamxx_model_init.cpp
+++ b/components/eamxx/src/share/eamxx_model_init.cpp
@@ -106,6 +106,7 @@ set_constant_fields (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
     }
 
     m_const_fields.insert(f);
+    m_const_fields_values[f.name()] = val_str;
   }
   logger->info("    [EAMxx] Initializing constant fields ... done!");
 }

--- a/components/eamxx/src/share/eamxx_model_init.cpp
+++ b/components/eamxx/src/share/eamxx_model_init.cpp
@@ -1,0 +1,157 @@
+#include "eamxx_model_init.hpp"
+
+namespace scream
+{
+
+ModelInit::
+ModelInit (const strmap_t<Field>& eamxx_inputs,
+           const std::shared_ptr<const GridsManager>& gm,
+           const ekat::ParameterList& ic_pl,
+           const util::TimeStamp& run_t0)
+ : m_params       (ic_pl)
+ , m_gm           (gm)
+ , m_run_t0       (run_t0)
+ , m_eamxx_inputs (eamxx_inputs)
+{
+  separate_inputs ();
+}
+
+void ModelInit::
+set_constant_fields (const std::shared_ptr<ekat::logger::LoggerBase>& logger)
+{
+  logger->info("    [EAMxx] Initializing constant fields ...");
+
+  auto str2double = [&] (const std::string& fname, const std::string& val_str) {
+    double val;
+    try {
+      val = std::stod (val_str);
+    } catch (std::exception&) {
+      EKAT_ERROR_MSG (
+        "Error! Bad value specification for constant field initialization.\n"
+        " Field name: " + fname + "\n"
+        "Could not convert the string '" + val_str + "' to double.\n");
+    }
+    return val;
+  };
+
+  const auto& const_fields = m_params.get<strvec_t>("constant_fields",{});
+  for (const auto& s : const_fields) {
+    logger->info("      " + s);
+
+    // Split input string FNAME = VALUE(S)
+    auto tokens = ekat::split(s,"=");
+    EKAT_REQUIRE_MSG (tokens.size()==2,
+        "Error! Bad syntax specifying constant input fields.\n"
+        "  Valid syntax: 'field_name = field_value(s)'\n"
+        "  Input string: '" + s + "'\n");
+    const auto fname   = ekat::trim(tokens[0]);
+    const auto val_str = ekat::trim(tokens[1]);
+    EKAT_REQUIRE_MSG (fname.size()>0,
+        "Error! Bad syntax specifying constant input fields (empty field name).\n"
+        " Input string: '" + s + "'\n");
+    EKAT_REQUIRE_MSG (val_str.size()>0,
+        "Error! Bad syntax specifying constant input fields (empty value).\n"
+        " Input string: '" + s + "'\n");
+
+    auto get_fname = [&] (const strmap_t<Field>::value_type& it) {
+      return it.first;
+    };
+    EKAT_REQUIRE_MSG (m_eamxx_inputs.count(fname)==1,
+        "Error! Attempt to prescribe constant value for a field that is not an atm input.\n"
+        " - field name: " + fname + "\n"
+        " - atm inputs: " + ekat::join(m_eamxx_inputs,get_fname,",") + "\n");
+
+    // Get the field, and ensure it's in the ic fields list
+    auto& f = m_eamxx_inputs.at(fname);
+
+    // Check if we are attempting to init a vec field with f=(v1,v2,...,vN) syntax
+    bool vector_values = val_str.front()=='(' and val_str.back()==')';
+    if (vector_values) {
+      const auto& fl = f.get_header().get_identifier().get_layout();
+      EKAT_REQUIRE_MSG (fl.is_vector_layout(),
+          "Error! Attempt to assing a vector of values to a non-vector field.\n"
+          "  - field name: " + fname + "\n"
+          "  - field layout: " + to_string(fl) + "\n"
+          "  - input string: " + s + "\n");
+      const auto vals = ekat::split(val_str.substr(1,val_str.size()-2),",");
+      const int vec_dim = fl.get_vector_dim();
+      EKAT_REQUIRE_MSG (static_cast<int>(vals.size())==fl.dim(vec_dim),
+          "Error! Vector of values does not match vector field extent.\n"
+          "  - field name: " + fname + "\n"
+          "  - field layout: " + to_string(fl) + "\n"
+          "  - input string: " + s + "\n");
+      for (int icmp=0; icmp<fl.dim(vec_dim); ++icmp) {
+        auto f_i = f.subfield(vec_dim,icmp);
+        auto val = str2double(fname,vals[icmp]);
+        f_i.deep_copy(val);
+      }
+    } else {
+      // Not a vector assignment, so just init the whole field
+      // NOTE: if user had a typo, like "f=(v1,v2", notice missing ')',
+      //       this fcn will throw, cause "(v1,v2" cannot be converted to double
+      auto val = str2double(fname,val_str);
+      f.deep_copy(val);
+    }
+    
+    f.get_header().get_tracking().update_time_stamp(m_run_t0);
+
+    // Move this field out of m_ic_fields/m_topo_fields;
+    if (m_ic_fields.count(f)==1) {
+      m_ic_fields.erase(f);
+      m_ic_fields_names.erase(ekat::find(m_ic_fields_names,f.name()));
+    }
+    if (m_topo_fields.count(f)==1) {
+      m_topo_fields.erase(f);
+      m_topo_fields_names.erase(ekat::find(m_topo_fields_names,f.name()));
+    }
+
+    m_const_fields.insert(f);
+  }
+  logger->info("    [EAMxx] Initializing constant fields ... done!");
+}
+
+void ModelInit::
+separate_inputs ()
+{
+  // Separate inputs between topo-related fields and non-topo-related fields
+  for (const auto& it : m_eamxx_inputs) {
+    // const auto& fid = f.get_header().get_identifier();
+    // const auto& gname = fid.get_grid_name();
+    const auto& name = it.first;
+    const auto& f    = it.second;
+
+    if (name=="phis" or name=="sgh30") {
+      // Topography fields are set in a separate vector
+      // Also, keep track of the field name in the topo file vs eamxx
+      m_topo_fields.insert(f);
+      m_topo_fields_names.push_back(name);
+      // if (fid.name()=="phis") {
+      //   m_topo_fields_names_eamxx[gname].push_back("phis");
+      //   if (gname=="Physics PG2") {
+      //     m_topo_fields_names_file[gname].push_back("PHIS");
+      //   } else {
+      //     m_topo_fields_names_file[gname].push_back("PHIS_d");
+      //   }
+      // } else {
+      //   EKAT_ASSERT_MSG(gname == "Physics PG2",
+      //       "Error! Requesting sgh30 field on " + gname +
+      //       ", but topo file only has sgh30 for Physics PG2.\n");
+      //   m_topo_fields_names_file[gname].push_back("SGH30");
+      //   m_topo_fields_names_eamxx[gname].push_back("sgh30");
+      // }
+    // } else if (m_ic_grid->is_valid_alias(gname)) {
+    } else {
+      // We consider the field as an input only if it's on the IC grid
+      m_ic_fields.insert(f);
+      m_ic_fields_names.push_back(name);
+    // } else {
+    //   EKAT_ERROR_MSG (
+    //       "Error! Unexpected grid for non-topography-related eamxx input field.\n"
+    //       " - field name: " + fid.name() + "\n"
+    //       " - field grid: " + gname + "\n"
+    //       " - ic grid aliases: " + ekat::join(m_ic_grid->aliases(),",") + "\n");
+    }
+  };
+}
+
+} // namespace scream

--- a/components/eamxx/src/share/eamxx_model_init.hpp
+++ b/components/eamxx/src/share/eamxx_model_init.hpp
@@ -1,0 +1,90 @@
+#ifndef EAMXX_MODEL_INIT_HPP
+#define EAMXX_MODEL_INIT_HPP
+
+#include "share/field/field.hpp"
+#include "share/grid/grids_manager.hpp"
+#include "share/util/scream_time_stamp.hpp"
+#include "share/scream_types.hpp"
+
+#include <ekat/logging/ekat_logger.hpp>
+#include <ekat/util/ekat_factory.hpp>
+
+#include <vector>
+
+namespace scream
+{
+
+// Interface class for initializing fields at model init time
+// Derived classes can implement whatever strategy is needed
+// For instance, they could simply look for them in the IC file
+// An alternative (which is the case for PG2) is to read a version
+// of the fields on a different grid, and then remap to the actual
+// fields that were requested
+
+class ModelInit {
+public:
+  using strvec_t = std::vector<std::string>;
+  template<typename T>
+  using strmap_t = std::map<std::string,T>;
+
+  ModelInit (const strmap_t<Field>& eamxx_inputs,
+             const std::shared_ptr<const GridsManager>& gm,
+             const ekat::ParameterList& ic_pl,
+             const util::TimeStamp& run_t0);
+
+  virtual ~ModelInit () = default;
+
+  // Note: if all derived classes simply call set_constant_field->read_ic_file->read_topo_file,
+  //       you may want to put that impl in the base class
+  virtual void set_initial_conditions (const std::shared_ptr<ekat::logger::LoggerBase>& logger) = 0;
+
+protected:
+
+  // Separate inputs into topo fields and IC fields
+  void separate_inputs ();
+
+  void set_constant_fields (const std::shared_ptr<ekat::logger::LoggerBase>& logger);
+  virtual void read_ic_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger) = 0;
+  virtual void read_topo_file (const std::shared_ptr<ekat::logger::LoggerBase>& logger) = 0;
+
+  // ------------------------ Attributes ------------------------ //
+
+  // Parameters
+  ekat::ParameterList   m_params;
+
+  // Grids manager
+  std::shared_ptr<const GridsManager> m_gm;
+
+  // Run start date/time
+  util::TimeStamp     m_run_t0;
+
+  // Map name->field for all eamxx input fields (passed at construction time)
+  strmap_t<Field>   m_eamxx_inputs;
+
+  // Subset of EAMxx input fields that are const-inited
+  std::set<Field>   m_const_fields;
+
+  // Subset of EAMxx input fields that are topography-related
+  // NOTE: when set_constant_fields is called, we remove const fields from these lists
+  strvec_t          m_topo_fields_names;
+  std::set<Field>   m_topo_fields;
+
+  // Subset of EAMxx input fields that are not topography-related
+  // NOTE: when set_constant_fields is called, we remove const fields from these lists
+  strvec_t          m_ic_fields_names;
+  std::set<Field>   m_ic_fields;
+};
+
+// The driver will use this factory to agnostically build the concrete model init
+using ModelInitFactory =
+    ekat::Factory<ModelInit,
+                  ekat::CaseInsensitiveString,
+                  std::shared_ptr<ModelInit>,
+                  const std::map<std::string,Field>&,
+                  const std::shared_ptr<const GridsManager>&,
+                  const ekat::ParameterList&,
+                  const util::TimeStamp&>;
+
+} // namespace scream
+
+#endif // EAMXX_MODEL_INIT_HPP

--- a/components/eamxx/src/share/eamxx_model_init.hpp
+++ b/components/eamxx/src/share/eamxx_model_init.hpp
@@ -62,7 +62,8 @@ protected:
   strmap_t<Field>   m_eamxx_inputs;
 
   // Subset of EAMxx input fields that are const-inited
-  std::set<Field>   m_const_fields;
+  std::set<Field>         m_const_fields;
+  strmap_t<std::string>   m_const_fields_values; // This is needed by fvphys later in the init
 
   // Subset of EAMxx input fields that are topography-related
   // NOTE: when set_constant_fields is called, we remove const fields from these lists

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -329,6 +329,9 @@ protected:
 inline bool operator== (const Field& lhs, const Field& rhs) {
   return lhs.get_header().get_identifier() == rhs.get_header().get_identifier();
 }
+inline bool operator< (const Field& lhs, const Field& rhs) {
+  return lhs.get_header().get_identifier() < rhs.get_header().get_identifier();
+}
 
 } // namespace scream
 

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -23,10 +23,10 @@ void FieldManager::register_field (const FieldRequest& req)
   const auto& id = req.fid;
 
   // Make sure the grid name from the id matches the name of m_grid
-  EKAT_REQUIRE_MSG(id.get_grid_name()==m_grid->name(),
+  EKAT_REQUIRE_MSG(m_grid->is_valid_alias(id.get_grid_name()),
       "Error! Input field request identifier stores a different grid name than the FM:\n"
-      "         - input id grid name: " + id.get_grid_name() + "\n"
-      "         - stored grid name:   " + m_grid->name() + "\n");
+      " - input id grid name:  " + id.get_grid_name() + "\n"
+      " - stored grid aliases: " + ekat::join(m_grid->aliases(),",") + "\n");
 
   // Get or create the new field
   if (req.incomplete) {

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -74,6 +74,21 @@ get_vertical_layout (const bool midpoints) const
 
 }
 
+FieldLayout AbstractGrid::
+get_global_layout (const FieldLayout& local) const
+{
+  // If one of the tags is the partitioned dimension, replace extent
+  // with the global size of the partitioned dimension.
+  auto tags = local.tags();
+  auto dims = local.dims();
+  for (int i=0; i<local.rank(); ++i) {
+    if (tags[i]==get_partitioned_dim_tag()) {
+      dims[i] = get_partitioned_dim_global_size();
+    }
+  }
+  return FieldLayout (tags,dims);
+}
+
 bool AbstractGrid::is_unique () const {
   auto compute_is_unique = [&]() {
     // Get a copy of gids on host. CAREFUL: do not use the stored dofs,

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -66,6 +66,7 @@ public:
   const std::string& name () const { return m_name; }
   const ekat::Comm& get_comm () const { return m_comm; }
   const std::vector<std::string>& aliases () const { return m_aliases; }
+  bool is_valid_alias (const std::string& n) const { return ekat::contains(m_aliases,n); }
   void add_alias (const std::string& alias);
 
   // Native layout of a dof. This is the natural way to index a dof in the grid.

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -6,7 +6,7 @@
 #include "share/field/field_layout.hpp"
 #include "share/field/field.hpp"
 
-#include "ekat/mpi//ekat_comm.hpp"
+#include "ekat/mpi/ekat_comm.hpp"
 
 #include <map>
 #include <list>
@@ -77,6 +77,7 @@ public:
   virtual FieldLayout get_3d_scalar_layout (const bool midpoints) const = 0;
   virtual FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const = 0;
 
+  FieldLayout get_global_layout (const FieldLayout& local) const;
   int get_num_vertical_levels () const { return m_num_vert_levs; }
 
   // Whether this grid contains unique dof GIDs

--- a/components/eamxx/src/share/io/scream_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.hpp
@@ -38,6 +38,9 @@ namespace scorpio {
   int get_dimlen(const std::string& filename, const std::string& dimname);
   bool has_dim(const std::string& filename, const std::string& dimname);
   bool has_variable (const std::string& filename, const std::string& varname);
+  bool has_variable (const std::string& filename, const std::string& varname,
+                     const std::vector<std::string>& dim_names,
+                     const std::vector<int>& dim_extents);
   void set_decomp(const std::string& filename);
   /* Sets the degrees-of-freedom for a particular variable in a particular file.  Called once for each variable, for each file. */
   void set_dof(const std::string &filename, const std::string &varname, const Int dof_len, const offset_t* x_dof);

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_mam4xx_pg2/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_mam4xx_pg2/input.yaml
@@ -11,8 +11,9 @@ time_stepping:
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/homme_mam4xx_ne4_init.nc
   topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
-  cldfrac_tot : 0.0
-  pbl_height : 1000.0
+  constant_fields:
+    - cldfrac_tot = 0.0
+    - pbl_height  = 1000.0
 
 atmosphere_processes:
   atm_procs_list: [homme,physics]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -16,14 +16,11 @@ initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
   get_topo_from_file: true
-  surf_evap: 0.0
-  surf_sens_flux: 0.0
-  precip_liq_surf_mass: 0.0
-  precip_ice_surf_mass: 0.0
-  aero_g_sw: 0.0
-  aero_ssa_sw: 0.0
-  aero_tau_sw: 0.0
-  aero_tau_lw: 0.0
+  constant_fields:
+    - surf_evap            = 0.0
+    - surf_sens_flux       = 0.0
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
 
 atmosphere_processes:
   atm_procs_list: [homme,physics]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -11,10 +11,11 @@ time_stepping:
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  surf_evap: 0.0
-  surf_sens_flux: 0.0
-  precip_liq_surf_mass: 0.0
-  precip_ice_surf_mass: 0.0
+  constant_fields:
+    - surf_evap            = 0.0
+    - surf_sens_flux       = 0.0
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
 
 atmosphere_processes:
   atm_procs_list: [homme,physics]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -11,10 +11,11 @@ time_stepping:
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  surf_evap: 0.0
-  surf_sens_flux: 0.0
-  precip_ice_surf_mass: 0.0
-  precip_liq_surf_mass: 0.0
+  constant_fields:
+    - surf_evap            = 0.0
+    - surf_sens_flux       = 0.0
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
 
 atmosphere_processes:
   atm_procs_list: [homme,physics]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
@@ -18,13 +18,14 @@ time_stepping:
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  surf_evap: 0.0
-  surf_sens_flux: 0.0
-  precip_liq_surf_mass: 0.0
-  precip_ice_surf_mass: 0.0
   perturbed_fields: [T_mid]
   perturbation_limit: 0.001
   perturbation_minimum_pressure: 900.0 # in millibar
+  constant_fields:
+    - precip_liq_surf_mass = 0
+    - precip_ice_surf_mass = 0
+    - surf_evap = 0
+    - surf_sens_flux = 0
 
 atmosphere_processes:
   atm_procs_list: [sc_import,homme,physics]

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2/input.yaml
@@ -11,18 +11,19 @@ time_stepping:
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  surf_evap: 0.0
-  surf_sens_flux: 0.0
-  precip_liq_surf_mass: 0.0
-  precip_ice_surf_mass: 0.0
-  tke: 0.0
-  qm: 0.0
-  bm: 0.0
-  sfc_alb_dir_vis: 0.0
-  sfc_alb_dir_nir: 0.0
-  sfc_alb_dif_vis: 0.0
-  sfc_alb_dif_nir: 0.0
-  landfrac: 0.5
+  constant_fields:
+    - surf_evap            = 0.0
+    - surf_sens_flux       = 0.0
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
+    - tke                  = 0.0
+    - qm                   = 0.0
+    - bm                   = 0.0
+    - sfc_alb_dir_vis      = 0.0
+    - sfc_alb_dir_nir      = 0.0
+    - sfc_alb_dif_vis      = 0.0
+    - sfc_alb_dif_nir      = 0.0
+    - landfrac             = 0.5
 
 atmosphere_processes:
   atm_procs_list: [homme,physics]

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_baseline.yaml
@@ -12,15 +12,11 @@ time_stepping:
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  Restart Run: false
-  surf_evap: 0.0
-  surf_sens_flux: 0.0
-  precip_liq_surf_mass: 0.0
-  precip_ice_surf_mass: 0.0
-  aero_g_sw: 0.0
-  aero_ssa_sw: 0.0
-  aero_tau_sw: 0.0
-  aero_tau_lw: 0.0
+  constant_fields:
+    - surf_evap            = 0.0
+    - surf_sens_flux       = 0.0
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
 
 atmosphere_processes:
   atm_procs_list: [homme,physics]

--- a/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/model_restart/input_initial.yaml
@@ -12,15 +12,11 @@ time_stepping:
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  Restart Run: false
-  surf_evap: 0.0
-  surf_sens_flux: 0.0
-  precip_liq_surf_mass: 0.0
-  precip_ice_surf_mass: 0.0
-  aero_g_sw: 0.0
-  aero_ssa_sw: 0.0
-  aero_tau_sw: 0.0
-  aero_tau_lw: 0.0
+  constant_fields:
+    - surf_evap            = 0.0
+    - surf_sens_flux       = 0.0
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
 
 atmosphere_processes:
   atm_procs_list: [homme,physics]

--- a/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/atm_proc_subcycling/input.yaml
@@ -43,10 +43,11 @@ initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  surf_evap: 0.0
-  surf_sens_flux: 0.0
-  precip_ice_surf_mass: 0.0
-  precip_liq_surf_mass: 0.0
+  constant_fields:
+    - surf_evap            = 0.0
+    - surf_sens_flux       = 0.0
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -56,14 +56,11 @@ initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  surf_sens_flux: 0.0
-  surf_evap: 0.0
-  precip_ice_surf_mass: 0.0
-  precip_liq_surf_mass: 0.0
-  aero_g_sw: 0.0
-  aero_ssa_sw: 0.0
-  aero_tau_sw: 0.0
-  aero_tau_lw: 0.0
+  constant_fields:
+    - surf_evap            = 0.0
+    - surf_sens_flux       = 0.0
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -57,10 +57,11 @@ initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  surf_evap: 0.0
-  surf_sens_flux: 0.0
-  precip_liq_surf_mass: 0.0
-  precip_ice_surf_mass: 0.0
+  constant_fields:
+    - surf_evap            = 0.0
+    - surf_sens_flux       = 0.0
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
@@ -49,10 +49,11 @@ initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  surf_evap: 0.0
-  surf_sens_flux: 0.0
-  precip_ice_surf_mass: 0.0
-  precip_liq_surf_mass: 0.0
+  constant_fields:
+    - surf_evap            = 0.0
+    - surf_sens_flux       = 0.0
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_source_data.yaml
@@ -41,10 +41,11 @@ initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  surf_evap: 0.0
-  surf_sens_flux: 0.0
-  precip_ice_surf_mass: 0.0
-  precip_liq_surf_mass: 0.0
+  constant_fields:
+    - surf_evap            = 0.0
+    - surf_sens_flux       = 0.0
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/cld_fraction/input.yaml
+++ b/components/eamxx/tests/uncoupled/cld_fraction/input.yaml
@@ -24,6 +24,7 @@ grids_manager:
     number_of_vertical_levels:  128
 
 initial_conditions:
-  cldfrac_liq: 0.0
-  qi: 0.0
+  constant_fields:
+    - cldfrac_liq = 0.0
+    - qi          = 0.0
 ...

--- a/components/eamxx/tests/uncoupled/cosp/input.yaml
+++ b/components/eamxx/tests/uncoupled/cosp/input.yaml
@@ -26,13 +26,14 @@ initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
-  dtau067: 1.0
-  dtau105: 1.0
-  cldfrac_tot_for_analysis: 0.5
-  eff_radius_qc: 0.0
-  eff_radius_qi: 0.0
-  sunlit: 1.0
-  surf_radiative_T: 288.0
+  constant_fields:
+    - dtau067                  = 1.0
+    - dtau105                  = 1.0
+    - cldfrac_tot_for_analysis = 0.5
+    - eff_radius_qc            = 0.0
+    - eff_radius_qi            = 0.0
+    - sunlit                   = 1.0
+    - surf_radiative_T         = 288.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/mam4/input.yaml
+++ b/components/eamxx/tests/uncoupled/mam4/input.yaml
@@ -24,13 +24,14 @@ grids_manager:
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  q_aitken_so4: 0.0
-  n_aitken: 0.0
-  q_h2so4: 1.9186478479542893e-011 # 0.65e-10 is from namelist, but this is what gets to nucleation
-  pbl_height: 1100.0
-  T_mid: 273.0
-  p_mid: 1.e5
-  qv: 0.0018908932854425809 # computed from relative humidity = 0.5 using Hardy formulae
+  constant_fields:
+    - q_aitken_so4 = 0.0
+    - n_aitken     = 0.0
+    - q_h2so4      = 1.9186478479542893e-011 # 0.65e-10 is from namelist, but this is what gets to nucleation
+    - pbl_height   = 1100.0
+    - T_mid        = 273.0
+    - p_mid        = 1.e5
+    - qv           = 0.0018908932854425809 # computed from relative humidity = 0.5 using Hardy formulae
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/ml_correction/input.yaml
+++ b/components/eamxx/tests/uncoupled/ml_correction/input.yaml
@@ -26,5 +26,6 @@ grids_manager:
     number_of_vertical_levels:  128
 
 initial_conditions:
-  qi: 0.0
+  constant_fields:
+    - qi = 0.0
 ...

--- a/components/eamxx/tests/uncoupled/p3/input.yaml
+++ b/components/eamxx/tests/uncoupled/p3/input.yaml
@@ -26,8 +26,9 @@ grids_manager:
 initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  precip_liq_surf_mass: 0.0
-  precip_ice_surf_mass: 0.0
+  constant_fields:
+    - precip_liq_surf_mass = 0.0
+    - precip_ice_surf_mass = 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/rrtmgp/input.yaml
+++ b/components/eamxx/tests/uncoupled/rrtmgp/input.yaml
@@ -37,10 +37,6 @@ grids_manager:
 # Specifications for setting initial conditions
 initial_conditions:
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
-  aero_g_sw: 0.0
-  aero_ssa_sw: 0.0
-  aero_tau_sw: 0.0
-  aero_tau_lw: 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/rrtmgp/input_unit.yaml
+++ b/components/eamxx/tests/uncoupled/rrtmgp/input_unit.yaml
@@ -34,32 +34,22 @@ grids_manager:
 
 # Specifications for setting initial conditions
 initial_conditions:
-  p_mid: 0.0
-  p_int: 0.0
-  pseudo_density: 0.0
-  T_mid: 0.0
-  surf_lw_flux_up: 0.0
-  sfc_alb_dir_vis: 0.0
-  sfc_alb_dir_nir: 0.0
-  sfc_alb_dif_vis: 0.0
-  sfc_alb_dif_nir: 0.0
-  cos_zenith: 0.0
-  qc: 0.0
-  nc: 0.0
-  qi: 0.0
-  cldfrac_tot: 0.0
-  eff_radius_qc: 0.0
-  eff_radius_qi: 0.0
-  qv: 0.0
-  co2: 0.0
-  o3: 0.0
-  n2o: 0.0
-  co: 0.0
-  ch4: 0.0
-  o2: 0.0
-  n2: 0.0
-  aero_g_sw: 0.0
-  aero_ssa_sw: 0.0
-  aero_tau_sw: 0.0
-  aero_tau_lw: 0.0
+  constant_fields:
+    - p_mid = 0.0
+    - p_int = 0.0
+    - pseudo_density = 0.0
+    - T_mid = 0.0
+    - surf_lw_flux_up = 0.0
+    - sfc_alb_dir_vis = 0.0
+    - sfc_alb_dir_nir = 0.0
+    - sfc_alb_dif_vis = 0.0
+    - sfc_alb_dif_nir = 0.0
+    - qc = 0.0
+    - nc = 0.0
+    - qi = 0.0
+    - cldfrac_tot = 0.0
+    - eff_radius_qc = 0.0
+    - eff_radius_qi = 0.0
+    - qv = 0.0
+    - o3_volume_mix_ratio = 0.0
 ...

--- a/components/eamxx/tests/uncoupled/shoc/input.yaml
+++ b/components/eamxx/tests/uncoupled/shoc/input.yaml
@@ -40,8 +40,9 @@ initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  surf_sens_flux: 0.0
-  surf_evap: 0.0
+  constant_fields:
+    - surf_sens_flux = 0.0
+    - surf_evap      = 0.0
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/uncoupled/surface_coupling/input.yaml
+++ b/components/eamxx/tests/uncoupled/surface_coupling/input.yaml
@@ -23,17 +23,18 @@ initial_conditions:
   # The name of the file containing the initial conditions for this test.
   Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_72lev}
   topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
-  # Some fields needed for the exports (not in ic file)
-  precip_ice_surf_mass: 1.0
-  precip_liq_surf_mass: 2.0
-  sfc_flux_sw_net:      3.0
-  # These fields are needed for the export,
-  # but will be computed for the import
-  sfc_flux_dif_nir:     0.0
-  sfc_flux_dif_vis:     0.0
-  sfc_flux_dir_nir:     0.0
-  sfc_flux_dir_vis:     0.0
-  sfc_flux_lw_dn:       0.0
+  constant_fields:
+    # Some fields needed for the exports (not in ic file)
+    - precip_ice_surf_mass = 1.0
+    - precip_liq_surf_mass = 2.0
+    - sfc_flux_sw_net      = 3.0
+    # These fields are needed for the export,
+    # but will be computed for the import
+    - sfc_flux_dif_nir     = 0.0
+    - sfc_flux_dif_vis     = 0.0
+    - sfc_flux_dir_nir     = 0.0
+    - sfc_flux_dir_vis     = 0.0
+    - sfc_flux_lw_dn       = 0.0
 
 # The parameters for I/O control
 Scorpio:


### PR DESCRIPTION
The initial conditions setup is one of the hackiest parts in EAMxx. The reason is that when EAMxx started, there was no PG2 support, and everything was easy: the fields to read from file are all the inputs to the atmosphere. With PG2, things got complicated, and forced us to add some hacks to get things to work.

This PR is an attempt to "hide" a bit better the hack, without using existing tools in a way that they were not meant to. In particular, rather than funneling the PG2 particular case through the non-PG2 framework (input to atm is what we read), this PR creates an interface `ModelInit` (all names up for discussions, ofc) to be used for IC read. The interface is abstract, and different implementations will be used depending on whether PG2 is active or not. This allows to be more explicit in the PG2 case, without trying to shove a square peg in a round hole.

So far I implemented the non-PG2 case. I tried it on a couple of non-PG2 tests (`p3_standalone` and `homme_shoc_cld_spa_p3_rrtmgp`), and it seems to work (meaning that it runs to completion...I have no baselines testing for standalone scream). I will work on the PG2 case next week. Basically, the code will do the same stuff (read on physGLL, remap to dyn, then remap to PG2), but it won't have to create dummy physGLL version of the input fields and add them as "Required" fields jsut so that the AD can add them to the list of fields to read. Instead, the PG2 model init instance will directly access the IC file, and read on GLL grid, without adding any additional field to the main AD field manager.

@AaronDonahue @tcclevenger this is still incomplete (there's no PG2 support!), but I'd like you to start taking a look, to see if the framework makes sense or it is even more confusing than before.

@tcclevenger I would particularly appreciate if you can take a look at how I handle IOP-vs-nonIOP in the init sequence. I hope I am doing things correctly (I haven't tried to run the dp test yet, maybe I should do that first).