### PR TITLE
Make nudging log which file it's reading

### DIFF
--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -233,6 +233,7 @@ void Nudging::initialize_impl (const RunType /* run_type */)
 
   // Initialize the time interpolator and horiz remapper
   m_time_interp = util::TimeInterpolation(grid_ext, m_datafiles);
+  m_time_interp.set_logger(m_atm_logger,"[EAMxx::Nudging] Reading nudging data");
 
   // NOTE: we are ASSUMING all fields are 3d and scalar!
   const auto layout_ext = grid_ext->get_3d_scalar_layout(true);

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -12,7 +12,7 @@ namespace scream
 
 AtmosphereInput::
 AtmosphereInput (const ekat::ParameterList& params,
-                const std::shared_ptr<const fm_type>& field_mgr)
+                 const std::shared_ptr<const fm_type>& field_mgr)
 {
   init(params,field_mgr);
 }
@@ -206,7 +206,12 @@ void AtmosphereInput::read_variables (const int time_index)
 {
   auto func_start = std::chrono::steady_clock::now();
   if (m_atm_logger) {
-    m_atm_logger->info("[EAMxx::scorpio_input] Reading variables from file:\n\t " + m_filename + " ...\n");
+    m_atm_logger->info("[EAMxx::scorpio_input] Reading variables from file");
+    m_atm_logger->info("  file name: " + m_filename);
+    m_atm_logger->info("  var names: " + ekat::join(m_fields_names,", "));
+    if (time_index!=-1) {
+      m_atm_logger->info("  time idx : " + std::to_string(time_index));
+    }
   }
   EKAT_REQUIRE_MSG (m_inited_with_views || m_inited_with_fields,
       "Error! Scorpio structures not inited yet. Did you forget to call 'init(..)'?\n");
@@ -323,7 +328,7 @@ void AtmosphereInput::read_variables (const int time_index)
   auto func_finish = std::chrono::steady_clock::now();
   if (m_atm_logger) {
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(func_finish - func_start)/1000.0;
-    m_atm_logger->info("[EAMxx::scorpio_input] Reading variables from file:\n\t " + m_filename + " ... done! (Elapsed time = " + std::to_string(duration.count()) +" seconds)\n");
+    m_atm_logger->info("  Done! Elapsed time: " + std::to_string(duration.count()) +" seconds");
   }
 } 
 

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -376,7 +376,8 @@ run (const std::string& filename,
   Real duration_write = 0.0;  // Record of time spent writing output
   if (is_write_step) {
     if (m_atm_logger) {
-      m_atm_logger->info("[EAMxx::scorpio_output] Writing variables to file:\n\t " + filename + " ...\n");
+      m_atm_logger->info("[EAMxx::scorpio_output] Writing variables to file");
+      m_atm_logger->info("  file name: " + filename);
     }
   }
 
@@ -634,7 +635,7 @@ run (const std::string& filename,
   }
   if (is_write_step) {
     if (m_atm_logger) {
-      m_atm_logger->info("[EAMxx::scorpio_output] Writing variables to file:\n\t " + filename + " ...done! (Elapsed time = " + std::to_string(duration_write/1000.0) +" seconds)\n");
+      m_atm_logger->info("  Done! Elapsed time: " + std::to_string(duration_write/1000.0) +" seconds");
     }
   }
 } // run

--- a/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
@@ -161,6 +161,7 @@ void TimeInterpolation::initialize_data_from_files()
   input_params.set("Field Names",m_field_names);
   input_params.set("Filename",triplet_curr.filename);
   m_file_data_atm_input = AtmosphereInput(input_params,m_fm_time1);
+  m_file_data_atm_input.set_logger(m_logger);
   // Assign the mask value gathered from the FillValue found in the source file.
   // TODO: Should we make it possible to check if FillValue is in the metadata and only assign mask_value if it is?
   float var_fill_value;
@@ -327,6 +328,11 @@ void TimeInterpolation::read_data()
       auto& field = m_fm_time1->get_field(name);
       field.get_header().set_extra_data("mask_value",var_fill_value);
     }
+  }
+
+  if (m_logger) {
+    m_logger->info(m_header);
+    m_logger->info("[EAMxx:time_interpolation] Reading data at time " + triplet_curr.timestamp.to_string());
   }
   m_file_data_atm_input.read_variables(triplet_curr.time_idx);
   m_time1 = triplet_curr.timestamp;

--- a/components/eamxx/src/share/util/eamxx_time_interpolation.hpp
+++ b/components/eamxx/src/share/util/eamxx_time_interpolation.hpp
@@ -45,6 +45,13 @@ public:
   // Informational
   void print();
 
+  // Option to add a logger
+  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& logger,
+                  const std::string& header) {
+      m_logger = logger;
+      m_header = header;
+  }
+
 protected:
 
   // Internal structure to store data source triplets (when using data from file)
@@ -85,7 +92,8 @@ protected:
   AtmosphereInput                            m_file_data_atm_input;
   bool                                       m_is_data_from_file=false;
 
-
+  std::shared_ptr<ekat::logger::LoggerBase>  m_logger;
+  std::string                                m_header;
 }; // class TimeInterpolation
 
 } // namespace util


### PR DESCRIPTION
With these small mods, the log from a test that uses nudging contains snippets of the form

```
[EAMxx::Nudging] Reading nudging data
[EAMxx:time_interpolation] Reading data at time 2021-10-12-46500
[EAMxx::scorpio_input] Reading variables from file
  file name: shoc_p3_source_data_nudged.INSTANT.nsteps_x5.2021-10-12-45000.nc
  var names: T_mid, qv, p_mid
  time idx : 1
  Done! Elapsed time: 0.050000 seconds

```