### PR TITLE
EAMxx: fix typo in spa_remap testmod

### DIFF
--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/spa_remap/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/spa_remap/shell_commands
@@ -1,2 +1,2 @@
-$CIMEROOT/../components/eamxx/scripts/atmchange -b spa_data_file='${DIN_LOC_ROOT}'/atm/scream/init/spa_file_unified_and_complete_ne4pg2_20231222
+$CIMEROOT/../components/eamxx/scripts/atmchange -b spa_data_file='${DIN_LOC_ROOT}'/atm/scream/init/spa_file_unified_and_complete_ne4pg2_20231222.nc
 $CIMEROOT/../components/eamxx/scripts/atmchange -b spa_remap_file='${DIN_LOC_ROOT}'/atm/scream/maps/map_ne4pg2_to_ne30pg2_20231201.nc


### PR DESCRIPTION
The filename was missing `.nc` at the end.