### PR TITLE
Fix issue in FieldLayout related to shallow copies

### DIFF
--- a/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
+++ b/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
@@ -295,8 +295,7 @@ TEST_CASE("nudging_tests") {
       int ncols = fid.get_layout().dim(0);
       comm.all_reduce(&ncols,1,MPI_SUM);
 
-      FieldLayout glb_layout = fid.get_layout();
-      glb_layout.set_dimension(0,ncols);
+      FieldLayout glb_layout = fid.get_layout().clone_with_different_extent(0,ncols);
       FieldIdentifier glb_fid(fid.name(),glb_layout,fid.get_units(),fid.get_grid_name());
       Field glb(glb_fid);
       glb.allocate_view();

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -17,6 +17,28 @@ FieldLayout::FieldLayout (const std::vector<FieldTag>& tags,
   }
 }
 
+FieldLayout::
+FieldLayout (const FieldLayout& src)
+ : FieldLayout(src.tags(),src.dims())
+{
+  // Nothing to do here
+}
+
+FieldLayout& FieldLayout::
+operator= (const FieldLayout& src)
+{
+  m_tags = src.m_tags;
+  m_rank = src.m_rank;
+
+  m_dims.resize(m_rank,-1);
+  m_extents = decltype(m_extents)("",m_rank);
+  for (int idim=0; idim<m_rank; ++idim) {
+    set_dimension(idim,src.m_dims[idim]);
+  }
+
+  return *this;
+}
+
 bool FieldLayout::is_vector_layout () const {
   const auto lt = get_layout_type (m_tags);
   return lt==LayoutType::Vector2D || lt==LayoutType::Vector3D;

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -110,7 +110,7 @@ FieldLayout FieldLayout::clone_with_different_extent (const int idim, const int 
   FieldLayout copy(m_tags,m_dims);
   copy.set_dimension(idim,extent);
 
-  return *this;
+  return copy;
 }
 
 void FieldLayout::set_dimension (const int idim, const int dimension) {

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -17,28 +17,6 @@ FieldLayout::FieldLayout (const std::vector<FieldTag>& tags,
   }
 }
 
-FieldLayout::
-FieldLayout (const FieldLayout& src)
- : FieldLayout(src.tags(),src.dims())
-{
-  // Nothing to do here
-}
-
-FieldLayout& FieldLayout::
-operator= (const FieldLayout& src)
-{
-  m_tags = src.m_tags;
-  m_rank = src.m_rank;
-
-  m_dims.resize(m_rank,-1);
-  m_extents = decltype(m_extents)("",m_rank);
-  for (int idim=0; idim<m_rank; ++idim) {
-    set_dimension(idim,src.m_dims[idim]);
-  }
-
-  return *this;
-}
-
 bool FieldLayout::is_vector_layout () const {
   const auto lt = get_layout_type (m_tags);
   return lt==LayoutType::Vector2D || lt==LayoutType::Vector3D;
@@ -125,6 +103,14 @@ FieldLayout FieldLayout::strip_dim (const int idim) const {
   t.erase(t.begin()+idim);
   d.erase(d.begin()+idim);
   return FieldLayout (t,d);
+}
+
+FieldLayout FieldLayout::clone_with_different_extent (const int idim, const int extent) const
+{
+  FieldLayout copy(m_tags,m_dims);
+  copy.set_dimension(idim,extent);
+
+  return *this;
 }
 
 void FieldLayout::set_dimension (const int idim, const int dimension) {

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -54,6 +54,11 @@ inline std::string e2str (const LayoutType lt) {
  *  Note: the content of extents() is the same as the content of dims().
  *        The difference is that the former returns a device view, while
  *        the latter returns a std::vector.
+ *  Note: we used to have copy ctor and op= defaulted. However, with
+ *        extents being a view, that is dangerous. What we really want
+ *        is a deep copy. We're not interested in sharing data with
+ *        other instances, since a) it's a small amount of data and
+ *        b) we usually don't modify layout dims after creation
  */
 
 class FieldLayout {
@@ -62,12 +67,12 @@ public:
 
   // Constructor(s)
   FieldLayout () = delete;
-  FieldLayout (const FieldLayout&) = default;
+  FieldLayout (const FieldLayout&);
   FieldLayout (const std::vector<FieldTag>& tags,
                const std::vector<int>& dims);
 
   // Assignment (defaulted)
-  FieldLayout& operator= (const FieldLayout&) = default;
+  FieldLayout& operator= (const FieldLayout&);
 
   // Create invalid layout
   static FieldLayout invalid () { return FieldLayout({FieldTag::Invalid},{0}); }

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -54,11 +54,6 @@ inline std::string e2str (const LayoutType lt) {
  *  Note: the content of extents() is the same as the content of dims().
  *        The difference is that the former returns a device view, while
  *        the latter returns a std::vector.
- *  Note: we used to have copy ctor and op= defaulted. However, with
- *        extents being a view, that is dangerous. What we really want
- *        is a deep copy. We're not interested in sharing data with
- *        other instances, since a) it's a small amount of data and
- *        b) we usually don't modify layout dims after creation
  */
 
 class FieldLayout {
@@ -67,12 +62,12 @@ public:
 
   // Constructor(s)
   FieldLayout () = delete;
-  FieldLayout (const FieldLayout&);
+  FieldLayout (const FieldLayout&) = default;
   FieldLayout (const std::vector<FieldTag>& tags,
                const std::vector<int>& dims);
 
   // Assignment (defaulted)
-  FieldLayout& operator= (const FieldLayout&);
+  FieldLayout& operator= (const FieldLayout&) = default;
 
   // Create invalid layout
   static FieldLayout invalid () { return FieldLayout({FieldTag::Invalid},{0}); }
@@ -114,12 +109,13 @@ public:
   // Returns a copy of this layout with a given dimension stripped
   FieldLayout strip_dim (const FieldTag tag) const;
   FieldLayout strip_dim (const int idim) const;
-
-  // ----- Setters ----- //
-
-  void set_dimension  (const int idim, const int dimension);
+  FieldLayout clone_with_different_extent (const int idim, const int extent) const;
 
 protected:
+
+  // Only this class is allowed to change a layout. Customers can request
+  // a *slightly* different layout (via strip_dim or clone_with_different_extent)
+  void set_dimension  (const int idim, const int dimension);
 
   int                   m_rank;
   std::vector<FieldTag> m_tags;

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -214,8 +214,7 @@ void HorizInterpRemapperBase::create_ov_fields ()
   for (int i=0; i<m_num_fields; ++i) {
     const auto& f = m_type==InterpType::Refine ? m_tgt_fields[i] : m_src_fields[i];
     const auto& fid = f.get_header().get_identifier();
-    auto layout = fid.get_layout();
-    layout.set_dimension(0,num_ov_gids);
+    const auto layout = fid.get_layout().clone_with_different_extent(0,num_ov_gids);
     FieldIdentifier ov_fid (fid.name(),layout,fid.get_units(),ov_gn,dt);
 
     auto& ov_f = m_ov_fields.emplace_back(ov_fid);


### PR DESCRIPTION
With shallow copies, changing extents on the copy would change them also in the original. In particular, this code in `HorizInterpRemapperBase` was causing some problem:
```
    const auto& fid = f.get_header().get_identifier();
    auto layout = fid.get_layout();
    layout.set_dimension(0,num_ov_gids);
    FieldIdentifier ov_fid (fid.name(),layout,fid.get_units(),ov_gn,dt);
```
In this snippet, the goal was to create a copy of the input layout, with a different extent along the `ncol` dimension. However, `set_dimension` also updates the extents. If the copy constructor (or `operator=`) is defaulted, the copy shares the same extents view as the original, which is _not_ what is intended.

This PR implements a copy constructor and an assignment operator, which ensure that the copy has an independent extents view from the source.