### PR TITLE
fix a minor warning in hasher

### DIFF
--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -129,7 +129,7 @@ void AtmosphereProcess
   if (m_comm.am_i_root())
     for (int i = 0; i < nslot; ++i)
       if (show[i])
-        fprintf(stderr, "exxhash> %4d-%9.5f %1d %16llx (%s)\n",
+        fprintf(stderr, "exxhash> %4d-%9.5f %1d %16lx (%s)\n",
                 timestamp().get_year(), timestamp().frac_of_year_in_days(),
                 i, gaccum[i], label.c_str());
 }

--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -140,7 +140,7 @@ void AtmosphereProcess::print_fast_global_state_hash (const std::string& label) 
   HashType gaccum;
   bfbhash::all_reduce_HashType(m_comm.mpi_comm(), &laccum, &gaccum, 1);
   if (m_comm.am_i_root())
-    fprintf(stderr, "bfbhash> %14d %16llx (%s)\n",
+    fprintf(stderr, "bfbhash> %14d %16lx (%s)\n",
             timestamp().get_num_steps(), gaccum, label.c_str());
 }
 


### PR DESCRIPTION
The warning takes the form of
```
/home/conda/feedstock_root/build_artifacts/pyscream_1720908292184/work/scream/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp:132:54: warning: format '%llx' expects argument of type 'long long unsigned int', but argument 6 has type 'scream::bfbhash::HashType' {aka 'long unsigned int'} [-Wformat=]
  132 |         fprintf(stderr, "exxhash> %4d-%9.5f %1d %16llx (%s)\n",
      |                                                 ~~~~~^
      |                                                      |
      |                                                      long long unsigned int
      |                                                 %16lx
  133 |                 timestamp().get_year(), timestamp().frac_of_year_in_days(),
  134 |                 i, gaccum[i], label.c_str());
      |                    ~~~~~~~~~                          
      |                            |
      |                            scream::bfbhash::HashType {aka long unsigned int}
/home/conda/feedstock_root/build_artifacts/pyscream_1720908292184/work/scream/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp: In member function 'void scream::AtmosphereProcess::print_fast_global_state_hash(const std::string&) const':
/home/conda/feedstock_root/build_artifacts/pyscream_1720908292184/work/scream/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp:143:41: warning: format '%llx' expects argument of type 'long long unsigned int', but argument 4 has type 'scream::bfbhash::HashType' {aka 'long unsigned int'} [-Wformat=]
  143 |     fprintf(stderr, "bfbhash> %14d %16llx (%s)\n",
      |                                    ~~~~~^
      |                                         |
      |                                         long long unsigned int
      |                                    %16lx
  144 |             timestamp().get_num_steps(), gaccum, label.c_str());
      |                                          ~~~~~~
      |                                          |
      |                                          scream::bfbhash::HashType {aka long unsigned int}
```

taken from here: https://github.com/mahf708/experimental-scream-feedstock/actions/runs/9923142784/job/27412982688#step:3:1452