### PR TITLE
Use add_tracer() shortcut for adding a field to tracers group

### DIFF
--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -43,7 +43,7 @@ void SurfaceCouplingExporter::set_grids(const std::shared_ptr<const GridsManager
   add_field<Required>("pseudo_density",       scalar3d_layout_mid,  Pa,     grid_name, ps);
   add_field<Required>("phis",                 scalar2d_layout,      m2/s2,  grid_name);
   add_field<Required>("p_mid",                scalar3d_layout_mid,  Pa,     grid_name, ps);
-  add_field<Required>("qv",                   scalar3d_layout_mid,  kg/kg,  grid_name, "tracers", ps);
+  add_tracer<Required>("qv",                  scalar3d_layout_mid,  kg/kg,  grid_name, ps);
   add_field<Required>("T_mid",                scalar3d_layout_mid,  K,      grid_name, ps);
   // TODO: Switch horiz_winds to using U and V, note right now there is an issue with when the subfields are created, so can't switch yet.
   add_field<Required>("horiz_winds",          vector3d_layout,      m/s,    grid_name);

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -43,8 +43,8 @@ void SurfaceCouplingExporter::set_grids(const std::shared_ptr<const GridsManager
   add_field<Required>("pseudo_density",       scalar3d_layout_mid,  Pa,     grid_name, ps);
   add_field<Required>("phis",                 scalar2d_layout,      m2/s2,  grid_name);
   add_field<Required>("p_mid",                scalar3d_layout_mid,  Pa,     grid_name, ps);
-  add_tracer<Required>("qv",                  scalar3d_layout_mid,  kg/kg,  grid_name, ps);
   add_field<Required>("T_mid",                scalar3d_layout_mid,  K,      grid_name, ps);
+  add_tracer<Required>("qv", m_grid,  kg/kg, ps);
   // TODO: Switch horiz_winds to using U and V, note right now there is an issue with when the subfields are created, so can't switch yet.
   add_field<Required>("horiz_winds",          vector3d_layout,      m/s,    grid_name);
   add_field<Required>("sfc_flux_dir_nir",     scalar2d_layout,      W/m2,   grid_name);

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -179,7 +179,7 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
   add_field<Computed>("p_dry_mid",          pg_scalar3d_mid, Pa,    pgn,N);
   add_field<Computed>("omega",              pg_scalar3d_mid, Pa/s,  pgn,N);
 
-  add_tracer<Updated >("qv",   pg_scalar3d_mid, kg/kg, pgn, N);
+  add_tracer<Updated >("qv", m_phys_grid, kg/kg, N);
   add_group<Updated>("tracers",pgn,N, Bundling::Required);
 
   if (fv_phys_active()) {

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -172,13 +172,14 @@ void HommeDynamics::set_grids (const std::shared_ptr<const GridsManager> grids_m
   add_field<Computed>("pseudo_density",     pg_scalar3d_mid, Pa,    pgn,N);
   add_field<Computed>("pseudo_density_dry", pg_scalar3d_mid, Pa,    pgn,N);
   add_field<Updated> ("ps",                 pg_scalar2d    , Pa,    pgn);
-  add_field<Updated >("qv",                 pg_scalar3d_mid, kg/kg, pgn,"tracers",N);
   add_field<Updated >("phis",               pg_scalar2d    , m2/s2, pgn);
   add_field<Computed>("p_int",              pg_scalar3d_int, Pa,    pgn,N);
   add_field<Computed>("p_mid",              pg_scalar3d_mid, Pa,    pgn,N);
   add_field<Computed>("p_dry_int",          pg_scalar3d_int, Pa,    pgn,N);
   add_field<Computed>("p_dry_mid",          pg_scalar3d_mid, Pa,    pgn,N);
   add_field<Computed>("omega",              pg_scalar3d_mid, Pa/s,  pgn,N);
+
+  add_tracer<Updated >("qv",   pg_scalar3d_mid, kg/kg, pgn, N);
   add_group<Updated>("tracers",pgn,N, Bundling::Required);
 
   if (fv_phys_active()) {

--- a/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
+++ b/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
@@ -38,7 +38,7 @@ void CldFraction::set_grids(const std::shared_ptr<const GridsManager> grids_mana
 
   // Set of fields used strictly as input
   constexpr int ps = Pack::n;
-  add_field<Required>("qi",          scalar3d_layout_mid, kg/kg,  grid_name,"tracers",ps);
+  add_tracer<Required>("qi", scalar3d_layout_mid, kg/kg,  grid_name, ps);
   add_field<Required>("cldfrac_liq", scalar3d_layout_mid, nondim, grid_name,ps);
 
   // Set of fields used strictly as output

--- a/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
+++ b/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
@@ -38,7 +38,7 @@ void CldFraction::set_grids(const std::shared_ptr<const GridsManager> grids_mana
 
   // Set of fields used strictly as input
   constexpr int ps = Pack::n;
-  add_tracer<Required>("qi", scalar3d_layout_mid, kg/kg,  grid_name, ps);
+  add_tracer<Required>("qi", m_grid, kg/kg, ps);
   add_field<Required>("cldfrac_liq", scalar3d_layout_mid, nondim, grid_name,ps);
 
   // Set of fields used strictly as output

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -74,9 +74,9 @@ void Cosp::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>("phis",             scalar2d    , m2/s2,  grid_name);
   add_field<Required>("pseudo_density",   scalar3d_mid, Pa,     grid_name);
   add_field<Required>("cldfrac_rad",      scalar3d_mid, nondim, grid_name);
-  add_tracer<Required>("qv", scalar3d_mid, kg/kg, grid_name);
-  add_tracer<Required>("qc", scalar3d_mid, kg/kg, grid_name);
-  add_tracer<Required>("qi", scalar3d_mid, kg/kg, grid_name);
+  add_tracer<Required>("qv", m_grid, kg/kg);
+  add_tracer<Required>("qc", m_grid, kg/kg);
+  add_tracer<Required>("qi", m_grid, kg/kg);
   // Optical properties, should be computed in radiation interface
   add_field<Required>("dtau067",     scalar3d_mid, nondim, grid_name); // 0.67 micron optical depth
   add_field<Required>("dtau105",     scalar3d_mid, nondim, grid_name); // 10.5 micron optical depth

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -49,7 +49,7 @@ void Cosp::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 
   // Define the different field layouts that will be used for this process
 
-  // Layout for 3D (2d horiz X 1d vertical) variable defined at mid-level and interfaces 
+  // Layout for 3D (2d horiz X 1d vertical) variable defined at mid-level and interfaces
   FieldLayout scalar2d     = m_grid->get_2d_scalar_layout();
   FieldLayout scalar3d_mid = m_grid->get_3d_scalar_layout(true);
   FieldLayout scalar3d_int = m_grid->get_3d_scalar_layout(false);
@@ -71,12 +71,12 @@ void Cosp::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   //add_field<Required>("height_mid",  scalar3d_mid, m,      grid_name);
   //add_field<Required>("height_int",  scalar3d_int, m,      grid_name);
   add_field<Required>("T_mid",            scalar3d_mid, K,      grid_name);
-  add_field<Required>("qv",               scalar3d_mid, kg/kg,      grid_name, "tracers");
-  add_field<Required>("qc",               scalar3d_mid, kg/kg,      grid_name, "tracers");
-  add_field<Required>("qi",               scalar3d_mid, kg/kg,      grid_name, "tracers");
   add_field<Required>("phis",             scalar2d    , m2/s2,  grid_name);
   add_field<Required>("pseudo_density",   scalar3d_mid, Pa,     grid_name);
   add_field<Required>("cldfrac_rad",      scalar3d_mid, nondim, grid_name);
+  add_tracer<Required>("qv", scalar3d_mid, kg/kg, grid_name);
+  add_tracer<Required>("qc", scalar3d_mid, kg/kg, grid_name);
+  add_tracer<Required>("qi", scalar3d_mid, kg/kg, grid_name);
   // Optical properties, should be computed in radiation interface
   add_field<Required>("dtau067",     scalar3d_mid, nondim, grid_name); // 0.67 micron optical depth
   add_field<Required>("dtau105",     scalar3d_mid, nondim, grid_name); // 10.5 micron optical depth

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -86,19 +86,19 @@ void MAMAci::set_grids(
 
   // atmospheric quantities
   // specific humidity [kg/kg]
-  add_field<Required>("qv", scalar3d_layout_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qv", scalar3d_layout_mid, q_unit, grid_name);
 
   // cloud liquid mass mixing ratio [kg/kg]
-  add_field<Required>("qc", scalar3d_layout_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qc", scalar3d_layout_mid, q_unit, grid_name);
 
   // cloud ice mass mixing ratio [kg/kg]
-  add_field<Required>("qi", scalar3d_layout_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qi", scalar3d_layout_mid, q_unit, grid_name);
 
   // cloud liquid number mixing ratio [1/kg]
-  add_field<Required>("nc", scalar3d_layout_mid, n_unit, grid_name, "tracers");
+  add_tracer<Required>("nc", scalar3d_layout_mid, n_unit, grid_name);
 
   // cloud ice number mixing ratio [1/kg]
-  add_field<Required>("ni", scalar3d_layout_mid, n_unit, grid_name, "tracers");
+  add_tracer<Required>("ni", scalar3d_layout_mid, n_unit, grid_name);
 
   // Temperature[K] at midpoints
   add_field<Required>("T_mid", scalar3d_layout_mid, K, grid_name);
@@ -164,8 +164,8 @@ void MAMAci::set_grids(
     // interstitial aerosol tracers of interest: number (n) mixing ratios
     const char *int_nmr_field_name =
         mam_coupling::int_aero_nmr_field_name(mode);
-    add_field<Updated>(int_nmr_field_name, scalar3d_layout_mid, n_unit,
-                       grid_name, "tracers");
+    add_tracer<Updated>(int_nmr_field_name, scalar3d_layout_mid, n_unit,
+                        grid_name);
 
     // cloudborne aerosol tracers of interest: number (n) mixing ratios
     // NOTE: DO NOT add cld borne aerosols to the "tracer" group as these are
@@ -180,8 +180,8 @@ void MAMAci::set_grids(
       const char *int_mmr_field_name =
           mam_coupling::int_aero_mmr_field_name(mode, a);
       if(strlen(int_mmr_field_name) > 0) {
-        add_field<Updated>(int_mmr_field_name, scalar3d_layout_mid, q_unit,
-                           grid_name, "tracers");
+        add_tracer<Updated>(int_mmr_field_name, scalar3d_layout_mid, q_unit,
+                            grid_name);
       }
       // (cloudborne) aerosol tracers of interest: mass (q) mixing ratios
       // NOTE: DO NOT add cld borne aerosols to the "tracer" group as these are
@@ -197,8 +197,8 @@ void MAMAci::set_grids(
 
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char *gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_field<Updated>(gas_mmr_field_name, scalar3d_layout_mid, q_unit,
-                       grid_name, "tracers");
+    add_tracer<Updated>(gas_mmr_field_name, scalar3d_layout_mid, q_unit,
+                        grid_name);
   }  // end for loop num gases
 
   // ------------------------------------------------------------------------

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -86,19 +86,19 @@ void MAMAci::set_grids(
 
   // atmospheric quantities
   // specific humidity [kg/kg]
-  add_tracer<Required>("qv", scalar3d_layout_mid, q_unit, grid_name);
+  add_tracer<Required>("qv", grid_, q_unit);
 
   // cloud liquid mass mixing ratio [kg/kg]
-  add_tracer<Required>("qc", scalar3d_layout_mid, q_unit, grid_name);
+  add_tracer<Required>("qc", grid_, q_unit);
 
   // cloud ice mass mixing ratio [kg/kg]
-  add_tracer<Required>("qi", scalar3d_layout_mid, q_unit, grid_name);
+  add_tracer<Required>("qi", grid_, q_unit);
 
   // cloud liquid number mixing ratio [1/kg]
-  add_tracer<Required>("nc", scalar3d_layout_mid, n_unit, grid_name);
+  add_tracer<Required>("nc", grid_, n_unit);
 
   // cloud ice number mixing ratio [1/kg]
-  add_tracer<Required>("ni", scalar3d_layout_mid, n_unit, grid_name);
+  add_tracer<Required>("ni", grid_, n_unit);
 
   // Temperature[K] at midpoints
   add_field<Required>("T_mid", scalar3d_layout_mid, K, grid_name);
@@ -164,8 +164,7 @@ void MAMAci::set_grids(
     // interstitial aerosol tracers of interest: number (n) mixing ratios
     const char *int_nmr_field_name =
         mam_coupling::int_aero_nmr_field_name(mode);
-    add_tracer<Updated>(int_nmr_field_name, scalar3d_layout_mid, n_unit,
-                        grid_name);
+    add_tracer<Updated>(int_nmr_field_name, grid_, n_unit);
 
     // cloudborne aerosol tracers of interest: number (n) mixing ratios
     // NOTE: DO NOT add cld borne aerosols to the "tracer" group as these are
@@ -180,8 +179,7 @@ void MAMAci::set_grids(
       const char *int_mmr_field_name =
           mam_coupling::int_aero_mmr_field_name(mode, a);
       if(strlen(int_mmr_field_name) > 0) {
-        add_tracer<Updated>(int_mmr_field_name, scalar3d_layout_mid, q_unit,
-                            grid_name);
+        add_tracer<Updated>(int_mmr_field_name, grid_, q_unit);
       }
       // (cloudborne) aerosol tracers of interest: mass (q) mixing ratios
       // NOTE: DO NOT add cld borne aerosols to the "tracer" group as these are
@@ -197,8 +195,7 @@ void MAMAci::set_grids(
 
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char *gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_tracer<Updated>(gas_mmr_field_name, scalar3d_layout_mid, q_unit,
-                        grid_name);
+    add_tracer<Updated>(gas_mmr_field_name, grid_, q_unit);
   }  // end for loop num gases
 
   // ------------------------------------------------------------------------

--- a/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
@@ -43,19 +43,19 @@ void MAMConstituentFluxes::set_grids(
   // --------------------------------------------------------------------------
   // ----------- Atmospheric quantities -------------
   // Specific humidity [kg/kg](Require only for building DS)
-  add_field<Required>("qv", scalar3d_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qv", scalar3d_mid, q_unit, grid_name);
 
   // Cloud liquid mass mixing ratio [kg/kg](Require only for building DS)
-  add_field<Required>("qc", scalar3d_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qc", scalar3d_mid, q_unit, grid_name);
 
   // Cloud ice mass mixing ratio [kg/kg](Require only for building DS)
-  add_field<Required>("qi", scalar3d_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qi", scalar3d_mid, q_unit, grid_name);
 
   // Cloud liquid number mixing ratio [1/kg](Require only for building DS)
-  add_field<Required>("nc", scalar3d_mid, n_unit, grid_name, "tracers");
+  add_tracer<Required>("nc", scalar3d_mid, n_unit, grid_name);
 
   // Cloud ice number mixing ratio [1/kg](Require only for building DS)
-  add_field<Required>("ni", scalar3d_mid, n_unit, grid_name, "tracers");
+  add_tracer<Required>("ni", scalar3d_mid, n_unit, grid_name);
 
   // Temperature[K] at midpoints
   add_field<Required>("T_mid", scalar3d_mid, K, grid_name);
@@ -102,8 +102,7 @@ void MAMConstituentFluxes::set_grids(
     // interstitial aerosol tracers of interest: number (n) mixing ratios
     const std::string int_nmr_field_name =
         mam_coupling::int_aero_nmr_field_name(mode);
-    add_field<Updated>(int_nmr_field_name, scalar3d_mid, n_unit, grid_name,
-                       "tracers");
+    add_tracer<Updated>(int_nmr_field_name, scalar3d_mid, n_unit, grid_name);
 
     // cloudborne aerosol tracers of interest: number (n) mixing ratios
     // NOTE: DO NOT add cld borne aerosols to the "tracer" group as these are
@@ -117,8 +116,7 @@ void MAMConstituentFluxes::set_grids(
       const std::string int_mmr_field_name =
           mam_coupling::int_aero_mmr_field_name(mode, a);
       if(not int_mmr_field_name.empty()) {
-        add_field<Updated>(int_mmr_field_name, scalar3d_mid, q_unit, grid_name,
-                           "tracers");
+        add_tracer<Updated>(int_mmr_field_name, scalar3d_mid, q_unit, grid_name);
       }
       // (cloudborne) aerosol tracers of interest: mass (q) mixing ratios
       // NOTE: DO NOT add cld borne aerosols to the "tracer" group as these are
@@ -133,8 +131,7 @@ void MAMConstituentFluxes::set_grids(
 
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const std::string gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_field<Updated>(gas_mmr_field_name, scalar3d_mid, q_unit, grid_name,
-                       "tracers");
+    add_tracer<Updated>(gas_mmr_field_name, scalar3d_mid, q_unit, grid_name);
   }  // end for loop num gases
 
 }  // set_grid

--- a/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
@@ -43,19 +43,19 @@ void MAMConstituentFluxes::set_grids(
   // --------------------------------------------------------------------------
   // ----------- Atmospheric quantities -------------
   // Specific humidity [kg/kg](Require only for building DS)
-  add_tracer<Required>("qv", scalar3d_mid, q_unit, grid_name);
+  add_tracer<Required>("qv", grid_, q_unit);
 
   // Cloud liquid mass mixing ratio [kg/kg](Require only for building DS)
-  add_tracer<Required>("qc", scalar3d_mid, q_unit, grid_name);
+  add_tracer<Required>("qc", grid_, q_unit);
 
   // Cloud ice mass mixing ratio [kg/kg](Require only for building DS)
-  add_tracer<Required>("qi", scalar3d_mid, q_unit, grid_name);
+  add_tracer<Required>("qi", grid_, q_unit);
 
   // Cloud liquid number mixing ratio [1/kg](Require only for building DS)
-  add_tracer<Required>("nc", scalar3d_mid, n_unit, grid_name);
+  add_tracer<Required>("nc", grid_, n_unit);
 
   // Cloud ice number mixing ratio [1/kg](Require only for building DS)
-  add_tracer<Required>("ni", scalar3d_mid, n_unit, grid_name);
+  add_tracer<Required>("ni", grid_, n_unit);
 
   // Temperature[K] at midpoints
   add_field<Required>("T_mid", scalar3d_mid, K, grid_name);
@@ -102,7 +102,7 @@ void MAMConstituentFluxes::set_grids(
     // interstitial aerosol tracers of interest: number (n) mixing ratios
     const std::string int_nmr_field_name =
         mam_coupling::int_aero_nmr_field_name(mode);
-    add_tracer<Updated>(int_nmr_field_name, scalar3d_mid, n_unit, grid_name);
+    add_tracer<Updated>(int_nmr_field_name, grid_, n_unit);
 
     // cloudborne aerosol tracers of interest: number (n) mixing ratios
     // NOTE: DO NOT add cld borne aerosols to the "tracer" group as these are
@@ -116,7 +116,7 @@ void MAMConstituentFluxes::set_grids(
       const std::string int_mmr_field_name =
           mam_coupling::int_aero_mmr_field_name(mode, a);
       if(not int_mmr_field_name.empty()) {
-        add_tracer<Updated>(int_mmr_field_name, scalar3d_mid, q_unit, grid_name);
+        add_tracer<Updated>(int_mmr_field_name, grid_, q_unit);
       }
       // (cloudborne) aerosol tracers of interest: mass (q) mixing ratios
       // NOTE: DO NOT add cld borne aerosols to the "tracer" group as these are
@@ -131,7 +131,7 @@ void MAMConstituentFluxes::set_grids(
 
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const std::string gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_tracer<Updated>(gas_mmr_field_name, scalar3d_mid, q_unit, grid_name);
+    add_tracer<Updated>(gas_mmr_field_name, grid_, q_unit);
   }  // end for loop num gases
 
 }  // set_grid

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -73,19 +73,19 @@ void MAMDryDep::set_grids(
 
   // ----------- Atmospheric quantities -------------
   // Specific humidity [kg/kg](Require only for building DS)
-  add_tracer<Required>("qv", scalar3d_mid, q_unit, grid_name);
+  add_tracer<Required>("qv", grid_, q_unit);
 
   // Cloud liquid mass mixing ratio [kg/kg](Require only for building DS)
-  add_tracer<Required>("qc", scalar3d_mid, q_unit, grid_name);
+  add_tracer<Required>("qc", grid_, q_unit);
 
   // Cloud ice mass mixing ratio [kg/kg](Require only for building DS)
-  add_tracer<Required>("qi", scalar3d_mid, q_unit, grid_name);
+  add_tracer<Required>("qi", grid_, q_unit);
 
   // Cloud liquid number mixing ratio [1/kg](Require only for building DS)
-  add_tracer<Required>("nc", scalar3d_mid, n_unit, grid_name);
+  add_tracer<Required>("nc", grid_, n_unit);
 
   // Cloud ice number mixing ratio [1/kg](Require only for building DS)
-  add_tracer<Required>("ni", scalar3d_mid, n_unit, grid_name);
+  add_tracer<Required>("ni", grid_, n_unit);
 
   // Temperature[K] at midpoints
   add_field<Required>("T_mid", scalar3d_mid, K, grid_name);
@@ -158,13 +158,13 @@ void MAMDryDep::set_grids(
   for(int m = 0; m < num_aero_modes; ++m) {
     const char *int_nmr_field_name = mam_coupling::int_aero_nmr_field_name(m);
 
-    add_tracer<Updated>(int_nmr_field_name, scalar3d_mid, n_unit, grid_name);
+    add_tracer<Updated>(int_nmr_field_name, grid_, n_unit);
     for(int a = 0; a < mam_coupling::num_aero_species(); ++a) {
       const char *int_mmr_field_name =
           mam_coupling::int_aero_mmr_field_name(m, a);
 
       if(strlen(int_mmr_field_name) > 0) {
-        add_tracer<Updated>(int_mmr_field_name, scalar3d_mid, q_unit, grid_name);
+        add_tracer<Updated>(int_mmr_field_name, grid_, q_unit);
       }
     }
   }
@@ -186,7 +186,7 @@ void MAMDryDep::set_grids(
   // aerosol-related gases: mass mixing ratios
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char *gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_tracer<Updated>(gas_mmr_field_name, scalar3d_mid, q_unit, grid_name);
+    add_tracer<Updated>(gas_mmr_field_name, grid_, q_unit);
   }
 
   // -------------------------------------------------------------

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -56,7 +56,7 @@ void MAMDryDep::set_grids(
   // Layout for 4D (2d horiz X 1d vertical x number of modes) variables
   // at mid points
   const int num_aero_modes = mam_coupling::num_aero_modes();
-  const FieldLayout vector3d_mid = grid_->get_3d_vector_layout(true, num_aero_modes, "num_modes"); 
+  const FieldLayout vector3d_mid = grid_->get_3d_vector_layout(true, num_aero_modes, "num_modes");
 
   using namespace ekat::units;
 
@@ -73,19 +73,19 @@ void MAMDryDep::set_grids(
 
   // ----------- Atmospheric quantities -------------
   // Specific humidity [kg/kg](Require only for building DS)
-  add_field<Required>("qv", scalar3d_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qv", scalar3d_mid, q_unit, grid_name);
 
   // Cloud liquid mass mixing ratio [kg/kg](Require only for building DS)
-  add_field<Required>("qc", scalar3d_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qc", scalar3d_mid, q_unit, grid_name);
 
   // Cloud ice mass mixing ratio [kg/kg](Require only for building DS)
-  add_field<Required>("qi", scalar3d_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qi", scalar3d_mid, q_unit, grid_name);
 
   // Cloud liquid number mixing ratio [1/kg](Require only for building DS)
-  add_field<Required>("nc", scalar3d_mid, n_unit, grid_name, "tracers");
+  add_tracer<Required>("nc", scalar3d_mid, n_unit, grid_name);
 
   // Cloud ice number mixing ratio [1/kg](Require only for building DS)
-  add_field<Required>("ni", scalar3d_mid, n_unit, grid_name, "tracers");
+  add_tracer<Required>("ni", scalar3d_mid, n_unit, grid_name);
 
   // Temperature[K] at midpoints
   add_field<Required>("T_mid", scalar3d_mid, K, grid_name);
@@ -158,15 +158,13 @@ void MAMDryDep::set_grids(
   for(int m = 0; m < num_aero_modes; ++m) {
     const char *int_nmr_field_name = mam_coupling::int_aero_nmr_field_name(m);
 
-    add_field<Updated>(int_nmr_field_name, scalar3d_mid, n_unit, grid_name,
-                       "tracers");
+    add_tracer<Updated>(int_nmr_field_name, scalar3d_mid, n_unit, grid_name);
     for(int a = 0; a < mam_coupling::num_aero_species(); ++a) {
       const char *int_mmr_field_name =
           mam_coupling::int_aero_mmr_field_name(m, a);
 
       if(strlen(int_mmr_field_name) > 0) {
-        add_field<Updated>(int_mmr_field_name, scalar3d_mid, q_unit, grid_name,
-                           "tracers");
+        add_tracer<Updated>(int_mmr_field_name, scalar3d_mid, q_unit, grid_name);
       }
     }
   }
@@ -188,8 +186,7 @@ void MAMDryDep::set_grids(
   // aerosol-related gases: mass mixing ratios
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char *gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_field<Updated>(gas_mmr_field_name, scalar3d_mid, q_unit, grid_name,
-                       "tracers");
+    add_tracer<Updated>(gas_mmr_field_name, scalar3d_mid, q_unit, grid_name);
   }
 
   // -------------------------------------------------------------

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -122,26 +122,26 @@ void MAMMicrophysics::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Required>("omega", scalar3d_layout_mid, Pa/s, grid_name); // vertical pressure velocity
   add_field<Required>("T_mid", scalar3d_layout_mid, K, grid_name); // Temperature
   add_field<Required>("p_mid", scalar3d_layout_mid, Pa, grid_name); // total pressure
-  add_tracer<Required>("qv", scalar3d_layout_mid, kg/kg, grid_name); // specific humidity
-  add_tracer<Required>("qi", scalar3d_layout_mid, kg/kg, grid_name); // ice wet mixing ratio
-  add_tracer<Required>("ni", scalar3d_layout_mid, n_unit, grid_name); // ice number mixing ratio
   add_field<Required>("pbl_height", scalar2d_layout_col, m, grid_name); // planetary boundary layer height
   add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa, grid_name); // p_del, hydrostatic pressure
   add_field<Required>("phis",           scalar2d_layout_col, m2/s2, grid_name);
   add_field<Required>("cldfrac_tot", scalar3d_layout_mid, nondim, grid_name); // cloud fraction
+  add_tracer<Required>("qv", grid_, kg/kg); // specific humidity
+  add_tracer<Required>("qi", grid_, kg/kg); // ice wet mixing ratio
+  add_tracer<Required>("ni", grid_, n_unit); // ice number mixing ratio
 
   // droplet activation can alter cloud liquid and number mixing ratios
-  add_tracer<Updated>("qc", scalar3d_layout_mid, kg/kg, grid_name); // cloud liquid wet mixing ratio
-  add_tracer<Updated>("nc", scalar3d_layout_mid, n_unit, grid_name); // cloud liquid wet number mixing ratio
+  add_tracer<Updated>("qc", grid_, kg/kg); // cloud liquid wet mixing ratio
+  add_tracer<Updated>("nc", grid_, n_unit); // cloud liquid wet number mixing ratio
 
   // (interstitial) aerosol tracers of interest: mass (q) and number (n) mixing ratios
   for (int m = 0; m < mam_coupling::num_aero_modes(); ++m) {
     const char* int_nmr_field_name = mam_coupling::int_aero_nmr_field_name(m);
-    add_tracer<Updated>(int_nmr_field_name, scalar3d_layout_mid, n_unit, grid_name);
+    add_tracer<Updated>(int_nmr_field_name, grid_, n_unit);
     for (int a = 0; a < mam_coupling::num_aero_species(); ++a) {
       const char* int_mmr_field_name = mam_coupling::int_aero_mmr_field_name(m, a);
       if (strlen(int_mmr_field_name) > 0) {
-        add_tracer<Updated>(int_mmr_field_name, scalar3d_layout_mid, kg/kg, grid_name);
+        add_tracer<Updated>(int_mmr_field_name, grid_, kg/kg);
       }
     }
   }
@@ -149,7 +149,7 @@ void MAMMicrophysics::set_grids(const std::shared_ptr<const GridsManager> grids_
   // aerosol-related gases: mass mixing ratios
   for (int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char* gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_tracer<Updated>(gas_mmr_field_name, scalar3d_layout_mid, kg/kg, grid_name);
+    add_tracer<Updated>(gas_mmr_field_name, grid_, kg/kg);
   }
 
   // Tracers group -- do we need this in addition to the tracers above? In any

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -122,26 +122,26 @@ void MAMMicrophysics::set_grids(const std::shared_ptr<const GridsManager> grids_
   add_field<Required>("omega", scalar3d_layout_mid, Pa/s, grid_name); // vertical pressure velocity
   add_field<Required>("T_mid", scalar3d_layout_mid, K, grid_name); // Temperature
   add_field<Required>("p_mid", scalar3d_layout_mid, Pa, grid_name); // total pressure
-  add_field<Required>("qv", scalar3d_layout_mid, kg/kg, grid_name, "tracers"); // specific humidity
-  add_field<Required>("qi", scalar3d_layout_mid, kg/kg, grid_name, "tracers"); // ice wet mixing ratio
-  add_field<Required>("ni", scalar3d_layout_mid, n_unit, grid_name, "tracers"); // ice number mixing ratio
+  add_tracer<Required>("qv", scalar3d_layout_mid, kg/kg, grid_name); // specific humidity
+  add_tracer<Required>("qi", scalar3d_layout_mid, kg/kg, grid_name); // ice wet mixing ratio
+  add_tracer<Required>("ni", scalar3d_layout_mid, n_unit, grid_name); // ice number mixing ratio
   add_field<Required>("pbl_height", scalar2d_layout_col, m, grid_name); // planetary boundary layer height
   add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa, grid_name); // p_del, hydrostatic pressure
   add_field<Required>("phis",           scalar2d_layout_col, m2/s2, grid_name);
   add_field<Required>("cldfrac_tot", scalar3d_layout_mid, nondim, grid_name); // cloud fraction
 
   // droplet activation can alter cloud liquid and number mixing ratios
-  add_field<Updated>("qc", scalar3d_layout_mid, kg/kg, grid_name, "tracers"); // cloud liquid wet mixing ratio
-  add_field<Updated>("nc", scalar3d_layout_mid, n_unit, grid_name, "tracers"); // cloud liquid wet number mixing ratio
+  add_tracer<Updated>("qc", scalar3d_layout_mid, kg/kg, grid_name); // cloud liquid wet mixing ratio
+  add_tracer<Updated>("nc", scalar3d_layout_mid, n_unit, grid_name); // cloud liquid wet number mixing ratio
 
   // (interstitial) aerosol tracers of interest: mass (q) and number (n) mixing ratios
   for (int m = 0; m < mam_coupling::num_aero_modes(); ++m) {
     const char* int_nmr_field_name = mam_coupling::int_aero_nmr_field_name(m);
-    add_field<Updated>(int_nmr_field_name, scalar3d_layout_mid, n_unit, grid_name, "tracers");
+    add_tracer<Updated>(int_nmr_field_name, scalar3d_layout_mid, n_unit, grid_name);
     for (int a = 0; a < mam_coupling::num_aero_species(); ++a) {
       const char* int_mmr_field_name = mam_coupling::int_aero_mmr_field_name(m, a);
       if (strlen(int_mmr_field_name) > 0) {
-        add_field<Updated>(int_mmr_field_name, scalar3d_layout_mid, kg/kg, grid_name, "tracers");
+        add_tracer<Updated>(int_mmr_field_name, scalar3d_layout_mid, kg/kg, grid_name);
       }
     }
   }
@@ -149,7 +149,7 @@ void MAMMicrophysics::set_grids(const std::shared_ptr<const GridsManager> grids_
   // aerosol-related gases: mass mixing ratios
   for (int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char* gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_field<Updated>(gas_mmr_field_name, scalar3d_layout_mid, kg/kg, grid_name, "tracers");
+    add_tracer<Updated>(gas_mmr_field_name, scalar3d_layout_mid, kg/kg, grid_name);
   }
 
   // Tracers group -- do we need this in addition to the tracers above? In any
@@ -201,7 +201,7 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
   wet_atm_.nc = get_field_out("nc").get_view<Real**>();
   wet_atm_.qi = get_field_in("qi").get_view<const Real**>();
   wet_atm_.ni = get_field_in("ni").get_view<const Real**>();
-  
+
 
   dry_atm_.T_mid     = get_field_in("T_mid").get_view<const Real**>();
   dry_atm_.p_mid     = get_field_in("p_mid").get_view<const Real**>();

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -55,13 +55,13 @@ void MAMOptics::set_grids(
   add_field<Required>("p_int",              scalar3d_int, Pa,     grid_name);  // total pressure
   add_field<Required>("pseudo_density",     scalar3d_mid, Pa,     grid_name);
   add_field<Required>("pseudo_density_dry", scalar3d_mid, Pa,     grid_name);
-  add_field<Required>("qv",                 scalar3d_mid, kg/kg,  grid_name,"tracers");  // specific humidity
-  add_field<Required>("qi",                 scalar3d_mid, kg/kg,  grid_name,"tracers");  // ice wet mixing ratio
-  add_field<Required>("ni",                 scalar3d_mid, n_unit, grid_name,"tracers");  // ice number mixing ratio
+  add_tracer<Required>("qv",                scalar3d_mid, kg/kg,  grid_name);  // specific humidity
+  add_tracer<Required>("qi",                scalar3d_mid, kg/kg,  grid_name);  // ice wet mixing ratio
+  add_tracer<Required>("ni",                scalar3d_mid, n_unit, grid_name);  // ice number mixing ratio
 
   // droplet activation can alter cloud liquid and number mixing ratios
-  add_field<Required>("qc", scalar3d_mid, kg/kg, grid_name,"tracers");  // cloud liquid wet mixing ratio
-  add_field<Required>("nc", scalar3d_mid, n_unit, grid_name,"tracers");  // cloud liquid wet number mixing ratio
+  add_tracer<Required>("qc", scalar3d_mid, kg/kg, grid_name);  // cloud liquid wet mixing ratio
+  add_tracer<Required>("nc", scalar3d_mid, n_unit, grid_name);  // cloud liquid wet number mixing ratio
 
   add_field<Required>("phis", scalar2d, m2 / s2, grid_name);
   add_field<Required>("cldfrac_tot", scalar3d_mid, nondim,grid_name);  // cloud fraction
@@ -86,12 +86,12 @@ void MAMOptics::set_grids(
   for(int m = 0; m < mam_coupling::num_aero_modes(); ++m) {
     const char *int_nmr_field_name = mam_coupling::int_aero_nmr_field_name(m);
 
-    add_field<Updated>(int_nmr_field_name, scalar3d_mid, n_unit,grid_name, "tracers");
+    add_tracer<Updated>(int_nmr_field_name, scalar3d_mid, n_unit,grid_name);
     for(int a = 0; a < mam_coupling::num_aero_species(); ++a) {
       const char *int_mmr_field_name = mam_coupling::int_aero_mmr_field_name(m, a);
 
       if(strlen(int_mmr_field_name) > 0) {
-        add_field<Updated>(int_mmr_field_name, scalar3d_mid, kg/kg,grid_name, "tracers");
+        add_tracer<Updated>(int_mmr_field_name, scalar3d_mid, kg/kg,grid_name);
       }
     }
   }
@@ -113,7 +113,7 @@ void MAMOptics::set_grids(
   // aerosol-related gases: mass mixing ratios
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char *gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_field<Updated>(gas_mmr_field_name, scalar3d_mid, kg/kg, grid_name, "tracers");
+    add_tracer<Updated>(gas_mmr_field_name, scalar3d_mid, kg/kg, grid_name);
   }
 }
 
@@ -140,7 +140,7 @@ void MAMOptics::initialize_impl(const RunType run_type) {
   wet_atm_.nc    = get_field_in("nc").get_view<const Real **>();
   wet_atm_.qi    = get_field_in("qi").get_view<const Real **>();
   wet_atm_.ni    = get_field_in("ni").get_view<const Real **>();
-  
+
 
   constexpr int ntot_amode = mam4::AeroConfig::num_modes();
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -55,13 +55,13 @@ void MAMOptics::set_grids(
   add_field<Required>("p_int",              scalar3d_int, Pa,     grid_name);  // total pressure
   add_field<Required>("pseudo_density",     scalar3d_mid, Pa,     grid_name);
   add_field<Required>("pseudo_density_dry", scalar3d_mid, Pa,     grid_name);
-  add_tracer<Required>("qv",                scalar3d_mid, kg/kg,  grid_name);  // specific humidity
-  add_tracer<Required>("qi",                scalar3d_mid, kg/kg,  grid_name);  // ice wet mixing ratio
-  add_tracer<Required>("ni",                scalar3d_mid, n_unit, grid_name);  // ice number mixing ratio
+  add_tracer<Required>("qv",                grid_, kg/kg);                     // specific humidity
+  add_tracer<Required>("qi",                grid_, kg/kg);                     // ice wet mixing ratio
+  add_tracer<Required>("ni",                grid_, n_unit);                    // ice number mixing ratio
 
   // droplet activation can alter cloud liquid and number mixing ratios
-  add_tracer<Required>("qc", scalar3d_mid, kg/kg, grid_name);  // cloud liquid wet mixing ratio
-  add_tracer<Required>("nc", scalar3d_mid, n_unit, grid_name);  // cloud liquid wet number mixing ratio
+  add_tracer<Required>("qc", grid_, kg/kg);  // cloud liquid wet mixing ratio
+  add_tracer<Required>("nc", grid_, n_unit);  // cloud liquid wet number mixing ratio
 
   add_field<Required>("phis", scalar2d, m2 / s2, grid_name);
   add_field<Required>("cldfrac_tot", scalar3d_mid, nondim,grid_name);  // cloud fraction
@@ -86,12 +86,12 @@ void MAMOptics::set_grids(
   for(int m = 0; m < mam_coupling::num_aero_modes(); ++m) {
     const char *int_nmr_field_name = mam_coupling::int_aero_nmr_field_name(m);
 
-    add_tracer<Updated>(int_nmr_field_name, scalar3d_mid, n_unit,grid_name);
+    add_tracer<Updated>(int_nmr_field_name, grid_, n_unit);
     for(int a = 0; a < mam_coupling::num_aero_species(); ++a) {
       const char *int_mmr_field_name = mam_coupling::int_aero_mmr_field_name(m, a);
 
       if(strlen(int_mmr_field_name) > 0) {
-        add_tracer<Updated>(int_mmr_field_name, scalar3d_mid, kg/kg,grid_name);
+        add_tracer<Updated>(int_mmr_field_name, grid_, kg/kg);
       }
     }
   }
@@ -113,7 +113,7 @@ void MAMOptics::set_grids(
   // aerosol-related gases: mass mixing ratios
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char *gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_tracer<Updated>(gas_mmr_field_name, scalar3d_mid, kg/kg, grid_name);
+    add_tracer<Updated>(gas_mmr_field_name, grid_, kg/kg);
   }
 }
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -61,19 +61,19 @@ void MAMWetscav::set_grids(
 
   // ----------- Atmospheric quantities -------------
   // Specific humidity [kg/kg]
-  add_field<Required>("qv", scalar3d_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qv", scalar3d_mid, q_unit, grid_name);
 
   // cloud liquid mass mixing ratio [kg/kg]
-  add_field<Required>("qc", scalar3d_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qc", scalar3d_mid, q_unit, grid_name);
 
   // cloud ice mass mixing ratio [kg/kg]
-  add_field<Required>("qi", scalar3d_mid, q_unit, grid_name, "tracers");
+  add_tracer<Required>("qi", scalar3d_mid, q_unit, grid_name);
 
   // cloud liquid number mixing ratio [1/kg]
-  add_field<Required>("nc", scalar3d_mid, n_unit, grid_name, "tracers");
+  add_tracer<Required>("nc", scalar3d_mid, n_unit, grid_name);
 
   // cloud ice number mixing ratio [1/kg]
-  add_field<Required>("ni", scalar3d_mid, n_unit, grid_name, "tracers");
+  add_tracer<Required>("ni", scalar3d_mid, n_unit, grid_name);
 
   // Temperature[K] at midpoints
   add_field<Required>("T_mid", scalar3d_mid, K, grid_name);
@@ -161,8 +161,7 @@ void MAMWetscav::set_grids(
     // interstitial aerosol tracers of interest: number (n) mixing ratios
     const char *int_nmr_field_name =
         mam_coupling::int_aero_nmr_field_name(imode);
-    add_field<Updated>(int_nmr_field_name, scalar3d_mid, n_unit, grid_name,
-                       "tracers");
+    add_tracer<Updated>(int_nmr_field_name, scalar3d_mid, n_unit, grid_name);
 
     // cloudborne aerosol tracers of interest: number (n) mixing ratios
     // Note: Do *not* add cld borne aerosols to the "tracer" group as these are
@@ -177,8 +176,7 @@ void MAMWetscav::set_grids(
       const char *int_mmr_field_name =
           mam_coupling::int_aero_mmr_field_name(imode, ispec);
       if(strlen(int_mmr_field_name) > 0) {
-        add_field<Updated>(int_mmr_field_name, scalar3d_mid, q_unit, grid_name,
-                           "tracers");
+        add_tracer<Updated>(int_mmr_field_name, scalar3d_mid, q_unit, grid_name);
       }
 
       // (cloudborne) aerosol tracers of interest: mass (q) mixing ratios
@@ -198,8 +196,7 @@ void MAMWetscav::set_grids(
   // aerosol-related gases: mass mixing ratios
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char *gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_field<Updated>(gas_mmr_field_name, scalar3d_mid, q_unit, grid_name,
-                       "tracers");
+    add_tracer<Updated>(gas_mmr_field_name, scalar3d_mid, q_unit, grid_name);
   }
 
   // -------------------------------------------------------------

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -61,19 +61,19 @@ void MAMWetscav::set_grids(
 
   // ----------- Atmospheric quantities -------------
   // Specific humidity [kg/kg]
-  add_tracer<Required>("qv", scalar3d_mid, q_unit, grid_name);
+  add_tracer<Required>("qv", m_grid, q_unit);
 
   // cloud liquid mass mixing ratio [kg/kg]
-  add_tracer<Required>("qc", scalar3d_mid, q_unit, grid_name);
+  add_tracer<Required>("qc", m_grid, q_unit);
 
   // cloud ice mass mixing ratio [kg/kg]
-  add_tracer<Required>("qi", scalar3d_mid, q_unit, grid_name);
+  add_tracer<Required>("qi", m_grid, q_unit);
 
   // cloud liquid number mixing ratio [1/kg]
-  add_tracer<Required>("nc", scalar3d_mid, n_unit, grid_name);
+  add_tracer<Required>("nc", m_grid, n_unit);
 
   // cloud ice number mixing ratio [1/kg]
-  add_tracer<Required>("ni", scalar3d_mid, n_unit, grid_name);
+  add_tracer<Required>("ni", m_grid, n_unit);
 
   // Temperature[K] at midpoints
   add_field<Required>("T_mid", scalar3d_mid, K, grid_name);
@@ -161,7 +161,7 @@ void MAMWetscav::set_grids(
     // interstitial aerosol tracers of interest: number (n) mixing ratios
     const char *int_nmr_field_name =
         mam_coupling::int_aero_nmr_field_name(imode);
-    add_tracer<Updated>(int_nmr_field_name, scalar3d_mid, n_unit, grid_name);
+    add_tracer<Updated>(int_nmr_field_name, m_grid, n_unit);
 
     // cloudborne aerosol tracers of interest: number (n) mixing ratios
     // Note: Do *not* add cld borne aerosols to the "tracer" group as these are
@@ -176,7 +176,7 @@ void MAMWetscav::set_grids(
       const char *int_mmr_field_name =
           mam_coupling::int_aero_mmr_field_name(imode, ispec);
       if(strlen(int_mmr_field_name) > 0) {
-        add_tracer<Updated>(int_mmr_field_name, scalar3d_mid, q_unit, grid_name);
+        add_tracer<Updated>(int_mmr_field_name, m_grid, q_unit);
       }
 
       // (cloudborne) aerosol tracers of interest: mass (q) mixing ratios
@@ -196,7 +196,7 @@ void MAMWetscav::set_grids(
   // aerosol-related gases: mass mixing ratios
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char *gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_tracer<Updated>(gas_mmr_field_name, scalar3d_mid, q_unit, grid_name);
+    add_tracer<Updated>(gas_mmr_field_name, m_grid, q_unit);
   }
 
   // -------------------------------------------------------------

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -50,7 +50,7 @@ void MLCorrection::set_grids(
     add_field<Updated>("sfc_flux_sw_net", scalar2d, W/m2, grid_name);
     add_field<Updated>("sfc_flux_lw_dn", scalar2d, W/m2, grid_name);
     m_lat  = m_grid->get_geometry_data("lat");
-    m_lon  = m_grid->get_geometry_data("lon");      
+    m_lon  = m_grid->get_geometry_data("lon");
   }
 
   /* ----------------------- WARNING --------------------------------*/
@@ -60,20 +60,20 @@ void MLCorrection::set_grids(
    * to be used here which we can then setup using the m_fields_ml_output_variables variable
    */
   add_field<Updated>("T_mid",       scalar3d_mid, K,     grid_name, ps);
-  add_field<Updated>("qv",          scalar3d_mid, kg/kg, grid_name, "tracers", ps);
   add_field<Updated>("horiz_winds", vector3d_mid, m/s,   grid_name, ps);
   /* Note: we also need to update the precipitation after ML commits any column drying */
   add_field<Required>("pseudo_density",      scalar3d_mid, Pa,     grid_name, ps);
   add_field<Updated>("precip_liq_surf_mass", scalar2d,     kg/m2,  grid_name);
   add_field<Updated>("precip_ice_surf_mass", scalar2d,     kg/m2,  grid_name);
   /* ----------------------- WARNING --------------------------------*/
+  add_tracer<Updated>("qv", scalar3d_mid, kg/kg, grid_name, ps);
   add_group<Updated>("tracers", grid_name, 1, Bundling::Required);
 }
 
 // =========================================================================================
 void MLCorrection::initialize_impl(const RunType /* run_type */) {
   fpe_mask = ekat::get_enabled_fpes();
-  ekat::disable_all_fpes();  // required for importing numpy  
+  ekat::disable_all_fpes();  // required for importing numpy
   if ( Py_IsInitialized() == 0 ) {
     pybind11::initialize_interpreter();
   }
@@ -103,7 +103,7 @@ void MLCorrection::run_impl(const double dt) {
   std::string datetime_str = current_ts.get_date_string() + " " + current_ts.get_time_string();
 
   const auto &phis            = get_field_in("phis").get_view<const Real *, Host>();
-  const auto &sfc_alb_dif_vis = get_field_in("sfc_alb_dif_vis").get_view<const Real *, Host>();  
+  const auto &sfc_alb_dif_vis = get_field_in("sfc_alb_dif_vis").get_view<const Real *, Host>();
 
   const auto &qv              = get_field_out("qv").get_view<Real **, Host>();
   const auto &T_mid           = get_field_out("T_mid").get_view<Real **, Host>();
@@ -135,29 +135,29 @@ void MLCorrection::run_impl(const double dt) {
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
           m_num_cols * m_num_levs, T_mid.data(), pybind11::str{}),
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
-          m_num_cols * m_num_levs * num_tracers, qv.data(), pybind11::str{}),          
+          m_num_cols * m_num_levs * num_tracers, qv.data(), pybind11::str{}),
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
-          m_num_cols * m_num_levs, u.data(), pybind11::str{}),        
+          m_num_cols * m_num_levs, u.data(), pybind11::str{}),
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
-          m_num_cols * m_num_levs, v.data(), pybind11::str{}),       
+          m_num_cols * m_num_levs, v.data(), pybind11::str{}),
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
-          m_num_cols, h_lat.data(), pybind11::str{}),       
+          m_num_cols, h_lat.data(), pybind11::str{}),
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
           m_num_cols, h_lon.data(), pybind11::str{}),
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
-          m_num_cols, phis.data(), pybind11::str{}),   
+          m_num_cols, phis.data(), pybind11::str{}),
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
           m_num_cols * (m_num_levs+1), SW_flux_dn.data(), pybind11::str{}),
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
           m_num_cols, sfc_alb_dif_vis.data(), pybind11::str{}),
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
-          m_num_cols, sfc_flux_sw_net.data(), pybind11::str{}),   
+          m_num_cols, sfc_flux_sw_net.data(), pybind11::str{}),
       pybind11::array_t<Real, pybind11::array::c_style | pybind11::array::forcecast>(
-          m_num_cols, sfc_flux_lw_dn.data(), pybind11::str{}),                                                                                                   
-      m_num_cols, m_num_levs, num_tracers, dt, 
+          m_num_cols, sfc_flux_lw_dn.data(), pybind11::str{}),
+      m_num_cols, m_num_levs, num_tracers, dt,
       ML_model_tq, ML_model_uv, ML_model_sfc_fluxes, datetime_str);
-  pybind11::gil_scoped_release no_gil;  
-  ekat::enable_fpes(fpe_mask);   
+  pybind11::gil_scoped_release no_gil;
+  ekat::enable_fpes(fpe_mask);
 
   // Now back out the qv change abd apply it to precipitation, only if Tq ML is turned on
   if (m_ML_model_path_tq != "None") {
@@ -171,7 +171,7 @@ void MLCorrection::run_impl(const double dt) {
     constexpr Real g = PC::gravit;
     const auto num_levs = m_num_levs;
     const auto policy = ESU::get_default_team_policy(m_num_cols, m_num_levs);
-    
+
     const auto &qv_told = qv_in.get_view<const Real **>();
     const auto &qv_tnew = get_field_in("qv").get_view<const Real **>();
     Kokkos::parallel_for("Compute WVP diff", policy,
@@ -233,4 +233,4 @@ void MLCorrection::finalize_impl() {
 }
 // =========================================================================================
 
-}  // namespace scream 
+}  // namespace scream

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -66,7 +66,7 @@ void MLCorrection::set_grids(
   add_field<Updated>("precip_liq_surf_mass", scalar2d,     kg/m2,  grid_name);
   add_field<Updated>("precip_ice_surf_mass", scalar2d,     kg/m2,  grid_name);
   /* ----------------------- WARNING --------------------------------*/
-  add_tracer<Updated>("qv", scalar3d_mid, kg/kg, grid_name, ps);
+  add_tracer<Updated>("qv", m_grid, kg/kg, ps);
   add_group<Updated>("tracers", grid_name, 1, Bundling::Required);
 }
 

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -47,7 +47,7 @@ Nudging::Nudging (const ekat::Comm& comm, const ekat::ParameterList& params)
                        "Error! Inconsistent 'lev' dimension found in nudging data files.");
   }
   // use nudging weights
-  if (m_use_weights) 
+  if (m_use_weights)
     m_weights_file = m_params.get<std::string>("nudging_weights_file");
 
   // TODO: Add some warning messages here.
@@ -84,7 +84,7 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
     add_field<Updated>("T_mid", scalar3d_layout_mid, K, grid_name, ps);
   }
   if (ekat::contains(m_fields_nudge,"qv")) {
-    add_field<Updated>("qv",    scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
+    add_tracer<Updated>("qv", scalar3d_layout_mid, kg/kg, grid_name, ps);
   }
   if (ekat::contains(m_fields_nudge,"U") or ekat::contains(m_fields_nudge,"V")) {
     add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,     grid_name, ps);
@@ -107,7 +107,7 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   /* Check for consistency between nudging files, map file, and remapper */
 
   // Number of columns globally
-  auto num_cols_global = m_grid->get_num_global_dofs(); 
+  auto num_cols_global = m_grid->get_num_global_dofs();
 
   // Get the information from the first nudging data file
   int num_cols_src = scorpio::get_dimlen(m_datafiles[0],"ncol");
@@ -136,7 +136,7 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
                      << "model grid and/or the mapfile.");
     EKAT_REQUIRE_MSG(m_use_weights == false,
                      "Error! Nudging::set_grids - it seems that the user intends to use both nuding "
-                     << "from coarse data as well as weighted nudging simultaneously. This is not supported. " 
+                     << "from coarse data as well as weighted nudging simultaneously. This is not supported. "
                      << "If the user wants to use both at their own risk, the user should edit the source code "
                      << "by deleting this error message.");
     // If we get here, we are good to go!

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -84,7 +84,7 @@ void Nudging::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
     add_field<Updated>("T_mid", scalar3d_layout_mid, K, grid_name, ps);
   }
   if (ekat::contains(m_fields_nudge,"qv")) {
-    add_tracer<Updated>("qv", scalar3d_layout_mid, kg/kg, grid_name, ps);
+    add_tracer<Updated>("qv", m_grid, kg/kg, ps);
   }
   if (ekat::contains(m_fields_nudge,"U") or ekat::contains(m_fields_nudge,"V")) {
     add_field<Updated>("horiz_winds",   horiz_wind_layout,   m/s,     grid_name, ps);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -71,15 +71,15 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_field<Updated> ("T_mid",       scalar3d_layout_mid, K,      grid_name, ps);  // T_mid is the only one of these variables that is also updated.
 
   // Prognostic State:  (all fields are both input and output)
-  add_tracer<Updated>("qv",     scalar3d_layout_mid, kg/kg, grid_name, ps);
-  add_tracer<Updated>("qc",     scalar3d_layout_mid, kg/kg, grid_name, ps);
-  add_tracer<Updated>("qr",     scalar3d_layout_mid, kg/kg, grid_name, ps);
-  add_tracer<Updated>("qi",     scalar3d_layout_mid, kg/kg, grid_name, ps);
-  add_tracer<Updated>("qm",     scalar3d_layout_mid, kg/kg, grid_name, ps);
-  add_tracer<Updated>("nc",     scalar3d_layout_mid, 1/kg,  grid_name, ps);
-  add_tracer<Updated>("nr",     scalar3d_layout_mid, 1/kg,  grid_name, ps);
-  add_tracer<Updated>("ni",     scalar3d_layout_mid, 1/kg,  grid_name, ps);
-  add_tracer<Updated>("bm",     scalar3d_layout_mid, 1/kg,  grid_name, ps);
+  add_tracer<Updated>("qv", m_grid, kg/kg, ps);
+  add_tracer<Updated>("qc", m_grid, kg/kg, ps);
+  add_tracer<Updated>("qr", m_grid, kg/kg, ps);
+  add_tracer<Updated>("qi", m_grid, kg/kg, ps);
+  add_tracer<Updated>("qm", m_grid, kg/kg, ps);
+  add_tracer<Updated>("nc", m_grid, 1/kg,  ps);
+  add_tracer<Updated>("nr", m_grid, 1/kg,  ps);
+  add_tracer<Updated>("ni", m_grid, 1/kg,  ps);
+  add_tracer<Updated>("bm", m_grid, 1/kg,  ps);
 
   // Diagnostic Inputs: (only the X_prev fields are both input and output, all others are just inputs)
   add_field<Required>("nc_nuceat_tend",     scalar3d_layout_mid, 1/(kg*s), grid_name, ps);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -71,15 +71,15 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_field<Updated> ("T_mid",       scalar3d_layout_mid, K,      grid_name, ps);  // T_mid is the only one of these variables that is also updated.
 
   // Prognostic State:  (all fields are both input and output)
-  add_field<Updated>("qv",     scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
-  add_field<Updated>("qc",     scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
-  add_field<Updated>("qr",     scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
-  add_field<Updated>("qi",     scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
-  add_field<Updated>("qm",     scalar3d_layout_mid, kg/kg, grid_name, "tracers", ps);
-  add_field<Updated>("nc",     scalar3d_layout_mid, 1/kg,  grid_name, "tracers", ps);
-  add_field<Updated>("nr",     scalar3d_layout_mid, 1/kg,  grid_name, "tracers", ps);
-  add_field<Updated>("ni",     scalar3d_layout_mid, 1/kg,  grid_name, "tracers", ps);
-  add_field<Updated>("bm",     scalar3d_layout_mid, 1/kg,  grid_name, "tracers", ps);
+  add_tracer<Updated>("qv",     scalar3d_layout_mid, kg/kg, grid_name, ps);
+  add_tracer<Updated>("qc",     scalar3d_layout_mid, kg/kg, grid_name, ps);
+  add_tracer<Updated>("qr",     scalar3d_layout_mid, kg/kg, grid_name, ps);
+  add_tracer<Updated>("qi",     scalar3d_layout_mid, kg/kg, grid_name, ps);
+  add_tracer<Updated>("qm",     scalar3d_layout_mid, kg/kg, grid_name, ps);
+  add_tracer<Updated>("nc",     scalar3d_layout_mid, 1/kg,  grid_name, ps);
+  add_tracer<Updated>("nr",     scalar3d_layout_mid, 1/kg,  grid_name, ps);
+  add_tracer<Updated>("ni",     scalar3d_layout_mid, 1/kg,  grid_name, ps);
+  add_tracer<Updated>("bm",     scalar3d_layout_mid, 1/kg,  grid_name, ps);
 
   // Diagnostic Inputs: (only the X_prev fields are both input and output, all others are just inputs)
   add_field<Required>("nc_nuceat_tend",     scalar3d_layout_mid, 1/(kg*s), grid_name, ps);

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -61,7 +61,7 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
   add_field<Updated>("surf_evap",       scalar2d    , kg/(m2*s), grid_name);
   add_field<Updated> ("T_mid",          scalar3d_mid, K,         grid_name, ps);
-  add_field<Updated> ("qv",             scalar3d_mid, kg/kg,     grid_name, "tracers", ps);
+  add_tracer<Updated>("qv",             scalar3d_mid, kg/kg,     grid_name, ps);
 
   // If TMS is a process, add surface drag coefficient to required fields
   if (m_params.get<bool>("apply_tms", false)) {
@@ -75,11 +75,11 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   add_field<Required>("phis",           scalar2d    , m2/s2, grid_name, ps);
 
   // Input/Output variables
-  add_field<Updated>("tke",           scalar3d_mid, m2/s2,   grid_name, "tracers", ps);
+  add_tracer<Updated>("tke",          scalar3d_mid, m2/s2,   grid_name, ps);
   add_field<Updated>("horiz_winds",   vector3d_mid,   m/s,     grid_name, ps);
   add_field<Updated>("sgs_buoy_flux", scalar3d_mid, K*(m/s), grid_name, ps);
   add_field<Updated>("eddy_diff_mom", scalar3d_mid, m2/s,    grid_name, ps);
-  add_field<Updated>("qc",            scalar3d_mid, kg/kg,   grid_name, "tracers", ps);
+  add_tracer<Updated>("qc",           scalar3d_mid, kg/kg,   grid_name, ps);
   add_field<Updated>("cldfrac_liq",   scalar3d_mid, nondim,  grid_name, ps);
 
   // Output variables

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -61,7 +61,7 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
 
   add_field<Updated>("surf_evap",       scalar2d    , kg/(m2*s), grid_name);
   add_field<Updated> ("T_mid",          scalar3d_mid, K,         grid_name, ps);
-  add_tracer<Updated>("qv",             scalar3d_mid, kg/kg,     grid_name, ps);
+  add_tracer<Updated>("qv", m_grid, kg/kg, ps);
 
   // If TMS is a process, add surface drag coefficient to required fields
   if (m_params.get<bool>("apply_tms", false)) {
@@ -75,12 +75,12 @@ void SHOCMacrophysics::set_grids(const std::shared_ptr<const GridsManager> grids
   add_field<Required>("phis",           scalar2d    , m2/s2, grid_name, ps);
 
   // Input/Output variables
-  add_tracer<Updated>("tke",          scalar3d_mid, m2/s2,   grid_name, ps);
   add_field<Updated>("horiz_winds",   vector3d_mid,   m/s,     grid_name, ps);
   add_field<Updated>("sgs_buoy_flux", scalar3d_mid, K*(m/s), grid_name, ps);
   add_field<Updated>("eddy_diff_mom", scalar3d_mid, m2/s,    grid_name, ps);
-  add_tracer<Updated>("qc",           scalar3d_mid, kg/kg,   grid_name, ps);
   add_field<Updated>("cldfrac_liq",   scalar3d_mid, nondim,  grid_name, ps);
+  add_tracer<Updated>("tke", m_grid, m2/s2, ps);
+  add_tracer<Updated>("qc",  m_grid, kg/kg, ps);
 
   // Output variables
   add_field<Computed>("pbl_height",    scalar2d    , m,            grid_name);

--- a/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
+++ b/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
@@ -50,9 +50,9 @@ void TurbulentMountainStress::set_grids(const std::shared_ptr<const GridsManager
   add_field<Required>("T_mid",          scalar3d_mid, K,      grid_name,            ps);
   add_field<Required>("p_mid",          scalar3d_mid, Pa,     grid_name,            ps);
   add_field<Required>("pseudo_density", scalar3d_mid, Pa,     grid_name,            ps);
-  add_tracer<Required>("qv",            scalar3d_mid, kg/kg,  grid_name,            ps);
   add_field<Required>("sgh30",          scalar2d    , m,      grid_name);
   add_field<Required>("landfrac",       scalar2d    , nondim, grid_name);
+  add_tracer<Required>("qv", m_grid, kg/kg, ps);
 
   add_field<Computed>("surf_drag_coeff_tms", scalar2d, kg/(m2*s), grid_name);
   add_field<Computed>("wind_stress_tms",     vector2d, N/m2,      grid_name);

--- a/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
+++ b/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
@@ -50,7 +50,7 @@ void TurbulentMountainStress::set_grids(const std::shared_ptr<const GridsManager
   add_field<Required>("T_mid",          scalar3d_mid, K,      grid_name,            ps);
   add_field<Required>("p_mid",          scalar3d_mid, Pa,     grid_name,            ps);
   add_field<Required>("pseudo_density", scalar3d_mid, Pa,     grid_name,            ps);
-  add_field<Required>("qv",             scalar3d_mid, kg/kg,  grid_name, "tracers", ps);
+  add_tracer<Required>("qv",            scalar3d_mid, kg/kg,  grid_name,            ps);
   add_field<Required>("sgh30",          scalar2d    , m,      grid_name);
   add_field<Required>("landfrac",       scalar2d    , nondim, grid_name);
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -348,6 +348,13 @@ protected:
   void add_field (const FieldIdentifier& fid, const std::list<std::string>& groups, const int ps)
   { add_field<RT>(FieldRequest(fid,groups,ps)); }
 
+  // Specialization for add_field to tracer group
+  template<RequestType RT>
+  void add_tracer (const std::string& name, const FieldLayout& layout,
+                   const ekat::units::Units& u, const std::string& grid_name,
+                   const int ps = 1)
+  { add_field<RT>(name, layout, u, grid_name, "tracers", ps); }
+
   // Group requests
   template<RequestType RT>
   void add_group (const std::string& name, const std::string& grid, const int ps, const Bundling b,

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -350,10 +350,9 @@ protected:
 
   // Specialization for add_field to tracer group
   template<RequestType RT>
-  void add_tracer (const std::string& name, const FieldLayout& layout,
-                   const ekat::units::Units& u, const std::string& grid_name,
-                   const int ps = 1)
-  { add_field<RT>(name, layout, u, grid_name, "tracers", ps); }
+  void add_tracer (const std::string& name, std::shared_ptr<const AbstractGrid> grid,
+                   const ekat::units::Units& u, const int ps = 1)
+  { add_field<RT>(name, grid->get_3d_scalar_layout(true), u, grid->name(), "tracers", ps); }
 
   // Group requests
   template<RequestType RT>


### PR DESCRIPTION
Later this will be extended to place tracers into specific groups.

Unfortunately, `AtmosphereProcess` class does not know about the grids, so `Layout` can't be automatically deduced in `add_tracer()`. If we wanted we could consider
```
Current:
- virtual void set_grid(grid_manager) = 0; // Defined by specific process

Change:
+ virtual void set_grids_impl() = 0; // Defined by specific process
+ void set_grid(grid_manager) {
+   m_grids_manager = grids_manager;
+   set_grids_impl();
+ }
```
so that the generic process stored the grids. But this is a bigger change than might be worth for not having to pass layout.