### PR TITLE
Change handling of multiple matches in atmchange/atmquery

### DIFF
--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -126,7 +126,7 @@ def perform_consistency_checks(case, xml):
     >>> case = MockCase({'ATM_NCPL':'24', 'REST_N':2, 'REST_OPTION':'nsteps'})
     >>> perform_consistency_checks(case,xml)
     Traceback (most recent call last):
-    CIME.utils.CIMEError: ERROR: rrtmgp::rad_frequency incompatible with restart frequency.
+    CIME.utils.CIMEError: ERROR: rrtmgp::rad_frequency (3 steps) incompatible with restart frequency (2 steps).
      Please, ensure restart happens on a step when rad is ON
     >>> case = MockCase({'ATM_NCPL':'24', 'REST_N':10800, 'REST_OPTION':'nseconds'})
     >>> perform_consistency_checks(case,xml)
@@ -970,7 +970,7 @@ def create_input_data_list_file(case,caseroot):
                             permissions = stat.filemode(file_stat.st_mode)
 
                         except Exception as e:
-                            raise RuntimeError(f"Error retrieving file info for '{file_path}': {e}")
+                            raise RuntimeError(f"Error retrieving file info for '{file_path}': {e}") from e
 
                         curr_user = getpass.getuser()
                         user_info = pwd.getpwnam(curr_user)

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/internal_diagnostics_level/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/internal_diagnostics_level/shell_commands
@@ -1,2 +1,2 @@
-$CIMEROOT/../components/eamxx/scripts/atmchange --all internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0 -b
+$CIMEROOT/../components/eamxx/scripts/atmchange ANY::internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0 -b
 ./xmlchange POSTRUN_SCRIPT="$CIMEROOT/../components/eamxx/scripts/check-hashes-ers"

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/small_kernels/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/small_kernels/shell_commands
@@ -1,2 +1,2 @@
 ./xmlchange --append SCREAM_CMAKE_OPTIONS='SCREAM_SMALL_KERNELS On'
-$CIMEROOT/../components/eamxx/scripts/atmchange --all internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0 -b
+$CIMEROOT/../components/eamxx/scripts/atmchange ANY::internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0 -b

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/small_kernels_p3/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/small_kernels_p3/shell_commands
@@ -1,2 +1,2 @@
 ./xmlchange --append SCREAM_CMAKE_OPTIONS='SCREAM_P3_SMALL_KERNELS On'
-$CIMEROOT/../components/eamxx/scripts/atmchange --all internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0 -b
+$CIMEROOT/../components/eamxx/scripts/atmchange ANY::internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0 -b

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/scream/small_kernels_shoc/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/scream/small_kernels_shoc/shell_commands
@@ -1,2 +1,2 @@
 ./xmlchange --append SCREAM_CMAKE_OPTIONS='SCREAM_SHOC_SMALL_KERNELS On'
-$CIMEROOT/../components/eamxx/scripts/atmchange --all internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0 -b
+$CIMEROOT/../components/eamxx/scripts/atmchange ANY::internal_diagnostics_level=1 atmosphere_processes::internal_diagnostics_level=0 -b

--- a/components/eamxx/docs/user/model_input.md
+++ b/components/eamxx/docs/user/model_input.md
@@ -148,7 +148,7 @@ scoped name, which allows `atmchange` to uniquely identify the XML node to modif
 $ ./atmquery homme::number_of_subcycles
     namelist_defaults::atmosphere_processes::homme::number_of_subcycles: 1
 $ ./atmchange number_of_subcycles=10
-ERROR: number_of_subcycles is ambiguous (use --all to change all matches), matches:
+ERROR: internal_diagnostics_level is ambiguous. Use ANY in the node path to allow multiple matches. Matches:
   namelist_defaults::atmosphere_processes::number_of_subcycles
   namelist_defaults::atmosphere_processes::sc_import::number_of_subcycles
   namelist_defaults::atmosphere_processes::homme::number_of_subcycles
@@ -167,7 +167,7 @@ $ ./atmquery homme::number_of_subcycles
 ```
 
 In some cases, the user may be interested in changing _all_ nodes with a given name. In that case,
-the `--all` flag can be used:
+you can use 'ANY' as a node name:
 
 ```shell
 $ ./atmquery --grep number_of_subcycles
@@ -183,7 +183,7 @@ $ ./atmquery --grep number_of_subcycles
     p3::number_of_subcycles: 1
     rrtmgp::number_of_subcycles: 1
     sc_export::number_of_subcycles: 1
-$ ./atmchange --all number_of_subcycles=3
+$ ./atmchange ANY::number_of_subcycles=3
 Regenerating /path/to/namelist_scream.xml. Manual edits will be lost.
 $ ./atmquery --grep number_of_subcycles
     atmosphere_processes::number_of_subcycles: 3

--- a/components/eamxx/docs/user/model_input.md
+++ b/components/eamxx/docs/user/model_input.md
@@ -157,6 +157,7 @@ ERROR: internal_diagnostics_level is ambiguous. Use ANY in the node path to allo
   namelist_defaults::atmosphere_processes::physics::mac_aero_mic::tms::number_of_subcycles
   namelist_defaults::atmosphere_processes::physics::mac_aero_mic::shoc::number_of_subcycles
   namelist_defaults::atmosphere_processes::physics::mac_aero_mic::cldFraction::number_of_subcycles
+  namelist_defaults::atmosphere_processes::physics::mac_aero_mic::spa::internal_diagnostics_level
   namelist_defaults::atmosphere_processes::physics::mac_aero_mic::p3::number_of_subcycles
   namelist_defaults::atmosphere_processes::physics::rrtmgp::number_of_subcycles
   namelist_defaults::atmosphere_processes::sc_export::number_of_subcycles
@@ -196,6 +197,24 @@ $ ./atmquery --grep number_of_subcycles
     cldFraction::number_of_subcycles: 3
     spa::number_of_subcycles: 3
     p3::number_of_subcycles: 3
+    rrtmgp::number_of_subcycles: 3
+    sc_export::number_of_subcycles: 3
+```
+In addition, "ANY" can be used in a "scoped" string, to limit the set of matches:
+```shell
+$ ./atmchange mac_aero_mic::ANY::number_of_subcycles=1
+Regenerating /path/to/namelist_scream.xml. Manual edits will be lost.
+$ ./atmquery --grep number_of_subcycles
+    atmosphere_processes::number_of_subcycles: 3
+    sc_import::number_of_subcycles: 3
+    homme::number_of_subcycles: 3
+    physics::number_of_subcycles: 3
+    mac_aero_mic::number_of_subcycles: 1
+    tms::number_of_subcycles: 1
+    shoc::number_of_subcycles: 1
+    cldFraction::number_of_subcycles: 1
+    spa::number_of_subcycles: 1
+    p3::number_of_subcycles: 1
     rrtmgp::number_of_subcycles: 3
     sc_export::number_of_subcycles: 3
 ```

--- a/components/eamxx/scripts/atm_manip.py
+++ b/components/eamxx/scripts/atm_manip.py
@@ -478,6 +478,14 @@ def get_parents(elem, parent_map):
 def print_var_impl(node,parent_map,full,dtype,value,valid_values,print_style="invalid",indent=""):
 ###############################################################################
 
+    if len(node)>0:
+        print (f"{indent}{node.tag}:")
+        # This is not a leaf, so print all nested nodes
+        for child in node:
+            print_var_impl(child,parent_map,full,dtype,value,valid_values,'short',indent+"  ")
+
+        return
+
     expect (print_style in ["short","full"],
             f"Invalid print_style '{print_style}' for print_var_impl. Use 'full' or 'short'.")
 
@@ -597,6 +605,7 @@ def atm_query_impl(xml_root,variables,listall=False,full=False,value=False,
         root::prop1: one
         sub::prop1: two
     """
+
     parent_map = create_parent_map(xml_root)
     if listall:
         print_all_vars(xml_root,xml_root,parent_map,"::",full,dtype,value,valid_values,"short","    ")
@@ -619,6 +628,6 @@ def atm_query_impl(xml_root,variables,listall=False,full=False,value=False,
 
     else:
         for var in variables:
-            print_var(xml_root,parent_map,var,full,dtype,value,valid_values,"full","    ")
+            print_var(xml_root,parent_map,var,full,dtype,value,valid_values,"full","  ")
 
     return True

--- a/components/eamxx/scripts/atm_manip.py
+++ b/components/eamxx/scripts/atm_manip.py
@@ -454,7 +454,9 @@ def atm_config_chg_impl(xml_root, change):
 ###############################################################################
 def create_parent_map(root):
 ###############################################################################
-    return {c: p for p in root.iter() for c in p}
+    pmap = {c: p for p in root.iter() for c in p}
+    pmap[root] = None
+    return pmap
 
 ###############################################################################
 def get_parents(elem, parent_map):
@@ -464,9 +466,11 @@ def get_parents(elem, parent_map):
     be the furthest ancestor, last item will be direct parent)
     """
     results = []
-    if elem in parent_map:
+    if elem in parent_map and parent_map[elem] is not None:
         parent = parent_map[elem]
-        results = get_parents(parent, parent_map) + [parent]
+        results = get_parents(parent, parent_map)
+        if parent_map[parent] is not None:
+            results.append(parent)
 
     return results
 

--- a/components/eamxx/scripts/atm_manip.py
+++ b/components/eamxx/scripts/atm_manip.py
@@ -118,7 +118,6 @@ def get_xml_nodes(xml_root, name):
         # Split tokens list into two parts: before and after 'ANY'
         before_any = tokens[:tokens.index('ANY')]
         after_any = tokens[tokens.index('ANY') + 1:]
-        expect (after_any, "Input name should not end with ANY")
 
         # The case where name starts with ::ANY is delicate, since before_any=[''], and this
         # trips the call to get_xml_nodes. Since ANY and ::ANY are conceptually the same,
@@ -133,7 +132,7 @@ def get_xml_nodes(xml_root, name):
         xml_root = new_root[0]
 
         # Use new_root to find all matches for whatever comes after 'ANY::'
-        name = '::'.join(after_any)
+        name = '*' if not after_any else '::'.join(after_any)
     else:
         multiple_hits_ok = False
 

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -122,7 +122,8 @@ OR
 
     parser.add_argument(
         "-a", "--all",
-        action=DeprecatedAction,
+        action=DeprecatedAllFlag,
+        default=argparse.SUPPRESS,
         help="This syntax is deprecated and should not be used. Use ANY:: scope instead."
     )
 

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -31,7 +31,7 @@ def recreate_raw_xml_file():
         create_raw_xml_file(case, caseroot)
 
 ###############################################################################
-def atm_config_chg(changes, reset=False, all_matches=False, buffer_only=False):
+def atm_config_chg(changes, reset=False, buffer_only=False):
 ###############################################################################
     if not buffer_only:
         expect(os.path.exists("namelist_scream.xml"),
@@ -66,7 +66,7 @@ def atm_config_chg(changes, reset=False, all_matches=False, buffer_only=False):
             root = tree.getroot()
 
         for change in changes:
-            this_changed = atm_config_chg_impl(root, change, all_matches)
+            this_changed = atm_config_chg_impl(root, change)
             any_change |= this_changed
 
 
@@ -74,7 +74,7 @@ def atm_config_chg(changes, reset=False, all_matches=False, buffer_only=False):
         # NOTE: if a change is wrong (e.g., typo in param name), we are still buffering it.
         #       We have no way of checking this, unfortunately. If you get an error that is
         #       not just syntax, your best course of action is to run atmchange --reset.
-        buffer_changes(changes, all_matches=all_matches)
+        buffer_changes(changes)
 
         if not buffer_only:
             recreate_raw_xml_file()
@@ -103,13 +103,6 @@ OR
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    parser.add_argument(
-        "-a", "--all",
-        default=False,
-        dest="all_matches",
-        action="store_true",
-        help="Apply change to all entries matching the name"
-    )
     parser.add_argument(
         "-r", "--reset",
         default=False,

--- a/components/eamxx/scripts/atmchange
+++ b/components/eamxx/scripts/atmchange
@@ -23,6 +23,13 @@ sys.path.append(os.path.join(_CIMEROOT, "CIME", "Tools"))
 from standard_script_setup import * # pylint: disable=wildcard-import
 from CIME.case import Case
 
+class DeprecatedAllFlag(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        error_msg  = f"Error: '{option_string}' has been deprecated and should not be used.\n"
+        error_msg +=  "  If you want to change ALL matches for a given var, use 'ANY::$varname=value' syntax instead."
+        print(error_msg, file=sys.stderr)
+        sys.exit(1)
+
 ###############################################################################
 def recreate_raw_xml_file():
 ###############################################################################
@@ -96,6 +103,9 @@ OR
     \033[1;32m# Change param foo to 'hi' (only works if foo is unambiguous)\033[0m
     > {0} foo=hi
 
+    \033[1;32m# Change all matches of param foo to 'hi'\033[0m
+    > {0} ANY::foo=hi
+
     \033[1;32m# Change params foo to 'hi' and append 'there' to bar (only works if both are unambiguous)\033[0m
     > {0} foo=hi bar+=there
 """.format(pathlib.Path(args[0]).name),
@@ -108,6 +118,12 @@ OR
         default=False,
         action="store_true",
         help="Forget all previous atmchanges",
+    )
+
+    parser.add_argument(
+        "-a", "--all",
+        action=DeprecatedAction,
+        help="This syntax is deprecated and should not be used. Use ANY:: scope instead."
     )
 
     parser.add_argument(

--- a/components/eamxx/scripts/atmquery
+++ b/components/eamxx/scripts/atmquery
@@ -69,7 +69,7 @@ OR
         "--grep",
         default=False,
         action="store_true",
-        help="List all matching variables and their values.",
+        help="List all variables matching the input regex string and their values.",
     )
 
     parser.add_argument(

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -253,7 +253,8 @@ class TestBuildnml(unittest.TestCase):
         Test that atmchanges via testmod are preserved
         """
         def_mach_comp = \
-            run_cmd_assert_result(self, "../CIME/Tools/list_e3sm_tests cime_tiny", from_dir=CIME_SCRIPTS_DIR).splitlines()[-1].split(".")[-1]
+            run_cmd_assert_result(self, "../CIME/Tools/list_e3sm_tests cime_tiny", from_dir=CIME_SCRIPTS_DIR).splitlines()[-2].split(".")[-1]
+
         case = self._create_test(f"SMS.ne30_ne30.F2010-SCREAMv1.{def_mach_comp}.scream-scream_example_testmod_atmchange --no-build")
 
         # Check that the value match what's in the testmod

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -119,6 +119,7 @@ class TestBuildnml(unittest.TestCase):
     def setUp(self):
     ###########################################################################
         self._dirs_to_cleanup = []
+        self._common_case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
     ###########################################################################
     def tearDown(self):
@@ -174,7 +175,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that atmchanges are not lost when eamxx setup is called
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         self._chg_atmconfig([("atm_log_level", "trace"), ("output_to_screen", "true")], case)
 
@@ -192,7 +193,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that the append attribute for array-type params in namelist defaults works as expected
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         # Add testOnly proc
         self._chg_atmconfig([("mac_aero_mic::atm_procs_list", "shoc,cldFraction,spa,p3,testOnly")], case)
@@ -213,7 +214,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that var+=value syntax behaves as expected
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         # Append to an existing entry
         name = 'output_yaml_files'
@@ -230,7 +231,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that atmchanges are lost when resetting
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         self._chg_atmconfig([("atm_log_level", "trace")], case, reset=True)
 
@@ -240,7 +241,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that atmchanges are lost if SCREAM_HACK_XML=TRUE
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         run_cmd_assert_result(self, "./xmlchange SCREAM_HACK_XML=TRUE", from_dir=case)
 
@@ -267,7 +268,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that atmchange works when using 'namespace' syntax foo::bar
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         self._chg_atmconfig([("p3::enable_precondition_checks", "false")], case)
 
@@ -277,7 +278,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that atmchange works for array data
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         self._chg_atmconfig([("surf_mom_flux", "40.0,2.0")], case)
 
@@ -287,7 +288,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test that atmchange works with ANY
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         self._chg_atmconfig([("ANY::enable_precondition_checks", "false")], case)
 
@@ -297,7 +298,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test atmchange with ANY followed by an atmchange of one of them
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         self._chg_atmconfig([("ANY::enable_precondition_checks", "false"),
                              ("p3::enable_precondition_checks", "true")], case)
@@ -308,7 +309,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test atmchanges that add atm procs
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         self._chg_atmconfig([("mac_aero_mic::atm_procs_list", "shoc,cldFraction,spa,p3,testOnly")], case)
 
@@ -322,7 +323,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test atmchanges that add atm procs
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         # modifying a procs list requires known processes or "_" pre/post suffixes
         stat, out, err = run_cmd ("./atmchange mac_aero_mic::atm_procs_list=shoc,cldfraction,spa,p3,spiderman",
@@ -336,7 +337,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test atmchange does not change buffer if syntax was wrong
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         # Attempting a bad change should not alter the content of SCREAM_ATMCHANGE_BUFFER
         old = run_cmd_no_fail ("./xmlquery --value SCREAM_ATMCHANGE_BUFFER",from_dir=case)
@@ -353,7 +354,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test atmchange errors out with invalid param names
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         stat, out, err = run_cmd ("./atmchange p3::non_existent=3",from_dir=case)
         expect (stat!=0,"Command './atmchange p3::non_existent=3' should have failed")
@@ -364,7 +365,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test atmchanges that add atm proc groups
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         out = run_cmd_no_fail ("./atmchange mac_aero_mic::atm_procs_list=shoc,_my_group_",from_dir=case)
 
@@ -380,7 +381,7 @@ class TestBuildnml(unittest.TestCase):
         """
         Test atmchanges that remove atm procs
         """
-        case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
+        case = self._common_case
 
         self._chg_atmconfig([("mac_aero_mic::atm_procs_list", "shoc,cldFraction,spa")], case)
 

--- a/components/eamxx/scripts/cime-nml-tests
+++ b/components/eamxx/scripts/cime-nml-tests
@@ -63,13 +63,13 @@ class TestBuildnml(unittest.TestCase):
         return cases[0] if len(cases) == 1 else cases
 
     ###########################################################################
-    def _get_values(self, case, name, value=None, expect_equal=True, all_matches=False):
+    def _get_values(self, case, name, value=None, expect_equal=True):
     ###########################################################################
         """
         Queries a name, optionally checking if the value matches or does not match the
         argument.
         """
-        if not all_matches:
+        if 'ANY' not in name:
             orig = run_cmd_assert_result(self, f"./atmquery {name} --value", from_dir=case)
             if value:
                 if expect_equal:
@@ -80,7 +80,7 @@ class TestBuildnml(unittest.TestCase):
             return [name]
 
         else:
-            output = run_cmd_assert_result(self, f"./atmquery {name} --grep", from_dir=case).splitlines()
+            output = run_cmd_assert_result(self, f"./atmquery {name}", from_dir=case).splitlines()
             names  = [line.rsplit(": ", maxsplit=1)[0].strip() for line in output]
             values = [line.rsplit(": ", maxsplit=1)[1].strip() for line in output]
 
@@ -96,17 +96,13 @@ class TestBuildnml(unittest.TestCase):
     ###########################################################################
     def _chg_atmconfig(self, changes, case, reset=False, expect_lost=None):
     ###########################################################################
-        changes = [(item[0], item[1], False) if len(item) == 2 else item for item in changes]
-
-        expect_lost     = reset if expect_lost is None else expect_lost
+        expect_lost = reset if expect_lost is None else expect_lost
 
         changes_unpacked = {}
-        for name, value, all_matches in changes:
-            all_matches_opt = "-a" if all_matches else ""
+        for name, value in changes:
+            names = self._get_values(case, name, value=value, expect_equal=False)
 
-            names = self._get_values(case, name, value=value, expect_equal=False, all_matches=all_matches)
-
-            run_cmd_assert_result(self, f"./atmchange {all_matches_opt} {name}='{value}'", from_dir=case)
+            run_cmd_assert_result(self, f"./atmchange {name}='{value}'", from_dir=case)
 
             for item in names:
                 changes_unpacked[item] = value
@@ -288,21 +284,21 @@ class TestBuildnml(unittest.TestCase):
     def test_atmchanges_on_all_matches(self):
     ###########################################################################
         """
-        Test that atmchange --all works
+        Test that atmchange works with ANY
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
-        self._chg_atmconfig([("enable_precondition_checks", "false", True)], case)
+        self._chg_atmconfig([("ANY::enable_precondition_checks", "false")], case)
 
     ###########################################################################
     def test_atmchanges_on_all_matches_plus_spec(self):
     ###########################################################################
         """
-        Test atmchange --all followed by an atmchange of one of them
+        Test atmchange with ANY followed by an atmchange of one of them
         """
         case = self._create_test("SMS.ne30_ne30.F2010-SCREAMv1 --no-build")
 
-        self._chg_atmconfig([("enable_precondition_checks", "false", True),
+        self._chg_atmconfig([("ANY::enable_precondition_checks", "false"),
                              ("p3::enable_precondition_checks", "true")], case)
 
     ###########################################################################


### PR DESCRIPTION
The old syntax was `atmchange --all my_param=1` to allow changing all matches of `my_param`. This had two disadvantages:
- it made scripts harder
- it only allows to change ALL matches in the xml

This PR changes the syntax. Instead of passing a flag, we add `ANY` in the scoped name. For instance, given this xml:
```xml
<root>
    <prop1>one</prop1>
    <sub>
        <prop1>two</prop1>
        <prop2 type="integer" valid_values="1,2">2</prop2>
       <other>
          <prop1>43</prop1>
       </other>
    </sub>
</root>
```
we have:
- `atmchange ANY::prop1=2`: changes ALL occurrences of `prop1`
- `atmchange sub::ANY::prop1=2`: changes all occurrences of `prop` _that are nested inside_ `sub`, hence skipping `root::prop1`.

Basically, using this syntax allows to better scope the area of the XML where "--all" (as it was called before) will act.Use ANY:: in the node name string to allow multiple matches.
Notice that as implemented, `ANY` does NOT have to match _at least one sub-node_. In the example above, `sub::ANY::prop1` also matches `sub::prop1`. I considered adding a second keyword, to enforce that ANY would not expand to nothing, something like `sub::ANY_CHILD::prop1`, which would only match `sub::other1::prop1`, but it seemed complicated, and I did not see a real need for it.


WARNING: this is not a backward compatible change. If your run script contains the `--all` flag, it will not work. However, the error message will explain how to change the syntax to comply with the new interface.