### PR TITLE
EAMxx, Ascent: Work around apparent --fmad=false bug.

### DIFF
--- a/components/eamxx/src/dynamics/homme/CMakeLists.txt
+++ b/components/eamxx/src/dynamics/homme/CMakeLists.txt
@@ -117,7 +117,22 @@ macro (CreateDynamicsLib HOMME_TARGET NP PLEV QSIZE)
     if (HOMME_ENABLE_COMPOSE)
       target_link_libraries (${hommeLibName} composec++)
     endif()
-    SetCudaFlags(${hommeLibName})
+
+    string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_ci)
+    if (CMAKE_BUILD_TYPE_ci STREQUAL "debug")
+      # --fmad=false is causing nondeterminism in RRTMGP on Ascent, perhaps due
+      # to an nvcc bug. Provide a FLAGS entry to prevent SetCudaFlags from
+      # adding --fmad=false. Use -UNDEBUG as an entry for FLAGS so that
+      # cmake_parse_arguments defines it.
+      SetCudaFlags(${hommeLibName} CUDA_LANG FLAGS -UNDEBUG)
+    else()
+      # In the non-debug case, I want to make sure anything else that is done in
+      # SetCudaFlags continues to be done. Right now, I don't think any of it
+      # matters, but given the generality of the name "SetCudaFlags", it's
+      # possible something that matters will be added in the future.
+      SetCudaFlags(${hommeLibName} CUDA_LANG)
+    endif()
+    
     SetOmpFlags(${hommeLibName})
 
     #####################################

--- a/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
@@ -8,6 +8,7 @@ include(ScreamUtils)
 
 # RRTMGP++ requires YAKL
 
+string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_ci)
 if (TARGET yakl)
   # Other E3SM components are building YAKL...
   message ("It appears some other part of E3SM is building YAKL.\n"
@@ -39,16 +40,18 @@ else ()
   EkatDisableAllWarning(yakl)
 
   # For debug builds, set -DYAKL_DEBUG
-  string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_ci)
   if (CMAKE_BUILD_TYPE_ci STREQUAL "debug")
     target_compile_definitions(yakl PUBLIC YAKL_DEBUG)
   endif()
 endif()
 
-# Whether we built yakl or it was already built, we still need to ensure
-# debug builds have --fmad=false in it. The EKAT util automatically sets
-# the flag for debug builds
-SetCudaFlags(yakl CUDA_LANG)
+# See eamxx/src/dynamics/homme/CMakeLists.txt for an explanation of this
+# workaround.
+if (CMAKE_BUILD_TYPE_ci STREQUAL "debug")
+  SetCudaFlags(yakl CUDA_LANG FLAGS -UNDEBUG)
+else()
+  SetCudaFlags(yakl CUDA_LANG)
+endif()
 
 ##################################
 #           RRTMGP               #


### PR DESCRIPTION
Nondeterminism on Ascent in RRMTGP in debug CIME-based tests appears to result from --fmad=false, counterintuitively. Possibly there is a bug in nvcc. In any case, work around this issue.