### PR TITLE
Mergify: dismiss reviews when new commits are added

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,6 +31,12 @@ merge_protections:
         - check-skipped=cpu-gcc
 
 pull_request_rules:
+    - name: dismiss stale reviews
+      conditions:
+        - base=master
+      actions:
+        dismiss_reviews:
+          when: synchronize # Dismiss reviews when synchronize event happens
     - name: Automatic merge when CI passes and approved
       conditions:
         - "label=CI: automerge"


### PR DESCRIPTION
When commits are pushed, we dismiss reviews, to prevent mergify from thinking that PRs can be merged just because they were approved "at some point" in the past.

It's up to the PR author to re-request a review.