### PR TITLE
Add WindSpeed diagnostic

### DIFF
--- a/components/eamxx/src/diagnostics/CMakeLists.txt
+++ b/components/eamxx/src/diagnostics/CMakeLists.txt
@@ -16,6 +16,7 @@ set(DIAGNOSTIC_SRCS
   vertical_layer.cpp
   virtual_temperature.cpp
   water_path.cpp
+  wind_speed.cpp
 )
 
 add_library(diagnostics ${DIAGNOSTIC_SRCS})

--- a/components/eamxx/src/diagnostics/exner.hpp
+++ b/components/eamxx/src/diagnostics/exner.hpp
@@ -16,9 +16,6 @@ public:
   // Constructors
   ExnerDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // Set type to diagnostic
-  AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
-
   // The name of the diagnostic
   std::string name () const { return "Exner"; }
 

--- a/components/eamxx/src/diagnostics/longwave_cloud_forcing.hpp
+++ b/components/eamxx/src/diagnostics/longwave_cloud_forcing.hpp
@@ -16,9 +16,6 @@ public:
   // Constructors
   LongwaveCloudForcingDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // Set type to diagnostic
-  AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
-
   // The name of the diagnostic
   std::string name () const { return "LongwaveCloudForcing"; }
 

--- a/components/eamxx/src/diagnostics/potential_temperature.hpp
+++ b/components/eamxx/src/diagnostics/potential_temperature.hpp
@@ -20,9 +20,6 @@ public:
   // Constructors
   PotentialTemperatureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // Set type to diagnostic
-  AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
-
   // The name of the diagnostic
   std::string name () const { return "PotentialTemperature"; }
 

--- a/components/eamxx/src/diagnostics/register_diagnostics.hpp
+++ b/components/eamxx/src/diagnostics/register_diagnostics.hpp
@@ -19,6 +19,7 @@
 #include "diagnostics/field_at_pressure_level.hpp"
 #include "diagnostics/precip_surf_mass_flux.hpp"
 #include "diagnostics/surf_upward_latent_heat_flux.hpp"
+#include "diagnostics/wind_speed.hpp"
 
 namespace scream {
 
@@ -45,6 +46,7 @@ inline void register_diagnostics () {
   diag_factory.register_product("VaporFlux",&create_atmosphere_diagnostic<VaporFluxDiagnostic>);
   diag_factory.register_product("precip_surf_mass_flux",&create_atmosphere_diagnostic<PrecipSurfMassFlux>);
   diag_factory.register_product("surface_upward_latent_heat_flux",&create_atmosphere_diagnostic<SurfaceUpwardLatentHeatFlux>);
+  diag_factory.register_product("wind_speed",&create_atmosphere_diagnostic<WindSpeed>);
 }
 
 } // namespace scream

--- a/components/eamxx/src/diagnostics/sea_level_pressure.hpp
+++ b/components/eamxx/src/diagnostics/sea_level_pressure.hpp
@@ -25,9 +25,6 @@ public:
   // Constructors
   SeaLevelPressureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // Set type to diagnostic
-  AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
-
   // The name of the diagnostic
   std::string name () const { return "SeaLevelPressure"; }
 

--- a/components/eamxx/src/diagnostics/shortwave_cloud_forcing.hpp
+++ b/components/eamxx/src/diagnostics/shortwave_cloud_forcing.hpp
@@ -16,9 +16,6 @@ public:
   // Constructors
   ShortwaveCloudForcingDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // Set type to diagnostic
-  AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
-
   // The name of the diagnostic
   std::string name () const { return "ShortwaveCloudForcing"; }
 

--- a/components/eamxx/src/diagnostics/tests/CMakeLists.txt
+++ b/components/eamxx/src/diagnostics/tests/CMakeLists.txt
@@ -59,4 +59,6 @@ if (NOT SCREAM_BASELINES_ONLY)
   # Test surface latent heat flux
   CreateDiagTest(surface_upward_latent_heat_flux "surf_upward_latent_heat_flux_tests.cpp")
 
+  # Test wind speed diagnostic
+  CreateDiagTest(wind_speed "wind_speed_tests.cpp")
 endif()

--- a/components/eamxx/src/diagnostics/tests/wind_speed_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/wind_speed_tests.cpp
@@ -81,7 +81,7 @@ TEST_CASE("wind_speed")
     diag->get_diagnostic().sync_to_host();
 
     auto uv_h = uv.get_view<const Real***,Host>();
-    auto ws_h = diag->get_diagnostic().get_view<const Real**>();
+    auto ws_h = diag->get_diagnostic().get_view<const Real**,Host>();
 
     for (int icol=0; icol<grid->get_num_local_dofs(); ++icol) {
       for (int ilev=0; ilev<nlevs; ++ilev) {

--- a/components/eamxx/src/diagnostics/tests/wind_speed_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/wind_speed_tests.cpp
@@ -1,0 +1,96 @@
+#include "catch2/catch.hpp"
+
+#include "diagnostics/register_diagnostics.hpp"
+#include "share/grid/mesh_free_grids_manager.hpp"
+#include "share/util/scream_setup_random_test.hpp"
+#include "share/field/field_utils.hpp"
+
+namespace scream {
+
+std::shared_ptr<GridsManager>
+create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
+
+  const int num_global_cols = ncols*comm.size();
+
+  using vos_t = std::vector<std::string>;
+  ekat::ParameterList gm_params;
+  gm_params.set("grids_names",vos_t{"Point Grid"});
+  auto& pl = gm_params.sublist("Point Grid");
+  pl.set<std::string>("type","point_grid");
+  pl.set("aliases",vos_t{"Physics"});
+  pl.set<int>("number_of_global_columns", num_global_cols);
+  pl.set<int>("number_of_vertical_levels", nlevs);
+
+  auto gm = create_mesh_free_grids_manager(comm,gm_params);
+  gm->build_grids();
+
+  return gm;
+}
+
+TEST_CASE("wind_speed")
+{
+  using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
+
+  // A world comm
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  // A time stamp
+  util::TimeStamp t0 ({2022,1,1},{0,0,0});
+
+  // Create a grids manager - single column for these tests
+  constexpr int nlevs = 33;
+  const int ngcols = 2*comm.size();;
+  auto gm = create_gm(comm,ngcols,nlevs);
+  auto grid = gm->get_grid("Physics");
+
+  // Input (randomized) velocity
+  auto vector3d = grid->get_3d_vector_layout(true,CMP,2);
+  FieldIdentifier uv_fid ("horiz_winds",vector3d,m/s,grid->name());
+  Field uv(uv_fid);
+  uv.allocate_view();
+  uv.get_header().get_tracking().update_time_stamp(t0);
+
+  // Construct random number generator stuff
+  using RPDF = std::uniform_real_distribution<Real>;
+  RPDF pdf(-1,1);
+  auto engine = scream::setup_random_test();
+
+  // Construct the Diagnostics
+  std::map<std::string,std::shared_ptr<AtmosphereDiagnostic>> diags;
+  auto& diag_factory = AtmosphereDiagnosticFactory::instance();
+  register_diagnostics();
+
+  constexpr int ntests = 5;
+  for (int itest=0; itest<ntests; ++itest) {
+    // Randomize wind
+    randomize(uv,engine,pdf);
+
+    // Create and set up the diagnostic
+    ekat::ParameterList params;
+    auto diag = diag_factory.create("wind_speed",comm,params);
+    diag->set_grids(gm);
+    diag->set_required_field(uv);
+    diag->initialize(t0,RunType::Initial);
+
+    // Run diag
+    diag->compute_diagnostic();
+
+    // Check result
+    uv.sync_to_host();
+    diag->get_diagnostic().sync_to_host();
+
+    auto uv_h = uv.get_view<const Real***,Host>();
+    auto ws_h = diag->get_diagnostic().get_view<const Real**>();
+
+    for (int icol=0; icol<grid->get_num_local_dofs(); ++icol) {
+      for (int ilev=0; ilev<nlevs; ++ilev) {
+        const auto u = uv_h (icol,0,ilev);
+        const auto v = uv_h (icol,1,ilev);
+        REQUIRE (ws_h(icol,ilev) == std::sqrt(u*u+v*v));
+      }
+    }
+  }
+}
+
+} // namespace

--- a/components/eamxx/src/diagnostics/vapor_flux.hpp
+++ b/components/eamxx/src/diagnostics/vapor_flux.hpp
@@ -16,9 +16,6 @@ public:
   // Constructors
   VaporFluxDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // Set type to diagnostic
-  AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
-
   // The name of the diagnostic
   std::string name () const;
 

--- a/components/eamxx/src/diagnostics/vertical_layer.hpp
+++ b/components/eamxx/src/diagnostics/vertical_layer.hpp
@@ -32,9 +32,6 @@ public:
   // Constructors
   VerticalLayerDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // Set type to diagnostic
-  AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
-
   // The name of the diagnostic.
   std::string name () const { return m_diag_name; }
 

--- a/components/eamxx/src/diagnostics/virtual_temperature.hpp
+++ b/components/eamxx/src/diagnostics/virtual_temperature.hpp
@@ -20,9 +20,6 @@ public:
   // Constructors
   VirtualTemperatureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // Set type to diagnostic
-  AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
-
   // The name of the diagnostic
   std::string name () const { return "VirtualTemperature"; }
 

--- a/components/eamxx/src/diagnostics/water_path.hpp
+++ b/components/eamxx/src/diagnostics/water_path.hpp
@@ -1,5 +1,5 @@
-#ifndef EAMXX_ggWATER_PATH_DIAGNOSTIC_HPP
-#define EAMXX_ggWATER_PATH_DIAGNOSTIC_HPP
+#ifndef EAMXX_WATER_PATH_DIAGNOSTIC_HPP
+#define EAMXX_WATER_PATH_DIAGNOSTIC_HPP
 
 #include "share/atm_process/atmosphere_diagnostic.hpp"
 
@@ -15,9 +15,6 @@ class WaterPathDiagnostic : public AtmosphereDiagnostic
 public:
   // Constructors
   WaterPathDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
-
-  // Set type to diagnostic
-  AtmosphereProcessType type () const { return AtmosphereProcessType::Diagnostic; }
 
   // The name of the diagnostic
   std::string name () const;
@@ -42,4 +39,4 @@ protected:
 
 } //namespace scream
 
-#endif // EAMXX_ggWATER_PATH_DIAGNOSTIC_HPP
+#endif // EAMXX_WATER_PATH_DIAGNOSTIC_HPP

--- a/components/eamxx/src/diagnostics/wind_speed.cpp
+++ b/components/eamxx/src/diagnostics/wind_speed.cpp
@@ -1,0 +1,58 @@
+#include "diagnostics/wind_speed.hpp"
+
+#include <ekat/kokkos/ekat_kokkos_utils.hpp>
+
+namespace scream
+{
+
+WindSpeed::
+WindSpeed (const ekat::Comm& comm, const ekat::ParameterList& params)
+  : AtmosphereDiagnostic(comm,params)
+{
+  // Nothing to do here
+}
+
+void WindSpeed::
+set_grids(const std::shared_ptr<const GridsManager> grids_manager)
+{
+  using namespace ekat::units;
+  using namespace ShortFieldTagsNames;
+
+  auto grid  = grids_manager->get_grid("Physics");
+  const auto& grid_name = grid->name();
+
+  m_ncols = grid->get_num_local_dofs();
+  m_nlevs = grid->get_num_vertical_levels();
+
+  auto scalar3d = grid->get_3d_scalar_layout(true);
+  auto vector3d = grid->get_3d_vector_layout(true,CMP,2);
+
+  // The fields required for this diagnostic to be computed
+  add_field<Required>("horiz_winds", vector3d, Pa, grid_name);
+
+  // Construct and allocate the 3d wind_speed field
+  FieldIdentifier fid ("wind_speed", scalar3d, m/s, grid_name);
+  m_diagnostic_output = Field(fid);
+  m_diagnostic_output.allocate_view();
+}
+
+void WindSpeed::compute_diagnostic_impl()
+{
+  using KT = KokkosTypes<DefaultDevice>;
+  using RP = typename KT::RangePolicy;
+
+  const auto uv = get_field_in("horiz_winds").get_view<const Real***>();
+  const auto ws = m_diagnostic_output.get_view<Real**>();
+
+  const int nlevs = m_nlevs;
+  Kokkos::parallel_for("Compute " + name(), RP(0,m_nlevs*m_ncols),
+                       KOKKOS_LAMBDA(const int& idx) {
+    const int icol = idx / nlevs;
+    const int ilev = idx % nlevs;
+    const auto& u = uv(icol,0,ilev);
+    const auto& v = uv(icol,1,ilev);
+    ws (icol,ilev) = sqrt(u*u + v*v);
+  });
+}
+
+} //namespace scream

--- a/components/eamxx/src/diagnostics/wind_speed.hpp
+++ b/components/eamxx/src/diagnostics/wind_speed.hpp
@@ -1,0 +1,37 @@
+#ifndef EAMXX_WIND_SPEED_HPP
+#define EAMXX_WIND_SPEED_HPP
+
+#include "share/atm_process/atmosphere_diagnostic.hpp"
+
+namespace scream
+{
+
+/*
+ * This diagnostic will compute the magnitute of the horiz_winds vector
+ */
+
+class WindSpeed : public AtmosphereDiagnostic
+{
+public:
+  // Constructors
+  WindSpeed (const ekat::Comm& comm, const ekat::ParameterList& params);
+
+  // The name of the diagnostic
+  std::string name () const override { return "wind_speed"; }
+
+  // Set the grid
+  void set_grids (const std::shared_ptr<const GridsManager> grids_manager) override;
+
+protected:
+#ifdef KOKKOS_ENABLE_CUDA
+public:
+#endif
+  void compute_diagnostic_impl () override;
+
+  int m_ncols;
+  int m_nlevs;
+};
+
+} //namespace scream
+
+#endif // EAMXX_WIND_SPEED_HPP


### PR DESCRIPTION
It computes the (3d field) magnitude of the "horiz_winds" field. Can probably be generalized to compute magnitude of any field if need be in the future.

Note: the most important use case is to get the wind speed at 100m of elevation. This can be achieved by requesting `wind_speed_at_100m_above_surface` in the output yaml file. Our I/O infrastructure will automatically pipe the WindSpeed diag with the FieldAtHeight one.