### PR TITLE
Use IOP lat/lon in rrtmgp interface

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -199,9 +199,6 @@ setup_iop ()
                                                        hyam,
                                                        hybm);
 
-  auto dx_short_f = phys_grid->get_geometry_data("dx_short");
-  m_iop->set_grid_spacing(dx_short_f.get_view<const Real,Host>()());
-
   // Set IOP object in atm processes
   m_atm_process_group->set_iop(m_iop);
 }

--- a/components/eamxx/src/control/intensive_observation_period.hpp
+++ b/components/eamxx/src/control/intensive_observation_period.hpp
@@ -115,13 +115,6 @@ public:
   //       data.
   void correct_temperature_and_water_vapor(const field_mgr_ptr field_mgr);
 
-  // Store grid spacing for use in SHOC ad interface
-  void set_grid_spacing (const Real dx_short) {
-    m_dynamics_dx_size = dx_short*1000;
-  }
-
-  Real get_dynamics_dx_size () { return m_dynamics_dx_size; }
-
   ekat::ParameterList& get_params() { return m_params; }
 
   bool has_iop_field(const std::string& fname) {

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -58,8 +58,19 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   const auto& grid_name = m_grid->name();
   m_ncol = m_grid->get_num_local_dofs();
   m_nlay = m_grid->get_num_vertical_levels();
-  m_lat  = m_grid->get_geometry_data("lat");
-  m_lon  = m_grid->get_geometry_data("lon");
+
+  if (m_iop) {
+    // For IOP runs, we need to use the lat/lon from the
+    // IOP files instead of the geometry data.
+    m_lat = m_grid->get_geometry_data("lat").clone();
+    m_lat.deep_copy(m_iop->get_params().get<Real>("target_latitude"));
+
+    m_lon = m_grid->get_geometry_data("lon").clone();
+    m_lon.deep_copy(m_iop->get_params().get<Real>("target_longitude"));
+  } else {
+    m_lat = m_grid->get_geometry_data("lat");
+    m_lon = m_grid->get_geometry_data("lon");
+  }
 
   // Figure out radiation column chunks stats
   m_col_chunk_size = std::min(m_params.get("column_chunk_size", m_ncol),m_ncol);


### PR DESCRIPTION
Use IOP lat/lon in rrtmgp interface.

Unrelated change: `dx_short` code no longer needed in iop.