### PR TITLE
For machine `frontier-scream-gpu`, upgrade to rocm 5.4

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1433,7 +1433,7 @@
         <command name="reset"></command>
         <command name="load">PrgEnv-cray</command>
         <command name="load">craype-accel-amd-gfx90a</command>
-        <command name="load">rocm/5.1.0</command>
+        <command name="load">rocm/5.4.0</command>
         <command name="load">libunwind/1.6.2</command>
       </modules>
       <modules>


### PR DESCRIPTION
Only for machine `frontier-scream-gpu`, upgrade rocm from 5.1 to 5.4.

Note that other similar machines (frontier and crusher) already have rocm 5.4.
We could also upgrade `crusher-scream-gpu` to 5.4 as well.

The reason for upgrade is that we found it's needed to complete the kokkos version upgrade to 4.2 (`bartgol/eamxx/kokkos-4.2`)
So I wanted to make this change first as a clean PR.

With at least a simple ne30 test, results are not BFB.
[NBFB]

