### PR TITLE
Add explicit Core/24.00 module to crayclang-scream for Frontier.

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1160,10 +1160,11 @@ commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" iss
       </modules>
       <modules compiler="crayclang-scream">
         <command name="reset"></command>
+        <command name="load">Core/24.00</command>
         <command name="load">cpe/22.12</command>
         <command name="load">craype-accel-amd-gfx90a</command>
         <command name="load">rocm/5.4.0</command>
-        <command name="load">libunwind/1.6.2</command>
+        <command name="load">libunwind/1.5.0</command>
         <command name="load">cce/15.0.1</command>
         <command name="load">libfabric/1.15.2.0</command>
         <command name="load">craype/2.7.20</command>


### PR DESCRIPTION
OLCF plans to switch defaults for module `Core` from `24.00` to `24.07`. The newer module has a newer version of `cmake`, and not `cmake/3.21.3`. The newer `cmake` is apparently confused by the older style of handling the Cray and AMD compilers. This pull request adds explicit loading of the soon-to-be-previous-default module, `Core/24.00`, for Frontier build with `crayclang-scream`. I also changed the version of `libunwind` to one that is actually available. I think the previous builds quietly failed to load it.

I confirmed that the newer software stack, represented by compiler `craygnuamdgpu`, works with `Core/24.07`, so I made no changes to that config.

As an aside, I recommend that all new E3SM runs on Frontier move to `craygnuamdgpu`.