### PR TITLE
scripts-tests: Fix on weaver

### DIFF
--- a/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
@@ -125,7 +125,9 @@ if [ $skip_testing -eq 0 ]; then
         fi
       fi
 
-      if [[ "$SCREAM_MACHINE" == "weaver" ]]; then
+      if [[ -z "$SCREAM_FAKE_ONLY" && "$SCREAM_MACHINE" == "weaver" ]]; then
+        # The fake-only tests don't launch any kernels which will cause all
+        # the compute-sanitizer runs to fail.
         ./scripts/gather-all-data "./scripts/test-all-scream -t csm -t csr -t csi -t css ${TAS_ARGS}" -l -m $SCREAM_MACHINE
         if [[ $? != 0 ]]; then
           fails=$fails+1;


### PR DESCRIPTION
The fake-only tests don't launch any kernels which will cause all the compute-sanitizer runs to fail. This used to work but I guess compute-sanitizer has been updated.