### PR TITLE
Rework vertical remapper

### DIFF
--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -17,61 +17,56 @@
 namespace scream
 {
 
+std::shared_ptr<AbstractGrid>
 VerticalRemapper::
-VerticalRemapper (const grid_ptr_type& src_grid,
-                  const std::string& map_file,
-                  const Field& pmid_src,
-                  const Field& pint_src)
-  : VerticalRemapper(src_grid,map_file,pmid_src,pint_src,constants::DefaultFillValue<float>::value)
+create_tgt_grid (const grid_ptr_type& src_grid,
+                 const std::string& map_file)
 {
-  // Nothing to do here
-}
-
-VerticalRemapper::
-VerticalRemapper (const grid_ptr_type& src_grid,
-                  const std::string& map_file,
-                  const Field& pmid_src,
-                  const Field& pint_src,
-                  const Real mask_val)
- : AbstractRemapper()
- , m_comm (src_grid->get_comm())
- , m_mask_val(mask_val)
-{
-  using namespace ShortFieldTagsNames;
-
-  // Sanity checks
-  EKAT_REQUIRE_MSG (src_grid->type()==GridType::Point,
-      "Error! VerticalRemapper only works on PointGrid grids.\n"
-      "  - src grid name: " + src_grid->name() + "\n"
-      "  - src_grid_type: " + e2str(src_grid->type()) + "\n");
-  EKAT_REQUIRE_MSG (src_grid->is_unique(),
-      "Error! VerticalRemapper requires a unique source grid.\n");
-
-  // This is a vertical remapper. We only go in one direction
-  m_bwd_allowed = false;
-
-  // Create tgt_grid that is a clone of the src grid but with
-  // the correct number of levels.  Note that when vertically
-  // remapping the target field will be defined on the same DOFs
-  // as the source field, but will have a different number of 
-  // vertical levels.
+  // Create tgt_grid as a clone of src_grid with different nlevs
   scorpio::register_file(map_file,scorpio::FileMode::Read);
   auto nlevs_tgt = scorpio::get_dimlen(map_file,"lev");
 
   auto tgt_grid = src_grid->clone("vertical_remap_tgt_grid",true);
   tgt_grid->reset_num_vertical_lev(nlevs_tgt);
-  this->set_grids(src_grid,tgt_grid);
-
-  // Set the LEV and ILEV vertical profiles for interpolation from
-  set_source_pressure_fields(pmid_src,pint_src);
 
   // Gather the pressure level data for vertical remapping
-  set_pressure_levels(map_file);
+  auto layout = tgt_grid->get_vertical_layout(true);
+  Field p_tgt(FieldIdentifier("p_levs",layout,ekat::units::Pa,tgt_grid->name()));
+  p_tgt.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
+  p_tgt.allocate_view();
+  scorpio::read_var(map_file,"p_levs",p_tgt.get_view<Real*,Host>().data());
+  p_tgt.sync_to_dev();
 
   // Add tgt pressure levels to the tgt grid
-  tgt_grid->set_geometry_data(m_tgt_pressure);
+  tgt_grid->set_geometry_data(p_tgt);
 
   scorpio::release_file(map_file);
+
+  return tgt_grid;
+}
+
+VerticalRemapper::
+VerticalRemapper (const grid_ptr_type& src_grid,
+                  const std::string& map_file)
+ : VerticalRemapper(src_grid,create_tgt_grid(src_grid,map_file))
+{
+  // NOTE: we prescribe a uniform tgt pressure levels, so pmid_tgt = pint_tgt (1d field)
+  //       Cannot call set_target_pressure(p_tgt,p_tgt), since in there we do check the
+  //       number of levels (i.e., pint/pmid cannot have the same nlevs). Since we remap
+  //       every field (mid or int) to the same pressure coords, we just hard-code them.
+  m_tgt_pmid = m_tgt_pint = m_tgt_grid->get_geometry_data("p_levs");
+}
+
+VerticalRemapper::
+VerticalRemapper (const grid_ptr_type& src_grid,
+                  const grid_ptr_type& tgt_grid)
+{
+  m_bwd_allowed = false;
+
+  EKAT_REQUIRE_MSG (src_grid->get_2d_scalar_layout().congruent(tgt_grid->get_2d_scalar_layout()),
+      "Error! Source and target grid can only differ for their number of level.\n");
+
+  this->set_grids (src_grid,tgt_grid);
 }
 
 FieldLayout VerticalRemapper::
@@ -136,32 +131,30 @@ create_layout (const FieldLayout& fl_in,
 }
 
 void VerticalRemapper::
-set_pressure_levels(const std::string& map_file)
+set_extrapolation_type (const ExtrapType etype, const TopBot where)
 {
-  // Ensure each map file gets a different decomp name
-  static std::map<std::string,int> file2idx;
-  if (file2idx.find(map_file)==file2idx.end()) {
-    file2idx[map_file] = file2idx.size();
+  if (where & Top) {
+    m_etype_top = etype;
   }
-
-  using namespace ShortFieldTagsNames;
-  auto layout = m_tgt_grid->get_vertical_layout(true);
-  FieldIdentifier fid("p_levs",layout,ekat::units::Pa,m_tgt_grid->name());
-  m_tgt_pressure = Field(fid);
-  // Just in case input fields are packed
-  m_tgt_pressure.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
-  m_tgt_pressure.allocate_view();
-
-  auto remap_pres_data = m_tgt_pressure.get_view<Real*,Host>().data();
-  scorpio::read_var(map_file,"p_levs",remap_pres_data);
-
-  m_tgt_pressure.sync_to_dev();
+  if (where & Bot) {
+    m_etype_bot = etype;
+  }
 }
 
 void VerticalRemapper::
-set_source_pressure_fields(const Field& pmid, const Field& pint)
+set_mask_value (const Real mask_val)
+{
+  EKAT_REQUIRE_MSG (not ekat::is_invalid(mask_val),
+      "[VerticalRemapper::set_mask_value] Error! Input mask value must be a valid number.\n");
+
+  m_mask_val = mask_val;
+}
+
+void VerticalRemapper::
+set_source_pressure (const Field& pmid, const Field& pint)
 {
   using namespace ShortFieldTagsNames;
+  using PackT = ekat::Pack<Real,SCREAM_PACK_SIZE>;
 
   EKAT_REQUIRE_MSG(pmid.is_allocated(),
       "Error! Source midpoint pressure field is not yet allocated.\n"
@@ -171,21 +164,58 @@ set_source_pressure_fields(const Field& pmid, const Field& pint)
       "Error! Source interface pressure field is not yet allocated.\n"
       " - field name: " + pint.name() + "\n");
 
+  EKAT_REQUIRE_MSG(pmid.get_header().get_alloc_properties().is_compatible<PackT>(),
+      "Error! Source midpoints pressure field not compatible with default pack size.\n"
+      " - pack size: " + std::to_string(SCREAM_PACK_SIZE) + "\n");
+  EKAT_REQUIRE_MSG(pint.get_header().get_alloc_properties().is_compatible<PackT>(),
+      "Error! Source interfaces pressure field not compatible with default pack size.\n"
+      " - pack size: " + std::to_string(SCREAM_PACK_SIZE) + "\n");
+
   const auto& pmid_layout = pmid.get_header().get_identifier().get_layout();
   const auto& pint_layout = pint.get_header().get_identifier().get_layout();
-  EKAT_REQUIRE_MSG(pmid_layout.congruent(m_src_grid->get_3d_scalar_layout(true)),
+  EKAT_REQUIRE_MSG(pmid_layout.dim(LEV)==m_src_grid->get_num_vertical_levels(),
       "Error! Source midpoint pressure field has the wrong layout.\n"
       " - field name: " + pmid.name() + "\n"
       " - field layout: " + pmid_layout.to_string() + "\n"
-      " - expected layout: " + m_src_grid->get_3d_scalar_layout(true).to_string() + "\n");
-  EKAT_REQUIRE_MSG(pint_layout.congruent(m_src_grid->get_3d_scalar_layout(false)),
+      " - expected num levels: " + std::to_string(m_src_grid->get_num_vertical_levels()) + "\n");
+  EKAT_REQUIRE_MSG(pint_layout.dim(ILEV)==m_src_grid->get_num_vertical_levels()+1,
       "Error! Source interface pressure field has the wrong layout.\n"
       " - field name: " + pint.name() + "\n"
       " - field layout: " + pint_layout.to_string() + "\n"
-      " - expected layout: " + m_src_grid->get_3d_scalar_layout(false).to_string() + "\n");
+      " - expected num levels: " + std::to_string(m_src_grid->get_num_vertical_levels()+1) + "\n");
 
   m_src_pmid = pmid;
   m_src_pint = pint;
+}
+
+void VerticalRemapper::
+set_target_pressure (const Field& pmid, const Field& pint)
+{
+  using namespace ShortFieldTagsNames;
+
+  EKAT_REQUIRE_MSG(pmid.is_allocated(),
+      "Error! Target midpoint pressure field is not yet allocated.\n"
+      " - field name: " + pmid.name() + "\n");
+
+  EKAT_REQUIRE_MSG(pint.is_allocated(),
+      "Error! Target interface pressure field is not yet allocated.\n"
+      " - field name: " + pint.name() + "\n");
+
+  const auto& pmid_layout = pmid.get_header().get_identifier().get_layout();
+  const auto& pint_layout = pint.get_header().get_identifier().get_layout();
+  EKAT_REQUIRE_MSG(pmid_layout.dim(LEV)==m_tgt_grid->get_num_vertical_levels(),
+      "Error! Target midpoint pressure field has the wrong layout.\n"
+      " - field name: " + pmid.name() + "\n"
+      " - field layout: " + pmid_layout.to_string() + "\n"
+      " - expected num levels: " + std::to_string(m_tgt_grid->get_num_vertical_levels()) + "\n");
+  EKAT_REQUIRE_MSG(pint_layout.dim(ILEV)==m_tgt_grid->get_num_vertical_levels()+1,
+      "Error! Target interface pressure field has the wrong layout.\n"
+      " - field name: " + pint.name() + "\n"
+      " - field layout: " + pint_layout.to_string() + "\n"
+      " - expected num levels: " + std::to_string(m_tgt_grid->get_num_vertical_levels()+1) + "\n");
+
+  m_tgt_pmid = pmid;
+  m_tgt_pint = pint;
 }
 
 void VerticalRemapper::
@@ -198,7 +228,7 @@ do_register_field (const identifier_type& src, const identifier_type& tgt)
   // could have src with ILEV and tgt with LEV)
   auto src_layout = src.get_layout().clone();
   auto tgt_layout = tgt.get_layout().clone();
-  EKAT_REQUIRE_MSG(src_layout.strip_dims({ILEV,LEV}).congruent(tgt_layout.strip_dims({LEV})),
+  EKAT_REQUIRE_MSG(src_layout.strip_dims({ILEV,LEV}).congruent(tgt_layout.strip_dims({LEV,ILEV})),
     "[VerticalRemapper] Error! Once vertical level tag is stripped, src/tgt layouts are incompatible.\n"
     "  - src field name: " + src.name() + "\n"
     "  - tgt field name: " + tgt.name() + "\n"
@@ -231,54 +261,56 @@ do_bind_field (const int ifield, const field_type& src, const field_type& tgt)
     ft.packed    = src.get_header().get_alloc_properties().is_compatible<PackT>() and
                    tgt.get_header().get_alloc_properties().is_compatible<PackT>();
 
-    // NOTE: for now we assume that masking is determined only by the COL,LEV location in space
-    //       and that fields with multiple components will have the same masking for each component
-    //       at a specific COL,LEV
-    src_layout.strip_dims({CMP});
+    if (m_etype_top==Mask or m_etype_bot==Mask) {
+      // NOTE: for now we assume that masking is determined only by the COL,LEV location in space
+      //       and that fields with multiple components will have the same masking for each component
+      //       at a specific COL,LEV
+      src_layout.strip_dims({CMP});
 
-    // I this mask has already been created, retrieve it, otherwise create it
-    const auto mask_name = m_tgt_grid->name() + "_" + ekat::join(src_layout.names(),"_") + "_mask";
-    Field tgt_mask;
-    if (m_field2type.count(mask_name)==0) {
-      auto nondim = ekat::units::Units::nondimensional();
-      // Create this src/tgt mask fields, and assign them to these src/tgt fields extra data
+      // I this mask has already been created, retrieve it, otherwise create it
+      const auto mask_name = m_tgt_grid->name() + "_" + ekat::join(src_layout.names(),"_") + "_mask";
+      Field tgt_mask;
+      if (m_field2type.count(mask_name)==0) {
+        auto nondim = ekat::units::Units::nondimensional();
+        // Create this src/tgt mask fields, and assign them to these src/tgt fields extra data
 
-      FieldIdentifier src_mask_fid (mask_name, src_layout, nondim, m_src_grid->name() );
-      FieldIdentifier tgt_mask_fid = create_tgt_fid(src_mask_fid);
+        FieldIdentifier src_mask_fid (mask_name, src_layout, nondim, m_src_grid->name() );
+        FieldIdentifier tgt_mask_fid = create_tgt_fid(src_mask_fid);
 
-      Field src_mask (src_mask_fid);
-      src_mask.allocate_view();
+        Field src_mask (src_mask_fid);
+        src_mask.allocate_view();
 
-      tgt_mask  = Field (tgt_mask_fid);
-      tgt_mask.allocate_view();
+        tgt_mask  = Field (tgt_mask_fid);
+        tgt_mask.allocate_view();
 
-      // Initialize the src mask values to 1.0
-      src_mask.deep_copy(1.0);
+        // Initialize the src mask values to 1.0
+        src_mask.deep_copy(1.0);
 
-      m_src_masks.push_back(src_mask);
-      m_tgt_masks.push_back(tgt_mask);
+        m_src_masks.push_back(src_mask);
+        m_tgt_masks.push_back(tgt_mask);
 
-      auto& mt = m_field2type[src_mask_fid.name()];
-      mt.packed = false;
-      mt.midpoints = src_layout.has_tag(LEV);
-    } else {
-      for (size_t i=0; i<m_tgt_masks.size(); ++i) {
-        if (m_tgt_masks[i].name()==mask_name) {
-          tgt_mask = m_tgt_masks[i];
-          break;
+        auto& mt = m_field2type[src_mask_fid.name()];
+        mt.packed = false;
+        mt.midpoints = src_layout.has_tag(LEV);
+      } else {
+        for (size_t i=0; i<m_tgt_masks.size(); ++i) {
+          if (m_tgt_masks[i].name()==mask_name) {
+            tgt_mask = m_tgt_masks[i];
+            break;
+          }
         }
       }
+
+      EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_data"),
+          "[VerticalRemapper::do_bind_field] Error! Target field already has mask data assigned.\n"
+          " - tgt field name: " + tgt.name() + "\n");
+      EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_value"),
+          "[VerticalRemapper::do_bind_field] Error! Target field already has mask value assigned.\n"
+          " - tgt field name: " + tgt.name() + "\n");
+
+      f_tgt.get_header().set_extra_data("mask_data",tgt_mask);
+      f_tgt.get_header().set_extra_data("mask_value",m_mask_val);
     }
-
-    EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_data"),
-        "[VerticalRemapper::do_bind_field] Error! Target field already has mask data assigned.\n"
-        " - tgt field name: " + tgt.name() + "\n");
-    EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_value"),
-        "[VerticalRemapper::do_bind_field] Error! Target field already has mask value assigned.\n"
-        " - tgt field name: " + tgt.name() + "\n");
-
-    f_tgt.get_header().set_extra_data("mask_data",tgt_mask);
-    f_tgt.get_header().set_extra_data("mask_value",m_mask_val);
   } else {
     // If a field does not have LEV or ILEV it may still have mask tracking assigned from somewhere else.
     // For instance, this could be a 2d field computed by FieldAtPressureLevel diagnostic.
@@ -365,16 +397,16 @@ void VerticalRemapper::do_remap_fwd ()
 {
   // 1. Setup any interp object that was created (if nullptr, no fields need it)
   if (m_lin_interp_mid_packed) {
-    setup_lin_interp(*m_lin_interp_mid_packed,m_src_pmid);
+    setup_lin_interp(*m_lin_interp_mid_packed,m_src_pmid,m_tgt_pmid);
   }
   if (m_lin_interp_int_packed) {
-    setup_lin_interp(*m_lin_interp_int_packed,m_src_pint);
+    setup_lin_interp(*m_lin_interp_int_packed,m_src_pint,m_tgt_pint);
   }
   if (m_lin_interp_mid_scalar) {
-    setup_lin_interp(*m_lin_interp_mid_scalar,m_src_pmid);
+    setup_lin_interp(*m_lin_interp_mid_scalar,m_src_pmid,m_tgt_pmid);
   }
   if (m_lin_interp_int_scalar) {
-    setup_lin_interp(*m_lin_interp_int_scalar,m_src_pint);
+    setup_lin_interp(*m_lin_interp_int_scalar,m_src_pint,m_tgt_pint);
   }
 
   using namespace ShortFieldTagsNames;
@@ -389,16 +421,18 @@ void VerticalRemapper::do_remap_fwd ()
       // Dispatch interpolation to the proper lin interp object
       if (type.midpoints) {
         if (type.packed) {
-          apply_vertical_interpolation(*m_lin_interp_mid_packed,f_src,f_tgt,m_src_pmid,m_mask_val);
+          apply_vertical_interpolation(*m_lin_interp_mid_packed,f_src,f_tgt,m_src_pmid,m_tgt_pmid);
         } else {
-          apply_vertical_interpolation(*m_lin_interp_mid_scalar,f_src,f_tgt,m_src_pmid,m_mask_val);
+          apply_vertical_interpolation(*m_lin_interp_mid_scalar,f_src,f_tgt,m_src_pmid,m_tgt_pmid);
         }
+        extrapolate(f_src,f_tgt,m_src_pmid,m_tgt_pmid,m_mask_val);
       } else {
         if (type.packed) {
-          apply_vertical_interpolation(*m_lin_interp_int_packed,f_src,f_tgt,m_src_pint,m_mask_val);
+          apply_vertical_interpolation(*m_lin_interp_int_packed,f_src,f_tgt,m_src_pint,m_tgt_pint);
         } else {
-          apply_vertical_interpolation(*m_lin_interp_int_scalar,f_src,f_tgt,m_src_pint,m_mask_val);
+          apply_vertical_interpolation(*m_lin_interp_int_scalar,f_src,f_tgt,m_src_pint,m_tgt_pint);
         }
+        extrapolate(f_src,f_tgt,m_src_pint,m_tgt_pint,m_mask_val);
       }
     } else {
       // There is nothing to do, this field does not need vertical interpolation,
@@ -422,16 +456,18 @@ void VerticalRemapper::do_remap_fwd ()
     // Dispatch interpolation to the proper lin interp object
     if (type.midpoints) {
       if (type.packed) {
-        apply_vertical_interpolation(*m_lin_interp_mid_packed,f_src,f_tgt,m_src_pmid,0);
+        apply_vertical_interpolation(*m_lin_interp_mid_packed,f_src,f_tgt,m_src_pmid,m_tgt_pmid);
       } else {
-        apply_vertical_interpolation(*m_lin_interp_mid_scalar,f_src,f_tgt,m_src_pmid,0);
+        apply_vertical_interpolation(*m_lin_interp_mid_scalar,f_src,f_tgt,m_src_pmid,m_tgt_pmid);
       }
+      extrapolate(f_src,f_tgt,m_src_pmid,m_tgt_pmid,0);
     } else {
       if (type.packed) {
-        apply_vertical_interpolation(*m_lin_interp_int_packed,f_src,f_tgt,m_src_pint,0);
+        apply_vertical_interpolation(*m_lin_interp_int_packed,f_src,f_tgt,m_src_pint,m_tgt_pint);
       } else {
-        apply_vertical_interpolation(*m_lin_interp_int_scalar,f_src,f_tgt,m_src_pint,0);
+        apply_vertical_interpolation(*m_lin_interp_int_scalar,f_src,f_tgt,m_src_pint,m_tgt_pint);
       }
+      extrapolate(f_src,f_tgt,m_src_pint,m_tgt_pint,0);
     }
   }
 }
@@ -439,20 +475,42 @@ void VerticalRemapper::do_remap_fwd ()
 template<int Packsize>
 void VerticalRemapper::
 setup_lin_interp (const ekat::LinInterp<Real,Packsize>& lin_interp,
-                  const Field& p_src) const
+                  const Field& p_src, const Field& p_tgt) const
 {
   using LI_t = ekat::LinInterp<Real,Packsize>;
   using ESU = ekat::ExeSpaceUtils<DefaultDevice::execution_space>;
   using PackT = ekat::Pack<Real,Packsize>;
-  auto p_src_v = p_src.get_view<const PackT**>();
-  auto p_tgt_v = m_tgt_pressure.get_view<const PackT*>();
+  using view2d = typename KokkosTypes<DefaultDevice>::view<const PackT**>;
+  using view1d = typename KokkosTypes<DefaultDevice>::view<const PackT*>;
+
+  auto src1d = p_src.rank()==1;
+  auto tgt1d = p_tgt.rank()==1;
+
+  view2d p_src2d_v, p_tgt2d_v;
+  view1d p_src1d_v, p_tgt1d_v;
+  if (src1d) {
+    p_src1d_v = p_src.get_view<const PackT*>();
+  } else {
+    p_src2d_v = p_src.get_view<const PackT**>();
+  }
+  if (tgt1d) {
+    p_tgt1d_v = p_tgt.get_view<const PackT*>();
+  } else {
+    p_tgt2d_v = p_tgt.get_view<const PackT**>();
+  }
 
   auto lambda = KOKKOS_LAMBDA(typename LI_t::MemberType const& team) {
     const int icol = team.league_rank();
-    lin_interp.setup(team,ekat::subview(p_src_v,icol),
-                          p_tgt_v);
-  };
+    // Extract subviews if src/tgt were not 1d to start with
+    auto x_src = p_src1d_v;
+    if (not src1d)
+      x_src = ekat::subview(p_src2d_v,icol);
+    auto x_tgt = p_tgt1d_v;
+    if (not tgt1d)
+      x_tgt = ekat::subview(p_tgt2d_v,icol);
 
+    lin_interp.setup(team,x_src,x_tgt);
+  };
   const int ncols = m_src_grid->get_num_local_dofs();
   const int nlevs_tgt = m_tgt_grid->get_num_vertical_levels();
   const int npacks_tgt = ekat::PackInfo<Packsize>::num_packs(nlevs_tgt);
@@ -465,8 +523,7 @@ template<int Packsize>
 void VerticalRemapper::
 apply_vertical_interpolation(const ekat::LinInterp<Real,Packsize>& lin_interp,
                              const Field& f_src, const Field& f_tgt,
-                             const Field& p_src,
-                             const Real mask_val) const
+                             const Field& p_src, const Field& p_tgt) const
 {
   // Note: if Packsize==1, we grab packs of size 1, which are for sure
   //       compatible with the allocation
@@ -474,44 +531,51 @@ apply_vertical_interpolation(const ekat::LinInterp<Real,Packsize>& lin_interp,
   using PackT = ekat::Pack<Real,Packsize>;
   using ESU = ekat::ExeSpaceUtils<DefaultDevice::execution_space>;
 
-  auto p_src_v = p_src.get_view<const PackT**>();
-  auto x_tgt = m_tgt_pressure.get_view<const PackT*>();
-  const auto& f_src_l = f_src.get_header().get_identifier().get_layout();
+  using view2d = typename KokkosTypes<DefaultDevice>::view<const PackT**>;
+  using view1d = typename KokkosTypes<DefaultDevice>::view<const PackT*>;
+
+  auto src1d = p_src.rank()==1;
+  auto tgt1d = p_tgt.rank()==1;
+
+  view2d p_src2d_v, p_tgt2d_v;
+  view1d p_src1d_v, p_tgt1d_v;
+  if (src1d) {
+    p_src1d_v = p_src.get_view<const PackT*>();
+  } else {
+    p_src2d_v = p_src.get_view<const PackT**>();
+  }
+  if (tgt1d) {
+    p_tgt1d_v = p_tgt.get_view<const PackT*>();
+  } else {
+    p_tgt2d_v = p_tgt.get_view<const PackT**>();
+  }
+
+  const auto& f_tgt_l = f_tgt.get_header().get_identifier().get_layout();
   const int ncols = m_src_grid->get_num_local_dofs();
-  const int nlevs_tgt = m_tgt_grid->get_num_vertical_levels();
-  const int nlevs_src = f_src_l.dims().back();
+  const int nlevs_tgt = f_tgt_l.dims().back();
   const int npacks_tgt = ekat::PackInfo<Packsize>::num_packs(nlevs_tgt);
 
-  const int last_src_pack_idx = ekat::PackInfo<Packsize>::last_pack_idx(nlevs_src);
-  const int last_src_pack_end = ekat::PackInfo<Packsize>::last_vec_end(nlevs_src);
-  
   switch(f_src.rank()) {
     case 2:
     {
       auto f_src_v = f_src.get_view<const PackT**>();
       auto f_tgt_v = f_tgt.get_view<      PackT**>();
       auto policy = ESU::get_default_team_policy(ncols,npacks_tgt);
-      auto lambda = KOKKOS_LAMBDA(typename LI_t::MemberType const& team) {
-
-        // Interpolate
+      auto lambda = KOKKOS_LAMBDA(typename LI_t::MemberType const& team)
+      {
         const int icol = team.league_rank();
-        auto x_src = ekat::subview(p_src_v,icol);
+
+        // Extract subviews if src/tgt pressures were not 1d to start with
+        auto x_src = p_src1d_v;
+        auto x_tgt = p_tgt1d_v;
+        if (not src1d)
+          x_src = ekat::subview(p_src2d_v,icol);
+        if (not tgt1d)
+          x_tgt = ekat::subview(p_tgt2d_v,icol);
+
         auto y_src = ekat::subview(f_src_v,icol);
         auto y_tgt = ekat::subview(f_tgt_v,icol);
         lin_interp.lin_interp(team,x_src,x_tgt,y_src,y_tgt,icol);
-        team.team_barrier();
-
-        // If x_tgt is extrapolated, set to mask_val
-        auto x_min = x_src[0][0];
-        auto x_max = x_src[last_src_pack_idx][last_src_pack_end-1];
-        auto set_mask = [&](const int ipack) {
-          auto in_range = ekat::range<PackT>(ipack*Packsize) < nlevs_tgt;
-          auto oob = (x_tgt[ipack]<x_min or x_tgt[ipack]>x_max) and in_range;
-          if (oob.any()) {
-            y_tgt[ipack].set(oob,mask_val);
-          }
-        };
-        Kokkos::parallel_for (Kokkos::TeamThreadRange(team,npacks_tgt), set_mask);
       };
       Kokkos::parallel_for("VerticalRemapper::apply_vertical_interpolation",policy,lambda);
       break;
@@ -520,31 +584,25 @@ apply_vertical_interpolation(const ekat::LinInterp<Real,Packsize>& lin_interp,
     {
       auto f_src_v = f_src.get_view<const PackT***>();
       auto f_tgt_v = f_tgt.get_view<      PackT***>();
-      const auto& layout = f_src.get_header().get_identifier().get_layout();
-      const int ncomps = layout.get_vector_dim();
+      const int ncomps = f_tgt_l.get_vector_dim();
       auto policy = ESU::get_default_team_policy(ncols*ncomps,npacks_tgt);
 
       auto lambda = KOKKOS_LAMBDA(typename LI_t::MemberType const& team)
       {
-        // Interpolate
         const int icol = team.league_rank() / ncomps;
         const int icmp = team.league_rank() % ncomps;
-        auto x_src = ekat::subview(p_src_v,icol);
+
+        // Extract subviews if src/tgt pressures were not 1d to start with
+        auto x_src = p_src1d_v;
+        auto x_tgt = p_tgt1d_v;
+        if (not src1d)
+          x_src = ekat::subview(p_src2d_v,icol);
+        if (not tgt1d)
+          x_tgt = ekat::subview(p_tgt2d_v,icol);
+
         auto y_src = ekat::subview(f_src_v,icol,icmp);
         auto y_tgt = ekat::subview(f_tgt_v,icol,icmp);
         lin_interp.lin_interp(team,x_src,x_tgt,y_src,y_tgt,icol);
-        team.team_barrier();
-
-        // If x_tgt is extrapolated, set to mask_val
-        auto x_min = x_src[0][0];
-        auto x_max = x_src[last_src_pack_idx][last_src_pack_end-1];
-        auto set_mask = [&](const int ipack) {
-          auto oob = x_tgt[ipack]<x_min or x_tgt[ipack]>x_max;
-          if (oob.any()) {
-            y_tgt[ipack].set(oob,mask_val);
-          }
-        };
-        Kokkos::parallel_for (Kokkos::TeamThreadRange(team,npacks_tgt), set_mask);
       };
       Kokkos::parallel_for("VerticalRemapper::apply_vertical_interpolation",policy,lambda);
       break;
@@ -552,6 +610,150 @@ apply_vertical_interpolation(const ekat::LinInterp<Real,Packsize>& lin_interp,
     default:
       EKAT_ERROR_MSG (
           "[VerticalRemapper::apply_vertical_interpolation] Error! Unsupported field rank.\n"
+          " - src field name: " + f_src.name() + "\n"
+          " - src field rank: " + std::to_string(f_src.rank()) + "\n");
+  }
+}
+
+void VerticalRemapper::
+extrapolate (const Field& f_src,
+             const Field& f_tgt,
+             const Field& p_src,
+             const Field& p_tgt,
+             const Real mask_val) const
+{
+  using ESU = ekat::ExeSpaceUtils<DefaultDevice::execution_space>;
+
+  using view2d = typename KokkosTypes<DefaultDevice>::view<const Real**>;
+  using view1d = typename KokkosTypes<DefaultDevice>::view<const Real*>;
+
+  auto src1d = p_src.rank()==1;
+  auto tgt1d = p_tgt.rank()==1;
+
+  view2d p_src2d_v, p_tgt2d_v;
+  view1d p_src1d_v, p_tgt1d_v;
+  if (src1d) {
+    p_src1d_v = p_src.get_view<const Real*>();
+  } else {
+    p_src2d_v = p_src.get_view<const Real**>();
+  }
+  if (tgt1d) {
+    p_tgt1d_v = p_tgt.get_view<const Real*>();
+  } else {
+    p_tgt2d_v = p_tgt.get_view<const Real**>();
+  }
+
+  const auto& f_tgt_l = f_tgt.get_header().get_identifier().get_layout();
+  const auto& f_src_l = f_src.get_header().get_identifier().get_layout();
+  const int ncols = m_src_grid->get_num_local_dofs();
+  const int nlevs_tgt = f_tgt_l.dims().back();
+  const int nlevs_src = f_src_l.dims().back();
+
+  auto etop = m_etype_top;
+  auto ebot = m_etype_bot;
+  auto mid = nlevs_tgt / 2;
+  switch(f_src.rank()) {
+    case 2:
+    {
+      auto f_src_v = f_src.get_view<const Real**>();
+      auto f_tgt_v = f_tgt.get_view<      Real**>();
+      auto policy = ESU::get_default_team_policy(ncols,nlevs_tgt);
+      auto lambda = KOKKOS_LAMBDA(const auto& team)
+      {
+        const int icol = team.league_rank();
+
+        // Extract subviews if src/tgt pressures were not 1d to start with
+        auto x_src = p_src1d_v;
+        auto x_tgt = p_tgt1d_v;
+        if (not src1d)
+          x_src = ekat::subview(p_src2d_v,icol);
+        if (not tgt1d)
+          x_tgt = ekat::subview(p_tgt2d_v,icol);
+
+        auto y_src = ekat::subview(f_src_v,icol);
+        auto y_tgt = ekat::subview(f_tgt_v,icol);
+
+        auto x_min = x_src[0];
+        auto x_max = x_src[nlevs_src-1];
+        auto extrapolate = [&](const int ilev) {
+          if (ilev>=mid) {
+            // Near surface
+            if (x_tgt[ilev]>x_max) {
+              if (ebot==P0) {
+                y_tgt[ilev] = y_src[nlevs_src-1];
+              } else {
+                y_tgt[ilev] = mask_val;
+              }
+            }
+          } else {
+            // Near top
+            if (x_tgt[ilev]<x_min) {
+              if (etop==P0) {
+                y_tgt[ilev] = y_src[0];
+              } else {
+                y_tgt[ilev] = mask_val;
+              }
+            }
+          }
+        };
+        Kokkos::parallel_for (Kokkos::TeamVectorRange(team,nlevs_tgt), extrapolate);
+      };
+      Kokkos::parallel_for("VerticalRemapper::extrapolate",policy,lambda);
+      break;
+    }
+    case 3:
+    {
+      auto f_src_v = f_src.get_view<const Real***>();
+      auto f_tgt_v = f_tgt.get_view<      Real***>();
+      const int ncomps = f_tgt_l.get_vector_dim();
+      auto policy = ESU::get_default_team_policy(ncols*ncomps,nlevs_tgt);
+
+      auto lambda = KOKKOS_LAMBDA(const auto& team)
+      {
+        const int icol = team.league_rank() / ncomps;
+        const int icmp = team.league_rank() % ncomps;
+
+        // Extract subviews if src/tgt pressures were not 1d to start with
+        auto x_src = p_src1d_v;
+        auto x_tgt = p_tgt1d_v;
+        if (not src1d)
+          x_src = ekat::subview(p_src2d_v,icol);
+        if (not tgt1d)
+          x_tgt = ekat::subview(p_tgt2d_v,icol);
+
+        auto y_src = ekat::subview(f_src_v,icol,icmp);
+        auto y_tgt = ekat::subview(f_tgt_v,icol,icmp);
+        auto x_min = x_src[0];
+        auto x_max = x_src[nlevs_src-1];
+        auto extrapolate = [&](const int ilev) {
+          if (ilev>=mid) {
+            // Near surface
+            if (x_tgt[ilev]>x_max) {
+              if (ebot==P0) {
+                y_tgt[ilev] = y_src[nlevs_src-1];
+              } else {
+                y_tgt[ilev] = mask_val;
+              }
+            }
+          } else {
+            // Near top
+            if (x_tgt[ilev]<x_min) {
+              if (etop==P0) {
+                y_tgt[ilev] = y_src[0];
+              } else {
+                y_tgt[ilev] = mask_val;
+              }
+            }
+          }
+        };
+        Kokkos::parallel_for (Kokkos::TeamVectorRange(team,nlevs_tgt), extrapolate);
+      };
+      Kokkos::parallel_for("VerticalRemapper::extrapolate",policy,lambda);
+      break;
+    }
+    default:
+      EKAT_ERROR_MSG (
+          "[VerticalRemapper::extrapolate] Error! Unsupported field rank.\n"
           " - src field name: " + f_src.name() + "\n"
           " - src field rank: " + std::to_string(f_src.rank()) + "\n");
   }

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -63,6 +63,9 @@ VerticalRemapper::
 VerticalRemapper (const grid_ptr_type& src_grid,
                   const grid_ptr_type& tgt_grid)
 {
+  // We only go in one direction for simplicity, since we need to setup some
+  // infrsatructures, and we don't want to setup 2x as many "just in case".
+  // If you need to remap bwd, just create another remapper with src/tgt grids swapped.
   m_bwd_allowed = false;
 
   EKAT_REQUIRE_MSG (src_grid->get_2d_scalar_layout().congruent(tgt_grid->get_2d_scalar_layout()),

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -75,9 +75,6 @@ public:
 
 protected:
 
-  FieldLayout create_layout (const FieldLayout& fl_in,
-                             const grid_ptr_type& grid_out) const;
-
   const identifier_type& do_get_src_field_id (const int ifield) const override {
     return m_src_fields[ifield].get_header().get_identifier();
   }
@@ -144,6 +141,10 @@ protected:
   Field                 m_src_pint;
   Field                 m_tgt_pmid;
   Field                 m_tgt_pint;
+
+  // If we remap to a fixed set of pressure levels during I/O,
+  // our tgt pint would be the same as tgt pmid.
+  bool m_tgt_int_same_as_mid = false;
 
   // Extrapolation settings at top/bottom. Default to P0 extrapolation
   ExtrapType            m_etype_top = P0;

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -15,18 +15,23 @@ namespace scream
 class VerticalRemapper : public AbstractRemapper
 {
 public:
+  enum ExtrapType {
+    Mask,  // Use fixed value
+    P0     // Constant extrapolation
+  };
+
+  enum TopBot {
+    Top = 1,
+    Bot = 2,
+    TopAndBot = Top | Bot
+  };
+
+  // Use fixed value as mask value
+  VerticalRemapper (const grid_ptr_type& src_grid,
+                    const std::string& map_file);
 
   VerticalRemapper (const grid_ptr_type& src_grid,
-                    const std::string& map_file,
-                    const Field& lev_prof,
-                    const Field& ilev_prof,
-                    const Real mask_val);
-
-  // Calls the above one, with mask_val=max_float/10
-  VerticalRemapper (const grid_ptr_type& src_grid,
-                    const std::string& map_file,
-                    const Field& lev_prof,
-                    const Field& ilev_prof);
+                    const grid_ptr_type& tgt_grid);
 
   ~VerticalRemapper () = default;
 
@@ -56,6 +61,17 @@ public:
     return not layout.has_tag(ILEV)
            and AbstractRemapper::is_valid_tgt_layout(layout);
   }
+
+  void set_extrapolation_type (const ExtrapType etype, const TopBot where = TopAndBot);
+  void set_mask_value (const Real mask_val);
+
+  void set_source_pressure (const Field& pmid, const Field& pint);
+  void set_target_pressure (const Field& pmid, const Field& pint);
+
+  // This method simply creates the tgt grid from a map file
+  static std::shared_ptr<AbstractGrid>
+  create_tgt_grid (const grid_ptr_type& src_grid,
+                   const std::string& map_file);
 
 protected:
 
@@ -89,25 +105,23 @@ protected:
     EKAT_ERROR_MSG ("VerticalRemapper only supports fwd remapping.\n");
   }
 
-  void set_pressure_levels (const std::string& map_file);
-  void do_print();
-
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
   template<int N>
   void apply_vertical_interpolation (const ekat::LinInterp<Real,N>& lin_interp,
                                      const Field& f_src, const Field& f_tgt,
-                                     const Field& p_src,
-                                     const Real mask_value) const;
+                                     const Field& p_src, const Field& p_tgt) const;
 
+  void extrapolate (const Field& f_src, const Field& f_tgt,
+                    const Field& p_src, const Field& p_tgt,
+                    const Real mask_val) const;
 
   template<int N>
   void setup_lin_interp (const ekat::LinInterp<Real,N>& lin_interp,
-                         const Field& p_src) const;
+                         const Field& p_src, const Field& p_tgt) const;
 protected:
 
-  void set_source_pressure_fields(const Field& pmid, const Field& pint);
   void create_lin_interp ();
   
   using KT = KokkosTypes<DefaultDevice>;
@@ -122,14 +136,19 @@ protected:
   // Source and target fields
   std::vector<Field>    m_src_fields;
   std::vector<Field>    m_tgt_fields;
-  std::vector<Field>    m_tgt_masks;
   std::vector<Field>    m_src_masks;
+  std::vector<Field>    m_tgt_masks;
 
   // Vertical profile fields, both for source and target
-  Real                  m_mask_val;
-  Field                 m_tgt_pressure;
-  Field                 m_src_pmid;  // Src vertical profile for LEV layouts
-  Field                 m_src_pint;  // Src vertical profile for ILEV layouts
+  Field                 m_src_pmid;
+  Field                 m_src_pint;
+  Field                 m_tgt_pmid;
+  Field                 m_tgt_pint;
+
+  // Extrapolation settings at top/bottom. Default to P0 extrapolation
+  ExtrapType            m_etype_top = P0;
+  ExtrapType            m_etype_bot = P0;
+  Real                  m_mask_val = std::numeric_limits<Real>::quiet_NaN();
 
   // We need to remap mid/int fields separately, and we want to use packs if possible,
   // so we need to divide input fields into 4 separate categories

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -227,9 +227,13 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
   if (use_vertical_remap_from_file) {
     // We build a remapper, to remap fields from the fm grid to the io grid
     auto vert_remap_file   = params.get<std::string>("vertical_remap_file");
-    auto f_lev = get_field("p_mid","sim");
-    auto f_ilev = get_field("p_int","sim");
-    m_vert_remapper = std::make_shared<VerticalRemapper>(io_grid,vert_remap_file,f_lev,f_ilev,m_fill_value);
+    auto p_mid = get_field("p_mid","sim");
+    auto p_int = get_field("p_int","sim");
+    auto vert_remapper = std::make_shared<VerticalRemapper>(io_grid,vert_remap_file);
+    vert_remapper->set_source_pressure (p_mid,p_int);
+    vert_remapper->set_mask_value(m_fill_value);
+    vert_remapper->set_extrapolation_type(VerticalRemapper::Mask); // both Top AND Bot
+    m_vert_remapper = vert_remapper;
     io_grid = m_vert_remapper->get_tgt_grid();
     set_grid(io_grid);
 


### PR DESCRIPTION
Compared to previous version:

* Allow to build the remapper from existing grids (rather than read tgt from file)
* Handle masked as well as P0 extrapolation
* Handle top/bot extrapolations separately

This PR is a pre-requisite for the work on unifying our input data interpolation.