### PR TITLE
Workflows: nano-fixes to eamxx workflows

### DIFF
--- a/.github/workflows/eamxx-sa-testing.yml
+++ b/.github/workflows/eamxx-sa-testing.yml
@@ -44,7 +44,8 @@ jobs:
       relevant_paths: ${{ steps.check_paths.outputs.value }}
       labels: ${{ steps.get_labels.outputs.labels }}
     steps:
-      - id: check_paths
+      - name: Check files modified by PR
+        id: check_paths
         run: |
           paths=(
             components/eamxx
@@ -74,14 +75,15 @@ jobs:
             echo "No relevant files touched by this PR."
             echo "value=false" >> $GITHUB_OUTPUT
           fi
-      - id: get_labels
+      - name: Retrieve PR labels
+        id: get_labels
         run: |
           labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
           echo "labels=${labels}" >> $GITHUB_OUTPUT
   gcc-openmp:
     needs: [pre_process_pr]
     if: |
-      github.event_name == 'schedule' ||
+      success() && github.event_name == 'schedule' ||
       (
         github.event_name == 'pull_request' &&
         needs.pre_process_pr.outputs.relevant_paths=='true' &&
@@ -128,7 +130,7 @@ jobs:
   gcc-cuda:
     needs: [pre_process_pr]
     if: |
-      github.event_name == 'schedule' ||
+      success() && github.event_name == 'schedule' ||
       (
         github.event_name == 'pull_request' &&
         needs.pre_process_pr.outputs.relevant_paths=='true' &&

--- a/.github/workflows/eamxx-scripts-tests.yml
+++ b/.github/workflows/eamxx-scripts-tests.yml
@@ -28,7 +28,8 @@ jobs:
       relevant_paths: ${{ steps.check_paths.outputs.value}}
       labels: ${{ steps.get_labels.outputs.labels }}
     steps:
-      - id: check_paths
+      - name: Check files modified by PR
+        id: check_paths
         run: |
           paths=(
             components/eamxx/scripts
@@ -53,7 +54,8 @@ jobs:
             echo "No relevant files touched by this PR."
             echo "value=false" >> $GITHUB_OUTPUT
           fi
-      - id: get_labels
+      - name: Retrieve PR labels
+        id: get_labels
         run: |
           labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
           echo "labels=${labels}" >> $GITHUB_OUTPUT

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -36,7 +36,8 @@ jobs:
       relevant_paths: ${{ steps.check_paths.outputs.value }}
       labels: ${{ steps.get_labels.outputs.labels }}
     steps:
-      - id: check_paths
+      - name: Check files modified by PR
+        id: check_paths
         run: |
           paths=(
             components/eamxx
@@ -66,7 +67,8 @@ jobs:
             echo "No relevant files touched by this PR."
             echo "value=false" >> $GITHUB_OUTPUT
           fi
-      - id: get_labels
+      - name: Retrieve PR labels
+        id: get_labels
         run: |
           labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
           echo "labels=${labels}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Namely:

-  Add name entry for pre_process_pr steps
- Ensure actual jobs run if pre_process_pr is skipped

This bug is what prevented nightlies to run last night on ghci-snl containers. It would also prevent us from regen baselines (workflow_dispatch), so this fix is somewhat urgent.