### PR TITLE
Fix hist regex for scream

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -29,7 +29,7 @@
     <rest_file_extension>r\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*</rest_file_extension>
     <rest_file_extension>rhist\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*</rest_file_extension>
     <!-- The following matches "hi.AVGTYPE.FREQUNITS_xFREQ.TIMESTAMP.nc"-->
-    <hist_file_extension>.*\.h\..*\.nc$</hist_file_extension>
+    <hist_file_extension>.*\.h\.(?!rhist\.).*\.nc$</hist_file_extension>
   </comp_archive_spec>
 
   <comp_archive_spec compname="elm" compclass="lnd">

--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -29,7 +29,7 @@
     <rest_file_extension>r\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*</rest_file_extension>
     <rest_file_extension>rhist\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*</rest_file_extension>
     <!-- The following matches "hi.AVGTYPE.FREQUNITS_xFREQ.TIMESTAMP.nc"-->
-    <hist_file_extension>hi\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*\.\d{4}-\d{2}-\d{2}-\d{5}\.nc$</hist_file_extension>
+    <hist_file_extension>.*\.h\..*\.nc$</hist_file_extension>
   </comp_archive_spec>
 
   <comp_archive_spec compname="elm" compclass="lnd">

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/output/diags/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/output/diags/shell_commands
@@ -29,7 +29,7 @@ $YAML_EDIT_SCRIPT -g \
  --avg-type INSTANT               \
  --freq HIST_N                    \
  --freq-units HIST_OPTION         \
- --prefix ${CASE}.scream.diags.hi \
+ --prefix ${CASE}.scream.diags.h  \
  --grid "Physics ${PGTYPE}"       \
  --fields ${FIELDS}
 

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/output/phys/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/output/phys/shell_commands
@@ -26,7 +26,7 @@ $YAML_EDIT_SCRIPT -g \
  --avg-type INSTANT               \
  --freq HIST_N                    \
  --freq-units HIST_OPTION         \
- --prefix ${CASE}.scream.phys.hi  \
+ --prefix ${CASE}.scream.phys.h   \
  --grid "Physics ${PGTYPE}"       \
  --fields ${FIELDS}
 

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/output/phys_dyn/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/output/phys_dyn/shell_commands
@@ -26,7 +26,7 @@ $YAML_EDIT_SCRIPT -g \
  --avg-type INSTANT                   \
  --freq HIST_N                        \
  --freq-units HIST_OPTION             \
- --prefix ${CASE}.scream.phys_dyn.hi  \
+ --prefix ${CASE}.scream.phys_dyn.h   \
  --grid Dynamics                      \
  --io-grid 'Physics GLL'              \
  --fields ${FIELDS}


### PR DESCRIPTION
The file names in the output testmods were producing files that were getting skipped by CIME due to not matching the regex in config_archive.xml.

I was looking at the case SMS_Lh4.ne4_ne4.F2010-SCREAMv1.mappy_gnu.scream-output-preset-1 on mappy. The following scream hist outputs are produced:
```
SMS_Lh4.ne4_ne4.F2010-SCREAMv1.mappy_gnu.scream-output-preset-1.C.20240821_094612_ga4yqd.scream.diags.hi.INSTANT.nhours_x4.0001-01-01-00000.nc
SMS_Lh4.ne4_ne4.F2010-SCREAMv1.mappy_gnu.scream-output-preset-1.C.20240821_094612_ga4yqd.scream.phys_dyn.hi.INSTANT.nhours_x4.0001-01-01-00000.nc
SMS_Lh4.ne4_ne4.F2010-SCREAMv1.mappy_gnu.scream-output-preset-1.C.20240821_094612_ga4yqd.scream.phys.hi.INSTANT.nhours_x4.0001-01-01-00000.nc
```
None of these are recognized by CIME and are skipped. Here is the config_archive.xml entry for scream:
`<hist_file_extension>hi\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*\.\d{4}-\d{2}-\d{2}-\d{5}\.nc$</hist_file_extension>`

In CIME, this is processed into the regex:
`scream\d?_?(\d{4})?\.hi\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*\.\d{4}-\d{2}-\d{2}-\d{5}\.nc`

Note: in the hist files in the case, the words `diags` , `phys_dyn` , and `phys` all appear in between `scream` and `.hi` . The `hist_file_extension` is not set up to match those words, and so these files are all skipped.

Based on slack conversation, `.hi` is usually used for "history initialization" files, not output files, so we should use `.h` instead in our scream output files. 

The new hist_file_extension will match ANY file with `scream` followed by `.h.` and ending with `.nc`.