### PR TITLE
EAMxx: See if removing --fmad=false fixes nondeterminism in pm-gpu nightlies.

### DIFF
--- a/components/eamxx/src/dynamics/homme/CMakeLists.txt
+++ b/components/eamxx/src/dynamics/homme/CMakeLists.txt
@@ -119,11 +119,13 @@ macro (CreateDynamicsLib HOMME_TARGET NP PLEV QSIZE)
     endif()
 
     string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_ci)
-    if (SCREAM_MACHINE STREQUAL "ascent" AND CMAKE_BUILD_TYPE_ci STREQUAL "debug")
+    if (CMAKE_BUILD_TYPE_ci STREQUAL "debug")
       # --fmad=false is causing nondeterminism in RRTMGP on Ascent, perhaps due
       # to an nvcc bug. Provide a FLAGS entry to prevent SetCudaFlags from
       # adding --fmad=false. Use -UNDEBUG as an (inert) entry for FLAGS so that
-      # cmake_parse_arguments defines SCF_FLAGS.
+      # cmake_parse_arguments defines SCF_FLAGS. Update: I'm checking if this
+      # fixes the nondeterminism on pm-gpu and am thus removing the condition
+      #     SCREAM_MACHINE STREQUAL "ascent".
       SetCudaFlags(${hommeLibName} CUDA_LANG FLAGS -UNDEBUG)
     else()
       # In the non-debug case, I want to make sure anything else that is done in

--- a/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 
 # See eamxx/src/dynamics/homme/CMakeLists.txt for an explanation of this
 # workaround.
-if (SCREAM_MACHINE STREQUAL "ascent" AND CMAKE_BUILD_TYPE_ci STREQUAL "debug")
+if (CMAKE_BUILD_TYPE_ci STREQUAL "debug")
   SetCudaFlags(yakl CUDA_LANG FLAGS -UNDEBUG)
 else()
   SetCudaFlags(yakl CUDA_LANG)


### PR DESCRIPTION
pm-gpu is showing nondeterminism in debug builds. Try the `--fmad=false` fix that works on Ascent. I'm not going to do any analysis on pm-gpu right now; I'm just seeing if I get lucky.