### PR TITLE
Use C++ in shoc property tests

### DIFF
--- a/components/eamxx/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
@@ -102,8 +102,6 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
     }
 
     // Check that the inputs make sense
-
-    // Load input data
     for(Int s = 0; s < shcol; ++s) {
       for(Int n = 0; n < nlev; ++n) {
         const auto offset = n + s * nlev;
@@ -142,8 +140,14 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
     // For this test we want exactly two columns
     REQUIRE(SDS.shcol == 2);
 
-    // Call the fortran implementation
-    shoc_assumed_pdf(SDS);
+    // Call the C++ implementation.
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    shoc_assumed_pdf_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.thetal, SDS.qw, SDS.w_field,
+                       SDS.thl_sec, SDS.qw_sec, SDS.wthl_sec, SDS.w_sec, SDS.wqw_sec,
+                       SDS.qwthl_sec, SDS.w3, SDS.pres, SDS.zt_grid, SDS.zi_grid,
+                       SDS.shoc_cldfrac, SDS.shoc_ql, SDS.wqls, SDS.wthv_sec, SDS.shoc_ql2);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Verify the result
     // Make sure cloud fraction is either 1 or 0 and all
@@ -182,8 +186,14 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
       }
     }
 
-    // Call the fortran implementation
-    shoc_assumed_pdf(SDS);
+    // Call the C++ implementation.
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    shoc_assumed_pdf_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.thetal, SDS.qw, SDS.w_field,
+                       SDS.thl_sec, SDS.qw_sec, SDS.wthl_sec, SDS.w_sec, SDS.wqw_sec,
+                       SDS.qwthl_sec, SDS.w3, SDS.pres, SDS.zt_grid, SDS.zi_grid,
+                       SDS.shoc_cldfrac, SDS.shoc_ql, SDS.wqls, SDS.wthv_sec, SDS.shoc_ql2);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Verify the result
     // Make sure cloud fraction is either 1 or 0 and all
@@ -240,8 +250,14 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
       }
     }
 
-    // Call the fortran implementation
-    shoc_assumed_pdf(SDS);
+    // Call the C++ implementation.
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    shoc_assumed_pdf_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.thetal, SDS.qw, SDS.w_field,
+                       SDS.thl_sec, SDS.qw_sec, SDS.wthl_sec, SDS.w_sec, SDS.wqw_sec,
+                       SDS.qwthl_sec, SDS.w3, SDS.pres, SDS.zt_grid, SDS.zi_grid,
+                       SDS.shoc_cldfrac, SDS.shoc_ql, SDS.wqls, SDS.wthv_sec, SDS.shoc_ql2);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the result
 
@@ -324,8 +340,14 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
       }
     }
 
-    // Call the fortran implementation
-    shoc_assumed_pdf(SDS);
+    // Call the C++ implementation.
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    shoc_assumed_pdf_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.thetal, SDS.qw, SDS.w_field,
+                       SDS.thl_sec, SDS.qw_sec, SDS.wthl_sec, SDS.w_sec, SDS.wqw_sec,
+                       SDS.qwthl_sec, SDS.w3, SDS.pres, SDS.zt_grid, SDS.zi_grid,
+                       SDS.shoc_cldfrac, SDS.shoc_ql, SDS.wqls, SDS.wthv_sec, SDS.shoc_ql2);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the result
 

--- a/components/eamxx/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
@@ -160,9 +160,8 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
         REQUIRE( (SDS.shoc_cldfrac[offset] == 0  || SDS.shoc_cldfrac[offset] == 1) );
         REQUIRE(SDS.wqls[offset] == 0);
         REQUIRE(SDS.wthv_sec[offset] == 0);
-        REQUIRE(SDS.shoc_ql2[offset] == 0);
+        REQUIRE(std::abs(SDS.shoc_ql2[offset]) < std::numeric_limits<Real>::epsilon());
         REQUIRE(SDS.shoc_ql[offset] >= 0);
-
       }
     }
 
@@ -207,7 +206,7 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
         REQUIRE(SDS.wqls[offset] == 0);
         REQUIRE(SDS.wthv_sec[offset] != 0);
         REQUIRE(std::abs(SDS.wthv_sec[offset] < wthv_sec_bound));
-        REQUIRE(SDS.shoc_ql2[offset] == 0);
+        REQUIRE(std::abs(SDS.shoc_ql2[offset]) < std::numeric_limits<Real>::epsilon());
         REQUIRE(SDS.shoc_ql[offset] >= 0);
         REQUIRE(SDS.shoc_ql[offset] < shoc_ql_bound);
       }

--- a/components/eamxx/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
@@ -160,7 +160,7 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
         REQUIRE( (SDS.shoc_cldfrac[offset] == 0  || SDS.shoc_cldfrac[offset] == 1) );
         REQUIRE(SDS.wqls[offset] == 0);
         REQUIRE(SDS.wthv_sec[offset] == 0);
-        REQUIRE(std::abs(SDS.shoc_ql2[offset]) < std::numeric_limits<Real>::epsilon());
+        REQUIRE(std::abs(SDS.shoc_ql2[offset]) < std::numeric_limits<Real>::epsilon()); // Computation is not exactly BFB with 0
         REQUIRE(SDS.shoc_ql[offset] >= 0);
       }
     }
@@ -206,7 +206,7 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf {
         REQUIRE(SDS.wqls[offset] == 0);
         REQUIRE(SDS.wthv_sec[offset] != 0);
         REQUIRE(std::abs(SDS.wthv_sec[offset] < wthv_sec_bound));
-        REQUIRE(std::abs(SDS.shoc_ql2[offset]) < std::numeric_limits<Real>::epsilon());
+        REQUIRE(std::abs(SDS.shoc_ql2[offset]) < std::numeric_limits<Real>::epsilon()); // Computation is not exactly BFB with 0
         REQUIRE(SDS.shoc_ql[offset] >= 0);
         REQUIRE(SDS.shoc_ql[offset] < shoc_ql_bound);
       }

--- a/components/eamxx/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
@@ -90,8 +90,11 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength {
       }
     }
 
-    // Call the fortran implementation
-    compute_brunt_shoc_length(SDS);
+    // Call the C++ implementation.
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    compute_brunt_shoc_length_f(SDS.nlev,SDS.nlevi,SDS.shcol,SDS.dz_zt,SDS.thv,SDS.thv_zi,SDS.brunt);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the results
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_check_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_check_length_tests.cpp
@@ -75,8 +75,11 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength {
       REQUIRE(SDS.host_dy[s] > 0);
     }
 
-    // Call the fortran implementation
-    check_length_scale_shoc_length(SDS);
+    // Call the C++ implementation.
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    check_length_scale_shoc_length_f(SDS.nlev,SDS.shcol,SDS.host_dx,SDS.host_dy,SDS.shoc_mix);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the results
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_check_tke_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_check_tke_tests.cpp
@@ -52,8 +52,11 @@ struct UnitWrap::UnitTest<D>::TestShocCheckTke {
     // Check some input
     REQUIRE((SDS.shcol > 0 && SDS.nlev > 0));
 
-    // call the fortran implementation
-    check_tke(SDS);
+    // Call the C++ implementation.
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    check_tke_f(SDS.nlev, SDS.shcol, SDS.tke);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the result against the input values
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
@@ -82,8 +82,11 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms {
       REQUIRE(w3_large == true);
     }
 
-    // Call the fortran implementation
-    clipping_diag_third_shoc_moments(SDS);
+    // Call the C++ implementation.
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    clipping_diag_third_shoc_moments_f(SDS.nlevi,SDS.shcol,SDS.w_sec_zi,SDS.w3);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the result
     // For large values of w3, verify that the result has been reduced

--- a/components/eamxx/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
@@ -145,8 +145,15 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird {
       }
     }
 
-    // Call the fortran implementation
-    compute_diag_third_shoc_moment(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    compute_diag_third_shoc_moment_f(SDS.shcol,SDS.nlev,SDS.nlevi,SDS.w_sec,SDS.thl_sec,
+                                     SDS.wthl_sec,SDS.tke,SDS.dz_zt,
+                                     SDS.dz_zi,SDS.isotropy_zi,
+                                     SDS.brunt_zi,SDS.w_sec_zi,SDS.thetal_zi,
+                                     SDS.w3);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the result
 

--- a/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_temperature_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_temperature_tests.cpp
@@ -67,8 +67,10 @@ struct UnitWrap::UnitTest<D>::TestComputeShocTemp {
       }
     }
 
-    // Call the fortran implementation
-    compute_shoc_temperature(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    compute_shoc_temperature_f(SDS.shcol, SDS.nlev, SDS.thetal, SDS.ql, SDS.inv_exner, SDS.tabs);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Require that absolute temperature is equal to thetal
     for(Int s = 0; s < shcol; ++s) {
@@ -113,8 +115,10 @@ struct UnitWrap::UnitTest<D>::TestComputeShocTemp {
       }
     }
 
-    // Call the fortran implementation
-    compute_shoc_temperature(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    compute_shoc_temperature_f(SDS.shcol, SDS.nlev, SDS.thetal, SDS.ql, SDS.inv_exner, SDS.tabs);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Require that absolute temperature is greather than thetal
     for(Int s = 0; s < shcol; ++s) {
@@ -172,8 +176,10 @@ struct UnitWrap::UnitTest<D>::TestComputeShocTemp {
       }
     }
 
-    // Call the fortran implementation
-    compute_shoc_temperature(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    compute_shoc_temperature_f(SDS.shcol, SDS.nlev, SDS.thetal, SDS.ql, SDS.inv_exner, SDS.tabs);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Require that absolute temperature be less than thetal
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_vapor_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_vapor_tests.cpp
@@ -62,8 +62,10 @@ struct UnitWrap::UnitTest<D>::TestComputeShocVapor {
       }
     }
 
-    // Call the fortran implementation
-    compute_shoc_vapor(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    compute_shoc_vapor_f(SDS.shcol, SDS.nlev, SDS.qw, SDS.ql, SDS.qv);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Verify the result
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_obklen_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_obklen_tests.cpp
@@ -83,8 +83,13 @@ struct UnitWrap::UnitTest<D>::TestShocDiagObklen {
       REQUIRE( (SDS.qv_sfc[s] > 0 && SDS.qv_sfc[s] < 0.1) );
     }
 
-    // Call the fortran implementation
-    shoc_diag_obklen(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    shoc_diag_obklen_f(SDS.shcol, SDS.uw_sfc, SDS.vw_sfc, SDS.wthl_sfc, SDS.wqw_sfc,
+                       SDS.thl_sfc, SDS.cldliq_sfc, SDS.qv_sfc, SDS.ustar, SDS.kbfs,
+                       SDS.obklen);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the result
 
@@ -148,8 +153,13 @@ struct UnitWrap::UnitTest<D>::TestShocDiagObklen {
               SDS.wthl_sfc[s]+SDS.wqw_sfc[s]);
     }
 
-    // Call the fortran implementation
-    shoc_diag_obklen(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    shoc_diag_obklen_f(SDS.shcol, SDS.uw_sfc, SDS.vw_sfc, SDS.wthl_sfc, SDS.wqw_sfc,
+                       SDS.thl_sfc, SDS.cldliq_sfc, SDS.qv_sfc, SDS.ustar, SDS.kbfs,
+                       SDS.obklen);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Verify that DIMENSIONLESS obukhov length decreases as columns
     //   increases due to the increasing surface fluxes

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_srf_test.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_srf_test.cpp
@@ -51,8 +51,8 @@ struct UnitWrap::UnitTest<D>::TestSecondMomSrf {
       SDS.vw_sfc[s] = vw_sfc[s];
     }
 
-    // Call the fortran implementation
-    diag_second_moments_srf(SDS);
+    // Call the C++ implementation
+    shoc_diag_second_moments_srf_f(SDS.shcol, SDS.wthl_sfc, SDS.uw_sfc, SDS.vw_sfc, SDS.ustar2, SDS.wstar);
 
     // Verify the output
     for (Int s = 0; s < shcol; ++s){

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_ubycond_test.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_ubycond_test.cpp
@@ -42,8 +42,9 @@ struct UnitWrap::UnitTest<D>::TestSecondMomUbycond {
     REQUIRE(SDS.shcol == shcol);
     REQUIRE(shcol > 0);
 
-    // Call the fortran implementation
-    diag_second_moments_ubycond(SDS);
+    // Call the C++ implementation
+    shoc_diag_second_moments_ubycond_f(SDS.shcol, SDS.thl_sec, SDS.qw_sec, SDS.qwthl_sec, SDS.wthl_sec,
+                                       SDS.wqw_sec, SDS.uw_sec, SDS.vw_sec, SDS.wtke_sec);
 
     // Verify the result
     //  all output should be zero.

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_lbycond_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_lbycond_tests.cpp
@@ -75,8 +75,11 @@ struct UnitWrap::UnitTest<D>::TestDiagSecondMomentsLbycond {
       REQUIRE(SDS.ustar2[s] >= 0);
     }
 
-    // Call the fortran implementation
-    diag_second_moments_lbycond(SDS);
+    // Call the C++ implementation
+    diag_second_moments_lbycond_f(SDS.shcol, SDS.wthl_sfc, SDS.wqw_sfc, SDS.uw_sfc,
+                                  SDS.vw_sfc, SDS.ustar2, SDS.wstar, SDS.wthl_sec,
+                                  SDS.wqw_sec, SDS.uw_sec, SDS.vw_sec, SDS.wtke_sec,
+                                  SDS.thl_sec, SDS.qw_sec, SDS.qwthl_sec);
 
     // Verify output is as expected
     for (Int s = 0; s < shcol; ++s){

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_tests.cpp
@@ -162,8 +162,13 @@ struct UnitWrap::UnitTest<D>::TestDiagSecondMoments {
       }
     }
 
-    // Call the fortran implementation
-    diag_second_moments(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    diag_second_moments_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.thetal, SDS.qw, SDS.u_wind, SDS.v_wind,
+                          SDS.tke, SDS.isotropy, SDS.tkh, SDS.tk, SDS.dz_zi, SDS.zt_grid, SDS.zi_grid, SDS.shoc_mix,
+                          SDS.thl_sec, SDS.qw_sec, SDS.wthl_sec, SDS.wqw_sec, SDS.qwthl_sec, SDS.uw_sec,
+                          SDS.vw_sec, SDS.wtke_sec, SDS.w_sec);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Verify output makes sense
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_shoc_moments_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_shoc_moments_tests.cpp
@@ -160,8 +160,13 @@ struct UnitWrap::UnitTest<D>::TestDiagSecondShocMoments {
       }
     }
 
-    // Call the fortran implementation
-    diag_second_shoc_moments(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    diag_second_shoc_moments_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.thetal, SDS.qw, SDS.u_wind, SDS.v_wind, SDS.tke, SDS.isotropy,
+                               SDS.tkh, SDS.tk, SDS.dz_zi, SDS.zt_grid, SDS.zi_grid, SDS.shoc_mix, SDS.wthl_sfc, SDS.wqw_sfc,
+                               SDS.uw_sfc, SDS.vw_sfc, SDS.thl_sec, SDS.qw_sec, SDS.wthl_sec, SDS.wqw_sec, SDS.qwthl_sec,
+                               SDS.uw_sec, SDS.vw_sec, SDS.wtke_sec, SDS.w_sec);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Verify output makes sense
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_third_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_third_tests.cpp
@@ -142,8 +142,14 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
       }
     }
 
-    // Call the fortran implementation
-    diag_third_shoc_moments(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    diag_third_shoc_moments_f(SDS.shcol,SDS.nlev,SDS.nlevi,SDS.w_sec,SDS.thl_sec,
+                              SDS.wthl_sec,SDS.isotropy,SDS.brunt,SDS.thetal,
+                              SDS.tke,SDS.dz_zt,SDS.dz_zi,SDS.zt_grid,SDS.zi_grid,
+                              SDS.w3);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check to make sure there is at least one
     //  positive w3 value for convective boundary layer
@@ -186,8 +192,14 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird {
       }
     }
 
-    // Call the fortran implementation
-    diag_third_shoc_moments(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    diag_third_shoc_moments_f(SDS.shcol,SDS.nlev,SDS.nlevi,SDS.w_sec,SDS.thl_sec,
+                              SDS.wthl_sec,SDS.isotropy,SDS.brunt,SDS.thetal,
+                              SDS.tke,SDS.dz_zt,SDS.dz_zi,SDS.zt_grid,SDS.zi_grid,
+                              SDS.w3);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Verify that new result is greater or equal in magnitude
     //  that the result from test one

--- a/components/eamxx/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
@@ -97,8 +97,11 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
       }
     }
 
-    // Call the fortran implementation
-    eddy_diffusivities(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    eddy_diffusivities_f(SDS.nlev, SDS.shcol, SDS.pblh, SDS.zt_grid, SDS.tabs, SDS.shoc_mix,
+                         SDS.sterm_zt, SDS.isotropy, SDS.tke, SDS.tkh, SDS.tk);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check to make sure the answers in the columns are different
     for(Int s = 0; s < shcol-1; ++s) {
@@ -164,8 +167,11 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
       }
     }
 
-    // Call the fortran implementation
-    eddy_diffusivities(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    eddy_diffusivities_f(SDS.nlev, SDS.shcol, SDS.pblh, SDS.zt_grid, SDS.tabs, SDS.shoc_mix,
+                         SDS.sterm_zt, SDS.isotropy, SDS.tke, SDS.tkh, SDS.tk);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check to make sure the answers in the columns are larger
     //   when the length scale and shear term are larger
@@ -234,8 +240,11 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff {
       }
     }
 
-    // Call the fortran implementation
-    eddy_diffusivities(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    eddy_diffusivities_f(SDS.nlev, SDS.shcol, SDS.pblh, SDS.zt_grid, SDS.tabs, SDS.shoc_mix,
+                         SDS.sterm_zt, SDS.isotropy, SDS.tke, SDS.tkh, SDS.tk);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check to make sure the diffusivities are smaller
     //  in the columns where isotropy and tke are smaller

--- a/components/eamxx/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
@@ -157,8 +157,15 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
       }
     }
 
-    // Call the fortran implementation
-    shoc_energy_fixer(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    shoc_energy_fixer_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.dtime, SDS.nadv,
+                        SDS.zt_grid, SDS.zi_grid, SDS.se_b, SDS.ke_b, SDS.wv_b,
+                        SDS.wl_b, SDS.se_a, SDS.ke_a, SDS.wv_a, SDS.wl_a, SDS.wthl_sfc,
+                        SDS.wqw_sfc, SDS.rho_zt, SDS.tke, SDS.pint,
+                        SDS.host_dse);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check test
     // Verify that the dry static energy has not changed if surface
@@ -231,8 +238,15 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer {
       }
     }
 
-    // Call the fortran implementation
-    shoc_energy_fixer(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    shoc_energy_fixer_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.dtime, SDS.nadv,
+                        SDS.zt_grid, SDS.zi_grid, SDS.se_b, SDS.ke_b, SDS.wv_b,
+                        SDS.wl_b, SDS.se_a, SDS.ke_a, SDS.wv_a, SDS.wl_a, SDS.wthl_sfc,
+                        SDS.wqw_sfc, SDS.rho_zt, SDS.tke, SDS.pint,
+                        SDS.host_dse);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Verify the result
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
@@ -107,8 +107,13 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt {
       }
     }
 
-    // Call the fortran implementation
-    shoc_energy_integrals(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    shoc_energy_integrals_f(SDS.shcol, SDS.nlev, SDS.host_dse, SDS.pdel,
+                            SDS.rtm, SDS.rcm, SDS.u_wind, SDS.v_wind,
+                            SDS.se_int, SDS.ke_int, SDS.wv_int, SDS.wl_int);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check test
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
@@ -108,8 +108,12 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse {
       }
     }
 
-    // Call the fortran implementation
-    update_host_dse(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    update_host_dse_f(SDS.shcol,SDS.nlev,SDS.thlm,SDS.shoc_ql,SDS.inv_exner,SDS.zt_grid,
+                      SDS.phis,SDS.host_dse);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check test
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_grid_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_grid_tests.cpp
@@ -79,8 +79,10 @@ struct UnitWrap::UnitTest<D>::TestShocGrid {
       }
     }
 
-    // Call the fortran implementation
-    shoc_grid(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    shoc_grid_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.zt_grid, SDS.zi_grid, SDS.pdel, SDS.dz_zt, SDS.dz_zi, SDS.rho_zt);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // First check that dz is correct
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_impli_comp_tmpi_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_impli_comp_tmpi_tests.cpp
@@ -86,8 +86,10 @@ struct UnitWrap::UnitTest<D>::TestImpCompTmpi {
       }
     }
 
-    // Call the fortran implementation
-    compute_tmpi(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    compute_tmpi_f(SDS.nlevi, SDS.shcol, SDS.dtime, SDS.rho_zi, SDS.dz_zi, SDS.tmpi);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Verify result
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_impli_dp_inverse_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_impli_dp_inverse_tests.cpp
@@ -73,8 +73,10 @@ struct UnitWrap::UnitTest<D>::TestImpDpInverse {
       }
     }
 
-    // Call the fortran implementation
-    dp_inverse(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    dp_inverse_f(SDS.nlev, SDS.shcol, SDS.rho_zt, SDS.dz_zt, SDS.rdp_zt);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Verify result
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_l_inf_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_l_inf_length_tests.cpp
@@ -88,8 +88,11 @@ struct UnitWrap::UnitTest<D>::TestLInfShocLength {
       }
     }
 
-    // Call the fortran implementation
-    compute_l_inf_shoc_length(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    compute_l_inf_shoc_length_f(SDS.nlev,SDS.shcol,SDS.zt_grid,SDS.dz_zt,SDS.tke,SDS.l_inf);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the results
     // Make sure result is bounded correctly

--- a/components/eamxx/src/physics/shoc/tests/shoc_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_length_tests.cpp
@@ -120,8 +120,13 @@ struct UnitWrap::UnitTest<D>::TestShocLength {
       }
     }
 
-    // Call the Fortran implementation
-    shoc_length(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    shoc_length_f(SDS.shcol,SDS.nlev,SDS.nlevi,SDS.host_dx,SDS.host_dy,
+                  SDS.zt_grid,SDS.zi_grid,SDS.dz_zt,SDS.tke,
+                  SDS.thv,SDS.brunt,SDS.shoc_mix);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Verify output
     for(Int s = 0; s < shcol; ++s) {
@@ -169,8 +174,13 @@ struct UnitWrap::UnitTest<D>::TestShocLength {
       SDS.host_dy[s] = host_dy_small;
     }
 
-    // call fortran implentation
-    shoc_length(SDS);
+    // call C++ implentation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    shoc_length_f(SDS.shcol,SDS.nlev,SDS.nlevi,SDS.host_dx,SDS.host_dy,
+                  SDS.zt_grid,SDS.zi_grid,SDS.dz_zt,SDS.tke,
+                  SDS.thv,SDS.brunt,SDS.shoc_mix);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Verify output
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_linear_interp_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_linear_interp_tests.cpp
@@ -99,8 +99,10 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
       }
     }
 
-    // Call the fortran implementation
-    linear_interp(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    linear_interp_f(SDS.x1, SDS.x2, SDS.y1, SDS.y2, SDS.km1, SDS.km2, SDS.ncol, SDS.minthresh);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // First check that all output temperatures are greater than zero
 
@@ -191,7 +193,10 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
       }
     }
 
-    linear_interp(SDS2);
+    // Call the C++ implementation
+    SDS2.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    linear_interp_f(SDS2.x1, SDS2.x2, SDS2.y1, SDS2.y2, SDS2.km1, SDS2.km2, SDS2.ncol, SDS2.minthresh);
+    SDS2.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check the result, make sure output is bounded correctly
 
@@ -275,7 +280,10 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt {
       }
     }
 
-    linear_interp(d);
+    // Call the C++ implementation
+    d.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    linear_interp_f(d.x1, d.x2, d.y1, d.y2, d.km1, d.km2, d.ncol, d.minthresh);
+    d.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // The combination of single-precision and randomness generating points
     // close together can result in larger error margins.

--- a/components/eamxx/src/physics/shoc/tests/shoc_main_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_main_tests.cpp
@@ -258,8 +258,19 @@ struct UnitWrap::UnitTest<D>::TestShocMain {
 
     }
 
-    // Call the fortran implementation
-    shoc_main(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    const int npbl = shoc_init_f(SDS.nlev, SDS.pref_mid, SDS.nbot_shoc, SDS.ntop_shoc);
+
+    shoc_main_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.dtime, SDS.nadv, npbl, SDS.host_dx, SDS.host_dy,
+                SDS.thv, SDS.zt_grid, SDS.zi_grid, SDS.pres, SDS.presi, SDS.pdel, SDS.wthl_sfc,
+                SDS.wqw_sfc, SDS.uw_sfc, SDS.vw_sfc, SDS.wtracer_sfc, SDS.num_qtracers,
+                SDS.w_field, SDS.inv_exner, SDS.phis, SDS.host_dse, SDS.tke, SDS.thetal, SDS.qw,
+                SDS.u_wind, SDS.v_wind, SDS.qtracers, SDS.wthv_sec, SDS.tkh, SDS.tk, SDS.shoc_ql,
+                SDS.shoc_cldfrac, SDS.pblh, SDS.shoc_mix, SDS.isotropy, SDS.w_sec, SDS.thl_sec,
+                SDS.qw_sec, SDS.qwthl_sec, SDS.wthl_sec, SDS.wqw_sec, SDS.wtke_sec, SDS.uw_sec,
+                SDS.vw_sec, SDS.w3, SDS.wqls_sec, SDS.brunt, SDS.shoc_ql2);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Make sure output falls within reasonable bounds
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_mix_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_mix_length_tests.cpp
@@ -90,8 +90,14 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength {
       }
     }
 
-    // Call the fortran implementation
-    compute_shoc_mix_shoc_length(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    compute_shoc_mix_shoc_length_f(SDS.nlev, SDS.shcol,
+                                   SDS.tke, SDS.brunt,
+                                   SDS.zt_grid,
+                                   SDS.l_inf, SDS.shoc_mix);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the results
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_check_pblh_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_check_pblh_tests.cpp
@@ -67,8 +67,10 @@ struct UnitWrap::UnitTest<D>::TestPblintdCheckPblh {
       }
     }
 
-    // Call the fortran implementation
-    pblintd_check_pblh(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    pblintd_check_pblh_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.nlev, SDS.z, SDS.ustar, SDS.check, SDS.pblh);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check the result
     // Check that PBL height is greater than zero.  This is an

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_cldcheck_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_cldcheck_tests.cpp
@@ -79,8 +79,9 @@ struct UnitWrap::UnitTest<D>::TestPblintdCldCheck {
       }
     }
 
-    // Call the fortran implementation
-    pblintd_cldcheck(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    shoc_pblintd_cldcheck_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.zi, SDS.cldn, SDS.pblh);
 
     // Check the result
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_height_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_height_tests.cpp
@@ -85,8 +85,11 @@ struct UnitWrap::UnitTest<D>::TestPblintdHeight {
       REQUIRE(SDS.ustar[s+1] > SDS.ustar[s]);
     }
 
-    // Call the fortran implementation
-    pblintd_height(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    pblintd_height_f(SDS.shcol, SDS.nlev, SDS.npbl, SDS.z, SDS.u, SDS.v, SDS.ustar,
+                     SDS.thv, SDS.thv_ref, SDS.pblh, SDS.rino, SDS.check);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check the result
     for(Int s = 0; s < shcol; ++s) {
@@ -119,8 +122,11 @@ struct UnitWrap::UnitTest<D>::TestPblintdHeight {
       SDS.thv[offset] = SDS.thv[offset-1] + 2;
     }
 
-    // Call the fortran implementation
-    pblintd_height(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    pblintd_height_f(SDS.shcol, SDS.nlev, SDS.npbl, SDS.z, SDS.u, SDS.v, SDS.ustar,
+                     SDS.thv, SDS.thv_ref, SDS.pblh, SDS.rino, SDS.check);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check the result
     for(Int s = 0; s < shcol; ++s) {
@@ -158,8 +164,11 @@ struct UnitWrap::UnitTest<D>::TestPblintdHeight {
       }
     }
 
-    // Call the fortran implementation
-    pblintd_height(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    pblintd_height_f(SDS.shcol, SDS.nlev, SDS.npbl, SDS.z, SDS.u, SDS.v, SDS.ustar,
+                     SDS.thv, SDS.thv_ref, SDS.pblh, SDS.rino, SDS.check);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check that PBLH is zero (not modified) everywhere
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_init_pot_test.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_init_pot_test.cpp
@@ -76,8 +76,8 @@ struct UnitWrap::UnitTest<D>::TestPblintdInitPot {
       }
     }
 
-    // call the fortran implementation
-    pblintd_init_pot(SDS);
+    // call the C++ implementation
+    shoc_pblintd_init_pot_f(SDS.shcol, SDS.nlev, SDS.thl, SDS.ql, SDS.q, SDS.thv);
 
     // Check the result.
     // Verify that virtual potential temperature is idential
@@ -125,8 +125,8 @@ struct UnitWrap::UnitTest<D>::TestPblintdInitPot {
       }
     }
 
-    // Call the fortran implementation
-    pblintd_init_pot(SDS);
+    // Call the C++ implementation
+    shoc_pblintd_init_pot_f(SDS.shcol, SDS.nlev, SDS.thl, SDS.ql, SDS.q, SDS.thv);
 
     // Check test
     // Verify that column with condensate loading

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_surf_temp_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_surf_temp_tests.cpp
@@ -83,8 +83,11 @@ struct UnitWrap::UnitTest<D>::TestPblintdSurfTemp {
       }
     }
 
-    // Call the fortran implementation
-    pblintd_surf_temp(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    pblintd_surf_temp_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.z, SDS.ustar, SDS.obklen,
+                        SDS.kbfs, SDS.thv, SDS.tlv, SDS.pblh, SDS.check, SDS.rino);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check the result
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_tests.cpp
@@ -121,8 +121,12 @@ struct UnitWrap::UnitTest<D>::TestPblintd {
       }
     }
 
-    // Call the fortran implementation
-    pblintd(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    pblintd_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.npbl, SDS.z, SDS.zi,
+              SDS.thl, SDS.ql, SDS.q, SDS.u, SDS.v, SDS.ustar, SDS.obklen,
+              SDS.kbfs, SDS.cldn, SDS.pblh);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Make sure PBL height is reasonable
     // Should be larger than second lowest zi level and lower

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_adv_sgs_tke_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_adv_sgs_tke_tests.cpp
@@ -94,8 +94,10 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
       }
     }
 
-    // Call the fortran implementation
-    adv_sgs_tke(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    adv_sgs_tke_f(SDS.nlev, SDS.shcol, SDS.dtime, SDS.shoc_mix, SDS.wthv_sec, SDS.sterm_zt, SDS.tk, SDS.tke, SDS.a_diss);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check to make sure that there has been
     //  TKE growth
@@ -159,8 +161,10 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke {
       }
     }
 
-    // Call the fortran implementation
-    adv_sgs_tke(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    adv_sgs_tke_f(SDS.nlev, SDS.shcol, SDS.dtime, SDS.shoc_mix, SDS.wthv_sec, SDS.sterm_zt, SDS.tk, SDS.tke, SDS.a_diss);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check to make sure that the column with
     //  the smallest length scale has larger

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
@@ -75,8 +75,10 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
       }
     }
 
-    // Call the fortran implementation
-    integ_column_stability(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    integ_column_stability_f(SDS.nlev, SDS.shcol, SDS.dz_zt, SDS.pres, SDS.brunt, SDS.brunt_int);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check test
     //  Verify that output is zero
@@ -107,8 +109,10 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab {
       }
     }
 
-    // Call the fortran implementation
-    integ_column_stability(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    integ_column_stability_f(SDS.nlev, SDS.shcol, SDS.dz_zt, SDS.pres, SDS.brunt, SDS.brunt_int);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check test
     //  Verify that output is negative

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
@@ -81,8 +81,10 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
       }
     }
 
-    // Call the fortran implementation
-    isotropic_ts(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    isotropic_ts_f(SDS.nlev, SDS.shcol, SDS.brunt_int, SDS.tke, SDS.a_diss, SDS.brunt, SDS.isotropy);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check that output falls within reasonable bounds
     for(Int s = 0; s < shcol; ++s) {
@@ -145,8 +147,10 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs {
       }
     }
 
-    // Call the fortran implementation
-    isotropic_ts(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    isotropic_ts_f(SDS.nlev, SDS.shcol, SDS.brunt_int, SDS.tke, SDS.a_diss, SDS.brunt, SDS.isotropy);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check that output falls within reasonable bounds
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
@@ -93,8 +93,10 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
       }
     }
 
-    // Call the fortran implementation
-    compute_shr_prod(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    compute_shr_prod_f(SDS.nlevi, SDS.nlev, SDS.shcol, SDS.dz_zi, SDS.u_wind, SDS.v_wind, SDS.sterm);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check test
     for(Int s = 0; s < shcol; ++s) {
@@ -142,8 +144,10 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd {
       }
     }
 
-    // Call the fortran implementation
-    compute_shr_prod(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    compute_shr_prod_f(SDS.nlevi, SDS.nlev, SDS.shcol, SDS.dz_zi, SDS.u_wind, SDS.v_wind, SDS.sterm);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check test
     // Verify that shear term is zero everywhere

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_tests.cpp
@@ -153,8 +153,12 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
       }
     }
 
-    // Call the fortran implementation
-    shoc_tke(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    shoc_tke_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.dtime, SDS.wthv_sec, SDS.shoc_mix, SDS.dz_zi, SDS.dz_zt,
+               SDS.pres, SDS.tabs, SDS.u_wind, SDS.v_wind, SDS.brunt, SDS.zt_grid, SDS.zi_grid, SDS.pblh,
+               SDS.tke, SDS.tk, SDS.tkh, SDS.isotropy);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check test
     // Make sure that TKE has increased everwhere relative
@@ -226,8 +230,12 @@ struct UnitWrap::UnitTest<D>::TestShocTke {
       }
     }
 
-    // Call the fortran implementation
-    shoc_tke(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    shoc_tke_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.dtime, SDS.wthv_sec, SDS.shoc_mix, SDS.dz_zi, SDS.dz_zt,
+               SDS.pres, SDS.tabs, SDS.u_wind, SDS.v_wind, SDS.brunt, SDS.zt_grid, SDS.zi_grid, SDS.pblh,
+               SDS.tke, SDS.tk, SDS.tkh, SDS.isotropy);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check the result
 

--- a/components/eamxx/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
@@ -258,10 +258,18 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit {
       }
     }
 
-    // Call the fortran implementation
-    update_prognostics_implicit(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    update_prognostics_implicit_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.num_tracer, SDS.dtime,
+                                  SDS.dz_zt, SDS.dz_zi, SDS.rho_zt, SDS.zt_grid, SDS.zi_grid,
+                                  SDS.tk, SDS.tkh, SDS.uw_sfc, SDS.vw_sfc, SDS.wthl_sfc, SDS.wqw_sfc,
+                                  SDS.wtracer_sfc, SDS.thetal, SDS.qw, SDS.tracer, SDS.tke, SDS.u_wind, SDS.v_wind);
+    SDS.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
+
     // Call linear interp to get rho value at surface for checking
-    linear_interp(SDSL);
+    SDSL.transpose<ekat::TransposeDirection::c2f>(); // _f expects data in fortran layout
+    linear_interp_f(SDSL.x1, SDSL.x2, SDSL.y1, SDSL.y2, SDSL.km1, SDSL.km2, SDSL.ncol, SDSL.minthresh);
+    SDSL.transpose<ekat::TransposeDirection::f2c>(); // go back to C layout
 
     // Check the result
 

--- a/components/eamxx/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
@@ -115,8 +115,14 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
       }
     }
 
-    // Call the fortran implementation for variance
-    calc_shoc_varorcovar(SDS);
+    // Call the C++ implementation for variance
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    calc_shoc_varorcovar_f(SDS.shcol, SDS.nlev, SDS.nlevi,
+                           SDS.tunefac, SDS.isotropy_zi,
+                           SDS.tkh_zi, SDS.dz_zi,
+                           SDS.invar1, SDS.invar2, SDS.varorcovar);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the results
     for(Int s = 0; s < shcol; ++s) {
@@ -172,8 +178,14 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
       }
     }
 
-    // Call the fortran implementation for covariance
-    calc_shoc_varorcovar(SDS);
+    // Call the C++ implementation for covariance
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    calc_shoc_varorcovar_f(SDS.shcol, SDS.nlev, SDS.nlevi,
+                           SDS.tunefac, SDS.isotropy_zi,
+                           SDS.tkh_zi, SDS.dz_zi,
+                           SDS.invar1, SDS.invar2, SDS.varorcovar);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the results
     for(Int s = 0; s < shcol; ++s) {
@@ -250,8 +262,14 @@ struct UnitWrap::UnitTest<D>::TestShocVarorCovar {
       }
     }
 
-    // Call the fortran implementation for variance
-    calc_shoc_varorcovar(SDS);
+    // Call the C++ implementation for variance
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    calc_shoc_varorcovar_f(SDS.shcol, SDS.nlev, SDS.nlevi,
+                           SDS.tunefac, SDS.isotropy_zi,
+                           SDS.tkh_zi, SDS.dz_zi,
+                           SDS.invar1, SDS.invar2, SDS.varorcovar);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the results
     for(Int s = 0; s < shcol; ++s) {

--- a/components/eamxx/src/physics/shoc/tests/shoc_vertflux_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_vertflux_tests.cpp
@@ -95,8 +95,11 @@ struct UnitWrap::UnitTest<D>::TestCalcShocVertflux {
       }
     }
 
-    // Call the fortran implementation
-    calc_shoc_vertflux(SDS);
+    // Call the C++ implementation
+    SDS.transpose<ekat::TransposeDirection::c2f>();
+    // expects data in fortran layout
+    calc_shoc_vertflux_f(SDS.shcol, SDS.nlev, SDS.nlevi, SDS.tkh_zi, SDS.dz_zi, SDS.invar, SDS.vertflux);
+    SDS.transpose<ekat::TransposeDirection::f2c>();
 
     // Check the results
     for(Int s = 0; s < shcol; ++s) {


### PR DESCRIPTION
Call C++ interface functions in shoc property tests. Partly addresses https://github.com/E3SM-Project/scream/issues/1376.

I'm not sure the reason the functions calling C++ code (e.g., `shoc_assumed_pdf_f()`) expect a fortran data layout, and the functions calling F90 (e.g., shoc_assumed_pdf(ShocAssumedPDFData)`) expect C layout. But that can be changed whenever we drop F90.