### PR TITLE
Remove unused and buggy constructors for FieldLayout

### DIFF
--- a/components/eamxx/src/control/intensive_observation_period.cpp
+++ b/components/eamxx/src/control/intensive_observation_period.cpp
@@ -200,7 +200,7 @@ initialize_iop_file(const util::TimeStamp& run_t0,
   // Check if the following variables exist in the iop file
 
   // Scalar data
-  FieldLayout fl_scalar({}); // Zero dim fields used for iop file scalars
+  FieldLayout fl_scalar({},{}); // Zero dim fields used for iop file scalars
   setup_iop_field({"Ps"},          fl_scalar);
   setup_iop_field({"Tg"},          fl_scalar);
   setup_iop_field({"lhflx", "lh"}, fl_scalar);

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -5,18 +5,6 @@
 namespace scream
 {
 
-FieldLayout::FieldLayout (const std::initializer_list<FieldTag>& tags)
- : FieldLayout(std::vector<FieldTag>(tags))
-{
-  // Nothing to do here
-}
-
-FieldLayout::FieldLayout (const std::vector<FieldTag>& tags)
- : FieldLayout(tags,std::vector<int>(tags.size(),-1))
-{
-  // Nothing to do here
-}
-
 FieldLayout::FieldLayout (const std::vector<FieldTag>& tags,
                           const std::vector<int>& dims)
  : m_rank(tags.size())

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -70,7 +70,7 @@ public:
   FieldLayout& operator= (const FieldLayout&) = default;
 
   // Create invalid layout
-  static FieldLayout invalid () { return FieldLayout({}); }
+  static FieldLayout invalid () { return FieldLayout({FieldTag::Invalid},{0}); }
 
   // ----- Getters ----- //
 

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -63,8 +63,6 @@ public:
   // Constructor(s)
   FieldLayout () = delete;
   FieldLayout (const FieldLayout&) = default;
-  FieldLayout (const std::initializer_list<FieldTag>& tags);
-  FieldLayout (const std::vector<FieldTag>& tags);
   FieldLayout (const std::vector<FieldTag>& tags,
                const std::vector<int>& dims);
 

--- a/components/eamxx/src/share/grid/remap/do_nothing_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/do_nothing_remapper.hpp
@@ -42,7 +42,7 @@ public:
         " - input layout: " + to_string(tgt));
 
     auto type = get_layout_type(tgt.tags());
-    FieldLayout src = {{}};
+    auto src = FieldLayout::invalid();
     switch (type) {
       case LayoutType::Scalar2D:
         src = this->m_src_grid->get_2d_scalar_layout();
@@ -70,7 +70,7 @@ public:
         " - input layout: " + to_string(src));
 
     auto type = get_layout_type(src.tags());
-    FieldLayout tgt = {{}};
+    auto tgt = FieldLayout::invalid();
     switch (type) {
       case LayoutType::Scalar2D:
         tgt = this->m_tgt_grid->get_2d_scalar_layout();

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -358,7 +358,7 @@ TEST_CASE("field", "") {
 
   SECTION ("rank0_field") {
     // Create 0d field
-    FieldIdentifier fid0("f_0d", FieldLayout({}), Units::nondimensional(), "dummy_grid");
+    FieldIdentifier fid0("f_0d", FieldLayout({},{}), Units::nondimensional(), "dummy_grid");
     Field f0(fid0);
     f0.allocate_view();
 


### PR DESCRIPTION
The constructor that only accepts tags, was only used to create empty (0-dimensional) layouts. When used with a non-empty list of tags, it was causing an error, since it tried to set extents to -1, which is invalid. So I removed those constructors, forcing users to do something like `FieldLayout layout0d ({},{});` instead of `FieldLayout layout0d ({});`. Furthermore, this change makes the following

```
FieldLayout fl { {}, {} };
```
Before this change, the above was parsed by the compiler as a call to `FieldLayout (const std::initializer_list<FieldTag>& tags);`, with an initializer list of size 2. Now, with that constructor gone, the best match is the constructor that takes two vectors (one of tags, and one of extents).