### PR TITLE
Increase length of performance test to 300 steps

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -606,7 +606,7 @@ _TESTS = {
     "e3sm_scream_v1_hires" : {
         "time"  : "01:00:00",
         "tests" : (
-            "SMS_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1.scream-perf_test"
+            "SMS_Ln300.ne30pg2_ne30pg2.F2010-SCREAMv1.scream-perf_test"
             )
     },
 


### PR DESCRIPTION
We need to run long enough to get at least 4 memory usage dumps, otherwise the perf comparison stuff in CIME won't work.