### PR TITLE
Add ustar and obklen to FM

### DIFF
--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -395,7 +395,6 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   add_postcondition_check<Interval>(get_field_out("qc"),m_grid,0.0,0.1,false);
   add_postcondition_check<Interval>(get_field_out("horiz_winds"),m_grid,-400.0,400.0,false);
   add_postcondition_check<LowerBound>(get_field_out("pbl_height"),m_grid,0);
-  add_postcondition_check<LowerBound>(get_field_out("obklen"),m_grid,0);
   add_postcondition_check<Interval>(get_field_out("cldfrac_liq"),m_grid,0.0,1.0,false);
   add_postcondition_check<LowerBound>(get_field_out("tke"),m_grid,0);
   // For qv, ensure it doesn't get negative, by allowing repair of any neg value.

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -88,6 +88,8 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   add_field<Computed>("eddy_diff_heat",   scalar3d_mid, m2/s,        grid_name, ps);
   add_field<Computed>("w_variance",       scalar3d_mid, m2/s2,       grid_name, ps);
   add_field<Computed>("cldfrac_liq_prev", scalar3d_mid, nondim,      grid_name, ps);
+  add_field<Computed>("ustar",            scalar2d,     m/s,         grid_name, ps);
+  add_field<Computed>("obklen",           scalar2d,     m,           grid_name, ps);
 
   // Tracer group
   add_group<Updated>("tracers", grid_name, ps, Bundling::Required);
@@ -157,7 +159,7 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
 #ifdef SCREAM_SMALL_KERNELS
      , &m_buffer.se_b, &m_buffer.ke_b, &m_buffer.wv_b, &m_buffer.wl_b
      , &m_buffer.se_a, &m_buffer.ke_a, &m_buffer.wv_a, &m_buffer.wl_a
-     , &m_buffer.ustar, &m_buffer.kbfs, &m_buffer.obklen, &m_buffer.ustar2, &m_buffer.wstar
+     , &m_buffer.kbfs, &m_buffer.ustar2, &m_buffer.wstar
 #endif
     };
   for (int i = 0; i < Buffer::num_1d_scalar_ncol; ++i) {
@@ -332,6 +334,8 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   output.pblh     = get_field_out("pbl_height").get_view<Real*>();
   output.shoc_ql2 = shoc_ql2;
   output.tkh      = get_field_out("eddy_diff_heat").get_view<Spack**>();
+  output.ustar    = get_field_out("ustar").get_view<Real*>();
+  output.obklen   = get_field_out("obklen").get_view<Real*>();
 
   // Ouput (diagnostic)
   history_output.shoc_mix  = m_buffer.shoc_mix;
@@ -358,9 +362,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   temporaries.ke_a = m_buffer.ke_a;
   temporaries.wv_a = m_buffer.wv_a;
   temporaries.wl_a = m_buffer.wl_a;
-  temporaries.ustar = m_buffer.ustar;
   temporaries.kbfs = m_buffer.kbfs;
-  temporaries.obklen = m_buffer.obklen;
   temporaries.ustar2 = m_buffer.ustar2;
   temporaries.wstar = m_buffer.wstar;
 
@@ -393,6 +395,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   add_postcondition_check<Interval>(get_field_out("qc"),m_grid,0.0,0.1,false);
   add_postcondition_check<Interval>(get_field_out("horiz_winds"),m_grid,-400.0,400.0,false);
   add_postcondition_check<LowerBound>(get_field_out("pbl_height"),m_grid,0);
+  add_postcondition_check<LowerBound>(get_field_out("obklen"),m_grid,0);
   add_postcondition_check<Interval>(get_field_out("cldfrac_liq"),m_grid,0.0,1.0,false);
   add_postcondition_check<LowerBound>(get_field_out("tke"),m_grid,0);
   // For qv, ensure it doesn't get negative, by allowing repair of any neg value.

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
@@ -388,7 +388,7 @@ public:
 #ifndef SCREAM_SMALL_KERNELS
     static constexpr int num_1d_scalar_ncol = 4;
 #else
-    static constexpr int num_1d_scalar_ncol = 17;
+    static constexpr int num_1d_scalar_ncol = 15;
 #endif
     static constexpr int num_1d_scalar_nlev = 1;
 #ifndef SCREAM_SMALL_KERNELS
@@ -413,9 +413,7 @@ public:
     uview_1d<Real> ke_a;
     uview_1d<Real> wv_a;
     uview_1d<Real> wl_a;
-    uview_1d<Real> ustar;
     uview_1d<Real> kbfs;
-    uview_1d<Real> obklen;
     uview_1d<Real> ustar2;
     uview_1d<Real> wstar;
 #endif

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -118,6 +118,8 @@ void Functions<S,D>::shoc_main_internal(
   const uview_1d<Spack>&       shoc_ql,
   // Output Variables
   Scalar&                      pblh,
+  Scalar&                      ustar,
+  Scalar&                      obklen,
   const uview_1d<Spack>&       shoc_ql2,
   const uview_1d<Spack>&       tkh,
   // Diagnostic Output Variables
@@ -144,9 +146,9 @@ void Functions<S,D>::shoc_main_internal(
     {&rho_zt, &shoc_qv, &shoc_tabs, &dz_zt, &dz_zi});
 
   // Local scalars
-  Scalar se_b{0},   ke_b{0}, wv_b{0},   wl_b{0},
-         se_a{0},   ke_a{0}, wv_a{0},   wl_a{0},
-         ustar{0},  kbfs{0}, obklen{0}, ustar2{0}, wstar{0};
+  Scalar se_b{0},   ke_b{0},   wv_b{0}, wl_b{0},
+         se_a{0},   ke_a{0},   wv_a{0}, wl_a{0},
+         kbfs{0},   ustar2{0}, wstar{0};
 
   // Scalarize some views for single entry access
   const auto s_thetal  = ekat::scalarize(thetal);
@@ -371,6 +373,8 @@ void Functions<S,D>::shoc_main_internal(
   const view_2d<Spack>&       shoc_ql,
   // Output Variables
   const view_1d<Scalar>&      pblh,
+  const view_1d<Scalar>&      ustar,
+  const view_1d<Scalar>&      obklen,
   const view_2d<Spack>&       shoc_ql2,
   const view_2d<Spack>&       tkh,
   // Diagnostic Output Variables
@@ -397,9 +401,7 @@ void Functions<S,D>::shoc_main_internal(
   const view_1d<Scalar>& ke_a,
   const view_1d<Scalar>& wv_a,
   const view_1d<Scalar>& wl_a,
-  const view_1d<Scalar>& ustar,
   const view_1d<Scalar>& kbfs,
-  const view_1d<Scalar>& obklen,
   const view_1d<Scalar>& ustar2,
   const view_1d<Scalar>& wstar,
   const view_2d<Spack>& rho_zt,
@@ -625,6 +627,8 @@ Int Functions<S,D>::shoc_main(
     const Scalar vw_sfc_s{shoc_input.vw_sfc(i)};
     const Scalar phis_s{shoc_input.phis(i)};
     Scalar pblh_s{0};
+    Scalar ustar_s{0};
+    Scalar obklen_s{0};
 
     const auto zt_grid_s      = ekat::subview(shoc_input.zt_grid, i);
     const auto zi_grid_s      = ekat::subview(shoc_input.zi_grid, i);
@@ -676,7 +680,7 @@ Int Functions<S,D>::shoc_main(
                        host_dse_s, tke_s, thetal_s, qw_s, u_wind_s, v_wind_s, // Input/Output
                        wthv_sec_s, qtracers_s, tk_s, shoc_cldfrac_s,          // Input/Output
                        shoc_ql_s,                                             // Input/Output
-                       pblh_s, shoc_ql2_s, tkh_s,                             // Output
+                       pblh_s, ustar_s, obklen_s, shoc_ql2_s, tkh_s,          // Output
                        shoc_mix_s, w_sec_s, thl_sec_s, qw_sec_s, qwthl_sec_s, // Diagnostic Output Variables
                        wthl_sec_s, wqw_sec_s, wtke_sec_s, uw_sec_s, vw_sec_s, // Diagnostic Output Variables
                        w3_s, wqls_sec_s, brunt_s, isotropy_s);                // Diagnostic Output Variables
@@ -700,14 +704,14 @@ Int Functions<S,D>::shoc_main(
     shoc_input_output.host_dse, shoc_input_output.tke, shoc_input_output.thetal, shoc_input_output.qw, u_wind_s, v_wind_s, // Input/Output
     shoc_input_output.wthv_sec, shoc_input_output.qtracers, shoc_input_output.tk, shoc_input_output.shoc_cldfrac, // Input/Output
     shoc_input_output.shoc_ql, // Input/Output
-    shoc_output.pblh, shoc_output.shoc_ql2, shoc_output.tkh, // Output
+    shoc_output.pblh, shoc_output.ustar, shoc_output.obklen, shoc_output.shoc_ql2, shoc_output.tkh, // Output
     shoc_history_output.shoc_mix, shoc_history_output.w_sec, shoc_history_output.thl_sec, shoc_history_output.qw_sec, shoc_history_output.qwthl_sec, // Diagnostic Output Variables
     shoc_history_output.wthl_sec, shoc_history_output.wqw_sec, shoc_history_output.wtke_sec, shoc_history_output.uw_sec, shoc_history_output.vw_sec, // Diagnostic Output Variables
     shoc_history_output.w3, shoc_history_output.wqls_sec, shoc_history_output.brunt, shoc_history_output.isotropy, // Diagnostic Output Variables
     // Temporaries
     shoc_temporaries.se_b, shoc_temporaries.ke_b, shoc_temporaries.wv_b, shoc_temporaries.wl_b,
     shoc_temporaries.se_a, shoc_temporaries.ke_a, shoc_temporaries.wv_a, shoc_temporaries.wl_a,
-    shoc_temporaries.ustar, shoc_temporaries.kbfs, shoc_temporaries.obklen, shoc_temporaries.ustar2,
+    shoc_temporaries.kbfs, shoc_temporaries.ustar2,
     shoc_temporaries.wstar, shoc_temporaries.rho_zt, shoc_temporaries.shoc_qv,
     shoc_temporaries.tabs, shoc_temporaries.dz_zt, shoc_temporaries.dz_zi);
 #endif

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -686,6 +686,8 @@ Int Functions<S,D>::shoc_main(
                        w3_s, wqls_sec_s, brunt_s, isotropy_s);                // Diagnostic Output Variables
 
     shoc_output.pblh(i) = pblh_s;
+    shoc_output.ustar(i) = ustar_s;
+    shoc_output.obklen(i) = obklen_s;
   });
   Kokkos::fence();
 #else

--- a/components/eamxx/src/physics/shoc/shoc_functions.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions.hpp
@@ -159,6 +159,10 @@ struct Functions
 
     // planetary boundary layer depth [m]
     view_1d<Scalar> pblh;
+    // surface friction velocity [m/s]
+    view_1d<Scalar> ustar;
+    // Monin Obukhov length [m]
+    view_1d<Scalar> obklen;
     // cloud liquid mixing ratio variance [kg^2/kg^2]
     view_2d<Spack>  shoc_ql2;
     // eddy coefficient for heat [m2/s]
@@ -211,9 +215,7 @@ struct Functions
     view_1d<Scalar> ke_a;
     view_1d<Scalar> wv_a;
     view_1d<Scalar> wl_a;
-    view_1d<Scalar> ustar;
     view_1d<Scalar> kbfs;
-    view_1d<Scalar> obklen;
     view_1d<Scalar> ustar2;
     view_1d<Scalar> wstar;
 
@@ -889,6 +891,8 @@ struct Functions
     const uview_1d<Spack>&       shoc_ql,
     // Output Variables
     Scalar&                      pblh,
+    Scalar&                      ustar,
+    Scalar&                      obklen,
     const uview_1d<Spack>&       shoc_ql2,
     const uview_1d<Spack>&       tkh,
     // Diagnostic Output Variables
@@ -961,6 +965,8 @@ struct Functions
     const view_2d<Spack>&       shoc_ql,
     // Output Variables
     const view_1d<Scalar>&      pblh,
+    const view_1d<Scalar>&      ustar,
+    const view_1d<Scalar>&      obklen,
     const view_2d<Spack>&       shoc_ql2,
     const view_2d<Spack>&       tkh,
     // Diagnostic Output Variables
@@ -987,9 +993,7 @@ struct Functions
     const view_1d<Scalar>& ke_a,
     const view_1d<Scalar>& wv_a,
     const view_1d<Scalar>& wl_a,
-    const view_1d<Scalar>& ustar,
     const view_1d<Scalar>& kbfs,
-    const view_1d<Scalar>& obklen,
     const view_1d<Scalar>& ustar2,
     const view_1d<Scalar>& wstar,
     const view_2d<Spack>& rho_zt,

--- a/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions_f90.cpp
@@ -2801,7 +2801,9 @@ Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, 
     uw_sfc_d  (temp_1d_d[index_counter++]),
     vw_sfc_d  (temp_1d_d[index_counter++]),
     phis_d    (temp_1d_d[index_counter++]),
-    pblh_d    ("pblh",shcol);
+    pblh_d    ("pblh",shcol),
+    ustar_d   ("ustar",shcol),
+    obklen_d  ("obklen",shcol);
 
   index_counter = 0;
   view_2d
@@ -2878,7 +2880,7 @@ Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, 
   SHF::SHOCInputOutput shoc_input_output{host_dse_d,   tke_d,      thetal_d,       qw_d,
                                          horiz_wind_d, wthv_sec_d, qtracers_cxx_d,
                                          tk_d,         shoc_cldfrac_d, shoc_ql_d};
-  SHF::SHOCOutput shoc_output{pblh_d, shoc_ql2_d, tkh_d};
+  SHF::SHOCOutput shoc_output{pblh_d, ustar_d, obklen_d, shoc_ql2_d, tkh_d};
   SHF::SHOCHistoryOutput shoc_history_output{shoc_mix_d,  w_sec_d,    thl_sec_d, qw_sec_d,
                                              qwthl_sec_d, wthl_sec_d, wqw_sec_d, wtke_sec_d,
                                              uw_sec_d,    vw_sec_d,   w3_d,      wqls_sec_d,
@@ -2897,9 +2899,7 @@ Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, 
     ke_a   ("ke_a", shcol),
     wv_a   ("wv_a", shcol),
     wl_a   ("wl_a", shcol),
-    ustar  ("ustar", shcol),
     kbfs   ("kbfs", shcol),
-    obklen ("obklen", shcol),
     ustar2 ("ustar2", shcol),
     wstar  ("wstar", shcol);
 
@@ -2911,7 +2911,7 @@ Int shoc_main_f(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npbl, 
     dz_zi   ("dz_zi",   shcol, nlevi_packs);
 
   SHF::SHOCTemporaries shoc_temporaries{
-    se_b, ke_b, wv_b, wl_b, se_a, ke_a, wv_a, wl_a, ustar, kbfs, obklen, ustar2, wstar,
+    se_b, ke_b, wv_b, wl_b, se_a, ke_a, wv_a, wl_a, kbfs, ustar2, wstar,
     rho_zt, shoc_qv, tabs, dz_zt, dz_zi};
 #endif
 


### PR DESCRIPTION
Add `ustar` and `obklen` to FM in SHOC interface (needed for MAM4xx interface).