### PR TITLE
Fix bug in io with registering avg_cnt vars in Append mode.

### DIFF
--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1038,11 +1038,42 @@ register_variables(const std::string& filename,
   }
   // Now register the average count variables
   if (m_track_avg_cnt) {
+    std::string unitless = "unitless";
     for (const auto& name : m_avg_cnt_names) {
       const auto layout = m_layouts.at(name);
       auto vec_of_dims   = set_vec_of_dims(layout);
-      scorpio::define_var(filename, name, "unitless", vec_of_dims,
-                          "real",fp_precision, m_add_time_dim);
+      if (mode==scorpio::FileMode::Append) {
+        // Similar to the regular fields above, check that the var is in the file, and has the right properties
+        EKAT_REQUIRE_MSG (scorpio::has_var(filename,name),
+            "Error! Cannot append, due to variable missing from the file.\n"
+            "  - filename : " + filename + "\n"
+            "  - varname  : " + name + "\n");
+        const auto& var = scorpio::get_var(filename,name);
+        EKAT_REQUIRE_MSG (var.dim_names()==vec_of_dims,
+            "Error! Cannot append, due to variable dimensions mismatch.\n"
+            "  - filename : " + filename + "\n"
+            "  - varname  : " + name + "\n"
+            "  - var dims : " + ekat::join(vec_of_dims,",") + "\n"
+            "  - var dims from file: " + ekat::join(var.dim_names(),",") + "\n");
+        EKAT_REQUIRE_MSG (var.units==unitless,
+            "Error! Cannot append, due to variable units mismatch.\n"
+            "  - filename : " + filename + "\n"
+            "  - varname  : " + name + "\n"
+            "  - var units: " + unitless + "\n"
+            "  - var units from file: " + var.units + "\n");
+        EKAT_REQUIRE_MSG (var.time_dep==m_add_time_dim,
+            "Error! Cannot append, due to time dependency mismatch.\n"
+            "  - filename : " + filename + "\n"
+            "  - varname  : " + name + "\n"
+            "  - var time dep: " + (m_add_time_dim ? "yes" : "no") + "\n"
+            "  - var time dep from file: " + (var.time_dep ? "yes" : "no") + "\n");
+      } else {
+	// Note, unlike with regular output variables, for the average counting
+	// variables we don't need to add all of the extra metadata.  So we simply
+	// define the variable.
+        scorpio::define_var(filename, name, unitless, vec_of_dims,
+                            "real",fp_precision, m_add_time_dim);
+      }
     }
   }
 } // register_variables


### PR DESCRIPTION
This commit addresses a bug where average count tracking variables may be registered again when a file is in Append mode.  There is logic in the registration of typical output variables that was missing for average count variables.

Addresses #2898