### PR TITLE
Add more eamxx workflows for nightlies

### DIFF
--- a/.github/workflows/eamxx-sa-coverage.yml
+++ b/.github/workflows/eamxx-sa-coverage.yml
@@ -1,0 +1,58 @@
+name: eamxx-sa-coverage
+
+on:
+  workflow_dispatch:
+
+  # Add schedule trigger for nightly runs at midnight MT (Standard Time)
+  schedule:
+    - cron: '0 7 * * *'  # Runs at 7 AM UTC, which is midnight MT during Standard Time
+
+concurrency:
+  # Two runs are in the same group if they are testing the same git ref
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  submit: ${{ github.event_name == 'schedule' && 'true' || 'false' }}  # Submit to cdash only for nightlies
+
+jobs:
+  gcc-openmp:
+    runs-on:  [self-hosted, ghci-snl-cpu, gcc]
+    name: gcc-openmp / cov
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          show-progress: false
+          submodules: recursive
+      - name: Show action trigger
+        uses: ./.github/actions/show-workflow-trigger
+      - name: Run tests
+        uses: ./.github/actions/test-all-scream
+        with:
+          build_type: cov
+          machine: ghci-snl-cpu
+          generate: false
+          submit: ${{ env.submit }}
+          cmake-configs: Kokkos_ENABLE_OPENMP=ON
+  gcc-cuda:
+    runs-on:  [self-hosted, ghci-snl-cuda, cuda, gcc]
+    name: gcc-cuda / cov
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          show-progress: false
+          submodules: recursive
+      - name: Show action trigger
+        uses: ./.github/actions/show-workflow-trigger
+      - name: Run tests
+        uses: ./.github/actions/test-all-scream
+        with:
+          build_type: cov
+          machine: ghci-snl-cuda
+          generate: false
+          submit: ${{ env.submit }}
+          cmake-configs: Kokkos_ARCH_VOLTA70=ON;CMAKE_CUDA_ARCHITECTURES=70

--- a/.github/workflows/eamxx-sa-sanitizer.yml
+++ b/.github/workflows/eamxx-sa-sanitizer.yml
@@ -1,0 +1,62 @@
+name: eamxx-sa-sanitizer
+
+on:
+  workflow_dispatch:
+
+  # Add schedule trigger for nightly runs at midnight MT (Standard Time)
+  schedule:
+    - cron: '0 7 * * *'  # Runs at 7 AM UTC, which is midnight MT during Standard Time
+
+concurrency:
+  # Two runs are in the same group if they are testing the same git ref
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  submit: ${{ github.event_name == 'schedule' && 'true' || 'false' }}  # Submit to cdash only for nightlies
+
+jobs:
+  gcc-openmp:
+    runs-on:  [self-hosted, ghci-snl-cpu, gcc]
+    name: gcc-openmp / cov
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          show-progress: false
+          submodules: recursive
+      - name: Show action trigger
+        uses: ./.github/actions/show-workflow-trigger
+      - name: Run tests
+        uses: ./.github/actions/test-all-scream
+        with:
+          build_type: valg
+          machine: ghci-snl-cpu
+          generate: false
+          submit: ${{ env.submit }}
+          cmake-configs: Kokkos_ENABLE_OPENMP=ON
+  gcc-cuda:
+    runs-on:  [self-hosted, ghci-snl-cuda, cuda, gcc]
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [csm, csr, csi, css]
+    name: gcc-cuda / ${{ matrix.build_type }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          show-progress: false
+          submodules: recursive
+      - name: Show action trigger
+        uses: ./.github/actions/show-workflow-trigger
+      - name: Run tests
+        uses: ./.github/actions/test-all-scream
+        with:
+          build_type: ${{ matrix.build_type }}
+          machine: ghci-snl-cuda
+          generate: false
+          submit: ${{ env.submit }}
+          cmake-configs: Kokkos_ARCH_VOLTA70=ON;CMAKE_CUDA_ARCHITECTURES=70

--- a/.github/workflows/eamxx-sa-testing.yml
+++ b/.github/workflows/eamxx-sa-testing.yml
@@ -44,6 +44,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  submit: ${{ github.event_name == 'schedule' && 'true' || 'false' }}  # Submit to cdash only for nightlies
+
 jobs:
   gcc-openmp:
     runs-on:  [self-hosted, ghci-snl-cpu, gcc]
@@ -73,11 +76,8 @@ jobs:
           pr_number: ${{ github.event.pull_request.number }}
       - name: Set test-all inputs based on event specs
         run: |
-          echo "submit=false" >> $GITHUB_ENV
           echo "generate=false" >> $GITHUB_ENV
-          if [ "${{ github.event_name }}" == "schedule" ]; then
-            echo "submit=true" >> $GITHUB_ENV
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             if [ "${{ inputs.bless }}" == "true" ]; then
               echo "generate=true" >> $GITHUB_ENV
             fi
@@ -118,11 +118,8 @@ jobs:
           pr_number: ${{ github.event.pull_request.number }}
       - name: Set test-all inputs based on event specs
         run: |
-          echo "submit=false" >> $GITHUB_ENV
           echo "generate=false" >> $GITHUB_ENV
-          if [ "${{ github.event_name }}" == "schedule" ]; then
-            echo "submit=true" >> $GITHUB_ENV
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             if [ "${{ inputs.bless }}" == "true" ]; then
               echo "generate=true" >> $GITHUB_ENV
             fi


### PR DESCRIPTION
In particular:

* Added coverage workflow: runs ghci-snl-cuda and ghci-snl-cpu.
* Added sanitizer workflow: runs valg on ghci-snl-cpu, and csm/csi/css/csr on ghci-snl-cuda.
* Renamed PR testing eamxx workflow: make the root name eamxx-sa, like others
* Use workflow env var for submit: since check is on static workflow value, we can do at workflow level, and save a few lines down below


Regarding cov, we used to run cov only on mappy. While in theory this should be enough, we do have a few fcns that are only compiled for GPU runs (and viceversa), so I figured we might as well run the workflow for all our ghci-snl-* machines... But I can easily roll that back, and only test on ghci-snl-cpu, similarly to what we used to do.