### PR TITLE
Change output specs for mam tests

### DIFF
--- a/components/eamxx/tests/multi-process/dynamics_physics/CMakeLists.txt
+++ b/components/eamxx/tests/multi-process/dynamics_physics/CMakeLists.txt
@@ -8,13 +8,7 @@ if (SCREAM_DOUBLE_PRECISION)
     add_subdirectory(homme_shoc_cld_spa_p3_rrtmgp_128levels)
     add_subdirectory(homme_shoc_cld_spa_p3_rrtmgp_pg2_dp)
     if (SCREAM_ENABLE_MAM)
-      # Once the mam4xx aerosol microphysics AtmosphereProcess is running, the
-      # corresponding test here needs to be reworked with valid aerosol
-      # initial conditions.
-      #add_subdirectory(homme_mam4xx_pg2)
-      add_subdirectory(mam/homme_shoc_cld_p3_mam_optics_rrtmgp)
-      add_subdirectory(mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep)
-      add_subdirectory(mam/homme_shoc_cld_spa_p3_rrtmgp_mam4_wetscav)
+      add_subdirectory(mam)
     endif()
   endif()
 endif()

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/CMakeLists.txt
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory(homme_shoc_cld_p3_mam_optics_rrtmgp)
+add_subdirectory(homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep)
+add_subdirectory(homme_shoc_cld_spa_p3_rrtmgp_mam4_wetscav)

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/output.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/output.yaml
@@ -2,7 +2,6 @@
 ---
 filename_prefix: homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep
 Averaging Type: Instant
-Max Snapshots Per File: 1
 Fields:
   Physics GLL:
     Field Names:

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_p3_mam_optics_rrtmgp/output.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_p3_mam_optics_rrtmgp/output.yaml
@@ -2,7 +2,6 @@
 ---
 filename_prefix: homme_shoc_cld_p3_mam_optics_rrtmgp
 Averaging Type: Instant
-Max Snapshots Per File: 1
 Fields:
   Physics GLL:
     Field Names:

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_spa_p3_rrtmgp_mam4_wetscav/output.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_spa_p3_rrtmgp_mam4_wetscav/output.yaml
@@ -2,7 +2,6 @@
 ---
 filename_prefix: homme_shoc_cld_spa_p3_rrtmgp_mam4_wetscav_output
 Averaging Type: Instant
-Max Snapshots Per File: 1
 Fields:
   Physics GLL:
     Field Names:


### PR DESCRIPTION
The baselines tests only check the first file. So put all snapshots in the same file, not just the t0 snap, to make sure we're comparing the final state, not just the IC.