### PR TITLE
Run rrtmgp standalone baseline tests only if baselines tests are enabled

### DIFF
--- a/components/eamxx/tests/uncoupled/rrtmgp/CMakeLists.txt
+++ b/components/eamxx/tests/uncoupled/rrtmgp/CMakeLists.txt
@@ -83,8 +83,10 @@ CompareNCFiles(
   FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_chunked_np${TEST_RANK_END}_omp1
                     ${FIXTURES_BASE_NAME}_not_chunked_np${TEST_RANK_END}_omp1)
 
-# Compare one of the output files with the baselines.
-# Note: one is enough, since we already check that np1 is BFB with npX,
-#       and that chunked is bfb with not_chunked
-set (OUT_FILE ${TEST_BASE_NAME}_output_chunked.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_END}.${RUN_T0}.nc)
-CreateBaselineTest(${TEST_BASE_NAME}_chunked ${TEST_RANK_END} ${OUT_FILE} ${FIXTURES_BASE_NAME}_chunked)
+if (SCREAM_ENABLE_BASELINE_TESTS)
+  # Compare one of the output files with the baselines.
+  # Note: one is enough, since we already check that np1 is BFB with npX,
+  #       and that chunked is bfb with not_chunked
+  set (OUT_FILE ${TEST_BASE_NAME}_output_chunked.INSTANT.nsteps_x${NUM_STEPS}.np${TEST_RANK_END}.${RUN_T0}.nc)
+  CreateBaselineTest(${TEST_BASE_NAME}_chunked ${TEST_RANK_END} ${OUT_FILE} ${FIXTURES_BASE_NAME}_chunked)
+endif()


### PR DESCRIPTION
We were running this test for FPE and memcheck builds, which don't set a baseline dir, causing errors.