### PR TITLE
Allow diags in IO to perform some ops at beginning of a timestep

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1605,6 +1605,16 @@ void AtmosphereDriver::run (const int dt) {
   //       nano-opt of removing the call for the 1st timestep.
   reset_accumulated_fields();
 
+  // Tell the output managers that we're starting a timestep. This is usually
+  // a no-op, but some diags *may* require to do something. E.g., a diag that
+  // computes tendency of an arbitrary quantity may want to store a copy of
+  // that quantity at the beginning of the timestep. Or they may need to store
+  // the timestamp at the beginning of the timestep, so that we can compute
+  // dt at the end.
+  for (auto it : m_output_managers) {
+    it.init_timestep(m_current_ts);
+  }
+
   // The class AtmosphereProcessGroup will take care of dispatching arguments to
   // the individual processes, which will be called in the correct order.
   m_atm_process_group->run(dt);

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1612,7 +1612,7 @@ void AtmosphereDriver::run (const int dt) {
   // the timestamp at the beginning of the timestep, so that we can compute
   // dt at the end.
   for (auto it : m_output_managers) {
-    it.init_timestep(m_current_ts);
+    it.init_timestep(m_current_ts,dt);
   }
 
   // The class AtmosphereProcessGroup will take care of dispatching arguments to

--- a/components/eamxx/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -51,6 +51,8 @@ public:
   // Getting the diagnostic output
   Field get_diagnostic () const;
 
+  // Allows the diagnostic to save some start-of-step quantity (e.g., in case
+  // we need to compute tendencies, or accumulated stuff)
   virtual void init_timestep (const util::TimeStamp& /* start_of_step */) {}
 
   void compute_diagnostic (const double dt = 0);

--- a/components/eamxx/src/share/atm_process/atmosphere_diagnostic.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_diagnostic.hpp
@@ -51,6 +51,8 @@ public:
   // Getting the diagnostic output
   Field get_diagnostic () const;
 
+  virtual void init_timestep (const util::TimeStamp& /* start_of_step */) {}
+
   void compute_diagnostic (const double dt = 0);
 protected:
 

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -362,6 +362,14 @@ void AtmosphereOutput::init()
 }
 
 void AtmosphereOutput::
+init_timestep (const util::TimeStamp& start_of_step)
+{
+  for (auto& it : m_diagnostics) {
+    it.second->init_timestep(start_of_step);
+  }
+}
+
+void AtmosphereOutput::
 run (const std::string& filename,
      const bool output_step, const bool checkpoint_step,
      const int nsteps_since_last_output,

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -139,6 +139,8 @@ public:
   void reset_dev_views();
   void update_avg_cnt_view(const Field&, view_1d_dev& dev_view);
   void setup_output_file (const std::string& filename, const std::string& fp_precision, const scorpio::FileMode mode);
+
+  void init_timestep (const util::TimeStamp& start_of_step);
   void run (const std::string& filename,
             const bool output_step, const bool checkpoint_step,
             const int nsteps_since_last_output,

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -264,8 +264,9 @@ setup (const ekat::Comm& io_comm, const ekat::ParameterList& params,
   {
     // In order to trigger a t0 write, we need to have next_write_ts matching run_t0
     m_output_control.next_write_ts = m_run_t0;
-    // This is in case some diags need to init the timestep. Most likely, their output
-    // is meaningless at t0, but they may still require the start-of-step timestamp to be valid
+    // This is in case some diags need to init the timestep. Their output may be meaningless
+    // at t0 (e.g., if their input fields are not in the initial condition fields set,
+    // and have yet to be computed), but they may still require the start-of-step timestamp to be valid
     init_timestep(m_run_t0,0);
     this->run(m_run_t0);
   }

--- a/components/eamxx/src/share/io/scream_output_manager.hpp
+++ b/components/eamxx/src/share/io/scream_output_manager.hpp
@@ -113,7 +113,7 @@ public:
   }
   void add_global (const std::string& name, const ekat::any& global);
 
-  void init_timestep (const util::TimeStamp& start_of_step);
+  void init_timestep (const util::TimeStamp& start_of_step, const Real dt);
   void run (const util::TimeStamp& current_ts);
   void finalize();
 

--- a/components/eamxx/src/share/io/scream_output_manager.hpp
+++ b/components/eamxx/src/share/io/scream_output_manager.hpp
@@ -112,6 +112,8 @@ public:
       m_atm_logger = atm_logger;
   }
   void add_global (const std::string& name, const ekat::any& global);
+
+  void init_timestep (const util::TimeStamp& start_of_step);
   void run (const util::TimeStamp& current_ts);
   void finalize();
 

--- a/components/eamxx/src/share/io/tests/io_basic.cpp
+++ b/components/eamxx/src/share/io/tests/io_basic.cpp
@@ -167,6 +167,7 @@ void write (const std::string& avg_type, const std::string& freq_units,
   const int nsteps = num_output_steps*freq;
   auto t = t0;
   for (int n=0; n<nsteps; ++n) {
+    om.init_timestep(t,dt);
     // Update time
     t += dt;
 

--- a/components/eamxx/src/share/io/tests/io_diags.cpp
+++ b/components/eamxx/src/share/io/tests/io_diags.cpp
@@ -207,7 +207,7 @@ void write (const int seed, const ekat::Comm& comm)
     f.get_header().get_tracking().update_time_stamp(t0+dt);
     f.update(one,1.0,1.0);
   }
-  om.init_timestep(t0);
+  om.init_timestep(t0,dt);
   om.run (t0+dt);
 
   // Close file and cleanup

--- a/components/eamxx/src/share/io/tests/io_diags.cpp
+++ b/components/eamxx/src/share/io/tests/io_diags.cpp
@@ -35,9 +35,9 @@ public:
     //Do nothing
   }
 
-  std::string name() const { return "MyDiag"; }
+  std::string name() const override { return "MyDiag"; }
 
-  void set_grids (const std::shared_ptr<const GridsManager> gm) {
+  void set_grids (const std::shared_ptr<const GridsManager> gm) override {
     using namespace ekat::units;
     using namespace ShortFieldTagsNames;
     using FL = FieldLayout;
@@ -64,13 +64,13 @@ public:
     m_one.deep_copy(1.0);
   }
 
-  void init_timestep (const util::TimeStamp& start_of_step) {
+  void init_timestep (const util::TimeStamp& start_of_step) override {
     m_t_beg = start_of_step;
   }
 
 protected:
 
-  void compute_diagnostic_impl () {
+  void compute_diagnostic_impl () override {
     const auto& f_in  = get_field_in(m_f_in);
 
     const auto& t = f_in.get_header().get_tracking().get_time_stamp();
@@ -80,12 +80,12 @@ protected:
     m_diagnostic_output.update(m_one,dt,2.0);
   }
 
-  void initialize_impl (const RunType /* run_type */ ) {
+  void initialize_impl (const RunType /* run_type */ ) override {
     m_diagnostic_output.get_header().get_tracking().update_time_stamp(timestamp());
   }
 
   // Clean up
-  void finalize_impl ( /* inputs */ ) {}
+  void finalize_impl ( /* inputs */ ) override {}
 
   // Internal variables
   int m_num_cols, m_num_levs;

--- a/components/eamxx/src/share/io/tests/io_filled.cpp
+++ b/components/eamxx/src/share/io/tests/io_filled.cpp
@@ -148,6 +148,7 @@ void write (const std::string& avg_type, const std::string& freq_units,
   const int nsteps = num_output_steps*freq;
   auto t = t0;
   for (int n=0; n<nsteps; ++n) {
+    om.init_timestep(t,dt);
     // Update time
     t += dt;
 

--- a/components/eamxx/src/share/io/tests/io_monthly.cpp
+++ b/components/eamxx/src/share/io/tests/io_monthly.cpp
@@ -138,6 +138,7 @@ void write (const int seed, const ekat::Comm& comm)
   const int nsteps = 11;
   auto t = t0;
   for (int n=0; n<nsteps; ++n) {
+    om.init_timestep(t,dt);
     // Update time
     t += dt;
 

--- a/components/eamxx/src/share/io/tests/io_packed.cpp
+++ b/components/eamxx/src/share/io/tests/io_packed.cpp
@@ -127,6 +127,7 @@ void write (const int freq, const int seed, const int ps, const ekat::Comm& comm
   om.setup(comm,om_pl,fm,gm,t0,t0,false);
 
   // Run output manager
+  om.init_timestep(t0,0);
   om.run (t0);
 
   // Close file and cleanup

--- a/components/eamxx/src/share/io/tests/io_remap_test.cpp
+++ b/components/eamxx/src/share/io/tests/io_remap_test.cpp
@@ -57,6 +57,8 @@ TEST_CASE("io_remap_test","io_remap_test")
   scorpio::init_subsystem(io_comm);
   const int ncols_src = 64*io_comm.size();
   const int nlevs_src = 2*packsize + 1;
+  const int dt = 10;
+
   // Construct a timestamp
   util::TimeStamp t0 ({2000,1,1},{0,0,0});
   // Setup for target levels.
@@ -234,7 +236,8 @@ TEST_CASE("io_remap_test","io_remap_test")
   auto source_remap_control = set_output_params("remap_source",remap_filename,p_ref,false,false);
   om_source.setup(io_comm,source_remap_control,field_manager,gm,t0,t0,false);
   io_comm.barrier();
-  om_source.run(t0);
+  om_source.init_timestep(t0,dt);
+  om_source.run(t0+dt);
   om_source.finalize();
   print ("    -> source data ... done\n",io_comm);
 
@@ -242,7 +245,8 @@ TEST_CASE("io_remap_test","io_remap_test")
   auto vert_remap_control = set_output_params("remap_vertical",remap_filename,p_ref,true,false);
   om_vert.setup(io_comm,vert_remap_control,field_manager,gm,t0,t0,false);
   io_comm.barrier();
-  om_vert.run(t0);
+  om_vert.init_timestep(t0,dt);
+  om_vert.run(t0+dt);
   om_vert.finalize();
   print ("    -> vertical remap ... done\n",io_comm);
 
@@ -250,7 +254,8 @@ TEST_CASE("io_remap_test","io_remap_test")
   auto horiz_remap_control = set_output_params("remap_horizontal",remap_filename,p_ref,false,true);
   om_horiz.setup(io_comm,horiz_remap_control,field_manager,gm,t0,t0,false);
   io_comm.barrier();
-  om_horiz.run(t0);
+  om_horiz.init_timestep(t0,dt);
+  om_horiz.run(t0+dt);
   om_horiz.finalize();
   print ("    -> horizontal remap ... done\n",io_comm);
 
@@ -258,7 +263,8 @@ TEST_CASE("io_remap_test","io_remap_test")
   auto vert_horiz_remap_control = set_output_params("remap_vertical_horizontal",remap_filename,p_ref,true,true);
   om_vert_horiz.setup(io_comm,vert_horiz_remap_control,field_manager,gm,t0,t0,false);
   io_comm.barrier();
-  om_vert_horiz.run(t0);
+  om_vert_horiz.init_timestep(t0,dt);
+  om_vert_horiz.run(t0+dt);
   om_vert_horiz.finalize();
   print ("    -> vertical-horizontal remap ... done\n",io_comm);
   print (" -> Create output ... done\n",io_comm);

--- a/components/eamxx/src/share/io/tests/io_se_grid.cpp
+++ b/components/eamxx/src/share/io/tests/io_se_grid.cpp
@@ -45,6 +45,7 @@ TEST_CASE("se_grid_io")
   int num_my_elems = 2;
   int np = 4;
   int num_levs = 2 + SCREAM_PACK_SIZE;
+  int dt = 10;
 
   // Initialize the pio_subsystem for this test:
   scorpio::init_subsystem(io_comm);
@@ -70,7 +71,8 @@ TEST_CASE("se_grid_io")
 
   OutputManager om;
   om.setup(io_comm,params,fm0,gm,t0,t0,false);
-  om.run(t0);
+  om.init_timestep(t0,dt);
+  om.run(t0+dt);
   om.finalize();
 
   // Get a fresh new field manager, and set fields to NaN

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -99,6 +99,7 @@ TEST_CASE("output_restart","io")
     // The output restart data is written every 5 time steps, while the output freq is 10.
     auto time = run_t0;
     for (int i=0; i<nsteps; ++i) {
+      output_manager.init_timestep(time,dt);
       time_advance(*fm,out_fields,dt);
       time += dt;
       output_manager.run(time);


### PR DESCRIPTION
This PR allows the AD to (weakly) interact with the diagnostics. In particular, it allows the diags to perform setup operations at the beginning of the timestep, if needed.

For instance, it could be useful for PR #2810: if one wants _instantaneous_ tendencies of an arbitrary field (which could be a diagnostic field), then we need to be able to store the start-of-step value of the input field, which can be done in this method. This method can also be used to store the start-of-step timestamp, which can later be used when the IO runs to back out the timestep.

Note: for that PR, a little extra work will be needed, since the input field may itself be a diagnostic field, which may have not been yet calculated, or calculated several timesteps ago. I discussed a way to approach this with @mahf708 offline.