### PR TITLE
ensure that lines are ascii in scream defaults xml

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -203,7 +203,7 @@ be lost if SCREAM_HACK_XML is not enabled.
         ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8
       </tables>
       <p3_autoconversion_prefactor type="real" doc="P3 autoconversion_prefactor (scale factor in autoconversion)">1350.0</p3_autoconversion_prefactor>
-      <p3_mu_r_constant type="real" doc="P3 mu_r_constant (rain “shape parameter” in gamma drop-size distribution)">1.0</p3_mu_r_constant>
+      <p3_mu_r_constant type="real" doc="P3 mu_r_constant (rain shape parameter in gamma drop-size distribution)">1.0</p3_mu_r_constant>
       <p3_spa_to_nc type="real" doc="P3 spa_to_nc (scaling factor for turning CCN into nc in SPA)">1.0</p3_spa_to_nc>
       <p3_k_accretion type="real" doc="P3 k_accretion (scaling factor on accretion)">67.0</p3_k_accretion>
       <p3_eci type="real" doc="P3 eci (liquid/ice collision/collection coefficient)">0.5</p3_eci>

--- a/components/eamxx/cime_config/tests/eamxx_default_files.py
+++ b/components/eamxx/cime_config/tests/eamxx_default_files.py
@@ -44,6 +44,26 @@ class testNamelistDefaultsScream(unittest.TestCase):
             for file in files_of_interest
         ]
 
+        self.my_lines = []
+        with open(
+            f"{scream_defaults_path.parent.parent}/namelist_defaults_scream.xml",
+            "r"
+        ) as the_file:
+            for a_line in the_file:
+                self.my_lines.append(a_line)
+
+    def test_ascii_lines(self):
+        """
+        Test that all lines are ASCII
+        """
+
+        for i_line, a_line in enumerate(self.my_lines):
+            with self.subTest(i_line=i_line):
+                self.assertTrue(
+                    a_line.isascii(),
+                    msg=f"\nERROR! This line is not ASCII!\n{a_line}"
+                )
+
     def test_opening_files(self):
         """
         Test the opening of files from the inputdata server.


### PR DESCRIPTION
In a future iteration, I could add more sophisticated testing. For now, this line-by-line check will catch obvious issues. We could ensure individual entries are appropriately formatted later (e.g., doc must be string, type must be some sort of thing from a list of approved types, etc.)