### PR TITLE
Fix handling of cloud fraction for COSP

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -372,7 +372,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     </mac_aero_mic>
 
     <cosp inherit="atm_proc_base">
-      <cosp_subcolumns>10</cosp_subcolumns>
+      <cosp_subcolumns doc="Number of subcolumns to use for COSP simulators; cosp_subcolumns=1 implies no subcolumn sampling">10</cosp_subcolumns>
       <cosp_subcolumns hgrid="ne1024np4">1</cosp_subcolumns>  <!-- No subcolumn sampling at satellite pixel scales -->
       <cosp_subcolumns hgrid="ne512np4" >1</cosp_subcolumns>  <!-- No subcolumn sampling at satellite pixel scales -->
       <cosp_subcolumns hgrid="ne256np4" >1</cosp_subcolumns>  <!-- No subcolumn sampling at satellite pixel scales -->

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -354,7 +354,9 @@ be lost if SCREAM_HACK_XML is not enabled.
       >
         false
       </extra_clnsky_diag>
-      <do_subcol_sampling type="logical">true</do_subcol_sampling>
+      <do_subcol_sampling type="logical" doc="Flag to turn on/off subcolumn sampling of optical properties; if false treat cells as either completely clear or cloudy">
+          true
+      </do_subcol_sampling>
     </rrtmgp>
 
     <mac_aero_mic inherit="atm_proc_group">

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -373,6 +373,9 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <cosp inherit="atm_proc_base">
       <cosp_subcolumns>10</cosp_subcolumns>
+      <cosp_subcolumns hgrid="ne1024np4">1</cosp_subcolumns>  <!-- No subcolumn sampling at satellite pixel scales -->
+      <cosp_subcolumns hgrid="ne512np4" >1</cosp_subcolumns>  <!-- No subcolumn sampling at satellite pixel scales -->
+      <cosp_subcolumns hgrid="ne256np4" >1</cosp_subcolumns>  <!-- No subcolumn sampling at satellite pixel scales -->
       <!-- Frequency at which to call COSP; positive values interpreted as number of steps, negative as number of hours -->
       <cosp_frequency>1</cosp_frequency>
       <cosp_frequency_units valid_values="steps,hours">hours</cosp_frequency_units>

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -354,6 +354,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       >
         false
       </extra_clnsky_diag>
+      <do_subcol_sampling type="logical">true</do_subcol_sampling>
     </rrtmgp>
 
     <mac_aero_mic inherit="atm_proc_group">

--- a/components/eamxx/src/physics/cosp/cosp_c2f.F90
+++ b/components/eamxx/src/physics/cosp/cosp_c2f.F90
@@ -295,41 +295,27 @@ contains
     ! In-cloud values are assumed. If ncolumns = 1, then convert in-cloud values to gridbox
     if (ncolumns == 1) then
        tca(:npoints,:nlevels) = cldfrac(:npoints,:nlevels)
-       cca(:npoints,:nlevels) = 0
-       mr_lsliq(:npoints,:nlevels) = 0
-       mr_ccliq(:npoints,:nlevels) = 0
-       mr_lsice(:npoints,:nlevels) = 0
-       mr_ccice(:npoints,:nlevels) = 0
-       dtau_c(:npoints,:nlevels) = 0
        dtau_s(:npoints,:nlevels) = cldfrac(:npoints,:nlevels) * dtau067(:npoints,:nlevels)
-       dem_c (:npoints,:nlevels) = 0
        dem_s (:npoints,:nlevels) = 1._wp - exp(-cldfrac(:npoints,:nlevels) * dtau105(:npoints,:nlevels))
-       mr_lsrain(:npoints,:nlevels) = 0
-       mr_ccrain(:npoints,:nlevels) = 0
-       mr_lssnow(:npoints,:nlevels) = 0
-       mr_lssnow(:npoints,:nlevels) = 0
-       mr_ccsnow(:npoints,:nlevels) = 0
-       mr_lsgrpl(:npoints,:nlevels) = 0
-       reff = 0  ! FIXME
     else
        tca(:npoints,:nlevels) = cldfrac(:npoints,:nlevels)
-       cca(:npoints,:nlevels) = 0
-       mr_lsliq(:npoints,:nlevels) = 0
-       mr_ccliq(:npoints,:nlevels) = 0
-       mr_lsice(:npoints,:nlevels) = 0
-       mr_ccice(:npoints,:nlevels) = 0
-       dtau_c(:npoints,:nlevels) = 0
        dtau_s(:npoints,:nlevels) = dtau067(:npoints,:nlevels)
-       dem_c (:npoints,:nlevels) = 0
        dem_s (:npoints,:nlevels) = 1._wp - exp(-dtau105(:npoints,:nlevels))
-       mr_lsrain(:npoints,:nlevels) = 0
-       mr_ccrain(:npoints,:nlevels) = 0
-       mr_lssnow(:npoints,:nlevels) = 0
-       mr_lssnow(:npoints,:nlevels) = 0
-       mr_ccsnow(:npoints,:nlevels) = 0
-       mr_lsgrpl(:npoints,:nlevels) = 0
-       reff = 0  ! FIXME
     end if
+    ! Fields not currently being used (will need to be revisted when turning on additional simulators)
+    cca(:npoints,:nlevels) = 0        ! Cloud fraction of convective clouds; not present or used in our model
+    dtau_c(:npoints,:nlevels) = 0     ! Optical depth of convective clouds; not present or used in our model
+    dem_c (:npoints,:nlevels) = 0     ! Emissivity of convective clouds; not present or used in our model
+    mr_lsliq(:npoints,:nlevels) = 0   ! Mixing ratio of cloud liquid; will be needed for radar/lidar
+    mr_ccliq(:npoints,:nlevels) = 0   ! Mixing ratio of cloud liquid for convective clouds; not present or used in our model
+    mr_lsice(:npoints,:nlevels) = 0   ! Mixing ratio of cloud ice; will be needed for radar/lidar
+    mr_ccice(:npoints,:nlevels) = 0   ! Mixing ratio of cloud ice for convective clouds; not present or used in our model
+    mr_lsrain(:npoints,:nlevels) = 0  ! Mixing ratio of rain; will be needed for radar/lidar
+    mr_ccrain(:npoints,:nlevels) = 0  ! Mixing ratio of rain for convective clouds; not present or used in our model 
+    mr_lssnow(:npoints,:nlevels) = 0  ! Mixing ratio of snow; will be needed for radar/lidar
+    mr_ccsnow(:npoints,:nlevels) = 0  ! Mixing ratio of snow for convective clouds; will be needed for radar/lidar
+    mr_lsgrpl(:npoints,:nlevels) = 0  ! Mixing ratio of graupel; will be needed for radar/lidar
+    reff = 0                          ! Effective radii; will be needed for MODIS
 
     start_idx = 1
     end_idx = npoints

--- a/components/eamxx/src/physics/cosp/cosp_c2f.F90
+++ b/components/eamxx/src/physics/cosp/cosp_c2f.F90
@@ -292,39 +292,43 @@ contains
  
     nptsperit = npoints
 
-    tca(:npoints,:nlevels) = cldfrac(:npoints,:nlevels)
-    cca(:npoints,:nlevels) = 0
-    mr_lsliq(:npoints,:nlevels) = 0
-    mr_ccliq(:npoints,:nlevels) = 0
-    mr_lsice(:npoints,:nlevels) = 0
-    mr_ccice(:npoints,:nlevels) = 0
-    dtau_c(:npoints,:nlevels) = 0
-    dtau_s(:npoints,:nlevels) = dtau067(:npoints,:nlevels)
-    dem_c (:npoints,:nlevels) = 0
-    dem_s (:npoints,:nlevels) = 1._wp - exp(-dtau105(:npoints,:nlevels))
-    mr_lsrain(:npoints,:nlevels) = 0
-    mr_ccrain(:npoints,:nlevels) = 0
-    mr_lssnow(:npoints,:nlevels) = 0
-    mr_lssnow(:npoints,:nlevels) = 0
-    mr_ccsnow(:npoints,:nlevels) = 0
-    mr_lsgrpl(:npoints,:nlevels) = 0
-    reff = 0  ! FIXME
-
     ! In-cloud values are assumed. If ncolumns = 1, then convert in-cloud values to gridbox
     if (ncolumns == 1) then
-       dtau_s = dtau_s * tca
-       dtau_c = dtau_c * cca
-       dem_s = dem_s * tca
-       dem_c = dem_c * cca
-       mr_lsliq = mr_lsliq * tca
-       mr_ccliq = mr_ccliq * cca
-       mr_lsice = mr_lsice * tca
-       mr_ccice = mr_ccice * cca
-       mr_lsrain = mr_lsrain * tca
-       mr_ccrain = mr_ccrain * cca
-       mr_lssnow = mr_lssnow * tca
-       mr_ccsnow = mr_ccsnow * cca
-       mr_lsgrpl = mr_lsgrpl * tca
+       tca(:npoints,:nlevels) = cldfrac(:npoints,:nlevels)
+       cca(:npoints,:nlevels) = 0
+       mr_lsliq(:npoints,:nlevels) = 0
+       mr_ccliq(:npoints,:nlevels) = 0
+       mr_lsice(:npoints,:nlevels) = 0
+       mr_ccice(:npoints,:nlevels) = 0
+       dtau_c(:npoints,:nlevels) = 0
+       dtau_s(:npoints,:nlevels) = cldfrac(:npoints,:nlevels) * dtau067(:npoints,:nlevels)
+       dem_c (:npoints,:nlevels) = 0
+       dem_s (:npoints,:nlevels) = 1._wp - exp(-cldfrac(:npoints,:nlevels) * dtau105(:npoints,:nlevels))
+       mr_lsrain(:npoints,:nlevels) = 0
+       mr_ccrain(:npoints,:nlevels) = 0
+       mr_lssnow(:npoints,:nlevels) = 0
+       mr_lssnow(:npoints,:nlevels) = 0
+       mr_ccsnow(:npoints,:nlevels) = 0
+       mr_lsgrpl(:npoints,:nlevels) = 0
+       reff = 0  ! FIXME
+    else
+       tca(:npoints,:nlevels) = cldfrac(:npoints,:nlevels)
+       cca(:npoints,:nlevels) = 0
+       mr_lsliq(:npoints,:nlevels) = 0
+       mr_ccliq(:npoints,:nlevels) = 0
+       mr_lsice(:npoints,:nlevels) = 0
+       mr_ccice(:npoints,:nlevels) = 0
+       dtau_c(:npoints,:nlevels) = 0
+       dtau_s(:npoints,:nlevels) = dtau067(:npoints,:nlevels)
+       dem_c (:npoints,:nlevels) = 0
+       dem_s (:npoints,:nlevels) = 1._wp - exp(-dtau105(:npoints,:nlevels))
+       mr_lsrain(:npoints,:nlevels) = 0
+       mr_ccrain(:npoints,:nlevels) = 0
+       mr_lssnow(:npoints,:nlevels) = 0
+       mr_lssnow(:npoints,:nlevels) = 0
+       mr_ccsnow(:npoints,:nlevels) = 0
+       mr_lsgrpl(:npoints,:nlevels) = 0
+       reff = 0  ! FIXME
     end if
 
     start_idx = 1

--- a/components/eamxx/src/physics/cosp/cosp_c2f.F90
+++ b/components/eamxx/src/physics/cosp/cosp_c2f.F90
@@ -310,6 +310,23 @@ contains
     mr_lsgrpl(:npoints,:nlevels) = 0
     reff = 0  ! FIXME
 
+    ! In-cloud values are assumed. If ncolumns = 1, then convert in-cloud values to gridbox
+    if (ncolumns == 1) then
+       dtau_s = dtau_s * tca
+       dtau_c = dtau_c * cca
+       dem_s = dem_s * tca
+       dem_c = dem_c * cca
+       mr_lsliq = mr_lsliq * tca
+       mr_ccliq = mr_ccliq * cca
+       mr_lsice = mr_lsice * tca
+       mr_ccice = mr_ccice * cca
+       mr_lsrain = mr_lsrain * tca
+       mr_ccrain = mr_ccrain * cca
+       mr_lssnow = mr_lssnow * tca
+       mr_ccsnow = mr_ccsnow * cca
+       mr_lsgrpl = mr_lsgrpl * tca
+    end if
+
     start_idx = 1
     end_idx = npoints
     ! Translate arrays to derived types

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -69,7 +69,7 @@ void Cosp::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>("qv",               scalar3d_layout_mid, Q,      grid_name, "tracers");
   add_field<Required>("qc",               scalar3d_layout_mid, Q,      grid_name, "tracers");
   add_field<Required>("qi",               scalar3d_layout_mid, Q,      grid_name, "tracers");
-  add_field<Required>("cldfrac_tot_for_analysis", scalar3d_layout_mid, nondim, grid_name);
+  add_field<Required>("cldfrac_tot",      scalar3d_layout_mid, nondim, grid_name);
   // Optical properties, should be computed in radiation interface
   add_field<Required>("dtau067",     scalar3d_layout_mid, nondim, grid_name); // 0.67 micron optical depth
   add_field<Required>("dtau105",     scalar3d_layout_mid, nondim, grid_name); // 10.5 micron optical depth
@@ -140,7 +140,7 @@ void Cosp::run_impl (const double dt)
   get_field_in("T_mid").sync_to_host();
   get_field_in("p_mid").sync_to_host();
   get_field_in("p_int").sync_to_host();
-  get_field_in("cldfrac_tot_for_analysis").sync_to_host();
+  get_field_in("cldfrac_tot").sync_to_host();
   get_field_in("eff_radius_qc").sync_to_host();
   get_field_in("eff_radius_qi").sync_to_host();
   get_field_in("dtau067").sync_to_host();
@@ -154,7 +154,7 @@ void Cosp::run_impl (const double dt)
   auto T_mid   = get_field_in("T_mid").get_view<const Real**, Host>();
   auto p_mid   = get_field_in("p_mid").get_view<const Real**, Host>();
   auto p_int   = get_field_in("p_int").get_view<const Real**, Host>();
-  auto cldfrac = get_field_in("cldfrac_tot_for_analysis").get_view<const Real**, Host>();
+  auto cldfrac = get_field_in("cldfrac_tot").get_view<const Real**, Host>();
   auto reff_qc = get_field_in("eff_radius_qc").get_view<const Real**, Host>();
   auto reff_qi = get_field_in("eff_radius_qi").get_view<const Real**, Host>();
   auto dtau067 = get_field_in("dtau067").get_view<const Real**, Host>();

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -69,7 +69,7 @@ void Cosp::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>("qv",               scalar3d_layout_mid, Q,      grid_name, "tracers");
   add_field<Required>("qc",               scalar3d_layout_mid, Q,      grid_name, "tracers");
   add_field<Required>("qi",               scalar3d_layout_mid, Q,      grid_name, "tracers");
-  add_field<Required>("cldfrac_tot",      scalar3d_layout_mid, nondim, grid_name);
+  add_field<Required>("cldfrac_rad",      scalar3d_layout_mid, nondim, grid_name);
   // Optical properties, should be computed in radiation interface
   add_field<Required>("dtau067",     scalar3d_layout_mid, nondim, grid_name); // 0.67 micron optical depth
   add_field<Required>("dtau105",     scalar3d_layout_mid, nondim, grid_name); // 10.5 micron optical depth
@@ -140,7 +140,7 @@ void Cosp::run_impl (const double dt)
   get_field_in("T_mid").sync_to_host();
   get_field_in("p_mid").sync_to_host();
   get_field_in("p_int").sync_to_host();
-  get_field_in("cldfrac_tot").sync_to_host();
+  get_field_in("cldfrac_rad").sync_to_host();
   get_field_in("eff_radius_qc").sync_to_host();
   get_field_in("eff_radius_qi").sync_to_host();
   get_field_in("dtau067").sync_to_host();
@@ -154,7 +154,7 @@ void Cosp::run_impl (const double dt)
   auto T_mid   = get_field_in("T_mid").get_view<const Real**, Host>();
   auto p_mid   = get_field_in("p_mid").get_view<const Real**, Host>();
   auto p_int   = get_field_in("p_int").get_view<const Real**, Host>();
-  auto cldfrac = get_field_in("cldfrac_tot").get_view<const Real**, Host>();
+  auto cldfrac = get_field_in("cldfrac_rad").get_view<const Real**, Host>();
   auto reff_qc = get_field_in("eff_radius_qc").get_view<const Real**, Host>();
   auto reff_qi = get_field_in("eff_radius_qi").get_view<const Real**, Host>();
   auto dtau067 = get_field_in("dtau067").get_view<const Real**, Host>();

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -159,6 +159,7 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Computed>("dtau067"       , scalar3d_layout_mid, nondim, grid_name);
   add_field<Computed>("dtau105"       , scalar3d_layout_mid, nondim, grid_name);
   add_field<Computed>("sunlit"        , scalar2d_layout    , nondim, grid_name);
+  add_field<Computed>("cldfrac_rad"   , scalar3d_layout_mid, nondim, grid_name);
   // Cloud-top diagnostics following AeroCOM recommendation
   add_field<Computed>("T_mid_at_cldtop", scalar2d_layout, K, grid_name);
   add_field<Computed>("p_mid_at_cldtop", scalar2d_layout, Pa, grid_name);
@@ -468,6 +469,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
   auto d_surf_lw_flux_up = get_field_in("surf_lw_flux_up").get_view<const Real*>();
   // Output fields
   auto d_tmid = get_field_out("T_mid").get_view<Real**>();
+  auto d_cldfrac_rad = get_field_out("cldfrac_rad").get_view<Real**>();
 
   // Aerosol optics only exist if m_do_aerosol_rad is true, so declare views and copy from FM if so
   using view_3d = Field::view_dev_t<const Real***>;
@@ -868,6 +870,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
             } else {
               cldfrac_tot(i+1,k+1) = 0;
             }
+            d_cldfrac_rad(icol,k) = cldfrac_tot(i+1,k+1);
           });
         });
       } else {
@@ -877,6 +880,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
           const int icol = i + beg;
           Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlay), [&] (const int& k) {
             cldfrac_tot(i+1,k+1) = d_cldfrac_tot(icol,k);
+            d_cldfrac_rad(icol,k) = d_cldfrac_tot(icol,k);
           });
         });
       }

--- a/components/eamxx/tests/uncoupled/cosp/input.yaml
+++ b/components/eamxx/tests/uncoupled/cosp/input.yaml
@@ -28,7 +28,7 @@ initial_conditions:
   topography_filename: ${TOPO_DATA_DIR}/USGS-gtopo30_ne4np4pg2_16x_converted.c20200527.nc
   dtau067: 1.0
   dtau105: 1.0
-  cldfrac_tot_for_analysis: 0.5
+  cldfrac_rad: 0.5
   eff_radius_qc: 0.0
   eff_radius_qi: 0.0
   sunlit: 1.0


### PR DESCRIPTION
Fix handling of cloud fraction for COSP. This makes two changes to how cloud fraction is treated in COSP. First, we switch to using the cloud fraction that is consistent with that used in radiation and the mask used in microphysics. Previously, we used the "analysis" cloud fraction (`cldfrac_tot_for_analysis`) to set the cloud fraction for subcolumn sampling in COSP for all configurations of EAMxx, in a misguided attempt to use a cloud fraction that is more consistent with observations. This was inconsistent with the cloud fraction used for subcolumn sampling in radiation, however, which uses a less stringent criteria for considering a cell to contain ice cloud. This also led to a gross underestimation/reporting of ISCCP-simulated cloud area at ne1024. Second, we disable subcolumn sampling in COSP by default for resolutions finer than ne256, which is on the order of the resolution of ISCCP satellite pixels. The point of the subcolumn sampling in COSP is to address the mis-match between model resolutions and satellite retrieval scales, accounting for vertical overlap of unresolved clouds. However, at resolutions finer than ne256 we approach the scale of satellite pixels, so performing pseudo-retrievals on gridbox-mean optical properties is more consistent with the satellite retrievals, and is less ambiguous. Making this change further improves the ISCCP-simulated cloud cover.

Note that these changes will be non-BFB only for ISCCP-simulated outputs (isccp_ctptau, isccp_cldtot).