### PR TITLE
Update module versions on pm-gpu

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -678,6 +678,7 @@
         <command name="unload">nvidia</command>
         <command name="unload">aocc</command>
         <command name="unload">cudatoolkit</command>
+        <command name="unload">cray-libsci</command>
         <command name="unload">climate-utils</command>
         <command name="unload">matlab</command>
         <command name="unload">craype-accel-nvidia80</command>
@@ -688,26 +689,24 @@
       </modules>
 
       <modules compiler="gnu.*">
-        <command name="load">PrgEnv-gnu/8.3.3</command>
-        <command name="load">gcc/11.2.0</command>
-        <!--command name="load">PrgEnv-gnu/8.5.0</command>
-        <command name="load">gcc-native/12.3</command-->
+        <command name="load">PrgEnv-gnu/8.5.0</command>
+        <command name="load">gcc-native/12.3</command>
       </modules>
 
       <modules compiler="nvidia.*">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/23.9</command>
+        <command name="load">nvidia/24.5</command>
       </modules>
 
       <modules compiler="gnugpu">
-        <command name="load">cudatoolkit/11.7</command>
-        <!--command name="load">cudatoolkit/12.2</command-->
+        <command name="load">cudatoolkit/12.2</command>
         <command name="load">craype-accel-nvidia80</command>
       </modules>
 
       <modules compiler="nvidiagpu">
-        <command name="load">cudatoolkit/11.7</command>
+        <command name="load">cudatoolkit/12.2</command>
         <command name="load">craype-accel-nvidia80</command>
+        <command name="load">gcc-native-mixed/12.3</command>
       </modules>
 
       <modules compiler="gnu">
@@ -719,20 +718,13 @@
       </modules>
 
       <modules>
-        <command name="load">cray-libsci/23.02.1.1</command>
-        <command name="load">craype/2.7.20</command>
-        <command name="load">cray-mpich/8.1.25</command>
-        <command name="load">cray-hdf5-parallel/1.12.2.3</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
-        <command name="load">cray-parallel-netcdf/1.12.3.3</command>
-        <!--command name="load">cray-libsci/23.12.5</command>
+        <command name="load">cray-libsci/23.12.5</command>
         <command name="load">craype/2.7.30</command>
         <command name="load">cray-mpich/8.1.28</command>
         <command name="load">cray-hdf5-parallel/1.12.2.9</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
-        <command name="load">cray-parallel-netcdf/1.12.3.9</command-->
+        <command name="load">cray-parallel-netcdf/1.12.3.9</command>
         <command name="load">cmake/3.24.3</command>
-        <command name="load">evp-patch</command>
       </modules>
     </module_system>
 

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -368,6 +368,7 @@
         <command name="unload">nvidia</command>
         <command name="unload">aocc</command>
         <command name="unload">cudatoolkit</command>
+        <command name="unload">cray-libsci</command>
         <command name="unload">climate-utils</command>
         <command name="unload">matlab</command>
         <command name="unload">craype-accel-nvidia80</command>
@@ -378,24 +379,24 @@
       </modules>
 
       <modules compiler="gnu.*">
-        <command name="load">PrgEnv-gnu/8.3.3</command>
-        <command name="load">gcc/11.2.0</command>
+        <command name="load">PrgEnv-gnu/8.5.0</command>
+        <command name="load">gcc-native/12.3</command>
       </modules>
 
       <modules compiler="nvidia.*">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/22.7</command>
+        <command name="load">nvidia/24.5</command>
       </modules>
 
       <modules compiler="gnugpu">
-        <command name="load">cudatoolkit/11.7</command>
+        <command name="load">cudatoolkit/12.2</command>
         <command name="load">craype-accel-nvidia80</command>
       </modules>
 
       <modules compiler="nvidiagpu">
-        <command name="load">cudatoolkit/11.7</command>
+        <command name="load">cudatoolkit/12.2</command>
         <command name="load">craype-accel-nvidia80</command>
-        <command name="load">gcc-mixed/11.2.0</command>
+        <command name="load">gcc-native-mixed/12.3</command>
       </modules>
 
       <modules compiler="gnu">
@@ -407,12 +408,12 @@
       </modules>
 
       <modules>
-        <command name="load">cray-libsci/23.02.1.1</command>
-        <command name="load">craype/2.7.20</command>
-        <command name="load">cray-mpich/8.1.25</command>
-        <command name="load">cray-hdf5-parallel/1.12.2.3</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
-        <command name="load">cray-parallel-netcdf/1.12.3.3</command>
+        <command name="load">cray-libsci/23.12.5</command>
+        <command name="load">craype/2.7.30</command>
+        <command name="load">cray-mpich/8.1.28</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.9</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.9</command>
         <command name="load">cmake/3.24.3</command>
       </modules>
     </module_system>


### PR DESCRIPTION
On pm-gpu, there are new default versions of several modules and this PR updates all of them. What we really want is the newer cudatoolkit version 12, but to get that version, need to also update the compiler (as NERSC made this a package update). This change updates to GNU version 12.

All of the tests we run on cdash are passing, but of course, we don't expect BFB with a newer compiler.
We don't see any major performance differences yet. 
Tried basic ne30 cases as well as a basic ne256 Cess-style case.
For the NESAP benchmark (ne1024 cess-style case) -- it actually ran quite a bit faster, but looking at timing data, the compute intensive timers were a bit slower (1-2% ?), where the IO timers were faster -- suspect that is from another PR.

I'm also updating nvidia compiler version, but we already know this currently has trouble building.
In debugging that issue, I found I needed to update the compiler, so hopefully this is a step in the direction of getting nvidia working again with SCREAM.

Note we are not updating the versions on pm-cpu in this PR.

[NBFB] only pm-gpu/muller-gpu 

