### PR TITLE
Remove multiprocess tests for compute sanitizer

### DIFF
--- a/components/eamxx/tests/CMakeLists.txt
+++ b/components/eamxx/tests/CMakeLists.txt
@@ -68,9 +68,13 @@ if (NOT DEFINED ENV{SCREAM_FAKE_ONLY})
   # Testing individual atm processes
   add_subdirectory(single-process)
 
-  # Testing multiple atm processes coupled together
-  add_subdirectory(multi-process)
-
+  # Testing multiple atm processes coupled together.
+  # Some compute-sanitizer tests time out with these
+  # larger multiprocess tests, so disable in that case.
+  if (NOT EKAT_ENABLE_COMPUTE_SANITIZER)
+    add_subdirectory(multi-process)
+  endif()
+  
   if (EAMXX_ENABLE_PYBIND)
     add_subdirectory(python)
   endif()


### PR DESCRIPTION
The multi-process unit tests were quite a strain on the compute sanitizer racecheck. Even without dynamics, they would take around 20-40 min each. I think with the addition of some mam tests, this has made the CSR test start timing out consistently.

A quick solution is to just disable them for compute sanitizer tests. All processes should be touched in the single process tests.

Let me know thoughts. Are we missing out on anything valuable by doing this?

Other options:
- still run a subset of the multi-process tests
- only do this for racecheck (instead of init, sync, and mem, which do not have problems running all these tests)