### PR TITLE
enable reading nudging_filename in pattern and bypass vert_interp for nudging

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -240,7 +240,7 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <!-- nudging -->
     <nudging inherit="atm_proc_base">
-      <nudging_filename type="array(string)"/>
+      <nudging_filenames_patterns type="array(string)" doc="One or more strings to indicate the actual filenames or patterns"/>
       <nudging_fields type="array(string)" doc="List of fields to be nudged.  Note, syntax of 'A:B' represents nudging field A with data from field B in files, syntax of 'A' assumes that nudging file has the same variables name as EAMxx"/>
       <nudging_timescale type="integer" doc="Timescale to apply nudging tendencies, 0: full replacement, >0: actual timescale">0</nudging_timescale>
       <use_nudging_weights type="logical" doc="Flag for nudging weights option">false</use_nudging_weights>
@@ -252,7 +252,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).
     TIME_DEPENDENT_3D_HYBRID: The dataset uses a hybrid coordinate with hyai(ilev),hybi(ilev),hyam(lev),hybm(lev),ilev(ilev),lev(lev),P0,PS(time, ncol).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
       <source_pressure_file type="string" doc="If STATIC_1D_VERTICAL_PROFILE, this is an optional arg to point to a file with the source pressure levels defined.  
-    Default is to look for p_levs in the first nudging_filename file"/>
+    Default is to look for p_levs in the first nudging_filenames_patterns file"/>
       <nudging_refine_remap_mapfile
         type="string"
         doc="Refine-remapping mapfile from the source nudging dataset to the physics grid"

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -246,10 +246,11 @@ be lost if SCREAM_HACK_XML is not enabled.
       <use_nudging_weights type="logical" doc="Flag for nudging weights option">false</use_nudging_weights>
       <nudging_weights_file type="string" doc="weights that relax the nudging fields update"/>
       <source_pressure_type type="string" 
-	                    valid_values="TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE"
+	                    valid_values="TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE,TIME_DEPENDENT_3D_HYBRID"
 			    doc="Flag for how source pressure levels are handled in the nudging dataset.
     TIME_DEPENDENT_3D_PROFILE: The dataset contains a time-varying pressure profile, variable name 'p_mid' with dimensions (time,ncol,nlev).
-    STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
+    STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).
+    TIME_DEPENDENT_3D_HYBRID: The dataset uses a hybrid coordinate with hyai(ilev),hybi(ilev),hyam(lev),hybm(lev),ilev(ilev),lev(lev),P0,PS(time, ncol).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
       <source_pressure_file type="string" doc="If STATIC_1D_VERTICAL_PROFILE, this is an optional arg to point to a file with the source pressure levels defined.  
     Default is to look for p_levs in the first nudging_filename file"/>
       <nudging_refine_remap_mapfile

--- a/components/eamxx/docs/user/coarse_nudging.md
+++ b/components/eamxx/docs/user/coarse_nudging.md
@@ -20,6 +20,6 @@ In other words, the following options are needed:
 ```shell
 ./atmchange atm_procs_list=(sc_import,nudging,homme,physics,sc_export)
 ./atmchange nudging_fields=U,V
-./atmchange nudging_filename=/path/to/nudging_data_ne4pg2_L72.nc
+./atmchange nudging_filenames_patterns=/path/to/nudging_data_ne4pg2_L72.nc
 ./atmchange nudging_refine_remap_mapfile=/another/path/to/mapping_file_ne4pg2_to_ne120pg2.nc
 ```

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -2,6 +2,8 @@
 #include "share/util/scream_universal_constants.hpp"
 #include "share/grid/remap/refining_remapper_p2p.hpp"
 #include "share/grid/remap/do_nothing_remapper.hpp"
+#include <glob.h>
+
 
 namespace scream
 {
@@ -10,7 +12,7 @@ namespace scream
 Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
   : AtmosphereProcess(comm, params)
 {
-  m_datafiles  = m_params.get<std::vector<std::string>>("nudging_filename");
+  m_datafiles  = filename_glob(m_params.get<std::vector<std::string>>("nudging_filename"));
   m_timescale = m_params.get<int>("nudging_timescale",0);
   m_fields_nudge = m_params.get<std::vector<std::string>>("nudging_fields");
   m_use_weights   = m_params.get<bool>("use_nudging_weights",false);
@@ -26,8 +28,11 @@ Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
     m_src_pres_type = STATIC_1D_VERTICAL_PROFILE;
     // Check for a designated source pressure file, default to first nudging data source if not given.
     m_static_vertical_pressure_file = m_params.get<std::string>("source_pressure_file",m_datafiles[0]);
+  } else if (src_pres_type=="TIME_DEPENDENT_3D_HYBRID") {
+    m_src_pres_type = TIME_DEPENDENT_3D_HYBRID;
   } else {
-    EKAT_ERROR_MSG("ERROR! Nudging::parameter_list - unsupported source_pressure_type provided.  Current options are [TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE].  Please check");
+    EKAT_ERROR_MSG("ERROR! Nudging::parameter_list - unsupported source_pressure_type provided.  "
+                   "Current options are [TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE,TIME_DEPENDENT_3D_HYBRID].  Please check");
   }
   // use nudging weights
   if (m_use_weights) 
@@ -37,6 +42,37 @@ Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
   // 1. if m_timescale is <= 0 we will do direct replacement.
   // 2. if m_fields_nudge is empty or =NONE then we will skip nudging altogether.
 }
+
+// =========================================================================================
+std::vector<std::string> Nudging::filename_glob(const std::vector<std::string>& patterns) {
+  std::vector<std::string> all_files;
+  for (const auto& pattern : patterns) {
+      auto files = globloc(pattern);
+      all_files.insert(all_files.end(), files.begin(), files.end());
+  }
+  return all_files;
+}
+
+std::vector<std::string> Nudging::globloc(const std::string& pattern) {
+  // glob struct resides on the stack
+  glob_t glob_result;
+  memset(&glob_result, 0, sizeof(glob_result));
+
+  int return_value = ::glob(pattern.c_str(), GLOB_TILDE, NULL, &glob_result);
+  if (return_value != 0) {
+    globfree(&glob_result);
+    EKAT_REQUIRE_MSG(return_value == 0, "glob() failed with return value " + std::to_string(return_value));
+  }
+
+  std::vector<std::string> filenames;
+  for (size_t i = 0; i < glob_result.gl_pathc; ++i) {
+      filenames.push_back(std::string(glob_result.gl_pathv[i]));
+  }
+
+  globfree(&glob_result);
+  return filenames;
+}
+
 
 // =========================================================================================
 void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
@@ -79,10 +115,16 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   /* ----------------------- WARNING --------------------------------*/
 
   //Now need to read in the file
-  if (m_src_pres_type == TIME_DEPENDENT_3D_PROFILE) {
-    m_num_src_levs = scorpio::get_dimlen(m_datafiles[0],"lev");
-  } else {
+  if (m_src_pres_type == STATIC_1D_VERTICAL_PROFILE) {
     m_num_src_levs = scorpio::get_dimlen(m_static_vertical_pressure_file,"lev");
+  } else {
+    m_num_src_levs = scorpio::get_dimlen(m_datafiles[0],"lev");
+    // HYBRID needs the same vertical grid as model for now to bypass vert_interp
+    if (m_src_pres_type == TIME_DEPENDENT_3D_HYBRID) {
+      EKAT_REQUIRE_MSG(m_num_src_levs == m_num_levs,
+                     "Error! TIME_DEPENDENT_3D_HYBRID requires the vertical level to be "
+                     << " the same as model vertical level ");
+    }
   }
 
   /* Check for consistency between nudging files, map file, and remapper */
@@ -449,6 +491,8 @@ void Nudging::run_impl (const double dt)
                                                int_mask_view,
                                                m_num_src_levs,
                                                m_num_levs);
+    } else if (m_src_pres_type == TIME_DEPENDENT_3D_HYBRID) {
+      Kokkos::deep_copy(tmp_state_view,ext_state_view);
     }
 
     // Check that none of the nudging targets are masked, if they are, set value to
@@ -461,43 +505,45 @@ void Nudging::run_impl (const double dt)
     //       surface.
     // Here we change the int_state_view which represents the vertically interpolated fields onto
     // the simulation grid.
-    const int num_levs = m_num_levs;
-    Kokkos::parallel_for("correct_for_masked_values", policy,
-       	       KOKKOS_LAMBDA(MemberType const& team) {
-      const int icol = team.league_rank();
-      auto int_mask_view_1d  = ekat::subview(int_mask_view,icol);
-      auto tmp_state_view_1d = ekat::subview(tmp_state_view,icol);
-      Real fill_value;
-      int  fill_idx = -1;
-      // Scan top to surf and backfill all values near TOM that are masked.
-      for (int kk=0; kk<num_levs; ++kk) {
-        const auto ipack = kk / mPack::n;
-	const auto iidx  = kk % mPack::n;
-        // Check if this index is masked
-	if (!int_mask_view_1d(ipack)[iidx]) {
-	  fill_value = tmp_state_view_1d(ipack)[iidx];
-	  fill_idx = kk;
-	  for (int jj=0; jj<fill_idx; ++jj) {
-            const auto jpack = jj / mPack::n;
-	    const auto jidx  = jj % mPack::n;
-	    tmp_state_view_1d(jpack)[jidx] = fill_value;
-	  }
-	  break;
-	}
-      }
-      // Now fill the rest, the fill_idx should be non-negative.  If it isn't that means
-      // we have a column that is fully masked
-      for (int kk=fill_idx+1; kk<num_levs; ++kk) {
-        const auto ipack = kk / mPack::n;
-	const auto iidx  = kk % mPack::n;
-        // Check if this index is masked
-	if (!int_mask_view_1d(ipack)[iidx]) {
-	  fill_value = tmp_state_view_1d(ipack)[iidx];
-	} else {
-	  tmp_state_view_1d(ipack)[iidx] = fill_value;
-	}
-      }
-    });
+    if (m_src_pres_type != TIME_DEPENDENT_3D_HYBRID) {
+      const int num_levs = m_num_levs;
+      Kokkos::parallel_for("correct_for_masked_values", policy,
+                  KOKKOS_LAMBDA(MemberType const& team) {
+        const int icol = team.league_rank();
+        auto int_mask_view_1d  = ekat::subview(int_mask_view,icol);
+        auto tmp_state_view_1d = ekat::subview(tmp_state_view,icol);
+        Real fill_value;
+        int  fill_idx = -1;
+        // Scan top to surf and backfill all values near TOM that are masked.
+        for (int kk=0; kk<num_levs; ++kk) {
+          const auto ipack = kk / mPack::n;
+          const auto iidx  = kk % mPack::n;
+          // Check if this index is masked
+          if (!int_mask_view_1d(ipack)[iidx]) {
+            fill_value = tmp_state_view_1d(ipack)[iidx];
+            fill_idx = kk;
+            for (int jj=0; jj<fill_idx; ++jj) {
+              const auto jpack = jj / mPack::n;
+              const auto jidx  = jj % mPack::n;
+              tmp_state_view_1d(jpack)[jidx] = fill_value;
+            }
+            break;
+          }
+        }
+        // Now fill the rest, the fill_idx should be non-negative.  If it isn't that means
+        // we have a column that is fully masked
+        for (int kk=fill_idx+1; kk<num_levs; ++kk) {
+          const auto ipack = kk / mPack::n;
+          const auto iidx  = kk % mPack::n;
+          // Check if this index is masked
+          if (!int_mask_view_1d(ipack)[iidx]) {
+            fill_value = tmp_state_view_1d(ipack)[iidx];
+          } else {
+            tmp_state_view_1d(ipack)[iidx] = fill_value;
+          }
+        }
+      });
+    }
 
   }
 

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -12,7 +12,7 @@ namespace scream
 Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
   : AtmosphereProcess(comm, params)
 {
-  m_datafiles  = filename_glob(m_params.get<std::vector<std::string>>("nudging_filename"));
+  m_datafiles  = filename_glob(m_params.get<std::vector<std::string>>("nudging_filenames_patterns"));
   m_timescale = m_params.get<int>("nudging_timescale",0);
   m_fields_nudge = m_params.get<std::vector<std::string>>("nudging_fields");
   m_use_weights   = m_params.get<bool>("use_nudging_weights",false);

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -64,12 +64,6 @@ public:
   // The name of the subcomponent
   std::string name () const { return "Nudging"; }
 
-  // Find the full filename list from patterns
-  std::vector<std::string> filename_glob(const std::vector<std::string>& patterns);
-
-  // Use globloc for each filename pattern
-  std::vector<std::string> globloc(const std::string& pattern);
-
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -28,6 +28,7 @@ namespace scream
 enum SourcePresType {
   TIME_DEPENDENT_3D_PROFILE  = 0,  // DEFAULT - source data should include time/spatially varying p_mid with dimensions (time, col, lev)
   STATIC_1D_VERTICAL_PROFILE = 1,  // source data includes p_levs which is a static set of levels in both space and time, with dimensions (lev)
+  TIME_DEPENDENT_3D_HYBRID = 2,  // hybrid data includes hyai(ilev),hybi(ilev),hyam(lev),hybm(lev),ilev(ilev),lev(lev),P0,PS(time, ncol)
 };
 
 class Nudging : public AtmosphereProcess
@@ -62,6 +63,12 @@ public:
 
   // The name of the subcomponent
   std::string name () const { return "Nudging"; }
+
+  // Find the full filename list from patterns
+  std::vector<std::string> filename_glob(const std::vector<std::string>& patterns);
+
+  // Use globloc for each filename pattern
+  std::vector<std::string> globloc(const std::string& pattern);
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
+++ b/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
@@ -251,7 +251,7 @@ TEST_CASE("nudging") {
   ekat::ParameterList params_mid;
   std::string nudging_f = "io_output_test.INSTANT.nsteps_x1."\
                           "np1.2000-01-01-00000.nc";
-  params_mid.set<std::vector<std::string>>("nudging_filename",{nudging_f});
+  params_mid.set<std::vector<std::string>>("nudging_filenames_patterns",{nudging_f});
   params_mid.set<std::vector<std::string>>("nudging_fields",{"T_mid","qv","U","V"});
   params_mid.set<bool>("use_nudging_weights",false);
   std::shared_ptr<AtmosphereProcess> nudging_mid = std::make_shared<Nudging>(io_comm,params_mid);

--- a/components/eamxx/src/share/util/scream_utils.hpp
+++ b/components/eamxx/src/share/util/scream_utils.hpp
@@ -347,6 +347,12 @@ check_mpi_call (int err, const std::string& context) {
       "  - context: " + context + "\n");
 }
 
+// Find the full filename list from patterns
+std::vector<std::string> filename_glob(const std::vector<std::string>& patterns);
+
+// Use globloc for each filename pattern
+std::vector<std::string> globloc(const std::string& pattern);
+
 } // namespace scream
 
 #endif // SCREAM_UTILS_HPP

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/CMakeLists.txt
@@ -57,3 +57,16 @@ CreateUnitTestFromExec (shoc_p3_nudged_remapped shoc_p3_nudging
       EXE_ARGS "--use-colour no --ekat-test-params ifile=input_nudging_remapped.yaml"
       FIXTURES_REQUIRED shoc_p3_source_data)
 
+# Run a test with nudging using data in hybrid coordinate and use glob pattern:
+set (NUM_STEPS  5)
+set (ATM_TIME_STEP 300)
+set (POSTFIX nudged_hybrid_glob)
+set (VERT_TYPE TIME_DEPENDENT_3D_HYBRID)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_nudging_glob.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input_nudging_hybrid_glob.yaml)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/output_nudged_hybrid_glob.yaml)
+CreateUnitTestFromExec (shoc_p3_nudged_hybrid_glob shoc_p3_nudging
+      EXE_ARGS "--use-colour no --ekat-test-params ifile=input_nudging_hybrid_glob.yaml"
+      FIXTURES_REQUIRED shoc_p3_source_data)
+

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/create_vert_remap_and_weights.cpp
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/create_vert_remap_and_weights.cpp
@@ -80,5 +80,6 @@ TEST_CASE("create_vert_remap_and_weights","create_vert_remap_and_weights")
 {
   create_vert_remap();
   create_nudging_weights_ncfile(1, 218, 72, "nudging_weights.nc");
+  create_nudging_weights_ncfile(1, 218, 128, "nudging_weights_L128.nc");
 }
 } // end namespace

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
@@ -14,7 +14,7 @@ atmosphere_processes:
   p3:
     max_total_ni: 720.0e3
   nudging:
-    nudging_filename: [shoc_p3_source_data_${POSTFIX}.INSTANT.nsteps_x${NUM_STEPS}.${RUN_T0}.nc]
+    nudging_filenames_patterns: [shoc_p3_source_data_${POSTFIX}.INSTANT.nsteps_x${NUM_STEPS}.${RUN_T0}.nc]
     nudging_fields: ["T_mid", "qv"]
     nudging_timescale: 1000
     use_nudging_weights: true

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging_glob.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging_glob.yaml
@@ -14,7 +14,7 @@ atmosphere_processes:
   p3:
     max_total_ni: 720.0e3
   nudging:
-    nudging_filename: [./shoc_p3_source_data_nudged.INSTANT.nsteps_x*.nc]
+    nudging_filenames_patterns: [./shoc_p3_source_data_nudged.INSTANT.nsteps_x*.nc]
     nudging_fields: ["T_mid", "qv"]
     nudging_timescale: 1000
     use_nudging_weights: true

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging_glob.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging_glob.yaml
@@ -1,0 +1,60 @@
+%YAML 1.1
+---
+driver_options:
+  atmosphere_dag_verbosity_level: 5
+
+time_stepping:
+  time_step: ${ATM_TIME_STEP}
+  run_t0: ${RUN_T0}  # YYYY-MM-DD-XXXXX
+  number_of_steps: ${NUM_STEPS}
+
+atmosphere_processes:
+  schedule_type: Sequential
+  atm_procs_list: [shoc,p3,nudging]
+  p3:
+    max_total_ni: 720.0e3
+  nudging:
+    nudging_filename: [./shoc_p3_source_data_nudged.INSTANT.nsteps_x*.nc]
+    nudging_fields: ["T_mid", "qv"]
+    nudging_timescale: 1000
+    use_nudging_weights: true
+    nudging_weights_file: nudging_weights_L128.nc      
+    source_pressure_type: ${VERT_TYPE}
+    source_pressure_file: vertical_remap.nc ## Only used in the case of STATIC_1D_VERTICAL_PROFILE
+  shoc:
+    lambda_low: 0.001
+    lambda_high: 0.04
+    lambda_slope: 2.65
+    lambda_thresh: 0.02
+    thl2tune: 1.0
+    qw2tune: 1.0
+    qwthl2tune: 1.0
+    w2tune: 1.0
+    length_fac: 0.5
+    c_diag_3rd_mom: 7.0
+    Ckh: 0.1
+    Ckm: 0.1
+
+grids_manager:
+  Type: Mesh Free
+  geo_data_source: IC_FILE
+  grids_names: [Physics GLL]
+  Physics GLL:
+    aliases: [Physics]
+    type: point_grid
+    number_of_global_columns:   218
+    number_of_vertical_levels:  128
+
+initial_conditions:
+  # The name of the file containing the initial conditions for this test.
+  Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
+  topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
+  surf_evap: 0.0
+  surf_sens_flux: 0.0
+  precip_ice_surf_mass: 0.0
+  precip_liq_surf_mass: 0.0
+
+# The parameters for I/O control
+Scorpio:
+  output_yaml_files: [output_${POSTFIX}.yaml]
+...

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/output.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/output.yaml
@@ -7,6 +7,7 @@ Field Names:
   - p_mid
   - T_mid
   - qv
+  - horiz_winds
   - qc
   - qr
   - qi


### PR DESCRIPTION
Two small features:

1. Add a glob function to enable reading nudging_filename in pattern (idea from Aaron).
2. Use a TIME_DEPENDENT_3D_HYBRID condition to bypass vert_interp and the following fill_mask in nudging.

A unit test has been added for them. Besides, a short run when a glob pattern matches 30 filename strings was passed. 

The glob function (or similar capability) is intended to address the needs of the long-term nudged runs, so that the user does not have to change the nudging_filename in each submission cycle. The TIME_DEPENDENT_3D_HYBRID condition can only be used if the nudging data has the same vertical coordinate as the model (i.e. vertical interpolation for nudging data is done offline). These changes should not affect existing nudging capabilities.

Not sure if these changes will apply to the needs of most users, but I am opening this PR since Aaron said "being able to use a pattern for nudging file names is a useful feature others would want". Please feel free to close/modify it.