### PR TITLE
Add option to output a field at height above the surface.

### DIFF
--- a/components/eamxx/src/diagnostics/field_at_height.cpp
+++ b/components/eamxx/src/diagnostics/field_at_height.cpp
@@ -42,8 +42,9 @@ FieldAtHeight (const ekat::Comm& comm, const ekat::ParameterList& params)
   EKAT_REQUIRE_MSG(surf_ref == "sealevel" or surf_ref == "surface",
       "Error! Invalid surface reference for FieldAtHeight.\n"
       " -        field name: " + m_field_name + "\n"
-      " - surface reference: " + surf_ref + "\n");
-  m_surf_ref = (surf_ref == "sealevel") ? "z" : "geopotential";
+      " - surface reference: " + surf_ref + "\n"
+      " -     valid options: sealevel, surface\n");
+  m_z_name = (surf_ref == "sealevel") ? "z" : "geopotential";
   const auto& location = m_params.get<std::string>("vertical_location");
   auto chars_start = location.find_first_not_of("0123456789.");
   EKAT_REQUIRE_MSG (chars_start!=0 && chars_start!=std::string::npos,
@@ -68,8 +69,8 @@ set_grids (const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>(m_field_name,gname);
 
   // We don't know yet which one we need
-  add_field<Required>(m_surf_ref+"_mid",gname);
-  add_field<Required>(m_surf_ref+"_int",gname);
+  add_field<Required>(m_z_name+"_mid",gname);
+  add_field<Required>(m_z_name+"_int",gname);
 }
 
 void FieldAtHeight::
@@ -96,7 +97,7 @@ initialize_impl (const RunType /*run_type*/)
       " - field layout: " + to_string(layout) + "\n");
 
   // Figure out the z value
-  m_z_name = tag==LEV ? m_surf_ref+"_mid" : m_surf_ref+"_int";
+  m_z_suffix = tag==LEV ? "_mid" : "_int";
 
   // All good, create the diag output
   FieldIdentifier d_fid (m_diag_name,layout.strip_dim(tag),fid.get_units(),fid.get_grid_name());
@@ -117,7 +118,7 @@ initialize_impl (const RunType /*run_type*/)
 // =========================================================================================
 void FieldAtHeight::compute_diagnostic_impl()
 {
-  const auto z_view = get_field_in(m_z_name).get_view<const Real**>();
+  const auto z_view = get_field_in(m_z_name + m_z_suffix).get_view<const Real**>();
   const Field& f = get_field_in(m_field_name);
   const auto& fl = f.get_header().get_identifier().get_layout();
 

--- a/components/eamxx/src/diagnostics/field_at_height.cpp
+++ b/components/eamxx/src/diagnostics/field_at_height.cpp
@@ -38,6 +38,12 @@ FieldAtHeight (const ekat::Comm& comm, const ekat::ParameterList& params)
  : AtmosphereDiagnostic(comm,params)
 {
   m_field_name = m_params.get<std::string>("field_name");
+  auto surf_ref = m_params.get<std::string>("surface_reference");
+  EKAT_REQUIRE_MSG(surf_ref == "sealevel" or surf_ref == "surface",
+      "Error! Invalid surface reference for FieldAtHeight.\n"
+      " -        field name: " + m_field_name + "\n"
+      " - surface reference: " + surf_ref + "\n");
+  m_surf_ref = (surf_ref == "sealevel") ? "z" : "geopotential";
   const auto& location = m_params.get<std::string>("vertical_location");
   auto chars_start = location.find_first_not_of("0123456789.");
   EKAT_REQUIRE_MSG (chars_start!=0 && chars_start!=std::string::npos,
@@ -52,7 +58,7 @@ FieldAtHeight (const ekat::Comm& comm, const ekat::ParameterList& params)
       "Error! Invalid string for height value for FieldAtHeight.\n"
       " - input string   : " + location + "\n"
       " - expected format: Nm, with N integer\n");
-  m_diag_name = m_field_name + "_at_" + m_params.get<std::string>("vertical_location");
+  m_diag_name = m_field_name + "_at_" + m_params.get<std::string>("vertical_location") + "_above_" + surf_ref;
 }
 
 void FieldAtHeight::
@@ -62,8 +68,8 @@ set_grids (const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>(m_field_name,gname);
 
   // We don't know yet which one we need
-  add_field<Required>("z_mid",gname);
-  add_field<Required>("z_int",gname);
+  add_field<Required>(m_surf_ref+"_mid",gname);
+  add_field<Required>(m_surf_ref+"_int",gname);
 }
 
 void FieldAtHeight::
@@ -90,7 +96,7 @@ initialize_impl (const RunType /*run_type*/)
       " - field layout: " + to_string(layout) + "\n");
 
   // Figure out the z value
-  m_z_name = tag==LEV ? "z_mid" : "z_int";
+  m_z_name = tag==LEV ? m_surf_ref+"_mid" : m_surf_ref+"_int";
 
   // All good, create the diag output
   FieldIdentifier d_fid (m_diag_name,layout.strip_dim(tag),fid.get_units(),fid.get_grid_name());

--- a/components/eamxx/src/diagnostics/field_at_height.hpp
+++ b/components/eamxx/src/diagnostics/field_at_height.hpp
@@ -33,6 +33,7 @@ protected:
 
   std::string         m_diag_name;
   std::string         m_z_name;
+  std::string         m_surf_ref;
   std::string         m_field_name;
 
   Real                m_z;

--- a/components/eamxx/src/diagnostics/field_at_height.hpp
+++ b/components/eamxx/src/diagnostics/field_at_height.hpp
@@ -33,7 +33,7 @@ protected:
 
   std::string         m_diag_name;
   std::string         m_z_name;
-  std::string         m_surf_ref;
+  std::string         m_z_suffix;
   std::string         m_field_name;
 
   Real                m_z;

--- a/components/eamxx/src/diagnostics/tests/field_at_height_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_height_tests.cpp
@@ -145,6 +145,14 @@ TEST_CASE("field_at_height")
     // z[ilev] = nlevs-ilev, so the tgt slice is nlevs-z_tgt
     lev_tgt = nlevs-z_tgt;
 
+    // Make sure that an unsupported reference height throws an error.
+    print(" -> Testing throws error with unsupported reference height...\n");
+    {
+      REQUIRE_THROWS(run_diag (s_mid,z_mid,loc,"foobar"));
+    }
+    print(" -> Testing throws error with unsupported reference height... OK\n");
+
+
     print(" -> Testing with z_tgt coinciding with a z level\n");
     {
       print("    -> scalar midpoint field...............\n");

--- a/components/eamxx/src/diagnostics/tests/field_at_height_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_height_tests.cpp
@@ -110,7 +110,7 @@ TEST_CASE("field_at_height")
     const auto& dims = f.get_header().get_identifier().get_layout().dims();
     for (int i=0; i<dims[0]; ++i) {
       for (int j=0; j<dims[1]; ++j) {
-        v(i,j) = dims[1]-j;
+        v(i,j) = dims[1]-j+i;
       }
     };
     f.sync_to_dev();
@@ -121,7 +121,7 @@ TEST_CASE("field_at_height")
     const auto& dims = f.get_header().get_identifier().get_layout().dims();
     for (int i=0; i<dims[0]; ++i) {
       for (int j=0; j<dims[1]; ++j) {
-        v(i,j) = dims[1]-j+i;
+        v(i,j) = dims[1]-j;
       }
     };
     f.sync_to_dev();
@@ -151,7 +151,7 @@ TEST_CASE("field_at_height")
     // Make sure that an unsupported reference height throws an error.
     print(" -> Testing throws error with unsupported reference height...\n");
     {
-      REQUIRE_THROWS(run_diag (s_mid,z_mid,loc,"foobar"));
+      REQUIRE_THROWS(run_diag (s_mid,geo_mid,loc,"foobar"));
     }
     print(" -> Testing throws error with unsupported reference height... OK\n");
 
@@ -159,41 +159,41 @@ TEST_CASE("field_at_height")
     print(" -> Testing with z_tgt coinciding with a z level\n");
     {
       print("    -> scalar midpoint field...............\n");
-      auto d = run_diag (s_mid,z_mid,loc,"sealevel");
-      auto tgt = get_ref_field(lev_tgt,s_mid,"sealevel");
+      auto d = run_diag (s_mid,geo_mid,loc,"surface");
+      auto tgt = get_ref_field(lev_tgt,s_mid,"surface");
       REQUIRE (views_are_equal(d,tgt,&comm));
       print("    -> scalar midpoint field............... OK!\n");
     }
     {
       print("    -> scalar interface field...............\n");
-      auto d = run_diag (s_int,z_int,loc,"sealevel");
-      // z_int = nlevs+1-ilev, so the tgt slice is nlevs+1-z_tgt
-      auto tgt = get_ref_field(lev_tgt+1,s_int,"sealevel");
+      auto d = run_diag (s_int,geo_int,loc,"surface");
+      // geo_int = nlevs+1-ilev, so the tgt slice is nlevs+1-z_tgt
+      auto tgt = get_ref_field(lev_tgt+1,s_int,"surface");
       REQUIRE (views_are_equal(d,tgt,&comm));
       print("    -> scalar interface field............... OK!\n");
     }
     {
       print("    -> vector midpoint field...............\n");
-      auto d = run_diag (v_mid,z_mid,loc,"sealevel");
+      auto d = run_diag (v_mid,geo_mid,loc,"surface");
       // We can't subview over 3rd index and keep layout right,
       // so do all cols separately
       for (int i=0; i<ncols; ++i) {
         auto fi = v_mid.subfield(0,i);
         auto di = d.subfield(0,i);
-        auto tgt = get_ref_field(lev_tgt,fi,"sealevel");
+        auto tgt = get_ref_field(lev_tgt,fi,"surface");
         REQUIRE (views_are_equal(di,tgt,&comm));
       }
       print("    -> vector midpoint field............... OK!\n");
     }
     {
       print("    -> vector interface field...............\n");
-      auto d = run_diag (v_int,z_int,loc,"sealevel");
+      auto d = run_diag (v_int,geo_int,loc,"surface");
       // We can't subview over 3rd index and keep layout right,
       // so do all cols separately
       for (int i=0; i<ncols; ++i) {
         auto fi = v_int.subfield(0,i);
         auto di = d.subfield(0,i);
-        auto tgt = get_ref_field(lev_tgt+1,fi,"sealevel");
+        auto tgt = get_ref_field(lev_tgt+1,fi,"surface");
         REQUIRE (views_are_equal(di,tgt,&comm));
       }
       print("    -> vector interface field............... OK!\n");
@@ -209,40 +209,40 @@ TEST_CASE("field_at_height")
     print(" -> Testing with z_tgt between levels\n");
     {
       print("    -> scalar midpoint field...............\n");
-      auto d = run_diag (s_mid,z_mid,loc,"sealevel");
-      auto tgt = get_ref_field(zm1,zp1,s_mid,"sealevel");
+      auto d = run_diag (s_mid,geo_mid,loc,"surface");
+      auto tgt = get_ref_field(zm1,zp1,s_mid,"surface");
       REQUIRE (views_are_equal(d,tgt,&comm));
       print("    -> scalar midpoint field............... OK!\n");
     }
     {
       print("    -> scalar interface field...............\n");
-      auto d = run_diag (s_int,z_int,loc,"sealevel");
-      auto tgt = get_ref_field(zm1+1,zp1+1,s_int,"sealevel");
+      auto d = run_diag (s_int,geo_int,loc,"surface");
+      auto tgt = get_ref_field(zm1+1,zp1+1,s_int,"surface");
       REQUIRE (views_are_equal(d,tgt,&comm));
       print("    -> scalar interface field............... OK!\n");
     }
     {
       print("    -> vector midpoint field...............\n");
-      auto d = run_diag (v_mid,z_mid,loc,"sealevel");
+      auto d = run_diag (v_mid,geo_mid,loc,"surface");
       // We can't subview over 3rd index and keep layout right,
       // so do all cols separately
       for (int i=0; i<ncols; ++i) {
         auto fi = v_mid.subfield(0,i);
         auto di = d.subfield(0,i);
-        auto tgt = get_ref_field(zm1,zp1,fi,"sealevel");
+        auto tgt = get_ref_field(zm1,zp1,fi,"surface");
         REQUIRE (views_are_equal(di,tgt,&comm));
       }
       print("    -> vector midpoint field............... OK!\n");
     }
     {
       print("    -> vector interface field...............\n");
-      auto d = run_diag (v_int,z_int,loc,"sealevel");
+      auto d = run_diag (v_int,geo_int,loc,"surface");
       // We can't subview over 3rd index and keep layout right,
       // so do all cols separately
       for (int i=0; i<ncols; ++i) {
         auto fi = v_int.subfield(0,i);
         auto di = d.subfield(0,i);
-        auto tgt = get_ref_field(zm1+1,zp1+1,fi,"sealevel");
+        auto tgt = get_ref_field(zm1+1,zp1+1,fi,"surface");
         REQUIRE (views_are_equal(di,tgt,&comm));
       }
       print("    -> vector interface field............... OK!\n");
@@ -254,7 +254,7 @@ TEST_CASE("field_at_height")
 Field get_ref_field(const int lev, const Field& src_data, const std::string& surf_ref)
 {
   // A single level implies this is a test where the height matches a single level.
-  if (surf_ref == "sealevel") {
+  if (surf_ref == "surface") {
     return src_data.subfield(1,static_cast<int>(lev));
   }
 }
@@ -262,7 +262,7 @@ Field get_ref_field(const int lev, const Field& src_data, const std::string& sur
 Field get_ref_field(const int levm, const int levp, const Field& src_data, const std::string& surf_ref)
 {
   // Two levels implies this is a test where the height is midway between two levels
-  if (surf_ref == "sealevel") {
+  if (surf_ref == "surface") {
     auto tgt = src_data.subfield(1,levp).clone();
     tgt.update(src_data.subfield(1,levm),0.5,0.5);
     return tgt;

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1279,7 +1279,7 @@ AtmosphereOutput::create_diagnostic (const std::string& diag_field_name) {
       }
       if (units=="m") {
         diag_name = "FieldAtHeight";
-	EKAT_REQUIRE_MSG(params.isParameter("surface_reference"),"Error! Output field request for " + diag_field_name + "is missing a surface reference."
+	EKAT_REQUIRE_MSG(params.isParameter("surface_reference"),"Error! Output field request for " + diag_field_name + " is missing a surface reference."
 			"  Please add either '_above_sealevel' or '_above_surface' to the field name");
       } else if (units=="mb" or units=="Pa" or units=="hPa") {
         diag_name = "FieldAtPressureLevel";

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/output.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/output.yaml
@@ -68,6 +68,15 @@ Fields:
       - sfc_flux_sw_net
       - EAMxx_T_mid_tend
       - EAMxx_qv_tend
+      # Sliced Output
+      - T_mid_at_2m_above_surface
+      - T_mid_at_1000m_above_sealevel
+      - T_mid_at_500hPa
+      - T_mid_at_50000Pa
+      - T_mid_at_500mb
+      - T_mid_at_model_top
+      - T_mid_at_model_bot
+      - T_mid_at_lev_10
  
 output_control:
   Frequency: 1

--- a/components/eamxx/tests/uncoupled/p3/output.yaml
+++ b/components/eamxx/tests/uncoupled/p3/output.yaml
@@ -4,7 +4,7 @@ filename_prefix: p3_standalone_output
 Averaging Type: Instant
 Field Names:
   - T_mid
-  - T_mid_at_2m
+  - T_mid_at_2m_above_sealevel
   - T_prev_micro_step
   - qv
   - qc


### PR DESCRIPTION
The current implementation of FieldAtHeight assumes the user wants to output the field at a specific height above sealevel.  In practice this means the reference height used for interpolation is either z_mid or z_int.

It is likely that users would also like the option to output a field at a specific height above the surface, for example the 2 meter temperature.

This commit adds that capability by including a reference surface to the FieldAtHeight diagnostic.  This can either be "sealevel" or "surface". If a user specifies "sealevel" then z_mid or z_int are used as the level heights.  If a user specifies "surface" than geopotential_mid or geopotential_int are used instead.

This is controlled by the diagnostic name.  The old way to trigger a FieldAtHeight was to list the variable X at N meters like follows:
  - X_at_Nm
  
 The new approach allows for

  - X_at_Nm_above_sealevel, or
  - X_at_Nm_above_surface.

If a user still uses the old way without specifying "above_Y" then it defaults to "sealevel" and prints a warning to the ATM log.