### PR TITLE
EAMxx: enable kokkos bounds checks in full_debug standalone build

### DIFF
--- a/components/eamxx/scripts/test_factory.py
+++ b/components/eamxx/scripts/test_factory.py
@@ -81,15 +81,13 @@ class TestProperty(object):
 class DBG(TestProperty):
 ###############################################################################
 
-    CMAKE_ARGS = [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_DEFAULT_BFB", "True"),
-                  ("Kokkos_ENABLE_DEBUG_BOUNDS_CHECK", "True")]
-
     def __init__(self, _):
         TestProperty.__init__(
             self,
             "full_debug",
             "debug",
-            self.CMAKE_ARGS,
+            [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_DEFAULT_BFB", "True"),
+             ("Kokkos_ENABLE_DEBUG_BOUNDS_CHECK", "True")]
         )
 
 ###############################################################################
@@ -101,7 +99,8 @@ class SP(TestProperty):
             self,
             "full_sp_debug",
             "debug single precision",
-            DBG.CMAKE_ARGS + [("SCREAM_DOUBLE_PRECISION", "False")],
+            [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_DEFAULT_BFB", "True"),
+             ("SCREAM_DOUBLE_PRECISION", "False")],
         )
 
 ###############################################################################
@@ -113,7 +112,8 @@ class FPE(TestProperty):
             self,
             "debug_nopack_fpe",
             "debug pksize=1 floating point exceptions on",
-            DBG.CMAKE_ARGS + [("SCREAM_PACK_SIZE", "1"), ("SCREAM_FPE","True")],
+            [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_DEFAULT_BFB", "True"),
+             ("SCREAM_PACK_SIZE", "1"), ("SCREAM_FPE","True")],
             uses_baselines=False,
             on_by_default=(tas is not None and not tas.on_cuda())
         )

--- a/components/eamxx/scripts/test_factory.py
+++ b/components/eamxx/scripts/test_factory.py
@@ -81,7 +81,8 @@ class TestProperty(object):
 class DBG(TestProperty):
 ###############################################################################
 
-    CMAKE_ARGS = [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_DEFAULT_BFB", "True")]
+    CMAKE_ARGS = [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_DEFAULT_BFB", "True"),
+                  ("Kokkos_ENABLE_DEBUG_BOUNDS_CHECK", "True")]
 
     def __init__(self, _):
         TestProperty.__init__(

--- a/components/eamxx/src/diagnostics/tests/aerocom_cld_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/aerocom_cld_test.cpp
@@ -233,8 +233,8 @@ TEST_CASE("aerocom_cld") {
 
     // Case 5a: test independence of ice and liq fractions
     cd_v(0, 3) = 1.0;
-    cd_v(0, 8) = 1.0;
-    cd_v(0, 9) = 0.2;
+    cd_v(0, 7) = 1.0;
+    cd_v(0, 8) = 0.2;
     qc.deep_copy(1.0);
     qi.deep_copy(0.0);  // zero ice!
     cd.sync_to_dev();

--- a/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
+++ b/components/eamxx/src/physics/nudging/tests/nudging_tests.cpp
@@ -169,6 +169,9 @@ TEST_CASE("nudging_tests") {
       auto fine_h = fine.get_view<Real**,Host>();
       auto data_h = data.get_view<Real**,Host>();
       const bool is_pmid = data.name()=="p_mid";
+      const int nlevs_fine = 2*nlevs_data-1;
+      const int top = 0;
+      const int bot = nlevs_fine-1;
       for (int icol=0; icol<ncols_data; ++icol) {
         // Even entries match original data
         for (int ilev=0; ilev<nlevs_data; ++ilev) {
@@ -179,8 +182,6 @@ TEST_CASE("nudging_tests") {
           fine_h(icol,2*ilev+1) = (fine_h(icol,2*ilev)+fine_h(icol,2*ilev+2))/2;
         }
         if (not in_bounds) {
-          const int top = 0;
-          const int bot = 2*nlevs_data - 1;
           fine_h(icol,top) *= 0.5;
           fine_h(icol,bot) *= is_pmid ? 2 : 1;
         }


### PR DESCRIPTION
Fixes #2828 