### PR TITLE
AD Debug Option to set a FAIL point

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -604,6 +604,7 @@ be lost if SCREAM_HACK_XML is not enabled.
 
   <!-- driver_options options for scream -->
   <driver_options>
+    <step_to_fail type="integer">-9999</step_to_fail>
     <atmosphere_dag_verbosity_level>0</atmosphere_dag_verbosity_level>
     <atm_log_level type="string"
                    valid_values="trace,debug,info,warn,error"

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -48,7 +48,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <sections>ctl_nl</sections>
     </file>
     <file name="data/scream_input.yaml" format="yaml">
-      <sections>driver_options,iop_options,atmosphere_processes,grids_manager,initial_conditions,Scorpio,e3sm_parameters</sections>
+      <sections>driver_debug_options,driver_options,iop_options,atmosphere_processes,grids_manager,initial_conditions,Scorpio,e3sm_parameters</sections>
     </file>
   </generated_files>
 
@@ -602,9 +602,20 @@ be lost if SCREAM_HACK_XML is not enabled.
     </model_restart>
   </Scorpio>
 
+  <!-- driver debug options for eamxx -->
+  <!--
+       These options are meant for power users to debug the code.
+       They are not meant to be used for typical eamxx simulations.
+  --> 
+  <driver_debug_options>
+    <force_crash_nsteps type="integer"
+		  doc="Force simulation to fail at a specific atmosphere timestep">
+      -9999
+    </force_crash_nsteps>
+  </driver_debug_options>
+
   <!-- driver_options options for scream -->
   <driver_options>
-    <step_to_fail type="integer">-9999</step_to_fail>
     <atmosphere_dag_verbosity_level>0</atmosphere_dag_verbosity_level>
     <atm_log_level type="string"
                    valid_values="trace,debug,info,warn,error"

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1594,6 +1594,10 @@ initialize (const ekat::Comm& atm_comm,
 void AtmosphereDriver::run (const int dt) {
   start_timer("EAMxx::run");
 
+  int dtf = m_atm_params.sublist("driver_options").get("step_to_fail", -9999);
+  if (m_current_ts.get_num_steps()==dtf) {
+    abort(); 
+  }
   // Make sure the end of the time step is after the current start_time
   EKAT_REQUIRE_MSG (dt>0, "Error! Input time step must be positive.\n");
 

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1595,12 +1595,12 @@ void AtmosphereDriver::run (const int dt) {
   start_timer("EAMxx::run");
 
   // DEBUG option: Check if user has set the run to fail at a specific timestep.
-  if (m_atm_params.isSublist("driver_debug_options")) {
-    bool force_fail_nstep = m_atm_params.sublist("driver_debug_options").get<int>("force_crash_nsteps", -9999)==m_current_ts.get_num_steps();
-    if (force_fail_nstep) {
-      abort();
-    }
+  auto& debug = m_atm_params.sublist("driver_debug_options"); 
+  auto fail_step = debug.get<int>("force_crash_nsteps",-1); 
+  if (fail_step==m_current_ts.get_num_steps()) { 
+    std::abort(); 
   }
+
   // Make sure the end of the time step is after the current start_time
   EKAT_REQUIRE_MSG (dt>0, "Error! Input time step must be positive.\n");
 

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1594,9 +1594,12 @@ initialize (const ekat::Comm& atm_comm,
 void AtmosphereDriver::run (const int dt) {
   start_timer("EAMxx::run");
 
-  int dtf = m_atm_params.sublist("driver_options").get("step_to_fail", -9999);
-  if (m_current_ts.get_num_steps()==dtf) {
-    abort(); 
+  // DEBUG option: Check if user has set the run to fail at a specific timestep.
+  if (m_atm_params.isSublist("driver_debug_options")) {
+    bool force_fail_nstep = m_atm_params.sublist("driver_debug_options").get<int>("force_crash_nsteps", -9999)==m_current_ts.get_num_steps();
+    if (force_fail_nstep) {
+      abort();
+    }
   }
   // Make sure the end of the time step is after the current start_time
   EKAT_REQUIRE_MSG (dt>0, "Error! Input time step must be positive.\n");


### PR DESCRIPTION
This commit will add a new sub-parameter list for the AD that will control debug options that would not typically be run for a model simulation.

The first application of the new DEBUG parameters is to add an option to force an `abort` at the driver level at a specific time step.  The new option is called `force_crash_nsteps` and will force the AD to abort once a specific timestep is reached.