### PR TITLE
Add support for ne512pg2 bi-grid

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1683,6 +1683,26 @@
       <mask>oRRS18to6v3</mask>
     </model_grid>
 
+    <model_grid alias="ne512pg2_ICOS10">
+      <grid name="atm">ne512np4.pg2</grid>
+      <grid name="lnd">ne512np4.pg2</grid>
+      <grid name="ocnice">ICOS10</grid>
+      <grid name="rof">r0125</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>ICOS10</mask>
+    </model_grid>
+
+    <model_grid alias="ne512pg2_ne512pg2">
+      <grid name="atm">ne512np4.pg2</grid>
+      <grid name="lnd">ne512np4.pg2</grid>
+      <grid name="ocnice">ne512np4.pg2</grid>
+      <grid name="rof">r0125</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>ICOS10</mask>
+    </model_grid>
+
     <model_grid alias="ne512np4_360x720cru_ne512np4">
       <grid name="atm">ne512np4</grid>
       <grid name="lnd">360x720cru</grid>
@@ -2894,6 +2914,8 @@
       <ny>1</ny>
       <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne512pg2_oRRS18to6v3.200212.nc</file>
       <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne512pg2_oRRS18to6v3.200212.nc</file>
+      <file grid="atm|lnd" mask="ICOS10">$DIN_LOC_ROOT/share/domains/domain.lnd.ne512pg2_ICOS10.240602.nc</file>
+      <file grid="ice|ocn" mask="ICOS10">$DIN_LOC_ROOT/share/domains/domain.ocn.ne512pg2_ICOS10.240602.nc</file>
       <desc>ne512np4.pg2 is Spectral Elem 6km grid w/ 2x2 FV physics grid per element:</desc>
     </domain>
 
@@ -3934,6 +3956,11 @@
       <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne256pg2/map_ne256pg2_to_r0125_bilin.200212.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ne512np4.pg2" rof_grid="r0125">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne512pg2/map_ne512pg2_to_r0125_mono.c20240625.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne512pg2/map_ne512pg2_to_r0125_mono.c20240625.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="ne512np4.pg2" ocn_grid="oRRS18to6v3">
       <!-- 6km atm /  18to6 ocean, so use bilin for state -->
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne512pg2/map_ne512pg2_to_oRRS18to6v3_nco.200212.nc</map>
@@ -3941,6 +3968,15 @@
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne512pg2/map_ne512pg2_to_oRRS18to6v3_bilin.200212.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne512pg2/map_oRRS18to6v3_to_ne512pg2_nco.200212.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne512pg2/map_oRRS18to6v3_to_ne512pg2_nco.200212.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne512np4.pg2" ocn_grid="ICOS10">
+      <!-- 6km atm to 7.5 km ICOS10 ocean, so also use nco for state -->
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne512pg2/map_ne512pg2_to_ICOS10_nco_c240531.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne512pg2/map_ne512pg2_to_ICOS10_nco_c240531.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne512pg2/map_ne512pg2_to_ICOS10_nco_c240531.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne512pg2/map_ICOS10_to_ne512pg2_nco_c240531.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne512pg2/map_ICOS10_to_ne512pg2_nco_c240531.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne512np4.pg2" lnd_grid="r0125">
@@ -4717,6 +4753,11 @@
       <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne256pg2/map_r0125_to_ne256pg2_mono.200212.nc</map>
     </gridmap>
 
+    <gridmap lnd_grid="ne5124np4.pg2" rof_grid="r0125">
+      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne512pg2/map_ne512pg2_to_r0125_mono.c20240625.nc</map>
+      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne512pg2/map_r0125_to_ne512pg2_mono.c20240625.nc</map>
+    </gridmap>
+
     <gridmap lnd_grid="ne1024np4.pg2" rof_grid="r0125">
       <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne1024pg2/map_ne1024pg2_to_r0125_mono.200212.nc</map>
       <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne1024pg2/map_r0125_to_ne1024pg2_mono.200212.nc</map>
@@ -4795,6 +4836,11 @@
     <gridmap lnd_grid="ne240np4" rof_grid="r05">
       <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne240np4/map_ne240np4_nomask_to_0.5x0.5_nomask_aave_da_c110922.nc</map>
       <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne240np4/map_0.5x0.5_nomask_to_ne240np4_nomask_aave_da_c121019.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="ne512np4.pg2" rof_grid="r0125">
+      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne512pg2/map_ne512pg2_to_r0125_mono.c20240625.nc</map>
+      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne512pg2/map_r0125_to_ne512pg2_mono.c20240625.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne1024np4.pg2" rof_grid="r0125">

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -517,10 +517,10 @@ be lost if SCREAM_HACK_XML is not enabled.
     <num_c4 type="real">0.0</num_c4>
     <!-- default ne1024 initial condition files do not have these, so init to zero here -->
     <!-- TODO: delete this once we can tell the AD that some fields can be inited by procs -->
-    <qc hgrid="ne256np4|ne1024np4">0.0</qc>
-    <qi hgrid="ne256np4|ne1024np4">0.0</qi>
-    <nc hgrid="ne256np4|ne1024np4">0.0</nc>
-    <ni hgrid="ne256np4|ne1024np4">0.0</ni>
+    <qc hgrid="ne256np4|ne512np4|ne1024np4">0.0</qc>
+    <qi hgrid="ne256np4|ne512np4|ne1024np4">0.0</qi>
+    <nc hgrid="ne256np4|ne512np4|ne1024np4">0.0</nc>
+    <ni hgrid="ne256np4|ne512np4|ne1024np4">0.0</ni>
     <o3_volume_mix_ratio hgrid="ne0np4_conus_x4v1_lowcon">0.0</o3_volume_mix_ratio>
 
     <!-- Information about perturbed fields-->

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -306,6 +306,8 @@ lnd/clm2/surfdata_map/surfdata_ne120pg2_simyr2010_c230119.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne256pg2_simyr1850_c240131.nc</fsurdat>
 <fsurdat hgrid="ne256np4.pg2" sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne256pg2_simyr2010_c230207.nc</fsurdat>
+<fsurdat hgrid="ne512np4.pg2"   sim_year="2010" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_ne512pg2_simyr2010_c240522.nc</fsurdat>
 <fsurdat hgrid="ne1024np4.pg2"   sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne1024pg2_simyr2010_c211021.nc</fsurdat>
 <fsurdat hgrid="ne1024np4"   sim_year="2010" use_crop=".false." >

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1409,7 +1409,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne120np4.pg2,ne240np4,ne256np4,ne256np4.pg2,ne1024np4,ne1024np4.pg2,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r2,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2,ne0np4_arcticx4v1.pg2,r025">
+"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne120np4.pg2,ne240np4,ne256np4,ne256np4.pg2,ne512np4.pg2,ne1024np4,ne1024np4.pg2,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r2,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2,ne0np4_arcticx4v1.pg2,r025">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry>

--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -1527,6 +1527,7 @@
       <value atm_grid="ne1024np4.pg2" lnd_grid="ne1024np4.pg2">1.e-10</value>
       <value atm_grid="ne120np4.pg2" lnd_grid="ne120np4.pg2">1.e-10</value>
       <value atm_grid="ne256np4.pg2" lnd_grid="ne256np4.pg2">1.e-10</value>
+      <value atm_grid="ne512np4.pg2" lnd_grid="ne512np4.pg2">1.e-10</value>
     </values>
   </entry>
 


### PR DESCRIPTION
Enable ne512pg2_ne512pg2 and be512pg2_ICOS10 grids. 
The latter has ocean and ice on ICOS10 mesh. 
Both use ICOS10 ocean mask.

[BFB] no other grids are affected