### PR TITLE
Change horiz+vert remaps in Nudging

### DIFF
--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -510,7 +510,6 @@ void Nudging::run_impl (const double dt)
       apply_tendency(atm_state_field,field_after_vinterp,dt);
     }
   }
-  m_atm_logger->info("Running nudging...done!");
 }
 
 // =========================================================================================

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -5,6 +5,7 @@
 #include "share/grid/remap/do_nothing_remapper.hpp"
 
 #include <ekat/util/ekat_lin_interp.hpp>
+#include <ekat/util/ekat_math_utils.hpp>
 #include <ekat/kokkos/ekat_kokkos_utils.hpp>
 
 namespace scream
@@ -351,8 +352,8 @@ void Nudging::run_impl (const double dt)
       for (int k=0; k<nlevs; ++k) {
         if (std::abs(v(icol,k)-var_fill_value)>thresh) {
           // This entry is substantially different from var_fill_value, so it's good
-          first_good = std::min(first_good,k);
-          last_good  = std::max(last_good,k);
+          first_good = ekat::impl::min(first_good,k);
+          last_good  = ekat::impl::max(last_good,k);
         }
       }
       EKAT_KERNEL_REQUIRE_MSG (first_good<nlevs and last_good>=0,

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -16,9 +16,6 @@ Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
 {
   m_datafiles  = m_params.get<std::vector<std::string>>("nudging_filename");
   m_timescale = m_params.get<int>("nudging_timescale",0);
-  EKAT_REQUIRE_MSG(m_timescale>0,
-      "[Nudging] Error! Value of nudging_timescale must be positive.\n"
-      "  - input value: " + std::to_string(m_timescale) + "\n");
 
   m_fields_nudge = m_params.get<std::vector<std::string>>("nudging_fields");
   m_use_weights   = m_params.get<bool>("use_nudging_weights",false);

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -375,7 +375,7 @@ void Nudging::run_impl (const double dt)
 
     const int ncols = fl.dim(0);
     const int nlevs = fl.dim(1);
-    const auto thresh = var_fill_value*0.0001;
+    const auto thresh = std::abs(var_fill_value)*0.0001;
     auto lambda = KOKKOS_LAMBDA(const int icol) {
       int first_good = nlevs;
       int last_good = -1;

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -47,7 +47,7 @@ public:
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
 
   // Internal function to apply nudging at specific timescale with weights
-  void apply_weighted_tendency(Field& base, const Field& next, const Field& weights, const Real dt);
+  void apply_weighted_tendency(Field& base, const Field& next, const Field& weights, const Real dt) const;
 
 #ifndef KOKKOS_ENABLE_CUDA
   // Cuda requires methods enclosing __device__ lambda's to be public
@@ -61,8 +61,7 @@ protected:
   // Must add this here to make it public for CUDA
   // (refining) remapper vertically-weighted tendency application
   void apply_vert_cutoff_tendency(Field &base, const Field &next,
-                                  const Field &p_mid, const Real cutoff,
-                                  const Real dt);
+                                  const Field &p_mid, const Real dt) const;
 protected:
 
   Field get_field_out_wrap(const std::string& field_name);
@@ -82,7 +81,7 @@ protected:
   // Retrieve a helper field
   Field get_helper_field (const std::string& name) const { return m_helper_fields.at(name); }
   // Internal function to apply nudging at specific timescale
-  void apply_tendency(Field& base, const Field& next, const Real dt);
+  void apply_tendency(Field& base, const Field& next, const Real dt) const;
 
   std::shared_ptr<const AbstractGrid>   m_grid;
   // Keep track of field dimensions and the iteration count

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -45,13 +45,13 @@ protected:
 
   void run_impl (const double dt) override;
 
-protected:
-
-  Field get_field_out_wrap(const std::string& field_name);
-
   // Internal function to apply nudging at specific timescale
   // NOTE: this method will handle weighted and cutoff cases as well
   void apply_tendency (Field &state, const Field &nudge, const Real dt) const;
+
+protected:
+
+  Field get_field_out_wrap(const std::string& field_name);
 
   // The two other main overrides for the subcomponent
   void initialize_impl (const RunType run_type) override;

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -111,7 +111,7 @@ protected:
   Field create_helper_field (const std::string& name,
                             const FieldLayout& layout,
                             const std::string& grid_name,
-                            const int ps=0);
+                            const int ps = 1);
 
   // Query if a local field exists
   bool has_helper_field (const std::string& name) const { return m_helper_fields.find(name)!=m_helper_fields.end(); }
@@ -146,7 +146,7 @@ protected:
   // file containing coarse data mapping
   std::string m_refine_remap_file;
   // (refining) remapper object
-  std::shared_ptr<scream::AbstractRemapper> m_refine_remapper;
+  std::shared_ptr<scream::AbstractRemapper> m_horiz_remapper;
   // (refining) remapper vertical cutoff
   Real m_refine_remap_vert_cutoff;
 

--- a/components/eamxx/src/physics/nudging/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/nudging/tests/CMakeLists.txt
@@ -1,8 +1,19 @@
 if (NOT SCREAM_BASELINES_ONLY)
   include(ScreamUtils)
 
+  CreateUnitTest (nudging_data "create_nudging_data.cpp"
+    LIBS scream_io
+    FIXTURES_SETUP nudging_data
+  )
+  CreateUnitTest (nudging_map_files "create_map_file.cpp"
+    LIBS scream_io
+    FIXTURES_SETUP nudging_map_files
+  )
   CreateUnitTest(nudging_tests "nudging_tests.cpp"
-      LIBS nudging scream_io
-      LABELS "physics_nudging" )
+    LIBS nudging scream_io
+    MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+    LABELS physics nudging
+    FIXTURES_REQUIRED "nudging_map_files;nudging_data"
+  )
 
 endif()

--- a/components/eamxx/src/physics/nudging/tests/create_map_file.cpp
+++ b/components/eamxx/src/physics/nudging/tests/create_map_file.cpp
@@ -14,7 +14,7 @@ TEST_CASE("create_map_file")
   const int ngdofs_tgt = 2*ngdofs_src-1;
 
   std::string filename = "map_ncol" + std::to_string(ngdofs_src)
-                       + "_to_"     + std::to_string(ngdofs_src) + ".nc";
+                       + "_to_"     + std::to_string(ngdofs_tgt) + ".nc";
 
   // Existing dofs are "copied", added dofs are averaged from neighbors
   const int nnz = ngdofs_src + 2*(ngdofs_src-1);

--- a/components/eamxx/src/physics/nudging/tests/create_map_file.cpp
+++ b/components/eamxx/src/physics/nudging/tests/create_map_file.cpp
@@ -1,0 +1,63 @@
+#include <catch2/catch.hpp>
+
+#include "share/io/scream_scorpio_interface.hpp"
+
+TEST_CASE("create_map_file")
+{
+  using namespace scream;
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+  scorpio::eam_init_pio_subsystem(comm);
+
+  // Add a dof in the middle of two coarse dofs
+  const int ngdofs_src = 12;
+  const int ngdofs_tgt = 2*ngdofs_src-1;
+
+  std::string filename = "map_ncol" + std::to_string(ngdofs_src)
+                       + "_to_"     + std::to_string(ngdofs_src) + ".nc";
+
+  // Existing dofs are "copied", added dofs are averaged from neighbors
+  const int nnz = ngdofs_src + 2*(ngdofs_src-1);
+
+  scorpio::register_file(filename, scorpio::FileMode::Write);
+
+  scorpio::register_dimension(filename, "n_a", "n_a", ngdofs_src, false);
+  scorpio::register_dimension(filename, "n_b", "n_b", ngdofs_tgt, false);
+  scorpio::register_dimension(filename, "n_s", "n_s", nnz,        false);
+
+  scorpio::register_variable(filename, "col", "col", "1", {"n_s"}, "int",    "int",    "");
+  scorpio::register_variable(filename, "row", "row", "1", {"n_s"}, "int",    "int",    "");
+  scorpio::register_variable(filename, "S",   "S",   "1", {"n_s"}, "double", "double", "");
+
+  std::vector<scorpio::offset_t> dofs(nnz);
+  std::iota(dofs.begin(),dofs.end(),0);
+  scorpio::set_dof(filename,"col",dofs.size(),dofs.data());
+  scorpio::set_dof(filename,"row",dofs.size(),dofs.data());
+  scorpio::set_dof(filename,"S",  dofs.size(),dofs.data());
+
+  scorpio::eam_pio_enddef(filename);
+
+  std::vector<int> col(nnz), row(nnz);
+  std::vector<double> S(nnz);
+  for (int i=0; i<ngdofs_src; ++i) {
+    col[i] = i;
+    row[i] = i;
+      S[i] = 1.0;
+  }
+  for (int i=0; i<ngdofs_src-1; ++i) {
+    col[ngdofs_src+2*i] = i;
+    row[ngdofs_src+2*i] = ngdofs_src+i;
+      S[ngdofs_src+2*i] = 0.5;
+
+    col[ngdofs_src+2*i+1] = i+1;
+    row[ngdofs_src+2*i+1] = ngdofs_src+i;
+      S[ngdofs_src+2*i+1] = 0.5;
+  }
+
+  scorpio::grid_write_data_array(filename,"row",row.data(),nnz);
+  scorpio::grid_write_data_array(filename,"col",col.data(),nnz);
+  scorpio::grid_write_data_array(filename,"S",  S.data(),  nnz);
+
+  scorpio::eam_pio_closefile(filename);
+  scorpio::eam_pio_finalize();
+}

--- a/components/eamxx/src/physics/nudging/tests/create_nudging_data.cpp
+++ b/components/eamxx/src/physics/nudging/tests/create_nudging_data.cpp
@@ -30,9 +30,9 @@ TEST_CASE("create_nudging_data") {
   const auto fm1 = create_fm(grid);
   const auto fm2 = create_fm(grid);
   const auto fm3 = create_fm(grid);
-  update_fields(fm1,t0,0);
-  update_fields(fm2,t0,nlevs_filled);
-  update_fields(fm3,t0,0);
+  compute_fields(fm1,t0,comm,0);
+  compute_fields(fm2,t0,comm,nlevs_filled);
+  compute_fields(fm3,t0,comm,0);
 
   // Create output manager
   const auto om1 = create_om("nudging_data",fm1,gm,t0,comm);
@@ -44,9 +44,9 @@ TEST_CASE("create_nudging_data") {
     time += dt;
 
     // Compute fields, but keep p_mid constnat in fm1 and fm2, to avoid vinterp
-    update_fields(fm1,time,0,false);
-    update_fields(fm2,time,nlevs_filled,false);
-    update_fields(fm3,time,0);
+    compute_fields(fm1,time,comm,0,false);
+    compute_fields(fm2,time,comm,nlevs_filled,false);
+    compute_fields(fm3,time,comm,0);
 
     om1->run(time);
     om2->run(time);

--- a/components/eamxx/src/physics/nudging/tests/create_nudging_data.cpp
+++ b/components/eamxx/src/physics/nudging/tests/create_nudging_data.cpp
@@ -1,0 +1,64 @@
+#include "catch2/catch.hpp"
+
+#include "nudging_tests_helpers.hpp"
+
+using namespace scream;
+
+TEST_CASE("create_nudging_data") {
+
+  // Generate nudging data on a grid with 12 global cols and 20 levs.
+  // We create two copies of the data set. One with some filled values,
+  // and one without any filled values
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  const int nlevs  = nlevs_data;
+  const int ngcols = ngcols_data;
+
+  const int dt     = dt_data;
+  const int nsteps = nsteps_data;
+  const auto t0    = get_t0();
+
+  // Initialize the pio_subsystem for this test:
+  scorpio::eam_init_pio_subsystem(comm);
+
+  // Create a grids manager
+  const auto gm = create_gm(comm,ngcols,nlevs);
+  const auto grid = gm->get_grid("Point Grid");
+
+  // Create a field manager, and init fields
+  const auto fm1 = create_fm(grid);
+  const auto fm2 = create_fm(grid);
+  const auto fm3 = create_fm(grid);
+  update_fields(fm1,t0,0);
+  update_fields(fm2,t0,2);
+  update_fields(fm3,t0,0);
+
+  update_field(fm1->get_field("p_mid"),t0,0);
+  update_field(fm2->get_field("p_mid"),t0,2);
+  update_field(fm3->get_field("p_mid"),t0,0);
+
+  // Create output manager
+  const auto om1 = create_om("nudging_data",fm1,gm,t0,comm);
+  const auto om2 = create_om("nudging_data_filled",fm2,gm,t0,comm);
+  const auto om3 = create_om("nudging_data_nonconst_p",fm3,gm,t0,comm);
+
+  auto time = t0;
+  for (int istep=1; istep<=nsteps; ++istep) {
+    time += dt;
+
+    // Compute fields, but keep p_mid constnat in fm1 and fm2, to avoid vinterp
+    update_fields(fm1,time,0,1e30,false);
+    update_fields(fm2,time,2,1e30,false);
+    update_fields(fm3,time,0);
+
+    om1->run(time);
+    om2->run(time);
+    om3->run(time);
+  }
+  om1->finalize();
+  om2->finalize();
+  om3->finalize();
+
+  scorpio::eam_pio_finalize();
+}

--- a/components/eamxx/src/physics/nudging/tests/create_nudging_data.cpp
+++ b/components/eamxx/src/physics/nudging/tests/create_nudging_data.cpp
@@ -26,17 +26,13 @@ TEST_CASE("create_nudging_data") {
   const auto gm = create_gm(comm,ngcols,nlevs);
   const auto grid = gm->get_grid("Point Grid");
 
-  // Create a field manager, and init fields
+  // Create a field manager, and init fields (since OM's need t0 values)
   const auto fm1 = create_fm(grid);
   const auto fm2 = create_fm(grid);
   const auto fm3 = create_fm(grid);
   update_fields(fm1,t0,0);
-  update_fields(fm2,t0,2);
+  update_fields(fm2,t0,nlevs_filled);
   update_fields(fm3,t0,0);
-
-  update_field(fm1->get_field("p_mid"),t0,0);
-  update_field(fm2->get_field("p_mid"),t0,2);
-  update_field(fm3->get_field("p_mid"),t0,0);
 
   // Create output manager
   const auto om1 = create_om("nudging_data",fm1,gm,t0,comm);
@@ -48,8 +44,8 @@ TEST_CASE("create_nudging_data") {
     time += dt;
 
     // Compute fields, but keep p_mid constnat in fm1 and fm2, to avoid vinterp
-    update_fields(fm1,time,0,1e30,false);
-    update_fields(fm2,time,2,1e30,false);
+    update_fields(fm1,time,0,false);
+    update_fields(fm2,time,nlevs_filled,false);
     update_fields(fm3,time,0);
 
     om1->run(time);

--- a/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
+++ b/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
@@ -1,390 +1,215 @@
 #include "catch2/catch.hpp"
+
 #include "physics/nudging/eamxx_nudging_process_interface.hpp"
-#include "share/grid/mesh_free_grids_manager.hpp"
 
-#include "share/io/scream_output_manager.hpp"
-#include "share/io/scorpio_output.hpp"
-#include "share/io/scorpio_input.hpp"
-#include "share/io/scream_scorpio_interface.hpp"
+#include "nudging_tests_helpers.hpp"
 
-#include "share/grid/mesh_free_grids_manager.hpp"
-#include "share/grid/point_grid.hpp"
-
-#include "share/field/field_identifier.hpp"
-#include "share/field/field_header.hpp"
-#include "share/field/field.hpp"
-#include "share/field/field_manager.hpp"
-
-#include "share/util/scream_time_stamp.hpp"
-#include "share/scream_types.hpp"
-#include "scream_config.h"
+#include "share/field/field_utils.hpp"
 
 using namespace scream;
 
-std::shared_ptr<GridsManager>
-create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
+std::shared_ptr<Nudging>
+create_nudging (const ekat::Comm& comm,
+                const ekat::ParameterList& params,
+                const std::shared_ptr<FieldManager>& fm,
+                const std::shared_ptr<GridsManager>& gm,
+                const util::TimeStamp& t0)
+{
+  auto nudging = std::make_shared<Nudging>(comm,params);
+  nudging->set_grids(gm);
+  for (const auto& req : nudging->get_required_field_requests()) {
+    auto f = fm->get_field(req.fid.name());
+    nudging->set_required_field(f);
+  }
+  for (const auto& req : nudging->get_computed_field_requests()) {
+    auto f = fm->get_field(req.fid.name());
+    nudging->set_computed_field(f);
+  }
+  nudging->initialize(t0,RunType::Initial);
 
-  const int num_global_cols = ncols*comm.size();
-
-  using vos_t = std::vector<std::string>;
-  ekat::ParameterList gm_params;
-  gm_params.set("grids_names",vos_t{"Point Grid"});
-  auto& pl = gm_params.sublist("Point Grid");
-  pl.set<std::string>("type","point_grid");
-  pl.set("aliases",vos_t{"Physics"});
-  pl.set<int>("number_of_global_columns", num_global_cols);
-  pl.set<int>("number_of_vertical_levels", nlevs);
-
-  auto gm = create_mesh_free_grids_manager(comm,gm_params);
-  gm->build_grids();
-
-  return gm;
+  return nudging;
 }
 
-TEST_CASE("nudging") {
+TEST_CASE("nudging_tests") {
+  using strvec_t = std::vector<std::string>;
 
-  //This test makes a netcdf file with 3 columns and 34 levels
-  //with 4 fields, T_mid, p_mid, qv, and horiz_winds
-  //The p_mid field is filled based on the following equation:
-  //2j+1, where j is the level
-  //The T_mid, qv, and horiz_winds fields are filled based on the equations:
-  //(i-1)*10000+200*j+10*(dt/250.)*ii, where i is the column, j is the level,
-  //and ii in the timestep
-  //It then runs then nudging module with the netcdf file as input to nudge
-  //And then checks that the output fields of the nudging module match
-  //what should be in the netcdf file
+  ekat::Comm comm(MPI_COMM_WORLD);
 
-  using namespace ekat::units;
-  using namespace ShortFieldTagsNames;
-  using FL = FieldLayout;
+  // Init scorpio
+  scorpio::eam_init_pio_subsystem(comm);
 
-  // A time stamp
-  util::TimeStamp t0 ({2000,1,1},{0,0,0});
+  const std::string nudging_data        = "nudging_data.INSTANT.nsteps_x1." + get_t0().to_string() + ".nc";
+  const std::string nudging_data_filled = "nudging_data_filled.INSTANT.nsteps_x1." + get_t0().to_string() + ".nc";
 
-  ekat::Comm io_comm(MPI_COMM_WORLD);  // MPI communicator group used for I/O set as ekat object.
-  const int packsize = SCREAM_PACK_SIZE;
-  Int num_levs = 34;
+  // A refined grid, with one extra node in between each of the coarse ones
+  const int ngcols_fine = 2*ngcols_data - 1;
+  const int nlevs_fine  = 2*nlevs_data -1;
 
-  // Initialize the pio_subsystem for this test:
-  // MPI communicator group used for I/O.
-  // In our simple test we use MPI_COMM_WORLD, however a subset could be used.
-  MPI_Fint fcomm = MPI_Comm_c2f(io_comm.mpi_comm());
-  // Gather the initial PIO subsystem data creater by component coupler
-  scorpio::eam_init_pio_subsystem(fcomm);
+  // For grids managers, depending on whether ncols/nlevs match the (coarse)
+  // values used to generate the data or are finer
+  auto gm_data   = create_gm (comm,ngcols_data,nlevs_data);
+  auto gm_fine_h = create_gm (comm,ngcols_fine,nlevs_data);
+  auto gm_fine_v = create_gm (comm,ngcols_data,nlevs_fine);
+  auto gm_fine   = create_gm (comm,ngcols_fine,nlevs_fine);
 
-  // First set up a field manager and grids manager to interact
-  // with the output functions
-  auto gm2 = create_gm(io_comm,3,num_levs);
-  auto grid2 = gm2->get_grid("Point Grid");
-  int num_lcols = grid2->get_num_local_dofs();
+  auto grid_data   = gm_data->get_grid("Point Grid");
+  auto grid_fine_h = gm_fine_h->get_grid("Point Grid");
+  auto grid_fine_v = gm_fine_v->get_grid("Point Grid");
+  auto grid_fine   = gm_fine->get_grid("Point Grid");
+  
+  const int ncols_data = grid_data->get_num_local_dofs();
+  // const int ncols_fine = grid_fine->get_num_local_dofs();
 
-  IOControl io_control; // Needed for testing input.
-  io_control.timestamp_of_last_write = t0;
-  io_control.nsamples_since_last_write = 0;
-  io_control.frequency_units         = "nsteps";
-  std::vector<std::string> output_stamps;
-
-  const Int dt        = 250;
-  const Int max_steps = 12;
-  {
-    util::TimeStamp time  = t0;
-    util::TimeStamp time0(t0);
-
-    // Re-create the fm anew, so the fields are re-inited for each output type
-    //auto field_manager = get_test_fm(grid);
-
-    using namespace ShortFieldTagsNames;
-    using FR = FieldRequest;
-
-    // Create a fm
-    auto fm = std::make_shared<FieldManager>(grid2);
-
-    const int num_levs = grid2->get_num_vertical_levels();
-
-    // Create some fields for this fm
-    std::vector<FieldTag> tag_h      = {COL};
-    std::vector<FieldTag> tag_v      = {LEV};
-    std::vector<FieldTag> tag_2d     = {COL,LEV};
-    std::vector<FieldTag> tag_2d_vec = {COL,CMP,LEV};
-
-    std::vector<Int>     dims_h      = {num_lcols};
-    std::vector<Int>     dims_v      = {num_levs};
-    std::vector<Int>     dims_2d     = {num_lcols,num_levs};
-    std::vector<Int>     dims_2d_vec = {num_lcols,2,num_levs};
-
-    const std::string& gn = grid2->name();
-
-    FieldIdentifier fid1("p_mid",FL{tag_2d,dims_2d},Pa,gn);
-    FieldIdentifier fid2("T_mid",FL{tag_2d,dims_2d},K,gn);
-    FieldIdentifier fid3("qv",FL{tag_2d,dims_2d},kg/kg,gn);
-    FieldIdentifier fidhw("horiz_winds",FL{tag_2d_vec,dims_2d_vec},m/s,gn);
-
-    // Register fields with fm
-    fm->registration_begins();
-    fm->register_field(FR{fid1,"output",packsize});
-    fm->register_field(FR{fid2,"output",packsize});
-    fm->register_field(FR{fid3,"output",packsize});
-    fm->register_field(FR{fidhw,"output",packsize});
-    fm->registration_ends();
-
-    // Initialize these fields
-    auto f1      = fm->get_field(fid1);
-    auto f1_host = f1.get_view<Real**,Host>();
-
-    auto f2      = fm->get_field(fid2);
-    auto f2_host = f2.get_view<Real**,Host>();
-
-    auto f3      = fm->get_field(fid3);
-    auto f3_host = f3.get_view<Real**,Host>();
-
-    auto fhw      = fm->get_field(fidhw);
-    auto fhw_host = fhw.get_view<Real***,Host>();
-
-    for (int ii=0;ii<num_lcols;++ii) {
-      for (int jj=0;jj<num_levs;++jj) {
-	f1_host(ii,jj) = 2*jj+1;
-	f2_host(ii,jj) = (ii-1)*10000+200*jj+10*(-1);
-	f3_host(ii,jj) = (ii-1)*10000+200*jj+10*(-1);
-	fhw_host(ii,0,jj) = (ii-1)*10000+200*jj+10*(-1);
-	fhw_host(ii,1,jj) = (ii-1)*10000+200*jj+10*(-1);
-      }
-    }
-    fm->init_fields_time_stamp(time);
-    f1.sync_to_dev();
-    f2.sync_to_dev();
-    f3.sync_to_dev();
-    fhw.sync_to_dev();
-
-    // Add subfields U and V to field manager
-    {
-    auto hw = fm->get_field("horiz_winds");
-    const auto& fid = hw.get_header().get_identifier();
-    const auto& layout = fid.get_layout();
-    const int vec_dim = layout.get_vector_dim();
-    const auto& units = fid.get_units();
-    auto fU = hw.subfield("U",units,vec_dim,0);
-    auto fV = hw.subfield("V",units,vec_dim,1);
-    fm->add_field(fU);
-    fm->add_field(fV);
-    }
-
-    // Set up parameter list control for output
+  // First section tests nudging when there is no horiz-vert interp
+  SECTION ("no-horiz-no-vert") {
     ekat::ParameterList params;
-    params.set<std::string>("filename_prefix","io_output_test");
-    params.set<std::string>("Averaging Type","Instant");
-    params.set<int>("Max Snapshots Per File",15);
-    std::vector<std::string> fnames = {"T_mid","p_mid","qv","U","V"};
-    params.set<std::vector<std::string>>("Field Names",fnames);
-    auto& params_sub = params.sublist("output_control");
-    params_sub.set<std::string>("frequency_units","nsteps");
-    params_sub.set<int>("Frequency",1);
-    params_sub.set<bool>("MPI Ranks in Filename",true);
-    io_control.frequency = params_sub.get<int>("Frequency");
+    params.set<strvec_t>("nudging_filename",{nudging_data});
+    params.set<std::string>("source_pressure_type","TIME_DEPENDENT_3D_PROFILE");
+    params.set<strvec_t>("nudging_fields",{"U","V"});
+    params.get<std::string>("log_level","warn");
 
-    // Set up output manager.
-    OutputManager om;
-    om.setup(io_comm,params,fm,gm2,t0,t0,false);
-    io_comm.barrier();
+    // Create fm. Init p_mid, since it's constant in this file
+    auto fm = create_fm(grid_data);
+    update_field(fm->get_field("p_mid"),get_t0(),0);
 
-    const auto& out_fields = fm->get_groups_info().at("output");
-    using namespace ShortFieldTagsNames;
-    // Time loop
-    for (Int ii=0;ii<max_steps;++ii) {
-      time += dt;
-      // Update the fields
-      for (const auto& fname : out_fields->m_fields_names) {
-        auto f  = fm->get_field(fname);
-        f.sync_to_host();
-        auto fl = f.get_header().get_identifier().get_layout();
-        switch (fl.rank()) {
-          case 2:
-            {
-              auto v = f.get_view<Real**,Host>();
-              for (int i=0; i<fl.dim(0); ++i) {
-                for (int j=0; j<fl.dim(1); ++j) {
-                  if (fname != "p_mid"){
-		      v(i,j) = (i-1)*10000+200*j+10*(dt/250.)*ii;
-                  }
-                  if (fname == "p_mid"){
-                    v(i,j) = 2*j+1;
-		  }
-                }
-              }
-            }
-	    break;
-          case 3:
-            {
-              auto v = f.get_view<Real***,Host>();
-              for (int i=0; i<fl.dim(0); ++i) {
-                for (int j=0; j<fl.dim(2); ++j) {
-		  v(i,0,j) = (i-1)*10000+200*j+10*(dt/250.)*ii;
-		  v(i,1,j) = (i-1)*10000+200*j+10*(dt/250.)*ii;
-                }
-              }
-            }
-	    break;
-          default:
-            EKAT_ERROR_MSG ("Error! Unexpected field rank.\n");
+    auto U = fm->get_field("U");
+    auto V = fm->get_field("V");
+    auto p = fm->get_field("p_mid");
+
+    // Test case where model times coincide with input data times
+    SECTION ("same-time") {
+      std::cout << " -> Testing same time/horiz/vert grid as data ...........\n";
+
+      // Create and init nudging process
+      auto nudging = create_nudging(comm,params,fm,gm_data,get_t0());
+
+      // Same space-time grid, should return the same data
+      auto fm_tgt = create_fm(grid_data);
+      auto time = get_t0();
+
+      auto U_tgt = fm_tgt->get_field("U");
+      auto V_tgt = fm_tgt->get_field("V");
+      for (int n=0; n<nsteps_data; ++n) {
+        time += dt_data;
+
+        // Run nudging
+        nudging->run(dt_data);
+
+        // Recompute original data
+        update_fields(fm_tgt,time,0);
+
+        // Since all values are integers, we should have no rounding
+        REQUIRE (views_are_equal(U,U_tgt));
+        REQUIRE (views_are_equal(V,V_tgt));
+      }
+      std::cout << " -> Testing same time/horiz/vert grid as data ........... PASS\n";
+    }
+
+    // Test case where model times are in the middle of input data time intervals
+    SECTION ("half-time") {
+      std::cout << " -> Testing same horiz/vert grid, different time grid ...\n";
+
+      // Init time as t0-dt/2, so we're "half way" between data slices
+      auto time = get_t0() - dt_data/2;
+
+      // Create and init nudging process
+      auto nudging = create_nudging(comm,params,fm,gm_data,time);
+
+      auto tmp1 = U.clone("");
+      auto tmp2 = U.clone("");
+
+      auto check_f = [&](const Field& f,
+                         const util::TimeStamp& t_prev,
+                         const util::TimeStamp& t_next) {
+        update_field(tmp1,t_prev,0);
+        update_field(tmp2,t_next,0);
+        tmp1.update(tmp2,0.5,0.5);
+
+        // Since input data are integers, and the time-interp coeff is 0.5,
+        // we should be getting the exact answer
+        REQUIRE (views_are_equal(f,tmp1));
+      };
+
+      auto t_prev = get_t0();
+      for (int n=1; n<nsteps_data; ++n) {
+        auto t_next = t_prev+dt_data;
+        time += dt_data;
+
+        // Run nudging
+        nudging->run(dt_data);
+
+        // Compare the two. Since we're exactly half way, we should get exact fp representation
+        check_f(fm->get_field("U"),t_prev,t_next);
+
+        t_prev = t_next;
+      }
+      std::cout << " -> Testing same horiz/vert grid, different time grid ... PASS\n";
+    }
+  }
+
+  // Now test the case where we do have vertical interp.
+  SECTION ("no-horiz-yes-vert") {
+    std::cout << " -> Testing same time/horiz grid, different vert grid ...\n";
+    const auto Pa = ekat::units::Pa;
+
+    // Helper lambda, to compute f on the "fine" vert grid from f on the data vert grid
+    auto manual_interp = [&](const Field& data, const Field& fine) {
+      auto fine_h = fine.get_view<Real**,Host>();
+      auto data_h = data.get_view<Real**,Host>();
+      for (int icol=0; icol<ncols_data; ++icol) {
+        // Even entries match original data
+        for (int ilev=0; ilev<nlevs_data; ++ilev) {
+          fine_h(icol,2*ilev) = data_h(icol,ilev);
         }
-        f.sync_to_dev();
+        // Odd entries are avg of the two adjacent even entries
+        for (int ilev=0; ilev<nlevs_data-1; ++ilev) {
+          fine_h(icol,2*ilev+1) = (fine_h(icol,2*ilev)+fine_h(icol,2*ilev+2))/2;
+        }
       }
+      fine.sync_to_dev();
+    };
 
-      // Run the output manager for this time step
-      om.run(time);
-      if (io_control.is_write_step(time)) {
-        output_stamps.push_back(time.to_string());
-        io_control.nsamples_since_last_write = 0;
-        io_control.timestamp_of_last_write = time;
-      }
+    ekat::ParameterList params;
+    params.set<strvec_t>("nudging_filename",{nudging_data});
+    params.set<std::string>("source_pressure_type","TIME_DEPENDENT_3D_PROFILE");
+    params.set<strvec_t>("nudging_fields",{"U","V"});
+    params.get<std::string>("log_level","warn");
+
+    // Create fm
+    auto fm = create_fm(grid_fine_v);
+    auto U = fm->get_field("U");
+    auto V = fm->get_field("V");
+    auto p_mid = fm->get_field("p_mid");
+
+    // Create and init nudging process
+    auto nudging = create_nudging(comm,params,fm,gm_fine_v,get_t0());
+
+    // Compute pmid on data grid
+    auto layout_data = grid_data->get_3d_scalar_layout(true);
+    Field p_mid_data(FieldIdentifier("p_mid",layout_data,Pa,grid_data->name()));
+    p_mid_data.allocate_view();
+    update_field(p_mid_data,get_t0(),0);
+
+    manual_interp(p_mid_data,p_mid);
+
+    auto time = get_t0();
+    Field tmp_data = p_mid_data.clone("tmp data");
+    Field tmp_fine = p_mid.clone("tmp fine");
+    for (int n=0; n<nsteps_data; ++n) {
+      // Run nudging
+      nudging->run(dt_data);
+
+      // Compute data on fine grid, by manually interpolating
+      // (recall that nudging runs at t+dt)
+      update_field(tmp_data,time+dt_data,0);
+      manual_interp(tmp_data,tmp_fine);
+
+      REQUIRE (views_are_equal(tmp_fine,fm->get_field("U")));
+      time += dt_data;
     }
-
-    // Finalize the output manager (close files)
-    om.finalize();
+    std::cout << " -> Testing same time/horiz grid, different vert grid ... PASS\n";
   }
 
-  // Create a grids manager
-  const int ncols = 3;
-  const int nlevs = 35;
-  auto gm = create_gm(io_comm,ncols,nlevs);
-  auto grid = gm->get_grid("Physics");
-
-  ekat::ParameterList params_mid;
-  std::string nudging_f = "io_output_test.INSTANT.nsteps_x1."\
-                          "np1.2000-01-01-00000.nc";
-  params_mid.set<std::vector<std::string>>("nudging_filename",{nudging_f});
-  params_mid.set<std::vector<std::string>>("nudging_fields",{"T_mid","qv","U","V"});
-  params_mid.set<bool>("use_nudging_weights",false);
-  std::shared_ptr<AtmosphereProcess> nudging_mid = std::make_shared<Nudging>(io_comm,params_mid);
-
-  nudging_mid->set_grids(gm);
-
-  std::map<std::string,Field> input_fields;
-  std::map<std::string,Field> output_fields;
-  for (const auto& req : nudging_mid->get_required_field_requests()) {
-    Field f(req.fid);
-    auto & f_ap = f.get_header().get_alloc_properties();
-    f_ap.request_allocation(packsize);
-    f.allocate_view();
-    const auto name = f.name();
-    f.get_header().get_tracking().update_time_stamp(t0);
-    nudging_mid->set_required_field(f);
-    input_fields.emplace(name,f);
-    if (name != "p_mid"){
-      nudging_mid->set_computed_field(f);
-      output_fields.emplace(name,f);
-    }
-  }
-
-  //initialize
-  nudging_mid->initialize(t0,RunType::Initial);
-  Field p_mid       = input_fields["p_mid"];
-  Field T_mid       = input_fields["T_mid"];
-  Field qv          = input_fields["qv"];
-  Field hw          = input_fields["horiz_winds"];
-  Field T_mid_o     = output_fields["T_mid"];
-  Field qv_mid_o    = output_fields["qv"];
-  Field hw_o        = output_fields["horiz_winds"];
-  // Initialize memory buffer for all atm processes
-  auto memory_buffer = std::make_shared<ATMBufferManager>();
-  memory_buffer->request_bytes(nudging_mid->requested_buffer_size_in_bytes());
-  memory_buffer->allocate();
-  nudging_mid->init_buffers(*memory_buffer);
-
-  //fill data
-  //Don't fill T,qv,u,v because they will be nudged anyways
-  auto p_mid_v_h   = p_mid.get_view<Real**, Host>();
-  for (int icol=0; icol<ncols; icol++){
-    for (int ilev=0; ilev<nlevs; ilev++){
-      p_mid_v_h(icol,ilev) = 2*ilev;
-    }
-  }
-  T_mid.sync_to_dev();
-  qv.sync_to_dev();
-  hw.sync_to_dev();
-  p_mid.sync_to_dev();
-
-  //10 timesteps of 100 s
-  for (int time_s = 1; time_s < 10; time_s++){
-    T_mid_o.sync_to_dev();
-    qv_mid_o.sync_to_dev();
-    hw_o.sync_to_dev();
-    auto T_mid_v_h_o   = T_mid_o.get_view<Real**, Host>();
-    auto qv_h_o        = qv_mid_o.get_view<Real**, Host>();
-    auto hw_h_o        = hw_o.get_view<Real***, Host>();
-    nudging_mid->run(100);
-    T_mid_o.sync_to_host();
-    qv_mid_o.sync_to_host();
-    hw_o.sync_to_host();
-
-    for (int icol=0; icol<ncols; icol++){
-      for (int ilev=0; ilev<nlevs; ilev++){
-        const int time_index = time_s*100./250.;
-
-	//First deal with cases where destination pressure levels are outside
-	//the range of the pressure levels from the external file
-        //If destination pressure is 0 than it will use pressure value of 1
-	//from external file since that is the lowest value. A time interpolation
-	//is performed but there is no interpolation between levels necessary
-	//NOTE: The nearest unmasked value will be the average between ilev=1 and 
-	//      ilev=2 so the vertical contribution will be 200*((1-1) + (2-1))/2 = 100
-	if (ilev == 0){
-	  Real val_before  = 10000*(icol-1) + 100.0 + 10*int(time_index-1);
-	  Real val_after   = 10000*(icol-1) + 100.0 + 10*int(time_index);
-	  Real w_aft       = time_s*100.-time_index*250.;
-	  Real w_bef       = (time_index+1)*250-time_s*100.;
-	  Real val_tim_avg = (val_before*w_bef + val_after*w_aft) / 250.;
-          REQUIRE(abs(T_mid_v_h_o(icol,ilev) - val_tim_avg)<0.001);
-          REQUIRE(abs(qv_h_o(icol,ilev) - val_tim_avg)<0.001);
-          REQUIRE(abs(hw_h_o(icol,0,ilev) - val_tim_avg)<0.001);
-          REQUIRE(abs(hw_h_o(icol,1,ilev) - val_tim_avg)<0.001);
-	  continue;
-	}
-
-        //If destination pressure is 68 than it will use highest pressure value
-	//from external file. A time interpolation is performed but there is
-	//no interpolation between levels necessary
-	//NOTE: The nearest unmasked value will be the average between ilev=num_levs-1 and 
-	//      ilev=num_levs-2 so the vertical contribution will be 
-	//      200*((num_levs-1) + (num_levs-2))/2 = 100*(2*num_levs-3)
-	//NOTE: The use of num_levs instead of nlevs.  In this test num_levs is the number
-	//      of levels in the source data and nlevs is the number of levels on the test
-	//      atm. state.
-	if (ilev == (nlevs-1)){
-	  Real val_before  = 10000*(icol-1) + 100*(2*num_levs-3) + 10*int(time_index-1);
-	  Real val_after   = 10000*(icol-1) + 100*(2*num_levs-3) + 10*int(time_index);
-	  Real w_aft       = time_s*100.-time_index*250.;
-	  Real w_bef       = (time_index+1)*250-time_s*100.;
-	  Real val_tim_avg = (val_before*w_bef + val_after*w_aft) / 250.;
-          REQUIRE(abs(T_mid_v_h_o(icol,ilev) - val_tim_avg)<0.001);
-          REQUIRE(abs(qv_h_o(icol,ilev) - val_tim_avg)<0.001);
-          REQUIRE(abs(hw_h_o(icol,0,ilev) - val_tim_avg)<0.001);
-          REQUIRE(abs(hw_h_o(icol,1,ilev) - val_tim_avg)<0.001);
-	  continue;
-	}
-
-        Real val_before = 10000*(icol-1) + 200*(ilev-1) + 10*int(time_index-1);
-        Real val_after = 10000*(icol-1) + 200*(ilev-1) + 10*int(time_index);
-        Real w_aft = time_s*100.-time_index*250.;
-        Real w_bef = (time_index+1)*250-time_s*100.;
-	Real val_tim_avg = (val_before*w_bef + val_after*w_aft) / 250.;
-
-        Real val_before_n = 10000*(icol-1) + 200*(ilev) + 10*int(time_index-1);
-        Real val_after_n = 10000*(icol-1) + 200*(ilev) + 10*int(time_index);
-        Real w_aft_n = time_s*100.-time_index*250.;
-        Real w_bef_n = (time_index+1)*250-time_s*100.;
-	Real val_tim_avg_next = (val_before_n*w_bef_n + val_after_n*w_aft_n) / 250.;
-	Real val_avg = (val_tim_avg_next + val_tim_avg)/2.;
-
-	REQUIRE(abs(T_mid_v_h_o(icol,ilev) - val_avg)<0.001);
-	REQUIRE(abs(qv_h_o(icol,ilev) - val_avg)<0.001);
-	REQUIRE(abs(hw_h_o(icol,0,ilev) - val_avg)<0.001);
-	REQUIRE(abs(hw_h_o(icol,1,ilev) - val_avg)<0.001);
-      }
-    }
-
+  // Clean up scorpio
+  scorpio::eam_pio_finalize();
 }
-
-nudging_mid->finalize();
-
-}
-

--- a/components/eamxx/src/physics/nudging/tests/nudging_tests_helpers.hpp
+++ b/components/eamxx/src/physics/nudging/tests/nudging_tests_helpers.hpp
@@ -52,16 +52,12 @@ create_fm (const std::shared_ptr<const AbstractGrid>& grid)
   auto vector3d = grid->get_3d_vector_layout(true,CMP,2);
 
   FieldIdentifier fid1("p_mid",scalar3d,Pa,gn);
-  FieldIdentifier fid2("T_mid",scalar3d,K,gn);
-  FieldIdentifier fid3("qv",   scalar3d,kg/kg,gn);
-  FieldIdentifier fid4("horiz_winds",vector3d,m/s,gn);
+  FieldIdentifier fid2("horiz_winds",vector3d,m/s,gn);
 
   // Register fields with fm
   fm->registration_begins();
   fm->register_field(FR(fid1));
   fm->register_field(FR(fid2));
-  fm->register_field(FR(fid3));
-  fm->register_field(FR(fid4));
   fm->registration_ends();
 
   auto U = fm->get_field("horiz_winds").subfield("U",1,0);
@@ -126,8 +122,6 @@ void update_fields (const std::shared_ptr<FieldManager>& fm,
     // Don't mask pressure
     update_field(fm->get_field("p_mid"),time,0);
   }
-  update_field(fm->get_field("T_mid"),time,num_masked_levs);
-  update_field(fm->get_field("qv"),time,num_masked_levs);
   update_field(fm->get_field("U"),time,num_masked_levs);
   update_field(fm->get_field("V"),time,num_masked_levs);
 
@@ -150,7 +144,7 @@ create_om (const std::string& filename_prefix,
   params.set<std::string>("Averaging Type","INSTANT");
   params.set<std::string>("filename_prefix",filename_prefix);
   params.set<std::string>("Floating Point Precision","real");
-  params.set("Field Names",strvec_t{"p_mid","T_mid","qv","U","V"});
+  params.set("Field Names",strvec_t{"p_mid","U","V"});
   params.set("fill_value",fill_val);
 
   auto& ctrl_pl = params.sublist("output_control");

--- a/components/eamxx/src/physics/nudging/tests/nudging_tests_helpers.hpp
+++ b/components/eamxx/src/physics/nudging/tests/nudging_tests_helpers.hpp
@@ -1,0 +1,164 @@
+#include "share/io/scream_output_manager.hpp"
+#include "share/grid/mesh_free_grids_manager.hpp"
+#include "share/field/field.hpp"
+#include "share/field/field_manager.hpp"
+#include "share/util/scream_time_stamp.hpp"
+#include "share/scream_types.hpp"
+
+namespace scream
+{
+
+constexpr int ngcols_data = 12;
+constexpr int nlevs_data  = 20;
+constexpr int nsteps_data = 5;
+constexpr int dt_data     = 100;
+
+util::TimeStamp get_t0 () {
+  return  util::TimeStamp ({2000,1,1},{12,0,0});
+}
+
+std::shared_ptr<GridsManager>
+create_gm (const ekat::Comm& comm, const int ngcols, const int nlevs) {
+
+  using vos_t = std::vector<std::string>;
+  ekat::ParameterList gm_params;
+  gm_params.set("grids_names",vos_t{"Point Grid"});
+  auto& pl = gm_params.sublist("Point Grid");
+  pl.set<std::string>("type","point_grid");
+  pl.set("aliases",vos_t{"Physics"});
+  pl.set<int>("number_of_global_columns", ngcols);
+  pl.set<int>("number_of_vertical_levels", nlevs);
+
+  auto gm = create_mesh_free_grids_manager(comm,gm_params);
+  gm->build_grids();
+
+  return gm;
+}
+
+std::shared_ptr<FieldManager>
+create_fm (const std::shared_ptr<const AbstractGrid>& grid)
+{
+  using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
+  using FR = FieldRequest;
+
+  auto fm = std::make_shared<FieldManager>(grid);
+
+  const std::string& gn = grid->name();
+
+  auto scalar3d = grid->get_3d_scalar_layout(true);
+  auto vector3d = grid->get_3d_vector_layout(true,CMP,2);
+
+  FieldIdentifier fid1("p_mid",scalar3d,Pa,gn);
+  FieldIdentifier fid2("T_mid",scalar3d,K,gn);
+  FieldIdentifier fid3("qv",   scalar3d,kg/kg,gn);
+  FieldIdentifier fid4("horiz_winds",vector3d,m/s,gn);
+
+  // Register fields with fm
+  fm->registration_begins();
+  fm->register_field(FR(fid1));
+  fm->register_field(FR(fid2));
+  fm->register_field(FR(fid3));
+  fm->register_field(FR(fid4));
+  fm->registration_ends();
+
+  auto U = fm->get_field("horiz_winds").subfield("U",1,0);
+  auto V = fm->get_field("horiz_winds").subfield("V",1,1);
+  fm->add_field(U);
+  fm->add_field(V);
+
+  return fm;
+}
+
+void update_field (Field f,
+                   const util::TimeStamp& time,
+                   const int num_masked_levs = 0,
+                   const Real mask_val = 1e30)
+{
+  const auto& fl = f.get_header().get_identifier().get_layout();
+
+  const int ncols = fl.dim(0);
+  const int nlevs = fl.dim(1);
+
+  const int step = time.get_num_steps();
+  const int lev_beg = num_masked_levs;
+  const int lev_end = nlevs - num_masked_levs;
+
+  if (fl.rank()==2) {
+    const auto f_h = f.get_view<Real**, Host>();
+    for (int icol=0;icol<ncols;++icol) {
+      for (int ilev=0; ilev<lev_beg; ++ilev) {
+        f_h(icol,ilev) = mask_val;
+      }
+      for (int ilev=lev_beg;ilev<lev_end;++ilev) {
+        f_h(icol,ilev) = step + icol*nlevs + ilev + 1;
+      }
+      for (int ilev=lev_end; ilev<nlevs; ++ilev) {
+        f_h(icol,ilev) = mask_val;
+      }
+    }
+  } else {
+    const auto f_h = f.get_view<Real***, Host>();
+    for (int icol=0;icol<ncols;++icol) {
+      for (int ilev=0; ilev<lev_beg; ++ilev) {
+        f_h(icol,0,ilev) = f_h(icol,1,ilev) = mask_val;
+      }
+      for (int ilev=lev_beg;ilev<lev_end;++ilev) {
+        f_h(icol,0,ilev) = step + icol*2*nlevs + ilev + 1;
+        f_h(icol,1,ilev) = step + icol*2*nlevs + ilev + 1;
+      }
+      for (int ilev=lev_end; ilev<nlevs; ++ilev) {
+        f_h(icol,0,ilev) = f_h(icol,1,ilev) = mask_val;
+      }
+    }
+  }
+  f.sync_to_dev();
+  f.get_header().get_tracking().update_time_stamp(time);
+}
+
+void update_fields (const std::shared_ptr<FieldManager>& fm,
+                    const util::TimeStamp& time,
+                    const int num_masked_levs = 0,
+                    const Real mask_val = 1e30,
+                    const bool update_p_mid = true)
+{
+  if (update_p_mid) {
+    update_field(fm->get_field("p_mid"),time,num_masked_levs,mask_val);
+  }
+  update_field(fm->get_field("T_mid"),time,num_masked_levs,mask_val);
+  update_field(fm->get_field("qv"),time,num_masked_levs,mask_val);
+  update_field(fm->get_field("U"),time,num_masked_levs,mask_val);
+  update_field(fm->get_field("V"),time,num_masked_levs,mask_val);
+
+  // Not sure if we need it, since we don't handle horiz_winds directly, I think
+  fm->get_field("horiz_winds").get_header().get_tracking().update_time_stamp(time);
+}
+
+std::shared_ptr<OutputManager>
+create_om (const std::string& filename_prefix,
+           const std::shared_ptr<FieldManager>& fm,
+           const std::shared_ptr<GridsManager>& gm,
+           const util::TimeStamp& t0,
+           const ekat::Comm& comm)
+{
+  using strvec_t = std::vector<std::string>;
+
+  // NOTE: ask "real" fp precision, so even when building in double precision
+  //       we can retrieve exactly the nudging data (if no remapping happens)
+  ekat::ParameterList params;
+  params.set<std::string>("Averaging Type","INSTANT");
+  params.set<std::string>("filename_prefix",filename_prefix);
+  params.set<std::string>("Floating Point Precision","real");
+  params.set("Field Names",strvec_t{"p_mid","T_mid","qv","U","V"});
+
+  auto& ctrl_pl = params.sublist("output_control");
+  ctrl_pl.set<std::string>("frequency_units","nsteps");
+  ctrl_pl.set("Frequency",1);
+  ctrl_pl.set("save_grid_data",false);
+
+  auto om = std::make_shared<OutputManager>();
+  om->setup(comm,params,fm,gm,t0,t0,false);
+  return om;
+}
+
+} // namespace scream


### PR DESCRIPTION
This PR does quite an invasive rework of the Nudging horiz+vert remaps. Here's a summary.

- Do horiz remap first (if needed), then vertical. The reason is that we do not have a horiz-coarse pmid on the model vertical grid. We would have to "remap back" the model `p_mid` to the nudging horiz grid to get that, but that's pointless work. Instead, we can do horiz remap right away (does not need anything from the target grid), then vertical.
- Use IdentityRemapper (with aliasing) rather than DoNothingRemapper, if model and nudging data grids are the same. This remapper allows aliasing of src and tgt fields, saving some space (I think the DoNothingRemapper is kind of moot at this point, and we should remove it).
- We do not need the stuff from `scream::vinterp`, since we are *not* going to mask output. Quite the opposite: we need the fields after all the remaps to contain _valid_ values, or else we're going to pollute the EAMxx state! The "raw" `ekat::LinInterp` is enough.
- Since we are not masking, we need to "pad" the data right before the vertical linear interp. That allows to extrapolate values at model top/bot in case `p_mid_tgt` is slightly out of bounds of `p_mid_src`.
- Right after time interpolation, and before horiz interp, we need to "cure" any possible masked value in the input data. That's b/c we don't want that to pollute results in the horiz remapper. The current implementation was only curing data at the model top, but was not doing anything about data near the surface. I changed that, to cure also the bottom levels. Here, "curing" means "set the masked values to whatever is the first valid value in the column", where first is first from the top or bot, depending which end we are "curing". The key assumption is that the masked values form a _contiguous_ chunks of the array, at the model top or bot (or both), but you don't have, say, `[valid, valid, MASKED, valid, valid]` or `[MASKED,valid,MASKED,valid, valid]`. I think this makes sense, considering why data may have been masked in the first place.

Notes:
- Besides for the "curing" part, the vert+horiz infrastructure is _very_ similar to what SPA does (the main difference being that SPA computes a vertical p_mid from ps/hyam/hybm, rather than reading it in). This is a strong signal that this whole infrastructure for reading in a time series of data, possibly interpolating in time/space, _ought_ to be implemented once in a single place.
- The current impl is suboptimal in a few places, but for the sake of getting nudging going (this is only to spin up the autotuning, not for the autotuning samples), I don't want to get this too shiny (also, as mentioned above, we want to move this to a common implementation somewhere else):
  - All the vert interp and masked values "curing" could probably be done in one kernel, like we do in SPA
  - The horiz remap should only be done on `f0` and `f1` in the TimeInterpolation, rather than on the time-interpolated value `f=a*f0 + (1-a)*f1`. That is b/c, unless `f0` and `f1` have to be updated at _every atm step_ (that is, the nudging data has the same time frequency as the model), we would end up doing _less_ horizontal remaps. Again, that's exactly what SPA does.
  - If we keep one kernel dispatch per field, we _may_ be able to alias a few temporaries, to reduce memory consumption.
  - Packs can probably be used more effectively on CPU.
- I am still testing this works as expected. As of this writing, mappy is slammed by e3sm testing, so I need to call it a day. I was only able to verify the code did not crash when running an ne4 case with ne4 nudging data.