### PR TITLE
EAMxx: subfield of read-only fields must be read-only

### DIFF
--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -99,6 +99,7 @@ subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
   Field sf;
   sf.m_header = create_subfield_header(sf_id,m_header,idim,index,dynamic);
   sf.m_data = m_data;
+  sf.m_is_read_only = m_is_read_only;
 
   return sf;
 }

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -237,9 +237,9 @@ public:
   //     to store a stride for the slowest dimension.
   //   - If dynamic = true, it is possible to "reset" the slice index (k) at runtime.
   Field subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
-                       const int idim, const int index, const bool dynamic = false) const;
+                  const int idim, const int index, const bool dynamic = false) const;
   Field subfield (const std::string& sf_name, const int idim,
-                       const int index, const bool dynamic = false) const;
+                  const int index, const bool dynamic = false) const;
   Field subfield (const int idim, const int k, const bool dynamic = false) const;
 
   // If this field is a vector field, get a subfield for the ith component.

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -166,6 +166,9 @@ TEST_CASE("field", "") {
 
     // Trying to reshape into something that the allocation cannot accommodate should throw
     REQUIRE_THROWS (f1.get_view<P16***>());
+
+    // Can't get non-const data type view from a read-only field
+    REQUIRE_THROWS (f1.get_const().get_view<Real**>());
   }
 
   SECTION ("equivalent") {
@@ -299,6 +302,10 @@ TEST_CASE("field", "") {
         for (int k=0; k<d1[3]; ++k) {
           REQUIRE (v4d_h(i,ivar,j,k)==v3d_h(i,j,k));
         }
+
+    // Subfields of read-only fields must be read-only
+    auto f3 = f1.get_const().subfield(idim,ivar);
+    REQUIRE (f3.is_read_only());
   }
 
   // Dynamic Subfields


### PR DESCRIPTION
In current master, a bug allowed users to take a subfield of a read only and write to it. This PR fixes it.