### PR TITLE
Update ekat submodule

### DIFF
--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -25,15 +25,8 @@ void SurfaceCouplingExporter::set_grids(const std::shared_ptr<const GridsManager
   m_num_cols = m_grid->get_num_local_dofs();       // Number of columns on this rank
   m_num_levs = m_grid->get_num_vertical_levels();  // Number of levels per column
 
-  const auto m2 = m*m;
-  const auto s2 = s*s;
-  auto Wm2 = W/m2;
-  Wm2.set_string("W/m2");
-
-  // The units of mixing ratio Q are technically non-dimensional.
-  // Nevertheless, for output reasons, we like to see 'kg/kg'.
-  auto Qunit = kg/kg;
-  Qunit.set_string("kg/kg");
+  Units m2 (m*m,"m2");
+  Units s2 (s*s,"s2");
 
   // Define the different field layouts that will be used for this process
   using namespace ShortFieldTagsNames;
@@ -50,16 +43,16 @@ void SurfaceCouplingExporter::set_grids(const std::shared_ptr<const GridsManager
   add_field<Required>("pseudo_density",       scalar3d_layout_mid,  Pa,     grid_name, ps);
   add_field<Required>("phis",                 scalar2d_layout,      m2/s2,  grid_name);
   add_field<Required>("p_mid",                scalar3d_layout_mid,  Pa,     grid_name, ps);
-  add_field<Required>("qv",                   scalar3d_layout_mid,  Qunit,  grid_name, "tracers", ps);
+  add_field<Required>("qv",                   scalar3d_layout_mid,  kg/kg,  grid_name, "tracers", ps);
   add_field<Required>("T_mid",                scalar3d_layout_mid,  K,      grid_name, ps);
   // TODO: Switch horiz_winds to using U and V, note right now there is an issue with when the subfields are created, so can't switch yet.
   add_field<Required>("horiz_winds",          vector3d_layout,      m/s,    grid_name);
-  add_field<Required>("sfc_flux_dir_nir",     scalar2d_layout,      Wm2,    grid_name);
-  add_field<Required>("sfc_flux_dir_vis",     scalar2d_layout,      Wm2,    grid_name);
-  add_field<Required>("sfc_flux_dif_nir",     scalar2d_layout,      Wm2,    grid_name);
-  add_field<Required>("sfc_flux_dif_vis",     scalar2d_layout,      Wm2,    grid_name);
-  add_field<Required>("sfc_flux_sw_net" ,     scalar2d_layout,      Wm2,    grid_name);
-  add_field<Required>("sfc_flux_lw_dn"  ,     scalar2d_layout,      Wm2,    grid_name);
+  add_field<Required>("sfc_flux_dir_nir",     scalar2d_layout,      W/m2,   grid_name);
+  add_field<Required>("sfc_flux_dir_vis",     scalar2d_layout,      W/m2,   grid_name);
+  add_field<Required>("sfc_flux_dif_nir",     scalar2d_layout,      W/m2,   grid_name);
+  add_field<Required>("sfc_flux_dif_vis",     scalar2d_layout,      W/m2,   grid_name);
+  add_field<Required>("sfc_flux_sw_net" ,     scalar2d_layout,      W/m2,   grid_name);
+  add_field<Required>("sfc_flux_lw_dn"  ,     scalar2d_layout,      W/m2,   grid_name);
   add_field<Required>("precip_liq_surf_mass", scalar2d_layout,      kg/m2,  grid_name);
   add_field<Required>("precip_ice_surf_mass", scalar2d_layout,      kg/m2,  grid_name);
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
@@ -28,12 +28,8 @@ void SurfaceCouplingImporter::set_grids(const std::shared_ptr<const GridsManager
 
   // The units of mixing ratio Q are technically non-dimensional.
   // Nevertheless, for output reasons, we like to see 'kg/kg'.
-  auto Qunit = kg/kg;
-  Qunit.set_string("kg/kg");
   auto nondim = Units::nondimensional();
-  auto Wm2 = W / m / m;
-  Wm2.set_string("W/m2)");
-  const auto m2 = m*m;
+  Units m2 (m*m,"m2");
 
   // Define the different field layouts that will be used for this process
   using namespace ShortFieldTagsNames;
@@ -51,7 +47,7 @@ void SurfaceCouplingImporter::set_grids(const std::shared_ptr<const GridsManager
   add_field<Computed>("surf_mom_flux",    vector2d_layout, N/m2,    grid_name);
   add_field<Computed>("surf_radiative_T", scalar2d_layout, K,       grid_name);
   add_field<Computed>("T_2m",             scalar2d_layout, K,       grid_name);
-  add_field<Computed>("qv_2m",            scalar2d_layout, Qunit,   grid_name);
+  add_field<Computed>("qv_2m",            scalar2d_layout, kg/kg,   grid_name);
   add_field<Computed>("wind_speed_10m",   scalar2d_layout, m/s,     grid_name);
   add_field<Computed>("snow_depth_land",  scalar2d_layout, m,       grid_name);
   add_field<Computed>("ocnfrac",          scalar2d_layout, nondim,  grid_name);

--- a/components/eamxx/src/diagnostics/atm_density.cpp
+++ b/components/eamxx/src/diagnostics/atm_density.cpp
@@ -16,9 +16,6 @@ void AtmDensityDiagnostic::set_grids(const std::shared_ptr<const GridsManager> g
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
-
   // Boiler Plate
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();
@@ -29,10 +26,10 @@ void AtmDensityDiagnostic::set_grids(const std::shared_ptr<const GridsManager> g
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid",          scalar3d_layout_mid, K,  grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa, grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa, grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("qv",             scalar3d_layout_mid, Q,  grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("T_mid",          scalar3d_layout_mid, K,     grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,    grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,    grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("qv",             scalar3d_layout_mid, kg/kg, grid_name, SCREAM_PACK_SIZE);
 
   // Construct and allocate the diagnostic field
   FieldIdentifier fid (name(), scalar3d_layout_mid, kg/(m*m*m), grid_name);

--- a/components/eamxx/src/diagnostics/dry_static_energy.cpp
+++ b/components/eamxx/src/diagnostics/dry_static_energy.cpp
@@ -20,10 +20,8 @@ void DryStaticEnergyDiagnostic::set_grids(const std::shared_ptr<const GridsManag
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
-  const auto m2 = m*m;
-  const auto s2 = s*s;
+  auto m2  = pow(m,2);
+  auto s2  = pow(s,2);
 
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();
@@ -35,11 +33,11 @@ void DryStaticEnergyDiagnostic::set_grids(const std::shared_ptr<const GridsManag
   constexpr int ps = Pack::n;
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid",          scalar3d_layout_mid, K,  grid_name, ps);
-  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa, grid_name, ps);
-  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa, grid_name, ps);
-  add_field<Required>("qv",             scalar3d_layout_mid, Q,  grid_name, ps);
-  add_field<Required>("phis",           scalar2d_layout_col, m2/s2, grid_name, ps);
+  add_field<Required>("T_mid",          scalar3d_layout_mid, K,      grid_name, ps);
+  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,     grid_name, ps);
+  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,     grid_name, ps);
+  add_field<Required>("qv",             scalar3d_layout_mid, kg/kg,  grid_name, ps);
+  add_field<Required>("phis",           scalar2d_layout_col, m2/s2,  grid_name, ps);
 
   // Construct and allocate the diagnostic field
   FieldIdentifier fid (name(), scalar3d_layout_mid, m2/s2, grid_name);

--- a/components/eamxx/src/diagnostics/longwave_cloud_forcing.cpp
+++ b/components/eamxx/src/diagnostics/longwave_cloud_forcing.cpp
@@ -18,9 +18,7 @@ void LongwaveCloudForcingDiagnostic::set_grids(const std::shared_ptr<const Grids
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  const auto m2 = m*m;
-  auto radflux_units = W/(m2);
-  radflux_units.set_string("W/m2");
+  Units m2 (m*m,"m2");
 
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();
@@ -35,7 +33,7 @@ void LongwaveCloudForcingDiagnostic::set_grids(const std::shared_ptr<const Grids
   add_field<Required>("LW_clrsky_flux_up", scalar3d_layout_mid, W/m2,  grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d_layout_col, radflux_units, grid_name);
+  FieldIdentifier fid (name(), scalar2d_layout_col, W/m2, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation();

--- a/components/eamxx/src/diagnostics/number_path.cpp
+++ b/components/eamxx/src/diagnostics/number_path.cpp
@@ -39,8 +39,7 @@ void NumberPathDiagnostic::set_grids(
     const std::shared_ptr<const GridsManager> grids_manager) {
   using namespace ekat::units;
 
-  auto out_units = kg / (kg * m * m);
-  out_units.set_string("kg/(kg m2)");
+  auto m2 = pow(m,2);
 
   auto grid             = grids_manager->get_grid("Physics");
   const auto &grid_name = grid->name();
@@ -56,7 +55,7 @@ void NumberPathDiagnostic::set_grids(
   add_field<Required>(m_nname, scalar3d, 1 / kg, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid(name(), scalar2d, out_units, grid_name);
+  FieldIdentifier fid(name(), scalar2d, kg/(kg*m2), grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/potential_temperature.cpp
+++ b/components/eamxx/src/diagnostics/potential_temperature.cpp
@@ -35,9 +35,6 @@ void PotentialTemperatureDiagnostic::set_grids(const std::shared_ptr<const Grids
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
-
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
@@ -51,7 +48,7 @@ void PotentialTemperatureDiagnostic::set_grids(const std::shared_ptr<const Grids
   add_field<Required>("p_mid",          scalar3d_layout_mid, Pa, grid_name, ps);
   // Only needed for LiqPotentialTemperature, but put it here for ease
   // TODO: only request it if it is needed
-  add_field<Required>("qc",             scalar3d_layout_mid, Q,  grid_name, ps);
+  add_field<Required>("qc",             scalar3d_layout_mid, kg/kg,  grid_name, ps);
 
   // Construct and allocate the diagnostic field
   FieldIdentifier fid (name(), scalar3d_layout_mid, K, grid_name);

--- a/components/eamxx/src/diagnostics/relative_humidity.cpp
+++ b/components/eamxx/src/diagnostics/relative_humidity.cpp
@@ -18,8 +18,6 @@ void RelativeHumidityDiagnostic::set_grids(const std::shared_ptr<const GridsMana
   using namespace ShortFieldTagsNames;
 
   auto nondim = Units::nondimensional();
-  auto Q = nondim;
-  Q.set_string("kg/kg");
 
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();
@@ -29,11 +27,11 @@ void RelativeHumidityDiagnostic::set_grids(const std::shared_ptr<const GridsMana
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid",              scalar3d_layout_mid, K,  grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("p_dry_mid",          scalar3d_layout_mid, Pa, grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("qv",                 scalar3d_layout_mid, Q,  grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("pseudo_density",     scalar3d_layout_mid, Pa, grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("pseudo_density_dry", scalar3d_layout_mid, Pa, grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("T_mid",              scalar3d_layout_mid, K,     grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("p_dry_mid",          scalar3d_layout_mid, Pa,    grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("qv",                 scalar3d_layout_mid, kg/kg, grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("pseudo_density",     scalar3d_layout_mid, Pa,    grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("pseudo_density_dry", scalar3d_layout_mid, Pa,    grid_name, SCREAM_PACK_SIZE);
 
   // Construct and allocate the diagnostic field
   FieldIdentifier fid (name(), scalar3d_layout_mid, nondim, grid_name);

--- a/components/eamxx/src/diagnostics/sea_level_pressure.cpp
+++ b/components/eamxx/src/diagnostics/sea_level_pressure.cpp
@@ -17,10 +17,8 @@ void SeaLevelPressureDiagnostic::set_grids(const std::shared_ptr<const GridsMana
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
-  const auto m2 = m*m;
-  const auto s2 = s*s;
+  const auto m2 = pow(m,2);
+  const auto s2 = pow(s,2);
 
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();

--- a/components/eamxx/src/diagnostics/shortwave_cloud_forcing.cpp
+++ b/components/eamxx/src/diagnostics/shortwave_cloud_forcing.cpp
@@ -17,8 +17,7 @@ void ShortwaveCloudForcingDiagnostic::set_grids(const std::shared_ptr<const Grid
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  auto radflux_units = W/(m*m);
-  radflux_units.set_string("W/m2");
+  Units m2 (m*m,"m2");
 
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();
@@ -29,13 +28,13 @@ void ShortwaveCloudForcingDiagnostic::set_grids(const std::shared_ptr<const Grid
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("SW_flux_dn",        scalar3d_layout_mid, radflux_units, grid_name);
-  add_field<Required>("SW_flux_up",        scalar3d_layout_mid, radflux_units, grid_name);
-  add_field<Required>("SW_clrsky_flux_dn", scalar3d_layout_mid, radflux_units, grid_name);
-  add_field<Required>("SW_clrsky_flux_up", scalar3d_layout_mid, radflux_units, grid_name);
+  add_field<Required>("SW_flux_dn",        scalar3d_layout_mid, W/m2, grid_name);
+  add_field<Required>("SW_flux_up",        scalar3d_layout_mid, W/m2, grid_name);
+  add_field<Required>("SW_clrsky_flux_dn", scalar3d_layout_mid, W/m2, grid_name);
+  add_field<Required>("SW_clrsky_flux_up", scalar3d_layout_mid, W/m2, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d_layout_col, radflux_units, grid_name);
+  FieldIdentifier fid (name(), scalar2d_layout_col, W/m2, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation();

--- a/components/eamxx/src/diagnostics/surf_upward_latent_heat_flux.cpp
+++ b/components/eamxx/src/diagnostics/surf_upward_latent_heat_flux.cpp
@@ -20,10 +20,8 @@ SurfaceUpwardLatentHeatFlux(const ekat::Comm& comm, const ekat::ParameterList& p
 void SurfaceUpwardLatentHeatFlux::
 set_grids (const std::shared_ptr<const GridsManager> grids_manager)
 {
-  const auto m2 = ekat::units::m * ekat::units::m;
-  const auto W = ekat::units::W;
-  auto radflux_units = W/(m2);
-  radflux_units.set_string("W/m2");
+  using namespace ekat::units;
+  Units m2(m*m,"m2");
 
   const auto surf_evap_units = ekat::units::kg / m2 / ekat::units::s;
 
@@ -38,7 +36,7 @@ set_grids (const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>("surf_evap", scalar2d_layout_mid, surf_evap_units,  grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid(name(), scalar2d_layout_mid, radflux_units, grid_name);
+  FieldIdentifier fid(name(), scalar2d_layout_mid, W/m2, grid_name);
   // handle parent class member variables
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.get_header().get_alloc_properties().request_allocation();

--- a/components/eamxx/src/diagnostics/tests/number_paths_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/number_paths_tests.cpp
@@ -37,8 +37,6 @@ template <typename DeviceT>
 void run(std::mt19937_64 &engine) {
   using PC         = scream::physics::Constants<Real>;
   using KT         = ekat::KokkosTypes<DeviceT>;
-  using ESU        = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
-  using MemberType = typename KT::MemberType;
   using view_1d    = typename KT::template view_1d<Real>;
 
   constexpr int num_levs = 33;
@@ -51,9 +49,6 @@ void run(std::mt19937_64 &engine) {
   // Create a grids manager - single column for these tests
   const int ncols = 10;
   auto gm         = create_gm(comm, ncols, num_levs);
-
-  // Kokkos Policy
-  auto policy = ESU::get_default_team_policy(ncols, num_levs);
 
   // Input (randomized) views
   view_1d pseudo_density("pseudo_density", num_levs), qc("qc", num_levs),

--- a/components/eamxx/src/diagnostics/vapor_flux.cpp
+++ b/components/eamxx/src/diagnostics/vapor_flux.cpp
@@ -36,12 +36,6 @@ void VaporFluxDiagnostic::set_grids(const std::shared_ptr<const GridsManager> gr
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
-
-  auto vel = m/s;
-  vel.set_string("m/s");
-
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
@@ -52,9 +46,9 @@ void VaporFluxDiagnostic::set_grids(const std::shared_ptr<const GridsManager> gr
   auto vector3d = grid->get_3d_vector_layout(true,2);
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("pseudo_density", scalar3d, Pa,  grid_name);
-  add_field<Required>("qv",             scalar3d, Q,   grid_name);
-  add_field<Required>("horiz_winds",    vector3d, m/s, grid_name);
+  add_field<Required>("pseudo_density", scalar3d, Pa,    grid_name);
+  add_field<Required>("qv",             scalar3d, kg/kg, grid_name);
+  add_field<Required>("horiz_winds",    vector3d, m/s,   grid_name);
 
   // Construct and allocate the diagnostic field
   FieldIdentifier fid (name(), scalar2d, kg/m/s, grid_name);

--- a/components/eamxx/src/diagnostics/vertical_layer.cpp
+++ b/components/eamxx/src/diagnostics/vertical_layer.cpp
@@ -29,10 +29,8 @@ set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
-  auto m2 = m*m;
-  auto s2 = s*s;
+  auto m2 = pow(m,2);
+  auto s2 = pow(s,2);
 
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();
@@ -48,7 +46,7 @@ set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>("T_mid",          scalar3d_layout_mid, K,     grid_name, ps);
   add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,    grid_name, ps);
   add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,    grid_name, ps);
-  add_field<Required>("qv",             scalar3d_layout_mid, Q,     grid_name, ps);
+  add_field<Required>("qv",             scalar3d_layout_mid, kg/kg, grid_name, ps);
 
   // Only need phis if computing geopotential_*
   if (not m_only_compute_dz and not m_from_sea_level) {

--- a/components/eamxx/src/diagnostics/virtual_temperature.cpp
+++ b/components/eamxx/src/diagnostics/virtual_temperature.cpp
@@ -15,9 +15,6 @@ void VirtualTemperatureDiagnostic::set_grids(const std::shared_ptr<const GridsMa
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
-
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
@@ -27,8 +24,8 @@ void VirtualTemperatureDiagnostic::set_grids(const std::shared_ptr<const GridsMa
   constexpr int ps = Pack::n;
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid",       scalar3d_layout_mid, K,  grid_name, ps);
-  add_field<Required>("qv",          scalar3d_layout_mid, Q,  grid_name, ps);
+  add_field<Required>("T_mid",       scalar3d_layout_mid, K,     grid_name, ps);
+  add_field<Required>("qv",          scalar3d_layout_mid, kg/kg, grid_name, ps);
 
   // Construct and allocate the diagnostic field
   FieldIdentifier fid (name(), scalar3d_layout_mid, K, grid_name);

--- a/components/eamxx/src/diagnostics/water_path.cpp
+++ b/components/eamxx/src/diagnostics/water_path.cpp
@@ -42,9 +42,7 @@ set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
 
-  const auto m2 = m*m;
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
+  auto m2 = pow (m,2);
 
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();
@@ -55,8 +53,8 @@ set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   auto scalar3d = grid->get_3d_scalar_layout(true);
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("pseudo_density", scalar3d, Pa, grid_name);
-  add_field<Required>(m_qname,          scalar3d, Q,  grid_name);
+  add_field<Required>("pseudo_density", scalar3d, Pa,    grid_name);
+  add_field<Required>(m_qname,          scalar3d, kg/kg, grid_name);
 
   // Construct and allocate the diagnostic field
   FieldIdentifier fid (name(), scalar2d, kg/m2, grid_name);

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
@@ -238,8 +238,6 @@ void HommeDynamics
   if (trace_gases_workaround.is_restart()) return; // always false b/c it hasn't been set yet
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
-  auto molmol = mol/mol;
-  molmol.set_string("mol/mol");
   const auto& rgn = m_cgll_grid->name();
   const auto& pgn = m_phys_grid->name();
   const auto rnc = m_cgll_grid->get_num_local_dofs();
@@ -247,10 +245,10 @@ void HommeDynamics
   const auto nlev = m_cgll_grid->get_num_vertical_levels();
   constexpr int ps = SCREAM_SMALL_PACK_SIZE;
   for (const auto& e : trace_gases_workaround.get_active_gases()) {
-    add_field<Required>(e, FieldLayout({COL,LEV},{rnc,nlev}), molmol, rgn, ps);
+    add_field<Required>(e, FieldLayout({COL,LEV},{rnc,nlev}), mol/mol, rgn, ps);
     // 'Updated' rather than just 'Computed' so that it gets written to the
     // restart file.
-    add_field<Updated >(e, FieldLayout({COL,LEV},{pnc,nlev}), molmol, pgn, ps);
+    add_field<Updated >(e, FieldLayout({COL,LEV},{pnc,nlev}), mol/mol, pgn, ps);
   }
   trace_gases_workaround.set_remapper(gm->create_remapper(m_cgll_grid, m_dyn_grid));
 }

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -115,10 +115,6 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
   constexpr int QTL = HOMMEXX_Q_NUM_TIME_LEVELS;
   constexpr int N   = HOMMEXX_PACK_SIZE;
 
-  // Some units
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
-
   const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
   const int nlev_mid = m_dyn_grid->get_num_vertical_levels();
   const int nlev_int = nlev_mid+1;
@@ -161,8 +157,8 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
   //       into the n0 time-slice of Homme's vtheta_dp, and then do the conversion
   //       T_mid->VTheta_dp in place.
 
-  const auto m2 = m*m;
-  const auto s2 = s*s;
+  const auto m2 = pow(m,2);
+  const auto s2 = pow(s,2);
 
   // Note: qv is needed to transform T<->Theta
 
@@ -176,7 +172,7 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
   add_field<Computed>("pseudo_density",     pg_scalar3d_mid, Pa,    pgn,N);
   add_field<Computed>("pseudo_density_dry", pg_scalar3d_mid, Pa,    pgn,N);
   add_field<Updated> ("ps",                 pg_scalar2d    , Pa,    pgn);
-  add_field<Updated >("qv",                 pg_scalar3d_mid, Q,     pgn,"tracers",N);
+  add_field<Updated >("qv",                 pg_scalar3d_mid, kg/kg, pgn,"tracers",N);
   add_field<Updated >("phis",               pg_scalar2d    , m2/s2, pgn);
   add_field<Computed>("p_int",              pg_scalar3d_int, Pa,    pgn,N);
   add_field<Computed>("p_mid",              pg_scalar3d_mid, Pa,    pgn,N);

--- a/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
+++ b/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
@@ -140,6 +140,7 @@ void HommeGridsManager::build_dynamics_grid () {
   }
 
   using gid_type = AbstractGrid::gid_type;
+  using namespace ekat::units;
 
   // Get dimensions and create "empty" grid
   const int nlelem = get_num_local_elems_f90();
@@ -149,7 +150,7 @@ void HommeGridsManager::build_dynamics_grid () {
   dyn_grid->setSelfPointer(dyn_grid);
 
   const auto layout2d = dyn_grid->get_2d_scalar_layout();
-  const auto rad = ekat::units::Units::nondimensional();
+  const Units rad (Units::nondimensional(),"rad");
 
   // Filling the cg/dg gids, elgpgp, coords, lat/lon views
   auto dg_dofs = dyn_grid->get_dofs_gids();
@@ -218,8 +219,9 @@ build_physics_grid (const ci_string& type, const ci_string& rebalance) {
 
   // Create the gids, coords, area views
   using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
   const auto layout2d = phys_grid->get_2d_scalar_layout();
-  const auto rad = ekat::units::Units::nondimensional();
+  const Units rad (Units::nondimensional(),"rad");
 
   auto dofs = phys_grid->get_dofs_gids();
   auto lat  = phys_grid->create_geometry_data("lat",layout2d,rad);
@@ -260,15 +262,15 @@ build_physics_grid (const ci_string& type, const ci_string& rebalance) {
   if (get_grid("Dynamics")->has_geometry_data("hyam")) {
     auto layout_mid = phys_grid->get_vertical_layout(true);
     auto layout_int = phys_grid->get_vertical_layout(false);
-    const auto nondim = ekat::units::Units::nondimensional();
-    auto lev_unit = ekat::units::Units::nondimensional();;
-    lev_unit.set_string("mb");
+    using namespace ekat::units;
+    Units nondim = Units::nondimensional();
+    Units mbar(bar/1000,"mb");
 
     auto hyai = phys_grid->create_geometry_data("hyai",layout_int,nondim);
     auto hybi = phys_grid->create_geometry_data("hybi",layout_int,nondim);
     auto hyam = phys_grid->create_geometry_data("hyam",layout_mid,nondim);
     auto hybm = phys_grid->create_geometry_data("hybm",layout_mid,nondim);
-    auto lev  = phys_grid->create_geometry_data("lev",  layout_mid, lev_unit);
+    auto lev  = phys_grid->create_geometry_data("lev", layout_mid,mbar);
 
     for (auto f : {hyai, hybi, hyam, hybm}) {
       auto f_d = get_grid("Dynamics")->get_geometry_data(f.name());

--- a/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
+++ b/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
@@ -24,8 +24,6 @@ void CldFraction::set_grids(const std::shared_ptr<const GridsManager> grids_mana
 
   // The units of mixing ratio Q are technically non-dimensional.
   // Nevertheless, for output reasons, we like to see 'kg/kg'.
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
   auto nondim = Units::nondimensional();
 
   m_grid = grids_manager->get_grid("Physics");
@@ -40,7 +38,7 @@ void CldFraction::set_grids(const std::shared_ptr<const GridsManager> grids_mana
 
   // Set of fields used strictly as input
   constexpr int ps = Pack::n;
-  add_field<Required>("qi",          scalar3d_layout_mid, Q,      grid_name,"tracers",ps);
+  add_field<Required>("qi",          scalar3d_layout_mid, kg/kg,  grid_name,"tracers",ps);
   add_field<Required>("cldfrac_liq", scalar3d_layout_mid, nondim, grid_name,ps);
 
   // Set of fields used strictly as output

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -31,16 +31,14 @@ Cosp::Cosp (const ekat::Comm& comm, const ekat::ParameterList& params)
 void Cosp::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
+  using namespace ekat::prefixes;
   using namespace ShortFieldTagsNames;
 
   // The units of mixing ratio Q are technically non-dimensional.
   // Nevertheless, for output reasons, we like to see 'kg/kg'.
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
-  auto nondim = Units::nondimensional();
-  auto percent = Units::nondimensional();
-  percent.set_string("%");
-  auto micron = m / 1000000;
+  Units nondim = Units::nondimensional();
+  Units percent (nondim,"%");
+  auto micron = micro*m;
 
   m_grid = grids_manager->get_grid("Physics");
   const auto& grid_name = m_grid->name();
@@ -68,9 +66,9 @@ void Cosp::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   //add_field<Required>("height_mid",  scalar3d_mid, m,      grid_name);
   //add_field<Required>("height_int",  scalar3d_int, m,      grid_name);
   add_field<Required>("T_mid",            scalar3d_mid, K,      grid_name);
-  add_field<Required>("qv",               scalar3d_mid, Q,      grid_name, "tracers");
-  add_field<Required>("qc",               scalar3d_mid, Q,      grid_name, "tracers");
-  add_field<Required>("qi",               scalar3d_mid, Q,      grid_name, "tracers");
+  add_field<Required>("qv",               scalar3d_mid, kg/kg,      grid_name, "tracers");
+  add_field<Required>("qc",               scalar3d_mid, kg/kg,      grid_name, "tracers");
+  add_field<Required>("qi",               scalar3d_mid, kg/kg,      grid_name, "tracers");
   add_field<Required>("cldfrac_rad",      scalar3d_mid, nondim, grid_name);
   // Optical properties, should be computed in radiation interface
   add_field<Required>("dtau067",     scalar3d_mid, nondim, grid_name); // 0.67 micron optical depth

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -91,13 +91,10 @@ void MAMMicrophysics::configure(const ekat::ParameterList& params) {
 void MAMMicrophysics::set_grids(const std::shared_ptr<const GridsManager> grids_manager) {
   using namespace ekat::units;
 
-  auto q_unit = kg/kg; // mass mixing ratios [kg stuff / kg air]
-  q_unit.set_string("kg/kg");
-  auto n_unit = 1/kg;  // number mixing ratios [# / kg air]
-  n_unit.set_string("#/kg");
-  Units nondim(0,0,0,0,0,0,0);
-  const auto m2 = m*m;
-  const auto s2 = s*s;
+  Units nondim = Units::nondimensional();
+  Units n_unit (1/kg,"#/kg");  // number mixing ratios [# / kg air]
+  const auto m2 = pow(m,2);
+  const auto s2 = pow(s,2);
 
   grid_ = grids_manager->get_grid("Physics");
   const auto& grid_name = grid_->name();
@@ -125,8 +122,8 @@ void MAMMicrophysics::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Required>("omega", scalar3d_layout_mid, Pa/s, grid_name); // vertical pressure velocity
   add_field<Required>("T_mid", scalar3d_layout_mid, K, grid_name); // Temperature
   add_field<Required>("p_mid", scalar3d_layout_mid, Pa, grid_name); // total pressure
-  add_field<Required>("qv", scalar3d_layout_mid, q_unit, grid_name, "tracers"); // specific humidity
-  add_field<Required>("qi", scalar3d_layout_mid, q_unit, grid_name, "tracers"); // ice wet mixing ratio
+  add_field<Required>("qv", scalar3d_layout_mid, kg/kg, grid_name, "tracers"); // specific humidity
+  add_field<Required>("qi", scalar3d_layout_mid, kg/kg, grid_name, "tracers"); // ice wet mixing ratio
   add_field<Required>("ni", scalar3d_layout_mid, n_unit, grid_name, "tracers"); // ice number mixing ratio
   add_field<Required>("pbl_height", scalar2d_layout_col, m, grid_name); // planetary boundary layer height
   add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa, grid_name); // p_del, hydrostatic pressure
@@ -134,7 +131,7 @@ void MAMMicrophysics::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Required>("cldfrac_tot", scalar3d_layout_mid, nondim, grid_name); // cloud fraction
 
   // droplet activation can alter cloud liquid and number mixing ratios
-  add_field<Updated>("qc", scalar3d_layout_mid, q_unit, grid_name, "tracers"); // cloud liquid wet mixing ratio
+  add_field<Updated>("qc", scalar3d_layout_mid, kg/kg, grid_name, "tracers"); // cloud liquid wet mixing ratio
   add_field<Updated>("nc", scalar3d_layout_mid, n_unit, grid_name, "tracers"); // cloud liquid wet number mixing ratio
 
   // (interstitial) aerosol tracers of interest: mass (q) and number (n) mixing ratios
@@ -144,7 +141,7 @@ void MAMMicrophysics::set_grids(const std::shared_ptr<const GridsManager> grids_
     for (int a = 0; a < mam_coupling::num_aero_species(); ++a) {
       const char* int_mmr_field_name = mam_coupling::int_aero_mmr_field_name(m, a);
       if (strlen(int_mmr_field_name) > 0) {
-        add_field<Updated>(int_mmr_field_name, scalar3d_layout_mid, q_unit, grid_name, "tracers");
+        add_field<Updated>(int_mmr_field_name, scalar3d_layout_mid, kg/kg, grid_name, "tracers");
       }
     }
   }
@@ -152,7 +149,7 @@ void MAMMicrophysics::set_grids(const std::shared_ptr<const GridsManager> grids_
   // aerosol-related gases: mass mixing ratios
   for (int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char* gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_field<Updated>(gas_mmr_field_name, scalar3d_layout_mid, q_unit, grid_name, "tracers");
+    add_field<Updated>(gas_mmr_field_name, scalar3d_layout_mid, kg/kg, grid_name, "tracers");
   }
 
   // Tracers group -- do we need this in addition to the tracers above? In any

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -25,12 +25,9 @@ void MAMOptics::set_grids(
 
   grid_                 = grids_manager->get_grid("Physics");
   const auto &grid_name = grid_->name();
-  auto q_unit           = kg / kg;  // mass mixing ratios [kg stuff / kg air]
-  q_unit.set_string("kg/kg");
-  auto n_unit = 1 / kg;  // number mixing ratios [# / kg air]
-  n_unit.set_string("#/kg");
-  const auto m2 = m * m;
-  const auto s2 = s * s;
+  Units n_unit (1 / kg, "#/kg");  // number mixing ratios [# / kg air]
+  const auto m2 = pow(m,2);
+  const auto s2 = pow(s,2);
 
   ncol_     = grid_->get_num_local_dofs();  // number of columns on this rank
   nlev_     = grid_->get_num_vertical_levels();  // number of levels per column
@@ -58,12 +55,12 @@ void MAMOptics::set_grids(
   add_field<Required>("p_int",              scalar3d_int, Pa,     grid_name);  // total pressure
   add_field<Required>("pseudo_density",     scalar3d_mid, Pa,     grid_name);
   add_field<Required>("pseudo_density_dry", scalar3d_mid, Pa,     grid_name);
-  add_field<Required>("qv",                 scalar3d_mid, q_unit, grid_name,"tracers");  // specific humidity
-  add_field<Required>("qi",                 scalar3d_mid, q_unit, grid_name,"tracers");  // ice wet mixing ratio
+  add_field<Required>("qv",                 scalar3d_mid, kg/kg,  grid_name,"tracers");  // specific humidity
+  add_field<Required>("qi",                 scalar3d_mid, kg/kg,  grid_name,"tracers");  // ice wet mixing ratio
   add_field<Required>("ni",                 scalar3d_mid, n_unit, grid_name,"tracers");  // ice number mixing ratio
 
   // droplet activation can alter cloud liquid and number mixing ratios
-  add_field<Required>("qc", scalar3d_mid, q_unit, grid_name,"tracers");  // cloud liquid wet mixing ratio
+  add_field<Required>("qc", scalar3d_mid, kg/kg, grid_name,"tracers");  // cloud liquid wet mixing ratio
   add_field<Required>("nc", scalar3d_mid, n_unit, grid_name,"tracers");  // cloud liquid wet number mixing ratio
 
   add_field<Required>("phis", scalar2d, m2 / s2, grid_name);
@@ -94,7 +91,7 @@ void MAMOptics::set_grids(
       const char *int_mmr_field_name = mam_coupling::int_aero_mmr_field_name(m, a);
 
       if(strlen(int_mmr_field_name) > 0) {
-        add_field<Updated>(int_mmr_field_name, scalar3d_mid, q_unit,grid_name, "tracers");
+        add_field<Updated>(int_mmr_field_name, scalar3d_mid, kg/kg,grid_name, "tracers");
       }
     }
   }
@@ -108,7 +105,7 @@ void MAMOptics::set_grids(
           mam_coupling::cld_aero_mmr_field_name(m, a);
 
       if(strlen(cld_mmr_field_name) > 0) {
-        add_field<Updated>(cld_mmr_field_name, scalar3d_mid, q_unit, grid_name);
+        add_field<Updated>(cld_mmr_field_name, scalar3d_mid, kg/kg, grid_name);
       }
     }
   }
@@ -116,7 +113,7 @@ void MAMOptics::set_grids(
   // aerosol-related gases: mass mixing ratios
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char *gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_field<Updated>(gas_mmr_field_name, scalar3d_mid, q_unit, grid_name, "tracers");
+    add_field<Updated>(gas_mmr_field_name, scalar3d_mid, kg/kg, grid_name, "tracers");
   }
 }
 

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -68,8 +68,6 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   FieldLayout horiz_wind_layout = m_grid->get_3d_vector_layout(true,2);
 
   constexpr int ps = 1;
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
   add_field<Required>("p_mid", scalar3d_layout_mid, Pa, grid_name, ps);
 
   /* ----------------------- WARNING --------------------------------*/
@@ -85,7 +83,7 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
     add_field<Updated>("T_mid", scalar3d_layout_mid, K, grid_name, ps);
   }
   if (ekat::contains(m_fields_nudge,"qv")) {
-    add_field<Updated>("qv",    scalar3d_layout_mid, Q, grid_name, "tracers", ps);
+    add_field<Updated>("qv",    scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
   }
   if (ekat::contains(m_fields_nudge,"U") or ekat::contains(m_fields_nudge,"V")) {
     add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,     grid_name, ps);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -25,14 +25,13 @@ P3Microphysics::P3Microphysics (const ekat::Comm& comm, const ekat::ParameterLis
 void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
+  using namespace ekat::prefixes;
 
   // The units of mixing ratio Q are technically non-dimensional.
   // Nevertheless, for output reasons, we like to see 'kg/kg'.
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
   auto nondim = Units::nondimensional();
-  auto micron = m / 1000000;
-  auto m2 = m * m;
+  auto micron = micro*m;
+  auto m2 = pow(m,2);
 
   m_grid = grids_manager->get_grid("Physics");
   const auto& grid_name = m_grid->name();
@@ -73,27 +72,27 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_field<Updated> ("T_mid",       scalar3d_layout_mid, K,      grid_name, ps);  // T_mid is the only one of these variables that is also updated.
 
   // Prognostic State:  (all fields are both input and output)
-  add_field<Updated>("qv",     scalar3d_layout_mid, Q,    grid_name, "tracers", ps);
-  add_field<Updated>("qc",     scalar3d_layout_mid, Q,    grid_name, "tracers", ps);
-  add_field<Updated>("qr",     scalar3d_layout_mid, Q,    grid_name, "tracers", ps);
-  add_field<Updated>("qi",     scalar3d_layout_mid, Q,    grid_name, "tracers", ps);
-  add_field<Updated>("qm",     scalar3d_layout_mid, Q,    grid_name, "tracers", ps);
-  add_field<Updated>("nc",     scalar3d_layout_mid, 1/kg, grid_name, "tracers", ps);
-  add_field<Updated>("nr",     scalar3d_layout_mid, 1/kg, grid_name, "tracers", ps);
-  add_field<Updated>("ni",     scalar3d_layout_mid, 1/kg, grid_name, "tracers", ps);
-  add_field<Updated>("bm",     scalar3d_layout_mid, 1/kg, grid_name, "tracers", ps);
+  add_field<Updated>("qv",     scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
+  add_field<Updated>("qc",     scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
+  add_field<Updated>("qr",     scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
+  add_field<Updated>("qi",     scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
+  add_field<Updated>("qm",     scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
+  add_field<Updated>("nc",     scalar3d_layout_mid, 1/kg,  grid_name, "tracers", ps);
+  add_field<Updated>("nr",     scalar3d_layout_mid, 1/kg,  grid_name, "tracers", ps);
+  add_field<Updated>("ni",     scalar3d_layout_mid, 1/kg,  grid_name, "tracers", ps);
+  add_field<Updated>("bm",     scalar3d_layout_mid, 1/kg,  grid_name, "tracers", ps);
 
   // Diagnostic Inputs: (only the X_prev fields are both input and output, all others are just inputs)
   add_field<Required>("nc_nuceat_tend",     scalar3d_layout_mid, 1/(kg*s), grid_name, ps);
   if (infrastructure.prescribedCCN) {
     add_field<Required>("nccn",               scalar3d_layout_mid, 1/kg,     grid_name, ps);
   }
-  add_field<Required>("ni_activated",       scalar3d_layout_mid, 1/kg,     grid_name, ps);
-  add_field<Required>("inv_qc_relvar",      scalar3d_layout_mid, Q*Q,      grid_name, ps);
-  add_field<Required>("pseudo_density",     scalar3d_layout_mid, Pa,       grid_name, ps);
-  add_field<Required>("pseudo_density_dry", scalar3d_layout_mid, Pa,       grid_name, ps);
-  add_field<Updated> ("qv_prev_micro_step", scalar3d_layout_mid, Q,        grid_name, ps);
-  add_field<Updated> ("T_prev_micro_step",  scalar3d_layout_mid, K,        grid_name, ps);
+  add_field<Required>("ni_activated",       scalar3d_layout_mid, 1/kg,         grid_name, ps);
+  add_field<Required>("inv_qc_relvar",      scalar3d_layout_mid, pow(kg/kg,2), grid_name, ps);
+  add_field<Required>("pseudo_density",     scalar3d_layout_mid, Pa,           grid_name, ps);
+  add_field<Required>("pseudo_density_dry", scalar3d_layout_mid, Pa,           grid_name, ps);
+  add_field<Updated> ("qv_prev_micro_step", scalar3d_layout_mid, kg/kg,        grid_name, ps);
+  add_field<Updated> ("T_prev_micro_step",  scalar3d_layout_mid, K,            grid_name, ps);
 
   // Diagnostic Outputs: (all fields are just outputs w.r.t. P3)
   add_field<Updated>("precip_liq_surf_mass", scalar2d_layout,     kg/m2,  grid_name, "ACCUMULATED");
@@ -106,9 +105,9 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   // TODO: These should be averaged over subcycle as well.  But there is no simple mechanism
   //       yet to reset these values at the beginning of the atmosphere timestep.  When this
   //       mechanism is developed we should add these variables to the accumulated variables.
-  add_field<Computed>("micro_liq_ice_exchange", scalar3d_layout_mid, Q, grid_name, ps);
-  add_field<Computed>("micro_vap_liq_exchange", scalar3d_layout_mid, Q, grid_name, ps);
-  add_field<Computed>("micro_vap_ice_exchange", scalar3d_layout_mid, Q, grid_name, ps);
+  add_field<Computed>("micro_liq_ice_exchange", scalar3d_layout_mid, kg/kg,  grid_name, ps);
+  add_field<Computed>("micro_vap_liq_exchange", scalar3d_layout_mid, kg/kg,  grid_name, ps);
+  add_field<Computed>("micro_vap_ice_exchange", scalar3d_layout_mid, kg/kg,  grid_name, ps);
   add_field<Computed>("rainfrac",               scalar3d_layout_mid, nondim, grid_name, ps);
 
   // Boundary flux fields for energy and mass conservation checks

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -42,17 +42,12 @@ RRTMGPRadiation (const ekat::Comm& comm, const ekat::ParameterList& params)
 void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_manager) {
 
   using namespace ekat::units;
+  using namespace ekat::prefixes;
 
   // Declare the set of fields used by rrtmgp
-  auto kgkg = kg/kg;
-  kgkg.set_string("kg/kg");
-  auto m2 = m * m;
-  auto Wm2 = W / m / m;
-  Wm2.set_string("W/m2");
-  auto nondim = m/m;  // dummy unit for non-dimensional fields
-  auto micron = m / 1000000;
-  auto molmol = mol/mol;
-  molmol.set_string("mol/mol");
+  Units m2(m*m,"m2");
+  auto nondim = Units::nondimensional();
+  auto micron = micro*m;
 
   m_grid = grids_manager->get_grid("Physics");
   const auto& grid_name = m_grid->name();
@@ -92,24 +87,24 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Required>("sfc_alb_dir_nir", scalar2d, nondim, grid_name);
   add_field<Required>("sfc_alb_dif_vis", scalar2d, nondim, grid_name);
   add_field<Required>("sfc_alb_dif_nir", scalar2d, nondim, grid_name);
-  add_field<Required>("qc", scalar3d_mid, kgkg, grid_name);
+  add_field<Required>("qc", scalar3d_mid, kg/kg, grid_name);
   add_field<Required>("nc", scalar3d_mid, 1/kg, grid_name);
-  add_field<Required>("qi", scalar3d_mid, kgkg, grid_name);
+  add_field<Required>("qi", scalar3d_mid, kg/kg, grid_name);
   add_field<Required>("cldfrac_tot", scalar3d_mid, nondim, grid_name);
   add_field<Required>("eff_radius_qc", scalar3d_mid, micron, grid_name);
   add_field<Required>("eff_radius_qi", scalar3d_mid, micron, grid_name);
-  add_field<Required>("qv",scalar3d_mid,kgkg,grid_name);
+  add_field<Required>("qv",scalar3d_mid,kg/kg,grid_name);
   add_field<Required>("surf_lw_flux_up",scalar2d,W/(m*m),grid_name);
   // Set of required gas concentration fields
   for (auto& it : m_gas_names) {
     // Add gas VOLUME mixing ratios (moles of gas / moles of air; what actually gets input to RRTMGP)
     if (it == "o3") {
       // o3 is read from file, or computed by chemistry
-      add_field<Required>(it + "_volume_mix_ratio", scalar3d_mid, molmol, grid_name);
+      add_field<Required>(it + "_volume_mix_ratio", scalar3d_mid, mol/mol, grid_name);
     } else {
       // the rest are computed by RRTMGP from prescribed surface values
       // NOTE: this may change at some point
-      add_field<Computed>(it + "_volume_mix_ratio", scalar3d_mid, molmol, grid_name);
+      add_field<Computed>(it + "_volume_mix_ratio", scalar3d_mid, mol/mol, grid_name);
     }
   }
   // Required aerosol optical properties from SPA
@@ -127,26 +122,26 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
 
   // Set computed (output) fields
   add_field<Updated >("T_mid"     , scalar3d_mid, K  , grid_name);
-  add_field<Computed>("SW_flux_dn", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("SW_flux_up", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("SW_flux_dn_dir", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("LW_flux_up", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("LW_flux_dn", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnclrsky_flux_dn", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnclrsky_flux_up", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnclrsky_flux_dn_dir", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("SW_clrsky_flux_dn", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("SW_clrsky_flux_up", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("SW_clrsky_flux_dn_dir", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnsky_flux_dn", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnsky_flux_up", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("SW_clnsky_flux_dn_dir", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("LW_clnclrsky_flux_up", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("LW_clnclrsky_flux_dn", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("LW_clrsky_flux_up", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("LW_clrsky_flux_dn", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("LW_clnsky_flux_up", scalar3d_int, Wm2, grid_name);
-  add_field<Computed>("LW_clnsky_flux_dn", scalar3d_int, Wm2, grid_name);
+  add_field<Computed>("SW_flux_dn", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("SW_flux_up", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("SW_flux_dn_dir", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("LW_flux_up", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("LW_flux_dn", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("SW_clnclrsky_flux_dn", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("SW_clnclrsky_flux_up", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("SW_clnclrsky_flux_dn_dir", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("SW_clrsky_flux_dn", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("SW_clrsky_flux_up", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("SW_clrsky_flux_dn_dir", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("SW_clnsky_flux_dn", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("SW_clnsky_flux_up", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("SW_clnsky_flux_dn_dir", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("LW_clnclrsky_flux_up", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("LW_clnclrsky_flux_dn", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("LW_clrsky_flux_up", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("LW_clrsky_flux_dn", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("LW_clnsky_flux_up", scalar3d_int, W/m2, grid_name);
+  add_field<Computed>("LW_clnsky_flux_dn", scalar3d_int, W/m2, grid_name);
   add_field<Computed>("rad_heating_pdel", scalar3d_mid, Pa*K/s, grid_name);
   // Cloud properties added as computed fields for diagnostic purposes
   add_field<Computed>("cldlow"        , scalar2d, nondim, grid_name);
@@ -179,12 +174,12 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
   // netsw      sfc_flux_sw_net    net (down - up) SW flux at surface
   // flwds      sfc_flux_lw_dn     downwelling LW flux at surface
   // --------------------------------------------------------------
-  add_field<Computed>("sfc_flux_dir_nir", scalar2d, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_dir_vis", scalar2d, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_dif_nir", scalar2d, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_dif_vis", scalar2d, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_sw_net" , scalar2d, Wm2, grid_name);
-  add_field<Computed>("sfc_flux_lw_dn"  , scalar2d, Wm2, grid_name);
+  add_field<Computed>("sfc_flux_dir_nir", scalar2d, W/m2, grid_name);
+  add_field<Computed>("sfc_flux_dir_vis", scalar2d, W/m2, grid_name);
+  add_field<Computed>("sfc_flux_dif_nir", scalar2d, W/m2, grid_name);
+  add_field<Computed>("sfc_flux_dif_vis", scalar2d, W/m2, grid_name);
+  add_field<Computed>("sfc_flux_sw_net" , scalar2d, W/m2, grid_name);
+  add_field<Computed>("sfc_flux_lw_dn"  , scalar2d, W/m2, grid_name);
 
   // Boundary flux fields for energy and mass conservation checks
   if (has_column_conservation_check()) {

--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -26,10 +26,6 @@ void SPA::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  // The units of mixing ratio Q are technically non-dimensional.
-  // Nevertheless, for output reasons, we like to see 'kg/kg'.
-  auto Q = kg/kg;
-  Q.set_string("kg/kg");
   auto nondim = Units::nondimensional();
 
   m_grid = grids_manager->get_grid("Physics");

--- a/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
+++ b/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
@@ -26,10 +26,8 @@ void TurbulentMountainStress::set_grids(const std::shared_ptr<const GridsManager
   // Define some useful units. The units of mixing ratio
   // Q are technically non-dimensional. Nevertheless,
   // for output reasons, we like to see 'kg/kg'.
-  auto Qunit = kg/kg;
-  Qunit.set_string("kg/kg");
   const auto nondim = Units::nondimensional();
-  const auto m2 = m*m;
+  const auto m2 = pow(m,2);
 
   // Initialize grid from grids manager
   m_grid = grids_manager->get_grid("Physics");
@@ -52,12 +50,12 @@ void TurbulentMountainStress::set_grids(const std::shared_ptr<const GridsManager
   add_field<Required>("T_mid",          scalar3d_mid, K,      grid_name,            ps);
   add_field<Required>("p_mid",          scalar3d_mid, Pa,     grid_name,            ps);
   add_field<Required>("pseudo_density", scalar3d_mid, Pa,     grid_name,            ps);
-  add_field<Required>("qv",             scalar3d_mid, Qunit,  grid_name, "tracers", ps);
+  add_field<Required>("qv",             scalar3d_mid, kg/kg,  grid_name, "tracers", ps);
   add_field<Required>("sgh30",          scalar2d    , m,      grid_name);
   add_field<Required>("landfrac",       scalar2d    , nondim, grid_name);
 
-  add_field<Computed>("surf_drag_coeff_tms", scalar2d, kg/s/m2, grid_name);
-  add_field<Computed>("wind_stress_tms",     vector2d, N/m2,    grid_name);
+  add_field<Computed>("surf_drag_coeff_tms", scalar2d, kg/(m2*s), grid_name);
+  add_field<Computed>("wind_stress_tms",     vector2d, N/m2,      grid_name);
 }
 
 // =========================================================================================

--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
@@ -29,12 +29,7 @@ ZMDeepConvection::ZMDeepConvection (const ekat::Comm& comm,const ekat::Parameter
 void ZMDeepConvection::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace std;
-  using namespace ekat;
-  using namespace units;
-
-  auto Q = kg/kg;
-  auto nondim = m/m;
-  Q.set_string("kg/kg");
+  using namespace ekat::units;
 
   constexpr int NVL = 72;  /* TODO THIS NEEDS TO BE CHANGED TO A CONFIGURABLE */
   constexpr int QSZ =  35;  /* TODO THIS NEEDS TO BE CHANGED TO A CONFIGURABLE */
@@ -57,9 +52,9 @@ void ZMDeepConvection::set_grids(const std::shared_ptr<const GridsManager> grids
   set_grid_opts(opt_map);
 
   for ( auto i = opt_map.begin(); i != opt_map.end(); ++i) {
-    add_required_field((i->second).name, layout_opts[((i->second).field_idx)], Q, grid->name());
+    add_required_field((i->second).name, layout_opts[((i->second).field_idx)], kg/kg, grid->name());
     if ( (i->second).isOut == true ) {
-      add_computed_field((i->second).name, layout_opts[((i->second).field_idx)], Q, grid->name());
+      add_computed_field((i->second).name, layout_opts[((i->second).field_idx)], kg/kg, grid->name());
     }
   }
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process_dag.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_dag.cpp
@@ -146,7 +146,7 @@ void AtmProcDAG::write_dag (const std::string& fname, const int verbosity) const
       s.back() = ')';
 
       if (verbosity>2) {
-        s += " [" + fid.get_units().get_string() + "]";
+        s += " [" + fid.get_units().to_string() + "]";
       }
     }
     return s;

--- a/components/eamxx/src/share/field/field_identifier.cpp
+++ b/components/eamxx/src/share/field/field_identifier.cpp
@@ -48,7 +48,7 @@ void FieldIdentifier::update_identifier () {
   m_identifier += ">";
   m_identifier += "(" + ekat::join(m_layout.dims(),",") + ")";
 
-  m_identifier += " [" + m_units.get_string() + "]";
+  m_identifier += " [" + m_units.to_string() + "]";
 }
 
 // Free functions for identifiers comparison

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -46,8 +46,8 @@ void FieldManager::register_field (const FieldRequest& req)
       const auto id0 = m_fields[id.name()]->get_header().get_identifier();
       EKAT_REQUIRE_MSG(id.get_units()==id0.get_units(),
           "Error! Field '" + id.name() + "' already registered with different units:\n"
-          "         - input field units:  " + to_string(id.get_units()) + "\n"
-          "         - stored field units: " + to_string(id0.get_units()) + "\n"
+          "         - input field units:  " + id.get_units().to_string() + "\n"
+          "         - stored field units: " + id0.get_units().to_string() + "\n"
           "       Please, check and make sure all atmosphere processes use the same units.\n");
 
       EKAT_REQUIRE_MSG(id.get_layout()==id0.get_layout(),

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
@@ -230,14 +230,15 @@ load_vertical_coordinates (const nonconstgrid_ptr_type& grid, const std::string&
   using geo_view_host = AtmosphereInput::view_1d_host;
 
   using namespace ShortFieldTagsNames;
-  FieldLayout layout_mid ({LEV},{grid->get_num_vertical_levels()});
-  const auto units = ekat::units::Units::nondimensional();
-  auto lev_unit = ekat::units::Units::nondimensional();;
-  lev_unit.set_string("mb");
+  using namespace ekat::units;
 
-  auto hyam = grid->create_geometry_data("hyam", layout_mid, units);
-  auto hybm = grid->create_geometry_data("hybm", layout_mid, units);
-  auto lev  = grid->create_geometry_data("lev",  layout_mid, lev_unit);
+  FieldLayout layout_mid ({LEV},{grid->get_num_vertical_levels()});
+  Units nondim = Units::nondimensional();
+  Units mbar (100*Pa,"mb");
+
+  auto hyam = grid->create_geometry_data("hyam", layout_mid, nondim);
+  auto hybm = grid->create_geometry_data("hybm", layout_mid, nondim);
+  auto lev  = grid->create_geometry_data("lev",  layout_mid, mbar);
 
   // Create host mirrors for reading in data
   std::map<std::string,geo_view_host> host_views = {

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -953,7 +953,7 @@ register_variables(const std::string& filename,
     // in the simulation and not the one used in the output file.
     const auto& layout = fid.get_layout();
     auto vec_of_dims   = set_vec_of_dims(layout);
-    std::string units = fid.get_units().get_string();
+    std::string units = fid.get_units().to_string();
 
     // Gather longname
     auto longname = m_longnames.get_longname(name);


### PR DESCRIPTION
Update the ekat submodule to the commit just before the one that updates to kokkos 4.2. This takes care of some pervasive changes related to ekat's Units, so that we don't need those changes when we do the upstream merge.

The main change is that `Units` no longer offers `set_string`. The good news is that any arithmetic expression, such as `kg/kg` will correspond verbatim to the stored string (possibly with parentheses, for legibility). If one still wants a peculiar string (suche as "m2" for squared meters), they can pass it _at consturction time_, like `Units m2 (m*m,"m2");`. That string will then be used in downstream expressions, so that `auto Wm2 = W/m2;` will automatically display as "W/m2".

This takes away the need of the almost ubiquitous snippet
```
auto Q = kg/kg;
Q.set_string("kg/kg");
```
and we can simply just use `kg/kg` directly.

Note: we can still get a string in the fundamental SI units:
```
auto Wm2 = W/m2;
std::cout << Wm2.to_string() << "\n"; // prints "W/m2"
std::cout << Wm2.get_si_string() << "\n"; // prints something like kg^a m^b s^c
```