### PR TITLE
Fix how we read/write timestamp to file

### DIFF
--- a/components/eamxx/src/share/io/scream_io_control.hpp
+++ b/components/eamxx/src/share/io/scream_io_control.hpp
@@ -22,30 +22,14 @@ struct IOControl {
   util::TimeStamp next_write_ts;
   util::TimeStamp last_write_ts;
 
-  mutable int dt = 0;
-
   bool output_enabled () const {
     return frequency_units!="none" && frequency_units!="never";
   }
 
-  void compute_dt (const util::TimeStamp& ts) {
-    if (dt==0 and frequency_units=="nsteps") {
-      int nsteps = ts.get_num_steps() - last_write_ts.get_num_steps();
-      if (nsteps>0) {
-        dt = (ts-last_write_ts) / nsteps;
-      }
-
-      // Now that we have dt, we can compute the next write ts
-      // NOTE: when OutputManager calls this for t0 output, we still have dt=0,
-      //       so this call sets next_write_ts=last_write_ts. We'll have to wait
-      //       until the first call during the time loop for a nonzero dt.
-      compute_next_write_ts();
-    }
-  }
-
   bool is_write_step (const util::TimeStamp& ts) const {
     if (not output_enabled()) return false;
-    return ts==next_write_ts;
+    return frequency_units=="nsteps" ? ts.get_num_steps()==next_write_ts.get_num_steps()
+                                     : ts==next_write_ts;
   }
 
   // Computes next_write_ts from frequency and last_write_ts
@@ -53,11 +37,9 @@ struct IOControl {
     EKAT_REQUIRE_MSG (last_write_ts.is_valid(),
         "Error! Cannot compute next_write_ts, since last_write_ts was never set.\n");
     if (frequency_units=="nsteps") {
+      // This avoids having an invalid date/time in the above check next time this fcn runs
       next_write_ts = last_write_ts;
-      if (dt>0) {
-        next_write_ts += dt*frequency;
-        next_write_ts.set_num_steps(last_write_ts.get_num_steps()+frequency);
-      }
+      next_write_ts.set_num_steps(last_write_ts.get_num_steps()+frequency);
     } else if (frequency_units=="nsecs") {
       next_write_ts = last_write_ts;
       next_write_ts += frequency;
@@ -89,13 +71,6 @@ struct IOControl {
     } else {
       EKAT_ERROR_MSG ("Error! Unrecognized/unsupported frequency unit '" + frequency_units + "'\n");
     }
-  }
-
-  void update_write_timestamps () {
-    // Shift next_write_ts into last_write_ts, recompute next_write_ts, and zero-out nsamples_since_last_write
-    last_write_ts = next_write_ts;
-    compute_next_write_ts ();
-    nsamples_since_last_write = 0;
   }
 };
 

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -168,7 +168,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
       auto rhist_file = find_filename_in_rpointer(hist_restart_filename_prefix,false,m_io_comm,m_run_t0);
 
       // From restart file, get the time of last write, as well as the current size of the avg sample
-      m_output_control.last_write_ts = read_timestamp(rhist_file,"last_write");
+      m_output_control.last_write_ts = read_timestamp(rhist_file,"last_write",true);
       m_output_control.compute_next_write_ts();
       m_output_control.nsamples_since_last_write = get_attribute<int>(rhist_file,"num_snapshots_since_last_write");
 
@@ -440,8 +440,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
       } else {
         if (filespecs.ftype==FileType::HistoryRestart) {
           // Update the date of last write and sample size
-          scorpio::write_timestamp (filespecs.filename,"last_write",m_output_control.last_write_ts);
-          scorpio::set_attribute (filespecs.filename,"last_write_nsteps",m_output_control.last_write_ts.get_num_steps());
+          scorpio::write_timestamp (filespecs.filename,"last_write",m_output_control.last_write_ts,true);
           scorpio::set_attribute (filespecs.filename,"last_output_filename",m_output_file_specs.filename);
           scorpio::set_attribute (filespecs.filename,"num_snapshots_since_last_write",m_output_control.nsamples_since_last_write);
         }

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -290,13 +290,6 @@ void OutputManager::run(const util::TimeStamp& timestamp)
 
   using namespace scorpio;
 
-  // We did not have dt at init time. Now we can compute it based on timestamp and the ts of last write.
-  // NOTE: dt is only needed for frequency_units='nsteps'. For other units, the function returns immediately
-  m_output_control.compute_dt(timestamp);
-  if (m_checkpoint_control.output_enabled()) {
-    m_checkpoint_control.compute_dt(timestamp);
-  }
-
   std::string timer_root = m_is_model_restart_output ? "EAMxx::IO::restart" : "EAMxx::IO::standard";
   start_timer(timer_root);
 
@@ -432,7 +425,9 @@ void OutputManager::run(const util::TimeStamp& timestamp)
       }
 
       // Since we wrote to file we need to reset the timestamps
-      control.update_write_timestamps();
+      control.last_write_ts = timestamp;
+      control.compute_next_write_ts();
+      control.nsamples_since_last_write = 0;
 
       if (m_is_model_restart_output) {
         // Only write nsteps on model restart
@@ -678,7 +673,6 @@ set_params (const ekat::ParameterList& params,
       m_checkpoint_file_specs.ftype = FileType::HistoryRestart;
     }
   }
-
 }
 
 /*===============================================================================================*/

--- a/components/eamxx/src/share/io/scream_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.cpp
@@ -686,7 +686,9 @@ void write_timestamp (const std::string& filename, const std::string& ts_name, c
 util::TimeStamp read_timestamp (const std::string& filename, const std::string& ts_name)
 {
   auto ts = util::str_to_time_stamp(get_attribute<std::string>(filename,ts_name));
-  ts.set_num_steps(get_attribute<int>(filename,ts_name+"_nsteps"));
+  if (has_attribute(filename,ts_name+"_nsteps")) {
+    ts.set_num_steps(get_attribute<int>(filename,ts_name+"_nsteps"));
+  }
   return ts;
 }
 /* ----------------------------------------------------------------- */

--- a/components/eamxx/src/share/io/scream_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.cpp
@@ -190,10 +190,58 @@ bool has_variable (const std::string& filename, const std::string& varname)
     return false;
   }
   EKAT_REQUIRE_MSG (err==PIO_NOERR,
-      "Error! Something went wrong while retrieving dimension id.\n"
+      "Error! Something went wrong while retrieving variable id.\n"
       " - filename : " + filename + "\n"
       " - varname  : " + varname + "\n"
       " - pio error: " + std::to_string(err) + "\n");
+  if (not was_open) {
+    eam_pio_closefile(filename);
+  }
+
+  return true;
+}
+
+bool has_attribute (const std::string& filename, const std::string& attname)
+{
+  return has_attribute(filename,"GLOBAL",attname);
+}
+
+bool has_attribute (const std::string& filename, const std::string& varname, const std::string& attname)
+{
+  int ncid, varid, attid, err;
+
+  bool was_open = is_file_open_c2f(filename.c_str(),-1);
+  if (not was_open) {
+    register_file(filename,Read);
+  }
+
+  // Get file id
+  ncid = get_file_ncid_c2f (filename.c_str());
+
+  // Get var id
+  if (varname=="GLOBAL") {
+    varid = PIO_GLOBAL;
+  } else {
+    err = PIOc_inq_varid(ncid,varname.c_str(),&varid);
+    EKAT_REQUIRE_MSG (err==PIO_NOERR,
+        "Error! Something went wrong while retrieving variable id.\n"
+        " - filename : " + filename + "\n"
+        " - varname  : " + varname + "\n"
+        " - pio error: " + std::to_string(err) + "\n");
+  }
+
+  // Get att id
+  err = PIOc_inq_attid(ncid,varid,varname.c_str(),&attid);
+  if (err==PIO_ENOTATT) {
+    return false;
+  }
+  EKAT_REQUIRE_MSG (err==PIO_NOERR,
+      "Error! Something went wrong while retrieving attribute id.\n"
+      " - filename : " + filename + "\n"
+      " - varname  : " + varname + "\n"
+      " - attname  : " + attname + "\n"
+      " - pio error: " + std::to_string(err) + "\n");
+
   if (not was_open) {
     eam_pio_closefile(filename);
   }

--- a/components/eamxx/src/share/io/scream_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.cpp
@@ -231,7 +231,7 @@ bool has_attribute (const std::string& filename, const std::string& varname, con
   }
 
   // Get att id
-  err = PIOc_inq_attid(ncid,varid,varname.c_str(),&attid);
+  err = PIOc_inq_attid(ncid,varid,attname.c_str(),&attid);
   if (err==PIO_ENOTATT) {
     return false;
   }

--- a/components/eamxx/src/share/io/scream_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.cpp
@@ -677,16 +677,21 @@ void grid_write_data_array<double>(const std::string &filename, const std::strin
   grid_write_data_array_c2f_double(filename.c_str(),varname.c_str(),hbuf,buf_size);
 }
 /* ----------------------------------------------------------------- */
-void write_timestamp (const std::string& filename, const std::string& ts_name, const util::TimeStamp& ts)
+void write_timestamp (const std::string& filename, const std::string& ts_name,
+                      const util::TimeStamp& ts, const bool write_nsteps)
 {
   set_attribute(filename,ts_name,ts.to_string());
-  set_attribute(filename,ts_name+"_nsteps",ts.get_num_steps());
+  if (write_nsteps) {
+    set_attribute(filename,ts_name+"_nsteps",ts.get_num_steps());
+  }
 }
 /* ----------------------------------------------------------------- */
-util::TimeStamp read_timestamp (const std::string& filename, const std::string& ts_name)
+util::TimeStamp read_timestamp (const std::string& filename,
+                                const std::string& ts_name,
+                                const bool read_nsteps)
 {
   auto ts = util::str_to_time_stamp(get_attribute<std::string>(filename,ts_name));
-  if (has_attribute(filename,ts_name+"_nsteps")) {
+  if (read_nsteps and has_attribute(filename,ts_name+"_nsteps")) {
     ts.set_num_steps(get_attribute<int>(filename,ts_name+"_nsteps"));
   }
   return ts;

--- a/components/eamxx/src/share/io/scream_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.hpp
@@ -38,6 +38,8 @@ namespace scorpio {
   int get_dimlen(const std::string& filename, const std::string& dimname);
   bool has_dim(const std::string& filename, const std::string& dimname);
   bool has_variable (const std::string& filename, const std::string& varname);
+  bool has_attribute (const std::string& filename, const std::string& attname);
+  bool has_attribute (const std::string& filename, const std::string& varname, const std::string& attname);
   void set_decomp(const std::string& filename);
   /* Sets the degrees-of-freedom for a particular variable in a particular file.  Called once for each variable, for each file. */
   void set_dof(const std::string &filename, const std::string &varname, const Int dof_len, const offset_t* x_dof);

--- a/components/eamxx/src/share/io/scream_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.hpp
@@ -95,8 +95,11 @@ namespace scorpio {
   }
 
   // Shortcut to write/read to/from YYYYMMDD/HHMMSS attributes in the NC file
-  void write_timestamp (const std::string& filename, const std::string& ts_name, const util::TimeStamp& ts);
-  util::TimeStamp read_timestamp (const std::string& filename, const std::string& ts_name);
+  void write_timestamp (const std::string& filename, const std::string& ts_name,
+                        const util::TimeStamp& ts, const bool write_nsteps = false);
+  util::TimeStamp read_timestamp (const std::string& filename,
+                                  const std::string& ts_name,
+                                  const bool read_nsteps = false);
 
 extern "C" {
   /* Query whether the pio subsystem is inited or not */

--- a/components/eamxx/src/share/io/tests/io_utils.cpp
+++ b/components/eamxx/src/share/io/tests/io_utils.cpp
@@ -55,9 +55,6 @@ TEST_CASE ("io_control") {
 
   SECTION ("nsteps") {
     control.frequency_units = "nsteps";
-    // dt only matters for nsteps output
-    control.compute_dt(t0+1);
-    REQUIRE (control.dt==1);
     control.compute_next_write_ts();
     auto t1 = t0 + 1;
     auto t2 = t1 + 1;

--- a/components/eamxx/src/share/util/scream_time_stamp.hpp
+++ b/components/eamxx/src/share/util/scream_time_stamp.hpp
@@ -46,8 +46,7 @@ public:
 
   // === Update method(s) === //
 
-  // Set the counter for the number of steps. Must be called while m_num_steps==0,
-  // for safety reasons (do not alter num steps while the count started).
+  // Set the counter for the number of steps.
   void set_num_steps (const int num_steps) { m_num_steps  = num_steps; }
 
   TimeStamp& operator= (const TimeStamp&) = default;
@@ -63,7 +62,7 @@ protected:
   std::vector<int> m_date;  // [year, month, day]
   std::vector<int> m_time;  // [hour, min, sec]
 
-  int m_num_steps = 0; // Number of steps since simulation started
+  int m_num_steps = std::numeric_limits<int>::lowest(); // Number of steps since simulation started
 };
 
 // Overload operators for TimeStamp


### PR DESCRIPTION
A previous PR added the possibility of writing/reading also the global attribute `${timestamp_name}_nsteps`, which is used to correctly restart INSTANT output. However, this attributed is not present in older output files, so we should only read it if it's present and/or needed.