### PR TITLE
Port advance_iop functions

### DIFF
--- a/components/eamxx/src/control/intensive_observation_period.cpp
+++ b/components/eamxx/src/control/intensive_observation_period.cpp
@@ -135,16 +135,18 @@ IntensiveObservationPeriod(const ekat::Comm& comm,
   if (not m_params.isParameter("iop_nudge_tscale"))     m_params.set<Real>("iop_nudge_tscale",     10800);
   if (not m_params.isParameter("zero_non_iop_tracers")) m_params.set<bool>("zero_non_iop_tracers", false);
 
+  // Store hybrid coords in helper fields
+  m_helper_fields.insert({"hyam", hyam});
+  m_helper_fields.insert({"hybm", hybm});
+
   // Use IOP file to initialize parameters
   // and timestepping information
-  initialize_iop_file(run_t0, model_nlevs, hyam, hybm);
+  initialize_iop_file(run_t0, model_nlevs);
 }
 
 void IntensiveObservationPeriod::
 initialize_iop_file(const util::TimeStamp& run_t0,
-                    int model_nlevs,
-                    const Field& hyam,
-                    const Field& hybm)
+                    int model_nlevs)
 {
   EKAT_REQUIRE_MSG(m_params.isParameter("iop_file"),
                    "Error! Using IOP requires defining an iop_file parameter.\n");
@@ -312,10 +314,6 @@ initialize_iop_file(const util::TimeStamp& run_t0,
   model_pressure.get_header().get_alloc_properties().request_allocation(Pack::n);
   model_pressure.allocate_view();
   m_helper_fields.insert({"model_pressure", model_pressure});
-
-  // Store hyam and hybm in helper fields
-  m_helper_fields.insert({"hyam", hyam});
-  m_helper_fields.insert({"hybm", hybm});
 }
 
 void IntensiveObservationPeriod::

--- a/components/eamxx/src/control/intensive_observation_period.hpp
+++ b/components/eamxx/src/control/intensive_observation_period.hpp
@@ -177,9 +177,7 @@ private:
   };
 
   void initialize_iop_file(const util::TimeStamp& run_t0,
-                           int model_nlevs,
-                           const Field& hyam,
-                           const Field& hybm);
+                           int model_nlevs);
 
   ekat::Comm m_comm;
   ekat::ParameterList m_params;

--- a/components/eamxx/src/dynamics/homme/CMakeLists.txt
+++ b/components/eamxx/src/dynamics/homme/CMakeLists.txt
@@ -132,7 +132,7 @@ macro (CreateDynamicsLib HOMME_TARGET NP PLEV QSIZE)
       # possible something that matters will be added in the future.
       SetCudaFlags(${hommeLibName} CUDA_LANG)
     endif()
-    
+
     SetOmpFlags(${hommeLibName})
 
     #####################################
@@ -146,6 +146,7 @@ macro (CreateDynamicsLib HOMME_TARGET NP PLEV QSIZE)
       ${SCREAM_DYNAMICS_SRC_DIR}/eamxx_homme_process_interface.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/eamxx_homme_fv_phys.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/eamxx_homme_rayleigh_friction.cpp
+      ${SCREAM_DYNAMICS_SRC_DIR}/eamxx_homme_iop.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/physics_dynamics_remapper.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/homme_grids_manager.cpp
       ${SCREAM_DYNAMICS_SRC_DIR}/interface/homme_context_mod.F90

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_iop.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_iop.cpp
@@ -197,8 +197,14 @@ apply_iop_forcing(const Real dt)
 
   // Sanity checks since we will be switching between ekat::Pack
   // and Homme::Scalar view types
-  EKAT_ASSERT(NLEV  == ekat::npack<Pack>(total_levels));
-  EKAT_ASSERT(NLEVI == ekat::npack<Pack>(total_levels+1));
+  EKAT_ASSERT_MSG(NLEV  == ekat::npack<Pack>(total_levels),
+    "Error! Dimension for vectorized Homme levels does not match level dimension "
+    "of the packed views used here. Check that Pack typedef is using a pack size "
+    "consistent with Homme's vector size.\n");
+  EKAT_ASSERT_MSG(NLEVI == ekat::npack<Pack>(total_levels+1),
+    "Error! Dimension for vectorized Homme levels does not match level dimension "
+    "of the packed views used here. Check that Pack typedef is using a pack size "
+    "consistent with Homme's vector size.\n");
 
   // Hybrid coord values
   const auto ps0 = hvcoord.ps0;

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_iop.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_iop.cpp
@@ -1,0 +1,408 @@
+#include "eamxx_homme_process_interface.hpp"
+
+// EAMxx includes
+#include "control/intensive_observation_period.hpp"
+#include "dynamics/homme/homme_dimensions.hpp"
+#include "dynamics/homme/homme_dynamics_helpers.hpp"
+#include "physics/share/physics_constants.hpp"
+#include "share/util/scream_column_ops.hpp"
+
+// Homme includes
+#include "Context.hpp"
+#include "ColumnOps.hpp"
+#include "ElementOps.hpp"
+#include "EquationOfState.hpp"
+#include "HommexxEnums.hpp"
+#include "HybridVCoord.hpp"
+#include "KernelVariables.hpp"
+#include "SimulationParams.hpp"
+#include "Types.hpp"
+
+// EKAT includes
+#include "ekat/ekat_workspace.hpp"
+#include "ekat/kokkos/ekat_kokkos_types.hpp"
+
+namespace scream {
+
+// Compute effects of large scale subsidence on T, q, u, and v.
+KOKKOS_FUNCTION
+void HommeDynamics::
+advance_iop_subsidence(const KT::MemberType& team,
+                       const int nlevs,
+                       const Real dt,
+                       const Real ps,
+                       const view_1d<const Pack>& pmid,
+                       const view_1d<const Pack>& pint,
+                       const view_1d<const Pack>& pdel,
+                       const view_1d<const Pack>& omega,
+                       const Workspace& workspace,
+                       const view_1d<Pack>& u,
+                       const view_1d<Pack>& v,
+                       const view_1d<Pack>& T,
+                       const view_2d<Pack>& Q)
+{
+  using ColOps = ColumnOps<DefaultDevice, Real>;
+  using C = physics::Constants<Real>;
+  constexpr Real Rair = C::Rair;
+  constexpr Real Cpair = C::Cpair;
+
+  const auto n_q_tracers = Q.extent_int(0);
+  const auto nlev_packs = ekat::npack<Pack>(nlevs);
+
+  // Get some temporary views from WS
+  uview_1d<Pack> omega_int, delta_u, delta_v, delta_T, tmp;
+  workspace.take_many_contiguous_unsafe<4>({"omega_int", "delta_u", "delta_v", "delta_T"},
+                                           {&omega_int,  &delta_u,  &delta_v,  &delta_T});
+  const auto delta_Q_slot = workspace.take_macro_block("delta_Q", n_q_tracers);
+  uview_2d<Pack> delta_Q(delta_Q_slot.data(), n_q_tracers, nlev_packs);
+
+  auto s_pmid = ekat::scalarize(pmid);
+  auto s_omega = ekat::scalarize(omega);
+  auto s_delta_u = ekat::scalarize(delta_u);
+  auto s_delta_v = ekat::scalarize(delta_v);
+  auto s_delta_T = ekat::scalarize(delta_T);
+  auto s_delta_Q = ekat::scalarize(delta_Q);
+  auto s_omega_int = ekat::scalarize(omega_int);
+
+  // Compute omega on the interface grid by using a weighted average in pressure
+  const int pack_begin = 1/Pack::n, pack_end = (nlevs-1)/Pack::n;
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pack_begin, pack_end+1), [&] (const int k){
+    auto range_pack = ekat::range<IntPack>(k*Pack::n);
+    range_pack.set(range_pack<1, 1);
+    Pack pmid_k, pmid_km1, omega_k, omega_km1;
+    ekat::index_and_shift<-1>(s_pmid, range_pack, pmid_k, pmid_km1);
+    ekat::index_and_shift<-1>(s_omega, range_pack, omega_k, omega_km1);
+
+    const auto weight = (pint(k) - pmid_km1)/(pmid_k - pmid_km1);
+    omega_int(k).set(range_pack>=1 and range_pack<=nlevs-1,
+                      weight*omega_k + (1-weight)*omega_km1);
+  });
+  omega_int(0)[0] = 0;
+  omega_int(nlevs/Pack::n)[nlevs%Pack::n] = 0;
+
+  // Compute delta views for u, v, T, and Q (e.g., u(k+1) - u(k), k=0,...,nlevs-2)
+  ColOps::compute_midpoint_delta(team, nlevs-1, u, delta_u);
+  ColOps::compute_midpoint_delta(team, nlevs-1, v, delta_v);
+  ColOps::compute_midpoint_delta(team, nlevs-1, T, delta_T);
+  for (int iq=0; iq<n_q_tracers; ++iq) {
+    auto tracer       = Kokkos::subview(Q,       iq, Kokkos::ALL());
+    auto delta_tracer = Kokkos::subview(delta_Q, iq, Kokkos::ALL());
+    ColOps::compute_midpoint_delta(team, nlevs-1, tracer, delta_tracer);
+  }
+  team.team_barrier();
+
+  // Compute updated temperature, horizontal winds, and tracers
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_packs), [&] (const int k) {
+    auto range_pack = ekat::range<IntPack>(k*Pack::n);
+
+    // Get delta(k-1) packs. We need a range pack
+    // that does not contain 0 so that we do not
+    // attempt to access k=-1 index.
+    auto range_pack_m1 = range_pack;
+    range_pack_m1.set(range_pack_m1<1, 1);
+    Pack delta_u_k, delta_u_km1,
+          delta_v_k, delta_v_km1,
+          delta_T_k, delta_T_km1;
+    ekat::index_and_shift<-1>(s_delta_u, range_pack_m1, delta_u_k, delta_u_km1);
+    ekat::index_and_shift<-1>(s_delta_v, range_pack_m1, delta_v_k, delta_v_km1);
+    ekat::index_and_shift<-1>(s_delta_T, range_pack_m1, delta_T_k, delta_T_km1);
+
+    // Get omega_int(k+1) pack. We don't need a specialized
+    // range pack since omega_int contains nlevs+1 entries.
+    Pack omega_int_k, omega_int_kp1;
+    ekat::index_and_shift<1>(s_omega_int, range_pack, omega_int_k, omega_int_kp1);
+
+    auto at_top = range_pack==0;
+    auto at_bot = range_pack==nlevs-1;
+
+    auto fac = dt/(2*pdel(k));
+
+    // Update u
+    u(k).set(at_top,                    u(k) - fac*omega_int_kp1*delta_u_k);
+    u(k).set(at_bot,                    u(k) - fac*omega_int_k*delta_u_km1);
+    u(k).set(not at_top and not at_bot, u(k) - fac*(omega_int_kp1*delta_u_k + omega_int_k*delta_u_km1));
+
+    // Update v
+    v(k).set(at_top,                    v(k) - fac*omega_int_kp1*delta_v_k);
+    v(k).set(at_bot,                    v(k) - fac*omega_int_k*delta_v_km1);
+    v(k).set(not at_top and not at_bot, v(k) - fac*(omega_int_kp1*delta_v_k + omega_int_k*delta_v_km1));
+
+    // Update T
+    const auto T_k = T(k);
+    T(k).set(at_top,                    T_k - fac*omega_int_kp1*delta_T_k);
+    T(k).set(at_bot,                    T_k - fac*omega_int_k*delta_T_km1);
+    T(k).set(not at_top and not at_bot, T_k - fac*(omega_int_kp1*delta_T_k + omega_int_k*delta_T_km1));
+    // Add thermal expansion term due to LS vertical advection
+    T(k) += dt*omega(k)*T_k*Rair/(Cpair*pmid(k));;
+
+    // Update Q
+    for (int iq=0; iq<n_q_tracers; ++iq) {
+      auto s_delta_tracer = Kokkos::subview(s_delta_Q, iq, Kokkos::ALL());
+      Pack delta_tracer_k, delta_tracer_km1;
+      ekat::index_and_shift<-1>(s_delta_tracer, range_pack_m1, delta_tracer_k, delta_tracer_km1);
+      Q(iq, k).set(at_top,                    Q(iq, k) - fac*omega_int_kp1*delta_tracer_k);
+      Q(iq, k).set(at_bot,                    Q(iq, k) - fac*omega_int_k*delta_tracer_km1);
+      Q(iq, k).set(not at_top and not at_bot, Q(iq, k) - fac*(omega_int_kp1*delta_tracer_k + omega_int_k*delta_tracer_km1));
+    }
+  });
+
+  // Release WS views
+  workspace.release_macro_block(delta_Q_slot, n_q_tracers);
+  workspace.release_many_contiguous<4>({&omega_int,  &delta_u,  &delta_v,  &delta_T});
+}
+
+// Apply large scale forcing for temperature and water vapor as provided by the IOP file
+KOKKOS_FUNCTION
+void HommeDynamics::
+advance_iop_forcing(const KT::MemberType& team,
+                         const int nlevs,
+                         const Real dt,
+                         const view_1d<const Pack>& divT,
+                         const view_1d<const Pack>& divq,
+                         const view_1d<Pack>& T,
+                         const view_1d<Pack>& qv)
+{
+  const auto nlev_packs = ekat::npack<Pack>(nlevs);
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_packs), [&] (const int k) {
+    T(k) += dt*divT(k);
+    qv(k) += dt*divq(k);
+  });
+}
+
+void HommeDynamics::
+apply_iop_forcing(const Real dt)
+{
+  using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
+
+  using EOS = Homme::EquationOfState;
+  using ElementOps = Homme::ElementOps;
+  using KV = Homme::KernelVariables;
+
+  using ColOps = ColumnOps<DefaultDevice, Real>;
+  using C = physics::Constants<Real>;
+  constexpr Real Rair = C::Rair;
+
+  // Homme objects
+  const auto& c = Homme::Context::singleton();
+  const auto& hvcoord = c.get<Homme::HybridVCoord>();
+  const auto& params = c.get<Homme::SimulationParams>();
+
+  // Dimensions
+  constexpr int NGP   = HOMMEXX_NP;
+  constexpr int NLEV  = HOMMEXX_NUM_LEV;
+  constexpr int NLEVI = HOMMEXX_NUM_LEV_P;
+  const auto nelem    = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
+  const auto total_levels = m_dyn_grid->get_num_vertical_levels();
+  const auto qsize = params.qsize;
+
+  // Sanity checks since we will be switching between ekat::Pack
+  // and Homme::Scalar view types
+  EKAT_ASSERT(NLEV  == ekat::npack<Pack>(total_levels));
+  EKAT_ASSERT(NLEVI == ekat::npack<Pack>(total_levels+1));
+
+  // Hybrid coord values
+  const auto ps0 = hvcoord.ps0;
+  const auto hyam = m_dyn_grid->get_geometry_data("hyam").get_view<const Real*>();
+  const auto hybm = m_dyn_grid->get_geometry_data("hybm").get_view<const Real*>();
+  const auto hyai = m_dyn_grid->get_geometry_data("hyai").get_view<const Real*>();
+  const auto hybi = m_dyn_grid->get_geometry_data("hybi").get_view<const Real*>();
+
+  // Homme element states and EOS/EO classes
+  auto ps_dyn = get_internal_field("ps_dyn").get_view<Real***>();
+  auto dp3d_dyn = get_internal_field("dp3d_dyn").get_view<Pack****>();
+  auto vtheta_dp_dyn = get_internal_field("vtheta_dp_dyn").get_view<Pack****>();
+  auto phi_int_dyn = get_internal_field("phi_int_dyn").get_view<Pack****>();
+  auto v_dyn = get_internal_field("v_dyn").get_view<Pack*****>();
+  auto Q_dyn = m_helper_fields.at("Q_dyn").get_view<Pack*****>();
+  auto Qdp_dyn = get_internal_field("Qdp_dyn").get_view<Pack*****>();
+
+  EOS eos;
+  eos.init(params.theta_hydrostatic_mode, hvcoord);
+
+  ElementOps elem_ops;
+  elem_ops.init(hvcoord);
+  const bool use_moisture = (params.moisture == Homme::MoistDry::MOIST);
+
+  // Define local IOP param values and views
+  const auto iop_dosubsidence = m_iop->get_params().get<bool>("iop_dosubsidence");
+  const auto use_3d_forcing = m_iop->get_params().get<bool>("use_3d_forcing");
+  const auto omega = m_iop->get_iop_field("omega").get_view<const Pack*>();
+  const auto divT = use_3d_forcing ? m_iop->get_iop_field("divT3d").get_view<const Pack*>()
+                                   : m_iop->get_iop_field("divT").get_view<const Pack*>();
+  const auto divq = use_3d_forcing ? m_iop->get_iop_field("divq3d").get_view<const Pack*>()
+                                   : m_iop->get_iop_field("divq").get_view<const Pack*>();
+
+  // Team policy and workspace manager for both homme and scream
+  // related loops. We need separate policies since hommexx functions used here
+  // assume they are called inside nested loops for elements and Gaussian points,
+  // whereas EAMxx function we use expects a single level of parallelism
+  // for elements and Guassian points.
+  // TODO: scream::ColumnOps functions could take an arbitary loop boundary
+  //       (TeamVectorRange, TeamThreadRange, ThreadVectorRange) so that
+  //       all 3 kernel launches here could be combined.
+  const auto policy_homme = ESU::get_default_team_policy(nelem, NLEV);
+  const auto policy_eamxx = ESU::get_default_team_policy(nelem*NGP*NGP, NLEV);
+
+  // TODO: Create a memory buffer for this class
+  //       and add the below WSM and views
+  WorkspaceMgr eamxx_wsm(NLEVI, 7+qsize, policy_eamxx);
+  WorkspaceMgr homme_wsm(NLEV,  32,      policy_homme);
+  view_Nd<Pack, 4>
+    temperature("temperature", nelem, NGP, NGP, NLEV),
+    exner("exner", nelem, NGP, NGP, NLEV);
+
+  // Preprocess some homme states to get temperature and exner
+  Kokkos::parallel_for("compute_t_and_exner", policy_homme, KOKKOS_LAMBDA (const KT::MemberType& team) {
+    KV kv(team);
+    const int ie  =  team.league_rank();
+
+    // Get temp views from workspace
+    auto ws = homme_wsm.get_workspace(team);
+    auto pnh_slot   = ws.take_macro_block("pnh"  , NGP*NGP);
+    auto rstar_slot = ws.take_macro_block("rstar", NGP*NGP);
+    uview_2d<Pack>
+      pnh  (reinterpret_cast<Pack*>(pnh_slot.data()),   NGP*NGP, NLEV),
+      rstar(reinterpret_cast<Pack*>(rstar_slot.data()), NGP*NGP, NLEV);
+
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team, NGP*NGP), [&] (const int idx) {
+      const int igp = idx/NGP;
+      const int jgp = idx%NGP;
+
+      auto dp3d_i      = ekat::subview(dp3d_dyn, ie, igp, jgp);
+      auto vtheta_dp_i = ekat::subview(vtheta_dp_dyn, ie, igp, jgp);
+      auto phi_int_i   = ekat::subview(phi_int_dyn, ie, igp, jgp);
+      auto qv_i        = ekat::subview(Q_dyn, ie, 0, igp, jgp);
+      auto pnh_i         = ekat::subview(pnh, idx);
+      auto rstar_i       = ekat::subview(rstar, idx);
+      auto exner_i       = ekat::subview(exner, ie, igp, jgp);
+      auto temperature_i = ekat::subview(temperature, ie, igp, jgp);
+
+      // Reinterperate into views of Homme::Scalar for calling Hommexx function.
+      Homme::ExecViewUnmanaged<Homme::Scalar[NLEV]> dp3d_scalar(reinterpret_cast<Homme::Scalar*>(dp3d_i.data()), NLEV);
+      Homme::ExecViewUnmanaged<Homme::Scalar[NLEV]> vtheta_dp_scalar(reinterpret_cast<Homme::Scalar*>(vtheta_dp_i.data()), NLEV);
+      Homme::ExecViewUnmanaged<Homme::Scalar[NLEVI]> phi_int_scalar(reinterpret_cast<Homme::Scalar*>(phi_int_i.data()), NLEVI);
+      Homme::ExecViewUnmanaged<Homme::Scalar[NLEV]> qv_scalar(reinterpret_cast<Homme::Scalar*>(qv_i.data()), NLEV);
+      Homme::ExecViewUnmanaged<Homme::Scalar[NLEV]> pnh_scalar(reinterpret_cast<Homme::Scalar*>(pnh_i.data()), NLEV);
+      Homme::ExecViewUnmanaged<Homme::Scalar[NLEV]> exner_scalar(reinterpret_cast<Homme::Scalar*>(exner_i.data()), NLEV);
+      Homme::ExecViewUnmanaged<Homme::Scalar[NLEV]> rstar_scalar(reinterpret_cast<Homme::Scalar*>(rstar_i.data()), NLEV);
+      Homme::ExecViewUnmanaged<Homme::Scalar[NLEV]> temperature_scalar(reinterpret_cast<Homme::Scalar*>(temperature_i.data()), NLEV);
+
+      // Compute exner from EOS
+      if (params.theta_hydrostatic_mode) {
+        auto hydro_p_int = ws.take("hydro_p_int");
+        Homme::ExecViewUnmanaged<Homme::Scalar[NLEVI]> hydro_p_int_scalar(reinterpret_cast<Homme::Scalar*>(hydro_p_int.data()), NLEVI);
+        elem_ops.compute_hydrostatic_p(kv, dp3d_scalar, hydro_p_int_scalar, pnh_scalar);
+        eos.compute_exner(kv, pnh_scalar, exner_scalar);
+        ws.release(hydro_p_int);
+      } else {
+        eos.compute_pnh_and_exner(kv, vtheta_dp_scalar, phi_int_scalar, pnh_scalar, exner_scalar);
+      }
+
+      // Get the temperature from dynamics states
+      elem_ops.get_temperature(kv, eos, use_moisture, dp3d_scalar, exner_scalar, vtheta_dp_scalar, qv_scalar, rstar_scalar, temperature_scalar);
+    });
+
+    // Release WS views
+    ws.release_macro_block(rstar_slot, NGP*NGP);
+    ws.release_macro_block(pnh_slot, NGP*NGP);
+  });
+  Kokkos::fence();
+
+  // Apply IOP forcing
+  Kokkos::parallel_for("apply_iop_forcing", policy_eamxx, KOKKOS_LAMBDA (const KT::MemberType& team) {
+    const int ie  =  team.league_rank()/(NGP*NGP);
+    const int igp = (team.league_rank()/NGP)%NGP;
+    const int jgp =  team.league_rank()%NGP;
+
+    // Get temp views from workspace
+    auto ws = eamxx_wsm.get_workspace(team);
+    uview_1d<Pack> pmid, pint, pdel;
+    ws.take_many_contiguous_unsafe<3>({"pmid", "pint", "pdel"},
+                                      {&pmid,  &pint,  &pdel});
+
+    auto ps_i = ps_dyn(ie, igp, jgp);
+    auto u_i = ekat::subview(v_dyn, ie, 0, igp, jgp);
+    auto v_i = ekat::subview(v_dyn, ie, 1, igp, jgp);
+    auto temperature_i = ekat::subview(temperature, ie, igp, jgp);
+    auto qv_i = ekat::subview(Q_dyn, ie, 0, igp, jgp);
+    auto Q_i = Kokkos::subview(Q_dyn, ie, Kokkos::ALL(), igp, jgp, Kokkos::ALL());
+
+    // Compute reference pressures and layer thickness.
+    // TODO: Allow geometry data to allocate packsize
+    auto s_pmid = ekat::scalarize(pmid);
+    auto s_pint = ekat::scalarize(pint);
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, total_levels+1), [&](const int& k) {
+      s_pint(k) = hyai(k)*ps0 + hybi(k)*ps_i;
+      if (k < total_levels) {
+        s_pmid(k) = hyam(k)*ps0 + hybm(k)*ps_i;
+      }
+    });
+    team.team_barrier();
+    ColOps::compute_midpoint_delta(team, total_levels, pint, pdel);
+    team.team_barrier();
+
+    if (iop_dosubsidence) {
+    // Compute subsidence due to large-scale forcing
+      advance_iop_subsidence(team, total_levels, dt, ps_i, pmid, pint, pdel, omega, ws, u_i, v_i, temperature_i, Q_i);
+    }
+
+    // Update T and qv according to large scale forcing as specified in IOP file.
+    advance_iop_forcing(team, total_levels, dt, divT, divq, temperature_i, qv_i);
+
+    // Release WS views
+    ws.release_many_contiguous<3>({&pmid, &pint, &pdel});
+  });
+  Kokkos::fence();
+
+  // Postprocess homme states Qdp and vtheta_dp
+  Kokkos::parallel_for("compute_qdp_and_vtheta_dp", policy_homme, KOKKOS_LAMBDA (const KT::MemberType& team) {
+    KV kv(team);
+    const int ie  =  team.league_rank();
+
+    // Get temp views from workspace
+    auto ws = homme_wsm.get_workspace(team);
+    auto rstar_slot = ws.take_macro_block("rstar", NGP*NGP);
+    uview_2d<Pack>
+      rstar(reinterpret_cast<Pack*>(rstar_slot.data()), NGP*NGP, NLEV);
+
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team, NGP*NGP), [&] (const int idx) {
+      const int igp = idx/NGP;
+      const int jgp = idx%NGP;
+
+      auto dp3d_i      = ekat::subview(dp3d_dyn, ie, igp, jgp);
+      auto vtheta_dp_i = ekat::subview(vtheta_dp_dyn, ie, igp, jgp);
+      auto qv_i        = ekat::subview(Q_dyn, ie, 0, igp, jgp);
+      auto Q_i         = Kokkos::subview(Q_dyn, ie, Kokkos::ALL(), igp, jgp, Kokkos::ALL());
+      auto Qdp_i       = Kokkos::subview(Qdp_dyn, ie, Kokkos::ALL(), igp, jgp, Kokkos::ALL());
+      auto rstar_i = ekat::subview(rstar, idx);
+      auto exner_i       = ekat::subview(exner, ie, igp, jgp);
+      auto temperature_i = ekat::subview(temperature, ie, igp, jgp);
+
+      // Reinterperate into views of Homme::Scalar for calling Hommexx function.
+      Homme::ExecViewUnmanaged<Homme::Scalar[NLEV]> qv_scalar(reinterpret_cast<Homme::Scalar*>(qv_i.data()), NLEV);
+      Homme::ExecViewUnmanaged<Homme::Scalar[NLEV]> rstar_scalar(reinterpret_cast<Homme::Scalar*>(rstar_i.data()), NLEV);
+
+      // Compute Qdp from updated Q
+      Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, NLEV*qsize), [&] (const int k) {
+        const int ilev = k/qsize;
+        const int q = k%qsize;
+
+        Qdp_i(q, ilev) = Q_i(q, ilev)*dp3d_i(ilev);
+        // For BFB on restarts, Q needs to be updated after we compute Qdp
+        // TODO: Is this needed?
+        Q_i(q, ilev) = Qdp_i(q, ilev)/dp3d_i(ilev);
+      });
+
+      // Convert updated temperature back to potential temperature
+      elem_ops.get_R_star(kv, use_moisture, qv_scalar, rstar_scalar);
+      Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, NLEV), [&] (const int k) {
+        vtheta_dp_i(k) = temperature_i(k)*rstar_i(k)*dp3d_i(k)/(Rair*exner_i(k));
+      });
+    });
+
+    // Release WS views
+    ws.release_macro_block(rstar_slot, NGP*NGP);
+  });
+}
+
+} // namespace scream

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -547,16 +547,13 @@ void HommeDynamics::homme_pre_process (const double dt) {
   // T and uv tendencies are backed out on the ref grid.
   // Homme takes care of turning the FT tendency into a tendency for VTheta_dp.
 
-  constexpr int N = sizeof(Homme::Scalar) / sizeof(Real);
-  using Pack = RPack<N>;
-
   using namespace Homme;
   const auto& c = Context::singleton();
   const auto& params = c.get<SimulationParams>();
 
   const int ncols = m_phys_grid->get_num_local_dofs();
   const int nlevs = m_phys_grid->get_num_vertical_levels();
-  const int npacks = ekat::PackInfo<N>::num_packs(nlevs);
+  const int npacks = ekat::npack<Pack>(nlevs);
 
   const auto& pgn = m_phys_grid->name();
 
@@ -664,6 +661,10 @@ void HommeDynamics::homme_post_process (const double dt) {
     get_internal_field("w_int_dyn").get_header().get_alloc_properties().reset_subview_idx(tl.n0);
   }
 
+  if (m_iop) {
+    apply_iop_forcing(dt);
+  }
+
   if (fv_phys_active()) {
     fv_phys_post_process();
     // Apply Rayleigh friction to update temperature and horiz_winds
@@ -675,8 +676,6 @@ void HommeDynamics::homme_post_process (const double dt) {
   // Remap outputs to ref grid
   m_d2p_remapper->remap(true);
 
-  constexpr int N = HOMMEXX_PACK_SIZE;
-  using Pack = RPack<N>;
   using ColOps = ColumnOps<DefaultDevice,Real>;
   using PF = PhysicsFunctions<DefaultDevice>;
 
@@ -697,7 +696,7 @@ void HommeDynamics::homme_post_process (const double dt) {
 
   const auto ncols = m_phys_grid->get_num_local_dofs();
   const auto nlevs = m_phys_grid->get_num_vertical_levels();
-  const auto npacks= ekat::PackInfo<N>::num_packs(nlevs);
+  const auto npacks= ekat::npack<Pack>(nlevs);
 
   using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
   const auto policy = ESU::get_thread_range_parallel_scan_team_policy(ncols,npacks);
@@ -797,14 +796,13 @@ void HommeDynamics::init_homme_views () {
   constexpr int QSZ  = HOMMEXX_QSIZE_D;
   constexpr int NVL  = HOMMEXX_NUM_LEV;
   constexpr int NVLI = HOMMEXX_NUM_LEV_P;
-  constexpr int N    = HOMMEXX_PACK_SIZE;
 
   const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
   const int qsize = tracers.num_tracers();
 
   const auto ncols = m_phys_grid->get_num_local_dofs();
   const auto nlevs = m_phys_grid->get_num_vertical_levels();
-  const auto npacks= ekat::PackInfo<N>::num_packs(nlevs);
+  const auto npacks= ekat::npack<Pack>(nlevs);
 
   using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
   const auto default_policy = ESU::get_default_team_policy(ncols,npacks);
@@ -931,8 +929,6 @@ void HommeDynamics::restart_homme_state () {
         "  - field name: " + f.get_header().get_identifier().name() + "\n");
   }
 
-  constexpr int N = HOMMEXX_PACK_SIZE;
-  using Pack = RPack<N>;
   using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
   using PF = PhysicsFunctions<DefaultDevice>;
 
@@ -957,7 +953,7 @@ void HommeDynamics::restart_homme_state () {
   const int nlevs = m_phys_grid->get_num_vertical_levels();
   const int ncols = m_phys_grid->get_num_local_dofs();
   const int nelem = m_dyn_grid->get_num_local_dofs() / (NGP*NGP);
-  const int npacks = ekat::PackInfo<N>::num_packs(nlevs);
+  const int npacks = ekat::npack<Pack>(nlevs);
   const int qsize = params.qsize;
 
   // NOTE: when restarting stuff like T_prev, and other "previous steps" quantities that HommeDynamics
@@ -1060,12 +1056,10 @@ void HommeDynamics::restart_homme_state () {
 
 void HommeDynamics::initialize_homme_state () {
   // Some types
-  using Pack = RPack<HOMMEXX_PACK_SIZE>;
   using ColOps = ColumnOps<DefaultDevice,Real>;
   using PF = PhysicsFunctions<DefaultDevice>;
   using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
   using EOS = Homme::EquationOfState;
-  using WS = ekat::WorkspaceManager<Pack,DefaultDevice>;
 
   const auto& rgn = m_cgll_grid->name();
 
@@ -1080,8 +1074,8 @@ void HommeDynamics::initialize_homme_state () {
   constexpr int NGP = HOMMEXX_NP;
   const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
   const int qsize = params.qsize;
-  const int npacks_mid = ekat::PackInfo<HOMMEXX_PACK_SIZE>::num_packs(nlevs);
-  const int npacks_int = ekat::PackInfo<HOMMEXX_PACK_SIZE>::num_packs(nlevs+1);
+  const int npacks_mid = ekat::npack<Pack>(nlevs);
+  const int npacks_int = ekat::npack<Pack>(nlevs+1);
 
   // Bootstrap dp on phys grid, and let the ic remapper transfer dp on dyn grid
   // NOTE: HybridVCoord already stores hyai and hybi deltas as packed views,
@@ -1138,7 +1132,7 @@ void HommeDynamics::initialize_homme_state () {
   const auto hyai0 = hvcoord.hybrid_ai0;
   // Need two temporaries, for pi_mid and pi_int
   const auto policy = ESU::get_thread_range_parallel_scan_team_policy(nelem*NGP*NGP,npacks_mid);
-  WS wsm(npacks_int,2,policy);
+  WorkspaceMgr wsm(npacks_int,2,policy);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
     const int ie  =  team.league_rank() / (NGP*NGP);
     const int igp = (team.league_rank() / NGP) % NGP;
@@ -1149,8 +1143,8 @@ void HommeDynamics::initialize_homme_state () {
 
     // Compute p_mid
     auto ws = wsm.get_workspace(team);
-    ekat::Unmanaged<WS::view_1d<Pack> > p_int, p_mid;
-    ws.template take_many_and_reset<2>({"p_int", "p_mid"}, {&p_int, &p_mid});
+    ekat::Unmanaged<WorkspaceMgr::view_1d<Pack> > p_int, p_mid;
+    ws.take_many_and_reset<2>({"p_int", "p_mid"}, {&p_int, &p_mid});
 
     ColOps::column_scan<true>(team,nlevs,dp,p_int,ps0*hyai0);
     team.team_barrier();
@@ -1281,12 +1275,11 @@ copy_dyn_states_to_all_timelevels () {
 //       TODO item to consolidate how we update the pressure during initialization and run, but
 //       for now we have two locations where we do this.
 void HommeDynamics::update_pressure(const std::shared_ptr<const AbstractGrid>& grid) {
-  using Pack = RPack<HOMMEXX_PACK_SIZE>;
   using ColOps = ColumnOps<DefaultDevice,Real>;
 
   const auto ncols = grid->get_num_local_dofs();
   const auto nlevs = grid->get_num_vertical_levels();
-  const auto npacks= ekat::PackInfo<HOMMEXX_PACK_SIZE>::num_packs(nlevs);
+  const auto npacks= ekat::npack<Pack>(nlevs);
 
   const auto& c = Homme::Context::singleton();
   const auto& hvcoord = c.get<Homme::HybridVCoord>();

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
@@ -6,12 +6,12 @@
 
 #include "ekat/ekat_parameter_list.hpp"
 #include "ekat/ekat_pack.hpp"
+#include "ekat/ekat_workspace.hpp"
 
 #include <string>
 
 namespace scream
 {
-
 /*
  *  The class responsible to handle the atmosphere dynamics
  *
@@ -23,6 +23,25 @@ namespace scream
  */
 class HommeDynamics : public AtmosphereProcess
 {
+  // Define some types needed by class
+  using Pack = ekat::Pack<Real, SCREAM_PACK_SIZE>;
+  using IntPack = ekat::Pack<int, SCREAM_PACK_SIZE>;
+
+  using KT = KokkosTypes<DefaultDevice>;
+  template<typename ScalarT>
+  using view_1d = typename KT::template view_1d<ScalarT>;
+  template<typename ScalarT>
+  using view_2d = typename KT::template view_2d<ScalarT>;
+  template<typename ScalarT, int N>
+  using view_Nd = typename KT::template view_ND<ScalarT, N>;
+  template<typename ST>
+  using uview_1d = ekat::Unmanaged<view_1d<ST>>;
+  template<typename ST>
+  using uview_2d = ekat::Unmanaged<view_2d<ST>>;
+
+  using WorkspaceMgr = ekat::WorkspaceManager<Pack, DefaultDevice>;
+  using Workspace = WorkspaceMgr::Workspace;
+
 public:
 
   // Constructor(s) and Destructor
@@ -89,6 +108,33 @@ protected:
   void rayleigh_friction_init ();
   void rayleigh_friction_apply (const Real dt) const;
 
+  // IOP functions
+  void apply_iop_forcing(const Real dt);
+
+  KOKKOS_FUNCTION
+  static void advance_iop_subsidence(const KT::MemberType& team,
+                                     const int nlevs,
+                                     const Real dt,
+                                     const Real ps,
+                                     const view_1d<const Pack>& pmid,
+                                     const view_1d<const Pack>& pint,
+                                     const view_1d<const Pack>& pdel,
+                                     const view_1d<const Pack>& omega,
+                                     const Workspace& workspace,
+                                     const view_1d<Pack>& u,
+                                     const view_1d<Pack>& v,
+                                     const view_1d<Pack>& T,
+                                     const view_2d<Pack>& Q);
+
+  KOKKOS_FUNCTION
+  static void advance_iop_forcing(const KT::MemberType& team,
+                                  const int nlevs,
+                                  const Real dt,
+                                  const view_1d<const Pack>& divT,
+                                  const view_1d<const Pack>& divq,
+                                  const view_1d<Pack>& T,
+                                  const view_1d<Pack>& qv);
+
 public:
   // Fast boolean function returning whether Physics PGN is being used.
   bool fv_phys_active() const;
@@ -134,15 +180,8 @@ protected:
   std::shared_ptr<const AbstractGrid> m_phys_grid; // Column parameterizations grid
   std::shared_ptr<const AbstractGrid> m_cgll_grid; // Unique CGLL
 
-  template<int N>
-  using RPack = ekat::Pack<Real,N>;
-
-  using KT = KokkosTypes<DefaultDevice>;
-  template<typename ScalarT>
-  using view_1d = typename KT::template view_1d<ScalarT>;
-
   // Rayleigh friction decay rate profile
-  view_1d<RPack<SCREAM_PACK_SIZE>> m_otau;
+  view_1d<Pack> m_otau;
 
   // Rayleigh friction paramaters
   int m_rayk0;      // Vertical level at which rayleigh friction term is centered.

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp_dp/homme_shoc_cld_p3_rrtmgp_dp.cpp
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp_dp/homme_shoc_cld_p3_rrtmgp_dp.cpp
@@ -82,7 +82,6 @@ TEST_CASE("scream_homme_physics", "scream_homme_physics") {
   ad.setup_surface_coupling_data_manager(SurfaceCouplingTransferType::Import,
                                          4, 4, ncols, import_data.data(), import_names[0], import_cpl_indices.data(),
                                          import_vec_comps.data(), import_constant_multiple.data(), do_import_during_init.data());
-
   ad.initialize_fields ();
   ad.initialize_output_managers ();
   ad.initialize_atm_procs ();

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp_dp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_p3_rrtmgp_dp/input.yaml
@@ -9,6 +9,7 @@ intensive_observation_period_options:
   iop_file: ${IOP_DATA_DIR}/DYCOMSrf01_iopfile_4scam.nc
   target_latitude: 31.5
   target_longitude: 238.5
+  iop_dosubsidence: true
 
 time_stepping:
   time_step: ${ATM_TIME_STEP}


### PR DESCRIPTION
Port `apply_iop_forcing()` (partially) which is the main function called by dynamics post process. This function is ported fully for the current test case (still need to port `iop_domain_relaxation()` for other cases).

**Other changes:**
- Consolidate `Pack` typedefs in Homme-AP interface
- Add parameter `iop_dosubsidence=true` for this case

**Testing:**
I ran F90 case and C++ unit test with hacked in input directly before `apply_iop_forcing()` and the output matches up to machine precision on CPU (serial and openmp) and GPU.

**Next PRs up:**
- Correctly load SPA data, add SPA back to test
- Add CIME case to lowres test suite
- Port `iop_domain_relaxation()` and add test cases which use that code