### PR TITLE
fix errors and warning in rrtmgp-k

### DIFF
--- a/components/eamxx/src/physics/rrtmgp/rrtmgp_utils.hpp
+++ b/components/eamxx/src/physics/rrtmgp/rrtmgp_utils.hpp
@@ -112,7 +112,7 @@ bool check_range(T x, Real xmin, Real xmax, std::string msg, std::ostream& out=s
 }
 #endif
 #ifdef RRTMGP_ENABLE_KOKKOS
-template <class T, typename std::enable_if<T::rank == 1>::type* = nullptr>
+template <class T, typename std::enable_if<T::rank == 1>::type* dummy = nullptr>
 bool check_range_k(T x, typename T::const_value_type xmin, typename T::const_value_type xmax,
                    std::string msg, std::ostream& out=std::cout) {
   bool pass = true;
@@ -137,7 +137,7 @@ bool check_range_k(T x, typename T::const_value_type xmin, typename T::const_val
   return pass;
 }
 
-template <class T, typename std::enable_if<T::rank == 2>::type* = nullptr>
+template <class T, typename std::enable_if<T::rank == 2>::type* dummy = nullptr>
 bool check_range_k(T x, typename T::const_value_type xmin, typename T::const_value_type xmax,
                    std::string msg, std::ostream& out=std::cout) {
   bool pass = true;
@@ -166,7 +166,7 @@ bool check_range_k(T x, typename T::const_value_type xmin, typename T::const_val
   return pass;
 }
 
-template <class T, typename std::enable_if<T::rank == 3>::type* = nullptr>
+template <class T, typename std::enable_if<T::rank == 3>::type* dummy = nullptr>
 bool check_range_k(T x, typename T::const_value_type xmin, typename T::const_value_type xmax,
                    std::string msg, std::ostream& out=std::cout) {
   bool pass = true;

--- a/components/eamxx/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
+++ b/components/eamxx/src/physics/rrtmgp/scream_rrtmgp_interface.hpp
@@ -1190,14 +1190,14 @@ static void mixing_ratio_to_cloud_mass(
  * property look-up tables, but could be used to limit other
  * fields as well.
  */
-template<typename InT, typename T, typename OutT, typename std::enable_if<OutT::rank == 1>::type* = nullptr>
+template<typename InT, typename T, typename OutT, typename std::enable_if<OutT::rank == 1>::type* dummy = nullptr>
 static void limit_to_bounds_k(InT const &arr_in, T const lower, T const upper, OutT &arr_out) {
   Kokkos::parallel_for(arr_out.size(), KOKKOS_LAMBDA(int i) {
     arr_out(i) = std::min(std::max(arr_in(i), lower), upper);
   });
 }
 
-template<typename InT, typename T, typename OutT, typename std::enable_if<OutT::rank == 2>::type* = nullptr>
+template<typename InT, typename T, typename OutT, typename std::enable_if<OutT::rank == 2>::type* dummy = nullptr>
 static void limit_to_bounds_k(InT const &arr_in, T const lower, T const upper, OutT &arr_out) {
   Kokkos::parallel_for(MDRP::template get<2>({arr_out.extent(0), arr_out.extent(1)}), KOKKOS_LAMBDA(int i, int j) {
     arr_out(i, j) = std::min(std::max(arr_in(i, j), lower), upper);


### PR DESCRIPTION
these were uncovered trying to compile rrtmgp-k on cuda12.2 and cuda12.4 on pm-gpu

❌ errors: the [missing dummies](https://stackoverflow.com/a/74385729/22990681)

<details><summary>e.g.,</summary>
<p>

```
error: ‘__T0’ was not declared in this scope; did you mean ‘__y0’?
```

</p>
</details> 

⚠️ warnings: the deep copies
<details><summary>e.g.,</summary>
<p>

```
scream/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp(1174): warning #20011-D: calling a __host__ function("void Kokkos::deep_copy<double ***,  ::Kokkos::LayoutRight,  ::Kokkos::Device< ::Kokkos::Cuda,  ::Kokkos::CudaSpace> ,  ::Kokkos::MemoryTraits<(unsigned int)1u>  > (const  ::Kokkos::View<T1, T2... >  &,  ::Kokkos::ViewTraits<T1, T2... > ::const_value_type &,    ::std::enable_if<std::is_same< ::Kokkos::ViewTraits<T1, T2... > ::specialize, void> ::value, void> ::type *)") from a __host__ __device__ function("scream::RRTMGPRadiation::run_impl(double)::[lambda(const  ::Kokkos::Impl::CudaTeamMember &) (instance 3)]::operator () const") is not allowed
```

</p>
</details> 

xref https://github.com/E3SM-Project/scream/issues/2953#issuecomment-2294983317