### PR TITLE
Add pnetcdf paths to config line when running test-all-scream

### DIFF
--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -443,6 +443,9 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
         stat, c_path, _ = run_cmd("nc-config --prefix")
         if stat == 0:
             result += f" -DNetCDF_C_PATH={c_path}"
+        stat, pc_path, _ = run_cmd("pnetcdf-config --prefix")
+        if stat == 0:
+            result += f" -DPnetCDF_C_PATH={pc_path}"
 
         # Test-specific cmake options
         for key, value in test.cmake_args:

--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -868,6 +868,7 @@ remove existing baselines first. Otherwise, please run 'git fetch $remote'.
 
         finally:
             # Cleanup the repo if needed
-            cleanup_repo(self._original_branch, self._original_commit, self._has_backup_commit)
+            if self._original_commit!=get_current_commit():
+                cleanup_repo(self._original_branch, self._original_commit, self._has_backup_commit)
 
         return success


### PR DESCRIPTION
We were not considering adding pnetcdf paths to the config line. This PR fixes it.

Also, a big fix in test-all-scream: we were cleaning up the repo even if it didn't need to, causing all unsaved changes to get lost.