### PR TITLE
Enable pyeamxx testing in SP builds

### DIFF
--- a/components/eamxx/cmake/machine-files/mappy.cmake
+++ b/components/eamxx/cmake/machine-files/mappy.cmake
@@ -1,5 +1,6 @@
 include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
 common_setup()
-set(PYTHON_EXECUTABLE "/ascldap/users/jgfouca/packages/Python-3.8.5/bin/python3.8" CACHE STRING "" FORCE)
 
 set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch"  CACHE STRING "" FORCE)
+
+set(pybind11_ROOT /home/e3sm-jenkins/.local/lib/python3.8/site-packages CACHE PATH "Path to pybind11 installation folder")

--- a/components/eamxx/cmake/machine-files/weaver.cmake
+++ b/components/eamxx/cmake/machine-files/weaver.cmake
@@ -7,3 +7,5 @@ set(SCREAM_INPUT_ROOT "/home/projects/e3sm/scream/data" CACHE STRING "")
 #set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
 set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch"  CACHE STRING "" FORCE)
 set(HOMMEXX_CUDA_MAX_WARP_PER_TEAM 8 CACHE STRING "")
+
+set(pybind11_ROOT /home/e3sm-jenkins/.local/lib/python3.10/site-packages CACHE PATH "Path to pybind11 installation folder")

--- a/components/eamxx/scripts/test_factory.py
+++ b/components/eamxx/scripts/test_factory.py
@@ -101,8 +101,8 @@ class SP(TestProperty):
             "debug single precision",
             [("CMAKE_BUILD_TYPE", "Debug"),
              ("EKAT_DEFAULT_BFB", "True"),
-             ("SCREAM_DOUBLE_PRECISION", "False")
-             ("EAMXX_ENABLE_PYBIND", "True"],
+             ("SCREAM_DOUBLE_PRECISION", "False"),
+             ("EAMXX_ENABLE_PYBIND", "True")],
         )
 
 ###############################################################################

--- a/components/eamxx/scripts/test_factory.py
+++ b/components/eamxx/scripts/test_factory.py
@@ -99,8 +99,10 @@ class SP(TestProperty):
             self,
             "full_sp_debug",
             "debug single precision",
-            [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_DEFAULT_BFB", "True"),
-             ("SCREAM_DOUBLE_PRECISION", "False")],
+            [("CMAKE_BUILD_TYPE", "Debug"),
+             ("EKAT_DEFAULT_BFB", "True"),
+             ("SCREAM_DOUBLE_PRECISION", "False")
+             ("EAMXX_ENABLE_PYBIND", "True"],
         )
 
 ###############################################################################

--- a/components/eamxx/src/python/pyatmproc.hpp
+++ b/components/eamxx/src/python/pyatmproc.hpp
@@ -131,11 +131,8 @@ struct PyAtmProc {
     return pybind11::cast(missing);
   }
 
-  void setup_output (const std::string& yaml_file) {
+  void setup_output (const ekat::ParameterList& params) {
     auto comm = PySession::get().comm;
-
-    // Load output params
-    auto params = ekat::parse_yaml_file(yaml_file);
 
     // Stuff all fields in a field manager
     auto gm = PySession::get().gm;
@@ -154,6 +151,16 @@ struct PyAtmProc {
     output_mgr = std::make_shared<OutputManager>();
     output_mgr->setup(comm,params,fms,gm,t0,t0,false);
     output_mgr->set_logger(ap->get_logger());
+  }
+
+  void setup_output (const std::string& yaml_file) {
+    auto params = ekat::parse_yaml_file(yaml_file);
+    setup_output(params);
+  }
+
+  void setup_output (const pybind11::dict& d) {
+    PyParamList py_params(d);
+    setup_output(py_params.pl_ref.get());
   }
 
   void run (double dt) {

--- a/components/eamxx/src/python/pyatmproc.hpp
+++ b/components/eamxx/src/python/pyatmproc.hpp
@@ -180,7 +180,8 @@ inline void pybind_pyatmproc(pybind11::module& m)
     .def("get_field",&PyAtmProc::get_field)
     .def("initialize",&PyAtmProc::initialize)
     .def("get_params",&PyAtmProc::get_params)
-    .def("setup_output",&PyAtmProc::setup_output)
+    .def("setup_output",pybind11::overload_cast<const pybind11::dict&>(&PyAtmProc::setup_output))
+    .def("setup_output",pybind11::overload_cast<const std::string&>(&PyAtmProc::setup_output))
     .def("run",&PyAtmProc::run)
     .def("read_ic",&PyAtmProc::read_ic);
 }


### PR DESCRIPTION
We were not unit testing pyeamxx, so enable it in SP builds (which are faster, since there's no dynamics or rrtmgp).

~Also, add a documentation page for pyeamxx to our docs~ Removed docs commit, since we'll do it in another PR.