### PR TITLE
Add 2d Sliced output to the default output yaml file.

### DIFF
--- a/components/eamxx/data/scream_default_output.yaml
+++ b/components/eamxx/data/scream_default_output.yaml
@@ -61,6 +61,10 @@ Fields:
       - surf_sens_flux
       # Diagnostics
       - PotentialTemperature
+      # 2D Sliced Ouput
+      - T_mid_at_100m_above_surface
+      - T_mid_at_500hPa
+      - T_mid_at_100m_above_sealevel
   # GLL output for homme states.
   Dynamics:
     Field Names:


### PR DESCRIPTION
This will make sure that 2d sliced output is represented in our nightly testing.