### PR TITLE
EAMxx: use portable format for unsigned std::int64_t in printf

### DIFF
--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -129,7 +129,7 @@ void AtmosphereProcess
   if (m_comm.am_i_root())
     for (int i = 0; i < nslot; ++i)
       if (show[i])
-        fprintf(stderr, "exxhash> %4d-%9.5f %1d %16lx (%s)\n",
+        fprintf(stderr, "exxhash> %4d-%9.5f %1d %" PRIx64 " (%s)\n",
                 timestamp().get_year(), timestamp().frac_of_year_in_days(),
                 i, gaccum[i], label.c_str());
 }
@@ -140,7 +140,7 @@ void AtmosphereProcess::print_fast_global_state_hash (const std::string& label) 
   HashType gaccum;
   bfbhash::all_reduce_HashType(m_comm.mpi_comm(), &laccum, &gaccum, 1);
   if (m_comm.am_i_root())
-    fprintf(stderr, "bfbhash> %14d %16lx (%s)\n",
+    fprintf(stderr, "bfbhash> %14d %" PRIx64 " (%s)\n",
             timestamp().get_num_steps(), gaccum, label.c_str());
 }
 


### PR DESCRIPTION
The actual type of `std::int64_t` can be `long` or `long long`, depending on the implementation. This causes `printf`/`fprintf` statements to complain if we use `%ll`, since the correct format may be `%l` if `std::int64_t` expands to `long`. Luckily, our good AI bot told me that C99 introduced the PRI*64 macros (with *=x,d,u), which are a portable (i.e., guaranteed by the standard) way to printf a 64bit number.

Why this PR? I was getting errors while building EAMxx inside a container (in view of AT2 switch).