### PR TITLE
bind gpus to srun on pm-gpu

### DIFF
--- a/components/eamxx/cmake/machine-files/pm-gpu.cmake
+++ b/components/eamxx/cmake/machine-files/pm-gpu.cmake
@@ -18,7 +18,7 @@ endif()
 
 include (${EKAT_MACH_FILES_PATH}/mpi/srun.cmake)
 
-set(EKAT_MPI_EXTRA_ARGS "${EKAT_MPI_EXTRA_ARGS} --gpu-per-task 1")
+set(EKAT_MPI_EXTRA_ARGS "${EKAT_MPI_EXTRA_ARGS} --gpu-per-node 4 --gpu-bind=none")
 
 #option(Kokkos_ARCH_AMPERE80 "" ON)
 set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)

--- a/components/eamxx/cmake/machine-files/pm-gpu.cmake
+++ b/components/eamxx/cmake/machine-files/pm-gpu.cmake
@@ -18,7 +18,7 @@ endif()
 
 include (${EKAT_MACH_FILES_PATH}/mpi/srun.cmake)
 
-set(EKAT_MPI_EXTRA_ARGS "${EKAT_MPI_EXTRA_ARGS} --gpu-per-node 4 --gpu-bind=none")
+set(EKAT_MPI_EXTRA_ARGS "${EKAT_MPI_EXTRA_ARGS} --gpus-per-task=1" CACHE STRING "" FORCE)
 
 #option(Kokkos_ARCH_AMPERE80 "" ON)
 set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)

--- a/components/eamxx/cmake/machine-files/pm-gpu.cmake
+++ b/components/eamxx/cmake/machine-files/pm-gpu.cmake
@@ -18,6 +18,8 @@ endif()
 
 include (${EKAT_MACH_FILES_PATH}/mpi/srun.cmake)
 
+set(EKAT_MPI_EXTRA_ARGS "${EKAT_MPI_EXTRA_ARGS} --gpu-per-task 1")
+
 #option(Kokkos_ARCH_AMPERE80 "" ON)
 set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
 


### PR DESCRIPTION
this is needed for standalone tests to work correctly with `srun` via ctest -R xyz