### PR TITLE
Fix valgrind errors

### DIFF
--- a/components/eamxx/scripts/CMakeLists.txt
+++ b/components/eamxx/scripts/CMakeLists.txt
@@ -9,4 +9,6 @@ add_executable(query-cf-database query-cf-database.cpp)
 target_compile_definitions(query-cf-database PUBLIC
                            CF_STANDARD_NAME_FILE=${CF_STANDARD_NAME_FILE}
                            CF_SCREAM_NAME_FILE=${CF_SCREAM_NAME_FILE})
+
+find_package (yaml-cpp HINTS ${YAML_CPP_ROOT})
 target_link_libraries(query-cf-database ekat yaml-cpp)

--- a/components/eamxx/scripts/jenkins/valgrind/mappy.supp
+++ b/components/eamxx/scripts/jenkins/valgrind/mappy.supp
@@ -550,3 +550,21 @@
    fun:start_thread
    fun:clone
 }
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   pwrite64(buf)
+   fun:pwrite
+   fun:mca_fbtl_posix_pwritev
+   fun:write_init.constprop.0
+   fun:mca_fcoll_vulcan_file_write_all
+   fun:mca_common_ompio_file_write_at_all
+   fun:mca_io_ompio_file_write_at_all
+   fun:PMPI_File_write_at_all
+   fun:ncmpio_read_write
+   fun:wait_getput
+   fun:ncmpio_wait
+   fun:ncmpi_wait_all
+   fun:flush_output_buffer
+}

--- a/components/eamxx/src/share/io/tests/scorpio_interface_tests.cpp
+++ b/components/eamxx/src/share/io/tests/scorpio_interface_tests.cpp
@@ -20,18 +20,14 @@ TEST_CASE ("io_subsystem") {
 TEST_CASE ("write_and_read") {
   ekat::Comm comm (MPI_COMM_WORLD);
 
-  EKAT_REQUIRE_MSG (comm.size()<=4,
-      "Error! This test is tailored for an MPI_Comm of size 1, 2, 3, or 4.\n"
-      " - MPI_Comm size: " + std::to_string(comm.size()) + "\n");
-
   init_subsystem (comm);
 
   std::string filename = "scorpio_interface_write_test_np" + std::to_string(comm.size()) + ".nc";
 
   const int dim1 = 2;
   const int dim2 = 4;
-  const int dim3 = 12;
-  const int ldim3 = dim3 / comm.size();
+  const int ldim3 = 3;
+  const int dim3  = ldim3 * comm.size();
 
   // Offsets for dim3 decomp owned by this rank
   std::vector<offset_t> my_offsets;


### PR DESCRIPTION
Only one error was truly our fault, while most of the fails are due to some error reported inside pnetcdf, which appears to be not our responsibility. I added an entry in mappy's suppressions file for valgrind, so that we can ignore it.