### PR TITLE
EAMxx: add possibility of auto-flushing the atm logger

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -501,6 +501,11 @@ be lost if SCREAM_HACK_XML is not enabled.
                    doc="Verbosity level for the atm logger">
       info
     </atm_log_level>
+    <atm_flush_level type="string"
+                   valid_values="trace,debug,info,warn,error"
+                   doc="Verbosity level that triggers automatic flush of the atm logger">
+      warn
+    </atm_flush_level>
     <output_to_screen type="logical">false</output_to_screen>
     <mass_column_conservation_error_tolerance>1e-10</mass_column_conservation_error_tolerance>
     <energy_column_conservation_error_tolerance>1e-14</energy_column_conservation_error_tolerance>


### PR DESCRIPTION
Everytime a msg is logged with level >= flush_level, the logger will automatically flush. By default, it is set to warn.

In general, we don't want to flush to file too often, but while debugging some issues, it may be convenient to flush at every logging. Setting `atmchange atm_flush_level=trace` should do precisely that.