### PR TITLE
Call MPI_Abort in CIME runs when an exception is thrown inside EAMxx

### DIFF
--- a/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -57,10 +57,15 @@ void fpe_guard_wrapper (const Lambda& f) {
   try {
     f();
   } catch (std::exception &e) {
+    // Print exception msg, then call MPI_Abort
     fprintf(stderr, "%s\n", e.what());
+
+    // Get raw comm before cleaning up singleton
     auto& c = ScreamContext::singleton();
+    auto raw_comm = c.get<ekat::Comm>().mpi_comm();
     c.clean_up();
-    throw;
+
+    MPI_Abort (raw_comm,1);
   }
 
   // Restore the FPE flag as it was when control was handed to us.

--- a/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -66,6 +66,14 @@ void fpe_guard_wrapper (const Lambda& f) {
     c.clean_up();
 
     MPI_Abort (raw_comm,1);
+  } catch (...) {
+
+    // Get raw comm before cleaning up singleton
+    auto& c = ScreamContext::singleton();
+    auto raw_comm = c.get<ekat::Comm>().mpi_comm();
+    c.clean_up();
+
+    MPI_Abort (raw_comm,1);
   }
 
   // Restore the FPE flag as it was when control was handed to us.


### PR DESCRIPTION
This ensures that the whole job is terminated. The MPI standard does not guarantee that an uncaught exception will cause the whole MPI job to terminate.

Note: this *may* fix the very long hangs we were sometimes getting when the code crashed, and yet the job did not terminate.

Fixes #2964 