### PR TITLE
Fix small bug in flushing file in scorpio interface

### DIFF
--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -167,6 +167,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
       using namespace scorpio;
       auto rhist_file = find_filename_in_rpointer(hist_restart_filename_prefix,false,m_io_comm,m_run_t0);
 
+      scorpio::register_file(rhist_file,scorpio::Read);
       // From restart file, get the time of last write, as well as the current size of the avg sample
       m_output_control.last_write_ts = read_timestamp(rhist_file,"last_write",true);
       m_output_control.compute_next_write_ts();
@@ -249,6 +250,7 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
         // since those are a property of the run, not of the file.
         setup_file(m_output_file_specs,m_output_control);
       }
+      scorpio::eam_pio_closefile(rhist_file);
     }
   }
 

--- a/components/eamxx/src/share/io/scream_scorpio_interface.F90
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.F90
@@ -998,7 +998,7 @@ contains
     call lookup_pio_atm_file(trim(fname),pio_atm_file,found)
 
     if (found) then
-      if ( is_write(pio_atm_file%purpose) ) then
+      if ( is_write(pio_atm_file%purpose) .or. is_append(pio_atm_file%purpose) ) then
         call PIO_syncfile(pio_atm_file%pioFileDesc)
       else
         call errorHandle("PIO ERROR: unable to flush file: "//trim(fname)//", is not open in write mode",-999)

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -80,6 +80,7 @@ TEST_CASE("output_restart","io")
   output_params.set<std::vector<std::string>>("Field Names",{"field_1", "field_2", "field_3", "field_4","field_5"});
   output_params.set<double>("fill_value",FillValue);
   output_params.set<bool>("MPI Ranks in Filename","true");
+  output_params.set<int>("flush_frequency",1);
   output_params.sublist("output_control").set<std::string>("frequency_units","nsteps");
   output_params.sublist("output_control").set<int>("Frequency",10);
   output_params.sublist("Checkpoint Control").set<int>("Frequency",5);


### PR DESCRIPTION
The scorpio utility for flushing a file was only checking that file was open in "Write" mode, without considering the possibility of "Append" mode.