### PR TITLE
DP-SCREAM v0 diagnostic coordinate fix

### DIFF
--- a/components/eam/src/dynamics/se/stepon.F90
+++ b/components/eam/src/dynamics/se/stepon.F90
@@ -585,8 +585,8 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    if (dp_crm) then
 
      do ie=1,nelemd
-       out_gridx(:,:) = dyn_in%elem(ie)%spherep(:,:)%lat
-       out_gridy(:,:) = dyn_in%elem(ie)%spherep(:,:)%lon
+       out_gridx(:,:) = dyn_in%elem(ie)%spherep(:,:)%lon
+       out_gridy(:,:) = dyn_in%elem(ie)%spherep(:,:)%lat
        call outfld('crm_grid_x', out_gridx, npsq, ie)
        call outfld('crm_grid_y', out_gridy, npsq, ie)
      enddo


### PR DESCRIPTION
Fixes DP SCREAM output coordinate issue where x-coordinates should be associated with spherep lon values and y-coordinates should be associated with lat values.  This is a diagnostic output fix and thus B4B.

@tcclevenger if this section of code has already been converted to v1 could you let me know and I will make the fix.