### PR TITLE
pyeamxx: allow to set atm procs parameters from python

### DIFF
--- a/components/eamxx/src/python/pyatmproc.hpp
+++ b/components/eamxx/src/python/pyatmproc.hpp
@@ -26,8 +26,10 @@ struct PyAtmProc {
 
   std::shared_ptr<OutputManager> output_mgr;
 
-  PyAtmProc (const PyParamList& params)
+  PyAtmProc (const pybind11::dict& d, const std::string& name)
   {
+    PyParamList params(d,name);
+
     // Get the comm
     const auto& comm = PySession::get().comm;
 
@@ -162,7 +164,7 @@ struct PyAtmProc {
 inline void pybind_pyatmproc(pybind11::module& m)
 {
   pybind11::class_<PyAtmProc>(m,"AtmProc")
-    .def(pybind11::init<const PyParamList&>())
+    .def(pybind11::init<const pybind11::dict&,const std::string&>())
     .def("get_field",&PyAtmProc::get_field)
     .def("initialize",&PyAtmProc::initialize)
     .def("setup_output",&PyAtmProc::setup_output)

--- a/components/eamxx/src/python/pyatmproc.hpp
+++ b/components/eamxx/src/python/pyatmproc.hpp
@@ -49,6 +49,11 @@ struct PyAtmProc {
   // I don't think virtual is needed, but just in case
   virtual ~PyAtmProc () = default;
 
+  PyParamList get_params () const {
+    PyParamList pypl(ap->get_params());
+    return pypl;
+  }
+
   void create_fields () {
     // Create  fields that are input/output to the atm proc
     for (const auto& req : ap->get_required_field_requests()) {
@@ -167,6 +172,7 @@ inline void pybind_pyatmproc(pybind11::module& m)
     .def(pybind11::init<const pybind11::dict&,const std::string&>())
     .def("get_field",&PyAtmProc::get_field)
     .def("initialize",&PyAtmProc::initialize)
+    .def("get_params",&PyAtmProc::get_params)
     .def("setup_output",&PyAtmProc::setup_output)
     .def("run",&PyAtmProc::run)
     .def("read_ic",&PyAtmProc::read_ic);

--- a/components/eamxx/src/python/pyparamlist.hpp
+++ b/components/eamxx/src/python/pyparamlist.hpp
@@ -35,6 +35,9 @@ struct PyParamList {
     return spl;
   }
 
+  bool get_bool (const std::string& name) const {
+    return pl_ref.get().get<bool>(name);
+  }
   int get_int (const std::string& name) const {
     return pl_ref.get().get<int>(name);
   }
@@ -132,12 +135,14 @@ inline void pybind_pyparamlist (pybind11::module& m)
     .def(pybind11::init<const pybind11::dict&,const std::string&>())
     .def("sublist",&PyParamList::sublist)
     .def("print",&PyParamList::print)
+    .def("set",&PyParamList::set<bool>)
     .def("set",&PyParamList::set<int>)
     .def("set",&PyParamList::set<double>)
     .def("set",&PyParamList::set<std::string>)
     .def("set",&PyParamList::set<std::vector<int>>)
     .def("set",&PyParamList::set<std::vector<double>>)
     .def("set",&PyParamList::set<std::vector<std::string>>)
+    .def("get_bool",&PyParamList::get_bool)
     .def("get_int",&PyParamList::get_int)
     .def("get_dbl",&PyParamList::get_dbl)
     .def("get_str",&PyParamList::get_str)

--- a/components/eamxx/src/python/pyparamlist.hpp
+++ b/components/eamxx/src/python/pyparamlist.hpp
@@ -45,6 +45,16 @@ struct PyParamList {
     return pl_ref.get().get<std::string>(name);
   }
 
+  std::vector<int> get_int_vec (const std::string& name) const {
+    return pl_ref.get().get<std::vector<int>>(name);
+  }
+  std::vector<double> get_dbl_vec (const std::string& name) const {
+    return pl_ref.get().get<std::vector<double>>(name);
+  }
+  std::vector<std::string> get_str_vec (const std::string& name) const {
+    return pl_ref.get().get<std::vector<std::string>>(name);
+  }
+
   template<typename T>
   void set (const std::string& name, T val) {
     pl_ref.get().set(name,val);
@@ -125,9 +135,15 @@ inline void pybind_pyparamlist (pybind11::module& m)
     .def("set",&PyParamList::set<int>)
     .def("set",&PyParamList::set<double>)
     .def("set",&PyParamList::set<std::string>)
+    .def("set",&PyParamList::set<std::vector<int>>)
+    .def("set",&PyParamList::set<std::vector<double>>)
+    .def("set",&PyParamList::set<std::vector<std::string>>)
     .def("get_int",&PyParamList::get_int)
     .def("get_dbl",&PyParamList::get_dbl)
-    .def("get_str",&PyParamList::get_str);
+    .def("get_str",&PyParamList::get_str)
+    .def("get_int_vec",&PyParamList::get_int_vec)
+    .def("get_dbl_vec",&PyParamList::get_dbl_vec)
+    .def("get_str_vec",&PyParamList::get_str_vec);
 }
 
 } // namespace scream

--- a/components/eamxx/tests/python/pyp3/p3_standalone_py
+++ b/components/eamxx/tests/python/pyp3/p3_standalone_py
@@ -40,8 +40,7 @@ def main ():
     nlevs = 72
     pyeamxx.create_grids_manager(ncols,nlevs,str(ic_file))
 
-    p3params = pyeamxx.ParameterList(yaml_input['atmosphere_processes']['p3'],'p3')
-    p3 = pyeamxx.AtmProc(p3params)
+    p3 = pyeamxx.AtmProc(yaml_input['atmosphere_processes']['p3'],'p3')
     missing = p3.read_ic(str(ic_file))
     if len(missing)>0:
         print (f"WARNING! The following input fields were not found in the IC file, and must be manually initialized: {missing}")

--- a/components/eamxx/tests/python/pyp3/p3_standalone_py
+++ b/components/eamxx/tests/python/pyp3/p3_standalone_py
@@ -41,6 +41,14 @@ def main ():
     pyeamxx.create_grids_manager(ncols,nlevs,str(ic_file))
 
     p3 = pyeamxx.AtmProc(yaml_input['atmosphere_processes']['p3'],'p3')
+    params = p3.get_params()
+    old = params.get_dbl('max_total_ni')
+    print (f"max_total_ni: {params.get_dbl('max_total_ni')}")
+    params.set("max_total_ni",1000000.0)
+    print (f"max_total_ni: {params.get_dbl('max_total_ni')}")
+    params.set("max_total_ni",old)
+    print (f"max_total_ni: {params.get_dbl('max_total_ni')}")
+
     missing = p3.read_ic(str(ic_file))
     if len(missing)>0:
         print (f"WARNING! The following input fields were not found in the IC file, and must be manually initialized: {missing}")


### PR DESCRIPTION
This PR adds some interfaces to PyParamList, which allow to change the value of a parameter list from python. The [p3_standalone_py](https://github.com/E3SM-Project/scream/blob/54c1ece88d58a427d951dfef7db723344698e1ca/components/eamxx/tests/python/pyp3/p3_standalone_py#L45) script shows an example of how this is done.