### PR TITLE
Fix handling of accum fields to avoid errors with t=0 INSTANT output

### DIFF
--- a/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -219,6 +219,9 @@ void scream_init_atm (const char* caseid,
     // Init all fields, atm processes, and output streams
     ad.initialize_fields ();
     ad.initialize_atm_procs ();
+    // Do this before init-ing the output managers,
+    // so the fields are valid if outputing at t=0
+    ad.reset_accumulated_fields();
     ad.initialize_output_managers ();
   });
 }


### PR DESCRIPTION
In case of t=0 output for INSTANT output, we need the accum fields to be reset during init (not just at run time), since they need to store valid time stamps. 

Fixes #2662 

Edit: I am not sure why this bug was not exposed by our current testing. I believe we are outputing accum fields (like precip mass) with instant output, so we should hit this bug. I will investigate, and add a test if the case is not covered. I may do that in a follow-up PR if I can't do it in time before the AT is ready to merge, since I'd like the bug to be fixed sooner than later.