### PR TITLE
Make rrtmgp explicitly find kokkos

### DIFF
--- a/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
@@ -127,7 +127,9 @@ yakl_process_target(rrtmgp)
 # NOTE: cannot use 'PUBLIC' in target_link_libraries,
 #       since yakl_process_target already used it
 #       with the "plain" signature
-find_package(Kokkos REQUIRED)
+if (NOT TARGET Kokkos::kokkos)
+  find_package(Kokkos REQUIRED)
+endif ()
 target_link_libraries(rrtmgp yakl Kokkos::kokkos)
 target_include_directories(rrtmgp PUBLIC
     ${SCREAM_BASE_DIR}/../../externals/YAKL

--- a/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
@@ -127,6 +127,7 @@ yakl_process_target(rrtmgp)
 # NOTE: cannot use 'PUBLIC' in target_link_libraries,
 #       since yakl_process_target already used it
 #       with the "plain" signature
+find_package(Kokkos REQUIRED)
 target_link_libraries(rrtmgp yakl Kokkos::kokkos)
 target_include_directories(rrtmgp PUBLIC
     ${SCREAM_BASE_DIR}/../../externals/YAKL


### PR DESCRIPTION
This PR fixes a nano bug that only shows if you try to use an existing Kokkos installation, by setting the env var Kokkos_ROOT.

In particular, in that case, Ekat finds the installation via find_package. But the imported target has local scope, so following calls to cmake's `target_link_libraries` won't recognize Kokkos , since the package was found while parsing the ekat subdir. Hence, we must call find_package again to make the imported target available in the current scope.

Also, subsequent calls to find_package are virtually no-op (once the package was found the first time), so it doesn't even cost to call it again and again.

NOTE: there's also the option of making the imported target via find_package GLOBAL, so that CMake can use the imported target even after exiting the scope where find_package was called. However, that's conceptually wrong, imho, since it doesn't encapsulate specific needs.