### PR TITLE
fix capture this warning in mam micro

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -317,6 +317,8 @@ void MAMMicrophysics::run_impl(const double dt) {
   // FIXME: read relevant chlorine loading data from file based on time
 
   // loop over atmosphere columns and compute aerosol microphyscs
+  auto some_step = step_;
+
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const ThreadTeam& team) {
     const int icol = team.league_rank(); // column index
 
@@ -448,7 +450,7 @@ void MAMMicrophysics::run_impl(const double dt) {
       impl::compute_water_content(progs, k, qv, temp, pmid, dgncur_a, dgncur_awet, wetdens, qaerwat);
 
       // do aerosol microphysics (gas-aerosol exchange, nucleation, coagulation)
-      impl::modal_aero_amicphys_intr(config.amicphys, step_, dt, t, pmid, pdel,
+      impl::modal_aero_amicphys_intr(config.amicphys, some_step, dt, t, pmid, pdel,
                                      zm, pblh, qv, cldfrac, vmr, vmrcw, vmr_pregaschem,
                                      vmr_precldchem, vmrcw_precldchem, vmr_tendbb,
                                      vmrcw_tendbb, dgncur_a, dgncur_awet,


### PR DESCRIPTION
I am not entirely sure if this step_ gets ever updated; it doesn't look like it. Anyway, we cannot use members deep inside kernels automatically (it is only a warning, but sometimes it becomes an error). Fixing here to avoid the warning.