### PR TITLE
enable reading nudging_filename in pattern and bypass vert_interp for nudging (v1)

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -239,7 +239,7 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <!-- nudging -->
     <nudging inherit="atm_proc_base">
-      <nudging_filename type="array(string)"/>
+      <nudging_filenames_patterns type="array(string)"/>
       <nudging_fields type="array(string)" doc="List of fields to be nudged.  Note, syntax of 'A:B' represents nudging field A with data from field B in files, syntax of 'A' assumes that nudging file has the same variables name as EAMxx"/>
       <nudging_timescale type="integer" doc="Timescale to apply nudging tendencies, 0: full replacement, >0: actual timescale">0</nudging_timescale>
       <use_nudging_weights type="logical" doc="Flag for nudging weights option">false</use_nudging_weights>
@@ -250,7 +250,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     TIME_DEPENDENT_3D_PROFILE: The dataset contains a time-varying pressure profile, variable name 'p_mid' with dimensions (time,ncol,nlev).
     STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
       <source_pressure_file type="string" doc="If STATIC_1D_VERTICAL_PROFILE, this is an optional arg to point to a file with the source pressure levels defined.  
-    Default is to look for p_levs in the first nudging_filename file"/>
+    Default is to look for p_levs in the first nudging_filenames_patterns file"/>
       <nudging_refine_remap_mapfile
         type="string"
         doc="Refine-remapping mapfile from the source nudging dataset to the physics grid"

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -244,12 +244,12 @@ be lost if SCREAM_HACK_XML is not enabled.
       <nudging_timescale type="integer" doc="Timescale to apply nudging tendencies, 0: full replacement, >0: actual timescale">0</nudging_timescale>
       <use_nudging_weights type="logical" doc="Flag for nudging weights option">false</use_nudging_weights>
       <nudging_weights_file type="string" doc="weights that relax the nudging fields update"/>
+      <skip_vert_interpolation type="logical" doc="Flag for skipping vertical interpolation">false</skip_vert_interpolation>
       <source_pressure_type type="string" 
-	                    valid_values="TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE,TIME_DEPENDENT_3D_HYBRID"
+	                    valid_values="TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE"
 			    doc="Flag for how source pressure levels are handled in the nudging dataset.
     TIME_DEPENDENT_3D_PROFILE: The dataset contains a time-varying pressure profile, variable name 'p_mid' with dimensions (time,ncol,nlev).
-    STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).
-    TIME_DEPENDENT_3D_HYBRID: The dataset uses a hybrid coordinate with hyai(ilev),hybi(ilev),hyam(lev),hybm(lev),ilev(ilev),lev(lev),P0,PS(time, ncol).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
+    STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
       <source_pressure_file type="string" doc="If STATIC_1D_VERTICAL_PROFILE, this is an optional arg to point to a file with the source pressure levels defined.  
     Default is to look for p_levs in the first nudging_filenames_patterns file"/>
       <nudging_refine_remap_mapfile

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -245,10 +245,11 @@ be lost if SCREAM_HACK_XML is not enabled.
       <use_nudging_weights type="logical" doc="Flag for nudging weights option">false</use_nudging_weights>
       <nudging_weights_file type="string" doc="weights that relax the nudging fields update"/>
       <source_pressure_type type="string" 
-	                    valid_values="TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE"
+	                    valid_values="TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE,TIME_DEPENDENT_3D_HYBRID"
 			    doc="Flag for how source pressure levels are handled in the nudging dataset.
     TIME_DEPENDENT_3D_PROFILE: The dataset contains a time-varying pressure profile, variable name 'p_mid' with dimensions (time,ncol,nlev).
-    STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
+    STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).
+    TIME_DEPENDENT_3D_HYBRID: The dataset uses a hybrid coordinate with hyai(ilev),hybi(ilev),hyam(lev),hybm(lev),ilev(ilev),lev(lev),P0,PS(time, ncol).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
       <source_pressure_file type="string" doc="If STATIC_1D_VERTICAL_PROFILE, this is an optional arg to point to a file with the source pressure levels defined.  
     Default is to look for p_levs in the first nudging_filenames_patterns file"/>
       <nudging_refine_remap_mapfile

--- a/components/eamxx/docs/user/coarse_nudging.md
+++ b/components/eamxx/docs/user/coarse_nudging.md
@@ -20,6 +20,6 @@ In other words, the following options are needed:
 ```shell
 ./atmchange atm_procs_list=(sc_import,nudging,homme,physics,sc_export)
 ./atmchange nudging_fields=U,V
-./atmchange nudging_filename=/path/to/nudging_data_ne4pg2_L72.nc
+./atmchange nudging_filenames_patterns=/path/to/nudging_data_ne4pg2_L72.nc
 ./atmchange nudging_refine_remap_mapfile=/another/path/to/mapping_file_ne4pg2_to_ne120pg2.nc
 ```

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -33,8 +33,17 @@ Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
     m_src_pres_type = STATIC_1D_VERTICAL_PROFILE;
     // Check for a designated source pressure file, default to first nudging data source if not given.
     m_static_vertical_pressure_file = m_params.get<std::string>("source_pressure_file",m_datafiles[0]);
+  } else if (src_pres_type=="TIME_DEPENDENT_3D_HYBRID") {
+    m_src_pres_type = TIME_DEPENDENT_3D_HYBRID;
+    int first_file_levs = scorpio::get_dimlen(m_datafiles[0],"lev");
+    for (const auto& file : m_datafiles) {
+        int current_file_levs = scorpio::get_dimlen(file,"lev");
+        EKAT_REQUIRE_MSG(current_file_levs == first_file_levs,
+                         "Error! Inconsistent 'lev' dimension found in nudging data files.");
+    }
   } else {
-    EKAT_ERROR_MSG("ERROR! Nudging::parameter_list - unsupported source_pressure_type provided.  Current options are [TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE].  Please check");
+    EKAT_ERROR_MSG("ERROR! Nudging::parameter_list - unsupported source_pressure_type provided.  "
+                   "Current options are [TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE,TIME_DEPENDENT_3D_HYBRID].  Please check");
   }
   // use nudging weights
   if (m_use_weights) 
@@ -86,8 +95,14 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   /* ----------------------- WARNING --------------------------------*/
 
   //Now need to read in the file
-  if (m_src_pres_type == TIME_DEPENDENT_3D_PROFILE) {
+  if (m_src_pres_type == TIME_DEPENDENT_3D_PROFILE || m_src_pres_type == TIME_DEPENDENT_3D_HYBRID) {
     m_num_src_levs = scorpio::get_dimlen(m_datafiles[0],"lev");
+    // HYBRID needs the same vertical grid as model for now to bypass vert_interp
+    if (m_src_pres_type == TIME_DEPENDENT_3D_HYBRID) {
+      EKAT_REQUIRE_MSG(m_num_src_levs == m_num_levs,
+                     "Error! TIME_DEPENDENT_3D_HYBRID requires the vertical level to be "
+                     << " the same as model vertical level ");
+    }
   } else {
     m_num_src_levs = scorpio::get_dimlen(m_static_vertical_pressure_file,"lev");
   }
@@ -381,6 +396,19 @@ void Nudging::run_impl (const double dt)
 
   // Perform horizontal remap (if needed)
   m_horiz_remapper->remap(true);
+
+  // bypass copy_and_pad and vert_interp for hybrid coordinate:
+  if (m_src_pres_type == TIME_DEPENDENT_3D_HYBRID) {
+    for (const auto& name : m_fields_nudge) {
+      auto tmp_state_field = get_helper_field(name+"_tmp");
+
+      if (m_timescale > 0) {
+        auto atm_state_field = get_field_out_wrap(name);
+        apply_tendency(atm_state_field,tmp_state_field,dt);
+      }
+    }
+    return;
+  }
 
   // Copy remapper tgt fields into padded views, to allow extrapolation at top/bot,
   // then call remapping routines

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -3,6 +3,7 @@
 #include "share/util/scream_universal_constants.hpp"
 #include "share/grid/remap/refining_remapper_p2p.hpp"
 #include "share/grid/remap/do_nothing_remapper.hpp"
+#include "share/util/scream_utils.hpp"
 
 #include <ekat/util/ekat_lin_interp.hpp>
 #include <ekat/util/ekat_math_utils.hpp>
@@ -15,7 +16,7 @@ namespace scream
 Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
   : AtmosphereProcess(comm, params)
 {
-  m_datafiles  = m_params.get<std::vector<std::string>>("nudging_filename");
+  m_datafiles  = filename_glob(m_params.get<std::vector<std::string>>("nudging_filename"));
   m_timescale = m_params.get<int>("nudging_timescale",0);
 
   m_fields_nudge = m_params.get<std::vector<std::string>>("nudging_fields");

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -278,7 +278,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
   FieldLayout layout_padded ({COL,LEV},{m_num_cols,m_num_src_levs+2});
   create_helper_field("padded_field",layout_padded,"");
 
-  if (m_src_pres_type == TIME_DEPENDENT_3D_PROFILE) {
+  if (m_src_pres_type == TIME_DEPENDENT_3D_PROFILE && !m_skip_vert_interpolation) {
     // If the pressure profile is 3d and time-dep, we need to interpolate (in time/horiz)
     auto pmid_ext = create_helper_field("p_mid_ext", layout_ext, grid_ext->name());
     m_time_interp.add_field(pmid_ext.alias("p_mid"),true);

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -16,7 +16,7 @@ namespace scream
 Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
   : AtmosphereProcess(comm, params)
 {
-  m_datafiles  = filename_glob(m_params.get<std::vector<std::string>>("nudging_filename"));
+  m_datafiles  = filename_glob(m_params.get<std::vector<std::string>>("nudging_filenames_patterns"));
   m_timescale = m_params.get<int>("nudging_timescale",0);
 
   m_fields_nudge = m_params.get<std::vector<std::string>>("nudging_fields");

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -23,7 +23,9 @@ public:
     // DEFAULT - source data should include time/spatially varying p_mid with dimensions (time, col, lev)
     TIME_DEPENDENT_3D_PROFILE,
     // source data includes p_levs which is a static set of levels in both space and time, with dimensions (lev),
-    STATIC_1D_VERTICAL_PROFILE
+    STATIC_1D_VERTICAL_PROFILE,
+    // hybrid data includes hyai(ilev),hybi(ilev),hyam(lev),hybm(lev),ilev(ilev),lev(lev),P0,PS(time, ncol)
+    TIME_DEPENDENT_3D_HYBRID
   };
 
   // Constructors

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -23,9 +23,7 @@ public:
     // DEFAULT - source data should include time/spatially varying p_mid with dimensions (time, col, lev)
     TIME_DEPENDENT_3D_PROFILE,
     // source data includes p_levs which is a static set of levels in both space and time, with dimensions (lev),
-    STATIC_1D_VERTICAL_PROFILE,
-    // hybrid data includes hyai(ilev),hybi(ilev),hyam(lev),hybm(lev),ilev(ilev),lev(lev),P0,PS(time, ncol)
-    TIME_DEPENDENT_3D_HYBRID
+    STATIC_1D_VERTICAL_PROFILE
   };
 
   // Constructors
@@ -75,6 +73,7 @@ protected:
   int m_num_src_levs;
   int m_timescale;
   bool m_use_weights;
+  bool m_skip_vert_interpolation;
   std::vector<std::string> m_datafiles;
   std::string              m_static_vertical_pressure_file;
   // add nudging weights for regional nudging update

--- a/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
+++ b/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
@@ -74,7 +74,7 @@ TEST_CASE("nudging_tests") {
   // First section tests nudging when there is no horiz-vert interp
   SECTION ("no-horiz-no-vert") {
     ekat::ParameterList params;
-    params.set<strvec_t>("nudging_filename",{nudging_data});
+    params.set<strvec_t>("nudging_filenames_patterns",{nudging_data});
     params.set<std::string>("source_pressure_type","TIME_DEPENDENT_3D_PROFILE");
     params.set<strvec_t>("nudging_fields",{"U"});
     params.get<std::string>("log_level","warn");
@@ -189,7 +189,7 @@ TEST_CASE("nudging_tests") {
     };
 
     ekat::ParameterList params;
-    params.set<strvec_t>("nudging_filename",{nudging_data});
+    params.set<strvec_t>("nudging_filenames_patterns",{nudging_data});
     params.set<std::string>("source_pressure_type","TIME_DEPENDENT_3D_PROFILE");
     params.set<strvec_t>("nudging_fields",{"U"});
     params.get<std::string>("log_level","warn");
@@ -365,7 +365,7 @@ TEST_CASE("nudging_tests") {
     };
 
     ekat::ParameterList params;
-    params.set<strvec_t>("nudging_filename",{nudging_data});
+    params.set<strvec_t>("nudging_filenames_patterns",{nudging_data});
     params.set<std::string>("source_pressure_type","TIME_DEPENDENT_3D_PROFILE");
     params.set<std::string>("nudging_refine_remap_mapfile",map_file);
     params.set<strvec_t>("nudging_fields",{"U"});
@@ -430,7 +430,7 @@ TEST_CASE("nudging_tests") {
     };
 
     ekat::ParameterList params;
-    params.set<strvec_t>("nudging_filename",{nudging_data_filled});
+    params.set<strvec_t>("nudging_filenames_patterns",{nudging_data_filled});
     params.set<std::string>("source_pressure_type","TIME_DEPENDENT_3D_PROFILE");
     params.set<strvec_t>("nudging_fields",{"U"});
     params.get<std::string>("log_level","warn");

--- a/components/eamxx/src/share/util/scream_utils.hpp
+++ b/components/eamxx/src/share/util/scream_utils.hpp
@@ -347,6 +347,12 @@ check_mpi_call (int err, const std::string& context) {
       "  - context: " + context + "\n");
 }
 
+// Find the full filename list from patterns
+std::vector<std::string> filename_glob(const std::vector<std::string>& patterns);
+
+// Use globloc for each filename pattern
+std::vector<std::string> globloc(const std::string& pattern);
+
 } // namespace scream
 
 #endif // SCREAM_UTILS_HPP

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/CMakeLists.txt
@@ -57,3 +57,16 @@ CreateUnitTestFromExec (shoc_p3_nudged_remapped shoc_p3_nudging
       EXE_ARGS "--use-colour no --ekat-test-params ifile=input_nudging_remapped.yaml"
       FIXTURES_REQUIRED shoc_p3_source_data)
 
+# Run a test with nudging using data in hybrid coordinate and use glob pattern:
+set (NUM_STEPS  5)
+set (ATM_TIME_STEP 300)
+set (POSTFIX nudged_hybrid_glob)
+set (VERT_TYPE TIME_DEPENDENT_3D_HYBRID)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_nudging_glob.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input_nudging_hybrid_glob.yaml)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/output_nudged_hybrid_glob.yaml)
+CreateUnitTestFromExec (shoc_p3_nudged_hybrid_glob shoc_p3_nudging
+      EXE_ARGS "--use-colour no --ekat-test-params ifile=input_nudging_hybrid_glob.yaml"
+      FIXTURES_REQUIRED shoc_p3_source_data)
+

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/CMakeLists.txt
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/CMakeLists.txt
@@ -57,16 +57,16 @@ CreateUnitTestFromExec (shoc_p3_nudged_remapped shoc_p3_nudging
       EXE_ARGS "--use-colour no --ekat-test-params ifile=input_nudging_remapped.yaml"
       FIXTURES_REQUIRED shoc_p3_source_data)
 
-# Run a test with nudging using data in hybrid coordinate and use glob pattern:
+# Run a test with nudging using data read in glob pattern and skip vertical interpolation:
 set (NUM_STEPS  5)
 set (ATM_TIME_STEP 300)
-set (POSTFIX nudged_hybrid_glob)
-set (VERT_TYPE TIME_DEPENDENT_3D_HYBRID)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_nudging_glob.yaml
-               ${CMAKE_CURRENT_BINARY_DIR}/input_nudging_hybrid_glob.yaml)
+set (POSTFIX nudged_glob_novert)
+set (VERT_TYPE TIME_DEPENDENT_3D_PROFILE)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_nudging_glob_novert.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input_nudging_glob_novert.yaml)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output.yaml
-               ${CMAKE_CURRENT_BINARY_DIR}/output_nudged_hybrid_glob.yaml)
-CreateUnitTestFromExec (shoc_p3_nudged_hybrid_glob shoc_p3_nudging
-      EXE_ARGS "--use-colour no --ekat-test-params ifile=input_nudging_hybrid_glob.yaml"
+               ${CMAKE_CURRENT_BINARY_DIR}/output_nudged_glob_novert.yaml)
+CreateUnitTestFromExec (shoc_p3_nudging_glob_novert shoc_p3_nudging
+      EXE_ARGS "--use-colour no --ekat-test-params ifile=input_nudging_glob_novert.yaml"
       FIXTURES_REQUIRED shoc_p3_source_data)
 

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/create_vert_remap_and_weights.cpp
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/create_vert_remap_and_weights.cpp
@@ -80,5 +80,6 @@ TEST_CASE("create_vert_remap_and_weights","create_vert_remap_and_weights")
 {
   create_vert_remap();
   create_nudging_weights_ncfile(1, 218, 72, "nudging_weights.nc");
+  create_nudging_weights_ncfile(1, 218, 128, "nudging_weights_L128.nc");
 }
 } // end namespace

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging.yaml
@@ -14,7 +14,7 @@ atmosphere_processes:
   p3:
     max_total_ni: 720.0e3
   nudging:
-    nudging_filename: [shoc_p3_source_data_${POSTFIX}.INSTANT.nsteps_x${NUM_STEPS}.${RUN_T0}.nc]
+    nudging_filenames_patterns: [shoc_p3_source_data_${POSTFIX}.INSTANT.nsteps_x${NUM_STEPS}.${RUN_T0}.nc]
     nudging_fields: ["T_mid", "qv"]
     nudging_timescale: 1000
     use_nudging_weights: true

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging_glob.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging_glob.yaml
@@ -1,0 +1,60 @@
+%YAML 1.1
+---
+driver_options:
+  atmosphere_dag_verbosity_level: 5
+
+time_stepping:
+  time_step: ${ATM_TIME_STEP}
+  run_t0: ${RUN_T0}  # YYYY-MM-DD-XXXXX
+  number_of_steps: ${NUM_STEPS}
+
+atmosphere_processes:
+  schedule_type: Sequential
+  atm_procs_list: [shoc,p3,nudging]
+  p3:
+    max_total_ni: 720.0e3
+  nudging:
+    nudging_filenames_patterns: [./shoc_p3_source_data_nudged.INSTANT.nsteps_x*.nc]
+    nudging_fields: ["T_mid", "qv"]
+    nudging_timescale: 1000
+    use_nudging_weights: true
+    nudging_weights_file: nudging_weights_L128.nc      
+    source_pressure_type: ${VERT_TYPE}
+    source_pressure_file: vertical_remap.nc ## Only used in the case of STATIC_1D_VERTICAL_PROFILE
+  shoc:
+    lambda_low: 0.001
+    lambda_high: 0.04
+    lambda_slope: 2.65
+    lambda_thresh: 0.02
+    thl2tune: 1.0
+    qw2tune: 1.0
+    qwthl2tune: 1.0
+    w2tune: 1.0
+    length_fac: 0.5
+    c_diag_3rd_mom: 7.0
+    Ckh: 0.1
+    Ckm: 0.1
+
+grids_manager:
+  Type: Mesh Free
+  geo_data_source: IC_FILE
+  grids_names: [Physics GLL]
+  Physics GLL:
+    aliases: [Physics]
+    type: point_grid
+    number_of_global_columns:   218
+    number_of_vertical_levels:  128
+
+initial_conditions:
+  # The name of the file containing the initial conditions for this test.
+  Filename: ${SCREAM_DATA_DIR}/init/${EAMxx_tests_IC_FILE_128lev}
+  topography_filename: ${TOPO_DATA_DIR}/${EAMxx_tests_TOPO_FILE}
+  surf_evap: 0.0
+  surf_sens_flux: 0.0
+  precip_ice_surf_mass: 0.0
+  precip_liq_surf_mass: 0.0
+
+# The parameters for I/O control
+Scorpio:
+  output_yaml_files: [output_${POSTFIX}.yaml]
+...

--- a/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging_glob_novert.yaml
+++ b/components/eamxx/tests/coupled/physics_only/shoc_p3_nudging/input_nudging_glob_novert.yaml
@@ -18,7 +18,8 @@ atmosphere_processes:
     nudging_fields: ["T_mid", "qv"]
     nudging_timescale: 1000
     use_nudging_weights: true
-    nudging_weights_file: nudging_weights_L128.nc      
+    nudging_weights_file: nudging_weights_L128.nc
+    skip_vert_interpolation: true
     source_pressure_type: ${VERT_TYPE}
     source_pressure_file: vertical_remap.nc ## Only used in the case of STATIC_1D_VERTICAL_PROFILE
   shoc:


### PR DESCRIPTION
Redo #2689 based on the updated master (after the reconstructed nudging interface #2701 was merged into the master)

==========

Two small features:

Add a glob function to enable reading nudging_filename in pattern (idea from Aaron).
Use a TIME_DEPENDENT_3D_HYBRID condition to bypass copy_and_pad and vert_interp in nudging.
A unit test has been added for them. Besides, a short run when a glob pattern matches 30 filename strings was passed.

The glob function (or similar capability) is intended to address the needs of the long-term nudged runs, so that the user does not have to change the nudging_filename in each submission cycle. The TIME_DEPENDENT_3D_HYBRID condition can only be used if the nudging data has the same vertical coordinate as the model (i.e. vertical interpolation for nudging data is done offline). These changes should not affect existing nudging capabilities.