### PR TITLE
Add timers on a per-yaml-file-basis

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -724,6 +724,7 @@ void AtmosphereDriver::initialize_output_managers () {
   for (const auto& fname : output_yaml_files) {
     ekat::ParameterList params;
     ekat::parse_yaml_file(fname,params);
+    params.rename(ekat::split(fname,"/").back());
     auto& checkpoint_pl = params.sublist("Checkpoint Control");
     checkpoint_pl.set("frequency_units",checkpoint_params.get<std::string>("frequency_units"));
     checkpoint_pl.set("Frequency",checkpoint_params.get<int>("Frequency"));

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
@@ -116,8 +116,6 @@ void FieldAtPressureLevel::compute_diagnostic_impl()
 {
   using KT = KokkosTypes<DefaultDevice>;
   using MemberType = typename KT::MemberType;
-  using view_1d = typename KT::template view_1d<Real>;
-  using view_2d = typename KT::template view_2d<Real>;
 
   //This is 2D source pressure
   const Field& p_src = get_field_in(m_pressure_name);

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -334,6 +334,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
 
   std::string timer_root = m_is_model_restart_output ? "EAMxx::IO::restart" : "EAMxx::IO::standard";
   start_timer(timer_root);
+  start_timer("EAMxx::IO::" + m_params.name());
 
   // Check if this is a write step (and what kind)
   // Note: a full checkpoint not only writes globals in the restart file, but also all the history variables.
@@ -545,6 +546,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     }
   }
 
+  stop_timer("EAMxx::IO::" + m_params.name());
   stop_timer(timer_root);
 }
 /*===============================================================================================*/


### PR DESCRIPTION
On top of global IO timers (adding up all equivalent timers from all output streams), this PR adds timers that show the overall time spent on each output stream. These additional timers are not split internally (e.g., no per-yaml-file `update_snapshot_tally` timer); they simply show what's the overall run time spent on an output stream. I tested it duplicating the output of the p3_standalone test, and this is what I see in the timings file:

```
EAMxx::IO::output.yaml                      -          1        1 6.000000e+00   3.732990e-01     0.373 (     0      0)     0.373 (     0      0)
...
EAMxx::IO::output2.yaml                     -          1        1 6.000000e+00   2.916770e-01     0.292 (     0      0)     0.292 (     0      0)
```