### PR TITLE
Fix frontier builds

### DIFF
--- a/components/eamxx/src/physics/mam/srf_emission_impl.hpp
+++ b/components/eamxx/src/physics/mam/srf_emission_impl.hpp
@@ -90,6 +90,7 @@ srfEmissFunctions<S, D>::create_srfEmiss_data_reader(
 
 template <typename S, typename D>
 template <typename ScalarX, typename ScalarT>
+KOKKOS_INLINE_FUNCTION
 ScalarX srfEmissFunctions<S, D>::linear_interp(const ScalarX &x0,
                                                const ScalarX &x1,
                                                const ScalarT &t) {


### PR DESCRIPTION
One function that was being called from kernels was missing KOKKOS_INLINE_FUNCTION.