### PR TITLE
test-all-scream: allow git symmetric diff to fail

### DIFF
--- a/components/eamxx/scripts/git_utils.py
+++ b/components/eamxx/scripts/git_utils.py
@@ -55,7 +55,7 @@ def get_current_head(repo=None):
         return branch
 
 ###############################################################################
-def git_refs_difference (cmp_ref, head="HEAD", repo=None):
+def git_refs_difference(cmp_ref, head="HEAD", repo=None):
 ###############################################################################
     """
     Return the difference in commits between cmp_ref and head.

--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -398,7 +398,13 @@ class TestAllScream(object):
                 continue
 
             # There is a sha file, so check how it compares with self._baseline_ref
-            num_ref_is_behind_file, num_ref_is_ahead_file = git_refs_difference(baseline_file_sha, baseline_ref_sha)
+            try:
+                num_ref_is_behind_file, num_ref_is_ahead_file = git_refs_difference(baseline_file_sha, baseline_ref_sha)
+            except SystemExit as e:
+                test.baselines_expired = True
+                reason = f"Failed to get refs difference between {baseline_file_sha} and {baseline_ref_sha} because: {e}"
+                print(f" -> Test {test} baselines are expired because {reason}")
+                continue
 
             # If the copy in our repo is behind, then we need to update the repo
             expect (num_ref_is_behind_file==0 or not self._integration_test,


### PR DESCRIPTION
... without crashing the entire run. Just assume baselines are expired in that case.

We got AT errors for one of our PRs:
```
ERROR: Command: '\''git rev-list --left-right --count 43a7c5f30db5319d0b91b373e7a8689181f39f84...09e4afb675b14a131c45acc5b6f64b6100e170fe'\'' failed with error
 '\''fatal: Invalid symmetric difference expression 43a7c5f30db5319d0b91b373e7a8689181f39f84...09e4afb675b14a131c45acc5b6f64b6100e170fe'\'' from dir
 '\''/home/e3sm-jenkins/weaver/workspace/SCREAM_PullRequest_Autotester_Weaver/5463/scream/components/eamxx'\''
```

I don't know how it got into this state. The 43a7 sha, from the baseline_file, is a bad object.