### PR TITLE
expose p3 parameters

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -206,6 +206,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <p3_pre_autoconversion_factor type="real" doc="P3 pre_autoconversion_factor">1350.0</p3_pre_autoconversion_factor>
       <p3_mu_r_constant type="real" doc="P3 mu_r_constant">1.0</p3_mu_r_constant>
       <p3_spa_to_nc type="real" doc="P3 spa_to_nc">1.0</p3_spa_to_nc>
+      <p3_k_accretion type="real" doc="P3 k_accretion">67.0</p3_k_accretion>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -207,6 +207,11 @@ be lost if SCREAM_HACK_XML is not enabled.
       <p3_mu_r_constant type="real" doc="P3 mu_r_constant">1.0</p3_mu_r_constant>
       <p3_spa_to_nc type="real" doc="P3 spa_to_nc">1.0</p3_spa_to_nc>
       <p3_k_accretion type="real" doc="P3 k_accretion">67.0</p3_k_accretion>
+      <p3_eci type="real" doc="P3 eci">0.5</p3_eci>
+      <p3_eri type="real" doc="P3 eri">1.0</p3_eri>
+      <p3_rho_rime_min type="real" doc="P3 rho_rime_min">50.0</p3_rho_rime_min>
+      <p3_rho_rime_max type="real" doc="P3 rho_rime_max">900.0</p3_rho_rime_max>
+      <p3_a_imm type="real" doc="P3 a_imm">0.65</p3_a_imm>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -203,7 +203,7 @@ be lost if SCREAM_HACK_XML is not enabled.
         ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
         ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8
       </tables>
-      <p3_autoconversion_factor type="real" doc="P3 autoconversion factor">1350.0</p3_autoconversion_factor>
+      <p3_pre_autoconversion_factor type="real" doc="P3 pre_autoconversion_factor">1350.0</p3_pre_autoconversion_factor>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -203,15 +203,15 @@ be lost if SCREAM_HACK_XML is not enabled.
         ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
         ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8
       </tables>
-      <p3_pre_autoconversion_factor type="real" doc="P3 pre_autoconversion_factor">1350.0</p3_pre_autoconversion_factor>
-      <p3_mu_r_constant type="real" doc="P3 mu_r_constant">1.0</p3_mu_r_constant>
-      <p3_spa_to_nc type="real" doc="P3 spa_to_nc">1.0</p3_spa_to_nc>
-      <p3_k_accretion type="real" doc="P3 k_accretion">67.0</p3_k_accretion>
-      <p3_eci type="real" doc="P3 eci">0.5</p3_eci>
-      <p3_eri type="real" doc="P3 eri">1.0</p3_eri>
-      <p3_rho_rime_min type="real" doc="P3 rho_rime_min">50.0</p3_rho_rime_min>
-      <p3_rho_rime_max type="real" doc="P3 rho_rime_max">900.0</p3_rho_rime_max>
-      <p3_a_imm type="real" doc="P3 a_imm">0.65</p3_a_imm>
+      <p3_pre_autoconversion_factor type="real" doc="P3 pre_autoconversion_factor (scale factor in autoconversion)">1350.0</p3_pre_autoconversion_factor>
+      <p3_mu_r_constant type="real" doc="P3 mu_r_constant (rain “shape parameter” in gamma drop-size distribution)">1.0</p3_mu_r_constant>
+      <p3_spa_to_nc type="real" doc="P3 spa_to_nc (scaling factor for turning CCN into nc in SPA)">1.0</p3_spa_to_nc>
+      <p3_k_accretion type="real" doc="P3 k_accretion (scaling factor on accretion)">67.0</p3_k_accretion>
+      <p3_eci type="real" doc="P3 eci (liquid/ice collision/collection coefficient)">0.5</p3_eci>
+      <p3_eri type="real" doc="P3 eri (ice/rain collision/collection coefficient)">1.0</p3_eri>
+      <p3_rho_rime_min type="real" doc="P3 rho_rime_min (riming density maximum)">50.0</p3_rho_rime_min>
+      <p3_rho_rime_max type="real" doc="P3 rho_rime_max (riming density minimum)">900.0</p3_rho_rime_max>
+      <p3_a_imm type="real" doc="P3 a_imm (drop freezing exponent )">0.65</p3_a_imm>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -203,7 +203,7 @@ be lost if SCREAM_HACK_XML is not enabled.
         ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
         ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8
       </tables>
-      <p3_pre_autoconversion_factor type="real" doc="P3 pre_autoconversion_factor (scale factor in autoconversion)">1350.0</p3_pre_autoconversion_factor>
+      <p3_autoconversion_prefactor type="real" doc="P3 autoconversion_prefactor (scale factor in autoconversion)">1350.0</p3_autoconversion_prefactor>
       <p3_mu_r_constant type="real" doc="P3 mu_r_constant (rain “shape parameter” in gamma drop-size distribution)">1.0</p3_mu_r_constant>
       <p3_spa_to_nc type="real" doc="P3 spa_to_nc (scaling factor for turning CCN into nc in SPA)">1.0</p3_spa_to_nc>
       <p3_k_accretion type="real" doc="P3 k_accretion (scaling factor on accretion)">67.0</p3_k_accretion>
@@ -212,6 +212,9 @@ be lost if SCREAM_HACK_XML is not enabled.
       <p3_rho_rime_min type="real" doc="P3 rho_rime_min (riming density maximum)">50.0</p3_rho_rime_min>
       <p3_rho_rime_max type="real" doc="P3 rho_rime_max (riming density minimum)">900.0</p3_rho_rime_max>
       <p3_a_imm type="real" doc="P3 a_imm (drop freezing exponent )">0.65</p3_a_imm>
+      <p3_dep_nucleation_exponent type="real" doc="P3 dep_nucleation_exponent (deposition nucleation)">0.304</p3_dep_nucleation_exponent>
+      <p3_ice_sed_knob type="real" doc="P3 ice_sed_knob (ice fall speed)">1.0</p3_ice_sed_knob>
+      <p3_d_breakup_cutoff type="real" doc="P3 d_breakup_cutoff (rain self collection and breakup)">0.00028</p3_d_breakup_cutoff>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -205,6 +205,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       </tables>
       <p3_pre_autoconversion_factor type="real" doc="P3 pre_autoconversion_factor">1350.0</p3_pre_autoconversion_factor>
       <p3_mu_r_constant type="real" doc="P3 mu_r_constant">1.0</p3_mu_r_constant>
+      <p3_spa_to_nc type="real" doc="P3 spa_to_nc">1.0</p3_spa_to_nc>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -203,6 +203,7 @@ be lost if SCREAM_HACK_XML is not enabled.
         ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
         ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8
       </tables>
+      <p3_autoconversion_factor type="real" doc="P3 autoconversion factor">1350.0</p3_autoconversion_factor>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -204,6 +204,7 @@ be lost if SCREAM_HACK_XML is not enabled.
         ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8
       </tables>
       <p3_pre_autoconversion_factor type="real" doc="P3 pre_autoconversion_factor">1350.0</p3_pre_autoconversion_factor>
+      <p3_mu_r_constant type="real" doc="P3 mu_r_constant">1.0</p3_mu_r_constant>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -206,28 +206,21 @@ void scream_init_atm (const char* caseid,
                       const char* hostname,
                       const char* username)
 {
-	std::cout << "        vvvvvvvvvvvvv scream init begin \n" << std::flush;
   using namespace scream;
   using namespace scream::control;
 
   fpe_guard_wrapper([&](){
     // Get the ad, then complete initialization
     auto& ad = get_ad_nonconst();
-	std::cout << "        222vvvvvvvvvvvvv scream init begin \n" << std::flush;
 
     // Set provenance info in the driver (will be added to the output files)
     ad.set_provenance_data (caseid,hostname,username);
-	std::cout << "        333vvvvvvvvvvvvv scream init begin \n" << std::flush;
 
     // Init all fields, atm processes, and output streams
     ad.initialize_fields ();
-	std::cout << "        444vvvvvvvvvvvvv scream init begin \n" << std::flush;
     ad.initialize_atm_procs ();
-	std::cout << "        555vvvvvvvvvvvvv scream init begin \n" << std::flush;
     ad.initialize_output_managers ();
-	std::cout << "        666vvvvvvvvvvvvv scream init begin \n" << std::flush;
   });
-	std::cout << "        777vvvvvvvvvvvvv scream init begin \n" << std::flush;
 }
 
 /*===============================================================================================*/

--- a/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -206,21 +206,28 @@ void scream_init_atm (const char* caseid,
                       const char* hostname,
                       const char* username)
 {
+	std::cout << "        vvvvvvvvvvvvv scream init begin \n" << std::flush;
   using namespace scream;
   using namespace scream::control;
 
   fpe_guard_wrapper([&](){
     // Get the ad, then complete initialization
     auto& ad = get_ad_nonconst();
+	std::cout << "        222vvvvvvvvvvvvv scream init begin \n" << std::flush;
 
     // Set provenance info in the driver (will be added to the output files)
     ad.set_provenance_data (caseid,hostname,username);
+	std::cout << "        333vvvvvvvvvvvvv scream init begin \n" << std::flush;
 
     // Init all fields, atm processes, and output streams
     ad.initialize_fields ();
+	std::cout << "        444vvvvvvvvvvvvv scream init begin \n" << std::flush;
     ad.initialize_atm_procs ();
+	std::cout << "        555vvvvvvvvvvvvv scream init begin \n" << std::flush;
     ad.initialize_output_managers ();
+	std::cout << "        666vvvvvvvvvvvvv scream init begin \n" << std::flush;
   });
+	std::cout << "        777vvvvvvvvvvvvv scream init begin \n" << std::flush;
 }
 
 /*===============================================================================================*/

--- a/components/eamxx/src/physics/p3/disp/p3_ice_sed_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_ice_sed_impl_disp.cpp
@@ -28,7 +28,8 @@ void Functions<Real,DefaultDevice>
   const view_ice_table& ice_table_vals,
   const uview_1d<Scalar>& precip_ice_surf,
   const uview_1d<bool>& nucleationPossible,
-  const uview_1d<bool>& hydrometeorsPresent)
+  const uview_1d<bool>& hydrometeorsPresent,
+  const physics::P3_Constants<Real> & p3constants)
 {
   using ExeSpace = typename KT::ExeSpace;
   const Int nk_pack = ekat::npack<Spack>(nk);
@@ -49,7 +50,7 @@ void Functions<Real,DefaultDevice>
       ekat::subview(inv_dz, i), team, workspace, nk, ktop, kbot, kdir, dt, inv_dt, 
       ekat::subview(qi, i), ekat::subview(qi_incld, i), ekat::subview(ni, i), ekat::subview(ni_incld, i),
       ekat::subview(qm, i), ekat::subview(qm_incld, i), ekat::subview(bm, i), ekat::subview(bm_incld, i), ekat::subview(qi_tend, i), ekat::subview(ni_tend, i),
-      ice_table_vals, precip_ice_surf(i));
+      ice_table_vals, precip_ice_surf(i), p3constants);
 
  });
 }

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -275,7 +275,7 @@ Int Functions<Real,DefaultDevice>
       rho, inv_rho, rhofacr, cld_frac_r, inv_dz, qr_incld, workspace_mgr,
       lookup_tables.vn_table_vals, lookup_tables.vm_table_vals, nj, nk, ktop, kbot, kdir, infrastructure.dt, inv_dt, qr,
       nr, nr_incld, mu_r, lamr, precip_liq_flux, qtend_ignore, ntend_ignore,
-      diagnostic_outputs.precip_liq_surf, nucleationPossible, hydrometeorsPresent);
+      diagnostic_outputs.precip_liq_surf, nucleationPossible, hydrometeorsPresent, p3constants);
 
   // Ice sedimentation:  (adaptive substepping)
   ice_sedimentation_disp(
@@ -298,7 +298,8 @@ Int Functions<Real,DefaultDevice>
       rho, inv_rho, rhofaci, qv, th, qc, nc, qr, nr, qi, ni,
       qm, bm, latent_heat_vapor, latent_heat_sublim, mu_c, nu, lamc, mu_r, lamr,
       vap_liq_exchange, ze_rain, ze_ice, diag_vm_qi, diag_eff_radius_qi, diag_diam_qi,
-      rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc, diag_eff_radius_qr, nucleationPossible, hydrometeorsPresent);
+      rho_qi, diag_equiv_reflectivity, diag_eff_radius_qc, diag_eff_radius_qr, nucleationPossible, hydrometeorsPresent,
+      p3constants);
 
   //
   // merge ice categories with similar properties

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -35,6 +35,7 @@ void Functions<Real,DefaultDevice>
 {       
   using ExeSpace = typename KT::ExeSpace;
   const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+
   Kokkos::parallel_for("p3_main_init",
          policy, KOKKOS_LAMBDA(const MemberType& team) {
         
@@ -111,6 +112,8 @@ Int Functions<Real,DefaultDevice>
   Int nk)
 {
   using ExeSpace = typename KT::ExeSpace;
+
+  physics::P3_Constants<Real> loc_p3constants;
 
   view_2d<Spack> latent_heat_sublim("latent_heat_sublim", nj, nk), latent_heat_vapor("latent_heat_vapor", nj, nk), latent_heat_fusion("latent_heat_fusion", nj, nk);
 
@@ -247,7 +250,7 @@ Int Functions<Real,DefaultDevice>
       nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr,
       mu_r, lamr, logn0r, qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend,
       vap_liq_exchange, vap_ice_exchange, liq_ice_exchange,
-      pratot, prctot, nucleationPossible, hydrometeorsPresent);
+      pratot, prctot, nucleationPossible, hydrometeorsPresent, loc_p3constants);
 
   //NOTE: At this point, it is possible to have negative (but small) nc, nr, ni.  This is not
   //      a problem; those values get clipped to zero in the sedimentation section (if necessary).

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -109,11 +109,12 @@ Int Functions<Real,DefaultDevice>
   const P3LookupTables& lookup_tables,
   const WorkspaceManager& workspace_mgr,
   Int nj,
-  Int nk)
+  Int nk,
+  physics::P3_Constants<Real> & loc_p3constants)
 {
   using ExeSpace = typename KT::ExeSpace;
 
-  physics::P3_Constants<Real> loc_p3constants;
+  //physics::P3_Constants<Real> loc_p3constants;
 
   view_2d<Spack> latent_heat_sublim("latent_heat_sublim", nj, nk), latent_heat_vapor("latent_heat_vapor", nj, nk), latent_heat_fusion("latent_heat_fusion", nj, nk);
 

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -110,7 +110,7 @@ Int Functions<Real,DefaultDevice>
   const WorkspaceManager& workspace_mgr,
   Int nj,
   Int nk,
-  const physics::P3_Constants<Real> & loc_p3constants)
+  const physics::P3_Constants<Real> & p3constants)
 {
   using ExeSpace = typename KT::ExeSpace;
 
@@ -249,7 +249,7 @@ Int Functions<Real,DefaultDevice>
       nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr,
       mu_r, lamr, logn0r, qv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend,
       vap_liq_exchange, vap_ice_exchange, liq_ice_exchange,
-      pratot, prctot, nucleationPossible, hydrometeorsPresent, loc_p3constants);
+      pratot, prctot, nucleationPossible, hydrometeorsPresent, p3constants);
 
   //NOTE: At this point, it is possible to have negative (but small) nc, nr, ni.  This is not
   //      a problem; those values get clipped to zero in the sedimentation section (if necessary).

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -114,8 +114,6 @@ Int Functions<Real,DefaultDevice>
 {
   using ExeSpace = typename KT::ExeSpace;
 
-  //physics::P3_Constants<Real> loc_p3constants;
-
   view_2d<Spack> latent_heat_sublim("latent_heat_sublim", nj, nk), latent_heat_vapor("latent_heat_vapor", nj, nk), latent_heat_fusion("latent_heat_fusion", nj, nk);
 
   get_latent_heat(nj, nk, latent_heat_vapor, latent_heat_sublim, latent_heat_fusion);

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -110,7 +110,7 @@ Int Functions<Real,DefaultDevice>
   const WorkspaceManager& workspace_mgr,
   Int nj,
   Int nk,
-  physics::P3_Constants<Real> & loc_p3constants)
+  const physics::P3_Constants<Real> & loc_p3constants)
 {
   using ExeSpace = typename KT::ExeSpace;
 

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -233,7 +233,7 @@ Int Functions<Real,DefaultDevice>
       T_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr,
       rhofaci, acn, qv, th, qc, nc, qr, nr, qi, ni, qm,
       bm, qc_incld, qr_incld, qi_incld, qm_incld, nc_incld, nr_incld,
-      ni_incld, bm_incld, nucleationPossible, hydrometeorsPresent);
+      ni_incld, bm_incld, nucleationPossible, hydrometeorsPresent, p3constants);
 
   // ------------------------------------------------------------------------------------------
   // main k-loop (for processes):

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -282,7 +282,7 @@ Int Functions<Real,DefaultDevice>
       rho, inv_rho, rhofaci, cld_frac_i, inv_dz, workspace_mgr, nj, nk, ktop, kbot,
       kdir, infrastructure.dt, inv_dt, qi, qi_incld, ni, ni_incld,
       qm, qm_incld, bm, bm_incld, qtend_ignore, ntend_ignore,
-      lookup_tables.ice_table_vals, diagnostic_outputs.precip_ice_surf, nucleationPossible, hydrometeorsPresent);
+      lookup_tables.ice_table_vals, diagnostic_outputs.precip_ice_surf, nucleationPossible, hydrometeorsPresent, p3constants);
 
   // homogeneous freezing f cloud and rain
   homogeneous_freezing_disp(

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part1_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part1_disp.cpp
@@ -62,7 +62,8 @@ void Functions<Real,DefaultDevice>
   const uview_2d<Spack>& ni_incld,
   const uview_2d<Spack>& bm_incld,
   const uview_1d<bool>& nucleationPossible,
-  const uview_1d<bool>& hydrometeorsPresent)
+  const uview_1d<bool>& hydrometeorsPresent,
+  const physics::P3_Constants<Real> & p3constants)
 {
   using ExeSpace = typename KT::ExeSpace;
   const Int nk_pack = ekat::npack<Spack>(nk);
@@ -83,7 +84,7 @@ void Functions<Real,DefaultDevice>
       ekat::subview(qv, i), ekat::subview(th_atm, i), ekat::subview(qc, i), ekat::subview(nc, i), ekat::subview(qr, i), ekat::subview(nr, i), ekat::subview(qi, i),
       ekat::subview(ni, i), ekat::subview(qm, i), ekat::subview(bm, i), ekat::subview(qc_incld, i), ekat::subview(qr_incld, i), ekat::subview(qi_incld, i),
       ekat::subview(qm_incld, i), ekat::subview(nc_incld, i), ekat::subview(nr_incld, i), ekat::subview(ni_incld, i), ekat::subview(bm_incld, i), 
-      nucleationPossible(i), hydrometeorsPresent(i));
+      nucleationPossible(i), hydrometeorsPresent(i), p3constants);
 
   });
 }

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
@@ -89,11 +89,14 @@ void Functions<Real,DefaultDevice>
   const uview_2d<Spack>& pratot,
   const uview_2d<Spack>& prctot,
   const uview_1d<bool>& nucleationPossible,
-  const uview_1d<bool>& hydrometeorsPresent)
+  const uview_1d<bool>& hydrometeorsPresent,
+  const physics::P3_Constants<Real> & loc_p3constants)
 {
   using ExeSpace = typename KT::ExeSpace;
   const Int nk_pack = ekat::npack<Spack>(nk);
   const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+
+
   // p3_cloud_sedimentation loop
   Kokkos::parallel_for(
     "p3_main_part2_disp",
@@ -122,7 +125,7 @@ void Functions<Real,DefaultDevice>
       ekat::subview(cdist1, i), ekat::subview(cdistr, i), ekat::subview(mu_r, i), ekat::subview(lamr, i), ekat::subview(logn0r, i), 
       ekat::subview(qv2qi_depos_tend, i), ekat::subview(precip_total_tend, i),
       ekat::subview(nevapr, i), ekat::subview(qr_evap_tend, i), ekat::subview(vap_liq_exchange, i), ekat::subview(vap_ice_exchange, i), ekat::subview(liq_ice_exchange, i),
-      ekat::subview(pratot, i), ekat::subview(prctot, i), hydrometeorsPresent(i), nk);
+      ekat::subview(pratot, i), ekat::subview(prctot, i), hydrometeorsPresent(i), nk, loc_p3constants);
 
     if (!hydrometeorsPresent(i)) return;
   });

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
@@ -90,7 +90,7 @@ void Functions<Real,DefaultDevice>
   const uview_2d<Spack>& prctot,
   const uview_1d<bool>& nucleationPossible,
   const uview_1d<bool>& hydrometeorsPresent,
-  const physics::P3_Constants<Real> & loc_p3constants)
+  const physics::P3_Constants<Real> & p3constants)
 {
   using ExeSpace = typename KT::ExeSpace;
   const Int nk_pack = ekat::npack<Spack>(nk);
@@ -125,7 +125,7 @@ void Functions<Real,DefaultDevice>
       ekat::subview(cdist1, i), ekat::subview(cdistr, i), ekat::subview(mu_r, i), ekat::subview(lamr, i), ekat::subview(logn0r, i), 
       ekat::subview(qv2qi_depos_tend, i), ekat::subview(precip_total_tend, i),
       ekat::subview(nevapr, i), ekat::subview(qr_evap_tend, i), ekat::subview(vap_liq_exchange, i), ekat::subview(vap_ice_exchange, i), ekat::subview(liq_ice_exchange, i),
-      ekat::subview(pratot, i), ekat::subview(prctot, i), hydrometeorsPresent(i), nk, loc_p3constants);
+      ekat::subview(pratot, i), ekat::subview(prctot, i), hydrometeorsPresent(i), nk, p3constants);
 
     if (!hydrometeorsPresent(i)) return;
   });

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part3_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part3_disp.cpp
@@ -56,7 +56,8 @@ void Functions<Real,DefaultDevice>
   const uview_2d<Spack>& diag_eff_radius_qc,
   const uview_2d<Spack>& diag_eff_radius_qr,
   const uview_1d<bool>& nucleationPossible,
-  const uview_1d<bool>& hydrometeorsPresent)
+  const uview_1d<bool>& hydrometeorsPresent,
+  const physics::P3_Constants<Real> & p3constants)
 {
   using ExeSpace = typename KT::ExeSpace;
   const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
@@ -82,7 +83,7 @@ void Functions<Real,DefaultDevice>
       ekat::subview(mu_c, i), ekat::subview(nu, i), ekat::subview(lamc, i), ekat::subview(mu_r, i), ekat::subview(lamr, i),
       ekat::subview(vap_liq_exchange, i), ekat::subview(ze_rain, i), ekat::subview(ze_ice, i), ekat::subview(diag_vm_qi, i), ekat::subview(diag_eff_radius_qi, i), 
       ekat::subview(diag_diam_qi, i), ekat::subview(rho_qi, i), ekat::subview(diag_equiv_reflectivity, i), ekat::subview(diag_eff_radius_qc, i),
-      ekat::subview(diag_eff_radius_qr, i));
+      ekat::subview(diag_eff_radius_qr, i), p3constants);
 
   });
 }

--- a/components/eamxx/src/physics/p3/disp/p3_rain_sed_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_rain_sed_impl_disp.cpp
@@ -27,7 +27,8 @@ void Functions<Real,DefaultDevice>
   const uview_2d<Spack>& nr_tend,
   const uview_1d<Scalar>& precip_liq_surf,
   const uview_1d<bool>& nucleationPossible,
-  const uview_1d<bool>& hydrometeorsPresent)
+  const uview_1d<bool>& hydrometeorsPresent,
+  const physics::P3_Constants<Real> & p3constants)
 {
   using ExeSpace = typename KT::ExeSpace;
   const Int nk_pack = ekat::npack<Spack>(nk);
@@ -49,7 +50,7 @@ void Functions<Real,DefaultDevice>
       team, workspace, vn_table_vals, vm_table_vals, nk, ktop, kbot, kdir, dt, inv_dt, 
       ekat::subview(qr, i), ekat::subview(nr, i), ekat::subview(nr_incld, i), ekat::subview(mu_r, i), 
       ekat::subview(lamr, i), ekat::subview(precip_liq_flux, i), 
-      ekat::subview(qr_tend, i), ekat::subview(nr_tend, i), precip_liq_surf(i));
+      ekat::subview(qr_tend, i), ekat::subview(nr_tend, i), precip_liq_surf(i), p3constants);
   });
 
 }

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -13,8 +13,6 @@
 namespace scream
 {
 
-using CP3 = physics::P3_Constants<Real>; 
-
 // =========================================================================================
 P3Microphysics::P3Microphysics (const ekat::Comm& comm, const ekat::ParameterList& params)
   : AtmosphereProcess(comm, params)
@@ -209,7 +207,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
 
   //1350 will be from nl...
   //what is the
-  CP3::set_p3_autoconversion_factor(m_params.get<double>("p3_autoconversion_factor"));
+  CP3::p3_autoconversion_factor = m_params.get<double>("p3_autoconversion_factor");
 
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0,500.0,false);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -13,6 +13,8 @@
 namespace scream
 {
 
+using CP3 = physics::P3_Constants<Real>; 
+
 // =========================================================================================
 P3Microphysics::P3Microphysics (const ekat::Comm& comm, const ekat::ParameterList& params)
   : AtmosphereProcess(comm, params)
@@ -204,6 +206,11 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
 {
   // Gather runtime options
   runtime_options.max_total_ni = m_params.get<double>("max_total_ni");
+
+  //1350 will be from nl...
+  //what is the
+  CP3::set_p3_autoconversion_factor(m_params.get<double>("p3_autoconversion_factor"));
+
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0,500.0,false);
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("qv"),m_grid,1e-13,0.2,true);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -206,8 +206,11 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   // Gather runtime options
   runtime_options.max_total_ni = m_params.get<double>("max_total_ni");
 
-  CP3::set_p3_defaults();
-  CP3::p3_autoconversion_factor = m_params.get<double>("p3_autoconversion_factor");
+//  CP3::set_p3_defaults();
+//  CP3::p3_autoconversion_factor = m_params.get<double>("p3_autoconversion_factor");
+  m_p3constants.p3_autoconversion_factor = m_params.get<double>("p3_autoconversion_factor");
+
+//std::cout << "AAAAAAAAAAAAAANG "<<CP3::p3_autoconversion_factor <<"\n";
 
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0,500.0,false);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -206,10 +206,10 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   // Gather runtime options
   runtime_options.max_total_ni = m_params.get<double>("max_total_ni");
 
-  //////////// setting P3 constants in a struct
+  // setting P3 constants in a struct
   m_p3constants.set_p3_from_namelist(m_params);
   m_p3constants.print_p3constants(m_atm_logger);
-  //////////// done setting P3 constants
+  // done setting P3 constants
 
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0,500.0,false);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -3,6 +3,7 @@
 #include "share/property_checks/field_lower_bound_check.hpp"
 // Needed for p3_init, the only F90 code still used.
 #include "physics/p3/p3_functions.hpp"
+#include "physics/share/physics_constants.hpp"
 #include "physics/p3/p3_f90.hpp"
 
 #include "ekat/ekat_assert.hpp"
@@ -205,8 +206,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   // Gather runtime options
   runtime_options.max_total_ni = m_params.get<double>("max_total_ni");
 
-  //1350 will be from nl...
-  //what is the
+  CP3::set_p3_defaults();
   CP3::p3_autoconversion_factor = m_params.get<double>("p3_autoconversion_factor");
 
   // Set property checks for fields in this process

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -206,11 +206,13 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   // Gather runtime options
   runtime_options.max_total_ni = m_params.get<double>("max_total_ni");
 
-//  CP3::set_p3_defaults();
-//  CP3::p3_autoconversion_factor = m_params.get<double>("p3_autoconversion_factor");
+  m_p3constants.set_p3_defaults();
+
+  //does this work when the value is not in the nl?
   m_p3constants.p3_autoconversion_factor = m_params.get<double>("p3_autoconversion_factor");
 
-std::cout << "AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor <<"\n";
+//temp to check   
+std::cout << "AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor <<"\n" << std::flush;
 
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0,500.0,false);
@@ -232,12 +234,10 @@ std::cout << "AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor <<"\n";
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qi"),m_grid,0.0,5.0e3,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qr"),m_grid,0.0,5.0e3,false);
 
-std::cout << "before p3_init 22222222AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor <<"\n";
   // Initialize p3
   p3::p3_init(/* write_tables = */ false,
               this->get_comm().am_i_root());
 
-std::cout << "22222222AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor <<"\n";
   // Initialize all of the structures that are passed to p3_main in run_impl.
   // Note: Some variables in the structures are not stored in the field manager.  For these
   //       variables a local view is constructed.
@@ -352,7 +352,6 @@ std::cout << "22222222AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor
   // Setup WSM for internal local variables
   const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);
   workspace_mgr.setup(m_buffer.wsm_data, nk_pack_p1, 52, policy);
-std::cout << "3333333333333AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor <<"\n";
 }
 
 // =========================================================================================

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -210,7 +210,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
 //  CP3::p3_autoconversion_factor = m_params.get<double>("p3_autoconversion_factor");
   m_p3constants.p3_autoconversion_factor = m_params.get<double>("p3_autoconversion_factor");
 
-//std::cout << "AAAAAAAAAAAAAANG "<<CP3::p3_autoconversion_factor <<"\n";
+std::cout << "AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor <<"\n";
 
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0,500.0,false);
@@ -232,10 +232,12 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qi"),m_grid,0.0,5.0e3,false);
   add_postcondition_check<FieldWithinIntervalCheck>(get_field_out("eff_radius_qr"),m_grid,0.0,5.0e3,false);
 
+std::cout << "before p3_init 22222222AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor <<"\n";
   // Initialize p3
   p3::p3_init(/* write_tables = */ false,
               this->get_comm().am_i_root());
 
+std::cout << "22222222AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor <<"\n";
   // Initialize all of the structures that are passed to p3_main in run_impl.
   // Note: Some variables in the structures are not stored in the field manager.  For these
   //       variables a local view is constructed.
@@ -350,6 +352,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   // Setup WSM for internal local variables
   const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);
   workspace_mgr.setup(m_buffer.wsm_data, nk_pack_p1, 52, policy);
+std::cout << "3333333333333AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor <<"\n";
 }
 
 // =========================================================================================

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -206,13 +206,10 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   // Gather runtime options
   runtime_options.max_total_ni = m_params.get<double>("max_total_ni");
 
-  m_p3constants.set_p3_defaults();
-
-  //does this work when the value is not in the nl?
-  m_p3constants.p3_autoconversion_factor = m_params.get<double>("p3_autoconversion_factor");
-
-//temp to check   
-std::cout << "AAAAAAAAAAAAAANG "<<m_p3constants.p3_autoconversion_factor <<"\n" << std::flush;
+  //////////// setting P3 constants in a struct
+  m_p3constants.set_p3_from_namelist(m_params);
+  m_p3constants.print_p3constants(m_atm_logger);
+  //////////// done setting P3 constants
 
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0,500.0,false);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
@@ -22,6 +22,7 @@ namespace scream
 class P3Microphysics : public AtmosphereProcess
 {
   using P3F          = p3::Functions<Real, DefaultDevice>;
+  using CP3          = physics::P3_Constants<Real>;
   using Spack        = typename P3F::Spack;
   using Smask        = typename P3F::Smask;
   using Pack         = ekat::Pack<Real,Spack::n>;
@@ -52,6 +53,8 @@ public:
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
+
+  CP3 aaa;
 
   /*--------------------------------------------------------------------------------------------*/
   // Most individual processes have a pre-processing step that constructs needed variables from

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
@@ -54,7 +54,7 @@ public:
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
-  CP3 aaa;
+  CP3 m_p3constants;
 
   /*--------------------------------------------------------------------------------------------*/
   // Most individual processes have a pre-processing step that constructs needed variables from

--- a/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
@@ -29,7 +29,7 @@ void P3Microphysics::run_impl (const double dt)
   get_field_out("micro_vap_ice_exchange").deep_copy(0.0);
 
   P3F::p3_main(runtime_options, prog_state, diag_inputs, diag_outputs, infrastructure,
-               history_only, lookup_tables, workspace_mgr, m_num_cols, m_num_levs);
+               history_only, lookup_tables, workspace_mgr, m_num_cols, m_num_levs, m_p3constants);
 
   // Conduct the post-processing of the p3_main output.
   Kokkos::parallel_for(

--- a/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
@@ -4,7 +4,6 @@ namespace scream {
 
 void P3Microphysics::run_impl (const double dt)
 {
-  std::cout << "22222begin CCCCCCCCCCCCCCCCCCCCCCCc are we in run_impl \n" << std::flush;
   // Set the dt for p3 postprocessing
   p3_postproc.m_dt = dt;
 
@@ -28,10 +27,6 @@ void P3Microphysics::run_impl (const double dt)
   get_field_out("micro_liq_ice_exchange").deep_copy(0.0);
   get_field_out("micro_vap_liq_exchange").deep_copy(0.0);
   get_field_out("micro_vap_ice_exchange").deep_copy(0.0);
-
-
-  std::cout << "CCCCCCCCCCCCCCCCCCCCCCCc are we in run_impl \n" << std::flush;
-
 
   P3F::p3_main(runtime_options, prog_state, diag_inputs, diag_outputs, infrastructure,
                history_only, lookup_tables, workspace_mgr, m_num_cols, m_num_levs, m_p3constants);

--- a/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
@@ -4,6 +4,7 @@ namespace scream {
 
 void P3Microphysics::run_impl (const double dt)
 {
+  std::cout << "22222begin CCCCCCCCCCCCCCCCCCCCCCCc are we in run_impl \n" << std::flush;
   // Set the dt for p3 postprocessing
   p3_postproc.m_dt = dt;
 
@@ -27,6 +28,10 @@ void P3Microphysics::run_impl (const double dt)
   get_field_out("micro_liq_ice_exchange").deep_copy(0.0);
   get_field_out("micro_vap_liq_exchange").deep_copy(0.0);
   get_field_out("micro_vap_ice_exchange").deep_copy(0.0);
+
+
+  std::cout << "CCCCCCCCCCCCCCCCCCCCCCCc are we in run_impl \n" << std::flush;
+
 
   P3F::p3_main(runtime_options, prog_state, diag_inputs, diag_outputs, infrastructure,
                history_only, lookup_tables, workspace_mgr, m_num_cols, m_num_levs, m_p3constants);

--- a/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
@@ -14,7 +14,7 @@ void Functions<S,D>
 ::cloud_water_autoconversion(
   const Spack& rho, const Spack& qc_incld, const Spack& nc_incld,
   const Spack& inv_qc_relvar, Spack& qc2qr_autoconv_tend, Spack& nc2nr_autoconv_tend, Spack& ncautr,
-  const physics::P3_Constants<S> & loc_p3constants,
+  const physics::P3_Constants<S> & p3constants,
   const Smask& context)
 {
 
@@ -22,7 +22,7 @@ void Functions<S,D>
   const auto qc_not_small = qc_incld >= 1e-8 && context;
   constexpr Scalar CONS3 = C::CONS3;
 
-  Scalar p3_autoconversion_factor = loc_p3constants.p3_autoconversion_factor;
+  const Scalar p3_pre_autoconversion_factor = p3constants.p3_pre_autoconversion_factor;
 
 //printf("  hey inside  AAAAAAAAAAAAAAAA %13.6f \n", p3_autoconversion_factor);
 
@@ -32,7 +32,7 @@ void Functions<S,D>
     sgs_var_coef = 1;
 
     qc2qr_autoconv_tend.set(qc_not_small,
-              sgs_var_coef*p3_autoconversion_factor*pow(qc_incld,sp(2.47))*pow(nc_incld*sp(1.e-6)*rho,sp(-1.79)));
+              sgs_var_coef*p3_pre_autoconversion_factor*pow(qc_incld,sp(2.47))*pow(nc_incld*sp(1.e-6)*rho,sp(-1.79)));
     // note: ncautr is change in Nr; nc2nr_autoconv_tend is change in Nc
     ncautr.set(qc_not_small, qc2qr_autoconv_tend*CONS3);
     nc2nr_autoconv_tend.set(qc_not_small, qc2qr_autoconv_tend*nc_incld/qc_incld);

--- a/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
@@ -24,6 +24,8 @@ void Functions<S,D>
 
   Scalar p3_autoconversion_factor = loc_p3constants.p3_autoconversion_factor;
 
+//printf("  hey inside  AAAAAAAAAAAAAAAA %13.6f \n", p3_autoconversion_factor);
+
   if(qc_not_small.any()){
     Spack sgs_var_coef;
     // sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, sp(2.47) );

--- a/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
@@ -3,7 +3,7 @@
 
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
 #include "p3_subgrid_variance_scaling_impl.hpp"
-//#include "physics/share/physics_constants.hpp"
+#include "physics/share/physics_constants.hpp"
 
 namespace scream {
 namespace p3 {
@@ -14,13 +14,15 @@ void Functions<S,D>
 ::cloud_water_autoconversion(
   const Spack& rho, const Spack& qc_incld, const Spack& nc_incld,
   const Spack& inv_qc_relvar, Spack& qc2qr_autoconv_tend, Spack& nc2nr_autoconv_tend, Spack& ncautr,
+const physics::P3_Constants<S> & bbb,
   const Smask& context)
 {
 
   // Khroutdinov and Kogan (2000)
   const auto qc_not_small = qc_incld >= 1e-8 && context;
   constexpr Scalar CONS3 = C::CONS3;
-  Scalar p3_autoconversion_factor = CP3::get_p3_autoconversion_factor();
+  //Scalar p3_autoconversion_factor = CP3::get_p3_autoconversion_factor();
+  Scalar p3_autoconversion_factor = bbb.p3_autoconversion_factor;
 
   if(qc_not_small.any()){
     Spack sgs_var_coef;

--- a/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
@@ -22,7 +22,7 @@ void Functions<S,D>
   const auto qc_not_small = qc_incld >= 1e-8 && context;
   constexpr Scalar CONS3 = C::CONS3;
 
-  const Scalar p3_pre_autoconversion_factor = p3constants.p3_pre_autoconversion_factor;
+  const Scalar p3_autoconversion_prefactor = p3constants.p3_autoconversion_prefactor;
 
 //printf("  hey inside  AAAAAAAAAAAAAAAA %13.6f \n", p3_autoconversion_factor);
 
@@ -32,7 +32,7 @@ void Functions<S,D>
     sgs_var_coef = 1;
 
     qc2qr_autoconv_tend.set(qc_not_small,
-              sgs_var_coef*p3_pre_autoconversion_factor*pow(qc_incld,sp(2.47))*pow(nc_incld*sp(1.e-6)*rho,sp(-1.79)));
+              sgs_var_coef*p3_autoconversion_prefactor*pow(qc_incld,sp(2.47))*pow(nc_incld*sp(1.e-6)*rho,sp(-1.79)));
     // note: ncautr is change in Nr; nc2nr_autoconv_tend is change in Nc
     ncautr.set(qc_not_small, qc2qr_autoconv_tend*CONS3);
     nc2nr_autoconv_tend.set(qc_not_small, qc2qr_autoconv_tend*nc_incld/qc_incld);

--- a/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
@@ -3,6 +3,7 @@
 
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
 #include "p3_subgrid_variance_scaling_impl.hpp"
+//#include "physics/share/physics_constants.hpp"
 
 namespace scream {
 namespace p3 {
@@ -15,16 +16,19 @@ void Functions<S,D>
   const Spack& inv_qc_relvar, Spack& qc2qr_autoconv_tend, Spack& nc2nr_autoconv_tend, Spack& ncautr,
   const Smask& context)
 {
+
   // Khroutdinov and Kogan (2000)
   const auto qc_not_small = qc_incld >= 1e-8 && context;
   constexpr Scalar CONS3 = C::CONS3;
+  Scalar p3_autoconversion_factor = CP3::get_p3_autoconversion_factor();
+
   if(qc_not_small.any()){
     Spack sgs_var_coef;
     // sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, sp(2.47) );
     sgs_var_coef = 1;
 
     qc2qr_autoconv_tend.set(qc_not_small,
-              sgs_var_coef*1350*pow(qc_incld,sp(2.47))*pow(nc_incld*sp(1.e-6)*rho,sp(-1.79)));
+              sgs_var_coef*p3_autoconversion_factor*pow(qc_incld,sp(2.47))*pow(nc_incld*sp(1.e-6)*rho,sp(-1.79)));
     // note: ncautr is change in Nr; nc2nr_autoconv_tend is change in Nc
     ncautr.set(qc_not_small, qc2qr_autoconv_tend*CONS3);
     nc2nr_autoconv_tend.set(qc_not_small, qc2qr_autoconv_tend*nc_incld/qc_incld);

--- a/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
@@ -14,15 +14,15 @@ void Functions<S,D>
 ::cloud_water_autoconversion(
   const Spack& rho, const Spack& qc_incld, const Spack& nc_incld,
   const Spack& inv_qc_relvar, Spack& qc2qr_autoconv_tend, Spack& nc2nr_autoconv_tend, Spack& ncautr,
-const physics::P3_Constants<S> & bbb,
+  const physics::P3_Constants<S> & loc_p3constants,
   const Smask& context)
 {
 
   // Khroutdinov and Kogan (2000)
   const auto qc_not_small = qc_incld >= 1e-8 && context;
   constexpr Scalar CONS3 = C::CONS3;
-  //Scalar p3_autoconversion_factor = CP3::get_p3_autoconversion_factor();
-  Scalar p3_autoconversion_factor = bbb.p3_autoconversion_factor;
+
+  Scalar p3_autoconversion_factor = loc_p3constants.p3_autoconversion_factor;
 
   if(qc_not_small.any()){
     Spack sgs_var_coef;

--- a/components/eamxx/src/physics/p3/impl/p3_cldliq_imm_freezing_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_cldliq_imm_freezing_impl.hpp
@@ -20,20 +20,21 @@ void Functions<S,D>
   const Spack& mu_c, const Spack& cdist1,
   const Spack& qc_incld, const Spack& inv_qc_relvar,
   Spack& qc2qi_hetero_freeze_tend, Spack& nc2ni_immers_freeze_tend,
+  const physics::P3_Constants<S> & p3constants,
   const Smask& context)
 {
   constexpr Scalar qsmall   = C::QSMALL;
-  constexpr Scalar AIMM     = C::AIMM;
   constexpr Scalar T_rainfrz = C::T_rainfrz;
   constexpr Scalar T_zerodegc = C::T_zerodegc;
   constexpr Scalar CONS5    = C::CONS5;
   constexpr Scalar CONS6    = C::CONS6;
+  const Scalar p3_a_imm = p3constants.p3_a_imm;
 
   const auto qc_not_small_and_t_freezing = (qc_incld >= qsmall) &&
                                            (T_atm <= T_rainfrz) && context;
   if (qc_not_small_and_t_freezing.any()) {
     Spack expAimmDt, inv_lamc3;
-    expAimmDt.set(qc_not_small_and_t_freezing, exp(AIMM * (T_zerodegc-T_atm)));
+    expAimmDt.set(qc_not_small_and_t_freezing, exp(p3_a_imm * (T_zerodegc-T_atm)));
     inv_lamc3.set(qc_not_small_and_t_freezing, cube(1/lamc));
 
     Spack sgs_var_coef;

--- a/components/eamxx/src/physics/p3/impl/p3_cloud_rain_acc_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_cloud_rain_acc_impl.hpp
@@ -20,9 +20,12 @@ void Functions<S,D>
   const Spack& qc_incld, const Spack& nc_incld,
   const Spack& qr_incld, const Spack& inv_qc_relvar,
   Spack& qc2qr_accret_tend, Spack& nc_accret_tend,
+  const physics::P3_Constants<S> & p3constants,
   const Smask& context)
 {
   constexpr Scalar qsmall = C::QSMALL;
+
+  const Scalar p3_k_accretion = p3constants.p3_k_accretion;;
 
   Spack sgs_var_coef;
   // sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, sp(1.15) );
@@ -32,7 +35,7 @@ void Functions<S,D>
   if (qr_and_qc_not_small.any()) {
     // Khroutdinov and Kogan (2000)
     qc2qr_accret_tend.set(qr_and_qc_not_small,
-              sgs_var_coef * sp(67.0) * pow(qc_incld * qr_incld, sp(1.15)));
+              sgs_var_coef * sp(p3_k_accretion) * pow(qc_incld * qr_incld, sp(1.15)));
     nc_accret_tend.set(qr_and_qc_not_small, qc2qr_accret_tend * nc_incld / qc_incld);
 
     qc2qr_accret_tend.set(nc_accret_tend == 0 && context, 0);

--- a/components/eamxx/src/physics/p3/impl/p3_dsd2_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_dsd2_impl.hpp
@@ -77,6 +77,7 @@ void Functions<S,D>::
 get_rain_dsd2 (
   const Spack& qr, Spack& nr, Spack& mu_r,
   Spack& lamr, Spack& cdistr, Spack& logn0r, 
+  const physics::P3_Constants<S> & p3constants,
   const Smask& context)
 {
   constexpr auto nsmall = C::NSMALL;
@@ -89,8 +90,9 @@ get_rain_dsd2 (
 
   const auto qr_gt_small = qr >= qsmall && context;
 
+  const Scalar mu_r_const = p3constants.p3_mu_r_constant;
+
   if (qr_gt_small.any()) {
-    constexpr Scalar mu_r_const = C::mu_r_const;
     // use lookup table to get mu
     // mu-lambda relationship is from Cao et al. (2008), eq. (7)
 

--- a/components/eamxx/src/physics/p3/impl/p3_ice_nucleation_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_ice_nucleation_impl.hpp
@@ -13,6 +13,7 @@ void Functions<S,D>
   const Spack& temp, const Spack& inv_rho, const Spack& ni, const Spack& ni_activated,
   const Spack& qv_supersat_i, const Scalar& inv_dt, const bool& do_predict_nc, const bool& do_prescribed_CCN,
   Spack& qv2qi_nucleat_tend, Spack& ni_nucleat_tend,
+  const physics::P3_Constants<S> & p3constants, 
   const Smask& context)
 {
    constexpr Scalar nsmall  = C::NSMALL;
@@ -21,6 +22,8 @@ void Functions<S,D>
    constexpr Scalar zero    = C::ZERO;
    constexpr Scalar piov3   = C::PIOV3;
    constexpr Scalar mi0     = sp(4.0)*piov3*sp(900.0)*sp(1.e-18);
+
+   const Scalar p3_dep_nucleation_exponent = p3constants.p3_dep_nucleation_exponent;
 
    const auto t_lt_T_icenuc = temp < T_icenuc;
    const auto qv_supersat_i_ge_005 = qv_supersat_i >= 0.05;
@@ -33,7 +36,7 @@ void Functions<S,D>
    Spack dum{0.0}, N_nuc{0.0}, Q_nuc{0.0};
 
    if (any_if_not_log.any()) {
-     dum = sp(0.005)*exp(sp(0.304)*(tmelt-temp))*sp(1.0e3)*inv_rho;
+     dum = sp(0.005)*exp(sp(p3_dep_nucleation_exponent)*(tmelt-temp))*sp(1.0e3)*inv_rho;
 
      dum = min(dum, sp(1.0e5)*inv_rho);
 

--- a/components/eamxx/src/physics/p3/impl/p3_ice_sed_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_ice_sed_impl.hpp
@@ -17,12 +17,13 @@ typename Functions<S,D>::Spack
 Functions<S,D>
 ::calc_bulk_rho_rime(
   const Spack& qi_tot, Spack& qi_rim, Spack& bi_rim,
+  const physics::P3_Constants<S> & p3constants,
   const Smask& context)
 {
   constexpr Scalar bsmall       = C::BSMALL;
   constexpr Scalar qsmall       = C::QSMALL;
-  constexpr Scalar rho_rime_min = C::rho_rimeMin;
-  constexpr Scalar rho_rime_max = C::rho_rimeMax;
+  const Scalar p3_rho_rime_min = p3constants.p3_rho_rime_min;
+  const Scalar p3_rho_rime_max = p3constants.p3_rho_rime_max;
 
   Spack rho_rime(0);
 
@@ -32,12 +33,12 @@ Functions<S,D>
     rho_rime.set(bi_rim_gt_small, qi_rim / bi_rim);
   }
 
-  Smask rho_rime_lt_min = rho_rime < rho_rime_min;
-  Smask rho_rime_gt_max = rho_rime > rho_rime_max;
+  Smask rho_rime_lt_min = rho_rime < p3_rho_rime_min;
+  Smask rho_rime_gt_max = rho_rime > p3_rho_rime_max;
 
   // impose limits on rho_rime;  adjust bi_rim if needed
-  rho_rime.set(bi_rim_gt_small && rho_rime_lt_min, rho_rime_min);
-  rho_rime.set(bi_rim_gt_small && rho_rime_gt_max, rho_rime_max);
+  rho_rime.set(bi_rim_gt_small && rho_rime_lt_min, p3_rho_rime_min);
+  rho_rime.set(bi_rim_gt_small && rho_rime_gt_max, p3_rho_rime_max);
   Smask adjust = bi_rim_gt_small && (rho_rime_gt_max || rho_rime_lt_min);
   if (adjust.any()) {
     bi_rim.set(adjust, qi_rim / rho_rime);
@@ -85,7 +86,8 @@ void Functions<S,D>
   const uview_1d<Spack>& qi_tend,
   const uview_1d<Spack>& ni_tend,
   const view_ice_table& ice_table_vals,
-  Scalar& precip_ice_surf)
+  Scalar& precip_ice_surf,
+  const physics::P3_Constants<S> & p3constants)
 {
   // Get temporary workspaces needed for the ice-sed calculation
   uview_1d<Spack> V_qit, V_nit, flux_nit, flux_bir, flux_qir, flux_qit;
@@ -140,7 +142,7 @@ void Functions<S,D>
           // impose lower limits to prevent log(<0)
           ni_incld(pk).set(qi_gt_small, max(ni_incld(pk), nsmall));
 
-          const auto rhop = calc_bulk_rho_rime(qi_incld(pk), qm_incld(pk), bm_incld(pk), qi_gt_small);
+          const auto rhop = calc_bulk_rho_rime(qi_incld(pk), qm_incld(pk), bm_incld(pk), p3constants, qi_gt_small);
           qm(pk).set(qi_gt_small, qm_incld(pk)*cld_frac_i(pk) );
           bm(pk).set(qi_gt_small, bm_incld(pk)*cld_frac_i(pk) );
 

--- a/components/eamxx/src/physics/p3/impl/p3_ice_sed_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_ice_sed_impl.hpp
@@ -104,6 +104,9 @@ void Functions<S,D>
   const auto sqi = scalarize(qi);
   constexpr Scalar qsmall = C::QSMALL;
   constexpr Scalar nsmall = C::NSMALL;
+
+  const Scalar p3_ice_sed_knob = p3constants.p3_ice_sed_knob;
+
   bool log_qxpresent;
   const Int k_qxtop = find_top(team, sqi, qsmall, kbot, ktop, kdir, log_qxpresent);
 
@@ -160,8 +163,8 @@ void Functions<S,D>
           ni_incld(pk).set(qi_gt_small, max(ni_incld(pk), table_val_ni_lammin * ni_incld(pk)));
           ni(pk).set(qi_gt_small, ni_incld(pk) * cld_frac_i(pk));
 
-          V_qit(pk).set(qi_gt_small, table_val_qi_fallspd * rhofaci(pk)); // mass-weighted   fall speed (with density factor)
-          V_nit(pk).set(qi_gt_small, table_val_ni_fallspd * rhofaci(pk)); // number-weighted fall speed (with density factor)
+          V_qit(pk).set(qi_gt_small, p3_ice_sed_knob * table_val_qi_fallspd * rhofaci(pk)); // mass-weighted   fall speed (with density factor)
+          V_nit(pk).set(qi_gt_small, p3_ice_sed_knob * table_val_ni_fallspd * rhofaci(pk)); // number-weighted fall speed (with density factor)
         }
         const auto Co_max_local = max(qi_gt_small, 0,
                                       V_qit(pk) * dt_left * inv_dz(pk));

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -85,8 +85,11 @@ Int Functions<S,D>
   const WorkspaceManager& workspace_mgr,
   Int nj,
   Int nk,
-  physics::P3_Constants<S> & loc_p3constants)
+  const physics::P3_Constants<S> & loc_p3constants)
 {
+
+	std::cout << "ARE WE HERE???? \n";
+
   using ExeSpace = typename KT::ExeSpace;
 
   view_2d<Spack> latent_heat_sublim("latent_heat_sublim", nj, nk), latent_heat_vapor("latent_heat_vapor", nj, nk), latent_heat_fusion("latent_heat_fusion", nj, nk);
@@ -110,6 +113,8 @@ Int Functions<S,D>
   auto start = std::chrono::steady_clock::now();
 
   //physics::P3_Constants<S> loc_p3constants = loc_p3;
+
+  std::cout << "before MAIN || " << loc_p3constants.p3_autoconversion_factor << "\n";
 
   // p3_main loop
   Kokkos::parallel_for(
@@ -348,8 +353,11 @@ Int Functions<S,D>
   const WorkspaceManager& workspace_mgr,
   Int nj,
   Int nk,
-  physics::P3_Constants<S> & loc_p3constants)
+  const physics::P3_Constants<S> & loc_p3constants)
 {
+
+	std::cout << "BBBBBBBBBBBBB are we in p3_main ? \n";
+
 #ifndef SCREAM_SMALL_KERNELS
   return p3_main_internal(runtime_options,
                          prognostic_state,

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -108,7 +108,7 @@ Int Functions<S,D>
   // we do not want to measure init stuff
   auto start = std::chrono::steady_clock::now();
 
-  physics::P3_Constants<S> aaa2;
+  physics::P3_Constants<S> loc_p3constants;
 
   // p3_main loop
   Kokkos::parallel_for(
@@ -256,7 +256,7 @@ Int Functions<S,D>
       nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr,
       mu_r, lamr, logn0r, oqv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend,
       ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange,
-      pratot, prctot, hydrometeorsPresent, nk, aaa2);
+      pratot, prctot, hydrometeorsPresent, nk, loc_p3constants);
 
     //NOTE: At this point, it is possible to have negative (but small) nc, nr, ni.  This is not
     //      a problem; those values get clipped to zero in the sedimentation section (if necessary).

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -84,7 +84,7 @@ Int Functions<S,D>
   const WorkspaceManager& workspace_mgr,
   Int nj,
   Int nk,
-  const physics::P3_Constants<S> & loc_p3constants)
+  const physics::P3_Constants<S> & p3constants)
 {
   using ExeSpace = typename KT::ExeSpace;
 
@@ -254,7 +254,7 @@ Int Functions<S,D>
       nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr,
       mu_r, lamr, logn0r, oqv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend,
       ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange,
-      pratot, prctot, hydrometeorsPresent, nk, loc_p3constants);
+      pratot, prctot, hydrometeorsPresent, nk, p3constants);
 
     //NOTE: At this point, it is possible to have negative (but small) nc, nr, ni.  This is not
     //      a problem; those values get clipped to zero in the sedimentation section (if necessary).
@@ -345,7 +345,7 @@ Int Functions<S,D>
   const WorkspaceManager& workspace_mgr,
   Int nj,
   Int nk,
-  const physics::P3_Constants<S> & loc_p3constants)
+  const physics::P3_Constants<S> & p3constants)
 {
 #ifndef SCREAM_SMALL_KERNELS
   return p3_main_internal(runtime_options,
@@ -356,7 +356,7 @@ Int Functions<S,D>
                          history_only,
                          lookup_tables,
                          workspace_mgr,
-                         nj, nk, loc_p3constants);
+                         nj, nk, p3constants);
 #else 
   return p3_main_internal_disp(runtime_options,
                                prognostic_state,
@@ -366,7 +366,7 @@ Int Functions<S,D>
                                history_only,
                                lookup_tables,
                                workspace_mgr,
-                               nj, nk, loc_p3constants);
+                               nj, nk, p3constants);
 #endif
 }
 } // namespace p3

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -84,7 +84,8 @@ Int Functions<S,D>
   const P3LookupTables& lookup_tables,
   const WorkspaceManager& workspace_mgr,
   Int nj,
-  Int nk)
+  Int nk,
+  physics::P3_Constants<S> & loc_p3constants)
 {
   using ExeSpace = typename KT::ExeSpace;
 
@@ -108,7 +109,7 @@ Int Functions<S,D>
   // we do not want to measure init stuff
   auto start = std::chrono::steady_clock::now();
 
-  physics::P3_Constants<S> loc_p3constants;
+  //physics::P3_Constants<S> loc_p3constants = loc_p3;
 
   // p3_main loop
   Kokkos::parallel_for(
@@ -346,7 +347,8 @@ Int Functions<S,D>
   const P3LookupTables& lookup_tables,
   const WorkspaceManager& workspace_mgr,
   Int nj,
-  Int nk)
+  Int nk,
+  physics::P3_Constants<S> & loc_p3constants)
 {
 #ifndef SCREAM_SMALL_KERNELS
   return p3_main_internal(runtime_options,
@@ -357,7 +359,7 @@ Int Functions<S,D>
                          history_only,
                          lookup_tables,
                          workspace_mgr,
-                         nj, nk);
+                         nj, nk, loc_p3constants);
 #else 
   return p3_main_internal_disp(runtime_options,
                                prognostic_state,
@@ -367,7 +369,7 @@ Int Functions<S,D>
                                history_only,
                                lookup_tables,
                                workspace_mgr,
-                               nj, nk);
+                               nj, nk, loc_p3constants);
 #endif
 }
 } // namespace p3

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -8,6 +8,7 @@
 #include "ekat/kokkos/ekat_subview_utils.hpp"
 
 namespace scream {
+
 namespace p3 {
 
 /*
@@ -106,6 +107,8 @@ Int Functions<S,D>
 
   // we do not want to measure init stuff
   auto start = std::chrono::steady_clock::now();
+
+  physics::P3_Constants<S> aaa2;
 
   // p3_main loop
   Kokkos::parallel_for(
@@ -253,7 +256,7 @@ Int Functions<S,D>
       nr_incld, ni_incld, bm_incld, mu_c, nu, lamc, cdist, cdist1, cdistr,
       mu_r, lamr, logn0r, oqv2qi_depos_tend, precip_total_tend, nevapr, qr_evap_tend,
       ovap_liq_exchange, ovap_ice_exchange, oliq_ice_exchange,
-      pratot, prctot, hydrometeorsPresent, nk);
+      pratot, prctot, hydrometeorsPresent, nk, aaa2);
 
     //NOTE: At this point, it is possible to have negative (but small) nc, nr, ni.  This is not
     //      a problem; those values get clipped to zero in the sedimentation section (if necessary).

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -8,7 +8,6 @@
 #include "ekat/kokkos/ekat_subview_utils.hpp"
 
 namespace scream {
-
 namespace p3 {
 
 /*
@@ -87,9 +86,6 @@ Int Functions<S,D>
   Int nk,
   const physics::P3_Constants<S> & loc_p3constants)
 {
-
-	std::cout << "ARE WE HERE???? \n";
-
   using ExeSpace = typename KT::ExeSpace;
 
   view_2d<Spack> latent_heat_sublim("latent_heat_sublim", nj, nk), latent_heat_vapor("latent_heat_vapor", nj, nk), latent_heat_fusion("latent_heat_fusion", nj, nk);
@@ -111,10 +107,6 @@ Int Functions<S,D>
 
   // we do not want to measure init stuff
   auto start = std::chrono::steady_clock::now();
-
-  //physics::P3_Constants<S> loc_p3constants = loc_p3;
-
-  std::cout << "before MAIN || " << loc_p3constants.p3_autoconversion_factor << "\n";
 
   // p3_main loop
   Kokkos::parallel_for(
@@ -355,9 +347,6 @@ Int Functions<S,D>
   Int nk,
   const physics::P3_Constants<S> & loc_p3constants)
 {
-
-	std::cout << "BBBBBBBBBBBBB are we in p3_main ? \n";
-
 #ifndef SCREAM_SMALL_KERNELS
   return p3_main_internal(runtime_options,
                          prognostic_state,

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -289,7 +289,7 @@ Int Functions<S,D>
       rho, inv_rho, rhofaci, ocld_frac_i, inv_dz, team, workspace, nk, ktop, kbot,
       kdir, infrastructure.dt, inv_dt, oqi, qi_incld, oni, ni_incld,
       oqm, qm_incld, obm, bm_incld, qtend_ignore, ntend_ignore,
-      lookup_tables.ice_table_vals, diagnostic_outputs.precip_ice_surf(i));
+      lookup_tables.ice_table_vals, diagnostic_outputs.precip_ice_surf(i), p3constants);
 
     // homogeneous freezing of cloud and rain
     homogeneous_freezing(

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -234,7 +234,7 @@ Int Functions<S,D>
       T_atm, rho, inv_rho, qv_sat_l, qv_sat_i, qv_supersat_i, rhofacr,
       rhofaci, acn, oqv, oth, oqc, onc, oqr, onr, oqi, oni, oqm,
       obm, qc_incld, qr_incld, qi_incld, qm_incld, nc_incld, nr_incld,
-      ni_incld, bm_incld, nucleationPossible, hydrometeorsPresent);
+      ni_incld, bm_incld, nucleationPossible, hydrometeorsPresent, p3constants);
 
     // There might not be any work to do for this team
     if (!(nucleationPossible || hydrometeorsPresent)) {
@@ -282,7 +282,7 @@ Int Functions<S,D>
       rho, inv_rho, rhofacr, ocld_frac_r, inv_dz, qr_incld, team, workspace,
       lookup_tables.vn_table_vals, lookup_tables.vm_table_vals, nk, ktop, kbot, kdir, infrastructure.dt, inv_dt, oqr,
       onr, nr_incld, mu_r, lamr, oprecip_liq_flux, qtend_ignore, ntend_ignore,
-      diagnostic_outputs.precip_liq_surf(i));
+      diagnostic_outputs.precip_liq_surf(i), p3constants);
 
     // Ice sedimentation:  (adaptive substepping)
     ice_sedimentation(
@@ -305,7 +305,7 @@ Int Functions<S,D>
       rho, inv_rho, rhofaci, oqv, oth, oqc, onc, oqr, onr, oqi, oni,
       oqm, obm, olatent_heat_vapor, olatent_heat_sublim, mu_c, nu, lamc, mu_r, lamr,
       ovap_liq_exchange, ze_rain, ze_ice, diag_vm_qi, odiag_eff_radius_qi, diag_diam_qi,
-      orho_qi, diag_equiv_reflectivity, odiag_eff_radius_qc, odiag_eff_radius_qr);
+      orho_qi, diag_equiv_reflectivity, odiag_eff_radius_qc, odiag_eff_radius_qr, p3constants);
 
     //
     // merge ice categories with similar properties

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part1.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part1.hpp
@@ -65,7 +65,8 @@ void Functions<S,D>
   const uview_1d<Spack>& ni_incld,
   const uview_1d<Spack>& bm_incld,
   bool& nucleationPossible,
-  bool& hydrometeorsPresent)
+  bool& hydrometeorsPresent,
+  const physics::P3_Constants<S> & p3constants)
 {
   // Get access to saturation functions
   using physics = scream::physics::Functions<Scalar, Device>;
@@ -79,6 +80,8 @@ void Functions<S,D>
   constexpr Scalar T_zerodegc   = C::T_zerodegc;
   constexpr Scalar qsmall       = C::QSMALL;
   constexpr Scalar inv_cp       = C::INV_CP;
+
+  const Scalar p3_spa_to_nc = p3constants.p3_spa_to_nc;
 
   nucleationPossible = false;
   hydrometeorsPresent = false;
@@ -131,7 +134,7 @@ void Functions<S,D>
       // prescribe that value
 
       if (do_prescribed_CCN) {
-         nc(k).set(not_drymass, max(nc(k), nccn_prescribed(k)/inv_cld_frac_l(k)));
+         nc(k).set(not_drymass, max(nc(k), p3_spa_to_nc*nccn_prescribed(k)/inv_cld_frac_l(k)));
       } else if (predictNc) {
          nc(k).set(not_drymass, max(nc(k) + nc_nuceat_tend(k) * dt, 0.0));
       } else {

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -95,7 +95,7 @@ void Functions<S,D>
   const uview_1d<Spack>& pratot,
   const uview_1d<Spack>& prctot,
   bool& hydrometeorsPresent, const Int& nk,
-  const physics::P3_Constants<S> & loc_p3constants )
+  const physics::P3_Constants<S> & p3constants )
 {
   constexpr Scalar qsmall       = C::QSMALL;
   constexpr Scalar nsmall       = C::NSMALL;
@@ -350,7 +350,7 @@ void Functions<S,D>
     // NOTE: cloud_water_autoconversion must be called before droplet_self_collection
     cloud_water_autoconversion(
       rho(k), qc_incld(k), nc_incld(k), inv_qc_relvar(k),
-      qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, loc_p3constants, not_skip_all);
+      qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, p3constants, not_skip_all);
 
     // self-collection of droplets
     droplet_self_collection(

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -360,7 +360,7 @@ void Functions<S,D>
     // accretion of cloud by rain
     cloud_rain_accretion(
       rho(k), inv_rho(k), qc_incld(k), nc_incld(k), qr_incld(k), inv_qc_relvar(k),
-      qc2qr_accret_tend, nc_accret_tend, not_skip_all);
+      qc2qr_accret_tend, nc_accret_tend, p3constants, not_skip_all);
 
     // self-collection and breakup of rain
     // (breakup following modified Verlinde and Cotton scheme)

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -216,7 +216,7 @@ void Functions<S,D>
                      lamc(k), cdist(k), cdist1(k), not_skip_micro);
       nc(k).set(not_skip_micro, nc_incld(k) * cld_frac_l(k));
 
-      get_rain_dsd2(qr_incld(k), nr_incld(k), mu_r(k), lamr(k), cdistr(k), logn0r(k), not_skip_micro);
+      get_rain_dsd2(qr_incld(k), nr_incld(k), mu_r(k), lamr(k), cdistr(k), logn0r(k), p3constants, not_skip_micro);
       nr(k).set(not_skip_micro, nr_incld(k) * cld_frac_r(k));
 
       impose_max_total_ni(ni_incld(k), max_total_ni, inv_rho(k), not_skip_micro);

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -228,7 +228,7 @@ void Functions<S,D>
         ni_incld(k).set(qi_gt_small, max(ni_incld(k), nsmall));
         nr_incld(k).set(qi_gt_small, max(nr_incld(k), nsmall));
 
-        const auto rhop = calc_bulk_rho_rime(qi_incld(k), qm_incld(k), bm_incld(k), qi_gt_small);
+        const auto rhop = calc_bulk_rho_rime(qi_incld(k), qm_incld(k), bm_incld(k), p3constants, qi_gt_small);
         qm(k).set(qi_gt_small, qm_incld(k)*cld_frac_i(k) );
         bm(k).set(qi_gt_small, bm_incld(k)*cld_frac_i(k) );
 
@@ -269,12 +269,12 @@ void Functions<S,D>
       // collection of droplets
       ice_cldliq_collection(
         rho(k), T_atm(k), rhofaci(k), table_val_qc2qi_collect, qi_incld(k), qc_incld(k), ni_incld(k), nc_incld(k),
-        qc2qi_collect_tend, nc_collect_tend, qc2qr_ice_shed_tend, ncshdc, not_skip_micro);
+        qc2qi_collect_tend, nc_collect_tend, qc2qr_ice_shed_tend, ncshdc, p3constants, not_skip_micro);
 
       // collection of rain
       ice_rain_collection(
         rho(k), T_atm(k), rhofaci(k), logn0r(k), table_val_nr_collect, table_val_qr2qi_collect, qi_incld(k), ni_incld(k), qr_incld(k),
-        qr2qi_collect_tend, nr_collect_tend, not_skip_micro);
+        qr2qi_collect_tend, nr_collect_tend, p3constants, not_skip_micro);
 
       // collection between ice categories
 
@@ -310,12 +310,12 @@ void Functions<S,D>
       // contact and immersion freezing droplets
       cldliq_immersion_freezing(
         T_atm(k), lamc(k), mu_c(k), cdist1(k), qc_incld(k), inv_qc_relvar(k),
-        qc2qi_hetero_freeze_tend, nc2ni_immers_freeze_tend, not_skip_micro);
+        qc2qi_hetero_freeze_tend, nc2ni_immers_freeze_tend, p3constants, not_skip_micro);
 
       // for future: get rid of log statements below for rain freezing
       rain_immersion_freezing(
         T_atm(k), lamr(k), mu_r(k), cdistr(k), qr_incld(k),
-        qr2qi_immers_freeze_tend, nr2ni_immers_freeze_tend, not_skip_micro);
+        qr2qi_immers_freeze_tend, nr2ni_immers_freeze_tend, p3constants, not_skip_micro);
 
       //  rime splintering (Hallet-Mossop 1974)
       // PMC comment: Morrison and Milbrandt 2015 part 1 and 2016 part 3 both say

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -95,7 +95,7 @@ void Functions<S,D>
   const uview_1d<Spack>& pratot,
   const uview_1d<Spack>& prctot,
   bool& hydrometeorsPresent, const Int& nk,
-  const physics::P3_Constants<S> & p3constants )
+  const physics::P3_Constants<S> & p3constants)
 {
   constexpr Scalar qsmall       = C::QSMALL;
   constexpr Scalar nsmall       = C::NSMALL;

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -95,8 +95,7 @@ void Functions<S,D>
   const uview_1d<Spack>& pratot,
   const uview_1d<Spack>& prctot,
   bool& hydrometeorsPresent, const Int& nk,
-  const physics::P3_Constants<S> &ccc
-  )
+  const physics::P3_Constants<S> & loc_p3constants )
 {
   constexpr Scalar qsmall       = C::QSMALL;
   constexpr Scalar nsmall       = C::NSMALL;
@@ -351,7 +350,7 @@ void Functions<S,D>
     // NOTE: cloud_water_autoconversion must be called before droplet_self_collection
     cloud_water_autoconversion(
       rho(k), qc_incld(k), nc_incld(k), inv_qc_relvar(k),
-      qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, ccc, not_skip_all);
+      qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, loc_p3constants, not_skip_all);
 
     // self-collection of droplets
     droplet_self_collection(

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -94,7 +94,9 @@ void Functions<S,D>
   const uview_1d<Spack>& liq_ice_exchange,
   const uview_1d<Spack>& pratot,
   const uview_1d<Spack>& prctot,
-  bool& hydrometeorsPresent, const Int& nk)
+  bool& hydrometeorsPresent, const Int& nk,
+  const physics::P3_Constants<S> &ccc
+  )
 {
   constexpr Scalar qsmall       = C::QSMALL;
   constexpr Scalar nsmall       = C::NSMALL;
@@ -349,7 +351,7 @@ void Functions<S,D>
     // NOTE: cloud_water_autoconversion must be called before droplet_self_collection
     cloud_water_autoconversion(
       rho(k), qc_incld(k), nc_incld(k), inv_qc_relvar(k),
-      qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, not_skip_all);
+      qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, ccc, not_skip_all);
 
     // self-collection of droplets
     droplet_self_collection(

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -344,7 +344,7 @@ void Functions<S,D>
     // deposition/condensation-freezing nucleation
     ice_nucleation(
       T_atm(k), inv_rho(k), ni(k), ni_activated(k), qv_supersat_i(k), inv_dt, predictNc, do_prescribed_CCN,
-      qv2qi_nucleat_tend, ni_nucleat_tend, not_skip_all);
+      qv2qi_nucleat_tend, ni_nucleat_tend, p3constants, not_skip_all);
 
     // cloud water autoconversion
     // NOTE: cloud_water_autoconversion must be called before droplet_self_collection
@@ -366,7 +366,7 @@ void Functions<S,D>
     // (breakup following modified Verlinde and Cotton scheme)
     rain_self_collection(
       rho(k), qr_incld(k), nr_incld(k),
-      nr_selfcollect_tend, not_skip_all);
+      nr_selfcollect_tend, p3constants, not_skip_all);
 
     // Here we map the microphysics tendency rates back to CELL-AVERAGE quantities for updating
     // cell-average quantities.

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
@@ -57,7 +57,8 @@ void Functions<S,D>
   const uview_1d<Spack>& rho_qi,
   const uview_1d<Spack>& diag_equiv_reflectivity,
   const uview_1d<Spack>& diag_eff_radius_qc,
-  const uview_1d<Spack>& diag_eff_radius_qr)
+  const uview_1d<Spack>& diag_eff_radius_qr,
+  const physics::P3_Constants<S> & p3constants)
 {
   constexpr Scalar qsmall       = C::QSMALL;
   constexpr Scalar inv_cp       = C::INV_CP;
@@ -107,7 +108,7 @@ void Functions<S,D>
       auto nr_incld = nr(k)/cld_frac_r(k); //nr_incld is updated in get_rain_dsd2 but isn't used again
 
       get_rain_dsd2(
-        qr_incld, nr_incld, mu_r(k), lamr(k), ignore1, ignore2, qr_gt_small);
+        qr_incld, nr_incld, mu_r(k), lamr(k), ignore1, ignore2, p3constants, qr_gt_small);
 
       //Note that integrating over the drop-size PDF as done here should only be done to in-cloud
       //quantities but radar reflectivity is likely meant to be a cell ave. Thus nr in the next line

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
@@ -143,7 +143,7 @@ void Functions<S,D>
       auto qm_incld = qm(k)/cld_frac_i(k);
       auto bm_incld = bm(k)/cld_frac_i(k);
 
-      const auto rhop = calc_bulk_rho_rime(qi_incld, qm_incld, bm_incld, qi_gt_small);
+      const auto rhop = calc_bulk_rho_rime(qi_incld, qm_incld, bm_incld, p3constants, qi_gt_small);
       qm(k).set(qi_gt_small, qm_incld*cld_frac_i(k) );
       bm(k).set(qi_gt_small, bm_incld*cld_frac_i(k) );
 

--- a/components/eamxx/src/physics/p3/impl/p3_rain_imm_freezing_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_rain_imm_freezing_impl.hpp
@@ -17,14 +17,16 @@ void Functions<S,D>
 ::rain_immersion_freezing(const Spack& T_atm, const Spack& lamr,
                           const Spack& mu_r, const Spack& cdistr,
                           const Spack& qr_incld, Spack& qr2qi_immers_freeze_tend, Spack& nr2ni_immers_freeze_tend,
-                          const Smask& context)
+                          const physics::P3_Constants<S> & p3constants,
+			  const Smask& context)
 {
   constexpr Scalar qsmall = C::QSMALL;
   constexpr Scalar T_rainfrz = C::T_rainfrz;
   constexpr Scalar T_zerodegc = C::T_zerodegc;
-  constexpr Scalar AIMM = C::AIMM;
   constexpr Scalar CONS5 = C::CONS5;
   constexpr Scalar CONS6 = C::CONS6;
+
+  const Scalar p3_a_imm = p3constants.p3_a_imm;
 
   const auto qr_not_small_and_t_freezing = (qr_incld >= qsmall) &&
                                            (T_atm <= T_rainfrz) && context;
@@ -32,11 +34,11 @@ void Functions<S,D>
     qr2qi_immers_freeze_tend.set(qr_not_small_and_t_freezing,
                CONS6 *
                exp(log(cdistr) + log(tgamma(sp(7.)+mu_r)) - sp(6.)*log(lamr)) *
-               exp(AIMM*(T_zerodegc-T_atm)));
+               exp(p3_a_imm*(T_zerodegc-T_atm)));
     nr2ni_immers_freeze_tend.set(qr_not_small_and_t_freezing,
                CONS5 *
                exp(log(cdistr) + log(tgamma(sp(4.)+mu_r)) - sp(3.)*log(lamr)) *
-               exp(AIMM*(T_zerodegc-T_atm)));
+               exp(p3_a_imm*(T_zerodegc-T_atm)));
   }
 }
 

--- a/components/eamxx/src/physics/p3/impl/p3_rain_sed_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_rain_sed_impl.hpp
@@ -18,11 +18,12 @@ void Functions<S,D>
   const view_2d_table& vn_table_vals, const view_2d_table& vm_table_vals,
   const Spack& qr_incld, const Spack& rhofacr,
   Spack& nr_incld, Spack& mu_r, Spack& lamr, Spack& V_qr, Spack& V_nr,
+  const physics::P3_Constants<S> & p3constants,
   const Smask& context)
 {
   Table3 table;
   Spack tmp1, tmp2; //ignore
-  get_rain_dsd2(qr_incld, nr_incld, mu_r, lamr, tmp1, tmp2, context);
+  get_rain_dsd2(qr_incld, nr_incld, mu_r, lamr, tmp1, tmp2, p3constants, context);
 
   if (context.any()) {
     lookup(mu_r, lamr, table, context);
@@ -55,7 +56,8 @@ void Functions<S,D>
   const uview_1d<Spack>& precip_liq_flux,
   const uview_1d<Spack>& qr_tend,
   const uview_1d<Spack>& nr_tend,
-  Scalar& precip_liq_surf)
+  Scalar& precip_liq_surf,
+  const physics::P3_Constants<S> & p3constants)
 {
   // Get temporary workspaces needed for the ice-sed calculation
   uview_1d<Spack> V_qr, V_nr, flux_qx, flux_nx;
@@ -111,7 +113,7 @@ void Functions<S,D>
           compute_rain_fall_velocity(vn_table_vals, vm_table_vals,
                                      qr_incld(pk), rhofacr(pk),
                                      nr_incld(pk), mu_r(pk), lamr(pk),
-				     V_qr(pk), V_nr(pk), qr_gt_small);
+				     V_qr(pk), V_nr(pk), p3constants, qr_gt_small);
 
 	  //in compute_rain_fall_velocity, get_rain_dsd2 keeps the drop-size
 	  //distribution within reasonable bounds by modifying nr_incld.

--- a/components/eamxx/src/physics/p3/impl/p3_rain_self_collection_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_rain_self_collection_impl.hpp
@@ -11,6 +11,7 @@ KOKKOS_FUNCTION
 void Functions<S,D>
 ::rain_self_collection(
   const Spack& rho, const Spack& qr_incld, const Spack& nr_incld, Spack& nr_selfcollect_tend,
+  const physics::P3_Constants<S> & p3constants,
   const Smask& context)
 {
   // ------------------------------------------------------
@@ -21,18 +22,20 @@ void Functions<S,D>
   constexpr Scalar rho_h2o  = C::RHO_H2O;
   constexpr Scalar pi       = C::Pi;
 
+  const Scalar p3_d_breakup_cutoff = p3constants.p3_d_breakup_cutoff;
+
   const auto qr_incld_not_small = qr_incld >= qsmall && context;
 
   if (qr_incld_not_small.any()) {
-    const Real dum1 = 280.e-6;
+    
     const auto dum2 = cbrt((qr_incld)/(pi*rho_h2o*nr_incld));
 
     Spack dum;
-    const auto dum2_lt_dum1 = dum2 < dum1 && qr_incld_not_small;
-    const auto dum2_gt_dum1 = dum2 >= dum1 && qr_incld_not_small;
+    const auto dum2_lt_dum1 = dum2 < p3_d_breakup_cutoff && qr_incld_not_small;
+    const auto dum2_gt_dum1 = dum2 >= p3_d_breakup_cutoff && qr_incld_not_small;
     dum.set(dum2_lt_dum1, 1);
     if (dum2_gt_dum1.any()) {
-      dum.set(dum2_gt_dum1, 2 - exp(2300 * (dum2-dum1)));
+      dum.set(dum2_gt_dum1, 2 - exp(2300 * (dum2-p3_d_breakup_cutoff)));
     }
 
     nr_selfcollect_tend.set(qr_incld_not_small, dum*sp(5.78)*nr_incld*qr_incld*rho);

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -1275,7 +1275,7 @@ struct Functions
     const WorkspaceManager& workspace_mgr,
     Int nj, // number of columns
     Int nk, // number of vertical cells per column
-    physics::P3_Constants<ScalarT> & loc_p3constants);
+    const physics::P3_Constants<ScalarT> & loc_p3constants);
 
   static Int p3_main_internal(
     const P3Runtime& runtime_options,
@@ -1288,7 +1288,7 @@ struct Functions
     const WorkspaceManager& workspace_mgr,
     Int nj, // number of columns
     Int nk, // number of vertical cells per column
-    physics::P3_Constants<ScalarT> & loc_p3constants);
+    const physics::P3_Constants<ScalarT> & loc_p3constants);
 
 #ifdef SCREAM_SMALL_KERNELS
   static Int p3_main_internal_disp(
@@ -1302,7 +1302,7 @@ struct Functions
     const WorkspaceManager& workspace_mgr,
     Int nj, // number of columns
     Int nk, // number of vertical cells per column
-    physics::P3_Constants<ScalarT> & loc_p3constants);
+    const physics::P3_Constants<ScalarT> & loc_p3constants);
 #endif
 
   KOKKOS_FUNCTION

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -661,6 +661,7 @@ struct Functions
   static void cloud_rain_accretion(const Spack& rho, const Spack& inv_rho,
     const Spack& qc_incld, const Spack& nc_incld, const Spack& qr_incld, const Spack& inv_qc_relvar,
     Spack& qc2qr_accret_tend, Spack& nc_accret_tend,
+    const physics::P3_Constants<ScalarT> & p3constants,
     const Smask& context = Smask(true) );
 
   // Computes cloud water autoconversion process rate

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -964,7 +964,8 @@ struct Functions
     const uview_1d<Spack>& ni_incld,
     const uview_1d<Spack>& bm_incld,
     bool& is_nucleat_possible,
-    bool& is_hydromet_present);
+    bool& is_hydromet_present,
+    const physics::P3_Constants<ScalarT> & p3constants);
 
 #ifdef SCREAM_SMALL_KERNELS
   static void p3_main_part1_disp(
@@ -1014,7 +1015,8 @@ struct Functions
     const uview_2d<Spack>& ni_incld,
     const uview_2d<Spack>& bm_incld,
     const uview_1d<bool>& is_nucleat_possible,
-    const uview_1d<bool>& is_hydromet_present);
+    const uview_1d<bool>& is_hydromet_present,
+    const physics::P3_Constants<ScalarT> & p3constants);
 #endif
 
   KOKKOS_FUNCTION

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -665,7 +665,8 @@ struct Functions
   static void cloud_water_autoconversion(const Spack& rho,  const Spack& qc_incld,
     const Spack& nc_incld, const Spack& inv_qc_relvar,
     Spack& qc2qr_autoconv_tend, Spack& nc2nr_autoconv_tend, Spack& ncautr,
-    const Smask& context = Smask(true) );
+    const physics::P3_Constants<ScalarT> & ccc,
+    const Smask& context = Smask(true));
 
   // Computes rain self collection process rate
   KOKKOS_FUNCTION
@@ -1090,7 +1091,8 @@ struct Functions
     const uview_1d<Spack>& pratot,
     const uview_1d<Spack>& prctot,
     bool& is_hydromet_present,
-    const Int& nk);
+    const Int& nk,
+    const physics::P3_Constants<ScalarT> &ccc);
 
 #ifdef SCREAM_SMALL_KERNELS
   static void p3_main_part2_disp(

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -1274,7 +1274,8 @@ struct Functions
     const P3LookupTables& lookup_tables,
     const WorkspaceManager& workspace_mgr,
     Int nj, // number of columns
-    Int nk); // number of vertical cells per column
+    Int nk, // number of vertical cells per column
+    physics::P3_Constants<ScalarT> & loc_p3constants);
 
   static Int p3_main_internal(
     const P3Runtime& runtime_options,
@@ -1286,7 +1287,8 @@ struct Functions
     const P3LookupTables& lookup_tables,
     const WorkspaceManager& workspace_mgr,
     Int nj, // number of columns
-    Int nk); // number of vertical cells per column
+    Int nk, // number of vertical cells per column
+    physics::P3_Constants<ScalarT> & loc_p3constants);
 
 #ifdef SCREAM_SMALL_KERNELS
   static Int p3_main_internal_disp(
@@ -1299,7 +1301,8 @@ struct Functions
     const P3LookupTables& lookup_tables,
     const WorkspaceManager& workspace_mgr,
     Int nj, // number of columns
-    Int nk); // number of vertical cells per column
+    Int nk, // number of vertical cells per column
+    physics::P3_Constants<ScalarT> & loc_p3constants);
 #endif
 
   KOKKOS_FUNCTION

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -679,6 +679,7 @@ struct Functions
   // Computes rain self collection process rate
   KOKKOS_FUNCTION
   static void rain_self_collection(const Spack& rho, const Spack& qr_incld, const Spack& nr_incld, Spack& nr_selfcollect_tend,
+		                   const physics::P3_Constants<ScalarT> & p3constants,
                                    const Smask& context = Smask(true) );
 
   // Impose maximum ice number
@@ -834,6 +835,7 @@ struct Functions
                              const Spack& qv_supersat_i, const Scalar& inv_dt,
                              const bool& do_predict_nc, const bool& do_prescribed_CCN,
                              Spack& qv2qi_nucleat_tend, Spack& ni_nucleat_tend,
+                             const physics::P3_Constants<ScalarT> & p3constants,
                              const Smask& context = Smask(true));
 
   KOKKOS_FUNCTION

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -511,7 +511,8 @@ struct Functions
     const uview_1d<Spack>& qi_tend,
     const uview_1d<Spack>& ni_tend,
     const view_ice_table& ice_table_vals,
-    Scalar& precip_ice_surf);
+    Scalar& precip_ice_surf,
+    const physics::P3_Constants<ScalarT> & p3constants);
 
 #ifdef SCREAM_SMALL_KERNELS
   static void ice_sedimentation_disp(
@@ -535,7 +536,8 @@ struct Functions
     const view_ice_table& ice_table_vals,
     const uview_1d<Scalar>& precip_ice_surf,
     const uview_1d<bool>& is_nucleat_possible,
-    const uview_1d<bool>& is_hydromet_present);
+    const uview_1d<bool>& is_hydromet_present,
+    const physics::P3_Constants<ScalarT> & p3constants);
 #endif
 
   // homogeneous freezing of cloud and rain
@@ -640,6 +642,7 @@ struct Functions
   static void cldliq_immersion_freezing(const Spack& T_atm, const Spack& lamc,
     const Spack& mu_c, const Spack& cdist1, const Spack& qc_incld, const Spack& inv_qc_relvar,
     Spack& qc2qi_hetero_freeze_tend, Spack& nc2ni_immers_freeze_tend,
+    const physics::P3_Constants<ScalarT> & p3constants,
     const Smask& context = Smask(true) );
 
   // Computes the immersion freezing of rain
@@ -647,6 +650,7 @@ struct Functions
   static void rain_immersion_freezing(const Spack& T_atm, const Spack& lamr,
     const Spack& mu_r, const Spack& cdistr, const Spack& qr_incld,
     Spack& qr2qi_immers_freeze_tend, Spack& nr2ni_immers_freeze_tend,
+    const physics::P3_Constants<ScalarT> & p3constants,
     const Smask& context = Smask(true) );
 
   // Computes droplet self collection
@@ -689,6 +693,7 @@ struct Functions
   KOKKOS_FUNCTION
   static Spack calc_bulk_rho_rime(
     const Spack& qi_tot, Spack& qi_rim, Spack& bi_rim,
+    const physics::P3_Constants<ScalarT> & p3constants,
     const Smask& context = Smask(true) );
 
   // TODO - comment
@@ -733,7 +738,8 @@ struct Functions
                                     const Spack& qi_incld, const Spack& qc_incld,
                                     const Spack& ni_incld, const Spack& nc_incld,
                                     Spack& qc2qi_collect_tend, Spack& nc_collect_tend, Spack& qc2qr_ice_shed_tend, Spack& ncshdc,
-                                    const Smask& context = Smask(true));
+                                    const physics::P3_Constants<ScalarT> & p3constants,
+	      			    const Smask& context = Smask(true));
 
   // TODO (comments)
   KOKKOS_FUNCTION
@@ -743,6 +749,7 @@ struct Functions
                                   const Spack& qi_incld, const Spack& ni_incld,
                                   const Spack& qr_incld,
                                   Spack& qr2qi_collect_tend, Spack& nr_collect_tend,
+                                  const physics::P3_Constants<ScalarT> & p3constants,
                                   const Smask& context = Smask(true));
 
   // TODO (comments)

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -461,7 +461,8 @@ struct Functions
     const uview_1d<Spack>& precip_liq_flux,
     const uview_1d<Spack>& qr_tend,
     const uview_1d<Spack>& nr_tend,
-    Scalar& precip_liq_surf);
+    Scalar& precip_liq_surf,
+    const physics::P3_Constants<ScalarT> & p3constants);
 
 #ifdef SCREAM_SMALL_KERNELS
   static void rain_sedimentation_disp(
@@ -484,7 +485,8 @@ struct Functions
     const uview_2d<Spack>& nr_tend,
     const uview_1d<Scalar>& precip_liq_surf,
     const uview_1d<bool>& is_nucleat_possible,
-    const uview_1d<bool>& is_hydromet_present);
+    const uview_1d<bool>& is_hydromet_present,
+    const physics::P3_Constants<ScalarT> & p3constants);
 #endif
 
   // TODO: comment
@@ -622,6 +624,7 @@ struct Functions
   static void get_rain_dsd2 (
     const Spack& qr, Spack& nr, Spack& mu_r,
     Spack& lamr, Spack& cdistr, Spack& logn0r,
+    const physics::P3_Constants<ScalarT> & p3constants,
     const Smask& context = Smask(true) );
 
   // Calculates rime density
@@ -693,6 +696,7 @@ struct Functions
     const view_2d_table& vn_table_vals, const view_2d_table& vm_table_vals,
     const Spack& qr_incld, const Spack& rhofacr,
     Spack& nr_incld, Spack& mu_r, Spack& lamr, Spack& V_qr, Spack& V_nr,
+    const physics::P3_Constants<ScalarT> & p3constants,
     const Smask& context = Smask(true));
 
   //---------------------------------------------------------------------------------
@@ -1216,7 +1220,8 @@ struct Functions
     const uview_1d<Spack>& rho_qi,
     const uview_1d<Spack>& diag_equiv_reflectivity,
     const uview_1d<Spack>& diag_eff_radius_qc,
-    const uview_1d<Spack>& diag_eff_radius_qr);
+    const uview_1d<Spack>& diag_eff_radius_qr,
+    const physics::P3_Constants<ScalarT> & p3constants);
 
 #ifdef SCREAM_SMALL_KERNELS
   static void p3_main_part3_disp(
@@ -1260,7 +1265,8 @@ struct Functions
     const uview_2d<Spack>& diag_eff_radius_qc,
     const uview_2d<Spack>& diag_eff_radius_qr,
     const uview_1d<bool>& is_nucleat_possible,
-    const uview_1d<bool>& is_hydromet_present);
+    const uview_1d<bool>& is_hydromet_present,
+    const physics::P3_Constants<ScalarT> & p3constants);
 #endif
 
   // Return microseconds elapsed

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -72,6 +72,7 @@ struct Functions
   using KT = KokkosTypes<Device>;
 
   using C = scream::physics::Constants<Scalar>;
+  using CP3 = scream::physics::P3_Constants<Scalar>;
 
   template <typename S>
   using view_1d = typename KT::template view_1d<S>;

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -665,7 +665,7 @@ struct Functions
   static void cloud_water_autoconversion(const Spack& rho,  const Spack& qc_incld,
     const Spack& nc_incld, const Spack& inv_qc_relvar,
     Spack& qc2qr_autoconv_tend, Spack& nc2nr_autoconv_tend, Spack& ncautr,
-    const physics::P3_Constants<ScalarT> & loc_p3constants,
+    const physics::P3_Constants<ScalarT> & p3constants,
     const Smask& context = Smask(true));
 
   // Computes rain self collection process rate
@@ -1092,7 +1092,7 @@ struct Functions
     const uview_1d<Spack>& prctot,
     bool& is_hydromet_present,
     const Int& nk,
-    const physics::P3_Constants<ScalarT> & loc_p3constants);
+    const physics::P3_Constants<ScalarT> & p3constants);
 
 #ifdef SCREAM_SMALL_KERNELS
   static void p3_main_part2_disp(
@@ -1173,7 +1173,7 @@ struct Functions
     const uview_2d<Spack>& prctot,
     const uview_1d<bool>& is_nucleat_possible,
     const uview_1d<bool>& is_hydromet_present,
-    const physics::P3_Constants<ScalarT> & loc_p3constants);
+    const physics::P3_Constants<ScalarT> & p3constants);
 #endif
 
   KOKKOS_FUNCTION
@@ -1275,7 +1275,7 @@ struct Functions
     const WorkspaceManager& workspace_mgr,
     Int nj, // number of columns
     Int nk, // number of vertical cells per column
-    const physics::P3_Constants<ScalarT> & loc_p3constants);
+    const physics::P3_Constants<ScalarT> & p3constants);
 
   static Int p3_main_internal(
     const P3Runtime& runtime_options,
@@ -1288,7 +1288,7 @@ struct Functions
     const WorkspaceManager& workspace_mgr,
     Int nj, // number of columns
     Int nk, // number of vertical cells per column
-    const physics::P3_Constants<ScalarT> & loc_p3constants);
+    const physics::P3_Constants<ScalarT> & p3constants);
 
 #ifdef SCREAM_SMALL_KERNELS
   static Int p3_main_internal_disp(
@@ -1302,7 +1302,7 @@ struct Functions
     const WorkspaceManager& workspace_mgr,
     Int nj, // number of columns
     Int nk, // number of vertical cells per column
-    const physics::P3_Constants<ScalarT> & loc_p3constants);
+    const physics::P3_Constants<ScalarT> & p3constants);
 #endif
 
   KOKKOS_FUNCTION

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -665,7 +665,7 @@ struct Functions
   static void cloud_water_autoconversion(const Spack& rho,  const Spack& qc_incld,
     const Spack& nc_incld, const Spack& inv_qc_relvar,
     Spack& qc2qr_autoconv_tend, Spack& nc2nr_autoconv_tend, Spack& ncautr,
-    const physics::P3_Constants<ScalarT> & ccc,
+    const physics::P3_Constants<ScalarT> & loc_p3constants,
     const Smask& context = Smask(true));
 
   // Computes rain self collection process rate
@@ -1092,7 +1092,7 @@ struct Functions
     const uview_1d<Spack>& prctot,
     bool& is_hydromet_present,
     const Int& nk,
-    const physics::P3_Constants<ScalarT> &ccc);
+    const physics::P3_Constants<ScalarT> & loc_p3constants);
 
 #ifdef SCREAM_SMALL_KERNELS
   static void p3_main_part2_disp(
@@ -1172,7 +1172,8 @@ struct Functions
     const uview_2d<Spack>& pratot,
     const uview_2d<Spack>& prctot,
     const uview_1d<bool>& is_nucleat_possible,
-    const uview_1d<bool>& is_hydromet_present);
+    const uview_1d<bool>& is_hydromet_present,
+    const physics::P3_Constants<ScalarT> & loc_p3constants);
 #endif
 
   KOKKOS_FUNCTION

--- a/components/eamxx/src/physics/p3/p3_functions_f90.cpp
+++ b/components/eamxx/src/physics/p3/p3_functions_f90.cpp
@@ -1329,7 +1329,7 @@ void ice_sedimentation_f(
       nk, ktop, kbot, kdir, dt, inv_dt,
       qi_d, qi_incld_d, ni_d, ni_incld_d, qm_d, qm_incld_d, bm_d, bm_incld_d,
       qi_tend_d, ni_tend_d, ice_table_vals,
-      precip_ice_surf_k);
+      precip_ice_surf_k, physics::P3_Constants<Real>());
 
   }, my_precip_ice_surf);
   *precip_ice_surf += my_precip_ice_surf;
@@ -1402,7 +1402,7 @@ void rain_sedimentation_f(
       team, wsm.get_workspace(team), vn_table_vals, vm_table_vals,
       nk, ktop, kbot, kdir, dt, inv_dt,
       qr_d, nr_d, nr_incld_d, mu_r_d, lamr_d, precip_liq_flux_d, qr_tend_d, nr_tend_d,
-      precip_liq_surf_k);
+      precip_liq_surf_k, physics::P3_Constants<Real>());
 
   }, my_precip_liq_surf);
   *precip_liq_surf += my_precip_liq_surf;
@@ -1634,7 +1634,7 @@ void p3_main_part1_f(
       t_d, rho_d, inv_rho_d, qv_sat_l_d, qv_sat_i_d, qv_supersat_i_d, rhofacr_d, rhofaci_d,
       acn_d, qv_d, th_atm_d, qc_d, nc_d, qr_d, nr_d, qi_d, ni_d, qm_d, bm_d, qc_incld_d, qr_incld_d, qi_incld_d,
       qm_incld_d, nc_incld_d, nr_incld_d, ni_incld_d, bm_incld_d,
-      bools_d(0), bools_d(1));
+      bools_d(0), bools_d(1), physics::P3_Constants<Real>());
   });
 
   // Sync back to host
@@ -1784,7 +1784,7 @@ void p3_main_part2_f(
       qm_incld_d, nc_incld_d, nr_incld_d, ni_incld_d, bm_incld_d,
       mu_c_d, nu_d, lamc_d, cdist_d, cdist1_d, cdistr_d, mu_r_d, lamr_d,
       logn0r_d, qv2qi_depos_tend_d, precip_total_tend_d, nevapr_d, qr_evap_tend_d, vap_liq_exchange_d,
-      vap_ice_exchange_d, liq_ice_exchange_d, pratot_d, prctot_d, bools_d(0),nk);
+      vap_ice_exchange_d, liq_ice_exchange_d, pratot_d, prctot_d, bools_d(0),nk, physics::P3_Constants<Real>());
   });
 
   // Sync back to host. Skip intent in variables.
@@ -1902,7 +1902,7 @@ void p3_main_part3_f(
                        latent_heat_sublim_d, mu_c_d, nu_d, lamc_d, mu_r_d, lamr_d,
                        vap_liq_exchange_d, ze_rain_d, ze_ice_d,
                        diag_vm_qi_d, diag_eff_radius_qi_d, diag_diam_qi_d, rho_qi_d,
-                       diag_equiv_reflectivity_d, diag_eff_radius_qc_d, diag_eff_radius_qr_d);
+                       diag_equiv_reflectivity_d, diag_eff_radius_qc_d, diag_eff_radius_qr_d, physics::P3_Constants<Real>());
   });
 
   // Sync back to host
@@ -2073,7 +2073,7 @@ Int p3_main_f(
   ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(nk_pack, 52, policy);
 
   auto elapsed_microsec = P3F::p3_main(runtime_options, prog_state, diag_inputs, diag_outputs, infrastructure,
-                                       history_only, lookup_tables, workspace_mgr, nj, nk);
+                                       history_only, lookup_tables, workspace_mgr, nj, nk, physics::P3_Constants<Real>());
 
   Kokkos::parallel_for(nj, KOKKOS_LAMBDA(const Int& i) {
     precip_liq_surf_temp_d(0, i / Spack::n)[i % Spack::n] = precip_liq_surf_d(i);

--- a/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
@@ -81,7 +81,7 @@ static void  cloud_water_autoconversion_unit_bfb_tests(){
     }
 
     Functions::cloud_water_autoconversion(rho, qc_incld, nc_incld,
-      inv_qc_relvar, qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr);
+      inv_qc_relvar, qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, physics::P3_Constants<Real>());
 
     // Copy results back into views
     for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {
@@ -123,7 +123,8 @@ static void  cloud_water_autoconversion_unit_bfb_tests(){
     for(int si=0; si<Spack::n; ++si){
         qc_incld[si] = 1e-6 * i * Spack::n + si;
       }
-    Functions::cloud_water_autoconversion(rho, qc_incld, nc_incld, inv_qc_relvar, qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr);
+    Functions::cloud_water_autoconversion(rho, qc_incld, nc_incld, inv_qc_relvar, qc2qr_autoconv_tend, 
+		    nc2nr_autoconv_tend, ncautr, physics::P3_Constants<Real>());
         if((qc2qr_autoconv_tend < 0.0).any()){errors++;}
     }
 

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -94,7 +94,7 @@ static void run_bfb()
     Spack nc2ni_immers_freeze_tend{0.0};
 
     Functions::cldliq_immersion_freezing(T_atm, lamc, mu_c, cdist1, qc_incld, inv_qc_relvar,
-                                         qc2qi_hetero_freeze_tend, nc2ni_immers_freeze_tend);
+                                         qc2qi_hetero_freeze_tend, nc2ni_immers_freeze_tend, physics::P3_Constants<Real>());
 
     // Copy results back into views
     for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {

--- a/components/eamxx/src/physics/p3/tests/p3_cloud_rain_acc_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cloud_rain_acc_unit_tests.cpp
@@ -97,7 +97,7 @@ static void run_bfb()
     Spack nc_accret_tend{0.0};
 
     Functions::cloud_rain_accretion(rho, inv_rho, qc_incld, nc_incld, qr_incld,
-                                    inv_qc_relvar, qc2qr_accret_tend, nc_accret_tend);
+                                    inv_qc_relvar, qc2qr_accret_tend, nc_accret_tend, physics::P3_Constants<Real>());
 
     // Copy results back into views
     for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {

--- a/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
@@ -161,7 +161,7 @@ struct UnitWrap::UnitTest<D>::TestDsd2 {
       }
 
       Spack mu_r(0.0), lamr(0.0), cdistr(0.0), logn0r(0.0);
-      Functions::get_rain_dsd2(qr, nr, mu_r, lamr, cdistr, logn0r);
+      Functions::get_rain_dsd2(qr, nr, mu_r, lamr, cdistr, logn0r, physics::P3_Constants<Real>());
 
       // Copy results back into views
       for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {

--- a/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
@@ -92,7 +92,7 @@ struct UnitWrap::UnitTest<D>::TestIceCollection {
 
       Functions::ice_cldliq_collection(rho, temp, rhofaci, table_val_qc2qi_collect, qi_incld,
                                        qc_incld, ni_incld, nc_incld,
-                                       qc2qi_collect_tend, nc_collect_tend, qc2qr_ice_shed_tend, ncshdc);
+                                       qc2qi_collect_tend, nc_collect_tend, qc2qr_ice_shed_tend, ncshdc, physics::P3_Constants<Real>());
 
       // Copy results back into views
       for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {
@@ -181,7 +181,7 @@ struct UnitWrap::UnitTest<D>::TestIceCollection {
       Spack qr2qi_collect_tend(0.0), nr_collect_tend(0.0);
       Functions::ice_rain_collection(rho, temp, rhofaci, logn0r, table_val_nr_collect, table_val_qr2qi_collect,
                                      qi_incld, ni_incld, qr_incld,
-                                     qr2qi_collect_tend, nr_collect_tend);
+                                     qr2qi_collect_tend, nr_collect_tend, physics::P3_Constants<Real>());
 
       // Copy results back into views
       for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {

--- a/components/eamxx/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
@@ -82,7 +82,7 @@ struct UnitWrap::UnitTest<D>::TestIceNucleation {
 	    Spack qv2qi_nucleat_tend{0.0};
 	    Spack ni_nucleat_tend{0.0};
 	    Functions::ice_nucleation(temp, inv_rho, ni, ni_activated, qv_supersat_i, self_device(0).inv_dt, do_predict_nc,
-				      do_prescribed_CCN, qv2qi_nucleat_tend, ni_nucleat_tend);
+				      do_prescribed_CCN, qv2qi_nucleat_tend, ni_nucleat_tend, physics::P3_Constants<Real>());
 
 	    for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {
 	      self_device(vs).qv2qi_nucleat_tend = qv2qi_nucleat_tend[s];

--- a/components/eamxx/src/physics/p3/tests/p3_ice_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_sed_unit_tests.cpp
@@ -98,7 +98,7 @@ static void run_bfb_calc_bulk_rhime()
     }
 
     Smask gt_small(qi_tot > qsmall);
-    Spack rho_rime = Functions::calc_bulk_rho_rime(qi_tot, qi_rim, bi_rim, gt_small);
+    Spack rho_rime = Functions::calc_bulk_rho_rime(qi_tot, qi_rim, bi_rim, physics::P3_Constants<Real>(), gt_small);
 
     // Copy results back into views
     for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {

--- a/components/eamxx/src/physics/p3/tests/p3_rain_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_imm_freezing_unit_tests.cpp
@@ -92,7 +92,7 @@ static void run_bfb()
     Spack nr2ni_immers_freeze_tend{0.0};
 
     Functions::rain_immersion_freezing(T_atm, lamr, mu_r, cdistr, qr_incld,
-                                       qr2qi_immers_freeze_tend, nr2ni_immers_freeze_tend);
+                                       qr2qi_immers_freeze_tend, nr2ni_immers_freeze_tend, physics::P3_Constants<Real>());
 
     // Copy results back into views
     for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {

--- a/components/eamxx/src/physics/p3/tests/p3_rain_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_sed_unit_tests.cpp
@@ -96,7 +96,7 @@ static void run_bfb_rain_vel()
 
     Spack mu_r(0), lamr(0), V_qr(0), V_nr(0);
     Functions::compute_rain_fall_velocity(
-      vn_table_vals, vm_table_vals, qr_incld, rhofacr, nr_incld, mu_r, lamr, V_qr, V_nr);
+      vn_table_vals, vm_table_vals, qr_incld, rhofacr, nr_incld, mu_r, lamr, V_qr, V_nr, physics::P3_Constants<Real>());
 
     // Copy results back into views
     for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {

--- a/components/eamxx/src/physics/p3/tests/p3_rain_self_collection_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_self_collection_tests.cpp
@@ -74,7 +74,8 @@ struct UnitWrap::UnitTest<D>::TestRainSelfCollection {
         nr_selfcollect_tend_local[s]    = dc_device(vs).nr_selfcollect_tend;
       }
 
-      Functions::rain_self_collection(rho_local, qr_incld_local, nr_incld_local, nr_selfcollect_tend_local);
+      Functions::rain_self_collection(rho_local, qr_incld_local, nr_incld_local, nr_selfcollect_tend_local,
+		      physics::P3_Constants<Real>());
 
       // Copy results back into views
       for (Int s = 0, vs = offset; s < Spack::n; ++s, ++vs) {

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -130,17 +130,18 @@ template <typename Scalar>
 struct P3_Constants
 {
   public:
-  static Scalar p3_autoconversion_factor;
+  Scalar p3_autoconversion_factor;
 
-  static void set_p3_defaults(){
+  void set_p3_defaults(){
     //set it to 1000 for debugging, otherwise 1350.0
     p3_autoconversion_factor = 1000.0;
   };
 
 }; // p3 constants
 
-template<typename Scalar>
-Scalar P3_Constants<Scalar>::p3_autoconversion_factor = 1000.0;
+//template<typename Scalar>
+//Scalar P3_Constants<Scalar>::p3_autoconversion_factor = 1000.0;
+
 
 // Gases
 // Define the molecular weight for each gas, which can then be

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -126,6 +126,29 @@ struct Constants
   static constexpr Scalar earth_ellipsoid3 = 1.175;     // third expansion coefficient for WGS84 ellipsoid
 };
 
+template <typename Scalar>
+struct P3_Constants
+{
+
+private:
+   static Scalar p3_autoconversion_factor;
+
+public:
+static void set_p3_defaults(){
+  set_p3_autoconversion_factor(1350.0);
+};
+
+static Scalar get_p3_autoconversion_factor(){
+  return p3_autoconversion_factor;
+}
+
+static void set_p3_autoconversion_factor(Scalar inp){
+  p3_autoconversion_factor = inp;
+}
+
+}; // p3 constants
+
+
 // Gases
 // Define the molecular weight for each gas, which can then be
 // used to determine the volume mixing ratio for each gas.

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -5,6 +5,7 @@
 
 #include "ekat/util/ekat_string_utils.hpp"
 #include "ekat/ekat_scalar_traits.hpp"
+#include "ekat/logging/ekat_logger.hpp"
 
 #include <vector>
 
@@ -130,11 +131,19 @@ template <typename Scalar>
 struct P3_Constants
 {
   public:
-  Scalar p3_autoconversion_factor;
+  Scalar p3_pre_autoconversion_factor = 1350.0;
 
-  void set_p3_defaults(){
-    //set it to 1000 for debugging, otherwise 1350.0
-    p3_autoconversion_factor = 1000.0;
+  void set_p3_from_namelist(ekat::ParameterList &params){
+    std::string nname = "p3_pre_autoconversion_factor";
+    if(params.isParameter(nname))
+       p3_pre_autoconversion_factor = params.get<double>(nname);
+  };
+
+  void print_p3constants(std::shared_ptr<ekat::logger::LoggerBase> logger){
+      logger->info("P3 Constants:");
+      std::string nname = "p3_pre_autoconversion_factor";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_pre_autoconversion_factor));
+      logger->info(" ");
   };
 
 }; // P3_Constants

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -131,7 +131,8 @@ struct P3_Constants
 {
   public:
   Scalar p3_pre_autoconversion_factor = 1350.0;
-  Scalar p3_mu_r_constant = 1.0;
+  Scalar p3_mu_r_constant             = 1.0;
+  Scalar p3_spa_to_nc                 = 1.0;
 
   void set_p3_from_namelist(ekat::ParameterList &params){
     std::string nname = "p3_pre_autoconversion_factor";
@@ -140,6 +141,9 @@ struct P3_Constants
     nname = "p3_mu_r_constant";
     if(params.isParameter(nname))
        p3_mu_r_constant = params.get<double>(nname);
+    nname = "p3_spa_to_nc";
+    if(params.isParameter(nname))
+       p3_spa_to_nc = params.get<double>(nname);
 
   };
 
@@ -149,6 +153,8 @@ struct P3_Constants
       logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_pre_autoconversion_factor));
       nname = "p3_mu_r_constant";
       logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_mu_r_constant));
+      nname = "p3_spa_to_nc";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_spa_to_nc));
       logger->info(" ");
   };
 

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -132,12 +132,15 @@ struct P3_Constants
   public:
   static Scalar p3_autoconversion_factor;
 
-  void set_p3_defaults(){
-    p3_autoconversion_factor = 1350.0;
+  static void set_p3_defaults(){
+    //set it to 1000 for debugging, otherwise 1350.0
+    p3_autoconversion_factor = 1000.0;
   };
 
 }; // p3 constants
 
+template<typename Scalar>
+Scalar P3_Constants<Scalar>::p3_autoconversion_factor = 1000.0;
 
 // Gases
 // Define the molecular weight for each gas, which can then be

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -125,7 +125,7 @@ template <typename Scalar>
 struct P3_Constants
 {
   public:
-  Scalar p3_pre_autoconversion_factor = 1350.0;
+  Scalar p3_autoconversion_prefactor = 1350.0;
   Scalar p3_mu_r_constant             = 1.0;
   Scalar p3_spa_to_nc                 = 1.0;
   Scalar p3_k_accretion               = 67.0;
@@ -134,12 +134,15 @@ struct P3_Constants
   Scalar p3_rho_rime_min              = 50.0;
   Scalar p3_rho_rime_max              = 900.0;
   Scalar p3_a_imm                     = 0.65;
+  Scalar p3_dep_nucleation_exponent   = 0.304;
+  Scalar p3_ice_sed_knob              = 1.0;
+  Scalar p3_d_breakup_cutoff          = 0.00028;
 
   void set_p3_from_namelist(ekat::ParameterList &params){
 
-    std::string nname = "p3_pre_autoconversion_factor";
+    std::string nname = "p3_autoconversion_prefactor";
     if(params.isParameter(nname))
-       p3_pre_autoconversion_factor = params.get<double>(nname);
+       p3_autoconversion_prefactor = params.get<double>(nname);
 
     nname = "p3_mu_r_constant";
     if(params.isParameter(nname))
@@ -173,13 +176,25 @@ struct P3_Constants
     if(params.isParameter(nname))
        p3_a_imm = params.get<double>(nname);
 
+    nname = "p3_dep_nucleation_exponent";
+    if(params.isParameter(nname))
+       p3_dep_nucleation_exponent = params.get<double>(nname);
+
+    nname = "p3_ice_sed_knob";
+    if(params.isParameter(nname))
+       p3_ice_sed_knob = params.get<double>(nname);
+
+    nname = "p3_d_breakup_cutoff";
+    if(params.isParameter(nname))
+       p3_d_breakup_cutoff = params.get<double>(nname);
+
   };
 
   void print_p3constants(std::shared_ptr<ekat::logger::LoggerBase> logger){
       logger->info("P3 Constants:");
 
-      std::string nname = "p3_pre_autoconversion_factor";
-      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_pre_autoconversion_factor));
+      std::string nname = "p3_autoconversion_prefactor";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_autoconversion_prefactor));
 
       nname = "p3_mu_r_constant";
       logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_mu_r_constant));
@@ -204,6 +219,15 @@ struct P3_Constants
 
       nname = "p3_a_imm";
       logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_a_imm));
+
+      nname = "p3_dep_nucleation_exponent";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_dep_nucleation_exponent));
+
+      nname = "p3_ice_sed_knob";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_ice_sed_knob));
+
+      nname = "p3_d_breakup_cutoff";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_d_breakup_cutoff));
 
       logger->info(" ");
   };

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -137,11 +137,7 @@ struct P3_Constants
     p3_autoconversion_factor = 1000.0;
   };
 
-}; // p3 constants
-
-//template<typename Scalar>
-//Scalar P3_Constants<Scalar>::p3_autoconversion_factor = 1000.0;
-
+}; // P3_Constants
 
 // Gases
 // Define the molecular weight for each gas, which can then be

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -129,22 +129,12 @@ struct Constants
 template <typename Scalar>
 struct P3_Constants
 {
+  public:
+  static Scalar p3_autoconversion_factor;
 
-private:
-   static Scalar p3_autoconversion_factor;
-
-public:
-static void set_p3_defaults(){
-  set_p3_autoconversion_factor(1350.0);
-};
-
-static Scalar get_p3_autoconversion_factor(){
-  return p3_autoconversion_factor;
-}
-
-static void set_p3_autoconversion_factor(Scalar inp){
-  p3_autoconversion_factor = inp;
-}
+  void set_p3_defaults(){
+    p3_autoconversion_factor = 1350.0;
+  };
 
 }; // p3 constants
 

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -53,7 +53,6 @@ struct Constants
   static constexpr Scalar SXTH          = 1.0/6.0;
   static constexpr Scalar PIOV3         = Pi*THIRD;
   static constexpr Scalar PIOV6         = Pi*SXTH;
-  static constexpr Scalar AIMM          = 0.65;
   static constexpr Scalar BIMM          = 2.0;
   static constexpr Scalar CONS1         = PIOV6*RHOW;
   static constexpr Scalar CONS2         = 4.*PIOV3*RHOW;
@@ -79,10 +78,6 @@ struct Constants
   static constexpr Scalar macheps = std::numeric_limits<Real>::epsilon();
   static constexpr Scalar dt_left_tol   = 1.e-4;
   static constexpr Scalar bcn           = 2.;
-  static constexpr Scalar rho_rimeMin   = 50.;
-  static constexpr Scalar rho_rimeMax   = 900.;
-  static constexpr Scalar eci           = 0.5;
-  static constexpr Scalar eri           = 1.0;
   static constexpr Scalar dropmass      = 5.2e-7;
   static constexpr Scalar NCCNST        = 200.0e+6;
   static constexpr Scalar incloud_limit = 5.1e-3;
@@ -134,6 +129,11 @@ struct P3_Constants
   Scalar p3_mu_r_constant             = 1.0;
   Scalar p3_spa_to_nc                 = 1.0;
   Scalar p3_k_accretion               = 67.0;
+  Scalar p3_eci                       = 0.5;
+  Scalar p3_eri                       = 1.0;
+  Scalar p3_rho_rime_min              = 50.0;
+  Scalar p3_rho_rime_max              = 900.0;
+  Scalar p3_a_imm                     = 0.65;
 
   void set_p3_from_namelist(ekat::ParameterList &params){
 
@@ -153,16 +153,58 @@ struct P3_Constants
     if(params.isParameter(nname))
        p3_k_accretion = params.get<double>(nname);
 
+    nname = "p3_eci";
+    if(params.isParameter(nname))
+       p3_eci = params.get<double>(nname);
+
+    nname = "p3_eri";
+    if(params.isParameter(nname))
+       p3_eri = params.get<double>(nname);
+
+    nname = "p3_rho_rime_min";
+    if(params.isParameter(nname))
+       p3_rho_rime_min = params.get<double>(nname);
+
+    nname = "p3_rho_rime_max";
+    if(params.isParameter(nname))
+       p3_rho_rime_max = params.get<double>(nname);
+
+    nname = "p3_a_imm";
+    if(params.isParameter(nname))
+       p3_a_imm = params.get<double>(nname);
+
   };
 
   void print_p3constants(std::shared_ptr<ekat::logger::LoggerBase> logger){
       logger->info("P3 Constants:");
+
       std::string nname = "p3_pre_autoconversion_factor";
       logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_pre_autoconversion_factor));
+
       nname = "p3_mu_r_constant";
       logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_mu_r_constant));
+
       nname = "p3_spa_to_nc";
       logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_spa_to_nc));
+
+      nname = "p3_k_accretion";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_k_accretion));
+
+      nname = "p3_eci";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_eci));
+
+      nname = "p3_eri";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_eri));
+
+      nname = "p3_rho_rime_min";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_rho_rime_min));
+
+      nname = "p3_rho_rime_max";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_rho_rime_max));
+
+      nname = "p3_a_imm";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_a_imm));
+
       logger->info(" ");
   };
 

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -77,7 +77,6 @@ struct Constants
   static constexpr Scalar INV_CP        = 1.0/CP;
   //  static constexpr Scalar Tol           = ekat::is_single_precision<Real>::value ? 2e-5 : 1e-14;
   static constexpr Scalar macheps = std::numeric_limits<Real>::epsilon();
-  static constexpr Scalar mu_r_const    = 1.0;
   static constexpr Scalar dt_left_tol   = 1.e-4;
   static constexpr Scalar bcn           = 2.;
   static constexpr Scalar rho_rimeMin   = 50.;
@@ -132,19 +131,28 @@ struct P3_Constants
 {
   public:
   Scalar p3_pre_autoconversion_factor = 1350.0;
+  Scalar p3_mu_r_constant = 1.0;
 
   void set_p3_from_namelist(ekat::ParameterList &params){
     std::string nname = "p3_pre_autoconversion_factor";
     if(params.isParameter(nname))
        p3_pre_autoconversion_factor = params.get<double>(nname);
+    nname = "p3_mu_r_constant";
+    if(params.isParameter(nname))
+       p3_mu_r_constant = params.get<double>(nname);
+
   };
 
   void print_p3constants(std::shared_ptr<ekat::logger::LoggerBase> logger){
       logger->info("P3 Constants:");
       std::string nname = "p3_pre_autoconversion_factor";
       logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_pre_autoconversion_factor));
+      nname = "p3_mu_r_constant";
+      logger->info(std::string("P3   ") + nname + std::string(" = ") + std::to_string(p3_mu_r_constant));
       logger->info(" ");
   };
+
+  //one can implement a check here too, for acceptable ranges
 
 }; // P3_Constants
 

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -133,17 +133,25 @@ struct P3_Constants
   Scalar p3_pre_autoconversion_factor = 1350.0;
   Scalar p3_mu_r_constant             = 1.0;
   Scalar p3_spa_to_nc                 = 1.0;
+  Scalar p3_k_accretion               = 67.0;
 
   void set_p3_from_namelist(ekat::ParameterList &params){
+
     std::string nname = "p3_pre_autoconversion_factor";
     if(params.isParameter(nname))
        p3_pre_autoconversion_factor = params.get<double>(nname);
+
     nname = "p3_mu_r_constant";
     if(params.isParameter(nname))
        p3_mu_r_constant = params.get<double>(nname);
+
     nname = "p3_spa_to_nc";
     if(params.isParameter(nname))
        p3_spa_to_nc = params.get<double>(nname);
+
+    nname = "p3_k_accretion";
+    if(params.isParameter(nname))
+       p3_k_accretion = params.get<double>(nname);
 
   };
 

--- a/components/eamxx/src/physics/share/tests/physics_saturation_run_and_cmp.cpp
+++ b/components/eamxx/src/physics/share/tests/physics_saturation_run_and_cmp.cpp
@@ -50,7 +50,7 @@ struct UnitWrap::UnitTest<D>::TestSaturation
     sat_ice_fp  = physics::polysvp1(temps, true, Smask(true))[0];
     sat_liq_fp  = physics::polysvp1(temps, false, Smask(true))[0];
 
-    //Functions<S,D>::qv_sat_dry(const Spack& t_atm, const Spack& p_atm_dry, const bool ice, const Smask& range_mask, 
+    //Functions<S,D>::qv_sat_dry(const Spack& t_atm, const Spack& p_atm_dry, const bool ice, const Smask& range_mask,
     //                           const SaturationFcn func_idx, const char* caller)
     mix_ice_fr = physics::qv_sat_dry(temps, pres, true, Smask(true), physics::Polysvp1)[0];
     mix_liq_fr = physics::qv_sat_dry(temps, pres, false,Smask(true), physics::Polysvp1)[0];
@@ -109,24 +109,27 @@ struct UnitWrap::UnitTest<D>::TestSaturation
     EKAT_REQUIRE_MSG( fid, "generate_baseline can't write " << filename);
 
     for (auto p : params_) {
-      OutputData d;
       ParamSet ps = p;
-      Kokkos::parallel_reduce(1,
-        KOKKOS_LAMBDA(const size_t&, OutputData& output) {
+      Kokkos::View<OutputData*> d_dev("",1);
+      Kokkos::parallel_for(1,
+        KOKKOS_LAMBDA(const size_t&) {
           TestSaturation::saturation_tests(
             ps.temperature, ps.pressure,
-            output.sat_ice_fp,
-            output.sat_liq_fp,
-            output.mix_ice_fr,
-            output.mix_liq_fr,
-            output.sat_ice_mkp,
-            output.sat_liq_mkp,
-            output.mix_ice_mkr,
-            output.mix_liq_mkr);
-        }, d);
-
+            d_dev[0].sat_ice_fp,
+            d_dev[0].sat_liq_fp,
+            d_dev[0].mix_ice_fr,
+            d_dev[0].mix_liq_fr,
+            d_dev[0].sat_ice_mkp,
+            d_dev[0].sat_liq_mkp,
+            d_dev[0].mix_ice_mkr,
+            d_dev[0].mix_liq_mkr);
+      });
       Kokkos::fence();
-      write(fid, d); // Save the fields to the baseline file.
+
+      auto d_host = Kokkos::create_mirror_view(d_dev);
+      Kokkos::deep_copy(d_host,d_dev);
+
+      write(fid, d_host[0]); // Save the fields to the baseline file.
     }
 
     return 0;
@@ -139,28 +142,31 @@ struct UnitWrap::UnitTest<D>::TestSaturation
     int case_num = 0;
     for (auto p : params_) {
       ++case_num;
-      OutputData ref, d;
+      OutputData ref;
       ParamSet ps = p;
       std::cout << "--- checking physics saturation case # " << case_num << std::endl;
       read(fid, ref);
 
-      Kokkos::parallel_reduce(1,
-        KOKKOS_LAMBDA(const size_t&, OutputData& output) {
+      Kokkos::View<OutputData*> d_dev("",1);
+      Kokkos::parallel_for(1,
+        KOKKOS_LAMBDA(const size_t&) {
           TestSaturation::saturation_tests(
             ps.temperature, ps.pressure,
-            output.sat_ice_fp,
-            output.sat_liq_fp,
-            output.mix_ice_fr,
-            output.mix_liq_fr,
-            output.sat_ice_mkp,
-            output.sat_liq_mkp,
-            output.mix_ice_mkr,
-            output.mix_liq_mkr);
-        }, d);
-
+            d_dev[0].sat_ice_fp,
+            d_dev[0].sat_liq_fp,
+            d_dev[0].mix_ice_fr,
+            d_dev[0].mix_liq_fr,
+            d_dev[0].sat_ice_mkp,
+            d_dev[0].sat_liq_mkp,
+            d_dev[0].mix_ice_mkr,
+            d_dev[0].mix_liq_mkr);
+      });
       Kokkos::fence();
 
-      ne = compare(tol, ref, d);
+      auto d_host = Kokkos::create_mirror_view(d_dev);
+      Kokkos::deep_copy(d_host,d_dev);
+
+      ne = compare(tol, ref, d_host[0]);
       if (ne) std::cout << "Ref impl failed.\n";
       nerr += ne;
     }

--- a/components/eamxx/src/physics/share/tests/physics_saturation_run_and_cmp.cpp
+++ b/components/eamxx/src/physics/share/tests/physics_saturation_run_and_cmp.cpp
@@ -189,7 +189,7 @@ struct UnitWrap::UnitTest<D>::TestSaturation
     Scalar mix_ice_mkr;
     Scalar mix_liq_mkr;
 
-    //KOKKOS_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     OutputData& operator+=(const OutputData& rhs)
     {
       sat_ice_fp += rhs.sat_ice_fp;

--- a/components/eamxx/src/physics/share/tests/physics_saturation_run_and_cmp.cpp
+++ b/components/eamxx/src/physics/share/tests/physics_saturation_run_and_cmp.cpp
@@ -189,6 +189,7 @@ struct UnitWrap::UnitTest<D>::TestSaturation
     Scalar mix_ice_mkr;
     Scalar mix_liq_mkr;
 
+    KOKKOS_INLINE_FUNCTION
     OutputData& operator+=(const OutputData& rhs)
     {
       sat_ice_fp += rhs.sat_ice_fp;

--- a/components/eamxx/src/physics/share/tests/physics_saturation_run_and_cmp.cpp
+++ b/components/eamxx/src/physics/share/tests/physics_saturation_run_and_cmp.cpp
@@ -189,7 +189,7 @@ struct UnitWrap::UnitTest<D>::TestSaturation
     Scalar mix_ice_mkr;
     Scalar mix_liq_mkr;
 
-    KOKKOS_INLINE_FUNCTION
+    //KOKKOS_INLINE_FUNCTION
     OutputData& operator+=(const OutputData& rhs)
     {
       sat_ice_fp += rhs.sat_ice_fp;


### PR DESCRIPTION
Expose some of P3 parameters as namelist variables, put them in one struct.

Here are vars exposed:
P3   p3_autoconversion_prefactor = 1350.000000
P3   p3_mu_r_constant = 1.000000
P3   p3_spa_to_nc = 1.000000
P3   p3_k_accretion = 67.000000
P3   p3_eci = 0.500000
P3   p3_eri = 1.000000
P3   p3_rho_rime_min = 50.000000
P3   p3_rho_rime_max = 900.000000
P3   p3_a_imm = 0.650000
P3   p3_dep_nucleation_exponent = 0.304000
P3   p3_ice_sed_knob = 1.000000
P3   p3_d_breakup_cutoff = 0.000280


[nonbfb] for physics_saturation_run_and_cmp for weaver because of inlining line in physics/share/tests/physics_saturation_run_and_cmp.cpp .