### PR TITLE
Bug fix when defining gsize in DP mode

### DIFF
--- a/share/streams/shr_dmodel_mod.F90
+++ b/share/streams/shr_dmodel_mod.F90
@@ -383,7 +383,7 @@ CONTAINS
          nxgo = scm_nx
          nygo = scm_ny
          nzgo = -1
-         gsize = abs(scm_nx*scm_nx*nzgo)
+         gsize = abs(scm_nx*scm_ny*nzgo)
        else
          nxgo = nxg
          nygo = nyg


### PR DESCRIPTION
Was causing code to seg fault when attempting to define large domains in DP mode (relevant for both DPv0 and DPv1).