### PR TITLE
p3 auto, accr, scol runtime params

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -210,6 +210,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <p3_accretion_qc_exponent type="real" doc="Accretion qc exponent in P3">1.15</p3_accretion_qc_exponent>
       <p3_accretion_qr_exponent type="real" doc="Accretion qr exponent in P3">1.15</p3_accretion_qr_exponent>
       <p3_rain_selfcollection_prefactor type="real" doc="Rain selfcollection prefactor in P3">5.78</p3_rain_selfcollection_prefactor>
+      <p3_rain_selfcollection_breakup_diameter type="real" doc="Rain selfcollection breakup diameter (meter) in P3">0.00028</p3_rain_selfcollection_breakup_diameter>
       <p3_mu_r_constant type="real" doc="P3 mu_r_constant (rain shape parameter in gamma drop-size distribution)">1.0</p3_mu_r_constant>
       <p3_spa_to_nc type="real" doc="P3 spa_to_nc (scaling factor for turning CCN into nc in SPA)">1.0</p3_spa_to_nc>
       <p3_eci type="real" doc="P3 eci (liquid/ice collision/collection coefficient)">0.5</p3_eci>
@@ -219,7 +220,6 @@ be lost if SCREAM_HACK_XML is not enabled.
       <p3_a_imm type="real" doc="P3 a_imm (drop freezing exponent )">0.65</p3_a_imm>
       <p3_dep_nucleation_exponent type="real" doc="P3 dep_nucleation_exponent (deposition nucleation)">0.304</p3_dep_nucleation_exponent>
       <p3_ice_sed_knob type="real" doc="P3 ice_sed_knob (ice fall speed)">1.0</p3_ice_sed_knob>
-      <p3_d_breakup_cutoff type="real" doc="P3 d_breakup_cutoff (rain self collection and breakup)">0.00028</p3_d_breakup_cutoff>
       <p3_do_ice_production type="logical" doc="Flag to turn on ice production processes in P3 (loss processes unaffected by this flag)">true</p3_do_ice_production>
     </p3>
 

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -208,6 +208,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <p3_accretion_prefactor type="real" doc="Accretion linear prefactor in P3">67.0</p3_accretion_prefactor>
       <p3_accretion_qc_exponent type="real" doc="Accretion qc exponent in P3">1.15</p3_accretion_qc_exponent>
       <p3_accretion_qr_exponent type="real" doc="Accretion qr exponent in P3">1.15</p3_accretion_qr_exponent>
+      <p3_rain_selfcollection_prefactor type="real" doc="Rain selfcollection prefactor in P3">5.78</p3_rain_selfcollection_prefactor>
       <p3_mu_r_constant type="real" doc="P3 mu_r_constant (rain shape parameter in gamma drop-size distribution)">1.0</p3_mu_r_constant>
       <p3_spa_to_nc type="real" doc="P3 spa_to_nc (scaling factor for turning CCN into nc in SPA)">1.0</p3_spa_to_nc>
       <p3_eci type="real" doc="P3 eci (liquid/ice collision/collection coefficient)">0.5</p3_eci>

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -205,6 +205,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <p3_autoconversion_prefactor type="real" doc="Autoconversion linear prefactor in P3">1350.0</p3_autoconversion_prefactor>
       <p3_autoconversion_qc_exponent type="real" doc="Autoconversion qc exponent in P3">2.47</p3_autoconversion_qc_exponent>
       <p3_autoconversion_nc_exponent type="real" doc="Autoconversion nc exponent in P3">1.79</p3_autoconversion_nc_exponent>
+      <p3_autoconversion_radius type="real" doc="Autoconversion droplet radius (meter) in P3">25.0e-6</p3_autoconversion_radius>
       <p3_accretion_prefactor type="real" doc="Accretion linear prefactor in P3">67.0</p3_accretion_prefactor>
       <p3_accretion_qc_exponent type="real" doc="Accretion qc exponent in P3">1.15</p3_accretion_qc_exponent>
       <p3_accretion_qr_exponent type="real" doc="Accretion qr exponent in P3">1.15</p3_accretion_qr_exponent>

--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -202,10 +202,14 @@ be lost if SCREAM_HACK_XML is not enabled.
         ${DIN_LOC_ROOT}/atm/scream/tables/vn_table_vals.dat8,
         ${DIN_LOC_ROOT}/atm/scream/tables/vm_table_vals.dat8
       </tables>
-      <p3_autoconversion_prefactor type="real" doc="P3 autoconversion_prefactor (scale factor in autoconversion)">1350.0</p3_autoconversion_prefactor>
+      <p3_autoconversion_prefactor type="real" doc="Autoconversion linear prefactor in P3">1350.0</p3_autoconversion_prefactor>
+      <p3_autoconversion_qc_exponent type="real" doc="Autoconversion qc exponent in P3">2.47</p3_autoconversion_qc_exponent>
+      <p3_autoconversion_nc_exponent type="real" doc="Autoconversion nc exponent in P3">1.79</p3_autoconversion_nc_exponent>
+      <p3_accretion_prefactor type="real" doc="Accretion linear prefactor in P3">67.0</p3_accretion_prefactor>
+      <p3_accretion_qc_exponent type="real" doc="Accretion qc exponent in P3">1.15</p3_accretion_qc_exponent>
+      <p3_accretion_qr_exponent type="real" doc="Accretion qr exponent in P3">1.15</p3_accretion_qr_exponent>
       <p3_mu_r_constant type="real" doc="P3 mu_r_constant (rain shape parameter in gamma drop-size distribution)">1.0</p3_mu_r_constant>
       <p3_spa_to_nc type="real" doc="P3 spa_to_nc (scaling factor for turning CCN into nc in SPA)">1.0</p3_spa_to_nc>
-      <p3_k_accretion type="real" doc="P3 k_accretion (scaling factor on accretion)">67.0</p3_k_accretion>
       <p3_eci type="real" doc="P3 eci (liquid/ice collision/collection coefficient)">0.5</p3_eci>
       <p3_eri type="real" doc="P3 eri (ice/rain collision/collection coefficient)">1.0</p3_eri>
       <p3_rho_rime_min type="real" doc="P3 rho_rime_min (riming density maximum)">50.0</p3_rho_rime_min>

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -224,6 +224,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   runtime_options.p3_autoconversion_prefactor = m_params.get<double>("p3_autoconversion_prefactor", 1350.0);
   runtime_options.p3_autoconversion_qc_exponent = m_params.get<double>("p3_autoconversion_qc_exponent", 2.47);
   runtime_options.p3_autoconversion_nc_exponent = m_params.get<double>("p3_autoconversion_nc_exponent", 1.79);
+  runtime_options.p3_autoconversion_radius = m_params.get<double>("p3_autoconversion_radius", 25.0e-6);
   runtime_options.p3_accretion_prefactor = m_params.get<double>("p3_accretion_prefactor", 67.0);
   runtime_options.p3_accretion_qc_exponent = m_params.get<double>("p3_accretion_qc_exponent", 1.15);
   runtime_options.p3_accretion_qr_exponent = m_params.get<double>("p3_accretion_qr_exponent", 1.15);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -222,9 +222,13 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   // Gather runtime options
   runtime_options.max_total_ni = m_params.get<double>("max_total_ni", 740.0e3);
   runtime_options.p3_autoconversion_prefactor = m_params.get<double>("p3_autoconversion_prefactor", 1350.0);
+  runtime_options.p3_autoconversion_qc_exponent = m_params.get<double>("p3_autoconversion_qc_exponent", 2.47);
+  runtime_options.p3_autoconversion_nc_exponent = m_params.get<double>("p3_autoconversion_nc_exponent", 1.79);
+  runtime_options.p3_accretion_prefactor = m_params.get<double>("p3_accretion_prefactor", 67.0);
+  runtime_options.p3_accretion_qc_exponent = m_params.get<double>("p3_accretion_qc_exponent", 1.15);
+  runtime_options.p3_accretion_qr_exponent = m_params.get<double>("p3_accretion_qr_exponent", 1.15);
   runtime_options.p3_mu_r_constant = m_params.get<double>("p3_mu_r_constant", 1.0);
   runtime_options.p3_spa_to_nc = m_params.get<double>("p3_spa_to_nc", 1.0);
-  runtime_options.p3_k_accretion = m_params.get<double>("p3_k_accretion", 67.0);
   runtime_options.p3_eci = m_params.get<double>("p3_eci", 0.5);
   runtime_options.p3_eri = m_params.get<double>("p3_eri", 1.0);
   runtime_options.p3_rho_rime_min = m_params.get<double>("p3_rho_rime_min", 50.0);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -227,6 +227,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   runtime_options.p3_accretion_prefactor = m_params.get<double>("p3_accretion_prefactor", 67.0);
   runtime_options.p3_accretion_qc_exponent = m_params.get<double>("p3_accretion_qc_exponent", 1.15);
   runtime_options.p3_accretion_qr_exponent = m_params.get<double>("p3_accretion_qr_exponent", 1.15);
+  runtime_options.p3_rain_selfcollection_prefactor = m_params.get<double>("p3_rain_selfcollection_prefactor", 5.78);
   runtime_options.p3_mu_r_constant = m_params.get<double>("p3_mu_r_constant", 1.0);
   runtime_options.p3_spa_to_nc = m_params.get<double>("p3_spa_to_nc", 1.0);
   runtime_options.p3_eci = m_params.get<double>("p3_eci", 0.5);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -229,6 +229,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   runtime_options.p3_accretion_qc_exponent = m_params.get<double>("p3_accretion_qc_exponent", 1.15);
   runtime_options.p3_accretion_qr_exponent = m_params.get<double>("p3_accretion_qr_exponent", 1.15);
   runtime_options.p3_rain_selfcollection_prefactor = m_params.get<double>("p3_rain_selfcollection_prefactor", 5.78);
+  runtime_options.p3_rain_selfcollection_breakup_diameter = m_params.get<double>("p3_rain_selfcollection_breakup_diameter", 0.00028);
   runtime_options.p3_mu_r_constant = m_params.get<double>("p3_mu_r_constant", 1.0);
   runtime_options.p3_spa_to_nc = m_params.get<double>("p3_spa_to_nc", 1.0);
   runtime_options.p3_eci = m_params.get<double>("p3_eci", 0.5);
@@ -238,7 +239,6 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   runtime_options.p3_a_imm = m_params.get<double>("p3_a_imm", 0.65);
   runtime_options.p3_dep_nucleation_exponent = m_params.get<double>("p3_dep_nucleation_exponent", 0.304);
   runtime_options.p3_ice_sed_knob = m_params.get<double>("p3_ice_sed_knob", 1.0);
-  runtime_options.p3_d_breakup_cutoff = m_params.get<double>("p3_d_breakup_cutoff", 0.00028);
   runtime_options.p3_do_ice_production = m_params.get<bool>("p3_do_ice_production", true);
 
   // Set property checks for fields in this process

--- a/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
@@ -22,17 +22,23 @@ void Functions<S,D>
   constexpr Scalar CONS3 = C::CONS3;
 
   const Scalar p3_autoconversion_prefactor = runtime_options.p3_autoconversion_prefactor;
+  const Scalar p3_autoconversion_qc_exponent = runtime_options.p3_autoconversion_qc_exponent;
+  const Scalar p3_autoconversion_nc_exponent = runtime_options.p3_autoconversion_nc_exponent;
 
-  if(qc_not_small.any()){
+  if(qc_not_small.any()) {
     Spack sgs_var_coef;
     // sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, sp(2.47) );
     sgs_var_coef = 1;
 
-    qc2qr_autoconv_tend.set(qc_not_small,
-              sgs_var_coef*p3_autoconversion_prefactor*pow(qc_incld,sp(2.47))*pow(nc_incld*sp(1.e-6)*rho,sp(-1.79)));
+    qc2qr_autoconv_tend.set(
+        qc_not_small, sgs_var_coef * p3_autoconversion_prefactor *
+                          pow(qc_incld, sp(p3_autoconversion_qc_exponent)) *
+                          pow(nc_incld * sp(1.e-6) * rho,
+                              sp(-1 * p3_autoconversion_nc_exponent)));
     // note: ncautr is change in Nr; nc2nr_autoconv_tend is change in Nc
-    ncautr.set(qc_not_small, qc2qr_autoconv_tend*CONS3);
-    nc2nr_autoconv_tend.set(qc_not_small, qc2qr_autoconv_tend*nc_incld/qc_incld);
+    ncautr.set(qc_not_small, qc2qr_autoconv_tend * CONS3);
+    nc2nr_autoconv_tend.set(qc_not_small,
+                            qc2qr_autoconv_tend * nc_incld / qc_incld);
   }
 
   nc2nr_autoconv_tend.set(qc2qr_autoconv_tend == 0 && context, 0);

--- a/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
@@ -19,11 +19,19 @@ void Functions<S,D>
 
   // Khroutdinov and Kogan (2000)
   const auto qc_not_small = qc_incld >= 1e-8 && context;
-  constexpr Scalar CONS3 = C::CONS3;
 
   const Scalar p3_autoconversion_prefactor = runtime_options.p3_autoconversion_prefactor;
   const Scalar p3_autoconversion_qc_exponent = runtime_options.p3_autoconversion_qc_exponent;
   const Scalar p3_autoconversion_nc_exponent = runtime_options.p3_autoconversion_nc_exponent;
+  const Scalar p3_autoconversion_radius = runtime_options.p3_autoconversion_radius;
+
+  // TODO: remove this conditional (and keep CONS3 defined as in else) once BFB reqs are satisfied
+  Scalar CONS3;
+  if(p3_autoconversion_radius == 25.0e-6) {
+    CONS3 = C::CONS3;
+  } else {
+    CONS3 = sp(1.0) / (C::CONS2 * pow(p3_autoconversion_radius, sp(3.0)));
+  }
 
   if(qc_not_small.any()) {
     Spack sgs_var_coef;

--- a/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_autoconversion_impl.hpp
@@ -25,13 +25,8 @@ void Functions<S,D>
   const Scalar p3_autoconversion_nc_exponent = runtime_options.p3_autoconversion_nc_exponent;
   const Scalar p3_autoconversion_radius = runtime_options.p3_autoconversion_radius;
 
-  // TODO: remove this conditional (and keep CONS3 defined as in else) once BFB reqs are satisfied
-  Scalar CONS3;
-  if(p3_autoconversion_radius == 25.0e-6) {
-    CONS3 = C::CONS3;
-  } else {
-    CONS3 = sp(1.0) / (C::CONS2 * pow(p3_autoconversion_radius, sp(3.0)));
-  }
+  // TODO: correct this later (by keeping commented-out def) once BFB reqs are satisfied
+  const Scalar CONS3 = C::CONS3; // sp(1.0) / (C::CONS2 * pow(p3_autoconversion_radius, sp(3.0)));
 
   if(qc_not_small.any()) {
     Spack sgs_var_coef;
@@ -39,10 +34,10 @@ void Functions<S,D>
     sgs_var_coef = 1;
 
     qc2qr_autoconv_tend.set(
-        qc_not_small, sgs_var_coef * p3_autoconversion_prefactor *
-                          pow(qc_incld, sp(p3_autoconversion_qc_exponent)) *
-                          pow(nc_incld * sp(1.e-6) * rho,
-                              sp(-1 * p3_autoconversion_nc_exponent)));
+        qc_not_small,
+        sgs_var_coef * p3_autoconversion_prefactor *
+            pow(qc_incld, p3_autoconversion_qc_exponent) *
+            pow(nc_incld * sp(1.e-6) * rho, -p3_autoconversion_nc_exponent));
     // note: ncautr is change in Nr; nc2nr_autoconv_tend is change in Nc
     ncautr.set(qc_not_small, qc2qr_autoconv_tend * CONS3);
     nc2nr_autoconv_tend.set(qc_not_small,

--- a/components/eamxx/src/physics/p3/impl/p3_cloud_rain_acc_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_cloud_rain_acc_impl.hpp
@@ -25,18 +25,23 @@ void Functions<S,D>
 {
   constexpr Scalar qsmall = C::QSMALL;
 
-  const Scalar p3_k_accretion = runtime_options.p3_k_accretion;;
+  const Scalar p3_accretion_prefactor = runtime_options.p3_accretion_prefactor;
+  const Scalar p3_accretion_qc_exponent = runtime_options.p3_accretion_qc_exponent;
+  const Scalar p3_accretion_qr_exponent = runtime_options.p3_accretion_qr_exponent;
 
   Spack sgs_var_coef;
   // sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, sp(1.15) );
   sgs_var_coef = 1;
 
   const auto qr_and_qc_not_small = (qr_incld >= qsmall) && (qc_incld >= qsmall) && context;
-  if (qr_and_qc_not_small.any()) {
+  if(qr_and_qc_not_small.any()) {
     // Khroutdinov and Kogan (2000)
     qc2qr_accret_tend.set(qr_and_qc_not_small,
-              sgs_var_coef * sp(p3_k_accretion) * pow(qc_incld * qr_incld, sp(1.15)));
-    nc_accret_tend.set(qr_and_qc_not_small, qc2qr_accret_tend * nc_incld / qc_incld);
+                          sgs_var_coef * sp(p3_accretion_prefactor) *
+                              pow(qc_incld, sp(p3_accretion_qc_exponent)) *
+                              pow(qr_incld, sp(p3_accretion_qr_exponent)));
+    nc_accret_tend.set(qr_and_qc_not_small,
+                       qc2qr_accret_tend * nc_incld / qc_incld);
 
     qc2qr_accret_tend.set(nc_accret_tend == 0 && context, 0);
     nc_accret_tend.set(qc2qr_accret_tend == 0 && context, 0);

--- a/components/eamxx/src/physics/p3/impl/p3_cloud_rain_acc_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_cloud_rain_acc_impl.hpp
@@ -34,13 +34,14 @@ void Functions<S,D>
   sgs_var_coef = 1;
 
   const auto qr_and_qc_not_small = (qr_incld >= qsmall) && (qc_incld >= qsmall) && context;
-  if (qr_and_qc_not_small.any()) {
+  if(qr_and_qc_not_small.any()) {
     // Khroutdinov and Kogan (2000)
     qc2qr_accret_tend.set(
         qr_and_qc_not_small,
         sgs_var_coef * sp(p3_accretion_prefactor) *
             // TODO: split this pow into two in a later PR due to NBFB behavior
-            pow(qc_incld * qr_incld, sp(p3_accretion_qr_exponent)));
+            // pow(qc_incld, p3_accretion_qc_exponent) * pow(qr_incld, p3_accretion_qr_exponent));
+            pow(qc_incld * qr_incld, p3_accretion_qr_exponent));
     nc_accret_tend.set(qr_and_qc_not_small,
                        qc2qr_accret_tend * nc_incld / qc_incld);
 

--- a/components/eamxx/src/physics/p3/impl/p3_cloud_rain_acc_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_cloud_rain_acc_impl.hpp
@@ -34,12 +34,13 @@ void Functions<S,D>
   sgs_var_coef = 1;
 
   const auto qr_and_qc_not_small = (qr_incld >= qsmall) && (qc_incld >= qsmall) && context;
-  if(qr_and_qc_not_small.any()) {
+  if (qr_and_qc_not_small.any()) {
     // Khroutdinov and Kogan (2000)
-    qc2qr_accret_tend.set(qr_and_qc_not_small,
-                          sgs_var_coef * sp(p3_accretion_prefactor) *
-                              pow(qc_incld, sp(p3_accretion_qc_exponent)) *
-                              pow(qr_incld, sp(p3_accretion_qr_exponent)));
+    qc2qr_accret_tend.set(
+        qr_and_qc_not_small,
+        sgs_var_coef * sp(p3_accretion_prefactor) *
+            // TODO: split this pow into two in a later PR due to NBFB behavior
+            pow(qc_incld * qr_incld, sp(p3_accretion_qr_exponent)));
     nc_accret_tend.set(qr_and_qc_not_small,
                        qc2qr_accret_tend * nc_incld / qc_incld);
 

--- a/components/eamxx/src/physics/p3/impl/p3_rain_self_collection_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_rain_self_collection_impl.hpp
@@ -23,6 +23,7 @@ void Functions<S,D>
   constexpr Scalar pi       = C::Pi;
 
   const Scalar p3_d_breakup_cutoff = runtime_options.p3_d_breakup_cutoff;
+  const Scalar p3_rain_selfcollection_prefactor = runtime_options.p3_rain_selfcollection_prefactor;
 
   const auto qr_incld_not_small = qr_incld >= qsmall && context;
 
@@ -38,7 +39,9 @@ void Functions<S,D>
       dum.set(dum2_gt_dum1, 2 - exp(2300 * (dum2-p3_d_breakup_cutoff)));
     }
 
-    nr_selfcollect_tend.set(qr_incld_not_small, dum*sp(5.78)*nr_incld*qr_incld*rho);
+    nr_selfcollect_tend.set(
+        qr_incld_not_small,
+        dum * sp(p3_rain_selfcollection_prefactor) * nr_incld * qr_incld * rho);
   }
 }
 

--- a/components/eamxx/src/physics/p3/impl/p3_rain_self_collection_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_rain_self_collection_impl.hpp
@@ -22,26 +22,33 @@ void Functions<S,D>
   constexpr Scalar rho_h2o  = C::RHO_H2O;
   constexpr Scalar pi       = C::Pi;
 
-  const Scalar p3_d_breakup_cutoff = runtime_options.p3_d_breakup_cutoff;
+  const Scalar p3_rain_selfcollection_breakup_diameter = runtime_options.p3_rain_selfcollection_breakup_diameter;
   const Scalar p3_rain_selfcollection_prefactor = runtime_options.p3_rain_selfcollection_prefactor;
 
   const auto qr_incld_not_small = qr_incld >= qsmall && context;
 
-  if (qr_incld_not_small.any()) {
-    
-    const auto dum2 = cbrt((qr_incld)/(pi*rho_h2o*nr_incld));
+  if(qr_incld_not_small.any()) {
+    // use mass-mean diameter (do this by using
+    // the old version of lambda w/o mu dependence)
+    // note there should be a factor of 6^(1/3), but we
+    // want to keep breakup threshold consistent so 'dum'
+    // is expressed in terms of lambda rather than mass-mean D
+    const auto dum2 = cbrt((qr_incld) / (pi * rho_h2o * nr_incld));
 
     Spack dum;
-    const auto dum2_lt_dum1 = dum2 < p3_d_breakup_cutoff && qr_incld_not_small;
-    const auto dum2_gt_dum1 = dum2 >= p3_d_breakup_cutoff && qr_incld_not_small;
+    const auto dum2_lt_dum1 =
+        dum2 < p3_rain_selfcollection_breakup_diameter && qr_incld_not_small;
+    const auto dum2_gt_dum1 =
+        dum2 >= p3_rain_selfcollection_breakup_diameter && qr_incld_not_small;
     dum.set(dum2_lt_dum1, 1);
-    if (dum2_gt_dum1.any()) {
-      dum.set(dum2_gt_dum1, 2 - exp(2300 * (dum2-p3_d_breakup_cutoff)));
+    if(dum2_gt_dum1.any()) {
+      dum.set(dum2_gt_dum1,
+              2 - exp(2300 * (dum2 - p3_rain_selfcollection_breakup_diameter)));
     }
 
     nr_selfcollect_tend.set(
         qr_incld_not_small,
-        dum * sp(p3_rain_selfcollection_prefactor) * nr_incld * qr_incld * rho);
+        dum * p3_rain_selfcollection_prefactor * nr_incld * qr_incld * rho);
   }
 }
 

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -118,6 +118,7 @@ struct Functions
     Scalar p3_accretion_qc_exponent = 1.15;
     Scalar p3_accretion_qr_exponent = 1.15;
     Scalar p3_rain_selfcollection_prefactor = 5.78;
+    Scalar p3_rain_selfcollection_breakup_diameter = 0.00028;
     Scalar p3_mu_r_constant = 1.0;
     Scalar p3_spa_to_nc = 1.0;
     Scalar p3_eci = 0.5;
@@ -127,7 +128,6 @@ struct Functions
     Scalar p3_a_imm = 0.65;
     Scalar p3_dep_nucleation_exponent = 0.304;
     Scalar p3_ice_sed_knob = 1.0;
-    Scalar p3_d_breakup_cutoff = 0.00028;
     bool p3_do_ice_production = true;
   };
 

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -111,9 +111,13 @@ struct Functions
   struct P3Runtime {
     Scalar max_total_ni = 740.0e3;
     Scalar p3_autoconversion_prefactor = 1350.0;
+    Scalar p3_autoconversion_qc_exponent = 2.47;
+    Scalar p3_autoconversion_nc_exponent = 1.79;
+    Scalar p3_accretion_prefactor = 67.0;
+    Scalar p3_accretion_qc_exponent = 1.15;
+    Scalar p3_accretion_qr_exponent = 1.15;
     Scalar p3_mu_r_constant = 1.0;
     Scalar p3_spa_to_nc = 1.0;
-    Scalar p3_k_accretion = 67.0;
     Scalar p3_eci = 0.5;
     Scalar p3_eri = 1.0;
     Scalar p3_rho_rime_min = 50.0;

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -113,6 +113,7 @@ struct Functions
     Scalar p3_autoconversion_prefactor = 1350.0;
     Scalar p3_autoconversion_qc_exponent = 2.47;
     Scalar p3_autoconversion_nc_exponent = 1.79;
+    Scalar p3_autoconversion_radius = 25.0e-6;
     Scalar p3_accretion_prefactor = 67.0;
     Scalar p3_accretion_qc_exponent = 1.15;
     Scalar p3_accretion_qr_exponent = 1.15;

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -116,6 +116,7 @@ struct Functions
     Scalar p3_accretion_prefactor = 67.0;
     Scalar p3_accretion_qc_exponent = 1.15;
     Scalar p3_accretion_qr_exponent = 1.15;
+    Scalar p3_rain_selfcollection_prefactor = 5.78;
     Scalar p3_mu_r_constant = 1.0;
     Scalar p3_spa_to_nc = 1.0;
     Scalar p3_eci = 0.5;


### PR DESCRIPTION
Exposing more p3 runtime params in a BFB fashion, this PR comes with a planned follow-up that would be NBFB (see TODO items).