### PR TITLE
Minor changes for our CUDA testing machine/workflows

### DIFF
--- a/.github/workflows/eamxx-sa-coverage.yml
+++ b/.github/workflows/eamxx-sa-coverage.yml
@@ -48,6 +48,38 @@ jobs:
           submodules: recursive
       - name: Show action trigger
         uses: ./.github/actions/show-workflow-trigger
+      - name: Get CUDA Arch
+        run: |
+          # Ensure nvidia-smi is available
+          if ! command -v nvidia-smi &> /dev/null; then
+              echo "nvidia-smi could not be found. Please ensure you have Nvidia drivers installed."
+              exit 1
+          fi
+
+          # Get the GPU model from nvidia-smi
+          gpu_model=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -n 1)
+          case "$gpu_model" in
+              *"H100"*)
+                  Hopper=ON
+                  ARCH=90
+                  ;;
+              *"A100"*)
+                  Amper=ON
+                  ARCH=80
+                  ;;
+              *"V100"*)
+                  Volta=ON
+                  ARCH=70
+                  ;;
+              *)
+                  echo "Unsupported GPU model: $gpu_model"
+                  exit 1
+                  ;;
+          esac
+
+          # Set the output variables for the next step
+          echo "KOKKOS_ARCH=${KOKKOS_ARCH}" >> $GITHUB_ENV
+          echo "CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}" >> $GITHUB_ENV
       - name: Run tests
         uses: ./.github/actions/test-all-scream
         with:
@@ -55,4 +87,4 @@ jobs:
           machine: ghci-snl-cuda
           generate: false
           submit: ${{ env.submit }}
-          cmake-configs: Kokkos_ARCH_VOLTA70=ON;CMAKE_CUDA_ARCHITECTURES=70
+          cmake-configs: Kokkos_ARCH_HOPPER90=${{ env.Hopper }};Kokkos_ARCH_AMPERE80=${{ env.Ampere }};Kokkos_ARCH_VOLTA70=${{ env.Volta }};CMAKE_CUDA_ARCHITECTURES=${{ env.ARCH }}

--- a/.github/workflows/eamxx-sa-sanitizer.yml
+++ b/.github/workflows/eamxx-sa-sanitizer.yml
@@ -52,6 +52,38 @@ jobs:
           submodules: recursive
       - name: Show action trigger
         uses: ./.github/actions/show-workflow-trigger
+      - name: Get CUDA Arch
+        run: |
+          # Ensure nvidia-smi is available
+          if ! command -v nvidia-smi &> /dev/null; then
+              echo "nvidia-smi could not be found. Please ensure you have Nvidia drivers installed."
+              exit 1
+          fi
+
+          # Get the GPU model from nvidia-smi
+          gpu_model=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -n 1)
+          case "$gpu_model" in
+              *"H100"*)
+                  Hopper=ON
+                  ARCH=90
+                  ;;
+              *"A100"*)
+                  Amper=ON
+                  ARCH=80
+                  ;;
+              *"V100"*)
+                  Volta=ON
+                  ARCH=70
+                  ;;
+              *)
+                  echo "Unsupported GPU model: $gpu_model"
+                  exit 1
+                  ;;
+          esac
+
+          # Set the output variables for the next step
+          echo "KOKKOS_ARCH=${KOKKOS_ARCH}" >> $GITHUB_ENV
+          echo "CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}" >> $GITHUB_ENV
       - name: Run tests
         uses: ./.github/actions/test-all-scream
         with:
@@ -59,4 +91,4 @@ jobs:
           machine: ghci-snl-cuda
           generate: false
           submit: ${{ env.submit }}
-          cmake-configs: Kokkos_ARCH_VOLTA70=ON;CMAKE_CUDA_ARCHITECTURES=70
+          cmake-configs: Kokkos_ARCH_HOPPER90=${{ env.Hopper }};Kokkos_ARCH_AMPERE80=${{ env.Ampere }};Kokkos_ARCH_VOLTA70=${{ env.Volta }};CMAKE_CUDA_ARCHITECTURES=${{ env.ARCH }}

--- a/.github/workflows/eamxx-sa-testing.yml
+++ b/.github/workflows/eamxx-sa-testing.yml
@@ -172,6 +172,38 @@ jobs:
               echo "generate=true" >> $GITHUB_ENV
             fi
           fi
+      - name: Get CUDA Arch
+        run: |
+          # Ensure nvidia-smi is available
+          if ! command -v nvidia-smi &> /dev/null; then
+              echo "nvidia-smi could not be found. Please ensure you have Nvidia drivers installed."
+              exit 1
+          fi
+
+          # Get the GPU model from nvidia-smi
+          gpu_model=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -n 1)
+          case "$gpu_model" in
+              *"H100"*)
+                  Hopper=ON
+                  ARCH=90
+                  ;;
+              *"A100"*)
+                  Amper=ON
+                  ARCH=80
+                  ;;
+              *"V100"*)
+                  Volta=ON
+                  ARCH=70
+                  ;;
+              *)
+                  echo "Unsupported GPU model: $gpu_model"
+                  exit 1
+                  ;;
+          esac
+
+          # Set the output variables for the next step
+          echo "KOKKOS_ARCH=${KOKKOS_ARCH}" >> $GITHUB_ENV
+          echo "CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}" >> $GITHUB_ENV
       - name: Run tests
         uses: ./.github/actions/test-all-scream
         with:
@@ -179,4 +211,4 @@ jobs:
           machine: ghci-snl-cuda
           generate: ${{ env.generate }}
           submit: ${{ env.submit }}
-          cmake-configs: Kokkos_ARCH_VOLTA70=ON;CMAKE_CUDA_ARCHITECTURES=70
+          cmake-configs: Kokkos_ARCH_HOPPER90=${{ env.Hopper }};Kokkos_ARCH_AMPERE80=${{ env.Ampere }};Kokkos_ARCH_VOLTA70=${{ env.Volta }};CMAKE_CUDA_ARCHITECTURES=${{ env.ARCH }}

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -221,9 +221,10 @@ class GHCISNLCuda(Machine):
     concrete = True
     @classmethod
     def setup(cls):
-        super().setup_base(name="ghci-snl-cuda",num_bld_res=16,num_run_res=1)
+        super().setup_base(name="ghci-snl-cuda")
         cls.baselines_dir = "/projects/e3sm/baselines/scream/ghci-snl-cuda"
         cls.gpu_arch = "cuda"
+        cls.num_run_res = int(run_cmd_no_fail("nvidia-smi --query-gpu=name --format=csv,noheader | wc -l"))
 
 ###############################################################################
 class Lassen(Machine):


### PR DESCRIPTION
- In machine specs, instead of hardcoding the number of GPUs, use nvidia-smi to query it (must be already on compute node)
- For eamxx-sa workflow, pick the correct CUDA arch cmake specs depending on nvidia-smi output.

This allows to move our gh action containers to A100, V100, H100 without changing anything else in our code.Grab number of gpus without hard-coding it