### PR TITLE
Quick fix for baseline generation

### DIFF
--- a/components/eamxx/src/physics/p3/CMakeLists.txt
+++ b/components/eamxx/src/physics/p3/CMakeLists.txt
@@ -69,6 +69,8 @@ if (SCREAM_P3_SMALL_KERNELS)
   add_library(p3 ${P3_SRCS} ${P3_SK_SRCS})
 else()
   add_library(p3 ${P3_SRCS})
+  # If small kernels are ON, we don't need a separate executable to test them.
+  # Also, we never want to generate baselines with this separate executable
   if (NOT SCREAM_LIBS_ONLY AND NOT SCREAM_ONLY_GENERATE_BASELINES)
     add_library(p3_sk ${P3_SRCS} ${P3_SK_SRCS})
     # Always build p3_sk with SCREAM_P3_SMALL_KERNELS on

--- a/components/eamxx/src/physics/p3/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/p3/tests/CMakeLists.txt
@@ -74,7 +74,9 @@ if (SCREAM_ENABLE_BASELINE_TESTS)
     ${FORCE_RUN_DIFF_FAILS})
 endif()
 
-if (NOT SCREAM_P3_SMALL_KERNELS)
+# If small kernels are ON, we don't need a separate executable to test them.
+# Also, we never want to generate baselines with this separate executable
+if (NOT SCREAM_P3_SMALL_KERNELS AND NOT SCREAM_ONLY_GENERATE_BASELINES)
   CreateUnitTest(p3_sk_tests "${P3_TESTS_SRCS}"
     LIBS p3_sk p3_test_infra
     EXE_ARGS "--args ${BASELINE_FILE_ARG}"


### PR DESCRIPTION
The seperate small kernel testing does not need to be (and should not) run when generating baselines.