### PR TITLE
Revert back to using string hex format for writing hashes

### DIFF
--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -129,9 +129,9 @@ void AtmosphereProcess
   if (m_comm.am_i_root())
     for (int i = 0; i < nslot; ++i)
       if (show[i])
-        fprintf(stderr, "exxhash> %4d-%9.5f %1d %16lld (%s)\n",
+        fprintf(stderr, "exxhash> %4d-%9.5f %1d %16lx (%s)\n",
                 timestamp().get_year(), timestamp().frac_of_year_in_days(),
-                i, (long long int)gaccum[i], label.c_str());
+                i, gaccum[i], label.c_str());
 }
 
 void AtmosphereProcess::print_fast_global_state_hash (const std::string& label) const {
@@ -140,8 +140,8 @@ void AtmosphereProcess::print_fast_global_state_hash (const std::string& label) 
   HashType gaccum;
   bfbhash::all_reduce_HashType(m_comm.mpi_comm(), &laccum, &gaccum, 1);
   if (m_comm.am_i_root())
-    fprintf(stderr, "bfbhash> %14d %16lld (%s)\n",
-            timestamp().get_num_steps(), (long long int) gaccum, label.c_str());
+    fprintf(stderr, "bfbhash> %14d %16lx (%s)\n",
+            timestamp().get_num_steps(), gaccum, label.c_str());
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -129,7 +129,7 @@ void AtmosphereProcess
   if (m_comm.am_i_root())
     for (int i = 0; i < nslot; ++i)
       if (show[i])
-        fprintf(stderr, "exxhash> %4d-%9.5f %1d %16lx (%s)\n",
+        fprintf(stderr, "exxhash> %4d-%9.5f %1d %16llx (%s)\n",
                 timestamp().get_year(), timestamp().frac_of_year_in_days(),
                 i, gaccum[i], label.c_str());
 }
@@ -140,7 +140,7 @@ void AtmosphereProcess::print_fast_global_state_hash (const std::string& label) 
   HashType gaccum;
   bfbhash::all_reduce_HashType(m_comm.mpi_comm(), &laccum, &gaccum, 1);
   if (m_comm.am_i_root())
-    fprintf(stderr, "bfbhash> %14d %16lx (%s)\n",
+    fprintf(stderr, "bfbhash> %14d %16llx (%s)\n",
             timestamp().get_num_steps(), gaccum, label.c_str());
 }
 


### PR DESCRIPTION
Use string hex values for hash prints that are used to compare cases.

Fixes https://github.com/E3SM-Project/scream/issues/2883

[bfb]