### PR TITLE
Change Implementation of get_vector_dim() in FieldLayout

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -845,7 +845,7 @@ initialize_fields ()
       auto hw = fm->get_field("horiz_winds");
       const auto& fid = hw.get_header().get_identifier();
       const auto& layout = fid.get_layout();
-      const int vec_dim = layout.get_vector_dim();
+      const int vec_dim = layout.get_vector_component_idx();
       const auto& units = fid.get_units();
       auto U = hw.subfield("U",units,vec_dim,0);
       auto V = hw.subfield("V",units,vec_dim,1);
@@ -861,7 +861,7 @@ initialize_fields ()
       auto hw = fm->get_field("surf_mom_flux");
       const auto& fid = hw.get_header().get_identifier();
       const auto& layout = fid.get_layout();
-      const int vec_dim = layout.get_vector_dim();
+      const int vec_dim = layout.get_vector_component_idx();
       const auto& units = fid.get_units();
       auto surf_mom_flux_U = hw.subfield("surf_mom_flux_U",units,vec_dim,0);
       auto surf_mom_flux_V = hw.subfield("surf_mom_flux_V",units,vec_dim,1);
@@ -1454,8 +1454,8 @@ initialize_constant_field(const FieldIdentifier& fid,
   // In the first case, all entries of the field are inited to val, while in the latter,
   // each component is inited to the corresponding entry of the array.
   if (layout.is_vector_layout() and ic_pl.isType<std::vector<double>>(name)) {
-    const auto idim = layout.get_vector_dim();
-    const auto vec_dim = layout.dim(idim);
+    const auto idim = layout.get_vector_component_idx();
+    const auto vec_dim = layout.get_vector_dim();
     const auto& values = ic_pl.get<std::vector<double>>(name);
     EKAT_REQUIRE_MSG (values.size()==static_cast<size_t>(vec_dim),
         "Error! Initial condition values array for '" + name + "' has the wrong dimension.\n"

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -122,7 +122,7 @@ get_component (const int i, const bool dynamic) {
       "Error! 'get_component' available only for vector fields.\n"
       "       Layout of '" + fname + "': " + e2str(get_layout_type(layout.tags())) + "\n");
 
-  const int idim = layout.get_vector_dim();
+  const int idim = layout.get_vector_component_idx();
   EKAT_REQUIRE_MSG (i>=0 && i<layout.dim(idim),
       "Error! Component index out of bounds [0," + std::to_string(layout.dim(idim)) + ").\n");
 

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -27,7 +27,10 @@ bool FieldLayout::is_tensor_layout () const {
   return lt==LayoutType::Tensor2D || lt==LayoutType::Tensor3D;
 }
 
-int FieldLayout::get_vector_dim () const {
+// get the index of the CMP (Components) tag in the FieldLayout
+// e.g., for FieldLayout f({COL, CMP, LEV}, {...});
+// we have get_component_idx(f) = 1
+int FieldLayout::get_vector_component_idx () const {
   EKAT_REQUIRE_MSG (is_vector_layout(),
       "Error! 'get_vector_dim' available only for vector layouts.\n"
       "       Current layout: " + e2str(get_layout_type(m_tags)) + "\n");
@@ -43,8 +46,17 @@ int FieldLayout::get_vector_dim () const {
   return std::distance(m_tags.cbegin(),it);
 }
 
+// get the extent of the CMP (Components) tag in the FieldLayout
+// e.g., for FieldLayout f({COL, CMP, LEV}, {ncol, ncmp, nlev});
+// we have get_component_idx(f) = ncmp
+int FieldLayout::get_vector_dim () const {
+  // since we immediately call get_vector_component_idx(), the error checking
+  // there should be sufficient
+  return dim(get_vector_component_idx());
+}
+
 FieldTag FieldLayout::get_vector_tag () const {
-  return m_tags[get_vector_dim()];
+  return m_tags[get_vector_component_idx()];
 }
 
 std::vector<int> FieldLayout::get_tensor_dims () const {

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -29,7 +29,7 @@ bool FieldLayout::is_tensor_layout () const {
 
 // get the index of the CMP (Components) tag in the FieldLayout
 // e.g., for FieldLayout f({COL, CMP, LEV}, {...});
-// we have get_component_idx(f) = 1
+// we have get_vector_component_idx(f) = 1
 int FieldLayout::get_vector_component_idx () const {
   EKAT_REQUIRE_MSG (is_vector_layout(),
       "Error! 'get_vector_dim' available only for vector layouts.\n"
@@ -48,7 +48,7 @@ int FieldLayout::get_vector_component_idx () const {
 
 // get the extent of the CMP (Components) tag in the FieldLayout
 // e.g., for FieldLayout f({COL, CMP, LEV}, {ncol, ncmp, nlev});
-// we have get_component_idx(f) = ncmp
+// we have get_vector_dim(f) = ncmp
 int FieldLayout::get_vector_dim () const {
   // since we immediately call get_vector_component_idx(), the error checking
   // there should be sufficient

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -13,7 +13,7 @@
 namespace scream
 {
 
-// The type of the layout, that is, the kind of field it represent.
+// The type of the layout, that is, the kind of field it represents.
 enum class LayoutType {
   Invalid,
   Scalar0D,
@@ -81,7 +81,7 @@ public:
   bool has_tags (const std::vector<FieldTag>& tags) const;
 
   // The rank is the number of tags associated to this field.
-  int     rank () const  { return m_rank; }
+  int rank () const  { return m_rank; }
 
   int dim (const FieldTag tag) const;
   int dim (const int idim) const;
@@ -96,8 +96,12 @@ public:
   bool is_vector_layout () const;
   bool is_tensor_layout () const;
 
-  // If this is the layout of a vector field, get the idx of the vector dimension
+  // If this is the layout of a vector field, get the idx of the
+  // vector (CMP, Component) dimension
   // Note: throws if is_vector_layout()==false.
+  int get_vector_component_idx () const;
+  // get the dimension (extent) of the vector (CMP, Component) dimension
+  // calls get_vector_component_idx()
   int get_vector_dim () const;
   FieldTag get_vector_tag () const;
 
@@ -129,6 +133,7 @@ std::string to_string (const FieldLayout& l);
 
 // ========================== IMPLEMENTATION ======================= //
 
+// returns extent
 inline int FieldLayout::dim (const FieldTag t) const {
   auto it = ekat::find(m_tags,t);
 
@@ -158,10 +163,10 @@ inline long long FieldLayout::size () const {
   return prod;
 }
 
-inline FieldTag FieldLayout::tag (const int idim) const { 
+inline FieldTag FieldLayout::tag (const int idim) const {
   ekat::error::runtime_check(idim>=0 && idim<m_rank, "Error! Index out of bounds.", -1);
   return m_tags[idim];
-} 
+}
 
 inline bool FieldLayout::has_tags (const std::vector<FieldTag>& tags) const {
   bool b = true;
@@ -189,4 +194,3 @@ inline bool operator== (const FieldLayout& fl1, const FieldLayout& fl2) {
 } // namespace scream
 
 #endif // SCREAM_FIELD_LAYOUT_HPP
-

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -169,7 +169,7 @@ is_valid_layout (const FieldLayout& layout) const
     case LayoutType::Vector2D: [[fallthrough]];
     case LayoutType::Vector3D:
     {
-      const auto vec_dim = layout.dims()[layout.get_vector_dim()];
+      const auto vec_dim = layout.dims()[layout.get_vector_component_idx()];
       const auto vec_tag = layout.get_vector_tag();
       return is3d ? layout==get_3d_vector_layout(midpoints,vec_tag,vec_dim)
                   : layout==get_2d_vector_layout(vec_tag,vec_dim);

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -54,6 +54,8 @@ TEST_CASE("field_layout", "") {
 
   REQUIRE (fl2.get_vector_tag()==CMP);
   REQUIRE (fl5.get_vector_tag()==CMP);
+  REQUIRE (fl2.get_vector_component_idx()==1);
+  REQUIRE (fl5.get_vector_component_idx()==1);
   REQUIRE (fl2.get_vector_dim()==1);
   REQUIRE (fl5.get_vector_dim()==1);
 


### PR DESCRIPTION
This PR addresses #1996 and makes the following changes:

1. The function previously-named `get_vector_dim()` was re-named `get_vector_component_idx()` to align with its functionality. Namely, when a `FieldLayout` object is a vector, which is to say

    ```
    fv.is_vector_layout() == true
    ```

    then this function returns the index that corresponds to the vector of _**Components**_, which may be a vector holding any of these field tags: `{CMP, NGAS, SWBND, LWBND, SWGPT, ISCCPTAU, ISCCPPRS}`.
3. A replacement version of `get_vector_dim()` has been added and provides the extent (length) of the dimension with the index provided by `get_vector_component_idx()`. E.g., in pseudocode
    ```
    fv(fv.get_vector_component_idx()).extent() == fv.get_vector_dim().
    ```
4. Tests were added for `get_vector_component_idx()`.
5. Necessary modifications were made to other parts of the code that called the previous version of `get_vector_dim()`.