### PR TITLE
Fix ghci snl machine settings

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1656,6 +1656,7 @@ commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" iss
       <executable>mpirun</executable>
       <arguments>
         <arg name="binding"> --bind-to core</arg>
+        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="none"/>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1633,6 +1633,48 @@ commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" iss
     </environment_variables>
   </machine>
 
+  <machine MACH="ghci-snl-cpu">
+    <DESC>Huge Linux workstation for Sandia climate scientists</DESC>
+    <NODENAME_REGEX>^[a-fA-F0-9]{12}$</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <PROXY>proxy.sandia.gov:80</PROXY>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS>openmpi</MPILIBS>
+    <CIME_OUTPUT_ROOT>/projects/e3sm/scratch</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/projects/e3sm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/projects/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/projects/e3sm/baselines/ghci-snl-cpu/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/projects/e3sm/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>32</GMAKE_J>
+    <TESTS>e3sm_developer</TESTS>
+    <BATCH_SYSTEM>none</BATCH_SYSTEM>
+    <SUPPORTED_BY>lbertag at sandia dot gov</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="binding"> --bind-to core</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="none"/>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <MAX_GB_OLD_TEST_DATA>0</MAX_GB_OLD_TEST_DATA>
+    <environment_variables>
+      <env name="NETCDF_C_PATH">$ENV{NETCDF_C_ROOT}</env>
+      <env name="NETCDF_FORTRAN_PATH">$ENV{NETCDF_FORTRAN_ROOT}</env>
+      <env name="PNETCDF_PATH">$ENV{PARALLEL_NETCDF_ROOT}</env>
+      <env name="OMP_STACKSIZE">64M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
+      <env name="BLA_VENDOR">Generic</env>
+      <env name="GATOR_INITIAL_MB">4000MB</env>
+    </environment_variables>
+  </machine>
+
   <machine MACH="weaver">
     <DESC>Sandia GPU testbed</DESC>
     <NODENAME_REGEX>weaver</NODENAME_REGEX>

--- a/components/eamxx/cmake/machine-files/ghci-snl-cpu.cmake
+++ b/components/eamxx/cmake/machine-files/ghci-snl-cpu.cmake
@@ -1,0 +1,5 @@
+# Common settings for our ghci images
+include(${CMAKE_CURRENT_LIST_DIR}/ghci-snl.cmake)
+
+# Set SCREAM_MACHINE
+set(SCREAM_MACHINE ghci-snl-cpu CACHE STRING "")

--- a/components/eamxx/cmake/machine-files/ghci-snl-openmp.cmake
+++ b/components/eamxx/cmake/machine-files/ghci-snl-openmp.cmake
@@ -1,9 +1,0 @@
-# Common settings for our ghci images
-include(${CMAKE_CURRENT_LIST_DIR}/ghci-snl.cmake)
-
-# Set SCREAM_MACHINE
-set(SCREAM_MACHINE ghci-snl-openmp CACHE STRING "")
-
-# Set OpenMP backend
-set(EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/cmake/machine-files)
-include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -93,11 +93,11 @@ MACHINE_METADATA = {
     "linux-generic" :        ([],["mpicxx","mpifort","mpicc"],"", ""),
     "linux-generic-debug" :  ([],["mpicxx","mpifort","mpicc"],"", ""),
     "linux-generic-serial" : ([],["mpicxx","mpifort","mpicc"],"", ""),
-    "ghci-snl-openmp" : ([],
-                         ["mpicxx","mpifort","mpicc"],
-                         "",
-                         "/projects/e3sm/baselines/scream/master-baselines"
-                        ),
+    "ghci-snl-cpu" : ([],
+                      ["mpicxx","mpifort","mpicc"],
+                      "",
+                      "/projects/e3sm/baselines/scream/ghci-snl-cpu"
+                     ),
 }
 
 if pathlib.Path("~/.cime/scream_mach_specs.py").expanduser().is_file(): # pylint: disable=no-member

--- a/components/eamxx/src/physics/p3/tests/p3_find_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_find_unit_tests.cpp
@@ -28,7 +28,7 @@ static void run()
 {
   const int max_threads =
 #ifdef KOKKOS_ENABLE_OPENMP
-    Kokkos::OpenMP::concurrency()
+    Kokkos::OpenMP().concurrency()
 #else
     1
 #endif


### PR DESCRIPTION
This PR prepares for running actions on a SNL-hosted CPU-only machine (a container that runs on mappy).

I'm going to let the AT run on this, since it also removes one leftover instance of kokkos 4 deprecated code (so it's not just adding a new machine). I am planning to have our CI disable deprecated code by default (I'd argue we should do it everywhere, but that's another story), so we'll need the fix anyways.

Note: all the paths in the config machine are relative to the container. That said, one can always run any container mounting local volumes to those paths, so it is not, strictly speaking, only for this container image.

I will share the container recipe somewhere else (only the part I implemented, since SNL adds some secret sauce on top...long story, ping me if your interested).

After this PR is merged, I will 
- enable the AT2 "listener" script on mappy (where the ghci-snl containers are run)
- issue another PR to add the eamxx standalone testing actions needed by AT2