### PR TITLE
Adding support for PIO_REARR_ANY

### DIFF
--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -2692,10 +2692,10 @@
 
   <entry id="PIO_REARRANGER">
     <type>integer</type>
-    <valid_values>1,2</valid_values>
+    <valid_values>1,2,3</valid_values>
     <group>run_pio</group>
     <file>env_run.xml</file>
-    <desc>pio rearranger choice box=1, subset=2 </desc>
+    <desc>pio rearranger choice box=1, subset=2, any=3 </desc>
     <values>
       <value compclass="ATM">$PIO_VERSION</value>
       <value compclass="CPL">$PIO_VERSION</value>

--- a/driver-mct/cime_config/namelist_definition_modelio.xml
+++ b/driver-mct/cime_config/namelist_definition_modelio.xml
@@ -90,9 +90,9 @@
     <type>integer</type>
     <category>pio</category>
     <group>pio_inparm</group>
-    <valid_values>-99,1,2</valid_values>
+    <valid_values>-99,1,2,3</valid_values>
     <desc>
-      Rearranger method for pio 1=box, 2=subset.
+      Rearranger method for pio 1=box, 2=subset, 3=any.
     </desc>
     <values>
     <value component="cpl">$CPL_PIO_REARRANGER</value>

--- a/share/util/shr_pio_mod.F90
+++ b/share/util/shr_pio_mod.F90
@@ -730,7 +730,8 @@ contains
     if(pio_stride == 1 .and. .not. pio_async_interface) then
        pio_root = 0
     endif
-    if(pio_rearranger .ne. PIO_REARR_SUBSET .and. pio_rearranger .ne. PIO_REARR_BOX) then
+    if(pio_rearranger .ne. PIO_REARR_SUBSET .and. pio_rearranger .ne. PIO_REARR_BOX .and.&
+        pio_rearranger .ne. PIO_REARR_ANY) then
        write(shr_log_unit,*) 'pio_rearranger value, ',pio_rearranger,&
             ', not supported - using PIO_REARR_BOX'
        pio_rearranger = PIO_REARR_BOX


### PR DESCRIPTION
Adding support for new SCORPIO rearranger, PIO_REARR_ANY.

This rearranger lets the SCORPIO library decide on the optimal
rearranger to use. The current default settings for this rearranger
gives us the best performance for ne1024 runs (when using the
PnetCDF I/O type for history output and ADIOS I/O type for
restart output)