### PR TITLE
Limit compute-sanitizer racecheck resources

### DIFF
--- a/components/eamxx/scripts/test_factory.py
+++ b/components/eamxx/scripts/test_factory.py
@@ -176,7 +176,7 @@ class CSM(TestProperty):
             "debug with compute sanitizer memcheck",
             [("CMAKE_BUILD_TYPE", "Debug"),
              ("EKAT_ENABLE_COMPUTE_SANITIZER", "True"),
-             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "--tool=memcheck")],
+             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "'--tool=memcheck'")],
             uses_baselines=False,
             on_by_default=False,
             default_test_len="short"
@@ -210,7 +210,7 @@ class CSI(TestProperty):
             "debug with compute sanitizer initcheck",
             [("CMAKE_BUILD_TYPE", "Debug"),
              ("EKAT_ENABLE_COMPUTE_SANITIZER", "True"),
-             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "--tool=initcheck")],
+             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "'--tool=initcheck'")],
             uses_baselines=False,
             on_by_default=False,
             default_test_len="short"
@@ -227,7 +227,7 @@ class CSS(TestProperty):
             "debug with compute sanitizer synccheck",
             [("CMAKE_BUILD_TYPE", "Debug"),
              ("EKAT_ENABLE_COMPUTE_SANITIZER", "True"),
-             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "--tool=synccheck")],
+             ("EKAT_COMPUTE_SANITIZER_OPTIONS", "'--tool=synccheck'")],
             uses_baselines=False,
             on_by_default=False,
             default_test_len="short"


### PR DESCRIPTION
`compute-sanitizer --tool=racecheck` was attempting to use the entire node worth of threads, which is an issue in a parallel `test-all-scream` build, since all other tests would start to hang. This was causing the non-report from compute-sanitizer nightlies.

Solution: if we are in a parallel build, limit racecheck to using `compile_res_count` threads (approx `total_cpu_threads/num_parallel_tests`).

Running exact `gather-all-scream` command as the compute-sanitizer nightlies took ~70 min which should be plenty fast enough to report.