### PR TITLE
Frontier: use cpe/22.12 in the post-maintenance configuration

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1434,10 +1434,10 @@
       <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
       <modules compiler="crayclang-scream">
         <command name="reset"></command>
-        <command name="load">PrgEnv-cray</command>
+        <command name="load">cpe/22.12</command>
         <command name="load">craype-accel-amd-gfx90a</command>
         <command name="load">rocm/5.4.0</command>
-        <command name="load">libunwind/1.5.0</command>
+        <command name="load">libunwind/1.6.2</command>
       </modules>
       <modules>
         <command name="load">cce/15.0.1</command>


### PR DESCRIPTION
The change in the default cpe version (22.12 -> 23.12) may be one
of the main breaking changes for post-maintenance SCREAM builds.

Trey White recommended using cpe/22.12 to get as close as possible
to the pre-maintenance configuration.