### PR TITLE
test-all-scream: Fix force_baseline_regen

### DIFF
--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -70,7 +70,7 @@ class TestAllScream(object):
         self._test_size               = test_size
         self._force_baseline_regen    = force_baseline_regen
         # Integration test always updates expired baselines
-        self._update_expired_baselines= update_expired_baselines or self._integration_test
+        self._update_expired_baselines= update_expired_baselines or self._integration_test or self._force_baseline_regen
         # If we are to update expired baselines, then we must run the generate phase
         # NOTE: the gen phase will do nothing if baselines are present and not expired
         self._generate                = generate or self._update_expired_baselines

--- a/components/eamxx/scripts/utils.py
+++ b/components/eamxx/scripts/utils.py
@@ -2,9 +2,11 @@
 Utilities
 """
 
-import os, sys, re, signal, subprocess, site, time
+import os, sys, re, signal, subprocess, site, time, shutil
 from importlib import import_module
+import stat as statlib
 from pathlib import Path
+from distutils import file_util # pylint: disable=deprecated-module
 
 ###############################################################################
 def expect(condition, error_msg, exc_type=SystemExit, error_prefix="ERROR:"):
@@ -415,3 +417,77 @@ def ensure_yaml():   _ensure_pylib_impl("yaml", pip_libname="pyyaml",min_version
 def ensure_pylint(): _ensure_pylib_impl("pylint")
 def ensure_psutil(): _ensure_pylib_impl("psutil")
 def ensure_netcdf4(): _ensure_pylib_impl("netCDF4")
+
+###############################################################################
+def safe_copy(src_path, tgt_path, preserve_meta=True):
+###############################################################################
+    """
+    A flexbile and safe copy routine. Will try to copy file and metadata, but this
+    can fail if the current user doesn't own the tgt file. A fallback data-only copy is
+    attempted in this case. Works even if overwriting a read-only file.
+
+    tgt_path can be a directory, src_path must be a file
+
+    most of the complexity here is handling the case where the tgt_path file already
+    exists. This problem does not exist for the tree operations so we don't need to wrap those.
+
+    preserve_meta toggles if file meta-data, like permissions, should be preserved. If you are
+    copying baseline files, you should be within a SharedArea context manager and preserve_meta
+    should be false so that the umask set up by SharedArea can take affect regardless of the
+    permissions of the src files.
+    """
+
+    tgt_path = (
+        os.path.join(tgt_path, os.path.basename(src_path))
+        if os.path.isdir(tgt_path)
+        else tgt_path
+    )
+
+    # Handle pre-existing file
+    if os.path.isfile(tgt_path):
+        st = os.stat(tgt_path)
+        owner_uid = st.st_uid
+
+        # Handle read-only files if possible
+        if not os.access(tgt_path, os.W_OK):
+            if owner_uid == os.getuid():
+                # I am the owner, make writeable
+                os.chmod(tgt_path, st.st_mode | statlib.S_IWRITE)
+            else:
+                # I won't be able to copy this file
+                raise OSError(
+                    "Cannot copy over file {}, it is readonly and you are not the owner".format(
+                        tgt_path
+                    )
+                )
+
+        if owner_uid == os.getuid():
+            # I am the owner, copy file contents, permissions, and metadata
+            file_util.copy_file(
+                src_path,
+                tgt_path,
+                preserve_mode=preserve_meta,
+                preserve_times=preserve_meta,
+                verbose=0,
+            )
+        else:
+            # I am not the owner, just copy file contents
+            shutil.copyfile(src_path, tgt_path)
+
+    else:
+        # We are making a new file, copy file contents, permissions, and metadata.
+        # This can fail if the underlying directory is not writable by current user.
+        file_util.copy_file(
+            src_path,
+            tgt_path,
+            preserve_mode=preserve_meta,
+            preserve_times=preserve_meta,
+            verbose=0,
+        )
+
+    # If src file was executable, then the tgt file should be too
+    st = os.stat(tgt_path)
+    if os.access(src_path, os.X_OK) and st.st_uid == os.getuid():
+        os.chmod(
+            tgt_path, st.st_mode | statlib.S_IXUSR | statlib.S_IXGRP | statlib.S_IXOTH
+        )

--- a/components/eamxx/scripts/utils.py
+++ b/components/eamxx/scripts/utils.py
@@ -437,6 +437,10 @@ def safe_copy(src_path, tgt_path, preserve_meta=True):
     permissions of the src files.
     """
 
+    # Only works for str paths for now
+    src_path = str(src_path)
+    tgt_path = str(tgt_path)
+
     tgt_path = (
         os.path.join(tgt_path, os.path.basename(src_path))
         if os.path.isdir(tgt_path)


### PR DESCRIPTION
Option was being ignored.

Found some other issues while trying to help Balwinder's PR with missing baselines on AT machines:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.6/concurrent/futures/process.py", line 175, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/tmp/jgfouca/scream/components/eamxx/scripts/test_all_scream.py", line 661, in generate_baselines
    shutil.copy(src, dst)
  File "/usr/lib64/python3.6/shutil.py", line 246, in copy
    copymode(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib64/python3.6/shutil.py", line 144, in copymode
    chmod_func(dst, stat.S_IMODE(st.st_mode))
```

^^^ You aren't allowed to change permissions on a file you don't own. We've already hit and solved these issues in CIME, so I copied some code over and used the CIME pattern for managing TAS baselines.
