### PR TITLE
Add support for tensor fields in horizontal interp remappers

### DIFF
--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -166,17 +166,17 @@ LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
     std::vector<FieldTag> lev_tags = {LEV,ILEV};
     return ekat::contains(lev_tags,t);
   };
-  auto is_vec_tag = [](const FieldTag t) {
-    std::vector<FieldTag> vec_tags = {CMP,NGAS,SWBND,LWBND,SWGPT,ISCCPTAU,ISCCPPRS};
-    return ekat::contains(vec_tags,t);
+  auto is_cmp_tag = [](const FieldTag t) {
+    std::vector<FieldTag> cmp_tags = {CMP,NGAS,SWBND,LWBND,SWGPT,ISCCPTAU,ISCCPPRS};
+    return ekat::contains(cmp_tags,t);
   };
   switch (size) {
     case 0:
       result = LayoutType::Scalar2D;
       break;
     case 1:
-      // The only tag left should be a vec tag, 'TL', or a lev tag
-      if (is_vec_tag(tags[0]) or tags[0]==TL) {
+      // The only tag left should be a cmp tag or a lev tag
+      if (is_cmp_tag(tags[0])) {
         result = LayoutType::Vector2D;
       } else if (is_lev_tag(tags[0])) {
         result = LayoutType::Scalar3D;
@@ -184,18 +184,20 @@ LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
       break;
     case 2:
       // Possible supported scenarios:
-      //  1) <CMP|TL,LEV|ILEV>
-      //  2) <TL,CMP>
-      if ( (is_vec_tag(tags[0]) or tags[0]==TL) and is_lev_tag(tags[1]) ) {
+      //  1) <CMP,LEV|ILEV>
+      //  3) <CMP1,CMP2>
+      // where CMP,CMP1,CMP2 are any tag in cmp_tags
+      if ( is_cmp_tag(tags[0]) and is_lev_tag(tags[1]) ) {
         result = LayoutType::Vector3D;
-      } else if (tags[0]==TL && is_vec_tag(tags[1]) ) {
+      } else if (is_cmp_tag(tags[0]) and is_cmp_tag(tags[1])) {
         result = LayoutType::Tensor2D;
       }
       break;
     case 3:
       // The only supported scenario is:
-      //  1) <TL,  CMP, LEV|ILEV>
-      if ( tags[0]==TL && is_vec_tag(tags[1]) && is_lev_tag(tags[2]) ) {
+      //  1) <CMP1, CMP2, LEV|ILEV>
+      // where CMP1,CMP2 are any tag in cmp_tags
+      if (is_cmp_tag(tags[0]) and is_cmp_tag(tags[1]) and is_lev_tag(tags[2])) {
         result = LayoutType::Tensor3D;
       }
   }

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -92,14 +92,21 @@ public:
 
   bool are_dimensions_set () const;
 
-  // Check if this layout is that of a vector field
+  // Check if this layout is that of a vector/tensor field
   bool is_vector_layout () const;
+  bool is_tensor_layout () const;
 
   // If this is the layout of a vector field, get the idx of the vector dimension
   // Note: throws if is_vector_layout()==false.
   int get_vector_dim () const;
   FieldTag get_vector_tag () const;
 
+  // If this is the layout of a tensor field, get the idx of the tensor dimensions
+  // Note: throws if is_tensor_layout()==false.
+  std::vector<int> get_tensor_dims () const;
+  std::vector<FieldTag> get_tensor_tags () const;
+
+  // Returns a copy of this layout with a given dimension stripped
   FieldLayout strip_dim (const FieldTag tag) const;
   FieldLayout strip_dim (const int idim) const;
 

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -152,10 +152,9 @@ is_valid_layout (const FieldLayout& layout) const
     // Let's return true early to avoid segfautls below
     return true;
   }
+
   const bool midpoints = layout.tags().back()==LEV;
-  const bool is_vec = layout.is_vector_layout();
-  const int vec_dim = is_vec ? layout.dims()[layout.get_vector_dim()] : 0;
-  const auto vec_tag = is_vec ? layout.get_vector_tag() : INV;
+  const bool is3d = layout.tags().back()==LEV or layout.tags().back()==ILEV;
 
   switch (lt) {
     case LayoutType::Scalar1D: [[fallthrough]];
@@ -163,14 +162,29 @@ is_valid_layout (const FieldLayout& layout) const
       // 1d layouts need the right number of levels
       return layout.dims().back() == m_num_vert_levs or
              layout.dims().back() == (m_num_vert_levs+1);
-    case LayoutType::Scalar2D:
-      return layout==get_2d_scalar_layout();
-    case LayoutType::Vector2D:
-      return layout==get_2d_vector_layout(vec_tag,vec_dim);
+    case LayoutType::Scalar2D: [[fallthrough]];
     case LayoutType::Scalar3D:
-      return layout==get_3d_scalar_layout(midpoints);
+      return is3d ? layout==get_3d_scalar_layout(midpoints)
+                  : layout==get_2d_scalar_layout();
+    case LayoutType::Vector2D: [[fallthrough]];
     case LayoutType::Vector3D:
-      return layout==get_3d_vector_layout(midpoints,vec_tag,vec_dim);
+    {
+      const auto vec_dim = layout.dims()[layout.get_vector_dim()];
+      const auto vec_tag = layout.get_vector_tag();
+      return is3d ? layout==get_3d_vector_layout(midpoints,vec_tag,vec_dim)
+                  : layout==get_2d_vector_layout(vec_tag,vec_dim);
+    }
+    case LayoutType::Tensor2D: [[fallthrough]];
+    case LayoutType::Tensor3D:
+    {
+      const auto ttags = layout.get_tensor_tags();
+      std::vector<int> tdims;
+      for (auto idx : layout.get_tensor_dims()) {
+        tdims.push_back(layout.dim(idx));
+      }
+      return is3d ? layout==get_3d_tensor_layout(midpoints,ttags,tdims)
+                  : layout==get_2d_tensor_layout(ttags,tdims);
+    }
     default:
       // Anything else is probably no
       return false;

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -74,8 +74,13 @@ public:
   FieldLayout get_vertical_layout (const bool midpoints) const;
   virtual FieldLayout get_2d_scalar_layout () const = 0;
   virtual FieldLayout get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const = 0;
+  virtual FieldLayout get_2d_tensor_layout (const std::vector<FieldTag>& cmp_tags,
+                                            const std::vector<int>& cmp_dims) const = 0;
   virtual FieldLayout get_3d_scalar_layout (const bool midpoints) const = 0;
   virtual FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const = 0;
+  virtual FieldLayout get_3d_tensor_layout (const bool midpoints,
+                                            const std::vector<FieldTag>& cmp_tags,
+                                            const std::vector<int>& cmp_dims) const = 0;
 
   int get_num_vertical_levels () const { return m_num_vert_levs; }
 

--- a/components/eamxx/src/share/grid/point_grid.cpp
+++ b/components/eamxx/src/share/grid/point_grid.cpp
@@ -56,6 +56,20 @@ PointGrid::get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim
 }
 
 FieldLayout
+PointGrid::get_2d_tensor_layout (const std::vector<FieldTag>& cmp_tags,
+                                 const std::vector<int>& cmp_dims) const
+{
+  using namespace ShortFieldTagsNames;
+
+  std::vector<FieldTag> tags = {COL};
+  std::vector<int>      dims = {get_num_local_dofs()};
+
+  tags.insert(tags.end(),cmp_tags.begin(),cmp_tags.end());
+  dims.insert(dims.end(),cmp_dims.begin(),cmp_dims.end());
+  return FieldLayout(tags,dims);
+}
+
+FieldLayout
 PointGrid::get_3d_scalar_layout (const bool midpoints) const
 {
   using namespace ShortFieldTagsNames;
@@ -75,6 +89,26 @@ PointGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag
   auto VL = midpoints ? LEV : ILEV;
 
   return FieldLayout({COL,vector_tag,VL},{get_num_local_dofs(),vector_dim,nvl});
+}
+
+FieldLayout
+PointGrid::get_3d_tensor_layout (const bool midpoints,
+                                 const std::vector<FieldTag>& cmp_tags,
+                                 const std::vector<int>& cmp_dims) const
+{
+  using namespace ShortFieldTagsNames;
+
+  int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
+  auto VL = midpoints ? LEV : ILEV;
+
+  std::vector<FieldTag> tags = {COL};
+  std::vector<int>      dims = {get_num_local_dofs()};
+
+  tags.insert(tags.end(),cmp_tags.begin(),cmp_tags.end());
+  dims.insert(dims.end(),cmp_dims.begin(),cmp_dims.end());
+  tags.push_back(VL);
+  dims.push_back(nvl);
+  return FieldLayout(tags,dims);
 }
 
 std::shared_ptr<AbstractGrid>

--- a/components/eamxx/src/share/grid/point_grid.hpp
+++ b/components/eamxx/src/share/grid/point_grid.hpp
@@ -45,8 +45,13 @@ public:
   // E.g., for a 2d structured grid, this could be a set of 2 indices.
   FieldLayout get_2d_scalar_layout () const override;
   FieldLayout get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const override;
+  FieldLayout get_2d_tensor_layout (const std::vector<FieldTag>& cmp_tags,
+                                    const std::vector<int>& cmp_dims) const override;
   FieldLayout get_3d_scalar_layout (const bool midpoints) const override;
   FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const override;
+  FieldLayout get_3d_tensor_layout (const bool midpoints,
+                                    const std::vector<FieldTag>& cmp_tags,
+                                    const std::vector<int>& cmp_dims) const override;
 
   FieldTag get_partitioned_dim_tag () const override {
     return FieldTag::Column;

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -347,6 +347,57 @@ rescale_masked_fields (const Field& x, const Field& mask) const
       });
       break;
     }
+    case 4:
+    {
+      auto x_view = x.get_view<Pack****>();
+      bool mask1d = mask.rank()==1;
+      view_1d<const Real> mask_1d;
+      view_2d<const Pack> mask_2d;
+      // If the mask comes from FieldAtLevel, it's only defined on columns (rank=1)
+      // If the mask comes from vert interpolation remapper, it is defined on ncols x nlevs (rank=2)
+      if (mask.rank()==1) {
+        mask_1d = mask.get_view<const Real*>();
+      } else {
+        mask_2d = mask.get_view<const Pack**>();
+      }
+      const int dim1 = layout.dim(1);
+      const int dim2 = layout.dim(2);
+      const int dim3 = PackInfo::num_packs(layout.dim(3));
+      auto policy = ESU::get_default_team_policy(ncols,dim1*dim2*dim3);
+      Kokkos::parallel_for(policy,
+                           KOKKOS_LAMBDA(const MemberType& team) {
+        const auto icol = team.league_rank();
+        if (mask1d) {
+          auto mask = mask_1d(icol);
+          if (mask>mask_threshold) {
+            Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dim1*dim2*dim3),
+                                [&](const int idx){
+              const int j = (idx / dim3) / dim2;
+              const int k = (idx / dim3) % dim2;
+              const int l =  idx % dim3;
+              auto x_sub = ekat::subview(x_view,icol,j,k);
+              x_sub(l) /= mask;
+            });
+          }
+        } else {
+          auto m_sub      = ekat::subview(mask_2d,icol);
+          Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dim1*dim2*dim3),
+                              [&](const int idx){
+            const int j = (idx / dim3) / dim2;
+            const int k = (idx / dim3) % dim2;
+            const int l =  idx % dim3;
+            auto x_sub = ekat::subview(x_view,icol,j,k);
+            auto masked = m_sub(l) > mask_threshold;
+
+            if (masked.any()) {
+              x_sub(l).set(masked,x_sub(l)/m_sub(l));
+            }
+            x_sub(l).set(!masked,mask_val);
+          });
+        }
+      });
+      break;
+    }
   }
 }
 
@@ -461,6 +512,46 @@ local_mat_vec (const Field& x, const Field& y, const Field& mask) const
       });
       break;
     }
+    case 4:
+    {
+      auto x_view = x.get_view<const Pack****>();
+      auto y_view = y.get_view<      Pack****>();
+      // Note, the mask is still assumed to be defined on COLxLEV so still only 2D for case 3.
+      view_1d<const Real> mask_1d;
+      view_2d<const Pack> mask_2d;
+      bool mask1d = mask.rank()==1;
+      // If the mask comes from FieldAtLevel, it's only defined on columns (rank=1)
+      // If the mask comes from vert interpolation remapper, it is defined on ncols x nlevs (rank=2)
+      if (mask1d) {
+        mask_1d = mask.get_view<const Real*>();
+      } else {
+        mask_2d = mask.get_view<const Pack**>();
+      }
+      const int dim1 = src_layout.dim(1);
+      const int dim2 = src_layout.dim(2);
+      const int dim3 = PackInfo::num_packs(src_layout.dim(3));
+      auto policy = ESU::get_default_team_policy(nrows,dim1*dim2*dim3);
+      Kokkos::parallel_for(policy,
+                           KOKKOS_LAMBDA(const MemberType& team) {
+        const auto row = team.league_rank();
+
+        const auto beg = row_offsets(row);
+        const auto end = row_offsets(row+1);
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dim1*dim2*dim3),
+                            [&](const int idx){
+          const int j = (idx / dim3) / dim2;
+          const int k = (idx / dim3) % dim2;
+          const int l =  idx % dim3;
+          y_view(row,j,k,l) = weights(beg)*x_view(col_lids(beg),j,k,l) * 
+                          (mask1d ? mask_1d (col_lids(beg)) : mask_2d(col_lids(beg),l));
+          for (int icol=beg+1; icol<end; ++icol) {
+            y_view(row,j,k,l) += weights(icol)*x_view(col_lids(icol),j,k,l) *
+                          (mask1d ? mask_1d (col_lids(icol)) : mask_2d(col_lids(icol),l));
+          }
+        });
+      });
+      break;
+    }
     default:
     {
       EKAT_ERROR_MSG("Error::coarsening_remapper::local_mat_vec doesn't support fields of rank 4 or greater");
@@ -539,6 +630,30 @@ void CoarseningRemapper::pack_and_send ()
             const int idim = idx / dim2;
             const int ilev = idx % dim2;
             buf(offset + lidpos*dim1*dim2 + idim*dim2 + ilev) = v(lid,idim,ilev);
+          });
+        });
+      } break;
+      case 4:
+      {
+        auto v = f.get_view<const Real****>();
+        const int dim1 = fl.dim(1);
+        const int dim2 = fl.dim(2);
+        const int dim3 = fl.dim(3);
+        auto policy = ESU::get_default_team_policy(num_send_gids,dim1*dim2*dim3);
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const MemberType& team){
+          const int i = team.league_rank();
+          const int lid = lids_pids(i,0);
+          const int pid = lids_pids(i,1);
+          const int lidpos = i - pid_lid_start(pid);
+          const int offset = f_pid_offsets(pid);
+
+          Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dim1*dim2*dim3),
+                               [&](const int idx) {
+            const int idim = (idx / dim3) / dim2;
+            const int jdim = (idx / dim3) % dim2;
+            const int ilev =  idx % dim3;
+            buf(offset + lidpos*dim1*dim2*dim3 + idim*dim2*dim3 + jdim*dim3 + ilev) = v(lid,idim,jdim,ilev);
           });
         });
       } break;
@@ -657,6 +772,34 @@ void CoarseningRemapper::recv_and_unpack ()
               const int idim = idx / dim2;
               const int ilev = idx % dim2;
               v(lid,idim,ilev) += buf (offset + idim*dim2 + ilev);
+            });
+          }
+        });
+      } break;
+
+      case 4:
+      {
+        auto v = f.get_view<Real****>();
+        const int dim1 = fl.dim(1);
+        const int dim2 = fl.dim(2);
+        const int dim3 = fl.dim(3);
+        auto policy = ESU::get_default_team_policy(num_tgt_dofs,dim1*dim2*dim3);
+        Kokkos::parallel_for(policy,
+                             KOKKOS_LAMBDA(const MemberType& team){
+          const int lid = team.league_rank();
+          const int recv_beg = recv_lids_beg(lid);
+          const int recv_end = recv_lids_end(lid);
+          for (int irecv=recv_beg; irecv<recv_end; ++irecv) {
+            const int pid = recv_lids_pidpos(irecv,0);
+            const int lidpos = recv_lids_pidpos(irecv,1);
+            const int offset = f_pid_offsets(pid) + lidpos*dim1*dim2*dim3;
+
+            Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dim1*dim2*dim3),
+                                 [&](const int idx) {
+              const int idim = (idx / dim3) / dim2;
+              const int jdim = (idx / dim3) % dim2;
+              const int ilev =  idx % dim3;
+              v(lid,idim,jdim,ilev) += buf (offset + idim*dim2*dim3 + jdim*dim3 + ilev);
             });
           }
         });

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -58,29 +58,7 @@ create_src_layout (const FieldLayout& tgt_layout) const
       "[HorizInterpRemapperBase] Error! Input target layout is not valid for this remapper.\n"
       " - input layout: " + to_string(tgt_layout));
 
-  using namespace ShortFieldTagsNames;
-  const auto lt = get_layout_type(tgt_layout.tags());
-  const bool midpoints = tgt_layout.has_tag(LEV);
-  const auto vec_tag = tgt_layout.is_vector_layout() ? tgt_layout.get_vector_tag() : INV;
-  const int vec_dim  = tgt_layout.is_vector_layout() ? tgt_layout.dim(vec_tag) : -1;
-  auto src = FieldLayout::invalid();
-  switch (lt) {
-    case LayoutType::Scalar2D:
-      src = m_src_grid->get_2d_scalar_layout();
-      break;
-    case LayoutType::Vector2D:
-      src = m_src_grid->get_2d_vector_layout(vec_tag,vec_dim);
-      break;
-    case LayoutType::Scalar3D:
-      src = m_src_grid->get_3d_scalar_layout(midpoints);
-      break;
-    case LayoutType::Vector3D:
-      src = m_src_grid->get_3d_vector_layout(midpoints,vec_tag,vec_dim);
-      break;
-    default:
-      EKAT_ERROR_MSG ("Target layout not supported by HorizInterpRemapperBase: " + e2str(lt) + "\n");
-  }
-  return src;
+  return create_layout (tgt_layout, m_src_grid);
 }
 
 FieldLayout HorizInterpRemapperBase::
@@ -93,29 +71,55 @@ create_tgt_layout (const FieldLayout& src_layout) const
       "[HorizInterpRemapperBase] Error! Input source layout is not valid for this remapper.\n"
       " - input layout: " + to_string(src_layout));
 
+  return create_layout (src_layout, m_tgt_grid);
+}
+
+FieldLayout HorizInterpRemapperBase::
+create_layout (const FieldLayout& fl_in,
+               const grid_ptr_type& grid) const
+{
   using namespace ShortFieldTagsNames;
-  const auto lt = get_layout_type(src_layout.tags());
-  auto tgt = FieldLayout::invalid();
-  const bool midpoints = src_layout.has_tag(LEV);
-  const auto vec_tag = src_layout.is_vector_layout() ? src_layout.get_vector_tag() : INV;
-  const int vec_dim  = src_layout.is_vector_layout() ? src_layout.dim(vec_tag) : -1;
-  switch (lt) {
-    case LayoutType::Scalar2D:
-      tgt = m_tgt_grid->get_2d_scalar_layout();
-      break;
-    case LayoutType::Vector2D:
-      tgt = m_tgt_grid->get_2d_vector_layout(vec_tag,vec_dim);
-      break;
+  const auto type = get_layout_type(fl_in.tags());
+        auto fl_out = FieldLayout::invalid();
+  const bool midpoints = fl_in.has_tag(LEV);
+  const bool is3d = fl_in.has_tag(LEV) or fl_in.has_tag(ILEV);
+  switch (type) {
+    case LayoutType::Scalar2D: [[ fallthrough ]];
     case LayoutType::Scalar3D:
-      tgt = m_tgt_grid->get_3d_scalar_layout(midpoints);
+      fl_out = is3d
+             ? grid->get_3d_scalar_layout(midpoints)
+             : grid->get_2d_scalar_layout();
       break;
+    case LayoutType::Vector2D: [[ fallthrough ]];
     case LayoutType::Vector3D:
-      tgt = m_tgt_grid->get_3d_vector_layout(midpoints,vec_tag,vec_dim);
+    {
+      auto vtag = fl_in.get_vector_tag();
+      auto vdim = fl_in.dim(vtag);
+      fl_out = is3d
+             ? grid->get_3d_vector_layout(midpoints,vtag,vdim)
+             : grid->get_2d_vector_layout(vtag,vdim);
       break;
+    }
+
+    case LayoutType::Tensor2D: [[ fallthrough ]];
+    case LayoutType::Tensor3D:
+    {
+      auto ttags = fl_in.get_tensor_tags();
+      std::vector<int> tdims;
+      for (auto idx : fl_in.get_tensor_dims()) {
+        tdims.push_back(fl_in.dim(idx));
+      }
+      fl_out = is3d
+             ? grid->get_3d_tensor_layout(midpoints,ttags,tdims)
+             : grid->get_2d_tensor_layout(ttags,tdims);
+      break;
+    }
+
     default:
-      EKAT_ERROR_MSG ("Source layout not supported by HorizInterpRemapperBase: " + e2str(lt) + "\n");
+      EKAT_ERROR_MSG ("Layout not supported by HorizInterpRemapperBase:\n"
+                      " - layout: " + to_string(fl_in) + "\n");
   }
-  return tgt;
+  return fl_out;
 }
 
 void HorizInterpRemapperBase::do_registration_ends ()
@@ -504,6 +508,33 @@ local_mat_vec (const Field& x, const Field& y) const
           y_view(row,j,k) = weights(beg)*x_view(col_lids(beg),j,k);
           for (int icol=beg+1; icol<end; ++icol) {
             y_view(row,j,k) += weights(icol)*x_view(col_lids(icol),j,k);
+          }
+        });
+      });
+      break;
+    }
+    case 4:
+    {
+      auto x_view = x.get_view<const Pack****>();
+      auto y_view = y.get_view<      Pack****>();
+      const int dim1 = src_layout.dim(1);
+      const int dim2 = src_layout.dim(2);
+      const int dim3 = PackInfo::num_packs(src_layout.dim(3));
+      auto policy = ESU::get_default_team_policy(nrows,dim1*dim2*dim3);
+      Kokkos::parallel_for(policy,
+                           KOKKOS_LAMBDA(const MemberType& team) {
+        const auto row = team.league_rank();
+
+        const auto beg = row_offsets(row);
+        const auto end = row_offsets(row+1);
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(team,dim1*dim2*dim3),
+                            [&](const int idx){
+          const int j = (idx / dim3) / dim2;
+          const int k = (idx / dim3) % dim2;
+          const int l =  idx % dim3;
+          y_view(row,j,k,l) = weights(beg)*x_view(col_lids(beg),j,k,l);
+          for (int icol=beg+1; icol<end; ++icol) {
+            y_view(row,j,k,l) += weights(icol)*x_view(col_lids(icol),j,k,l);
           }
         });
       });

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.hpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.hpp
@@ -44,6 +44,9 @@ public:
 
 protected:
 
+  FieldLayout create_layout (const FieldLayout& fl_in,
+                             const grid_ptr_type& grid) const;
+
   const identifier_type& do_get_src_field_id (const int ifield) const override {
     return m_src_fields[ifield].get_header().get_identifier();
   }

--- a/components/eamxx/src/share/grid/se_grid.cpp
+++ b/components/eamxx/src/share/grid/se_grid.cpp
@@ -48,6 +48,24 @@ SEGrid::get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) c
 }
 
 FieldLayout
+SEGrid::get_2d_tensor_layout (const std::vector<FieldTag>& cmp_tags,
+                              const std::vector<int>& cmp_dims) const
+{
+  using namespace ShortFieldTagsNames;
+
+  std::vector<FieldTag> tags = {EL};
+  std::vector<int>      dims = {m_num_local_elem};
+
+  tags.insert(tags.end(),cmp_tags.begin(),cmp_tags.end());
+  dims.insert(dims.end(),cmp_dims.begin(),cmp_dims.end());
+  tags.push_back(GP);
+  tags.push_back(GP);
+  dims.push_back(m_num_gp);
+  dims.push_back(m_num_gp);
+  return FieldLayout(tags,dims);
+}
+
+FieldLayout
 SEGrid::get_3d_scalar_layout (const bool midpoints) const
 {
   using namespace ShortFieldTagsNames;
@@ -67,6 +85,30 @@ SEGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, c
   auto VL = midpoints ? LEV : ILEV;
 
   return FieldLayout({EL,vector_tag,GP,GP,VL},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp,nvl});
+}
+
+FieldLayout
+SEGrid::get_3d_tensor_layout (const bool midpoints,
+                              const std::vector<FieldTag>& cmp_tags,
+                              const std::vector<int>& cmp_dims) const
+{
+  using namespace ShortFieldTagsNames;
+
+  int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
+  auto VL = midpoints ? LEV : ILEV;
+
+  std::vector<FieldTag> tags = {EL};
+  std::vector<int>      dims = {m_num_local_elem};
+
+  tags.insert(tags.end(),cmp_tags.begin(),cmp_tags.end());
+  dims.insert(dims.end(),cmp_dims.begin(),cmp_dims.end());
+  tags.push_back(GP);
+  tags.push_back(GP);
+  tags.push_back(VL);
+  dims.push_back(m_num_gp);
+  dims.push_back(m_num_gp);
+  dims.push_back(nvl);
+  return FieldLayout(tags,dims);
 }
 
 Field SEGrid::get_cg_dofs_gids ()

--- a/components/eamxx/src/share/grid/se_grid.hpp
+++ b/components/eamxx/src/share/grid/se_grid.hpp
@@ -22,8 +22,13 @@ public:
   // Native layout of a dof. This is the natural way to index a dof in the grid.
   FieldLayout get_2d_scalar_layout () const override;
   FieldLayout get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const override;
+  FieldLayout get_2d_tensor_layout (const std::vector<FieldTag>& cmp_tags,
+                                    const std::vector<int>& cmp_dims) const override;
   FieldLayout get_3d_scalar_layout (const bool midpoints) const override;
   FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const override;
+  FieldLayout get_3d_tensor_layout (const bool midpoints,
+                                    const std::vector<FieldTag>& cmp_tags,
+                                    const std::vector<int>& cmp_dims) const override;
 
   FieldTag get_partitioned_dim_tag () const override {
     return FieldTag::Element;

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -17,6 +17,52 @@
 
 namespace {
 
+TEST_CASE("field_layout", "") {
+  using namespace scream;
+  using namespace ShortFieldTagsNames;
+
+  using TVec = std::vector<FieldTag>;
+  using IVec = std::vector<int>;
+
+  FieldLayout fl1 ({COL},{1});
+  FieldLayout fl2 ({COL,CMP},{1,1});
+  FieldLayout fl3 ({COL,SWBND,LWBND},{1,1,1});
+  FieldLayout fl4 ({COL,LEV},{1,1});
+  FieldLayout fl5 ({COL,CMP,LEV},{1,1,1});
+  FieldLayout fl6 ({COL,ISCCPTAU,ISCCPPRS,ILEV},{1,1,1,1});
+
+  REQUIRE (get_layout_type(fl1.tags())==LayoutType::Scalar2D);
+  REQUIRE (get_layout_type(fl2.tags())==LayoutType::Vector2D);
+  REQUIRE (get_layout_type(fl3.tags())==LayoutType::Tensor2D);
+  REQUIRE (get_layout_type(fl4.tags())==LayoutType::Scalar3D);
+  REQUIRE (get_layout_type(fl5.tags())==LayoutType::Vector3D);
+  REQUIRE (get_layout_type(fl6.tags())==LayoutType::Tensor3D);
+
+  REQUIRE (not fl1.is_vector_layout());
+  REQUIRE (    fl2.is_vector_layout());
+  REQUIRE (not fl3.is_vector_layout());
+  REQUIRE (not fl4.is_vector_layout());
+  REQUIRE (    fl5.is_vector_layout());
+  REQUIRE (not fl6.is_vector_layout());
+
+  REQUIRE (not fl1.is_tensor_layout());
+  REQUIRE (not fl2.is_tensor_layout());
+  REQUIRE (    fl3.is_tensor_layout());
+  REQUIRE (not fl4.is_tensor_layout());
+  REQUIRE (not fl5.is_tensor_layout());
+  REQUIRE (    fl6.is_tensor_layout());
+
+  REQUIRE (fl2.get_vector_tag()==CMP);
+  REQUIRE (fl5.get_vector_tag()==CMP);
+  REQUIRE (fl2.get_vector_dim()==1);
+  REQUIRE (fl5.get_vector_dim()==1);
+
+  REQUIRE (fl3.get_tensor_tags()==TVec{SWBND,LWBND});
+  REQUIRE (fl6.get_tensor_tags()==TVec{ISCCPTAU,ISCCPPRS});
+  REQUIRE (fl3.get_tensor_dims()==IVec{1,2});
+  REQUIRE (fl6.get_tensor_dims()==IVec{1,2});
+}
+
 TEST_CASE("field_identifier", "") {
   using namespace scream;
   using namespace ekat::units;


### PR DESCRIPTION
Currently, we were allowing 2d/3d scalar/vector fields only. This PR add tensor fields (of rank 2). Here, the rank of the tensor field is what is left in the layout after removing the COL and, possibly, the LEV/ILEV dims.

While a "tensor" layout, from the FieldLayout and AbstractGrid point of view, can have an arbitrary number of dimensions, I only added support for rank2 tensors for the remap, since I think this is all that is needed here.

I added testing for the CoarseningRemapper for 2d/3d tensor fields. I did not add any testing for RefiningRemapperP2P, even though I added support for 2d/3d tensor fields in it. If any parametrization needs it (usually this remapper is just for reading in data from a coarser grid dataset), I can add testing to ensure things works as expected.