### PR TITLE
Run e3sm gh action only if repo name is e3sm

### DIFF
--- a/.github/workflows/e3sm-gh-ci-cime-tests.yml
+++ b/.github/workflows/e3sm-gh-ci-cime-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
 
   ci:
+    if: ${{ github.event.repository.name == 'e3sm' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/e3sm-gh-pages.yml
+++ b/.github/workflows/e3sm-gh-pages.yml
@@ -15,7 +15,7 @@ concurrency:
   
 jobs:
   Build-and-Deploy-docs:
-    if: ${{ github.event.repository.name != 'scream' }}
+    if: ${{ github.event.repository.name == 'e3sm' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Ideally, if a gh action file starts with `e3sm-`, then it should only run on the `e3sm` repo (and have a check inside that that's the case). On top of that, the singularity tests seem to have little meaning for the SCREAM fork, since we virtually never modify code outside the eamxx folder, and in the rare instances where we do, it's probably in EAM, which _does_ get tested via SCREAMv0 label.