### PR TITLE
Some fixes/upgrades to avg count logic in output classes

### DIFF
--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1117,14 +1117,12 @@ void AtmosphereOutput::set_degrees_of_freedom(const std::string& filename)
     const auto& fid  = field.get_header().get_identifier();
     auto var_dof = get_var_dof_offsets(fid.get_layout());
     set_dof(filename,name,var_dof.size(),var_dof.data());
-    m_dofs.emplace(std::make_pair(name,var_dof.size()));
   }
   // Cycle through the average count fields and set degrees of freedom
   for (auto const& name : m_avg_cnt_names) {
     const auto layout = m_layouts.at(name);
     auto var_dof = get_var_dof_offsets(layout);
     set_dof(filename,name,var_dof.size(),var_dof.data());
-    m_dofs.emplace(std::make_pair(name,var_dof.size()));
   }
 
   /* TODO:

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -973,10 +973,6 @@ register_variables(const std::string& filename,
         set_variable_metadata(filename, name, "_FillValue",fill_value);
       } else {
         float fill_value = m_fill_value;
-        std::cout << "setting fill value:\n"
-                  << "  filename: " << filename << "\n"
-                  << "  varname : " << name << "\n"
-                  << "  fill val: " << fill_value << "\n";
         set_variable_metadata(filename, name, "_FillValue",fill_value);
       }
 

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -119,26 +119,30 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
 {
   using vos_t = std::vector<std::string>;
 
-  if (params.isParameter("fill_value")) {
-    m_fill_value = static_cast<float>(params.get<double>("fill_value"));
-    // If the fill_value is specified there is a good chance the user expects the average count to track filling.
-    m_track_avg_cnt = true;
-  }
-  if (params.isParameter("track_fill")) {
-    // Note, we do this after checking for fill_value to give users that opportunity to turn off fill tracking, even
-    // if they specify a specific fill value.
-    m_track_avg_cnt = params.get<bool>("track_fill");
-  }
-  if (params.isParameter("fill_threshold")) {
-    m_avg_coeff_threshold = params.get<Real>("fill_threshold");
-  }
-
   // Figure out what kind of averaging is requested
   auto avg_type = params.get<std::string>("Averaging Type");
   m_avg_type = str2avg(avg_type);
   EKAT_REQUIRE_MSG (m_avg_type!=OutputAvgType::Invalid,
       "Error! Unsupported averaging type '" + avg_type + "'.\n"
       "       Valid options: Instant, Max, Min, Average. Case insensitive.\n");
+
+  // Avg count only makes sense for non-instant output,
+  // and only if time dim is present (i.e., don't do it for geo_data streams)
+  if (m_avg_type!=OutputAvgType::Instant and m_add_time_dim) {
+    if (params.isParameter("fill_value")) {
+      m_fill_value = static_cast<float>(params.get<double>("fill_value"));
+      // If the fill_value is specified there is a good chance the user expects the average count to track filling.
+      m_track_avg_cnt = true;
+    }
+    if (params.isParameter("track_fill")) {
+      // Note, we do this after checking for fill_value to give users that opportunity to turn off fill tracking, even
+      // if they specify a specific fill value.
+      m_track_avg_cnt = params.get<bool>("track_fill");
+    }
+    if (params.isParameter("fill_threshold")) {
+      m_avg_coeff_threshold = params.get<Real>("fill_threshold");
+    }
+  }
 
   // Set all internal field managers to the simulation field manager to start with.  If
   // vertical remapping, horizontal remapping or both are used then those remapper will
@@ -216,8 +220,10 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
 
   // Setup remappers - if needed
   if (use_vertical_remap_from_file) {
-    // When vertically remapping there is a chance that filled values will be present, so be sure to track these
-    m_track_avg_cnt = true;
+    // When vertically remapping there is a chance that filled values will be present,
+    // so be sure to track these if the avg type is not INSTANT
+    m_track_avg_cnt = m_add_time_dim and m_avg_type!=OutputAvgType::Instant;
+
     // We build a remapper, to remap fields from the fm grid to the io grid
     auto vert_remap_file   = params.get<std::string>("vertical_remap_file");
     auto f_lev = get_field("p_mid","sim");
@@ -418,9 +424,9 @@ run (const std::string& filename,
   // temporary views for each layout that are either 0 or 1 depending on if the
   // value is filled or unfilled.
   // We then use these values to update the overall average count views for that layout.
-  if (m_track_avg_cnt && m_add_time_dim) {
+  if (m_track_avg_cnt) {
     // Note, we assume that all fields that share a layout are also masked/filled in the same
-    // way.  If, we need to handle a case where only a subset of output variables are expected to
+    // way. If we need to handle a case where only a subset of output variables are expected to
     // be masked/filled then the recommendation is to request those variables in a separate output
     // stream.
     // We cycle through all fields and mark points that are filled/masked in the local views.  First
@@ -449,6 +455,11 @@ run (const std::string& filename,
   }
 
   // Take care of updating and possibly writing fields.
+  // These are needed inside kernels, so crate local copies
+  auto do_avg_cnt = m_track_avg_cnt;
+  auto avg_type = m_avg_type;
+  auto fill_value = m_fill_value;
+  auto avg_coeff_threshold = m_avg_coeff_threshold;
   for (auto const& name : m_fields_names) {
     // Get all the info for this field.
           auto  field = get_field(name,"io");
@@ -486,7 +497,7 @@ run (const std::string& filename,
     // views for the average count, so we leave them as essentially empty.
     auto avg_cnt_dims = dims;
     auto avg_cnt_data = data;
-    if (m_track_avg_cnt && m_add_time_dim) {
+    if (do_avg_cnt) {
       const auto lookup = m_field_to_avg_cnt_map.at(name);
       avg_cnt_data = m_local_tmp_avg_cnt_views_1d.at(lookup).data();
     } else {
@@ -496,11 +507,6 @@ run (const std::string& filename,
       avg_cnt_data = nullptr;
     }
 
-    auto avg_type = m_avg_type;
-    auto track_avg_cnt = m_track_avg_cnt;
-    auto add_time_dim = m_add_time_dim;
-    auto fill_value = m_fill_value;
-    auto avg_coeff_threshold = m_avg_coeff_threshold;
     // If the dev_view_1d is aliasing the field device view (must be Instant output),
     // then there's no point in copying from the field's view to dev_view
     if (not is_aliasing_field_view) {
@@ -513,7 +519,7 @@ run (const std::string& filename,
           auto avg_view_1d = view_Nd_dev<1>(data,dims[0]);
           auto avg_coeff_1d = view_Nd_dev<1>(avg_cnt_data,avg_cnt_dims[0]);
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int i) {
-            if (track_avg_cnt && add_time_dim) {
+            if (do_avg_cnt) {
               combine_and_fill(new_view_1d(i), avg_view_1d(i),avg_coeff_1d(i),avg_type,fill_value);
             } else {
               combine(new_view_1d(i), avg_view_1d(i),avg_type);
@@ -529,7 +535,7 @@ run (const std::string& filename,
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
             int i,j;
             unflatten_idx(idx,extents,i,j);
-            if (track_avg_cnt && add_time_dim) {
+            if (do_avg_cnt) {
               combine_and_fill(new_view_2d(i,j), avg_view_2d(i,j),avg_coeff_2d(i,j),avg_type,fill_value);
             } else {
               combine(new_view_2d(i,j), avg_view_2d(i,j),avg_type);
@@ -545,7 +551,7 @@ run (const std::string& filename,
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
             int i,j,k;
             unflatten_idx(idx,extents,i,j,k);
-            if (track_avg_cnt && add_time_dim) {
+            if (do_avg_cnt) {
               combine_and_fill(new_view_3d(i,j,k), avg_view_3d(i,j,k),avg_coeff_3d(i,j,k),avg_type,fill_value);
             } else {
               combine(new_view_3d(i,j,k), avg_view_3d(i,j,k),avg_type);
@@ -561,7 +567,7 @@ run (const std::string& filename,
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
             int i,j,k,l;
             unflatten_idx(idx,extents,i,j,k,l);
-            if (track_avg_cnt && add_time_dim) {
+            if (do_avg_cnt) {
               combine_and_fill(new_view_4d(i,j,k,l), avg_view_4d(i,j,k,l),avg_coeff_4d(i,j,k,l),avg_type,fill_value);
             } else {
               combine(new_view_4d(i,j,k,l), avg_view_4d(i,j,k,l),avg_type);
@@ -577,7 +583,7 @@ run (const std::string& filename,
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
             int i,j,k,l,m;
             unflatten_idx(idx,extents,i,j,k,l,m);
-            if (track_avg_cnt && add_time_dim) {
+            if (do_avg_cnt) {
               combine_and_fill(new_view_5d(i,j,k,l,m), avg_view_5d(i,j,k,l,m),avg_coeff_5d(i,j,k,l,m),avg_type,fill_value);
             } else {
               combine(new_view_5d(i,j,k,l,m), avg_view_5d(i,j,k,l,m),avg_type);
@@ -593,7 +599,7 @@ run (const std::string& filename,
           Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
             int i,j,k,l,m,n;
             unflatten_idx(idx,extents,i,j,k,l,m,n);
-            if (track_avg_cnt && add_time_dim) {
+            if (do_avg_cnt) {
               combine_and_fill(new_view_6d(i,j,k,l,m,n), avg_view_6d(i,j,k,l,m,n), avg_coeff_6d(i,j,k,l,m,n),avg_type,fill_value);
             } else {
               combine(new_view_6d(i,j,k,l,m,n), avg_view_6d(i,j,k,l,m,n),avg_type);
@@ -608,7 +614,7 @@ run (const std::string& filename,
 
     if (is_write_step) {
       if (output_step and avg_type==OutputAvgType::Average) {
-        if (m_track_avg_cnt && m_add_time_dim) {
+        if (do_avg_cnt) {
           const auto avg_cnt_lookup = m_field_to_avg_cnt_map.at(name);
           const auto avg_cnt_view = m_dev_views_1d.at(avg_cnt_lookup);
           const auto avg_nsteps = avg_cnt_view.data();
@@ -837,9 +843,11 @@ void AtmosphereOutput::register_views()
       m_host_views_1d.emplace(name,Kokkos::create_mirror(m_dev_views_1d[name]));
     }
 
-    // Now create and store a dev view to track the averaging count for this layout (if we are tracking)
-    // We don't need to track average counts for files that are not tracking the time dim
-    set_avg_cnt_tracking(name,"",layout);
+    if (m_track_avg_cnt) {
+      // Now create and store a dev view to track the averaging count for this layout (if we are tracking)
+      // We don't need to track average counts for files that are not tracking the time dim
+      set_avg_cnt_tracking(name,"",layout);
+    }
   }
 
   // Initialize the local views
@@ -868,7 +876,7 @@ void AtmosphereOutput::set_avg_cnt_tracking(const std::string& name, const std::
   // We don't need to track average counts for files that are not tracking the time dim
   const auto size = layout.size();
   const auto tags = layout.tags();
-  if (m_add_time_dim && m_track_avg_cnt) {
+  if (m_track_avg_cnt) {
     std::string avg_cnt_name = "avg_count" + avg_cnt_suffix;
     for (int ii=0; ii<layout.rank(); ++ii) {
       auto tag_name = m_io_grid->get_dim_name(layout.tag(ii));
@@ -890,7 +898,7 @@ reset_dev_views()
 {
   // Reset the local device views depending on the averaging type
   // Init dev view with an "identity" for avg_type
-  const Real fill_for_average = (m_track_avg_cnt && m_add_time_dim) ? m_fill_value : 0.0;
+  const Real fill_for_average = m_track_avg_cnt ? m_fill_value : 0.0;
   for (auto const& name : m_fields_names) {
     switch (m_avg_type) {
       case OutputAvgType::Instant:
@@ -1019,7 +1027,7 @@ register_variables(const std::string& filename,
       }
 
       // If tracking average count variables then add the name of the tracking variable for this variable
-      if (m_track_avg_cnt && m_add_time_dim) {
+      if (m_track_avg_cnt) {
         const auto lookup = m_field_to_avg_cnt_map.at(name);
         set_variable_metadata(filename,name,"averaging_count_tracker",lookup);
       }
@@ -1033,7 +1041,7 @@ register_variables(const std::string& filename,
     }
   }
   // Now register the average count variables
-  if (m_track_avg_cnt && m_add_time_dim) {
+  if (m_track_avg_cnt) {
     for (const auto& name : m_avg_cnt_names) {
       const auto layout = m_layouts.at(name);
       auto io_decomp_tag = set_decomp_tag(layout);
@@ -1293,7 +1301,10 @@ AtmosphereOutput::create_diagnostic (const std::string& diag_field_name) {
       } else if (units=="mb" or units=="Pa" or units=="hPa") {
         diag_name = "FieldAtPressureLevel";
         diag_avg_cnt_name = "_" + tokens[1]; // Set avg_cnt tracking for this specific slice
-        m_track_avg_cnt = true; // If we have pressure slices we need to be tracking the average count.
+
+        // If we have pressure slices we need to be tracking the average count,
+        // if m_avg_type is not Instant
+        m_track_avg_cnt = m_add_time_dim and m_avg_type!=OutputAvgType::Instant;
       } else {
         EKAT_ERROR_MSG ("Error! Invalid units x for 'field_at_Nx' diagnostic.\n");
       }
@@ -1355,7 +1366,7 @@ AtmosphereOutput::create_diagnostic (const std::string& diag_field_name) {
   }
   diag->initialize(util::TimeStamp(),RunType::Initial);
   // If specified, set avg_cnt tracking for this diagnostic.
-  if (m_add_time_dim && m_track_avg_cnt) {
+  if (m_track_avg_cnt) {
     const auto diag_field = diag->get_diagnostic();
     const auto name       = diag_field.name();
     const auto layout     = diag_field.get_header().get_identifier().get_layout();

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -195,6 +195,12 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
   //    - field_at_XhPa diagnostic
   // We already set m_track_avg_cnt to true if field_at_XhPa is found in set_diagnostics.
   // Hence, here we only check if vert remap is active
+
+  if (params.isParameter("track_avg_cnt")) {
+    // This is to be used for unit testing only, so that we can test avg cnt even
+    // if there is no vert remap and no field_at_XhPa diagnostic in the stream
+    m_track_avg_cnt = params.get<bool>("track_avg_cnt");
+  }
   if (use_vertical_remap_from_file) {
     m_track_avg_cnt = true;
   }

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -199,7 +199,6 @@ protected:
   std::vector<std::string>                              m_avg_cnt_names;
   std::map<std::string,std::string>                     m_field_to_avg_cnt_map;
   std::map<std::string,FieldLayout>                     m_layouts;
-  std::map<std::string,int>                             m_dofs;
   std::map<std::string,std::pair<int,bool>>             m_dims;
   std::map<std::string,std::shared_ptr<atm_diag_type>>  m_diagnostics;
   std::map<std::string,std::vector<std::string>>        m_diag_depends_on_diags;
@@ -215,7 +214,6 @@ protected:
   // Local views of each field to be used for "averaging" output and writing to file.
   std::map<std::string,view_1d_host>    m_host_views_1d;
   std::map<std::string,view_1d_dev>     m_dev_views_1d;
-  std::map<std::string,view_1d_dev>     m_avg_coeff_views_1d;
 
   bool m_add_time_dim;
   bool m_track_avg_cnt = false;

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -215,7 +215,6 @@ protected:
   // Local views of each field to be used for "averaging" output and writing to file.
   std::map<std::string,view_1d_host>    m_host_views_1d;
   std::map<std::string,view_1d_dev>     m_dev_views_1d;
-  std::map<std::string,view_1d_dev>     m_local_tmp_avg_cnt_views_1d;
   std::map<std::string,view_1d_dev>     m_avg_coeff_views_1d;
 
   bool m_add_time_dim;

--- a/components/eamxx/src/share/io/tests/io_filled.cpp
+++ b/components/eamxx/src/share/io/tests/io_filled.cpp
@@ -133,7 +133,6 @@ void write (const std::string& avg_type, const std::string& freq_units,
   om_pl.set("Field Names",fnames);
   om_pl.set("Averaging Type", avg_type);
   om_pl.set<double>("fill_value",FillValue);
-  om_pl.set<bool>("track_fill",true);
   om_pl.set<Real>("fill_threshold",fill_threshold);
   auto& ctrl_pl = om_pl.sublist("output_control");
   ctrl_pl.set("frequency_units",freq_units);

--- a/components/eamxx/src/share/io/tests/io_filled.cpp
+++ b/components/eamxx/src/share/io/tests/io_filled.cpp
@@ -134,6 +134,7 @@ void write (const std::string& avg_type, const std::string& freq_units,
   om_pl.set("Averaging Type", avg_type);
   om_pl.set<double>("fill_value",FillValue);
   om_pl.set<Real>("fill_threshold",fill_threshold);
+  om_pl.set("track_avg_cnt",true);
   auto& ctrl_pl = om_pl.sublist("output_control");
   ctrl_pl.set("frequency_units",freq_units);
   ctrl_pl.set("Frequency",freq);
@@ -221,24 +222,24 @@ void read (const std::string& avg_type, const std::string& freq_units,
       auto f0 = fm0->get_field(fn).clone();
       auto f  = fm->get_field(fn);
       if (avg_type=="MIN") {
-	Real test_val = ((n+1)*freq%2==0) ? n*freq+1 : n*freq+2;
+        Real test_val = ((n+1)*freq%2==0) ? n*freq+1 : n*freq+2;
         set(f0,test_val);
         REQUIRE (views_are_equal(f,f0));
       } else if (avg_type=="MAX") {
-	Real test_val = ((n+1)*freq%2==0) ? (n+1)*freq : (n+1)*freq-1;
+        Real test_val = ((n+1)*freq%2==0) ? (n+1)*freq : (n+1)*freq-1;
         set(f0,test_val);
         REQUIRE (views_are_equal(f,f0));
       } else if (avg_type=="INSTANT") {
-	Real test_val = (n*freq%2==0) ? n*freq : FillValue;
+        Real test_val = (n*freq%2==0) ? n*freq : FillValue;
         set(f0,test_val);
         REQUIRE (views_are_equal(f,f0));
       } else { // Is avg_type = AVERAGE
-	// Note, for AVERAGE type output with filling we need to check that the
-	// number of contributing fill steps surpasses the fill_threshold, if not
-	// then we know that the snap will reflect the fill value.
-	Real test_val;
-	Real M = freq/2 + (n%2==0 ? 0.0 :  1.0);
-	Real a = n*freq + (n%2==0 ? 0.0 : -1.0);
+        // Note, for AVERAGE type output with filling we need to check that the
+        // number of contributing fill steps surpasses the fill_threshold, if not
+        // then we know that the snap will reflect the fill value.
+        Real test_val;
+        Real M = freq/2 + (n%2==0 ? 0.0 :  1.0);
+        Real a = n*freq + (n%2==0 ? 0.0 : -1.0);
         test_val = (M/freq > fill_threshold) ? a + (M+1.0) : FillValue;
         set(f0,test_val);
         REQUIRE (views_are_equal(f,f0));


### PR DESCRIPTION
There were mainly two things that could be done better:

- Ensure that avg_cnt logic is OFF for Instant output, or if the time dimension is not added to the vars (e.g., the geo_data streams used when a new file is setup). Currently, we were adding avg count logic also to instant output, and we were not correctly guarding all uses of avg cnt views (e.g., we were always creating an avg cnt for diagnostics, regardless of whether the avg cnt track was ON or OFF).
- No need to store a view of 1/0 to establish whether a certain field was filled or not. We can simply:
  - keep track of which avg_cnt fields were processed (so we don't update it twice when another field that share the same avg_cnt view is processed)
  - check the field new value to determine if it was filled
  
This allows to save
 - time: one less deep copy per avg cnt, as well as one less pfor for each field
 - space: one less view for each avg cnt