### PR TITLE
Fix and cleanup vertical layer diagnostic

### DIFF
--- a/components/eamxx/src/diagnostics/field_at_height.cpp
+++ b/components/eamxx/src/diagnostics/field_at_height.cpp
@@ -44,7 +44,7 @@ FieldAtHeight (const ekat::Comm& comm, const ekat::ParameterList& params)
       " -        field name: " + m_field_name + "\n"
       " - surface reference: " + surf_ref + "\n"
       " -     valid options: sealevel, surface\n");
-  m_z_name = (surf_ref == "sealevel") ? "z" : "geopotential";
+  m_z_name = (surf_ref == "sealevel") ? "z" : "altitude";
   const auto& location = m_params.get<std::string>("vertical_location");
   auto chars_start = location.find_first_not_of("0123456789.");
   EKAT_REQUIRE_MSG (chars_start!=0 && chars_start!=std::string::npos,

--- a/components/eamxx/src/diagnostics/field_at_height.cpp
+++ b/components/eamxx/src/diagnostics/field_at_height.cpp
@@ -44,7 +44,7 @@ FieldAtHeight (const ekat::Comm& comm, const ekat::ParameterList& params)
       " -        field name: " + m_field_name + "\n"
       " - surface reference: " + surf_ref + "\n"
       " -     valid options: sealevel, surface\n");
-  m_z_name = (surf_ref == "sealevel") ? "z" : "altitude";
+  m_z_name = (surf_ref == "sealevel") ? "z" : "height";
   const auto& location = m_params.get<std::string>("vertical_location");
   auto chars_start = location.find_first_not_of("0123456789.");
   EKAT_REQUIRE_MSG (chars_start!=0 && chars_start!=std::string::npos,

--- a/components/eamxx/src/diagnostics/register_diagnostics.hpp
+++ b/components/eamxx/src/diagnostics/register_diagnostics.hpp
@@ -36,9 +36,11 @@ inline void register_diagnostics () {
   diag_factory.register_product("Exner",&create_atmosphere_diagnostic<ExnerDiagnostic>);
   diag_factory.register_product("VirtualTemperature",&create_atmosphere_diagnostic<VirtualTemperatureDiagnostic>);
   diag_factory.register_product("z_int",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
-  diag_factory.register_product("geopotential_int",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
   diag_factory.register_product("z_mid",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
+  diag_factory.register_product("geopotential_int",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
   diag_factory.register_product("geopotential_mid",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
+  diag_factory.register_product("height_int",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
+  diag_factory.register_product("height_mid",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
   diag_factory.register_product("dz",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
   diag_factory.register_product("DryStaticEnergy",&create_atmosphere_diagnostic<DryStaticEnergyDiagnostic>);
   diag_factory.register_product("SeaLevelPressure",&create_atmosphere_diagnostic<SeaLevelPressureDiagnostic>);

--- a/components/eamxx/src/diagnostics/tests/field_at_height_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_height_tests.cpp
@@ -46,8 +46,8 @@ TEST_CASE("field_at_height")
   FieldIdentifier z_surf_fid ("z_surf",          FieldLayout({COL         },{ncols              }),m,grid->name());
   FieldIdentifier z_mid_fid   ("z_mid",           FieldLayout({COL,     LEV},{ncols,      nlevs  }),m,grid->name());
   FieldIdentifier z_int_fid   ("z_int",           FieldLayout({COL,    ILEV},{ncols,      nlevs+1}),m,grid->name());
-  FieldIdentifier geo_mid_fid ("geopotential_mid",FieldLayout({COL,     LEV},{ncols,      nlevs  }),m,grid->name());
-  FieldIdentifier geo_int_fid ("geopotential_int",FieldLayout({COL,    ILEV},{ncols,      nlevs+1}),m,grid->name());
+  FieldIdentifier h_mid_fid ("height_mid",FieldLayout({COL,     LEV},{ncols,      nlevs  }),m,grid->name());
+  FieldIdentifier h_int_fid ("height_int",FieldLayout({COL,    ILEV},{ncols,      nlevs+1}),m,grid->name());
   // Keep track of reference fields for comparison
   FieldIdentifier s_tgt_fid ("scalar_target",FieldLayout({COL    },{ncols      }),m,grid->name());
   FieldIdentifier v_tgt_fid ("vector_target",FieldLayout({COL,CMP},{ncols,ndims}),m,grid->name());
@@ -59,8 +59,8 @@ TEST_CASE("field_at_height")
   Field z_surf  (z_surf_fid);
   Field z_mid   (z_mid_fid);
   Field z_int   (z_int_fid);
-  Field geo_mid (geo_mid_fid);
-  Field geo_int (geo_int_fid);
+  Field h_mid (h_mid_fid);
+  Field h_int (h_int_fid);
   Field s_tgt   (s_tgt_fid);
   Field v_tgt   (v_tgt_fid);
 
@@ -71,8 +71,8 @@ TEST_CASE("field_at_height")
   z_surf.allocate_view();
   z_mid.allocate_view();
   z_int.allocate_view();
-  geo_mid.allocate_view();
-  geo_int.allocate_view();
+  h_mid.allocate_view();
+  h_int.allocate_view();
   s_tgt.allocate_view();
   v_tgt.allocate_view();
 
@@ -83,8 +83,8 @@ TEST_CASE("field_at_height")
   z_surf.get_header().get_tracking().update_time_stamp(t0);
   z_mid.get_header().get_tracking().update_time_stamp(t0);
   z_int.get_header().get_tracking().update_time_stamp(t0);
-  geo_mid.get_header().get_tracking().update_time_stamp(t0);
-  geo_int.get_header().get_tracking().update_time_stamp(t0);
+  h_mid.get_header().get_tracking().update_time_stamp(t0);
+  h_int.get_header().get_tracking().update_time_stamp(t0);
   s_tgt.get_header().get_tracking().update_time_stamp(t0);
   v_tgt.get_header().get_tracking().update_time_stamp(t0);
 
@@ -124,9 +124,9 @@ TEST_CASE("field_at_height")
 
   // Set up vertical structure for the tests.  Note,
   //   z_mid/int represents the height in m above sealevel
-  //   geo_mid/int represente the hegith in m above the surface
+  //   h_mid/int represente the hegith in m above the surface
   // So we first construct z_mid/int using z_surf as reference, and
-  // then can build geo_mid/int from z_mid/int
+  // then can build h_mid/int from z_mid/int
   // Furthermore, z_mid is just the midpoint between two adjacent z_int
   // points, so we back z_mid out of z_int.
   //
@@ -137,8 +137,8 @@ TEST_CASE("field_at_height")
   const auto& zint_v   = z_int.get_view<Real**,Host>();
   const auto& zmid_v   = z_mid.get_view<Real**,Host>();
   const auto& zsurf_v  = z_surf.get_view<Real*,Host>();
-  const auto& geoint_v = geo_int.get_view<Real**,Host>();
-  const auto& geomid_v = geo_mid.get_view<Real**,Host>();
+  const auto& geoint_v = h_int.get_view<Real**,Host>();
+  const auto& geomid_v = h_mid.get_view<Real**,Host>();
   int         min_col_thickness = z_top;
   int         max_surf = 0;
   for (int ii=0; ii<ncols; ++ii) {
@@ -159,21 +159,21 @@ TEST_CASE("field_at_height")
   z_mid.sync_to_dev();
   z_int.sync_to_dev();
   z_surf.sync_to_dev();
-  geo_int.sync_to_dev();
-  geo_mid.sync_to_dev();
+  h_int.sync_to_dev();
+  h_mid.sync_to_dev();
   // Set the PDF for target height in the test to always be within the shortest column.
   // This ensures that we don't havea target z that extrapolates everywhere.
   // We test this case individually.
   IPDF pdf_levs (max_surf,min_col_thickness);
   // Sanity check that the geo and z vertical structures are in fact different,
   // so we know we are testing above_surface and above_sealevel as different cases.
-  REQUIRE(! views_are_equal(z_int,geo_int));
-  REQUIRE(! views_are_equal(z_mid,geo_mid));
+  REQUIRE(! views_are_equal(z_int,h_int));
+  REQUIRE(! views_are_equal(z_mid,h_mid));
 
   // Make sure that an unsupported reference height throws an error.
   print(" -> Testing throws error with unsupported reference height...\n");
   {
-    REQUIRE_THROWS(run_diag (s_mid,geo_mid,"1m","foobar"));
+    REQUIRE_THROWS(run_diag (s_mid,h_mid,"1m","foobar"));
   }
   print(" -> Testing throws error with unsupported reference height... OK\n");
 
@@ -182,8 +182,8 @@ TEST_CASE("field_at_height")
   std::string loc;
   for (std::string surf_ref : {"sealevel","surface"}) {
     printf(" -> Testing for a reference height above %s...\n",surf_ref.c_str());
-    const auto mid_src = surf_ref == "sealevel" ? z_mid : geo_mid;
-    const auto int_src = surf_ref == "sealevel" ? z_int : geo_int;
+    const auto mid_src = surf_ref == "sealevel" ? z_mid : h_mid;
+    const auto int_src = surf_ref == "sealevel" ? z_int : h_int;
     const int  max_surf_4test = surf_ref == "sealevel" ? max_surf : 0;
     for (int irun=0; irun<nruns; ++irun) {
 
@@ -238,23 +238,23 @@ TEST_CASE("field_at_height")
       }
     }
     {
-      print("    -> Forced extrapolation ...............\n");
+      print("    -> Forced extrapolation at top...............\n");
       auto slope = pdf_m(engine); 
       auto inter = pdf_y0(engine);
       f_z_src(inter, slope, int_src, s_int);
-      print("    ->                      at top...............\n");
       z_tgt = 2*z_top;
       std::string loc = std::to_string(z_tgt) + "m";
       auto dtop = run_diag(s_int,int_src,loc,surf_ref);
       f_z_tgt(inter,slope,z_tgt,int_src,s_tgt);
       REQUIRE (views_are_approx_equal(dtop,s_tgt,tol));
-      print("    ->                      at bot...............\n");
+      print("    -> Forced extrapolation at top............... OK!\n");
+      print("    -> Forced extrapolation at bot...............\n");
       z_tgt = 0;
       loc = std::to_string(z_tgt) + "m";
       auto dbot = run_diag(s_int,int_src,loc,surf_ref);
       f_z_tgt(inter,slope,z_tgt,int_src,s_tgt);
       REQUIRE (views_are_approx_equal(dbot,s_tgt,tol));
-      print("    -> Forced extrapolation............... OK!\n");
+      print("    -> Forced extrapolation at bot............... OK!\n");
     }
     printf(" -> Testing for a reference height above %s... OK!\n",surf_ref.c_str());
   }

--- a/components/eamxx/src/diagnostics/tests/vertical_layer_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/vertical_layer_tests.cpp
@@ -106,13 +106,13 @@ void run (const std::string& diag_name, const std::string& location)
   diag_out.sync_to_host();
   auto d_h = diag_out.get_view<Real**,Host>();
 
-  // Compare against expecte value
+  // Compare against expected value
   const auto last_int = num_levs;
   const auto last_mid = last_int-1;
 
   // Precompute surface value and increment depending on the diag type
   Real delta, surf_val;
-  if (diag_name=="altitude") {
+  if (diag_name=="height") {
     surf_val = 0;
     delta = dz_val;
   } else if (diag_name=="z") {
@@ -169,7 +169,7 @@ TEST_CASE("vertical_layer_test", "vertical_layer_test]"){
     root_print("\n");
     root_print(" -> Testing diagnostic for pack_size=" + std::to_string(N) + "\n");
     for (std::string loc : {"midpoints","interfaces"}) {
-      for (std::string diag : {"geopotential","altitude","z"}) {
+      for (std::string diag : {"geopotential","height","z"}) {
         std::string msg = "    -> Testing diag=" + diag + " at " + loc + " ";
         std::string dots (50-msg.size(),'.');
         root_print (msg + dots + "\n");

--- a/components/eamxx/src/diagnostics/tests/vertical_layer_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/vertical_layer_tests.cpp
@@ -1,20 +1,8 @@
 #include "catch2/catch.hpp"
 
-#include "share/grid/mesh_free_grids_manager.hpp"
-#include "diagnostics/vertical_layer.hpp"
 #include "diagnostics/register_diagnostics.hpp"
-
 #include "physics/share/physics_constants.hpp"
-
-#include "share/util/scream_setup_random_test.hpp"
-#include "share/util/scream_common_physics_functions.hpp"
-#include "share/field/field_utils.hpp"
-
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
-
-#include <iomanip>
+#include "share/grid/mesh_free_grids_manager.hpp"
 
 namespace scream {
 
@@ -39,24 +27,13 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
 }
 
 //-----------------------------------------------------------------------------------------------//
-template<typename DeviceT, typename Engine>
-void run(      Engine& engine,
-               std::string  diag_name,
-         const std::string& location)
+template<typename DeviceT, int N>
+void run (const std::string& diag_name, const std::string& location)
 {
-  using PC         = scream::physics::Constants<Real>;
-  using Pack       = ekat::Pack<Real,SCREAM_PACK_SIZE>;
-  using KT         = ekat::KokkosTypes<DeviceT>;
-  using ExecSpace  = typename KT::ExeSpace;
-  using MemberType = typename KT::MemberType;
-  using view_1d    = typename KT::template view_1d<Pack>;
-  using rview_1d   = typename KT::template view_1d<Real>;
-  using view_2d    = typename KT::template view_2d<Pack>;
+  using PC = scream::physics::Constants<Real>;
 
-  const     int packsize = SCREAM_PACK_SIZE;
+  const     int packsize = N;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
-  const     int num_mid_packs    = ekat::npack<Pack>(num_levs);
-  const     int num_mid_packs_p1 = ekat::npack<Pack>(num_levs+1);
 
   // A world comm
   ekat::Comm comm(MPI_COMM_WORLD);
@@ -68,31 +45,19 @@ void run(      Engine& engine,
   // A time stamp
   util::TimeStamp t0 ({2022,1,1},{0,0,0});
 
-  // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_mid_packs);
-
-  // Input (randomized) views
-  view_1d temperature("temperature",num_mid_packs),
-          pseudodensity("pseudo_density",num_mid_packs),
-          pressure("pressure",num_mid_packs),
-          watervapor("watervapor",num_mid_packs);
-
-  auto dview_as_real = [&] (const view_1d& v) -> rview_1d {
-    return rview_1d(reinterpret_cast<Real*>(v.data()),v.size()*packsize);
-  };
-
   register_diagnostics();
   auto& diag_factory = AtmosphereDiagnosticFactory::instance();
   
   // Construct the Diagnostic
   ekat::ParameterList params;
+  std::string name = diag_name;
   if (location=="midpoints") {
-    diag_name += "_mid";
+    name += "_mid";
   } else if (location=="interfaces") {
-    diag_name += "_int";
+    name += "_int";
   }
-  params.set<std::string>("diag_name", diag_name);
-  auto diag = diag_factory.create(diag_name,comm,params);
+  params.set<std::string>("diag_name", name);
+  auto diag = diag_factory.create(name,comm,params);
   diag->set_grids(gm);
 
   const bool needs_phis = diag_name=="z" or diag_name=="geopotential";
@@ -107,21 +72,31 @@ void run(      Engine& engine,
     const auto name = f.name();
     f.get_header().get_tracking().update_time_stamp(t0);
     diag->set_required_field(f.get_const());
-    REQUIRE_THROWS(diag->set_computed_field(f));
     input_fields.emplace(name,f);
   }
+
+  // Can't set computed fields in the diag
+  REQUIRE_THROWS(diag->set_computed_field(input_fields.begin()->second));
 
   // Note: we are not testing the calculate_dz utility. We are testing
   //       the diag class, so use some inputs that make checking results easier
   //       With these inputs, T_virt=T, and dz=8*rd/g
-  const Real dz = PC::RD/PC::gravit;
-  const Real phis = 3;
-  input_fields["T_mid"].deep_copy(Real(4));
-  input_fields["p_mid"].deep_copy(Real(2));
-  input_fields["pseudo_density"].deep_copy(Real(4));
-  input_fields["qv"].deep_copy(Real(0));
+  const Real g = PC::gravit;
+  const Real rho_val = 4;
+  const Real qv_val = 0;
+  const Real p_val = 2;
+  const Real T_val = 4;
+  const Real c1 = -PC::ONE + PC::ONE / PC::ep_2;
+  const Real Tvirt_val = T_val*(PC::ONE + c1*qv_val);
+  const Real dz_val = (PC::RD/g) * rho_val*Tvirt_val / p_val;
+  const Real phis_val = 3;
+
+  input_fields["T_mid"].deep_copy(T_val);
+  input_fields["p_mid"].deep_copy(p_val);
+  input_fields["pseudo_density"].deep_copy(rho_val);
+  input_fields["qv"].deep_copy(qv_val);
   if (needs_phis) {
-    input_fields["phis"].deep_copy(phis);
+    input_fields["phis"].deep_copy(phis_val);
   }
 
   // Initialize and run the diagnostic
@@ -132,28 +107,43 @@ void run(      Engine& engine,
   auto d_h = diag_out.get_view<Real**,Host>();
 
   // Compare against expecte value
-  const auto last_lev = location=="interfaces" ? num_levs : num_levs-1;
-  for (int icol=0; icol<ncols; ++icol) {
-    for (int ilev=last_lev; ilev>=0; --ilev) {
-      int num_mid_levs_below = ilev-last_lev;
-      Real tgt_mid, tgt_int;
-      if (diag_name=="dz") {
-        tgt_mid = dz;
-      } else if (diag_name=="altitude") {
-        tgt_int = phis/PC::gravit + num_mid_levs_below*dz;
-        tgt_mid = tgt_int + dz/2;
-      } else if (diag_name=="geopotential") {
-        tgt_int = phis + num_mid_levs_below*dz*PC::gravit;
-        tgt_mid = tgt_int + PC::gravit*dz/2;
-      } else {
-        tgt_int = num_mid_levs_below*dz;
-        tgt_mid = tgt_int + dz/2;
-      }
+  const auto last_int = num_levs;
+  const auto last_mid = last_int-1;
 
-      if (location=="interfaces") {
-        REQUIRE (d_h(icol,ilev)==tgt_int);
+  // Precompute surface value and increment depending on the diag type
+  Real delta, surf_val;
+  if (diag_name=="altitude") {
+    surf_val = 0;
+    delta = dz_val;
+  } else if (diag_name=="z") {
+    surf_val = phis_val/g;
+    delta = dz_val;
+  } else {
+    surf_val = phis_val;
+    delta = dz_val*g;
+  }
+
+  for (int icol=0; icol<ncols; ++icol) {
+    Real prev_int_val = surf_val;
+
+    if (location=="interfaces") {
+      // Check surface value
+      REQUIRE (d_h(icol,num_levs)==prev_int_val);
+    }
+
+    for (int ilev=last_mid; ilev>=0; --ilev) {
+      if (diag_name=="dz") {
+        REQUIRE (d_h(icol,ilev)==dz_val);
       } else {
-        REQUIRE (d_h(icol,ilev)==tgt_mid);
+        // If interface, check value, otherwise perform int->mid averaging and check value
+        auto int_val = prev_int_val + delta;
+        if (location=="interfaces") {
+          REQUIRE_THAT(d_h(icol,ilev), Catch::Matchers::WithinRel(int_val,1e-5));
+        } else {
+          auto mid_val = (int_val + prev_int_val) / 2;
+          REQUIRE_THAT(d_h(icol,ilev), Catch::Matchers::WithinRel(mid_val,1e-5));
+        }
+        prev_int_val = int_val;
       }
     }
   }
@@ -168,26 +158,36 @@ TEST_CASE("vertical_layer_test", "vertical_layer_test]"){
   using scream::Real;
   using Device = scream::DefaultDevice;
 
-  constexpr int num_runs = 5;
-
-  auto engine = scream::setup_random_test();
-
-  printf("Test specs\n");
-  printf(" - number of randomized runs: %d\n",num_runs);
-  printf(" - scalar type: Pack<Real,%d>\n\n", SCREAM_PACK_SIZE);
-
-  for (int irun=0; irun<num_runs; ++irun) {
+  ekat::Comm comm(MPI_COMM_WORLD);
+  auto root_print = [&](const std::string& msg) {
+    if (comm.am_i_root()) {
+      printf("%s",msg.c_str());
+    }
+  };
+  auto do_run = [&] (auto int_const) {
+    constexpr int N = decltype(int_const)::value;
+    root_print("\n");
+    root_print(" -> Testing diagnostic for pack_size=" + std::to_string(N) + "\n");
     for (std::string loc : {"midpoints","interfaces"}) {
       for (std::string diag : {"geopotential","altitude","z"}) {
-        printf(" -> Testing diag=%s at %s ...\n",diag.c_str(),loc.c_str());
-        run<Device>(engine, loc, diag);
-        printf(" -> Testing diag=%s at %s ... PASS!\n",diag.c_str(),loc.c_str());
+        std::string msg = "    -> Testing diag=" + diag + " at " + loc + " ";
+        std::string dots (50-msg.size(),'.');
+        root_print (msg + dots + "\n");
+        run<Device,N>(diag, loc);
+        root_print (msg + dots + " PASS!\n");
       }
     }
-    printf(" -> Testing diag=dz ...\n");
-    run<Device>(engine, "", "dz");
-    printf(" -> Testing diag=dz ... PASS!\n");
+    std::string msg = "    -> Testing diag=dz ";
+    std::string dots (50-msg.size(),'.');
+    root_print (msg + dots + "\n");
+    run<Device, N>("dz", "UNUSED");
+    root_print (msg + dots + " PASS!\n");
+  };
+
+  if (SCREAM_PACK_SIZE!=1) {
+    do_run(std::integral_constant<int,1>());
   }
+  do_run(std::integral_constant<int,SCREAM_PACK_SIZE>());
 
 } // TEST_CASE
 

--- a/components/eamxx/src/diagnostics/vertical_layer.hpp
+++ b/components/eamxx/src/diagnostics/vertical_layer.hpp
@@ -57,15 +57,14 @@ protected:
   // field in the computation is output (dz, z_int, or z_mid).
   std::string m_diag_name;
 
-  // Store if we only need to compute dz to save computation/memory requirements.
-  bool m_only_compute_dz;
-
   // Store if the diagnostic output field exists on interface values
   bool m_is_interface_layout;
 
-  // If z_int or z_mid is computed, determine whether the BC
-  // is from sea level or not (from topography data).
+  // True z_mid/int, false for altitude_mid/int. Unused for others
   bool m_from_sea_level;
+
+  // If true, output is a geopotential (units m2/s2), otherwise an elevation
+  bool m_geopotential;
 
 }; // class VerticalLayerDiagnostic
 

--- a/components/eamxx/src/diagnostics/vertical_layer.hpp
+++ b/components/eamxx/src/diagnostics/vertical_layer.hpp
@@ -47,14 +47,13 @@ protected:
   Field m_tmp_interface;
   Field m_tmp_midpoint;
 
-  // The diagnostic name. This will dictate which
-  // field in the computation is output (dz, z_int, or z_mid).
+  // The diagnostic name.
   std::string m_diag_name;
 
   // Store if the diagnostic output field exists on interface values
   bool m_is_interface_layout;
 
-  // True z_mid/int, false for altitude_mid/int. Unused for others
+  // True z_mid/int and geopotential_mid/int, false for height_mid/int. Unused for dz
   bool m_from_sea_level;
 
   // If true, output is a geopotential (units m2/s2), otherwise an elevation

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1394,7 +1394,7 @@ AtmosphereOutput::create_diagnostic (const std::string& diag_field_name) {
   // The diagnostics requires the name to be given as param value.
   if (diag_name == "z_int"            or diag_name == "z_mid"            or
       diag_name == "geopotential_int" or diag_name == "geopotential_mid" or
-      diag_name == "altitude_int"     or diag_name == "altitude_mid"     or
+      diag_name == "height_int"       or diag_name == "height_mid"     or
       diag_name == "dz") {
     params.set<std::string>("diag_name", diag_name);
   }

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1315,25 +1315,25 @@ AtmosphereOutput::create_diagnostic (const std::string& diag_field_name) {
       if (units.find("_above_") != std::string::npos) {
         // The field is at a height above a specific reference.
         // Currently we only support FieldAtHeight above "sealevel" or "surface"
-	auto subtokens = ekat::split(units,"_above_");
-	params.set("surface_reference",subtokens[1]);
-	units = subtokens[0];
-	// Need to reset the vertical location to strip the "_above_" part of the string.
-        params.set("vertical_location", tokens[1].substr(0,units_start)+subtokens[0]);
-	// If the slice is "above_sealevel" then we need to track the avg cnt uniquely.
-	// Note, "above_surface" is expected to never have masking and can thus use
-	// the typical 2d layout avg cnt.
-	if (subtokens[1]=="sealevel") {
-          diag_avg_cnt_name = "_" + tokens[1]; // Set avg_cnt tracking for this specific slice
-          // If we have 2D slices we need to be tracking the average count,
-          // if m_avg_type is not Instant
-          m_track_avg_cnt = m_track_avg_cnt || m_avg_type!=OutputAvgType::Instant;
-	}
+        auto subtokens = ekat::split(units,"_above_");
+        params.set("surface_reference",subtokens[1]);
+        units = subtokens[0];
+        // Need to reset the vertical location to strip the "_above_" part of the string.
+              params.set("vertical_location", tokens[1].substr(0,units_start)+subtokens[0]);
+        // If the slice is "above_sealevel" then we need to track the avg cnt uniquely.
+        // Note, "above_surface" is expected to never have masking and can thus use
+        // the typical 2d layout avg cnt.
+        if (subtokens[1]=="sealevel") {
+                diag_avg_cnt_name = "_" + tokens[1]; // Set avg_cnt tracking for this specific slice
+                // If we have 2D slices we need to be tracking the average count,
+                // if m_avg_type is not Instant
+                m_track_avg_cnt = m_track_avg_cnt || m_avg_type!=OutputAvgType::Instant;
+        }
       }
       if (units=="m") {
         diag_name = "FieldAtHeight";
-	EKAT_REQUIRE_MSG(params.isParameter("surface_reference"),"Error! Output field request for " + diag_field_name + " is missing a surface reference."
-			"  Please add either '_above_sealevel' or '_above_surface' to the field name");
+        EKAT_REQUIRE_MSG(params.isParameter("surface_reference"),"Error! Output field request for " + diag_field_name + " is missing a surface reference."
+            "  Please add either '_above_sealevel' or '_above_surface' to the field name");
       } else if (units=="mb" or units=="Pa" or units=="hPa") {
         diag_name = "FieldAtPressureLevel";
         diag_avg_cnt_name = "_" + tokens[1]; // Set avg_cnt tracking for this specific slice
@@ -1390,9 +1390,10 @@ AtmosphereOutput::create_diagnostic (const std::string& diag_field_name) {
   }
 
   // These fields are special case of VerticalLayer diagnostic.
-  // The diagnostics requires the names be given as param value.
-  if (diag_name == "z_int" or diag_name == "geopotential_int" or
-      diag_name == "z_mid" or diag_name == "geopotential_mid" or
+  // The diagnostics requires the name to be given as param value.
+  if (diag_name == "z_int"            or diag_name == "z_mid"            or
+      diag_name == "geopotential_int" or diag_name == "geopotential_mid" or
+      diag_name == "altitude_int"     or diag_name == "altitude_mid"     or
       diag_name == "dz") {
     params.set<std::string>("diag_name", diag_name);
   }
@@ -1401,7 +1402,7 @@ AtmosphereOutput::create_diagnostic (const std::string& diag_field_name) {
   auto diag = diag_factory.create(diag_name,m_comm,params);
   diag->set_grids(m_grids_manager);
 
-  // Add empty entry for this map, so .at(..) always works
+  // Ensure there's an entry in the map for this diag, so .at(diag_name) always works
   auto& deps = m_diag_depends_on_diags[diag->name()];
 
   // Initialize the diagnostic

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -955,9 +955,6 @@ register_variables(const std::string& filename,
     auto vec_of_dims   = set_vec_of_dims(layout);
     std::string units = fid.get_units().to_string();
 
-    // Gather longname
-    auto longname = m_longnames.get_longname(name);
-
     // TODO  Need to change dtype to allow for other variables.
     // Currently the field_manager only stores Real variables so it is not an issue,
     // but in the future if non-Real variables are added we will want to accomodate that.
@@ -990,8 +987,6 @@ register_variables(const std::string& filename,
     } else {
       scorpio::define_var (filename, name, units, vec_of_dims,
                             "real",fp_precision, m_add_time_dim);
-
-      scorpio::set_attribute(filename, name, "long_name", longname);
 
       // Add FillValue as an attribute of each variable
       // FillValue is a protected metadata, do not add it if it already existed
@@ -1032,6 +1027,12 @@ register_variables(const std::string& filename,
       const auto& str_atts = field.get_header().get_extra_data<stratts_t>("io: string attributes");
       for (const auto& [att_name,att_val] : str_atts) {
         scorpio::set_attribute(filename,name,att_name,att_val);
+      }
+
+      // Gather longname (if not already in the io: string attributes)
+      if (str_atts.count("long_name")==0) {
+        auto longname = m_longnames.get_longname(name);
+        scorpio::set_attribute(filename, name, "long_name", longname);
       }
     }
   }

--- a/components/eamxx/src/share/io/scream_io_utils.hpp
+++ b/components/eamxx/src/share/io/scream_io_utils.hpp
@@ -80,9 +80,9 @@ struct LongNames {
   std::map<std::string,std::string> name_2_longname = {
 	  {"lev","hybrid level at midpoints (1000*(A+B))"},
 	  {"hyai","hybrid A coefficient at layer interfaces"},
-          {"hybi","hybrid B coefficient at layer interfaces"},
-          {"hyam","hybrid A coefficient at layer midpoints"},
-          {"hybm","hybrid B coefficient at layer midpoints"}
+    {"hybi","hybrid B coefficient at layer interfaces"},
+    {"hyam","hybrid A coefficient at layer midpoints"},
+    {"hybm","hybrid B coefficient at layer midpoints"}
   };
   
 };

--- a/components/eamxx/tests/single-process/p3/output.yaml
+++ b/components/eamxx/tests/single-process/p3/output.yaml
@@ -4,7 +4,7 @@ filename_prefix: p3_standalone_output
 Averaging Type: Instant
 Field Names:
   - T_mid
-  - T_mid_at_2m_above_sealevel
+  - T_mid_at_2m_above_surface
   - T_prev_micro_step
   - qv
   - qc


### PR DESCRIPTION
A few mods were needed, since there was an inconsistency in the handling of the surface value, as well as on how this diagnostic was used in the FieldAtHeight diagnostic. Summary:

* Fix usage of surface value (the b.c. for the vertical integral)
* Added "height" as a version of "z" but from surface
* Reworked the unit tests, so that they are simpler, and they do not just copy+paste the implementation of the class. In particular, no need to ensure `calculate_dz` works correctly, since it's already tested elsewhere. We just need to test that the diag computes the correct diagnostic type, and has the right behavior w.r.t. level index.


Also, one thing we should do in _all_ the diagnostics: we are not free to request a pack size. By the time diags are created, all fields have been allocated, so the diag does not have a saying in pack size. Instead, the diag should defer the creation of the output field until all inputs are set (i.e.., do it inside `initialize_impl`), and pick as a pack size for the output whatever can work with all its inputs (i.e., the smallest among the pack sizes of the inputs).