### PR TITLE
IOP fixes (shoc cell length and iop file read)

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -627,7 +627,7 @@ _TESTS = {
     "e3sm_scream_v1_dp-eamxx" : {
         "time"  : "01:00:00",
         "tests" : (
-            "ERS_Ln22.ne30_ne30.F2010-SCREAMv1-DP-DYCOMSrf01", # 225 phys cols, roughly size of ne2
+            "ERS_Ln22.ne30_ne30.F2010-SCREAMv1-DP-DYCOMSrf01.scream-ntasks-16", # 225 phys cols, roughly size of ne2
             )
     },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -627,7 +627,7 @@ _TESTS = {
     "e3sm_scream_v1_dp-eamxx" : {
         "time"  : "01:00:00",
         "tests" : (
-            "ERS_Ln22.ne30_ne30.F2010-SCREAMv1-DP-DYCOMSrf01.scream-ntasks-16", # 225 phys cols, roughly size of ne2
+            "ERS_P16_Ln22.ne30_ne30.F2010-SCREAMv1-DP-DYCOMSrf01", # 225 phys cols, roughly size of ne2
             )
     },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -635,7 +635,7 @@ _TESTS = {
     # should be fast, so we limit it to low res and add some thread tests
     # specifically for mappy.
     "e3sm_scream_v1_at" : {
-        "inherit" : ("e3sm_scream_v1_lowres"),
+        "inherit" : ("e3sm_scream_v1_lowres", "e3sm_scream_v1_dp-eamxx"),
         "tests"   : ("PET_Ln9_P32x2.ne4pg2_ne4pg2.F2010-SCREAMv1.scream-output-preset-1")
     },
 

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/ntasks/16/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/ntasks/16/shell_commands
@@ -1,2 +1,0 @@
-./xmlchange NTASKS=16 
-

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/ntasks/16/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/ntasks/16/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange NTASKS=16 
+

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -432,7 +432,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   if (m_grid->has_geometry_data("dx_short")) {
     // We must be running with IntensiveObservationPeriod on, with a planar geometry
     auto dx = m_grid->get_geometry_data("dx_short").get_view<const Real,Host>()();
-    Kokkos::deep_copy(cell_length, dx);
+    Kokkos::deep_copy(cell_length, dx*1000); // convert km -> m
   } else {
     const auto area = m_grid->get_geometry_data("area").get_view<const Real*>();
     const auto lat  = m_grid->get_geometry_data("lat").get_view<const Real*>();


### PR DESCRIPTION
Two fixes:
1. SHOC cell length computation should be converted to meters.
2. IOP file read in EAMxx was interpolating endpoints different from EAM.