### PR TITLE
Fixup small kernel situation

### DIFF
--- a/components/eamxx/src/physics/p3/disp/p3_check_values_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_check_values_impl_disp.cpp
@@ -16,7 +16,7 @@ void Functions<Real, DefaultDevice>
   using ExeSpace = typename KT::ExeSpace;
   const Int nk_pack = ekat::npack<Spack>(nk);
   const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
-  
+
   Kokkos::parallel_for(
     "p3_check_values",
     policy, KOKKOS_LAMBDA(const MemberType& team) {
@@ -32,4 +32,3 @@ void Functions<Real, DefaultDevice>
 
 } // namespace p3
 } // namespace scream
-

--- a/components/eamxx/src/physics/p3/disp/p3_cloud_sed_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_cloud_sed_impl_disp.cpp
@@ -48,7 +48,7 @@ void Functions<Real,DefaultDevice>
     }
 
     cloud_sedimentation(
-      ekat::subview(qc_incld, i), ekat::subview(rho, i), ekat::subview(inv_rho, i), ekat::subview(cld_frac_l, i), 
+      ekat::subview(qc_incld, i), ekat::subview(rho, i), ekat::subview(inv_rho, i), ekat::subview(cld_frac_l, i),
       ekat::subview(acn, i), ekat::subview(inv_dz, i), dnu, team, workspace,
       nk, ktop, kbot, kdir, dt, inv_dt, do_predict_nc,
       ekat::subview(qc, i), ekat::subview(nc, i), ekat::subview(nc_incld, i), ekat::subview(mu_c, i), ekat::subview(lamc, i), ekat::subview(qc_tend, i),
@@ -60,4 +60,3 @@ void Functions<Real,DefaultDevice>
 
 } // namespace p3
 } // namespace scream
-

--- a/components/eamxx/src/physics/p3/disp/p3_rain_sed_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_rain_sed_impl_disp.cpp
@@ -45,11 +45,11 @@ void Functions<Real,DefaultDevice>
 
     // Rain sedimentation:  (adaptive substepping)
     rain_sedimentation(
-      ekat::subview(rho, i), ekat::subview(inv_rho, i), ekat::subview(rhofacr, i), ekat::subview(cld_frac_r, i), 
-      ekat::subview(inv_dz, i), ekat::subview(qr_incld, i), 
-      team, workspace, vn_table_vals, vm_table_vals, nk, ktop, kbot, kdir, dt, inv_dt, 
-      ekat::subview(qr, i), ekat::subview(nr, i), ekat::subview(nr_incld, i), ekat::subview(mu_r, i), 
-      ekat::subview(lamr, i), ekat::subview(precip_liq_flux, i), 
+      ekat::subview(rho, i), ekat::subview(inv_rho, i), ekat::subview(rhofacr, i), ekat::subview(cld_frac_r, i),
+      ekat::subview(inv_dz, i), ekat::subview(qr_incld, i),
+      team, workspace, vn_table_vals, vm_table_vals, nk, ktop, kbot, kdir, dt, inv_dt,
+      ekat::subview(qr, i), ekat::subview(nr, i), ekat::subview(nr_incld, i), ekat::subview(mu_r, i),
+      ekat::subview(lamr, i), ekat::subview(precip_liq_flux, i),
       ekat::subview(qr_tend, i), ekat::subview(nr_tend, i), precip_liq_surf(i), runtime_options);
   });
 

--- a/components/eamxx/src/physics/p3/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/p3/tests/CMakeLists.txt
@@ -77,22 +77,15 @@ endif()
 # If small kernels are ON, we don't need a separate executable to test them.
 # Also, we never want to generate baselines with this separate executable
 if (NOT SCREAM_P3_SMALL_KERNELS AND NOT SCREAM_ONLY_GENERATE_BASELINES)
-  CreateUnitTest(p3_sk_tests "${P3_TESTS_SRCS}"
+  # Note: Only the p3_main test does something different when
+  # small kernels are on. The SK dispatch routines are mostly trivial
+  # and it's not worth adding tons of test infrastructure to support
+  # BFB unit tests for these.
+  CreateUnitTest(p3_sk_tests "p3_main_unit_tests.cpp"
     LIBS p3_sk p3_test_infra
     EXE_ARGS "--args ${BASELINE_FILE_ARG}"
     THREADS 1 ${SCREAM_TEST_MAX_THREADS} ${SCREAM_TEST_THREAD_INC}
     LABELS "p3_sk;physics")
-
-  # Make sure that a diff in the two implementation triggers a failed test (in debug only)
-  # No need to run lots of different thread counts.
-  if (SCREAM_ENABLE_BASELINE_TESTS)
-    CreateUnitTest (p3_sk_tests_fail p3_rain_sed_unit_tests.cpp
-      LIBS p3_sk p3_test_infra
-      EXE_ARGS "--args ${BASELINE_FILE_ARG}"
-      COMPILER_CXX_DEFS SCREAM_FORCE_RUN_DIFF
-      LABELS "p3_sk;physics;fail"
-      ${FORCE_RUN_DIFF_FAILS})
-  endif()
 endif()
 
 CreateUnitTest(p3_run_and_cmp "p3_run_and_cmp.cpp"


### PR DESCRIPTION
It was a bit surprising that only the p3_main test actually did something different with small kernels turned on. After reviewing the code, I think I understand why. All the _disp functions are just thin wrappers around the corresponding p3 function. I don't think it's really worth the effort to have separate BFB unit tests for all the _disp functions. The p3_main test (which *does* test the small kernel stuff) should be adequate.

I've added some comments and change the p3_sk test to only test p3_main since any other bfb testing would be redundant.