### PR TITLE
add DP and RRM docs to mkdocs.yaml file

### DIFF
--- a/components/eamxx/mkdocs.yaml
+++ b/components/eamxx/mkdocs.yaml
@@ -10,6 +10,8 @@ nav:
     - 'Nudging': 'user/nudging.md'
     - 'Extra radiation calls': 'user/clean_clear_sky.md'
     - 'COSP': 'user/cosp.md'
+    - 'Regionally Refined EAMxx': 'user/rrm_eamxx.md'
+    - 'Doubly Periodic EAMxx': 'user/dp_eamxx.md'
   - 'Developer Guide':
     - 'Overview': 'developer/index.md'
     - 'Installation': 'common/installation.md'


### PR DESCRIPTION
Didn't do this in the PR where the DP and RRM docs were added.