### PR TITLE
Add support for pm-cpu for test-all-scream, and fix pm-gpu env

### DIFF
--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -4,6 +4,8 @@ import os, sys, pathlib
 ensure_psutil()
 import psutil
 
+CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","cime")
+
 # MACHINE -> (env_setup,                      # list of shell commands to set up scream-approved env
 #             compilers,                      # list of compilers [CXX, F90, C]
 #             batch submit prefix,            # string shell commmand prefix
@@ -57,15 +59,19 @@ MACHINE_METADATA = {
                 ["mpicxx","mpifort","mpicc"],
                 "bsub -I -q batch -W 0:30 -P cli115 -nnodes 1",
                 "/gpfs/alpine/cli115/proj-shared/scream/master-baselines"),
-    "pm-gpu" : (["module load PrgEnv-gnu gcc/10.3.0 cudatoolkit craype-accel-nvidia80 cray-libsci craype cray-mpich cray-hdf5-parallel cray-netcdf-hdf5parallel cray-parallel-netcdf cmake evp-patch","module unload craype-accel-host perftools-base perftools darshan", "export NVCC_WRAPPER_DEFAULT_COMPILER=CC", "export NVCC_WRAPPER_DEFAULT_ARCH=sm_80"],
+    "pm-cpu" : ([f"eval $({CIMEROOT}/CIME/Tools/get_case_env -c SMS.ne4pg2_ne4pg2.F2010-SCREAMv1.pm-cpu_gnu)"],
+                ["CC","ftn","cc"],
+                "srun --time 00:30:00 --nodes=1 --constraint=cpu -q regular --account e3sm_g",
+                "/global/cfs/cdirs/e3sm/baselines/gnu/scream/pm-cpu"),
+    "pm-gpu" : ([f"eval $({CIMEROOT}/CIME/Tools/get_case_env -c SMS.ne4pg2_ne4pg2.F2010-SCREAMv1.pm-gpu_gnugpu)"],
                 ["CC","ftn","cc"],
                 "srun --time 00:30:00 --nodes=1 --constraint=gpu --exclusive -q regular --account e3sm_g",
-                ""),
+                "/global/cfs/cdirs/e3sm/baselines/gnugpu/scream/pm-gpu"),
     "compy"   : (["module purge", "module load cmake/3.19.6 gcc/8.1.0  mvapich2/2.3.1 python/3.7.3"],
                  ["mpicxx","mpifort","mpicc"],
                   "srun --time 02:00:00 --nodes=1 -p short --exclusive --account e3sm",
                   ""),
-    "chrysalis" : (["eval $(../../cime/CIME/Tools/get_case_env)", "export OMP_NUM_THREADS=1"],
+    "chrysalis" : ([f"eval $({CIMEROOT}/CIME/Tools/get_case_env)", "export OMP_NUM_THREADS=1"],
                   ["mpic++","mpif90","mpicc"],
                   "srun --mpi=pmi2 -l -N 1 --kill-on-bad-exit --cpu_bind=cores",
                   "/lcrc/group/e3sm/baselines/chrys/intel/scream"),

--- a/components/eamxx/src/diagnostics/tests/field_at_height_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_height_tests.cpp
@@ -178,7 +178,7 @@ TEST_CASE("field_at_height")
   print(" -> Testing throws error with unsupported reference height... OK\n");
 
   // Run many times
-  int z_tgt,lev_tgt;
+  int z_tgt;
   std::string loc;
   for (std::string surf_ref : {"sealevel","surface"}) {
     printf(" -> Testing for a reference height above %s...\n",surf_ref.c_str());

--- a/components/eamxx/src/diagnostics/tests/vapor_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/vapor_flux_tests.cpp
@@ -83,7 +83,7 @@ void run(std::mt19937_64& engine)
   REQUIRE_THROWS (diag_factory.create("VaporFlux",comm,params)); // No 'Wind Component'
   params.set<std::string>("Wind Component","foo");
   REQUIRE_THROWS (diag_factory.create("VaporFlux",comm,params)); // Invalid 'Wind Component'
-  for (const std::string& which_comp : {"Zonal", "Meridional"}) {
+  for (const std::string which_comp : {"Zonal", "Meridional"}) {
     // Construct the Diagnostic
     params.set<std::string>("Wind Component",which_comp);
     auto diag = diag_factory.create("VaporFlux",comm,params);

--- a/components/eamxx/src/share/io/tests/io_remap_test.cpp
+++ b/components/eamxx/src/share/io/tests/io_remap_test.cpp
@@ -640,7 +640,7 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
   auto f_Vi = fm->get_field(fid_Vi);
 
   // Set some string to be written to file as attribute to the variables
-  for (const std::string& fname : {"Y_flat","Y_mid","Y_int","V_mid","V_int"}) {
+  for (const std::string fname : {"Y_flat","Y_mid","Y_int","V_mid","V_int"}) {
     auto& f = fm->get_field(fname);
     auto& str_atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");
     str_atts["test"] = fname;

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -118,7 +118,7 @@ TEST_CASE("output_restart","io")
     }
   };
   // Run test for different avg type choices
-  for (const std::string& avg_type : {"INSTANT","AVERAGE"}) {
+  for (const std::string avg_type : {"INSTANT","AVERAGE"}) {
     {
       // In normal runs, the OM for the model restart takes care of nuking rpointer.atm,
       // and re-creating a new one. Here, we don't have that, so we must nuke it manually


### PR DESCRIPTION
pm-cpu was not supported, and pm-gpu gave some errors due to bad modules being loaded. I switched machine_specs.py to simply use CIME to get the correct env, which ensures we build standalone in the same way we'd build a v1 case.

@jgfouca perhaps we should make this the default: if a machine is supported by CIME, its line in machine_specs.py for the env setup should simply be `$(../../cime/CIME/Tools/get_case_env)`, possibly passing `-c SMS.ne4pg2_ne4pg2.F2010-SCREAMv1.$mach_$compiler` if we need to select non-default stuff.

I also went ahead and created master's baseline folders on pm, for both pm-cpu and pm-gpu.

On a separate note: on PM I'm getting (rightfully so) some warnings, I'll go ahead and fix them to avoid surprises somewhere else.