### PR TITLE
Add target pressure levels to the vert remapper tgt grid

### DIFF
--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -67,6 +67,8 @@ VerticalRemapper (const grid_ptr_type& src_grid,
   // Gather the pressure level data for vertical remapping
   set_pressure_levels(map_file);
 
+  // Add tgt pressure levels to the tgt grid
+  tgt_grid->set_geometry_data(m_remap_pres);
   scorpio::eam_pio_closefile(map_file);
 }
 
@@ -146,7 +148,7 @@ set_pressure_levels(const std::string& map_file)
   std::vector<FieldTag> tags = {LEV};
   std::vector<int>      dims = {m_num_remap_levs};
   FieldLayout layout(tags,dims);
-  FieldIdentifier fid("p_remap",layout,ekat::units::Pa,m_tgt_grid->name());
+  FieldIdentifier fid("p_levs",layout,ekat::units::Pa,m_tgt_grid->name());
   m_remap_pres = Field(fid);
   m_remap_pres.get_header().get_alloc_properties().request_allocation(mPack::n);
   m_remap_pres.allocate_view();

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -5,6 +5,7 @@
 #include "share/io/scorpio_input.hpp"
 #include "share/field/field_tag.hpp"
 #include "share/field/field_identifier.hpp"
+#include "share/util/scream_universal_constants.hpp"
 
 #include "ekat/util/ekat_units.hpp"
 #include <ekat/kokkos/ekat_kokkos_utils.hpp>
@@ -20,7 +21,7 @@ VerticalRemapper (const grid_ptr_type& src_grid,
                   const std::string& map_file,
                   const Field& lev_prof,
                   const Field& ilev_prof)
-  : VerticalRemapper(src_grid,map_file,lev_prof,ilev_prof,std::numeric_limits<float>::max()/10.0)
+  : VerticalRemapper(src_grid,map_file,lev_prof,ilev_prof,constants::DefaultFillValue<float>::value)
 {
   // Nothing to do here
 }

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -23,6 +23,7 @@ public:
                     const Field& ilev_prof,
                     const Real mask_val);
 
+  // Calls the above one, with mask_val=max_float/10
   VerticalRemapper (const grid_ptr_type& src_grid,
                     const std::string& map_file,
                     const Field& lev_prof,

--- a/components/eamxx/src/share/util/scream_universal_constants.hpp
+++ b/components/eamxx/src/share/util/scream_universal_constants.hpp
@@ -2,6 +2,7 @@
 #define SCREAM_UNIVERSAL_CONSTANTS_HPP
 
 #include <limits>
+#include <type_traits>
 
 namespace scream {
 
@@ -14,9 +15,9 @@ constexpr int days_per_nonleap_year = 365;
 // TODO: When we switch to supporting C++17 we can use a simple `inline constexpr` rather than a struct
 template<typename T>
 struct DefaultFillValue {
-  static const bool is_float = std::is_floating_point<T>::value;
-  static const bool is_int   = std::is_integral<T>::value;
-  T value = is_int ? std::numeric_limits<int>::max() / 2 : 
+  static constexpr bool is_float = std::is_floating_point<T>::value;
+  static constexpr bool is_int   = std::is_integral<T>::value;
+  static constexpr T value = is_int ? std::numeric_limits<int>::max() / 2 :
 	  is_float ? std::numeric_limits<float>::max() / 1e5 : std::numeric_limits<char>::max();
 
 };


### PR DESCRIPTION
The nc variable name is `p_levs`, so that it's compatible with what the vert remapper reads from the map file. This way, one can recycle an old output file as a map file for vertical remap of another run.

Fixes #2686 