### PR TITLE
remove DPxx dt_remap_factor setting

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -659,7 +659,6 @@ be lost if SCREAM_HACK_XML is not enabled.
     <cubed_sphere_map COMPSET=".*DP-EAMxx">2</cubed_sphere_map>
     <disable_diagnostics>False</disable_diagnostics>
     <dt_remap_factor constraints="ge 1">2</dt_remap_factor>
-    <dt_remap_factor COMPSET=".*DP-EAMxx" constraints="ge 1">1</dt_remap_factor>
     <dt_tracer_factor constraints="ge 1">1</dt_tracer_factor>
     <hv_ref_profiles>6</hv_ref_profiles>                <!-- Default (rough topography) -->
     <hv_ref_profiles hgrid="ne4np4">0</hv_ref_profiles> <!-- Value for smooth topography/aquaplanet -->


### PR DESCRIPTION
DPxx is not using the same dt_remap_factor as the global model.  This setting is a lingering relic from the days when DP was forced to run on GLL.

DPxx tests are expected to baseline fail since this is answer changing.