### PR TITLE
Add libfabric/1.15.2.0 module to frontier-scream-gpu.

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1436,11 +1436,10 @@
         <command name="load">craype-accel-amd-gfx90a</command>
         <command name="load">rocm/5.4.0</command>
         <command name="load">libunwind/1.6.2</command>
-      </modules>
-      <modules>
         <command name="load">cce/15.0.1</command>
-        <command name="switch">craype craype/2.7.20</command>
-        <command name="switch">cray-mpich cray-mpich/8.1.26</command>
+        <command name="load">libfabric/1.15.2.0</command>
+        <command name="load">craype/2.7.20</command>
+        <command name="load">cray-mpich/8.1.26</command>
         <command name="load">cray-python/3.9.13.1</command>
         <command name="load">subversion/1.14.1</command>
         <command name="load">git/2.36.1</command>


### PR DESCRIPTION
The default version of module `libfabric` on Frontier changed from `1.15.2.0` to `1.20.1`, and this caused hangs in the decadal run. I confirmed that the run hangs even if compiled with `libfabric/1.20.1` when using the current `cpe/22.12`-based software environment, but it runs to completion with the module `libfabric/1.15.2.0`.

I also combined the two `<module>` blocks into one, since they both actually depend on the setting `compiler="crayclang-scream"`.