### PR TITLE
Fixes a bug when copying grid data for a geo data of scalar type.

### DIFF
--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -398,7 +398,7 @@ deep_copy_impl (const Field& src) const {
   if (rank == 0) {
     auto v     =     get_view<      ST,HD>();
     auto v_src = src.get_view<const ST,HD>();
-    v() = v_src();
+    Kokkos::deep_copy(v,v_src);
     return;
   }
 

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -37,7 +37,13 @@ CoarseningRemapper (const grid_ptr_type& src_grid,
       const auto& src_data = src_grid->get_geometry_data(name);
       const auto& src_data_fid = src_data.get_header().get_identifier();
       const auto& layout = src_data_fid.get_layout();
-      if (layout.tags()[0]!=COL) {
+      if (layout.tags().empty()) {
+        // This is a scalar field, so won't be coarsened.
+        // Simply copy it in the tgt grid, but we still need to assign the new grid name.
+        FieldIdentifier tgt_data_fid(src_data_fid.name(),src_data_fid.get_layout(),src_data_fid.get_units(),m_tgt_grid->name());
+        auto tgt_data = m_coarse_grid->create_geometry_data(tgt_data_fid);
+        tgt_data.deep_copy(src_data);
+      } else if (layout.tags()[0]!=COL) {
         // Not a field to be coarsened (perhaps a vertical coordinate field).
         // Simply copy it in the tgt grid, but we still need to assign the new grid name.
         FieldIdentifier tgt_data_fid(src_data_fid.name(),src_data_fid.get_layout(),src_data_fid.get_units(),m_tgt_grid->name());


### PR DESCRIPTION
When copying the grid geo data from one grid to the another there is a check if the geo data has COL or not.  This led to an error for the unique case of a geo data that is a scalar and thus the layout is essentially empty.

This happens for DPxx cases.