### PR TITLE
Changes for running through CIME

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -583,6 +583,13 @@ _TESTS = {
             )
     },
 
+    "e3sm_scream_v1_dp-eamxx" : {
+        "time"  : "01:00:00",
+        "tests" : (
+            "ERS_Ln22.ne30_ne30.F2010-SCREAMv1-DP-DYCOMSrf01", # 225 phys cols, roughly size of ne2
+            )
+    },
+
     # Tests run on exclusively on mappy for scream AT testing. These tests
     # should be fast, so we limit it to low res and add some thread tests
     # specifically for mappy.

--- a/components/eamxx/cime_config/config_compsets.xml
+++ b/components/eamxx/cime_config/config_compsets.xml
@@ -74,12 +74,74 @@
       <lname>20TR_SCREAM_ELM%SPBC_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+      <alias>F2010-SCREAMv1-DP-DYCOMSrf01</alias> <!-- DP-EAMxx DYCOMSrf01 case -->
+      <lname>2010_SCREAM_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP%DP-EAMxx%DYCOMSrf01</lname>
+      <support_level>Experimental, under development</support_level>
+  </compset>
+
   <entries>
 
     <entry id="RUN_STARTDATE">
       <values>
         <value  compset=".*DYAMOND-1">2016-08-01</value>
         <value  compset=".*DYAMOND-2">2020-01-20</value>
+        <value  compset=".*DYCOMSrf01">1999-07-10</value>
+      </values>
+    </entry>
+
+    <!-- DP-EAMxx specific xml vars -->
+    <entry id="ATM_NCPL">
+      <values>
+        <value  compset=".*DYCOMSrf01">864</value>
+      </values>
+    </entry>
+
+    <entry id="PTS_MULTCOLS_MODE">
+      <values>
+        <value  compset=".*DYCOMSrf01">TRUE</value>
+      </values>
+    </entry>
+
+    <entry id="PTS_MODE">
+      <values>
+        <value  compset=".*DYCOMSrf01">TRUE</value>
+      </values>
+    </entry>
+
+    <entry id="PTS_LAT">
+      <values>
+        <value  compset=".*DYCOMSrf01">31.5</value>
+      </values>
+    </entry>
+
+    <entry id="PTS_LON">
+      <values>
+        <value  compset=".*DYCOMSrf01">238.5</value>
+      </values>
+    </entry>
+
+    <entry id="PTS_NX">
+      <values>
+        <value  compset=".*DYCOMSrf01">225</value>
+      </values>
+    </entry>
+
+    <entry id="PTS_NY">
+      <values>
+        <value  compset=".*DYCOMSrf01">1</value>
+      </values>
+    </entry>
+
+    <entry id="ICE_NX">
+      <values>
+        <value  compset=".*DYCOMSrf01">225</value>
+      </values>
+    </entry>
+
+    <entry id="ICE_NY">
+      <values>
+        <value  compset=".*DYCOMSrf01">1</value>
       </values>
     </entry>
 

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -48,7 +48,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <sections>ctl_nl</sections>
     </file>
     <file name="data/scream_input.yaml" format="yaml">
-      <sections>driver_options,intensive_observation_period_options,atmosphere_processes,grids_manager,initial_conditions,Scorpio,e3sm_parameters</sections>
+      <sections>driver_options,iop_options,atmosphere_processes,grids_manager,initial_conditions,Scorpio,e3sm_parameters</sections>
     </file>
   </generated_files>
 
@@ -473,10 +473,12 @@ be lost if SCREAM_HACK_XML is not enabled.
     <o3_volume_mix_ratio hgrid="ne0np4_conus_x4v1_lowcon">0.0</o3_volume_mix_ratio>
 
     <!-- Information about perturbed fields-->
-    <perturbed_fields type="array(string)"/>
+    <perturbed_fields type="array(string)" doc="IC fields (with level dimension) to apply a random perturbation to based on the parameters below."/>
     <perturbed_fields type="array(string)" COMPSET=".*DP-EAMxx">T_mid</perturbed_fields>
-    <perturbation_limit type="real">0.001</perturbation_limit>
-    <perturbation_minimum_pressure type="real">900.0</perturbation_minimum_pressure>
+    <generate_perturbation_random_seed type="logical" doc="Whether or not to generate a random seed for perturbation.">false</generate_perturbation_random_seed>
+    <perturbation_random_seed type="integer" doc="Random seed used for perturbation. Will be overridded by generate_perturbation_random_seed=true.">0</perturbation_random_seed>
+    <perturbation_limit type="real" doc="Defines a range [1-x, 1+x] which perturbation will be taken from.">0.001</perturbation_limit>
+    <perturbation_minimum_pressure type="real" doc="Minimum pressure (relative to a reference level pressure profile) for which perturbation will be applied.">900.0</perturbation_minimum_pressure>
   </initial_conditions>
 
   <!-- List of yaml files containing I/O output specs -->
@@ -505,8 +507,8 @@ be lost if SCREAM_HACK_XML is not enabled.
     <column_conservation_checks_fail_handling_type>Warning</column_conservation_checks_fail_handling_type>
     <check_all_computed_fields_for_nans type="logical">true</check_all_computed_fields_for_nans >
     <property_check_data_fields type="array(string)" doc="list of additional data fields to output in property checks (only for physics grid)">phis,landfrac</property_check_data_fields>
-    <enable_intensive_observation_period type="logical" doc="Enable intensive observation period. Currently the only use case is DP-EAMxx">false</enable_intensive_observation_period>
-    <enable_intensive_observation_period COMPSET=".*DP-EAMxx">true</enable_intensive_observation_period>
+    <enable_iop type="logical" doc="Enable intensive observation period. Currently the only use case is DP-EAMxx">false</enable_iop>
+    <enable_iop COMPSET=".*DP-EAMxx">true</enable_iop>
   </driver_options>
 
   <!-- E3SM Simulation Settings -->
@@ -515,19 +517,19 @@ be lost if SCREAM_HACK_XML is not enabled.
   </e3sm_parameters>
 
   <!-- Settings for IOP -->
-  <intensive_observation_period_options>
-    <doubly_periodic_mode type="logical">true</doubly_periodic_mode>
-    <iop_file type="file">UNSET</iop_file>
+  <iop_options>
+    <doubly_periodic_mode type="logical" doc="Type of intensive observation period. Currently only DP is supported.">true</doubly_periodic_mode>
+    <iop_file type="file" doc="File containing DP level data">UNSET</iop_file>
     <iop_file COMPSET=".*DYCOMSrf01">${DIN_LOC_ROOT}/atm/cam/scam/iop/DYCOMSrf01_iopfile_4scam.nc</iop_file>
-    <target_latitude type="real">-999</target_latitude>
+    <target_latitude type="real" doc="Latitude to initialize IC columns.">-999</target_latitude>
     <target_latitude COMPSET=".*DYCOMSrf01">31.5</target_latitude>
-    <target_longitude type="real">-999</target_longitude>
+    <target_longitude type="real" doc="Longitude to initialize IC columns.">-999</target_longitude>
     <target_longitude COMPSET=".*DYCOMSrf01">238.5</target_longitude>
-    <iop_dosubsidence type="logical">false</iop_dosubsidence>
+    <iop_dosubsidence type="logical" doc="Whether or not to compute Eulerian LS vertical advection.">false</iop_dosubsidence>
     <iop_dosubsidence COMPSET=".*DYCOMSrf01">true</iop_dosubsidence>
-    <iop_srf_prop type="logical">false</iop_srf_prop>
+    <iop_srf_prop type="logical" doc="Use IOP file specified surface values in surface coupling importer.">false</iop_srf_prop>
     <iop_srf_prop COMPSET=".*DYCOMSrf01">true</iop_srf_prop>
-  </intensive_observation_period_options>
+  </iop_options>
 
   <!-- Homme control namelist -->
   <ctl_nl>

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -292,6 +292,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <spa_remap_file hgrid="ne256np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30pg2_to_ne256pg2_20231201.nc</spa_remap_file>
       <spa_remap_file hgrid="ne512np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30pg2_to_ne512pg2_20231201.nc</spa_remap_file>
       <spa_remap_file hgrid="ne1024np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30pg2_to_ne1024pg2_20231201.nc</spa_remap_file>
+      <spa_remap_file COMPSET=".*DP-EAMxx"/>
 
       <spa_data_file type="file" doc="File containing aerosol data. Must be on same grid as the atm, or a coarser one"/>
       <spa_data_file hgrid="ne.*np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30_20220428.nc</spa_data_file>
@@ -338,6 +339,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <rad_frequency hgrid="ne256np4">3</rad_frequency>
       <rad_frequency hgrid="ne512np4">3</rad_frequency>
       <rad_frequency hgrid="ne1024np4">3</rad_frequency>
+      <rad_frequency COMPSET=".*DYCOMSrf01">3</rad_frequency>
       <rad_frequency hgrid="ne0np4_conus_x4v1_lowcon">4</rad_frequency>
       <do_aerosol_rad type="logical" doc="Flag to turn on/off considering aerosols in radiation calculations">true</do_aerosol_rad>
       <do_aerosol_rad COMPSET=".*SCREAM.*noAero">false</do_aerosol_rad>
@@ -370,6 +372,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <number_of_subcycles hgrid="ne256np4">6</number_of_subcycles>
       <number_of_subcycles hgrid="ne512np4">2</number_of_subcycles>
       <number_of_subcycles hgrid="ne1024np4">1</number_of_subcycles>
+      <number_of_subcycles COMPSET=".*DP-EAMxx">1</number_of_subcycles>
       <number_of_subcycles hgrid="ne0np4_conus_x4v1_lowcon">5</number_of_subcycles>
     </mac_aero_mic>
 
@@ -471,6 +474,7 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <!-- Information about perturbed fields-->
     <perturbed_fields type="array(string)"/>
+    <perturbed_fields type="array(string)" COMPSET=".*DP-EAMxx">T_mid</perturbed_fields>
     <perturbation_limit type="real">0.001</perturbation_limit>
     <perturbation_minimum_pressure type="real">900.0</perturbation_minimum_pressure>
   </initial_conditions>
@@ -502,6 +506,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <check_all_computed_fields_for_nans type="logical">true</check_all_computed_fields_for_nans >
     <property_check_data_fields type="array(string)" doc="list of additional data fields to output in property checks (only for physics grid)">phis,landfrac</property_check_data_fields>
     <enable_intensive_observation_period type="logical" doc="Enable intensive observation period. Currently the only use case is DP-EAMxx">false</enable_intensive_observation_period>
+    <enable_intensive_observation_period COMPSET=".*DP-EAMxx">true</enable_intensive_observation_period>
   </driver_options>
 
   <!-- E3SM Simulation Settings -->
@@ -509,20 +514,28 @@ be lost if SCREAM_HACK_XML is not enabled.
     <e3sm_casename>${CASE}</e3sm_casename>
   </e3sm_parameters>
 
+  <!-- Settings for IOP -->
   <intensive_observation_period_options>
     <doubly_periodic_mode type="logical">true</doubly_periodic_mode>
     <iop_file type="file">UNSET</iop_file>
+    <iop_file COMPSET=".*DYCOMSrf01">${DIN_LOC_ROOT}/atm/cam/scam/iop/DYCOMSrf01_iopfile_4scam.nc</iop_file>
     <target_latitude type="real">-999</target_latitude>
+    <target_latitude COMPSET=".*DYCOMSrf01">31.5</target_latitude>
     <target_longitude type="real">-999</target_longitude>
+    <target_longitude COMPSET=".*DYCOMSrf01">238.5</target_longitude>
     <iop_dosubsidence type="logical">false</iop_dosubsidence>
+    <iop_dosubsidence COMPSET=".*DYCOMSrf01">true</iop_dosubsidence>
     <iop_srf_prop type="logical">false</iop_srf_prop>
+    <iop_srf_prop COMPSET=".*DYCOMSrf01">true</iop_srf_prop>
   </intensive_observation_period_options>
 
   <!-- Homme control namelist -->
   <ctl_nl>
     <cubed_sphere_map>0</cubed_sphere_map>
+    <cubed_sphere_map COMPSET=".*DYCOMSrf01">2</cubed_sphere_map>
     <disable_diagnostics>False</disable_diagnostics>
     <dt_remap_factor constraints="ge 1">2</dt_remap_factor>
+    <dt_remap_factor COMPSET=".*DYCOMSrf01" constraints="ge 1">1</dt_remap_factor>
     <dt_tracer_factor constraints="ge 1">1</dt_tracer_factor>
     <hv_ref_profiles>6</hv_ref_profiles>                <!-- Default (rough topography) -->
     <hv_ref_profiles hgrid="ne4np4">0</hv_ref_profiles> <!-- Value for smooth topography/aquaplanet -->
@@ -536,6 +549,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <hypervis_subcycle_tom>1</hypervis_subcycle_tom>
     <hypervis_subcycle_q>1</hypervis_subcycle_q>
     <nu>3.4e-08</nu>
+    <nu COMPSET=".*DYCOMSrf01">0.216784</nu>
     <nu_top>UNSET</nu_top>
     <nu_top hgrid="ne4np4">250000.0</nu_top>
     <nu_top hgrid="ne30np4">250000.0</nu_top>
@@ -543,6 +557,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <nu_top hgrid="ne256np4">4.0e4</nu_top>
     <nu_top hgrid="ne512np4">2.0e4</nu_top>
     <nu_top hgrid="ne1024np4">1.0e4</nu_top>
+    <nu_top COMPSET=".*DP-EAMxx">1.0e4</nu_top>
     <nu_top hgrid="ne0np4_conus_x4v1_lowcon">100000.0</nu_top>
     <pgrad_correction>1</pgrad_correction>                <!-- Default (rough topography) -->
     <pgrad_correction hgrid="ne4np4">0</pgrad_correction> <!-- Value for smooth topography/aquaplanet -->
@@ -552,6 +567,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <pgrad_correction COMPSET=".*SCREAM%AQUA.*">0</pgrad_correction>
     <se_ftype valid_values="0,2">0</se_ftype>
     <se_geometry>sphere</se_geometry>
+    <se_geometry COMPSET=".*DP-EAMxx">plane</se_geometry>
     <se_limiter_option>9</se_limiter_option>
     <se_ne>UNSET</se_ne>
     <se_ne hgrid="ne4np4" constraints="ge 2">4</se_ne>
@@ -560,14 +576,20 @@ be lost if SCREAM_HACK_XML is not enabled.
     <se_ne hgrid="ne256np4" constraints="ge 2">256</se_ne>
     <se_ne hgrid="ne512np4" constraints="ge 2">512</se_ne>
     <se_ne hgrid="ne1024np4" constraints="ge 2">1024</se_ne>
+    <se_ne COMPSET=".*DP-EAMxx">1024</se_ne>
     <se_ne hgrid="ne0np4_conus_x4v1_lowcon">0</se_ne>
     <se_ne_x>0</se_ne_x>
+    <se_ne_x COMPSET=".*DYCOMSrf01">5</se_ne_x>
     <se_ne_y>0</se_ne_y>
+    <se_ne_y COMPSET=".*DYCOMSrf01">5</se_ne_y>
     <se_lx>0</se_lx>
+    <se_lx COMPSET=".*DYCOMSrf01">50000</se_lx>
     <se_ly>0</se_ly>
+    <se_ly COMPSET=".*DYCOMSrf01">50000</se_ly>
     <se_nsplit>-1</se_nsplit>
     <se_partmethod>4</se_partmethod>
     <se_topology>cube</se_topology>
+    <se_topology COMPSET=".*DP-EAMxx">plane</se_topology>
     <se_tstep type="real">UNSET</se_tstep>
     <se_tstep hgrid="ne4np4" constraints="gt 0">600</se_tstep>
     <se_tstep hgrid="ne30np4" constraints="gt 0">300</se_tstep>
@@ -575,6 +597,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <se_tstep hgrid="ne256np4" constraints="gt 0">33.33333333333</se_tstep>
     <se_tstep hgrid="ne512np4" constraints="gt 0">16.6666666666666</se_tstep>
     <se_tstep hgrid="ne1024np4" constraints="gt 0">8.3333333333333</se_tstep>
+    <se_tstep COMPSET=".*DP-EAMxx" constraints="gt 0">8.3333333333333</se_tstep>
     <se_tstep hgrid="ne0np4_conus_x4v1_lowcon" constraints="gt 0">75</se_tstep>
     <statefreq>9999</statefreq>
     <theta_advect_form>1</theta_advect_form>

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -48,7 +48,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <sections>ctl_nl</sections>
     </file>
     <file name="data/scream_input.yaml" format="yaml">
-      <sections>driver_options,atmosphere_processes,grids_manager,initial_conditions,Scorpio,e3sm_parameters</sections>
+      <sections>driver_options,intensive_observation_period_options,atmosphere_processes,grids_manager,initial_conditions,Scorpio,e3sm_parameters</sections>
     </file>
   </generated_files>
 
@@ -245,12 +245,12 @@ be lost if SCREAM_HACK_XML is not enabled.
       <use_nudging_weights type="logical" doc="Flag for nudging weights option">false</use_nudging_weights>
       <nudging_weights_file type="string" doc="weights that relax the nudging fields update"/>
       <skip_vert_interpolation type="logical" doc="Flag for skipping vertical interpolation">false</skip_vert_interpolation>
-      <source_pressure_type type="string" 
+      <source_pressure_type type="string"
 	                    valid_values="TIME_DEPENDENT_3D_PROFILE,STATIC_1D_VERTICAL_PROFILE"
 			    doc="Flag for how source pressure levels are handled in the nudging dataset.
     TIME_DEPENDENT_3D_PROFILE: The dataset contains a time-varying pressure profile, variable name 'p_mid' with dimensions (time,ncol,nlev).
     STATIC_1D_VERTICAL_PROFILE: The dataset uses a fixed in time single pressure profile, variable name 'p_lev' with dimension (nlev).">TIME_DEPENDENT_3D_PROFILE</source_pressure_type>
-      <source_pressure_file type="string" doc="If STATIC_1D_VERTICAL_PROFILE, this is an optional arg to point to a file with the source pressure levels defined.  
+      <source_pressure_file type="string" doc="If STATIC_1D_VERTICAL_PROFILE, this is an optional arg to point to a file with the source pressure levels defined.
     Default is to look for p_levs in the first nudging_filenames_patterns file"/>
       <nudging_refine_remap_mapfile
         type="string"
@@ -468,6 +468,11 @@ be lost if SCREAM_HACK_XML is not enabled.
     <nc hgrid="ne256np4|ne1024np4">0.0</nc>
     <ni hgrid="ne256np4|ne1024np4">0.0</ni>
     <o3_volume_mix_ratio hgrid="ne0np4_conus_x4v1_lowcon">0.0</o3_volume_mix_ratio>
+
+    <!-- Information about perturbed fields-->
+    <perturbed_fields type="array(string)"/>
+    <perturbation_limit type="real">0.001</perturbation_limit>
+    <perturbation_minimum_pressure type="real">900.0</perturbation_minimum_pressure>
   </initial_conditions>
 
   <!-- List of yaml files containing I/O output specs -->
@@ -496,12 +501,22 @@ be lost if SCREAM_HACK_XML is not enabled.
     <column_conservation_checks_fail_handling_type>Warning</column_conservation_checks_fail_handling_type>
     <check_all_computed_fields_for_nans type="logical">true</check_all_computed_fields_for_nans >
     <property_check_data_fields type="array(string)" doc="list of additional data fields to output in property checks (only for physics grid)">phis,landfrac</property_check_data_fields>
+    <enable_intensive_observation_period type="logical" doc="Enable intensive observation period. Currently the only use case is DP-EAMxx">false</enable_intensive_observation_period>
   </driver_options>
 
   <!-- E3SM Simulation Settings -->
   <e3sm_parameters>
     <e3sm_casename>${CASE}</e3sm_casename>
   </e3sm_parameters>
+
+  <intensive_observation_period_options>
+    <doubly_periodic_mode type="logical">true</doubly_periodic_mode>
+    <iop_file type="file">UNSET</iop_file>
+    <target_latitude type="real">-999</target_latitude>
+    <target_longitude type="real">-999</target_longitude>
+    <iop_dosubsidence type="logical">false</iop_dosubsidence>
+    <iop_srf_prop type="logical">false</iop_srf_prop>
+  </intensive_observation_period_options>
 
   <!-- Homme control namelist -->
   <ctl_nl>
@@ -548,10 +563,12 @@ be lost if SCREAM_HACK_XML is not enabled.
     <se_ne hgrid="ne0np4_conus_x4v1_lowcon">0</se_ne>
     <se_ne_x>0</se_ne_x>
     <se_ne_y>0</se_ne_y>
+    <se_lx>0</se_lx>
+    <se_ly>0</se_ly>
     <se_nsplit>-1</se_nsplit>
     <se_partmethod>4</se_partmethod>
     <se_topology>cube</se_topology>
-    <se_tstep>UNSET</se_tstep>
+    <se_tstep type="real">UNSET</se_tstep>
     <se_tstep hgrid="ne4np4" constraints="gt 0">600</se_tstep>
     <se_tstep hgrid="ne30np4" constraints="gt 0">300</se_tstep>
     <se_tstep hgrid="ne120np4" constraints="gt 0">75</se_tstep>

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -167,29 +167,27 @@ init_time_stamps (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0)
 
 
 void AtmosphereDriver::
-setup_intensive_observation_period ()
+setup_iop ()
 {
   // At this point, must have comm, params, initialized timestamps created.
   check_ad_status(s_comm_set | s_params_set | s_ts_inited);
 
   // Check to make sure iop is not already initialized
-  EKAT_REQUIRE_MSG(not m_iop, "Error! setup_intensive_observation_period() is "
-                              "called, but IOP already set up.\n");
+  EKAT_REQUIRE_MSG(not m_iop, "Error! setup_iop() is called, but IOP already set up.\n");
 
   // This function should only be called if we are enabling IOP
   const bool enable_iop =
-    m_atm_params.sublist("driver_options").get("enable_intensive_observation_period", false);
-  EKAT_REQUIRE_MSG(enable_iop, "Error! setup_intensive_observation_period() is called, but "
-                               "enable_intensive_observation_period=false "
+    m_atm_params.sublist("driver_options").get("enable_iop", false);
+  EKAT_REQUIRE_MSG(enable_iop, "Error! setup_iop() is called, but enable_iop=false "
                                "in driver_options parameters.\n");
 
-  // Params must include intensive_observation_period_options sublist.
-  const auto iop_sublist_exists = m_atm_params.isSublist("intensive_observation_period_options");
+  // Params must include iop_options sublist.
+  const auto iop_sublist_exists = m_atm_params.isSublist("iop_options");
   EKAT_REQUIRE_MSG(iop_sublist_exists,
-                   "Error! setup_intensive_observation_period() is called, but no intensive_observation_period_options "
+                   "Error! setup_iop() is called, but no iop_options "
                    "defined in parameters.\n");
 
-  const auto iop_params = m_atm_params.sublist("intensive_observation_period_options");
+  const auto iop_params = m_atm_params.sublist("iop_options");
   const auto phys_grid = m_grids_manager->get_grid("Physics");
   const auto nlevs = phys_grid->get_num_vertical_levels();
   const auto hyam = phys_grid->get_geometry_data("hyam");
@@ -206,7 +204,7 @@ setup_intensive_observation_period ()
   m_iop->set_grid_spacing(dx_short_f.get_view<const Real,Host>()());
 
   // Set IOP object in atm processes
-  m_atm_process_group->set_intensive_observation_period(m_iop);
+  m_atm_process_group->set_iop(m_iop);
 }
 
 void AtmosphereDriver::create_atm_processes()
@@ -284,9 +282,9 @@ void AtmosphereDriver::create_grids()
   // IOP object needs the grids_manager to have been created, but is then needed in set_grids()
   // implementation of some processes, so setup here.
   const bool enable_iop =
-    m_atm_params.sublist("driver_options").get("enable_intensive_observation_period", false);
+    m_atm_params.sublist("driver_options").get("enable_iop", false);
   if (enable_iop) {
-    setup_intensive_observation_period ();
+    setup_iop ();
   }
 
   // Set the grids in the processes. Do this by passing the grids manager.

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -72,7 +72,7 @@ public:
   void init_scorpio (const int atm_id = 0);
 
   // Setup IntensiveObservationPeriod
-  void setup_intensive_observation_period ();
+  void setup_iop ();
 
   // Create atm processes, without initializing them
   void create_atm_processes ();

--- a/components/eamxx/src/control/intensive_observation_period.cpp
+++ b/components/eamxx/src/control/intensive_observation_period.cpp
@@ -116,7 +116,7 @@ IntensiveObservationPeriod(const ekat::Comm& comm,
   EKAT_REQUIRE_MSG(m_params.isParameter("target_latitude") && m_params.isParameter("target_longitude"),
                    "Error! Using intensive observation period files requires "
                    "target_latitude and target_longitude be gives as parameters in "
-                   "\"intensive_observation_period_options\" in the input yaml file.\n");
+                   "\"iop_options\" in the input yaml file.\n");
   const auto target_lat = m_params.get<Real>("target_latitude");
   const auto target_lon = m_params.get<Real>("target_longitude");
   EKAT_REQUIRE_MSG(-90 <= target_lat and target_lat <= 90,

--- a/components/eamxx/src/control/intensive_observation_period.hpp
+++ b/components/eamxx/src/control/intensive_observation_period.hpp
@@ -43,7 +43,7 @@ public:
   // Constructor
   // Input:
   //   - comm: MPI communicator
-  //   - params: Input yaml file needs intensive_observation_period_options sublist
+  //   - params: Input yaml file needs iop_options sublist
   //   - run_t0: Initial timestamp for the simulation
   //   - model_nlevs: Number of vertical levels in the simulation. Needed since
   //                  the iop file contains a (potentially) different number of levels

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_iop.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_iop.cpp
@@ -426,7 +426,6 @@ apply_iop_forcing(const Real dt)
 
         Qdp_i(q, ilev) = Q_i(q, ilev)*dp3d_i(ilev);
         // For BFB on restarts, Q needs to be updated after we compute Qdp
-        // TODO: Is this needed?
         Q_i(q, ilev) = Qdp_i(q, ilev)/dp3d_i(ilev);
       });
 

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -423,6 +423,11 @@ void HommeDynamics::initialize_impl (const RunType run_type)
   if (run_type==RunType::Initial) {
     initialize_homme_state ();
   } else {
+    if (m_iop) {
+      // We need to reload IOP data after restarting
+      m_iop->read_iop_file_data(timestamp());
+    }
+
     restart_homme_state ();
   }
 

--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -68,7 +68,7 @@ void SPA::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   // where a single column of data corresponding to the closest lat/lon pair to
   // the IOP lat/lon parameters is read from file, and that column data is mapped
   // to all columns of the IdentityRemapper source fields.
-  EKAT_REQUIRE_MSG(spa_map_file == "" or not m_iop,
+  EKAT_REQUIRE_MSG(spa_map_file == "" or spa_map_file == "None" or not m_iop,
     "Error! Cannot define spa_remap_file for cases with an Intensive Observation Period defined. "
     "The IOP class defines it's own remap from file data -> model data.\n");
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -281,7 +281,7 @@ public:
   void print_fast_global_state_hash(const std::string& label) const;
 
   // Set IOP object
-  virtual void set_intensive_observation_period(const iop_ptr& iop) {
+  virtual void set_iop(const iop_ptr& iop) {
     m_iop = iop;
   }
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
@@ -106,9 +106,9 @@ public:
   void add_additional_data_fields_to_property_checks (const Field& data_field);
 
   // Loop through all proceeses in group and set IOP object
-  void set_intensive_observation_period(const iop_ptr& iop) {
+  void set_iop(const iop_ptr& iop) {
     for (auto& atm_proc : m_atm_processes) {
-      atm_proc->set_intensive_observation_period(iop);
+      atm_proc->set_iop(iop);
     }
   }
 

--- a/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
+++ b/components/eamxx/tests/coupled/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_dp/input.yaml
@@ -2,9 +2,9 @@
 ---
 driver_options:
   atmosphere_dag_verbosity_level: 5
-  enable_intensive_observation_period: true
+  enable_iop: true
 
-intensive_observation_period_options:
+iop_options:
   doubly_periodic_mode: true
   iop_file: ${IOP_DATA_DIR}/DYCOMSrf01_iopfile_4scam.nc
   target_latitude: 31.5


### PR DESCRIPTION
Adds a compset `F2010-SCREAMv1-DP-DYCOMSrf01` and a test for Mappy AT (roughly the size of ne2 unit test). Have both `DP-EAMxx` and `DYCOMSrf01` in the compset name since some setting are general to DP-EAMxx, and some are case specific for DYCOMSrf01.

Other changes
- additions to namelist defaults
- Reload IOP data after restart
- SPA remap file to check "None" for IOP