### PR TITLE
Enhance handling of tags in FieldLayout

### DIFF
--- a/components/eamxx/src/control/intensive_observation_period.cpp
+++ b/components/eamxx/src/control/intensive_observation_period.cpp
@@ -522,7 +522,7 @@ read_fields_from_file_for_iop (const std::string& file_name,
     // Create a temporary field to store the data from the
     // single column of the closest lat/lon pair
     const auto io_fid = io_field.get_header().get_identifier();
-    FieldLayout col_data_fl = io_fid.get_layout().strip_dim(0);
+    FieldLayout col_data_fl = io_fid.get_layout().clone().strip_dim(0);
     FieldIdentifier col_data_fid("col_data", col_data_fl, dummy_units, "");
     Field col_data(col_data_fid);
     col_data.allocate_view();

--- a/components/eamxx/src/control/intensive_observation_period.cpp
+++ b/components/eamxx/src/control/intensive_observation_period.cpp
@@ -498,9 +498,8 @@ read_fields_from_file_for_iop (const std::string& file_name,
                      "as first dim tag.\n");
 
     // Set first dimension to match input file
-    auto dims = fm_fid.get_layout().dims();
-    dims[0] = io_grid->get_num_local_dofs();
-    FieldLayout io_fl(fm_fid.get_layout().tags(), dims);
+    FieldLayout io_fl = fm_fid.get_layout();
+    io_fl.reset_dim(0,io_grid->get_num_local_dofs());
     FieldIdentifier io_fid(fm_fid.name(), io_fl, fm_fid.get_units(), io_grid->name());
     Field io_field(io_fid);
     io_field.allocate_view();

--- a/components/eamxx/src/control/surface_coupling_utils.cpp
+++ b/components/eamxx/src/control/surface_coupling_utils.cpp
@@ -11,7 +11,7 @@ void get_col_info_for_surface_values(const std::shared_ptr<const FieldHeader>& f
   const auto& layout = fh->get_identifier().get_layout();
   const auto& dims = layout.dims();
 
-  auto lt = get_layout_type(layout.tags());
+  auto lt = layout.type();
   const bool scalar   = lt==LayoutType::Scalar2D || lt==LayoutType::Scalar3D;
   const bool vector   = lt==LayoutType::Vector2D || lt==LayoutType::Vector3D;
   const bool layout3d = lt==LayoutType::Scalar3D || lt==LayoutType::Vector3D;
@@ -50,7 +50,7 @@ void get_col_info_for_surface_values(const std::shared_ptr<const FieldHeader>& f
     EKAT_REQUIRE_MSG(parent->get_parent().lock() == nullptr,
                      "Error! Currently support isn't added for fields with grandparents.\n");
 
-    const auto parent_lt = get_layout_type(parent->get_identifier().get_layout().tags());
+    const auto parent_lt = parent->get_identifier().get_layout().type();
 
     EKAT_REQUIRE_MSG(parent_lt==LayoutType::Vector3D,
                      "Error! SurfaceCoupling expects all subfields to have parents "

--- a/components/eamxx/src/diagnostics/aodvis.cpp
+++ b/components/eamxx/src/diagnostics/aodvis.cpp
@@ -23,9 +23,8 @@ void AODVis::set_grids(
   m_nlevs = grid->get_num_vertical_levels();
 
   // Define layouts we need (both inputs and outputs)
-  FieldLayout scalar3d_swband_layout{{COL, SWBND, LEV},
-                                     {m_ncols, m_swbands, m_nlevs}};
-  FieldLayout scalar1d_layout{{COL}, {m_ncols}};
+  FieldLayout scalar3d_swband_layout = grid->get_3d_vector_layout(true,m_swbands,"swband");
+  FieldLayout scalar1d_layout        = grid->get_2d_scalar_layout();
 
   // The fields required for this diagnostic to be computed
   add_field<Required>("aero_tau_sw", scalar3d_swband_layout, nondim, grid_name);

--- a/components/eamxx/src/diagnostics/field_at_height.cpp
+++ b/components/eamxx/src/diagnostics/field_at_height.cpp
@@ -100,7 +100,7 @@ initialize_impl (const RunType /*run_type*/)
   m_z_suffix = tag==LEV ? "_mid" : "_int";
 
   // All good, create the diag output
-  FieldIdentifier d_fid (m_diag_name,layout.strip_dim(tag),fid.get_units(),fid.get_grid_name());
+  FieldIdentifier d_fid (m_diag_name,layout.clone().strip_dim(tag),fid.get_units(),fid.get_grid_name());
   m_diagnostic_output = Field(d_fid);
   m_diagnostic_output.allocate_view();
 

--- a/components/eamxx/src/diagnostics/field_at_height.cpp
+++ b/components/eamxx/src/diagnostics/field_at_height.cpp
@@ -89,12 +89,12 @@ initialize_impl (const RunType /*run_type*/)
   EKAT_REQUIRE_MSG (layout.rank()>=2 && layout.rank()<=3,
       "Error! Field rank not supported by FieldAtHeight.\n"
       " - field name: " + fid.name() + "\n"
-      " - field layout: " + to_string(layout) + "\n");
+      " - field layout: " + layout.to_string() + "\n");
   const auto tag = layout.tags().back();
   EKAT_REQUIRE_MSG (tag==LEV || tag==ILEV,
       "Error! FieldAtHeight diagnostic expects a layout ending with 'LEV'/'ILEV' tag.\n"
       " - field name  : " + fid.name() + "\n"
-      " - field layout: " + to_string(layout) + "\n");
+      " - field layout: " + layout.to_string() + "\n");
 
   // Figure out the z value
   m_z_suffix = tag==LEV ? "_mid" : "_int";

--- a/components/eamxx/src/diagnostics/field_at_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_level.cpp
@@ -33,12 +33,12 @@ initialize_impl (const RunType /*run_type*/)
   EKAT_REQUIRE_MSG (layout.rank()>1 && layout.rank()<=6,
       "Error! Field rank not supported by FieldAtLevel.\n"
       " - field name: " + fid.name() + "\n"
-      " - field layout: " + to_string(layout) + "\n");
+      " - field layout: " + layout.to_string() + "\n");
   const auto tag = layout.tags().back();
   EKAT_REQUIRE_MSG (tag==LEV || tag==ILEV,
       "Error! FieldAtLevel diagnostic expects a layout ending with 'LEV'/'ILEV' tag.\n"
       " - field name  : " + fid.name() + "\n"
-      " - field layout: " + to_string(layout) + "\n");
+      " - field layout: " + layout.to_string() + "\n");
 
   // Figure out the level
   const auto& location = m_params.get<std::string>("vertical_location");

--- a/components/eamxx/src/diagnostics/field_at_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_level.cpp
@@ -65,7 +65,7 @@ initialize_impl (const RunType /*run_type*/)
   }
 
   // All good, create the diag output
-  FieldIdentifier d_fid (m_diag_name,layout.strip_dim(tag),fid.get_units(),fid.get_grid_name());
+  FieldIdentifier d_fid (m_diag_name,layout.clone().strip_dim(tag),fid.get_units(),fid.get_grid_name());
   m_diagnostic_output = Field(d_fid);
   m_diagnostic_output.allocate_view();
 

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
@@ -74,7 +74,7 @@ initialize_impl (const RunType /*run_type*/)
       " - field layout: " + to_string(layout) + "\n");
 
   // All good, create the diag output
-  FieldIdentifier d_fid (m_diag_name,layout.strip_dim(tag),fid.get_units(),fid.get_grid_name());
+  FieldIdentifier d_fid (m_diag_name,layout.clone().strip_dim(tag),fid.get_units(),fid.get_grid_name());
   m_diagnostic_output = Field(d_fid);
   m_diagnostic_output.allocate_view();
 

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
@@ -66,12 +66,12 @@ initialize_impl (const RunType /*run_type*/)
   EKAT_REQUIRE_MSG (layout.rank()>=2 && layout.rank()<=3,
       "Error! Field rank not supported by FieldAtPressureLevel.\n"
       " - field name: " + fid.name() + "\n"
-      " - field layout: " + to_string(layout) + "\n");
+      " - field layout: " + layout.to_string() + "\n");
   const auto tag = layout.tags().back();
   EKAT_REQUIRE_MSG (tag==LEV || tag==ILEV,
       "Error! FieldAtPressureLevel diagnostic expects a layout ending with 'LEV'/'ILEV' tag.\n"
       " - field name  : " + fid.name() + "\n"
-      " - field layout: " + to_string(layout) + "\n");
+      " - field layout: " + layout.to_string() + "\n");
 
   // All good, create the diag output
   FieldIdentifier d_fid (m_diag_name,layout.clone().strip_dim(tag),fid.get_units(),fid.get_grid_name());

--- a/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
@@ -49,7 +49,7 @@ TEST_CASE("aodvis") {
   auto grid = gm->get_grid("Physics");
 
   // Input (randomized) tau
-  FieldLayout scalar3d_swband_layout{{COL, SWBND, LEV}, {ngcols, nbnds, nlevs}};
+  FieldLayout scalar3d_swband_layout = grid->get_3d_vector_layout(true,nbnds,"swband");
   FieldIdentifier tau_fid("aero_tau_sw", scalar3d_swband_layout, nondim,
                           grid->name());
   Field tau(tau_fid);

--- a/components/eamxx/src/diagnostics/tests/wind_speed_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/wind_speed_tests.cpp
@@ -45,7 +45,7 @@ TEST_CASE("wind_speed")
   auto grid = gm->get_grid("Physics");
 
   // Input (randomized) velocity
-  auto vector3d = grid->get_3d_vector_layout(true,CMP,2);
+  auto vector3d = grid->get_3d_vector_layout(true,2);
   FieldIdentifier uv_fid ("horiz_winds",vector3d,m/s,grid->name());
   Field uv(uv_fid);
   uv.allocate_view();

--- a/components/eamxx/src/diagnostics/vapor_flux.cpp
+++ b/components/eamxx/src/diagnostics/vapor_flux.cpp
@@ -49,7 +49,7 @@ void VaporFluxDiagnostic::set_grids(const std::shared_ptr<const GridsManager> gr
 
   auto scalar2d = grid->get_2d_scalar_layout();
   auto scalar3d = grid->get_3d_scalar_layout(true);
-  auto vector3d = grid->get_3d_vector_layout(true,CMP,2);
+  auto vector3d = grid->get_3d_vector_layout(true,2);
 
   // The fields required for this diagnostic to be computed
   add_field<Required>("pseudo_density", scalar3d, Pa,  grid_name);

--- a/components/eamxx/src/diagnostics/wind_speed.cpp
+++ b/components/eamxx/src/diagnostics/wind_speed.cpp
@@ -25,7 +25,7 @@ set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   m_nlevs = grid->get_num_vertical_levels();
 
   auto scalar3d = grid->get_3d_scalar_layout(true);
-  auto vector3d = grid->get_3d_vector_layout(true,CMP,2);
+  auto vector3d = grid->get_3d_vector_layout(true,2);
 
   // The fields required for this diagnostic to be computed
   add_field<Required>("horiz_winds", vector3d, Pa, grid_name);

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -769,7 +769,7 @@ create_helper_field (const std::string& name,
   using namespace ekat::units;
   FieldIdentifier id(name,FieldLayout{tags,dims},Units::nondimensional(),grid);
 
-  const auto lt = get_layout_type(id.get_layout().tags());
+  const auto lt = id.get_layout().type();
 
   // Only request packed field for 3d quantities
   int pack_size = 1;

--- a/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
+++ b/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
@@ -68,7 +68,7 @@ create_src_layout (const FieldLayout& tgt_layout) const {
 
   EKAT_REQUIRE_MSG (is_valid_tgt_layout(tgt_layout),
       "[PhysicsDynamicsRemapper] Error! Input target layout is not valid for this remapper.\n"
-      " - input layout: " + to_string(tgt_layout));
+      " - input layout: " + tgt_layout.to_string());
 
   auto tags = tgt_layout.tags();
   auto dims = tgt_layout.dims();
@@ -102,7 +102,7 @@ create_tgt_layout (const FieldLayout& src_layout) const {
 
   EKAT_REQUIRE_MSG (is_valid_src_layout(src_layout),
       "[PhysicsDynamicsRemapper] Error! Input source layout is not valid for this remapper.\n"
-      " - input layout: " + to_string(src_layout));
+      " - input layout: " + src_layout.to_string());
 
   auto tags = src_layout.tags();
   auto dims = src_layout.dims();

--- a/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
+++ b/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
@@ -112,7 +112,7 @@ create_tgt_layout (const FieldLayout& src_layout) const {
   dims[0] = this->m_tgt_grid->get_num_local_dofs() / (HOMMEXX_NP*HOMMEXX_NP);
 
   // For position of GP and NP, it's easier to switch between 2d and 3d
-  auto lt = get_layout_type(src_layout.tags());
+  auto lt = src_layout.type();
   switch (lt) {
     case LayoutType::Scalar2D:
     case LayoutType::Vector2D:
@@ -260,7 +260,7 @@ initialize_device_variables()
 
     const auto& pl = ph.get_identifier().get_layout();
 
-    auto lt = get_layout_type(pl.tags());
+    auto lt = pl.type();
     h_layout(i) = etoi(lt);
 
     const bool is_field_3d = lt==LayoutType::Scalar3D || lt==LayoutType::Vector3D;
@@ -478,7 +478,7 @@ setup_boundary_exchange () {
   int num_3d_int = 0;
   for (int i=0; i<this->m_num_fields; ++i) {
     const auto& layout = m_dyn_fields[i].get_header().get_identifier().get_layout();
-    const auto lt = get_layout_type(layout.tags());
+    const auto lt = layout.type();
     switch (lt) {
       case LayoutType::Scalar2D:
         ++num_2d;
@@ -528,7 +528,7 @@ setup_boundary_exchange () {
   for (int i=0; i<this->m_num_fields; ++i) {
     const auto& layout = m_dyn_fields[i].get_header().get_identifier().get_layout();
     const auto& dims = layout.dims();
-    const auto lt = get_layout_type(layout.tags());
+    const auto lt = layout.type();
     switch (lt) {
       case LayoutType::Scalar2D:
         m_be->register_field(getHommeView<Real*[NP][NP]>(m_dyn_fields[i]));

--- a/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -46,7 +46,7 @@ public:
 
   bool compatible_layouts (const layout_type& src,
                            const layout_type& tgt) const override {
-    return get_layout_type(src.tags())==get_layout_type(tgt.tags());
+    return src.type()==tgt.type();
   }
 
 protected:

--- a/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -37,8 +37,6 @@ TEST_CASE("dyn_grid_io")
 {
   using namespace scream;
   using namespace ShortFieldTagsNames;
-  constexpr int np  = HOMMEXX_NP;
-  constexpr int nlev = HOMMEXX_NUM_PHYSICAL_LEV;
 
   ekat::Comm comm(MPI_COMM_WORLD);  // MPI communicator group used for I/O set as ekat object.
 
@@ -68,28 +66,26 @@ TEST_CASE("dyn_grid_io")
   auto phys_grid = gm->get_grid("Physics GLL");
 
   // Local counters
-  const int nelems = get_num_local_elems_f90();
-  const int ncols  = phys_grid->get_num_local_dofs();
-  EKAT_REQUIRE_MSG(ncols>0, "Internal test error! Fix dyn_grid_io, please.\n");
-  EKAT_REQUIRE_MSG(nelems>0, "Internal test error! Fix dyn_grid_io, please.\n");
+  EKAT_REQUIRE_MSG(phys_grid->get_num_local_dofs()>0, "Internal test error! Fix dyn_grid_io, please.\n");
+  EKAT_REQUIRE_MSG(get_num_local_elems_f90()>0, "Internal test error! Fix dyn_grid_io, please.\n");
 
   // Create physics and dynamics Fields
-  FieldLayout layout_dyn_1({EL,GP,GP,LEV},{nelems,np,np,nlev});
-  FieldLayout layout_dyn_2({EL,CMP,GP,GP,LEV},{nelems,2,np,np,nlev});
-  FieldLayout layout_dyn_3({EL,GP,GP},{nelems,np,np});
+  auto dyn_scalar3d_mid = dyn_grid->get_3d_scalar_layout(true);
+  auto dyn_vector3d_mid = dyn_grid->get_3d_vector_layout(true,2);
+  auto dyn_scalar2d     = dyn_grid->get_2d_scalar_layout();
 
-  FieldLayout layout_phys_1({COL,LEV},{ncols,nlev});
-  FieldLayout layout_phys_2({COL,CMP,LEV},{ncols,2,nlev});
-  FieldLayout layout_phys_3({COL},{ncols});
+  auto phys_scalar3d_mid = phys_grid->get_3d_scalar_layout(true);
+  auto phys_vector3d_mid = phys_grid->get_3d_vector_layout(true,2);
+  auto phys_scalar2d     = phys_grid->get_2d_scalar_layout();
 
   auto nondim = ekat::units::Units::nondimensional();
-  FieldIdentifier fid_dyn_1 ("field_1",layout_dyn_1,nondim,dyn_grid->name());
-  FieldIdentifier fid_dyn_2 ("field_2",layout_dyn_2,nondim,dyn_grid->name());
-  FieldIdentifier fid_dyn_3 ("field_3",layout_dyn_3,nondim,dyn_grid->name());
+  FieldIdentifier fid_dyn_1 ("field_1",dyn_scalar3d_mid,nondim,dyn_grid->name());
+  FieldIdentifier fid_dyn_2 ("field_2",dyn_vector3d_mid,nondim,dyn_grid->name());
+  FieldIdentifier fid_dyn_3 ("field_3",dyn_scalar2d    ,nondim,dyn_grid->name());
 
-  FieldIdentifier fid_phys_1 ("field_1",layout_phys_1,nondim,phys_grid->name());
-  FieldIdentifier fid_phys_2 ("field_2",layout_phys_2,nondim,phys_grid->name());
-  FieldIdentifier fid_phys_3 ("field_3",layout_phys_3,nondim,phys_grid->name());
+  FieldIdentifier fid_phys_1 ("field_1",phys_scalar3d_mid,nondim,phys_grid->name());
+  FieldIdentifier fid_phys_2 ("field_2",phys_vector3d_mid,nondim,phys_grid->name());
+  FieldIdentifier fid_phys_3 ("field_3",phys_scalar2d    ,nondim,phys_grid->name());
 
   // The starting FM
   auto fm_dyn = std::make_shared<FieldManager> (dyn_grid);

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -50,41 +50,42 @@ void Cosp::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   // Define the different field layouts that will be used for this process
 
   // Layout for 3D (2d horiz X 1d vertical) variable defined at mid-level and interfaces 
-  FieldLayout scalar2d_layout     { {COL},      {m_num_cols}              };
-  FieldLayout scalar3d_layout_mid { {COL,LEV},  {m_num_cols,m_num_levs}   };
-  FieldLayout scalar3d_layout_int { {COL,ILEV}, {m_num_cols,m_num_levs+1} };
-  FieldLayout scalar4d_layout_ctptau { {COL,ISCCPTAU,ISCCPPRS}, {m_num_cols,m_num_isccptau,m_num_isccpctp} };
+  FieldLayout scalar2d     = m_grid->get_2d_scalar_layout();
+  FieldLayout scalar3d_mid = m_grid->get_3d_scalar_layout(true);
+  FieldLayout scalar3d_int = m_grid->get_3d_scalar_layout(false);
+  FieldLayout scalar4d_ctptau ( {COL,CMP,CMP},
+                                {m_num_cols,m_num_isccptau,m_num_isccpctp},
+                                {e2str(COL), "ISCCPTAU", "ISCCPPRS"});
 
   // Set of fields used strictly as input
   //                  Name in AD     Layout               Units   Grid       Group
-  add_field<Required>("surf_radiative_T", scalar2d_layout    , K,      grid_name);
-  //add_field<Required>("surfelev",    scalar2d_layout    , m,      grid_name);
-  //add_field<Required>("landmask",    scalar2d_layout    , nondim, grid_name);
-  add_field<Required>("sunlit",           scalar2d_layout    , nondim, grid_name);
-  add_field<Required>("p_mid",             scalar3d_layout_mid, Pa,     grid_name);
-  add_field<Required>("p_int",             scalar3d_layout_int, Pa,     grid_name);
-  //add_field<Required>("height_mid",  scalar3d_layout_mid, m,      grid_name);
-  //add_field<Required>("height_int",  scalar3d_layout_int, m,      grid_name);
-  add_field<Required>("T_mid",            scalar3d_layout_mid, K,      grid_name);
-  add_field<Required>("qv",               scalar3d_layout_mid, Q,      grid_name, "tracers");
-  add_field<Required>("qc",               scalar3d_layout_mid, Q,      grid_name, "tracers");
-  add_field<Required>("qi",               scalar3d_layout_mid, Q,      grid_name, "tracers");
-  add_field<Required>("cldfrac_rad",      scalar3d_layout_mid, nondim, grid_name);
+  add_field<Required>("surf_radiative_T", scalar2d    , K,      grid_name);
+  //add_field<Required>("surfelev",    scalar2d    , m,      grid_name);
+  //add_field<Required>("landmask",    scalar2d    , nondim, grid_name);
+  add_field<Required>("sunlit",           scalar2d    , nondim, grid_name);
+  add_field<Required>("p_mid",             scalar3d_mid, Pa,     grid_name);
+  add_field<Required>("p_int",             scalar3d_int, Pa,     grid_name);
+  //add_field<Required>("height_mid",  scalar3d_mid, m,      grid_name);
+  //add_field<Required>("height_int",  scalar3d_int, m,      grid_name);
+  add_field<Required>("T_mid",            scalar3d_mid, K,      grid_name);
+  add_field<Required>("qv",               scalar3d_mid, Q,      grid_name, "tracers");
+  add_field<Required>("qc",               scalar3d_mid, Q,      grid_name, "tracers");
+  add_field<Required>("qi",               scalar3d_mid, Q,      grid_name, "tracers");
+  add_field<Required>("cldfrac_rad",      scalar3d_mid, nondim, grid_name);
   // Optical properties, should be computed in radiation interface
-  add_field<Required>("dtau067",     scalar3d_layout_mid, nondim, grid_name); // 0.67 micron optical depth
-  add_field<Required>("dtau105",     scalar3d_layout_mid, nondim, grid_name); // 10.5 micron optical depth
+  add_field<Required>("dtau067",     scalar3d_mid, nondim, grid_name); // 0.67 micron optical depth
+  add_field<Required>("dtau105",     scalar3d_mid, nondim, grid_name); // 10.5 micron optical depth
   // Effective radii, should be computed in either microphysics or radiation interface
   // TODO: should these be meters or microns? Was meters before, but using "m" instead
   // of "micron" seemed to cause prim_model_finalize to throw error with the following:
   // ABORTING WITH ERROR: Error! prim_init_model_f90 was not called yet (or prim_finalize_f90 was already called).
   // P3 defines this field with micron instead of meters units, so is this a unit conversion issue?
-  add_field<Required>("eff_radius_qc",     scalar3d_layout_mid, micron,      grid_name);
-  add_field<Required>("eff_radius_qi",     scalar3d_layout_mid, micron,      grid_name);
+  add_field<Required>("eff_radius_qc",     scalar3d_mid, micron,      grid_name);
+  add_field<Required>("eff_radius_qi",     scalar3d_mid, micron,      grid_name);
   // Set of fields used strictly as output
-  add_field<Computed>("isccp_cldtot", scalar2d_layout, percent, grid_name);
-  add_field<Computed>("isccp_ctptau", scalar4d_layout_ctptau, percent, grid_name, 1);
-  add_field<Computed>("isccp_mask"  , scalar2d_layout, nondim, grid_name);
-
+  add_field<Computed>("isccp_cldtot", scalar2d, percent, grid_name);
+  add_field<Computed>("isccp_ctptau", scalar4d_ctptau, percent, grid_name, 1);
+  add_field<Computed>("isccp_mask"  , scalar2d, nondim, grid_name);
 }
 
 // =========================================================================================

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -223,9 +223,6 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
   dry_atm_.w_updraft = buffer_.w_updraft;
   dry_atm_.z_surf = 0.0; // FIXME: for now
 
-  const auto& tracers = get_group_out("tracers");
-  const auto& tracers_info = tracers.m_info;
-
   // perform any initialization work
   if (run_type==RunType::Initial) {
   }
@@ -324,7 +321,6 @@ void MAMMicrophysics::run_impl(const double dt) {
     // fetch column-specific atmosphere state data
     auto atm = mam_coupling::atmosphere_for_column(dry_atm_, icol);
     auto z_iface = ekat::subview(dry_atm_.z_iface, icol);
-    Real z_surf = dry_atm_.z_surf;
     Real phis = dry_atm_.phis(icol);
 
     // set surface state data
@@ -365,7 +361,6 @@ void MAMMicrophysics::run_impl(const double dt) {
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev_), [&](const int k) {
 
       constexpr int num_modes = mam4::AeroConfig::num_modes();
-      constexpr int num_aero_ids = mam4::AeroConfig::num_aerosol_ids();
       constexpr int gas_pcnst = mam_coupling::gas_pcnst();
       constexpr int nqtendbb = mam_coupling::nqtendbb();
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -38,7 +38,6 @@ void MAMOptics::set_grids(
   nlwbands_ = mam4::modal_aer_opt::nlwbands;     // number of longwave bands
 
   // Define the different field layouts that will be used for this process
-  using namespace ShortFieldTagsNames;
 
   // Define aerosol optics fields computed by this process.
   auto nondim = Units::nondimensional();

--- a/components/eamxx/src/physics/mam/impl/compute_o3_column_density.cpp
+++ b/components/eamxx/src/physics/mam/impl/compute_o3_column_density.cpp
@@ -3,19 +3,18 @@ namespace scream::impl {
 KOKKOS_INLINE_FUNCTION
 void compute_o3_column_density(const ThreadTeam& team, const haero::Atmosphere& atm,
                                const mam4::Prognostics &progs, ColumnView o3_col_dens) {
-  constexpr int nabscol = mam4::gas_chemistry::nabscol;     // number of absorbing densities
   constexpr int gas_pcnst = mam4::gas_chemistry::gas_pcnst; // number of gas phase species
   constexpr int nfs = mam4::gas_chemistry::nfs;             // number of "fixed species"
-  constexpr Real mwdry = 1.0/haero::Constants::molec_weight_dry_air;
+  // constexpr Real mwdry = 1.0/haero::Constants::molec_weight_dry_air;
 
   Real o3_col_deltas[mam4::nlev+1] = {}; // o3 column density above model [1/cm^2]
   // NOTE: if we need o2 column densities, set_ub_col and setcol must be changed
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, atm.num_levels()), [&](const int k) {
 
-    Real temp = atm.temperature(k);
-    Real pmid = atm.pressure(k);
+    // Real temp = atm.temperature(k);
+    // Real pmid = atm.pressure(k);
     Real pdel = atm.hydrostatic_dp(k);
-    Real qv   = atm.vapor_mixing_ratio(k);
+    // Real qv   = atm.vapor_mixing_ratio(k);
 
     // ... map incoming mass mixing ratios to working array
     Real q[gas_pcnst], qqcw[gas_pcnst];
@@ -23,8 +22,8 @@ void compute_o3_column_density(const ThreadTeam& team, const haero::Atmosphere& 
 
     // ... set atmosphere mean mass to the molecular weight of dry air
     //     and compute water vapor vmr
-    Real mbar = mwdry;
-    Real h2ovmr = mam4::conversions::vmr_from_mmr(qv, mbar);
+    // Real mbar = mwdry;
+    // Real h2ovmr = mam4::conversions::vmr_from_mmr(qv, mbar);
 
     // ... Xform from mmr to vmr
     Real vmr[gas_pcnst], vmrcw[gas_pcnst];

--- a/components/eamxx/src/physics/mam/impl/gas_phase_chemistry.cpp
+++ b/components/eamxx/src/physics/mam/impl/gas_phase_chemistry.cpp
@@ -265,14 +265,13 @@ void gas_phase_chemistry(Real zm, Real zi, Real phis, Real temp, Real pmid, Real
                          const Real extfrc[mam4::gas_chemistry::extcnt], // in
                          Real q[mam4::gas_chemistry::gas_pcnst], // VMRs, inout
                          Real invariants[mam4::gas_chemistry::nfs]) { // out
-  constexpr Real rga = 1.0/haero::Constants::gravity;
-  constexpr Real m2km = 0.01; // converts m -> km
+  // constexpr Real rga = 1.0/haero::Constants::gravity;
+  // constexpr Real m2km = 0.01; // converts m -> km
 
   // The following things are chemical mechanism dependent! See mam4xx/src/mam4xx/gas_chem_mechanism.hpp)
   constexpr int gas_pcnst = mam4::gas_chemistry::gas_pcnst; // number of gas phase species
   constexpr int rxntot = mam4::gas_chemistry::rxntot;       // number of chemical reactions
   constexpr int extcnt = mam4::gas_chemistry::extcnt;       // number of species with external forcing
-  constexpr int nabscol = mam4::gas_chemistry::nabscol;     // number of "absorbing column densities"
   constexpr int indexm = 0;  // FIXME: index of total atm density in invariants array
 
   constexpr int phtcnt = mam4::mo_photo::phtcnt; // number of photolysis reactions
@@ -296,7 +295,6 @@ void gas_phase_chemistry(Real zm, Real zi, Real phis, Real temp, Real pmid, Real
   //                         "so4_a3", "bc_a3", "pom_a3", "soa_a3", "mom_a3",
   //                         "num_a3", "pom_a4", "bc_a4", "mom_a4", "num_a4"};
   constexpr int ndx_h2so4 = 2;
-  constexpr int o3_ndx = 0;
   // std::string extfrc_list[] = {"SO2", "so4_a1", "so4_a2", "pom_a4", "bc_a4",
   //                              "num_a1", "num_a2", "num_a3", "num_a4", "SOAG"};
   constexpr int synoz_ndx = -1;
@@ -305,16 +303,13 @@ void gas_phase_chemistry(Real zm, Real zi, Real phis, Real temp, Real pmid, Real
   // FIXME: For now, we fix the zenith angle. At length, we need to compute it
   // FIXME: from EAMxx's current set of orbital parameters, which requires some
   // FIXME: conversation with the EAMxx team.
-  Real zen_angle = 0.0; // [deg]
 
   // xform geopotential height from m to km and pressure from Pa to mb
-  Real zsurf = rga * phis;
-  Real zintr = m2km * zi;
-  Real zmid = m2km * (zm + zsurf);
-  Real zint = m2km * (zi + zsurf);
+  // Real zsurf = rga * phis;
+  // Real zmid = m2km * (zm + zsurf);
 
   // ... compute the column's invariants
-  Real h2ovmr = q[0];
+  // Real h2ovmr = q[0];
   // setinv(invariants, temp, h2ovmr, q, pmid); FIXME: not ported yet
 
   // ... set rates for "tabular" and user specified reactions
@@ -349,7 +344,6 @@ void gas_phase_chemistry(Real zm, Real zi, Real phis, Real temp, Real pmid, Real
   //sethet(het_rates, pmid, zmid, phis, temp, cmfdqr, prain, nevapr, delt,
   //       invariants[indexm], q);
 
-  int ltrop_sol = 0; // apply solver to all levels
 
   // save h2so4 before gas phase chem (for later new particle nucleation)
   Real del_h2so4_gasprod = q[ndx_h2so4];

--- a/components/eamxx/src/physics/mam/mam_coupling.hpp
+++ b/components/eamxx/src/physics/mam/mam_coupling.hpp
@@ -829,7 +829,6 @@ void convert_work_arrays_to_vmr(const Real q[gas_pcnst()],
       vmr[i] = mam4::conversions::vmr_from_mmr(q[i], mw);
       vmrcw[i] = mam4::conversions::vmr_from_mmr(qqcw[i], mw);
     } else {
-      int m = static_cast<int>(mode_index);
       if (aero_id != NoAero) { // constituent is an aerosol species
         int a = aerosol_index_for_mode(mode_index, aero_id);
         const Real mw = mam4::aero_species(a).molecular_weight;
@@ -862,7 +861,6 @@ void convert_work_arrays_to_mmr(const Real vmr[gas_pcnst()],
       q[i] = mam4::conversions::mmr_from_vmr(vmr[i], mw);
       qqcw[i] = mam4::conversions::mmr_from_vmr(vmrcw[i], mw);
     } else {
-      int m = static_cast<int>(mode_index);
       if (aero_id != NoAero) { // constituent is an aerosol species
         int a = aerosol_index_for_mode(mode_index, aero_id);
         const Real mw = mam4::aero_species(a).molecular_weight;
@@ -901,7 +899,6 @@ void transfer_work_arrays_to_prognostics(const Real q[gas_pcnst()],
         progs.q_aero_i[m][a](k) = q[i];
         progs.q_aero_c[m][a](k) = qqcw[i];
       } else { // constituent is a modal number mixing ratio
-        int m = static_cast<int>(mode_index);
         progs.n_mode_i[m](k) = q[i];
         progs.n_mode_c[m](k) = qqcw[i];
       }

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -35,20 +35,20 @@ void MLCorrection::set_grids(
 
   // Layout for 3D (2d horiz X 1d vertical) variable defined at mid-level and
   // interfaces
-  FieldLayout scalar2d_layout{ {COL}, {m_num_cols}};
-  FieldLayout scalar3d_layout_mid{{COL, LEV}, {m_num_cols, m_num_levs}};
-  FieldLayout scalar3d_layout_int{{COL, ILEV}, {m_num_cols, m_num_levs+1}};
-  FieldLayout horiz_wind_layout { {COL,CMP,LEV}, {m_num_cols,2,m_num_levs} };
+  FieldLayout scalar2d     = m_grid->get_2d_scalar_layout();
+  FieldLayout scalar3d_mid = m_grid->get_3d_scalar_layout_mid();
+  FieldLayout scalar3d_int = m_grid->get_3d_scalar_layout_int();
+  FieldLayout vector3d_mid = m_grid->get_3d_vector_layout_mid(2);
   if (not m_ML_correction_unit_test) {
     const auto m2 = m*m;
     const auto s2 = s*s;
     auto Wm2 = W / m / m;
     auto nondim = m/m;
-    add_field<Required>("phis", scalar2d_layout, m2/s2, grid_name);
-    add_field<Updated>("SW_flux_dn", scalar3d_layout_int, Wm2, grid_name, ps);
-    add_field<Required>("sfc_alb_dif_vis", scalar2d_layout, nondim, grid_name);
-    add_field<Updated>("sfc_flux_sw_net", scalar2d_layout, Wm2, grid_name);
-    add_field<Updated>("sfc_flux_lw_dn", scalar2d_layout, Wm2, grid_name);
+    add_field<Required>("phis", scalar2d, m2/s2, grid_name);
+    add_field<Updated>("SW_flux_dn", scalar3d_int, Wm2, grid_name, ps);
+    add_field<Required>("sfc_alb_dif_vis", scalar2d, nondim, grid_name);
+    add_field<Updated>("sfc_flux_sw_net", scalar2d, Wm2, grid_name);
+    add_field<Updated>("sfc_flux_lw_dn", scalar2d, Wm2, grid_name);
     m_lat  = m_grid->get_geometry_data("lat");
     m_lon  = m_grid->get_geometry_data("lon");      
   }
@@ -59,9 +59,9 @@ void MLCorrection::set_grids(
    * is adapting the infrastructure to allow for a generic "add_field" call
    * to be used here which we can then setup using the m_fields_ml_output_variables variable
    */
-  add_field<Updated>("T_mid", scalar3d_layout_mid, K, grid_name, ps);
-  add_field<Updated>("qv",    scalar3d_layout_mid, Q, grid_name, "tracers", ps);
-  add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,     grid_name, ps);
+  add_field<Updated>("T_mid",       scalar3d_mid, K,   grid_name, ps);
+  add_field<Updated>("qv",          scalar3d_mid, Q,   grid_name, "tracers", ps);
+  add_field<Updated>("horiz_winds", vector3d_mid, m/s, grid_name, ps);
   /* ----------------------- WARNING --------------------------------*/
   add_group<Updated>("tracers", grid_name, 1, Bundling::Required);
 }

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -64,8 +64,8 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   m_num_cols = m_grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = m_grid->get_num_vertical_levels();  // Number of levels per column
 
-  FieldLayout scalar3d_layout_mid = m_grid->get_3d_scalar_layout_mid();
-  FieldLayout horiz_wind_layout = m_grid->get_3d_vector_layout_mid(2);
+  FieldLayout scalar3d_layout_mid = m_grid->get_3d_scalar_layout(true);
+  FieldLayout horiz_wind_layout = m_grid->get_3d_vector_layout(true,2);
 
   constexpr int ps = 1;
   auto Q = kg/kg;

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -58,15 +58,14 @@ Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
 void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
-  using namespace ShortFieldTagsNames;
 
   m_grid = grids_manager->get_grid("Physics");
   const auto& grid_name = m_grid->name();
   m_num_cols = m_grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = m_grid->get_num_vertical_levels();  // Number of levels per column
 
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols, m_num_levs} };
-  FieldLayout horiz_wind_layout { {COL,CMP,LEV}, {m_num_cols,2,m_num_levs} };
+  FieldLayout scalar3d_layout_mid = m_grid->get_3d_scalar_layout_mid();
+  FieldLayout horiz_wind_layout = m_grid->get_3d_vector_layout_mid(2);
 
   constexpr int ps = 1;
   auto Q = kg/kg;

--- a/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
+++ b/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
@@ -295,7 +295,7 @@ TEST_CASE("nudging_tests") {
       int ncols = fid.get_layout().dim(0);
       comm.all_reduce(&ncols,1,MPI_SUM);
 
-      FieldLayout glb_layout = fid.get_layout().clone_with_different_extent(0,ncols);
+      FieldLayout glb_layout = fid.get_layout().clone().reset_dim(0,ncols);
       FieldIdentifier glb_fid(fid.name(),glb_layout,fid.get_units(),fid.get_grid_name());
       Field glb(glb_fid);
       glb.allocate_view();

--- a/components/eamxx/src/physics/nudging/tests/nudging_tests_helpers.hpp
+++ b/components/eamxx/src/physics/nudging/tests/nudging_tests_helpers.hpp
@@ -49,7 +49,7 @@ create_fm (const std::shared_ptr<const AbstractGrid>& grid)
   const std::string& gn = grid->name();
 
   auto scalar3d = grid->get_3d_scalar_layout(true);
-  auto vector3d = grid->get_3d_vector_layout(true,CMP,2);
+  auto vector3d = grid->get_3d_vector_layout(true,2);
 
   FieldIdentifier fid1("p_mid",scalar3d,Pa,gn);
   FieldIdentifier fid2("horiz_winds",vector3d,m/s,gn);

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -54,8 +54,6 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   auto molmol = mol/mol;
   molmol.set_string("mol/mol");
 
-  using namespace ShortFieldTagsNames;
-
   m_grid = grids_manager->get_grid("Physics");
   const auto& grid_name = m_grid->name();
   m_ncol = m_grid->get_num_local_dofs();
@@ -78,49 +76,49 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   // Set up dimension layouts
   m_nswgpts = m_params.get<int>("nswgpts",112);
   m_nlwgpts = m_params.get<int>("nlwgpts",128);
-  FieldLayout scalar2d_layout     { {COL   }, {m_ncol    } };
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_ncol,m_nlay} };
-  FieldLayout scalar3d_layout_int { {COL,ILEV}, {m_ncol,m_nlay+1} };
-  FieldLayout scalar3d_swband_layout { {COL,SWBND,LEV}, {m_ncol, m_nswbands, m_nlay} };
-  FieldLayout scalar3d_lwband_layout { {COL,LWBND,LEV}, {m_ncol, m_nlwbands, m_nlay} };
-  FieldLayout scalar3d_swgpts_layout { {COL,SWGPT,LEV}, {m_ncol, m_nswgpts, m_nlay} };
-  FieldLayout scalar3d_lwgpts_layout { {COL,LWGPT,LEV}, {m_ncol, m_nlwgpts, m_nlay} };
+  FieldLayout scalar2d = m_grid->get_2d_scalar_layout();
+  FieldLayout scalar3d_mid = m_grid->get_3d_scalar_layout(true);
+  FieldLayout scalar3d_int = m_grid->get_3d_scalar_layout(false);
+  FieldLayout scalar3d_swband = m_grid->get_3d_vector_layout(true,m_nswbands,"swband");
+  FieldLayout scalar3d_lwband = m_grid->get_3d_vector_layout(true,m_nlwbands,"lwband");
+  FieldLayout scalar3d_swgpts = m_grid->get_3d_vector_layout(true,m_nswgpts,"swgpt");
+  FieldLayout scalar3d_lwgpts = m_grid->get_3d_vector_layout(true,m_nlwgpts,"lwgpt");
 
   // Set required (input) fields here
-  add_field<Required>("p_mid" , scalar3d_layout_mid, Pa, grid_name);
-  add_field<Required>("p_int", scalar3d_layout_int, Pa, grid_name);
-  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa, grid_name);
-  add_field<Required>("sfc_alb_dir_vis", scalar2d_layout, nondim, grid_name);
-  add_field<Required>("sfc_alb_dir_nir", scalar2d_layout, nondim, grid_name);
-  add_field<Required>("sfc_alb_dif_vis", scalar2d_layout, nondim, grid_name);
-  add_field<Required>("sfc_alb_dif_nir", scalar2d_layout, nondim, grid_name);
-  add_field<Required>("qc", scalar3d_layout_mid, kgkg, grid_name);
-  add_field<Required>("nc", scalar3d_layout_mid, 1/kg, grid_name);
-  add_field<Required>("qi", scalar3d_layout_mid, kgkg, grid_name);
-  add_field<Required>("cldfrac_tot", scalar3d_layout_mid, nondim, grid_name);
-  add_field<Required>("eff_radius_qc", scalar3d_layout_mid, micron, grid_name);
-  add_field<Required>("eff_radius_qi", scalar3d_layout_mid, micron, grid_name);
-  add_field<Required>("qv",scalar3d_layout_mid,kgkg,grid_name);
-  add_field<Required>("surf_lw_flux_up",scalar2d_layout,W/(m*m),grid_name);
+  add_field<Required>("p_mid" , scalar3d_mid, Pa, grid_name);
+  add_field<Required>("p_int", scalar3d_int, Pa, grid_name);
+  add_field<Required>("pseudo_density", scalar3d_mid, Pa, grid_name);
+  add_field<Required>("sfc_alb_dir_vis", scalar2d, nondim, grid_name);
+  add_field<Required>("sfc_alb_dir_nir", scalar2d, nondim, grid_name);
+  add_field<Required>("sfc_alb_dif_vis", scalar2d, nondim, grid_name);
+  add_field<Required>("sfc_alb_dif_nir", scalar2d, nondim, grid_name);
+  add_field<Required>("qc", scalar3d_mid, kgkg, grid_name);
+  add_field<Required>("nc", scalar3d_mid, 1/kg, grid_name);
+  add_field<Required>("qi", scalar3d_mid, kgkg, grid_name);
+  add_field<Required>("cldfrac_tot", scalar3d_mid, nondim, grid_name);
+  add_field<Required>("eff_radius_qc", scalar3d_mid, micron, grid_name);
+  add_field<Required>("eff_radius_qi", scalar3d_mid, micron, grid_name);
+  add_field<Required>("qv",scalar3d_mid,kgkg,grid_name);
+  add_field<Required>("surf_lw_flux_up",scalar2d,W/(m*m),grid_name);
   // Set of required gas concentration fields
   for (auto& it : m_gas_names) {
     // Add gas VOLUME mixing ratios (moles of gas / moles of air; what actually gets input to RRTMGP)
     if (it == "o3") {
       // o3 is read from file, or computed by chemistry
-      add_field<Required>(it + "_volume_mix_ratio", scalar3d_layout_mid, molmol, grid_name);
+      add_field<Required>(it + "_volume_mix_ratio", scalar3d_mid, molmol, grid_name);
     } else {
       // the rest are computed by RRTMGP from prescribed surface values
       // NOTE: this may change at some point
-      add_field<Computed>(it + "_volume_mix_ratio", scalar3d_layout_mid, molmol, grid_name);
+      add_field<Computed>(it + "_volume_mix_ratio", scalar3d_mid, molmol, grid_name);
     }
   }
   // Required aerosol optical properties from SPA
   m_do_aerosol_rad = m_params.get<bool>("do_aerosol_rad",true);
   if (m_do_aerosol_rad) {
-    add_field<Required>("aero_tau_sw", scalar3d_swband_layout, nondim, grid_name);
-    add_field<Required>("aero_ssa_sw", scalar3d_swband_layout, nondim, grid_name);
-    add_field<Required>("aero_g_sw"  , scalar3d_swband_layout, nondim, grid_name);
-    add_field<Required>("aero_tau_lw", scalar3d_lwband_layout, nondim, grid_name);
+    add_field<Required>("aero_tau_sw", scalar3d_swband, nondim, grid_name);
+    add_field<Required>("aero_ssa_sw", scalar3d_swband, nondim, grid_name);
+    add_field<Required>("aero_g_sw"  , scalar3d_swband, nondim, grid_name);
+    add_field<Required>("aero_tau_lw", scalar3d_lwband, nondim, grid_name);
   }
 
   // Whether we do extra clean/clear sky calculations
@@ -128,47 +126,47 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   m_extra_clnsky_diag    = m_params.get<bool>("extra_clnsky_diag", false);
 
   // Set computed (output) fields
-  add_field<Updated >("T_mid"     , scalar3d_layout_mid, K  , grid_name);
-  add_field<Computed>("SW_flux_dn", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("SW_flux_up", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("SW_flux_dn_dir", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("LW_flux_up", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("LW_flux_dn", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnclrsky_flux_dn", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnclrsky_flux_up", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnclrsky_flux_dn_dir", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("SW_clrsky_flux_dn", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("SW_clrsky_flux_up", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("SW_clrsky_flux_dn_dir", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnsky_flux_dn", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnsky_flux_up", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnsky_flux_dn_dir", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("LW_clnclrsky_flux_up", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("LW_clnclrsky_flux_dn", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("LW_clrsky_flux_up", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("LW_clrsky_flux_dn", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("LW_clnsky_flux_up", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("LW_clnsky_flux_dn", scalar3d_layout_int, Wm2, grid_name);
-  add_field<Computed>("rad_heating_pdel", scalar3d_layout_mid, Pa*K/s, grid_name);
+  add_field<Updated >("T_mid"     , scalar3d_mid, K  , grid_name);
+  add_field<Computed>("SW_flux_dn", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_flux_up", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_flux_dn_dir", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("LW_flux_up", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("LW_flux_dn", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_clnclrsky_flux_dn", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_clnclrsky_flux_up", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_clnclrsky_flux_dn_dir", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_clrsky_flux_dn", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_clrsky_flux_up", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_clrsky_flux_dn_dir", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_clnsky_flux_dn", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_clnsky_flux_up", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_clnsky_flux_dn_dir", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("LW_clnclrsky_flux_up", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("LW_clnclrsky_flux_dn", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("LW_clrsky_flux_up", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("LW_clrsky_flux_dn", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("LW_clnsky_flux_up", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("LW_clnsky_flux_dn", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("rad_heating_pdel", scalar3d_mid, Pa*K/s, grid_name);
   // Cloud properties added as computed fields for diagnostic purposes
-  add_field<Computed>("cldlow"        , scalar2d_layout, nondim, grid_name);
-  add_field<Computed>("cldmed"        , scalar2d_layout, nondim, grid_name);
-  add_field<Computed>("cldhgh"        , scalar2d_layout, nondim, grid_name);
-  add_field<Computed>("cldtot"        , scalar2d_layout, nondim, grid_name);
+  add_field<Computed>("cldlow"        , scalar2d, nondim, grid_name);
+  add_field<Computed>("cldmed"        , scalar2d, nondim, grid_name);
+  add_field<Computed>("cldhgh"        , scalar2d, nondim, grid_name);
+  add_field<Computed>("cldtot"        , scalar2d, nondim, grid_name);
   // 0.67 micron and 10.5 micron optical depth (needed for COSP)
-  add_field<Computed>("dtau067"       , scalar3d_layout_mid, nondim, grid_name);
-  add_field<Computed>("dtau105"       , scalar3d_layout_mid, nondim, grid_name);
-  add_field<Computed>("sunlit"        , scalar2d_layout    , nondim, grid_name);
-  add_field<Computed>("cldfrac_rad"   , scalar3d_layout_mid, nondim, grid_name);
+  add_field<Computed>("dtau067"       , scalar3d_mid, nondim, grid_name);
+  add_field<Computed>("dtau105"       , scalar3d_mid, nondim, grid_name);
+  add_field<Computed>("sunlit"        , scalar2d    , nondim, grid_name);
+  add_field<Computed>("cldfrac_rad"   , scalar3d_mid, nondim, grid_name);
   // Cloud-top diagnostics following AeroCOM recommendation
-  add_field<Computed>("T_mid_at_cldtop", scalar2d_layout, K, grid_name);
-  add_field<Computed>("p_mid_at_cldtop", scalar2d_layout, Pa, grid_name);
-  add_field<Computed>("cldfrac_ice_at_cldtop", scalar2d_layout, nondim, grid_name);
-  add_field<Computed>("cldfrac_liq_at_cldtop", scalar2d_layout, nondim, grid_name);
-  add_field<Computed>("cldfrac_tot_at_cldtop", scalar2d_layout, nondim, grid_name);
-  add_field<Computed>("cdnc_at_cldtop", scalar2d_layout, 1 / (m * m * m), grid_name);
-  add_field<Computed>("eff_radius_qc_at_cldtop", scalar2d_layout, micron, grid_name);
-  add_field<Computed>("eff_radius_qi_at_cldtop", scalar2d_layout, micron, grid_name);
+  add_field<Computed>("T_mid_at_cldtop", scalar2d, K, grid_name);
+  add_field<Computed>("p_mid_at_cldtop", scalar2d, Pa, grid_name);
+  add_field<Computed>("cldfrac_ice_at_cldtop", scalar2d, nondim, grid_name);
+  add_field<Computed>("cldfrac_liq_at_cldtop", scalar2d, nondim, grid_name);
+  add_field<Computed>("cldfrac_tot_at_cldtop", scalar2d, nondim, grid_name);
+  add_field<Computed>("cdnc_at_cldtop", scalar2d, 1 / (m * m * m), grid_name);
+  add_field<Computed>("eff_radius_qc_at_cldtop", scalar2d, micron, grid_name);
+  add_field<Computed>("eff_radius_qi_at_cldtop", scalar2d, micron, grid_name);
 
   // Translation of variables from EAM
   // --------------------------------------------------------------
@@ -181,19 +179,19 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   // netsw      sfc_flux_sw_net    net (down - up) SW flux at surface
   // flwds      sfc_flux_lw_dn     downwelling LW flux at surface
   // --------------------------------------------------------------
-  add_field<Computed>("sfc_flux_dir_nir", scalar2d_layout, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_dir_vis", scalar2d_layout, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_dif_nir", scalar2d_layout, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_dif_vis", scalar2d_layout, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_sw_net" , scalar2d_layout, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_lw_dn"  , scalar2d_layout, Wm2, grid_name);
+  add_field<Computed>("sfc_flux_dir_nir", scalar2d, Wm2, grid_name);
+  add_field<Computed>("sfc_flux_dir_vis", scalar2d, Wm2, grid_name);
+  add_field<Computed>("sfc_flux_dif_nir", scalar2d, Wm2, grid_name);
+  add_field<Computed>("sfc_flux_dif_vis", scalar2d, Wm2, grid_name);
+  add_field<Computed>("sfc_flux_sw_net" , scalar2d, Wm2, grid_name);
+  add_field<Computed>("sfc_flux_lw_dn"  , scalar2d, Wm2, grid_name);
 
   // Boundary flux fields for energy and mass conservation checks
   if (has_column_conservation_check()) {
-    add_field<Computed>("vapor_flux", scalar2d_layout, kg/m2/s, grid_name);
-    add_field<Computed>("water_flux", scalar2d_layout, m/s,     grid_name);
-    add_field<Computed>("ice_flux",   scalar2d_layout, m/s,     grid_name);
-    add_field<Computed>("heat_flux",  scalar2d_layout, W/m2,    grid_name);
+    add_field<Computed>("vapor_flux", scalar2d, kg/m2/s, grid_name);
+    add_field<Computed>("water_flux", scalar2d, m/s,     grid_name);
+    add_field<Computed>("ice_flux",   scalar2d, m/s,     grid_name);
+    add_field<Computed>("heat_flux",  scalar2d, W/m2,    grid_name);
   }
 }  // RRTMGPRadiation::set_grids
 

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -36,20 +36,19 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   m_num_levs = m_grid->get_num_vertical_levels();  // Number of levels per column
 
   // Define the different field layouts that will be used for this process
-  using namespace ShortFieldTagsNames;
 
   // Layout for 2D (1d horiz X 1d vertical) variable
-  FieldLayout scalar2d_layout_col{ {COL}, {m_num_cols} };
+  FieldLayout scalar2d = m_grid->get_2d_scalar_layout();
 
   // Layout for surf_mom_flux
-  FieldLayout surf_mom_flux_layout { {COL, CMP}, {m_num_cols, 2} };
+  FieldLayout vector2d = m_grid->get_2d_vector_layout(2);
 
   // Layout for 3D (2d horiz X 1d vertical) variable defined at mid-level and interfaces
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
-  FieldLayout scalar3d_layout_int { {COL,ILEV}, {m_num_cols,m_num_levs+1} };
+  FieldLayout scalar3d_mid = m_grid->get_3d_scalar_layout(true);
+  FieldLayout scalar3d_int = m_grid->get_3d_scalar_layout(false);
 
   // Layout for horiz_wind field
-  FieldLayout horiz_wind_layout { {COL,CMP,LEV}, {m_num_cols,2,m_num_levs} };
+  FieldLayout vector3d_mid = m_grid->get_3d_vector_layout(true,2);
 
   // Define fields needed in SHOC.
   // Note: shoc_main is organized by a set of 5 structures, variables below are organized
@@ -61,46 +60,46 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   const auto s2 = s*s;
 
   // These variables are needed by the interface, but not actually passed to shoc_main.
-  add_field<Required>("omega",               scalar3d_layout_mid,  Pa/s,    grid_name, ps);
-  add_field<Required>("surf_sens_flux",      scalar2d_layout_col,  W/m2,    grid_name);
-  add_field<Required>("surf_mom_flux",       surf_mom_flux_layout, N/m2, grid_name);
+  add_field<Required>("omega",          scalar3d_mid, Pa/s, grid_name, ps);
+  add_field<Required>("surf_sens_flux", scalar2d    , W/m2, grid_name);
+  add_field<Required>("surf_mom_flux",  vector2d    , N/m2, grid_name);
 
-  add_field<Updated>("surf_evap",           scalar2d_layout_col,  kg/m2/s, grid_name);
-  add_field<Updated> ("T_mid",               scalar3d_layout_mid,  K,       grid_name, ps);
-  add_field<Updated> ("qv",                  scalar3d_layout_mid,  Qunit,   grid_name, "tracers", ps);
+  add_field<Updated>("surf_evap",       scalar2d    , kg/m2/s, grid_name);
+  add_field<Updated> ("T_mid",          scalar3d_mid, K,       grid_name, ps);
+  add_field<Updated> ("qv",             scalar3d_mid, Qunit,   grid_name, "tracers", ps);
 
   // If TMS is a process, add surface drag coefficient to required fields
   if (m_params.get<bool>("apply_tms", false)) {
-    add_field<Required>("surf_drag_coeff_tms", scalar2d_layout_col,  kg/s/m2, grid_name);
+    add_field<Required>("surf_drag_coeff_tms", scalar2d,  kg/s/m2, grid_name);
   }
 
   // Input variables
-  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,    grid_name, ps);
-  add_field<Required>("p_int",          scalar3d_layout_int, Pa,    grid_name, ps);
-  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,    grid_name, ps);
-  add_field<Required>("phis",           scalar2d_layout_col, m2/s2, grid_name, ps);
+  add_field<Required>("p_mid",          scalar3d_mid, Pa,    grid_name, ps);
+  add_field<Required>("p_int",          scalar3d_int, Pa,    grid_name, ps);
+  add_field<Required>("pseudo_density", scalar3d_mid, Pa,    grid_name, ps);
+  add_field<Required>("phis",           scalar2d    , m2/s2, grid_name, ps);
 
   // Input/Output variables
-  add_field<Updated>("tke",           scalar3d_layout_mid, m2/s2,   grid_name, "tracers", ps);
-  add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,     grid_name, ps);
-  add_field<Updated>("sgs_buoy_flux", scalar3d_layout_mid, K*(m/s), grid_name, ps);
-  add_field<Updated>("eddy_diff_mom", scalar3d_layout_mid, m2/s,    grid_name, ps);
-  add_field<Updated>("qc",            scalar3d_layout_mid, Qunit,   grid_name, "tracers", ps);
-  add_field<Updated>("cldfrac_liq",   scalar3d_layout_mid, nondim,  grid_name, ps);
+  add_field<Updated>("tke",           scalar3d_mid, m2/s2,   grid_name, "tracers", ps);
+  add_field<Updated>("horiz_winds",   vector3d_mid,   m/s,     grid_name, ps);
+  add_field<Updated>("sgs_buoy_flux", scalar3d_mid, K*(m/s), grid_name, ps);
+  add_field<Updated>("eddy_diff_mom", scalar3d_mid, m2/s,    grid_name, ps);
+  add_field<Updated>("qc",            scalar3d_mid, Qunit,   grid_name, "tracers", ps);
+  add_field<Updated>("cldfrac_liq",   scalar3d_mid, nondim,  grid_name, ps);
 
   // Output variables
-  add_field<Computed>("pbl_height",    scalar2d_layout_col, m,           grid_name);
-  add_field<Computed>("inv_qc_relvar", scalar3d_layout_mid, Qunit*Qunit, grid_name, ps);
+  add_field<Computed>("pbl_height",    scalar2d    , m,           grid_name);
+  add_field<Computed>("inv_qc_relvar", scalar3d_mid, Qunit*Qunit, grid_name, ps);
 
   // Tracer group
   add_group<Updated>("tracers", grid_name, ps, Bundling::Required);
 
   // Boundary flux fields for energy and mass conservation checks
   if (has_column_conservation_check()) {
-    add_field<Computed>("vapor_flux", scalar2d_layout_col, kg/m2/s, grid_name);
-    add_field<Computed>("water_flux", scalar2d_layout_col, m/s,     grid_name);
-    add_field<Computed>("ice_flux",   scalar2d_layout_col, m/s,     grid_name);
-    add_field<Computed>("heat_flux",  scalar2d_layout_col, W/m2,    grid_name);
+    add_field<Computed>("vapor_flux", scalar2d, kg/m2/s, grid_name);
+    add_field<Computed>("water_flux", scalar2d, m/s,     grid_name);
+    add_field<Computed>("ice_flux",   scalar2d, m/s,     grid_name);
+    add_field<Computed>("heat_flux",  scalar2d, W/m2,    grid_name);
   }
 }
 

--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -40,23 +40,23 @@ void SPA::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   // Define the different field layouts that will be used for this process
 
   // Layout for 3D (2d horiz X 1d vertical) variable defined at mid-level and interfaces
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols, m_num_levs} };
-  FieldLayout scalar2d_layout     { {COL},     {m_num_cols} };
-  FieldLayout scalar1d_layout_mid { {LEV},     {m_num_levs} };
+  FieldLayout scalar3d_mid = m_grid->get_3d_scalar_layout(true);
+  FieldLayout scalar2d     = m_grid->get_2d_scalar_layout();
+  FieldLayout scalar1d_mid = m_grid->get_vertical_layout(true);
   // Use VAR field tag for gases for now; consider adding a tag?
-  FieldLayout scalar3d_swband_layout { {COL,SWBND, LEV}, {m_num_cols, m_nswbands, m_num_levs} };
-  FieldLayout scalar3d_lwband_layout { {COL,LWBND, LEV}, {m_num_cols, m_nlwbands, m_num_levs} };
+  FieldLayout scalar3d_swband = m_grid->get_3d_vector_layout(true,m_nswbands,"swband");
+  FieldLayout scalar3d_lwband = m_grid->get_3d_vector_layout(true,m_nlwbands,"lwband");
 
   // Set of fields used strictly as input
   constexpr int ps = Spack::n;
-  add_field<Required>("p_mid"      , scalar3d_layout_mid, Pa,     grid_name, ps);
+  add_field<Required>("p_mid"      , scalar3d_mid, Pa,     grid_name, ps);
 
   // Set of fields used strictly as output
-  add_field<Computed>("nccn",        scalar3d_layout_mid,    1/kg,   grid_name, ps);
-  add_field<Computed>("aero_g_sw",   scalar3d_swband_layout, nondim, grid_name, ps);
-  add_field<Computed>("aero_ssa_sw", scalar3d_swband_layout, nondim, grid_name, ps);
-  add_field<Computed>("aero_tau_sw", scalar3d_swband_layout, nondim, grid_name, ps);
-  add_field<Computed>("aero_tau_lw", scalar3d_lwband_layout, nondim, grid_name, ps);
+  add_field<Computed>("nccn",        scalar3d_mid,    1/kg,   grid_name, ps);
+  add_field<Computed>("aero_g_sw",   scalar3d_swband, nondim, grid_name, ps);
+  add_field<Computed>("aero_ssa_sw", scalar3d_swband, nondim, grid_name, ps);
+  add_field<Computed>("aero_tau_sw", scalar3d_swband, nondim, grid_name, ps);
+  add_field<Computed>("aero_tau_lw", scalar3d_lwband, nondim, grid_name, ps);
 
   // We can already create some of the spa structures
 
@@ -75,8 +75,8 @@ void SPA::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   SPAHorizInterp = SPAFunc::create_horiz_remapper (m_grid,spa_data_file,spa_map_file, m_iop!=nullptr);
 
   // Grab a sw and lw field from the horiz interp, and check sw/lw dim against what we hardcoded in this class
-  auto nswbands_data = SPAHorizInterp->get_src_field(4).get_header().get_identifier().get_layout().dim(SWBND);
-  auto nlwbands_data = SPAHorizInterp->get_src_field(5).get_header().get_identifier().get_layout().dim(LWBND);
+  auto nswbands_data = SPAHorizInterp->get_src_field(4).get_header().get_identifier().get_layout().dim("swband");
+  auto nlwbands_data = SPAHorizInterp->get_src_field(5).get_header().get_identifier().get_layout().dim("lwband");
   EKAT_REQUIRE_MSG (nswbands_data==m_nswbands,
       "Error! Spa data file has a different number of sw bands than the model.\n"
       " - spa data swbands: " + std::to_string(nswbands_data) + "\n"

--- a/components/eamxx/src/physics/spa/spa_functions_impl.hpp
+++ b/components/eamxx/src/physics/spa/spa_functions_impl.hpp
@@ -114,8 +114,8 @@ create_horiz_remapper (
 
   const auto layout_2d   = tgt_grid->get_2d_scalar_layout();
   const auto layout_ccn3 = tgt_grid->get_3d_scalar_layout(true);
-  const auto layout_sw   = tgt_grid->get_3d_vector_layout(true,SWBND,nswbands);
-  const auto layout_lw   = tgt_grid->get_3d_vector_layout(true,LWBND,nlwbands);
+  const auto layout_sw   = tgt_grid->get_3d_vector_layout(true,nswbands,"swband");
+  const auto layout_lw   = tgt_grid->get_3d_vector_layout(true,nlwbands,"lwband");
   const auto nondim = ekat::units::Units::nondimensional();
 
   Field ps          (FieldIdentifier("PS",        layout_2d,  nondim,tgt_grid->name()));
@@ -491,8 +491,8 @@ void SPAFunctions<S,D>
 
   const int ncols    = sw_layout.dim(COL);
   const int nlevs    = sw_layout.dim(LEV);
-  const int nswbands = sw_layout.dim(SWBND);
-  const int nlwbands = lw_layout.dim(LWBND);
+  const int nswbands = sw_layout.dim("swband");
+  const int nlwbands = lw_layout.dim("lwband");
 
   Kokkos::deep_copy(spa_input.PS,ps);
   Kokkos::fence();

--- a/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
+++ b/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
@@ -42,22 +42,22 @@ void TurbulentMountainStress::set_grids(const std::shared_ptr<const GridsManager
   m_nlevs = m_grid->get_num_vertical_levels();  // Number of levels per column
 
   // Add required/computed fields
-  FieldLayout scalar2d_layout{          {COL},           {m_ncols} },
-              scalar3d_midpoint_layout{ {COL, LEV},      {m_ncols, m_nlevs} },
-              vector2d_layout{          {COL, CMP},      {m_ncols, 2} },
-              vector3d_midpoint_layout{ {COL, CMP, LEV}, {m_ncols, 2, m_nlevs} };
+  auto scalar2d     = m_grid->get_2d_scalar_layout();
+  auto vector2d     = m_grid->get_2d_vector_layout(2);
+  auto scalar3d_mid = m_grid->get_3d_scalar_layout(true);
+  auto vector3d_mid = m_grid->get_3d_vector_layout(true,2);
 
   constexpr int ps = Spack::n;
-  add_field<Required>("horiz_winds",    vector3d_midpoint_layout, m/s,    grid_name,            ps);
-  add_field<Required>("T_mid",          scalar3d_midpoint_layout, K,      grid_name,            ps);
-  add_field<Required>("p_mid",          scalar3d_midpoint_layout, Pa,     grid_name,            ps);
-  add_field<Required>("pseudo_density", scalar3d_midpoint_layout, Pa,     grid_name,            ps);
-  add_field<Required>("qv",             scalar3d_midpoint_layout, Qunit,  grid_name, "tracers", ps);
-  add_field<Required>("sgh30",          scalar2d_layout,          m,      grid_name);
-  add_field<Required>("landfrac",       scalar2d_layout,          nondim, grid_name);
+  add_field<Required>("horiz_winds",    vector3d_mid, m/s,    grid_name,            ps);
+  add_field<Required>("T_mid",          scalar3d_mid, K,      grid_name,            ps);
+  add_field<Required>("p_mid",          scalar3d_mid, Pa,     grid_name,            ps);
+  add_field<Required>("pseudo_density", scalar3d_mid, Pa,     grid_name,            ps);
+  add_field<Required>("qv",             scalar3d_mid, Qunit,  grid_name, "tracers", ps);
+  add_field<Required>("sgh30",          scalar2d    , m,      grid_name);
+  add_field<Required>("landfrac",       scalar2d    , nondim, grid_name);
 
-  add_field<Computed>("surf_drag_coeff_tms", scalar2d_layout, kg/s/m2, grid_name);
-  add_field<Computed>("wind_stress_tms",     vector2d_layout, N/m2,    grid_name);
+  add_field<Computed>("surf_drag_coeff_tms", scalar2d, kg/s/m2, grid_name);
+  add_field<Computed>("wind_stress_tms",     vector2d, N/m2,    grid_name);
 }
 
 // =========================================================================================

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -121,7 +121,7 @@ get_component (const int i, const bool dynamic) {
   const auto& fname = get_header().get_identifier().name();
   EKAT_REQUIRE_MSG (layout.is_vector_layout(),
       "Error! 'get_component' available only for vector fields.\n"
-      "       Layout of '" + fname + "': " + e2str(get_layout_type(layout.tags())) + "\n");
+      "       Layout of '" + fname + "': " + e2str(layout.type()) + "\n");
 
   const int idim = layout.get_vector_component_idx();
   EKAT_REQUIRE_MSG (i>=0 && i<layout.dim(idim),

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -92,7 +92,7 @@ subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
         "Error! Subview dimension index must be either 0 or 1.\n");
 
   // Create identifier for subfield
-  FieldIdentifier sf_id(sf_name,lt.strip_dim(idim),sf_units,id.get_grid_name());
+  FieldIdentifier sf_id(sf_name,lt.clone().strip_dim(idim),sf_units,id.get_grid_name());
 
   // Create empty subfield, then set header and views
   // Note: we can access protected members, since it's the same type

--- a/components/eamxx/src/share/field/field_alloc_prop.cpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.cpp
@@ -47,7 +47,7 @@ subview (const int idim, const int k, const bool dynamic) const {
   FieldAllocProp props(m_scalar_type_size);
   props.m_committed = true;
   props.m_scalar_type_size = m_scalar_type_size;
-  props.m_layout = m_layout.strip_dim(idim);
+  props.m_layout = m_layout.clone().strip_dim(idim);
 
   // Output is contioguous if either
   //  - this->m_contiguous=true AND idim==0

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -73,7 +73,7 @@ Field (const identifier_type& id,
   // Create an unmanaged dev view, and its host mirror
   const auto view_dim = alloc_prop.get_alloc_size();
   char* data = reinterpret_cast<char*>(view_d.data());
-  std::cout << "fl: " << to_string(fl) << "\n"
+  std::cout << "fl: " << fl.to_string() << "\n"
             << "view dim: " << view_dim << "\n";
   m_data.d_view = decltype(m_data.d_view)(data,view_dim);
   m_data.h_view = Kokkos::create_mirror_view(m_data.d_view);
@@ -593,8 +593,8 @@ update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val)
       "Error! Incompatible layouts for update_field.\n"
       " - x name: " + x.name() + "\n"
       " - y name: " + name() + "\n"
-      " - x layout: " + to_string(x_l) + "\n"
-      " - y layout: " + to_string(y_l) + "\n");
+      " - x layout: " + x_l.to_string() + "\n"
+      " - y layout: " + y_l.to_string() + "\n");
 
   using device_t = typename Field::get_device<HD>;
   using exec_space = typename device_t::execution_space;

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -78,7 +78,7 @@ FieldTag FieldLayout::get_vector_tag () const {
 std::vector<int> FieldLayout::get_tensor_components_ids () const {
   EKAT_REQUIRE_MSG (is_tensor_layout(),
       "Error! 'get_tensor_dims' available only for tensor layouts.\n"
-      "       Current layout: " + to_string(*this) + "\n"
+      "       Current layout: " + to_string() + "\n"
       "       Layout type   : " + e2str(m_type) + "\n");
 
   using namespace ShortFieldTagsNames;
@@ -95,7 +95,7 @@ std::vector<int> FieldLayout::get_tensor_components_ids () const {
 
   EKAT_REQUIRE_MSG (idx.size()==2,
     "Error! Could not find a two tensor tags in the layout.\n"
-    " - layout: " + to_string(*this) + "\n"
+    " - layout: " + to_string() + "\n"
     " - detected tags indices: " + ekat::join(idx,",") + "\n");
 
   return idx;
@@ -294,18 +294,13 @@ void FieldLayout::compute_type () {
   }
 }
 
-std::string to_string (const FieldLayout& layout)
+std::string FieldLayout::to_string () const
 {
-  if (layout.rank()==0) {
-    return "<>()";
-  }
-
   std::string s;
-  s += "<" + e2str(layout.tags()[0]);
-  for (int dim=1; dim<layout.rank(); ++dim) {
-    s += "," + e2str(layout.tags()[dim]);
-  }
-  s += ">(" + ekat::join(layout.dims(),",") + ")";
+  // Note: I don't know how to pass e2str directly to ekat::join,
+  //       so wrap it in a lambda
+  s += "<" + ekat::join(m_names,",") + ">";
+  s += "(" + ekat::join(m_dims,",") + ")";
 
   return s;
 }

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -197,6 +197,16 @@ FieldLayout& FieldLayout::rename_dim (const FieldTag t, const std::string& n, co
 
   return *this;
 }
+
+FieldLayout& FieldLayout::rename_dims (const std::map<FieldTag,std::string>& new_names)
+{
+  for (const auto& it : new_names) {
+    rename_dim(it.first,it.second,false);
+  }
+
+  return *this;
+}
+
 FieldLayout& FieldLayout::reset_dim (const int idim, const int extent)
 {
   EKAT_REQUIRE_MSG(idim>=0 && idim<m_rank, "Error! Index out of bounds.");

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -18,12 +18,12 @@ FieldLayout::FieldLayout (const std::vector<FieldTag>& tags,
 }
 
 bool FieldLayout::is_vector_layout () const {
-  const auto lt = get_layout_type (m_tags);
-  return lt==LayoutType::Vector2D || lt==LayoutType::Vector3D;
+  using namespace ShortFieldTagsNames;
+  return ekat::count(m_tags,CMP)==1;
 }
 
 bool FieldLayout::is_tensor_layout () const {
-  const auto lt = get_layout_type (m_tags);
+  const auto lt = type();
   return lt==LayoutType::Tensor2D || lt==LayoutType::Tensor3D;
 }
 
@@ -33,17 +33,10 @@ bool FieldLayout::is_tensor_layout () const {
 int FieldLayout::get_vector_component_idx () const {
   EKAT_REQUIRE_MSG (is_vector_layout(),
       "Error! 'get_vector_dim' available only for vector layouts.\n"
-      "       Current layout: " + e2str(get_layout_type(m_tags)) + "\n");
+      "       Current layout: " + e2str(type()) + "\n");
 
   using namespace ShortFieldTagsNames;
-  std::vector<FieldTag> vec_tags = {CMP,NGAS,SWBND,LWBND,SWGPT,ISCCPTAU,ISCCPPRS};
-  auto it = std::find_first_of (m_tags.cbegin(),m_tags.cend(),vec_tags.cbegin(),vec_tags.cend());
-
-  EKAT_REQUIRE_MSG (it!=m_tags.cend(),
-    "Error! Could not find a vector tag in the layout.\n"
-    " - layout: " + to_string(*this) + "\n");
-
-  return std::distance(m_tags.cbegin(),it);
+  return std::distance(m_tags.begin(),ekat::find(m_tags,CMP));
 }
 
 // get the extent of the CMP (Components) tag in the FieldLayout
@@ -63,15 +56,14 @@ std::vector<int> FieldLayout::get_tensor_dims () const {
   EKAT_REQUIRE_MSG (is_tensor_layout(),
       "Error! 'get_tensor_dims' available only for tensor layouts.\n"
       "       Current layout: " + to_string(*this) + "\n"
-      "       Layout type   : " + e2str(get_layout_type(m_tags)) + "\n");
+      "       Layout type   : " + e2str(type()) + "\n");
 
   using namespace ShortFieldTagsNames;
-  std::vector<FieldTag> cmp_tags = {CMP,NGAS,SWBND,LWBND,SWGPT,ISCCPTAU,ISCCPPRS};
 
   std::vector<int> idx;
   auto it = m_tags.begin();
   do {
-    it = std::find_first_of (it,m_tags.cend(),cmp_tags.cbegin(),cmp_tags.cend());
+    it = std::find(it,m_tags.cend(),CMP);
     if (it!=m_tags.end()) {
       idx.push_back(std::distance(m_tags.begin(),it));
       ++it;
@@ -136,12 +128,13 @@ void FieldLayout::set_dimension (const int idim, const int dimension) {
   Kokkos::deep_copy(m_extents,extents_h);
 }
 
-LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
-  using ekat::erase;
-  using ekat::count;
+LayoutType FieldLayout::type () const {
   using namespace ShortFieldTagsNames;
 
-  auto tags = field_tags;
+  using ekat::erase;
+  using ekat::count;
+
+  auto tags = this->tags();
 
   const int n_element = count(tags,EL);
   const int n_column  = count(tags,COL);
@@ -177,7 +170,7 @@ LayoutType get_layout_type (const std::vector<FieldTag>& field_tags) {
     return LayoutType::Vector1D;
   } else {
     // Not a supported layout.
-    return result;
+    return LayoutType::Invalid;
   }
 
   // Get the size of what's left

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -114,11 +114,14 @@ std::vector<FieldTag> FieldLayout::get_tensor_tags () const {
   return {m_tags[idx[0]], m_tags[idx[1]]};
 }
 
-FieldLayout& FieldLayout::strip_dim (const FieldTag tag) {
+FieldLayout& FieldLayout::strip_dim (const FieldTag tag, const bool throw_if_not_found) {
   auto it = ekat::find(m_tags,tag);
 
-  // Check if found
-  EKAT_REQUIRE_MSG(it!=m_tags.end(), "Error! Tag '" + e2str(tag) + "' not found.\n");
+  if (it==m_tags.end()) {
+    // Check if found
+    EKAT_REQUIRE_MSG(not throw_if_not_found, "Error! Tag '" + e2str(tag) + "' not found.\n");
+    return *this;
+  }
 
   // Check only one tag (no ambiguity)
   EKAT_REQUIRE_MSG(ekat::count(m_tags,tag)==1,

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -136,6 +136,8 @@ public:
   FieldLayout& rename_dim (const int idim, const std::string& n);
   FieldLayout& rename_dim (const FieldTag tag, const std::string& n);
   FieldLayout& reset_dim (const int idim, const int extent);
+  // For printing purposes
+  std::string to_string () const;
 
 protected:
   void compute_type ();
@@ -151,7 +153,6 @@ protected:
 };
 
 bool operator== (const FieldLayout& fl1, const FieldLayout& fl2);
-std::string to_string (const FieldLayout& l);
 
 // ========================== IMPLEMENTATION ======================= //
 

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -74,6 +74,8 @@ public:
 
   // ----- Getters ----- //
 
+  LayoutType type () const;
+
   // Name and layout informations
   const std::vector<FieldTag>& tags () const { return m_tags; }
   FieldTag tag  (const int idim) const;
@@ -128,7 +130,6 @@ protected:
 };
 
 bool operator== (const FieldLayout& fl1, const FieldLayout& fl2);
-LayoutType get_layout_type (const std::vector<FieldTag>& field_tags);
 std::string to_string (const FieldLayout& l);
 
 // ========================== IMPLEMENTATION ======================= //

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -122,6 +122,10 @@ public:
   FieldLayout strip_dim (const int idim) const;
   FieldLayout clone_with_different_extent (const int idim, const int extent) const;
 
+  // NOTE: congruent does not check the tags names. It only checks
+  //       rank, m_tags, and m_dims. Use operator== if names are important
+  bool congruent (const FieldLayout& rhs) const;
+
   // Change the name of a dimension
   void rename_dim (const int idim, const std::string& n);
   void rename_dim (const FieldTag tag, const std::string& n);
@@ -201,10 +205,14 @@ inline bool FieldLayout::are_dimensions_set () const {
   return true;
 }
 
+inline bool FieldLayout::congruent (const FieldLayout& rhs) const {
+  return rank()==rhs.rank() &&
+         tags()==rhs.tags() &&
+         dims()==rhs.dims();
+}
+
 inline bool operator== (const FieldLayout& fl1, const FieldLayout& fl2) {
-  return fl1.rank()==fl2.rank() &&
-         fl1.tags()==fl2.tags() &&
-         fl1.dims()==fl2.dims();
+  return fl1.congruent(fl2) and fl1.names()==fl2.names();
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -121,21 +121,24 @@ public:
   std::vector<int> get_tensor_dims () const;
   std::vector<FieldTag> get_tensor_tags () const;
 
-  // Returns a copy of this layout with a given dimension stripped
+  // Change this layout by adding/removing a dimension or changing its extent/name
+  // NOTE: the strip_dim/rename_dim/reset_dim overloads with FieldTag will alter *all*
+  //       dimension matching the input tag
   FieldLayout& strip_dim (const FieldTag tag, const bool throw_if_not_found = true);
   FieldLayout& strip_dim (const int idim);
   FieldLayout& append_dim (const FieldTag t, const int extent);
   FieldLayout& append_dim (const FieldTag t, const int extent, const std::string& name);
+  FieldLayout& rename_dim (const int idim, const std::string& n);
+  FieldLayout& rename_dim (const FieldTag tag, const std::string& n, const bool throw_if_not_found = true);
+  FieldLayout& reset_dim (const int idim, const int extent);
+  FieldLayout& reset_dim (const FieldTag t, const int extent, const bool throw_if_not_found = true);
+
   FieldLayout clone() const;
 
   // NOTE: congruent does not check the tags names. It only checks
   //       rank, m_tags, and m_dims. Use operator== if names are important
   bool congruent (const FieldLayout& rhs) const;
 
-  // Change the name of a dimension
-  FieldLayout& rename_dim (const int idim, const std::string& n);
-  FieldLayout& rename_dim (const FieldTag tag, const std::string& n);
-  FieldLayout& reset_dim (const int idim, const int extent);
   // For printing purposes
   std::string to_string () const;
 

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -122,7 +122,7 @@ public:
   std::vector<FieldTag> get_tensor_tags () const;
 
   // Returns a copy of this layout with a given dimension stripped
-  FieldLayout& strip_dim (const FieldTag tag);
+  FieldLayout& strip_dim (const FieldTag tag, const bool throw_if_not_found = true);
   FieldLayout& strip_dim (const int idim);
   FieldLayout& append_dim (const FieldTag t, const int extent);
   FieldLayout& append_dim (const FieldTag t, const int extent, const std::string& name);

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -130,6 +130,7 @@ public:
   FieldLayout& append_dim (const FieldTag t, const int extent, const std::string& name);
   FieldLayout& rename_dim (const int idim, const std::string& n);
   FieldLayout& rename_dim (const FieldTag tag, const std::string& n, const bool throw_if_not_found = true);
+  FieldLayout& rename_dims (const std::map<FieldTag,std::string>& new_names); // Does not throw if not found
   FieldLayout& reset_dim (const int idim, const int extent);
   FieldLayout& reset_dim (const FieldTag t, const int extent, const bool throw_if_not_found = true);
 

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -132,6 +132,7 @@ public:
 
 protected:
   void compute_type ();
+  void set_extents ();
 
   int                       m_rank;
   std::vector<FieldTag>     m_tags;

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -74,7 +74,7 @@ public:
 
   // ----- Getters ----- //
 
-  LayoutType type () const;
+  LayoutType type () const { return m_type; }
 
   // Name and layout informations
   const std::vector<FieldTag>& tags () const { return m_tags; }
@@ -118,6 +118,7 @@ public:
   FieldLayout clone_with_different_extent (const int idim, const int extent) const;
 
 protected:
+  void compute_type ();
 
   // Only this class is allowed to change a layout. Customers can request
   // a *slightly* different layout (via strip_dim or clone_with_different_extent)
@@ -127,6 +128,8 @@ protected:
   std::vector<FieldTag> m_tags;
   std::vector<int>      m_dims;
   extents_type          m_extents;
+
+  LayoutType            m_type;
 };
 
 bool operator== (const FieldLayout& fl1, const FieldLayout& fl2);

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -525,13 +525,13 @@ void FieldManager::registration_ends ()
         const auto& id = f->get_header().get_identifier();
         if (lt==LayoutType::Invalid) {
          f_layout = id.get_layout();
-         lt = get_layout_type(f_layout.tags());
+         lt = f_layout.type();
         } else {
-          EKAT_REQUIRE_MSG (lt==get_layout_type(id.get_layout().tags()),
+          EKAT_REQUIRE_MSG (lt==id.get_layout().type(),
               "Error! Found a group to bundle containing fields with different layouts.\n"
               "       Group name: " + cluster_name + "\n"
               "       Layout 1: " + e2str(lt) + "\n"
-              "       Layout 2: " + e2str(get_layout_type(id.get_layout().tags())) + "\n");
+              "       Layout 2: " + e2str(id.get_layout().type()) + "\n");
         }
       }
 
@@ -651,7 +651,7 @@ void FieldManager::registration_ends ()
     // whether they are 2d or 3d.
     auto f1 = m_fields.at(info.m_fields_names.front());
     auto f1_layout = f1->get_header().get_identifier().get_layout();
-    auto lt = get_layout_type(f1_layout.tags());
+    auto lt = f1_layout.type();
     FieldLayout g_layout = FieldLayout::invalid();
     if (lt==LayoutType::Scalar2D) {
       g_layout = m_grid->get_2d_vector_layout(size);

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -657,7 +657,7 @@ void FieldManager::registration_ends ()
       g_layout = m_grid->get_2d_vector_layout(size);
     } else {
       bool mid = f1_layout.tags().back()==LEV;
-      g_layout = m_grid->get_3d_vector_layout(mid,size);
+      g_layout = m_grid->get_3d_vector_layout(mid,size,e2str(CMP));
     }
 
     FieldIdentifier g_fid(gname,g_layout,nondim,m_grid->name());

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -540,9 +540,9 @@ void FieldManager::registration_ends ()
 
       FieldLayout c_layout = FieldLayout::invalid();
       if (lt==LayoutType::Scalar2D) {
-        c_layout = m_grid->get_2d_vector_layout(CMP,cluster_ordered_fields.size());
+        c_layout = m_grid->get_2d_vector_layout(cluster_ordered_fields.size());
       } else {
-        c_layout = m_grid->get_3d_vector_layout(f_layout.tags().back()==LEV,CMP,cluster_ordered_fields.size());
+        c_layout = m_grid->get_3d_vector_layout(f_layout.tags().back()==LEV,cluster_ordered_fields.size());
       }
 
       // The units for the bundled field are nondimensional, cause checking whether
@@ -654,10 +654,10 @@ void FieldManager::registration_ends ()
     auto lt = get_layout_type(f1_layout.tags());
     FieldLayout g_layout = FieldLayout::invalid();
     if (lt==LayoutType::Scalar2D) {
-      g_layout = m_grid->get_2d_vector_layout(CMP,size);
+      g_layout = m_grid->get_2d_vector_layout(size);
     } else {
       bool mid = f1_layout.tags().back()==LEV;
-      g_layout = m_grid->get_3d_vector_layout(mid,CMP,size);
+      g_layout = m_grid->get_3d_vector_layout(mid,size);
     }
 
     FieldIdentifier g_fid(gname,g_layout,nondim,m_grid->name());

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -736,7 +736,7 @@ void FieldManager::add_field (const Field& f) {
       "Error! Input field to 'add_field' has a layout not compatible with the stored grid.\n"
       "  - input field name : " + f.name() + "\n"
       "  - field manager grid: " + m_grid->name() + "\n"
-      "  - input field layout:   " + to_string(f.get_header().get_identifier().get_layout()) + "\n");
+      "  - input field layout:   " + f.get_header().get_identifier().get_layout().to_string() + "\n");
   EKAT_REQUIRE_MSG (not has_field(f.name()),
       "Error! The method 'add_field' requires the input field to not be already existing.\n"
       "  - field name: " + f.get_header().get_identifier().name() + "\n");

--- a/components/eamxx/src/share/field/field_tag.hpp
+++ b/components/eamxx/src/share/field/field_tag.hpp
@@ -33,20 +33,6 @@ enum class FieldTag {
   GaussPoint,
   Component,
   TimeLevel,
-  // Added for RRTMGP, TODO: Revisit this approach, is there a better way than adding more field tags?
-  Gases,
-  ShortWaveBand,
-  ShortWaveGpoint,
-  LongWaveBand,
-  LongWaveGpoint,
-  IsccpTau,
-  IsccpPrs,
-  //
-  MAM_NumModes,
-  MAM_NumRefIndexReal,
-  MAM_NumRefIndexImag,
-  MAM_NumCoefficients,
-  MAM_NumModesInFile
 };
 
 // If using tags a lot, consider adding 'using namespace ShortFieldTagsNames'
@@ -63,21 +49,6 @@ namespace ShortFieldTagsNames {
   constexpr auto LEV  = FieldTag::LevelMidPoint;
   constexpr auto ILEV = FieldTag::LevelInterface;
   constexpr auto CMP  = FieldTag::Component;
-  // Added for rrtmgp - see TODO item above
-  constexpr auto NGAS = FieldTag::Gases;
-  constexpr auto SWBND = FieldTag::ShortWaveBand;
-  constexpr auto LWBND = FieldTag::LongWaveBand;
-  constexpr auto SWGPT = FieldTag::ShortWaveGpoint;
-  constexpr auto LWGPT = FieldTag::LongWaveGpoint;
-  constexpr auto ISCCPTAU = FieldTag::IsccpTau;
-  constexpr auto ISCCPPRS = FieldTag::IsccpPrs;
-  constexpr auto NMODES = FieldTag::MAM_NumModes;
-  //
-  constexpr auto NREFINDEX_REAL = FieldTag::MAM_NumRefIndexReal;
-  constexpr auto NREFINDEX_IM = FieldTag::MAM_NumRefIndexImag;
-
-  constexpr auto NCOEF_NUMBER = FieldTag::MAM_NumCoefficients;
-  constexpr auto MODE = FieldTag::MAM_NumModesInFile;
 }
 
 inline std::string e2str (const FieldTag ft) {
@@ -107,43 +78,6 @@ inline std::string e2str (const FieldTag ft) {
       break;
     case FieldTag::Component:
       name = "dim";
-      break;
-    // Added for rrtmgp - see TODO item above
-    case FieldTag::Gases:
-      name = "ngas";
-      break;
-    case FieldTag::ShortWaveBand:
-      name = "swband";
-      break;
-    case FieldTag::ShortWaveGpoint:
-      name = "swgpt";
-      break;
-    case FieldTag::LongWaveBand:
-      name = "lwband";
-      break;
-    case FieldTag::LongWaveGpoint:
-      name = "lwgpt";
-      break;
-    case FieldTag::IsccpTau:
-      name = "ISCCPTAU";
-      break;
-    case FieldTag::IsccpPrs:
-      name = "ISCCPPRS";
-      break;
-    case FieldTag::MAM_NumModes:
-      name = "num_modes";
-      break;
-    case FieldTag::MAM_NumRefIndexReal:
-      name = "refindex_real";
-      break;
-    case FieldTag::MAM_NumRefIndexImag:
-      name = "refindex_im";
-      break;
-    case FieldTag::MAM_NumCoefficients:
-      name = "coef_number";
-      break;
-    case FieldTag::MAM_NumModesInFile:
-      name = "mode";
       break;
     default:
       EKAT_ERROR_MSG("Error! Unrecognized field tag.");

--- a/components/eamxx/src/share/field/field_tag.hpp
+++ b/components/eamxx/src/share/field/field_tag.hpp
@@ -151,6 +151,15 @@ inline std::string e2str (const FieldTag ft) {
   return name;
 }
 
+inline std::vector<std::string> tags2str (const std::vector<FieldTag>& tags) {
+  std::vector<std::string> names;
+  names.reserve(tags.size());
+  for (auto t : tags) {
+    names.push_back(e2str(t));
+  }
+  return names;
+}
+
 // Allow to stream FieldTag values as strings.
 inline std::ostream& operator<< (std::ostream& out, const FieldTag t) {
   out << e2str(t);

--- a/components/eamxx/src/share/field/field_tag.hpp
+++ b/components/eamxx/src/share/field/field_tag.hpp
@@ -4,6 +4,7 @@
 #include "ekat/ekat_assert.hpp"
 
 #include <string>
+#include <vector>
 
 namespace scream
 {

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -87,7 +87,7 @@ void perturb (const Field& f,
                    "Error! Trying to perturb field \""+f.name()+"\", but field "
 	                 "does not have LEV or ILEV as last dimension.\n"
                    "  - field name: " + f.name() + "\n"
-                   "  - field layout: " + to_string(fl) + "\n");
+                   "  - field layout: " + fl.to_string() + "\n");
 
   if (fl.has_tag(COL)) {
     // If field has a column dimension, it should be the first dimension
@@ -95,7 +95,7 @@ void perturb (const Field& f,
                      "Error! Trying to perturb field \""+f.name()+"\", but field "
 	                   "does not have COL as first dimension.\n"
                      "  - field name: " + f.name() + "\n"
-                     "  - field layout: " + to_string(fl) + "\n");
+                     "  - field layout: " + fl.to_string() + "\n");
 
     const auto& dof_gids_fl = dof_gids.get_header().get_identifier().get_layout();
     EKAT_REQUIRE_MSG(dof_gids_fl.dim(0) == fl.dim(COL),
@@ -103,7 +103,7 @@ void perturb (const Field& f,
                      "perturbed field's column dimension.\n"
                      "  - dof_gids dim: " + std::to_string(dof_gids_fl.dim(0)) + "\n"
                      "  - field name: " + f.name() + "\n"
-                     "  - field layout: " + to_string(fl) + "\n");
+                     "  - field layout: " + fl.to_string() + "\n");
     EKAT_REQUIRE_MSG(dof_gids.data_type() == DataType::IntType,
                      "Error! DoF GIDs field must have \"int\" as data type.\n");
   }

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -742,7 +742,7 @@ void print_field_hyperslab (const Field& f,
 
     f.sync_to_host();
     const int rank = layout.rank();
-    out << "     " << f.name() << to_string(orig_layout) << "\n\n";
+    out << "     " << f.name() << orig_layout.to_string() << "\n\n";
     switch (rank) {
       case 0:
       {
@@ -830,8 +830,7 @@ void print_field_hyperslab (const Field& f,
         EKAT_ERROR_MSG (
             "Unsupported rank in print_field_hyperslab.\n"
             "  - field name  : " + f.name() + "\n"
-            "  - field layout (upon slicing): " + to_string(layout) + "\n");
-
+            "  - field layout (upon slicing): " + layout.to_string() + "\n");
     }
   } else {
     auto tag = tags[curr_idx];
@@ -841,14 +840,14 @@ void print_field_hyperslab (const Field& f,
     EKAT_REQUIRE_MSG (it!=layout.tags().end(),
         "Error! Something went wrong while slicing field.\n"
         "  - field name  : " + f.name() + "\n"
-        "  - field layout: " + to_string(layout) + "\n"
+        "  - field layout: " + layout.to_string() + "\n"
         "  - curr tag    : " + e2str(tag) + "\n");
     auto idim = std::distance(layout.tags().begin(),it);
 
     EKAT_REQUIRE_MSG (idim==0 || idim==1,
         "Error! Cannot subview field for printing.\n"
         "  - field name  : " + f.name() + "\n"
-        "  - field layout: " + to_string(layout) + "\n"
+        "  - field layout: " + layout.to_string() + "\n"
         "  - loc tags    : <" + ekat::join(tags,",") + ">\n"
         "  - loc indices : (" + ekat::join(indices,",") + ")\n");
 

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -237,7 +237,7 @@ void perturb (const Field& f,
 
     // Create a field to store perturbation values with layout
     // the same as f, but stripped of column and level dimension.
-    auto perturb_fl = fl.strip_dim(COL).strip_dim(LEV);
+    auto perturb_fl = fl.clone().strip_dim(COL).strip_dim(LEV);
     FieldIdentifier perturb_fid("perturb_field", perturb_fl, ekat::units::Units::nondimensional(), "");
     Field perturb_f(perturb_fid);
     perturb_f.allocate_view();
@@ -263,7 +263,7 @@ void perturb (const Field& f,
 
     // Create a field to store perturbation values with layout
     // the same as f, but stripped of level dimension.
-    auto perturb_fl = fl.strip_dim(LEV);
+    auto perturb_fl = fl.clone().strip_dim(LEV);
     FieldIdentifier perturb_fid("perturb_field", perturb_fl, ekat::units::Units::nondimensional(), "");
     Field perturb_f(perturb_fid);
     perturb_f.allocate_view();

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -69,8 +69,9 @@ FieldLayout AbstractGrid::
 get_vertical_layout (const bool midpoints) const
 {
   using namespace ShortFieldTagsNames;
-  return midpoints ? FieldLayout ({ LEV},{m_num_vert_levs})
-                   : FieldLayout ({ILEV},{m_num_vert_levs+1});
+  const auto t = midpoints ? LEV : ILEV;
+  const auto d = m_num_vert_levs + (midpoints ? 0 : 1);
+  return FieldLayout({t},{d}).rename_dims(m_special_tag_names);
 }
 
 FieldLayout

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -71,7 +71,36 @@ get_vertical_layout (const bool midpoints) const
   using namespace ShortFieldTagsNames;
   return midpoints ? FieldLayout ({ LEV},{m_num_vert_levs})
                    : FieldLayout ({ILEV},{m_num_vert_levs+1});
+}
 
+FieldLayout
+AbstractGrid::get_2d_vector_layout (const int vector_dim) const
+{
+  using namespace ShortFieldTagsNames;
+  return get_2d_vector_layout(vector_dim,e2str(CMP));
+}
+
+FieldLayout
+AbstractGrid::get_2d_tensor_layout (const std::vector<int>& cmp_dims) const
+{
+  using namespace ShortFieldTagsNames;
+  std::vector<std::string> names (cmp_dims.size(),e2str(CMP));
+  return get_2d_tensor_layout(cmp_dims,names);
+}
+
+FieldLayout
+AbstractGrid::get_3d_vector_layout (const bool midpoints, const int vector_dim) const
+{
+  using namespace ShortFieldTagsNames;
+  return get_3d_vector_layout(midpoints,vector_dim,e2str(CMP));
+}
+
+FieldLayout
+AbstractGrid::get_3d_tensor_layout (const bool midpoints, const std::vector<int>& cmp_dims) const
+{
+  using namespace ShortFieldTagsNames;
+  std::vector<std::string> names (cmp_dims.size(),e2str(CMP));
+  return get_3d_tensor_layout(midpoints,cmp_dims,names);
 }
 
 bool AbstractGrid::is_unique () const {
@@ -154,11 +183,11 @@ is_valid_layout (const FieldLayout& layout) const
       return true;
     case LayoutType::Scalar1D: [[fallthrough]];
     case LayoutType::Vector1D:
-      return layout.congruent(get_vertical_layout(midpoints);
+      return layout.congruent(get_vertical_layout(midpoints));
     case LayoutType::Scalar2D:
       return layout.congruent(get_2d_scalar_layout());
     case LayoutType::Scalar3D:
-      return layout.congruent(get_3d_scalar_layout(midpoints);
+      return layout.congruent(get_3d_scalar_layout(midpoints));
     case LayoutType::Vector2D:
       return layout.congruent(get_2d_vector_layout(layout.get_vector_dim()));
     case LayoutType::Vector3D:

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -259,8 +259,8 @@ AbstractGrid::create_geometry_data (const FieldIdentifier& fid)
       "Error! Cannot create geometry data, since it already exists.\n"
       "  - grid name: " + this->name() + "\n"
       "  - geo data name: " + name + "\n"
-      "  - geo data layout: " + to_string(m_geo_fields.at(name).get_header().get_identifier().get_layout()) + "\n"
-      "  - input layout: " + to_string(fid.get_layout()) + "\n");
+      "  - geo data layout: " + m_geo_fields.at(name).get_header().get_identifier().get_layout().to_string() + "\n"
+      "  - input layout: " + fid.get_layout().to_string() + "\n");
 
   // Create field and the read only copy as well
   auto& f = m_geo_fields[name] = Field(fid);

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -146,7 +146,7 @@ is_valid_layout (const FieldLayout& layout) const
 {
   using namespace ShortFieldTagsNames;
 
-  const auto lt = get_layout_type(layout.tags());
+  const auto lt = layout.type();
   if (lt==LayoutType::Scalar0D or lt==LayoutType::Vector0D) {
     // 0d layouts are compatible with any grid
     // Let's return true early to avoid segfautls below

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -186,12 +186,16 @@ is_valid_layout (const FieldLayout& layout) const
       return layout.congruent(get_vertical_layout(midpoints));
     case LayoutType::Scalar2D:
       return layout.congruent(get_2d_scalar_layout());
-    case LayoutType::Scalar3D:
-      return layout.congruent(get_3d_scalar_layout(midpoints));
     case LayoutType::Vector2D:
       return layout.congruent(get_2d_vector_layout(layout.get_vector_dim()));
+    case LayoutType::Tensor2D:
+      return layout.congruent(get_2d_tensor_layout(layout.get_tensor_dims()));
+    case LayoutType::Scalar3D:
+      return layout.congruent(get_3d_scalar_layout(midpoints));
     case LayoutType::Vector3D:
       return layout.congruent(get_3d_vector_layout(midpoints,layout.get_vector_dim()));
+    case LayoutType::Tensor3D:
+      return layout.congruent(get_3d_tensor_layout(midpoints,layout.get_tensor_dims()));
     default:
       // Anything else is probably not ok
       return false;

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -203,7 +203,6 @@ protected:
   //       since it calls get_2d_scalar_layout.
   void create_dof_fields (const int scalar2d_layout_rank);
 
-private:
 
   // The grid name and type
   GridType     m_type;

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -73,12 +73,24 @@ public:
   //       for a vector 3d field on a Point grid it will be (ncols,vector_dim,nlevs)
   FieldLayout get_vertical_layout (const bool midpoints) const;
   virtual FieldLayout get_2d_scalar_layout () const = 0;
-  virtual FieldLayout get_2d_vector_layout (const int vector_dim) const = 0;
-  virtual FieldLayout get_2d_tensor_layout (const std::vector<int>& cmp_dims) const = 0;
+  virtual FieldLayout get_2d_vector_layout (const int vector_dim, const std::string& vec_dim_name) const = 0;
+  virtual FieldLayout get_2d_tensor_layout (const std::vector<int>& cmp_dims,
+                                            const std::vector<std::string>& cmp_dims_names) const = 0;
   virtual FieldLayout get_3d_scalar_layout (const bool midpoints) const = 0;
-  virtual FieldLayout get_3d_vector_layout (const bool midpoints, const int vector_dim) const = 0;
+  virtual FieldLayout get_3d_vector_layout (const bool midpoints, const int vector_dim,
+                                            const std::string& vec_dim_name) const = 0;
   virtual FieldLayout get_3d_tensor_layout (const bool midpoints,
-                                            const std::vector<int>& cmp_dims) const = 0;
+                                            const std::vector<int>& cmp_dims,
+                                            const std::vector<std::string>& cmp_dims_names) const = 0;
+
+  // Some shortcut versions of the above ones, where the name of the vector/tensor
+  // components are all equal to e2str(CMP)
+  FieldLayout get_2d_vector_layout (const int vector_dim) const;
+  FieldLayout get_2d_tensor_layout (const std::vector<int>& cmp_dims) const;
+
+  FieldLayout get_3d_vector_layout (const bool midpoints) const;
+  FieldLayout get_3d_vector_layout (const bool midpoints, const int vector_dim) const;
+  FieldLayout get_3d_tensor_layout (const bool midpoints, const std::vector<int>& cmp_dims) const;
 
   int get_num_vertical_levels () const { return m_num_vert_levs; }
 

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -180,8 +180,9 @@ public:
   virtual bool check_valid_lid_to_idx () const { return true; }
 
   void reset_field_tag_name (const FieldTag t, const std::string& s) { m_special_tag_names[t] = s; }
-  std::string get_dim_name (const FieldTag t) const {
-    return m_special_tag_names.count(t)==1 ? m_special_tag_names.at(t) : e2str(t);
+  std::string get_dim_name (const FieldLayout& lt, const int idim) const {
+    const auto t = lt.tag(idim);
+    return m_special_tag_names.count(t)==1 ? m_special_tag_names.at(t) : lt.names()[idim];
   }
 
   // This member is used mostly by IO: if a field exists on multiple grids

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -73,13 +73,11 @@ public:
   //       for a vector 3d field on a Point grid it will be (ncols,vector_dim,nlevs)
   FieldLayout get_vertical_layout (const bool midpoints) const;
   virtual FieldLayout get_2d_scalar_layout () const = 0;
-  virtual FieldLayout get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const = 0;
-  virtual FieldLayout get_2d_tensor_layout (const std::vector<FieldTag>& cmp_tags,
-                                            const std::vector<int>& cmp_dims) const = 0;
+  virtual FieldLayout get_2d_vector_layout (const int vector_dim) const = 0;
+  virtual FieldLayout get_2d_tensor_layout (const std::vector<int>& cmp_dims) const = 0;
   virtual FieldLayout get_3d_scalar_layout (const bool midpoints) const = 0;
-  virtual FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const = 0;
+  virtual FieldLayout get_3d_vector_layout (const bool midpoints, const int vector_dim) const = 0;
   virtual FieldLayout get_3d_tensor_layout (const bool midpoints,
-                                            const std::vector<FieldTag>& cmp_tags,
                                             const std::vector<int>& cmp_dims) const = 0;
 
   int get_num_vertical_levels () const { return m_num_vert_levs; }

--- a/components/eamxx/src/share/grid/point_grid.cpp
+++ b/components/eamxx/src/share/grid/point_grid.cpp
@@ -48,25 +48,34 @@ PointGrid::get_2d_scalar_layout () const
 }
 
 FieldLayout
-PointGrid::get_2d_vector_layout (const int vector_dim) const
+PointGrid::get_2d_vector_layout (const int vector_dim, const std::string& vec_dim_name) const
 {
   using namespace ShortFieldTagsNames;
 
-  return FieldLayout({COL,CMP},{get_num_local_dofs(),vector_dim});
+  FieldLayout fl({COL,CMP},{get_num_local_dofs(),vector_dim});
+  fl.rename_dim(1,vec_dim_name);
+  return fl;
 }
 
 FieldLayout
-PointGrid::get_2d_tensor_layout (const std::vector<FieldTag>& cmp_tags,
-                                 const std::vector<int>& cmp_dims) const
+PointGrid::get_2d_tensor_layout (const std::vector<int>& cmp_dims,
+                                 const std::vector<std::string>& cmp_names) const
 {
+  EKAT_REQUIRE_MSG (cmp_names.size()==cmp_dims.size(),
+      "[PointGrid::get_2d_tensor_layout] Input vector dimensions mismatch.\n"
+      "  - grid name: " + name() + "\n"
+      "  - cmp_names: " + ekat::join(cmp_names,",") + "\n"
+      "  - cmp_dims : " + ekat::join(cmp_dims,",") + "\n");
   using namespace ShortFieldTagsNames;
 
-  std::vector<FieldTag> tags = {COL};
-  std::vector<int>      dims = {get_num_local_dofs()};
+  FieldLayout fl;
 
-  tags.insert(tags.end(),cmp_tags.begin(),cmp_tags.end());
-  dims.insert(dims.end(),cmp_dims.begin(),cmp_dims.end());
-  return FieldLayout(tags,dims);
+  fl.append_dim(COL, get_num_local_dofs());
+  for (size_t i=0; i<cmp_dims.size(); ++i) {
+    fl.append_dim(CMP,cmp_dims[i],cmp_names[i]);
+  }
+
+  return fl;
 }
 
 FieldLayout
@@ -81,34 +90,43 @@ PointGrid::get_3d_scalar_layout (const bool midpoints) const
 }
 
 FieldLayout
-PointGrid::get_3d_vector_layout (const bool midpoints, const int vector_dim) const
+PointGrid::get_3d_vector_layout (const bool midpoints, const int vector_dim,
+                                 const std::string& vec_dim_name) const
 {
   using namespace ShortFieldTagsNames;
 
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
   auto VL = midpoints ? LEV : ILEV;
 
-  return FieldLayout({COL,CMP,VL},{get_num_local_dofs(),vector_dim,nvl});
+  FieldLayout fl({COL,CMP,VL},{get_num_local_dofs(),vector_dim,nvl});
+  fl.rename_dim(1,vec_dim_name);
+  return fl;
 }
 
 FieldLayout
 PointGrid::get_3d_tensor_layout (const bool midpoints,
-                                 const std::vector<FieldTag>& cmp_tags,
-                                 const std::vector<int>& cmp_dims) const
+                                 const std::vector<int>& cmp_dims,
+                                 const std::vector<std::string>& cmp_names) const
 {
+  EKAT_REQUIRE_MSG (cmp_names.size()==cmp_dims.size(),
+      "[PointGrid::get_2d_tensor_layout] Input vector dimensions mismatch.\n"
+      "  - grid name: " + name() + "\n"
+      "  - cmp_names: " + ekat::join(cmp_names,",") + "\n"
+      "  - cmp_dims : " + ekat::join(cmp_dims,",") + "\n");
   using namespace ShortFieldTagsNames;
 
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
   auto VL = midpoints ? LEV : ILEV;
 
-  std::vector<FieldTag> tags = {COL};
-  std::vector<int>      dims = {get_num_local_dofs()};
+  FieldLayout fl;
 
-  tags.insert(tags.end(),cmp_tags.begin(),cmp_tags.end());
-  dims.insert(dims.end(),cmp_dims.begin(),cmp_dims.end());
-  tags.push_back(VL);
-  dims.push_back(nvl);
-  return FieldLayout(tags,dims);
+  fl.append_dim(COL, get_num_local_dofs());
+  for (size_t i=0; i<cmp_dims.size(); ++i) {
+    fl.append_dim(CMP,cmp_dims[i],cmp_names[i]);
+  }
+  fl.append_dim(VL,nvl);
+
+  return fl;
 }
 
 std::shared_ptr<AbstractGrid>

--- a/components/eamxx/src/share/grid/point_grid.cpp
+++ b/components/eamxx/src/share/grid/point_grid.cpp
@@ -44,7 +44,7 @@ PointGrid::get_2d_scalar_layout () const
 {
   using namespace ShortFieldTagsNames;
 
-  return FieldLayout({COL},{get_num_local_dofs()});
+  return FieldLayout({COL},{get_num_local_dofs()}).rename_dims(m_special_tag_names);
 }
 
 FieldLayout
@@ -54,7 +54,7 @@ PointGrid::get_2d_vector_layout (const int vector_dim, const std::string& vec_di
 
   FieldLayout fl({COL,CMP},{get_num_local_dofs(),vector_dim});
   fl.rename_dim(1,vec_dim_name);
-  return fl;
+  return fl.rename_dims(m_special_tag_names);
 }
 
 FieldLayout
@@ -75,7 +75,7 @@ PointGrid::get_2d_tensor_layout (const std::vector<int>& cmp_dims,
     fl.append_dim(CMP,cmp_dims[i],cmp_names[i]);
   }
 
-  return fl;
+  return fl.rename_dims(m_special_tag_names);
 }
 
 FieldLayout
@@ -86,7 +86,7 @@ PointGrid::get_3d_scalar_layout (const bool midpoints) const
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
   auto VL = midpoints ? LEV : ILEV;
 
-  return FieldLayout({COL,VL},{get_num_local_dofs(),nvl});
+  return FieldLayout({COL,VL},{get_num_local_dofs(),nvl}).rename_dims(m_special_tag_names);
 }
 
 FieldLayout
@@ -100,7 +100,7 @@ PointGrid::get_3d_vector_layout (const bool midpoints, const int vector_dim,
 
   FieldLayout fl({COL,CMP,VL},{get_num_local_dofs(),vector_dim,nvl});
   fl.rename_dim(1,vec_dim_name);
-  return fl;
+  return fl.rename_dims(m_special_tag_names);
 }
 
 FieldLayout
@@ -126,7 +126,7 @@ PointGrid::get_3d_tensor_layout (const bool midpoints,
   }
   fl.append_dim(VL,nvl);
 
-  return fl;
+  return fl.rename_dims(m_special_tag_names);
 }
 
 std::shared_ptr<AbstractGrid>

--- a/components/eamxx/src/share/grid/point_grid.cpp
+++ b/components/eamxx/src/share/grid/point_grid.cpp
@@ -48,11 +48,11 @@ PointGrid::get_2d_scalar_layout () const
 }
 
 FieldLayout
-PointGrid::get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const
+PointGrid::get_2d_vector_layout (const int vector_dim) const
 {
   using namespace ShortFieldTagsNames;
 
-  return FieldLayout({COL,vector_tag},{get_num_local_dofs(),vector_dim});
+  return FieldLayout({COL,CMP},{get_num_local_dofs(),vector_dim});
 }
 
 FieldLayout
@@ -81,14 +81,14 @@ PointGrid::get_3d_scalar_layout (const bool midpoints) const
 }
 
 FieldLayout
-PointGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const
+PointGrid::get_3d_vector_layout (const bool midpoints, const int vector_dim) const
 {
   using namespace ShortFieldTagsNames;
 
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
   auto VL = midpoints ? LEV : ILEV;
 
-  return FieldLayout({COL,vector_tag,VL},{get_num_local_dofs(),vector_dim,nvl});
+  return FieldLayout({COL,CMP,VL},{get_num_local_dofs(),vector_dim,nvl});
 }
 
 FieldLayout

--- a/components/eamxx/src/share/grid/point_grid.hpp
+++ b/components/eamxx/src/share/grid/point_grid.hpp
@@ -44,12 +44,16 @@ public:
   // Native layout of a dof. This is the natural way to index a dof in the grid.
   // E.g., for a 2d structured grid, this could be a set of 2 indices.
   FieldLayout get_2d_scalar_layout () const override;
-  FieldLayout get_2d_vector_layout (const int vector_dim) const override;
-  FieldLayout get_2d_tensor_layout (const std::vector<int>& cmp_dims) const override;
+  FieldLayout get_2d_vector_layout (const int vector_dim,
+                                    const std::string& vec_dim_name) const override;
+  FieldLayout get_2d_tensor_layout (const std::vector<int>& cmp_dims,
+                                    const std::vector<std::string>& cmp_names) const override;
   FieldLayout get_3d_scalar_layout (const bool midpoints) const override;
-  FieldLayout get_3d_vector_layout (const bool midpoints, const int vector_dim) const override;
+  FieldLayout get_3d_vector_layout (const bool midpoints, const int vector_dim,
+                                    const std::string& vec_dim_name) const override;
   FieldLayout get_3d_tensor_layout (const bool midpoints,
-                                    const std::vector<int>& cmp_dims) const override;
+                                    const std::vector<int>& cmp_dims,
+                                    const std::vector<std::string>& cmp_names) const override;
 
   FieldTag get_partitioned_dim_tag () const override {
     return FieldTag::Column;

--- a/components/eamxx/src/share/grid/point_grid.hpp
+++ b/components/eamxx/src/share/grid/point_grid.hpp
@@ -44,13 +44,11 @@ public:
   // Native layout of a dof. This is the natural way to index a dof in the grid.
   // E.g., for a 2d structured grid, this could be a set of 2 indices.
   FieldLayout get_2d_scalar_layout () const override;
-  FieldLayout get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const override;
-  FieldLayout get_2d_tensor_layout (const std::vector<FieldTag>& cmp_tags,
-                                    const std::vector<int>& cmp_dims) const override;
+  FieldLayout get_2d_vector_layout (const int vector_dim) const override;
+  FieldLayout get_2d_tensor_layout (const std::vector<int>& cmp_dims) const override;
   FieldLayout get_3d_scalar_layout (const bool midpoints) const override;
-  FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const override;
+  FieldLayout get_3d_vector_layout (const bool midpoints, const int vector_dim) const override;
   FieldLayout get_3d_tensor_layout (const bool midpoints,
-                                    const std::vector<FieldTag>& cmp_tags,
                                     const std::vector<int>& cmp_dims) const override;
 
   FieldTag get_partitioned_dim_tag () const override {

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.cpp
@@ -33,18 +33,18 @@ register_field (const identifier_type& src, const identifier_type& tgt) {
   EKAT_REQUIRE_MSG(is_valid_src_layout(src.get_layout()),
       "Error! Source field has an invalid layout.\n"
       " - field name  : " + src.name() + "\n"
-      " - field layout: " + to_string(src.get_layout()) + "\n");
+      " - field layout: " + src.get_layout().to_string() + "\n");
   EKAT_REQUIRE_MSG(is_valid_tgt_layout(tgt.get_layout()),
       "Error! Source field has an invalid layout.\n"
       " - field name  : " + tgt.name() + "\n"
-      " - field layout: " + to_string(tgt.get_layout()) + "\n");
+      " - field layout: " + tgt.get_layout().to_string() + "\n");
 
   EKAT_REQUIRE_MSG(compatible_layouts(src.get_layout(),tgt.get_layout()),
       "Error! Source and target layouts are not compatible.\n"
       " - src name: " + src.name() + "\n"
       " - tgt name: " + tgt.name() + "\n"
-      " - src layout: " + to_string(src.get_layout()) + "\n"
-      " - tgt layout: " + to_string(tgt.get_layout()) + "\n");
+      " - src layout: " + src.get_layout().to_string() + "\n"
+      " - tgt layout: " + tgt.get_layout().to_string() + "\n");
 
   do_register_field (src,tgt);
 

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
@@ -163,8 +163,8 @@ public:
 
   virtual bool compatible_layouts (const layout_type& src,
                                    const layout_type& tgt) const {
-    // By default, the only compatible layouts are identical
-    return src==tgt;
+    // By default, the only compatible layouts are congruent
+    return src.congruent(tgt);
   }
 
   virtual bool is_valid_src_layout (const layout_type& layout) const {

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -927,7 +927,7 @@ void CoarseningRemapper::setup_mpi_data_structures ()
   for (int i=0; i<m_num_fields; ++i) {
     const auto& f  = m_src_fields[i];
     const auto& fl = f.get_header().get_identifier().get_layout();
-    field_col_size[i] = fl.strip_dim(COL).size();
+    field_col_size[i] = fl.clone().strip_dim(COL).size();
     sum_fields_col_sizes += field_col_size[i];
   }
 

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -133,13 +133,13 @@ do_bind_field (const int ifield, const field_type& src, const field_type& tgt)
       EKAT_REQUIRE_MSG(f_lt.has_tag(COL) == m_lt.has_tag(COL),
           "Error! Incompatible field and mask layouts.\n"
           "  - field name: " + src.name() + "\n"
-          "  - field layout: " + to_string(f_lt) + "\n"
-          "  - mask layout: " + to_string(m_lt) + "\n");
+          "  - field layout: " + f_lt.to_string() + "\n"
+          "  - mask layout: " + m_lt.to_string() + "\n");
       EKAT_REQUIRE_MSG(f_lt.has_tag(LEV) == m_lt.has_tag(LEV),
           "Error! Incompatible field and mask layouts.\n"
           "  - field name: " + src.name() + "\n"
-          "  - field layout: " + to_string(f_lt) + "\n"
-          "  - mask layout: " + to_string(m_lt) + "\n");
+          "  - field layout: " + f_lt.to_string() + "\n"
+          "  - mask layout: " + m_lt.to_string() + "\n");
     }
   }
   HorizInterpRemapperBase::do_bind_field(ifield,src,tgt);

--- a/components/eamxx/src/share/grid/remap/do_nothing_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/do_nothing_remapper.hpp
@@ -54,7 +54,7 @@ public:
       default:
         EKAT_ERROR_MSG (
           "[DoNothingRemapper] Error! Input target layout is not valid for this remapper.\n"
-          " - input layout: " + to_string(tgt));
+          " - input layout: " + tgt.to_string());
     }
     return src;
   }
@@ -79,7 +79,7 @@ public:
       default:
         EKAT_ERROR_MSG (
           "[DoNothingRemapper] Error! Input source layout is not valid for this remapper.\n"
-          " - input layout: " + to_string(src));
+          " - input layout: " + src.to_string());
     }
     return tgt;
   }

--- a/components/eamxx/src/share/grid/remap/do_nothing_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/do_nothing_remapper.hpp
@@ -48,13 +48,13 @@ public:
         src = this->m_src_grid->get_2d_scalar_layout();
         break;
       case LayoutType::Vector2D:
-        src = this->m_src_grid->get_2d_vector_layout(CMP,tgt.dim(CMP));
+        src = this->m_src_grid->get_2d_vector_layout(tgt.dim(CMP));
         break;
       case LayoutType::Scalar3D:
         src = this->m_src_grid->get_3d_scalar_layout(tgt.has_tag(LEV));
         break;
       case LayoutType::Vector3D:
-        src = this->m_src_grid->get_3d_vector_layout(tgt.has_tag(LEV),CMP,tgt.dim(CMP));
+        src = this->m_src_grid->get_3d_vector_layout(tgt.has_tag(LEV),tgt.dim(CMP));
         break;
       default:
         EKAT_ERROR_MSG ("Error! Unsupported field layout.\n");
@@ -76,13 +76,13 @@ public:
         tgt = this->m_tgt_grid->get_2d_scalar_layout();
         break;
       case LayoutType::Vector2D:
-        tgt = this->m_tgt_grid->get_2d_vector_layout(CMP,tgt.dim(CMP));
+        tgt = this->m_tgt_grid->get_2d_vector_layout(tgt.dim(CMP));
         break;
       case LayoutType::Scalar3D:
         tgt = this->m_tgt_grid->get_3d_scalar_layout(tgt.has_tag(LEV));
         break;
       case LayoutType::Vector3D:
-        tgt = this->m_tgt_grid->get_3d_vector_layout(tgt.has_tag(LEV),CMP,tgt.dim(CMP));
+        tgt = this->m_tgt_grid->get_3d_vector_layout(tgt.has_tag(LEV),tgt.dim(CMP));
         break;
       default:
         EKAT_ERROR_MSG ("Error! Unsupported field layout.\n");

--- a/components/eamxx/src/share/grid/remap/do_nothing_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/do_nothing_remapper.hpp
@@ -37,13 +37,8 @@ public:
   FieldLayout create_src_layout (const FieldLayout& tgt) const override {
     using namespace ShortFieldTagsNames;
 
-    EKAT_REQUIRE_MSG (is_valid_tgt_layout(tgt),
-        "[DoNothingRemapper] Error! Input target layout is not valid for this remapper.\n"
-        " - input layout: " + to_string(tgt));
-
-    auto type = get_layout_type(tgt.tags());
-    auto src = FieldLayout::invalid();
-    switch (type) {
+    FieldLayout src = {{},{}};
+    switch (tgt.type()) {
       case LayoutType::Scalar2D:
         src = this->m_src_grid->get_2d_scalar_layout();
         break;
@@ -57,7 +52,9 @@ public:
         src = this->m_src_grid->get_3d_vector_layout(tgt.has_tag(LEV),tgt.dim(CMP));
         break;
       default:
-        EKAT_ERROR_MSG ("Error! Unsupported field layout.\n");
+        EKAT_ERROR_MSG (
+          "[DoNothingRemapper] Error! Input target layout is not valid for this remapper.\n"
+          " - input layout: " + to_string(tgt));
     }
     return src;
   }
@@ -65,13 +62,8 @@ public:
   FieldLayout create_tgt_layout (const FieldLayout& src) const override {
     using namespace ShortFieldTagsNames;
 
-    EKAT_REQUIRE_MSG (is_valid_src_layout(src),
-        "[DoNothingRemapper] Error! Input source layout is not valid for this remapper.\n"
-        " - input layout: " + to_string(src));
-
-    auto type = get_layout_type(src.tags());
-    auto tgt = FieldLayout::invalid();
-    switch (type) {
+    FieldLayout tgt = {{},{}};
+    switch (src.type()) {
       case LayoutType::Scalar2D:
         tgt = this->m_tgt_grid->get_2d_scalar_layout();
         break;
@@ -85,7 +77,9 @@ public:
         tgt = this->m_tgt_grid->get_3d_vector_layout(tgt.has_tag(LEV),tgt.dim(CMP));
         break;
       default:
-        EKAT_ERROR_MSG ("Error! Unsupported field layout.\n");
+        EKAT_ERROR_MSG (
+          "[DoNothingRemapper] Error! Input source layout is not valid for this remapper.\n"
+          " - input layout: " + to_string(src));
     }
     return tgt;
   }

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -121,24 +121,34 @@ create_layout (const FieldLayout& fl_in,
         auto fl_out = FieldLayout::invalid();
   using namespace ShortFieldTagsNames;
   const bool midpoints = fl_in.has_tag(LEV);
+  std::vector<std::string> tdims_names;
+  std::string vdim_name;
   switch (fl_in.type()) {
     case LayoutType::Scalar2D:
       fl_out = grid->get_2d_scalar_layout();
       break;
     case LayoutType::Vector2D:
-      fl_out = grid->get_2d_vector_layout(fl_in.get_vector_dim());
+      vdim_name = fl_in.names()[fl_in.get_vector_component_idx()];
+      fl_out = grid->get_2d_vector_layout(fl_in.get_vector_dim(),vdim_name);
       break;
     case LayoutType::Tensor2D:
-      fl_out = grid->get_2d_tensor_layout(fl_in.get_tensor_dims());
+      for (auto idx  : fl_in.get_tensor_components_ids()) {
+        tdims_names.push_back(fl_in.names()[idx]);
+      }
+      fl_out = grid->get_2d_tensor_layout(fl_in.get_tensor_dims(),tdims_names);
       break;
     case LayoutType::Scalar3D:
       fl_out = grid->get_3d_scalar_layout(midpoints);
       break;
     case LayoutType::Vector3D:
-      fl_out = grid->get_3d_vector_layout(midpoints,fl_in.get_vector_dim());
+      vdim_name = fl_in.names()[fl_in.get_vector_component_idx()];
+      fl_out = grid->get_3d_vector_layout(midpoints,fl_in.get_vector_dim(),vdim_name);
       break;
     case LayoutType::Tensor3D:
-      fl_out = grid->get_3d_tensor_layout(midpoints,fl_in.get_tensor_dims());
+      for (auto idx  : fl_in.get_tensor_components_ids()) {
+        tdims_names.push_back(fl_in.names()[idx]);
+      }
+      fl_out = grid->get_3d_tensor_layout(midpoints,fl_in.get_tensor_dims(),tdims_names);
     default:
       EKAT_ERROR_MSG ("Layout not supported by HorizInterpRemapperBase:\n"
                       " - layout: " + to_string(fl_in) + "\n");

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -124,37 +124,37 @@ create_layout (const FieldLayout& fl_in,
   const bool midpoints = fl_in.has_tag(LEV);
   const bool is3d = fl_in.has_tag(LEV) or fl_in.has_tag(ILEV);
   switch (type) {
-    case LayoutType::Scalar2D: [[ fallthrough ]];
-    case LayoutType::Scalar3D:
-      fl_out = is3d
-             ? grid->get_3d_scalar_layout(midpoints)
-             : grid->get_2d_scalar_layout();
+    case LayoutType::Scalar2D:
+      fl_out = m_tgt_grid->get_2d_scalar_layout();
       break;
-    case LayoutType::Vector2D: [[ fallthrough ]];
-    case LayoutType::Vector3D:
+    case LayoutType::Vector2D:
+      fl_out = m_tgt_grid->get_2d_vector_layout(fl_in.dim(CMP));
+      break;
+    case LayoutType::Tensor2D:
     {
-      auto vtag = fl_in.get_vector_tag();
-      auto vdim = fl_in.dim(vtag);
-      fl_out = is3d
-             ? grid->get_3d_vector_layout(midpoints,vtag,vdim)
-             : grid->get_2d_vector_layout(vtag,vdim);
+      std::vector<int> tdims;
+      for (auto idx : fl_in.get_tensor_dims()) {
+        tdims.push_back(fl_in.dim(idx));
+      }   
+
+      fl_out = m_tgt_grid->get_2d_tensor_layout(fl_in.dim(CMP));
       break;
     }
-
-    case LayoutType::Tensor2D: [[ fallthrough ]];
+    case LayoutType::Scalar3D:
+      fl_out = grid->get_3d_scalar_layout(midpoints);
+      break;
+    case LayoutType::Vector3D:
+      fl_out = grid->get_3d_vector_layout(midpoints,fl_in.dim(CMP));
+      break;
     case LayoutType::Tensor3D:
     {
-      auto ttags = fl_in.get_tensor_tags();
       std::vector<int> tdims;
       for (auto idx : fl_in.get_tensor_dims()) {
         tdims.push_back(fl_in.dim(idx));
       }
-      fl_out = is3d
-             ? grid->get_3d_tensor_layout(midpoints,ttags,tdims)
-             : grid->get_2d_tensor_layout(ttags,tdims);
+      fl_out = grid->get_3d_tensor_layout(midpoints,tdims);
       break;
     }
-
     default:
       EKAT_ERROR_MSG ("Layout not supported by HorizInterpRemapperBase:\n"
                       " - layout: " + to_string(fl_in) + "\n");

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -96,7 +96,7 @@ create_src_layout (const FieldLayout& tgt_layout) const
 
   EKAT_REQUIRE_MSG (is_valid_tgt_layout(tgt_layout),
       "[HorizInterpRemapperBase] Error! Input target layout is not valid for this remapper.\n"
-      " - input layout: " + to_string(tgt_layout));
+      " - input layout: " + tgt_layout.to_string());
 
   return create_layout (tgt_layout, m_src_grid);
 }
@@ -109,7 +109,7 @@ create_tgt_layout (const FieldLayout& src_layout) const
 
   EKAT_REQUIRE_MSG (is_valid_src_layout(src_layout),
       "[HorizInterpRemapperBase] Error! Input source layout is not valid for this remapper.\n"
-      " - input layout: " + to_string(src_layout));
+      " - input layout: " + src_layout.to_string());
 
   return create_layout (src_layout, m_tgt_grid);
 }
@@ -151,7 +151,7 @@ create_layout (const FieldLayout& fl_in,
       fl_out = grid->get_3d_tensor_layout(midpoints,fl_in.get_tensor_dims(),tdims_names);
     default:
       EKAT_ERROR_MSG ("Layout not supported by HorizInterpRemapperBase:\n"
-                      " - layout: " + to_string(fl_in) + "\n");
+                      " - layout: " + fl_in.to_string() + "\n");
   }
   return fl_out;
 }
@@ -171,7 +171,7 @@ do_register_field (const identifier_type& src, const identifier_type& tgt)
   EKAT_REQUIRE_MSG (src.get_layout().has_tag(COL),
       "Error! Cannot register a field without COL tag in RefiningRemapperP2P.\n"
       "  - field name: " + src.name() + "\n"
-      "  - field layout: " + to_string(src.get_layout()) + "\n");
+      "  - field layout: " + src.get_layout().to_string() + "\n");
   m_src_fields.push_back(field_type(src));
   m_tgt_fields.push_back(field_type(tgt));
 }

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -119,11 +119,10 @@ create_layout (const FieldLayout& fl_in,
                const grid_ptr_type& grid) const
 {
   using namespace ShortFieldTagsNames;
-  const auto type = get_layout_type(fl_in.tags());
         auto fl_out = FieldLayout::invalid();
   const bool midpoints = fl_in.has_tag(LEV);
   const bool is3d = fl_in.has_tag(LEV) or fl_in.has_tag(ILEV);
-  switch (type) {
+  switch (fl_in.type()) {
     case LayoutType::Scalar2D:
       fl_out = m_tgt_grid->get_2d_scalar_layout();
       break;

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -118,42 +118,27 @@ FieldLayout HorizInterpRemapperBase::
 create_layout (const FieldLayout& fl_in,
                const grid_ptr_type& grid) const
 {
-  using namespace ShortFieldTagsNames;
         auto fl_out = FieldLayout::invalid();
+  using namespace ShortFieldTagsNames;
   const bool midpoints = fl_in.has_tag(LEV);
-  const bool is3d = fl_in.has_tag(LEV) or fl_in.has_tag(ILEV);
   switch (fl_in.type()) {
     case LayoutType::Scalar2D:
-      fl_out = m_tgt_grid->get_2d_scalar_layout();
+      fl_out = grid->get_2d_scalar_layout();
       break;
     case LayoutType::Vector2D:
-      fl_out = m_tgt_grid->get_2d_vector_layout(fl_in.dim(CMP));
+      fl_out = grid->get_2d_vector_layout(fl_in.get_vector_dim());
       break;
     case LayoutType::Tensor2D:
-    {
-      std::vector<int> tdims;
-      for (auto idx : fl_in.get_tensor_dims()) {
-        tdims.push_back(fl_in.dim(idx));
-      }   
-
-      fl_out = m_tgt_grid->get_2d_tensor_layout(fl_in.dim(CMP));
+      fl_out = grid->get_2d_tensor_layout(fl_in.get_tensor_dims());
       break;
-    }
     case LayoutType::Scalar3D:
       fl_out = grid->get_3d_scalar_layout(midpoints);
       break;
     case LayoutType::Vector3D:
-      fl_out = grid->get_3d_vector_layout(midpoints,fl_in.dim(CMP));
+      fl_out = grid->get_3d_vector_layout(midpoints,fl_in.get_vector_dim());
       break;
     case LayoutType::Tensor3D:
-    {
-      std::vector<int> tdims;
-      for (auto idx : fl_in.get_tensor_dims()) {
-        tdims.push_back(fl_in.dim(idx));
-      }
-      fl_out = grid->get_3d_tensor_layout(midpoints,tdims);
-      break;
-    }
+      fl_out = grid->get_3d_tensor_layout(midpoints,fl_in.get_tensor_dims());
     default:
       EKAT_ERROR_MSG ("Layout not supported by HorizInterpRemapperBase:\n"
                       " - layout: " + to_string(fl_in) + "\n");
@@ -213,7 +198,7 @@ void HorizInterpRemapperBase::create_ov_fields ()
   for (int i=0; i<m_num_fields; ++i) {
     const auto& f = m_type==InterpType::Refine ? m_tgt_fields[i] : m_src_fields[i];
     const auto& fid = f.get_header().get_identifier();
-    const auto layout = fid.get_layout().clone_with_different_extent(0,num_ov_gids);
+    const auto layout = fid.get_layout().clone().reset_dim(0,num_ov_gids);
     FieldIdentifier ov_fid (fid.name(),layout,fid.get_units(),ov_gn,dt);
 
     auto& ov_f = m_ov_fields.emplace_back(ov_fid);

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.hpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.hpp
@@ -34,7 +34,8 @@ public:
     // be 0 src/tgt gids on some ranks, which means src/tgt.dim(0)=0.
     using namespace ShortFieldTagsNames;
 
-    return src.clone().strip_dim(COL)==tgt.clone().strip_dim(COL);
+    // Use congruence, since we don't really care about dimension names, only tags/extents
+    return src.clone().strip_dim(COL).congruent(tgt.clone().strip_dim(COL));
   }
 
 protected:

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.hpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.hpp
@@ -34,7 +34,7 @@ public:
     // be 0 src/tgt gids on some ranks, which means src/tgt.dim(0)=0.
     using namespace ShortFieldTagsNames;
 
-    return src.strip_dim(COL)==tgt.strip_dim(COL);
+    return src.clone().strip_dim(COL)==tgt.clone().strip_dim(COL);
   }
 
 protected:

--- a/components/eamxx/src/share/grid/remap/identity_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/identity_remapper.hpp
@@ -49,7 +49,7 @@ public:
   FieldLayout create_src_layout (const FieldLayout& tgt_layout) const override {
     EKAT_REQUIRE_MSG (is_valid_tgt_layout(tgt_layout),
         "[IdentityRemapper] Error! Input target layout is not valid for this remapper.\n"
-        " - input layout: " + to_string(tgt_layout));
+        " - input layout: " + tgt_layout.to_string());
 
     // Src and tgt grids are the same, so return the input
     return tgt_layout;
@@ -57,7 +57,7 @@ public:
   FieldLayout create_tgt_layout (const FieldLayout& src_layout) const override {
     EKAT_REQUIRE_MSG (is_valid_src_layout(src_layout),
         "[IdentityRemapper] Error! Input source layout is not valid for this remapper.\n"
-        " - input layout: " + to_string(src_layout));
+        " - input layout: " + src_layout.to_string());
 
     // Src and tgt grids are the same, so return the input
     return src_layout;

--- a/components/eamxx/src/share/grid/remap/refining_remapper_p2p.cpp
+++ b/components/eamxx/src/share/grid/remap/refining_remapper_p2p.cpp
@@ -89,7 +89,7 @@ void RefiningRemapperP2P::setup_mpi_data_structures ()
   for (int i=0; i<m_num_fields; ++i) {
     const auto& f = m_src_fields[i];
     const auto& fl = f.get_header().get_identifier().get_layout();
-    const auto& col_size = fl.strip_dim(COL).size();
+    const auto& col_size = fl.clone().strip_dim(COL).size();
     m_fields_col_sizes_scan_sum[i+1] = m_fields_col_sizes_scan_sum[i] + col_size;
   }
   auto total_col_size = m_fields_col_sizes_scan_sum.back();

--- a/components/eamxx/src/share/grid/remap/refining_remapper_rma.cpp
+++ b/components/eamxx/src/share/grid/remap/refining_remapper_rma.cpp
@@ -121,7 +121,7 @@ void RefiningRemapperRMA::setup_mpi_data_structures ()
     const auto& fh = f.get_header();
     const auto& fap = fh.get_alloc_properties();
     const auto& layout = fh.get_identifier().get_layout();
-    m_col_size[i]   = layout.strip_dim(COL).size();
+    m_col_size[i]   = layout.clone().strip_dim(COL).size();
 
     const int col_stride = m_col_stride[i] = fap.get_num_scalars() / layout.dim(COL);
 

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -80,7 +80,7 @@ create_src_layout (const FieldLayout& tgt_layout) const
 
   EKAT_REQUIRE_MSG (is_valid_tgt_layout(tgt_layout),
       "[VerticalRemapper] Error! Input target layout is not valid for this remapper.\n"
-      " - input layout: " + to_string(tgt_layout));
+      " - input layout: " + tgt_layout.to_string());
 
   return create_layout(tgt_layout,m_src_grid);
 }
@@ -92,7 +92,7 @@ create_tgt_layout (const FieldLayout& src_layout) const
 
   EKAT_REQUIRE_MSG (is_valid_src_layout(src_layout),
       "[VerticalRemapper] Error! Input source layout is not valid for this remapper.\n"
-      " - input layout: " + to_string(src_layout));
+      " - input layout: " + src_layout.to_string());
 
   return create_layout(src_layout,m_tgt_grid);
 }
@@ -129,7 +129,7 @@ create_layout (const FieldLayout& fl_in,
       //       that needs to handle a tensor3d quantity, so no need to add it
       EKAT_ERROR_MSG (
         "[VerticalRemapper] Error! Layout not supported by VerticalRemapper.\n"
-        " - input layout: " + to_string(fl_in) + "\n");
+        " - input layout: " + fl_in.to_string() + "\n");
   }
   return fl_out;
 }
@@ -179,7 +179,7 @@ register_vertical_source_field(const Field& src)
   EKAT_REQUIRE_MSG (vert_tag==LEV or vert_tag==ILEV,
       "Error! Input vertical level field does not have a vertical level tag at the end.\n"
       " - field name: " + src.name() + "\n"
-      " - field layout: " + to_string(layout) + "\n");
+      " - field layout: " + layout.to_string() + "\n");
 
   if (vert_tag==LEV) {
     m_src_mid = src;

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -121,16 +121,15 @@ create_layout (const FieldLayout& fl_in,
     case LayoutType::Scalar1D:
       fl_out = grid_out->get_vertical_layout(true);
       break;
+    case LayoutType::Vector2D:
+      tgt = m_tgt_grid->get_2d_vector_layout(fl_in.dim(CMP));
+      break;
     case LayoutType::Scalar3D:
       fl_out = grid_out->get_3d_scalar_layout(true);
       break;
     case LayoutType::Vector3D:
-    {
-      const auto vec_tag = fl_in.get_vector_tag();
-      const auto vec_dim = fl_in.dim(vec_tag);
-      fl_out = grid_out->get_3d_vector_layout(true,vec_tag,vec_dim);
+      fl_out = grid_out->get_3d_vector_layout(true,vec_dim,fl_in.dim(CMP));
       break;
-    }
     default:
       // NOTE: this also include Tensor3D. We don't really have any atm proc
       //       that needs to handle a tensor3d quantity, so no need to add it

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -107,9 +107,8 @@ create_layout (const FieldLayout& fl_in,
   //       between midpoints and interfaces: we're simply asking for a quantity
   //       at a given set of pressure levels. So we choose to have fl_out
   //       to *always* have LEV as vertical tag.
-  const auto lt = get_layout_type(fl_in.tags());
   auto fl_out = FieldLayout::invalid();
-  switch (lt) {
+  switch (fl_in.type()) {
     case LayoutType::Scalar0D: [[ fallthrough ]];
     case LayoutType::Vector0D: [[ fallthrough ]];
     case LayoutType::Scalar2D: [[ fallthrough ]];
@@ -134,8 +133,8 @@ create_layout (const FieldLayout& fl_in,
       // NOTE: this also include Tensor3D. We don't really have any atm proc
       //       that needs to handle a tensor3d quantity, so no need to add it
       EKAT_ERROR_MSG (
-          "Layout not supported by VerticalRemapper.\n"
-          " - input layout: " + to_string(fl_in) + "\n");
+        "[VerticalRemapper] Error! Layout not supported by VerticalRemapper.\n"
+        " - input layout: " + to_string(fl_in) + "\n");
   }
   return fl_out;
 }

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -101,13 +101,11 @@ FieldLayout VerticalRemapper::
 create_layout (const FieldLayout& fl_in,
                const grid_ptr_type& grid_out) const
 {
-  using namespace ShortFieldTagsNames;
-
   // NOTE: for the vert remapper, it doesn't really make sense to distinguish
   //       between midpoints and interfaces: we're simply asking for a quantity
   //       at a given set of pressure levels. So we choose to have fl_out
   //       to *always* have LEV as vertical tag.
-  auto fl_out = FieldLayout::invalid();
+        auto fl_out = FieldLayout::invalid();
   switch (fl_in.type()) {
     case LayoutType::Scalar0D: [[ fallthrough ]];
     case LayoutType::Vector0D: [[ fallthrough ]];
@@ -120,14 +118,11 @@ create_layout (const FieldLayout& fl_in,
     case LayoutType::Scalar1D:
       fl_out = grid_out->get_vertical_layout(true);
       break;
-    case LayoutType::Vector2D:
-      tgt = m_tgt_grid->get_2d_vector_layout(fl_in.dim(CMP));
-      break;
     case LayoutType::Scalar3D:
       fl_out = grid_out->get_3d_scalar_layout(true);
       break;
     case LayoutType::Vector3D:
-      fl_out = grid_out->get_3d_vector_layout(true,vec_dim,fl_in.dim(CMP));
+      fl_out = grid_out->get_3d_vector_layout(true,fl_in.get_vector_dim());
       break;
     default:
       // NOTE: this also include Tensor3D. We don't really have any atm proc

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -216,7 +216,7 @@ do_bind_field (const int ifield, const field_type& src, const field_type& tgt)
   // Note, for vertical remapper we set all target fields as having LEV as the vertical dimension.  So we check that all other tags
   // between source and target match if source has ILEV
   if (has_ilev) {
-    EKAT_REQUIRE_MSG(src_layout.strip_dim(ILEV).tags()==tgt_layout.strip_dim(LEV).tags(),
+    EKAT_REQUIRE_MSG(src_layout.clone().strip_dim(ILEV).tags()==tgt_layout.clone().strip_dim(LEV).tags(),
         "ERROR! vert_remap:do_bind_field:" + name + ", tgt and src do not have the same set of field tags");
   } else {
     EKAT_REQUIRE_MSG(src_layout.tags()==tgt_layout.tags(),
@@ -248,7 +248,7 @@ do_bind_field (const int ifield, const field_type& src, const field_type& tgt)
     auto tags = src_lay.tags();
     for (auto tag : tags) {
       if (tag != COL && tag != LEV && tag != ILEV) {
-        src_lay = src_lay.strip_dim(tag);
+        src_lay.strip_dim(tag);
       }
     }
     const auto  lname  = src.get_header().get_identifier().get_id_string()+"_mask";

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -36,36 +36,16 @@ public:
 
   bool compatible_layouts (const layout_type& src,
                            const layout_type& tgt) const override {
-    // Same type of layout, and same sizes except for possibly the first one
-    // Note: we can't do tgt.size()/tgt.dim(0), since there may be 0 tgt gids
-    //       on some ranks, which means tgt.dim(0)=0.
-    // Note: for vertical remapping we strip out the LEV or ILEV dimension when
-    //       calculating the size.
-    auto src_dims = src.dims();
-    auto tgt_dims = tgt.dims();
-    auto src_size = src.rank();
-    auto tgt_size = tgt.rank();
+    // Strip the LEV/ILEV tags, and check if they are the same
+    // Also, check rank compatibility, in case one has LEV/ILEV and the other doesn't
+    // NOTE: tgt layouts always use LEV (not ILEV), while src can have ILEV or LEV.
 
     using namespace ShortFieldTagsNames;
-    if (src.has_tag(LEV) || src.has_tag(ILEV)) {
-      // Then we ignore the last dimension:
-      src_size -= 1; 
-    } 
-    if (tgt.has_tag(LEV) || tgt.has_tag(ILEV)) {
-      // Then we ignore the last dimension:
-      tgt_size -= 1; 
-    } 
+    auto src_stripped = src.clone().strip_dim(ILEV,false).strip_dim(LEV,false);
+    auto tgt_stripped = tgt.clone().strip_dim(LEV,false);
 
-    int src_col_size = 1;
-    for (int i=0; i<src_size; ++i) {
-      src_col_size *= src_dims[i];
-    }
-    int tgt_col_size = 1;
-    for (int i=0; i<tgt_size; ++i) {
-      tgt_col_size *= tgt_dims[i];
-    }
-    return src.type()==tgt.type() &&
-           src_col_size == tgt_col_size;
+    return src.rank()==tgt.rank() and
+           src_stripped.congruent(tgt_stripped);
   }
 
   // NOTE: for the vert remapper, it doesn't really make sense to distinguish

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -64,7 +64,7 @@ public:
     for (int i=0; i<tgt_size; ++i) {
       tgt_col_size *= tgt_dims[i];
     }
-    return get_layout_type(src.tags())==get_layout_type(tgt.tags()) &&
+    return src.type()==tgt.type() &&
            src_col_size == tgt_col_size;
   }
 

--- a/components/eamxx/src/share/grid/se_grid.cpp
+++ b/components/eamxx/src/share/grid/se_grid.cpp
@@ -40,29 +40,37 @@ SEGrid::get_2d_scalar_layout () const
 }
 
 FieldLayout
-SEGrid::get_2d_vector_layout (const int vector_dim) const
+SEGrid::get_2d_vector_layout (const int vector_dim, const std::string& vec_dim_name) const
 {
   using namespace ShortFieldTagsNames;
 
-  return FieldLayout({EL,CMP,GP,GP},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp});
+  FieldLayout fl({EL,CMP,GP,GP},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp});
+  fl.rename_dim(1,vec_dim_name);
+  return fl;
 }
 
 FieldLayout
-SEGrid::get_2d_tensor_layout (const std::vector<FieldTag>& cmp_tags,
-                              const std::vector<int>& cmp_dims) const
+SEGrid::get_2d_tensor_layout (const std::vector<int>& cmp_dims,
+                              const std::vector<std::string>& cmp_names) const
 {
+  EKAT_REQUIRE_MSG (cmp_names.size()==cmp_dims.size(),
+      "[SEGrid::get_2d_tensor_layout] Input vector dimensions mismatch.\n"
+      "  - grid name: " + name() + "\n"
+      "  - cmp_names: " + ekat::join(cmp_names,",") + "\n"
+      "  - cmp_dims : " + ekat::join(cmp_dims,",") + "\n");
+
   using namespace ShortFieldTagsNames;
 
-  std::vector<FieldTag> tags = {EL};
-  std::vector<int>      dims = {m_num_local_elem};
+  FieldLayout fl;
 
-  tags.insert(tags.end(),cmp_tags.begin(),cmp_tags.end());
-  dims.insert(dims.end(),cmp_dims.begin(),cmp_dims.end());
-  tags.push_back(GP);
-  tags.push_back(GP);
-  dims.push_back(m_num_gp);
-  dims.push_back(m_num_gp);
-  return FieldLayout(tags,dims);
+  fl = fl.append_dim(EL,m_num_local_elem);
+
+  for (size_t i=0; i<cmp_dims.size(); ++i) {
+    fl.append_dim(CMP,cmp_dims[i],cmp_names[i]);
+  }
+  fl.append_dim(GP,m_num_gp);
+
+  return fl;
 }
 
 FieldLayout
@@ -77,38 +85,46 @@ SEGrid::get_3d_scalar_layout (const bool midpoints) const
 }
 
 FieldLayout
-SEGrid::get_3d_vector_layout (const bool midpoints, const int vector_dim) const
+SEGrid::get_3d_vector_layout (const bool midpoints, const int vector_dim,
+                              const std::string& vec_dim_name) const
 {
   using namespace ShortFieldTagsNames;
 
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
   auto VL = midpoints ? LEV : ILEV;
 
-  return FieldLayout({EL,CMP,GP,GP,VL},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp,nvl});
+  FieldLayout fl({EL,CMP,GP,GP,VL},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp,nvl});
+  fl.rename_dim(1,vec_dim_name);
+  return fl;
 }
 
 FieldLayout
 SEGrid::get_3d_tensor_layout (const bool midpoints,
-                              const std::vector<FieldTag>& cmp_tags,
-                              const std::vector<int>& cmp_dims) const
+                              const std::vector<int>& cmp_dims,
+                              const std::vector<std::string>& cmp_names) const
 {
+  EKAT_REQUIRE_MSG (cmp_names.size()==cmp_dims.size(),
+      "[SEGrid::get_2d_tensor_layout] Input vector dimensions mismatch.\n"
+      "  - grid name: " + name() + "\n"
+      "  - cmp_names: " + ekat::join(cmp_names,",") + "\n"
+      "  - cmp_dims : " + ekat::join(cmp_dims,",") + "\n");
+
   using namespace ShortFieldTagsNames;
 
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
   auto VL = midpoints ? LEV : ILEV;
 
-  std::vector<FieldTag> tags = {EL};
-  std::vector<int>      dims = {m_num_local_elem};
+  FieldLayout fl;
 
-  tags.insert(tags.end(),cmp_tags.begin(),cmp_tags.end());
-  dims.insert(dims.end(),cmp_dims.begin(),cmp_dims.end());
-  tags.push_back(GP);
-  tags.push_back(GP);
-  tags.push_back(VL);
-  dims.push_back(m_num_gp);
-  dims.push_back(m_num_gp);
-  dims.push_back(nvl);
-  return FieldLayout(tags,dims);
+  fl.append_dim(EL,m_num_local_elem);
+
+  for (size_t i=0; i<cmp_dims.size(); ++i) {
+    fl.append_dim(CMP,cmp_dims[i],cmp_names[i]);
+  }
+  fl.append_dim(GP,m_num_gp);
+  fl.append_dim(VL,nvl);
+
+  return fl;
 }
 
 Field SEGrid::get_cg_dofs_gids ()

--- a/components/eamxx/src/share/grid/se_grid.cpp
+++ b/components/eamxx/src/share/grid/se_grid.cpp
@@ -36,7 +36,7 @@ SEGrid::get_2d_scalar_layout () const
 {
   using namespace ShortFieldTagsNames;
 
-  return FieldLayout({EL,GP,GP},{m_num_local_elem,m_num_gp,m_num_gp});
+  return FieldLayout({EL,GP,GP},{m_num_local_elem,m_num_gp,m_num_gp}).rename_dims(m_special_tag_names);
 }
 
 FieldLayout
@@ -46,7 +46,7 @@ SEGrid::get_2d_vector_layout (const int vector_dim, const std::string& vec_dim_n
 
   FieldLayout fl({EL,CMP,GP,GP},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp});
   fl.rename_dim(1,vec_dim_name);
-  return fl;
+  return fl.rename_dims(m_special_tag_names);
 }
 
 FieldLayout
@@ -70,7 +70,7 @@ SEGrid::get_2d_tensor_layout (const std::vector<int>& cmp_dims,
   }
   fl.append_dim(GP,m_num_gp);
 
-  return fl;
+  return fl.rename_dims(m_special_tag_names);
 }
 
 FieldLayout
@@ -81,7 +81,7 @@ SEGrid::get_3d_scalar_layout (const bool midpoints) const
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
   auto VL = midpoints ? LEV : ILEV;
 
-  return FieldLayout({EL,GP,GP,VL},{m_num_local_elem,m_num_gp,m_num_gp,nvl});
+  return FieldLayout({EL,GP,GP,VL},{m_num_local_elem,m_num_gp,m_num_gp,nvl}).rename_dims(m_special_tag_names);
 }
 
 FieldLayout
@@ -95,7 +95,7 @@ SEGrid::get_3d_vector_layout (const bool midpoints, const int vector_dim,
 
   FieldLayout fl({EL,CMP,GP,GP,VL},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp,nvl});
   fl.rename_dim(1,vec_dim_name);
-  return fl;
+  return fl.rename_dims(m_special_tag_names);
 }
 
 FieldLayout
@@ -124,7 +124,7 @@ SEGrid::get_3d_tensor_layout (const bool midpoints,
   fl.append_dim(GP,m_num_gp);
   fl.append_dim(VL,nvl);
 
-  return fl;
+  return fl.rename_dims(m_special_tag_names);
 }
 
 Field SEGrid::get_cg_dofs_gids ()

--- a/components/eamxx/src/share/grid/se_grid.cpp
+++ b/components/eamxx/src/share/grid/se_grid.cpp
@@ -40,11 +40,11 @@ SEGrid::get_2d_scalar_layout () const
 }
 
 FieldLayout
-SEGrid::get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const
+SEGrid::get_2d_vector_layout (const int vector_dim) const
 {
   using namespace ShortFieldTagsNames;
 
-  return FieldLayout({EL,vector_tag,GP,GP},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp});
+  return FieldLayout({EL,CMP,GP,GP},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp});
 }
 
 FieldLayout
@@ -77,14 +77,14 @@ SEGrid::get_3d_scalar_layout (const bool midpoints) const
 }
 
 FieldLayout
-SEGrid::get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const
+SEGrid::get_3d_vector_layout (const bool midpoints, const int vector_dim) const
 {
   using namespace ShortFieldTagsNames;
 
   int nvl = this->get_num_vertical_levels() + (midpoints ? 0 : 1);
   auto VL = midpoints ? LEV : ILEV;
 
-  return FieldLayout({EL,vector_tag,GP,GP,VL},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp,nvl});
+  return FieldLayout({EL,CMP,GP,GP,VL},{m_num_local_elem,vector_dim,m_num_gp,m_num_gp,nvl});
 }
 
 FieldLayout

--- a/components/eamxx/src/share/grid/se_grid.hpp
+++ b/components/eamxx/src/share/grid/se_grid.hpp
@@ -21,12 +21,16 @@ public:
 
   // Native layout of a dof. This is the natural way to index a dof in the grid.
   FieldLayout get_2d_scalar_layout () const override;
-  FieldLayout get_2d_vector_layout (const int vector_dim) const override;
-  FieldLayout get_2d_tensor_layout (const std::vector<int>& cmp_dims) const override;
+  FieldLayout get_2d_vector_layout (const int vector_dim,
+                                    const std::string& vec_dim_name) const override;
+  FieldLayout get_2d_tensor_layout (const std::vector<int>& cmp_dims,
+                                    const std::vector<std::string>& cmp_names) const override;
   FieldLayout get_3d_scalar_layout (const bool midpoints) const override;
-  FieldLayout get_3d_vector_layout (const bool midpoints, const int vector_dim) const override;
+  FieldLayout get_3d_vector_layout (const bool midpoints, const int vector_dim,
+                                    const std::string& vec_dim_name) const override;
   FieldLayout get_3d_tensor_layout (const bool midpoints,
-                                    const std::vector<int>& cmp_dims) const override;
+                                    const std::vector<int>& cmp_dims,
+                                    const std::vector<std::string>& cmp_names) const override;
 
   FieldTag get_partitioned_dim_tag () const override {
     return FieldTag::Element;

--- a/components/eamxx/src/share/grid/se_grid.hpp
+++ b/components/eamxx/src/share/grid/se_grid.hpp
@@ -21,13 +21,11 @@ public:
 
   // Native layout of a dof. This is the natural way to index a dof in the grid.
   FieldLayout get_2d_scalar_layout () const override;
-  FieldLayout get_2d_vector_layout (const FieldTag vector_tag, const int vector_dim) const override;
-  FieldLayout get_2d_tensor_layout (const std::vector<FieldTag>& cmp_tags,
-                                    const std::vector<int>& cmp_dims) const override;
+  FieldLayout get_2d_vector_layout (const int vector_dim) const override;
+  FieldLayout get_2d_tensor_layout (const std::vector<int>& cmp_dims) const override;
   FieldLayout get_3d_scalar_layout (const bool midpoints) const override;
-  FieldLayout get_3d_vector_layout (const bool midpoints, const FieldTag vector_tag, const int vector_dim) const override;
+  FieldLayout get_3d_vector_layout (const bool midpoints, const int vector_dim) const override;
   FieldLayout get_3d_tensor_layout (const bool midpoints,
-                                    const std::vector<FieldTag>& cmp_tags,
                                     const std::vector<int>& cmp_dims) const override;
 
   FieldTag get_partitioned_dim_tag () const override {

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -409,10 +409,9 @@ AtmosphereInput::get_vec_of_dims(const FieldLayout& layout)
   dims_names.reserve(layout.rank());
   for (int i=0; i<layout.rank(); ++i) {
     const FieldTag t = layout.tag(i);
+    dims_names.push_back(m_io_grid->get_dim_name(layout,i));
     if (t==CMP) {
-      dims_names.push_back("dim" + std::to_string(layout.dim(i)));
-    } else {
-      dims_names.push_back(m_io_grid->get_dim_name(t));
+      dims_names.back() += std::to_string(layout.dim(i));
     }
   }
 
@@ -428,7 +427,7 @@ get_io_decomp(const FieldLayout& layout)
   std::vector<int> range(layout.rank());
   std::iota(range.begin(),range.end(),0);
   auto tag_and_dim = [&](int i) {
-    return m_io_grid->get_dim_name(layout.tag(i)) +
+    return m_io_grid->get_dim_name(layout,i) +
            std::to_string(layout.dim(i));
   };
 

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -138,8 +138,8 @@ set_field_manager (const std::shared_ptr<const fm_type>& field_mgr)
       auto lay_curr   = field_curr.get_header().get_identifier().get_layout();
       auto lay_new    = field_new.get_header().get_identifier().get_layout();
       EKAT_REQUIRE_MSG(lay_curr==lay_new,"ERROR!! AtmosphereInput::set_field_manager - setting new field manager which has different layout for field " << name <<"\n"
-		      << "    Old Layout: " << to_string(lay_curr) << "\n"
-		      << "    New Layout: " << to_string(lay_new) << "\n");
+		      << "    Old Layout: " << lay_curr.to_string() << "\n"
+		      << "    New Layout: " << lay_new.to_string() << "\n");
     }
   }
 

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -408,9 +408,8 @@ AtmosphereInput::get_vec_of_dims(const FieldLayout& layout)
   std::vector<std::string> dims_names;
   dims_names.reserve(layout.rank());
   for (int i=0; i<layout.rank(); ++i) {
-    const FieldTag t = layout.tag(i);
     dims_names.push_back(m_io_grid->get_dim_name(layout,i));
-    if (t==CMP) {
+    if (dims_names.back()=="dim") {
       dims_names.back() += std::to_string(layout.dim(i));
     }
   }

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -759,7 +759,7 @@ void AtmosphereOutput::register_dimensions(const std::string& name)
     const auto& tags = layout.tags();
     const auto& dims = layout.dims();
     auto tag_name = m_io_grid->get_dim_name(layout,i);
-    if (tags[i]==CMP) {
+    if (tag_name=="dim") {
       tag_name += std::to_string(dims[i]);
     }
     auto tag_loc = m_dims.find(tag_name);
@@ -935,7 +935,7 @@ register_variables(const std::string& filename,
     std::vector<std::string> vec_of_dims;
     for (int i=0; i<layout.rank(); ++i) {
       auto tag_name = m_io_grid->get_dim_name(layout,i);
-      if (layout.tag(i)==CMP) {
+      if (tag_name=="dim") {
         tag_name += std::to_string(layout.dim(i));
       }
       vec_of_dims.push_back(tag_name); // Add dimensions string to vector of dims.

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -758,7 +758,7 @@ void AtmosphereOutput::register_dimensions(const std::string& name)
     // check tag against m_dims map.  If not in there, then add it.
     const auto& tags = layout.tags();
     const auto& dims = layout.dims();
-    auto tag_name = m_io_grid->get_dim_name(tags[i]);
+    auto tag_name = m_io_grid->get_dim_name(layout,i);
     if (tags[i]==CMP) {
       tag_name += std::to_string(dims[i]);
     }
@@ -855,7 +855,7 @@ void AtmosphereOutput::set_avg_cnt_tracking(const std::string& name, const Field
   if (m_track_avg_cnt) {
     std::string avg_cnt_name = "avg_count" + avg_cnt_suffix;
     for (int ii=0; ii<layout.rank(); ++ii) {
-      auto tag_name = m_io_grid->get_dim_name(layout.tag(ii));
+      auto tag_name = m_io_grid->get_dim_name(layout,ii);
       avg_cnt_name += "_" + tag_name;
     }
     if (std::find(m_avg_cnt_names.begin(),m_avg_cnt_names.end(),avg_cnt_name)==m_avg_cnt_names.end()) {
@@ -919,7 +919,7 @@ register_variables(const std::string& filename,
     std::vector<int> range(layout.rank());
     std::iota(range.begin(),range.end(),0);
     auto tag_and_dim = [&](int i) {
-      return m_io_grid->get_dim_name(layout.tag(i)) +
+      return m_io_grid->get_dim_name(layout,i) +
              std::to_string(layout.dim(i));
     };
 
@@ -934,7 +934,7 @@ register_variables(const std::string& filename,
   auto set_vec_of_dims = [&](const FieldLayout& layout) {
     std::vector<std::string> vec_of_dims;
     for (int i=0; i<layout.rank(); ++i) {
-      auto tag_name = m_io_grid->get_dim_name(layout.tag(i));
+      auto tag_name = m_io_grid->get_dim_name(layout,i);
       if (layout.tag(i)==CMP) {
         tag_name += std::to_string(layout.dim(i));
       }

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1462,7 +1462,7 @@ update_avg_cnt_view(const Field& field, view_1d_dev& dev_view) {
       EKAT_ERROR_MSG (
             "Error! Field rank not not supported by AtmosphereOutput.\n"
           "  - field name:   " + field.name() + "\n"
-          "  - field layout: " + to_string(layout) + "\n");
+          "  - field layout: " + layout.to_string() + "\n");
   }
 }
 

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -160,36 +160,25 @@ get_test_fm(const std::shared_ptr<const AbstractGrid>& grid)
   using namespace ShortFieldTagsNames;
   using namespace ekat::units;
 
-  using FL = FieldLayout;
   using FR = FieldRequest;
   using SL = std::list<std::string>;
 
   // Create a fm
   auto fm = std::make_shared<FieldManager>(grid);
 
-  const int num_lcols = grid->get_num_local_dofs();
-  const int num_levs = grid->get_num_vertical_levels();
-
-  // Create some fields for this fm
-  std::vector<FieldTag> tag_h  = {COL};
-  std::vector<FieldTag> tag_v  = {LEV};
-  std::vector<FieldTag> tag_2d = {COL,LEV};
-  std::vector<FieldTag> tag_3d = {COL,CMP,LEV};
-  std::vector<FieldTag> tag_bnd = {COL,SWBND,LEV};
-
-  std::vector<Int>     dims_h  = {num_lcols};
-  std::vector<Int>     dims_v  = {num_levs};
-  std::vector<Int>     dims_2d = {num_lcols,num_levs};
-  std::vector<Int>     dims_3d = {num_lcols,2,num_levs};
-  std::vector<Int>     dims_bnd = {num_lcols,3,num_levs};
+  auto scalar_1d = grid->get_vertical_layout(true);
+  auto scalar_2d = grid->get_2d_scalar_layout();
+  auto scalar_3d = grid->get_3d_scalar_layout(true);
+  auto vector_3d = grid->get_3d_vector_layout(true,2);
+  auto rad_vector_3d = grid->get_3d_vector_layout(true,3,"SWBND");
 
   const std::string& gn = grid->name();
 
-  FieldIdentifier fid1("field_1",FL{tag_h,dims_h},m,gn);
-  FieldIdentifier fid2("field_2",FL{tag_v,dims_v},kg,gn);
-  FieldIdentifier fid3("field_3",FL{tag_2d,dims_2d},kg/m,gn);
-  FieldIdentifier fid4("field_4",FL{tag_3d,dims_3d},kg/m,gn);
-  FieldIdentifier fid5("field_5",FL{tag_bnd,dims_bnd},m*m,gn);
+  FieldIdentifier fid1("field_1",scalar_2d,    m,   gn);
+  FieldIdentifier fid2("field_2",scalar_1d,    kg,  gn);
+  FieldIdentifier fid3("field_3",scalar_3d,    kg/m,gn);
+  FieldIdentifier fid4("field_4",vector_3d,    kg/m,gn);
+  FieldIdentifier fid5("field_5",rad_vector_3d,m*m, gn);
 
   // Register fields with fm
   fm->registration_begins();
@@ -284,14 +273,14 @@ void time_advance (const FieldManager& fm,
           for (int i=0; i<fl.dim(0); ++i) {
             for (int j=0; j<fl.dim(1); ++j) {
               for (int k=0; k<fl.dim(2); ++k) {
-		if (fname == "field_5") {
-		  // field_5 is used to test restarts w/ filled values, so
-		  // we cycle between filled and unfilled states.
-		  v(i,j,k) = (v(i,j,k)==FillValue) ? dt :
-			  ( (v(i,j,k)==1.0) ? 2.0*dt : FillValue );
-		} else {
-                  v(i,j,k) += dt;
-		}
+                if (fname == "field_5") {
+                  // field_5 is used to test restarts w/ filled values, so
+                  // we cycle between filled and unfilled states.
+                  v(i,j,k) = (v(i,j,k)==FillValue) ? dt :
+                    ( (v(i,j,k)==1.0) ? 2.0*dt : FillValue );
+                } else {
+                              v(i,j,k) += dt;
+                }
               }
             }
           }

--- a/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
@@ -376,9 +376,9 @@ TEST_CASE("coarsening_remap")
       auto gtgt = all_gather_field(tgt_f[ifield],comm);
 
       const auto& l = gsrc.get_header().get_identifier().get_layout();
-      const auto ls = to_string(l);
+      const auto ls = l.to_string();
       std::string dots (30-ls.size(),'.');
-      auto msg = "   -> Checking field with layout " + to_string(l) + " " + dots;
+      auto msg = "   -> Checking field with layout " + ls + " " + dots;
       root_print (msg + "\n",comm);
       bool ok = true;
       switch (l.type()) {

--- a/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
@@ -110,26 +110,25 @@ constexpr int tens_dim2 = 4;
 Field create_field (const std::string& name, const LayoutType lt, const AbstractGrid& grid, const bool midpoints)
 {
   const auto u = ekat::units::Units::nondimensional();
-  const auto CMP = ShortFieldTagsNames::CMP;
   const auto& gn = grid.name();
   Field f;
   switch (lt) {
     case LayoutType::Scalar2D:
       f = Field(FieldIdentifier(name,grid.get_2d_scalar_layout(),u,gn));  break;
     case LayoutType::Vector2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(CMP,vec_dim),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(vec_dim),u,gn));  break;
     case LayoutType::Tensor2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_tensor_layout({CMP,CMP},{tens_dim1,tens_dim2}),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_tensor_layout({tens_dim1,tens_dim2}),u,gn));  break;
     case LayoutType::Scalar3D:
       f = Field(FieldIdentifier(name,grid.get_3d_scalar_layout(midpoints),u,gn));
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
       break;
     case LayoutType::Vector3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(midpoints,CMP,vec_dim),u,gn));
+      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(midpoints,vec_dim),u,gn));
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
       break;
     case LayoutType::Tensor3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_tensor_layout(midpoints,{CMP,CMP},{tens_dim1,tens_dim2}),u,gn));
+      f = Field(FieldIdentifier(name,grid.get_3d_tensor_layout(midpoints,{tens_dim1,tens_dim2}),u,gn));
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
       break;
     default:

--- a/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
@@ -381,7 +381,7 @@ TEST_CASE("coarsening_remap")
       auto msg = "   -> Checking field with layout " + to_string(l) + " " + dots;
       root_print (msg + "\n",comm);
       bool ok = true;
-      switch (get_layout_type(l.tags())) {
+      switch (l.type()) {
         case LayoutType::Scalar2D:
         {
           const auto v_src = gsrc.get_view<const Real*,Host>();

--- a/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
@@ -161,7 +161,7 @@ Field all_gather_field_impl (const Field& f, const ekat::Comm& comm) {
   constexpr auto COL = ShortFieldTagsNames::COL;
   const auto& fid = f.get_header().get_identifier();
   const auto& fl  = fid.get_layout();
-  int col_size = fl.strip_dim(COL).size();
+  int col_size = fl.clone().strip_dim(COL).size();
   auto tags = fl.tags();
   auto dims = fl.dims();
   int my_cols = dims[0];;

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -31,12 +31,12 @@ TEST_CASE("field_layout", "") {
   FieldLayout fl5 ({COL,CMP,LEV},{1,1,1});
   FieldLayout fl6 ({COL,ISCCPTAU,ISCCPPRS,ILEV},{1,1,1,1});
 
-  REQUIRE (get_layout_type(fl1.tags())==LayoutType::Scalar2D);
-  REQUIRE (get_layout_type(fl2.tags())==LayoutType::Vector2D);
-  REQUIRE (get_layout_type(fl3.tags())==LayoutType::Tensor2D);
-  REQUIRE (get_layout_type(fl4.tags())==LayoutType::Scalar3D);
-  REQUIRE (get_layout_type(fl5.tags())==LayoutType::Vector3D);
-  REQUIRE (get_layout_type(fl6.tags())==LayoutType::Tensor3D);
+  REQUIRE (fl1.type()==LayoutType::Scalar2D);
+  REQUIRE (fl2.type()==LayoutType::Vector2D);
+  REQUIRE (fl3.type()==LayoutType::Tensor2D);
+  REQUIRE (fl4.type()==LayoutType::Scalar3D);
+  REQUIRE (fl5.type()==LayoutType::Vector3D);
+  REQUIRE (fl6.type()==LayoutType::Tensor3D);
 
   REQUIRE (not fl1.is_vector_layout());
   REQUIRE (    fl2.is_vector_layout());

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -26,10 +26,10 @@ TEST_CASE("field_layout", "") {
 
   FieldLayout fl1 ({COL},{1});
   FieldLayout fl2 ({COL,CMP},{1,1});
-  FieldLayout fl3 ({COL,SWBND,LWBND},{1,1,1});
+  FieldLayout fl3 ({COL,CMP,CMP},{1,3,4});
   FieldLayout fl4 ({COL,LEV},{1,1});
   FieldLayout fl5 ({COL,CMP,LEV},{1,1,1});
-  FieldLayout fl6 ({COL,ISCCPTAU,ISCCPPRS,ILEV},{1,1,1,1});
+  FieldLayout fl6 ({COL,CMP,CMP,ILEV},{1,5,6,1});
 
   REQUIRE (fl1.type()==LayoutType::Scalar2D);
   REQUIRE (fl2.type()==LayoutType::Vector2D);
@@ -59,10 +59,10 @@ TEST_CASE("field_layout", "") {
   REQUIRE (fl2.get_vector_dim()==1);
   REQUIRE (fl5.get_vector_dim()==1);
 
-  REQUIRE (fl3.get_tensor_tags()==TVec{SWBND,LWBND});
-  REQUIRE (fl6.get_tensor_tags()==TVec{ISCCPTAU,ISCCPPRS});
-  REQUIRE (fl3.get_tensor_dims()==IVec{1,2});
-  REQUIRE (fl6.get_tensor_dims()==IVec{1,2});
+  REQUIRE (fl3.get_tensor_tags()==TVec{CMP,CMP});
+  REQUIRE (fl6.get_tensor_components_ids()==IVec{1,2});
+  REQUIRE (fl3.get_tensor_dims()==IVec{3,4});
+  REQUIRE (fl6.get_tensor_dims()==IVec{5,6});
 }
 
 TEST_CASE("field_identifier", "") {

--- a/components/eamxx/src/share/tests/field_utils.cpp
+++ b/components/eamxx/src/share/tests/field_utils.cpp
@@ -327,7 +327,7 @@ TEST_CASE ("print_field_hyperslab") {
     print_field_hyperslab(f,loc_tags,loc_idxs,out);
 
     std::stringstream expected;
-    expected << "     f" << to_string(fid.get_layout()) << "\n\n";
+    expected << "     f" << fid.get_layout().to_string() << "\n\n";
       for (int gp1=0; gp1<ngp; ++gp1) {
         for (int gp2=0; gp2<ngp; ++gp2) {
           expected <<  "  f(" << iel << "," << icmp << "," << gp1 << "," << gp2 << ",:)";
@@ -350,7 +350,7 @@ TEST_CASE ("print_field_hyperslab") {
     print_field_hyperslab(f,loc_tags,loc_idxs,out);
 
     std::stringstream expected;
-    expected << "     f" << to_string(fid.get_layout()) << "\n\n";
+    expected << "     f" << fid.get_layout().to_string() << "\n\n";
       expected <<  "  f(" << iel << ",:," << igp << "," << jgp << "," << ilev << ")";
       for (int cmp=0; cmp<ncmp; ++cmp) {
         if (cmp % max_per_line == 0) {
@@ -369,7 +369,7 @@ TEST_CASE ("print_field_hyperslab") {
     print_field_hyperslab(f,loc_tags,loc_idxs,out);
 
     std::stringstream expected;
-    expected << "     f" << to_string(fid.get_layout()) << "\n\n";
+    expected << "     f" << fid.get_layout().to_string() << "\n\n";
       expected <<  "  f(" << ekat::join(loc_idxs,",") << ")\n";
       expected << "    " << v(iel,icmp,igp,jgp,ilev) << ", \n";
 

--- a/components/eamxx/src/share/tests/refining_remapper_p2p_tests.cpp
+++ b/components/eamxx/src/share/tests/refining_remapper_p2p_tests.cpp
@@ -64,7 +64,7 @@ Field all_gather_field (const Field& f, const ekat::Comm& comm) {
   constexpr auto COL = ShortFieldTagsNames::COL;
   const auto& fid = f.get_header().get_identifier();
   const auto& fl  = fid.get_layout();
-  int col_size = fl.strip_dim(COL).size();
+  int col_size = fl.clone().strip_dim(COL).size();
   auto tags = fl.tags();
   auto dims = fl.dims();
   int my_cols = dims[0];;

--- a/components/eamxx/src/share/tests/refining_remapper_p2p_tests.cpp
+++ b/components/eamxx/src/share/tests/refining_remapper_p2p_tests.cpp
@@ -21,7 +21,6 @@ public:
 Field create_field (const std::string& name, const LayoutType lt, const AbstractGrid& grid)
 {
   const auto u = ekat::units::Units::nondimensional();
-  const auto CMP = ShortFieldTagsNames::CMP;
   const auto& gn = grid.name();
   const auto  ndims = 2;
   Field f;
@@ -29,12 +28,12 @@ Field create_field (const std::string& name, const LayoutType lt, const Abstract
     case LayoutType::Scalar2D:
       f = Field(FieldIdentifier(name,grid.get_2d_scalar_layout(),u,gn));  break;
     case LayoutType::Vector2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(CMP,ndims),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(ndims),u,gn));  break;
     case LayoutType::Scalar3D:
       f = Field(FieldIdentifier(name,grid.get_3d_scalar_layout(true),u,gn));  break;
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
     case LayoutType::Vector3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(false,CMP,ndims),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(false,ndims),u,gn));  break;
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
     default:
       EKAT_ERROR_MSG ("Invalid layout type for this unit test.\n");

--- a/components/eamxx/src/share/tests/refining_remapper_rma_tests.cpp
+++ b/components/eamxx/src/share/tests/refining_remapper_rma_tests.cpp
@@ -37,7 +37,7 @@ public:
       const auto& fl = fh.get_identifier().get_layout();
       const auto& fap = fh.get_alloc_properties();
       const auto col_alloc_size = fap.get_num_scalars() / fl.dim(COL);
-      REQUIRE (m_col_size[i]==fl.strip_dim(COL).size());
+      REQUIRE (m_col_size[i]==fl.clone().strip_dim(COL).size());
       if (fh.get_parent().lock()) {
         REQUIRE (m_col_stride[i]==col_alloc_size*fap.get_subview_info().dim_extent);
         REQUIRE (m_col_offset[i]==col_alloc_size*fap.get_subview_info().slice_idx);
@@ -119,7 +119,7 @@ Field all_gather_field (const Field& f, const ekat::Comm& comm) {
   constexpr auto COL = ShortFieldTagsNames::COL;
   const auto& fid = f.get_header().get_identifier();
   const auto& fl  = fid.get_layout();
-  int col_size = fl.strip_dim(COL).size();
+  int col_size = fl.clone().strip_dim(COL).size();
   auto tags = fl.tags();
   auto dims = fl.dims();
   int my_cols = dims[0];;

--- a/components/eamxx/src/share/tests/refining_remapper_rma_tests.cpp
+++ b/components/eamxx/src/share/tests/refining_remapper_rma_tests.cpp
@@ -76,7 +76,6 @@ public:
 Field create_field (const std::string& name, const LayoutType lt, const AbstractGrid& grid)
 {
   const auto u = ekat::units::Units::nondimensional();
-  const auto CMP = ShortFieldTagsNames::CMP;
   const auto& gn = grid.name();
   const auto  ndims = 2;
   Field f;
@@ -84,12 +83,12 @@ Field create_field (const std::string& name, const LayoutType lt, const Abstract
     case LayoutType::Scalar2D:
       f = Field(FieldIdentifier(name,grid.get_2d_scalar_layout(),u,gn));  break;
     case LayoutType::Vector2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(CMP,ndims),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(ndims),u,gn));  break;
     case LayoutType::Scalar3D:
       f = Field(FieldIdentifier(name,grid.get_3d_scalar_layout(true),u,gn));  break;
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
     case LayoutType::Vector3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(false,CMP,ndims),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(false,ndims),u,gn));  break;
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
     default:
       EKAT_ERROR_MSG ("Invalid layout type for this unit test.\n");

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -263,7 +263,7 @@ TEST_CASE ("vertical_remap") {
   auto src_gids    = remap->get_src_grid()->get_dofs_gids().get_view<const gid_type*,Host>();
   for (const auto& f : src_f) {
     const auto& l = f.get_header().get_identifier().get_layout();
-    switch (get_layout_type(l.tags())) {
+    switch (l.type()) {
       case LayoutType::Scalar2D:
       {
         const auto v_src = f.get_view<Real*,Host>();
@@ -334,7 +334,7 @@ TEST_CASE ("vertical_remap") {
 
       f.sync_to_host();
 
-      switch (get_layout_type(lsrc.tags())) {
+      switch (lsrc.type()) {
         case LayoutType::Scalar2D:
         {
           // This is a flat array w/ no LEV tag so the interpolated value for source and target should match.

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -328,9 +328,9 @@ TEST_CASE ("vertical_remap") {
       const auto& lsrc  = fsrc.get_header().get_identifier().get_layout();
       const auto p_v    = lsrc.has_tag(LEV) ? pmid_v : pint_v;
       const int nlevs_p = lsrc.has_tag(LEV) ? nlevs_src : nlevs_src+1;
-      const auto ls     = to_string(lsrc);
+      const auto ls     = lsrc.to_string();
       std::string dots (25-ls.size(),'.');
-      print ("   -> Checking field with source layout " + to_string(lsrc) +" " + dots + "\n",comm);
+      print ("   -> Checking field with source layout " + ls +" " + dots + "\n",comm);
 
       f.sync_to_host();
 
@@ -383,7 +383,7 @@ TEST_CASE ("vertical_remap") {
           EKAT_ERROR_MSG ("Unexpected layout.\n");
       }
 
-      print ("   -> Checking field with source layout " + to_string(lsrc) + " " + dots + " OK!\n",comm);
+      print ("   -> Checking field with source layout " + ls + " " + dots + " OK!\n",comm);
     }
     print ("check tgt fields ... done!\n",comm);
   }

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -67,13 +67,13 @@ build_src_grid(const ekat::Comm& comm, const int nldofs_src, const int nlevs_src
 Field
 create_field(const std::string& name, const std::shared_ptr<const AbstractGrid>& grid, const bool twod, const bool vec, const bool mid = false, const int ps = 1)
 {
+  using namespace ShortFieldTagsNames;
   constexpr int vec_dim = 3;
-  constexpr auto CMP = FieldTag::Component;
   constexpr auto units = ekat::units::Units::nondimensional();
   auto fl = twod
-          ? (vec ? grid->get_2d_vector_layout (CMP,vec_dim)
+          ? (vec ? grid->get_2d_vector_layout (vec_dim)
                  : grid->get_2d_scalar_layout ())
-          : (vec ? grid->get_3d_vector_layout (mid,CMP,vec_dim)
+          : (vec ? grid->get_3d_vector_layout (mid,vec_dim)
                  : grid->get_3d_scalar_layout (mid));
   FieldIdentifier fid(name,fl,units,grid->name());
   Field f(fid);

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/CMakeLists.txt
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/CMakeLists.txt
@@ -10,7 +10,7 @@ CreateDynamicsLib("theta-l_kokkos"  4   72   10)
 # Create the test
 CreateADUnitTest(${TEST_BASE_NAME}
   LABELS dynamics tms shoc cld p3 rrtmgp physics pg2
-  LIBS cld_fraction nudging tms shoc p3 scream_rrtmgp ${dynLibName} diagnostics
+  LIBS cld_fraction tms shoc p3 scream_rrtmgp ${dynLibName} diagnostics
   MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
   FIXTURES_SETUP_INDIVIDUAL ${FIXTURES_BASE_NAME}
 )


### PR DESCRIPTION
This PR should make it easier to add new field layouts without having to add new FieldTag enum's.

The main modifications are:
- Store tag names inside the layout. By default, we use `e2str(tag)` for each tag, but the user can overwrite with specific values.
- Remove Rad-related FieldTag values. Radiation will use `CMP`, setting the tag name to "swband"/"lwband" and the likes
- Minor change in some layout methods. The `strip_dim` method now modifies the current layout, so one has to do `fl.clone().strip_dim(CMP)` to obtain a copy of `fl` with the dimension stripped.
- Some fixes for handling tensor fields