### PR TITLE
Fetch changed files from PR in chunks

### DIFF
--- a/.github/workflows/eamxx-sa-sanitizer.yml
+++ b/.github/workflows/eamxx-sa-sanitizer.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   gcc-openmp:
     runs-on:  [self-hosted, ghci-snl-cpu, gcc]
-    name: gcc-openmp / cov
+    name: gcc-openmp / valg
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4

--- a/.github/workflows/eamxx-sa-testing.yml
+++ b/.github/workflows/eamxx-sa-testing.yml
@@ -62,9 +62,22 @@ jobs:
           pattern=$(IFS=\|; echo "${paths[*]}")
 
           # Use the GitHub API to get the list of changed files
-          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.number }}/files")
-          changed_files=$(echo "$response" | grep -o '"filename": *"[^"]*"' | sed 's/"filename": *//; s/"//g')
+          # There are page size limits, so do it in chunks
+          page=1
+          while true; do
+            response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/E3SM-Project/scream/pulls/${{ github.event.number }}/files?per_page=100&page=$page")
+
+            # Check if the response is empty, and break if it is
+            [ -z "$response" ] && break
+
+            changed_files+=$(echo "$response" | grep -o '"filename": *"[^"]*"' | sed 's/"filename": *//; s/"//g')$'\n'
+
+            # Check if there are more pages, and quite if there aren't
+            [[ $(echo "$response" | jq '. | length') -lt 100 ]] && break
+
+            page=$((page + 1))
+          done
 
           # Check for matches and echo the matching files (or "" if none)
           matching_files=$(echo "$changed_files" | grep -E "^($pattern)" || echo "")

--- a/.github/workflows/eamxx-scripts-tests.yml
+++ b/.github/workflows/eamxx-scripts-tests.yml
@@ -41,9 +41,22 @@ jobs:
           pattern=$(IFS=\|; echo "${paths[*]}")
 
           # Use the GitHub API to get the list of changed files
-          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.number }}/files")
-          changed_files=$(echo "$response" | grep -o '"filename": *"[^"]*"' | sed 's/"filename": *//; s/"//g')
+          # There are page size limits, so do it in chunks
+          page=1
+          while true; do
+            response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/E3SM-Project/scream/pulls/${{ github.event.number }}/files?per_page=100&page=$page")
+
+            # Check if the response is empty, and break if it is
+            [ -z "$response" ] && break
+
+            changed_files+=$(echo "$response" | grep -o '"filename": *"[^"]*"' | sed 's/"filename": *//; s/"//g')$'\n'
+
+            # Check if there are more pages, and quite if there aren't
+            [[ $(echo "$response" | jq '. | length') -lt 100 ]] && break
+
+            page=$((page + 1))
+          done
 
           # Check for matches and echo the matching files (or "" if none)
           matching_files=$(echo "$changed_files" | grep -E "^($pattern)" || echo "")

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -54,9 +54,22 @@ jobs:
           pattern=$(IFS=\|; echo "${paths[*]}")
 
           # Use the GitHub API to get the list of changed files
-          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.number }}/files")
-          changed_files=$(echo "$response" | grep -o '"filename": *"[^"]*"' | sed 's/"filename": *//; s/"//g')
+          # There are page size limits, so do it in chunks
+          page=1
+          while true; do
+            response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/E3SM-Project/scream/pulls/${{ github.event.number }}/files?per_page=100&page=$page")
+
+            # Check if the response is empty, and break if it is
+            [ -z "$response" ] && break
+
+            changed_files+=$(echo "$response" | grep -o '"filename": *"[^"]*"' | sed 's/"filename": *//; s/"//g')$'\n'
+
+            # Check if there are more pages, and quite if there aren't
+            [[ $(echo "$response" | jq '. | length') -lt 100 ]] && break
+
+            page=$((page + 1))
+          done
 
           # Check for matches and echo the matching files (or "" if none)
           matching_files=$(echo "$changed_files" | grep -E "^($pattern)" || echo "")


### PR DESCRIPTION
There are page size limits when using rest API. By default, it returns max 30 items. One can force up to 100, but if there are more, we need to do some paging.

E.g.:
```bash
response=$(curl -s -H "Authorization: token ***" "https://api.github.com/repos/E3SM-Project/scream/pulls/3115/fies")
$ changed_files=$(echo "$response" | grep -o '"filename": *"[^"]*"' | sed 's/"filename": *//; s/"//g')
$ echo $changed_files | sed 's/ /\n/g' | wc -l
30
```

```bash
$ response=$(curl -s -H "Authorization: token ***" "https://api.github.com/repos/E3SM-Project/scream/pulls/3115/files?per_page=10000")
$ changed_files=$(echo "$response" | grep -o '"filename": *"[^"]*"' | sed 's/"filename": *//; s/"//g')
$ echo $changed_files | sed 's/ /\n/g' | wc -l
100
```

```bash
$ changed_files=""
$ page=1
$ while true; do
     response=$(curl -s -H "Authorization: token ***" "https://api.github.com/repos/E3SM-Project/scream/pulls/3115/files?per_page=100&page=$page");
     if [ -z "$response" ]; then
         break;
     fi;
     files=$(echo "$response" | grep -o '"filename": *"[^"]*"' | sed 's/"filename": *//; s/"//g');
     changed_files+="$files"$'\n';
     if [[ $(echo "$response" | jq '. | length') -lt 100 ]]; then
         break;
     fi;
     page=$((page + 1)); done
$ echo $changed_files | sed 's/ /\n/g' | wc -l
221
```

The authors would like to thank sandia AI chat bot for its invaluable help.