### PR TITLE
DPxx: IOP pressure level fix and fix to lat/lon relative error checking

### DIFF
--- a/components/eamxx/src/share/iop/intensive_observation_period.cpp
+++ b/components/eamxx/src/share/iop/intensive_observation_period.cpp
@@ -541,6 +541,15 @@ read_iop_file_data (const util::TimeStamp& current_ts)
     scorpio::read_var(iop_file,"Ps",ps_data,iop_file_time_idx);
     surface_pressure.sync_to_dev();
 
+    // Read in IOP lev data
+    auto data = iop_file_pressure.get_view<Real*, Host>().data();
+    scorpio::read_var(iop_file,"lev",data);
+
+    // Convert to pressure to millibar (file gives pressure in Pa)
+    for (int ilev=0; ilev<file_levs; ++ilev) data[ilev] /= 100;
+    iop_file_pressure.sync_to_dev();
+    m_helper_fields.insert({"iop_file_pressure", iop_file_pressure});
+
     // Pre-process file pressures, store number of file levels
     // where the last level is the first level equal to surface pressure.
     const auto iop_file_pres_v = iop_file_pressure.get_view<Real*>();

--- a/components/eamxx/src/share/iop/intensive_observation_period.cpp
+++ b/components/eamxx/src/share/iop/intensive_observation_period.cpp
@@ -268,9 +268,9 @@ initialize_iop_file(const util::TimeStamp& run_t0,
   scorpio::read_var(iop_file,"lon",&iop_file_lon);
 
   const Real rel_lat_err = std::fabs(iop_file_lat - m_params.get<Real>("target_latitude"))/
-                             m_params.get<Real>("target_latitude");
+                             ekat::impl::max(m_params.get<Real>("target_latitude"),0.1);
   const Real rel_lon_err = std::fabs(std::fmod(iop_file_lon + 360.0, 360.0)-m_params.get<Real>("target_longitude"))/
-                             m_params.get<Real>("target_longitude");
+                             ekat::impl::max(m_params.get<Real>("target_longitude"),0.1);
   EKAT_REQUIRE_MSG(rel_lat_err < std::numeric_limits<float>::epsilon(),
                    "Error! IOP file variable \"lat\" does not match target_latitude from IOP parameters.\n");
   EKAT_REQUIRE_MSG(rel_lon_err < std::numeric_limits<float>::epsilon(),

--- a/components/eamxx/src/share/iop/intensive_observation_period.cpp
+++ b/components/eamxx/src/share/iop/intensive_observation_period.cpp
@@ -268,9 +268,9 @@ initialize_iop_file(const util::TimeStamp& run_t0,
   scorpio::read_var(iop_file,"lon",&iop_file_lon);
 
   const Real rel_lat_err = std::fabs(iop_file_lat - m_params.get<Real>("target_latitude"))/
-                             ekat::impl::max(m_params.get<Real>("target_latitude"),0.1);
+                             std::max(m_params.get<Real>("target_latitude"),0.1);
   const Real rel_lon_err = std::fabs(std::fmod(iop_file_lon + 360.0, 360.0)-m_params.get<Real>("target_longitude"))/
-                             ekat::impl::max(m_params.get<Real>("target_longitude"),0.1);
+                             std::max(m_params.get<Real>("target_longitude"),0.1);
   EKAT_REQUIRE_MSG(rel_lat_err < std::numeric_limits<float>::epsilon(),
                    "Error! IOP file variable \"lat\" does not match target_latitude from IOP parameters.\n");
   EKAT_REQUIRE_MSG(rel_lon_err < std::numeric_limits<float>::epsilon(),
@@ -548,7 +548,6 @@ read_iop_file_data (const util::TimeStamp& current_ts)
     // Convert to pressure to millibar (file gives pressure in Pa)
     for (int ilev=0; ilev<file_levs; ++ilev) data[ilev] /= 100;
     iop_file_pressure.sync_to_dev();
-    m_helper_fields.insert({"iop_file_pressure", iop_file_pressure});
 
     // Pre-process file pressures, store number of file levels
     // where the last level is the first level equal to surface pressure.

--- a/components/eamxx/src/share/iop/intensive_observation_period.cpp
+++ b/components/eamxx/src/share/iop/intensive_observation_period.cpp
@@ -268,9 +268,9 @@ initialize_iop_file(const util::TimeStamp& run_t0,
   scorpio::read_var(iop_file,"lon",&iop_file_lon);
 
   const Real rel_lat_err = std::fabs(iop_file_lat - m_params.get<Real>("target_latitude"))/
-                             std::max(m_params.get<Real>("target_latitude"),0.1);
+                             std::max(m_params.get<Real>("target_latitude"),(Real)0.1);
   const Real rel_lon_err = std::fabs(std::fmod(iop_file_lon + 360.0, 360.0)-m_params.get<Real>("target_longitude"))/
-                             std::max(m_params.get<Real>("target_longitude"),0.1);
+                             std::max(m_params.get<Real>("target_longitude"),(Real)0.1);
   EKAT_REQUIRE_MSG(rel_lat_err < std::numeric_limits<float>::epsilon(),
                    "Error! IOP file variable \"lat\" does not match target_latitude from IOP parameters.\n");
   EKAT_REQUIRE_MSG(rel_lon_err < std::numeric_limits<float>::epsilon(),


### PR DESCRIPTION
Fix to read in IOP pressure level data each time the IOP file is read.  This prevents the persistence of IOP pressure level data, which may be adjusted due to the surface pressure and occasionally may result in pressure increasing with height and hence crashes.

In addition, fix an issue where the IOP lat and lon is checked to be consistent with that provided by case specifications.  The relative error checker divides by the lat and lon, which creates NaNs when either of these is 0.  Thus introduce a minimum threshold (0.1 degree).

This PR will not be b4b for DPxx, answer changes are expected.