### PR TITLE
test-all-scream: Simplify the baseline model

### DIFF
--- a/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
@@ -72,7 +72,7 @@ if [ $skip_testing -eq 0 ]; then
   # IF such dir is not found, then the default (ctest-build/baselines) is used
   BASELINES_DIR=AUTO
 
-  TAS_ARGS="--baseline-dir $BASELINES_DIR \$compiler -p -c EKAT_DISABLE_TPL_WARNINGS=ON -i -m \$machine"
+  TAS_ARGS="--baseline-dir $BASELINES_DIR \$compiler -p -c EKAT_DISABLE_TPL_WARNINGS=ON -m \$machine"
   # pm-gpu needs to do work in scratch area in order not to fill home quota
   if [[ "$SCREAM_MACHINE" == "pm-gpu" ]]; then
       TAS_ARGS="${TAS_ARGS} -w /pscratch/sd/e/e3smtest/e3sm_scratch/pm-gpu/ctest-build"
@@ -90,6 +90,16 @@ if [ $skip_testing -eq 0 ]; then
       if [ -z "$SCREAM_FAKE_ONLY" ]; then
           # Run EKAT tests for real nightly runs
           TAS_ARGS="${TAS_ARGS} --submit -c EKAT_ENABLE_TESTS=ON"
+      fi
+  fi
+
+  # AT runs may need an upstream merge in order to ensure that any DIFFs
+  # are caused by this PR and not simply because the PR is too far behind master.
+  if [ -z "$SCREAM_FAKE_ONLY" && $is_at_run == 1 ]; then
+      ./scripts/git-merge-ref origin/master
+      if [[ $? != 0 ]]; then
+          echo "MERGE FAILED! Please resolve conflicts"
+          exit 1
       fi
   fi
 
@@ -167,15 +177,6 @@ if [ $skip_testing -eq 0 ]; then
     if [[ -z "$SCREAM_FAKE_ONLY" && $is_at_run == 1 ]]; then
 
       if [[ $test_v0 == 1 || $test_v1 == 1 ]]; then
-        # AT CIME runs may need an upstream merge in order to ensure that any DIFFs
-        # are caused by this PR and not simply because the PR is too far behind master.
-        if [ -n "$PULLREQUESTNUM" ]; then
-          ./scripts/git-merge-ref origin/master
-          if [[ $? != 0 ]]; then
-              echo "MERGE FAILED! Please resolve conflicts"
-              exit 1
-          fi
-        fi
       fi
 
       if [[ $test_v0 == 1 ]]; then

--- a/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
@@ -93,16 +93,6 @@ if [ $skip_testing -eq 0 ]; then
       fi
   fi
 
-  # AT runs may need an upstream merge in order to ensure that any DIFFs
-  # are caused by this PR and not simply because the PR is too far behind master.
-  if [ -z "$SCREAM_FAKE_ONLY" && $is_at_run == 1 ]; then
-      ./scripts/git-merge-ref origin/master
-      if [[ $? != 0 ]]; then
-          echo "MERGE FAILED! Please resolve conflicts"
-          exit 1
-      fi
-  fi
-
   SA_FAILURES_DETAILS=""
   # Run scream stand-alone tests (SA)
   if [ $test_SA -eq 1 ]; then

--- a/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
@@ -166,9 +166,6 @@ if [ $skip_testing -eq 0 ]; then
     # Also, for the nightlies, we use a separate job to run CIME tests
     if [[ -z "$SCREAM_FAKE_ONLY" && $is_at_run == 1 ]]; then
 
-      if [[ $test_v0 == 1 || $test_v1 == 1 ]]; then
-      fi
-
       if [[ $test_v0 == 1 ]]; then
         ../../cime/scripts/create_test e3sm_scream_v0 -c -b master --wait
         if [[ $? != 0 ]]; then

--- a/components/eamxx/scripts/scripts-tests
+++ b/components/eamxx/scripts/scripts-tests
@@ -214,7 +214,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
 ###############################################################################
 
     CMDS_TO_TEST = [
-        "./test-all-scream -m $machine -p -i -c EKAT_DISABLE_TPL_WARNINGS=ON",
+        "./test-all-scream -m $machine -p -c EKAT_DISABLE_TPL_WARNINGS=ON",
         "./test-all-scream -m $machine -t dbg",
     ]
 
@@ -390,7 +390,7 @@ class TestTestAllScream(TestBaseOuter.TestBase):
 
             # Start a couple new tests, baselines will be generated in ctest-build/baselines
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_GIT_HEAD=FAKE1"
-            opts = " -g -t dbg -t sp --no-tests"
+            opts = "-b LOCAL -g -t dbg -t sp"
             cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
                                self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
@@ -400,56 +400,13 @@ class TestTestAllScream(TestBaseOuter.TestBase):
 
             # Re-run reusing baselines from above
             env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_GIT_HEAD=FAKE2"
-            opts = "--baseline-dir LOCAL -t dbg -t sp --no-tests"
+            opts = "-b LOCAL -t dbg -t sp"
             cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
                                self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
 
             test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE1")
             test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE1")
-
-            # Re-run dbg reusing baselines from above with a fake commit that's not ahead
-            # The flag -u implies -g, but nothing should happen, since SCREAM_FAKE_AHEAD=0
-            env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_AHEAD=0 SCREAM_FAKE_GIT_HEAD=FAKE2"
-            opts = "--baseline-dir LOCAL -t dbg -u --no-tests"
-            cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
-                               self._machine)
-            run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
-
-            test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE1")
-            test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE1")
-
-            # Re-run dbg reusing baselines from above but expire them
-            # The flag -u implies -g, and since SCREAM_FAKE_AHEAD=1, baseline should be regenerated
-            env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_AHEAD=1 SCREAM_FAKE_GIT_HEAD=FAKE2"
-            opts = "--baseline-dir LOCAL -t dbg -u --no-tests"
-            cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
-                               self._machine)
-            run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
-
-            test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE2")
-            test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE1")
-
-            # Re-run reusing some baselines and expiring others
-            # The dbg baselines were generated in the prev step, so this should only gen the sp baselines
-            env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_AHEAD=1 SCREAM_FAKE_GIT_HEAD=FAKE2"
-            opts = "--baseline-dir LOCAL -t dbg -t sp -u --no-tests"
-            cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
-                               self._machine)
-            run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
-
-            test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE2")
-            test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE2")
-
-            # Re-run without reusing baselines, should force regeneration
-            env = "SCREAM_FAKE_ONLY=ON SCREAM_FAKE_GIT_HEAD=FAKE3"
-            opts = "-g -t dbg -t sp --no-tests"
-            cmd = self.get_cmd(f"{env} ./test-all-scream -m $machine {opts}",
-                               self._machine)
-            run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
-
-            test_baseline_has_sha(self, TEST_DIR, "full_debug",    "FAKE3")
-            test_baseline_has_sha(self, TEST_DIR, "full_sp_debug", "FAKE3")
 
         else:
             self.skipTest("Skipping full run")

--- a/components/eamxx/scripts/test-all-scream
+++ b/components/eamxx/scripts/test-all-scream
@@ -9,6 +9,27 @@ do batch submissions.
 IMPORTANT: the default behavior of this script *changes your environment*,
            by loading machine-specific modules and setting machine-specific
            env vars. To prevent this behavior, use --preserve-env flag.
+
+Baselines: By default, test-all-scream will not run baseline tests. If you set
+-b AUTO, baseline tests will be done with the pre-existing public baselines in
+the location specified by the machine spec. You can regenerate
+baselines any time by using the -g flag, but be aware this will impact everyone
+if you regenerate the public baselines. You can change the target baseline area
+using -b $path. If -g is provided, no tests will be run; -g means generate only.
+
+The general workflow for baseline-changing PRs is:
+1) Issue PR
+2) AT will fail with differences in the baseline tests
+3) Review and merge.
+4) Ask JimF or LucaB for a bless to baselines on mappy and weaver.
+
+If you are developing a branch and baselines tests are failing unexpectedly, it is
+likely that your branch has fallen out of date. You should upstream merge or rebase
+your branch.
+
+To sum up, the baseline handling for test-all-scream should basically match what we
+do for create_test tests, the only difference is that test-all-scream does baseline
+comparison tests by default.
 """
 
 from utils import check_minimum_python_version
@@ -27,26 +48,26 @@ def parse_command_line(args, description):
 OR
 {0} --help
 
-\033[1mEXAMPLES (assumes user is on machine melvin):\033[0m
-    \033[1;32m# Run all tests on current machine using the SCREAM-approved env for this machine (this is the default env behavior) and your origin/master common ancestor for baseline generation (the default baseline behavior) \033[0m
+\033[1mEXAMPLES (assumes user is on machine mappy):\033[0m
+    \033[1;32m# Run all tests on current machine using the SCREAM-approved env for this machine \033[0m
     > cd $scream_repo/components/eamxx
-    > ./scripts/{0} -m melvin
+    > ./scripts/{0} -m mappy
 
     \033[1;32m# Run all tests on current machine with defaut behavior except using your current shell env \033[0m
     > cd $scream_repo/components/eamxx
-    > ./scripts/{0} --preserve-env -m melvin
+    > ./scripts/{0} --preserve-env -m mappy
 
-    \033[1;32m# Run all tests on current machine with default behavior except using pre-existing baselines (skips baseline generation) \033[0m
+    \033[1;32m# Run all tests on current machine with default behavior except using non-default baselines \033[0m
     > cd $scream_repo/components/eamxx
-    > ./scripts/{0} -m melvin --baseline-dir=PATH_TO_BASELINES
+    > ./scripts/{0} -m mappy --baseline-dir=PATH_TO_BASELINES
+
+    \033[1;32m# Run all tests on current machine with default behavior except using local baselines \033[0m
+    > cd $scream_repo/components/eamxx
+    > ./scripts/{0} -m mappy --baseline-dir=LOCAL
 
     \033[1;32m# Run only the dbg test on current machine with default behavior otherwise\033[0m
     > cd $scream_repo/components/eamxx
-    > ./scripts/{0} -m melvin -t dbg
-
-    \033[1;32m# Run all tests on current machine with default behavior on a repo with uncommitted changes\033[0m
-    > cd $scream_repo/components/eamxx
-    > ./scripts/{0} -m melvin -k -b AUTO
+    > ./scripts/{0} -m mappy -t dbg
 """.format(pathlib.Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -63,11 +84,8 @@ OR
     parser.add_argument("-g", "--generate", action="store_true",
         help="Instruct test-all-scream to generate baselines from current commit. Skips tests")
 
-    parser.add_argument("-b", "--baseline-dir", default=None,
-        help="Directory where baselines should be read from (or written to, if -g/-i is used)")
-
-    parser.add_argument("-u", "--update-expired-baselines", action="store_true",
-        help="Update baselines that appear to be expired (only used with -g)")
+    parser.add_argument("-b", "--baseline-dir",
+        help="Directory where baselines should be read from (or written to, if -g is used). Default is None which skips all baseline tests. AUTO means use public baselines. You can also use LOCAL to manage baselines in your local work dir. Lastly, you can provide a path here as well.")
 
     parser.add_argument("-m", "--machine",
         help="Provide machine name. This is *always* required. It can, but does not"
@@ -76,7 +94,6 @@ OR
 "used as the CTEST_SITE for cdash if the tests are submitted. It is"
 "expected that a scream machine file exists for this value.")
 
-    parser.add_argument("--no-tests", action="store_true", help="Only build baselines, skip testing phase")
     parser.add_argument("--config-only", action="store_true",
             help="In the testing phase, only run config step, skip build and tests")
 
@@ -94,9 +111,6 @@ OR
     choices_doc = ", ".join(["'{}' ({})".format(k, v) for k, v in get_test_name_dict().items()])
     parser.add_argument("-t", "--test", dest="tests", action="append", default=[],
                         help=f"Only run specific test configurations, choices={choices_doc}")
-
-    parser.add_argument("-i", "--integration-test", action="store_true",
-                        help="Merge origin/master into this branch before testing (implies -u).")
 
     parser.add_argument("-l", "--local", action="store_true",
                         help="Allow to not specify a machine name, and have test-all-scream to look"
@@ -132,9 +146,6 @@ OR
     parser.add_argument("--test-size", action="store", choices=("short", "medium", "long"),
                         help="Set the testing level. Defaults to medium unless the test is cov or mem_check"
                         "(short is default in those cases).")
-
-    parser.add_argument("--force-baseline-regen", action="store_true",
-                        help="Existing baseline will always be considered expired even if they do not appear to be.")
 
     return parser.parse_args(args[1:])
 

--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -714,12 +714,12 @@ class TestAllScream(object):
     def baselines_to_be_generated(self):
     ###############################################################################
         """
-        Return list of baselines to generate. Baselines need to be generated if
-         - they are missing
+        Return list of baselines to generate. Baselines will always be generated
+        for tests that use baselines.
         """
         ret = []
         for test in self._tests:
-            if test.baselines_missing:
+            if test.uses_baselines:
                 ret.append(test)
 
         return ret


### PR DESCRIPTION
By default, test-all-scream will not run baseline tests. If you set -b AUTO, baseline tests will be done with the pre-existing public baselines in the location specified by the machine spec. You can regenerate baselines any time by using the -g flag, but be aware this will impact everyone if you regenerate the public baselines. You can change the target baseline area using -b $path. If -g is provided, no tests will be run; -g means generate only.

The general workflow for baseline-changing PRs is:
1) Issue PR
2) AT will fail with differences in the baseline tests
3) Review and merge.
4) Ask JimF or LucaB for a bless to baselines on mappy and weaver.

If you are developing a branch and baselines tests are failing unexpectedly, it is likely that your branch has fallen out of date. You should upstream merge or rebase your branch.

To sum up, the baseline handling for test-all-scream should basically match what we do for create_test tests, the only difference is that test-all-scream does baseline comparison tests by default.

Fixes #2852 