### PR TITLE
Aarondonahue/fix bug related to avg cnt tracking

### DIFF
--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -820,7 +820,11 @@ void AtmosphereOutput::register_views()
     if (m_track_avg_cnt) {
       // Now create and store a dev view to track the averaging count for this layout (if we are tracking)
       // We don't need to track average counts for files that are not tracking the time dim
-      set_avg_cnt_tracking(name,"",layout);
+      std::string suffix = "";
+      if (m_field_to_avg_cnt_suffix.count(name)>0) {
+        suffix = m_field_to_avg_cnt_suffix.at(name);
+      }
+      set_avg_cnt_tracking(name,suffix,layout);
     }
   }
 
@@ -1353,7 +1357,7 @@ AtmosphereOutput::create_diagnostic (const std::string& diag_field_name) {
     const auto diag_field = diag->get_diagnostic();
     const auto name       = diag_field.name();
     const auto layout     = diag_field.get_header().get_identifier().get_layout();
-    set_avg_cnt_tracking(name,diag_avg_cnt_name,layout);
+    m_field_to_avg_cnt_suffix.emplace(name,diag_avg_cnt_name);
   }
 
   return diag;

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -820,11 +820,7 @@ void AtmosphereOutput::register_views()
     if (m_track_avg_cnt) {
       // Now create and store a dev view to track the averaging count for this layout (if we are tracking)
       // We don't need to track average counts for files that are not tracking the time dim
-      std::string suffix = "";
-      if (m_field_to_avg_cnt_suffix.count(name)>0) {
-        suffix = m_field_to_avg_cnt_suffix.at(name);
-      }
-      set_avg_cnt_tracking(name,suffix,layout);
+      set_avg_cnt_tracking(name,layout);
     }
   }
 
@@ -832,7 +828,7 @@ void AtmosphereOutput::register_views()
   reset_dev_views();
 }
 /* ---------------------------------------------------------- */
-void AtmosphereOutput::set_avg_cnt_tracking(const std::string& name, const std::string& avg_cnt_suffix, const FieldLayout& layout)
+void AtmosphereOutput::set_avg_cnt_tracking(const std::string& name, const FieldLayout& layout)
 {
   // Make sure this field "name" hasn't already been registered with avg_cnt tracking.
   // Note, we check this because some diagnostics need to have their own tracking which
@@ -852,6 +848,7 @@ void AtmosphereOutput::set_avg_cnt_tracking(const std::string& name, const std::
 
   // Now create and store a dev view to track the averaging count for this layout (if we are tracking)
   // We don't need to track average counts for files that are not tracking the time dim
+  const auto& avg_cnt_suffix = m_field_to_avg_cnt_suffix[name];
   const auto size = layout.size();
   const auto tags = layout.tags();
   if (m_track_avg_cnt) {

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -175,7 +175,7 @@ protected:
   create_diagnostic (const std::string& diag_name);
 
   // Tracking the averaging of any filled values:
-  void set_avg_cnt_tracking(const std::string& name, const std::string& avg_cnt_suffix, const FieldLayout& layout);
+  void set_avg_cnt_tracking(const std::string& name, const FieldLayout& layout);
 
   // --- Internal variables --- //
   ekat::Comm                          m_comm;

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -198,6 +198,7 @@ protected:
   std::vector<std::string>                              m_fields_names;
   std::vector<std::string>                              m_avg_cnt_names;
   std::map<std::string,std::string>                     m_field_to_avg_cnt_map;
+  std::map<std::string,std::string>                     m_field_to_avg_cnt_suffix;
   std::map<std::string,FieldLayout>                     m_layouts;
   std::map<std::string,std::pair<int,bool>>             m_dims;
   std::map<std::string,std::shared_ptr<atm_diag_type>>  m_diagnostics;


### PR DESCRIPTION
Fixes a bug related to horizontal remapping of 2d sliced output.

There was a bug in how we handled 2D sliced output such that if a user requested a 2d slice at NNNhPa and also requested horizontal remapping the code would throw an FPE error.

We tracked the issue down to the layout assigned to the internal average count tracking field.  It was set to be on the simulation grid, which differs from the output grid when horizontal remapping is triggered.