### PR TITLE
Fix field sync for subfields

### DIFF
--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -177,7 +177,7 @@ Field Field::subfield(const std::string& sf_name,
   auto sf_layout = lt.clone();
   sf_layout.reset_dim(idim, index_end - index_beg);
   // Create identifier for subfield
-  FieldIdentifier sf_id(sf_name, sf_layout, sf_units, id.get_grid_name());
+  FieldIdentifier sf_id(sf_name, sf_layout, sf_units, id.get_grid_name(), id.data_type());
 
   // Create empty subfield, then set header and views
   // Note: we can access protected members, since it's the same type

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -68,6 +68,10 @@ sync_to_host () const {
   // Check for early return if Host and Device are the same memory space
   if (m_data.h_view.data() == m_data.d_view.data()) return;
 
+  // We allow sync_to_host for constant fields. Temporarily disable read only flag.
+  const bool original_read_only = m_is_read_only;
+  m_is_read_only = false;
+
   switch (data_type()) {
     case DataType::IntType:
       sync_to_host_impl<int>();
@@ -81,6 +85,9 @@ sync_to_host () const {
     default:
       EKAT_ERROR_MSG("Error! Unrecognized field data type in Field::sync_to_host.\n");
   }
+
+  // Return field to read-only state
+  m_is_read_only = original_read_only;
 }
 
 void Field::

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -137,6 +137,14 @@ subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
   sf.m_data = m_data;
   sf.m_is_read_only = m_is_read_only;
 
+  if (not sf.m_header->get_alloc_properties().contiguous() and
+      not sf.host_and_device_share_memory_space()) {
+    // If subfield is not contiguous and Host and Device do not
+    // share a memory space, we must initialize the helper field
+    // for sync_to functions.
+    sf.initialize_contiguous_helper_field();
+  }
+
   return sf;
 }
 
@@ -177,6 +185,14 @@ Field Field::subfield(const std::string& sf_name,
   sf.m_header = create_subfield_header(sf_id, m_header, idim, index_beg,
                                        index_end);
   sf.m_data = m_data;
+
+  if (not sf.m_header->get_alloc_properties().contiguous() and
+      not sf.host_and_device_share_memory_space()) {
+    // If subfield is not contiguous and Host and Device do not
+    // share a memory space, we must initialize the helper field
+    // for sync_to functions.
+    sf.initialize_contiguous_helper_field();
+  }
 
   return sf;
 }

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -92,7 +92,7 @@ subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
         "Error! Subview dimension index must be either 0 or 1.\n");
 
   // Create identifier for subfield
-  FieldIdentifier sf_id(sf_name,lt.clone().strip_dim(idim),sf_units,id.get_grid_name());
+  FieldIdentifier sf_id(sf_name,lt.clone().strip_dim(idim),sf_units,id.get_grid_name(),id.data_type());
 
   // Create empty subfield, then set header and views
   // Note: we can access protected members, since it's the same type

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -74,13 +74,13 @@ sync_to_host () const {
 
   switch (data_type()) {
     case DataType::IntType:
-      sync_to_host_impl<int>();
+      sync_views_impl<int, Device, Host>();
       break;
     case DataType::FloatType:
-      sync_to_host_impl<float>();
+      sync_views_impl<float, Device, Host>();
       break;
     case DataType::DoubleType:
-      sync_to_host_impl<double>();
+      sync_views_impl<double, Device, Host>();
       break;
     default:
       EKAT_ERROR_MSG("Error! Unrecognized field data type in Field::sync_to_host.\n");
@@ -101,13 +101,13 @@ sync_to_dev () const {
 
   switch (data_type()) {
     case DataType::IntType:
-      sync_to_dev_impl<int>();
+      sync_views_impl<int, Host, Device>();
       break;
     case DataType::FloatType:
-      sync_to_dev_impl<float>();
+      sync_views_impl<float, Host, Device>();
       break;
     case DataType::DoubleType:
-      sync_to_dev_impl<double>();
+      sync_views_impl<double, Host, Device>();
       break;
     default:
       EKAT_ERROR_MSG("Error! Unrecognized field data type in Field::sync_to_dev.\n");

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -60,7 +60,7 @@ Field::clone(const std::string& name) const {
 }
 
 void Field::
-sync_to_host () const {
+sync_to_host (const bool fence) const {
   // Sanity check
   EKAT_REQUIRE_MSG (is_allocated(),
       "Error! Input field must be allocated in order to sync host and device views.\n");
@@ -86,12 +86,14 @@ sync_to_host () const {
       EKAT_ERROR_MSG("Error! Unrecognized field data type in Field::sync_to_host.\n");
   }
 
+  if (fence) Kokkos::fence();
+
   // Return field to read-only state
   m_is_read_only = original_read_only;
 }
 
 void Field::
-sync_to_dev () const {
+sync_to_dev (const bool fence) const {
   // Sanity check
   EKAT_REQUIRE_MSG (is_allocated(),
       "Error! Input field must be allocated in order to sync host and device views.\n");
@@ -112,6 +114,8 @@ sync_to_dev () const {
     default:
       EKAT_ERROR_MSG("Error! Unrecognized field data type in Field::sync_to_dev.\n");
   }
+
+  if (fence) Kokkos::fence();
 }
 
 Field Field::

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -65,7 +65,22 @@ sync_to_host () const {
   EKAT_REQUIRE_MSG (is_allocated(),
       "Error! Input field must be allocated in order to sync host and device views.\n");
 
-  Kokkos::deep_copy(m_data.h_view,m_data.d_view);
+  // Check for early return if Host and Device are the same memory space
+  if (m_data.h_view.data() == m_data.d_view.data()) return;
+
+  switch (data_type()) {
+    case DataType::IntType:
+      sync_to_host_impl<int>();
+      break;
+    case DataType::FloatType:
+      sync_to_host_impl<float>();
+      break;
+    case DataType::DoubleType:
+      sync_to_host_impl<double>();
+      break;
+    default:
+      EKAT_ERROR_MSG("Error! Unrecognized field data type in Field::sync_to_host.\n");
+  }
 }
 
 void Field::

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -66,7 +66,7 @@ sync_to_host () const {
       "Error! Input field must be allocated in order to sync host and device views.\n");
 
   // Check for early return if Host and Device are the same memory space
-  if (m_data.h_view.data() == m_data.d_view.data()) return;
+  if (host_and_device_share_memory_space()) return;
 
   // We allow sync_to_host for constant fields. Temporarily disable read only flag.
   const bool original_read_only = m_is_read_only;
@@ -97,7 +97,7 @@ sync_to_dev () const {
       "Error! Input field must be allocated in order to sync host and device views.\n");
 
   // Check for early return if Host and Device are the same memory space
-  if (m_data.h_view.data() == m_data.d_view.data()) return;
+  if (host_and_device_share_memory_space()) return;
 
   switch (data_type()) {
     case DataType::IntType:

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -89,8 +89,22 @@ sync_to_dev () const {
   EKAT_REQUIRE_MSG (is_allocated(),
       "Error! Input field must be allocated in order to sync host and device views.\n");
 
-  // Ensure host view was created (lazy construction)
-  Kokkos::deep_copy(m_data.d_view,m_data.h_view);
+  // Check for early return if Host and Device are the same memory space
+  if (m_data.h_view.data() == m_data.d_view.data()) return;
+
+  switch (data_type()) {
+    case DataType::IntType:
+      sync_to_dev_impl<int>();
+      break;
+    case DataType::FloatType:
+      sync_to_dev_impl<float>();
+      break;
+    case DataType::DoubleType:
+      sync_to_dev_impl<double>();
+      break;
+    default:
+      EKAT_ERROR_MSG("Error! Unrecognized field data type in Field::sync_to_dev.\n");
+  }
 }
 
 Field Field::

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -285,6 +285,9 @@ protected:
   template<typename ST>
   void sync_to_host_impl () const;
 
+  template<typename ST>
+  void sync_to_dev_impl () const;
+
   template<HostOrDevice HD, typename ST>
   void deep_copy_impl (const ST value);
 

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -278,6 +278,13 @@ public:
   // Allocate the actual view
   void allocate_view ();
 
+  inline bool host_and_device_share_memory_space() const {
+    EKAT_REQUIRE_MSG(is_allocated(),
+                     "Error! Must allocate view before querying "
+                     "host_and_device_share_memory_space().\n");
+    return m_data.h_view.data() == m_data.d_view.data();
+  }
+
 #ifndef KOKKOS_ENABLE_CUDA
   // Cuda requires methods enclosing __device__ lambda's to be public
 protected:

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -193,8 +193,11 @@ public:
   // Note: this class takes no responsibility in keeping track of whether
   //       a sync is required in either direction. Mainly because we expect
   //       host views to be seldom used, and even less frequently modified.
-  void sync_to_host () const;
-  void sync_to_dev () const;
+  // The fence input controls whether a fence is done at the end of the sync.
+  // If multiple syncs are performed in a row on different data, the user may
+  // want to run them asynchronously and fence the final sync_to call.
+  void sync_to_host (const bool fence = true) const;
+  void sync_to_dev (const bool fence = true) const;
 
   // Set the field to a constant value (on host or device)
   template<typename T, HostOrDevice HD = Device>

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -198,11 +198,11 @@ public:
 
   // Set the field to a constant value (on host or device)
   template<typename T, HostOrDevice HD = Device>
-  void deep_copy (const T value);
+  void deep_copy (const T value) const;
 
   // Copy the data from one field to this field
   template<HostOrDevice HD = Device>
-  void deep_copy (const Field& src);
+  void deep_copy (const Field& src) const;
 
   // Updates this field y as y=alpha*x+beta*y
   // NOTE: ST=void is just so we can give a default to HD,
@@ -314,10 +314,10 @@ protected:
   void sync_views_impl () const;
 
   template<HostOrDevice HD, typename ST>
-  void deep_copy_impl (const ST value);
+  void deep_copy_impl (const ST value) const;
 
   template<HostOrDevice HD, typename ST>
-  void deep_copy_impl (const Field& src);
+  void deep_copy_impl (const Field& src) const;
 
   template<CombineMode CM, HostOrDevice HD, typename ST>
   void update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val);

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -282,6 +282,9 @@ public:
   // Cuda requires methods enclosing __device__ lambda's to be public
 protected:
 #endif
+  template<typename ST>
+  void sync_to_host_impl () const;
+
   template<HostOrDevice HD, typename ST>
   void deep_copy_impl (const ST value);
 

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -343,7 +343,9 @@ protected:
   // Actual data.
   dual_view_t<char*> m_data;
 
-  // Whether this field is read-only
+  // Whether this field is read-only. This is given
+  // mutable keyword since it needs to be turned off/on
+  // to allow sync_to_host for constant, read-only fields.
   mutable bool m_is_read_only = false;
 };
 

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -282,11 +282,8 @@ public:
   // Cuda requires methods enclosing __device__ lambda's to be public
 protected:
 #endif
-  template<typename ST>
-  void sync_to_host_impl () const;
-
-  template<typename ST>
-  void sync_to_dev_impl () const;
+  template<typename ST, HostOrDevice From, HostOrDevice To>
+  void sync_views_impl () const;
 
   template<HostOrDevice HD, typename ST>
   void deep_copy_impl (const ST value);

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -344,7 +344,7 @@ protected:
   dual_view_t<char*> m_data;
 
   // Whether this field is read-only
-  bool m_is_read_only = false;
+  mutable bool m_is_read_only = false;
 };
 
 // We use this to find a Field in a std container.

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -222,195 +222,99 @@ get_strided_view_type<DT, HD> {
   return DstView(get_ND_view<HD, DstValueType, DstRank>());
 }
 
-template<typename ST>
-void Field::sync_to_host_impl () const {
+template<typename ST, HostOrDevice From, HostOrDevice To>
+void Field::sync_views_impl () const {
   const auto alloc_props = get_header().get_alloc_properties();
   switch (rank()) {
     case 0:
-      Kokkos::deep_copy(get_view<ST, Host>(), get_view<const ST, Device>());
+      Kokkos::deep_copy(get_view<ST, To>(), get_view<const ST, From>());
       break;
     case 1:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST*, Host>(), get_view<const ST*, Device>());
+        Kokkos::deep_copy(get_view<ST*, To>(), get_view<const ST*, From>());
       } else {
-        auto host_view = get_strided_view<      ST*, Host>();
-        auto dev_view  = get_strided_view<const ST*, Device>();
-        for (size_t i=0; i<host_view.extent(0); ++i) {
-          auto host_view_i = Kokkos::subview(host_view, i);
-          auto dev_view_i  = Kokkos::subview(dev_view,  i);
-          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(host_view_i, dev_view_i);
+        auto to_view   = get_strided_view<      ST*, To  >();
+        auto from_view = get_strided_view<const ST*, From>();
+        for (size_t i=0; i<to_view.extent(0); ++i) {
+          auto to_view_i   = Kokkos::subview(to_view,   i);
+          auto from_view_i = Kokkos::subview(from_view, i);
+          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(to_view_i, from_view_i);
         }
       }
       break;
     case 2:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST**, Host>(), get_view<const ST**, Device>());
+        Kokkos::deep_copy(get_view<ST**, To>(), get_view<const ST**, From>());
       } else {
-        auto host_view = get_strided_view<      ST**, Host>();
-        auto dev_view  = get_strided_view<const ST**, Device>();
-        for (size_t i=0; i<host_view.extent(0); ++i) {
-          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL());
-          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL());
-          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(host_view_i, dev_view_i);
+        auto to_view   = get_strided_view<      ST**, To  >();
+        auto from_view = get_strided_view<const ST**, From>();
+        for (size_t i=0; i<to_view.extent(0); ++i) {
+          auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL());
+          auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL());
+          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(to_view_i, from_view_i);
         }
       }
       break;
     case 3:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST***, Host>(), get_view<const ST***, Device>());
+        Kokkos::deep_copy(get_view<ST***, To>(), get_view<const ST***, From>());
       } else {
-        auto host_view = get_strided_view<      ST***, Host>();
-        auto dev_view  = get_strided_view<const ST***, Device>();
-        for (size_t i=0; i<host_view.extent(0); ++i) {
-          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL());
-          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(host_view_i, dev_view_i);
+        auto to_view   = get_strided_view<      ST***, To  >();
+        auto from_view = get_strided_view<const ST***, From>();
+        for (size_t i=0; i<to_view.extent(0); ++i) {
+          auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL());
+          auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(to_view_i, from_view_i);
         }
       }
       break;
     case 4:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST****, Host>(), get_view<const ST****, Device>());
+        Kokkos::deep_copy(get_view<ST****, To>(), get_view<const ST****, From>());
       } else {
-        auto host_view = get_strided_view<      ST****, Host>();
-        auto dev_view  = get_strided_view<const ST****, Device>();
-        for (size_t i=0; i<host_view.extent(0); ++i) {
-          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(host_view_i, dev_view_i);
+        auto to_view   = get_strided_view<      ST****, To  >();
+        auto from_view = get_strided_view<const ST****, From>();
+        for (size_t i=0; i<to_view.extent(0); ++i) {
+          auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(to_view_i, from_view_i);
         }
       }
       break;
     case 5:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST*****, Host>(), get_view<const ST*****, Device>());
+        Kokkos::deep_copy(get_view<ST*****, To>(), get_view<const ST*****, From>());
       } else {
-        auto host_view = get_strided_view<      ST*****, Host>();
-        auto dev_view  = get_strided_view<const ST*****, Device>();
-        for (size_t i=0; i<host_view.extent(0); ++i) {
-          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(host_view_i, dev_view_i);
+        auto to_view   = get_strided_view<      ST*****, To  >();
+        auto from_view = get_strided_view<const ST*****, From>();
+        for (size_t i=0; i<to_view.extent(0); ++i) {
+          auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(to_view_i, from_view_i);
         }
       }
       break;
     case 6:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST******, Host>(), get_view<const ST******, Device>());
+        Kokkos::deep_copy(get_view<ST******, To>(), get_view<const ST******, From>());
       } else {
-        auto host_view = get_strided_view<      ST******, Host>();
-        auto dev_view  = get_strided_view<const ST******, Device>();
-        for (size_t i=0; i<host_view.extent(0); ++i) {
-          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(host_view_i, dev_view_i);
+        auto to_view   = get_strided_view<      ST******, To  >();
+        auto from_view = get_strided_view<const ST******, From>();
+        for (size_t i=0; i<to_view.extent(0); ++i) {
+          auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(to_view_i, from_view_i);
         }
       }
       break;
     default:
       EKAT_ERROR_MSG ("Error! Unsupported field rank in Field::sync_to_host.\n");
-  }
-}
-
-template<typename ST>
-void Field::sync_to_dev_impl () const {
-  const auto alloc_props = get_header().get_alloc_properties();
-  switch (rank()) {
-    case 0:
-      Kokkos::deep_copy(get_view<ST, Device>(), get_view<const ST, Host>());
-      break;
-    case 1:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST*, Device>(), get_view<const ST*, Host>());
-      } else {
-        auto dev_view  = get_strided_view<      ST*, Device>();
-        auto host_view = get_strided_view<const ST*, Host>();
-        for (size_t i=0; i<dev_view.extent(0); ++i) {
-          auto dev_view_i  = Kokkos::subview(dev_view,  i);
-          auto host_view_i = Kokkos::subview(host_view, i);
-          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(dev_view_i, host_view_i);
-        }
-      }
-      break;
-    case 2:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST**, Device>(), get_view<const ST**, Host>());
-      } else {
-        auto dev_view  = get_strided_view<      ST**, Device>();
-        auto host_view = get_strided_view<const ST**, Host>();
-        for (size_t i=0; i<dev_view.extent(0); ++i) {
-          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL());
-          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL());
-          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(dev_view_i, host_view_i);
-        }
-      }
-      break;
-    case 3:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST***, Device>(), get_view<const ST***, Host>());
-      } else {
-        auto dev_view  = get_strided_view<      ST***, Device>();
-        auto host_view = get_strided_view<const ST***, Host>();
-        for (size_t i=0; i<dev_view.extent(0); ++i) {
-          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL());
-          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(dev_view_i, host_view_i);
-        }
-      }
-      break;
-    case 4:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST****, Device>(), get_view<const ST****, Host>());
-      } else {
-        auto dev_view  = get_strided_view<      ST****, Device>();
-        auto host_view = get_strided_view<const ST****, Host>();
-        for (size_t i=0; i<dev_view.extent(0); ++i) {
-          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(dev_view_i, host_view_i);
-        }
-      }
-      break;
-    case 5:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST*****, Device>(), get_view<const ST*****, Host>());
-      } else {
-        auto dev_view  = get_strided_view<      ST*****, Device>();
-        auto host_view = get_strided_view<const ST*****, Host>();
-        for (size_t i=0; i<dev_view.extent(0); ++i) {
-          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(dev_view_i, host_view_i);
-        }
-      }
-      break;
-    case 6:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST******, Device>(), get_view<const ST******, Host>());
-      } else {
-        auto dev_view  = get_strided_view<      ST******, Device>();
-        auto host_view = get_strided_view<const ST******, Host>();
-        for (size_t i=0; i<dev_view.extent(0); ++i) {
-          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(dev_view_i, host_view_i);
-        }
-      }
-      break;
-    default:
-      EKAT_ERROR_MSG ("Error! Unsupported field rank in 'sync_to_dev'.\n");
   }
 }
 

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -224,103 +224,48 @@ get_strided_view_type<DT, HD> {
 
 template<typename ST, HostOrDevice From, HostOrDevice To>
 void Field::sync_views_impl () const {
-  using ExecSpace = typename Field::get_device<Device>::execution_space;
-  
-  const auto alloc_props = get_header().get_alloc_properties();
-  switch (rank()) {
-    case 0:
-      Kokkos::deep_copy(ExecSpace(), get_view<ST, To>(), get_view<const ST, From>());
-      break;
-    case 1:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(ExecSpace(), get_view<ST*, To>(), get_view<const ST*, From>());
-      } else {
-        auto to_view   = get_strided_view<      ST*, To  >();
-        auto from_view = get_strided_view<const ST*, From>();
-        for (size_t i=0; i<to_view.extent(0); ++i) {
-          auto to_view_i   = Kokkos::subview(to_view,   i);
-          auto from_view_i = Kokkos::subview(from_view, i);
-          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
-        }
-      }
-      break;
-    case 2:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(ExecSpace(), get_view<ST**, To>(), get_view<const ST**, From>());
-      } else {
-        auto to_view   = get_strided_view<      ST**, To  >();
-        auto from_view = get_strided_view<const ST**, From>();
-        for (size_t i=0; i<to_view.extent(0); ++i) {
-          auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL());
-          auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL());
-          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
-        }
-      }
-      break;
-    case 3:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(ExecSpace(), get_view<ST***, To>(), get_view<const ST***, From>());
-      } else {
-        auto to_view   = get_strided_view<      ST***, To  >();
-        auto from_view = get_strided_view<const ST***, From>();
-        for (size_t i=0; i<to_view.extent(0); ++i) {
-          auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL());
-          auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
-        }
-      }
-      break;
-    case 4:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(ExecSpace(), get_view<ST****, To>(), get_view<const ST****, From>());
-      } else {
-        auto to_view   = get_strided_view<      ST****, To  >();
-        auto from_view = get_strided_view<const ST****, From>();
-        for (size_t i=0; i<to_view.extent(0); ++i) {
-          auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
-        }
-      }
-      break;
-    case 5:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(ExecSpace(), get_view<ST*****, To>(), get_view<const ST*****, From>());
-      } else {
-        auto to_view   = get_strided_view<      ST*****, To  >();
-        auto from_view = get_strided_view<const ST*****, From>();
-        for (size_t i=0; i<to_view.extent(0); ++i) {
-          auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
-        }
-      }
-      break;
-    case 6:
-      if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(ExecSpace(), get_view<ST******, To>(), get_view<const ST******, From>());
-      } else {
-        auto to_view   = get_strided_view<      ST******, To  >();
-        auto from_view = get_strided_view<const ST******, From>();
-        for (size_t i=0; i<to_view.extent(0); ++i) {
-          auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
-          EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
-        }
-      }
-      break;
-    default:
-      EKAT_ERROR_MSG ("Error! Unsupported field rank in Field::sync_to_host.\n");
-  }
-  // Since deep_copy are all async wrt host, we need to fence before returning
-  if constexpr (To == Host) { 
-    Kokkos::fence();
+
+  const bool is_contiguous = get_header().get_alloc_properties().contiguous();
+  if (is_contiguous) {
+    // For contiguous fields, simply use Kokkos::deep_copy()
+    switch (rank()) {
+      case 0:
+        Kokkos::deep_copy(get_view<ST, To>(), get_view<const ST, From>());
+        break;
+      case 1:
+        Kokkos::deep_copy(get_view<ST*, To>(), get_view<const ST*, From>());
+        break;
+      case 2:
+        Kokkos::deep_copy(get_view<ST**, To>(), get_view<const ST**, From>());
+        break;
+      case 3:
+        Kokkos::deep_copy(get_view<ST***, To>(), get_view<const ST***, From>());
+        break;
+      case 4:
+        Kokkos::deep_copy(get_view<ST****, To>(), get_view<const ST****, From>());
+        break;
+      case 5:
+        Kokkos::deep_copy(get_view<ST*****, To>(), get_view<const ST*****, From>());
+        break;
+      case 6:
+        Kokkos::deep_copy(get_view<ST******, To>(), get_view<const ST******, From>());
+        break;
+      default:
+        EKAT_ERROR_MSG ("Error! Unsupported field rank in Field::sync_to_host.\n");
+    }
+  } else {
+    // Store values in contiguous helper field
+    m_contiguous_field->deep_copy<From>(*this);
+
+    // Sync helper field
+    if constexpr (To==Host) {
+      m_contiguous_field->sync_to_host();
+    } else {
+      m_contiguous_field->sync_to_dev();
+    }
+
+    // Copy values back to this field
+    deep_copy<To>(*m_contiguous_field);
   }
 }
 

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -222,6 +222,102 @@ get_strided_view_type<DT, HD> {
   return DstView(get_ND_view<HD, DstValueType, DstRank>());
 }
 
+template<typename ST>
+void Field::sync_to_host_impl () const {
+  const auto alloc_props = get_header().get_alloc_properties();
+  switch (rank()) {
+    case 0:
+      Kokkos::deep_copy(get_view<ST, Host>(), get_view<const ST, Device>());
+      break;
+    case 1:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST*, Host>(), get_view<const ST*, Device>());
+      } else {
+        auto host_view = get_strided_view<      ST*, Host>();
+        auto dev_view  = get_strided_view<const ST*, Device>();
+        for (size_t i=0; i<host_view.extent(0); ++i) {
+          auto host_view_i = Kokkos::subview(host_view, i);
+          auto dev_view_i  = Kokkos::subview(dev_view,  i);
+          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(host_view_i, dev_view_i);
+        }
+      }
+      break;
+    case 2:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST**, Host>(), get_view<const ST**, Device>());
+      } else {
+        auto host_view = get_strided_view<      ST**, Host>();
+        auto dev_view  = get_strided_view<const ST**, Device>();
+        for (size_t i=0; i<host_view.extent(0); ++i) {
+          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL());
+          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL());
+          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(host_view_i, dev_view_i);
+        }
+      }
+      break;
+    case 3:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST***, Host>(), get_view<const ST***, Device>());
+      } else {
+        auto host_view = get_strided_view<      ST***, Host>();
+        auto dev_view  = get_strided_view<const ST***, Device>();
+        for (size_t i=0; i<host_view.extent(0); ++i) {
+          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL());
+          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(host_view_i, dev_view_i);
+        }
+      }
+      break;
+    case 4:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST****, Host>(), get_view<const ST****, Device>());
+      } else {
+        auto host_view = get_strided_view<      ST****, Host>();
+        auto dev_view  = get_strided_view<const ST****, Device>();
+        for (size_t i=0; i<host_view.extent(0); ++i) {
+          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(host_view_i, dev_view_i);
+        }
+      }
+      break;
+    case 5:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST*****, Host>(), get_view<const ST*****, Device>());
+      } else {
+        auto host_view = get_strided_view<      ST*****, Host>();
+        auto dev_view  = get_strided_view<const ST*****, Device>();
+        for (size_t i=0; i<host_view.extent(0); ++i) {
+          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(host_view_i, dev_view_i);
+        }
+      }
+      break;
+    case 6:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST******, Host>(), get_view<const ST******, Device>());
+      } else {
+        auto host_view = get_strided_view<      ST******, Host>();
+        auto dev_view  = get_strided_view<const ST******, Device>();
+        for (size_t i=0; i<host_view.extent(0); ++i) {
+          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(host_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(host_view_i, dev_view_i);
+        }
+      }
+      break;
+    default:
+      EKAT_ERROR_MSG ("Error! Unsupported field rank in Field::sync_to_host.\n");
+  }
+}
+
 template<HostOrDevice HD>
 void Field::
 deep_copy (const Field& src) {

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -224,14 +224,16 @@ get_strided_view_type<DT, HD> {
 
 template<typename ST, HostOrDevice From, HostOrDevice To>
 void Field::sync_views_impl () const {
+  using ExecSpace = typename Field::get_device<Device>::execution_space;
+  
   const auto alloc_props = get_header().get_alloc_properties();
   switch (rank()) {
     case 0:
-      Kokkos::deep_copy(get_view<ST, To>(), get_view<const ST, From>());
+      Kokkos::deep_copy(ExecSpace(), get_view<ST, To>(), get_view<const ST, From>());
       break;
     case 1:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST*, To>(), get_view<const ST*, From>());
+        Kokkos::deep_copy(ExecSpace(), get_view<ST*, To>(), get_view<const ST*, From>());
       } else {
         auto to_view   = get_strided_view<      ST*, To  >();
         auto from_view = get_strided_view<const ST*, From>();
@@ -239,13 +241,13 @@ void Field::sync_views_impl () const {
           auto to_view_i   = Kokkos::subview(to_view,   i);
           auto from_view_i = Kokkos::subview(from_view, i);
           EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(to_view_i, from_view_i);
+          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
         }
       }
       break;
     case 2:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST**, To>(), get_view<const ST**, From>());
+        Kokkos::deep_copy(ExecSpace(), get_view<ST**, To>(), get_view<const ST**, From>());
       } else {
         auto to_view   = get_strided_view<      ST**, To  >();
         auto from_view = get_strided_view<const ST**, From>();
@@ -253,13 +255,13 @@ void Field::sync_views_impl () const {
           auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL());
           auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL());
           EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(to_view_i, from_view_i);
+          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
         }
       }
       break;
     case 3:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST***, To>(), get_view<const ST***, From>());
+        Kokkos::deep_copy(ExecSpace(), get_view<ST***, To>(), get_view<const ST***, From>());
       } else {
         auto to_view   = get_strided_view<      ST***, To  >();
         auto from_view = get_strided_view<const ST***, From>();
@@ -267,13 +269,13 @@ void Field::sync_views_impl () const {
           auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL());
           auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL());
           EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(to_view_i, from_view_i);
+          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
         }
       }
       break;
     case 4:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST****, To>(), get_view<const ST****, From>());
+        Kokkos::deep_copy(ExecSpace(), get_view<ST****, To>(), get_view<const ST****, From>());
       } else {
         auto to_view   = get_strided_view<      ST****, To  >();
         auto from_view = get_strided_view<const ST****, From>();
@@ -281,13 +283,13 @@ void Field::sync_views_impl () const {
           auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
           auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
           EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(to_view_i, from_view_i);
+          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
         }
       }
       break;
     case 5:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST*****, To>(), get_view<const ST*****, From>());
+        Kokkos::deep_copy(ExecSpace(), get_view<ST*****, To>(), get_view<const ST*****, From>());
       } else {
         auto to_view   = get_strided_view<      ST*****, To  >();
         auto from_view = get_strided_view<const ST*****, From>();
@@ -295,13 +297,13 @@ void Field::sync_views_impl () const {
           auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
           auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
           EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(to_view_i, from_view_i);
+          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
         }
       }
       break;
     case 6:
       if (alloc_props.contiguous()) {
-        Kokkos::deep_copy(get_view<ST******, To>(), get_view<const ST******, From>());
+        Kokkos::deep_copy(ExecSpace(), get_view<ST******, To>(), get_view<const ST******, From>());
       } else {
         auto to_view   = get_strided_view<      ST******, To  >();
         auto from_view = get_strided_view<const ST******, From>();
@@ -309,12 +311,16 @@ void Field::sync_views_impl () const {
           auto to_view_i   = Kokkos::subview(to_view,   i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
           auto from_view_i = Kokkos::subview(from_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
           EKAT_REQUIRE_MSG(to_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
-          Kokkos::deep_copy(to_view_i, from_view_i);
+          Kokkos::deep_copy(ExecSpace(), to_view_i, from_view_i);
         }
       }
       break;
     default:
       EKAT_ERROR_MSG ("Error! Unsupported field rank in Field::sync_to_host.\n");
+  }
+  // Since deep_copy are all async wrt host, we need to fence before returning
+  if constexpr (To == Host) { 
+    Kokkos::fence();
   }
 }
 

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -318,6 +318,102 @@ void Field::sync_to_host_impl () const {
   }
 }
 
+template<typename ST>
+void Field::sync_to_dev_impl () const {
+  const auto alloc_props = get_header().get_alloc_properties();
+  switch (rank()) {
+    case 0:
+      Kokkos::deep_copy(get_view<ST, Device>(), get_view<const ST, Host>());
+      break;
+    case 1:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST*, Device>(), get_view<const ST*, Host>());
+      } else {
+        auto dev_view  = get_strided_view<      ST*, Device>();
+        auto host_view = get_strided_view<const ST*, Host>();
+        for (size_t i=0; i<dev_view.extent(0); ++i) {
+          auto dev_view_i  = Kokkos::subview(dev_view,  i);
+          auto host_view_i = Kokkos::subview(host_view, i);
+          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(dev_view_i, host_view_i);
+        }
+      }
+      break;
+    case 2:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST**, Device>(), get_view<const ST**, Host>());
+      } else {
+        auto dev_view  = get_strided_view<      ST**, Device>();
+        auto host_view = get_strided_view<const ST**, Host>();
+        for (size_t i=0; i<dev_view.extent(0); ++i) {
+          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL());
+          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL());
+          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(dev_view_i, host_view_i);
+        }
+      }
+      break;
+    case 3:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST***, Device>(), get_view<const ST***, Host>());
+      } else {
+        auto dev_view  = get_strided_view<      ST***, Device>();
+        auto host_view = get_strided_view<const ST***, Host>();
+        for (size_t i=0; i<dev_view.extent(0); ++i) {
+          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL());
+          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(dev_view_i, host_view_i);
+        }
+      }
+      break;
+    case 4:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST****, Device>(), get_view<const ST****, Host>());
+      } else {
+        auto dev_view  = get_strided_view<      ST****, Device>();
+        auto host_view = get_strided_view<const ST****, Host>();
+        for (size_t i=0; i<dev_view.extent(0); ++i) {
+          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(dev_view_i, host_view_i);
+        }
+      }
+      break;
+    case 5:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST*****, Device>(), get_view<const ST*****, Host>());
+      } else {
+        auto dev_view  = get_strided_view<      ST*****, Device>();
+        auto host_view = get_strided_view<const ST*****, Host>();
+        for (size_t i=0; i<dev_view.extent(0); ++i) {
+          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(dev_view_i, host_view_i);
+        }
+      }
+      break;
+    case 6:
+      if (alloc_props.contiguous()) {
+        Kokkos::deep_copy(get_view<ST******, Device>(), get_view<const ST******, Host>());
+      } else {
+        auto dev_view  = get_strided_view<      ST******, Device>();
+        auto host_view = get_strided_view<const ST******, Host>();
+        for (size_t i=0; i<dev_view.extent(0); ++i) {
+          auto dev_view_i  = Kokkos::subview(dev_view,  i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          auto host_view_i = Kokkos::subview(host_view, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          EKAT_REQUIRE_MSG(dev_view_i.span_is_contiguous(), "Error! EAMxx field must be contiguous after the first dimension.\n");
+          Kokkos::deep_copy(dev_view_i, host_view_i);
+        }
+      }
+      break;
+    default:
+      EKAT_ERROR_MSG ("Error! Unsupported field rank in 'sync_to_dev'.\n");
+  }
+}
+
 template<HostOrDevice HD>
 void Field::
 deep_copy (const Field& src) {

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -326,7 +326,7 @@ void Field::sync_views_impl () const {
 
 template<HostOrDevice HD>
 void Field::
-deep_copy (const Field& src) {
+deep_copy (const Field& src) const {
   EKAT_REQUIRE_MSG (not m_is_read_only,
       "Error! Cannot call deep_copy on read-only fields.\n");
 
@@ -350,7 +350,7 @@ deep_copy (const Field& src) {
 
 template<typename ST, HostOrDevice HD>
 void Field::
-deep_copy (const ST value) {
+deep_copy (const ST value) const {
   EKAT_REQUIRE_MSG (not m_is_read_only,
       "Error! Cannot call deep_copy on read-only fields.\n");
 
@@ -384,7 +384,7 @@ deep_copy (const ST value) {
 
 template<HostOrDevice HD, typename ST>
 void Field::
-deep_copy_impl (const Field& src) {
+deep_copy_impl (const Field& src) const {
 
   const auto& layout     =     get_header().get_identifier().get_layout();
   const auto& layout_src = src.get_header().get_identifier().get_layout();
@@ -528,7 +528,7 @@ deep_copy_impl (const Field& src) {
 }
 
 template<HostOrDevice HD, typename ST>
-void Field::deep_copy_impl (const ST value) {
+void Field::deep_copy_impl (const ST value) const {
 
   // Note: we can't just do a deep copy on get_view_impl<HD>(), since this
   //       field might be a subfield of another. Instead, get the

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -224,7 +224,8 @@ get_strided_view_type<DT, HD> {
 
 template<typename ST, HostOrDevice From, HostOrDevice To>
 void Field::sync_views_impl () const {
-  // All deep_copy call we want to be async for host.
+  // For all Kokkos::deep_copy() calls we will pass in an instance of the
+  // device execution space so that we are asynchronous w.r.t. host.
   using DeviceExecSpace = typename Field::get_device<Device>::execution_space;
 
   // Rank 0 will always be contiguous. Copy and return early.

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -3,6 +3,7 @@
 #include "share/grid/point_grid.hpp"
 #include "share/grid/grid_import_export.hpp"
 #include "share/io/scorpio_input.hpp"
+#include "share/field/field.hpp"
 
 #include <ekat/kokkos/ekat_kokkos_utils.hpp>
 #include <ekat/ekat_pack_utils.hpp>

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -835,8 +835,7 @@ TEST_CASE ("sync_subfields") {
   f.allocate_view();
 
   // Store whether mem space for host and device are the same for testing subfield values
-  const bool shared_mem_space =
-      f.get_view<int***,Device>().data() == f.get_view<int***, Host>().data();
+  const bool shared_mem_space = f.host_and_device_share_memory_space();
 
   // Deep copy all values to ndims on device and host
   f.deep_copy(ndims);


### PR DESCRIPTION
Closes https://github.com/E3SM-Project/scream/issues/2973. Previously, calling `sub_field.sync_to_{host|dev}()` would sync the entire parent data array. Now only sync subfield data.

Test added here previously failed on GPU machine when Device and Host did not share a memory space.

Can do some performance testing if anyone is interested.