### PR TITLE
Reduces buffer size by 1 for shoc small kernels

### DIFF
--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
@@ -395,7 +395,7 @@ public:
     static constexpr int num_2d_vector_mid  = 18;
     static constexpr int num_2d_vector_int  = 12;
 #else
-    static constexpr int num_2d_vector_mid  = 23;
+    static constexpr int num_2d_vector_mid  = 22;
     static constexpr int num_2d_vector_int  = 13;
 #endif
     static constexpr int num_2d_vector_tr   = 1;


### PR DESCRIPTION
While implementing aerosol-cloud interactions code, we removed one variable (`tkh` - eddy diffusivity of heat) from the SHOC small kernels but forgot to reduce the buffer size by 1.