### PR TITLE
Fix logic to execute/skip eamxx testing workflows

### DIFF
--- a/.github/workflows/eamxx-sa-testing.yml
+++ b/.github/workflows/eamxx-sa-testing.yml
@@ -83,18 +83,21 @@ jobs:
   gcc-openmp:
     needs: [pre_process_pr]
     if: |
-      success() && github.event_name == 'schedule' ||
+      !failure() && !cancelled() &&
       (
-        github.event_name == 'pull_request' &&
-        needs.pre_process_pr.outputs.relevant_paths=='true' &&
-        !contains(needs.pre_process_pr.outputs.labels,'CI: skip gcc') &&
-        !contains(needs.pre_process_pr.outputs.labels,'CI: skip openmp') &&
-        !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-sa') &&
-        !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-all')
-      ) || (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.job_to_run == 'gcc-openmp' || 
-        github.event.inputs.job_to_run == 'all'
+        github.event_name == 'schedule' ||
+        (
+          github.event_name == 'pull_request' &&
+          needs.pre_process_pr.outputs.relevant_paths=='true' &&
+          !contains(needs.pre_process_pr.outputs.labels,'CI: skip gcc') &&
+          !contains(needs.pre_process_pr.outputs.labels,'CI: skip openmp') &&
+          !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-sa') &&
+          !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-all')
+        ) || (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.job_to_run == 'gcc-openmp' || 
+          github.event.inputs.job_to_run == 'all'
+        )
       )
     runs-on:  [self-hosted, ghci-snl-cpu, gcc]
     strategy:
@@ -130,18 +133,21 @@ jobs:
   gcc-cuda:
     needs: [pre_process_pr]
     if: |
-      success() && github.event_name == 'schedule' ||
+      !failure() && !cancelled() &&
       (
-        github.event_name == 'pull_request' &&
-        needs.pre_process_pr.outputs.relevant_paths=='true' &&
-        !contains(needs.pre_process_pr.outputs.labels,'CI: skip gcc') &&
-        !contains(needs.pre_process_pr.outputs.labels,'CI: skip cuda') &&
-        !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-sa') &&
-        !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-all')
-      ) || (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.job_to_run == 'gcc-cuda' ||
-        github.event.inputs.job_to_run == 'all'
+        github.event_name == 'schedule' ||
+        (
+          github.event_name == 'pull_request' &&
+          needs.pre_process_pr.outputs.relevant_paths=='true' &&
+          !contains(needs.pre_process_pr.outputs.labels,'CI: skip gcc') &&
+          !contains(needs.pre_process_pr.outputs.labels,'CI: skip cuda') &&
+          !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-sa') &&
+          !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-all')
+        ) || (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.job_to_run == 'gcc-cuda' ||
+          github.event.inputs.job_to_run == 'all'
+        )
       )
     runs-on:  [self-hosted, ghci-snl-cuda, cuda, gcc]
     strategy:

--- a/.github/workflows/eamxx-scripts-tests.yml
+++ b/.github/workflows/eamxx-scripts-tests.yml
@@ -62,11 +62,14 @@ jobs:
   cpu-gcc:
     needs: [pre_process_pr]
     if: |
+      !failure() && !cancelled() &&
+      (
         github.event_name != 'pull_request' ||
         (
           needs.pre_process_pr.outputs.relevant_paths == 'true' &&
           !contains(needs.pre_process_pr.outputs.labels, 'CI: skip eamxx-all')
         )
+      )
     runs-on:  [self-hosted, gcc, ghci-snl-cpu]
     steps:
       - name: Check out the repository

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -75,17 +75,20 @@ jobs:
   cpu-gcc:
     needs: [pre_process_pr]
     if: |
-      github.event_name == 'schedule' ||
+      !failure() && !cancelled() &&
       (
-        github.event_name == 'pull_request' &&
-        needs.pre_process_pr.outputs.relevant_paths=='true' &&
-        !contains(needs.pre_process_pr.outputs.labels,'CI: skip gcc') &&
-        !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-v1') &&
-        !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-all')
-      ) || (
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.job_to_run == 'cpu-gcc' ||
-        github.event.inputs.job_to_run == 'all'
+        github.event_name == 'schedule' ||
+        (
+          github.event_name == 'pull_request' &&
+          needs.pre_process_pr.outputs.relevant_paths=='true' &&
+          !contains(needs.pre_process_pr.outputs.labels,'CI: skip gcc') &&
+          !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-v1') &&
+          !contains(needs.pre_process_pr.outputs.labels,'CI: skip eamxx-all')
+        ) || (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.job_to_run == 'cpu-gcc' ||
+          github.event.inputs.job_to_run == 'all'
+        )
       )
     runs-on:  [self-hosted, gcc, ghci-snl-cpu]
     strategy:


### PR DESCRIPTION
The condition to ensure schedule events ran was wrong. After digging some more on gh discussions, I think I found the correct syntax. We will find out tomorrow.

In short, the condition `success()` evaluates to true only if previous jobs all PASSED. If they are SKIPPED, it evaluates to false. My AI suggested otherwise, but I think it's wrong. So in order to ensure there were not failures and the job was not cancelled, we have to manually do `!failure() && !cancelled()`.