### PR TITLE
Add workflow files for eamxx standalone and v1 testing

### DIFF
--- a/.github/actions/test-all-scream/README.md
+++ b/.github/actions/test-all-scream/README.md
@@ -1,0 +1,32 @@
+# Composite action to call test-all-scream inside a workflow
+
+This action is meant to be used inside a workflow. E.g.,
+
+```yaml
+jobs:
+  my-testing:
+    steps:
+      ...
+      - name: run-test-all-scream
+        uses: ./.github/actions/eamxx-test-all-scream
+        with:
+          build_type: <build-type>
+          machine: <machine>
+          run_type: <run-type>
+```
+
+The input run_type is the only input that this action has to explicitly handle.
+As such, this action checks that its value is one of the following.
+
+ - nightly: runs tests and then submit to cdash
+ - at-run: runs tests without submitting to cdash
+ - bless: runs tests and copy output files to baselines folder
+
+As for build_type and machine, we do not prescribe a list of
+valid values, as that will be handled by components/eamxx/scripts/test-all-scream.
+If their values are not supported, it is up to test-all-scram to handle the error.
+As a guideline, however, you may have to ensure that the following exist:
+ - the file components/eamxx/cmake/machine-files/${machine}.cmake
+ - the entry ${machine} in the MACHINE_METADATA dict in components/eamxx/scripts/machine_specs.py
+
+ Questions? Contact Luca Bertagna (lbertag@sandia.gov)

--- a/.github/actions/test-all-scream/README.md
+++ b/.github/actions/test-all-scream/README.md
@@ -18,15 +18,16 @@ jobs:
 The input run_type is the only input that this action has to explicitly handle.
 As such, this action checks that its value is one of the following.
 
- - nightly: runs tests and then submit to cdash
- - at-run: runs tests without submitting to cdash
- - bless: runs tests and copy output files to baselines folder
+- nightly: runs tests and then submit to cdash
+- at-run: runs tests without submitting to cdash
+- bless: runs tests and copy output files to baselines folder
 
 As for build_type and machine, we do not prescribe a list of
 valid values, as that will be handled by components/eamxx/scripts/test-all-scream.
 If their values are not supported, it is up to test-all-scram to handle the error.
 As a guideline, however, you may have to ensure that the following exist:
- - the file components/eamxx/cmake/machine-files/${machine}.cmake
- - the entry ${machine} in the MACHINE_METADATA dict in components/eamxx/scripts/machine_specs.py
 
- Questions? Contact Luca Bertagna (lbertag@sandia.gov)
+- the file components/eamxx/cmake/machine-files/${machine}.cmake
+- the entry ${machine} in the MACHINE_METADATA dict in components/eamxx/scripts/machine_specs.py
+
+ Questions? Contact Luca Bertagna [lbertag@sandia.gov](mailto:lbertag@sandia.gov)

--- a/.github/actions/test-all-scream/action.yml
+++ b/.github/actions/test-all-scream/action.yml
@@ -1,0 +1,104 @@
+name: EAMxx standalone testing
+description: |
+  Run EAMxx standalone testing with required configuration inputs.
+  More precisely, it launches test-all-scream with the proper flags.
+  See components/eamxx/scripts/test-all-scream for more details.
+  The configuration inputs are:
+    - build_type: the type of build to pass to test-all-scream.
+    - machine: the name of the machine to pass to test-all-scream
+    - generate: whether to generate baselines
+    - submit: whether to submit to cdash (unused if generate is 'true')
+
+inputs:
+  build_type:
+    description: 'Build type to run'
+    required: true
+  machine:
+    description: 'Machine name for test-all-scream'
+    required: true
+  generate:
+    description: 'Generate baselines instead of running tests'
+    required: true
+    default: 'false'
+    valid_values:
+      - 'true'
+      - 'false'
+  submit:
+    description: 'Submit results to cdash (unused if generate=true)'
+    required: true
+    default: 'false'
+    valid_values:
+      - 'true'
+      - 'false'
+  cmake-configs:
+    description: 'Semicolon-separated list of key=value pairs for CMake to pass to test-all-scream'
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set CA certificates env var
+      run: |
+        # Ensure the operating system is Linux
+        if [ "$(uname)" != "Linux" ]; then
+          echo "This action only supports Linux."
+          exit 1
+        fi
+        # Set env var to be used in upload-artifacts phase
+        if [ -f /etc/debian_version ]; then
+          echo "NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt" >> $GITHUB_ENV
+        elif [ -f /etc/redhat-release ] || [ -f /etc/centos-release ] || [ -f /etc/fedora-release ]; then
+          echo "NODE_EXTRA_CA_CERTS=/etc/pki/tls/certs/ca-bundle.crt" >> $GITHUB_ENV
+        else
+          echo "Unsupported Linux distribution"
+          exit 1
+        fi
+      shell: sh
+    - name: Check repo presence
+      run: |
+        if [ ! -d ".git" ]; then
+          echo "Repository is not checked out. Please ensure the repository is checked out before running this action."
+          exit 1
+        fi
+      shell: sh
+    - name: Print build specs
+      run: |
+        echo "Testing EAMxx standalone, for the following configuration:"
+        echo "  build type   : ${{ inputs.build_type }}"
+        echo "  machine      : ${{ inputs.machine }}"
+        echo "  generate     : ${{ inputs.generate }}"
+        echo "  submit       : ${{ inputs.submit }}"
+        echo "  cmake-configs: ${{ inputs.cmake-configs }}"
+      shell: sh
+    - name: Run test-all-scream
+      working-directory: components/eamxx
+      run: |
+        cmd="./scripts/test-all-scream -m ${{ inputs.machine }} -t ${{inputs.build_type}} --baseline-dir AUTO -c EKAT_DISABLE_TPL_WARNINGS=ON"
+        if [ "${{ inputs.generate }}" = "true" ]; then
+          cmd+=" -g"
+        elif [ "${{ inputs.submit }}" = "true" ]; then 
+          cmd+=" -s"
+        fi
+
+        # If cmake-configs is non-empty, add tokens to test-all-scream via "-c key=val"
+        IFS=';' read -ra configs <<< "${{ inputs.cmake-configs }}"
+        for config in "${configs[@]}"; do
+          cmd+=" -c $config"
+        done
+
+        # Print the full command, then run it
+        echo "test-all-scream call: $cmd"
+        $cmd
+      shell: sh
+    - name: Upload ctest logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: log-files-${{ inputs.build_type }}
+        path: |
+          components/eamxx/ctest-build/*/Testing/Temporary/Last*.log
+          components/eamxx/ctest-build/*/ctest_resource_file.json
+          components/eamxx/ctest-build/*/CMakeCache.txt
+      env:
+        NODE_EXTRA_CA_CERTS: ${{ env.NODE_EXTRA_CA_CERTS }}

--- a/.github/workflows/eamxx-scripts-tests.yml
+++ b/.github/workflows/eamxx-scripts-tests.yml
@@ -1,0 +1,72 @@
+name: EAMxx scripts testing
+
+on:
+  # Runs on PRs against master, but only if they touch eamxx scripts
+  pull_request:
+    branches: [ master ]
+    types: [opened, synchronize, ready_for_review, reopened]
+    paths:
+      - components/eamxx/scripts
+      - components/eamxx/cime_config/*.py
+
+  # Manual run for debug purposes only
+  workflow_dispatch:
+
+  # Add schedule trigger for nightly runs at midnight MT (Standard Time)
+  # schedule:
+  #   - cron: '0 7 * * *'  # Runs at 7 AM UTC, which is midnight MT during Standard Time
+
+concurrency:
+  # Two runs are in the same group if:
+  #  - they have the same trigger
+  #  - if trigger=pull_request, the PR number must match
+  #  - if trigger=workflow_dispatch, the inputs are the same
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{
+             github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id
+           }}
+  cancel-in-progress: true
+
+jobs:
+  cpu-gcc:
+    runs-on:  [self-hosted, gcc, ghci-snl-cpu]
+    # Run this workflow if:
+    #   - workflow_dispatch: user requested this job.
+    #   - schedule: always:
+    #   - pull_request: matching skip label is NOT found
+    if: |
+      ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' ||
+          (
+            github.event_name == 'pull_request' &&
+            !(
+              contains(github.event.pull_request.labels.*.name, 'AT: skip all')
+            )
+          )
+        }}
+    steps:
+      - name: Show action trigger
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            const eventAction = context.payload.action || 'N/A';
+            const actor = context.actor;
+            console.log(`The job was triggered by a ${eventName} event.`);
+            console.log(`  - Event action: ${eventAction}`);
+            console.log(`  - Triggered by: ${actor}`);
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          show-progress: false
+          submodules: recursive
+      - name: Run test
+        run: |
+          cd components/eamxx
+          if [ ${{ github.event_name == 'schedule' }} ]; then
+            ./scripts/scripts-ctest-driver -s -m ghci-snl-cpu
+          else
+            ./scripts/scripts-tests -f -m ghci-snl-cpu
+            ./scripts/cime-nml-tests
+          fi

--- a/.github/workflows/eamxx-standalone-testing.yml
+++ b/.github/workflows/eamxx-standalone-testing.yml
@@ -1,0 +1,123 @@
+name: EAMxx standalone testing
+
+on:
+  # Runs on PRs against master
+  pull_request:
+    branches: [ master ]
+    types: [opened, synchronize, ready_for_review, reopened]
+
+  # Manual run is used to bless
+  workflow_dispatch:
+    inputs:
+      jobs_list:
+        description: 'Job to run'
+        required: true
+        type: choice
+        options:
+          - gcc-openmp
+      bless:
+        description: 'Generate baselines'
+        required: true
+        type: boolean
+
+  # Add schedule trigger for nightly runs at midnight MT (Standard Time)
+  # schedule:
+  #   - cron: '0 7 * * *'  # Runs at 7 AM UTC, which is midnight MT during Standard Time
+
+concurrency:
+  # Two runs are in the same group if:
+  #  - they have the same trigger
+  #  - if trigger=pull_request, the PR number must match
+  #  - if trigger=workflow_dispatch, the inputs are the same
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{
+             github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id
+           }}
+  cancel-in-progress: true
+
+jobs:
+  gcc-openmp:
+    runs-on:  [self-hosted, ghci-snl-cpu, gcc]
+    strategy:
+      fail-fast: true
+      matrix:
+        build_type: [sp, dbg, fpe, opt]
+    # Run this workflow if:
+    #   - workflow_dispatch: user requested this job.
+    #   - schedule: always:
+    #   - pull_request: matching skip label is NOT found
+    if: |
+      ${{
+          github.event_name == 'schedule' || 
+          ( github.event_name == 'workflow_dispatch' && github.event.inputs.jobs_list == 'gcc-openmp' ) ||
+          (
+            github.event_name == 'pull_request' &&
+            !(
+              contains(github.event.pull_request.labels.*.name, 'AT: skip gcc-openmp') || 
+              contains(github.event.pull_request.labels.*.name, 'AT: skip standalone')
+            )
+          )
+        }}
+    name: gcc-openmp-${{ matrix.build_type }}
+    steps:
+      - name: Show action trigger
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            const eventAction = context.payload.action || 'N/A';
+            const actor = context.actor;
+            console.log(`The job was triggered by a ${eventName} event.`);
+            console.log(`  - Event action: ${eventAction}`);
+            console.log(`  - Triggered by: ${actor}`);
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          show-progress: false
+          submodules: recursive
+      - name: Set test-all inputs based on event specs
+        run: |
+          echo "submit=false" >> $GITHUB_ENV
+          echo "generate=false" >> $GITHUB_ENV
+          if [ "${{ github.event_name }}" == "schedule" ]; then
+            echo "submit=true" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            if [ "${{ inputs.bless }}" == "true" ]; then
+              echo "generate=true" >> $GITHUB_ENV
+            fi
+          fi
+      - name: Run tests
+        uses: ./.github/actions/test-all-scream
+        with:
+          build_type: ${{ matrix.build_type }}
+          machine: ghci-snl-cpu
+          generate: ${{ env.generate }}
+          submit: ${{ env.submit }}
+          cmake-configs: Kokkos_ENABLE_OPENMP=ON
+  # cuda:
+  #   # Disable until the CUDA container is up and running. When CUDA container is availabe, remove
+  #   # this line and uncomment the next if
+  #   if: false
+  #   # Runs always for pull_request. For workflow_dispatch, user must request this machine
+  #   # if: ${{ github.event_name == 'pull_request' || contains(github.event.inputs.jobs_to_run, 'openmp-gcc') }}
+  #   runs-on:  [self-hosted, cuda]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       build_type: [sp, dbg, fpe, opt]
+  #   name: cuda-${{ matrix.build_type }}
+  #   steps:
+  #     - name: Show action trigger
+  #       uses: ./.github/actions/print-workflow-trigger
+  #     - name: Check out the repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         persist-credentials: false
+  #         show-progress: false
+  #         submodules: recursive
+  #     - name: Run tests
+  #       uses: ./.github/actions/test-all-scream
+  #       with:
+  #         build_type: ${{ matrix.build_type }}
+  #         machine: ghci-snl-cuda
+  #         run_type: at-run

--- a/.github/workflows/eamxx-standalone-testing.yml
+++ b/.github/workflows/eamxx-standalone-testing.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
     branches: [ master ]
     types: [opened, synchronize, ready_for_review, reopened]
+    paths:
+      - components/eamxx
+      - components/eam/src/physics/rrtmgp
+      - components/eam/src/physics/p3/scream
+      - components/eam/src/physics/cam
 
   # Manual run is used to bless
   workflow_dispatch:
@@ -47,13 +52,15 @@ jobs:
     #   - pull_request: matching skip label is NOT found
     if: |
       ${{
-          github.event_name == 'schedule' || 
+          github.event_name == 'schedule' ||
           ( github.event_name == 'workflow_dispatch' && github.event.inputs.jobs_list == 'gcc-openmp' ) ||
           (
             github.event_name == 'pull_request' &&
             !(
-              contains(github.event.pull_request.labels.*.name, 'AT: skip gcc-openmp') || 
-              contains(github.event.pull_request.labels.*.name, 'AT: skip standalone')
+              contains(github.event.pull_request.labels.*.name, 'AT: skip gcc') ||
+              contains(github.event.pull_request.labels.*.name, 'AT: skip openmp') ||
+              contains(github.event.pull_request.labels.*.name, 'AT: skip eamxx-standalone') ||
+              contains(github.event.pull_request.labels.*.name, 'AT: skip all')
             )
           )
         }}

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
     branches: [ master ]
     types: [opened, synchronize, ready_for_review, reopened]
+    paths:
+      - components/eamxx
+      - components/eam/src/physics/rrtmgp
+      - components/eam/src/physics/p3/scream
+      - components/eam/src/physics/cam
 
   # Manual run is used to bless
   workflow_dispatch:
@@ -52,7 +57,8 @@ jobs:
             github.event_name == 'pull_request' &&
             !(
               contains(github.event.pull_request.labels.*.name, 'AT: skip gcc') ||
-              contains(github.event.pull_request.labels.*.name, 'AT: skip v1')
+              contains(github.event.pull_request.labels.*.name, 'AT: skip eamxx-v1') ||
+              contains(github.event.pull_request.labels.*.name, 'AT: skip all')
             )
           )
         }}

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -1,0 +1,125 @@
+name: EAMxx v1 CI testing
+
+on:
+  # Runs on PRs against master
+  pull_request:
+    branches: [ master ]
+    types: [opened, synchronize, ready_for_review, reopened]
+
+  # Manual run is used to bless
+  workflow_dispatch:
+    inputs:
+      jobs_list:
+        description: 'Job to run'
+        required: true
+        type: choice
+        options:
+          - cpu-gcc
+      bless:
+        description: 'Generate baselines'
+        required: true
+        type: boolean
+
+concurrency:
+  # Two runs are in the same group if:
+  #  - they have the same trigger
+  #  - if trigger=pull_request, the PR number must match
+  #  - if trigger=workflow_dispatch, the inputs are the same
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{
+             github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id
+           }}
+  cancel-in-progress: true
+
+jobs:
+  cpu-gcc:
+    runs-on:  [self-hosted, gcc, ghci-snl-cpu]
+    strategy:
+      matrix:
+        test:
+          - ERS_Ln9.ne4_ne4.F2000-SCREAMv1-AQP1.ghci-snl-cpu_gnu.scream-output-preset-2
+          - ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.ghci-snl-cpu_gnu.scream-dpxx-arm97
+          - ERS_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.ghci-snl-cpu_gnu.scream-small_kernels--scream-output-preset-5
+      fail-fast: false
+    # Run this workflow if:
+    #   - workflow_dispatch: user requested this job.
+    #   - schedule: always:
+    #   - pull_request: matching skip label is NOT found
+    if: |
+      ${{
+          github.event_name == 'schedule' ||
+          ( github.event_name == 'workflow_dispatch' && contains(github.event.inputs.jobs_list, 'gcc-openmp') ) ||
+          (
+            github.event_name == 'pull_request' &&
+            !(
+              contains(github.event.pull_request.labels.*.name, 'AT: skip gcc') ||
+              contains(github.event.pull_request.labels.*.name, 'AT: skip v1')
+            )
+          )
+        }}
+    steps:
+      - name: Show action trigger
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            const eventAction = context.payload.action || 'N/A';
+            const actor = context.actor;
+            console.log(`The job was triggered by a ${eventName} event.`);
+            console.log(`  - Event action: ${eventAction}`);
+            console.log(`  - Triggered by: ${actor}`);
+      - name: Set CA certificates env var
+        run: |
+          # Ensure the operating system is Linux
+          if [ "$(uname)" != "Linux" ]; then
+            echo "This action only supports Linux."
+            exit 1
+          fi
+          # Set env var to be used in upload-artifacts phase
+          if [ -f /etc/debian_version ]; then
+            echo "NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt" >> $GITHUB_ENV
+          elif [ -f /etc/redhat-release ] || [ -f /etc/centos-release ] || [ -f /etc/fedora-release ]; then
+            echo "NODE_EXTRA_CA_CERTS=/etc/pki/tls/certs/ca-bundle.crt" >> $GITHUB_ENV
+          else
+            echo "Unsupported Linux distribution"
+            exit 1
+          fi
+      - name: Establish cmp/gen flag
+        run: |
+          dir_suffix=".C"
+          cmp_gen_flag="-c"
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            if [ ${{ inputs.bless }} ]; then
+              cmp_gen_flag="-o -g"
+              dir_suffix=".G"
+            fi
+          fi
+          echo "flags=$cmp_gen_flag -b master" >> $GITHUB_ENV
+          echo "folder_suffix=$dir_suffix" >> $GITHUB_ENV
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          show-progress: false
+          submodules: recursive
+      - name: Run test
+        run: |
+          ./cime/scripts/create_test ${{ matrix.test }} ${{ env.flags }} --wait
+      - name: Upload case files
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.test }}
+          path: |
+            /projects/e3sm/scratch/${{ matrix.test }}${{ env.folder_suffix }}*/TestStatus.log
+            /projects/e3sm/scratch/${{ matrix.test }}${{ env.folder_suffix }}*/bld/*.bldlog.*
+            /projects/e3sm/scratch/${{ matrix.test }}${{ env.folder_suffix }}*/bld/case2bld/*.bldlog.*
+            /projects/e3sm/scratch/${{ matrix.test }}${{ env.folder_suffix }}*/run/*.log.*
+            /projects/e3sm/scratch/${{ matrix.test }}${{ env.folder_suffix }}*/run/case2run/*.log.*
+            /projects/e3sm/scratch/${{ matrix.test }}${{ env.folder_suffix }}*/run/*.cprnc.out
+            /projects/e3sm/scratch/${{ matrix.test }}${{ env.folder_suffix }}*/run/case2run/*.cprnc.out
+        env:
+          NODE_EXTRA_CA_CERTS: ${{ env.NODE_EXTRA_CA_CERTS }}
+      - name: Clean up
+        if: ${{ always() }}
+        run: |
+          rm -rf /projects/e3sm/scratch/${{ matrix.test }}*

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -1,4 +1,4 @@
-name: EAMxx v1 CI testing
+name: EAMxx v1 testing
 
 on:
   # Runs on PRs against master


### PR DESCRIPTION
This PR introduces the workflow files to run what is currently the AT tests as gh actions on SNL machines. Some comments:

- So far, only testing for openmp on CPU: a container image for Nvidia GPU is currently being tested, and the actions will be updated once it's ready
- I still need to add more v1 tests. On slack, we settled on having ~6 ERS tests. I will add those before this PR is ready to merge
- The workflows run on pull_request as well as workflow_dispatch triggers. The latter can be used to generate baselines or simply to run master's tests. Additionally, the standalone workflow will have a schedule trigger, to submit to cdash (it's not there yet, cause I don't want to overlap with our jenkins infrastructure until I fully trust the actions).
- gh actions checks will not be required for now, so that AT1 can continue to merge PRs while we gradually switch to actions
- I added a composite action for test-all-scream. Although it adds very little compared to copy-pasting its content in the standalone workflow, it has a couple of steps related to artifacts upload. When the standalone testing will consist of several jobs (one per platform/arch or compiler), having these extra lines would make the workflow file clunkier. Encapsulating those lines in another file makes the workflow file easier to parse (hopefully).

I welcome questions/suggestions/contributions to make the transition smoother/better.