### PR TITLE
test-all-scream: Get scripts-tests working again

### DIFF
--- a/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
@@ -143,20 +143,6 @@ if [ $skip_testing -eq 0 ]; then
 
     # Run scripts-tests
     if [[ $test_scripts == 1 ]]; then
-      # JGF: I'm not sure there's much value in these dry-run comparisons
-      # since we aren't changing HEADs
-      ./scripts/scripts-tests -g -m $SCREAM_MACHINE
-      if [[ $? != 0 ]]; then
-        fails=$fails+1;
-        scripts_fail=1
-      fi
-
-      ./scripts/scripts-tests -c -m $SCREAM_MACHINE
-      if [[ $? != 0 ]]; then
-        fails=$fails+1;
-        scripts_fail=1
-      fi
-
       ./scripts/scripts-tests -f -m $SCREAM_MACHINE
       if [[ $? != 0 ]]; then
         fails=$fails+1;

--- a/components/eamxx/scripts/scripts-tests
+++ b/components/eamxx/scripts/scripts-tests
@@ -3,14 +3,7 @@
 """
 Script containing python test suite for SCREAM test
 infrastructure. This suite should be run to confirm overall
-correctness. You should run this test once in generation mode to
-generate baseline results using your reference commit (common
-ancestor) and once in comparison mode to compare against these
-baselines using your development commit. Baseline and compare runs
-will use dry-run modes so we are only comparing hypothetical shell
-commands, not actually running them.
-
-You can also do a full run which will actually execute the commands.
+correctness.
 
 If you are on a batch machine, it is expected that you are on a compute node.
 
@@ -33,35 +26,9 @@ from pathlib import Path
 TEST_DIR = Path(__file__).resolve().parent
 CONFIG = {
     "machine"  : None,
-    "compare"  : False,
-    "generate" : False,
     "full"     : False,
     "jenkins"  : False
 }
-
-###############################################################################
-def run_cmd_store_output(test_obj, cmd, output_file):
-###############################################################################
-    output_file.parent.mkdir(parents=True, exist_ok=True)
-    output = run_cmd_assert_result(test_obj, cmd, from_dir=TEST_DIR)
-    head = get_current_head()
-    output = output.replace(head, "CURRENT_HEAD_NORMALIZED")
-    output_file.write_text(output)
-
-###############################################################################
-def run_cmd_check_baseline(test_obj, cmd, baseline_path):
-###############################################################################
-    test_obj.assertTrue(baseline_path.is_file(), msg="Missing baseline {}".format(baseline_path))
-    output = run_cmd_assert_result(test_obj, cmd, from_dir=TEST_DIR)
-    head = get_current_head()
-    output = output.replace(head, "CURRENT_HEAD_NORMALIZED")
-    diff = difflib.unified_diff(
-        baseline_path.read_text().splitlines(),
-        output.splitlines(),
-        fromfile=str(baseline_path),
-        tofile=cmd)
-    diff_output = "\n".join(diff)
-    test_obj.assertEqual("", diff_output, msg=diff_output)
 
 ###############################################################################
 def test_cmake_cache_contents(test_obj, build_name, cache_var, expected_value):
@@ -150,8 +117,6 @@ class TestBaseOuter: # Hides the TestBase class from test scanner
             self._source_file = source_file
             self._cmds        = list(cmds)
             self._machine     = CONFIG["machine"]
-            self._compare     = CONFIG["compare"]
-            self._generate    = CONFIG["generate"]
             self._full        = CONFIG["full"]
             self._jenkins     = CONFIG["jenkins"]
 
@@ -160,13 +125,8 @@ class TestBaseOuter: # Hides the TestBase class from test scanner
             self._results = TEST_DIR.joinpath("results")
             self._results.mkdir(parents=True, exist_ok=True) # pylint: disable=no-member
 
-        def get_baseline(self, cmd, machine):
-            return self._results.joinpath(self._source_file).with_suffix("").\
-                joinpath(machine, self.get_cmd(cmd, machine, dry_run=False).translate(str.maketrans(" /='", "____")))
-
         def get_cmd(self, cmd, machine, dry_run=True):
-            return "{}{}".format(cmd.replace("$machine", machine).replace("$results", str(self._results)),
-                                 " --dry-run" if (dry_run and "--dry-run" not in cmd) else "")
+            return cmd.replace("$machine", machine).replace("$results", str(self._results))
 
         def test_doctests(self):
             run_cmd_assert_result(self, "python3 -m doctest {}".format(self._source_file), from_dir=TEST_DIR)
@@ -174,23 +134,6 @@ class TestBaseOuter: # Hides the TestBase class from test scanner
         def test_pylint(self):
             ensure_pylint()
             run_cmd_assert_result(self, "python3 -m pylint --disable C --disable R {}".format(self._source_file), from_dir=TEST_DIR)
-
-        def test_gen_baseline(self):
-            if self._generate:
-                for cmd in self._cmds:
-                    run_cmd_store_output(self, self.get_cmd(cmd, self._machine), self.get_baseline(cmd, self._machine))
-            else:
-                self.skipTest("Skipping dry run baseline generation")
-
-        def test_cmp_baseline(self):
-            if self._compare:
-                for cmd in self._cmds:
-                    if "-p" in cmd:
-                        # Parallel builds can generate scrambled output. Skip them.
-                        continue
-                    run_cmd_check_baseline(self, self.get_cmd(cmd, self._machine), self.get_baseline(cmd, self._machine))
-            else:
-                self.skipTest("Skipping dry run baseline comparison")
 
         def test_full(self):
             if self._full:
@@ -271,9 +214,8 @@ class TestTestAllScream(TestBaseOuter.TestBase):
 ###############################################################################
 
     CMDS_TO_TEST = [
-        "./test-all-scream -m $machine -p",
+        "./test-all-scream -m $machine -p -i -c EKAT_DISABLE_TPL_WARNINGS=ON",
         "./test-all-scream -m $machine -t dbg",
-        "./test-all-scream --baseline-dir $results -p -c EKAT_DISABLE_TPL_WARNINGS=ON -i -m $machine --submit --dry-run", # always dry run
     ]
 
     def __init__(self, *internal_args):
@@ -592,7 +534,7 @@ class TestGatherAllData(TestBaseOuter.TestBase):
 ###############################################################################
 
     CMDS_TO_TEST = [
-        "./gather-all-data './scripts/test-all-scream -m $machine' -l -m $machine",
+        "./gather-all-data 'echo -m $machine' -l -m $machine",
     ]
 
     def __init__(self, *internal_args):
@@ -631,27 +573,10 @@ OR
     \033[1;32m# Run pylint tests for test_all_scream \033[0m
     > {0} TestTestAllScream.test_pylint
 
-    \033[1;32m# Do a dry-run generation for test_all_scream \033[0m
-    > {0} -g TestTestAllScream -m $machine
-
-    \033[1;32m# Do a dry-run comparison for test_all_scream \033[0m
-    > {0} -c TestTestAllScream -m $machine
-
     \033[1;32m# Do a full test run of test_all_scream \033[0m
     > {0} -f -m $machine TestTestAllScream
 
-    \033[1;32m# Do a full test run of everything \033[0m
-    > {0} -f -m $machine
-
-    \033[1;32m# Do a dry-run generation for everything \033[0m
-    > {0} -g -m $machine
-
-    \033[1;32m# Do a dry-run comparison for comparison \033[0m
-    > {0} -c -m $machine
-
     \033[1;32m# Run every possible test. This should be done before a PR is issued \033[0m
-    > {0} -g -m $machine # You likely want to do this for a reference commit
-    > {0} -c -m $machine
     > {0} -f -m $machine
 
     \033[1;32m# Test Jenkins script \033[0m
@@ -667,12 +592,6 @@ OR
     parser.add_argument("-m", "--machine",
                         help="Provide machine name. This is required for full (not dry) runs")
 
-    parser.add_argument("-g", "--generate", action="store_true",
-                        help="Do a dry run with baseline generation")
-
-    parser.add_argument("-c", "--compare", action="store_true",
-                        help="Do a dry run with baseline comparison")
-
     parser.add_argument("-f", "--full", action="store_true",
                         help="Do a full (not dry) run")
 
@@ -685,7 +604,7 @@ OR
     return args
 
 ###############################################################################
-def scripts_tests(machine=None, generate=False, compare=False, full=False, jenkins=False):
+def scripts_tests(machine=None, full=False, jenkins=False):
 ###############################################################################
     os.environ["SCREAM_FAKE_ONLY"] = "True"
 
@@ -694,9 +613,6 @@ def scripts_tests(machine=None, generate=False, compare=False, full=False, jenki
         expect(is_machine_supported(machine), "Machine {} is not supported".format(machine))
         CONFIG["machine"] = machine
 
-    expect(not (generate and compare), "Cannot do generate and compare in the same run")
-    CONFIG["compare"] = compare
-    CONFIG["generate"] = generate
     CONFIG["jenkins"] = jenkins
 
     if full:

--- a/components/eamxx/scripts/scripts-tests
+++ b/components/eamxx/scripts/scripts-tests
@@ -19,7 +19,7 @@ from machines_specs import is_machine_supported, is_cuda_machine
 from git_utils import get_current_branch, get_current_commit, get_current_head, git_refs_difference, \
     is_repo_clean, get_common_ancestor, checkout_git_ref, get_git_toplevel_dir
 
-import unittest, argparse, sys, difflib, shutil, os
+import unittest, argparse, sys, shutil, os
 from pathlib import Path
 
 # Globals
@@ -125,7 +125,7 @@ class TestBaseOuter: # Hides the TestBase class from test scanner
             self._results = TEST_DIR.joinpath("results")
             self._results.mkdir(parents=True, exist_ok=True) # pylint: disable=no-member
 
-        def get_cmd(self, cmd, machine, dry_run=True):
+        def get_cmd(self, cmd, machine):
             return cmd.replace("$machine", machine).replace("$results", str(self._results))
 
         def test_doctests(self):

--- a/components/eamxx/scripts/scripts-tests
+++ b/components/eamxx/scripts/scripts-tests
@@ -138,7 +138,7 @@ class TestBaseOuter: # Hides the TestBase class from test scanner
         def test_full(self):
             if self._full:
                 for cmd in self._cmds:
-                    run_cmd_assert_result(self, self.get_cmd(cmd, self._machine, dry_run=False), from_dir=TEST_DIR)
+                    run_cmd_assert_result(self, self.get_cmd(cmd, self._machine), from_dir=TEST_DIR)
             else:
                 self.skipTest("Skipping full run")
 
@@ -232,7 +232,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         if not self._jenkins:
             options = "-t dbg --config-only"
             cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
-                                self._machine, dry_run=False)
+                                self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_cmake_cache_contents(self, "full_debug", "CMAKE_BUILD_TYPE", "Debug")
             test_cmake_cache_contents(self, "full_debug", "SCREAM_DOUBLE_PRECISION", "TRUE")
@@ -251,7 +251,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         if not self._jenkins:
             options = "-t sp --config-only"
             cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
-                                self._machine, dry_run=False)
+                                self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_cmake_cache_contents(self, "full_sp_debug", "CMAKE_BUILD_TYPE", "Debug")
             test_cmake_cache_contents(self, "full_sp_debug", "SCREAM_DOUBLE_PRECISION", "FALSE")
@@ -273,7 +273,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             else:
                 options = "-t fpe --config-only"
                 cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
-                                    self._machine, dry_run=False)
+                                    self._machine)
                 run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
                 test_cmake_cache_contents(self, "debug_nopack_fpe", "CMAKE_BUILD_TYPE", "Debug")
                 test_cmake_cache_contents(self, "debug_nopack_fpe", "SCREAM_DOUBLE_PRECISION", "TRUE")
@@ -289,7 +289,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         if not self._jenkins:
             options = "-t mem --config-only"
             cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
-                                self._machine, dry_run=False)
+                                self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             builddir = "compute_sanitizer_memcheck" if is_cuda_machine(self._machine) else "valgrind"
             test_cmake_cache_contents(self, builddir, "CMAKE_BUILD_TYPE", "Debug")
@@ -309,7 +309,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         if not self._jenkins:
             options = "-t opt --config-only"
             cmd = self.get_cmd("./test-all-scream -m $machine {}".format(options),
-                               self._machine, dry_run=False)
+                               self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_cmake_cache_contents(self, "release", "CMAKE_BUILD_TYPE", "Release")
         else:
@@ -321,7 +321,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that the 'dbg' test in test-all-scream detects and returns non-zero if there's a cmake configure error
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_CONFIG_FAIL=True -m $machine -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_CONFIG_FAIL=True -m $machine -t dbg", self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR, expect_works=False)
         else:
             self.skipTest("Skipping full run")
@@ -331,7 +331,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that the 'dbg' test in test-all-scream detects and returns non-zero if there's a build error
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_BUILD_FAIL=True -m $machine -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_BUILD_FAIL=True -m $machine -t dbg", self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR, expect_works=False)
         else:
             self.skipTest("Skipping full run")
@@ -341,7 +341,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that a failure from ctest in the testing phase is caught by test-all-scream
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_RUN_FAIL=True -m $machine -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -e SCREAM_FORCE_RUN_FAIL=True -m $machine -t dbg", self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR, expect_works=False)
         else:
             self.skipTest("Skipping full run")
@@ -351,7 +351,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that the at test level works
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -x -m $machine -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -x -m $machine -t dbg", self._machine)
             output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_test_levels_were_run(self, output, ["AT"], ["NIGHTLY", "EXPERIMENTAL"])
         else:
@@ -362,7 +362,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that the nightly test level works
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -x --test-level=nightly -m $machine -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -x --test-level=nightly -m $machine -t dbg", self._machine)
             output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_test_levels_were_run(self, output, ["AT", "NIGHTLY"], ["EXPERIMENTAL"])
         else:
@@ -373,7 +373,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         Test that the experimental test level works
         """
         if self._full:
-            cmd = self.get_cmd("./test-all-scream -x --test-level=experimental -m $machine -t dbg", self._machine, dry_run=False)
+            cmd = self.get_cmd("./test-all-scream -x --test-level=experimental -m $machine -t dbg", self._machine)
             output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_test_levels_were_run(self, output, ["AT", "NIGHTLY", "EXPERIMENTAL"], [])
         else:
@@ -392,7 +392,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_GIT_HEAD=FAKE1"
             opts = " -g -t dbg -t sp --no-tests"
             cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
-                               self._machine, dry_run=False)
+                               self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
             test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE1")
@@ -402,7 +402,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_GIT_HEAD=FAKE2"
             opts = "--baseline-dir LOCAL -t dbg -t sp --no-tests"
             cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
-                               self._machine, dry_run=False)
+                               self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
             test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE1")
@@ -413,7 +413,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_AHEAD=0 SCREAM_FAKE_GIT_HEAD=FAKE2"
             opts = "--baseline-dir LOCAL -t dbg -u --no-tests"
             cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
-                               self._machine, dry_run=False)
+                               self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
             test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE1")
@@ -424,7 +424,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_AHEAD=1 SCREAM_FAKE_GIT_HEAD=FAKE2"
             opts = "--baseline-dir LOCAL -t dbg -u --no-tests"
             cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
-                               self._machine, dry_run=False)
+                               self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
             test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE2")
@@ -435,7 +435,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_AHEAD=1 SCREAM_FAKE_GIT_HEAD=FAKE2"
             opts = "--baseline-dir LOCAL -t dbg -t sp -u --no-tests"
             cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
-                               self._machine, dry_run=False)
+                               self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
             test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE2")
@@ -445,7 +445,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_GIT_HEAD=FAKE3"
             opts = "-g -t dbg -t sp --no-tests"
             cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
-                               self._machine, dry_run=False)
+                               self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
             test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE3")
@@ -464,11 +464,11 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         if self._full and self._machine == "mappy":
             spread_test_opts = "-x -e SCREAM_TEST_THREAD_SPREAD=True -e SCREAM_TEST_RANK_SPREAD=True -c EKAT_TEST_LAUNCHER_MANAGE_RESOURCES=True -c EKAT_MPIRUN_EXE=mpiexec -c EKAT_MPI_EXTRA_ARGS='-bind-to core' -c EKAT_MPI_NP_FLAG='--map-by' -c EKAT_MPI_THREAD_FLAG='' -m $machine -t dbg"
 
-            cmd = self.get_cmd(f"./test-all-scream {spread_test_opts} --ctest-parallel-level=40 ", self._machine, dry_run=False)
+            cmd = self.get_cmd(f"./test-all-scream {spread_test_opts} --ctest-parallel-level=40 ", self._machine)
             output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_omp_spread(self, output, 40)
 
-            cmd = self.get_cmd(f"taskset -c 8-47 ./test-all-scream {spread_test_opts} --ctest-parallel-level=40 ", self._machine, dry_run=False)
+            cmd = self.get_cmd(f"taskset -c 8-47 ./test-all-scream {spread_test_opts} --ctest-parallel-level=40 ", self._machine)
             output = run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             test_omp_spread(self, output, 48, begin=8)
 
@@ -483,7 +483,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             # We set PULLREQUESTNUM to block dashboard submission
             # We set SCREAM_FAKE_AUTO to not interere with real baselines
             cmd = self.get_cmd("PR_LABELS= NODE_NAME={} SCREAM_FAKE_AUTO=TRUE PULLREQUESTNUM=42 ./jenkins/jenkins_common.sh".format(self._machine),
-                               self._machine, dry_run=False)
+                               self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
         else:
@@ -497,7 +497,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
             # We set PULLREQUESTNUM to block dashboard submission
             # We set SCREAM_FAKE_AUTO to not interere with real baselines
             cmd = self.get_cmd("PR_LABELS= NODE_NAME={} SCREAM_FAKE_AUTO=TRUE PULLREQUESTNUM= ./jenkins/jenkins_common.sh".format(self._machine),
-                               self._machine, dry_run=False)
+                               self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
         else:
@@ -510,7 +510,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         if self._jenkins:
             # Any fail will do, we already checked test-all-scream captures all the fail types
             cmd = self.get_cmd("PR_LABELS= SCREAM_FORCE_CONFIG_FAIL=True NODE_NAME={} SCREAM_FAKE_AUTO=TRUE PULLREQUESTNUM=42 ./jenkins/jenkins_common.sh".format(self._machine),
-                               self._machine, dry_run=False)
+                               self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR, expect_works=False)
 
         else:
@@ -523,7 +523,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
         if self._jenkins:
             # Any fail will do, we already checked test-all-scream captures all the fail types
             cmd = self.get_cmd("PR_LABELS= SCREAM_FORCE_CONFIG_FAIL=True NODE_NAME={} SCREAM_FAKE_AUTO=TRUE PULLREQUESTNUM= ./jenkins/jenkins_common.sh".format(self._machine),
-                               self._machine, dry_run=False)
+                               self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR, expect_works=False)
 
         else:

--- a/components/eamxx/scripts/test-all-scream
+++ b/components/eamxx/scripts/test-all-scream
@@ -36,10 +36,6 @@ OR
     > cd $scream_repo/components/eamxx
     > ./scripts/{0} --preserve-env -m melvin
 
-    \033[1;32m# Run all tests on current machine with default behavior except using a custom ref for baseline generation\033[0m
-    > cd $scream_repo/components/eamxx
-    > ./scripts/{0} -m melvin -b BASELINE_REF
-
     \033[1;32m# Run all tests on current machine with default behavior except using pre-existing baselines (skips baseline generation) \033[0m
     > cd $scream_repo/components/eamxx
     > ./scripts/{0} -m melvin --baseline-dir=PATH_TO_BASELINES
@@ -50,7 +46,7 @@ OR
 
     \033[1;32m# Run all tests on current machine with default behavior on a repo with uncommitted changes\033[0m
     > cd $scream_repo/components/eamxx
-    > ./scripts/{0} -m melvin -k -b HEAD
+    > ./scripts/{0} -m melvin -k -b AUTO
 """.format(pathlib.Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -67,7 +63,7 @@ OR
     parser.add_argument("-g", "--generate", action="store_true",
         help="Instruct test-all-scream to generate baselines from current commit. Skips tests")
 
-    parser.add_argument("--baseline-dir", default=None,
+    parser.add_argument("-b", "--baseline-dir", default=None,
         help="Directory where baselines should be read from (or written to, if -g/-i is used)")
 
     parser.add_argument("-u", "--update-expired-baselines", action="store_true",

--- a/components/eamxx/scripts/test-all-scream
+++ b/components/eamxx/scripts/test-all-scream
@@ -114,9 +114,6 @@ OR
     parser.add_argument("--quick-rerun-failed", action="store_true",
                         help="Do not clean the build dir, and do not reconfigure. Just (incremental) build and retest failed tests only.")
 
-    parser.add_argument("-d", "--dry-run", action="store_true",
-                        help="Do a dry run, commands will be printed but not executed")
-
     parser.add_argument("--make-parallel-level", action="store", type=int, default=0,
         help="Max number of jobs to be created during compilation. If not provided, use default for given machine.")
 


### PR DESCRIPTION
Main change: remove support for dry runs. Dry runs can no longer be supported because CMake has to actually run to create key baseline files in order for TAS to work. We had a lot of test infrastructure based on comparing dry runs, which was never used, so I had to remove all that as well.

Other changes: `-b` is now free to be used as a shortcut for `--baseline-dir`. 