### PR TITLE
Fix query-scream util script

### DIFF
--- a/components/eamxx/scripts/query_scream.py
+++ b/components/eamxx/scripts/query_scream.py
@@ -1,9 +1,5 @@
 
-from machines_specs import assert_machine_supported, \
-    get_mach_cxx_compiler, get_mach_c_compiler, get_mach_f90_compiler, \
-    get_mach_batch_command, get_mach_env_setup_command, \
-    get_mach_baseline_root_dir, is_cuda_machine, \
-    get_mach_compilation_resources, get_mach_testing_resources
+from machines_specs import assert_machine_supported, get_machine, get_mach_env_setup_command
 from utils import expect
 
 CHOICES = (
@@ -24,23 +20,24 @@ def query_scream(machine, param):
     assert_machine_supported(machine)
     expect(param in CHOICES, f"Unknown param {param}")
 
+    mach = get_machine(machine)
     if param == "cxx_compiler":
-        return get_mach_cxx_compiler(machine)
+        return mach.cxx_compiler
     elif param == "c_compiler":
-        return get_mach_c_compiler(machine)
+        return mach.c_compiler
     elif param == "f90_compiler":
-        return get_mach_f90_compiler(machine)
+        return mach.ftn_compiler
     elif param == "batch":
-        return get_mach_batch_command(machine)
+        return mach.batch
     elif param == "env":
         return get_mach_env_setup_command(machine)
     elif param == "baseline_root":
-        return get_mach_baseline_root_dir(machine)
+        return mach.baselines_dir
     elif param == "cuda":
-        return str(is_cuda_machine(machine))
+        return str(mach.gpu_arch == "cuda")
     elif param == "comp_j":
-        return get_mach_compilation_resources()
+        return num_bld_res
     elif param == "test_j":
-        return get_mach_testing_resources(machine)
+        return gnum_run_res
     else:
         expect(False, f"Unhandled param {param}")


### PR DESCRIPTION
It's used by ekat when testing a PR