### PR TITLE
Small mods in test-all-scream related to baseline generation

### DIFF
--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -511,7 +511,7 @@ class TestAllScream(object):
                f"Something is off. generate_baseline should have not be called for test {test}")
 
         baseline_dir = self.get_test_dir(self._baseline_dir, test)
-        test_dir = self.get_test_dir(self._work_dir / "tas_baseline_build", test)
+        test_dir = self.get_test_dir(self._work_dir, test)
         if test_dir.exists():
             shutil.rmtree(test_dir)
         test_dir.mkdir()
@@ -590,10 +590,9 @@ class TestAllScream(object):
         print(f"Generating baselines using '{git_head}'")
         print("###############################################################################")
 
-        tas_baseline_bld = self._work_dir / "tas_baseline_build"
-        if tas_baseline_bld.exists():
-            shutil.rmtree(tas_baseline_bld)
-        tas_baseline_bld.mkdir()
+        if self._work_dir.exists():
+            shutil.rmtree(self._work_dir)
+        self._work_dir.mkdir()
 
         success = True
         num_workers = len(tests_needing_baselines) if self._parallel else 1

--- a/components/eamxx/scripts/test_all_scream.py
+++ b/components/eamxx/scripts/test_all_scream.py
@@ -590,10 +590,6 @@ class TestAllScream(object):
         print(f"Generating baselines using '{git_head}'")
         print("###############################################################################")
 
-        if self._work_dir.exists():
-            shutil.rmtree(self._work_dir)
-        self._work_dir.mkdir()
-
         success = True
         num_workers = len(tests_needing_baselines) if self._parallel else 1
         with threading3.ProcessPoolExecutor(max_workers=num_workers) as executor:


### PR DESCRIPTION
Since generation will never happen along with running tests, use same folder that we use in test phase when generating.

This will allow certain scripts (e.g., gh actions that will come soon) to find build folders without checking whether this was a baselines generation run or not.

Edit: to expand on the motivation, in the gh actions I wand to upload test-all ctest logs as artifacts to the action (for debug/inspection). To specify the logs path, I am doing `ctest-build/*/Testing/Temporary/*.log`, but this is currently failing for baseline gen, since the correct path would be `ctest-build/tas_baseline_build/*/Testing/Temporary/*.log`.