### PR TITLE
Fix usage of code deprecated Kokkos code, and updates ekat

### DIFF
--- a/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
+++ b/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
@@ -413,7 +413,7 @@ do_remap_fwd()
 
   using TeamPolicy = typename KT::TeamTagPolicy<RemapFwdTag>;
 
-  const auto concurrency = KT::ExeSpace::concurrency();
+  const auto concurrency = KT::ExeSpace().concurrency();
 #ifdef KOKKOS_ENABLE_CUDA
 #ifdef KOKKOS_ENABLE_DEBUG
   const int team_size = std::min(256, std::min(128*m_num_phys_cols,32*(concurrency/this->m_num_fields+31)/32));
@@ -450,7 +450,7 @@ do_remap_bwd()
 
   using TeamPolicy = typename KT::TeamTagPolicy<RemapBwdTag>;
 
-  const auto concurrency = KT::ExeSpace::concurrency();
+  const auto concurrency = KT::ExeSpace().concurrency();
 #ifdef KOKKOS_ENABLE_CUDA
   const int num_levs  = m_phys_grid->get_num_vertical_levels();
   const int team_size = std::min(128,32*(int)ceil(((Real)num_levs)/32));

--- a/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -135,8 +135,8 @@ protected:
   //       so we'll just force to call this as pack_view<const T>(v).
   template<typename NewValueT, typename OldViewT>
   KOKKOS_INLINE_FUNCTION
-  view_Nd<NewValueT,OldViewT::Rank> pack_view (const OldViewT& v) const {
-    constexpr int N = OldViewT::Rank;
+  view_Nd<NewValueT,OldViewT::rank> pack_view (const OldViewT& v) const {
+    constexpr int N = OldViewT::rank;
     Kokkos::LayoutRight kl;
     for (int i=0; i<N; ++i) {
       kl.dimension[i] = v.extent(i);

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -16,7 +16,7 @@ Field (const identifier_type& id,
        const ViewT& view_d)
  : Field(id)
 {
-  constexpr auto N = ViewT::Rank;
+  constexpr int N = ViewT::rank;
   using ScalarT  = typename ViewT::traits::value_type;
   using ExeSpace = typename ViewT::traits::execution_space;
 

--- a/components/eamxx/src/share/tests/column_ops.cpp
+++ b/components/eamxx/src/share/tests/column_ops.cpp
@@ -79,7 +79,7 @@ TEST_CASE("column_ops_ps_1") {
   constexpr int num_cols = 1;
   constexpr int num_levs = 16;
 
-  policy_type policy(num_cols,std::min(num_levs,exec_space::concurrency()));
+  policy_type policy(num_cols,std::min(num_levs,exec_space().concurrency()));
 
   view_2d_type v_int("",num_cols,num_levs+1);
   view_2d_type v_mid("",num_cols,num_levs);
@@ -560,7 +560,7 @@ TEST_CASE("column_ops_ps_N") {
       auto dv_mid_h = Kokkos::create_mirror_view(dv_mid);
       auto dz_mid_h = Kokkos::create_mirror_view(dz_mid);
 
-      policy_type policy(num_cols,std::min(num_mid_packs,exec_space::concurrency()));
+      policy_type policy(num_cols,std::min(num_mid_packs,exec_space().concurrency()));
 
       SECTION ("int_to_mid") {
 


### PR DESCRIPTION
We can now build with `Kokkos_ENABLE_DEPRECATED_CODE_4=OFF`. Also, brings in an update in ekat that suppresses the zillion warnings we were getting.

@jgfouca I did not set `Kokkos_ENABLE_DEPRECATED_CODE_4=OFF` in our test-all-scream builds. But maybe we should consider doing it at some point?