### PR TITLE
Add runtime and buildnml-time checks on output frequency

### DIFF
--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -328,7 +328,11 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     return;
   }
 
-  EKAT_REQUIRE_MSG (timestamp<=m_output_control.next_write_ts,
+  // Ensure we did not go past the scheduled write time without hitting it
+  EKAT_REQUIRE_MSG (
+      (m_output_control.frequency_units=="nsteps"
+          ? timestamp.get_num_steps()<=m_output_control.next_write_ts.get_num_steps()
+          : timestamp<=m_output_control.next_write_ts),
       "Error! The input timestamp is past the next scheduled write timestamp.\n"
       "  - current time stamp   : " + timestamp.to_string() + "\n"
       "  - next write time stamp: " + m_output_control.next_write_ts.to_string() + "\n"

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -328,6 +328,13 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     return;
   }
 
+  EKAT_REQUIRE_MSG (timestamp<=m_output_control.next_write_ts,
+      "Error! The input timestamp is past the next scheduled write timestamp.\n"
+      "  - current time stamp   : " + timestamp.to_string() + "\n"
+      "  - next write time stamp: " + m_output_control.next_write_ts.to_stirng() + "\n"
+      "The most likely cause is an output frequency that is faster than the atm timestep.\n"
+      "Try to increase 'Frequency' and/or 'frequency_units' in your output yaml file.\n");
+
   // Update counters
   ++m_output_control.nsamples_since_last_write;
   ++m_checkpoint_control.nsamples_since_last_write;

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -331,7 +331,7 @@ void OutputManager::run(const util::TimeStamp& timestamp)
   EKAT_REQUIRE_MSG (timestamp<=m_output_control.next_write_ts,
       "Error! The input timestamp is past the next scheduled write timestamp.\n"
       "  - current time stamp   : " + timestamp.to_string() + "\n"
-      "  - next write time stamp: " + m_output_control.next_write_ts.to_stirng() + "\n"
+      "  - next write time stamp: " + m_output_control.next_write_ts.to_string() + "\n"
       "The most likely cause is an output frequency that is faster than the atm timestep.\n"
       "Try to increase 'Frequency' and/or 'frequency_units' in your output yaml file.\n");
 


### PR DESCRIPTION
Ensures dt_output is not smaller than dt_atm, which would cause empty output files. I ran case.setup with an output file with frequency=1800s, for a case with dt_atm=3600s, and got the error
```
ERROR: Cannot have output frequency faster than atm timestep.
  yaml file: /home/lbertag/acme/scratch/SMS.ne4pg2_ne4pg2.F2010-SCREAMv1.groppello_gnu.20240725_082320_8zpnc3/output.yaml
   Frequency: 1800
   frequency_units: nsecs
   ATM_NCPL: 24
 This yields dt_atm=3600.0 > dt_output=1800. Please, adjust 'Frequency' and/or 'frequency_units'
```

Fixes #2891 .