### PR TITLE
Make TimeStamp::operator+= more stable

### DIFF
--- a/components/eamxx/src/share/tests/utils_tests.cpp
+++ b/components/eamxx/src/share/tests/utils_tests.cpp
@@ -179,6 +179,16 @@ TEST_CASE ("time_stamp") {
     auto ts6 = ts1 + spd*1000;
     REQUIRE ( (ts6-ts1)==spd*1000 );
   }
+  SECTION ("large_updates") {
+    TS base ({1850,1,1},{0,0,0},1);
+    for (int i=1; i<=500; ++i) {
+      TS curr ({1850+i,1,1},{0,0,0},0);
+      auto diff = curr.seconds_from(base);
+      TS time = base;
+      time += diff;
+      REQUIRE (time==curr);
+    }
+  }
 }
 
 TEST_CASE ("array_utils") {

--- a/components/eamxx/src/share/util/scream_time_stamp.cpp
+++ b/components/eamxx/src/share/util/scream_time_stamp.cpp
@@ -161,30 +161,32 @@ TimeStamp& TimeStamp::operator+=(const double seconds) {
   auto& yy = m_date[0];
 
   ++m_num_steps;
-  sec += seconds;
+
+  constexpr auto spd = constants::seconds_per_day;
+  auto add_days = std::floor(seconds / spd);
+  auto add_secs = seconds - add_days*spd;
+
+  sec += add_secs;
+  dd  += add_days;
 
   // Carry over
   int carry;
   carry = sec / 60;
-  if (carry==0) {
-    return *this;
-  }
+  if (carry!=0) {
+    sec = sec % 60;
+    min += carry;
+    carry = min / 60;
+    if (carry!=0) {
+      min = min % 60;
+      hour += carry;
+      carry = hour / 24;
 
-  sec = sec % 60;
-  min += carry;
-  carry = min / 60;
-  if (carry==0) {
-    return *this;
+      if (carry!=0) {
+        hour = hour % 24;
+        dd += carry;
+      }
+    }
   }
-  min = min % 60;
-  hour += carry;
-  carry = hour / 24;
-
-  if (carry==0) {
-    return *this;
-  }
-  hour = hour % 24;
-  dd += carry;
 
   while (dd>days_in_month(yy,mm)) {
     dd -= days_in_month(yy,mm);


### PR DESCRIPTION
We were not handling well the case where the input seconds were larger than what int can store. So instead of adding to the seconds the whole input (which can overflow), we split the seconds to add in days and seconds. This should allow to handle correctly input arguments that are 86400x larger than `std::numeric_limits<int>::max()`, which I think it's plenty for our needs.

A new test checks that an input arg of up to 500y still generates the correct dates.

Fixes #2693 