### PR TITLE
Add "append" attribute to namelist defaults

### DIFF
--- a/components/eamxx/cime_config/buildlib_cmake
+++ b/components/eamxx/cime_config/buildlib_cmake
@@ -25,9 +25,16 @@ def buildlib(bldroot, installpath, case):
     expect (len(tokens) % 2 == 0, "Error! SCREAM_CMAKE_OPTIONS should contain a string of the form 'option1 value1 option2 value2 ...'\n")
     it = iter(tokens)
 
-    cmake_args = ""
+    # Parse all options and put them in a dict first. This allows to overwrite options via
+    #  ./xmlchange --append SCRAM_CMAKE_OPTIONS="NAME VALUE"
+    # rather than having to reset them all, running ./xmlquery first to see what the others are
+    cmake_args_dict = {}
     for item in it:
-        cmake_args += " -D{}={}".format(item,next(it))
+        cmake_args_dict[item] = next(it)
+
+    cmake_args = ""
+    for k,v in cmake_args_dict.items():
+        cmake_args += f" -D{k}={v}"
 
     atm_dyn_tgt = case.get_value("CAM_TARGET")
     cmake_args += " -DSCREAM_DYN_TARGET={}".format(atm_dyn_tgt)

--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -273,7 +273,7 @@ def evaluate_selectors(element, case, ez_selectors):
                     "Unrecognized value for 'append' attribute\n" +
                     f"  param name  : {child_name}\n" +
                     f"  append value: {append}\n" +
-                    f"  valid values: base, last\n")
+                     "  valid values: base, last\n")
             if selectors:
                 all_match = True
                 had_case_selectors = False

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -252,7 +252,13 @@ be lost if SCREAM_HACK_XML is not enabled.
     </mlcorrection>
 
     <!-- For internal testing only -->
-    <testOnly inherit="atm_proc_base"/>
+    <testOnly inherit="atm_proc_base">
+      <my_param type="array(integer)">1,2</my_param>
+      <my_param nlev="1" append="base">3,4</my_param>
+      <my_param nlev="1" append="last">5,6</my_param>
+      <my_param nlev="2" append="last">3,4</my_param>
+      <my_param nlev="2" append="base">5,6</my_param>
+    </testOnly>
 
     <!-- Simple Prescribed Aerosols (SPA) -->
     <spa inherit="atm_proc_base">

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -191,6 +191,27 @@ class TestBuildnml(unittest.TestCase):
         expect (out2=="true",  "An atm change appears to have been lost during case.setup")
 
     ###########################################################################
+    def test_nml_defaults_append(self):
+    ###########################################################################
+        """
+        Test that the append attribute for array-type params in namelist defaults works as expected
+        """
+        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+
+        # Add testOnly proc
+        self._chg_atmconfig([("mac_aero_mic::atm_procs_list", "shoc,cldFraction,spa,p3,testOnly")], case)
+
+        # Test case 1: append to base, then to last. Should give all 3 entries stacked
+        run_cmd_no_fail(f"./xmlchange --append SCREAM_CMAKE_OPTIONS='SCREAM_NUM_VERTICAL_LEV 1'", from_dir=case)
+        run_cmd_no_fail("./case.setup", from_dir=case)
+        self._get_values(case,"my_param","1,2,3,4,5,6")
+
+        # Test case 2: append to last, then to base. Should give 1st and 3rd entry
+        run_cmd_no_fail(f"./xmlchange --append SCREAM_CMAKE_OPTIONS='SCREAM_NUM_VERTICAL_LEV 2'", from_dir=case)
+        run_cmd_no_fail("./case.setup", from_dir=case)
+        self._get_values(case,"my_param","1,2,5,6")
+
+    ###########################################################################
     def test_append(self):
     ###########################################################################
         """


### PR DESCRIPTION
The new parameter is meant to simplify the input file in case of very long arrays, whose entries depend on case settings. As an example, consider this parameter
```
<my_param type="array(string)">string1, ..., string 10</my_param>
<my_param hgrid="foo">string1, ..., string 10, string11, string12</my_param>
<my_param COMPSET="ONE" hgrid="foo">string1, ..., string 10, string11, string13, string14</my_param>
<my_param COMPSET="TWO" hgrid="foo">string1, ..., string 10, string11, string15, string16</my_param>
<my_param COMPSET="ONE" hgrid="bar">string1, ..., string 10, string12, string13, string14</my_param>
<my_param COMPSET="TWO" hgrid="bar">string1, ..., string 10, string12, string15, string16</my_param>
```
This can easily make the nameslist defaults xml file long. With this PR, we can now do
```
<my_param type="array(string)">string1, ..., string 10</my_param>
<my_param hgrid="foo" append="base">string11</my_param>
<my_param hgrid="bar" append="base">string12</my_param>
<my_param COMPSET="ONE" append="last">string13, string14</my_param>
<my_param COMPSET="TWO" append="last">string15, string16</my_param>
```
The value `append="base"` is probably not needed in most cases (all?), since you can probably rearrange the entries in such a way that `last` will be ok. But I can imagine we may have lots of selectors, with so many combinations that you _may_ want to "reset" to the base case before appending new params, to make life easier. If that never happens, we may consider removing the 'base' version, and only have `append="true"`.

Note: this new attribute is only supported if `type="array(T)"` for some T (I didn't think it made sense for other parameters.