### PR TITLE
Add 128 REP test to medres

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -705,6 +705,7 @@ _TESTS = {
             "PEM_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1.scream-spa_remap--scream-output-preset-4",
             "ERS_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1.scream-small_kernels--scream-output-preset-5",
             "ERP_Ln22.conusx4v1pg2_r05_oECv3.F2010-SCREAMv1-noAero.scream-bfbhash--scream-output-preset-6",
+            "REP_P8_Ld1.ne30pg2_ne30pg2.F2010-SCREAMv1.scream-L128",
             )
     },
 


### PR DESCRIPTION
Based on today's meeting, we want to add a 128 level test for frontier. I'm going to add REP_Ld1.ne30pg2_ne30pg2.F2010-SCREAMv1.scream-L128 to our medres suite and turn on baselines for this suite on frontier. Some uncertainty was the in meeting notes, this test was hardcoded to P8 . I think we probably don't want that hardcoded in the suite since it would then apply to all machines, so I left it off.