### PR TITLE
Workflows: add standalone nightly testing and beef up v1 testing

### DIFF
--- a/.github/workflows/eamxx-standalone-testing.yml
+++ b/.github/workflows/eamxx-standalone-testing.yml
@@ -26,8 +26,8 @@ on:
         type: boolean
 
   # Add schedule trigger for nightly runs at midnight MT (Standard Time)
-  # schedule:
-  #   - cron: '0 7 * * *'  # Runs at 7 AM UTC, which is midnight MT during Standard Time
+  schedule:
+    - cron: '0 7 * * *'  # Runs at 7 AM UTC, which is midnight MT during Standard Time
 
 concurrency:
   # Two runs are in the same group if:

--- a/.github/workflows/eamxx-standalone-testing.yml
+++ b/.github/workflows/eamxx-standalone-testing.yml
@@ -60,8 +60,8 @@ jobs:
             !(
               contains(github.event.pull_request.labels.*.name, 'AT: skip gcc') ||
               contains(github.event.pull_request.labels.*.name, 'AT: skip openmp') ||
-              contains(github.event.pull_request.labels.*.name, 'AT: skip eamxx-standalone') ||
-              contains(github.event.pull_request.labels.*.name, 'AT: skip all')
+              contains(github.event.pull_request.labels.*.name, 'AT: skip eamxx-sa') ||
+              contains(github.event.pull_request.labels.*.name, 'AT: skip eamxx-all')
             )
           )
         }}

--- a/.github/workflows/eamxx-standalone-testing.yml
+++ b/.github/workflows/eamxx-standalone-testing.yml
@@ -10,6 +10,7 @@ on:
       - components/eam/src/physics/rrtmgp/**
       - components/eam/src/physics/p3/scream/**
       - components/eam/src/physics/cam/**
+      - .github/workflows/eamxx-standalone-testing.yml
 
   # Manual run is used to bless
   workflow_dispatch:

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -65,7 +65,7 @@ jobs:
             !(
               contains(github.event.pull_request.labels.*.name, 'AT: skip gcc') ||
               contains(github.event.pull_request.labels.*.name, 'AT: skip eamxx-v1') ||
-              contains(github.event.pull_request.labels.*.name, 'AT: skip all')
+              contains(github.event.pull_request.labels.*.name, 'AT: skip eamxx-all')
             )
           )
         }}

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -10,6 +10,7 @@ on:
       - components/eam/src/physics/rrtmgp/**
       - components/eam/src/physics/p3/scream/**
       - components/eam/src/physics/cam/**
+      - .github/workflows/eamxx-v1-testing.yml
 
   # Manual run is used to bless
   workflow_dispatch:

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -47,6 +47,8 @@ jobs:
             short_name: ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.scream-dpxx-arm97
           - full_name: ERS_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.ghci-snl-cpu_gnu.scream-small_kernels--scream-output-preset-5
             short_name: ERS_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.scream-small_kernels--scream-output-preset-5
+          - full_name: SMS_D_Ln5.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.ghci-snl-cpu_gnu.scream-mam4xx-all_mam4xx_procs
+            short_name: SMS_D_Ln5.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.scream-mam4xx-all_mam4xx_procs
       fail-fast: false
     name: cpu-gcc / ${{ matrix.test.short_name }}
     # Run this workflow if:

--- a/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
+++ b/components/eamxx/scripts/jenkins/jenkins_common_impl.sh
@@ -17,11 +17,11 @@ if [ ${#labels[@]} -gt 0 ]; then
   # We do have some labels. Look for some supported ones.
   for label in "${labels[@]}"
   do
-    if [ "$label" == "AT: Integrate Without Testing" ]; then
+    if [ "$label" == "AT: skip eamxx-all" ]; then
       skip_testing=1
-    elif [ "$label" == "AT: Skip Stand-Alone Testing" ]; then
+    elif [ "$label" == "AT: skip eamxx-sa" ]; then
       test_SA=0
-    elif [ "$label" == "AT: Skip v1 Testing" ]; then
+    elif [ "$label" == "AT: skip eamxx-v1" ]; then
       test_v1=0
     elif [ "$label" == "scripts" ]; then
       test_scripts=1
@@ -137,7 +137,7 @@ if [ $skip_testing -eq 0 ]; then
 
     fi
   else
-    echo "SCREAM Stand-Alone tests were skipped, since the Github label 'AT: Skip Stand-Alone Testing' was found.\n"
+    echo "SCREAM Stand-Alone tests were skipped, since the Github label 'AT: skip eamxx-sa' was found.\n"
   fi
 
   # Run expensive tests on mappy only


### PR DESCRIPTION
FYI, the label "AT: workflow change approved" is needed in order to make AT2 accept changes to the workflows.