### PR TITLE
Some changes to test-all-scream and scripts-tests

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -403,11 +403,64 @@ option (SCREAM_ENABLE_STATM "Whether /proc/self/statm can be used to get memory 
 # Whether to disable warnings from tpls.
 set (SCREAM_DISABLE_TPL_WARNINGS ON CACHE BOOL "")
 
-include(EkatBuildEkat)
-BuildEkat(PREFIX "SCREAM"
-  ENABLE_TESTS OFF
-  ENABLE_FPE   ON
-  ENABLE_FPE_DEFAULT_MASK OFF)
+if (DEFINED ENV{SCREAM_FAKE_ONLY})
+  # We don't really need to build ekat, but we do need to configure the test-launcher
+
+  # Declare some vars that Ekat would have declared, and may be used later
+  option (EKAT_ENABLE_MPI "Whether EKAT requires MPI." ON)
+  option (EKAT_TEST_LAUNCHER_MANAGE_RESOURCES "Whether test-launcher should try to manage thread distribution. Requires a ctest resource file to be effective." OFF)
+  option (EKAT_ENABLE_VALGRIND "Whether to run tests with valgrind" OFF)
+  set(EKAT_VALGRIND_SUPPRESSION_FILE "" CACHE FILEPATH "Use this valgrind suppression file if valgrind is enabled.")
+  set (EKAT_ENABLE_GPU False)
+  if (Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP OR Kokkos_ENABLE_SYCL)
+    set (EKAT_ENABLE_GPU True)
+  endif ()
+
+  if (EKAT_TEST_LAUNCHER_MANAGE_RESOURCES)
+    set (TEST_LAUNCHER_MANAGE_RESOURCES True)
+  else()
+    set (TEST_LAUNCHER_MANAGE_RESOURCES False)
+  endif()
+  if (EKAT_ENABLE_GPU)
+    set (TEST_LAUNCHER_ON_GPU True)
+  else()
+    set (TEST_LAUNCHER_ON_GPU False)
+  endif()
+
+  set (EKAT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../externals/ekat)
+
+  # Configure/install test-launcher to build/install folder
+  configure_file(${EKAT_SOURCE_DIR}/bin/test-launcher
+                 ${CMAKE_BINARY_DIR}/bin/test-launcher)
+  if (EKAT_ENABLE_MPI)
+    find_package(MPI REQUIRED)
+
+    # NOTE: may be an overkill, but depending on which FindMPI module is called,
+    #       if _FIND_REQUIRED is not checked, we may not get a fatal error
+    #       if the required components are not found. So check the _FOUND var.
+    if (NOT MPI_C_FOUND)
+      message (FATAL_ERROR "EKAT *requires* the C component of MPI to be found")
+    endif()
+
+    # We should avoid cxx bindings in mpi; they are already deprecated,
+    # and can cause headaches at link time, cause they require -lmpi_cxx
+    # (openpmi) or -lmpicxx (mpich) flags.
+    include(EkatMpiUtils)
+    DisableMpiCxxBindings()
+  endif()
+
+  if (EKAT_ENABLE_VALGRIND)
+    add_subdirectory(${EKAT_SOURCE_DIR}/valgrind_support
+                     ${CMAKE_BINARY_DIR}/externals/ekat/valgrind_support)
+  endif()
+
+else()
+  include(EkatBuildEkat)
+  BuildEkat(PREFIX "SCREAM"
+    ENABLE_TESTS OFF
+    ENABLE_FPE   ON
+    ENABLE_FPE_DEFAULT_MASK OFF)
+endif()
 
 # Set compiler-specific flags
 include(EkatSetCompilerFlags)

--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -429,11 +429,8 @@ if (DEFINED ENV{SCREAM_FAKE_ONLY})
 
   set (EKAT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../externals/ekat)
 
-  # Configure/install test-launcher to build/install folder
-  configure_file(${EKAT_SOURCE_DIR}/bin/test-launcher
-                 ${CMAKE_BINARY_DIR}/bin/test-launcher)
   if (EKAT_ENABLE_MPI)
-    find_package(MPI REQUIRED)
+    find_package(MPI REQUIRED COMPONENTS C)
 
     # NOTE: may be an overkill, but depending on which FindMPI module is called,
     #       if _FIND_REQUIRED is not checked, we may not get a fatal error
@@ -447,7 +444,12 @@ if (DEFINED ENV{SCREAM_FAKE_ONLY})
     # (openpmi) or -lmpicxx (mpich) flags.
     include(EkatMpiUtils)
     DisableMpiCxxBindings()
+    SetMpiRuntimeEnvVars()
   endif()
+
+  # Configure/install test-launcher to build/install folder
+  configure_file(${EKAT_SOURCE_DIR}/bin/test-launcher
+                 ${CMAKE_BINARY_DIR}/bin/test-launcher)
 
   if (EKAT_ENABLE_VALGRIND)
     add_subdirectory(${EKAT_SOURCE_DIR}/valgrind_support

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -222,9 +222,10 @@ class TestBuildnml(unittest.TestCase):
         # Append to an existing entry
         name = 'output_yaml_files'
         out = run_cmd_no_fail(f"./atmchange {name}+=a.yaml", from_dir=case)
+        out = run_cmd_no_fail(f"./atmchange {name}+=b.yaml", from_dir=case)
 
         # Get the yaml files
-        expected =f'{EAMXX_DIR / "data/scream_default_output.yaml"}, a.yaml'
+        expected =f'a.yaml, b.yaml'
         self._get_values(case, name, value=expected, expect_equal=True)
 
     ###########################################################################

--- a/components/eamxx/scripts/git_utils.py
+++ b/components/eamxx/scripts/git_utils.py
@@ -193,7 +193,7 @@ def get_git_toplevel_dir(repo=None):
     return output if stat == 0 else None
 
 ###############################################################################
-def cleanup_repo(orig_branch, orig_commit, repo=None, dry_run=False):
+def cleanup_repo(orig_branch, orig_commit, has_backup_commit=False, repo=None, dry_run=False):
 ###############################################################################
     """
     Discards all unstaged changes, as well as untracked files
@@ -217,4 +217,10 @@ def cleanup_repo(orig_branch, orig_commit, repo=None, dry_run=False):
     # NOTE: if you reset the branch, don't forget to re-update the modules!!
     if curr_commit != orig_commit and not dry_run:
         run_cmd_no_fail("git reset --hard {}".format(orig_commit), from_dir=repo)
+        if has_backup_commit:
+            # This can happen if we ran an integration test with a dirty repo.
+            # test_all_scream will create a temporary backup commit, which we
+            # need to undo, but leaving the changed files in the workspace.
+            # So DON'T add --hard to this call!
+            run_cmd_no_fail("git reset {HEAD~1}", from_dir=repo)
         update_submodules(repo=repo)

--- a/components/eamxx/scripts/git_utils.py
+++ b/components/eamxx/scripts/git_utils.py
@@ -137,6 +137,17 @@ def merge_git_ref(git_ref, repo=None, verbose=False, dry_run=False):
             print_last_commit()
 
 ###############################################################################
+def create_backup_commit (repo=None, dry_run=False):
+###############################################################################
+
+    bkp_cmd = "git add -A && git commit -m 'WARNING: test-all-scream backup commit'"
+    if dry_run:
+        print (f"Woudl run: {bkp_cmd}")
+    else:
+        run_cmd_no_fail(bkp_cmd, from_dir=repo)
+        expect(is_repo_clean(repo=repo), "Something went wrong while performing the backup commit")
+
+###############################################################################
 def print_last_commit(git_ref=None, repo=None, dry_run=False):
 ###############################################################################
     """

--- a/components/eamxx/scripts/scripts-tests
+++ b/components/eamxx/scripts/scripts-tests
@@ -173,7 +173,7 @@ class TestBaseOuter: # Hides the TestBase class from test scanner
 
         def test_pylint(self):
             ensure_pylint()
-            run_cmd_assert_result(self, "python3 -m pylint --disable C --disable R {}".format(self._source_file), from_dir=TEST_DIR, verbose=True)
+            run_cmd_assert_result(self, "python3 -m pylint --disable C --disable R {}".format(self._source_file), from_dir=TEST_DIR)
 
         def test_gen_baseline(self):
             if self._generate:
@@ -271,8 +271,8 @@ class TestTestAllScream(TestBaseOuter.TestBase):
 ###############################################################################
 
     CMDS_TO_TEST = [
-        "./test-all-scream -m $machine -b HEAD -k -p",
-        "./test-all-scream -m $machine -b HEAD -k -t dbg",
+        "./test-all-scream -m $machine -p",
+        "./test-all-scream -m $machine -t dbg",
         "./test-all-scream --baseline-dir $results -p -c EKAT_DISABLE_TPL_WARNINGS=ON -i -m $machine --submit --dry-run", # always dry run
     ]
 
@@ -288,7 +288,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test the 'dbg' test in test-all-scream. It should set certain CMake values
         """
         if not self._jenkins:
-            options = "-b HEAD -k -t dbg --config-only"
+            options = "-t dbg --config-only"
             cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
                                 self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
@@ -307,7 +307,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test the 'sp' test in test-all-scream. It should set certain CMake values
         """
         if not self._jenkins:
-            options = "-b HEAD -k -t sp --config-only"
+            options = "-t sp --config-only"
             cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
                                 self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
@@ -329,7 +329,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             if is_cuda_machine(self._machine):
                 self.skipTest("Skipping FPE check on cuda")
             else:
-                options = "-b HEAD -k -t fpe --config-only"
+                options = "-t fpe --config-only"
                 cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
                                     self._machine, dry_run=False)
                 run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
@@ -345,7 +345,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test the mem (default mem-check build) in test-all-scream. It should set certain CMake values
         """
         if not self._jenkins:
-            options = "-b HEAD -k -t mem --config-only"
+            options = "-t mem --config-only"
             cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
                                 self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
@@ -365,7 +365,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test the 'opt' test in test-all-scream. It should set certain CMake values
         """
         if not self._jenkins:
-            options = "-b HEAD -k -t opt --config-only"
+            options = "-t opt --config-only"
             cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
                                self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
@@ -379,7 +379,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that the 'dbg' test in test-all-scream detects and returns non-zero if there's a cmake configure error
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_CONFIG_FAIL=True -m $machine -b HEAD -k -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_CONFIG_FAIL=True -m $machine -t dbg", self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR, expect_works=False)
         else:
             self.skipTest("Skipping full run")
@@ -389,7 +389,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that the 'dbg' test in test-all-scream detects and returns non-zero if there's a build error
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_BUILD_FAIL=True -m $machine -b HEAD -k -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_BUILD_FAIL=True -m $machine -t dbg", self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR, expect_works=False)
         else:
             self.skipTest("Skipping full run")
@@ -399,7 +399,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that a failure from ctest in the testing phase is caught by test-all-scream
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_RUN_FAIL=True -m $machine -b HEAD -k -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_RUN_FAIL=True -m $machine -t dbg", self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR, expect_works=False)
         else:
             self.skipTest("Skipping full run")
@@ -409,7 +409,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that the at test level works
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -x -m $machine -b HEAD -k -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -x -m $machine -t dbg", self._machine, dry_run=False)
             output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_test_levels_were_run(self, output, ["AT"], ["NIGHTLY", "EXPERIMENTAL"])
         else:
@@ -420,7 +420,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that the nightly test level works
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -x --test-level=nightly -m $machine -b HEAD -k -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -x --test-level=nightly -m $machine -t dbg", self._machine, dry_run=False)
             output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_test_levels_were_run(self, output, ["AT", "NIGHTLY"], ["EXPERIMENTAL"])
         else:
@@ -431,7 +431,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that the experimental test level works
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -x --test-level=experimental -m $machine -b HEAD -k -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -x --test-level=experimental -m $machine -t dbg", self._machine, dry_run=False)
             output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_test_levels_were_run(self, output, ["AT", "NIGHTLY", "EXPERIMENTAL"], [])
         else:
@@ -445,12 +445,11 @@ class TestTestAllScream(TestBaseOuter.TestBase):
               So set SCREAM_FAKE_ONLY=ON, to lower the build time
         """
         if self._full:
-            baseline_dir = TEST_DIR.parent/"ctest-build"/"baselines"
 
-            # Start a couple new tests, baselines will be generated
+            # Start a couple new tests, baselines will be generated in ctest-build/baselines
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_GIT_HEAD=FAKE1"
-            opts = "-b HEAD -k -t dbg -t sp --no-tests"
-            cmd = self.get_cmd("{} ./test-all-scream -m $machine {}".format(env,opts),
+            opts = " -g -t dbg -t sp --no-tests"
+            cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
                                self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
@@ -459,8 +458,8 @@ class TestTestAllScream(TestBaseOuter.TestBase):
 
             # Re-run reusing baselines from above
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_GIT_HEAD=FAKE2"
-            opts = "--baseline-dir={} -b HEAD -k -t dbg -t sp --no-tests".format(baseline_dir)
-            cmd = self.get_cmd("{} ./test-all-scream -m $machine {}".format(env,opts),
+            opts = "--baseline-dir LOCAL -t dbg -t sp --no-tests"
+            cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
                                self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
@@ -468,9 +467,10 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE1")
 
             # Re-run dbg reusing baselines from above with a fake commit that's not ahead
+            # The flag -u implies -g, but nothing should happen, since SCREAM_FAKE_AHEAD=0
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_AHEAD=0 SCREAM_FAKE_GIT_HEAD=FAKE2"
-            opts = "--baseline-dir={} -b HEAD -k -t dbg -u --no-tests".format(baseline_dir)
-            cmd = self.get_cmd("{} ./test-all-scream -m $machine {}".format(env,opts),
+            opts = "--baseline-dir LOCAL -t dbg -u --no-tests"
+            cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
                                self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
@@ -478,9 +478,10 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE1")
 
             # Re-run dbg reusing baselines from above but expire them
+            # The flag -u implies -g, and since SCREAM_FAKE_AHEAD=1, baseline should be regenerated
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_AHEAD=1 SCREAM_FAKE_GIT_HEAD=FAKE2"
-            opts = "--baseline-dir={} -b HEAD -k -t dbg -u --no-tests".format(baseline_dir)
-            cmd = self.get_cmd("{} ./test-all-scream -m $machine {}".format(env,opts),
+            opts = "--baseline-dir LOCAL -t dbg -u --no-tests"
+            cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
                                self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
@@ -488,9 +489,10 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE1")
 
             # Re-run reusing some baselines and expiring others
+            # The dbg baselines were generated in the prev step, so this should only gen the sp baselines
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_AHEAD=1 SCREAM_FAKE_GIT_HEAD=FAKE2"
-            opts = "--baseline-dir={} -b HEAD -k -t dbg -t sp -u --no-tests".format(baseline_dir)
-            cmd = self.get_cmd("{} ./test-all-scream -m $machine {}".format(env,opts),
+            opts = "--baseline-dir LOCAL -t dbg -t sp -u --no-tests"
+            cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
                                self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
@@ -499,8 +501,8 @@ class TestTestAllScream(TestBaseOuter.TestBase):
 
             # Re-run without reusing baselines, should force regeneration
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_GIT_HEAD=FAKE3"
-            opts = "-b HEAD -k -t dbg -t sp --no-tests"
-            cmd = self.get_cmd("{} ./test-all-scream -m $machine {}".format(env,opts),
+            opts = "-g -t dbg -t sp --no-tests"
+            cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
                                self._machine, dry_run=False)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
@@ -518,7 +520,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         can manage resources correctly.
         """
         if self._full and self._machine == "mappy":
-            spread_test_opts = "-x -e SCREAM_TEST_THREAD_SPREAD=True -c EKAT_TEST_LAUNCHER_MANAGE_RESOURCES=True -c EKAT_MPIRUN_EXE=mpiexec -c EKAT_MPI_EXTRA_ARGS='-bind-to core' -c EKAT_MPI_NP_FLAG='--map-by' -c EKAT_MPI_THREAD_FLAG='' -m $machine -b HEAD -k -t dbg"
+            spread_test_opts = "-x -e SCREAM_TEST_THREAD_SPREAD=True -c EKAT_TEST_LAUNCHER_MANAGE_RESOURCES=True -c EKAT_MPIRUN_EXE=mpiexec -c EKAT_MPI_EXTRA_ARGS='-bind-to core' -c EKAT_MPI_NP_FLAG='--map-by' -c EKAT_MPI_THREAD_FLAG='' -m $machine -t dbg"
 
             cmd = self.get_cmd(f"./test-all-scream {spread_test_opts} --ctest-parallel-level=40 ", self._machine, dry_run=False)
             output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
@@ -598,7 +600,7 @@ class TestGatherAllData(TestBaseOuter.TestBase):
 ###############################################################################
 
     CMDS_TO_TEST = [
-        "./gather-all-data './scripts/test-all-scream -m $machine -b HEAD -k' -l -m $machine",
+        "./gather-all-data './scripts/test-all-scream -m $machine' -l -m $machine",
     ]
 
     def __init__(self, *internal_args):

--- a/components/eamxx/scripts/scripts-tests
+++ b/components/eamxx/scripts/scripts-tests
@@ -520,19 +520,11 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         can manage resources correctly.
         """
         if self._full and self._machine == "mappy":
-            spread_test_opts = "-x -e SCREAM_TEST_THREAD_SPREAD=True -c EKAT_TEST_LAUNCHER_MANAGE_RESOURCES=True -c EKAT_MPIRUN_EXE=mpiexec -c EKAT_MPI_EXTRA_ARGS='-bind-to core' -c EKAT_MPI_NP_FLAG='--map-by' -c EKAT_MPI_THREAD_FLAG='' -m $machine -t dbg"
+            spread_test_opts = "-x -e SCREAM_TEST_THREAD_SPREAD=True -e SCREAM_TEST_RANK_SPREAD=True -c EKAT_TEST_LAUNCHER_MANAGE_RESOURCES=True -c EKAT_MPIRUN_EXE=mpiexec -c EKAT_MPI_EXTRA_ARGS='-bind-to core' -c EKAT_MPI_NP_FLAG='--map-by' -c EKAT_MPI_THREAD_FLAG='' -m $machine -t dbg"
 
             cmd = self.get_cmd(f"./test-all-scream {spread_test_opts} --ctest-parallel-level=40 ", self._machine, dry_run=False)
             output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_omp_spread(self, output, 40)
-
-            cmd = self.get_cmd(f"./test-all-scream {spread_test_opts} --ctest-parallel-level=40 ", self._machine, dry_run=False)
-            output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
-            test_omp_spread(self, output, 40)
-
-            cmd = self.get_cmd(f"taskset -c 8-47 ./test-all-scream {spread_test_opts} --ctest-parallel-level=40 ", self._machine, dry_run=False)
-            output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
-            test_omp_spread(self, output, 48, begin=8)
 
             cmd = self.get_cmd(f"taskset -c 8-47 ./test-all-scream {spread_test_opts} --ctest-parallel-level=40 ", self._machine, dry_run=False)
             output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)

--- a/components/eamxx/scripts/test-all-scream
+++ b/components/eamxx/scripts/test-all-scream
@@ -64,14 +64,11 @@ OR
     parser.add_argument("-p", "--parallel", action="store_true",
                         help="Launch the different build types stacks in parallel")
 
-    parser.add_argument("-f", "--fast-fail", action="store_true",
-                        help="Stop testing when the first failure is detected (ignored with -g)")
-
     parser.add_argument("-g", "--generate", action="store_true",
         help="Instruct test-all-scream to generate baselines from current commit. Skips tests")
 
     parser.add_argument("--baseline-dir", default=None,
-        help="Directory where baselines should be read from (or written to, if -g is used)")
+        help="Directory where baselines should be read from (or written to, if -g/-i is used)")
 
     parser.add_argument("-u", "--update-expired-baselines", action="store_true",
         help="Update baselines that appear to be expired (only used with -g)")
@@ -103,7 +100,7 @@ OR
                         help=f"Only run specific test configurations, choices={choices_doc}")
 
     parser.add_argument("-i", "--integration-test", action="store_true",
-                        help="Merge origin/master into this branch before testing.")
+                        help="Merge origin/master into this branch before testing (implies -u).")
 
     parser.add_argument("-l", "--local", action="store_true",
                         help="Allow to not specify a machine name, and have test-all-scream to look"

--- a/components/eamxx/scripts/test-all-scream
+++ b/components/eamxx/scripts/test-all-scream
@@ -65,16 +65,16 @@ OR
                         help="Launch the different build types stacks in parallel")
 
     parser.add_argument("-f", "--fast-fail", action="store_true",
-                        help="Stop testing when the first failure is detected")
+                        help="Stop testing when the first failure is detected (ignored with -g)")
 
-    parser.add_argument("-b", "--baseline-ref", default=None, # default will be computed later
-        help="What commit to use to generate baselines. Default is merge-base of current commit and origin/master (or HEAD if --keep-tree)")
+    parser.add_argument("-g", "--generate", action="store_true",
+        help="Instruct test-all-scream to generate baselines from current commit. Skips tests")
 
     parser.add_argument("--baseline-dir", default=None,
-        help="Use baselines from the given directory, skip baseline creation.")
+        help="Directory where baselines should be read from (or written to, if -g is used)")
 
     parser.add_argument("-u", "--update-expired-baselines", action="store_true",
-        help="Update baselines that appear to be expired.")
+        help="Update baselines that appear to be expired (only used with -g)")
 
     parser.add_argument("-m", "--machine",
         help="Provide machine name. This is *always* required. It can, but does not"
@@ -86,9 +86,6 @@ OR
     parser.add_argument("--no-tests", action="store_true", help="Only build baselines, skip testing phase")
     parser.add_argument("--config-only", action="store_true",
             help="In the testing phase, only run config step, skip build and tests")
-
-    parser.add_argument("-k", "--keep-tree", action="store_true",
-        help="Allow to keep the current work tree when testing against HEAD (only valid with `-b HEAD`)")
 
     parser.add_argument("-c", "--custom-cmake-opts", action="append", default=[],
         help="Extra custom options to pass to cmake. Can use multiple times for multiple cmake options. The -D is added for you")

--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -29,7 +29,7 @@ class TestAllScream(object):
 
     ###########################################################################
     def __init__(self, cxx_compiler=None, f90_compiler=None, c_compiler=None,
-                 submit=False, parallel=False, fast_fail=False, generate=False, no_tests=False,
+                 submit=False, parallel=False, generate=False, no_tests=False,
                  baseline_dir=None, machine=None, config_only=False,
                  custom_cmake_opts=(), custom_env_vars=(), preserve_env=False, tests=(),
                  integration_test=False, local=False, root_dir=None, work_dir=None,
@@ -51,7 +51,6 @@ class TestAllScream(object):
         self._c_compiler              = c_compiler
         self._submit                  = submit
         self._parallel                = parallel
-        self._fast_fail               = fast_fail
         self._machine                 = machine
         self._local                   = local
         self._run_tests               = not no_tests
@@ -694,9 +693,6 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
                 test = future_to_test[future]
                 success &= future.result()
 
-                if not success and self._fast_fail:
-                    print(f"Generation of baselines for test {test} failed")
-
         return success
 
     ###############################################################################
@@ -753,10 +749,6 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
                 test = future_to_test[future]
                 tests_success[test] = future.result()
                 success &= tests_success[test]
-                # If failed, and fast fail is requested, return immediately
-                # Note: this is effective only if num_worksers=1
-                if not success and self._fast_fail:
-                    break
 
         for t,s in tests_success.items():
             if not s:

--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -198,6 +198,9 @@ class TestAllScream(object):
         # These two dir are special dir for "on-the-fly baselines" and "machine's official baselines"
         local_baseline_dir = self._work_dir/"baselines"
         auto_dir = Path(get_mach_baseline_root_dir(self._machine)).absolute()
+        # Handle the "fake" auto case, used in scripts tests
+        if "SCREAM_FAKE_AUTO" in os.environ:
+            auto_dir = auto_dir / "fake"
 
         if self._baseline_dir == "LOCAL":
             self._baseline_dir = local_baseline_dir

--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -1,6 +1,8 @@
 from utils import run_cmd, run_cmd_no_fail, expect, check_minimum_python_version, ensure_psutil
 from git_utils import get_current_head, get_current_commit, get_current_branch, is_repo_clean, \
-    cleanup_repo, merge_git_ref, checkout_git_ref, git_refs_difference, print_last_commit
+    cleanup_repo, merge_git_ref, git_refs_difference, print_last_commit, \
+    create_backup_commit
+
 from test_factory import create_tests, COV
 
 from machines_specs import get_mach_compilation_resources, get_mach_testing_resources, \
@@ -27,8 +29,8 @@ class TestAllScream(object):
 
     ###########################################################################
     def __init__(self, cxx_compiler=None, f90_compiler=None, c_compiler=None,
-                 submit=False, parallel=False, fast_fail=False,
-                 baseline_ref=None, baseline_dir=None, machine=None, no_tests=False, config_only=False, keep_tree=False,
+                 submit=False, parallel=False, fast_fail=False, generate=False, no_tests=False,
+                 baseline_dir=None, machine=None, config_only=False,
                  custom_cmake_opts=(), custom_env_vars=(), preserve_env=False, tests=(),
                  integration_test=False, local=False, root_dir=None, work_dir=None,
                  quick_rerun=False,quick_rerun_failed=False,dry_run=False,
@@ -50,12 +52,10 @@ class TestAllScream(object):
         self._submit                  = submit
         self._parallel                = parallel
         self._fast_fail               = fast_fail
-        self._baseline_ref            = baseline_ref
         self._machine                 = machine
         self._local                   = local
-        self._perform_tests           = not no_tests
+        self._run_tests               = not no_tests
         self._config_only             = config_only
-        self._keep_tree               = keep_tree
         self._baseline_dir            = baseline_dir
         self._custom_cmake_opts       = custom_cmake_opts
         self._custom_env_vars         = custom_env_vars
@@ -66,14 +66,16 @@ class TestAllScream(object):
         self._quick_rerun             = quick_rerun
         self._quick_rerun_failed      = quick_rerun_failed
         self._dry_run                 = dry_run
-        self._update_expired_baselines= update_expired_baselines
         self._extra_verbose           = extra_verbose
         self._limit_test_regex        = limit_test_regex
         self._test_level              = test_level
         self._test_size               = test_size
         self._force_baseline_regen    = force_baseline_regen
-
-        # Not all builds are ment to perform comparisons against pre-built baselines
+        # Integration test always updates expired baselines
+        self._update_expired_baselines= update_expired_baselines or self._integration_test
+        # If we are to update expired baselines, then we must run the generate phase
+        # NOTE: the gen phase will do nothing if baselines are present and not expired
+        self._generate                = generate or self._update_expired_baselines
 
         if self._quick_rerun_failed:
             self._quick_rerun = True
@@ -105,8 +107,8 @@ class TestAllScream(object):
             self._root_dir = Path(__file__).resolve().parent.parent
         else:
             self._root_dir = Path(self._root_dir).resolve()
-            expect(self._root_dir.is_dir() and self._root_dir.parts()[-2:] == ("scream", "components"),
-                   f"Bad root-dir '{self._root_dir}', should be: $scream_repo/components/eamxx")
+            expect(self._root_dir.is_dir() and list(self._root_dir.parts)[-2:] == ["components","eamxx"],
+                   f"Bad root-dir '{self._root_dir}', should end with: /components/eamxx")
 
         # Make our test objects! Change mem to default mem-check test for current platform
         if "mem" in tests:
@@ -121,13 +123,6 @@ class TestAllScream(object):
         self._work_dir.mkdir(parents=True, exist_ok=True)
 
         os.chdir(str(self._root_dir)) # needed, or else every git command will need repo=root_dir
-        expect(get_current_commit(), f"Root dir: {self._root_dir}, does not appear to be a git repo")
-
-        # Print some info on the branch
-        self._original_branch = get_current_branch()
-        self._original_commit = get_current_commit()
-
-        print_last_commit(git_ref=self._original_branch, dry_run=self._dry_run)
 
         ###################################
         #  Compilation/testing resources  #
@@ -199,75 +194,79 @@ class TestAllScream(object):
         ###################################
 
         expect (not self._baseline_dir or self._work_dir != self._baseline_dir,
-                f"Error! For your safety, do NOT use '{self._work_dir}' to store baselines. Move them to a different directory (even a subdirectory if that works).")
+                f"Error! For your safety, do NOT use '{self._work_dir}' (the work_dir) to store baselines. Move them to a different directory (even a subdirectory if that works).")
 
-        # If no baseline ref/dir was provided, use default master baseline dir for this machine
-        # NOTE: if user specifies baseline ref, baseline dir will be set later to a path within work dir
-        if self._baseline_dir is None and self._baseline_ref is None:
-            self._baseline_dir = "AUTO"
-            print ("No '--baseline-dir XYZ' nor '-b XYZ' provided. Testing against default baselines dir for this machine.")
+        # These two dir are special dir for "on-the-fly baselines" and "machine's official baselines"
+        local_baseline_dir = self._work_dir/"baselines"
+        auto_dir = Path(get_mach_baseline_root_dir(self._machine)).absolute()
 
-        # If -k was used, make sure it's allowed
-        if self._keep_tree:
-            expect(not self._integration_test, "Should not be doing keep-tree with integration testing")
-            print("WARNING! You have uncommitted changes in your repo.",
-                  "         The PASS/FAIL status may depend on these changes",
-                  "         so if you want to keep them, don't forget to create a commit.",sep="\n")
-            if self._baseline_dir is None:
-                # Make sure the baseline ref is HEAD
-                expect(self._baseline_ref == "HEAD",
-                       "The option --keep-tree is only available when testing against pre-built baselines "
-                       "(--baseline-dir) or HEAD (-b HEAD)")
+        if self._baseline_dir == "LOCAL":
+            self._baseline_dir = local_baseline_dir
+        elif self._baseline_dir == "AUTO":
+            self._baseline_dir = auto_dir
+        elif self._baseline_dir is None:
+            if self._generate and not self._integration_test:
+                print ("No '--baseline-dir XYZ' provided. Baselines will be generated in {local_baseline_dir}.")
+                print ("NOTE: test-all-scream will proceed as if --force-baseline-regen was passed")
+                self._baseline_dir = local_baseline_dir
+                self._force_baseline_regen = True
+                self._update_expired_baselines = True
             else:
-                # Make sure the baseline ref is unset (or HEAD)
-                expect(self._baseline_ref is None or self._baseline_ref == "HEAD",
-                       "The option --keep-tree is only available when testing against pre-built baselines "
-                       "(--baseline-dir) or HEAD (-b HEAD)")
-        else:
-            expect(self._dry_run or is_repo_clean(),
-                   "Repo must be clean before running. If testing against HEAD or pre-built baselines, "
-                   "you can pass `--keep-tree` to allow non-clean repo.")
+                print ("No '--baseline-dir XYZ' provided. Testing against default baselines dir for this machine.")
+                self._baseline_dir = auto_dir
 
-        # For integration test, enforce baseline_ref==origin/master, and proceed to merge origin/master
-        if self._integration_test:
-            expect (self._baseline_ref is None or self._baseline_ref=="origin/master",
-                    "Error! Integration tests cannot be done against an arbitrary baseline ref.")
+        self._baseline_dir = Path(self._baseline_dir).absolute()
 
-            # Set baseline ref and merge it
-            self._baseline_ref = "origin/master"
-            merge_git_ref(git_ref=self._baseline_ref, verbose=True, dry_run=self._dry_run)
+        # Only integration tests can overwrite the mach-specific baselines
+        if self._baseline_dir==auto_dir:
+            expect (not self._generate or self._integration_test or self._force_baseline_regen,
+                    "You are not allowed to overwrite baselines in AUTO dir folder. Only -i and --force-baseline-regen can do that\n"
+                    f"  AUTO dir: {auto_dir}")
 
-            # Always update expired baselines if this is an integration test
-            self._update_expired_baselines = True
+        # Make the baseline dir, if not already existing.
+        if self._generate:
+            self.create_tests_dirs(self._baseline_dir, clean=False)
 
-        # By now, we should have at least one between baseline_dir and baseline_ref set (possibly both)
-        default_baselines_root_dir = self._work_dir/"baselines"
-        if self._baseline_dir is None:
-            # Use default baseline dir, and create it if necessary
-            self._baseline_dir = Path(default_baselines_root_dir).absolute()
-            self.create_tests_dirs(self._baseline_dir, True) # Wipe out previous baselines
+            # For now, assume baselines are generated from HEAD. If -i was used, we'll change this
+            self._baseline_ref = "origin/master" if self._integration_test else get_current_commit()
 
-        else:
-            if self._baseline_dir == "AUTO":
-                expect (self._baseline_ref is None or self._baseline_ref == "origin/master",
-                        "Do not specify `-b XYZ` when using `--baseline-dir AUTO`. The AUTO baseline dir should be used for the master baselines only.\n"
-                        "       `-b XYZ` needs to probably build baselines for ref XYZ. However, no baselines will be built if the dir already contains baselines.\n")
-                # We treat the "AUTO" string as a request for automatic baseline dir.
-                auto_dir = get_mach_baseline_root_dir(self._machine)
-                self._baseline_dir = Path(auto_dir) if auto_dir else default_baselines_root_dir
-                if "SCREAM_FAKE_AUTO" in os.environ:
-                    self._baseline_dir = self._baseline_dir/"fake"
-            else:
-                self._baseline_dir = Path(self._baseline_dir).absolute()
-
-            # Make sure the baseline folders exist (but do not purge content if they exist)
-            self.create_tests_dirs(self._baseline_dir, False)
-
-        # Do not do baseline operations if mem checking is on
+        # Check baselines status
         print (f"Checking baselines directory: {self._baseline_dir}")
-        self.baselines_are_present()
+        missing_baselines = self.check_baselines_are_present()
+        expect (len(missing_baselines)==0 or self._generate,
+                f"Missing baselines for builds {missing_baselines}. Re-run with -g to generate them")
+
         if self._update_expired_baselines:
-            self.baselines_are_expired()
+            self.check_baselines_are_expired()
+
+        ############################################
+        #           Check repo status              #
+        ############################################
+
+        expect(get_current_commit(), f"Root dir: {self._root_dir}, does not appear to be a git repo")
+
+        # Get git status info. Besides printing this info, we will need it to restore the repo initial
+        # configuration if we are running an integration test (where baselines need to be created
+        # from the origin/master commit)
+        self._original_branch = get_current_branch()
+        self._original_commit = get_current_commit()
+
+        print_last_commit(git_ref=self._original_branch, dry_run=self._dry_run)
+
+        # If we have an integration test, we need to merge master. Hence, do two things:
+        #  1) create bkp commit for all uncommitted/unstaged changes
+        #  2) save commit, so we can undo the merge after testing
+        self._has_backup_commit = False
+        if self._integration_test:
+            if not is_repo_clean():
+                # Back up work in a temporary commit
+                create_backup_commit()
+                self._has_backup_commit = True
+
+            self._original_commit = get_current_commit()
+
+            # Merge origin/master
+            merge_git_ref(git_ref=self._baseline_ref, verbose=True, dry_run=self._dry_run)
 
         ############################################
         #    Deduce compilers if needed/possible   #
@@ -317,8 +316,9 @@ class TestAllScream(object):
         return None
 
     ###############################################################################
-    def set_baseline_file_sha(self, test, sha):
+    def set_baseline_file_sha(self, test):
     ###############################################################################
+        sha = get_current_commit()
         baseline_file = (self.get_preexisting_baseline(test).parent)/"baseline_git_sha"
         with baseline_file.open("w", encoding="utf-8") as fd:
             return fd.write(sha)
@@ -350,7 +350,7 @@ class TestAllScream(object):
         return self._baseline_dir/str(test)/"data"
 
     ###############################################################################
-    def baselines_are_present(self):
+    def check_baselines_are_present(self):
     ###############################################################################
         """
         Check that all baselines are present (one subdir for all values of self._tests)
@@ -360,19 +360,23 @@ class TestAllScream(object):
         expect(self._baseline_dir is not None,
                 "Error! Baseline directory not correctly set.")
 
+        missing = []
         for test in self._tests:
             if test.uses_baselines:
                 data_dir = self.get_preexisting_baseline(test)
                 if not data_dir.is_dir():
                     test.baselines_missing = True
+                    missing += [test.longname]
                     print(f" -> Test {test} is missing baselines")
                 else:
                     print(f" -> Test {test} appears to have baselines")
             else:
                 print(f" -> Test {test} does not use baselines")
 
+        return missing
+
     ###############################################################################
-    def baselines_are_expired(self):
+    def check_baselines_are_expired(self):
     ###############################################################################
         """
         Baselines are expired if either:
@@ -381,40 +385,44 @@ class TestAllScream(object):
         """
         baseline_ref_sha = get_current_commit(commit=self._baseline_ref)
 
-        # Sanity check
-        expect(self._baseline_dir is not None, "Error! This routine should only be called when testing against pre-existing baselines.")
-
         for test in self._tests:
-            if test.uses_baselines and not test.baselines_missing:
-                # this test is not missing a baseline, but it may be expired.
+            if not test.uses_baselines or test.baselines_missing:
+                continue
 
-                baseline_file_sha = self.get_baseline_file_sha(test)
-                if baseline_file_sha is None:
-                    test.baselines_missing = True
-                    print(f" -> Test {test} has no stored sha so must be considered expired")
-                else:
-                    num_ref_is_behind_file, num_ref_is_ahead_file = git_refs_difference(baseline_file_sha, baseline_ref_sha)
+            if self._force_baseline_regen:
+                test.baselines_expired = True
+                print(f" -> Test {test} baselines are expired because self._force_baseline_regen=True")
+                continue
 
-                    # If the copy in our repo is behind, then we need to update the repo
-                    expect (num_ref_is_behind_file==0 or not self._integration_test,
+            # this test is not missing a baseline, but it may be expired.
+            baseline_file_sha = self.get_baseline_file_sha(test)
+            if baseline_file_sha is None:
+                test.baselines_missing = True
+                print(f" -> Test {test} has no stored sha so must be considered expired")
+                continue
+
+            # There is a sha file, so check how it compares with self._baseline_ref
+            num_ref_is_behind_file, num_ref_is_ahead_file = git_refs_difference(baseline_file_sha, baseline_ref_sha)
+
+            # If the copy in our repo is behind, then we need to update the repo
+            expect (num_ref_is_behind_file==0 or not self._integration_test,
 f"""Error! Your repo seems stale, since the baseline sha in your repo is behind
 the one last used to generated them. We do *not* allow an integration
 test to replace baselines with older ones, for security reasons.
 If this is a legitimate case where baselines need to be 'rewound',
 e.g. b/c of a (hopefully VERY RARE) force push to master, then
 remove existing baselines first. Otherwise, please run 'git fetch $remote'.
- - baseline_ref: {self._baseline_ref}
- - repo baseline sha: {baseline_ref_sha}
- - last used baseline sha: {baseline_file_sha}""")
+- baseline_ref: {self._baseline_ref}
+- repo baseline sha: {baseline_ref_sha}
+- last used baseline sha: {baseline_file_sha}""")
 
-                    # If the copy in our repo is not ahead, then baselines are not expired
-                    if num_ref_is_ahead_file > 0 or self._force_baseline_regen:
-                        test.baselines_missing = True
-                        reason = "forcing baseline regen" if self._force_baseline_regen \
-                                 else f"{self._baseline_ref} is ahead of the baseline commit by {num_ref_is_ahead_file}"
-                        print(f" -> Test {test} baselines are expired because {reason}")
-                    else:
-                        print(f" -> Test {test} baselines are valid and do not need to be regenerated")
+            # If the copy in our repo is ahead, then baselines are expired
+            if num_ref_is_ahead_file > 0:
+                test.baselines_expired = True
+                reason = f"{self._baseline_ref} is ahead of the existing baseline commit {baseline_file_sha} by {num_ref_is_ahead_file}"
+                print(f" -> Test {test} baselines are expired because {reason}")
+            else:
+                print(f" -> Test {test} baselines are valid and do not need to be regenerated")
 
     ###############################################################################
     def get_machine_file(self):
@@ -596,13 +604,15 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         return result
 
     ###############################################################################
-    def generate_baselines(self, test, commit):
+    def generate_baselines(self, test):
     ###############################################################################
         expect(test.uses_baselines,
                f"Something is off. generate_baseline should have not be called for test {test}")
 
         baseline_dir = self.get_test_dir(self._baseline_dir, test)
-        test_dir = self.get_test_dir(self._work_dir, test) / "tas_baseline_build"
+        test_dir = self.get_test_dir(self._work_dir / "tas_baseline_build", test)
+        if test_dir.exists():
+            shutil.rmtree(test_dir)
         test_dir.mkdir()
 
         num_test_res = self.create_ctest_resource_file(test,test_dir)
@@ -645,7 +655,7 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
             return False
 
         # Store the sha used for baselines generation
-        self.set_baseline_file_sha(test,commit)
+        self.set_baseline_file_sha(test)
         test.baselines_missing = False
 
         # Clean up the directory by removing everything
@@ -656,24 +666,28 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
     ###############################################################################
     def generate_all_baselines(self):
     ###############################################################################
-        git_head_ref = get_current_head()
+
+        tests_needing_baselines = self.baselines_to_be_generated()
+        if len(tests_needing_baselines)==0:
+            return True
+
+        git_ref = get_current_head()
 
         print("###############################################################################")
-        print(f"Generating baselines for ref {self._baseline_ref}")
+        print(f"Generating baselines from git ref {git_ref}")
         print("###############################################################################")
 
-        commit = get_current_commit(commit=self._baseline_ref)
-
-        # Switch to the baseline commit
-        checkout_git_ref(self._baseline_ref, verbose=True, dry_run=self._dry_run)
+        tas_baseline_bld = self._work_dir / "tas_baseline_build"
+        if tas_baseline_bld.exists():
+            shutil.rmtree(tas_baseline_bld)
+        tas_baseline_bld.mkdir()
 
         success = True
-        tests_needing_baselines = [test for test in self._tests if test.baselines_missing]
         num_workers = len(tests_needing_baselines) if self._parallel else 1
         with threading3.ProcessPoolExecutor(max_workers=num_workers) as executor:
 
             future_to_test = {
-                executor.submit(self.generate_baselines, test, commit) : test
+                executor.submit(self.generate_baselines, test) : test
                 for test in tests_needing_baselines}
 
             for future in threading3.as_completed(future_to_test):
@@ -682,10 +696,6 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
 
                 if not success and self._fast_fail:
                     print(f"Generation of baselines for test {test} failed")
-                    return False
-
-        # Switch back to the branch commit
-        checkout_git_ref(git_head_ref, verbose=True, dry_run=self._dry_run)
 
         return success
 
@@ -711,9 +721,10 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
             if self._quick_rerun_failed:
                 ctest_config += "--rerun-failed "
         else:
-            # This directory might have been used also to build the model to generate baselines.
+            # This directory might have been used before during another test-all-scream run.
             # Although it's ok to build in the same dir, we MUST make sure to erase cmake's cache
-            # and internal files from the previous build (CMakeCache.txt and CMakeFiles folder)
+            # and internal files from the previous build (CMakeCache.txt and CMakeFiles folder),
+            # Otherwise, we may not pick up changes in certain cmake vars that are already cached.
             run_cmd_no_fail("rm -rf CMake*", from_dir=test_dir, dry_run=self._dry_run)
 
         success = run_cmd(ctest_config, from_dir=test_dir, arg_stdout=None, arg_stderr=None, verbose=True, dry_run=self._dry_run)[0] == 0
@@ -801,6 +812,23 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
             return None
 
     ###############################################################################
+    def baselines_to_be_generated(self):
+    ###############################################################################
+        """
+        Return list of baselines to generate. Baselines need to be generated if
+         - they are missing
+         - they are expired and we asked to update expired baselines
+        """
+        ret = []
+        for test in self._tests:
+            if test.baselines_missing:
+                ret.append(test)
+            elif self._update_expired_baselines and test.baselines_expired:
+                ret.append(test)
+
+        return ret
+
+    ###############################################################################
     def test_all_scream(self):
     ###############################################################################
 
@@ -811,29 +839,21 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
 
         success = True
         try:
-            # If needed, generate baselines first
-
-            # First, create build directories (one per test). If existing, nuke the content
-            self.create_tests_dirs(self._work_dir, not self._quick_rerun)
-
-            tests_needing_baselines = [test for test in self._tests if test.baselines_missing]
-            if tests_needing_baselines:
-                expect(self._baseline_ref is not None, "Missing baseline ref")
-
+            if self._generate:
                 success = self.generate_all_baselines()
                 if not success:
                     print ("Error(s) occurred during baselines generation phase")
-                    return False
 
-            # If requested, run tests
-            if self._perform_tests:
+            if self._run_tests:
+                # First, create build directories (one per test). If existing, nuke the content
+                self.create_tests_dirs(self._work_dir, not self._quick_rerun)
+
                 success &= self.run_all_tests()
                 if not success:
                     print ("Error(s) occurred during test phase")
 
         finally:
-            if not self._keep_tree:
-                # Cleanup the repo if needed
-                cleanup_repo(self._original_branch, self._original_commit, dry_run=self._dry_run)
+            # Cleanup the repo if needed
+            cleanup_repo(self._original_branch, self._original_commit, self._has_backup_commit, dry_run=self._dry_run)
 
         return success

--- a/components/eamxx/tests/meta-tests/CMakeLists.txt
+++ b/components/eamxx/tests/meta-tests/CMakeLists.txt
@@ -11,24 +11,24 @@ include(ScreamUtils)
 # the test executable).
 
 # Test to ensure that a build failure is detected by our testing scripts
-EkatCreateUnitTest(build_fail build_fail.cpp
+EkatCreateUnitTest(build_fail build_fail.cpp EXCLUDE_MAIN_CPP EXCLUDE_TEST_SESSION
   LABELS "fail")
 
 # Test to ensure that a test failure is detected by our testing scripts
-EkatCreateUnitTest(test_fail test_fail.cpp
+EkatCreateUnitTest(test_fail test_fail.cpp EXCLUDE_MAIN_CPP EXCLUDE_TEST_SESSION
   LABELS "fail")
 
 # Tests to ensure the testing infrastructure is correctly spreading
 # concurrent tests across the available resources
 if (SCREAM_TEST_MAX_TOTAL_THREADS GREATER_EQUAL 16)
-  EkatCreateUnitTestExec(resource_spread resource_spread.cpp)
+  EkatCreateUnitTestExec(resource_spread resource_spread.cpp EXCLUDE_MAIN_CPP EXCLUDE_TEST_SESSION)
 
-  CreateUnitTestFromExec(resource_spread_thread resource_spread
+  EkatCreateUnitTestFromExec(resource_spread_thread resource_spread
     PRINT_OMP_AFFINITY
     THREADS 1 4 1
     MPI_RANKS 4)
 
-  CreateUnitTestFromExec(resource_spread_rank resource_spread
+  EkatCreateUnitTestFromExec(resource_spread_rank resource_spread
     PRINT_OMP_AFFINITY
     THREADS 4
     MPI_RANKS 1 4 1)

--- a/components/eamxx/tests/meta-tests/CMakeLists.txt
+++ b/components/eamxx/tests/meta-tests/CMakeLists.txt
@@ -23,6 +23,12 @@ EkatCreateUnitTest(test_fail test_fail.cpp EXCLUDE_MAIN_CPP EXCLUDE_TEST_SESSION
 if (SCREAM_TEST_MAX_TOTAL_THREADS GREATER_EQUAL 16)
   EkatCreateUnitTestExec(resource_spread resource_spread.cpp EXCLUDE_MAIN_CPP EXCLUDE_TEST_SESSION)
 
+  # When scripts-tests builds this folder, they are not building Ekat (or even Kokkos).
+  # So we must add openmp to the compiler/linker flags manually
+  # NOTE: scripts-tests is already checking that this is an "OpenMP machine", so this is safe
+  find_package(OpenMP REQUIRED COMPONENTS CXX)
+  target_link_libraries(resource_spread OpenMP::OpenMP_CXX MPI::MPI_C)
+
   EkatCreateUnitTestFromExec(resource_spread_thread resource_spread
     PRINT_OMP_AFFINITY
     THREADS 1 4 1

--- a/components/eamxx/tests/meta-tests/build_fail.cpp
+++ b/components/eamxx/tests/meta-tests/build_fail.cpp
@@ -1,16 +1,10 @@
-#include <catch2/catch.hpp>
-
 #include <iostream>
-
-namespace scream {
 
 #ifdef SCREAM_FORCE_BUILD_FAIL
 #error "Forcing failure to test test-all-scream"
 #endif
 
-TEST_CASE("pass", "[fake_infra_test]")
+int main(int,char**)
 {
-  REQUIRE(true);
+  return 0;
 }
-
-} // empty namespace

--- a/components/eamxx/tests/meta-tests/resource_spread.cpp
+++ b/components/eamxx/tests/meta-tests/resource_spread.cpp
@@ -1,11 +1,17 @@
 #include <chrono>
 #include <thread>
 
-int main(int, char**)
+#include <mpi.h>
+
+int main(int argc, char** argv)
 {
+  MPI_Init(&argc,&argv);
+
   // Nothing needs to be done here except sleeping to give a chance
   // for tests to run concurrently.
   const auto seconds_to_sleep = 5;
   std::this_thread::sleep_for(std::chrono::seconds(seconds_to_sleep));
+
+  MPI_Finalize();
   return 0;
 }

--- a/components/eamxx/tests/meta-tests/resource_spread.cpp
+++ b/components/eamxx/tests/meta-tests/resource_spread.cpp
@@ -1,19 +1,11 @@
-#include "ekat/kokkos/ekat_kokkos_types.hpp"
-
-#include <catch2/catch.hpp>
-
-#include <iostream>
 #include <chrono>
 #include <thread>
 
-namespace scream {
-
-TEST_CASE("rank_and_thread_spread", "[fake_infra_test]")
+int main(int, char**)
 {
   // Nothing needs to be done here except sleeping to give a chance
   // for tests to run concurrently.
   const auto seconds_to_sleep = 5;
   std::this_thread::sleep_for(std::chrono::seconds(seconds_to_sleep));
+  return 0;
 }
-
-} // empty namespace

--- a/components/eamxx/tests/meta-tests/test_fail.cpp
+++ b/components/eamxx/tests/meta-tests/test_fail.cpp
@@ -1,16 +1,10 @@
-#include <catch2/catch.hpp>
-
 #include <iostream>
 
-namespace scream {
-
-TEST_CASE("pass", "[fake_infra_test]")
+int main(int, char**)
 {
 #ifdef SCREAM_FORCE_RUN_FAIL
-  REQUIRE(false);
+  return 1;
 #else
-  REQUIRE(true);
+  return 0;
 #endif
 }
-
-} // empty namespace

--- a/components/eamxx/tests/meta-tests/test_level_check/CMakeLists.txt
+++ b/components/eamxx/tests/meta-tests/test_level_check/CMakeLists.txt
@@ -1,8 +1,8 @@
 include(ScreamUtils)
 
-EkatCreateUnitTestExec(at_unit at_unit.cpp)
-EkatCreateUnitTestExec(nightly_unit nightly_unit.cpp)
-EkatCreateUnitTestExec(experimental_unit experimental_unit.cpp)
+EkatCreateUnitTestExec(at_unit at_unit.cpp EXCLUDE_MAIN_CPP EXCLUDE_TEST_SESSION)
+EkatCreateUnitTestExec(nightly_unit nightly_unit.cpp EXCLUDE_MAIN_CPP EXCLUDE_TEST_SESSION)
+EkatCreateUnitTestExec(experimental_unit experimental_unit.cpp EXCLUDE_MAIN_CPP EXCLUDE_TEST_SESSION)
 
 CreateUnitTestFromExec(at_unit at_unit)
 CreateUnitTestFromExec(nightly_unit nightly_unit MINIMUM_TEST_LEVEL ${SCREAM_TEST_LEVEL_NIGHTLY})

--- a/components/eamxx/tests/meta-tests/test_level_check/at_unit.cpp
+++ b/components/eamxx/tests/meta-tests/test_level_check/at_unit.cpp
@@ -1,12 +1,7 @@
-#include <catch2/catch.hpp>
-
 #include <iostream>
 
-namespace scream {
-
-TEST_CASE("at_unit")
+int main(int,char**)
 {
   std::cout << "AT unit test running" << std::endl;
+  return 0;
 }
-
-} // empty namespace

--- a/components/eamxx/tests/meta-tests/test_level_check/experimental_unit.cpp
+++ b/components/eamxx/tests/meta-tests/test_level_check/experimental_unit.cpp
@@ -1,12 +1,7 @@
-#include <catch2/catch.hpp>
-
 #include <iostream>
 
-namespace scream {
-
-TEST_CASE("experimental_unit")
+int main(int,char**)
 {
   std::cout << "EXPERIMENTAL unit test running" << std::endl;
+  return 0;
 }
-
-} // empty namespace

--- a/components/eamxx/tests/meta-tests/test_level_check/nightly_unit.cpp
+++ b/components/eamxx/tests/meta-tests/test_level_check/nightly_unit.cpp
@@ -1,12 +1,7 @@
-#include <catch2/catch.hpp>
-
 #include <iostream>
 
-namespace scream {
-
-TEST_CASE("nightly_unit")
+int main(int,char**)
 {
   std::cout << "NIGHTLY unit test running" << std::endl;
+  return 0;
 }
-
-} // empty namespace


### PR DESCRIPTION
This PR does a few changes

For test-all-scream:
- Remove `-f`/`--fast-fail`. This option was never used. It only matters if we have 2+ builds _not_ built in parallel. This likely doesn't happen anymore
- Remove `-b`/`--baseline-ref` option. Instead, we always generate from current HEAD, _except_ for integration tests, when we temporarily switch to `origin/master`.
- Remove `-k`/`--keep-tree`. Instead, always allow to test from a dirty tree (create temp commit if we need to switch to `origin/master` to create baselines when doing `-i` tests)
- Request to use `-g` to generate baselines. If not passed, and baselines are not found, we error out. This avoids overwriting by accident local baselines in `ctest-build/baselines`. Using `-i` or `-u` will automatically add `-g`.
- Add "LOCAL" as possible choice for `--baseline-dir`. This is resolved to `ctest-build/baselines`.
- When not specifying a baseline-dir, we default to:
	- "LOCAL": if `-g` was used but not `-i`
	- "AUTO": otherwise
- When running with `-g` without `--baseline-dir` (i.e., LOCAL is used), always assume baselines are expired, so they will be regenerated.

For scripts-tests:
- Do not build ekat when SCREAM_FAKE_ONLY is defined in the env. The scripts tests don't really care about running an executable via ekat's `ekat_catch_main` main. All they need is an executable that does what expected (e.g., print a msg to screen, pass, fail, ...). Running `time ./scripts-tests -m local -f TestTestAllScream.test_baseline_handling` on my laptop with this branch gives ~25s, compared to 5m25s on master.
- Propagate changes to test-all-scream to this script