### PR TITLE
Update DPxx tests to run with PG2 grid

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -657,10 +657,10 @@ _TESTS = {
         "time"  : "01:00:00",
         # each test 225 phys cols, roughly size of ne2
         "tests" : (
-            "ERS_P16_Ln22.ne30_ne30.FIOP-SCREAMv1-DP.scream-dpxx-dycomsrf01",
-            "ERS_P16_Ln22.ne30_ne30.FIOP-SCREAMv1-DP.scream-dpxx-arm97",
-            "ERS_P16_Ln22.ne30_ne30.FIOP-SCREAMv1-DP.scream-dpxx-comble",
-            "ERS_P16_Ln22.ne30_ne30.FRCE-SCREAMv1-DP",
+            "ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.scream-dpxx-dycomsrf01",
+            "ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.scream-dpxx-arm97",
+            "ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.scream-dpxx-comble",
+            "ERS_P16_Ln22.ne30pg2_ne30pg2.FRCE-SCREAMv1-DP",
             )
     },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -654,7 +654,7 @@ _TESTS = {
     },
 
     "e3sm_scream_v1_dp-eamxx" : {
-        "time"  : "00:30:00",
+        "time"  : "01:00:00",
         # each test runs with 225 dynamics and 100 physics columns, roughly size of ne2
         "tests" : (
             "ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.scream-dpxx-dycomsrf01",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -654,8 +654,8 @@ _TESTS = {
     },
 
     "e3sm_scream_v1_dp-eamxx" : {
-        "time"  : "01:00:00",
-        # each test 225 phys cols, roughly size of ne2
+        "time"  : "00:30:00",
+        # each test runs with 225 dynamics and 100 physics columns, roughly size of ne2
         "tests" : (
             "ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.scream-dpxx-dycomsrf01",
             "ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.scream-dpxx-arm97",

--- a/components/eamxx/cime_config/config_compsets.xml
+++ b/components/eamxx/cime_config/config_compsets.xml
@@ -117,7 +117,7 @@
 
     <entry id="PTS_NX">
       <values>
-        <value  compset=".*DP-EAMxx">225</value>
+        <value  compset=".*DP-EAMxx">100</value>
       </values>
     </entry>
 
@@ -129,7 +129,7 @@
 
     <entry id="ICE_NX">
       <values>
-        <value  compset=".*DP-EAMxx">225</value>
+        <value  compset=".*DP-EAMxx">100</value>
       </values>
     </entry>
 


### PR DESCRIPTION
At long last we are able to run DP mode with PG2.  This PR modifies all DPxx tests so that they use PG2 by default.

Note that I verified that DPxx simulations with PG2 perform scientifically as expected and produce credible results in all the cases I test (about 10).