### PR TITLE
Aarondonahue/io add longname metadata

### DIFF
--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
@@ -144,19 +144,22 @@ add_geo_data (const nonconstgrid_ptr_type& grid) const
     FieldLayout layout_mid ({LEV},{grid->get_num_vertical_levels()});
     const auto units = ekat::units::Units::nondimensional();
 
-    auto lat  = grid->create_geometry_data("lat" , grid->get_2d_scalar_layout(), units);
-    auto lon  = grid->create_geometry_data("lon" , grid->get_2d_scalar_layout(), units);
-    auto hyam  = grid->create_geometry_data("hyam" , layout_mid, units);
-    auto hybm  = grid->create_geometry_data("hybm" , layout_mid, units);
+    auto lat  = grid->create_geometry_data("lat" ,  grid->get_2d_scalar_layout(), units);
+    auto lon  = grid->create_geometry_data("lon" ,  grid->get_2d_scalar_layout(), units);
+    auto hyam = grid->create_geometry_data("hyam" , layout_mid, units);
+    auto hybm = grid->create_geometry_data("hybm" , layout_mid, units);
+    auto lev  = grid->create_geometry_data("lev" ,  layout_mid, units);
 
     lat.deep_copy(ekat::ScalarTraits<Real>::invalid());
     lon.deep_copy(ekat::ScalarTraits<Real>::invalid());
     hyam.deep_copy(ekat::ScalarTraits<Real>::invalid());
     hybm.deep_copy(ekat::ScalarTraits<Real>::invalid());
+    lev.deep_copy(ekat::ScalarTraits<Real>::invalid());
     lat.sync_to_dev();
     lon.sync_to_dev();
     hyam.sync_to_dev();
     hybm.sync_to_dev();
+    lev.sync_to_dev();
   } else if (geo_data_source=="IC_FILE"){
     const auto& filename = m_params.get<std::string>("ic_filename");
     if (scorpio::has_variable(filename,"lat") &&
@@ -225,9 +228,12 @@ load_vertical_coordinates (const nonconstgrid_ptr_type& grid, const std::string&
   using namespace ShortFieldTagsNames;
   FieldLayout layout_mid ({LEV},{grid->get_num_vertical_levels()});
   const auto units = ekat::units::Units::nondimensional();
+  auto lev_unit = ekat::units::Units::nondimensional();;
+  lev_unit.set_string("mb");
 
   auto hyam = grid->create_geometry_data("hyam", layout_mid, units);
   auto hybm = grid->create_geometry_data("hybm", layout_mid, units);
+  auto lev  = grid->create_geometry_data("lev",  layout_mid, lev_unit);
 
   // Create host mirrors for reading in data
   std::map<std::string,geo_view_host> host_views = {
@@ -251,9 +257,21 @@ load_vertical_coordinates (const nonconstgrid_ptr_type& grid, const std::string&
   vcoord_reader.read_variables();
   vcoord_reader.finalize();
 
+  // Build lev from hyam and hybm
+  using PC             = scream::physics::Constants<Real>;
+  const Real ps0        = PC::P0;
+
+  auto hya_v = hyam.get_view<const Real*>();
+  auto hyb_v = hybm.get_view<const Real*>();
+  auto lev_v = lev.get_view<Real*>();
+  for (int ii=0;ii<grid->get_num_vertical_levels();ii++) {
+    lev_v(ii) = 0.01*ps0*(hya_v(ii)+hyb_v(ii));
+  }
+
   // Sync to dev
   hyam.sync_to_dev();
   hybm.sync_to_dev();
+  lev.sync_to_dev();
 
 #ifndef NDEBUG
   for (auto f : {hyam, hybm}) {

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
@@ -261,9 +261,9 @@ load_vertical_coordinates (const nonconstgrid_ptr_type& grid, const std::string&
   using PC             = scream::physics::Constants<Real>;
   const Real ps0        = PC::P0;
 
-  auto hya_v = hyam.get_view<const Real*>();
-  auto hyb_v = hybm.get_view<const Real*>();
-  auto lev_v = lev.get_view<Real*>();
+  auto hya_v = hyam.get_view<const Real*,Host>();
+  auto hyb_v = hybm.get_view<const Real*,Host>();
+  auto lev_v = lev.get_view<Real*,Host>();
   for (int ii=0;ii<grid->get_num_vertical_levels();ii++) {
     lev_v(ii) = 0.01*ps0*(hya_v(ii)+hyb_v(ii));
   }

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -964,11 +964,14 @@ register_variables(const std::string& filename,
     auto vec_of_dims   = set_vec_of_dims(layout);
     std::string units = fid.get_units().get_string();
 
+    // Gather longname
+    auto longname = m_longnames.get_longname(name);
+
     // TODO  Need to change dtype to allow for other variables.
     // Currently the field_manager only stores Real variables so it is not an issue,
     // but in the future if non-Real variables are added we will want to accomodate that.
 
-    register_variable(filename, name, name, units, vec_of_dims,
+    register_variable(filename, name, longname, units, vec_of_dims,
                       "real",fp_precision, io_decomp_tag);
 
     // Add any extra attributes for this variable

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -204,6 +204,7 @@ protected:
   std::map<std::string,std::shared_ptr<atm_diag_type>>  m_diagnostics;
   std::map<std::string,std::vector<std::string>>        m_diag_depends_on_diags;
   std::map<std::string,bool>                            m_diag_computed;
+  LongNames                                             m_longnames;
 
   // Use float, so that if output fp_precision=float, this is a representable value.
   // Otherwise, you would get an error from Netcdf, like

--- a/components/eamxx/src/share/io/scream_io_utils.hpp
+++ b/components/eamxx/src/share/io/scream_io_utils.hpp
@@ -65,5 +65,27 @@ std::string find_filename_in_rpointer (
     const ekat::Comm& comm,
     const util::TimeStamp& run_t0);
 
+struct LongNames {
+
+  std::string get_longname (const std::string& name) {
+    if (name_2_longname.count(name)>0) {
+      return name_2_longname.at(name);
+    } else {
+      // TODO: Do we want to print a Warning message?  I'm not sure if its needed.
+      return name;
+    }
+  }
+
+  // Create map of longnames, can be added to as developers see fit.
+  std::map<std::string,std::string> name_2_longname = {
+	  {"lev","hybrid level at midpoints (1000*(A+B))"},
+	  {"hyai","hybrid A coefficient at layer interfaces"},
+          {"hybi","hybrid B coefficient at layer interfaces"},
+          {"hyam","hybrid A coefficient at layer midpoints"},
+          {"hybm","hybrid B coefficient at layer midpoints"}
+  };
+  
+};
+
 } // namespace scream
 #endif // SCREAM_IO_UTILS_HPP


### PR DESCRIPTION
Add an option to specify a 'longname' for output variables.
Using the new longname feature we add the variable 'lev' to the grid data so that it can be output.
    
This commit adds a structure to io_utils that allows the developer to specify a longname to go into the metadata of an output variable.  Building on the longname capability this commit adds a new grid variable 'lev' which is a representative pressure at each level built from hyam and hybm.  It is necessary for some post-processing.