### PR TITLE
Do not run AT on dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     reviewers:
       - "mahf708"
       - "bartgol"
+    labels:
+      - "AT: Integrate Without Testing"


### PR DESCRIPTION
The prs are not going to impact EAMxx anyways, since they only impact gh actions