### PR TITLE
Improve eamxx workflow files

### DIFF
--- a/.github/actions/check-skip-labels/README.md
+++ b/.github/actions/check-skip-labels/README.md
@@ -1,0 +1,24 @@
+# Composite action to check if we can skip a job for a PR
+
+This action is meant to be used inside a PR testing workflow, as
+
+```yaml
+jobs:
+  my-testing:
+    steps:
+      ...
+      - name: check-pr-labels
+        if: github.event_name == "pull_request" || github.event_name == "pull_request_review"
+        uses: ./.github/actions/check-skip-labels
+        with:
+          skip_labels: label1,label2,label3
+```
+
+The input skip_label is a comma-separated list of labels that, if found
+on the PR, will cause this job to terminate immediately with a PASS state.
+
+Ideally, we would like to run this check at the job level, so that we can
+skip the job altogether (without using runner time). But while for the
+pull_request event we DO have access to the labels from the gh context
+(and therefore can check), for pull_request_review we don't, so we need
+to ping github for some information

--- a/.github/actions/check-skip-labels/action.yml
+++ b/.github/actions/check-skip-labels/action.yml
@@ -4,21 +4,26 @@ inputs:
   skip_labels:
     description: 'Comma-separated list of skip labels'
     required: true
+  token:
+    description: 'GitHub token for authentication'
+    required: true
+  pr_number:
+    description: 'Pull request number'
+    required: true
+
+# Note: inputs are available as env vars in the shell run steps, convertet to uppercase
 
 runs:
   using: "composite"
   steps:
     - name: Get Pull Request Labels
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         echo "Fetching pull request labels..."
-        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          LABELS="${{ toJson(github.event.pull_request.labels) }}"
-        elif [[ "${{ github.event_name }}" == "pull_request_review" ]]; then
-          prNumber="${{ github.payload.pull_request.number }}"
-          response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/$prNumber")
+        if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+          LABELS="$SKIP_LABELS"
+        elif [[ "$GITHUB_EVENT_NAME" == "pull_request_review" ]]; then
+          response=$(curl -s -H "Authorization: token $TOKEN" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
           LABELS=$(echo "$response" | jq -r '.labels | map(.name) | join(",")')
         fi
         echo "labels=$LABELS" >> $GITHUB_ENV
@@ -26,7 +31,7 @@ runs:
     - name: Check for Skip Labels
       run: |
         echo "Checking for skip labels..."
-        IFS=',' read -r -a SKIP_LABELS <<< "${{ inputs.skip_labels }}"
+        IFS=',' read -r -a SKIP_LABELS <<< "$SKIP_LABELS"
         IFS=',' read -r -a LABEL_ARRAY <<< "$labels"
 
         for label in "${SKIP_LABELS[@]}"; do

--- a/.github/actions/check-skip-labels/action.yml
+++ b/.github/actions/check-skip-labels/action.yml
@@ -1,0 +1,41 @@
+name: 'Check Skip Labels'
+description: 'Check for specific skip labels in a pull request'
+inputs:
+  skip_labels:
+    description: 'Comma-separated list of skip labels'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Pull Request Labels
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "Fetching pull request labels..."
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          LABELS="${{ toJson(github.event.pull_request.labels) }}"
+        elif [[ "${{ github.event_name }}" == "pull_request_review" ]]; then
+          prNumber="${{ github.payload.pull_request.number }}"
+          response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/$prNumber")
+          LABELS=$(echo "$response" | jq -r '.labels | map(.name) | join(",")')
+        fi
+        echo "labels=$LABELS" >> $GITHUB_ENV
+      shell: sh
+    - name: Check for Skip Labels
+      run: |
+        echo "Checking for skip labels..."
+        IFS=',' read -r -a SKIP_LABELS <<< "${{ inputs.skip_labels }}"
+        IFS=',' read -r -a LABEL_ARRAY <<< "$labels"
+
+        for label in "${SKIP_LABELS[@]}"; do
+          for pr_label in "${LABEL_ARRAY[@]}"; do
+            if [[ "$pr_label" == "$label" ]]; then
+              echo "Found skip label '$label'. Skipping this job."
+              exit 0  # Exit with success status
+            fi
+          done
+        done
+        echo "No relevant skip labels found. Continuing with the job."
+      shell: sh

--- a/.github/actions/show-workflow-trigger/README.md
+++ b/.github/actions/show-workflow-trigger/README.md
@@ -1,0 +1,3 @@
+# Composite action to show the trigger of a workflow
+
+If possible, prints also the user that triggered it

--- a/.github/actions/show-workflow-trigger/action.yml
+++ b/.github/actions/show-workflow-trigger/action.yml
@@ -1,0 +1,27 @@
+name: 'Show workflow trigger'
+description: 'Prints what triggered this workflow'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Print trigger info
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const eventName = context.eventName;
+          const actor = context.actor || 'unknown';  // Default to 'unknown' if actor is not defined
+          let eventAction = 'N/A';
+
+          // Determine the event action based on the event type
+          if (eventName === 'pull_request') {
+            eventAction = context.payload.action || 'N/A';
+          } else if (eventName === 'pull_request_review') {
+            eventAction = context.payload.review.state || 'N/A';
+          } else if (eventName === 'workflow_dispatch') {
+            eventAction = 'manual trigger';
+          } else if (eventName === 'schedule') {
+            eventAction = 'scheduled trigger';
+          }
+          console.log(`The job was triggered by a ${eventName} event.`);
+          console.log(`  - Event action: ${eventAction}`);
+          console.log(`  - Triggered by: ${actor}`);

--- a/.github/workflows/eamxx-scripts-tests.yml
+++ b/.github/workflows/eamxx-scripts-tests.yml
@@ -31,32 +31,14 @@ concurrency:
 jobs:
   cpu-gcc:
     runs-on:  [self-hosted, gcc, ghci-snl-cpu]
-    # Run this workflow if:
-    #   - workflow_dispatch: user requested this job.
-    #   - schedule: always:
-    #   - pull_request: matching skip label is NOT found
-    if: |
-      ${{
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch' ||
-          (
-            github.event_name == 'pull_request' &&
-            !(
-              contains(github.event.pull_request.labels.*.name, 'AT: skip all')
-            )
-          )
-        }}
     steps:
       - name: Show action trigger
-        uses: actions/github-script@v7
+        uses: ./.github/actions/show-workflow-trigger
+      - name: Check for skip labels
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_review' }}
+        uses: ./.github/actions/check-skip-labels
         with:
-          script: |
-            const eventName = context.eventName;
-            const eventAction = context.payload.action || 'N/A';
-            const actor = context.actor;
-            console.log(`The job was triggered by a ${eventName} event.`);
-            console.log(`  - Event action: ${eventAction}`);
-            console.log(`  - Triggered by: ${actor}`);
+          skip_labels: 'AT: skip eamxx-all'
       - name: Check out the repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/eamxx-scripts-tests.yml
+++ b/.github/workflows/eamxx-scripts-tests.yml
@@ -32,6 +32,12 @@ jobs:
   cpu-gcc:
     runs-on:  [self-hosted, gcc, ghci-snl-cpu]
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          show-progress: false
+          submodules: recursive
       - name: Show action trigger
         uses: ./.github/actions/show-workflow-trigger
       - name: Check for skip labels
@@ -39,12 +45,6 @@ jobs:
         uses: ./.github/actions/check-skip-labels
         with:
           skip_labels: 'AT: skip eamxx-all'
-      - name: Check out the repository
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          show-progress: false
-          submodules: recursive
       - name: Run test
         run: |
           cd components/eamxx

--- a/.github/workflows/eamxx-scripts-tests.yml
+++ b/.github/workflows/eamxx-scripts-tests.yml
@@ -15,8 +15,8 @@ on:
   workflow_dispatch:
 
   # Add schedule trigger for nightly runs at midnight MT (Standard Time)
-  # schedule:
-  #   - cron: '0 7 * * *'  # Runs at 7 AM UTC, which is midnight MT during Standard Time
+  schedule:
+    - cron: '0 7 * * *'  # Runs at 7 AM UTC, which is midnight MT during Standard Time
 
 concurrency:
   # Two runs are in the same group if:

--- a/.github/workflows/eamxx-scripts-tests.yml
+++ b/.github/workflows/eamxx-scripts-tests.yml
@@ -45,6 +45,8 @@ jobs:
         uses: ./.github/actions/check-skip-labels
         with:
           skip_labels: 'AT: skip eamxx-all'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr_number: ${{ github.event.pull_request.number }}
       - name: Run test
         run: |
           cd components/eamxx

--- a/.github/workflows/eamxx-scripts-tests.yml
+++ b/.github/workflows/eamxx-scripts-tests.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - components/eamxx/scripts/**
       - components/eamxx/cime_config/*.py
+  pull_request_review:
+    types: [submitted]
 
   # Manual run for debug purposes only
   workflow_dispatch:

--- a/.github/workflows/eamxx-scripts-tests.yml
+++ b/.github/workflows/eamxx-scripts-tests.yml
@@ -21,10 +21,10 @@ on:
 concurrency:
   # Two runs are in the same group if:
   #  - they have the same trigger
-  #  - if trigger=pull_request, the PR number must match
-  #  - if trigger=workflow_dispatch, the inputs are the same
+  #  - if trigger=pull_request/pull_request_review, the PR number must match
+  #  - if trigger=workflow_dispatch/schedule: no concurrency
   group: ${{ github.workflow }}-${{ github.event_name }}-${{
-             github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id
+             (github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && github.event.pull_request.number || github.run_id
            }}
   cancel-in-progress: true
 

--- a/.github/workflows/eamxx-standalone-testing.yml
+++ b/.github/workflows/eamxx-standalone-testing.yml
@@ -52,6 +52,12 @@ jobs:
     if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.jobs_list != 'gcc-openmp') }}
     name: gcc-openmp / ${{ matrix.build_type }}
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          show-progress: false
+          submodules: recursive
       - name: Show action trigger
         uses: ./.github/actions/show-workflow-trigger
       - name: Check for skip labels
@@ -59,12 +65,6 @@ jobs:
         uses: ./.github/actions/check-skip-labels
         with:
           skip_labels: 'AT: skip gcc,AT: skip openmp,AT: skip eamxx-sa,AT: skip eamxx-all'
-      - name: Check out the repository
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          show-progress: false
-          submodules: recursive
       - name: Set test-all inputs based on event specs
         run: |
           echo "submit=false" >> $GITHUB_ENV

--- a/.github/workflows/eamxx-standalone-testing.yml
+++ b/.github/workflows/eamxx-standalone-testing.yml
@@ -35,10 +35,10 @@ on:
 concurrency:
   # Two runs are in the same group if:
   #  - they have the same trigger
-  #  - if trigger=pull_request, the PR number must match
-  #  - if trigger=workflow_dispatch, the inputs are the same
+  #  - if trigger=pull_request/pull_request_review, the PR number must match
+  #  - if trigger=workflow_dispatch/schedule: no concurrency
   group: ${{ github.workflow }}-${{ github.event_name }}-${{
-             github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id
+             (github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && github.event.pull_request.number || github.run_id
            }}
   cancel-in-progress: true
 

--- a/.github/workflows/eamxx-standalone-testing.yml
+++ b/.github/workflows/eamxx-standalone-testing.yml
@@ -11,6 +11,8 @@ on:
       - components/eam/src/physics/p3/scream/**
       - components/eam/src/physics/cam/**
       - .github/workflows/eamxx-standalone-testing.yml
+  pull_request_review:
+    types: [submitted]
 
   # Manual run is used to bless
   workflow_dispatch:

--- a/.github/workflows/eamxx-standalone-testing.yml
+++ b/.github/workflows/eamxx-standalone-testing.yml
@@ -65,6 +65,8 @@ jobs:
         uses: ./.github/actions/check-skip-labels
         with:
           skip_labels: 'AT: skip gcc,AT: skip openmp,AT: skip eamxx-sa,AT: skip eamxx-all'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr_number: ${{ github.event.pull_request.number }}
       - name: Set test-all inputs based on event specs
         run: |
           echo "submit=false" >> $GITHUB_ENV

--- a/.github/workflows/eamxx-standalone-testing.yml
+++ b/.github/workflows/eamxx-standalone-testing.yml
@@ -49,36 +49,16 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [sp, dbg, fpe, opt]
-    # Run this workflow if:
-    #   - workflow_dispatch: user requested this job.
-    #   - schedule: always:
-    #   - pull_request: matching skip label is NOT found
-    if: |
-      ${{
-          github.event_name == 'schedule' ||
-          ( github.event_name == 'workflow_dispatch' && github.event.inputs.jobs_list == 'gcc-openmp' ) ||
-          (
-            github.event_name == 'pull_request' &&
-            !(
-              contains(github.event.pull_request.labels.*.name, 'AT: skip gcc') ||
-              contains(github.event.pull_request.labels.*.name, 'AT: skip openmp') ||
-              contains(github.event.pull_request.labels.*.name, 'AT: skip eamxx-sa') ||
-              contains(github.event.pull_request.labels.*.name, 'AT: skip eamxx-all')
-            )
-          )
-        }}
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.jobs_list != 'gcc-openmp') }}
     name: gcc-openmp / ${{ matrix.build_type }}
     steps:
       - name: Show action trigger
-        uses: actions/github-script@v7
+        uses: ./.github/actions/show-workflow-trigger
+      - name: Check for skip labels
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_review' }}
+        uses: ./.github/actions/check-skip-labels
         with:
-          script: |
-            const eventName = context.eventName;
-            const eventAction = context.payload.action || 'N/A';
-            const actor = context.actor;
-            console.log(`The job was triggered by a ${eventName} event.`);
-            console.log(`  - Event action: ${eventAction}`);
-            console.log(`  - Triggered by: ${actor}`);
+          skip_labels: 'AT: skip gcc,AT: skip openmp,AT: skip eamxx-sa,AT: skip eamxx-all'
       - name: Check out the repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -11,6 +11,8 @@ on:
       - components/eam/src/physics/p3/scream/**
       - components/eam/src/physics/cam/**
       - .github/workflows/eamxx-v1-testing.yml
+  pull_request_review:
+    types: [submitted]
 
   # Manual run is used to bless
   workflow_dispatch:

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -60,6 +60,12 @@ jobs:
     #   - pull_request/pull_request_review: matching skip label is NOT found
     if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.jobs_list != 'cpu-gcc') }}
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          show-progress: false
+          submodules: recursive
       - name: Show action trigger
         uses: ./.github/actions/show-workflow-trigger
       - name: Check for skip labels
@@ -95,12 +101,6 @@ jobs:
           fi
           echo "flags=$cmp_gen_flag -b master" >> $GITHUB_ENV
           echo "folder_suffix=$dir_suffix" >> $GITHUB_ENV
-      - name: Check out the repository
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          show-progress: false
-          submodules: recursive
       - name: Run test
         run: |
           ./cime/scripts/create_test ${{ matrix.test.full_name }} ${{ env.flags }} --wait

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -73,6 +73,8 @@ jobs:
         uses: ./.github/actions/check-skip-labels
         with:
           skip_labels: 'AT: skip gcc,AT: skip openmp,AT: skip eamxx-sa,AT: skip eamxx-all'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr_number: ${{ github.event.pull_request.number }}
       - name: Set CA certificates env var
         run: |
           # Ensure the operating system is Linux

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -31,10 +31,10 @@ on:
 concurrency:
   # Two runs are in the same group if:
   #  - they have the same trigger
-  #  - if trigger=pull_request, the PR number must match
-  #  - if trigger=workflow_dispatch, the inputs are the same
+  #  - if trigger=pull_request/pull_request_review: the PR number must match
+  #  - if trigger=workflow_dispatch: no concurrency
   group: ${{ github.workflow }}-${{ github.event_name }}-${{
-             github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id
+             (github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && github.event.pull_request.number || github.run_id
            }}
   cancel-in-progress: true
 

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -57,31 +57,16 @@ jobs:
     # Run this workflow if:
     #   - workflow_dispatch: user requested this job.
     #   - schedule: always:
-    #   - pull_request: matching skip label is NOT found
-    if: |
-      ${{
-          github.event_name == 'schedule' ||
-          ( github.event_name == 'workflow_dispatch' && contains(github.event.inputs.jobs_list, 'gcc-openmp') ) ||
-          (
-            github.event_name == 'pull_request' &&
-            !(
-              contains(github.event.pull_request.labels.*.name, 'AT: skip gcc') ||
-              contains(github.event.pull_request.labels.*.name, 'AT: skip eamxx-v1') ||
-              contains(github.event.pull_request.labels.*.name, 'AT: skip eamxx-all')
-            )
-          )
-        }}
+    #   - pull_request/pull_request_review: matching skip label is NOT found
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.jobs_list != 'cpu-gcc') }}
     steps:
       - name: Show action trigger
-        uses: actions/github-script@v7
+        uses: ./.github/actions/show-workflow-trigger
+      - name: Check for skip labels
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_review' }}
+        uses: ./.github/actions/check-skip-labels
         with:
-          script: |
-            const eventName = context.eventName;
-            const eventAction = context.payload.action || 'N/A';
-            const actor = context.actor;
-            console.log(`The job was triggered by a ${eventName} event.`);
-            console.log(`  - Event action: ${eventAction}`);
-            console.log(`  - Triggered by: ${actor}`);
+          skip_labels: 'AT: skip gcc,AT: skip openmp,AT: skip eamxx-sa,AT: skip eamxx-all'
       - name: Set CA certificates env var
         run: |
           # Ensure the operating system is Linux


### PR DESCRIPTION
This PR does a few improvements to the eamxx workflow files:

- Make the workflow trigger when a review is added: this allows approved members to review the PR and trigger the actions to re-run
- Relegate some common steps to a composite action in the repo:
  - show-action-trigger: prints the workflow trigger info
  - check-skip-label: for `pull_request` and `pull_request_review` events, check if the PR labels contain any relevant skip label
- turn on nigthly testing for eamxx-scripts

Notice that the check on the labels for PR runs is now done at run time, while before it was a conditional at the job level. As a consequence, we no longer _skip_ the job based on label (in the sense that the job did not run, so did not use runner resources). The reason for this is that while for `pull_request` events we can check the labels from the gh context (so we can do it at the job level), for `pull_request_event` the context does NOT contain the PR labels list, so we need to ping github for some info, and cannot do that inside the if conditional at the job level. The only downsides are
- we need to wait for the job to be picked up by a runner even if we want to skip it
- if the PR contains unauthorized users commits, the job will fail to start inside SNL runners, so the check will fail (despite the fact that we wanted to skip it)

Imho, the downsides are relatively mild, ~also considering that the check is done BEFORE cloning the repo, so it's quite early in the workflow~. The last part of the sentence was wrong: we need to checkout the repo first, otherwise we cannot access our own action (which is defined in our repo).
