### PR TITLE
Avoid expensive and pointless stuff in VerticalRemapper constructor

### DIFF
--- a/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
+++ b/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
@@ -66,6 +66,10 @@ FieldLayout PhysicsDynamicsRemapper::
 create_src_layout (const FieldLayout& tgt_layout) const {
   using namespace ShortFieldTagsNames;
 
+  EKAT_REQUIRE_MSG (is_valid_tgt_layout(tgt_layout),
+      "[PhysicsDynamicsRemapper] Error! Input target layout is not valid for this remapper.\n"
+      " - input layout: " + to_string(tgt_layout));
+
   auto tags = tgt_layout.tags();
   auto dims = tgt_layout.dims();
 
@@ -95,6 +99,10 @@ create_src_layout (const FieldLayout& tgt_layout) const {
 FieldLayout PhysicsDynamicsRemapper::
 create_tgt_layout (const FieldLayout& src_layout) const {
   using namespace ShortFieldTagsNames;
+
+  EKAT_REQUIRE_MSG (is_valid_src_layout(src_layout),
+      "[PhysicsDynamicsRemapper] Error! Input source layout is not valid for this remapper.\n"
+      " - input layout: " + to_string(src_layout));
 
   auto tags = src_layout.tags();
   auto dims = src_layout.dims();

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -336,7 +336,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
     auto nudging_weights = create_helper_field("nudging_weights", scalar3d_layout_mid, grid_name, ps);
     std::vector<Field> fields;
     fields.push_back(nudging_weights);
-    AtmosphereInput src_weights_input(m_weights_file, grid_ext, fields);
+    AtmosphereInput src_weights_input(m_weights_file, m_grid, fields);
     src_weights_input.read_variables();
     src_weights_input.finalize();
     nudging_weights.sync_to_dev();

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -40,13 +40,18 @@ int FieldLayout::get_vector_dim () const {
       "       Current layout: " + e2str(get_layout_type(m_tags)) + "\n");
 
   using namespace ShortFieldTagsNames;
-  int idim = -1;
-  if (has_tag(CMP)) {
-    idim = std::distance(m_tags.begin(),ekat::find(m_tags,CMP));
-  } else {
-    EKAT_ERROR_MSG ("Error! Unrecognized layout for a '" + e2str(get_layout_type(m_tags)) + "' quantity.\n");
-  }
-  return idim;
+  std::vector<FieldTag> vec_tags = {CMP,NGAS,SWBND,LWBND,SWGPT,ISCCPTAU,ISCCPPRS};
+  auto it = std::find_first_of (m_tags.cbegin(),m_tags.cend(),vec_tags.cbegin(),vec_tags.cend());
+
+  EKAT_REQUIRE_MSG (it!=m_tags.cend(),
+    "Error! Could not find a vector tag in the layout.\n"
+    " - layout: " + to_string(*this) + "\n");
+
+  return std::distance(m_tags.cbegin(),it);
+}
+
+FieldTag FieldLayout::get_vector_tag () const {
+  return m_tags[get_vector_dim()];
 }
 
 FieldLayout FieldLayout::strip_dim (const FieldTag tag) const {
@@ -129,15 +134,23 @@ LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
 
   // Get the size of what's left
   const auto size = tags.size();
+  auto is_lev_tag = [](const FieldTag t) {
+    std::vector<FieldTag> lev_tags = {LEV,ILEV};
+    return ekat::contains(lev_tags,t);
+  };
+  auto is_vec_tag = [](const FieldTag t) {
+    std::vector<FieldTag> vec_tags = {CMP,NGAS,SWBND,LWBND,SWGPT,ISCCPTAU,ISCCPPRS};
+    return ekat::contains(vec_tags,t);
+  };
   switch (size) {
     case 0:
       result = LayoutType::Scalar2D;
       break;
     case 1:
-      // The only tag left should be 'CMP', 'TL', or 'LEV'/'ILEV'
-      if (tags[0]==CMP || tags[0]==TL) {
+      // The only tag left should be a vec tag, 'TL', or a lev tag
+      if (is_vec_tag(tags[0]) or tags[0]==TL) {
         result = LayoutType::Vector2D;
-      } else if (tags[0]==LEV || tags[0]==ILEV) {
+      } else if (is_lev_tag(tags[0])) {
         result = LayoutType::Scalar3D;
       }
       break;
@@ -145,7 +158,7 @@ LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
       // Possible supported scenarios:
       //  1) <CMP|TL,LEV|ILEV>
       //  2) <TL,CMP>
-      if ( (tags[1]==LEV || tags[1]==ILEV) && (tags[0]==CMP || tags[0]==TL)) {
+      if ( is_lev_tag(tags[1]) and is_vec_tag(tags[0]) ) {
         result = LayoutType::Vector3D;
       } else if (tags[0]==TL && tags[1]==CMP ) {
         result = LayoutType::Tensor2D;

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -158,17 +158,16 @@ LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
       // Possible supported scenarios:
       //  1) <CMP|TL,LEV|ILEV>
       //  2) <TL,CMP>
-      if ( is_lev_tag(tags[1]) and is_vec_tag(tags[0]) ) {
+      if ( (is_vec_tag(tags[0]) or tags[0]==TL) and is_lev_tag(tags[1]) ) {
         result = LayoutType::Vector3D;
-      } else if (tags[0]==TL && tags[1]==CMP ) {
+      } else if (tags[0]==TL && is_vec_tag(tags[1]) ) {
         result = LayoutType::Tensor2D;
       }
       break;
     case 3:
       // The only supported scenario is:
       //  1) <TL,  CMP, LEV|ILEV>
-      if ( tags[0]==TL && tags[1]==CMP &&
-          (tags[2]==LEV || tags[2]==ILEV)) {
+      if ( tags[0]==TL && is_vec_tag(tags[1]) && is_lev_tag(tags[2]) ) {
         result = LayoutType::Tensor3D;
       }
   }

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -100,6 +100,7 @@ public:
   // If this is the layout of a vector field, get the idx of the vector dimension
   // Note: throws if is_vector_layout()==false.
   int get_vector_dim () const;
+  FieldTag get_vector_tag () const;
 
   FieldLayout strip_dim (const FieldTag tag) const;
   FieldLayout strip_dim (const int idim) const;

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -734,6 +734,7 @@ void FieldManager::add_field (const Field& f) {
       "Error! The method 'add_field' requires the input field to be already allocated.\n");
   EKAT_REQUIRE_MSG (m_grid->is_valid_layout(f.get_header().get_identifier().get_layout()),
       "Error! Input field to 'add_field' has a layout not compatible with the stored grid.\n"
+      "  - input field name : " + f.name() + "\n"
       "  - field manager grid: " + m_grid->name() + "\n"
       "  - input field layout:   " + to_string(f.get_header().get_identifier().get_layout()) + "\n");
   EKAT_REQUIRE_MSG (not has_field(f.name()),

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -732,10 +732,10 @@ void FieldManager::add_field (const Field& f) {
       "Error! The method 'add_field' can only be called on a closed repo.\n");
   EKAT_REQUIRE_MSG (f.is_allocated(),
       "Error! The method 'add_field' requires the input field to be already allocated.\n");
-  EKAT_REQUIRE_MSG (f.get_header().get_identifier().get_grid_name()==m_grid->name(),
-      "Error! Input field to 'add_field' is defined on a grid different from the one stored.\n"
+  EKAT_REQUIRE_MSG (m_grid->is_valid_layout(f.get_header().get_identifier().get_layout()),
+      "Error! Input field to 'add_field' has a layout not compatible with the stored grid.\n"
       "  - field manager grid: " + m_grid->name() + "\n"
-      "  - input field grid:   " + f.get_header().get_identifier().get_grid_name() + "\n");
+      "  - input field layout:   " + to_string(f.get_header().get_identifier().get_layout()) + "\n");
   EKAT_REQUIRE_MSG (not has_field(f.name()),
       "Error! The method 'add_field' requires the input field to not be already existing.\n"
       "  - field name: " + f.get_header().get_identifier().name() + "\n");

--- a/components/eamxx/src/share/field/field_tag.hpp
+++ b/components/eamxx/src/share/field/field_tag.hpp
@@ -49,6 +49,7 @@ enum class FieldTag {
 //   using enum FieldTag;
 namespace ShortFieldTagsNames {
 
+  constexpr auto INV  = FieldTag::Invalid;
   constexpr auto EL   = FieldTag::Element;
   constexpr auto COL  = FieldTag::Column;
   constexpr auto GP   = FieldTag::GaussPoint;

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -151,7 +151,8 @@ is_valid_layout (const FieldLayout& layout) const
     case LayoutType::Scalar1D: [[fallthrough]];
     case LayoutType::Vector1D:
       // 1d layouts need the right number of levels
-      return layout.dims().back() == m_num_vert_levs;
+      return layout.dims().back() == m_num_vert_levs or
+             layout.dims().back() == (m_num_vert_levs+1);
     case LayoutType::Scalar2D:
       return layout==get_2d_scalar_layout();
     case LayoutType::Vector2D:

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -141,7 +141,9 @@ is_valid_layout (const FieldLayout& layout) const
 
   const auto lt = get_layout_type(layout.tags());
   const bool midpoints = layout.tags().back()==LEV;
-  const int vec_dim = layout.is_vector_layout() ? layout.dims()[layout.get_vector_dim()] : 0;
+  const bool is_vec = layout.is_vector_layout();
+  const int vec_dim = is_vec ? layout.dims()[layout.get_vector_dim()] : 0;
+  const auto vec_tag = is_vec ? layout.get_vector_tag() : INV;
 
   switch (lt) {
     case LayoutType::Scalar0D: [[fallthrough]];
@@ -156,11 +158,11 @@ is_valid_layout (const FieldLayout& layout) const
     case LayoutType::Scalar2D:
       return layout==get_2d_scalar_layout();
     case LayoutType::Vector2D:
-      return layout==get_2d_vector_layout(CMP,vec_dim);
+      return layout==get_2d_vector_layout(vec_tag,vec_dim);
     case LayoutType::Scalar3D:
       return layout==get_3d_scalar_layout(midpoints);
     case LayoutType::Vector3D:
-      return layout==get_3d_vector_layout(midpoints,CMP,vec_dim);
+      return layout==get_3d_vector_layout(midpoints,vec_tag,vec_dim);
     default:
       // Anything else is probably no
       return false;

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -134,6 +134,38 @@ bool AbstractGrid::is_unique () const {
   return unique_gids;
 }
 
+bool AbstractGrid::
+is_valid_layout (const FieldLayout& layout) const
+{
+  using namespace ShortFieldTagsNames;
+
+  const auto lt = get_layout_type(layout.tags());
+  const bool midpoints = layout.tags().back()==LEV;
+  const int vec_dim = layout.is_vector_layout() ? layout.dims()[layout.get_vector_dim()] : 0;
+
+  switch (lt) {
+    case LayoutType::Scalar0D: [[fallthrough]];
+    case LayoutType::Vector0D:
+      // 0d layouts are compatible with any grid
+      return true;
+    case LayoutType::Scalar1D: [[fallthrough]];
+    case LayoutType::Vector1D:
+      // 1d layouts need the right number of levels
+      return layout.dims().back() == m_num_vert_levs;
+    case LayoutType::Scalar2D:
+      return layout==get_2d_scalar_layout();
+    case LayoutType::Vector2D:
+      return layout==get_2d_vector_layout(CMP,vec_dim);
+    case LayoutType::Scalar3D:
+      return layout==get_3d_scalar_layout(midpoints);
+    case LayoutType::Vector3D:
+      return layout==get_3d_vector_layout(midpoints,CMP,vec_dim);
+    default:
+      // Anything else is probably no
+      return false;
+  }
+}
+
 auto AbstractGrid::
 get_global_min_dof_gid () const ->gid_type
 {

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -256,8 +256,19 @@ AbstractGrid::get_geometry_data_names () const
 void AbstractGrid::reset_num_vertical_lev (const int num_vertical_lev) {
   m_num_vert_levs = num_vertical_lev;
 
-  // TODO: when the PR storing geo data as Field goes in, you should
-  //       invalidate all geo data whose FieldLayout contains LEV/ILEV
+  using namespace ShortFieldTagsNames;
+
+  // Loop over geo data. If they have the LEV or ILEV tag, they are
+  // no longer valid, so we must erase them.
+  for (auto it=m_geo_fields.cbegin(); it!=m_geo_fields.cend(); ) {
+    const auto& fl = it->second.get_header().get_identifier().get_layout();
+    const auto has_lev = fl.has_tag(LEV) or fl.has_tag(ILEV);
+    if (has_lev) {
+      it = m_geo_fields.erase(it);
+    } else {
+      ++it;
+    }
+  }
 }
 
 std::vector<AbstractGrid::gid_type>

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -82,6 +82,9 @@ public:
   // Whether this grid contains unique dof GIDs
   bool is_unique () const;
 
+  // Check if the input layout is compatible with this grid
+  bool is_valid_layout (const FieldLayout& layout) const;
+
   // When running with multiple ranks, fields are partitioned across ranks along this FieldTag
   virtual FieldTag get_partitioned_dim_tag () const = 0;
 

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.cpp
@@ -135,34 +135,6 @@ void AbstractRemapper::remap (const bool forward) {
   }
 }
 
-bool AbstractRemapper::
-is_valid_layout (const layout_type& layout,
-                 const grid_ptr_type& grid) const
-{
-  using namespace ShortFieldTagsNames;
-
-  const auto lt = get_layout_type(layout.tags());
-  const bool midpoints = layout.tags().back()==LEV;
-  const int vec_dim = layout.is_vector_layout() ? layout.dims()[layout.get_vector_dim()] : 0;
-
-  switch (lt) {
-    case LayoutType::Scalar1D: [[fallthrough]];
-    case LayoutType::Vector1D:
-      return layout.dims().back() == grid->get_num_vertical_levels();
-    case LayoutType::Scalar2D:
-      return layout==grid->get_2d_scalar_layout();
-    case LayoutType::Vector2D:
-      return layout==grid->get_2d_vector_layout(CMP,vec_dim);
-    case LayoutType::Scalar3D:
-      return layout==grid->get_3d_scalar_layout(midpoints);
-    case LayoutType::Vector3D:
-      return layout==grid->get_3d_vector_layout(midpoints,CMP,vec_dim);
-    default:
-      // Anything else is probably not supported
-      return false;
-  }
-}
-
 void AbstractRemapper::
 set_grids (const grid_ptr_type& src_grid,
            const grid_ptr_type& tgt_grid)

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.cpp
@@ -13,8 +13,8 @@ AbstractRemapper (const grid_ptr_type& src_grid,
 void AbstractRemapper::
 registration_begins () {
   EKAT_REQUIRE_MSG(m_state==RepoState::Clean,
-                       "Error! Cannot start registration on a non-clean repo.\n"
-                       "       Did you call 'registration_begins' already?\n");
+      "Error! Cannot start registration on a non-clean repo.\n"
+      "       Did you call 'registration_begins' already?\n");
 
   do_registration_begins();
 
@@ -24,19 +24,27 @@ registration_begins () {
 void AbstractRemapper::
 register_field (const identifier_type& src, const identifier_type& tgt) {
   EKAT_REQUIRE_MSG(m_state!=RepoState::Clean,
-                       "Error! Cannot register fields in the remapper at this time.\n"
-                       "       Did you forget to call 'registration_begins' ?");
+      "Error! Cannot register fields in the remapper at this time.\n"
+      "       Did you forget to call 'registration_begins' ?");
   EKAT_REQUIRE_MSG(m_state!=RepoState::Closed,
-                       "Error! Cannot register fields in the remapper at this time.\n"
-                       "       Did you accidentally call 'registration_ends' already?");
+      "Error! Cannot register fields in the remapper at this time.\n"
+      "       Did you accidentally call 'registration_ends' already?");
 
-  EKAT_REQUIRE_MSG(src.get_grid_name()==m_src_grid->name(),
-                       "Error! Source field stores the wrong grid.\n");
-  EKAT_REQUIRE_MSG(tgt.get_grid_name()==m_tgt_grid->name(),
-                       "Error! Target field stores the wrong grid.\n");
+  EKAT_REQUIRE_MSG(is_valid_src_layout(src.get_layout()),
+      "Error! Source field has an invalid layout.\n"
+      " - field name  : " + src.name() + "\n"
+      " - field layout: " + to_string(src.get_layout()) + "\n");
+  EKAT_REQUIRE_MSG(is_valid_tgt_layout(tgt.get_layout()),
+      "Error! Source field has an invalid layout.\n"
+      " - field name  : " + tgt.name() + "\n"
+      " - field layout: " + to_string(tgt.get_layout()) + "\n");
 
   EKAT_REQUIRE_MSG(compatible_layouts(src.get_layout(),tgt.get_layout()),
-                     "Error! Source and target layouts are not compatible.\n");
+      "Error! Source and target layouts are not compatible.\n"
+      " - src name: " + src.name() + "\n"
+      " - tgt name: " + tgt.name() + "\n"
+      " - src layout: " + to_string(src.get_layout()) + "\n"
+      " - tgt layout: " + to_string(tgt.get_layout()) + "\n");
 
   do_register_field (src,tgt);
 
@@ -54,8 +62,8 @@ register_field (const field_type& src, const field_type& tgt) {
 void AbstractRemapper::
 bind_field (const field_type& src, const field_type& tgt) {
   EKAT_REQUIRE_MSG(m_state!=RepoState::Clean,
-                     "Error! Cannot bind fields in the remapper at this time.\n"
-                     "       Did you forget to call 'registration_begins' ?");
+      "Error! Cannot bind fields in the remapper at this time.\n"
+      "       Did you forget to call 'registration_begins' ?");
 
   const auto& src_fid = src.get_header().get_identifier();
   const auto& tgt_fid = tgt.get_header().get_identifier();
@@ -63,16 +71,16 @@ bind_field (const field_type& src, const field_type& tgt) {
   // Try to locate the pair of fields
   const int ifield = find_field(src_fid, tgt_fid);
   EKAT_REQUIRE_MSG(ifield>=0,
-                     "Error! The src/tgt field pair\n"
-                     "         " + src_fid.get_id_string() + "\n"
-                     "         " + tgt_fid.get_id_string() + "\n"
-                     "       was not registered. Please, register fields before binding them.\n");
+      "Error! The src/tgt field pair\n"
+      "         " + src_fid.get_id_string() + "\n"
+      "         " + tgt_fid.get_id_string() + "\n"
+      "       was not registered. Please, register fields before binding them.\n");
 
   EKAT_REQUIRE_MSG(src.is_allocated(), "Error! Source field is not yet allocated.\n");
   EKAT_REQUIRE_MSG(tgt.is_allocated(), "Error! Target field is not yet allocated.\n");
 
   EKAT_REQUIRE_MSG(!m_fields_are_bound[ifield],
-                     "Error! Field " + src_fid.get_id_string() + " already bound.\n");
+      "Error! Field " + src_fid.get_id_string() + " already bound.\n");
 
   do_bind_field(ifield,src,tgt);
 
@@ -91,8 +99,8 @@ bind_field (const field_type& src, const field_type& tgt) {
 void AbstractRemapper::
 registration_ends () {
   EKAT_REQUIRE_MSG(m_state!=RepoState::Closed,
-                       "Error! Cannot call registration_ends at this time.\n"
-                       "       Did you accidentally call 'registration_ends' already?");
+      "Error! Cannot call registration_ends at this time.\n"
+      "       Did you accidentally call 'registration_ends' already?");
 
   m_num_fields = m_num_registered_fields;
 
@@ -103,27 +111,55 @@ registration_ends () {
 
 void AbstractRemapper::remap (const bool forward) {
   EKAT_REQUIRE_MSG(m_state!=RepoState::Open,
-                     "Error! Cannot perform remapping at this time.\n"
-                     "       Did you forget to call 'registration_ends'?\n");
+      "Error! Cannot perform remapping at this time.\n"
+      "       Did you forget to call 'registration_ends'?\n");
 
   EKAT_REQUIRE_MSG(m_num_bound_fields==m_num_fields,
-                     "Error! Not all fields have been set in the remapper.\n"
-                     "       In particular, field " +
+      "Error! Not all fields have been set in the remapper.\n"
+      "       In particular, field " +
                      std::to_string(std::distance(m_fields_are_bound.begin(),std::find(m_fields_are_bound.begin(),m_fields_are_bound.end(),false))) +
-                     " has not been bound.\n");
+      " has not been bound.\n");
 
   if (m_state!=RepoState::Clean) {
     if (forward) {
       EKAT_REQUIRE_MSG (m_fwd_allowed,
-                       "Error! Forward remap is not allowed by this remapper.\n"
-                       "       This means that some fields on the target grid are read-only.\n");
+          "Error! Forward remap is not allowed by this remapper.\n"
+          "       This means that some fields on the target grid are read-only.\n");
       do_remap_fwd ();
     } else {
       EKAT_REQUIRE_MSG (m_bwd_allowed,
-                       "Error! Backward remap is not allowed by this remapper.\n"
-                       "       This means that some fields on the source grid are read-only.\n");
+          "Error! Backward remap is not allowed by this remapper.\n"
+          "       This means that some fields on the source grid are read-only.\n");
       do_remap_bwd ();
     }
+  }
+}
+
+bool AbstractRemapper::
+is_valid_layout (const layout_type& layout,
+                 const grid_ptr_type& grid) const
+{
+  using namespace ShortFieldTagsNames;
+
+  const auto lt = get_layout_type(layout.tags());
+  const bool midpoints = layout.tags().back()==LEV;
+  const int vec_dim = layout.is_vector_layout() ? layout.dims()[layout.get_vector_dim()] : 0;
+
+  switch (lt) {
+    case LayoutType::Scalar1D: [[fallthrough]];
+    case LayoutType::Vector1D:
+      return layout.dims().back() == grid->get_num_vertical_levels();
+    case LayoutType::Scalar2D:
+      return layout==grid->get_2d_scalar_layout();
+    case LayoutType::Vector2D:
+      return layout==grid->get_2d_vector_layout(CMP,vec_dim);
+    case LayoutType::Scalar3D:
+      return layout==grid->get_3d_scalar_layout(midpoints);
+    case LayoutType::Vector3D:
+      return layout==grid->get_3d_vector_layout(midpoints,CMP,vec_dim);
+    default:
+      // Anything else is probably not supported
+      return false;
   }
 }
 

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
@@ -77,7 +77,7 @@ public:
   // during field registration).
   const identifier_type& get_src_field_id (const int ifield) const {
     EKAT_REQUIRE_MSG(ifield>=0 && ifield<m_num_registered_fields,
-                       "Error! Field index out of bounds.\n");
+        "Error! Field index out of bounds.\n");
     return do_get_src_field_id(ifield);
   }
 
@@ -85,25 +85,25 @@ public:
   // during field registration).
   const identifier_type& get_tgt_field_id (const int ifield) const {
     EKAT_REQUIRE_MSG(ifield>=0 && ifield<m_num_registered_fields,
-                       "Error! Field index out of bounds.\n");
+        "Error! Field index out of bounds.\n");
     return do_get_tgt_field_id(ifield);
   }
 
   // Returns the source field for the given field index.
   const field_type& get_src_field (const int ifield) const {
     EKAT_REQUIRE_MSG(m_state==RepoState::Closed,
-                       "Error! Cannot call 'get_src_field' until registration has ended.\n");
+        "Error! Cannot call 'get_src_field' until registration has ended.\n");
     EKAT_REQUIRE_MSG(ifield>=0 && ifield<m_num_registered_fields,
-                       "Error! Field index out of bounds.\n");
+        "Error! Field index out of bounds.\n");
     return do_get_src_field(ifield);
   }
 
   // Returns the target field for the given field index.
   const field_type& get_tgt_field (const int ifield) const {
     EKAT_REQUIRE_MSG(m_state==RepoState::Closed,
-                       "Error! Cannot call 'get_tgt_field' until registration has ended.\n");
+        "Error! Cannot call 'get_tgt_field' until registration has ended.\n");
     EKAT_REQUIRE_MSG(ifield>=0 && ifield<m_num_registered_fields,
-                       "Error! Field index out of bounds.\n");
+        "Error! Field index out of bounds.\n");
     return do_get_tgt_field(ifield);
   }
 
@@ -164,7 +164,17 @@ public:
     return src==tgt;
   }
 
+  virtual bool is_valid_src_layout (const layout_type& layout) const {
+    return is_valid_layout(layout,m_src_grid);
+  }
+  virtual bool is_valid_tgt_layout (const layout_type& layout) const {
+    return is_valid_layout(layout,m_tgt_grid);
+  }
+
 protected:
+
+  bool is_valid_layout (const layout_type& layout,
+                        const grid_ptr_type& grid) const;
 
   void set_grids (const grid_ptr_type& src_grid,
                   const grid_ptr_type& tgt_grid);

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
@@ -165,16 +165,13 @@ public:
   }
 
   virtual bool is_valid_src_layout (const layout_type& layout) const {
-    return is_valid_layout(layout,m_src_grid);
+    return m_src_grid->is_valid_layout(layout);
   }
   virtual bool is_valid_tgt_layout (const layout_type& layout) const {
-    return is_valid_layout(layout,m_tgt_grid);
+    return m_tgt_grid->is_valid_layout(layout);
   }
 
 protected:
-
-  bool is_valid_layout (const layout_type& layout,
-                        const grid_ptr_type& grid) const;
 
   void set_grids (const grid_ptr_type& src_grid,
                   const grid_ptr_type& tgt_grid);

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
@@ -111,11 +111,6 @@ public:
   virtual FieldLayout create_tgt_layout (const FieldLayout& src_layout) const = 0;
 
   FieldIdentifier create_src_fid (const FieldIdentifier& tgt_fid) const {
-    EKAT_REQUIRE_MSG (tgt_fid.get_grid_name()==m_tgt_grid->name(),
-        "Error! Input FieldIdentifier has the wrong grid name:\n"
-        "   - input tgt fid grid name: " + tgt_fid.get_grid_name() + "\n"
-        "   - remapper tgt grid name:  " + m_tgt_grid->name() + "\n");
-
     const auto& name = tgt_fid.name();
     const auto& layout = create_src_layout(tgt_fid.get_layout());
     const auto& units = tgt_fid.get_units();
@@ -124,11 +119,6 @@ public:
   }
 
   FieldIdentifier create_tgt_fid (const FieldIdentifier& src_fid) const {
-    EKAT_REQUIRE_MSG (src_fid.get_grid_name()==m_src_grid->name(),
-        "Error! Input FieldIdentifier has the wrong grid name:\n"
-        "   - input src fid grid name: " + src_fid.get_grid_name() + "\n"
-        "   - remapper src grid name:  " + m_src_grid->name() + "\n");
-
     const auto& name = src_fid.name();
     const auto& layout = create_tgt_layout(src_fid.get_layout());
     const auto& units = src_fid.get_units();

--- a/components/eamxx/src/share/grid/remap/do_nothing_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/do_nothing_remapper.hpp
@@ -37,6 +37,10 @@ public:
   FieldLayout create_src_layout (const FieldLayout& tgt) const override {
     using namespace ShortFieldTagsNames;
 
+    EKAT_REQUIRE_MSG (is_valid_tgt_layout(tgt),
+        "[DoNothingRemapper] Error! Input target layout is not valid for this remapper.\n"
+        " - input layout: " + to_string(tgt));
+
     auto type = get_layout_type(tgt.tags());
     FieldLayout src = {{}};
     switch (type) {
@@ -60,6 +64,10 @@ public:
 
   FieldLayout create_tgt_layout (const FieldLayout& src) const override {
     using namespace ShortFieldTagsNames;
+
+    EKAT_REQUIRE_MSG (is_valid_src_layout(src),
+        "[DoNothingRemapper] Error! Input source layout is not valid for this remapper.\n"
+        " - input layout: " + to_string(src));
 
     auto type = get_layout_type(src.tags());
     FieldLayout tgt = {{}};

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -21,7 +21,7 @@ HorizInterpRemapperBase (const grid_ptr_type& fine_grid,
 {
   // Sanity checks
   EKAT_REQUIRE_MSG (fine_grid->type()==GridType::Point,
-      "Error! CoarseningRemapper only works on PointGrid grids.\n"
+      "Error! Horizontal interpolatory remap only works on PointGrid grids.\n"
       "  - fine grid name: " + fine_grid->name() + "\n"
       "  - fine_grid_type: " + e2str(fine_grid->type()) + "\n");
   EKAT_REQUIRE_MSG (fine_grid->is_unique(),
@@ -54,6 +54,10 @@ create_src_layout (const FieldLayout& tgt_layout) const
   EKAT_REQUIRE_MSG (m_src_grid!=nullptr,
       "Error! Cannot create source layout until the source grid has been set.\n");
 
+  EKAT_REQUIRE_MSG (is_valid_tgt_layout(tgt_layout),
+      "[HorizInterpRemapperBase] Error! Input target layout is not valid for this remapper.\n"
+      " - input layout: " + to_string(tgt_layout));
+
   using namespace ShortFieldTagsNames;
   const auto lt = get_layout_type(tgt_layout.tags());
   const bool midpoints = tgt_layout.has_tag(LEV);
@@ -83,6 +87,10 @@ create_tgt_layout (const FieldLayout& src_layout) const
 {
   EKAT_REQUIRE_MSG (m_tgt_grid!=nullptr,
       "Error! Cannot create target layout until the target grid has been set.\n");
+
+  EKAT_REQUIRE_MSG (is_valid_src_layout(src_layout),
+      "[HorizInterpRemapperBase] Error! Input source layout is not valid for this remapper.\n"
+      " - input layout: " + to_string(src_layout));
 
   using namespace ShortFieldTagsNames;
   const auto lt = get_layout_type(src_layout.tags());

--- a/components/eamxx/src/share/grid/remap/identity_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/identity_remapper.hpp
@@ -36,10 +36,18 @@ public:
   ~IdentityRemapper () = default;
 
   FieldLayout create_src_layout (const FieldLayout& tgt_layout) const override {
+    EKAT_REQUIRE_MSG (is_valid_tgt_layout(tgt_layout),
+        "[IdentityRemapper] Error! Input target layout is not valid for this remapper.\n"
+        " - input layout: " + to_string(tgt_layout));
+
     // Src and tgt grids are the same, so return the input
     return tgt_layout;
   }
   FieldLayout create_tgt_layout (const FieldLayout& src_layout) const override {
+    EKAT_REQUIRE_MSG (is_valid_src_layout(src_layout),
+        "[IdentityRemapper] Error! Input source layout is not valid for this remapper.\n"
+        " - input layout: " + to_string(src_layout));
+
     // Src and tgt grids are the same, so return the input
     return src_layout;
   }

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -74,6 +74,11 @@ FieldLayout VerticalRemapper::
 create_src_layout (const FieldLayout& tgt_layout) const
 {
   using namespace ShortFieldTagsNames;
+
+  EKAT_REQUIRE_MSG (is_valid_tgt_layout(tgt_layout),
+      "[VerticalRemapper] Error! Input target layout is not valid for this remapper.\n"
+      " - input layout: " + to_string(tgt_layout));
+
   const auto lt = get_layout_type(tgt_layout.tags());
   auto src = FieldLayout::invalid();
   const bool midpoints = tgt_layout.has_tag(LEV);
@@ -100,6 +105,11 @@ FieldLayout VerticalRemapper::
 create_tgt_layout (const FieldLayout& src_layout) const
 {
   using namespace ShortFieldTagsNames;
+
+  EKAT_REQUIRE_MSG (is_valid_src_layout(src_layout),
+      "[VerticalRemapper] Error! Input source layout is not valid for this remapper.\n"
+      " - input layout: " + to_string(src_layout));
+
   const auto lt = get_layout_type(src_layout.tags());
   auto tgt = FieldLayout::invalid();
   const bool midpoints = true; //src_layout.has_tag(LEV);

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -56,12 +56,8 @@ VerticalRemapper (const grid_ptr_type& src_grid,
   scorpio::register_file(map_file,scorpio::FileMode::Read);
   m_num_remap_levs = scorpio::get_dimlen(map_file,"lev");
 
-  auto tgt_grid_gids = src_grid->get_unique_gids();
-  const int ngids = tgt_grid_gids.size();
-  auto tgt_grid = std::make_shared<PointGrid>("vertical_remap_tgt_grid",ngids,m_num_remap_levs,m_comm);
-  auto tgt_grid_gids_h = tgt_grid->get_dofs_gids().get_view<gid_type*,Host>();
-  std::memcpy(tgt_grid_gids_h.data(),tgt_grid_gids.data(),ngids*sizeof(gid_type));
-  tgt_grid->get_dofs_gids().sync_to_dev();
+  auto tgt_grid = src_grid->clone("vertical_remap_tgt_grid",true);
+  tgt_grid->reset_num_vertical_lev(m_num_remap_levs);
   this->set_grids(src_grid,tgt_grid);
 
   // Replicate the src grid geo data in the tgt grid.
@@ -79,7 +75,6 @@ VerticalRemapper (const grid_ptr_type& src_grid,
       tgt_data.deep_copy(src_data);
     } 
   }
-
 
   // Set the LEV and ILEV vertical profiles for interpolation from
   register_vertical_source_field(lev_prof,"mid");

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -60,22 +60,6 @@ VerticalRemapper (const grid_ptr_type& src_grid,
   tgt_grid->reset_num_vertical_lev(m_num_remap_levs);
   this->set_grids(src_grid,tgt_grid);
 
-  // Replicate the src grid geo data in the tgt grid.
-  const auto& src_geo_data_names = src_grid->get_geometry_data_names();
-  for (const auto& name : src_geo_data_names) {
-    const auto& src_data = src_grid->get_geometry_data(name);
-    const auto& src_data_fid = src_data.get_header().get_identifier();
-    const auto& layout = src_data_fid.get_layout();
-    // We only add geo data that is horizontal in nature,  vertical geo data won't be added because the vertical structure
-    // has a rigid definition already.
-    if (layout.tags().back()!=LEV && layout.tags().back()!=ILEV) {
-      // Simply copy it in the tgt grid, but we still need to assign the new grid name.
-      FieldIdentifier tgt_data_fid(src_data_fid.name(),src_data_fid.get_layout(),src_data_fid.get_units(),m_tgt_grid->name());
-      auto tgt_data = tgt_grid->create_geometry_data(tgt_data_fid);
-      tgt_data.deep_copy(src_data);
-    } 
-  }
-
   // Set the LEV and ILEV vertical profiles for interpolation from
   register_vertical_source_field(lev_prof);
   register_vertical_source_field(ilev_prof);

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -70,7 +70,7 @@ public:
 
 protected:
 
-  void register_vertical_source_field(const Field& src, const std::string& mode);
+  void register_vertical_source_field(const Field& src);
 
   const identifier_type& do_get_src_field_id (const int ifield) const override {
     return m_src_fields[ifield].get_header().get_identifier();


### PR DESCRIPTION
We don't need to create a whole new grid as our tgt grid, and we also don't need to find out which gids in the src grid are unique. All we need is a shallow clone of the src grid, resetting the number of vert levs.