### PR TITLE
Sort gids of ov coarse grid in horiz remappers, to ensure same results regardless of PES count

### DIFF
--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -329,6 +329,10 @@ create_coarse_grids (const std::vector<Triplet>& triplets)
   for (const auto& it : ov_gid2lid) {
     ov_coarse_gids_h[it.second] = it.first;
   }
+  auto beg = ov_coarse_gids_h.data();
+  auto end = beg+ov_coarse_gids_h.size();
+  std::sort(beg,end);
+
   ov_coarse_grid->get_dofs_gids().sync_to_dev();
   m_ov_coarse_grid = ov_coarse_grid;
 


### PR DESCRIPTION
I ran `PEM_Ln1.ne30pg2_ne30pg2.F2010-SCREAMv1.mappy_gnu9.scream-spa_remap` with master and with this branch. On master, the test fails, on this branch it passes. I am moderately confident this may fix our PEM failures in the nightlies.

Fixes #2690 