### PR TITLE
Pm-cpu: do static libc++ linking

### DIFF
--- a/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
@@ -10,3 +10,6 @@ set(MPIFC "ftn")
 set(SCC "gcc")
 set(SCXX "g++")
 set(SFC "gfortran")
+
+string(APPEND CMAKE_EXE_LINKER_FLAGS " -static-libstdc++")
+

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -218,7 +218,7 @@
 
       <modules compiler="gnu">
         <command name="load">PrgEnv-gnu/8.5.0</command>
-        <command name="load">gcc/12.2.0</command>
+        <command name="load">gcc/11.2.0</command>
         <command name="load">cray-libsci/23.02.1.1</command>
       </modules>
 

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -218,7 +218,7 @@
 
       <modules compiler="gnu">
         <command name="load">PrgEnv-gnu/8.5.0</command>
-        <command name="load">gcc/11.2.0</command>
+        <command name="load">gcc/12.2.0</command>
         <command name="load">cray-libsci/23.02.1.1</command>
       </modules>
 


### PR DESCRIPTION
There are several libraries we use that were built with gcc-11:

```
    <environment_variables compiler="gnu" mpilib="mpich">
      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/gcc-11.2.0; else echo "$ADIOS2_ROOT"; fi}</env>
      <env name="BLA_VENDOR">Generic</env>
      <env name="Albany_ROOT">$SHELL{if [ -z "$Albany_ROOT" ]; then echo /global/common/software/e3sm/albany/2024.03.26/gcc/11.2.0; else echo "$Albany_ROOT"; fi}</env>
      <env name="Trilinos_ROOT">$SHELL{if [ -z "$Trilinos_ROOT" ]; then echo /global/common/software/e3sm/trilinos/15.1.1/gcc/11.2.0; else echo "$Trilinos_ROOT"; fi}</env>
    </environment_variables>
```

This PR fixes the error:
```
 92: /pscratch/sd/a/acmetest/e3sm_scratch/pm-cpu/ERS_Ln22.ne30_ne30.F2010-SCREAMv1.pm-cpu_gnu.scream-internal_diagnostics_level--scream-output-preset-3.20240826_132116_eilkpw/bld/e3sm.exe: /opt/cray/pe/gcc-libs/libstdc++.so\
.6: version `GLIBCXX_3.4.30' not found (required by /pscratch/sd/a/acmetest/e3sm_scratch/pm-cpu/ERS_Ln22.ne30_ne30.F2010-SCREAMv1.pm-cpu_gnu.scream-internal_diagnostics_level--scream-output-preset-3.20240826_132116_eilkpw/b\
ld/e3sm.exe)
```

... which started happening after the upstream merge, which changed the pm-cpu compiler to 12.2