### PR TITLE
Allow to generate ALL baselines at ones for eamxx

### DIFF
--- a/.github/workflows/eamxx-standalone-testing.yml
+++ b/.github/workflows/eamxx-standalone-testing.yml
@@ -20,13 +20,14 @@ on:
   # Manual run is used to bless
   workflow_dispatch:
     inputs:
-      jobs_list:
+      job_to_run:
         description: 'Job to run'
         required: true
         type: choice
         options:
           - gcc-openmp
           - gcc-cuda
+          - all
       bless:
         description: 'Generate baselines'
         required: true
@@ -50,7 +51,9 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [sp, dbg, fpe, opt]
-    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.jobs_list != 'gcc-openmp') }}
+    if: ${{ !(github.event_name == 'workflow_dispatch' &&
+              github.event.inputs.jobs_list != 'gcc-openmp' &&
+              github.event.inputs.jobs_list != 'all') }}
     name: gcc-openmp / ${{ matrix.build_type }}
     steps:
       - name: Check out the repository
@@ -93,7 +96,9 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [sp, dbg, opt]
-    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.jobs_list != 'gcc-cuda') }}
+    if: ${{ !(github.event_name == 'workflow_dispatch' &&
+              github.event.inputs.jobs_list != 'gcc-cuda' &&
+              github.event.inputs.jobs_list != 'all') }}
     name: gcc-cuda / ${{ matrix.build_type }}
     steps:
       - name: Check out the repository

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -20,12 +20,13 @@ on:
   # Manual run is used to bless
   workflow_dispatch:
     inputs:
-      jobs_list:
+      job_to_run:
         description: 'Job to run'
         required: true
         type: choice
         options:
           - cpu-gcc
+          - all
       bless:
         description: 'Generate baselines'
         required: true
@@ -54,7 +55,9 @@ jobs:
             short_name: SMS_D_Ln5.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.scream-mam4xx-all_mam4xx_procs
       fail-fast: false
     name: cpu-gcc / ${{ matrix.test.short_name }}
-    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.jobs_list != 'cpu-gcc') }}
+    if: ${{ !(github.event_name == 'workflow_dispatch' &&
+              github.event.inputs.jobs_list != 'cpu-gcc' &&
+              github.event.inputs.jobs_list != 'all') }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
I was re-generating the eamxx baselines after the MAM4xx pr got merged, and noticed that running the eamxx-sa twice for cuda and openmp backends caused one job to cancel the other. So I decided to just add another option to the "job to run" input called `all`, which simply runs all the jobs in the workflow...