### PR TITLE
generalize table reading in p3_iso_c

### DIFF
--- a/components/eamxx/src/physics/p3/p3_iso_c.f90
+++ b/components/eamxx/src/physics/p3/p3_iso_c.f90
@@ -70,15 +70,15 @@ contains
     ok = .false.
 
 #ifdef SCREAM_DOUBLE_PRECISION
-    mu_r_filename  = lookup_file_dir//'/mu_r_table_vals.dat8'//C_NULL_CHAR
-    revap_filename = lookup_file_dir//'/revap_table_vals.dat8'//C_NULL_CHAR
-    vn_filename    = lookup_file_dir//'/vn_table_vals.dat8'//C_NULL_CHAR
-    vm_filename    = lookup_file_dir//'/vm_table_vals.dat8'//C_NULL_CHAR
+    mu_r_filename  = lookup_file_dir(1:len)//'/mu_r_table_vals.dat8'//C_NULL_CHAR
+    revap_filename = lookup_file_dir(1:len)//'/revap_table_vals.dat8'//C_NULL_CHAR
+    vn_filename    = lookup_file_dir(1:len)//'/vn_table_vals.dat8'//C_NULL_CHAR
+    vm_filename    = lookup_file_dir(1:len)//'/vm_table_vals.dat8'//C_NULL_CHAR
 #else
-    mu_r_filename  = lookup_file_dir//'/mu_r_table_vals.dat4'//C_NULL_CHAR
-    revap_filename = lookup_file_dir//'/revap_table_vals.dat4'//C_NULL_CHAR
-    vn_filename    = lookup_file_dir//'/vn_table_vals.dat4'//C_NULL_CHAR
-    vm_filename    = lookup_file_dir//'/vm_table_vals.dat4'//C_NULL_CHAR
+    mu_r_filename  = lookup_file_dir(1:len)//'/mu_r_table_vals.dat4'//C_NULL_CHAR
+    revap_filename = lookup_file_dir(1:len)//'/revap_table_vals.dat4'//C_NULL_CHAR
+    vn_filename    = lookup_file_dir(1:len)//'/vn_table_vals.dat4'//C_NULL_CHAR
+    vm_filename    = lookup_file_dir(1:len)//'/vm_table_vals.dat4'//C_NULL_CHAR
 #endif
 
     if (write_tables) then

--- a/components/eamxx/src/physics/p3/p3_iso_c.f90
+++ b/components/eamxx/src/physics/p3/p3_iso_c.f90
@@ -17,7 +17,7 @@ contains
   subroutine append_precision(string, prefix)
 
     character(kind=c_char, len=256), intent(out) :: string
-    character(kind=c_char, len=*), intent(in) :: prefix
+    character(*), intent(in) :: prefix
     real(kind=c_real) :: s
 
     write (string, '(a,i1,a1)') prefix, sizeof(s), C_NULL_CHAR

--- a/components/eamxx/src/physics/p3/p3_iso_c.f90
+++ b/components/eamxx/src/physics/p3/p3_iso_c.f90
@@ -16,7 +16,7 @@ module p3_iso_c
 contains
   subroutine append_precision(string, prefix)
 
-    character(kind=c_char, len=256), intent(out) :: string
+    character(kind=c_char, len=512), intent(out) :: string
     character(*), intent(in) :: prefix
     real(kind=c_real) :: s
 
@@ -57,7 +57,7 @@ contains
     real(kind=c_real), dimension(300,10), target :: vn_table_vals, vm_table_vals, revap_table_vals
 
     character(len=256), pointer :: lookup_file_dir
-    character(kind=c_char, len=256) :: mu_r_filename, revap_filename, vn_filename, vm_filename
+    character(kind=c_char, len=512) :: mu_r_filename, revap_filename, vn_filename, vm_filename
     integer :: len
     logical :: ok
     character(len=16) :: p3_version="4.1.1"  ! TODO: Change to be dependent on table version and path specified in p3_functions.hpp
@@ -69,10 +69,17 @@ contains
     info = 0
     ok = .false.
 
-    call append_precision(mu_r_filename, SCREAM_DATA_DIR//"/tables/mu_r_table_vals.dat")
-    call append_precision(revap_filename, SCREAM_DATA_DIR//"/tables/revap_table_vals.dat")
-    call append_precision(vn_filename, SCREAM_DATA_DIR//"/tables/vn_table_vals.dat")
-    call append_precision(vm_filename, SCREAM_DATA_DIR//"/tables/vm_table_vals.dat")
+#ifdef SCREAM_DOUBLE_PRECISION
+    mu_r_filename  = lookup_file_dir//'/mu_r_table_vals.dat8'//C_NULL_CHAR
+    revap_filename = lookup_file_dir//'/revap_table_vals.dat8'//C_NULL_CHAR
+    vn_filename    = lookup_file_dir//'/vn_table_vals.dat8'//C_NULL_CHAR
+    vm_filename    = lookup_file_dir//'/vm_table_vals.dat8'//C_NULL_CHAR
+#else
+    mu_r_filename  = lookup_file_dir//'/mu_r_table_vals.dat4'//C_NULL_CHAR
+    revap_filename = lookup_file_dir//'/revap_table_vals.dat4'//C_NULL_CHAR
+    vn_filename    = lookup_file_dir//'/vn_table_vals.dat4'//C_NULL_CHAR
+    vm_filename    = lookup_file_dir//'/vm_table_vals.dat4'//C_NULL_CHAR
+#endif
 
     if (write_tables) then
        call p3_init_b()

--- a/components/eamxx/src/physics/p3/p3_iso_c.f90
+++ b/components/eamxx/src/physics/p3/p3_iso_c.f90
@@ -16,8 +16,8 @@ module p3_iso_c
 contains
   subroutine append_precision(string, prefix)
 
-    character(kind=c_char, len=256), intent(inout) :: string
-    character(*), intent(in) :: prefix
+    character(kind=c_char, len=256), intent(out) :: string
+    character(kind=c_char, len=*), intent(in) :: prefix
     real(kind=c_real) :: s
 
     write (string, '(a,i1,a1)') prefix, sizeof(s), C_NULL_CHAR


### PR DESCRIPTION
Two issues that appeared in cases where the produced shared object was patched to make the hard links softer.
1. The length of the paths was more than 256 characters
2. Somehow the `write` logic in the append_precision wasn't working, so fixing that with a more hardcoded char concat

In both cases, the issues weren't reproducible in supported machines or supported builds (the issue is essentially when the shared objects are built on one machine and used on another, hence the need to change the hard links to softer links, so that the paths can be different on different machines)