### PR TITLE
Allow adding geo fields to grid objects, even if they are const

### DIFF
--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -4,6 +4,7 @@
 #include "physics/rrtmgp/shr_orb_mod_c2f.hpp"
 #include "physics/share/scream_trcmix.hpp"
 
+#include "share/io/scream_scorpio_interface.hpp"
 #include "share/util/eamxx_fv_phys_rrtmgp_active_gases_workaround.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
 #include "share/util/scream_common_physics_functions.hpp"
@@ -189,6 +190,45 @@ void RRTMGPRadiation::set_grids(const std::shared_ptr<const GridsManager> grids_
     add_field<Computed>("water_flux", scalar2d, m/s,     grid_name);
     add_field<Computed>("ice_flux",   scalar2d, m/s,     grid_name);
     add_field<Computed>("heat_flux",  scalar2d, W/m2,    grid_name);
+  }
+
+  // Load bands bounds from coefficients files and compute the band centerpoint.
+  // Store both in the grid (if not already present)
+  const auto cm = centi*m;
+  for (std::string prefix : {"sw", "lw"} ) {
+    int nbands = prefix == "sw" ? m_nswbands : m_nlwbands;
+
+    if (not m_grid->has_geometry_data(prefix + "band_bounds")) {
+      using namespace ShortFieldTagsNames;
+
+      // NOTE: use append, so we get builtin name for (CMP,2) dim, without hard-coding it here
+      FieldLayout layout({CMP},{nbands},{prefix+"band"});
+      layout.append_dim(CMP,2);
+      Field bounds (FieldIdentifier(prefix + "band_bounds", layout, 1/cm, grid_name));
+      bounds.allocate_view();
+
+      std::string fname = m_params.get<std::string>("rrtmgp_coefficients_file_" + prefix);
+      scorpio::register_file(fname,scorpio::FileMode::Read);
+      scorpio::read_var(fname,"bnd_limits_wavenumber",bounds.get_view<Real**,Host>().data());
+      scorpio::release_file(fname);
+
+      bounds.sync_to_dev();
+      m_grid->set_geometry_data(bounds);
+    }
+
+    // If no bounds were in the grid, the bands centerpoint likely wouldn't either. Still, let's check...
+    if (not m_grid->has_geometry_data(prefix + "bands")) {
+      auto bounds = m_grid->get_geometry_data(prefix + "band_bounds");
+      auto bounds_h = bounds.get_view<const Real**,Host>();
+
+      auto bands = bounds.subfield(1,0).clone(prefix + "band");
+      auto bands_h = bands.get_view<Real*,Host>();
+      for (int i=0; i<nbands; ++i) {
+        bands_h(i) = (bounds_h(i,0) + bounds_h(i,1)) / 2;
+      }
+      bands.sync_to_dev();
+      m_grid->set_geometry_data(bands);
+    }
   }
 }  // RRTMGPRadiation::set_grids
 

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -285,6 +285,8 @@ void FieldLayout::compute_type () {
     m_type = LayoutType::Vector0D; return;
   } else if (tags.size()==1 and nvlevs==1) {
     m_type = LayoutType::Scalar1D; return;
+  } else if (tags[0]==CMP and tags[1]==CMP) {
+    m_type = LayoutType::Tensor0D; return;
   } else if (tags.size()==2 and ncomps==1 and nvlevs==1) {
     m_type = LayoutType::Vector1D; return;
   } else {

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -19,6 +19,7 @@ enum class LayoutType {
   Invalid,
   Scalar0D,
   Vector0D,
+  Tensor0D,
   Scalar1D,
   Vector1D,
   Scalar2D,

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -311,7 +311,7 @@ AbstractGrid::delete_geometry_data (const std::string& name)
 }
 
 void
-AbstractGrid::set_geometry_data (const Field& f)
+AbstractGrid::set_geometry_data (const Field& f) const
 {
   EKAT_REQUIRE_MSG (not has_geometry_data(f.name()),
       "Error! Cannot set geometry data, since it already exists.\n"

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -74,6 +74,17 @@ get_vertical_layout (const bool midpoints) const
   return FieldLayout({t},{d}).rename_dims(m_special_tag_names);
 }
 
+FieldLayout AbstractGrid::
+get_vertical_layout (const bool midpoints,
+                     const int vector_dim,
+                     const std::string& vec_dim_name) const
+{
+  using namespace ShortFieldTagsNames;
+  auto l = get_vertical_layout(midpoints);
+  l.append_dim(CMP,vector_dim,vec_dim_name);
+  return l;
+}
+
 FieldLayout
 AbstractGrid::get_2d_vector_layout (const int vector_dim) const
 {
@@ -180,6 +191,7 @@ is_valid_layout (const FieldLayout& layout) const
   switch (layout.type()) {
     case LayoutType::Scalar0D: [[fallthrough]];
     case LayoutType::Vector0D:
+    case LayoutType::Tensor0D:
       // 0d quantities are always ok
       return true;
     case LayoutType::Scalar1D: [[fallthrough]];

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -72,6 +72,9 @@ public:
   // E.g., for a scalar 2d field on a SE grid, this will be (nelem,np,np),
   //       for a vector 3d field on a Point grid it will be (ncols,vector_dim,nlevs)
   FieldLayout get_vertical_layout (const bool midpoints) const;
+  FieldLayout get_vertical_layout (const bool midpoints,
+                                   const int vector_dim,
+                                   const std::string& vec_dim_name = e2str(FieldTag::Component)) const;
   virtual FieldLayout get_2d_scalar_layout () const = 0;
   virtual FieldLayout get_2d_vector_layout (const int vector_dim, const std::string& vec_dim_name) const = 0;
   virtual FieldLayout get_2d_tensor_layout (const std::vector<int>& cmp_dims,

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -142,7 +142,10 @@ public:
   }
 
   // Sets pre-existing field as geometry data.
-  void set_geometry_data (const Field& f);
+  // NOTE: setter is const, since we do allow adding new data even if grid is const
+  //       E.g., this allows atm procs to define coordinate vars for dimensions
+  //       peculiar to that process
+  void set_geometry_data (const Field& f) const;
   void delete_geometry_data (const std::string& name);
 
   bool has_geometry_data (const std::string& name) const {
@@ -244,7 +247,7 @@ protected:
   // The map lid->idx
   Field     m_lid_to_idx;
 
-  std::map<std::string,Field>  m_geo_fields;
+  mutable std::map<std::string,Field>  m_geo_fields;
 
   // The MPI comm containing the ranks across which the global mesh is partitioned
   ekat::Comm            m_comm;

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -124,6 +124,20 @@ create_layout (const FieldLayout& fl_in,
   std::vector<std::string> tdims_names;
   std::string vdim_name;
   switch (fl_in.type()) {
+    case LayoutType::Scalar0D: [[ fallthrough ]];
+    case LayoutType::Vector0D: [[ fallthrough ]];
+    case LayoutType::Tensor0D:
+      // 0d layouts are the same on all grids
+      fl_out = fl_in;
+      break;
+    case LayoutType::Scalar1D:
+      // 1d layouts require the grid correct number of levs
+      fl_out = grid->get_vertical_layout(midpoints);
+      break;
+    case LayoutType::Vector1D:
+      vdim_name = fl_in.names()[fl_in.get_vector_component_idx()];
+      fl_out = grid->get_vertical_layout(midpoints,fl_in.get_vector_dim(),vdim_name);
+      break;
     case LayoutType::Scalar2D:
       fl_out = grid->get_2d_scalar_layout();
       break;


### PR DESCRIPTION
This can be used by atm procs to add fields corresponding to the values of dimensions peculiar to vars of that process. For instance, in this PR I made RRTMGP load the sw/lw bands bounds and save them in the physics grid, so that they can later be saved to output file by adding `save_grid_data: true` to the output yaml file (it actually is true by default, so if you don't see this param, data will be saved)

As a follow up PR, we could make RRTMGP _not_ hardcode the values for `m_nswbands` and `m_nlwbands`, but rather read them from file. I understand that other atm procs may need this info, so at some point we may add a singleton-like data structure in `physics/share`, which upon construction will load this info from file. First atm proc to be created will init the singleton, while the ones after that will simply read the data from it.

I also patched up some use cases of LayoutType that were not really correctly supported.