### PR TITLE
Add alias options for frequency units of output.

### DIFF
--- a/components/eamxx/src/share/io/scream_io_control.hpp
+++ b/components/eamxx/src/share/io/scream_io_control.hpp
@@ -39,6 +39,30 @@ struct IOControl {
                                         ts.get_time()==next_write_ts.get_time());
   }
 
+  void set_frequency_units (const std::string& freq_unit) {
+    if (freq_unit=="none" or freq_unit=="never") {
+      frequency_units = freq_unit;
+    } else if (freq_unit=="nstep" or freq_unit=="nsteps") {
+      frequency_units = "nsteps";
+    } else if (freq_unit=="nsecond" or freq_unit=="nseconds" or freq_unit=="nsecs") {
+      frequency_units = "nsecs";
+    } else if (freq_unit=="nminute" or freq_unit=="nminutes" or freq_unit=="nmins") {
+      frequency_units = "nmins";
+    } else if (freq_unit=="nhour" or freq_unit=="nhours") {
+      frequency_units = "nhours";
+    } else if (freq_unit=="nday" or freq_unit=="ndays") {
+      frequency_units = "ndays";
+    } else if (freq_unit=="nmonth" or freq_unit=="nmonths") {
+      frequency_units = "nmonths";
+    } else if (freq_unit=="nyear" or freq_unit=="nyears") {
+      frequency_units = "nyears";
+    } else {
+      // TODO - add support for "end" as an option
+      EKAT_ERROR_MSG("Error! Unsupported frequency units of " + freq_unit + " provided.");
+    }
+
+  }
+
   void set_dt (const double dt_in) {
     EKAT_REQUIRE_MSG (dt==0 or dt==dt_in,
         "[IOControl::set_dt] Error! Cannot reset dt once it is set.\n");

--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -721,7 +721,7 @@ setup_internals (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgr
   EKAT_REQUIRE_MSG(m_params.isSublist("output_control"),
       "Error! The output control YAML file for " + m_filename_prefix + " is missing the sublist 'output_control'");
   auto& out_control_pl = m_params.sublist("output_control");
-  m_output_control.frequency_units = out_control_pl.get<std::string>("frequency_units");
+  m_output_control.set_frequency_units(out_control_pl.get<std::string>("frequency_units"));
 
   // In case output is disabled, no point in doing anything else
   if (m_output_control.frequency_units=="none" || m_output_control.frequency_units=="never") {
@@ -747,7 +747,7 @@ setup_internals (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgr
 
   if (m_params.isSublist("Checkpoint Control")) {
     auto& pl = m_params.sublist("Checkpoint Control");
-    m_checkpoint_control.frequency_units = pl.get<std::string>("frequency_units");
+    m_checkpoint_control.set_frequency_units(pl.get<std::string>("frequency_units"));
 
     if (m_checkpoint_control.output_enabled()) {
       m_checkpoint_control.frequency = pl.get<int>("Frequency");


### PR DESCRIPTION
Addresses issue #2990 which notes that the list of options for output frequency in CIME covers more cases than are currently allowed in EAMxx.  This commit expands the list of acceptable strings to include those with full words spelled out, with and without plural.