### PR TITLE
Add git-hash information to EAMxx and in the output metadata

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -807,7 +807,8 @@ void AtmosphereDriver::
 set_provenance_data (std::string caseid,
                      std::string rest_caseid,
                      std::string hostname,
-                     std::string username)
+                     std::string username,
+		     std::string versionid)
 {
 #ifdef SCREAM_CIME_BUILD
   // Check the inputs are valid
@@ -816,6 +817,7 @@ set_provenance_data (std::string caseid,
       "Error! Invalid restart case id: " + rest_caseid + "\n");
   EKAT_REQUIRE_MSG (hostname!="", "Error! Invalid hostname: " + hostname + "\n");
   EKAT_REQUIRE_MSG (username!="", "Error! Invalid username: " + username + "\n");
+  EKAT_REQUIRE_MSG (versionid!="", "Error! Invalid version: " + versionid + "\n");
 #else
   caseid = rest_caseid = m_casename;
   char* user = new char[32];
@@ -835,13 +837,14 @@ set_provenance_data (std::string caseid,
   }
   delete[] user;
   delete[] host;
+  versionid = EAMXX_GIT_VERSION;
 #endif
   auto& provenance = m_atm_params.sublist("provenance");
   provenance.set("caseid",caseid);
   provenance.set("rest_caseid",rest_caseid);
   provenance.set("hostname",hostname);
   provenance.set("username",username);
-  provenance.set("version",std::string(EAMXX_GIT_VERSION));
+  provenance.set("git_version",versionid);
 }
 
 void AtmosphereDriver::

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -116,7 +116,8 @@ public:
   void set_provenance_data (std::string caseid = "",
                             std::string rest_caseid = "",
                             std::string hostname = "",
-                            std::string username = "");
+                            std::string username = "",
+                            std::string versionid = "");
 
   // Load initial conditions for atm inputs
   void initialize_fields ();

--- a/components/eamxx/src/mct_coupling/atm_comp_mct.F90
+++ b/components/eamxx/src/mct_coupling/atm_comp_mct.F90
@@ -137,8 +137,8 @@ CONTAINS
     ! TODO: read this from the namelist?
     character(len=256)                :: yaml_fname = "./data/scream_input.yaml"
     character(kind=c_char,len=256), target :: yaml_fname_c, atm_log_fname_c
-    character(len=256) :: caseid, username, hostname, rest_caseid
-    character(kind=c_char,len=256), target :: caseid_c, username_c, hostname_c, calendar_c, rest_caseid_c
+    character(len=256) :: caseid, username, hostname, rest_caseid, versionid
+    character(kind=c_char,len=256), target :: caseid_c, username_c, hostname_c, calendar_c, rest_caseid_c, versionid_c
     integer (kind=c_int) :: run_type_c
     !-------------------------------------------------------------------------------
 
@@ -151,7 +151,8 @@ CONTAINS
          infodata=infodata)
     call seq_infodata_getData(infodata, atm_phase=phase, start_type=run_type, &
                               username=username, case_name=caseid, &
-                              rest_case_name=rest_caseid, hostname=hostname)
+                              rest_case_name=rest_caseid, hostname=hostname, &
+                              model_version=versionid)
     call seq_infodata_PutData(infodata, atm_aero=.true.)
     call seq_infodata_PutData(infodata, atm_prognostic=.true.)
 
@@ -213,10 +214,11 @@ CONTAINS
     call string_f2c(trim(rest_caseid),rest_caseid_c)
     call string_f2c(trim(hostname),hostname_c)
     call string_f2c(trim(username),username_c)
+    call string_f2c(trim(versionid),versionid_c)
     call scream_create_atm_instance (mpicom_atm, ATM_ID, yaml_fname_c, atm_log_fname_c, run_type_c, &
                           INT(cur_ymd,kind=C_INT),  INT(cur_tod,kind=C_INT), &
                           INT(case_start_ymd,kind=C_INT), INT(case_start_tod,kind=C_INT), &
-                          calendar_c, caseid_c, rest_caseid_c, hostname_c, username_c)
+                          calendar_c, caseid_c, rest_caseid_c, hostname_c, username_c, versionid_c)
 
     ! Init MCT gsMap
     call atm_Set_gsMap_mct (mpicom_atm, ATM_ID, gsMap_atm)

--- a/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
+++ b/components/eamxx/src/mct_coupling/scream_cxx_f90_interface.cpp
@@ -110,7 +110,8 @@ void scream_create_atm_instance (const MPI_Fint f_comm, const int atm_id,
                                  const char* caseid,
                                  const char* rest_caseid,
                                  const char* hostname,
-                                 const char* username)
+                                 const char* username,
+                                 const char* versionid)
 {
   using namespace scream;
   using namespace scream::control;
@@ -176,7 +177,7 @@ void scream_create_atm_instance (const MPI_Fint f_comm, const int atm_id,
     ad.set_params(scream_params);
     ad.init_scorpio(atm_id);
     ad.init_time_stamps(run_t0,case_t0,run_type);
-    ad.set_provenance_data (caseid,rest_caseid,hostname,username);
+    ad.set_provenance_data (caseid,rest_caseid,hostname,username,versionid);
     ad.create_output_managers ();
     ad.create_atm_processes ();
     ad.create_grids ();

--- a/components/eamxx/src/mct_coupling/scream_f2c_mod.F90
+++ b/components/eamxx/src/mct_coupling/scream_f2c_mod.F90
@@ -18,7 +18,8 @@ interface
                                          run_start_ymd,run_start_tod, &
                                          case_start_ymd,case_start_tod, &
                                          calendar_name, &
-                                         caseid, rest_caseid, hostname, username) bind(c)
+                                         caseid, rest_caseid, hostname, username, &
+                                         versionid) bind(c)
     use iso_c_binding, only: c_int, c_char
     !
     ! Input(s)
@@ -27,7 +28,8 @@ interface
     integer (kind=c_int),  value, intent(in) :: run_start_tod, run_start_ymd
     integer (kind=c_int),  value, intent(in) :: case_start_tod, case_start_ymd
     character(kind=c_char), target, intent(in) :: yaml_fname(*), atm_log_fname(*), calendar_name(*), &
-                                                  caseid(*), rest_caseid(*), hostname(*), username(*)
+                                                  caseid(*), rest_caseid(*), hostname(*), username(*), &
+                                                  versionid(*)
   end subroutine scream_create_atm_instance
 
   subroutine scream_get_cols_latlon (lat, lon) bind(c)


### PR DESCRIPTION
This commit changes the CMake commands for eamxx to ensure that the git-hash is saved to the EAMXX_GIT_VERSION variable and is thus available to EAMxx itself.

This naturally causes the git-hash to be added to the netCDF metadata for all EAMxx output.

Partially addresses #2142